### PR TITLE
Camera additions

### DIFF
--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -61,6 +61,8 @@ def __cameraSummary( plug ) :
 	if plug["renderCropWindow"]["enabled"].getValue() :
 		crop = plug["renderCropWindow"]["value"].getValue()
 		info.append( "Crop %s,%s-%s,%s" % tuple( __floatToString( x ) for x in ( crop.min.x, crop.min.y, crop.max.x, crop.max.y ) ) )
+	if plug["overscan"]["enabled"].getValue() :
+		info.append( "Overscan %s" % ( "On" if plug["overscan"]["value"].getValue() else "Off" ) )
 
 	return ", ".join( info )
 
@@ -94,6 +96,11 @@ GafferUI.PlugValueWidget.registerCreator(
 				( "render:pixelAspectRatio", "Pixel Aspect Ratio" ),
 				( "render:resolutionMultiplier", "Resolution Multiplier" ),
 				( "render:cropWindow", "Crop Window" ),
+				( "render:overscan", "Overscan" ),
+				( "render:overscanTop", "Overscan Top" ),
+				( "render:overscanBottom", "Overscan Bottom" ),
+				( "render:overscanLeft", "Overscan Left" ),
+				( "render:overscanRight", "Overscan Right" ),
 			),
 		},
 

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -179,7 +179,101 @@ void outputCamera( const ScenePlug *scene, const IECore::CompoundObject *globals
 		camera->parameters()["cropWindow"] = cropWindowData->copy();
 	}
 
+	// calculate an appropriate screen window
+
 	camera->addStandardParameters();
+
+	// apply overscan
+	
+	const BoolData *overscanData = globals->member<BoolData>( "option:render:overscan" );
+	if( overscanData && overscanData->readable() )
+	{
+		
+		// get offsets for each corner of image (as a multiplier of the image width)
+		V2f minOffset( 0.1 ), maxOffset( 0.1 );
+		if( const FloatData *overscanValueData = globals->member<FloatData>( "option:render:overscanLeft" ) )
+		{
+			minOffset.x = overscanValueData->readable();
+		}
+		if( const FloatData *overscanValueData = globals->member<FloatData>( "option:render:overscanRight" ) )
+		{
+			maxOffset.x = overscanValueData->readable();
+		}
+		if( const FloatData *overscanValueData = globals->member<FloatData>( "option:render:overscanBottom" ) )
+		{
+			minOffset.y = overscanValueData->readable();
+		}
+		if( const FloatData *overscanValueData = globals->member<FloatData>( "option:render:overscanTop" ) )
+		{
+			maxOffset.y = overscanValueData->readable();
+		}
+				
+		// convert those offsets into pixel values
+		
+		V2i minPixelOffset(
+			minOffset.x * (float)resolution.x,
+			minOffset.y * (float)resolution.y
+		);
+		
+		V2i maxPixelOffset(
+			maxOffset.x * (float)resolution.x,
+			maxOffset.y * (float)resolution.y
+		);
+
+		// recalculate original offsets to account for the rounding when
+		// converting to integer pixel space
+		
+		minOffset = V2f(
+			(float)minPixelOffset.x / (float)resolution.x,
+			(float)minPixelOffset.y / (float)resolution.y
+		);
+		
+		maxOffset = V2f(
+			(float)maxPixelOffset.x / (float)resolution.x,
+			(float)maxPixelOffset.y / (float)resolution.y
+		);
+		
+		// adjust camera resolution and screen window appropriately
+
+		V2i &cameraResolution = camera->parametersData()->member<V2iData>( "resolution" )->writable();
+		Box2f &cameraScreenWindow = camera->parametersData()->member<Box2fData>( "screenWindow" )->writable();
+		
+		cameraResolution += minPixelOffset + maxPixelOffset;
+		
+		const Box2f originalScreenWindow = cameraScreenWindow;
+		cameraScreenWindow.min -= originalScreenWindow.size() * minOffset;
+		cameraScreenWindow.max += originalScreenWindow.size() * maxOffset;
+		
+		// adjust crop window too, if it was specified by the user
+		
+		if( cropWindowData )
+		{
+			Box2f &cameraCropWindow = camera->parametersData()->member<Box2fData>( "cropWindow" )->writable();
+			// convert into original screen space
+			Box2f cropWindowScreen(
+				V2f(
+					Imath::lerp( originalScreenWindow.min.x, originalScreenWindow.max.x, cameraCropWindow.min.x ),
+					Imath::lerp( originalScreenWindow.max.y, originalScreenWindow.min.y, cameraCropWindow.max.y )
+				),
+				V2f(
+					Imath::lerp( originalScreenWindow.min.x, originalScreenWindow.max.x, cameraCropWindow.max.x ),
+					Imath::lerp( originalScreenWindow.max.y, originalScreenWindow.min.y, cameraCropWindow.min.y )
+				)
+			);
+			// convert out of new screen space
+			cameraCropWindow = Box2f(
+				V2f(
+					lerpfactor( cropWindowScreen.min.x, cameraScreenWindow.min.x, cameraScreenWindow.max.x ),
+					lerpfactor( cropWindowScreen.max.y, cameraScreenWindow.max.y, cameraScreenWindow.min.y )
+				),
+				V2f(
+					lerpfactor( cropWindowScreen.max.x, cameraScreenWindow.min.x, cameraScreenWindow.max.x ),
+					lerpfactor( cropWindowScreen.min.y, cameraScreenWindow.max.y, cameraScreenWindow.min.y )
+				)
+			);
+		}
+		
+	}
 
 	// apply the shutter
 

--- a/src/GafferScene/StandardOptions.cpp
+++ b/src/GafferScene/StandardOptions.cpp
@@ -55,6 +55,12 @@ StandardOptions::StandardOptions( const std::string &name )
 	options->addOptionalMember( "render:resolutionMultiplier", new IECore::FloatData( 1.0f ), "resolutionMultiplier", Plug::Default, false );
 	options->addOptionalMember( "render:cropWindow", new IECore::Box2fData( Imath::Box2f( Imath::V2f( 0 ), Imath::V2f( 1 ) ) ), "renderCropWindow", Plug::Default, false );
 
+	options->addOptionalMember( "render:overscan", new IECore::BoolData( false ), "overscan", Plug::Default, false );
+	options->addOptionalMember( "render:overscanTop", new FloatPlug( "value", Plug::In, 0.1f, 0.0f, 1.0f ), "overscanTop", false );
+	options->addOptionalMember( "render:overscanBottom", new FloatPlug( "value", Plug::In, 0.1f, 0.0f, 1.0f ), "overscanBottom", false );
+	options->addOptionalMember( "render:overscanLeft", new FloatPlug( "value", Plug::In, 0.1f, 0.0f, 1.0f ), "overscanLeft", false );
+	options->addOptionalMember( "render:overscanRight", new FloatPlug( "value", Plug::In, 0.1f, 0.0f, 1.0f ), "overscanRight", false );
+	
 	// motion blur
 
 	options->addOptionalMember( "render:cameraBlur", new IECore::BoolData( false ), "cameraBlur", Gaffer::Plug::Default, false );


### PR DESCRIPTION
This adds pixel aspect ratio, resolution multiplier and overscan options to GafferScene. It requires https://github.com/ImageEngine/cortex/pull/335 for the pixel aspect ratio to work correctly, but there's no hard dependency - it's possible to build still with the existing cortex master.

Note that this doesn't add pixel aspect ratio support to the GafferImage side of things, just GafferScene (the Display node won't show the correct pixel aspect).
