### PR TITLE
Reduced string interning in Shader generation.

### DIFF
--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -126,7 +126,7 @@ class Shader : public Gaffer::DependencyNode
 				IECore::Shader *shader( const Shader *shaderNode );
 
 				void parameterHashWalk( const Shader *shaderNode, const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h );
-				void parameterValueWalk( const Shader *shaderNode, const Gaffer::Plug *parameterPlug, const std::string &parameterName, IECore::CompoundDataMap &values );
+				void parameterValueWalk( const Shader *shaderNode, const Gaffer::Plug *parameterPlug, const IECore::InternedString &parameterName, IECore::CompoundDataMap &values );
 
 				const Shader *m_rootNode;
 				IECore::ObjectVectorPtr m_state;

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -330,7 +330,7 @@ IECore::Shader *Shader::NetworkBuilder::shader( const Shader *shaderNode )
 
 	shaderAndHash.shader = new IECore::Shader( shaderNode->namePlug()->getValue(), shaderNode->typePlug()->getValue() );
 
-	parameterValueWalk( shaderNode, shaderNode->parametersPlug(), "", shaderAndHash.shader->parameters() );
+	parameterValueWalk( shaderNode, shaderNode->parametersPlug(), IECore::InternedString(), shaderAndHash.shader->parameters() );
 
 	shaderAndHash.shader->blindData()->writable()["gaffer:nodeName"] = new IECore::StringData( shaderNode->nodeNamePlug()->getValue() );
 
@@ -338,18 +338,18 @@ IECore::Shader *Shader::NetworkBuilder::shader( const Shader *shaderNode )
 	return shaderAndHash.shader.get();
 }
 
-void Shader::NetworkBuilder::parameterValueWalk( const Shader *shaderNode, const Gaffer::Plug *parameterPlug, const std::string &parameterName, IECore::CompoundDataMap &values )
+void Shader::NetworkBuilder::parameterValueWalk( const Shader *shaderNode, const Gaffer::Plug *parameterPlug, const IECore::InternedString &parameterName, IECore::CompoundDataMap &values )
 {
 	for( InputPlugIterator it( parameterPlug ); it != it.end(); ++it )
 	{
-		std::string childParameterName;
-		if( parameterName.size() )
+		IECore::InternedString childParameterName;
+		if( parameterName.string().size() )
 		{
-			childParameterName = parameterName + "." + (*it)->getName().string();
+			childParameterName = parameterName.string() + "." + (*it)->getName().string();
 		}
 		else
 		{
-			childParameterName = (*it)->getName().string();
+			childParameterName = (*it)->getName();
 		}
 
 		if( (*it)->typeId() == CompoundPlug::staticTypeId() )


### PR DESCRIPTION
At least for the RenderMan case, our parameters only go one level deep (no structs), so we don't need to construct any new InternedStrings at all. This gives a very mild (~1.5%) reduction in runtime for a benchmark scene generation test.
