### PR TITLE
Added a channel mask feature to GafferImageUI::ImageView.

### DIFF
--- a/include/GafferImageUI/ImageView.h
+++ b/include/GafferImageUI/ImageView.h
@@ -72,7 +72,11 @@ class ImageView : public GafferUI::View
 		const GafferImage::ImageStats *imageStatsNode() const;
 		
 		static ViewDescription<ImageView> g_viewDescription;
-	
+
+	private:
+
+		int m_colorMask;
+		Imath::V2f m_mousePos;
 };
 
 IE_CORE_DECLAREPTR( ImageView );

--- a/include/GafferUI/StandardStyle.h
+++ b/include/GafferUI/StandardStyle.h
@@ -74,11 +74,11 @@ class StandardStyle : public Style
 		virtual void renderNodule( float radius, State state = NormalState ) const;
 		virtual void renderConnection( const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent, State state = NormalState ) const;
 		virtual void renderSelectionBox( const Imath::Box2f &box ) const;
-		virtual void renderImage( const Imath::Box2f &box, const IECoreGL::Texture *texture ) const;
+		virtual void renderImage( const Imath::Box2f &box, const IECoreGL::Texture *texture, int mask = Style::All ) const;
 		virtual void renderLine( const IECore::LineSegment3f &line ) const;
 		virtual void renderSolidRectangle( const Imath::Box2f &box ) const;
 		virtual void renderRectangle( const Imath::Box2f &box ) const;
-		
+
 		enum Color
 		{
 			BackgroundColor,
@@ -89,6 +89,7 @@ class StandardStyle : public Style
 			ConnectionColor,
 			LastColor
 		};
+
 		
 		void setColor( Color c, Imath::Color3f v );
 		const Imath::Color3f &getColor( Color c ) const;
@@ -106,6 +107,7 @@ class StandardStyle : public Style
 		static int g_edgeAntiAliasingParameter;
 		static int g_textureParameter;
 		static int g_textureTypeParameter;
+		static int g_colorMaskParameter;
 		static int g_bezierParameter;
 		static int g_v0Parameter;
 		static int g_v1Parameter;

--- a/include/GafferUI/Style.h
+++ b/include/GafferUI/Style.h
@@ -79,13 +79,23 @@ class Style : public IECore::RunTimeTyped
 		/// any of the render* methods below. The currently bound style is passed as it may
 		/// be possible to use it to optimise the binding of a new style of the same type.
 		virtual void bind( const Style *currentStyle=0 ) const = 0;
-		
+
+		enum ColorMask
+		{
+			None = 0,
+			Red = 1,
+			Green = 2,
+			Blue = 4,
+			Alpha = 8,
+			All = 15
+		};
+
 		enum TextType
 		{
 			LabelText,
 			LastText
 		};
-		
+
 		virtual Imath::Box3f textBound( TextType textType, const std::string &text ) const = 0;
 		virtual void renderText( TextType textType, const std::string &text, State state = NormalState ) const = 0;
 
@@ -95,7 +105,7 @@ class Style : public IECore::RunTimeTyped
 		/// The tangents give an indication of which direction is "out" from a node.
 		virtual void renderConnection( const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent, State state = NormalState ) const = 0;
 		virtual void renderSelectionBox( const Imath::Box2f &box ) const = 0;
-		virtual void renderImage( const Imath::Box2f &box, const IECoreGL::Texture *texture ) const = 0;
+		virtual void renderImage( const Imath::Box2f &box, const IECoreGL::Texture *texture, int colorMask = All ) const = 0;
 		virtual void renderLine( const IECore::LineSegment3f &line ) const = 0;
 		virtual void renderSolidRectangle( const Imath::Box2f &box ) const = 0;
 		virtual void renderRectangle( const Imath::Box2f &box ) const = 0;

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -117,6 +117,7 @@ void StandardStyle::renderText( TextType textType, const std::string &text, Stat
 	/// or use the sRGB texture extension in IECoreGL::Font::texture() to ensure that data is
 	/// automatically linearised before arriving in the shader.
 	glUniform1i( g_textureTypeParameter, 2 );
+	glUniform1i( g_colorMaskParameter, All );
 
 	glColor( m_colors[ForegroundColor] );
 
@@ -268,7 +269,7 @@ void StandardStyle::renderSelectionBox( const Imath::Box2f &box ) const
 
 }
 
