### PR TITLE
Fixed NodeGraph framing bug.

### DIFF
--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -356,8 +356,12 @@ class NodeGraph( GafferUI.EditorWidget ) :
 			
 	def __drop( self, widget, event ) :
 	
+		if event.sourceWidget is self.__gadgetWidget :
+			return False
+			
 		self.__frame( self.__dropNodes( event.data ) )
-	
+		return True
+		
 	def __dropNodes( self, dragData ) :
 	
 		if isinstance( dragData, Gaffer.Node ) :


### PR DESCRIPTION
It was framing every time a node was moved. This was happening because I moved the dropSignal connection from self to __gadgetWidget in the recent rejig "for consistency". But because the GadgetWidget generates drags for moving nodes, but doesn't handle drops, we were ending up with drops which we didn't want.
