### PR TITLE
Shader nodule visibility

### DIFF
--- a/arnold/plugins/gaffer.mtd
+++ b/arnold/plugins/gaffer.mtd
@@ -134,6 +134,23 @@
 [node standard]
 
 	gaffer.nodeMenu.category STRING "Surface"
+	gaffer.nodeGraphLayout.defaultVisibility BOOL false
+
+	[attr Kd_color]
+
+		gaffer.nodeGraphLayout.visible BOOL true
+
+	[attr Kd]
+
+		gaffer.nodeGraphLayout.visible BOOL true
+
+	[attr Ks_color]
+
+		gaffer.nodeGraphLayout.visible BOOL true
+
+	[attr Ks]
+
+		gaffer.nodeGraphLayout.visible BOOL true
 
 
 [node utility]
@@ -1030,7 +1047,7 @@
 
 
 [node htoa__max]
-      
+
 	primaryInput STRING "input1"
 	gaffer.nodeMenu.category STRING "Houdini/Maths"
 
@@ -1401,7 +1418,23 @@
 [node alSurface]
 
 	gaffer.nodeMenu.category STRING "Surface"
+	gaffer.nodeGraphLayout.defaultVisibility BOOL false
 
+	[attr diffuseStrength]
+
+		gaffer.nodeGraphLayout.visible BOOL true
+
+	[attr diffuseColor]
+
+		gaffer.nodeGraphLayout.visible BOOL true
+
+	[attr specular1Strength]
+
+		gaffer.nodeGraphLayout.visible BOOL true
+
+	[attr specular1Color]
+
+		gaffer.nodeGraphLayout.visible BOOL true
 
 [node alSwitchColor]
 

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -46,6 +46,7 @@ namespace Gaffer
 
 class GraphComponent;
 class Plug;
