### PR TITLE
Added parameterName.type RenderManShader annotation

### DIFF
--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -940,6 +940,27 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		self.assertEqual( len( s ), 2 )
 		self.assertEqual( s[1].parameters["coshaderParameter"], s[0].parameters["__handle"] )
 		self.assertEqual( s[0].name, coshader )
+	
+	def testNumericTypeAnnotations( self ) :
+	
+		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/numericTypeAnnotations.sl" )
+		shaderNode = GafferRenderMan.RenderManShader()
+		shaderNode.loadShader( shader )
+		
+		self.assertTrue( isinstance( shaderNode["parameters"]["floatParameter1"], Gaffer.FloatPlug ) )
+		self.assertTrue( isinstance( shaderNode["parameters"]["floatParameter2"], Gaffer.FloatPlug ) )
+		self.assertTrue( isinstance( shaderNode["parameters"]["intParameter"], Gaffer.IntPlug ) )
+		self.assertTrue( isinstance( shaderNode["parameters"]["boolParameter"], Gaffer.BoolPlug ) )
+		
+		self.assertEqual( shaderNode["parameters"]["floatParameter1"].defaultValue(), 1.25 )
+		self.assertEqual( shaderNode["parameters"]["floatParameter2"].defaultValue(), 1.5 )
+		self.assertEqual( shaderNode["parameters"]["intParameter"].defaultValue(), 10 )
+		self.assertEqual( shaderNode["parameters"]["boolParameter"].defaultValue(), True )
+		
+		self.assertEqual( shaderNode["parameters"]["floatParameter1"].getValue(), 1.25 )
+		self.assertEqual( shaderNode["parameters"]["floatParameter2"].getValue(), 1.5 )
+		self.assertEqual( shaderNode["parameters"]["intParameter"].getValue(), 10 )
+		self.assertEqual( shaderNode["parameters"]["boolParameter"].getValue(), True )
 		
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferRenderManTest/shaders/numericTypeAnnotations.sl
+++ b/python/GafferRenderManTest/shaders/numericTypeAnnotations.sl
@@ -1,0 +1,49 @@
+//////////////////////////////////////////////////////////////////////////
+//  
+//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//  
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//  
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//  
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+//////////////////////////////////////////////////////////////////////////
+
+surface numericTypeAnnotations(
+	float floatParameter1 = 1.25;
+#pragma annotation "floatParameter2.type" "float"
+	float floatParameter2 = 1.5;
+#pragma annotation "intParameter.type" "int"
+	float intParameter = 10;
+#pragma annotation "boolParameter.type" "bool"
+	float boolParameter = 1;
+)
+{
+	Ci = 1;
+	Oi = 1;
+}


### PR DESCRIPTION
This allows numeric shader parameters (which are always floats) to be represented within gaffer as FloatPlugs, IntPlugs or BoolPlugs by specifying a value of "float", "int" or "bool". If you get a chance Ben, it'd be good to get this documented on your branch...

Fixes #456.
