### PR TITLE
Guaranteeing unique name when using setName

### DIFF
--- a/python/GafferTest/GraphComponentTest.py
+++ b/python/GafferTest/GraphComponentTest.py
@@ -281,6 +281,16 @@ class GraphComponentTest( GafferTest.TestCase ) :
 		p.addChild( c4 )
 		self.assertEqual( c4.getName(), "a3" )
 
+		c1.setName( "b" )
+		c2.setName( "b" )
+		c3.setName( "b" )
+		c4.setName( "b" )
+
+		self.assertEqual( c1.getName(), "b" )
+		self.assertEqual( c2.getName(), "b1" )
+		self.assertEqual( c3.getName(), "b2" )
+		self.assertEqual( c4.getName(), "b3" )
+
 	def testAncestor( self ) :
 
 		a = Gaffer.ApplicationRoot()

--- a/src/Gaffer/GraphComponent.cpp
+++ b/src/Gaffer/GraphComponent.cpp
@@ -89,7 +89,7 @@ const IECore::InternedString &GraphComponent::setName( const IECore::InternedStr
 		bool uniqueAlready = true;
 		for( ChildContainer::const_iterator it=m_parent->m_children.begin(), eIt=m_parent->m_children.end(); it != eIt; it++ )
 		{
-			if( *it != this && (*it)->m_name == m_name )
+			if( *it != this && (*it)->m_name == newName )
 			{
 				uniqueAlready = false;
 				break;


### PR DESCRIPTION
GraphComponent.setName() wasn't properly guaranteeing that the names were unique.

I've fixed the bug and added a test for it.
