### PR TITLE
IECoreArnoldPreview/Renderer: write individual metadata entries

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -251,7 +251,6 @@ class ArnoldOutput : public IECore::RefCounted
 					{
 						customAttributes.push_back( formattedString );
 					}
-					continue;
 				}
 
 				ParameterAlgo::setParameter( m_driver.get(), it->first.c_str(), it->second.get() );


### PR DESCRIPTION
In order for DisplayDrivers in cortex to retrieve the metadata entries that we pass on to Arnold as well, we should set them on the node and not skip them.

This PR is related to a PR [0] in cortex as that one adds support for a few more data types. There are some open questions about data type support that we should discuss.

[0] https://github.com/ImageEngine/cortex/pull/548