### PR TITLE
Fixed read only on CompoundPlugValueWidget labels

### DIFF
--- a/python/GafferUI/CompoundPlugValueWidget.py
+++ b/python/GafferUI/CompoundPlugValueWidget.py
@@ -141,6 +141,9 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 				continue
 			if isinstance( w, GafferUI.PlugValueWidget ) :
 				w.setReadOnly( readOnly )
+			elif isinstance(  w, GafferUI.PlugWidget ) :
+				w.labelPlugValueWidget().setReadOnly( readOnly )
+				w.plugValueWidget().setReadOnly( readOnly )
 			else :
 				w.plugValueWidget().setReadOnly( readOnly )
 
@@ -209,6 +212,9 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 				if widget is not None :
 					if isinstance( widget, GafferUI.PlugValueWidget ) :
 						widget.setReadOnly( self.getReadOnly() )
+					elif isinstance(  widget, GafferUI.PlugWidget ) :
+						widget.labelPlugValueWidget().setReadOnly( self.getReadOnly() )
+						widget.plugValueWidget().setReadOnly( self.getReadOnly() )
 					else :
 						widget.plugValueWidget().setReadOnly( self.getReadOnly() )
 			else :


### PR DESCRIPTION
Previously, the labels on a CompoundPlugValueWidget weren't affected by __updateChildPlugUIs or setReadOnly(), meaning you could promote plugs in a read only node ui in certain situations.
