### PR TITLE
Switch : Fix `setup()` to work with non-serialisable plugs.

### DIFF
--- a/include/Gaffer/Switch.inl
+++ b/include/Gaffer/Switch.inl
@@ -118,10 +118,12 @@ void Switch<BaseType>::setup( const Plug *plug )
 		throw IECore::Exception( "Switch already has an \"out\" plug." );
 	}
 
+	PlugPtr inElement = plug->createCounterpart( "in0", Plug::In );
+	inElement->setFlags( Plug::Dynamic | Plug::Serialisable, true );
 	ArrayPlugPtr in = new ArrayPlug(
 		"in",
 		Plug::In,
-		plug->createCounterpart( "in0", Plug::In ),
+		inElement,
 		0,
 		Imath::limits<size_t>::max(),
 		Plug::Default | Plug::Dynamic
@@ -129,7 +131,7 @@ void Switch<BaseType>::setup( const Plug *plug )
 	BaseType::addChild( in );
 
 	PlugPtr out = plug->createCounterpart( "out", Plug::Out );
-	out->setFlags( Plug::Dynamic, true );
+	out->setFlags( Plug::Dynamic | Plug::Serialisable, true );
 	BaseType::addChild( out );
 }
 

--- a/python/GafferTest/SwitchTest.py
+++ b/python/GafferTest/SwitchTest.py
@@ -414,6 +414,27 @@ class SwitchTest( GafferTest.TestCase ) :
 			c.setFrame( 2 )
 			self.assertTrue( s["switch"].activeInPlug().isSame( s["switch"]["in"][0] ) )
 
+	def testSetupFromNonSerialisablePlug( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n1"] = GafferTest.AddNode()
+		s["n2"] = GafferTest.AddNode()
+
+		s["n1"]["sum"].setFlags( Gaffer.Plug.Flags.Serialisable, False )
+
+		s["switch"] = Gaffer.SwitchComputeNode()
+		s["switch"].setup( s["n1"]["sum"] )
+
+		s["switch"]["in"][0].setInput( s["n1"]["sum"] )
+		s["n2"]["op1"].setInput( s["switch"]["out"] )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertTrue( s2["n2"]["op1"].getInput().isSame( s2["switch"]["out"] ) )
+		self.assertTrue( s2["switch"]["in"][0].getInput().isSame( s2["n1"]["sum"] ) )
+
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )


### PR DESCRIPTION
This is basically the same fix as Andrew's #1946, but applied to Switches, which had the same problem.