+class Node;
 
 namespace MetadataAlgo
 {
@@ -86,9 +87,10 @@ bool readOnly( const GraphComponent *graphComponent );
 /// Utilities
 /// =========
 
-/// Utility to determine if a metadata value change (as signalled by `Metadata::plugValueChangedSignal()`)
-/// affects a given plug.
+/// Determines if a metadata value change (as signalled by `Metadata::plugValueChangedSignal()`
+/// or `Metadata:nodeValueChangedSignal()`) affects a given plug or node.
 bool affectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
+bool affectedByChange( const Node *node, IECore::TypeId changedNodeTypeId, const Gaffer::Node *changedNode );
 /// As above, but determines if any child plug will be affected.
 bool childAffectedByChange( const GraphComponent *parent, IECore::TypeId changedNodeTypeId, const StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
 /// As above, but determines if any ancestor plug will be affected. This is particularly useful in conjunction with

--- a/include/GafferSceneUI/Private/ShaderNodeGadget.h
+++ b/include/GafferSceneUI/Private/ShaderNodeGadget.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,24 +34,33 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERSCENEUI_TYPEIDS_H
-#define GAFFERSCENEUI_TYPEIDS_H
+#ifndef GAFFERSCENEUI_PRIVATE_SHADERNODEGADGET_H
+#define GAFFERSCENEUI_PRIVATE_SHADERNODEGADGET_H
+
+#include "GafferUI/StandardNodeGadget.h"
 
 namespace GafferSceneUI
 {
 
-enum TypeId
+namespace Private
 {
-	SceneViewTypeId = 110651,
-	SceneGadgetTypeId = 110652,
-	SelectionToolTypeId = 110653,
-	CropWindowToolTypeId = 110654,
-	ShaderViewTypeId = 110655,
-	ShaderNodeGadgetTypeId = 110656,
 
-	LastTypeId = 110700
+class ShaderNodeGadget : public GafferUI::StandardNodeGadget
+{
+
+	public :
+
+		ShaderNodeGadget( Gaffer::NodePtr node );
+		virtual ~ShaderNodeGadget();
+
+	private :
+
+		static NodeGadgetTypeDescription<ShaderNodeGadget> g_nodeGadgetTypeDescription;
+
 };
+
+} // namespace Private
 
 } // namespace GafferSceneUI
 
-#endif // GAFFERSCENEUI_TYPEIDS_H
+#endif // GAFFERSCENEUI_PRIVATE_SHADERNODEGADGET_H

--- a/include/GafferSceneUIBindings/ShaderNodeGadgetBinding.h
+++ b/include/GafferSceneUIBindings/ShaderNodeGadgetBinding.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,24 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERSCENEUI_TYPEIDS_H
-#define GAFFERSCENEUI_TYPEIDS_H
+#ifndef GAFFERSCENEUIBINDINGS_SHADERNODEGADGETBINDING_H
+#define GAFFERSCENEUIBINDINGS_SHADERNODEGADGETBINDING_H
 
-namespace GafferSceneUI
+namespace GafferSceneUIBindings
 {
 
-enum TypeId
-{
-	SceneViewTypeId = 110651,
-	SceneGadgetTypeId = 110652,
-	SelectionToolTypeId = 110653,
-	CropWindowToolTypeId = 110654,
-	ShaderViewTypeId = 110655,
-	ShaderNodeGadgetTypeId = 110656,
+void bindShaderNodeGadget();
 
-	LastTypeId = 110700
-};
+} // namespace GafferSceneUIBindings
 
-} // namespace GafferSceneUI
-
-#endif // GAFFERSCENEUI_TYPEIDS_H
+#endif // GAFFERSCENEUIBINDINGS_SHADERNODEGADGETBINDING_H

--- a/include/GafferUI/CompoundNodule.h
+++ b/include/GafferUI/CompoundNodule.h
@@ -38,30 +38,22 @@
 #ifndef GAFFERUI_COMPOUNDNODULE_H
 #define GAFFERUI_COMPOUNDNODULE_H
 
-#include "Gaffer/Metadata.h"
-
 #include "GafferUI/Nodule.h"
 #include "GafferUI/LinearContainer.h"
 
 namespace GafferUI
 {
 
-IE_CORE_FORWARDDECLARE( LinearContainer );
+IE_CORE_FORWARDDECLARE( NoduleLayout );
 
 /// A Nodule subclass to represent each of the children of a
 /// Plug with their own nodule.
-///
-/// Supported plug metadata :
-///
-/// - "compoundNodule:orientation", with a value of "x", "y" or "z"
-/// - "compoundNodule:spacing", with a float value
-/// - "compoundNodule:direction", with a value of "increasing" or "decreasing"
 class CompoundNodule : public Nodule
 {
 
 	public :
 
-		/// \deprecated All arguments except the plug are deprecated -
+		/// \deprecated All arguments except the plug are ignored -
 		/// use plug metadata instead.
 		CompoundNodule( Gaffer::PlugPtr plug, LinearContainer::Orientation orientation=LinearContainer::X,
 			float spacing = 0.0f, LinearContainer::Direction direction=LinearContainer::InvalidDirection );
@@ -69,29 +61,16 @@ class CompoundNodule : public Nodule
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::CompoundNodule, CompoundNoduleTypeId, Nodule );
 
-		virtual Imath::Box3f bound() const;
-
 		virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
 
 		/// Returns a Nodule for a child of the plug being represented.
 		Nodule *nodule( const Gaffer::Plug *plug );
 		const Nodule *nodule( const Gaffer::Plug *plug ) const;
 
-	protected :
-
-		void doRender( const Style *style ) const;
-
 	private :
 
-		void childAdded( Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
-		void childRemoved( Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
-
-		void plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
-
-		typedef std::map<const Gaffer::Plug *, Nodule *> NoduleMap;
-		NoduleMap m_nodules;
-
-		LinearContainerPtr m_row;
+		NoduleLayout *noduleLayout();
+		const NoduleLayout *noduleLayout() const;
 
 		static NoduleTypeDescription<CompoundNodule> g_noduleTypeDescription;
 

--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -212,10 +212,15 @@ class GraphGadget : public ContainerGadget
 		NodeGadget *findNodeGadget( const Gaffer::Node *node ) const;
 		void updateNodeGadgetTransform( NodeGadget *nodeGadget );
 
-		void addConnectionGadgets( Gaffer::GraphComponent *nodeOrPlug );
-		void addConnectionGadget( Gaffer::Plug *dstPlug );
-		void removeConnectionGadgets( const Gaffer::GraphComponent *nodeOrPlug );
-		void removeConnectionGadget( const Gaffer::Plug *dstPlug );
+		Nodule *findNodule( const Gaffer::Plug *plug ) const;
+
+		void addConnectionGadgets( NodeGadget *nodeGadget );
+		void addConnectionGadgets( Nodule *nodule );
+		void addConnectionGadget( Nodule *dstNodule );
+		void removeConnectionGadgets( const NodeGadget *nodeGadget );
+		void removeConnectionGadgets( const Nodule *nodule );
+		void removeConnectionGadget( const Nodule *dstNodule );
+		ConnectionGadget *findConnectionGadget( const Nodule *dstNodule ) const;
 		ConnectionGadget *findConnectionGadget( const Gaffer::Plug *dstPlug ) const;
 		void updateConnectionGadgetMinimisation( ConnectionGadget *gadget );
 		ConnectionGadget *reconnectionGadgetAt( const NodeGadget *gadget, const IECore::LineSegment3f &lineInGadgetSpace ) const;
@@ -246,7 +251,7 @@ class GraphGadget : public ContainerGadget
 		typedef std::map<const Gaffer::Node *, NodeGadgetEntry> NodeGadgetMap;
 		NodeGadgetMap m_nodeGadgets;
 
-		typedef std::map<const Gaffer::Plug *, ConnectionGadget *> ConnectionGadgetMap;
+		typedef std::map<const Nodule *, ConnectionGadget *> ConnectionGadgetMap;
 		ConnectionGadgetMap m_connectionGadgets;
 
 		enum DragMode

--- a/include/GafferUI/NoduleLayout.h
+++ b/include/GafferUI/NoduleLayout.h
@@ -1,0 +1,123 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2011-2012, John Haddon. All rights reserved.
+//  Copyright (c) 2011-2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERUI_NODULELAYOUT_H
+#define GAFFERUI_NODULELAYOUT_H
+
+#include "Gaffer/StringAlgo.h"
+
+#include "GafferUI/Gadget.h"
+
+namespace Gaffer
+{
+
+IE_CORE_FORWARDDECLARE( Plug )
+IE_CORE_FORWARDDECLARE( Node )
+
+} // namespace Gaffer
+
+namespace GafferUI
+{
+
+IE_CORE_FORWARDDECLARE( LinearContainer )
+IE_CORE_FORWARDDECLARE( Nodule )
+
+/// Child plug metadata
+/// ===================
+///
+/// nodeGraphLayout:index, int, controls relative order of nodules
+/// nodeGraphLayout:section, string, "left"/"right"/"top"/"bottom"
+/// nodeGraphLayout:visible, bool
+///
+/// Parent metadata
+/// ===============
+///
+/// - nodeGraphLayout:section:<sectionName>:spacing, float
+/// - nodeGraphLayout:section:<sectionName>:direction, string, "increasing" or "decreasing"
+class NoduleLayout : public Gadget
+{
+
+	public :
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::NoduleLayout, NoduleLayoutTypeId, Gadget );
+
+		NoduleLayout( Gaffer::GraphComponentPtr parent, IECore::InternedString section = IECore::InternedString() );
+		virtual ~NoduleLayout();
+
+		virtual Nodule *nodule( const Gaffer::Plug *plug );
+		virtual const Nodule *nodule( const Gaffer::Plug *plug ) const;
+
+	private :
+
+		LinearContainer *noduleContainer();
+		const LinearContainer *noduleContainer() const;
+
+		struct TypeAndNodule
+		{
+			TypeAndNodule() {}
+			TypeAndNodule( IECore::InternedString type, NodulePtr nodule ) : type( type ), nodule( nodule ) {}
+			IECore::InternedString type;
+			NodulePtr nodule;
+		};
+		typedef std::map<const Gaffer::Plug *, TypeAndNodule> NoduleMap;
+		NoduleMap m_nodules;
+
+		void childAdded( Gaffer::GraphComponent *child );
+		void childRemoved( Gaffer::GraphComponent *child );
+
+		void plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
+		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node );
+
+		void updateNodules( std::vector<Nodule *> &nodules, std::vector<Nodule *> &added, std::vector<NodulePtr> &removed );
+		void updateNoduleLayout();
+		void updateSpacing();
+		void updateDirection();
+		void updateOrientation();
+
+		Gaffer::GraphComponentPtr m_parent;
+		const IECore::InternedString m_section;
+
+};
+
+IE_CORE_DECLAREPTR( NoduleLayout )
+
+typedef Gaffer::FilteredChildIterator<Gaffer::TypePredicate<NoduleLayout> > NoduleLayoutIterator;
+typedef Gaffer::FilteredRecursiveChildIterator<Gaffer::TypePredicate<NoduleLayout> > RecursiveNoduleLayoutIterator;
+
+} // namespace GafferUI
+
+#endif // GAFFERUI_NODULELAYOUT_H

--- a/include/GafferUI/NoduleLayout.h
+++ b/include/GafferUI/NoduleLayout.h
@@ -59,15 +59,15 @@ IE_CORE_FORWARDDECLARE( Nodule )
 /// Child plug metadata
 /// ===================
 ///
-/// nodeGraphLayout:index, int, controls relative order of nodules
-/// nodeGraphLayout:section, string, "left"/"right"/"top"/"bottom"
-/// nodeGraphLayout:visible, bool
+/// noduleLayout:index, int, controls relative order of nodules
+/// noduleLayout:section, string, "left"/"right"/"top"/"bottom"
+/// noduleLayout:visible, bool
 ///
 /// Parent metadata
 /// ===============
 ///
-/// - nodeGraphLayout:section:<sectionName>:spacing, float
-/// - nodeGraphLayout:section:<sectionName>:direction, string, "increasing" or "decreasing"
+/// - noduleLayout:section:<sectionName>:spacing, float
+/// - noduleLayout:section:<sectionName>:direction, string, "increasing" or "decreasing"
 class NoduleLayout : public Gadget
 {
 

--- a/include/GafferUI/PlugAdder.h
+++ b/include/GafferUI/PlugAdder.h
@@ -42,7 +42,6 @@
 namespace GafferUI
 {
 
-/// \todo Support Box and Dot in addition to Switch.
 class PlugAdder : public Gadget
 {
 
@@ -50,26 +49,27 @@ class PlugAdder : public Gadget
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::PlugAdder, PlugAdderTypeId, Gadget );
 
-		PlugAdder( Gaffer::NodePtr node, StandardNodeGadget::Edge edge );
+		PlugAdder( StandardNodeGadget::Edge edge );
 		virtual ~PlugAdder();
 
 		virtual Imath::Box3f bound() const;
 
 		void updateDragEndPoint( const Imath::V3f position, const Imath::V3f &tangent );
 
+		/// Returns `true` if a call to `addPlug( connectionEndPoint )` is possible.
+		/// Should be implemented by derived classes.
+		virtual bool acceptsPlug( const Gaffer::Plug *connectionEndPoint ) const = 0;
+		/// Adds a plug compatible with `connectionEndPoint` and connects them together.
+		/// Should be implemented by derived classes.
+		virtual void addPlug( Gaffer::Plug *connectionEndPoint ) = 0;
+
 	protected :
 
 		virtual void doRender( const Style *style ) const;
 
+		void applyEdgeMetadata( Gaffer::Plug *plug, bool opposite = false ) const;
+
 	private :
-
-		friend class StandardNodule;
-		void addPlug( Gaffer::Plug *connectionEndPoint );
-
-		void childAdded();
-		void childRemoved();
-
-		void updateVisibility();
 
 		void enter( GadgetPtr gadget, const ButtonEvent &event );
 		void leave( GadgetPtr gadget, const ButtonEvent &event );
@@ -81,7 +81,6 @@ class PlugAdder : public Gadget
 		bool drop( const DragDropEvent &event );
 		bool dragEnd( const DragDropEvent &event );
 
-		Gaffer::NodePtr m_node;
 		StandardNodeGadget::Edge m_edge;
 
 		bool m_dragging;

--- a/include/GafferUI/PlugAdder.h
+++ b/include/GafferUI/PlugAdder.h
@@ -63,6 +63,12 @@ class PlugAdder : public Gadget
 		/// Should be implemented by derived classes.
 		virtual void addPlug( Gaffer::Plug *connectionEndPoint ) = 0;
 
+		/// When emitted, shows a menu containing the specified plugs, and returns
+		/// the chosen plug. Implemented as a signal so the menu can be implemented
+		/// externally in Python code.
+		typedef boost::signal<Gaffer::Plug *( const std::string &title, const std::vector<Gaffer::Plug *> & )> PlugMenuSignal;
+		static PlugMenuSignal &plugMenuSignal();
+
 	protected :
 
 		virtual void doRender( const Style *style ) const;

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -47,19 +47,16 @@ namespace GafferUI
 {
 
 class PlugAdder;
+class NoduleLayout;
 
 /// The standard means of representing a Node in a GraphGadget.
 /// Nodes are represented as rectangular boxes with the name displayed
 /// centrally and the nodules arranged at the sides. Supports the following
 /// Metadata entries :
 ///
-/// - "nodeGadget:nodulePosition" : a plug entry with a value of
-/// "left", "right", "top" or "bottom"
-/// - "nodeGadget:noduleIndex" : a plug entry with an int value
 /// - "nodeGadget:minimumWidth" : a node entry with a float value
-/// - "nodeGadget:horizontalNoduleSpacing" : a node entry with a float value
-/// - "nodeGadget:verticalNoduleSpacing" : a node entry with a float value
 /// - "nodeGadget:padding" : a node entry with a float value
+/// - "nodeGadget:color" : Color3f
 class StandardNodeGadget : public NodeGadget
 {
 
@@ -111,28 +108,16 @@ class StandardNodeGadget : public NodeGadget
 
 	private :
 
-		Edge plugEdge( const Gaffer::Plug *plug );
-
 		LinearContainer *noduleContainer( Edge edge );
 		const LinearContainer *noduleContainer( Edge edge ) const;
+
+		NoduleLayout *noduleLayout( Edge edge );
+		const NoduleLayout *noduleLayout( Edge edge ) const;
 
 		IndividualContainer *contentsContainer();
 		const IndividualContainer *contentsContainer() const;
 
 		static NodeGadgetTypeDescription<StandardNodeGadget> g_nodeGadgetTypeDescription;
-
-		struct TypeAndNodule
-		{
-			TypeAndNodule() {}
-			TypeAndNodule( IECore::InternedString type, NodulePtr nodule ) : type( type ), nodule( nodule ) {}
-			IECore::InternedString type;
-			NodulePtr nodule;
-		};
-		typedef std::map<const Gaffer::Plug *, TypeAndNodule> NoduleMap;
-		NoduleMap m_nodules;
-
-		void childAdded( Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
-		void childRemoved( Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
 
 		void plugDirtied( const Gaffer::Plug *plug );
 
@@ -147,11 +132,8 @@ class StandardNodeGadget : public NodeGadget
 		bool noduleIsCompatible( const Nodule *nodule, const DragDropEvent &event ) const;
 		bool plugAdderIsCompatible( const PlugAdder *plugAdder, const DragDropEvent &event ) const;
 
-		void plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
 		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node );
 
-		void updateNodules( std::vector<Nodule *> &nodules, std::vector<Nodule *> &added, std::vector<NodulePtr> &removed );
-		void updateNoduleLayout();
 		bool updateUserColor();
 		void updatePadding();
 		void updateNodeEnabled( const Gaffer::Plug *dirtiedPlug = NULL );

--- a/include/GafferUI/TypeIds.h
+++ b/include/GafferUI/TypeIds.h
@@ -76,6 +76,7 @@ enum TypeId
 	ToolTypeId = 110281,
 	DotNodeGadgetTypeId = 110282,
 	PlugAdderTypeId = 110283,
+	NoduleLayoutTypeId = 110284,
 
 	LastTypeId = 110450
 };

--- a/include/GafferUIBindings/NoduleLayoutBinding.h
+++ b/include/GafferUIBindings/NoduleLayoutBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERUIBINDINGS_NODULELAYOUTBINDING_H
+#define GAFFERUIBINDINGS_NODULELAYOUTBINDING_H
+
+namespace GafferUIBindings
+{
+
+void bindNoduleLayout();
+
+} // namespace GafferUIBindings
+
+#endif // GAFFERUIBINDINGS_NODULELAYOUTBINDING_H

--- a/include/GafferUIBindings/PlugAdderBinding.h
+++ b/include/GafferUIBindings/PlugAdderBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERUIBINDINGS_PLUGADDERBINDING_H
+#define GAFFERUIBINDINGS_PLUGADDERBINDING_H
+
+namespace GafferUIBindings
+{
+
+void bindPlugAdder();
+
+} // namespace GafferUIBindings
+
+#endif // GAFFERUIBINDINGS_PLUGADDERBINDING_H

--- a/python/GafferArnoldUI/ArnoldDisplacementUI.py
+++ b/python/GafferArnoldUI/ArnoldDisplacementUI.py
@@ -68,7 +68,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "GafferUI::StandardNodule",
-			"nodeGadget:nodulePosition", "left",
+			"nodeGraphLayout:section", "left",
 
 		],
 

--- a/python/GafferArnoldUI/ArnoldDisplacementUI.py
+++ b/python/GafferArnoldUI/ArnoldDisplacementUI.py
@@ -68,7 +68,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "GafferUI::StandardNodule",
-			"nodeGraphLayout:section", "left",
+			"noduleLayout:section", "left",
 
 		],
 

--- a/python/GafferArnoldUI/ArnoldMeshLightUI.py
+++ b/python/GafferArnoldUI/ArnoldMeshLightUI.py
@@ -76,10 +76,9 @@ Gaffer.Metadata.registerNode(
 
 			## \todo Extend the Metadata API so we can register a provider for "*",
 			# which can automatically transfer all internal metadata.
-			"nodeGadget:nodulePosition", functools.partial( __shaderMetadata, name = "nodeGadget:nodulePosition" ),
+			"nodeGraphLayout:section", functools.partial( __shaderMetadata, name = "nodeGraphLayout:section" ),
 			"nodule:type", functools.partial( __shaderMetadata, name = "nodule:type" ),
-			"compoundNodule:orientation", functools.partial( __shaderMetadata, name = "compoundNodule:orientation" ),
-			"compoundNodule:spacing", functools.partial( __shaderMetadata, name = "compoundNodule:spacing" ),
+			"nodeGraphLayout:spacing", functools.partial( __shaderMetadata, name = "nodeGraphLayout:spacing" ),
 			"plugValueWidget:type", functools.partial( __shaderMetadata, name = "plugValueWidget:type" ),
 
 		],
@@ -93,7 +92,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", functools.partial( __shaderMetadata, name = "nodule:type" ),
-			"nodeGadget:nodulePosition", functools.partial( __shaderMetadata, name = "nodeGadget:nodulePosition" ),
+			"nodeGraphLayout:section", functools.partial( __shaderMetadata, name = "nodeGraphLayout:section" ),
 			"nodule:color", functools.partial( __shaderMetadata, name = "nodule:color" ),
 			"plugValueWidget:type", functools.partial( __shaderMetadata, name = "plugValueWidget:type" ),
 			"presetNames", functools.partial( __shaderMetadata, name = "presetNames" ),

--- a/python/GafferArnoldUI/ArnoldMeshLightUI.py
+++ b/python/GafferArnoldUI/ArnoldMeshLightUI.py
@@ -76,9 +76,9 @@ Gaffer.Metadata.registerNode(
 
 			## \todo Extend the Metadata API so we can register a provider for "*",
 			# which can automatically transfer all internal metadata.
-			"nodeGraphLayout:section", functools.partial( __shaderMetadata, name = "nodeGraphLayout:section" ),
+			"noduleLayout:section", functools.partial( __shaderMetadata, name = "noduleLayout:section" ),
 			"nodule:type", functools.partial( __shaderMetadata, name = "nodule:type" ),
-			"nodeGraphLayout:spacing", functools.partial( __shaderMetadata, name = "nodeGraphLayout:spacing" ),
+			"noduleLayout:spacing", functools.partial( __shaderMetadata, name = "noduleLayout:spacing" ),
 			"plugValueWidget:type", functools.partial( __shaderMetadata, name = "plugValueWidget:type" ),
 
 		],
@@ -92,7 +92,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", functools.partial( __shaderMetadata, name = "nodule:type" ),
-			"nodeGraphLayout:section", functools.partial( __shaderMetadata, name = "nodeGraphLayout:section" ),
+			"noduleLayout:section", functools.partial( __shaderMetadata, name = "noduleLayout:section" ),
 			"nodule:color", functools.partial( __shaderMetadata, name = "nodule:color" ),
 			"plugValueWidget:type", functools.partial( __shaderMetadata, name = "plugValueWidget:type" ),
 			"presetNames", functools.partial( __shaderMetadata, name = "presetNames" ),

--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -363,6 +363,14 @@ def __nodeMetadata( node, name ) :
 
 def __plugMetadata( plug, name ) :
 
+	if name == "nodeGraphLayout:visible" and plug.getInput() is not None :
+		# Before the introduction of nodule visibility controls,
+		# users may have made connections to plugs which are now
+		# hidden by default. Make sure we continue to show them
+		# by default - they can still be hidden explicitly by
+		# adding an instance metadata value.
+		return True
+
 	node = plug.node()
 	if isinstance( node, GafferArnold.ArnoldShader ) :
 		key = plug.node()["name"].getValue() + "." + plug.relativeName( node )

--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -198,7 +198,7 @@ def __translateNodeMetadata( nodeEntry ) :
 		visible = __aiMetadataGetBool( nodeEntry, None, "gaffer.nodeGraphLayout.defaultVisibility" )
 		visible = __aiMetadataGetBool( nodeEntry, paramName, "gaffer.nodeGraphLayout.visible", visible )
 		if visible is not None :
-			__metadata[paramPath]["nodeGraphLayout:visible"] = visible
+			__metadata[paramPath]["noduleLayout:visible"] = visible
 
 	# If we haven't seen any nice sane OSL "page" metadata, then have
 	# a go at translating the houdini layout metadata. Surely one of the
@@ -363,7 +363,7 @@ def __nodeMetadata( node, name ) :
 
 def __plugMetadata( plug, name ) :
 
-	if name == "nodeGraphLayout:visible" and plug.getInput() is not None :
+	if name == "noduleLayout:visible" and plug.getInput() is not None :
 		# Before the introduction of nodule visibility controls,
 		# users may have made connections to plugs which are now
 		# hidden by default. Make sure we continue to show them

--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -193,6 +193,13 @@ def __translateNodeMetadata( nodeEntry ) :
 		if label is not None :
 			__metadata[paramPath]["label"] = label
 
+		# NodeGraph visibility from Gaffer-specific metadata
+
+		visible = __aiMetadataGetBool( nodeEntry, None, "gaffer.nodeGraphLayout.defaultVisibility" )
+		visible = __aiMetadataGetBool( nodeEntry, paramName, "gaffer.nodeGraphLayout.visible", visible )
+		if visible is not None :
+			__metadata[paramPath]["nodeGraphLayout:visible"] = visible
+
 	# If we haven't seen any nice sane OSL "page" metadata, then have
 	# a go at translating the houdini layout metadata. Surely one of the
 	# most tortured ways of defining a UI ever.

--- a/python/GafferDispatchUI/TaskNodeUI.py
+++ b/python/GafferDispatchUI/TaskNodeUI.py
@@ -88,10 +88,9 @@ Gaffer.Metadata.registerNode(
 			need to be executed before downstream nodes.
 			""",
 
-			"nodeGadget:nodulePosition", "right",
 			"nodule:type", "GafferUI::CompoundNodule",
-			"compoundNodule:spacing", 0.2,
-			"compoundNodule:orientation", "y",
+			"nodeGraphLayout:section", "right",
+			"nodeGraphLayout:spacing", 0.2,
 
 			"plugValueWidget:type", "",
 
@@ -100,7 +99,7 @@ Gaffer.Metadata.registerNode(
 		"postTasks.*" : (
 
 			"plugValueWidget:type", "",
-			"nodeGadget:nodulePosition", "right",
+			"nodeGraphLayout:section", "right",
 
 		),
 

--- a/python/GafferDispatchUI/TaskNodeUI.py
+++ b/python/GafferDispatchUI/TaskNodeUI.py
@@ -67,7 +67,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "GafferUI::CompoundNodule",
-			"nodeGraphLayout:spacing", 0.4,
+			"noduleLayout:spacing", 0.4,
 
 			"plugValueWidget:type", "",
 
@@ -89,8 +89,8 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "GafferUI::CompoundNodule",
-			"nodeGraphLayout:section", "right",
-			"nodeGraphLayout:spacing", 0.2,
+			"noduleLayout:section", "right",
+			"noduleLayout:spacing", 0.2,
 
 			"plugValueWidget:type", "",
 
@@ -99,7 +99,7 @@ Gaffer.Metadata.registerNode(
 		"postTasks.*" : (
 
 			"plugValueWidget:type", "",
-			"nodeGraphLayout:section", "right",
+			"noduleLayout:section", "right",
 
 		),
 

--- a/python/GafferDispatchUI/TaskNodeUI.py
+++ b/python/GafferDispatchUI/TaskNodeUI.py
@@ -67,7 +67,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "GafferUI::CompoundNodule",
-			"compoundNodule:spacing", 0.4,
+			"nodeGraphLayout:spacing", 0.4,
 
 			"plugValueWidget:type", "",
 

--- a/python/GafferImageUI/ImageProcessorUI.py
+++ b/python/GafferImageUI/ImageProcessorUI.py
@@ -56,7 +56,7 @@ Gaffer.Metadata.registerNode(
 
 			"plugValueWidget:type", "",
 			"nodule:type", lambda plug : "GafferUI::CompoundNodule" if isinstance( plug, Gaffer.ArrayPlug ) else "GafferUI::StandardNodule",
-			"nodeGraphLayout:spacing", 2.0,
+			"noduleLayout:spacing", 2.0,
 
 		],
 

--- a/python/GafferImageUI/ImageProcessorUI.py
+++ b/python/GafferImageUI/ImageProcessorUI.py
@@ -56,7 +56,7 @@ Gaffer.Metadata.registerNode(
 
 			"plugValueWidget:type", "",
 			"nodule:type", lambda plug : "GafferUI::CompoundNodule" if isinstance( plug, Gaffer.ArrayPlug ) else "GafferUI::StandardNodule",
-			"compoundNodule:spacing", 2.0,
+			"nodeGraphLayout:spacing", 2.0,
 
 		],
 

--- a/python/GafferOSLUI/OSLImageUI.py
+++ b/python/GafferOSLUI/OSLImageUI.py
@@ -67,7 +67,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "GafferUI::StandardNodule",
-			"nodeGraphLayout:section", "left",
+			"noduleLayout:section", "left",
 
 		],
 

--- a/python/GafferOSLUI/OSLImageUI.py
+++ b/python/GafferOSLUI/OSLImageUI.py
@@ -66,8 +66,8 @@ Gaffer.Metadata.registerNode(
 				InLayer->ProcessingNodes->OutLayer->OutImage
 			""",
 
-			"nodeGadget:nodulePosition", "left",
 			"nodule:type", "GafferUI::StandardNodule",
+			"nodeGraphLayout:section", "left",
 
 		],
 

--- a/python/GafferOSLUI/OSLObjectUI.py
+++ b/python/GafferOSLUI/OSLObjectUI.py
@@ -66,8 +66,8 @@ Gaffer.Metadata.registerNode(
 				InPoint->ProcessingNodes->OutPoint->OutObject
 			""",
 
-			"nodeGadget:nodulePosition", "left",
 			"nodule:type", "GafferUI::StandardNodule",
+			"nodeGraphLayout:section", "left",
 
 		],
 

--- a/python/GafferOSLUI/OSLObjectUI.py
+++ b/python/GafferOSLUI/OSLObjectUI.py
@@ -67,7 +67,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "GafferUI::StandardNodule",
-			"nodeGraphLayout:section", "left",
+			"noduleLayout:section", "left",
 
 		],
 

--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -158,8 +158,7 @@ Gaffer.Metadata.registerNode(
 		"out" : [
 
 			"nodule:type", __outPlugNoduleType,
-			"compoundNodule:spacing", 0.2,
-			"compoundNodule:orientation", "y",
+			"nodeGraphLayout:spacing", 0.2,
 
 		],
 

--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -158,7 +158,7 @@ Gaffer.Metadata.registerNode(
 		"out" : [
 
 			"nodule:type", __outPlugNoduleType,
-			"nodeGraphLayout:spacing", 0.2,
+			"noduleLayout:spacing", 0.2,
 
 		],
 

--- a/python/GafferRenderManUI/RenderManShaderUI.py
+++ b/python/GafferRenderManUI/RenderManShaderUI.py
@@ -399,7 +399,7 @@ Gaffer.Metadata.registerNode(
 			"nodule:type", __plugNoduleType,
 			# Coshader arrays tend to be used for layering, so we prefer to
 			# present the last entry at the top, hence the increasing direction.
-			"nodeGraphLayout:direction", "increasing",
+			"noduleLayout:direction", "increasing",
 
 		],
 

--- a/python/GafferRenderManUI/RenderManShaderUI.py
+++ b/python/GafferRenderManUI/RenderManShaderUI.py
@@ -397,10 +397,9 @@ Gaffer.Metadata.registerNode(
 		"parameters.*" : [
 
 			"nodule:type", __plugNoduleType,
-			"compoundNodule:orientation", "y",
 			# Coshader arrays tend to be used for layering, so we prefer to
 			# present the last entry at the top, hence the increasing direction.
-			"compoundNodule:direction", "increasing",
+			"nodeGraphLayout:direction", "increasing",
 
 		],
 

--- a/python/GafferSceneUI/FilterProcessorUI.py
+++ b/python/GafferSceneUI/FilterProcessorUI.py
@@ -66,7 +66,7 @@ Gaffer.Metadata.registerNode(
 
 			"description", lambda plug : "The input filter" + ( "s" if isinstance( plug, Gaffer.ArrayPlug ) else "" ),
 			"nodule:type", lambda plug : "GafferUI::CompoundNodule" if isinstance( plug, Gaffer.ArrayPlug ) else "GafferUI::StandardNodule",
-			"compoundNodule:spacing", 2.0,
+			"nodeGraphLayout:spacing", 2.0,
 
 		],
 

--- a/python/GafferSceneUI/FilterProcessorUI.py
+++ b/python/GafferSceneUI/FilterProcessorUI.py
@@ -66,7 +66,7 @@ Gaffer.Metadata.registerNode(
 
 			"description", lambda plug : "The input filter" + ( "s" if isinstance( plug, Gaffer.ArrayPlug ) else "" ),
 			"nodule:type", lambda plug : "GafferUI::CompoundNodule" if isinstance( plug, Gaffer.ArrayPlug ) else "GafferUI::StandardNodule",
-			"nodeGraphLayout:spacing", 2.0,
+			"noduleLayout:spacing", 2.0,
 
 		],
 

--- a/python/GafferSceneUI/FilteredSceneProcessorUI.py
+++ b/python/GafferSceneUI/FilteredSceneProcessorUI.py
@@ -67,7 +67,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"layout:section", "Filter",
-			"nodeGadget:nodulePosition", "right",
+			"nodeGraphLayout:section", "right",
 			"layout:index", -3, # Just before the enabled plug,
 			"nodule:type", "GafferUI::StandardNodule",
 			"plugValueWidget:type", "GafferSceneUI.FilterPlugValueWidget",

--- a/python/GafferSceneUI/FilteredSceneProcessorUI.py
+++ b/python/GafferSceneUI/FilteredSceneProcessorUI.py
@@ -67,7 +67,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"layout:section", "Filter",
-			"nodeGraphLayout:section", "right",
+			"noduleLayout:section", "right",
 			"layout:index", -3, # Just before the enabled plug,
 			"nodule:type", "GafferUI::StandardNodule",
 			"plugValueWidget:type", "GafferSceneUI.FilterPlugValueWidget",

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -58,10 +58,9 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
-			"nodeGadget:nodulePosition", "left",
 			"nodule:type", "GafferUI::CompoundNodule",
-			"compoundNodule:orientation", "y",
-			"compoundNodule:spacing", 0.2,
+			"nodeGraphLayout:section", "left",
+			"nodeGraphLayout:spacing", 0.2,
 
 
 		],
@@ -73,7 +72,7 @@ Gaffer.Metadata.registerNode(
 			# appropriate values for each individual parameter,
 			# for the case where they get promoted to a box
 			# individually.
-			"nodeGadget:nodulePosition", "left",
+			"nodeGraphLayout:section", "left",
 			"nodule:type", "",
 
 		],

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -59,8 +59,8 @@ Gaffer.Metadata.registerNode(
 
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 			"nodule:type", "GafferUI::CompoundNodule",
-			"nodeGraphLayout:section", "left",
-			"nodeGraphLayout:spacing", 0.2,
+			"noduleLayout:section", "left",
+			"noduleLayout:spacing", 0.2,
 
 
 		],
@@ -72,7 +72,7 @@ Gaffer.Metadata.registerNode(
 			# appropriate values for each individual parameter,
 			# for the case where they get promoted to a box
 			# individually.
-			"nodeGraphLayout:section", "left",
+			"noduleLayout:section", "left",
 			"nodule:type", "",
 
 		],

--- a/python/GafferSceneUI/SceneProcessorUI.py
+++ b/python/GafferSceneUI/SceneProcessorUI.py
@@ -56,7 +56,7 @@ Gaffer.Metadata.registerNode(
 			"description", lambda plug : "The input scene" + ( "s" if isinstance( plug, Gaffer.ArrayPlug ) else "" ),
 			"plugValueWidget:type", "",
 			"nodule:type", lambda plug : "GafferUI::CompoundNodule" if isinstance( plug, Gaffer.ArrayPlug ) else "GafferUI::StandardNodule",
-			"compoundNodule:spacing", 2.0,
+			"nodeGraphLayout:spacing", 2.0,
 
 		],
 

--- a/python/GafferSceneUI/SceneProcessorUI.py
+++ b/python/GafferSceneUI/SceneProcessorUI.py
@@ -56,7 +56,7 @@ Gaffer.Metadata.registerNode(
 			"description", lambda plug : "The input scene" + ( "s" if isinstance( plug, Gaffer.ArrayPlug ) else "" ),
 			"plugValueWidget:type", "",
 			"nodule:type", lambda plug : "GafferUI::CompoundNodule" if isinstance( plug, Gaffer.ArrayPlug ) else "GafferUI::StandardNodule",
-			"nodeGraphLayout:spacing", 2.0,
+			"noduleLayout:spacing", 2.0,
 
 		],
 

--- a/python/GafferSceneUI/ShaderAssignmentUI.py
+++ b/python/GafferSceneUI/ShaderAssignmentUI.py
@@ -58,7 +58,7 @@ Gaffer.Metadata.registerNode(
 			The shader to be assigned.
 			""",
 
-			"nodeGraphLayout:section", "left",
+			"noduleLayout:section", "left",
 			"nodule:type", "GafferUI::StandardNodule",
 
 		]

--- a/python/GafferSceneUI/ShaderAssignmentUI.py
+++ b/python/GafferSceneUI/ShaderAssignmentUI.py
@@ -58,7 +58,7 @@ Gaffer.Metadata.registerNode(
 			The shader to be assigned.
 			""",
 
-			"nodeGadget:nodulePosition", "left",
+			"nodeGraphLayout:section", "left",
 			"nodule:type", "GafferUI::StandardNodule",
 
 		]

--- a/python/GafferSceneUI/ShaderBallUI.py
+++ b/python/GafferSceneUI/ShaderBallUI.py
@@ -55,7 +55,7 @@ Gaffer.Metadata.registerNode(
 			The shader to be rendered.
 			""",
 
-			"nodeGraphLayout:section", "left",
+			"noduleLayout:section", "left",
 			"nodule:type", "GafferUI::StandardNodule",
 
 		],

--- a/python/GafferSceneUI/ShaderBallUI.py
+++ b/python/GafferSceneUI/ShaderBallUI.py
@@ -55,7 +55,7 @@ Gaffer.Metadata.registerNode(
 			The shader to be rendered.
 			""",
 
-			"nodeGadget:nodulePosition", "left",
+			"nodeGraphLayout:section", "left",
 			"nodule:type", "GafferUI::StandardNodule",
 
 		],

--- a/python/GafferSceneUI/ShaderSwitchUI.py
+++ b/python/GafferSceneUI/ShaderSwitchUI.py
@@ -64,9 +64,8 @@ Gaffer.Metadata.registerNode(
 
 			"plugValueWidget:type", "",
 			"nodule:type", "GafferUI::CompoundNodule",
-			"nodeGadget:nodulePosition", "left",
-			"compoundNodule:orientation", "y",
-			"compoundNodule:spacing", 0.2,
+			"nodeGraphLayout:section", "left",
+			"nodeGraphLayout:spacing", 0.2,
 
 		],
 
@@ -77,7 +76,7 @@ Gaffer.Metadata.registerNode(
 			The output shader.
 			""",
 
-			"nodeGadget:nodulePosition", "right",
+			"nodeGraphLayout:section", "right",
 			"plugValueWidget:type", "",
 
 		],

--- a/python/GafferSceneUI/ShaderSwitchUI.py
+++ b/python/GafferSceneUI/ShaderSwitchUI.py
@@ -64,8 +64,8 @@ Gaffer.Metadata.registerNode(
 
 			"plugValueWidget:type", "",
 			"nodule:type", "GafferUI::CompoundNodule",
-			"nodeGraphLayout:section", "left",
-			"nodeGraphLayout:spacing", 0.2,
+			"noduleLayout:section", "left",
+			"noduleLayout:spacing", 0.2,
 
 		],
 
@@ -76,7 +76,7 @@ Gaffer.Metadata.registerNode(
 			The output shader.
 			""",
 
-			"nodeGraphLayout:section", "right",
+			"noduleLayout:section", "right",
 			"plugValueWidget:type", "",
 
 		],

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -102,10 +102,9 @@ Gaffer.Metadata.registerNode(
 			Where the parameters for the shader are represented.
 			""",
 
-			"nodeGadget:nodulePosition", "left",
 			"nodule:type", "GafferUI::CompoundNodule",
-			"compoundNodule:orientation", "y",
-			"compoundNodule:spacing", 0.2,
+			"nodeGraphLayout:section", "left",
+			"nodeGraphLayout:spacing", 0.2,
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 
 		],
@@ -117,7 +116,7 @@ Gaffer.Metadata.registerNode(
 			# appropriate values for each individual parameter,
 			# for the case where they get promoted to a box
 			# individually.
-			"nodeGadget:nodulePosition", "left",
+			"nodeGraphLayout:section", "left",
 
 		],
 
@@ -128,8 +127,14 @@ Gaffer.Metadata.registerNode(
 			The output from the shader.
 			""",
 
-			"nodeGadget:nodulePosition", "right",
+			"nodeGraphLayout:section", "right",
 			"plugValueWidget:type", "",
+
+		],
+
+		"out.*" : [
+
+			"nodeGraphLayout:section", "right",
 
 		],
 

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -103,8 +103,8 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "GafferUI::CompoundNodule",
-			"nodeGraphLayout:section", "left",
-			"nodeGraphLayout:spacing", 0.2,
+			"noduleLayout:section", "left",
+			"noduleLayout:spacing", 0.2,
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
 
 		],
@@ -116,7 +116,7 @@ Gaffer.Metadata.registerNode(
 			# appropriate values for each individual parameter,
 			# for the case where they get promoted to a box
 			# individually.
-			"nodeGraphLayout:section", "left",
+			"noduleLayout:section", "left",
 
 		],
 
@@ -127,14 +127,14 @@ Gaffer.Metadata.registerNode(
 			The output from the shader.
 			""",
 
-			"nodeGraphLayout:section", "right",
+			"noduleLayout:section", "right",
 			"plugValueWidget:type", "",
 
 		],
 
 		"out.*" : [
 
-			"nodeGraphLayout:section", "right",
+			"noduleLayout:section", "right",
 
 		],
 
@@ -305,7 +305,7 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 
 		"/Hide",
 		{
-			"command" : functools.partial( __setPlugMetadata, plug, "nodeGraphLayout:visible", False ),
+			"command" : functools.partial( __setPlugMetadata, plug, "noduleLayout:visible", False ),
 			"active" : plug.getInput() is None and not Gaffer.readOnly( plug ),
 		}
 

--- a/python/GafferSceneUITest/ShaderUITest.py
+++ b/python/GafferSceneUITest/ShaderUITest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,15 +34,28 @@
 #
 ##########################################################################
 
-from SceneViewTest import SceneViewTest
-from ShaderAssignmentUITest import ShaderAssignmentUITest
-from StandardGraphLayoutTest import StandardGraphLayoutTest
-from SceneGadgetTest import SceneGadgetTest
-from SceneInspectorTest import SceneInspectorTest
-from SceneHierarchyTest import SceneHierarchyTest
-from DocumentationTest import DocumentationTest
-from ShaderViewTest import ShaderViewTest
-from ShaderUITest import ShaderUITest
+import IECore
+
+import GafferUI
+import GafferUITest
+import GafferSceneTest
+import GafferSceneUI
+
+class ShaderUITest( GafferUITest.TestCase ) :
+
+	def testNoduleOrdering( self ) :
+
+		s = GafferSceneTest.TestShader()
+
+		g = GafferUI.NodeGadget.create( s )
+		n1 = g.nodule( s["parameters"]["i"] )
+		n2 = g.nodule( s["parameters"]["c"] )
+		g.bound()
+
+		self.assertGreater(
+			n1.transformedBound( None ).center().y,
+			n2.transformedBound( None ).center().y
+		)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -124,5 +124,33 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 		self.assertEqual( ancestorAffected, [ False, False, True ] )
 		self.assertEqual( childAffected, [ False, True, False ] )
 
+	def testNodeAffected( self ) :
+
+		n = GafferTest.CompoundPlugNode()
+
+		affected = []
+		def nodeValueChanged( nodeTypeId, key, node ) :
+			affected.append( Gaffer.MetadataAlgo.affectedByChange( n, nodeTypeId, node ) )
+
+		c = Gaffer.Metadata.nodeValueChangedSignal().connect( nodeValueChanged )
+
+		Gaffer.Metadata.registerValue( Gaffer.Node, "metadataAlgoTest", 1 )
+		self.assertEqual( affected, [ True ] )
+
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "metadataAlgoTest", 2 )
+		self.assertEqual( affected, [ True, False ] )
+
+		Gaffer.Metadata.registerValue( n, "metadataAlgoTest", 3 )
+		self.assertEqual( affected, [ True, False, True ] )
+
+		a = GafferTest.AddNode()
+		Gaffer.Metadata.registerValue( a, "metadataAlgoTest", 4 )
+		self.assertEqual( affected, [ True, False, True, False ] )
+
+	def tearDown( self ) :
+
+		for n in ( Gaffer.Node, GafferTest.AddNode ) :
+			Gaffer.Metadata.deregisterValue( n, "metadataAlgoTest" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/BoxUI.py
+++ b/python/GafferUI/BoxUI.py
@@ -361,7 +361,7 @@ def __reorderPlugs( plugs, plug, newIndex ) :
 	plugs.insert( newIndex, plug )
 	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
 		for index, plug in enumerate( plugs ) :
-			Gaffer.Metadata.registerValue( plug, "nodeGadget:noduleIndex", index )
+			Gaffer.Metadata.registerValue( plug, "nodeGraphLayout:index", index )
 
 def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 
@@ -378,7 +378,7 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 
 		menuDefinition.append( "/MoveDivider", { "divider" : True } )
 
-		currentEdge = Gaffer.Metadata.value( plug, "nodeGadget:nodulePosition" )
+		currentEdge = Gaffer.Metadata.value( plug, "nodeGraphLayout:section" )
 		if not currentEdge :
 			currentEdge = "top" if plug.direction() == plug.Direction.In else "bottom"
 
@@ -386,7 +386,7 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 			menuDefinition.append(
 				"/Move To/" + edge.capitalize(),
 				{
-					"command" : functools.partial( __setPlugMetadata, plug, "nodeGadget:nodulePosition", edge ),
+					"command" : functools.partial( __setPlugMetadata, plug, "nodeGraphLayout:section", edge ),
 					"active" : edge != currentEdge and not readOnly,
 				}
 			)

--- a/python/GafferUI/BoxUI.py
+++ b/python/GafferUI/BoxUI.py
@@ -361,7 +361,7 @@ def __reorderPlugs( plugs, plug, newIndex ) :
 	plugs.insert( newIndex, plug )
 	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
 		for index, plug in enumerate( plugs ) :
-			Gaffer.Metadata.registerValue( plug, "nodeGraphLayout:index", index )
+			Gaffer.Metadata.registerValue( plug, "noduleLayout:index", index )
 
 def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 
@@ -378,7 +378,7 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 
 		menuDefinition.append( "/MoveDivider", { "divider" : True } )
 
-		currentEdge = Gaffer.Metadata.value( plug, "nodeGraphLayout:section" )
+		currentEdge = Gaffer.Metadata.value( plug, "noduleLayout:section" )
 		if not currentEdge :
 			currentEdge = "top" if plug.direction() == plug.Direction.In else "bottom"
 
@@ -386,7 +386,7 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 			menuDefinition.append(
 				"/Move To/" + edge.capitalize(),
 				{
-					"command" : functools.partial( __setPlugMetadata, plug, "nodeGraphLayout:section", edge ),
+					"command" : functools.partial( __setPlugMetadata, plug, "noduleLayout:section", edge ),
 					"active" : edge != currentEdge and not readOnly,
 				}
 			)

--- a/python/GafferUI/DotUI.py
+++ b/python/GafferUI/DotUI.py
@@ -186,7 +186,7 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 
 		## \todo This duplicates functionality from BoxUI. Is there some way
 		# we could share it?
-		currentEdge = Gaffer.Metadata.value( plug, "nodeGraphLayout:section" )
+		currentEdge = Gaffer.Metadata.value( plug, "noduleLayout:section" )
 		if not currentEdge :
 			currentEdge = "top" if plug.direction() == plug.Direction.In else "bottom"
 
@@ -195,7 +195,7 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 			menuDefinition.append(
 				"/Move To/" + edge.capitalize(),
 				{
-					"command" : functools.partial( __setPlugMetadata, plug, "nodeGraphLayout:section", edge ),
+					"command" : functools.partial( __setPlugMetadata, plug, "noduleLayout:section", edge ),
 					"active" : edge != currentEdge and not readOnly,
 				}
 			)

--- a/python/GafferUI/DotUI.py
+++ b/python/GafferUI/DotUI.py
@@ -186,7 +186,7 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 
 		## \todo This duplicates functionality from BoxUI. Is there some way
 		# we could share it?
-		currentEdge = Gaffer.Metadata.value( plug, "nodeGadget:nodulePosition" )
+		currentEdge = Gaffer.Metadata.value( plug, "nodeGraphLayout:section" )
 		if not currentEdge :
 			currentEdge = "top" if plug.direction() == plug.Direction.In else "bottom"
 
@@ -195,7 +195,7 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 			menuDefinition.append(
 				"/Move To/" + edge.capitalize(),
 				{
-					"command" : functools.partial( __setPlugMetadata, plug, "nodeGadget:nodulePosition", edge ),
+					"command" : functools.partial( __setPlugMetadata, plug, "nodeGraphLayout:section", edge ),
 					"active" : edge != currentEdge and not readOnly,
 				}
 			)

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -80,7 +80,7 @@ class Menu( GafferUI.Widget ) :
 	# doing so means some of it will be off screen. If grabFocus is False, then
 	# the menu will not take keyboard events unless the first such event is a
 	# press of the up or down arrows.
-	def popup( self, parent=None, position=None, forcePosition=False, grabFocus=True ) :
+	def popup( self, parent=None, position=None, forcePosition=False, grabFocus=True, modal=False ) :
 
 		if parent is not None :
 			self.__popupParent = weakref.ref( parent )
@@ -96,7 +96,10 @@ class Menu( GafferUI.Widget ) :
 
 		self._qtWidget().keyboardMode = _Menu.KeyboardMode.Grab if grabFocus else _Menu.KeyboardMode.Close
 
-		self._qtWidget().popup( position )
+		if modal :
+			self._qtWidget().exec_( position )
+		else :
+			self._qtWidget().popup( position )
 
 		# qt is helpful and tries to keep you menu on screen, but this isn't always
 		# what you want, so we override the helpfulness if requested.

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -1494,8 +1494,8 @@ class _PlugEditor( GafferUI.Widget ) :
 					with _Row() :
 
 						_Label( "Position" )
-						self.__metadataWidgets["nodeGadget:nodulePosition"] = _MenuMetadataWidget(
-							key = "nodeGadget:nodulePosition",
+						self.__metadataWidgets["nodeGraphLayout:section"] = _MenuMetadataWidget(
+							key = "nodeGraphLayout:section",
 							labelsAndValues = [
 								( "Default", None ),
 								( "Top", "top" ),

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -1494,8 +1494,8 @@ class _PlugEditor( GafferUI.Widget ) :
 					with _Row() :
 
 						_Label( "Position" )
-						self.__metadataWidgets["nodeGraphLayout:section"] = _MenuMetadataWidget(
-							key = "nodeGraphLayout:section",
+						self.__metadataWidgets["noduleLayout:section"] = _MenuMetadataWidget(
+							key = "noduleLayout:section",
 							labelsAndValues = [
 								( "Default", None ),
 								( "Top", "top" ),

--- a/python/GafferUI/_PlugAdder.py
+++ b/python/GafferUI/_PlugAdder.py
@@ -1,0 +1,63 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import IECore
+
+import GafferUI
+
+def __plugMenu( title, plugs ) :
+
+	chosenPlugs = []
+	def choosePlug( plug ) :
+		chosenPlugs.append( plug )
+
+	menuDefinition = IECore.MenuDefinition()
+	for plug in plugs :
+		menuDefinition.append(
+			"/" + plug.getName(),
+			{
+				"command" : functools.partial( choosePlug, plug )
+			}
+		)
+
+	menu = GafferUI.Menu( menuDefinition, title = title )
+	menu.popup( modal = True )
+
+	return chosenPlugs[0] if chosenPlugs else None
+
+__plugMenuConnection = GafferUI.PlugAdder.plugMenuSignal().connect( __plugMenu )

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -271,6 +271,7 @@ from Playback import Playback
 from UIEditor import UIEditor
 import GraphBookmarksUI
 import DocumentationAlgo
+import _PlugAdder
 
 # and then specific node uis
 

--- a/python/GafferUITest/BoxUITest.py
+++ b/python/GafferUITest/BoxUITest.py
@@ -51,8 +51,8 @@ class BoxUITest( GafferUITest.TestCase ) :
 
 	IECore.registerRunTimeTyped( NodulePositionNode )
 
-	Gaffer.Metadata.registerValue( NodulePositionNode, "op1", "nodeGraphLayout:section", "left" )
-	Gaffer.Metadata.registerValue( NodulePositionNode, "sum", "nodeGraphLayout:section", "right" )
+	Gaffer.Metadata.registerValue( NodulePositionNode, "op1", "noduleLayout:section", "left" )
+	Gaffer.Metadata.registerValue( NodulePositionNode, "sum", "noduleLayout:section", "right" )
 
 	Gaffer.Metadata.registerValue( NodulePositionNode, "op2", "nodule:type", "" )
 

--- a/python/GafferUITest/BoxUITest.py
+++ b/python/GafferUITest/BoxUITest.py
@@ -51,8 +51,8 @@ class BoxUITest( GafferUITest.TestCase ) :
 
 	IECore.registerRunTimeTyped( NodulePositionNode )
 
-	Gaffer.Metadata.registerValue( NodulePositionNode, "op1", "nodeGadget:nodulePosition", "left" )
-	Gaffer.Metadata.registerValue( NodulePositionNode, "sum", "nodeGadget:nodulePosition", "right" )
+	Gaffer.Metadata.registerValue( NodulePositionNode, "op1", "nodeGraphLayout:section", "left" )
+	Gaffer.Metadata.registerValue( NodulePositionNode, "sum", "nodeGraphLayout:section", "right" )
 
 	Gaffer.Metadata.registerValue( NodulePositionNode, "op2", "nodule:type", "" )
 

--- a/python/GafferUITest/CompoundNoduleTest.py
+++ b/python/GafferUITest/CompoundNoduleTest.py
@@ -56,7 +56,7 @@ class CompoundNoduleTest( GafferUITest.TestCase ) :
 		size = nodule.bound().size()
 		self.assertTrue( size.x > size.y )
 
-		Gaffer.Metadata.registerValue( arrayNode["in"], "nodeGraphLayout:spacing", 100.0 )
+		Gaffer.Metadata.registerValue( arrayNode["in"], "noduleLayout:spacing", 100.0 )
 		self.assertTrue( nodule.bound().size().x > size.x )
 
 		# For backwards compatibility only. We no longer have a non-deprecated orientation

--- a/python/GafferUITest/CompoundNoduleTest.py
+++ b/python/GafferUITest/CompoundNoduleTest.py
@@ -56,9 +56,11 @@ class CompoundNoduleTest( GafferUITest.TestCase ) :
 		size = nodule.bound().size()
 		self.assertTrue( size.x > size.y )
 
-		Gaffer.Metadata.registerValue( arrayNode["in"], "compoundNodule:spacing", 100.0 )
+		Gaffer.Metadata.registerValue( arrayNode["in"], "nodeGraphLayout:spacing", 100.0 )
 		self.assertTrue( nodule.bound().size().x > size.x )
 
+		# For backwards compatibility only. We no longer have a non-deprecated orientation
+		# key, and always infer orientation automatically by section.
 		Gaffer.Metadata.registerValue( arrayNode["in"], "compoundNodule:orientation", "y" )
 		size = nodule.bound().size()
 		self.assertTrue( size.y > size.x )

--- a/python/GafferUITest/DotNodeGadgetTest.py
+++ b/python/GafferUITest/DotNodeGadgetTest.py
@@ -68,7 +68,7 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		s = Gaffer.ScriptNode()
 
 		s["n"] = GafferTest.AddNode()
-		Gaffer.Metadata.registerValue( s["n"]["sum"], "nodeGraphLayout:section", "right" )
+		Gaffer.Metadata.registerValue( s["n"]["sum"], "noduleLayout:section", "right" )
 
 		s["d"] = Gaffer.Dot()
 
@@ -87,7 +87,7 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		s = Gaffer.ScriptNode()
 
 		s["n"] = GafferTest.AddNode()
-		Gaffer.Metadata.registerValue( s["n"]["op1"], "nodeGraphLayout:section", "left" )
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "noduleLayout:section", "left" )
 
 		s["d"] = Gaffer.Dot()
 
@@ -109,7 +109,7 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		s["n2"] = GafferTest.AddNode()
 		s["n2"]["op1"].setInput( s["n1"]["sum"] )
 
-		Gaffer.Metadata.registerValue( s["n1"]["sum"], "nodeGraphLayout:section", "right" )
+		Gaffer.Metadata.registerValue( s["n1"]["sum"], "noduleLayout:section", "right" )
 
 		s["d"] = Gaffer.Dot()
 
@@ -128,7 +128,7 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		s = Gaffer.ScriptNode()
 
 		s["n"] = GafferTest.AddNode()
-		Gaffer.Metadata.registerValue( s["n"]["sum"], "nodeGraphLayout:section", "right" )
+		Gaffer.Metadata.registerValue( s["n"]["sum"], "noduleLayout:section", "right" )
 
 		graphGadget = GafferUI.GraphGadget( s )
 

--- a/python/GafferUITest/DotNodeGadgetTest.py
+++ b/python/GafferUITest/DotNodeGadgetTest.py
@@ -68,7 +68,7 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		s = Gaffer.ScriptNode()
 
 		s["n"] = GafferTest.AddNode()
-		Gaffer.Metadata.registerValue( s["n"]["sum"], "nodeGadget:nodulePosition", "right" )
+		Gaffer.Metadata.registerValue( s["n"]["sum"], "nodeGraphLayout:section", "right" )
 
 		s["d"] = Gaffer.Dot()
 
@@ -87,7 +87,7 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		s = Gaffer.ScriptNode()
 
 		s["n"] = GafferTest.AddNode()
-		Gaffer.Metadata.registerValue( s["n"]["op1"], "nodeGadget:nodulePosition", "left" )
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "nodeGraphLayout:section", "left" )
 
 		s["d"] = Gaffer.Dot()
 
@@ -109,7 +109,7 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		s["n2"] = GafferTest.AddNode()
 		s["n2"]["op1"].setInput( s["n1"]["sum"] )
 
-		Gaffer.Metadata.registerValue( s["n1"]["sum"], "nodeGadget:nodulePosition", "right" )
+		Gaffer.Metadata.registerValue( s["n1"]["sum"], "nodeGraphLayout:section", "right" )
 
 		s["d"] = Gaffer.Dot()
 
@@ -128,7 +128,7 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		s = Gaffer.ScriptNode()
 
 		s["n"] = GafferTest.AddNode()
-		Gaffer.Metadata.registerValue( s["n"]["sum"], "nodeGadget:nodulePosition", "right" )
+		Gaffer.Metadata.registerValue( s["n"]["sum"], "nodeGraphLayout:section", "right" )
 
 		graphGadget = GafferUI.GraphGadget( s )
 

--- a/python/GafferUITest/GraphGadgetTest.py
+++ b/python/GafferUITest/GraphGadgetTest.py
@@ -1256,5 +1256,45 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		g.setNodePosition( s["n"], IECore.V2f( 0 ) )
 		self.assertEqual( g.unpositionedNodeGadgets(), [] )
 
+	def testInputConnectionMaintainedOnNoduleMove( self ) :
+
+		s = Gaffer.ScriptNode()
+		g = GafferUI.GraphGadget( s )
+
+		s["n1"] = GafferTest.AddNode()
+		s["n2"] = GafferTest.AddNode()
+
+		s["n2"]["op1"].setInput( s["n1"]["sum"] )
+
+		self.assertTrue( g.connectionGadget( s["n2"]["op1"] ) is not None )
+
+		for section in ( "top", "bottom", "top", "left", "right", "left", "bottom", "right" ) :
+			Gaffer.Metadata.registerValue( s["n2"]["op1"], "nodeGraphLayout:section", section )
+			connection = g.connectionGadget( s["n2"]["op1"] )
+			self.assertTrue( connection is not None )
+			self.assertTrue( connection.srcNodule() is not None )
+			self.assertTrue( connection.srcNodule().isSame( g.nodeGadget( s["n1"] ).nodule( s["n1"]["sum"] ) ) )
+			self.assertTrue( connection.dstNodule().isSame( g.nodeGadget( s["n2"] ).nodule( s["n2"]["op1"] ) ) )
+
+	def testOutputConnectionMaintainedOnNoduleMove( self ) :
+
+		s = Gaffer.ScriptNode()
+		g = GafferUI.GraphGadget( s )
+
+		s["n1"] = GafferTest.AddNode()
+		s["n2"] = GafferTest.AddNode()
+
+		s["n2"]["op1"].setInput( s["n1"]["sum"] )
+
+		self.assertTrue( g.connectionGadget( s["n2"]["op1"] ) is not None )
+
+		for section in ( "top", "bottom", "top", "left", "right", "left", "bottom", "right" ) :
+			Gaffer.Metadata.registerValue( s["n1"]["sum"], "nodeGraphLayout:section", section )
+			connection = g.connectionGadget( s["n2"]["op1"] )
+			self.assertTrue( connection is not None )
+			self.assertTrue( connection.srcNodule() is not None )
+			self.assertTrue( connection.srcNodule().isSame( g.nodeGadget( s["n1"] ).nodule( s["n1"]["sum"] ) ) )
+			self.assertTrue( connection.dstNodule().isSame( g.nodeGadget( s["n2"] ).nodule( s["n2"]["op1"] ) ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/GraphGadgetTest.py
+++ b/python/GafferUITest/GraphGadgetTest.py
@@ -1269,7 +1269,7 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		self.assertTrue( g.connectionGadget( s["n2"]["op1"] ) is not None )
 
 		for section in ( "top", "bottom", "top", "left", "right", "left", "bottom", "right" ) :
-			Gaffer.Metadata.registerValue( s["n2"]["op1"], "nodeGraphLayout:section", section )
+			Gaffer.Metadata.registerValue( s["n2"]["op1"], "noduleLayout:section", section )
 			connection = g.connectionGadget( s["n2"]["op1"] )
 			self.assertTrue( connection is not None )
 			self.assertTrue( connection.srcNodule() is not None )
@@ -1289,7 +1289,7 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		self.assertTrue( g.connectionGadget( s["n2"]["op1"] ) is not None )
 
 		for section in ( "top", "bottom", "top", "left", "right", "left", "bottom", "right" ) :
-			Gaffer.Metadata.registerValue( s["n1"]["sum"], "nodeGraphLayout:section", section )
+			Gaffer.Metadata.registerValue( s["n1"]["sum"], "noduleLayout:section", section )
 			connection = g.connectionGadget( s["n2"]["op1"] )
 			self.assertTrue( connection is not None )
 			self.assertTrue( connection.srcNodule() is not None )

--- a/python/GafferUITest/NoduleLayoutTest.py
+++ b/python/GafferUITest/NoduleLayoutTest.py
@@ -1,0 +1,122 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferTest
+import GafferUI
+import GafferUITest
+
+class NoduleLayoutTest( GafferUITest.TestCase ) :
+
+	def testChangingSection( self ) :
+
+		n = GafferTest.AddNode()
+
+		top = GafferUI.NoduleLayout( n, "top" )
+		left = GafferUI.NoduleLayout( n, "left" )
+
+		self.assertTrue( top.nodule( n["op1"] ) is not None )
+		self.assertTrue( left.nodule( n["op1"] ) is None )
+
+		Gaffer.Metadata.registerValue( n["op1"], "nodeGraphLayout:section", "left" )
+
+		self.assertTrue( top.nodule( n["op1"] ) is None )
+		self.assertTrue( left.nodule( n["op1"] ) is not None )
+
+	def testDefaultDirection( self ) :
+
+		n = GafferTest.AddNode()
+
+		top = GafferUI.NoduleLayout( n, "top" )
+		self.assertGreater( top.bound().size().x, top.bound().size().y )
+
+		self.assertGreater(
+			top.nodule( n["op2"] ).transformedBound( None ).center().x,
+			top.nodule( n["op1"] ).transformedBound( None ).center().x
+		)
+
+		Gaffer.Metadata.registerValue( n["op1"], "nodeGraphLayout:section", "left" )
+		Gaffer.Metadata.registerValue( n["op2"], "nodeGraphLayout:section", "left" )
+
+		left = GafferUI.NoduleLayout( n, "left" )
+		self.assertGreater( left.bound().size().y, left.bound().size().x )
+
+		self.assertGreater(
+			left.nodule( n["op1"] ).transformedBound( None ).center().y,
+			left.nodule( n["op2"] ).transformedBound( None ).center().y
+		)
+
+	def testExplicitDirection( self ) :
+
+		n = GafferTest.AddNode()
+
+		top = GafferUI.NoduleLayout( n, "top" )
+		self.assertGreater( top.bound().size().x, top.bound().size().y )
+
+		self.assertGreater(
+			top.nodule( n["op2"] ).transformedBound( None ).center().x,
+			top.nodule( n["op1"] ).transformedBound( None ).center().x
+		)
+
+		Gaffer.Metadata.registerValue( n, "nodeGraphLayout:section:top:direction", "decreasing" )
+
+		self.assertGreater( top.bound().size().x, top.bound().size().y )
+
+		self.assertLess(
+			top.nodule( n["op2"] ).transformedBound( None ).center().x,
+			top.nodule( n["op1"] ).transformedBound( None ).center().x
+		)
+
+	def testVisible( self ) :
+
+		n = GafferTest.AddNode()
+
+		top = GafferUI.NoduleLayout( n, "top" )
+		self.assertTrue( top.nodule( n["op1"] ) is not None )
+		self.assertTrue( top.nodule( n["op2"] ) is not None )
+
+		Gaffer.Metadata.registerValue( n["op1"], "nodeGraphLayout:visible", False )
+		self.assertTrue( top.nodule( n["op1"] ) is None )
+		self.assertTrue( top.nodule( n["op2"] ) is not None )
+
+		Gaffer.Metadata.registerValue( n["op1"], "nodeGraphLayout:visible", True )
+		self.assertTrue( top.nodule( n["op1"] ) is not None )
+		self.assertTrue( top.nodule( n["op2"] ) is not None )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/NoduleLayoutTest.py
+++ b/python/GafferUITest/NoduleLayoutTest.py
@@ -53,7 +53,7 @@ class NoduleLayoutTest( GafferUITest.TestCase ) :
 		self.assertTrue( top.nodule( n["op1"] ) is not None )
 		self.assertTrue( left.nodule( n["op1"] ) is None )
 
-		Gaffer.Metadata.registerValue( n["op1"], "nodeGraphLayout:section", "left" )
+		Gaffer.Metadata.registerValue( n["op1"], "noduleLayout:section", "left" )
 
 		self.assertTrue( top.nodule( n["op1"] ) is None )
 		self.assertTrue( left.nodule( n["op1"] ) is not None )
@@ -70,8 +70,8 @@ class NoduleLayoutTest( GafferUITest.TestCase ) :
 			top.nodule( n["op1"] ).transformedBound( None ).center().x
 		)
 
-		Gaffer.Metadata.registerValue( n["op1"], "nodeGraphLayout:section", "left" )
-		Gaffer.Metadata.registerValue( n["op2"], "nodeGraphLayout:section", "left" )
+		Gaffer.Metadata.registerValue( n["op1"], "noduleLayout:section", "left" )
+		Gaffer.Metadata.registerValue( n["op2"], "noduleLayout:section", "left" )
 
 		left = GafferUI.NoduleLayout( n, "left" )
 		self.assertGreater( left.bound().size().y, left.bound().size().x )
@@ -93,7 +93,7 @@ class NoduleLayoutTest( GafferUITest.TestCase ) :
 			top.nodule( n["op1"] ).transformedBound( None ).center().x
 		)
 
-		Gaffer.Metadata.registerValue( n, "nodeGraphLayout:section:top:direction", "decreasing" )
+		Gaffer.Metadata.registerValue( n, "noduleLayout:section:top:direction", "decreasing" )
 
 		self.assertGreater( top.bound().size().x, top.bound().size().y )
 
@@ -110,11 +110,11 @@ class NoduleLayoutTest( GafferUITest.TestCase ) :
 		self.assertTrue( top.nodule( n["op1"] ) is not None )
 		self.assertTrue( top.nodule( n["op2"] ) is not None )
 
-		Gaffer.Metadata.registerValue( n["op1"], "nodeGraphLayout:visible", False )
+		Gaffer.Metadata.registerValue( n["op1"], "noduleLayout:visible", False )
 		self.assertTrue( top.nodule( n["op1"] ) is None )
 		self.assertTrue( top.nodule( n["op2"] ) is not None )
 
-		Gaffer.Metadata.registerValue( n["op1"], "nodeGraphLayout:visible", True )
+		Gaffer.Metadata.registerValue( n["op1"], "noduleLayout:visible", True )
 		self.assertTrue( top.nodule( n["op1"] ) is not None )
 		self.assertTrue( top.nodule( n["op2"] ) is not None )
 

--- a/python/GafferUITest/StandardGraphLayoutTest.py
+++ b/python/GafferUITest/StandardGraphLayoutTest.py
@@ -70,10 +70,10 @@ class LayoutNode( Gaffer.Node ) :
 
 IECore.registerRunTimeTyped( LayoutNode )
 
-Gaffer.Metadata.registerValue( LayoutNode, "left*", "nodeGraphLayout:section", "left" )
-Gaffer.Metadata.registerValue( LayoutNode, "right*", "nodeGraphLayout:section", "right" )
-Gaffer.Metadata.registerValue( LayoutNode, "top*", "nodeGraphLayout:section", "top" )
-Gaffer.Metadata.registerValue( LayoutNode, "bottom*", "nodeGraphLayout:section", "bottom" )
+Gaffer.Metadata.registerValue( LayoutNode, "left*", "noduleLayout:section", "left" )
+Gaffer.Metadata.registerValue( LayoutNode, "right*", "noduleLayout:section", "right" )
+Gaffer.Metadata.registerValue( LayoutNode, "top*", "noduleLayout:section", "top" )
+Gaffer.Metadata.registerValue( LayoutNode, "bottom*", "noduleLayout:section", "bottom" )
 
 class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 

--- a/python/GafferUITest/StandardGraphLayoutTest.py
+++ b/python/GafferUITest/StandardGraphLayoutTest.py
@@ -70,10 +70,10 @@ class LayoutNode( Gaffer.Node ) :
 
 IECore.registerRunTimeTyped( LayoutNode )
 
-Gaffer.Metadata.registerValue( LayoutNode, "left*", "nodeGadget:nodulePosition", "left" )
-Gaffer.Metadata.registerValue( LayoutNode, "right*", "nodeGadget:nodulePosition", "right" )
-Gaffer.Metadata.registerValue( LayoutNode, "top*", "nodeGadget:nodulePosition", "top" )
-Gaffer.Metadata.registerValue( LayoutNode, "bottom*", "nodeGadget:nodulePosition", "bottom" )
+Gaffer.Metadata.registerValue( LayoutNode, "left*", "nodeGraphLayout:section", "left" )
+Gaffer.Metadata.registerValue( LayoutNode, "right*", "nodeGraphLayout:section", "right" )
+Gaffer.Metadata.registerValue( LayoutNode, "top*", "nodeGraphLayout:section", "top" )
+Gaffer.Metadata.registerValue( LayoutNode, "bottom*", "nodeGraphLayout:section", "bottom" )
 
 class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 

--- a/python/GafferUITest/StandardNodeGadgetTest.py
+++ b/python/GafferUITest/StandardNodeGadgetTest.py
@@ -128,7 +128,7 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 		g = GafferUI.StandardNodeGadget( n )
 		self.assertEqual( g.noduleTangent( g.nodule( n["op1"] ) ), IECore.V3f( 0, 1, 0 ) )
 
-		Gaffer.Metadata.registerValue( n.typeId(), "op1", "nodeGraphLayout:section", "left" )
+		Gaffer.Metadata.registerValue( n.typeId(), "op1", "noduleLayout:section", "left" )
 
 		g = GafferUI.StandardNodeGadget( n )
 		self.assertEqual( g.noduleTangent( g.nodule( n["op1"] ) ), IECore.V3f( -1, 0, 0 ) )
@@ -176,7 +176,7 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 		g = GafferUI.StandardNodeGadget( n )
 		self.assertEqual( g.noduleTangent( g.nodule( n["op2"] ) ), IECore.V3f( 0, 1, 0 ) )
 
-		Gaffer.Metadata.registerValue( n["op2"], "nodeGraphLayout:section", "left" )
+		Gaffer.Metadata.registerValue( n["op2"], "noduleLayout:section", "left" )
 		self.assertEqual( g.noduleTangent( g.nodule( n["op2"] ) ), IECore.V3f( -1, 0, 0 ) )
 
 	def testRemoveNoduleAfterCreation( self ) :
@@ -279,8 +279,8 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 			g.nodule( n["b"] ).transformedBound().center().x
 		)
 
-		Gaffer.Metadata.registerValue( n["a"], "nodeGraphLayout:index", 1 )
-		Gaffer.Metadata.registerValue( n["b"], "nodeGraphLayout:index", 0 )
+		Gaffer.Metadata.registerValue( n["a"], "noduleLayout:index", 1 )
+		Gaffer.Metadata.registerValue( n["b"], "noduleLayout:index", 0 )
 
 		g.bound()
 		self.assertGreater(

--- a/python/GafferUITest/StandardNodeGadgetTest.py
+++ b/python/GafferUITest/StandardNodeGadgetTest.py
@@ -128,7 +128,7 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 		g = GafferUI.StandardNodeGadget( n )
 		self.assertEqual( g.noduleTangent( g.nodule( n["op1"] ) ), IECore.V3f( 0, 1, 0 ) )
 
-		Gaffer.Metadata.registerValue( n.typeId(), "op1", "nodeGadget:nodulePosition", "left" )
+		Gaffer.Metadata.registerValue( n.typeId(), "op1", "nodeGraphLayout:section", "left" )
 
 		g = GafferUI.StandardNodeGadget( n )
 		self.assertEqual( g.noduleTangent( g.nodule( n["op1"] ) ), IECore.V3f( -1, 0, 0 ) )
@@ -176,7 +176,7 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 		g = GafferUI.StandardNodeGadget( n )
 		self.assertEqual( g.noduleTangent( g.nodule( n["op2"] ) ), IECore.V3f( 0, 1, 0 ) )
 
-		Gaffer.Metadata.registerValue( n["op2"], "nodeGadget:nodulePosition", "left" )
+		Gaffer.Metadata.registerValue( n["op2"], "nodeGraphLayout:section", "left" )
 		self.assertEqual( g.noduleTangent( g.nodule( n["op2"] ) ), IECore.V3f( -1, 0, 0 ) )
 
 	def testRemoveNoduleAfterCreation( self ) :
@@ -279,8 +279,8 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 			g.nodule( n["b"] ).transformedBound().center().x
 		)
 
-		Gaffer.Metadata.registerValue( n["a"], "nodeGadget:noduleIndex", 1 )
-		Gaffer.Metadata.registerValue( n["b"], "nodeGadget:noduleIndex", 0 )
+		Gaffer.Metadata.registerValue( n["a"], "nodeGraphLayout:index", 1 )
+		Gaffer.Metadata.registerValue( n["b"], "nodeGraphLayout:index", 0 )
 
 		g.bound()
 		self.assertGreater(

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -109,6 +109,7 @@ from MenuBarTest import MenuBarTest
 from GadgetWidgetTest import GadgetWidgetTest
 from CompoundNoduleTest import CompoundNoduleTest
 from SwitchNodeGadgetTest import SwitchNodeGadgetTest
+from NoduleLayoutTest import NoduleLayoutTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/Dot.cpp
+++ b/src/Gaffer/Dot.cpp
@@ -45,7 +45,7 @@ IE_CORE_DEFINERUNTIMETYPED( Dot );
 
 static InternedString g_inPlugName( "in" );
 static InternedString g_outPlugName( "out" );
-static InternedString g_nodulePositionName( "nodeGadget:nodulePosition" );
+static InternedString g_sectionName( "nodeGraphLayout:section" );
 
 size_t Dot::g_firstPlugIndex = 0;
 
@@ -80,43 +80,43 @@ void Dot::setup( const Plug *plug )
 	// than later because the NodeGraph will add a Nodule for the plug as soon as the plug
 	// is added as a child.
 
-	ConstStringDataPtr nodulePosition;
+	ConstStringDataPtr sectionData;
 	for( const Plug *metadataPlug = plug; metadataPlug; metadataPlug = metadataPlug->parent<Plug>() )
 	{
-		if( ( nodulePosition = Metadata::value<StringData>( metadataPlug, g_nodulePositionName ) ) )
+		if( ( sectionData = Metadata::value<StringData>( metadataPlug, g_sectionName ) ) )
 		{
 			break;
 		}
 	}
 
-	if( nodulePosition )
+	if( sectionData )
 	{
-		const std::string &position = nodulePosition->readable();
-		std::string oppositePosition;
-		if( position == "left" )
+		const std::string &section = sectionData->readable();
+		std::string oppositeSection;
+		if( section == "left" )
 		{
-			oppositePosition = "right";
+			oppositeSection = "right";
 		}
-		else if( position == "right" )
+		else if( section == "right" )
 		{
-			oppositePosition = "left";
+			oppositeSection = "left";
 		}
-		else if( position == "bottom" )
+		else if( section == "bottom" )
 		{
-			oppositePosition = "top";
+			oppositeSection = "top";
 		}
 		else
 		{
-			oppositePosition = "bottom";
+			oppositeSection = "bottom";
 		}
 
 		Metadata::registerValue(
 			plug->direction() == Plug::In ? in.get() : out.get(),
-			g_nodulePositionName, nodulePosition
+			g_sectionName, sectionData
 		);
 		Metadata::registerValue(
 			plug->direction() == Plug::In ? out.get() : in.get(),
-			g_nodulePositionName, new StringData( oppositePosition )
+			g_sectionName, new StringData( oppositeSection )
 		);
 	}
 

--- a/src/Gaffer/Dot.cpp
+++ b/src/Gaffer/Dot.cpp
@@ -45,7 +45,7 @@ IE_CORE_DEFINERUNTIMETYPED( Dot );
 
 static InternedString g_inPlugName( "in" );
 static InternedString g_outPlugName( "out" );
-static InternedString g_sectionName( "nodeGraphLayout:section" );
+static InternedString g_sectionName( "noduleLayout:section" );
 
 size_t Dot::g_firstPlugIndex = 0;
 

--- a/src/Gaffer/MetadataAlgo.cpp
+++ b/src/Gaffer/MetadataAlgo.cpp
@@ -167,6 +167,16 @@ bool ancestorAffectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeI
 	return false;
 }
 
+bool affectedByChange( const Node *node, IECore::TypeId changedNodeTypeId, const Gaffer::Node *changedNode )
+{
+	if( changedNode )
+	{
+		return node == changedNode;
+	}
+
+	return node->isInstanceOf( changedNodeTypeId );
+}
+
 } // namespace MetadataAlgo
 
 } // namespace Gaffer

--- a/src/GafferBindings/MetadataAlgoBinding.cpp
+++ b/src/GafferBindings/MetadataAlgoBinding.cpp
@@ -39,8 +39,10 @@
 #include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/GraphComponent.h"
 #include "Gaffer/Plug.h"
+#include "Gaffer/Node.h"
 
 using namespace boost::python;
+using namespace Gaffer;
 using namespace Gaffer::MetadataAlgo;
 
 namespace GafferBindings
@@ -55,7 +57,16 @@ void bindMetadataAlgo()
 	def( "setReadOnly", &setReadOnly, ( arg( "graphComponent" ), arg( "readOnly"), arg( "persistent" ) = true ) );
 	def( "getReadOnly", &getReadOnly );
 	def( "readOnly", &readOnly );
-	def( "affectedByChange", &affectedByChange, ( arg( "plug" ), arg( "changedNodeTypeId"), arg( "changedPlugPath" ), arg( "changedPlug" ) ) );
+	def(
+		"affectedByChange",
+		(bool (*)( const Plug *, IECore::TypeId, const MatchPattern &, const Plug * ))&affectedByChange,
+		( arg( "plug" ), arg( "changedNodeTypeId"), arg( "changedPlugPath" ), arg( "changedPlug" ) )
+	);
+	def(
+		"affectedByChange",
+		(bool (*)( const Node *node, IECore::TypeId changedNodeTypeId, const Node *changedNode ))&affectedByChange,
+		( arg( "node" ), arg( "changedNodeTypeId"), arg( "changedNode" ) )
+	);
 	def( "childAffectedByChange", &childAffectedByChange, ( arg( "parent" ), arg( "changedNodeTypeId"), arg( "changedPlugPath" ), arg( "changedPlug" ) ) );
 	def( "ancestorAffectedByChange", &ancestorAffectedByChange, ( arg( "plug" ), arg( "changedNodeTypeId"), arg( "changedPlugPath" ), arg( "changedPlug" ) ) );
 

--- a/src/GafferSceneUI/ShaderNodeGadget.cpp
+++ b/src/GafferSceneUI/ShaderNodeGadget.cpp
@@ -61,7 +61,7 @@ using namespace GafferSceneUI::Private;
 namespace
 {
 
-IECore::InternedString g_visibleKey( "nodeGraphLayout:visible" );
+IECore::InternedString g_visibleKey( "noduleLayout:visible" );
 IECore::InternedString g_noduleTypeKey( "nodule:type" );
 
 class ShaderPlugAdder : public PlugAdder

--- a/src/GafferSceneUI/ShaderNodeGadget.cpp
+++ b/src/GafferSceneUI/ShaderNodeGadget.cpp
@@ -1,0 +1,213 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/bind.hpp"
+
+#include "Gaffer/UndoContext.h"
+#include "Gaffer/ScriptNode.h"
+#include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
+
+#include "GafferUI/Nodule.h"
+#include "GafferUI/PlugAdder.h"
+
+#include "GafferScene/Shader.h"
+
+#include "GafferSceneUI/Private/ShaderNodeGadget.h"
+
+using namespace std;
+using namespace Gaffer;
+using namespace GafferUI;
+using namespace GafferScene;
+using namespace GafferSceneUI::Private;
+
+//////////////////////////////////////////////////////////////////////////
+// ShaderPlugAdder
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+IECore::InternedString g_visibleKey( "nodeGraphLayout:visible" );
+IECore::InternedString g_noduleTypeKey( "nodule:type" );
+
+class ShaderPlugAdder : public PlugAdder
+{
+
+	public :
+
+		ShaderPlugAdder( ShaderPtr shader, StandardNodeGadget::Edge edge )
+			: PlugAdder( edge ), m_shader( shader )
+		{
+			shader->parametersPlug()->childAddedSignal().connect( boost::bind( &ShaderPlugAdder::childAdded, this ) );
+			shader->parametersPlug()->childRemovedSignal().connect( boost::bind( &ShaderPlugAdder::childRemoved, this ) );
+			Metadata::plugValueChangedSignal().connect( boost::bind( &ShaderPlugAdder::plugMetadataChanged, this, ::_1, ::_2, ::_3, ::_4 ) );
+
+			buttonReleaseSignal().connect( boost::bind( &ShaderPlugAdder::buttonRelease, this, ::_2 ) );
+
+			updateVisibility();
+		}
+
+	protected :
+
+		bool acceptsPlug( const Plug *plug ) const
+		{
+			vector<Plug *> plugs = showablePlugs( plug );
+			return !plugs.empty();
+		}
+
+		void addPlug( Plug *connectionEndPoint )
+		{
+			vector<Plug *> plugs = showablePlugs( connectionEndPoint );
+			Plug *plug = plugMenuSignal()( "Connect To", plugs );
+			if( !plug )
+			{
+				return;
+			}
+
+			UndoContext undoContext( m_shader->scriptNode() );
+
+			Metadata::registerValue( plug, g_visibleKey, new IECore::BoolData( true ) );
+			plug->setInput( connectionEndPoint );
+		}
+
+	private :
+
+		bool buttonRelease( const ButtonEvent &event )
+		{
+			vector<Plug *> plugs = showablePlugs();
+			Plug *plug = plugMenuSignal()( "Show Parameter", plugs );
+			if( !plug )
+			{
+				return false;
+			}
+
+			UndoContext undoContext( m_shader->scriptNode() );
+			Metadata::registerValue( plug, g_visibleKey, new IECore::BoolData( true ) );
+			return true;
+		}
+
+		vector<Plug *> showablePlugs( const Plug *input = NULL ) const
+		{
+			vector<Plug *> result;
+
+			for( PlugIterator it( m_shader->parametersPlug() ); !it.done(); ++it )
+			{
+				Plug *plug = it->get();
+				if( !plug->getFlags( Plug::AcceptsInputs ) )
+				{
+					continue;
+				}
+				if( input && !plug->acceptsInput( input ) )
+				{
+					continue;
+				}
+				if( IECore::ConstStringDataPtr noduleType = Metadata::value<IECore::StringData>( plug, g_noduleTypeKey ) )
+				{
+					if( noduleType->readable() == "" )
+					{
+						continue;
+					}
+				}
+				IECore::ConstBoolDataPtr visible = Metadata::value<IECore::BoolData>( plug, g_visibleKey );
+				if( !visible || visible->readable() )
+				{
+					continue;
+				}
+				if( readOnly( plug ) )
+				{
+					continue;
+				}
+				result.push_back( it->get() );
+			}
+
+			return result;
+		}
+
+		void updateVisibility()
+		{
+			setVisible( !showablePlugs().empty() );
+		}
+
+		void childAdded()
+		{
+			updateVisibility();
+		}
+
+		void childRemoved()
+		{
+			updateVisibility();
+		}
+
+		void plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
+		{
+			if( childAffectedByChange( m_shader->parametersPlug(), nodeTypeId, plugPath, plug ) )
+			{
+				if( key == g_visibleKey || key == g_noduleTypeKey )
+				{
+					updateVisibility();
+				}
+			}
+		}
+
+		ShaderPtr m_shader;
+
+};
+
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// ShaderNodeGadget
+//////////////////////////////////////////////////////////////////////////
+
+StandardNodeGadget::NodeGadgetTypeDescription<ShaderNodeGadget> ShaderNodeGadget::g_nodeGadgetTypeDescription( Shader::staticTypeId() );
+
+ShaderNodeGadget::ShaderNodeGadget( Gaffer::NodePtr node )
+	:	StandardNodeGadget( node )
+{
+	ShaderPtr shader = IECore::runTimeCast<Shader>( node );
+	if( !shader )
+	{
+		throw IECore::Exception( "ShaderNodeGadget requires a Shader" );
+	}
+
+	setEdgeGadget( LeftEdge, new ShaderPlugAdder( shader, LeftEdge ) );
+}
+
+ShaderNodeGadget::~ShaderNodeGadget()
+{
+}

--- a/src/GafferSceneUIBindings/ShaderNodeGadgetBinding.cpp
+++ b/src/GafferSceneUIBindings/ShaderNodeGadgetBinding.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,24 +34,17 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERSCENEUI_TYPEIDS_H
-#define GAFFERSCENEUI_TYPEIDS_H
+#include "boost/python.hpp"
 
-namespace GafferSceneUI
+#include "GafferSceneUI/Private/ShaderNodeGadget.h"
+#include "GafferSceneUIBindings/ShaderNodeGadgetBinding.h"
+
+using namespace boost::python;
+using namespace GafferUI;
+using namespace GafferSceneUI::Private;
+
+void GafferSceneUIBindings::bindShaderNodeGadget()
 {
-
-enum TypeId
-{
-	SceneViewTypeId = 110651,
-	SceneGadgetTypeId = 110652,
-	SelectionToolTypeId = 110653,
-	CropWindowToolTypeId = 110654,
-	ShaderViewTypeId = 110655,
-	ShaderNodeGadgetTypeId = 110656,
-
-	LastTypeId = 110700
-};
-
-} // namespace GafferSceneUI
-
-#endif // GAFFERSCENEUI_TYPEIDS_H
+	// See comments in StandardNodeGadgetBinding.
+	objects::copy_class_object( type_id<StandardNodeGadget>(), type_id<ShaderNodeGadget>() );
+}

--- a/src/GafferSceneUIModule/GafferSceneUIModule.cpp
+++ b/src/GafferSceneUIModule/GafferSceneUIModule.cpp
@@ -50,6 +50,7 @@
 #include "GafferSceneUIBindings/StandardLightVisualiserBinding.h"
 #include "GafferSceneUIBindings/SceneHierarchyBinding.h"
 #include "GafferSceneUIBindings/ShaderViewBinding.h"
+#include "GafferSceneUIBindings/ShaderNodeGadgetBinding.h"
 
 using namespace boost::python;
 using namespace IECorePython;
@@ -102,5 +103,6 @@ BOOST_PYTHON_MODULE( _GafferSceneUI )
 	bindLightVisualiser();
 	bindStandardLightVisualiser();
 	bindSceneHierarchy();
+	bindShaderNodeGadget();
 
 }

--- a/src/GafferUI/CompoundNodule.cpp
+++ b/src/GafferUI/CompoundNodule.cpp
@@ -35,78 +35,16 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/bind.hpp"
-#include "boost/bind/placeholders.hpp"
-
-#include "IECore/SimpleTypedData.h"
-
 #include "Gaffer/Plug.h"
-#include "Gaffer/MetadataAlgo.h"
 
+#include "GafferUI/NoduleLayout.h"
 #include "GafferUI/CompoundNodule.h"
-#include "GafferUI/LinearContainer.h"
 
 using namespace std;
 using namespace Imath;
 using namespace IECore;
 using namespace Gaffer;
 using namespace GafferUI;
-
-//////////////////////////////////////////////////////////////////////////
-// Internal utilities
-//////////////////////////////////////////////////////////////////////////
-
-namespace
-{
-
-IECore::InternedString g_orientationKey( "compoundNodule:orientation"  );
-IECore::InternedString g_spacingKey( "compoundNodule:spacing"  );
-IECore::InternedString g_directionKey( "compoundNodule:direction"  );
-
-LinearContainer::Orientation orientationMetadata( const Plug *plug, LinearContainer::Orientation defaultValue )
-{
-	ConstStringDataPtr orientationData = Metadata::value<StringData>( plug, g_orientationKey );
-	if( !orientationData )
-	{
-		return defaultValue;
-	}
-
-	if( orientationData->readable() == "x" )
-	{
-		return LinearContainer::X;
-	}
-	else if( orientationData->readable() == "y" )
-	{
-		return LinearContainer::Y;
-	}
-	else
-	{
-		return LinearContainer::Z;
-	}
-}
-
-float spacingMetadata( const Plug *plug, float defaultValue )
-{
-	ConstFloatDataPtr spacingData = Metadata::value<FloatData>( plug, g_spacingKey );
-	return spacingData ? spacingData->readable() : defaultValue;
-}
-
-LinearContainer::Direction directionMetadata( const Plug *plug, LinearContainer::Direction defaultValue )
-{
-	ConstStringDataPtr directionData = Metadata::value<StringData>( plug, g_directionKey );
-	if( !directionData )
-	{
-		return defaultValue;
-	}
-
-	return directionData->readable() == "increasing" ? LinearContainer::Increasing : LinearContainer::Decreasing;
-}
-
-} // namespace
-
-//////////////////////////////////////////////////////////////////////////
-// CompoundNodule
-//////////////////////////////////////////////////////////////////////////
 
 IE_CORE_DEFINERUNTIMETYPED( CompoundNodule );
 
@@ -116,45 +54,11 @@ CompoundNodule::CompoundNodule( Gaffer::PlugPtr plug, LinearContainer::Orientati
 	float spacing, LinearContainer::Direction direction )
 	:	Nodule( plug )
 {
-	orientation = orientationMetadata( plug.get(), orientation );
-	spacing = spacingMetadata( plug.get(), spacing );
-	direction = directionMetadata( plug.get(), direction );
-
-	if( direction == LinearContainer::InvalidDirection )
-	{
-		direction = orientation == LinearContainer::X ? LinearContainer::Increasing : LinearContainer::Decreasing;
-	}
-
-	m_row = new LinearContainer( "row", orientation, LinearContainer::Centre, spacing, direction );
-	addChild( m_row );
-
-	for( Gaffer::PlugIterator it( plug.get() ); !it.done(); ++it )
-	{
-		NodulePtr nodule = Nodule::create( *it );
-		if( nodule )
-		{
-			m_row->addChild( nodule );
-		}
-	}
-
-	plug->childAddedSignal().connect( boost::bind( &CompoundNodule::childAdded, this, ::_1,  ::_2 ) );
-	plug->childRemovedSignal().connect( boost::bind( &CompoundNodule::childRemoved, this, ::_1,  ::_2 ) );
-
-	Metadata::plugValueChangedSignal().connect( boost::bind( &CompoundNodule::plugMetadataChanged, this, ::_1, ::_2, ::_3, ::_4 ) );
+	addChild( new NoduleLayout( plug ) );
 }
 
 CompoundNodule::~CompoundNodule()
 {
-}
-
-Imath::Box3f CompoundNodule::bound() const
-{
-	return m_row->bound();
-}
-
-void CompoundNodule::doRender( const Style *style ) const
-{
-	m_row->render( style );
 }
 
 bool CompoundNodule::acceptsChild( const Gaffer::GraphComponent *potentialChild ) const
@@ -164,83 +68,20 @@ bool CompoundNodule::acceptsChild( const Gaffer::GraphComponent *potentialChild 
 
 Nodule *CompoundNodule::nodule( const Gaffer::Plug *plug )
 {
-	for( NoduleIterator it( m_row.get() ); !it.done(); ++it )
-	{
-		if( (*it)->plug() == plug )
-		{
-			return it->get();
-		}
-	}
-	return 0;
+	return noduleLayout()->nodule( plug );
 }
 
 const Nodule *CompoundNodule::nodule( const Gaffer::Plug *plug ) const
 {
-	// preferring the nasty casts over mainaining two nearly identical implementations
-	return const_cast<CompoundNodule *>( this )->nodule( plug );
+	return noduleLayout()->nodule( plug );
 }
 
-void CompoundNodule::childAdded( Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child )
+NoduleLayout *CompoundNodule::noduleLayout()
 {
-	Gaffer::Plug *plug = IECore::runTimeCast<Gaffer::Plug>( child );
-	if( !plug )
-	{
-		return;
-	}
-
-	if( nodule( plug ) )
-	{
-		return;
-	}
-
-	NodulePtr nodule = Nodule::create( plug );
-	if( nodule )
-	{
-		m_row->addChild( nodule );
-	}
+	return getChild<NoduleLayout>( 0 );
 }
 
-void CompoundNodule::childRemoved( Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child )
+const NoduleLayout *CompoundNodule::noduleLayout() const
 {
-	Gaffer::Plug *plug = IECore::runTimeCast<Gaffer::Plug>( child );
-	if( !plug )
-	{
-		return;
-	}
-
-	for( NoduleIterator it( m_row.get() ); !it.done(); ++it )
-	{
-		if( (*it)->plug() == plug )
-		{
-			m_row->removeChild( *it );
-			break;
-		}
-	}
-}
-
-void CompoundNodule::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
-{
-	if( !MetadataAlgo::affectedByChange( this->plug(), nodeTypeId, plugPath, plug ) )
-	{
-		return;
-	}
-
-	if( key == g_orientationKey )
-	{
-		m_row->setOrientation( orientationMetadata( this->plug(), LinearContainer::X ) );
-	}
-	else if( key == g_spacingKey )
-	{
-		m_row->setSpacing( spacingMetadata( this->plug(), 0 ) );
-	}
-
-	if( key == g_directionKey || key == g_orientationKey )
-	{
-		m_row->setDirection(
-			directionMetadata(
-				this->plug(),
-				m_row->getOrientation() == LinearContainer::X ? LinearContainer::Increasing : LinearContainer::Decreasing
-			)
-		);
-	}
+	return getChild<NoduleLayout>( 0 );
 }

--- a/src/GafferUI/NoduleLayout.cpp
+++ b/src/GafferUI/NoduleLayout.cpp
@@ -100,6 +100,8 @@ IECore::InternedString g_top( "top" );
 IECore::InternedString g_indexKey( "nodeGraphLayout:index" );
 IECore::InternedString g_sectionKey( "nodeGraphLayout:section" );
 IECore::InternedString g_visibleKey( "nodeGraphLayout:visible" );
+IECore::InternedString g_spacingKey( "nodeGraphLayout:spacing" );
+IECore::InternedString g_directionKey( "nodeGraphLayout:direction" );
 IECore::InternedString g_noduleTypeKey( "nodule:type" );
 
 // Deprecated metadata keys
@@ -125,7 +127,7 @@ float spacing( const Gaffer::GraphComponent *parent, IECore::InternedString sect
 	}
 	else
 	{
-		f = Metadata::value<FloatData>( parent, "nodeGraphLayout:spacing" );
+		f = Metadata::value<FloatData>( parent, g_spacingKey );
 	}
 
 	if( !f )
@@ -159,7 +161,7 @@ bool affectsSpacing( IECore::InternedString key, IECore::InternedString section 
 	}
 	else
 	{
-		if( key == "nodeGraphLayout:spacing" )
+		if( key == g_spacingKey )
 		{
 			return true;
 		}
@@ -244,7 +246,7 @@ LinearContainer::Direction direction( const Gaffer::GraphComponent *parent, IECo
 	}
 	else
 	{
-		d = Metadata::value<StringData>( parent, "nodeGraphLayout:direction" );
+		d = Metadata::value<StringData>( parent, g_directionKey );
 	}
 
 	if( !d && section == "" )

--- a/src/GafferUI/NoduleLayout.cpp
+++ b/src/GafferUI/NoduleLayout.cpp
@@ -97,11 +97,11 @@ IECore::InternedString g_top( "top" );
 
 // Metadata keys
 
-IECore::InternedString g_indexKey( "nodeGraphLayout:index" );
-IECore::InternedString g_sectionKey( "nodeGraphLayout:section" );
-IECore::InternedString g_visibleKey( "nodeGraphLayout:visible" );
-IECore::InternedString g_spacingKey( "nodeGraphLayout:spacing" );
-IECore::InternedString g_directionKey( "nodeGraphLayout:direction" );
+IECore::InternedString g_indexKey( "noduleLayout:index" );
+IECore::InternedString g_sectionKey( "noduleLayout:section" );
+IECore::InternedString g_visibleKey( "noduleLayout:visible" );
+IECore::InternedString g_spacingKey( "noduleLayout:spacing" );
+IECore::InternedString g_directionKey( "noduleLayout:direction" );
 IECore::InternedString g_noduleTypeKey( "nodule:type" );
 
 // Deprecated metadata keys
@@ -123,7 +123,7 @@ float spacing( const Gaffer::GraphComponent *parent, IECore::InternedString sect
 	ConstFloatDataPtr f;
 	if( section != "" )
 	{
-		f = Metadata::value<FloatData>( parent, "nodeGraphLayout:section:" + section.string() + ":spacing" );
+		f = Metadata::value<FloatData>( parent, "noduleLayout:section:" + section.string() + ":spacing" );
 	}
 	else
 	{
@@ -170,7 +170,7 @@ bool affectsSpacing( IECore::InternedString key, IECore::InternedString section 
 {
 	if( section != "" )
 	{
-		if( key == "nodeGraphLayout:section:" + section.string() + ":spacing" )
+		if( key == "noduleLayout:section:" + section.string() + ":spacing" )
 		{
 			return true;
 		}
@@ -258,7 +258,7 @@ LinearContainer::Direction direction( const Gaffer::GraphComponent *parent, IECo
 	ConstStringDataPtr d;
 	if( section != "" )
 	{
-		d = Metadata::value<StringData>( parent, "nodeGraphLayout:section:" + section.string() + ":direction" );
+		d = Metadata::value<StringData>( parent, "noduleLayout:section:" + section.string() + ":direction" );
 	}
 	else
 	{
@@ -297,7 +297,7 @@ LinearContainer::Direction direction( const Gaffer::GraphComponent *parent, IECo
 
 bool affectsDirection( IECore::InternedString key, IECore::InternedString section )
 {
-	if( key == "nodeGraphLayout:section:" + section.string() + ":direction" )
+	if( key == "noduleLayout:section:" + section.string() + ":direction" )
 	{
 		return true;
 	}

--- a/src/GafferUI/NoduleLayout.cpp
+++ b/src/GafferUI/NoduleLayout.cpp
@@ -147,7 +147,23 @@ float spacing( const Gaffer::GraphComponent *parent, IECore::InternedString sect
 			f = Metadata::value<FloatData>( parent, g_compoundNoduleSpacingKey );
 		}
 	}
-	return f ? f->readable() : 0.0f;
+
+	if( f )
+	{
+		return f->readable();
+	}
+	else if( section == g_left || section == g_right )
+	{
+		return 0.2f;
+	}
+	else if( section == g_top || section == g_bottom )
+	{
+		return 2.0f;
+	}
+	else
+	{
+		return 0.0f;
+	}
 }
 
 bool affectsSpacing( IECore::InternedString key, IECore::InternedString section )

--- a/src/GafferUI/NoduleLayout.cpp
+++ b/src/GafferUI/NoduleLayout.cpp
@@ -1,0 +1,590 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2011-2012, John Haddon. All rights reserved.
+//  Copyright (c) 2011-2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/bind.hpp"
+#include "boost/algorithm/string/predicate.hpp"
+
+#include "IECore/SimpleTypedData.h"
+
+#include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
+#include "Gaffer/Plug.h"
+#include "Gaffer/Node.h"
+
+#include "GafferUI/Nodule.h"
+#include "GafferUI/LinearContainer.h"
+#include "GafferUI/CompoundNodule.h"
+#include "GafferUI/NoduleLayout.h"
+#include "GafferUI/NodeGadget.h"
+
+using namespace std;
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferUI;
+
+//////////////////////////////////////////////////////////////////////////
+// Utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+// Used for sorting nodules for layout
+
+struct IndexAndNodule
+{
+
+	IndexAndNodule()
+		:	index( 0 ), nodule( NULL )
+	{
+	}
+
+	IndexAndNodule( int index, Nodule *nodule )
+		:	index( index ), nodule( nodule )
+	{
+	}
+
+	bool operator < ( const IndexAndNodule &rhs ) const
+	{
+		return index < rhs.index;
+	}
+
+	int index;
+	Nodule *nodule;
+
+};
+
+// Section names
+
+IECore::InternedString g_left( "left" );
+IECore::InternedString g_right( "right" );
+IECore::InternedString g_bottom( "bottom" );
+IECore::InternedString g_top( "top" );
+
+// Metadata keys
+
+IECore::InternedString g_indexKey( "nodeGraphLayout:index" );
+IECore::InternedString g_sectionKey( "nodeGraphLayout:section" );
+IECore::InternedString g_visibleKey( "nodeGraphLayout:visible" );
+IECore::InternedString g_noduleTypeKey( "nodule:type" );
+
+// Deprecated metadata keys
+/// \todo Remove support for these
+
+IECore::InternedString g_horizontalNoduleSpacingKey( "nodeGadget:horizontalNoduleSpacing"  );
+IECore::InternedString g_verticalNoduleSpacingKey( "nodeGadget:verticalNoduleSpacing"  );
+IECore::InternedString g_nodulePositionKey( "nodeGadget:nodulePosition" );
+IECore::InternedString g_noduleIndexKey( "nodeGadget:noduleIndex" );
+
+IECore::InternedString g_compoundNoduleSpacingKey( "compoundNodule:spacing"  );
+IECore::InternedString g_compoundNoduleOrientationKey( "compoundNodule:orientation"  );
+IECore::InternedString g_compoundNoduleDirectionKey( "compoundNodule:direction"  );
+
+// Metadata accessors
+
+float spacing( const Gaffer::GraphComponent *parent, IECore::InternedString section )
+{
+	ConstFloatDataPtr f;
+	if( section != "" )
+	{
+		f = Metadata::value<FloatData>( parent, "nodeGraphLayout:section:" + section.string() + ":spacing" );
+	}
+	else
+	{
+		f = Metadata::value<FloatData>( parent, "nodeGraphLayout:spacing" );
+	}
+
+	if( !f )
+	{
+		// Backwards compatibility with old StandardNodeGadget and
+		// CompoundNodule metadata.
+		if( section == g_left || section == g_right )
+		{
+			f = Metadata::value<FloatData>( parent, g_verticalNoduleSpacingKey );
+		}
+		else if( section == g_top || section == g_bottom )
+		{
+			f = Metadata::value<FloatData>( parent, g_horizontalNoduleSpacingKey );
+		}
+		else
+		{
+			f = Metadata::value<FloatData>( parent, g_compoundNoduleSpacingKey );
+		}
+	}
+	return f ? f->readable() : 0.0f;
+}
+
+bool affectsSpacing( IECore::InternedString key, IECore::InternedString section )
+{
+	if( section != "" )
+	{
+		if( key == "nodeGraphLayout:section:" + section.string() + ":spacing" )
+		{
+			return true;
+		}
+	}
+	else
+	{
+		if( key == "nodeGraphLayout:spacing" )
+		{
+			return true;
+		}
+	}
+
+	if( section == g_left || section == g_right )
+	{
+		return key == g_verticalNoduleSpacingKey;
+	}
+	else if( section == g_top || section == g_bottom )
+	{
+		return key == g_horizontalNoduleSpacingKey;
+	}
+	else
+	{
+		return key == g_compoundNoduleSpacingKey;
+	}
+}
+
+int index( const Plug *plug, int defaultValue )
+{
+	ConstIntDataPtr i = Metadata::value<IntData>( plug, g_indexKey );
+	if( !i )
+	{
+		i = Metadata::value<IntData>( plug, g_noduleIndexKey );
+	}
+	return i ? i->readable() : defaultValue;
+}
+
+std::string section( const Plug *plug )
+{
+	ConstStringDataPtr s = Metadata::value<StringData>( plug, g_sectionKey );
+	if( !s )
+	{
+		s = Metadata::value<StringData>( plug, g_nodulePositionKey );
+	}
+
+	if( s )
+	{
+		return s->readable();
+	}
+
+	return plug->direction() == Plug::In ? "top" : "bottom";
+}
+
+LinearContainer::Orientation orientation( const Gaffer::GraphComponent *parent, IECore::InternedString section )
+{
+	if( section == "" )
+	{
+		if( const Plug *parentPlug = runTimeCast<const Plug>( parent ) )
+		{
+			if( ConstStringDataPtr s = Metadata::value<StringData>( parentPlug, g_compoundNoduleOrientationKey ) )
+			{
+				// Backwards compatibility with old CompoundNodule metadata.
+				return s->readable() == "x" ? LinearContainer::X : LinearContainer::Y;
+			}
+			section = ::section( parentPlug );
+		}
+	}
+
+	if( section == g_left || section == g_right )
+	{
+		return LinearContainer::Y;
+	}
+	else
+	{
+		return LinearContainer::X;
+	}
+}
+
+bool affectsOrientation( IECore::InternedString key, IECore::InternedString section )
+{
+	return section == "" && key == g_compoundNoduleOrientationKey;
+}
+
+LinearContainer::Direction direction( const Gaffer::GraphComponent *parent, IECore::InternedString section )
+{
+	ConstStringDataPtr d;
+	if( section != "" )
+	{
+		d = Metadata::value<StringData>( parent, "nodeGraphLayout:section:" + section.string() + ":direction" );
+	}
+	else
+	{
+		d = Metadata::value<StringData>( parent, "nodeGraphLayout:direction" );
+	}
+
+	if( !d && section == "" )
+	{
+		// Backwards compatibility with old
+		// CompoundNodule metadata.
+		d = Metadata::value<StringData>( parent, g_compoundNoduleSpacingKey );
+	}
+
+	if( d )
+	{
+		return d->readable() == "increasing" ? LinearContainer::Increasing : LinearContainer::Decreasing;
+	}
+
+	if( section == "" )
+	{
+		if( const Plug *parentPlug = runTimeCast<const Plug>( parent ) )
+		{
+			section = ::section( parentPlug );
+		}
+	}
+
+	if( section == g_left || section == g_right )
+	{
+		return LinearContainer::Decreasing;
+	}
+	else
+	{
+		return LinearContainer::Increasing;
+	}
+}
+
+bool affectsDirection( IECore::InternedString key, IECore::InternedString section )
+{
+	if( key == "nodeGraphLayout:section:" + section.string() + ":direction" )
+	{
+		return true;
+	}
+	if( section == "" && key == g_compoundNoduleDirectionKey )
+	{
+		return true;
+	}
+	return false;
+}
+
+bool visible( const Plug *plug, IECore::InternedString section )
+{
+	if( section != InternedString() && ::section( plug ) != section.string() )
+	{
+		return false;
+	}
+
+	if( ConstBoolDataPtr b = Metadata::value<BoolData>( plug, g_visibleKey ) )
+	{
+		return b->readable();
+	}
+
+	return true;
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// NoduleLayout implementation
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( NoduleLayout );
+
+NoduleLayout::NoduleLayout( Gaffer::GraphComponentPtr parent, IECore::InternedString section )
+	:	Gadget(), m_parent( parent ), m_section( section )
+{
+	LinearContainerPtr noduleContainer = new LinearContainer(
+		"__noduleContainer",
+		orientation( m_parent.get(), m_section ),
+		LinearContainer::Centre,
+		spacing( m_parent.get(), m_section ),
+		direction( m_parent.get(), m_section )
+	);
+
+	addChild( noduleContainer );
+
+	m_parent->childAddedSignal().connect( boost::bind( &NoduleLayout::childAdded, this, ::_2 ) );
+	m_parent->childRemovedSignal().connect( boost::bind( &NoduleLayout::childRemoved, this, ::_2 ) );
+
+	Metadata::plugValueChangedSignal().connect( boost::bind( &NoduleLayout::plugMetadataChanged, this, ::_1, ::_2, ::_3, ::_4 ) );
+	Metadata::nodeValueChangedSignal().connect( boost::bind( &NoduleLayout::nodeMetadataChanged, this, ::_1, ::_2, ::_3 ) );
+
+	updateNoduleLayout();
+}
+
+NoduleLayout::~NoduleLayout()
+{
+}
+
+Nodule *NoduleLayout::nodule( const Gaffer::Plug *plug )
+{
+	const GraphComponent *plugParent = plug->parent<GraphComponent>();
+	if( !plugParent )
+	{
+		return NULL;
+	}
+
+	if( plugParent == m_parent.get() )
+	{
+		NoduleMap::iterator it = m_nodules.find( plug );
+		if( it != m_nodules.end() )
+		{
+			return it->second.nodule.get();
+		}
+		return NULL;
+	}
+	else if( const Plug *parentPlug = IECore::runTimeCast<const Plug>( plugParent ) )
+	{
+		CompoundNodule *compoundNodule = IECore::runTimeCast<CompoundNodule>( nodule( parentPlug ) );
+		if( compoundNodule )
+		{
+			return compoundNodule->nodule( plug );
+		}
+	}
+	return NULL;
+}
+
+const Nodule *NoduleLayout::nodule( const Gaffer::Plug *plug ) const
+{
+	// naughty cast is better than repeating the above logic.
+	return const_cast<NoduleLayout *>( this )->nodule( plug );
+}
+
+LinearContainer *NoduleLayout::noduleContainer()
+{
+	return getChild<LinearContainer>( 0 );
+}
+
+const LinearContainer *NoduleLayout::noduleContainer() const
+{
+	return getChild<LinearContainer>( 0 );
+}
+
+void NoduleLayout::childAdded( Gaffer::GraphComponent *child )
+{
+	if( IECore::runTimeCast<Gaffer::Plug>( child ) )
+	{
+		updateNoduleLayout();
+	}
+}
+
+void NoduleLayout::childRemoved( Gaffer::GraphComponent *child )
+{
+	if( IECore::runTimeCast<Gaffer::Plug>( child ) )
+	{
+		updateNoduleLayout();
+	}
+}
+
+void NoduleLayout::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
+{
+	if( childAffectedByChange( m_parent.get(), nodeTypeId, plugPath, plug ) )
+	{
+		if(
+			key == g_sectionKey || key == g_indexKey || key == g_visibleKey ||
+			key == g_noduleTypeKey ||
+			key == g_nodulePositionKey || key == g_noduleIndexKey
+		)
+		{
+			updateNoduleLayout();
+		}
+	}
+
+	if( const Plug *typedParent = runTimeCast<const Plug>( m_parent.get() ) )
+	{
+		if( affectedByChange( typedParent, nodeTypeId, plugPath, plug ) )
+		{
+			if( affectsSpacing( key, m_section ) )
+			{
+				updateSpacing();
+			}
+			if( affectsDirection( key, m_section ) )
+			{
+				updateDirection();
+			}
+			if( affectsOrientation( key, m_section ) )
+			{
+				updateOrientation();
+			}
+		}
+	}
+}
+
+void NoduleLayout::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node )
+{
+	const Node *typedParent = runTimeCast<const Node>( m_parent.get() );
+	if( !typedParent || !affectedByChange( typedParent, nodeTypeId, node ) )
+	{
+		return;
+	}
+
+	if( affectsSpacing( key, m_section ) )
+	{
+		updateSpacing();
+	}
+	if( affectsDirection( key, m_section ) )
+	{
+		updateDirection();
+	}
+	if( affectsOrientation( key, m_section ) )
+	{
+		updateOrientation();
+	}
+}
+
+void NoduleLayout::updateNodules( std::vector<Nodule *> &nodules, std::vector<Nodule *> &added, std::vector<NodulePtr> &removed )
+{
+	// Update the nodules for all our plugs, and build a vector
+	// of IndexAndNodule to sort ready for layout.
+	vector<IndexAndNodule> sortedNodules;
+	for( PlugIterator plugIt( m_parent.get() ); !plugIt.done(); ++plugIt )
+	{
+		Plug *plug = plugIt->get();
+		if( boost::starts_with( plug->getName().string(), "__" ) )
+		{
+			continue;
+		}
+
+		Nodule *nodule = NULL;
+		NoduleMap::iterator it = m_nodules.find( plug );
+
+		if( ::visible( plug, m_section ) )
+		{
+			IECore::InternedString type;
+			IECore::ConstStringDataPtr typeData = Metadata::value<IECore::StringData>( plug, g_noduleTypeKey );
+			type = typeData ? typeData->readable() : "GafferUI::StandardNodule";
+
+			if( it != m_nodules.end() && it->second.type == type )
+			{
+				// Reuse existing nodule
+				nodule = it->second.nodule.get();
+			}
+			else
+			{
+				// Remove old nodule.
+				if( it != m_nodules.end() && it->second.nodule )
+				{
+					removed.push_back( it->second.nodule );
+				}
+				// Add new one
+				NodulePtr n = Nodule::create( plug );
+				m_nodules[plug] = TypeAndNodule( type, n );
+				if( n )
+				{
+					added.push_back( n.get() );
+					nodule = n.get();
+				}
+			}
+		}
+		else if( it != m_nodules.end() )
+		{
+			// Not visible, but we have an old
+			// record for it.
+			if( it->second.nodule )
+			{
+				removed.push_back( it->second.nodule );
+			}
+			m_nodules.erase( it );
+		}
+
+		if( nodule )
+		{
+			sortedNodules.push_back( IndexAndNodule( index( plug, sortedNodules.size() ), nodule ) );
+		}
+	}
+
+	// Remove any nodules for which a plug no longer exists.
+	for( NoduleMap::iterator it = m_nodules.begin(); it != m_nodules.end(); )
+	{
+		NoduleMap::iterator next = it; next++;
+		if( it->first->parent<GraphComponent>() != m_parent.get() )
+		{
+			if( it->second.nodule )
+			{
+				removed.push_back( it->second.nodule );
+			}
+			m_nodules.erase( it );
+		}
+		it = next;
+	}
+
+	// Sort ready for layout.
+	sort( sortedNodules.begin(), sortedNodules.end() );
+	for( vector<IndexAndNodule>::const_iterator it = sortedNodules.begin(), eIt = sortedNodules.end(); it != eIt; ++it )
+	{
+		nodules.push_back( it->nodule );
+	}
+}
+
+void NoduleLayout::updateNoduleLayout()
+{
+	// Get an updated array of all our nodules,
+	// remembering what was added and removed.
+	vector<Nodule *> nodules;
+	vector<Nodule *> added;
+	vector<NodulePtr> removed;
+	updateNodules( nodules, added, removed );
+
+	// Clear the nodule container and refill it
+	// in the right order.
+
+	LinearContainer *c = noduleContainer();
+	c->clearChildren();
+	for( vector<Nodule *>::const_iterator it = nodules.begin(), eIt = nodules.end(); it != eIt; ++it )
+	{
+		c->addChild( *it );
+	}
+
+	// Let everyone know what we've done.
+	/// \todo Maybe we shouldn't know about the NodeGadget?
+	if( NodeGadget *nodeGadget = ancestor<NodeGadget>() )
+	{
+		for( vector<NodulePtr>::const_iterator it = removed.begin(), eIt = removed.end(); it != eIt; ++it )
+		{
+			nodeGadget->noduleRemovedSignal()( nodeGadget, it->get() );
+		}
+
+		for( vector<Nodule *>::const_iterator it = added.begin(), eIt = added.end(); it != eIt; ++it )
+		{
+			nodeGadget->noduleAddedSignal()( nodeGadget, *it );
+		}
+	}
+}
+
+void NoduleLayout::updateSpacing()
+{
+	noduleContainer()->setSpacing( spacing( m_parent.get(), m_section ) );
+}
+
+void NoduleLayout::updateDirection()
+{
+	noduleContainer()->setDirection( direction( m_parent.get(), m_section ) );
+}
+
+void NoduleLayout::updateOrientation()
+{
+	noduleContainer()->setOrientation( orientation( m_parent.get(), m_section ) );
+}

--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -207,7 +207,7 @@ void PlugAdder::doRender( const Style *style ) const
 void PlugAdder::applyEdgeMetadata( Gaffer::Plug *plug, bool opposite ) const
 {
 	StandardNodeGadget::Edge edge = opposite ? oppositeEdge( m_edge ) : m_edge;
-	updateMetadata( plug, "nodeGraphLayout:section", edgeName( edge ) );
+	updateMetadata( plug, "noduleLayout:section", edgeName( edge ) );
 }
 
 void PlugAdder::enter( GadgetPtr gadget, const ButtonEvent &event )

--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -219,12 +219,7 @@ void PlugAdder::doRender( const Style *style ) const
 void PlugAdder::applyEdgeMetadata( Gaffer::Plug *plug, bool opposite ) const
 {
 	StandardNodeGadget::Edge edge = opposite ? oppositeEdge( m_edge ) : m_edge;
-
-	updateMetadata( plug, "nodeGadget:nodulePosition", edgeName( edge ) );
-	if( runTimeCast<ArrayPlug>( plug ) )
-	{
-		updateMetadata( plug, "compoundNodule:orientation", edgeOrientation( edge ) );
-	}
+	updateMetadata( plug, "nodeGraphLayout:section", edgeName( edge ) );
 }
 
 void PlugAdder::enter( GadgetPtr gadget, const ButtonEvent &event )

--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -40,10 +40,8 @@
 #include "IECoreGL/Selector.h"
 
 #include "Gaffer/UndoContext.h"
-#include "Gaffer/ScriptNode.h"
-#include "Gaffer/Switch.h"
-#include "Gaffer/ArrayPlug.h"
 #include "Gaffer/Metadata.h"
+#include "Gaffer/ArrayPlug.h"
 
 #include "GafferUI/Nodule.h"
 #include "GafferUI/ImageGadget.h"
@@ -160,12 +158,9 @@ void updateMetadata( Plug *plug, InternedString key, const char *value )
 
 IE_CORE_DEFINERUNTIMETYPED( PlugAdder );
 
-PlugAdder::PlugAdder( Gaffer::NodePtr node, StandardNodeGadget::Edge edge )
-	:	m_node( node ), m_edge( edge ), m_dragging( false )
+PlugAdder::PlugAdder( StandardNodeGadget::Edge edge )
+	:	m_edge( edge ), m_dragging( false )
 {
-	node->childAddedSignal().connect( boost::bind( &PlugAdder::childAdded, this ) );
-	node->childRemovedSignal().connect( boost::bind( &PlugAdder::childRemoved, this ) );
-
 	enterSignal().connect( boost::bind( &PlugAdder::enter, this, ::_1, ::_2 ) );
 	leaveSignal().connect( boost::bind( &PlugAdder::leave, this, ::_1, ::_2 ) );
 	buttonPressSignal().connect( boost::bind( &PlugAdder::buttonPress, this, ::_1,  ::_2 ) );
@@ -175,8 +170,6 @@ PlugAdder::PlugAdder( Gaffer::NodePtr node, StandardNodeGadget::Edge edge )
 	dragLeaveSignal().connect( boost::bind( &PlugAdder::dragLeave, this, ::_2 ) );
 	dropSignal().connect( boost::bind( &PlugAdder::drop, this, ::_2 ) );
 	dragEndSignal().connect( boost::bind( &PlugAdder::dragEnd, this, ::_2 ) );
-
-	updateVisibility();
 }
 
 PlugAdder::~PlugAdder()
@@ -217,49 +210,14 @@ void PlugAdder::doRender( const Style *style ) const
 	style->renderImage( Box2f( V2f( -radius ), V2f( radius ) ), texture( state ) );
 }
 
-void PlugAdder::addPlug( Gaffer::Plug *connectionEndPoint )
+void PlugAdder::applyEdgeMetadata( Gaffer::Plug *plug, bool opposite ) const
 {
-	UndoContext undoContext( m_node->ancestor<ScriptNode>() );
+	StandardNodeGadget::Edge edge = opposite ? oppositeEdge( m_edge ) : m_edge;
 
-	if( SwitchComputeNode *switchNode = runTimeCast<SwitchComputeNode>( m_node.get() ) )
+	updateMetadata( plug, "nodeGadget:nodulePosition", edgeName( edge ) );
+	if( runTimeCast<ArrayPlug>( plug ) )
 	{
-		switchNode->setup( connectionEndPoint );
-		ArrayPlug *inPlug = switchNode->getChild<ArrayPlug>( "in" );
-		Plug *outPlug = switchNode->getChild<Plug>( "out" );
-
-		StandardNodeGadget::Edge inEdge = StandardNodeGadget::InvalidEdge;
-		if( connectionEndPoint->direction() == Plug::Out )
-		{
-			inPlug->getChild<Plug>( 0 )->setInput( connectionEndPoint );
-			inEdge = m_edge;
-		}
-		else
-		{
-			connectionEndPoint->setInput( switchNode->getChild<Plug>( "out" ) );
-			inEdge = oppositeEdge( m_edge );
-		}
-
-		updateMetadata( inPlug, "nodeGadget:nodulePosition", edgeName( inEdge ) );
-		updateMetadata( inPlug, "compoundNodule:orientation", edgeOrientation( inEdge ) );
-		updateMetadata( outPlug, "nodeGadget:nodulePosition", edgeName( oppositeEdge( inEdge ) ) );
-	}
-}
-
-void PlugAdder::childAdded()
-{
-	updateVisibility();
-}
-
-void PlugAdder::childRemoved()
-{
-	updateVisibility();
-}
-
-void PlugAdder::updateVisibility()
-{
-	if( SwitchComputeNode *switchNode = runTimeCast<SwitchComputeNode>( m_node.get() ) )
-	{
-		setVisible( switchNode->getChild<ArrayPlug>( "in" ) == NULL );
+		updateMetadata( plug, "compoundNodule:orientation", edgeOrientation( edge ) );
 	}
 }
 
@@ -297,7 +255,7 @@ bool PlugAdder::dragEnter( const DragDropEvent &event )
 	}
 
 	const Plug *plug = runTimeCast<Plug>( event.data.get() );
-	if( !plug )
+	if( !plug || !acceptsPlug( plug ) )
 	{
 		return false;
 	}

--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -125,18 +125,6 @@ const char *edgeName( StandardNodeGadget::Edge edge )
 	}
 }
 
-const char *edgeOrientation( StandardNodeGadget::Edge edge )
-{
-	switch( edge )
-	{
-		case StandardNodeGadget::TopEdge :
-		case StandardNodeGadget::BottomEdge :
-			return "x";
-		default :
-			return "y";
-	}
-}
-
 void updateMetadata( Plug *plug, InternedString key, const char *value )
 {
 	ConstStringDataPtr s = Metadata::value<StringData>( plug, key );

--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -189,6 +189,12 @@ void PlugAdder::updateDragEndPoint( const Imath::V3f position, const Imath::V3f 
 	requestRender();
 }
 
+PlugAdder::PlugMenuSignal &PlugAdder::plugMenuSignal()
+{
+	static PlugMenuSignal s;
+	return s;
+}
+
 void PlugAdder::doRender( const Style *style ) const
 {
 	if( m_dragging )

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -59,6 +59,7 @@
 #include "GafferUI/SpacerGadget.h"
 #include "GafferUI/ImageGadget.h"
 #include "GafferUI/PlugAdder.h"
+#include "GafferUI/NoduleLayout.h"
 
 using namespace std;
 using namespace Imath;
@@ -192,13 +193,8 @@ IE_CORE_DEFINERUNTIMETYPED( StandardNodeGadget );
 NodeGadget::NodeGadgetTypeDescription<StandardNodeGadget> StandardNodeGadget::g_nodeGadgetTypeDescription( Gaffer::Node::staticTypeId() );
 
 static const float g_borderWidth = 0.5f;
-static IECore::InternedString g_horizontalNoduleSpacingKey( "nodeGadget:horizontalNoduleSpacing"  );
-static IECore::InternedString g_verticalNoduleSpacingKey( "nodeGadget:verticalNoduleSpacing"  );
 static IECore::InternedString g_minWidthKey( "nodeGadget:minWidth"  );
 static IECore::InternedString g_paddingKey( "nodeGadget:padding"  );
-static IECore::InternedString g_nodulePositionKey( "nodeGadget:nodulePosition" );
-static IECore::InternedString g_noduleIndexKey( "nodeGadget:noduleIndex" );
-static IECore::InternedString g_noduleTypeKey( "nodule:type" );
 static IECore::InternedString g_colorKey( "nodeGadget:color" );
 static IECore::InternedString g_errorGadgetName( "__error" );
 
@@ -213,20 +209,7 @@ StandardNodeGadget::StandardNodeGadget( Gaffer::NodePtr node )
 	// build our ui structure
 	////////////////////////////////////////////////////////
 
-	float horizontalNoduleSpacing = 2.0f;
-	float verticalNoduleSpacing = 0.2f;
 	float minWidth = 10.0f;
-
-	if( IECore::ConstFloatDataPtr d = Metadata::value<IECore::FloatData>( node.get(), g_horizontalNoduleSpacingKey ) )
-	{
-		horizontalNoduleSpacing = d->readable();
-	}
-
-	if( IECore::ConstFloatDataPtr d = Metadata::value<IECore::FloatData>( node.get(), g_verticalNoduleSpacingKey ) )
-	{
-		verticalNoduleSpacing = d->readable();
-	}
-
 	if( IECore::ConstFloatDataPtr d = Metadata::value<IECore::FloatData>( node.get(), g_minWidthKey ) )
 	{
 		minWidth = d->readable();
@@ -237,21 +220,25 @@ StandardNodeGadget::StandardNodeGadget( Gaffer::NodePtr node )
 	// the corners of the node gadget, and also to guarantee a minimim width for the
 	// vertical containers and a minimum height for the horizontal ones.
 
-	LinearContainerPtr topNoduleContainer = new LinearContainer( "topNoduleContainer", LinearContainer::X, LinearContainer::Centre, horizontalNoduleSpacing );
-	topNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 0, 1, 0 ) ) ) );
-	topNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 0, 1, 0 ) ) ) );
+	LinearContainerPtr topNoduleContainer = new LinearContainer( "topNoduleContainer", LinearContainer::X );
+	topNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 2, 1, 0 ) ) ) );
+	topNoduleContainer->addChild( new NoduleLayout( node, "top" ) );
+	topNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 2, 1, 0 ) ) ) );
 
