### PR TITLE
Shift drag to new editor

### DIFF
--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -543,7 +543,14 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 		else :
 			nodeSet = Gaffer.StandardSet( [ x for x in event.data if isinstance( x, Gaffer.Node ) ] )		
 	
-		self.getCurrent().setNodeSet( nodeSet )
+		if event.modifiers & event.Modifiers.Shift :
+			currentEditor = self.getCurrent()
+			newEditor = currentEditor.__class__( currentEditor.scriptNode() )
+			newEditor.setNodeSet( nodeSet )
+			self.insert( 0, newEditor )
+			self.setCurrent( newEditor )
+		else :
+			self.getCurrent().setNodeSet( nodeSet )
 		
 		self.setHighlighted( False )
 		self.__pinningButton.setHighlighted( False )


### PR DESCRIPTION
This allows users to easily create new pinned editors by shift+middle-mouse dragging a node onto an existing editor. The editor will be copied and then have the node pinned into it.

Also did some refactoring work on CompoundEditor to make it easier to extend - it's not all the way there yet but it's in a better shape for beginning to add the various things we have tickets for.
