### PR TITLE
Added an empty LINKFLAGS option to SConstruct.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -71,6 +71,12 @@ options.Add(
 )
 
 options.Add(
+        "LINKFLAGS",
+        "The extra flags to pass to the C++ linker during compilation.",
+        "",
+)
+
+options.Add(
 	"BUILD_DIR",
 	"The destination directory in which the build will be made.",
 	"./build/gaffer-${GAFFER_MAJOR_VERSION}.${GAFFER_MINOR_VERSION}.${GAFFER_PATCH_VERSION}-${PLATFORM}",


### PR DESCRIPTION
Without it, SCons won't respect if LINKFLAGS is specified in a config file.

I created this simple pull request from Hradec's as follows :

> git pull upstream master # get my working copy up to date
> git checkout -b linkFlags # make a branch for this feature
> git fetch https://github.com/hradec/gaffer.git # get hradec's repository, but don't merge
> git cherry-pick fc239cf46cf0b2632a4cd734c5dcc5b56b31bcea # merge one commit
> git push origin linkFlags
