### PR TITLE
"childNodesAreReadOnly" Metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 doc/html
 doc/python
 config.log
+.idea

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -81,9 +81,17 @@ namespace MetadataAlgo
 
 void setReadOnly( GraphComponent *graphComponent, bool readOnly, bool persistent = true );
 bool getReadOnly( const GraphComponent *graphComponent );
-/// Takes into account the result of `getReadOnly()` for ancestors, so that read-only-ness
-/// is inherited. This is the method that should be used to determine if a graphComponent
-/// should be editable by the user or not.
+
+/// The "childNodesAreReadOnly" metadata is similar to the "readOnly" metadata
+/// but only indicates the read-only-ness to the internal nodes of a node, and not its own plugs.
+
+void setChildNodesAreReadOnly( Node *node, bool readOnly, bool persistent = true );
+bool getChildNodesAreReadOnly( const Node *node );
+
+/// Takes into account the result of `getReadOnly()` and `getChildNodesAreReadOnly()` for ancestors,
+/// so that read-only-ness is inherited.
+/// This is the method that should be used to determine if a graphComponent should be editable
+/// by the user or not.
 bool readOnly( const GraphComponent *graphComponent );
 
 /// Bookmarks

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -72,6 +72,54 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n ), True )
 		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n["op1"] ), True )
 
