### PR TITLE
Made Plug::acceptsInput() consider current output connections.

### DIFF
--- a/python/GafferTest/NodeTest.py
+++ b/python/GafferTest/NodeTest.py
@@ -194,7 +194,10 @@ class NodeTest( GafferTest.TestCase ) :
 				
 			def acceptsInput( self, plug, inputPlug ) :
 			
-				return isinstance( inputPlug.node(), AcceptsInputTestNode )
+				if plug.isSame( self["in"] ) :
+					return isinstance( inputPlug.source().node(), AcceptsInputTestNode )
+					
+				return True
 	
 		n1 = AcceptsInputTestNode()
 		n2 = AcceptsInputTestNode()
@@ -202,7 +205,16 @@ class NodeTest( GafferTest.TestCase ) :
 	
 		self.assertEqual( n1["in"].acceptsInput( n2["out"] ), True )
 		self.assertEqual( n1["in"].acceptsInput( n3["sum"] ), False )
-			
+		
+		# check that we can't use a pass-through connection as
+		# a loophole.
+		
+		# this particular connection makes no sense but breaks
+		# no rules - we're just using it to test the loophole.
+		n2["out"].setInput( n3["sum"] )
+		
+		self.assertEqual( n1["in"].acceptsInput( n2["out"] ), False )
+		
 	def testPlugFlagsChangedSignal( self ) :
 	
 		n = Gaffer.Node()

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -134,7 +134,7 @@ void Plug::setFlags( unsigned flags, bool enable )
 
 bool Plug::acceptsInput( const Plug *input ) const
 {
-	if( !getFlags( AcceptsInputs ) )
+	if( !getFlags( AcceptsInputs ) || getFlags( ReadOnly ) )
 	{
 		return false;
 	}
@@ -151,7 +151,16 @@ bool Plug::acceptsInput( const Plug *input ) const
 			return false;
 		}
 	}
-	return !getFlags( ReadOnly );
+	
+	for( OutputContainer::const_iterator it=m_outputs.begin(), eIt=m_outputs.end(); it!=eIt; ++it )
+	{
+		if( !(*it)->acceptsInput( input ) )
+		{
+			return false;
+		}
+	}
+	
+	return true;
 }
 
 void Plug::setInput( PlugPtr input )

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -140,20 +140,24 @@ bool RenderManShader::acceptsInput( const Plug *plug, const Plug *inputPlug ) co
 		
 		if( plug->typeId() == Plug::staticTypeId() )
 		{
-		
-			const Node* sourceNode = inputPlug->node();
+			// coshader parameter - source must be another
+			// renderman shader hosting a coshader, or a box
+			// with a currently dangling connection. in the box case,
+			// we will be called again when the box is connected to
+			// something, so we can check that the indirect connection
+			// is to our liking.
+			const Node* sourceNode = sourcePlug->node();
+			
 			if( runTimeCast<const Box>( sourceNode ) )
 			{
 				// looks like we're exposing this input via a box, or
-				// connecting it to an unconnected output on a box. At
-				// the moment, we're just accepting this and trusting
-				// the user not to connect something nonsensical to inputPlug.
-				// \todo: make it so we can't make illegal connections to inputPlug
+				// connecting it to an unconnected output on a box. we'll
+				// accept the input for now - later when the plug on the
+				// box itself is connected we'll be called again to check
+				// that we accept the new indirect connection.
 				return true;
 			}
 			
-			// coshader parameter - input must be another
-			// renderman shader hosting a coshader.
 			const RenderManShader *inputShader = sourcePlug->parent<RenderManShader>();
 			if(
 				!inputShader ||


### PR DESCRIPTION
A plug will now never accept an input if any of its immediate outputs would not themselves accept the same connection directly. This allows the RenderManShader node to accept connections to Boxes without them being used a loophole to bypass the usual connection checks for coshaders.

Fixes #532.
