### PR TITLE
Improved platform naming in package filenames.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -79,7 +79,7 @@ options.Add(
 options.Add(
 	"BUILD_DIR",
 	"The destination directory in which the build will be made.",
-	"./build/gaffer-${GAFFER_MAJOR_VERSION}.${GAFFER_MINOR_VERSION}.${GAFFER_PATCH_VERSION}-${PLATFORM}",
+	"./build/gaffer-${GAFFER_MAJOR_VERSION}.${GAFFER_MINOR_VERSION}.${GAFFER_PATCH_VERSION}-${GAFFER_PLATFORM}",
 )
 
 options.Add(
@@ -93,7 +93,7 @@ options.Add(
 options.Add(
 	"INSTALL_DIR",
 	"The destination directory for the installation.",
-	"./install/gaffer-${GAFFER_MAJOR_VERSION}.${GAFFER_MINOR_VERSION}.${GAFFER_PATCH_VERSION}-${PLATFORM}",
+	"./install/gaffer-${GAFFER_MAJOR_VERSION}.${GAFFER_MINOR_VERSION}.${GAFFER_PATCH_VERSION}-${GAFFER_PLATFORM}",
 )
 
 options.Add(
@@ -476,17 +476,21 @@ for e in env["ENV_VARS_TO_IMPORT"].split() :
 		env["ENV"][e] = os.environ[e]
 
 if env["PLATFORM"] == "darwin" :
+
 	env["ENV"]["MACOSX_DEPLOYMENT_TARGET"] = "10.4"
 	env.Append( CXXFLAGS = [ "-D__USE_ISOC99" ] )
+	env["GAFFER_PLATFORM"] = "osx"
 	
-if env["PLATFORM"] == "posix" :
+elif env["PLATFORM"] == "posix" :
+	
 	## We really want to not have the -Wno-strict-aliasing flag, but it's necessary to stop boost
 	# python warnings that don't seem to be prevented by including boost via -isystem even. Better to
 	# be able to have -Werror but be missing one warning than to have no -Werror.
 	## \todo This is probably only necessary for specific gcc versions where -isystem doesn't
 	# fully work. Reenable when we encounter versions that work correctly.
 	env.Append( CXXFLAGS = [ "-Wno-strict-aliasing" ] )
-
+	env["GAFFER_PLATFORM"] = "linux"
+	
 if env["BUILD_CACHEDIR"] != "" :
 	CacheDir( env["BUILD_CACHEDIR"] )
 			

--- a/config/ie/publicBuild
+++ b/config/ie/publicBuild
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-BUILD_DIR=$HOME'/publicGafferBuild/builds/gaffer-${GAFFER_MAJOR_VERSION}.${GAFFER_MINOR_VERSION}.${GAFFER_PATCH_VERSION}-${PLATFORM}'
-INSTALL_DIR=$HOME'/publicGafferBuild/packages/gaffer-${GAFFER_MAJOR_VERSION}.${GAFFER_MINOR_VERSION}.${GAFFER_PATCH_VERSION}-${PLATFORM}'
+BUILD_DIR=$HOME'/publicGafferBuild/builds/gaffer-${GAFFER_MAJOR_VERSION}.${GAFFER_MINOR_VERSION}.${GAFFER_PATCH_VERSION}-${GAFFER_PLATFORM}'
+INSTALL_DIR=$HOME'/publicGafferBuild/packages/gaffer-${GAFFER_MAJOR_VERSION}.${GAFFER_MINOR_VERSION}.${GAFFER_PATCH_VERSION}-${GAFFER_PLATFORM}'
 DEPENDENCIES_SRC_DIR=$HOME'/publicGafferBuild/dependencies'
 DOXYGEN='/software/apps/doxygen/1.8.4/cent6.x86_64/bin/doxygen'
 RMAN_ROOT='/software/apps/3delight/10.0.163/cent6.x86_64'


### PR DESCRIPTION
The SCons PLATFORM variable isn't very user friendly - "darwin" for OSX and "posix" for Linux. This introduces a new GAFFER_PLATFORM variable with values "osx" and "linux" and uses them when building release packages.
