### PR TITLE
Added FrameBegin/FrameEnd in RIBs generated by RenderManRender.

### DIFF
--- a/python/GafferRenderMan/RenderManRender.py
+++ b/python/GafferRenderMan/RenderManRender.py
@@ -75,8 +75,11 @@ class RenderManRender( GafferScene.ExecutableRender ) :
 				# raise if it fails. we reraise only in the latter case.
 				if not os.path.isdir( directory ) :
 					raise
-				
-		return IECoreRI.Renderer( fileName )
+		
+		renderer = IECoreRI.Renderer( fileName )
+		renderer.setOption( "ri:frame", int( Gaffer.Context.current().getFrame() ) )
+		
+		return renderer
 		
 	def _outputWorldProcedural( self, scenePlug, renderer ) :
 			

--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -421,6 +421,24 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
 		self.assertTrue( "PixelSamples 2 3" in rib )
 
+	def testFrameBlock( self ) :
+	
+		s = Gaffer.ScriptNode()
+		
+		s["p"] = GafferScene.Plane()
+				
+		s["r"] = GafferRenderMan.RenderManRender()
+		s["r"]["mode"].setValue( "generate" )
+		s["r"]["ribFileName"].setValue( "/tmp/test.rib" )
+		s["r"]["in"].setInput( s["p"]["out"] )
+		
+		with Gaffer.Context( s.context() ) as context :
+			for i in range( 0, 10 ) :
+				context.setFrame( i )
+				s["r"].execute()
+				rib = "\n".join( file( "/tmp/test.rib" ).readlines() )
+				self.assertTrue( "FrameBegin %d" % i in rib )
+
 	def setUp( self ) :
 	
 		for f in (

--- a/src/GafferScene/ExecutableRender.cpp
+++ b/src/GafferScene/ExecutableRender.cpp
@@ -115,16 +115,23 @@ void ExecutableRender::execute() const
 	
 	createDisplayDirectories( globals.get() );
 	
-	IECore::RendererPtr renderer = createRenderer();		
-	outputOptions( globals.get(), renderer.get() );
-	outputOutputs( globals.get(), renderer.get() );
-	outputCamera( scene, globals.get(), renderer.get() );
+	// Scoping the lifetime of the renderer so that
+	// the destructor is run before we run the system
+	// command. This can be essential for renderman
+	// renders, where the rib stream may not be flushed
+	// to disk before RiEnd is called.
 	{
-		WorldBlock world( renderer );
+		IECore::RendererPtr renderer = createRenderer();
+		outputOptions( globals.get(), renderer.get() );
+		outputOutputs( globals.get(), renderer.get() );
+		outputCamera( scene, globals.get(), renderer.get() );
+		{
+			WorldBlock world( renderer );
 		
-		outputCoordinateSystems( scene, globals.get(), renderer.get() );
-		outputLights( scene, globals.get(), renderer.get() );
-		outputWorldProcedural( scene, renderer.get() );
+			outputCoordinateSystems( scene, globals.get(), renderer.get() );
+			outputLights( scene, globals.get(), renderer.get() );
+			outputWorldProcedural( scene, renderer.get() );
+		}
 	}
 	
 	std::string systemCommand = command();


### PR DESCRIPTION
This relies on functionality introduced in ImageEngine/cortex/#329. If used without that Cortex functionality, it will simply result in a warning message stating that "ri:frame" is an unsupported option - so it's fairly harmless to merge this before the Cortex feature is deployed everywhere.

Fixes #358.
