### PR TITLE
Crop : Don't offset empty data windows

### DIFF
--- a/src/GafferImage/Crop.cpp
+++ b/src/GafferImage/Crop.cpp
@@ -278,8 +278,11 @@ Imath::Box2i Crop::computeDataWindow( const Gaffer::Context *context, const Imag
 		result = BufferAlgo::intersection( result, cropWindow );
 	}
 
-	result.min += offset;
-	result.max += offset;
+	if( !result.isEmpty() )
+	{
+		result.min += offset;
+		result.max += offset;
+	}
 
 	return result;
 }


### PR DESCRIPTION
The hang I was describing was turned out to be quite a bit different once I could reproduce it.  It wasn't actually locking the GL driver, it was just continually spamming the GL driver with commands that kept any other software from getting much of anything displayed to the screen ( if you wait long enough, you can actually eventually see things update. )

In the course of narrowing down a clean test case, I ended up finding the problem.

The repro is actually really simple: just create a Crop node with no input, and set the minimum value to something positive in both X and Y.

The issue is the offset in the crop being applied to an empty data window, which causes it to wrap into a window with a size of 1.  For example: [-2147483648, 2147483647), offset down 29, becomes [ 2147483617, 2147483618 ).  This is certainly wrong, but in theory shouldn't be a huge problem.  Where it really blows up though is in renderTiles(), where it steps through adding tileSize() to the tileOrigin and checking if it is still less than the dataWindow max.  With these extreme values, this will wrap into the negatives without ever becoming >= dataWindow max, producing an infinite loop of requests to GL to render a quad for these bogus tiles.

The fix to the source of the problem in Crop is a one liner, so I've gone ahead and done that.  Not sure whether putting something defensive in renderTiles() might also be worthwhile.