-	LinearContainerPtr bottomNoduleContainer = new LinearContainer( "bottomNoduleContainer", LinearContainer::X, LinearContainer::Centre, horizontalNoduleSpacing );
-	bottomNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 0, 1, 0 ) ) ) );
-	bottomNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 0, 1, 0 ) ) ) );
+	LinearContainerPtr bottomNoduleContainer = new LinearContainer( "bottomNoduleContainer", LinearContainer::X );
+	bottomNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 2, 1, 0 ) ) ) );
+	bottomNoduleContainer->addChild( new NoduleLayout( node, "bottom" ) );
+	bottomNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 2, 1, 0 ) ) ) );
 
-	LinearContainerPtr leftNoduleContainer = new LinearContainer( "leftNoduleContainer", LinearContainer::Y, LinearContainer::Centre, verticalNoduleSpacing, LinearContainer::Decreasing );
-	leftNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 1, 0, 0 ) ) ) );
-	leftNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 1, 0, 0 ) ) ) );
+	LinearContainerPtr leftNoduleContainer = new LinearContainer( "leftNoduleContainer", LinearContainer::Y, LinearContainer::Centre, 0.0f, LinearContainer::Decreasing );
+	leftNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 1, 0.2, 0 ) ) ) );
+	leftNoduleContainer->addChild( new NoduleLayout( node, "left" ) );
+	leftNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 1, 0.2, 0 ) ) ) );
 
