### PR TITLE
Render nodes : Don't serialise internal connections

### DIFF
--- a/python/GafferAppleseedTest/AppleseedRenderTest.py
+++ b/python/GafferAppleseedTest/AppleseedRenderTest.py
@@ -236,5 +236,11 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/appleseedTests" ) )
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/appleseedTests/test.0001.appleseed" ) )
 
+	def testInternalConnectionsNotSerialised( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["render"] = GafferAppleseed.AppleseedRender()
+		self.assertFalse( "__adaptedIn" in s.serialise() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/Preview/InteractiveRender.cpp
+++ b/src/GafferScene/Preview/InteractiveRender.cpp
@@ -665,7 +665,7 @@ void InteractiveRender::construct( const IECore::InternedString &rendererType )
 	addChild( new StringPlug( rendererType.string().empty() ? "renderer" : "__renderer", Plug::In, rendererType.string() ) );
 	addChild( new IntPlug( "state", Plug::In, Stopped, Stopped, Paused, Plug::Default & ~Plug::Serialisable ) );
 	addChild( new ScenePlug( "out", Plug::Out, Plug::Default & ~Plug::Serialisable ) );
-	addChild( new ScenePlug( "__adaptedIn" ) );
+	addChild( new ScenePlug( "__adaptedIn", Plug::In, Plug::Default & ~Plug::Serialisable ) );
 
 	SceneProcessorPtr adaptors = createAdaptors();
 	setChild( "__adaptors", adaptors );

--- a/src/GafferScene/Preview/Render.cpp
+++ b/src/GafferScene/Preview/Render.cpp
@@ -89,7 +89,7 @@ void Render::construct( const IECore::InternedString &rendererType )
 	addChild( new IntPlug( "mode", Plug::In, RenderMode, RenderMode, SceneDescriptionMode ) );
 	addChild( new StringPlug( "fileName" ) );
 	addChild( new ScenePlug( "out", Plug::Out, Plug::Default & ~Plug::Serialisable ) );
-	addChild( new ScenePlug( "__adaptedIn" ) );
+	addChild( new ScenePlug( "__adaptedIn", Plug::In, Plug::Default & ~Plug::Serialisable ) );
 
 	SceneProcessorPtr adaptors = createAdaptors();
 	setChild( "__adaptors", adaptors );


### PR DESCRIPTION
I believe this fixes the root cause of the failing test case in @mattigruener's PR #1985. Once this is merged, could you do a quick rebase of your PR to kick off the tests again please Matti?