### PR TITLE
DispatcherUI: change order of labels to fix update bug.

### DIFF
--- a/python/GafferDispatchUI/DispatcherUI.py
+++ b/python/GafferDispatchUI/DispatcherUI.py
@@ -376,6 +376,9 @@ class _FramesModePlugValueWidget( GafferUI.PlugValueWidget ) :
 		# save the metadata in case the frameRange plug is set prior to enabling CustomRange mode
 		self.__customFrameRangeChanged( self.getPlug().node()["frameRange"] )
 
+		# set the current mode so that _updatePlug can set __selectionMenu accordingly
+		Gaffer.Metadata.registerValue( self.getPlug(), "dispatcherWindow:framesMode", "CurrentFrame" )
+
 		self._updateFromPlug()
 
 	def selectionMenu( self ) :
@@ -389,14 +392,9 @@ class _FramesModePlugValueWidget( GafferUI.PlugValueWidget ) :
 		if self.getPlug() is None :
 			return
 
-		with self.getContext() :
-			plugValue = self.getPlug().getValue()
-
-		for labelAndValue in self.__labelsAndValues :
-			if labelAndValue[1] == plugValue :
-				with Gaffer.BlockedConnection( self.__selectionChangedConnection ) :
-					self.__selectionMenu.setSelection( labelAndValue[0] )
-				break
+		mode = Gaffer.Metadata.value( self.getPlug(), "dispatcherWindow:framesMode" )
+		with Gaffer.BlockedConnection( self.__selectionChangedConnection ) :
+			self.__selectionMenu.setSelection( mode )
 
 	def __frameRangeWidget( self ) :
 
@@ -428,6 +426,8 @@ class _FramesModePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		script = window.scriptNode()
 		context = script.context()
+
+		Gaffer.Metadata.registerValue( self.getPlug(), "dispatcherWindow:framesMode", label )
 
 		if label == "CurrentFrame" :
 			self.__updateFrameRangeConnection = context.changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ) )


### PR DESCRIPTION
Not sure if this is the best way to fix the bug, but I wanted to get your opinion, John.

The problem this is supposed to fix is that https://github.com/GafferHQ/gaffer/blob/master/python/GafferDispatchUI/DispatcherUI.py#L398 will pick the wrong label, when triggered from https://github.com/GafferHQ/gaffer/blob/master/python/GafferDispatchUI/DispatcherUI.py#L483. It'll just find the first one, but ignores the fact that it was triggered from an update of the frameRange.

Alternatively, we could add an entry for the PlaybackRange in https://github.com/GafferHQ/gaffer/blob/master/include/GafferDispatch/Dispatcher.h#L138? Maybe it's a little fragile in general to map those 3 values onto 4 options in the UI?