### PR TITLE
Geometric interpretation on plugs

### DIFF
--- a/include/Gaffer/CompoundDataPlug.h
+++ b/include/Gaffer/CompoundDataPlug.h
@@ -140,6 +140,9 @@ class CompoundDataPlug : public Gaffer::ValuePlug
 		static ValuePlugPtr compoundNumericValuePlug( const std::string &name, Plug::Direction direction, unsigned flags, const T *value );
 
 		template<typename T>
+		static ValuePlugPtr geometricCompoundNumericValuePlug( const std::string &name, Plug::Direction direction, unsigned flags, const T *value );
+
+		template<typename T>
 		static ValuePlugPtr typedObjectValuePlug( const std::string &name, Plug::Direction direction, unsigned flags, const T *value );
 
 };

--- a/include/Gaffer/CompoundNumericPlug.h
+++ b/include/Gaffer/CompoundNumericPlug.h
@@ -41,6 +41,8 @@
 #include "OpenEXR/ImathVec.h"
 #include "OpenEXR/ImathColor.h"
 
+#include "IECore/GeometricTypedData.h"
+
 #include "Gaffer/NumericPlug.h"
 
 namespace Gaffer
@@ -63,10 +65,10 @@ class CompoundNumericPlug : public ValuePlug
 			T defaultValue = T( 0 ),
 			T minValue = T( Imath::limits<typename T::BaseType>::min() ),
 			T maxValue = T( Imath::limits<typename T::BaseType>::max() ),
-			unsigned flags = Default
+			unsigned flags = Default,
+			IECore::GeometricData::Interpretation interpretation = IECore::GeometricData::None
 		);
 		virtual ~CompoundNumericPlug();
-
 		/// Accepts no children following construction.
 		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
 		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
@@ -91,6 +93,15 @@ class CompoundNumericPlug : public ValuePlug
 		/// of the result.
 		T getValue() const;
 
+		/// Returns a hash to represent the value of this plug
+		/// in the current context.
+		virtual IECore::MurmurHash hash() const;
+		/// Convenience function to append the hash to h.
+		void hash( IECore::MurmurHash &h ) const;
+
+		/// Returns the interpretation of the vector
+		IECore::GeometricData::Interpretation interpretation() const;
+
 		/// @name Ganging
 		/// CompoundNumericPlugs may be ganged by connecting the child plugs
 		/// together so their values are driven by the first child. These
@@ -111,6 +122,7 @@ class CompoundNumericPlug : public ValuePlug
 		IE_CORE_DECLARERUNTIMETYPEDDESCRIPTION( CompoundNumericPlug<T> );
 
 		static const char **childNames();
+		const IECore::GeometricData::Interpretation m_interpretation;
 
 };
 

--- a/include/Gaffer/PlugAlgo.h
+++ b/include/Gaffer/PlugAlgo.h
@@ -1,0 +1,55 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2012, John Haddon. All rights reserved.
+//  Copyright (c) 2014, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_PLUGALGO_H
+#define GAFFER_PLUGALGO_H
+
+#include "Gaffer/Plug.h"
+
+namespace Gaffer
+{
+
+namespace PlugAlgo
+{
+
+void replacePlug( GraphComponent *parent, PlugPtr plug );
+
+} // namespace PlugAlgo
+
+} // namespace Gaffer
+
+#endif // GAFFER_PLUGALGO_H

