### PR TITLE
Enabled Python threading by default in Gaffer python module.

### DIFF
--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -149,4 +149,10 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	
 	bindBehaviours();
 
+	// Various parts of gaffer create new threads from C++, and those
+	// threads may call back into Python via wrapped classes at any time.
+	// We must prepare Python for this by calling PyEval_InitThreads().
+
+	PyEval_InitThreads();
+	
 }


### PR DESCRIPTION
Since Gaffer graph evaluation is multithreaded and standard API methods such as ImagePlug::image() may spawn threads, it seems unreasonable to place the burden of calling this on the user.
