### PR TITLE
GafferImage::Display now hashes port number

### DIFF
--- a/src/GafferImage/Display.cpp
+++ b/src/GafferImage/Display.cpp
@@ -245,6 +245,7 @@ Node::UnaryPlugSignal &Display::imageReceivedSignal()
 
 void Display::hashImagePrimitive( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
+	portPlug()->hash( h );
 	updateCountPlug()->hash( h );
 }
 


### PR DESCRIPTION
This avoids cache problems in the situation where you've got eg multiple IPR renders going to different displays
