### PR TITLE
Shader refactoring

### DIFF
--- a/arnold/plugins/gaffer.mtd
+++ b/arnold/plugins/gaffer.mtd
@@ -64,6 +64,7 @@
 
 [node flat]
 
+	primaryInput STRING "color"
 	gaffer.nodeMenu.category STRING "Surface"
 
 
@@ -323,6 +324,7 @@
 
 [node MayaBlendColors]
 
+	primaryInput STRING "color1"
 	gaffer.nodeMenu.category STRING "Maya/Color Utilities"
 
 
@@ -363,6 +365,7 @@
 
 [node MayaCondition]
 
+	primaryInput STRING "colorIfTrue"
 	gaffer.nodeMenu.category STRING "Maya/General Utilities"
 
 
@@ -418,6 +421,7 @@
 
 [node MayaHsvToRgb]
 
+  primaryInput STRING "inHsv"
 	gaffer.nodeMenu.category STRING "Maya/Color Utilities"
 
 
@@ -428,11 +432,13 @@
 
 [node MayaLayeredShader]
 
+	primaryInput STRING "color0"
 	gaffer.nodeMenu.category STRING "Maya/Surface"
 
 
 [node MayaLayeredTexture]
 
+	primaryInput STRING "color0"
 	gaffer.nodeMenu.category STRING "Maya/2D Textures"
 
 
@@ -443,6 +449,7 @@
 
 [node MayaMultiplyDivide]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Maya/General Utilities"
 
 
@@ -498,11 +505,13 @@
 
 [node MayaRemapColor]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Maya/Color Utilities"
 
 
 [node MayaRemapHsv]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Maya/Color Utilities"
 
 
@@ -518,11 +527,13 @@
 
 [node MayaReverse]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Maya/General Utilities"
 
 
 [node MayaRgbToHsv]
 
+	primaryInput STRING "inRgb"
 	gaffer.nodeMenu.category STRING "Maya/Color Utilities"
 
 
@@ -771,11 +782,13 @@
 
 [node htoa__abs]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__add]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -811,6 +824,7 @@
 
 [node htoa__atan]
 
+	primaryInput STRING "y"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -821,6 +835,7 @@
 
 [node htoa__cache]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Texture"
 
 
@@ -836,16 +851,19 @@
 
 [node htoa__clamp]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__color_convert]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Color Utilities"
 
 
 [node htoa__color_correct]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Color Utilities"
 
 
@@ -856,21 +874,25 @@
 
 [node htoa__complement]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__composite]
 
+	primaryInput STRING "A"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__cross]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__curvature]
 
+	primaryInput STRING "color1"
 	gaffer.nodeMenu.category STRING "Houdini/General Utilities"
 
 
@@ -881,6 +903,7 @@
 
 [node htoa__divide]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -891,6 +914,7 @@
 
 [node htoa__exp]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -921,6 +945,7 @@
 
 [node htoa__fraction]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -941,16 +966,19 @@
 
 [node htoa__linearize]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__ln]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__log]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -976,6 +1004,7 @@
 
 [node htoa__matrix_multiply]
 
+	primaryInput STRING "m1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -996,56 +1025,66 @@
 
 [node htoa__matte]
 
+	primaryInput STRING "passthrough"
 	gaffer.nodeMenu.category STRING "Houdini/General Utilities"
 
 
 [node htoa__max]
-
+      
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__min]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__mix]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__modulo]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__multiply]
-
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__negate]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__normalize]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__passthrough]
 
+	primaryInput STRING "passthrough"
 	gaffer.nodeMenu.category STRING "Houdini/General Utilities"
 
 
 [node htoa__pow]
 
+	primaryInput STRING "base"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__print]
 
+	primaryInput STRING "passthrough"
 	gaffer.nodeMenu.category STRING "Houdini/General Utilities"
 
 
@@ -1061,16 +1100,19 @@
 
 [node htoa__random]
 
+	primaryInput STRING "input_color"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__range]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
 [node htoa__reciprocal]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -1101,6 +1143,7 @@
 
 [node htoa__sign]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -1116,6 +1159,7 @@
 
 [node htoa__sqrt]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -1151,6 +1195,7 @@
 
 [node htoa__switch]
 
+	primaryInput STRING "input0"
 	gaffer.nodeMenu.category STRING "Houdini/General Utilities"
 
 
@@ -1166,6 +1211,7 @@
 
 [node htoa__trigo]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
 
@@ -1254,21 +1300,25 @@
 
 [node alColorSpace]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
 [node alCombineColor]
 
+	primaryInput STRING "a"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
 [node alCombineFloat]
 
+	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
 [node alCurvature]
 
+	primaryInput STRING "color1"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
@@ -1314,31 +1364,37 @@
 
 [node alLayer]
 
+	primaryInput STRING "layer1"
 	gaffer.nodeMenu.category STRING "Surface"
 
 
 [node alLayerColor]
 
+	primaryInput STRING "layer1"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
 [node alLayerFloat]
 
+	primaryInput STRING "layer1"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
 [node alPattern]
 
+	primaryInput STRING "color1"
 	gaffer.nodeMenu.category STRING "Texture"
 
 
 [node alRemapColor]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
 [node alRemapFloat]
 
+	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
@@ -1349,14 +1405,16 @@
 
 [node alSwitchColor]
 
+	primaryInput STRING "inputA"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
 [node alSwitchFloat]
 
+	primaryInput STRING "inputA"
 	gaffer.nodeMenu.category STRING "Utility"
 
 
-	[node alTriplanar]
+[node alTriplanar]
 
 	gaffer.nodeMenu.category STRING "Texture"

--- a/include/GafferArnold/ArnoldShader.h
+++ b/include/GafferArnold/ArnoldShader.h
@@ -55,11 +55,29 @@ class ArnoldShader : public GafferScene::Shader
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferArnold::ArnoldShader, ArnoldShaderTypeId, GafferScene::Shader );
 
+		/// Implemented for outPlug(), returning the parameter named in the "primaryInput"
+		/// shader annotation if it has been specified.
+		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output );
+		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
+
 		/// \todo Remove this version, and add `keepExistingValues = false` default
 		/// to version below.
 		void loadShader( const std::string &shaderName );
 		void loadShader( const std::string &shaderName, bool keepExistingValues );
 
+		/// Returns an Arnold metadata item from the shader.
+		const IECore::Data *shaderMetadata( const IECore::InternedString &name ) const;
+		/// Returns an Arnold metadata item from the specified shader parameter.
+		const IECore::Data *parameterMetadata( const Gaffer::Plug *plug, const IECore::InternedString &name ) const;
+
+	private :
+
+		// Shader metadata is stored in a "shader" member of the result and
+		// parameter metadata is stored indexed by name inside a
+		// "parameter" member of the result.
+		const IECore::CompoundData *metadata() const;
+
+		mutable IECore::ConstCompoundDataPtr m_metadata;
 };
 
 IE_CORE_DECLAREPTR( ArnoldShader )

