### PR TITLE
Reduced occurences of accidental connection snatching.

### DIFF
--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -788,30 +788,6 @@ void GraphGadget::updateDragReconnectCandidate( const DragDropEvent &event )
 		return;
 	}
 	
-	// make sure there is a free output for reconnection
-	for ( Gaffer::RecursiveOutputPlugIterator cIt( node ); cIt != cIt.end(); ++cIt )
-	{
-		Gaffer::Plug *p = cIt->get();
-		for ( Gaffer::Plug::OutputContainer::const_iterator oIt = p->outputs().begin(); oIt != p->outputs().end(); ++oIt )
-		{
-			NodeGadget *oNodeGadget = nodeGadget( (*oIt)->node() );
-			if ( oNodeGadget && oNodeGadget->nodule( *oIt ) )
-			{
-				return;
-			}
-		}
-		
-		// make sure its corresponding input is also free
-		if ( Gaffer::DependencyNode *depNode = IECore::runTimeCast<Gaffer::DependencyNode>( node ) )
-		{
-			Gaffer::Plug *in = depNode->correspondingInput( p );
-			if ( in && in->getInput<Gaffer::Plug>() )
-			{
-				return;
-			}
-		}
-	}
-	
 	m_dragReconnectCandidate = reconnectionGadgetAt( selNodeGadget, event.line );
 	if ( !m_dragReconnectCandidate )
 	{
@@ -827,32 +803,79 @@ void GraphGadget::updateDragReconnectCandidate( const DragDropEvent &event )
 		return;
 	}
 	
-	for( Gaffer::RecursiveInputPlugIterator cIt( node ); cIt != cIt.end(); ++cIt )
+	Gaffer::DependencyNode *depNode = IECore::runTimeCast<Gaffer::DependencyNode>( node );
+	for ( Gaffer::RecursiveOutputPlugIterator cIt( node ); cIt != cIt.end(); ++cIt )
 	{
+		// must be compatible
 		Gaffer::Plug *p = cIt->get();
-		if( !p->getInput<Gaffer::Plug>() && p->acceptsInput( srcPlug ) )
+		if ( !dstPlug->acceptsInput( p ) )
 		{
-			m_dragReconnectDstNodule = selNodeGadget->nodule( p );
+			continue;
+		}
+		
+		// must have a nodule
+		m_dragReconnectSrcNodule = selNodeGadget->nodule( p );
+		if ( !m_dragReconnectSrcNodule )
+		{
+			continue;
+		}
+		
+		// must not be connected to a nodule
+		for ( Gaffer::Plug::OutputContainer::const_iterator oIt = p->outputs().begin(); oIt != p->outputs().end(); ++oIt )
+		{
+			NodeGadget *oNodeGadget = nodeGadget( (*oIt)->node() );
+			if ( oNodeGadget && oNodeGadget->nodule( *oIt ) )
+			{
+				m_dragReconnectSrcNodule = 0;
+				break;
+			}
+		}
+		
+		if ( !m_dragReconnectSrcNodule )
+		{
+			continue;
+		}
+		
+		if ( !depNode )
+		{
+			// found the best option
+			break;
+		}
+		
+		// make sure its corresponding input is also free
+		if ( Gaffer::Plug *in = depNode->correspondingInput( p ) )
+		{
+			if ( in->getInput<Gaffer::Plug>() )
+			{
+				m_dragReconnectSrcNodule = 0;
+				continue;
+			}
+			
+			m_dragReconnectDstNodule = selNodeGadget->nodule( in );
 			if ( m_dragReconnectDstNodule )
 			{
 				break;
 			}
 		}
 	}
-
-	for( Gaffer::RecursiveOutputPlugIterator cIt( node ); cIt != cIt.end(); ++cIt )
+	
+	// check input plugs on non-dependencyNodes
+	if ( !depNode && !m_dragReconnectDstNodule )
 	{
-		Gaffer::Plug *p = cIt->get();
-		if( dstPlug->acceptsInput( p ) )
+		for ( Gaffer::RecursiveInputPlugIterator cIt( node ); cIt != cIt.end(); ++cIt )
 		{
-			m_dragReconnectSrcNodule = selNodeGadget->nodule( p );
-			if ( m_dragReconnectSrcNodule )
+			Gaffer::Plug *p = cIt->get();
+			if ( !p->getInput<Gaffer::Plug>() && p->acceptsInput( srcPlug ) )
 			{
-				break;
+				m_dragReconnectDstNodule = selNodeGadget->nodule( p );
+				if ( m_dragReconnectDstNodule )
+				{
+					break;
+				}
 			}
 		}
 	}
-		
+	
 	if ( !m_dragReconnectSrcNodule && !m_dragReconnectDstNodule )
 	{
 		m_dragReconnectCandidate = 0;


### PR DESCRIPTION
GraphGadget::updateDragReconnectCandidate will early out if there are no free output plugs, or if a free output plug defines a corresonding input which is not free. Fixes #325 and Fixes #313. Fixes #283 enough that I think we should close it, lest it be open for all eternity.
