### PR TITLE
Refactoring GraphGadget::connectionGadgetAt

### DIFF
--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -150,7 +150,7 @@ class GraphGadget : public ContainerGadget
 		void removeConnectionGadgets( const Gaffer::GraphComponent *plugParent );
 		void removeConnectionGadget( const Gaffer::Plug *dstPlug );
 		ConnectionGadget *findConnectionGadget( const Gaffer::Plug *dstPlug ) const;
-		ConnectionGadget *connectionGadgetAt( const IECore::LineSegment3f &lineInGadgetSpace, bool forReconnect ) const;
+		ConnectionGadget *reconnectionGadgetAt( NodeGadget *gadget, const IECore::LineSegment3f &lineInGadgetSpace ) const;
 		void updateDragReconnectCandidate( const DragDropEvent &event );
 		
 		Gaffer::NodePtr m_root;


### PR DESCRIPTION
The public and private functions are now completely separate, reducing unneeded calls to GraphGadget::nodeGadgetAt and Gadget::select during drag-reconnect queries.

This goes towards addressing Issue #283, though the issue should remain open to investigate further speedups within ViewportGadget::SelectionScope or possibly IECoreGL::Selector directly.
