### PR TITLE
Arnold test fixes

### DIFF
--- a/python/GafferArnoldTest/ArnoldLightTest.py
+++ b/python/GafferArnoldTest/ArnoldLightTest.py
@@ -59,7 +59,7 @@ class ArnoldLightTest( GafferSceneTest.SceneTestCase ) :
 	def testLoadAllLightsWithoutWarnings( self ) :
 
 		lightNames = []
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = False ) :
 			it = arnold.AiUniverseGetNodeEntryIterator( arnold.AI_NODE_LIGHT )
 			while not arnold.AiNodeEntryIteratorFinished( it ) :
 				nodeEntry = arnold.AiNodeEntryIteratorGetNext( it )

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -337,7 +337,7 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 		s["options"]["options"]["transformBlur"]["value"].setValue( False )
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -365,7 +365,7 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 		s["options"]["options"]["transformBlur"]["value"].setValue( True )
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -430,7 +430,7 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 			options = arnold.AiUniverseGetOptions()
@@ -443,7 +443,7 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 		s["options"]["options"]["renderCamera"]["value"].setValue( "/camera" )
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 			options = arnold.AiUniverseGetOptions()
@@ -469,7 +469,7 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 		# Default region
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 			options = arnold.AiUniverseGetOptions()
@@ -486,7 +486,7 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 			options = arnold.AiUniverseGetOptions()
@@ -502,7 +502,7 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 			options = arnold.AiUniverseGetOptions()
@@ -530,7 +530,7 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 			options = arnold.AiUniverseGetOptions()
@@ -651,7 +651,7 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 
 		render["task"].execute()
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -409,6 +409,8 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 
 	def testColorParameterMetadata( self ) :
 
+		self.__forceArnoldRestart()
+
 		n = GafferArnold.ArnoldShader()
 		n.loadShader( "ray_switch" )
 
@@ -417,6 +419,8 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 
 		self.addCleanup( os.environ.__setitem__, "ARNOLD_PLUGIN_PATH", os.environ["ARNOLD_PLUGIN_PATH"] )
 		os.environ["ARNOLD_PLUGIN_PATH"] = os.environ["ARNOLD_PLUGIN_PATH"] + ":" + os.path.join( os.path.dirname( __file__ ), "metadata" )
+
+		self.__forceArnoldRestart()
 
 		n = GafferArnold.ArnoldShader()
 		n.loadShader( "ray_switch" )
@@ -429,12 +433,16 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 
 	def testEmptyPlugTypeMetadata( self ) :
 
+		self.__forceArnoldRestart()
+
 		n = GafferArnold.ArnoldShader()
 		n.loadShader( "standard" )
 		self.assertTrue( "aov_direct_diffuse" in n["parameters"] )
 
 		self.addCleanup( os.environ.__setitem__, "ARNOLD_PLUGIN_PATH", os.environ["ARNOLD_PLUGIN_PATH"] )
 		os.environ["ARNOLD_PLUGIN_PATH"] = os.environ["ARNOLD_PLUGIN_PATH"] + ":" + os.path.join( os.path.dirname( __file__ ), "metadata" )
+
+		self.__forceArnoldRestart()
 
 		n.loadShader( "standard" )
 		self.assertTrue( "aov_direct_diffuse" not in n["parameters"] )
@@ -609,6 +617,11 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( s2["n1"]["out"].defaultValue(), IECore.Color3f( 0 ) )
 		self.assertTrue( s2["n2"]["parameters"]["color"].getInput().isSame( s2["n1"]["out"] ) )
 		self.assertTrue( s2["a"]["shader"].getInput().isSame( s2["n2"]["out"] ) )
+
+	def __forceArnoldRestart( self ) :
+
+		with IECoreArnold.UniverseBlock( writable = True ) :
+			pass
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -74,7 +74,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -105,7 +105,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 			options = arnold.AiUniverseGetOptions()
@@ -143,7 +143,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 			self.assertEqual( len( self.__allNodes( type = arnold.AI_NODE_SHADER ) ), 1 )
@@ -173,7 +173,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 			# We only want one shader to have been saved, because only one was genuinely used.
@@ -220,7 +220,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -274,7 +274,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
 			target = arnold.AtNode.from_address( arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "testPlane_scalarColor" ), "shader" ) )
@@ -317,7 +317,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -354,7 +354,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -402,7 +402,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -463,7 +463,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -517,7 +517,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 			filters = self.__allNodes( type = arnold.AI_NODE_FILTER )
@@ -591,7 +591,7 @@ class RendererTest( GafferTest.TestCase ) :
 		del defaultAttributes, adaptiveAttributes, nonAdaptiveAttributes, adaptiveObjectSpaceAttributes
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -653,7 +653,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 			node = arnold.AiNodeLookUpByName( "plane" )
@@ -702,7 +702,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -762,7 +762,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -825,7 +825,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -865,7 +865,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -917,7 +917,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -999,7 +999,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -1053,7 +1053,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -1097,7 +1097,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -1169,7 +1169,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -1330,7 +1330,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
@@ -1424,7 +1424,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.render()
 		del r
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -126,6 +126,10 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		)
 		script["outputs"]["in"].setInput( script["attributes"]["out"] )
 
+		# Emulate the connection the UI makes, so the Display knows someone is listening and
+		# it needs to actually make servers.
+		dataReceivedConnection = GafferImage.Display.dataReceivedSignal().connect( lambda plug : None )
+
 		script["display"] = GafferImage.Display()
 		script["display"]["port"].setValue( 2500 )
 

--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -319,7 +319,7 @@ def __walkHoudiniParameters( nodeEntry, parameters, sectionName ) :
 
 			__metadata[nodeName + ".parameters." + parameter.name]["layout:section"] = sectionNameWithHeading
 
-with IECoreArnold.UniverseBlock() :
+with IECoreArnold.UniverseBlock( writable = False ) :
 
 	nodeIt = arnold.AiUniverseGetNodeEntryIterator( arnold.AI_NODE_SHADER | arnold.AI_NODE_LIGHT )
 	while not arnold.AiNodeEntryIteratorFinished( nodeIt ) :

--- a/python/GafferArnoldUI/ShaderMenu.py
+++ b/python/GafferArnoldUI/ShaderMenu.py
@@ -54,7 +54,7 @@ def appendShaders( menuDefinition, prefix="/Arnold" ) :
 
 	categorisedMenuItems = []
 	uncategorisedMenuItems = []
-	with IECoreArnold.UniverseBlock() :
+	with IECoreArnold.UniverseBlock( writable = False ) :
 
 		it = arnold.AiUniverseGetNodeEntryIterator( arnold.AI_NODE_SHADER | arnold.AI_NODE_LIGHT )
 


### PR DESCRIPTION
This fixes UniverseBlock management problems in the GafferArnoldTest module, which were exposed by https://github.com/ImageEngine/cortex/pull/533. There's also a fix for another test failure caused by recent changes to Display server management.