### PR TITLE
Changed default gui app size to fit the layout

### DIFF
--- a/apps/gui/gui-1.py
+++ b/apps/gui/gui-1.py
@@ -43,6 +43,8 @@ import IECore
 import Gaffer
 import GafferUI
 
+QtGui = GafferUI._qtImport( "QtGui" )
+
 class gui( Gaffer.Application ) :
 
 	def __init__( self ) :
@@ -92,6 +94,17 @@ class gui( Gaffer.Application ) :
 				del scriptNode
 		else :
 			self.root()["scripts"]["script1"] = Gaffer.ScriptNode()
+		
+		# centre the window on the primary screen at 3/4 size.
+		## \todo Implement save/restore of geometry, and do all this without using Qt APIs
+		# in the app itself.
+		desktop = QtGui.QApplication.instance().desktop()
+		geometry = desktop.availableGeometry()
+		adjustment = geometry.size() / 8
+		geometry.adjust( adjustment.width(), adjustment.height(), -adjustment.width(), -adjustment.height() )
+		for script in self.root()["scripts"] :
+			window = GafferUI.ScriptWindow.acquire( script )
+			window._qtWidget().setGeometry( geometry )
 		
 		if args["fullScreen"].value :
 			primaryScript = self.root()["scripts"][-1]

--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -95,16 +95,18 @@ def __open( currentScript, fileName ) :
 
 	application["scripts"].addChild( script )
 	
+	# maintain the geometry of the current window, as that is the user's preferred window size
+	currentWindow = GafferUI.ScriptWindow.acquire( currentScript )
+	newWindow = GafferUI.ScriptWindow.acquire( script )
+	## \todo We probably want a way of querying and setting geometry in the public API
+	newWindow._qtWidget().restoreGeometry( currentWindow._qtWidget().saveGeometry() )
+	
 	addRecentFile( application, fileName )
 
 	if not currentScript["fileName"].getValue() and not currentScript["unsavedChanges"].getValue() :
 		# the current script is empty - the user will think of the operation as loading
 		# the new script into the current window, rather than adding a new window. so make it
 		# look like that.
-		currentWindow = GafferUI.ScriptWindow.acquire( currentScript )
-		newWindow = GafferUI.ScriptWindow.acquire( script )
-		## \todo We probably want a way of querying and setting geometry in the public API
-		newWindow._qtWidget().restoreGeometry( currentWindow._qtWidget().saveGeometry() )
 		currentWindow.setVisible( False )
 		
 		# We must defer the removal of the old script because otherwise we trigger a crash bug


### PR DESCRIPTION
I'm really just putting this up for advice at this point. The window flashes when you startup or open a new file, which I presume is the initial window being set visible when the script gets added to `self.root()["scripts"]`, prior to my resizing.

Also, I wasn't sure how happy you'd be about me setting the size on File->Open. I think it's necessary though, otherwise we get that smaller size for anything but the initial app startup.
