### PR TITLE
ContextMonitor

### DIFF
--- a/include/Gaffer/ContextMonitor.h
+++ b/include/Gaffer/ContextMonitor.h
@@ -1,0 +1,129 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_CONTEXTMONITOR_H
+#define GAFFER_CONTEXTMONITOR_H
+
+#include <vector>
+
+#include "tbb/enumerable_thread_specific.h"
+
+#include "boost/unordered_map.hpp"
+#include "boost/unordered_set.hpp"
+
+#include "IECore/RefCounted.h"
+#include "IECore/MurmurHash.h"
+
+#include "Gaffer/Monitor.h"
+
+namespace Gaffer
+{
+
+IE_CORE_FORWARDDECLARE( GraphComponent )
+IE_CORE_FORWARDDECLARE( Plug )
+IE_CORE_FORWARDDECLARE( Context )
+
+/// A monitor which collects statistics about
+/// what contexts plugs are evaluated in.
+class ContextMonitor : public Monitor
+{
+
+	public :
+
+		/// Statistics are only collected for the root and its
+		/// descendants.
+		ContextMonitor( const GraphComponent *root = NULL );
+		virtual ~ContextMonitor();
+
+		struct Statistics
+		{
+
+			size_t numUniqueContexts() const;
+			std::vector<IECore::InternedString> variableNames() const;
+			size_t numUniqueValues( IECore::InternedString variableName ) const;
+
+			Statistics & operator += ( const Context *rhs );
+			Statistics & operator += ( const Statistics &rhs );
+
+			bool operator == ( const Statistics &rhs );
+			bool operator != ( const Statistics &rhs );
+
+			private :
+
+				typedef boost::unordered_set<IECore::MurmurHash> ContextSet;
+				typedef boost::unordered_map<IECore::MurmurHash, size_t> CountingMap;
+				typedef std::map<IECore::InternedString, CountingMap> VariableMap;
+
+				ContextSet m_contexts;
+				VariableMap m_variables;
+
+		};
+
+		typedef boost::unordered_map<ConstPlugPtr, Statistics> StatisticsMap;
+
+		const StatisticsMap &allStatistics() const;
+		const Statistics &plugStatistics( const Plug *plug ) const;
+		const Statistics &combinedStatistics() const;
+
+	protected :
+
+		virtual void processStarted( const Process *process );
+		virtual void processFinished( const Process *process );
+
+	private :
+
+		const GraphComponent *m_root;
+
+		// For performance reasons we accumulate our statistics into
+		// thread local storage while computations are running.
+		struct ThreadData
+		{
+			// Stores the per-plug statistics captured by this thread.
+			StatisticsMap statistics;
+		};
+
+		tbb::enumerable_thread_specific<ThreadData, tbb::cache_aligned_allocator<ThreadData>, tbb::ets_key_per_instance> m_threadData;
+
+		// Then when we want to query it, we collate it into m_statistics.
+		void collate() const;
+		mutable StatisticsMap m_statistics;
+		mutable Statistics m_combinedStatistics;
+
+};
+
+} // namespace Gaffer
+
+#endif // GAFFER_CONTEXTMONITOR_H

--- a/include/Gaffer/PerformanceMonitor.h
+++ b/include/Gaffer/PerformanceMonitor.h
@@ -54,7 +54,7 @@ namespace Gaffer
 IE_CORE_FORWARDDECLARE( Plug )
 
 /// A monitor which collects statistics about the frequency
