### PR TITLE
GafferImage::Sampler : Several small optimizations

### DIFF
--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -135,20 +135,25 @@ class ImagePlug : public Gaffer::ValuePlug
 		IECore::MurmurHash imageHash() const;
 		//@}
 
-		static int tileSize() { return 64; };
+		static int tileSize() { return 1 << tileSizeLog2(); };
 		static const IECore::FloatVectorData *blackTile();
 		static const IECore::FloatVectorData *whiteTile();
+
+		/// Returns the index of the tile containing a point
+		/// This just means dividing by tile size ( always rounding down )
+		inline static const Imath::V2i tileIndex( const Imath::V2i &point )
+		{
+			return Imath::V2i( point.x >> tileSizeLog2(), point.y >> tileSizeLog2() );
+		};
 
 		/// Returns the origin of the tile that contains the point.
 		inline static Imath::V2i tileOrigin( const Imath::V2i &point )
 		{
-			Imath::V2i tileOrigin;
-			tileOrigin.x = point.x < 0 && point.x % tileSize() != 0 ? ( point.x / tileSize() - 1 ) * tileSize() : ( point.x / tileSize() ) * tileSize();
-			tileOrigin.y = point.y < 0 && point.y % tileSize() != 0 ? ( point.y / tileSize() - 1 ) * tileSize() : ( point.y / tileSize() ) * tileSize();
-			return tileOrigin;
+			return tileIndex( point ) * tileSize();
 		}
 
 	private :
+		static int tileSizeLog2() { return 6; };
 
 		static void compoundObjectToCompoundData( const IECore::CompoundObject *object, IECore::CompoundData *data );
 

--- a/include/GafferImage/Sampler.h
+++ b/include/GafferImage/Sampler.h
@@ -107,9 +107,8 @@ class Sampler
 		/// Cached data access
 		/// @param p Any point within the cache that we wish to retrieve the data for.
 		/// @param tileData Is set to the tile's channel data.
-		/// @param tileOrigin The coordinate of the tile's  minimum corner.
 		/// @param tileIndex XY indices that can be used to access the colour value of point 'p' from tileData.
-		inline void cachedData( Imath::V2i p, const float *& tileData, Imath::V2i &tileOrigin, Imath::V2i &tileIndex );
+		inline void cachedData( Imath::V2i p, const float *& tileData, Imath::V2i &tileIndex );
 
 		const ImagePlug *m_plug;
 		const std::string m_channelName;
@@ -117,10 +116,11 @@ class Sampler
 		Imath::Box2i m_dataWindow;
 
 		std::vector< IECore::ConstFloatVectorDataPtr > m_dataCache;
+		std::vector< const float * > m_dataCacheRaw;
 		Imath::Box2i m_cacheWindow;
 		int m_cacheWidth;
 
-		BoundingMode m_boundingMode;
+		int m_boundingMode;
 
 };
 

--- a/include/GafferImage/Sampler.h
+++ b/include/GafferImage/Sampler.h
@@ -107,8 +107,8 @@ class Sampler
 		/// Cached data access
 		/// @param p Any point within the cache that we wish to retrieve the data for.
 		/// @param tileData Is set to the tile's channel data.
-		/// @param tileIndex XY indices that can be used to access the colour value of point 'p' from tileData.
-		inline void cachedData( Imath::V2i p, const float *& tileData, Imath::V2i &tileIndex );
+		/// @param tilePixelIndex XY indices that can be used to access the colour value of point 'p' from tileData.
+		inline void cachedData( Imath::V2i p, const float *& tileData, Imath::V2i &tilePixelIndex );
 
 		const ImagePlug *m_plug;
 		const std::string m_channelName;

--- a/include/GafferImage/Sampler.inl
+++ b/include/GafferImage/Sampler.inl
@@ -53,24 +53,29 @@ float Sampler::sample( int x, int y )
 
 #endif
 
