### PR TITLE
FilterResults node and Set filter fix

### DIFF
--- a/include/GafferScene/Filter.h
+++ b/include/GafferScene/Filter.h
@@ -41,6 +41,7 @@
 #include "Gaffer/NumericPlug.h"
 
 #include "GafferScene/TypeIds.h"
+#include "GafferScene/FilterPlug.h"
 
 namespace GafferScene
 {
@@ -72,9 +73,8 @@ class Filter : public Gaffer::ComputeNode
 		virtual Gaffer::BoolPlug *enabledPlug();
 		virtual const Gaffer::BoolPlug *enabledPlug() const;
 
-		/// \todo Change return type to FilterPlug.
-		Gaffer::IntPlug *outPlug();
-		const Gaffer::IntPlug *outPlug() const;
+		FilterPlug *outPlug();
+		const FilterPlug *outPlug() const;
 
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 		virtual bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const;

--- a/include/GafferScene/FilterPlug.h
+++ b/include/GafferScene/FilterPlug.h
@@ -39,7 +39,7 @@
 
 #include "Gaffer/NumericPlug.h"
 
-#include "GafferScene/Filter.h"
+#include "GafferScene/TypeIds.h"
 
 namespace GafferScene
 {

--- a/include/GafferScene/FilterProcessor.h
+++ b/include/GafferScene/FilterProcessor.h
@@ -73,9 +73,8 @@ class FilterProcessor : public Filter
 		/// with a single input, it will be a plug parented directly to the
 		/// node. If the node is disabled via enabledPlug(), then the inPlug()
 		/// is automatically passed through directly to the outPlug().
-		/// \todo Change return type to FilterPlug.
-		Gaffer::IntPlug *inPlug();
-		const Gaffer::IntPlug *inPlug() const;
+		FilterPlug *inPlug();
+		const FilterPlug *inPlug() const;
 
 		/// For nodes with multiple inputs, returns the ArrayPlug which
 		/// hosts them. For single input nodes, returns NULL;

--- a/include/GafferScene/FilterResults.h
+++ b/include/GafferScene/FilterResults.h
@@ -1,0 +1,87 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENE_FILTERRESULTS_H
+#define GAFFERSCENE_FILTERRESULTS_H
+
+#include "Gaffer/ComputeNode.h"
+
+#include "GafferScene/TypeIds.h"
+#include "GafferScene/PathMatcherDataPlug.h"
+
+namespace GafferScene
+{
+
+IE_CORE_FORWARDDECLARE( ScenePlug )
+IE_CORE_FORWARDDECLARE( FilterPlug )
+
+class FilterResults : public Gaffer::ComputeNode
+{
+
+	public :
+
+		FilterResults( const std::string &name=defaultName<FilterResults>() );
+		virtual ~FilterResults();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::FilterResults, FilterResultsTypeId, ComputeNode );
+
+		ScenePlug *scenePlug();
+		const ScenePlug *scenePlug() const;
+
+		FilterPlug *filterPlug();
+		const FilterPlug *filterPlug() const;
+
+		PathMatcherDataPlug *outPlug();
+		const PathMatcherDataPlug *outPlug() const;
+
+		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+
+	protected :
+
+		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( FilterResults )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_FILTERRESULTS_H

--- a/include/GafferScene/FilteredSceneProcessor.h
+++ b/include/GafferScene/FilteredSceneProcessor.h
@@ -57,9 +57,8 @@ class FilteredSceneProcessor : public SceneProcessor
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::FilteredSceneProcessor, FilteredSceneProcessorTypeId, SceneProcessor );
 
-		/// \todo Change return type to FilterPlug.
-		Gaffer::IntPlug *filterPlug();
-		const Gaffer::IntPlug *filterPlug() const;
+		FilterPlug *filterPlug();
+		const FilterPlug *filterPlug() const;
 
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 

--- a/include/GafferScene/Set.h
+++ b/include/GafferScene/Set.h
@@ -83,8 +83,6 @@ class Set : public FilteredSceneProcessor
 
 	protected :
 
-		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
-
 		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
 
@@ -95,6 +93,9 @@ class Set : public FilteredSceneProcessor
 		virtual ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
 
 	private :
+
+		PathMatcherDataPlug *filterResultsPlug();
+		const PathMatcherDataPlug *filterResultsPlug() const;
 
 		PathMatcherDataPlug *pathMatcherPlug();
 		const PathMatcherDataPlug *pathMatcherPlug() const;

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -133,6 +133,7 @@ enum TypeId
 	LightTweaksTweakPlugTypeId = 110588,
 	CopyOptionsTypeId = 110589,
 	LightToCameraTypeId = 110590,
+	FilterResultsTypeId = 110591,
 
 	PreviewInteractiveRenderTypeId = 110649,
 

--- a/include/GafferSceneBindings/FilterResultsBinding.h
+++ b/include/GafferSceneBindings/FilterResultsBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEBINDINGS_FILTERRESULTSBINDING_H
+#define GAFFERSCENEBINDINGS_FILTERRESULTSBINDING_H
+
+namespace GafferSceneBindings
+{
+
+void bindFilterResults();
+
+} // namespace GafferSceneBindings
+
+#endif // GAFFERSCENEBINDINGS_FILTERRESULTSBINDING_H

--- a/python/GafferSceneTest/FilterResultsTest.py
+++ b/python/GafferSceneTest/FilterResultsTest.py
@@ -1,0 +1,126 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferScene
+import GafferSceneTest
+
+class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
+
+	def testChangingFilter( self ) :
+
+		p = GafferScene.Plane()
+		s = GafferScene.Sphere()
+		g = GafferScene.Group()
+		g["in"][0].setInput( p["out"] )
+		g["in"][1].setInput( s["out"] )
+
+		f = GafferScene.PathFilter()
+		f["paths"].setValue( IECore.StringVectorData( [ "/group/*" ] ) )
+
+		n = GafferScene.FilterResults()
+		n["scene"].setInput( g["out"] )
+		n["filter"].setInput( f["out"] )
+
+		self.assertEqual(
+			n["out"].getValue().value,
+			GafferScene.PathMatcher( [
+				"/group/sphere",
+				"/group/plane"
+			] )
+		)
+
+		f["paths"].setValue( IECore.StringVectorData( [ "/group/p*" ] ) )
+
+		self.assertEqual(
+			n["out"].getValue().value,
+			GafferScene.PathMatcher( [
+				"/group/plane"
+			] )
+		)
+
+	def testChangingScene( self ) :
+
+		p = GafferScene.Plane()
+		g = GafferScene.Group()
+		g["in"][0].setInput( p["out"] )
+
+		f = GafferScene.PathFilter()
+		f["paths"].setValue( IECore.StringVectorData( [ "/group/plain" ] ) )
+
+		n = GafferScene.FilterResults()
+		n["scene"].setInput( g["out"] )
+		n["filter"].setInput( f["out"] )
+
+		self.assertEqual( n["out"].getValue().value, GafferScene.PathMatcher() )
+
+		p["name"].setValue( "plain" )
+
+		self.assertEqual(
+			n["out"].getValue().value,
+			GafferScene.PathMatcher( [
+				"/group/plain"
+			] )
+		)
+
+	def testDirtyPropagation( self ) :
+
+		p = GafferScene.Plane()
+		p["sets"].setValue( "A" )
+
+		f = GafferScene.SetFilter()
+		f["set"].setValue( "A" )
+
+		n = GafferScene.FilterResults()
+		n["scene"].setInput( p["out"] )
+		n["filter"].setInput( f["out"] )
+
+		cs = GafferTest.CapturingSlot( n.plugDirtiedSignal() )
+
+		f["set"].setValue( "planeSet" )
+		self.assertTrue( n["out"] in { x[0] for x in cs } )
+		del cs[:]
+
+		p["name"].setValue( "thing" )
+		self.assertTrue( n["out"] in { x[0] for x in cs } )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/SetTest.py
+++ b/python/GafferSceneTest/SetTest.py
@@ -255,6 +255,7 @@ class SetTest( GafferSceneTest.SceneTestCase ) :
 			s["filter"],
 			s["out"]["set"],
 			s["out"],
+			s["__filterResults"],
 			s["__pathMatcher"],
 		}
 
@@ -269,6 +270,24 @@ class SetTest( GafferSceneTest.SceneTestCase ) :
 
 		f["paths"].setValue( IECore.StringVectorData( [ "/group/plane*2" ] ) )
 		self.assertEqual( set( s["out"].set( "n" ).value.paths() ), set( [ "/group/plane2", "/group/plane12", "/group/plane22" ] ) )
+
+	def testFilterWithChangingInputScene( self ) :
+
+		p = GafferScene.Plane()
+		g = GafferScene.Group()
+		g["in"].setInput( p["out"] )
+
+		f = GafferScene.PathFilter()
+		f["paths"].setValue( IECore.StringVectorData( [ "/group/plain" ] ) )
+
+		s = GafferScene.Set()
+		s["in"].setInput( g["out"] )
+		s["filter"].setInput( f["out"] )
+
+		self.assertEqual( s["out"].set( "set" ).value, GafferScene.PathMatcher() )
+
+		p["name"].setValue( "plain" )
+		self.assertEqual( s["out"].set( "set" ).value, GafferScene.PathMatcher( [ "/group/plain" ] ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -116,6 +116,7 @@ from InteractiveRenderTest import InteractiveRenderTest
 from FilteredSceneProcessorTest import FilteredSceneProcessorTest
 from ShaderBallTest import ShaderBallTest
 from LightTweaksTest import LightTweaksTest
+from FilterResultsTest import FilterResultsTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferSceneUI/FilterResultsUI.py
+++ b/python/GafferSceneUI/FilterResultsUI.py
@@ -1,0 +1,89 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.FilterResults,
+
+	"description",
+	"""
+	Searches an input scene for all locations matched
+	by a filter.
+
+	> Warning : This can be an arbitrarily expensive operation
+	depending on the size of the input scene and the filter
+	used. In particular it should be noted that the usage of
+	`...` in a PathFilter will cause the entire input scene to
+	be searched even if there are no matches to be found.
+	""",
+
+	plugs = {
+
+		"scene" : [
+
+			"description",
+			"""
+			The scene to be searched for matching
+			locations.
+			""",
+
+		],
+
+		"filter" : [
+
+			"description",
+			"""
+			The filter to be used when searching for
+			matching locations.
+			""",
+
+		],
+
+		"out" : [
+
+			"description",
+			"""
+			The results of the search.
+			""",
+
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -111,6 +111,13 @@ Gaffer.Metadata.registerNode(
 			"""
 			A filter to define additional paths to be added to
 			or removed from the set.
+
+			> Warning : Using a filter can be very expensive.
+			It is advisable to limit use to filters with a
+			limited number of matches and/or sets which are
+			not used heavily downstream. Wherever possible,
+			prefer to use the `paths` plug directly instead
+			of using a filter.
 			""",
 
 		],

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -128,6 +128,7 @@ import RenderUI
 import ShaderBallUI
 import LightTweaksUI
 import LightToCameraUI
+import FilterResultsUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/Filter.cpp
+++ b/src/GafferScene/Filter.cpp
@@ -69,14 +69,14 @@ const Gaffer::BoolPlug *Filter::enabledPlug() const
 	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex );
 }
 
-Gaffer::IntPlug *Filter::outPlug()
+FilterPlug *Filter::outPlug()
 {
-	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 1 );
+	return getChild<FilterPlug>( g_firstPlugIndex + 1 );
 }
 
-const Gaffer::IntPlug *Filter::outPlug() const
+const FilterPlug *Filter::outPlug() const
 {
-	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 1 );
+	return getChild<FilterPlug>( g_firstPlugIndex + 1 );
 }
 
 void Filter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const

--- a/src/GafferScene/FilterPlug.cpp
+++ b/src/GafferScene/FilterPlug.cpp
@@ -39,6 +39,7 @@
 #include "Gaffer/ArrayPlug.h"
 
 #include "GafferScene/FilterPlug.h"
+#include "GafferScene/Filter.h"
 
 using namespace IECore;
 using namespace Gaffer;

--- a/src/GafferScene/FilterProcessor.cpp
+++ b/src/GafferScene/FilterProcessor.cpp
@@ -66,29 +66,29 @@ FilterProcessor::~FilterProcessor()
 {
 }
 
-Gaffer::IntPlug *FilterProcessor::inPlug()
+FilterPlug *FilterProcessor::inPlug()
 {
 	GraphComponent *p = getChild<GraphComponent>( g_firstPlugIndex );
-	if( IntPlug *s = IECore::runTimeCast<IntPlug>( p ) )
+	if( FilterPlug *s = IECore::runTimeCast<FilterPlug>( p ) )
 	{
 		return s;
 	}
 	else
 	{
-		return static_cast<ArrayPlug *>( p )->getChild<IntPlug>( 0 );
+		return static_cast<ArrayPlug *>( p )->getChild<FilterPlug>( 0 );
 	}
 }
 
-const Gaffer::IntPlug *FilterProcessor::inPlug() const
+const FilterPlug *FilterProcessor::inPlug() const
 {
 	const GraphComponent *p = getChild<GraphComponent>( g_firstPlugIndex );
-	if( const IntPlug *s = IECore::runTimeCast<const IntPlug>( p ) )
+	if( const FilterPlug *s = IECore::runTimeCast<const FilterPlug>( p ) )
 	{
 		return s;
 	}
 	else
 	{
-		return static_cast<const ArrayPlug *>( p )->getChild<IntPlug>( 0 );
+		return static_cast<const ArrayPlug *>( p )->getChild<FilterPlug>( 0 );
 	}
 }
 

--- a/src/GafferScene/FilterResults.cpp
+++ b/src/GafferScene/FilterResults.cpp
@@ -1,0 +1,153 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/FilterResults.h"
+#include "GafferScene/ScenePlug.h"
+#include "GafferScene/Filter.h"
+#include "GafferScene/SceneAlgo.h"
+
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+
+size_t FilterResults::g_firstPlugIndex = 0;
+
+IE_CORE_DEFINERUNTIMETYPED( FilterResults )
+
+FilterResults::FilterResults( const std::string &name )
+	:	ComputeNode( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new ScenePlug( "scene" ) );
+	addChild( new FilterPlug( "filter" ) );
+	addChild( new PathMatcherDataPlug( "out", Gaffer::Plug::Out, new PathMatcherData ) );
+}
+
+FilterResults::~FilterResults()
+{
+}
+
+ScenePlug *FilterResults::scenePlug()
+{
+	return getChild<ScenePlug>( g_firstPlugIndex );
+}
+
+const ScenePlug *FilterResults::scenePlug() const
+{
+	return getChild<ScenePlug>( g_firstPlugIndex );
+}
+
+FilterPlug *FilterResults::filterPlug()
+{
+	return getChild<FilterPlug>( g_firstPlugIndex + 1 );
+}
+
+const FilterPlug *FilterResults::filterPlug() const
+{
+	return getChild<FilterPlug>( g_firstPlugIndex + 1 );
+}
+
+PathMatcherDataPlug *FilterResults::outPlug()
+{
+	return getChild<PathMatcherDataPlug>( g_firstPlugIndex + 2 );
+}
+
+const PathMatcherDataPlug *FilterResults::outPlug() const
+{
+	return getChild<PathMatcherDataPlug>( g_firstPlugIndex + 2 );
+}
+
+void FilterResults::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	ComputeNode::affects( input, outputs );
+
+	const ScenePlug *scenePlug = input->parent<ScenePlug>();
+	if( scenePlug && scenePlug == this->scenePlug() )
+	{
+		const Filter *filter = runTimeCast<const Filter>( filterPlug()->source<Plug>()->node() );
+		if( filter && filter->sceneAffectsMatch( scenePlug, static_cast<const ValuePlug *>( input ) ) )
+		{
+			outputs.push_back( filterPlug() );
+		}
+	}
+	else if( input == filterPlug() )
+	{
+		outputs.push_back( outPlug() );
+	}
+}
+
+void FilterResults::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	ComputeNode::hash( output, context, h );
+
+	if( output == outPlug() )
+	{
+		/// \todo This is potentially incredibly expensive, because depending
+		/// on the filter it might visit every single location of a scene.
+		/// Do better. Possibilities include :
+		///
+		/// - Using an __internalOut plug to do the work, and ensuring that the
+		///   computation of the out plug pulls on __internalOut with a context
+		///   which is as clean as possible (removing scene:path, scene:set,
+		///   image:tileOrigin and image:channelName). This would give the hash
+		///   cache a better chance of mitigating the expense.
+		/// - Adding protected Filter virtual methods to perform all the work
+		///   and exposing them via public methods on FilterPlug. Filters such
+		///   as SetFilter could then have much faster implementations given
+		///   their specific knowledge of the situation.
+		/// - Using David Minor's "poor man's hash" trick whereby the dirty
+		///   count of the input scene is used as a substitute for the true
+		///   hash.
+		/// - Coming up with a way of cheaply computing a hierarchy hash,
+		///   that mythical beast that solves all our problems.
+		PathMatcherDataPtr data = new PathMatcherData;
+		matchingPaths( filterPlug(), scenePlug(), data->writable() );
+		data->hash( h );
+	}
+}
+
+void FilterResults::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const
+{
+	if( output == outPlug() )
+	{
+		PathMatcherDataPtr data = new PathMatcherData;
+		matchingPaths( filterPlug(), scenePlug(), data->writable() );
+		static_cast<PathMatcherDataPlug *>( output )->setValue( data );
+		return;
+	}
+
+	ComputeNode::compute( output, context );
+}

