### PR TITLE
Fixed SectionedCompoundDataPlugValueWidget child widget bugs.

### DIFF
--- a/python/GafferUI/CompoundDataPlugValueWidget.py
+++ b/python/GafferUI/CompoundDataPlugValueWidget.py
@@ -158,7 +158,25 @@ class _MemberPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def hasLabel( self ) :
 	
 		return True
+
+	def childPlugValueWidget( self, childPlug, lazy=True ) :
+	
+		for w in self.__row :
+			if w.getPlug().isSame( childPlug ) :
+				return w
+				
+		return None
+	
+	def setReadOnly( self, readOnly ) :
+	
+		if readOnly == self.getReadOnly() :
+			return
+			
+		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
 		
+		for w in self.__row :
+			w.setReadOnly( readOnly )
+	
 	def _updateFromPlug( self ) :
 	
 		if "enabled" in self.getPlug() :

--- a/python/GafferUI/SectionedCompoundDataPlugValueWidget.py
+++ b/python/GafferUI/SectionedCompoundDataPlugValueWidget.py
@@ -57,13 +57,14 @@ class _Section( GafferUI.CompoundDataPlugValueWidget ) :
 class SectionedCompoundDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, sections, **kw ) :
-		column = GafferUI.ListContainer( spacing = 8 )
+		
+		self.__column = GafferUI.ListContainer( spacing = 8 )
 	
-		GafferUI.PlugValueWidget.__init__( self, column, plug, **kw )
+		GafferUI.PlugValueWidget.__init__( self, self.__column, plug, **kw )
 		
 		self.__sections = []
 		
-		with column :
+		with self.__column :
 			for section in sections :
 				self.__sections.append( _Section(
 						plug,
@@ -84,7 +85,26 @@ class SectionedCompoundDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def hasLabel( self ) :
 	
 		return True
+	
+	def childPlugValueWidget( self, childPlug, lazy=True ) :
+	
+		for section in self.__column :
+			result = section.childPlugValueWidget( childPlug, lazy )
+			if result is not None :
+				return result
+				
+		return None
+	
+	def setReadOnly( self, readOnly ) :
+	
+		if readOnly == self.getReadOnly() :
+			return
 			
+		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
+		
+		for section in self.__column :
+			section.setReadOnly( readOnly )
+	
 	def _updateFromPlug( self ) :
 	
 		pass	

--- a/python/GafferUITest/SectionedCompoundDataPlugValueWidgetTest.py
+++ b/python/GafferUITest/SectionedCompoundDataPlugValueWidgetTest.py
@@ -1,0 +1,137 @@
+##########################################################################
+#  
+#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#  
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#  
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#  
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#  
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#  
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferUI
+import GafferUITest
+
+class SectionedCompoundDataPlugValueWidgetTest( GafferUITest.TestCase ) :
+
+	def test( self ) :
+	
+		class SectionedTestNode( Gaffer.Node ) :
+		
+			def __init__( self, name = "SectionedTestNode" ) :
+			
+				Gaffer.Node.__init__( self, name )
+			
+				self["p"] = Gaffer.CompoundDataPlug()
+				self["p"].addMember( "test1", IECore.IntData( 10 ), "test1", Gaffer.Plug.Flags.Default )
+				self["p"].addOptionalMember( "test2", IECore.IntData( 20 ), "test2", Gaffer.Plug.Flags.Default )
+	
+		IECore.registerRunTimeTyped( SectionedTestNode )
+		
+		GafferUI.PlugValueWidget.registerCreator(
+	
+			SectionedTestNode.staticTypeId(),
+			"p",
+			GafferUI.SectionedCompoundDataPlugValueWidget,
+			sections = (
+	
+				{
+					"label" : "One",
+					"namesAndLabels" : (
+						( "test1", "Test" ),
+					),
+				},
+	
+				{
+					"label" : "One",
+					"namesAndLabels" : (
+						( "test2", "Test" ),
+					),
+				},
+	
+			),	
+
+		)
+
+		node = SectionedTestNode()
+		nodeUI = GafferUI.StandardNodeUI( node )
+		
+		self.assertTrue( isinstance( nodeUI.plugValueWidget( node["p"] ), GafferUI.SectionedCompoundDataPlugValueWidget ) )
+		
+		for plugName in [ 
+			"p",
+			"p.test1",
+			"p.test2",
+			"p.test1.value",
+			"p.test2.enabled",
+			"p.test2.value",
+		] :
+			plug = node.descendant( plugName )
+			self.assertTrue( nodeUI.plugValueWidget( plug, lazy=False ).getPlug().isSame( plug ) )
+		
+		for plugName in [ 
+			"p.test1.name",
+			"p.test2.name",
+		] :
+			# there aren't ui elements for the name plug
+			plug = node.descendant( plugName )
+			self.assertTrue( nodeUI.plugValueWidget( plug, lazy=False ) is None )
+		
+		nodeUI.setReadOnly( True )
+		
+		for plugName in [ 
+			"p",
+			"p.test1",
+			"p.test2",
+			"p.test1.value",
+			"p.test2.enabled",
+			"p.test2.value",
+		] :
+			plug = node.descendant( plugName )
+			self.assertTrue( nodeUI.plugValueWidget( plug, lazy=True ).getReadOnly() )
+
+		nodeUI.setReadOnly( False )
+
+		for plugName in [ 
+			"p",
+			"p.test1",
+			"p.test2",
+			"p.test1.value",
+			"p.test2.enabled",
+			"p.test2.value",
+		] :
+			plug = node.descendant( plugName )
+			self.assertFalse( nodeUI.plugValueWidget( plug, lazy=True ).getReadOnly() )
+		
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -92,6 +92,7 @@ from CompoundNumericPlugValueWidgetTest import CompoundNumericPlugValueWidgetTes
 from NameLabelTest import NameLabelTest
 from GLWidgetTest import GLWidgetTest
 from BookmarksTest import BookmarksTest
+from SectionedCompoundDataPlugValueWidgetTest import SectionedCompoundDataPlugValueWidgetTest
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
It wasn't implementing childPlugValueWidget(), or setReadOnly(), both of which are required for any PlugValueWidgets which have PlugValueWidget children.

Fixes #588.
