### PR TITLE
ShaderSwitch Improvements

### DIFF
--- a/include/Gaffer/Switch.h
+++ b/include/Gaffer/Switch.h
@@ -80,6 +80,11 @@ class Switch : public BaseType
 		/// \undoable
 		void setup( const Plug *plug );
 
+		/// Returns the input plug which will be passed through
+		/// by the switch in the current context.
+		Plug *activeInPlug();
+		const Plug *activeInPlug() const;
+
 		IntPlug *indexPlug();
 		const IntPlug *indexPlug() const;
 

--- a/include/Gaffer/Switch.h
+++ b/include/Gaffer/Switch.h
@@ -53,12 +53,13 @@ namespace Gaffer
 /// Switches can be instantiated in either of two ways :
 ///
 /// - By instantiating Switch<BaseType> where BaseType creates an "in" and
-/// and "out" plug during construction. This is the method used to create
-/// the SceneSwitch and ImageSwitch.
+///   and "out" plug during construction. This is the method used to create
+///   the SceneSwitch and ImageSwitch.
 ///
-/// - By adding dynamic "in" and "out" plugs to a generic Switch node after
-/// construction. This method can be seen in the GafferTest.SwitchTest
-/// test cases.
+/// - By adding "in" and "out" plugs to a generic Switch node after
+///   construction, using the `Switch::setup()`. This method can be seen
+///   in the GafferTest.SwitchTest
+///   test cases.
 template<typename BaseType>
 class Switch : public BaseType
 {
@@ -69,6 +70,15 @@ class Switch : public BaseType
 
 		Switch( const std::string &name=GraphComponent::defaultName<Switch>() );
 		virtual ~Switch();
+
+		/// Sets up a SwitchComputeNode or SwitchDependencyNode
+		/// to work with the specified plug type. The passed plug
+		/// is used as a template, but will not be referenced by the
+		/// Switch itself - typically you will pass a plug
+		/// which you will connect to the Switch after calling
+		/// setup().
+		/// \undoable
+		void setup( const Plug *plug );
 
 		IntPlug *indexPlug();
 		const IntPlug *indexPlug() const;

--- a/include/Gaffer/Switch.inl
+++ b/include/Gaffer/Switch.inl
@@ -106,6 +106,33 @@ Switch<BaseType>::~Switch()
 }
 
 template<typename BaseType>
+void Switch<BaseType>::setup( const Plug *plug )
+{
+	if( BaseType::template getChild<Plug>( "in") )
+	{
+		throw IECore::Exception( "Switch already has an \"in\" plug." );
+	}
+	if( BaseType::template getChild<Plug>( "out" ) )
+	{
+		throw IECore::Exception( "Switch already has an \"out\" plug." );
+	}
+
+	ArrayPlugPtr in = new ArrayPlug(
+		"in",
+		Plug::In,
+		plug->createCounterpart( "in0", Plug::In ),
+		0,
+		Imath::limits<size_t>::max(),
+		Plug::Default | Plug::Dynamic
+	);
+	BaseType::addChild( in );
+
+	PlugPtr out = plug->createCounterpart( "out", Plug::Out );
+	out->setFlags( Plug::Dynamic, true );
+	BaseType::addChild( out );
+}
+
+template<typename BaseType>
 IntPlug *Switch<BaseType>::indexPlug()
 {
 	return BaseType::template getChild<IntPlug>( g_firstPlugIndex );

--- a/include/Gaffer/Switch.inl
+++ b/include/Gaffer/Switch.inl
@@ -40,6 +40,7 @@
 
 #include "Gaffer/Switch.h"
 #include "Gaffer/ArrayPlug.h"
+#include "Gaffer/Context.h"
 
 namespace Gaffer
 {
@@ -130,6 +131,23 @@ void Switch<BaseType>::setup( const Plug *plug )
 	PlugPtr out = plug->createCounterpart( "out", Plug::Out );
 	out->setFlags( Plug::Dynamic, true );
 	BaseType::addChild( out );
+}
+
+template<typename BaseType>
+Plug *Switch<BaseType>::activeInPlug()
+{
+	ArrayPlug *inputs = BaseType::template getChild<ArrayPlug>( "in" );
+	if( !inputs )
+	{
+		return NULL;
+	}
+	return inputs->getChild<Plug>( inputIndex( Context::current() ) );
+}
+
+template<typename BaseType>
+const Plug *Switch<BaseType>::activeInPlug() const
+{
+	return const_cast<Switch *>( this )->activeInPlug();
 }
 
 template<typename BaseType>

--- a/include/GafferBindings/SwitchBinding.h
+++ b/include/GafferBindings/SwitchBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERBINDINGS_SWITCHBINDING_H
+#define GAFFERBINDINGS_SWITCHBINDING_H
+
+namespace GafferBindings
+{
+
+void bindSwitch();
+
+} // namespace GafferBindings
+
+#endif // GAFFERBINDINGS_SWITCHBINDING_H

--- a/include/GafferScene/ShaderSwitch.h
+++ b/include/GafferScene/ShaderSwitch.h
@@ -44,7 +44,7 @@
 namespace GafferScene
 {
 
-class ShaderSwitch : public Gaffer::SwitchDependencyNode
+class ShaderSwitch : public Gaffer::SwitchComputeNode
 {
 
 	public :
@@ -52,7 +52,7 @@ class ShaderSwitch : public Gaffer::SwitchDependencyNode
 		ShaderSwitch( const std::string &name=defaultName<ShaderSwitch>() );
 		virtual ~ShaderSwitch();
 
-		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ShaderSwitch, ShaderSwitchTypeId, Gaffer::SwitchDependencyNode );
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ShaderSwitch, ShaderSwitchTypeId, Gaffer::SwitchComputeNode );
 
 };
 

--- a/include/GafferUI/CompoundNodule.h
+++ b/include/GafferUI/CompoundNodule.h
@@ -38,6 +38,8 @@
 #ifndef GAFFERUI_COMPOUNDNODULE_H
 #define GAFFERUI_COMPOUNDNODULE_H
 
+#include "Gaffer/Metadata.h"
+
 #include "GafferUI/Nodule.h"
 #include "GafferUI/LinearContainer.h"
 
