### PR TITLE
Allowed PathFilter paths plug to receive inputs.

### DIFF
--- a/python/GafferSceneTest/PathFilterTest.py
+++ b/python/GafferSceneTest/PathFilterTest.py
@@ -98,15 +98,7 @@ class PathFilterTest( unittest.TestCase ) :
 			for path in paths :
 				c["scene:path"] = IECore.InternedStringVectorData( path[1:].split( "/" ) )
 				self.assertTrue( f["match"].getValue() & f.Result.ExactMatch )
-	
-	def testInputsDenied( self ) :
-	
-		f = GafferScene.PathFilter()
-		p = Gaffer.StringVectorDataPlug( direction = Gaffer.Plug.Direction.Out, defaultValue = IECore.StringVectorData() )
-		self.failIf( f["paths"].acceptsInput( p ) )
 		
-		self.failUnless( f["paths"].getFlags( Gaffer.Plug.Flags.Serialisable ) )
-	
 	def testBox( self ) :
 	
 		s = Gaffer.ScriptNode()

--- a/python/GafferSceneUI/SceneNodeUI.py
+++ b/python/GafferSceneUI/SceneNodeUI.py
@@ -238,3 +238,5 @@ GafferUI.PlugValueWidget.registerCreator(
 	"paths",
 	__pathsPlugWidgetCreator,
 )
+
+GafferUI.Nodule.registerNodule( GafferScene.PathFilter.staticTypeId(), "paths", lambda plug : None )

--- a/src/GafferScene/PathFilter.cpp
+++ b/src/GafferScene/PathFilter.cpp
@@ -55,10 +55,7 @@ PathFilter::PathFilter( const std::string &name )
 	:	Filter( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	// we don't allow inputs to the paths plug, because then the paths could vary
-	// from computation to computation - resulting in nonsense as far as descendant
-	// matches go.
-	addChild( new StringVectorDataPlug( "paths", Plug::In, new StringVectorData(), Plug::Default & ~Plug::AcceptsInputs ) );
+	addChild( new StringVectorDataPlug( "paths", Plug::In, new StringVectorData() ) );
 
 	plugSetSignal().connect( boost::bind( &PathFilter::plugSet, this, ::_1 ) );
 }


### PR DESCRIPTION
I had disallowed it because in theory you could connect an expression into it where the expression depended on scene:path, and that would mean that ancestor/descendant queries could fail. However this prevented lots of sensible use cases including plug promotion - it's preferable to allow the sensible use cases, as the problematic case is really obscure and unlikely to occur in practice

When we start implementing AttributeFilters and the like, we might add a mechanism whereby filters can specify that they can't support efficient ancestor/descendant queries, and when we detect an input from a ComputeNode the PathFilter could perhaps disable those queries. But that might be overthinking it again too...
