### PR TITLE
Fixed IPR bug where shaders could leak onto the wrong objects.

### DIFF
--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -227,7 +227,7 @@ void InteractiveRender::updateShaders( const ScenePlug::ScenePath &path )
 		}
 		
 		CompoundDataMap parameters;
-		parameters["scopename"] = new StringData( name );
+		parameters["exactscopename"] = new StringData( name );
 		m_renderer->editBegin( "attribute", parameters );
 		
 			for( ObjectVector::MemberContainer::const_iterator it = shader->members().begin(), eIt = shader->members().end(); it != eIt; it++ )


### PR DESCRIPTION
We were using the "scopename" parameter to describe where the shader edits belong. As it turns out, that is treated as a regular expression, and partial matches are accepted. That meant that edits were leaking on to similarly named objects. We now use the "exactscopename" parameter to target the shader edits instead.
