### PR TITLE
TaskList : Fix `hash()` method

### DIFF
--- a/python/GafferDispatch/TaskList.py
+++ b/python/GafferDispatch/TaskList.py
@@ -52,8 +52,6 @@ class TaskList( GafferDispatch.TaskNode ) :
 		return self["sequence"].getValue()
 
 	def hash( self, context ) :
-		if self.requiresSequenceExecution() :
-			return IECore.MurmurHash().append( context.getFrame() )
 
 		return IECore.MurmurHash()
 


### PR DESCRIPTION
As soon as I merged #2044, I had a nagging doubt - why did a no-op need to append the frame to the hash? I figured it was doing that to work around a bug in the dispatcher - this PR reverts the `TaskList.hash()` method and fixes the dispatcher bug instead. Hopefully this makes sense?