--- a/src/GafferScene/FilteredSceneProcessor.cpp
+++ b/src/GafferScene/FilteredSceneProcessor.cpp
@@ -61,14 +61,14 @@ FilteredSceneProcessor::~FilteredSceneProcessor()
 {
 }
 
-Gaffer::IntPlug *FilteredSceneProcessor::filterPlug()
+FilterPlug *FilteredSceneProcessor::filterPlug()
 {
-	return getChild<IntPlug>( g_firstPlugIndex );
+	return getChild<FilterPlug>( g_firstPlugIndex );
 }
 
-const Gaffer::IntPlug *FilteredSceneProcessor::filterPlug() const
+const FilterPlug *FilteredSceneProcessor::filterPlug() const
 {
-	return getChild<IntPlug>( g_firstPlugIndex );
+	return getChild<FilterPlug>( g_firstPlugIndex );
 }
 
 void FilteredSceneProcessor::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const

--- a/src/GafferSceneBindings/FilterPlugBinding.cpp
+++ b/src/GafferSceneBindings/FilterPlugBinding.cpp
@@ -39,6 +39,7 @@
 #include "GafferBindings/PlugBinding.h"
 
 #include "GafferScene/FilterPlug.h"
+#include "GafferScene/Filter.h"
 
 #include "GafferSceneBindings/FilterPlugBinding.h"
 

