### PR TITLE
Added basic support for RenderMan volume shaders.

### DIFF
--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -1579,5 +1579,19 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		self.assertEqual( a["out"].attributes( "/plane" ).keys(), [ "ri:surface"] )
 
+	def testVolumeShader( self ) :
+
+		s = GafferRenderMan.RenderManShader()
+		s.loadShader( "fog" )
+
+		self.assertEqual( s["type"].getValue(), "ri:atmosphere" )
+
+		s["type"].setValue( "ri:interior" )
+		s.loadShader( "fog", keepExistingValues = True )
+		self.assertEqual( s["type"].getValue(), "ri:interior" )
+
+		s.loadShader( "fog", keepExistingValues = False )
+		self.assertEqual( s["type"].getValue(), "ri:atmosphere" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -127,7 +127,22 @@ void RenderManShader::loadShader( const std::string &shaderName, bool keepExisti
 	IECore::ConstShaderPtr shader = runTimeCast<const IECore::Shader>( shaderLoader()->read( shaderName + ".sdl" ) );
 	loadShaderParameters( shader.get(), parametersPlug(), keepExistingValues );
 	namePlug()->setValue( shaderName );
-	typePlug()->setValue( "ri:" + shader->getType() );
+
+	string type = "ri:" + shader->getType();
+	bool oldAndNewTypesCompatible = false;
+	if( type == "ri:volume" )
+	{
+		// "ri:volume" is the type of the shader, but it's not a valid assignment
+		// type. Valid assignment types are "ri:atmosphere", "ri:interior" and "ri:exterior".
+		type = "ri:atmosphere";
+		const string oldType = typePlug()->getValue();
+		oldAndNewTypesCompatible = oldType == "ri:atmosphere" || oldType == "ri:interior" || oldType == "ri:exterior";
+	}
+
+	if( !keepExistingValues || !oldAndNewTypesCompatible )
+	{
+		typePlug()->setValue( type );
+	}
 }
 
 bool RenderManShader::acceptsInput( const Plug *plug, const Plug *inputPlug ) const


### PR DESCRIPTION
The type of a RenderMan volume shader itself is simply "ri:volume", but that's not a valid type for actually assigning it to an object - we must use either "ri:atmosphere", "ri:interior" or "ri:exterior". This patch ensures that by default a volume shader will be assigned as "ri:atmosphere", but allows the type to be changed following loading. The type can be changed as follows :

`script["myShader"]["type"].setValue( "ri:interior" )`

We'll need some UI for setting this at some point - for the moment this pull request is just the bare minimum to get Beau working, and to get me on to other priorities...
