### PR TITLE
Fixed copy/paste bug with unselected PathFilter input.

### DIFF
--- a/python/GafferSceneTest/PathFilterTest.py
+++ b/python/GafferSceneTest/PathFilterTest.py
@@ -119,6 +119,21 @@ class PathFilterTest( unittest.TestCase ) :
 		s["a"]["filter"].setInput( s["f"]["match"] )
 		
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["a"] ] ) )
+	
+	def testCopyPaste( self ) :
+	
+		s = Gaffer.ScriptNode()
+		
+		s["f"] = GafferScene.PathFilter()
+		s["a"] = GafferScene.Attributes()
+		s["a"]["filter"].setInput( s["f"]["match"] )
+		
+		ss = s.serialise( s, Gaffer.StandardSet( [ s["a"] ] ) )
+		
+		s.execute( ss )
+		
+		self.assertTrue( isinstance( s["a1"], GafferScene.Attributes ) )
+		self.assertEqual( s["a1"]["filter"].getInput(), None )
 		
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/PathFilter.cpp
+++ b/src/GafferScene/PathFilter.cpp
@@ -99,8 +99,13 @@ void PathFilter::hashMatch( const Gaffer::Context *context, IECore::MurmurHash &
 
 unsigned PathFilter::computeMatch( const Gaffer::Context *context ) const
 {
-	const ScenePlug::ScenePath &path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
-	return m_matcher.match( path );
+	typedef IECore::TypedData<ScenePlug::ScenePath> ScenePathData;
+	const ScenePathData *pathData = context->get<ScenePathData>( ScenePlug::scenePathContextName, 0 );
+	if( pathData )
+	{
+		return m_matcher.match( pathData->readable() );
+	}
+	return NoMatch;
 }
 
 void PathFilter::plugSet( Gaffer::Plug *plug )


### PR DESCRIPTION
I noticed David was having to work around this copy/paste error in the ShaderGraphApp, and since it's a pretty simple fix thought it'd be worth having it done in Gaffer itself.
