### PR TITLE
Fixed serialization bug with extra plugs on references

### DIFF
--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -498,14 +498,20 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s2["r"].load( "/tmp/test.grf" )
 		s2["r"]["__pluggy"] = Gaffer.CompoundPlug( flags = Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
 		s2["r"]["__pluggy"]["int"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
+		s2["r"]["__pluggy"]["compound"] = Gaffer.CompoundPlug( flags = Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
+		s2["r"]["__pluggy"]["compound"]["int"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
 
 		self.assertEqual( s2["r"]["__pluggy"].getFlags(), Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
 		self.assertEqual( s2["r"]["__pluggy"]["int"].getFlags(), Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
+		self.assertEqual( s2["r"]["__pluggy"]["compound"].getFlags(), Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
+		self.assertEqual( s2["r"]["__pluggy"]["compound"]["int"].getFlags(), Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
 
 		s2["r"].load( "/tmp/test.grf" )
 
 		self.assertEqual( s2["r"]["__pluggy"].getFlags(), Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
 		self.assertEqual( s2["r"]["__pluggy"]["int"].getFlags(), Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
+		self.assertEqual( s2["r"]["__pluggy"]["compound"].getFlags(), Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
+		self.assertEqual( s2["r"]["__pluggy"]["compound"]["int"].getFlags(), Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
 
 	def tearDown( self ) :
 

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -196,19 +196,29 @@ void Reference::load( const std::string &fileName )
 
 bool Reference::isReferencePlug( const Plug *plug ) const
 {
-	// assume plugs starting with __ are for gaffer's
-	// internal use, so would never come directly from a
-	// reference - this lines up with the export code
-	// in Box::exportForReference(), where such plugs
-	// are excluded from the export.
-	if( boost::starts_with( plug->getName().c_str(), "__" ) )
+	// If a plug is the descendant of a plug starting with
+	// __, and that plug is a direct child of the reference,
+	// assume that it is for gaffer's internal use, so would
+	// never come directly from a reference. This lines up
+	// with the export code in Box::exportForReference(), where
+	// such plugs are excluded from the export.
+	
+	// find ancestor of p which is a direct child of this node:
+	const Plug* ancestorPlug = plug;
+	const GraphComponent* parent = plug->parent<GraphComponent>();
+	while( parent != this )
 	{
-		return false;
+		ancestorPlug = runTimeCast< const Plug >( parent );
+		if( !ancestorPlug )
+		{
+			// Looks like the plug we're looking for doesn't exist,
+			// so we exit the loop.
+			break;
+		}
+		parent = ancestorPlug->parent<GraphComponent>();
 	}
 	
-	// apply the same logic to compound plugs:
-	const Gaffer::CompoundPlug* compoundPlugAncestor = plug->ancestor<CompoundPlug>();
-	if( compoundPlugAncestor && boost::starts_with( compoundPlugAncestor->getName().c_str(), "__" ) )
+	if( ancestorPlug && boost::starts_with( ancestorPlug->getName().c_str(), "__" ) )
 	{
 		return false;
 	}


### PR DESCRIPTION
The reference nodes we use in production have an extra "__jabuka" CompoundPlug on them, with a bunch of children containing asset info. The children's names aren't prefixed by a double underscore, so Reference::isReferencePlug thinks they're referenced, and wipes out their Plug::Dynamic flag when we reload a reference. This means the node's asset tracking info gets destroyed when the reference gets reloaded and we load/save the file. I've fixed this by classifying descendants of a CompoundPlug with a double underscore in its name as non referenced.
