### PR TITLE
GafferUI : Support alternate shiboken install location.

### DIFF
--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -98,7 +98,11 @@ def _qtAddress( o ) :
 		import sip
 		return sip.unwrapinstance( o )
 	else :
-		import shiboken
+		try :
+			import PySide.shiboken as shiboken
+		except ImportError :
+			import shiboken
+
 		return shiboken.getCppPointer( o )[0]
 
 ##########################################################################
@@ -114,7 +118,11 @@ def _qtObject( address, type ) :
 		import sip
 		return sip.wrapinstance( address, type )
 	else :
-		import shiboken
+		try :
+			import PySide.shiboken as shiboken
+		except ImportError :
+			import shiboken
+
 		return shiboken.wrapInstance( address, type )
 
 ##########################################################################


### PR DESCRIPTION
If PySide has been compiled with an embedded shiboken, we should use that one. Otherwise fall back to an external shiboken.

This change seems to be enough to allow us to set `GAFFERUI_QT_BINDINGS` to `PySide` for Houdini 15.0 and 15.5.

I'm still waiting to hear back from the Foundry as to what magical incantation will do the same for Nuke...