### PR TITLE
Read-only UI for Reference internals

### DIFF
--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -77,104 +77,131 @@ class Metadata
 		typedef boost::function<IECore::ConstDataPtr ( const Node *node )> NodeValueFunction;
 		typedef boost::function<IECore::ConstDataPtr ( const Plug *plug )> PlugValueFunction;
 
+		/// Value registration
+		/// ==================
+
 		/// Registers a static value.
 		static void registerValue( IECore::InternedString target, IECore::InternedString key, IECore::ConstDataPtr value );
 		/// Registers a dynamic value. Each time the data is retrieved, the ValueFunction will
 		/// be called to compute it.
 		static void registerValue( IECore::InternedString target, IECore::InternedString key, ValueFunction value );
-		/// Fills the keys vector with keys for all values registered with the methods above.
-		static void registeredValues( IECore::InternedString target, std::vector<IECore::InternedString> &keys );
-		/// Retrieves a value, returning NULL if none exists.
-		template<typename T>
-		static typename T::ConstPtr value( IECore::InternedString target, IECore::InternedString key );
 
 		/// Registers a static metadata value for the specified node type.
-		static void registerNodeValue( IECore::TypeId nodeTypeId, IECore::InternedString key, IECore::ConstDataPtr value );
+		static void registerValue( IECore::TypeId nodeTypeId, IECore::InternedString key, IECore::ConstDataPtr value );
 		/// Registers a dynamic metadata value for the specified node type. Each time the data is retrieved, the
 		/// NodeValueFunction will be called to compute it.
-		static void registerNodeValue( IECore::TypeId nodeTypeId, IECore::InternedString key, NodeValueFunction value );
+		static void registerValue( IECore::TypeId nodeTypeId, IECore::InternedString key, NodeValueFunction value );
+
+		/// Registers a static metadata value for plugs with the specified path on the specified node type.
+		static void registerValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value );
+		/// Registers a dynamic metadata value for the specified plug. Each time the data is retrieved, the
+		/// PlugValueFunction will be called to compute it.
+		static void registerValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, PlugValueFunction value );
+
 		/// Registers a metadata value specific to a single instance - this will take precedence over any
 		/// values registered above. If persistent is true, the value will be preserved across script save/load and cut/paste.
 		/// \undoable
-		static void registerNodeValue( Node *node, IECore::InternedString key, IECore::ConstDataPtr value, bool persistent = true );
+		static void registerValue( GraphComponent *target, IECore::InternedString key, IECore::ConstDataPtr value, bool persistent = true );
 
-		/// Fills the keys vector with keys for all values registered for the specified node. If instanceOnly is true,
-		/// then only the values registered for that exact instance are returned. If persistentOnly is true, then
-		/// non-persistent instance values are ignored.
-		static void registeredNodeValues( const Node *node, std::vector<IECore::InternedString> &keys, bool inherit = true, bool instanceOnly = false, bool persistentOnly = false );
+		/// Registration queries
+		/// ====================
 
-		/// Retrieves a previously registered value, returning NULL if none exists. If inherit is true
-		/// then the search falls through to the base classes of the node if the node itself doesn't have a value.
+		/// Fills the keys vector with keys for all values registered with the methods above.
+		static void registeredValues( IECore::InternedString target, std::vector<IECore::InternedString> &keys );
+		/// Fills the keys vector with keys for all values registered for the specified graphComponent.
+		/// If instanceOnly is true, then only the values registered for that exact instance are returned.
+		/// If persistentOnly is true, then non-persistent instance values are ignored.
+		static void registeredValues( const GraphComponent *target, std::vector<IECore::InternedString> &keys, bool inherit = true, bool instanceOnly = false, bool persistentOnly = false );
+
+		/// Value retrieval
+		/// ===============
+
+		/// Retrieves a value, returning NULL if none exists.
 		template<typename T>
-		static typename T::ConstPtr nodeValue( const Node *node, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
+		static typename T::ConstPtr value( IECore::InternedString target, IECore::InternedString key );
+		template<typename T>
+		static typename T::ConstPtr value( const GraphComponent *target, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
 
-		/// Deregisters a previously registered node value.
-		static void deregisterNodeValue( IECore::TypeId nodeTypeId, IECore::InternedString key );
-		/// Deregisters a previously registered node value.
-		/// \undoable
-		static void deregisterNodeValue( Node *node, IECore::InternedString key );
+		/// Value deregistration
+		/// ====================
 
-		/// Utility method calling registerNodeValue( nodeTypeId, "description", description ).
-		static void registerNodeDescription( IECore::TypeId nodeTypeId, const std::string &description );
-		static void registerNodeDescription( IECore::TypeId nodeTypeId, NodeValueFunction description );
-		/// Utility method calling nodeValue( node, "description", inherit );
-		static std::string nodeDescription( const Node *node, bool inherit = true );
+		static void deregisterValue( IECore::TypeId nodeTypeId, IECore::InternedString key );
+		static void deregisterValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key );
+		static void deregisterValue( GraphComponent *target, IECore::InternedString key );
+
+		/// Utilities
+		/// =========
 
 		/// Lists all node descendants of "root" with the specified metadata key. If inherit is true
 		/// then the search falls through to the base classes of the node if the node itself doesn't have a value,
 		/// and if instanceOnly is true the search is restricted to instance metadata.
 		static std::vector<Node*> nodesWithMetadata( GraphComponent *root, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
 
-		/// Registers a static metadata value for plugs with the specified path on the specified node type.
-		static void registerPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value );
-		/// Registers a dynamic metadata value for the specified plug. Each time the data is retrieved, the
-		/// PlugValueFunction will be called to compute it.
-		static void registerPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, PlugValueFunction value );
-		/// Registers a metadata value specific to a single instance - this will take precedence over any
-		/// values registered above. If persistent is true, the value will be preserved across script
-		/// save/load and cut/paste.
-		/// \undoable
-		static void registerPlugValue( Plug *plug, IECore::InternedString key, IECore::ConstDataPtr value, bool persistent = true );
-
-		/// Fills the keys vector with keys for all values registered for the specified plug. If instanceOnly is true,
-		/// then only the values registered for that exact instance are returned. If persistentOnly is true, then
-		/// non-persistent instance values are ignored.
-		static void registeredPlugValues( const Plug *plug, std::vector<IECore::InternedString> &keys, bool inherit = true, bool instanceOnly = false, bool persistentOnly = false );
-
-		/// Retrieves a previously registered value, returning NULL if none exists. If inherit is true
-		/// then the search falls through to the base classes of the node if the node itself doesn't have a value.
-		template<typename T>
-		static typename T::ConstPtr plugValue( const Plug *plug, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
-
-		/// Deregisters a previously registered plug value.
-		static void deregisterPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key );
-		/// Deregisters a previously registered plug value.
-		/// \undoable
-		static void deregisterPlugValue( Plug *plug, IECore::InternedString key );
-
-		/// Utility function calling registerPlugValue( nodeTypeId, plugPath, "description", description )
-		static void registerPlugDescription( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, const std::string &description );
-		static void registerPlugDescription( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, PlugValueFunction description );
-		/// Utility function calling plugValue( plug, "description", inherit )
-		static std::string plugDescription( const Plug *plug, bool inherit = true );
-
 		/// Lists all plug descendants of "root" with the specified metadata key. If inherit is true
 		/// then the search falls through to the base classes of the node if the node itself doesn't have a value,
 		/// and if instanceOnly is true the search is restricted to instance metadata.
 		static std::vector<Plug*> plugsWithMetadata( GraphComponent *root, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
 
-		/// @name Signals
+		/// Signals
+		/// =======
+		///
 		/// These are emitted when the Metadata has been changed with one
 		/// of the register*() methods. If dynamic metadata is registered
 		/// with a NodeValueFunction or PlugValueFunction then it is the
 		/// responsibility of the registrant to manually emit the signals
 		/// when necessary.
-		////////////////////////////////////////////////////////////////////
-		//@{
 		static ValueChangedSignal &valueChangedSignal();
 		static NodeValueChangedSignal &nodeValueChangedSignal();
 		static PlugValueChangedSignal &plugValueChangedSignal();
-		//@}
+
+		/// Deprecated
+		/// ==============
+
+		/// \deprecated
+		static void registerNodeValue( IECore::TypeId nodeTypeId, IECore::InternedString key, IECore::ConstDataPtr value );
+		/// \deprecated
+		static void registerNodeValue( IECore::TypeId nodeTypeId, IECore::InternedString key, NodeValueFunction value );
+		/// \deprecated
+		static void registerNodeValue( Node *node, IECore::InternedString key, IECore::ConstDataPtr value, bool persistent = true );
+		/// \deprecated
+		static void registeredNodeValues( const Node *node, std::vector<IECore::InternedString> &keys, bool inherit = true, bool instanceOnly = false, bool persistentOnly = false );
+		/// \deprecated
+		template<typename T>
+		static typename T::ConstPtr nodeValue( const Node *node, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
+		/// \deprecated
+		static void deregisterNodeValue( IECore::TypeId nodeTypeId, IECore::InternedString key );
+		/// \deprecated
+		static void deregisterNodeValue( Node *node, IECore::InternedString key );
+
+		/// \deprecated
+		static void registerPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value );
+		/// \deprecated
+		static void registerPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, PlugValueFunction value );
+		/// \deprecated
+		static void registerPlugValue( Plug *plug, IECore::InternedString key, IECore::ConstDataPtr value, bool persistent = true );
+		/// \deprecated
+		static void registeredPlugValues( const Plug *plug, std::vector<IECore::InternedString> &keys, bool inherit = true, bool instanceOnly = false, bool persistentOnly = false );
+		/// \deprecated
+		template<typename T>
+		static typename T::ConstPtr plugValue( const Plug *plug, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
+		/// \deprecated
+		static void deregisterPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key );
+		/// \deprecated
+		static void deregisterPlugValue( Plug *plug, IECore::InternedString key );
+
+		/// \deprecated
+		static void registerNodeDescription( IECore::TypeId nodeTypeId, const std::string &description );
+		/// \deprecated
+		static void registerNodeDescription( IECore::TypeId nodeTypeId, NodeValueFunction description );
+		/// \deprecated
+		static std::string nodeDescription( const Node *node, bool inherit = true );
+
+		/// \deprecated
+		static void registerPlugDescription( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, const std::string &description );
+		/// \deprecated
+		static void registerPlugDescription( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, PlugValueFunction description );
+		/// \deprecated
+		static std::string plugDescription( const Plug *plug, bool inherit = true );
 
 	private :
 
@@ -190,6 +217,7 @@ class Metadata
 		static void clearInstanceMetadata( const GraphComponent *graphComponent );
 
 		static IECore::ConstDataPtr valueInternal( IECore::InternedString target, IECore::InternedString key );
+		static IECore::ConstDataPtr valueInternal( const GraphComponent *target, IECore::InternedString key, bool inherit, bool instanceOnly );
 		static IECore::ConstDataPtr nodeValueInternal( const Node *node, IECore::InternedString key, bool inherit, bool instanceOnly );
 		static IECore::ConstDataPtr plugValueInternal( const Plug *plug, IECore::InternedString key, bool inherit, bool instanceOnly );
 

--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -111,7 +111,7 @@ class Metadata
 		/// Fills the keys vector with keys for all values registered for the specified graphComponent.
 		/// If instanceOnly is true, then only the values registered for that exact instance are returned.
 		/// If persistentOnly is true, then non-persistent instance values are ignored.
-		static void registeredValues( const GraphComponent *target, std::vector<IECore::InternedString> &keys, bool inherit = true, bool instanceOnly = false, bool persistentOnly = false );
+		static void registeredValues( const GraphComponent *target, std::vector<IECore::InternedString> &keys, bool instanceOnly = false, bool persistentOnly = false );
 
 		/// Value retrieval
 		/// ===============
@@ -120,7 +120,7 @@ class Metadata
 		template<typename T>
 		static typename T::ConstPtr value( IECore::InternedString target, IECore::InternedString key );
 		template<typename T>
-		static typename T::ConstPtr value( const GraphComponent *target, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
+		static typename T::ConstPtr value( const GraphComponent *target, IECore::InternedString key, bool instanceOnly = false );
 
 		/// Value deregistration
 		/// ====================
@@ -135,12 +135,12 @@ class Metadata
 		/// Lists all node descendants of "root" with the specified metadata key. If inherit is true
 		/// then the search falls through to the base classes of the node if the node itself doesn't have a value,
 		/// and if instanceOnly is true the search is restricted to instance metadata.
-		static std::vector<Node*> nodesWithMetadata( GraphComponent *root, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
+		static std::vector<Node*> nodesWithMetadata( GraphComponent *root, IECore::InternedString key, bool instanceOnly = false );
 
 		/// Lists all plug descendants of "root" with the specified metadata key. If inherit is true
 		/// then the search falls through to the base classes of the node if the node itself doesn't have a value,
 		/// and if instanceOnly is true the search is restricted to instance metadata.
-		static std::vector<Plug*> plugsWithMetadata( GraphComponent *root, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
+		static std::vector<Plug*> plugsWithMetadata( GraphComponent *root, IECore::InternedString key, bool instanceOnly = false );
 
 		/// Signals
 		/// =======
@@ -217,7 +217,7 @@ class Metadata
 		static void clearInstanceMetadata( const GraphComponent *graphComponent );
 
 		static IECore::ConstDataPtr valueInternal( IECore::InternedString target, IECore::InternedString key );
-		static IECore::ConstDataPtr valueInternal( const GraphComponent *target, IECore::InternedString key, bool inherit, bool instanceOnly );
+		static IECore::ConstDataPtr valueInternal( const GraphComponent *target, IECore::InternedString key, bool instanceOnly );
 		static IECore::ConstDataPtr nodeValueInternal( const Node *node, IECore::InternedString key, bool inherit, bool instanceOnly );
 		static IECore::ConstDataPtr plugValueInternal( const Plug *plug, IECore::InternedString key, bool inherit, bool instanceOnly );
 

--- a/include/Gaffer/Metadata.inl
+++ b/include/Gaffer/Metadata.inl
@@ -47,6 +47,12 @@ typename T::ConstPtr Metadata::value( IECore::InternedString target, IECore::Int
 }
 
 template<typename T>
+typename T::ConstPtr Metadata::value( const GraphComponent *target, IECore::InternedString key, bool inherit, bool instanceOnly )
+{
+	return IECore::runTimeCast<const T>( valueInternal( target, key, inherit, instanceOnly ) );
+}
+
+template<typename T>
 typename T::ConstPtr Metadata::nodeValue( const Node *node, IECore::InternedString key, bool inherit, bool instanceOnly )
 {
 	return IECore::runTimeCast<const T>( nodeValueInternal( node, key, inherit, instanceOnly ) );

--- a/include/Gaffer/Metadata.inl
+++ b/include/Gaffer/Metadata.inl
@@ -47,9 +47,9 @@ typename T::ConstPtr Metadata::value( IECore::InternedString target, IECore::Int
 }
 
 template<typename T>
-typename T::ConstPtr Metadata::value( const GraphComponent *target, IECore::InternedString key, bool inherit, bool instanceOnly )
+typename T::ConstPtr Metadata::value( const GraphComponent *target, IECore::InternedString key, bool instanceOnly )
 {
-	return IECore::runTimeCast<const T>( valueInternal( target, key, inherit, instanceOnly ) );
+	return IECore::runTimeCast<const T>( valueInternal( target, key, instanceOnly ) );
 }
 
 template<typename T>

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -37,10 +37,15 @@
 #ifndef GAFFER_METADATAALGO_H
 #define GAFFER_METADATAALGO_H
 
+#include "IECore/TypeIds.h"
+
+#include "Gaffer/StringAlgo.h"
+
 namespace Gaffer
 {
 
 class GraphComponent;
+class Plug;
 
 /// Read-only-ness
 /// ==============
@@ -74,6 +79,18 @@ bool getReadOnly( const GraphComponent *graphComponent );
 /// is inherited. This is the method that should be used to determine if a graphComponent
 /// should be editable by the user or not.
 bool readOnly( const GraphComponent *graphComponent );
+
+/// Utilities
+/// =========
+
+/// Utility to determine if a metadata value change (as signalled by `Metadata::plugValueChangedSignal()`)
+/// affects a given plug.
+bool affectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
+/// As above, but determines if any child plug will be affected.
+bool childAffectedByChange( const GraphComponent *parent, IECore::TypeId changedNodeTypeId, const MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
+/// As above, but determines if any ancestor plug will be affected. This is particularly useful in conjunction with
+/// the `readOnly()` method.
+bool ancestorAffectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
 
 } // namespace Gaffer
 

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -1,0 +1,80 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_METADATAALGO_H
+#define GAFFER_METADATAALGO_H
+
+namespace Gaffer
+{
+
+class GraphComponent;
+
+/// Read-only-ness
+/// ==============
+///
+/// The Gaffer API itself provides few restrictions about how and when a node graph
+/// can be edited. Methods such as `GraphComponent::acceptsChild()` and `Plug::acceptsInput()`
+/// do provide protection against the creation of totally invalid graphs, but beyond that
+/// all responsibility lies with the user.
+///
+/// The "readOnly" metadata improves this situation by providing a hint that the user should
+/// not be allowed to edit the target plug or node despite this underlying flexibility of the API.
+/// It can be set either by implementations to protect their internals, or directly by users
+/// to "lock" parts of their graph against modification by others.
+///
+/// In other words, the API itself provides hard constraints as to what _could_ be edited,
+/// and "readOnly" metadata provides a convention as to what _should_ be edited from a user
+/// standpoint.
+///
+/// > Note :
+/// >
+/// > The primary reason for implementing read-only-ness as a convention rather than a hard API
+/// > constraint is that many nodes use the API to modify their internals on the fly, even when
+/// > those nodes are read-only from a user perspective. For instance, a switch may modify internal
+/// > connections as part of its implementation, and needs to continue to do so even when
+/// > hosted inside a Reference (because the index may be promoted). In this scenario, the API
+/// > must allow edits, although the UI should not.
+
+void setReadOnly( GraphComponent *graphComponent, bool readOnly, bool persistent = true );
+bool getReadOnly( const GraphComponent *graphComponent );
+/// Takes into account the result of `getReadOnly()` for ancestors, so that read-only-ness
+/// is inherited. This is the method that should be used to determine if a graphComponent
+/// should be editable by the user or not.
+bool readOnly( const GraphComponent *graphComponent );
+
+} // namespace Gaffer
+
+#endif // GAFFER_METADATAALGO_H

--- a/include/Gaffer/Plug.h
+++ b/include/Gaffer/Plug.h
@@ -106,6 +106,7 @@ class Plug : public GraphComponent
 			/// an exception if an attempt is made to call their setValue() method. It is
 			/// not valid to make an output plug read only - in the case of an attempt to
 			/// do so an exception will be thrown from setFlags().
+			/// \deprecated Use MetadataAlgo instead.
 			ReadOnly = 0x00000020,
 			/// Generally it is an error to have cyclic dependencies between plugs,
 			/// and creating them will cause an exception to be thrown during dirty

--- a/include/GafferBindings/MetadataAlgoBinding.h
+++ b/include/GafferBindings/MetadataAlgoBinding.h
@@ -1,0 +1,49 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERBINDINGS_METADATAALGOBINDING_H
+#define GAFFERBINDINGS_METADATAALGOBINDING_H
+
+#include "Gaffer/Node.h"
+
+namespace GafferBindings
+{
+
+void bindMetadataAlgo();
+
+} // namespace GafferBindings
+
+#endif // GAFFERBINDINGS_METADATAALGOBINDING_H

--- a/include/GafferBindings/NodeBinding.h
+++ b/include/GafferBindings/NodeBinding.h
@@ -136,15 +136,15 @@ class NodeSerialiser : public Serialisation::Serialiser
 
 	public :
 
-		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules ) const;
+		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const;
 		/// Implemented to serialise per-instance metadata.
 		virtual std::string postHierarchy( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const;
 		/// Implemented so that only plugs are serialised - child nodes are expected to
 		/// be a part of the implementation of the node rather than something the user
 		/// has created themselves.
-		virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child ) const;
+		virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const;
 		/// Implemented so that dynamic plugs are constructed appropriately.
-		virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child ) const;
+		virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const;
 
 };
 

--- a/include/GafferBindings/PlugBinding.h
+++ b/include/GafferBindings/PlugBinding.h
@@ -141,10 +141,10 @@ class PlugSerialiser : public Serialisation::Serialiser
 
 	public :
 
-		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules ) const;
+		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const;
 		virtual std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const;
 		virtual std::string postHierarchy( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const;
-		virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child ) const;
+		virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const;
 
 		static std::string directionRepr( Gaffer::Plug::Direction direction );
 		static std::string flagsRepr( unsigned flags );

--- a/include/GafferBindings/Serialisation.h
+++ b/include/GafferBindings/Serialisation.h
@@ -86,7 +86,7 @@ class Serialisation
 
 				/// Should be implemented to insert the names of any modules the serialiser will need
 				/// into the modules set. The default implementation returns modulePath( graphComponent ).
-				virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules ) const;
+				virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const;
 				/// Should be implemented to return a string which when executed will reconstruct the specified object.
 				/// The default implementation uses repr().
 				virtual std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const;
@@ -104,11 +104,11 @@ class Serialisation
 				virtual std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const;
 				/// May be implemented to say whether or not the child needs to be serialised. The default
 				/// implementation returns true.
-				virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child ) const;
+				virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const;
 				/// May be implemented to say whether or not the child needs to be constructed explicitly by the serialisation,
 				/// or it will be created by the parent automatically on construction of the parent. Default
 				/// implementation returns false.
-				virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child ) const;
+				virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const;
 
 		};
 

--- a/include/GafferBindings/ValuePlugBinding.h
+++ b/include/GafferBindings/ValuePlugBinding.h
@@ -58,7 +58,7 @@ class ValuePlugSerialiser : public PlugSerialiser
 
 	public :
 
-		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules ) const;
+		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const;
 		virtual std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const;
 		virtual std::string postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const;
 

--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -67,7 +67,7 @@ class GraphGadget : public ContainerGadget
 		/// Creates a graph showing the children of root, optionally
 		/// filtered by the specified set. Nodes are only displayed if
 		/// they are both a child of root and a member of filter.
-		GraphGadget( Gaffer::NodePtr root, Gaffer::SetPtr filter = 0 );
+		GraphGadget( Gaffer::NodePtr root, Gaffer::SetPtr filter = NULL );
 
 		virtual ~GraphGadget();
 
@@ -75,24 +75,24 @@ class GraphGadget : public ContainerGadget
 
 		Gaffer::Node *getRoot();
 		const Gaffer::Node *getRoot() const;
-		void setRoot( Gaffer::NodePtr root, Gaffer::SetPtr filter = 0 );
+		void setRoot( Gaffer::NodePtr root, Gaffer::SetPtr filter = NULL );
 		typedef boost::signal<void ( GraphGadget *, Gaffer::Node * )> RootChangedSignal;
 		/// A signal emitted when the root has been changed - the signature
 		/// of the signal is ( graphGadget, previousRoot ).
 		RootChangedSignal &rootChangedSignal();
 
-		/// May return 0 if no filter has been specified.
+		/// May return NULL if no filter has been specified.
 		Gaffer::Set *getFilter();
 		const Gaffer::Set *getFilter() const;
 		void setFilter( Gaffer::SetPtr filter );
 
-		/// Returns the NodeGadget representing the specified node or 0
+		/// Returns the NodeGadget representing the specified node or NULL
 		/// if none exists.
 		NodeGadget *nodeGadget( const Gaffer::Node *node );
 		const NodeGadget *nodeGadget( const Gaffer::Node *node ) const;
 
 		/// Returns the ConnectionGadget representing the specified
-		/// destination Plug or 0 if none exists.
+		/// destination Plug or NULL if none exists.
 		ConnectionGadget *connectionGadget( const Gaffer::Plug *dstPlug );
 		const ConnectionGadget *connectionGadget( const Gaffer::Plug *dstPlug ) const;
 
@@ -100,15 +100,15 @@ class GraphGadget : public ContainerGadget
 		/// to the specified plug and appends them to the connections vector.
 		/// Returns the new size of the vector. If excludedNodes is specified,
 		/// then connections to any nodes it contains will be ignored.
-		size_t connectionGadgets( const Gaffer::Plug *plug, std::vector<ConnectionGadget *> &connections, const Gaffer::Set *excludedNodes = 0 );
-		size_t connectionGadgets( const Gaffer::Plug *plug, std::vector<const ConnectionGadget *> &connections, const Gaffer::Set *excludedNodes = 0 ) const;
+		size_t connectionGadgets( const Gaffer::Plug *plug, std::vector<ConnectionGadget *> &connections, const Gaffer::Set *excludedNodes = NULL );
+		size_t connectionGadgets( const Gaffer::Plug *plug, std::vector<const ConnectionGadget *> &connections, const Gaffer::Set *excludedNodes = NULL ) const;
 
 		/// Finds all the ConnectionGadgets connected to the specified node and
 		/// appends them to the connections vector. Returns the new size of the
 		/// vector. If excludedNodes is specified, then connections to any
 		/// nodes it contains will be ignored.
-		size_t connectionGadgets( const Gaffer::Node *node, std::vector<ConnectionGadget *> &connections, const Gaffer::Set *excludedNodes = 0 );
-		size_t connectionGadgets( const Gaffer::Node *node, std::vector<const ConnectionGadget *> &connections, const Gaffer::Set *excludedNodes = 0 ) const;
+		size_t connectionGadgets( const Gaffer::Node *node, std::vector<ConnectionGadget *> &connections, const Gaffer::Set *excludedNodes = NULL );
+		size_t connectionGadgets( const Gaffer::Node *node, std::vector<const ConnectionGadget *> &connections, const Gaffer::Set *excludedNodes = NULL ) const;
 
 		/// Finds all the upstream NodeGadgets connected to the specified node
 		/// and appends them to the specified vector. Returns the new size of the vector.

--- a/python/Gaffer/NodeAlgo.py
+++ b/python/Gaffer/NodeAlgo.py
@@ -53,11 +53,11 @@ import Gaffer
 def presets( plug ) :
 
 	result = []
-	for n in Gaffer.Metadata.registeredPlugValues( plug ) :
+	for n in Gaffer.Metadata.registeredValues( plug ) :
 		if n.startswith( "preset:" ) :
 			result.append( n[7:] )
 
-	result.extend( Gaffer.Metadata.plugValue( plug, "presetNames" ) or [] )
+	result.extend( Gaffer.Metadata.value( plug, "presetNames" ) or [] )
 
 	return result
 
@@ -70,17 +70,17 @@ def currentPreset( plug ) :
 
 	value = plug.getValue()
 	failedNames = set()
-	for n in Gaffer.Metadata.registeredPlugValues( plug ) :
+	for n in Gaffer.Metadata.registeredValues( plug ) :
 		if n.startswith( "preset:" ) :
 			presetName = n[7:]
-			if Gaffer.Metadata.plugValue( plug, n ) == value :
+			if Gaffer.Metadata.value( plug, n ) == value :
 				return presetName
 			else :
 				failedNames.add( presetName )
 
-	presetNames = Gaffer.Metadata.plugValue( plug, "presetNames" )
+	presetNames = Gaffer.Metadata.value( plug, "presetNames" )
 	if presetNames is not None :
-		for presetName, presetValue in zip( presetNames, Gaffer.Metadata.plugValue( plug, "presetValues" ) ) :
+		for presetName, presetValue in zip( presetNames, Gaffer.Metadata.value( plug, "presetValues" ) ) :
 			if value == presetValue and presetName not in failedNames :
 				return presetName
 
@@ -89,10 +89,10 @@ def currentPreset( plug ) :
 ## Applies the named preset to the plug.
 def applyPreset( plug, presetName ) :
 
-	value = Gaffer.Metadata.plugValue( plug, "preset:" + presetName )
+	value = Gaffer.Metadata.value( plug, "preset:" + presetName )
 	if value is None :
-		presetNames = Gaffer.Metadata.plugValue( plug, "presetNames" )
-		presetValues = Gaffer.Metadata.plugValue( plug, "presetValues" )
+		presetNames = Gaffer.Metadata.value( plug, "presetNames" )
+		presetValues = Gaffer.Metadata.value( plug, "presetValues" )
 		value = presetValues[presetNames.index( presetName )]
 
 	plug.setValue( value )
@@ -112,14 +112,14 @@ def applyUserDefaults( nodeOrNodes ) :
 
 def hasUserDefault( plug ) :
 
-	return Gaffer.Metadata.plugValue( plug, "userDefault" ) is not None
+	return Gaffer.Metadata.value( plug, "userDefault" ) is not None
 
 def isSetToUserDefault( plug ) :
 
 	if not hasattr( plug, "getValue" ) :
 		return False
 
-	userDefault = Gaffer.Metadata.plugValue( plug, "userDefault" )
+	userDefault = Gaffer.Metadata.value( plug, "userDefault" )
 	if userDefault is None :
 		return False
 
@@ -132,7 +132,7 @@ def applyUserDefault( plug ) :
 def __applyUserDefaults( graphComponent ) :
 
 	if isinstance( graphComponent, Gaffer.Plug ) :
-		plugValue = Gaffer.Metadata.plugValue( graphComponent, "userDefault" )
+		plugValue = Gaffer.Metadata.value( graphComponent, "userDefault" )
 		if plugValue is not None :
 			graphComponent.setValue( plugValue )
 

--- a/python/GafferArnoldUI/ArnoldMeshLightUI.py
+++ b/python/GafferArnoldUI/ArnoldMeshLightUI.py
@@ -41,7 +41,7 @@ import GafferArnold
 
 def __shaderMetadata( plug, name ) :
 
-	return Gaffer.Metadata.plugValue( plug.node()["__shader"].descendant( plug.relativeName( plug.node() ) ), name )
+	return Gaffer.Metadata.value( plug.node()["__shader"].descendant( plug.relativeName( plug.node() ) ), name )
 
 Gaffer.Metadata.registerNode(
 

--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -376,12 +376,12 @@ for nodeType in ( GafferArnold.ArnoldShader, GafferArnold.ArnoldLight ) :
 		keys.update( metadata.keys() )
 
 	for key in nodeKeys :
-		Gaffer.Metadata.registerNodeValue( nodeType, key, functools.partial( __nodeMetadata, name = key ) )
+		Gaffer.Metadata.registerValue( nodeType, key, functools.partial( __nodeMetadata, name = key ) )
 
 	for key in parametersPlugKeys :
-		Gaffer.Metadata.registerPlugValue( nodeType, "parameters", key, functools.partial( __plugMetadata, name = key ) )
+		Gaffer.Metadata.registerValue( nodeType, "parameters", key, functools.partial( __plugMetadata, name = key ) )
 
 	for key in parameterPlugKeys :
-		Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", key, functools.partial( __plugMetadata, name = key ) )
+		Gaffer.Metadata.registerValue( nodeType, "parameters.*", key, functools.partial( __plugMetadata, name = key ) )
 
-	Gaffer.Metadata.registerNodeValue( nodeType, "description", __nodeDescription )
+	Gaffer.Metadata.registerValue( nodeType, "description", __nodeDescription )

--- a/python/GafferArnoldUITest/ArnoldShaderUITest.py
+++ b/python/GafferArnoldUITest/ArnoldShaderUITest.py
@@ -49,33 +49,33 @@ class ArnoldShaderUITest( GafferUITest.TestCase ) :
 		shader.loadShader( "noise" )
 
 		self.assertEqual(
-			Gaffer.Metadata.plugValue( shader["parameters"]["octaves"], "nodule:type" ),
+			Gaffer.Metadata.value( shader["parameters"]["octaves"], "nodule:type" ),
 			""
 		)
 
 		self.assertEqual(
-			Gaffer.Metadata.plugValue( shader["parameters"]["amplitude"], "nodule:type" ),
+			Gaffer.Metadata.value( shader["parameters"]["amplitude"], "nodule:type" ),
 			"GafferUI::StandardNodule"
 		)
 
 		self.assertEqual(
-			Gaffer.Metadata.plugValue( shader["parameters"]["octaves"], "plugValueWidget:type" ),
+			Gaffer.Metadata.value( shader["parameters"]["octaves"], "plugValueWidget:type" ),
 			None
 		)
 
 		self.assertEqual(
-			Gaffer.Metadata.plugValue( shader["parameters"]["coord_space"], "plugValueWidget:type" ),
+			Gaffer.Metadata.value( shader["parameters"]["coord_space"], "plugValueWidget:type" ),
 			"GafferUI.PresetsPlugValueWidget"
 		)
 
 		self.assertEqual(
-			Gaffer.Metadata.plugValue( shader["parameters"]["coord_space"], "presetNames" ),
+			Gaffer.Metadata.value( shader["parameters"]["coord_space"], "presetNames" ),
 			IECore.StringVectorData( [ "world", "object", "Pref" ] ),
 		)
 
 		self.assertEqual(
-			Gaffer.Metadata.plugValue( shader["parameters"]["coord_space"], "presetValues" ),
-			Gaffer.Metadata.plugValue( shader["parameters"]["coord_space"], "presetNames" ),
+			Gaffer.Metadata.value( shader["parameters"]["coord_space"], "presetValues" ),
+			Gaffer.Metadata.value( shader["parameters"]["coord_space"], "presetNames" ),
 		)
 
 	def testLightMetadata( self ) :
@@ -96,28 +96,28 @@ class ArnoldShaderUITest( GafferUITest.TestCase ) :
 			self.assertTrue( "Unsupported parameter" in message.message )
 
 		self.assertEqual(
-			Gaffer.Metadata.plugValue( light["parameters"]["cast_shadows"], "nodule:type" ),
+			Gaffer.Metadata.value( light["parameters"]["cast_shadows"], "nodule:type" ),
 			""
 		)
 
 		self.assertEqual(
-			Gaffer.Metadata.plugValue( light["parameters"]["color"], "nodule:type" ),
+			Gaffer.Metadata.value( light["parameters"]["color"], "nodule:type" ),
 			"GafferUI::StandardNodule"
 		)
 
 		self.assertEqual(
-			Gaffer.Metadata.plugValue( light["parameters"]["format"], "plugValueWidget:type" ),
+			Gaffer.Metadata.value( light["parameters"]["format"], "plugValueWidget:type" ),
 			"GafferUI.PresetsPlugValueWidget"
 		)
 
 		self.assertEqual(
-			Gaffer.Metadata.plugValue( light["parameters"]["format"], "presetNames" ),
+			Gaffer.Metadata.value( light["parameters"]["format"], "presetNames" ),
 			IECore.StringVectorData( [ "mirrored_ball", "angular", "latlong" ] ),
 		)
 
 		self.assertEqual(
-			Gaffer.Metadata.plugValue( light["parameters"]["format"], "presetValues" ),
-			Gaffer.Metadata.plugValue( light["parameters"]["format"], "presetNames" ),
+			Gaffer.Metadata.value( light["parameters"]["format"], "presetValues" ),
+			Gaffer.Metadata.value( light["parameters"]["format"], "presetNames" ),
 		)
 
 if __name__ == "__main__":

--- a/python/GafferCortexUI/FileSequenceParameterValueWidget.py
+++ b/python/GafferCortexUI/FileSequenceParameterValueWidget.py
@@ -100,5 +100,5 @@ def __includeFrameRange( plug ) :
 	return includeFrameRange
 
 for nodeType in __nodeTypes :
-	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "fileSystemPathPlugValueWidget:includeSequences", __isFileSequence )
-	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "fileSystemPathPlugValueWidget:includeSequenceFrameRange", __includeFrameRange )
+	Gaffer.Metadata.registerValue( nodeType, "parameters.*", "fileSystemPathPlugValueWidget:includeSequences", __isFileSequence )
+	Gaffer.Metadata.registerValue( nodeType, "parameters.*", "fileSystemPathPlugValueWidget:includeSequenceFrameRange", __includeFrameRange )

--- a/python/GafferCortexUI/OpDialogue.py
+++ b/python/GafferCortexUI/OpDialogue.py
@@ -484,7 +484,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 
 		if isinstance( graphComponent, Gaffer.Plug ) and hasattr( graphComponent, "getValue" ) :
 			with IECore.IgnoredExceptions( Exception ) :
-				Gaffer.Metadata.registerPlugValue( graphComponent, "userDefault", graphComponent.getValue() )
+				Gaffer.Metadata.registerValue( graphComponent, "userDefault", graphComponent.getValue() )
 
 		for child in graphComponent.children() :
 			self.__setUserDefaults( child )

--- a/python/GafferCortexUI/ParameterisedHolderUI.py
+++ b/python/GafferCortexUI/ParameterisedHolderUI.py
@@ -134,7 +134,7 @@ class _InfoButton( GafferUI.Button ) :
 		context = self.__node.scriptNode().context() if self.__node.scriptNode() else Gaffer.Context.current()
 		with context :
 			result = Gaffer.Metadata.nodeDescription( self.__node )
-			summary = Gaffer.Metadata.nodeValue( self.__node, "summary" )
+			summary = Gaffer.Metadata.value( self.__node, "summary" )
 
 		if summary :
 			if result :

--- a/python/GafferCortexUI/StringParameterValueWidget.py
+++ b/python/GafferCortexUI/StringParameterValueWidget.py
@@ -103,4 +103,4 @@ def __fixedLineHeight( plug ) :
 	return fixedLineHeight
 
 for nodeType in __nodeTypes:
