### PR TITLE
Optimize Image Stuff By Evaluating Plugs in Global Context

### DIFF
--- a/include/Gaffer/PerformanceMonitor.h
+++ b/include/Gaffer/PerformanceMonitor.h
@@ -89,6 +89,8 @@ class PerformanceMonitor : public Monitor
 
 		const StatisticsMap &allStatistics() const;
 		const Statistics &plugStatistics( const Plug *plug ) const;
+		const Statistics &combinedStatistics() const;
+
 
 	protected :
 
@@ -117,6 +119,7 @@ class PerformanceMonitor : public Monitor
 		// Then when we want to query it, we collate it into m_statistics.
 		void collate() const;
 		mutable StatisticsMap m_statistics;
+		mutable Statistics m_combinedStatistics;
 
 };
 

--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -42,6 +42,7 @@
 
 #include "Gaffer/TypedObjectPlug.h"
 #include "Gaffer/TypedPlug.h"
+#include "Gaffer/Context.h"
 
 #include "GafferImage/TypeIds.h"
 #include "GafferImage/AtomicFormatPlug.h"
@@ -135,6 +136,25 @@ class ImagePlug : public Gaffer::ValuePlug
 		IECore::MurmurHash imageHash() const;
 		//@}
 
+		/// Utility class to scope a temporary copy of a context,
+		/// with tile/channel specific variables removed. This can be used
+		/// when evaluating plugs which must be global to the whole image,
+		/// and can improve performance by reducing pressure on the hash cache
+		struct GlobalScope : public Gaffer::Context::EditableScope
+		{
+			GlobalScope( const Gaffer::Context *context );
+		};
+
+		/// Utility class to scope a temporary copy of a context,
+		/// with convenient accessors to set tileOrigin and channelName,
+		/// which you often need to do while accessing channelData
+		struct ChannelDataScope : public Gaffer::Context::EditableScope
+		{
+			ChannelDataScope( const Gaffer::Context *context );
+			void setTileOrigin( const Imath::V2i &tileOrigin );
+			void setChannelName( const std::string &channelName );
+		};
+
 		static int tileSize() { return 1 << tileSizeLog2(); };
 		static const IECore::FloatVectorData *blackTile();
 		static const IECore::FloatVectorData *whiteTile();
@@ -151,6 +171,8 @@ class ImagePlug : public Gaffer::ValuePlug
 		{
 			return tileIndex( point ) * tileSize();
 		}
+
+		
 
 	private :
 		static int tileSizeLog2() { return 6; };

--- a/include/GafferImage/Warp.h
+++ b/include/GafferImage/Warp.h
@@ -123,14 +123,7 @@ class Warp : public ImageProcessor
 		Gaffer::CompoundObjectPlug *sampleRegionsPlug();
 		const Gaffer::CompoundObjectPlug *sampleRegionsPlug() const;
 
-		// This shouldn't even be exposed in the header, but it requires access to Warp::Engine
-		static void hashEngineIfTileValid( Gaffer::Context &context, const Gaffer::ObjectPlug *plug, const Imath::Box2i &dataWindow, const Imath::V2i &tileOrigin, IECore::MurmurHash &h );
-		static ConstEngineDataPtr computeEngineIfTileValid( Gaffer::Context &context, const Gaffer::ObjectPlug *plug, const Imath::Box2i &dataWindow, const Imath::V2i &tileOrigin );
-		
-
-
 		static float approximateDerivative( float upperPos, float center, float lower );
-
 
 		static size_t g_firstPlugIndex;
 };

--- a/python/GafferImageTest/ImageTransformTest.py
+++ b/python/GafferImageTest/ImageTransformTest.py
@@ -163,18 +163,13 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		t = GafferImage.ImageTransform()
 		t["in"].setInput( r["out"] )
 
-		c = Gaffer.Context()
-		c["image:channelName"] = "R"
-		c["image:tileOrigin"] = IECore.V2i( 0 )
-		with c:
-			cs = GafferTest.CapturingSlot( t.plugDirtiedSignal() )
-			t["transform"]["translate"].setValue( IECore.V2f( 2., 2. ) )
-			t["transform"]["rotate"].setValue( 90 )
-			t["enabled"].setValue( True )
-			self.assertNotEqual( r["out"].hash(), t["out"].hash() )
+		t["transform"]["translate"].setValue( IECore.V2f( 2., 2. ) )
+		t["transform"]["rotate"].setValue( 90 )
+		t["enabled"].setValue( True )
+		self.assertNotEqual( r["out"].imageHash(), t["out"].imageHash() )
 
-			t["enabled"].setValue( False )
-			self.assertEqual( r["out"].hash(), t["out"].hash() )
+		t["enabled"].setValue( False )
+		self.assertEqual( r["out"].imageHash(), t["out"].imageHash() )
 
 	def testPassThrough( self ) :
 

--- a/src/Gaffer/PerformanceMonitor.cpp
+++ b/src/Gaffer/PerformanceMonitor.cpp
@@ -108,6 +108,13 @@ const PerformanceMonitor::Statistics &PerformanceMonitor::plugStatistics( const 
 	return it->second;
 }
 
+const PerformanceMonitor::Statistics &PerformanceMonitor::combinedStatistics() const
+{
+	collate();
+	return m_combinedStatistics;
+}
+
+
 void PerformanceMonitor::processStarted( const Process *process )
 {
 	const IECore::InternedString type = process->type();
@@ -162,6 +169,7 @@ void PerformanceMonitor::collate() const
 		for( StatisticsMap::const_iterator mIt = m.begin(), meIt = m.end(); mIt != meIt; ++mIt )
 		{
 			m_statistics[mIt->first] += mIt->second;
+			m_combinedStatistics += mIt->second;
 		}
 		m.clear();
 	}

--- a/src/GafferBindings/MonitorBinding.cpp
+++ b/src/GafferBindings/MonitorBinding.cpp
@@ -180,6 +180,7 @@ void GafferBindings::bindMonitor()
 		scope s = class_<PerformanceMonitor, bases<Monitor>, boost::noncopyable >( "PerformanceMonitor" )
 			.def( "allStatistics", &allStatistics<PerformanceMonitor> )
 			.def( "plugStatistics", &PerformanceMonitor::plugStatistics, return_value_policy<copy_const_reference>() )
+			.def( "combinedStatistics", &PerformanceMonitor::combinedStatistics, return_value_policy<copy_const_reference>() )
 		;
 
 		class_<PerformanceMonitor::Statistics>( "Statistics" )