-/// of hash and compute processes per plug.
+/// and duration of hash and compute processes per plug.
 class PerformanceMonitor : public Monitor
 {
 
@@ -98,7 +98,7 @@ class PerformanceMonitor : public Monitor
 	private :
 
 		// For performance reasons we accumulate our statistics into
-		// thread local storage while computations are running.		
+		// thread local storage while computations are running.
 		struct ThreadData
 		{
 			// Stores the per-plug statistics captured by this thread.
@@ -111,7 +111,7 @@ class PerformanceMonitor : public Monitor
 			// The last time measurement we made.
 			boost::chrono::high_resolution_clock::time_point then;
 		};
-		
+
 		tbb::enumerable_thread_specific<ThreadData, tbb::cache_aligned_allocator<ThreadData>, tbb::ets_key_per_instance> m_threadData;
 
 		// Then when we want to query it, we collate it into m_statistics.

--- a/python/GafferTest/ContextMonitorTest.py
+++ b/python/GafferTest/ContextMonitorTest.py
@@ -1,0 +1,111 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import time
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+
+class ContextMonitorTest( GafferTest.TestCase ) :
+
+	def test( self ) :
+
+		c = Gaffer.Context()
+		defaultVariableNames = c.keys()
+
+		a1 = GafferTest.AddNode()
+		a2 = GafferTest.AddNode()
+
+		m = Gaffer.ContextMonitor()
+		with c, m :
+			a1["sum"].getValue()
+
+		a1s = m.plugStatistics( a1["sum"] )
+		self.assertEqual( a1s.numUniqueContexts(), 1 )
+		self.assertEqual( set( a1s.variableNames() ), set( defaultVariableNames ) )
+		for n in defaultVariableNames :
+			self.assertEqual( a1s.numUniqueValues( n ), 1 )
+
+		self.assertFalse( a2["sum"] in m.allStatistics() )
+
+		with c, m :
+			c.setFrame( 10 )
+			a1["sum"].getValue()
+			a2["sum"].getValue()
+
+		a1s = m.plugStatistics( a1["sum"] )
+		self.assertEqual( a1s.numUniqueContexts(), 2 )
+		self.assertEqual( set( a1s.variableNames() ), set( defaultVariableNames ) )
+		for n in defaultVariableNames :
+			self.assertEqual( a1s.numUniqueValues( n ), 1 if n != "frame" else 2 )
+
+		a2s = m.plugStatistics( a2["sum"] )
+		self.assertEqual( a2s.numUniqueContexts(), 1 )
+		self.assertEqual( set( a2s.variableNames() ), set( defaultVariableNames ) )
+		for n in defaultVariableNames :
+			self.assertEqual( a2s.numUniqueValues( n ), 1 )
+
+		with c, m :
+			c["test"] = 10
+			a1["sum"].getValue()
+			c["test"] = 20
+			a2["sum"].getValue()
+
+		cs = m.combinedStatistics()
+		self.assertEqual( cs.numUniqueContexts(), 4 )
+		self.assertEqual( set( cs.variableNames() ), set( defaultVariableNames + [ "test" ] ) )
+		self.assertEqual( cs.numUniqueValues( "frame" ), 2 )
+		self.assertEqual( cs.numUniqueValues( "test" ), 2 )
+
+	def testRoot( self ) :
+
+		a1 = GafferTest.AddNode()
+		a2 = GafferTest.AddNode()
+
+		with Gaffer.Context() as c :
+			with Gaffer.ContextMonitor( a2 ) as m :
+				a1["sum"].getValue()
+				a2["sum"].getValue()
+
+		self.assertFalse( a1["sum"] in m.allStatistics() )
+		self.assertTrue( a2["sum"] in m.allStatistics() )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -130,6 +130,7 @@ from StatsApplicationTest import StatsApplicationTest
 from DownstreamIteratorTest import DownstreamIteratorTest
 from PerformanceMonitorTest import PerformanceMonitorTest
 from MetadataAlgoTest import MetadataAlgoTest
+from ContextMonitorTest import ContextMonitorTest
 
 if __name__ == "__main__":
 	import unittest

--- a/src/Gaffer/ContextMonitor.cpp
+++ b/src/Gaffer/ContextMonitor.cpp
@@ -1,0 +1,178 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/ContextMonitor.h"
+#include "Gaffer/Process.h"
+#include "Gaffer/Plug.h"
+#include "Gaffer/Context.h"
+
+using namespace std;
+using namespace IECore;
+using namespace Gaffer;
+
+static ContextMonitor::Statistics g_emptyStatistics;
+
+//////////////////////////////////////////////////////////////////////////
+// ContextMonitor::Statistics
+//////////////////////////////////////////////////////////////////////////
+
+size_t ContextMonitor::Statistics::numUniqueContexts() const
+{
+	return m_contexts.size();
+}
+
+std::vector<IECore::InternedString> ContextMonitor::Statistics::variableNames() const
+{
+	vector<InternedString> result;
+	for( VariableMap::const_iterator it = m_variables.begin(), eIt = m_variables.end(); it != eIt; ++it )
+	{
+		result.push_back( it->first );
+	}
+	return result;
+}
+
+size_t ContextMonitor::Statistics::numUniqueValues( IECore::InternedString variableName ) const
+{
+	VariableMap::const_iterator it = m_variables.find( variableName );
+	if( it != m_variables.end() )
+	{
+		return it->second.size();
+	}
+	return 0;
+}
+
+ContextMonitor::Statistics & ContextMonitor::Statistics::operator += ( const Context *context )
+{
+	m_contexts.insert( context->hash() );
+	vector<InternedString> names;
+	context->names( names );
+	for( vector<InternedString>::const_iterator it = names.begin(), eIt = names.end(); it != eIt; ++it )
+	{
+		const Data *d = context->get<Data>( *it );
+		m_variables[*it][d->Object::hash()] += 1;
+	}
+	return *this;
+}
+
+ContextMonitor::Statistics & ContextMonitor::Statistics::operator += ( const Statistics &rhs )
+{
+	m_contexts.insert( rhs.m_contexts.begin(), rhs.m_contexts.end() );
+	for( VariableMap::const_iterator it = rhs.m_variables.begin(), eIt = rhs.m_variables.end(); it != eIt; ++it )
+	{
+		CountingMap &c = m_variables[it->first];
+		for( CountingMap::const_iterator cIt = it->second.begin(), ceIt = it->second.end(); cIt != ceIt; ++cIt )
+		{
+			c[cIt->first] += cIt->second;
+		}
+	}
+	return *this;
+}
+
+bool ContextMonitor::Statistics::operator == ( const Statistics &rhs )
+{
+	return m_contexts == rhs.m_contexts && m_variables == rhs.m_variables;
+}
+
+bool ContextMonitor::Statistics::operator != ( const Statistics &rhs )
+{
+	return !( *this == rhs );
+}
+
+//////////////////////////////////////////////////////////////////////////
+// PerformanceMonitor
+//////////////////////////////////////////////////////////////////////////
+
+ContextMonitor::ContextMonitor( const GraphComponent *root )
+	:	m_root( root )
+{
+}
+
+ContextMonitor::~ContextMonitor()
+{
+}
+
+const ContextMonitor::StatisticsMap &ContextMonitor::allStatistics() const
+{
+	collate();
+	return m_statistics;
+}
+
+const ContextMonitor::Statistics &ContextMonitor::plugStatistics( const Plug *plug ) const
+{
+	collate();
+	StatisticsMap::const_iterator it = m_statistics.find( plug );
+	if( it == m_statistics.end() )
+	{
+		return g_emptyStatistics;
+	}
+	return it->second;
+}
+
+const ContextMonitor::Statistics &ContextMonitor::combinedStatistics() const
+{
+	collate();
+	return m_combinedStatistics;
+}
+
+void ContextMonitor::processStarted( const Process *process )
+{
+	if( m_root && m_root != process->plug() && !m_root->isAncestorOf( process->plug() ) )
+	{
+		return;
+	}
+	const Context *context = Context::current();
+	ThreadData &threadData = m_threadData.local();
+	threadData.statistics[process->plug()] += context;
+}
+
+void ContextMonitor::processFinished( const Process *process )
+{
+}
+
+void ContextMonitor::collate() const
+{
+	tbb::enumerable_thread_specific<ThreadData, tbb::cache_aligned_allocator<ThreadData>, tbb::ets_key_per_instance>::iterator it, eIt;
+	for( it = m_threadData.begin(), eIt = m_threadData.end(); it != eIt; ++it )
+	{
+		StatisticsMap &m = it->statistics;
+		for( StatisticsMap::const_iterator mIt = m.begin(), meIt = m.end(); mIt != meIt; ++mIt )
+		{
+			m_statistics[mIt->first] += mIt->second;
+			m_combinedStatistics += mIt->second;
+		}
+		m.clear();
+	}
+}

--- a/src/GafferBindings/MonitorBinding.cpp
+++ b/src/GafferBindings/MonitorBinding.cpp
@@ -39,6 +39,7 @@
 
 #include "Gaffer/Monitor.h"
 #include "Gaffer/PerformanceMonitor.h"
+#include "Gaffer/ContextMonitor.h"
 #include "Gaffer/MonitorAlgo.h"
 #include "Gaffer/Plug.h"
 
@@ -102,13 +103,25 @@ void setComputeDuration( PerformanceMonitor::Statistics &s, boost::chrono::nanos
 	s.computeDuration = boost::chrono::nanoseconds( v );
 }
 
-dict allStatistics( PerformanceMonitor &m )
+template<typename T>
+dict allStatistics( T &m )
 {
 	dict result;
-	const PerformanceMonitor::StatisticsMap &s = m.allStatistics();
-	for( PerformanceMonitor::StatisticsMap::const_iterator it = s.begin(), eIt = s.end(); it != eIt; ++it )
+	const typename T::StatisticsMap &s = m.allStatistics();
+	for( typename T::StatisticsMap::const_iterator it = s.begin(), eIt = s.end(); it != eIt; ++it )
 	{
 		result[boost::const_pointer_cast<Plug>( it->first)] = it->second;
+	}
+	return result;
+}
+
+list contextMonitorVariableNames( const ContextMonitor::Statistics &s )
+{
+	std::vector<IECore::InternedString> names = s.variableNames();
+	list result;
+	for( std::vector<IECore::InternedString>::const_iterator it = names.begin(), eIt = names.end(); it != eIt; ++it )
+	{
+		result.append( it->c_str() );
 	}
 	return result;
 }
@@ -156,28 +169,47 @@ void GafferBindings::bindMonitor()
 		.def( "__exit__", &exitScope )
 	;
 
-	scope s = class_<PerformanceMonitor, bases<Monitor>, boost::noncopyable >( "PerformanceMonitor" )
-		.def( "allStatistics", &allStatistics )
-		.def( "plugStatistics", &PerformanceMonitor::plugStatistics, return_value_policy<copy_const_reference>() )
-	;
+	{
+		scope s = class_<PerformanceMonitor, bases<Monitor>, boost::noncopyable >( "PerformanceMonitor" )
+			.def( "allStatistics", &allStatistics<PerformanceMonitor> )
+			.def( "plugStatistics", &PerformanceMonitor::plugStatistics, return_value_policy<copy_const_reference>() )
+		;
 
-	class_<PerformanceMonitor::Statistics>( "Statistics" )
-		.def( "__init__", make_constructor( statisticsConstructor, default_call_policies(),
-				(
-					arg( "hashCount" ) = 0,
-					arg( "computeCount" ) = 0,
-					arg( "hashDuration" ) = 0,
-					arg( "computeDuration" ) = 0
+		class_<PerformanceMonitor::Statistics>( "Statistics" )
+			.def( "__init__", make_constructor( statisticsConstructor, default_call_policies(),
+					(
+						arg( "hashCount" ) = 0,
+						arg( "computeCount" ) = 0,
+						arg( "hashDuration" ) = 0,
+						arg( "computeDuration" ) = 0
+					)
 				)
 			)
-		)
-		.def_readwrite( "hashCount", &PerformanceMonitor::Statistics::hashCount )
-		.def_readwrite( "computeCount", &PerformanceMonitor::Statistics::computeCount )
-		.add_property( "hashDuration", &getHashDuration, &setHashDuration )
-		.add_property( "computeDuration", &getComputeDuration, &setComputeDuration )
-		.def( self == self )
-		.def( self != self )
-		.def( "__repr__", &repr )
-	;
+			.def_readwrite( "hashCount", &PerformanceMonitor::Statistics::hashCount )
+			.def_readwrite( "computeCount", &PerformanceMonitor::Statistics::computeCount )
+			.add_property( "hashDuration", &getHashDuration, &setHashDuration )
+			.add_property( "computeDuration", &getComputeDuration, &setComputeDuration )
+			.def( self == self )
+			.def( self != self )
+			.def( "__repr__", &repr )
+		;
+	}
+
+	{
+		scope s = class_<ContextMonitor, bases<Monitor>, boost::noncopyable>( "ContextMonitor", no_init )
+			.def( init<const GraphComponent *>( arg( "root" ) = object() ) )
+			.def( "allStatistics", &allStatistics<ContextMonitor> )
+			.def( "plugStatistics", &ContextMonitor::plugStatistics, return_value_policy<copy_const_reference>() )
+			.def( "combinedStatistics", &ContextMonitor::combinedStatistics, return_value_policy<copy_const_reference>() )
+		;
+
+		class_<ContextMonitor::Statistics>( "Statistics" )
+			.def( "numUniqueContexts", &ContextMonitor::Statistics::numUniqueContexts )
+			.def( "variableNames", &contextMonitorVariableNames )
+			.def( "numUniqueValues", &ContextMonitor::Statistics::numUniqueValues )
+			.def( self == self )
+			.def( self != self )
+		;
+	}
 
 }


### PR DESCRIPTION
This adds a new monitor class to help in debugging and optimising. It records statistics about the number of unique contexts in which each plug is hashed/computed, and acts as a complement to the existing PerformanceMonitor. A common use pattern would be to use the PerformanceMonitor to note that a particular plug has an unexpectedly high hash/compute ratio, and then go in with the ContextMonitor to figure out which context variables were causing this.