### PR TITLE
Move Algo to namespaces

### DIFF
--- a/apps/screengrab/screengrab-1.py
+++ b/apps/screengrab/screengrab-1.py
@@ -337,7 +337,7 @@ class screengrab( Gaffer.Application ) :
 		)
 		for node in script.selection() :
 			for scenePlug in [ p for p in node.children( GafferScene.ScenePlug ) if p.direction() == Gaffer.Plug.Direction.Out ] :
-				GafferScene.matchingPaths( fullyExpandedPathsFilter, scenePlug, pathsToExpand )
+				GafferScene.SceneAlgo.matchingPaths( fullyExpandedPathsFilter, scenePlug, pathsToExpand )
 
 		script.context()["ui:scene:expandedPaths"] = GafferScene.PathMatcherData( pathsToExpand )
 		script.context()["ui:scene:selectedPaths"] = args["scene"]["selectedPaths"]

--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -370,7 +370,7 @@ class stats( Gaffer.Application ) :
 			self.__printItems( self.__timers.items() )
 
 			if self.__performanceMonitor is not None :
-				print "\n" + Gaffer.formatStatistics(
+				print "\n" + Gaffer.MonitorAlgo.formatStatistics(
 					self.__performanceMonitor,
 					maxLinesPerMetric = args["maxLinesPerMetric"].value
 				)

--- a/include/Gaffer/MatchPatternPathFilter.h
+++ b/include/Gaffer/MatchPatternPathFilter.h
@@ -54,13 +54,13 @@ class MatchPatternPathFilter : public Gaffer::PathFilter
 		/// one or more of the patterns (using StringAlgo match()).
 		/// If leafOnly is true then directories will always be passed
 		/// through.
-		MatchPatternPathFilter( const std::vector<MatchPattern> &patterns, IECore::InternedString propertyName = "name", bool leafOnly = true, IECore::CompoundDataPtr userData = NULL );
+		MatchPatternPathFilter( const std::vector<StringAlgo::MatchPattern> &patterns, IECore::InternedString propertyName = "name", bool leafOnly = true, IECore::CompoundDataPtr userData = NULL );
 		virtual ~MatchPatternPathFilter();
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::MatchPatternPathFilter, MatchPatternPathFilterTypeId, PathFilter );
 
-		void setMatchPatterns( const std::vector<MatchPattern> &patterns );
-		const std::vector<MatchPattern> &getMatchPatterns() const;
+		void setMatchPatterns( const std::vector<StringAlgo::MatchPattern> &patterns );
+		const std::vector<StringAlgo::MatchPattern> &getMatchPatterns() const;
 
 		void setPropertyName( IECore::InternedString propertyName );
 		IECore::InternedString getPropertyName() const;
@@ -80,7 +80,7 @@ class MatchPatternPathFilter : public Gaffer::PathFilter
 		bool invert( bool b ) const;
 		bool remove( PathPtr path ) const;
 
-		std::vector<MatchPattern> m_patterns;
+		std::vector<StringAlgo::MatchPattern> m_patterns;
 		IECore::InternedString m_propertyName;
 		bool m_leafOnly;
 		bool m_inverted;

--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -71,7 +71,7 @@ class Metadata
 		/// Type for a signal emitted when new plug metadata is registered. The
 		/// plug argument will be NULL when generic (rather than per-instance)
 		/// metadata is registered.
-		typedef boost::signal<void ( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, Gaffer::Plug *plug ), CatchingSignalCombiner<void> > PlugValueChangedSignal;
+		typedef boost::signal<void ( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key, Gaffer::Plug *plug ), CatchingSignalCombiner<void> > PlugValueChangedSignal;
 
 		typedef boost::function<IECore::ConstDataPtr ()> ValueFunction;
 		typedef boost::function<IECore::ConstDataPtr ( const Node *node )> NodeValueFunction;
@@ -93,10 +93,10 @@ class Metadata
 		static void registerValue( IECore::TypeId nodeTypeId, IECore::InternedString key, NodeValueFunction value );
 
 		/// Registers a static metadata value for plugs with the specified path on the specified node type.
-		static void registerValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value );
+		static void registerValue( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value );
 		/// Registers a dynamic metadata value for the specified plug. Each time the data is retrieved, the
 		/// PlugValueFunction will be called to compute it.
-		static void registerValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, PlugValueFunction value );
+		static void registerValue( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key, PlugValueFunction value );
 
 		/// Registers a metadata value specific to a single instance - this will take precedence over any
 		/// values registered above. If persistent is true, the value will be preserved across script save/load and cut/paste.
@@ -126,7 +126,7 @@ class Metadata
 		/// ====================
 
 		static void deregisterValue( IECore::TypeId nodeTypeId, IECore::InternedString key );
-		static void deregisterValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key );
+		static void deregisterValue( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key );
 		static void deregisterValue( GraphComponent *target, IECore::InternedString key );
 
 		/// Utilities
@@ -172,9 +172,9 @@ class Metadata
 		static void deregisterNodeValue( Node *node, IECore::InternedString key );
 
 		/// \deprecated
-		static void registerPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value );
+		static void registerPlugValue( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value );
 		/// \deprecated
-		static void registerPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, PlugValueFunction value );
+		static void registerPlugValue( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key, PlugValueFunction value );
 		/// \deprecated
 		static void registerPlugValue( Plug *plug, IECore::InternedString key, IECore::ConstDataPtr value, bool persistent = true );
 		/// \deprecated
@@ -183,7 +183,7 @@ class Metadata
 		template<typename T>
 		static typename T::ConstPtr plugValue( const Plug *plug, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
 		/// \deprecated
-		static void deregisterPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key );
+		static void deregisterPlugValue( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key );
 		/// \deprecated
 		static void deregisterPlugValue( Plug *plug, IECore::InternedString key );
 
@@ -195,9 +195,9 @@ class Metadata
 		static std::string nodeDescription( const Node *node, bool inherit = true );
 
 		/// \deprecated
-		static void registerPlugDescription( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, const std::string &description );
+		static void registerPlugDescription( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, const std::string &description );
 		/// \deprecated
-		static void registerPlugDescription( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, PlugValueFunction description );
+		static void registerPlugDescription( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, PlugValueFunction description );
 		/// \deprecated
 		static std::string plugDescription( const Plug *plug, bool inherit = true );
 

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -47,6 +47,9 @@ namespace Gaffer
 class GraphComponent;
 class Plug;
 
+namespace MetadataAlgo
+{
+
 /// Read-only-ness
 /// ==============
 ///
@@ -85,12 +88,17 @@ bool readOnly( const GraphComponent *graphComponent );
 
 /// Utility to determine if a metadata value change (as signalled by `Metadata::plugValueChangedSignal()`)
 /// affects a given plug.
-bool affectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
+bool affectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
 /// As above, but determines if any child plug will be affected.
-bool childAffectedByChange( const GraphComponent *parent, IECore::TypeId changedNodeTypeId, const MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
+bool childAffectedByChange( const GraphComponent *parent, IECore::TypeId changedNodeTypeId, const StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
 /// As above, but determines if any ancestor plug will be affected. This is particularly useful in conjunction with
 /// the `readOnly()` method.
-bool ancestorAffectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
+bool ancestorAffectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
+
+} // namespace MetadataAlgo
+
+/// \todo Remove this temporary backwards compatibility.
+using namespace MetadataAlgo;
 
 } // namespace Gaffer
 

--- a/include/Gaffer/MonitorAlgo.h
+++ b/include/Gaffer/MonitorAlgo.h
@@ -44,6 +44,9 @@ namespace Gaffer
 
 class PerformanceMonitor;
 
+namespace MonitorAlgo
+{
+
 enum PerformanceMetric
 {
 	Invalid,
@@ -62,6 +65,11 @@ enum PerformanceMetric
 
 std::string formatStatistics( const PerformanceMonitor &monitor, size_t maxLinesPerMetric = 50 );
 std::string formatStatistics( const PerformanceMonitor &monitor, PerformanceMetric metric, size_t maxLines = 50 );
+
+} // namespace MonitorAlgo
+
+/// \todo Remove this temporary backwards compatibility.
+using namespace MonitorAlgo;
 
 } // namespace Gaffer
 

--- a/include/Gaffer/StringAlgo.h
+++ b/include/Gaffer/StringAlgo.h
@@ -43,6 +43,9 @@
 namespace Gaffer
 {
 
+namespace StringAlgo
+{
+
 /// A type which can be used to store a pattern to be matched against.
 /// Note that the match() function can actually operate on other string
 /// types as well so the use of this type is purely optional. The main
@@ -80,6 +83,11 @@ template<typename TokenType, typename OutputIterator>
 void tokenize( const std::string &s, const char separator, OutputIterator outputIterator );
 template<typename OutputContainer>
 void tokenize( const std::string &s, const char separator, OutputContainer &outputContainer );
+
+} // namespace StringAlgo
+
+/// \todo Remove this temporary backwards compatibility.
+using namespace StringAlgo;
 
 } // namespace Gaffer
 

--- a/include/Gaffer/StringAlgo.inl
+++ b/include/Gaffer/StringAlgo.inl
@@ -117,6 +117,9 @@ inline bool matchInternal( const char * const ss, const char *pattern, bool mult
 
 } // namespace Detail
 
+namespace StringAlgo
+{
+
 inline bool match( const std::string &string, const std::string &pattern )
 {
 	return match( string.c_str(), pattern.c_str() );
@@ -169,6 +172,8 @@ void tokenize( const std::string &s, const char separator, OutputContainer &outp
 {
 	tokenize<typename OutputContainer::value_type>( s, separator, std::back_inserter( outputContainer ) );
 }
+
+} // namespace StringAlgo
 
 } // namespace Gaffer
 

--- a/include/GafferBindings/ComputeNodeBinding.h
+++ b/include/GafferBindings/ComputeNodeBinding.h
@@ -102,7 +102,7 @@ class ComputeNodeWrapper : public DependencyNodeWrapper<WrappedType>
 				}
 				catch( const boost::python::error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 		}
@@ -123,7 +123,7 @@ class ComputeNodeWrapper : public DependencyNodeWrapper<WrappedType>
 				}
 				catch( const boost::python::error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 			WrappedType::compute( output, context );

--- a/include/GafferBindings/DependencyNodeBinding.h
+++ b/include/GafferBindings/DependencyNodeBinding.h
@@ -115,7 +115,7 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 				}
 				catch( const boost::python::error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 			WrappedType::affects( input, outputs );
@@ -136,7 +136,7 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 				}
 				catch( const boost::python::error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 			return WrappedType::enabledPlug();
@@ -166,7 +166,7 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 				}
 				catch( const boost::python::error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 			return WrappedType::correspondingInput( output );

--- a/include/GafferBindings/ExceptionAlgo.h
+++ b/include/GafferBindings/ExceptionAlgo.h
@@ -40,6 +40,9 @@
 namespace GafferBindings
 {
 
+namespace ExceptionAlgo
+{
+
 /// Formats the current python exception using the traceback module,
 /// and returns it in the form of a string. If lineNumber is provided, it
 /// will be filled with the number of the line where the error occurred.
@@ -50,6 +53,11 @@ std::string formatPythonException( bool withStacktrace = true, int *lineNumber =
 /// boost::python::error_already_set.
 /// \todo Maybe this should be moved to IECorePython?
 void translatePythonException( bool withStacktrace = true );
+
+} // namespace ExceptionAlgo
+
+/// \todo Remove this temporary backwards compatibility.
+using namespace ExceptionAlgo;
 
 } // namespace GafferBindings
 

--- a/include/GafferBindings/SignalBinding.inl
+++ b/include/GafferBindings/SignalBinding.inl
@@ -210,7 +210,7 @@ struct SlotBase<0, Signal, Caller>
 		}
 		catch( const boost::python::error_already_set& e )
 		{
-			translatePythonException();
+			ExceptionAlgo::translatePythonException();
 		}
 		return typename Signal::slot_result_type();
 	}
@@ -242,7 +242,7 @@ struct SlotBase<1, Signal, Caller>
 		}
 		catch( const boost::python::error_already_set& e )
 		{
-			translatePythonException();
+			ExceptionAlgo::translatePythonException();
 		}
 		return typename Signal::slot_result_type();
 	}
@@ -274,7 +274,7 @@ struct SlotBase<2, Signal, Caller>
 		}
 		catch( const boost::python::error_already_set& e )
 		{
-			translatePythonException();
+			ExceptionAlgo::translatePythonException();
 		}
 		return typename Signal::slot_result_type();
 	}
@@ -306,7 +306,7 @@ struct SlotBase<3, Signal, Caller>
 		}
 		catch( const boost::python::error_already_set& e )
 		{
-			translatePythonException();
+			ExceptionAlgo::translatePythonException();
 		}
 		return typename Signal::slot_result_type();
 	}
@@ -338,7 +338,7 @@ struct SlotBase<4, Signal, Caller>
 		}
 		catch( const boost::python::error_already_set& e )
 		{
-			translatePythonException();
+			ExceptionAlgo::translatePythonException();
 		}
 		return typename Signal::slot_result_type();
 	}

--- a/include/GafferCortexBindings/ParameterisedHolderBinding.h
+++ b/include/GafferCortexBindings/ParameterisedHolderBinding.h
@@ -92,7 +92,7 @@ class ParameterisedHolderWrapper : public BaseType
 				}
 				catch( boost::python::error_already_set &e )
 				{
-					GafferBindings::translatePythonException();
+					GafferBindings::ExceptionAlgo::translatePythonException();
 				}
 			}
 		}

--- a/include/GafferDispatchBindings/TaskNodeBinding.h
+++ b/include/GafferDispatchBindings/TaskNodeBinding.h
@@ -95,7 +95,7 @@ class TaskNodeWrapper : public GafferBindings::NodeWrapper<WrappedType>
 				}
 				catch( const boost::python::error_already_set &e )
 				{
-					GafferBindings::translatePythonException();
+					GafferBindings::ExceptionAlgo::translatePythonException();
 				}
 			}
 			WrappedType::preTasks( context, tasks );
@@ -120,7 +120,7 @@ class TaskNodeWrapper : public GafferBindings::NodeWrapper<WrappedType>
 				}
 				catch( const boost::python::error_already_set &e )
 				{
-					GafferBindings::translatePythonException();
+					GafferBindings::ExceptionAlgo::translatePythonException();
 				}
 			}
 			WrappedType::postTasks( context, tasks );
@@ -143,7 +143,7 @@ class TaskNodeWrapper : public GafferBindings::NodeWrapper<WrappedType>
 				}
 				catch( const boost::python::error_already_set &e )
 				{
-					GafferBindings::translatePythonException();
+					GafferBindings::ExceptionAlgo::translatePythonException();
 				}
 			}
 			return WrappedType::hash( context );
@@ -165,7 +165,7 @@ class TaskNodeWrapper : public GafferBindings::NodeWrapper<WrappedType>
 				}
 				catch( const boost::python::error_already_set &e )
 				{
-					GafferBindings::translatePythonException();
+					GafferBindings::ExceptionAlgo::translatePythonException();
 				}
 			}
 			WrappedType::execute();
@@ -192,7 +192,7 @@ class TaskNodeWrapper : public GafferBindings::NodeWrapper<WrappedType>
 				}
 				catch( const boost::python::error_already_set &e )
 				{
-					GafferBindings::translatePythonException();
+					GafferBindings::ExceptionAlgo::translatePythonException();
 				}
 			}
 			WrappedType::executeSequence( frames );
@@ -213,7 +213,7 @@ class TaskNodeWrapper : public GafferBindings::NodeWrapper<WrappedType>
 				}
 				catch( const boost::python::error_already_set &e )
 				{
-					GafferBindings::translatePythonException();
+					GafferBindings::ExceptionAlgo::translatePythonException();
 				}
 			}
 			return WrappedType::requiresSequenceExecution();

--- a/include/GafferImage/BufferAlgo.h
+++ b/include/GafferImage/BufferAlgo.h
@@ -42,6 +42,9 @@
 namespace GafferImage
 {
 
+namespace BufferAlgo
+{
+
 /// Image window utility functions. The GafferImage convention is that
 /// the minimum coordinate is included within the window and the
 /// maximum coordinate is outside it - these functions take that into
@@ -68,6 +71,11 @@ inline Imath::V2i clamp( const Imath::V2i &point, const Imath::Box2i &window );
 
 /// Returns the index of point p within a buffer with bounds b.
 inline size_t index( const Imath::V2i &p, const Imath::Box2i &b );
+
+} // namespace BufferAlgo
+
+/// \todo Remove this temporary backwards compatibility.
+using namespace BufferAlgo;
 
 } // namespace GafferImage
 

--- a/include/GafferImage/BufferAlgo.inl
+++ b/include/GafferImage/BufferAlgo.inl
@@ -42,6 +42,9 @@
 namespace GafferImage
 {
 
+namespace BufferAlgo
+{
+
 //////////////////////////////////////////////////////////////////////////
 // Window/Box utilities
 //////////////////////////////////////////////////////////////////////////
@@ -125,6 +128,8 @@ inline size_t index( const Imath::V2i &p, const Imath::Box2i &b )
 		( p.y - b.min.y ) * b.size().x +
 		( p.x - b.min.x );
 }
+
+} // namespace BufferAlgo
 
 } // namespace GafferImage
 

--- a/include/GafferImage/Format.inl
+++ b/include/GafferImage/Format.inl
@@ -150,7 +150,7 @@ inline Imath::V2i Format::toEXRSpace( const Imath::V2i &internalSpace ) const
 
 inline Imath::Box2i Format::toEXRSpace( const Imath::Box2i &internalSpace ) const
 {
-	if( empty( internalSpace ) )
+	if( BufferAlgo::empty( internalSpace ) )
 	{
 		return Imath::Box2i();
 	}

--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -45,6 +45,9 @@ namespace GafferImage
 
 class ImagePlug;
 
+namespace ImageAlgo
+{
+
 /// Channel name utility functions.
 ///
 /// Gaffer follows the OpenEXR convention for channel names, as documented at
@@ -130,6 +133,11 @@ void parallelGatherTiles(
 	const Imath::Box2i &window = Imath::Box2i(), // Uses dataWindow if not specified.
 	TileOrder tileOrder = Unordered
 );
+
+} // namespace ImageAlgo
+
+/// \todo Remove this temporary backwards compatibility.
+using namespace ImageAlgo;
 
 } // namespace GafferImage
 

