### PR TITLE
Set the name attribute for lights properly in the Render node.

### DIFF
--- a/python/GafferSceneTest/RenderTest.py
+++ b/python/GafferSceneTest/RenderTest.py
@@ -143,6 +143,29 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertTrue( isinstance( l[0], IECore.AttributeState ) )
 		self.assertEqual( l[0].attributes["user:test"], IECore.IntData( 10 ) )
 		self.assertTrue( isinstance( l[1], IECore.Light ) )
-				
+	
+	def testLightName( self ) :
+	
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( "/tmp/test.gfr" )
+		
+		s["l"] = GafferSceneTest.TestLight()
+		s["g"] = GafferScene.Group()
+		s["g"]["in"].setInput( s["l"]["out"] )
+		
+		self.assertSceneValid( s["g"]["out"] )
+	
+		s["r"] = GafferSceneTest.TestRender()
+		s["r"]["in"].setInput( s["g"]["out"] )
+		
+		# CapturingRenderer outputs some spurious errors which
+		# we suppress by capturing them.
+		with IECore.CapturingMessageHandler() :
+			s["r"].execute( [ Gaffer.Context.current() ] )
+		
+		w = s["r"].world()
+		self.assertEqual( w.children()[0].state()[0].attributes["name"].value, "/group/light" )
+		self.assertEqual( w.children()[0].state()[1].handle, "/group/light" )
+					
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -203,6 +203,8 @@ void Render::outputLights( const ScenePlug *scene, const IECore::CompoundObject 
 		{
 			AttributeBlock attributeBlock( renderer );
 		
+			renderer->setAttribute( "name", new StringData( it->first ) );
+		
 			CompoundObject::ObjectMap::const_iterator aIt, aeIt;
 			for( aIt = attributes->members().begin(), aeIt = attributes->members().end(); aIt != aeIt; aIt++ )
 			{


### PR DESCRIPTION
Fixes #326.
