### PR TITLE
Typing Escape in a submenu closes all parent menus as well.

### DIFF
--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -456,6 +456,8 @@ class _Menu( QtGui.QMenu ) :
 			while isinstance( parent, _Menu ) :
 				parent.close()
 				parent = parent.parentWidget()
+			
+			return
 		
 		if not self.keyboardMode == _Menu.KeyboardMode.Grab :
 			


### PR DESCRIPTION
Navigation back to parent menus is still possible using the arrow keys or mouse.
