### PR TITLE
Travis OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: cpp
 
 os:
     - linux
+    - osx
 
 addons:
   apt:
@@ -19,14 +20,15 @@ addons:
 
 before_install:
     - export DISPLAY=:99.0
-    - sh -e /etc/init.d/xvfb start
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
 
 install:
+    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install scons; fi
+    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install doxygen; fi
+    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew tap homebrew/gui && brew install inkscape; fi
     - python ./config/travis/installDependencies.py
-    - export DELIGHT_PACKAGE=3delight-12.0.113-Linux-x86_64
-    - curl -A Mozilla/4.0 http://www.3delight.com/downloads/free/$DELIGHT_PACKAGE.tar.xz > $DELIGHT_PACKAGE.tar.xz
-    - tar -xf $DELIGHT_PACKAGE.tar.xz
-    - export DELIGHT=`pwd`/$DELIGHT_PACKAGE/3delight/Linux-x86_64
+    - ./config/travis/installDelight.sh
+    - export DELIGHT=`pwd`/3delight
     - export LD_LIBRARY_PATH=$DELIGHT/lib:$LD_LIBRARY_PATH
     - export DL_SHADERS_PATH=$DELIGHT/shaders
     - export DL_DISPLAYS_PATH=$DELIGHT/displays
@@ -56,22 +58,32 @@ script:
     - source ./config/travis/runGafferTest GafferAppleseedUITest
     - ./config/travis/printTestResults
 
-compiler:
-    - gcc
-    - clang
-
+# Default values for environment variables we use to
+# control the build.
 env:
     - COMPILER_VERSION= CXXSTD=c++98 DEBUG=0
-    - COMPILER_VERSION= CXXSTD=c++98 DEBUG=1
-    - COMPILER_VERSION=4.8 CXXSTD=c++98 DEBUG=0
-    - COMPILER_VERSION=4.8 CXXSTD=c++11 DEBUG=0
-    - COMPILER_VERSION=5 CXXSTD=c++11 DEBUG=0
 
 matrix:
-    exclude:
-        - compiler: clang
+    # Explicit list of all permutations of environment
+    # and compiler we want to test. These are on top
+    # of the defaults provided by the compiler and
+    # env setup above.
+    include:
+        - os: linux
+          compiler: gcc
+          env: COMPILER_VERSION= CXXSTD=c++98 DEBUG=1
+        - os: linux
+          compiler: gcc
           env: COMPILER_VERSION=4.8 CXXSTD=c++98 DEBUG=0
-        - compiler: clang
+        - os: linux
+          compiler: gcc
           env: COMPILER_VERSION=4.8 CXXSTD=c++11 DEBUG=0
-        - compiler: clang
+        - os: linux
+          compiler: gcc
           env: COMPILER_VERSION=5 CXXSTD=c++11 DEBUG=0
+        - os: linux
+          compiler: clang
+          env: COMPILER_VERSION= CXXSTD=c++98 DEBUG=0
+        - os: linux
+          compiler: clang
+          env: COMPILER_VERSION= CXXSTD=c++98 DEBUG=1

--- a/SConstruct
+++ b/SConstruct
@@ -41,6 +41,7 @@ import sys
 import glob
 import shutil
 import fnmatch
+import platform
 import py_compile
 import subprocess
 
@@ -313,6 +314,11 @@ if env["PLATFORM"] == "darwin" :
 	env["ENV"]["MACOSX_DEPLOYMENT_TARGET"] = "10.4"
 	env.Append( CXXFLAGS = [ "-D__USE_ISOC99" ] )
 	env["GAFFER_PLATFORM"] = "osx"
+
+	osxVersion = [ int( v ) for v in platform.mac_ver()[0].split( "." ) ]
+	if osxVersion[0] == 10 and osxVersion[1] > 7 :
+		# Fix problems with Boost 1.55 and recent versions of Clang.
+		env.Append( CXXFLAGS = [ "-DBOOST_HAS_INT128", "-Wno-unused-local-typedef" ] )
 
 elif env["PLATFORM"] == "posix" :
 

