### PR TITLE
Fixed context errors in the scene inspector

### DIFF
--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -222,9 +222,8 @@ class SceneInspector( GafferUI.NodeSetEditor ) :
 				if window is not None :
 					window.parent().removeChild( window )
 
-			with self.getContext() :
-				for section in self.__sections :
-					section.update( targets )
+			for section in self.__sections :
+				section.update( targets )
 
 			return False # remove idle callback
 


### PR DESCRIPTION
We noticed a problem in a scene where an expression was trying to pull a variable from the context. This variable was defined in script['variables'], and should have been available to the SceneInspector, but wasn't, as its __update method was being called with an incorrect context. This was causing errors while trying to use the SceneInspector. I've added a 'with self.getContext()' in SceneInspector.__update() to address this.
