### PR TITLE
Isolate: Fix hashing problem when using sets to keep locations

### DIFF
--- a/python/GafferSceneTest/IsolateTest.py
+++ b/python/GafferSceneTest/IsolateTest.py
@@ -443,6 +443,31 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( isolate["out"].setHash( "__lights" ), group["out"].setHash( "__lights" ) )
 		self.assertEqual( isolate["out"].setHash( "__cameras" ), group["out"].setHash( "__cameras" ) )
 
+	def testKeepLightsAndCamerasHashing( self ):
+
+		# - group
+		#    - cameraGroup
+		#       - camera
+
+		camera = GafferScene.Camera()
+
+		cameraGroup = GafferScene.Group()
+		cameraGroup["name"].setValue( "cameraGroup" )
+		cameraGroup["in"][0].setInput( camera["out"] )
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( cameraGroup["out"] )
+
+		filter = GafferScene.PathFilter()
+
+		isolate = GafferScene.Isolate()
+		isolate["in"].setInput( group["out"] )
+		isolate["filter"].setInput( filter["out"] )
+
+		isolate["keepCameras"].setValue( True )
+
+		self.assertTrue( GafferScene.SceneAlgo.exists( isolate["out"], "/group/cameraGroup/camera" ) )
+
 	def testSetFilter( self ) :
 
 		sphere = GafferScene.Sphere()

--- a/src/GafferScene/Isolate.cpp
+++ b/src/GafferScene/Isolate.cpp
@@ -261,7 +261,10 @@ void Isolate::hashChildNames( const ScenePath &path, const Gaffer::Context *cont
 		// we might be computing new childnames for this level.
 		FilteredSceneProcessor::hashChildNames( path, context, parent, h );
 
-		ConstInternedStringVectorDataPtr inputChildNamesData = inPlug()->childNamesPlug()->getValue();
+		const IECore::MurmurHash inputChildNamesHash = inPlug()->childNamesPlug()->hash();
+		h.append( inputChildNamesHash );
+
+		ConstInternedStringVectorDataPtr inputChildNamesData = inPlug()->childNamesPlug()->getValue( &inputChildNamesHash );
 		const vector<InternedString> &inputChildNames = inputChildNamesData->readable();
 
 		ScenePath childPath = path;


### PR DESCRIPTION
Hey John,

please ignore this until you have time to look at it - I am sure you have more important things to do right now. I thought I'd look into it anyway because we got bitten by this a little yesterday.

We found that when using the Isolate node and setting it to keep all the cameras, it would do something odd to the names in the hierarchy. I added a test case that builds a simple scene that illustrates the problem. What happens there is that the root "/" hashes identically to the first group "/group" which ironically makes the group set the childNames to be its own name if that makes sense? Basically root and group have the same childNames now which is wrong.

I was hesitant regarding fixing it in the way I propose here because the code looks like you did the hashing using the constant deliberately? Hashing the childName seemed the more intuitive thing to me, but maybe you used the constant for performance reasons? Hashing the whole list of childNames by removing the else clause and always calling 

`h = inPlug()->childNamesPlug()->hash();`

would work as well, but might perform worse?

Any thoughts appreciated, but please take your time :)

Matti.