### PR TITLE
Added member context to GafferScene::InteractiveRender

### DIFF
--- a/include/GafferScene/InteractiveRender.h
+++ b/include/GafferScene/InteractiveRender.h
@@ -37,6 +37,7 @@
 #ifndef GAFFERSCENE_INTERACTIVERENDER_H
 #define GAFFERSCENE_INTERACTIVERENDER_H
 
+#include "Gaffer/Context.h"
 #include "GafferScene/Render.h"
 
 namespace GafferScene
@@ -70,6 +71,12 @@ class InteractiveRender : public Render
 		Gaffer::BoolPlug *updateShadersPlug();
 		const Gaffer::BoolPlug *updateShadersPlug() const;
 		
+		/// The Context in which the InteractiveRender should operate.
+		Gaffer::Context *getContext();
+		const Gaffer::Context *getContext() const;
+		void setContext( Gaffer::ContextPtr context );
+		
+		
 	protected :
 	
 		/// Must be implemented by derived classes to return the renderer that will be used.
@@ -79,14 +86,17 @@ class InteractiveRender : public Render
 
 		void plugInputChanged( const Gaffer::Plug *plug );
 		void plugSetOrDirtied( const Gaffer::Plug *plug );
-
+		void parentChanged( Gaffer::GraphComponent *child, Gaffer::GraphComponent *oldParent );
+		
 		void start();
 		void update();
 		void updateLights();
 		void updateShaders( const ScenePlug::ScenePath &path = ScenePlug::ScenePath() );
 	
 		IECore::RendererPtr m_renderer;
-
+		
+		Gaffer::ContextPtr m_context;
+		
 		static size_t g_firstPlugIndex;
 		
 };

--- a/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
+++ b/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
@@ -285,6 +285,23 @@ class InteractiveRenderManRenderTest( unittest.TestCase ) :
 			IECore.V2f( 0.5 ),
 		)
 		self.assertEqual( c, IECore.Color3f( 0.5 ) )
-				
+	
+	def testContext( self ):
+		
+		s = Gaffer.ScriptNode()
+		
+		r = GafferRenderMan.InteractiveRenderManRender()
+		
+		self.assertNotEqual( r.getContext(), None )
+		self.failIf( r.getContext().isSame( s.context() ) )
+		
+		s["r"] = r
+		
+		self.failUnless( r.getContext().isSame( s.context() ) )
+		
+		s.removeChild( r )
+		
+		self.failIf( r.getContext().isSame( s.context() ) )
+		
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneBindings/RenderBinding.cpp
+++ b/src/GafferSceneBindings/RenderBinding.cpp
@@ -108,6 +108,11 @@ class ExecutableRenderWrapper : public NodeWrapper<ExecutableRender>
 
 IE_CORE_DECLAREPTR( ExecutableRenderWrapper )
 
+static ContextPtr interactiveRenderGetContext( InteractiveRender &r )
+{
+	return r.getContext();
+}
+
 void GafferSceneBindings::bindRender()
 {
 
@@ -118,7 +123,9 @@ void GafferSceneBindings::bindRender()
 	
 	GafferBindings::NodeClass<OpenGLRender>();
 	
-	scope s = GafferBindings::NodeClass<InteractiveRender>();
+	scope s = GafferBindings::NodeClass<InteractiveRender>()
+		.def( "getContext", &interactiveRenderGetContext )
+		.def( "setContext", &InteractiveRender::setContext );
 	
 	enum_<InteractiveRender::State>( "State" )
 		.value( "Stopped", InteractiveRender::Stopped )


### PR DESCRIPTION
GafferScene::InteractiveRender now has a context member variable, which is used while it's evaluating the scene. It's also got accessor methods, and is automatically set to the context of the script it belongs to (if one exists)
