### PR TITLE
PerformanceMonitorTest : Avoid interference from garbage collector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,9 +85,6 @@ matrix:
         - os: linux
           compiler: gcc
           env: COMPILER_VERSION=5 CXXSTD=c++11 DEBUG=0
-        - os: linux
-          compiler: clang
-          env: COMPILER_VERSION= CXXSTD=c++98 DEBUG=1
     exclude:
         - os: osx
           compiler: gcc

--- a/python/GafferTest/PerformanceMonitorTest.py
+++ b/python/GafferTest/PerformanceMonitorTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import gc
 import time
 import unittest
 
@@ -44,6 +45,23 @@ import Gaffer
 import GafferTest
 
 class PerformanceMonitorTest( GafferTest.TestCase ) :
+
+	def setUp( self ) :
+
+		GafferTest.TestCase.setUp( self )
+
+		# Clean up any garbage from previous tests.
+		# If python were to trigger the garbage collection
+		# of an old plug during a test here, it could
+		# clear the hash cache and give us unexpected
+		# results.
+		## \todo If we clear or invalidate the hash cache
+		# selectively for only dirtied/deleted plugs,
+		# this won't be an issue and we could remove this
+		# workaround.
+		IECore.RefCounted.collectGarbage()
+		while gc.collect() :
+			pass
 
 	def testActiveStatus( self ) :
 


### PR DESCRIPTION
I believe this to be the cause of the following intermittent failure on Travis :

```
======================================================================

FAIL: testDurations (GafferTest.PerformanceMonitorTest.PerformanceMonitorTest)

----------------------------------------------------------------------

Traceback (most recent call last):

File "/home/travis/build/GafferHQ/gaffer/install/gaffer-0.32.0.0-linux/python/GafferTest/PerformanceMonitorTest.py", line 210, in testDurations

self.assertEqual( m.plugStatistics( n1["out"] ).hashCount, 1 )

AssertionError: 2 != 1
```

I wasn't able to catch this in the act locally except by artificially forcing a collection, but I do believe this to be the best explanation for the behaviour we're seeing (having reviewed the PerformanceMonitor code again and found no issues).