### PR TITLE
Implement correspondingInput for OSLShader and ArnoldShader

### DIFF
--- a/arnold/plugins/gaffer.mtd
+++ b/arnold/plugins/gaffer.mtd
@@ -64,6 +64,7 @@
 
 [node flat]
 
+	primaryInput STRING "color"
 	gaffer.nodeMenu.category STRING "Surface"
 
 
@@ -323,6 +324,7 @@
 
 [node MayaBlendColors]
 
+	primaryInput STRING "color1"
 	gaffer.nodeMenu.category STRING "Maya/Color Utilities"
 
 
@@ -363,6 +365,7 @@
 
 [node MayaCondition]
 
+	primaryInput STRING "colorIfTrue"
 	gaffer.nodeMenu.category STRING "Maya/General Utilities"
 
 
@@ -418,6 +421,7 @@
 
 [node MayaHsvToRgb]
 
+  primaryInput STRING "inHsv"
 	gaffer.nodeMenu.category STRING "Maya/Color Utilities"
 
 
@@ -428,11 +432,13 @@
 
 [node MayaLayeredShader]
 
+	primaryInput STRING "color0"
 	gaffer.nodeMenu.category STRING "Maya/Surface"
 
 
 [node MayaLayeredTexture]
 
+	primaryInput STRING "color0"
 	gaffer.nodeMenu.category STRING "Maya/2D Textures"
 
 
@@ -443,6 +449,7 @@
 
 [node MayaMultiplyDivide]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Maya/General Utilities"
 
 
@@ -498,11 +505,13 @@
 
 [node MayaRemapColor]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Maya/Color Utilities"
 
 
 [node MayaRemapHsv]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Maya/Color Utilities"
 
 
@@ -518,11 +527,13 @@
 
 [node MayaReverse]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Maya/General Utilities"
 
 
 [node MayaRgbToHsv]
 
+	primaryInput STRING "inRgb"
 	gaffer.nodeMenu.category STRING "Maya/Color Utilities"
 
 
@@ -771,11 +782,13 @@
 
 [node htoa__abs]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__add]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -811,6 +824,7 @@
 
 [node htoa__atan]
 
+	primaryInput STRING "y"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -821,6 +835,7 @@
 
 [node htoa__cache]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Texture"
 
 
@@ -836,16 +851,19 @@
 
 [node htoa__clamp]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__color_convert]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Color Utilities"
 
 
 [node htoa__color_correct]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Color Utilities"
 
 
@@ -856,21 +874,25 @@
 
 [node htoa__complement]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__composite]
 
+	primaryInput STRING "B"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__cross]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__curvature]
 
+	primaryInput STRING "color1"
 	gaffer.nodeMenu.category STRING "Houdini/General Utilities"
 
 
@@ -881,6 +903,7 @@
 
 [node htoa__divide]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -891,6 +914,7 @@
 
 [node htoa__exp]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -921,6 +945,7 @@
 
 [node htoa__fraction]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -941,16 +966,19 @@
 
 [node htoa__linearize]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__ln]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__log]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -976,6 +1004,7 @@
 
 [node htoa__matrix_multiply]
 
+	primaryInput STRING "m1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -996,56 +1025,66 @@
 
 [node htoa__matte]
 
+	primaryInput STRING "passthrough"
 	gaffer.nodeMenu.category STRING "Houdini/General Utilities"
 
 
 [node htoa__max]
-
+      
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__min]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__mix]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__modulo]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__multiply]
-
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__negate]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__normalize]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__passthrough]
 
+	primaryInput STRING "passthrough"
 	gaffer.nodeMenu.category STRING "Houdini/General Utilities"
 
 
 [node htoa__pow]
 
+	primaryInput STRING "base"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__print]
 
+	primaryInput STRING "passthrough"
 	gaffer.nodeMenu.category STRING "Houdini/General Utilities"
 
 
@@ -1061,16 +1100,19 @@
 
 [node htoa__random]
 
