### PR TITLE
OIIO stats

### DIFF
--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -309,7 +309,7 @@ class stats( Gaffer.Application ) :
 				GafferImageTest.processTiles( image )
 		self.__timers["Image generation"] = sceneTimer
 		self.__memory["Image generation"] = _Memory.maxRSS() - memory
-		self.__memory["OIIO cache limit"] = _Memory( GafferImage.OpenImageIOReader.getCacheMemoryLimit() * 1024 * 1024 )
+		self.__memory["OIIO cache limit"] = _Memory( GafferImage.OpenImageIOReader.getCacheMemoryLimit() )
 		self.__memory["OIIO cache usage"] = _Memory( GafferImage.OpenImageIOReader.cacheMemoryUsage() )
 
 		items = [

--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -309,6 +309,8 @@ class stats( Gaffer.Application ) :
 				GafferImageTest.processTiles( image )
 		self.__timers["Image generation"] = sceneTimer
 		self.__memory["Image generation"] = _Memory.maxRSS() - memory
+		self.__memory["OIIO cache limit"] = _Memory( GafferImage.OpenImageIOReader.getCacheMemoryLimit() * 1024 * 1024 )
+		self.__memory["OIIO cache usage"] = _Memory( GafferImage.OpenImageIOReader.cacheMemoryUsage() )
 
 		items = [
 			( "Format", image["format"].getValue() ),

--- a/include/GafferImage/OpenImageIOReader.h
+++ b/include/GafferImage/OpenImageIOReader.h
@@ -90,6 +90,8 @@ class OpenImageIOReader : public ImageNode
 		static size_t getCacheMemoryLimit();
 		/// Sets the maximum amount of memory the cache may use in Mb.
 		static void setCacheMemoryLimit( size_t mb );
+		/// Returns the current memory usage of the cache in _bytes_.
+		static size_t cacheMemoryUsage();
 
 	protected :
 

--- a/include/GafferImage/OpenImageIOReader.h
+++ b/include/GafferImage/OpenImageIOReader.h
@@ -86,11 +86,13 @@ class OpenImageIOReader : public ImageNode
 
 		static size_t supportedExtensions( std::vector<std::string> &extensions );
 
-		/// Returns the maximum amount of memory in Mb to use for the cache.
+		/// Returns the maximum number of bytes OIIO will use
+		/// to cache file loading.
 		static size_t getCacheMemoryLimit();
-		/// Sets the maximum amount of memory the cache may use in Mb.
-		static void setCacheMemoryLimit( size_t mb );
-		/// Returns the current memory usage of the cache in _bytes_.
+		/// Sets the maximum number of bytes OIIO will use to
+		/// cache file loading.
+		static void setCacheMemoryLimit( size_t bytes );
+		/// Returns the current memory usage of OIIO's cache in bytes.
 		static size_t cacheMemoryUsage();
 
 	protected :

--- a/python/GafferImageTest/OpenImageIOReaderTest.py
+++ b/python/GafferImageTest/OpenImageIOReaderTest.py
@@ -503,5 +503,13 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( reader["out"]["metadata"].hash(), explicitMetadataHash )
 			self.assertEqual( reader["out"]["metadata"].getValue(), sequenceMetadataValue )
 
+	def testCacheLimits( self ) :
+
+		l = GafferImage.OpenImageIOReader.getCacheMemoryLimit()
+		self.addCleanup( GafferImage.OpenImageIOReader.setCacheMemoryLimit, l )
+
+		GafferImage.OpenImageIOReader.setCacheMemoryLimit( 100 * 1024 * 1024 ) # 100 megs
+		self.assertEqual( GafferImage.OpenImageIOReader.getCacheMemoryLimit(), 100 * 1024 * 1024 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -394,7 +394,7 @@ class ValuePlug::ComputeProcess : public Process
 };
 
 const IECore::InternedString ValuePlug::ComputeProcess::staticType( "computeNode:compute" );
-ValuePlug::ComputeProcess::Cache ValuePlug::ComputeProcess::g_cache( nullGetter, 1024 * 1024 * 500 );
+ValuePlug::ComputeProcess::Cache ValuePlug::ComputeProcess::g_cache( nullGetter, 1024 * 1024 * 1024 * 1 ); // 1 gig
 
 //////////////////////////////////////////////////////////////////////////
 // SetValueAction implementation

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -676,12 +676,12 @@ size_t OpenImageIOReader::getCacheMemoryLimit()
 {
 	float memoryLimit;
 	imageCache()->getattribute( "max_memory_MB", memoryLimit );
-	return (size_t)memoryLimit;
+	return (size_t)(memoryLimit * 1024 * 1024);
 }
 
-void OpenImageIOReader::setCacheMemoryLimit( size_t mb )
+void OpenImageIOReader::setCacheMemoryLimit( size_t bytes )
 {
-	imageCache()->attribute( "max_memory_MB", float( mb ) );
+	imageCache()->attribute( "max_memory_MB", ((float)bytes) / (1024.0f * 1024.0f) );
 }
 
 size_t OpenImageIOReader::cacheMemoryUsage()

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -684,6 +684,13 @@ void OpenImageIOReader::setCacheMemoryLimit( size_t mb )
 	imageCache()->attribute( "max_memory_MB", float( mb ) );
 }
 
+size_t OpenImageIOReader::cacheMemoryUsage()
+{
+	long long v = 0;
+	imageCache()->getattribute( "stat:cache_memory_used", BaseTypeFromC<long long>::value, &v );
+	return v;
+}
+
 void OpenImageIOReader::plugSet( Gaffer::Plug *plug )
 {
 	// this clears the cache every time the refresh count is updated, so you don't get entries

--- a/src/GafferImageBindings/OpenImageIOReaderBinding.cpp
+++ b/src/GafferImageBindings/OpenImageIOReaderBinding.cpp
@@ -65,6 +65,7 @@ void GafferImageBindings::bindOpenImageIOReader()
 		.def( "supportedExtensions", &supportedExtensions ).staticmethod( "supportedExtensions" )
 		.def( "getCacheMemoryLimit", &OpenImageIOReader::getCacheMemoryLimit ).staticmethod( "getCacheMemoryLimit" )
 		.def( "setCacheMemoryLimit", &OpenImageIOReader::setCacheMemoryLimit ).staticmethod( "setCacheMemoryLimit" )
+		.def( "cacheMemoryUsage", &OpenImageIOReader::cacheMemoryUsage ).staticmethod( "cacheMemoryUsage" )
 	;
 
 	boost::python::enum_<OpenImageIOReader::MissingFrameMode>( "MissingFrameMode" )

--- a/startup/gui/cache.py
+++ b/startup/gui/cache.py
@@ -44,7 +44,7 @@ preferences = application.root()["preferences"]
 preferences["cache"] = Gaffer.CompoundPlug()
 preferences["cache"]["enabled"] = Gaffer.BoolPlug( defaultValue = True )
 preferences["cache"]["memoryLimit"] = Gaffer.IntPlug( defaultValue = Gaffer.ValuePlug.getCacheMemoryLimit() / ( 1024 * 1024 ) )
-preferences["cache"]["imageReaderMemoryLimit"] = Gaffer.IntPlug( defaultValue = GafferImage.OpenImageIOReader.getCacheMemoryLimit() )
+preferences["cache"]["imageReaderMemoryLimit"] = Gaffer.IntPlug( defaultValue = GafferImage.OpenImageIOReader.getCacheMemoryLimit() / ( 1024 * 1024 ) )
 
 Gaffer.Metadata.registerPlugValue(
     preferences["cache"]["memoryLimit"],
@@ -71,7 +71,7 @@ def __plugSet( plug ) :
 		return
 
 	memoryLimit = plug["memoryLimit"].getValue() * 1024 * 1024
-	imageReaderMemoryLimit = plug["imageReaderMemoryLimit"].getValue()
+	imageReaderMemoryLimit = plug["imageReaderMemoryLimit"].getValue() * 1024 * 1024
 	if not plug["enabled"].getValue() :
 		memoryLimit = 0
 		imageReaderMemoryLimit = 0

--- a/startup/gui/cache.py
+++ b/startup/gui/cache.py
@@ -51,7 +51,8 @@ Gaffer.Metadata.registerPlugValue(
     "description",
     """
     Controls the memory limit for Gaffer's ValuePlug cache.
-    """
+    """,
+    persistent = False
 )
 
 Gaffer.Metadata.registerPlugValue(
@@ -59,9 +60,9 @@ Gaffer.Metadata.registerPlugValue(
     "description",
     """
     Controls the memory limit for the OpenImageIO cache that the OpenImageIOReader node uses.
-    """
+    """,
+    persistent = False
 )
-
 
 # update cache settings when they change
 


### PR DESCRIPTION
This adds basic reporting of OIIO memory usage via the stats app.

Note the comment in the second commit about the mismatch of Mb/bytes. This matches the OIIO API, but not the equivalent methods in our ValuePlug API, which use bytes exclusively. If you can tolerate the breaking change, I'd love to update this to match.