-	LinearContainerPtr rightNoduleContainer = new LinearContainer( "rightNoduleContainer", LinearContainer::Y, LinearContainer::Centre, verticalNoduleSpacing, LinearContainer::Decreasing );
-	rightNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 1, 0, 0 ) ) ) );
-	rightNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 1, 0, 0 ) ) ) );
+	LinearContainerPtr rightNoduleContainer = new LinearContainer( "rightNoduleContainer", LinearContainer::Y, LinearContainer::Centre, 0.0f, LinearContainer::Decreasing );
+	rightNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 1, 0.2, 0 ) ) ) );
+	rightNoduleContainer->addChild( new NoduleLayout( node, "right" ) );
+	rightNoduleContainer->addChild( new SpacerGadget( Box3f( V3f( 0 ), V3f( 1, 0.2, 0 ) ) ) );
 
 	// column - this is our outermost structuring container
 
@@ -304,8 +291,6 @@ StandardNodeGadget::StandardNodeGadget( Gaffer::NodePtr node )
 	// connect to the signals we need in order to operate
 	////////////////////////////////////////////////////////
 
-	node->childAddedSignal().connect( boost::bind( &StandardNodeGadget::childAdded, this, ::_1,  ::_2 ) );
-	node->childRemovedSignal().connect( boost::bind( &StandardNodeGadget::childRemoved, this, ::_1,  ::_2 ) );
 	node->errorSignal().connect( boost::bind( &StandardNodeGadget::error, this, ::_1, ::_2, ::_3 ) );
 	node->plugDirtiedSignal().connect( boost::bind( &StandardNodeGadget::plugDirtied, this, ::_1 ) );
 
