### PR TITLE
Optimised Wrapper isInstanceOf() implementations for common cases.

### DIFF
--- a/include/GafferBindings/NodeBinding.h
+++ b/include/GafferBindings/NodeBinding.h
@@ -73,6 +73,32 @@ class NodeWrapper : public GraphComponentWrapper<T>
 		{
 		}		
 		
+		virtual bool isInstanceOf( IECore::TypeId typeId ) const
+		{
+			// Optimise for common queries we know should fail.
+			// The standard wrapper implementation of isInstanceOf()
+			// would have to enter Python only to discover this inevitable
+			// failure as it doesn't have knowledge of the relationships
+			// among types. Entering Python is incredibly costly for such
+			// a simple operation, and we perform these operations often,
+			// so this optimisation is well worth it.
+			//
+			// Note that we can't actually guarantee that we're not a
+			// ScriptNode, but ScriptNode queries are so common that we
+			// must accelerate them. We adjust for this slightly overzealous
+			// optimisation in ScriptNodeWrapper where we also override
+			// isInstanceOf() and make the necessary correction.
+			if(
+				typeId == (IECore::TypeId)Gaffer::ScriptNodeTypeId ||
+				typeId == (IECore::TypeId)Gaffer::PlugTypeId ||
+				typeId == (IECore::TypeId)Gaffer::CompoundPlugTypeId
+			)
+			{
+				return false;
+			}
+			return GraphComponentWrapper<T>::isInstanceOf( typeId );
+		}
+		
 		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
 		{
 			IECorePython::ScopedGILLock gilLock;

--- a/include/GafferBindings/PlugBinding.h
+++ b/include/GafferBindings/PlugBinding.h
@@ -58,6 +58,27 @@ class PlugWrapper : public GraphComponentWrapper<WrappedType>
 		{
 		}		
 
+		virtual bool isInstanceOf( IECore::TypeId typeId ) const
+		{
+			// Optimise for common queries we know should fail.
+			// The standard wrapper implementation of isInstanceOf()
+			// would have to enter Python only to discover this inevitable
+			// failure as it doesn't have knowledge of the relationships
+			// among types. Entering Python is incredibly costly for such
+			// a simple operation, and we perform these operations often,
+			// so this optimisation is well worth it.
+			if(
+				typeId == (IECore::TypeId)Gaffer::ScriptNodeTypeId ||
+				typeId == (IECore::TypeId)Gaffer::NodeTypeId ||
+				typeId == (IECore::TypeId)Gaffer::DependencyNodeTypeId ||
+				typeId == (IECore::TypeId)Gaffer::ComputeNodeTypeId
+			)
+			{
+				return false;
+			}
+			return GraphComponentWrapper<WrappedType>::isInstanceOf( typeId );
+		}
+
 		virtual bool acceptsInput( const Gaffer::Plug *input ) const
 		{
 			IECorePython::ScopedGILLock gilLock;

--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -296,6 +296,8 @@ class ScriptNodeTest( unittest.TestCase ) :
 			def acceptsChild( self, child ) :
 			
 				return isinstance( child, GafferTest.AddNode )
+		
+		IECore.registerRunTimeTyped( MyScriptNode )
 				
 		n = MyScriptNode( "s" )
 		
@@ -304,6 +306,7 @@ class ScriptNodeTest( unittest.TestCase ) :
 		
 		n.addChild( c1 )
 		self.failUnless( c1.parent() is n )
+		self.failUnless( c1.scriptNode() is n )
 	
 		self.assertRaises( RuntimeError, n.addChild, c2 )
 		self.failUnless( c2.parent() is None )

--- a/src/GafferBindings/ScriptNodeBinding.cpp
+++ b/src/GafferBindings/ScriptNodeBinding.cpp
@@ -78,6 +78,17 @@ class ScriptNodeWrapper : public NodeWrapper<ScriptNode>
 		{
 		}
 
+		virtual bool isInstanceOf( IECore::TypeId typeId ) const
+		{
+			if( typeId == (IECore::TypeId)Gaffer::ScriptNodeTypeId )
+			{
+				// Correct for the slightly overzealous (but hugely beneficial)
+				// optimisation in NodeWrapper::isInstanceOf().
+				return true;
+			}
+			return NodeWrapper<ScriptNode>::isInstanceOf( typeId );
+		}
+		
 		virtual void execute( const std::string &pythonScript, Node *parent = 0 )
 		{
 			IECorePython::ScopedGILLock gilLock;


### PR DESCRIPTION
This is a nice little speedup that came out of my work from #763, but doesn't require all the Wrapper::isSubclassed() shenanigans in Cortex that we've discussed for that. It came about after still seeing significant overhead in Python implementations of isInstanceOf(), even with the (work in progress) isSubclassed() accelerations in place. This turned out to be because IE is currently actually using quite a lot of custom nodes developed in Python (PassOutput, RenderAttributes, ShaderOutput, ieStandardMaterial), which naturally can't benefit from the isSubclassed() optimisation.

The optimisation here is a direct optimisation for isInstanceOf() which is highly specific to Gaffer's use patterns and works whether or not an object is subclassed in Python. It knocks a good 10% off the load time for the monster scene David provided to me.

There are other use patterns for wrapped nodes (#760 for one) which will require the full optimisation approach, but I thought it was worth merging this one individually, as it's a nice improvement and doesn't come with all the upheaval entailed in the full approach.
