### PR TITLE
Prevented rogue connections being made to Shader "parameters" Plug.

### DIFF
--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -154,6 +154,22 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		n.loadShader( os.path.basename( s ) )
 		
 		self.assertEqual( n["parameters"].keys(), [ "i", "f", "c", "s" ] )
+	
+	def testNoConnectionToParametersPlug( self ) :
+	
+		splitPoint = GafferOSL.OSLShader()
+		splitPoint.loadShader( "utility/splitPoint" )
+		
+		globals = GafferOSL.OSLShader()
+		globals.loadShader( "utility/globals" )
+		
+		splitPoint["parameters"]["p"].setInput( globals["out"]["globalP"] )
+		
+		self.assertTrue( splitPoint["parameters"]["p"].getInput().isSame( globals["out"]["globalP"] ) )
+		self.assertTrue( splitPoint["parameters"]["p"][0].getInput().isSame( globals["out"]["globalP"][0] ) )
+		self.assertTrue( splitPoint["parameters"]["p"][1].getInput().isSame( globals["out"]["globalP"][1] ) )
+		self.assertTrue( splitPoint["parameters"]["p"][2].getInput().isSame( globals["out"]["globalP"][2] ) )
+		self.assertTrue( splitPoint["parameters"].getInput() is None )
 		
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -57,7 +57,7 @@ Shader::Shader( const std::string &name )
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new StringPlug( "name" ) );
 	addChild( new StringPlug( "type" ) );
-	addChild( new CompoundPlug( "parameters" ) );
+	addChild( new CompoundPlug( "parameters", Plug::In, Plug::Default & ~Plug::AcceptsInputs ) );
 	addChild( new BoolPlug( "enabled", Gaffer::Plug::In, true ) );
 }
 


### PR DESCRIPTION
CompoundPlugs track the connections of their children, and connect themselves to match the child connections in the case that all children receive inputs from plugs which share the same parent. When connecting the output of an OSL node into the input of an OSL node with only a single parameter, this could lead to an unwanted connection being made to the top level parameters plug in addition to the wanted connection made to the child plug. Removing the AcceptsInputs flag on the parameters plug fixes the problem.
