### PR TITLE
Simplified OpDialogue exception reporting.

### DIFF
--- a/python/GafferUI/OpDialogue.py
+++ b/python/GafferUI/OpDialogue.py
@@ -311,9 +311,15 @@ class OpDialogue( GafferUI.Dialogue ) :
 		self.__forwardButtonClickedConnection = self.__forwardButton.clickedSignal().connect( Gaffer.WeakMethod( self.__initiateParameterEditing ) )
 		
 		self.__messageWidget.messageHandler().handle(
+			IECore.Msg.Level.Debug,
+			"Python Traceback",
+			"".join( traceback.format_exception( *exceptionInfo ) )
+		)
+		
+		self.__messageWidget.messageHandler().handle(
 			IECore.Msg.Level.Error,
 			str( exceptionInfo[1] ),
-			"".join( traceback.format_exception( *exceptionInfo ) )
+			""
 		)
 		
 		self.__frame.setChild( self.__progressUI )


### PR DESCRIPTION
This does 3) as discussed in #806. When an exception occurs only the short form of the error is shown by default. Clicking the green triangle will show the full debug information. Let us know if you want something different...
