### PR TITLE
Fixed a GafferImage bug involving filters

### DIFF
--- a/include/GafferImage/Filter.h
+++ b/include/GafferImage/Filter.h
@@ -212,23 +212,11 @@ private:
 
 	/// Registration mechanism for Filter classes.
 	/// We keep a vector of the names so that we can maintain an order.
-	static std::vector< CreatorFn >& creators()
-	{
-		static std::vector< CreatorFn > g_creators;
-		return g_creators;
-	}
+	static std::vector< CreatorFn >& creators();
+	
+	static std::vector< std::string >& filterList();
 
-	static std::vector< std::string >& filterList()
-	{
-		static std::vector< std::string > g_filters;
-		return g_filters;
-	}
-
-	static std::map< std::string, boost::weak_ptr<IECore::Lookupff> > &lutMap()
-	{
-		static std::map< std::string, boost::weak_ptr<IECore::Lookupff> > l;
-		return l;
-	}
+	static std::map< std::string, boost::weak_ptr<IECore::Lookupff> > &lutMap();
 
 	boost::shared_ptr<IECore::Lookupff> m_lut;
 

--- a/src/GafferImage/Filter.cpp
+++ b/src/GafferImage/Filter.cpp
@@ -64,6 +64,25 @@ void Filter::setScale( float scale )
 	m_scaledRadius = m_radius * m_scale;
 }
 
+std::vector< Filter::CreatorFn >& Filter::creators()
+{
+	static std::vector< CreatorFn > g_creators;
+	return g_creators;
+}
+
+std::vector< std::string >& Filter::filterList()
+{
+	static std::vector< std::string > g_filters;
+	return g_filters;
+}
+
+std::map< std::string, boost::weak_ptr<IECore::Lookupff> > &Filter::lutMap()
+{
+	static std::map< std::string, boost::weak_ptr<IECore::Lookupff> > l;
+	return l;
+}
+
+
 FilterPtr Filter::create( const std::string &name, float scale )
 {
 	// Check to see whether the requested Filter is registered and if not, throw an exception.


### PR DESCRIPTION
It turns out that when using Gaffer in maya, calling GafferImage.FilterPlug.filters() reinitializes the static string vector defined in GafferImage::FilterPlug::filters(), and wipes out all the filters, leading to a load of errors when you try and use nodes like the Reformat. This seems to be because it was defined in the header, and therefore defined separately in a number of .cpp files, including GafferImage/Filter.cpp, GafferImageBindings/FilterPlugBinding.cpp and GafferImageBindings/FilterBinding.cpp. How and why this works in standalone gaffer but not maya is a mystery to me, but defining these functions in Filter.cpp fixes the problem, and is also a bit more consistent with our style, so this is what I've done.
