### PR TITLE
ExpressionUI Context Menu

### DIFF
--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -37,8 +37,11 @@
 #ifndef GAFFER_METADATAALGO_H
 #define GAFFER_METADATAALGO_H
 
+#include <vector>
+
 #include "IECore/TypeIds.h"
 
+#include "Gaffer/Node.h"
 #include "Gaffer/StringAlgo.h"
 
 namespace Gaffer
@@ -46,7 +49,6 @@ namespace Gaffer
 
 class GraphComponent;
 class Plug;
-class Node;
 
 namespace MetadataAlgo
 {
@@ -83,6 +85,17 @@ bool getReadOnly( const GraphComponent *graphComponent );
 /// is inherited. This is the method that should be used to determine if a graphComponent
 /// should be editable by the user or not.
 bool readOnly( const GraphComponent *graphComponent );
+
+/// Bookmarks
+/// =========
+///
+/// Node bookmarks can be used to mark a subset of a complex graph as important to the user.
+/// This metadata may be fetched by client code in order to provide convenient mechanisms for
+/// accessing the node and/or its plugs.
+
+void setBookmarked( Node *node, bool bookmarked, bool persistent = true );
+bool getBookmarked( const Node *node );
+void bookmarks( const Node *node, std::vector<NodePtr> &bookmarks );
 
 /// Utilities
 /// =========

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -387,7 +387,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 			( "/Pattern/Periodic Noise", "noise( \"perlin\", p, period )" ),
 			( "/Pattern/Cell Noise", "cellnoise( p )" ),
 
-			( "/String/Length", "length( str )" ),
+			( "/String/Length", "strlen( str )" ),
 			( "/String/Format", "format( \"\", ... )" ),
 			( "/String/Join", "concat( str0, str1 )" ),
 			( "/String/Split", "split( str, results )" ),

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -43,6 +43,8 @@ import Gaffer
 import GafferUI
 import GafferOSL
 
+import _CodeMenu
+
 Gaffer.Metadata.registerNode(
 
 	GafferOSL.OSLCode,
@@ -335,85 +337,19 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 
 	elif plug.isSame( node["code"] ) :
 
-		for label, text in reversed( [
-
-			( "/Math/Constants/Pi", "M_PI" ),
-			( "/Math/Angles/Radians", "radians( angleInDegrees )" ),
-			( "/Math/Angles/Degrees", "degrees( angleInRadians )" ),
-			( "/Math/Trigonometry/Sin", "sin( angleInRadians )" ),
-			( "/Math/Trigonometry/Cosine", "cos( angleInRadians )" ),
-			( "/Math/Trigonometry/Tangent", "tan( angleInRadians )" ),
-			( "/Math/Trigonometry/Arc Sin", "asin( y )" ),
-			( "/Math/Trigonometry/Arc Cosine", "acos( x )" ),
-			( "/Math/Trigonometry/Arc Tangent", "atan( yOverX )" ),
-			( "/Math/Trigonometry/Arc Tangent 2", "atan2( y, x )" ),
-			( "/Math/Exponents/Pow", "pow( x, y )" ),
-			( "/Math/Exponents/Exp", "exp( x )" ),
-			( "/Math/Exponents/Log", "log( x )" ),
-			( "/Math/Exponents/Square Root", "sqrt( x )" ),
-			( "/Math/Utility/Abs", "abs( x )" ),
-			( "/Math/Utility/Sign", "sign( x )" ),
-			( "/Math/Utility/Floor", "floor( x )" ),
-			( "/Math/Utility/Ceil", "ceil( x )" ),
-			( "/Math/Utility/Round", "round( x )" ),
-			( "/Math/Utility/Trunc", "trunc( x )" ),
-			( "/Math/Utility/Mod", "mod( x )" ),
-			( "/Math/Utility/Min", "min( a, b )" ),
-			( "/Math/Utility/Max", "max( a, b )" ),
-			( "/Math/Utility/Clamp", "clamp( x, minValue, maxValue )" ),
-			( "/Math/Utility/Mix", "mix( a, b, alpha )" ),
-			( "/Math/Geometry/Dot", "dot( a, b )" ),
-
-			( "/Geometry/Cross", "cross( a, b )" ),
-			( "/Geometry/Length", "length( V )" ),
-			( "/Geometry/Length", "distance( p0, p1 )" ),
-			( "/Geometry/Normalize", "normalize( V )" ),
-			( "/Geometry/Face Forward", "faceforward( N, I )" ),
-			( "/Geometry/Reflect", "reflect( I, N )" ),
-			( "/Geometry/Refract", "refract( I, N, eta )" ),
-			( "/Geometry/Rotate", "rotate( p, angle, p0, p1 )" ),
-			( "/Geometry/Transform", "transform( toSpace, p )" ),
-			( "/Geometry/Transform", "transform( fromSpace, toSpace, p )" ),
-
-			( "/Color/Luminance", "luminance( c )" ),
-			( "/Color/BlackBody", "blackbody( degreesKelvin )" ),
-			( "/Color/Wavelength Color", "wavelength_color( wavelengthNm )" ),
-			( "/Color/Transform", "transformc( fromSpace, toSpace, c )" ),
-
-			( "/Pattern/Step", "step( edge, x )" ),
-			( "/Pattern/Linear Step", "linearstep( edge0, edge1, x )" ),
-			( "/Pattern/Smooth Step", "smoothstep( edge0, edge1, x )" ),
-			( "/Pattern/Noise", "noise( \"perlin\", p )" ),
-			( "/Pattern/Periodic Noise", "noise( \"perlin\", p, period )" ),
-			( "/Pattern/Cell Noise", "cellnoise( p )" ),
-
-			( "/String/Length", "strlen( str )" ),
-			( "/String/Format", "format( \"\", ... )" ),
-			( "/String/Join", "concat( str0, str1 )" ),
-			( "/String/Split", "split( str, results )" ),
-			( "/String/Starts With", "startswith( str, prefix )" ),
-			( "/String/Ends With", "endswith( str, suffix )" ),
-			( "/String/Substring", "substr( str, start, length )" ),
-			( "/String/Get Char", "getchar( str, n )" ),
-			( "/String/Hash", "hash( str )" ),
-
-			( "/Texture/Texture", "texture( filename, s, t )" ),
-			( "/Texture/Environment", "environment( filename, R )" ),
-
-			( "/Parameter/Is Connected", "isconnected( parameter )" ),
-			( "/Parameter/Is Constant", "isconstant( parameter )" ),
-
-		] ) :
-
+		if len( menuDefinition.items() ) :
 			menuDefinition.prepend( "/InsertDivider", { "divider" : True } )
 
-			menuDefinition.prepend(
-				"/Insert" + label,
-				{
-					"command" : functools.partial( plugValueWidget.textWidget().insertText, text ),
-					"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
-				},
-			)
+		menuDefinition.prepend(
+			"/Insert",
+			{
+				"subMenu" : functools.partial(
+					_CodeMenu.commonFunctionMenu,
+					command = plugValueWidget.textWidget().insertText,
+					activator = lambda : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
+				),
+			},
+		)
 
 __plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )
 

--- a/python/GafferOSLUI/OSLExpressionEngineUI.py
+++ b/python/GafferOSLUI/OSLExpressionEngineUI.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, John Haddon. All rights reserved.
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,10 +34,31 @@
 #
 ##########################################################################
 
-import OSLShaderUI
-import OSLImageUI
-import OSLObjectUI
-import OSLCodeUI
-import OSLExpressionEngineUI
+import functools
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferOSLUI" )
+import Gaffer
+import GafferUI
+
+import _CodeMenu
+
+def __oslPopupMenu( menuDefinition, widget ) :
+
+	node = widget.node()
+	if not isinstance( node, Gaffer.Expression ) or node.getExpression()[-1] != "OSL" :
+		return
+
+	if len( menuDefinition.items() ) :
+		menuDefinition.append( "/InsertOSLDivider", { "divider" : True } )
+
+	menuDefinition.append(
+		"/Insert OSL",
+		{
+			"subMenu" : functools.partial(
+				_CodeMenu.commonFunctionMenu,
+				command = widget.textWidget().insertText,
+				activator = lambda : widget.textWidget().getEditable() and not Gaffer.MetadataAlgo.readOnly( node["__expression"] ),
+			),
+		},
+	)
+
+GafferUI.ExpressionUI.ExpressionWidget.expressionContextMenuSignal().connect( __oslPopupMenu, scoped = False )

--- a/python/GafferOSLUI/_CodeMenu.py
+++ b/python/GafferOSLUI/_CodeMenu.py
@@ -1,0 +1,126 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import IECore
+
+import Gaffer
+import GafferUI
+
+def commonFunctionMenu( command, activator ) :
+
+	menuDefinition = IECore.MenuDefinition()
+
+	for label, text in [
+
+		( "/Math/Constants/Pi", "M_PI" ),
+		( "/Math/Angles/Radians", "radians( angleInDegrees )" ),
+		( "/Math/Angles/Degrees", "degrees( angleInRadians )" ),
+		( "/Math/Trigonometry/Sin", "sin( angleInRadians )" ),
+		( "/Math/Trigonometry/Cosine", "cos( angleInRadians )" ),
+		( "/Math/Trigonometry/Tangent", "tan( angleInRadians )" ),
+		( "/Math/Trigonometry/Arc Sin", "asin( y )" ),
+		( "/Math/Trigonometry/Arc Cosine", "acos( x )" ),
+		( "/Math/Trigonometry/Arc Tangent", "atan( yOverX )" ),
+		( "/Math/Trigonometry/Arc Tangent 2", "atan2( y, x )" ),
+		( "/Math/Exponents/Pow", "pow( x, y )" ),
+		( "/Math/Exponents/Exp", "exp( x )" ),
+		( "/Math/Exponents/Log", "log( x )" ),
+		( "/Math/Exponents/Square Root", "sqrt( x )" ),
+		( "/Math/Utility/Abs", "abs( x )" ),
+		( "/Math/Utility/Sign", "sign( x )" ),
+		( "/Math/Utility/Floor", "floor( x )" ),
+		( "/Math/Utility/Ceil", "ceil( x )" ),
+		( "/Math/Utility/Round", "round( x )" ),
+		( "/Math/Utility/Trunc", "trunc( x )" ),
+		( "/Math/Utility/Mod", "mod( x )" ),
+		( "/Math/Utility/Min", "min( a, b )" ),
+		( "/Math/Utility/Max", "max( a, b )" ),
+		( "/Math/Utility/Clamp", "clamp( x, minValue, maxValue )" ),
+		( "/Math/Utility/Mix", "mix( a, b, alpha )" ),
+		( "/Math/Geometry/Dot", "dot( a, b )" ),
+
+		( "/Geometry/Cross", "cross( a, b )" ),
+		( "/Geometry/Length", "length( V )" ),
+		( "/Geometry/Length", "distance( p0, p1 )" ),
+		( "/Geometry/Normalize", "normalize( V )" ),
+		( "/Geometry/Face Forward", "faceforward( N, I )" ),
+		( "/Geometry/Reflect", "reflect( I, N )" ),
+		( "/Geometry/Refract", "refract( I, N, eta )" ),
+		( "/Geometry/Rotate", "rotate( p, angle, p0, p1 )" ),
+		( "/Geometry/Transform", "transform( toSpace, p )" ),
+		( "/Geometry/Transform", "transform( fromSpace, toSpace, p )" ),
+
+		( "/Color/Luminance", "luminance( c )" ),
+		( "/Color/BlackBody", "blackbody( degreesKelvin )" ),
+		( "/Color/Wavelength Color", "wavelength_color( wavelengthNm )" ),
+		( "/Color/Transform", "transformc( fromSpace, toSpace, c )" ),
+
+		( "/Pattern/Step", "step( edge, x )" ),
+		( "/Pattern/Linear Step", "linearstep( edge0, edge1, x )" ),
+		( "/Pattern/Smooth Step", "smoothstep( edge0, edge1, x )" ),
+		( "/Pattern/Noise", "noise( \"perlin\", p )" ),
+		( "/Pattern/Periodic Noise", "noise( \"perlin\", p, period )" ),
+		( "/Pattern/Cell Noise", "cellnoise( p )" ),
+
+		( "/String/Length", "strlen( str )" ),
+		( "/String/Format", "format( \"\", ... )" ),
+		( "/String/Join", "concat( str0, str1 )" ),
+		( "/String/Split", "split( str, results )" ),
+		( "/String/Starts With", "startswith( str, prefix )" ),
+		( "/String/Ends With", "endswith( str, suffix )" ),
+		( "/String/Substring", "substr( str, start, length )" ),
+		( "/String/Get Char", "getchar( str, n )" ),
+		( "/String/Hash", "hash( str )" ),
+
+		( "/Texture/Texture", "texture( filename, s, t )" ),
+		( "/Texture/Environment", "environment( filename, R )" ),
+
+		( "/Parameter/Is Connected", "isconnected( parameter )" ),
+		( "/Parameter/Is Constant", "isconstant( parameter )" ),
+
+	] :
+
+		menuDefinition.append(
+			label,
+			{
+				"command" : functools.partial( command, text ),
+				"active" : functools.partial( activator ),
+			},
+		)
+
+	return menuDefinition

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -72,6 +72,49 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n ), True )
 		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n["op1"] ), True )
 
