### PR TITLE
Render Adaptors

### DIFF
--- a/include/GafferScene/Preview/InteractiveRender.h
+++ b/include/GafferScene/Preview/InteractiveRender.h
@@ -105,6 +105,9 @@ class InteractiveRender : public Gaffer::Node
 
 		void construct( const IECore::InternedString &rendererType = IECore::InternedString() );
 
+		ScenePlug *adaptedInPlug();
+		const ScenePlug *adaptedInPlug() const;
+
 		void plugDirtied( const Gaffer::Plug *plug );
 		void contextChanged( const IECore::InternedString &name );
 

--- a/include/GafferScene/Preview/InteractiveRender.h
+++ b/include/GafferScene/Preview/InteractiveRender.h
@@ -125,7 +125,7 @@ class InteractiveRender : public Gaffer::Node
 		IECoreScenePreview::Renderer::ObjectInterfacePtr m_defaultCamera;
 
 		Gaffer::ContextPtr m_context; // Accessed with setContext()/getContext()
-		Gaffer::ContextPtr m_effectiveContext; // Context actually used for rendering
+		Gaffer::ContextPtr m_effectiveContext; // Base context actually used for rendering
 		boost::signals::scoped_connection m_contextChangedConnection;
 
 		static size_t g_firstPlugIndex;

--- a/include/GafferScene/Preview/Render.h
+++ b/include/GafferScene/Preview/Render.h
@@ -97,6 +97,9 @@ class Render : public GafferDispatch::TaskNode
 
 		void construct( const IECore::InternedString &rendererType = IECore::InternedString() );
 
+		ScenePlug *adaptedInPlug();
+		const ScenePlug *adaptedInPlug() const;
+
 		static size_t g_firstPlugIndex;
 
 };

--- a/include/GafferScene/RendererAlgo.h
+++ b/include/GafferScene/RendererAlgo.h
@@ -47,6 +47,8 @@
 namespace GafferScene
 {
 
+IE_CORE_FORWARDDECLARE( SceneProcessor )
+
 namespace RendererAlgo
 {
 
@@ -117,6 +119,17 @@ void objectSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &s
 
 /// Outputs the object for the current location, using objectSamples() to generate the samples.
 void outputObject( const ScenePlug *scene, IECore::Renderer *renderer, size_t segments = 0, const Imath::V2f &shutter = Imath::V2i( 0 ) );
+
+/// Function to return a SceneProcessor used to adapt the
+/// scene for rendering.
+typedef boost::function<SceneProcessorPtr ()> Adaptor;
+/// Registers an adaptor.
+void registerAdaptor( const std::string &name, Adaptor adaptor );
+/// Removes a previously registered adaptor.
+void deregisterAdaptor( const std::string &name );
+/// Returns a SceneProcessor that will apply all the currently
+/// registered adaptors.
+SceneProcessorPtr createAdaptors();
 
 } // namespace RendererAlgo
 

--- a/include/GafferSceneBindings/RendererAlgoBinding.h
+++ b/include/GafferSceneBindings/RendererAlgoBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEBINDINGS_RENDERERALGOBINDING_H
+#define GAFFERSCENEBINDINGS_RENDERERALGOBINDING_H
+
+namespace GafferSceneBindings
+{
+
+void bindRendererAlgo();
+
+} // namespace GafferSceneBindings
+
+#endif // GAFFERSCENEBINDINGS_RENDERERALGOBINDING_H

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -775,6 +775,23 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 							seed or round( frame )
 						)
 
+	def testRendererContextVariable( self ) :
+
+		sphere = GafferScene.Sphere()
+		sphere["name"].setValue( "sphere${scene:renderer}" )
+
+		render = GafferArnold.ArnoldRender()
+		render["in"].setInput( sphere["out"] )
+		render["mode"].setValue( render.Mode.SceneDescriptionMode )
+		render["fileName"].setValue( self.temporaryDirectory() + "/test.ass" )
+
+		render["task"].execute()
+
+		with IECoreArnold.UniverseBlock() :
+
+			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+			self.assertTrue( arnold.AiNodeLookUpByName( "/sphereArnold" ) is not None )
+
 	def __arrayToSet( self, a ) :
 
 		result = set()

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -51,16 +51,23 @@ import GafferTest
 import GafferDispatch
 import GafferImage
 import GafferScene