--- a/include/GafferImage/OpenImageIOAlgo.h
+++ b/include/GafferImage/OpenImageIOAlgo.h
@@ -48,6 +48,7 @@ namespace OpenImageIOAlgo
 {
 
 OIIO::TypeDesc::VECSEMANTICS vecSemantics( IECore::GeometricData::Interpretation interpretation );
+IECore::GeometricData::Interpretation geometricInterpretation( OIIO::TypeDesc::VECSEMANTICS );
 
 struct DataView
 {

--- a/python/GafferOSLTest/OSLCodeTest.py
+++ b/python/GafferOSLTest/OSLCodeTest.py
@@ -38,6 +38,7 @@ import os
 import subprocess
 import shutil
 import unittest
+import functools
 
 import IECore
 
@@ -56,7 +57,7 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 		for i, plugType in enumerate( [
 			Gaffer.IntPlug,
 			Gaffer.FloatPlug,
-			Gaffer.V3fPlug,
+			functools.partial( Gaffer.V3fPlug, interpretation = IECore.GeometricData.Interpretation.Vector ),
 			Gaffer.Color3fPlug,
 			Gaffer.M44fPlug,
 			Gaffer.StringPlug,

--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -556,6 +556,7 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 				"typeChanged2",
 				"typeChanged3",
 				"typeChanged4",
+				"typeChanged5",
 				"defaultChangedArray",
 			]
 		)
@@ -600,6 +601,8 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		self.assertTrue( isinstance( n["parameters"]["typeChanged2"], Gaffer.FloatPlug ) )
 		self.assertTrue( isinstance( n["parameters"]["typeChanged3"], Gaffer.Color3fPlug ) )
 		self.assertTrue( isinstance( n["parameters"]["typeChanged4"], Gaffer.StringPlug ) )
+		self.assertTrue( isinstance( n["parameters"]["typeChanged5"], Gaffer.V3fPlug ) )
+		self.assertTrue( n["parameters"]["typeChanged5"].interpretation(), IECore.GeometricData.Interpretation.Vector)
 
 		n.loadShader( s2, keepExistingValues = True )
 
@@ -616,6 +619,7 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 				"typeChanged2",
 				"typeChanged3",
 				"typeChanged4",
+				"typeChanged5",
 				"addedI",
 				"addedF",
 				"addedColor",
@@ -653,6 +657,8 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		self.assertTrue( isinstance( n["parameters"]["typeChanged2"], Gaffer.Color3fPlug ) )
 		self.assertTrue( isinstance( n["parameters"]["typeChanged3"], Gaffer.FloatPlug ) )
 		self.assertTrue( isinstance( n["parameters"]["typeChanged4"], Gaffer.IntPlug ) )
+		self.assertTrue( isinstance( n["parameters"]["typeChanged5"], Gaffer.V3fPlug ) )
+		self.assertEqual( n["parameters"]["typeChanged5"].interpretation(), IECore.GeometricData.Interpretation.Normal)
 
 		n.loadShader( s2, keepExistingValues = False )
 		for plug in n["parameters"] :

--- a/python/GafferOSLTest/shaders/version1.osl
+++ b/python/GafferOSLTest/shaders/version1.osl
@@ -83,6 +83,7 @@ shader version1
 	float typeChanged2 = 2,
 	color typeChanged3 = 3,
 	string typeChanged4 = "four",
+	vector typeChanged5 = vector(0, 0, 0),
 
 	// Parameters which change defaults in version 2
 	float defaultChangedArray[3] = { 0, 1, 2 },

--- a/python/GafferOSLTest/shaders/version2.osl
+++ b/python/GafferOSLTest/shaders/version2.osl
@@ -74,6 +74,7 @@ shader version2
 	color typeChanged2 = 2,
 	float typeChanged3 = 3,
 	int typeChanged4 = 4,
+	normal typeChanged5 = normal(0, 0, 0),
 
 	// Parameters added in version 2
 

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -191,7 +191,9 @@ class _ParametersFooter( GafferUI.PlugValueWidget ) :
 		labelsAndConstructors = [
 			( "Int", Gaffer.IntPlug ),
 			( "Float", Gaffer.FloatPlug ),
-			( "Vector", Gaffer.V3fPlug ),
+			( "Vector", functools.partial( Gaffer.V3fPlug, interpretation = IECore.GeometricData.Interpretation.Vector ) ),
+			( "Normal", functools.partial( Gaffer.V3fPlug, interpretation = IECore.GeometricData.Interpretation.Normal ) ),
+			( "Point", functools.partial( Gaffer.V3fPlug, interpretation = IECore.GeometricData.Interpretation.Point ) ),
 			( "Color", Gaffer.Color3fPlug ),
 			( "Matrix", Gaffer.M44fPlug ),
 			( "String", Gaffer.StringPlug ),

--- a/python/GafferSceneTest/PrimitiveVariablesTest.py
+++ b/python/GafferSceneTest/PrimitiveVariablesTest.py
@@ -68,5 +68,42 @@ class PrimitiveVariablesTest( GafferSceneTest.SceneTestCase ) :
 		del o2["a"]
 		self.assertEqual( o1, o2 )
 
+	def testGeometricInterpretation( self ) :
+
+		s = GafferScene.Sphere()
+		p = GafferScene.PrimitiveVariables()
+		p["in"].setInput( s["out"] )
+
+		p["primitiveVariables"].addMember( "myFirstData", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Vector ) )
+		p["primitiveVariables"].addMember( "mySecondData", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Normal ) )
+		p["primitiveVariables"].addMember( "myThirdData", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Point ) )
+
+		o = p["out"].object( "/sphere" )
+
+		# test if the geometric interpretation makes it into the primitive variable
+		self.assertEqual( o["myFirstData"].data.getInterpretation(), IECore.GeometricData.Interpretation.Vector )
+		self.assertEqual( o["mySecondData"].data.getInterpretation(), IECore.GeometricData.Interpretation.Normal )
+		self.assertEqual( o["myThirdData"].data.getInterpretation(), IECore.GeometricData.Interpretation.Point )
+
+		del o["myFirstData"]
+		del o["mySecondData"]
+		del o["myThirdData"]
+
+		self.assertFalse( 'myFirstData' in o )
+		self.assertFalse( 'mySecondData' in o )
+		self.assertFalse( 'myThirdData' in o )
+
+		p["primitiveVariables"].addMember( "myFirstData", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Point ) )
+		p["primitiveVariables"].addMember( "mySecondData", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Vector ) )
+		p["primitiveVariables"].addMember( "myThirdData", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Normal ) )
+
+		o = p["out"].object( "/sphere" )
+
+		# test if the new geometric interpretation makes it into the primitive variable
+		# this tests the hashing on the respective plugs
+		self.assertEqual( o["myFirstData"].data.getInterpretation(), IECore.GeometricData.Interpretation.Point )
+		self.assertEqual( o["mySecondData"].data.getInterpretation(), IECore.GeometricData.Interpretation.Vector )
+		self.assertEqual( o["myThirdData"].data.getInterpretation(), IECore.GeometricData.Interpretation.Normal )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/CompoundDataPlugTest.py
+++ b/python/GafferTest/CompoundDataPlugTest.py
@@ -92,6 +92,11 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( d, None )
 		self.assertEqual( n, "" )
 
