### PR TITLE
Group now remaps the root path in sets

### DIFF
--- a/python/GafferSceneTest/GroupTest.py
+++ b/python/GafferSceneTest/GroupTest.py
@@ -631,6 +631,22 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 				"/group/lightGroup2/light",
 			] )
 		)
+	
+	def testSetsWithRootPath( self ) :
+		
+		sph = GafferScene.Sphere()
+		
+		s = GafferScene.Set()
+		s["in"].setInput( sph["out"] )
+		s["name"].setValue( "stuff" )
+		s["paths"].setValue( IECore.StringVectorData(["/", "/sphere"]) )
+		
+		g = GafferScene.Group()
+		g["name"].setValue( "group" )
+		
+		g["in"].setInput( s["out"] )
+		
+		self.assertEqual( set( g["out"]["globals"].getValue()["gaffer:sets"]["stuff"].value.paths() ), set( ["/group", "/group/sphere"] ) )
 
 	def testMakeConnectionAndUndo( self ) :
 

--- a/src/GafferScene/Group.cpp
+++ b/src/GafferScene/Group.cpp
@@ -502,6 +502,12 @@ IECore::ConstCompoundObjectPtr Group::computeGlobals( const Gaffer::Context *con
 			for( vector<string>::const_iterator pIt = inputPaths.begin(), peIt = inputPaths.end(); pIt != peIt; ++pIt )
 			{
 				const string &inputPath = *pIt;
+				if( inputPath == "/" )
+				{
+					outputSet.addPath( std::string( "/" ) + groupName );
+					continue;
+				}
+				
 				const size_t secondSlashPos = inputPath.find( '/', 1 );
 				const std::string inputName( inputPath, 1, secondSlashPos - 1 );
 				const InternedStringData *outputName = forwardMapping->member<InternedStringData>( inputName );


### PR DESCRIPTION
We were having a problem in our automated renders, where we were assembling a scene hierarchy using groups. The incoming scene caches all had a "GeoId" set containing only the root path, which we expected to end up as the location of the scene cache in the final assembled hierarchy. However, it turns out that the Group was skipping over the root path when remapping the incoming sets, meaning it was getting removed and our renders were incorrect. I've added a little tweak that fixes it