+	primaryInput STRING "input_color"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__range]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__reciprocal]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -1101,6 +1143,7 @@
 
 [node htoa__sign]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -1116,6 +1159,7 @@
 
 [node htoa__sqrt]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -1151,6 +1195,7 @@
 
 [node htoa__switch]
 
+	primaryInput STRING "input0"
 	gaffer.nodeMenu.category STRING "Houdini/General Utilities"
 
 
@@ -1166,6 +1211,7 @@
 
 [node htoa__trigo]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -1254,21 +1300,25 @@
 
 [node alColorSpace]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
 [node alCombineColor]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
 [node alCombineFloat]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
 [node alCurvature]
 
+	primaryInput STRING "color1"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
@@ -1314,31 +1364,37 @@
 
 [node alLayer]
 
+	primaryInput STRING "layer1"
 	gaffer.nodeMenu.category STRING "Surface"
 
 
 [node alLayerColor]
 
+	primaryInput STRING "layer1"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
 [node alLayerFloat]
 
+	primaryInput STRING "layer1"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
 [node alPattern]
 
+	primaryInput STRING "color1"
 	gaffer.nodeMenu.category STRING "Texture"
 
 
 [node alRemapColor]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
 [node alRemapFloat]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
@@ -1349,14 +1405,16 @@
 
 [node alSwitchColor]
 
+	primaryInput STRING "inputA"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
 [node alSwitchFloat]
 
+	primaryInput STRING "inputA"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
-	[node alTriplanar]
+[node alTriplanar]
 
 	gaffer.nodeMenu.category STRING "Texture"

--- a/include/GafferArnold/ArnoldShader.h
+++ b/include/GafferArnold/ArnoldShader.h
@@ -55,11 +55,24 @@ class ArnoldShader : public GafferScene::Shader
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferArnold::ArnoldShader, ArnoldShaderTypeId, GafferScene::Shader );
 
+		/// Implemented for outPlug(), returning the parameter named in the "primaryInput"
+		/// shader annotation if it has been specified.
+		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output );
+		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
+
 		/// \todo Remove this version, and add `keepExistingValues = false` default
 		/// to version below.
 		void loadShader( const std::string &shaderName );
 		void loadShader( const std::string &shaderName, bool keepExistingValues );
 
+	private :
+
+		// Shader metadata is stored in a "shader" member of the result and
+		// parameter metadata is stored indexed by name inside a
+		// "parameter" member of the result.
+		const IECore::CompoundData *metadata() const;
+
+		mutable IECore::ConstCompoundDataPtr m_metadata;
 };
 
 IE_CORE_DECLAREPTR( ArnoldShader )

--- a/include/GafferOSL/OSLShader.h
+++ b/include/GafferOSL/OSLShader.h
@@ -56,6 +56,10 @@ class OSLShader : public GafferScene::Shader
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferOSL::OSLShader, OSLShaderTypeId, GafferScene::Shader );
 
+		/// Returns a plug based on the "correspondingInput" metadata of each output plug
+		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output );
+		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
+
 		/// \undoable.
 		/// \todo Make this method virtual and define it on the Shader base class.
 		void loadShader( const std::string &shaderName, bool keepExistingValues=false );

--- a/python/GafferTest/NodeTest.py
+++ b/python/GafferTest/NodeTest.py
@@ -349,5 +349,6 @@ class NodeTest( GafferTest.TestCase ) :
 		s.addChild( n )
 		assertConnections()
 
