### PR TITLE
Implemented dividers in the NodeEditor.

### DIFF
--- a/python/GafferRenderManUI/RenderManShaderUI.py
+++ b/python/GafferRenderManUI/RenderManShaderUI.py
@@ -387,8 +387,20 @@ def __plugLabel( plug ) :
 	
 	return d.value if d is not None else None
 
+def __plugDivider( plug ) :
+
+	annotations = _shaderAnnotations( plug.node() )
+	d = annotations.get( plug.getName() + ".divider", None )
+	if d is None :
+		return False
+		
+	return d.value.lower() in ( "True", "true", "1" )	
+
 GafferUI.Metadata.registerPlugDescription( GafferRenderMan.RenderManShader, "parameters.*", __plugDescription )
 GafferUI.Metadata.registerPlugDescription( GafferRenderMan.RenderManLight, "parameters.*", __plugDescription )
 
 GafferUI.Metadata.registerPlugValue( GafferRenderMan.RenderManShader, "parameters.*", "label", __plugLabel )
 GafferUI.Metadata.registerPlugValue( GafferRenderMan.RenderManLight, "parameters.*", "label", __plugLabel )
+
+GafferUI.Metadata.registerPlugValue( GafferRenderMan.RenderManShader, "parameters.*", "divider", __plugDivider )
+GafferUI.Metadata.registerPlugValue( GafferRenderMan.RenderManLight, "parameters.*", "divider", __plugDivider )

--- a/python/GafferUI/CompoundPlugValueWidget.py
+++ b/python/GafferUI/CompoundPlugValueWidget.py
@@ -215,6 +215,8 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 				widget = self.__childPlugUIs[childPlug.getName()]
 			if widget is not None :	
 				orderedChildUIs.append( widget )
+				if GafferUI.Metadata.plugValue( childPlug, "divider" ) :
+					orderedChildUIs.append( GafferUI.Divider() )
 		
 		# add header and footer
 		headerWidget = self._headerWidget()

--- a/python/GafferUI/Divider.py
+++ b/python/GafferUI/Divider.py
@@ -1,0 +1,68 @@
+##########################################################################
+#  
+#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#  
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#  
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#  
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#  
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#  
+##########################################################################
+
+import IECore
+
+import GafferUI
+
+QtGui = GafferUI._qtImport( "QtGui" )
+
+class Divider( GafferUI.Widget ) :
+
+	Orientation = IECore.Enum.create( "Vertical", "Horizontal" )
+	
+	def __init__( self, orientation = Orientation.Horizontal, **kw ) :
+
+		GafferUI.Widget.__init__( self, QtGui.QFrame(), **kw )
+		
+		self._qtWidget().setObjectName( "gafferDivider" )
+		
+		self.setOrientation( orientation )
+		
+	def setOrientation( self, orientation ) :
+	
+		if orientation == self.Orientation.Horizontal :
+			self._qtWidget().setFrameShape( QtGui.QFrame.HLine )
+		else :
+			self._qtWidget().setFrameShape( QtGui.QFrame.VLine )
+
+	def getOrientation( self ) :
+	
+		if self._qtWidget().frameShape() == QtGui.QFrame.HLine :
+			return self.Orientation.Horizontal
+		else :
+			return self.Orientation.Vertical
+		

--- a/python/GafferUI/StandardNodeUI.py
+++ b/python/GafferUI/StandardNodeUI.py
@@ -172,6 +172,9 @@ class StandardNodeUI( GafferUI.NodeUI ) :
 			sectionColumn = self.__sectionColumn( sectionName )
 			sectionColumn.append( widget )
 
+			if GafferUI.Metadata.plugValue( plug, "divider" ) :
+				sectionColumn.append( GafferUI.Divider() )
+
 	def __currentTabChanged( self, tabbedContainer, current ) :
 
 		assert( tabbedContainer is self.__tabbedContainer )

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -1321,6 +1321,10 @@ class Widget( object ) :
 			padding: 2px;
 		}
 		
+		.QFrame#gafferDivider {
+			color: $backgroundDark;
+		}
+		
 		QToolTip {
 			background-clip: border;
 			color: $backgroundDarkest;

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -146,6 +146,7 @@ from MenuButton import MenuButton
 from PopupWindow import PopupWindow
 from ConfirmationDialogue import ConfirmationDialogue
 from DisplayTransform import DisplayTransform
+from Divider import Divider
 import _Pointer
 
 # then stuff specific to graph uis


### PR DESCRIPTION
A divider is introduced underneath a plug when that plug has a "divider" metadata entry of True. RenderMan shader writers may use the annotation "parameterName.divider" with a value of "True", "true", or "1" to enable this behaviour for a particular shader parameter.

Fixes #288.
