### PR TITLE
OSLShader : Allow vector -> color connections

### DIFF
--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -245,7 +245,7 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		self.assertNotEqual( h1, h2 )
 
-	def testCantConnectVectorToColor( self ) :
+	def testCanConnectVectorToColor( self ) :
 
 		globals = GafferOSL.OSLShader()
 		globals.loadShader( "Utility/Globals" )
@@ -253,7 +253,9 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		constant = GafferOSL.OSLShader()
 		constant.loadShader( "Surface/Constant" )
 
-		self.assertFalse( constant["parameters"]["Cs"].acceptsInput( globals["out"]["globalP"] ) )
+		self.assertTrue( constant["parameters"]["Cs"].acceptsInput( globals["out"]["globalP"] ) )
+		constant["parameters"]["Cs"].setInput( globals["out"]["globalP"] )
+		self.assertTrue( constant["parameters"]["Cs"].getInput().isSame( globals["out"]["globalP"] ) )
 
 	def testClosureParameters( self ) :
 

--- a/python/GafferOSLTest/ShadingEngineTest.py
+++ b/python/GafferOSLTest/ShadingEngineTest.py
@@ -374,6 +374,18 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		# Transform from world to object
 		self.assertEqual( p["Ci"], IECore.Color3fVectorData( [ IECore.Color3f( i + IECore.V3f( -2, 0, 0 ) ) for i in self.rectanglePoints()["P"] ] ) )
 
+	def testVectorToColorConnections( self ) :
+
+		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
+			IECore.Shader( "Utility/Globals", "shader", { "__handle" : "h" } ),
+			IECore.Shader( "Surface/Constant", "surface", { "Cs" : "link:h.globalP" } ),
+		] ) )
+
+		p = self.rectanglePoints()
+		r = e.shade( p )
+
+		for i, c in enumerate( r["Ci"] ) :
+			self.assertEqual( IECore.V3f( *c ), p["P"][i] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferOSL/OSLShader.cpp
+++ b/src/GafferOSL/OSLShader.cpp
@@ -218,11 +218,6 @@ bool OSLShader::acceptsInput( const Plug *plug, const Plug *inputPlug ) const
 			{
 				return false;
 			}
-			// osl disallows the connection of vectors to colours
-			if( plug->isInstanceOf( Color3fPlug::staticTypeId() ) && inputPlug->isInstanceOf( V3fPlug::staticTypeId() ) )
-			{
-				return false;
-			}
 			// and we can only connect closures into closures
 			if( plug->typeId() == Plug::staticTypeId() && inputPlug->typeId() != Plug::staticTypeId() )
 			{


### PR DESCRIPTION
We were disallowing these on the grounds that OSL doesn't allow it, but that turns out to be incorrect. I don't know if this is something that has changed or I was just wrong in the first place, but the additional ShadingEngine test demonstrates such a connection working, as does the OSLCode node interactively in the shader viewer.