### PR TITLE
Dispatching can be cancelled via preDispatchSignal().

### DIFF
--- a/python/GafferTest/DispatcherTest.py
+++ b/python/GafferTest/DispatcherTest.py
@@ -168,7 +168,38 @@ class DispatcherTest( GafferTest.TestCase ) :
 		self.assertEqual( len( postCs ), 1 )
 		self.failUnless( postCs[0][0].isSame( dispatcher ) )
 		self.assertEqual( postCs[0][1], [ s["n1"] ] )
-
+	
+	def testCancelDispatch( self ) :
+		
+		def onlyRunOnce( dispatcher, nodes ) :
+			
+			if len(dispatcher.log) :
+				return True
+			
+			return False
+		
+		connection = Gaffer.Dispatcher.preDispatchSignal().connect( onlyRunOnce )
+		
+		dispatcher = DispatcherTest.MyDispatcher()
+		op1 = TestOp( "1", dispatcher.log )
+		s = Gaffer.ScriptNode()
+		s["n1"] = Gaffer.ExecutableOpHolder()
+		s["n1"].setParameterised( op1 )
+		
+		# never run
+		self.assertEqual( len(dispatcher.log), 0 )
+		self.assertEqual( op1.counter, 0 )
+		
+		# runs the first time
+		dispatcher.dispatch( [ s["n1"] ] )
+		self.assertEqual( len(dispatcher.log), 1 )
+		self.assertEqual( op1.counter, 1 )
+		
+		# never runs again
+		dispatcher.dispatch( [ s["n1"] ] )
+		self.assertEqual( len(dispatcher.log), 1 )
+		self.assertEqual( op1.counter, 1 )
+	
 	def testPlugs( self ) :
 
 		n = Gaffer.ExecutableOpHolder()

--- a/src/Gaffer/Dispatcher.cpp
+++ b/src/Gaffer/Dispatcher.cpp
@@ -86,7 +86,11 @@ void Dispatcher::dispatch( const std::vector<ExecutableNodePtr> &nodes ) const
 		}
 	}
 	
-	preDispatchSignal()( this, nodes );
+	if ( preDispatchSignal()( this, nodes ) )
+	{
+		/// \todo: communicate the cancellation to the user
+		return;
+	}
 	
 	const Context *context = Context::current();
 	

--- a/src/GafferBindings/DispatcherBinding.cpp
+++ b/src/GafferBindings/DispatcherBinding.cpp
@@ -144,7 +144,7 @@ class DispatcherWrapper : public NodeWrapper<Dispatcher>
 
 struct DispatchSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, const Dispatcher *d, const std::vector<ExecutableNodePtr> &nodes )
+	bool operator()( boost::python::object slot, const Dispatcher *d, const std::vector<ExecutableNodePtr> &nodes )
 	{
 		try
 		{
@@ -154,13 +154,13 @@ struct DispatchSlotCaller
 				nodeList.append( *nIt );
 			}
 			DispatcherPtr dd = const_cast<Dispatcher*>(d);
-			slot( dd, nodeList );
+			return slot( dd, nodeList );
 		}
 		catch( const error_already_set &e )
 		{
 			PyErr_PrintEx( 0 ); // clears the error status
 		}
-		return boost::signals::detail::unusable();
+		return false;
 	}
 };
 


### PR DESCRIPTION
Slots should have the signature `bool slot( dispatcher, nodes )`, and may return True to cancel execution, or False to allow it to continue.

Note that I've left reporting the cancellation to the user as a todo until we address #299. I can put an info message in there for now if you prefer.

Fixes #929.
