### PR TITLE
InteractiveRender updates all attributes

### DIFF
--- a/include/GafferScene/InteractiveRender.h
+++ b/include/GafferScene/InteractiveRender.h
@@ -86,8 +86,8 @@ class InteractiveRender : public Gaffer::Node
 		Gaffer::BoolPlug *updateLightsPlug();
 		const Gaffer::BoolPlug *updateLightsPlug() const;
 
-		Gaffer::BoolPlug *updateShadersPlug();
-		const Gaffer::BoolPlug *updateShadersPlug() const;
+		Gaffer::BoolPlug *updateAttributesPlug();
+		const Gaffer::BoolPlug *updateAttributesPlug() const;
 
 		Gaffer::BoolPlug *updateCameraPlug();
 		const Gaffer::BoolPlug *updateCameraPlug() const;
@@ -112,8 +112,8 @@ class InteractiveRender : public Gaffer::Node
 
 		void update();
 		void updateLights();
-		void updateShaders();
-		void updateShadersWalk( const ScenePlug::ScenePath &path );
+		void updateAttributes();
+		void updateAttributesWalk( const ScenePlug::ScenePath &path );
 		void updateCamera();
 		void updateCoordinateSystems();
 
@@ -126,7 +126,7 @@ class InteractiveRender : public Gaffer::Node
 		State m_state;
 		LightHandles m_lightHandles;
 		bool m_lightsDirty;
-		bool m_shadersDirty;
+		bool m_attributesDirty;
 		bool m_cameraDirty;
 		bool m_coordinateSystemsDirty;
 

--- a/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
+++ b/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
@@ -195,7 +195,7 @@ class InteractiveRenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		)
 		self.assertEqual( c / c[2], IECore.Color3f( 0.25, 0.5, 1 ) )
 
-	def testShaders( self ) :
+	def testAttributes( self ) :
 
 		s = Gaffer.ScriptNode()
 
@@ -243,14 +243,14 @@ class InteractiveRenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["o"]["options"]["renderCamera"]["value"].setValue( "/group/camera" )
 		s["o"]["options"]["renderCamera"]["enabled"].setValue( True )
 		s["o"]["in"].setInput( s["d"]["out"] )
-
+		
 		s["r"] = GafferRenderMan.InteractiveRenderManRender()
 		s["r"]["in"].setInput( s["o"]["out"] )
 
 		# start a render, give it time to finish, and check the output
 
 		s["r"]["state"].setValue( s["r"].State.Running )
