### PR TITLE
GafferScene : Added render:sampleMotion parameter, with Arnold support

### DIFF
--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -103,6 +103,7 @@ class Renderer : public IECore::RefCounted
 		///
 		/// "camera", StringData, "", The name of the primary render camera.
 		/// "frame", IntData, 1, The frame being rendered.
+		/// "sampleMotion", BoolData, true, Whether to actually render motion blur.  Disable to render with motion blocks set up but no real blur.
 		virtual void option( const IECore::InternedString &name, const IECore::Data *value ) = 0;
 		/// Adds an output image to be rendered, In interactive renders an output may be
 		/// removed by passing NULL as the value.

--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -315,6 +315,20 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"options.sampleMotion" : [
+
+			"description",
+			"""
+			Whether to actually render motion blur.  Disabling this
+			setting while motion blur is set up produces a render where
+			there is no blur, but there is accurate motion information.
+			Useful for rendering motion vector passes.
+			""",
+
+			"layout:section", "Motion Blur",
+
+		],
+
 		# Statistics plugs
 
 		"options.performanceMonitor" : [

--- a/src/GafferScene/StandardOptions.cpp
+++ b/src/GafferScene/StandardOptions.cpp
@@ -67,6 +67,7 @@ StandardOptions::StandardOptions( const std::string &name )
 	options->addOptionalMember( "render:transformBlur", new IECore::BoolData( false ), "transformBlur", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "render:deformationBlur", new IECore::BoolData( false ), "deformationBlur", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "render:shutter", new IECore::V2fData( Imath::V2f( -0.25, 0.25 ) ), "shutter", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "sampleMotion", new IECore::BoolData( true ), "sampleMotion", Gaffer::Plug::Default, false );
 
 	// Statistics
 


### PR DESCRIPTION
It will also support RenderMan, but this requires a Cortex update.  To make it easier to potentially roll this out quickly, I've tagged the RenderMan test case as an expected failure for the moment.

Following John's last suggestion, this seems pretty straightforward, but there is one last wrinkle:  what time do we want to use as the shutter when sampleMotion is disabled.  The two possibilities are "on frame" and "shutter open".  For example, if rendering frame 17, we would usually use a shutter something like [ 16.75, 17.25 ].  "on frame" would be 17.0, "shutter open" would be 16.75.

"on frame" pros:
* probably the closest to what artists would expect ( closest to rendering without motion blur )
* probably higher quality blur in post ( if your actual data is in the middle and you blur to both sides, you don't introduce as much error as starting from one side and blurring twice as far )

"on frame" cons:
* does not match RenderMan's "sampleMotion" hider option, which uses shutter open
* only produces an exact match to rendering without motion blur if you write out a motion sample on the frame.  If you render with a centered shutter with a single motion segment, then your "on frame" value is actually the result of interpolating the beginning and end.  This is OK as long as you render all your images the same way, but it's not any less confusing than the shift to shutter open time.  On the other hand, if you use two motion segments, then the result evaluating in the middle would match rendering without motion blur.

What do you think, John?  Does it matter if this feature behaves the same way across renderers?  Should we match the RenderMan implementation even if it produces potentially lower quality results?  ( I do have some other ideas that might help reduce the need for ever using post blur at IE anyway ).