--- a/include/GafferImage/ImageAlgo.inl
+++ b/include/GafferImage/ImageAlgo.inl
@@ -140,13 +140,13 @@ class TileInputIterator
 
 		TileInputIterator(
 				const Imath::V2i &numTiles,
-				const TileOrder tileOrder
+				const ImageAlgo::TileOrder tileOrder
 			) :
 				m_numTiles( numTiles ),
 				m_tileOrder( tileOrder ),
 				nextTileId( Imath::V2i( 0 ) )
 		{
-			if( m_tileOrder == TopToBottom )
+			if( m_tileOrder == ImageAlgo::TopToBottom )
 			{
 				nextTileId.y = m_numTiles.y - 1;
 			}
@@ -154,7 +154,7 @@ class TileInputIterator
 
 		bool finished()
 		{
-			if( m_tileOrder == TopToBottom )
+			if( m_tileOrder == ImageAlgo::TopToBottom )
 			{
 				return nextTileId.y < 0;
 			}
@@ -172,7 +172,7 @@ class TileInputIterator
 			if( nextTileId.x >= m_numTiles.x )
 			{
 				nextTileId.x = 0;
-				if( m_tileOrder == TopToBottom )
+				if( m_tileOrder == ImageAlgo::TopToBottom )
 				{
 					--nextTileId.y;
 				}
@@ -187,7 +187,7 @@ class TileInputIterator
 
 	private:
 		const Imath::V2i &m_numTiles;
-		const TileOrder m_tileOrder;
+		const ImageAlgo::TileOrder m_tileOrder;
 		Imath::V2i nextTileId;
 };
 
@@ -199,7 +199,7 @@ class TileChannelInputIterator
 		TileChannelInputIterator(
 				const std::vector<std::string> &channelNames,
 				const Imath::V2i &numTiles,
-				const TileOrder tileOrder
+				const ImageAlgo::TileOrder tileOrder
 			) :
 				m_channelNames( channelNames ),
 				m_numTiles( numTiles ),
@@ -207,7 +207,7 @@ class TileChannelInputIterator
 				nextTileId( Imath::V2i( 0 ) ),
 				nextChannelIndex( 0 )
 		{
-			if( m_tileOrder == TopToBottom )
+			if( m_tileOrder == ImageAlgo::TopToBottom )
 			{
 				nextTileId.y = m_numTiles.y - 1;
 			}
@@ -215,7 +215,7 @@ class TileChannelInputIterator
 
 		bool finished()
 		{
-			if( m_tileOrder == TopToBottom )
+			if( m_tileOrder == ImageAlgo::TopToBottom )
 			{
 				return nextTileId.y < 0;
 			}
@@ -239,7 +239,7 @@ class TileChannelInputIterator
 				if( nextTileId.x >= m_numTiles.x )
 				{
 					nextTileId.x = 0;
-					if( m_tileOrder == TopToBottom )
+					if( m_tileOrder == ImageAlgo::TopToBottom )
 					{
 						--nextTileId.y;
 					}
@@ -256,7 +256,7 @@ class TileChannelInputIterator
 	private:
 		const std::vector<std::string> &m_channelNames;
 		const Imath::V2i &m_numTiles;
-		const TileOrder m_tileOrder;
+		const ImageAlgo::TileOrder m_tileOrder;
 		Imath::V2i nextTileId;
 		size_t nextChannelIndex;
 
@@ -416,6 +416,9 @@ class GatherFunctorFilter
 // Channel name utilities
 //////////////////////////////////////////////////////////////////////////
 
+namespace ImageAlgo
+{
+
 inline std::string layerName( const std::string &channelName )
 {
 	const size_t p = channelName.find_last_of( '.' );
@@ -496,10 +499,10 @@ template <class ThreadableFunctor>
 void parallelProcessTiles( const ImagePlug *imagePlug, ThreadableFunctor &functor, const Imath::Box2i &window )
 {
 	Imath::Box2i processWindow = window;
-	if( empty( processWindow ) )
+	if( BufferAlgo::empty( processWindow ) )
 	{
 		processWindow = imagePlug->dataWindowPlug()->getValue();
-		if( empty( processWindow ) )
+		if( BufferAlgo::empty( processWindow ) )
 		{
 			return;
 		}
@@ -516,10 +519,10 @@ template <class ThreadableFunctor>
 void parallelProcessTiles( const ImagePlug *imagePlug, const std::vector<std::string> &channelNames, ThreadableFunctor &functor, const Imath::Box2i &window )
 {
 	Imath::Box2i processWindow = window;
-	if( empty( processWindow ) )
+	if( BufferAlgo::empty( processWindow ) )
 	{
 		processWindow = imagePlug->dataWindowPlug()->getValue();
-		if( empty( processWindow ) )
+		if( BufferAlgo::empty( processWindow ) )
 		{
 			return;
 		}
@@ -536,10 +539,10 @@ template <class TileFunctor, class GatherFunctor>
 void parallelGatherTiles( const ImagePlug *imagePlug, TileFunctor &tileFunctor, GatherFunctor &gatherFunctor, const Imath::Box2i &window, TileOrder tileOrder )
 {
 	Imath::Box2i processWindow = window;
-	if( empty( processWindow ) )
+	if( BufferAlgo::empty( processWindow ) )
 	{
 		processWindow = imagePlug->dataWindowPlug()->getValue();
-		if( empty( processWindow ) )
+		if( BufferAlgo::empty( processWindow ) )
 		{
 			return;
 		}
@@ -570,10 +573,10 @@ template <class TileFunctor, class GatherFunctor>
 void parallelGatherTiles( const ImagePlug *imagePlug, const std::vector<std::string> &channelNames, TileFunctor &tileFunctor, GatherFunctor &gatherFunctor, const Imath::Box2i &window, TileOrder tileOrder )
 {
 	Imath::Box2i processWindow = window;
-	if( empty( processWindow ) )
+	if( BufferAlgo::empty( processWindow ) )
 	{
 		processWindow = imagePlug->dataWindowPlug()->getValue();
-		if( empty( processWindow ) )
+		if( BufferAlgo::empty( processWindow ) )
 		{
 			return;
 		}
@@ -599,6 +602,8 @@ void parallelGatherTiles( const ImagePlug *imagePlug, const std::vector<std::str
 		)
 	);
 }
+
+} // namespace ImageAlgo
 
 } // namespace GafferImage
 

--- a/include/GafferImage/Sampler.inl
+++ b/include/GafferImage/Sampler.inl
@@ -49,22 +49,22 @@ float Sampler::sample( int x, int y )
 
 	// It is the caller's responsibility to ensure that sampling
 	// is only performed within the sample window.
-	assert( contains( m_sampleWindow, p ) );
+	assert( BufferAlgo::contains( m_sampleWindow, p ) );
 
 #endif
 
 	// Deal with lookups outside of the data window.
-	if( m_boundingMode == Black && !contains( m_dataWindow, p ) )
+	if( m_boundingMode == Black && !BufferAlgo::contains( m_dataWindow, p ) )
 	{
 		return 0.0f;
 	}
 	else
 	{
-		if( empty( m_dataWindow ) )
+		if( BufferAlgo::empty( m_dataWindow ) )
 		{
 			return 0.0f;
 		}
-		p = clamp( p, m_dataWindow );
+		p = BufferAlgo::clamp( p, m_dataWindow );
 	}
 
 	const float *tileData;

--- a/include/GafferScene/Preview/InteractiveRender.h
+++ b/include/GafferScene/Preview/InteractiveRender.h
@@ -121,7 +121,7 @@ class InteractiveRender : public Gaffer::Node
 		State m_state;
 		unsigned m_dirtyComponents;
 		IECore::ConstCompoundObjectPtr m_globals;
-		GafferScene::Preview::RenderSets m_renderSets;
+		GafferScene::Preview::RendererAlgo::RenderSets m_renderSets;
 		IECoreScenePreview::Renderer::ObjectInterfacePtr m_defaultCamera;
 
 		Gaffer::ContextPtr m_context; // Accessed with setContext()/getContext()

--- a/include/GafferScene/Preview/RendererAlgo.h
+++ b/include/GafferScene/Preview/RendererAlgo.h
@@ -52,6 +52,9 @@ IE_CORE_FORWARDDECLARE( ScenePlug )
 namespace Preview
 {
 
+namespace RendererAlgo
+{
+
 void outputOptions( const IECore::CompoundObject *globals, IECoreScenePreview::Renderer *renderer );
 void outputOptions( const IECore::CompoundObject *globals, const IECore::CompoundObject *previousGlobals, IECoreScenePreview::Renderer *renderer );
 
@@ -111,6 +114,11 @@ void outputObjects( const ScenePlug *scene, const IECore::CompoundObject *global
 
 /// Applies the resolution, aspect ratio etc from the globals to the camera.
 void applyCameraGlobals( IECore::Camera *camera, const IECore::CompoundObject *globals );
+
+} // namespace RendererAlgo
+
+/// \todo Remove this temporary backwards compatibility.
+using namespace RendererAlgo;
 
 } // namespace Preview
 

--- a/include/GafferScene/RendererAlgo.h
+++ b/include/GafferScene/RendererAlgo.h
@@ -47,6 +47,9 @@
 namespace GafferScene
 {
 
+namespace RendererAlgo
+{
+
 /// Outputs an entire scene, using a SceneProcedural for the main body of the world.
 /// Individual parts of a scene may be output more specifically using the methods below.
 void outputScene( const ScenePlug *scene, IECore::Renderer *renderer );
@@ -114,6 +117,11 @@ void objectSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &s
 
 /// Outputs the object for the current location, using objectSamples() to generate the samples.
 void outputObject( const ScenePlug *scene, IECore::Renderer *renderer, size_t segments = 0, const Imath::V2f &shutter = Imath::V2i( 0 ) );
+
+} // namespace RendererAlgo
+
+/// \todo Remove this temporary backwards compatibility.
+using namespace RendererAlgo;
 
 } // namespace GafferScene
 

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -57,6 +57,9 @@ namespace GafferScene
 class Filter;
 class PathMatcher;
 
+namespace SceneAlgo
+{
+
 /// Returns true if the specified location exists within the scene, and false otherwise.
 /// This operates by traversing the path from the root, ensuring that each location includes
 /// the next path element within its child names.
@@ -125,6 +128,11 @@ IECore::ConstCompoundDataPtr sets( const ScenePlug *scene, const std::vector<IEC
 /// this is provided by the VisibleRenderable::bound() method, but
 /// for other object types we must return a synthetic bound.
 Imath::Box3f bound( const IECore::Object *object );
+
+} // namespace SceneAlgo
+
+/// \todo Remove this temporary backwards compatibility.
+using namespace SceneAlgo;
 
 } // namespace GafferScene
 

--- a/include/GafferScene/SceneAlgo.inl
+++ b/include/GafferScene/SceneAlgo.inl
@@ -165,6 +165,9 @@ struct PathMatcherFunctor
 
 } // namespace Detail
 
+namespace SceneAlgo
+{
+
 template <class ThreadableFunctor>
 void parallelTraverse( const GafferScene::ScenePlug *scene, ThreadableFunctor &f )
 {
@@ -193,5 +196,7 @@ void filteredParallelTraverse( const ScenePlug *scene, const PathMatcher &filter
 	Detail::PathMatcherFunctor<ThreadableFunctor> ff( f, filter );
 	parallelTraverse( scene, ff );
 }
+
+} // namespace SceneAlgo
 
 } // namespace GafferScene

--- a/include/GafferUI/CompoundNodule.h
+++ b/include/GafferUI/CompoundNodule.h
@@ -86,7 +86,7 @@ class CompoundNodule : public Nodule
 		void childAdded( Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
 		void childRemoved( Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
 
-		void plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
+		void plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
 
 		typedef std::map<const Gaffer::Plug *, Nodule *> NoduleMap;
 		NoduleMap m_nodules;

--- a/include/GafferUI/StandardConnectionGadget.h
+++ b/include/GafferUI/StandardConnectionGadget.h
@@ -88,7 +88,7 @@ class StandardConnectionGadget : public ConnectionGadget
 
 		bool nodeSelected( const Nodule *nodule ) const;
 
-		void plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
+		void plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
 
 		bool updateUserColor();
 

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -147,7 +147,7 @@ class StandardNodeGadget : public NodeGadget
 		bool noduleIsCompatible( const Nodule *nodule, const DragDropEvent &event ) const;
 		bool plugAdderIsCompatible( const PlugAdder *plugAdder, const DragDropEvent &event ) const;
 
-		void plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
+		void plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
 		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node );
 
 		void updateNodules( std::vector<Nodule *> &nodules, std::vector<Nodule *> &added, std::vector<NodulePtr> &removed );

--- a/include/GafferUI/StandardNodule.h
+++ b/include/GafferUI/StandardNodule.h
@@ -89,7 +89,7 @@ class StandardNodule : public Nodule
 
 	private :
 
-		void plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
+		void plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
 
 		bool updateUserColor();
 

--- a/python/GafferImageTest/BufferAlgoTest.py
+++ b/python/GafferImageTest/BufferAlgoTest.py
@@ -46,34 +46,34 @@ class BufferAlgoTest( GafferImageTest.ImageTestCase ) :
 
 	def testEmpty( self ) :
 
-		self.assertTrue( GafferImage.empty( IECore.Box2i() ) )
-		self.assertTrue( GafferImage.empty( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 0 ) ) ) )
-		self.assertFalse( GafferImage.empty( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 1 ) ) ) )
-		self.assertTrue( GafferImage.empty( IECore.Box2i( IECore.V2i( 2147483646 ), IECore.V2i( -2147483646 ) ) ) )
-		self.assertTrue( GafferImage.empty( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( -2147483647 ) ) ) )
-		self.assertTrue( GafferImage.empty( IECore.Box2i( IECore.V2i( 2147483647 ), IECore.V2i( 0 ) ) ) )
-		self.assertTrue( GafferImage.empty( IECore.Box2i( IECore.V2i( -1 ), IECore.V2i( -2147483647 ) ) ) )
-		self.assertTrue( GafferImage.empty( IECore.Box2i( IECore.V2i( 2147483647 ), IECore.V2i( 1 ) ) ) )
-		self.assertTrue( GafferImage.empty( IECore.Box2i( IECore.V2i( 1 ), IECore.V2i( -2147483647 ) ) ) )
-		self.assertTrue( GafferImage.empty( IECore.Box2i( IECore.V2i( 2147483647 ), IECore.V2i( -1 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i() ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 0 ) ) ) )
+		self.assertFalse( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 1 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 2147483646 ), IECore.V2i( -2147483646 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( -2147483647 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 2147483647 ), IECore.V2i( 0 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( -1 ), IECore.V2i( -2147483647 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 2147483647 ), IECore.V2i( 1 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 1 ), IECore.V2i( -2147483647 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 2147483647 ), IECore.V2i( -1 ) ) ) )
 
 	def testIntersects( self ) :
 
 		self.assertFalse(
-			GafferImage.intersects(
+			GafferImage.BufferAlgo.intersects(
 				IECore.Box2i(), IECore.Box2i()
 			)
 		)
 
 		self.assertFalse(
-			GafferImage.intersects(
+			GafferImage.BufferAlgo.intersects(
 				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) ),
 				IECore.Box2i( IECore.V2i( 10 ), IECore.V2i( 20 ) ),
 			)
 		)
 
 		self.assertTrue(
-			GafferImage.intersects(
+			GafferImage.BufferAlgo.intersects(
 				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) ),
 				IECore.Box2i( IECore.V2i( 9 ), IECore.V2i( 20 ) ),
 			)
@@ -82,7 +82,7 @@ class BufferAlgoTest( GafferImageTest.ImageTestCase ) :
 	def testIntersection( self ) :
 
 		self.assertEqual(
-			GafferImage.intersection(
+			GafferImage.BufferAlgo.intersection(
 				IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 9, 10 ) ),
 				IECore.Box2i( IECore.V2i( 2, 0 ), IECore.V2i( 8, 29 ) ),
 			),
@@ -95,28 +95,28 @@ class BufferAlgoTest( GafferImageTest.ImageTestCase ) :
 	def testContains( self ) :
 
 		self.assertFalse(
-			GafferImage.contains(
+			GafferImage.BufferAlgo.contains(
 				IECore.Box2i(),
 				IECore.V2i( 0 )
 			)
 		)
 
 		self.assertFalse(
-			GafferImage.contains(
+			GafferImage.BufferAlgo.contains(
 				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 0 ) ),
 				IECore.V2i( 0 )
 			)
 		)
 
 		self.assertFalse(
-			GafferImage.contains(
+			GafferImage.BufferAlgo.contains(
 				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 1 ) ),
 				IECore.V2i( 1 )
 			)
 		)
 
 		self.assertTrue(
-			GafferImage.contains(
+			GafferImage.BufferAlgo.contains(
 				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 1 ) ),
 				IECore.V2i( 0 )
 			)
@@ -125,7 +125,7 @@ class BufferAlgoTest( GafferImageTest.ImageTestCase ) :
 	def testClamp( self ) :
 
 		self.assertEqual(
-			GafferImage.clamp(
+			GafferImage.BufferAlgo.clamp(
 				IECore.V2i( 5, 6 ),
 				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) )
 			),
@@ -133,7 +133,7 @@ class BufferAlgoTest( GafferImageTest.ImageTestCase ) :
 		)
 
 		self.assertEqual(
-			GafferImage.clamp(
+			GafferImage.BufferAlgo.clamp(
 				IECore.V2i( 10, 6 ),
 				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) )
 			),
@@ -141,7 +141,7 @@ class BufferAlgoTest( GafferImageTest.ImageTestCase ) :
 		)
 
 		self.assertEqual(
-			GafferImage.clamp(
+			GafferImage.BufferAlgo.clamp(
 				IECore.V2i( 0, 6 ),
 				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) )
 			),
@@ -149,7 +149,7 @@ class BufferAlgoTest( GafferImageTest.ImageTestCase ) :
 		)
 
 		self.assertEqual(
-			GafferImage.clamp(
+			GafferImage.BufferAlgo.clamp(
 				IECore.V2i( 5, -1 ),
 				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) )
 			),
@@ -157,7 +157,7 @@ class BufferAlgoTest( GafferImageTest.ImageTestCase ) :
 		)
 
 		self.assertEqual(
-			GafferImage.clamp(
+			GafferImage.BufferAlgo.clamp(
 				IECore.V2i( 5, 10 ),
 				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) )
 			),

--- a/python/GafferImageTest/FormatPlugTest.py
+++ b/python/GafferImageTest/FormatPlugTest.py
@@ -94,7 +94,7 @@ class FormatPlugTest( GafferImageTest.ImageTestCase ) :
 			# Even if we haven't specified a default context, we should still
 			# be given something.
 			self.assertFalse(
-				GafferImage.empty(
+				GafferImage.BufferAlgo.empty(
 					constant["out"]["format"].getValue().getDisplayWindow()
 				)
 			)
@@ -139,7 +139,7 @@ class FormatPlugTest( GafferImageTest.ImageTestCase ) :
 		with s.context() :
 
 			self.assertFalse(
-				GafferImage.empty(
+				GafferImage.BufferAlgo.empty(
 					s["c"]["out"]["format"].getValue().getDisplayWindow()
 				)
 			)

--- a/python/GafferImageTest/FormatTest.py
+++ b/python/GafferImageTest/FormatTest.py
@@ -149,7 +149,7 @@ class FormatTest( GafferImageTest.ImageTestCase ) :
 			b.extendBy( IECore.V2i( int( random.uniform( -500, 500 ) ), int( random.uniform( -500, 500 ) ) ) )
 
 			bDown = f.toEXRSpace( b )
-			if not GafferImage.empty( b ) :
+			if not GafferImage.BufferAlgo.empty( b ) :
 				self.assertEqual( f.fromEXRSpace( bDown ), b )
 			else :
 				self.assertEqual( f.fromEXRSpace( bDown ), IECore.Box2i() )

--- a/python/GafferImageTest/ImageAlgoTest.py
+++ b/python/GafferImageTest/ImageAlgoTest.py
@@ -55,7 +55,7 @@ class ImageAlgoTest( GafferImageTest.ImageTestCase ) :
 			( "right.myFunkyChannel", "right" ),
 			( "diffuse.left.R", "diffuse.left" ),
 		] :
-			self.assertEqual( GafferImage.layerName( channelName ), layerName )
+			self.assertEqual( GafferImage.ImageAlgo.layerName( channelName ), layerName )
 
 	def testBaseName( self ) :
 
@@ -68,7 +68,7 @@ class ImageAlgoTest( GafferImageTest.ImageTestCase ) :
 			( "right.myFunkyChannel", "myFunkyChannel" ),
 			( "diffuse.left.R", "R" ),
 		] :
-			self.assertEqual( GafferImage.baseName( channelName ), baseName )
+			self.assertEqual( GafferImage.ImageAlgo.baseName( channelName ), baseName )
 
 	def testColorIndex( self ) :
 
@@ -91,7 +91,7 @@ class ImageAlgoTest( GafferImageTest.ImageTestCase ) :
 			( "diffuse.left.A", 3 ),
 			( "diffuse.left.Z", -1 ),
 		] :
-			self.assertEqual( GafferImage.colorIndex( channelName ), index )
+			self.assertEqual( GafferImage.ImageAlgo.colorIndex( channelName ), index )
 
 	def testChannelExists( self ) :
 
@@ -102,14 +102,14 @@ class ImageAlgoTest( GafferImageTest.ImageTestCase ) :
 		d["mode"].setValue( GafferImage.DeleteChannels.Mode.Delete )
 		d["channels"].setValue( IECore.StringVectorData( [] ) )
 
-		self.assertTrue( GafferImage.channelExists( d["out"], "R" ) )
-		self.assertTrue( GafferImage.channelExists( d["out"], "G" ) )
-		self.assertTrue( GafferImage.channelExists( d["out"], "B" ) )
-		self.assertTrue( GafferImage.channelExists( d["out"], "A" ) )
+		self.assertTrue( GafferImage.ImageAlgo.channelExists( d["out"], "R" ) )
+		self.assertTrue( GafferImage.ImageAlgo.channelExists( d["out"], "G" ) )
+		self.assertTrue( GafferImage.ImageAlgo.channelExists( d["out"], "B" ) )
+		self.assertTrue( GafferImage.ImageAlgo.channelExists( d["out"], "A" ) )
 
 		for chan in [ "R", "G", "B", "A" ] :
 			d["channels"].setValue( IECore.StringVectorData( [ chan ] ) )
-			self.assertFalse( GafferImage.channelExists( d["out"], chan ) )
+			self.assertFalse( GafferImage.ImageAlgo.channelExists( d["out"], chan ) )
 
 	def testChannelExistsBindings( self ) :
 
@@ -124,7 +124,7 @@ class ImageAlgoTest( GafferImageTest.ImageTestCase ) :
 		d["channels"].setValue( IECore.StringVectorData( [ "R", "A" ] ) )
 
 		for chan in [ "R", "G", "B", "A" ] :
-			self.assertEqual( GafferImage.channelExists( d["out"], chan ), GafferImage.channelExists( d["out"]["channelNames"].getValue(), chan ) )
+			self.assertEqual( GafferImage.ImageAlgo.channelExists( d["out"], chan ), GafferImage.ImageAlgo.channelExists( d["out"]["channelNames"].getValue(), chan ) )
 
 	def testParallelProcessEmptyDataWindow( self ) :
 

--- a/python/GafferImageTest/MirrorTest.py
+++ b/python/GafferImageTest/MirrorTest.py
@@ -60,8 +60,8 @@ class MirrorTest( GafferImageTest.ImageTestCase ) :
 	def testEmptyInputDataWindow( self ) :
 
 		m = GafferImage.Mirror()
-		self.assertTrue( GafferImage.empty( m["in"]["dataWindow"].getValue() ) )
-		self.assertTrue( GafferImage.empty( m["out"]["dataWindow"].getValue() ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( m["in"]["dataWindow"].getValue() ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( m["out"]["dataWindow"].getValue() ) )
 
 	def testFormatAndDataWindow( self ) :
 

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -176,7 +176,7 @@ class _ParametersFooter( GafferUI.PlugValueWidget ) :
 					),
 					toolTip = "Add " + ( "Input" if plug.direction() == plug.Direction.In else "Output" ),
 				)
-				menuButton.setEnabled( not Gaffer.readOnly( plug ) )
+				menuButton.setEnabled( not Gaffer.MetadataAlgo.readOnly( plug ) )
 
 				GafferUI.Spacer( IECore.V2i( 1 ), IECore.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
@@ -327,7 +327,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 			"/Delete",
 			{
 				"command" : IECore.curry( __deletePlug, plug ),
-				"active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug )
+				"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug )
 			}
 		)
 
@@ -409,7 +409,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 				"/Insert" + label,
 				{
 					"command" : functools.partial( plugValueWidget.textWidget().insertText, text ),
-					"active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug ),
+					"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
 				},
 			)
 

--- a/python/GafferScene/ScriptProcedural.py
+++ b/python/GafferScene/ScriptProcedural.py
@@ -217,6 +217,6 @@ class ScriptProcedural( IECore.ParameterisedProcedural ) :
 
 		sys.stderr.write( "\nPerformance Monitor\n===================\n\n" )
 
-		sys.stderr.write( Gaffer.formatStatistics( cls.__performanceMonitor ) )
+		sys.stderr.write( Gaffer.MonitorAlgo.formatStatistics( cls.__performanceMonitor ) )
 
 IECore.registerRunTimeTyped( ScriptProcedural, typeName = "GafferScene::ScriptProcedural" )

--- a/python/GafferSceneTest/IsolateTest.py
+++ b/python/GafferSceneTest/IsolateTest.py
@@ -390,15 +390,15 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertSceneValid( isolate["out"] )
 
-		self.assertTrue( GafferScene.exists( isolate["out"], "/group/model1/sphere" ) )
-		self.assertTrue( GafferScene.exists( isolate["out"], "/group/model1/light" ) )
-		self.assertTrue( GafferScene.exists( isolate["out"], "/group/model1" ) )
+		self.assertTrue( GafferScene.SceneAlgo.exists( isolate["out"], "/group/model1/sphere" ) )
+		self.assertTrue( GafferScene.SceneAlgo.exists( isolate["out"], "/group/model1/light" ) )
+		self.assertTrue( GafferScene.SceneAlgo.exists( isolate["out"], "/group/model1" ) )
 
-		self.assertFalse( GafferScene.exists( isolate["out"], "/group/model2/sphere" ) )
-		self.assertFalse( GafferScene.exists( isolate["out"], "/group/model2" ) )
+		self.assertFalse( GafferScene.SceneAlgo.exists( isolate["out"], "/group/model2/sphere" ) )
+		self.assertFalse( GafferScene.SceneAlgo.exists( isolate["out"], "/group/model2" ) )
 
-		self.assertFalse( GafferScene.exists( isolate["out"], "/group/light" ) )
-		self.assertFalse( GafferScene.exists( isolate["out"], "/group/camera" ) )
+		self.assertFalse( GafferScene.SceneAlgo.exists( isolate["out"], "/group/light" ) )
+		self.assertFalse( GafferScene.SceneAlgo.exists( isolate["out"], "/group/camera" ) )
 
 		self.assertEqual( isolate["out"].set( "__lights" ).value.paths(), [ "/group/model1/light" ] )
 		self.assertEqual( isolate["out"].set( "__cameras" ).value.paths(), [] )
@@ -413,7 +413,7 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertSceneValid( isolate["out"] )
 
-		self.assertFalse( GafferScene.exists( isolate["out"], "/group/camera" ) )
+		self.assertFalse( GafferScene.SceneAlgo.exists( isolate["out"], "/group/camera" ) )
 
 		self.assertEqual( isolate["out"].set( "__lights" ), group["out"].set( "__lights" ) )
 		self.assertEqual( isolate["out"].set( "__cameras" ).value.paths(), [] )
@@ -431,7 +431,7 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertSceneValid( isolate["out"] )
 
-		self.assertTrue( GafferScene.exists( isolate["out"], "/group/camera" ) )
+		self.assertTrue( GafferScene.SceneAlgo.exists( isolate["out"], "/group/camera" ) )
 
 		self.assertEqual( isolate["out"].set( "__lights" ), group["out"].set( "__lights" ) )
 		self.assertEqual( isolate["out"].set( "__cameras" ), group["out"].set( "__cameras" ) )
@@ -456,7 +456,7 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 		isolate["filter"].setInput( filter["out"] )
 
 		self.assertSceneValid( isolate["out"] )
