### PR TITLE
Ganging for CompoundNumericPlugs.

### DIFF
--- a/include/Gaffer/CompoundNumericPlug.h
+++ b/include/Gaffer/CompoundNumericPlug.h
@@ -91,6 +91,21 @@ class CompoundNumericPlug : public CompoundPlug
 		/// of the result.
 		T getValue() const;
 		
+		/// @name Ganging
+		/// CompoundNumericPlugs may be ganged by connecting the child plugs
+		/// together so their values are driven by the first child. These
+		/// methods allow the children to be ganged and unganged, and for their
+		/// ganging status to be queried.
+		////////////////////////////////////////////////////////////////////
+		//@{
+		bool canGang() const;
+		/// \undoable
+		void gang();
+		bool isGanged() const;
+		/// \undoable
+		void ungang();
+		//@}
+		
 	private :
 	
 		IE_CORE_DECLARERUNTIMETYPEDDESCRIPTION( CompoundNumericPlug<T> );

--- a/python/GafferTest/CompoundNumericPlugTest.py
+++ b/python/GafferTest/CompoundNumericPlugTest.py
@@ -325,6 +325,25 @@ class CompoundNumericPlugTest( unittest.TestCase ) :
 		
 		self.assertTrue( n["p1"].settable() )
 		self.assertFalse( n["p2"].settable() )
+	
+	def testGanging( self ) :
+	
+		p = Gaffer.Color4fPlug()
+		
+		self.assertFalse( p.isGanged() )
+		self.assertTrue( p.canGang() )
+		p.gang()
+		self.assertTrue( p.isGanged() )
+		self.assertTrue( p[0].getInput() is None )
+		self.assertTrue( p[1].getInput().isSame( p[0] ) )
+		self.assertTrue( p[2].getInput().isSame( p[0] ) )
+		self.assertTrue( p[3].getInput() is None )
+		
+		p.ungang()
+		for c in p.children() :
+			self.assertTrue( c.getInput() is None )
+		self.assertFalse( p.isGanged() )
+		self.assertTrue( p.canGang() )
 		
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/CompoundNumericPlug.cpp
+++ b/src/Gaffer/CompoundNumericPlug.cpp
@@ -177,6 +177,62 @@ const char **CompoundNumericPlug<T>::childNames()
 	return names;
 }
 
+template<typename T>
+bool CompoundNumericPlug<T>::canGang() const
+{
+	for( size_t i = 1, e = std::min( (size_t)3, children().size() ); i < e; ++i )
+	{
+		if( !getChild( i )->acceptsInput( getChild( 0 ) ) )
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+template<typename T>
+void CompoundNumericPlug<T>::gang()
+{
+	// ignore any 4th children - these are alpha values and ganging them
+	// doesn't really make any sense.
+	for( size_t i = 1, e = std::min( (size_t)3, children().size() ); i < e; ++i )
+	{
+		getChild( i )->setInput( getChild( 0 ) );
+	}
+}
+
+template<typename T>
+bool CompoundNumericPlug<T>::isGanged() const
+{
+	for( size_t i = 1, e = children().size(); i < e; ++i )
+	{
+		if( const Plug *input = getChild( i )->getInput<Plug>() )
+		{
+			if( input->parent<Plug>() == this )
+			{
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+template<typename T>
+void CompoundNumericPlug<T>::ungang()
+{
+	for( size_t i = 1, e = children().size(); i < e; ++i )
+	{
+		Plug *child = getChild( i );
+		if( const Plug *input = child->getInput<Plug>() )
+		{
+			if( input->parent<Plug>() == this )
+			{
+				child->setInput( 0 );
+			}
+		}
+	}
+}
+
 // specialisations
 
 namespace Gaffer

--- a/src/GafferBindings/CompoundNumericPlugBinding.cpp
+++ b/src/GafferBindings/CompoundNumericPlugBinding.cpp
@@ -114,6 +114,10 @@ static void bind()
 		.def( "setValue", &T::setValue )
 		.def( "getValue", &T::getValue )
 		.def( "__repr__", &compoundNumericPlugRepr<T> )
+		.def( "canGang", &T::canGang )
+		.def( "gang", &T::gang )
+		.def( "isGanged", &T::isGanged )
+		.def( "ungang", &T::ungang )
 	;
 
 }


### PR DESCRIPTION
This is provided at the API level by new methods on the CompoundNumericPlug. It is then made available to the user on the popup menu on plug fields, and via a Ctrl-G shortcut when the cursor is in a plug field.

Fixes #402.