--- a/SConstruct
+++ b/SConstruct
@@ -957,10 +957,14 @@ for libraryName, libraryDef in libraries.items() :
 
 	# osl shaders
 
+	def buildOSL( target, source, env ) :
+
+		subprocess.check_call( [ "oslc", "-I./shaders", "-o", str( target[0] ), str( source[0] ) ], env = env["ENV"] )
+
 	for oslShader in libraryDef.get( "oslShaders", [] ) :
 		oslShaderInstall = env.InstallAs( "$BUILD_DIR/" + oslShader, oslShader )
 		env.Alias( "build", oslShader )
-		compiledFile = commandEnv.Command( os.path.splitext( str( oslShaderInstall[0] ) )[0] + ".oso", oslShader, "oslc -I./shaders -o $TARGET $SOURCE" )
+		compiledFile = commandEnv.Command( os.path.splitext( str( oslShaderInstall[0] ) )[0] + ".oso", oslShader, buildOSL )
 		env.Depends( compiledFile, "oslHeaders" )
 		env.Alias( "build", compiledFile )
 

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -80,7 +80,7 @@ popd &> /dev/null
 # $2 is the name of the path to edit
 #
 # e.g. includeInPath ~/bin PATH
-function includeInPath {
+function prependToPath {
 
 	if [[ ":${!2}:" != *":$1:"* ]] ; then
 
@@ -94,32 +94,50 @@ function includeInPath {
 
 }
 
-export IECOREGL_SHADER_PATHS=$GAFFER_ROOT/glsl${IECOREGL_SHADER_PATHS:+:}${IECOREGL_SHADER_PATHS:-}
-export IECOREGL_SHADER_INCLUDE_PATHS=$GAFFER_ROOT/glsl${IECOREGL_SHADER_INCLUDE_PATHS:+:}${IECOREGL_SHADER_INCLUDE_PATHS:-}
-export IECORE_FONT_PATHS=$GAFFER_ROOT/fonts${IECORE_FONT_PATHS:+:}${IECORE_FONT_PATHS:-}
-export IECORE_OP_PATHS=~/gaffer/ops:$GAFFER_ROOT/ops${IECORE_OP_PATHS:+:}${IECORE_OP_PATHS:-}
-export IECORE_OP_PRESET_PATHS=~/gaffer/opPresets:$GAFFER_ROOT/opPresets${IECORE_OP_PRESET_PATHS:+:}${IECORE_OP_PRESET_PATHS:-}
-export IECORE_PROCEDURAL_PATHS=~/gaffer/procedurals:$GAFFER_ROOT/procedurals${IECORE_PROCEDURAL_PATHS:+:}${IECORE_PROCEDURAL_PATHS:-}
-export IECORE_PROCEDURAL_PRESET_PATHS=~/gaffer/proceduralPresets:$GAFFER_ROOT/proceduralPresets${IECORE_PROCEDURAL_PRESET_PATHS:+:}${IECORE_PROCEDURAL_PRESET_PATHS:-}
+function appendToPath {
+
+	if [[ ":${!2}:" != *":$1:"* ]] ; then
+
+		if [[ ${!2} ]] ; then
+			eval "export $2=${!2}:$1"
+		else
+			eval "export $2=$1"
+		fi
+
+	fi
+
+}
+
+prependToPath $GAFFER_ROOT/glsl IECOREGL_SHADER_PATHS
+prependToPath $GAFFER_ROOT/glsl IECOREGL_SHADER_INCLUDE_PATHS
+
+prependToPath $GAFFER_ROOT/fonts IECORE_FONT_PATHS
+prependToPath ~/gaffer/ops:$GAFFER_ROOT/ops IECORE_OP_PATHS
+
+prependToPath ~/gaffer/opPresets:$GAFFER_ROOT/opPresets IECORE_OP_PRESET_PATHS
+prependToPath ~/gaffer/procedurals:$GAFFER_ROOT/procedurals IECORE_PROCEDURAL_PATHS
+prependToPath ~/gaffer/proceduralPresets:$GAFFER_ROOT/proceduralPresets IECORE_PROCEDURAL_PRESET_PATHS
 
 if [[ -z $CORTEX_POINTDISTRIBUTION_TILESET ]] ; then
 	export CORTEX_POINTDISTRIBUTION_TILESET=$GAFFER_ROOT/resources/cortex/tileset_2048.dat
 fi
 
-export GAFFER_APP_PATHS=~/gaffer/apps:$GAFFER_ROOT/apps${GAFFER_APP_PATHS:+:}${GAFFER_APP_PATHS:-}
-export GAFFER_STARTUP_PATHS=~/gaffer/startup:${GAFFER_STARTUP_PATHS:-}${GAFFER_STARTUP_PATHS:+:}$GAFFER_ROOT/startup
+prependToPath ~/gaffer/apps:$GAFFER_ROOT/apps GAFFER_APP_PATHS
 
-export GAFFERUI_IMAGE_PATHS=$GAFFER_ROOT/graphics${GAFFERUI_IMAGE_PATHS:+:}${GAFFERUI_IMAGE_PATHS:-}
+prependToPath ~/gaffer/startup GAFFER_STARTUP_PATHS
+appendToPath $GAFFER_ROOT/startup GAFFER_STARTUP_PATHS
+
+prependToPath $GAFFER_ROOT/graphics GAFFERUI_IMAGE_PATHS
 
 if [[ -e $GAFFER_ROOT/bin/oslc ]] ; then
 	export OSLHOME=$GAFFER_ROOT
 fi
 
-export OSL_SHADER_PATHS=$HOME/gaffer/shaders:$GAFFER_ROOT/shaders${OSL_SHADER_PATHS:+:}${OSL_SHADER_PATHS:-}
+prependToPath $HOME/gaffer/shaders:$GAFFER_ROOT/shaders OSL_SHADER_PATHS
 
 if [[ -z $GAFFEROSL_CODE_DIRECTORY ]] ; then
 	export GAFFEROSL_CODE_DIRECTORY=$HOME/gaffer/oslCode
-	export OSL_SHADER_PATHS=$OSL_SHADER_PATHS:$GAFFEROSL_CODE_DIRECTORY
+	appendToPath $GAFFEROSL_CODE_DIRECTORY OSL_SHADER_PATHS
 fi
 
 # Get python set up properly
@@ -148,57 +166,54 @@ export PYTHONPATH=$GAFFER_ROOT/python${PYTHONPATH:+:}${PYTHONPATH:-}
 ##########################################################################
 
 if [[ `uname` = "Linux" ]] ; then
-	export LD_LIBRARY_PATH=$GAFFER_ROOT/lib/${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH:-}
+	prependToPath $GAFFER_ROOT/lib LD_LIBRARY_PATH
 else
-	export DYLD_FRAMEWORK_PATH=$GAFFER_ROOT/lib${DYLD_FRAMEWORK_PATH:+:}${DYLD_FRAMEWORK_PATH:-}
-	export DYLD_LIBRARY_PATH=$GAFFER_ROOT/lib/${DYLD_LIBRARY_PATH:+:}${DYLD_LIBRARY_PATH:-}
-	export DYLD_LIBRARY_PATH=/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ImageIO.framework/Resources/:$DYLD_LIBRARY_PATH
+	prependToPath $GAFFER_ROOT/lib DYLD_FRAMEWORK_PATH
+	prependToPath $GAFFER_ROOT/lib DYLD_LIBRARY_PATH
+	prependToPath /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ImageIO.framework/Resources/ DYLD_LIBRARY_PATH
 	if [[ -n $DELIGHT ]] ; then
-		export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$DELIGHT/lib
+		appendToPath $DELIGHT/lib DYLD_LIBRARY_PATH
 	fi
 fi
 
 # Get the executable path set up, for running child processes from Gaffer
 ##########################################################################
 
-export PATH=$GAFFER_ROOT/bin:$PATH
+prependToPath $GAFFER_ROOT/bin PATH
 
-# If appleseed isn't configured in the environment, and we've been
-# shipped with it, then get that set up.
+# Set up Appleseed
 ##########################################################################
 
 if [[ -z $APPLESEED && -d $GAFFER_ROOT/appleseed ]] ; then
 
 	export APPLESEED=$GAFFER_ROOT/appleseed
 
-	if [[ `uname` = "Linux" ]] ; then
-		export LD_LIBRARY_PATH=$APPLESEED/lib:$LD_LIBRARY_PATH
-	else
-		export DYLD_LIBRARY_PATH=$APPLESEED/lib:$DYLD_LIBRARY_PATH
-	fi
-
-	# Using a glob to keep the wrapper agnostic of python version.
-	for appleseedPython in $APPLESEED/lib/python* ; do
-		export PYTHONPATH=$appleseedPython:$PYTHONPATH
-	done
-
-	export OSL_SHADER_PATHS=$APPLESEED/shaders:$OSL_SHADER_PATHS
-	export APPLESEED_SEARCHPATH=$OSL_SHADER_PATHS:$GAFFER_ROOT/appleseedDisplays
-
-	export PATH=$APPLESEED/bin:$PATH
-
 fi
 
 if [[ $APPLESEED ]] ; then
 
-	includeInPath $APPLESEED/lib DYLD_LIBRARY_PATH
+	if [[ `uname` = "Linux" ]] ; then
+		prependToPath $APPLESEED/lib LD_LIBRARY_PATH
+	else
+		prependToPath $APPLESEED/lib DYLD_LIBRARY_PATH
+	fi
+
+	# Using a glob to keep the wrapper agnostic of python version.
+	for appleseedPython in $APPLESEED/lib/python* ; do
+		prependToPath $appleseedPython PYTHONPATH
+	done
+
+	prependToPath $APPLESEED/shaders OSL_SHADER_PATHS
+	prependToPath $GAFFER_ROOT/appleseedDisplays APPLESEED_SEARCHPATH
+
+	prependToPath $APPLESEED/bin PATH
 
 fi
 
 # Set up Arnold
 ##########################################################################
 
-export ARNOLD_PLUGIN_PATH=$GAFFER_ROOT/arnold/plugins${ARNOLD_PLUGIN_PATH:+:}${ARNOLD_PLUGIN_PATH:-}
+prependToPath $GAFFER_ROOT/arnold/plugins ARNOLD_PLUGIN_PATH
 
 # Run gaffer itself
 ##########################################################################

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -73,6 +73,27 @@ popd &> /dev/null
 # Make sure resource paths are set appropriately
 ##########################################################################
 
+# Prepend a directory to a path if it is not
+# already there.
+#
+# $1 is the value to include in the path
+# $2 is the name of the path to edit
+#
+# e.g. includeInPath ~/bin PATH
+function includeInPath {
+
+	if [[ ":${!2}:" != *":$1:"* ]] ; then
+
+		if [[ ${!2} ]] ; then
+			eval "export $2=$1:${!2}"
+		else
+			eval "export $2=$1"
+		fi
+
+	fi
+
+}
+
 export IECOREGL_SHADER_PATHS=$GAFFER_ROOT/glsl${IECOREGL_SHADER_PATHS:+:}${IECOREGL_SHADER_PATHS:-}
 export IECOREGL_SHADER_INCLUDE_PATHS=$GAFFER_ROOT/glsl${IECOREGL_SHADER_INCLUDE_PATHS:+:}${IECOREGL_SHADER_INCLUDE_PATHS:-}
 export IECORE_FONT_PATHS=$GAFFER_ROOT/fonts${IECORE_FONT_PATHS:+:}${IECORE_FONT_PATHS:-}
@@ -165,6 +186,12 @@ if [[ -z $APPLESEED && -d $GAFFER_ROOT/appleseed ]] ; then
 	export APPLESEED_SEARCHPATH=$OSL_SHADER_PATHS:$GAFFER_ROOT/appleseedDisplays
 
 	export PATH=$APPLESEED/bin:$PATH
+
+fi
+
+if [[ $APPLESEED ]] ; then
+
+	includeInPath $APPLESEED/lib DYLD_LIBRARY_PATH
 
 fi
 

--- a/config/travis/installDelight.sh
+++ b/config/travis/installDelight.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+set -e
+
+version=12.0.113
+
+if [[ `uname` = "Linux" ]] ; then
+	package=3delight-$version-Linux-x86_64
+	curl -A Mozilla/4.0 http://www.3delight.com/downloads/free/$package.tar.xz > $package.tar.xz
+	tar -xf $package.tar.xz
+	mv ./$package/3delight/Linux-x86_64 ./3delight
+else
+	package=3delight-$version-Darwin-Universal
+	curl -A Mozilla/4.0 http://www.3delight.com/downloads/free/$package.dmg > $package.dmg
+	sudo hdiutil mount $package.dmg
+	sudo installer -pkg /Volumes/3Delight\ $version/$package.pkg -target /
+	sudo mv /Applications/3Delight ./3delight
+fi

--- a/config/travis/installDependencies.py
+++ b/config/travis/installDependencies.py
@@ -15,7 +15,7 @@ buildDir = "build/gaffer-%d.%d.%d.%d-%s" % ( gafferMilestoneVersion, gafferMajor
 
 # get the prebuilt dependencies package and unpack it into the build directory
 
-downloadURL = "https://github.com/johnhaddon/gafferDependencies/releases/download/0.29.0.0/gafferDependencies-0.29.0.0-linux.tar.gz"
+downloadURL = "https://github.com/johnhaddon/gafferDependencies/releases/download/0.29.0.0/gafferDependencies-0.29.0.0-" + platform + ".tar.gz"
 
 sys.stderr.write( "Downloading dependencies \"%s\"" % downloadURL )
 tarFileName, headers = urllib.urlretrieve( downloadURL )

--- a/include/GafferScene/ExecutableRender.h
+++ b/include/GafferScene/ExecutableRender.h
@@ -85,10 +85,6 @@ class ExecutableRender : public GafferDispatch::TaskNode
 		/// generating just such a file. The default implementation just outputs a SceneProcedural
 		/// which is suitable for immediate mode rendering.
 		virtual void outputWorldProcedural( const ScenePlug *scene, IECore::Renderer *renderer ) const;
-		/// May be implemented to return a shell command which should be run after doing the "render".
-		/// This can be useful for nodes which wish to render in two stages by creating a scene file
-		/// with the createRenderer() and then rendering it with a command.
-		virtual std::string command() const;
 
 	private :
 

--- a/python/GafferAppleseedTest/AppleseedRenderTest.py
+++ b/python/GafferAppleseedTest/AppleseedRenderTest.py
@@ -69,13 +69,9 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 		s["fileName"].setValue( self.__scriptFileName )
 		s.save()
 
-		p = subprocess.Popen(
-			"gaffer execute " + self.__scriptFileName + " -frames 1-3",
-			shell=True,
-			stderr = subprocess.PIPE,
+		subprocess.check_call(
+			[ "gaffer", "execute", self.__scriptFileName, "-frames", "1-3" ]
 		)
-		p.wait()
-		self.failIf( p.returncode )
 
 		for i in range( 1, 4 ) :
 			self.failUnless( os.path.exists( self.temporaryDirectory() + "/test.%d.appleseed" % i ) )
@@ -123,13 +119,9 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 		s["fileName"].setValue( self.__scriptFileName )
 		s.save()
 
-		p = subprocess.Popen(
-			"gaffer execute " + self.__scriptFileName + " -frames 1-3",
-			shell=True,
-			stderr = subprocess.PIPE,
+		subprocess.check_call(
+			[ "gaffer", "execute", self.__scriptFileName, "-frames", "1-3" ]
 		)
-		p.wait()
-		self.failIf( p.returncode )
 
 		for i in range( 1, 4 ) :
 			self.failUnless( os.path.exists( self.temporaryDirectory() + "/test.%04d.appleseed" % i ) )

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -399,7 +399,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 			# the writer adds several standard attributes that aren't in the original file
 			expectedMetadata["Software"] = IECore.StringData( "Gaffer " + Gaffer.About.versionString() )
 			expectedMetadata["HostComputer"] = IECore.StringData( platform.node() )
-			expectedMetadata["Artist"] = IECore.StringData( os.getlogin() )
+			expectedMetadata["Artist"] = IECore.StringData( os.environ["USER"] )
 			expectedMetadata["DocumentName"] = IECore.StringData( "untitled" )
 
 			for key in overrideMetadata :
@@ -717,7 +717,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		# the writer adds several standard attributes that aren't in the original file
 		expectedMetadata["Software"] = IECore.StringData( "Gaffer " + Gaffer.About.versionString() )
 		expectedMetadata["HostComputer"] = IECore.StringData( platform.node() )
-		expectedMetadata["Artist"] = IECore.StringData( os.getlogin() )
+		expectedMetadata["Artist"] = IECore.StringData( os.environ["USER"] )
 		expectedMetadata["DocumentName"] = IECore.StringData( "untitled" )
 
 		self.__addExpectedIPTCMetadata( afterMetadata, expectedMetadata )

--- a/python/GafferOSLTest/OSLTestCase.py
+++ b/python/GafferOSLTest/OSLTestCase.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import subprocess32 as subprocess
 
 import GafferSceneTest
 
@@ -44,10 +45,10 @@ class OSLTestCase( GafferSceneTest.SceneTestCase ) :
 
 		outputFileName = self.temporaryDirectory() + "/" + os.path.splitext( os.path.basename( sourceFileName ) )[0] + ".oso"
 
-		includes = os.environ.get( "OSL_SHADER_PATHS", "" )
-		if includes :
-			includes = "-I" + " -I".join( includes.split( ":" ) )
-
-		os.system( "oslc -q %s -o %s %s" % ( includes, outputFileName, sourceFileName ) )
+		subprocess.check_call(
+			[ "oslc", "-q" ] +
+			[ "-I" + p for p in os.environ.get( "OSL_SHADER_PATHS", "" ).split( ":" ) ] +
+			[ "-o", outputFileName, sourceFileName ]
+		)
 
 		return os.path.splitext( outputFileName )[0]

--- a/python/GafferRenderMan/RenderManRender.py
+++ b/python/GafferRenderMan/RenderManRender.py
@@ -35,6 +35,8 @@
 ##########################################################################
 
 import os
+import shlex
+import subprocess32 as subprocess
 
 import IECore
 import IECoreRI
@@ -68,6 +70,22 @@ class RenderManRender( GafferScene.ExecutableRender ) :
 				defaultValue = "renderdl",
 			)
 		)
+
+	def execute( self ) :
+
+		GafferScene.ExecutableRender.execute( self )
+
+		if self["mode"].getValue() != "render" :
+			return
+
+		command = self["command"].getValue().strip()
+		if not command :
+			return
+
+		args = shlex.split( command )
+		args.append( self["ribFileName"].getValue() )
+
+		subprocess.check_call( args )
 
 	def _createRenderer( self ) :
 
@@ -138,19 +156,5 @@ class RenderManRender( GafferScene.ExecutableRender ) :
 			}
 		)
 		renderer.procedural( externalProcedural )
-
-	def _command( self ) :
-
-		if self["mode"].getValue() != "render" :
-			return ""
-
-		result = self["command"].getValue()
-		result = result.strip()
-		if result == "" :
-			return
-
-		result += " '" + self["ribFileName"].getValue() + "'"
-
-		return result
 
 IECore.registerRunTimeTyped( RenderManRender, typeName = "GafferRenderMan::RenderManRender" )

--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import sys
 import unittest
 import subprocess32 as subprocess
 
@@ -82,14 +83,12 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/test.rib" ) )
 
-		p = subprocess.Popen(
-			"renderdl " + self.temporaryDirectory() + "/test.rib",
-			shell = True,
-			stderr = subprocess.PIPE
+		output = subprocess.check_output(
+			[ "renderdl", self.temporaryDirectory() + "/test.rib" ],
+			stderr = subprocess.STDOUT
 		)
-		p.wait()
 
-		self.failIf( "exceeded its bounds" in "".join( p.stderr.readlines() ) )
+		self.failIf( "exceeded its bounds" in output )
 
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/test.tif" ) )
 

--- a/python/GafferTest/ApplicationTest.py
+++ b/python/GafferTest/ApplicationTest.py
@@ -34,6 +34,9 @@
 #
 ##########################################################################
 
+import os
+import subprocess32 as subprocess
+
 import Gaffer
 import GafferTest
 
@@ -48,6 +51,17 @@ class ApplicationTest( GafferTest.TestCase ) :
 				raise Exception( "Woops!")
 
 		self.assertRaises( Exception, f )
+
+	def testWrapperDoesntDuplicatePaths( self ) :
+
+		output = subprocess.check_output( [ "gaffer", "env", "env" ] )
+		externalEnv = {}
+		for line in output.split( '\n' ) :
+			partition = line.partition( "=" )
+			externalEnv[partition[0]] = partition[2]
+
+		self.assertEqual( externalEnv["GAFFER_STARTUP_PATHS"], os.environ["GAFFER_STARTUP_PATHS"] )
+		self.assertEqual( externalEnv["GAFFER_APP_PATHS"], os.environ["GAFFER_APP_PATHS"] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/PerformanceMonitorTest.py
+++ b/python/GafferTest/PerformanceMonitorTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import os
 import time
 import unittest
 
@@ -204,15 +205,17 @@ class PerformanceMonitorTest( GafferTest.TestCase ) :
 
 		self.assertEqual( len( m.allStatistics() ), 2 )
 
+		delta = 0.01 if "TRAVIS" not in os.environ else 0.12
+
 		self.assertEqual( m.plugStatistics( n1["out"] ).hashCount, 1 )
 		self.assertEqual( m.plugStatistics( n1["out"] ).computeCount, 1 )
-		self.assertAlmostEqual( seconds( m.plugStatistics( n1["out"] ).hashDuration ), 0.2, delta = 0.01 )
-		self.assertAlmostEqual( seconds( m.plugStatistics( n1["out"] ).computeDuration ), 0.4, delta = 0.01 )
+		self.assertAlmostEqual( seconds( m.plugStatistics( n1["out"] ).hashDuration ), 0.2, delta = delta )
+		self.assertAlmostEqual( seconds( m.plugStatistics( n1["out"] ).computeDuration ), 0.4, delta = delta )
 
 		self.assertEqual( m.plugStatistics( n2["out"] ).hashCount, 1 )
 		self.assertEqual( m.plugStatistics( n2["out"] ).computeCount, 1 )
-		self.assertAlmostEqual( seconds( m.plugStatistics( n2["out"] ).hashDuration ), 0.1, delta = 0.01 )
-		self.assertAlmostEqual( seconds( m.plugStatistics( n2["out"] ).computeDuration ), 0.2, delta = 0.01 )
+		self.assertAlmostEqual( seconds( m.plugStatistics( n2["out"] ).hashDuration ), 0.1, delta = delta )
+		self.assertAlmostEqual( seconds( m.plugStatistics( n2["out"] ).computeDuration ), 0.2, delta = delta )
 
 		with m :
 			with Gaffer.Context() as c :
@@ -221,13 +224,13 @@ class PerformanceMonitorTest( GafferTest.TestCase ) :
 
 		self.assertEqual( m.plugStatistics( n1["out"] ).hashCount, 2 )
 		self.assertEqual( m.plugStatistics( n1["out"] ).computeCount, 1 )
-		self.assertAlmostEqual( seconds( m.plugStatistics( n1["out"] ).hashDuration ), 0.4, delta = 0.01 )
-		self.assertAlmostEqual( seconds( m.plugStatistics( n1["out"] ).computeDuration ), 0.4, delta = 0.01 )
+		self.assertAlmostEqual( seconds( m.plugStatistics( n1["out"] ).hashDuration ), 0.4, delta = delta )
+		self.assertAlmostEqual( seconds( m.plugStatistics( n1["out"] ).computeDuration ), 0.4, delta = delta )
 
 		self.assertEqual( m.plugStatistics( n2["out"] ).hashCount, 2 )
 		self.assertEqual( m.plugStatistics( n2["out"] ).computeCount, 1 )
-		self.assertAlmostEqual( seconds( m.plugStatistics( n2["out"] ).hashDuration ), 0.2, delta = 0.01 )
-		self.assertAlmostEqual( seconds( m.plugStatistics( n2["out"] ).computeDuration ), 0.2, delta = 0.01 )
+		self.assertAlmostEqual( seconds( m.plugStatistics( n2["out"] ).hashDuration ), 0.2, delta = delta )
+		self.assertAlmostEqual( seconds( m.plugStatistics( n2["out"] ).computeDuration ), 0.2, delta = delta )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/ExecutableRender.cpp
+++ b/src/GafferScene/ExecutableRender.cpp
@@ -134,24 +134,9 @@ void ExecutableRender::execute() const
 			outputWorldProcedural( scene, renderer.get() );
 		}
 	}
-
-	std::string systemCommand = command();
-	if( systemCommand.size() )
-	{
-		int result = system( systemCommand.c_str() );
-		if( result )
-		{
-			throw Exception( "System command failed" );
-		}
-	}
 }
 
 void ExecutableRender::outputWorldProcedural( const ScenePlug *scene, IECore::Renderer *renderer ) const
 {
 	renderer->procedural( new SceneProcedural( scene, Context::current() ) );
-}
-
-std::string ExecutableRender::command() const
-{
-	return "";
 }

