### PR TITLE
Fixed shader edit bug with SceneProcedural

### DIFF
--- a/src/GafferScene/SceneProcedural.cpp
+++ b/src/GafferScene/SceneProcedural.cpp
@@ -323,7 +323,6 @@ void SceneProcedural::render( Renderer *renderer ) const
 				for( vector<InternedString>::const_iterator it=childNames->readable().begin(); it!=childNames->readable().end(); it++ )
 				{
 					childScenePath[m_scenePath.size()] = *it;
-					renderer->setAttribute( "name", new StringData( *it ) );
 					renderer->procedural( new SceneProcedural( *this, childScenePath ) );
 				}
 			}	


### PR DESCRIPTION
SceneProcedural was changing the names of locations with children, which was confusing interactive renders. Now it aint.
