### PR TITLE
GafferImage::Grade : Support grading all channels

### DIFF
--- a/include/GafferImage/Grade.h
+++ b/include/GafferImage/Grade.h
@@ -64,20 +64,20 @@ class Grade : public ChannelDataProcessor
         /// Returns a pointer to the node's plugs.
         //////////////////////////////////////////////////////////////
         //@{
-		Gaffer::Color3fPlug *blackPointPlug();
-		const Gaffer::Color3fPlug *blackPointPlug() const;
-		Gaffer::Color3fPlug *whitePointPlug();
-		const Gaffer::Color3fPlug *whitePointPlug() const;
-		Gaffer::Color3fPlug *liftPlug();
-		const Gaffer::Color3fPlug *liftPlug() const;
-		Gaffer::Color3fPlug *gainPlug();
-		const Gaffer::Color3fPlug *gainPlug() const;
-		Gaffer::Color3fPlug *multiplyPlug();
-		const Gaffer::Color3fPlug *multiplyPlug() const;
-		Gaffer::Color3fPlug *offsetPlug();
-		const Gaffer::Color3fPlug *offsetPlug() const;
-		Gaffer::Color3fPlug *gammaPlug();
-		const Gaffer::Color3fPlug *gammaPlug() const;
+		Gaffer::Color4fPlug *blackPointPlug();
+		const Gaffer::Color4fPlug *blackPointPlug() const;
+		Gaffer::Color4fPlug *whitePointPlug();
+		const Gaffer::Color4fPlug *whitePointPlug() const;
+		Gaffer::Color4fPlug *liftPlug();
+		const Gaffer::Color4fPlug *liftPlug() const;
+		Gaffer::Color4fPlug *gainPlug();
+		const Gaffer::Color4fPlug *gainPlug() const;
+		Gaffer::Color4fPlug *multiplyPlug();
+		const Gaffer::Color4fPlug *multiplyPlug() const;
+		Gaffer::Color4fPlug *offsetPlug();
+		const Gaffer::Color4fPlug *offsetPlug() const;
+		Gaffer::Color4fPlug *gammaPlug();
+		const Gaffer::Color4fPlug *gammaPlug() const;
 		Gaffer::BoolPlug *blackClampPlug();
 		const Gaffer::BoolPlug *blackClampPlug() const;
 		Gaffer::BoolPlug *whiteClampPlug();

--- a/python/GafferUI/ColorSwatch.py
+++ b/python/GafferUI/ColorSwatch.py
@@ -54,10 +54,23 @@ class ColorSwatch( GafferUI.Widget ) :
 
 	def __init__( self, color=IECore.Color4f( 1 ), useDisplayTransform = True, **kw ) :
 
-		GafferUI.Widget.__init__( self, _Checker(), **kw )
+		GafferUI.Widget.__init__( self, QtGui.QWidget(), **kw )
+
+		self.opaqueChecker = _Checker()
+		self.transparentChecker = _Checker()
+
+		self.__qtLayout = QtGui.QVBoxLayout()
+		self.__qtLayout.setSpacing( 0 )
+		self.__qtLayout.setContentsMargins( 0, 0, 0, 0 )
+		self.__qtLayout.addWidget( self.opaqueChecker )
+		self.__qtLayout.addWidget( self.transparentChecker )
+
+		self._qtWidget().setLayout( self.__qtLayout )
+
 
 		## \todo Should this be an option? Should it be an option for all Widgets?
-		self._qtWidget().setMinimumSize( 12, 12 )
+		self.opaqueChecker.setMinimumSize( 12, 6 )
+		self.transparentChecker.setMinimumSize( 12, 6 )
 
 		self.__useDisplayTransform = useDisplayTransform
 		self.__color = color
@@ -92,9 +105,10 @@ class ColorSwatch( GafferUI.Widget ) :
 		displayTransform = GafferUI.DisplayTransform.get()
 		effectiveDisplayTransform = displayTransform if self.__useDisplayTransform else lambda x : x
 
+		opaqueDisplayColor = self._qtColor( effectiveDisplayTransform( self.__color ) )
+		self.opaqueChecker.color0 = self.opaqueChecker.color1 = opaqueDisplayColor
 		if self.__color.dimensions()==3 :