-	// Deal with lookups outside of the data window.
-	if( m_boundingMode == Black && !BufferAlgo::contains( m_dataWindow, p ) )
+	if( m_boundingMode != -1 )
 	{
-		return 0.0f;
-	}
-	else
-	{
-		if( BufferAlgo::empty( m_dataWindow ) )
+		// Deal with lookups outside of the data window.
+		if( m_boundingMode == Black )
 		{
-			return 0.0f;
+			if( !BufferAlgo::contains( m_dataWindow, p ) )
+			{
+				return 0.0f;
+			}
 		}
-		p = BufferAlgo::clamp( p, m_dataWindow );
+		else
+		{
+			if( BufferAlgo::empty( m_dataWindow ) )
+			{
+				return 0.0f;
+			}
+			p = BufferAlgo::clamp( p, m_dataWindow );
+		}
 	}
 
 	const float *tileData;
-	Imath::V2i tileOrigin;
 	Imath::V2i tileIndex;
-	cachedData( p, tileData, tileOrigin, tileIndex );
+	cachedData( p, tileData, tileIndex );
 	return *(tileData + tileIndex.y * ImagePlug::tileSize() + tileIndex.x);
 }
 
@@ -89,19 +94,28 @@ float Sampler::sample( float x, float y )
 	return OIIO::bilerp( x0y0, x1y0, x0y1, x1y1, xf, yf );
 }
 
-void Sampler::cachedData( Imath::V2i p, const float *& tileData, Imath::V2i &tileOrigin, Imath::V2i &tileIndex )
+void Sampler::cachedData( Imath::V2i p, const float *& tileData, Imath::V2i &tileIndex )
 {
 	// Get the smart pointer to the tile we want.
-	p -= m_cacheWindow.min;
-	Imath::V2i cacheIndex( p / Imath::V2i( ImagePlug::tileSize() ) );
-	tileIndex = Imath::V2i( p - cacheIndex * Imath::V2i( ImagePlug::tileSize() ) );
-	IECore::ConstFloatVectorDataPtr &cacheTilePtr = m_dataCache[ cacheIndex.x + cacheIndex.y * m_cacheWidth ];
+	Imath::V2i relP = p - m_cacheWindow.min;
+	Imath::V2i cacheIndex = ImagePlug::tileIndex( relP );
 
-	// Get the origin of the tile we want.
-	tileOrigin = Imath::V2i( (( m_cacheWindow.min / ImagePlug::tileSize()) + cacheIndex ) * ImagePlug::tileSize() );
-	if ( cacheTilePtr == NULL ) cacheTilePtr = m_plug->channelData( m_channelName, tileOrigin );
+	tileIndex = relP - cacheIndex * ImagePlug::tileSize();
 
-	tileData = &cacheTilePtr->readable()[0];
+	int cacheI = cacheIndex.x + cacheIndex.y * m_cacheWidth;
+	const float *(&cacheTileRawPtr) = m_dataCacheRaw[ cacheI ];
+
+	if ( cacheTileRawPtr == NULL )
+	{
+		// Get the origin of the tile we want.
+		Imath::V2i tileOrigin = ( ImagePlug::tileIndex( m_cacheWindow.min ) + cacheIndex ) * ImagePlug::tileSize();
+
+		IECore::ConstFloatVectorDataPtr &cacheTilePtr = m_dataCache[ cacheI ];
+		cacheTilePtr = m_plug->channelData( m_channelName, tileOrigin );
+		cacheTileRawPtr = &cacheTilePtr->readable()[0];
+	}
+
+	tileData = cacheTileRawPtr;
 }
 
 }; // namespace GafferImage

--- a/include/GafferImage/Sampler.inl
+++ b/include/GafferImage/Sampler.inl
@@ -94,13 +94,13 @@ float Sampler::sample( float x, float y )
 	return OIIO::bilerp( x0y0, x1y0, x0y1, x1y1, xf, yf );
 }
 