-	Gaffer.Metadata.registerPlugValue( nodeType, "*", "fixedLineHeight", __fixedLineHeight )
+	Gaffer.Metadata.registerValue( nodeType, "*", "fixedLineHeight", __fixedLineHeight )

--- a/python/GafferDispatchUI/DispatcherUI.py
+++ b/python/GafferDispatchUI/DispatcherUI.py
@@ -411,7 +411,7 @@ class _FramesModePlugValueWidget( GafferUI.PlugValueWidget ) :
 		label = selectionMenu.getSelection()[0]
 		value = self.__labelsAndValues[ selectionMenu.index( label ) ][1]
 
-		Gaffer.Metadata.registerNodeValue(
+		Gaffer.Metadata.registerValue(
 			self.getPlug().node(),
 			"layout:activator:customRange",
 			label == "CustomRange",
@@ -440,7 +440,7 @@ class _FramesModePlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__updateFrameRangeConnection = playback.frameRangeChangedSignal().connect( Gaffer.WeakMethod( self.__playbackFrameRangeChanged ) )
 			self.__playbackFrameRangeChanged( playback )
 		else :
-			frameRange = Gaffer.Metadata.plugValue( self.getPlug(), "dispatcherWindow:frameRange", inherit=False )
+			frameRange = Gaffer.Metadata.value( self.getPlug(), "dispatcherWindow:frameRange", inherit=False )
 			if frameRange is not None :
 				self.getPlug().node()["frameRange"].setValue( frameRange )
 			self.__updateFrameRangeConnection = self.getPlug().node().plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__customFrameRangeChanged ) )
@@ -480,7 +480,7 @@ class _FramesModePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		if plug.isSame( self.getPlug().node()["frameRange"] ) :
 			with self.getContext() :
-				Gaffer.Metadata.registerPlugValue( self.getPlug(), "dispatcherWindow:frameRange", plug.getValue() )
+				Gaffer.Metadata.registerValue( self.getPlug(), "dispatcherWindow:frameRange", plug.getValue() )
 
 class _FrameRangePlugValueWidget( GafferUI.StringPlugValueWidget ) :
 

--- a/python/GafferImageTest/ImageProcessorTest.py
+++ b/python/GafferImageTest/ImageProcessorTest.py
@@ -89,7 +89,7 @@ class ImageProcessorTest( GafferImageTest.ImageTestCase ) :
 		self.assertTrue( "A" in n["out"]["channelNames"].getValue() )
 
 		self.assertEqual(
-			Gaffer.Metadata.nodeValue( n, "description" ),
+			Gaffer.Metadata.value( n, "description" ),
 			"Deletes the alpha channel.",
 		)
 

--- a/python/GafferImageUI/FormatPlugValueWidget.py
+++ b/python/GafferImageUI/FormatPlugValueWidget.py
@@ -95,7 +95,7 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 		mode = "standard"
 		if self.getPlug() is not None :
 
-			mode = Gaffer.Metadata.plugValue( self.getPlug(), "formatPlugValueWidget:mode" )
+			mode = Gaffer.Metadata.value( self.getPlug(), "formatPlugValueWidget:mode" )
 			with self.getContext() :
 				fmt = self.getPlug().getValue()
 
@@ -133,7 +133,7 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 			formats.insert( 0, GafferImage.Format() )
 
 		currentFormat = self.getPlug().getValue()
-		modeIsCustom = Gaffer.Metadata.plugValue( self.getPlug(), "formatPlugValueWidget:mode" ) == "custom"
+		modeIsCustom = Gaffer.Metadata.value( self.getPlug(), "formatPlugValueWidget:mode" ) == "custom"
 		for fmt in formats :
 			result.append(
 				"/" + self.__formatLabel( fmt ),
@@ -169,7 +169,7 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __applyFormat( self, unused, fmt ) :
 
 		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
-			Gaffer.Metadata.registerPlugValue( self.getPlug(), "formatPlugValueWidget:mode", "standard", persistent = False )
+			Gaffer.Metadata.registerValue( self.getPlug(), "formatPlugValueWidget:mode", "standard", persistent = False )
 			self.getPlug().setValue( fmt )
 
 	def __applyCustomFormat( self, unused ) :
@@ -190,7 +190,7 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 			# custom mode despite of this fact. We use metadata rather than
 			# a member variable so that undo will take us back to the non-custom
 			# state automatically.
-			Gaffer.Metadata.registerPlugValue( self.getPlug(), "formatPlugValueWidget:mode", "custom", persistent = False )
+			Gaffer.Metadata.registerValue( self.getPlug(), "formatPlugValueWidget:mode", "custom", persistent = False )
 
 	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
 

--- a/python/GafferImageUI/FormatPlugValueWidget.py
+++ b/python/GafferImageUI/FormatPlugValueWidget.py
@@ -69,7 +69,6 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__pixelAspectWidget = GafferUI.NumericPlugValueWidget( plug["pixelAspect"] )
 		grid[1,3] = self.__pixelAspectWidget
 
-		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
 		# If the plug hasn't got an input, the PlugValueWidget base class assumes we're not
 		# sensitive to contex changes and omits calls to _updateFromPlug(). But the default
 		# format mechanism uses the context, so we must arrange to do updates ourselves when
@@ -191,17 +190,6 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 			# a member variable so that undo will take us back to the non-custom
 			# state automatically.
 			Gaffer.Metadata.registerValue( self.getPlug(), "formatPlugValueWidget:mode", "custom", persistent = False )
-
-	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
-
-		if self.getPlug() is None or plug is None :
-			return
-
-		if not self.getPlug().isSame( plug ) :
-			return
-
-		if key == "formatPlugValueWidget:mode" :
-			self._updateFromPlug()
 
 	def __contextChanged( self, context, key ) :
 

--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -149,7 +149,7 @@ class _TogglePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		GafferUI.PlugValueWidget.__init__( self, row, plug, **kw )
 
-		self.__imagePrefix = Gaffer.Metadata.plugValue( plug, "togglePlugValueWidget:imagePrefix" )
+		self.__imagePrefix = Gaffer.Metadata.value( plug, "togglePlugValueWidget:imagePrefix" )
 		with row :
 
 			self.__button = GafferUI.Button( "", self.__imagePrefix + "Off.png", hasFrame=False )
@@ -159,7 +159,7 @@ class _TogglePlugValueWidget( GafferUI.PlugValueWidget ) :
 				plugValueWidget = GafferUI.PlugValueWidget.create( plug, useTypeOnly=True )
 				plugValueWidget.numericWidget().setFixedCharacterWidth( 5 )
 
-		self.__toggleValue = Gaffer.Metadata.plugValue( plug, "togglePlugValueWidget:defaultToggleValue" )
+		self.__toggleValue = Gaffer.Metadata.value( plug, "togglePlugValueWidget:defaultToggleValue" )
 		self._updateFromPlug()
 
 	def hasLabel( self ) :

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -167,15 +167,16 @@ class _ParametersFooter( GafferUI.PlugValueWidget ) :
 
 				GafferUI.Spacer( IECore.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 
-				GafferUI.MenuButton(
+				menuButton = GafferUI.MenuButton(
 					image = "plus.png",
 					hasFrame = False,
 					menu = GafferUI.Menu(
 						Gaffer.WeakMethod( self.__menuDefinition ),
 						title = "Add " + ( "Input" if plug.direction() == plug.Direction.In else "Output" )
 					),
-					toolTip = "Add " + ( "Input" if plug.direction() == plug.Direction.In else "Output" )
+					toolTip = "Add " + ( "Input" if plug.direction() == plug.Direction.In else "Output" ),
 				)
+				menuButton.setEnabled( not Gaffer.readOnly( plug ) )
 
 				GafferUI.Spacer( IECore.V2i( 1 ), IECore.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
@@ -322,7 +323,13 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 	if plug.parent() in ( node["parameters"], node["out"] ) :
 
 		menuDefinition.append( "/DeleteDivider", { "divider" : True } )
-		menuDefinition.append( "/Delete", { "command" : IECore.curry( __deletePlug, plug ), "active" : not plugValueWidget.getReadOnly() } )
+		menuDefinition.append(
+			"/Delete",
+			{
+				"command" : IECore.curry( __deletePlug, plug ),
+				"active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug )
+			}
+		)
 
 	elif plug.isSame( node["code"] ) :
 
@@ -400,7 +407,10 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 
 			menuDefinition.prepend(
 				"/Insert" + label,
-				{ "command" : functools.partial( plugValueWidget.textWidget().insertText, text ) },
+				{
+					"command" : functools.partial( plugValueWidget.textWidget().insertText, text ),
+					"active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug ),
+				},
 			)
 
 __plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )

--- a/python/GafferRenderManUI/RenderManShaderUI.py
+++ b/python/GafferRenderManUI/RenderManShaderUI.py
@@ -85,7 +85,7 @@ def __parametersPlugValueWidgetCreator( plug ) :
 	for name, value in annotations.items() :
 		m = collapsedRe.match( name )
 		if m :
-			Gaffer.Metadata.registerPlugValue(
+			Gaffer.Metadata.registerValue(
 				plug,
 				"layout:section:" + m.group( 1 ) + ":collapsed",
 				value in ( "True", "true", "1" ),
@@ -108,7 +108,7 @@ def __parametersPlugValueWidgetCreator( plug ) :
 			elif name.endswith( "Positions" ) and name[:-9] + "Values" in shader.parameters :
 				continue
 			if name in plug :
-				Gaffer.Metadata.registerPlugValue( plug[name], "layout:index", index, persistent = False )
+				Gaffer.Metadata.registerValue( plug[name], "layout:index", index, persistent = False )
 				index += 1
 
 	# Now we've created the appropriate metadata, we can just defer to a standard LayoutPlugValueWidget
@@ -410,10 +410,10 @@ Gaffer.Metadata.registerNode(
 
 for nodeType in( GafferRenderMan.RenderManShader, GafferRenderMan.RenderManLight ) :
 
-	Gaffer.Metadata.registerPlugValue( nodeType, "parameters", "layout:activators", __parameterActivators )
-	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "description", __plugDescription )
-	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "label", __plugLabel )
-	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "layout:divider", __plugDivider )
-	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "ui:visibleDimensions", __plugVisibleDimensions )
-	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "layout:section", __plugSection )
-	Gaffer.Metadata.registerPlugValue( nodeType, "parameters.*", "layout:activator", __plugActivator )
+	Gaffer.Metadata.registerValue( nodeType, "parameters", "layout:activators", __parameterActivators )
+	Gaffer.Metadata.registerValue( nodeType, "parameters.*", "description", __plugDescription )
+	Gaffer.Metadata.registerValue( nodeType, "parameters.*", "label", __plugLabel )
+	Gaffer.Metadata.registerValue( nodeType, "parameters.*", "layout:divider", __plugDivider )
+	Gaffer.Metadata.registerValue( nodeType, "parameters.*", "ui:visibleDimensions", __plugVisibleDimensions )
+	Gaffer.Metadata.registerValue( nodeType, "parameters.*", "layout:section", __plugSection )
+	Gaffer.Metadata.registerValue( nodeType, "parameters.*", "layout:activator", __plugActivator )

--- a/python/GafferSceneTest/AttributeVisualiserTest.py
+++ b/python/GafferSceneTest/AttributeVisualiserTest.py
@@ -119,7 +119,7 @@ class AttributeVisualiserTest( GafferSceneTest.SceneTestCase ) :
 		shader2 = GafferSceneTest.TestShader()
 		shader2["name"].setValue( "test" )
 		shader2["type"].setValue( "gfr:surface" )
-		Gaffer.Metadata.registerNodeValue( shader2, "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
+		Gaffer.Metadata.registerValue( shader2, "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
 
 		filter2 = GafferScene.PathFilter()
 		filter2["paths"].setValue( IECore.StringVectorData( [ "/group/sphere2" ] ) )

--- a/python/GafferSceneTest/SceneNodeTest.py
+++ b/python/GafferSceneTest/SceneNodeTest.py
@@ -263,12 +263,12 @@ class SceneNodeTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( n["out"].childNames( "/"), IECore.InternedStringVectorData() )
 
 		self.assertEqual(
-			Gaffer.Metadata.nodeValue( n, "description" ),
+			Gaffer.Metadata.value( n, "description" ),
 			"A little test node",
 		)
 
 		self.assertEqual(
-			Gaffer.Metadata.plugValue( n["type"], "description" ),
+			Gaffer.Metadata.value( n["type"], "description" ),
 			"Pick yer lovely primitive here.",
 		)
 

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -106,7 +106,7 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 
 		cs = GafferTest.CapturingSlot( s.plugDirtiedSignal() )
 
-		Gaffer.Metadata.registerNodeValue( s, "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
+		Gaffer.Metadata.registerValue( s, "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
 
 		self.assertTrue( s["out"] in [ x[0] for x in cs ] )
 

--- a/python/GafferSceneUI/CustomAttributesUI.py
+++ b/python/GafferSceneUI/CustomAttributesUI.py
@@ -136,7 +136,7 @@ def __attributePopupMenu( menuDefinition, plugValueWidget ) :
 			{
 				"command" : functools.partial( __setValue, plug, " ".join( sorted( newNames ) ) ),
 				"checkBox" : attributeName in currentNames,
-				"active" : plug.settable() and not plugValueWidget.getReadOnly(),
+				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug ),
 			}
 		)
 

--- a/python/GafferSceneUI/CustomAttributesUI.py
+++ b/python/GafferSceneUI/CustomAttributesUI.py
@@ -89,8 +89,8 @@ def __attributePopupMenu( menuDefinition, plugValueWidget ) :
 	if plug is None :
 		return
 
-	acceptsAttributeName = Gaffer.Metadata.plugValue( plug, "ui:scene:acceptsAttributeName" )
-	acceptsAttributeNames = Gaffer.Metadata.plugValue( plug, "ui:scene:acceptsAttributeNames" )
+	acceptsAttributeName = Gaffer.Metadata.value( plug, "ui:scene:acceptsAttributeName" )
+	acceptsAttributeNames = Gaffer.Metadata.value( plug, "ui:scene:acceptsAttributeNames" )
 	if not acceptsAttributeName and not acceptsAttributeNames :
 		return
 

--- a/python/GafferSceneUI/DeleteGlobalsUI.py
+++ b/python/GafferSceneUI/DeleteGlobalsUI.py
@@ -125,7 +125,7 @@ def __namesPopupMenu( menuDefinition, plugValueWidget ) :
 			menuPrefix + nameWithoutPrefix,
 			{
 				"command" : IECore.curry( __toggleName, plug, nameWithoutPrefix ),
-				"active" : plug.settable() and not plugValueWidget.getReadOnly(),
+				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug ),
 				"checkBox" : nameWithoutPrefix in currentNames,
 			}
 		)

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -110,7 +110,7 @@ __originalDragPointer = None
 def __pathsPlug( node ) :
 
 	for plug in node.children( Gaffer.Plug ) :
-		if Gaffer.Metadata.plugValue( plug, "ui:scene:acceptsPaths" ) :
+		if Gaffer.Metadata.value( plug, "ui:scene:acceptsPaths" ) :
 			return plug
 
 	return None

--- a/python/GafferSceneUI/ScenePathPlugValueWidget.py
+++ b/python/GafferSceneUI/ScenePathPlugValueWidget.py
@@ -45,11 +45,11 @@ class ScenePathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 		if path is None :
 
 			filter = None
-			sets = Gaffer.Metadata.plugValue( plug, "scenePathPlugValueWidget:setNames" )
+			sets = Gaffer.Metadata.value( plug, "scenePathPlugValueWidget:setNames" )
 			if sets :
 				filter = GafferScene.ScenePath.createStandardFilter(
 					list( sets ),
-					Gaffer.Metadata.plugValue( plug, "scenePathPlugValueWidget:setsLabel" )
+					Gaffer.Metadata.value( plug, "scenePathPlugValueWidget:setsLabel" )
 				)
 
 			path = GafferScene.ScenePath(

--- a/python/GafferSceneUI/SceneReaderUI.py
+++ b/python/GafferSceneUI/SceneReaderUI.py
@@ -156,7 +156,7 @@ def __tagsPopupMenu( menuDefinition, plugValueWidget ) :
 			{
 				"command" : IECore.curry( __toggleTag, plug, tag ),
 				"checkBox" : tag in currentTags,
-				"active" : plug.settable() and not plugValueWidget.getReadOnly(),
+				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug ),
 			}
 		)
 

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -182,7 +182,7 @@ def __setsPopupMenu( menuDefinition, plugValueWidget ) :
 			{
 				"command" : functools.partial( __setValue, plug, " ".join( sorted( newNames ) ) ),
 				"checkBox" : setName in currentNames,
-				"active" : plug.settable() and not plugValueWidget.getReadOnly(),
+				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug ),
 			}
 		)
 

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -136,8 +136,8 @@ def __setsPopupMenu( menuDefinition, plugValueWidget ) :
 	if plug is None :
 		return
 
-	acceptsSetName = Gaffer.Metadata.plugValue( plug, "ui:scene:acceptsSetName" )
-	acceptsSetNames = Gaffer.Metadata.plugValue( plug, "ui:scene:acceptsSetNames" )
+	acceptsSetName = Gaffer.Metadata.value( plug, "ui:scene:acceptsSetName" )
+	acceptsSetNames = Gaffer.Metadata.value( plug, "ui:scene:acceptsSetNames" )
 	if not acceptsSetName and not acceptsSetNames :
 		return
 

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -168,7 +168,7 @@ class _ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 			shaderName = self.getPlug().getValue()
 			self.__label.setText( "<h3>Shader : " + shaderName + "</h3>" )
 			## \todo Disable the type check once we've got OpenGLShader implementing reloading properly.
-			self.__button.setEnabled( not isinstance( self.getPlug().node(), GafferScene.OpenGLShader ) )
+			self.__button.setEnabled( not Gaffer.readOnly( self.getPlug() ) and not isinstance( self.getPlug().node(), GafferScene.OpenGLShader ) )
 
 	def __buttonClicked( self, button ) :
 

--- a/python/GafferSceneUI/ShaderViewUI.py
+++ b/python/GafferSceneUI/ShaderViewUI.py
@@ -137,7 +137,7 @@ class _SettingsWindow( GafferUI.Window ) :
 
 		plugLayout = None
 		if self.__shaderView.scene() is not None :
-			Gaffer.Metadata.registerPlugValue( self.__shaderView.scene()["shader"], "plugValueWidget:type", "" )
+			Gaffer.Metadata.registerValue( self.__shaderView.scene()["shader"], "plugValueWidget:type", "" )
 			plugLayout = GafferUI.PlugLayout( self.__shaderView.scene(), rootSection = "Settings" )
 
 		self.__frame.setChild( plugLayout )

--- a/python/GafferTest/BoxTest.py
+++ b/python/GafferTest/BoxTest.py
@@ -555,15 +555,15 @@ class BoxTest( GafferTest.TestCase ) :
 
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["a2"] ] ) )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( b["op1"], "description" ), None )
+		self.assertEqual( Gaffer.Metadata.value( b["op1"], "description" ), None )
 
-		Gaffer.Metadata.registerPlugValue( b["op1"], "description", "hello" )
-		self.assertEqual( Gaffer.Metadata.plugValue( b["op1"], "description" ), "hello" )
+		Gaffer.Metadata.registerValue( b["op1"], "description", "hello" )
+		self.assertEqual( Gaffer.Metadata.value( b["op1"], "description" ), "hello" )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["Box"]["op1"], "description" ), "hello" )
+		self.assertEqual( Gaffer.Metadata.value( s2["Box"]["op1"], "description" ), "hello" )
 
 	def testCantPromoteReadOnlyPlug( self ) :
 
@@ -659,7 +659,7 @@ class BoxTest( GafferTest.TestCase ) :
 
 		cs = GafferTest.CapturingSlot( Gaffer.Metadata.plugValueChangedSignal() )
 
-		Gaffer.Metadata.registerPlugValue( p, "description", "hello" )
+		Gaffer.Metadata.registerValue( p, "description", "hello" )
 
 		self.assertEqual( len( cs ), 1 )
 		self.assertEqual( cs[0], ( Gaffer.Box.staticTypeId(), p.relativeName( b ), "description", p ) )
@@ -669,12 +669,12 @@ class BoxTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 
 		s["b"] = Gaffer.Box()
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["b"], "description" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s["b"], "description" ), None )
 
 		cs = GafferTest.CapturingSlot( Gaffer.Metadata.nodeValueChangedSignal() )
 
-		Gaffer.Metadata.registerNodeValue( s["b"], "description", "aaa" )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["b"], "description" ), "aaa" )
+		Gaffer.Metadata.registerValue( s["b"], "description", "aaa" )
+		self.assertEqual( Gaffer.Metadata.value( s["b"], "description" ), "aaa" )
 
 		self.assertEqual( len( cs ), 1 )
 		self.assertEqual( cs[0], ( Gaffer.Box.staticTypeId(), "description", s["b"] ) )
@@ -682,7 +682,7 @@ class BoxTest( GafferTest.TestCase ) :
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["b"], "description" ), "aaa" )
+		self.assertEqual( Gaffer.Metadata.value( s["b"], "description" ), "aaa" )
 
 	def testMetadataSignallingIgnoresIdenticalValues( self ) :
 
@@ -695,22 +695,22 @@ class BoxTest( GafferTest.TestCase ) :
 		ncs = GafferTest.CapturingSlot( Gaffer.Metadata.nodeValueChangedSignal() )
 		pcs = GafferTest.CapturingSlot( Gaffer.Metadata.plugValueChangedSignal() )
 
-		Gaffer.Metadata.registerNodeValue( b, "description", "t" )
-		Gaffer.Metadata.registerPlugValue( p, "description", "tt" )
+		Gaffer.Metadata.registerValue( b, "description", "t" )
+		Gaffer.Metadata.registerValue( p, "description", "tt" )
 
 		self.assertEqual( len( ncs ), 1 )
 		self.assertEqual( len( pcs ), 1 )
 		self.assertEqual( ncs[0], ( Gaffer.Box.staticTypeId(), "description", b ) )
 		self.assertEqual( pcs[0], ( Gaffer.Box.staticTypeId(), p.relativeName( b ), "description", p ) )
 
-		Gaffer.Metadata.registerNodeValue( b, "description", "t" )
-		Gaffer.Metadata.registerPlugValue( p, "description", "tt" )
+		Gaffer.Metadata.registerValue( b, "description", "t" )
+		Gaffer.Metadata.registerValue( p, "description", "tt" )
 
 		self.assertEqual( len( ncs ), 1 )
 		self.assertEqual( len( pcs ), 1 )
 
-		Gaffer.Metadata.registerNodeValue( b, "description", "d" )
-		Gaffer.Metadata.registerPlugValue( p, "description", "dd" )
+		Gaffer.Metadata.registerValue( b, "description", "d" )
+		Gaffer.Metadata.registerValue( p, "description", "dd" )
 
 		self.assertEqual( len( ncs ), 2 )
 		self.assertEqual( len( pcs ), 2 )
@@ -725,42 +725,42 @@ class BoxTest( GafferTest.TestCase ) :
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n"] ] ) )
 		p = b.promotePlug( b["n"]["op1"] )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( b, "description" ), None )
-		self.assertEqual( Gaffer.Metadata.plugValue( p, "description" ), None )
+		self.assertEqual( Gaffer.Metadata.value( b, "description" ), None )
+		self.assertEqual( Gaffer.Metadata.value( p, "description" ), None )
 
 		with Gaffer.UndoContext( s ) :
-			Gaffer.Metadata.registerNodeValue( b, "description", "d" )
-			Gaffer.Metadata.registerPlugValue( p, "description", "dd" )
+			Gaffer.Metadata.registerValue( b, "description", "d" )
+			Gaffer.Metadata.registerValue( p, "description", "dd" )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( b, "description" ), "d" )
-		self.assertEqual( Gaffer.Metadata.plugValue( p, "description" ), "dd" )
+		self.assertEqual( Gaffer.Metadata.value( b, "description" ), "d" )
+		self.assertEqual( Gaffer.Metadata.value( p, "description" ), "dd" )
 
 		with Gaffer.UndoContext( s ) :
-			Gaffer.Metadata.registerNodeValue( b, "description", "t" )
-			Gaffer.Metadata.registerPlugValue( p, "description", "tt" )
+			Gaffer.Metadata.registerValue( b, "description", "t" )
+			Gaffer.Metadata.registerValue( p, "description", "tt" )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( b, "description" ), "t" )
-		self.assertEqual( Gaffer.Metadata.plugValue( p, "description" ), "tt" )
+		self.assertEqual( Gaffer.Metadata.value( b, "description" ), "t" )
+		self.assertEqual( Gaffer.Metadata.value( p, "description" ), "tt" )
 
 		s.undo()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( b, "description" ), "d" )
-		self.assertEqual( Gaffer.Metadata.plugValue( p, "description" ), "dd" )
+		self.assertEqual( Gaffer.Metadata.value( b, "description" ), "d" )
+		self.assertEqual( Gaffer.Metadata.value( p, "description" ), "dd" )
 
 		s.undo()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( b, "description" ), None )
-		self.assertEqual( Gaffer.Metadata.plugValue( p, "description" ), None )
+		self.assertEqual( Gaffer.Metadata.value( b, "description" ), None )
+		self.assertEqual( Gaffer.Metadata.value( p, "description" ), None )
 
 		s.redo()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( b, "description" ), "d" )
-		self.assertEqual( Gaffer.Metadata.plugValue( p, "description" ), "dd" )
+		self.assertEqual( Gaffer.Metadata.value( b, "description" ), "d" )
+		self.assertEqual( Gaffer.Metadata.value( p, "description" ), "dd" )
 
 		s.redo()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( b, "description" ), "t" )
-		self.assertEqual( Gaffer.Metadata.plugValue( p, "description" ), "tt" )
+		self.assertEqual( Gaffer.Metadata.value( b, "description" ), "t" )
+		self.assertEqual( Gaffer.Metadata.value( p, "description" ), "tt" )
 
 	def testPromoteOutputPlug( self ) :
 
@@ -839,8 +839,8 @@ class BoxTest( GafferTest.TestCase ) :
 		s["b"] = Gaffer.Box()
 		s["b"]["n"] = Gaffer.Node()
 
-		Gaffer.Metadata.registerNodeValue( s["b"], "description", "Test description" )
-		Gaffer.Metadata.registerNodeValue( s["b"], "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
+		Gaffer.Metadata.registerValue( s["b"], "description", "Test description" )
+		Gaffer.Metadata.registerValue( s["b"], "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
 
 		ss = s.serialise( parent = s["b"] )
 		self.assertFalse( "Metadata" in ss )
@@ -849,8 +849,8 @@ class BoxTest( GafferTest.TestCase ) :
 		s.execute( ss, parent = s["b2"] )
 
 		self.assertTrue( "n" in s["b2"] )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["b2"], "description" ), None )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["b2"], "nodeGadget:color" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s["b2"], "description" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s["b2"], "nodeGadget:color" ), None )
 
 	def testPromoteDynamicBoxPlugAndSerialise( self ) :
 
@@ -969,20 +969,20 @@ class BoxTest( GafferTest.TestCase ) :
 		s["b"]["n"] = Gaffer.Node()
 		s["b"]["n"]["user"]["p"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
-		Gaffer.Metadata.registerPlugValue( s["b"]["n"]["user"]["p"], "testInt", 10 )
-		Gaffer.Metadata.registerPlugValue( s["b"]["n"]["user"]["p"], "testString", "test" )
+		Gaffer.Metadata.registerValue( s["b"]["n"]["user"]["p"], "testInt", 10 )
+		Gaffer.Metadata.registerValue( s["b"]["n"]["user"]["p"], "testString", "test" )
 
 		p = s["b"].promotePlug( s["b"]["n"]["user"]["p"] )
 		p.setName( "p" )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( p, "testInt" ), 10 )
-		self.assertEqual( Gaffer.Metadata.plugValue( p, "testString" ), "test" )
+		self.assertEqual( Gaffer.Metadata.value( p, "testInt" ), 10 )
+		self.assertEqual( Gaffer.Metadata.value( p, "testString" ), "test" )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["b"]["p"], "testInt" ), 10 )
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["b"]["p"], "testString" ), "test" )
+		self.assertEqual( Gaffer.Metadata.value( s2["b"]["p"], "testInt" ), 10 )
+		self.assertEqual( Gaffer.Metadata.value( s2["b"]["p"], "testString" ), "test" )
 
 	def testPromotionIncludesArbitraryChildMetadata( self ) :
 
@@ -993,20 +993,20 @@ class BoxTest( GafferTest.TestCase ) :
 		s["b"]["n"]["user"]["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["b"]["n"]["user"]["p"]["i"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
-		Gaffer.Metadata.registerPlugValue( s["b"]["n"]["user"]["p"], "testInt", 10 )
-		Gaffer.Metadata.registerPlugValue( s["b"]["n"]["user"]["p"]["i"], "testString", "test" )
+		Gaffer.Metadata.registerValue( s["b"]["n"]["user"]["p"], "testInt", 10 )
+		Gaffer.Metadata.registerValue( s["b"]["n"]["user"]["p"]["i"], "testString", "test" )
 
 		p = s["b"].promotePlug( s["b"]["n"]["user"]["p"] )
 		p.setName( "p" )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( p, "testInt" ), 10 )
-		self.assertEqual( Gaffer.Metadata.plugValue( p["i"], "testString" ), "test" )
+		self.assertEqual( Gaffer.Metadata.value( p, "testInt" ), 10 )
+		self.assertEqual( Gaffer.Metadata.value( p["i"], "testString" ), "test" )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["b"]["p"], "testInt" ), 10 )
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["b"]["p"]["i"], "testString" ), "test" )
+		self.assertEqual( Gaffer.Metadata.value( s2["b"]["p"], "testInt" ), 10 )
+		self.assertEqual( Gaffer.Metadata.value( s2["b"]["p"]["i"], "testString" ), "test" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -1,0 +1,75 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferTest
+
+class MetadataAlgoTest( GafferTest.TestCase ) :
+
+	def testReadOnly( self ) :
+
+		n = GafferTest.AddNode()
+
+		self.assertEqual( Gaffer.getReadOnly( n ), False )
+		self.assertEqual( Gaffer.getReadOnly( n["op1"] ), False )
+		self.assertEqual( Gaffer.readOnly( n ), False )
+		self.assertEqual( Gaffer.readOnly( n["op1"] ), False )
+
+		Gaffer.setReadOnly( n["op1"], True )
+
+		self.assertEqual( Gaffer.getReadOnly( n ), False )
+		self.assertEqual( Gaffer.getReadOnly( n["op1"] ), True )
+		self.assertEqual( Gaffer.readOnly( n ), False )
+		self.assertEqual( Gaffer.readOnly( n["op1"] ), True )
+
+		Gaffer.setReadOnly( n, True )
+
+		self.assertEqual( Gaffer.getReadOnly( n ), True )
+		self.assertEqual( Gaffer.getReadOnly( n["op1"] ), True )
+		self.assertEqual( Gaffer.readOnly( n ), True )
+		self.assertEqual( Gaffer.readOnly( n["op1"] ), True )
+
+		Gaffer.setReadOnly( n["op1"], False )
+
+		self.assertEqual( Gaffer.getReadOnly( n ), True )
+		self.assertEqual( Gaffer.getReadOnly( n["op1"] ), False )
+		self.assertEqual( Gaffer.readOnly( n ), True )
+		self.assertEqual( Gaffer.readOnly( n["op1"] ), True )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -997,5 +997,24 @@ class MetadataTest( GafferTest.TestCase ) :
 			self.assertEqual( Gaffer.Metadata.nodeValue( s2["n"], "test" ), value )
 			self.assertEqual( Gaffer.Metadata.plugValue( s2["n"]["p"], "test" ), value )
 
+	def testOverloadedMethods( self ) :
+
+		n = GafferTest.AddNode()
+
+		Gaffer.Metadata.registerValue( n, "one", 1 )
+		Gaffer.Metadata.registerValue( n["op1"], "two", 2 )
+
+		self.assertEqual( Gaffer.Metadata.registeredValues( n, instanceOnly = True ), [ "one" ] )
+		self.assertEqual( Gaffer.Metadata.registeredValues( n["op1"], instanceOnly = True ), [ "two" ] )
+
+		self.assertEqual( Gaffer.Metadata.value( n, "one" ), 1 )
+		self.assertEqual( Gaffer.Metadata.value( n["op1"], "two" ), 2 )
+
+		Gaffer.Metadata.deregisterValue( n, "one" )
+		Gaffer.Metadata.deregisterValue( n["op1"], "two" )
+
+		self.assertEqual( Gaffer.Metadata.registeredValues( n, instanceOnly = True ), [] )
+		self.assertEqual( Gaffer.Metadata.registeredValues( n["op1"], instanceOnly = True ), [] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -96,7 +96,7 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.nodeDescription( multiply ), "description" )
 		self.assertEqual( Gaffer.Metadata.plugDescription( multiply["op1"] ), "op1 description" )
 		self.assertEqual( Gaffer.Metadata.plugDescription( multiply["op2"] ), "op2 description" )
-		self.assertEqual( Gaffer.Metadata.plugValue( multiply["op2"], "otherValue" ), 100 )
+		self.assertEqual( Gaffer.Metadata.value( multiply["op2"], "otherValue" ), 100 )
 
 	def testPlugDescription( self ) :
 
@@ -125,45 +125,45 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		add = GafferTest.AddNode()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( add, "aKey" ), None )
-		self.assertEqual( Gaffer.Metadata.plugValue( add["op1"], "aKey" ), None )
+		self.assertEqual( Gaffer.Metadata.value( add, "aKey" ), None )
+		self.assertEqual( Gaffer.Metadata.value( add["op1"], "aKey" ), None )
 
-		Gaffer.Metadata.registerNodeValue( GafferTest.AddNode, "aKey", "something" )
-		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode, "op*", "aKey", "somethingElse" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "aKey", "something" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op*", "aKey", "somethingElse" )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( add, "aKey" ), "something" )
-		self.assertEqual( Gaffer.Metadata.plugValue( add["op1"], "aKey" ), "somethingElse" )
+		self.assertEqual( Gaffer.Metadata.value( add, "aKey" ), "something" )
+		self.assertEqual( Gaffer.Metadata.value( add["op1"], "aKey" ), "somethingElse" )
 
 	def testInheritance( self ) :
 
-		Gaffer.Metadata.registerNodeValue( GafferTest.AddNode, "iKey", "Base class value" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "iKey", "Base class value" )
 
 		derivedAdd = self.DerivedAddNode()
-		self.assertEqual( Gaffer.Metadata.nodeValue( derivedAdd, "iKey" ), "Base class value" )
-		self.assertEqual( Gaffer.Metadata.nodeValue( derivedAdd, "iKey", inherit=False ), None )
+		self.assertEqual( Gaffer.Metadata.value( derivedAdd, "iKey" ), "Base class value" )
+		self.assertEqual( Gaffer.Metadata.value( derivedAdd, "iKey", inherit=False ), None )
 
-		Gaffer.Metadata.registerNodeValue( self.DerivedAddNode, "iKey", "Derived class value" )
-		self.assertEqual( Gaffer.Metadata.nodeValue( derivedAdd, "iKey", inherit=False ), "Derived class value" )
+		Gaffer.Metadata.registerValue( self.DerivedAddNode, "iKey", "Derived class value" )
+		self.assertEqual( Gaffer.Metadata.value( derivedAdd, "iKey", inherit=False ), "Derived class value" )
 
-		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode, "op1", "iKey", "Base class plug value" )
-		self.assertEqual( Gaffer.Metadata.plugValue( derivedAdd["op1"], "iKey" ), "Base class plug value" )
-		self.assertEqual( Gaffer.Metadata.plugValue( derivedAdd["op1"], "iKey", inherit=False ), None )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "iKey", "Base class plug value" )
+		self.assertEqual( Gaffer.Metadata.value( derivedAdd["op1"], "iKey" ), "Base class plug value" )
+		self.assertEqual( Gaffer.Metadata.value( derivedAdd["op1"], "iKey", inherit=False ), None )
 
-		Gaffer.Metadata.registerPlugValue( self.DerivedAddNode, "op1", "iKey", "Derived class plug value" )
-		self.assertEqual( Gaffer.Metadata.plugValue( derivedAdd["op1"], "iKey", inherit=False ), "Derived class plug value" )
+		Gaffer.Metadata.registerValue( self.DerivedAddNode, "op1", "iKey", "Derived class plug value" )
+		self.assertEqual( Gaffer.Metadata.value( derivedAdd["op1"], "iKey", inherit=False ), "Derived class plug value" )
 
 	def testNodeSignals( self ) :
 
 		ns = GafferTest.CapturingSlot( Gaffer.Metadata.nodeValueChangedSignal() )
 		ps = GafferTest.CapturingSlot( Gaffer.Metadata.plugValueChangedSignal() )
 
-		Gaffer.Metadata.registerNodeValue( GafferTest.AddNode, "k", "something" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "k", "something" )
 
 		self.assertEqual( len( ps ), 0 )
 		self.assertEqual( len( ns ), 1 )
 		self.assertEqual( ns[0], ( GafferTest.AddNode.staticTypeId(), "k", None ) )
 
