### PR TITLE
Preventing OIIO error overflow crash

### DIFF
--- a/src/GafferImage/ImageReader.cpp
+++ b/src/GafferImage/ImageReader.cpp
@@ -122,7 +122,14 @@ bool ImageReader::enabled() const
 {
 	std::string fileName = fileNamePlug()->getValue();
 	const ImageSpec *spec = imageCache()->imagespec( ustring( fileName.c_str() ) );
-	return (spec != 0) ? ImageNode::enabled() : false;
+	if( spec == 0 )
+	{
+		// clear error on failure to prevent error buffer overflow crash.
+		imageCache()->geterror();
+		return false;
+	}
+	
+	return ImageNode::enabled();
 }
 
 size_t ImageReader::supportedExtensions( std::vector<std::string> &extensions )


### PR DESCRIPTION
ImageView::enabled() checks for valid files using ImageCache::imagespec(), which appends to an error message buffer when it encounters an invalid file. The function gets called by the hash() method, and therefore gets called loads of times, meaning a lot of errors can get added to the buffer very quickly in some situations. If the error buffer exceeds 16mb in size, this triggers an assertion failure, which can crash the application. I've prevented this by calling ImageCache::geterror() on failure so the buffer gets cleared.