--- a/src/GafferSceneBindings/RenderBinding.cpp
+++ b/src/GafferSceneBindings/RenderBinding.cpp
@@ -98,20 +98,6 @@ class ExecutableRenderWrapper : public TaskNodeWrapper<ExecutableRender>
 			return ExecutableRender::outputWorldProcedural( scene, renderer );
 		}
 
-		virtual std::string command() const
-		{
-			if( this->isSubclassed() )
-			{
-				IECorePython::ScopedGILLock gilLock;
-				boost::python::object f = this->methodOverride( "_command" );
-				if( f )
-				{
-					return extract<std::string>( f() );
-				}
-			}
-			return ExecutableRender::command();
-		}
-
 };
 
 ContextPtr interactiveRenderGetContext( InteractiveRender &r )


### PR DESCRIPTION
This fixes a number of problems building on the latest OSX version, and sets up automated testing of OSX builds on Travis. Up till now, we've had occasional build breaks on OSX because of a lack of automated testing, the latest of which affected the release of version 0.29 at the last minute, so I thought it was time to get on top of things.

One of the biggest problems dealt with here is Apple's System Integrity Protection, whereby they redefine "system integrity" to ignore long standing mechanisms for setting up library paths, and then go ahead and break those mechanisms. The biggest effect of this is that any time anything is run via a shell script, you lose the DYLD_LIBRARY_PATH entirely. This includes launching subprocesses via `system()` or any python `subprocess` call where `shell == True`. If we want to work with SIP, we will need to avoid those entirely going forwards...

@HughMacdonald, if you have the time to try to build this on your machines I'd be grateful. Mine is ancient (10.7) and the Travis one is 10.11, so getting anything in between tested would be good if you have the chance.