-		Gaffer.Metadata.registerNodeValue( GafferTest.AddNode, "k", "somethingElse" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "k", "somethingElse" )
 
 		self.assertEqual( len( ps ), 0 )
 		self.assertEqual( len( ns ), 2 )
@@ -174,13 +174,13 @@ class MetadataTest( GafferTest.TestCase ) :
 		ns = GafferTest.CapturingSlot( Gaffer.Metadata.nodeValueChangedSignal() )
 		ps = GafferTest.CapturingSlot( Gaffer.Metadata.plugValueChangedSignal() )
 
-		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode, "op1", "k", "something" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "k", "something" )
 
 		self.assertEqual( len( ps ), 1 )
 		self.assertEqual( len( ns ), 0 )
 		self.assertEqual( ps[0], ( GafferTest.AddNode.staticTypeId(), "op1", "k", None ) )
 
-		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode, "op1", "k", "somethingElse" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "k", "somethingElse" )
 
 		self.assertEqual( len( ps ), 2 )
 		self.assertEqual( len( ns ), 0 )
@@ -189,77 +189,77 @@ class MetadataTest( GafferTest.TestCase ) :
 	def testSignalsDontExposeInternedStrings( self ) :
 
 		cs = GafferTest.CapturingSlot( Gaffer.Metadata.nodeValueChangedSignal() )
-		Gaffer.Metadata.registerNodeValue( GafferTest.AddNode, "k", "aaa" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "k", "aaa" )
 		self.assertTrue( type( cs[0][1] ) is str )
 
 		cs = GafferTest.CapturingSlot( Gaffer.Metadata.plugValueChangedSignal() )
-		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode, "op1", "k", "bbb" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "k", "bbb" )
 		self.assertTrue( type( cs[0][1] ) is str )
 		self.assertTrue( type( cs[0][2] ) is str )
 
 	def testInstanceMetadata( self ) :
 
-		Gaffer.Metadata.registerNodeValue( GafferTest.AddNode.staticTypeId(), "imt", "globalNodeValue" )
-		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode.staticTypeId(), "op1", "imt", "globalPlugValue" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode.staticTypeId(), "imt", "globalNodeValue" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode.staticTypeId(), "op1", "imt", "globalPlugValue" )
 
 		n = GafferTest.AddNode()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "imt" ), "globalNodeValue" )
-		self.assertEqual( Gaffer.Metadata.plugValue( n["op1"], "imt" ), "globalPlugValue" )
+		self.assertEqual( Gaffer.Metadata.value( n, "imt" ), "globalNodeValue" )
+		self.assertEqual( Gaffer.Metadata.value( n["op1"], "imt" ), "globalPlugValue" )
 
-		Gaffer.Metadata.registerNodeValue( n, "imt", "instanceNodeValue" )
-		Gaffer.Metadata.registerPlugValue( n["op1"], "imt", "instancePlugValue" )
+		Gaffer.Metadata.registerValue( n, "imt", "instanceNodeValue" )
+		Gaffer.Metadata.registerValue( n["op1"], "imt", "instancePlugValue" )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "imt" ), "instanceNodeValue" )
-		self.assertEqual( Gaffer.Metadata.plugValue( n["op1"], "imt" ), "instancePlugValue" )
+		self.assertEqual( Gaffer.Metadata.value( n, "imt" ), "instanceNodeValue" )
+		self.assertEqual( Gaffer.Metadata.value( n["op1"], "imt" ), "instancePlugValue" )
 
-		Gaffer.Metadata.registerNodeValue( n, "imt", None )
-		Gaffer.Metadata.registerPlugValue( n["op1"], "imt", None )
+		Gaffer.Metadata.registerValue( n, "imt", None )
+		Gaffer.Metadata.registerValue( n["op1"], "imt", None )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "imt" ), None )
-		self.assertEqual( Gaffer.Metadata.plugValue( n["op1"], "imt" ), None )
+		self.assertEqual( Gaffer.Metadata.value( n, "imt" ), None )
+		self.assertEqual( Gaffer.Metadata.value( n["op1"], "imt" ), None )
 
 	def testInstanceMetadataUndo( self ) :
 
 		s = Gaffer.ScriptNode()
 		s["n"] = GafferTest.AddNode()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "undoTest" ), None )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "undoTest" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "undoTest" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "undoTest" ), None )
 
 		with Gaffer.UndoContext( s ) :
-			Gaffer.Metadata.registerNodeValue( s["n"], "undoTest", "instanceNodeValue" )
-			Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "undoTest", "instancePlugValue" )
+			Gaffer.Metadata.registerValue( s["n"], "undoTest", "instanceNodeValue" )
+			Gaffer.Metadata.registerValue( s["n"]["op1"], "undoTest", "instancePlugValue" )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "undoTest" ), "instanceNodeValue" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "undoTest" ), "instancePlugValue" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "undoTest" ), "instanceNodeValue" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "undoTest" ), "instancePlugValue" )
 
 		with Gaffer.UndoContext( s ) :
-			Gaffer.Metadata.registerNodeValue( s["n"], "undoTest", "instanceNodeValue2" )
-			Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "undoTest", "instancePlugValue2" )
+			Gaffer.Metadata.registerValue( s["n"], "undoTest", "instanceNodeValue2" )
+			Gaffer.Metadata.registerValue( s["n"]["op1"], "undoTest", "instancePlugValue2" )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "undoTest" ), "instanceNodeValue2" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "undoTest" ), "instancePlugValue2" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "undoTest" ), "instanceNodeValue2" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "undoTest" ), "instancePlugValue2" )
 
 		s.undo()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "undoTest" ), "instanceNodeValue" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "undoTest" ), "instancePlugValue" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "undoTest" ), "instanceNodeValue" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "undoTest" ), "instancePlugValue" )
 
 		s.undo()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "undoTest" ), None )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "undoTest" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "undoTest" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "undoTest" ), None )
 
 		s.redo()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "undoTest" ), "instanceNodeValue" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "undoTest" ), "instancePlugValue" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "undoTest" ), "instanceNodeValue" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "undoTest" ), "instancePlugValue" )
 
 		s.redo()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "undoTest" ), "instanceNodeValue2" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "undoTest" ), "instancePlugValue2" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "undoTest" ), "instanceNodeValue2" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "undoTest" ), "instancePlugValue2" )
 
 	def testInstanceMetadataSignals( self ) :
 
@@ -268,22 +268,22 @@ class MetadataTest( GafferTest.TestCase ) :
 		ncs = GafferTest.CapturingSlot( Gaffer.Metadata.nodeValueChangedSignal() )
 		pcs = GafferTest.CapturingSlot( Gaffer.Metadata.plugValueChangedSignal() )
 
-		Gaffer.Metadata.registerNodeValue( n, "signalTest", 1 )
-		Gaffer.Metadata.registerPlugValue( n["op1"], "signalTest", 1 )
+		Gaffer.Metadata.registerValue( n, "signalTest", 1 )
+		Gaffer.Metadata.registerValue( n["op1"], "signalTest", 1 )
 
 		self.assertEqual( len( ncs ), 1 )
 		self.assertEqual( len( pcs ), 1 )
 		self.assertEqual( ncs[0], ( GafferTest.AddNode.staticTypeId(), "signalTest", n ) )
 		self.assertEqual( pcs[0], ( GafferTest.AddNode.staticTypeId(), "op1", "signalTest", n["op1"] ) )
 
-		Gaffer.Metadata.registerNodeValue( n, "signalTest", 1 )
-		Gaffer.Metadata.registerPlugValue( n["op1"], "signalTest", 1 )
+		Gaffer.Metadata.registerValue( n, "signalTest", 1 )
+		Gaffer.Metadata.registerValue( n["op1"], "signalTest", 1 )
 
 		self.assertEqual( len( ncs ), 1 )
 		self.assertEqual( len( pcs ), 1 )
 
-		Gaffer.Metadata.registerNodeValue( n, "signalTest", 2 )
-		Gaffer.Metadata.registerPlugValue( n["op1"], "signalTest", 2 )
+		Gaffer.Metadata.registerValue( n, "signalTest", 2 )
+		Gaffer.Metadata.registerValue( n["op1"], "signalTest", 2 )
 
 		self.assertEqual( len( ncs ), 2 )
 		self.assertEqual( len( pcs ), 2 )
@@ -296,14 +296,14 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		s["n"] = GafferTest.AddNode()
 
-		Gaffer.Metadata.registerNodeValue( s["n"], "serialisationTest", 1 )
-		Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "serialisationTest", 2 )
+		Gaffer.Metadata.registerValue( s["n"], "serialisationTest", 1 )
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "serialisationTest", 2 )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2["n"], "serialisationTest" ), 1 )
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["n"]["op1"], "serialisationTest" ), 2 )
+		self.assertEqual( Gaffer.Metadata.value( s2["n"], "serialisationTest" ), 1 )
+		self.assertEqual( Gaffer.Metadata.value( s2["n"]["op1"], "serialisationTest" ), 2 )
 
 	def testStringSerialisationWithNewlinesAndQuotes( self ) :
 
@@ -320,7 +320,7 @@ class MetadataTest( GafferTest.TestCase ) :
 		for s in trickyStrings :
 			p = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 			script["n"]["user"].addChild( p )
-			Gaffer.Metadata.registerPlugValue( p, "description", s )
+			Gaffer.Metadata.registerValue( p, "description", s )
 
 		script2 = Gaffer.ScriptNode()
 		script2.execute( script.serialise() )
@@ -332,43 +332,43 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		n = GafferTest.AddNode()
 
-		self.assertTrue( "r" not in Gaffer.Metadata.registeredNodeValues( n ) )
-		self.assertTrue( "rp" not in Gaffer.Metadata.registeredPlugValues( n["op1"] ) )
-		self.assertTrue( "ri" not in Gaffer.Metadata.registeredNodeValues( n ) )
-		self.assertTrue( "rpi" not in Gaffer.Metadata.registeredPlugValues( n["op1"] ) )
+		self.assertTrue( "r" not in Gaffer.Metadata.registeredValues( n ) )
+		self.assertTrue( "rp" not in Gaffer.Metadata.registeredValues( n["op1"] ) )
+		self.assertTrue( "ri" not in Gaffer.Metadata.registeredValues( n ) )
+		self.assertTrue( "rpi" not in Gaffer.Metadata.registeredValues( n["op1"] ) )
 
-		Gaffer.Metadata.registerNodeValue( n.staticTypeId(), "r", 10 )
-		Gaffer.Metadata.registerPlugValue( n.staticTypeId(), "op1", "rp", 20 )
+		Gaffer.Metadata.registerValue( n.staticTypeId(), "r", 10 )
+		Gaffer.Metadata.registerValue( n.staticTypeId(), "op1", "rp", 20 )
 
-		self.assertTrue( "r" in Gaffer.Metadata.registeredNodeValues( n ) )
-		self.assertTrue( "rp" in Gaffer.Metadata.registeredPlugValues( n["op1"] ) )
-		self.assertTrue( "ri" not in Gaffer.Metadata.registeredNodeValues( n ) )
-		self.assertTrue( "rpi" not in Gaffer.Metadata.registeredPlugValues( n["op1"] ) )
+		self.assertTrue( "r" in Gaffer.Metadata.registeredValues( n ) )
+		self.assertTrue( "rp" in Gaffer.Metadata.registeredValues( n["op1"] ) )
+		self.assertTrue( "ri" not in Gaffer.Metadata.registeredValues( n ) )
+		self.assertTrue( "rpi" not in Gaffer.Metadata.registeredValues( n["op1"] ) )
 
-		Gaffer.Metadata.registerNodeValue( n, "ri", 10 )
-		Gaffer.Metadata.registerPlugValue( n["op1"], "rpi", 20 )
+		Gaffer.Metadata.registerValue( n, "ri", 10 )
+		Gaffer.Metadata.registerValue( n["op1"], "rpi", 20 )
 
-		self.assertTrue( "r" in Gaffer.Metadata.registeredNodeValues( n ) )
-		self.assertTrue( "rp" in Gaffer.Metadata.registeredPlugValues( n["op1"] ) )
-		self.assertTrue( "ri" in Gaffer.Metadata.registeredNodeValues( n ) )
-		self.assertTrue( "rpi" in Gaffer.Metadata.registeredPlugValues( n["op1"] ) )
+		self.assertTrue( "r" in Gaffer.Metadata.registeredValues( n ) )
+		self.assertTrue( "rp" in Gaffer.Metadata.registeredValues( n["op1"] ) )
+		self.assertTrue( "ri" in Gaffer.Metadata.registeredValues( n ) )
+		self.assertTrue( "rpi" in Gaffer.Metadata.registeredValues( n["op1"] ) )
 
-		self.assertTrue( "r" not in Gaffer.Metadata.registeredNodeValues( n, instanceOnly=True ) )
-		self.assertTrue( "rp" not in Gaffer.Metadata.registeredPlugValues( n["op1"], instanceOnly=True ) )
-		self.assertTrue( "ri" in Gaffer.Metadata.registeredNodeValues( n ) )
-		self.assertTrue( "rpi" in Gaffer.Metadata.registeredPlugValues( n["op1"] ) )
+		self.assertTrue( "r" not in Gaffer.Metadata.registeredValues( n, instanceOnly=True ) )
+		self.assertTrue( "rp" not in Gaffer.Metadata.registeredValues( n["op1"], instanceOnly=True ) )
+		self.assertTrue( "ri" in Gaffer.Metadata.registeredValues( n ) )
+		self.assertTrue( "rpi" in Gaffer.Metadata.registeredValues( n["op1"] ) )
 
 	def testInstanceDestruction( self ) :
 
 		for i in range( 0, 1000 ) :
 			p = Gaffer.Plug()
 			n = Gaffer.Node()
-			self.assertEqual( Gaffer.Metadata.plugValue( p, "destructionTest" ), None )
-			self.assertEqual( Gaffer.Metadata.nodeValue( n, "destructionTest" ), None )
-			Gaffer.Metadata.registerPlugValue( p, "destructionTest", 10 )
-			Gaffer.Metadata.registerNodeValue( n, "destructionTest", 20 )
-			self.assertEqual( Gaffer.Metadata.plugValue( p, "destructionTest" ), 10 )
-			self.assertEqual( Gaffer.Metadata.nodeValue( n, "destructionTest" ), 20 )
+			self.assertEqual( Gaffer.Metadata.value( p, "destructionTest" ), None )
+			self.assertEqual( Gaffer.Metadata.value( n, "destructionTest" ), None )
+			Gaffer.Metadata.registerValue( p, "destructionTest", 10 )
+			Gaffer.Metadata.registerValue( n, "destructionTest", 20 )
+			self.assertEqual( Gaffer.Metadata.value( p, "destructionTest" ), 10 )
+			self.assertEqual( Gaffer.Metadata.value( n, "destructionTest" ), 20 )
 			del p
 			del n
 
@@ -396,20 +396,20 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		node = MetadataTestNodeB()
 
-		Gaffer.Metadata.registerNodeValue( node, "nodeSeven", 7 )
-		Gaffer.Metadata.registerNodeValue( node, "nodeEight", 8 )
-		Gaffer.Metadata.registerNodeValue( node, "nodeNine", 9 )
+		Gaffer.Metadata.registerValue( node, "nodeSeven", 7 )
+		Gaffer.Metadata.registerValue( node, "nodeEight", 8 )
+		Gaffer.Metadata.registerValue( node, "nodeNine", 9 )
 
-		Gaffer.Metadata.registerNodeValue( MetadataTestNodeB, "nodeFour", 4 )
-		Gaffer.Metadata.registerNodeValue( MetadataTestNodeB, "nodeFive", 5 )
-		Gaffer.Metadata.registerNodeValue( MetadataTestNodeB, "nodeSix", 6 )
+		Gaffer.Metadata.registerValue( MetadataTestNodeB, "nodeFour", 4 )
+		Gaffer.Metadata.registerValue( MetadataTestNodeB, "nodeFive", 5 )
+		Gaffer.Metadata.registerValue( MetadataTestNodeB, "nodeSix", 6 )
 
-		Gaffer.Metadata.registerNodeValue( MetadataTestNodeA, "nodeOne", 1 )
-		Gaffer.Metadata.registerNodeValue( MetadataTestNodeA, "nodeTwo", 2 )
-		Gaffer.Metadata.registerNodeValue( MetadataTestNodeA, "nodeThree", 3 )
+		Gaffer.Metadata.registerValue( MetadataTestNodeA, "nodeOne", 1 )
+		Gaffer.Metadata.registerValue( MetadataTestNodeA, "nodeTwo", 2 )
+		Gaffer.Metadata.registerValue( MetadataTestNodeA, "nodeThree", 3 )
 
 		self.assertEqual(
-			Gaffer.Metadata.registeredNodeValues( node ),
+			Gaffer.Metadata.registeredValues( node ),
 			[
 				# base class values first, in order of their registration
 				"nodeOne",
@@ -428,20 +428,20 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		# test plug registrations
 
-		Gaffer.Metadata.registerPlugValue( node["a"], "plugSeven", 7 )
-		Gaffer.Metadata.registerPlugValue( node["a"], "plugEight", 8 )
-		Gaffer.Metadata.registerPlugValue( node["a"], "plugNine", 9 )
+		Gaffer.Metadata.registerValue( node["a"], "plugSeven", 7 )
+		Gaffer.Metadata.registerValue( node["a"], "plugEight", 8 )
+		Gaffer.Metadata.registerValue( node["a"], "plugNine", 9 )
 
-		Gaffer.Metadata.registerPlugValue( MetadataTestNodeB, "a", "plugFour", 4 )
-		Gaffer.Metadata.registerPlugValue( MetadataTestNodeB, "a", "plugFive", 5 )
-		Gaffer.Metadata.registerPlugValue( MetadataTestNodeB, "a", "plugSix", 6 )
+		Gaffer.Metadata.registerValue( MetadataTestNodeB, "a", "plugFour", 4 )
+		Gaffer.Metadata.registerValue( MetadataTestNodeB, "a", "plugFive", 5 )
+		Gaffer.Metadata.registerValue( MetadataTestNodeB, "a", "plugSix", 6 )
 
-		Gaffer.Metadata.registerPlugValue( MetadataTestNodeA, "a", "plugOne", 1 )
-		Gaffer.Metadata.registerPlugValue( MetadataTestNodeA, "a", "plugTwo", 2 )
-		Gaffer.Metadata.registerPlugValue( MetadataTestNodeA, "a", "plugThree", 3 )
+		Gaffer.Metadata.registerValue( MetadataTestNodeA, "a", "plugOne", 1 )
+		Gaffer.Metadata.registerValue( MetadataTestNodeA, "a", "plugTwo", 2 )
+		Gaffer.Metadata.registerValue( MetadataTestNodeA, "a", "plugThree", 3 )
 
 		self.assertEqual(
-			Gaffer.Metadata.registeredPlugValues( node["a"] ),
+			Gaffer.Metadata.registeredValues( node["a"] ),
 			[
 				# base class values first, in order of their registration
 				"plugOne",
@@ -466,24 +466,24 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		n = Gaffer.Node()
 
-		Gaffer.Metadata.registerNodeValue( n, "stringVector", IECore.StringVectorData( [ "a", "b", "c" ] ) )
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "stringVector" ), IECore.StringVectorData( [ "a", "b", "c" ] ) )
+		Gaffer.Metadata.registerValue( n, "stringVector", IECore.StringVectorData( [ "a", "b", "c" ] ) )
+		self.assertEqual( Gaffer.Metadata.value( n, "stringVector" ), IECore.StringVectorData( [ "a", "b", "c" ] ) )
 
-		Gaffer.Metadata.registerNodeValue( n, "intVector", IECore.IntVectorData( [ 1, 2, 3 ] ) )
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "intVector" ), IECore.IntVectorData( [ 1, 2, 3 ] ) )
+		Gaffer.Metadata.registerValue( n, "intVector", IECore.IntVectorData( [ 1, 2, 3 ] ) )
+		self.assertEqual( Gaffer.Metadata.value( n, "intVector" ), IECore.IntVectorData( [ 1, 2, 3 ] ) )
 
 	def testCopy( self ) :
 
 		n = Gaffer.Node()
 
 		s = IECore.StringVectorData( [ "a", "b", "c" ] )
-		Gaffer.Metadata.registerNodeValue( n, "stringVector", s )
+		Gaffer.Metadata.registerValue( n, "stringVector", s )
 
-		s2 = Gaffer.Metadata.nodeValue( n, "stringVector" )
+		s2 = Gaffer.Metadata.value( n, "stringVector" )
 		self.assertEqual( s, s2 )
 		self.assertFalse( s.isSame( s2 ) )
 
-		s3 = Gaffer.Metadata.nodeValue( n, "stringVector", _copy = False )
+		s3 = Gaffer.Metadata.value( n, "stringVector", _copy = False )
 		self.assertEqual( s, s3 )
 		self.assertTrue( s.isSame( s3 ) )
 
@@ -503,7 +503,7 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		n = Gaffer.Node()
 		with IECore.CapturingMessageHandler() as mh :
-			Gaffer.Metadata.registerNodeValue( n, "test", 10 )
+			Gaffer.Metadata.registerValue( n, "test", 10 )
 
 		self.assertTrue( self.__goodSlotExecuted )
 
@@ -560,49 +560,49 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		n = MetadataTestNodeC()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "description" ), "I am a multi\nline description" )
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "nodeGadget:color" ), IECore.Color3f( 1, 0, 0 ) )
+		self.assertEqual( Gaffer.Metadata.value( n, "description" ), "I am a multi\nline description" )
+		self.assertEqual( Gaffer.Metadata.value( n, "nodeGadget:color" ), IECore.Color3f( 1, 0, 0 ) )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( n["a"], "description" ), "Another multi\nline description" )
-		self.assertEqual( Gaffer.Metadata.plugValue( n["a"], "preset:One" ), 1 )
-		self.assertEqual( Gaffer.Metadata.plugValue( n["a"], "preset:Two" ), 2 )
-		self.assertEqual( Gaffer.Metadata.plugValue( n["a"], "preset:Three" ), 3 )
-		self.assertEqual( Gaffer.Metadata.registeredPlugValues( n["a"] ), [ "description", "preset:One", "preset:Two", "preset:Three" ] )
+		self.assertEqual( Gaffer.Metadata.value( n["a"], "description" ), "Another multi\nline description" )
+		self.assertEqual( Gaffer.Metadata.value( n["a"], "preset:One" ), 1 )
+		self.assertEqual( Gaffer.Metadata.value( n["a"], "preset:Two" ), 2 )
+		self.assertEqual( Gaffer.Metadata.value( n["a"], "preset:Three" ), 3 )
+		self.assertEqual( Gaffer.Metadata.registeredValues( n["a"] ), [ "description", "preset:One", "preset:Two", "preset:Three" ] )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( n["b"], "description" ), "I am the first paragraph.\n\nI am the second paragraph." )
-		self.assertEqual( Gaffer.Metadata.plugValue( n["b"], "otherValue" ), 100 )
+		self.assertEqual( Gaffer.Metadata.value( n["b"], "description" ), "I am the first paragraph.\n\nI am the second paragraph." )
+		self.assertEqual( Gaffer.Metadata.value( n["b"], "otherValue" ), 100 )
 
 	def testPersistenceOfInstanceValues( self ) :
 
 		s = Gaffer.ScriptNode()
 		s["n"] = GafferTest.AddNode()
 
-		Gaffer.Metadata.registerNodeValue( s["n"], "persistent1", 1 )
-		Gaffer.Metadata.registerNodeValue( s["n"], "persistent2", 2, persistent = True )
-		Gaffer.Metadata.registerNodeValue( s["n"], "nonpersistent", 3, persistent = False )
+		Gaffer.Metadata.registerValue( s["n"], "persistent1", 1 )
+		Gaffer.Metadata.registerValue( s["n"], "persistent2", 2, persistent = True )
+		Gaffer.Metadata.registerValue( s["n"], "nonpersistent", 3, persistent = False )
 
-		Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "persistent1", "one" )
-		Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "persistent2", "two", persistent = True )
-		Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "nonpersistent", "three", persistent = False )
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "persistent1", "one" )
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "persistent2", "two", persistent = True )
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "nonpersistent", "three", persistent = False )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "persistent1" ), 1 )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "persistent2" ), 2 )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "nonpersistent" ), 3 )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "persistent1" ), 1 )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "persistent2" ), 2 )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "nonpersistent" ), 3 )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "persistent1" ), "one" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "persistent2" ), "two" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "nonpersistent" ), "three" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "persistent1" ), "one" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "persistent2" ), "two" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "nonpersistent" ), "three" )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2["n"], "persistent1" ), 1 )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2["n"], "persistent2" ), 2 )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2["n"], "nonpersistent" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s2["n"], "persistent1" ), 1 )
+		self.assertEqual( Gaffer.Metadata.value( s2["n"], "persistent2" ), 2 )
+		self.assertEqual( Gaffer.Metadata.value( s2["n"], "nonpersistent" ), None )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["n"]["op1"], "persistent1" ), "one" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["n"]["op1"], "persistent2" ), "two" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["n"]["op1"], "nonpersistent" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s2["n"]["op1"], "persistent1" ), "one" )
+		self.assertEqual( Gaffer.Metadata.value( s2["n"]["op1"], "persistent2" ), "two" )
+		self.assertEqual( Gaffer.Metadata.value( s2["n"]["op1"], "nonpersistent" ), None )
 
 	def testUndoOfPersistentInstanceValues( self ) :
 
@@ -611,40 +611,40 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		def assertNonExistent() :
 
-			self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "a" ), None )
-			self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "b" ), None )
+			self.assertEqual( Gaffer.Metadata.value( s["n"], "a" ), None )
+			self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "b" ), None )
 
 		def assertPersistent() :
 
-			self.assertEqual( Gaffer.Metadata.registeredNodeValues( s["n"], instanceOnly = True ), [ "a" ] )
-			self.assertEqual( Gaffer.Metadata.registeredPlugValues( s["n"]["op1"], instanceOnly = True ), [ "b" ] )
-			self.assertEqual( Gaffer.Metadata.registeredNodeValues( s["n"], instanceOnly = True, persistentOnly = True ), [ "a" ] )
-			self.assertEqual( Gaffer.Metadata.registeredPlugValues( s["n"]["op1"], instanceOnly = True, persistentOnly = True ), [ "b" ] )
-			self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "a" ), 1 )
-			self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "b" ), 2 )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True ), [ "a" ] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"]["op1"], instanceOnly = True ), [ "b" ] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True, persistentOnly = True ), [ "a" ] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"]["op1"], instanceOnly = True, persistentOnly = True ), [ "b" ] )
+			self.assertEqual( Gaffer.Metadata.value( s["n"], "a" ), 1 )
+			self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "b" ), 2 )
 
 		def assertNonPersistent() :
 
-			self.assertEqual( Gaffer.Metadata.registeredNodeValues( s["n"], instanceOnly = True ), [ "a" ] )
-			self.assertEqual( Gaffer.Metadata.registeredPlugValues( s["n"]["op1"], instanceOnly = True ), [ "b" ] )
-			self.assertEqual( Gaffer.Metadata.registeredNodeValues( s["n"], instanceOnly = True, persistentOnly = True ), [] )
-			self.assertEqual( Gaffer.Metadata.registeredPlugValues( s["n"]["op1"], instanceOnly = True, persistentOnly = True ), [] )
-			self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "a" ), 1 )
-			self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "b" ), 2 )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True ), [ "a" ] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"]["op1"], instanceOnly = True ), [ "b" ] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True, persistentOnly = True ), [] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"]["op1"], instanceOnly = True, persistentOnly = True ), [] )
+			self.assertEqual( Gaffer.Metadata.value( s["n"], "a" ), 1 )
+			self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "b" ), 2 )
 
 		assertNonExistent()
 
 		with Gaffer.UndoContext( s ) :
 
-			Gaffer.Metadata.registerNodeValue( s["n"], "a", 1, persistent = True )
-			Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "b", 2, persistent = True )
+			Gaffer.Metadata.registerValue( s["n"], "a", 1, persistent = True )
+			Gaffer.Metadata.registerValue( s["n"]["op1"], "b", 2, persistent = True )
 
 		assertPersistent()
 
 		with Gaffer.UndoContext( s ) :
 
-			Gaffer.Metadata.registerNodeValue( s["n"], "a", 1, persistent = False )
-			Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "b", 2, persistent = False )
+			Gaffer.Metadata.registerValue( s["n"], "a", 1, persistent = False )
+			Gaffer.Metadata.registerValue( s["n"]["op1"], "b", 2, persistent = False )
 
 		assertNonPersistent()
 
@@ -666,25 +666,25 @@ class MetadataTest( GafferTest.TestCase ) :
 		s["n"] = GafferTest.AddNode()
 
 		ncs = GafferTest.CapturingSlot( Gaffer.Metadata.nodeValueChangedSignal() )
-		pcs = GafferTest.CapturingSlot( Gaffer.Metadata.nodeValueChangedSignal() )
+		pcs = GafferTest.CapturingSlot( Gaffer.Metadata.plugValueChangedSignal() )
 
 		self.assertEqual( len( ncs ), 0 )
 		self.assertEqual( len( pcs ), 0 )
 
-		Gaffer.Metadata.registerNodeValue( s["n"], "a", 1, persistent = False )
-		Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "b", 2, persistent = False )
+		Gaffer.Metadata.registerValue( s["n"], "a", 1, persistent = False )
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "b", 2, persistent = False )
 
 		self.assertEqual( len( ncs ), 1 )
 		self.assertEqual( len( pcs ), 1 )
 
-		Gaffer.Metadata.registerNodeValue( s["n"], "a", 1, persistent = True )
-		Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "b", 2, persistent = True )
+		Gaffer.Metadata.registerValue( s["n"], "a", 1, persistent = True )
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "b", 2, persistent = True )
 
 		self.assertEqual( len( ncs ), 2 )
 		self.assertEqual( len( pcs ), 2 )
 
-		Gaffer.Metadata.registerNodeValue( s["n"], "a", 1, persistent = False )
-		Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "b", 2, persistent = False )
+		Gaffer.Metadata.registerValue( s["n"], "a", 1, persistent = False )
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "b", 2, persistent = False )
 
 		self.assertEqual( len( ncs ), 3 )
 		self.assertEqual( len( pcs ), 3 )
@@ -719,8 +719,8 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		n = MetadataTestNodeD()
 
-		self.assertEqual( Gaffer.Metadata.plugValue( n["a"], "test" ), "exact" )
-		self.assertEqual( Gaffer.Metadata.plugValue( n["b"], "test" ), "wildcard" )
+		self.assertEqual( Gaffer.Metadata.value( n["a"], "test" ), "exact" )
+		self.assertEqual( Gaffer.Metadata.value( n["b"], "test" ), "wildcard" )
 
 	def testNoSerialiseAfterUndo( self ) :
 
@@ -730,7 +730,7 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertFalse( "Metadata" in s.serialise() )
 
 		with Gaffer.UndoContext( s ) :
-			Gaffer.Metadata.registerNodeValue( s["n"], "test", 1 )
+			Gaffer.Metadata.registerValue( s["n"], "test", 1 )
 
 		self.assertTrue( "Metadata" in s.serialise() )
 
@@ -740,113 +740,113 @@ class MetadataTest( GafferTest.TestCase ) :
 	def testNoneMasksOthers( self ) :
 
 		n = GafferTest.AddNode()
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "maskTest" ), None )
+		self.assertEqual( Gaffer.Metadata.value( n, "maskTest" ), None )
 
-		Gaffer.Metadata.registerNodeValue( Gaffer.DependencyNode, "maskTest", 10 )
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "maskTest" ), 10 )
+		Gaffer.Metadata.registerValue( Gaffer.DependencyNode, "maskTest", 10 )
+		self.assertEqual( Gaffer.Metadata.value( n, "maskTest" ), 10 )
 
-		Gaffer.Metadata.registerNodeValue( Gaffer.ComputeNode, "maskTest", None )
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "maskTest" ), None )
+		Gaffer.Metadata.registerValue( Gaffer.ComputeNode, "maskTest", None )
+		self.assertEqual( Gaffer.Metadata.value( n, "maskTest" ), None )
 
-		Gaffer.Metadata.registerNodeValue( GafferTest.AddNode, "maskTest", 20 )
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "maskTest" ), 20 )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "maskTest", 20 )
+		self.assertEqual( Gaffer.Metadata.value( n, "maskTest" ), 20 )
 
-		Gaffer.Metadata.registerNodeValue( n, "maskTest", 30 )
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "maskTest" ), 30 )
+		Gaffer.Metadata.registerValue( n, "maskTest", 30 )
+		self.assertEqual( Gaffer.Metadata.value( n, "maskTest" ), 30 )
 
-		Gaffer.Metadata.registerNodeValue( n, "maskTest", None )
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "maskTest" ), None )
+		Gaffer.Metadata.registerValue( n, "maskTest", None )
+		self.assertEqual( Gaffer.Metadata.value( n, "maskTest" ), None )
 
 	def testDeregisterNodeValue( self ) :
 
 		n = GafferTest.AddNode()
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "deleteMe" ), None )
+		self.assertEqual( Gaffer.Metadata.value( n, "deleteMe" ), None )
 
-		Gaffer.Metadata.registerNodeValue( Gaffer.Node, "deleteMe", 10 )
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "deleteMe" ), 10 )
+		Gaffer.Metadata.registerValue( Gaffer.Node, "deleteMe", 10 )
+		self.assertEqual( Gaffer.Metadata.value( n, "deleteMe" ), 10 )
 
-		Gaffer.Metadata.registerNodeValue( Gaffer.ComputeNode, "deleteMe", 20 )
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "deleteMe" ), 20 )
+		Gaffer.Metadata.registerValue( Gaffer.ComputeNode, "deleteMe", 20 )
+		self.assertEqual( Gaffer.Metadata.value( n, "deleteMe" ), 20 )
 
-		Gaffer.Metadata.deregisterNodeValue( Gaffer.ComputeNode, "deleteMe" )
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "deleteMe" ), 10 )
+		Gaffer.Metadata.deregisterValue( Gaffer.ComputeNode, "deleteMe" )
+		self.assertEqual( Gaffer.Metadata.value( n, "deleteMe" ), 10 )
 
-		Gaffer.Metadata.deregisterNodeValue( Gaffer.Node, "deleteMe" )
-		self.assertEqual( Gaffer.Metadata.nodeValue( n, "deleteMe" ), None )
+		Gaffer.Metadata.deregisterValue( Gaffer.Node, "deleteMe" )
+		self.assertEqual( Gaffer.Metadata.value( n, "deleteMe" ), None )
 
 	def testDeregisterNodeInstanceValue( self ) :
 
 		s = Gaffer.ScriptNode()
 		s["n"] = GafferTest.AddNode()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "deleteMe" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "deleteMe" ), None )
 
-		Gaffer.Metadata.registerNodeValue( GafferTest.AddNode, "deleteMe", 10 )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "deleteMe" ), 10 )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "deleteMe", 10 )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "deleteMe" ), 10 )
 
-		Gaffer.Metadata.registerNodeValue( s["n"], "deleteMe", 20 )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "deleteMe" ), 20 )
+		Gaffer.Metadata.registerValue( s["n"], "deleteMe", 20 )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "deleteMe" ), 20 )
 		self.assertTrue( "Metadata" in s.serialise() )
 
 		with Gaffer.UndoContext( s ) :
-			Gaffer.Metadata.deregisterNodeValue( s["n"], "deleteMe" )
+			Gaffer.Metadata.deregisterValue( s["n"], "deleteMe" )
 			self.assertTrue( "Metadata" not in s.serialise() )
-			self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "deleteMe" ), 10 )
+			self.assertEqual( Gaffer.Metadata.value( s["n"], "deleteMe" ), 10 )
 
 		s.undo()
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "deleteMe" ), 20 )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "deleteMe" ), 20 )
 		self.assertTrue( "Metadata" in s.serialise() )
 
 		s.redo()
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "deleteMe" ), 10 )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "deleteMe" ), 10 )
 		self.assertTrue( "Metadata" not in s.serialise() )
 
-		Gaffer.Metadata.deregisterNodeValue( GafferTest.AddNode, "deleteMe" )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "deleteMe" ), None )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "deleteMe" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "deleteMe" ), None )
 
 		self.assertTrue( "Metadata" not in s.serialise() )
 
 	def testDeregisterPlugValue( self ) :
 
 		n = GafferTest.AddNode()
-		self.assertEqual( Gaffer.Metadata.plugValue( n["op1"], "deleteMe" ), None )
+		self.assertEqual( Gaffer.Metadata.value( n["op1"], "deleteMe" ), None )
 
-		Gaffer.Metadata.registerPlugValue( Gaffer.Node, "op1", "deleteMe", 10 )
-		self.assertEqual( Gaffer.Metadata.plugValue( n["op1"], "deleteMe" ), 10 )
+		Gaffer.Metadata.registerValue( Gaffer.Node, "op1", "deleteMe", 10 )
+		self.assertEqual( Gaffer.Metadata.value( n["op1"], "deleteMe" ), 10 )
 
