### PR TITLE
Viewports can be panned/tracked using middle mouse with no modifier key.

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,8 @@
 
 * Added drag and drop node connection re-wiring (#78).
 
+* Viewports can be panned/tracked using middle mouse with no modifier key (#28).
+
 0.58.0
 ======
 


### PR DESCRIPTION
This affects all viewports (3d, 2d, and Node Graph).

Fixes Issue #28
