### PR TITLE
SceneReaderPathPreview : Work around browser app shutdown issues.

### DIFF
--- a/python/Gaffer/WeakMethod.py
+++ b/python/Gaffer/WeakMethod.py
@@ -61,7 +61,7 @@ class WeakMethod( object ) :
 			if "fallbackResult" in self.__kw :
 				return self.__kw["fallbackResult"]
 			else :
-				raise ReferenceError( "Instance referenced by WeakMethod %s() no longer exists" % self.__method.__name__ )
+				raise ReferenceError( "Instance referenced by WeakMethod %s.%s() no longer exists" % ( self.__method.__module__, self.__method.__name__ ) )
 
 		m = new.instancemethod( self.__method, s, s.__class__ )
 		return m( *args, **kwArgs )

--- a/python/GafferSceneUI/SceneReaderPathPreview.py
+++ b/python/GafferSceneUI/SceneReaderPathPreview.py
@@ -75,8 +75,6 @@ class SceneReaderPathPreview( GafferUI.PathPreviewWidget ) :
 		column.append( self.__viewer )
 		column.append( GafferUI.Timeline( self.__script ) )
 
-		self.__script.selection().add( self.__script["camera"] )
-
 		self._updateFromPath()
 
 	def isValid( self ) :
@@ -111,6 +109,7 @@ class SceneReaderPathPreview( GafferUI.PathPreviewWidget ) :
 		self.__script["ObjectPreview"]["fileName"].setValue( "" )
 
 		if not self.isValid() :
+			self.__script.selection().clear()
 			return
 
 		path = self.getPath()
@@ -173,6 +172,7 @@ class SceneReaderPathPreview( GafferUI.PathPreviewWidget ) :
 			GafferUI.Playback.acquire( self.__script.context() ).setFrameRange( startFrame, endFrame )
 
 		# focus the viewer
+		self.__script.selection().add( self.__script["camera"] )
 		with self.__script.context() :
 			self.__viewer.viewGadgetWidget().getViewportGadget().frame( self.__script["OpenGLAttributes"]["out"].bound( "/" ) )
 


### PR DESCRIPTION
We were getting messages like the following where our Widgets were receiving signals but had already had their Qt part destroyed :

```
Traceback (most recent call last):
  File "/disk1/john/dev/build/gaffer/python/Gaffer/WeakMethod.py", line 67, in __call__
    return m( *args, **kwArgs )
  File "/disk1/john/dev/build/gaffer/python/GafferUI/PlugLayout.py", line 502, in __plugDirtied
    if not self.visible() or plug.direction() != plug.Direction.In :
  File "/disk1/john/dev/build/gaffer/python/GafferUI/Widget.py", line 252, in visible
    return self.__qtWidget.isVisibleTo( relativeTo )
RuntimeError: Internal C++ object (PySide.QtGui.QWidget) already deleted.
```

These appear to have been coming from the toolbar UIs in the Viewer within the SceneReaderPathPreview as the script node was being destroyed. Deferring the viewing of the scene, and only viewing valid scenes seems to fix the issue, although it's unclear why. The behaviour of the SceneReaderPathPreview is at least much closer to the behaviour of the main GUI app now, so there is some cause for hope that this will be robust.

I searched in vain for a more satisfactory understanding of what was going on here, but I think it might simply be the case that we really don't have enough control over the order of destruction of python objects at shutdown.