### PR TITLE
Added error handling for bad RenderManShader activator annotations.

### DIFF
--- a/python/GafferRenderManUI/RenderManShaderUI.py
+++ b/python/GafferRenderManUI/RenderManShaderUI.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import fnmatch
+import traceback
 
 import IECore
 
@@ -150,8 +151,12 @@ class __NodeUI( GafferUI.StandardNodeUI ) :
 			if not plugs :
 				continue
 
-			active = eval( expression, globals(), ExpressionVariables( parametersPlug ) )
-
+			try :
+				active = eval( expression, globals(), ExpressionVariables( parametersPlug ) )
+			except Exception, e :
+				IECore.msg( IECore.Msg.Level.Error, "Parameter activator", "".join( traceback.format_exception_only( type( e ), e ) ) )
+				continue
+				
 			for plug in plugs :
 				plugValueWidget = self.plugValueWidget( plug, lazy=False )
 				if plugValueWidget is not None :


### PR DESCRIPTION
Prior to this they would destroy the UI to the point that you couldn't reload the shader to fix the problem. Now they just print our a helpful error message.
