### PR TITLE
Additions to `StringAlgo::match()`

### DIFF
--- a/include/Gaffer/StringAlgo.h
+++ b/include/Gaffer/StringAlgo.h
@@ -58,6 +58,10 @@ namespace StringAlgo
 /// - "*", which matches any sequence of characters
 /// - "?", which matches any single character
 /// - "\", which escapes a subsequent wildcard
+/// - [ABC], which matches any single character from the specified set
+/// - [A-Z], which matches any single character from the specified range
+/// - [!ABC], which matches any character not in the specified set
+/// - [!A-Z], which matches any character not in the specified range
 typedef std::string MatchPattern;
 
 /// Returns true if the string matches the pattern and false otherwise.

--- a/include/Gaffer/StringAlgo.h
+++ b/include/Gaffer/StringAlgo.h
@@ -52,8 +52,12 @@ namespace StringAlgo
 /// reason to use a MatchPattern is documentation - by including it in a function
 /// signature, the use of an argument can be made more obvious.
 ///
-/// Patterns currently support only the "*" wildcard, which matches any
-/// sequence of characters.
+/// Patterns support the following syntax, which is
+/// based on shell glob expressions :
+///
+/// - "*", which matches any sequence of characters
+/// - "?", which matches any single character
+/// - "\", which escapes a subsequent wildcard
 typedef std::string MatchPattern;
 
 /// Returns true if the string matches the pattern and false otherwise.

--- a/include/Gaffer/StringAlgo.inl
+++ b/include/Gaffer/StringAlgo.inl
@@ -80,6 +80,22 @@ inline bool matchInternal( const char * const ss, const char *pattern, bool mult
 				}
 				break;
 
+			case '?' :
+
+				if( *s++ != '\0' )
+				{
+					continue;
+				}
+				break;
+
+			case '\\' :
+
+				if( *pattern++ == *s++ )
+				{
+					continue;
+				}
+				break;
+
 			case ' ' :
 
 				if( multiple && *s == '\0' )
@@ -153,7 +169,7 @@ inline bool hasWildcards( const std::string &pattern )
 
 inline bool hasWildcards( const char *pattern )
 {
-	return strchr( pattern, '*' );
+	return pattern[strcspn( pattern, "*?\\" )];
 }
 
 template<typename Token, typename OutputIterator>

--- a/include/Gaffer/StringAlgo.inl
+++ b/include/Gaffer/StringAlgo.inl
@@ -52,6 +52,9 @@ inline bool matchInternal( const char * const ss, const char *pattern, bool mult
 	const char *s = ss;
 	while( true )
 	{
+		// Each case either returns a result if it can determine one,
+		// continues if the match is ok so far, or breaks if the match
+		// has failed.
 		switch( c = *pattern++ )
 		{
 			case '\0' :
@@ -68,49 +71,52 @@ inline bool matchInternal( const char * const ss, const char *pattern, bool mult
 				}
 
 				// general case - recurse.
-				while( *s != '\0' )
+				for( const char *rs = s; *rs != '\0'; ++rs )
 				{
-					if( matchInternal( s, pattern, multiple ) )
+					if( matchInternal( rs, pattern, multiple ) )
 					{
 						return true;
 					}
-					s++;
 				}
-				return false;
+				break;
+
+			case ' ' :
+
+				if( multiple && *s == '\0' )
+				{
+					// Space terminates sub-patterns, so we've
+					// found a match.
+					return true;
+				}
+				// Fall through to default
 
 			default :
 
-				if( c == *s )
+				if( c == *s++ )
 				{
-					s++;
+					continue;
 				}
-				else if( !multiple )
+
+		}
+
+		// Match failed
+
+		if( !multiple )
+		{
+			return false;
+		}
+		else
+		{
+			// Reset to start of string, and advance to next pattern.
+			s = ss;
+			while( c != ' ' )
+			{
+				if( c == '\0' )
 				{
 					return false;
 				}
-				else
-				{
-					if( c == ' ' && *s == '\0' )
-					{
-						// space terminates sub-patterns, so we've
-						// found a match.
-						return true;
-					}
-					else
-					{
-						// no match in this pattern. reset to start
-						// of string, and advance to next pattern.
-						s = ss;
-						while( c != ' ' )
-						{
-							if( c == '\0' )
-							{
-								return false;
-							}
-							c = *pattern++;
-						}
-					}
-				}
+				c = *pattern++;
+			}
 		}
 	}
 }

--- a/python/GafferTest/StringAlgoTest.py
+++ b/python/GafferTest/StringAlgoTest.py
@@ -79,6 +79,7 @@ class StringAlgoTest( GafferTest.TestCase ) :
 			( "dogcollar", "dog *fish", False ),
 			( "dogcollar", "dog collar", False ),
 			( "a1", "*1 b2", True ),
+			( "abc", "a*d abc", True ),
 		] :
 
 			if r :

--- a/python/GafferTest/StringAlgoTest.py
+++ b/python/GafferTest/StringAlgoTest.py
@@ -53,6 +53,19 @@ class StringAlgoTest( GafferTest.TestCase ) :
 			( "dog collar", "dog co*", True ),
 			( "dog collar", "dog *", True ),
 			( "dog collar", "dog*", True ),