--- a/include/GafferOSL/OSLShader.h
+++ b/include/GafferOSL/OSLShader.h
@@ -56,6 +56,10 @@ class OSLShader : public GafferScene::Shader
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferOSL::OSLShader, OSLShaderTypeId, GafferScene::Shader );
 
+		/// Returns a plug based on the "correspondingInput" metadata of each output plug
+		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output );
+		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
+
 		/// \undoable.
 		/// \todo Make this method virtual and define it on the Shader base class.
 		void loadShader( const std::string &shaderName, bool keepExistingValues=false );

--- a/include/GafferRenderMan/RenderManShader.h
+++ b/include/GafferRenderMan/RenderManShader.h
@@ -75,9 +75,6 @@ class RenderManShader : public GafferScene::Shader
 
 		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
 
-		virtual void parameterHash( const Gaffer::Plug *parameterPlug, NetworkBuilder &network, IECore::MurmurHash &h ) const;
-		virtual IECore::DataPtr parameterValue( const Gaffer::Plug *parameterPlug, NetworkBuilder &network ) const;
-
 		const IECore::ConstCompoundDataPtr annotations() const;
 
 	private :

--- a/include/GafferScene/OpenGLShader.h
+++ b/include/GafferScene/OpenGLShader.h
@@ -57,8 +57,8 @@ class OpenGLShader : public GafferScene::Shader
 	protected :
 
 		/// Reimplemented to allow ImageNodes to be plugged in to texture parameters.
-		virtual void parameterHash( const Gaffer::Plug *parameterPlug, NetworkBuilder &network, IECore::MurmurHash &h ) const;
-		virtual IECore::DataPtr parameterValue( const Gaffer::Plug *parameterPlug, NetworkBuilder &network ) const;
+		virtual void parameterHash( const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h ) const;
+		virtual IECore::DataPtr parameterValue( const Gaffer::Plug *parameterPlug ) const;
 
 };
 

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -133,20 +133,21 @@ class Shader : public Gaffer::DependencyNode
 				IECore::ConstObjectVectorPtr state();
 
 				IECore::MurmurHash shaderHash( const Shader *shaderNode );
-				/// May return an empty string if a shader has been disabled.
-				const std::string &shaderHandle( const Shader *shaderNode );
+				IECore::Shader *shader( const Shader *shaderNode );
 
 			private :
 
 				NetworkBuilder();
 
-				// Returns the node that should be used taking into account
-				// enabledPlug() and correspondingInput().
-				const Shader *effectiveNode( const Shader *shaderNode ) const;
-				IECore::Shader *shader( const Shader *shaderNode );
+				// Returns the effective shader parameter that should be used taking into account
+				// enabledPlug() and correspondingInput(). Accepts either output or input parameters
+				// and may return either an output or input parameter.
+				const Gaffer::Plug *effectiveParameter( const Gaffer::Plug *parameterPlug ) const;
 
-				void parameterHashWalk( const Shader *shaderNode, const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h );
-				void parameterValueWalk( const Shader *shaderNode, const Gaffer::Plug *parameterPlug, const IECore::InternedString &parameterName, IECore::CompoundDataMap &values );
+				const std::string &shaderHandle( const Shader *shaderNode );
+
+				void parameterHashWalk( const Gaffer::Plug *parameter, IECore::MurmurHash &h );
+				void parameterValueWalk( const Gaffer::Plug *parameter, const IECore::InternedString &parameterName, IECore::CompoundDataMap &values );
 				bool isLeafParameter( const Gaffer::Plug *parameterPlug ) const;
 
 				const Shader *m_rootNode;
@@ -173,8 +174,7 @@ class Shader : public Gaffer::DependencyNode
 		/// to deal with special cases, in which case parameterValue() should be reimplemented too.
 		virtual void parameterHash( const Gaffer::Plug *parameterPlug, NetworkBuilder &network, IECore::MurmurHash &h ) const;
 		/// Called for each parameter plug when constructing an IECore::Shader from this node.
-		/// May be reimplemented in derived classes to deal with special cases, and must currently
-		/// be reimplemented to deal with shader connections.
+		/// May be reimplemented in derived classes to deal with special cases.
 		virtual IECore::DataPtr parameterValue( const Gaffer::Plug *parameterPlug, NetworkBuilder &network ) const;
 
 	private :

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -47,6 +47,7 @@
 #include "Gaffer/DependencyNode.h"
 #include "Gaffer/TypedPlug.h"
 #include "Gaffer/CompoundNumericPlug.h"
+#include "Gaffer/ArrayPlug.h"
 
 #include "GafferScene/TypeIds.h"
 
@@ -145,9 +146,17 @@ class Shader : public Gaffer::DependencyNode
 				const Gaffer::Plug *effectiveParameter( const Gaffer::Plug *parameterPlug ) const;
 
 				const std::string &shaderHandle( const Shader *shaderNode );
+				std::string link( const Shader *shaderNode, const Gaffer::Plug *outputParameter );
 
 				void parameterHashWalk( const Gaffer::Plug *parameter, IECore::MurmurHash &h );
 				void parameterValueWalk( const Gaffer::Plug *parameter, const IECore::InternedString &parameterName, IECore::CompoundDataMap &values );
+
+				void parameterHash( const Gaffer::Plug *parameter, IECore::MurmurHash &h );
+				IECore::DataPtr parameterValue( const Gaffer::Plug *parameter );
+
+				void arrayParameterHash( const Gaffer::ArrayPlug *parameter, IECore::MurmurHash &h );
+				IECore::DataPtr arrayParameterValue( const Gaffer::ArrayPlug *parameter );
+
 				bool isLeafParameter( const Gaffer::Plug *parameterPlug ) const;
 
 				const Shader *m_rootNode;

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -123,70 +123,16 @@ class Shader : public Gaffer::DependencyNode
 
 	protected :
 
-		class NetworkBuilder
-		{
-
-			public :
-
-				NetworkBuilder( const Shader *rootNode );
-
-				IECore::MurmurHash stateHash();
-				IECore::ConstObjectVectorPtr state();
-
-				IECore::MurmurHash shaderHash( const Shader *shaderNode );
-				IECore::Shader *shader( const Shader *shaderNode );
-
-			private :
-
-				NetworkBuilder();
-
-				// Returns the effective shader parameter that should be used taking into account
-				// enabledPlug() and correspondingInput(). Accepts either output or input parameters
-				// and may return either an output or input parameter.
-				const Gaffer::Plug *effectiveParameter( const Gaffer::Plug *parameterPlug ) const;
-
-				const std::string &shaderHandle( const Shader *shaderNode );
-				std::string link( const Shader *shaderNode, const Gaffer::Plug *outputParameter );
-
-				void parameterHashWalk( const Gaffer::Plug *parameter, IECore::MurmurHash &h );
-				void parameterValueWalk( const Gaffer::Plug *parameter, const IECore::InternedString &parameterName, IECore::CompoundDataMap &values );
-
-				void parameterHash( const Gaffer::Plug *parameter, IECore::MurmurHash &h );
-				IECore::DataPtr parameterValue( const Gaffer::Plug *parameter );
-
-				void arrayParameterHash( const Gaffer::ArrayPlug *parameter, IECore::MurmurHash &h );
-				IECore::DataPtr arrayParameterValue( const Gaffer::ArrayPlug *parameter );
-
-				bool isLeafParameter( const Gaffer::Plug *parameterPlug ) const;
-
-				const Shader *m_rootNode;
-				IECore::ObjectVectorPtr m_state;
-
-				struct ShaderAndHash
-				{
-				 	IECore::ShaderPtr shader;
-				 	IECore::MurmurHash hash;
-				};
-
-				typedef std::map<const Shader *, ShaderAndHash> ShaderMap;
-				ShaderMap m_shaders;
-
-				typedef boost::unordered_set<const Shader *> ShaderSet;
-				ShaderSet m_downstreamShaders; // Used for detecting cycles
-				struct CycleDetector;
-
-				unsigned int m_handleCount;
-
-		};
-
 		/// Called when computing the hash for this node. May be reimplemented in derived classes
 		/// to deal with special cases, in which case parameterValue() should be reimplemented too.
