### PR TITLE
Fixed GraphGadget for NULL return from NodeGadget::create().

### DIFF
--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -169,7 +169,9 @@ class GraphGadget : public ContainerGadget
 		void offsetNodes( Gaffer::Set *nodes, const Imath::V2f &offset );
 		
 		void updateGraph();
-		void addNodeGadget( Gaffer::Node *node );
+		/// May return NULL if NodeGadget::create() returns NULL, signifying that
+		/// someone has registered a creator in order to hide all nodes of a certain type.
+		NodeGadget *addNodeGadget( Gaffer::Node *node );
 		void removeNodeGadget( const Gaffer::Node *node );
 		NodeGadget *findNodeGadget( const Gaffer::Node *node ) const;
 		void updateNodeGadgetTransform( NodeGadget *nodeGadget );

--- a/python/GafferUITest/NodeGraphTest.py
+++ b/python/GafferUITest/NodeGraphTest.py
@@ -845,6 +845,40 @@ class NodeGraphTest( GafferUITest.TestCase ) :
 		
 		self.assertFalse( c1.getMinimised() )
 		self.assertFalse( c2.getMinimised() )
+	
+	def testNodeGadgetCreatorReturningNull( self ) :
+	
+		class InvisibleNode( GafferTest.AddNode ) :
+		
+			def __init__( self, name = "InvisibleNode" ) :
+			
+				GafferTest.AddNode.__init__( self, name )
+				
+		IECore.registerRunTimeTyped( InvisibleNode )
+		
+		GafferUI.NodeGadget.registerNodeGadget( InvisibleNode.staticTypeId(), lambda node : None )
+		
+		script = Gaffer.ScriptNode()
+		g = GafferUI.GraphGadget( script )
+		
+		script["n1"] = InvisibleNode()
+		script["n2"] = InvisibleNode()
+		
+		self.assertEqual( g.nodeGadget( script["n1"] ), None )
+		self.assertEqual( g.nodeGadget( script["n2"] ), None )
+		
+		script["n2"]["op1"].setInput( script["n1"]["sum"] )
+		
+		self.assertEqual( g.connectionGadget( script["n2"]["op1"] ), None )
+		
+		# in case it wasn't clear, hiding the nodes has zero
+		# effect on their computations.
+		
+		script["n1"]["op1"].setValue( 12 )
+		script["n1"]["op2"].setValue( 13 )
+		script["n2"]["op2"].setValue( 100 )
+		
+		self.assertEqual( script["n2"]["sum"].getValue(), 125 )
 		
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This allows NodeGadget::registerNodeGadget() to be used with functions that will return NULL to signify that the node should be hidden.