+		# test if creating a plug from data that has a geometric
+		# interpretation specified transfers that interpretation to the plug
+		m4 = p.addOptionalMember( "vector", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Vector ), plugName = "vector", enabled = True )
+		self.assertEqual( m4["value"].interpretation(), IECore.GeometricData.Interpretation.Vector )
+
 	def testVectorData( self ) :
 
 		p = Gaffer.CompoundDataPlug()

--- a/python/GafferUI/CompoundDataPlugValueWidget.py
+++ b/python/GafferUI/CompoundDataPlugValueWidget.py
@@ -115,10 +115,22 @@ class CompoundDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 		result.append( "/Add/String", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.StringData( "" ) ) } )
 		result.append( "/Add/StringDivider", { "divider" : True } )
 
-		result.append( "/Add/V2i", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2iData( IECore.V2i( 0 ) ) ) } )
-		result.append( "/Add/V3i", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3iData( IECore.V3i( 0 ) ) ) } )
-		result.append( "/Add/V2f", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2fData( IECore.V2f( 0 ) ) ) } )
-		result.append( "/Add/V3f", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3fData( IECore.V3f( 0 ) ) ) } )
+		result.append( "/Add/V2i/Vector", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2iData( IECore.V2i( 0 ), IECore.GeometricData.Interpretation.Vector ) ) } )
+		result.append( "/Add/V2i/Normal", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2iData( IECore.V2i( 0 ), IECore.GeometricData.Interpretation.Normal ) ) } )
+		result.append( "/Add/V2i/Point", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2iData( IECore.V2i( 0 ), IECore.GeometricData.Interpretation.Point ) ) } )
+
+		result.append( "/Add/V3i/Vector", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3iData( IECore.V3i( 0 ), IECore.GeometricData.Interpretation.Vector ) ) } )
+		result.append( "/Add/V3i/Normal", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3iData( IECore.V3i( 0 ), IECore.GeometricData.Interpretation.Normal ) ) } )
+		result.append( "/Add/V3i/Point", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3iData( IECore.V3i( 0 ), IECore.GeometricData.Interpretation.Point ) ) } )
+
+		result.append( "/Add/V2f/Vector", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2fData( IECore.V2f( 0 ), IECore.GeometricData.Interpretation.Vector ) ) } )
+		result.append( "/Add/V2f/Normal", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2fData( IECore.V2f( 0 ), IECore.GeometricData.Interpretation.Normal ) ) } )
+		result.append( "/Add/V2f/Point", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2fData( IECore.V2f( 0 ), IECore.GeometricData.Interpretation.Point ) ) } )
+
+		result.append( "/Add/V3f/Vector", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Vector ) ) } )
+		result.append( "/Add/V3f/Normal", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Normal ) ) } )
+		result.append( "/Add/V3f/Point", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Point ) ) } )
+
 		result.append( "/Add/VectorDivider", { "divider" : True } )
 
 		result.append( "/Add/Color3f", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.Color3fData( IECore.Color3f( 0 ) ) ) } )

