### PR TITLE
PythonExpressionEngine : Prevent mutation of context

### DIFF
--- a/python/Gaffer/PythonExpressionEngine.py
+++ b/python/Gaffer/PythonExpressionEngine.py
@@ -76,7 +76,7 @@ class PythonExpressionEngine( Gaffer.Expression.Engine ) :
 			for p in plugPath.split( "." )[:-1] :
 				parentDict = parentDict.setdefault( p, {} )
 
-		executionDict = { "IECore" : IECore, "parent" : plugDict, "context" : context }
+		executionDict = { "IECore" : IECore, "parent" : plugDict, "context" : _ContextProxy( context ) }
 
 		exec( self.__expression, executionDict, executionDict )
 
@@ -370,3 +370,27 @@ _valueExtractors = {
 def _extractPlugValue( plug, topLevelPlug, value ) :
 
 	return _valueExtractors.get( type( topLevelPlug ), __defaultValueExtractor )( plug, topLevelPlug, value )
+
+##########################################################################
+# _ContextProxy
+##########################################################################
+
+class _ContextProxy( object ) :
+
+	__whitelist = { "get", "getFrame", "getFramesPerSecond", "getTime" }
+
+	def __init__( self, context ) :
+
+		self.__context = context
+
+	def __getitem__( self, key ) :
+
+		return self.__context[key]
+
+	def __getattr__( self, name ) :
+
+		if name in self.__whitelist :
+			return getattr( self.__context, name )
+		else :
+			raise AttributeError( name )
+


### PR DESCRIPTION
The C++ signature for `Engine::execute()` takes a `const Context *`, but because Python has no const, we use a const_cast so we can push it into Python. The PythonExpressionEngine was then exposing this directly to users as the `context` variable when executing the expression, giving them an opportunity to modify the context, with horrible hard-to-debug knock on effects.

We now provide access to the context through a proxy object which provides access to only non-mutating methods that are tracked by the _Parser class.