### PR TITLE
Added python subclassing ability to Serialisation::Serialiser.

### DIFF
--- a/include/GafferBindings/Serialisation.h
+++ b/include/GafferBindings/Serialisation.h
@@ -77,6 +77,8 @@ class Serialisation
 			
 			public :
 						
+				IE_CORE_DECLAREMEMBERPTR( Serialiser );
+
 				/// Should be implemented to insert the names of any modules the serialiser will need
 				/// into the modules set. The default implementation returns modulePath( graphComponent ).
 				virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules ) const;
@@ -128,6 +130,8 @@ class Serialisation
 		static const Serialiser *serialiser( const Gaffer::GraphComponent *graphComponent );
 				
 };
+
+void bindSerialisation();
 
 } // namespace GafferBindings
 

--- a/python/GafferTest/SerialisationTest.py
+++ b/python/GafferTest/SerialisationTest.py
@@ -1,0 +1,123 @@
+##########################################################################
+#  
+#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#  
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#  
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#  
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#  
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#  
+##########################################################################
+
+import IECore
+
+import Gaffer
+import GafferTest
+
+class SerialisationTest( GafferTest.TestCase ) :
+	
+	class SerialisationTestNode( Gaffer.Node ) :
+		
+		def __init__( self, name = "SerialisationTestNode", initArgument = 10 ) :
+
+			Gaffer.Node.__init__( self, name )
+
+			self.initArgument = initArgument
+
+			self["childNodeNeedingSerialisation"] = GafferTest.AddNode()
+			self["childNodeNotNeedingSerialisation"] = GafferTest.AddNode()
+
+	IECore.registerRunTimeTyped( SerialisationTestNode )
+		
+	def testCustomSerialiser( self ) :
+				
+		class CustomSerialiser( Gaffer.Serialisation.Serialiser ) :
+		
+			def moduleDependencies( self, node ) :
+			
+				return ( "GafferTest", )
+			
+			def constructor( self, node ) :
+			
+				return ( "GafferTest.SerialisationTest.SerialisationTestNode( \"%s\", %d )" % ( node.getName(), node.initArgument ) )
+				
+			def postConstructor( self, node, identifier, serialisation ) :
+			
+				return identifier + ".postConstructorWasHere = True\n"
+			
+			def postHierarchy( self, node, identifier, serialisation ) :
+			
+				return identifier + ".postHierarchyWasHere = True\n"
+				
+			def postScript( self, node, identifier, serialisation ) :
+			
+				return identifier + ".postScriptWasHere = True\n"
+				
+			def childNeedsSerialisation( self, child ) :
+			
+				if isinstance( child, Gaffer.Node ) :
+					return child.getName() == "childNodeNeedingSerialisation"
+				elif isinstance( child, Gaffer.Plug ) :
+					return child.getFlags( Gaffer.Plug.Flags.Serialisable )
+					
+				return False
+				
+			def childNeedsConstruction( self, child ) :
+			
+				if isinstance( child, Gaffer.Node ) :
+					return False
+				elif isinstance( child, Gaffer.Plug ) :
+					return child.getFlags( Gaffer.Plug.Flags.Dynamic )
+						
+				return False
+				
+		Gaffer.Serialisation.registerSerialiser( self.SerialisationTestNode.staticTypeId(), CustomSerialiser() )
+		
+		s = Gaffer.ScriptNode()
+		s["n"] = self.SerialisationTestNode( "a", initArgument=20 )
+		s["n"]["childNodeNeedingSerialisation"]["op1"].setValue( 101 )
+		s["n"]["childNodeNotNeedingSerialisation"]["op1"].setValue( 101 )
+		s["n"]["dynamicPlug"] = Gaffer.FloatPlug( defaultValue = 10, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+				
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+						
+		self.assertTrue( isinstance( s2["n"], self.SerialisationTestNode ) )
+		self.assertEqual( s["n"].keys(), s2["n"].keys() )
+	
+		self.assertEqual( s2["n"].initArgument, 20 )
+		self.assertEqual( s2["n"]["childNodeNeedingSerialisation"]["op1"].getValue(), 101 )
+		self.assertEqual( s2["n"]["childNodeNotNeedingSerialisation"]["op1"].getValue(), 0 )
+		self.assertEqual( s2["n"]["dynamicPlug"].getValue(), 10 )
+		self.assertEqual( s2["n"].postConstructorWasHere, True )
+		self.assertEqual( s2["n"].postHierarchyWasHere, True )
+		self.assertEqual( s2["n"].postScriptWasHere, True )
+		
+if __name__ == "__main__":
+	unittest.main()
+	

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -129,6 +129,7 @@ from InputGeneratorNode import InputGeneratorNode
 from InputGeneratorTest import InputGeneratorTest
 from ArrayPlugNode import ArrayPlugNode
 from ArrayPlugTest import ArrayPlugTest
+from SerialisationTest import SerialisationTest
 
 if __name__ == "__main__":
 	import unittest

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -79,6 +79,7 @@
 #include "GafferBindings/ReferenceBinding.h"
 #include "GafferBindings/BehaviourBinding.h"
 #include "GafferBindings/ArrayPlugBinding.h"
+#include "GafferBindings/Serialisation.h"
 
 using namespace boost::python;
 using namespace Gaffer;
@@ -127,6 +128,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindExecutableOpHolder();
 	bindReference();
 	bindArrayPlug();
+	bindSerialisation();
 			
 	DependencyNodeClass<ContextProcessorComputeNode>();
 	DependencyNodeClass<TimeWarpComputeNode>();


### PR DESCRIPTION
This allows the writer of a custom python node to also customise the serialisation for the node. This might be necessary when a node creates a child node network and needs to control which parts are serialised and how. For now I've just implemented it so Serialiser can be subclassed - it's possible to also bind NodeSerialiser, BoxSerialiser etc, but it means a bunch of nasty templated wrappers and suchlike. Call me on it if you think it should all be done now though...

Fixes #520.
