### PR TITLE
Fixed PathListingWidget errors when "/" path is invalid.

### DIFF
--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -363,10 +363,11 @@ class PathListingWidget( GafferUI.Widget ) :
 				# it's not valid. if we can make it
 				# valid by trimming the last element
 				# then do that
-				pp = p.copy()
-				del pp[-1]
-				if pp.isValid() :
-					p = pp
+				if len( p ) :
+					pp = p.copy()
+					del pp[-1]
+					if pp.isValid() :
+						p = pp
 			else :
 				# it's valid and not a leaf, and
 				# that's what we want.


### PR DESCRIPTION
Invalid root paths occur quite frequently in the SceneHierarchy editor when an invalid filename has been entered in a SceneReader or AlembicReader. Those nodes will still display an error, but the SceneHierarchy now won't output a confusing stacktrace which distracts people from the root cause.

Fixes #528.