-void StandardStyle::renderImage( const Imath::Box2f &box, const IECoreGL::Texture *texture ) const
+void StandardStyle::renderImage( const Imath::Box2f &box, const IECoreGL::Texture *texture, int colorMask ) const
 {
 	glPushAttrib( GL_COLOR_BUFFER_BIT );
 	
@@ -284,6 +285,7 @@ void StandardStyle::renderImage( const Imath::Box2f &box, const IECoreGL::Textur
 	glUniform1i( g_borderParameter, 0 );
 	glUniform1i( g_edgeAntiAliasingParameter, 0 );
 	glUniform1i( g_textureParameter, 0 );
+	glUniform1i( g_colorMaskParameter, colorMask );
 	glUniform1i( g_textureTypeParameter, 1 );
 
 	glColor3f( 1.0f, 1.0f, 1.0f );
@@ -452,6 +454,7 @@ static const char *g_fragmentSource =
 	"uniform bool edgeAntiAliasing;"
 
 	"uniform int textureType;"
+	"uniform int colorMask;"
 	"uniform sampler2D texture;"
 
 	"uniform uint ieCoreGLNameIn;"
@@ -490,7 +493,17 @@ static const char *g_fragmentSource =
 	"	{"
 	"		outColor = vec4( outColor.rgb, texture2D( texture, gl_TexCoord[0].xy ).a );"
 	"	}"
-
+	"	if( textureType!=0 && colorMask!=15 )"
+	"	{"
+	"		if( colorMask==8 )"
+	"		{"
+	"			outColor = vec4( outColor[3], outColor[3], outColor[3], 1. );"
+	"		}"
+	"		else"
+	"		{"
+	"			outColor = vec4( bool(colorMask & 1) ? outColor[0] : 0., bool(colorMask & 2) ? outColor[1] : 0., bool(colorMask & 4) ? outColor[2] : 0., 1. );"
+	"		}"
+	"	}"
 	"	ieCoreGLNameOut = ieCoreGLNameIn;"
 
 	"}";
@@ -500,6 +513,7 @@ int StandardStyle::g_borderRadiusParameter;
 int StandardStyle::g_edgeAntiAliasingParameter;
 int StandardStyle::g_textureParameter;
 int StandardStyle::g_textureTypeParameter;
+int StandardStyle::g_colorMaskParameter;
 int StandardStyle::g_bezierParameter;
 int StandardStyle::g_v0Parameter;
 int StandardStyle::g_v1Parameter;
@@ -519,6 +533,7 @@ IECoreGL::Shader *StandardStyle::shader()
 		g_edgeAntiAliasingParameter = g_shader->uniformParameter( "edgeAntiAliasing" )->location;
 		g_textureParameter = g_shader->uniformParameter( "texture" )->location;
 		g_textureTypeParameter = g_shader->uniformParameter( "textureType" )->location;
+		g_colorMaskParameter = g_shader->uniformParameter( "colorMask" )->location;
 		g_bezierParameter = g_shader->uniformParameter( "bezier" )->location;
 		g_v0Parameter = g_shader->uniformParameter( "v0" )->location;
 		g_v1Parameter = g_shader->uniformParameter( "v1" )->location;


### PR DESCRIPTION
This commit allows the user to view different channels by pressing the corresponding key for R,G,B and A. It is implemented by modifying the outColor variable within the fragment shader of GafferUI::StandardStyle. 
This addresses issue #403.
- Added an optional parameter to GafferUI::Style::renderImage() that allows a colorMask to be passed in. The default value enables all of the channels.
- Added a pretty little icon on the image viewer's info bar to indicate which channel is being viewed.
- Fixed a bug that caused the text that displays the mouse's position to be cleared when the viewer updates.
