### PR TITLE
Using FilterResults in expressions

### DIFF
--- a/python/GafferSceneTest/PathMatcherDataTest.py
+++ b/python/GafferSceneTest/PathMatcherDataTest.py
@@ -96,5 +96,23 @@ class PathMatcherDataTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertNotEqual( d1.hash(), d2.hash() )
 
+	def testRepr( self ) :
+
+		d1 = GafferScene.PathMatcherData(
+			GafferScene.PathMatcher()
+		)
+		d2 = GafferScene.PathMatcherData(
+			GafferScene.PathMatcher( [
+				"/a/b",
+				"/a/*"
+			] )
+		)
+
+		d1c = eval( repr( d1 ) )
+		d2c = eval( repr( d2 ) )
+
+		self.assertEqual( d1, d1c )
+		self.assertEqual( d2, d2c )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/PathMatcherTest.py
+++ b/python/GafferSceneTest/PathMatcherTest.py
@@ -987,5 +987,19 @@ class PathMatcherTest( GafferSceneTest.SceneTestCase ) :
 		s = m.subTree( "" )
 		self.assertTrue( s.isEmpty() )
 
+	def testRepr( self ) :
+
+		m1 = GafferScene.PathMatcher()
+		m2 = GafferScene.PathMatcher( [
+			"/a/b",
+			"/a/*"
+		] )
+
+		m1c = eval( repr( m1 ) )
+		m2c = eval( repr( m2 ) )
+
+		self.assertEqual( m1, m1c )
+		self.assertEqual( m2, m2c )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneBindings/PathMatcherBinding.cpp
+++ b/src/GafferSceneBindings/PathMatcherBinding.cpp
@@ -105,6 +105,12 @@ list paths( const PathMatcher &p )
 	return result;
 }
 
+std::string pathMatcherRepr( object p )
+{
+	std::string paths = extract<std::string>( p.attr( "paths" )().attr( "__repr__" )() );
+	return "GafferScene.PathMatcher( " + paths + " )";
+}
+
 } // namespace
 
 void GafferSceneBindings::bindPathMatcher()
@@ -130,6 +136,7 @@ void GafferSceneBindings::bindPathMatcher()
 		.def( "paths", &paths )
 		.def( "match", (unsigned (PathMatcher ::*)( const std::vector<IECore::InternedString> & ) const)&PathMatcher::match )
 		.def( "match", (unsigned (PathMatcher ::*)( const std::string & ) const)&PathMatcher::match )
+		.def( "__repr__", &pathMatcherRepr )
 		.def( self == self )
 		.def( self != self )
 	;

--- a/src/GafferSceneBindings/PathMatcherBinding.cpp
+++ b/src/GafferSceneBindings/PathMatcherBinding.cpp
@@ -48,13 +48,13 @@ using namespace boost::python;
 using namespace GafferSceneBindings;
 using namespace GafferScene;
 
-namespace GafferSceneBindings
+namespace
 {
 
 // we don't actually wrap the existing init, but rather reimplement it
 // here using clear() and addPath(), so that we can support a mixture
 // of strings and InternedStringVectorData.
-static void initWrapper( PathMatcher &m, boost::python::object paths )
+void initWrapper( PathMatcher &m, boost::python::object paths )
 {
 	m.clear();
 	for( size_t i = 0, e = len( paths ); i < e; ++i )
@@ -73,7 +73,7 @@ static void initWrapper( PathMatcher &m, boost::python::object paths )
 	}
 }
 
-static PathMatcher *constructFromObject( boost::python::object oPaths )
+PathMatcher *constructFromObject( boost::python::object oPaths )
 {
 	PathMatcher *result = new PathMatcher;
 	try
@@ -88,12 +88,12 @@ static PathMatcher *constructFromObject( boost::python::object oPaths )
 	return result;
 }
 
-static PathMatcher *constructFromVectorData( IECore::ConstStringVectorDataPtr paths )
+PathMatcher *constructFromVectorData( IECore::ConstStringVectorDataPtr paths )
 {
 	return new PathMatcher( paths->readable().begin(), paths->readable().end() );
 }
 
-static list paths( const PathMatcher &p )
+list paths( const PathMatcher &p )
 {
 	std::vector<std::string> paths;
 	p.paths( paths );
@@ -105,7 +105,9 @@ static list paths( const PathMatcher &p )
 	return result;
 }
 
-void bindPathMatcher()
+} // namespace
+
+void GafferSceneBindings::bindPathMatcher()
 {
 	class_<PathMatcher>( "PathMatcher" )
 		.def( "__init__", make_constructor( constructFromObject ) )
@@ -132,5 +134,3 @@ void bindPathMatcher()
 		.def( self != self )
 	;
 }
-
-} // namespace GafferSceneBindings

--- a/src/GafferSceneBindings/PathMatcherDataBinding.cpp
+++ b/src/GafferSceneBindings/PathMatcherDataBinding.cpp
@@ -43,6 +43,17 @@
 using namespace boost::python;
 using namespace GafferScene;
 
+namespace
+{
+
+std::string pathMatcherDataRepr( object d )
+{
+	std::string p = extract<std::string>( d.attr( "value" ).attr( "__repr__" )() );
+	return "GafferScene.PathMatcherData( " + p + " )";
+}
+
+} // namespace
+
 namespace GafferSceneBindings
 {
 
@@ -54,6 +65,7 @@ void bindPathMatcherData()
 		.def( init<const PathMatcher &>() )
 		.add_property( "value", make_function( &PathMatcherData::writable, return_internal_reference<1>() ) )
 		.def( "hasBase", &PathMatcherData::hasBase ).staticmethod( "hasBase" )
+		.def( "__repr__", &pathMatcherDataRepr )
 	;
 
 }


### PR DESCRIPTION
This makes it possible to use the output of a FilterResults node in an expression, which opens ups all sorts of interesting possibilities - for instance driving a Wedge to perform a render from each camera, or a texture bake for each object matching a filter.