### PR TITLE
ArnoldDisplacement : Fix `attributesHash()` signature

### DIFF
--- a/include/GafferArnold/ArnoldDisplacement.h
+++ b/include/GafferArnold/ArnoldDisplacement.h
@@ -83,8 +83,8 @@ class ArnoldDisplacement : public GafferScene::Shader
 
 	protected :
 
-		virtual void attributesHash( IECore::MurmurHash &h, const Gaffer::Plug* output ) const;
-		virtual IECore::ConstCompoundObjectPtr attributes( const Gaffer::Plug* output ) const;
+		virtual void attributesHash( const Gaffer::Plug *output, IECore::MurmurHash &h ) const;
+		virtual IECore::ConstCompoundObjectPtr attributes( const Gaffer::Plug *output ) const;
 
 		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
 

--- a/python/GafferArnoldTest/ArnoldDisplacementTest.py
+++ b/python/GafferArnoldTest/ArnoldDisplacementTest.py
@@ -39,6 +39,7 @@ import unittest
 import IECore
 
 import GafferTest
+import GafferScene
 import GafferSceneTest
 import GafferOSL
 import GafferArnold
@@ -117,6 +118,37 @@ class ArnoldDisplacementTest( GafferSceneTest.SceneTestCase ) :
 
 		d = GafferArnold.ArnoldDisplacement()
 		self.assertTrue( "ai:disp_map" not in d.attributes() )
+
+	def testAssignment( self ) :
+
+		s = GafferScene.Sphere()
+
+		n = GafferArnold.ArnoldShader()
+		n.loadShader( "noise" )
+
+		d = GafferArnold.ArnoldDisplacement()
+		d["map"].setInput( n["out"] )
+		d["height"].setValue( 2.5 )
+
+		f = GafferScene.PathFilter()
+		f["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		a = GafferScene.ShaderAssignment()
+		a["in"].setInput( s["out"] )
+		a["shader"].setInput( d["out"] )
+		a["filter"].setInput( f["out"] )
+
+		self.assertEqual(
+			a["out"].attributes( "/sphere" )["ai:disp_height"],
+			IECore.FloatData( 2.5 )
+		)
+
+		d["height"].setValue( 5 )
+
+		self.assertEqual(
+			a["out"].attributes( "/sphere" )["ai:disp_height"],
+			IECore.FloatData( 5 )
+		)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferArnold/ArnoldDisplacement.cpp
+++ b/src/GafferArnold/ArnoldDisplacement.cpp
@@ -144,7 +144,7 @@ void ArnoldDisplacement::affects( const Gaffer::Plug *input, AffectedPlugsContai
 	}
 }
 
-void ArnoldDisplacement::attributesHash( IECore::MurmurHash &h, const Gaffer::Plug *output ) const
+void ArnoldDisplacement::attributesHash( const Gaffer::Plug *output, IECore::MurmurHash &h ) const
 {
 	h.append( typeId() );
 	if( !enabledPlug()->getValue() )


### PR DESCRIPTION
This was broken in #2025.