### PR TITLE
Main menu : Add options for flushing Arnold render caches

### DIFF
--- a/include/GafferArnold/InteractiveArnoldRender.h
+++ b/include/GafferArnold/InteractiveArnoldRender.h
@@ -54,6 +54,10 @@ class InteractiveArnoldRender : public GafferScene::Preview::InteractiveRender
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferArnold::InteractiveArnoldRender, InteractiveArnoldRenderTypeId, GafferScene::Preview::InteractiveRender );
 
+		/// Utility to call AiUniverseCacheFlush() and
+		/// restart any running sessions.
+		static void flushCaches( int flags );
+
 };
 
 IE_CORE_DECLAREPTR( InteractiveArnoldRender );

--- a/python/GafferArnoldUI/CacheMenu.py
+++ b/python/GafferArnoldUI/CacheMenu.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,17 +34,26 @@
 #
 ##########################################################################
 
-import ArnoldShaderUI
-import ArnoldRenderUI
-import ShaderMenu
-import ArnoldOptionsUI
-import ArnoldAttributesUI
-import ArnoldLightUI
-import ArnoldVDBUI
-import InteractiveArnoldRenderUI
-import ArnoldDisplacementUI
-import ArnoldMeshLightUI
-import ArnoldShaderBallUI
-import CacheMenu
+import functools
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferArnoldUI" )
+import arnold
+
+import GafferArnold
+
+def appendDefinitions( menuDefinition, prefix="" ) :
+
+	for label, flags in (
+		( "All", arnold.AI_CACHE_ALL ),
+		( "Divider", None ),
+		( "Texture", arnold.AI_CACHE_TEXTURE ),
+		( "Skydome Lights", arnold.AI_CACHE_BACKGROUND ),
+		( "Quad Lights", arnold.AI_CACHE_QUAD ),
+	) :
+		menuDefinition.append(
+			prefix + "/Flush Cache/" + label,
+			{
+				"divider" : flags is None,
+				"command" : functools.partial( GafferArnold.InteractiveArnoldRender.flushCaches, flags ),
+			}
+		)
+

--- a/src/GafferArnold/InteractiveArnoldRender.cpp
+++ b/src/GafferArnold/InteractiveArnoldRender.cpp
@@ -34,18 +34,77 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include "boost/unordered_set.hpp"
+
+#include "ai_universe.h"
+
 #include "GafferArnold/InteractiveArnoldRender.h"
 
+using namespace Gaffer;
 using namespace GafferScene;
+using namespace GafferScene::Preview;
 using namespace GafferArnold;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+typedef boost::unordered_set<InteractiveArnoldRender *> InstanceSet;
+InstanceSet &instances()
+{
+	static InstanceSet i;
+	return i;
+}
+
+typedef std::pair<IntPlug *, InteractiveRender::State> Interrupted;
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// InteractiveArnoldRender
+//////////////////////////////////////////////////////////////////////////
 
 IE_CORE_DEFINERUNTIMETYPED( InteractiveArnoldRender );
 
 InteractiveArnoldRender::InteractiveArnoldRender( const std::string &name )
 	:	InteractiveRender( "IECoreArnold::Renderer", name )
 {
+	instances().insert( this );
 }
 
 InteractiveArnoldRender::~InteractiveArnoldRender()
 {
+	instances().erase( this );
+}
+
+void InteractiveArnoldRender::flushCaches( int flags )
+{
+	std::vector<Interrupted> interrupted;
+
+	const InstanceSet &i = instances();
+	for( InstanceSet::const_iterator it = i.begin(), eIt = i.end(); it != eIt; ++it )
+	{
+		IntPlug *statePlug = (*it)->statePlug()->source<IntPlug>();
+		if( !statePlug->settable() )
+		{
+			continue;
+		}
+
+		const State state = (InteractiveRender::State)statePlug->getValue();
+		if( state != Stopped )
+		{
+			statePlug->setValue( Stopped );
+			interrupted.push_back( Interrupted( statePlug, state ) );
+		}
+	}
+
+	AiUniverseCacheFlush( flags );
+
+	for( std::vector<Interrupted>::const_iterator it = interrupted.begin(), eIt = interrupted.end(); it != eIt; ++it )
+	{
+		it->first->setValue( it->second );
+	}
 }

--- a/src/GafferArnoldModule/GafferArnoldModule.cpp
+++ b/src/GafferArnoldModule/GafferArnoldModule.cpp
@@ -74,6 +74,12 @@ class ArnoldShaderSerialiser : public GafferBindings::NodeSerialiser
 
 };
 
+void flushCaches( int flags )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	InteractiveArnoldRender::flushCaches( flags );
+}
+
 } // namespace
 
 BOOST_PYTHON_MODULE( _GafferArnold )
@@ -100,7 +106,10 @@ BOOST_PYTHON_MODULE( _GafferArnold )
 	GafferBindings::DependencyNodeClass<ArnoldVDB>();
 	GafferBindings::DependencyNodeClass<ArnoldDisplacement>();
 	GafferBindings::DependencyNodeClass<ArnoldMeshLight>();
-	GafferBindings::NodeClass<InteractiveArnoldRender>();
+	GafferBindings::NodeClass<InteractiveArnoldRender>()
+		.def( "flushCaches", &flushCaches )
+		.staticmethod( "flushCaches" )
+	;
 	GafferDispatchBindings::TaskNodeClass<ArnoldRender>();
 
 }

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -117,6 +117,8 @@ if moduleSearchPath.find( "arnold" ) :
 		nodeMenu.append( "/Arnold/Interactive Render", GafferArnold.InteractiveArnoldRender, searchText = "InteractiveArnoldRender" )
 		nodeMenu.append( "/Arnold/Shader Ball", GafferArnold.ArnoldShaderBall, searchText = "ArnoldShaderBall" )
 
+		GafferArnoldUI.CacheMenu.appendDefinitions( scriptWindowMenu, "/Tools/Arnold" )
+
 	except Exception, m :
 
 		stacktrace = traceback.format_exc()

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -67,7 +67,8 @@ for menuItem, url in [
 		( "Node Reference", "$GAFFER_ROOT/doc/gaffer/html/NodeReference/index.html" ),
 		( "License", "$GAFFER_ROOT/doc/gaffer/html/Appendices/License/index.html" ),
 		( "LocalDocsDivider", None ),
-		( "Mailing List", "https://groups.google.com/forum/#!forum/gaffer-dev" ),
+		( "Forum", "https://groups.google.com/forum/#!forum/gaffer-dev" ),
+		( "Issue Tracker", "https://github.com/GafferHQ/gaffer/issues" ),
 		( "CoreDocsDivider", None ),
 	] :
 


### PR DESCRIPTION
This necessitated the addition of `InteractiveArnoldRender::flushCaches()` to do the actual work while taking care of restarting any running renders to reflect the changes. This is needed because the InteractiveArnoldRender node within the shader swatch viewer is not accessible via the script, so the CacheMenu code could not discover all nodes to perform the restarts itself.