### PR TITLE
Path filter plug promotion

### DIFF
--- a/include/GafferScene/PathFilter.h
+++ b/include/GafferScene/PathFilter.h
@@ -63,14 +63,16 @@ class PathFilter : public Filter
 
 	protected :
 
+		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+
 		virtual void hashMatch( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual unsigned computeMatch( const Gaffer::Context *context ) const;
 
 	private :
-	
-		void plugSet( Gaffer::Plug *plug );
-	
-		PathMatcher m_matcher;
+
+		Gaffer::ObjectPlug *pathMatcherPlug();
+		const Gaffer::ObjectPlug *pathMatcherPlug() const;
 	
 		static size_t g_firstPlugIndex;
 


### PR DESCRIPTION
This enables input connections to the PathFilter "paths" plug - this allows it to be promoted to box level, be driven by expressions etc. It's feasible for a very nefarious user to drive it with an expression which varies based on the "scene:path" context entry, in which case descendant and ancestor queries would be inaccurate, but a user that nefarious deserves what they get.
