### PR TITLE
Arnold AA_seed support

### DIFF
--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -102,6 +102,7 @@ class Renderer : public IECore::RefCounted
 		/// ----------------
 		///
 		/// "camera", StringData, "", The name of the primary render camera.
+		/// "frame", IntData, 1, The frame being rendered.
 		virtual void option( const IECore::InternedString &name, const IECore::Data *value ) = 0;
 		/// Adds an output image to be rendered, In interactive renders an output may be
 		/// removed by passing NULL as the value.

--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -1455,6 +1455,35 @@ class RendererTest( GafferTest.TestCase ) :
 
 			self.assertEqual( arnold.AiNodeGetStr( options, "myCustomOption" ), "myCustomOptionValue" )
 
+	def testFrameAndAASeed( self ) :
+
+		for frame in ( None, 1, 2 ) :
+			for seed in ( None, 3, 4 ) :
+
+				r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+					"IECoreArnold::Renderer",
+					GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+					self.temporaryDirectory() + "/test.ass"
+				)
+
+				if frame is not None :
+					r.option( "frame", IECore.IntData( frame ) )
+				if seed is not None :
+					r.option( "ai:AA_seed", IECore.IntData( seed ) )
+
+				r.render()
+				del r
+
+				with IECoreArnold.UniverseBlock( writable = True ) :
+
+					arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+
+					options = arnold.AiUniverseGetOptions()
+					self.assertEqual(
+						arnold.AiNodeGetInt( options, "AA_seed" ),
+						seed or frame or 1
+					)
+
 	@staticmethod
 	def __m44f( m ) :
 

--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -67,6 +67,8 @@ def __samplingSummary( plug ) :
 		info.append( "SSS %d" % plug["giSSSSamples"]["value"].getValue() )
 	if plug["giVolumeSamples"]["enabled"].getValue() :
 		info.append( "Volume %d" % plug["giVolumeSamples"]["value"].getValue() )
+	if plug["aaSeed"]["enabled"].getValue() :
+		info.append( "Seed {0}".format( plug["aaSeed"]["value"].getValue() ) )
 	return ", ".join( info )
 
 def __rayDepthSummary( plug ) :
@@ -324,6 +326,23 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Sampling",
 			"label", "Volume Samples",
+
+		],
+
+		"options.aaSeed" : [
+
+			"description",
+			"""
+			Seeds the randomness used when generating samples.
+			By default this is set to the current frame number
+			so that the pattern of sampling noise changes every
+			frame. It can be locked to a particular value so
+			that sampling noise does not change from frame to
+			frame.
+			""",
+
+			"layout:section", "Sampling",
+			"label", "AA Seed",
 
 		],
 

--- a/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
+++ b/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
@@ -1497,6 +1497,7 @@ namespace
 {
 
 InternedString g_cameraOptionName( "camera" );
+InternedString g_frameOptionName( "frame" );
 InternedString g_environmentEDFName( "as:environment_edf" );
 InternedString g_environmentEDFBackground( "as:environment_edf_background" );
 InternedString g_logLevelOptionName( "as:log:level" );
@@ -1576,6 +1577,12 @@ class AppleseedRenderer : public IECoreScenePreview::Renderer
 				return;
 			}
 
+			if( name == g_frameOptionName )
+			{
+				/// \todo Does this have a meaning in Appleseed?
+				return;
+			}
+
 			// appleseed render settings.
 			if( boost::starts_with( name.c_str(), "as:cfg:" ) )
 			{
@@ -1600,7 +1607,7 @@ class AppleseedRenderer : public IECoreScenePreview::Renderer
 						// if the number of passes is greater than one, we need to
 						// switch the shading result framebuffer in the final rendering config.
 						m_project->configurations().get_by_name( "final" )->get_parameters().insert( "shading_result_framebuffer", numPasses > 1 ? "permanent" : "ephemeral" );
-	
+
 						// enable decorrelate pixels if the number of render passes is greater than one.
 						m_project->configurations().get_by_name( "final" )->get_parameters().insert_path( "uniform_pixel_renderer.decorrelate_pixels", numPasses > 1 ? "true" : "false" );
 						m_project->configurations().get_by_name( "final" )->get_parameters().insert_path( optName.c_str(), numPasses );
@@ -1843,7 +1850,7 @@ class AppleseedRenderer : public IECoreScenePreview::Renderer
 				// Output render directly to a file.
 				m_project->get_frame()->get_parameters().insert( "output_filename", output->getName().c_str() );
 				m_project->get_frame()->get_parameters().insert( "output_aovs", false );
-		
+
 				if( output->getType() == "png" )
 				{
 					m_project->get_frame()->get_parameters().insert( "color_space", "srgb" );
@@ -2097,9 +2104,9 @@ class AppleseedRenderer : public IECoreScenePreview::Renderer
 				{
 					msg( MessageHandler::Error, "AppleseedRenderer", "Empty project filename" );
 				}
-	
+
 				m_projectPath = boost::filesystem::path( m_appleseedFileName ).parent_path();
-	
+
 				// Create a dir to store the mesh files if it does not exist yet.
 				boost::filesystem::path geomPath = m_projectPath / "_geometry";
 				if( !boost::filesystem::exists( geomPath ) )

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -59,6 +59,7 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	options->addOptionalMember( "ai:GI_refraction_samples", new IECore::IntData( 2 ), "giRefractionSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:GI_sss_samples", new IECore::IntData( 2 ), "giSSSSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:GI_volume_samples", new IECore::IntData( 2 ), "giVolumeSamples", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:AA_seed", new IECore::IntData( 1 ), "aaSeed", Gaffer::Plug::Default, false );
 
 	// Ray depth parameters
 

--- a/src/GafferScene/Preview/RendererAlgo.cpp
+++ b/src/GafferScene/Preview/RendererAlgo.cpp
@@ -360,6 +360,7 @@ namespace
 
 const std::string g_optionPrefix( "option:" );
 
+const IECore::InternedString g_frameOptionName( "frame" );
 const IECore::InternedString g_cameraOptionLegacyName( "option:render:camera" );
 const InternedString g_transformBlurOptionName( "option:render:transformBlur" );
 const InternedString g_deformationBlurOptionName( "option:render:deformationBlur" );
@@ -752,6 +753,10 @@ void outputOptions( const IECore::CompoundObject *globals, IECoreScenePreview::R
 
 void outputOptions( const IECore::CompoundObject *globals, const IECore::CompoundObject *previousGlobals, IECoreScenePreview::Renderer *renderer )
 {
+	// Output the current frame.
+
+	renderer->option( g_frameOptionName, new IntData( (int)round( Context::current()->getFrame() ) ) );
+
 	// Output anything that has changed or was added since last time.
 
 	CompoundObject::ObjectMap::const_iterator it, eIt;


### PR DESCRIPTION
This causes Arnold's AA_seed parameter to be set to the current frame number by default, with the option of overriding it using a setting on the ArnoldOptions node.