### PR TITLE
Check Bounds On ShadingEngine PrimVar Accesses?

### DIFF
--- a/include/GafferOSL/ShadingEngine.h
+++ b/include/GafferOSL/ShadingEngine.h
@@ -39,6 +39,7 @@
 #include "IECore/ObjectVector.h"
 
 #include "GafferOSL/TypeIds.h"
+#include "OpenImageIO/ustring.h"
 
 namespace GafferOSL
 {
@@ -53,7 +54,15 @@ class ShadingEngine : public IECore::RefCounted
 		ShadingEngine( const IECore::ObjectVector *shaderNetwork );
 		~ShadingEngine();
 
-		IECore::CompoundDataPtr shade( const IECore::CompoundData *points ) const;
+		struct Transform
+		{
+			Imath::M44f fromObjectSpace;
+			Imath::M44f toObjectSpace;
+		};
+
+		typedef std::map<OIIO::ustring, Transform> Transforms;
+
+		IECore::CompoundDataPtr shade( const IECore::CompoundData *points, const Transforms &transforms ) const;
 
 	private :
 

--- a/python/GafferOSLTest/OSLObjectTest.py
+++ b/python/GafferOSLTest/OSLObjectTest.py
@@ -100,6 +100,54 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( boundIn.min.y, boundOut.min.x )
 		self.assertEqual( boundIn.max.y, boundOut.max.x )
 
+	def testTransform( self ) :
+
+		p = GafferScene.Plane()
+		p["transform"]["translate"].setValue( IECore.V3f( 2, 0, 0 ) )
+
+
+
+		o = GafferOSL.OSLObject()
+		o["in"].setInput( p["out"] )
+
+		# shading network to swap x and y
+
+		inPoint = GafferOSL.OSLShader()
+		inPoint.loadShader( "ObjectProcessing/InPoint" )
+
+		code = GafferOSL.OSLCode()
+		code["parameters"].addChild( Gaffer.V3fPlug( "in" ) )
+		code["out"].addChild( Gaffer.Color3fPlug( "transformed", direction = Gaffer.Plug.Direction.Out ) )
+		code["out"].addChild( Gaffer.Color3fPlug( "transformedBack", direction = Gaffer.Plug.Direction.Out ) )
+		code["code"].setValue( 'transformed = transform( "world", point( in ) );\ntransformedBack = transform( "world", "object", point( transformed ) );' )
+
+		code["parameters"]["in"].setInput( inPoint["out"]["value"] )
+
+		outTransformed = GafferOSL.OSLShader()
+		outTransformed.loadShader( "ObjectProcessing/OutColor" )
+		outTransformed["parameters"]["name"].setValue( 'transformed' )
+		outTransformed["parameters"]["value"].setInput( code["out"]["transformed"] )
+
+		outTransformedBack = GafferOSL.OSLShader()
+		outTransformedBack.loadShader( "ObjectProcessing/OutColor" )
+		outTransformedBack["parameters"]["name"].setValue( 'transformedBack' )
+		outTransformedBack["parameters"]["value"].setInput( code["out"]["transformedBack"] )
+
+		primVarShader = GafferOSL.OSLShader()
+		primVarShader.loadShader( "ObjectProcessing/OutObject" )
+		primVarShader["parameters"]["in0"].setInput( outTransformed["out"]["primitiveVariable"] )
+		primVarShader["parameters"]["in1"].setInput( outTransformedBack["out"]["primitiveVariable"] )
+
+		o["shader"].setInput( primVarShader["out"] )
+
+		filter = GafferScene.PathFilter()
+		filter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		o["filter"].setInput( filter["out"] )
+
+		self.assertEqual( o["out"].object( "/plane" )["transformed"].data, IECore.Color3fVectorData( [ IECore.Color3f( 1.5, -0.5, 0 ), IECore.Color3f( 2.5, -0.5, 0 ), IECore.Color3f( 1.5, 0.5, 0 ), IECore.Color3f( 2.5, 0.5, 0 ) ] ) )
+		self.assertEqual( o["out"].object( "/plane" )["transformedBack"].data, IECore.Color3fVectorData( [ IECore.Color3f( -0.5, -0.5, 0 ), IECore.Color3f( 0.5, -0.5, 0 ), IECore.Color3f( -0.5, 0.5, 0 ), IECore.Color3f( 0.5, 0.5, 0 ) ] ) )
+
 	def testOnlyAcceptsSurfaceShaders( self ) :
 
 		object = GafferOSL.OSLObject()

--- a/src/GafferOSL/OSLImage.cpp
+++ b/src/GafferOSL/OSLImage.cpp
@@ -331,7 +331,8 @@ IECore::ConstCompoundDataPtr OSLImage::computeShading( const Gaffer::Context *co
 		shadingPoints->writable()[*it] = boost::const_pointer_cast<FloatVectorData>( inPlug()->channelData( *it, tileOrigin ) );
 	}
 
-	CompoundDataPtr result = shadingEngine->shade( shadingPoints.get() );
+	ShadingEngine::Transforms transforms;
+	CompoundDataPtr result = shadingEngine->shade( shadingPoints.get(), transforms );
 
 	// remove results that aren't suitable to become channels
 	for( CompoundDataMap::iterator it = result->writable().begin(); it != result->writable().end();  )

--- a/src/GafferOSL/OSLObject.cpp
+++ b/src/GafferOSL/OSLObject.cpp
@@ -85,6 +85,10 @@ void OSLObject::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 	{
 		outputs.push_back( outPlug()->objectPlug() );
 	}
+	else if( input == inPlug()->transformPlug() )
+	{
+		outputs.push_back( outPlug()->objectPlug() );
+	}
 	else if( input == outPlug()->objectPlug() )
 	{
 		outputs.push_back( outPlug()->boundPlug() );
@@ -147,7 +151,10 @@ void OSLObject::hashProcessedObject( const ScenePath &path, const Gaffer::Contex
 	{
 		shader->attributesHash( h );
 	}
+	h.append( inPlug()->fullTransformHash( path ) );
 }
+
+static const OIIO::ustring u_world("world");
 
 IECore::ConstObjectPtr OSLObject::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const
 {
@@ -183,7 +190,15 @@ IECore::ConstObjectPtr OSLObject::computeProcessedObject( const ScenePath &path,
 
 	PrimitivePtr outputPrimitive = inputPrimitive->copy();
 
-	CompoundDataPtr shadedPoints = shadingEngine->shade( shadingPoints.get() );
+	ShadingEngine::Transforms transforms;
+
+	ShadingEngine::Transform world;
+	world.fromObjectSpace = inPlug()->fullTransform( path );
+	world.toObjectSpace = world.fromObjectSpace.inverse();
+
+	transforms[ u_world ] = world;
+
+	CompoundDataPtr shadedPoints = shadingEngine->shade( shadingPoints.get(), transforms );
 	for( CompoundDataMap::const_iterator it = shadedPoints->readable().begin(), eIt = shadedPoints->readable().end(); it != eIt; ++it )
 	{
 		if( it->first != "Ci" )


### PR DESCRIPTION
This is just a quick sketch of an idea at the end of the day, there's something wrong with my env and I haven't been able to test it yet, but I thought I would start by seeing if it seems like a good idea to you.

It seems to me like if supplied with a uniform primvar, it is currently possible for us to just read into unallocated memory?  Long term we should totally support uniform primvars properly, which doesn't seem hard, but maybe as a first step just catch the out-of-bounds accesses?