### PR TITLE
Fixed bindings for Metadata types other than simple typed data.

### DIFF
--- a/include/GafferBindings/DataBinding.h
+++ b/include/GafferBindings/DataBinding.h
@@ -1,0 +1,62 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2014, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERBINDINGS_DATABINDING_H
+#define GAFFERBINDINGS_DATABINDING_H
+
+#include "boost/python.hpp"
+
+#include "IECore/Data.h"
+
+namespace GafferBindings
+{
+
+/// Converts an IECore::Data instance to Python. Simple data is "unwrapped" and
+/// returned as an instance of the internal type. For instance, Color3fData is
+/// converted to Color3f. This avoids the unintuitive hoop jumping of using the
+/// .value field in python all the time. Vector data and all other complex types
+/// are simply returned as they are, on the grounds that there's not a better type
+/// to represent them in Python.
+/// \todo It might be too late, but consider how this could be put to use
+/// in Cortex itself.
+boost::python::object dataToPython( IECore::Data *data, boost::python::object nullValue = boost::python::object() );
+/// As above, but since the data is const (and python has no const), requiring
+/// an argument specifying whether or not to copy the data.
+boost::python::object dataToPython( const IECore::Data *data, bool copy, boost::python::object nullValue = boost::python::object() );
+
+} // namespace GafferBindings
+
+#endif // GAFFERBINDINGS_DATABINDING_H

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -462,6 +462,31 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		GafferTest.testMetadataThreading()
 
+	def testVectorTypes( self ) :
+
+		n = Gaffer.Node()
+
+		Gaffer.Metadata.registerNodeValue( n, "stringVector", IECore.StringVectorData( [ "a", "b", "c" ] ) )
+		self.assertEqual( Gaffer.Metadata.nodeValue( n, "stringVector" ), IECore.StringVectorData( [ "a", "b", "c" ] ) )
+
+		Gaffer.Metadata.registerNodeValue( n, "intVector", IECore.IntVectorData( [ 1, 2, 3 ] ) )
+		self.assertEqual( Gaffer.Metadata.nodeValue( n, "intVector" ), IECore.IntVectorData( [ 1, 2, 3 ] ) )
+
+	def testCopy( self ) :
+
+		n = Gaffer.Node()
+
+		s = IECore.StringVectorData( [ "a", "b", "c" ] )
+		Gaffer.Metadata.registerNodeValue( n, "stringVector", s )
+
+		s2 = Gaffer.Metadata.nodeValue( n, "stringVector" )
+		self.assertEqual( s, s2 )
+		self.assertFalse( s.isSame( s2 ) )
+
+		s3 = Gaffer.Metadata.nodeValue( n, "stringVector", _copy = False )
+		self.assertEqual( s, s3 )
+		self.assertTrue( s.isSame( s3 ) )
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/src/GafferBindings/DataBinding.cpp
+++ b/src/GafferBindings/DataBinding.cpp
@@ -1,0 +1,101 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2014, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "IECore/DespatchTypedData.h"
+
+#include "GafferBindings/DataBinding.h"
+
+using namespace boost::python;
+using namespace IECore;
+
+namespace
+{
+
+struct SimpleTypedDataGetter
+{
+	typedef object ReturnType;
+
+	template<typename T>
+	object operator()( T *data )
+	{
+		return object( data->readable() );
+	}
+};
+
+boost::python::object dataToPythonInternal( IECore::Data *data, bool copy, boost::python::object nullValue )
+{
+	if( !data )
+	{
+		return nullValue;
+	}
+
+	try
+	{
+		return despatchTypedData<SimpleTypedDataGetter, TypeTraits::IsSimpleTypedData>( data );
+	}
+	catch( const InvalidArgumentException &e )
+	{
+		// In an ideal world, we wouldn't be using exception handling to detect
+		// the cases where IsSimpleTypedData is false. We _could_ use a null error
+		// handler for the despatchTypedData() call, except for two annoying facts :
+		//
+		//	- Error handlers don't get to return a value
+		//  - The error handler isn't used if a totally unknown datatype is
+		//    found, and Gaffer adds new datatypes.
+		//
+		// It might be nice to fix that in Cortex.
+		return object( copy ? data->copy() : DataPtr( data ) );
+	}
+}
+
+} // namespace
+
+namespace GafferBindings
+{
+
+boost::python::object dataToPython( IECore::Data *data, boost::python::object nullValue )
+{
+	return dataToPythonInternal( data, false, nullValue );
+}
+
+boost::python::object dataToPython( const IECore::Data *data, bool copy, boost::python::object nullValue )
+{
+	return dataToPythonInternal( const_cast<Data *>( data ), copy, nullValue );
+}
+
+} // namespace GafferBindings


### PR DESCRIPTION
Also introduced new DataBinding.h header with dataToPython() method, to consolidate duplicated code from Metadata and Context bindings.

Fixes #1136.
