### PR TITLE
FileSystemPathVectorDataWidget

### DIFF
--- a/python/GafferAppleseedUI/AppleseedAttributesUI.py
+++ b/python/GafferAppleseedUI/AppleseedAttributesUI.py
@@ -238,8 +238,8 @@ Gaffer.Metadata.registerNode(
 		"attributes.alphaMap.value" : [
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:bookmarks", "texture",
+			"path:leaf", True,
+			"path:bookmarks", "texture",
 
 		],
 

--- a/python/GafferAppleseedUI/AppleseedLightUI.py
+++ b/python/GafferAppleseedUI/AppleseedLightUI.py
@@ -103,8 +103,8 @@ Gaffer.Metadata.registerNode(
 		"parameters.radiance_map" : [
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:bookmarks", "image",
+			"path:leaf", True,
+			"path:bookmarks", "image",
 
 		],
 

--- a/python/GafferAppleseedUI/AppleseedOptionsUI.py
+++ b/python/GafferAppleseedUI/AppleseedOptionsUI.py
@@ -314,7 +314,7 @@ Gaffer.Metadata.registerNode(
 		"options.environmentEDF.value" : [
 
 			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
-			"pathPlugValueWidget:valid", True,
+			"path:valid", True,
 			"scenePathPlugValueWidget:setNames", IECore.StringVectorData( [ "__lights" ] ),
 			"scenePathPlugValueWidget:setsLabel", "Show only lights",
 
@@ -667,8 +667,8 @@ Gaffer.Metadata.registerNode(
 
 		"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 		"pathPlugValueWidget:leaf", True,
-		"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "txt", "log" ] ),
-		"fileSystemPathPlugValueWidget:extensionsLabel", "Show only log files",
+		"fileSystemPath:extensions", "txt log",
+		"fileSystemPath:extensionsLabel", "Show only log files",
 
 		],
 

--- a/python/GafferAppleseedUI/AppleseedRenderUI.py
+++ b/python/GafferAppleseedUI/AppleseedRenderUI.py
@@ -63,9 +63,9 @@ Gaffer.Metadata.registerNode(
 
 			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:bookmarks", "appleseed",
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "appleseed" ] ),
+			"path:leaf", True,
+			"path:bookmarks", "appleseed",
+			"fileSystemPath:extensions", "appleseed",
 
 		],
 

--- a/python/GafferAppleseedUI/AppleseedShaderBallUI.py
+++ b/python/GafferAppleseedUI/AppleseedShaderBallUI.py
@@ -57,9 +57,9 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:valid", True,
-			"pathPlugValueWidget:bookmarks", "texture",
+			"path:leaf", True,
+			"path:valid", True,
+			"path:bookmarks", "texture",
 
 		],
 

--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -761,9 +761,9 @@ Gaffer.Metadata.registerNode(
 		"options.logFileName.value" : [
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "txt", "log" ] ),
-			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only log files",
+			"path:leaf", True,
+			"fileSystemPath:extensions", "txt log",
+			"fileSystemPath:extensionsLabel", "Show only log files",
 
 		],
 

--- a/python/GafferArnoldUI/ArnoldRenderUI.py
+++ b/python/GafferArnoldUI/ArnoldRenderUI.py
@@ -65,8 +65,8 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "",
-			"pathPlugValueWidget:bookmarks", "ass",
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "ass", "ass.gz" ] ),
+			"path:bookmarks", "ass",
+			"fileSystemPath:extensions", "ass ass.gz",
 
 		],
 

--- a/python/GafferArnoldUI/ArnoldShaderBallUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderBallUI.py
@@ -57,9 +57,9 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:valid", True,
-			"pathPlugValueWidget:bookmarks", "texture",
+			"path:leaf", True,
+			"path:valid", True,
+			"path:bookmarks", "texture",
 
 		],
 

--- a/python/GafferArnoldUI/ArnoldVDBUI.py
+++ b/python/GafferArnoldUI/ArnoldVDBUI.py
@@ -59,11 +59,11 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:valid", True,
-			"pathPlugValueWidget:bookmarks", "vdb",
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "vdb" ] ),
-			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only VDB files",
+			"path:leaf", True,
+			"path:valid", True,
+			"path:bookmarks", "vdb",
+			"fileSystemPath:extensions", "vdb",
+			"fileSystemPath:extensionsLabel", "Show only VDB files",
 
 		],
 
