### PR TITLE
Added workaround for squash/stretch in viewport camera look-through.

### DIFF
--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -508,6 +508,15 @@ void SceneView::updateLookThrough()
 				{
 					camera = constCamera->copy();
 					camera->setTransform( new MatrixTransform( scene->fullTransform( cameraPath ) ) );
+					
+					// if the camera has an existing screen window, remove it.
+					// if we didn't, it would conflict with the resolution we set
+					// below, yielding squashed/stretched images.
+					/// \todo Properly specify how cameras are represented in Gaffer
+					/// (the Cortex representation is very renderer-centric, with no
+					/// real world parameters like film back) so that this isn't necessary,
+					/// and add nice overlays for resolution gate etc.
+					camera->parameters().erase( "screenWindow" );
 				}
 			}
 			catch( ... )


### PR DESCRIPTION
The Cortex camera specification is very RenderMan centric, and the camera defines the resolution and the screen window for the render. If the aspect ratios of these are different, then we get squashing or stretching of the viewed image - and when we're using the camera in the viewport we currently must set the resolution to match the resolution of the viewport. The GafferScene.Camera node deliberately doesn't specify screen window to avoid squash/stretch in this situation, but cameras from other sources may not. As a short-term solution we just remove the screen window.

Longer term (but pretty soon I imagine) we may need to revise the Cortex/Gaffer camera representation so that we can deal with cameras in more physical terms, only performing the mapping to a screenwindow/resolution pair for the renderer. Tickets we could bundle into this chunk of work include #277 (main ticket requesting physical cameras), and #371, #276, #58 as related smaller tickets. We may want to consider adopting something like the Alembic camera representation because a great deal of discussion has gone into it, and it aims to balance the complexity of a million physical parameters with the fairly simple requirements of a renderer (a frustum).

Fixes #826.
