### PR TITLE
Context variables flowing down the graph

### DIFF
--- a/include/GafferScene/ScenePlug.h
+++ b/include/GafferScene/ScenePlug.h
@@ -111,6 +111,11 @@ class ScenePlug : public Gaffer::CompoundPlug
 		/// each time.
 		static const IECore::InternedString scenePathContextName;
 		
+		
+		/// The name used to specify attributes that add themselves
+		/// to the context
+		static const IECore::InternedString contextVariablesAttributeName;
+		
 		/// @name Convenience accessors
 		/// These functions create temporary Contexts specifying the scenePath
 		/// and then return the result of calling getValue() or hash() on the

--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -166,5 +166,23 @@ class ShaderAssignmentTest( unittest.TestCase ) :
 		self.assertTrue( "shader" in s["a"]["out"].attributes( "/plane" ) )
 		self.assertEqual( s["a2"]["out"].attributes( "/plane" )["shader"][-1].name, "test" )
 		
+	def testContextVariables( self ) :
+		
+		# create a shader with its name defined in a substitution:
+		shader = GafferSceneTest.TestShader()
+		shader["name"].setValue( "${substitution}" )
+		
+		assignment = GafferScene.ShaderAssignment()
+		
+		# define that substitution in the attributes:
+		testAttributes = IECore.CompoundObject()
+		testAttributes["gaffer:contextVariables"] = IECore.CompoundObject( { "substitution" : IECore.StringData("substitutedValue") } )
+		assignment["in"]["attributes"].setValue( testAttributes )
+		assignment["shader"].setInput( shader["out"] )
+		
+		# the resulting shader's name should now be "substitutedValue":
+		outputAttributes = assignment["out"].attributes( "/testLocation" )
+		self.assertEqual( outputAttributes["shader"][-1].name, "substitutedValue" )
+		
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -51,6 +51,8 @@ IE_CORE_DEFINERUNTIMETYPED( ScenePlug );
 
 const IECore::InternedString ScenePlug::scenePathContextName( "scene:path" );
 
+const IECore::InternedString ScenePlug::contextVariablesAttributeName( "gaffer:contextVariables" );
+
 ScenePlug::ScenePlug( const std::string &name, Direction direction, unsigned flags )
 	:	CompoundPlug( name, direction, flags )
 {


### PR DESCRIPTION
For workflow reasons, it would be convenient if string subsitutions could flow down the graph, so eg a texture path could be defined on an asset before it's merged in to the hierarchy, and used in downstream shader assignments. This commit allows you to achieve that effect in ShaderAssignments by adding a CompoundObject called "gaffer:contextVariables" to the attributes, containing the string substitutions/context variables you require.
