### PR TITLE
Fixed SceneView expansion bug.

### DIFF
--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -205,6 +205,8 @@ bool SceneView::keyPress( GafferUI::GadgetPtr gadget, const GafferUI::KeyEvent &
 
 void SceneView::expandSelection()
 {
+	Context::Scope scopedContext( getContext() );
+
 	RenderableGadget::Selection &selection = m_renderableGadget->getSelection();
 	
 	vector<string> pathsToSelect;


### PR DESCRIPTION
The correct Context wasn't being used to evaluate the children of the selection, meaning that if the viewed Nodes used any context variables or where time dependent, errors would occur.

Fixes #438.