@@ -83,6 +85,8 @@ class CompoundNodule : public Nodule
 
 		void childAdded( Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
 		void childRemoved( Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
+
+		void plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
 
 		typedef std::map<const Gaffer::Plug *, Nodule *> NoduleMap;
 		NoduleMap m_nodules;

--- a/include/GafferUI/ImageGadget.h
+++ b/include/GafferUI/ImageGadget.h
@@ -40,6 +40,8 @@
 
 #include "IECore/ImagePrimitive.h"
 
+#include "IECoreGL/TextureLoader.h"
+
 #include "GafferUI/Gadget.h"
 
 namespace IECoreGL
@@ -68,6 +70,12 @@ class ImageGadget : public Gadget
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::ImageGadget, ImageGadgetTypeId, Gadget );
 
 		virtual Imath::Box3f bound() const;
+
+		/// Returns the texture loader used for converting images
+		/// on disk into textures for rendering. This is exposed
+		/// publicly so that other code can share the same texture
+		/// cache.
+		static IECoreGL::TextureLoader *textureLoader();
 
 	protected :
 

--- a/include/GafferUI/PlugAdder.h
+++ b/include/GafferUI/PlugAdder.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2011-2012, John Haddon. All rights reserved.
-//  Copyright (c) 2011-2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,51 +34,67 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERUI_TYPEIDS_H
-#define GAFFERUI_TYPEIDS_H
+#ifndef GAFFERUI_PLUGADDER_H
+#define GAFFERUI_PLUGADDER_H
+
+#include "GafferUI/StandardNodeGadget.h"
 
 namespace GafferUI
 {
 
-enum TypeId
+/// \todo Support Box and Dot in addition to Switch.
+class PlugAdder : public Gadget
 {
-	GadgetTypeId = 110251,
-	NodeGadgetTypeId = 110252,
-	GraphGadgetTypeId = 110253,
-	ContainerGadgetTypeId = 110254,
-	RenderableGadgetTypeId = 110255,
-	TextGadgetTypeId = 110256,
-	NameGadgetTypeId = 110257,
-	IndividualContainerTypeId = 110258,
-	FrameTypeId = 110259,
-	StyleTypeId = 110260,
-	StandardStyleTypeId = 110261,
-	NoduleTypeId = 110262,
-	LinearContainerTypeId = 110263,
-	ConnectionGadgetTypeId = 110264,
-	StandardNodeGadgetTypeId = 110265,
-	SplinePlugGadgetTypeId = 110266,
-	StandardNoduleTypeId = 110267,
-	CompoundNoduleTypeId = 110268,
-	ImageGadgetTypeId = 110269,
-	ViewportGadgetTypeId = 110270,
-	ViewTypeId = 110271,
-	View3DTypeId = 110272, // Obsolete - available for reuse
-	ObjectViewTypeId = 110273, // Obsolete - available for reuse
-	PlugGadgetTypeId = 110274,
-	GraphLayoutTypeId = 110275,
-	StandardGraphLayoutTypeId = 110276,
-	BackdropNodeGadgetTypeId = 110277,
-	SpacerGadgetTypeId = 110278,
-	StandardConnectionGadgetTypeId = 110279,
-	HandleTypeId = 110280,
-	ToolTypeId = 110281,
-	DotNodeGadgetTypeId = 110282,
-	PlugAdderTypeId = 110283,
 
-	LastTypeId = 110450
+	public :
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::PlugAdder, PlugAdderTypeId, Gadget );
+
+		PlugAdder( Gaffer::NodePtr node, StandardNodeGadget::Edge edge );
+		virtual ~PlugAdder();
+
+		virtual Imath::Box3f bound() const;
+
+		void updateDragEndPoint( const Imath::V3f position, const Imath::V3f &tangent );
+
+	protected :
+
+		virtual void doRender( const Style *style ) const;
+
+	private :
+
+		friend class StandardNodule;
+		void addPlug( Gaffer::Plug *connectionEndPoint );
+
+		void childAdded();
+		void childRemoved();
+
+		void updateVisibility();
+
+		void enter( GadgetPtr gadget, const ButtonEvent &event );
+		void leave( GadgetPtr gadget, const ButtonEvent &event );
+		bool buttonPress( GadgetPtr gadget, const ButtonEvent &event );
+		IECore::RunTimeTypedPtr dragBegin( GadgetPtr gadget, const ButtonEvent &event );
+		bool dragEnter( const DragDropEvent &event );
+		bool dragMove( GadgetPtr gadget, const DragDropEvent &event );
+		bool dragLeave( const DragDropEvent &event );
+		bool drop( const DragDropEvent &event );
+		bool dragEnd( const DragDropEvent &event );
+
+		Gaffer::NodePtr m_node;
+		StandardNodeGadget::Edge m_edge;
+
+		bool m_dragging;
+		Imath::V3f m_dragPosition;
+		Imath::V3f m_dragTangent;
+
 };
+
+IE_CORE_DECLAREPTR( PlugAdder )
+
+typedef Gaffer::FilteredChildIterator<Gaffer::TypePredicate<PlugAdder> > PlugAdderIterator;
+typedef Gaffer::FilteredRecursiveChildIterator<Gaffer::TypePredicate<PlugAdder> > RecursivePlugAdderIterator;
 
 } // namespace GafferUI
 
-#endif // GAFFERUI_TYPEIDS_H
+#endif // GAFFERUI_PLUGADDER_H

--- a/include/GafferUI/Private/SwitchNodeGadget.h
+++ b/include/GafferUI/Private/SwitchNodeGadget.h
@@ -34,33 +34,32 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "Gaffer/Switch.h"
+#ifndef GAFFERUI_PRIVATE_SWITCHNODEGADGET_H
+#define GAFFERUI_PRIVATE_SWITCHNODEGADGET_H
 
-#include "GafferUI/Nodule.h"
-#include "GafferUI/PlugAdder.h"
-#include "GafferUI/Private/SwitchNodeGadget.h"
+#include "GafferUI/StandardNodeGadget.h"
 
-using namespace Gaffer;
-using namespace GafferUI;
-using namespace GafferUI::Private;
-
-StandardNodeGadget::NodeGadgetTypeDescription<SwitchNodeGadget> SwitchNodeGadget::g_nodeGadgetTypeDescription( SwitchComputeNode::staticTypeId() );
-
-SwitchNodeGadget::SwitchNodeGadget( Gaffer::NodePtr node )
-	:	StandardNodeGadget( node )
+namespace GafferUI
 {
-	setEdgeGadget( LeftEdge, new PlugAdder( node, LeftEdge ) );
-	setEdgeGadget( RightEdge, new PlugAdder( node, RightEdge ) );
-	if( !node->isInstanceOf( "GafferScene::ShaderSwitch" ) )
-	{
-		/// \todo Either remove ShaderSwitch on the grounds that it
-		/// doesn't really do anything above and beyond a regular
-		/// SwitchComputeNode, or come up with a metadata convention
-		/// to control this behaviour. What would be really nice is
-		/// to control the whole of the NodeGadget layout using the
-		/// same metadata conventions as the PlugLayout on the widget
-		/// side of things.
-		setEdgeGadget( TopEdge, new PlugAdder( node, TopEdge ) );
-		setEdgeGadget( BottomEdge, new PlugAdder( node, BottomEdge ) );
-	}
-}
+
+namespace Private
+{
+
+class SwitchNodeGadget : public StandardNodeGadget
+{
+
+	public :
+
+		SwitchNodeGadget( Gaffer::NodePtr node );
+
+	private :
+
+		static NodeGadgetTypeDescription<SwitchNodeGadget> g_nodeGadgetTypeDescription;
+
+};
+
+} // namespace Private
+
+} // namespace GafferUI
+
+#endif // GAFFERUI_PRIVATE_SWITCHNODEGADGET_H

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -46,6 +46,8 @@
 namespace GafferUI
 {
 
+class PlugAdder;
+
 /// The standard means of representing a Node in a GraphGadget.
 /// Nodes are represented as rectangular boxes with the name displayed
 /// centrally and the nodules arranged at the sides. Supports the following
@@ -143,8 +145,9 @@ class StandardNodeGadget : public NodeGadget
 		bool dragLeave( GadgetPtr gadget, const DragDropEvent &event );
 		bool drop( GadgetPtr gadget, const DragDropEvent &event );
 
-		Nodule *closestCompatibleNodule( const DragDropEvent &event );
-		bool noduleIsCompatible( const Nodule *nodule, const DragDropEvent &event );
+		Gadget *closestDragDestinationProxy( const DragDropEvent &event ) const;
+		bool noduleIsCompatible( const Nodule *nodule, const DragDropEvent &event ) const;
+		bool plugAdderIsCompatible( const PlugAdder *plugAdder, const DragDropEvent &event ) const;
 
 		void plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
 		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node );
@@ -162,9 +165,12 @@ class StandardNodeGadget : public NodeGadget
 
 		bool m_nodeEnabled;
 		bool m_labelsVisibleOnHover;
-		// we accept drags from nodules and forward them to the
-		// closest compatible child nodule - m_dragDestinationProxy.
-		Nodule *m_dragDestinationProxy;
+		// We accept drags onto the node itself and
+		// forward them to the nearest compatible
+		// Nodule or PlugAdder. This provides the user
+		// with a bigger drag target that is easier
+		// to hit.
+		Gadget *m_dragDestinationProxy;
 		boost::optional<Imath::Color3f> m_userColor;
 
 };

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -92,10 +92,8 @@ class StandardNodeGadget : public NodeGadget
 		void setContents( GadgetPtr contents );
 		Gadget *getContents();
 		const Gadget *getContents() const;
-		/// Additional Gadgets can be placed alongside the
+		/// Places an additional Gadgets alongside the
 		/// Nodules at the end of each outside edge.
-		/// Initially these are SpacerGadgets, but they can
-		/// be replaced with anything.
 		void setEdgeGadget( Edge edge, GadgetPtr gadget );
 		Gadget *getEdgeGadget( Edge edge );
 		const Gadget *getEdgeGadget( Edge edge ) const;

