### PR TITLE
Support for icons in menus

### DIFF
--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -324,7 +324,12 @@ class Menu( GafferUI.Widget ) :
 		# when an icon file path is defined in the menu definition 		
 		icon = getattr( item, "icon", None )
 		if icon is not None :
-			qtAction.setIcon( QtGui.QIcon( icon ) )
+			if isinstance( icon, basestring ) :
+				image = GafferUI.Image( icon )
+			else :
+				assert( isinstance( icon, GafferUI.Image ) )
+				image = icon
+			qtAction.setIcon( QtGui.QIcon( image._qtPixmap() ) )
 
 		if item.description :
 			qtAction.setStatusTip( item.description )


### PR DESCRIPTION
Very small change that adds support for icons in menus, with this change icons can be defined in the menu definition through the key "icon" where the value of this key has to contain its file path.

Change log:
- Menu widget: Added support for icons
