### PR TITLE
Added even-more-simplified mode to StandardNodeUI.

### DIFF
--- a/python/GafferSceneUI/FilterPlugValueWidget.py
+++ b/python/GafferSceneUI/FilterPlugValueWidget.py
@@ -99,7 +99,7 @@ class FilterPlugValueWidget( GafferUI.PlugValueWidget ) :
 			if len( self.__column ) > 1 :
 				filterNodeUI = self.__column[1]
 			if filterNodeUI is None or not filterNodeUI.node().isSame( filterNode ) :
-				filterNodeUI = GafferUI.StandardNodeUI( filterNode, displayMode = GafferUI.StandardNodeUI.DisplayMode.Simplified )
+				filterNodeUI = GafferUI.StandardNodeUI( filterNode, displayMode = GafferUI.StandardNodeUI.DisplayMode.Bare )
 			if len( self.__column ) > 1 :
 				self.__column[1] = filterNodeUI
 			else :


### PR DESCRIPTION
This mode is specified using the new Bare value, and displays the single main column without a scrollbar. This makes it particularly suitable for embedding in other UIs, and in particular the FilterPlugValueWidget is now using it to prevent the triple-scrollbar layout it used to have when being displayed very small with a PathFilter in it.

Fixes #549.
