### PR TITLE
Arnold texture options

### DIFF
--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -96,6 +96,16 @@ def __rayDepthSummary( plug ) :
 		info.append( "Threshold %s" % GafferUI.NumericWidget.valueToString( plug["autoTransparencyThreshold"]["value"].getValue() ) )
 	return ", ".join( info )
 
+def __texturingSummary( plug ) :
+
+	info = []
+	if plug["textureMaxMemoryMB"]["enabled"].getValue() :
+		info.append( "Memory {0}".format( GafferUI.NumericWidget.valueToString( plug["textureMaxMemoryMB"]["value"].getValue() ) ) )
+	if plug["texturePerFileStats"]["enabled"].getValue() :
+		info.append( "Per File Stats {0}".format( "On" if plug["texturePerFileStats"]["value"].getValue() else "Off" ) )
+	if plug["textureMaxSharpen"]["enabled"].getValue() :
+		info.append( "Sharpen {0}".format( GafferUI.NumericWidget.valueToString( plug["textureMaxSharpen"]["value"].getValue() ) ) )
+	return ", ".join( info )
 
 def __featuresSummary( plug ) :
 
@@ -177,6 +187,7 @@ Gaffer.Metadata.registerNode(
 			"layout:section:Rendering:summary", __renderingSummary,
 			"layout:section:Sampling:summary", __samplingSummary,
 			"layout:section:Ray Depth:summary", __rayDepthSummary,
+			"layout:section:Texturing:summary", __texturingSummary,
 			"layout:section:Features:summary", __featuresSummary,
 			"layout:section:Search Paths:summary", __searchPathsSummary,
 			"layout:section:Error Colors:summary", __errorColorsSummary,
@@ -480,6 +491,57 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Ray Depth",
 			"label", "Opacity Threshold",
+		],
+
+		# Texturing
+
+		"options.textureMaxMemoryMB" : [
+
+			"description",
+			"""
+			The maximum amount of memory to use for caching
+			textures. Tiles are loaded on demand and cached,
+			and when the memory limit is reached the least
+			recently used tiles are discarded to make room
+			for more. Measured in megabytes.
+			""",
+
+			"layout:section", "Texturing",
+			"label", "Max Memory MB",
+		],
+
+		"options.texturePerFileStats" : [
+
+			"description",
+			"""
+			Turns on detailed statistics output for
+			each individual texture file used.
+			""",
+
+			"layout:section", "Texturing",
+			"label", "Per File Stats",
+
+		],
+
+		"options.textureMaxSharpen" : [
+
+			"description",
+			"""
+			Controls the sharpness of texture lookups,
+			providing a tradeoff between sharpness and
+			the amount of texture data loaded. If
+			textures appear too blurry, then the value
+			should be increased to add sharpness.
+
+			The theoretical optimum value is to match the
+			number of AA samples, but in practice the
+			improvement in sharpness this brings often
+			doesn't justify the increased render time and
+			memory usage.
+			""",
+
+			"layout:section", "Texturing",
+			"label", "Max Sharpen",
 		],
 
 		# Features

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -51,6 +51,7 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 
 	options->addOptionalMember( "ai:bucket_size", new IECore::IntData( 64 ), "bucketSize", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:bucket_scanning", new IECore::StringData( "spiral" ), "bucketScanning", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:threads", new IECore::IntData( 0 ), "threads", Gaffer::Plug::Default, false );
 
 	// Sampling parameters
 
@@ -87,10 +88,6 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	options->addOptionalMember( "ai:ignore_bump", new IECore::BoolData( false ), "ignoreBump", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:ignore_motion_blur", new IECore::BoolData( false ), "ignoreMotionBlur", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:ignore_sss", new IECore::BoolData( false ), "ignoreSSS", Gaffer::Plug::Default, false );
-
-	// Performance parameters
-
-	options->addOptionalMember( "ai:threads", new IECore::IntData( 0 ), "threads", Gaffer::Plug::Default, false );
 
 	// Searchpath parameters
 

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -76,6 +76,12 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	options->addOptionalMember( "ai:auto_transparency_depth", new IECore::IntData( 10 ), "autoTransparencyDepth", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:auto_transparency_threshold", new IECore::FloatData( 0.99 ), "autoTransparencyThreshold", Gaffer::Plug::Default, false );
 
+	// Texturing parameters
+
+	options->addOptionalMember( "ai:texture_max_memory_MB", new IECore::FloatData( 2048 ), "textureMaxMemoryMB", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:texture_per_file_stats", new IECore::BoolData( false ), "texturePerFileStats", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:texture_max_sharpen", new IECore::FloatData( 1.5 ), "textureMaxSharpen", Gaffer::Plug::Default, false );
+
 	// Ignore parameters
 
 	options->addOptionalMember( "ai:ignore_textures", new IECore::BoolData( false ), "ignoreTextures", Gaffer::Plug::Default, false );


### PR DESCRIPTION
This adds some texture system settings to the ArnoldOptions node. I've added the few I thought were of most use rather than add everything, but let me know if you think anything else should be included (bearing in mind that the CustomOptions node can always be used for the more esoteric stuff).