+			( "cat", "ca?", True ),
+			( "", "?", False ),
+			( "?", "?", True ),
+			# The following are mildly confusing, because we
+			# must type two backslashes to end up with a single
+			# backslash in the string literals we're constructing.
+			( "\\", "\\\\", True ),   # \ matches \\
+			( "d\\", "d\\\\", True ), # d\ matches d\\
+			( "*", "\\*", True ),     # * matches \*
+			( "a*", "a\\*", True ),   # a* matches a\*
+			( "a", "\\a", True ),     # a matches \a
+			( "\\", "\\x", False ),   # \ doesn't match \x
+			( "?", "\\?", True ),     # ? matches \?
 		] :
 
 			if r :
@@ -80,6 +93,10 @@ class StringAlgoTest( GafferTest.TestCase ) :
 			( "dogcollar", "dog collar", False ),
 			( "a1", "*1 b2", True ),
 			( "abc", "a*d abc", True ),
+			( "a", "a? a", True ),
+			( "ab", "x? ab", True ),
+			( "ab", "?x ab", True ),
+			( "a1", "\\x a1", True ),
 		] :
 
 			if r :
@@ -97,6 +114,10 @@ class StringAlgoTest( GafferTest.TestCase ) :
 			( "a**", True ),
 			( "a*b", True ),
 			( "*a", True ),
+			( "\\", True ),
+			( "?", True ),
+			( "\\?", True ),
+
 		] :
 
 			if r :

--- a/python/GafferTest/StringAlgoTest.py
+++ b/python/GafferTest/StringAlgoTest.py
@@ -56,6 +56,28 @@ class StringAlgoTest( GafferTest.TestCase ) :
 			( "cat", "ca?", True ),
 			( "", "?", False ),
 			( "?", "?", True ),
+			( "a", "[abc]", True ),
+			( "catA", "cat[ABC]", True ),
+			( "catD", "cat[A-Z]", True ),
+			( "cars", "ca[rb]s", True ),
+			( "cabs", "ca[rb]s", True ),
+			( "cats", "ca[rb]s", False ),
+			( "catD", "cat[CEF]", False ),
+			( "catD", "cat[!CEF]", True ),
+			( "cars", "ca[!r]s", False ),
+			( "cabs", "ca[!r]s", True ),
+			( "catch22", "c*[0-9]2", True ),
+			( "x", "[0-9]", False ),
+			( "x", "[!0-9]", True ),
+			( "x", "[A-Za-z]", True ),
+			# We should treat a leading or trailing
+			# '-' as a regular character and not
+			# a range specifier.
+			( "_", "[-|]", False ),
+			( "_", "[!-|]", True ),
+			( "-", "[!-]", False ),
+			( "x-", "x[d-]", True ),
+			( "hyphen-ated", "*[-]ated", True ),
 			# The following are mildly confusing, because we
 			# must type two backslashes to end up with a single
 			# backslash in the string literals we're constructing.
@@ -97,6 +119,9 @@ class StringAlgoTest( GafferTest.TestCase ) :
 			( "ab", "x? ab", True ),
 			( "ab", "?x ab", True ),
 			( "a1", "\\x a1", True ),
+			( "R", "[RGB] *.[RGB]", True ),
+			( "diffuse.R", "[RGB] *.[RGB]", True ),
+			( "diffuse.A", "[RGB] *.[RGB]", False ),
 		] :
 
 			if r :
@@ -117,7 +142,7 @@ class StringAlgoTest( GafferTest.TestCase ) :
 			( "\\", True ),
 			( "?", True ),
 			( "\\?", True ),
-
+			( "[abc]", True ),
 		] :
 
 			if r :

--- a/python/GafferTest/StringAlgoTest.py
+++ b/python/GafferTest/StringAlgoTest.py
@@ -55,7 +55,11 @@ class StringAlgoTest( GafferTest.TestCase ) :
 			( "dog collar", "dog*", True ),
 		] :
 
-			self.assertEqual( Gaffer.StringAlgo.match( s, p ), r )
+			if r :
+				self.assertTrue( Gaffer.StringAlgo.match( s, p ), '"{0}" should match "{1}"'.format( s, p ) )
+			else :
+				self.assertFalse( Gaffer.StringAlgo.match( s, p ), '"{0}" shouldn\'t match "{1}"'.format( s, p ) )
+
 			if " " not in s :
 				self.assertEqual( Gaffer.StringAlgo.matchMultiple( s, p ), r )
 
@@ -77,7 +81,10 @@ class StringAlgoTest( GafferTest.TestCase ) :
 			( "a1", "*1 b2", True ),
 		] :
 
-			self.assertEqual( Gaffer.StringAlgo.matchMultiple( s, p ), r )
+			if r :
+				self.assertTrue( Gaffer.StringAlgo.matchMultiple( s, p ), '"{0}" should match "{1}"'.format( s, p ) )
+			else :
+				self.assertFalse( Gaffer.StringAlgo.matchMultiple( s, p ), '"{0}" shouldn\'t match "{1}"'.format( s, p ) )
 
 	def testHasWildcards( self ) :
 
@@ -91,7 +98,10 @@ class StringAlgoTest( GafferTest.TestCase ) :
 			( "*a", True ),
 		] :
 
-			self.assertEqual( Gaffer.StringAlgo.hasWildcards( p ), r )
+			if r :
+				self.assertTrue( Gaffer.StringAlgo.hasWildcards( p ), "{0} has wildcards".format( p ) )
+			else :
+				self.assertFalse( Gaffer.StringAlgo.hasWildcards( p ), "{0} doesn't have wildcards".format( p ) )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This adds more glob-style matching to the syntax. My current motivation for this is that it's well suited to matching image channels, although it should be useful everywhere else we use `StringAlgo::match()` too.