### PR TITLE
Added support for RSL "parameterName.label" annotation.

### DIFF
--- a/python/GafferRenderManUI/RenderManShaderUI.py
+++ b/python/GafferRenderManUI/RenderManShaderUI.py
@@ -380,5 +380,15 @@ def __plugDescription( plug ) :
 
 	return d.value if d is not None else ""
 
+def __plugLabel( plug ) :
+
+	annotations = _shaderAnnotations( plug.node() )
+	d = annotations.get( plug.getName() + ".label", None )
+	
+	return d.value if d is not None else None
+
 GafferUI.Metadata.registerPlugDescription( GafferRenderMan.RenderManShader, "parameters.*", __plugDescription )
 GafferUI.Metadata.registerPlugDescription( GafferRenderMan.RenderManLight, "parameters.*", __plugDescription )
+
+GafferUI.Metadata.registerPlugValue( GafferRenderMan.RenderManShader, "parameters.*", "label", __plugLabel )
+GafferUI.Metadata.registerPlugValue( GafferRenderMan.RenderManLight, "parameters.*", "label", __plugLabel )

--- a/python/GafferUI/PlugWidget.py
+++ b/python/GafferUI/PlugWidget.py
@@ -80,6 +80,9 @@ class PlugWidget( GafferUI.Widget ) :
 		# interface. Perhaps we should have a SizeableContainer or something?
 		self.__label.label()._qtWidget().setFixedWidth( self.labelWidth() )
 
+		if label is None :
+			label = GafferUI.Metadata.plugValue( plug, "label" )
+			
 		if label is not None :
 			self.__label.label().setText( label )
 


### PR DESCRIPTION
This can be used to override the default label for a parameter. This has the secondary affect of allowing any plug to be relabelled using a "label" plug metadata entry.

Fixes #372.