-			displayColor = self._qtColor( effectiveDisplayTransform( self.__color ) )
-			self._qtWidget().color0 = self._qtWidget().color1 = displayColor
+			self.transparentChecker.color0 = self.transparentChecker.color1 = opaqueDisplayColor
 		else :
 			c = self.__color
 			# We want the background colour to be the same whether or not we're using the display transform for
@@ -107,11 +121,12 @@ class ColorSwatch( GafferUI.Widget ) :
 			color0 = bg0 * ( 1.0 - c.a ) + IECore.Color3f( c.r, c.g, c.b ) * c.a
 			color1 = bg1 * ( 1.0 - c.a ) + IECore.Color3f( c.r, c.g, c.b ) * c.a
 
-			self._qtWidget().color0 = self._qtColor( effectiveDisplayTransform( color0 ) )
-			self._qtWidget().color1 = self._qtColor( effectiveDisplayTransform( color1 ) )
+			self.transparentChecker.color0 = self._qtColor( effectiveDisplayTransform( color0 ) )
+			self.transparentChecker.color1 = self._qtColor( effectiveDisplayTransform( color1 ) )
 
 		## \todo Colour should come from the style when we have styles applying to Widgets as well as Gadgets
-		self._qtWidget().borderColor = QtGui.QColor( 119, 156, 255 ) if self.getHighlighted() else None
+		self.opaqueChecker.borderColor = QtGui.QColor( 119, 156, 255 ) if self.getHighlighted() else None
+		self.transparentChecker.borderColor = QtGui.QColor( 119, 156, 255 ) if self.getHighlighted() else None
 
 		self._qtWidget().update()
 

--- a/src/GafferImage/Grade.cpp
+++ b/src/GafferImage/Grade.cpp
@@ -51,13 +51,13 @@ Grade::Grade( const std::string &name )
 	:	ChannelDataProcessor( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	addChild( new Color3fPlug( "blackPoint" ) );
-	addChild( new Color3fPlug( "whitePoint", Gaffer::Plug::In, Imath::V3f(1.f, 1.f, 1.f) ) );
-	addChild( new Color3fPlug( "lift" ) );
-	addChild( new Color3fPlug( "gain", Gaffer::Plug::In, Imath::V3f(1.f, 1.f, 1.f) ) );
-	addChild( new Color3fPlug( "multiply", Gaffer::Plug::In, Imath::V3f(1.f, 1.f, 1.f) ) );
-	addChild( new Color3fPlug( "offset" ) );
-	addChild( new Color3fPlug( "gamma", Gaffer::Plug::In, Imath::Color3f( 1.0f ), Imath::Color3f( 0.0f ) ) );
+	addChild( new Color4fPlug( "blackPoint" ) );
+	addChild( new Color4fPlug( "whitePoint", Gaffer::Plug::In, Imath::Color4f( 1.0f ) ) );
+	addChild( new Color4fPlug( "lift" ) );
+	addChild( new Color4fPlug( "gain", Gaffer::Plug::In, Imath::Color4f( 1.0f ) ) );
+	addChild( new Color4fPlug( "multiply", Gaffer::Plug::In, Imath::Color4f( 1.0f ) ) );
+	addChild( new Color4fPlug( "offset" ) );
+	addChild( new Color4fPlug( "gamma", Gaffer::Plug::In, Imath::Color4f( 1.0f ), Imath::Color4f( 0.0f ) ) );
 	addChild( new BoolPlug( "blackClamp", Gaffer::Plug::In, true ) );
 	addChild( new BoolPlug( "whiteClamp" ) );
 }
@@ -66,74 +66,74 @@ Grade::~Grade()
 {
 }
 
-Gaffer::Color3fPlug *Grade::blackPointPlug()
+Gaffer::Color4fPlug *Grade::blackPointPlug()
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex );
+	return getChild<Color4fPlug>( g_firstPlugIndex );
 }
 
-const Gaffer::Color3fPlug *Grade::blackPointPlug() const
+const Gaffer::Color4fPlug *Grade::blackPointPlug() const
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex );
+	return getChild<Color4fPlug>( g_firstPlugIndex );
 }
 
