### PR TITLE
Warp Optimization

### DIFF
--- a/include/GafferImage/VectorWarp.h
+++ b/include/GafferImage/VectorWarp.h
@@ -75,8 +75,8 @@ class VectorWarp : public Warp
 	protected :
 
 		virtual bool affectsEngine( const Gaffer::Plug *input ) const;
-		virtual void hashEngine( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual const Engine *computeEngine( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context ) const;
+		virtual void hashEngine( const Imath::V2i &tileOrigin, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual const Engine *computeEngine( const Imath::V2i &tileOrigin, const Gaffer::Context *context ) const;
 
 	private :
 

--- a/include/GafferImage/Warp.h
+++ b/include/GafferImage/Warp.h
@@ -43,8 +43,6 @@
 
 #include "GafferImage/ImageProcessor.h"
 
-#include "GafferImage/Sampler.h"
-
 namespace GafferImage
 {
 

--- a/include/GafferImage/Warp.h
+++ b/include/GafferImage/Warp.h
@@ -108,10 +108,10 @@ class Warp : public ImageProcessor
 		/// hash all the inputs used in creating an engine for the specified
 		/// tile. If the tileOrigin is not included in the hash, then the
 		/// same engine may be reused for all tiles.
-		virtual void hashEngine( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
+		virtual void hashEngine( const Imath::V2i &tileOrigin, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
 		/// Must be implemented to return an Engine instance capable
 		/// of answering all queries for the specified tile.
-		virtual const Engine *computeEngine( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context ) const = 0;
+		virtual const Engine *computeEngine( const Imath::V2i &tileOrigin, const Gaffer::Context *context ) const = 0;
 
 	private :
 

--- a/src/GafferImage/VectorWarp.cpp
+++ b/src/GafferImage/VectorWarp.cpp
@@ -179,9 +179,9 @@ bool VectorWarp::affectsEngine( const Gaffer::Plug *input ) const
 		input == vectorUnitsPlug();
 }
 
-void VectorWarp::hashEngine( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void VectorWarp::hashEngine( const Imath::V2i &tileOrigin, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	Warp::hashEngine( channelName, tileOrigin, context, h );
+	Warp::hashEngine( tileOrigin, context, h );
 
 	h.append( tileOrigin );
 	vectorPlug()->dataWindowPlug()->hash( h );
@@ -215,7 +215,7 @@ void VectorWarp::hashEngine( const std::string &channelName, const Imath::V2i &t
 	vectorUnitsPlug()->hash( h );
 }
 
-const Warp::Engine *VectorWarp::computeEngine( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context ) const
+const Warp::Engine *VectorWarp::computeEngine( const Imath::V2i &tileOrigin, const Gaffer::Context *context ) const
 {
 	const Box2i tileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
 	const Box2i validTileBound = BufferAlgo::intersection( tileBound, vectorPlug()->dataWindowPlug()->getValue() );

--- a/src/GafferImage/Warp.cpp
+++ b/src/GafferImage/Warp.cpp
@@ -500,7 +500,10 @@ void Warp::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) 
 							( tileOrigin.x + x ) + 0.5,
 							( tileOrigin.y + y ) + 0.5 ) );
 
-						inputBound.extendBy( FilterAlgo::filterSupport( inputPosition, 1.0f, 1.0f,  filterWidth ) );
+						if( inputPosition != Engine::black )
+						{
+							inputBound.extendBy( FilterAlgo::filterSupport( inputPosition, 1.0f, 1.0f,  filterWidth ) );
+						}
 					}
 					pixelInputPositions.push_back( inputPosition );
 					pixelInputDerivatives.push_back( V2f( 1.0f ) );


### PR DESCRIPTION
Some current hackery with optimization of Warp node.  Will likely need some cleanup in morning, but both seem like pretty good additions.

The last commit can't be merged in this simple state:  I just completely broke the ability for engines to depend on the current channelName.  I'm thinking of adding a virtual member Warp::engineDependsOnChannelName, which can default true, but subclasses such as VectorWarp can set false to indicate that the current channel name doesn't affect them.  Computing the sample regions repeatedly for different channels may not be that expensive compared to the actual sampling, but this helps cut down on the hashing as well.  I just need that pr-speculative label.