@@ -137,10 +137,10 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:bookmarks", "arnoldProcedural",
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "so", "dylib" ] ),
-			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only DSOs",
+			"path:leaf", True,
+			"path:bookmarks", "arnoldProcedural",
+			"fileSystemPath:extensions", "so dylib",
+			"fileSystemPath:extensionsLabel", "Show only DSOs",
 
 		],
 

--- a/python/GafferCortexUI/FileSequenceParameterValueWidget.py
+++ b/python/GafferCortexUI/FileSequenceParameterValueWidget.py
@@ -100,5 +100,5 @@ def __includeFrameRange( plug ) :
 	return includeFrameRange
 
 for nodeType in __nodeTypes :
-	Gaffer.Metadata.registerValue( nodeType, "parameters.*", "fileSystemPathPlugValueWidget:includeSequences", __isFileSequence )
-	Gaffer.Metadata.registerValue( nodeType, "parameters.*", "fileSystemPathPlugValueWidget:includeSequenceFrameRange", __includeFrameRange )
+	Gaffer.Metadata.registerValue( nodeType, "parameters.*", "fileSystemPath:includeSequences", __isFileSequence )
+	Gaffer.Metadata.registerValue( nodeType, "parameters.*", "fileSystemPath:includeSequenceFrameRange", __includeFrameRange )

--- a/python/GafferCortexUI/ObjectReaderUI.py
+++ b/python/GafferCortexUI/ObjectReaderUI.py
@@ -63,11 +63,11 @@ Gaffer.Metadata.registerNode(
 
 			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:valid", True,
-			"pathPlugValueWidget:bookmarks", "cortex",
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( IECore.Reader.supportedExtensions() ),
-			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only supported files",
+			"path:leaf", True,
+			"path:valid", True,
+			"path:bookmarks", "cortex",
+			"fileSystemPath:extensions", " ".join( IECore.Reader.supportedExtensions() ),
+			"fileSystemPath:extensionsLabel", "Show only supported files",
 
 		],
 

--- a/python/GafferCortexUI/ObjectWriterUI.py
+++ b/python/GafferCortexUI/ObjectWriterUI.py
@@ -74,10 +74,10 @@ Gaffer.Metadata.registerNode(
 
 			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:bookmarks", "cortex",
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( IECore.Reader.supportedExtensions() ),
-			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only supported files",
+			"path:leaf", True,
+			"path:bookmarks", "cortex",
+			"fileSystemPath:extensions", " ".join( IECore.Reader.supportedExtensions() ),
+			"fileSystemPath:extensionsLabel", "Show only supported files",
 
 		],
 

--- a/python/GafferDispatchUI/DispatcherUI.py
+++ b/python/GafferDispatchUI/DispatcherUI.py
@@ -115,7 +115,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", False,
+			"path:leaf", False,
 
 		),
 

--- a/python/GafferImageUI/ImageReaderUI.py
+++ b/python/GafferImageUI/ImageReaderUI.py
@@ -72,11 +72,11 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:bookmarks", "image",
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( GafferImage.ImageReader.supportedExtensions() ),
-			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only image files",
-			"fileSystemPathPlugValueWidget:includeSequences", True,
+			"path:leaf", True,
+			"path:bookmarks", "image",
+			"fileSystemPath:extensions", " ".join( GafferImage.ImageReader.supportedExtensions() ),
+			"fileSystemPath:extensionsLabel", "Show only image files",
+			"fileSystemPath:includeSequences", True,
 
 		],
 

--- a/python/GafferImageUI/ImageWriterUI.py
+++ b/python/GafferImageUI/ImageWriterUI.py
@@ -76,11 +76,11 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:bookmarks", "image",
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( GafferImage.ImageReader.supportedExtensions() ),
-			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only image files",
-			"fileSystemPathPlugValueWidget:includeSequences", True,
+			"path:leaf", True,
+			"path:bookmarks", "image",
+			"fileSystemPath:extensions", " ".join( GafferImage.ImageReader.supportedExtensions() ),
+			"fileSystemPath:extensionsLabel", "Show only image files",
+			"fileSystemPath:includeSequences", True,
 
 		],
 

--- a/python/GafferImageUI/LUTUI.py
+++ b/python/GafferImageUI/LUTUI.py
@@ -61,10 +61,10 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:bookmarks", "color",
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( GafferImage.LUT.supportedExtensions() ),
-			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only LUT files",
+			"path:leaf", True,
+			"path:bookmarks", "color",
+			"fileSystemPath:extensions", " ".join( GafferImage.LUT.supportedExtensions() ),
+			"fileSystemPath:extensionsLabel", "Show only LUT files",
 
 		],
 

