### PR TITLE
Fixed serialisation of non-dynamic ArrayPlugs.

### DIFF
--- a/python/GafferTest/ArrayPlugTest.py
+++ b/python/GafferTest/ArrayPlugTest.py
@@ -115,6 +115,17 @@ class ArrayPlugTest( unittest.TestCase ) :
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 		
+		self.assertEqual( len( s2["n"]["in"] ), 4 )
+		self.assertTrue( s2["n"]["in"]["e1"].isSame( s2["n"]["in"][0] ) )
+		self.assertTrue( s2["n"]["in"]["e2"].isSame( s2["n"]["in"][1] ) )
+		self.assertTrue( s2["n"]["in"]["e3"].isSame( s2["n"]["in"][2] ) )
+		self.assertTrue( s2["n"]["in"]["e4"].isSame( s2["n"]["in"][3] ) )
+		
+		self.assertTrue( s2["n"]["in"]["e1"].getInput(), s2["a"]["sum"] )
+		self.assertTrue( s2["n"]["in"]["e2"].getInput() is None )
+		self.assertTrue( s2["n"]["in"]["e3"].getInput(), s2["a"]["sum"] )
+		self.assertTrue( s2["n"]["in"]["e4"].getInput() is None )
+		
 	def testMaximumInputs( self ) :
 	
 		a = GafferTest.AddNode()

--- a/src/Gaffer/ArrayPlug.cpp
+++ b/src/Gaffer/ArrayPlug.cpp
@@ -54,7 +54,13 @@ ArrayPlug::ArrayPlug( const std::string &name, Direction direction, PlugPtr elem
 	
 	if( element )
 	{
-		element->setFlags( Gaffer::Plug::Dynamic, true );
+		// If we're dynamic ourselves, then serialisations will include a constructor
+		// for us, but it will have element==None. In this case we make sure the first
+		// element is dynamic, so that it too will have a constructor written out (and then
+		// we'll capture it in childAdded()). But if we're not dynamic, we expect to be
+		// passed the element again upon reconstruction, so we don't need a constructor
+		// to be serialised for the element, and therefore we must set it to be non-dynamic.
+		element->setFlags( Gaffer::Plug::Dynamic, getFlags( Gaffer::Plug::Dynamic ) );
 		addChild( element );
 	}
 	else


### PR DESCRIPTION
We were serialising a construct/addChild pair for the first element of the array, even though the element would be provided again via the constructor next time. This led to one additional plug being added each time the ArrayPlug was serialised and unserialised.

Fixes #580.
