### PR TITLE
Optimised FilteredChildIterator and PlugIterator.

### DIFF
--- a/include/Gaffer/FilteredChildIterator.h
+++ b/include/Gaffer/FilteredChildIterator.h
@@ -37,24 +37,21 @@
 #ifndef GAFFER_FILTEREDCHILDITERATOR_H
 #define GAFFER_FILTEREDCHILDITERATOR_H
 
-#include "Gaffer/GraphComponent.h"
-
-#include "IECore/RunTimeTyped.h"
-
 #include "boost/iterator/filter_iterator.hpp"
+
+#include "Gaffer/GraphComponent.h"
 
 namespace Gaffer
 {
 
-/// \todo Perhaps this predicate class belongs in cortex?
 template<typename T>
 struct TypePredicate
 {
 	typedef T ChildType;
 
-	bool operator()( IECore::RunTimeTypedPtr x )
+	bool operator()( const GraphComponentPtr &g ) const
 	{
-		return IECore::runTimeCast<T>( x );
+		return IECore::runTimeCast<T>( g.get() );
 	}
 };
 

--- a/include/Gaffer/PlugIterator.h
+++ b/include/Gaffer/PlugIterator.h
@@ -41,8 +41,6 @@
 #include "Gaffer/FilteredChildIterator.h"
 #include "Gaffer/FilteredRecursiveChildIterator.h"
 
-#include "boost/iterator/filter_iterator.hpp"
-
 namespace Gaffer
 {
 
@@ -51,9 +49,9 @@ struct PlugPredicate
 {
 	typedef T ChildType;
 
-	bool operator()( GraphComponentPtr g )
+	bool operator()( const GraphComponentPtr &g ) const
 	{
-		typename T::Ptr p = IECore::runTimeCast<T>( g );
+		const T *p = IECore::runTimeCast<T>( g.get() );
 		if( !p )
 		{
 			return false;


### PR DESCRIPTION
They were making unnecessary temporary IntrusivesPtr, which perform unnecessary reference counting operations, which have unnecessary overhead.

This alone gives more than a 5% speedup in a simple Instancer hash benchmark because the CompoundPlug uses a ValuePlugIterator in its hash implementation. Similar speedups should be seen in other areas.
