### PR TITLE
GafferBindings : Fixed binding of childNeedsSerialisation

### DIFF
--- a/src/GafferBindings/Serialisation.cpp
+++ b/src/GafferBindings/Serialisation.cpp
@@ -538,7 +538,7 @@ void GafferBindings::bindSerialisation()
 		.def( "postConstructor", &Serialisation::Serialiser::postConstructor )
 		.def( "postHierarchy", &Serialisation::Serialiser::postHierarchy )
 		.def( "postScript", &Serialisation::Serialiser::postScript )
-		.def( "childNeedsSerialisation", &Serialisation::Serialiser::postScript )
+		.def( "childNeedsSerialisation", &Serialisation::Serialiser::childNeedsSerialisation )
 		.def( "childNeedsConstruction", &Serialisation::Serialiser::childNeedsConstruction )
 	;
 


### PR DESCRIPTION
Either there is something sophisticated and subtle happening here that I don't understand, or this was a simple copy-and-paste error.