### PR TITLE
ErrorDialogue : Fix parentWindow lifetime issues

### DIFF
--- a/python/GafferUITest/ErrorDialogueTest.py
+++ b/python/GafferUITest/ErrorDialogueTest.py
@@ -1,0 +1,58 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import weakref
+import unittest
+
+import GafferUI
+import GafferUITest
+
+class ErrorDialogueTest( GafferUITest.TestCase ) :
+
+	def testParentWindowLifetime( self ) :
+
+		w = GafferUI.Window()
+		ww = weakref.ref( w )
+
+		with GafferUI.ErrorDialogue.ErrorHandler( parentWindow = w ) :
+			pass
+
+		del w
+
+		self.assertEqual( ww(), None )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -110,6 +110,7 @@ from GadgetWidgetTest import GadgetWidgetTest
 from CompoundNoduleTest import CompoundNoduleTest
 from SwitchNodeGadgetTest import SwitchNodeGadgetTest
 from NoduleLayoutTest import NoduleLayoutTest
+from ErrorDialogueTest import ErrorDialogueTest
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Because ErrorDialogue.ErrorHandler was deriving from IECore.MessageHandler, it was subject to garbage collection. When used from the FileMenu (and others), the parentWindow passed was a full blown ScriptWindow, which in turn became subject to garbage collection. Garbage collection can kick in at any time, and on any thread. This could lead to a ScriptWindow being destroyed on a non-gui thread, leading to the attempted destruction of QtOpenGL resources on the wrong thread, and therefore deadlocks and crashes.

We fix this by changing the ErrorHandler/MessageHandler relationship from "is a" to "has a", which is arguably what it should have been anyway, even without lifetime considerations.