--- a/python/GafferTest/SwitchTest.py
+++ b/python/GafferTest/SwitchTest.py
@@ -45,16 +45,14 @@ class SwitchTest( GafferTest.TestCase ) :
 	def intSwitch( self ) :
 
 		result = Gaffer.SwitchComputeNode()
-		result["in"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		result["out"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic  )
+		result.setup( Gaffer.IntPlug() )
 
 		return result
 
 	def colorSwitch( self ) :
 
 		result = Gaffer.SwitchComputeNode()
-		result["in"] = Gaffer.ArrayPlug( element = Gaffer.Color3fPlug(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		result["out"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		result.setup( Gaffer.Color3fPlug() )
 
 		return result
 

--- a/python/GafferTest/SwitchTest.py
+++ b/python/GafferTest/SwitchTest.py
@@ -378,6 +378,42 @@ class SwitchTest( GafferTest.TestCase ) :
 		s2 = GafferTest.AddNode()
 		self.assertTrue( switches[0]["in"][0].acceptsInput( s2["sum"] ) )
 
+	def testActiveInPlug( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["a1"] = GafferTest.AddNode()
+		s["a2"] = GafferTest.AddNode()
+
+		s["switch"] = self.intSwitch()
+		s["switch"]["in"][0].setInput( s["a1"]["sum"] )
+		s["switch"]["in"][1].setInput( s["a2"]["sum"] )
+
+		self.assertTrue( s["switch"].activeInPlug().isSame( s["switch"]["in"][0] ) )
+
+		s["switch"]["index"].setValue( 1 )
+		self.assertTrue( s["switch"].activeInPlug().isSame( s["switch"]["in"][1] ) )
+
+		s["switch"]["enabled"].setValue( False )
+		self.assertTrue( s["switch"].activeInPlug().isSame( s["switch"]["in"][0] ) )
+
+		s["switch"]["enabled"].setValue( True )
+		self.assertTrue( s["switch"].activeInPlug().isSame( s["switch"]["in"][1] ) )
+
+		s["expression"] = Gaffer.Expression()
+		s["expression"].setExpression( 'parent["switch"]["index"] = context.getFrame()' )
+
+		with Gaffer.Context() as c :
+
+			c.setFrame( 0 )
+			self.assertTrue( s["switch"].activeInPlug().isSame( s["switch"]["in"][0] ) )
+
+			c.setFrame( 1 )
+			self.assertTrue( s["switch"].activeInPlug().isSame( s["switch"]["in"][1] ) )
+
+			c.setFrame( 2 )
+			self.assertTrue( s["switch"].activeInPlug().isSame( s["switch"]["in"][0] ) )
+
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )

--- a/python/GafferUI/SwitchUI.py
+++ b/python/GafferUI/SwitchUI.py
@@ -58,9 +58,23 @@ for nodeType in ( Gaffer.SwitchDependencyNode, Gaffer.SwitchComputeNode ) :
 				of 0 chooses the first input, 1 the second and so on. Values
 				larger than the number of available inputs wrap back around to
 				the beginning.
-				"""
+				""",
 
-			]
+				"nodule:type", "",
+
+			],
+
+			"in" : [
+
+				"description",
+				"""
+				The array of inputs to choose from. One of these is chosen
+				by the index plug to be passed through to the output.
+				""",
+
+				"nodule:type", "GafferUI::CompoundNodule",
+
+			],
 
 		}
 

--- a/python/GafferUI/SwitchUI.py
+++ b/python/GafferUI/SwitchUI.py
@@ -73,6 +73,18 @@ for nodeType in ( Gaffer.SwitchDependencyNode, Gaffer.SwitchComputeNode ) :
 				""",
 
 				"nodule:type", "GafferUI::CompoundNodule",
+				"plugValueWidget:type", "",
+
+			],
+
+			"out" : [
+
+				"description",
+				"""
+				Outputs the input specified by the index.
+				""",
+
+				"plugValueWidget:type", "",
 
 			],
 

--- a/python/GafferUITest/CompoundNoduleTest.py
+++ b/python/GafferUITest/CompoundNoduleTest.py
@@ -1,0 +1,67 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferTest
+import GafferUI
+import GafferUITest
+
+class CompoundNoduleTest( GafferUITest.TestCase ) :
+
+	def testMetadata( self ) :
+
+		arrayNode = GafferTest.ArrayPlugNode()
+		addNode = GafferTest.AddNode()
+
+		arrayNode["in"][0].setInput( addNode["sum"] )
+		arrayNode["in"][1].setInput( addNode["sum"] )
+		arrayNode["in"][2].setInput( addNode["sum"] )
+
+		nodule = GafferUI.CompoundNodule( arrayNode["in"] )
+		size = nodule.bound().size()
+		self.assertTrue( size.x > size.y )
+
+		Gaffer.Metadata.registerValue( arrayNode["in"], "compoundNodule:spacing", 100.0 )
+		self.assertTrue( nodule.bound().size().x > size.x )
+
+		Gaffer.Metadata.registerValue( arrayNode["in"], "compoundNodule:orientation", "y" )
+		size = nodule.bound().size()
+		self.assertTrue( size.y > size.x )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/ImageGadgetTest.py
+++ b/python/GafferUITest/ImageGadgetTest.py
@@ -62,5 +62,16 @@ class ImageGadgetTest( GafferUITest.TestCase ) :
 
 		self.assertRaises( Exception, GafferUI.ImageGadget, "iDonNotExist" )
 
+	def testTextureLoader( self ) :
+
+		# must access an attribute from IECoreGL to force import
+		# before calling textureLoader(), because it is imported
+		# lazily by GafferUI.
+		import IECoreGL
+		IECoreGL.TextureLoader
+
+		l = GafferUI.ImageGadget.textureLoader()
+		self.assertTrue( isinstance( l, IECoreGL.TextureLoader ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/StandardGraphLayoutTest.py
+++ b/python/GafferUITest/StandardGraphLayoutTest.py
@@ -729,5 +729,17 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		self.assertTrue( s["d"]["out"].source().isSame( s["n1"]["sum"] ) )
 		self.assertTrue( s["n2"]["op1"].getInput().isSame( s["d"]["out"] ) )
 
+	def testConnectSwitch( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = GafferTest.AddNode()
+		s["s"] = Gaffer.SwitchComputeNode()
+
+		g = GafferUI.GraphGadget( s )
+		g.getLayout().connectNode( g, s["s"], Gaffer.StandardSet( [ s["n"] ] ) )
+
+		self.assertTrue( isinstance( s["s"]["in"][0], Gaffer.IntPlug ) )
+		self.assertTrue( s["s"]["in"][0].getInput().isSame( s["n"]["sum"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/StandardNodeGadgetTest.py
+++ b/python/GafferUITest/StandardNodeGadgetTest.py
@@ -148,9 +148,13 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 		g = GafferUI.StandardNodeGadget( n )
 
 		for name, edge in g.Edge.names.items() :
+			self.assertTrue( g.getEdgeGadget( edge ) is None )
 			eg = GafferUI.TextGadget( name )
 			g.setEdgeGadget( edge, eg )
 			self.assertTrue( g.getEdgeGadget( edge ).isSame( eg ) )
+			g.setEdgeGadget( edge, None )
+			self.assertTrue( g.getEdgeGadget( edge ) is None )
+			self.assertTrue( eg.parent() is None )
 
 	def testEdgeGadgetsAndNoduleAddition( self ) :
 

--- a/python/GafferUITest/SwitchNodeGadgetTest.py
+++ b/python/GafferUITest/SwitchNodeGadgetTest.py
@@ -1,0 +1,58 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferUI
+import GafferUITest
+
+class SwitchNodeGadgetTest( GafferUITest.TestCase ) :
+
+	def testPythonBinding( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.SwitchComputeNode()
+
+		g = GafferUI.NodeGadget.create( s["n"] )
+		self.assertTrue( isinstance( g, GafferUI.StandardNodeGadget ) )
+		self.assertTrue( type( g ) is GafferUI.StandardNodeGadget )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -107,6 +107,7 @@ from CompoundDataPlugValueWidgetTest import CompoundDataPlugValueWidgetTest
 from GraphGadgetTest import GraphGadgetTest
 from MenuBarTest import MenuBarTest
 from GadgetWidgetTest import GadgetWidgetTest
+from CompoundNoduleTest import CompoundNoduleTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -108,6 +108,7 @@ from GraphGadgetTest import GraphGadgetTest
 from MenuBarTest import MenuBarTest
 from GadgetWidgetTest import GadgetWidgetTest
 from CompoundNoduleTest import CompoundNoduleTest
+from SwitchNodeGadgetTest import SwitchNodeGadgetTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -13,7 +13,7 @@
    height="1000"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.1 r9760"
+   inkscape:version="0.47 r22583"
    sodipodi:docname="graphics.svg"
    enable-background="new">
   <defs
@@ -128,19 +128,19 @@
      borderopacity="1"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="2"
-     inkscape:cx="306.05847"
-     inkscape:cy="808.91184"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="85.242348"
+     inkscape:cy="607.00699"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="1440"
-     inkscape:window-height="856"
-     inkscape:window-x="-2"
-     inkscape:window-y="0"
+     inkscape:window-width="1304"
+     inkscape:window-height="887"
+     inkscape:window-x="119"
+     inkscape:window-y="25"
      inkscape:window-maximized="0"
      inkscape:snap-global="true"
-     inkscape:snap-nodes="false"
+     inkscape:snap-nodes="true"
      inkscape:snap-bbox="true"
      inkscape:object-nodes="true"
      inkscape:snap-object-midpoints="false"
@@ -176,6 +176,14 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-52.362183)">
+    <rect
+       style="fill:none;fill-opacity:1;stroke:none"
+       id="forExport:plugAdder"
+       width="32"
+       height="32"
+       x="8"
+       y="465.36218"
+       inkscape:label="#rect3255" />
     <rect
        y="242.36218"
        x="440"
@@ -264,7 +272,7 @@
        inkscape:export-ydpi="10">
       <path
          transform="matrix(0,-0.65333366,0.646633,0,-363.80332,137.72889)"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
          inkscape:randomized="0"
          inkscape:rounded="0"
          inkscape:flatsided="true"
@@ -320,7 +328,7 @@
          inkscape:flatsided="true"
          inkscape:rounded="0"
          inkscape:randomized="0"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
          transform="matrix(0,-0.65333366,0.646633,0,-363.80333,137.72891)" />
       <rect
          style="fill:none;stroke:none"
@@ -350,7 +358,7 @@
          inkscape:flatsided="true"
          inkscape:rounded="0"
          inkscape:randomized="0"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
          transform="matrix(0,-0.65333366,0.646633,0,-363.80333,137.7289)" />
       <rect
          style="fill:none;stroke:none"
@@ -368,7 +376,7 @@
        inkscape:export-ydpi="10">
       <path
          transform="matrix(0,-0.65333366,0.646633,0,-363.80333,137.22889)"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
          inkscape:randomized="0"
          inkscape:rounded="0"
          inkscape:flatsided="true"
@@ -392,7 +400,7 @@
     </g>
     <path
        transform="matrix(-0.65333366,0,0,0.646633,135.86671,-311.44114)"
-       d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+       d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
        inkscape:randomized="0"
        inkscape:rounded="0"
        inkscape:flatsided="true"
@@ -435,7 +443,7 @@
          inkscape:flatsided="true"
          inkscape:rounded="0"
          inkscape:randomized="0"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
          transform="matrix(0,-0.65333366,0.646633,0,-363.80333,137.72889)" />
       <rect
          style="fill:none;stroke:none"
@@ -459,7 +467,7 @@
        inkscape:flatsided="true"
        inkscape:rounded="0"
        inkscape:randomized="0"
-       d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+       d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
        transform="matrix(0,-0.65333366,-0.646633,0,423.30333,137.72889)"
        inkscape:label="#path2847" />
     <rect
@@ -551,7 +559,7 @@
        inkscape:flatsided="true"
        inkscape:rounded="0"
        inkscape:randomized="0"
-       d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+       d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
        transform="matrix(-0.65333366,0,0,0.646633,155.86671,-311.44114)"
        inkscape:label="#forExport:collapsibleArrowRightHover" />
     <rect
@@ -565,7 +573,7 @@
        inkscape:label="#rect2914" />
     <path
        transform="matrix(0,-0.65333366,-0.646633,0,443.30333,137.72889)"
-       d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+       d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
        inkscape:randomized="0"
        inkscape:rounded="0"
        inkscape:flatsided="true"
@@ -1772,7 +1780,7 @@
        inkscape:flatsided="false"
        inkscape:rounded="0"
        inkscape:randomized="0"
-       d="m 302.30138,18.423424 -3.43097,-2.443491 -3.44073,2.429728 1.26367,-4.018128 -3.37406,-2.521504 4.21197,-0.03985 1.35545,-3.9881025 1.33946,3.9935005 4.21177,0.05672 -3.38412,2.507967 z"
+       d="m 302.30138,18.423424 -3.43097,-2.443491 -3.44073,2.429728 1.26367,-4.018128 -3.37406,-2.521504 4.21197,-0.03985 1.35545,-3.9881025 1.33946,3.9935005 4.21177,0.05672 -3.38412,2.507967 1.24756,4.023158 z"
        transform="matrix(1.2498253,0,0,1.2508721,-71.090254,52.672228)"
        inkscape:label="#path3064" />
     <rect
@@ -2351,7 +2359,7 @@
          inkscape:flatsided="true"
          inkscape:rounded="0"
          inkscape:randomized="0"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
          transform="matrix(0,-0.65333366,0.646633,0,-333.80333,151.72889)" />
     </g>
     <g
@@ -2556,7 +2564,7 @@
        inkscape:flatsided="false"
        inkscape:rounded="0"
        inkscape:randomized="0"
-       d="m 302.30138,18.423424 -3.26391,-3.457531 -2.55071,4.0569 1.36235,-4.555392 -4.78873,-0.180534 4.62626,-1.097861 -2.23802,-4.2374343 3.26391,3.4575313 2.55071,-4.0569002 -1.36235,4.5553922 4.78873,0.180534 -4.62626,1.097861 z"
+       d="m 302.30138,18.423424 -3.26391,-3.457531 -2.55071,4.0569 1.36235,-4.555392 -4.78873,-0.180534 4.62626,-1.097861 -2.23802,-4.2374343 3.26391,3.4575313 2.55071,-4.0569002 -1.36235,4.5553922 4.78873,0.180534 -4.62626,1.097861 2.23802,4.237434 z"
        transform="matrix(1.1039167,-0.49853331,0.49895085,1.1048412,55.474744,203.81434)"
        inkscape:label="#path3064" />
     <path
@@ -3110,6 +3118,48 @@
          id="path4241"
          d="m 336.5,148.36218 0,-14.5 10,11 -4,0 2,3.5 0,2.5 -2.5,0 -2.5,-5 z"
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
+    <g
+       id="g4065"
+       transform="matrix(1.7499936,0,0,1.7499936,-5.7499423,-348.76863)">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#262626;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 13.571445,466.36217 0,4.57145 -4.5714451,0 0,6.85716 4.5714451,0 0,4.57145 6.857168,0 0,-4.57145 4.571445,0 0,-6.85716 -4.571445,0 0,-4.57145 -6.857168,0 z"
+         id="fsd"
+         sodipodi:nodetypes="ccccccccccccc"
+         inkscape:label="#rect3638" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3257"
+         d="m 14.714307,467.50503 0,4.57145 -4.571446,0 0,4.57144 4.571446,0 0,4.57145 4.571445,0 0,-4.57145 4.571445,0 0,-4.57144 -4.571445,0 0,-4.57145 -4.571445,0 z"
+         style="fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         sodipodi:nodetypes="ccccccccccccc" />
+    </g>
+    <rect
+       inkscape:label="#rect3255"
+       y="465.36218"
+       x="48"
+       height="32"
+       width="32"
+       id="forExport:plugAdderHighlighted"
+       style="fill:none;stroke:none" />
+    <g
+       transform="matrix(1.7499936,0,0,1.7499936,34.250058,-348.76863)"
+       id="g3259">
+      <path
+         inkscape:label="#rect3638"
+         sodipodi:nodetypes="ccccccccccccc"
+         id="path3262"
+         d="m 13.571445,466.36217 0,4.57145 -4.5714451,0 0,6.85716 4.5714451,0 0,4.57145 6.857168,0 0,-4.57145 4.571445,0 0,-6.85716 -4.571445,0 0,-4.57145 -6.857168,0 z"
+         style="fill:#262626;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccccccccccc"
+         style="fill:#779cbd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 14.714307,467.50503 0,4.57145 -4.571446,0 0,4.57144 4.571446,0 0,4.57145 4.571445,0 0,-4.57145 4.571445,0 0,-4.57144 -4.571445,0 0,-4.57145 -4.571445,0 z"
+         id="path3264"
+         inkscape:connector-curvature="0" />
     </g>
   </g>
 </svg>

--- a/src/GafferBindings/SwitchBinding.cpp
+++ b/src/GafferBindings/SwitchBinding.cpp
@@ -1,0 +1,63 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "Gaffer/Switch.h"
+#include "GafferBindings/DependencyNodeBinding.h"
+#include "GafferBindings/SwitchBinding.h"
+
+using namespace Gaffer;
+using namespace GafferBindings;
+
+namespace
+{
+
+template<typename T>
+void bind()
+{
+	DependencyNodeClass<T>()
+		.def( "setup", &T::setup )
+	;
+}
+
+} // namespace
+
+void GafferBindings::bindSwitch()
+{
+	bind<SwitchDependencyNode>();
+	bind<SwitchComputeNode>();
+}

--- a/src/GafferBindings/SwitchBinding.cpp
+++ b/src/GafferBindings/SwitchBinding.cpp
@@ -40,6 +40,8 @@
 #include "GafferBindings/DependencyNodeBinding.h"
 #include "GafferBindings/SwitchBinding.h"
 
+using namespace boost::python;
+using namespace IECorePython;
 using namespace Gaffer;
 using namespace GafferBindings;
 
@@ -51,6 +53,7 @@ void bind()
 {
 	DependencyNodeClass<T>()
 		.def( "setup", &T::setup )
+		.def( "activeInPlug", (Plug *(T::*)())&T::activeInPlug, return_value_policy<CastToIntrusivePtr>() )
 	;
 }
 

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -40,7 +40,6 @@
 #include "Gaffer/TimeWarp.h"
 #include "Gaffer/ContextVariables.h"
 #include "Gaffer/Backdrop.h"
-#include "Gaffer/Switch.h"
 #include "Gaffer/Loop.h"
 
 #include "GafferBindings/ConnectionBinding.h"
@@ -92,6 +91,7 @@
 #include "GafferBindings/AnimationBinding.h"
 #include "GafferBindings/MonitorBinding.h"
 #include "GafferBindings/MetadataAlgoBinding.h"
+#include "GafferBindings/SwitchBinding.h"
 
 using namespace boost::python;
 using namespace Gaffer;
@@ -187,14 +187,13 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindAnimation();
 	bindMonitor();
 	bindMetadataAlgo();
+	bindSwitch();
 
 	NodeClass<Backdrop>();
 
 	DependencyNodeClass<ContextProcessorComputeNode>();
 	DependencyNodeClass<TimeWarpComputeNode>();
 	DependencyNodeClass<ContextVariablesComputeNode>();
-	DependencyNodeClass<SwitchDependencyNode>();
-	DependencyNodeClass<SwitchComputeNode>();
 	DependencyNodeClass<LoopComputeNode>();
 
 	object tsi = class_<TaskSchedulerInitWrapper, boost::noncopyable>( "_tbb_task_scheduler_init", no_init )

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -47,6 +47,7 @@
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/Metadata.h"
 #include "Gaffer/ScriptNode.h"
+#include "Gaffer/Switch.h"
 
 #include "GafferScene/Shader.h"
 
@@ -214,6 +215,18 @@ class Shader::NetworkBuilder
 				{
 					assert( isInputParameter( parameterPlug ) );
 					const Gaffer::Plug *source = parameterPlug->source<Gaffer::Plug>();
+
+					if( const SwitchComputeNode *switchNode = source->parent<SwitchComputeNode>() )
+					{
+						// Special case for switches with context-varying index values.
+						// Query the active input for this context, and manually traverse
+						// out the other side.
+						if( const Plug *activeInPlug = switchNode->activeInPlug() )
+						{
+							source = activeInPlug->source<Plug>();
+						}
+					}
+
 					if( source == parameterPlug || !isParameter( source ) )
 					{
 						return parameterPlug;

--- a/src/GafferScene/ShaderSwitch.cpp
+++ b/src/GafferScene/ShaderSwitch.cpp
@@ -44,13 +44,8 @@ using namespace GafferScene;
 IE_CORE_DEFINERUNTIMETYPED( ShaderSwitch );
 
 ShaderSwitch::ShaderSwitch( const std::string &name )
-	:	SwitchDependencyNode( name )
+	:	SwitchComputeNode( name )
 {
-	// We don't need to do anything other than create an input
-	// plug and an output plug - the SwitchDependencyNode takes care of
-	// everything else.
-	addChild( new ArrayPlug( "in", Plug::In, new Plug( "in0" ) ) );
-	addChild( new Plug( "out", Plug::Out ) );
 }
 
 ShaderSwitch::~ShaderSwitch()

--- a/src/GafferSceneTest/TestShader.cpp
+++ b/src/GafferSceneTest/TestShader.cpp
@@ -49,6 +49,7 @@ TestShader::TestShader( const std::string &name )
 {
 	addChild( new Color3fPlug( "out", Plug::Out ) );
 	parametersPlug()->addChild( new IntPlug( "i" ) );
+	parametersPlug()->addChild( new Color3fPlug( "c" ) );
 }
 
 TestShader::~TestShader()

--- a/src/GafferUI/ImageGadget.cpp
+++ b/src/GafferUI/ImageGadget.cpp
@@ -105,21 +105,25 @@ ImageGadget::~ImageGadget()
 {
 }
 
+IECoreGL::TextureLoader *ImageGadget::textureLoader()
+{
+	static TextureLoaderPtr loader = NULL;
+	if( !loader )
+	{
+		const char *s = getenv( "GAFFERUI_IMAGE_PATHS" );
+		IECore::SearchPath sp( s ? s : "", ":" );
+		loader = new TextureLoader( sp );
+	}
+	return loader.get();
+}
+
 void ImageGadget::doRender( const Style *style ) const
 {
 
 	if( const StringData *filename = runTimeCast<const StringData>( m_imageOrTextureOrFileName.get() ) )
 	{
 		// load texture from file
-		static TextureLoaderPtr g_textureLoader = 0;
-		if( !g_textureLoader )
-		{
-			const char *s = getenv( "GAFFERUI_IMAGE_PATHS" );
-			IECore::SearchPath sp( s ? s : "", ":" );
-			g_textureLoader = new TextureLoader( sp );
-		}
-
-		m_imageOrTextureOrFileName = g_textureLoader->load( filename->readable() );
+		m_imageOrTextureOrFileName = textureLoader()->load( filename->readable() );
 	}
 	else if( const ImagePrimitive *image = runTimeCast<const ImagePrimitive>( m_imageOrTextureOrFileName.get() ) )
 	{

--- a/src/GafferUI/ImageGadget.cpp
+++ b/src/GafferUI/ImageGadget.cpp
@@ -51,9 +51,14 @@ using namespace IECore;
 using namespace IECoreGL;
 using namespace GafferUI;
 
-IE_CORE_DEFINERUNTIMETYPED( ImageGadget );
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
 
-static Box3f boundGetter( const std::string &fileName, size_t &cost )
+namespace
+{
+
+Box3f boundGetter( const std::string &fileName, size_t &cost )
 {
 	const char *s = getenv( "GAFFERUI_IMAGE_PATHS" );
 	IECore::SearchPath sp( s ? s : "", ":" );
@@ -81,6 +86,49 @@ static Box3f boundGetter( const std::string &fileName, size_t &cost )
 	V3f size( pixelSize.x, pixelSize.y, 0.0f );
 	return Box3f( -size/2.0f, size/2.0f );
 }
+
+const IECoreGL::Texture *loadTexture( IECore::ConstRunTimeTypedPtr &imageOrTextureOrFileName )
+{
+	if( const Texture *texture = runTimeCast<const Texture>( imageOrTextureOrFileName.get() ) )
+	{
+		return texture;
+	}
+
+	TexturePtr texture;
+	if( const StringData *filename = runTimeCast<const StringData>( imageOrTextureOrFileName.get() ) )
+	{
+		// Load texture from file
+		texture = ImageGadget::textureLoader()->load( filename->readable() );
+	}
+	else if( const ImagePrimitive *image = runTimeCast<const ImagePrimitive>( imageOrTextureOrFileName.get() ) )
+	{
+		// Convert image to texture
+		ToGLTextureConverterPtr converter = new ToGLTextureConverter( image );
+		texture =  boost::static_pointer_cast<Texture>( converter->convert() );
+	}
+
+	if( texture )
+	{
+		IECoreGL::Texture::ScopedBinding binding( *texture );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
+		glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, -1.0 );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
+	}
+
+	imageOrTextureOrFileName = texture;
+
+	return texture.get();
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// ImageGadget
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( ImageGadget );
 
 ImageGadget::ImageGadget( const std::string &fileName )
 	:	Gadget( defaultName<ImageGadget>() )
@@ -119,21 +167,7 @@ IECoreGL::TextureLoader *ImageGadget::textureLoader()
 
 void ImageGadget::doRender( const Style *style ) const
 {
-
-	if( const StringData *filename = runTimeCast<const StringData>( m_imageOrTextureOrFileName.get() ) )
-	{
-		// load texture from file
-		m_imageOrTextureOrFileName = textureLoader()->load( filename->readable() );
-	}
-	else if( const ImagePrimitive *image = runTimeCast<const ImagePrimitive>( m_imageOrTextureOrFileName.get() ) )
-	{
-		// convert image to texture
-		ToGLTextureConverterPtr converter = new ToGLTextureConverter( image );
-		m_imageOrTextureOrFileName = converter->convert();
-	}
-
-	// render texture
-	if( const Texture *texture = runTimeCast<const Texture>( m_imageOrTextureOrFileName.get() ) )
+	if( const Texture *texture = loadTexture( m_imageOrTextureOrFileName ) )
 	{
 		Box2f b( V2f( m_bound.min.x, m_bound.min.y ), V2f( m_bound.max.x, m_bound.max.y ) );
 		style->renderImage( b, texture );

--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -1,0 +1,354 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/bind.hpp"
+
+#include "IECoreGL/Texture.h"
+#include "IECoreGL/Selector.h"
+
+#include "Gaffer/UndoContext.h"
+#include "Gaffer/ScriptNode.h"
+#include "Gaffer/Switch.h"
+#include "Gaffer/ArrayPlug.h"
+#include "Gaffer/Metadata.h"
+
+#include "GafferUI/Nodule.h"
+#include "GafferUI/ImageGadget.h"
+#include "GafferUI/PlugAdder.h"
+#include "GafferUI/Style.h"
+#include "GafferUI/ConnectionGadget.h"
+
+using namespace Imath;
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferUI;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+static IECoreGL::Texture *texture( Style::State state )
+{
+	static IECoreGL::TexturePtr normalTexture = NULL;
+	static IECoreGL::TexturePtr highlightedTexture = NULL;
+
+	IECoreGL::TexturePtr &texture = state == Style::HighlightedState ? highlightedTexture : normalTexture;
+	if( !texture )
+	{
+		texture = ImageGadget::textureLoader()->load(
+			state == Style::HighlightedState ? "plugAdderHighlighted.png" : "plugAdder.png"
+		);
+
+		IECoreGL::Texture::ScopedBinding binding( *texture );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST );
+	}
+	return texture.get();
+}
+
+V3f edgeTangent( StandardNodeGadget::Edge edge )
+{
+	switch( edge )
+	{
+		case StandardNodeGadget::TopEdge :
+			return V3f( 0, 1, 0 );
+		case StandardNodeGadget::BottomEdge :
+			return V3f( 0, -1, 0 );
+		case StandardNodeGadget::LeftEdge :
+			return V3f( -1, 0, 0 );
+		default :
+			return V3f( 1, 0, 0 );
+	}
+}
+
+StandardNodeGadget::Edge oppositeEdge( StandardNodeGadget::Edge edge )
+{
+	switch( edge )
+	{
+		case StandardNodeGadget::TopEdge :
+			return StandardNodeGadget::BottomEdge;
+		case StandardNodeGadget::BottomEdge :
+			return StandardNodeGadget::TopEdge;
+		case StandardNodeGadget::LeftEdge :
+			return StandardNodeGadget::RightEdge;
+		default :
+			return StandardNodeGadget::LeftEdge;
+	}
+}
+
+const char *edgeName( StandardNodeGadget::Edge edge )
+{
+	switch( edge )
+	{
+		case StandardNodeGadget::TopEdge :
+			return "top";
+		case StandardNodeGadget::BottomEdge :
+			return "bottom";
+		case StandardNodeGadget::LeftEdge :
+			return "left";
+		default :
+			return "right";
+	}
+}
+
+const char *edgeOrientation( StandardNodeGadget::Edge edge )
+{
+	switch( edge )
+	{
+		case StandardNodeGadget::TopEdge :
+		case StandardNodeGadget::BottomEdge :
+			return "x";
+		default :
+			return "y";
+	}
+}
+
+void updateMetadata( Plug *plug, InternedString key, const char *value )
+{
+	ConstStringDataPtr s = Metadata::value<StringData>( plug, key );
+	if( s && s->readable() == value )
+	{
+		// Metadata already has the value we want. No point adding on
+		// an instance override with the exact same value.
+		return;
+	}
+
+	Metadata::registerValue( plug, key, new StringData( value ) );
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// PlugAdder
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( PlugAdder );
+
+PlugAdder::PlugAdder( Gaffer::NodePtr node, StandardNodeGadget::Edge edge )
+	:	m_node( node ), m_edge( edge ), m_dragging( false )
+{
+	node->childAddedSignal().connect( boost::bind( &PlugAdder::childAdded, this ) );
+	node->childRemovedSignal().connect( boost::bind( &PlugAdder::childRemoved, this ) );
+
+	enterSignal().connect( boost::bind( &PlugAdder::enter, this, ::_1, ::_2 ) );
+	leaveSignal().connect( boost::bind( &PlugAdder::leave, this, ::_1, ::_2 ) );
+	buttonPressSignal().connect( boost::bind( &PlugAdder::buttonPress, this, ::_1,  ::_2 ) );
+	dragBeginSignal().connect( boost::bind( &PlugAdder::dragBegin, this, ::_1, ::_2 ) );
+	dragEnterSignal().connect( boost::bind( &PlugAdder::dragEnter, this, ::_2 ) );
+	dragMoveSignal().connect( boost::bind( &PlugAdder::dragMove, this, ::_1, ::_2 ) );
+	dragLeaveSignal().connect( boost::bind( &PlugAdder::dragLeave, this, ::_2 ) );
+	dropSignal().connect( boost::bind( &PlugAdder::drop, this, ::_2 ) );
+	dragEndSignal().connect( boost::bind( &PlugAdder::dragEnd, this, ::_2 ) );
+
+	updateVisibility();
+}
+
+PlugAdder::~PlugAdder()
+{
+}
+
+Imath::Box3f PlugAdder::bound() const
+{
+	return Box3f( V3f( -0.5f, -0.5f, 0.0f ), V3f( 0.5f, 0.5f, 0.0f ) );
+}
+
+void PlugAdder::updateDragEndPoint( const Imath::V3f position, const Imath::V3f &tangent )
+{
+	m_dragPosition = position;
+	m_dragTangent = tangent;
+	m_dragging = true;
+	requestRender();
+}
+
+void PlugAdder::doRender( const Style *style ) const
+{
+	if( m_dragging )
+	{
+		if( !IECoreGL::Selector::currentSelector() )
+		{
+			V3f srcTangent( 0.0f, 0.0f, 0.0f );
+			style->renderConnection( V3f( 0 ), srcTangent, m_dragPosition, m_dragTangent, Style::HighlightedState );
+		}
+	}
+
+	float radius = 0.75f;
+	Style::State state = Style::NormalState;
+	if( getHighlighted() )
+	{
+		radius = 1.25f;
+		state = Style::HighlightedState;
+	}
+	style->renderImage( Box2f( V2f( -radius ), V2f( radius ) ), texture( state ) );
+}
+
+void PlugAdder::addPlug( Gaffer::Plug *connectionEndPoint )
+{
+	UndoContext undoContext( m_node->ancestor<ScriptNode>() );
+
+	if( SwitchComputeNode *switchNode = runTimeCast<SwitchComputeNode>( m_node.get() ) )
+	{
+		switchNode->setup( connectionEndPoint );
+		ArrayPlug *inPlug = switchNode->getChild<ArrayPlug>( "in" );
+		Plug *outPlug = switchNode->getChild<Plug>( "out" );
+
+		StandardNodeGadget::Edge inEdge = StandardNodeGadget::InvalidEdge;
+		if( connectionEndPoint->direction() == Plug::Out )
+		{
+			inPlug->getChild<Plug>( 0 )->setInput( connectionEndPoint );
+			inEdge = m_edge;
+		}
+		else
+		{
+			connectionEndPoint->setInput( switchNode->getChild<Plug>( "out" ) );
+			inEdge = oppositeEdge( m_edge );
+		}
+
+		updateMetadata( inPlug, "nodeGadget:nodulePosition", edgeName( inEdge ) );
+		updateMetadata( inPlug, "compoundNodule:orientation", edgeOrientation( inEdge ) );
+		updateMetadata( outPlug, "nodeGadget:nodulePosition", edgeName( oppositeEdge( inEdge ) ) );
+	}
+}
+
+void PlugAdder::childAdded()
+{
+	updateVisibility();
+}
+
+void PlugAdder::childRemoved()
+{
+	updateVisibility();
+}
+
+void PlugAdder::updateVisibility()
+{
+	if( SwitchComputeNode *switchNode = runTimeCast<SwitchComputeNode>( m_node.get() ) )
+	{
+		setVisible( switchNode->getChild<ArrayPlug>( "in" ) == NULL );
+	}
+}
+
+void PlugAdder::enter( GadgetPtr gadget, const ButtonEvent &event )
+{
+	setHighlighted( true );
+}
+
+void PlugAdder::leave( GadgetPtr gadget, const ButtonEvent &event )
+{
+	setHighlighted( false );
+}
+
+bool PlugAdder::buttonPress( GadgetPtr gadget, const ButtonEvent &event )
+{
+	return event.buttons == ButtonEvent::Left;
+}
+
+IECore::RunTimeTypedPtr PlugAdder::dragBegin( GadgetPtr gadget, const ButtonEvent &event )
+{
+	return this;
+}
+
+bool PlugAdder::dragEnter( const DragDropEvent &event )
+{
+	if( event.buttons != DragDropEvent::Left )
+	{
+		return false;
+	}
+
+	if( event.sourceGadget == this )
+	{
+		updateDragEndPoint( event.line.p0, V3f( 0 ) );
+		return true;
+	}
+
+	const Plug *plug = runTimeCast<Plug>( event.data.get() );
+	if( !plug )
+	{
+		return false;
+	}
+
+	setHighlighted( true );
+
+	V3f center = V3f( 0.0f ) * fullTransform();
+	center = center * event.sourceGadget->fullTransform().inverse();
+	const V3f tangent = edgeTangent( m_edge );
+
+	if( Nodule *sourceNodule = runTimeCast<Nodule>( event.sourceGadget.get() ) )
+	{
+		sourceNodule->updateDragEndPoint( center, tangent );
+	}
+	else if( ConnectionGadget *connectionGadget = runTimeCast<ConnectionGadget>( event.sourceGadget.get() ) )
+	{
+		connectionGadget->updateDragEndPoint( center, tangent );
+	}
+
+	return true;
+}
+
+bool PlugAdder::dragMove( GadgetPtr gadget, const DragDropEvent &event )
+{
+	m_dragPosition = event.line.p0;
+	requestRender();
+	return true;
+}
+
+bool PlugAdder::dragLeave( const DragDropEvent &event )
+{
+	setHighlighted( false );
+	return true;
+}
+
+bool PlugAdder::drop( const DragDropEvent &event )
+{
+	setHighlighted( false );
+
+	if( Plug *plug = runTimeCast<Plug>( event.data.get() ) )
+	{
+		addPlug( plug );
+		return true;
+	}
+
+	return false;
+}
+
+bool PlugAdder::dragEnd( const DragDropEvent &event )
+{
+	m_dragging = false;
+	requestRender();
+	return false;
+}

--- a/src/GafferUI/StandardGraphLayout.cpp
+++ b/src/GafferUI/StandardGraphLayout.cpp
@@ -49,6 +49,7 @@
 #include "Gaffer/DependencyNode.h"
 #include "Gaffer/StandardSet.h"
 #include "Gaffer/Dot.h"
+#include "Gaffer/Switch.h"
 
 #include "GafferUI/StandardGraphLayout.h"
 #include "GafferUI/GraphGadget.h"
@@ -1045,12 +1046,19 @@ bool StandardGraphLayout::connectNodeInternal( GraphGadget *graph, Gaffer::Node 
 		return false;
 	}
 
-	// if we're trying to connect a dot, then we may need to give it plugs first
+	// if we're trying to connect a dot or switch, then we may need to give it plugs first
 	if( Dot *dot = runTimeCast<Dot>( node ) )
 	{
 		if( !dot->inPlug<Plug>() )
 		{
 			dot->setup( outputPlugs.front() );
+		}
+	}
+	else if( SwitchComputeNode *switchNode = runTimeCast<SwitchComputeNode>( node ) )
+	{
+		if( !switchNode->getChild<Plug>( "in" ) )
+		{
+			switchNode->setup( outputPlugs.front() );
 		}
 	}
 

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -670,6 +670,12 @@ void StandardNodeGadget::plugMetadataChanged( IECore::TypeId nodeTypeId, const G
 
 Gadget *StandardNodeGadget::closestDragDestinationProxy( const DragDropEvent &event ) const
 {
+	if( event.buttons != DragDropEvent::Left )
+	{
+		// See comments in StandardNodule::dragEnter()
+		return NULL;
+	}
+
 	Gadget *result = 0;
 	float maxDist = Imath::limits<float>::max();
 	for( RecursiveGadgetIterator it( this ); !it.done(); it++ )

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -268,7 +268,7 @@ bool StandardNodule::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
 	{
 		Gaffer::PlugPtr input, output;
 		connection( event, input, output );
-		accept = input;
+		accept = static_cast<bool>( input );
 	}
 	else if( IECore::runTimeCast<PlugAdder>( event.sourceGadget.get() ) )
 	{

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -455,13 +455,6 @@ void StandardStyle::renderImage( const Imath::Box2f &box, const IECoreGL::Textur
 	glActiveTexture( GL_TEXTURE0 );
 	texture->bind();
 
-	/// \todo It feels like it might be better to do this at texture creation time.
-	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR );
-	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
-	glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, -1.0 );
-	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
-	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
-
 	glUniform1i( g_bezierParameter, 0 );
 	glUniform1i( g_borderParameter, 0 );
 	glUniform1i( g_edgeAntiAliasingParameter, 0 );

--- a/src/GafferUI/SwitchNodeGadget.cpp
+++ b/src/GafferUI/SwitchNodeGadget.cpp
@@ -1,0 +1,81 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/Switch.h"
+
+#include "GafferUI/StandardNodeGadget.h"
+#include "GafferUI/Nodule.h"
+#include "GafferUI/PlugAdder.h"
+
+using namespace Gaffer;
+using namespace GafferUI;
+
+namespace
+{
+
+class SwitchNodeGadget : public StandardNodeGadget
+{
+
+	public :
+
+		SwitchNodeGadget( Gaffer::NodePtr node )
+			:	StandardNodeGadget( node )
+		{
+			setEdgeGadget( LeftEdge, new PlugAdder( node, LeftEdge ) );
+			setEdgeGadget( RightEdge, new PlugAdder( node, RightEdge ) );
+			if( !node->isInstanceOf( "GafferScene::ShaderSwitch" ) )
+			{
+				/// \todo Either remove ShaderSwitch on the grounds that it
+				/// doesn't really do anything above and beyond a regular
+				/// SwitchComputeNode, or come up with a metadata convention
+				/// to control this behaviour. What would be really nice is
+				/// to control the whole of the NodeGadget layout using the
+				/// same metadata conventions as the PlugLayout on the widget
+				/// side of things.
+				setEdgeGadget( TopEdge, new PlugAdder( node, TopEdge ) );
+				setEdgeGadget( BottomEdge, new PlugAdder( node, BottomEdge ) );
+			}
+		}
+
+	private :
+
+		static NodeGadgetTypeDescription<SwitchNodeGadget> g_nodeGadgetTypeDescription;
+
+};
+
+StandardNodeGadget::NodeGadgetTypeDescription<SwitchNodeGadget> SwitchNodeGadget::g_nodeGadgetTypeDescription( SwitchComputeNode::staticTypeId() );
+
+} // namespace

--- a/src/GafferUIBindings/ImageGadgetBinding.cpp
+++ b/src/GafferUIBindings/ImageGadgetBinding.cpp
@@ -42,13 +42,16 @@
 #include "GafferUIBindings/GadgetBinding.h"
 
 using namespace boost::python;
-using namespace GafferUIBindings;
+using namespace IECorePython;
 using namespace GafferUI;
+using namespace GafferUIBindings;
 
 void GafferUIBindings::bindImageGadget()
 {
 	GadgetClass<ImageGadget>()
 		.def( init<const std::string &>() )
 		.def( init<IECore::ConstImagePrimitivePtr>() )
+		.def( "textureLoader", &ImageGadget::textureLoader, return_value_policy<CastToIntrusivePtr>() )
+		.staticmethod( "textureLoader" )
 	;
 }

--- a/src/GafferUIBindings/StandardNodeGadgetBinding.cpp
+++ b/src/GafferUIBindings/StandardNodeGadgetBinding.cpp
@@ -49,6 +49,9 @@ using namespace boost::python;
 using namespace GafferUIBindings;
 using namespace GafferUI;
 
+namespace
+{
+
 class StandardNodeGadgetWrapper : public NodeGadgetWrapper<StandardNodeGadget>
 {
 
@@ -61,15 +64,17 @@ class StandardNodeGadgetWrapper : public NodeGadgetWrapper<StandardNodeGadget>
 
 };
 
-static GadgetPtr getContents( StandardNodeGadget &g )
+GadgetPtr getContents( StandardNodeGadget &g )
 {
 	return g.getContents();
 }
 
-static GadgetPtr getEdgeGadget( StandardNodeGadget &g, StandardNodeGadget::Edge edge )
+GadgetPtr getEdgeGadget( StandardNodeGadget &g, StandardNodeGadget::Edge edge )
 {
 	return g.getEdgeGadget( edge );
 }
+
+} // namespace
 
 void GafferUIBindings::bindStandardNodeGadget()
 {

--- a/src/GafferUIBindings/StandardNodeGadgetBinding.cpp
+++ b/src/GafferUIBindings/StandardNodeGadgetBinding.cpp
@@ -41,13 +41,15 @@
 
 #include "GafferUI/StandardNodeGadget.h"
 #include "GafferUI/Nodule.h"
+#include "GafferUI/Private/SwitchNodeGadget.h"
 
 #include "GafferUIBindings/StandardNodeGadgetBinding.h"
 #include "GafferUIBindings/NodeGadgetBinding.h"
 
 using namespace boost::python;
-using namespace GafferUIBindings;
 using namespace GafferUI;
+using namespace GafferUI::Private;
+using namespace GafferUIBindings;
 
 namespace
 {
@@ -92,4 +94,16 @@ void GafferUIBindings::bindStandardNodeGadget()
 		.value( "LeftEdge", StandardNodeGadget::LeftEdge )
 		.value( "RightEdge", StandardNodeGadget::RightEdge )
 	;
+
+	// Expose private derived classes of StandardNodeGadget as copies of
+	// StandardNodeGadget. We don't want to bind them fully because then
+	// we'd be exposing a private class, but we need to register them so
+	// that they can be returned to Python successfully.
+	//
+	// See "Boost.Python and slightly more tricky inheritance" at
+	// http://lists.boost.org/Archives/boost/2005/09/93017.php for
+	// more details.
+
+	objects::copy_class_object( type_id<StandardNodeGadget>(), type_id<SwitchNodeGadget>() );
+
 }

--- a/startup/GafferScene/shaderSwitchCompatibility.py
+++ b/startup/GafferScene/shaderSwitchCompatibility.py
@@ -1,0 +1,53 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import Gaffer
+import GafferScene
+
+def __shaderSwitchGetItem( originalGetItem ) :
+
+	def getItem( self, key ) :
+
+		if key in ( "in", "out" ) and key not in self :
+			self.setup( Gaffer.Plug() )
+
+		return originalGetItem( self, key )
+
+	return getItem
+
+GafferScene.ShaderSwitch.__getitem__ = __shaderSwitchGetItem( GafferScene.ShaderSwitch.__getitem__ )

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -393,6 +393,7 @@ nodeMenu.append( "/Utility/Box", GafferUI.BoxUI.nodeMenuCreateCommand )
 nodeMenu.append( "/Utility/Reference", GafferUI.ReferenceUI.nodeMenuCreateCommand )
 nodeMenu.definition().append( "/Utility/Backdrop", { "command" : GafferUI.BackdropUI.nodeMenuCreateCommand } )
 nodeMenu.append( "/Utility/Dot", Gaffer.Dot )
+nodeMenu.append( "/Utility/Switch", functools.partial( Gaffer.SwitchComputeNode, "Switch" ) )
 
 ## Miscellaneous UI
 ###########################################################################


### PR DESCRIPTION
This makes big improvements to the ShaderSwitch so that it is much more useful with Arnold and OSL shaders. It can now switch the input for parameters of any type whereas before it could only switch entire shaders and RSL coshaders. It can now also have a context-varying index value, so expressions can be used to drive the index for the first time.

The low level work here was actually pretty straightforward, since I'd planned for it when rejigging the NetworkGenerator to support pass-throughs for OSL shaders. The UI needed much more work though. Whereas before the ShaderSwitch could just add the "in" and "out" plugs during construction, we must now wait until the user first wants to make a connection, because only then do we know what sort of plug is needed. I've dealt with this by introducing a new PlugAdder gadget, that appears as a + icon on the side of the node. Dragging to or from this triggers the addition of the relevant plugs and the creation of a connection, as show below...

![switch](https://cloud.githubusercontent.com/assets/1133871/20794399/0772a4c8-b7c4-11e6-836e-dccd62e909cf.png)

The implementation of this is a little nasty because of the required interaction between PlugAdder, StandardNodule and StandardNodeGadget, but I don't see any other way without a significant redesign, and the drag snapping that required the interactions is essential for a decent experience. I'll be capitalising on this bit of ickiness as much as possible in the future by extending the PlugAdder to add plugs to Boxes and Dots, and for connecting to hidden plugs in the upcoming please-don't-show-me-all-of-alsurface-at-once feature. I expect the PlugAdder implementation to change a bit to allow these customisations (maybe becoming an abstract base class), but I didn't want to second guess what the right design was until I started working on the additional use cases.

Finally, all this work means that we can now add a generic Switch node to the Utility menu, which can be set up to work with any plug type. In fact, you could argue that the specialised switch types are no longer actually necessary. User polling didn't really reveal a preference one way or the other, so the specialised switches remain for now - I suspect we need to get the generic Switch into people's hands until they'll know what they prefer.