### PR TITLE
Fixed size issues caused by TabbedContainer size policy.

### DIFF
--- a/python/GafferUI/SplitContainer.py
+++ b/python/GafferUI/SplitContainer.py
@@ -1,7 +1,7 @@
 ##########################################################################
 #  
 #  Copyright (c) 2011, John Haddon. All rights reserved.
-#  Copyright (c) 2011-2012, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2011-2013, Image Engine Design Inc. All rights reserved.
 #  
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -76,6 +76,7 @@ class SplitContainer( GafferUI.ContainerWidget ) :
 		if oldParent is not None :
 			oldParent.removeChild( child )
 			
+		self.__applySizePolicy( child )
 		self.__widgets.append( child )
 		self._qtWidget().addWidget( child._qtWidget() )
 		child._applyVisibility()
@@ -93,6 +94,7 @@ class SplitContainer( GafferUI.ContainerWidget ) :
 		if oldParent :
 			oldParent.removeChild( child )
 			
+		self.__applySizePolicy( child )
 		self.__widgets.insert( index, child )
 		self._qtWidget().insertWidget( index,  child._qtWidget() )
 		child._applyVisibility()
@@ -109,6 +111,7 @@ class SplitContainer( GafferUI.ContainerWidget ) :
 	def removeChild( self, child ) :
 	
 		assert( child in self.__widgets )
+		child._qtWidget().setSizePolicy( child.__originalSizePolicy )
 		child._qtWidget().setParent( None )
 		child._applyVisibility()
 		self.__widgets.remove( child )
@@ -194,6 +197,14 @@ class SplitContainer( GafferUI.ContainerWidget ) :
 	def __len__( self ) :
 		
 		return len( self.__widgets )
+		
+	def __applySizePolicy( self, widget ) :
+	
+		# this size policy allows the children to be cropped to any size - otherwise some stubbornly
+		# stay at a minimum size and then suddenly collapse to nothing when moving the splitter all
+		# the way. we store the original size policy on the widget and reapply it in removeChild().
+		widget.__originalSizePolicy = widget._qtWidget().sizePolicy()
+		widget._qtWidget().setSizePolicy( QtGui.QSizePolicy.Ignored, QtGui.QSizePolicy.Ignored )
 
 # We inherit from QSplitter purely so that the handles can be created
 # in Python rather than C++. This seems to help PyQt and PySide in tracking

--- a/python/GafferUI/TabbedContainer.py
+++ b/python/GafferUI/TabbedContainer.py
@@ -62,11 +62,6 @@ class TabbedContainer( GafferUI.ContainerWidget ) :
 		
 		self._qtWidget().setUsesScrollButtons( False )
 		self._qtWidget().setElideMode( QtCore.Qt.ElideNone )
-		# this size policy allows TabbedContainers to be cropped when placed inside SplitContainers -
-		# otherwise they stubbornly stay at a minimum width and then suddenly collapse. might it turn
-		# out that we'd be better off setting this size policy automatically when any child is added
-		# to a SplitContainer? and resetting it on removal?
-		self._qtWidget().setSizePolicy( QtGui.QSizePolicy.Ignored, QtGui.QSizePolicy.Ignored )
 		
 		self.__widgets = []
 		


### PR DESCRIPTION
This one has been annoying me for a while, so I thought I'd fix it quickly...

Previously we had set the TabbedContainer size policy to Ignore, regardless of where it was being used. But really we just wanted it to stop the SplitContainers in the main layout from collapsing, and the size policy broke the sizing for the Settings and About windows. Now the SplitContainer sets the size policy to ignore for all its children, restoring the real size policy when they're removed. This keeps the nice smooth splitting behaviour in the main layout, but prevents the unwanted side effects where the other windows were created too small.
