### PR TITLE
Save on exit

### DIFF
--- a/python/GafferCortexUI/ParameterPresets.py
+++ b/python/GafferCortexUI/ParameterPresets.py
@@ -238,7 +238,7 @@ class SavePresetDialogue( PresetDialogue ) :
 			dialogue = GafferUI.ConfirmationDialogue(
 				"Preset already exists!",
 				"A preset named \"%s\" already exists.\nReplace it?" % presetName,
-				confirmLabel = "Replace"
+				buttonLabels = [ "Cancel", "Replace" ]
 			)
 			if not dialogue.waitForConfirmation( parentWindow = self ) :
 				return False

--- a/python/GafferUI/ApplicationMenu.py
+++ b/python/GafferUI/ApplicationMenu.py
@@ -68,7 +68,7 @@ def quit( menu ) :
 			"The following files have unsaved changes : \n\n" +
 			"\n".join( [ " - " + n for n in unsavedNames ] ) +
 			"\n\nDo you want to discard the changes and quit?",
-			confirmLabel = "Discard and Quit"
+			buttonLabels = [ "Cancel", "Discard and Quit" ]
 		)
 
 		if not dialogue.waitForConfirmation( parentWindow=scriptWindow ) :

--- a/python/GafferUI/ConfirmationDialogue.py
+++ b/python/GafferUI/ConfirmationDialogue.py
@@ -41,22 +41,22 @@ import GafferUI
 
 class ConfirmationDialogue( GafferUI.Dialogue ) :
 
-	def __init__( self, title, message, cancelLabel="Cancel", confirmLabel="OK", sizeMode=GafferUI.Window.SizeMode.Automatic, **kw ) :
+    def __init__( self, title, message, buttonLabels = [ "Cancel", "OK" ], defaultButton = 1, sizeMode=GafferUI.Window.SizeMode.Automatic, **kw ) :
 
-		GafferUI.Dialogue.__init__( self, title, sizeMode=sizeMode, **kw )
+        GafferUI.Dialogue.__init__( self, title, sizeMode=sizeMode, **kw )
 
-		self._setWidget( GafferUI.Label( message ) )
+        self._setWidget( GafferUI.Label( message ) )
 
-		self._addButton( cancelLabel )
-		self.__confirmButton = self._addButton( confirmLabel )
+        self.__defaultButton = defaultButton if defaultButton < len(buttonLabels) else (len(buttonLabels)-1)
 
-	## Causes the dialogue to enter a modal state, returning True if the confirm
-	# button was pressed, and False otherwise.
-	def waitForConfirmation( self, **kw ) :
+        self.__buttons = []
+        for buttonLabel in buttonLabels:
+            self.__buttons.append( self._addButton( buttonLabel ) )
 
-		self.__confirmButton._qtWidget().setFocus()
-		button = self.waitForButton( **kw )
-		if button is self.__confirmButton :
-			return True
+    ## Causes the dialogue to enter a modal state, returning the ID of the
+    # button that was pressed
+    def waitForConfirmation( self, **kw ) :
 
-		return False
+        self.__buttons[self.__defaultButton]._qtWidget().setFocus()
+        button = self.waitForButton( **kw )
+        return self.__buttons.index(button)

--- a/python/GafferUI/ScriptWindow.py
+++ b/python/GafferUI/ScriptWindow.py
@@ -97,11 +97,24 @@ class ScriptWindow( GafferUI.Window ) :
 		f = f.rpartition( "/" )[2] if f else "untitled"
 
 		dialogue = GafferUI.ConfirmationDialogue(
-			"Discard Unsaved Changes?",
-			"The file %s has unsaved changes. Do you want to discard them?" % f,
-			confirmLabel = "Discard"
+			"Unsaved Changes.",
+			"The file %s has unsaved changes. Do you want to save them or discard them?" % f,
+			buttonLabels = [ "Cancel", "Discard", "Save" ],
+			defaultButton = 2
 		)
-		return dialogue.waitForConfirmation( parentWindow=self )
+		result = dialogue.waitForConfirmation( parentWindow=self )
+
+		if result == 2 :
+			menuBar = self.__listContainer[0]
+			GafferUI.FileMenu.save( menuBar )
+
+			if not self.__script["unsavedChanges"].getValue():
+				return True
+
+		elif result == 1 :
+			return True
+
+		return False
 
 	def __closed( self, widget ) :
 


### PR DESCRIPTION
This PR adds the option to save a script when you try to close a script with unsaved changes, as well as discard or cancel.

I had to add a MultiButtonConfirmationDialogue class to allow for a dialogue with more than two buttons. You pass in a list of buttons, and the index of the default button, and waitForConfirmation() returns the index of the button that was pressed.

I couldn't figure out how to get the actual Menu object to pass to FileMenu.save(), but as that method only needs the menu to get back to the ScriptWindow, any child of the ScriptWindow seemed appropriate.

If the script has never been saved, then the SaveAs dialogue will be launched, and if that is cancelled, it will do the same as if the Cancel button is pressed on the initial dialogue.
