### PR TITLE
Gaffer::ContextMonitor : Fix compilation for Maya

### DIFF
--- a/include/Gaffer/ContextMonitor.h
+++ b/include/Gaffer/ContextMonitor.h
@@ -38,6 +38,7 @@
 #define GAFFER_CONTEXTMONITOR_H
 
 #include <vector>
+#include <map>
 
 #include "tbb/enumerable_thread_specific.h"
 


### PR DESCRIPTION
Not sure why this passed the Travis tests, but when trying to build for Maya at IE ( which is an older env in a variety of ways ), nothing had properly included std::map, causing a compilation fail.  Including it explicitly fixes the issue.