### PR TITLE
Fix NodeUI documentation:url metadata.

### DIFF
--- a/python/GafferUI/NodeUI.py
+++ b/python/GafferUI/NodeUI.py
@@ -44,7 +44,7 @@ import GafferUI
 
 def __documentationURL( node ) :
 
-	fileName = "$GAFFER_ROOT/doc/gaffer/html/NodeReference/" + node.typeName().replace( "::", "/" ) + ".html"
+	fileName = "$GAFFER_ROOT/doc/gaffer/html/Reference/NodeReference/" + node.typeName().replace( "::", "/" ) + ".html"
 	fileName = os.path.expandvars( fileName )
 	return "file://" + fileName if os.path.isfile( fileName ) else ""
 

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -85,6 +85,14 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 
 				with _Row() :
 
+					_Label( "Documentation URL" )
+
+					self.__nodeMetadataWidgets.append(
+						_StringMetadataWidget( key = "documentation:url" )
+					)
+
+				with _Row() :
+
 					_Label( "Color" )
 
 					self.__nodeMetadataWidgets.append(


### PR DESCRIPTION
The file structure of the docs was re-organized a while back, but we forgot to update these links.