### PR TITLE
Added Context.__contains__ binding.

### DIFF
--- a/python/GafferTest/ContextTest.py
+++ b/python/GafferTest/ContextTest.py
@@ -508,7 +508,20 @@ class ContextTest( GafferTest.TestCase ) :
 		self.assertEqual( set( c.names() ), set( [ "b", "frame" ] ) )
 		
 		self.assertEqual( c["b"], "bear" )
+
+	def testContains( self ) :
+
+		c = Gaffer.Context()
+		self.assertFalse( "a" in c )
+		self.assertTrue( "a" not in c )
+
+		c["a"] = 1
+		self.assertTrue( "a" in c )
+		self.assertFalse( "a" not in c )
 		
+		del c["a"]
+		self.assertFalse( "a" in c )
+		self.assertTrue( "a" not in c )
 		
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferBindings/ContextBinding.cpp
+++ b/src/GafferBindings/ContextBinding.cpp
@@ -108,6 +108,11 @@ object getItem( Context &c, const IECore::InternedString &name )
 	return get( c, name, /* copy = */ true );
 }
 
+bool contains( Context &c, const IECore::InternedString &name )
+{
+	return c.get<Data>( name, NULL );
+}
+
 void delItem( Context &context, const IECore::InternedString &name )
 {
 	context.remove( name );
@@ -177,6 +182,7 @@ void GafferBindings::bindContext()
 		.def( "get", &get, arg( "_copy" ) = true )
 		.def( "get", &getWithDefault, ( arg( "defaultValue" ), arg( "_copy" ) = true ) )
 		.def( "__getitem__", &getItem )
+		.def( "__contains__", &contains )
 		.def( "remove", &Context::remove )
 		.def( "__delitem__", &delItem )
 		.def( "changed", &Context::changed )


### PR DESCRIPTION
This allows expressions of the form `"a" in context` and `"a" not in context`.
