### PR TITLE
Fixed a bug with the ImagePlug and negative data windows.

### DIFF
--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -108,7 +108,9 @@ class ImagePlug : public Gaffer::CompoundPlug
 		static Imath::Box2i tileBound( const Imath::V2i &tileOrigin ) { return Imath::Box2i( tileOrigin * tileSize(), ( tileOrigin + Imath::V2i( 1 ) ) * tileSize() - Imath::V2i( 1 ) ); }
 		static const IECore::FloatVectorData *blackTile();
 		static const IECore::FloatVectorData *whiteTile();
-	
+		
+		/// Returns the origin of the tile that contains the point.
+		inline static Imath::V2i tileOrigin( const Imath::V2i &point );
 };
 
 IE_CORE_DECLAREPTR( ImagePlug );

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -72,8 +72,6 @@ class ImageReaderTest( unittest.TestCase ) :
 		
 		self.assertEqual( image, image2 )
 
-	#todo: This test currently fails as there is an issue with the Image Plug and reading negative data windows.
-	# Remove this todo when this bug passes...
 	def testNegativeDataWindow( self ) :
 	
 		n = GafferImage.ImageReader()

--- a/python/GafferImageTest/ReformatTest.py
+++ b/python/GafferImageTest/ReformatTest.py
@@ -57,7 +57,7 @@ class ReformatTest( unittest.TestCase ) :
 		reformat["format"].setValue( GafferImage.Format( 150, 125, 1. ) )
 		reformat["in"].setInput( read["out"] )
 		reformatWindow = reformat["out"]["dataWindow"].getValue()
-		self.assertEqual( reformatWindow, IECore.Box2i( IECore.V2i( 45, 25 ), IECore.V2i( 119, 99 )  ) )
+		self.assertEqual( reformatWindow, IECore.Box2i( IECore.V2i( 45, 25 ), IECore.V2i( 119, 87 )  ) )
 		
 	# Test that when the input and output format are the same that the hash is passed through.
 	def testHashPassThrough( self ) :

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -81,9 +81,9 @@ class CopyTiles
 		void operator()( const blocked_range2d<size_t>& r ) const
 		{
 			ContextPtr context = new Context( *m_parentContext );
-			const Box2i operationWindow( V2i( r.rows().begin(), r.cols().begin() ), V2i( r.rows().end()-1, r.cols().end()-1 ) );
-			V2i minTileOrigin = ( operationWindow.min / m_tileSize ) * m_tileSize;
-			V2i maxTileOrigin = ( operationWindow.max / m_tileSize ) * m_tileSize;
+			const Box2i operationWindow( V2i( r.rows().begin()+m_dataWindow.min.x, r.cols().begin()+m_dataWindow.min.y ), V2i( r.rows().end()+m_dataWindow.min.x-1, r.cols().end()+m_dataWindow.min.y-1 ) );
+			V2i minTileOrigin = ImagePlug::tileOrigin( operationWindow.min );
+			V2i maxTileOrigin = ImagePlug::tileOrigin( operationWindow.max );
 			size_t imageStride = m_dataWindow.size().x + 1;
 			
 			for( int tileOriginY = minTileOrigin.y; tileOriginY <= maxTileOrigin.y; tileOriginY += m_tileSize )
@@ -203,6 +203,14 @@ const IECore::FloatVectorData *ImagePlug::blackTile()
 	return g_blackTile.get();
 };
 
+Imath::V2i ImagePlug::tileOrigin( const Imath::V2i &point )
+{
+	Imath::V2i tileOrigin;
+	tileOrigin.x = int( floor( double( point.x ) / tileSize() ) ) * tileSize();
+	tileOrigin.y = int( floor( double( point.y ) / tileSize() ) ) * tileSize();
+	return tileOrigin;
+}
+
 bool ImagePlug::acceptsChild( const GraphComponent *potentialChild ) const
 {
 	return children().size() != 4;
@@ -319,7 +327,7 @@ IECore::ImagePrimitivePtr ImagePlug::image() const
 		imageChannelData.push_back( &(c[0]) );
 	}
 	
-	parallel_for( blocked_range2d<size_t>(dataWindow.min.x, dataWindow.max.x+1, tileSize(), dataWindow.min.y, dataWindow.max.y+1, tileSize() ),
+	parallel_for( blocked_range2d<size_t>( 0, dataWindow.size().x+1, tileSize(), 0, dataWindow.size().y+1, tileSize() ),
 		      GafferImage::Detail::CopyTiles( imageChannelData, channelNames, channelDataPlug(), dataWindow, Context::current(), tileSize()) );
 	
 	return result;
@@ -335,8 +343,8 @@ IECore::MurmurHash ImagePlug::imageHash() const
 	result.append( dataWindowPlug()->hash() );
 	result.append( channelNamesPlug()->hash() );
 
-	V2i minTileOrigin = ( dataWindow.min / tileSize() ) * tileSize();
-	V2i maxTileOrigin = ( dataWindow.max / tileSize() ) * tileSize();
+	V2i minTileOrigin = tileOrigin( dataWindow.min );
+	V2i maxTileOrigin = tileOrigin( dataWindow.max );
 
 	ContextPtr context = new Context( *Context::current() );
 	for( vector<string>::const_iterator it = channelNames.begin(), eIt = channelNames.end(); it!=eIt; it++ )

--- a/src/GafferImage/Sampler.cpp
+++ b/src/GafferImage/Sampler.cpp
@@ -49,6 +49,7 @@ Sampler::Sampler( const GafferImage::ImagePlug *plug, const std::string &channel
 	m_channelName( channelName )
 {
 	// Get the new sample bounds that includes all intersecting tiles.	
+	//todo: I think that there will be an error with this logic when using images with a negative data window offset. Use the ImagePlug::tileOrigin() call instead.
 	m_sampleWindow = Imath::Box2i( 
 		Imath::V2i( ( sampleWindow.min / Imath::V2i( ImagePlug::tileSize() ) ) * Imath::V2i( ImagePlug::tileSize() ) ),
 		Imath::V2i( ( sampleWindow.max / Imath::V2i( ImagePlug::tileSize() ) ) * Imath::V2i( ImagePlug::tileSize() ) + Imath::V2i( ImagePlug::tileSize() ) - Imath::V2i(1) )


### PR DESCRIPTION
It would appear that the parameters to the tbb blocked_range2d can't be negative which causes issues with negative bounding boxes.
