### PR TITLE
Added per-column visibility for CompoundVectorParameterValueWidget.

### DIFF
--- a/python/GafferUI/CompoundVectorParameterValueWidget.py
+++ b/python/GafferUI/CompoundVectorParameterValueWidget.py
@@ -99,7 +99,13 @@ class _PlugValueWidget( GafferUI.CompoundParameterValueWidget._PlugValueWidget )
 		
 		self.__vectorDataWidget.setData( data )
 		self.__vectorDataWidget.setEditable( self._editable() )
-					
+		
+		for columnIndex, childParameter in enumerate( self._parameter().values() ) :
+			columnVisible = True
+			with IECore.IgnoredExceptions( KeyError ) :
+				columnVisible = childParameter.userData()["UI"]["visible"].value
+			self.__vectorDataWidget.setColumnVisible( columnIndex, columnVisible )
+				
 	def __dataChanged( self, vectorDataWidget ) :
 	
 		data = vectorDataWidget.getData()

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -261,6 +261,20 @@ class VectorDataWidget( GafferUI.Widget ) :
 	
 		return self.__sizeEditable
 	
+	## Note that the number of columns is not necessarily the
+	# same as the length of the list returned by getData() - for
+	# instance a V3fVectorData in the list will generate 3 columns
+	# in the UI. The columnIndex is specified taking this into account,
+	# so there are actually 3 columns indexes relating to a single
+	# V3fVectorData, and each can be shown/hidden individually.
+	def setColumnVisible( self, columnIndex, visible ) :
+	
+		self.__tableView.setColumnHidden( columnIndex, not visible )
+		
+	def getColumnVisible( self, columnIndex ) :
+	
+		return not self.__tableView.isColumnHidden( columnIndex )
+	
 	def setDragPointer( self, dragPointer ) :
 	
 		self.__dragPointer = dragPointer


### PR DESCRIPTION
Visibility is specified using the standard ["UI"]["visible"] userData entries on the child parameters which provide the columns.

Also added setColumnVisible/getColumnVisible methods to VectorDataWidget to support this.

Fixes #526.
