### PR TITLE
Shader disabling bugs

### DIFF
--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -1045,6 +1045,70 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 		self.assertEqual( len( s ), 2 )
 		self.assertEqual( s[1].parameters["fixedShaderArray"], IECore.StringVectorData( [ s[0].parameters["__handle"].value, s[0].parameters["__handle"].value, "", "" ] ) )
 		self.assertEqual( s[0].name, coshader )
-			
+	
+	def testSerialDisabledShaders( self ) :
+	
+		# C ----> D1 ----> D2 ----> S
+		
+		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/coshaderParameter.sl" )
+		S = GafferRenderMan.RenderManShader()
+		S.loadShader( shader )
+				
+		passThroughCoshader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/coshaderWithPassThrough.sl" )
+		D1 = GafferRenderMan.RenderManShader()
+		D1.loadShader( passThroughCoshader )
+		D2 = GafferRenderMan.RenderManShader()
+		D2.loadShader( passThroughCoshader )
+		
+		coshader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/coshader.sl" )
+		C = GafferRenderMan.RenderManShader()
+		C.loadShader( coshader )
+		
+		S["parameters"]["coshaderParameter"].setInput( D2["out"] )
+		D2["parameters"]["aColorIWillTint"].setInput( D1["out"] )
+		D1["parameters"]["aColorIWillTint"].setInput( C["out"] )
+		
+		h1 = S.stateHash()
+		s = S.state()
+		
+		self.assertEqual( len( s ), 4 )
+		self.assertEqual( s[0].name, coshader )
+		self.assertEqual( s[1].name, passThroughCoshader )
+		self.assertEqual( s[2].name, passThroughCoshader )
+		self.assertEqual( s[3].name, shader )
+		
+		self.assertEqual( s[3].parameters["coshaderParameter"], s[2].parameters["__handle"] )
+		self.assertEqual( s[2].parameters["aColorIWillTint"], s[1].parameters["__handle"] )
+		self.assertEqual( s[1].parameters["aColorIWillTint"], s[0].parameters["__handle"] )
+		
+		D2["enabled"].setValue( False )
+				
+		h2 = S.stateHash()
+		self.assertNotEqual( h1, h2 )
+		
+		s = S.state()
+		
+		self.assertEqual( len( s ), 3 )
+		self.assertEqual( s[0].name, coshader )
+		self.assertEqual( s[1].name, passThroughCoshader )
+		self.assertEqual( s[2].name, shader )
+		
+		self.assertEqual( s[2].parameters["coshaderParameter"], s[1].parameters["__handle"] )
+		self.assertEqual( s[1].parameters["aColorIWillTint"], s[0].parameters["__handle"] )
+		
+		D1["enabled"].setValue( False )
+				
+		h3 = S.stateHash()
+		self.assertNotEqual( h3, h2 )
+		self.assertNotEqual( h3, h1 )
+		
+		s = S.state()
+		
+		self.assertEqual( len( s ), 2 )
+		self.assertEqual( s[0].name, coshader )
+		self.assertEqual( s[1].name, shader )
+		
+		self.assertEqual( s[1].parameters["coshaderParameter"], s[0].parameters["__handle"] )
+		
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -296,22 +296,26 @@ const std::string &Shader::NetworkBuilder::shaderHandle( const Shader *shaderNod
 
 const Shader *Shader::NetworkBuilder::effectiveNode( const Shader *shaderNode ) const
 {
-	if( shaderNode->enabledPlug()->getValue() )
+	while( shaderNode )
 	{
-		return shaderNode;
-	}
+		if( shaderNode->enabledPlug()->getValue() )
+		{
+			return shaderNode;
+		}
 
-	const Plug *correspondingInput = shaderNode->correspondingInput( shaderNode->outPlug() );
-	if( !correspondingInput )
-	{
-		return 0;
+		const Plug *correspondingInput = shaderNode->correspondingInput( shaderNode->outPlug() );
+		if( !correspondingInput )
+		{
+			return NULL;
+		}
+
+		const Plug *source = correspondingInput->source<Plug>();
+		if( source == correspondingInput )
+		{
+			return NULL;
+		}
+
+		shaderNode = source->ancestor<Shader>();
 	}
-	
-	const Plug *source = correspondingInput->source<Plug>();
-	if( source == correspondingInput )
-	{
-		return 0;
-	}
-	
-	return source->ancestor<Shader>();
+	return NULL;
 }


### PR DESCRIPTION
This fixes two things that weren't working :
- Shaders used twice in a network, once via a disabled node and once directly.
- Several disabled shaders in a row.

I suspect that although they will both merge cleanly on their own, this will conflict with #467. If this one seems good to go I suggest we merge it first while waiting for a consensus on the indexing question in #467. I'll then rejig that one for a clean merge.