-		self.assertTrue( GafferScene.exists( isolate["out"], "/sphere" ) )
+		self.assertTrue( GafferScene.SceneAlgo.exists( isolate["out"], "/sphere" ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -64,7 +64,7 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		filter["paths"].setValue( IECore.StringVectorData( [ "/plane/instances/*1/group/plane" ] ) )
 
 		matchingPaths = GafferScene.PathMatcher()
-		GafferScene.matchingPaths( filter, instancer["out"], matchingPaths )
+		GafferScene.SceneAlgo.matchingPaths( filter, instancer["out"], matchingPaths )
 
 		self.assertEqual( len( matchingPaths.paths() ), 1000 )
 		self.assertEqual( matchingPaths.match( "/plane/instances/1/group/plane" ), GafferScene.Filter.Result.ExactMatch )
@@ -79,15 +79,15 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		group["in"][0].setInput( sphere["out"] )
 		group["in"][1].setInput( plane["out"] )
 
-		self.assertTrue( GafferScene.exists( group["out"], "/" ) )
-		self.assertTrue( GafferScene.exists( group["out"], "/group" ) )
-		self.assertTrue( GafferScene.exists( group["out"], "/group/sphere" ) )
-		self.assertTrue( GafferScene.exists( group["out"], "/group/plane" ) )
+		self.assertTrue( GafferScene.SceneAlgo.exists( group["out"], "/" ) )
+		self.assertTrue( GafferScene.SceneAlgo.exists( group["out"], "/group" ) )
+		self.assertTrue( GafferScene.SceneAlgo.exists( group["out"], "/group/sphere" ) )
+		self.assertTrue( GafferScene.SceneAlgo.exists( group["out"], "/group/plane" ) )
 
-		self.assertFalse( GafferScene.exists( group["out"], "/a" ) )
-		self.assertFalse( GafferScene.exists( group["out"], "/group2" ) )
-		self.assertFalse( GafferScene.exists( group["out"], "/group/sphere2" ) )
-		self.assertFalse( GafferScene.exists( group["out"], "/group/plane/child" ) )
+		self.assertFalse( GafferScene.SceneAlgo.exists( group["out"], "/a" ) )
+		self.assertFalse( GafferScene.SceneAlgo.exists( group["out"], "/group2" ) )
+		self.assertFalse( GafferScene.SceneAlgo.exists( group["out"], "/group/sphere2" ) )
+		self.assertFalse( GafferScene.SceneAlgo.exists( group["out"], "/group/plane/child" ) )
 
 	def testVisible( self ) :
 
@@ -113,60 +113,60 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		attributes2["in"].setInput( attributes1["out"] )
 		attributes2["filter"].setInput( invisibleFilter["out"] )
 
-		self.assertTrue( GafferScene.visible( attributes2["out"], "/group/group/sphere" ) )
-		self.assertTrue( GafferScene.visible( attributes2["out"], "/group/group" ) )
-		self.assertTrue( GafferScene.visible( attributes2["out"], "/group" ) )
-		self.assertTrue( GafferScene.visible( attributes2["out"], "/" ) )
+		self.assertTrue( GafferScene.SceneAlgo.visible( attributes2["out"], "/group/group/sphere" ) )
+		self.assertTrue( GafferScene.SceneAlgo.visible( attributes2["out"], "/group/group" ) )
+		self.assertTrue( GafferScene.SceneAlgo.visible( attributes2["out"], "/group" ) )
+		self.assertTrue( GafferScene.SceneAlgo.visible( attributes2["out"], "/" ) )
 
 		visibleFilter["paths"].setValue( IECore.StringVectorData( [ "/group" ] ) )
 
-		self.assertTrue( GafferScene.visible( attributes2["out"], "/group/group/sphere" ) )
-		self.assertTrue( GafferScene.visible( attributes2["out"], "/group/group" ) )
-		self.assertTrue( GafferScene.visible( attributes2["out"], "/group" ) )
-		self.assertTrue( GafferScene.visible( attributes2["out"], "/" ) )
+		self.assertTrue( GafferScene.SceneAlgo.visible( attributes2["out"], "/group/group/sphere" ) )
+		self.assertTrue( GafferScene.SceneAlgo.visible( attributes2["out"], "/group/group" ) )
+		self.assertTrue( GafferScene.SceneAlgo.visible( attributes2["out"], "/group" ) )
+		self.assertTrue( GafferScene.SceneAlgo.visible( attributes2["out"], "/" ) )
 
 		invisibleFilter["paths"].setValue( IECore.StringVectorData( [ "/group/group" ] ) )
 
-		self.assertFalse( GafferScene.visible( attributes2["out"], "/group/group/sphere" ) )
-		self.assertFalse( GafferScene.visible( attributes2["out"], "/group/group" ) )
-		self.assertTrue( GafferScene.visible( attributes2["out"], "/group" ) )
-		self.assertTrue( GafferScene.visible( attributes2["out"], "/" ) )
+		self.assertFalse( GafferScene.SceneAlgo.visible( attributes2["out"], "/group/group/sphere" ) )
+		self.assertFalse( GafferScene.SceneAlgo.visible( attributes2["out"], "/group/group" ) )
+		self.assertTrue( GafferScene.SceneAlgo.visible( attributes2["out"], "/group" ) )
+		self.assertTrue( GafferScene.SceneAlgo.visible( attributes2["out"], "/" ) )
 
 		visibleFilter["paths"].setValue( IECore.StringVectorData( [ "/group/group/sphere" ] ) )
 
-		self.assertFalse( GafferScene.visible( attributes2["out"], "/group/group/sphere" ) )
-		self.assertFalse( GafferScene.visible( attributes2["out"], "/group/group" ) )
-		self.assertTrue( GafferScene.visible( attributes2["out"], "/group" ) )
-		self.assertTrue( GafferScene.visible( attributes2["out"], "/" ) )
+		self.assertFalse( GafferScene.SceneAlgo.visible( attributes2["out"], "/group/group/sphere" ) )
+		self.assertFalse( GafferScene.SceneAlgo.visible( attributes2["out"], "/group/group" ) )
+		self.assertTrue( GafferScene.SceneAlgo.visible( attributes2["out"], "/group" ) )
+		self.assertTrue( GafferScene.SceneAlgo.visible( attributes2["out"], "/" ) )
 
 	def testSetExists( self ) :
 
 		plane = GafferScene.Plane()
 		plane["sets"].setValue( "A B" )
 
-		self.assertTrue( GafferScene.setExists( plane["out"], "A" ) )
-		self.assertTrue( GafferScene.setExists( plane["out"], "B" ) )
-		self.assertFalse( GafferScene.setExists( plane["out"], " " ) )
-		self.assertFalse( GafferScene.setExists( plane["out"], "" ) )
-		self.assertFalse( GafferScene.setExists( plane["out"], "C" ) )
+		self.assertTrue( GafferScene.SceneAlgo.setExists( plane["out"], "A" ) )
+		self.assertTrue( GafferScene.SceneAlgo.setExists( plane["out"], "B" ) )
+		self.assertFalse( GafferScene.SceneAlgo.setExists( plane["out"], " " ) )
+		self.assertFalse( GafferScene.SceneAlgo.setExists( plane["out"], "" ) )
+		self.assertFalse( GafferScene.SceneAlgo.setExists( plane["out"], "C" ) )
 
 	def testSets( self ) :
 
 		light = GafferSceneTest.TestLight()
 		light["sets"].setValue( "A B C" )
 
-		sets = GafferScene.sets( light["out"] )
+		sets = GafferScene.SceneAlgo.sets( light["out"] )
 		self.assertEqual( set( sets.keys() ), { "__lights", "A", "B", "C" } )
 		for n in sets.keys() :
 			self.assertEqual( sets[n], light["out"].set( n ) )
 			self.assertFalse( sets[n].isSame( light["out"].set( n, _copy = False ) ) )
 
-		sets = GafferScene.sets( light["out"], _copy = False )
+		sets = GafferScene.SceneAlgo.sets( light["out"], _copy = False )
 		self.assertEqual( set( sets.keys() ), { "__lights", "A", "B", "C" } )
 		for n in sets.keys() :
 			self.assertTrue( sets[n].isSame( light["out"].set( n, _copy = False ) ) )
 
-		someSets = GafferScene.sets( light["out"], ( "A", "B" ), _copy = False )
+		someSets = GafferScene.SceneAlgo.sets( light["out"], ( "A", "B" ), _copy = False )
 		self.assertEqual( set( someSets.keys() ), { "A", "B" } )
 		for n in someSets.keys() :
 			self.assertTrue( someSets[n].isSame( light["out"].set( n, _copy = False ) ) )
@@ -181,18 +181,18 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		f = GafferScene.PathMatcher( [ "/group/s*" ] )
 		m = GafferScene.PathMatcher()
-		GafferScene.matchingPaths( f, g["out"], m )
+		GafferScene.SceneAlgo.matchingPaths( f, g["out"], m )
 
 		self.assertEqual( set( m.paths() ), { "/group/sphere", "/group/sphere1", "/group/sphere2" } )
 
 	def testDefaultCamera( self ) :
 
 		o = GafferScene.StandardOptions()
-		c1 = GafferScene.camera( o["out"] )
+		c1 = GafferScene.SceneAlgo.camera( o["out"] )
 		self.assertTrue( isinstance( c1, IECore.Camera ) )
 
 		o["options"]["renderCamera"]["enabled"].setValue( True )
-		c2 = GafferScene.camera( o["out"] )
+		c2 = GafferScene.SceneAlgo.camera( o["out"] )
 		self.assertEqual( c1, c2 )
 
 	def testSetsNeedContextEntry( self ) :
@@ -209,7 +209,7 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		for i in range( 0, 100 ) :
 			with Gaffer.Context() as context :
 				context["lightName"] = "light%d" % i
-				GafferScene.sets( script["light"]["out"] )
+				GafferScene.SceneAlgo.sets( script["light"]["out"] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/CameraUI.py
+++ b/python/GafferSceneUI/CameraUI.py
@@ -129,7 +129,7 @@ def __nodeEditorToolMenu( nodeEditor, node, menuDefinition ) :
 			"/Copy From Viewer" + ( "/" + viewer.getTitle() if len( viewers ) > 1 else "" ),
 			{
 				"command" : functools.partial( __copyCamera, node, viewer.view().viewportGadget().getCamera() ),
-				"active" : not Gaffer.readOnly( node["transform"] ),
+				"active" : not Gaffer.MetadataAlgo.readOnly( node["transform"] ),
 			}
 
 		)

--- a/python/GafferSceneUI/CustomAttributesUI.py
+++ b/python/GafferSceneUI/CustomAttributesUI.py
@@ -136,7 +136,7 @@ def __attributePopupMenu( menuDefinition, plugValueWidget ) :
 			{
 				"command" : functools.partial( __setValue, plug, " ".join( sorted( newNames ) ) ),
 				"checkBox" : attributeName in currentNames,
-				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug ),
+				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
 			}
 		)
 

--- a/python/GafferSceneUI/DeleteGlobalsUI.py
+++ b/python/GafferSceneUI/DeleteGlobalsUI.py
@@ -125,7 +125,7 @@ def __namesPopupMenu( menuDefinition, plugValueWidget ) :
 			menuPrefix + nameWithoutPrefix,
 			{
 				"command" : IECore.curry( __toggleName, plug, nameWithoutPrefix ),
-				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug ),
+				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
 				"checkBox" : nameWithoutPrefix in currentNames,
 			}
 		)

--- a/python/GafferSceneUI/FilteredSceneProcessorUI.py
+++ b/python/GafferSceneUI/FilteredSceneProcessorUI.py
@@ -115,7 +115,7 @@ def __selectAffected( node, context ) :
 	pathMatcher = GafferScene.PathMatcher()
 	with context :
 		for scene in scenes :
-			GafferScene.matchingPaths( filter, scene, pathMatcher )
+			GafferScene.SceneAlgo.matchingPaths( filter, scene, pathMatcher )
 
 	context["ui:scene:selectedPaths"] = IECore.StringVectorData( pathMatcher.paths() )
 

--- a/python/GafferSceneUI/LightTweaksUI.py
+++ b/python/GafferSceneUI/LightTweaksUI.py
@@ -258,7 +258,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 		if node is not None :
 			pathMatcher = GafferScene.PathMatcher()
 			with self.getContext() :
-				GafferScene.matchingPaths( node["filter"], node["in"], pathMatcher )
+				GafferScene.SceneAlgo.matchingPaths( node["filter"], node["in"], pathMatcher )
 				paths = pathMatcher.paths()
 
 		return self.__addFromPathsMenuDefinition( paths )
@@ -269,7 +269,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 		node = self.__lightTweaksNode()
 		if node is not None :
 			paths = self.getContext().get( "ui:scene:selectedPaths", [] )
-			paths = [ p for p in paths if GafferScene.exists( node["in"], p ) ]
+			paths = [ p for p in paths if GafferScene.SceneAlgo.exists( node["in"], p ) ]
 
 		return self.__addFromPathsMenuDefinition( paths )
 
@@ -290,7 +290,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 			for path in paths :
 				attributes = node["in"].attributes( path )
 				for name, network in attributes.items() :
-					if not Gaffer.matchMultiple( name, attributeNamePatterns ) :
+					if not Gaffer.StringAlgo.matchMultiple( name, attributeNamePatterns ) :
 						continue
 					if not isinstance( network, IECore.ObjectVector ) or not len( network ):
 						continue

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -277,7 +277,7 @@ class SceneInspector( GafferUI.NodeSetEditor ) :
 			targets = []
 			for scene in self.__scenePlugs :
 				for path in paths :
-					if not GafferScene.exists( scene, path ) :
+					if not GafferScene.SceneAlgo.exists( scene, path ) :
 						# selection may not be valid for both scenes,
 						# and we can't inspect invalid paths.
 						path = None
@@ -932,7 +932,7 @@ class DiffColumn( GafferUI.Widget ) :
 			visible = False
 			if row.__valid :
 				numValidRows += 1
-				if Gaffer.matchMultiple( row.inspector().name().lower(), patterns ) :
+				if Gaffer.StringAlgo.matchMultiple( row.inspector().name().lower(), patterns ) :
 					visible = True
 
 			row.setVisible( visible )
@@ -1225,7 +1225,7 @@ class _HistorySection( Section ) :
 			if sourceScene.node() == target.scene.node() :
 				return None
 
-			if not GafferScene.exists( sourceScene, target.path ) :
+			if not GafferScene.SceneAlgo.exists( sourceScene, target.path ) :
 				return None
 
 			return SceneInspector.Target( sourceScene, target.path )

--- a/python/GafferSceneUI/SceneReaderUI.py
+++ b/python/GafferSceneUI/SceneReaderUI.py
@@ -156,7 +156,7 @@ def __tagsPopupMenu( menuDefinition, plugValueWidget ) :
 			{
 				"command" : IECore.curry( __toggleTag, plug, tag ),
 				"checkBox" : tag in currentTags,
-				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug ),
+				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
 			}
 		)
 

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -189,7 +189,7 @@ def __setsPopupMenu( menuDefinition, plugValueWidget ) :
 			{
 				"command" : functools.partial( __setValue, plug, " ".join( sorted( newNames ) ) ),
 				"checkBox" : setName in currentNames,
-				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug ),
+				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
 			}
 		)
 

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -168,7 +168,7 @@ class _ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 			shaderName = self.getPlug().getValue()
 			self.__label.setText( "<h3>Shader : " + shaderName + "</h3>" )
 			## \todo Disable the type check once we've got OpenGLShader implementing reloading properly.
-			self.__button.setEnabled( not Gaffer.readOnly( self.getPlug() ) and not isinstance( self.getPlug().node(), GafferScene.OpenGLShader ) )
+			self.__button.setEnabled( not Gaffer.MetadataAlgo.readOnly( self.getPlug() ) and not isinstance( self.getPlug().node(), GafferScene.OpenGLShader ) )
 
 	def __buttonClicked( self, button ) :
 

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -45,31 +45,31 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 
 		n = GafferTest.AddNode()
 
-		self.assertEqual( Gaffer.getReadOnly( n ), False )
-		self.assertEqual( Gaffer.getReadOnly( n["op1"] ), False )
-		self.assertEqual( Gaffer.readOnly( n ), False )
-		self.assertEqual( Gaffer.readOnly( n["op1"] ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n["op1"] ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n["op1"] ), False )
 
-		Gaffer.setReadOnly( n["op1"], True )
+		Gaffer.MetadataAlgo.setReadOnly( n["op1"], True )
 
-		self.assertEqual( Gaffer.getReadOnly( n ), False )
-		self.assertEqual( Gaffer.getReadOnly( n["op1"] ), True )
-		self.assertEqual( Gaffer.readOnly( n ), False )
-		self.assertEqual( Gaffer.readOnly( n["op1"] ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n["op1"] ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n["op1"] ), True )
 
-		Gaffer.setReadOnly( n, True )
+		Gaffer.MetadataAlgo.setReadOnly( n, True )
 
-		self.assertEqual( Gaffer.getReadOnly( n ), True )
-		self.assertEqual( Gaffer.getReadOnly( n["op1"] ), True )
-		self.assertEqual( Gaffer.readOnly( n ), True )
-		self.assertEqual( Gaffer.readOnly( n["op1"] ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n["op1"] ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n["op1"] ), True )
 
-		Gaffer.setReadOnly( n["op1"], False )
+		Gaffer.MetadataAlgo.setReadOnly( n["op1"], False )
 
-		self.assertEqual( Gaffer.getReadOnly( n ), True )
-		self.assertEqual( Gaffer.getReadOnly( n["op1"] ), False )
-		self.assertEqual( Gaffer.readOnly( n ), True )
-		self.assertEqual( Gaffer.readOnly( n["op1"] ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n["op1"] ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n["op1"] ), True )
 
 	def testAffected( self ) :
 
@@ -79,9 +79,9 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 		ancestorAffected = []
 		childAffected = []
 		def plugValueChanged( nodeTypeId, plugPath, key, plug ) :
-			affected.append( Gaffer.affectedByChange( n["p"]["s"], nodeTypeId, plugPath, plug ) )
-			ancestorAffected.append( Gaffer.ancestorAffectedByChange( n["p"]["s"], nodeTypeId, plugPath, plug ) )
-			childAffected.append( Gaffer.childAffectedByChange( n["p"], nodeTypeId, plugPath, plug ) )
+			affected.append( Gaffer.MetadataAlgo.affectedByChange( n["p"]["s"], nodeTypeId, plugPath, plug ) )
+			ancestorAffected.append( Gaffer.MetadataAlgo.ancestorAffectedByChange( n["p"]["s"], nodeTypeId, plugPath, plug ) )
+			childAffected.append( Gaffer.MetadataAlgo.childAffectedByChange( n["p"], nodeTypeId, plugPath, plug ) )
 
 		c = Gaffer.Metadata.plugValueChangedSignal().connect( plugValueChanged )
 

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -1009,8 +1009,8 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["r"] = Gaffer.Reference()
 		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
-		self.assertTrue( Gaffer.readOnly( s["r"]["a1"] ) )
-		self.assertTrue( Gaffer.readOnly( s["r"]["a2"] ) )
+		self.assertTrue( Gaffer.MetadataAlgo.readOnly( s["r"]["a1"] ) )
+		self.assertTrue( Gaffer.MetadataAlgo.readOnly( s["r"]["a2"] ) )
 
 		s.execute( s.serialise( parent = s["r"], filter = Gaffer.StandardSet( [ s["r"]["a1"], s["r"]["a2"] ] ) ) )
 
@@ -1018,8 +1018,8 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertTrue( "a2" in s )
 		self.assertTrue( s["a2"]["op1"].getInput().isSame( s["a1"]["sum"] ) )
 
-		self.assertFalse( Gaffer.readOnly( s["a1"] ) )
-		self.assertFalse( Gaffer.readOnly( s["a2"] ) )
+		self.assertFalse( Gaffer.MetadataAlgo.readOnly( s["a1"] ) )
+		self.assertFalse( Gaffer.MetadataAlgo.readOnly( s["a2"] ) )
 
 	def testReloadWithNestedInputConnections( self ) :
 

--- a/python/GafferTest/StringAlgoTest.py
+++ b/python/GafferTest/StringAlgoTest.py
@@ -55,9 +55,9 @@ class StringAlgoTest( GafferTest.TestCase ) :
 			( "dog collar", "dog*", True ),
 		] :
 
-			self.assertEqual( Gaffer.match( s, p ), r )
+			self.assertEqual( Gaffer.StringAlgo.match( s, p ), r )
 			if " " not in s :
-				self.assertEqual( Gaffer.matchMultiple( s, p ), r )
+				self.assertEqual( Gaffer.StringAlgo.matchMultiple( s, p ), r )
 
 	def testMatchMultiple( self ) :
 
@@ -77,7 +77,7 @@ class StringAlgoTest( GafferTest.TestCase ) :
 			( "a1", "*1 b2", True ),
 		] :
 
-			self.assertEqual( Gaffer.matchMultiple( s, p ), r )
+			self.assertEqual( Gaffer.StringAlgo.matchMultiple( s, p ), r )
 
 	def testHasWildcards( self ) :
 
@@ -91,7 +91,7 @@ class StringAlgoTest( GafferTest.TestCase ) :
 			( "*a", True ),
 		] :
 
-			self.assertEqual( Gaffer.hasWildcards( p ), r )
+			self.assertEqual( Gaffer.StringAlgo.hasWildcards( p ), r )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/BoxUI.py
+++ b/python/GafferUI/BoxUI.py
@@ -365,7 +365,7 @@ def __reorderPlugs( plugs, plug, newIndex ) :
 
 def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 
-	readOnly = Gaffer.readOnly( plug )
+	readOnly = Gaffer.MetadataAlgo.readOnly( plug )
 	if isinstance( plug.node(), Gaffer.Box ) :
 
 		menuDefinition.append(

--- a/python/GafferUI/CompoundDataPlugValueWidget.py
+++ b/python/GafferUI/CompoundDataPlugValueWidget.py
@@ -248,7 +248,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 		"/Delete",
 		{
 			"command" : IECore.curry( __deletePlug, memberPlug ),
-			"active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( memberPlug ),
+			"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( memberPlug ),
 		}
 	)
 

--- a/python/GafferUI/CompoundNumericPlugValueWidget.py
+++ b/python/GafferUI/CompoundNumericPlugValueWidget.py
@@ -169,14 +169,14 @@ class CompoundNumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 			menuDefinition.append( "/Ungang", {
 				"command" : Gaffer.WeakMethod( compoundNumericPlugValueWidget.__ungang ),
 				"shortCut" : "Ctrl+G",
-				"active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( compoundNumericPlugValueWidget.getPlug() ),
+				"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( compoundNumericPlugValueWidget.getPlug() ),
 			} )
 		elif compoundNumericPlugValueWidget.getPlug().canGang() :
 			menuDefinition.append( "/GangDivider", { "divider" : True } )
 			menuDefinition.append( "/Gang", {
 				"command" : Gaffer.WeakMethod( compoundNumericPlugValueWidget.__gang ),
 				"shortCut" : "Ctrl+G",
-				"active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( compoundNumericPlugValueWidget.getPlug() ),
+				"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( compoundNumericPlugValueWidget.getPlug() ),
 			} )
 
 	def __applyVisibleDimensions( self ) :

--- a/python/GafferUI/DotUI.py
+++ b/python/GafferUI/DotUI.py
@@ -169,7 +169,7 @@ def __connectionContextMenu( nodeGraph, destinationPlug, menuDefinition ) :
 		"/Insert Dot",
 		{
 			"command" : functools.partial( __insertDot, destinationPlug = destinationPlug ),
-			"active" : not destinationPlug.getFlags( Gaffer.Plug.Flags.ReadOnly ) and not Gaffer.readOnly( destinationPlug ),
+			"active" : not destinationPlug.getFlags( Gaffer.Plug.Flags.ReadOnly ) and not Gaffer.MetadataAlgo.readOnly( destinationPlug ),
 		}
 	)
 
@@ -190,7 +190,7 @@ def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :
 		if not currentEdge :
 			currentEdge = "top" if plug.direction() == plug.Direction.In else "bottom"
 
-		readOnly = Gaffer.readOnly( plug )
+		readOnly = Gaffer.MetadataAlgo.readOnly( plug )
 		for edge in ( "top", "bottom", "left", "right" ) :
 			menuDefinition.append(
 				"/Move To/" + edge.capitalize(),

--- a/python/GafferUI/ExpressionUI.py
+++ b/python/GafferUI/ExpressionUI.py
@@ -122,7 +122,7 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 		return
 
 	input = plug.getInput()
-	if input is not None or not plugValueWidget._editable() or Gaffer.readOnly( plug ) :
+	if input is not None or not plugValueWidget._editable() or Gaffer.MetadataAlgo.readOnly( plug ) :
 		return
 
 	languages = [ l for l in Gaffer.Expression.languages() if Gaffer.Expression.defaultExpression( plug, l ) ]
@@ -158,10 +158,10 @@ class _ExpressionWidget( GafferUI.Widget ) :
 
 				GafferUI.Label( "Language" )
 				self.__languageMenu = GafferUI.MenuButton( "", menu = GafferUI.Menu( Gaffer.WeakMethod( self.__languageMenuDefinition ) ) )
-				self.__languageMenu.setEnabled( not Gaffer.readOnly( node ) )
+				self.__languageMenu.setEnabled( not Gaffer.MetadataAlgo.readOnly( node ) )
 
 			self.__textWidget = GafferUI.MultiLineTextWidget( role = GafferUI.MultiLineTextWidget.Role.Code )
-			self.__textWidget.setEditable( not Gaffer.readOnly( node ) )
+			self.__textWidget.setEditable( not Gaffer.MetadataAlgo.readOnly( node ) )
 
 			self.__activatedConnection = self.__textWidget.activatedSignal().connect( Gaffer.WeakMethod( self.__activated ) )
 			self.__editingFinishedConnection = self.__textWidget.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__editingFinished ) )

--- a/python/GafferUI/GraphBookmarksUI.py
+++ b/python/GafferUI/GraphBookmarksUI.py
@@ -52,7 +52,7 @@ def appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition ) :
 		{
 			"checkBox" : __getBookmarked( node ),
 			"command" : functools.partial( __setBookmarked, node ),
-			"active" : not Gaffer.readOnly( node ),
+			"active" : not Gaffer.MetadataAlgo.readOnly( node ),
 		}
 	)
 
@@ -89,7 +89,7 @@ def appendPlugContextMenuDefinitions( nodeGraph, plug, menuDefinition ) :
 				"/Connect Bookmark/" + label,
 				{
 					"command" : functools.partial( __connect, inPlug, outPlug ),
-					"active" : not outPlug.isSame( inPlug.getInput() ) and not Gaffer.readOnly( inPlug )
+					"active" : not outPlug.isSame( inPlug.getInput() ) and not Gaffer.MetadataAlgo.readOnly( inPlug )
 				}
 			)
 

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -194,7 +194,7 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		assert( label is self.__label )
 
-		if self.getPlug().getFlags( Gaffer.Plug.Flags.ReadOnly ) or Gaffer.readOnly( self.getPlug() ) :
+		if self.getPlug().getFlags( Gaffer.Plug.Flags.ReadOnly ) or Gaffer.MetadataAlgo.readOnly( self.getPlug() ) :
 			return
 
 		if self.__editableLabel is None :
@@ -233,5 +233,5 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if self.getPlug() is None :
 			return
 
-		if key=="label" and Gaffer.affectedByChange( self.getPlug(), nodeTypeId, plugPath, plug ) :
+		if key=="label" and Gaffer.MetadataAlgo.affectedByChange( self.getPlug(), nodeTypeId, plugPath, plug ) :
 			self.__updateFormatter()

