### PR TITLE
exposes application to any subsequent 'cmd' run in this process

### DIFF
--- a/apps/screengrab/screengrab-1.py
+++ b/apps/screengrab/screengrab-1.py
@@ -103,11 +103,15 @@ class screengrab( Gaffer.Application ) :
 			IECore.msg( IECore.Msg.Level.Info, "screengrab", "Creating target directory [ %s ]" % (targetdir) )
 			os.makedirs(targetdir)
 		
-		#expose self as a["application"] when running the cmd
-		d = { "application" : self }
+		#expose some variables when running the cmd
+		d = {
+				"application" 	: self,
+				"script"		: script,
+			}
+		
 		
 		#execute any commands passed as arguments prior to doing the screengrab
-		exec(str(args["cmd"]))
+		exec(str(args["cmd"]), d, d)
 		
 		#register the function to run when the app is idle.
 		self.__idleCount = 0


### PR DESCRIPTION
By declaring the d{} variable this can then be queried by the commands executed post gaffer launch.
Is requried to provide access to the 'application' in order to  be able to things like:
`layouts = GafferUI.Layouts.acquire( d['application'] )`
