### PR TITLE
Dispatch GIL management fix

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -600,10 +600,10 @@ libraries = {
 
 	"GafferSceneTest" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "GafferScene" ],
+			"LIBS" : [ "Gaffer", "GafferDispatch", "GafferScene" ],
 		},
 		"pythonEnvAppends" : {
-			"LIBS" : [ "Gaffer", "GafferBindings", "GafferScene", "GafferSceneTest" ],
+			"LIBS" : [ "Gaffer", "GafferDispatch", "GafferBindings", "GafferScene", "GafferSceneTest" ],
 		},
 		"additionalFiles" : glob.glob( "python/GafferSceneTest/*/*" ),
 	},

--- a/include/GafferSceneTest/TraverseScene.h
+++ b/include/GafferSceneTest/TraverseScene.h
@@ -61,6 +61,9 @@ boost::signals::connection connectTraverseSceneToPlugDirtiedSignal( const Gaffer
 /// traversals will be triggered automatically from Context::changedSignal().
 boost::signals::connection connectTraverseSceneToContextChangedSignal( const GafferScene::ConstScenePlugPtr &scene, const Gaffer::ContextPtr &context );
 
+/// Arranges for traverseScene() to be called when Dispatcher::preDispatchSignal() is emitted.
+boost::signals::connection connectTraverseSceneToPreDispatchSignal( const GafferScene::ConstScenePlugPtr &scene );
+
 } // namespace GafferSceneTest
 
 #endif // GAFFERSCENETEST_TRAVERSESCENE_H

--- a/src/GafferDispatchBindings/DispatcherBinding.cpp
+++ b/src/GafferDispatchBindings/DispatcherBinding.cpp
@@ -241,6 +241,7 @@ void dispatch( Dispatcher &dispatcher, object pythonNodes )
 {
 	std::vector<NodePtr> nodes;
 	boost::python::container_utils::extend_container( nodes, pythonNodes );
+	IECorePython::ScopedGILRelease gilRelease;
 	dispatcher.dispatch( nodes );
 }
 

--- a/src/GafferDispatchBindings/TaskNodeBinding.cpp
+++ b/src/GafferDispatchBindings/TaskNodeBinding.cpp
@@ -107,7 +107,10 @@ void taskPlugExecuteSequence( const TaskNode::TaskPlug &t, const boost::python::
 boost::python::list taskPlugPreTasks( const TaskNode::TaskPlug &t )
 {
 	GafferDispatch::TaskNode::Tasks tasks;
-	t.preTasks( tasks );
+	{
+		IECorePython::ScopedGILRelease gilRelease;
+		t.preTasks( tasks );
+	}
 	boost::python::list result;
 	for( GafferDispatch::TaskNode::Tasks::const_iterator tIt = tasks.begin(); tIt != tasks.end(); ++tIt )
 	{
@@ -119,7 +122,10 @@ boost::python::list taskPlugPreTasks( const TaskNode::TaskPlug &t )
 boost::python::list taskPlugPostTasks( const TaskNode::TaskPlug &t )
 {
 	GafferDispatch::TaskNode::Tasks tasks;
-	t.postTasks( tasks );
+	{
+		IECorePython::ScopedGILRelease gilRelease;
+		t.postTasks( tasks );
+	}
 	boost::python::list result;
 	for( GafferDispatch::TaskNode::Tasks::const_iterator tIt = tasks.begin(); tIt != tasks.end(); ++tIt )
 	{

--- a/src/GafferSceneTest/TraverseScene.cpp
+++ b/src/GafferSceneTest/TraverseScene.cpp
@@ -36,6 +36,7 @@
 
 #include "boost/bind.hpp"
 
+#include "GafferDispatch/Dispatcher.h"
 #include "GafferScene/SceneAlgo.h"
 #include "GafferSceneTest/TraverseScene.h"
 
@@ -74,6 +75,12 @@ void traverseOnChanged( ConstScenePlugPtr scene, ConstContextPtr context )
 	traverseScene( scene.get() );
 }
 
+bool traverseOnPreDispatch( ConstScenePlugPtr scene )
+{
+	traverseScene( scene.get() );
+	return false;
+}
+
 } // namespace
 
 void GafferSceneTest::traverseScene( const GafferScene::ScenePlug *scenePlug )
@@ -102,3 +109,9 @@ boost::signals::connection GafferSceneTest::connectTraverseSceneToContextChanged
 {
 	return context->changedSignal().connect( boost::bind( &traverseOnChanged, scene, context ) );
 }
+
+boost::signals::connection GafferSceneTest::connectTraverseSceneToPreDispatchSignal( const GafferScene::ConstScenePlugPtr &scene )
+{
+	return GafferDispatch::Dispatcher::preDispatchSignal().connect( boost::bind( traverseOnPreDispatch, scene ) );
+}
+

--- a/src/GafferSceneTestModule/GafferSceneTestModule.cpp
+++ b/src/GafferSceneTestModule/GafferSceneTestModule.cpp
@@ -67,6 +67,7 @@ BOOST_PYTHON_MODULE( _GafferSceneTest )
 	def( "traverseScene", &traverseSceneWrapper );
 	def( "connectTraverseSceneToPlugDirtiedSignal", &connectTraverseSceneToPlugDirtiedSignal );
 	def( "connectTraverseSceneToContextChangedSignal", &connectTraverseSceneToContextChangedSignal );
+	def( "connectTraverseSceneToPreDispatchSignal", &connectTraverseSceneToPreDispatchSignal );
 
 	def( "testManyStringToPathCalls", &testManyStringToPathCalls );
 


### PR DESCRIPTION
This fixes hangs caused when a slot connected to `preDispatchSignal()` invokes a threaded graph computation.