-		Gaffer.Metadata.deregisterPlugValue( Gaffer.Node, "op1", "deleteMe" )
-		self.assertEqual( Gaffer.Metadata.plugValue( n["op1"], "deleteMe" ), None )
+		Gaffer.Metadata.deregisterValue( Gaffer.Node, "op1", "deleteMe" )
+		self.assertEqual( Gaffer.Metadata.value( n["op1"], "deleteMe" ), None )
 
 	def testDeregisterPlugInstanceValue( self ) :
 
 		s = Gaffer.ScriptNode()
 		s["n"] = GafferTest.AddNode()
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "deleteMe" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "deleteMe" ), None )
 
-		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode, "op1", "deleteMe", 10 )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "deleteMe" ), 10 )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "deleteMe", 10 )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "deleteMe" ), 10 )
 		self.assertTrue( "Metadata" not in s.serialise() )
 
-		Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "deleteMe", 20 )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "deleteMe" ), 20 )
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "deleteMe", 20 )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "deleteMe" ), 20 )
 		self.assertTrue( "Metadata" in s.serialise() )
 
 		with Gaffer.UndoContext( s ) :
-			Gaffer.Metadata.deregisterPlugValue( s["n"]["op1"], "deleteMe" )
+			Gaffer.Metadata.deregisterValue( s["n"]["op1"], "deleteMe" )
 			self.assertTrue( "Metadata" not in s.serialise() )
-			self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "deleteMe" ), 10 )
+			self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "deleteMe" ), 10 )
 
 		s.undo()
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "deleteMe" ), 20 )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "deleteMe" ), 20 )
 		self.assertTrue( "Metadata" in s.serialise() )
 
 		s.redo()
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "deleteMe" ), 10 )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "deleteMe" ), 10 )
 		self.assertTrue( "Metadata" not in s.serialise() )
 
-		Gaffer.Metadata.deregisterPlugValue( GafferTest.AddNode, "op1", "deleteMe" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["op1"], "deleteMe" ), None )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "op1", "deleteMe" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "deleteMe" ), None )
 
 		self.assertTrue( "Metadata" not in s.serialise() )
 
@@ -861,22 +861,22 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "nodeData1"), [] )
 
 		# register instance node values on n and n2:
-		Gaffer.Metadata.registerNodeValue( s["n"], "nodeData1", "something" )
-		Gaffer.Metadata.registerNodeValue( s["n2"], "nodeData2", "something" )
-		Gaffer.Metadata.registerNodeValue( s["m"], "nodeData3", "something" )
-		Gaffer.Metadata.registerNodeValue( s["n"], "nodeData3", "something" )
+		Gaffer.Metadata.registerValue( s["n"], "nodeData1", "something" )
+		Gaffer.Metadata.registerValue( s["n2"], "nodeData2", "something" )
+		Gaffer.Metadata.registerValue( s["m"], "nodeData3", "something" )
+		Gaffer.Metadata.registerValue( s["n"], "nodeData3", "something" )
 
 		# register class value on GafferTest.AddNode:
-		Gaffer.Metadata.registerNodeValue( GafferTest.AddNode, "nodeData3", "something" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "nodeData3", "something" )
 
 		# register some instance plug values:
-		Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "plugData1", "something" )
-		Gaffer.Metadata.registerPlugValue( s["n2"]["op2"], "plugData2", "something" )
-		Gaffer.Metadata.registerPlugValue( s["m"]["op2"], "plugData3", "something" )
-		Gaffer.Metadata.registerPlugValue( s["m"]["op1"], "plugData3", "something" )
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "plugData1", "something" )
+		Gaffer.Metadata.registerValue( s["n2"]["op2"], "plugData2", "something" )
+		Gaffer.Metadata.registerValue( s["m"]["op2"], "plugData3", "something" )
+		Gaffer.Metadata.registerValue( s["m"]["op1"], "plugData3", "something" )
 
 		# register class value on GafferTest.AddNode:
-		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode, "op1", "plugData3", "somethingElse" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "plugData3", "somethingElse" )
 
 		# test it lists nodes with matching data:
 		self.assertEqual( Gaffer.Metadata.nodesWithMetadata( s, "nodeData1" ), [ s["n"] ] )
@@ -944,23 +944,23 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		needsQuoting = """'"\n\\'!"""
 
-		Gaffer.Metadata.registerNodeValue( s["n"], "test", needsQuoting )
-		Gaffer.Metadata.registerNodeValue( s["n"], needsQuoting, "test" )
-		Gaffer.Metadata.registerPlugValue( s["n"]["p"], "test", needsQuoting )
-		Gaffer.Metadata.registerPlugValue( s["n"]["p"], needsQuoting, "test" )
+		Gaffer.Metadata.registerValue( s["n"], "test", needsQuoting )
+		Gaffer.Metadata.registerValue( s["n"], needsQuoting, "test" )
+		Gaffer.Metadata.registerValue( s["n"]["p"], "test", needsQuoting )
+		Gaffer.Metadata.registerValue( s["n"]["p"], needsQuoting, "test" )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "test" ), needsQuoting )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], needsQuoting ), "test" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["p"], "test" ), needsQuoting )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["p"], needsQuoting ), "test" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], "test" ), needsQuoting )
+		self.assertEqual( Gaffer.Metadata.value( s["n"], needsQuoting ), "test" )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["p"], "test" ), needsQuoting )
+		self.assertEqual( Gaffer.Metadata.value( s["n"]["p"], needsQuoting ), "test" )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2["n"], "test" ), needsQuoting )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2["n"], needsQuoting ), "test" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["n"]["p"], "test" ), needsQuoting )
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["n"]["p"], needsQuoting ), "test" )
+		self.assertEqual( Gaffer.Metadata.value( s2["n"], "test" ), needsQuoting )
+		self.assertEqual( Gaffer.Metadata.value( s2["n"], needsQuoting ), "test" )
+		self.assertEqual( Gaffer.Metadata.value( s2["n"]["p"], "test" ), needsQuoting )
+		self.assertEqual( Gaffer.Metadata.value( s2["n"]["p"], needsQuoting ), "test" )
 
 	def testSerialisationOnlyUsesDataWhenNecessary( self ) :
 
@@ -981,11 +981,11 @@ class MetadataTest( GafferTest.TestCase ) :
 			IECore.IntVectorData( [ 1, 2, 3 ] ),
 		] :
 
-			Gaffer.Metadata.registerNodeValue( s["n"], "test", value )
-			Gaffer.Metadata.registerPlugValue( s["n"]["p"], "test", value )
+			Gaffer.Metadata.registerValue( s["n"], "test", value )
+			Gaffer.Metadata.registerValue( s["n"]["p"], "test", value )
 
-			self.assertEqual( Gaffer.Metadata.nodeValue( s["n"], "test" ), value )
-			self.assertEqual( Gaffer.Metadata.plugValue( s["n"]["p"], "test" ), value )
+			self.assertEqual( Gaffer.Metadata.value( s["n"], "test" ), value )
+			self.assertEqual( Gaffer.Metadata.value( s["n"]["p"], "test" ), value )
 
 			ss = s.serialise()
 			if not isinstance( value, IECore.Data ) :
@@ -994,8 +994,8 @@ class MetadataTest( GafferTest.TestCase ) :
 			s2 = Gaffer.ScriptNode()
 			s2.execute( ss )
 
-			self.assertEqual( Gaffer.Metadata.nodeValue( s2["n"], "test" ), value )
-			self.assertEqual( Gaffer.Metadata.plugValue( s2["n"]["p"], "test" ), value )
+			self.assertEqual( Gaffer.Metadata.value( s2["n"], "test" ), value )
+			self.assertEqual( Gaffer.Metadata.value( s2["n"]["p"], "test" ), value )
 
 	def testOverloadedMethods( self ) :
 

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -140,17 +140,13 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		derivedAdd = self.DerivedAddNode()
 		self.assertEqual( Gaffer.Metadata.value( derivedAdd, "iKey" ), "Base class value" )
-		self.assertEqual( Gaffer.Metadata.value( derivedAdd, "iKey", inherit=False ), None )
 
 		Gaffer.Metadata.registerValue( self.DerivedAddNode, "iKey", "Derived class value" )
-		self.assertEqual( Gaffer.Metadata.value( derivedAdd, "iKey", inherit=False ), "Derived class value" )
 
 		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "iKey", "Base class plug value" )
 		self.assertEqual( Gaffer.Metadata.value( derivedAdd["op1"], "iKey" ), "Base class plug value" )
-		self.assertEqual( Gaffer.Metadata.value( derivedAdd["op1"], "iKey", inherit=False ), None )
 
 		Gaffer.Metadata.registerValue( self.DerivedAddNode, "op1", "iKey", "Derived class plug value" )
-		self.assertEqual( Gaffer.Metadata.value( derivedAdd["op1"], "iKey", inherit=False ), "Derived class plug value" )
 
 	def testNodeSignals( self ) :
 

--- a/python/GafferTest/NodeAlgoTest.py
+++ b/python/GafferTest/NodeAlgoTest.py
@@ -47,7 +47,7 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 
 		self.assertEqual( node["op1"].getValue(), 0 )
 		self.assertFalse( Gaffer.NodeAlgo.hasUserDefault( node["op1"] ) )
-		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode.staticTypeId(), "op1", "userDefault", IECore.IntData( 7 ) )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode.staticTypeId(), "op1", "userDefault", IECore.IntData( 7 ) )
 		self.assertTrue( Gaffer.NodeAlgo.hasUserDefault( node["op1"] ) )
 		self.assertFalse( Gaffer.NodeAlgo.isSetToUserDefault( node["op1"] ) )
 		Gaffer.NodeAlgo.applyUserDefaults( node )
@@ -67,7 +67,7 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 
 		# the userDefault can be unregistered by overriding with None
 		node3 = GafferTest.AddNode()
-		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode.staticTypeId(), "op1", "userDefault", None )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode.staticTypeId(), "op1", "userDefault", None )
 		self.assertFalse( Gaffer.NodeAlgo.hasUserDefault( node3["op1"] ) )
 		Gaffer.NodeAlgo.applyUserDefaults( node3 )
 		self.assertEqual( node3["op1"].getValue(), 0 )
@@ -78,14 +78,14 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 		node = GafferTest.CompoundPlugNode()
 
 		self.assertEqual( node["p"]["s"].getValue(), "" )
-		Gaffer.Metadata.registerPlugValue( GafferTest.CompoundPlugNode.staticTypeId(), "p.s", "userDefault", IECore.StringData( "from the metadata" ) )
+		Gaffer.Metadata.registerValue( GafferTest.CompoundPlugNode.staticTypeId(), "p.s", "userDefault", IECore.StringData( "from the metadata" ) )
 		self.assertFalse( Gaffer.NodeAlgo.isSetToUserDefault( node["p"]["s"] ) )
 		Gaffer.NodeAlgo.applyUserDefaults( node )
 		self.assertEqual( node["p"]["s"].getValue(), "from the metadata" )
 		self.assertTrue( Gaffer.NodeAlgo.isSetToUserDefault( node["p"]["s"] ) )
 
 		# override the metadata for this particular instance
-		Gaffer.Metadata.registerPlugValue( node["p"]["s"], "userDefault", IECore.StringData( "i am special" ) )
+		Gaffer.Metadata.registerValue( node["p"]["s"], "userDefault", IECore.StringData( "i am special" ) )
 		self.assertFalse( Gaffer.NodeAlgo.isSetToUserDefault( node["p"]["s"] ) )
 		Gaffer.NodeAlgo.applyUserDefaults( node )
 		self.assertEqual( node["p"]["s"].getValue(), "i am special" )
@@ -106,8 +106,8 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 		self.assertEqual( node["op1"].getValue(), 0 )
 		self.assertEqual( node2["op1"].getValue(), 0 )
 
-		Gaffer.Metadata.registerPlugValue( GafferTest.AddNode.staticTypeId(), "op1", "userDefault", IECore.IntData( 1 ) )
-		Gaffer.Metadata.registerPlugValue( node2["op1"], "userDefault", IECore.IntData( 2 ) )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode.staticTypeId(), "op1", "userDefault", IECore.IntData( 1 ) )
+		Gaffer.Metadata.registerValue( node2["op1"], "userDefault", IECore.IntData( 2 ) )
 		Gaffer.NodeAlgo.applyUserDefaults( [ node, node2 ] )
 
 		self.assertEqual( node["op1"].getValue(), 1 )
@@ -120,8 +120,8 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.NodeAlgo.presets( node["op1"] ), [] )
 		self.assertEqual( Gaffer.NodeAlgo.currentPreset( node["op1"] ), None )
 
-		Gaffer.Metadata.registerPlugValue( node["op1"], "preset:one", 1 )
-		Gaffer.Metadata.registerPlugValue( node["op1"], "preset:two", 2 )
+		Gaffer.Metadata.registerValue( node["op1"], "preset:one", 1 )
+		Gaffer.Metadata.registerValue( node["op1"], "preset:two", 2 )
 
 		self.assertEqual( Gaffer.NodeAlgo.presets( node["op1"] ), [ "one", "two" ] )
 		self.assertEqual( Gaffer.NodeAlgo.currentPreset( node["op1"] ), None )
@@ -139,12 +139,12 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 		node = GafferTest.AddNode()
 		self.assertEqual( Gaffer.NodeAlgo.presets( node["op1"] ), [] )
 
-		Gaffer.Metadata.registerPlugValue(
+		Gaffer.Metadata.registerValue(
 			node["op1"], "presetNames",
 			IECore.StringVectorData( [ "a", "b", "c" ] )
 		)
 
-		Gaffer.Metadata.registerPlugValue(
+		Gaffer.Metadata.registerValue(
 			node["op1"], "presetValues",
 			IECore.IntVectorData( [ 1, 2, 3 ] )
 		)
@@ -165,7 +165,7 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 
 		# a preset registered individually should take precedence
 
-		Gaffer.Metadata.registerPlugValue( node["op1"], "preset:c", 10 )
+		Gaffer.Metadata.registerValue( node["op1"], "preset:c", 10 )
 		self.assertEqual( Gaffer.NodeAlgo.currentPreset( node["op1"] ), None )
 
 		Gaffer.NodeAlgo.applyPreset( node["op1"], "c" )

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -249,7 +249,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n1"] ] ) )
 		p = b.promotePlug( b["n1"]["op1"] )
 
-		Gaffer.Metadata.registerPlugValue( p, "description", "ppp" )
+		Gaffer.Metadata.registerValue( p, "description", "ppp" )
 
 		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
@@ -257,11 +257,11 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s2["r"] = Gaffer.Reference()
 		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["r"].descendant( p.relativeName( b ) ), "description" ), "ppp" )
+		self.assertEqual( Gaffer.Metadata.value( s2["r"].descendant( p.relativeName( b ) ), "description" ), "ppp" )
 
 		s3 = Gaffer.ScriptNode()
 		s3.execute( s2.serialise() )
-		self.assertEqual( Gaffer.Metadata.plugValue( s3["r"].descendant( p.relativeName( b ) ), "description" ), "ppp" )
+		self.assertEqual( Gaffer.Metadata.value( s3["r"].descendant( p.relativeName( b ) ), "description" ), "ppp" )
 
 	def testMetadataIsntResaved( self ) :
 
@@ -271,7 +271,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n1"] ] ) )
 		p = b.promotePlug( b["n1"]["op1"] )
 
-		Gaffer.Metadata.registerPlugValue( p, "description", "ppp" )
+		Gaffer.Metadata.registerValue( p, "description", "ppp" )
 
 		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
@@ -287,14 +287,14 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["b"] = Gaffer.Box()
 		s["b"]["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
-		Gaffer.Metadata.registerPlugValue( s["b"]["p"], "description", "ddd" )
+		Gaffer.Metadata.registerValue( s["b"]["p"], "description", "ddd" )
 
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
 		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s["r"]["p"], "description" ), "ddd" )
+		self.assertEqual( Gaffer.Metadata.value( s["r"]["p"], "description" ), "ddd" )
 
 	def testEditPlugMetadata( self ) :
 
@@ -307,7 +307,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		p = b.promotePlug( b["n1"]["op1"] )
 		p.setName( "p" )
 
-		Gaffer.Metadata.registerPlugValue( p, "test", "referenced" )
+		Gaffer.Metadata.registerValue( p, "test", "referenced" )
 
 		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
@@ -317,23 +317,23 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s2["r"] = Gaffer.Reference()
 		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["r"]["p"], "test" ), "referenced" )
+		self.assertEqual( Gaffer.Metadata.value( s2["r"]["p"], "test" ), "referenced" )
 
 		# Edit it, and check it overwrote the original.
 
-		Gaffer.Metadata.registerPlugValue( s2["r"]["p"], "test", "edited" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["r"]["p"], "test" ), "edited" )
+		Gaffer.Metadata.registerValue( s2["r"]["p"], "test", "edited" )
+		self.assertEqual( Gaffer.Metadata.value( s2["r"]["p"], "test" ), "edited" )
 
 		# Save and load the script, and check the edit stays in place.
 
 		s3 = Gaffer.ScriptNode()
 		s3.execute( s2.serialise() )
-		self.assertEqual( Gaffer.Metadata.plugValue( s3["r"]["p"], "test" ), "edited" )
+		self.assertEqual( Gaffer.Metadata.value( s3["r"]["p"], "test" ), "edited" )
 
 		# Reload the reference, and check the edit stays in place.
 
 		s3["r"].load( self.temporaryDirectory() + "/test.grf" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s3["r"]["p"], "test" ), "edited" )
+		self.assertEqual( Gaffer.Metadata.value( s3["r"]["p"], "test" ), "edited" )
 
 	def testAddPlugMetadata( self ) :
 
@@ -356,19 +356,19 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		# Add some metadata to the Reference node (not the reference file)
 
-		Gaffer.Metadata.registerPlugValue( s2["r"]["p"], "test", "added" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["r"]["p"], "test" ), "added" )
+		Gaffer.Metadata.registerValue( s2["r"]["p"], "test", "added" )
+		self.assertEqual( Gaffer.Metadata.value( s2["r"]["p"], "test" ), "added" )
 
 		# Save and load the script, and check the added metadata stays in place.
 
 		s3 = Gaffer.ScriptNode()
 		s3.execute( s2.serialise() )
-		self.assertEqual( Gaffer.Metadata.plugValue( s3["r"]["p"], "test" ), "added" )
+		self.assertEqual( Gaffer.Metadata.value( s3["r"]["p"], "test" ), "added" )
 
 		# Reload the reference, and check the edit stays in place.
 
 		s3["r"].load( self.temporaryDirectory() + "/test.grf" )
-		self.assertEqual( Gaffer.Metadata.plugValue( s3["r"]["p"], "test" ), "added" )
+		self.assertEqual( Gaffer.Metadata.value( s3["r"]["p"], "test" ), "added" )
 
 	def testReloadWithUnconnectedPlugs( self ) :
 
@@ -397,14 +397,14 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["r"] = Gaffer.Reference()
 		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s["r"]["p"], "test" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s["r"]["p"], "test" ), None )
 
-		Gaffer.Metadata.registerPlugValue( s["b"]["p"], "test", 10 )
+		Gaffer.Metadata.registerValue( s["b"]["p"], "test", 10 )
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s["r"]["p"], "test" ), 10 )
+		self.assertEqual( Gaffer.Metadata.value( s["r"]["p"], "test" ), 10 )
 
 	def testDefaultValueClashes( self ) :
 
@@ -736,16 +736,16 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["b"] = Gaffer.Box()
 
-		Gaffer.Metadata.registerNodeValue( s["b"], "description", "Test description" )
-		Gaffer.Metadata.registerNodeValue( s["b"], "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
+		Gaffer.Metadata.registerValue( s["b"], "description", "Test description" )
+		Gaffer.Metadata.registerValue( s["b"], "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
 
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
 		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["r"], "description" ), "Test description" )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["r"], "nodeGadget:color" ), IECore.Color3f( 1, 0, 0 ) )
+		self.assertEqual( Gaffer.Metadata.value( s["r"], "description" ), "Test description" )
+		self.assertEqual( Gaffer.Metadata.value( s["r"], "nodeGadget:color" ), IECore.Color3f( 1, 0, 0 ) )
 
 	def testVersionMetadata( self ) :
 
@@ -756,15 +756,15 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["r"] = Gaffer.Reference()
 		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["r"], "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["r"], "serialiser:majorVersion" ), Gaffer.About.majorVersion() )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["r"], "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s["r"], "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s["r"], "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s["r"], "serialiser:majorVersion" ), Gaffer.About.majorVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s["r"], "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s["r"], "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
 
-		self.assertTrue( "serialiser:milestoneVersion" not in Gaffer.Metadata.registeredNodeValues( s["r"], persistentOnly = True ) )
-		self.assertTrue( "serialiser:majorVersion" not in Gaffer.Metadata.registeredNodeValues( s["r"], persistentOnly = True ) )
-		self.assertTrue( "serialiser:minorVersion" not in Gaffer.Metadata.registeredNodeValues( s["r"], persistentOnly = True ) )
-		self.assertTrue( "serialiser:patchVersion" not in Gaffer.Metadata.registeredNodeValues( s["r"], persistentOnly = True ) )
+		self.assertTrue( "serialiser:milestoneVersion" not in Gaffer.Metadata.registeredValues( s["r"], persistentOnly = True ) )
+		self.assertTrue( "serialiser:majorVersion" not in Gaffer.Metadata.registeredValues( s["r"], persistentOnly = True ) )
+		self.assertTrue( "serialiser:minorVersion" not in Gaffer.Metadata.registeredValues( s["r"], persistentOnly = True ) )
+		self.assertTrue( "serialiser:patchVersion" not in Gaffer.Metadata.registeredValues( s["r"], persistentOnly = True ) )
 
 	def testBackwardCompatibility( self ) :
 
@@ -845,26 +845,26 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["r"] = Gaffer.Reference()
 		s["r"]["user"]["p"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
-		Gaffer.Metadata.registerPlugValue( s["r"]["user"], "testPersistent", 1, persistent = True )
-		Gaffer.Metadata.registerPlugValue( s["r"]["user"], "testNonPersistent", 2, persistent = False )
+		Gaffer.Metadata.registerValue( s["r"]["user"], "testPersistent", 1, persistent = True )
+		Gaffer.Metadata.registerValue( s["r"]["user"], "testNonPersistent", 2, persistent = False )
 
-		Gaffer.Metadata.registerPlugValue( s["r"]["user"]["p"], "testPersistent", 3, persistent = True )
-		Gaffer.Metadata.registerPlugValue( s["r"]["user"]["p"], "testNonPersistent", 4, persistent = False )
+		Gaffer.Metadata.registerValue( s["r"]["user"]["p"], "testPersistent", 3, persistent = True )
+		Gaffer.Metadata.registerValue( s["r"]["user"]["p"], "testNonPersistent", 4, persistent = False )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s["r"]["user"], "testPersistent" ), 1 )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["r"]["user"], "testNonPersistent" ), 2 )
+		self.assertEqual( Gaffer.Metadata.value( s["r"]["user"], "testPersistent" ), 1 )
+		self.assertEqual( Gaffer.Metadata.value( s["r"]["user"], "testNonPersistent" ), 2 )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s["r"]["user"]["p"], "testPersistent" ), 3 )
-		self.assertEqual( Gaffer.Metadata.plugValue( s["r"]["user"]["p"], "testNonPersistent" ), 4 )
+		self.assertEqual( Gaffer.Metadata.value( s["r"]["user"]["p"], "testPersistent" ), 3 )
+		self.assertEqual( Gaffer.Metadata.value( s["r"]["user"]["p"], "testNonPersistent" ), 4 )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["r"]["user"], "testPersistent" ), 1 )
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["r"]["user"], "testNonPersistent" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s2["r"]["user"], "testPersistent" ), 1 )
+		self.assertEqual( Gaffer.Metadata.value( s2["r"]["user"], "testNonPersistent" ), None )
 
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["r"]["user"]["p"], "testPersistent" ), 3 )
-		self.assertEqual( Gaffer.Metadata.plugValue( s2["r"]["user"]["p"], "testNonPersistent" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s2["r"]["user"]["p"], "testPersistent" ), 3 )
+		self.assertEqual( Gaffer.Metadata.value( s2["r"]["user"]["p"], "testNonPersistent" ), None )
 
 	def testNamespaceIsClear( self ) :
 

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -991,6 +991,26 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertTrue( "a" in s2["r"]["user"] )
 		self.assertTrue( "b" in s2["r"]["user"] )
 
