### PR TITLE
Added Group::nextInPlug() method.

### DIFF
--- a/include/GafferScene/Group.h
+++ b/include/GafferScene/Group.h
@@ -56,6 +56,15 @@ class Group : public SceneProcessor
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Group, GroupTypeId, SceneProcessor );
 
+		/// The Group adds new input plugs as needed as the existing
+		/// ones receive input connections. This method returns the
+		/// most recently added plug - the one that should be used
+		/// to connect a new input.
+		/// \todo If SceneProcessor::inPlug() was an ArrayPlug as
+		/// per #996, we wouldn't need this method.
+		ScenePlug *nextInPlug();
+		const ScenePlug *nextInPlug() const;
+
 		Gaffer::StringPlug *namePlug();
 		const Gaffer::StringPlug *namePlug() const;
 

--- a/include/GafferSceneBindings/GroupBinding.h
+++ b/include/GafferSceneBindings/GroupBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2014, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEBINDINGS_GROUPBINDING_H
+#define GAFFERSCENEBINDINGS_GROUPBINDING_H
+
+namespace GafferSceneBindings
+{
+
+void bindGroup();
+
+} // namespace GafferSceneBindings
+
+#endif // GAFFERSCENEBINDINGS_GROUPBINDING_H

--- a/python/GafferSceneTest/GroupTest.py
+++ b/python/GafferSceneTest/GroupTest.py
@@ -709,6 +709,25 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 			} )
 		)
 
+	def testNextInPlug( self ) :
+
+		g = GafferScene.Group()
+		self.assertTrue( g.nextInPlug().isSame( g["in"] ) )
+
+		p = GafferScene.Plane()
+		g["in"].setInput( p["out"] )
+		self.assertTrue( g.nextInPlug().isSame( g["in1"] ) )
+
+		g["in"].setInput( None )
+		self.assertTrue( g.nextInPlug().isSame( g["in"] ) )
+
+		g["in"].setInput( p["out"] )
+		g["in1"].setInput( p["out"] )
+		self.assertTrue( g.nextInPlug().isSame( g["in2"] ) )
+
+		g["in"].setInput( None )
+		self.assertTrue( g.nextInPlug().isSame( g["in2"] ) )
+
 	def setUp( self ) :
 
 		self.__originalCacheMemoryLimit = Gaffer.ValuePlug.getCacheMemoryLimit()

--- a/src/GafferScene/Group.cpp
+++ b/src/GafferScene/Group.cpp
@@ -76,6 +76,16 @@ Group::~Group()
 {
 }
 
+ScenePlug *Group::nextInPlug()
+{
+	return m_inPlugs.inputs().back().get();
+}
+
+const ScenePlug *Group::nextInPlug() const
+{
+	return m_inPlugs.inputs().back().get();
+}
+
 Gaffer::StringPlug *Group::namePlug()
 {
 	return getChild<StringPlug>( g_firstPlugIndex );

--- a/src/GafferSceneBindings/GroupBinding.cpp
+++ b/src/GafferSceneBindings/GroupBinding.cpp
@@ -1,0 +1,54 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2014, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "GafferBindings/DependencyNodeBinding.h"
+
+#include "GafferScene/Group.h"
+
+#include "GafferSceneBindings/GroupBinding.h"
+
+using namespace boost::python;
+using namespace IECorePython;
+using namespace GafferScene;
+
+void GafferSceneBindings::bindGroup()
+{
+	GafferBindings::DependencyNodeClass<Group>()
+		.def( "nextInPlug", (ScenePlug *(Group::*)())&Group::nextInPlug, return_value_policy<CastToIntrusivePtr>() )
+	;
+}

--- a/src/GafferSceneModule/GafferSceneModule.cpp
+++ b/src/GafferSceneModule/GafferSceneModule.cpp
@@ -48,7 +48,6 @@
 #include "GafferScene/PrimitiveVariableProcessor.h"
 #include "GafferScene/DeletePrimitiveVariables.h"
 #include "GafferScene/MeshType.h"
-#include "GafferScene/Group.h"
 #include "GafferScene/Plane.h"
 #include "GafferScene/Seeds.h"
 #include "GafferScene/Instancer.h"
@@ -94,6 +93,7 @@
 #include "GafferSceneBindings/CoordinateSystemBinding.h"
 #include "GafferSceneBindings/DeleteGlobalsBinding.h"
 #include "GafferSceneBindings/ExternalProceduralBinding.h"
+#include "GafferSceneBindings/GroupBinding.h"
 
 using namespace boost::python;
 using namespace GafferScene;
@@ -112,7 +112,6 @@ BOOST_PYTHON_MODULE( _GafferScene )
 	GafferBindings::DependencyNodeClass<SceneElementProcessor>();
 	GafferBindings::DependencyNodeClass<AttributeCache>();
 	GafferBindings::DependencyNodeClass<MeshType>();
-	GafferBindings::DependencyNodeClass<Group>();
 	GafferBindings::DependencyNodeClass<ObjectSource>();
 	GafferBindings::DependencyNodeClass<Cube>();
 	GafferBindings::DependencyNodeClass<Plane>();
@@ -132,6 +131,7 @@ BOOST_PYTHON_MODULE( _GafferScene )
 	bindSceneProcedural();
 	bindShader();
 	bindOptions();
+	bindGroup();
 
 	GafferBindings::DependencyNodeClass<AlembicSource>();
 	GafferBindings::DependencyNodeClass<SubTree>();


### PR DESCRIPTION
I made this always return the very last plug, which is guaranteed to have no input, even in the case where an earlier plug has no input as well. In the example below, it's the highlighted plug, "in3", that will be returned.

![nextinplug](https://cloud.githubusercontent.com/assets/1133871/4629533/446d18d4-53a5-11e4-8f26-cb0023c4f94b.png)

My rationale was that the order is relevant when deciding which locations to rename when inputs have locations with the same name, so it was best always to connect at the end for consistency. When connecting a new input via `nextInPlug()`, it will always be the last one, so will always be the one that is renamed to avoid conflicts with the existing inputs. I'm not 100% sure about that decision, so if anyone wants to argue for reuse of the earlier plug (but with less clear renaming semantics), then please do.
