### PR TITLE
Removed Transform2DPlug's dependency on GafferImage

### DIFF
--- a/include/Gaffer/Transform2DPlug.h
+++ b/include/Gaffer/Transform2DPlug.h
@@ -71,7 +71,7 @@ class Transform2DPlug : public CompoundPlug
 		V2fPlug *scalePlug();
 		const V2fPlug *scalePlug() const;
 
-		Imath::M33f matrix( const GafferImage::Format &format ) const;
+		Imath::M33f matrix( const Imath::Box2i &displayWindow, double pixelAspect ) const;
 
 	private :
 		

--- a/python/GafferTest/Transform2DPlugTest.py
+++ b/python/GafferTest/Transform2DPlugTest.py
@@ -38,7 +38,6 @@ import unittest
 
 import IECore
 import Gaffer
-import GafferImage
 import math
 
 class Transform2DPlugTest( unittest.TestCase ) :
@@ -52,8 +51,9 @@ class Transform2DPlugTest( unittest.TestCase ) :
 		p["rotate"].setValue( 45 )
 		p["scale"].setValue( IECore.V2f( 2, 3 ) )
 	
-		format = GafferImage.Format( 10, 10, 1. )
-		formatHeight = format.height() 
+		displayWindow = IECore.Box2i( IECore.V2i(0), IECore.V2i(9) )
+		pixelAspect = 1.
+		formatHeight = displayWindow.size().y+1 
 		pivotValue = p["pivot"].getValue()
 		pivotValue.y = formatHeight - pivotValue.y
 		pivot = IECore.M33f.createTranslated( pivotValue )
@@ -78,11 +78,14 @@ class Transform2DPlugTest( unittest.TestCase ) :
 		for m in ( "pi", "s", "r", "t", "p" ) :
 			transform = transform * transforms[m]
 
-		self.assertEqual( p.matrix( format ), transform )
+		self.assertEqual( p.matrix( displayWindow, pixelAspect ), transform )
 
 	def testTransformOrderExplicit( self ) :
 	
 		plug = Gaffer.Transform2DPlug()
+		
+		displayWindow = IECore.Box2i( IECore.V2i(0), IECore.V2i(9) )
+		pixelAspect = 1.
 	
 		t =	IECore.V2f( 100, 0 )
 		r =	90
@@ -96,7 +99,7 @@ class Transform2DPlugTest( unittest.TestCase ) :
 		# Test if this is equal to a simple hardcoded matrix, down to floating point error
 		# This verifies that translation is not being affected by rotation and scale,
 		# which is what users will expect
-		self.assertTrue( plug.matrix( GafferImage.Format( 10, 10, 1. ) ).equalWithAbsError(
+		self.assertTrue( plug.matrix( displayWindow, pixelAspect ).equalWithAbsError(
 			IECore.M33f(
 				0,   2, 0,
 				-2,  0, 0,

--- a/src/Gaffer/Transform2DPlug.cpp
+++ b/src/Gaffer/Transform2DPlug.cpp
@@ -37,7 +37,6 @@
 #include "IECore/AngleConversion.h"
 
 #include "Gaffer/Transform2DPlug.h"
-#include "GafferImage/Format.h"
 
 using namespace Imath;
 using namespace Gaffer;
@@ -151,14 +150,14 @@ const V2fPlug *Transform2DPlug::scalePlug() const
 	return getChild<V2fPlug>( g_firstPlugIndex+2 );
 }
 
-Imath::M33f Transform2DPlug::matrix( const GafferImage::Format &format ) const
+Imath::M33f Transform2DPlug::matrix( const Imath::Box2i &displayWindow, double pixelAspect ) const
 {
 	// We need to transform from image space (with 0x0 being the bottom left)
 	// to Gadget space (where 0x0 is the top left). To do this, we need to know the
 	// size of the Format.
 	
 	///\todo: We don't handle the pixel aspect of the format here but we should!
-	float formatHeight = format.getDisplayWindow().size().y + 1;
+	float formatHeight = displayWindow.size().y + 1;
 	
 	M33f p;
 	V2f pivotVec = pivotPlug()->getValue();

--- a/src/GafferImage/ImageTransform.cpp
+++ b/src/GafferImage/ImageTransform.cpp
@@ -128,7 +128,7 @@ Imath::Box2i ImageTransform::computeDataWindow( const Gaffer::Context *context, 
 {
 	Format inFormat( inPlug()->formatPlug()->getValue() );
 	Imath::Box2i inWindow( inPlug()->dataWindowPlug()->getValue() );
-	Imath::Box2i outWindow( transformBox( transformPlug()->matrix( inFormat ), inWindow ) );
+	Imath::Box2i outWindow( transformBox( transformPlug()->matrix( inFormat.getDisplayWindow(), inFormat.getPixelAspect() ), inWindow ) );
 	return outWindow;
 }
 
@@ -179,7 +179,7 @@ IECore::ConstFloatVectorDataPtr ImageTransform::computeChannelData( const std::s
 
 	// Work out the sample area that we require to compute this tile.
 	Format inputFormat = inPlug()->formatPlug()->getValue();
-	Imath::M33f t( transformPlug()->matrix( inputFormat ).inverse() );
+	Imath::M33f t( transformPlug()->matrix( inputFormat.getDisplayWindow(), inputFormat.getPixelAspect() ).inverse() );
 	Imath::Box2i inWindow( inPlug()->dataWindowPlug()->getValue() );
 	Imath::Box2i sampleBox( transformBox( t, tile ) );
 	


### PR DESCRIPTION
Changed Transform2DPlug::Matrix( GafferImage::Format ) to Transform2DPlug::Matrix( const &Imath::Box2i displayWindow, double pixelAspect ) to remove dependency on the GafferImage module from within the Gaffer module.

This fixes issue: #274 