@@ -316,18 +301,16 @@ StandardNodeGadget::StandardNodeGadget( Gaffer::NodePtr node )
 
 	for( int e = FirstEdge; e <= LastEdge; e++ )
 	{
-		LinearContainer *c = noduleContainer( (Edge)e );
-		c->enterSignal().connect( boost::bind( &StandardNodeGadget::enter, this, ::_1 ) );
-		c->leaveSignal().connect( boost::bind( &StandardNodeGadget::leave, this, ::_1 ) );
+		NoduleLayout *l = noduleLayout( (Edge)e );
+		l->enterSignal().connect( boost::bind( &StandardNodeGadget::enter, this, ::_1 ) );
+		l->leaveSignal().connect( boost::bind( &StandardNodeGadget::leave, this, ::_1 ) );
 	}
 
-	Metadata::plugValueChangedSignal().connect( boost::bind( &StandardNodeGadget::plugMetadataChanged, this, ::_1, ::_2, ::_3, ::_4 ) );
 	Metadata::nodeValueChangedSignal().connect( boost::bind( &StandardNodeGadget::nodeMetadataChanged, this, ::_1, ::_2, ::_3 ) );
 
 	// do our first update
 	////////////////////////////////////////////////////////
 
-	updateNoduleLayout();
 	updateUserColor();
 	updatePadding();
 	updateNodeEnabled();
