### PR TITLE
Added fixes for OSX public build.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -603,7 +603,7 @@ if depEnv["BUILD_DEPENDENCY_FREETYPE"] :
 	runCommand( "cd $FREETYPE_SRC_DIR && ./configure --prefix=$BUILD_DIR && make clean && make && make install" )
 			
 if depEnv["BUILD_DEPENDENCY_BOOST"] :
-	runCommand( "cd $BOOST_SRC_DIR; ./bootstrap.sh --prefix=$BUILD_DIR --with-python=$BUILD_DIR/bin/python --with-python-root=$BUILD_DIR && ./bjam -d+2 variant=release link=shared threading=multi install" )
+	runCommand( "cd $BOOST_SRC_DIR; ./bootstrap.sh --prefix=$BUILD_DIR --with-python=$BUILD_DIR/bin/python --with-python-root=$BUILD_DIR && ./bjam linkflags=-L$BUILD_DIR/lib -d+2 variant=release link=shared threading=multi install" )
 
 if depEnv["BUILD_DEPENDENCY_TBB"] :
 	runCommand( "cd $TBB_SRC_DIR; make clean; make" )
@@ -665,6 +665,7 @@ if depEnv["BUILD_DEPENDENCY_HDF5"] :
 
 if depEnv["BUILD_DEPENDENCY_ALEMBIC"] :
 	# may need to hand edit build/AlembicBoost.cmake in the alembic distribution to remove Boost_USE_STATIC_LIBS.
+	# may also need to set ALEMBIC_NO_TESTS=TRUE on OSX (in CMakeLists.txt).
 	runCommand( "cd $ALEMBIC_SRC_DIR && rm -f CMakeCache.txt && cmake -DCMAKE_INSTALL_PREFIX=$BUILD_DIR -DBoost_NO_SYSTEM_PATHS=TRUE -DBoost_NO_BOOST_CMAKE=TRUE -DBOOST_ROOT=$BUILD_DIR -DILMBASE_ROOT=$BUILD_DIR -DUSE_PYILMBASE=FALSE -DUSE_PYALEMBIC=FALSE && make clean && make -j 4 && make install" )
 	runCommand( "mv $BUILD_DIR/alembic-*/include/* $BUILD_DIR/include" )
 	runCommand( "mv $BUILD_DIR/alembic-*/lib/static/* $BUILD_DIR/lib" )


### PR DESCRIPTION
Helped boost find the libraries it has just built - otherwise boost_wave fails to link because it can't find boost_system. Added notes about a modification to the Alembic CMake setup necessary to get the build to work - the Alembic tests don't compile on OS X so we must skip them. I tried setting the variable on the CMake command line but it had no effect - will get a patched version of Alembic into the dependencies tarball instead.