--- a/python/GafferUI/NodeEditor.py
+++ b/python/GafferUI/NodeEditor.py
@@ -115,7 +115,7 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 				# our Widget readonlyness. Really our Widget readonlyness mechanism is a
 				# bit lacking, and it should really be inherited automatically so we don't
 				# have to propagate it like this.
-				self.__nameWidget.setEditable( not self.getReadOnly() and not Gaffer.readOnly( node ) )
+				self.__nameWidget.setEditable( not self.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( node ) )
 
 				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing=4 ) as infoSection :
 
@@ -170,7 +170,7 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 			"/Revert to Defaults",
 			{
 				"command" : Gaffer.WeakMethod( self.__revertToDefaults ),
-				"active" : not Gaffer.readOnly( self.nodeUI().node() ),
+				"active" : not Gaffer.MetadataAlgo.readOnly( self.nodeUI().node() ),
 			}
 		)
 
@@ -195,7 +195,7 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 				elif plug.getName().startswith( "__" ) :
 					# Private plugs are none of our business.
 					return
-				elif Gaffer.readOnly( plug ) :
+				elif Gaffer.MetadataAlgo.readOnly( plug ) :
 					return
 
 				if isinstance( plug, Gaffer.ValuePlug ) :

--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -172,7 +172,7 @@ class NodeGraph( GafferUI.EditorWidget ) :
 				{
 					"command" : functools.partial( cls.__setEnabled, node ),
 					"checkBox" : enabledPlug.getValue(),
-					"active" : enabledPlug.settable() and not Gaffer.readOnly( enabledPlug )
+					"active" : enabledPlug.settable() and not Gaffer.MetadataAlgo.readOnly( enabledPlug )
 				}
 			)
 

--- a/python/GafferUI/NodeUI.py
+++ b/python/GafferUI/NodeUI.py
@@ -179,6 +179,6 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 	node = plug.node()
 	if plug.parent().isSame( node["user"] ) :
 		menuDefinition.append( "/DeleteDivider", { "divider" : True } )
-		menuDefinition.append( "/Delete", { "command" : IECore.curry( __deletePlug, plug ), "active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug ) } )
+		menuDefinition.append( "/Delete", { "command" : IECore.curry( __deletePlug, plug ), "active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ) } )
 
 __plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -476,8 +476,8 @@ class PlugLayout( GafferUI.Widget ) :
 
 	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
 
-		parentAffected = isinstance( self.__parent, Gaffer.Plug ) and Gaffer.affectedByChange( self.__parent, nodeTypeId, plugPath, plug )
-		childAffected = Gaffer.childAffectedByChange( self.__parent, nodeTypeId, plugPath, plug )
+		parentAffected = isinstance( self.__parent, Gaffer.Plug ) and Gaffer.MetadataAlgo.affectedByChange( self.__parent, nodeTypeId, plugPath, plug )
+		childAffected = Gaffer.MetadataAlgo.childAffectedByChange( self.__parent, nodeTypeId, plugPath, plug )
 		if not parentAffected and not childAffected :
 			return
 

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -192,7 +192,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 			if not canEditAnimation or not Gaffer.Animation.isAnimated( plug ) :
 				return False
 
-		if Gaffer.readOnly( plug ) :
+		if Gaffer.MetadataAlgo.readOnly( plug ) :
 			return False
 
 		return True
@@ -287,7 +287,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 			menuDefinition.append(
 				"/Remove input", {
 					"command" : Gaffer.WeakMethod( self.__removeInput ),
-					"active" : self.getPlug().acceptsInput( None ) and not self.getReadOnly() and not Gaffer.readOnly( self.getPlug() ),
+					"active" : self.getPlug().acceptsInput( None ) and not self.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( self.getPlug() ),
 				}
 			)
 		if hasattr( self.getPlug(), "defaultValue" ) and self.getPlug().direction() == Gaffer.Plug.Direction.In :
@@ -317,12 +317,12 @@ class PlugValueWidget( GafferUI.Widget ) :
 		if len( menuDefinition.items() ) :
 			menuDefinition.append( "/LockDivider", { "divider" : True } )
 
-		readOnly = Gaffer.getReadOnly( self.getPlug() ) or self.getPlug().getFlags( Gaffer.Plug.Flags.ReadOnly )
+		readOnly = Gaffer.MetadataAlgo.getReadOnly( self.getPlug() ) or self.getPlug().getFlags( Gaffer.Plug.Flags.ReadOnly )
 		menuDefinition.append(
 			"/Unlock" if readOnly else "/Lock",
 			{
 				"command" : functools.partial( Gaffer.WeakMethod( self.__applyReadOnly ), not readOnly ),
-				"active" : not self.getReadOnly() and not Gaffer.readOnly( self.getPlug().parent() ),
+				"active" : not self.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( self.getPlug().parent() ),
 			}
 		)
 
@@ -460,8 +460,8 @@ class PlugValueWidget( GafferUI.Widget ) :
 			return
 
 		if (
-			Gaffer.affectedByChange( self.__plug, nodeTypeId, plugPath, plug ) or
-			( key == "readOnly" and Gaffer.ancestorAffectedByChange( self.__plug, nodeTypeId, plugPath, plug ) )
+			Gaffer.MetadataAlgo.affectedByChange( self.__plug, nodeTypeId, plugPath, plug ) or
+			( key == "readOnly" and Gaffer.MetadataAlgo.ancestorAffectedByChange( self.__plug, nodeTypeId, plugPath, plug ) )
 		) :
 			self._updateFromPlug()
 
@@ -613,7 +613,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 			# instead. Clear the old flags so that metadata is in
 			# control.
 			clearFlags( self.getPlug() )
-			Gaffer.setReadOnly( self.getPlug(), readOnly )
+			Gaffer.MetadataAlgo.setReadOnly( self.getPlug(), readOnly )
 
 	# drag and drop stuff
 

--- a/python/GafferUI/RandomUI.py
+++ b/python/GafferUI/RandomUI.py
@@ -228,7 +228,7 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 			"/Randomise...",
 			{
 				"command" : functools.partial( __createRandom, plug ),
-				"active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug ),
+				"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
 			}
 		)
 

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -145,7 +145,7 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 			"/Set Color...",
 			{
 				"command" : functools.partial( cls.__setColor, node = node ),
-				"active" : not Gaffer.readOnly( node ),
+				"active" : not Gaffer.MetadataAlgo.readOnly( node ),
 			}
 		)
 
@@ -158,7 +158,7 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 				"command" : functools.partial( GafferUI.UIEditor.acquire, node ),
 				"active" : (
 					( isinstance( node, Gaffer.Box ) or nodeEditor.nodeUI().plugValueWidget( node["user"] ) is not None ) and
-					not Gaffer.readOnly( node )
+					not Gaffer.MetadataAlgo.readOnly( node )
 				)
 			}
 		)
@@ -261,7 +261,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 	menuDefinition.append( "/Edit UI...",
 		{
 			"command" : IECore.curry( __editPlugUI, node, plug ),
-			"active" : not plugValueWidget.getReadOnly() and not Gaffer.readOnly( plug )
+			"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug )
 		}
 	)
 
@@ -390,7 +390,7 @@ class _MetadataWidget( GafferUI.Widget ) :
 		if self.__key != key :
 			return
 
-		if Gaffer.affectedByChange( self.__target, nodeTypeId, plugPath, plug ) :
+		if Gaffer.MetadataAlgo.affectedByChange( self.__target, nodeTypeId, plugPath, plug ) :
 			self.__update()
 
 class _BoolMetadataWidget( _MetadataWidget ) :
@@ -1058,8 +1058,8 @@ class _PlugListing( GafferUI.Widget ) :
 		if self.__parent is None :
 			return
 
-		parentAffected = isinstance( self.__parent, Gaffer.Plug ) and Gaffer.affectedByChange( self.__parent, nodeTypeId, plugPath, plug )
-		childAffected = Gaffer.childAffectedByChange( self.__parent, nodeTypeId, plugPath, plug )
+		parentAffected = isinstance( self.__parent, Gaffer.Plug ) and Gaffer.MetadataAlgo.affectedByChange( self.__parent, nodeTypeId, plugPath, plug )
+		childAffected = Gaffer.MetadataAlgo.childAffectedByChange( self.__parent, nodeTypeId, plugPath, plug )
 		if not parentAffected and not childAffected :
 			return
 
@@ -1273,7 +1273,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 
 	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
 
-		if self.__plug is None or not Gaffer.affectedByChange( self.__plug, nodeTypeId, plugPath, plug ) :
+		if self.__plug is None or not Gaffer.MetadataAlgo.affectedByChange( self.__plug, nodeTypeId, plugPath, plug ) :
 			return
 
 		if key.startswith( "preset:" ) :
@@ -1546,7 +1546,7 @@ class _PlugEditor( GafferUI.Widget ) :
 		if self.getPlug() is None :
 			return
 
-		if not Gaffer.affectedByChange( self.getPlug(), nodeTypeId, plugPath, plug ) :
+		if not Gaffer.MetadataAlgo.affectedByChange( self.getPlug(), nodeTypeId, plugPath, plug ) :
 			return
 
 		if key == "plugValueWidget:type" :

