### PR TITLE
Added sneaky hotkey for navigating inside any node in NodeGraph.

### DIFF
--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -289,12 +289,13 @@ class NodeGraph( GafferUI.EditorWidget ) :
 		# generalisation.
 		elif event.key == "Down" :
 			selection = self.scriptNode().selection()
-			if selection.size() and isinstance( selection[0], Gaffer.Box ) :
-				self.graphGadget().setRoot( selection[0] )
-				return True
+			if selection.size() :
+				if isinstance( selection[0], Gaffer.Box ) or event.modifiers == event.modifiers.Shift | event.modifiers.Control :
+					self.graphGadget().setRoot( selection[0] )
+					return True
 		elif event.key == "Up" :
 			root = self.graphGadget().getRoot()
-			if isinstance( root, Gaffer.Box ) :
+			if not isinstance( root, Gaffer.ScriptNode ) :
 				self.graphGadget().setRoot( root.parent() )
 				return True
 		elif event.key == "Tab" :


### PR DESCRIPTION
This is useful for seeing inside References and other nodes which have internal networks. We really need to put the NodeGraph in a read-only mode for this, but since we don't yet have one, we're consoling ourselves that the naive user is unlikely to hit upon this particular key combo.
