### PR TITLE
Wrapper : Include OSL shaders on APPLESEED_SEARCHPATH.

### DIFF
--- a/bin/gaffer
+++ b/bin/gaffer
@@ -205,6 +205,7 @@ if [[ $APPLESEED ]] ; then
 
 	prependToPath $APPLESEED/shaders OSL_SHADER_PATHS
 	prependToPath $GAFFER_ROOT/appleseedDisplays APPLESEED_SEARCHPATH
+	prependToPath $OSL_SHADER_PATHS APPLESEED_SEARCHPATH
 
 	prependToPath $APPLESEED/bin PATH
 


### PR DESCRIPTION
This was broken by bc0b4bcc854c49a676b22691e4d6c81185e22421.