-		virtual void parameterHash( const Gaffer::Plug *parameterPlug, NetworkBuilder &network, IECore::MurmurHash &h ) const;
+		virtual void parameterHash( const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h ) const;
 		/// Called for each parameter plug when constructing an IECore::Shader from this node.
 		/// May be reimplemented in derived classes to deal with special cases.
-		virtual IECore::DataPtr parameterValue( const Gaffer::Plug *parameterPlug, NetworkBuilder &network ) const;
+		virtual IECore::DataPtr parameterValue( const Gaffer::Plug *parameterPlug ) const;
 
 	private :
+
+		class NetworkBuilder;
 
 		void nameChanged();
 		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Node *node );

--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -791,5 +791,65 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		n.loadShader( self.compileShader( os.path.dirname( __file__ ) + "/shaders/constant.osl" ) )
 		self.assertEqual( len( n["out"] ), 0 )
 
+	def testReconnectionOfChildPlugShader( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n1"] = GafferOSL.OSLShader()
+		s["n1"].loadShader( "Maths/VectorAdd" )
+
+		s["n2"] = GafferOSL.OSLShader()
+		s["n2"].loadShader( "Maths/VectorAdd" )
+
+		s["n3"] = GafferOSL.OSLShader()
+		s["n3"].loadShader( "Maths/VectorAdd" )
+
+		s["n2"]["parameters"]["a"].setInput( s["n1"]["out"]["out"] )
+		s["n3"]["parameters"]["a"].setInput( s["n2"]["out"]["out"] )
+
+		s.deleteNodes( filter = Gaffer.StandardSet( [ s["n2"] ] ) )
+		self.assertTrue( s["n3"]["parameters"]["a"].getInput().isSame( s["n1"]["out"]["out"] ) )
+
+	def testDisablingShader( self ) :
+
+		n1 = GafferOSL.OSLShader()
+		n1.loadShader( "Maths/VectorAdd" )
+		n1["parameters"]["a"].setValue( IECore.V3f( 5, 7, 6 ) )
+
+		n2 = GafferOSL.OSLShader()
+		n2.loadShader( "Maths/VectorAdd" )
+
+		n3 = GafferOSL.OSLShader()
+		n3.loadShader( "Maths/VectorAdd" )
+
+		n2["parameters"]["a"].setInput( n1["out"]["out"] )
+		n3["parameters"]["a"].setInput( n2["out"]["out"] )
+
+		n2["enabled"].setValue( False )
+		network = n3.attributes()["osl:shader"]
+		self.assertEqual( len( network ), 2 )
+		self.assertEqual( network[1].parameters["a"].value, "link:" + network[0].parameters["__handle"].value + ".out" )
+		self.assertEqual( network[0].parameters["a"].value, IECore.V3f( 5, 7, 6 ) )
+
+	def testDisabledShaderPassesThroughExternalValue( self ) :
+
+		n1 = Gaffer.Node()
+		n1["user"]["v"] = Gaffer.V3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		n1["user"]["v"].setValue( IECore.V3f( 12, 11, 10 ) )
+
+		n2 = GafferOSL.OSLShader()
+		n2.loadShader( "Maths/VectorAdd" )
+		n2["parameters"]["a"].setInput( n1["user"]["v"] )
+
+		n3 = GafferOSL.OSLShader()
+		n3.loadShader( "Maths/VectorAdd" )
+		n3["parameters"]["a"].setInput( n2["parameters"]["a"] )
+
+		n2["enabled"].setValue( False )
+
+		network = n3.attributes()["osl:shader"]
+		self.assertEqual( len( network ), 1 )
+		self.assertEqual( network[0].parameters["a"].value, IECore.V3f( 12, 11, 10 ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/shaders/Maths/FloatAdd.osl
+++ b/shaders/Maths/FloatAdd.osl
@@ -38,7 +38,7 @@ shader FloatAdd
 (
 	float a = 0,
 	float b = 0,
-	output float out = 0
+	output float out = 0 [[ string correspondingInput = "a" ]]
 )
 {
 	out = a + b;

--- a/shaders/Maths/FloatMix.osl
+++ b/shaders/Maths/FloatMix.osl
@@ -39,7 +39,7 @@ shader FloatMix
 	float a = 0,
 	float b = 0,
 	float m = 0,
-	output float out = 0
+	output float out = 0 [[ string correspondingInput = "a" ]]
 )
 {
 	out = mix( a, b, m );

--- a/shaders/Maths/FloatMultiply.osl
+++ b/shaders/Maths/FloatMultiply.osl
@@ -38,7 +38,7 @@ shader FloatMultiply
 (
 	float a = 0,
 	float b = 0,
-	output float out = 0
+	output float out = 0 [[ string correspondingInput = "a" ]]
 )
 {
 	out = a * b;

--- a/shaders/Maths/VectorAdd.osl
+++ b/shaders/Maths/VectorAdd.osl
@@ -38,7 +38,7 @@ shader VectorAdd
 (
 	vector a = 0,
 	vector b = 0,
-	output vector out = 0
+	output vector out = 0 [[ string correspondingInput = "a" ]]
 )
 {
 	out = a + b;

--- a/shaders/Maths/VectorMix.osl
+++ b/shaders/Maths/VectorMix.osl
@@ -39,7 +39,7 @@ shader VectorMix
 	vector a = 0,
 	vector b = 0,
 	float m = 0,
-	output vector out = 0
+	output vector out = 0 [[ string correspondingInput = "a" ]]
 )
 {
 	out = mix( a, b, m );

--- a/shaders/Maths/VectorMultiply.osl
+++ b/shaders/Maths/VectorMultiply.osl
@@ -38,7 +38,7 @@ shader VectorMultiply
 (
 	vector a = 0,
 	float b = 0,
-	output vector out = 0
+	output vector out = 0 [[ string correspondingInput = "a" ]]
 )
 {
 	out = a * b;

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -252,64 +252,6 @@ bool RenderManShader::acceptsInput( const Plug *plug, const Plug *inputPlug ) co
 	return true;
 }
 
-void RenderManShader::parameterHash( const Gaffer::Plug *parameterPlug, NetworkBuilder &network, IECore::MurmurHash &h ) const
-{
-	if( parameterPlug->isInstanceOf( ArrayPlug::staticTypeId() ) )
-	{
-		// coshader array parameter
-		for( InputPlugIterator cIt( parameterPlug ); !cIt.done(); ++cIt )
-		{
-			Shader::parameterHash( cIt->get(), network, h );
-		}
-	}
-	else
-	{
-		Shader::parameterHash( parameterPlug, network, h );
-	}
-}
-
-IECore::DataPtr RenderManShader::parameterValue( const Gaffer::Plug *parameterPlug, NetworkBuilder &network ) const
-{
-	if( parameterPlug->typeId() == Plug::staticTypeId() )
-	{
-		// coshader parameter
-		const Plug *inputPlug = parameterPlug->source<Plug>();
-		if( inputPlug && inputPlug != parameterPlug )
-		{
-			const RenderManShader *inputShader = inputPlug->parent<RenderManShader>();
-			if( inputShader )
-			{
-				const std::string &handle = network.shaderHandle( inputShader );
-				if( handle.size() )
-				{
-					return new StringData( handle );
-				}
-			}
-		}
-	}
-	else if( parameterPlug->isInstanceOf( ArrayPlug::staticTypeId() ) )
-	{
-		// coshader array parameter
-		StringVectorDataPtr value = new StringVectorData();
-		for( InputPlugIterator cIt( parameterPlug ); !cIt.done(); ++cIt )
-		{
-			const Plug *inputPlug = (*cIt)->source<Plug>();
-			const RenderManShader *inputShader = inputPlug && inputPlug != *cIt ? inputPlug->parent<RenderManShader>() : 0;
-			if( inputShader )
-			{
-				value->writable().push_back( network.shaderHandle( inputShader ) );
-			}
-			else
-			{
-				value->writable().push_back( "" );
-			}
-		}
-		return value;
-	}
-
-	return Shader::parameterValue( parameterPlug, network );
-}
-
 const IECore::ConstCompoundDataPtr RenderManShader::annotations() const
 {
 	std::string shaderName = namePlug()->getValue();

--- a/src/GafferScene/OpenGLShader.cpp
+++ b/src/GafferScene/OpenGLShader.cpp
@@ -144,7 +144,7 @@ void OpenGLShader::loadShader( const std::string &shaderName )
 	typePlug()->setValue( "gl:surface" );
 }
 
-void OpenGLShader::parameterHash( const Gaffer::Plug *parameterPlug, NetworkBuilder &network, IECore::MurmurHash &h ) const
+void OpenGLShader::parameterHash( const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h ) const
 {
 	if( const GafferImage::ImagePlug *imagePlug = runTimeCast<const GafferImage::ImagePlug>( parameterPlug ) )
 	{
@@ -152,11 +152,11 @@ void OpenGLShader::parameterHash( const Gaffer::Plug *parameterPlug, NetworkBuil
 	}
 	else
 	{
-		Shader::parameterHash( parameterPlug, network, h );
+		Shader::parameterHash( parameterPlug, h );
 	}
 }
 
-IECore::DataPtr OpenGLShader::parameterValue( const Gaffer::Plug *parameterPlug, NetworkBuilder &network ) const
+IECore::DataPtr OpenGLShader::parameterValue( const Gaffer::Plug *parameterPlug ) const
 {
 	if( const GafferImage::ImagePlug *imagePlug = runTimeCast<const GafferImage::ImagePlug>( parameterPlug ) )
 	{
@@ -176,10 +176,10 @@ IECore::DataPtr OpenGLShader::parameterValue( const Gaffer::Plug *parameterPlug,
 			value->writable()["channels"] = channelData;
 			return value;
 		}
-		return 0;
+		return NULL;
 	}
 	else
 	{
-		return Shader::parameterValue( parameterPlug, network );
+		return Shader::parameterValue( parameterPlug );
 	}
 }

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -66,13 +66,13 @@ bool isOutputParameter( const Gaffer::Plug *parameterPlug )
 	const Shader *shaderNode = IECore::runTimeCast<const Shader>( parameterPlug->node() );
 	if( !shaderNode )
 	{
-		return NULL;
+		return false;
 	}
 
 	const Plug *shaderNodeOutPlug = shaderNode->outPlug();
 	if( !shaderNodeOutPlug )
 	{
-		return NULL;
+		return false;
 	}
 
 	return parameterPlug == shaderNodeOutPlug || shaderNodeOutPlug->isAncestorOf( parameterPlug );
@@ -83,7 +83,7 @@ bool isInputParameter( const Gaffer::Plug *parameterPlug )
 	const Shader *shaderNode = IECore::runTimeCast<const Shader>( parameterPlug->node() );
 	if( !shaderNode )
 	{
-		return NULL;
+		return false;
 	}
 
 	return shaderNode->parametersPlug()->isAncestorOf( parameterPlug );

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -55,6 +55,445 @@ using namespace GafferScene;
 using namespace Gaffer;
 
 //////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+bool isOutputParameter( const Gaffer::Plug *parameterPlug )
+{
+	const Shader *shaderNode = IECore::runTimeCast<const Shader>( parameterPlug->node() );
+	if( !shaderNode )
+	{
+		return NULL;
+	}
+
+	const Plug *shaderNodeOutPlug = shaderNode->outPlug();
+	if( !shaderNodeOutPlug )
+	{
+		return NULL;
+	}
+
+	return parameterPlug == shaderNodeOutPlug || shaderNodeOutPlug->isAncestorOf( parameterPlug );
+}
+
+bool isInputParameter( const Gaffer::Plug *parameterPlug )
+{
+	const Shader *shaderNode = IECore::runTimeCast<const Shader>( parameterPlug->node() );
+	if( !shaderNode )
+	{
+		return NULL;
+	}
+
+	return shaderNode->parametersPlug()->isAncestorOf( parameterPlug );
+}
+
+bool isParameter( const Gaffer::Plug *parameterPlug )
+{
+	return isInputParameter( parameterPlug ) || isOutputParameter( parameterPlug );
+}
+
+bool isLeafParameter( const Gaffer::Plug *parameterPlug )
+{
+	const IECore::TypeId typeId = parameterPlug->typeId();
+	if( typeId == Plug::staticTypeId() || typeId == ValuePlug::staticTypeId() )
+	{
+		if( !parameterPlug->children().empty() )
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+typedef boost::unordered_set<const Shader *> ShaderSet;
+
+struct CycleDetector
+{
+
+	CycleDetector( ShaderSet &downstreamShaders, const Shader *shader )
+		:	m_downstreamShaders( downstreamShaders ), m_shader( shader )
+	{
+		if( !m_downstreamShaders.insert( m_shader ).second )
+		{
+			throw IECore::Exception(
+				boost::str(
+					boost::format( "Shader \"%s\" is involved in a dependency cycle." ) %
+						m_shader->relativeName( m_shader->ancestor<ScriptNode>() )
+				)
+			);
+		}
+	}
+
+	~CycleDetector()
+	{
+		m_downstreamShaders.erase( m_shader );
+	}
+
+	private :
+
+		ShaderSet &m_downstreamShaders;
+		const Shader *m_shader;
+
+};
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Shader::NetworkBuilder implementation
+//////////////////////////////////////////////////////////////////////////
+
+class Shader::NetworkBuilder
+{
+
+	public :
+
+		NetworkBuilder( const Shader *rootNode )
+			:	m_rootNode( rootNode ), m_handleCount( 0 )
+		{
+		}
+
+		IECore::MurmurHash stateHash()
+		{
+			if( const Gaffer::Plug *p = effectiveParameter( m_rootNode->outPlug() ) )
+			{
+				if( isOutputParameter( p ) )
+				{
+					return shaderHash( static_cast<const Shader *>( p->node() ) );
+				}
+			}
+
+			return IECore::MurmurHash();
+		}
+
+		IECore::ConstObjectVectorPtr state()
+		{
+			if( !m_state )
+			{
+				m_state = new IECore::ObjectVector;
+				if( const Gaffer::Plug *p = effectiveParameter( m_rootNode->outPlug() ) )
+				{
+					if( isOutputParameter( p ) )
+					{
+						shader( static_cast<const Shader *>( p->node() ) );
+					}
+				}
+			}
+			return m_state;
+		}
+
+	private :
+
+		// Returns the effective shader parameter that should be used taking into account
+		// enabledPlug() and correspondingInput(). Accepts either output or input parameters
+		// and may return either an output or input parameter.
+		const Gaffer::Plug *effectiveParameter( const Gaffer::Plug *parameterPlug ) const
+		{
+			while( true )
+			{
+				if( !parameterPlug )
+				{
+					return NULL;
+				}
+
+				if( isOutputParameter( parameterPlug ) )
+				{
+					const Shader *shaderNode = static_cast<const Shader *>( parameterPlug->node() );
+					if( shaderNode->enabledPlug()->getValue() )
+					{
+						return parameterPlug;
+					}
+					else
+					{
+						// Follow pass-through, ready for next iteration.
+						parameterPlug = shaderNode->correspondingInput( parameterPlug );
+					}
+				}
+				else
+				{
+					assert( isInputParameter( parameterPlug ) );
+					const Gaffer::Plug *source = parameterPlug->source<Gaffer::Plug>();
+					if( source == parameterPlug || !isParameter( source ) )
+					{
+						return parameterPlug;
+					}
+					else
+					{
+						// Follow connection, ready for next iteration.
+						parameterPlug = source;
+					}
+				}
+			}
+		}
+
+		IECore::MurmurHash shaderHash( const Shader *shaderNode )
+		{
+			assert( shaderNode );
+			assert( shaderNode->enabledPlug()->getValue() );
+
+			CycleDetector cycleDetector( m_downstreamShaders, shaderNode );
+
+			ShaderAndHash &shaderAndHash = m_shaders[shaderNode];
+			if( shaderAndHash.hash != IECore::MurmurHash() )
+			{
+				return shaderAndHash.hash;
+			}
+
+			shaderAndHash.hash.append( shaderNode->typeId() );
+			shaderNode->namePlug()->hash( shaderAndHash.hash );
+			shaderNode->typePlug()->hash( shaderAndHash.hash );
+
+			parameterHashWalk( shaderNode->parametersPlug(), shaderAndHash.hash );
+
+			shaderNode->nodeNamePlug()->hash( shaderAndHash.hash );
+			shaderNode->nodeColorPlug()->hash( shaderAndHash.hash );
+
+			return shaderAndHash.hash;
+		}
+
+		IECore::Shader *shader( const Shader *shaderNode )
+		{
+			assert( shaderNode );
+			assert( shaderNode->enabledPlug()->getValue() );
+
+			CycleDetector cycleDetector( m_downstreamShaders, shaderNode );
+
+			ShaderAndHash &shaderAndHash = m_shaders[shaderNode];
+			if( shaderAndHash.shader )
+			{
+				return shaderAndHash.shader.get();
+			}
+
+			shaderAndHash.shader = new IECore::Shader( shaderNode->namePlug()->getValue(), shaderNode->typePlug()->getValue() );
+			parameterValueWalk( shaderNode->parametersPlug(), IECore::InternedString(), shaderAndHash.shader->parameters() );
+
+			shaderAndHash.shader->blindData()->writable()["gaffer:nodeName"] = new IECore::StringData( shaderNode->nodeNamePlug()->getValue() );
+			shaderAndHash.shader->blindData()->writable()["gaffer:nodeColor"] = new IECore::Color3fData( shaderNode->nodeColorPlug()->getValue() );
+
+			m_state->members().push_back( shaderAndHash.shader );
+
+			return shaderAndHash.shader.get();
+		}
+
+		const std::string &shaderHandle( const Shader *shaderNode )
+		{
+			IECore::Shader *s = shader( shaderNode );
+			if( !s )
+			{
+				static std::string emptyString;
+				return emptyString;
+			}
+
+			IECore::StringDataPtr handleData = s->parametersData()->member<IECore::StringData>( "__handle" );
+			if( !handleData )
+			{
+				// Some renderers (Arnold for one) allow surface shaders to be connected
+				// as inputs to other shaders, so we may need to change the shader type to
+				// convert it into a standard shader. We must take care to preserve any
+				// renderer specific prefix when doing this.
+				const std::string &type = s->getType();
+				if( !boost::ends_with( type, "shader" ) )
+				{
+					size_t i = type.find_first_of( ":" );
+					if( i != std::string::npos )
+					{
+						s->setType( type.substr( 0, i + 1 ) + "shader" );
+					}
+					else
+					{
+						s->setType( "shader" );
+					}
+				}
+				// the handle includes the node name so as to help with debugging, but also
+				// includes an integer unique to this shader group, as two shaders could have
+				// the same name if they don't have the same parent - because one is inside a
+				// Box for instance.
+				handleData = new IECore::StringData(
+					 boost::lexical_cast<std::string>( ++m_handleCount ) + "_" +
+					 s->blindData()->member<IECore::StringData>( "gaffer:nodeName" )->readable()
+				);
+				s->parameters()["__handle"] = handleData;
+			}
+			return handleData->readable();
+		}
+
+		std::string link( const Shader *shaderNode, const Gaffer::Plug *outputParameter )
+		{
+			std::string result = this->shaderHandle( shaderNode );
+			if( shaderNode->outPlug()->isAncestorOf( outputParameter ) )
+			{
+				result += "." + outputParameter->relativeName( shaderNode->outPlug() );
+			}
+
+			if( !shaderNode->isInstanceOf( "GafferRenderMan::RenderManShader" ) )
+			{
+				// All our other renderer backends use a "link:" prefix to specify
+				// shader connections, but the legacy RenderMan backend doesn't. In
+				// return for the special case hack here, we get to remove complexity
+				// from the entire shader generation mechanism.
+				/// \todo Write a new RenderMan backend following the usual conventio
+				/// and remove this hack.
+				result = "link:" + result;
+			}
+
+			return result;
+		}
+
+		void parameterHashWalk( const Gaffer::Plug *parameter, IECore::MurmurHash &h )
+		{
+			if( !isLeafParameter( parameter ) || parameter->parent<Node>() )
+			{
+				// Compound parameter - recurse
+				for( InputPlugIterator it( parameter ); !it.done(); ++it )
+				{
+					parameterHashWalk( it->get(), h );
+				}
+			}
+			else if( const Gaffer::ArrayPlug *arrayParameter = IECore::runTimeCast<const Gaffer::ArrayPlug>( parameter ) )
+			{
+				// Array parameter
+				arrayParameterHash( arrayParameter, h );
+			}
+			else
+			{
+				// Leaf parameter
+				parameterHash( parameter, h );
+			}
+		}
+
+		void parameterValueWalk( const Gaffer::Plug *parameter, const IECore::InternedString &parameterName, IECore::CompoundDataMap &values )
+		{
+			if( !isLeafParameter( parameter ) || parameter->parent<Node>() )
+			{
+				// Compound parameter - recurse
+				for( InputPlugIterator it( parameter ); !it.done(); ++it )
+				{
+					IECore::InternedString childParameterName;
+					if( parameterName.string().size() )
+					{
+						childParameterName = parameterName.string() + "." + (*it)->getName().string();
+					}
+					else
+					{
+						childParameterName = (*it)->getName();
+					}
+
+					parameterValueWalk( it->get(), childParameterName, values );
+				}
+			}
+			else if( const Gaffer::ArrayPlug *arrayParameter = IECore::runTimeCast<const Gaffer::ArrayPlug>( parameter ) )
+			{
+				// Array parameter
+				if( IECore::DataPtr value = arrayParameterValue( arrayParameter ) )
+				{
+					values[parameterName] = value;
+				}
+			}
+			else
+			{
+				// Leaf parameter
+				if( IECore::DataPtr value = parameterValue( parameter ) )
+				{
+					values[parameterName] = value;
+				}
+			}
+		}
+
+		void parameterHash( const Gaffer::Plug *parameter, IECore::MurmurHash &h )
+		{
+			const Gaffer::Plug *effectiveParameter = this->effectiveParameter( parameter );
+			if( !effectiveParameter )
+			{
+				return;
+			}
+
+			const Shader *effectiveShader = static_cast<const Shader *>( effectiveParameter->node() );
+			if( isInputParameter( effectiveParameter ) )
+			{
+				effectiveShader->parameterHash( effectiveParameter, h );
+			}
+			else
+			{
+				assert( isOutputParameter( effectiveParameter ) );
+				h.append( shaderHash( effectiveShader ) );
+				if( effectiveShader->outPlug()->isAncestorOf( effectiveParameter ) )
+				{
+					h.append( effectiveParameter->relativeName( effectiveShader->outPlug() ) );
+				}
+				return;
+			}
+		}
+
+		IECore::DataPtr parameterValue( const Gaffer::Plug *parameter )
+		{
+			const Gaffer::Plug *effectiveParameter = this->effectiveParameter( parameter );
+			if( !effectiveParameter )
+			{
+				return NULL;
+			}
+
+			const Shader *effectiveShader = static_cast<const Shader *>( effectiveParameter->node() );
+			if( isInputParameter( effectiveParameter ) )
+			{
+				return effectiveShader->parameterValue( effectiveParameter );
+			}
+			else
+			{
+				assert( isOutputParameter( effectiveParameter ) );
+				return new IECore::StringData( link( effectiveShader, effectiveParameter ) );
+			}
+		}
+
+		void arrayParameterHash( const Gaffer::ArrayPlug *parameter, IECore::MurmurHash &h )
+		{
+			for( InputPlugIterator it( parameter ); !it.done(); ++it )
+			{
+				parameterHash( it->get(), h );
+			}
+		}
+
+		IECore::DataPtr arrayParameterValue( const Gaffer::ArrayPlug *parameter )
+		{
+			/// \todo We're just supporting arrays of connections - support arrays of values too.
+			IECore::StringVectorDataPtr resultData = new IECore::StringVectorData;
+			std::vector<std::string> &result = resultData->writable();
+			for( InputPlugIterator it( parameter ); !it.done(); ++it )
+			{
+				const Gaffer::Plug *effectiveParameter = this->effectiveParameter( it->get() );
+				if( effectiveParameter && isOutputParameter( effectiveParameter ) )
+				{
+					const Shader *effectiveShader = static_cast<const Shader *>( effectiveParameter->node() );
+					result.push_back( link( effectiveShader, effectiveParameter ) );
+				}
+				else
+				{
+					result.push_back( "" );
+				}
+			}
+
+			return resultData;
+		}
+
+		const Shader *m_rootNode;
+		IECore::ObjectVectorPtr m_state;
+
+		struct ShaderAndHash
+		{
+			IECore::ShaderPtr shader;
+			IECore::MurmurHash hash;
+		};
+
+		typedef std::map<const Shader *, ShaderAndHash> ShaderMap;
+		ShaderMap m_shaders;
+
+		ShaderSet m_downstreamShaders; // Used for detecting cycles
+
+		unsigned int m_handleCount;
+
+};
+
+//////////////////////////////////////////////////////////////////////////
 // Shader implementation
 //////////////////////////////////////////////////////////////////////////
 
@@ -233,7 +672,7 @@ void Shader::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs
 	}
 }
 
-void Shader::parameterHash( const Gaffer::Plug *parameterPlug, NetworkBuilder &network, IECore::MurmurHash &h ) const
+void Shader::parameterHash( const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h ) const
 {
 	const ValuePlug *vplug = IECore::runTimeCast<const ValuePlug>( parameterPlug );
 	if( vplug )
@@ -246,7 +685,7 @@ void Shader::parameterHash( const Gaffer::Plug *parameterPlug, NetworkBuilder &n
 	}
 }
 
-IECore::DataPtr Shader::parameterValue( const Gaffer::Plug *parameterPlug, NetworkBuilder &network ) const
+IECore::DataPtr Shader::parameterValue( const Gaffer::Plug *parameterPlug ) const
 {
 	if( const Gaffer::ValuePlug *valuePlug = IECore::runTimeCast<const Gaffer::ValuePlug>( parameterPlug ) )
 	{
@@ -273,413 +712,4 @@ void Shader::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedStr
 		IECore::ConstColor3fDataPtr d = Metadata::value<const IECore::Color3fData>( this, g_nodeColorMetadataName );
 		nodeColorPlug()->setValue( d ? d->readable() : Color3f( 0.0f ) );
 	}
-}
-
-//////////////////////////////////////////////////////////////////////////
-// Internal utilities
-//////////////////////////////////////////////////////////////////////////
-
-namespace
-{
-
-bool isOutputParameter( const Gaffer::Plug *parameterPlug )
-{
-	const Shader *shaderNode = IECore::runTimeCast<const Shader>( parameterPlug->node() );
-	if( !shaderNode )
-	{
-		return NULL;
-	}
-
-	const Plug *shaderNodeOutPlug = shaderNode->outPlug();
-	if( !shaderNodeOutPlug )
-	{
-		return NULL;
-	}
-
-	return parameterPlug == shaderNodeOutPlug || shaderNodeOutPlug->isAncestorOf( parameterPlug );
-}
-
-bool isInputParameter( const Gaffer::Plug *parameterPlug )
-{
-	const Shader *shaderNode = IECore::runTimeCast<const Shader>( parameterPlug->node() );
-	if( !shaderNode )
-	{
-		return NULL;
-	}
-
-	return shaderNode->parametersPlug()->isAncestorOf( parameterPlug );
-}
-
-bool isParameter( const Gaffer::Plug *parameterPlug )
-{
-	return isInputParameter( parameterPlug ) || isOutputParameter( parameterPlug );
-}
-
-} // namespace
-
-//////////////////////////////////////////////////////////////////////////
-// NetworkBuilder implementation
-//////////////////////////////////////////////////////////////////////////
-
-struct Shader::NetworkBuilder::CycleDetector
-{
-
-	CycleDetector( ShaderSet &downstreamShaders, const Shader *shader )
-		:	m_downstreamShaders( downstreamShaders ), m_shader( shader )
-	{
-		if( !m_downstreamShaders.insert( m_shader ).second )
-		{
-			throw IECore::Exception(
-				boost::str(
-					boost::format( "Shader \"%s\" is involved in a dependency cycle." ) %
-						m_shader->relativeName( m_shader->ancestor<ScriptNode>() )
-				)
-			);
-		}
-	}
-
-	~CycleDetector()
-	{
-		m_downstreamShaders.erase( m_shader );
-	}
-
-	private :
-
-		ShaderSet &m_downstreamShaders;
-		const Shader *m_shader;
-
-};
-
-Shader::NetworkBuilder::NetworkBuilder( const Shader *rootNode )
-	:	m_rootNode( rootNode ), m_handleCount( 0 )
-{
-}
-
-IECore::MurmurHash Shader::NetworkBuilder::stateHash()
-{
-	if( const Gaffer::Plug *p = effectiveParameter( m_rootNode->outPlug() ) )
-	{
-		if( isOutputParameter( p ) )
-		{
-			return shaderHash( static_cast<const Shader *>( p->node() ) );
-		}
-	}
-
-	return IECore::MurmurHash();
-}
-
-IECore::ConstObjectVectorPtr Shader::NetworkBuilder::state()
-{
-	if( !m_state )
-	{
-		m_state = new IECore::ObjectVector;
-		if( const Gaffer::Plug *p = effectiveParameter( m_rootNode->outPlug() ) )
-		{
-			if( isOutputParameter( p ) )
-			{
-				shader( static_cast<const Shader *>( p->node() ) );
-			}
-		}
-	}
-	return m_state;
-}
-
-IECore::MurmurHash Shader::NetworkBuilder::shaderHash( const Shader *shaderNode )
-{
-	assert( shaderNode );
-	assert( shaderNode->enabledPlug()->getValue() );
-
-	CycleDetector cycleDetector( m_downstreamShaders, shaderNode );
-
-	ShaderAndHash &shaderAndHash = m_shaders[shaderNode];
-	if( shaderAndHash.hash != IECore::MurmurHash() )
-	{
-		return shaderAndHash.hash;
-	}
-
-	shaderAndHash.hash.append( shaderNode->typeId() );
-	shaderNode->namePlug()->hash( shaderAndHash.hash );
-	shaderNode->typePlug()->hash( shaderAndHash.hash );
-
-	parameterHashWalk( shaderNode->parametersPlug(), shaderAndHash.hash );
-
-	shaderNode->nodeNamePlug()->hash( shaderAndHash.hash );
-	shaderNode->nodeColorPlug()->hash( shaderAndHash.hash );
-
-	return shaderAndHash.hash;
-}
-
-IECore::Shader *Shader::NetworkBuilder::shader( const Shader *shaderNode )
-{
-	assert( shaderNode );
-	assert( shaderNode->enabledPlug()->getValue() );
-
-	CycleDetector cycleDetector( m_downstreamShaders, shaderNode );
-
-	ShaderAndHash &shaderAndHash = m_shaders[shaderNode];
-	if( shaderAndHash.shader )
-	{
-		return shaderAndHash.shader.get();
-	}
-
-	shaderAndHash.shader = new IECore::Shader( shaderNode->namePlug()->getValue(), shaderNode->typePlug()->getValue() );
-	parameterValueWalk( shaderNode->parametersPlug(), IECore::InternedString(), shaderAndHash.shader->parameters() );
-
-	shaderAndHash.shader->blindData()->writable()["gaffer:nodeName"] = new IECore::StringData( shaderNode->nodeNamePlug()->getValue() );
-	shaderAndHash.shader->blindData()->writable()["gaffer:nodeColor"] = new IECore::Color3fData( shaderNode->nodeColorPlug()->getValue() );
-
-	m_state->members().push_back( shaderAndHash.shader );
-
-	return shaderAndHash.shader.get();
-}
-
-const Gaffer::Plug *Shader::NetworkBuilder::effectiveParameter( const Gaffer::Plug *parameterPlug ) const
-{
-	while( true )
-	{
-		if( !parameterPlug )
-		{
-			return NULL;
-		}
-
-		if( isOutputParameter( parameterPlug ) )
-		{
-			const Shader *shaderNode = static_cast<const Shader *>( parameterPlug->node() );
-			if( shaderNode->enabledPlug()->getValue() )
-			{
-				return parameterPlug;
-			}
-			else
-			{
-				// Follow pass-through, ready for next iteration.
-				parameterPlug = shaderNode->correspondingInput( parameterPlug );
-			}
-		}
-		else
-		{
-			assert( isInputParameter( parameterPlug ) );
-			const Gaffer::Plug *source = parameterPlug->source<Gaffer::Plug>();
-			if( source == parameterPlug || !isParameter( source ) )
-			{
-				return parameterPlug;
-			}
-			else
-			{
-				// Follow connection, ready for next iteration.
-				parameterPlug = source;
-			}
-		}
-	}
-}
-
-void Shader::NetworkBuilder::parameterHashWalk( const Gaffer::Plug *parameter, IECore::MurmurHash &h )
-{
-	if( !isLeafParameter( parameter ) || parameter->parent<Node>() )
-	{
-		// Compound parameter - recurse
-		for( InputPlugIterator it( parameter ); !it.done(); ++it )
-		{
-			parameterHashWalk( it->get(), h );
-		}
-	}
-	else if( const Gaffer::ArrayPlug *arrayParameter = IECore::runTimeCast<const Gaffer::ArrayPlug>( parameter ) )
-	{
-		// Array parameter
-		arrayParameterHash( arrayParameter, h );
-	}
-	else
-	{
-		// Leaf parameter
-		parameterHash( parameter, h );
-	}
-}
-
-void Shader::NetworkBuilder::parameterValueWalk( const Gaffer::Plug *parameter, const IECore::InternedString &parameterName, IECore::CompoundDataMap &values )
-{
-	if( !isLeafParameter( parameter ) || parameter->parent<Node>() )
-	{
-		// Compound parameter - recurse
-		for( InputPlugIterator it( parameter ); !it.done(); ++it )
-		{
-			IECore::InternedString childParameterName;
-			if( parameterName.string().size() )
-			{
-				childParameterName = parameterName.string() + "." + (*it)->getName().string();
-			}
-			else
-			{
-				childParameterName = (*it)->getName();
-			}
-
-			parameterValueWalk( it->get(), childParameterName, values );
-		}
-	}
-	else if( const Gaffer::ArrayPlug *arrayParameter = IECore::runTimeCast<const Gaffer::ArrayPlug>( parameter ) )
-	{
-		// Array parameter
-		if( IECore::DataPtr value = arrayParameterValue( arrayParameter ) )
-		{
-			values[parameterName] = value;
-		}
-	}
-	else
-	{
-		// Leaf parameter
-		if( IECore::DataPtr value = parameterValue( parameter ) )
-		{
-			values[parameterName] = value;
-		}
-	}
-}
-
-void Shader::NetworkBuilder::parameterHash( const Gaffer::Plug *parameter, IECore::MurmurHash &h )
-{
-	const Gaffer::Plug *effectiveParameter = this->effectiveParameter( parameter );
-	if( !effectiveParameter )
-	{
-		return;
-	}
-
-	const Shader *effectiveShader = static_cast<const Shader *>( effectiveParameter->node() );
-	if( isInputParameter( effectiveParameter ) )
-	{
-		effectiveShader->parameterHash( effectiveParameter, *this, h );
-	}
-	else
-	{
-		assert( isOutputParameter( effectiveParameter ) );
-		h.append( shaderHash( effectiveShader ) );
-		if( effectiveShader->outPlug()->isAncestorOf( effectiveParameter ) )
-		{
-			h.append( effectiveParameter->relativeName( effectiveShader->outPlug() ) );
-		}
-		return;
-	}
-}
-
-IECore::DataPtr Shader::NetworkBuilder::parameterValue( const Gaffer::Plug *parameter )
-{
-	const Gaffer::Plug *effectiveParameter = this->effectiveParameter( parameter );
-	if( !effectiveParameter )
-	{
-		return NULL;
-	}
-
-	const Shader *effectiveShader = static_cast<const Shader *>( effectiveParameter->node() );
-	if( isInputParameter( effectiveParameter ) )
-	{
-		return effectiveShader->parameterValue( effectiveParameter, *this );
-	}
-	else
-	{
-		assert( isOutputParameter( effectiveParameter ) );
-		return new IECore::StringData( link( effectiveShader, effectiveParameter ) );
-	}
-}
-
-void Shader::NetworkBuilder::arrayParameterHash( const Gaffer::ArrayPlug *parameter, IECore::MurmurHash &h )
-{
-	for( InputPlugIterator it( parameter ); !it.done(); ++it )
-	{
-		parameterHash( it->get(), h );
-	}
-}
-
-IECore::DataPtr Shader::NetworkBuilder::arrayParameterValue( const Gaffer::ArrayPlug *parameter )
-{
-	/// \todo We're just supporting arrays of connections - support arrays of values too.
-	IECore::StringVectorDataPtr resultData = new IECore::StringVectorData;
-	std::vector<std::string> &result = resultData->writable();
-	for( InputPlugIterator it( parameter ); !it.done(); ++it )
-	{
-		const Gaffer::Plug *effectiveParameter = this->effectiveParameter( it->get() );
-		if( effectiveParameter && isOutputParameter( effectiveParameter ) )
-		{
-			const Shader *effectiveShader = static_cast<const Shader *>( effectiveParameter->node() );
-			result.push_back( link( effectiveShader, effectiveParameter ) );
-		}
-		else
-		{
-			result.push_back( "" );
-		}
-	}
-
-	return resultData;
-}
-
-bool Shader::NetworkBuilder::isLeafParameter( const Gaffer::Plug *parameterPlug ) const
-{
-	const IECore::TypeId typeId = parameterPlug->typeId();
-	if( typeId == Plug::staticTypeId() || typeId == ValuePlug::staticTypeId() )
-	{
-		if( !parameterPlug->children().empty() )
-		{
-			return false;
-		}
-	}
-	return true;
-}
-
-const std::string &Shader::NetworkBuilder::shaderHandle( const Shader *shaderNode )
-{
-	IECore::Shader *s = shader( shaderNode );
-	if( !s )
-	{
-		static std::string emptyString;
-		return emptyString;
-	}
-
-	IECore::StringDataPtr handleData = s->parametersData()->member<IECore::StringData>( "__handle" );
-	if( !handleData )
-	{
-		// Some renderers (Arnold for one) allow surface shaders to be connected
-		// as inputs to other shaders, so we may need to change the shader type to
-		// convert it into a standard shader. We must take care to preserve any
-		// renderer specific prefix when doing this.
-		const std::string &type = s->getType();
-		if( !boost::ends_with( type, "shader" ) )
-		{
-			size_t i = type.find_first_of( ":" );
-			if( i != std::string::npos )
-			{
-				s->setType( type.substr( 0, i + 1 ) + "shader" );
-			}
-			else
-			{
-				s->setType( "shader" );
-			}
-		}
-		// the handle includes the node name so as to help with debugging, but also
-		// includes an integer unique to this shader group, as two shaders could have
-		// the same name if they don't have the same parent - because one is inside a
-		// Box for instance.
-		handleData = new IECore::StringData(
-			 boost::lexical_cast<std::string>( ++m_handleCount ) + "_" +
-			 s->blindData()->member<IECore::StringData>( "gaffer:nodeName" )->readable()
-		);
-		s->parameters()["__handle"] = handleData;
-	}
-	return handleData->readable();
-}
-
-std::string Shader::NetworkBuilder::link( const Shader *shaderNode, const Gaffer::Plug *outputParameter )
-{
-	std::string result = this->shaderHandle( shaderNode );
-	if( shaderNode->outPlug()->isAncestorOf( outputParameter ) )
-	{
-		result += "." + outputParameter->relativeName( shaderNode->outPlug() );
-	}
-
-	if( !shaderNode->isInstanceOf( "GafferRenderMan::RenderManShader" ) )
-	{
-		// All our other renderer backends use a "link:" prefix to specify
-		// shader connections, but the legacy RenderMan backend doesn't. In
-		// return for the special case hack here, we get to remove complexity
-		// from the entire shader generation mechanism.
-		/// \todo Write a new RenderMan backend following the usual conventio
-		/// and remove this hack.
-		result = "link:" + result;
-	}
-
-	return result;
 }


### PR DESCRIPTION
This builds on Matti's #1919, updating the shader network generation code to support pass-through of disabled OSL shader nodes. I've also taken the opportunity to refactor the network generation to remove most of the complexity from the public API. The complexity stemmed from the special needs of the RenderManShader, but all the other shader types are converging on a more straightforward common code path, so I think it's time to simplify. There's a little bit of a RenderMan-specific hack in `NetworkGenerator::link`, but I think that's justified by the simplification in the external API, and the fact that RSL shaders are on their last legs anyway.
