### PR TITLE
Add "nodeGraph:childrenViewable" metadata.

### DIFF
--- a/python/GafferUI/BoxUI.py
+++ b/python/GafferUI/BoxUI.py
@@ -59,6 +59,8 @@ Gaffer.Metadata.registerNode(
 	node.
 	""",
 
+	"nodeGraph:childrenViewable", True,
+
 	# Add a + button for creating new plugs in the Settings tab.
 	"layout:customWidget:addButton:widgetType", "GafferUI.UserPlugs.plugCreationWidget",
 	"layout:customWidget:addButton:section", "Settings",
@@ -103,10 +105,7 @@ def nodeMenuCreateCommand( menu ) :
 
 	return Gaffer.Box.create( graphGadget.getRoot(), script.selection() )
 
-## A callback suitable for use with NodeGraph.nodeContextMenuSignal - it provides
-# menu options specific to Boxes. We don't actually register it automatically,
-# but instead let the startup files for particular applications register
-# it if it suits their purposes.
+## \deprecated Use NodeGraph.appendSubGraphMenuDefinitions()
 def appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition ) :
 
 	if not isinstance( node, Gaffer.Box ) :

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -393,7 +393,7 @@ class Menu( GafferUI.Widget ) :
 
 		if callable( itemValue ) :
 			kwArgs = {}
-			if "menu" in inspect.getargspec( itemValue )[0] :
+			if "menu" in self.__argNames( itemValue ) :
 				kwArgs["menu"] = self
 			itemValue = itemValue( **kwArgs )
 

--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -176,6 +176,15 @@ class NodeGraph( GafferUI.EditorWidget ) :
 				}
 			)
 
+	@classmethod
+	def appendContentsMenuDefinitions( cls, nodeGraph, node, menuDefinition ) :
+
+		if not Gaffer.Metadata.value( node, "nodeGraph:childrenViewable" ) :
+			return
+
+		menuDefinition.append( "/ContentsDivider", { "divider" : True } )
+		menuDefinition.append( "/Show Contents...", { "command" : functools.partial( cls.acquire, node ) } )
+
 	__nodeDoubleClickSignal = Gaffer.Signal2()
 	## Returns a signal which is emitted whenever a node is double clicked.
 	# Slots should have the signature ( nodeGraph, node ).
@@ -285,9 +294,11 @@ class NodeGraph( GafferUI.EditorWidget ) :
 		elif event.key == "Down" :
 			selection = self.scriptNode().selection()
 			if selection.size() :
-				needsModifiers = not isinstance( selection[0], ( Gaffer.Reference, Gaffer.Box ) )
-				haveModifiers = bool( event.modifiers & ( event.modifiers.Shift | event.modifiers.Control ) )
-				if needsModifiers == haveModifiers :
+				needsModifiers = not Gaffer.Metadata.value( selection[0], "nodeGraph:childrenViewable" )
+				if (
+					( needsModifiers and event.modifiers == event.modifiers.Shift | event.modifiers.Control ) or
+					( not needsModifiers and event.modifiers == event.modifiers.None )
+				) :
 					self.graphGadget().setRoot( selection[0] )
 					return True
 		elif event.key == "Up" :

--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import functools
+
 import IECore
 
 import Gaffer
@@ -145,15 +147,15 @@ class NodeGraph( GafferUI.EditorWidget ) :
 		menuDefinition.append(
 			"/Show Input Connections",
 			{
-				"checkBox" : IECore.curry( cls.__getNodeInputConnectionsVisible, nodeGraph.graphGadget(), node ),
-				"command" : IECore.curry( cls.__setNodeInputConnectionsVisible, nodeGraph.graphGadget(), node )
+				"checkBox" : functools.partial( cls.__getNodeInputConnectionsVisible, nodeGraph.graphGadget(), node ),
+				"command" : functools.partial( cls.__setNodeInputConnectionsVisible, nodeGraph.graphGadget(), node )
 			}
 		)
 		menuDefinition.append(
 			"/Show Output Connections",
 			{
-				"checkBox" : IECore.curry( cls.__getNodeOutputConnectionsVisible, nodeGraph.graphGadget(), node ),
-				"command" : IECore.curry( cls.__setNodeOutputConnectionsVisible, nodeGraph.graphGadget(), node )
+				"checkBox" : functools.partial( cls.__getNodeOutputConnectionsVisible, nodeGraph.graphGadget(), node ),
+				"command" : functools.partial( cls.__setNodeOutputConnectionsVisible, nodeGraph.graphGadget(), node )
 			}
 		)
 
@@ -168,7 +170,7 @@ class NodeGraph( GafferUI.EditorWidget ) :
 			menuDefinition.append(
 				"/Enabled",
 				{
-					"command" : IECore.curry( cls.__setEnabled, node ),
+					"command" : functools.partial( cls.__setEnabled, node ),
 					"checkBox" : enabledPlug.getValue(),
 					"active" : enabledPlug.settable() and not Gaffer.readOnly( enabledPlug )
 				}

--- a/python/GafferUI/ReferenceUI.py
+++ b/python/GafferUI/ReferenceUI.py
@@ -56,6 +56,8 @@ Gaffer.Metadata.registerNode(
 	node and then export it for referencing.
 	""",
 
+	"nodeGraph:childrenViewable", True,
+
 	"layout:customWidget:fileName:widgetType", "GafferUI.ReferenceUI._FileNameWidget"
 
 )

--- a/startup/gui/nodeGraph.py
+++ b/startup/gui/nodeGraph.py
@@ -105,7 +105,7 @@ def __nodeContextMenu( nodeGraph, node, menuDefinition ) :
 	GafferUI.NodeGraph.appendEnabledPlugMenuDefinitions( nodeGraph, node, menuDefinition )
 	GafferUI.NodeGraph.appendConnectionVisibilityMenuDefinitions( nodeGraph, node, menuDefinition )
 	GafferDispatchUI.DispatcherUI.appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition )
-	GafferUI.BoxUI.appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition )
+	GafferUI.NodeGraph.appendContentsMenuDefinitions( nodeGraph, node, menuDefinition )
 	GafferUI.UIEditor.appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition )
 	GafferSceneUI.FilteredSceneProcessorUI.appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition )
 	GafferUI.GraphBookmarksUI.appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition )


### PR DESCRIPTION
This allows any node type to request the privilege that used to be reserved to Boxes - a "Show Contents..." menu item in the NodeGraph. Likewise, such nodes are included in the whitelist for the cursor down navigation into subgraphs. Also made the "secret" shortcut to get inside other node types a bit harder to find.