### PR TITLE
IECoreScenePreview::Renderer: allow declaring unprefixed custom options

### DIFF
--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -1435,6 +1435,26 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertTrue( arnold.AiNodeIs( shape, "volume" ) )
 			self.assertEqual( arnold.AiNodeGetFlt( shape, "step_size" ), 0.25 )
 
+	def testDeclaringCustomOptions( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"IECoreArnold::Renderer",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			self.temporaryDirectory() + "/test.ass"
+		)
+
+		r.option( "ai:declare:myCustomOption", IECore.StringData( "myCustomOptionValue" ) )
+
+		r.render()
+		del r
+
+		with IECoreArnold.UniverseBlock( writable = True ) :
+
+			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+			options = arnold.AiUniverseGetOptions()
+
+			self.assertEqual( arnold.AiNodeGetStr( options, "myCustomOption" ), "myCustomOptionValue" )
+
 	@staticmethod
 	def __m44f( m ) :
 

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1439,6 +1439,27 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 				AiNodeSetStr( options, "shader_searchpath", s.c_str() );
 				return;
 			}
+			else if( boost::starts_with( name.c_str(), "ai:declare:" ) )
+			{
+				const AtParamEntry *parameter = AiNodeEntryLookUpParameter( AiNodeGetNodeEntry( options ), name.c_str() + 11 );
+				if( parameter )
+				{
+					IECore::msg( IECore::Msg::Warning, "IECoreArnold::Renderer::option", boost::format( "Unable to declare existing option \"%s\"." ) % (name.c_str() + 11) );
+				}
+				else
+				{
+					const AtUserParamEntry *userParameter = AiNodeLookUpUserParameter( options, name.c_str() + 11);
+					if( userParameter )
+					{
+						AiNodeResetParameter( options, name.c_str() + 11 );
+					}
+					if( value )
+					{
+						ParameterAlgo::setParameter( options, name.c_str() + 11, value );
+					}
+				}
+				return;
+			}
 			else if( boost::starts_with( name.c_str(), "ai:" ) )
 			{
 				const AtParamEntry *parameter = AiNodeEntryLookUpParameter( AiNodeGetNodeEntry( options ), name.c_str() + 3 );


### PR DESCRIPTION
@johnhaddon, I guess we might also want to consider doing this for attributes?

I added a test for the option's value, but I don't check the warning yet... Let me know if you think it's necessary to add that.