### PR TITLE
Added support for Parameter ui type hint "presets".

### DIFF
--- a/python/GafferUI/ParameterValueWidget.py
+++ b/python/GafferUI/ParameterValueWidget.py
@@ -91,11 +91,15 @@ class ParameterValueWidget( GafferUI.Widget ) :
 		with IECore.IgnoredExceptions( KeyError ) :
 			uiTypeHint = parameter.userData()["UI"]["typeHint"].value
 	
-		parameterHierarchy = IECore.RunTimeTyped.baseTypeIds( parameter.typeId() )
-		for typeId in [ parameter.typeId() ] + parameterHierarchy :	
-			creator = cls.__typesToCreators.get( ( typeId, uiTypeHint ), None )
-			if creator is not None :
-				return creator( parameterHandler )
+		parameterHierarchy = [ parameter.typeId() ] + IECore.RunTimeTyped.baseTypeIds( parameter.typeId() )
+		
+		if uiTypeHint is not None :
+			for typeId in parameterHierarchy :	
+				creator = cls.__typesToCreators.get( ( typeId, uiTypeHint ), None )
+				if creator is not None :
+					return creator( parameterHandler )
+			
+		for typeId in parameterHierarchy :	
 			creator = cls.__typesToCreators.get( ( typeId, None ), None )
 			if creator is not None :
 				return creator( parameterHandler )	

--- a/python/GafferUI/PresetsOnlyParameterValueWidget.py
+++ b/python/GafferUI/PresetsOnlyParameterValueWidget.py
@@ -51,6 +51,8 @@ class PresetsOnlyParameterValueWidget( GafferUI.ParameterValueWidget ) :
 			parameterHandler,
 			**kw
 		)
+
+GafferUI.ParameterValueWidget.registerType( IECore.Parameter.staticTypeId(), PresetsOnlyParameterValueWidget, "presets" )
 		
 # The actual ui is more easily implemented as a PlugValueWidget, because
 # we get _addPopupMenu() and the machinery for updating on plug changes for free.


### PR DESCRIPTION
This can be used to use the PresetsOnlyParameterValueWidgets for parameters which have presets but for which presetsOnly != True. This necessitated changing the precedence of type hints within ParameterValueWidget.create(). Matching type hints for all subclasses of the parameter are now considered to be a better match than a more specific parameter type registrations lacking the type hint.
