### PR TITLE
- add new pragma annotation : overrideShaderType

### DIFF
--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -1608,5 +1608,13 @@ class RenderManShaderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		self.assertTrue( shaderNode["parameters"]["coshaderParameter"].acceptsInput( dot["out"] ) )
 
+	def testShaderTypeOverride( self ) :
+
+		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/shaderTypeOverride.sl" )
+		shaderNode = GafferRenderMan.RenderManShader()
+		shaderNode.loadShader( shader )
+
+		self.assertEqual( shaderNode['type'].getValue(), "ri:overrideType" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferRenderManTest/shaders/shaderTypeOverride.sl
+++ b/python/GafferRenderManTest/shaders/shaderTypeOverride.sl
@@ -1,0 +1,46 @@
+//////////////////////////////////////////////////////////////////////////
+//  
+//  Copyright (c) 2014, Image Engine Design Inc. All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//  
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//  
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//  
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+//////////////////////////////////////////////////////////////////////////
+
+#pragma annotation "shaderTypeOverride" "ri:overrideType"
+
+class shaderTypeOverride()
+{
+	public void surface( output color Ci, Oi)
+	{
+		Ci = ( 1, 1, 1 );
+		Oi = 1;
+	}
+}

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -130,6 +130,21 @@ void RenderManShader::loadShader( const std::string &shaderName, bool keepExisti
 	namePlug()->setValue( shaderName );
 
 	string type = "ri:" + shader->getType();
+
+	// A metadata option to override the shader type.
+	// This can be useful to work around some 3delight issues.
+	// For example, if you want to call illuminance() in a coshader, you need to add a 
+	// dummy surface() method, but you still want the type to be "ri:shader".
+	ConstCompoundDataPtr annotations = shader->blindData()->member<CompoundData>( "ri:annotations" );
+	if( annotations )
+	{
+		const StringData *shaderTypeOverride = annotations->member<StringData>( "shaderTypeOverride" );
+		if( shaderTypeOverride )
+		{
+			type = shaderTypeOverride->readable();
+		}
+	}
+
 	bool oldAndNewTypesCompatible = false;
 	if( type == "ri:volume" )
 	{


### PR DESCRIPTION
- add new pragma annotation : overrideShaderType for defind the type of a sdl file

exemple of use in shader : #pragma annotation "overrideShaderType" "ri:shader"
