### PR TITLE
Fixed deadlocks if computes spawn their own threads

### DIFF
--- a/include/GafferBindings/TypedPlugBinding.inl
+++ b/include/GafferBindings/TypedPlugBinding.inl
@@ -54,6 +54,15 @@ static void setValue( T *plug, const typename T::ValueType value )
 	plug->setValue( value );
 }
 
+template<typename T>
+static typename T::ValueType getValue( const T *plug, const IECore::MurmurHash *precomputedHash )
+{
+	// Must release GIL in case computation spawns threads which need
+	// to reenter Python.
+	IECorePython::ScopedGILRelease r;
+	return plug->getValue( precomputedHash );
+}
+
 } // namespace Detail
 
 template<typename T, typename TWrapper>
@@ -74,7 +83,7 @@ TypedPlugClass<T, TWrapper>::TypedPlugClass( const char *docString )
 	);
 	this->def( "defaultValue", &T::defaultValue, boost::python::return_value_policy<boost::python::copy_const_reference>() );
 	this->def( "setValue", &Detail::setValue<T> );
-	this->def( "getValue", &T::getValue, ( boost::python::arg( "_precomputedHash" ) = boost::python::object() ) );
+	this->def( "getValue", &Detail::getValue<T>, ( boost::python::arg( "_precomputedHash" ) = boost::python::object() ) );
 }
 
 } // namespace GafferBindings

--- a/src/GafferBindings/BoxPlugBinding.cpp
+++ b/src/GafferBindings/BoxPlugBinding.cpp
@@ -49,6 +49,15 @@ using namespace GafferBindings;
 using namespace Gaffer;
 
 template<typename T>
+static typename T::ValueType getValue( const T *plug )
+{
+	// Must release GIL in case computation spawns threads which need
+	// to reenter Python.
+	IECorePython::ScopedGILRelease r;
+	return plug->getValue();
+}
+
+template<typename T>
 static void bind()
 {
 	typedef typename T::ValueType V;
@@ -65,7 +74,7 @@ static void bind()
 		)
 		.def( "defaultValue", &T::defaultValue )
 		.def( "setValue", &T::setValue )
-		.def( "getValue", &T::getValue )
+		.def( "getValue", &getValue<T> )
 	;
 }
 

--- a/src/GafferBindings/CompoundNumericPlugBinding.cpp
+++ b/src/GafferBindings/CompoundNumericPlugBinding.cpp
@@ -143,6 +143,15 @@ void setValue( T *plug, const typename T::ValueType value )
 }
 
 template<typename T>
+typename T::ValueType getValue( const T *plug )
+{
+	// Must release GIL in case computation spawns threads which need
+	// to reenter Python.
+	IECorePython::ScopedGILRelease r;
+	return plug->getValue();
+}
+
+template<typename T>
 void bind()
 {
 	typedef typename T::ValueType V;
@@ -165,7 +174,7 @@ void bind()
 		.def( "minValue", &T::minValue )
 		.def( "maxValue", &T::maxValue )
 		.def( "setValue", &setValue<T> )
-		.def( "getValue", &T::getValue )
+		.def( "getValue", &getValue<T> )
 		.def( "__repr__", &compoundNumericPlugRepr<T> )
 		.def( "canGang", &T::canGang )
 		.def( "gang", &T::gang )

--- a/src/GafferBindings/NumericPlugBinding.cpp
+++ b/src/GafferBindings/NumericPlugBinding.cpp
@@ -106,6 +106,15 @@ void setValue( T *plug, const typename T::ValueType value )
 }
 
 template<typename T>
+typename T::ValueType getValue( const T *plug, const IECore::MurmurHash *precomputedHash )
+{
+	// Must release GIL in case computation spawns threads which need
+	// to reenter Python.
+	IECorePython::ScopedGILRelease r;
+	return plug->getValue( precomputedHash );
+}
+
+template<typename T>
 class NumericPlugSerialiser : public ValuePlugSerialiser
 {
 
@@ -141,7 +150,7 @@ void bind()
 		.def( "minValue", &T::minValue )
 		.def( "maxValue", &T::maxValue )
 		.def( "setValue", setValue<T> )
-		.def( "getValue", &T::getValue, ( boost::python::arg( "_precomputedHash" ) = boost::python::object() ) )
+		.def( "getValue", &getValue<T>, ( boost::python::arg( "_precomputedHash" ) = boost::python::object() ) )
 		.def( "__repr__", &repr<T> )
 	;
 

--- a/src/GafferBindings/SplinePlugBinding.cpp
+++ b/src/GafferBindings/SplinePlugBinding.cpp
@@ -89,6 +89,15 @@ typename T::YPlugType::Ptr pointYPlug( T &s, size_t index )
 }
 
 template<typename T>
+typename T::ValueType getValue( const T &plug )
+{
+	// Must release GIL in case computation spawns threads which need
+	// to reenter Python.
+	IECorePython::ScopedGILRelease r;
+	return plug.getValue();
+}
+
+template<typename T>
 void bind()
 {
 	typedef typename T::ValueType V;
@@ -105,7 +114,7 @@ void bind()
 		)
 		.def( "defaultValue", &T::defaultValue, return_value_policy<copy_const_reference>() )
 		.def( "setValue", &T::setValue )
-		.def( "getValue", &T::getValue )
+		.def( "getValue", &getValue<T> )
 		.def( "numPoints", &T::numPoints )
 		.def( "addPoint", &T::addPoint )
 		.def( "removePoint", &T::removePoint )