-Gaffer::Color3fPlug *Grade::whitePointPlug()
+Gaffer::Color4fPlug *Grade::whitePointPlug()
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex+1 );
+	return getChild<Color4fPlug>( g_firstPlugIndex+1 );
 }
 
-const Gaffer::Color3fPlug *Grade::whitePointPlug() const
+const Gaffer::Color4fPlug *Grade::whitePointPlug() const
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex+1 );
+	return getChild<Color4fPlug>( g_firstPlugIndex+1 );
 }
 
-Gaffer::Color3fPlug *Grade::liftPlug()
+Gaffer::Color4fPlug *Grade::liftPlug()
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex+2 );
+	return getChild<Color4fPlug>( g_firstPlugIndex+2 );
 }
 
-const Gaffer::Color3fPlug *Grade::liftPlug() const
+const Gaffer::Color4fPlug *Grade::liftPlug() const
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex+2 );
+	return getChild<Color4fPlug>( g_firstPlugIndex+2 );
 }
 
-Gaffer::Color3fPlug *Grade::gainPlug()
+Gaffer::Color4fPlug *Grade::gainPlug()
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex+3 );
+	return getChild<Color4fPlug>( g_firstPlugIndex+3 );
 }
 
-const Gaffer::Color3fPlug *Grade::gainPlug() const
+const Gaffer::Color4fPlug *Grade::gainPlug() const
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex+3 );
+	return getChild<Color4fPlug>( g_firstPlugIndex+3 );
 }
 
-Gaffer::Color3fPlug *Grade::multiplyPlug()
+Gaffer::Color4fPlug *Grade::multiplyPlug()
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex+4 );
+	return getChild<Color4fPlug>( g_firstPlugIndex+4 );
 }
 
-const Gaffer::Color3fPlug *Grade::multiplyPlug() const
+const Gaffer::Color4fPlug *Grade::multiplyPlug() const
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex+4 );
+	return getChild<Color4fPlug>( g_firstPlugIndex+4 );
 }
 
-Gaffer::Color3fPlug *Grade::offsetPlug()
+Gaffer::Color4fPlug *Grade::offsetPlug()
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex+5 );
+	return getChild<Color4fPlug>( g_firstPlugIndex+5 );
 }
 
-const Gaffer::Color3fPlug *Grade::offsetPlug() const
+const Gaffer::Color4fPlug *Grade::offsetPlug() const
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex+5 );
+	return getChild<Color4fPlug>( g_firstPlugIndex+5 );
 }
 
-Gaffer::Color3fPlug *Grade::gammaPlug()
+Gaffer::Color4fPlug *Grade::gammaPlug()
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex+6 );
+	return getChild<Color4fPlug>( g_firstPlugIndex+6 );
 }
 
-const Gaffer::Color3fPlug *Grade::gammaPlug() const
+const Gaffer::Color4fPlug *Grade::gammaPlug() const
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex+6 );
+	return getChild<Color4fPlug>( g_firstPlugIndex+6 );
 }
 
 Gaffer::BoolPlug *Grade::blackClampPlug()
@@ -165,9 +165,6 @@ bool Grade::channelEnabled( const std::string &channel ) const
 
 	const int channelIndex = std::max( 0, ImageAlgo::colorIndex( channel ) );
 
-	// Never bother to process the alpha channel.
-	if ( channelIndex == 3 ) return false;
-
 	// And don't bother to process identity transforms or invalid gammas
 	float a, b, gamma;
 	parameters( channelIndex, a, b, gamma );
@@ -187,7 +184,7 @@ void Grade::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs 
 	ChannelDataProcessor::affects( input, outputs );
 
 	// Process the children of the compound plugs.