@@ -383,25 +366,15 @@ const Imath::Color3f *StandardNodeGadget::userColor() const
 
 Nodule *StandardNodeGadget::nodule( const Gaffer::Plug *plug )
 {
-	const GraphComponent *parent = plug->parent<GraphComponent>();
-	if( !parent || parent == node() )
+	for( int e = FirstEdge; e <= LastEdge; e++ )
 	{
-		NoduleMap::iterator it = m_nodules.find( plug );
-		if( it != m_nodules.end() )
+		NoduleLayout *l = noduleLayout( (Edge)e );
+		if( Nodule *n = l->nodule( plug ) )
 		{
-			return it->second.nodule.get();
-		}
-		return 0;
-	}
-	else if( const Plug *parentPlug = IECore::runTimeCast<const Plug>( parent ) )
-	{
-		CompoundNodule *compoundNodule = IECore::runTimeCast<CompoundNodule>( nodule( parentPlug ) );
-		if( compoundNodule )
-		{
-			return compoundNodule->nodule( plug );
+			return n;
 		}
 	}
-	return 0;
+	return NULL;
 }
 
 const Nodule *StandardNodeGadget::nodule( const Gaffer::Plug *plug ) const
@@ -428,33 +401,6 @@ Imath::V3f StandardNodeGadget::noduleTangent( const Nodule *nodule ) const
 	{
 		return V3f( 0, -1, 0 );
 	}
