### PR TITLE
Fixed Display node for bucket sizes larger than the native tile size.

### DIFF
--- a/src/GafferImage/Display.cpp
+++ b/src/GafferImage/Display.cpp
@@ -154,7 +154,7 @@ class GafferDisplayDriver : public IECore::DisplayDriver
 						for( int y = transferBound.min.y; y<=transferBound.max.y; ++y )
 						{
 							int srcY = m_gafferFormat.formatToYDownSpace( y );
-							size_t srcIndex = ( ( srcY - box.min.y ) * ( box.size().x + 1 ) * numChannels ) + ( transferBound.min.x - box.min.x ) + channelIndex;
+							size_t srcIndex = ( ( srcY - box.min.y ) * ( box.size().x + 1 ) + ( transferBound.min.x - box.min.x ) ) * numChannels + channelIndex;
 							size_t dstIndex = ( y - tileBound.min.y ) * ImagePlug::tileSize() + transferBound.min.x - tileBound.min.x;
 							const size_t srcEndIndex = srcIndex + transferBound.size().x * numChannels;
 							while( srcIndex <= srcEndIndex )


### PR DESCRIPTION
We were incorrectly applying the x offset of the transfer area within the bucket data, by not taking into account the number of channels (the source channels are interleaved). This hadn't been seen noticed till now because we'd never rendered with a 3delight bucket size greater than the Gaffer tile size. The latest version of 3delight has a new IPR refinement pattern which starts with really big buckets, thus revealing my previous ineptitude.
