### PR TITLE
StandardNodule : Use "nodeGraphLayout:label" not "label" metadata.

### DIFF
--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -64,7 +64,7 @@ IE_CORE_DEFINERUNTIMETYPED( StandardNodule );
 Nodule::NoduleTypeDescription<StandardNodule> StandardNodule::g_noduleTypeDescription( Gaffer::Plug::staticTypeId() );
 
 static IECore::InternedString g_colorKey( "nodule:color" );
-static IECore::InternedString g_labelKey( "label" );
+static IECore::InternedString g_labelKey( "nodeGraphLayout:label" );
 
 StandardNodule::StandardNodule( Gaffer::PlugPtr plug )
 	:	Nodule( plug ), m_labelVisible( false ), m_draggingConnection( false )


### PR DESCRIPTION
The "label" metadata is typically registered to simplify a name taking into account the NodeEditor section it will appear in. Using the same label in the NodeGraph makes no sense, because there is no section there to provide a context. This was totally breaking the AlSurface UI.

Using a "nodeGraphLayout:" prefix allows us to provide a label better suited to the context. Over time my intention is to refactor most of the "nodeGadget:" and "compoundNodule:" metadata so that it all becomes "nodeGraphLayout:" metadata instead, and is analogous to the "layout:" metadata we use in the NodeEditor and the "toolbarLayout:" metadata we use in the Viewer. This will involve refactoring CompoundNodule and StandardNodeGadget to make use of a NoduleLayout class.

@danieldresser, as the requester of the original feature, I think you're the only one to have used it so far. Hopefully you can update to use the new metadata easily enough?