### PR TITLE
Plug promotion refactoring

### DIFF
--- a/include/Gaffer/Box.h
+++ b/include/Gaffer/Box.h
@@ -93,7 +93,6 @@ class Box : public SubGraph
 
 		bool validatePromotability( const Plug *descendantPlug, bool throwExceptions, bool childPlug = false ) const;
 		std::string promotedCounterpartName( const Plug *plug ) const;
-		static void copyMetadata( const Plug *from, Plug *to );
 
 };
 

--- a/include/Gaffer/Box.h
+++ b/include/Gaffer/Box.h
@@ -64,20 +64,13 @@ class Box : public SubGraph
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Box, BoxTypeId, SubGraph );
 
-		/// Returns true if it would be valid to call promotePlug( descendantPlug ),
-		/// and false otherwise.
+		/// \deprecated Use MetadataAlgo::canPromote() instead.
 		bool canPromotePlug( const Plug *descendantPlug ) const;
-		/// Promotes the internal descendantPlug so that it is represented
-		/// as an external plug on the Box. The descendantPlug must belong
-		/// to one of the nodes contained in the box.
-		/// Returns the newly created plug.
-		/// \undoable
+		/// \deprecated Use MetadataAlgo::promote() instead.
 		Plug *promotePlug( Plug *descendantPlug );
-		/// Returns true if the descendantPlug has been promoted.
+		/// \deprecated Use MetadataAlgo::isPromoted() instead.
 		bool plugIsPromoted( const Plug *descendantPlug ) const;
-		/// Unpromotes a previously promoted plug, removing the
-		/// plug on the Box where possible.
-		/// \undoable
+		/// \deprecated Use MetadataAlgo::unpromote() instead.
 		void unpromotePlug( Plug *promotedDescendantPlug );
 
 		/// Exports the contents of the Box so that it can be referenced
@@ -88,11 +81,6 @@ class Box : public SubGraph
 		/// were previously held by a different parent.
 		/// \undoable
 		static BoxPtr create( Node *parent, const Set *childNodes );
-
-	private :
-
-		bool validatePromotability( const Plug *descendantPlug, bool throwExceptions, bool childPlug = false ) const;
-		std::string promotedCounterpartName( const Plug *plug ) const;
 
 };
 

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -97,6 +97,9 @@ bool childAffectedByChange( const GraphComponent *parent, IECore::TypeId changed
 /// the `readOnly()` method.
 bool ancestorAffectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
 
+/// Copies metadata from one target to another. The exclude pattern is used with StringAlgo::matchMultiple().
+void copy( const GraphComponent *from, GraphComponent *to, const StringAlgo::MatchPattern &exclude = "", bool persistentOnly = true, bool persistent = true );
+
 } // namespace MetadataAlgo
 
 /// \todo Remove this temporary backwards compatibility.

--- a/include/Gaffer/PlugAlgo.h
+++ b/include/Gaffer/PlugAlgo.h
@@ -38,15 +38,47 @@
 #ifndef GAFFER_PLUGALGO_H
 #define GAFFER_PLUGALGO_H
 
-#include "Gaffer/Plug.h"
+#include "IECore/RefCounted.h"
+
+#include "Gaffer/StringAlgo.h"
 
 namespace Gaffer
 {
+
+IE_CORE_FORWARDDECLARE( Plug )
 
 namespace PlugAlgo
 {
 
 void replacePlug( GraphComponent *parent, PlugPtr plug );
+
+/// Promotion
+/// =========
+///
+/// When a node has an internal node graph of its own, it
+/// is often useful to expose some internal settings by
+/// promoting internal plugs so that they are driven by
+/// external plugs. These functions assist in this process.
+
+/// Returns true if a call to `promote( plug, parent )` would
+/// succeed, false otherwise.
+bool canPromote( const Plug *plug, const Plug *parent = NULL );
+/// Promotes an internal plug, returning the newly created
+/// external plug. By default the external plug is parented
+/// directly to the node, but the `parent` argument
+/// may specify a plug on that node to be used as parent
+/// instead. By default, all metadata values except those
+/// related to plug layouts are copied to the external
+/// plug - this can be controlled with the `excludeMetadata`
+/// argument.
+/// \undoable
+Plug *promote( Plug *plug, Plug *parent = NULL, const StringAlgo::MatchPattern &excludeMetadata = "layout:*" );
+/// Returns true if the plug appears to have been promoted.
+bool isPromoted( const Plug *plug );
+/// Unpromotes a previously promoted plug, removing the
+/// external plug where possible.
+/// \undoable
+void unpromote( Plug *plug );
 
 } // namespace PlugAlgo
 

--- a/include/Gaffer/Reference.h
+++ b/include/Gaffer/Reference.h
@@ -71,7 +71,6 @@ class Reference : public SubGraph
 		bool isReferencePlug( const Plug *plug ) const;
 
 		void convertPersistentMetadata( Plug *plug ) const;
-		void transferPersistentMetadata( const Plug *srcPlug, Plug *dstPlug ) const;
 
 		std::string m_fileName;
 		ReferenceLoadedSignal m_referenceLoadedSignal;

--- a/include/GafferBindings/PlugAlgoBinding.h
+++ b/include/GafferBindings/PlugAlgoBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERBINDINGS_PLUGALGOBINDING_H
+#define GAFFERBINDINGS_PLUGALGOBINDING_H
+
+namespace GafferBindings
+{
+
+void bindPlugAlgo();
+
+} // namespace GafferBindings
+
+#endif // GAFFERBINDINGS_PLUGALGOBINDING_H

--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -41,13 +41,6 @@
 
 #include "GafferSceneUI/TypeIds.h"
 
-namespace Gaffer
-{
-
-IE_CORE_FORWARDDECLARE( Box )
-
-} // namespace Gaffer
-
 namespace GafferSceneUI
 {
 
@@ -103,7 +96,7 @@ class ShaderView : public GafferImageUI::ImageView
 		void preRender();
 
 		bool m_framed;
-		Gaffer::BoxPtr m_imageConverter;
+		Gaffer::NodePtr m_imageConverter;
 
 		boost::signals::scoped_connection m_idleConnection;
 

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -630,10 +630,10 @@ class DispatcherTest( GafferTest.TestCase ) :
 		s["n4"]["mode"].setValue( "a" )
 		s["n4"]["fileName"].setValue( fileName )
 		s["n4"]["text"].setValue( "n4 on ${frame};" )
-		promotedPreTaskPlug = s["b"].promotePlug( s["b"]["n3"]["preTasks"][0] )
+		promotedPreTaskPlug = Gaffer.PlugAlgo.promote( s["b"]["n3"]["preTasks"][0] )
 		promotedPreTaskPlug.setInput( s["n1"]["task"] )
 		s["b"]["n3"]["preTasks"][1].setInput( s["b"]["n2"]["task"] )
-		promotedTaskPlug = s["b"].promotePlug( s["b"]["n3"]["task"] )
+		promotedTaskPlug = Gaffer.PlugAlgo.promote( s["b"]["n3"]["task"] )
 		s["n4"]["preTasks"][0].setInput( promotedTaskPlug )
 		# export a reference too
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )

--- a/python/GafferDispatchTest/TaskNodeTest.py
+++ b/python/GafferDispatchTest/TaskNodeTest.py
@@ -370,7 +370,7 @@ class TaskNodeTest( GafferTest.TestCase ) :
 
 		s["b"] = Gaffer.Box()
 		s["b"]["e"] = GafferDispatchTest.TextWriter()
-		p = s["b"].promotePlug( s["b"]["e"]["preTasks"][0] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["e"]["preTasks"][0] )
 		p.setName( "p" )
 
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
@@ -388,7 +388,7 @@ class TaskNodeTest( GafferTest.TestCase ) :
 
 		s["b"] = Gaffer.Box()
 		s["b"]["e"] = GafferDispatchTest.TextWriter()
-		p = s["b"].promotePlug( s["b"]["e"]["preTasks"] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["e"]["preTasks"] )
 		p.setName( "p" )
 
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )

--- a/python/GafferImageTest/ImageMetadataTest.py
+++ b/python/GafferImageTest/ImageMetadataTest.py
@@ -137,8 +137,8 @@ class ImageMetadataTest( GafferImageTest.ImageTestCase ) :
 		memberDataAndName2 = s["m"]["metadata"].memberDataAndName( s["m"]["metadata"]["member2"] )
 
 		Gaffer.Box.create( s, Gaffer.StandardSet( [ s["m"] ] ) )