+
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -1298,5 +1298,54 @@ a = A()"""
 			self.assertEqual( mh.messages[0].context, "Line 2 of " + fileName )
 			self.assertTrue( "NameError: name 'iDontExist' is not defined" in mh.messages[0].message )
 
+	def testReconnectionOfChildPlug( self ) :
+		class NestedPlugsNode( Gaffer.DependencyNode ) :
+			def __init__( self, name = "NestedOutputNode" ) :
+				Gaffer.DependencyNode.__init__( self, name )
+
+				self["in"] = Gaffer.Plug()
+				self["in"]["a"] = Gaffer.IntPlug()
+				self["in"]["b"] = Gaffer.IntPlug()
+
+				self["out"] = Gaffer.Plug( direction = Gaffer.Plug.Direction.Out )
+				self["out"]["a"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
+				self["out"]["b"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
+
+			def correspondingInput( self, output ) :
+
+				if output.isSame( self["out"] ) :
+					return self["in"]
+
+				if output.isSame( self["out"]["a"] ) :
+					return self["in"]["a"]
+
+				if output.isSame( self["out"]["b"] ) :
+					return self["in"]["b"]
+
+				return Gaffer.DependencyNode.correspondingInput( self, output )
+
+		s = Gaffer.ScriptNode()
+
+		s["n1"] = NestedPlugsNode()
+		s["n2"] = NestedPlugsNode()
+		s["n3"] = NestedPlugsNode()
+
+		# check top level connection
+		s["n2"]["in"].setInput( s["n1"]["out"] )
+		s["n3"]["in"].setInput( s["n2"]["out"] )
+
+		s.deleteNodes( filter = Gaffer.StandardSet( [ s["n2"] ] ) )
+		self.assertTrue( s["n3"]["in"].getInput().isSame( s["n1"]["out"] ) )
+
+		# check connection for nested plug
+		s["n4"] = NestedPlugsNode()
+		s["n3"]["in"].setInput( None )
+		s["n3"]["in"]["a"].setInput( s["n1"]["out"]["a"] )
+		s["n4"]["in"]["a"].setInput( s["n3"]["out"]["a"] )
+
+		s.deleteNodes( filter = Gaffer.StandardSet( [ s["n3"] ] ) )
+		self.assertTrue( s["n4"]["in"]["a"].getInput().isSame( s["n1"]["out"]["a"] ) )
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/shaders/Maths/FloatAdd.osl
+++ b/shaders/Maths/FloatAdd.osl
@@ -38,7 +38,7 @@ shader FloatAdd
 (
 	float a = 0,
 	float b = 0,
-	output float out = 0
+	output float out = 0 [[ string correspondingInput = "a" ]]
 )
 {
 	out = a + b;

--- a/shaders/Maths/FloatMix.osl
+++ b/shaders/Maths/FloatMix.osl
@@ -39,7 +39,7 @@ shader FloatMix
 	float a = 0,
 	float b = 0,
 	float m = 0,
-	output float out = 0
+	output float out = 0 [[ string correspondingInput = "a" ]]
 )
 {
 	out = mix( a, b, m );

--- a/shaders/Maths/FloatMultiply.osl
+++ b/shaders/Maths/FloatMultiply.osl
@@ -38,7 +38,7 @@ shader FloatMultiply
 (
 	float a = 0,
 	float b = 0,
-	output float out = 0
+	output float out = 0 [[ string correspondingInput = "a" ]]
 )
 {
 	out = a * b;

--- a/shaders/Maths/VectorAdd.osl
+++ b/shaders/Maths/VectorAdd.osl
@@ -38,7 +38,7 @@ shader VectorAdd
 (
 	vector a = 0,
 	vector b = 0,
-	output vector out = 0
+	output vector out = 0 [[ string correspondingInput = "a" ]]
 )
 {
 	out = a + b;

--- a/shaders/Maths/VectorMix.osl
+++ b/shaders/Maths/VectorMix.osl
@@ -39,7 +39,7 @@ shader VectorMix
 	vector a = 0,
 	vector b = 0,
 	float m = 0,
-	output vector out = 0
+	output vector out = 0 [[ string correspondingInput = "a" ]]
 )
 {
 	out = mix( a, b, m );

--- a/shaders/Maths/VectorMultiply.osl
+++ b/shaders/Maths/VectorMultiply.osl
@@ -38,7 +38,7 @@ shader VectorMultiply
 (
 	vector a = 0,
 	float b = 0,
-	output vector out = 0
+	output vector out = 0 [[ string correspondingInput = "a" ]]
 )
 {
 	out = a * b;

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -549,7 +549,7 @@ void ScriptNode::deleteNodes( Node *parent, const Set *filter, bool reconnect )
 			DependencyNode *dependencyNode = IECore::runTimeCast<DependencyNode>( node );
 			if( reconnect && dependencyNode )
 			{
-				for( OutputPlugIterator it( node ); !it.done(); ++it )
+				for( RecursiveOutputPlugIterator it( node ); !it.done(); ++it )
 				{
 					Plug *inPlug = dependencyNode->correspondingInput( it->get() );
 					if ( !inPlug )
@@ -566,17 +566,12 @@ void ScriptNode::deleteNodes( Node *parent, const Set *filter, bool reconnect )
 					// record this plug's current outputs, and reconnect them. This is a copy of (*it)->outputs() rather
 					// than a reference, as reconnection can modify (*it)->outputs()...
 					Plug::OutputContainer outputs = (*it)->outputs();
-					for ( Plug::OutputContainer::const_iterator oIt = outputs.begin(); oIt != outputs.end(); )
+					for ( Plug::OutputContainer::const_iterator oIt = outputs.begin(); oIt != outputs.end(); ++oIt )
 					{
 						Plug *dstPlug = *oIt;
 						if ( dstPlug && dstPlug->acceptsInput( srcPlug ) && this->isAncestorOf( dstPlug ) )
 						{
-							oIt++;
 							dstPlug->setInput( srcPlug );
-						}
-						else
-						{
-							oIt++;
 						}
 					}
 				}

--- a/src/GafferArnold/ArnoldShader.cpp
+++ b/src/GafferArnold/ArnoldShader.cpp
@@ -40,6 +40,7 @@
 #include "ai.h"
 
 #include "IECore/MessageHandler.h"
+#include "IECore/LRUCache.h"
 
 #include "IECoreArnold/UniverseBlock.h"
 
@@ -67,6 +68,43 @@ ArnoldShader::ArnoldShader( const std::string &name )
 
 ArnoldShader::~ArnoldShader()
 {
+}
+
+Gaffer::Plug *ArnoldShader::correspondingInput( const Gaffer::Plug *output )
+{
+	// better to do a few harmless casts than manage a duplicate implementation
+	return const_cast<Gaffer::Plug *>(
+		const_cast<const ArnoldShader *>( this )->correspondingInput( output )
+	);
+}
+
+const Gaffer::Plug *ArnoldShader::correspondingInput( const Gaffer::Plug *output ) const
+{
+	if( output != outPlug() )
+	{
+		return Shader::correspondingInput( output );
+	}
+
+	const CompoundData *metadata = ArnoldShader::metadata();
+	if( !metadata )
+	{
+		return NULL;
+	}
+
+	const StringData *primaryInput = static_cast<const StringData*>( metadata->member<IECore::CompoundData>( "shader" )->member<IECore::Data>( "primaryInput" ) );
+	if( !primaryInput )
+	{
+		return NULL;
+	}
+
+	const Plug *result = parametersPlug()->getChild<Plug>( primaryInput->readable() );
+	if( !result )
+	{
+		IECore::msg( IECore::Msg::Error, "ArnoldShader::correspondingInput", boost::format( "Parameter \"%s\" does not exist" ) % primaryInput->readable() );
+		return NULL;
+	}
+
+	return result;
 }
 
 void ArnoldShader::loadShader( const std::string &shaderName )
@@ -102,4 +140,52 @@ void ArnoldShader::loadShader( const std::string &shaderName, bool keepExistingV
 	ParameterHandler::setupPlugs( shader, parametersPlug() );
 	ParameterHandler::setupPlug( "out", isLightShader ? AI_TYPE_POINTER : AiNodeEntryGetOutputType( shader ), this, Plug::Out );
 
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Metadata loading code
+//////////////////////////////////////////////////////////////////////////
+
+static IECore::ConstCompoundDataPtr metadataGetter( const std::string &key, size_t &cost )
+{
+	IECoreArnold::UniverseBlock arnoldUniverse( /* writable = */ false );
+
+	const AtNodeEntry *shader = AiNodeEntryLookUp( key.c_str() );
+	if( !shader )
+	{
+		throw Exception( str( format( "Shader \"%s\" not found" ) % key ) );
+	}
+
+	CompoundDataPtr metadata = new CompoundData;
+
+	CompoundDataPtr shaderMetadata = new CompoundData;
+	metadata->writable()["shader"] = shaderMetadata;
+
+	// Currently we don't store metadata for parameters.
+	// We add the "parameter" CompoundData mainly so that we are consistent with the OSLShader.
+	// Eventually we will load all metadata here and access it from ArnoldShaderUI.
+	CompoundDataPtr parameterMetadata = new CompoundData;
+	metadata->writable()["parameter"] = parameterMetadata;
+
+	const char* value;
+	if( AiMetaDataGetStr( shader, /* look up metadata on node, not on parameter */ NULL , "primaryInput", &value ) )
+	{
+		shaderMetadata->writable()["primaryInput"] = new StringData( value );
+	}
+
+	return metadata;
+}
+
+typedef LRUCache<std::string, IECore::ConstCompoundDataPtr> MetadataCache;
+MetadataCache g_arnoldMetadataCache( metadataGetter, 10000 );
+
+const IECore::CompoundData *ArnoldShader::metadata() const
+{
+	if( m_metadata )
+	{
+		return m_metadata.get();
+	}
+
+	m_metadata = g_arnoldMetadataCache.get( namePlug()->getValue() );
+	return m_metadata.get();
 }

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -98,26 +98,26 @@ const Gaffer::Plug *RenderManShader::correspondingInput( const Gaffer::Plug *out
 	ConstCompoundDataPtr ann = annotations();
 	if( !ann )
 	{
-		return 0;
+		return NULL;
 	}
 
 	const StringData *primaryInput = ann->member<StringData>( "primaryInput" );
 	if( !primaryInput )
 	{
-		return 0;
+		return NULL;
 	}
 
 	const Plug *result = parametersPlug()->getChild<Plug>( primaryInput->readable() );
 	if( !result )
 	{
 		IECore::msg( IECore::Msg::Error, "RenderManShader::correspondingInput", boost::format( "Parameter \"%s\" does not exist" ) % primaryInput->readable() );
-		return 0;
+		return NULL;
 	}
 
 	if( result->typeId() != Gaffer::Plug::staticTypeId() )
 	{
 		IECore::msg( IECore::Msg::Error, "RenderManShader::correspondingInput", boost::format( "Parameter \"%s\" is not of type shader" ) % primaryInput->readable() );
-		return 0;
+		return NULL;
 	}
 
 	return result;
@@ -662,7 +662,7 @@ static IECore::FloatVectorDataPtr parseFloats( const std::string &value )
 
 	if( !r || first != value.end() )
 	{
-		return 0;
+		return NULL;
 	}
 
 	return result;
@@ -726,7 +726,7 @@ static IECore::Color3fVectorDataPtr parseColors( const std::string &value )
 
 	if( !r || first != value.end() )
 	{
-		return 0;
+		return NULL;
 	}
 	return result;
 }


### PR DESCRIPTION
Hey John,

here's my first stab at implementing `correspondingInput()` for the two shader types. I think it should be pretty close to what we were discussing last week. 

The multiple outputs of OSLShader nodes are still a little problematic. I did add code that is able to reconnect nodes when a node is deleted in `ScriptNode::deleteNodes` - that should work already.
Dragging an OSLShader with multiple outputs onto connections is a little funny, though. Maybe you could test whether the current behavior is what you want. I've been testing with instances of an artificial node that just connect multiple outputs to multiple inputs. I kinda assumed that a node that I drag onto the connections between two other nodes should just make all necessary connections and not just one. The current implementation in `GraphGadget::updateDragReconnectCandidate` doesn't really allow that kind of behavior though, I think.

As for the actual metadata that I'm adding in this PR - I guess there'll be a few iterations to get the behavior that people want. I went through all of the nodes and added the tags that I thought make sense, but I might have missed something.

I'm sure there's a couple of things that you want changed in the implementation too. Let me know what you want revised :)

Matti.