--- a/python/GafferImageUI/OpenImageIOReaderUI.py
+++ b/python/GafferImageUI/OpenImageIOReaderUI.py
@@ -64,11 +64,11 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:bookmarks", "image",
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( GafferImage.OpenImageIOReader.supportedExtensions() ),
-			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only image files",
-			"fileSystemPathPlugValueWidget:includeSequences", True,
+			"path:leaf", True,
+			"path:bookmarks", "image",
+			"fileSystemPath:extensions", " ".join( GafferImage.OpenImageIOReader.supportedExtensions() ),
+			"fileSystemPath:extensionsLabel", "Show only image files",
+			"fileSystemPath:includeSequences", True,
 
 		],
 

--- a/python/GafferImageUI/TextUI.py
+++ b/python/GafferImageUI/TextUI.py
@@ -93,10 +93,10 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:bookmarks", "font",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:valid", True,
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "ttf" ] ),
+			"path:bookmarks", "font",
+			"path:leaf", True,
+			"path:valid", True,
+			"fileSystemPath:extensions", "ttf",
 
 		],
 

--- a/python/GafferRenderManUI/RenderManOptionsUI.py
+++ b/python/GafferRenderManUI/RenderManOptionsUI.py
@@ -293,9 +293,9 @@ Gaffer.Metadata.registerNode(
 		"options.statisticsFileName.value" : [
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:bookmarks", "statistics",
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "htm", "html", "txt", "stats" ] ),
+			"path:leaf", True,
+			"path:bookmarks", "statistics",
+			"fileSystemPath:extensions", "htm html txt stats",
 
 		],
 

--- a/python/GafferRenderManUI/RenderManRenderUI.py
+++ b/python/GafferRenderManUI/RenderManRenderUI.py
@@ -90,9 +90,9 @@ Gaffer.Metadata.registerNode(
 
 			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:bookmarks", "rib",
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "rib" ] ),
+			"path:leaf", True,
+			"path:bookmarks", "rib",
+			"fileSystemPath:extensions", "rib",
 
 		],
 

--- a/python/GafferRenderManUI/RenderManShaderBallUI.py
+++ b/python/GafferRenderManUI/RenderManShaderBallUI.py
@@ -57,9 +57,9 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:valid", True,
-			"pathPlugValueWidget:bookmarks", "texture",
+			"path:leaf", True,
+			"path:valid", True,
+			"path:bookmarks", "texture",
 
 		]
 

--- a/python/GafferSceneUI/AlembicSourceUI.py
+++ b/python/GafferSceneUI/AlembicSourceUI.py
@@ -68,10 +68,10 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:valid", True,
-			"pathPlugValueWidget:bookmarks", "sceneCache",
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "abc" ] ),
+			"path:leaf", True,
+			"path:valid", True,
+			"path:bookmarks", "sceneCache",
+			"fileSystemPath:extensions", "abc",
 
 		],
 

--- a/python/GafferSceneUI/ExternalProceduralUI.py
+++ b/python/GafferSceneUI/ExternalProceduralUI.py
@@ -63,8 +63,8 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:bookmarks", "procedurals",
+			"path:leaf", True,
+			"path:bookmarks", "procedurals",
 
 
 		],

--- a/python/GafferSceneUI/OutputsUI.py
+++ b/python/GafferSceneUI/OutputsUI.py
@@ -94,8 +94,8 @@ Gaffer.Metadata.registerNode(
 		"outputs.*.fileName" : [
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:bookmarks", "image",
-			"pathPlugValueWidget:leaf", True,
+			"path:bookmarks", "image",
+			"path:leaf", True,
 
 		],
 

--- a/python/GafferSceneUI/RenderUI.py
+++ b/python/GafferSceneUI/RenderUI.py
@@ -91,7 +91,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
+			"path:leaf", True,
 
 			"layout:activator", "modeIsSceneDescription",
 

--- a/python/GafferSceneUI/SceneReaderUI.py
+++ b/python/GafferSceneUI/SceneReaderUI.py
@@ -72,11 +72,11 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:valid", True,
-			"pathPlugValueWidget:bookmarks", "sceneCache",
-			"fileSystemPathPlugValueWidget:extensions", lambda plug : IECore.StringVectorData( IECore.SceneInterface.supportedExtensions() ),
-			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only cache files",
+			"path:leaf", True,
+			"path:valid", True,
+			"path:bookmarks", "sceneCache",
+			"fileSystemPath:extensions", " ".join( IECore.SceneInterface.supportedExtensions() ),
+			"fileSystemPath:extensionsLabel", "Show only cache files",
 
 		],
 

