### PR TITLE
Supporting Coordinates Spaces in OSLObject

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -696,7 +696,7 @@ libraries = {
 	"GafferOSL" : {
 		"envAppends" : {
 			"CPPPATH" : [ "$OSLHOME/include/OSL" ],
-			"LIBS" : [ "Gaffer", "GafferScene", "GafferImage", "OpenImageIO$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX" ],
+			"LIBS" : [ "Gaffer", "GafferScene", "GafferImage", "OpenImageIO$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "Iex$OPENEXR_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
 			"CPPPATH" : [ "$OSLHOME/include/OSL" ],

--- a/include/GafferOSL/ShadingEngine.h
+++ b/include/GafferOSL/ShadingEngine.h
@@ -53,7 +53,23 @@ class ShadingEngine : public IECore::RefCounted
 		ShadingEngine( const IECore::ObjectVector *shaderNetwork );
 		~ShadingEngine();
 
-		IECore::CompoundDataPtr shade( const IECore::CompoundData *points ) const;
+		struct Transform
+		{
+			Transform(){}
+
+			Transform( Imath::M44f fromObjectSpace, Imath::M44f toObjectSpace ):
+				fromObjectSpace( fromObjectSpace ), toObjectSpace( toObjectSpace ) {}
+
+			Transform( Imath::M44f fromObjectSpace ):
+				fromObjectSpace( fromObjectSpace ), toObjectSpace( fromObjectSpace.inverse() ) {}
+			
+			Imath::M44f fromObjectSpace;
+			Imath::M44f toObjectSpace;
+		};
+
+		typedef std::map< IECore::InternedString, Transform> Transforms;
+
+		IECore::CompoundDataPtr shade( const IECore::CompoundData *points, const Transforms &transforms = Transforms() ) const;
 
 	private :
 

--- a/python/GafferOSLTest/shaders/transform.osl
+++ b/python/GafferOSLTest/shaders/transform.osl
@@ -1,0 +1,50 @@
+//////////////////////////////////////////////////////////////////////////
+//  
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//  
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//  
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//  
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  
+//////////////////////////////////////////////////////////////////////////
+
+surface transform
+(
+	int backwards = 0
+)
+{
+	if( backwards )
+	{
+		Ci = color( transform( "world", "object", P ) ) * emission();
+	}
+	else
+	{
+		Ci = color( transform( "world", P ) ) * emission();
+	}
+}

--- a/src/GafferOSL/OSLObject.cpp
+++ b/src/GafferOSL/OSLObject.cpp
@@ -85,6 +85,10 @@ void OSLObject::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 	{
 		outputs.push_back( outPlug()->objectPlug() );
 	}
+	else if( input == inPlug()->transformPlug() )
+	{
+		outputs.push_back( outPlug()->objectPlug() );
+	}
 	else if( input == outPlug()->objectPlug() )
 	{
 		outputs.push_back( outPlug()->boundPlug() );
@@ -147,7 +151,10 @@ void OSLObject::hashProcessedObject( const ScenePath &path, const Gaffer::Contex
 	{
 		shader->attributesHash( h );
 	}
+	h.append( inPlug()->fullTransformHash( path ) );
 }
+
+static const IECore::InternedString g_world("world");
 
 IECore::ConstObjectPtr OSLObject::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const
 {
@@ -183,7 +190,11 @@ IECore::ConstObjectPtr OSLObject::computeProcessedObject( const ScenePath &path,
 
 	PrimitivePtr outputPrimitive = inputPrimitive->copy();
 
-	CompoundDataPtr shadedPoints = shadingEngine->shade( shadingPoints.get() );
+	ShadingEngine::Transforms transforms;
+
+	transforms[ g_world ] = ShadingEngine::Transform( inPlug()->fullTransform( path ));
+
+	CompoundDataPtr shadedPoints = shadingEngine->shade( shadingPoints.get(), transforms );
 	for( CompoundDataMap::const_iterator it = shadedPoints->readable().begin(), eIt = shadedPoints->readable().end(); it != eIt; ++it )
 	{
 		if( it->first != "Ci" )

--- a/src/GafferOSLModule/GafferOSLModule.cpp
+++ b/src/GafferOSLModule/GafferOSLModule.cpp
@@ -117,6 +117,8 @@ std::string oslCodeSource( const OSLCode &oslCode, const std::string &shaderName
 	return oslCode.source( shaderName );
 }
 
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS( shadeOverloads, shade, 1, 2 );
+
 } // namespace
 
 BOOST_PYTHON_MODULE( _GafferOSL )
@@ -140,7 +142,7 @@ BOOST_PYTHON_MODULE( _GafferOSL )
 
 	IECorePython::RefCountedClass<ShadingEngine, IECore::RefCounted>( "ShadingEngine" )
 		.def( init<const IECore::ObjectVector *>() )
-		.def( "shade", &ShadingEngine::shade )
+		.def( "shade", &ShadingEngine::shade, shadeOverloads() )
 	;
 
 	scope s = GafferBindings::DependencyNodeClass<OSLCode>()


### PR DESCRIPTION
This is some very early experimentation, but I feel like this will likely need some feedback from John about the approach, so I'm putting it up for initial comments sooner rather than later.

I need to do some object processing in Gaffer where I create prim vars based on the world space position.  I could probably hack this by manually passing an extra transform into some custom OSL, but it seems like it would be generally quite useful if the built-in ```transform( "world", P )``` worked.  I'm not sure if these changes could affect other users of this code, but I think it's still early enough in our use of this stuff at IE that it's probably easier to change now than later.

The first change is to call ```s->attribute( "commonspace", "object" );```.  This tells OSL that the default working space of OSLObject is object space, which makes sense.  Currently, it won't even try to convert to world space because it thinks everything is already in world space ( which it isn't ).

The next step is to implement get_matrix ( and probably get_inverse_matrix as well since we actually start with the object to world matrix, and it would be silly to inverse twice ).

This will require passing some extra data into renderstate ( or create a new objstate container, which doesn't appear necessary if we're creating a separate ShadingSystem per object anyway ).  It's not clear to me what the clean way to get this data passed in will be.  Any thoughts?