### PR TITLE
Fixed poor performance of Prune/Isolate in presence of SetFilter

### DIFF
--- a/python/GafferSceneTest/IsolateTest.py
+++ b/python/GafferSceneTest/IsolateTest.py
@@ -235,5 +235,27 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 		lightSet = isolate["out"]["globals"].getValue()["gaffer:sets"]["__lights"]
 		self.assertEqual( set( lightSet.value.paths() ), set( [ "/group/light", "/group/light1" ] ) )
 
+	def testGlobalsDoNotDependOnScenePath( self ) :
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/grid/borderLines" ] ) )
+
+		grid = GafferScene.Grid()
+
+		isolate = GafferScene.Isolate()
+		isolate["in"].setInput( grid["out"] )
+		isolate["filter"].setInput( pathFilter["match"] )
+
+		c = Gaffer.Context()
+		with c :
+			h1 = isolate["out"]["globals"].hash()
+			c["scene:path"] = IECore.InternedStringVectorData( [ "grid" ] )
+			h2 = isolate["out"]["globals"].hash()
+			c["scene:path"] = IECore.InternedStringVectorData( [ "grid", "centerLines" ] )
+			h3 = isolate["out"]["globals"].hash()
+
+		self.assertEqual( h1, h2 )
+		self.assertEqual( h2, h3 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/PruneTest.py
+++ b/python/GafferSceneTest/PruneTest.py
@@ -269,5 +269,27 @@ class PruneTest( GafferSceneTest.SceneTestCase ) :
 		b.promotePlug( b["n"]["filter"] )
 		self.assertTrue( b.plugIsPromoted( b["n"]["filter"] ) )
 
+	def testGlobalsDoNotDependOnScenePath( self ) :
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/grid/borderLines" ] ) )
+
+		grid = GafferScene.Grid()
+
+		prune = GafferScene.Prune()
+		prune["in"].setInput( grid["out"] )
+		prune["filter"].setInput( pathFilter["match"] )
+
+		c = Gaffer.Context()
+		with c :
+			h1 = prune["out"]["globals"].hash()
+			c["scene:path"] = IECore.InternedStringVectorData( [ "grid" ] )
+			h2 = prune["out"]["globals"].hash()
+			c["scene:path"] = IECore.InternedStringVectorData( [ "grid", "centerLines" ] )
+			h3 = prune["out"]["globals"].hash()
+
+		self.assertEqual( h1, h2 )
+		self.assertEqual( h2, h3 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/Isolate.cpp
+++ b/src/GafferScene/Isolate.cpp
@@ -180,7 +180,22 @@ void Isolate::hashGlobals( const Gaffer::Context *context, const ScenePlug *pare
 {
 	FilteredSceneProcessor::hashGlobals( context, parent, h );
 	inPlug()->globalsPlug()->hash( h );
-	filterHash( context, h );
+
+	// The globals themselves do not depend on the "scene:path"
+	// context entry - the whole point is that they're global.
+	// However, the PathFilter is dependent on scene:path, so
+	// we must remove the path before hashing in the filter in
+	// case we're computed from multiple contexts with different
+	// paths (from a SetFilter for instance). If we didn't do this,
+	// our different hashes would lead to huge numbers of redundant
+	// calls to computeGlobals() and a huge overhead in recomputing
+	// the same sets repeatedly.
+	//
+	// See further comments in FilteredSceneProcessor::affects().
+	ContextPtr c = filterContext( context );
+	c->remove( ScenePlug::scenePathContextName );
+	Context::Scope s( c.get() );
+	filterPlug()->hash( h );
 }
 
 IECore::ConstCompoundObjectPtr Isolate::computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const


### PR DESCRIPTION
Due to an inaccurate hash, we were repeatedly computing the globals every time the SetFilter requested them. Not doing that is quicker.
