### PR TITLE
Documentation fixes

### DIFF
--- a/Changes
+++ b/Changes
@@ -2860,8 +2860,6 @@ Build
 - Enabled testing of UI modules on Travis CI.
 - Added debug output to installDependencies.py.
 
------------------------------------------------------------------------
-
 0.8.0.0
 =======
 
@@ -2960,8 +2958,6 @@ Incompatibilities
 - Removed Source node.
 - Removed FileSource node.
 - Detemplatized ObjectSource.
-
------------------------------------------------------------------------
 
 0.7.0.0
 ========
@@ -3533,8 +3529,6 @@ This release features significant improvements to Dispatcher and SceneInspector 
 - Requires Cortex-9.0.0a2
 - Updated default build to use PySide 1.2.2.
 - Stopped using python-config for build configuration. It was unreliable on Mac, and the hardcoded paths it returns prevented us from building with prebuilt binary dependencies.
-
--------------------------------------------------------------------------------
 
 0.98.0
 ======

--- a/doc/source/Installation/index.md
+++ b/doc/source/Installation/index.md
@@ -1,7 +1,7 @@
 Installation
 ============
 
-To install Gaffer, simply download and unpackage the appropriate bundle for your platform from the [GitHub release page](https://github.com/ImageEngine/gaffer/releases/!GAFFER_VERSION!). The resulting directory will contain the complete application ready to use, and you can launch Gaffer immediately by running the `bin/gaffer` script from within that directory.
+To install Gaffer, simply download and unpackage the appropriate bundle for your platform from the [GitHub release page](https://github.com/GafferHQ/gaffer/releases/!GAFFER_VERSION!). The resulting directory will contain the complete application ready to use, and you can launch Gaffer immediately by running the `bin/gaffer` script from within that directory.
 
 The gaffer distribution can be moved to any suitable location on the filesystem. For convenience, you should add `<GAFFER_INSTALL_PATH>/bin` to the `PATH` environment variable so that Gaffer can be run more simply as `gaffer` (where `<GAFFER_INSTALL_PATH>` is the location where you have moved the gaffer directory).
 

--- a/doc/source/Tutorials/GettingStarted/index.md
+++ b/doc/source/Tutorials/GettingStarted/index.md
@@ -402,6 +402,6 @@ There is no doubt still a lot that could be done to improve our render, but alas
 Hopefully this provides a solid basis for your own further exploration, which will no doubt be less creatively challenged. You might like to start by exploring the addition of more lights, found in the _/Appleseed/Lights_ node menu, or by creating more expansive shading networks using the shaders found in the _/Appleseed/Shaders_ node menu.
 
 [1]: ../../Installation/index.md
-[2]: ../../NodeReference/GafferScene/SceneReader.md
-[3]: ../../UIReference/NodeGraph.md
-[4]: ../../UIReference/Viewer.md
+[2]: ../../Reference/NodeReference/GafferScene/SceneReader.md
+[3]: ../../Reference/UIReference/NodeGraph.md
+[4]: ../../Reference/UIReference/Viewer.md

--- a/doc/source/Tutorials/ManagingComplexity/index.md
+++ b/doc/source/Tutorials/ManagingComplexity/index.md
@@ -89,4 +89,4 @@ Gaffer includes a built in performance monitor which can be useful when optimisi
 
 ![Turning on the performance monitor](images/performanceMonitor.png)
 
-Alternatively, the [stats app](../../CommandLineReference/stats.md) allows the same monitoring to be performed from the command line, without the need to perform a render.
+Alternatively, the [stats app](../../Reference/CommandLineReference/stats.md) allows the same monitoring to be performed from the command line, without the need to perform a render.

--- a/doc/source/Tutorials/Scripting/AddingAMenuItem/index.md
+++ b/doc/source/Tutorials/Scripting/AddingAMenuItem/index.md
@@ -126,5 +126,5 @@ def __iWantAPony( menu ) :
 GafferUI.ScriptWindow.menuDefinition(application).append( "/Help/I Want A Pony", { "command" : __iWantAPony } )
 ```
 
-[1]: ../ConfigurationFiles/index.md
-[2]: https://github.com/ImageEngine/gaffer/tree/!GAFFER_VERSION!/startup/gui
+[1]: ../CreatingConfigurationFiles/index.md
+[2]: https://github.com/GafferHQ/gaffer/tree/!GAFFER_VERSION!/startup/gui

--- a/doc/source/Tutorials/Scripting/CreatingConfigurationFiles/index.md
+++ b/doc/source/Tutorials/Scripting/CreatingConfigurationFiles/index.md
@@ -80,4 +80,4 @@ Next steps
 Naturally, we might want to do something slightly more useful at startup. Taking a look at [Gaffer’s internal config
 files][1] might provide some good starting points for more useful customisations.
 
-[1]: https://github.com/ImageEngine/gaffer/tree/!GAFFER_VERSION!/startup/gui
+[1]: https://github.com/GafferHQ/gaffer/tree/!GAFFER_VERSION!/startup/gui

--- a/doc/source/Tutorials/Scripting/GettingStarted/index.md
+++ b/doc/source/Tutorials/Scripting/GettingStarted/index.md
@@ -146,7 +146,7 @@ We've seen that Gaffer's node graphs can be constructed using a minimal set of s
 
 
 
-[1]: ../../../UIReference/ScriptEditor.md
-[2]: ../../../NodeReference/index.md
-[3]: ../../../ScriptingReference/index.md
-[4]: https://github.com/ImageEngine/gaffer/tree/!GAFFER_VERSION!
+[1]: ../../../Reference/UIReference/ScriptEditor.md
+[2]: ../../../Reference/NodeReference/index.md
+[3]: ../../../Reference/ScriptingReference/index.md
+[4]: https://github.com/GafferHQ/gaffer/tree/!GAFFER_VERSION!


### PR DESCRIPTION
In which John learns that recommonmark/Sphinx only warn about broken links in the toctree, and not links in the main document body.