--- a/src/GafferImage/ColorProcessor.cpp
+++ b/src/GafferImage/ColorProcessor.cpp
@@ -142,13 +142,12 @@ void ColorProcessor::compute( Gaffer::ValuePlug *output, const Gaffer::Context *
 
 		FloatVectorDataPtr r, g, b;
 		{
-			ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-			Context::Scope scopedContext( tmpContext.get() );
-			tmpContext->set( ImagePlug::channelNameContextName, ImageAlgo::channelName( layerName, "R" ) );
+			ImagePlug::ChannelDataScope channelDataScope( context );
+			channelDataScope.setChannelName( ImageAlgo::channelName( layerName, "R" ) );
 			r = inPlug()->channelDataPlug()->getValue()->copy();
-			tmpContext->set( ImagePlug::channelNameContextName, ImageAlgo::channelName( layerName, "G" ) );
+			channelDataScope.setChannelName( ImageAlgo::channelName( layerName, "G" ) );
 			g = inPlug()->channelDataPlug()->getValue()->copy();
-			tmpContext->set( ImagePlug::channelNameContextName, ImageAlgo::channelName( layerName, "B" ) );
+			channelDataScope.setChannelName( ImageAlgo::channelName( layerName, "B" ) );
 			b = inPlug()->channelDataPlug()->getValue()->copy();
 		}
 
@@ -185,9 +184,8 @@ void ColorProcessor::hashChannelData( const GafferImage::ImagePlug *output, cons
 	ImageProcessor::hashChannelData( output, context, h );
 	h.append( baseName );
 	{
-		ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-		Context::Scope scopedContext( tmpContext.get() );
-		tmpContext->set( g_layerNameKey, ImageAlgo::layerName( channel ) );
+		Context::EditableScope layerScope( context );
+		layerScope.set( g_layerNameKey, ImageAlgo::layerName( channel ) );
 		colorDataPlug()->hash( h );
 	}
 }
@@ -209,9 +207,8 @@ IECore::ConstFloatVectorDataPtr ColorProcessor::computeChannelData( const std::s
 
 	ConstObjectVectorPtr colorData;
 	{
-		ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-		Context::Scope scopedContext( tmpContext.get() );
-		tmpContext->set( g_layerNameKey, ImageAlgo::layerName( channel ) );
+		Context::EditableScope layerScope( context );
+		layerScope.set( g_layerNameKey, ImageAlgo::layerName( channel ) );
 		colorData = boost::static_pointer_cast<const ObjectVector>( colorDataPlug()->getValue() );
 	}
 	return boost::static_pointer_cast<const FloatVectorData>( colorData->members()[ImageAlgo::colorIndex( baseName)] );
@@ -226,12 +223,11 @@ void ColorProcessor::hashColorData( const Gaffer::Context *context, IECore::Murm
 {
 	const string &layerName = context->get<string>( g_layerNameKey );
 
-	ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-	Context::Scope scopedContext( tmpContext.get() );
-	tmpContext->set( ImagePlug::channelNameContextName, ImageAlgo::channelName( layerName, "R" ) );
+	ImagePlug::ChannelDataScope channelDataScope( context );
+	channelDataScope.setChannelName( ImageAlgo::channelName( layerName, "R" ) );
 	inPlug()->channelDataPlug()->hash( h );
-	tmpContext->set( ImagePlug::channelNameContextName, ImageAlgo::channelName( layerName, "G" ) );
+	channelDataScope.setChannelName( ImageAlgo::channelName( layerName, "G" ) );
 	inPlug()->channelDataPlug()->hash( h );
-	tmpContext->set( ImagePlug::channelNameContextName, ImageAlgo::channelName( layerName, "B" ) );
+	channelDataScope.setChannelName( ImageAlgo::channelName( layerName, "B" ) );
 	inPlug()->channelDataPlug()->hash( h );
 }

--- a/src/GafferImage/CopyChannels.cpp
+++ b/src/GafferImage/CopyChannels.cpp
@@ -253,13 +253,23 @@ IECore::ConstStringVectorDataPtr CopyChannels::computeChannelNames( const Gaffer
 
 void CopyChannels::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	ConstCompoundObjectPtr mapping = mappingPlug()->getValue();
+	ConstCompoundObjectPtr mapping;
+	{
+		ImagePlug::GlobalScope c( context );
+		mapping = mappingPlug()->getValue();
+	}
 	if( const IntData *i = mapping->member<const IntData>( context->get<string>( ImagePlug::channelNameContextName ) ) )
 	{
 		const ImagePlug *inputImage = inPlugs()->getChild<ImagePlug>( i->readable() );
 		const V2i tileOrigin = context->get<V2i>( ImagePlug::tileOriginContextName );
 		const Box2i tileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
-		const Box2i inputDataWindow = inputImage->dataWindowPlug()->getValue();
+
+		Box2i inputDataWindow;
+		{
+			ImagePlug::GlobalScope c( context );
+			inputDataWindow = inputImage->dataWindowPlug()->getValue();
+		}
+
 		const Box2i validBound = BufferAlgo::intersection( tileBound, inputDataWindow );
 		if( validBound == tileBound )
 		{
@@ -283,13 +293,21 @@ void CopyChannels::hashChannelData( const GafferImage::ImagePlug *parent, const 
 
 IECore::ConstFloatVectorDataPtr CopyChannels::computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const
 {
-	ConstCompoundObjectPtr mapping = mappingPlug()->getValue();
+	ConstCompoundObjectPtr mapping;
+	{
+		ImagePlug::GlobalScope c( context );
+		mapping = mappingPlug()->getValue();
+	}
 	if( const IntData *i = mapping->member<const IntData>( channelName ) )
 	{
 		const ImagePlug *inputImage = inPlugs()->getChild<ImagePlug>( i->readable() );
 		const V2i tileOrigin = context->get<V2i>( ImagePlug::tileOriginContextName );
 		const Box2i tileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
-		const Box2i inputDataWindow = inputImage->dataWindowPlug()->getValue();
+		Box2i inputDataWindow;
+		{
+			ImagePlug::GlobalScope c( context );
+			inputDataWindow = inputImage->dataWindowPlug()->getValue();
+		}
 		const Box2i validBound = BufferAlgo::intersection( tileBound, inputDataWindow );
 		if( validBound == tileBound )
 		{

--- a/src/GafferImage/Crop.cpp
+++ b/src/GafferImage/Crop.cpp
@@ -325,6 +325,7 @@ void Crop::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context
 	}
 	else if( output->parent<Plug>() == offsetPlug() )
 	{
+		ImagePlug::GlobalScope c( context );
 		affectDisplayWindowPlug()->hash( h );
 		resetOriginPlug()->hash( h );
 		cropWindowPlug()->hash( h );
@@ -378,6 +379,7 @@ void Crop::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) 
 	}
 	else if( output->parent<Plug>() == offsetPlug() )
 	{
+		ImagePlug::GlobalScope c( context );
 		V2i offset( 0 );
 		if( affectDisplayWindowPlug()->getValue() )
 		{

--- a/src/GafferImage/ImageNode.cpp
+++ b/src/GafferImage/ImageNode.cpp
@@ -91,7 +91,12 @@ bool ImageNode::enabled() const
 void ImageNode::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	const ImagePlug *imagePlug = output->parent<ImagePlug>();
-	if( imagePlug && enabled() )
+	bool enabledValue;
+	{
+		ImagePlug::GlobalScope c( context );
+		enabledValue = enabled();
+	}
+	if( imagePlug && enabledValue )
 	{
 		// We don't call ComputeNode::hash() immediately here, because for subclasses which
 		// want to pass through a specific hash in the hash*() methods it's a waste of time (the
@@ -200,7 +205,13 @@ void ImageNode::compute( ValuePlug *output, const Context *context ) const
 
 	// we're computing part of an ImagePlug
 
-	if( !enabled() )
+	bool enabledValue;
+	{
+		ImagePlug::GlobalScope c( context );
+		enabledValue = enabled();
+	}
+
+	if( !enabledValue )
 	{
 		// disabled nodes just output a default black image.
 		output->setToDefault();

--- a/src/GafferImage/ImageNode.cpp
+++ b/src/GafferImage/ImageNode.cpp
@@ -112,18 +112,31 @@ void ImageNode::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 		}
 		else if( output == imagePlug->formatPlug() )
 		{
+			// The asserts in these 4 conditionals can be uncommented to catch anywhere that these
+			// global plugs are being hashed with unnecessary tile specific context.  This can be
+			// a performance hazard because it means we can't reuse hashes from the hash cache
+			// nearly as effectively
+
+			//assert( context->get<std::string>( ImagePlug::channelNameContextName, "UNDEF" ) == "UNDEF" );
+			//assert( context->get<Imath::V2i>( ImagePlug::tileOriginContextName, V2i( 42 ) ) == V2i( 42 ) );
 			hashFormat( imagePlug, context, h );
 		}
 		else if( output == imagePlug->dataWindowPlug() )
 		{
+			//assert( context->get<std::string>( ImagePlug::channelNameContextName, "UNDEF" ) == "UNDEF" );
+			//assert( context->get<Imath::V2i>( ImagePlug::tileOriginContextName, V2i( 42 ) ) == V2i( 42 ) );
 			hashDataWindow( imagePlug, context, h );
 		}
 		else if( output == imagePlug->metadataPlug() )
 		{
+			//assert( context->get<std::string>( ImagePlug::channelNameContextName, "UNDEF" ) == "UNDEF" );
+			//assert( context->get<Imath::V2i>( ImagePlug::tileOriginContextName, V2i( 42 ) ) == V2i( 42 ) );
 			hashMetadata( imagePlug, context, h );
 		}
 		else if( output == imagePlug->channelNamesPlug() )
 		{
+			//assert( context->get<std::string>( ImagePlug::channelNameContextName, "UNDEF" ) == "UNDEF" );
+			//assert( context->get<Imath::V2i>( ImagePlug::tileOriginContextName, V2i( 42 ) ) == V2i( 42 ) );
 			hashChannelNames( imagePlug, context, h );
 		}
 	}

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -332,20 +332,18 @@ IECore::ConstFloatVectorDataPtr ImagePlug::channelData( const std::string &chann
 		return channelDataPlug()->defaultValue();
 	}
 
-	ContextPtr tmpContext = new Context( *Context::current(), Context::Borrowed );
-	tmpContext->set( ImagePlug::channelNameContextName, channelName );
-	tmpContext->set( ImagePlug::tileOriginContextName, tile );
-	Context::Scope scopedContext( tmpContext.get() );
+	ChannelDataScope channelDataScope( Context::current() );
+	channelDataScope.setChannelName( channelName );
+	channelDataScope.setTileOrigin( tile );
 
 	return channelDataPlug()->getValue();
 }
 
 IECore::MurmurHash ImagePlug::channelDataHash( const std::string &channelName, const Imath::V2i &tile ) const
 {
-	ContextPtr tmpContext = new Context( *Context::current(), Context::Borrowed );
-	tmpContext->set( ImagePlug::channelNameContextName, channelName );
-	tmpContext->set( ImagePlug::tileOriginContextName, tile );
-	Context::Scope scopedContext( tmpContext.get() );
+	ChannelDataScope channelDataScope( Context::current() );
+	channelDataScope.setChannelName( channelName );
+	channelDataScope.setTileOrigin( tile );
 	return channelDataPlug()->hash();
 }
 

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -303,6 +303,28 @@ const Gaffer::FloatVectorDataPlug *ImagePlug::channelDataPlug() const
 	return getChild<FloatVectorDataPlug>( g_firstPlugIndex+4 );
 }
 
+ImagePlug::GlobalScope::GlobalScope( const Gaffer::Context *context )
+	:   EditableScope( context )
+{
+	remove( channelNameContextName );
+	remove( tileOriginContextName );
+}
+
+ImagePlug::ChannelDataScope::ChannelDataScope( const Gaffer::Context *context )
+	:   EditableScope( context )
+{
+}
+
+void ImagePlug::ChannelDataScope::setTileOrigin( const V2i &tileOrigin )
+{
+	set( tileOriginContextName, tileOrigin );
+}
+
+void ImagePlug::ChannelDataScope::setChannelName( const std::string &channelName )
+{
+	set( channelNameContextName, channelName );
+}
+
 IECore::ConstFloatVectorDataPtr ImagePlug::channelData( const std::string &channelName, const Imath::V2i &tile ) const
 {
 	if( direction()==In && !getInput<Plug>() )

--- a/src/GafferImage/ImageProcessor.cpp
+++ b/src/GafferImage/ImageProcessor.cpp
@@ -134,15 +134,19 @@ void ImageProcessor::hash( const Gaffer::ValuePlug *output, const Gaffer::Contex
 
 	// we're computing a component of the output image. if we're disabled,
 	// then we wish to pass through the hash from the input.
-	bool passThrough = !enabled();
-	if( !passThrough )
+	bool passThrough;
 	{
-		// even if we're enabled at the image level, the channel might be disabled
-		// at the channelData level.
-		if( output == imagePlug->channelDataPlug() )
+		ImagePlug::GlobalScope c( context );
+		passThrough = !enabled();
+		if( !passThrough )
 		{
-			const std::string &channel = context->get<std::string>( ImagePlug::channelNameContextName );
-			passThrough = !channelEnabled( channel );
+			// even if we're enabled at the image level, the channel might be disabled
+			// at the channelData level.
+			if( output == imagePlug->channelDataPlug() )
+			{
+				const std::string &channel = context->get<std::string>( ImagePlug::channelNameContextName );
+				passThrough = !channelEnabled( channel );
+			}
 		}
 	}
 
@@ -166,15 +170,19 @@ void ImageProcessor::compute( ValuePlug *output, const Context *context ) const
 		return;
 	}
 
-	bool passThrough = !enabled();
-	if( !passThrough )
+	bool passThrough;
 	{
-		// even if we're enabled at the image level, the channel might be disabled
-		// at the channelData level.
-		if( output == imagePlug->channelDataPlug() )
+		ImagePlug::GlobalScope c( context );
+		passThrough = !enabled();
+		if( !passThrough )
 		{
-			const std::string &channel = context->get<std::string>( ImagePlug::channelNameContextName );
-			passThrough = !channelEnabled( channel );
+			// even if we're enabled at the image level, the channel might be disabled
+			// at the channelData level.
+			if( output == imagePlug->channelDataPlug() )
+			{
+				const std::string &channel = context->get<std::string>( ImagePlug::channelNameContextName );
+				passThrough = !channelEnabled( channel );
+			}
 		}
 	}
 

--- a/src/GafferImage/ImageSwitch.cpp
+++ b/src/GafferImage/ImageSwitch.cpp
@@ -41,31 +41,6 @@
 
 using namespace GafferImage;
 
-namespace
-{
-
-/// \todo If we introduce a TemporaryContext base class in Context.h
-/// then this should derive from that.
-struct ImageSwitchIndexContext
-{
-
-	ImageSwitchIndexContext( const Gaffer::Context *context )
-		:	m_context( new Gaffer::Context( *context, Gaffer::Context::Borrowed ) ),
-			m_scopedContext( m_context.get() )
-	{
-		m_context->remove( ImagePlug::channelNameContextName );
-		m_context->remove( ImagePlug::tileOriginContextName );
-	}
-
-	private :
-
-		Gaffer::ContextPtr m_context;
-		Gaffer::Context::Scope m_scopedContext;
-
-};
-
-} // namespace
-
 namespace Gaffer
 {
 
@@ -75,7 +50,7 @@ template<>
 struct SwitchTraits<GafferImage::ImageProcessor>
 {
 
-	typedef ImageSwitchIndexContext IndexContext;
+	typedef ImagePlug::GlobalScope IndexContext;
 
 };
 

--- a/src/GafferImage/ImageTransform.cpp
+++ b/src/GafferImage/ImageTransform.cpp
@@ -276,7 +276,10 @@ void ImageTransform::hashChannelData( const GafferImage::ImagePlug *parent, cons
 	else
 	{
 		// Rotation of either the input or the resampled input.
-		ImageTransform::hashDataWindow( parent, context, h );
+		{
+			ImagePlug::GlobalScope c( context );
+			ImageTransform::hashDataWindow( parent, context, h );
+		}
 
 		const ImagePlug *samplerImage; M33f samplerMatrix;
 		const Box2i samplerRegion = sampler( op, matrix, resampleMatrix, context->get<V2i>( ImagePlug::tileOriginContextName ), samplerImage, samplerMatrix );

--- a/src/GafferImage/Median.cpp
+++ b/src/GafferImage/Median.cpp
@@ -327,9 +327,8 @@ void Median::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer
 	const std::string &masterChannel = masterChannelPlug()->getValue();
 	if( masterChannel != "" )
 	{
-		Gaffer::ContextPtr pixelOffsetsContext = new Gaffer::Context( *context, Gaffer::Context::Borrowed );
-		pixelOffsetsContext->set( ImagePlug::channelNameContextName, masterChannel );
-		Gaffer::Context::Scope pixelOffsetsScope( pixelOffsetsContext.get() );
+		ImagePlug::ChannelDataScope pixelOffsetsScope( context );
+		pixelOffsetsScope.setChannelName( masterChannel );
 	
 		pixelOffsetsPlug()->hash( h );
 	}
@@ -363,9 +362,8 @@ IECore::ConstFloatVectorDataPtr Median::computeChannelData( const std::string &c
 	{
 		ConstV2iVectorDataPtr pixelOffsets;
 		{
-			Gaffer::ContextPtr pixelOffsetsContext = new Gaffer::Context( *context, Gaffer::Context::Borrowed );
-			pixelOffsetsContext->set( ImagePlug::channelNameContextName, masterChannel );
-			Gaffer::Context::Scope pixelOffsetsScope( pixelOffsetsContext.get() );
+			ImagePlug::ChannelDataScope pixelOffsetsScope( context );
+			pixelOffsetsScope.setChannelName( masterChannel );
 
 			pixelOffsets = pixelOffsetsPlug()->getValue();
 		}

--- a/src/GafferImage/Merge.cpp
+++ b/src/GafferImage/Merge.cpp
@@ -204,7 +204,15 @@ void Merge::hashChannelData( const GafferImage::ImagePlug *output, const Gaffer:
 			continue;
 		}
 
-		IECore::ConstStringVectorDataPtr channelNamesData = (*it)->channelNamesPlug()->getValue();
+		IECore::ConstStringVectorDataPtr channelNamesData;
+		Box2i dataWindow;
+
+		{
+			ImagePlug::GlobalScope c( context );
+			channelNamesData = (*it)->channelNamesPlug()->getValue();
+			dataWindow = (*it)->dataWindowPlug()->getValue();
+		}
+		
 		const std::vector<std::string> &channelNames = channelNamesData->readable();
 
 		if( ImageAlgo::channelExists( channelNames, channelName ) )
@@ -227,7 +235,7 @@ void Merge::hashChannelData( const GafferImage::ImagePlug *output, const Gaffer:
 		// input data windows, we may be using/revealing the invalid parts of a tile. We
 		// deal with this in computeChannelData() by treating the invalid parts as black,
 		// and must therefore hash in the valid bound here to take that into account.
-		const Box2i validBound = boxIntersection( tileBound, (*it)->dataWindowPlug()->getValue() );
+		const Box2i validBound = boxIntersection( tileBound, dataWindow );
 		h.append( validBound );
 	}
 
@@ -287,7 +295,14 @@ IECore::ConstFloatVectorDataPtr Merge::merge( F f, const std::string &channelNam
 			continue;
 		}
 
-		IECore::ConstStringVectorDataPtr channelNamesData = (*it)->channelNamesPlug()->getValue();
+		IECore::ConstStringVectorDataPtr channelNamesData;
+		Box2i dataWindow;
+		{
+			ImagePlug::GlobalScope c( Context::current() );
+			channelNamesData = (*it)->channelNamesPlug()->getValue();
+			dataWindow = (*it)->dataWindowPlug()->getValue();
+		}
+
 		const std::vector<std::string> &channelNames = channelNamesData->readable();
 
 		ConstFloatVectorDataPtr channelData;
@@ -311,7 +326,7 @@ IECore::ConstFloatVectorDataPtr Merge::merge( F f, const std::string &channelNam
 			alphaData = ImagePlug::blackTile();
 		}
 
-		const Box2i validBound = boxIntersection( tileBound, (*it)->dataWindowPlug()->getValue() );
+		const Box2i validBound = boxIntersection( tileBound, dataWindow );
 
 		if( !resultData )
 		{

--- a/src/GafferImage/Mirror.cpp
+++ b/src/GafferImage/Mirror.cpp
@@ -213,12 +213,17 @@ void Mirror::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer
 	const std::string &channelName = context->get<string>( ImagePlug::channelNameContextName );
 	const V2i tileOrigin = context->get<V2i>( ImagePlug::tileOriginContextName );
 	const Box2i tileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
+	Box2i displayWindow;
+	{
+		ImagePlug::GlobalScope c( context );
+		displayWindow = inPlug()->formatPlug()->getValue().getDisplayWindow();
+	}
 
 	const Box2i sampleWindow = mirror(
 		tileBound,
 		horizontal,
 		vertical,
-		inPlug()->formatPlug()->getValue().getDisplayWindow()
+		displayWindow
 	);
 
 	Sampler sampler( inPlug(), channelName, sampleWindow );
@@ -238,7 +243,11 @@ IECore::ConstFloatVectorDataPtr Mirror::computeChannelData( const std::string &c
 		return inPlug()->channelDataPlug()->getValue();
 	}
 
-	const Box2i displayWindow = inPlug()->formatPlug()->getValue().getDisplayWindow();
+	Box2i displayWindow;
+	{
+		ImagePlug::GlobalScope c( context );
+		displayWindow = inPlug()->formatPlug()->getValue().getDisplayWindow();
+	}
 	const Box2i tileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
 	const Box2i sampleWindow = mirror(
 		tileBound,

--- a/src/GafferImage/Offset.cpp
+++ b/src/GafferImage/Offset.cpp
@@ -125,14 +125,13 @@ Imath::Box2i Offset::computeDataWindow( const Gaffer::Context *context, const Im
 
 void Offset::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	ContextPtr offsetContext = new Context( *context, Context::Borrowed );
-	Context::Scope scope( offsetContext.get() );
+	ImagePlug::ChannelDataScope offsetScope( context );
 
 	const V2i offset = offsetPlug()->getValue();
 	const V2i tileOrigin = context->get<V2i>( ImagePlug::tileOriginContextName );
 	if( offset.x % ImagePlug::tileSize() == 0 && offset.y % ImagePlug::tileSize() == 0 )
 	{
-		offsetContext->set( ImagePlug::tileOriginContextName, tileOrigin - offset );
+		offsetScope.setTileOrigin( tileOrigin - offset );
 		h = inPlug()->channelDataPlug()->hash();
 	}
 	else
@@ -147,7 +146,7 @@ void Offset::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer
 		{
 			for( inTileOrigin.x = ImagePlug::tileOrigin( inBound.min ).x; inTileOrigin.x < inBound.max.x; inTileOrigin.x += ImagePlug::tileSize() )
 			{
-				offsetContext->set( ImagePlug::tileOriginContextName, inTileOrigin );
+				offsetScope.setTileOrigin( inTileOrigin );
 				inPlug()->channelDataPlug()->hash( h );
 			}
 		}
@@ -158,13 +157,12 @@ void Offset::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer
 
 IECore::ConstFloatVectorDataPtr Offset::computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const
 {
-	ContextPtr offsetContext = new Context( *context, Context::Borrowed );
-	Context::Scope scope( offsetContext.get() );
+	ImagePlug::ChannelDataScope offsetScope( context );
 
 	const V2i offset = offsetPlug()->getValue();
 	if( offset.x % ImagePlug::tileSize() == 0 && offset.y % ImagePlug::tileSize() == 0 )
 	{
-		offsetContext->set( ImagePlug::tileOriginContextName, tileOrigin - offset );
+		offsetScope.setTileOrigin( tileOrigin - offset );
 		return inPlug()->channelDataPlug()->getValue();
 	}
 	else
@@ -181,7 +179,7 @@ IECore::ConstFloatVectorDataPtr Offset::computeChannelData( const std::string &c
 		{
 			for( inTileOrigin.x = ImagePlug::tileOrigin( inBound.min ).x; inTileOrigin.x < inBound.max.x; inTileOrigin.x += ImagePlug::tileSize() )
 			{
-				offsetContext->set( ImagePlug::tileOriginContextName, inTileOrigin );
+				offsetScope.setTileOrigin( inTileOrigin );
 				ConstFloatVectorDataPtr inData = inPlug()->channelDataPlug()->getValue();
 				const float *in = &inData->readable().front();
 

--- a/src/GafferImage/OpenColorIOTransform.cpp
+++ b/src/GafferImage/OpenColorIOTransform.cpp
@@ -112,7 +112,10 @@ bool OpenColorIOTransform::enabled() const
 	}
 
 	MurmurHash h;
-	hashTransform( Context::current(), h );
+	{
+		ImagePlug::GlobalScope c( Context::current() );
+		hashTransform( Context::current(), h );
+	}
 	return ( h != MurmurHash() );
 }
 
@@ -136,7 +139,11 @@ void OpenColorIOTransform::hashColorData( const Gaffer::Context *context, IECore
 	{
 		contextPlug()->hash( h );
 	}
-	hashTransform( context, h );
+
+	{
+		ImagePlug::GlobalScope c( Context::current() );
+		hashTransform( context, h );
+	}
 }
 
 OpenColorIO::ConstContextRcPtr OpenColorIOTransform::ocioContext(OpenColorIO::ConstConfigRcPtr config) const
@@ -189,7 +196,12 @@ OpenColorIO::ConstContextRcPtr OpenColorIOTransform::ocioContext(OpenColorIO::Co
 
 void OpenColorIOTransform::processColorData( const Gaffer::Context *context, IECore::FloatVectorData *r, IECore::FloatVectorData *g, IECore::FloatVectorData *b ) const
 {
-	OpenColorIO::ConstTransformRcPtr colorTransform = transform();
+	OpenColorIO::ConstTransformRcPtr colorTransform;
+	{
+		ImagePlug::GlobalScope c( context );
+		colorTransform = transform();
+	}
+
 	if( !colorTransform )
 	{
 		return;

--- a/src/GafferImage/Premultiply.cpp
+++ b/src/GafferImage/Premultiply.cpp
@@ -105,7 +105,12 @@ void Premultiply::processChannelData( const Gaffer::Context *context, const Imag
 		return;
 	}
 
-	ConstStringVectorDataPtr inChannelNamesPtr = inPlug()->channelNamesPlug()->getValue();
+	ConstStringVectorDataPtr inChannelNamesPtr;
+	{
+		ImagePlug::GlobalScope c( context );
+		inChannelNamesPtr = inPlug()->channelNamesPlug()->getValue();
+	}
+
 	const std::vector<std::string> &inChannelNames = inChannelNamesPtr->readable();
 	if ( std::find( inChannelNames.begin(), inChannelNames.end(), alphaChannel ) == inChannelNames.end() )
 	{

--- a/src/GafferImage/Premultiply.cpp
+++ b/src/GafferImage/Premultiply.cpp
@@ -89,9 +89,8 @@ void Premultiply::hashChannelData( const GafferImage::ImagePlug *output, const G
 
 	inPlug()->channelDataPlug()->hash( h );
 
-	ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-	tmpContext->set( ImagePlug::channelNameContextName, alphaChannel );
-	Context::Scope scopedContext( tmpContext.get() );
+	ImagePlug::ChannelDataScope channelDataScope( context );
+	channelDataScope.setChannelName( alphaChannel );
 
 	inPlug()->channelDataPlug()->hash( h );
 }
@@ -119,9 +118,8 @@ void Premultiply::processChannelData( const Gaffer::Context *context, const Imag
 		throw( IECore::Exception( channelError.str() ) );
 	}
 
-	ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-	tmpContext->set( ImagePlug::channelNameContextName, alphaChannel );
-	Context::Scope scopedContext( tmpContext.get() );
+	ImagePlug::ChannelDataScope channelDataScope( context );
+	channelDataScope.setChannelName( alphaChannel );
 
 	ConstFloatVectorDataPtr aData = inPlug()->channelDataPlug()->getValue();
 	const std::vector<float> &a = aData->readable();

--- a/src/GafferImage/Resample.cpp
+++ b/src/GafferImage/Resample.cpp
@@ -454,7 +454,10 @@ void Resample::hashChannelData( const GafferImage::ImagePlug *parent, const Gaff
 	ImageProcessor::hashChannelData( parent, context, h );
 
 	V2f ratio, offset;
-	ratioAndOffset( matrixPlug()->getValue(), ratio, offset );
+	{
+		ImagePlug::GlobalScope c( context );
+		ratioAndOffset( matrixPlug()->getValue(), ratio, offset );
+	}
 
 	V2f inputFilterScale;
 	const OIIO::Filter2D *filter = filterAndScale( filterPlug()->getValue(), ratio, inputFilterScale );
@@ -494,7 +497,10 @@ void Resample::hashChannelData( const GafferImage::ImagePlug *parent, const Gaff
 IECore::ConstFloatVectorDataPtr Resample::computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const
 {
 	V2f ratio, offset;
-	ratioAndOffset( matrixPlug()->getValue(), ratio, offset );
+	{
+		ImagePlug::GlobalScope c( context );
+		ratioAndOffset( matrixPlug()->getValue(), ratio, offset );
+	}
 
 	V2f inputFilterScale;
 	const OIIO::Filter2D *filter = filterAndScale( filterPlug()->getValue(), ratio, inputFilterScale );

--- a/src/GafferImage/Resize.cpp
+++ b/src/GafferImage/Resize.cpp
@@ -258,6 +258,7 @@ IECore::ConstFloatVectorDataPtr Resize::computeChannelData( const std::string &c
 
 const ImagePlug *Resize::source() const
 {
+	ImagePlug::GlobalScope c( Context::current() );
 	if( formatPlug()->getValue().getDisplayWindow() == inPlug()->formatPlug()->getValue().getDisplayWindow() )
 	{
 		return inPlug();

--- a/src/GafferImage/Sampler.cpp
+++ b/src/GafferImage/Sampler.cpp
@@ -46,7 +46,10 @@ Sampler::Sampler( const GafferImage::ImagePlug *plug, const std::string &channel
 	m_channelName( channelName ),
 	m_boundingMode( boundingMode )
 {
-	m_dataWindow = m_plug->dataWindowPlug()->getValue();
+	{
+		ImagePlug::GlobalScope c( Context::current() );
+		m_dataWindow = m_plug->dataWindowPlug()->getValue();
+	}
 
 	// We only store the sample window to be able to perform
 	// validation of the calls made to sample() in debug builds.

--- a/src/GafferImage/Shuffle.cpp
+++ b/src/GafferImage/Shuffle.cpp
@@ -188,9 +188,8 @@ void Shuffle::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffe
 	}
 	else
 	{
-		ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-		Context::Scope scopedContext( tmpContext.get() );
-		tmpContext->set( ImagePlug::channelNameContextName, c );
+		ImagePlug::ChannelDataScope channelDataScope( context );
+		channelDataScope.setChannelName( c );
 		h = inPlug()->channelDataPlug()->hash();
 	}
 }
@@ -209,9 +208,8 @@ IECore::ConstFloatVectorDataPtr Shuffle::computeChannelData( const std::string &
 	}
 	else
 	{
-		ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-		Context::Scope scopedContext( tmpContext.get() );
-		tmpContext->set( ImagePlug::channelNameContextName, c );
+		ImagePlug::ChannelDataScope channelDataScope( context );
+		channelDataScope.setChannelName( c );
 		return inPlug()->channelDataPlug()->getValue();
 	}
 }

--- a/src/GafferImage/Text.cpp
+++ b/src/GafferImage/Text.cpp
@@ -554,13 +554,20 @@ bool Text::affectsShapeChannelData( const Gaffer::Plug *input ) const
 void Text::hashShapeChannelData( const Imath::V2i &tileOrigin, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	Shape::hashShapeChannelData( tileOrigin, context, h );
-	layoutPlug()->hash( h );
+	{
+		ImagePlug::GlobalScope c( context );
+		layoutPlug()->hash( h );
+	}
 	h.append( tileOrigin );
 }
 
 IECore::ConstFloatVectorDataPtr Text::computeShapeChannelData(  const Imath::V2i &tileOrigin, const Gaffer::Context *context ) const
 {
-	ConstCompoundObjectPtr layout = layoutPlug()->getValue();
+	ConstCompoundObjectPtr layout;
+	{
+		ImagePlug::GlobalScope c( context );
+		layout = layoutPlug()->getValue();
+	}
 
 	const vector<char> &characters = layout->member<CharVectorData>( "characters" )->readable();
 	const vector<M33f> &transforms = layout->member<M33fVectorData>( "transforms" )->readable();

--- a/src/GafferImage/Unpremultiply.cpp
+++ b/src/GafferImage/Unpremultiply.cpp
@@ -105,7 +105,12 @@ void Unpremultiply::processChannelData( const Gaffer::Context *context, const Im
 		return;
 	}
 
-	ConstStringVectorDataPtr inChannelNamesPtr = inPlug()->channelNamesPlug()->getValue();
+	ConstStringVectorDataPtr inChannelNamesPtr;
+	{
+		ImagePlug::GlobalScope c( context );
+		inChannelNamesPtr = inPlug()->channelNamesPlug()->getValue();
+	}
+
 	const std::vector<std::string> &inChannelNames = inChannelNamesPtr->readable();
 	if ( std::find( inChannelNames.begin(), inChannelNames.end(), alphaChannel ) == inChannelNames.end() )
 	{

--- a/src/GafferImage/Unpremultiply.cpp
+++ b/src/GafferImage/Unpremultiply.cpp
@@ -89,9 +89,8 @@ void Unpremultiply::hashChannelData( const GafferImage::ImagePlug *output, const
 
 	inPlug()->channelDataPlug()->hash( h );
 
-	ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-	tmpContext->set( ImagePlug::channelNameContextName, alphaChannel );
-	Context::Scope scopedContext( tmpContext.get() );
+	ImagePlug::ChannelDataScope channelDataScope( context );
+	channelDataScope.setChannelName( alphaChannel );
 
 	inPlug()->channelDataPlug()->hash( h );
 }
@@ -119,9 +118,8 @@ void Unpremultiply::processChannelData( const Gaffer::Context *context, const Im
 		throw( IECore::Exception( channelError.str() ) );
 	}
 
-	ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-	tmpContext->set( ImagePlug::channelNameContextName, alphaChannel );
-	Context::Scope scopedContext( tmpContext.get() );
+	ImagePlug::ChannelDataScope channelDataScope( context );
+	channelDataScope.setChannelName( alphaChannel );
 
 	ConstFloatVectorDataPtr aData = inPlug()->channelDataPlug()->getValue();
 	const std::vector<float> &a = aData->readable();

--- a/src/GafferImage/VectorWarp.cpp
+++ b/src/GafferImage/VectorWarp.cpp
@@ -195,24 +195,23 @@ void VectorWarp::hashEngine( const Imath::V2i &tileOrigin, const Gaffer::Context
 	}
 
 
-	ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-	Context::Scope scopedContext( tmpContext.get() );
+	ImagePlug::ChannelDataScope channelDataScope( context );
 
 	if( ImageAlgo::channelExists( channelNames->readable(), "R" ) )
 	{
-		tmpContext->set<std::string>( ImagePlug::channelNameContextName, "R" );
+		channelDataScope.setChannelName( "R" );
 		vectorPlug()->channelDataPlug()->hash( h );
 	}
 
 	if( ImageAlgo::channelExists( channelNames->readable(), "G" ) )
 	{
-		tmpContext->set<std::string>( ImagePlug::channelNameContextName, "G" );
+		channelDataScope.setChannelName( "G" );
 		vectorPlug()->channelDataPlug()->hash( h );
 	}
 
 	if( ImageAlgo::channelExists( channelNames->readable(), "A" ) )
 	{
-		tmpContext->set<std::string>( ImagePlug::channelNameContextName, "A" );
+		channelDataScope.setChannelName( "A" );
 		vectorPlug()->channelDataPlug()->hash( h );
 	}
 
@@ -236,27 +235,26 @@ const Warp::Engine *VectorWarp::computeEngine( const Imath::V2i &tileOrigin, con
 		displayWindow = inPlug()->formatPlug()->getValue().getDisplayWindow();
 	}
 
-	ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-	Context::Scope scopedContext( tmpContext.get() );
+	ImagePlug::ChannelDataScope channelDataScope( context );
 
 	ConstFloatVectorDataPtr xData = ImagePlug::blackTile();
 	if( ImageAlgo::channelExists( channelNames->readable(), "R" ) )
 	{
-		tmpContext->set<std::string>( ImagePlug::channelNameContextName, "R" );
+		channelDataScope.setChannelName( "R" );
 		xData = vectorPlug()->channelDataPlug()->getValue();
 	}
 
 	ConstFloatVectorDataPtr yData = ImagePlug::blackTile();
 	if( ImageAlgo::channelExists( channelNames->readable(), "G" ) )
 	{
-		tmpContext->set<std::string>( ImagePlug::channelNameContextName, "G" );
+		channelDataScope.setChannelName( "G" );
 		yData = vectorPlug()->channelDataPlug()->getValue();
 	}
 
 	ConstFloatVectorDataPtr aData = ImagePlug::whiteTile();
 	if( ImageAlgo::channelExists( channelNames->readable(), "A" ) )
 	{
-		tmpContext->set<std::string>( ImagePlug::channelNameContextName, "A" );
+		channelDataScope.setChannelName( "A" );
 		aData = vectorPlug()->channelDataPlug()->getValue();
 	}
 

--- a/src/GafferImage/Warp.cpp
+++ b/src/GafferImage/Warp.cpp
@@ -311,7 +311,11 @@ void Warp::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context
 		h.append( useDerivatives );
 		if( useDerivatives )
 		{
-			const Box2i dataWindow = outPlug()->dataWindowPlug()->getValue();
+			Box2i dataWindow;
+			{
+				ImagePlug::GlobalScope c( context );
+				dataWindow = outPlug()->dataWindowPlug()->getValue();
+			}
 			
 			hashEngineIfTileValid( *tmpContext, enginePlug(), dataWindow,
 				tileOrigin + V2i( ImagePlug::tileSize(), 0 ), h );
@@ -347,7 +351,12 @@ void Warp::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) 
 	}
 	else if( output == sampleRegionsPlug() )
 	{
-		const Box2i dataWindow = outPlug()->dataWindowPlug()->getValue();
+		Box2i dataWindow;
+		{
+			ImagePlug::GlobalScope c( context );
+			dataWindow = outPlug()->dataWindowPlug()->getValue();
+		}
+
 		const OIIO::Filter2D *filter = FilterAlgo::acquireFilter( filterPlug()->getValue() );
 		const float filterWidth = filter->width();
 
@@ -603,7 +612,10 @@ void Warp::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::
 	);
 	sampler.hash( h );
 
-	outPlug()->dataWindowPlug()->hash( h );
+	{
+		ImagePlug::GlobalScope c( context );
+		outPlug()->dataWindowPlug()->hash( h );
+	}
 }
 
 
@@ -634,7 +646,12 @@ IECore::ConstFloatVectorDataPtr Warp::computeChannelData( const std::string &cha
 	const std::vector<V2f> &pixelInputPositions = sampleRegions->member< V2fVectorData >( g_pixelInputPositionsName, true )->readable();
 	const std::vector<V2f> &pixelInputDerivatives = sampleRegions->member< V2fVectorData >( g_pixelInputDerivativesName, true )->readable();
 
-	const Box2i dataWindow = outPlug()->dataWindowPlug()->getValue();
+	Box2i dataWindow;
+	{
+		ImagePlug::GlobalScope c( context );
+		dataWindow = outPlug()->dataWindowPlug()->getValue();
+	}
+
 	const Box2i validPixelsRelativeToTile( dataWindow.min - tileOrigin, dataWindow.max - tileOrigin );
 
 	Sampler sampler(

--- a/src/GafferImage/Warp.cpp
+++ b/src/GafferImage/Warp.cpp
@@ -61,6 +61,28 @@ namespace
 		static ConstCompoundObjectPtr g_sampleRegionsEmptyTile( new CompoundObject() );
 		return g_sampleRegionsEmptyTile.get();
 	}
+
+	void hashEngineIfTileValid( ImagePlug::ChannelDataScope &tileScope, const ObjectPlug *plug, const Box2i &dataWindow, const V2i &tileOrigin, IECore::MurmurHash &h )
+	{
+		if( BufferAlgo::intersects( dataWindow, Box2i( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) ) ) )
+		{
+			tileScope.setTileOrigin( tileOrigin );
+			plug->hash( h );
+		}
+	}
+
+	ConstObjectPtr computeEngineIfTileValid( ImagePlug::ChannelDataScope &tileScope, const ObjectPlug *plug, const Box2i &dataWindow, const V2i &tileOrigin )
+	{
+		if( BufferAlgo::intersects( dataWindow, Box2i( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) ) ) )
+		{
+			tileScope.setTileOrigin( tileOrigin );
+			return plug->getValue();
+		}
+		else
+		{
+			return NULL;
+		}
+	}
 }
 
 float Warp::approximateDerivative( float upper, float center, float lower )
@@ -266,28 +288,6 @@ void Warp::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs )
 	}
 }
 
-void Warp::hashEngineIfTileValid( Context &context, const ObjectPlug *plug, const Box2i &dataWindow, const V2i &tileOrigin, IECore::MurmurHash &h )
-{
-	if( BufferAlgo::intersects( dataWindow, Box2i( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) ) ) )
-	{
-		context.set( ImagePlug::tileOriginContextName, tileOrigin );
-		plug->hash( h );
-	}
-}
-
-Warp::ConstEngineDataPtr Warp::computeEngineIfTileValid( Context &context, const ObjectPlug *plug, const Box2i &dataWindow, const V2i &tileOrigin )
-{
-	if( BufferAlgo::intersects( dataWindow, Box2i( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) ) ) )
-	{
-		context.set( ImagePlug::tileOriginContextName, tileOrigin );
-		return static_pointer_cast<const EngineData>( plug->getValue() );
-	}
-	else
-	{
-		return NULL;
-	}
-}
-
 void Warp::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	if( output == enginePlug() )
@@ -301,8 +301,7 @@ void Warp::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context
 	}
 	else if( output == sampleRegionsPlug() )
 	{
-		ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-		Context::Scope scopedContext( tmpContext.get() );
+		ImagePlug::ChannelDataScope tileScope( context );
 
 		V2i tileOrigin = context->get<V2i>( ImagePlug::tileOriginContextName );
 		enginePlug()->hash( h );
@@ -317,13 +316,13 @@ void Warp::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context
 				dataWindow = outPlug()->dataWindowPlug()->getValue();
 			}
 			
-			hashEngineIfTileValid( *tmpContext, enginePlug(), dataWindow,
+			hashEngineIfTileValid( tileScope, enginePlug(), dataWindow,
 				tileOrigin + V2i( ImagePlug::tileSize(), 0 ), h );
-			hashEngineIfTileValid( *tmpContext, enginePlug(), dataWindow,
+			hashEngineIfTileValid( tileScope, enginePlug(), dataWindow,
 				tileOrigin - V2i( ImagePlug::tileSize(), 0 ), h );
-			hashEngineIfTileValid( *tmpContext, enginePlug(), dataWindow,
+			hashEngineIfTileValid( tileScope, enginePlug(), dataWindow,
 				tileOrigin + V2i( 0, ImagePlug::tileSize() ), h );
-			hashEngineIfTileValid( *tmpContext, enginePlug(), dataWindow,
+			hashEngineIfTileValid( tileScope, enginePlug(), dataWindow,
 				tileOrigin - V2i( 0, ImagePlug::tileSize() ), h );
 		}
 
@@ -421,16 +420,28 @@ void Warp::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) 
 		{
 			// Get engines for the 4 surrounding images tiles ( or leave them null if they're outside the
 			// dataWindow )
-			ContextPtr tmpContext = new Context( *context, Context::Borrowed );
-			Context::Scope scopedContext( tmpContext.get() );
-			ConstEngineDataPtr engineDataPlusX = computeEngineIfTileValid( *tmpContext, enginePlug(), dataWindow,
-				tileOrigin + V2i( ImagePlug::tileSize(), 0 ) );
-			ConstEngineDataPtr engineDataMinusX = computeEngineIfTileValid( *tmpContext, enginePlug(), dataWindow,
-				tileOrigin - V2i( ImagePlug::tileSize(), 0 ) );
-			ConstEngineDataPtr engineDataPlusY = computeEngineIfTileValid( *tmpContext, enginePlug(), dataWindow,
-				tileOrigin + V2i( 0, ImagePlug::tileSize() ) );
-			ConstEngineDataPtr engineDataMinusY = computeEngineIfTileValid( *tmpContext, enginePlug(), dataWindow,
-				tileOrigin - V2i( 0, ImagePlug::tileSize() ) );
+			ImagePlug::ChannelDataScope tileScope( context );
+
+			ConstEngineDataPtr engineDataPlusX = static_pointer_cast<const EngineData>( 
+				computeEngineIfTileValid( tileScope, enginePlug(), dataWindow,
+					tileOrigin + V2i( ImagePlug::tileSize(), 0 )
+				)
+			);
+			ConstEngineDataPtr engineDataMinusX = static_pointer_cast<const EngineData>(
+				computeEngineIfTileValid( tileScope, enginePlug(), dataWindow,
+					tileOrigin - V2i( ImagePlug::tileSize(), 0 )
+				)
+			);
+			ConstEngineDataPtr engineDataPlusY = static_pointer_cast<const EngineData>(
+				computeEngineIfTileValid( tileScope, enginePlug(), dataWindow,
+					tileOrigin + V2i( 0, ImagePlug::tileSize() )
+				)
+			);
+			ConstEngineDataPtr engineDataMinusY = static_pointer_cast<const EngineData>(
+				computeEngineIfTileValid( tileScope, enginePlug(), dataWindow,
+					tileOrigin - V2i( 0, ImagePlug::tileSize() )
+				)
+			);
 
 			const Engine *enginePlusX = NULL, *engineMinusX = NULL, *enginePlusY = NULL, *engineMinusY = NULL;
 			if( engineDataPlusX ) enginePlusX = engineDataPlusX->engine;
@@ -585,9 +596,8 @@ void Warp::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::
 	ConstCompoundObjectPtr sampleRegions;
 
 	{
-		Gaffer::ContextPtr sampleRegionsContext = new Gaffer::Context( *context, Gaffer::Context::Borrowed );
-		sampleRegionsContext->remove( ImagePlug::channelNameContextName );
-		Gaffer::Context::Scope sampleRegionsScope( sampleRegionsContext.get() );
+		Context::EditableScope sampleRegionsScope( context );
+		sampleRegionsScope.remove( ImagePlug::channelNameContextName );
 		sampleRegionsHash = sampleRegionsPlug()->hash();
 		sampleRegions = sampleRegionsPlug()->getValue( &sampleRegionsHash );
 	}
@@ -624,9 +634,8 @@ IECore::ConstFloatVectorDataPtr Warp::computeChannelData( const std::string &cha
 	ConstCompoundObjectPtr sampleRegions;
 
 	{
-		Gaffer::ContextPtr sampleRegionsContext = new Gaffer::Context( *context, Gaffer::Context::Borrowed );
-		sampleRegionsContext->remove( ImagePlug::channelNameContextName );
-		Gaffer::Context::Scope sampleRegionsScope( sampleRegionsContext.get() );
+		Context::EditableScope sampleRegionsScope( context );
+		sampleRegionsScope.remove( ImagePlug::channelNameContextName );
 		sampleRegions = sampleRegionsPlug()->getValue();
 	}
 

--- a/src/GafferOSL/OSLImage.cpp
+++ b/src/GafferOSL/OSLImage.cpp
@@ -238,9 +238,15 @@ void OSLImage::hashShading( const Gaffer::Context *context, IECore::MurmurHash &
 {
 	const V2i tileOrigin = context->get<V2i>( ImagePlug::tileOriginContextName );
 	h.append( tileOrigin );
-	inPlug()->formatPlug()->hash( h );
 
-	ConstStringVectorDataPtr channelNamesData = inPlug()->channelNamesPlug()->getValue();
+	ConstStringVectorDataPtr channelNamesData;
+
+	{
+		ImagePlug::GlobalScope c( context );
+		inPlug()->formatPlug()->hash( h );
+		channelNamesData = inPlug()->channelNamesPlug()->getValue();
+	}
+
 	const vector<string> &channelNames = channelNamesData->readable();
 	for( vector<string>::const_iterator it = channelNames.begin(), eIt = channelNames.end(); it != eIt; ++it )
 	{
@@ -268,7 +274,13 @@ IECore::ConstCompoundDataPtr OSLImage::computeShading( const Gaffer::Context *co
 	}
 
 	const V2i tileOrigin = context->get<V2i>( ImagePlug::tileOriginContextName );
-	const Format format = inPlug()->formatPlug()->getValue();
+	Format format;
+	ConstStringVectorDataPtr channelNamesData;
+	{
+		ImagePlug::GlobalScope c( context );
+		format = inPlug()->formatPlug()->getValue();
+		channelNamesData = inPlug()->channelNamesPlug()->getValue();
+	}
 
 	CompoundDataPtr shadingPoints = new CompoundData();
 
@@ -309,7 +321,6 @@ IECore::ConstCompoundDataPtr OSLImage::computeShading( const Gaffer::Context *co
 	shadingPoints->writable()["u"] = uData;
 	shadingPoints->writable()["v"] = vData;
 
-	ConstStringVectorDataPtr channelNamesData = inPlug()->channelNamesPlug()->getValue();
 	const vector<string> &channelNames = channelNamesData->readable();
 	for( vector<string>::const_iterator it = channelNames.begin(), eIt = channelNames.end(); it != eIt; ++it )
 	{

--- a/src/GafferOSL/OSLImage.cpp
+++ b/src/GafferOSL/OSLImage.cpp
@@ -184,9 +184,8 @@ void OSLImage::hashChannelNames( const GafferImage::ImagePlug *output, const Gaf
 	const Box2i dataWindow = inPlug()->dataWindowPlug()->getValue();
 	if( !dataWindow.isEmpty() )
 	{
-		ContextPtr c = new Context( *context, Context::Borrowed );
-		c->set( ImagePlug::tileOriginContextName, ImagePlug::tileOrigin( dataWindow.min ) );
-		Context::Scope s( c.get() );
+		ImagePlug::ChannelDataScope channelDataScope( context );
+		channelDataScope.setTileOrigin( ImagePlug::tileOrigin( dataWindow.min ) );
 		shadingPlug()->hash( h );
 	}
 }
@@ -200,9 +199,8 @@ IECore::ConstStringVectorDataPtr OSLImage::computeChannelNames( const Gaffer::Co
 	const Box2i dataWindow = inPlug()->dataWindowPlug()->getValue();
 	if( !dataWindow.isEmpty() )
 	{
-		ContextPtr c = new Context( *context, Context::Borrowed );
-		c->set( ImagePlug::tileOriginContextName, ImagePlug::tileOrigin( dataWindow.min ) );
-		Context::Scope s( c.get() );
+		ImagePlug::ChannelDataScope channelDataScope( context );
+		channelDataScope.setTileOrigin( ImagePlug::tileOrigin( dataWindow.min ) );
 
 		ConstCompoundDataPtr shading = runTimeCast<const CompoundData>( shadingPlug()->getValue() );
 		for( CompoundDataMap::const_iterator it = shading->readable().begin(), eIt = shading->readable().end(); it != eIt; ++it )


### PR DESCRIPTION
This is just being put up for comment - my guess is that some of these commits may be something that you think are a good idea anyway, some of them you probably don't want, and some of them you might only want if we can come up with good tests to prove performance.

I'm still testing to what extent I actually need these changes, so you could just ignore this until I've got some better data.

It's really hard to evaluate performance of this stuff in isolation. I was seeing significant costs to evaluating channelNames and dataWindow in a test, but I never saw much cost for format - but this depends entirely on the upstream network - it's tough to say whether you possibly build an upstream network that would make it costly to evaluate format plugs.

For a crazy test that I was benchmarking on, this originally sped up hashing by a factor of 2, and overall runtime by up to 20% - but after doing this work, I took a look at what was left, and cleaned up some of the stuff I was doing ( avoiding OSLImage seems to have been the big one ), and now this stuff seems to matter a lot less.  Which makes some sense, this stuff is only expensive if you have something upstream that blows up the hashing time, but now I'm not sure how useful this is.

I will evaluate further once I've got a full setup together of my current image processing thing.