### PR TITLE
Fixed copy/paste breaking filters

### DIFF
--- a/python/GafferSceneTest/PathFilterTest.py
+++ b/python/GafferSceneTest/PathFilterTest.py
@@ -135,6 +135,9 @@ class PathFilterTest( unittest.TestCase ) :
 		
 		self.assertTrue( isinstance( s["a1"], GafferScene.Attributes ) )
 		self.assertEqual( s["a1"]["filter"].getInput(), None )
+		
+		# if this is not EveryMatch and the filter is disconnected, the filter will no longer work
+		self.assertEqual( s["a1"]["filter"].getValue(), s["f"].Result.EveryMatch )
 
 	def testPathPlugPromotion( self ) :
 	

--- a/src/GafferScene/PathFilter.cpp
+++ b/src/GafferScene/PathFilter.cpp
@@ -141,5 +141,5 @@ unsigned PathFilter::computeMatch( const Gaffer::Context *context ) const
 		ConstPathMatcherDataPtr pathMatcher = staticPointerCast<const PathMatcherData>( pathMatcherPlug()->getValue() );
 		return pathMatcher->readable().match( pathData->readable() );
 	}
-	return NoMatch;
+	return EveryMatch;
 }


### PR DESCRIPTION
Previously, if a SceneElementProcessor node was connected to a filter, copy pasting the processor node would set the filter plug value on the copy to NoMatch, meaning that node would have no effect unless the filter was reconnected. I've fixed this by changing the default return value of PathFilter::computeMatch to EveryMatch