-	for( unsigned int i = 0; i < 3; ++i )
+	for( unsigned int i = 0; i < 4; ++i )
 	{
 		if( input == blackPointPlug()->getChild(i) ||
 				input == whitePointPlug()->getChild(i) ||
@@ -222,22 +219,17 @@ void Grade::hashChannelData( const GafferImage::ImagePlug *output, const Gaffer:
 	inPlug()->channelDataPlug()->hash( h );
 
 	const std::string &channelName = context->get<std::string>( ImagePlug::channelNameContextName );
-	const int channelIndex = ImageAlgo::colorIndex( channelName );
-	if( channelIndex >= 0 and channelIndex < 3 )
-	{
-		/// \todo The channelIndex tests above might be guaranteed true by
-		/// the effects of channelEnabled() anyway, but it's not clear from
-		/// the base class documentation.
-		blackPointPlug()->getChild( channelIndex )->hash( h );
-		whitePointPlug()->getChild( channelIndex )->hash( h );
-		liftPlug()->getChild( channelIndex )->hash( h );
-		gainPlug()->getChild( channelIndex )->hash( h );
-		multiplyPlug()->getChild( channelIndex )->hash( h );
-		offsetPlug()->getChild( channelIndex )->hash( h );
-		gammaPlug()->getChild( channelIndex )->hash( h );
-		blackClampPlug()->hash( h );
-		whiteClampPlug()->hash( h );
-	}
+	const int channelIndex = std::max( 0, ImageAlgo::colorIndex( channelName ) );
+	
+	blackPointPlug()->getChild( channelIndex )->hash( h );
+	whitePointPlug()->getChild( channelIndex )->hash( h );
+	liftPlug()->getChild( channelIndex )->hash( h );
+	gainPlug()->getChild( channelIndex )->hash( h );
+	multiplyPlug()->getChild( channelIndex )->hash( h );
+	offsetPlug()->getChild( channelIndex )->hash( h );
+	gammaPlug()->getChild( channelIndex )->hash( h );
+	blackClampPlug()->hash( h );
+	whiteClampPlug()->hash( h );
 }
 
 void Grade::processChannelData( const Gaffer::Context *context, const ImagePlug *parent, const std::string &channel, FloatVectorDataPtr outData ) const

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -483,11 +483,12 @@ void ImageView::plugSet( Gaffer::Plug *plug )
 	else if( plug == exposurePlug() )
 	{
 		const float m = pow( 2.0f, exposurePlug()->getValue() );
-		gradeNode()->multiplyPlug()->setValue( Color3f( m ) );
+		gradeNode()->multiplyPlug()->setValue( Color4f( m, m, m, 1.0f ) );
 	}
 	else if( plug == gammaPlug() )
 	{
-		gradeNode()->gammaPlug()->setValue( Color3f( gammaPlug()->getValue() ) );
+		const float g = gammaPlug()->getValue();
+		gradeNode()->gammaPlug()->setValue( Color4f( g, g, g, 1.0f ) );
 	}
 	else if( plug == displayTransformPlug() )
 	{

--- a/startup/GafferImage/gradeCompatibility.py
+++ b/startup/GafferImage/gradeCompatibility.py
@@ -1,0 +1,65 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+
+import types
+
+import IECore
+
+import Gaffer
+import GafferImage
+
+def __color4fPlugCompatSetValue( self, value ) :
+
+	if isinstance( value, IECore.Color3f ) :
+		for i in range(3):
+			self[i].setValue( value[i] )
+	else:
+		self.__class__.setValue( self, value )
+
+def __gradeGetItem( originalGetItem ) :
+
+	def getItem( self, key ) :
+
+		result = originalGetItem( self, key )
+		if type( result ) == Gaffer.Color4fPlug:
+			result.setValue = types.MethodType( __color4fPlugCompatSetValue, result )
+
+		return result
+
+	return getItem
+
+GafferImage.Grade.__getitem__ = __gradeGetItem( GafferImage.Grade.__getitem__ )


### PR DESCRIPTION
I had hoped that this would just be a one line fix to add the std::max in the hash function, but once I'd done that, the the >= 0 test on the next line didn't make much sense, and removing that led to wondering whether the < 3 test made sense either, which lead to asking Lucien whether he thought you should be able to grade the all alpha channel.

The logical conclusion seemed to be that we should use 4 element plugs here, and colorIndex is always -1 or a valid index.  Hopefully this seems reasonable.