-void Sampler::cachedData( Imath::V2i p, const float *& tileData, Imath::V2i &tileIndex )
+void Sampler::cachedData( Imath::V2i p, const float *& tileData, Imath::V2i &tilePixelIndex )
 {
 	// Get the smart pointer to the tile we want.
 	Imath::V2i relP = p - m_cacheWindow.min;
 	Imath::V2i cacheIndex = ImagePlug::tileIndex( relP );
 
-	tileIndex = relP - cacheIndex * ImagePlug::tileSize();
+	tilePixelIndex = relP - cacheIndex * ImagePlug::tileSize();
 
 	int cacheI = cacheIndex.x + cacheIndex.y * m_cacheWidth;
 	const float *(&cacheTileRawPtr) = m_dataCacheRaw[ cacheI ];

--- a/src/GafferImage/Sampler.cpp
+++ b/src/GafferImage/Sampler.cpp
@@ -57,6 +57,14 @@ Sampler::Sampler( const GafferImage::ImagePlug *plug, const std::string &channel
 	m_sampleWindow.min -= V2i( 1 );
 	m_sampleWindow.max += V2i( 1 );
 
+	if( BufferAlgo::contains( m_dataWindow, m_sampleWindow ) )
+	{
+		// If the sample window is fully contained in the data window, then
+		// we don't need to worry about bounds.  Bounding mode -1 disables
+		// all bounds checking.
+		m_boundingMode = -1;
+	}
+
 	// Compute the area we need to cache in order to
 	// be able to service calls within m_sampleWindow
 	// when taking into account m_boundingMode and m_dataWindow.
@@ -87,6 +95,7 @@ Sampler::Sampler( const GafferImage::ImagePlug *plug, const std::string &channel
 	m_cacheWidth = int( ceil( float( m_cacheWindow.size().x ) / ImagePlug::tileSize() ) );
 	int cacheHeight = int( ceil( float( m_cacheWindow.size().y ) / ImagePlug::tileSize() ) );
 	m_dataCache.resize( m_cacheWidth * cacheHeight, NULL );
+	m_dataCacheRaw.resize( m_cacheWidth * cacheHeight, NULL );
 }
 
 void Sampler::hash( IECore::MurmurHash &h ) const


### PR DESCRIPTION
These add up to a substantial speedup of of the sample() method.

My simplest test case is this:
```
import GafferImage
import IECore

__children = {}

__children["Resample"] = GafferImage.Resample( "Resample" )
parent.addChild( __children["Resample"] )
__children["Resample"]["filter"].setValue( 'box' )
__children["Resample"]["filterWidth"].setValue( IECore.V2f( 20, 20 ) )
__children["Resample"]["debug"].setValue( 2 )
__children["Constant"] = GafferImage.Constant( "Constant" )
parent.addChild( __children["Constant"] )
__children["Constant"]["format"].setValue( GafferImage.Format( 3000, 3000, 1.000 ) )
__children["Constant"]["color"].setValue( IECore.Color4f( 1, 0.5, 0.1, 1 ) )
__children["Resample"]["in"].setInput( __children["Constant"]["out"] )

del __children
```

The use of the single pass debug mode on Resample with a box filter emphasizes the cost of the sampler, and is a bit like what is going to happen in the warp, where the filter weights can be evaluated in a separable way, but you can't share sampling work with adjacent pixels because the the filter widths are different.

With this test, if I run ```gaffer stats ~/test_crud/warpPerf/slowResample.gfr -image Resample```
I get this with the current code:
```Image generation    22.907s (wall), 361.510s (CPU)```
And this with the new code:
```Image generation    12.154s (wall), 191.540s (CPU)```

In the end, after cleaning it up as much as I can, and removing any optimizations which didn't have a noticeable impact, it seems like a reasonably clean PR.

One of the things I fixed appears to have been an oversight in the original:  clamping the p to the dataWindow should only have been occuring when bounding mode is clamp, but it was happening for all pixels unless they were outside the image.  The thing I'm most expecting you might take issue with was I added a new value of -1 for m_boundingMode - this isn't a publicly visible boundingMode, it just flags that we don't need to think at all about bounding mode, because the sample window is a subset of the data window, so the sampler isn't responsible for any boundary pixels - would you prefer this as a separate bool?

I think most of the changes are moderately self-explanatory, and the tests pass, but this is some fairly core code, so it's definitely worth you taking a look through and making sure it makes sense and I haven't missed anything.
