### PR TITLE
Gui startup : Use unscoped connections.

### DIFF
--- a/startup/gui/cache.py
+++ b/startup/gui/cache.py
@@ -47,21 +47,21 @@ preferences["cache"]["memoryLimit"] = Gaffer.IntPlug( defaultValue = Gaffer.Valu
 preferences["cache"]["imageReaderMemoryLimit"] = Gaffer.IntPlug( defaultValue = GafferImage.OpenImageIOReader.getCacheMemoryLimit() / ( 1024 * 1024 ) )
 
 Gaffer.Metadata.registerPlugValue(
-    preferences["cache"]["memoryLimit"],
-    "description",
-    """
-    Controls the memory limit for Gaffer's ValuePlug cache.
-    """,
-    persistent = False
+	preferences["cache"]["memoryLimit"],
+	"description",
+	"""
+	Controls the memory limit for Gaffer's ValuePlug cache.
+	""",
+	persistent = False
 )
 
 Gaffer.Metadata.registerPlugValue(
-    preferences["cache"]["imageReaderMemoryLimit"],
-    "description",
-    """
-    Controls the memory limit for the OpenImageIO cache that the OpenImageIOReader node uses.
-    """,
-    persistent = False
+	preferences["cache"]["imageReaderMemoryLimit"],
+	"description",
+	"""
+	Controls the memory limit for the OpenImageIO cache that the OpenImageIOReader node uses.
+	""",
+	persistent = False
 )
 
 # update cache settings when they change
@@ -80,4 +80,4 @@ def __plugSet( plug ) :
 	Gaffer.ValuePlug.setCacheMemoryLimit( memoryLimit )
 	GafferImage.OpenImageIOReader.setCacheMemoryLimit( imageReaderMemoryLimit )
 
-application.__cachePlugSetConnection = preferences.plugSetSignal().connect( __plugSet )
+preferences.plugSetSignal().connect( __plugSet, scoped = False )

--- a/startup/gui/nodeEditor.py
+++ b/startup/gui/nodeEditor.py
@@ -43,4 +43,4 @@ def __toolMenu( nodeEditor, node, menuDefinition ) :
 	GafferUI.BoxUI.appendNodeEditorToolMenuDefinitions( nodeEditor, node, menuDefinition )
 	GafferSceneUI.FilteredSceneProcessorUI.appendNodeEditorToolMenuDefinitions( nodeEditor, node, menuDefinition )
 
-__nodeEditorToolMenuConnection = GafferUI.NodeEditor.toolMenuSignal().connect( __toolMenu )
+GafferUI.NodeEditor.toolMenuSignal().connect( __toolMenu, scoped = False )

--- a/startup/gui/nodeGraph.py
+++ b/startup/gui/nodeGraph.py
@@ -96,7 +96,7 @@ def __nodeDoubleClick( nodeGraph, node ) :
 
 	GafferUI.NodeEditor.acquire( node )
 
-__nodeDoubleClickConnection = GafferUI.NodeGraph.nodeDoubleClickSignal().connect( __nodeDoubleClick )
+GafferUI.NodeGraph.nodeDoubleClickSignal().connect( __nodeDoubleClick, scoped = False )
 
 def __nodeContextMenu( nodeGraph, node, menuDefinition ) :
 
@@ -110,10 +110,10 @@ def __nodeContextMenu( nodeGraph, node, menuDefinition ) :
 	GafferSceneUI.FilteredSceneProcessorUI.appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition )
 	GafferUI.GraphBookmarksUI.appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition )
 
-__nodeContextMenuConnection = GafferUI.NodeGraph.nodeContextMenuSignal().connect( __nodeContextMenu )
+GafferUI.NodeGraph.nodeContextMenuSignal().connect( __nodeContextMenu, scoped = False )
 
 def __plugContextMenu( nodeGraph, node, menuDefinition ) :
 
 	GafferUI.GraphBookmarksUI.appendPlugContextMenuDefinitions( nodeGraph, node, menuDefinition )
 
-__plugContextMenuConnection = GafferUI.NodeGraph.plugContextMenuSignal().connect( __plugContextMenu )
+GafferUI.NodeGraph.plugContextMenuSignal().connect( __plugContextMenu, scoped = False )

--- a/startup/gui/ocio.py
+++ b/startup/gui/ocio.py
@@ -93,7 +93,7 @@ def __plugSet( plug ) :
 	__setDisplayTransform()
 	__updateDefaultDisplayTransforms()
 
-application.__ocioPlugSetConnection = preferences.plugSetSignal().connect( __plugSet )
+preferences.plugSetSignal().connect( __plugSet, scoped = False )
 
 # register display transforms with the image viewer
 

--- a/startup/gui/project.py
+++ b/startup/gui/project.py
@@ -56,7 +56,7 @@ def __scriptAdded( container, script ) :
 		projectRoot = variables.addMember( "project:rootDirectory", IECore.StringData( "$HOME/gaffer/projects/${project:name}" ), "projectRootDirectory" )
 		projectRoot["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
 
-__scriptAddedConnection = application.root()["scripts"].childAddedSignal().connect( __scriptAdded )
+application.root()["scripts"].childAddedSignal().connect( __scriptAdded, scoped = False )
 
 ##########################################################################
 # Bookmarks


### PR DESCRIPTION
This means we don't have to worry about name clashes between the variables used to store the connections.