--- a/python/GafferSceneUI/SceneWriterUI.py
+++ b/python/GafferSceneUI/SceneWriterUI.py
@@ -64,10 +64,10 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:bookmarks", "sceneCache",
-			"fileSystemPathPlugValueWidget:extensions", lambda plug : IECore.StringVectorData( IECore.SceneInterface.supportedExtensions( IECore.IndexedIO.OpenMode.Write ) ),
-			"fileSystemPathPlugValueWidget:extensionsLabel", "Show only cache files",
+			"path:leaf", True,
+			"path:bookmarks", "sceneCache",
+			"fileSystemPath:extensions", " ".join( IECore.SceneInterface.supportedExtensions( IECore.IndexedIO.OpenMode.Write ) ),
+			"fileSystemPath:extensionsLabel", "Show only cache files",
 
 		],
 

--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -130,7 +130,7 @@ Gaffer.Metadata.registerNode(
 		"options.renderCamera.value" : [
 
 			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
-			"pathPlugValueWidget:valid", True,
+			"path:valid", True,
 			"scenePathPlugValueWidget:setNames", IECore.StringVectorData( [ "__cameras" ] ),
 			"scenePathPlugValueWidget:setsLabel", "Show only cameras",
 

--- a/python/GafferSceneUI/TextUI.py
+++ b/python/GafferSceneUI/TextUI.py
@@ -76,10 +76,10 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
-			"pathPlugValueWidget:bookmarks", "font",
-			"pathPlugValueWidget:leaf", True,
-			"pathPlugValueWidget:valid", True,
-			"fileSystemPathPlugValueWidget:extensions", IECore.StringVectorData( [ "ttf" ] ),
+			"path:bookmarks", "font",
+			"path:leaf", True,
+			"path:valid", True,
+			"fileSystemPath:extensions", "ttf",
 
 		],
 

--- a/python/GafferUI/DocumentationAlgo.py
+++ b/python/GafferUI/DocumentationAlgo.py
@@ -202,7 +202,7 @@ def __nodeDocumentation( node ) :
 			result += "\n\n" + __heading( plug.relativeName( node ), 1 )
 			result += description
 
-			extensions = Gaffer.Metadata.value( plug, "fileSystemPathPlugValueWidget:extensions" ) or []
+			extensions = Gaffer.Metadata.value( plug, "fileSystemPath:extensions" ) or []
 			if extensions :
 				result += "\n\n**Supported file extensions** : "+ ", ".join( extensions )
 

--- a/python/GafferUI/FileSystemPathPlugValueWidget.py
+++ b/python/GafferUI/FileSystemPathPlugValueWidget.py
@@ -39,10 +39,10 @@ import GafferUI
 
 ## Supported plug metadata :
 #
-# - "fileSystemPathPlugValueWidget:extensions"
-# - "fileSystemPathPlugValueWidget:extensionsLabel"
-# - "fileSystemPathPlugValueWidget:includeSequences"
-# - "fileSystemPathPlugValueWidget:includeSequenceFrameRange"
+# - "fileSystemPath:extensions"
+# - "fileSystemPath:extensionsLabel"
+# - "fileSystemPath:includeSequences"
+# - "fileSystemPath:includeSequenceFrameRange"
 #	Note that includeSequenceFrameRange is primarily used
 #	by GafferCortex. Think twice before using it elsewhere
 #	as it may not exist in the future.
@@ -73,7 +73,7 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
 		dialogue = GafferUI.PathPlugValueWidget._pathChooserDialogue( self )
 
-		if Gaffer.Metadata.value( self.getPlug(), "fileSystemPathPlugValueWidget:includeSequences" ) :
+		if self.__metadataValue( "includeSequences" ) :
 
 			columns = dialogue.pathChooserWidget().pathListingWidget().getColumns()
 			columns.append( GafferUI.PathListingWidget.StandardColumn( "Frame Range", "fileSystem:frameRange" ) )
@@ -85,12 +85,12 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
 		GafferUI.PathPlugValueWidget._updateFromPlug( self )
 
-		includeSequences = Gaffer.Metadata.value( self.getPlug(), "fileSystemPathPlugValueWidget:includeSequences" ) or False
+		includeSequences = self.__metadataValue( "includeSequences" ) or False
 
 		self.path().setFilter(
 			Gaffer.FileSystemPath.createStandardFilter(
 				self.__extensions(),
-				Gaffer.Metadata.value( self.getPlug(), "fileSystemPathPlugValueWidget:extensionsLabel" ) or "",
+				self.__metadataValue( "extensionsLabel" ) or "",
 				includeSequenceFilter = includeSequences,
 			)
 		)
@@ -99,7 +99,7 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
 	def _setPlugFromPath( self, path ) :
 
-		if Gaffer.Metadata.value( self.getPlug(), "fileSystemPathPlugValueWidget:includeSequenceFrameRange" ) :
+		if self.__metadataValue( "includeSequenceFrameRange" ) :
 			sequence = path.fileSequence()
 			if sequence :
 				self.getPlug().setValue( str(sequence) )
@@ -112,10 +112,19 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 		if self.getPlug() is None :
 			return []
 
-		extensions = Gaffer.Metadata.value( self.getPlug(), "fileSystemPathPlugValueWidget:extensions" ) or []
+		extensions = self.__metadataValue( "extensions" ) or []
 		if isinstance( extensions, str ) :
 			extensions = extensions.split()
 		else :
 			extensions = list( extensions )
 
 		return extensions
+
+	def __metadataValue( self, name ) :
+
+		v = Gaffer.Metadata.value( self.getPlug(), "fileSystemPath:" + name )
+		if v is None :
+			# Fall back to old metadata names
+			v = Gaffer.Metadata.value( self.getPlug(), "fileSystemPathPlugValueWidget:" + name )
+
+		return v

--- a/python/GafferUI/FileSystemPathVectorDataPlugValueWidget.py
+++ b/python/GafferUI/FileSystemPathVectorDataPlugValueWidget.py
@@ -1,0 +1,72 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+
+## Supported plug metadata :
+#
+# - "fileSystemPath:extensions"
+# - "fileSystemPath:extensionsLabel"
+class FileSystemPathVectorDataPlugValueWidget( GafferUI.PathVectorDataPlugValueWidget ) :
+
+	def __init__( self, plug, **kw ) :
+
+		GafferUI.PathVectorDataPlugValueWidget.__init__( self, plug, Gaffer.FileSystemPath(), **kw )
+
+	def _updateFromPlug( self ) :
+
+		GafferUI.PathVectorDataPlugValueWidget._updateFromPlug( self )
+
+		self.path().setFilter(
+			Gaffer.FileSystemPath.createStandardFilter(
+				self.__extensions(),
+				Gaffer.Metadata.value( self.getPlug(), "fileSystemPath:extensionsLabel" ) or "",
+			)
+		)
+
+	def __extensions( self ) :
+
+		if self.getPlug() is None :
+			return []
+
+		extensions = Gaffer.Metadata.value( self.getPlug(), "fileSystemPath:extensions" ) or []
+		if isinstance( extensions, str ) :
+			extensions = extensions.split()
+		else :
+			extensions = list( extensions )
+
+		return extensions

--- a/python/GafferUI/PathPlugValueWidget.py
+++ b/python/GafferUI/PathPlugValueWidget.py
@@ -45,9 +45,9 @@ import GafferUI
 ## Supported plug metadata - used to provide arguments to a
 # PathChooserDialogue :
 #
-# - "pathPlugValueWidget:leaf"
-# - "pathPlugValueWidget:valid"
-# - "pathPlugValueWidget:bookmarks"
+# - "path:leaf"
+# - "path:valid"
+# - "path:bookmarks"
 class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	## path should be an instance of Gaffer.Path, optionally with
@@ -114,10 +114,10 @@ class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 		# get the keywords for the dialogue constructor
 		# from the plug metadata.
 		pathChooserDialogueKeywords = {}
-		pathChooserDialogueKeywords["leaf"] = Gaffer.Metadata.value( self.getPlug(), "pathPlugValueWidget:leaf" )
-		pathChooserDialogueKeywords["valid"] = Gaffer.Metadata.value( self.getPlug(), "pathPlugValueWidget:valid" )
+		pathChooserDialogueKeywords["leaf"] = self.__metadataValue( "leaf" )
+		pathChooserDialogueKeywords["valid"] = self.__metadataValue( "valid" )
 
-		bookmarks = Gaffer.Metadata.value( self.getPlug(), "pathPlugValueWidget:bookmarks" )
+		bookmarks = self.__metadataValue( "bookmarks" )
 		if bookmarks is not None :
 			pathChooserDialogueKeywords["bookmarks"] = GafferUI.Bookmarks.acquire( self.getPlug(), type( pathCopy ), bookmarks )
 
@@ -172,3 +172,12 @@ class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if chosenPath is not None :
 			self.__path.setFromString( str( chosenPath ) )
 			self.__setPlugValue()
+
+	def __metadataValue( self, name ) :
+
+		v = Gaffer.Metadata.value( self.getPlug(), "path:" + name )
+		if v is None :
+			# Fall back to old metadata names
+			v = Gaffer.Metadata.value( self.getPlug(), "pathPlugValueWidget:" + name )
+
+		return v

--- a/python/GafferUI/PathVectorDataPlugValueWidget.py
+++ b/python/GafferUI/PathVectorDataPlugValueWidget.py
@@ -40,20 +40,34 @@ from __future__ import with_statement
 import Gaffer
 import GafferUI
 
+## Supported plug metadata - used to provide arguments to a
+# PathChooserDialogue :
+#
+# - "path:leaf"
+# - "path:valid"
+# - "path:bookmarks"
 class PathVectorDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	## path should be an instance of Gaffer.Path, optionally with
 	# filters applied. It will be used to convert string values to
 	# paths for the path uis to edit.
+	#
+	# \deprecated The pathChooserDialogueKeywords argument will be removed
+	# in a future version - use metadata instead.
 	def __init__( self, plug, path, pathChooserDialogueKeywords={}, **kw ) :
 
-		self.__dataWidget = GafferUI.PathVectorDataWidget( path=path, pathChooserDialogueKeywords=pathChooserDialogueKeywords )
+		self.__dataWidget = GafferUI.PathVectorDataWidget( path=path, pathChooserDialogueKeywords=Gaffer.WeakMethod( self.__pathChooserDialogueKeywords ) )
 
 		GafferUI.PlugValueWidget.__init__( self, self.__dataWidget, plug, **kw )
 
 		self.__dataChangedConnection = self.__dataWidget.dataChangedSignal().connect( Gaffer.WeakMethod( self.__dataChanged ) )
+		self.__deprecatedPathChooserDialogueKeywords = pathChooserDialogueKeywords
 
 		self._updateFromPlug()
+
+	def path( self ) :
+
+		return self.__dataWidget.path()
 
 	def _updateFromPlug( self ) :
 
@@ -69,3 +83,20 @@ class PathVectorDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			with Gaffer.BlockedConnection( self._plugConnections() ) :
 				self.getPlug().setValue( self.__dataWidget.getData()[0] )
+
+	def __pathChooserDialogueKeywords( self ) :
+
+		result = {}
+		result["leaf"] = Gaffer.Metadata.value( self.getPlug(), "path:leaf" )
+		result["valid"] = Gaffer.Metadata.value( self.getPlug(), "path:valid" )
+
+		bookmarks = Gaffer.Metadata.value( self.getPlug(), "path:bookmarks" )
+		if bookmarks is not None :
+			result["bookmarks"] = GafferUI.Bookmarks.acquire( self.getPlug(), type( self.path() ), bookmarks )
+
+		if callable( self.__deprecatedPathChooserDialogueKeywords ) :
+			result.update( self.__deprecatedPathChooserDialogueKeywords() )
+		else :
+			result.update( self.__deprecatedPathChooserDialogueKeywords )
+
+		return result

--- a/python/GafferUI/PathVectorDataWidget.py
+++ b/python/GafferUI/PathVectorDataWidget.py
@@ -60,6 +60,10 @@ class PathVectorDataWidget( GafferUI.VectorDataWidget ) :
 
 		self.__editConnection = self.editSignal().connect( Gaffer.WeakMethod( self.__edit ) )
 
+	def path( self ) :
+
+		return self.__path
+
 	def setData( self, data ) :
 
 		if isinstance( data, list ) :

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -377,10 +377,17 @@ class _MetadataWidget( GafferUI.Widget ) :
 
 	def __update( self ) :
 
-		if self.__target is not None :
-			self._updateFromValue( Gaffer.Metadata.value( self.__target, self.__key ) )
-		else :
+		if self.__target is None :
 			self._updateFromValue( None )
+			return
+
+		v = Gaffer.Metadata.value( self.__target, self.__key )
+		if v is None :
+			k = self.__fallbackKey( self.__key )
+			if k is not None :
+				v = Gaffer.Metadata.value( self.__target, k )
+
+		self._updateFromValue( v )
 
 	def __nodeMetadataChanged( self, nodeTypeId, key, node ) :
 
@@ -400,6 +407,18 @@ class _MetadataWidget( GafferUI.Widget ) :
 
 		if Gaffer.MetadataAlgo.affectedByChange( self.__target, nodeTypeId, plugPath, plug ) :
 			self.__update()
+
+	@staticmethod
+	def __fallbackKey( k ) :
+
+		for oldPrefix, newPrefix in [
+			( "pathPlugValueWidget:", "path:" ),
+			( "fileSystemPathPlugValueWidget:", "fileSystemPath:" ),
+		] :
+			if k.startswith( newPrefix ) :
+				return k.replace( newPrefix, oldPrefix )
+
+		return None
 
 class _BoolMetadataWidget( _MetadataWidget ) :
 
@@ -1697,14 +1716,14 @@ class _PlugEditor( GafferUI.Widget ) :
 
 	__MetadataDefinition = collections.namedtuple( "MetadataDefinition", ( "key", "label", "metadataWidgetType", "plugValueWidgetType" ) )
 	__metadataDefinitions = (
-		__MetadataDefinition( "fileSystemPathPlugValueWidget:extensions", "File Extensions", _StringMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
-		__MetadataDefinition( "pathPlugValueWidget:bookmarks", "Bookmarks Category", _StringMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
-		__MetadataDefinition( "pathPlugValueWidget:valid", "File Must Exist", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
-		__MetadataDefinition( "pathPlugValueWidget:leaf", "No Directories", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
-		__MetadataDefinition( "fileSystemPathPlugValueWidget:includeSequences", "Allow sequences", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
+		__MetadataDefinition( "fileSystemPath:extensions", "File Extensions", _StringMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
+		__MetadataDefinition( "path:bookmarks", "Bookmarks Category", _StringMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
+		__MetadataDefinition( "path:valid", "File Must Exist", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
+		__MetadataDefinition( "path:leaf", "No Directories", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
+		__MetadataDefinition( "fileSystemPath:includeSequences", "Allow sequences", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
 		# Note that includeSequenceFrameRange is primarily used by GafferCortex.
 		# Think twice before using it elsewhere	as it may not exist in the future.
-		__MetadataDefinition( "fileSystemPathPlugValueWidget:includeSequenceFrameRange", "Sequences include frame range", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
+		__MetadataDefinition( "fileSystemPath:includeSequenceFrameRange", "Sequences include frame range", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
 	)
 
 	__GadgetDefinition = collections.namedtuple( "GadgetDefinition", ( "label", "plugType", "metadata" ) )

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -1626,13 +1626,13 @@ class _PlugEditor( GafferUI.Widget ) :
 
 	def __updateWidgetSettings( self ) :
 
-		widgetType = None
+		widgetType = ""
 		if self.getPlug() is not None :
-			widgetType = Gaffer.Metadata.value( self.getPlug(), "plugValueWidget:type" )
+			widgetType = Gaffer.Metadata.value( self.getPlug(), "plugValueWidget:type" ) or ""
 
 		for m in self.__metadataDefinitions :
 			widget = self.__metadataWidgets[m.key]
-			widget.parent().setEnabled( m.plugValueWidgetType == widgetType )
+			widget.parent().setEnabled( Gaffer.StringAlgo.match( widgetType, m.plugValueWidgetType ) )
 
 		self.__metadataWidgets["connectionGadget:color"].parent().setEnabled(
 			self.getPlug() is not None and self.getPlug().direction() == Gaffer.Plug.Direction.In
@@ -1709,6 +1709,7 @@ class _PlugEditor( GafferUI.Widget ) :
 		__WidgetDefinition( "Checkbox", Gaffer.IntPlug, "GafferUI.BoolPlugValueWidget" ),
 		__WidgetDefinition( "Text Region", Gaffer.StringPlug, "GafferUI.MultiLineStringPlugValueWidget" ),
 		__WidgetDefinition( "File Chooser", Gaffer.StringPlug, "GafferUI.FileSystemPathPlugValueWidget" ),
+		__WidgetDefinition( "File Chooser", Gaffer.StringVectorDataPlug, "GafferUI.FileSystemPathVectorDataPlugValueWidget" ),
 		__WidgetDefinition( "Presets Menu", Gaffer.ValuePlug, "GafferUI.PresetsPlugValueWidget" ),
 		__WidgetDefinition( "Connection", Gaffer.Plug, "GafferUI.ConnectionPlugValueWidget" ),
 		__WidgetDefinition( "None", Gaffer.Plug, "" ),
@@ -1716,14 +1717,14 @@ class _PlugEditor( GafferUI.Widget ) :
 
 	__MetadataDefinition = collections.namedtuple( "MetadataDefinition", ( "key", "label", "metadataWidgetType", "plugValueWidgetType" ) )
 	__metadataDefinitions = (
-		__MetadataDefinition( "fileSystemPath:extensions", "File Extensions", _StringMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
-		__MetadataDefinition( "path:bookmarks", "Bookmarks Category", _StringMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
-		__MetadataDefinition( "path:valid", "File Must Exist", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
-		__MetadataDefinition( "path:leaf", "No Directories", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
-		__MetadataDefinition( "fileSystemPath:includeSequences", "Allow sequences", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
+		__MetadataDefinition( "fileSystemPath:extensions", "File Extensions", _StringMetadataWidget, "GafferUI.FileSystemPath*PlugValueWidget" ),
+		__MetadataDefinition( "path:bookmarks", "Bookmarks Category", _StringMetadataWidget, "GafferUI.FileSystemPath*PlugValueWidget" ),
+		__MetadataDefinition( "path:valid", "File Must Exist", _BoolMetadataWidget, "GafferUI.FileSystemPath*PlugValueWidget" ),
+		__MetadataDefinition( "path:leaf", "No Directories", _BoolMetadataWidget, "GafferUI.FileSystemPath*PlugValueWidget" ),
+		__MetadataDefinition( "fileSystemPath:includeSequences", "Allow sequences", _BoolMetadataWidget, "GafferUI.FileSystemPath*PlugValueWidget" ),
 		# Note that includeSequenceFrameRange is primarily used by GafferCortex.
 		# Think twice before using it elsewhere	as it may not exist in the future.
-		__MetadataDefinition( "fileSystemPath:includeSequenceFrameRange", "Sequences include frame range", _BoolMetadataWidget, "GafferUI.FileSystemPathPlugValueWidget" ),
+		__MetadataDefinition( "fileSystemPath:includeSequenceFrameRange", "Sequences include frame range", _BoolMetadataWidget, "GafferUI.FileSystemPath*PlugValueWidget" ),
 	)
 
 	__GadgetDefinition = collections.namedtuple( "GadgetDefinition", ( "label", "plugType", "metadata" ) )

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -439,7 +439,7 @@ class _StringMetadataWidget( _MetadataWidget ) :
 
 	def _updateFromValue( self, value ) :
 
-		self.__textWidget.setText( value if value is not None else "" )
+		self.__textWidget.setText( str( value ) if value is not None else "" )
 
 	def __editingFinished( self, *unused ) :
 

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -218,6 +218,7 @@ from PathPlugValueWidget import PathPlugValueWidget
 from FileSystemPathPlugValueWidget import FileSystemPathPlugValueWidget
 from VectorDataPlugValueWidget import VectorDataPlugValueWidget
 from PathVectorDataPlugValueWidget import PathVectorDataPlugValueWidget
+from FileSystemPathVectorDataPlugValueWidget import FileSystemPathVectorDataPlugValueWidget
 from PlugWidget import PlugWidget
 from PlugLayout import PlugLayout
 from EditorWidget import EditorWidget


### PR DESCRIPTION
This adds a widget for choosing an array of filenames - hopefully this does the trick for you @andrewkaufman? I was testing it by adding the following metadata to the WedgeUI strings plug :

```
"plugValueWidget:type", "GafferUI.FileSystemPathVectorDataPlugValueWidget",
"pathVectorDataPlugValueWidget:leaf", True,
"pathVectorDataPlugValueWidget:valid", True,
"pathVectorDataPlugValueWidget:bookmarks", "image",
"fileSystemPathVectorDataPlugValueWidget:extensions", "exr tiff png",
"fileSystemPathVectorDataPlugValueWidget:extensionsLabel", "Show only image files",
```

I've followed the convention of prefixing the metadata with the widget name, although it does feel unwieldy. Since these are all directly analogous to the non-array versions, I'm wondering if we shouldn't just use the same shorter "path:leaf" and "fileSystemPath:extensions" metadata for both types. It'd also be nice to add support for this to the UIEditor, but since this was meant to be a quick job I haven't looked at any of that...