### PR TITLE
Crop : Don't offset empty data windows

### DIFF
--- a/python/GafferImageTest/CropTest.py
+++ b/python/GafferImageTest/CropTest.py
@@ -261,5 +261,12 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( crop["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 0 ), area.size() ) )
 		self.assertEqual( crop["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( -50 ), IECore.V2i( 50, 150 ) ) )
 
+	def testEmptyInput( self ) :
+
+		crop = GafferImage.Crop()
+
+		crop["area"]["min"].setValue( IECore.V2i( 20 ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( crop["out"]["dataWindow"].getValue() ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImage/Crop.cpp
+++ b/src/GafferImage/Crop.cpp
@@ -278,8 +278,11 @@ Imath::Box2i Crop::computeDataWindow( const Gaffer::Context *context, const Imag
 		result = BufferAlgo::intersection( result, cropWindow );
 	}
 
-	result.min += offset;
-	result.max += offset;
+	if( !BufferAlgo::empty( result ) )
+	{
+		result.min += offset;
+		result.max += offset;
+	}
 
 	return result;
 }


### PR DESCRIPTION
With the help of integer overflow, this could make very large non-empty data windows.