### PR TITLE
IECoreArnoldPreview/Renderer: create directory for logs

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1494,6 +1494,10 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 				}
 				else if( const IECore::StringData *d = reportedCast<const IECore::StringData>( value, "option", name ) )
 				{
+					boost::filesystem::path path( d->readable() );
+					path.remove_filename();
+					boost::filesystem::create_directories( path );
+
 					AiMsgSetLogFileName( d->readable().c_str() );
 
 				}


### PR DESCRIPTION
If we don't do this, it's not guaranteed that the directories exist and Arnold will say something like

`00:00:00   244MB WARNING | unable to create log file <myLogFilename>: No such file or directory`
