### PR TITLE
Added GafferImage::ImageWriter::acceptsInput() method.

### DIFF
--- a/include/GafferImage/ImageWriter.h
+++ b/include/GafferImage/ImageWriter.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //  
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
 //  
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -87,6 +87,10 @@ class ImageWriter : public Gaffer::ExecutableNode
 		
 		/// Implemented to execute in all the specified contexts in sequence.
 		virtual void execute( const Executable::Contexts &contexts ) const;
+	
+	protected :
+
+		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
 
 	private :
 		

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #  
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
 #  
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -74,10 +74,18 @@ class ImageWriterTest( unittest.TestCase ) :
 			self.failUnless( "B" in channelNames )
 			self.failUnless( not "A" in channelNames )
 		
+	def testAcceptsInput( self ) :
+		
+		w = GafferImage.ImageWriter()
+		p = GafferImage.ImagePlug( direction = Gaffer.Plug.Direction.Out )		
+		
+		self.failIf( w['requirements']['requirement0'].acceptsInput( p ) )
+		self.failUnless( w["in"].acceptsInput( p ) )
+	
 	def testTiffWrite( self ) :
 		self.__testExtension( "tif" )
 
-	# Outputting RGBA images with JPG doens't work but it should... this is a known issue and needs fixing.
+	# Outputting RGBA images with JPG doesn't work but it should... this is a known issue and needs fixing.
 	def testJpgWrite( self ) :
 		self.__testExtension( "jpg" )
 

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //  
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
 //  
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -153,6 +153,10 @@ const GafferImage::ChannelMaskPlug *ImageWriter::channelsPlug() const
 	return getChild<ChannelMaskPlug>( g_firstPlugIndex+3 );
 }
 
+bool ImageWriter::acceptsInput( const Plug *plug, const Plug *inputPlug ) const
+{
+	return ExecutableNode::acceptsRequirementsInput( plug, inputPlug );
+}
 
 void ImageWriter::executionRequirements( const Context *context, Tasks &requirements ) const
 {


### PR DESCRIPTION
Implements an acceptsInput() method on the ImageWriter node. The method checks ExecutableNode::acceptsRequirementsInput() to ensure that an ImagePlug cannot be connected to a child of the "requirements" plug.

This solves the issue outlined in #681 but a more elegant solution should be found by moving the logic into the base class.

This should also address #255.
