### PR TITLE
Fixed a broken test case within GafferImageTest.FormatTest.

### DIFF
--- a/src/GafferImage/Format.cpp
+++ b/src/GafferImage/Format.cpp
@@ -306,7 +306,7 @@ void Format::addDefaultFormatPlug( ScriptNode *scriptNode )
 	
 	Format initialFormatValue( 1920, 1080, 1. ); // The initial value that the default format will start with when gaffer is opened.
 	
-	// If the plug hasn't been created already then it is likely that this script wasn't loaded. We deduce this becuase the
+	// If the plug hasn't been created already then it is likely that this script wasn't loaded. We deduce this because the
 	// default format plug on the script node is dynamic and therefore if we loaded the script, it would have been created.
 	if (!plug)
 	{

--- a/src/GafferImage/FormatPlug.cpp
+++ b/src/GafferImage/FormatPlug.cpp
@@ -76,6 +76,23 @@ IECore::MurmurHash FormatPlug::hash() const
 	if( direction()==Plug::In && !getInput<ValuePlug>() )
 	{
 		Format v = getValue();
+		if( v.getDisplayWindow().isEmpty() )
+		{
+			const Gaffer::Node *n( node() );
+			if( n )
+			{
+				const Gaffer::ScriptNode *s( n->scriptNode() );
+				if ( s )
+				{
+					const GafferImage::FormatPlug *p( s->getChild<FormatPlug>( GafferImage::Format::defaultFormatPlugName ) );
+					if ( p )
+					{
+						v = p->getValue();
+					}
+				}
+			}
+		}
+
 		result.append( v.getDisplayWindow().min );
 		result.append( v.getDisplayWindow().max );
 		result.append( v.getPixelAspect() );


### PR DESCRIPTION
Fixed the broken format test case: GafferImageTest.FormatTest.testHashChanged

The GafferImage::FormatPlug::hash() method will now lookup the value of the default hash from the script node if the result of getValue() is an empty box.