+	def testBookmarks( self ) :
+
+		b = Gaffer.Box()
+		b["n0"] = GafferTest.AddNode()
+		b["n1"] = GafferTest.AddNode()
+
+		self.assertEqual( Gaffer.MetadataAlgo.getBookmarked( b ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getBookmarked( b["n0"] ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getBookmarked( b["n1"] ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.bookmarks( b ), [] )
+
+		Gaffer.MetadataAlgo.setBookmarked( b["n0"], True )
+
+		self.assertEqual( Gaffer.MetadataAlgo.getBookmarked( b ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getBookmarked( b["n0"] ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.getBookmarked( b["n1"] ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.bookmarks( b ), [ b["n0"] ] )
+
+		Gaffer.MetadataAlgo.setBookmarked( b["n1"], True )
+
+		self.assertEqual( Gaffer.MetadataAlgo.getBookmarked( b ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getBookmarked( b["n0"] ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.getBookmarked( b["n1"] ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.bookmarks( b ), [ b["n0"], b["n1"] ] )
+
+		Gaffer.MetadataAlgo.setBookmarked( b["n0"], False )
+
+		self.assertEqual( Gaffer.MetadataAlgo.getBookmarked( b ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getBookmarked( b["n0"] ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getBookmarked( b["n1"] ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.bookmarks( b ), [ b["n1"] ] )
+
+		Gaffer.MetadataAlgo.setBookmarked( b, True )
+
+		self.assertEqual( Gaffer.MetadataAlgo.getBookmarked( b ), True )
+		self.assertTrue( b not in Gaffer.MetadataAlgo.bookmarks( b ) )
+
+		s = Gaffer.ScriptNode()
+		s.addChild( b )
+
+		self.assertEqual( Gaffer.MetadataAlgo.getBookmarked( b ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.bookmarks( s ), [ b ] )
+
 	def testAffected( self ) :
 
 		n = GafferTest.CompoundPlugNode()

--- a/python/GafferUI/ExpressionUI.py
+++ b/python/GafferUI/ExpressionUI.py
@@ -51,7 +51,7 @@ Gaffer.Metadata.registerNode(
 	scripted expressions.
 	""",
 
-	"layout:customWidget:Expression:widgetType", "GafferUI.ExpressionUI._ExpressionWidget",
+	"layout:customWidget:Expression:widgetType", "GafferUI.ExpressionUI.ExpressionWidget",
 
 	plugs = {
 
@@ -140,10 +140,10 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 
 __popupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __popupMenu )
 
-# _ExpressionPlugValueWidget
+# ExpressionWidget
 ##########################################################################
 
-class _ExpressionWidget( GafferUI.Widget ) :
+class ExpressionWidget( GafferUI.Widget ) :
 
 	def __init__( self, node, **kw ) :
 
@@ -166,6 +166,7 @@ class _ExpressionWidget( GafferUI.Widget ) :
 			self.__activatedConnection = self.__textWidget.activatedSignal().connect( Gaffer.WeakMethod( self.__activated ) )
 			self.__editingFinishedConnection = self.__textWidget.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__editingFinished ) )
 			self.__dropTextConnection = self.__textWidget.dropTextSignal().connect( Gaffer.WeakMethod( self.__dropText ) )
+			self.__contextMenuConnection = self.__textWidget.contextMenuSignal().connect( Gaffer.WeakMethod( self.__expressionContextMenu ) )
 
 			self.__messageWidget = GafferUI.MessageWidget()
 
@@ -173,6 +174,48 @@ class _ExpressionWidget( GafferUI.Widget ) :
 		self.__errorConnection = self.__node.errorSignal().connect( Gaffer.WeakMethod( self.__error ) )
 
 		self.__update()
+
+	def node( self ) :
+
+		return self.__node
+
+	def textWidget( self ) :
+
+		return self.__textWidget
+
+	__expressionContextMenuSignal = Gaffer.Signal2()
+	## This signal is emitted whenever a popup menu
+	# for an ExpressionWidget is about to be shown.
+	# This provides an opportunity to customise the
+	# menu from external code. The signature for
+	# slots is ( menuDefinition, widget ), and slots
+	# should just modify the menu definition in place.
+	@classmethod
+	def expressionContextMenuSignal( cls ) :
+
+		return cls.__expressionContextMenuSignal
+
+	def __expressionContextMenuDefinition( self ) :
+
+		menuDefinition = IECore.MenuDefinition()
+
+		self.expressionContextMenuSignal()( menuDefinition, self )
+
+		return menuDefinition
+
+	def __expressionContextMenu( self, *unused ) :
+
+		menuDefinition = self.__expressionContextMenuDefinition()
+		if not len( menuDefinition.items() ) :
+			return False
+
+		title = self.__node.relativeName( self.__node.scriptNode() )
+		title = ".".join( [ IECore.CamelCase.join( IECore.CamelCase.split( x ) ) for x in title.split( "." ) ] )
+
+		self.____expressionContextMenu = GafferUI.Menu( menuDefinition, title = title )
+		self.____expressionContextMenu.popup()
+
+		return True
 
 	def __update( self ) :
 

--- a/python/GafferUI/GraphBookmarksUI.py
+++ b/python/GafferUI/GraphBookmarksUI.py
@@ -50,7 +50,7 @@ def appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition ) :
 	menuDefinition.append(
 		"/Bookmarked",
 		{
-			"checkBox" : __getBookmarked( node ),
+			"checkBox" : Gaffer.MetadataAlgo.getBookmarked( node ),
 			"command" : functools.partial( __setBookmarked, node ),
 			"active" : not Gaffer.MetadataAlgo.readOnly( node ),
 		}
@@ -60,7 +60,7 @@ def appendPlugContextMenuDefinitions( nodeGraph, plug, menuDefinition ) :
 
 	parent = nodeGraph.graphGadget().getRoot()
 	dividerAdded = False
-	for bookmark in __bookmarks( parent ) :
+	for bookmark in Gaffer.MetadataAlgo.bookmarks( parent ) :
 
 		nodeGadget = nodeGraph.graphGadget().nodeGadget( bookmark )
 		if nodeGadget is None :
@@ -97,18 +97,10 @@ def appendPlugContextMenuDefinitions( nodeGraph, plug, menuDefinition ) :
 # Internal implementation
 ##########################################################################
 
-def __getBookmarked( node ) :
-
-	return Gaffer.Metadata.value( node, "graphBookmarks:bookmarked" ) or False
-
 def __setBookmarked( node, bookmarked ) :
 
 	with Gaffer.UndoContext( node.scriptNode() ) :
-		Gaffer.Metadata.registerValue( node, "graphBookmarks:bookmarked", bookmarked )
-
-def __bookmarks( parent ) :
-
-	return [ n for n in parent.children( Gaffer.Node ) if __getBookmarked( n ) ]
+		Gaffer.MetadataAlgo.setBookmarked( node, bookmarked )
 
 ## \todo Perhaps this functionality should be provided by the
 # GraphGadget or NodeGadget class?

--- a/src/Gaffer/MetadataAlgo.cpp
+++ b/src/Gaffer/MetadataAlgo.cpp
@@ -50,6 +50,9 @@ namespace
 {
 
 InternedString g_readOnlyName( "readOnly" );
+InternedString g_bookmarkedName( "bookmarked" );
+/// \todo: remove when we're no longer concerned with compatibility
+InternedString g_oldBookmarkedName( "graphBookmarks:bookmarked" );
 
 size_t findNth( const std::string &s, char c, int n )
 {
@@ -108,6 +111,36 @@ bool readOnly( const GraphComponent *graphComponent )
 		graphComponent = graphComponent->parent<GraphComponent>();
 	}
 	return false;
+}
+
+void setBookmarked( Node *node, bool bookmarked, bool persistent /* = true */ )
+{
+	Metadata::registerValue( node, g_bookmarkedName, new BoolData( bookmarked ), persistent );
+}
+
+bool getBookmarked( const Node *node )
+{
+	ConstBoolDataPtr d = Metadata::value<BoolData>( node, g_bookmarkedName );
+	if( !d )
+	{
+		/// \todo: remove when we're no longer concerned with compatibility
+		d = Metadata::value<BoolData>( node, g_oldBookmarkedName );
+	}
+
+	return d ? d->readable() : false;
+}
+
+void bookmarks( const Node *node, std::vector<NodePtr> &bookmarks )
+{
+	bookmarks.clear();
+
+	for( NodeIterator it( node ); !it.done(); ++it )
+	{
+		if( getBookmarked( it->get() ) )
+		{
+			bookmarks.push_back( *it );
+		}
+	}
 }
 
 bool affectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug )

--- a/src/GafferBindings/MetadataAlgoBinding.cpp
+++ b/src/GafferBindings/MetadataAlgoBinding.cpp
@@ -41,9 +41,30 @@
 #include "Gaffer/Plug.h"
 #include "Gaffer/Node.h"
 
+#include "GafferBindings/MetadataAlgoBinding.h"
+
 using namespace boost::python;
 using namespace Gaffer;
 using namespace Gaffer::MetadataAlgo;
+
+namespace
+{
+
+static boost::python::list bookmarksWrapper( const Node *node )
+{
+	std::vector<NodePtr> bookmarks;
+	MetadataAlgo::bookmarks( node, bookmarks );
+
+	boost::python::list result;
+	for( std::vector<NodePtr>::const_iterator it = bookmarks.begin(), endIt = bookmarks.end(); it != endIt; ++it )
+	{
+		result.append( *it );
+	}
+
+	return result;
+}
+
+}
 
 namespace GafferBindings
 {
@@ -57,7 +78,9 @@ void bindMetadataAlgo()
 	def( "setReadOnly", &setReadOnly, ( arg( "graphComponent" ), arg( "readOnly"), arg( "persistent" ) = true ) );
 	def( "getReadOnly", &getReadOnly );
 	def( "readOnly", &readOnly );
-
+	def( "setBookmarked", &setBookmarked, ( arg( "graphComponent" ), arg( "bookmarked"), arg( "persistent" ) = true ) );
+	def( "getBookmarked", &getBookmarked );
+	def( "bookmarks", &bookmarksWrapper );
 	def(
 		"affectedByChange",
 		(bool (*)( const Plug *, IECore::TypeId, const MatchPattern &, const Plug * ))&affectedByChange,


### PR DESCRIPTION
I was setting up a Wedge using OSL Expressions, and I found myself constantly dropping down an OSLCode node just to find all those helper functions in the context menu. So I've added a context menu for Expressions, and exposed those functions (when the expression language is OSL). I also fixed one that was broken (461aad4). I wasn't sure about the names `OSLUIUtil` or `commonFunctionMenu()`, but it did seem useful (and less error prone) not to duplicate that giant list of functions.

I've also added bookmarked nodes (from GraphBookmarksUI) to the context menu (regardless of language) for easy insertion. Note that for python expressions scene and image plugs are included here, which is unfortunate since they are not supported. I think the way to remove those would be to make the `PythonExpressionEngine.indentifier()` more strict, but I was hesitant to do that, because it seems handy to still be able to drag/drop unsupported plugs which have supported children. Also note that the "Insert Bookmarks" menu item exists unconditionally, even when its empty. I thought this made it more obvious that bookmarks can exist and be useful in this context, which will will hopefully encourage people to use them more.

And finally, the main reason I started down this road was to solve an issue I was having with my Wedge expression. I was wedging a string list, and my OSL expression never seemed to evaluate as expected. The solution was to use a function as in 24f03e46e1aff4b6b43c9fc60745f7027793a4d3 and it seemed fiddly enough that I added it to the menu. Not sure if that's acceptable (or if the label is clear) since its not a proper OSL function on its own. I also wasn't sure if it actually needs a fix on our end or if its just the way OSL operates on string variables...