### PR TITLE
DispatcherUI calls Dispatcher::dispatch() on the main thread.

### DIFF
--- a/python/GafferUI/DispatcherUI.py
+++ b/python/GafferUI/DispatcherUI.py
@@ -36,7 +36,6 @@
 ##########################################################################
 
 import fnmatch
-import threading
 import weakref
 
 import IECore
@@ -136,14 +135,10 @@ class _DispatcherWindow( GafferUI.Window ) :
 	
 	def __dispatchClicked( self, button ) :
 		
-		threading.Thread( target = self.__dispatch ).start()
-		self.close()
-	
-	def __dispatch( self ) :
-		
 		with self.parent().scriptNode().context() :
 			self.__dispatcher.dispatch( self.__nodes )
 		## \todo: update _executeUILastExecuted
+		self.close()
 	
 	def __dispatcherChanged( self, menu ) :
 		

--- a/python/GafferUI/LocalDispatcherUI.py
+++ b/python/GafferUI/LocalDispatcherUI.py
@@ -1,0 +1,43 @@
+##########################################################################
+#  
+#  Copyright (c) 2014, Image Engine Design Inc. All rights reserved.
+#  
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#  
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#  
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#  
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#  
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#  
+##########################################################################
+
+import Gaffer
+
+##########################################################################
+# Metadata, PlugValueWidgets and Nodules
+##########################################################################
+
+Gaffer.Metadata.registerPlugDescription( Gaffer.LocalDispatcher, "executeInBackground", "Executes the dispatched tasks on a background thread." )

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -218,6 +218,7 @@ from CompoundDataPlugValueWidget import CompoundDataPlugValueWidget
 from SectionedCompoundDataPlugValueWidget import SectionedCompoundDataPlugValueWidget
 import ScriptNodeUI
 import DispatcherUI
+import LocalDispatcherUI
 import ExecutableNodeUI
 from TransformPlugValueWidget import TransformPlugValueWidget
 from IncrementingPlugValueWidget import IncrementingPlugValueWidget


### PR DESCRIPTION
LocalDispatcher has a new executeInBackground plug and manages the background thread on its own. This is so we can do alter things before the asynchronous bit begins.

Note that while Dispatcher::postDispatchSignal() is still called after the dispatching itself finishes, it may now be called before the actual task execution finishes.

I know we had discussed offline having LocalDispatcher keep its background process alive to cut down on task execution time, but I'd rather leave that bit for now so we can get this into David's hands quicker.
