### PR TITLE
Adding workaround for PyQt/PySide pyqtSignal/Signal differences.

### DIFF
--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -495,7 +495,7 @@ class _TreeView( QtGui.QTreeView ) :
 	# expanded. It can be preferable to use this over the expanded or
 	# collapsed signals as it is emitted only once when making several
 	# changes.
-	expansionChanged = QtCore.pyqtSignal()
+	expansionChanged = QtCore.Signal()
 
 	def __init__( self ) :
 	

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -44,7 +44,8 @@
 __qtModuleName = None
 def _qtImport( name, lazy=False ) :
 
-	# decide which qt bindings to use
+	# decide which qt bindings to use, and apply any fix-ups we need
+	# to shield us from PyQt/PySide differences.
 	global __qtModuleName
 	if __qtModuleName is None :
 		import os
@@ -57,6 +58,15 @@ def _qtImport( name, lazy=False ) :
 				__qtModuleName = "PySide"
 			else :
 				__qtModuleName = "PyQt4"
+
+			# PyQt unfortunately uses an implementation-specific
+			# naming scheme for its new-style signal and slot classes.
+			# We use this to make it compatible with PySide, according to :
+			#
+			#     http://qt-project.org/wiki/Differences_Between_PySide_and_PyQt
+			if "PyQt" in __qtModuleName :
+				QtCore = __import__( __qtModuleName + ".QtCore" ).QtCore
+				QtCore.Signal = QtCore.pyqtSignal
 
 	# import the submodule from those bindings and return it
 	if lazy :


### PR DESCRIPTION
We adopt the more standard PySide naming.
