### PR TITLE
Fixed call sequence for GraphComponent::parentChanging().

### DIFF
--- a/include/GafferBindings/GraphComponentBinding.h
+++ b/include/GafferBindings/GraphComponentBinding.h
@@ -105,6 +105,21 @@ class GraphComponentWrapper : public IECorePython::RunTimeTypedWrapper<WrappedTy
 			return WrappedType::acceptsParent( potentialParent );
 		}
 
+		virtual void parentChanging( Gaffer::GraphComponent *newParent )
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				boost::python::object f = this->methodOverride( "_parentChanging" );
+				if( f )
+				{
+					f( Gaffer::GraphComponentPtr( newParent ) );
+					return;
+				}
+			}
+			return WrappedType::parentChanging( newParent );
+		}
+
 };
 	
 void bindGraphComponent();

--- a/python/GafferTest/GraphComponentTest.py
+++ b/python/GafferTest/GraphComponentTest.py
@@ -668,7 +668,52 @@ class GraphComponentTest( GafferTest.TestCase ) :
 		p.clearChildren()
 		
 		self.assertEqual( len( p ), 0 )
+	
+	def testParentChanging( self ) :
+	
+		class Child( Gaffer.GraphComponent ) :
 		
+			def __init__( self, name = "Child" ) :
+			
+				Gaffer.GraphComponent.__init__( self, name )
+			
+				self.parentChanges = []
+			
+			def _parentChanging( self, newParent ) :
+			
+				self.parentChanges.append( ( self.parent(), newParent ) )
+
+		p1 = Gaffer.GraphComponent()
+		p2 = Gaffer.GraphComponent()
+		
+		c = Child()
+		self.assertEqual( len( c.parentChanges ), 0 )
+		
+		p1.addChild( c )
+		self.assertEqual( len( c.parentChanges ), 1 )
+		self.assertEqual( c.parentChanges[-1], ( None, p1 ) )
+	
+		p1.removeChild( c )
+		self.assertEqual( len( c.parentChanges ), 2 )
+		self.assertEqual( c.parentChanges[-1], ( p1, None ) )
+	
+		p1.addChild( c )
+		self.assertEqual( len( c.parentChanges ), 3 )
+		self.assertEqual( c.parentChanges[-1], ( None, p1 ) )
+
+		p2.addChild( c )
+		self.assertEqual( len( c.parentChanges ), 4 )
+		self.assertEqual( c.parentChanges[-1], ( p1, p2 ) )
+	
+		# cause a parent change by destroying the parent.
+		# we need to remove all references to the parent to do
+		# this, including those stored in the parentChanges list.
+		del p2
+		del c.parentChanges[:]
+		
+		self.assertEqual( len( c.parentChanges ), 1 )
+		self.assertEqual( c.parentChanges[-1], ( None, None ) )
+	
 if __name__ == "__main__":
 	unittest.main()
 	

--- a/src/Gaffer/GraphComponent.cpp
+++ b/src/Gaffer/GraphComponent.cpp
@@ -290,6 +290,7 @@ void GraphComponent::throwIfChildRejected( const GraphComponent *potentialChild 
 
 void GraphComponent::addChildInternal( GraphComponentPtr child )
 {
+	child->parentChanging( this );
 	GraphComponent *previousParent = child->m_parent;
 	if( previousParent )
 	{
@@ -298,7 +299,6 @@ void GraphComponent::addChildInternal( GraphComponentPtr child )
 		// changed signal with the new parent.
 		previousParent->removeChildInternal( child, false );
 	}
-	child->parentChanging( this );
 	m_children.push_back( child );
 	child->m_parent = this;
 	child->setName( child->m_name.value() ); // to force uniqueness


### PR DESCRIPTION
When a child is being transferred from one parent to another, it is now called at a point where the child still has the original parent.

Also added the ability to override `parentChanged()` in Python, making it possible to write unit tests.
