### PR TITLE
Added Application._executeStartupFiles() method.

### DIFF
--- a/apps/screengrab/screengrab-1.py
+++ b/apps/screengrab/screengrab-1.py
@@ -82,12 +82,12 @@ class screengrab( Gaffer.Application ) :
 			]
 			
 		)
-		
-		#dirty hack - pretend we are the gui app so that we can load all of its startup files.
-		self.root().setName("gui") ## these startup files are required to initialise layouts, menus etc 
-
-	
+			
 	def _run( self, args ) :
+		
+		# run the gui startup files so the images we grab are representative
+		# of the layouts and configuration of the gui app.
+		self._executeStartupFiles( "gui" )
 		
 		GafferUI.ScriptWindow.connect( self.root() )
 		

--- a/python/Gaffer/Application.py
+++ b/python/Gaffer/Application.py
@@ -93,7 +93,11 @@ class Application( IECore.Parameterised ) :
 	
 		raise NotImplementedError
 
-	def __executeStartupFiles( self ) :
+	## Executes the startup files for the specified application. This
+	# is called automatically for this application before _run is called,
+	# but applications may call it in order to "borrow" the startup files
+	# for other applications. See the screengrab app for a good use case.
+	def _executeStartupFiles( self, applicationName ) :
 	
 		sp = os.environ.get( "GAFFER_STARTUP_PATHS", "" )
 		if not sp :
@@ -101,7 +105,7 @@ class Application( IECore.Parameterised ) :
 			return
 	
 		sp = IECore.SearchPath( sp, ":" )
-		paths = [ os.path.join( p, self.root().getName() ) for p in sp.paths ]
+		paths = [ os.path.join( p, applicationName ) for p in sp.paths ]
 		sp = IECore.SearchPath( ":".join( paths ), ":" )
 		
 		contextDict = {	"application" : self }	
@@ -109,7 +113,7 @@ class Application( IECore.Parameterised ) :
 		
 	def __run( self, args ) :
 	
-		self.__executeStartupFiles()
+		self._executeStartupFiles( self.root().getName() )
 		return self._run( args )
 
 IECore.registerRunTimeTyped( Application, typeName = "Gaffer::Application" )		


### PR DESCRIPTION
This may be used to "borrow" the configuration files from another application. The screengrab app uses it to ensure that the screengrabs made are representative of the gui app.

Fixes #354.