--- a/src/Gaffer/FileSystemPath.cpp
+++ b/src/Gaffer/FileSystemPath.cpp
@@ -356,7 +356,7 @@ PathFilterPtr FileSystemPath::createStandardFilter( const std::vector<std::strin
 	if( extensions.size() )
 	{
 		std::string defaultLabel = "Show only ";
-		vector<MatchPattern> patterns;
+		vector<StringAlgo::MatchPattern> patterns;
 		for( std::vector<std::string>::const_iterator it = extensions.begin(), eIt = extensions.end(); it != eIt; ++it )
 		{
 			patterns.push_back( "*." + to_lower_copy( *it ) );

--- a/src/Gaffer/GraphComponent.cpp
+++ b/src/Gaffer/GraphComponent.cpp
@@ -104,7 +104,7 @@ const IECore::InternedString &GraphComponent::setName( const IECore::InternedStr
 			// split name into a prefix and a numeric suffix. if no suffix
 			// exists then it defaults to 1.
 			std::string prefix;
-			int suffix = numericSuffix( newName.value(), 1, &prefix );
+			int suffix = StringAlgo::numericSuffix( newName.value(), 1, &prefix );
 
 			// iterate over all the siblings to find the minimum value for the suffix which
 			// will be greater than any existing suffix.

--- a/src/Gaffer/MatchPatternPathFilter.cpp
+++ b/src/Gaffer/MatchPatternPathFilter.cpp
@@ -48,7 +48,7 @@ static IECore::InternedString g_namePropertyName( "name" );
 
 IE_CORE_DEFINERUNTIMETYPED( MatchPatternPathFilter );
 
-MatchPatternPathFilter::MatchPatternPathFilter( const std::vector<MatchPattern> &patterns, IECore::InternedString propertyName, bool leafOnly, IECore::CompoundDataPtr userData )
+MatchPatternPathFilter::MatchPatternPathFilter( const std::vector<StringAlgo::MatchPattern> &patterns, IECore::InternedString propertyName, bool leafOnly, IECore::CompoundDataPtr userData )
 	:	PathFilter( userData ), m_patterns( patterns ), m_propertyName( propertyName ), m_leafOnly( leafOnly ), m_inverted( false )
 {
 }
@@ -57,7 +57,7 @@ MatchPatternPathFilter::~MatchPatternPathFilter()
 {
 }
 
-void MatchPatternPathFilter::setMatchPatterns( const std::vector<MatchPattern> &patterns )
+void MatchPatternPathFilter::setMatchPatterns( const std::vector<StringAlgo::MatchPattern> &patterns )
 {
 	if( patterns == m_patterns )
 	{
@@ -67,7 +67,7 @@ void MatchPatternPathFilter::setMatchPatterns( const std::vector<MatchPattern> &
 	changedSignal()( this );
 }
 
-const std::vector<MatchPattern> &MatchPatternPathFilter::getMatchPatterns() const
+const std::vector<StringAlgo::MatchPattern> &MatchPatternPathFilter::getMatchPatterns() const
 {
 	return m_patterns;
 }
@@ -147,9 +147,9 @@ bool MatchPatternPathFilter::remove( PathPtr path ) const
 		propertyValue = &propertyData->readable();
 	}
 
-	for( std::vector<MatchPattern>::const_iterator it = m_patterns.begin(), eIt = m_patterns.end(); it != eIt; ++it )
+	for( std::vector<StringAlgo::MatchPattern>::const_iterator it = m_patterns.begin(), eIt = m_patterns.end(); it != eIt; ++it )
 	{
-		if( match( propertyValue->c_str(), *it ) )
+		if( StringAlgo::match( propertyValue->c_str(), *it ) )
 		{
 			return invert( false );
 		}

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -108,7 +108,7 @@ struct NodeMetadata
 		>
 	> PlugValues;
 
-	typedef map<MatchPattern, PlugValues> PlugPathsToValues;
+	typedef map<StringAlgo::MatchPattern, PlugValues> PlugPathsToValues;
 
 	NodeValues nodeValues;
 	PlugPathsToValues plugPathsToValues;
@@ -423,7 +423,7 @@ void Metadata::deregisterValue( IECore::TypeId nodeTypeId, IECore::InternedStrin
 	deregisterNodeValue( nodeTypeId, key );
 }
 
-void Metadata::deregisterValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key )
+void Metadata::deregisterValue( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key )
 {
 	deregisterPlugValue( nodeTypeId, plugPath, key );
 }
@@ -507,12 +507,12 @@ std::vector<Node*> Metadata::nodesWithMetadata( GraphComponent *root, IECore::In
 	return nodes;
 }
 
-void Metadata::registerPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value )
+void Metadata::registerPlugValue( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value )
 {
 	registerPlugValue( nodeTypeId, plugPath, key, boost::lambda::constant( value ) );
 }
 
-void Metadata::registerPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, PlugValueFunction value )
+void Metadata::registerPlugValue( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key, PlugValueFunction value )
 {
 	NodeMetadata &nodeMetadata = nodeMetadataMap()[nodeTypeId];
 	NodeMetadata::PlugValues &plugValues = nodeMetadata.plugPathsToValues[plugPath];
@@ -553,7 +553,7 @@ void Metadata::registeredPlugValues( const Plug *plug, std::vector<IECore::Inter
 				NodeMetadata::PlugPathsToValues::const_iterator it, eIt;
 				for( it = nIt->second.plugPathsToValues.begin(), eIt = nIt->second.plugPathsToValues.end(); it != eIt; ++it )
 				{
-					if( match( plugPath, it->first ) )
+					if( StringAlgo::match( plugPath, it->first ) )
 					{
 						const NodeMetadata::PlugValues::nth_index<1>::type &index = it->second.get<1>();
 						for( NodeMetadata::PlugValues::nth_index<1>::type::const_reverse_iterator vIt = index.rbegin(), veIt = index.rend(); vIt != veIt; ++vIt )
@@ -612,7 +612,7 @@ IECore::ConstDataPtr Metadata::plugValueInternal( const Plug *plug, IECore::Inte
 			// wildcard matches.
 			for( it = nIt->second.plugPathsToValues.begin(); it != eIt; ++it )
 			{
-				if( match( plugPath, it->first ) )
+				if( StringAlgo::match( plugPath, it->first ) )
 				{
 					NodeMetadata::PlugValues::const_iterator vIt = it->second.find( key );
 					if( vIt != it->second.end() )
@@ -627,7 +627,7 @@ IECore::ConstDataPtr Metadata::plugValueInternal( const Plug *plug, IECore::Inte
 	return NULL;
 }
 
-void Metadata::deregisterPlugValue( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key )
+void Metadata::deregisterPlugValue( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key )
 {
 	NodeMetadata &nodeMetadata = nodeMetadataMap()[nodeTypeId];
 	NodeMetadata::PlugValues &plugValues = nodeMetadata.plugPathsToValues[plugPath];
@@ -647,12 +647,12 @@ void Metadata::deregisterPlugValue( Plug *plug, IECore::InternedString key )
 	registerInstanceValue( plug, key, OptionalData(), /* persistent = */ false );
 }
 
-void Metadata::registerPlugDescription( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, const std::string &description )
+void Metadata::registerPlugDescription( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, const std::string &description )
 {
 	registerPlugValue( nodeTypeId, plugPath, "description", ConstDataPtr( new StringData( description ) ) );
 }
 
-void Metadata::registerPlugDescription( IECore::TypeId nodeTypeId, const MatchPattern &plugPath, PlugValueFunction description )
+void Metadata::registerPlugDescription( IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, PlugValueFunction description )
 {
 	registerPlugValue( nodeTypeId, plugPath, "description", description );
 }

--- a/src/Gaffer/MetadataAlgo.cpp
+++ b/src/Gaffer/MetadataAlgo.cpp
@@ -66,6 +66,9 @@ size_t findNth( const std::string &s, char c, int n )
 namespace Gaffer
 {
 
+namespace MetadataAlgo
+{
+
 void setReadOnly( GraphComponent *graphComponent, bool readOnly, bool persistent )
 {
 	Metadata::registerValue( graphComponent, g_readOnlyName, new BoolData( readOnly ), persistent );
@@ -90,7 +93,7 @@ bool readOnly( const GraphComponent *graphComponent )
 	return false;
 }
 
-bool affectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug )
+bool affectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug )
 {
 	if( changedPlug )
 	{
@@ -103,7 +106,7 @@ bool affectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const
 		return false;
 	}
 
-	if( match( plug->relativeName( node ), changedPlugPath ) )
+	if( StringAlgo::match( plug->relativeName( node ), changedPlugPath ) )
 	{
 		return true;
 	}
@@ -111,7 +114,7 @@ bool affectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const
 	return false;
 }
 
-bool childAffectedByChange( const GraphComponent *parent, IECore::TypeId changedNodeTypeId, const MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug )
+bool childAffectedByChange( const GraphComponent *parent, IECore::TypeId changedNodeTypeId, const StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug )
 {
 	if( changedPlug )
 	{
@@ -143,10 +146,10 @@ bool childAffectedByChange( const GraphComponent *parent, IECore::TypeId changed
 		return false;
 	}
 
-	return match( parentName, changedPlugPath.substr( 0, parentMatchPatternEnd ) );
+	return StringAlgo::match( parentName, changedPlugPath.substr( 0, parentMatchPatternEnd ) );
 }
 
-bool ancestorAffectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug )
+bool ancestorAffectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug )
 {
 	if( changedPlug )
 	{
@@ -163,5 +166,7 @@ bool ancestorAffectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeI
 
 	return false;
 }
+
+} // namespace MetadataAlgo
 
 } // namespace Gaffer

--- a/src/Gaffer/MonitorAlgo.cpp
+++ b/src/Gaffer/MonitorAlgo.cpp
@@ -205,25 +205,25 @@ struct HashesPerComputeMetric
 
 // Utility for invoking a templated functor with a particular metric.
 template<typename F>
-typename F::ResultType dispatchMetric( const F &f, PerformanceMetric performanceMetric )
+typename F::ResultType dispatchMetric( const F &f, MonitorAlgo::PerformanceMetric performanceMetric )
 {
 	switch( performanceMetric )
 	{
-		case HashCount :
+		case MonitorAlgo::HashCount :
 			return f( HashCountMetric() );
-		case ComputeCount :
+		case MonitorAlgo::ComputeCount :
 			return f( ComputeCountMetric() );
-		case HashDuration :
+		case MonitorAlgo::HashDuration :
 			return f( HashDurationMetric() );
-		case ComputeDuration :
+		case MonitorAlgo::ComputeDuration :
 			return f( ComputeDurationMetric() );
-		case TotalDuration :
+		case MonitorAlgo::TotalDuration :
 			return f( TotalDurationMetric() );
-		case PerHashDuration :
+		case MonitorAlgo::PerHashDuration :
 			return f( PerHashDurationMetric() );
-		case PerComputeDuration :
+		case MonitorAlgo::PerComputeDuration :
 			return f( PerComputeDurationMetric() );
-		case HashesPerCompute :
+		case MonitorAlgo::HashesPerCompute :
 			return f( HashesPerComputeMetric() );
 		default :
 			return f( InvalidMetric() );
@@ -339,6 +339,9 @@ struct FormatStatistics
 namespace Gaffer
 {
 
+namespace MonitorAlgo
+{
+
 std::string formatStatistics( const PerformanceMonitor &monitor, size_t maxLinesPerMetric )
 {
 	std::string s;
@@ -357,5 +360,7 @@ std::string formatStatistics( const PerformanceMonitor &monitor, PerformanceMetr
 {
 	return dispatchMetric<FormatStatistics>( FormatStatistics( monitor.allStatistics(), maxLines ), metric );
 }
+
+} // namespace MonitorAlgo
 
 } // namespace Gaffer

--- a/src/Gaffer/Path.cpp
+++ b/src/Gaffer/Path.cpp
@@ -220,7 +220,7 @@ void Path::setFromPath( const Path *path )
 void Path::setFromString( const std::string &string )
 {
 	Names newNames;
-	tokenize<InternedString>( string, '/', back_inserter( newNames ) );
+	StringAlgo::tokenize<InternedString>( string, '/', back_inserter( newNames ) );
 
 	InternedString newRoot;
 	if( string.size() && string[0] == '/' )

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -269,7 +269,7 @@ void Reference::loadInternal( const std::string &fileName )
 			// would be lost on save/reload. We use non-persistent
 			// metadata for this so that they can copy/paste nodes
 			// out of the reference and have the copies be editable.
-			setReadOnly( node, true, /* persistent = */ false );
+			MetadataAlgo::setReadOnly( node, true, /* persistent = */ false );
 		}
 	}
 

--- a/src/Gaffer/StringAlgo.cpp
+++ b/src/Gaffer/StringAlgo.cpp
@@ -42,6 +42,9 @@
 namespace Gaffer
 {
 
+namespace StringAlgo
+{
+
 int numericSuffix( const std::string &s, std::string *stem )
 {
 	static boost::regex g_regex( "^(.*[^0-9]+)([0-9]+)$" );
@@ -66,5 +69,7 @@ int numericSuffix( const std::string &s, int defaultSuffix, std::string *stem )
 	int n = numericSuffix( s, stem );
 	return n < 0 ? defaultSuffix : n;
 }
+
+} // namespace StringAlgo
 
 } // namespace Gaffer

--- a/src/GafferArnold/ArnoldVDB.cpp
+++ b/src/GafferArnold/ArnoldVDB.cpp
@@ -234,11 +234,11 @@ IECore::ConstObjectPtr ArnoldVDB::computeSource( const Context *context ) const
 	parameters["filename"] = new StringData( fileNamePlug()->getValue() );
 
 	StringVectorDataPtr grids = new StringVectorData();
-	tokenize( gridsString, ' ', grids->writable() );
+	StringAlgo::tokenize( gridsString, ' ', grids->writable() );
 	parameters["grids"] = grids;
 
 	StringVectorDataPtr velocityGrids = new StringVectorData();
-	tokenize( velocityGridsPlug()->getValue(), ' ', velocityGrids->writable() );
+	StringAlgo::tokenize( velocityGridsPlug()->getValue(), ' ', velocityGrids->writable() );
 	parameters["velocity_grids"] = velocityGrids;
 
 	parameters["velocity_scale"] = new FloatData( velocityScalePlug()->getValue() );

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -320,7 +320,7 @@ class ArnoldOutput : public IECore::RefCounted
 			else
 			{
 				vector<std::string> tokens;
-				Gaffer::tokenize( m_data, ' ', tokens );
+				Gaffer::StringAlgo::tokenize( m_data, ' ', tokens );
 				if( tokens.size() == 2 && tokens[0] == "color" )
 				{
 					m_data = tokens[1] + " RGBA";

--- a/src/GafferBindings/ExceptionAlgo.cpp
+++ b/src/GafferBindings/ExceptionAlgo.cpp
@@ -45,6 +45,9 @@ using namespace boost::python;
 namespace GafferBindings
 {
 
+namespace ExceptionAlgo
+{
+
 std::string formatPythonException( bool withStacktrace, int *lineNumber )
 {
 	PyObject *exceptionPyObject, *valuePyObject, *tracebackPyObject;
@@ -106,5 +109,7 @@ void translatePythonException( bool withStacktrace )
 {
 	throw IECore::Exception( formatPythonException( withStacktrace ) );
 }
+
+} // namespace ExceptionAlgo
 
 } // namespace GafferBindings

--- a/src/GafferBindings/ExpressionBinding.cpp
+++ b/src/GafferBindings/ExpressionBinding.cpp
@@ -98,7 +98,7 @@ struct ExpressionChangedSlotCaller
 		}
 		catch( const error_already_set &e )
 		{
-			translatePythonException();
+			ExceptionAlgo::translatePythonException();
 		}
 		return boost::signals::detail::unusable();
 	}
@@ -134,7 +134,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 				}
 				catch( const error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 
@@ -163,7 +163,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 				}
 				catch( const error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 
@@ -186,7 +186,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 				}
 				catch( const error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 
@@ -209,7 +209,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 				}
 				catch( const error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 
@@ -242,7 +242,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 				}
 				catch( const error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 
@@ -265,7 +265,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 				}
 				catch( const error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 

--- a/src/GafferBindings/MatchPatternPathFilterBinding.cpp
+++ b/src/GafferBindings/MatchPatternPathFilterBinding.cpp
@@ -52,14 +52,14 @@ namespace
 
 MatchPatternPathFilterPtr construct( object pythonPatterns, const char *propertyName, bool leafOnly )
 {
-	std::vector<MatchPattern> patterns;
+	std::vector<StringAlgo::MatchPattern> patterns;
 	boost::python::container_utils::extend_container( patterns, pythonPatterns );
 	return new MatchPatternPathFilter( patterns, propertyName, leafOnly );
 }
 
 void setMatchPatterns( MatchPatternPathFilter &f, object pythonPatterns )
 {
-	std::vector<MatchPattern> patterns;
+	std::vector<StringAlgo::MatchPattern> patterns;
 	boost::python::container_utils::extend_container( patterns, pythonPatterns );
 	f.setMatchPatterns( patterns );
 }
@@ -67,8 +67,8 @@ void setMatchPatterns( MatchPatternPathFilter &f, object pythonPatterns )
 list getMatchPatterns( const MatchPatternPathFilter &f )
 {
 	list result;
-	const std::vector<MatchPattern> &patterns = f.getMatchPatterns();
-	for( std::vector<MatchPattern>::const_iterator it = patterns.begin(), eIt = patterns.end(); it != eIt; ++it )
+	const std::vector<StringAlgo::MatchPattern> &patterns = f.getMatchPatterns();
+	for( std::vector<StringAlgo::MatchPattern>::const_iterator it = patterns.begin(), eIt = patterns.end(); it != eIt; ++it )
 	{
 		result.append( *it );
 	}

--- a/src/GafferBindings/MetadataAlgoBinding.cpp
+++ b/src/GafferBindings/MetadataAlgoBinding.cpp
@@ -48,6 +48,9 @@ namespace GafferBindings
 
 void bindMetadataAlgo()
 {
+	object module( borrowed( PyImport_AddModule( "Gaffer.MetadataAlgo" ) ) );
+	scope().attr( "MetadataAlgo" ) = module;
+	scope moduleScope( module );
 
 	def( "setReadOnly", &setReadOnly, ( arg( "graphComponent" ), arg( "readOnly"), arg( "persistent" ) = true ) );
 	def( "getReadOnly", &getReadOnly );

--- a/src/GafferBindings/MetadataAlgoBinding.cpp
+++ b/src/GafferBindings/MetadataAlgoBinding.cpp
@@ -41,7 +41,7 @@
 #include "Gaffer/Plug.h"
 
 using namespace boost::python;
-using namespace Gaffer;
+using namespace Gaffer::MetadataAlgo;
 
 namespace GafferBindings
 {

--- a/src/GafferBindings/MetadataBinding.cpp
+++ b/src/GafferBindings/MetadataBinding.cpp
@@ -213,7 +213,7 @@ object registerNodeDescription( tuple args, dict kw )
 
 	for( size_t i = 2, e = len( args ); i < e; i += 2 )
 	{
-		MatchPattern plugPath = extract<MatchPattern>( args[i] )();
+		StringAlgo::MatchPattern plugPath = extract<StringAlgo::MatchPattern>( args[i] )();
 		extract<dict> dictExtractor( args[i+1] );
 		if( dictExtractor.check() )
 		{
@@ -254,7 +254,7 @@ object registerNode( tuple args, dict kw )
 		list plugsItems = plugs.items();
 		for( size_t i = 0, e = len( plugsItems ); i < e; ++i )
 		{
-			MatchPattern plugPath = extract<MatchPattern>( plugsItems[i][0] )();
+			StringAlgo::MatchPattern plugPath = extract<StringAlgo::MatchPattern>( plugsItems[i][0] )();
 			object plugValues = plugsItems[i][1];
 			for( size_t vi = 0, ve = len( plugValues ); vi < ve; vi += 2 )
 			{
@@ -303,7 +303,7 @@ struct ValueChangedSlotCaller
 		return boost::signals::detail::unusable();
 	}
 
-	boost::signals::detail::unusable operator()( boost::python::object slot, IECore::TypeId nodeTypeId, const MatchPattern &plugPath, IECore::InternedString key, Plug *plug )
+	boost::signals::detail::unusable operator()( boost::python::object slot, IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key, Plug *plug )
 	{
 		slot( nodeTypeId, plugPath.c_str(), key.c_str(), PlugPtr( plug ) );
 		return boost::signals::detail::unusable();
@@ -424,7 +424,7 @@ void bindMetadata()
 		.staticmethod( "value" )
 
 		.def( "deregisterValue", (void (*)( IECore::TypeId, IECore::InternedString ) )&Metadata::deregisterValue )
-		.def( "deregisterValue", (void (*)( IECore::TypeId, const MatchPattern &, IECore::InternedString ) )&Metadata::deregisterValue )
+		.def( "deregisterValue", (void (*)( IECore::TypeId, const StringAlgo::MatchPattern &, IECore::InternedString ) )&Metadata::deregisterValue )
 		.def( "deregisterValue", (void (*)( GraphComponent *, IECore::InternedString ) )&Metadata::deregisterValue )
 		.staticmethod( "deregisterValue" )
 
@@ -508,7 +508,7 @@ void bindMetadata()
 		)
 		.staticmethod( "plugValue" )
 
-		.def( "deregisterPlugValue", (void (*)( IECore::TypeId, const MatchPattern &, InternedString ))&Metadata::deregisterPlugValue )
+		.def( "deregisterPlugValue", (void (*)( IECore::TypeId, const StringAlgo::MatchPattern &, InternedString ))&Metadata::deregisterPlugValue )
 		.def( "deregisterPlugValue", (void (*)( Plug *, InternedString ))&Metadata::deregisterPlugValue )
 		.staticmethod( "deregisterPlugValue" )
 

--- a/src/GafferBindings/MonitorBinding.cpp
+++ b/src/GafferBindings/MonitorBinding.cpp
@@ -119,36 +119,42 @@ dict allStatistics( PerformanceMonitor &m )
 void GafferBindings::bindMonitor()
 {
 
-	enum_<PerformanceMetric>( "PerformanceMetric" )
-		.value( "Invalid", Invalid )
-		.value( "TotalDuration", TotalDuration )
-		.value( "HashDuration", HashDuration )
-		.value( "ComputeDuration", ComputeDuration )
-		.value( "PerHashDuration", PerHashDuration )
-		.value( "PerComputeDuration", PerComputeDuration )
-		.value( "HashCount", HashCount )
-		.value( "ComputeCount", ComputeCount )
-		.value( "HashesPerCompute", HashesPerCompute )
-	;
+	{
+		object module( borrowed( PyImport_AddModule( "Gaffer.MonitorAlgo" ) ) );
+		scope().attr( "MonitorAlgo" ) = module;
+		scope moduleScope( module );
 
-	def(
-		"formatStatistics",
-		( std::string (*)( const PerformanceMonitor &, size_t ) )&formatStatistics,
-		(
-			arg( "monitor" ),
-			arg( "maxLinesPerMetric" ) = 50
-		)
-	);
+		enum_<PerformanceMetric>( "PerformanceMetric" )
+			.value( "Invalid", Invalid )
+			.value( "TotalDuration", TotalDuration )
+			.value( "HashDuration", HashDuration )
+			.value( "ComputeDuration", ComputeDuration )
+			.value( "PerHashDuration", PerHashDuration )
+			.value( "PerComputeDuration", PerComputeDuration )
+			.value( "HashCount", HashCount )
+			.value( "ComputeCount", ComputeCount )
+			.value( "HashesPerCompute", HashesPerCompute )
+		;
 
-	def(
-		"formatStatistics",
-		( std::string (*)( const PerformanceMonitor &, PerformanceMetric, size_t ) )&formatStatistics,
-		(
-			arg( "monitor" ),
-			arg( "metric" ),
-			arg( "maxLines" ) = 50
-		)
-	);
+		def(
+			"formatStatistics",
+			( std::string (*)( const PerformanceMonitor &, size_t ) )&formatStatistics,
+			(
+				arg( "monitor" ),
+				arg( "maxLinesPerMetric" ) = 50
+			)
+		);
+
+		def(
+			"formatStatistics",
+			( std::string (*)( const PerformanceMonitor &, PerformanceMetric, size_t ) )&formatStatistics,
+			(
+				arg( "monitor" ),
+				arg( "metric" ),
+				arg( "maxLines" ) = 50
+			)
+		);
+	}
 
 	class_<Monitor, boost::noncopyable>( "Monitor", no_init )
 		.def( "setActive", &Monitor::setActive )

--- a/src/GafferBindings/MonitorBinding.cpp
+++ b/src/GafferBindings/MonitorBinding.cpp
@@ -46,6 +46,7 @@
 
 using namespace boost::python;
 using namespace Gaffer;
+using namespace Gaffer::MonitorAlgo;
 using namespace GafferBindings;
 
 namespace

--- a/src/GafferBindings/NodeBinding.cpp
+++ b/src/GafferBindings/NodeBinding.cpp
@@ -94,7 +94,7 @@ struct ErrorSlotCaller
 		}
 		catch( const error_already_set &e )
 		{
-			translatePythonException();
+			ExceptionAlgo::translatePythonException();
 		}
 		return boost::signals::detail::unusable();
 	}

--- a/src/GafferBindings/PathBinding.cpp
+++ b/src/GafferBindings/PathBinding.cpp
@@ -138,7 +138,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 				}
 				catch( const error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 			return WrappedType::isValid();
@@ -159,7 +159,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 				}
 				catch( const error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 			return WrappedType::isLeaf();
@@ -192,7 +192,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 				}
 				catch( const error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 			WrappedType::propertyNames( names );
@@ -225,7 +225,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 				}
 				catch( const error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 			return WrappedType::property( name );
@@ -250,7 +250,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 				}
 				catch( const error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 			return WrappedType::copy();
@@ -273,7 +273,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 				}
 				catch( const error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 			WrappedType::doChildren( children );

--- a/src/GafferBindings/ReferenceBinding.cpp
+++ b/src/GafferBindings/ReferenceBinding.cpp
@@ -63,7 +63,7 @@ struct ReferenceLoadedSlotCaller
 		}
 		catch( const error_already_set &e )
 		{
-			translatePythonException();
+			ExceptionAlgo::translatePythonException();
 		}
 		return boost::signals::detail::unusable();
 	}

--- a/src/GafferBindings/ScriptNodeBinding.cpp
+++ b/src/GafferBindings/ScriptNodeBinding.cpp
@@ -149,7 +149,7 @@ bool tolerantExec( const char *pythonScript, boost::python::object globals, boos
 		if( v == NULL)
 		{
 			int lineNumber = 0;
-			std::string message = formatPythonException( /* withTraceback = */ false, &lineNumber );
+			std::string message = ExceptionAlgo::formatPythonException( /* withTraceback = */ false, &lineNumber );
 			IECore::msg( IECore::Msg::Error, formattedErrorContext( lineNumber, context ), message );
 			result = true;
 		}
@@ -194,7 +194,7 @@ std::string serialise( const Node *parent, const Set *filter )
 	}
 	catch( boost::python::error_already_set &e )
 	{
-		translatePythonException();
+		ExceptionAlgo::translatePythonException();
 	}
 
 	return result;
@@ -222,7 +222,7 @@ bool execute( ScriptNode *script, const std::string &serialisation, Node *parent
 			catch( boost::python::error_already_set &e )
 			{
 				int lineNumber = 0;
-				std::string message = formatPythonException( /* withTraceback = */ false, &lineNumber );
+				std::string message = ExceptionAlgo::formatPythonException( /* withTraceback = */ false, &lineNumber );
 				throw IECore::Exception( formattedErrorContext( lineNumber, context ) + " : " + message );
 			}
 		}
@@ -233,7 +233,7 @@ bool execute( ScriptNode *script, const std::string &serialisation, Node *parent
 	}
 	catch( boost::python::error_already_set &e )
 	{
-		translatePythonException();
+		ExceptionAlgo::translatePythonException();
 	}
 
 	return result;

--- a/src/GafferBindings/StringAlgoBinding.cpp
+++ b/src/GafferBindings/StringAlgoBinding.cpp
@@ -47,9 +47,9 @@ namespace GafferBindings
 
 void bindStringAlgo()
 {
-	def( "match", (bool (*)( const char *, const char * ))&Gaffer::match );
-	def( "matchMultiple", (bool (*)( const char *, const char * ))&Gaffer::matchMultiple );
-	def( "hasWildcards", (bool (*)( const char * ))&Gaffer::hasWildcards );
+	def( "match", (bool (*)( const char *, const char * ))&Gaffer::StringAlgo::match );
+	def( "matchMultiple", (bool (*)( const char *, const char * ))&Gaffer::StringAlgo::matchMultiple );
+	def( "hasWildcards", (bool (*)( const char * ))&Gaffer::StringAlgo::hasWildcards );
 }
 
 } // namespace GafferBindings

--- a/src/GafferBindings/StringAlgoBinding.cpp
+++ b/src/GafferBindings/StringAlgoBinding.cpp
@@ -47,6 +47,10 @@ namespace GafferBindings
 
 void bindStringAlgo()
 {
+	object module( borrowed( PyImport_AddModule( "Gaffer.StringAlgo" ) ) );
+	scope().attr( "StringAlgo" ) = module;
+	scope moduleScope( module );
+
 	def( "match", (bool (*)( const char *, const char * ))&Gaffer::StringAlgo::match );
 	def( "matchMultiple", (bool (*)( const char *, const char * ))&Gaffer::StringAlgo::matchMultiple );
 	def( "hasWildcards", (bool (*)( const char * ))&Gaffer::StringAlgo::hasWildcards );

--- a/src/GafferDispatchBindings/DispatcherBinding.cpp
+++ b/src/GafferDispatchBindings/DispatcherBinding.cpp
@@ -85,7 +85,7 @@ class DispatcherWrapper : public NodeWrapper<Dispatcher>
 				}
 				catch( const boost::python::error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 			else
@@ -112,7 +112,7 @@ class DispatcherWrapper : public NodeWrapper<Dispatcher>
 				}
 				catch( const boost::python::error_already_set &e )
 				{
-					translatePythonException();
+					ExceptionAlgo::translatePythonException();
 				}
 			}
 
@@ -208,7 +208,7 @@ struct DispatcherHelper
 		}
 		catch( const boost::python::error_already_set &e )
 		{
-			translatePythonException();
+			ExceptionAlgo::translatePythonException();
 		}
 
 		return 0;
@@ -225,7 +225,7 @@ struct DispatcherHelper
 			}
 			catch( const boost::python::error_already_set &e )
 			{
-				translatePythonException();
+				ExceptionAlgo::translatePythonException();
 			}
 		}
 	}

--- a/src/GafferImage/ChannelMaskPlug.cpp
+++ b/src/GafferImage/ChannelMaskPlug.cpp
@@ -86,11 +86,11 @@ void ChannelMaskPlug::removeDuplicateIndices( std::vector<std::string> &inChanne
 		std::vector<std::string>::iterator cIt( inChannels.begin() );
 		while ( cIt != inChannels.end() )
 		{
-			int idx = colorIndex( *cIt );
+			int idx = ImageAlgo::colorIndex( *cIt );
 			std::vector<std::string>::iterator duplicateIt( cIt + 1 );
 			while ( duplicateIt != inChannels.end() )
 			{
-				if ( colorIndex( *duplicateIt ) == idx )
+				if( ImageAlgo::colorIndex( *duplicateIt ) == idx )
 				{
 					inChannels.erase( duplicateIt );
 					duplicateIt = cIt + 1;

--- a/src/GafferImage/Clamp.cpp
+++ b/src/GafferImage/Clamp.cpp
@@ -191,7 +191,7 @@ void Clamp::hashChannelData( const GafferImage::ImagePlug *output, const Gaffer:
 	inPlug()->channelDataPlug()->hash( h );
 
 	const std::string &channelName = context->get<std::string>( ImagePlug::channelNameContextName );
-	const int channelIndex = std::max( 0, colorIndex( channelName ) );
+	const int channelIndex = std::max( 0, ImageAlgo::colorIndex( channelName ) );
 
 	minPlug()->getChild( channelIndex )->hash( h );
 	maxPlug()->getChild( channelIndex )->hash( h );
@@ -206,7 +206,7 @@ void Clamp::hashChannelData( const GafferImage::ImagePlug *output, const Gaffer:
 
 void Clamp::processChannelData( const Gaffer::Context *context, const ImagePlug *parent, const std::string &channelName, FloatVectorDataPtr outData ) const
 {
-	const int channelIndex = std::max( 0, colorIndex( channelName ) );
+	const int channelIndex = std::max( 0, ImageAlgo::colorIndex( channelName ) );
 
 	const float minimum = minPlug()->getChild( channelIndex )->getValue();
 	const float maximum = maxPlug()->getChild( channelIndex )->getValue();

--- a/src/GafferImage/Constant.cpp
+++ b/src/GafferImage/Constant.cpp
@@ -159,13 +159,13 @@ void Constant::hashChannelData( const GafferImage::ImagePlug *output, const Gaff
 	ImageNode::hashChannelData( output, context, h );
 	// Don't bother hashing the format or tile origin here as we couldn't care less about the
 	// position on the canvas, only the colour!
-	const int channelIndex = colorIndex( context->get<std::string>( ImagePlug::channelNameContextName ) );
+	const int channelIndex = ImageAlgo::colorIndex( context->get<std::string>( ImagePlug::channelNameContextName ) );
 	colorPlug()->getChild( channelIndex )->hash( h );
 }
 
 IECore::ConstFloatVectorDataPtr Constant::computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const
 {
-	const int channelIndex = colorIndex( context->get<std::string>( ImagePlug::channelNameContextName ) );
+	const int channelIndex = ImageAlgo::colorIndex( context->get<std::string>( ImagePlug::channelNameContextName ) );
 	const float value = colorPlug()->getChild( channelIndex )->getValue();
 
 	FloatVectorDataPtr result = new FloatVectorData;

--- a/src/GafferImage/CopyImageMetadata.cpp
+++ b/src/GafferImage/CopyImageMetadata.cpp
@@ -128,7 +128,7 @@ IECore::ConstCompoundObjectPtr CopyImageMetadata::computeProcessedMetadata( cons
 	for ( IECore::CompoundObject::ObjectMap::const_iterator it = copyFrom->members().begin(), eIt = copyFrom->members().end(); it != eIt; ++it )
 	{
 		bool copy = false;
-		if ( matchMultiple( it->first.c_str(), names.c_str() ) != invert )
+		if( StringAlgo::matchMultiple( it->first.c_str(), names.c_str() ) != invert )
 		{
 			copy = true;
 		}

--- a/src/GafferImage/Crop.cpp
+++ b/src/GafferImage/Crop.cpp
@@ -275,7 +275,7 @@ Imath::Box2i Crop::computeDataWindow( const Gaffer::Context *context, const Imag
 	const V2i offset = offsetPlug()->getValue();
 	if( affectDataWindowPlug()->getValue() )
 	{
-		result = intersection( result, cropWindow );
+		result = BufferAlgo::intersection( result, cropWindow );
 	}
 
 	result.min += offset;

--- a/src/GafferImage/DeleteImageMetadata.cpp
+++ b/src/GafferImage/DeleteImageMetadata.cpp
@@ -115,7 +115,7 @@ IECore::ConstCompoundObjectPtr DeleteImageMetadata::computeProcessedMetadata( co
 	for ( IECore::CompoundObject::ObjectMap::const_iterator it = inputMetadata->members().begin(), eIt = inputMetadata->members().end(); it != eIt; ++it )
 	{
 		bool keep = true;
-		if ( matchMultiple( it->first.c_str(), names.c_str() ) != invert )
+		if ( StringAlgo::matchMultiple( it->first.c_str(), names.c_str() ) != invert )
 		{
 			keep = false;
 		}

--- a/src/GafferImage/Grade.cpp
+++ b/src/GafferImage/Grade.cpp
@@ -163,7 +163,7 @@ bool Grade::channelEnabled( const std::string &channel ) const
 		return false;
 	}
 
-	const int channelIndex = std::max( 0, colorIndex( channel ) );
+	const int channelIndex = std::max( 0, ImageAlgo::colorIndex( channel ) );
 
 	// Never bother to process the alpha channel.
 	if ( channelIndex == 3 ) return false;
@@ -222,7 +222,7 @@ void Grade::hashChannelData( const GafferImage::ImagePlug *output, const Gaffer:
 	inPlug()->channelDataPlug()->hash( h );
 
 	const std::string &channelName = context->get<std::string>( ImagePlug::channelNameContextName );
-	const int channelIndex = colorIndex( channelName );
+	const int channelIndex = ImageAlgo::colorIndex( channelName );
 	if( channelIndex >= 0 and channelIndex < 3 )
 	{
 		/// \todo The channelIndex tests above might be guaranteed true by
@@ -247,7 +247,7 @@ void Grade::processChannelData( const Gaffer::Context *context, const ImagePlug 
 
 	// Do some pre-processing.
 	float A, B, gamma;
-	parameters( std::max( 0, colorIndex( channel ) ), A, B, gamma );
+	parameters( std::max( 0, ImageAlgo::colorIndex( channel ) ), A, B, gamma );
 	const float invGamma = 1. / gamma;
 	const bool whiteClamp = whiteClampPlug()->getValue();
 	const bool blackClamp = blackClampPlug()->getValue();

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -76,7 +76,7 @@ class CopyTile
 		void operator()( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
 		{
 			const Box2i tileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
-			const Box2i b = intersection( tileBound, m_dataWindow );
+			const Box2i b = BufferAlgo::intersection( tileBound, m_dataWindow );
 
 			const size_t imageStride = m_dataWindow.size().x;
 			const size_t tileStrideSize = sizeof(float) * b.size().x;
@@ -332,7 +332,7 @@ IECore::ImagePrimitivePtr ImagePlug::image() const
 	Box2i dataWindow = dataWindowPlug()->getValue();
 	Box2i newDataWindow( Imath::V2i( 0 ) );
 
-	if( !empty( dataWindow ) )
+	if( !BufferAlgo::empty( dataWindow ) )
 	{
 		newDataWindow = format.toEXRSpace( dataWindow );
 	}
@@ -362,7 +362,7 @@ IECore::ImagePrimitivePtr ImagePlug::image() const
 	}
 
 	CopyTile copyTile( imageChannelData, channelNames, dataWindow );
-	parallelProcessTiles( this, channelNames, copyTile, dataWindow );
+	ImageAlgo::parallelProcessTiles( this, channelNames, copyTile, dataWindow );
 
 	return result;
 }
@@ -380,7 +380,7 @@ IECore::MurmurHash ImagePlug::imageHash() const
 
 	HashTile hashTile;
 	AppendHash appendHash( result );
-	parallelGatherTiles( this, channelNames, hashTile, appendHash, dataWindow, BottomToTop );
+	ImageAlgo::parallelGatherTiles( this, channelNames, hashTile, appendHash, dataWindow, ImageAlgo::BottomToTop );
 
 	return result;
 }

--- a/src/GafferImage/ImageStats.cpp
+++ b/src/GafferImage/ImageStats.cpp
@@ -255,7 +255,7 @@ void ImageStats::channelNameFromOutput( const ValuePlug *output, std::string &ch
 		{
 			for( std::vector<std::string>::iterator it( uniqueChannels.begin() ); it != uniqueChannels.end(); ++it )
 			{
-				if ( colorIndex( *it ) == channelIndex )
+				if( ImageAlgo::colorIndex( *it ) == channelIndex )
 				{
 					channelName = *it;
 					return;
@@ -299,7 +299,7 @@ void ImageStats::compute( ValuePlug *output, const Context *context ) const
 		return;
 	}
 
-	const int channelIndex = colorIndex( channelName );
+	const int channelIndex = ImageAlgo::colorIndex( channelName );
 
 	// Loop over the ROI and compute the min, max and average channel values and then set our outputs.
 	Sampler s( inPlug(), channelName, regionOfInterest );

--- a/src/GafferImage/Merge.cpp
+++ b/src/GafferImage/Merge.cpp
@@ -202,12 +202,12 @@ void Merge::hashChannelData( const GafferImage::ImagePlug *output, const Gaffer:
 		IECore::ConstStringVectorDataPtr channelNamesData = (*it)->channelNamesPlug()->getValue();
 		const std::vector<std::string> &channelNames = channelNamesData->readable();
 
-		if( channelExists( channelNames, channelName ) )
+		if( ImageAlgo::channelExists( channelNames, channelName ) )
 		{
 			(*it)->channelDataPlug()->hash( h );
 		}
 
-		if( channelExists( channelNames, "A" ) )
+		if( ImageAlgo::channelExists( channelNames, "A" ) )
 		{
 			h.append( (*it)->channelDataHash( "A", tileOrigin ) );
 		}
@@ -284,7 +284,7 @@ IECore::ConstFloatVectorDataPtr Merge::merge( F f, const std::string &channelNam
 		ConstFloatVectorDataPtr channelData;
 		ConstFloatVectorDataPtr alphaData;
 
-		if( channelExists( channelNames, channelName ) )
+		if( ImageAlgo::channelExists( channelNames, channelName ) )
 		{
 			channelData = (*it)->channelDataPlug()->getValue();
 		}
@@ -293,7 +293,7 @@ IECore::ConstFloatVectorDataPtr Merge::merge( F f, const std::string &channelNam
 			channelData = ImagePlug::blackTile();
 		}
 
-		if( channelExists( channelNames, "A" ) )
+		if( ImageAlgo::channelExists( channelNames, "A" ) )
 		{
 			alphaData = (*it)->channelData( "A", tileOrigin );
 		}

--- a/src/GafferImage/Mirror.cpp
+++ b/src/GafferImage/Mirror.cpp
@@ -177,7 +177,7 @@ void Mirror::hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer:
 Imath::Box2i Mirror::computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const
 {
 	const Box2i inDataWindow = inPlug()->dataWindowPlug()->getValue();
-	if( empty( inDataWindow ) )
+	if( BufferAlgo::empty( inDataWindow ) )
 	{
 		return inDataWindow;
 	}

--- a/src/GafferImage/Offset.cpp
+++ b/src/GafferImage/Offset.cpp
@@ -186,7 +186,7 @@ IECore::ConstFloatVectorDataPtr Offset::computeChannelData( const std::string &c
 				const float *in = &inData->readable().front();
 
 				const Box2i inTileBound( inTileOrigin, inTileOrigin + V2i( ImagePlug::tileSize() ) );
-				const Box2i inRegion = intersection(
+				const Box2i inRegion = BufferAlgo::intersection(
 					inBound,
 					inTileBound
 				);
@@ -197,9 +197,9 @@ IECore::ConstFloatVectorDataPtr Offset::computeChannelData( const std::string &c
 				{
 					memcpy(
 						// to
-						out + index( inScanlineOrigin + offset, outTileBound ),
+						out + BufferAlgo::index( inScanlineOrigin + offset, outTileBound ),
 						// from
-						in + index( inScanlineOrigin, inTileBound ),
+						in + BufferAlgo::index( inScanlineOrigin, inTileBound ),
 						sizeof( float ) * scanlineLength
 					);
 					++inScanlineOrigin.y;

--- a/src/GafferImage/Resample.cpp
+++ b/src/GafferImage/Resample.cpp
@@ -476,7 +476,7 @@ void Resample::hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffe
 Imath::Box2i Resample::computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const
 {
 	const Box2i srcDataWindow = inPlug()->dataWindowPlug()->getValue();
-	if( empty( srcDataWindow ) )
+	if( BufferAlgo::empty( srcDataWindow ) )
 	{
 		return srcDataWindow;
 	}

--- a/src/GafferImage/Sampler.cpp
+++ b/src/GafferImage/Sampler.cpp
@@ -61,17 +61,17 @@ Sampler::Sampler( const GafferImage::ImagePlug *plug, const std::string &channel
 	// be able to service calls within m_sampleWindow
 	// when taking into account m_boundingMode and m_dataWindow.
 
-	m_cacheWindow = intersection( m_sampleWindow, m_dataWindow );
-	if( empty( m_cacheWindow ) && m_boundingMode == Clamp )
+	m_cacheWindow = BufferAlgo::intersection( m_sampleWindow, m_dataWindow );
+	if( BufferAlgo::empty( m_cacheWindow ) && m_boundingMode == Clamp )
 	{
 		// The area being sampled is entirely outside the
 		// data window, but we still need to cache the region
 		// into which we will clamp the queries.
 		m_cacheWindow = Box2i();
-		m_cacheWindow.extendBy( clamp( m_sampleWindow.min, m_dataWindow ) );
-		m_cacheWindow.extendBy( clamp( m_sampleWindow.max, m_dataWindow ) );
-		m_cacheWindow.extendBy( clamp( V2i( m_sampleWindow.min.x, m_sampleWindow.max.y ), m_dataWindow ) );
-		m_cacheWindow.extendBy( clamp( V2i( m_sampleWindow.max.x, m_sampleWindow.min.y ), m_dataWindow ) );
+		m_cacheWindow.extendBy( BufferAlgo::clamp( m_sampleWindow.min, m_dataWindow ) );
+		m_cacheWindow.extendBy( BufferAlgo::clamp( m_sampleWindow.max, m_dataWindow ) );
+		m_cacheWindow.extendBy( BufferAlgo::clamp( V2i( m_sampleWindow.min.x, m_sampleWindow.max.y ), m_dataWindow ) );
+		m_cacheWindow.extendBy( BufferAlgo::clamp( V2i( m_sampleWindow.max.x, m_sampleWindow.min.y ), m_dataWindow ) );
 		m_cacheWindow.max += V2i( 1 ); // max is exclusive.
 	}
 

--- a/src/GafferImage/Shape.cpp
+++ b/src/GafferImage/Shape.cpp
@@ -303,7 +303,7 @@ IECore::ConstFloatVectorDataPtr Shape::computeChannelData( const std::string &ch
 float Shape::channelValue( const GafferImage::ImagePlug *parent, const std::string &channelName ) const
 {
 	const Color4fPlug *p = parent == shadowShapePlug() ? shadowColorPlug() : colorPlug();
-	const int i = colorIndex( channelName );
+	const int i = ImageAlgo::colorIndex( channelName );
 	float c = p->getChild( i )->getValue();
 	if( i != 3 )
 	{

--- a/src/GafferImage/Text.cpp
+++ b/src/GafferImage/Text.cpp
@@ -372,7 +372,7 @@ IECore::ConstCompoundObjectPtr Text::computeLayout( const Gaffer::Context *conte
 	// in a vector of Lines made up of Words.
 
 	Box2i area = areaPlug()->getValue();
-	if( empty( area ) )
+	if( BufferAlgo::empty( area ) )
 	{
 		area = inPlug()->formatPlug()->getValue().getDisplayWindow();
 	}
@@ -578,8 +578,8 @@ IECore::ConstFloatVectorDataPtr Text::computeShapeChannelData(  const Imath::V2i
 	for( int i = 0, e = characters.size(); i < e; ++i )
 	{
 		const Box2i &bitmapBound = bounds[i];
-		const Box2i validBound = GafferImage::intersection( tileBound, bitmapBound );
-		if( empty( validBound ) )
+		const Box2i validBound = BufferAlgo::intersection( tileBound, bitmapBound );
+		if( BufferAlgo::empty( validBound ) )
 		{
 			continue;
 		}

--- a/src/GafferImage/UVWarp.cpp
+++ b/src/GafferImage/UVWarp.cpp
@@ -66,7 +66,7 @@ struct UVWarp::Engine : public Warp::Engine
 		V2i oP;
 		for( oP.y = validTileBound.min.y; oP.y < validTileBound.max.y; ++oP.y )
 		{
-			size_t i = index( V2i( validTileBound.min.x, oP.y ), tileBound );
+			size_t i = BufferAlgo::index( V2i( validTileBound.min.x, oP.y ), tileBound );
 			for( oP.x = validTileBound.min.x; oP.x < validTileBound.max.x; ++oP.x, ++i )
 			{
 				if( m_a[i] == 0.0f )
@@ -91,7 +91,7 @@ struct UVWarp::Engine : public Warp::Engine
 	virtual Imath::V2f inputPixel( const Imath::V2f &outputPixel ) const
 	{
 		const V2i outputPixelI( (int)floorf( outputPixel.x ), (int)floorf( outputPixel.y ) );
-		const size_t i = index( outputPixelI, m_tileBound );
+		const size_t i = BufferAlgo::index( outputPixelI, m_tileBound );
 		if( m_a[i] == 0.0f )
 		{
 			return black;
@@ -179,19 +179,19 @@ void UVWarp::hashEngine( const std::string &channelName, const Imath::V2i &tileO
 	ContextPtr tmpContext = new Context( *context, Context::Borrowed );
 	Context::Scope scopedContext( tmpContext.get() );
 
-	if( channelExists( channelNames->readable(), "R" ) )
+	if( ImageAlgo::channelExists( channelNames->readable(), "R" ) )
 	{
 		tmpContext->set<std::string>( ImagePlug::channelNameContextName, "R" );
 		uvPlug()->channelDataPlug()->hash( h );
 	}
 
-	if( channelExists( channelNames->readable(), "G" ) )
+	if( ImageAlgo::channelExists( channelNames->readable(), "G" ) )
 	{
 		tmpContext->set<std::string>( ImagePlug::channelNameContextName, "G" );
 		uvPlug()->channelDataPlug()->hash( h );
 	}
 
-	if( channelExists( channelNames->readable(), "A" ) )
+	if( ImageAlgo::channelExists( channelNames->readable(), "A" ) )
 	{
 		tmpContext->set<std::string>( ImagePlug::channelNameContextName, "A" );
 		uvPlug()->channelDataPlug()->hash( h );
@@ -203,7 +203,7 @@ void UVWarp::hashEngine( const std::string &channelName, const Imath::V2i &tileO
 const Warp::Engine *UVWarp::computeEngine( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context ) const
 {
 	const Box2i tileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
-	const Box2i validTileBound = intersection( tileBound, uvPlug()->dataWindowPlug()->getValue() );
+	const Box2i validTileBound = BufferAlgo::intersection( tileBound, uvPlug()->dataWindowPlug()->getValue() );
 
 	ConstStringVectorDataPtr channelNames = uvPlug()->channelNamesPlug()->getValue();
 
@@ -211,21 +211,21 @@ const Warp::Engine *UVWarp::computeEngine( const std::string &channelName, const
 	Context::Scope scopedContext( tmpContext.get() );
 
 	ConstFloatVectorDataPtr uData = ImagePlug::blackTile();
-	if( channelExists( channelNames->readable(), "R" ) )
+	if( ImageAlgo::channelExists( channelNames->readable(), "R" ) )
 	{
 		tmpContext->set<std::string>( ImagePlug::channelNameContextName, "R" );
 		uData = uvPlug()->channelDataPlug()->getValue();
 	}
 
 	ConstFloatVectorDataPtr vData = ImagePlug::blackTile();
-	if( channelExists( channelNames->readable(), "G" ) )
+	if( ImageAlgo::channelExists( channelNames->readable(), "G" ) )
 	{
 		tmpContext->set<std::string>( ImagePlug::channelNameContextName, "G" );
 		vData = uvPlug()->channelDataPlug()->getValue();
 	}
 
 	ConstFloatVectorDataPtr aData = ImagePlug::whiteTile();
-	if( channelExists( channelNames->readable(), "A" ) )
+	if( ImageAlgo::channelExists( channelNames->readable(), "A" ) )
 	{
 		tmpContext->set<std::string>( ImagePlug::channelNameContextName, "A" );
 		aData = uvPlug()->channelDataPlug()->getValue();

--- a/src/GafferImage/Warp.cpp
+++ b/src/GafferImage/Warp.cpp
@@ -258,7 +258,7 @@ IECore::ConstFloatVectorDataPtr Warp::computeChannelData( const std::string &cha
 		for( oP.x = tileBound.min.x; oP.x < tileBound.max.x; ++oP.x )
 		{
 			float v = 0.0f;
-			if( contains( dataWindow, oP ) )
+			if( BufferAlgo::contains( dataWindow, oP ) )
 			{
 				const V2f iP = e->inputPixel( V2f( oP.x + 0.5, oP.y + 0.5 ) );
 				if( iP != Engine::black )

--- a/src/GafferImageBindings/BufferAlgoBinding.cpp
+++ b/src/GafferImageBindings/BufferAlgoBinding.cpp
@@ -44,6 +44,9 @@ namespace GafferImageBindings
 
 void bindBufferAlgo()
 {
+	object module( borrowed( PyImport_AddModule( "GafferImage.BufferAlgo" ) ) );
+	scope().attr( "BufferAlgo" ) = module;
+	scope moduleScope( module );
 
 	def( "empty", &GafferImage::BufferAlgo::empty );
 	def( "intersects", &GafferImage::BufferAlgo::intersects );

--- a/src/GafferImageBindings/BufferAlgoBinding.cpp
+++ b/src/GafferImageBindings/BufferAlgoBinding.cpp
@@ -45,11 +45,11 @@ namespace GafferImageBindings
 void bindBufferAlgo()
 {
 
-	def( "empty", &GafferImage::empty );
-	def( "intersects", &GafferImage::intersects );
-	def( "intersection", &GafferImage::intersection );
-	def( "clamp", &GafferImage::clamp );
-	def( "contains", ( bool (*)( const Imath::Box2i&, const Imath::V2i & ) )&GafferImage::contains );
+	def( "empty", &GafferImage::BufferAlgo::empty );
+	def( "intersects", &GafferImage::BufferAlgo::intersects );
+	def( "intersection", &GafferImage::BufferAlgo::intersection );
+	def( "clamp", &GafferImage::BufferAlgo::clamp );
+	def( "contains", ( bool (*)( const Imath::Box2i&, const Imath::V2i & ) )&GafferImage::BufferAlgo::contains );
 
 }
 

--- a/src/GafferImageBindings/ImageAlgoBinding.cpp
+++ b/src/GafferImageBindings/ImageAlgoBinding.cpp
@@ -78,7 +78,7 @@ struct StringVectorFromStringVectorData
 inline bool channelExistsWrapper( const GafferImage::ImagePlug *image, const std::string &channelName )
 {
 	IECorePython::ScopedGILRelease r;
-	return GafferImage::channelExists( image, channelName );
+	return GafferImage::ImageAlgo::channelExists( image, channelName );
 }
 
 } // namespace
@@ -89,11 +89,11 @@ namespace GafferImageBindings
 void bindImageAlgo()
 {
 
-	def( "layerName", &GafferImage::layerName );
-	def( "baseName", &GafferImage::baseName );
-	def( "colorIndex", &GafferImage::colorIndex );
+	def( "layerName", &GafferImage::ImageAlgo::layerName );
+	def( "baseName", &GafferImage::ImageAlgo::baseName );
+	def( "colorIndex", &GafferImage::ImageAlgo::colorIndex );
 	def( "channelExists", &channelExistsWrapper );
-	def( "channelExists", ( bool (*)( const std::vector<std::string> &channelNames, const std::string &channelName ) )&GafferImage::channelExists );
+	def( "channelExists", ( bool (*)( const std::vector<std::string> &channelNames, const std::string &channelName ) )&GafferImage::ImageAlgo::channelExists );
 
 	StringVectorFromStringVectorData();
 

--- a/src/GafferImageBindings/ImageAlgoBinding.cpp
+++ b/src/GafferImageBindings/ImageAlgoBinding.cpp
@@ -88,6 +88,9 @@ namespace GafferImageBindings
 
 void bindImageAlgo()
 {
+	object module( borrowed( PyImport_AddModule( "GafferImage.ImageAlgo" ) ) );
+	scope().attr( "ImageAlgo" ) = module;
+	scope moduleScope( module );
 
 	def( "layerName", &GafferImage::ImageAlgo::layerName );
 	def( "baseName", &GafferImage::ImageAlgo::baseName );

--- a/src/GafferImageTest/ProcessTiles.cpp
+++ b/src/GafferImageTest/ProcessTiles.cpp
@@ -63,7 +63,7 @@ namespace GafferImageTest
 void processTiles( const GafferImage::ImagePlug *imagePlug )
 {
 	TilesEvaluateFunctor f;
-	parallelProcessTiles( imagePlug, imagePlug->channelNamesPlug()->getValue()->readable(), f );
+	ImageAlgo::parallelProcessTiles( imagePlug, imagePlug->channelNamesPlug()->getValue()->readable(), f );
 }
 
 } // namespace GafferImageTest

--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -195,7 +195,7 @@ Imath::Box3f ImageGadget::bound() const
 	}
 
 	const Box2i &w = f.getDisplayWindow();
-	if( empty( w ) )
+	if( BufferAlgo::empty( w ) )
 	{
 		return Box3f();
 	}
@@ -372,7 +372,7 @@ void ImageGadget::updateTiles() const
 	TileFunctor tileFunctor( m_tiles );
 	{
 		Context::Scope scopedContext( m_context.get() );
-		parallelProcessTiles( m_image.get(), channelsToCompute, tileFunctor, dataWindow() );
+		ImageAlgo::parallelProcessTiles( m_image.get(), channelsToCompute, tileFunctor, dataWindow() );
 	}
 
 	// Now take the new channelData and convert it into textures for display.
@@ -415,7 +415,7 @@ void ImageGadget::removeOutOfBoundsTiles() const
 	for( Tiles::iterator it = m_tiles.begin(); it != m_tiles.end(); )
 	{
 		const Box2i tileBound( it->first.tileOrigin, it->first.tileOrigin + V2i( ImagePlug::tileSize() ) );
-		if( !intersects( dw, tileBound ) || find( ch.begin(), ch.end(), it->first.channelName.string() ) == ch.end() )
+		if( !BufferAlgo::intersects( dw, tileBound ) || find( ch.begin(), ch.end(), it->first.channelName.string() ) == ch.end() )
 		{
 			it = m_tiles.unsafe_erase( it );
 		}
@@ -568,7 +568,7 @@ void ImageGadget::renderTiles() const
 			}
 
 			const Box2i tileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
-			const Box2i validBound = intersection( tileBound, dataWindow );
+			const Box2i validBound = BufferAlgo::intersection( tileBound, dataWindow );
 			const Box2f uvBound(
 				V2f(
 					lerpfactor<float>( validBound.min.x, tileBound.min.x, tileBound.max.x ),
@@ -645,7 +645,7 @@ void ImageGadget::doRender( const GafferUI::Style *style ) const
 	// Early out if the image has no size.
 
 	const Box2i &displayWindow = format.getDisplayWindow();
-	if( empty( displayWindow ) )
+	if( BufferAlgo::empty( displayWindow ) )
 	{
 		return;
 	}
@@ -667,7 +667,7 @@ void ImageGadget::doRender( const GafferUI::Style *style ) const
 
 	glColor3f( 0.0f, 0.0f, 0.0f );
 	style->renderSolidRectangle( displayWindowF );
-	if( !empty( dataWindow ) )
+	if( !BufferAlgo::empty( dataWindow ) )
 	{
 		style->renderSolidRectangle( dataWindowF );
 	}
@@ -700,7 +700,7 @@ void ImageGadget::doRender( const GafferUI::Style *style ) const
 		renderText( lexical_cast<string>( displayWindow.max ), displayWindowF.max, V2f( 0, -0.5 ), style );
 	}
 
-	if( !empty( dataWindow ) && dataWindow != displayWindow )
+	if( !BufferAlgo::empty( dataWindow ) && dataWindow != displayWindow )
 	{
 		glColor3f( 0.5f, 0.5f, 0.5f );
 		style->renderRectangle( dataWindowF );

--- a/src/GafferOSL/OSLCode.cpp
+++ b/src/GafferOSL/OSLCode.cpp
@@ -282,7 +282,7 @@ boost::filesystem::path compile( const std::string &shaderName, const std::strin
 	vector<string> options;
 	if( const char *includePaths = getenv( "OSL_SHADER_PATHS" ) )
 	{
-		tokenize( includePaths, ':', options );
+		StringAlgo::tokenize( includePaths, ':', options );
 		for( vector<string>::iterator it = options.begin(), eIt = options.end(); it != eIt; ++it )
 		{
 			it->insert( 0, "-I" );

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -791,7 +791,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 			vector<string> options;
 			if( const char *includePaths = getenv( "OSL_SHADER_PATHS" ) )
 			{
-				tokenize( includePaths, ':', options );
+				StringAlgo::tokenize( includePaths, ':', options );
 				for( vector<string>::iterator it = options.begin(), eIt = options.end(); it != eIt; ++it )
 				{
 					it->insert( 0, "-I" );

--- a/src/GafferScene/AttributeProcessor.cpp
+++ b/src/GafferScene/AttributeProcessor.cpp
@@ -131,7 +131,7 @@ IECore::ConstCompoundObjectPtr AttributeProcessor::computeProcessedAttributes( c
 	for( CompoundObject::ObjectMap::const_iterator it = inputAttributes->members().begin(), eIt = inputAttributes->members().end(); it != eIt; ++it )
 	{
 		ConstObjectPtr attribute = it->second;
-		if( matchMultiple( it->first, names ) != invert )
+		if( StringAlgo::matchMultiple( it->first, names ) != invert )
 		{
 			attribute = processAttribute( path, context, it->first, attribute.get() );
 		}

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -599,7 +599,7 @@ IECore::ConstCompoundDataPtr BranchCreator::computeMapping( const Gaffer::Contex
 		{
 			// uniqueify the name
 			string prefix;
-			int suffix = numericSuffix( name, 1, &prefix );
+			int suffix = StringAlgo::numericSuffix( name, 1, &prefix );
 
 			do
 			{

--- a/src/GafferScene/CopyOptions.cpp
+++ b/src/GafferScene/CopyOptions.cpp
@@ -87,7 +87,7 @@ IECore::ConstCompoundObjectPtr CopyOptions::computeProcessedGlobals( const Gaffe
 	{
 		if( boost::starts_with( it->first.c_str(), prefix ) )
 		{
-			if( matchMultiple( it->first.c_str() + prefix.size(), names.c_str() ) )
+			if( StringAlgo::matchMultiple( it->first.c_str() + prefix.size(), names.c_str() ) )
 			{
 				result->members()[it->first] = it->second;
 			}

--- a/src/GafferScene/DeleteGlobals.cpp
+++ b/src/GafferScene/DeleteGlobals.cpp
@@ -123,7 +123,7 @@ IECore::ConstCompoundObjectPtr DeleteGlobals::computeProcessedGlobals( const Gaf
 		bool keep = true;
 		if( boost::starts_with( it->first.c_str(), prefix ) )
 		{
-			if( matchMultiple( it->first.c_str() + prefix.size(), names.c_str() ) != invert )
+			if( StringAlgo::matchMultiple( it->first.c_str() + prefix.size(), names.c_str() ) != invert )
 			{
 				keep = false;
 			}

--- a/src/GafferScene/DeleteSets.cpp
+++ b/src/GafferScene/DeleteSets.cpp
@@ -123,7 +123,7 @@ IECore::ConstInternedStringVectorDataPtr DeleteSets::computeSetNames( const Gaff
 
 	for( std::vector<InternedString>::const_iterator it = inputSetNames.begin(); it != inputSetNames.end(); ++it )
 	{
-		if( matchMultiple( *it, names ) != (!invert) )
+		if( StringAlgo::matchMultiple( *it, names ) != (!invert) )
 		{
 			outputSetNames.push_back( *it );
 		}
@@ -136,7 +136,7 @@ void DeleteSets::hashSet( const IECore::InternedString &setName, const Gaffer::C
 {
 	const std::string names = namesPlug()->getValue();
 	const bool invert = invertNamesPlug()->getValue();
-	if( matchMultiple( setName, names ) != (!invert) )
+	if( StringAlgo::matchMultiple( setName, names ) != (!invert) )
 	{
 		h = inPlug()->setPlug()->getValue()->Object::hash();
 	}
@@ -150,7 +150,7 @@ GafferScene::ConstPathMatcherDataPtr DeleteSets::computeSet( const IECore::Inter
 {
 	const std::string names = namesPlug()->getValue();
 	const bool invert = invertNamesPlug()->getValue();
-	if( matchMultiple( setName, names ) != (!invert) )
+	if( StringAlgo::matchMultiple( setName, names ) != (!invert) )
 	{
 		return inPlug()->setPlug()->getValue();
 	}

--- a/src/GafferScene/Duplicate.cpp
+++ b/src/GafferScene/Duplicate.cpp
@@ -219,7 +219,7 @@ void Duplicate::compute( ValuePlug *output, const Context *context ) const
 		// these from the name of the target.
 
 		std::string stem;
-		int suffix = numericSuffix( target.back(), 0, &stem );
+		int suffix = StringAlgo::numericSuffix( target.back(), 0, &stem );
 		suffix++;
 
 		const int copies = copiesPlug()->getValue();
@@ -231,7 +231,7 @@ void Duplicate::compute( ValuePlug *output, const Context *context ) const
 		if( name.size() )
 		{
 			std::string nameStem;
-			const int nameSuffix = numericSuffix( name, &nameStem );
+			const int nameSuffix = StringAlgo::numericSuffix( name, &nameStem );
 			stem = nameStem;
 			suffix = copies == 1 ? nameSuffix : max( nameSuffix, 1 );
 		}

--- a/src/GafferScene/ExecutableRender.cpp
+++ b/src/GafferScene/ExecutableRender.cpp
@@ -112,7 +112,7 @@ void ExecutableRender::execute() const
 
 	ConstCompoundObjectPtr globals = scene->globalsPlug()->getValue();
 
-	createDisplayDirectories( globals.get() );
+	RendererAlgo::createDisplayDirectories( globals.get() );
 
 	// Scoping the lifetime of the renderer so that
 	// the destructor is run before we run the system
@@ -121,16 +121,16 @@ void ExecutableRender::execute() const
 	// to disk before RiEnd is called.
 	{
 		IECore::RendererPtr renderer = createRenderer();
-		outputOptions( globals.get(), renderer.get() );
-		outputOutputs( globals.get(), renderer.get() );
-		outputCameras( scene, globals.get(), renderer.get() );
-		outputClippingPlanes( scene, globals.get(), renderer.get() );
+		RendererAlgo::outputOptions( globals.get(), renderer.get() );
+		RendererAlgo::outputOutputs( globals.get(), renderer.get() );
+		RendererAlgo::outputCameras( scene, globals.get(), renderer.get() );
+		RendererAlgo::outputClippingPlanes( scene, globals.get(), renderer.get() );
 		{
 			WorldBlock world( renderer );
 
-			outputGlobalAttributes( globals.get(), renderer.get() );
-			outputCoordinateSystems( scene, globals.get(), renderer.get() );
-			outputLights( scene, globals.get(), renderer.get() );
+			RendererAlgo::outputGlobalAttributes( globals.get(), renderer.get() );
+			RendererAlgo::outputCoordinateSystems( scene, globals.get(), renderer.get() );
+			RendererAlgo::outputLights( scene, globals.get(), renderer.get() );
 			outputWorldProcedural( scene, renderer.get() );
 		}
 	}

--- a/src/GafferScene/FilterResults.cpp
+++ b/src/GafferScene/FilterResults.cpp
@@ -134,7 +134,7 @@ void FilterResults::hash( const Gaffer::ValuePlug *output, const Gaffer::Context
 		/// - Coming up with a way of cheaply computing a hierarchy hash,
 		///   that mythical beast that solves all our problems.
 		PathMatcherDataPtr data = new PathMatcherData;
-		matchingPaths( filterPlug(), scenePlug(), data->writable() );
+		SceneAlgo::matchingPaths( filterPlug(), scenePlug(), data->writable() );
 		data->hash( h );
 	}
 }
@@ -144,7 +144,7 @@ void FilterResults::compute( Gaffer::ValuePlug *output, const Gaffer::Context *c
 	if( output == outPlug() )
 	{
 		PathMatcherDataPtr data = new PathMatcherData;
-		matchingPaths( filterPlug(), scenePlug(), data->writable() );
+		SceneAlgo::matchingPaths( filterPlug(), scenePlug(), data->writable() );
 		static_cast<PathMatcherDataPlug *>( output )->setValue( data );
 		return;
 	}

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -775,7 +775,7 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 						m_renderer->editBegin( "attribute", parameters );
 					}
 
-					outputAttributes( s->m_attributes.get(), m_renderer );
+					RendererAlgo::outputAttributes( s->m_attributes.get(), m_renderer );
 					s->m_attributes = NULL;
 
 					if( m_editMode )
@@ -887,15 +887,15 @@ void InteractiveRender::update()
 		m_renderer->setOption( "editable", new BoolData( true ) );
 
 		ConstCompoundObjectPtr globals = inPlug()->globalsPlug()->getValue();
-		outputOptions( globals.get(), m_renderer.get() );
-		outputOutputs( globals.get(), m_renderer.get() );
-		outputCameras( inPlug(), globals.get(), m_renderer.get() );
-		outputClippingPlanes( inPlug(), globals.get(), m_renderer.get() );
+		RendererAlgo::outputOptions( globals.get(), m_renderer.get() );
+		RendererAlgo::outputOutputs( globals.get(), m_renderer.get() );
+		RendererAlgo::outputCameras( inPlug(), globals.get(), m_renderer.get() );
+		RendererAlgo::outputClippingPlanes( inPlug(), globals.get(), m_renderer.get() );
 		{
 			WorldBlock world( m_renderer );
 
-			outputGlobalAttributes( globals.get(), m_renderer.get() );
-			outputCoordinateSystems( inPlug(), globals.get(), m_renderer.get() );
+			RendererAlgo::outputGlobalAttributes( globals.get(), m_renderer.get() );
+			RendererAlgo::outputCoordinateSystems( inPlug(), globals.get(), m_renderer.get() );
 			outputLightsInternal( globals.get(), /* editing = */ false );
 
 			// build the scene graph structure in parallel:
@@ -968,7 +968,7 @@ void InteractiveRender::outputLightsInternal( const IECore::CompoundObject *glob
 		if( !editing )
 		{
 			// defining the scene for the first time
-			if( outputLight( inPlug(), path, m_renderer.get() ) )
+			if( RendererAlgo::outputLight( inPlug(), path, m_renderer.get() ) )
 			{
 				m_lightHandles.insert( *it );
 			}
@@ -981,7 +981,7 @@ void InteractiveRender::outputLightsInternal( const IECore::CompoundObject *glob
 				bool visible = false;
 				{
 					EditBlock edit( m_renderer.get(), "light", CompoundDataMap() );
-					visible = outputLight( inPlug(), path, m_renderer.get() );
+					visible = RendererAlgo::outputLight( inPlug(), path, m_renderer.get() );
 				}
 				// we may have turned it off before, and need to turn
 				// it back on, or it may have been hidden and we need
@@ -995,7 +995,7 @@ void InteractiveRender::outputLightsInternal( const IECore::CompoundObject *glob
 			{
 				// we've not seen this light before - create a new one
 				EditBlock edit( m_renderer.get(), "attribute", CompoundDataMap() );
-				if( outputLight( inPlug(), path, m_renderer.get() ) )
+				if( RendererAlgo::outputLight( inPlug(), path, m_renderer.get() ) )
 				{
 					m_lightHandles.insert( *it );
 				}
@@ -1038,7 +1038,7 @@ void InteractiveRender::updateCameras()
 	IECore::ConstCompoundObjectPtr globals = inPlug()->globalsPlug()->getValue();
 	{
 		EditBlock edit( m_renderer.get(), "option", CompoundDataMap() );
-		outputCameras( inPlug(), globals.get(), m_renderer.get() );
+		RendererAlgo::outputCameras( inPlug(), globals.get(), m_renderer.get() );
 	}
 	m_camerasDirty = false;
 }
@@ -1053,7 +1053,7 @@ void InteractiveRender::updateCoordinateSystems()
 	IECore::ConstCompoundObjectPtr globals = inPlug()->globalsPlug()->getValue();
 	{
 		EditBlock edit( m_renderer.get(), "attribute", CompoundDataMap() );
-		outputCoordinateSystems( inPlug(), globals.get(), m_renderer.get() );
+		RendererAlgo::outputCoordinateSystems( inPlug(), globals.get(), m_renderer.get() );
 	}
 	m_coordinateSystemsDirty = false;
 }

--- a/src/GafferScene/LightTweaks.cpp
+++ b/src/GafferScene/LightTweaks.cpp
@@ -410,7 +410,7 @@ IECore::ConstCompoundObjectPtr LightTweaks::computeProcessedAttributes( const Sc
 	CompoundObject::ObjectMap &out = result->members();
 	for( CompoundObject::ObjectMap::const_iterator it = in.begin(), eIt = in.end(); it != eIt; ++it )
 	{
-		if( !matchMultiple( it->first, type ) )
+		if( !StringAlgo::matchMultiple( it->first, type ) )
 		{
 			out.insert( *it );
 			continue;

--- a/src/GafferScene/ObjectSource.cpp
+++ b/src/GafferScene/ObjectSource.cpp
@@ -177,7 +177,7 @@ void ObjectSource::hashBound( const SceneNode::ScenePath &path, const Gaffer::Co
 Imath::Box3f ObjectSource::computeBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
 	IECore::ConstObjectPtr object = sourcePlug()->getValue();
-	Imath::Box3f result = bound( object.get() );
+	Imath::Box3f result = SceneAlgo::bound( object.get() );
 
 	if( path.size() == 0 )
 	{
@@ -280,7 +280,7 @@ void ObjectSource::hashSetNames( const Gaffer::Context *context, const ScenePlug
 IECore::ConstInternedStringVectorDataPtr ObjectSource::computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const
 {
 	IECore::InternedStringVectorDataPtr result = new IECore::InternedStringVectorData;
-	Gaffer::tokenize( setsPlug()->getValue(), ' ', result->writable() );
+	Gaffer::StringAlgo::tokenize( setsPlug()->getValue(), ' ', result->writable() );
 	IECore::ConstInternedStringVectorDataPtr setNames = computeStandardSetNames();
 	for(unsigned int i = 0; i < setNames->readable().size(); ++i)
 	{
@@ -331,6 +331,6 @@ bool ObjectSource::setNameValid( const IECore::InternedString &setName ) const
 	}
 
 	std::vector<IECore::InternedString> setNames;
-	Gaffer::tokenize( setsPlug()->getValue(), ' ', setNames );
+	Gaffer::StringAlgo::tokenize( setsPlug()->getValue(), ' ', setNames );
 	return std::find( setNames.begin(), setNames.end(), setName ) != setNames.end();
 }

--- a/src/GafferScene/PathMatcher.cpp
+++ b/src/GafferScene/PathMatcher.cpp
@@ -50,7 +50,7 @@ static IECore::InternedString g_ellipsis( "..." );
 //////////////////////////////////////////////////////////////////////////
 
 inline PathMatcher::Name::Name( IECore::InternedString name )
-	: name( name ), type( name == g_ellipsis || Gaffer::hasWildcards( name.c_str() ) ? Wildcarded : Plain )
+	: name( name ), type( name == g_ellipsis || Gaffer::StringAlgo::hasWildcards( name.c_str() ) ? Wildcarded : Plain )
 {
 }
 
@@ -217,7 +217,7 @@ unsigned PathMatcher::match( const std::string &path ) const
 		return Filter::NoMatch;
 	}
 	std::vector<IECore::InternedString> tokenizedPath;
-	Gaffer::tokenize( path, '/', tokenizedPath );
+	Gaffer::StringAlgo::tokenize( path, '/', tokenizedPath );
 	return match( tokenizedPath );
 }
 
@@ -304,7 +304,7 @@ void PathMatcher::matchWalk( const Node *node, const NameIterator &start, const 
 		}
 
 		NameIterator newStart = start + 1;
-		if( Gaffer::match( start->c_str(), childIt->first.name.c_str() ) )
+		if( Gaffer::StringAlgo::match( start->c_str(), childIt->first.name.c_str() ) )
 		{
 			matchWalk( childIt->second.get(), newStart, end, result );
 			if( result == Filter::EveryMatch )
@@ -345,7 +345,7 @@ bool PathMatcher::addPath( const std::string &path )
 		return false;
 	}
 	std::vector<IECore::InternedString> tokenizedPath;
-	Gaffer::tokenize( path, '/', tokenizedPath );
+	Gaffer::StringAlgo::tokenize( path, '/', tokenizedPath );
 	return addPath( tokenizedPath );
 }
 
@@ -367,7 +367,7 @@ bool PathMatcher::removePath( const std::string &path )
 		return false;
 	}
 	std::vector<IECore::InternedString> tokenizedPath;
-	Gaffer::tokenize( path, '/', tokenizedPath );
+	Gaffer::StringAlgo::tokenize( path, '/', tokenizedPath );
 	return removePath( tokenizedPath );
 }
 
@@ -427,7 +427,7 @@ bool PathMatcher::prune( const std::string &path )
 		return false;
 	}
 	std::vector<IECore::InternedString> tokenizedPath;
-	Gaffer::tokenize( path, '/', tokenizedPath );
+	Gaffer::StringAlgo::tokenize( path, '/', tokenizedPath );
 	return prune( tokenizedPath );;
 }
 
@@ -449,7 +449,7 @@ PathMatcher PathMatcher::subTree( const std::string &root ) const
 		return PathMatcher();
 	}
 	std::vector<IECore::InternedString> tokenizedRoot;
-	Gaffer::tokenize( root, '/', tokenizedRoot );
+	Gaffer::StringAlgo::tokenize( root, '/', tokenizedRoot );
 	return subTree( tokenizedRoot );
 }
 

--- a/src/GafferScene/Preview/InteractiveRender.cpp
+++ b/src/GafferScene/Preview/InteractiveRender.cpp
@@ -148,7 +148,7 @@ class InteractiveRender::SceneGraph
 
 		// Called by SceneGraphUpdateTask to update this location. Returns a bitmask
 		// of the components which were changed.
-		unsigned update( const ScenePlug *scene, const ScenePlug::ScenePath &path, unsigned dirtyComponents, unsigned changedParentComponents, Type type, IECoreScenePreview::Renderer *renderer, const IECore::CompoundObject *globals, const RenderSets &renderSets )
+		unsigned update( const ScenePlug *scene, const ScenePlug::ScenePath &path, unsigned dirtyComponents, unsigned changedParentComponents, Type type, IECoreScenePreview::Renderer *renderer, const IECore::CompoundObject *globals, const RendererAlgo::RenderSets &renderSets )
 		{
 			unsigned changedComponents = 0;
 
@@ -318,7 +318,7 @@ class InteractiveRender::SceneGraph
 		{
 			assert( !m_parent );
 
-			ConstCompoundObjectPtr globalAttributes = GafferScene::globalAttributes( globals );
+			ConstCompoundObjectPtr globalAttributes = GafferScene::SceneAlgo::globalAttributes( globals );
 			if( m_fullAttributes && *m_fullAttributes == *globalAttributes )
 			{
 				return false;
@@ -330,7 +330,7 @@ class InteractiveRender::SceneGraph
 			return true;
 		}
 
-		bool updateRenderSets( const ScenePlug::ScenePath &path, const RenderSets &renderSets )
+		bool updateRenderSets( const ScenePlug::ScenePath &path, const RendererAlgo::RenderSets &renderSets )
 		{
 			m_fullAttributes->members()[g_setsAttributeName] = boost::const_pointer_cast<InternedStringVectorData>(
 				renderSets.setsAttribute( path )
@@ -408,7 +408,7 @@ class InteractiveRender::SceneGraph
 
 					// Explicit namespace can be removed once deprecated applyCameraGlobals
 					// is removed from GafferScene::SceneAlgo
-					GafferScene::Preview::applyCameraGlobals( cameraCopy.get(), globals );
+					GafferScene::Preview::RendererAlgo::applyCameraGlobals( cameraCopy.get(), globals );
 					m_objectInterface = renderer->camera( name, cameraCopy.get(), attributesInterface( renderer ) );
 				}
 			}
@@ -838,14 +838,14 @@ void InteractiveRender::update()
 	if( m_dirtyComponents & SceneGraph::GlobalsComponent )
 	{
 		ConstCompoundObjectPtr globals = inPlug()->globalsPlug()->getValue();
-		outputOptions( globals.get(), m_globals.get(), m_renderer.get() );
-		outputOutputs( globals.get(), m_globals.get(), m_renderer.get() );
+		RendererAlgo::outputOptions( globals.get(), m_globals.get(), m_renderer.get() );
+		RendererAlgo::outputOutputs( globals.get(), m_globals.get(), m_renderer.get() );
 		m_globals = globals;
 	}
 
 	if( m_dirtyComponents & SceneGraph::SetsComponent )
 	{
-		if( m_renderSets.update( inPlug() ) & RenderSets::RenderSetsChanged )
+		if( m_renderSets.update( inPlug() ) & RendererAlgo::RenderSets::RenderSetsChanged )
 		{
 			m_dirtyComponents |= SceneGraph::RenderSetsComponent;
 		}
@@ -915,7 +915,7 @@ void InteractiveRender::updateDefaultCamera()
 		return;
 	}
 
-	CameraPtr defaultCamera = camera( inPlug(), m_globals.get() );
+	CameraPtr defaultCamera = SceneAlgo::camera( inPlug(), m_globals.get() );
 	StringDataPtr name = new StringData( "gaffer:defaultCamera" );
 	IECoreScenePreview::Renderer::AttributesInterfacePtr defaultAttributes = m_renderer->attributes( inPlug()->attributesPlug()->defaultValue() );
 	m_defaultCamera = m_renderer->camera( name->readable(), defaultCamera.get(), defaultAttributes.get() );

--- a/src/GafferScene/Preview/Render.cpp
+++ b/src/GafferScene/Preview/Render.cpp
@@ -216,7 +216,7 @@ void Render::execute() const
 	}
 
 	ConstCompoundObjectPtr globals = inPlug()->globalsPlug()->getValue();
-	createDisplayDirectories( globals.get() );
+	GafferScene::RendererAlgo::createDisplayDirectories( globals.get() );
 
 	boost::shared_ptr<PerformanceMonitor> performanceMonitor;
 	if( const BoolData *d = globals->member<const BoolData>( g_performanceMonitorOptionName ) )
@@ -228,14 +228,14 @@ void Render::execute() const
 	}
 	Monitor::Scope performanceMonitorScope( performanceMonitor.get() );
 
-	outputOptions( globals.get(), renderer.get() );
-	outputOutputs( globals.get(), renderer.get() );
+	RendererAlgo::outputOptions( globals.get(), renderer.get() );
+	RendererAlgo::outputOutputs( globals.get(), renderer.get() );
 
-	RenderSets renderSets( inPlug() );
+	RendererAlgo::RenderSets renderSets( inPlug() );
 
-	outputCameras( inPlug(), globals.get(), renderSets, renderer.get() );
-	outputLights( inPlug(), globals.get(), renderSets, renderer.get() );
-	outputObjects( inPlug(), globals.get(), renderSets, renderer.get() );
+	RendererAlgo::outputCameras( inPlug(), globals.get(), renderSets, renderer.get() );
+	RendererAlgo::outputLights( inPlug(), globals.get(), renderSets, renderer.get() );
+	RendererAlgo::outputObjects( inPlug(), globals.get(), renderSets, renderer.get() );
 
 	// Now we have generated the scene, flush Cortex and Gaffer caches to
 	// provide more memory to the renderer.
@@ -255,6 +255,6 @@ void Render::execute() const
 	if( performanceMonitor )
 	{
 		std::cerr << "\nPerformance Monitor\n===================\n\n";
-		std::cerr << formatStatistics( *performanceMonitor );
+		std::cerr << MonitorAlgo::formatStatistics( *performanceMonitor );
 	}
 }

--- a/src/GafferScene/PrimitiveVariableProcessor.cpp
+++ b/src/GafferScene/PrimitiveVariableProcessor.cpp
@@ -135,7 +135,7 @@ IECore::ConstObjectPtr PrimitiveVariableProcessor::computeProcessedObject( const
 	{
 		next = it;
 		next++;
-		if( matchMultiple( it->first, names ) != invert )
+		if( StringAlgo::matchMultiple( it->first, names ) != invert )
 		{
 			processPrimitiveVariable( path, context, inputGeometry, it->second );
 			if( it->second.interpolation == IECore::PrimitiveVariable::Invalid || !it->second.data )

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -88,6 +88,9 @@ void motionTimes( size_t segments, const V2f &shutter, std::set<float> &times )
 namespace GafferScene
 {
 
+namespace RendererAlgo
+{
+
 void outputScene( const ScenePlug *scene, IECore::Renderer *renderer )
 {
 	ConstCompoundObjectPtr globals = scene->globalsPlug()->getValue();
@@ -179,13 +182,13 @@ void outputCameras( const ScenePlug *scene, const IECore::CompoundObject *global
 
 void outputCamera( const ScenePlug *scene, const IECore::CompoundObject *globals, IECore::Renderer *renderer )
 {
-	IECore::CameraPtr camera = GafferScene::camera( scene, globals );
+	IECore::CameraPtr camera = SceneAlgo::camera( scene, globals );
 	camera->render( renderer );
 }
 
 void outputCamera( const ScenePlug *scene, const ScenePlug::ScenePath &cameraPath, const IECore::CompoundObject *globals, IECore::Renderer *renderer )
 {
-	IECore::CameraPtr camera = GafferScene::camera( scene, cameraPath, globals );
+	IECore::CameraPtr camera = SceneAlgo::camera( scene, cameraPath, globals );
 	camera->render( renderer );
 }
 
@@ -222,7 +225,7 @@ void outputLights( const ScenePlug *scene, const IECore::CompoundObject *globals
 
 bool outputLight( const ScenePlug *scene, const ScenePlug::ScenePath &path, IECore::Renderer *renderer )
 {
-	if( !visible( scene, path ) )
+	if( !SceneAlgo::visible( scene, path ) )
 	{
 		/// \todo Since both visible() and fullAttributes() perform similar work,
 		/// we may want to combine them into one query if we see this function
@@ -361,7 +364,7 @@ bool outputCoordinateSystem( const ScenePlug *scene, const ScenePlug::ScenePath 
 		return false;
 	}
 
-	if( !visible( scene, path ) )
+	if( !SceneAlgo::visible( scene, path ) )
 	{
 		return false;
 	}
@@ -402,7 +405,7 @@ bool outputClippingPlane( const ScenePlug *scene, const ScenePlug::ScenePath &pa
 		return false;
 	}
 
-	if( !visible( scene, path ) )
+	if( !SceneAlgo::visible( scene, path ) )
 	{
 		return false;
 	}
@@ -599,5 +602,7 @@ void outputObject( const ScenePlug *scene, IECore::Renderer *renderer, size_t se
 		(*it)->render( renderer );
 	}
 }
+
+} // namespace RendererAlgo
 
 } // namespace GafferScene

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -60,7 +60,7 @@ using namespace IECore;
 using namespace Gaffer;
 using namespace GafferScene;
 
-bool GafferScene::exists( const ScenePlug *scene, const ScenePlug::ScenePath &path )
+bool GafferScene::SceneAlgo::exists( const ScenePlug *scene, const ScenePlug::ScenePath &path )
 {
 	ContextPtr context = new Context( *Context::current(), Context::Borrowed );
 	Context::Scope scopedContext( context.get() );
@@ -81,7 +81,7 @@ bool GafferScene::exists( const ScenePlug *scene, const ScenePlug::ScenePath &pa
 	return true;
 }
 
-bool GafferScene::visible( const ScenePlug *scene, const ScenePlug::ScenePath &path )
+bool GafferScene::SceneAlgo::visible( const ScenePlug *scene, const ScenePlug::ScenePath &path )
 {
 	ContextPtr context = new Context( *Context::current(), Context::Borrowed );
 	Context::Scope scopedContext( context.get() );
@@ -124,24 +124,24 @@ struct ThreadablePathAccumulator
 
 } // namespace
 
-void GafferScene::matchingPaths( const Filter *filter, const ScenePlug *scene, PathMatcher &paths )
+void GafferScene::SceneAlgo::matchingPaths( const Filter *filter, const ScenePlug *scene, PathMatcher &paths )
 {
 	matchingPaths( filter->outPlug(), scene, paths );
 }
 
-void GafferScene::matchingPaths( const Gaffer::IntPlug *filterPlug, const ScenePlug *scene, PathMatcher &paths )
+void GafferScene::SceneAlgo::matchingPaths( const Gaffer::IntPlug *filterPlug, const ScenePlug *scene, PathMatcher &paths )
 {
 	ThreadablePathAccumulator f( paths );
-	GafferScene::filteredParallelTraverse( scene, filterPlug, f );
+	GafferScene::SceneAlgo::filteredParallelTraverse( scene, filterPlug, f );
 }
 
-void GafferScene::matchingPaths( const PathMatcher &filter, const ScenePlug *scene, PathMatcher &paths )
+void GafferScene::SceneAlgo::matchingPaths( const PathMatcher &filter, const ScenePlug *scene, PathMatcher &paths )
 {
 	ThreadablePathAccumulator f( paths );
-	GafferScene::filteredParallelTraverse( scene, filter, f );
+	GafferScene::SceneAlgo::filteredParallelTraverse( scene, filter, f );
 }
 
-IECore::ConstCompoundObjectPtr GafferScene::globalAttributes( const IECore::CompoundObject *globals )
+IECore::ConstCompoundObjectPtr GafferScene::SceneAlgo::globalAttributes( const IECore::CompoundObject *globals )
 {
 	static const std::string prefix( "attribute:" );
 
@@ -164,7 +164,7 @@ IECore::ConstCompoundObjectPtr GafferScene::globalAttributes( const IECore::Comp
 	return result;
 }
 
-Imath::V2f GafferScene::shutter( const IECore::CompoundObject *globals )
+Imath::V2f GafferScene::SceneAlgo::shutter( const IECore::CompoundObject *globals )
 {
 	const BoolData *cameraBlurData = globals->member<BoolData>( "option:render:cameraBlur" );
 	const bool cameraBlur = cameraBlurData ? cameraBlurData->readable() : false;
@@ -186,7 +186,7 @@ Imath::V2f GafferScene::shutter( const IECore::CompoundObject *globals )
 	return shutter;
 }
 
-IECore::TransformPtr GafferScene::transform( const ScenePlug *scene, const ScenePlug::ScenePath &path, const Imath::V2f &shutter, bool motionBlur )
+IECore::TransformPtr GafferScene::SceneAlgo::transform( const ScenePlug *scene, const ScenePlug::ScenePath &path, const Imath::V2f &shutter, bool motionBlur )
 {
 	int numSamples = 1;
 	if( motionBlur )
@@ -221,7 +221,7 @@ IECore::TransformPtr GafferScene::transform( const ScenePlug *scene, const Scene
 // as we switch to new renderer backends, which will support the new renderRegion parameter
 //////////////////////////////////////////////////////////////////////////
 
-void GafferScene::applyCameraGlobals( IECore::Camera *camera, const IECore::CompoundObject *globals )
+void GafferScene::SceneAlgo::applyCameraGlobals( IECore::Camera *camera, const IECore::CompoundObject *globals )
 {
 
 	// apply the resolution, aspect ratio and crop window
@@ -368,7 +368,7 @@ void GafferScene::applyCameraGlobals( IECore::Camera *camera, const IECore::Comp
 
 }
 
-IECore::CameraPtr GafferScene::camera( const ScenePlug *scene, const IECore::CompoundObject *globals )
+IECore::CameraPtr GafferScene::SceneAlgo::camera( const ScenePlug *scene, const IECore::CompoundObject *globals )
 {
 	ConstCompoundObjectPtr computedGlobals;
 	if( !globals )
@@ -392,7 +392,7 @@ IECore::CameraPtr GafferScene::camera( const ScenePlug *scene, const IECore::Com
 	}
 }
 
-IECore::CameraPtr GafferScene::camera( const ScenePlug *scene, const ScenePlug::ScenePath &cameraPath, const IECore::CompoundObject *globals )
+IECore::CameraPtr GafferScene::SceneAlgo::camera( const ScenePlug *scene, const ScenePlug::ScenePath &cameraPath, const IECore::CompoundObject *globals )
 {
 	ConstCompoundObjectPtr computedGlobals;
 	if( !globals )
@@ -431,7 +431,7 @@ IECore::CameraPtr GafferScene::camera( const ScenePlug *scene, const ScenePlug::
 // Sets Algo
 //////////////////////////////////////////////////////////////////////////
 
-bool GafferScene::setExists( const ScenePlug *scene, const IECore::InternedString &setName )
+bool GafferScene::SceneAlgo::setExists( const ScenePlug *scene, const IECore::InternedString &setName )
 {
 	IECore::ConstInternedStringVectorDataPtr setNamesData = scene->setNamesPlug()->getValue();
 	const std::vector<IECore::InternedString> &setNames = setNamesData->readable();
@@ -469,13 +469,13 @@ struct Sets
 
 } // namespace
 
-IECore::ConstCompoundDataPtr GafferScene::sets( const ScenePlug *scene )
+IECore::ConstCompoundDataPtr GafferScene::SceneAlgo::sets( const ScenePlug *scene )
 {
 	ConstInternedStringVectorDataPtr setNamesData = scene->setNamesPlug()->getValue();
 	return sets( scene, setNamesData->readable() );
 }
 
-IECore::ConstCompoundDataPtr GafferScene::sets( const ScenePlug *scene, const std::vector<IECore::InternedString> &setNames )
+IECore::ConstCompoundDataPtr GafferScene::SceneAlgo::sets( const ScenePlug *scene, const std::vector<IECore::InternedString> &setNames )
 {
 	std::vector<GafferScene::ConstPathMatcherDataPtr> setsVector;
 	setsVector.resize( setNames.size(), NULL );
@@ -493,7 +493,7 @@ IECore::ConstCompoundDataPtr GafferScene::sets( const ScenePlug *scene, const st
 	return result;
 }
 
-Imath::Box3f GafferScene::bound( const IECore::Object *object )
+Imath::Box3f GafferScene::SceneAlgo::bound( const IECore::Object *object )
 {
 	if( const IECore::VisibleRenderable *renderable = IECore::runTimeCast<const IECore::VisibleRenderable>( object ) )
 	{

--- a/src/GafferScene/SceneElementProcessor.cpp
+++ b/src/GafferScene/SceneElementProcessor.cpp
@@ -138,7 +138,7 @@ Imath::Box3f SceneElementProcessor::computeBound( const ScenePath &path, const G
 				// We do have to resort to computing the object here, but its exceedingly
 				// rare to have an object at a location which also has children, so typically
 				// we should be receiving a NullObject cheaply.
-				result.extendBy( bound( inPlug()->objectPlug()->getValue().get() ) );
+				result.extendBy( SceneAlgo::bound( inPlug()->objectPlug()->getValue().get() ) );
 			}
 			else
 			{

--- a/src/GafferScene/ScenePath.cpp
+++ b/src/GafferScene/ScenePath.cpp
@@ -152,7 +152,7 @@ bool ScenePath::isValid() const
 	}
 
 	Context::Scope scopedContext( m_context.get() );
-	return exists( m_scene.get(), names() );
+	return SceneAlgo::exists( m_scene.get(), names() );
 }
 
 bool ScenePath::isLeaf() const

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -482,7 +482,7 @@ IECore::MurmurHash ScenePlug::setHash( const IECore::InternedString &setName ) c
 void ScenePlug::stringToPath( const std::string &s, ScenePlug::ScenePath &path )
 {
 	path.clear();
-	tokenize( s, '/', path );
+	StringAlgo::tokenize( s, '/', path );
 }
 
 void ScenePlug::pathToString( const ScenePlug::ScenePath &path, std::string &s )

--- a/src/GafferScene/SceneProcedural.cpp
+++ b/src/GafferScene/SceneProcedural.cpp
@@ -381,15 +381,15 @@ void SceneProcedural::render( Renderer *renderer ) const
 
 		// transform
 
-		outputTransform( m_scenePlug.get(), renderer, ( m_options.transformBlur && m_attributes.transformBlur ) ? m_attributes.transformBlurSegments : 0, m_options.shutter );
+		RendererAlgo::outputTransform( m_scenePlug.get(), renderer, ( m_options.transformBlur && m_attributes.transformBlur ) ? m_attributes.transformBlurSegments : 0, m_options.shutter );
 
 		// attributes
 
-		outputAttributes( m_attributesObject.get(), renderer );
+		RendererAlgo::outputAttributes( m_attributesObject.get(), renderer );
 
 		// object
 
-		outputObject( m_scenePlug.get(), renderer, ( m_options.deformationBlur && m_attributes.deformationBlur ) ? m_attributes.deformationBlurSegments : 0, m_options.shutter );
+		RendererAlgo::outputObject( m_scenePlug.get(), renderer, ( m_options.deformationBlur && m_attributes.deformationBlur ) ? m_attributes.deformationBlurSegments : 0, m_options.shutter );
 
 		// children
 

--- a/src/GafferScene/Set.cpp
+++ b/src/GafferScene/Set.cpp
@@ -194,10 +194,10 @@ void Set::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) c
 				continue;
 			}
 			tokenizedPath.clear();
-			Gaffer::tokenize( *it, '/', tokenizedPath );
+			StringAlgo::tokenize( *it, '/', tokenizedPath );
 			for( vector<InternedString>::const_iterator nIt = tokenizedPath.begin(), neIt = tokenizedPath.end(); nIt != neIt; ++nIt )
 			{
-				if( Gaffer::hasWildcards( nIt->c_str() ) || *nIt == g_ellipsis )
+				if( StringAlgo::hasWildcards( nIt->c_str() ) || *nIt == g_ellipsis )
 				{
 					throw IECore::Exception( "Path \"" + *it + "\" contains wildcards." );
 				}
@@ -238,7 +238,7 @@ IECore::ConstInternedStringVectorDataPtr Set::computeSetNames( const Gaffer::Con
 	}
 
 	vector<InternedString> tokenizedNames;
-	Gaffer::tokenize( names, ' ', tokenizedNames );
+	StringAlgo::tokenize( names, ' ', tokenizedNames );
 
 	// specific logic if we have only one item, to avoid the more complex logic of adding two lists together
 	if( tokenizedNames.size() == 1 ) {

--- a/src/GafferScene/SubTree.cpp
+++ b/src/GafferScene/SubTree.cpp
@@ -289,7 +289,7 @@ SceneNode::ScenePath SubTree::sourcePath( const ScenePath &outputPath, bool &cre
 		// because clients of the SubTree have the same obligation to make
 		// only valid queries, and this will necessarily involve them computing
 		// the child names for the root first.
-		if( !exists( inPlug(), result ) )
+		if( !SceneAlgo::exists( inPlug(), result ) )
 		{
 			throw IECore::Exception( boost::str( boost::format( "Root \"%s\" does not exist" ) % rootAsString ) );
 		}

--- a/src/GafferSceneBindings/SceneAlgoBinding.cpp
+++ b/src/GafferSceneBindings/SceneAlgoBinding.cpp
@@ -136,6 +136,10 @@ namespace GafferSceneBindings
 
 void bindSceneAlgo()
 {
+	object module( borrowed( PyImport_AddModule( "GafferScene.SceneAlgo" ) ) );
+	scope().attr( "SceneAlgo" ) = module;
+	scope moduleScope( module );
+
 	def( "exists", &existsWrapper );
 	def( "visible", visibleWrapper );
 	def( "matchingPaths", &matchingPathsWrapper1 );

--- a/src/GafferSceneBindings/SceneAlgoBinding.cpp
+++ b/src/GafferSceneBindings/SceneAlgoBinding.cpp
@@ -58,64 +58,64 @@ bool existsWrapper( const ScenePlug *scene, const ScenePlug::ScenePath &path )
 {
 	// gil release in case the scene traversal dips back into python:
 	IECorePython::ScopedGILRelease r;
-	return exists( scene, path );
+	return SceneAlgo::exists( scene, path );
 }
 
 bool visibleWrapper( const ScenePlug *scene, const ScenePlug::ScenePath &path )
 {
 	IECorePython::ScopedGILRelease r;
-	return visible( scene, path );
+	return SceneAlgo::visible( scene, path );
 }
 
 void matchingPathsWrapper1( const Filter *filter, const ScenePlug *scene, PathMatcher &paths )
 {
 	// gil release in case the scene traversal dips back into python:
 	IECorePython::ScopedGILRelease r;
-	matchingPaths( filter, scene, paths );
+	SceneAlgo::matchingPaths( filter, scene, paths );
 }
 
 void matchingPathsWrapper2( const Gaffer::IntPlug *filterPlug, const ScenePlug *scene, PathMatcher &paths )
 {
 	// gil release in case the scene traversal dips back into python:
 	IECorePython::ScopedGILRelease r;
-	matchingPaths( filterPlug, scene, paths );
+	SceneAlgo::matchingPaths( filterPlug, scene, paths );
 }
 
 void matchingPathsWrapper3( const PathMatcher &filter, const ScenePlug *scene, PathMatcher &paths )
 {
 	// gil release in case the scene traversal dips back into python:
 	IECorePython::ScopedGILRelease r;
-	matchingPaths( filter, scene, paths );
+	SceneAlgo::matchingPaths( filter, scene, paths );
 }
 
 Imath::V2f shutterWrapper( const IECore::CompoundObject *globals )
 {
 	IECorePython::ScopedGILRelease r;
-	return shutter( globals );
+	return SceneAlgo::shutter( globals );
 }
 
 IECore::CameraPtr cameraWrapper1( const ScenePlug *scene, const IECore::CompoundObject *globals )
 {
 	IECorePython::ScopedGILRelease r;
-	return camera( scene, globals );
+	return SceneAlgo::camera( scene, globals );
 }
 
 IECore::CameraPtr cameraWrapper2( const ScenePlug *scene, const ScenePlug::ScenePath &cameraPath, const IECore::CompoundObject *globals )
 {
 	IECorePython::ScopedGILRelease r;
-	return camera( scene, cameraPath, globals );
+	return SceneAlgo::camera( scene, cameraPath, globals );
 }
 
 bool setExistsWrapper( const ScenePlug *scene, const IECore::InternedString &setName )
 {
 	IECorePython::ScopedGILRelease r;
-	return setExists( scene, setName );
+	return SceneAlgo::setExists( scene, setName );
 }
 
 IECore::CompoundDataPtr setsWrapper1( const ScenePlug *scene, bool copy )
 {
 	IECorePython::ScopedGILRelease r;
-	IECore::ConstCompoundDataPtr result = sets( scene );
+	IECore::ConstCompoundDataPtr result = SceneAlgo::sets( scene );
 	return copy ? result->copy() : boost::const_pointer_cast<IECore::CompoundData>( result );
 }
 
@@ -125,7 +125,7 @@ IECore::CompoundDataPtr setsWrapper2( const ScenePlug *scene, object pythonSetNa
 	boost::python::container_utils::extend_container( setNames, pythonSetNames );
 
 	IECorePython::ScopedGILRelease r;
-	IECore::ConstCompoundDataPtr result = sets( scene, setNames );
+	IECore::ConstCompoundDataPtr result = SceneAlgo::sets( scene, setNames );
 	return copy ? result->copy() : boost::const_pointer_cast<IECore::CompoundData>( result );
 }
 

--- a/src/GafferSceneTest/TraverseScene.cpp
+++ b/src/GafferSceneTest/TraverseScene.cpp
@@ -86,7 +86,7 @@ bool traverseOnPreDispatch( ConstScenePlugPtr scene )
 void GafferSceneTest::traverseScene( const GafferScene::ScenePlug *scenePlug )
 {
 	SceneEvaluateFunctor f;
-	parallelTraverse( scenePlug, f );
+	SceneAlgo::parallelTraverse( scenePlug, f );
 }
 
 void GafferSceneTest::traverseScene( GafferScene::ScenePlug *scenePlug )

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -788,14 +788,14 @@ class SceneView::LookThrough : public boost::signals::trackable
 			// look through lights
 			SetFilterPtr lightFilter = new SetFilter;
 			lightFilter->setPlug()->setValue( "__lights" );
-			
+
 			LightToCameraPtr lightConverter = new LightToCamera;
 			lightConverter->inPlug()->setInput( view->inPlug<ScenePlug>() );
 			lightConverter->filterPlug()->setInput( lightFilter->outPlug() );
 
 			m_internalNodes.push_back( lightFilter );
 			m_internalNodes.push_back( lightConverter );
-			
+
 			// We use a standard options node to disable camera motion blur
 			// and overscan because we don't want them applied to the cameras we retrieve with SceneAlgo.
 			// We also must disable transform blur and deformation blur, because if either of those is
@@ -953,13 +953,13 @@ class SceneView::LookThrough : public boost::signals::trackable
 				const string cameraPathString = cameraPlug()->getValue();
 				if( cameraPathString.empty() )
 				{
-					m_lookThroughCamera = GafferScene::camera( scenePlug() ); // primary render camera
+					m_lookThroughCamera = GafferScene::SceneAlgo::camera( scenePlug() ); // primary render camera
 				}
 				else
 				{
 					ScenePlug::ScenePath cameraPath;
 					ScenePlug::stringToPath( cameraPathString, cameraPath );
-					m_lookThroughCamera = GafferScene::camera( scenePlug(), cameraPath );
+					m_lookThroughCamera = GafferScene::SceneAlgo::camera( scenePlug(), cameraPath );
 				}
 			}
 			catch( ... )

--- a/src/GafferSceneUIBindings/SceneHierarchyBinding.cpp
+++ b/src/GafferSceneUIBindings/SceneHierarchyBinding.cpp
@@ -451,7 +451,7 @@ class SceneHierarchySearchFilter : public SceneHierarchyFilter
 				// The user has entered a full match path.
 				toMatch.addPath( m_matchPattern );
 			}
-			else if( hasWildcards( m_matchPattern ) )
+			else if( StringAlgo::hasWildcards( m_matchPattern ) )
 			{
 				// The user has used some wildcards, we
 				// just need to make sure the pattern is
@@ -472,7 +472,7 @@ class SceneHierarchySearchFilter : public SceneHierarchyFilter
 			m_pathMatcher.clear();
 			try
 			{
-				matchingPaths( toMatch, getScene(), m_pathMatcher );
+				SceneAlgo::matchingPaths( toMatch, getScene(), m_pathMatcher );
 			}
 			catch( ... )
 			{

--- a/src/GafferSceneUIBindings/ShaderViewBinding.cpp
+++ b/src/GafferSceneUIBindings/ShaderViewBinding.cpp
@@ -155,7 +155,7 @@ struct SceneChangedSlotCaller
 		}
 		catch( const boost::python::error_already_set &e )
 		{
-			translatePythonException();
+			ExceptionAlgo::translatePythonException();
 		}
 		return boost::signals::detail::unusable();
 	}

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -303,7 +303,7 @@ void BackdropNodeGadget::plugDirtied( const Gaffer::Plug *plug )
 
 bool BackdropNodeGadget::mouseMove( Gadget *gadget, const ButtonEvent &event )
 {
-	if( readOnly( node() ) )
+	if( MetadataAlgo::readOnly( node() ) )
 	{
 		return false;
 	}
@@ -339,7 +339,7 @@ bool BackdropNodeGadget::mouseMove( Gadget *gadget, const ButtonEvent &event )
 
 bool BackdropNodeGadget::buttonPress( Gadget *gadget, const ButtonEvent &event )
 {
-	if( readOnly( node() ) )
+	if( MetadataAlgo::readOnly( node() ) )
 	{
 		return false;
 	}

--- a/src/GafferUI/CompoundNodule.cpp
+++ b/src/GafferUI/CompoundNodule.cpp
@@ -218,9 +218,9 @@ void CompoundNodule::childRemoved( Gaffer::GraphComponent *parent, Gaffer::Graph
 	}
 }
 
-void CompoundNodule::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
+void CompoundNodule::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
 {
-	if( !affectedByChange( this->plug(), nodeTypeId, plugPath, plug ) )
+	if( !MetadataAlgo::affectedByChange( this->plug(), nodeTypeId, plugPath, plug ) )
 	{
 		return;
 	}

--- a/src/GafferUI/DotNodeGadget.cpp
+++ b/src/GafferUI/DotNodeGadget.cpp
@@ -209,7 +209,7 @@ void DotNodeGadget::updateLabel()
 
 bool DotNodeGadget::dragEnter( const DragDropEvent &event )
 {
-	if( readOnly( dotNode() ) )
+	if( MetadataAlgo::readOnly( dotNode() ) )
 	{
 		return false;
 	}

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -81,7 +81,7 @@ bool readOnly( const Gaffer::StandardSet *set )
 	{
 		if( const Gaffer::GraphComponent *g = runTimeCast<const Gaffer::GraphComponent>( set->member( i ) ) )
 		{
-			if( readOnly( g ) )
+			if( Gaffer::MetadataAlgo::readOnly( g ) )
 			{
 				return true;
 			}
@@ -706,7 +706,7 @@ bool GraphGadget::keyPressed( GadgetPtr gadget, const KeyEvent &event )
 		for( size_t i = 0, s = selection->size(); i != s; i++ )
 		{
 			Gaffer::DependencyNode *node = IECore::runTimeCast<Gaffer::DependencyNode>( selection->member( i ) );
-			if( node && findNodeGadget( node ) && !readOnly( node ) )
+			if( node && findNodeGadget( node ) && !Gaffer::MetadataAlgo::readOnly( node ) )
 			{
 				Gaffer::BoolPlug *enabledPlug = node->enabledPlug();
 				if( enabledPlug && enabledPlug->settable() )

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -266,8 +266,8 @@ bool StandardConnectionGadget::buttonPress( const ButtonEvent &event )
 IECore::RunTimeTypedPtr StandardConnectionGadget::dragBegin( const DragDropEvent &event )
 {
 	if(
-		readOnly( dstNodule()->plug() ) ||
-		( srcNodule() && readOnly( srcNodule()->plug() ) )
+		MetadataAlgo::readOnly( dstNodule()->plug() ) ||
+		( srcNodule() && MetadataAlgo::readOnly( srcNodule()->plug() ) )
 	)
 	{
 		return NULL;
@@ -415,9 +415,9 @@ bool StandardConnectionGadget::nodeSelected( const Nodule *nodule ) const
 	return script && script->selection()->contains( node );
 }
 
-void StandardConnectionGadget::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
+void StandardConnectionGadget::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
 {
-	if( key != g_colorKey || !affectedByChange( dstNodule()->plug(), nodeTypeId, plugPath, plug ) )
+	if( key != g_colorKey || !MetadataAlgo::affectedByChange( dstNodule()->plug(), nodeTypeId, plugPath, plug ) )
 	{
 		return;
 	}

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -683,7 +683,7 @@ bool StandardNodeGadget::drop( GadgetPtr gadget, const DragDropEvent &event )
 	return result;
 }
 
-void StandardNodeGadget::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
+void StandardNodeGadget::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
 {
 	if( plug && plug->parent<Node>() != node() )
 	{
@@ -768,7 +768,7 @@ bool StandardNodeGadget::noduleIsCompatible( const Nodule *nodule, const DragDro
 	}
 
 	const Plug *nodulePlug = nodule->plug();
-	if( readOnly( nodulePlug ) )
+	if( MetadataAlgo::readOnly( nodulePlug ) )
 	{
 		return false;
 	}

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -242,7 +242,7 @@ IECore::RunTimeTypedPtr StandardNodule::dragBegin( GadgetPtr gadget, const Butto
 
 bool StandardNodule::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
 {
-	if( readOnly( plug() ) )
+	if( MetadataAlgo::readOnly( plug() ) )
 	{
 		return false;
 	}
@@ -467,9 +467,9 @@ void StandardNodule::setCompatibleLabelsVisible( const DragDropEvent &event, boo
 	}
 }
 
-void StandardNodule::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
+void StandardNodule::plugMetadataChanged( IECore::TypeId nodeTypeId, const Gaffer::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
 {
-	if( !affectedByChange( this->plug(), nodeTypeId, plugPath, plug ) )
+	if( !MetadataAlgo::affectedByChange( this->plug(), nodeTypeId, plugPath, plug ) )
 	{
 		return;
 	}

--- a/src/GafferUIBindings/GadgetBinding.cpp
+++ b/src/GafferUIBindings/GadgetBinding.cpp
@@ -153,7 +153,7 @@ struct ExecuteOnUIThreadSlotCaller
 		}
 		catch( const error_already_set &e )
 		{
-			translatePythonException();
+			ExceptionAlgo::translatePythonException();
 		}
 		return boost::signals::detail::unusable();
 	}

--- a/src/GafferUIBindings/NodeGadgetBinding.cpp
+++ b/src/GafferUIBindings/NodeGadgetBinding.cpp
@@ -66,7 +66,7 @@ struct NoduleSlotCaller
 		}
 		catch( const error_already_set &e )
 		{
-			translatePythonException();
+			ExceptionAlgo::translatePythonException();
 		}
 		return boost::signals::detail::unusable();
 	}

--- a/startup/Gaffer/algoCompatibility.py
+++ b/startup/Gaffer/algoCompatibility.py
@@ -1,0 +1,42 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+
+for module in ( Gaffer.StringAlgo, Gaffer.MetadataAlgo, Gaffer.MonitorAlgo ) :
+	for name in dir( module ) :
+		if not name.startswith( "__" ) :
+			setattr( Gaffer, name, getattr( module, name ) )

--- a/startup/GafferImage/algoCompatibility.py
+++ b/startup/GafferImage/algoCompatibility.py
@@ -1,0 +1,42 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferImage
+
+for module in ( GafferImage.ImageAlgo, GafferImage.BufferAlgo ) :
+	for name in dir( module ) :
+		if not name.startswith( "__" ) :
+			setattr( GafferImage, name, getattr( module, name ) )

--- a/startup/GafferScene/algoCompatibility.py
+++ b/startup/GafferScene/algoCompatibility.py
@@ -1,0 +1,41 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferScene
+
+for name in dir( GafferScene.SceneAlgo ) :
+	if not name.startswith( "__" ) :
+		setattr( GafferScene, name, getattr( GafferScene.SceneAlgo, name ) )


### PR DESCRIPTION
For instance, the contents of SceneAlgo.h is now in the GafferScene::SceneAlgo namespace. This has been @andrewkaufman's preference for a good while, and having given it a go I have to agree that it improves readability - otherwise it's hard to know the origin of those free functions when coming back to the code.

I've updated the entire repo to reference the code from the right namespace, but also provided backwards compatibility for external code via `using` directives in C++ and config files in Python.

Having realised exactly how many files this would touch only while doing it, I now wish we'd got the NoduleLayout stuff merged first, since I'm pretty sure we're guaranteed a conflict. I think merging this first _might_ be the easiest for me in terms of resolving the conflicts, but I'm not sure really - either way will do.