### PR TITLE
Moved renaming code from PlugWidget to LabelPlugValueWidget.

### DIFF
--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -37,20 +37,30 @@
 import Gaffer
 import GafferUI
 
+QtGui = GafferUI._qtImport( "QtGui" )
+
 ## A simple PlugValueWidget which just displays the name of the plug,
 # with the popup action menu for the plug.
 class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, horizontalAlignment=GafferUI.Label.HorizontalAlignment.Left, verticalAlignment=GafferUI.Label.VerticalAlignment.Center, **kw ) :
 		
+		GafferUI.PlugValueWidget.__init__( self, QtGui.QWidget(), plug, **kw )
+
+		layout = QtGui.QHBoxLayout()
+		layout.setContentsMargins( 0, 0, 0, 0 )
+		layout.setSizeConstraint( QtGui.QLayout.SetMinAndMaxSize )
+		self._qtWidget().setLayout( layout )
+
 		self.__label = GafferUI.NameLabel(
 			plug,
 			horizontalAlignment = horizontalAlignment,
 			verticalAlignment = verticalAlignment,
 		)
+		layout.addWidget( self.__label._qtWidget() )
 		
-		GafferUI.PlugValueWidget.__init__( self, self.__label, plug, **kw )
-			
+		self.__editableLabel = None # we'll make this lazily as needed
+		
 		# connecting at group 0 so we're called before the slots
 		# connected by the NameLabel class.
 		self.__dragBeginConnection = self.__label.dragBeginSignal().connect( 0, Gaffer.WeakMethod( self.__dragBegin ) )
@@ -69,10 +79,21 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 		GafferUI.PlugValueWidget.setPlug( self, plug )
 	
 		self.__label.setGraphComponent( plug )
+		if self.__editableLabel is not None :
+			self.__editableLabel.setGraphComponent( plug )
 		
 		label = Gaffer.Metadata.plugValue( plug, "label" ) if plug is not None else None
 		if label is not None :
 			self.__label.setText( label )
+		
+		# if the plug is a user plug, then set things up so it can be renamed
+		# by double clicking on the label. currently we only accept plugs immediately
+		# parented to the user plug, so as to avoid allowing the renaming of child
+		# plugs inside SplinePlugs and the like, where plug names have specific meanings.
+		if plug is not None and plug.node()["user"].isSame( plug.parent() ) :
+			self.__labelDoubleClickConnection = self.__label.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__labelDoubleClicked ) )
+		else :
+			self.__labelDoubleClickConnection = None
 
 	def setHighlighted( self, highlighted ) :
 	
@@ -122,4 +143,25 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __dragEnd( self, widget, event ) :
 		
 		GafferUI.Pointer.set( None )
+	
+	def __labelDoubleClicked( self, label, event ) :
+	
+		assert( label is self.__label )
 		
+		if self.__editableLabel is None :
+			self.__editableLabel = GafferUI.NameWidget( self.getPlug() )
+			self.__editableLabel._qtWidget().setMinimumSize( self.label()._qtWidget().minimumSize() )
+			self.__editableLabel._qtWidget().setMaximumSize( self.label()._qtWidget().maximumSize() )
+			self.__labelEditingFinishedConnection = self.__editableLabel.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__labelEditingFinished ) )
+			self._qtWidget().layout().insertWidget( 0, self.__editableLabel._qtWidget() )
+		
+		self.__label.setVisible( False )
+		self.__editableLabel.setVisible( True )
+		self.__editableLabel.setSelection( 0, len( self.__editableLabel.getText() ) )
+		self.__editableLabel.grabFocus()
+	
+	def __labelEditingFinished( self, label ) :
+	
+		self.__label.setVisible( True )
+		self.__editableLabel.setVisible( False )
+	

--- a/python/GafferUI/PlugWidget.py
+++ b/python/GafferUI/PlugWidget.py
@@ -99,12 +99,6 @@ class PlugWidget( GafferUI.Widget ) :
 		layout.addWidget( self.__label._qtWidget() )
 		layout.addWidget( self.__valueWidget._qtWidget() )
 		
-		# if the plug is a user plug, then set things up so it can be renamed
-		# by double clicking on the label.
-		if plug.node()["user"].isAncestorOf( plug ) :
-			self.__labelDoubleClickConnection = self.__label.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__labelDoubleClicked ) )
-			self.__editableLabel = None
-		
 		# The plugValueWidget() may have smarter drop behaviour than the labelPlugValueWidget(),
 		# because it has specialised PlugValueWidget._dropValue(). It's also more meaningful to the
 		# user if we highlight the plugValueWidget() on dragEnter rather than the label. So we
@@ -128,26 +122,6 @@ class PlugWidget( GafferUI.Widget ) :
 	def labelWidth() :
 	
 		return 150
-
-	def __labelDoubleClicked( self, label, event ) :
-	
-		assert( label is self.__label )
-		
-		if self.__editableLabel is None :
-			self.__editableLabel = GafferUI.NameWidget( self.plugValueWidget().getPlug() )
-			self.__editableLabel._qtWidget().setFixedWidth( self.labelWidth() )
-			self.__labelEditingFinishedConnection = self.__editableLabel.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__labelEditingFinished ) )
-			self._qtWidget().layout().insertWidget( 0, self.__editableLabel._qtWidget() )
-		
-		self.__label.setVisible( False )
-		self.__editableLabel.setVisible( True )
-		self.__editableLabel.setSelection( 0, len( self.__editableLabel.getText() ) )
-		self.__editableLabel.grabFocus()
-	
-	def __labelEditingFinished( self, label ) :
-	
-		self.__label.setVisible( True )
-		self.__editableLabel.setVisible( False )
 
 	def __labelDragEnter( self, label, event ) :
 			


### PR DESCRIPTION
This makes renaming available for promoted children of CompoundDataPlugs, the most common example of which is plugs promoted from the Attributes and Options nodes in GafferScene.
