### PR TITLE
Made Boxes export all non hidden plugs for referencing

### DIFF
--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -241,13 +241,14 @@ class ReferenceTest( unittest.TestCase ) :
 		self.assertEqual( s3["r"]["user"]["n2_op2"].getValue(), 123 )
 		self.assertTrue( s3["r"]["in"].getInput().isSame( s3["a"]["sum"] ) )
 	
-	def testReferencesDontGetCustomPlugsFromBoxes( self ) :
+	def testReferenceExportCustomPlugsFromBoxes( self ) :
 	
 		s = Gaffer.ScriptNode()
 		s["n1"] = GafferTest.AddNode()
 		
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n1"] ] ) )
 		b["myCustomPlug"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		b["__invisiblePlugThatShouldntGetExported"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		
 		b.exportForReference( "/tmp/test.grf" )
 		
@@ -255,7 +256,8 @@ class ReferenceTest( unittest.TestCase ) :
 		s2["r"] = Gaffer.Reference()
 		s2["r"].load( "/tmp/test.grf" )
 		
-		self.assertTrue( "myCustomPlug" not in s2["r"] )
+		self.assertTrue( "myCustomPlug" in s2["r"] )
+		self.assertTrue( "__invisiblePlugThatShouldntGetExported" not in s2["r"] )
 		
 	def tearDown( self ) :
 	

--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -257,10 +257,10 @@ void Box::exportForReference( const std::string &fileName ) const
 		throw IECore::Exception( "Box::exportForReference called without ScriptNode" );
 	}
 	
-	// we only want to save out our child nodes, user plugs and in*/out* plugs so we build a filter.
+	// we only want to save out our child nodes and plugs that are visible in the UI, so we build a filter
 	// to specify just the things to export.
 	
-	boost::regex inOrOut( "^in|out[0-9]*$" );
+	boost::regex invisiblePlug( "^__.*$" );
 	StandardSetPtr toExport = new StandardSet;
 	for( ChildIterator it = children().begin(), eIt = children().end(); it != eIt; ++it )
 	{
@@ -270,7 +270,7 @@ void Box::exportForReference( const std::string &fileName ) const
 		}
 		else if( const Plug *plug = IECore::runTimeCast<Plug>( it->get() ) )
 		{
-			if( plug == userPlug() || boost::regex_match( plug->getName().c_str(), inOrOut ) )
+			if( !boost::regex_match( plug->getName().c_str(), invisiblePlug ) )
 			{
 				toExport->add( *it );	
 			}


### PR DESCRIPTION
Box.exportForReference() now only skips exporting plugs starting with "__", as per an email conversation with John. This will soon become a production requirement as we start needing boxes with shader inputs and what not...