-}
-
-StandardNodeGadget::Edge StandardNodeGadget::plugEdge( const Gaffer::Plug *plug )
-{
-	Edge edge = plug->direction() == Gaffer::Plug::In ? TopEdge : BottomEdge;
-
-	if( IECore::ConstStringDataPtr d = Metadata::value<IECore::StringData>( plug, g_nodulePositionKey ) )
-	{
-		if( d->readable() == "left" )
-		{
-			edge = LeftEdge;
-		}
-		else if( d->readable() == "right" )
-		{
-			edge = RightEdge;
-		}
-		else if( d->readable() == "bottom" )
-		{
-			edge = BottomEdge;
-		}
-		else
-		{
-			edge = TopEdge;
-		}
-	}
-
-	return edge;
 }
 
 LinearContainer *StandardNodeGadget::noduleContainer( Edge edge )
@@ -486,6 +432,16 @@ const LinearContainer *StandardNodeGadget::noduleContainer( Edge edge ) const
 	return const_cast<StandardNodeGadget *>( this )->noduleContainer( edge );
 }
 
+NoduleLayout *StandardNodeGadget::noduleLayout( Edge edge )
+{
+	return noduleContainer( edge )->getChild<NoduleLayout>( 1 );
+}
+
+const NoduleLayout *StandardNodeGadget::noduleLayout( Edge edge ) const
+{
+	return noduleContainer( edge )->getChild<NoduleLayout>( 1 );
+}
+
 IndividualContainer *StandardNodeGadget::contentsContainer()
 {
 	return getChild<Gadget>( 0 ) // column
@@ -497,24 +453,6 @@ IndividualContainer *StandardNodeGadget::contentsContainer()
 const IndividualContainer *StandardNodeGadget::contentsContainer() const
 {
 	return const_cast<StandardNodeGadget *>( this )->contentsContainer();
-}
-
-void StandardNodeGadget::childAdded( Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child )
-{
-	Gaffer::Plug *p = IECore::runTimeCast<Gaffer::Plug>( child );
-	if( p )
-	{
-		updateNoduleLayout();
-	}
-}
-
-void StandardNodeGadget::childRemoved( Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child )
-{
-	Gaffer::Plug *p = IECore::runTimeCast<Gaffer::Plug>( child );
-	if( p )
-	{
-		updateNoduleLayout();
-	}
 }
 
 void StandardNodeGadget::setContents( GadgetPtr contents )
@@ -564,18 +502,12 @@ Gadget *StandardNodeGadget::getEdgeGadget( Edge edge )
 {
 	LinearContainer *c = noduleContainer( edge );
 	const size_t s = c->children().size();
-	if( s < 3 )
+	if( s != 4 )
 	{
 		return NULL;
 	}
 
-	Gadget *potentialEdgeGadget = c->getChild<Gadget>( s - 2 );
-	if( !IECore::runTimeCast<Nodule>( potentialEdgeGadget ) )
-	{
-		return potentialEdgeGadget;
-	}
-
-	return NULL;
+	return c->getChild<Gadget>( s - 2 );
 }
 
 const Gadget *StandardNodeGadget::getEdgeGadget( Edge edge ) const
@@ -681,24 +613,6 @@ bool StandardNodeGadget::drop( GadgetPtr gadget, const DragDropEvent &event )
 	const bool result = m_dragDestinationProxy->dropSignal()( m_dragDestinationProxy, event );
 	m_dragDestinationProxy = NULL;
 	return result;
-}
-
-void StandardNodeGadget::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
-{
-	if( plug && plug->parent<Node>() != node() )
-	{
-		return;
-	}
-
-	if( !node()->isInstanceOf( nodeTypeId ) )
-	{
-		return;
-	}
-
-	if( key == g_nodulePositionKey || key == g_noduleIndexKey || key == g_noduleTypeKey )
-	{
-		updateNoduleLayout();
-	}
 }
 
 Gadget *StandardNodeGadget::closestDragDestinationProxy( const DragDropEvent &event ) const
