### PR TITLE
Fixed missing shader nodules.

### DIFF
--- a/python/GafferUI/ReferenceUI.py
+++ b/python/GafferUI/ReferenceUI.py
@@ -153,6 +153,12 @@ def _waitForFileName( initialFileName="", parentWindow=None ) :
 	return str( path )
 
 ##########################################################################
+# Nodules
+##########################################################################
+
+GafferUI.Nodule.registerNodule( Gaffer.Reference.staticTypeId(), "fileName", lambda plug : None )
+
+##########################################################################
 # Metadata
 ##########################################################################
 

--- a/src/GafferUI/Nodule.cpp
+++ b/src/GafferUI/Nodule.cpp
@@ -79,11 +79,6 @@ Nodule::NamedCreatorMap &Nodule::namedCreators()
 
 NodulePtr Nodule::create( Gaffer::PlugPtr plug )
 {
-	if( !plug->getFlags( Gaffer::Plug::AcceptsInputs ) )
-	{
-		return 0;
-	}
-
 	Gaffer::ConstNodePtr node = plug->node();
 	if( node )
 	{


### PR DESCRIPTION
Because we removed the parameters CompoundPlug AcceptsInput flag, the nodule creation was being skipped. We now make nodules for plugs even if they don't accept inputs - this makes sense in the shader case where the child plugs do accept inputs, but also in the case that the plug is an output. If any UIs were relying on the old behaviour, they will now need to register a null Nodule creator - the ReferenceUI change here provides an example of this.
