### PR TITLE
Fixed connection drag bug.

### DIFF
--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -333,7 +333,10 @@ bool StandardNodule::drop( GadgetPtr gadget, const DragDropEvent &event )
 				// new connection above, as removing a connection can trigger an InputGenerator
 				// to remove plugs, possibly including the input plug we're want to connect to.
 				// see issue #302.
-				connection->dstNodule()->plug()->setInput( 0 );
+				if( connection->dstNodule()->plug() != input )
+				{
+					connection->dstNodule()->plug()->setInput( 0 );
+				}
 			}
 			
 		return true;


### PR DESCRIPTION
Dragging the endpoint of a connection around and then placing it back where it started was breaking the connection, whereas it should have been having no effect. This fixes that.