@@ -816,133 +730,6 @@ void StandardNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore:
 	{
 		updatePadding();
 	}
-}
-
-void StandardNodeGadget::updateNodules( std::vector<Nodule *> &nodules, std::vector<Nodule *> &added, std::vector<NodulePtr> &removed )
-{
-	// Update the nodules for all our plugs, and build a vector
-	// of IndexAndNodule to sort ready for layout.
-	vector<IndexAndNodule> sortedNodules;
-	for( PlugIterator plugIt( node() ); !plugIt.done(); ++plugIt )
-	{
-		Plug *plug = plugIt->get();
-		if( plug->getName().string().compare( 0, 2, "__" )==0 )
-		{
-			continue;
-		}
-
-		IECore::ConstStringDataPtr typeData = Metadata::value<IECore::StringData>( plug, g_noduleTypeKey );
-		IECore::InternedString type = typeData ? typeData->readable() : "GafferUI::StandardNodule";
-
-		Nodule *nodule = NULL;
-		NoduleMap::iterator it = m_nodules.find( plug );
-		if( it != m_nodules.end() && it->second.type == type )
-		{
-			nodule = it->second.nodule.get();
-		}
-		else
-		{
-			if( it != m_nodules.end() && it->second.nodule )
-			{
-				removed.push_back( it->second.nodule );
-			}
-			NodulePtr n = Nodule::create( plug );
-			m_nodules[plug] = TypeAndNodule( type, n );
-			if( n )
-			{
-				added.push_back( n.get() );
-				nodule = n.get();
-			}
-		}
-
-		if( nodule )
-		{
-			int index = sortedNodules.size();
-			if( IECore::ConstIntDataPtr indexData = Metadata::value<IECore::IntData>( plug, g_noduleIndexKey ) )
-			{
-				index = indexData->readable();
-			}
-			sortedNodules.push_back( IndexAndNodule( index, nodule ) );
-		}
-	}
-
-	// Remove any nodules for which a plug no longer exists.
-	for( NoduleMap::iterator it = m_nodules.begin(); it != m_nodules.end(); )
-	{
-		NoduleMap::iterator next = it; next++;
-		if( it->first->parent<Node>() != node() )
-		{
-			if( it->second.nodule )
-			{
-				removed.push_back( it->second.nodule );
-			}
-			m_nodules.erase( it );
-		}
-		it = next;
-	}
-
-	// Sort ready for layout.
-	sort( sortedNodules.begin(), sortedNodules.end() );
-	for( vector<IndexAndNodule>::const_iterator it = sortedNodules.begin(), eIt = sortedNodules.end(); it != eIt; ++it )
-	{
-		nodules.push_back( it->nodule );
-	}
-}
-
-void StandardNodeGadget::updateNoduleLayout()
-{
-	// Get an updated array of all our nodules,
-	// remembering what was added and removed.
-	vector<Nodule *> nodules;
-	vector<Nodule *> added;
-	vector<NodulePtr> removed;
-	updateNodules( nodules, added, removed );
-
-	// Clear the nodule containers for each edge,
-	// and remember the end gadget for each.
-	LinearContainer *edgeContainers[NumEdges];
-	GadgetPtr endGadgets[NumEdges];
-	GadgetPtr endSpacers[NumEdges];
-	for( int edge = FirstEdge; edge < NumEdges; ++edge )
-	{
-		endGadgets[edge] = getEdgeGadget( (Edge)edge );
-		edgeContainers[edge] = noduleContainer( (Edge)edge );
-		endSpacers[edge] = boost::static_pointer_cast<Gadget>( edgeContainers[edge]->children().back() );
-		while( edgeContainers[edge]->children().size() > 1 )
-		{
-			edgeContainers[edge]->removeChild( edgeContainers[edge]->children().back() );
-		}
-	}
-
-	// Refill the containers with the nodules in the
-	// right container.
-
-	for( vector<Nodule *>::const_iterator it = nodules.begin(), eIt = nodules.end(); it != eIt; ++it )
-	{
-		edgeContainers[plugEdge( (*it)->plug() )]->addChild( *it );
-	}
-
-	// Put back the end gadgets and spacers
-	for( int edge = FirstEdge; edge < NumEdges; ++edge )
-	{
-		if( endGadgets[edge] )
-		{
-			edgeContainers[edge]->addChild( endGadgets[edge] );
-		}
-		edgeContainers[edge]->addChild( endSpacers[edge] );
-	}
-
-	// Let everyone know what we've done.
-	for( vector<NodulePtr>::const_iterator it = removed.begin(), eIt = removed.end(); it != eIt; ++it )
-	{
-		noduleRemovedSignal()( this, it->get() );
-	}
-
-	for( vector<Nodule *>::const_iterator it = added.begin(), eIt = added.end(); it != eIt; ++it )
-	{
-		noduleAddedSignal()( this, *it );
-	}
-
 }
 
 bool StandardNodeGadget::updateUserColor()

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -785,7 +785,12 @@ bool StandardNodeGadget::noduleIsCompatible( const Nodule *nodule, const DragDro
 
 bool StandardNodeGadget::plugAdderIsCompatible( const PlugAdder *plugAdder, const DragDropEvent &event ) const
 {
-	return IECore::runTimeCast<Gaffer::Plug>( event.data.get() );
+	Gaffer::Plug *plug = IECore::runTimeCast<Gaffer::Plug>( event.data.get() );
+	if( !plug )
+	{
+		return false;
+	}
+	return plugAdder->acceptsPlug( plug );
 }
 
 void StandardNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node )

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -756,9 +756,9 @@ Gadget *StandardNodeGadget::closestDragDestinationProxy( const DragDropEvent &ev
 
 bool StandardNodeGadget::noduleIsCompatible( const Nodule *nodule, const DragDropEvent &event ) const
 {
-	if( IECore::runTimeCast<PlugAdder>( event.sourceGadget.get() ) )
+	if( const PlugAdder *plugAdder = IECore::runTimeCast<PlugAdder>( event.sourceGadget.get() ) )
 	{
-		return !IECore::runTimeCast<const CompoundNodule>( nodule );
+		return plugAdder->acceptsPlug( nodule->plug() );
 	}
 
 	const Plug *dropPlug = IECore::runTimeCast<Gaffer::Plug>( event.data.get() );

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -270,11 +270,11 @@ bool StandardNodule::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
 		connection( event, input, output );
 		accept = static_cast<bool>( input );
 	}
-	else if( IECore::runTimeCast<PlugAdder>( event.sourceGadget.get() ) )
+	else if( const PlugAdder *plugAdder = IECore::runTimeCast<PlugAdder>( event.sourceGadget.get() ) )
 	{
 		// We must accept the drag so that the PlugAdder gets
 		// a chance to do its thing.
-		accept = true;
+		accept = plugAdder->acceptsPlug( plug() );
 	}
 
 	if( accept )

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -65,7 +65,7 @@ IE_CORE_DEFINERUNTIMETYPED( StandardNodule );
 Nodule::NoduleTypeDescription<StandardNodule> StandardNodule::g_noduleTypeDescription( Gaffer::Plug::staticTypeId() );
 
 static IECore::InternedString g_colorKey( "nodule:color" );
-static IECore::InternedString g_labelKey( "nodeGraphLayout:label" );
+static IECore::InternedString g_labelKey( "noduleLayout:label" );
 
 StandardNodule::StandardNodule( Gaffer::PlugPtr plug )
 	:	Nodule( plug ), m_labelVisible( false ), m_draggingConnection( false )

--- a/src/GafferUIBindings/NoduleLayoutBinding.cpp
+++ b/src/GafferUIBindings/NoduleLayoutBinding.cpp
@@ -1,0 +1,61 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "Gaffer/Plug.h"
+
+#include "GafferUI/NoduleLayout.h"
+#include "GafferUI/Nodule.h"
+
+#include "GafferUIBindings/NoduleLayoutBinding.h"
+#include "GafferUIBindings/GadgetBinding.h"
+
+using namespace boost::python;
+using namespace IECorePython;
+using namespace Gaffer;
+using namespace GafferUI;
+using namespace GafferUIBindings;
+
+void GafferUIBindings::bindNoduleLayout()
+{
+
+	GadgetClass<NoduleLayout>()
+		.def( init<GraphComponentPtr, IECore::InternedString>() )
+		.def( "nodule", (Nodule * (NoduleLayout::*)( const Plug *))&NoduleLayout::nodule, return_value_policy<CastToIntrusivePtr>() )
+	;
+
+}

--- a/src/GafferUIBindings/PlugAdderBinding.cpp
+++ b/src/GafferUIBindings/PlugAdderBinding.cpp
@@ -1,0 +1,102 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "Gaffer/Plug.h"
+#include "GafferBindings/ExceptionAlgo.h"
+#include "GafferBindings/SignalBinding.h"
+
+#include "GafferUI/PlugAdder.h"
+#include "GafferUIBindings/PlugAdderBinding.h"
+#include "GafferUIBindings/GadgetBinding.h"
+
+using namespace boost::python;
+using namespace std;
+using namespace Gaffer;
+using namespace GafferBindings;
+using namespace GafferUI;
+using namespace GafferUIBindings;
+
+namespace
+{
+
+struct PlugMenuSignalCaller
+{
+
+	PlugPtr call( PlugAdder::PlugMenuSignal &s, const std::string &title, const vector<Plug *> &plugs )
+	{
+		return s( title, plugs );
+	}
+
+};
+
+struct PlugMenuSlotCaller
+{
+
+	Plug *operator()( boost::python::object slot, const std::string &title, const vector<Plug *> &plugs )
+	{
+		try
+		{
+			boost::python::list pythonPlugs;
+			for( vector<Plug *>::const_iterator it = plugs.begin(), eIt = plugs.end(); it != eIt; ++it )
+			{
+				pythonPlugs.append( PlugPtr( *it ) );
+			}
+			object r = slot( title, pythonPlugs );
+
+			return extract<Plug *>( r );
+		}
+		catch( const error_already_set &e )
+		{
+			translatePythonException();
+		}
+		return NULL;
+	}
+
+};
+
+} // namespace
+
+void GafferUIBindings::bindPlugAdder()
+{
+	scope s = GadgetClass<PlugAdder>()
+		.def( "plugMenuSignal", &PlugAdder::plugMenuSignal, return_value_policy<reference_existing_object>() )
+		.staticmethod( "plugMenuSignal" )
+	;
+
+	SignalClass<PlugAdder::PlugMenuSignal, PlugMenuSignalCaller, PlugMenuSlotCaller>( "PlugMenuSignal" );
+}

--- a/src/GafferUIModule/GafferUIModule.cpp
+++ b/src/GafferUIModule/GafferUIModule.cpp
@@ -77,6 +77,7 @@
 #include "GafferUIBindings/PathListingWidgetBinding.h"
 #include "GafferUIBindings/GLWidgetBinding.h"
 #include "GafferUIBindings/PlugAdderBinding.h"
+#include "GafferUIBindings/NoduleLayoutBinding.h"
 
 using namespace GafferUIBindings;
 
@@ -123,5 +124,6 @@ BOOST_PYTHON_MODULE( _GafferUI )
 	bindPathListingWidget();
 	bindGLWidget();
 	bindPlugAdder();
+	bindNoduleLayout();
 
 }

--- a/src/GafferUIModule/GafferUIModule.cpp
+++ b/src/GafferUIModule/GafferUIModule.cpp
@@ -76,6 +76,7 @@
 #include "GafferUIBindings/DotNodeGadgetBinding.h"
 #include "GafferUIBindings/PathListingWidgetBinding.h"
 #include "GafferUIBindings/GLWidgetBinding.h"
+#include "GafferUIBindings/PlugAdderBinding.h"
 
 using namespace GafferUIBindings;
 
@@ -121,5 +122,6 @@ BOOST_PYTHON_MODULE( _GafferUI )
 	bindDotNodeGadget();
 	bindPathListingWidget();
 	bindGLWidget();
+	bindPlugAdder();
 
 }


### PR DESCRIPTION
This makes the AlSurface shader much less unwieldy in the NodeGraph as follows :

- Refactor PlugAdder to allow custom adders to be created
- Refactor NodeGraph layout into a new NoduleLayout class that consolidates the layout code from StandardNodeGadget and CompoundNodule into one place
- Add support for "nodeGraphLayout:visible" metadata to control nodule visibility
- Hide most AlSurface parameters in the NodeGraph by default
- Introduce custom PlugAdder for shaders to reveal parameters when they are needed

From a user perspective this means they now see a much more compact AlSurface, but can drag connections onto a little "+" icon to reveal and connect to a hidden parameter. They can also click on the "+" to show a menu to reveal parameters without connecting them : 

![alsurfaceconnections](https://cloud.githubusercontent.com/assets/1133871/21105545/85af61c0-c082-11e6-9425-1a97c26e8aad.png)

We could use this to hide parameters for any shader by default, but here I've only done Arnold shaders, and of those only AlSurface and standard. Perfectly happy to do more, but those were the troublemakers I was aware of, and I could do with user feedback for any others.

Andrew, this doesn't take care of any of the aesthetic notes you had from the previous PR, but I have them written down ready to address after this is merged. I've also designed PlugAdder so that it should be useable to improve interaction with Boxes as well, so we should reconsider revisiting that at some point in the future too.
