### PR TITLE
GafferOSL::OSLImage : inPlug affects outPlug

### DIFF
--- a/src/GafferOSL/OSLImage.cpp
+++ b/src/GafferOSL/OSLImage.cpp
@@ -112,6 +112,10 @@ void OSLImage::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outpu
 		outputs.push_back( outPlug()->channelNamesPlug() );
 		outputs.push_back( outPlug()->channelDataPlug()	);
 	}
+	else if ( input->parent<ImagePlug>() == inPlug() )
+	{
+		outputs.push_back( outPlug()->getChild<ValuePlug>( input->getName() ) );
+	}
 }
 
 bool OSLImage::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const


### PR DESCRIPTION
I would have kind of expected this to happen automatically in ImageProcessor, but I guess you could have an ImageProcessor that throws away the channel data.

I based this on looking at what Grade does ( including what it inherits from ChannelDataProcessor ).

I was seeing issues with OSLImages not updating properly, which is fixed by this.