+	def testChildNodesAreReadOnly( self ) :
+
+		b = Gaffer.Box()
+
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( b ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getChildNodesAreReadOnly( b ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( b ), False )
+
+		p1 = Gaffer.IntPlug( "boxPlug", Gaffer.Plug.Direction.In )
+		b.addChild( p1 )
+
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( p1 ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( p1 ), False )
+
+		n = GafferTest.AddNode()
+
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n["op1"] ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n["op1"] ), False )
+
+		b.addChild( n )
+
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n["op1"] ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n["op1"] ), False )
+
+		Gaffer.MetadataAlgo.setChildNodesAreReadOnly( b, True )
+
+		self.assertEqual( Gaffer.MetadataAlgo.getChildNodesAreReadOnly( b ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( b ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( p1 ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n["op1"] ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n ), True )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n["op1"] ), True )
+
+		Gaffer.MetadataAlgo.setChildNodesAreReadOnly( b, False )
+
+		self.assertEqual( Gaffer.MetadataAlgo.getChildNodesAreReadOnly( b ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( b ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( p1 ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n["op1"] ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n ), False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n["op1"] ), False )
+
 	def testBookmarks( self ) :
 
 		b = Gaffer.Box()

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -1052,17 +1052,11 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["r"] = Gaffer.Reference()
 		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
-		self.assertTrue( Gaffer.MetadataAlgo.readOnly( s["r"]["a1"] ) )
-		self.assertTrue( Gaffer.MetadataAlgo.readOnly( s["r"]["a2"] ) )
-
 		s.execute( s.serialise( parent = s["r"], filter = Gaffer.StandardSet( [ s["r"]["a1"], s["r"]["a2"] ] ) ) )
 
 		self.assertTrue( "a1" in s )
 		self.assertTrue( "a2" in s )
 		self.assertTrue( s["a2"]["op1"].getInput().isSame( s["a1"]["sum"] ) )
-
-		self.assertFalse( Gaffer.MetadataAlgo.readOnly( s["a1"] ) )
-		self.assertFalse( Gaffer.MetadataAlgo.readOnly( s["a2"] ) )
 
 	def testReloadWithNestedInputConnections( self ) :
 

--- a/python/GafferUI/EditMenu.py
+++ b/python/GafferUI/EditMenu.py
@@ -318,12 +318,12 @@ def __mutableSelectionAvailable( menu ) :
 	if not selectionAvailable( menu ) :
 		return False
 
-	return not isinstance( scope( menu ).parent, Gaffer.Reference )
+	return not (Gaffer.MetadataAlgo.getChildNodesAreReadOnly( scope( menu ).parent ) or	Gaffer.MetadataAlgo.readOnly( scope( menu ).parent ) )
 
 def __pasteAvailable( menu ) :
 
 	s = scope( menu )
-	if isinstance( s.parent, Gaffer.Reference ) :
+	if Gaffer.MetadataAlgo.getChildNodesAreReadOnly( scope( menu ).parent ) or Gaffer.MetadataAlgo.readOnly( scope( menu ).parent ):
 		return False
 
 	root = s.script.ancestor( Gaffer.ApplicationRoot )
@@ -331,7 +331,7 @@ def __pasteAvailable( menu ) :
 
 def __arrangeAvailable( menu ) :
 
-	return not isinstance( scope( menu ).parent, Gaffer.Reference )
+	return not (Gaffer.MetadataAlgo.getChildNodesAreReadOnly( scope( menu ).parent ) or	Gaffer.MetadataAlgo.readOnly( scope( menu ).parent ) )
 
 def __undoAvailable( menu ) :
 

--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -274,7 +274,10 @@ class NodeGraph( GafferUI.EditorWidget ) :
 					self._m.popup( self )
 					return True
 
-			if not isinstance( self.graphGadget().getRoot(), Gaffer.Reference ) :
+			if not (
+				Gaffer.MetadataAlgo.getChildNodesAreReadOnly( self.graphGadget().getRoot() ) or
+				Gaffer.MetadataAlgo.readOnly( self.graphGadget().getRoot() )
+			):
 				self._nodeMenu().popup( self )
 				return True
 
@@ -307,7 +310,10 @@ class NodeGraph( GafferUI.EditorWidget ) :
 				self.graphGadget().setRoot( root.parent() )
 				return True
 		elif event.key == "Tab" :
-			if not isinstance( self.graphGadget().getRoot(), Gaffer.Reference ) :
+			if not (
+				Gaffer.MetadataAlgo.getChildNodesAreReadOnly( self.graphGadget().getRoot() ) or
+				Gaffer.MetadataAlgo.readOnly( self.graphGadget().getRoot() )
+			):
 				self._nodeMenu().popup( self )
 				return True
 

--- a/python/GafferUI/ReferenceUI.py
+++ b/python/GafferUI/ReferenceUI.py
@@ -57,6 +57,7 @@ Gaffer.Metadata.registerNode(
 	""",
 
 	"nodeGraph:childrenViewable", True,
+	"childNodesAreReadOnly", True,
 
 	"layout:customWidget:fileName:widgetType", "GafferUI.ReferenceUI._FileNameWidget"
 

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -262,15 +262,6 @@ void Reference::loadInternal( const std::string &fileName )
 				convertPersistentMetadata( it->get() );
 			}
 		}
-		else if( Node *node = runTimeCast<Node>( newChildren->member( i ) ) )
-		{
-			// Make the loaded nodes read-only as far as the UI is
-			// concerned, because any changes the user did make
-			// would be lost on save/reload. We use non-persistent
-			// metadata for this so that they can copy/paste nodes
-			// out of the reference and have the copies be editable.
-			MetadataAlgo::setReadOnly( node, true, /* persistent = */ false );
-		}
 	}
 
 	// figure out what version of gaffer was used to save the reference. prior to

--- a/src/GafferBindings/MetadataAlgoBinding.cpp
+++ b/src/GafferBindings/MetadataAlgoBinding.cpp
@@ -77,6 +77,8 @@ void bindMetadataAlgo()
 
 	def( "setReadOnly", &setReadOnly, ( arg( "graphComponent" ), arg( "readOnly"), arg( "persistent" ) = true ) );
 	def( "getReadOnly", &getReadOnly );
+	def( "setChildNodesAreReadOnly", &setChildNodesAreReadOnly, ( arg( "node" ), arg( "readOnly"), arg( "persistent" ) = true ) );
+	def( "getChildNodesAreReadOnly", &getChildNodesAreReadOnly );
 	def( "readOnly", &readOnly );
 	def( "setBookmarked", &setBookmarked, ( arg( "graphComponent" ), arg( "bookmarked"), arg( "persistent" ) = true ) );
 	def( "getBookmarked", &getBookmarked );


### PR DESCRIPTION
"childNodesAreReadOnly" is a metadata that can be added to nodes to indicate that child nodes of itself (and their children) are supposed to be considered read-only by the UI.

This should allow us to have other types of nodes with a behaviour similar to that of the `Gaffer.Reference` node.

The following new methods have been added to `Gaffer.MetadataAlgo`:
```
setChildNodesAreReadOnly(node, readOnly, persistent=True)
getChildNodesAreReadOnly(node)
```

`Gaffer.Metadta.readOnly()`, `Gaffer.Reference` has been updated to use that flag.

Menus and keybindings that were blocked for `Gaffer.Reference` are now looking for the metadata information instead.