-
+		
 		time.sleep( 2 )
 
 		c = self.__colorAtUV(
@@ -271,7 +271,7 @@ class InteractiveRenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		# turn off shader updates, do the same, and check that it hasn't changed
 
-		s["r"]["updateShaders"].setValue( False )
+		s["r"]["updateAttributes"].setValue( False )
 		s["s"]["parameters"]["blackcolor"].setValue( IECore.Color3f( 0.5 ) )
 		time.sleep( 1 )
 		c = self.__colorAtUV(
@@ -282,7 +282,7 @@ class InteractiveRenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		# turn shader updates back on, and check that it updates
 
-		s["r"]["updateShaders"].setValue( True )
+		s["r"]["updateAttributes"].setValue( True )
 		time.sleep( 1 )
 		c = self.__colorAtUV(
 			IECore.ImageDisplayDriver.storedImage( "myLovelyPlane" ),

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -60,7 +60,7 @@ IE_CORE_DEFINERUNTIMETYPED( InteractiveRender );
 size_t InteractiveRender::g_firstPlugIndex = 0;
 
 InteractiveRender::InteractiveRender( const std::string &name )
-	:	Node( name ), m_lightsDirty( true ), m_shadersDirty( true ), m_cameraDirty( true ), m_coordinateSystemsDirty( true )
+	:	Node( name ), m_lightsDirty( true ), m_attributesDirty( true ), m_cameraDirty( true ), m_coordinateSystemsDirty( true )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new ScenePlug( "in" ) );
@@ -68,7 +68,7 @@ InteractiveRender::InteractiveRender( const std::string &name )
 	outPlug()->setInput( inPlug() );
 	addChild( new IntPlug( "state", Plug::In, Stopped, Stopped, Paused, Plug::Default & ~Plug::Serialisable ) );
 	addChild( new BoolPlug( "updateLights", Plug::In, true ) );
-	addChild( new BoolPlug( "updateShaders", Plug::In, true ) );
+	addChild( new BoolPlug( "updateAttributes", Plug::In, true ) );
 	addChild( new BoolPlug( "updateCamera", Plug::In, true ) );
 	addChild( new BoolPlug( "updateCoordinateSystems", Plug::In, true ) );
 
@@ -122,12 +122,12 @@ const Gaffer::BoolPlug *InteractiveRender::updateLightsPlug() const
 	return getChild<BoolPlug>( g_firstPlugIndex + 3 );
 }
 
-Gaffer::BoolPlug *InteractiveRender::updateShadersPlug()
+Gaffer::BoolPlug *InteractiveRender::updateAttributesPlug()
 {
 	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
 }
 
-const Gaffer::BoolPlug *InteractiveRender::updateShadersPlug() const
+const Gaffer::BoolPlug *InteractiveRender::updateAttributesPlug() const
 {
 	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
 }
@@ -175,13 +175,13 @@ void InteractiveRender::plugDirtied( const Gaffer::Plug *plug )
 	else if( plug == inPlug()->attributesPlug() )
 	{
 		// as above.
-		m_shadersDirty = true;
+		m_attributesDirty = true;
 		m_lightsDirty = true;
 	}
 	else if(
 		plug == inPlug() ||
 		plug == updateLightsPlug() ||
-		plug == updateShadersPlug() ||
+		plug == updateAttributesPlug() ||
 		plug == updateCameraPlug() ||
 		plug == updateCoordinateSystemsPlug() ||
 		plug == statePlug()
@@ -234,7 +234,7 @@ void InteractiveRender::update()
 		m_scene = NULL;
 		m_state = Stopped;
 		m_lightHandles.clear();
-		m_shadersDirty = m_lightsDirty = m_cameraDirty = true;
+		m_attributesDirty = m_lightsDirty = m_cameraDirty = true;
 		if( !requiredScene || requiredState == Stopped )
 		{
 			return;
@@ -266,7 +266,7 @@ void InteractiveRender::update()
 
 		m_scene = requiredScene;
 		m_state = Running;
-		m_lightsDirty = m_shadersDirty = m_cameraDirty = false;
+		m_lightsDirty = m_attributesDirty = m_cameraDirty = false;
 	}
 
 	// Make sure the paused/running state is as we want.
@@ -289,7 +289,7 @@ void InteractiveRender::update()
 	if( m_state == Running )
 	{
 		updateLights();
-		updateShaders();
+		updateAttributes();
 		updateCamera();
 		updateCoordinateSystems();
 	}
@@ -378,22 +378,22 @@ void InteractiveRender::outputLightsInternal( const IECore::CompoundObject *glob
 	}
 }
 
-void InteractiveRender::updateShaders()
+void InteractiveRender::updateAttributes()
 {
-	if( !m_shadersDirty || !updateShadersPlug()->getValue() )
+	if( !m_attributesDirty || !updateAttributesPlug()->getValue() )
 	{
 		return;
 	}
 
-	updateShadersWalk( ScenePlug::ScenePath() );
+	updateAttributesWalk( ScenePlug::ScenePath() );
 
-	m_shadersDirty = false;
+	m_attributesDirty = false;
 }
 
-void InteractiveRender::updateShadersWalk( const ScenePlug::ScenePath &path )
+void InteractiveRender::updateAttributesWalk( const ScenePlug::ScenePath &path )
 {
-	/// \todo Keep a track of the hashes of the shaders at each path,
-	/// and use it to only update the shaders when they've changed.
+	/// \todo Keep a track of the hashes of the attributes at each path,
+	/// and use it to only update the attributes when they've changed.
 	ConstCompoundObjectPtr attributes = inPlug()->attributes( path );
 
 	// terminate recursion for invisible locations
@@ -402,36 +402,44 @@ void InteractiveRender::updateShadersWalk( const ScenePlug::ScenePath &path )
 	{
 		return;
 	}
-
-	ConstObjectVectorPtr shader = attributes->member<ObjectVector>( "shader" );
-	if( shader )
+	
+	std::string name;
+	ScenePlug::pathToString( path, name );
+	CompoundDataMap parameters;
+	parameters["exactscopename"] = new StringData( name );
 	{
-		std::string name;
-		ScenePlug::pathToString( path, name );
-
-		CompoundDataMap parameters;
-		parameters["exactscopename"] = new StringData( name );
+		EditBlock edit( m_renderer.get(), "attribute", parameters );
+		for( CompoundObject::ObjectMap::const_iterator it = attributes->members().begin(), eIt = attributes->members().end(); it != eIt; it++ )
 		{
-			EditBlock edit( m_renderer.get(), "attribute", parameters );
-
-			for( ObjectVector::MemberContainer::const_iterator it = shader->members().begin(), eIt = shader->members().end(); it != eIt; it++ )
+			if( const StateRenderable *s = runTimeCast<const StateRenderable>( it->second.get() ) )
 			{
-				const StateRenderable *s = runTimeCast<const StateRenderable>( it->get() );
-				if( s )
+				s->render( m_renderer.get() );
+			}
+			else if( const ObjectVector *o = runTimeCast<const ObjectVector>( it->second.get() ) )
+			{
+				for( ObjectVector::MemberContainer::const_iterator it = o->members().begin(), eIt = o->members().end(); it != eIt; it++ )
 				{
-					s->render( m_renderer.get() );
+					const StateRenderable *s = runTimeCast<const StateRenderable>( it->get() );
+					if( s )
+					{
+						s->render( m_renderer.get() );
+					}
 				}
+			}
+			else if( const Data *d = runTimeCast<const Data>( it->second.get() ) )
+			{
+				m_renderer->setAttribute( it->first, d );
 			}
 		}
 	}
-
+	
 	ConstInternedStringVectorDataPtr childNames = inPlug()->childNames( path );
 	ScenePlug::ScenePath childPath = path;
 	childPath.push_back( InternedString() ); // for the child name
 	for( vector<InternedString>::const_iterator it=childNames->readable().begin(); it!=childNames->readable().end(); it++ )
 	{
 		childPath[path.size()] = *it;
-		updateShadersWalk( childPath );
+		updateAttributesWalk( childPath );
 	}
 }
 


### PR DESCRIPTION
The recent shader type changes broke the shader updates on the InteractiveRender, as previously you could find the shader state under "shader", and now you can't. People have been asking for attribute updates anyway, so I thought I might as well fix it by updating all the attributes. The performance implications of this change don't worry me too much, as the InteractiveRender needs tons of optimization anyway.
