### PR TITLE
PlugAdderBinding: wrap PlugAdder for access from Python

### DIFF
--- a/src/GafferUIBindings/PlugAdderBinding.cpp
+++ b/src/GafferUIBindings/PlugAdderBinding.cpp
@@ -132,6 +132,7 @@ struct PlugAdderWrapper : public GadgetWrapper<PlugAdder>
 				try
 				{
 					f( Gaffer::PlugPtr( const_cast<Gaffer::Plug *>( connectionEndPoint ) ) );
+					return;
 				}
 				catch( const error_already_set &e )
 				{
@@ -139,10 +140,7 @@ struct PlugAdderWrapper : public GadgetWrapper<PlugAdder>
 				}
 			}
 		}
-		else
-		{
-			throw IECore::Exception( "No addPlug method defined in Python." );
-		}
+		throw IECore::Exception( "No addPlug method defined in Python." );
 	}
 };
 


### PR DESCRIPTION
Hey John,

I believe this should do the trick in terms of binding the `PlugAdder`? I used it in one of my UIs already and it did work fine. Would you like a test for this? Anything you want changed? Entirely wrong approach? ;) It took me a bit to figure out how to do it and how to pass through the `Plug*`, but I guess this is the expected way to do it?

@danieldresser and me thought it might be nice to add this to the OSLCode node for creating inputs and/or outputs. That's a discussion for another time, though :)

Thanks! :)

Matti.
