### PR TITLE
Fixed Box creation with nested connected plugs.

### DIFF
--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -892,6 +892,54 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		self.assertEqual( len( s ), 2 )
 		self.assertEqual( s[1].parameters["coshaderParameter"], s[0].parameters["__handle"] )
 		self.assertEqual( s[0].name, coshader )
+	
+	def testCoshadersInBox( self ) :
+	
+		s = Gaffer.ScriptNode()
+	
+		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/coshaderParameter.sl" )
+		s["shader"] = GafferRenderMan.RenderManShader()
+		s["shader"].loadShader( shader )
+				
+		coshader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/coshader.sl" )
+		s["coshader"] = GafferRenderMan.RenderManShader()
+		s["coshader"].loadShader( coshader )
+
+		s["shader"]["parameters"]["coshaderParameter"].setInput( s["coshader"]["out"] )
+				
+		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["coshader"] ] ) )
+
+		self.assertTrue( s["shader"]["parameters"]["coshaderParameter"].getInput().parent().isSame( b ) )
+		
+		s = s["shader"].state()
+		
+		self.assertEqual( len( s ), 2 )
+		self.assertEqual( s[1].parameters["coshaderParameter"], s[0].parameters["__handle"] )
+		self.assertEqual( s[0].name, coshader )
+		
+	def testShaderInBoxWithExternalCoshader( self ) :
+	
+		s = Gaffer.ScriptNode()
+	
+		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/coshaderParameter.sl" )
+		s["shader"] = GafferRenderMan.RenderManShader()
+		s["shader"].loadShader( shader )
+				
+		coshader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/coshader.sl" )
+		s["coshader"] = GafferRenderMan.RenderManShader()
+		s["coshader"].loadShader( coshader )
+
+		s["shader"]["parameters"]["coshaderParameter"].setInput( s["coshader"]["out"] )
+				
+		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["shader"] ] ) )
+
+		self.assertTrue( b["shader"]["parameters"]["coshaderParameter"].getInput().parent().isSame( b ) )
+		
+		s = b["shader"].state()
+		
+		self.assertEqual( len( s ), 2 )
+		self.assertEqual( s[1].parameters["coshaderParameter"], s[0].parameters["__handle"] )
+		self.assertEqual( s[0].name, coshader )
 		
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
We were only iterating over the top level plugs when finding the plugs to reroute via the Box, so weren't picking up nested plugs such as shader parameters. We now use a RecursivePlugIterator to make sure we iterate to the nested plugs, and after finding connected plugs we prune the iteration to avoid visiting their children, which will already have been promoted and connected when their parent was.
