### PR TITLE
Removed PathFilter paths nodule.

### DIFF
--- a/python/GafferSceneUI/SceneNodeUI.py
+++ b/python/GafferSceneUI/SceneNodeUI.py
@@ -249,6 +249,12 @@ GafferUI.PlugValueWidget.registerCreator(
 	__pathsPlugWidgetCreator,
 )
 
+GafferUI.Nodule.registerNodule(
+	GafferScene.PathFilter.staticTypeId(),
+	"paths",
+	lambda plug : None,
+)
+
 # UnionFilter
 
 GafferUI.PlugValueWidget.registerCreator(


### PR DESCRIPTION
It snuck in when we made the paths plug accept connections, but since we don't have any nodes we would connect into it at present, it doesn't make much sense to draw it in the node graph.