-		s["Box"].promotePlug( s["Box"]["m"]["metadata"]["member1"] )
-		s["Box"].promotePlug( s["Box"]["m"]["metadata"]["member2"] )
+		Gaffer.PlugAlgo.promote( s["Box"]["m"]["metadata"]["member1"] )
+		Gaffer.PlugAlgo.promote( s["Box"]["m"]["metadata"]["member2"] )
 
 		self.assertEqual(
 			s["Box"]["m"]["metadata"].memberDataAndName( s["Box"]["m"]["metadata"]["member1"] ),

--- a/python/GafferImageTest/ImagePlugTest.py
+++ b/python/GafferImageTest/ImagePlugTest.py
@@ -117,17 +117,17 @@ class ImagePlugTest( GafferImageTest.ImageTestCase ) :
 		b = Gaffer.Box()
 		b["n"] = GafferImage.Grade()
 
-		self.assertTrue( b.canPromotePlug( b["n"]["in"] ) )
-		self.assertTrue( b.canPromotePlug( b["n"]["out"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( b["n"]["in"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( b["n"]["out"] ) )
 
-		i = b.promotePlug( b["n"]["in"] )
-		o = b.promotePlug( b["n"]["out"] )
+		i = Gaffer.PlugAlgo.promote( b["n"]["in"] )
+		o = Gaffer.PlugAlgo.promote( b["n"]["out"] )
 
 		self.assertEqual( b["n"]["in"].getInput(), i )
 		self.assertEqual( o.getInput(), b["n"]["out"] )
 
-		self.assertTrue( b.plugIsPromoted( b["n"]["in"] ) )
-		self.assertTrue( b.plugIsPromoted( b["n"]["out"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( b["n"]["in"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( b["n"]["out"] ) )
 
 	def testTypeNamePrefixes( self ) :
 

--- a/python/GafferOSLTest/OSLImageTest.py
+++ b/python/GafferOSLTest/OSLImageTest.py
@@ -226,7 +226,7 @@ class OSLImageTest( GafferOSLTest.OSLTestCase ) :
 
 		s["b"] = Gaffer.Box()
 		s["b"]["i"] = GafferOSL.OSLImage()
-		p = s["b"].promotePlug( s["b"]["i"]["shader"] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["i"]["shader"] )
 		p.setName( "p" )
 
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )

--- a/python/GafferOSLTest/OSLObjectTest.py
+++ b/python/GafferOSLTest/OSLObjectTest.py
@@ -223,7 +223,7 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 
 		s["b"] = Gaffer.Box()
 		s["b"]["o"] = GafferOSL.OSLObject()
-		p = s["b"].promotePlug( s["b"]["o"]["shader"] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["o"]["shader"] )
 		p.setName( "p" )
 
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )

--- a/python/GafferSceneTest/CustomAttributesTest.py
+++ b/python/GafferSceneTest/CustomAttributesTest.py
@@ -249,12 +249,12 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["a"] ] ) )
 
-		self.assertTrue( b.canPromotePlug( b["a"]["attributes"]["deformationBlur"] ) )
-		self.assertFalse( b.plugIsPromoted( b["a"]["attributes"]["deformationBlur"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( b["a"]["attributes"]["deformationBlur"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( b["a"]["attributes"]["deformationBlur"] ) )
 
-		p = b.promotePlug( b["a"]["attributes"]["deformationBlur"] )
+		p = Gaffer.PlugAlgo.promote( b["a"]["attributes"]["deformationBlur"] )
 
-		self.assertTrue( b.plugIsPromoted( b["a"]["attributes"]["deformationBlur"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( b["a"]["attributes"]["deformationBlur"] ) )
 
 		self.assertTrue( b["a"]["attributes"]["deformationBlur"].getInput().isSame( p ) )
 		self.assertTrue( b["a"]["attributes"]["deformationBlur"]["name"].getInput().isSame( p["name"] ) )

--- a/python/GafferSceneTest/FilterSwitchTest.py
+++ b/python/GafferSceneTest/FilterSwitchTest.py
@@ -182,8 +182,8 @@ class FilterSwitchTest( GafferSceneTest.SceneTestCase ) :
 		fs["in"]["in0"].setInput( f1["out"] )
 		fs["in"]["in1"].setInput( f2["out"] )
 
-		promoted = b2.promotePlug( fs["index"] )
-		promoted = b1.promotePlug( promoted )
+		promoted = Gaffer.PlugAlgo.promote( fs["index"] )
+		promoted = Gaffer.PlugAlgo.promote( promoted )
 		promoted.setValue(1)
 
 		# correctly connected internally:

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -1371,7 +1371,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( box["r"].getContext(), None )
 		s["b"] = box
 		self.assertEqual( box["r"].getContext(), None )
-		p = box.promotePlug( box["r"]["in"] )
+		p = Gaffer.PlugAlgo.promote( box["r"]["in"] )
 		p.setInput( s["o"]["out"] )
 
 		errors = GafferTest.CapturingSlot( box["r"].errorSignal() )

--- a/python/GafferSceneTest/PathFilterTest.py
+++ b/python/GafferSceneTest/PathFilterTest.py
@@ -143,7 +143,7 @@ class PathFilterTest( GafferSceneTest.SceneTestCase ) :
 		s["f"] = GafferScene.PathFilter()
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["f"] ] ) )
 
-		p = b.promotePlug( b["f"]["paths"] )
+		p = Gaffer.PlugAlgo.promote( b["f"]["paths"] )
 		p.setValue( IECore.StringVectorData( [ "/a", "/red", "/b/c/d" ] ) )
 
 		for path, result in [

--- a/python/GafferSceneTest/PruneTest.py
+++ b/python/GafferSceneTest/PruneTest.py
@@ -281,9 +281,9 @@ class PruneTest( GafferSceneTest.SceneTestCase ) :
 		b = Gaffer.Box()
 		b["n"] = GafferScene.Prune()
 
-		self.assertTrue( b.canPromotePlug( b["n"]["filter"] ) )
-		b.promotePlug( b["n"]["filter"] )
-		self.assertTrue( b.plugIsPromoted( b["n"]["filter"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( b["n"]["filter"] ) )
+		Gaffer.PlugAlgo.promote( b["n"]["filter"] )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( b["n"]["filter"] ) )
 
 	def testGlobalsDoNotDependOnScenePath( self ) :
 

--- a/python/GafferSceneTest/ScenePlugTest.py
+++ b/python/GafferSceneTest/ScenePlugTest.py
@@ -169,17 +169,17 @@ class ScenePlugTest( GafferSceneTest.SceneTestCase ) :
 		b = Gaffer.Box()
 		b["n"] = GafferScene.StandardAttributes()
 
-		self.assertTrue( b.canPromotePlug( b["n"]["in"] ) )
-		self.assertTrue( b.canPromotePlug( b["n"]["out"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( b["n"]["in"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( b["n"]["out"] ) )
 
-		i = b.promotePlug( b["n"]["in"] )
-		o = b.promotePlug( b["n"]["out"] )
+		i = Gaffer.PlugAlgo.promote( b["n"]["in"] )
+		o = Gaffer.PlugAlgo.promote( b["n"]["out"] )
 
 		self.assertEqual( b["n"]["in"].getInput(), i )
 		self.assertEqual( o.getInput(), b["n"]["out"] )
 
-		self.assertTrue( b.plugIsPromoted( b["n"]["in"] ) )
-		self.assertTrue( b.plugIsPromoted( b["n"]["out"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( b["n"]["in"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( b["n"]["out"] ) )
 
 	def testNoneAsPath( self ) :
 

--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -242,7 +242,7 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 
 		s["b"] = Gaffer.Box()
 		s["b"]["a"] = GafferScene.ShaderAssignment()
-		p = s["b"].promotePlug( s["b"]["a"]["shader"] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["a"]["shader"] )
 
 		self.assertFalse( p.acceptsInput( s["n"]["out"] ) )
 		self.assertTrue( p.acceptsInput( s["s"]["out"] ) )
@@ -274,7 +274,7 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 		s = Gaffer.ScriptNode()
 		s["b"] = Gaffer.Box()
 		s["b"]["a"] = GafferScene.ShaderAssignment()
-		p = s["b"].promotePlug( s["b"]["a"]["filter"] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["a"]["filter"] )
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
@@ -294,7 +294,7 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 		s["b"]["d"].setup( s["b"]["a"]["filter"] )
 		s["b"]["a"]["filter"].setInput( s["b"]["d"]["out"] )
 
-		p = s["b"].promotePlug( s["b"]["d"]["in"] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["d"]["in"] )
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
@@ -311,7 +311,7 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 
 		s["b"] = Gaffer.Box()
 		s["b"]["a"] = GafferScene.ShaderAssignment()
-		p = s["b"].promotePlug( s["b"]["a"]["shader"] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["a"]["shader"] )
 
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 

--- a/python/GafferSceneTest/StandardOptionsTest.py
+++ b/python/GafferSceneTest/StandardOptionsTest.py
@@ -90,7 +90,7 @@ class StandardOptionsTest( GafferSceneTest.SceneTestCase ) :
 		memberDataAndName = s["n"]["options"].memberDataAndName( s["n"]["options"]["renderCamera"] )
 
 		Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n"] ] ) )
-		s["Box"].promotePlug( s["Box"]["n"]["options"]["renderCamera"] )
+		Gaffer.PlugAlgo.promote( s["Box"]["n"]["options"]["renderCamera"] )
 
 		self.assertEqual(
 			s["Box"]["n"]["options"].memberDataAndName( s["Box"]["n"]["options"]["renderCamera"] ),

--- a/python/GafferSceneTest/UnionFilterTest.py
+++ b/python/GafferSceneTest/UnionFilterTest.py
@@ -199,7 +199,7 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 
 		s["b"] = Gaffer.Box()
 		s["b"]["f"] = GafferScene.UnionFilter()
-		p = s["b"].promotePlug( s["b"]["f"]["in"][0] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["f"]["in"][0] )
 		p.setName( "p" )
 
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )

--- a/python/GafferTest/AnimationTest.py
+++ b/python/GafferTest/AnimationTest.py
@@ -406,15 +406,15 @@ class AnimationTest( GafferTest.TestCase ) :
 		s["b"]["n"] = Gaffer.Node()
 		s["b"]["n"] = GafferTest.AddNode()
 
-		s["b"].promotePlug( s["b"]["n"]["op1"] )
-		s["b"].promotePlug( s["b"]["n"]["sum"] )
+		Gaffer.PlugAlgo.promote( s["b"]["n"]["op1"] )
+		Gaffer.PlugAlgo.promote( s["b"]["n"]["sum"] )
 
-		self.assertTrue( s["b"].canPromotePlug( s["b"]["n"]["op2"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["op2"] ) )
 
 		op2Curve = Gaffer.Animation.acquire( s["b"]["n"]["op2"] )
 
 		# Cannot promote an animated plug, because it has an input.
-		self.assertFalse( s["b"].canPromotePlug( s["b"]["n"]["op2"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["op2"] ) )
 
 		op2Curve.addKey( Gaffer.Animation.Key( 0, 0, Gaffer.Animation.Type.Step ) )
 		op2Curve.addKey( Gaffer.Animation.Key( 1, 1, Gaffer.Animation.Type.Step ) )

--- a/python/GafferTest/CompoundDataPlugTest.py
+++ b/python/GafferTest/CompoundDataPlugTest.py
@@ -347,7 +347,7 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 		s["b"]["n"] = Gaffer.Node()
 		s["b"]["n"]["p"] = Gaffer.CompoundDataPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
-		p = s["b"].promotePlug( s["b"]["n"]["p"] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["p"] )
 		p.setName( "p" )
 
 		def assertPreconditions( script ) :

--- a/python/GafferTest/ComputeNodeTest.py
+++ b/python/GafferTest/ComputeNodeTest.py
@@ -416,7 +416,7 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 		csb = GafferTest.CapturingSlot( s["b"].errorSignal() )
 		csbb = GafferTest.CapturingSlot( s["b"]["b"].errorSignal() )
 
-		p = s["b"].promotePlug( s["b"]["a"]["sum"] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["a"]["sum"] )
 
 		self.assertRaises( RuntimeError, p.getValue )
 		self.assertEqual( len( css ), 0 )

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -147,6 +147,37 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 		Gaffer.Metadata.registerValue( a, "metadataAlgoTest", 4 )
 		self.assertEqual( affected, [ True, False, True, False ] )
 
+	def testCopy( self ) :
+
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "metadataAlgoTest", "test" )
+
+		s = GafferTest.AddNode()
+		Gaffer.Metadata.registerValue( s, "a", "a" )
+		Gaffer.Metadata.registerValue( s, "a2", "a2" )
+		Gaffer.Metadata.registerValue( s, "b", "b" )
+		Gaffer.Metadata.registerValue( s, "c", "c", persistent = False )
+
+		t = Gaffer.Node()
+		Gaffer.MetadataAlgo.copy( s, t )
+		self.assertEqual( set( Gaffer.Metadata.registeredValues( t ) ), { "metadataAlgoTest", "a", "a2", "b" } )
+
+		t = Gaffer.Node()
+		Gaffer.MetadataAlgo.copy( s, t, persistentOnly = False )
+		self.assertEqual( set( Gaffer.Metadata.registeredValues( t ) ), { "metadataAlgoTest", "a", "a2", "b", "c" } )
+
+		t = Gaffer.Node()
+		Gaffer.MetadataAlgo.copy( s, t, exclude = "a*" )
+		self.assertEqual( set( Gaffer.Metadata.registeredValues( t ) ), { "metadataAlgoTest", "b" } )
+
+		t = Gaffer.Node()
+		Gaffer.MetadataAlgo.copy( s, t, exclude = "a b" )
+		self.assertEqual( set( Gaffer.Metadata.registeredValues( t ) ), { "metadataAlgoTest", "a2" } )
+
+		t = Gaffer.Node()
+		Gaffer.MetadataAlgo.copy( s, t )
+		for k in Gaffer.Metadata.registeredValues( t ) :
+			self.assertEqual( Gaffer.Metadata.value( t, k ), Gaffer.Metadata.value( s, k ) )
+
 	def tearDown( self ) :
 
 		for n in ( Gaffer.Node, GafferTest.AddNode ) :

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -494,7 +494,7 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( s2["b"]["p"], "testInt" ), 10 )
 		self.assertEqual( Gaffer.Metadata.value( s2["b"]["p"]["i"], "testString" ), "test" )
 
-	def testNonBoxParent( self ) :
+	def testPromoteToNonBoxParent( self ) :
 
 		n = Gaffer.Node()
 		n["n"] = GafferTest.AddNode()
@@ -511,7 +511,7 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		self.assertTrue( "op1" not in "n" )
 		self.assertTrue( n["n"]["op1"].getInput() is None )
 
-	def testParent( self ) :
+	def testPromotionParent( self ) :
 
 		n1 = Gaffer.Node()
 		n1["n"] = GafferTest.AddNode()
@@ -526,7 +526,7 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		self.assertTrue( p.parent().isSame( n1["user"] ) )
 		self.assertTrue( Gaffer.PlugAlgo.isPromoted( n1["n"]["op1"] ) )
 
-	def testExcludeMetadata( self ) :
+	def testPromotionExcludingMetadata( self ) :
 
 		n = Gaffer.Node()
 		n["a"] = GafferTest.AddNode()

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -1,0 +1,554 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+
+class PlugAlgoTest( GafferTest.TestCase ) :
+
+	def testPromote( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n1"] = GafferTest.AddNode()
+		s["b"]["n1"]["op1"].setValue( -10 )
+		s["n2"] = GafferTest.AddNode()
+
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( s["b"]["n1"]["op1"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.canPromote( s["n2"]["op1"], parent = s["b"]["user"] ) )
+
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n1"]["op1"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n1"]["op2"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["n2"]["op1"] ) )
+
+		p = Gaffer.PlugAlgo.promote( s["b"]["n1"]["op1"] )
+		self.assertEqual( p.getName(), "op1" )
+		self.assertTrue( p.parent().isSame( s["b"] ) )
+		self.assertTrue( s["b"]["n1"]["op1"].getInput().isSame( p ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["n1"]["op1"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.canPromote( s["b"]["n1"]["op1"] ) )
+		self.assertEqual( p.getValue(), -10 )
+
+	def testPromoteColor( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+		s["b"]["n"]["c"] = Gaffer.Color3fPlug()
+		s["b"]["n"]["c"].setValue( IECore.Color3f( 1, 0, 1 ) )
+
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["c"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"] ) )
+
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["c"] )
+
+		self.assertTrue( isinstance( p, Gaffer.Color3fPlug ) )
+		self.assertTrue( s["b"]["n"]["c"].getInput().isSame( p ) )
+		self.assertTrue( s["b"]["n"]["c"]["r"].getInput().isSame( p["r"] ) )
+		self.assertTrue( s["b"]["n"]["c"]["g"].getInput().isSame( p["g"] ) )
+		self.assertTrue( s["b"]["n"]["c"]["b"].getInput().isSame( p["b"] ) )
+		self.assertEqual( p.getValue(), IECore.Color3f( 1, 0, 1 ) )
+
+	def testPromoteCompoundPlugAndSerialise( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = GafferTest.CompoundPlugNode()
+		s["b"]["n"]["p"]["s"].setValue( "hello" )
+
+		Gaffer.PlugAlgo.promote( s["b"]["n"]["p"] )
+
+		ss = s.serialise()
+
+		s = Gaffer.ScriptNode()
+		s.execute( ss )
+
+		self.assertEqual( s["b"]["n"]["p"]["s"].getValue(), "hello" )
+
+	def testPromoteDynamicColorPlugAndSerialise( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+		s["b"]["n"]["c"] = Gaffer.Color3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		Gaffer.PlugAlgo.promote( s["b"]["n"]["c"] )
+
+		ss = s.serialise()
+
+		s = Gaffer.ScriptNode()
+		s.execute( ss )
+
+		self.assertTrue( isinstance( s["b"]["c"], Gaffer.Color3fPlug ) )
+		self.assertTrue( s["b"]["n"]["c"].getInput().isSame( s["b"]["c"] ) )
+
+	def testPromoteNonDynamicColorPlugAndSerialise( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Random()
+
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["baseColor"] )
+		p.setValue( IECore.Color3f( 1, 2, 3 ) )
+		p.setName( "c" )
+
+		self.assertTrue( isinstance( s["b"]["c"], Gaffer.Color3fPlug ) )
+		self.assertTrue( s["b"]["n"]["baseColor"].getInput().isSame( s["b"]["c"] ) )
+		self.assertTrue( s["b"]["n"]["baseColor"]["r"].getInput().isSame( s["b"]["c"]["r"] ) )
+		self.assertTrue( s["b"]["n"]["baseColor"]["g"].getInput().isSame( s["b"]["c"]["g"] ) )
+		self.assertTrue( s["b"]["n"]["baseColor"]["b"].getInput().isSame( s["b"]["c"]["b"] ) )
+		self.assertEqual( s["b"]["c"].getValue(), IECore.Color3f( 1, 2, 3 ) )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertTrue( isinstance( s2["b"]["c"], Gaffer.Color3fPlug ) )
+		self.assertTrue( s2["b"]["n"]["baseColor"].getInput().isSame( s2["b"]["c"] ) )
+		self.assertTrue( s2["b"]["n"]["baseColor"]["r"].getInput().isSame( s2["b"]["c"]["r"] ) )
+		self.assertTrue( s2["b"]["n"]["baseColor"]["g"].getInput().isSame( s2["b"]["c"]["g"] ) )
+		self.assertTrue( s2["b"]["n"]["baseColor"]["b"].getInput().isSame( s2["b"]["c"]["b"] ) )
+		self.assertEqual( s2["b"]["c"].getValue(), IECore.Color3f( 1, 2, 3 ) )
+
+	def testCantPromoteNonSerialisablePlugs( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+		s["b"]["n"]["p"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default & ~Gaffer.Plug.Flags.Serialisable )
+
+		self.assertEqual( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["p"] ), False )
+		self.assertRaises( RuntimeError, Gaffer.PlugAlgo.promote, s["b"]["n"]["p"] )
+
+	def testUnpromoting( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n1"] = GafferTest.AddNode()
+
+		p = Gaffer.PlugAlgo.promote( s["b"]["n1"]["op1"] )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["n1"]["op1"] ) )
+		self.assertTrue( p.node().isSame( s["b"] ) )
+
+		Gaffer.PlugAlgo.unpromote( s["b"]["n1"]["op1"] )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n1"]["op1"] ) )
+		self.assertTrue( p.node() is None )
+
+	def testColorUnpromoting( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+		s["b"]["n"]["c"] = Gaffer.Color3fPlug()
+
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["c"] )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["r"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["g"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["b"] ) )
+		self.assertTrue( p.node().isSame( s["b"] ) )
+
+		Gaffer.PlugAlgo.unpromote( s["b"]["n"]["c"] )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["r"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["g"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["b"] ) )
+		self.assertTrue( p.node() is None )
+
+	def testIncrementalUnpromoting( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+
+		s["b"]["n"] = Gaffer.Node()
+		s["b"]["n"]["c"] = Gaffer.Color3fPlug()
+
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["c"] )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["r"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["g"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["b"] ) )
+		self.assertTrue( p.node().isSame( s["b"] ) )
+
+		Gaffer.PlugAlgo.unpromote( s["b"]["n"]["c"]["r"] )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["r"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["g"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["b"] ) )
+		self.assertTrue( p.node().isSame( s["b"] ) )
+
+		Gaffer.PlugAlgo.unpromote( s["b"]["n"]["c"]["g"] )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["r"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["g"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["b"] ) )
+		self.assertTrue( p.node().isSame( s["b"] ) )
+
+		Gaffer.PlugAlgo.unpromote( s["b"]["n"]["c"]["b"] )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["r"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["g"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"]["b"] ) )
+		self.assertTrue( p.node() is None )
+
+	def testCantPromoteReadOnlyPlug( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+		s["b"]["n"]["i"] = Gaffer.IntPlug()
+		s["b"]["n"]["c"] = Gaffer.Color3fPlug()
+
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["i"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["c"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["c"]["r"] ) )
+
+		s["b"]["n"]["i"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+		s["b"]["n"]["c"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+		s["b"]["n"]["c"]["r"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+
+		self.assertFalse( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["i"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["c"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["c"]["r"] ) )
+
+		self.assertRaises( RuntimeError, Gaffer.PlugAlgo.promote, s["b"]["n"]["i"] )
+		self.assertRaises( RuntimeError, Gaffer.PlugAlgo.promote, s["b"]["n"]["c"] )
+		self.assertRaises( RuntimeError, Gaffer.PlugAlgo.promote, s["b"]["n"]["c"]["r"] )
+
+		k = s["b"].keys()
+		uk = s["b"]["user"].keys()
+		try :
+			Gaffer.PlugAlgo.promote( s["b"]["n"]["i"] )
+		except Exception, e :
+			self.assertTrue( "Cannot promote" in str( e ) )
+			self.assertTrue( "read only" in str( e ) )
+			self.assertEqual( s["b"].keys(), k )
+			self.assertEqual( s["b"]["user"].keys(), uk )
+
+	def testCantPromotePlugWithReadOnlyChildren( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+		s["b"]["n"]["c"] = Gaffer.Color3fPlug()
+
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["c"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["c"]["r"] ) )
+
+		s["b"]["n"]["c"]["r"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+
+		self.assertFalse( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["c"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["c"]["r"] ) )
+
+		self.assertRaises( RuntimeError, Gaffer.PlugAlgo.promote, s["b"]["n"]["c"] )
+		self.assertRaises( RuntimeError, Gaffer.PlugAlgo.promote, s["b"]["n"]["c"]["r"] )
+
+		k = s["b"].keys()
+		uk = s["b"]["user"].keys()
+		try :
+			Gaffer.PlugAlgo.promote( s["b"]["n"]["c"] )
+		except Exception, e :
+			self.assertTrue( "Cannot promote" in str( e ) )
+			self.assertTrue( "read only" in str( e ) )
+			self.assertEqual( s["b"].keys(), k )
+			self.assertEqual( s["b"]["user"].keys(), uk )
+
+	def testMakePlugReadOnlyAfterPromoting( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = GafferTest.AddNode()
+		s["b"]["n"]["op1"].setValue( 0 )
+		s["b"]["n"]["op2"].setValue( 0 )
+
+		self.assertEqual( s["b"]["n"]["sum"].getValue(), 0 )
+
+		op1 = Gaffer.PlugAlgo.promote( s["b"]["n"]["op1"] )
+		s["b"]["n"]["op1"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+
+		op1.setValue( 1 )
+		self.assertEqual( s["b"]["n"]["sum"].getValue(), 1 )
+
+	def testPromoteOutputPlug( self ) :
+
+		b = Gaffer.Box()
+		b["n"] = GafferTest.AddNode()
+
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( b["n"]["sum"] ) )
+
+		sum = Gaffer.PlugAlgo.promote( b["n"]["sum"] )
+		self.assertTrue( b.isAncestorOf( sum ) )
+		self.assertTrue( sum.direction() == Gaffer.Plug.Direction.Out )
+		self.assertEqual( sum.getInput(), b["n"]["sum"] )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( b["n"]["sum"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.canPromote( b["n"]["sum"] ) )
+		self.assertRaises( RuntimeError, Gaffer.PlugAlgo.promote, b["n"]["sum"] )
+
+		b["n"]["op1"].setValue( 10 )
+		b["n"]["op2"].setValue( 12 )
+
+		self.assertEqual( sum.getValue(), 22 )
+
+		Gaffer.PlugAlgo.unpromote( b["n"]["sum"] )
+		self.assertFalse( Gaffer.PlugAlgo.isPromoted( b["n"]["sum"] ) )
+		self.assertTrue( sum.parent() is None )
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( b["n"]["sum"] ) )
+
+	def testPromoteDynamicBoxPlugAndSerialise( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+		s["b"]["n"]["p"] = Gaffer.Box2iPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["p"] )
+		p.setValue( IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 3, 4 ) ) )
+		p.setName( "c" )
+
+		self.assertTrue( isinstance( s["b"]["c"], Gaffer.Box2iPlug ) )
+		self.assertTrue( s["b"]["n"]["p"].getInput().isSame( s["b"]["c"] ) )
+		self.assertTrue( s["b"]["n"]["p"]["min"].getInput().isSame( s["b"]["c"]["min"] ) )
+		self.assertTrue( s["b"]["n"]["p"]["max"].getInput().isSame( s["b"]["c"]["max"] ) )
+		self.assertEqual( s["b"]["c"].getValue(), IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 3, 4 ) ) )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertTrue( isinstance( s2["b"]["c"], Gaffer.Box2iPlug ) )
+		self.assertTrue( s2["b"]["n"]["p"].getInput().isSame( s2["b"]["c"] ) )
+		self.assertTrue( s2["b"]["n"]["p"]["min"].getInput().isSame( s2["b"]["c"]["min"] ) )
+		self.assertTrue( s2["b"]["n"]["p"]["max"].getInput().isSame( s2["b"]["c"]["max"] ) )
+		self.assertEqual( s2["b"]["c"].getValue(), IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 3, 4 ) ) )
+
+	def testPromoteStaticPlugsWithChildren( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = GafferTest.CompoundPlugNode()
+		s["b"]["n"]["valuePlug"]["i"].setValue( 10 )
+
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["valuePlug"] )
+		p.setName( "p" )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( s2["b"]["n"]["valuePlug"]["i"].getValue(), 10 )
+		self.assertTrue( s2["b"]["n"]["valuePlug"]["i"].getInput().isSame( s2["b"]["p"]["i"] ) )
+
+	def testPromoteDynamicPlugsWithChildren( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+
+		s["b"]["n"]["user"]["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"]["n"]["user"]["p"]["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"]["n"]["user"]["p"]["p"]["i"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["b"]["n"]["user"]["v"] = Gaffer.ValuePlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"]["n"]["user"]["v"]["v"] = Gaffer.ValuePlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"]["n"]["user"]["v"]["v"]["i"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["user"]["p"] )
+		p.setName( "p" )
+		p["p"]["i"].setValue( 10 )
+
+		v = Gaffer.PlugAlgo.promote( s["b"]["n"]["user"]["v"] )
+		v.setName( "v" )
+		v["v"]["i"].setValue( 20 )
+
+		def assertValid( script ) :
+
+			self.assertEqual( script["b"]["n"]["user"]["p"]["p"]["i"].getValue(), 10 )
+			self.assertTrue( script["b"]["n"]["user"]["p"]["p"]["i"].getInput().isSame( script["b"]["p"]["p"]["i"] ) )
+			self.assertTrue( script["b"]["n"]["user"]["p"]["p"].getInput().isSame( script["b"]["p"]["p"] ) )
+			self.assertTrue( script["b"]["n"]["user"]["p"].getInput().isSame( script["b"]["p"] ) )
+
+			self.assertEqual( script["b"]["n"]["user"]["v"]["v"]["i"].getValue(), 20 )
+			self.assertTrue( script["b"]["n"]["user"]["v"]["v"]["i"].getInput().isSame( script["b"]["v"]["v"]["i"] ) )
+			self.assertTrue( script["b"]["n"]["user"]["v"]["v"].getInput().isSame( script["b"]["v"]["v"] ) )
+			self.assertTrue( script["b"]["n"]["user"]["v"].getInput().isSame( script["b"]["v"] ) )
+
+		assertValid( s )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		assertValid( s2 )
+
+	def testPromoteArrayPlug( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["a"] = GafferTest.AddNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = GafferTest.ArrayPlugNode()
+
+		p = Gaffer.PlugAlgo.promote( ( s["b"]["n"]["in"] ) )
+		p.setName( "p" )
+
+		s["b"]["p"][0].setInput( s["a"]["sum"] )
+		s["b"]["p"][1].setInput( s["a"]["sum"] )
+
+		self.assertEqual( len( s["b"]["n"]["in"] ), 3 )
+		self.assertTrue( s["b"]["n"]["in"].getInput().isSame( s["b"]["p"] ) )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( len( s2["b"]["n"]["in"] ), 3 )
+		self.assertTrue( s2["b"]["n"]["in"].getInput().isSame( s2["b"]["p"] ) )
+
+	def testPromotionIncludesArbitraryMetadata( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+		s["b"]["n"]["user"]["p"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		Gaffer.Metadata.registerValue( s["b"]["n"]["user"]["p"], "testInt", 10 )
+		Gaffer.Metadata.registerValue( s["b"]["n"]["user"]["p"], "testString", "test" )
+
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["user"]["p"] )
+		p.setName( "p" )
+
+		self.assertEqual( Gaffer.Metadata.value( p, "testInt" ), 10 )
+		self.assertEqual( Gaffer.Metadata.value( p, "testString" ), "test" )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( Gaffer.Metadata.value( s2["b"]["p"], "testInt" ), 10 )
+		self.assertEqual( Gaffer.Metadata.value( s2["b"]["p"], "testString" ), "test" )
+
+	def testPromotionIncludesArbitraryChildMetadata( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = Gaffer.Node()
+		s["b"]["n"]["user"]["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"]["n"]["user"]["p"]["i"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		Gaffer.Metadata.registerValue( s["b"]["n"]["user"]["p"], "testInt", 10 )
+		Gaffer.Metadata.registerValue( s["b"]["n"]["user"]["p"]["i"], "testString", "test" )
+
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["user"]["p"] )
+		p.setName( "p" )
+
+		self.assertEqual( Gaffer.Metadata.value( p, "testInt" ), 10 )
+		self.assertEqual( Gaffer.Metadata.value( p["i"], "testString" ), "test" )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( Gaffer.Metadata.value( s2["b"]["p"], "testInt" ), 10 )
+		self.assertEqual( Gaffer.Metadata.value( s2["b"]["p"]["i"], "testString" ), "test" )
+
+	def testNonBoxParent( self ) :
+
+		n = Gaffer.Node()
+		n["n"] = GafferTest.AddNode()
+
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( n["n"]["op1"] ) )
+
+		p = Gaffer.PlugAlgo.promote( n["n"]["op1"] )
+		self.assertTrue( p.isSame( n["op1"] ) )
+		self.assertTrue( n["n"]["op1"].getInput().isSame( n["op1"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( n["n"]["op1"] ) )
+		self.assertFalse( n["op1"].getFlags( Gaffer.Plug.Flags.Dynamic ) )
+
+		Gaffer.PlugAlgo.unpromote( n["n"]["op1"] )
+		self.assertTrue( "op1" not in "n" )
+		self.assertTrue( n["n"]["op1"].getInput() is None )
+
+	def testParent( self ) :
+
+		n1 = Gaffer.Node()
+		n1["n"] = GafferTest.AddNode()
+		n2 = Gaffer.Node()
+
+		self.assertTrue( Gaffer.PlugAlgo.canPromote( n1["n"]["op1"], parent = n1["user"] ) )
+		self.assertFalse( Gaffer.PlugAlgo.canPromote( n1["n"]["op1"], parent = n2["user"] ) )
+
+		self.assertRaises( RuntimeError,  Gaffer.PlugAlgo.promote, n1["n"]["op1"], parent = n2["user"] )
+
+		p = Gaffer.PlugAlgo.promote( n1["n"]["op1"], parent = n1["user"] )
+		self.assertTrue( p.parent().isSame( n1["user"] ) )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( n1["n"]["op1"] ) )
+
+	def testExcludeMetadata( self ) :
+
+		n = Gaffer.Node()
+		n["a"] = GafferTest.AddNode()
+		Gaffer.Metadata.registerValue( n["a"]["op1"], "test", "testValue" )
+		Gaffer.Metadata.registerValue( n["a"]["op2"], "test", "testValue" )
+
+		p1 = Gaffer.PlugAlgo.promote( n["a"]["op1"] )
+		self.assertEqual( Gaffer.Metadata.value( p1, "test" ), "testValue" )
+
+		p2 = Gaffer.PlugAlgo.promote( n["a"]["op2"], excludeMetadata = "*" )
+		self.assertEqual( Gaffer.Metadata.value( p2, "test" ), None )
+
+	def testPromotedNonBoxMetadataIsNonPersistent( self ) :
+
+		n = Gaffer.Node()
+		n["a"] = GafferTest.AddNode()
+		Gaffer.Metadata.registerValue( n["a"]["op1"], "testPersistence", 10 )
+
+		p = Gaffer.PlugAlgo.promote( n["a"]["op1"] )
+		self.assertEqual( Gaffer.Metadata.value( p, "testPersistence" ), 10 )
+		self.assertTrue( "testPersistence" in Gaffer.Metadata.registeredValues( p ) )
+		self.assertTrue( "testPersistence" not in Gaffer.Metadata.registeredValues( p, persistentOnly = True ) )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -82,7 +82,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["n2"] = GafferTest.AddNode()
 		s["n2"]["op1"].setInput( s["n1"]["sum"] )
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n1"] ] ) )
-		b.promotePlug( b["n1"]["op1"] )
+		Gaffer.PlugAlgo.promote( b["n1"]["op1"] )
 
 		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
@@ -123,7 +123,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["n2"]["op1"].setInput( s["n1"]["sum"] )
 		s["n3"]["op1"].setInput( s["n2"]["sum"] )
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n2"] ] ) )
-		b.promotePlug( b["n2"]["op2"] )
+		Gaffer.PlugAlgo.promote( b["n2"]["op2"] )
 
 		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
@@ -150,7 +150,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		originalReferencedNames = s2["r"].keys()
 
 		b["anotherNode"] = GafferTest.AddNode()
-		b.promotePlug( b["anotherNode"]["op2"] )
+		Gaffer.PlugAlgo.promote( b["anotherNode"]["op2"] )
 		s.serialiseToFile( self.temporaryDirectory() + "/test.grf", b )
 
 		s2["r"].load( self.temporaryDirectory() + "/test.grf" )
@@ -200,7 +200,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["n3"]["op1"].setInput( s["n2"]["sum"] )
 
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n2"] ] ) )
-		b.promotePlug( b["n2"]["op2"] )
+		Gaffer.PlugAlgo.promote( b["n2"]["op2"] )
 		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s2 = Gaffer.ScriptNode()
@@ -251,7 +251,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["n1"] = GafferTest.AddNode()
 
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n1"] ] ) )
-		p = b.promotePlug( b["n1"]["op1"] )
+		p = Gaffer.PlugAlgo.promote( b["n1"]["op1"] )
 
 		Gaffer.Metadata.registerValue( p, "description", "ppp" )
 
@@ -273,7 +273,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["n1"] = GafferTest.AddNode()
 
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n1"] ] ) )
-		p = b.promotePlug( b["n1"]["op1"] )
+		p = Gaffer.PlugAlgo.promote( b["n1"]["op1"] )
 
 		Gaffer.Metadata.registerValue( p, "description", "ppp" )
 
@@ -308,7 +308,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["n1"] = GafferTest.AddNode()
 
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n1"] ] ) )
-		p = b.promotePlug( b["n1"]["op1"] )
+		p = Gaffer.PlugAlgo.promote( b["n1"]["op1"] )
 		p.setName( "p" )
 
 		Gaffer.Metadata.registerValue( p, "test", "referenced" )
@@ -347,7 +347,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["n1"] = GafferTest.AddNode()
 
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n1"] ] ) )
-		p = b.promotePlug( b["n1"]["op1"] )
+		p = Gaffer.PlugAlgo.promote( b["n1"]["op1"] )
 		p.setName( "p" )
 
 		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
@@ -418,7 +418,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["b"] = Gaffer.Box()
 		s["b"]["n"] = GafferTest.AddNode()
-		p = s["b"].promotePlug( s["b"]["n"]["op1"] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["op1"] )
 		p.setValue( 10 )
 
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
@@ -523,7 +523,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		# create a box with a promoted output:
 		s["b"] = Gaffer.Box()
 		s["b"]["n"] = GafferTest.AddNode()
-		s["b"].promotePlug( s["b"]["n"]["sum"] )
+		Gaffer.PlugAlgo.promote( s["b"]["n"]["sum"] )
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		# load onto reference:
@@ -532,7 +532,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertEqual( s["r"].enabledPlug(), None )
 
 		# Wire it up to support enabledPlug() and correspondingInput()
-		s["b"].promotePlug( s["b"]["n"]["op1"] )
+		Gaffer.PlugAlgo.promote( s["b"]["n"]["op1"] )
 		s["b"]["n"]["op2"].setValue( 10 )
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
@@ -558,7 +558,6 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 		self.assertTrue( s["r"].enabledPlug().isSame( s["r"]["enabled"] ) )
 		self.assertTrue( s["r"].correspondingInput( s["r"]["sum"] ).isSame( s["r"]["op1"] ) )
-
 
 		# Connect it into a network, delete it, and check that we get nice auto-reconnect behaviour
 		s["a"] = GafferTest.AddNode()
@@ -1003,7 +1002,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["b"]["a1"] = GafferTest.AddNode()
 		s["b"]["a2"] = GafferTest.AddNode()
 		s["b"]["a2"]["op1"].setInput( s["b"]["a1"]["sum"] )
-		s["b"].promotePlug( s["b"]["a1"]["op1"] )
+		Gaffer.PlugAlgo.promote( s["b"]["a1"]["op1"] )
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()

--- a/python/GafferTest/SplinePlugTest.py
+++ b/python/GafferTest/SplinePlugTest.py
@@ -393,7 +393,7 @@ class SplinePlugTest( GafferTest.TestCase ) :
 		s["n"]["p"] = Gaffer.SplineffPlug( defaultValue=spline )
 
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n"] ] ) )
-		p = b.promotePlug( b["n"]["p"] )
+		p = Gaffer.PlugAlgo.promote( b["n"]["p"] )
 
 		self.assertEqual( p.defaultValue(), b["n"]["p"].defaultValue() )
 		self.assertEqual( p.numPoints(), b["n"]["p"].numPoints() )

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -131,6 +131,7 @@ from DownstreamIteratorTest import DownstreamIteratorTest
 from PerformanceMonitorTest import PerformanceMonitorTest
 from MetadataAlgoTest import MetadataAlgoTest
 from ContextMonitorTest import ContextMonitorTest
+from PlugAlgoTest import PlugAlgoTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferUITest/BoxUITest.py
+++ b/python/GafferUITest/BoxUITest.py
@@ -98,8 +98,8 @@ class BoxUITest( GafferUITest.TestCase ) :
 
 		boxGadget = g.nodeGadget( s["b"] )
 
-		p1 = s["b"].promotePlug( s["b"]["n"]["op1"] )
-		p2 = s["b"].promotePlug( s["b"]["n"]["sum"] )
+		p1 = Gaffer.PlugAlgo.promote( s["b"]["n"]["op1"] )
+		p2 = Gaffer.PlugAlgo.promote( s["b"]["n"]["sum"] )
 
 		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( p1 ) ), IECore.V3f( -1, 0, 0 ) )
 		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( p2 ) ), IECore.V3f( 1, 0, 0 ) )
@@ -114,7 +114,7 @@ class BoxUITest( GafferUITest.TestCase ) :
 
 		boxGadget = g.nodeGadget( s["b"] )
 
-		p = s["b"].promotePlug( s["b"]["n"]["op2"] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["op2"] )
 		self.assertEqual( boxGadget.nodule( p ), None )
 
 	def testRenamingPlugs( self ) :
@@ -150,7 +150,7 @@ class BoxUITest( GafferUITest.TestCase ) :
 
 		box = Gaffer.Box()
 		box["node"] = Gaffer.Random()
-		p = box.promotePlug( box["node"]["outColor"] )
+		p = Gaffer.PlugAlgo.promote( box["node"]["outColor"] )
 
 		nodeUI = GafferUI.NodeUI.create( box["node"] )
 		boxUI = GafferUI.NodeUI.create( box )
@@ -170,8 +170,8 @@ class BoxUITest( GafferUITest.TestCase ) :
 
 		g = GafferUI.GraphGadget( s )
 
-		s["b"].promotePlug( s["b"]["n"]["op1"] )
-		p = s["b"].promotePlug( s["b"]["n"]["op2"] )
+		Gaffer.PlugAlgo.promote( s["b"]["n"]["op1"] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["op2"] )
 		p.setName( "p" )
 
 		self.assertEqual( g.nodeGadget( s["b"] ).nodule( s["b"]["p"] ), None )
@@ -190,7 +190,7 @@ class BoxUITest( GafferUITest.TestCase ) :
 		s["b"]["n"]["user"]["p"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		Gaffer.Metadata.registerValue( s["b"]["n"]["user"]["p"], "layout:section", "SomeWeirdSection" )
 
-		p = s["b"].promotePlug( s["b"]["n"]["user"]["p"] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["user"]["p"] )
 		self.assertNotEqual( Gaffer.Metadata.value( p, "layout:section" ), "SomeWeirdSection" )
 
 if __name__ == "__main__":

--- a/python/GafferUITest/ReferenceUITest.py
+++ b/python/GafferUITest/ReferenceUITest.py
@@ -53,7 +53,7 @@ class ReferenceUITest( GafferUITest.TestCase ) :
 
 		Gaffer.Metadata.registerValue( s["b"]["n"]["p"], "nodule:type", "" )
 
-		p = s["b"].promotePlug( s["b"]["n"]["p"] )
+		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["p"] )
 		p.setName( "p" )
 
 		g = GafferUI.GraphGadget( s )

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -35,12 +35,23 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include "boost/format.hpp"
+#include "boost/algorithm/string/replace.hpp"
+#include "boost/algorithm/string/predicate.hpp"
+
 #include "Gaffer/ValuePlug.h"
+#include "Gaffer/Node.h"
 #include "Gaffer/PlugAlgo.h"
+#include "Gaffer/MetadataAlgo.h"
+#include "Gaffer/Box.h"
 
 using namespace std;
 using namespace IECore;
 using namespace Gaffer;
+
+//////////////////////////////////////////////////////////////////////////
+// Replace
+//////////////////////////////////////////////////////////////////////////
 
 namespace
 {
@@ -135,6 +146,371 @@ void replacePlug( Gaffer::GraphComponent *parent, PlugPtr plug )
 		{
 			(*oIt)->setInput( it->plug );
 		}
+	}
+}
+
+} // namespace PlugAlgo
+
+} // namespace Gaffer
+
+//////////////////////////////////////////////////////////////////////////
+// Promotion
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+Node *externalNode( Plug *plug )
+{
+	Node *node = plug->node();
+	return node ? node->parent<Node>() : NULL;
+}
+
+const Node *externalNode( const Plug *plug )
+{
+	const Node *node = plug->node();
+	return node ? node->parent<Node>() : NULL;
+}
+
+bool validatePromotability( const Plug *plug, const Plug *parent, bool throwExceptions, bool childPlug = false )
+{
+	if( !plug )
+	{
+		if( !throwExceptions )
+		{
+			return false;
+		}
+		else
+		{
+			throw IECore::Exception(  "Cannot promote null plug" );
+		}
+	}
+
+	if( PlugAlgo::isPromoted( plug ) )
+	{
+		if( !throwExceptions )
+		{
+			return false;
+		}
+		else
+		{
+			throw IECore::Exception(
+				boost::str(
+					boost::format( "Cannot promote plug \"%s\" as it is already promoted." ) % plug->fullName()
+				)
+			);
+		}
+	}
+
+	if( plug->direction() == Plug::In )
+	{
+		if( plug->getFlags( Plug::ReadOnly ) )
+		{
+			if( !throwExceptions )
+			{
+				return false;
+			}
+			else
+			{
+				throw IECore::Exception(
+					boost::str(
+						boost::format( "Cannot promote plug \"%s\" as it is read only." ) % plug->fullName()
+					)
+				);
+			}
+		}
+
+		// The plug must be serialisable, as we need its input to be saved,
+		// but we only need to check this for the topmost plug and not for
+		// children, because a setInput() call for a parent plug will also
+		// restore child inputs.
+		if( !childPlug && !plug->getFlags( Plug::Serialisable ) )
+		{
+			if( !throwExceptions )
+			{
+				return false;
+			}
+			else
+			{
+				throw IECore::Exception(
+					boost::str(
+						boost::format( "Cannot promote plug \"%s\" as it is not serialisable." ) % plug->fullName()
+					)
+				);
+			}
+		}
+
+		if( !plug->getFlags( Plug::AcceptsInputs ) )
+		{
+			if( !throwExceptions )
+			{
+				return false;
+			}
+			else
+			{
+				throw IECore::Exception(
+					boost::str(
+						boost::format( "Cannot promote plug \"%s\" as it does not accept inputs." ) % plug->fullName()
+					)
+				);
+			}
+		}
+
+		if( plug->getInput<Plug>() )
+		{
+			if( !throwExceptions )
+			{
+				return false;
+			}
+			else
+			{
+				throw IECore::Exception(
+					boost::str(
+						boost::format( "Cannot promote plug \"%s\" as it already has an input." ) % plug->fullName()
+					)
+				);
+			}
+		}
+	}
+
+	if( !childPlug )
+	{
+		const Node *node = externalNode( plug );
+		if( !node )
+		{
+			if( !throwExceptions )
+			{
+				return false;
+			}
+			else
+			{
+				throw IECore::Exception(
+					boost::str(
+						boost::format( "Cannot promote plug \"%s\" as there is no external node." ) % plug->fullName()
+					)
+				);
+			}
+		}
+
+		if( parent && parent->node() != node )
+		{
+			if( !throwExceptions )
+			{
+				return false;
+			}
+			else
+			{
+				throw IECore::Exception(
+					boost::str(
+						boost::format( "Cannot promote plug \"%s\" because parent \"%s\" is not a descendant of \"%s\"." ) %
+							plug->fullName() % parent % node
+					)
+				);
+			}
+		}
+	}
+
+	// Check all the children of this plug too
+	for( RecursivePlugIterator it( plug ); !it.done(); ++it )
+	{
+		if( !validatePromotability( it->get(), parent, throwExceptions, /* childPlug = */ true ) )
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+std::string promotedName( const Plug *plug )
+{
+	std::string result = plug->relativeName( plug->node() );
+	boost::replace_all( result, ".", "_" );
+	return result;
+}
+
+void applyDynamicFlag( Plug *plug )
+{
+	plug->setFlags( Plug::Dynamic, true );
+
+	// Flags are not automatically propagated to the children of compound plugs,
+	// so we need to do that ourselves. We don't want to propagate them to the
+	// children of plug types which create the children themselves during
+	// construction though, hence the typeId checks for the base classes
+	// which add no children during construction. I'm not sure this approach is
+	// necessarily the best - the alternative would be to set everything dynamic
+	// unconditionally and then implement Serialiser::childNeedsConstruction()
+	// for types like CompoundNumericPlug that create children in their constructors.
+	// Or, even better, abolish the Dynamic flag entirely and deal with everything
+	// via serialisers.
+	const Gaffer::TypeId compoundTypes[] = { PlugTypeId, ValuePlugTypeId, CompoundPlugTypeId, ArrayPlugTypeId };
+	const Gaffer::TypeId *compoundTypesEnd = compoundTypes + 4;
+	if( find( compoundTypes, compoundTypesEnd, (Gaffer::TypeId)plug->typeId() ) != compoundTypesEnd )
+	{
+		for( RecursivePlugIterator it( plug ); !it.done(); ++it )
+		{
+			(*it)->setFlags( Plug::Dynamic, true );
+			if( find( compoundTypes, compoundTypesEnd, (Gaffer::TypeId)(*it)->typeId() ) != compoundTypesEnd )
+			{
+				it.prune();
+			}
+		}
+	}
+}
+
+} // namespace
+
+namespace Gaffer
+{
+
+namespace PlugAlgo
+{
+
+bool canPromote( const Plug *plug, const Plug *parent )
+{
+	return validatePromotability( plug, parent, /* throwExceptions = */ false );
+}
+
+Plug *promote( Plug *plug, Plug *parent, const StringAlgo::MatchPattern &excludeMetadata )
+{
+	validatePromotability( plug, parent, /* throwExceptions = */ true );
+
+	PlugPtr externalPlug = plug->createCounterpart( promotedName( plug ), plug->direction() );
+	if( externalPlug->direction() == Plug::In )
+	{
+		if( ValuePlug *externalValuePlug = IECore::runTimeCast<ValuePlug>( externalPlug.get() ) )
+		{
+			externalValuePlug->setFrom( static_cast<ValuePlug *>( plug ) );
+		}
+	}
+
+	Node *externalNode = ::externalNode( plug );
+	const bool dynamic = runTimeCast<Box>( externalNode ) || parent == externalNode->userPlug();
+	MetadataAlgo::copy( plug, externalPlug.get(), excludeMetadata, /* persistentOnly = */ true, /* persistent = */ dynamic );
+	if( dynamic )
+	{
+		applyDynamicFlag( externalPlug.get() );
+	}
+
+	if( parent )
+	{
+		parent->addChild( externalPlug );
+	}
+	else
+	{
+		externalNode->addChild( externalPlug );
+	}
+
+	if( externalPlug->direction() == Plug::In )
+	{
+		plug->setInput( externalPlug );
+	}
+	else
+	{
+		externalPlug->setInput( plug );
+	}
+
+	return externalPlug.get();
+}
+
+bool isPromoted( const Plug *plug )
+{
+	if( !plug )
+	{
+		return false;
+	}
+
+	const Node *node = plug->node();
+	if( !node )
+	{
+		return false;
+	}
+
+	const Node *enclosingNode = node->parent<Node>();
+	if( !enclosingNode )
+	{
+		return false;
+	}
+
+	if( plug->direction() == Plug::In )
+	{
+		const Plug *input = plug->getInput<Plug>();
+		return input && input->node() == enclosingNode;
+	}
+	else
+	{
+		for( Plug::OutputContainer::const_iterator it = plug->outputs().begin(), eIt = plug->outputs().end(); it != eIt; ++it )
+		{
+			if( (*it)->node() == enclosingNode )
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+void unpromote( Plug *plug )
+{
+	if( !isPromoted( plug ) )
+	{
+		if( plug )
+		{
+			throw IECore::Exception(
+				boost::str(
+					boost::format( "Cannot unpromote plug \"%s\" as it has not been promoted." ) % plug->fullName()
+				)
+			);
+		}
+		else
+		{
+			throw IECore::Exception( "Cannot unpromote null plug" );
+		}
+	}
+
+	Node *externalNode = ::externalNode( plug );
+	Plug *externalPlug = NULL;
+	if( plug->direction() == Plug::In )
+	{
+		externalPlug = plug->getInput<Plug>();
+		plug->setInput( NULL );
+	}
+	else
+	{
+		for( Plug::OutputContainer::const_iterator it = plug->outputs().begin(), eIt = plug->outputs().end(); it != eIt; ++it )
+		{
+			if( (*it)->node() == externalNode )
+			{
+				externalPlug = *it;
+				break;
+			}
+		}
+		assert( externalPlug ); // should be true because we checked isPromoted()
+		externalPlug->setInput( NULL );
+	}
+
+	// Remove the top level external plug , but only if
+	// all the children are unused too in the case of a compound plug.
+	bool remove = true;
+	Plug *plugToRemove = externalPlug;
+	while( plugToRemove->parent<Plug>() && plugToRemove->parent<Plug>() != externalNode->userPlug() )
+	{
+		plugToRemove = plugToRemove->parent<Plug>();
+		for( PlugIterator it( plugToRemove ); !it.done(); ++it )
+		{
+			if(
+				( (*it)->direction() == Plug::In && (*it)->outputs().size() ) ||
+				( (*it)->direction() == Plug::Out && (*it)->getInput<Plug>() )
+			)
+			{
+				remove = false;
+				break;
+			}
+		}
+	}
+	if( remove )
+	{
+		plugToRemove->parent<GraphComponent>()->removeChild( plugToRemove );
 	}
 }
 

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -303,7 +303,7 @@ void Reference::loadInternal( const std::string &fileName )
 					copyInputsAndValues( oldPlug, newPlug, /* ignoreDefaultValues = */ !versionPriorTo09 );
 				}
 				transferOutputs( oldPlug, newPlug );
-				transferPersistentMetadata( oldPlug, newPlug );
+				MetadataAlgo::copy( oldPlug, newPlug );
 			}
 			catch( const std::exception &e )
 			{
@@ -389,24 +389,5 @@ void Reference::convertPersistentMetadata( Plug *plug ) const
 	{
 		ConstDataPtr value = Metadata::value<Data>( plug, *it );
 		Metadata::registerValue( plug, *it, value, /* persistent = */ false );
-	}
-}
-
-void Reference::transferPersistentMetadata( const Plug *srcPlug, Plug *dstPlug ) const
-{
-	vector<InternedString> keys;
-	Metadata::registeredValues( srcPlug, keys, /* instanceOnly = */ true, /* persistentOnly = */ true );
-	for( vector<InternedString>::const_iterator it = keys.begin(), eIt = keys.end(); it != eIt; ++it )
-	{
-		ConstDataPtr value = Metadata::value<Data>( srcPlug, *it );
-		Metadata::registerValue( dstPlug, *it, value );
-	}
-
-	for( PlugIterator it( srcPlug ); !it.done(); ++it )
-	{
-		if( Plug *dstChildPlug = dstPlug->getChild<Plug>( (*it)->getName() ) )
-		{
-			transferPersistentMetadata( it->get(), dstChildPlug );
-		}
 	}
 }

--- a/src/GafferBindings/MetadataAlgoBinding.cpp
+++ b/src/GafferBindings/MetadataAlgoBinding.cpp
@@ -70,6 +70,8 @@ void bindMetadataAlgo()
 	def( "childAffectedByChange", &childAffectedByChange, ( arg( "parent" ), arg( "changedNodeTypeId"), arg( "changedPlugPath" ), arg( "changedPlug" ) ) );
 	def( "ancestorAffectedByChange", &ancestorAffectedByChange, ( arg( "plug" ), arg( "changedNodeTypeId"), arg( "changedPlugPath" ), arg( "changedPlug" ) ) );
 
+	def( "copy", &copy, ( arg( "from" ), arg( "to" ), arg( "exclude" ) = "", arg( "persistentOnly" ) = true, arg( "persistent" ) = true ) );
+
 }
 
 } // namespace GafferBindings

--- a/src/GafferBindings/PlugAlgoBinding.cpp
+++ b/src/GafferBindings/PlugAlgoBinding.cpp
@@ -1,0 +1,68 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "IECorePython/RefCountedBinding.h"
+
+#include "Gaffer/Plug.h"
+#include "Gaffer/PlugAlgo.h"
+
+#include "GafferBindings/PlugAlgoBinding.h"
+
+using namespace boost::python;
+using namespace IECorePython;
+using namespace Gaffer;
+
+namespace GafferBindings
+{
+
+void bindPlugAlgo()
+{
+	object module( borrowed( PyImport_AddModule( "Gaffer.PlugAlgo" ) ) );
+	scope().attr( "PlugAlgo" ) = module;
+	scope moduleScope( module );
+
+	def( "replacePlug", &PlugAlgo::replacePlug, ( arg( "parent" ), arg( "plug" ) ) );
+
+	def( "canPromote", &PlugAlgo::canPromote, ( arg( "plug" ), arg( "parent" ) = object() ) );
+	def( "promote", &PlugAlgo::promote, ( arg( "plug" ), arg( "parent" ) = object(), arg( "excludeMetadata" ) = "layout:*" ), return_value_policy<CastToIntrusivePtr>() );
+	def( "isPromoted", &PlugAlgo::isPromoted, ( arg( "plug" ) ) );
+	def( "unpromote", &PlugAlgo::unpromote, ( arg( "plug" ) ) );
+
+}
+
+} // namespace GafferBindings

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -92,6 +92,7 @@
 #include "GafferBindings/MonitorBinding.h"
 #include "GafferBindings/MetadataAlgoBinding.h"
 #include "GafferBindings/SwitchBinding.h"
+#include "GafferBindings/PlugAlgoBinding.h"
 
 using namespace boost::python;
 using namespace Gaffer;
@@ -188,6 +189,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindMonitor();
 	bindMetadataAlgo();
 	bindSwitch();
+	bindPlugAlgo();
 
 	NodeClass<Backdrop>();
 

--- a/src/GafferSceneUI/ShaderView.cpp
+++ b/src/GafferSceneUI/ShaderView.cpp
@@ -41,9 +41,9 @@
 #include "boost/lexical_cast.hpp"
 
 #include "Gaffer/Context.h"
-#include "Gaffer/Box.h"
 #include "Gaffer/Reference.h"
 #include "Gaffer/StringPlug.h"
+#include "Gaffer/PlugAlgo.h"
 
 #include "GafferImage/Display.h"
 
@@ -129,7 +129,7 @@ ShaderView::ShaderView( const std::string &name )
 	// Create a converter to generate an image
 	// from the input shader.
 
-	m_imageConverter = new Box;
+	m_imageConverter = new Node;
 
 	PlugPtr in = new ShaderPlug( "in" );
 	m_imageConverter->addChild( in );
@@ -154,7 +154,7 @@ ShaderView::ShaderView( const std::string &name )
 	DisplayPtr display = new Display;
 	display->portPlug()->setValue( port );
 	m_imageConverter->addChild( display );
-	m_imageConverter->promotePlug( display->outPlug() );
+	PlugAlgo::promote( display->outPlug() );
 
 	insertConverter( m_imageConverter );
 


### PR DESCRIPTION
This is some preparatory work I've split off from the larger improvements I'm making to the Box UI. Would be good to get it reviewed/merged first, but I can include in a final monster PR instead if necessary.

@ivanimanishi, a long while back we discussed that you had to make your own `promotePlug()` that could work with Node types other than boxes, and @danieldresser I noticed you'd needed to do the same at some point (along with some metadata transfer code). This PR adds `MetadataAlgo::copy()` and `PlugAlgo::promote()` methods that hopefully mean that Gaffer now provides the functionality you need directly.

Cheers...
John