### PR TITLE
Added search prefix to arnold shader names

### DIFF
--- a/python/GafferArnoldUI/ShaderMenu.py
+++ b/python/GafferArnoldUI/ShaderMenu.py
@@ -66,7 +66,7 @@ def appendShaders( menuDefinition, prefix="/Arnold" ) :
 				menuPath,
 				{
 					"command" : GafferUI.NodeMenu.nodeCreatorWrapper( IECore.curry( __shaderCreator, shaderName, nodeType ) ),
-					"searchText" : 'ai' + displayName,
+					"searchText" : "ai" + displayName.replace( " ", "" ),
 				}
 			)
 


### PR DESCRIPTION
I've found it a bit tricky to find the arnold shader nodes I'm after when searching in the NodeMenu. As a (potentially temporary) fix I propose prefixing the search text for each arnold shader node with 'ai'.

In the future gaffer may have some way of setting 'context' for the menu search, but this prefix seems helpful as things are right now.
