### PR TITLE
IECoreArnoldPreview::Renderer : Don't instance ass archives.

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -604,6 +604,16 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 					return m_polyMesh.subdivAdaptiveError == 0.0f || m_polyMesh.subdivAdaptiveSpace == g_objectSpace;
 				}
 			}
+			else if( const IECore::ExternalProcedural *procedural = IECore::runTimeCast<const IECore::ExternalProcedural>( object ) )
+			{
+				// We don't instance "ass archive" procedurals, because Arnold
+				// does automatic instancing of those itself, using its procedural
+				// cache.
+				return (
+					!boost::ends_with( procedural->getFileName(), ".ass" ) &&
+					!boost::ends_with( procedural->getFileName(), ".ass.gz" )
+				);
+			}
 
 			return true;
 		}


### PR DESCRIPTION
This is for two reasons :

- There's no point, because Arnold's procedural cache already does automatic instancing anyway.
- Explicitly instancing a procedural triggers a crash bug when Arnold's procedural cache is in use (tested in Arnold 4.2.15.1)