### PR TITLE
Dot : Fix serialisation of plugs.

### DIFF
--- a/python/GafferTest/DotTest.py
+++ b/python/GafferTest/DotTest.py
@@ -101,6 +101,26 @@ class DotTest( GafferTest.TestCase ) :
 
 		self.assertTrue( s2["n2"]["op1"].source().isSame( s2["n1"]["sum"] ) )
 
+	def testSerialisationWithNonSerialisableConnections( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n1"] = GafferTest.AddNode()
+		s["n2"] = GafferTest.AddNode()
+
+		s["n1"]["sum"].setFlags( Gaffer.Plug.Flags.Serialisable, False )
+		
+		s["d"] = Gaffer.Dot()
+		s["d"].setup( s["n1"]["sum"] )
+
+		s["d"]["in"].setInput( s["n1"]["sum"] )
+		s["n2"]["op1"].setInput( s["d"]["out"] )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertTrue( s2["n2"]["op1"].source().isSame( s2["n1"]["sum"] ) )
+
 	def testDeletion( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/src/Gaffer/Dot.cpp
+++ b/src/Gaffer/Dot.cpp
@@ -73,8 +73,8 @@ void Dot::setup( const Plug *plug )
 	Gaffer::PlugPtr in = plug->createCounterpart( g_inPlugName, Plug::In );
 	Gaffer::PlugPtr out = plug->createCounterpart( g_outPlugName, Plug::Out );
 
-	in->setFlags( Plug::Dynamic, true );
-	out->setFlags( Plug::Dynamic, true );
+	in->setFlags( Plug::Dynamic | Plug::Serialisable, true );
+	out->setFlags( Plug::Dynamic | Plug::Serialisable, true );
 
 	// Set up Metadata so our plugs appear in the right place. We must do this now rather
 	// than later because the NodeGraph will add a Nodule for the plug as soon as the plug


### PR DESCRIPTION
If the Dot is setup from a non-serialisable plug, the user would still want the dot plugs to serialise. Without the change, the new test would fail with:

```RuntimeError: Exception : Line 18 : KeyError: "'out' is not a child of 'd'"```