### PR TITLE
Fixed ObjectSource to work after create/undo/redo.

### DIFF
--- a/include/GafferScene/ObjectSourceBase.h
+++ b/include/GafferScene/ObjectSourceBase.h
@@ -93,9 +93,6 @@ class ObjectSourceBase : public BaseType
 
 	private :
 
-		Gaffer::ObjectPlug *inputSourcePlug();
-		const Gaffer::ObjectPlug *inputSourcePlug() const;
-
 		static size_t g_firstPlugIndex;
 
 };

--- a/include/GafferScene/ObjectSourceBase.inl
+++ b/include/GafferScene/ObjectSourceBase.inl
@@ -62,8 +62,6 @@ ObjectSourceBase<BaseType>::ObjectSourceBase( const std::string &name, const std
 	BaseType::addChild( new Gaffer::StringPlug( "name", Gaffer::Plug::In, namePlugDefaultValue ) );
 	BaseType::addChild( new Gaffer::TransformPlug( "transform" ) );
 	BaseType::addChild( new Gaffer::ObjectPlug( "__source", Gaffer::Plug::Out, IECore::NullObject::defaultNullObject() ) );
-	BaseType::addChild( new Gaffer::ObjectPlug( "__inputSource", Gaffer::Plug::In, IECore::NullObject::defaultNullObject(), Gaffer::Plug::Default & ~Gaffer::Plug::Serialisable ) );
-	inputSourcePlug()->setInput( sourcePlug() );
 }
 
 template<typename BaseType>
@@ -100,7 +98,7 @@ void ObjectSourceBase<BaseType>::affects( const Gaffer::Plug *input, Gaffer::Dep
 {
 	BaseType::affects( input, outputs );
 
-	if( input == inputSourcePlug() )
+	if( input == sourcePlug() )
 	{
 		outputs.push_back( BaseType::outPlug()->boundPlug() );
 		outputs.push_back( BaseType::outPlug()->objectPlug() );
@@ -140,22 +138,10 @@ const Gaffer::ObjectPlug *ObjectSourceBase<BaseType>::sourcePlug() const
 }
 
 template<typename BaseType>
-Gaffer::ObjectPlug *ObjectSourceBase<BaseType>::inputSourcePlug()
-{
-	return BaseType::template getChild<Gaffer::ObjectPlug>( g_firstPlugIndex + 3 );
-}
-
-template<typename BaseType>
-const Gaffer::ObjectPlug *ObjectSourceBase<BaseType>::inputSourcePlug() const
-{
-	return BaseType::template getChild<Gaffer::ObjectPlug>( g_firstPlugIndex + 3 );
-}
-
-template<typename BaseType>
 void ObjectSourceBase<BaseType>::hashBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	BaseType::hashBound( path, context, parent, h );
-	inputSourcePlug()->hash( h );
+	sourcePlug()->hash( h );
 	if( path.size() == 0 )
 	{
 		transformPlug()->hash( h );
@@ -173,7 +159,7 @@ template<typename BaseType>
 void ObjectSourceBase<BaseType>::hashObject( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	BaseType::hashObject( path, context, parent, h );
-	inputSourcePlug()->hash( h );
+	sourcePlug()->hash( h );
 }
 
 template<typename BaseType>
@@ -199,7 +185,7 @@ template<typename BaseType>
 Imath::Box3f ObjectSourceBase<BaseType>::computeBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
 	Imath::Box3f result;
-	IECore::ConstObjectPtr object = inputSourcePlug()->getValue();
+	IECore::ConstObjectPtr object = sourcePlug()->getValue();
 
 	if( const IECore::VisibleRenderable *renderable = IECore::runTimeCast<const IECore::VisibleRenderable>( object.get() ) )
 	{
@@ -246,7 +232,7 @@ IECore::ConstObjectPtr ObjectSourceBase<BaseType>::computeObject( const SceneNod
 {
 	if( path.size() == 1 )
 	{
-		return inputSourcePlug()->getValue();
+		return sourcePlug()->getValue();
 	}
 	return parent->objectPlug()->defaultValue();
 }

--- a/python/GafferSceneTest/PlaneTest.py
+++ b/python/GafferSceneTest/PlaneTest.py
@@ -135,5 +135,19 @@ class PlaneTest( GafferSceneTest.SceneTestCase ) :
 
 		ss = s.serialise()
 
+	def testUndoAndRedoAndCompute( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		with Gaffer.UndoContext( s ) :
+			s["p"] = GafferScene.Plane()
+
+		self.assertTrue( isinstance( s["p"]["out"].object( "/plane" ), IECore.MeshPrimitive ) )
+
+		s.undo()
+		s.redo()
+
+		self.assertTrue( isinstance( s["p"]["out"].object( "/plane" ), IECore.MeshPrimitive ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/SceneWriterTest.py
+++ b/python/GafferSceneTest/SceneWriterTest.py
@@ -51,14 +51,10 @@ class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 
 	def testWrite( self ) :
 
-		s = GafferTest.SphereNode()
-
-		o = GafferScene.ObjectToScene()
-
-		o["__inputSource"].setInput( s["out"] )
+		s = GafferScene.Sphere()
 
 		g = GafferScene.Group()
-		g["in"].setInput( o["out"] )
+		g["in"].setInput( s["out"] )
 
 		g["transform"]["translate"]["x"].setValue( 5 )
 		g["transform"]["translate"]["z"].setValue( 2 )


### PR DESCRIPTION
It was using an outdated way of using the result of an internal computation in the computation of another output - since DependencyNode::affects() is now (and has been for a long time) called for output plugs as well as inputs during dirty propagation there is no need for the additional intermediate plug.

Although this fix is good in that it tidies up some code, I suspect there's another problem somewhere which caused the input to the internal plug to be removed upon undo but not restored upon redo. This may need investigating in its own right at some point.

I have no idea why the unrelated SceneWriterTest was mucking about with the private __inputSource plug - it had no business being there.