--- a/src/Gaffer/CompoundDataPlug.cpp
+++ b/src/Gaffer/CompoundDataPlug.cpp
@@ -339,19 +339,19 @@ ValuePlugPtr CompoundDataPlug::createPlugFromData( const std::string &name, Plug
 		}
 		case V2iDataTypeId :
 		{
-			return compoundNumericValuePlug( name, direction, flags, static_cast<const V2iData *>( value ) );
+			return geometricCompoundNumericValuePlug( name, direction, flags, static_cast<const V2iData *>( value ) );
 		}
 		case V3iDataTypeId :
 		{
-			return compoundNumericValuePlug( name, direction, flags, static_cast<const V3iData *>( value ) );
+			return geometricCompoundNumericValuePlug( name, direction, flags, static_cast<const V3iData *>( value ) );
 		}
 		case V2fDataTypeId :
 		{
-			return compoundNumericValuePlug( name, direction, flags, static_cast<const V2fData *>( value ) );
+			return geometricCompoundNumericValuePlug( name, direction, flags, static_cast<const V2fData *>( value ) );
 		}
 		case V3fDataTypeId :
 		{
-			return compoundNumericValuePlug( name, direction, flags, static_cast<const V3fData *>( value ) );
+			return geometricCompoundNumericValuePlug( name, direction, flags, static_cast<const V3fData *>( value ) );
 		}
 		case Color3fDataTypeId :
 		{
@@ -452,6 +452,26 @@ ValuePlugPtr CompoundDataPlug::compoundNumericValuePlug( const std::string &name
 }
 
 template<typename T>
+ValuePlugPtr CompoundDataPlug::geometricCompoundNumericValuePlug( const std::string &name, Plug::Direction direction, unsigned flags, const T *value )
+{
+	typedef typename T::ValueType ValueType;
+	typedef typename ValueType::BaseType BaseType;
+	typedef CompoundNumericPlug<ValueType> PlugType;
+
+	typename PlugType::Ptr result = new PlugType(
+		name,
+		direction,
+		value->readable(),
+		ValueType( Imath::limits<BaseType>::min() ),
+		ValueType( Imath::limits<BaseType>::max() ),
+		flags,
+		value->getInterpretation()
+	);
+
+	return result;
+}
+
+template<typename T>
 ValuePlugPtr CompoundDataPlug::typedObjectValuePlug( const std::string &name, Plug::Direction direction, unsigned flags, const T *value )
 {
 	typename TypedObjectPlug<T>::Ptr result = new TypedObjectPlug<T>(
@@ -477,13 +497,33 @@ IECore::DataPtr CompoundDataPlug::extractDataFromPlug( const ValuePlug *plug )
 		case BoolPlugTypeId :
 			return new BoolData( static_cast<const BoolPlug *>( plug )->getValue() );
 		case V2iPlugTypeId :
-			return new V2iData( static_cast<const V2iPlug *>( plug )->getValue() );
+		{
+			const V2iPlug *v2iPlug = static_cast<const V2iPlug *>( plug );
+			V2iDataPtr data = new V2iData( v2iPlug->getValue() );
+			data->setInterpretation( v2iPlug->interpretation() );
+			return data;
+		}
 		case V3iPlugTypeId :
-			return new V3iData( static_cast<const V3iPlug *>( plug )->getValue() );
+		{
+			const V3iPlug *v3iPlug = static_cast<const V3iPlug *>( plug );
+			V3iDataPtr data = new V3iData( v3iPlug->getValue() );
+			data->setInterpretation( v3iPlug->interpretation() );
+			return data;
+		}
 		case V2fPlugTypeId :
-			return new V2fData( static_cast<const V2fPlug *>( plug )->getValue() );
+		{
+			const V2fPlug *v2fPlug = static_cast<const V2fPlug *>( plug );
+			V2fDataPtr data = new V2fData( v2fPlug->getValue() );
+			data->setInterpretation( v2fPlug->interpretation() );
+			return data;
+		}
 		case V3fPlugTypeId :
-			return new V3fData( static_cast<const V3fPlug *>( plug )->getValue() );
+		{
+			const V3fPlug *v3fPlug = static_cast<const V3fPlug *>( plug );
+			V3fDataPtr data = new V3fData( v3fPlug->getValue() );
+			data->setInterpretation( v3fPlug->interpretation() );
+			return data;
+		}
 		case Color3fPlugTypeId :
 			return new Color3fData( static_cast<const Color3fPlug *>( plug )->getValue() );
 		case Color4fPlugTypeId :

--- a/src/Gaffer/CompoundNumericPlug.cpp
+++ b/src/Gaffer/CompoundNumericPlug.cpp
@@ -49,9 +49,10 @@ CompoundNumericPlug<T>::CompoundNumericPlug(
 	T defaultValue,
 	T minValue,
 	T maxValue,
-	unsigned flags
+	unsigned flags,
+	IECore::GeometricData::Interpretation interpretation
 )
-	:	ValuePlug( name, direction, flags )
+	:	ValuePlug( name, direction, flags ), m_interpretation( interpretation )
 {
 	const char **n = childNames();
 	unsigned childFlags = flags & ~Dynamic;
@@ -76,7 +77,7 @@ bool CompoundNumericPlug<T>::acceptsChild( const GraphComponent *potentialChild 
 template<class T>
 PlugPtr CompoundNumericPlug<T>::createCounterpart( const std::string &name, Direction direction ) const
 {
-	return new CompoundNumericPlug<T>( name, direction, defaultValue(), minValue(), maxValue(), getFlags() );
+	return new CompoundNumericPlug<T>( name, direction, defaultValue(), minValue(), maxValue(), getFlags(), interpretation() );
 }
 
 template<typename T>
@@ -168,6 +169,31 @@ T CompoundNumericPlug<T>::getValue() const
 		result[i] = getChild( i )->getValue();
 	}
 	return result;
+}
+
+template<typename T>
+IECore::GeometricData::Interpretation CompoundNumericPlug<T>::interpretation() const
+{
+	return m_interpretation;
+}
+
+template<typename T>
+IECore::MurmurHash CompoundNumericPlug<T>::hash() const
+{
+	IECore::MurmurHash result = ValuePlug::hash();
+
+	if( m_interpretation != IECore::GeometricData::None )
+	{
+		result.append( m_interpretation );
+	}
+
+	return result;
+}
+
+template<typename T>
+void CompoundNumericPlug<T>::hash( IECore::MurmurHash &h ) const
+{
+	h.append( hash() );
 }
 
 template<typename T>

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -1,0 +1,143 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2012, John Haddon. All rights reserved.
+//  Copyright (c) 2014, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/ValuePlug.h"
+#include "Gaffer/PlugAlgo.h"
+
+using namespace std;
+using namespace IECore;
+using namespace Gaffer;
+
+namespace
+{
+
+struct Connections
+{
+	Plug *plug;
+	PlugPtr input;
+	vector<PlugPtr> outputs;
+};
+
+typedef vector<Connections> ConnectionsVector;
+
+void replacePlugWalk( Plug *existingPlug, Plug *plug, ConnectionsVector &connections )
+{
+	// Record output connections.
+	Connections c;
+	c.plug = plug;
+	c.outputs.insert( c.outputs.begin(), existingPlug->outputs().begin(), existingPlug->outputs().end() );
+
+	if( plug->children().size() )
+	{
+		// Recurse
+		for( PlugIterator it( plug ); !it.done(); ++it )
+		{
+			if( Plug *existingChildPlug = existingPlug->getChild<Plug>( (*it)->getName() ) )
+			{
+				replacePlugWalk( existingChildPlug, it->get(), connections );
+			}
+		}
+	}
+	else
+	{
+		// At a leaf - record input connection and transfer values if
+		// necessary. We only store inputs for leaves because automatic
+		// connection tracking will take care of connecting the parent
+		// levels when all children are connected.
+		c.input = existingPlug->getInput<Plug>();
+		if( !c.input && plug->direction() == Plug::In )
+		{
+			ValuePlug *existingValuePlug = runTimeCast<ValuePlug>( existingPlug );
+			ValuePlug *valuePlug = runTimeCast<ValuePlug>( plug );
+			if( existingValuePlug && valuePlug )
+			{
+				valuePlug->setFrom( existingValuePlug );
+			}
+		}
+	}
+
+	connections.push_back( c );
+}
+
+} // namespace
+
+namespace Gaffer
+{
+
+namespace PlugAlgo
+{
+
+void replacePlug( Gaffer::GraphComponent *parent, PlugPtr plug )
+{
+	Plug *existingPlug = parent->getChild<Plug>( plug->getName() );
+	if( !existingPlug )
+	{
+		parent->addChild( plug );
+		return;
+	}
+
+	// Transfer values where necessary, and store connections
+	// to transfer after reparenting.
+
+	ConnectionsVector connections;
+	replacePlugWalk( existingPlug, plug.get(), connections );
+
+	// Replace old plug by parenting in new one.
+
+	parent->setChild( plug->getName(), plug );
+
+	// Transfer old connections. We do this after
+	// parenting because downstream acceptsInput() methods
+	// might care what sort of node the connection is coming
+	// from.
+
+	for( ConnectionsVector::const_iterator it = connections.begin(), eIt = connections.end(); it != eIt; ++it )
+	{
+		if( it->input )
+		{
+			it->plug->setInput( it->input.get() );
+		}
+		for( vector<PlugPtr>::const_iterator oIt = it->outputs.begin(), oeIt = it->outputs.end(); oIt != oeIt; ++oIt )
+		{
+			(*oIt)->setInput( it->plug );
+		}
+	}
+}
+
+} // namespace PlugAlgo
+
+} // namespace Gaffer

--- a/src/GafferImage/OpenImageIOAlgo.cpp
+++ b/src/GafferImage/OpenImageIOAlgo.cpp
@@ -65,6 +65,25 @@ OIIO::TypeDesc::VECSEMANTICS vecSemantics( IECore::GeometricData::Interpretation
 	}
 }
 
+IECore::GeometricData::Interpretation geometricInterpretation( OIIO::TypeDesc::VECSEMANTICS semantics )
+{
+	switch( semantics )
+	{
+		case TypeDesc::NOXFORM :
+			return GeometricData::Numeric;
+		case TypeDesc::COLOR :
+			return GeometricData::Color;
+		case TypeDesc::POINT :
+			return GeometricData::Point;
+		case TypeDesc::VECTOR :
+			return GeometricData::Vector;
+		case TypeDesc::NORMAL :
+			return GeometricData::Normal;
+		default :
+			return GeometricData::Numeric;
+	}
+}
+
 DataView::DataView()
 	:	data( NULL ), m_charPointer( NULL )
 {

--- a/src/GafferOSL/OSLShader.cpp
+++ b/src/GafferOSL/OSLShader.cpp
@@ -53,6 +53,8 @@
 
 #include "GafferScene/RendererAlgo.h"
 
+#include "GafferImage/OpenImageIOAlgo.h"
+
 #include "GafferOSL/OSLShader.h"
 #include "GafferOSL/ShadingEngine.h"
 
@@ -62,6 +64,7 @@ using namespace IECore;
 using namespace OSL;
 using namespace Gaffer;
 using namespace GafferScene;
+using namespace GafferImage;
 using namespace GafferOSL;
 
 //////////////////////////////////////////////////////////////////////////
@@ -70,23 +73,6 @@ using namespace GafferOSL;
 
 namespace
 {
-
-IECore::GeometricData::Interpretation vecSemanticsToGeometricInterpretation( TypeDesc::VECSEMANTICS vecsemantics )
-{
-	switch( vecsemantics )
-	{
-	case TypeDesc::POINT :
-		return IECore::GeometricData::Point;
-	case TypeDesc::NORMAL :
-		return IECore::GeometricData::Normal;
-	case TypeDesc::VECTOR :
-		return IECore::GeometricData::Vector;
-	case TypeDesc::COLOR :
-		return IECore::GeometricData::Color;
-	default:
-		return IECore::GeometricData::None;
-	}
-}
 
 struct ShadingEngineCacheKey
 {
@@ -460,7 +446,7 @@ Plug *loadCompoundNumericParameter( const OSLQuery::Parameter *parameter, const 
 		}
 	}
 
-	IECore::GeometricData::Interpretation interpretation = vecSemanticsToGeometricInterpretation( (TypeDesc::VECSEMANTICS)parameter->type.vecsemantics );
+	IECore::GeometricData::Interpretation interpretation = OpenImageIOAlgo::geometricInterpretation( (TypeDesc::VECSEMANTICS)parameter->type.vecsemantics );
 
 	// we don't set color because we have a dedicated plug type for that.
 	if( interpretation == GeometricData::Color )

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -95,25 +95,6 @@ struct TypeDescFromType<Color3f>
 	}
 };
 
-GeometricData::Interpretation geometricInterpretationFromVecSemantics( TypeDesc::VECSEMANTICS semantics )
-{
-	switch( semantics )
-	{
-		case TypeDesc::NOXFORM :
-			return GeometricData::Numeric;
-		case TypeDesc::COLOR :
-			return GeometricData::Color;
-		case TypeDesc::POINT :
-			return GeometricData::Point;
-		case TypeDesc::VECTOR :
-			return GeometricData::Vector;
-		case TypeDesc::NORMAL :
-			return GeometricData::Normal;
-		default :
-			return GeometricData::Numeric;
-	}
-}
-
 template<typename T>
 typename T::Ptr vectorDataFromTypeDesc( TypeDesc type, void *&basePointer )
 {
@@ -127,7 +108,7 @@ template<typename T>
 typename T::Ptr geometricVectorDataFromTypeDesc( TypeDesc type, void *&basePointer )
 {
 	typename T::Ptr result = vectorDataFromTypeDesc<T>( type, basePointer );
-	result->setInterpretation( geometricInterpretationFromVecSemantics( (TypeDesc::VECSEMANTICS)type.vecsemantics ) );
+	result->setInterpretation( OpenImageIOAlgo::geometricInterpretation( ( (TypeDesc::VECSEMANTICS)type.vecsemantics ) ) );
 	return result;
 }
 


### PR DESCRIPTION
Hey John,

I assume this will need a bit of back and forth between us, but I wanted to show you a prototype so you can tell me what you want changed.

The need for having a geometric interpretation on `V3fPlugs` came up when I started using the `PlugAdder`. I would like to react differently to connections made to plugs representing normals and points etc (basically to create the respective `oslOut<Type>` nodes). We also always had the problem of default values on plugs representing normals not coming through properly. This PR should address both of these issues. A remaining problem is that Arnold doesn't have a data type for normals... Converting the normals  to a color and showing it as Cs in the viewport works, but previewing the `VectorToColor` conversion doesn't.

As for implementation details - I'm not sure whether you like that I added an additional constructor for the `CompoundNumericPlug`? We decided to do that because we had the impression we'd want to keep the flags as the last arg? If that's not the case, we could save the string mangling in the serialiser and use that extraArg mechanism instead to append the geometric interpretation as an arg? If we need that constructor (and Dan and me both felt that having the interpretation very early in the arg list kinda makes sense because it kinda determines the type of the plug), - do we want to use an init() function that is called from both constructors to reduce code duplication or wait for c++11 so that we can use constructor delegation?

Maybe look through the commits and let me know what works for you and what doesn't - maybe you want this being approached completely differently? :)

Thanks and no rush!

Matti.