+import GafferSceneTest
 import GafferArnold
 import GafferArnoldTest
 
-class ArnoldRenderTest( GafferTest.TestCase ) :
+class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 	def setUp( self ) :
 
-		GafferTest.TestCase.setUp( self )
+		GafferSceneTest.SceneTestCase.setUp( self )
 
 		self.__scriptFileName = self.temporaryDirectory() + "/test.gfr"
+
+	def tearDown( self ) :
+
+		GafferSceneTest.SceneTestCase.tearDown( self )
+
+		GafferScene.deregisterAdaptor( "Test" )
 
 	def testExecute( self ) :
 
@@ -791,6 +798,36 @@ class ArnoldRenderTest( GafferTest.TestCase ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 			self.assertTrue( arnold.AiNodeLookUpByName( "/sphereArnold" ) is not None )
+
+	def testAdaptors( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		def a() :
+
+			result = GafferArnold.ArnoldAttributes()
+			result["attributes"]["matte"]["enabled"].setValue( True )
+			result["attributes"]["matte"]["value"].setValue( True )
+
+			return result
+
+		GafferScene.registerAdaptor( "Test", a )
+
+		sphere = GafferScene.Sphere()
+
+		render = GafferArnold.ArnoldRender()
+		render["in"].setInput( sphere["out"] )
+		render["mode"].setValue( render.Mode.SceneDescriptionMode )
+		render["fileName"].setValue( self.temporaryDirectory() + "/test.ass" )
+
+		render["task"].execute()
+
+		with IECoreArnold.UniverseBlock() :
+
+			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+			node = arnold.AiNodeLookUpByName( "/sphere" )
+
+			self.assertEqual( arnold.AiNodeGetBool( node, "matte" ), True )
 
 	def __arrayToSet( self, a ) :
 

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -172,7 +172,7 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		s["parameters"]["color"].setInput( f["parameters"]["color"] )
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
 		)
 

--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -50,15 +50,15 @@ class RendererTest( GafferTest.TestCase ) :
 
 	def testFactory( self ) :
 
-		self.assertTrue( "IECoreArnold::Renderer" in GafferScene.Private.IECoreScenePreview.Renderer.types() )
+		self.assertTrue( "Arnold" in GafferScene.Private.IECoreScenePreview.Renderer.types() )
 
-		r = GafferScene.Private.IECoreScenePreview.Renderer.create( "IECoreArnold::Renderer" )
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create( "Arnold" )
 		self.assertTrue( isinstance( r, GafferScene.Private.IECoreScenePreview.Renderer ) )
 
 	def testSceneDescription( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -84,7 +84,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testRenderRegion( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -121,7 +121,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testShaderReuse( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -151,7 +151,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testShaderGarbageCollection( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -182,7 +182,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testShaderNames( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -231,7 +231,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testShaderNodeConnectionType( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -298,7 +298,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testLightNames( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -328,7 +328,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testLightTransforms( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -383,7 +383,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testSharedLightAttributes( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -413,7 +413,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testAttributes( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -496,7 +496,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testOutputFilters( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -530,7 +530,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testExrMetadata( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -642,7 +642,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testInstancing( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -741,7 +741,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testSubdivisionAttributes( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -778,7 +778,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testUserAttributes( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -835,7 +835,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testDisplacementAttributes( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -911,7 +911,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testSubdividePolygonsAttribute( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -958,7 +958,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testMeshLight( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -998,7 +998,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testMeshLightsWithSharedShaders( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -1061,7 +1061,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testOSLShaders( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -1148,7 +1148,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testPureOSLShaders( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -1180,7 +1180,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testTraceSets( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -1228,7 +1228,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testCurvesAttributes( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -1326,7 +1326,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testAttributeEditFailures( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
 		)
 
@@ -1400,7 +1400,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testStepSizeAttribute( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -1509,7 +1509,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testStepSizeAttributeDefersToProceduralParameter( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -1550,7 +1550,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testDeclaringCustomOptions( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)
@@ -1573,7 +1573,7 @@ class RendererTest( GafferTest.TestCase ) :
 			for seed in ( None, 3, 4 ) :
 
 				r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-					"IECoreArnold::Renderer",
+					"Arnold",
 					GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 					self.temporaryDirectory() + "/test.ass"
 				)
@@ -1602,7 +1602,7 @@ class RendererTest( GafferTest.TestCase ) :
 		# it doesn't exist.
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"IECoreArnold::Renderer",
+			"Arnold",
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
 			self.temporaryDirectory() + "/test.ass"
 		)

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -1509,6 +1509,37 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 		assertReflected( True )
 
+	def testRendererContextVariable( self ):
+
+		s = Gaffer.ScriptNode()
+		s["s"] = GafferScene.Sphere()
+
+		s["o"] = GafferScene.Outputs()
+		s["o"].addOutput(
+			"beauty",
+			IECore.Display(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ImageDisplayDriver",
+					"handle" : "myLovelySphereRenderedIn${scene:renderer}",
+				}
+			)
+		)
+		s["o"]["in"].setInput( s["s"]["out"] )
+
+		s["r"] = self._createInteractiveRender()
+		s["r"]["in"].setInput( s["o"]["out"] )
+
+		s["r"]["state"].setValue( s["r"].State.Running )
+
+		time.sleep( 0.5 )
+
+		renderer = s["r"]["renderer"].getValue() if "renderer" in s["r"] else s["r"]["__renderer"].getValue()
+		image = IECore.ImageDisplayDriver.storedImage( "myLovelySphereRenderedIn" + renderer )
+		self.assertTrue( isinstance( image, IECore.ImagePrimitive ) )
+
 	## Should be implemented by derived classes to return an
 	# appropriate InteractiveRender node.
 	def _createInteractiveRender( self ) :

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -1540,6 +1540,61 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		image = IECore.ImageDisplayDriver.storedImage( "myLovelySphereRenderedIn" + renderer )
 		self.assertTrue( isinstance( image, IECore.ImagePrimitive ) )
 
+	def testAdaptors( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["s"] = GafferScene.Sphere()
+
+		def a() :
+
+			result = GafferScene.SceneProcessor()
+
+			result["__shader"], colorPlug = self._createConstantShader()
+			colorPlug.setValue( IECore.Color3f( 1, 0, 0 ) )
+
+			result["__assignment"] = GafferScene.ShaderAssignment()
+			result["__assignment"]["in"].setInput( result["in"] )
+			result["__assignment"]["shader"].setInput( result["__shader"]["out"] )
+
+			result["out"].setInput( result["__assignment"]["out"] )
+
+			return result
+
+		GafferScene.registerAdaptor( "Test", a )
+
+		s["o"] = GafferScene.Outputs()
+		s["o"].addOutput(
+			"beauty",
+			IECore.Display(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ImageDisplayDriver",
+					"handle" : "myLovelySphere",
+				}
+			)
+		)
+		s["o"]["in"].setInput( s["s"]["out"] )
+
+		s["r"] = self._createInteractiveRender()
+		s["r"]["in"].setInput( s["o"]["out"] )
+
+		s["r"]["state"].setValue( s["r"].State.Running )
+
+		time.sleep( 0.5 )
+
+		# Render red sphere
+
+		image = IECore.ImageDisplayDriver.storedImage( "myLovelySphere" )
+		self.__assertColorsAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ), IECore.Color4f( 1, 0, 0, 1 ), delta = 0.01 )
+
+	def tearDown( self ) :
+
+		GafferSceneTest.SceneTestCase.tearDown( self )
+
+		GafferScene.deregisterAdaptor( "Test" )
+
 	## Should be implemented by derived classes to return an
 	# appropriate InteractiveRender node.
 	def _createInteractiveRender( self ) :

--- a/python/GafferSceneTest/RendererAlgoTest.py
+++ b/python/GafferSceneTest/RendererAlgoTest.py
@@ -1,0 +1,87 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import GafferScene
+import GafferSceneTest
+
+class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		adaptors = GafferScene.createAdaptors()
+		adaptors["in"].setInput( sphere["out"] )
+
+		self.assertScenesEqual( sphere["out"], adaptors["out"] )
+		self.assertSceneHashesEqual( sphere["out"], adaptors["out"] )
+
+		def a() :
+
+			r = GafferScene.StandardAttributes()
+			r["attributes"]["doubleSided"]["enabled"].setValue( True )
+			r["attributes"]["doubleSided"]["value"].setValue( False )
+
+			return r
+
+		GafferScene.registerAdaptor( "Test", a )
+
+		adaptors = GafferScene.createAdaptors()
+		adaptors["in"].setInput( sphere["out"] )
+
+		self.assertFalse( "doubleSided" in sphere["out"].attributes( "/sphere" ) )
+		self.assertTrue( "doubleSided" in adaptors["out"].attributes( "/sphere" ) )
+		self.assertEqual( adaptors["out"].attributes( "/sphere" )["doubleSided"].value, False )
+
+		GafferScene.deregisterAdaptor( "Test" )
+
+		adaptors = GafferScene.createAdaptors()
+		adaptors["in"].setInput( sphere["out"] )
+
+		self.assertScenesEqual( sphere["out"], adaptors["out"] )
+		self.assertSceneHashesEqual( sphere["out"], adaptors["out"] )
+
+	def tearDown( self ) :
+
+		GafferSceneTest.SceneTestCase.tearDown( self )
+		GafferScene.deregisterAdaptor( "Test" )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -117,6 +117,7 @@ from FilteredSceneProcessorTest import FilteredSceneProcessorTest
 from ShaderBallTest import ShaderBallTest
 from LightTweaksTest import LightTweaksTest
 from FilterResultsTest import FilterResultsTest
+from RendererAlgoTest import RendererAlgoTest
 
 if __name__ == "__main__":
 	import unittest

--- a/src/GafferAppleseed/AppleseedRender.cpp
+++ b/src/GafferAppleseed/AppleseedRender.cpp
@@ -42,7 +42,7 @@ using namespace GafferAppleseed;
 IE_CORE_DEFINERUNTIMETYPED( AppleseedRender );
 
 AppleseedRender::AppleseedRender( const std::string &name )
-	:	Render( "IECoreAppleseed::Renderer", name )
+	:	Render( "Appleseed", name )
 {
 }
 

--- a/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
+++ b/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
@@ -2519,6 +2519,6 @@ class AppleseedRenderer : public IECoreScenePreview::Renderer
 
 };
 
-IECoreScenePreview::Renderer::TypeDescription<AppleseedRenderer> AppleseedRenderer::g_typeDescription( "IECoreAppleseed::Renderer" );
+IECoreScenePreview::Renderer::TypeDescription<AppleseedRenderer> AppleseedRenderer::g_typeDescription( "Appleseed" );
 
 } // namespace

--- a/src/GafferAppleseed/InteractiveAppleseedRender.cpp
+++ b/src/GafferAppleseed/InteractiveAppleseedRender.cpp
@@ -42,7 +42,7 @@ using namespace GafferAppleseed;
 IE_CORE_DEFINERUNTIMETYPED( InteractiveAppleseedRender );
 
 InteractiveAppleseedRender::InteractiveAppleseedRender( const std::string &name )
-	:	InteractiveRender( "IECoreAppleseed::Renderer", name )
+	:	InteractiveRender( "Appleseed", name )
 {
 }
 

--- a/src/GafferArnold/ArnoldRender.cpp
+++ b/src/GafferArnold/ArnoldRender.cpp
@@ -42,7 +42,7 @@ using namespace GafferArnold;
 IE_CORE_DEFINERUNTIMETYPED( ArnoldRender );
 
 ArnoldRender::ArnoldRender( const std::string &name )
-	:	Render( "IECoreArnold::Renderer", name )
+	:	Render( "Arnold", name )
 {
 }
 

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -2081,6 +2081,6 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 
 };
 
-IECoreScenePreview::Renderer::TypeDescription<ArnoldRenderer> ArnoldRenderer::g_typeDescription( "IECoreArnold::Renderer" );
+IECoreScenePreview::Renderer::TypeDescription<ArnoldRenderer> ArnoldRenderer::g_typeDescription( "Arnold" );
 
 } // namespace

--- a/src/GafferArnold/InteractiveArnoldRender.cpp
+++ b/src/GafferArnold/InteractiveArnoldRender.cpp
@@ -70,7 +70,7 @@ typedef std::pair<IntPlug *, InteractiveRender::State> Interrupted;
 IE_CORE_DEFINERUNTIMETYPED( InteractiveArnoldRender );
 
 InteractiveArnoldRender::InteractiveArnoldRender( const std::string &name )
-	:	InteractiveRender( "IECoreArnold::Renderer", name )
+	:	InteractiveRender( "Arnold", name )
 {
 	instances().insert( this );
 }

--- a/src/GafferScene/Preview/Render.cpp
+++ b/src/GafferScene/Preview/Render.cpp
@@ -64,6 +64,8 @@ InternedString g_performanceMonitorOptionName( "option:render:performanceMonitor
 
 size_t Render::g_firstPlugIndex = 0;
 
+static IECore::InternedString g_rendererContextName( "scene:renderer" );
+
 IE_CORE_DEFINERUNTIMETYPED( Render );
 
 Render::Render( const std::string &name )
@@ -185,6 +187,10 @@ void Render::execute() const
 	{
 		return;
 	}
+
+	ContextPtr rendererContext = new Context( *Context::current(), Context::Borrowed );
+	rendererContext->set( g_rendererContextName, rendererType );
+	Context::Scope rendererContextScope( rendererContext.get() );
 
 	const Mode mode = static_cast<Mode>( modePlug()->getValue() );
 	const std::string fileName = fileNamePlug()->getValue();

--- a/src/GafferSceneBindings/RendererAlgoBinding.cpp
+++ b/src/GafferSceneBindings/RendererAlgoBinding.cpp
@@ -1,0 +1,92 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "IECorePython/ScopedGILLock.h"
+
+#include "GafferScene/RendererAlgo.h"
+#include "GafferScene/SceneProcessor.h"
+
+#include "GafferSceneBindings/RendererAlgoBinding.h"
+
+using namespace boost::python;
+using namespace GafferScene;
+
+namespace
+{
+
+struct AdaptorWrapper
+{
+
+	AdaptorWrapper( object pythonAdaptor )
+		:	m_pythonAdaptor( pythonAdaptor )
+	{
+	}
+
+	SceneProcessorPtr operator()()
+	{
+		IECorePython::ScopedGILLock gilLock;
+		SceneProcessorPtr result = extract<SceneProcessorPtr>( m_pythonAdaptor() );
+		return result;
+	}
+
+	private :
+
+		object m_pythonAdaptor;
+
+};
+
+void registerAdaptorWrapper( const std::string &name, object adaptor )
+{
+	registerAdaptor( name, AdaptorWrapper( adaptor ) );
+}
+
+} // namespace
+
+namespace GafferSceneBindings
+{
+
+void bindRendererAlgo()
+{
+
+	def( "registerAdaptor", &registerAdaptorWrapper );
+	def( "deregisterAdaptor", &deregisterAdaptor );
+	def( "createAdaptors", &createAdaptors );
+
+}
+
+} // namespace GafferSceneBindings

--- a/src/GafferSceneModule/GafferSceneModule.cpp
+++ b/src/GafferSceneModule/GafferSceneModule.cpp
@@ -107,6 +107,7 @@
 #include "GafferSceneBindings/LightTweaksBinding.h"
 #include "GafferSceneBindings/LightToCameraBinding.h"
 #include "GafferSceneBindings/FilterResultsBinding.h"
+#include "GafferSceneBindings/RendererAlgoBinding.h"
 
 using namespace boost::python;
 using namespace GafferBindings;
@@ -195,5 +196,6 @@ BOOST_PYTHON_MODULE( _GafferScene )
 	bindLightTweaks();
 	bindLightToCamera();
 	bindFilterResults();
+	bindRendererAlgo();
 
 }


### PR DESCRIPTION
As discussed on #1985, here is my work on render adaptors to support Matti's light linking. Basically this just adds two things :

- A "scene:renderer" context variable, so the node graph knows which renderer it is being run for.
- A mechanism for registering "render adaptors" - SceneProcessor nodes which are hosted internally to the render nodes and which can therefore manipulate the scene before it hits the renderer.

I've resisted the addition of this feature for a long time, on the grounds that I believe the data the artist sees should be the ground truth, not a recipe for some invisible resolution process that could completely transform things, and which is hard for them to anticipate or introspect. But since the absence of this feature has just led to it being emulated internally at Image Engine, and we have a solid need for it in #1985, I'm caving. I suggest we think carefully about how we use it in the future - i.e. use it only to implement internal just-in-time processes that the user does not need to introspect.

I did have a partial implementation of this for the legacy 3delight backend, but I've ditched it from this PR on the grounds that any future serious 3delight work would require a new NSI backend anyway. So this is just an Arnold/Appleseed feature for now.