--- a/src/GafferBindings/TypedObjectPlugBinding.cpp
+++ b/src/GafferBindings/TypedObjectPlugBinding.cpp
@@ -83,6 +83,10 @@ static void setValue( typename T::Ptr p, typename T::ValuePtr v, bool copy=true 
 template<typename T>
 static IECore::ObjectPtr getValue( typename T::Ptr p, const IECore::MurmurHash *precomputedHash=NULL, bool copy=true )
 {
+	// Must release GIL in case computation spawns threads which need
+	// to reenter Python.
+	IECorePython::ScopedGILRelease r;
+	
 	typename IECore::ConstObjectPtr v = p->getValue( precomputedHash );
 	if( v )
 	{

--- a/src/GafferSceneBindings/ScenePlugBinding.cpp
+++ b/src/GafferSceneBindings/ScenePlugBinding.cpp
@@ -130,22 +130,91 @@ struct ScenePathFromString
 
 };
 
+Imath::Box3f boundWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.bound( scenePath );
+}
+
+Imath::M44f transformWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.transform( scenePath );
+}
+
+Imath::M44f fullTransformWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.fullTransform( scenePath );
+}
+
 IECore::ObjectPtr objectWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath, bool copy=true )
 {
+	IECorePython::ScopedGILRelease gilRelease;
 	IECore::ConstObjectPtr o = plug.object( scenePath );
 	return copy ? o->copy() : boost::const_pointer_cast<IECore::Object>( o );
 }
 
 IECore::InternedStringVectorDataPtr childNamesWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath, bool copy=true )
 {
+	IECorePython::ScopedGILRelease gilRelease;
 	IECore::ConstInternedStringVectorDataPtr n = plug.childNames( scenePath );
 	return copy ? n->copy() : boost::const_pointer_cast<IECore::InternedStringVectorData>( n );
 }
 
 IECore::CompoundObjectPtr attributesWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath, bool copy=true )
 {
+	IECorePython::ScopedGILRelease gilRelease;
 	IECore::ConstCompoundObjectPtr a = plug.attributes( scenePath );
 	return copy ? a->copy() : boost::const_pointer_cast<IECore::CompoundObject>( a );
+}
+
+IECore::CompoundObjectPtr fullAttributesWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.fullAttributes( scenePath );
+}
+
+IECore::MurmurHash boundHashWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.boundHash( scenePath );
+}
+
+IECore::MurmurHash transformHashWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.transformHash( scenePath );
+}
+
+IECore::MurmurHash fullTransformHashWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.fullTransformHash( scenePath );
+}
+
+IECore::MurmurHash objectHashWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.objectHash( scenePath );
+}
+
+IECore::MurmurHash childNamesHashWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.childNamesHash( scenePath );
+}
+
+IECore::MurmurHash attributesHashWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.attributesHash( scenePath );
+}
+
+IECore::MurmurHash fullAttributesHashWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.fullAttributesHash( scenePath );
 }
 
 } // namespace
@@ -163,19 +232,21 @@ void GafferSceneBindings::bindScenePlug()
 			)
 		)
 		// value accessors
-		.def( "bound", &ScenePlug::bound )
-		.def( "transform", &ScenePlug::transform )
-		.def( "fullTransform", &ScenePlug::fullTransform )
+		.def( "bound", &boundWrapper )
+		.def( "transform", &transformWrapper )
+		.def( "fullTransform", &fullTransformWrapper )
 		.def( "object", &objectWrapper, ( boost::python::arg_( "_copy" ) = true ) )
 		.def( "childNames", &childNamesWrapper, ( boost::python::arg_( "_copy" ) = true ) )
 		.def( "attributes", &attributesWrapper, ( boost::python::arg_( "_copy" ) = true ) )
-		.def( "fullAttributes", &ScenePlug::fullAttributes )
+		.def( "fullAttributes", &fullAttributesWrapper )
 		// hash accessors
-		.def( "boundHash", &ScenePlug::boundHash )
-		.def( "transformHash", &ScenePlug::transformHash )
-		.def( "objectHash", &ScenePlug::objectHash )
-		.def( "childNamesHash", &ScenePlug::childNamesHash )
-		.def( "attributesHash", &ScenePlug::attributesHash )
+		.def( "boundHash", &boundHashWrapper )
+		.def( "transformHash", &transformHashWrapper )
+		.def( "fullTransformHash", &fullTransformHashWrapper )
+		.def( "objectHash", &objectHashWrapper )
+		.def( "childNamesHash", &childNamesHashWrapper )
+		.def( "attributesHash", &attributesHashWrapper )
+		.def( "fullAttributesHash", &fullAttributesHashWrapper )
 	;
 
 	ScenePathFromInternedStringVectorData();


### PR DESCRIPTION
We need to release the GIL on the thread which requests the compute, so that if the compute spawns threads, they can enter into Python. The only example we have of this right now is the Instancer when getting the bounds, but I've fixed all the ValuePlug::getValue() bindings too for good measure.

Only the last two commits are unique to this pull request - the others are in #1089. I needed to build on that because it has made changes to the python bindings as well. This also requires ImageEngine/cortex#358.

It would be really helpful to me if we could get all these pull requests merged. I want to continue testing the viewer stuff through my daily work, but that's tricky if I'm trying to make my subsequent pull requests relative to master (which I failed to do here already). If you're worried about merging it in case we need to get a patch out before we've done enough testing, perhaps we could make a maintenance branch?
