### PR TITLE
ImageWriterTest : Remove `testMultipleWrite()`.

### DIFF
--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -318,23 +318,6 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual( w["webp"]["compressionQuality"].getValue(), 100 )
 
-	def testMultipleWrite( self ) :
-
-		r = GafferImage.ImageReader()
-		r["fileName"].setValue( self.__largeFilePath )
-
-		for i in range( 20 ) :
-			r['refreshCount'].setValue( r['refreshCount'].getValue() + 1 )
-
-			testFile = self.__testFile( "multiple_{}".format( i ), "RGBA", "exr" )
-
-			w = GafferImage.ImageWriter()
-			w["in"].setInput( r["out"] )
-			w["fileName"].setValue( testFile )
-
-			with Gaffer.Context() :
-				w["task"].execute()
-
 	# Write an RGBA image that has a data window to various supported formats and in both scanline and tile modes.
 	def __testExtension( self, ext, formatName, options = {}, metadataToIgnore = [] ) :
 


### PR DESCRIPTION
Opened issue #1923 to track the problem in detail. Is there an emoji for hanging your head in shame?