### PR TITLE
Fixed GafferScene.ScenePath.isValid().

### DIFF
--- a/python/GafferScene/ScenePath.py
+++ b/python/GafferScene/ScenePath.py
@@ -56,15 +56,18 @@ class ScenePath( Gaffer.Path ) :
 	
 	def isValid( self ) :
 	
+		if not Gaffer.Path.isValid( self ) :
+			return False
+	
 		with self.__context :
-			with IECore.IgnoredExceptions( Exception ) :
-				## \todo Possibly we should just have a "valid" child plug
-				# Or perhaps instead we should just walk up from the root,
-				# checking that all the correct child names exist.
-				self.__scenePlug.bound( str( self ) )
-				return True
+			path = IECore.InternedStringVectorData()
+			for p in self :
+				childNames = self.__scenePlug.childNames( path )
+				if p not in childNames :
+					return False
+				path.append( p )
 				
-		return False
+		return True
 	
 	def info( self ) :
 	

--- a/python/GafferSceneTest/ScenePathTest.py
+++ b/python/GafferSceneTest/ScenePathTest.py
@@ -68,6 +68,30 @@ class ScenePathTest( unittest.TestCase ) :
 		self.assertEqual( p2.root(), "" )
 		self.assertEqual( [ str( c ) for c in p2.children() ], [ "group1/pCube1" ] )
 	
+	def testIsValid( self ) :
+	
+		plane = GafferScene.Plane()
+		group = GafferScene.Group()
+		group["in"].setInput( plane["out"] )
+		
+		p = GafferScene.ScenePath( group["out"], Gaffer.Context(), "/" )
+		self.assertTrue( p.isValid() )
+		
+		p.setFromString( "/group" )
+		self.assertTrue( p.isValid() )
+		
+		p.setFromString( "/group/plane" )
+		self.assertTrue( p.isValid() )
+
+		p.setFromString( "/group/plane2" )
+		self.assertFalse( p.isValid() )
+		
+		p.setFromString( "/group2/plane" )
+		self.assertFalse( p.isValid() )
+
+		p.setFromString( "" )
+		self.assertFalse( p.isValid() )
+		
 if __name__ == "__main__":
 	unittest.main()
 	


### PR DESCRIPTION
The previous implementation attempted to call ScenePlug.bound() for the path and returned False if there was an Exception, but this wasn't a good approach in several cases. The problem was that many nodes don't do any sanity checking on the path during computation for the sake of speed. The Group node for instance doesn't check that the first element in the path is actually the name of the group - it just makes decisions based on the length of the path. Since efficiency is of major concern to us, the solution isn't to bog all the node implementations down in lots of unecessary input validation.

Instead, ScenePath.isValid() now traverses up the path from the root, ensuring that the next required path element is present in the child names at each point. This definition of validity doesn't affect node performance and is robust in all cases.

The most visible effect of this fix is that when a path chooser is opened for an invalid path, the path is automatically truncated until it is valid - this reduces confusion arising from renaming the hiearchy and then browsing for a previously set path.

Fixes #64.
