### PR TITLE
Check eval light links

### DIFF
--- a/doc/source/Reference/ScriptingReference/SetExpressions/index.md
+++ b/doc/source/Reference/ScriptingReference/SetExpressions/index.md
@@ -13,7 +13,7 @@ Set memberships in this imaginary scene are as follows.
 
 ```eval_rst
 ===== ===== ===== ====
-set1  set2  set3  set2
+set1  set2  set3  set4
 ===== ===== ===== ====
 A B C B C D C D E E
 ===== ===== ===== ====


### PR DESCRIPTION
This should address the test failure you found, @johnhaddon.

I also cleaned up the section that checks the bits coming back from Arnold to make naming a little more consistent and added a commit that fixes a typo in the docs.

With these changes the tests run through fine for me. Let me know if you still see problems on your end please :)

I should stop relying on travis so much and run the tests locally more often. The failing test was probably never properly run before. Thanks for catching that :)