### PR TITLE
Added Alt click modifier for selecting upstream nodes in GraphGadget.

### DIFF
--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -111,6 +111,14 @@ class GraphGadget : public ContainerGadget
 		size_t connectionGadgets( const Gaffer::Node *node, std::vector<ConnectionGadget *> &connections, const Gaffer::Set *excludedNodes = 0 );
 		size_t connectionGadgets( const Gaffer::Node *node, std::vector<const ConnectionGadget *> &connections, const Gaffer::Set *excludedNodes = 0 ) const;
 		
+		/// Finds all the upstream NodeGadgets connected to the specified node
+		/// and appends them to the specified vector. Returns the new size of the vector.
+		/// \note Here "upstream" nodes are defined as nodes at the end of input
+		/// connections as shown in the graph - invisible connections and
+		/// invisible nodes are not considered at all.
+		size_t upstreamNodeGadgets( const Gaffer::Node *node, std::vector<NodeGadget *> &upstreamNodeGadgets );
+		size_t upstreamNodeGadgets( const Gaffer::Node *node, std::vector<const NodeGadget *> &upstreamNodeGadgets ) const;
+		
 		/// Sets the position of the specified node within the graph. This
 		/// method may be used even when the node currently has no NodeGadget
 		/// associated with it, and the position will be used if and when a NodeGadget
@@ -184,6 +192,8 @@ class GraphGadget : public ContainerGadget
 		void updateConnectionGadgetMinimisation( ConnectionGadget *gadget );
 		ConnectionGadget *reconnectionGadgetAt( NodeGadget *gadget, const IECore::LineSegment3f &lineInGadgetSpace ) const;
 		void updateDragReconnectCandidate( const DragDropEvent &event );
+
+		void upstreamNodeGadgetsWalk( NodeGadget *gadget, std::set<NodeGadget *> &upstreamNodeGadgets );
 				
 		Gaffer::NodePtr m_root;
 		Gaffer::ScriptNodePtr m_scriptNode;

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -249,7 +249,7 @@ void ViewportGadget::childRemoved( GraphComponent *parent, GraphComponent *child
 
 bool ViewportGadget::buttonPress( GadgetPtr gadget, const ButtonEvent &event )
 {
-	if( event.modifiers & ModifiableEvent::Alt )
+	if( event.modifiers == ModifiableEvent::Alt )
 	{
 		// accept press so we get a dragBegin opportunity for camera movement
 		return true;
@@ -371,7 +371,7 @@ bool ViewportGadget::mouseMove( GadgetPtr gadget, const ButtonEvent &event )
 
 IECore::RunTimeTypedPtr ViewportGadget::dragBegin( GadgetPtr gadget, const DragDropEvent &event )
 {
-	if ( !(event.modifiers & ModifiableEvent::Alt) && m_lastButtonPressGadget )
+	if ( !(event.modifiers == ModifiableEvent::Alt) && m_lastButtonPressGadget )
 	{
 		// see if a child gadget would like to start a drag
 		RunTimeTypedPtr data = dispatchEvent( m_lastButtonPressGadget, &Gadget::dragBeginSignal, event );
@@ -383,7 +383,7 @@ IECore::RunTimeTypedPtr ViewportGadget::dragBegin( GadgetPtr gadget, const DragD
 		}
 	}
 	
-	if ( event.modifiers & ModifiableEvent::Alt || ( event.buttons == ButtonEvent::Middle && event.modifiers == ModifiableEvent::None ) )
+	if ( event.modifiers == ModifiableEvent::Alt || ( event.buttons == ButtonEvent::Middle && event.modifiers == ModifiableEvent::None ) )
 	{
 		// start camera motion
 	

--- a/src/GafferUIBindings/GraphGadgetBinding.cpp
+++ b/src/GafferUIBindings/GraphGadgetBinding.cpp
@@ -110,6 +110,19 @@ static list connectionGadgets2( GraphGadget &graphGadget, const Gaffer::Node *no
 	return l;
 }
 
+static list upstreamNodeGadgets( GraphGadget &graphGadget, const Gaffer::Node *node )
+{
+	std::vector<NodeGadget *> nodeGadgets;
+	graphGadget.upstreamNodeGadgets( node, nodeGadgets );
+	
+	boost::python::list l;
+	for( std::vector<NodeGadget *>::const_iterator it=nodeGadgets.begin(), eIt=nodeGadgets.end(); it!=eIt; ++it )
+	{
+		l.append( NodeGadgetPtr( *it ) );
+	}
+	return l;
+}
+
 static void setLayout( GraphGadget &g, GraphLayoutPtr l )
 {
 	return g.setLayout( l );
@@ -144,6 +157,7 @@ void GafferUIBindings::bindGraphGadget()
 		.def( "connectionGadget", &connectionGadget )
 		.def( "connectionGadgets", &connectionGadgets1, ( arg_( "plug" ), arg_( "excludedNodes" ) = object() ) )
 		.def( "connectionGadgets", &connectionGadgets2, ( arg_( "node" ), arg_( "excludedNodes" ) = object() ) )
+		.def( "upstreamNodeGadgets", &upstreamNodeGadgets )
 		.def( "setNodePosition", &GraphGadget::setNodePosition )
 		.def( "getNodePosition", &GraphGadget::getNodePosition )
 		.def( "setNodeInputConnectionsMinimised", &GraphGadget::setNodeInputConnectionsMinimised )


### PR DESCRIPTION
Alt+Shift click adds all upstream nodes to the selection. Alt+Ctrl click removes all upstream nodes from the selection. Alt click alone remains the domain of the ViewportGadget camera controller, but the ViewportGadget now passes through Alt+Something presses, not using them for camera motion any more.

Also added GraphGadget::upstreamNodeGadgets() public method which is likely to be handy in the future, and was necessary for implementing this.

Fixes #437.
