### PR TITLE
Simplified OpDialogue error display.

### DIFF
--- a/python/GafferUI/OpDialogue.py
+++ b/python/GafferUI/OpDialogue.py
@@ -280,7 +280,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 	def __initiateErrorDisplay( self, exceptionInfo ) :
 		
 		self.__progressIconFrame.setChild( GafferUI.Image( "opDialogueFailure.png" ) )
-		self.__progressLabel.setText( "<h3>" + str( exceptionInfo[1] ) + "</h3>" )
+		self.__progressLabel.setText( "<h3>Failed</h3>" )
 	
 		self.__backButton.setText( "Cancel" )
 		self.__backButton.setEnabled( True )


### PR DESCRIPTION
We were putting the entire error message inside a label, which meant that the window could become extremely large if the error was long. We now simply display a short "Failed" message and rely on the Details pane to provide the full information - this is the same thing we do for successful operation - there is a short "Completed" message and the result is displayed in the details pane.
