### PR TITLE
Adds help menu entry for launching documentation resources.

### DIFF
--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -37,7 +37,6 @@
 
 import os
 import traceback
-import webbrowser
 
 import IECore
 
@@ -58,27 +57,9 @@ GafferUI.LayoutMenu.appendDefinitions( scriptWindowMenu, name="/Layout" )
 GafferUI.ExecuteUI.appendMenuDefinitions( scriptWindowMenu, prefix="/Execute" )
 
 # Add help menu
-def launchUserGuide( menu ):
-	doc = os.path.join ( os.environ["GAFFER_ROOT"], 'doc', 'GafferUserGuide.pdf' )
-	if os.path.exists( doc ):
-		url = r'file://%s' % (doc) 
-		webbrowser.open( url )
-
-def launchNodeReference( menu ):
-	doc = os.path.join ( os.environ["GAFFER_ROOT"], 'doc', 'GafferNodeReference.pdf' )
-	if os.path.exists( doc ):
-		url = r'file://%s' % (doc) 
-		webbrowser.open( url )
-
-def launchLicenses( menu ):
-	doc = os.path.join ( os.environ["GAFFER_ROOT"], 'doc', 'GafferLicenses.pdf' )
-	if os.path.exists( doc ):
-		url = r'file://%s' % (doc) 
-		webbrowser.open( url )
-		
 def launchGoogleGroup( menu ):
 		url = r'https://groups.google.com/forum/#!forum/gaffer-dev'
-		webbrowser.open( url )
+		GafferUI.ShowURL.showURL( url )
 
 #TODO - scour an examples directory for .gfr files
 #TODO - ..then build a menu with items to launch each example
@@ -86,9 +67,21 @@ def helpExamples( menu ):
 	result = IECore.MenuDefinition()
 	return result
 
-scriptWindowMenu.append( "/Help/User Guide", 		{ "command" : launchUserGuide } )
-scriptWindowMenu.append( "/Help/Node Reference", 	{ "command" : launchNodeReference  } )
-scriptWindowMenu.append( "/Help/Licenses", 			{ "command" : launchLicenses } )
+for menuItem, fileName in [
+		( "/Help/User Guide", "$GAFFER_ROOT/doc/GafferUserGuide.pdf" ),
+		( "/Help/Node Reference", "$GAFFER_ROOT/doc/GafferNodeReference.pdf" ),
+		( "/Help/Licenses", "$GAFFER_ROOT/doc/GafferLicenses.pdf" ),
+	] :
+	
+	fileName = os.path.expandvars( fileName )
+	scriptWindowMenu.append(
+		menuItem,
+		{
+			"command" : IECore.curry( GafferUI.showURL, fileName ),
+			"active" : os.path.exists( fileName ),
+		}
+	)
+
 scriptWindowMenu.append( "/Help/DocsDivider", 		{ "divider" : True } )
 scriptWindowMenu.append( "/Help/Developer Discussion", { "command" : launchGoogleGroup } )
 scriptWindowMenu.append( "/Help/DevDivider", 		{ "divider" : True } )


### PR DESCRIPTION
- Body of new menu is defined in startup/gui as this content appears specific to main app
- Declares a placeholder for example-script launching, ready for future implementation.
- uses webbrowser module to perform launching as my research suggests that is the most platform independent approach.
  - for best results users would need to set $BROWSER env var, otherwise it's a bit of a gamble what app launches the files
  - also, the pdf files need to be placed in GAFFER_ROOT/doc as part of the install process.
