### PR TITLE
ImageStats/ImageSampler improvements

### DIFF
--- a/include/GafferImage/ImageSampler.h
+++ b/include/GafferImage/ImageSampler.h
@@ -39,6 +39,7 @@
 
 #include "Gaffer/ComputeNode.h"
 #include "Gaffer/CompoundNumericPlug.h"
+#include "Gaffer/TypedObjectPlug.h"
 
 #include "GafferImage/TypeIds.h"
 
@@ -48,9 +49,6 @@ namespace GafferImage
 IE_CORE_FORWARDDECLARE( ImagePlug )
 IE_CORE_FORWARDDECLARE( FilterPlug )
 
-/// Samples colours at image locations.
-/// \todo Support for choosing which channels to sample - ideally
-/// we need ChannelMaskPlug to properly support layers to do that.
 class ImageSampler : public Gaffer::ComputeNode
 {
 
@@ -63,6 +61,9 @@ class ImageSampler : public Gaffer::ComputeNode
 
 		ImagePlug *imagePlug();
 		const ImagePlug *imagePlug() const;
+
+		Gaffer::StringVectorDataPlug *channelsPlug();
+		const Gaffer::StringVectorDataPlug *channelsPlug() const;
 
 		Gaffer::V2fPlug *pixelPlug();
 		const Gaffer::V2fPlug *pixelPlug() const;

--- a/include/GafferImage/ImageStats.h
+++ b/include/GafferImage/ImageStats.h
@@ -90,9 +90,6 @@ class ImageStats : public Gaffer::ComputeNode
 		/// For more information on this, please see ChannelMaskPlug::removeDuplicateIndices().
 		void channelNameFromOutput( const Gaffer::ValuePlug *output, std::string &channelName ) const;
 
-		/// A convenience function to just set the plug to 0 or 1 depending on what it's index is.
-		void setOutputToDefault( Gaffer::FloatPlug *output ) const;
-
 		/// Implemented to initialize the default format settings if they don't exist already.
 		void parentChanging( Gaffer::GraphComponent *newParent );
 

--- a/include/GafferImage/ImageStats.h
+++ b/include/GafferImage/ImageStats.h
@@ -42,7 +42,6 @@
 #include "Gaffer/BoxPlug.h"
 
 #include "GafferImage/ImagePlug.h"
-#include "GafferImage/ChannelMaskPlug.h"
 
 namespace GafferImage
 {
@@ -63,8 +62,8 @@ class ImageStats : public Gaffer::ComputeNode
 
 		GafferImage::ImagePlug *inPlug();
 		const GafferImage::ImagePlug *inPlug() const;
-		ChannelMaskPlug *channelsPlug();
-		const ChannelMaskPlug *channelsPlug() const;
+		Gaffer::StringVectorDataPlug *channelsPlug();
+		const Gaffer::StringVectorDataPlug *channelsPlug() const;
 		Gaffer::Box2iPlug *regionOfInterestPlug();
 		const Gaffer::Box2iPlug *regionOfInterestPlug() const;
 		Gaffer::Color4fPlug *averagePlug();

--- a/include/GafferImage/ImageStats.h
+++ b/include/GafferImage/ImageStats.h
@@ -46,8 +46,8 @@
 namespace GafferImage
 {
 
-/// Provides statistics on an image's colour profile.
-/// The ImageStats node outputs the minimum, maximum and average values of the pixel values within a region of interest in the image.
+/// \todo Add an areaSource plug with the same semantics
+/// that the Crop node has.
 class ImageStats : public Gaffer::ComputeNode
 {
 
@@ -62,14 +62,19 @@ class ImageStats : public Gaffer::ComputeNode
 
 		GafferImage::ImagePlug *inPlug();
 		const GafferImage::ImagePlug *inPlug() const;
+
 		Gaffer::StringVectorDataPlug *channelsPlug();
 		const Gaffer::StringVectorDataPlug *channelsPlug() const;
-		Gaffer::Box2iPlug *regionOfInterestPlug();
-		const Gaffer::Box2iPlug *regionOfInterestPlug() const;
+
+		Gaffer::Box2iPlug *areaPlug();
+		const Gaffer::Box2iPlug *areaPlug() const;
+
 		Gaffer::Color4fPlug *averagePlug();
 		const Gaffer::Color4fPlug *averagePlug() const;
+
 		Gaffer::Color4fPlug *minPlug();
 		const Gaffer::Color4fPlug *minPlug() const;
+
 		Gaffer::Color4fPlug *maxPlug();
 		const Gaffer::Color4fPlug *maxPlug() const;
 

--- a/include/GafferImage/ImageStats.h
+++ b/include/GafferImage/ImageStats.h
@@ -84,11 +84,7 @@ class ImageStats : public Gaffer::ComputeNode
 
 	private :
 
-		/// Sets channelName to the channel which corresponds to the output plug. The channel name is
-		/// computed from the intersection of the "in" plug's channels and the "channels" plug's channels.
-		/// If multiple channels are found to have the same channel index, the first is used.
-		/// For more information on this, please see ChannelMaskPlug::removeDuplicateIndices().
-		void channelNameFromOutput( const Gaffer::ValuePlug *output, std::string &channelName ) const;
+		std::string channelName( int colorIndex ) const;
 
 		/// Implemented to initialize the default format settings if they don't exist already.
 		void parentChanging( Gaffer::GraphComponent *newParent );

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -291,11 +291,11 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		hiddenStats = GafferImage.ImageStats()
 		hiddenStats["in"].setInput( hidden["out"] )
-		hiddenStats["regionOfInterest"].setValue( hiddenStats["in"]["dataWindow"].getValue() )
+		hiddenStats["area"].setValue( hiddenStats["in"]["dataWindow"].getValue() )
 
 		visibleStats = GafferImage.ImageStats()
 		visibleStats["in"].setInput( visible["out"] )
-		visibleStats["regionOfInterest"].setValue( visibleStats["in"]["dataWindow"].getValue() )
+		visibleStats["area"].setValue( visibleStats["in"]["dataWindow"].getValue() )
 
 		self.assertLess( hiddenStats["average"].getValue()[0], 0.05 )
 		self.assertGreater( visibleStats["average"].getValue()[0], .35 )

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -136,7 +136,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		script["imageStats"] = GafferImage.ImageStats()
 		script["imageStats"]["in"].setInput( script["display"]["out"] )
 		script["imageStats"]["channels"].setValue( IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
-		script["imageStats"]["regionOfInterest"].setValue( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 640, 480 ) ) )
+		script["imageStats"]["area"].setValue( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 640, 480 ) ) )
 
 		script["render"] = self._createInteractiveRender()
 		script["render"]["in"].setInput( script["outputs"]["out"] )

--- a/python/GafferImageTest/BlurTest.py
+++ b/python/GafferImageTest/BlurTest.py
@@ -121,7 +121,7 @@ class BlurTest( GafferImageTest.ImageTestCase ) :
 
 		stats = GafferImage.ImageStats()
 		stats["in"].setInput( blur["out"] )
-		stats["regionOfInterest"].setValue( IECore.Box2i( IECore.V2i( 5 ), IECore.V2i( 15 ) ) )
+		stats["area"].setValue( IECore.Box2i( IECore.V2i( 5 ), IECore.V2i( 15 ) ) )
 
 		for i in range( 0, 10 ) :
 

--- a/python/GafferImageTest/ImageSamplerTest.py
+++ b/python/GafferImageTest/ImageSamplerTest.py
@@ -76,5 +76,19 @@ class ImageSamplerTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual( len( hashes ), 75 * 75 )
 
+	def testChannelsPlug( self ) :
+
+		constant = GafferImage.Constant()
+		constant["layer"].setValue( "diffuse" )
+		constant["color"].setValue( IECore.Color4f( 1, 0.5, 0.25, 1 ) )
+
+		sampler = GafferImage.ImageSampler()
+		sampler["image"].setInput( constant["out"] )
+		sampler["pixel"].setValue( IECore.V2f( 10.5 ) )
+		self.assertEqual( sampler["color"].getValue(), IECore.Color4f( 0, 0, 0, 0 ) )
+
+		sampler["channels"].setValue( IECore.StringVectorData( [ "diffuse.R", "diffuse.G", "diffuse.B", "diffuse.A" ] ) )
+		self.assertEqual( sampler["color"].getValue(), IECore.Color4f( 1, 0.5, 0.25, 1 ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ImageStatsTest.py
+++ b/python/GafferImageTest/ImageStatsTest.py
@@ -110,11 +110,11 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 
 		r = GafferImage.ImageReader()
 		r["fileName"].setValue( self.__rgbFilePath )
+
 		s = GafferImage.ImageStats()
-		s["in"].setInput( r["out"] )
+		s["regionOfInterest"].setValue( r["out"]["format"].getValue().getDisplayWindow() )
 
 		# Get the hashes of the outputs when there is no input.
-		s["in"].setInput( None )
 		minHash = s["min"].hash()
 		maxHash = s["max"].hash()
 		averageHash = s["average"].hash()

--- a/python/GafferImageTest/ImageStatsTest.py
+++ b/python/GafferImageTest/ImageStatsTest.py
@@ -57,12 +57,12 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		s["in"].setInput( r["out"] )
 		s["regionOfInterest"].setValue( r["out"]["format"].getValue().getDisplayWindow() )
 
-		s["channels"].setValue( IECore.StringVectorData( [ "G", "B" ] ) )
+		s["channels"].setValue( IECore.StringVectorData( [ "", "G", "B" ] ) )
 		self.__assertColour( s["average"].getValue(), IECore.Color4f( 0., 0.0744, 0.1250, 1. ) )
 		self.__assertColour( s["min"].getValue(), IECore.Color4f( 0, 0, 0, 1. ) )
 		self.__assertColour( s["max"].getValue(), IECore.Color4f( 0, 0.5, 0.5, 1. ) )
 
-		s["channels"].setValue( IECore.StringVectorData( [ "R", "B" ] ) )
+		s["channels"].setValue( IECore.StringVectorData( [ "R", "", "B" ] ) )
 		self.__assertColour( s["average"].getValue(), IECore.Color4f( 0.0544, 0, 0.1250, 1. ) )
 		self.__assertColour( s["min"].getValue(), IECore.Color4f( 0, 0, 0, 1. ) )
 		self.__assertColour( s["max"].getValue(), IECore.Color4f( 0.5, 0, 0.5, 1. ) )
@@ -174,6 +174,17 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual( s.affects( s["in"]["format"] ), [] )
 		self.assertEqual( s.affects( s["in"]["metadata"] ), [] )
+
+	def testRepeatedChannels( self ) :
+
+		c = GafferImage.Constant()
+		s = GafferImage.ImageStats()
+		s["in"].setInput( c["out"] )
+		s["regionOfInterest"].setValue( c["out"]["format"].getValue().getDisplayWindow() )
+		s["channels"].setValue( IECore.StringVectorData( [ "A", "A", "A", "A" ] ) )
+
+		self.assertEqual( s["min"].getValue(), IECore.Color4f( 1 ) )
+		self.assertEqual( s["max"].getValue(), IECore.Color4f( 1 ) )
 
 	def __assertColour( self, colour1, colour2 ) :
 		for i in range( 0, 4 ):

--- a/python/GafferImageTest/ImageStatsTest.py
+++ b/python/GafferImageTest/ImageStatsTest.py
@@ -168,6 +168,13 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual( s["max"]["r"].getValue(), 0 )
 
+	def testFormatAndMetadataAffectNothing( self ) :
+
+		s = GafferImage.ImageStats()
+
+		self.assertEqual( s.affects( s["in"]["format"] ), [] )
+		self.assertEqual( s.affects( s["in"]["metadata"] ), [] )
+
 	def __assertColour( self, colour1, colour2 ) :
 		for i in range( 0, 4 ):
 			self.assertEqual( "%.4f" % colour2[i], "%.4f" % colour1[i] )

--- a/python/GafferImageTest/ImageStatsTest.py
+++ b/python/GafferImageTest/ImageStatsTest.py
@@ -55,7 +55,7 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 
 		s = GafferImage.ImageStats()
 		s["in"].setInput( r["out"] )
-		s["regionOfInterest"].setValue( r["out"]["format"].getValue().getDisplayWindow() )
+		s["area"].setValue( r["out"]["format"].getValue().getDisplayWindow() )
 
 		s["channels"].setValue( IECore.StringVectorData( [ "", "G", "B" ] ) )
 		self.__assertColour( s["average"].getValue(), IECore.Color4f( 0., 0.0744, 0.1250, 1. ) )
@@ -112,7 +112,7 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		r["fileName"].setValue( self.__rgbFilePath )
 
 		s = GafferImage.ImageStats()
-		s["regionOfInterest"].setValue( r["out"]["format"].getValue().getDisplayWindow() )
+		s["area"].setValue( r["out"]["format"].getValue().getDisplayWindow() )
 
 		# Get the hashes of the outputs when there is no input.
 		minHash = s["min"].hash()
@@ -134,7 +134,7 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		s["in"].setInput( r["out"] )
 		s["channels"].setValue( IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
 
-		s["regionOfInterest"].setValue( r["out"]["format"].getValue().getDisplayWindow() )
+		s["area"].setValue( r["out"]["format"].getValue().getDisplayWindow() )
 		self.__assertColour( s["average"].getValue(), IECore.Color4f( 0.0544, 0.0744, 0.1250, 0.2537 ) )
 		self.__assertColour( s["min"].getValue(), IECore.Color4f( 0, 0, 0, 0 ) )
 		self.__assertColour( s["max"].getValue(), IECore.Color4f( 0.5, 0.5, 0.5, 0.875 ) )
@@ -149,12 +149,12 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		s["in"].setInput( r["out"] )
 		s["channels"].setValue( IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
 
-		s["regionOfInterest"].setValue( IECore.Box2i( IECore.V2i( 20, 20 ), IECore.V2i( 25, 25 ) ) )
+		s["area"].setValue( IECore.Box2i( IECore.V2i( 20, 20 ), IECore.V2i( 25, 25 ) ) )
 		self.__assertColour( s["average"].getValue(), IECore.Color4f( 0.5, 0, 0, 0.5 ) )
 		self.__assertColour( s["max"].getValue(), IECore.Color4f( 0.5, 0, 0, 0.5 ) )
 		self.__assertColour( s["min"].getValue(), IECore.Color4f( 0.5, 0, 0, 0.5 ) )
 
-		s["regionOfInterest"].setValue( IECore.Box2i( IECore.V2i( 20, 20 ), IECore.V2i( 41, 30 ) ) )
+		s["area"].setValue( IECore.Box2i( IECore.V2i( 20, 20 ), IECore.V2i( 41, 30 ) ) )
 		self.__assertColour( s["average"].getValue(), IECore.Color4f( 0.4048, 0.1905, 0, 0.5952 ) )
 		self.__assertColour( s["min"].getValue(), IECore.Color4f( 0.25, 0, 0, 0.5 ) )
 		self.__assertColour( s["max"].getValue(), IECore.Color4f( 0.5, 0.5, 0, 0.75 ) )
@@ -164,7 +164,7 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		c = GafferImage.Constant()
 		s = GafferImage.ImageStats()
 		s["in"].setInput( c["out"] )
-		s["regionOfInterest"].setValue( c["out"]["format"].getValue().getDisplayWindow() )
+		s["area"].setValue( c["out"]["format"].getValue().getDisplayWindow() )
 
 		self.assertEqual( s["max"]["r"].getValue(), 0 )
 
@@ -180,7 +180,7 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		c = GafferImage.Constant()
 		s = GafferImage.ImageStats()
 		s["in"].setInput( c["out"] )
-		s["regionOfInterest"].setValue( c["out"]["format"].getValue().getDisplayWindow() )
+		s["area"].setValue( c["out"]["format"].getValue().getDisplayWindow() )
 		s["channels"].setValue( IECore.StringVectorData( [ "A", "A", "A", "A" ] ) )
 
 		self.assertEqual( s["min"].getValue(), IECore.Color4f( 1 ) )

--- a/python/GafferImageTest/ImageTestCase.py
+++ b/python/GafferImageTest/ImageTestCase.py
@@ -87,7 +87,7 @@ class ImageTestCase( GafferTest.TestCase ) :
 
 		stats = GafferImage.ImageStats()
 		stats["in"].setInput( difference["out"] )
-		stats["regionOfInterest"].setValue( imageA["format"].getValue().getDisplayWindow() )
+		stats["area"].setValue( imageA["format"].getValue().getDisplayWindow() )
 		stats["channels"].setValue( IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
 
 		if "R" in imageA["channelNames"].getValue() :

--- a/python/GafferImageTest/TextTest.py
+++ b/python/GafferImageTest/TextTest.py
@@ -63,7 +63,7 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 
 		stats = GafferImage.ImageStats()
 		stats["in"].setInput( text["out"] )
-		stats["regionOfInterest"].setValue( text["out"]["dataWindow"].getValue() )
+		stats["area"].setValue( text["out"]["dataWindow"].getValue() )
 
 		self.assertEqual( stats["max"].getValue(), IECore.Color4f( 1, 1, 1, 1 ) )
 

--- a/python/GafferImageTest/TextTest.py
+++ b/python/GafferImageTest/TextTest.py
@@ -68,10 +68,10 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( stats["max"].getValue(), IECore.Color4f( 1, 1, 1, 1 ) )
 
 		text["color"]["a"].setValue( 0.5 )
-		self.assertEqual( stats["max"].getValue(), IECore.Color4f( 0.5, 0.5, 0.5, 1 ) )
+		self.assertEqual( stats["max"].getValue(), IECore.Color4f( 0.5, 0.5, 0.5, 0.5 ) )
 
 		text["color"].setValue( IECore.Color4f( 0.5, 0.25, 1, 0.5 ) )
-		self.assertEqual( stats["max"].getValue(), IECore.Color4f( 0.25, 0.125, 0.5, 1 ) )
+		self.assertEqual( stats["max"].getValue(), IECore.Color4f( 0.25, 0.125, 0.5, 0.5 ) )
 
 	def testDataWindow( self ) :
 

--- a/python/GafferImageUI/ImageSamplerUI.py
+++ b/python/GafferImageUI/ImageSamplerUI.py
@@ -57,6 +57,17 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"channels" : [
+
+			"description",
+			"""
+			The names of the four channels to be sampled.
+			""",
+
+			"plugValueWidget:type", "GafferImageUI.RGBAChannelsPlugValueWidget",
+
+		],
+
 		"pixel" : [
 
 			"description",

--- a/python/GafferImageUI/ImageStatsUI.py
+++ b/python/GafferImageUI/ImageStatsUI.py
@@ -77,7 +77,7 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			The names of the channels to be analysed.
+			The names of the four channels to be analysed.
 			""",
 
 			"nodule:type", "",

--- a/python/GafferImageUI/ImageStatsUI.py
+++ b/python/GafferImageUI/ImageStatsUI.py
@@ -81,6 +81,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferImageUI.RGBAChannelsPlugValueWidget",
 
 		],
 

--- a/python/GafferImageUI/RGBAChannelsPlugValueWidget.py
+++ b/python/GafferImageUI/RGBAChannelsPlugValueWidget.py
@@ -1,0 +1,117 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import IECore
+
+import Gaffer
+import GafferUI
+import GafferImage
+
+class RGBAChannelsPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug, **kw ) :
+
+		self.__menuButton = GafferUI.MenuButton( menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ) )
+		self.__menuButton._qtWidget().setMinimumWidth( 150 )
+
+		GafferUI.PlugValueWidget.__init__( self, self.__menuButton, plug, **kw )
+
+		self._updateFromPlug()
+
+	def _updateFromPlug( self ) :
+
+		with self.getContext() :
+			value = self.getPlug().getValue()
+
+		assert( len( value ) == 4 )
+
+		layers = [ GafferImage.ImageAlgo.layerName( x ) for x in value ]
+		channels = [ GafferImage.ImageAlgo.baseName( x ) for x in value ]
+
+		# Figure out a good label for the current list of channels.
+		# Start out with "Custom" to represent something arbitrary
+		# chosen via scripting, and then assign more descriptive labels
+		# to anything that can be chosen via the menu.
+		text = "Custom"
+		if len( set( layers ) ) == 1 :
+			prefix = layers[0] + "." if layers[0] else ""
+			if channels == [ "R", "G", "B", "A" ] :
+				text = prefix + "RGBA"
+			elif len( set( channels ) ) == 1 :
+				text = prefix + channels[0]
+
+		self.__menuButton.setText( text )
+		self.__menuButton.setEnabled( self._editable() )
+
+	def __menuDefinition( self ) :
+
+		image = next( iter( self.getPlug().node().children( GafferImage.ImagePlug ) ) )
+		with self.getContext() :
+			channelNames = image["channelNames"].getValue()
+
+		added = set()
+		result = IECore.MenuDefinition()
+		for channelName in channelNames :
+
+			if GafferImage.ImageAlgo.baseName( channelName ) in [ "R", "G", "B", "A" ] :
+				layerName = GafferImage.layerName( channelName )
+				prefix = layerName + "." if layerName else ""
+				text = prefix + "RGBA"
+				value = [ prefix + x for x in [ "R", "G", "B", "A" ] ]
+			else :
+				text = channelName
+				value = [ channelName ] * 4
+
+			if text in added :
+				continue
+
+			result.append(
+				"/" + text.replace( ".", "/" ),
+				{
+					"command" : functools.partial( Gaffer.WeakMethod( self.__setValue ), value = value ),
+					"checkBox" : text == self.__menuButton.getText(),
+				}
+			)
+
+		return result
+
+	def __setValue( self, unused, value ) :
+
+		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			self.getPlug().setValue( IECore.StringVectorData( value ) )
+

--- a/python/GafferImageUI/__init__.py
+++ b/python/GafferImageUI/__init__.py
@@ -40,6 +40,7 @@ from _GafferImageUI import *
 import DisplayUI
 from FormatPlugValueWidget import FormatPlugValueWidget
 from ChannelMaskPlugValueWidget import ChannelMaskPlugValueWidget
+from RGBAChannelsPlugValueWidget import RGBAChannelsPlugValueWidget
 
 import OpenImageIOReaderUI
 import ImageReaderUI

--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -720,11 +720,11 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		hiddenStats = GafferImage.ImageStats()
 		hiddenStats["in"].setInput( hidden["out"] )
-		hiddenStats["regionOfInterest"].setValue( hidden["out"]["format"].getValue().getDisplayWindow() )
+		hiddenStats["area"].setValue( hidden["out"]["format"].getValue().getDisplayWindow() )
 
 		visibleStats = GafferImage.ImageStats()
 		visibleStats["in"].setInput( visible["out"] )
-		visibleStats["regionOfInterest"].setValue( visible["out"]["format"].getValue().getDisplayWindow() )
+		visibleStats["area"].setValue( visible["out"]["format"].getValue().getDisplayWindow() )
 
 		self.assertLess( hiddenStats["average"].getValue()[0], 0.05 )
 		self.assertGreater( visibleStats["average"].getValue()[0], .35 )

--- a/src/GafferImage/ImageStats.cpp
+++ b/src/GafferImage/ImageStats.cpp
@@ -93,6 +93,7 @@ ImageStats::ImageStats( const std::string &name )
 	defaultChannels.push_back( "R" );
 	defaultChannels.push_back( "G" );
 	defaultChannels.push_back( "B" );
+	defaultChannels.push_back( "A" );
 	addChild( new StringVectorDataPlug( "channels", Plug::In, defaultChannelsData ) );
 
 	addChild( new Box2iPlug( "regionOfInterest", Gaffer::Plug::In ) );

--- a/src/GafferImage/ImageStats.cpp
+++ b/src/GafferImage/ImageStats.cpp
@@ -65,9 +65,9 @@ ImageStats::ImageStats( const std::string &name )
 		)
 	);
 	addChild( new Box2iPlug( "regionOfInterest", Gaffer::Plug::In ) );
-	addChild( new Color4fPlug( "average", Gaffer::Plug::Out ) );
-	addChild( new Color4fPlug( "min", Gaffer::Plug::Out ) );
-	addChild( new Color4fPlug( "max", Gaffer::Plug::Out ) );
+	addChild( new Color4fPlug( "average", Gaffer::Plug::Out, Imath::Color4f( 0, 0, 0, 1 ) ) );
+	addChild( new Color4fPlug( "min", Gaffer::Plug::Out, Imath::Color4f( 0, 0, 0, 1 ) ) );
+	addChild( new Color4fPlug( "max", Gaffer::Plug::Out, Imath::Color4f( 0, 0, 0, 1 ) ) );
 }
 
 ImageStats::~ImageStats()
@@ -220,18 +220,7 @@ void ImageStats::hash( const ValuePlug *output, const Context *context, IECore::
 	}
 
 	// If our node is not enabled then we just append the default value that we will give the plug.
-	if(
-			output == maxPlug()->getChild(3) ||
-			output == minPlug()->getChild(3) ||
-			output == averagePlug()->getChild(3)
-	  )
-	{
-		h.append( 0 );
-	}
-	else
-	{
-		h.append( 1 );
-	}
+	h.append( static_cast<const FloatPlug *>( output )->defaultValue() );
 }
 
 void ImageStats::channelNameFromOutput( const ValuePlug *output, std::string &channelName ) const
@@ -266,28 +255,12 @@ void ImageStats::channelNameFromOutput( const ValuePlug *output, std::string &ch
 	return;
 }
 
-void ImageStats::setOutputToDefault( FloatPlug *output ) const
-{
-	if (
-			output == minPlug()->getChild(3) ||
-			output == maxPlug()->getChild(3) ||
-			output == averagePlug()->getChild(3)
-	   )
-	{
-		output->setValue( 1. );
-	}
-	else
-	{
-		output->setValue( 0. );
-	}
-}
-
 void ImageStats::compute( ValuePlug *output, const Context *context ) const
 {
 	const Imath::Box2i &regionOfInterest( regionOfInterestPlug()->getValue() );
 	if( regionOfInterest.isEmpty() )
 	{
-		setOutputToDefault( static_cast<FloatPlug*>( output ) );
+		output->setToDefault();
 		return;
 	}
 
@@ -295,7 +268,7 @@ void ImageStats::compute( ValuePlug *output, const Context *context ) const
 	channelNameFromOutput( output, channelName );
 	if ( channelName.empty() )
 	{
-		setOutputToDefault( static_cast<FloatPlug*>( output ) );
+		output->setToDefault();
 		return;
 	}
 

--- a/src/GafferImage/ImageStats.cpp
+++ b/src/GafferImage/ImageStats.cpp
@@ -155,11 +155,13 @@ void ImageStats::parentChanging( Gaffer::GraphComponent *newParent )
 void ImageStats::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	ComputeNode::affects( input, outputs );
-	if (
-			input == channelsPlug() ||
-			input->parent<ImagePlug>() == inPlug() ||
-			regionOfInterestPlug()->isAncestorOf( input )
-	   )
+	if(
+		input == inPlug()->dataWindowPlug() ||
+		input == inPlug()->channelNamesPlug() ||
+		input == inPlug()->channelDataPlug() ||
+		input == channelsPlug() ||
+		regionOfInterestPlug()->isAncestorOf( input )
+	)
 	{
 		for( unsigned int i = 0; i < 4; ++i )
 		{

--- a/startup/GafferImage/imageStatsCompatibility.py
+++ b/startup/GafferImage/imageStatsCompatibility.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,94 +34,17 @@
 #
 ##########################################################################
 
-import Gaffer
-import GafferUI
 import GafferImage
-import GafferImageUI
 
-## A function suitable as the postCreator in a NodeMenu.append() call. It
-# sets the region of interest for the node to cover the entire format.
-def postCreate( node, menu ) :
+def __imageStatsGetItem( originalGetItem ) :
 
-	with node.scriptNode().context() :
-		if node["in"].getInput() :
-			format = node["in"]["format"].getValue()
-		else:
-			format = GafferImage.FormatPlug.getDefaultFormat( node.scriptNode().context() )
+	def getItem( self, key ) :
 
-	node["area"].setValue( format.getDisplayWindow() )
+		if key == "regionOfInterest" :
+			key = "area"
 
-Gaffer.Metadata.registerNode(
+		return originalGetItem( self, key )
 
-	GafferImage.ImageStats,
+	return getItem
 
-	"description",
-	"""
-	Calculates minimum, maximum and average colours for a region of
-	an image. These outputs can then be used to drive other plugs
-	within the node graph.
-	""",
-
-	plugs = {
-
-		"in" : [
-
-			"description",
-			"""
-			The input image to be analysed.
-			""",
-
-		],
-
-		"channels" : [
-
-			"description",
-			"""
-			The names of the four channels to be analysed.
-			""",
-
-			"nodule:type", "",
-
-		],
-
-		"area" : [
-
-			"description",
-			"""
-			The area of the image to be analysed.
-			""",
-
-			"nodule:type", "",
-
-		],
-
-		"average" : [
-
-			"description",
-			"""
-			The per-channel mean values computed from the input image region.
-			""",
-
-		],
-
-		"min" : [
-
-			"description",
-			"""
-			The per-channel minimum values computed from the input image region.
-			""",
-
-		],
-
-		"max" : [
-
-			"description",
-			"""
-			The per-channel maximum values computed from the input image region.
-			""",
-
-		],
-
-	}
-
-)
+GafferImage.ImageStats.__getitem__ = __imageStatsGetItem( GafferImage.ImageStats.__getitem__ )


### PR DESCRIPTION
Up till now we've been using ChannelMaskPlug for all channel choosers in GafferImage, but it wasn't an elegant solution. Our nodes seem to break down into two types :

1. Nodes that want exactly four input channels and will interpret them as RGBA in order to produce a strictly RGBA output. The ImageStats and ImageSampler nodes fall into this category, because their outputs are Color4fPlugs. The ChannelMaskPlug was a poor choice for these, because it introduced ambiguity in the channel specification, including allowing multiple potential channels to be selected for each output. This PR deals with this class of nodes.
2. Nodes that want a totally arbitrary number of channels and will interpret them based on name. These too are dealt with poorly by the ChannelMaskPlug, because it provides no wildcard matching to say "all channels" or "all RGB channels". These nodes will be updated to follow the new standard defined in the CopyChannels node recently, which I'll put into a separate PR once my StringAlgo PR is merged.

I've split this off of "everything needed for AOVs in the viewer" branch in the hope of getting this subset reviewed today - if that doesn't happen, it'll most likely appear again in a much larger PR tomorrow. @danieldresser, I think you're the developer with the most interest in seeing this happen, so maybe you'll have a chance to take a look?

One thing I wasn't sure about was whether I should introduce an RGBAChannelsPlug to complement the RGBAChannelsPlugValueWidget on the API side. This would enforce that values are always `string[4]` rather than just using StringVectorData and expecting the caller to get it right, and the UI to enforce the constraint. Maybe I should have gone for the extra constraints on the API side too?