--- a/src/GafferSceneBindings/FilterResultsBinding.cpp
+++ b/src/GafferSceneBindings/FilterResultsBinding.cpp
@@ -1,0 +1,51 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "GafferBindings/DependencyNodeBinding.h"
+
+#include "GafferScene/FilterResults.h"
+
+#include "GafferSceneBindings/FilterResultsBinding.h"
+
+using namespace GafferBindings;
+using namespace GafferScene;
+
+void GafferSceneBindings::bindFilterResults()
+{
+	DependencyNodeClass<FilterResults>();
+}

--- a/src/GafferSceneModule/GafferSceneModule.cpp
+++ b/src/GafferSceneModule/GafferSceneModule.cpp
@@ -106,6 +106,7 @@
 #include "GafferSceneBindings/FilterPlugBinding.h"
 #include "GafferSceneBindings/LightTweaksBinding.h"
 #include "GafferSceneBindings/LightToCameraBinding.h"
+#include "GafferSceneBindings/FilterResultsBinding.h"
 
 using namespace boost::python;
 using namespace GafferBindings;
@@ -193,5 +194,6 @@ BOOST_PYTHON_MODULE( _GafferScene )
 	bindMeshToPoints();
 	bindLightTweaks();
 	bindLightToCamera();
+	bindFilterResults();
 
 }


### PR DESCRIPTION
This introduces a FilterResults node that computes all filter matches for a particular scene, and uses it to fix #1878. I have no doubt that I'll be coming back to improve the performance of this as it starts to be used more widely, but at least we now have correct results on which to build.

I'm not sure how I feel about the "FilterResults" name - any other thoughts? I think maybe I would prefer "MatchingLocations" but I'm open to other ideas...