### PR TITLE
References - Reconnecting output connections even for input plugs

### DIFF
--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -130,12 +130,14 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s2 = Gaffer.ScriptNode()
 		s2["n1"] = GafferTest.AddNode()
 		s2["n3"] = GafferTest.AddNode()
+		s2["n4"] = GafferTest.AddNode()
 		s2["r"] = Gaffer.Reference()
 		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		s2["r"]["op1"].setInput( s2["n1"]["sum"] )
 		s2["r"]["op2"].setValue( 1001 )
 		s2["n3"]["op1"].setInput( s2["r"]["sum"] )
+		s2["n4"]["op1"].setInput( s2["r"]["op2"] )
 
 		self.assertTrue( "n2" in s2["r"] )
 		self.assertTrue( s2["r"]["n2"]["op1"].getInput().isSame( s2["r"]["op1"] ) )
@@ -144,6 +146,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertTrue( s2["r"]["sum"].getInput().isSame( s2["r"]["n2"]["sum"] ) )
 		self.assertTrue( s2["r"]["op1"].getInput().isSame( s2["n1"]["sum"] ) )
 		self.assertTrue( s2["n3"]["op1"].getInput().isSame( s2["r"]["sum"] ) )
+		self.assertTrue( s2["n4"]["op1"].getInput() and s2["n4"]["op1"].getInput().isSame( s2["r"]["op2"] ) )
 		originalReferencedNames = s2["r"].keys()
 
 		b["anotherNode"] = GafferTest.AddNode()
@@ -161,6 +164,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertTrue( s2["r"]["sum"].getInput().isSame( s2["r"]["n2"]["sum"] ) )
 		self.assertTrue( s2["r"]["op1"].getInput().isSame( s2["n1"]["sum"] ) )
 		self.assertTrue( s2["n3"]["op1"].getInput().isSame( s2["r"]["sum"] ) )
+		self.assertTrue( s2["n4"]["op1"].getInput() and s2["n4"]["op1"].getInput().isSame( s2["r"]["op2"] ) )
 
 	def testReloadDoesntRemoveCustomPlugs( self ) :
 

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -229,14 +229,11 @@ void Reference::loadInternal( const std::string &fileName )
 						}
 					}
 				}
-				else if( newPlug->direction() == Plug::Out && oldPlug->direction() == Plug::Out )
+				for( Plug::OutputContainer::const_iterator oIt = oldPlug->outputs().begin(), oeIt = oldPlug->outputs().end(); oIt != oeIt;  )
 				{
-					for( Plug::OutputContainer::const_iterator oIt = oldPlug->outputs().begin(), oeIt = oldPlug->outputs().end(); oIt != oeIt;  )
-					{
-						Plug *outputPlug = *oIt;
-						++oIt; // increment now because the setInput() call invalidates our iterator.
-						outputPlug->setInput( newPlug );
-					}
+					Plug *outputPlug = *oIt;
+					++oIt; // increment now because the setInput() call invalidates our iterator.
+					outputPlug->setInput( newPlug );
 				}
 				transferPersistentMetadata( oldPlug, newPlug );
 			}


### PR DESCRIPTION
Reloading a reference when one of its promoted plugs (which is an input plug) was set as the input for another plug, broke the connection.

That's because we were only considering the output connections on plugs for plugs for which the direction was set to output, which was too strict (I think), given that plugs with the direction input can in fact be used as the input for other plugs.