+	def testCopyPaste( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["a1"] = GafferTest.AddNode()
+		s["b"]["a2"] = GafferTest.AddNode()
+		s["b"]["a2"]["op1"].setInput( s["b"]["a1"]["sum"] )
+		s["b"].promotePlug( s["b"]["a1"]["op1"] )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
+
+		s["r"] = Gaffer.Reference()
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
+
+		s.execute( s.serialise( parent = s["r"], filter = Gaffer.StandardSet( [ s["r"]["a1"], s["r"]["a2"] ] ) ) )
+
+		self.assertTrue( "a1" in s )
+		self.assertTrue( "a2" in s )
+		self.assertTrue( s["a2"]["op1"].getInput().isSame( s["a1"]["sum"] ) )
+
 	def tearDown( self ) :
 
 		GafferTest.TestCase.tearDown( self )

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -1005,11 +1005,17 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["r"] = Gaffer.Reference()
 		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
+		self.assertTrue( Gaffer.readOnly( s["r"]["a1"] ) )
+		self.assertTrue( Gaffer.readOnly( s["r"]["a2"] ) )
+
 		s.execute( s.serialise( parent = s["r"], filter = Gaffer.StandardSet( [ s["r"]["a1"], s["r"]["a2"] ] ) ) )
 
 		self.assertTrue( "a1" in s )
 		self.assertTrue( "a2" in s )
 		self.assertTrue( s["a2"]["op1"].getInput().isSame( s["a1"]["sum"] ) )
+
+		self.assertFalse( Gaffer.readOnly( s["a1"] ) )
+		self.assertFalse( Gaffer.readOnly( s["a2"] ) )
 
 	def tearDown( self ) :
 

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -66,10 +66,10 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n1"] ] ) )
 
-		b.exportForReference( "/tmp/test.grf" )
+		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( "n1" in s["r"] )
 		self.assertTrue( s["r"]["sum"].getInput().isSame( s["r"]["n1"]["sum"] ) )
@@ -84,11 +84,11 @@ class ReferenceTest( GafferTest.TestCase ) :
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n1"] ] ) )
 		b.promotePlug( b["n1"]["op1"] )
 
-		b.exportForReference( "/tmp/test.grf" )
+		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s = Gaffer.ScriptNode()
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( "n1" in s["r"] )
 		self.assertTrue( s["r"]["n1"]["op1"].getInput().isSame( s["r"]["op1"] ) )
@@ -125,13 +125,13 @@ class ReferenceTest( GafferTest.TestCase ) :
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n2"] ] ) )
 		b.promotePlug( b["n2"]["op2"] )
 
-		b.exportForReference( "/tmp/test.grf" )
+		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s2 = Gaffer.ScriptNode()
 		s2["n1"] = GafferTest.AddNode()
 		s2["n3"] = GafferTest.AddNode()
 		s2["r"] = Gaffer.Reference()
-		s2["r"].load( "/tmp/test.grf" )
+		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		s2["r"]["op1"].setInput( s2["n1"]["sum"] )
 		s2["r"]["op2"].setValue( 1001 )
@@ -148,9 +148,9 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		b["anotherNode"] = GafferTest.AddNode()
 		b.promotePlug( b["anotherNode"]["op2"] )
-		s.serialiseToFile( "/tmp/test.grf", b )
+		s.serialiseToFile( self.temporaryDirectory() + "/test.grf", b )
 
-		s2["r"].load( "/tmp/test.grf" )
+		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( "n2" in s2["r"] )
 		self.assertEqual( set( s2["r"].keys() ), set( originalReferencedNames + [ "anotherNode", "op3" ] ) )
@@ -174,15 +174,15 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["n2"]["op1"].setInput( s["n1"]["sum"] )
 
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n1"] ] ) )
-		b.exportForReference( "/tmp/test.grf" )
+		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s2 = Gaffer.ScriptNode()
 		s2["r"] = Gaffer.Reference()
-		s2["r"].load( "/tmp/test.grf" )
+		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		s2["r"]["__mySpecialPlug"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
-		s2["r"].load( "/tmp/test.grf" )
+		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( "__mySpecialPlug" in s2["r"] )
 
@@ -197,11 +197,11 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n2"] ] ) )
 		b.promotePlug( b["n2"]["op2"] )
-		b.exportForReference( "/tmp/test.grf" )
+		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s2 = Gaffer.ScriptNode()
 		s2["r"] = Gaffer.Reference()
-		s2["r"].load( "/tmp/test.grf" )
+		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 		s2["a"] = GafferTest.AddNode()
 
 		s2["r"]["op2"].setValue( 123 )
@@ -211,11 +211,11 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertTrue( "sum" in s2["r"] )
 		self.assertTrue( s2["r"]["op1"].getInput().isSame( s2["a"]["sum"] ) )
 
-		s2["fileName"].setValue( "/tmp/test.gfr" )
+		s2["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s2.save()
 
 		s3 = Gaffer.ScriptNode()
-		s3["fileName"].setValue( "/tmp/test.gfr" )
+		s3["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s3.load()
 
 		self.assertEqual( s3["r"].keys(), s2["r"].keys() )
@@ -232,11 +232,11 @@ class ReferenceTest( GafferTest.TestCase ) :
 		b["myCustomPlug"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		b["__invisiblePlugThatShouldntGetExported"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
-		b.exportForReference( "/tmp/test.grf" )
+		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s2 = Gaffer.ScriptNode()
 		s2["r"] = Gaffer.Reference()
-		s2["r"].load( "/tmp/test.grf" )
+		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( "myCustomPlug" in s2["r"] )
 		self.assertTrue( "__invisiblePlugThatShouldntGetExported" not in s2["r"] )
@@ -251,11 +251,11 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		Gaffer.Metadata.registerPlugValue( p, "description", "ppp" )
 
-		b.exportForReference( "/tmp/test.grf" )
+		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s2 = Gaffer.ScriptNode()
 		s2["r"] = Gaffer.Reference()
-		s2["r"].load( "/tmp/test.grf" )
+		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertEqual( Gaffer.Metadata.plugValue( s2["r"].descendant( p.relativeName( b ) ), "description" ), "ppp" )
 
@@ -273,11 +273,11 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		Gaffer.Metadata.registerPlugValue( p, "description", "ppp" )
 
-		b.exportForReference( "/tmp/test.grf" )
+		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s2 = Gaffer.ScriptNode()
 		s2["r"] = Gaffer.Reference()
-		s2["r"].load( "/tmp/test.grf" )
+		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( "Metadata" not in s2.serialise() )
 
@@ -289,10 +289,10 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		Gaffer.Metadata.registerPlugValue( s["b"]["p"], "description", "ddd" )
 
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertEqual( Gaffer.Metadata.plugValue( s["r"]["p"], "description" ), "ddd" )
 
@@ -309,13 +309,13 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		Gaffer.Metadata.registerPlugValue( p, "test", "referenced" )
 
-		b.exportForReference( "/tmp/test.grf" )
+		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		# Reference it, and check it loaded.
 
 		s2 = Gaffer.ScriptNode()
 		s2["r"] = Gaffer.Reference()
-		s2["r"].load( "/tmp/test.grf" )
+		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertEqual( Gaffer.Metadata.plugValue( s2["r"]["p"], "test" ), "referenced" )
 
@@ -332,7 +332,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		# Reload the reference, and check the edit stays in place.
 
-		s3["r"].load( "/tmp/test.grf" )
+		s3["r"].load( self.temporaryDirectory() + "/test.grf" )
 		self.assertEqual( Gaffer.Metadata.plugValue( s3["r"]["p"], "test" ), "edited" )
 
 	def testAddPlugMetadata( self ) :
@@ -346,13 +346,13 @@ class ReferenceTest( GafferTest.TestCase ) :
 		p = b.promotePlug( b["n1"]["op1"] )
 		p.setName( "p" )
 
-		b.exportForReference( "/tmp/test.grf" )
+		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		# Reference it, and check it loaded.
 
 		s2 = Gaffer.ScriptNode()
 		s2["r"] = Gaffer.Reference()
-		s2["r"].load( "/tmp/test.grf" )
+		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		# Add some metadata to the Reference node (not the reference file)
 
@@ -367,7 +367,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		# Reload the reference, and check the edit stays in place.
 
-		s3["r"].load( "/tmp/test.grf" )
+		s3["r"].load( self.temporaryDirectory() + "/test.grf" )
 		self.assertEqual( Gaffer.Metadata.plugValue( s3["r"]["p"], "test" ), "added" )
 
 	def testReloadWithUnconnectedPlugs( self ) :
@@ -375,10 +375,10 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["b"] = Gaffer.Box()
 		s["b"]["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertEqual( s["r"].keys(), [ "user", "p" ] )
 
@@ -392,17 +392,17 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["b"] = Gaffer.Box()
 		s["b"]["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertEqual( Gaffer.Metadata.plugValue( s["r"]["p"], "test" ), None )
 
 		Gaffer.Metadata.registerPlugValue( s["b"]["p"], "test", 10 )
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertEqual( Gaffer.Metadata.plugValue( s["r"]["p"], "test" ), 10 )
 
@@ -417,27 +417,27 @@ class ReferenceTest( GafferTest.TestCase ) :
 		p = s["b"].promotePlug( s["b"]["n"]["op1"] )
 		p.setValue( 10 )
 
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		# reference it in to a new script, set the value back to
 		# its default, and save the script.
 
 		s2 = Gaffer.ScriptNode()
 		s2["r"] = Gaffer.Reference()
-		s2["r"].load( "/tmp/test.grf" )
+		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		p2 = s2["r"].descendant( p.relativeName( s["b"] ) )
 		self.assertEqual( p2.getValue(), 10 )
 		p2.setToDefault()
 		self.assertEqual( p2.getValue(), p2.defaultValue() )
 
-		s2["fileName"].setValue( "/tmp/test.gfr" )
+		s2["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s2.save()
 
 		# load the script, and check that the value is at the default.
 
 		s3 = Gaffer.ScriptNode()
-		s3["fileName"].setValue( "/tmp/test.gfr" )
+		s3["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s3.load()
 
 		p3 = s3["r"].descendant( p.relativeName( s["b"] ) )
@@ -449,7 +449,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["b"] = Gaffer.Box()
 		s["b"]["n"] = GafferTest.SphereNode()
 
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		del GafferTest.SphereNode # induce a failure during loading
 
@@ -457,7 +457,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s2["r"] = Gaffer.Reference()
 
 		with IECore.CapturingMessageHandler() as mh :
-			self.assertRaises( Exception, s2["r"].load, "/tmp/test.grf" )
+			self.assertRaises( Exception, s2["r"].load, self.temporaryDirectory() + "/test.grf" )
 
 		self.assertEqual( len( mh.messages ), 2 )
 		self.assertTrue( "has no attribute 'SphereNode'" in mh.messages[0].message )
@@ -472,13 +472,13 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["b"]["s"] = GafferTest.SphereNode()
 		s["b"]["a"] = GafferTest.AddNode()
 
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		# import it into a script.
 
 		s2 = Gaffer.ScriptNode()
 		s2["r"] = Gaffer.Reference()
-		s2["r"].load( "/tmp/test.grf" )
+		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( "a" in s2["r"] )
 		self.assertTrue( isinstance( s2["r"]["a"], GafferTest.AddNode ) )
@@ -486,7 +486,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		# save that script, and then mysteriously
 		# disable GafferTest.SphereNode.
 
-		s2["fileName"].setValue( "/tmp/test.gfr" )
+		s2["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s2.save()
 
 		del GafferTest.SphereNode
@@ -495,7 +495,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		# load in the other referenced node.
 
 		s3 = Gaffer.ScriptNode()
-		s3["fileName"].setValue( "/tmp/test.gfr" )
+		s3["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		with IECore.CapturingMessageHandler() as mh :
 			s3.load( continueOnError=True )
 
@@ -520,38 +520,38 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["b"] = Gaffer.Box()
 		s["b"]["n"] = GafferTest.AddNode()
 		s["b"].promotePlug( s["b"]["n"]["sum"] )
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		# load onto reference:
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 		self.assertEqual( s["r"].correspondingInput( s["r"]["sum"] ), None )
 		self.assertEqual( s["r"].enabledPlug(), None )
 
 		# Wire it up to support enabledPlug() and correspondingInput()
 		s["b"].promotePlug( s["b"]["n"]["op1"] )
 		s["b"]["n"]["op2"].setValue( 10 )
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		# reload reference and test:
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 		self.assertEqual( s["r"].correspondingInput( s["r"]["sum"] ), None )
 		self.assertEqual( s["r"].enabledPlug(), None )
 
 		# add an enabled plug:
 		s["b"]["enabled"] = Gaffer.BoolPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		# reload reference and test that's now visible via enabledPlug():
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 		self.assertEqual( s["r"].correspondingInput( s["r"]["sum"] ), None )
 		self.assertTrue( s["r"].enabledPlug().isSame( s["r"]["enabled"] ) )
 
 		# hook up the enabled plug inside the box:
 		s["b"]["n"]["enabled"].setInput( s["b"]["enabled"] )
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		# reload reference and test that's now visible via enabledPlug():
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 		self.assertTrue( s["r"].enabledPlug().isSame( s["r"]["enabled"] ) )
 		self.assertTrue( s["r"].correspondingInput( s["r"]["sum"] ).isSame( s["r"]["op1"] ) )
 
@@ -574,13 +574,13 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["b"]["s"] = GafferTest.SphereNode()
 		s["b"]["a"] = GafferTest.AddNode()
 
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		# import it into a script.
 
 		s2 = Gaffer.ScriptNode()
 		s2["r"] = Gaffer.Reference()
-		s2["r"].load( "/tmp/test.grf" )
+		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 		s2["r"]["__pluggy"] = Gaffer.CompoundPlug( flags = Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
 		s2["r"]["__pluggy"]["int"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
 		s2["r"]["__pluggy"]["compound"] = Gaffer.CompoundPlug( flags = Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
@@ -591,7 +591,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertEqual( s2["r"]["__pluggy"]["compound"].getFlags(), Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
 		self.assertEqual( s2["r"]["__pluggy"]["compound"]["int"].getFlags(), Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
 
-		s2["r"].load( "/tmp/test.grf" )
+		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertEqual( s2["r"]["__pluggy"].getFlags(), Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
 		self.assertEqual( s2["r"]["__pluggy"]["int"].getFlags(), Gaffer.Plug.Flags.Dynamic | Gaffer.Plug.Flags.Default )
@@ -604,10 +604,10 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["b"] = Gaffer.Box()
 		s["b"]["p"] = Gaffer.IntPlug( defaultValue = 1, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["b"]["p"].setValue( 2 )
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		# The value at the time of box export should become
 		# the default value on the reference node. But the
@@ -621,7 +621,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		# And we should be able to save and reload the script
 		# and have that still be the case.
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 		s.load()
 
@@ -635,8 +635,8 @@ class ReferenceTest( GafferTest.TestCase ) :
 		# and the new default.
 
 		s["b"]["p"].setValue( 3 )
-		s["b"].exportForReference( "/tmp/test.grf" )
-		s["r"].load( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertEqual( s["r"]["p"].getValue(), 3 )
 		self.assertEqual( s["r"]["p"].defaultValue(), 3 )
@@ -677,8 +677,8 @@ class ReferenceTest( GafferTest.TestCase ) :
 		# reference.
 
 		s["b"]["p"].setValue( 4 )
-		s["b"].exportForReference( "/tmp/test.grf" )
-		s["r"].load( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertEqual( s["r"]["p"].getValue(), 100 )
 		self.assertEqual( s["r"]["p"].defaultValue(), 4 )
@@ -700,7 +700,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		# value, there shouldn't be any need for a single
 		# setValue() call in the exported file.
 
-		e = "".join( file( "/tmp/test.grf" ).readlines() )
+		e = "".join( file( self.temporaryDirectory() + "/test.grf" ).readlines() )
 		self.assertTrue( "setValue" not in e )
 
 	def testInternalNodeDefaultValues( self ) :
@@ -710,10 +710,10 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["b"]["n"] = Gaffer.Node()
 		s["b"]["n"]["p"] = Gaffer.IntPlug( defaultValue = 1, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["b"]["n"]["p"].setValue( 2 )
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		# Nothing at all should have changed about the
 		# values and defaults on the internal nodes.
@@ -724,7 +724,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		# And we should be able to save and reload the script
 		# and have that still be the case.
 
-		s["fileName"].setValue( "/tmp/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 		s.load()
 
@@ -739,10 +739,10 @@ class ReferenceTest( GafferTest.TestCase ) :
 		Gaffer.Metadata.registerNodeValue( s["b"], "description", "Test description" )
 		Gaffer.Metadata.registerNodeValue( s["b"], "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
 
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertEqual( Gaffer.Metadata.nodeValue( s["r"], "description" ), "Test description" )
 		self.assertEqual( Gaffer.Metadata.nodeValue( s["r"], "nodeGadget:color" ), IECore.Color3f( 1, 0, 0 ) )
@@ -751,10 +751,10 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 		s["b"] = Gaffer.Box()
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertEqual( Gaffer.Metadata.nodeValue( s["r"], "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
 		self.assertEqual( Gaffer.Metadata.nodeValue( s["r"], "serialiser:majorVersion" ), Gaffer.About.majorVersion() )
@@ -883,10 +883,10 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["b"] = Gaffer.Box()
 		s["b"]["fileName"] = Gaffer.StringPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["b"]["fileName"].setValue( "iAmUsingThisForMyOwnPurposes" )
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertEqual( s["r"]["fileName"].getValue(), "iAmUsingThisForMyOwnPurposes" )
 
@@ -915,20 +915,20 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["b"] = Gaffer.Box()
 		s["b"]["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
 		self.assertEqual( s["r"].fileName(), "" )
 
-		s["r"].load( "/tmp/test.grf" )
-		self.assertEqual( s["r"].fileName(), "/tmp/test.grf" )
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
+		self.assertEqual( s["r"].fileName(), self.temporaryDirectory() + "/test.grf" )
 
 	def testUndo( self ) :
 
 		s = Gaffer.ScriptNode()
 		s["b"] = Gaffer.Box()
 		s["b"]["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		s["b"].exportForReference( "/tmp/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
 		self.assertEqual( s["r"].fileName(), "" )
@@ -942,12 +942,12 @@ class ReferenceTest( GafferTest.TestCase ) :
 		c = s["r"].referenceLoadedSignal().connect( referenceLoaded )
 
 		with Gaffer.UndoContext( s ) :
-			s["r"].load( "/tmp/test.grf" )
+			s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( "p" in s["r"] )
-		self.assertEqual( s["r"].fileName(), "/tmp/test.grf" )
+		self.assertEqual( s["r"].fileName(), self.temporaryDirectory() + "/test.grf" )
 		self.assertTrue( len( states ), 1 )
-		self.assertEqual( states[0], State( [ "user", "p" ], "/tmp/test.grf" ) )
+		self.assertEqual( states[0], State( [ "user", "p" ], self.temporaryDirectory() + "/test.grf" ) )
 
 		s.undo()
 		self.assertEqual( s["r"].fileName(), "" )
@@ -957,9 +957,9 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		s.redo()
 		self.assertTrue( "p" in s["r"] )
-		self.assertEqual( s["r"].fileName(), "/tmp/test.grf" )
+		self.assertEqual( s["r"].fileName(), self.temporaryDirectory() + "/test.grf" )
 		self.assertTrue( len( states ), 3 )
-		self.assertEqual( states[2], State( [ "user", "p" ], "/tmp/test.grf" ) )
+		self.assertEqual( states[2], State( [ "user", "p" ], self.temporaryDirectory() + "/test.grf" ) )
 
 	def testUserPlugsNotReferenced( self ) :
 
@@ -999,7 +999,6 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		for f in (
 			"/tmp/test.grf",
-			"/tmp/test.gfr",
 		) :
 			if os.path.exists( f ) :
 				os.remove( f )

--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -1127,9 +1127,9 @@ a = A()"""
 		self.assertEqual( s.refCount(), c )
 
 		with Gaffer.UndoContext( s ) :
-			Gaffer.Metadata.registerNodeValue( s, "test", 10 )
-			Gaffer.Metadata.registerNodeValue( s["n2"], "test", 10 )
-			Gaffer.Metadata.registerPlugValue( s["n2"]["p"], "test", 10 )
+			Gaffer.Metadata.registerValue( s, "test", 10 )
+			Gaffer.Metadata.registerValue( s["n2"], "test", 10 )
+			Gaffer.Metadata.registerValue( s["n2"]["p"], "test", 10 )
 		self.assertEqual( s.refCount(), c )
 
 		with Gaffer.UndoContext( s ) :
@@ -1189,36 +1189,36 @@ a = A()"""
 
 		s = Gaffer.ScriptNode()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:milestoneVersion" ), None )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:majorVersion" ), None )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:minorVersion" ), None )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:patchVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s, "serialiser:milestoneVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s, "serialiser:majorVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s, "serialiser:minorVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s, "serialiser:patchVersion" ), None )
 
 		s.serialiseToFile( self.temporaryDirectory() + "/test.gfr" )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:milestoneVersion" ), None )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:majorVersion" ), None )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:minorVersion" ), None )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:patchVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s, "serialiser:milestoneVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s, "serialiser:majorVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s, "serialiser:minorVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.value( s, "serialiser:patchVersion" ), None )
 
 		s2 = Gaffer.ScriptNode()
 		s2["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s2.load()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:majorVersion" ), Gaffer.About.majorVersion() )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s2, "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s2, "serialiser:majorVersion" ), Gaffer.About.majorVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s2, "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s2, "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
 
 		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
 
 		s2.load()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:majorVersion" ), Gaffer.About.majorVersion() )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s2, "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s2, "serialiser:majorVersion" ), Gaffer.About.majorVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s2, "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s2, "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
 
 	def testFileVersioningUpdatesOnSave( self ) :
 
@@ -1226,10 +1226,10 @@ a = A()"""
 		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/previousSerialisationVersion.gfr" )
 		s.load()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:milestoneVersion" ), 0 )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:majorVersion" ), 14 )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:minorVersion" ), 0 )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s, "serialiser:patchVersion" ), 0 )
+		self.assertEqual( Gaffer.Metadata.value( s, "serialiser:milestoneVersion" ), 0 )
+		self.assertEqual( Gaffer.Metadata.value( s, "serialiser:majorVersion" ), 14 )
+		self.assertEqual( Gaffer.Metadata.value( s, "serialiser:minorVersion" ), 0 )
+		self.assertEqual( Gaffer.Metadata.value( s, "serialiser:patchVersion" ), 0 )
 
 		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s.save()
@@ -1238,10 +1238,10 @@ a = A()"""
 		s2["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
 		s2.load()
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:majorVersion" ), Gaffer.About.majorVersion() )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
-		self.assertEqual( Gaffer.Metadata.nodeValue( s2, "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s2, "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s2, "serialiser:majorVersion" ), Gaffer.About.majorVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s2, "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
+		self.assertEqual( Gaffer.Metadata.value( s2, "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
 
 	def testFramesPerSecond( self ) :
 

--- a/python/GafferTest/SerialisationTest.py
+++ b/python/GafferTest/SerialisationTest.py
@@ -146,7 +146,7 @@ class SerialisationTest( GafferTest.TestCase ) :
 	def testIncludeParentMetadataWhenExcludingChildren( self ) :
 
 		n1 = Gaffer.Node()
-		Gaffer.Metadata.registerNodeValue( n1, "test", IECore.Color3f( 1, 2, 3 ) )
+		Gaffer.Metadata.registerValue( n1, "test", IECore.Color3f( 1, 2, 3 ) )
 
 		with Gaffer.Context() as c :
 			c["serialiser:includeParentMetadata"] = IECore.BoolData( True )
@@ -155,7 +155,7 @@ class SerialisationTest( GafferTest.TestCase ) :
 		scope = { "parent" : Gaffer.Node() }
 		exec( s.result(), scope, scope )
 
-		self.assertEqual( Gaffer.Metadata.nodeValue( scope["parent"], "test" ), IECore.Color3f( 1, 2, 3 ) )
+		self.assertEqual( Gaffer.Metadata.value( scope["parent"], "test" ), IECore.Color3f( 1, 2, 3 ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/SerialisationTest.py
+++ b/python/GafferTest/SerialisationTest.py
@@ -58,7 +58,7 @@ class SerialisationTest( GafferTest.TestCase ) :
 
 		class CustomSerialiser( Gaffer.Serialisation.Serialiser ) :
 
-			def moduleDependencies( self, node ) :
+			def moduleDependencies( self, node, serialisation ) :
 
 				return ( "GafferTest", )
 
@@ -78,7 +78,7 @@ class SerialisationTest( GafferTest.TestCase ) :
 
 				return identifier + ".postScriptWasHere = True\n"
 
-			def childNeedsSerialisation( self, child ) :
+			def childNeedsSerialisation( self, child, serialisation ) :
 
 				if isinstance( child, Gaffer.Node ) :
 					return child.getName() == "childNodeNeedingSerialisation"
@@ -87,7 +87,7 @@ class SerialisationTest( GafferTest.TestCase ) :
 
 				return False
 
-			def childNeedsConstruction( self, child ) :
+			def childNeedsConstruction( self, child, serialisation ) :
 
 				if isinstance( child, Gaffer.Node ) :
 					return False

--- a/python/GafferTest/SubGraphTest.py
+++ b/python/GafferTest/SubGraphTest.py
@@ -66,7 +66,7 @@ class SubGraphTest( GafferTest.TestCase ) :
 
 		n = MySubGraph()
 		self.assertEqual(
-			Gaffer.Metadata.nodeValue( n, "description" ),
+			Gaffer.Metadata.value( n, "description" ),
 			"If you're retrieving this, the subclassing has worked."
 		)
 

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -207,14 +207,31 @@ class TestCase( unittest.TestCase ) :
 			if not inspect.isclass( cls ) or not issubclass( cls, Gaffer.Node ) :
 				continue
 
+			if not cls.__module__.startswith( module.__name__ + "." ) :
+				# Skip nodes which look like they've been injected from
+				# another module by one of the compatibility config files.
+				# We use this same test in `DocumentationAlgo.exportNodeReference()`.
+				continue
+
 			try :
 				node = cls()
 			except :
 				continue
 
-			description = Gaffer.Metadata.value( node, "description", inherit = False )
+			description = Gaffer.Metadata.value( node, "description" )
 			if (not description) or description.isspace() :
+				# No description.
 				undocumentedNodes.append( node.getName() )
+			else :
+				baseNode = None
+				try :
+					baseNode = cls.__bases__[0]()
+				except :
+					pass
+				if baseNode is not None :
+					if description == Gaffer.Metadata.value( baseNode, "description" ) :
+						# Same description as base class
+						undocumentedNodes.append( node.getName() )
 
 			def checkPlugs( graphComponent ) :
 

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -212,14 +212,14 @@ class TestCase( unittest.TestCase ) :
 			except :
 				continue
 
-			description = Gaffer.Metadata.nodeValue( node, "description", inherit = False )
+			description = Gaffer.Metadata.value( node, "description", inherit = False )
 			if (not description) or description.isspace() :
 				undocumentedNodes.append( node.getName() )
 
 			def checkPlugs( graphComponent ) :
 
 				if isinstance( graphComponent, Gaffer.Plug ) and not graphComponent.getName().startswith( "__" ) :
-					description = Gaffer.Metadata.plugValue( graphComponent, "description" )
+					description = Gaffer.Metadata.value( graphComponent, "description" )
 					if (not description) or description.isspace() :
 						undocumentedPlugs.append( graphComponent.fullName() )
 

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -129,6 +129,7 @@ from AnimationTest import AnimationTest
 from StatsApplicationTest import StatsApplicationTest
 from DownstreamIteratorTest import DownstreamIteratorTest
 from PerformanceMonitorTest import PerformanceMonitorTest
+from MetadataAlgoTest import MetadataAlgoTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferUI/BoolPlugValueWidget.py
+++ b/python/GafferUI/BoolPlugValueWidget.py
@@ -81,7 +81,7 @@ class BoolPlugValueWidget( GafferUI.PlugValueWidget ) :
 				with Gaffer.BlockedConnection( self.__stateChangedConnection ) :
 					self.__boolWidget.setState( value )
 
-			displayMode = Gaffer.Metadata.plugValue( self.getPlug(), "boolPlugValueWidget:displayMode" )
+			displayMode = Gaffer.Metadata.value( self.getPlug(), "boolPlugValueWidget:displayMode" )
 			if displayMode is not None :
 				self.__boolWidget.setDisplayMode( self.__boolWidget.DisplayMode.Switch if displayMode == "switch" else self.__boolWidget.DisplayMode.CheckBox )
 

--- a/python/GafferUI/BoxUI.py
+++ b/python/GafferUI/BoxUI.py
@@ -342,9 +342,16 @@ def __reorderPlugs( plugs, plug, newIndex ) :
 
 def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 
+	readOnly = Gaffer.readOnly( plug )
 	if isinstance( plug.node(), Gaffer.Box ) :
 
-		menuDefinition.append( "/Rename...", { "command" : functools.partial( __renamePlug, plug = plug ) } )
+		menuDefinition.append(
+			"/Rename...",
+			{
+				"command" : functools.partial( __renamePlug, plug = plug ),
+				"active" : not readOnly,
+			}
+		)
 
 		menuDefinition.append( "/MoveDivider", { "divider" : True } )
 
@@ -357,7 +364,7 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 				"/Move To/" + edge.capitalize(),
 				{
 					"command" : functools.partial( __setPlugMetadata, plug, "nodeGadget:nodulePosition", edge ),
-					"active" : edge != currentEdge,
+					"active" : edge != currentEdge and not readOnly,
 				}
 			)
 
@@ -367,7 +374,7 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 			"/Move " + ( "Up" if currentEdge in ( "left", "right" ) else "Left" ),
 			{
 				"command" : functools.partial( __reorderPlugs, edgePlugs, plug, edgeIndex - 1 ),
-				"active" : edgeIndex > 0,
+				"active" : edgeIndex > 0 and not readOnly,
 			}
 		)
 
@@ -375,11 +382,11 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 			"/Move " + ( "Down" if currentEdge in ( "left", "right" ) else "Right" ),
 			{
 				"command" : functools.partial( __reorderPlugs, edgePlugs, plug, edgeIndex + 1 ),
-				"active" : edgeIndex < len( edgePlugs ) - 1,
+				"active" : edgeIndex < len( edgePlugs ) - 1 and not readOnly,
 			}
 		)
 
-	__appendPlugDeletionMenuItems( menuDefinition, plug )
-	__appendPlugPromotionMenuItems( menuDefinition, plug )
+	__appendPlugDeletionMenuItems( menuDefinition, plug, readOnly )
+	__appendPlugPromotionMenuItems( menuDefinition, plug, readOnly )
 
 __nodeGraphPlugContextMenuConnection = GafferUI.NodeGraph.plugContextMenuSignal().connect( __nodeGraphPlugContextMenu )

--- a/python/GafferUI/BoxUI.py
+++ b/python/GafferUI/BoxUI.py
@@ -324,7 +324,7 @@ def __renamePlug( menu, plug ) :
 def __setPlugMetadata( plug, key, value ) :
 
 	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
-		Gaffer.Metadata.registerPlugValue( plug, key, value )
+		Gaffer.Metadata.registerValue( plug, key, value )
 
 def __edgePlugs( nodeGraph, plug ) :
 
@@ -338,7 +338,7 @@ def __reorderPlugs( plugs, plug, newIndex ) :
 	plugs.insert( newIndex, plug )
 	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
 		for index, plug in enumerate( plugs ) :
-			Gaffer.Metadata.registerPlugValue( plug, "nodeGadget:noduleIndex", index )
+			Gaffer.Metadata.registerValue( plug, "nodeGadget:noduleIndex", index )
 
 def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 
@@ -348,7 +348,7 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 
 		menuDefinition.append( "/MoveDivider", { "divider" : True } )
 
-		currentEdge = Gaffer.Metadata.plugValue( plug, "nodeGadget:nodulePosition" )
+		currentEdge = Gaffer.Metadata.value( plug, "nodeGadget:nodulePosition" )
 		if not currentEdge :
 			currentEdge = "top" if plug.direction() == plug.Direction.In else "bottom"
 

--- a/python/GafferUI/CompoundDataPlugValueWidget.py
+++ b/python/GafferUI/CompoundDataPlugValueWidget.py
@@ -244,6 +244,12 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 		return
 
 	menuDefinition.append( "/DeleteDivider", { "divider" : True } )
-	menuDefinition.append( "/Delete", { "command" : IECore.curry( __deletePlug, memberPlug ), "active" : not plugValueWidget.getReadOnly() } )
+	menuDefinition.append(
+		"/Delete",
+		{
+			"command" : IECore.curry( __deletePlug, memberPlug ),
+			"active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( memberPlug ),
+		}
+	)
 
 __plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )

--- a/python/GafferUI/CompoundDataPlugValueWidget.py
+++ b/python/GafferUI/CompoundDataPlugValueWidget.py
@@ -99,7 +99,7 @@ class CompoundDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		editable = True
 		if self.getPlug() is not None :
-			editable = Gaffer.Metadata.plugValue( self.getPlug(), "compoundDataPlugValueWidget:editable" )
+			editable = Gaffer.Metadata.value( self.getPlug(), "compoundDataPlugValueWidget:editable" )
 			editable = editable if editable is not None else True
 
 		self.__editRow.setVisible( editable )

--- a/python/GafferUI/CompoundNumericPlugValueWidget.py
+++ b/python/GafferUI/CompoundNumericPlugValueWidget.py
@@ -169,14 +169,14 @@ class CompoundNumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 			menuDefinition.append( "/Ungang", {
 				"command" : Gaffer.WeakMethod( compoundNumericPlugValueWidget.__ungang ),
 				"shortCut" : "Ctrl+G",
-				"active" : not plugValueWidget.getReadOnly(),
+				"active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( compoundNumericPlugValueWidget.getPlug() ),
 			} )
 		elif compoundNumericPlugValueWidget.getPlug().canGang() :
 			menuDefinition.append( "/GangDivider", { "divider" : True } )
 			menuDefinition.append( "/Gang", {
 				"command" : Gaffer.WeakMethod( compoundNumericPlugValueWidget.__gang ),
 				"shortCut" : "Ctrl+G",
-				"active" : not plugValueWidget.getReadOnly(),
+				"active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( compoundNumericPlugValueWidget.getPlug() ),
 			} )
 
 	def __applyVisibleDimensions( self ) :

--- a/python/GafferUI/CompoundNumericPlugValueWidget.py
+++ b/python/GafferUI/CompoundNumericPlugValueWidget.py
@@ -182,7 +182,7 @@ class CompoundNumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __applyVisibleDimensions( self ) :
 
 		actualDimensions = len( self.getPlug() )
-		visibleDimensions = Gaffer.Metadata.plugValue( self.getPlug(), "ui:visibleDimensions" )
+		visibleDimensions = Gaffer.Metadata.value( self.getPlug(), "ui:visibleDimensions" )
 		visibleDimensions = visibleDimensions if visibleDimensions is not None else actualDimensions
 
 		for i in range( 0, actualDimensions ) :

--- a/python/GafferUI/CompoundPlugValueWidget.py
+++ b/python/GafferUI/CompoundPlugValueWidget.py
@@ -225,7 +225,7 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 				widget = self.__childPlugUIs[childPlug]
 			if widget is not None :
 				orderedChildUIs.append( widget )
-				if Gaffer.Metadata.plugValue( childPlug, "divider" ) :
+				if Gaffer.Metadata.value( childPlug, "divider" ) :
 					orderedChildUIs.append( GafferUI.Divider() )
 
 		# add header and footer

--- a/python/GafferUI/DocumentationAlgo.py
+++ b/python/GafferUI/DocumentationAlgo.py
@@ -185,7 +185,7 @@ def exportCommandLineReference( directory, appPath = "$GAFFER_ROOT/apps", ignore
 def __nodeDocumentation( node ) :
 
 	result = __heading( node.typeName().rpartition( ":" )[2] )
-	result += Gaffer.Metadata.nodeValue( node, "description" )
+	result += Gaffer.Metadata.value( node, "description" )
 
 	def walkPlugs( parent ) :
 
@@ -195,14 +195,14 @@ def __nodeDocumentation( node ) :
 			if plug.getName().startswith( "__" ) :
 				continue
 
-			description = Gaffer.Metadata.plugValue( plug, "description" )
+			description = Gaffer.Metadata.value( plug, "description" )
 			if not description :
 				continue
 
 			result += "\n\n" + __heading( plug.relativeName( node ), 1 )
 			result += description
 
-			extensions = Gaffer.Metadata.plugValue( plug, "fileSystemPathPlugValueWidget:extensions" ) or []
+			extensions = Gaffer.Metadata.value( plug, "fileSystemPathPlugValueWidget:extensions" ) or []
 			if extensions :
 				result += "\n\n**Supported file extensions** : "+ ", ".join( extensions )
 

--- a/python/GafferUI/DocumentationAlgo.py
+++ b/python/GafferUI/DocumentationAlgo.py
@@ -77,7 +77,7 @@ def exportNodeReference( directory, modules = [], modulePath = "" ) :
 
 			if not node.__module__.startswith( module.__name__ + "." ) :
 				# Skip nodes which look like they've been injected from
-				# another module by one of the compatibility onfig files.
+				# another module by one of the compatibility config files.
 				continue
 
 			__makeDirs( directory + "/" + module.__name__ )

--- a/python/GafferUI/DotUI.py
+++ b/python/GafferUI/DotUI.py
@@ -178,7 +178,7 @@ __connectionContextMenuConnection = GafferUI.NodeGraph.connectionContextMenuSign
 def __setPlugMetadata( plug, key, value ) :
 
 	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
-		Gaffer.Metadata.registerPlugValue( plug, key, value )
+		Gaffer.Metadata.registerValue( plug, key, value )
 
 def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 
@@ -186,7 +186,7 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 
 		## \todo This duplicates functionality from BoxUI. Is there some way
 		# we could share it?
-		currentEdge = Gaffer.Metadata.plugValue( plug, "nodeGadget:nodulePosition" )
+		currentEdge = Gaffer.Metadata.value( plug, "nodeGadget:nodulePosition" )
 		if not currentEdge :
 			currentEdge = "top" if plug.direction() == plug.Direction.In else "bottom"
 

--- a/python/GafferUI/DotUI.py
+++ b/python/GafferUI/DotUI.py
@@ -169,7 +169,7 @@ def __connectionContextMenu( nodeGraph, destinationPlug, menuDefinition ) :
 		"/Insert Dot",
 		{
 			"command" : functools.partial( __insertDot, destinationPlug = destinationPlug ),
-			"active" : not destinationPlug.getFlags( Gaffer.Plug.Flags.ReadOnly ),
+			"active" : not destinationPlug.getFlags( Gaffer.Plug.Flags.ReadOnly ) and not Gaffer.readOnly( destinationPlug ),
 		}
 	)
 
@@ -190,12 +190,13 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 		if not currentEdge :
 			currentEdge = "top" if plug.direction() == plug.Direction.In else "bottom"
 
+		readOnly = Gaffer.readOnly( plug )
 		for edge in ( "top", "bottom", "left", "right" ) :
 			menuDefinition.append(
 				"/Move To/" + edge.capitalize(),
 				{
 					"command" : functools.partial( __setPlugMetadata, plug, "nodeGadget:nodulePosition", edge ),
-					"active" : edge != currentEdge,
+					"active" : edge != currentEdge and not readOnly,
 				}
 			)
 

--- a/python/GafferUI/EditMenu.py
+++ b/python/GafferUI/EditMenu.py
@@ -51,16 +51,16 @@ def appendDefinitions( menuDefinition, prefix="" ) :
 	menuDefinition.append( prefix + "/Redo", { "command" : redo, "shortCut" : "Shift+Ctrl+Z", "active" : __redoAvailable } )
 	menuDefinition.append( prefix + "/UndoDivider", { "divider" : True } )
 
-	menuDefinition.append( prefix + "/Cut", { "command" : cut, "shortCut" : "Ctrl+X", "active" : selectionAvailable } )
+	menuDefinition.append( prefix + "/Cut", { "command" : cut, "shortCut" : "Ctrl+X", "active" : __mutableSelectionAvailable } )
 	menuDefinition.append( prefix + "/Copy", { "command" : copy, "shortCut" : "Ctrl+C", "active" : selectionAvailable } )
 	menuDefinition.append( prefix + "/Paste", { "command" : paste, "shortCut" : "Ctrl+V", "active" : __pasteAvailable } )
-	menuDefinition.append( prefix + "/Delete", { "command" : delete, "shortCut" : "Backspace, Delete", "active" : selectionAvailable } )
+	menuDefinition.append( prefix + "/Delete", { "command" : delete, "shortCut" : "Backspace, Delete", "active" : __mutableSelectionAvailable } )
 	menuDefinition.append( prefix + "/CutCopyPasteDeleteDivider", { "divider" : True } )
 
 	menuDefinition.append( prefix + "/Find...", { "command" : find, "shortCut" : "Ctrl+F" } )
 	menuDefinition.append( prefix + "/FindDivider", { "divider" : True } )
 
-	menuDefinition.append( prefix + "/Arrange", { "command" : arrange, "shortCut" : "Ctrl+L" } )
+	menuDefinition.append( prefix + "/Arrange", { "command" : arrange, "shortCut" : "Ctrl+L", "active" : __arrangeAvailable } )
 	menuDefinition.append( prefix + "/ArrangeDivider", { "divider" : True } )
 
 	menuDefinition.append( prefix + "/Select All", { "command" : selectAll, "shortCut" : "Ctrl+A" } )
@@ -87,7 +87,7 @@ def appendDefinitions( menuDefinition, prefix="" ) :
 __Scope = collections.namedtuple( "Scope", [ "scriptWindow", "script", "parent", "nodeGraph" ] )
 
 ## Returns the scope in which an edit menu item should operate. The return
-# value has "scriptWindow", "script", "root" and "nodeGraph" attributes.
+# value has "scriptWindow", "script", "parent" and "nodeGraph" attributes.
 # The "nodeGraph" attribute may be None if no NodeGraph can be found. Note
 # that in many cases user expectation is that an operation will only apply
 # to nodes currently visible within the NodeGraph, and that nodes can be
@@ -313,10 +313,25 @@ def __selectConnected( menu, direction, degreesOfSeparation, add ) :
 		selection.clear()
 	selection.add( connected )
 
+def __mutableSelectionAvailable( menu ) :
+
+	if not selectionAvailable( menu ) :
+		return False
+
+	return not isinstance( scope( menu ).parent, Gaffer.Reference )
+
 def __pasteAvailable( menu ) :
 
-	root = scope( menu ).script.ancestor( Gaffer.ApplicationRoot )
+	s = scope( menu )
+	if isinstance( s.parent, Gaffer.Reference ) :
+		return False
+
+	root = s.script.ancestor( Gaffer.ApplicationRoot )
 	return isinstance( root.getClipboardContents(), IECore.StringData )
+
+def __arrangeAvailable( menu ) :
+
+	return not isinstance( scope( menu ).parent, Gaffer.Reference )
 
 def __undoAvailable( menu ) :
 

--- a/python/GafferUI/ExpressionUI.py
+++ b/python/GafferUI/ExpressionUI.py
@@ -122,7 +122,7 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 		return
 
 	input = plug.getInput()
-	if input is not None or not plugValueWidget._editable() :
+	if input is not None or not plugValueWidget._editable() or Gaffer.readOnly( plug ) :
 		return
 
 	languages = [ l for l in Gaffer.Expression.languages() if Gaffer.Expression.defaultExpression( plug, l ) ]

--- a/python/GafferUI/FileSystemPathPlugValueWidget.py
+++ b/python/GafferUI/FileSystemPathPlugValueWidget.py
@@ -75,7 +75,7 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
 		dialogue = GafferUI.PathPlugValueWidget._pathChooserDialogue( self )
 
-		if Gaffer.Metadata.plugValue( self.getPlug(), "fileSystemPathPlugValueWidget:includeSequences" ) :
+		if Gaffer.Metadata.value( self.getPlug(), "fileSystemPathPlugValueWidget:includeSequences" ) :
 
 			columns = dialogue.pathChooserWidget().pathListingWidget().getColumns()
 			columns.append( GafferUI.PathListingWidget.StandardColumn( "Frame Range", "fileSystem:frameRange" ) )
@@ -87,12 +87,12 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
 		GafferUI.PathPlugValueWidget._updateFromPlug( self )
 
-		includeSequences = Gaffer.Metadata.plugValue( self.getPlug(), "fileSystemPathPlugValueWidget:includeSequences" ) or False
+		includeSequences = Gaffer.Metadata.value( self.getPlug(), "fileSystemPathPlugValueWidget:includeSequences" ) or False
 
 		self.path().setFilter(
 			Gaffer.FileSystemPath.createStandardFilter(
 				self.__extensions(),
-				Gaffer.Metadata.plugValue( self.getPlug(), "fileSystemPathPlugValueWidget:extensionsLabel" ) or "",
+				Gaffer.Metadata.value( self.getPlug(), "fileSystemPathPlugValueWidget:extensionsLabel" ) or "",
 				includeSequenceFilter = includeSequences,
 			)
 		)
@@ -101,7 +101,7 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
 	def _setPlugFromPath( self, path ) :
 
-		if Gaffer.Metadata.plugValue( self.getPlug(), "fileSystemPathPlugValueWidget:includeSequenceFrameRange" ) :
+		if Gaffer.Metadata.value( self.getPlug(), "fileSystemPathPlugValueWidget:includeSequenceFrameRange" ) :
 			sequence = path.fileSequence()
 			if sequence :
 				self.getPlug().setValue( str(sequence) )
@@ -128,7 +128,7 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 		if self.getPlug() is None :
 			return []
 
-		extensions = Gaffer.Metadata.plugValue( self.getPlug(), "fileSystemPathPlugValueWidget:extensions" ) or []
+		extensions = Gaffer.Metadata.value( self.getPlug(), "fileSystemPathPlugValueWidget:extensions" ) or []
 		if isinstance( extensions, str ) :
 			extensions = extensions.split()
 		else :

--- a/python/GafferUI/FileSystemPathPlugValueWidget.py
+++ b/python/GafferUI/FileSystemPathPlugValueWidget.py
@@ -59,8 +59,6 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
 		self._updateFromPlug()
 
-		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
-
 	def getToolTip( self ) :
 
 		result = GafferUI.PathPlugValueWidget.getToolTip( self )
@@ -108,20 +106,6 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 				return
 
 		GafferUI.PathPlugValueWidget._setPlugFromPath( self, path )
-
-	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
-
-		if self.getPlug() is None :
-			return
-
-		if plug is not None and not plug.isSame( self.getPlug() ) :
-			return
-
-		if not self.getPlug().node().isInstanceOf( nodeTypeId ) :
-			return
-
-		if key.startswith( "fileSystemPathPlugValueWidget:" ) :
-			self._updateFromPlug()
 
 	def __extensions( self ) :
 

--- a/python/GafferUI/GraphBookmarksUI.py
+++ b/python/GafferUI/GraphBookmarksUI.py
@@ -99,12 +99,12 @@ def appendPlugContextMenuDefinitions( nodeGraph, plug, menuDefinition ) :
 
 def __getBookmarked( node ) :
 
-	return Gaffer.Metadata.nodeValue( node, "graphBookmarks:bookmarked" ) or False
+	return Gaffer.Metadata.value( node, "graphBookmarks:bookmarked" ) or False
 
 def __setBookmarked( node, bookmarked ) :
 
 	with Gaffer.UndoContext( node.scriptNode() ) :
-		Gaffer.Metadata.registerNodeValue( node, "graphBookmarks:bookmarked", bookmarked )
+		Gaffer.Metadata.registerValue( node, "graphBookmarks:bookmarked", bookmarked )
 
 def __bookmarks( parent ) :
 

--- a/python/GafferUI/GraphBookmarksUI.py
+++ b/python/GafferUI/GraphBookmarksUI.py
@@ -52,7 +52,7 @@ def appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition ) :
 		{
 			"checkBox" : __getBookmarked( node ),
 			"command" : functools.partial( __setBookmarked, node ),
-			"active" : node.ancestor( Gaffer.Reference ) is None,
+			"active" : not Gaffer.readOnly( node ),
 		}
 	)
 
@@ -89,7 +89,7 @@ def appendPlugContextMenuDefinitions( nodeGraph, plug, menuDefinition ) :
 				"/Connect Bookmark/" + label,
 				{
 					"command" : functools.partial( __connect, inPlug, outPlug ),
-					"active" : not outPlug.isSame( inPlug.getInput() )
+					"active" : not outPlug.isSame( inPlug.getInput() ) and not Gaffer.readOnly( inPlug )
 				}
 			)
 

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -194,7 +194,7 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		assert( label is self.__label )
 
-		if self.getPlug().getFlags( Gaffer.Plug.Flags.ReadOnly ) :
+		if self.getPlug().getFlags( Gaffer.Plug.Flags.ReadOnly ) or Gaffer.readOnly( self.getPlug() ) :
 			return
 
 		if self.__editableLabel is None :

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -175,7 +175,7 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __updateFormatter( self ) :
 
 		plug = self.getPlug()
-		label = Gaffer.Metadata.plugValue( plug, "label" ) if plug is not None else None
+		label = Gaffer.Metadata.value( plug, "label" ) if plug is not None else None
 		if label is not None :
 			self.__label.setFormatter( lambda graphComponents : label )
 		else :
@@ -185,7 +185,7 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.__labelDoubleClickConnection = None
 
-		if self.getPlug() is None or not Gaffer.Metadata.plugValue( self.getPlug(), "labelPlugValueWidget:renameable" ) :
+		if self.getPlug() is None or not Gaffer.Metadata.value( self.getPlug(), "labelPlugValueWidget:renameable" ) :
 			return
 
 		self.__labelDoubleClickConnection = self.__label.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__labelDoubleClicked ) )
@@ -219,7 +219,7 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 			# Remove any metadata label which would mask the name - if a user
 			# has gone to the trouble of setting a sensible name, then it should
 			# take precedence.
-			Gaffer.Metadata.deregisterPlugValue( self.getPlug(), "label" )
+			Gaffer.Metadata.deregisterValue( self.getPlug(), "label" )
 
 		self.__label.setVisible( True )
 		self.__editableLabel.setVisible( False )

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -233,11 +233,5 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if self.getPlug() is None :
 			return
 
-		if plug is not None and not plug.isSame( self.getPlug() ) :
-			return
-
-		if not self.getPlug().node().isInstanceOf( nodeTypeId ) :
-			return
-
-		if key=="label" :
+		if key=="label" and Gaffer.affectedByChange( self.getPlug(), nodeTypeId, plugPath, plug ) :
 			self.__updateFormatter()

--- a/python/GafferUI/MultiLineStringPlugValueWidget.py
+++ b/python/GafferUI/MultiLineStringPlugValueWidget.py
@@ -79,15 +79,15 @@ class MultiLineStringPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 			self.__textWidget.setErrored( value is None )
 
-			fixedLineHeight = Gaffer.Metadata.plugValue( self.getPlug(), "fixedLineHeight" )
+			fixedLineHeight = Gaffer.Metadata.value( self.getPlug(), "fixedLineHeight" )
 			self.__textWidget.setFixedLineHeight( fixedLineHeight )
 
-			role = Gaffer.Metadata.plugValue( self.getPlug(), "multiLineStringPlugValueWidget:role" )
+			role = Gaffer.Metadata.value( self.getPlug(), "multiLineStringPlugValueWidget:role" )
 			role = getattr( self.__textWidget.Role, role.capitalize() ) if role else self.__textWidget.Role.Text
 			self.__textWidget.setRole( role )
 
 			self.__textChangedConnection.block(
-				not Gaffer.Metadata.plugValue( self.getPlug(), "multiLineStringPlugValueWidget:continuousUpdate" )
+				not Gaffer.Metadata.value( self.getPlug(), "multiLineStringPlugValueWidget:continuousUpdate" )
 			)
 
 		self.__textWidget.setEditable( self._editable() )

--- a/python/GafferUI/NodeEditor.py
+++ b/python/GafferUI/NodeEditor.py
@@ -109,7 +109,13 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 
 				GafferUI.Label( "<h4>Node Name</h4>" )
 				self.__nameWidget = GafferUI.NameWidget( node )
-				self.__nameWidget.setEditable( not self.getReadOnly() )
+				## \todo Make NameWidget support the readOnly metadata internally itself.
+				# We can't do that easily right now, because it would need to be managing
+				# the exact same `setEditable()` call that we're using here to propagate
+				# our Widget readonlyness. Really our Widget readonlyness mechanism is a
+				# bit lacking, and it should really be inherited automatically so we don't
+				# have to propagate it like this.
+				self.__nameWidget.setEditable( not self.getReadOnly() and not Gaffer.readOnly( node ) )
 
 				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing=4 ) as infoSection :
 
@@ -164,6 +170,7 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 			"/Revert to Defaults",
 			{
 				"command" : Gaffer.WeakMethod( self.__revertToDefaults ),
+				"active" : not Gaffer.readOnly( self.nodeUI().node() ),
 			}
 		)
 
@@ -180,13 +187,15 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 				plug = graphComponent
 				if plug.direction() == plug.Direction.Out :
 					return
-				if plug.isSame( plug.node()["user"] ) :
+				elif plug.isSame( plug.node()["user"] ) :
 					# Not much sense reverting user plugs, since we
 					# don't expect the user to have gone to the trouble
 					# of giving them defaults.
 					return
 				elif plug.getName().startswith( "__" ) :
 					# Private plugs are none of our business.
+					return
+				elif Gaffer.readOnly( plug ) :
 					return
 
 				if isinstance( plug, Gaffer.ValuePlug ) :

--- a/python/GafferUI/NodeEditor.py
+++ b/python/GafferUI/NodeEditor.py
@@ -116,7 +116,7 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 					GafferUI.Label( "<h4>" + node.typeName().rpartition( ":" )[-1] + "</h4>" )
 
 					button = GafferUI.Button( image = "info.png", hasFrame = False )
-					url = Gaffer.Metadata.nodeValue( node, "documentation:url" )
+					url = Gaffer.Metadata.value( node, "documentation:url" )
 					if url :
 						button.clickedSignal().connect(
 							lambda button : GafferUI.showURL( url ),
@@ -149,7 +149,7 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 
 		result = IECore.MenuDefinition()
 
-		url = Gaffer.Metadata.nodeValue( self.nodeUI().node(), "documentation:url" )
+		url = Gaffer.Metadata.value( self.nodeUI().node(), "documentation:url" )
 		result.append(
 			"/Documentation...",
 			{

--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -404,9 +404,9 @@ class NodeGraph( GafferUI.EditorWidget ) :
 		# save/restore the current framing so jumping in
 		# and out of Boxes isn't a confusing experience.
 
-		Gaffer.Metadata.registerNodeValue( previousRoot, "ui:nodeGraph:framing", self.__currentFrame(), persistent = False )
+		Gaffer.Metadata.registerValue( previousRoot, "ui:nodeGraph:framing", self.__currentFrame(), persistent = False )
 
-		frame = Gaffer.Metadata.nodeValue( self.graphGadget().getRoot(), "ui:nodeGraph:framing" )
+		frame = Gaffer.Metadata.value( self.graphGadget().getRoot(), "ui:nodeGraph:framing" )
 		if frame is not None :
 			self.graphGadgetWidget().getViewportGadget().frame(
 				IECore.Box3f( IECore.V3f( frame.min.x, frame.min.y, 0 ), IECore.V3f( frame.max.x, frame.max.y, 0 ) )

--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -280,16 +280,12 @@ class NodeGraph( GafferUI.EditorWidget ) :
 		if event.key == "F" and not event.modifiers :
 			self.__frame( self.scriptNode().selection() )
 			return True
-		## \todo This cursor key navigation might not make sense for all applications,
-		# so we should move it into BoxUI and load it in a config file that the gui app uses.
-		# I think this implies that every Widget.*Signal() method should have a
-		# Widget.static*Signal() method to allow global handlers to be registered by widget type.
-		# We already have a mix of static/nonstatic signals for menus, so that might make a nice
-		# generalisation.
 		elif event.key == "Down" :
 			selection = self.scriptNode().selection()
 			if selection.size() :
-				if isinstance( selection[0], Gaffer.Box ) or event.modifiers == event.modifiers.Shift | event.modifiers.Control :
+				needsModifiers = not isinstance( selection[0], ( Gaffer.Reference, Gaffer.Box ) )
+				haveModifiers = bool( event.modifiers & ( event.modifiers.Shift | event.modifiers.Control ) )
+				if needsModifiers == haveModifiers :
 					self.graphGadget().setRoot( selection[0] )
 					return True
 		elif event.key == "Up" :

--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -170,7 +170,7 @@ class NodeGraph( GafferUI.EditorWidget ) :
 				{
 					"command" : IECore.curry( cls.__setEnabled, node ),
 					"checkBox" : enabledPlug.getValue(),
-					"active" : enabledPlug.settable()
+					"active" : enabledPlug.settable() and not Gaffer.readOnly( enabledPlug )
 				}
 			)
 

--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -263,9 +263,9 @@ class NodeGraph( GafferUI.EditorWidget ) :
 					self._m.popup( self )
 					return True
 
-			self._nodeMenu().popup( self )
-
-			return True
+			if not isinstance( self.graphGadget().getRoot(), Gaffer.Reference ) :
+				self._nodeMenu().popup( self )
+				return True
 
 		return False
 
@@ -294,8 +294,9 @@ class NodeGraph( GafferUI.EditorWidget ) :
 				self.graphGadget().setRoot( root.parent() )
 				return True
 		elif event.key == "Tab" :
-			self._nodeMenu().popup( self )
-			return True
+			if not isinstance( self.graphGadget().getRoot(), Gaffer.Reference ) :
+				self._nodeMenu().popup( self )
+				return True
 
 		return False
 

--- a/python/GafferUI/NodeToolbar.py
+++ b/python/GafferUI/NodeToolbar.py
@@ -62,7 +62,7 @@ class NodeToolbar( GafferUI.Widget ) :
 	def create( cls, node, edge = GafferUI.Edge.Top ) :
 
 		# Try to create a toolbar using metadata.
-		toolbarType = Gaffer.Metadata.nodeValue( node, "nodeToolbar:%s:type" % str( edge ).lower() )
+		toolbarType = Gaffer.Metadata.value( node, "nodeToolbar:%s:type" % str( edge ).lower() )
 		if toolbarType is not None :
 			if toolbarType == "" :
 				return None

--- a/python/GafferUI/NodeUI.py
+++ b/python/GafferUI/NodeUI.py
@@ -179,6 +179,6 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 	node = plug.node()
 	if plug.parent().isSame( node["user"] ) :
 		menuDefinition.append( "/DeleteDivider", { "divider" : True } )
-		menuDefinition.append( "/Delete", { "command" : IECore.curry( __deletePlug, plug ), "active" : not plugValueWidget.getReadOnly() } )
+		menuDefinition.append( "/Delete", { "command" : IECore.curry( __deletePlug, plug ), "active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug ) } )
 
 __plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )

--- a/python/GafferUI/NumericPlugValueWidget.py
+++ b/python/GafferUI/NumericPlugValueWidget.py
@@ -183,7 +183,7 @@ class NumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		charWidth = None
 		if self.getPlug() is not None :
-			charWidth = Gaffer.Metadata.plugValue( self.getPlug(), "numericPlugValueWidget:fixedCharacterWidth" )
+			charWidth = Gaffer.Metadata.value( self.getPlug(), "numericPlugValueWidget:fixedCharacterWidth" )
 
 		if charWidth is None and isinstance( self.getPlug(), Gaffer.IntPlug ) and self.getPlug().hasMaxValue() :
 			charWidth = len( str( self.getPlug().maxValue() ) )

--- a/python/GafferUI/PathPlugValueWidget.py
+++ b/python/GafferUI/PathPlugValueWidget.py
@@ -114,10 +114,10 @@ class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 		# get the keywords for the dialogue constructor
 		# from the plug metadata.
 		pathChooserDialogueKeywords = {}
-		pathChooserDialogueKeywords["leaf"] = Gaffer.Metadata.plugValue( self.getPlug(), "pathPlugValueWidget:leaf" )
-		pathChooserDialogueKeywords["valid"] = Gaffer.Metadata.plugValue( self.getPlug(), "pathPlugValueWidget:valid" )
+		pathChooserDialogueKeywords["leaf"] = Gaffer.Metadata.value( self.getPlug(), "pathPlugValueWidget:leaf" )
+		pathChooserDialogueKeywords["valid"] = Gaffer.Metadata.value( self.getPlug(), "pathPlugValueWidget:valid" )
 
-		bookmarks = Gaffer.Metadata.plugValue( self.getPlug(), "pathPlugValueWidget:bookmarks" )
+		bookmarks = Gaffer.Metadata.value( self.getPlug(), "pathPlugValueWidget:bookmarks" )
 		if bookmarks is not None :
 			pathChooserDialogueKeywords["bookmarks"] = GafferUI.Bookmarks.acquire( self.getPlug(), type( pathCopy ), bookmarks )
 

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -476,10 +476,9 @@ class PlugLayout( GafferUI.Widget ) :
 
 	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
 
-		if plug is not None and not self.__parent.isSame( plug ) and not self.__parent.isSame( plug.parent() ) :
-			return
-
-		if not self.__node().isInstanceOf( nodeTypeId ) :
+		parentAffected = isinstance( self.__parent, Gaffer.Plug ) and Gaffer.affectedByChange( self.__parent, nodeTypeId, plugPath, plug )
+		childAffected = Gaffer.childAffectedByChange( self.__parent, nodeTypeId, plugPath, plug )
+		if not parentAffected and not childAffected :
 			return
 
 		if key in (

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -215,11 +215,7 @@ class PlugLayout( GafferUI.Widget ) :
 		items = [ plug for plug in items if not plug.getName().startswith( "__" ) ]
 
 		if includeCustomWidgets :
-			if isinstance( parent, Gaffer.Node ) :
-				metadataNames = Gaffer.Metadata.registeredNodeValues( parent )
-			else :
-				metadataNames = Gaffer.Metadata.registeredPlugValues( parent )
-			for name in metadataNames :
+			for name in Gaffer.Metadata.registeredValues( parent ) :
 				m = re.match( layoutName + ":customWidget:(.+):widgetType", name )
 				if m and cls.__metadataValue( parent, name ) :
 					items.append( m.group( 1 ) )
@@ -281,7 +277,7 @@ class PlugLayout( GafferUI.Widget ) :
 		# ditch widgets whose metadata type has changed - we must recreate these.
 		self.__widgets = {
 			k : v for k, v in self.__widgets.items()
-			if isinstance( k, str ) or v is not None and Gaffer.Metadata.plugValue( k, "plugValueWidget:type" ) == v.__plugValueWidgetType
+			if isinstance( k, str ) or v is not None and Gaffer.Metadata.value( k, "plugValueWidget:type" ) == v.__plugValueWidgetType
 		}
 
 
@@ -388,7 +384,7 @@ class PlugLayout( GafferUI.Widget ) :
 
 		# Store the metadata value that controlled the type created, so we can compare to it
 		# in the future to determine if we can reuse the widget.
-		result.__plugValueWidgetType = Gaffer.Metadata.plugValue( plug, "plugValueWidget:type" )
+		result.__plugValueWidgetType = Gaffer.Metadata.value( plug, "plugValueWidget:type" )
 
  		return result
 
@@ -407,18 +403,18 @@ class PlugLayout( GafferUI.Widget ) :
 	def __metadataValue( cls, plugOrNode, name ) :
 
 		if isinstance( plugOrNode, Gaffer.Node ) :
-			return Gaffer.Metadata.nodeValue( plugOrNode, name )
+			return Gaffer.Metadata.value( plugOrNode, name )
 		else :
-			return Gaffer.Metadata.plugValue( plugOrNode, name )
+			return Gaffer.Metadata.value( plugOrNode, name )
 
 	@classmethod
 	def __staticItemMetadataValue( cls, item, name, parent, layoutName ) :
 
 		if isinstance( item, Gaffer.Plug ) :
-			v = Gaffer.Metadata.plugValue( item, layoutName + ":" + name )
+			v = Gaffer.Metadata.value( item, layoutName + ":" + name )
 			if v is None and name in ( "divider", "label" ) :
 				# Backwards compatibility with old unprefixed metadata names.
-				v = Gaffer.Metadata.plugValue( item, name )
+				v = Gaffer.Metadata.value( item, name )
 			return v
 		else :
 			return cls.__metadataValue( parent, layoutName + ":customWidget:" + item + ":" + name )
@@ -552,16 +548,16 @@ class _Section( object ) :
 	def saveState( self, name, value ) :
 
 		if isinstance( self.__parent, Gaffer.Node ) :
-			Gaffer.Metadata.registerNodeValue( self.__parent, self.__stateName( name ), value, persistent = False )
+			Gaffer.Metadata.registerValue( self.__parent, self.__stateName( name ), value, persistent = False )
 		else :
-			Gaffer.Metadata.registerPlugValue( self.__parent, self.__stateName( name ), value, persistent = False )
+			Gaffer.Metadata.registerValue( self.__parent, self.__stateName( name ), value, persistent = False )
 
 	def restoreState( self, name ) :
 
 		if isinstance( self.__parent, Gaffer.Node ) :
-			return Gaffer.Metadata.nodeValue( self.__parent, self.__stateName( name ) )
+			return Gaffer.Metadata.value( self.__parent, self.__stateName( name ) )
 		else :
-			return Gaffer.Metadata.plugValue( self.__parent, self.__stateName( name ) )
+			return Gaffer.Metadata.value( self.__parent, self.__stateName( name ) )
 
 	def __stateName( self, name ) :
 

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -350,9 +350,9 @@ class PlugValueWidget( GafferUI.Widget ) :
 		# first try to create one using a creator registered for the specific plug
 		if not useTypeOnly :
 
-			widgetType = Gaffer.Metadata.plugValue( plug, "plugValueWidget:type" )
+			widgetType = Gaffer.Metadata.value( plug, "plugValueWidget:type" )
 			if widgetType is None :
-				widgetType = Gaffer.Metadata.plugValue( plug, "layout:widgetType" )
+				widgetType = Gaffer.Metadata.value( plug, "layout:widgetType" )
 				if widgetType is not None :
 					warnings.warn( "The \"layout:widgetType\" metadata entry is deprecated, use \"plugValueWidget:type\" instead.", DeprecationWarning )
 					if widgetType == "None" :

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -191,6 +191,9 @@ class PlugValueWidget( GafferUI.Widget ) :
 			if not canEditAnimation or not Gaffer.Animation.isAnimated( plug ) :
 				return False
 
+		if Gaffer.readOnly( plug ) :
+			return False
+
 		return True
 
 	## Called to convert the specified value into something
@@ -271,7 +274,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 			menuDefinition.append(
 				"/Paste Value", {
 					"command" : functools.partial( Gaffer.WeakMethod( self.__setValue ), pasteValue ),
-					"active" : pasteValue is not None
+					"active" : self._editable() and pasteValue is not None
 				}
 			)
 
@@ -283,7 +286,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 			menuDefinition.append(
 				"/Remove input", {
 					"command" : Gaffer.WeakMethod( self.__removeInput ),
-					"active" : self.getPlug().acceptsInput( None ) and not self.getReadOnly(),
+					"active" : self.getPlug().acceptsInput( None ) and not self.getReadOnly() and not Gaffer.readOnly( self.getPlug() ),
 				}
 			)
 		if hasattr( self.getPlug(), "defaultValue" ) and self.getPlug().direction() == Gaffer.Plug.Direction.In :

--- a/python/GafferUI/PresetsPlugValueWidget.py
+++ b/python/GafferUI/PresetsPlugValueWidget.py
@@ -48,8 +48,6 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__menuButton = GafferUI.MenuButton( "", menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ) )
 		GafferUI.PlugValueWidget.__init__( self, self.__menuButton, plug, **kw )
 
-		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
-
 		self._addPopupMenu( self.__menuButton )
 		self._updateFromPlug()
 
@@ -86,17 +84,3 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			Gaffer.NodeAlgo.applyPreset( self.getPlug(), preset )
-
-	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
-
-		if self.getPlug() is None :
-			return
-
-		if plug is not None and not plug.isSame( self.getPlug() ) :
-			return
-
-		if not self.getPlug().node().isInstanceOf( nodeTypeId ) :
-			return
-
-		if key.startswith( "preset:" ) :
-			self._updateFromPlug()

--- a/python/GafferUI/RandomUI.py
+++ b/python/GafferUI/RandomUI.py
@@ -34,7 +34,8 @@
 #
 ##########################################################################
 
-import IECore
+import functools
+
 import Gaffer
 import GafferUI
 
@@ -223,6 +224,12 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 	input = plug.getInput()
 	if input is None and plugValueWidget._editable() :
 		menuDefinition.prepend( "/RandomiseDivider", { "divider" : True } )
-		menuDefinition.prepend( "/Randomise...", { "command" : IECore.curry( __createRandom, plug ) } )
+		menuDefinition.prepend(
+			"/Randomise...",
+			{
+				"command" : functools.partial( __createRandom, plug ),
+				"active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug ),
+			}
+		)
 
 __popupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __popupMenu )

--- a/python/GafferUI/StringPlugValueWidget.py
+++ b/python/GafferUI/StringPlugValueWidget.py
@@ -90,7 +90,7 @@ class StringPlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__textWidget.setErrored( value is None )
 
 			self.__textChangedConnection.block(
-				not Gaffer.Metadata.plugValue( self.getPlug(), "stringPlugValueWidget:continuousUpdate" )
+				not Gaffer.Metadata.value( self.getPlug(), "stringPlugValueWidget:continuousUpdate" )
 			)
 
 		self.__textWidget.setEditable( self._editable() )

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -355,10 +355,8 @@ class _MetadataWidget( GafferUI.Widget ) :
 
 	def __update( self ) :
 
-		if isinstance( self.__target, Gaffer.Node ) :
-			self._updateFromValue( Gaffer.Metadata.nodeValue( self.__target, self.__key ) )
-		elif isinstance( self.__target, Gaffer.Plug ) :
-			self._updateFromValue( Gaffer.Metadata.plugValue( self.__target, self.__key ) )
+		if self.__target is not None :
+			self._updateFromValue( Gaffer.Metadata.value( self.__target, self.__key ) )
 		else :
 			self._updateFromValue( None )
 
@@ -883,8 +881,8 @@ class _PlugListing( GafferUI.Widget ) :
 
 			for childItem in layoutItem :
 				if isinstance( childItem, _PlugLayoutItem ) :
-					Gaffer.Metadata.registerPlugValue( childItem.plug, "layout:section", path )
-					Gaffer.Metadata.registerPlugValue( childItem.plug, "layout:index", index )
+					Gaffer.Metadata.registerValue( childItem.plug, "layout:section", path )
+					Gaffer.Metadata.registerValue( childItem.plug, "layout:index", index )
 					index += 1
 				elif isinstance( childItem, _SectionLayoutItem ) :
 					childPath = path + "." + childItem.name() if path else childItem.name()
@@ -1282,7 +1280,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 		if selectedPaths :
 			with Gaffer.BlockedConnection( self.__valuePlugSetConnection ) :
 				self.__valueNode["presetValue"].setValue(
-					Gaffer.Metadata.plugValue( self.getPlug(), "preset:" + selectedPaths[0][0] )
+					Gaffer.Metadata.value( self.getPlug(), "preset:" + selectedPaths[0][0] )
 				)
 
 		self.__editingColumn.setEnabled( bool( selectedPaths ) )
@@ -1332,9 +1330,9 @@ class _PresetsEditor( GafferUI.Widget ) :
 			with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 				# reorder by removing everything and reregistering in the order we want
 				for item in d.items() :
-					Gaffer.Metadata.deregisterPlugValue( self.getPlug(), "preset:" + item[0] )
+					Gaffer.Metadata.deregisterValue( self.getPlug(), "preset:" + item[0] )
 				for item in d.items() :
-					Gaffer.Metadata.registerPlugValue( self.getPlug(), "preset:" + item[0], item[1] )
+					Gaffer.Metadata.registerValue( self.getPlug(), "preset:" + item[0], item[1] )
 
 		self.__updatePath()
 
@@ -1351,7 +1349,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 			index += 1
 
 		with Gaffer.UndoContext( self.__plug.ancestor( Gaffer.ScriptNode ) ) :
-			Gaffer.Metadata.registerPlugValue( self.__plug, "preset:" + name, self.__plug.getValue() )
+			Gaffer.Metadata.registerValue( self.__plug, "preset:" + name, self.__plug.getValue() )
 
 		self.__pathListing.setSelectedPaths(
 			self.__pathListing.getPath().copy().setFromString( "/" + name )
@@ -1369,7 +1367,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 		selectedIndex = [ p[0] for p in paths ].index( selectedPreset )
 
 		with Gaffer.UndoContext( self.__plug.ancestor( Gaffer.ScriptNode ) ) :
-			Gaffer.Metadata.deregisterPlugValue( self.__plug, "preset:" + selectedPreset )
+			Gaffer.Metadata.deregisterValue( self.__plug, "preset:" + selectedPreset )
 
 		del paths[selectedIndex]
 		if len( paths ) :
@@ -1391,9 +1389,9 @@ class _PresetsEditor( GafferUI.Widget ) :
 			with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 				# retain order by removing and reregistering everything
 				for item in items :
-					Gaffer.Metadata.deregisterPlugValue( self.getPlug(), "preset:" + item[0] )
+					Gaffer.Metadata.deregisterValue( self.getPlug(), "preset:" + item[0] )
 				for item in items :
-					Gaffer.Metadata.registerPlugValue( self.getPlug(), "preset:" + (item[0] if item[0] != oldName else newName), item[1] )
+					Gaffer.Metadata.registerValue( self.getPlug(), "preset:" + (item[0] if item[0] != oldName else newName), item[1] )
 
 		self.__updatePath()
 		self.__pathListing.setSelectedPaths( [ self.__pathListing.getPath().copy().setFromString( "/" + newName ) ] )
@@ -1409,7 +1407,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 		preset = selectedPaths[0][0]
 
 		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
-			Gaffer.Metadata.registerPlugValue( self.getPlug(), "preset:" + preset, plug.getValue() )
+			Gaffer.Metadata.registerValue( self.getPlug(), "preset:" + preset, plug.getValue() )
 
 ##########################################################################
 # _PlugEditor. This provides a panel for editing a specific plug's name,
@@ -1559,7 +1557,7 @@ class _PlugEditor( GafferUI.Widget ) :
 			self.__widgetMenu.setText( "" )
 			return
 
-		metadata = Gaffer.Metadata.plugValue( self.getPlug(), "plugValueWidget:type" )
+		metadata = Gaffer.Metadata.value( self.getPlug(), "plugValueWidget:type" )
 		for w in self.__widgetDefinitions :
 			if w.metadata == metadata :
 				self.__widgetMenu.setText( w.label )
@@ -1571,7 +1569,7 @@ class _PlugEditor( GafferUI.Widget ) :
 
 		widgetType = None
 		if self.getPlug() is not None :
-			widgetType = Gaffer.Metadata.plugValue( self.getPlug(), "plugValueWidget:type" )
+			widgetType = Gaffer.Metadata.value( self.getPlug(), "plugValueWidget:type" )
 
 		for m in self.__metadataDefinitions :
 			widget = self.__metadataWidgets[m.key]
@@ -1587,7 +1585,7 @@ class _PlugEditor( GafferUI.Widget ) :
 		if self.getPlug() is None :
 			return result
 
-		metadata = Gaffer.Metadata.plugValue( self.getPlug(), "plugValueWidget:type" )
+		metadata = Gaffer.Metadata.value( self.getPlug(), "plugValueWidget:type" )
 		for w in self.__widgetDefinitions :
 			if not isinstance( self.getPlug(), w.plugType ) :
 				continue
@@ -1608,7 +1606,7 @@ class _PlugEditor( GafferUI.Widget ) :
 			self.__gadgetMenu.setText( "" )
 			return
 
-		metadata = Gaffer.Metadata.plugValue( self.getPlug(), "nodule:type" )
+		metadata = Gaffer.Metadata.value( self.getPlug(), "nodule:type" )
 		metadata = None if metadata == "GafferUI::StandardNodule" else metadata
 		for g in self.__gadgetDefinitions :
 			if g.metadata == metadata :
@@ -1623,7 +1621,7 @@ class _PlugEditor( GafferUI.Widget ) :
 		if self.getPlug() is None :
 			return result
 
-		metadata = Gaffer.Metadata.plugValue( self.getPlug(), "nodule:type" )
+		metadata = Gaffer.Metadata.value( self.getPlug(), "nodule:type" )
 		for g in self.__gadgetDefinitions :
 			if not isinstance( self.getPlug(), g.plugType ) :
 				continue
@@ -1642,9 +1640,9 @@ class _PlugEditor( GafferUI.Widget ) :
 
 		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			if value is not None :
-				Gaffer.Metadata.registerPlugValue( self.getPlug(), key, value )
+				Gaffer.Metadata.registerValue( self.getPlug(), key, value )
 			else :
-				Gaffer.Metadata.deregisterPlugValue( self.getPlug(), key )
+				Gaffer.Metadata.deregisterValue( self.getPlug(), key )
 
 	__WidgetDefinition = collections.namedtuple( "WidgetDefinition", ( "label", "plugType", "metadata" ) )
 	__widgetDefinitions = (

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -389,14 +389,9 @@ class _MetadataWidget( GafferUI.Widget ) :
 
 		if self.__key != key :
 			return
-		if plug is not None and not plug.isSame( self.__target ) :
-			return
-		if not self.__target.node().isInstanceOf( nodeTypeId ) :
-			return
-		if not Gaffer.match( self.__target.relativeName( self.__target.node() ), plugPath ) :
-			return
 
-		self.__update()
+		if Gaffer.affectedByChange( self.__target, nodeTypeId, plugPath, plug ) :
+			self.__update()
 
 class _BoolMetadataWidget( _MetadataWidget ) :
 
@@ -1063,11 +1058,9 @@ class _PlugListing( GafferUI.Widget ) :
 		if self.__parent is None :
 			return
 
-		if plug is not None and not self.__parent.isSame( plug ) and not self.__parent.isSame( plug.parent() ) :
-			return
-
-		node = self.__parent.node() if isinstance( self.__parent, Gaffer.Plug ) else self.__parent
-		if not node.isInstanceOf( nodeTypeId ) :
+		parentAffected = isinstance( self.__parent, Gaffer.Plug ) and Gaffer.affectedByChange( self.__parent, nodeTypeId, plugPath, plug )
+		childAffected = Gaffer.childAffectedByChange( self.__parent, nodeTypeId, plugPath, plug )
+		if not parentAffected and not childAffected :
 			return
 
 		if key in ( "layout:index", "layout:section", "uiEditor:emptySections", "uiEditor:emptySectionIndices" ) :
@@ -1280,7 +1273,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 
 	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
 
-		if plug is None or not plug.isSame( self.__plug ) :
+		if self.__plug is None or not Gaffer.affectedByChange( self.__plug, nodeTypeId, plugPath, plug ) :
 			return
 
 		if key.startswith( "preset:" ) :
@@ -1553,10 +1546,7 @@ class _PlugEditor( GafferUI.Widget ) :
 		if self.getPlug() is None :
 			return
 
-		if plug is not None and not plug.isSame( self.getPlug() ) :
-			return
-
-		if not self.getPlug().node().isInstanceOf( nodeTypeId ) :
+		if not Gaffer.affectedByChange( self.getPlug(), nodeTypeId, plugPath, plug ) :
 			return
 
 		if key == "plugValueWidget:type" :

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -141,7 +141,13 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 	def appendNodeContextMenuDefinitions( cls, nodeGraph, node, menuDefinition ) :
 
 		menuDefinition.append( "/UIEditorDivider", { "divider" : True } )
-		menuDefinition.append( "/Set Color...", { "command" : functools.partial( cls.__setColor, node = node ) } )
+		menuDefinition.append(
+			"/Set Color...",
+			{
+				"command" : functools.partial( cls.__setColor, node = node ),
+				"active" : not Gaffer.readOnly( node ),
+			}
+		)
 
 	@classmethod
 	def appendNodeEditorToolMenuDefinitions( cls, nodeEditor, node, menuDefinition ) :
@@ -150,7 +156,10 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 			"/Edit UI...",
 			{
 				"command" : functools.partial( GafferUI.UIEditor.acquire, node ),
-				"active" : isinstance( node, Gaffer.Box ) or nodeEditor.nodeUI().plugValueWidget( node["user"] ) is not None
+				"active" : (
+					( isinstance( node, Gaffer.Box ) or nodeEditor.nodeUI().plugValueWidget( node["user"] ) is not None ) and
+					not Gaffer.readOnly( node )
+				)
 			}
 		)
 
@@ -249,7 +258,12 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 			return
 
 	menuDefinition.append( "/EditUIDivider", { "divider" : True } )
-	menuDefinition.append( "/Edit UI...", { "command" : IECore.curry( __editPlugUI, node, plug ), "active" : not plugValueWidget.getReadOnly() } )
+	menuDefinition.append( "/Edit UI...",
+		{
+			"command" : IECore.curry( __editPlugUI, node, plug ),
+			"active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug )
+		}
+	)
 
 __plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )
 

--- a/python/GafferUI/UserPlugs.py
+++ b/python/GafferUI/UserPlugs.py
@@ -78,7 +78,7 @@ def __addPlug( plugParent, plugType ) :
 
 	with Gaffer.UndoContext( plugParent.ancestor( Gaffer.ScriptNode ) ) :
 		plug = plugType( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		Gaffer.Metadata.registerPlugValue( plug, "nodule:type", "" )
+		Gaffer.Metadata.registerValue( plug, "nodule:type", "" )
 		plugParent.addChild( plug )
 
 def __plugCreationMenuDefinition( plugParent ) :

--- a/python/GafferUI/VectorDataPlugValueWidget.py
+++ b/python/GafferUI/VectorDataPlugValueWidget.py
@@ -76,7 +76,7 @@ class VectorDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 					plugValue = plug.ValueType()
 				self.__dataWidget.setData( plugValue )
 
-			dragPointer = Gaffer.Metadata.plugValue( plug, "vectorDataPlugValueWidget:dragPointer" )
+			dragPointer = Gaffer.Metadata.value( plug, "vectorDataPlugValueWidget:dragPointer" )
 			if dragPointer is not None :
 				self.__dataWidget.setDragPointer( dragPointer )
 

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -208,7 +208,7 @@ class Viewer( GafferUI.NodeSetEditor ) :
 						if self.__currentView is not None:
 							self.__currentView.setContext( self.getContext() )
 							self.__viewTools[self.__currentView] = [ GafferUI.Tool.create( n, self.__currentView ) for n in GafferUI.Tool.registeredTools( self.__currentView.typeId() ) ]
-							self.__viewTools[self.__currentView].sort( key = lambda v : Gaffer.Metadata.nodeValue( v, "order" ) if Gaffer.Metadata.nodeValue( v, "order" ) is not None else 999 )
+							self.__viewTools[self.__currentView].sort( key = lambda v : Gaffer.Metadata.value( v, "order" ) if Gaffer.Metadata.value( v, "order" ) is not None else 999 )
 							if len( self.__viewTools[self.__currentView] ) :
 								self.__activateTool( self.__viewTools[self.__currentView][0] )
 							self.__views.append( self.__currentView )

--- a/python/GafferUITest/BoxUITest.py
+++ b/python/GafferUITest/BoxUITest.py
@@ -51,10 +51,10 @@ class BoxUITest( GafferUITest.TestCase ) :
 
 	IECore.registerRunTimeTyped( NodulePositionNode )
 
-	Gaffer.Metadata.registerPlugValue( NodulePositionNode, "op1", "nodeGadget:nodulePosition", "left" )
-	Gaffer.Metadata.registerPlugValue( NodulePositionNode, "sum", "nodeGadget:nodulePosition", "right" )
+	Gaffer.Metadata.registerValue( NodulePositionNode, "op1", "nodeGadget:nodulePosition", "left" )
+	Gaffer.Metadata.registerValue( NodulePositionNode, "sum", "nodeGadget:nodulePosition", "right" )
 
-	Gaffer.Metadata.registerPlugValue( NodulePositionNode, "op2", "nodule:type", "" )
+	Gaffer.Metadata.registerValue( NodulePositionNode, "op2", "nodule:type", "" )
 
 	def testNodulePositions( self ) :
 
@@ -188,10 +188,10 @@ class BoxUITest( GafferUITest.TestCase ) :
 		s["b"]["n"] = Gaffer.Node()
 
 		s["b"]["n"]["user"]["p"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		Gaffer.Metadata.registerPlugValue( s["b"]["n"]["user"]["p"], "layout:section", "SomeWeirdSection" )
+		Gaffer.Metadata.registerValue( s["b"]["n"]["user"]["p"], "layout:section", "SomeWeirdSection" )
 
 		p = s["b"].promotePlug( s["b"]["n"]["user"]["p"] )
-		self.assertNotEqual( Gaffer.Metadata.plugValue( p, "layout:section" ), "SomeWeirdSection" )
+		self.assertNotEqual( Gaffer.Metadata.value( p, "layout:section" ), "SomeWeirdSection" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/CompoundNumericPlugValueWidgetTest.py
+++ b/python/GafferUITest/CompoundNumericPlugValueWidgetTest.py
@@ -76,7 +76,7 @@ class CompoundNumericPlugValueWidgetTest( unittest.TestCase ) :
 
 		n = Gaffer.Node()
 		n["v"] = Gaffer.V3fPlug()
-		Gaffer.Metadata.registerPlugValue( n["v"], "ui:visibleDimensions", 2 )
+		Gaffer.Metadata.registerValue( n["v"], "ui:visibleDimensions", 2 )
 
 		w = GafferUI.CompoundNumericPlugValueWidget( n["v"] )
 

--- a/python/GafferUITest/DotNodeGadgetTest.py
+++ b/python/GafferUITest/DotNodeGadgetTest.py
@@ -68,7 +68,7 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		s = Gaffer.ScriptNode()
 
 		s["n"] = GafferTest.AddNode()
-		Gaffer.Metadata.registerPlugValue( s["n"]["sum"], "nodeGadget:nodulePosition", "right" )
+		Gaffer.Metadata.registerValue( s["n"]["sum"], "nodeGadget:nodulePosition", "right" )
 
 		s["d"] = Gaffer.Dot()
 
@@ -87,7 +87,7 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		s = Gaffer.ScriptNode()
 
 		s["n"] = GafferTest.AddNode()
-		Gaffer.Metadata.registerPlugValue( s["n"]["op1"], "nodeGadget:nodulePosition", "left" )
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "nodeGadget:nodulePosition", "left" )
 
 		s["d"] = Gaffer.Dot()
 
@@ -109,7 +109,7 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		s["n2"] = GafferTest.AddNode()
 		s["n2"]["op1"].setInput( s["n1"]["sum"] )
 
-		Gaffer.Metadata.registerPlugValue( s["n1"]["sum"], "nodeGadget:nodulePosition", "right" )
+		Gaffer.Metadata.registerValue( s["n1"]["sum"], "nodeGadget:nodulePosition", "right" )
 
 		s["d"] = Gaffer.Dot()
 
@@ -128,7 +128,7 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		s = Gaffer.ScriptNode()
 
 		s["n"] = GafferTest.AddNode()
-		Gaffer.Metadata.registerPlugValue( s["n"]["sum"], "nodeGadget:nodulePosition", "right" )
+		Gaffer.Metadata.registerValue( s["n"]["sum"], "nodeGadget:nodulePosition", "right" )
 
 		graphGadget = GafferUI.GraphGadget( s )
 

--- a/python/GafferUITest/GraphGadgetTest.py
+++ b/python/GafferUITest/GraphGadgetTest.py
@@ -1125,7 +1125,7 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		self.assertTrue( g.nodeGadget( script["n2"] ).nodule( script["n2"]["p"] ) is not None )
 		self.assertTrue( g.connectionGadget( script["n2"]["p"] ) is not None )
 
-		Gaffer.Metadata.registerPlugValue( script["n2"]["p"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( script["n2"]["p"], "nodule:type", "" )
 		self.assertTrue( g.nodeGadget( script["n2"] ).nodule( script["n2"]["p"] ) is None )
 		self.assertTrue( g.connectionGadget( script["n2"]["p"] ) is None )
 
@@ -1147,14 +1147,14 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		self.assertTrue( c.srcNodule().plug().isSame( script["n1"]["out"] ) )
 		self.assertTrue( c.dstNodule().plug().isSame( script["n2"]["in"] ) )
 
-		Gaffer.Metadata.registerPlugValue( script["n1"]["out"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( script["n1"]["out"], "nodule:type", "" )
 
 		c = g.connectionGadget( script["n2"]["in"] )
 		self.assertTrue( c is not None )
 		self.assertTrue( c.srcNodule() is None )
 		self.assertTrue( c.dstNodule().plug().isSame( script["n2"]["in"] ) )
 
-		Gaffer.Metadata.registerPlugValue( script["n1"]["out"], "nodule:type", "GafferUI::StandardNodule" )
+		Gaffer.Metadata.registerValue( script["n1"]["out"], "nodule:type", "GafferUI::StandardNodule" )
 
 		c = g.connectionGadget( script["n2"]["in"] )
 		self.assertTrue( c is not None )
@@ -1170,13 +1170,13 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		script["n"]["out"] = Gaffer.Plug( direction = Gaffer.Plug.Direction.Out )
 		script["n"]["out"].setInput( script["n"]["in"] )
 
-		Gaffer.Metadata.registerPlugValue( script["n"]["out"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( script["n"]["out"], "nodule:type", "" )
 
 		g = GafferUI.GraphGadget( script )
 		self.assertTrue( g.nodeGadget( script["n"] ).nodule( script["n"]["out"] ) is None )
 		self.assertTrue( g.connectionGadget( script["n"]["out"] ) is None )
 
-		Gaffer.Metadata.registerPlugValue( script["n"]["out"], "nodule:type", "GafferUI::StandardNodule" )
+		Gaffer.Metadata.registerValue( script["n"]["out"], "nodule:type", "GafferUI::StandardNodule" )
 
 		self.assertTrue( g.nodeGadget( script["n"] ).nodule( script["n"]["out"] ) is not None )
 		self.assertTrue( g.connectionGadget( script["n"]["out"] ) is None )
@@ -1192,14 +1192,14 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		script["n2"]["in"] = Gaffer.Plug()
 		script["n2"]["in"].setInput( script["n1"]["out"] )
 
-		Gaffer.Metadata.registerPlugValue( script["n1"]["out"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( script["n1"]["out"], "nodule:type", "" )
 
 		g = GafferUI.GraphGadget( script )
 		self.assertTrue( g.nodeGadget( script["n1"] ).nodule( script["n1"]["out"] ) is None )
 		self.assertTrue( g.connectionGadget( script["n2"]["in"] ) is not None )
 		self.assertTrue( g.connectionGadget( script["n2"]["in"] ).srcNodule() is None )
 
-		Gaffer.Metadata.registerPlugValue( script["n1"]["out"], "nodule:type", "GafferUI::StandardNodule" )
+		Gaffer.Metadata.registerValue( script["n1"]["out"], "nodule:type", "GafferUI::StandardNodule" )
 
 		self.assertTrue( g.nodeGadget( script["n1"] ).nodule( script["n1"]["out"] ) is not None )
 		self.assertTrue( g.connectionGadget( script["n2"]["in"] ) is not None )
@@ -1211,7 +1211,7 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 
 		s["n"] = Gaffer.Node()
 		s["n"]["p"] = Gaffer.Plug()
-		Gaffer.Metadata.registerPlugValue( s["n"]["p"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["n"]["p"], "nodule:type", "" )
 
 		g = GafferUI.GraphGadget( s )
 		self.assertTrue( g.nodeGadget( s["n"] ).nodule( s["n"]["p"] ) is None )

--- a/python/GafferUITest/NoduleTest.py
+++ b/python/GafferUITest/NoduleTest.py
@@ -77,7 +77,7 @@ class NoduleTest( GafferUITest.TestCase ) :
 		self.failUnless( isinstance( ni, GafferUI.StandardNodule ) )
 		self.failUnless( isinstance( nc, GafferUI.StandardNodule ) )
 
-		Gaffer.Metadata.registerPlugValue( NoduleTestNode, "c", "nodule:type", "GafferUI::CompoundNodule" )
+		Gaffer.Metadata.registerValue( NoduleTestNode, "c", "nodule:type", "GafferUI::CompoundNodule" )
 
 		nc = GafferUI.Nodule.create( n["c"] )
 		self.failUnless( isinstance( nc, GafferUI.CompoundNodule ) )

--- a/python/GafferUITest/PlugLayoutTest.py
+++ b/python/GafferUITest/PlugLayoutTest.py
@@ -73,9 +73,9 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 			[ n["user"]["a"], n["user"]["b"], n["user"]["c"] ],
 		)
 
-		Gaffer.Metadata.registerPlugValue( n["user"]["a"], "layout:index", 3 )
-		Gaffer.Metadata.registerPlugValue( n["user"]["b"], "layout:index", 2 )
-		Gaffer.Metadata.registerPlugValue( n["user"]["c"], "layout:index", 1 )
+		Gaffer.Metadata.registerValue( n["user"]["a"], "layout:index", 3 )
+		Gaffer.Metadata.registerValue( n["user"]["b"], "layout:index", 2 )
+		Gaffer.Metadata.registerValue( n["user"]["c"], "layout:index", 1 )
 
 		self.assertEqual(
 			GafferUI.PlugLayout.layoutOrder( n["user"] ),
@@ -93,7 +93,7 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 	def testCustomWidgets( self ) :
 
 		n = Gaffer.Node()
-		Gaffer.Metadata.registerNodeValue( n, "layout:customWidget:test:widgetType", "GafferUITest.PlugLayoutTest.CustomWidget" )
+		Gaffer.Metadata.registerValue( n, "layout:customWidget:test:widgetType", "GafferUITest.PlugLayoutTest.CustomWidget" )
 
 		p = GafferUI.PlugLayout( n )
 
@@ -123,13 +123,13 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 
 		self.assertEqual( GafferUI.PlugLayout.layoutSections( n["user"] ), [ "" ] )
 
-		Gaffer.Metadata.registerPlugValue( n["user"]["a"], "layout:section", "A" )
-		Gaffer.Metadata.registerPlugValue( n["user"]["b"], "layout:section", "B" )
-		Gaffer.Metadata.registerPlugValue( n["user"]["c"], "layout:section", "C" )
+		Gaffer.Metadata.registerValue( n["user"]["a"], "layout:section", "A" )
+		Gaffer.Metadata.registerValue( n["user"]["b"], "layout:section", "B" )
+		Gaffer.Metadata.registerValue( n["user"]["c"], "layout:section", "C" )
 
 		self.assertEqual( GafferUI.PlugLayout.layoutSections( n["user"] ), [ "A", "B", "C" ] )
 
-		Gaffer.Metadata.registerPlugValue( n["user"]["a"], "layout:index", 3 )
+		Gaffer.Metadata.registerValue( n["user"]["a"], "layout:index", 3 )
 		self.assertEqual( GafferUI.PlugLayout.layoutSections( n["user"] ), [ "B", "C", "A" ] )
 
 	def testLayoutOrderSectionArgument( self ) :
@@ -144,9 +144,9 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 			[ n["user"]["a"], n["user"]["b"], n["user"]["c"] ],
 		)
 
-		Gaffer.Metadata.registerPlugValue( n["user"]["a"], "layout:section", "AB" )
-		Gaffer.Metadata.registerPlugValue( n["user"]["b"], "layout:section", "AB" )
-		Gaffer.Metadata.registerPlugValue( n["user"]["c"], "layout:section", "C" )
+		Gaffer.Metadata.registerValue( n["user"]["a"], "layout:section", "AB" )
+		Gaffer.Metadata.registerValue( n["user"]["b"], "layout:section", "AB" )
+		Gaffer.Metadata.registerValue( n["user"]["c"], "layout:section", "C" )
 
 		self.assertEqual(
 			GafferUI.PlugLayout.layoutOrder( n["user"], section = "AB" ),
@@ -169,11 +169,11 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 		w2 = l.plugValueWidget( n["p2"], lazy = False )
 		self.assertTrue( isinstance( w2, GafferUI.NumericPlugValueWidget ) )
 
-		Gaffer.Metadata.registerPlugValue( n["p1"], "plugValueWidget:type", "GafferUI.ConnectionPlugValueWidget" )
+		Gaffer.Metadata.registerValue( n["p1"], "plugValueWidget:type", "GafferUI.ConnectionPlugValueWidget" )
 		self.assertTrue( isinstance( l.plugValueWidget( n["p1"], lazy = False ), GafferUI.ConnectionPlugValueWidget ) )
 		self.assertTrue( w2 is l.plugValueWidget( n["p2"], lazy = False ) )
 
-		Gaffer.Metadata.deregisterPlugValue( n["p1"], "plugValueWidget:type" )
+		Gaffer.Metadata.deregisterValue( n["p1"], "plugValueWidget:type" )
 		self.assertTrue( isinstance( l.plugValueWidget( n["p1"], lazy = False ), GafferUI.NumericPlugValueWidget ) )
 		self.assertTrue( w2 is l.plugValueWidget( n["p2"], lazy = False ) )
 
@@ -185,10 +185,10 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 		l = GafferUI.PlugLayout( n )
 		self.assertTrue( isinstance( l.plugValueWidget( n["p"], lazy = False ), GafferUI.NumericPlugValueWidget ) )
 
-		Gaffer.Metadata.registerPlugValue( n["p"], "plugValueWidget:type", "" )
+		Gaffer.Metadata.registerValue( n["p"], "plugValueWidget:type", "" )
 		self.assertTrue( l.plugValueWidget( n["p"], lazy = False ) is None )
 
-		Gaffer.Metadata.deregisterPlugValue( n["p"], "plugValueWidget:type" )
+		Gaffer.Metadata.deregisterValue( n["p"], "plugValueWidget:type" )
 		self.assertTrue( isinstance( l.plugValueWidget( n["p"], lazy = False ), GafferUI.NumericPlugValueWidget ) )
 
 	def testContext( self ) :
@@ -272,17 +272,17 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 		n["p1"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		n["p2"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
-		Gaffer.Metadata.registerNodeValue( n, "layout1:activator:true", True )
-		Gaffer.Metadata.registerNodeValue( n, "layout1:activator:false", False )
+		Gaffer.Metadata.registerValue( n, "layout1:activator:true", True )
+		Gaffer.Metadata.registerValue( n, "layout1:activator:false", False )
 
-		Gaffer.Metadata.registerNodeValue( n, "layout2:activator:true", True )
-		Gaffer.Metadata.registerNodeValue( n, "layout2:activator:false", False )
+		Gaffer.Metadata.registerValue( n, "layout2:activator:true", True )
+		Gaffer.Metadata.registerValue( n, "layout2:activator:false", False )
 
-		Gaffer.Metadata.registerPlugValue( n["p1"], "layout1:activator", "true" )
-		Gaffer.Metadata.registerPlugValue( n["p1"], "layout2:activator", "false" )
+		Gaffer.Metadata.registerValue( n["p1"], "layout1:activator", "true" )
+		Gaffer.Metadata.registerValue( n["p1"], "layout2:activator", "false" )
 
-		Gaffer.Metadata.registerPlugValue( n["p2"], "layout1:activator", "false" )
-		Gaffer.Metadata.registerPlugValue( n["p2"], "layout2:activator", "true" )
+		Gaffer.Metadata.registerValue( n["p2"], "layout1:activator", "false" )
+		Gaffer.Metadata.registerValue( n["p2"], "layout2:activator", "true" )
 
 		l1 = GafferUI.PlugLayout( n, layoutName = "layout1" )
 		l2 = GafferUI.PlugLayout( n, layoutName = "layout2" )
@@ -299,7 +299,7 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 		n["p1"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		n["p2"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
-		Gaffer.Metadata.registerPlugValue( n["p2"], "layout:section", "sectionA" )
+		Gaffer.Metadata.registerValue( n["p2"], "layout:section", "sectionA" )
 
 		l = GafferUI.PlugLayout( n, rootSection = "sectionA" )
 

--- a/python/GafferUITest/PlugValueWidgetTest.py
+++ b/python/GafferUITest/PlugValueWidgetTest.py
@@ -94,7 +94,7 @@ class PlugValueWidgetTest( unittest.TestCase ) :
 		self.assertTrue( isinstance( w, GafferUI.NumericPlugValueWidget ) )
 		self.assertTrue( w.getPlug().isSame( n["p"] ) )
 
-		Gaffer.Metadata.registerPlugValue( n["p"], "plugValueWidget:type", "GafferUI.ConnectionPlugValueWidget" )
+		Gaffer.Metadata.registerValue( n["p"], "plugValueWidget:type", "GafferUI.ConnectionPlugValueWidget" )
 
 		w = GafferUI.PlugValueWidget.create( n["p"] )
 		self.assertTrue( isinstance( w, GafferUI.ConnectionPlugValueWidget ) )

--- a/python/GafferUITest/ReferenceUITest.py
+++ b/python/GafferUITest/ReferenceUITest.py
@@ -51,7 +51,7 @@ class ReferenceUITest( GafferUITest.TestCase ) :
 		s["b"]["n"] = Gaffer.Node()
 		s["b"]["n"]["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
-		Gaffer.Metadata.registerPlugValue( s["b"]["n"]["p"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["b"]["n"]["p"], "nodule:type", "" )
 
 		p = s["b"].promotePlug( s["b"]["n"]["p"] )
 		p.setName( "p" )

--- a/python/GafferUITest/StandardGraphLayoutTest.py
+++ b/python/GafferUITest/StandardGraphLayoutTest.py
@@ -70,10 +70,10 @@ class LayoutNode( Gaffer.Node ) :
 
 IECore.registerRunTimeTyped( LayoutNode )
 
-Gaffer.Metadata.registerPlugValue( LayoutNode, "left*", "nodeGadget:nodulePosition", "left" )
-Gaffer.Metadata.registerPlugValue( LayoutNode, "right*", "nodeGadget:nodulePosition", "right" )
-Gaffer.Metadata.registerPlugValue( LayoutNode, "top*", "nodeGadget:nodulePosition", "top" )
-Gaffer.Metadata.registerPlugValue( LayoutNode, "bottom*", "nodeGadget:nodulePosition", "bottom" )
+Gaffer.Metadata.registerValue( LayoutNode, "left*", "nodeGadget:nodulePosition", "left" )
+Gaffer.Metadata.registerValue( LayoutNode, "right*", "nodeGadget:nodulePosition", "right" )
+Gaffer.Metadata.registerValue( LayoutNode, "top*", "nodeGadget:nodulePosition", "top" )
+Gaffer.Metadata.registerValue( LayoutNode, "bottom*", "nodeGadget:nodulePosition", "bottom" )
 
 class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 

--- a/python/GafferUITest/StandardNodeGadgetTest.py
+++ b/python/GafferUITest/StandardNodeGadgetTest.py
@@ -128,7 +128,7 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 		g = GafferUI.StandardNodeGadget( n )
 		self.assertEqual( g.noduleTangent( g.nodule( n["op1"] ) ), IECore.V3f( 0, 1, 0 ) )
 
-		Gaffer.Metadata.registerPlugValue( n.typeId(), "op1", "nodeGadget:nodulePosition", "left" )
+		Gaffer.Metadata.registerValue( n.typeId(), "op1", "nodeGadget:nodulePosition", "left" )
 
 		g = GafferUI.StandardNodeGadget( n )
 		self.assertEqual( g.noduleTangent( g.nodule( n["op1"] ) ), IECore.V3f( -1, 0, 0 ) )
@@ -172,7 +172,7 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 		g = GafferUI.StandardNodeGadget( n )
 		self.assertEqual( g.noduleTangent( g.nodule( n["op2"] ) ), IECore.V3f( 0, 1, 0 ) )
 
-		Gaffer.Metadata.registerPlugValue( n["op2"], "nodeGadget:nodulePosition", "left" )
+		Gaffer.Metadata.registerValue( n["op2"], "nodeGadget:nodulePosition", "left" )
 		self.assertEqual( g.noduleTangent( g.nodule( n["op2"] ) ), IECore.V3f( -1, 0, 0 ) )
 
 	def testRemoveNoduleAfterCreation( self ) :
@@ -183,7 +183,7 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 		g = GafferUI.StandardNodeGadget( n )
 		self.assertEqual( g.noduleTangent( g.nodule( n["p"] ) ), IECore.V3f( 0, 1, 0 ) )
 
-		Gaffer.Metadata.registerPlugValue( n["p"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( n["p"], "nodule:type", "" )
 		self.assertEqual( g.nodule( n["p"] ), None )
 
 	def testPlugReferences( self ) :
@@ -216,7 +216,7 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 		self.assertTrue( isinstance( n1, GafferUI.StandardNodule ) )
 		self.assertTrue( isinstance( n2, GafferUI.StandardNodule ) )
 
-		Gaffer.Metadata.registerPlugValue( n["p1"], "nodule:type", "GafferUI::CompoundNodule" )
+		Gaffer.Metadata.registerValue( n["p1"], "nodule:type", "GafferUI::CompoundNodule" )
 
 		self.assertTrue( isinstance( g.nodule( n["p1"] ), GafferUI.CompoundNodule ) )
 		self.assertTrue( g.nodule( n["p2"] ).isSame( n2 ) )
@@ -238,7 +238,7 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 
 		del added[:]
 
-		Gaffer.Metadata.registerPlugValue( n["p"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( n["p"], "nodule:type", "" )
 		self.assertEqual( len( added ), 0 )
 		self.assertEqual( len( removed ), 1 )
 		self.assertTrue( removed[0][0].isSame( g ) )
@@ -246,7 +246,7 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 
 		del removed[:]
 
-		Gaffer.Metadata.registerPlugValue( n["p"], "nodule:type", "GafferUI::StandardNodule" )
+		Gaffer.Metadata.registerValue( n["p"], "nodule:type", "GafferUI::StandardNodule" )
 		self.assertEqual( len( added ), 1 )
 		self.assertTrue( added[0][0].isSame( g ) )
 		self.assertTrue( added[0][1].isSame( g.nodule( n["p"] ) ) )
@@ -275,8 +275,8 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 			g.nodule( n["b"] ).transformedBound().center().x
 		)
 
-		Gaffer.Metadata.registerPlugValue( n["a"], "nodeGadget:noduleIndex", 1 )
-		Gaffer.Metadata.registerPlugValue( n["b"], "nodeGadget:noduleIndex", 0 )
+		Gaffer.Metadata.registerValue( n["a"], "nodeGadget:noduleIndex", 1 )
+		Gaffer.Metadata.registerValue( n["b"], "nodeGadget:noduleIndex", 0 )
 
 		g.bound()
 		self.assertGreater(

--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -494,7 +494,7 @@ void Box::copyMetadata( const Plug *from, Plug *to )
 	/// know all valid names. We'd also need to put a lot of thought into how we allowed the
 	/// user to delete values which were being mirrored dynamically.
 	vector<IECore::InternedString> keys;
-	Metadata::registeredValues( from, keys, /* inherit = */ true, /* instanceOnly = */ false, /* persistentOnly = */ true );
+	Metadata::registeredValues( from, keys, /* instanceOnly = */ false, /* persistentOnly = */ true );
 	for( vector<IECore::InternedString>::const_iterator it = keys.begin(), eIt = keys.end(); it != eIt; ++it )
 	{
 		if( boost::starts_with( it->string(), "layout:" ) )

--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -494,7 +494,7 @@ void Box::copyMetadata( const Plug *from, Plug *to )
 	/// know all valid names. We'd also need to put a lot of thought into how we allowed the
 	/// user to delete values which were being mirrored dynamically.
 	vector<IECore::InternedString> keys;
-	Metadata::registeredPlugValues( from, keys, /* inherit = */ true, /* instanceOnly = */ false, /* persistentOnly = */ true );
+	Metadata::registeredValues( from, keys, /* inherit = */ true, /* instanceOnly = */ false, /* persistentOnly = */ true );
 	for( vector<IECore::InternedString>::const_iterator it = keys.begin(), eIt = keys.end(); it != eIt; ++it )
 	{
 		if( boost::starts_with( it->string(), "layout:" ) )
@@ -502,7 +502,7 @@ void Box::copyMetadata( const Plug *from, Plug *to )
 			// Don't want to copy layout metadata because the user will be making their own layout.
 			continue;
 		}
-		Metadata::registerPlugValue( to, *it, Metadata::plugValue<IECore::Data>( from, *it ) );
+		Metadata::registerValue( to, *it, Metadata::value<IECore::Data>( from, *it ) );
 	}
 
 	for( PlugIterator it( from ); !it.done(); ++it )

--- a/src/Gaffer/Dot.cpp
+++ b/src/Gaffer/Dot.cpp
@@ -83,7 +83,7 @@ void Dot::setup( const Plug *plug )
 	ConstStringDataPtr nodulePosition;
 	for( const Plug *metadataPlug = plug; metadataPlug; metadataPlug = metadataPlug->parent<Plug>() )
 	{
-		if( ( nodulePosition = Metadata::plugValue<StringData>( metadataPlug, g_nodulePositionName ) ) )
+		if( ( nodulePosition = Metadata::value<StringData>( metadataPlug, g_nodulePositionName ) ) )
 		{
 			break;
 		}
@@ -110,11 +110,11 @@ void Dot::setup( const Plug *plug )
 			oppositePosition = "bottom";
 		}
 
-		Metadata::registerPlugValue(
+		Metadata::registerValue(
 			plug->direction() == Plug::In ? in.get() : out.get(),
 			g_nodulePositionName, nodulePosition
 		);
-		Metadata::registerPlugValue(
+		Metadata::registerValue(
 			plug->direction() == Plug::In ? out.get() : in.get(),
 			g_nodulePositionName, new StringData( oppositePosition )
 		);

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -471,7 +471,7 @@ std::string Metadata::nodeDescription( const Node *node, bool inherit )
 	return "";
 }
 
-std::vector<Node*> Metadata::nodesWithMetadata( GraphComponent *root, IECore::InternedString key, bool inherit, bool instanceOnly )
+std::vector<Node*> Metadata::nodesWithMetadata( GraphComponent *root, IECore::InternedString key, bool instanceOnly )
 {
 	std::vector<Node*> nodes;
 	if( instanceOnly )
@@ -498,7 +498,7 @@ std::vector<Node*> Metadata::nodesWithMetadata( GraphComponent *root, IECore::In
 	{
 		for( RecursiveNodeIterator it( root ); !it.done(); ++it )
 		{
-			if( nodeValueInternal( it->get(), key, inherit, instanceOnly ) )
+			if( nodeValueInternal( it->get(), key, /* inherit = */ true, instanceOnly ) )
 			{
 				nodes.push_back( it->get() );
 			}
@@ -666,7 +666,7 @@ std::string Metadata::plugDescription( const Plug *plug, bool inherit )
 	return "";
 }
 
-std::vector<Plug*> Metadata::plugsWithMetadata( GraphComponent *root, IECore::InternedString key, bool inherit, bool instanceOnly )
+std::vector<Plug*> Metadata::plugsWithMetadata( GraphComponent *root, IECore::InternedString key, bool instanceOnly )
 {
 	std::vector<Plug*> plugs;
 	if( instanceOnly )
@@ -696,7 +696,7 @@ std::vector<Plug*> Metadata::plugsWithMetadata( GraphComponent *root, IECore::In
 	{
 		for( FilteredRecursiveChildIterator<TypePredicate<Plug> > it( root ); !it.done(); ++it )
 		{
-			if( plugValueInternal( it->get(), key, inherit, false ) )
+			if( plugValueInternal( it->get(), key, /* inherit = */ true, false ) )
 			{
 				plugs.push_back( it->get() );
 			}
@@ -710,15 +710,15 @@ void Metadata::registerValue( GraphComponent *target, IECore::InternedString key
 	registerInstanceValue( target, key, value, persistent );
 }
 
-void Metadata::registeredValues( const GraphComponent *target, std::vector<IECore::InternedString> &keys, bool inherit, bool instanceOnly, bool persistentOnly )
+void Metadata::registeredValues( const GraphComponent *target, std::vector<IECore::InternedString> &keys, bool instanceOnly, bool persistentOnly )
 {
 	if( const Node *node = runTimeCast<const Node>( target ) )
 	{
-		registeredNodeValues( node, keys, inherit, instanceOnly, persistentOnly );
+		registeredNodeValues( node, keys, /* inherit = */ true, instanceOnly, persistentOnly );
 	}
 	else if( const Plug *plug = runTimeCast<const Plug>( target ) )
 	{
-		registeredPlugValues( plug, keys, inherit, instanceOnly, persistentOnly );
+		registeredPlugValues( plug, keys, /* inherit = */ true, instanceOnly, persistentOnly );
 	}
 	else
 	{
@@ -726,15 +726,15 @@ void Metadata::registeredValues( const GraphComponent *target, std::vector<IECor
 	}
 }
 
-IECore::ConstDataPtr Metadata::valueInternal( const GraphComponent *target, IECore::InternedString key, bool inherit, bool instanceOnly )
+IECore::ConstDataPtr Metadata::valueInternal( const GraphComponent *target, IECore::InternedString key, bool instanceOnly )
 {
 	if( const Node *node = runTimeCast<const Node>( target ) )
 	{
-		return nodeValueInternal( node, key, inherit, instanceOnly );
+		return nodeValueInternal( node, key, /* inherit = */ true, instanceOnly );
 	}
 	else if( const Plug *plug = runTimeCast<const Plug>( target ) )
 	{
-		return plugValueInternal( plug, key, inherit, instanceOnly );
+		return plugValueInternal( plug, key, /* inherit = */ true, instanceOnly );
 	}
 	else if( !instanceOnly )
 	{

--- a/src/Gaffer/MetadataAlgo.cpp
+++ b/src/Gaffer/MetadataAlgo.cpp
@@ -1,0 +1,79 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECore/SimpleTypedData.h"
+
+#include "Gaffer/GraphComponent.h"
+#include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
+
+using namespace IECore;
+
+namespace
+{
+
+InternedString g_readOnlyName( "readOnly" );
+
+} // namespace
+
+namespace Gaffer
+{
+
+void setReadOnly( GraphComponent *graphComponent, bool readOnly, bool persistent )
+{
+	Metadata::registerValue( graphComponent, g_readOnlyName, new BoolData( readOnly ), persistent );
+}
+
+bool getReadOnly( const GraphComponent *graphComponent )
+{
+	ConstBoolDataPtr d = Metadata::value<BoolData>( graphComponent, g_readOnlyName );
+	return d ? d->readable() : false;
+}
+
+bool readOnly( const GraphComponent *graphComponent )
+{
+	while( graphComponent )
+	{
+		if( getReadOnly( graphComponent ) )
+		{
+			return true;
+		}
+		graphComponent = graphComponent->parent<GraphComponent>();
+	}
+	return false;
+}
+
+} // namespace Gaffer

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -319,7 +319,7 @@ bool Reference::isReferencePlug( const Plug *plug ) const
 void Reference::convertPersistentMetadata( Plug *plug ) const
 {
 	vector<InternedString> keys;
-	Metadata::registeredValues( plug, keys, /* inherit = */ false, /* instanceOnly = */ true, /* persistentOnly = */ true );
+	Metadata::registeredValues( plug, keys, /* instanceOnly = */ true, /* persistentOnly = */ true );
 	for( vector<InternedString>::const_iterator it = keys.begin(), eIt = keys.end(); it != eIt; ++it )
 	{
 		ConstDataPtr value = Metadata::value<Data>( plug, *it );
@@ -330,7 +330,7 @@ void Reference::convertPersistentMetadata( Plug *plug ) const
 void Reference::transferPersistentMetadata( const Plug *srcPlug, Plug *dstPlug ) const
 {
 	vector<InternedString> keys;
-	Metadata::registeredValues( srcPlug, keys, /* inherit = */ false, /* instanceOnly = */ true, /* persistentOnly = */ true );
+	Metadata::registeredValues( srcPlug, keys, /* instanceOnly = */ true, /* persistentOnly = */ true );
 	for( vector<InternedString>::const_iterator it = keys.begin(), eIt = keys.end(); it != eIt; ++it )
 	{
 		ConstDataPtr value = Metadata::value<Data>( srcPlug, *it );

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -179,11 +179,11 @@ void Reference::loadInternal( const std::string &fileName )
 	// and we must make sure they don't clobber the user-set values on the reference node.
 	int milestoneVersion = 0;
 	int majorVersion = 0;
-	if( IECore::ConstIntDataPtr v = Metadata::nodeValue<IECore::IntData>( this, "serialiser:milestoneVersion" ) )
+	if( IECore::ConstIntDataPtr v = Metadata::value<IECore::IntData>( this, "serialiser:milestoneVersion" ) )
 	{
 		milestoneVersion = v->readable();
 	}
-	if( IECore::ConstIntDataPtr v = Metadata::nodeValue<IECore::IntData>( this, "serialiser:majorVersion" ) )
+	if( IECore::ConstIntDataPtr v = Metadata::value<IECore::IntData>( this, "serialiser:majorVersion" ) )
 	{
 		majorVersion = v->readable();
 	}
@@ -308,22 +308,22 @@ bool Reference::isReferencePlug( const Plug *plug ) const
 void Reference::convertPersistentMetadata( Plug *plug ) const
 {
 	vector<InternedString> keys;
-	Metadata::registeredPlugValues( plug, keys, /* inherit = */ false, /* instanceOnly = */ true, /* persistentOnly = */ true );
+	Metadata::registeredValues( plug, keys, /* inherit = */ false, /* instanceOnly = */ true, /* persistentOnly = */ true );
 	for( vector<InternedString>::const_iterator it = keys.begin(), eIt = keys.end(); it != eIt; ++it )
 	{
-		ConstDataPtr value = Metadata::plugValue<Data>( plug, *it );
-		Metadata::registerPlugValue( plug, *it, value, /* persistent = */ false );
+		ConstDataPtr value = Metadata::value<Data>( plug, *it );
+		Metadata::registerValue( plug, *it, value, /* persistent = */ false );
 	}
 }
 
 void Reference::transferPersistentMetadata( const Plug *srcPlug, Plug *dstPlug ) const
 {
 	vector<InternedString> keys;
-	Metadata::registeredPlugValues( srcPlug, keys, /* inherit = */ false, /* instanceOnly = */ true, /* persistentOnly = */ true );
+	Metadata::registeredValues( srcPlug, keys, /* inherit = */ false, /* instanceOnly = */ true, /* persistentOnly = */ true );
 	for( vector<InternedString>::const_iterator it = keys.begin(), eIt = keys.end(); it != eIt; ++it )
 	{
-		ConstDataPtr value = Metadata::plugValue<Data>( srcPlug, *it );
-		Metadata::registerPlugValue( dstPlug, *it, value );
+		ConstDataPtr value = Metadata::value<Data>( srcPlug, *it );
+		Metadata::registerValue( dstPlug, *it, value );
 	}
 
 	for( PlugIterator it( srcPlug ); !it.done(); ++it )

--- a/src/GafferBindings/BoxBinding.cpp
+++ b/src/GafferBindings/BoxBinding.cpp
@@ -52,22 +52,22 @@ namespace GafferBindings
 class BoxSerialiser : public NodeSerialiser
 {
 
-	virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child ) const
+	virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
 	{
 		if( child->isInstanceOf( Node::staticTypeId() ) )
 		{
 			return true;
 		}
-		return NodeSerialiser::childNeedsSerialisation( child );
+		return NodeSerialiser::childNeedsSerialisation( child, serialisation );
 	}
 
-	virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child ) const
+	virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
 	{
 		if( child->isInstanceOf( Node::staticTypeId() ) )
 		{
 			return true;
 		}
-		return NodeSerialiser::childNeedsConstruction( child );
+		return NodeSerialiser::childNeedsConstruction( child, serialisation );
 	}
 
 };

--- a/src/GafferBindings/CompoundDataPlugBinding.cpp
+++ b/src/GafferBindings/CompoundDataPlugBinding.cpp
@@ -148,7 +148,7 @@ class MemberPlugSerialiser : public ValuePlugSerialiser
 			return maskedMemberPlugRepr( static_cast<const CompoundDataPlug::MemberPlug *>( graphComponent ), Plug::All & ~Plug::ReadOnly );
 		}
 
-		virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child ) const
+		virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
 		{
 			// if the parent is dynamic then all the children will need construction.
 			const Plug *parent = child->parent<Plug>();

--- a/src/GafferBindings/ExpressionBinding.cpp
+++ b/src/GafferBindings/ExpressionBinding.cpp
@@ -307,7 +307,7 @@ static tuple languages()
 class ExpressionSerialiser : public NodeSerialiser
 {
 
-	virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules ) const
+	virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const
 	{
 		const Expression *e = static_cast<const Expression *>( graphComponent );
 		std::string language;

--- a/src/GafferBindings/MetadataAlgoBinding.cpp
+++ b/src/GafferBindings/MetadataAlgoBinding.cpp
@@ -1,0 +1,57 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "Gaffer/MetadataAlgo.h"
+#include "Gaffer/GraphComponent.h"
+
+using namespace boost::python;
+using namespace Gaffer;
+
+namespace GafferBindings
+{
+
+void bindMetadataAlgo()
+{
+
+	def( "setReadOnly", &setReadOnly, ( arg( "graphComponent" ), arg( "readOnly"), arg( "persistent" ) = true ) );
+	def( "getReadOnly", &getReadOnly );
+	def( "readOnly", &readOnly );
+
+}
+
+} // namespace GafferBindings

--- a/src/GafferBindings/MetadataAlgoBinding.cpp
+++ b/src/GafferBindings/MetadataAlgoBinding.cpp
@@ -38,6 +38,7 @@
 
 #include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/GraphComponent.h"
+#include "Gaffer/Plug.h"
 
 using namespace boost::python;
 using namespace Gaffer;
@@ -51,6 +52,9 @@ void bindMetadataAlgo()
 	def( "setReadOnly", &setReadOnly, ( arg( "graphComponent" ), arg( "readOnly"), arg( "persistent" ) = true ) );
 	def( "getReadOnly", &getReadOnly );
 	def( "readOnly", &readOnly );
+	def( "affectedByChange", &affectedByChange, ( arg( "plug" ), arg( "changedNodeTypeId"), arg( "changedPlugPath" ), arg( "changedPlug" ) ) );
+	def( "childAffectedByChange", &childAffectedByChange, ( arg( "parent" ), arg( "changedNodeTypeId"), arg( "changedPlugPath" ), arg( "changedPlug" ) ) );
+	def( "ancestorAffectedByChange", &ancestorAffectedByChange, ( arg( "plug" ), arg( "changedNodeTypeId"), arg( "changedPlugPath" ), arg( "changedPlug" ) ) );
 
 }
 

--- a/src/GafferBindings/MetadataBinding.cpp
+++ b/src/GafferBindings/MetadataBinding.cpp
@@ -189,9 +189,9 @@ object value( const char *target, const char *key, bool copy )
 	return dataToPython( d.get(), copy );
 }
 
-object graphComponentValue( const GraphComponent *graphComponent, const char *key, bool inherit, bool instanceOnly, bool copy )
+object graphComponentValue( const GraphComponent *graphComponent, const char *key, bool instanceOnly, bool copy )
 {
-	ConstDataPtr d = Metadata::value<Data>( graphComponent, key, inherit, instanceOnly );
+	ConstDataPtr d = Metadata::value<Data>( graphComponent, key, instanceOnly );
 	return dataToPython( d.get(), copy );
 }
 
@@ -329,10 +329,10 @@ list registeredValues( IECore::InternedString target )
 	return keysToList( keys );
 }
 
-list registeredGraphComponentValues( const GraphComponent *target, bool inherit, bool instanceOnly, bool persistentOnly )
+list registeredGraphComponentValues( const GraphComponent *target, bool instanceOnly, bool persistentOnly )
 {
 	std::vector<InternedString> keys;
-	Metadata::registeredValues( target, keys, inherit, instanceOnly, persistentOnly );
+	Metadata::registeredValues( target, keys, instanceOnly, persistentOnly );
 	return keysToList( keys );
 }
 
@@ -351,9 +351,9 @@ list registeredPlugValues( const Plug *plug, bool inherit, bool instanceOnly, bo
 }
 
 
-list plugsWithMetadata( GraphComponent *root, const std::string &key, bool inherit, bool instanceOnly )
+list plugsWithMetadata( GraphComponent *root, const std::string &key, bool instanceOnly )
 {
-	std::vector<Plug*> plugs = Metadata::plugsWithMetadata( root, key, inherit, instanceOnly );
+	std::vector<Plug*> plugs = Metadata::plugsWithMetadata( root, key, instanceOnly );
 	list result;
 	for( std::vector<Plug*>::const_iterator it = plugs.begin(); it != plugs.end(); ++it )
 	{
@@ -363,9 +363,9 @@ list plugsWithMetadata( GraphComponent *root, const std::string &key, bool inher
 	return result;
 }
 
-list nodesWithMetadata( GraphComponent *root, const std::string &key, bool inherit, bool instanceOnly )
+list nodesWithMetadata( GraphComponent *root, const std::string &key, bool instanceOnly )
 {
-	std::vector<Node*> nodes = Metadata::nodesWithMetadata( root, key, inherit, instanceOnly );
+	std::vector<Node*> nodes = Metadata::nodesWithMetadata( root, key, instanceOnly );
 	list result;
 	for( std::vector<Node*>::const_iterator it = nodes.begin(); it != nodes.end(); ++it )
 	{
@@ -400,7 +400,6 @@ void bindMetadata()
 		.def( "registeredValues", &registeredGraphComponentValues,
 			(
 				boost::python::arg( "target" ),
-				boost::python::arg( "inherit" ) = true,
 				boost::python::arg( "instanceOnly" ) = false,
 				boost::python::arg( "persistentOnly" ) = false
 			)
@@ -418,7 +417,6 @@ void bindMetadata()
 			(
 				boost::python::arg( "target" ),
 				boost::python::arg( "key" ),
-				boost::python::arg( "inherit" ) = true,
 				boost::python::arg( "instanceOnly" ) = false,
 				boost::python::arg( "_copy" ) = true
 			)
@@ -538,7 +536,6 @@ void bindMetadata()
 			(
 				boost::python::arg( "root" ),
 				boost::python::arg( "key" ),
-				boost::python::arg( "inherit" ) = true,
 				boost::python::arg( "instanceOnly" ) = false
 			)
 		)
@@ -548,7 +545,6 @@ void bindMetadata()
 			(
 				boost::python::arg( "root" ),
 				boost::python::arg( "key" ),
-				boost::python::arg( "inherit" ) = true,
 				boost::python::arg( "instanceOnly" ) = false
 			)
 		)
@@ -580,7 +576,7 @@ void metadataModuleDependencies( const Gaffer::Plug *plug, std::set<std::string>
 std::string metadataSerialisation( const Gaffer::Node *node, const std::string &identifier )
 {
 	std::vector<InternedString> keys;
-	Metadata::registeredValues( node, keys, /* inherit = */ false, /* instanceOnly = */ true, /* persistentOnly = */ true );
+	Metadata::registeredValues( node, keys, /* instanceOnly = */ true, /* persistentOnly = */ true );
 
 	std::string result;
 	for( std::vector<InternedString>::const_iterator it = keys.begin(), eIt = keys.end(); it != eIt; ++it )
@@ -606,7 +602,7 @@ std::string metadataSerialisation( const Gaffer::Node *node, const std::string &
 std::string metadataSerialisation( const Plug *plug, const std::string &identifier )
 {
 	std::vector<InternedString> keys;
-	Metadata::registeredValues( plug, keys, /* inherit = */ false, /* instanceOnly = */ true, /* persistentOnly = */ true );
+	Metadata::registeredValues( plug, keys, /* instanceOnly = */ true, /* persistentOnly = */ true );
 
 	std::string result;
 	for( std::vector<InternedString>::const_iterator it = keys.begin(), eIt = keys.end(); it != eIt; ++it )

--- a/src/GafferBindings/MetadataBinding.cpp
+++ b/src/GafferBindings/MetadataBinding.cpp
@@ -189,6 +189,12 @@ object value( const char *target, const char *key, bool copy )
 	return dataToPython( d.get(), copy );
 }
 
+object graphComponentValue( const GraphComponent *graphComponent, const char *key, bool inherit, bool instanceOnly, bool copy )
+{
+	ConstDataPtr d = Metadata::value<Data>( graphComponent, key, inherit, instanceOnly );
+	return dataToPython( d.get(), copy );
+}
+
 void registerNodeValue( IECore::TypeId nodeTypeId, IECore::InternedString key, object &value )
 {
 	Metadata::registerNodeValue( nodeTypeId, key, objectToNodeValueFunction( key, value ) );
@@ -323,6 +329,13 @@ list registeredValues( IECore::InternedString target )
 	return keysToList( keys );
 }
 
+list registeredGraphComponentValues( const GraphComponent *target, bool inherit, bool instanceOnly, bool persistentOnly )
+{
+	std::vector<InternedString> keys;
+	Metadata::registeredValues( target, keys, inherit, instanceOnly, persistentOnly );
+	return keysToList( keys );
+}
+
 list registeredNodeValues( const Node *node, bool inherit, bool instanceOnly, bool persistentOnly )
 {
 	std::vector<InternedString> keys;
@@ -372,9 +385,26 @@ void bindMetadata()
 	scope s = class_<Metadata>( "Metadata", no_init )
 
 		.def( "registerValue", &registerValue )
+		.def( "registerValue", &registerNodeValue )
+		.def( "registerValue", &registerPlugValue )
+		.def( "registerValue", (void (*)( GraphComponent *, InternedString key, ConstDataPtr value, bool ))&Metadata::registerValue,
+			(
+				boost::python::arg( "target" ),
+				boost::python::arg( "value" ),
+				boost::python::arg( "persistent" ) = true
+			)
+		)
 		.staticmethod( "registerValue" )
 
 		.def( "registeredValues", &registeredValues )
+		.def( "registeredValues", &registeredGraphComponentValues,
+			(
+				boost::python::arg( "target" ),
+				boost::python::arg( "inherit" ) = true,
+				boost::python::arg( "instanceOnly" ) = false,
+				boost::python::arg( "persistentOnly" ) = false
+			)
+		)
 		.staticmethod( "registeredValues" )
 
 		.def( "value", &value,
@@ -384,7 +414,21 @@ void bindMetadata()
 				boost::python::arg( "_copy" ) = true
 			)
 		)
+		.def( "value", &graphComponentValue,
+			(
+				boost::python::arg( "target" ),
+				boost::python::arg( "key" ),
+				boost::python::arg( "inherit" ) = true,
+				boost::python::arg( "instanceOnly" ) = false,
+				boost::python::arg( "_copy" ) = true
+			)
+		)
 		.staticmethod( "value" )
+
+		.def( "deregisterValue", (void (*)( IECore::TypeId, IECore::InternedString ) )&Metadata::deregisterValue )
+		.def( "deregisterValue", (void (*)( IECore::TypeId, const MatchPattern &, IECore::InternedString ) )&Metadata::deregisterValue )
+		.def( "deregisterValue", (void (*)( GraphComponent *, IECore::InternedString ) )&Metadata::deregisterValue )
+		.staticmethod( "deregisterValue" )
 
 		.def( "registerNodeValue", &registerNodeValue )
 		.def( "registerNodeValue", (void (*)( Node *, InternedString key, ConstDataPtr value, bool ))&Metadata::registerNodeValue,
@@ -536,7 +580,7 @@ void metadataModuleDependencies( const Gaffer::Plug *plug, std::set<std::string>
 std::string metadataSerialisation( const Gaffer::Node *node, const std::string &identifier )
 {
 	std::vector<InternedString> keys;
-	Metadata::registeredNodeValues( node, keys, /* inherit = */ false, /* instanceOnly = */ true, /* persistentOnly = */ true );
+	Metadata::registeredValues( node, keys, /* inherit = */ false, /* instanceOnly = */ true, /* persistentOnly = */ true );
 
 	std::string result;
 	for( std::vector<InternedString>::const_iterator it = keys.begin(), eIt = keys.end(); it != eIt; ++it )
@@ -544,7 +588,7 @@ std::string metadataSerialisation( const Gaffer::Node *node, const std::string &
 		object pythonKey( it->c_str() );
 		std::string key = extract<std::string>( pythonKey.attr( "__repr__" )() );
 
-		ConstDataPtr value = Metadata::nodeValue<Data>( node, *it );
+		ConstDataPtr value = Metadata::value<Data>( node, *it );
 		object pythonValue = dataToPython( value.get(), /* copy = */ false );
 		std::string stringValue = extract<std::string>( pythonValue.attr( "__repr__" )() );
 
@@ -562,7 +606,7 @@ std::string metadataSerialisation( const Gaffer::Node *node, const std::string &
 std::string metadataSerialisation( const Plug *plug, const std::string &identifier )
 {
 	std::vector<InternedString> keys;
-	Metadata::registeredPlugValues( plug, keys, /* inherit = */ false, /* instanceOnly = */ true, /* persistentOnly = */ true );
+	Metadata::registeredValues( plug, keys, /* inherit = */ false, /* instanceOnly = */ true, /* persistentOnly = */ true );
 
 	std::string result;
 	for( std::vector<InternedString>::const_iterator it = keys.begin(), eIt = keys.end(); it != eIt; ++it )
@@ -570,7 +614,7 @@ std::string metadataSerialisation( const Plug *plug, const std::string &identifi
 		object pythonKey( it->c_str() );
 		std::string key = extract<std::string>( pythonKey.attr( "__repr__" )() );
 
-		ConstDataPtr value = Metadata::plugValue<Data>( plug, *it );
+		ConstDataPtr value = Metadata::value<Data>( plug, *it );
 		object pythonValue = dataToPython( value.get(), /* copy = */ false );
 		std::string stringValue = extract<std::string>( pythonValue.attr( "__repr__" )() );
 

--- a/src/GafferBindings/NodeBinding.cpp
+++ b/src/GafferBindings/NodeBinding.cpp
@@ -102,9 +102,9 @@ struct ErrorSlotCaller
 
 } // namespace
 
-void NodeSerialiser::moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules ) const
+void NodeSerialiser::moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const
 {
-	Serialiser::moduleDependencies( graphComponent, modules );
+	Serialiser::moduleDependencies( graphComponent, modules, serialisation );
 	metadataModuleDependencies( static_cast<const Gaffer::Node *>( graphComponent ), modules );
 }
 
@@ -114,7 +114,7 @@ std::string NodeSerialiser::postHierarchy( const Gaffer::GraphComponent *graphCo
 		metadataSerialisation( static_cast<const Gaffer::Node *>( graphComponent ), identifier );
 }
 
-bool NodeSerialiser::childNeedsSerialisation( const Gaffer::GraphComponent *child ) const
+bool NodeSerialiser::childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
 {
 	if( const Plug *childPlug = IECore::runTimeCast<const Plug>( child ) )
 	{
@@ -123,7 +123,7 @@ bool NodeSerialiser::childNeedsSerialisation( const Gaffer::GraphComponent *chil
 	return false;
 }
 
-bool NodeSerialiser::childNeedsConstruction( const Gaffer::GraphComponent *child ) const
+bool NodeSerialiser::childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
 {
 	if( const Plug *childPlug = IECore::runTimeCast<const Plug>( child ) )
 	{

--- a/src/GafferBindings/NodeBinding.cpp
+++ b/src/GafferBindings/NodeBinding.cpp
@@ -120,7 +120,19 @@ bool NodeSerialiser::childNeedsSerialisation( const Gaffer::GraphComponent *chil
 	{
 		return childPlug->getFlags( Plug::Serialisable );
 	}
-	return false;
+	else
+	{
+		assert( child->isInstanceOf( Node::staticTypeId() ) );
+		// Typically we expect internal nodes to be part of the private
+		// implementation of the parent node, and to be created explicitly
+		// in the parent constructor. Therefore we don't expect them to
+		// need serialisation. But, if the root of the serialisation is
+		// the node itself, it won't be included, so we must serialise the
+		// children explicitly. This is most useful to allow nodes to be
+		// cut + pasted out of Reference nodes, but implementing it here
+		// makes it possible to inspect the internals of other nodes too.
+		return serialisation.parent() == child->parent<GraphComponent>();
+	}
 }
 
 bool NodeSerialiser::childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
@@ -129,7 +141,11 @@ bool NodeSerialiser::childNeedsConstruction( const Gaffer::GraphComponent *child
 	{
 		return childPlug->getFlags( Plug::Dynamic );
 	}
-	return false;
+	else
+	{
+		assert( child->isInstanceOf( Node::staticTypeId() ) );
+		return true;
+	}
 }
 
 void GafferBindings::bindNode()

--- a/src/GafferBindings/PlugBinding.cpp
+++ b/src/GafferBindings/PlugBinding.cpp
@@ -88,9 +88,9 @@ static NodePtr node( Plug &p )
 	return p.node();
 }
 
-void PlugSerialiser::moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules ) const
+void PlugSerialiser::moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const
 {
-	Serialiser::moduleDependencies( graphComponent, modules );
+	Serialiser::moduleDependencies( graphComponent, modules, serialisation );
 	metadataModuleDependencies( static_cast<const Plug *>( graphComponent ), modules );
 }
 
@@ -122,7 +122,7 @@ std::string PlugSerialiser::postHierarchy( const Gaffer::GraphComponent *graphCo
 	return "";
 }
 
-bool PlugSerialiser::childNeedsConstruction( const Gaffer::GraphComponent *child ) const
+bool PlugSerialiser::childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
 {
 	// cast is safe because of constraints maintained by Plug::acceptsChild().
 	const Plug *childPlug = static_cast<const Plug *>( child );

--- a/src/GafferBindings/ScriptNodeBinding.cpp
+++ b/src/GafferBindings/ScriptNodeBinding.cpp
@@ -388,29 +388,6 @@ void deleteNodes( ScriptNode &s, Node *parent, const Set *filter, bool reconnect
 	s.deleteNodes( parent, filter, reconnect );
 }
 
-class ScriptNodeSerialiser : public NodeSerialiser
-{
-
-	virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
-	{
-		if( child->isInstanceOf( Node::staticTypeId() ) )
-		{
-			return true;
-		}
-		return NodeSerialiser::childNeedsSerialisation( child, serialisation );
-	}
-
-	virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
-	{
-		if( child->isInstanceOf( Node::staticTypeId() ) )
-		{
-			return true;
-		}
-		return NodeSerialiser::childNeedsConstruction( child, serialisation );
-	}
-
-};
-
 struct ActionSlotCaller
 {
 
@@ -482,7 +459,5 @@ void GafferBindings::bindScriptNode()
 
 	SignalClass<ScriptNode::ScriptExecutedSignal>( "ScriptExecutedSignal" );
 	SignalClass<ScriptNode::ScriptEvaluatedSignal, DefaultSignalCaller<ScriptNode::ScriptEvaluatedSignal>, ScriptEvaluatedSlotCaller>( "ScriptEvaluatedSignal" );
-
-	Serialisation::registerSerialiser( ScriptNode::staticTypeId(), new ScriptNodeSerialiser );
 
 }

--- a/src/GafferBindings/ScriptNodeBinding.cpp
+++ b/src/GafferBindings/ScriptNodeBinding.cpp
@@ -391,22 +391,22 @@ void deleteNodes( ScriptNode &s, Node *parent, const Set *filter, bool reconnect
 class ScriptNodeSerialiser : public NodeSerialiser
 {
 
-	virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child ) const
+	virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
 	{
 		if( child->isInstanceOf( Node::staticTypeId() ) )
 		{
 			return true;
 		}
-		return NodeSerialiser::childNeedsSerialisation( child );
+		return NodeSerialiser::childNeedsSerialisation( child, serialisation );
 	}
 
-	virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child ) const
+	virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
 	{
 		if( child->isInstanceOf( Node::staticTypeId() ) )
 		{
 			return true;
 		}
-		return NodeSerialiser::childNeedsConstruction( child );
+		return NodeSerialiser::childNeedsConstruction( child, serialisation );
 	}
 
 };

--- a/src/GafferBindings/ValuePlugBinding.cpp
+++ b/src/GafferBindings/ValuePlugBinding.cpp
@@ -150,9 +150,9 @@ std::string ValuePlugSerialiser::repr( const Gaffer::ValuePlug *plug, unsigned f
 
 }
 
-void ValuePlugSerialiser::moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules ) const
+void ValuePlugSerialiser::moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const
 {
-	PlugSerialiser::moduleDependencies( graphComponent, modules );
+	PlugSerialiser::moduleDependencies( graphComponent, modules, serialisation );
 
 	const ValuePlug *valuePlug = static_cast<const ValuePlug *> ( graphComponent );
 	object pythonPlug( ValuePlugPtr( const_cast<ValuePlug *>( valuePlug ) ) );

--- a/src/GafferBindings/ValuePlugBinding.cpp
+++ b/src/GafferBindings/ValuePlugBinding.cpp
@@ -193,11 +193,11 @@ std::string ValuePlugSerialiser::postConstructor( const Gaffer::GraphComponent *
 		// in the `.grf` file.
 		int milestoneVersion = 0;
 		int majorVersion = 0;
-		if( IECore::ConstIntDataPtr v = Metadata::nodeValue<IECore::IntData>( reference, "serialiser:milestoneVersion" ) )
+		if( IECore::ConstIntDataPtr v = Metadata::value<IECore::IntData>( reference, "serialiser:milestoneVersion" ) )
 		{
 			milestoneVersion = v->readable();
 		}
-		if( IECore::ConstIntDataPtr v = Metadata::nodeValue<IECore::IntData>( reference, "serialiser:majorVersion" ) )
+		if( IECore::ConstIntDataPtr v = Metadata::value<IECore::IntData>( reference, "serialiser:majorVersion" ) )
 		{
 			majorVersion = v->readable();
 		}

--- a/src/GafferImageBindings/AtomicFormatPlugBinding.cpp
+++ b/src/GafferImageBindings/AtomicFormatPlugBinding.cpp
@@ -60,9 +60,9 @@ class AtomicFormatPlugSerialiser : public GafferBindings::ValuePlugSerialiser
 
 	public :
 
-		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules ) const
+		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const
 		{
-			ValuePlugSerialiser::moduleDependencies( graphComponent, modules );
+			ValuePlugSerialiser::moduleDependencies( graphComponent, modules, serialisation );
 			modules.insert( "IECore" );
 		}
 

--- a/src/GafferImageBindings/FormatPlugBinding.cpp
+++ b/src/GafferImageBindings/FormatPlugBinding.cpp
@@ -75,10 +75,10 @@ class FormatPlugSerialiser : public GafferBindings::ValuePlugSerialiser
 
 	public :
 
-		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules ) const
+		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const
 		{
 			// IECore is needed when reloading Format values which reference Box2i.
-			ValuePlugSerialiser::moduleDependencies( graphComponent, modules );
+			ValuePlugSerialiser::moduleDependencies( graphComponent, modules, serialisation );
 			modules.insert( "IECore" );
 		}
 

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -91,6 +91,7 @@
 #include "GafferBindings/FileSequencePathFilterBinding.h"
 #include "GafferBindings/AnimationBinding.h"
 #include "GafferBindings/MonitorBinding.h"
+#include "GafferBindings/MetadataAlgoBinding.h"
 
 using namespace boost::python;
 using namespace Gaffer;
@@ -185,6 +186,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindFileSequencePathFilter();
 	bindAnimation();
 	bindMonitor();
+	bindMetadataAlgo();
 
 	NodeClass<Backdrop>();
 

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -307,7 +307,7 @@ void Shader::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedStr
 
 	if( key == g_nodeColorMetadataName && this->isInstanceOf( nodeTypeId ) )
 	{
-		IECore::ConstColor3fDataPtr d = Metadata::nodeValue<const IECore::Color3fData>( this, g_nodeColorMetadataName );
+		IECore::ConstColor3fDataPtr d = Metadata::value<const IECore::Color3fData>( this, g_nodeColorMetadataName );
 		nodeColorPlug()->setValue( d ? d->readable() : Color3f( 0.0f ) );
 	}
 }

--- a/src/GafferSceneBindings/LightTweaksBinding.cpp
+++ b/src/GafferSceneBindings/LightTweaksBinding.cpp
@@ -93,7 +93,7 @@ class TweakPlugSerialiser : public PlugSerialiser
 			return maskedTweakPlugRepr( static_cast<const LightTweaks::TweakPlug *>( graphComponent ), Plug::All & ~Plug::ReadOnly );
 		}
 
-		virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child ) const
+		virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
 		{
 			// If the parent is dynamic then all the children will need construction.
 			const Plug *parent = child->parent<Plug>();

--- a/src/GafferTest/MetadataTest.cpp
+++ b/src/GafferTest/MetadataTest.cpp
@@ -59,14 +59,14 @@ struct TestThreading
 			NodePtr n = new Node();
 			PlugPtr p = new Plug();
 
-			GAFFERTEST_ASSERT( Metadata::nodeValue<Data>( n.get(), "threadingTest" ) == NULL );
-			GAFFERTEST_ASSERT( Metadata::plugValue<Data>( p.get(), "threadingTest" ) == NULL );
+			GAFFERTEST_ASSERT( Metadata::value<Data>( n.get(), "threadingTest" ) == NULL );
+			GAFFERTEST_ASSERT( Metadata::value<Data>( p.get(), "threadingTest" ) == NULL );
 
-			Metadata::registerNodeValue( n.get(), "threadingTest", new IECore::IntData( 1 ) );
-			Metadata::registerPlugValue( p.get(), "threadingTest", new IECore::IntData( 2 ) );
+			Metadata::registerValue( n.get(), "threadingTest", new IECore::IntData( 1 ) );
+			Metadata::registerValue( p.get(), "threadingTest", new IECore::IntData( 2 ) );
 
-			GAFFERTEST_ASSERT( Metadata::nodeValue<IntData>( n.get(), "threadingTest" )->readable() == 1 );
-			GAFFERTEST_ASSERT( Metadata::plugValue<IntData>( p.get(), "threadingTest" )->readable() == 2 );
+			GAFFERTEST_ASSERT( Metadata::value<IntData>( n.get(), "threadingTest" )->readable() == 1 );
+			GAFFERTEST_ASSERT( Metadata::value<IntData>( p.get(), "threadingTest" )->readable() == 2 );
 		}
 	}
 

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -43,6 +43,7 @@
 #include "IECoreGL/Selector.h"
 
 #include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/StringPlug.h"
 
 #include "GafferUI/BackdropNodeGadget.h"
@@ -302,6 +303,11 @@ void BackdropNodeGadget::plugDirtied( const Gaffer::Plug *plug )
 
 bool BackdropNodeGadget::mouseMove( Gadget *gadget, const ButtonEvent &event )
 {
+	if( readOnly( node() ) )
+	{
+		return false;
+	}
+
 	int h, v;
 	hoveredEdges( event, h, v );
 	if( h && v )
@@ -333,6 +339,11 @@ bool BackdropNodeGadget::mouseMove( Gadget *gadget, const ButtonEvent &event )
 
 bool BackdropNodeGadget::buttonPress( Gadget *gadget, const ButtonEvent &event )
 {
+	if( readOnly( node() ) )
+	{
+		return false;
+	}
+
 	if( event.buttons != ButtonEvent::Left )
 	{
 		return false;

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -468,7 +468,7 @@ void BackdropNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore:
 bool BackdropNodeGadget::updateUserColor()
 {
 	boost::optional<Color3f> c;
-	if( IECore::ConstColor3fDataPtr d = Metadata::nodeValue<IECore::Color3fData>( node(), g_colorKey ) )
+	if( IECore::ConstColor3fDataPtr d = Metadata::value<IECore::Color3fData>( node(), g_colorKey ) )
 	{
 		c = d->readable();
 	}

--- a/src/GafferUI/CompoundNodule.cpp
+++ b/src/GafferUI/CompoundNodule.cpp
@@ -64,7 +64,7 @@ CompoundNodule::CompoundNodule( Gaffer::PlugPtr plug, LinearContainer::Orientati
 	float spacing, LinearContainer::Direction direction )
 	:	Nodule( plug )
 {
-	if( ConstStringDataPtr orientationData = Metadata::plugValue<StringData>( plug.get(), g_orientationKey ) )
+	if( ConstStringDataPtr orientationData = Metadata::value<StringData>( plug.get(), g_orientationKey ) )
 	{
 		if( orientationData->readable() == "x" )
 		{
@@ -80,12 +80,12 @@ CompoundNodule::CompoundNodule( Gaffer::PlugPtr plug, LinearContainer::Orientati
 		}
 	}
 
-	if( ConstFloatDataPtr spacingData = Metadata::plugValue<FloatData>( plug.get(), g_spacingKey ) )
+	if( ConstFloatDataPtr spacingData = Metadata::value<FloatData>( plug.get(), g_spacingKey ) )
 	{
 		spacing = spacingData->readable();
 	}
 
-	if( ConstStringDataPtr directionData = Metadata::plugValue<StringData>( plug.get(), g_directionKey ) )
+	if( ConstStringDataPtr directionData = Metadata::value<StringData>( plug.get(), g_directionKey ) )
 	{
 		direction = directionData->readable() == "increasing" ? LinearContainer::Increasing : LinearContainer::Decreasing;
 	}

--- a/src/GafferUI/DotNodeGadget.cpp
+++ b/src/GafferUI/DotNodeGadget.cpp
@@ -43,6 +43,7 @@
 #include "Gaffer/UndoContext.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
+#include "Gaffer/MetadataAlgo.h"
 
 #include "GafferUI/DotNodeGadget.h"
 #include "GafferUI/Style.h"
@@ -208,6 +209,11 @@ void DotNodeGadget::updateLabel()
 
 bool DotNodeGadget::dragEnter( const DragDropEvent &event )
 {
+	if( readOnly( dotNode() ) )
+	{
+		return false;
+	}
+
 	if( dotNode()->inPlug<Plug>() )
 	{
 		// We've already got our plugs set up - StandardNodeGadget

--- a/src/GafferUI/NodeGadget.cpp
+++ b/src/GafferUI/NodeGadget.cpp
@@ -152,7 +152,7 @@ std::string NodeGadget::getToolTip( const IECore::LineSegment3f &line ) const
 		result += "\n\n" + description;
 	}
 
-	if( ConstStringDataPtr summary = Gaffer::Metadata::nodeValue<StringData>( m_node, "summary" ) )
+	if( ConstStringDataPtr summary = Gaffer::Metadata::value<StringData>( m_node, "summary" ) )
 	{
 		result += "\n\n" + summary->readable();
 	}

--- a/src/GafferUI/Nodule.cpp
+++ b/src/GafferUI/Nodule.cpp
@@ -92,7 +92,7 @@ Nodule::NamedCreatorMap &Nodule::namedCreators()
 
 NodulePtr Nodule::create( Gaffer::PlugPtr plug )
 {
-	IECore::ConstStringDataPtr noduleType = Gaffer::Metadata::plugValue<IECore::StringData>( plug.get(), "nodule:type" );
+	IECore::ConstStringDataPtr noduleType = Gaffer::Metadata::value<IECore::StringData>( plug.get(), "nodule:type" );
 	if( noduleType )
 	{
 		if( noduleType->readable() == "" )

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -433,7 +433,7 @@ void StandardConnectionGadget::plugMetadataChanged( IECore::TypeId nodeTypeId, c
 bool StandardConnectionGadget::updateUserColor()
 {
 	boost::optional<Color3f> c;
-	if( IECore::ConstColor3fDataPtr d = Metadata::plugValue<IECore::Color3fData>( dstNodule()->plug(), g_colorKey ) )
+	if( IECore::ConstColor3fDataPtr d = Metadata::value<IECore::Color3fData>( dstNodule()->plug(), g_colorKey ) )
 	{
 		c = d->readable();
 	}

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -417,18 +417,7 @@ bool StandardConnectionGadget::nodeSelected( const Nodule *nodule ) const
 
 void StandardConnectionGadget::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
 {
-	const Plug *dstPlug = dstNodule()->plug();
-	if( plug && plug != dstPlug )
-	{
-		return;
-	}
-
-	const Node *node = dstPlug->node();
-	if(
-		key != g_colorKey ||
-		!node->isInstanceOf( nodeTypeId ) ||
-		!match( dstPlug->relativeName( node ), plugPath )
-	)
+	if( key != g_colorKey || !affectedByChange( dstNodule()->plug(), nodeTypeId, plugPath, plug ) )
 	{
 		return;
 	}

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -45,6 +45,7 @@
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StandardSet.h"
 #include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/Dot.h"
 
 #include "GafferUI/StandardConnectionGadget.h"
@@ -264,6 +265,14 @@ bool StandardConnectionGadget::buttonPress( const ButtonEvent &event )
 
 IECore::RunTimeTypedPtr StandardConnectionGadget::dragBegin( const DragDropEvent &event )
 {
+	if(
+		readOnly( dstNodule()->plug() ) ||
+		( srcNodule() && readOnly( srcNodule()->plug() ) )
+	)
+	{
+		return NULL;
+	}
+
 	setPositionsFromNodules();
 	m_dragEnd = endAt( event.line );
 	switch( m_dragEnd )

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -215,17 +215,17 @@ StandardNodeGadget::StandardNodeGadget( Gaffer::NodePtr node )
 	float verticalNoduleSpacing = 0.2f;
 	float minWidth = 10.0f;
 
-	if( IECore::ConstFloatDataPtr d = Metadata::nodeValue<IECore::FloatData>( node.get(), g_horizontalNoduleSpacingKey ) )
+	if( IECore::ConstFloatDataPtr d = Metadata::value<IECore::FloatData>( node.get(), g_horizontalNoduleSpacingKey ) )
 	{
 		horizontalNoduleSpacing = d->readable();
 	}
 
-	if( IECore::ConstFloatDataPtr d = Metadata::nodeValue<IECore::FloatData>( node.get(), g_verticalNoduleSpacingKey ) )
+	if( IECore::ConstFloatDataPtr d = Metadata::value<IECore::FloatData>( node.get(), g_verticalNoduleSpacingKey ) )
 	{
 		verticalNoduleSpacing = d->readable();
 	}
 
-	if( IECore::ConstFloatDataPtr d = Metadata::nodeValue<IECore::FloatData>( node.get(), g_minWidthKey ) )
+	if( IECore::ConstFloatDataPtr d = Metadata::value<IECore::FloatData>( node.get(), g_minWidthKey ) )
 	{
 		minWidth = d->readable();
 	}
@@ -432,7 +432,7 @@ StandardNodeGadget::Edge StandardNodeGadget::plugEdge( const Gaffer::Plug *plug 
 {
 	Edge edge = plug->direction() == Gaffer::Plug::In ? TopEdge : BottomEdge;
 
-	if( IECore::ConstStringDataPtr d = Metadata::plugValue<IECore::StringData>( plug, g_nodulePositionKey ) )
+	if( IECore::ConstStringDataPtr d = Metadata::value<IECore::StringData>( plug, g_nodulePositionKey ) )
 	{
 		if( d->readable() == "left" )
 		{
@@ -745,7 +745,7 @@ void StandardNodeGadget::updateNodules( std::vector<Nodule *> &nodules, std::vec
 			continue;
 		}
 
-		IECore::ConstStringDataPtr typeData = Metadata::plugValue<IECore::StringData>( plug, g_noduleTypeKey );
+		IECore::ConstStringDataPtr typeData = Metadata::value<IECore::StringData>( plug, g_noduleTypeKey );
 		IECore::InternedString type = typeData ? typeData->readable() : "GafferUI::StandardNodule";
 
 		Nodule *nodule = NULL;
@@ -772,7 +772,7 @@ void StandardNodeGadget::updateNodules( std::vector<Nodule *> &nodules, std::vec
 		if( nodule )
 		{
 			int index = sortedNodules.size();
-			if( IECore::ConstIntDataPtr indexData = Metadata::plugValue<IECore::IntData>( plug, g_noduleIndexKey ) )
+			if( IECore::ConstIntDataPtr indexData = Metadata::value<IECore::IntData>( plug, g_noduleIndexKey ) )
 			{
 				index = indexData->readable();
 			}
@@ -856,7 +856,7 @@ void StandardNodeGadget::updateNoduleLayout()
 bool StandardNodeGadget::updateUserColor()
 {
 	boost::optional<Color3f> c;
-	if( IECore::ConstColor3fDataPtr d = Metadata::nodeValue<IECore::Color3fData>( node(), g_colorKey ) )
+	if( IECore::ConstColor3fDataPtr d = Metadata::value<IECore::Color3fData>( node(), g_colorKey ) )
 	{
 		c = d->readable();
 	}
@@ -873,7 +873,7 @@ bool StandardNodeGadget::updateUserColor()
 void StandardNodeGadget::updatePadding()
 {
 	float padding = 1.0f;
-	if( IECore::ConstFloatDataPtr d = Metadata::nodeValue<IECore::FloatData>( node(), g_paddingKey ) )
+	if( IECore::ConstFloatDataPtr d = Metadata::value<IECore::FloatData>( node(), g_paddingKey ) )
 	{
 		padding = d->readable();
 	}

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -46,6 +46,7 @@
 #include "Gaffer/StandardSet.h"
 #include "Gaffer/DependencyNode.h"
 #include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/ScriptNode.h"
 
 #include "GafferUI/StandardNodeGadget.h"
@@ -693,10 +694,15 @@ bool StandardNodeGadget::noduleIsCompatible( const Nodule *nodule, const DragDro
 	const Plug *dropPlug = IECore::runTimeCast<Gaffer::Plug>( event.data.get() );
 	if( !dropPlug || dropPlug->node() == node() )
 	{
-		return 0;
+		return false;
 	}
 
 	const Plug *nodulePlug = nodule->plug();
+	if( readOnly( nodulePlug ) )
+	{
+		return false;
+	}
+
 	if( dropPlug->direction() == Plug::Out )
 	{
 		return nodulePlug->direction() == Plug::In && nodulePlug->acceptsInput( dropPlug );

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -46,6 +46,7 @@
 #include "Gaffer/UndoContext.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
 
 #include "GafferUI/StandardNodule.h"
 #include "GafferUI/Style.h"
@@ -230,6 +231,11 @@ IECore::RunTimeTypedPtr StandardNodule::dragBegin( GadgetPtr gadget, const Butto
 
 bool StandardNodule::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
 {
+	if( readOnly( plug() ) )
+	{
+		return false;
+	}
+
 	if( event.buttons != DragDropEvent::Left )
 	{
 		// we only accept drags with the left button, so as to

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -428,17 +428,7 @@ void StandardNodule::setCompatibleLabelsVisible( const DragDropEvent &event, boo
 
 void StandardNodule::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
 {
-	if( plug && plug != this->plug() )
-	{
-		return;
-	}
-
-	const Node *node = this->plug()->node();
-	if(
-		key != g_colorKey ||
-		!node->isInstanceOf( nodeTypeId ) ||
-		!match( this->plug()->relativeName( node ), plugPath )
-	)
+	if( key != g_colorKey || !affectedByChange( this->plug(), nodeTypeId, plugPath, plug ) )
 	{
 		return;
 	}

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -446,7 +446,7 @@ void StandardNodule::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffe
 bool StandardNodule::updateUserColor()
 {
 	boost::optional<Color3f> c;
-	if( IECore::ConstColor3fDataPtr d = Metadata::plugValue<IECore::Color3fData>( plug(), g_colorKey ) )
+	if( IECore::ConstColor3fDataPtr d = Metadata::value<IECore::Color3fData>( plug(), g_colorKey ) )
 	{
 		c = d->readable();
 	}

--- a/startup/gui/nodeGraph.py
+++ b/startup/gui/nodeGraph.py
@@ -42,6 +42,7 @@ import GafferUI
 import GafferScene
 import GafferSceneUI
 import GafferDispatch
+import GafferDispatchUI
 
 ##########################################################################
 # Colour
@@ -103,7 +104,7 @@ def __nodeContextMenu( nodeGraph, node, menuDefinition ) :
 
 	GafferUI.NodeGraph.appendEnabledPlugMenuDefinitions( nodeGraph, node, menuDefinition )
 	GafferUI.NodeGraph.appendConnectionVisibilityMenuDefinitions( nodeGraph, node, menuDefinition )
-	GafferUI.DispatcherUI.appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition )
+	GafferDispatchUI.DispatcherUI.appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition )
 	GafferUI.BoxUI.appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition )
 	GafferUI.UIEditor.appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition )
 	GafferSceneUI.FilteredSceneProcessorUI.appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition )


### PR DESCRIPTION
Duplicate of #1880, hopefully Travis will pick it up...

This makes the UI read-only whenever viewing the internals of a Reference node. Because modifying the internals doesn't make sense, we previously didn't expose them except via a "secret" shortcut for power users. That shortcut quickly became known by nearly everyone, to the point where some folks didn't even know it was different from the regular one, so fixing all this became quite important.

I've also taken the opportunity to do some overdue refactoring of the Metadata API, and used that to simplify some of the UI code. And the Serialiser API is also slightly modified to allow us to implement cut+paste of Reference internals to extract them into an editable part of the node graph.

This is a pretty big PR, so if it would help to break it into a few smaller ones just let me know.
