### PR TITLE
Rename UndoContext -> UndoScope

### DIFF
--- a/include/Gaffer/Action.h
+++ b/include/Gaffer/Action.h
@@ -54,7 +54,7 @@ IE_CORE_FORWARDDECLARE( Action );
 /// The Action class forms the basis of the undo system - all
 /// methods which wish to support undo must be implemented by
 /// calling Action::enact(). Note that client code never creates Actions
-/// explicitly - instead they are created implicitly whenever an UndoContext
+/// explicitly - instead they are created implicitly whenever an UndoScope
 /// is active and an undoable method is called. Because Actions are
 /// essentially an implementation detail of the undo system, subclasses
 /// shouldn't be exposed in the public headers.

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -45,7 +45,7 @@
 #include "Gaffer/TypedPlug.h"
 #include "Gaffer/Container.h"
 #include "Gaffer/Set.h"
-#include "Gaffer/UndoContext.h"
+#include "Gaffer/UndoScope.h"
 #include "Gaffer/Action.h"
 #include "Gaffer/Behaviours/OrphanRemover.h"
 
@@ -98,7 +98,7 @@ class ScriptNode : public Node
 		/// These methods are implemented in terms of the Action class -
 		/// when the methods are called an Action instance is stored in an
 		/// undo list on the relevant ScriptNode so it can later be undone.
-		/// To enable undo for a series of operations an UndoContext must
+		/// To enable undo for a series of operations an UndoScope must
 		/// be active while those operations are being performed.
 		////////////////////////////////////////////////////////////////////
 		//@{
@@ -113,7 +113,7 @@ class ScriptNode : public Node
 		Action::Stage currentActionStage() const;
 		/// A signal emitted after an action is performed on the script or
 		/// one of its children. Note that this is only emitted for actions
-		/// performed within an UndoContext.
+		/// performed within an UndoScope.
 		/// \todo Have methods on Actions to provide a textual description
 		/// of what is being done, for use in Undo/Redo menu items, history
 		/// displays etc.
@@ -248,21 +248,21 @@ class ScriptNode : public Node
 		IE_CORE_FORWARDDECLARE( CompoundAction );
 
 		friend class Action;
-		friend class UndoContext;
+		friend class UndoScope;
 
-		// Called by the UndoContext and Action classes to
+		// Called by the UndoScope and Action classes to
 		// implement the undo system.
-		void pushUndoState( UndoContext::State state, const std::string &mergeGroup );
+		void pushUndoState( UndoScope::State state, const std::string &mergeGroup );
 		void addAction( ActionPtr action );
 		void popUndoState();
 
-		typedef std::stack<UndoContext::State> UndoStateStack;
+		typedef std::stack<UndoScope::State> UndoStateStack;
 		typedef std::list<CompoundActionPtr> UndoList;
 		typedef UndoList::iterator UndoIterator;
 
 		ActionSignal m_actionSignal;
 		UndoAddedSignal m_undoAddedSignal;
-		UndoStateStack m_undoStateStack; // pushed and popped by the creation and destruction of UndoContexts
+		UndoStateStack m_undoStateStack; // pushed and popped by the creation and destruction of UndoScopes
 		CompoundActionPtr m_actionAccumulator; // Actions are accumulated here until the state stack hits 0 size
 		UndoList m_undoList; // then the accumulated actions are transferred to this list for storage
 		UndoIterator m_undoIterator; // points to the next thing to redo

--- a/include/Gaffer/UndoScope.h
+++ b/include/Gaffer/UndoScope.h
@@ -35,8 +35,8 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFER_UNDOCONTEXT_H
-#define GAFFER_UNDOCONTEXT_H
+#ifndef GAFFER_UNDOSCOPE_H
+#define GAFFER_UNDOSCOPE_H
 
 #include <string>
 
@@ -49,10 +49,9 @@ namespace Gaffer
 
 IE_CORE_FORWARDDECLARE( ScriptNode );
 
-/// The UndoContext class is used to control the creation of
+/// The UndoScope class is used to control the creation of
 /// items on the undo stack held in a ScriptNode.
-/// \todo Rename to UndoScope to avoid confusion with Context.
-class UndoContext : DirtyPropagationScope
+class UndoScope : DirtyPropagationScope
 {
 
 	public :
@@ -68,13 +67,13 @@ class UndoContext : DirtyPropagationScope
 		/// will not be undoable regardless of the specified state.
 		///
 		/// If mergeGroup is specified and matches the group used by
-		/// the previous UndoContext, then the actions performed will
+		/// the previous UndoScope, then the actions performed will
 		/// be merged with the previous entry on the undo stack. This
 		/// can be used by UI elements to compress a series of individual
 		/// editing events such as an interactively updated drag into
 		/// a single item on the undo stack.
-		UndoContext( ScriptNodePtr script, State state=Enabled, const std::string &mergeGroup=std::string() );
-		~UndoContext();
+		UndoScope( ScriptNodePtr script, State state=Enabled, const std::string &mergeGroup=std::string() );
+		~UndoScope();
 
 	private :
 
@@ -84,4 +83,4 @@ class UndoContext : DirtyPropagationScope
 
 } // namespace Gaffer
 
-#endif // GAFFER_UNDOCONTEXT_H
+#endif // GAFFER_UNDOSCOPE_H

--- a/include/GafferBindings/UndoScopeBinding.h
+++ b/include/GafferBindings/UndoScopeBinding.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
 //  Copyright (c) 2011, John Haddon. All rights reserved.
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,31 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "IECore/MessageHandler.h"
+#ifndef GAFFERBINDINGS_UNDOSCOPEBINDING_H
+#define GAFFERBINDINGS_UNDOSCOPEBINDING_H
 
-#include "Gaffer/UndoContext.h"
-#include "Gaffer/ScriptNode.h"
-#include "Gaffer/Action.h"
-
-using namespace Gaffer;
-
-UndoContext::UndoContext( ScriptNodePtr script, State state, const std::string &mergeGroup )
-	:	m_script( script )
+namespace GafferBindings
 {
-	if( state==Invalid )
-	{
-		throw IECore::Exception( "Cannot construct UndoContext with Invalid state." );
-	}
-	if( m_script )
-	{
-		m_script->pushUndoState( state, mergeGroup );
-	}
-}
 
-UndoContext::~UndoContext()
-{
-	if( m_script )
-	{
-		m_script->popUndoState();
-	}
-}
+void bindUndoScope();
+
+} // namespace GafferBindings
+
+#endif // GAFFERBINDINGS_UNDOSCOPEBINDING_H

--- a/include/GafferCortex/ParameterisedHolder.h
+++ b/include/GafferCortex/ParameterisedHolder.h
@@ -83,7 +83,7 @@ class ParameterisedHolder : public BaseType
 		/// we're consistent with the interface provided in IECoreMaya?
 		void setParameterisedValues();
 
-		/// \todo Is this even needed? Can we just use an UndoContext instead?
+		/// \todo Is this even needed? Can we just use an UndoScope instead?
 		class ParameterModificationContext
 		{
 			public :

--- a/include/GafferSceneUI/TransformTool.h
+++ b/include/GafferSceneUI/TransformTool.h
@@ -136,7 +136,7 @@ class TransformTool : public GafferSceneUI::SelectionTool
 		/// Must be called by derived classes when they end
 		/// a drag.
 		void dragEnd();
-		/// Should be used in UndoContexts created by
+		/// Should be used in UndoScopes created by
 		/// derived classes.
 		std::string undoMergeGroup() const;
 

--- a/python/Gaffer/UndoScope.py
+++ b/python/Gaffer/UndoScope.py
@@ -35,13 +35,13 @@
 #
 ##########################################################################
 
-from _Gaffer import _UndoContext
+from _Gaffer import _UndoScope
 
-class UndoContext( object ) :
+class UndoScope( object ) :
 
-	State = _UndoContext.State
+	State = _UndoScope.State
 
-	def __init__( self, script, state=_UndoContext.State.Enabled, mergeGroup="" ) :
+	def __init__( self, script, state=_UndoScope.State.Enabled, mergeGroup="" ) :
 
 		self.__script = script
 		self.__state = state
@@ -49,8 +49,8 @@ class UndoContext( object ) :
 
 	def __enter__( self ) :
 
-		self.__context = _UndoContext( self.__script, self.__state, self.__mergeGroup )
+		self.__scope = _UndoScope( self.__script, self.__state, self.__mergeGroup )
 
 	def __exit__( self, type, value, traceBack ) :
 
-		del self.__context
+		del self.__scope

--- a/python/Gaffer/__init__.py
+++ b/python/Gaffer/__init__.py
@@ -43,7 +43,7 @@ from Application import Application
 from WeakMethod import WeakMethod
 from BlockedConnection import BlockedConnection
 from FileNamePathFilter import FileNamePathFilter
-from UndoContext import UndoContext
+from UndoScope import UndoScope
 from Context import Context
 from InfoPathFilter import InfoPathFilter
 from LazyModule import lazyImport, LazyModule

--- a/python/GafferCortexUI/CompoundVectorParameterValueWidget.py
+++ b/python/GafferCortexUI/CompoundVectorParameterValueWidget.py
@@ -124,7 +124,7 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 				# columns will have differing lengths until the last plug
 				# has been set. in this case we shortcut ourselves, and wait
 				# for the final plug to be set before updating the VectorDataWidget.
-				# \todo Now dirty propagation is batched via the UndoContext,
+				# \todo Now dirty propagation is batched via the UndoScope,
 				# we should remove this workaround, since _updateFromPlug()
 				# will only be called when the plug is in a valid state.
 				return
@@ -163,7 +163,7 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 
 		data = vectorDataWidget.getData()
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			for d, p in zip( data, self._parameterHandler().plug().children() ) :
 				p.setValue( d )
 
@@ -254,7 +254,7 @@ def __applyPreset( columnParameterHandler, indices, elementValue ) :
 	for index in indices :
 		value[index] = elementValue
 
-	with Gaffer.UndoContext( columnParameterHandler.plug().ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( columnParameterHandler.plug().ancestor( Gaffer.ScriptNode ) ) :
 		columnParameterHandler.setPlugValue()
 
 def __parameterPopupMenu( menuDefinition, parameterValueWidget ) :

--- a/python/GafferCortexUI/DateTimeParameterValueWidget.py
+++ b/python/GafferCortexUI/DateTimeParameterValueWidget.py
@@ -108,5 +108,5 @@ class _DateTimePlugValueWidget( GafferUI.PlugValueWidget ) :
 			delimited[17:19],
 		)
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().setValue( undelimited )

--- a/python/GafferCortexUI/ParameterValueWidget.py
+++ b/python/GafferCortexUI/ParameterValueWidget.py
@@ -182,5 +182,5 @@ __parameterPopupMenuConnection = ParameterValueWidget.popupMenuSignal().connect(
 def __setValue( parameterHandler, value ) :
 
 	parameterHandler.parameter().setValue( value )
-	with Gaffer.UndoContext( parameterHandler.plug().ancestor( Gaffer.ScriptNode.staticTypeId() ) ) :
+	with Gaffer.UndoScope( parameterHandler.plug().ancestor( Gaffer.ScriptNode.staticTypeId() ) ) :
 		parameterHandler.setPlugValue()

--- a/python/GafferCortexUI/PresetsOnlyParameterValueWidget.py
+++ b/python/GafferCortexUI/PresetsOnlyParameterValueWidget.py
@@ -105,7 +105,7 @@ class _PlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __applyPreset( self, unused, preset ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 
 			self.__parameterHandler.parameter().setValue( self.__parameterHandler.parameter().presets()[preset] )
 			self.__parameterHandler.setPlugValue()

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -835,7 +835,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		s = Gaffer.ScriptNode()
 		s["w"] = GafferImage.ImageWriter()
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s["w"]["fileName"].setValue( "test.tif" )
 
 		self.assertEqual( s["w"]["fileName"].getValue(), "test.tif" )

--- a/python/GafferImageUI/ChannelMaskPlugValueWidget.py
+++ b/python/GafferImageUI/ChannelMaskPlugValueWidget.py
@@ -195,12 +195,12 @@ class ChannelMaskPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __setValue( self, unused, value ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().setValue( value )
 
 	def __toggleCustom( self, checked ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			if not checked :
 				Gaffer.Metadata.deregisterValue( self.getPlug(), self.__customMetadataName )
 			else :

--- a/python/GafferImageUI/ChannelPlugValueWidget.py
+++ b/python/GafferImageUI/ChannelPlugValueWidget.py
@@ -126,7 +126,7 @@ class ChannelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __setValue( self, unused, value ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().setValue( value )
 
 	def __channelLabel( self, channelName ) :

--- a/python/GafferImageUI/FormatPlugValueWidget.py
+++ b/python/GafferImageUI/FormatPlugValueWidget.py
@@ -167,13 +167,13 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __applyFormat( self, unused, fmt ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			Gaffer.Metadata.registerValue( self.getPlug(), "formatPlugValueWidget:mode", "standard", persistent = False )
 			self.getPlug().setValue( fmt )
 
 	def __applyCustomFormat( self, unused ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 
 			with self.getContext() :
 				if self.getPlug().getValue() == GafferImage.Format() :

--- a/python/GafferImageUI/OpenColorIOTransformUI.py
+++ b/python/GafferImageUI/OpenColorIOTransformUI.py
@@ -110,5 +110,5 @@ class _ContextFooter( GafferUI.Widget ) :
 		if Gaffer.readOnly( self.__node["context"] ) :
 			return
 
-		with Gaffer.UndoContext( self.__node.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.__node.ancestor( Gaffer.ScriptNode ) ) :
 			self.__node["context"].addOptionalMember( "", "", enabled = True )

--- a/python/GafferImageUI/RGBAChannelsPlugValueWidget.py
+++ b/python/GafferImageUI/RGBAChannelsPlugValueWidget.py
@@ -118,6 +118,6 @@ class RGBAChannelsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __setValue( self, unused, value ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().setValue( IECore.StringVectorData( value ) )
 

--- a/python/GafferOSLTest/OSLCodeTest.py
+++ b/python/GafferOSLTest/OSLCodeTest.py
@@ -233,13 +233,13 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 
 		f1 = self.__osoFileName( s["o"] )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s["o"]["parameters"]["i"] = Gaffer.Color3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 			s["o"]["out"]["o"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
 		f2 = self.__osoFileName( s["o"] )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s["o"]["code"].setValue( "o = i * color( u, v, 0 );")
 
 		f3 = self.__osoFileName( s["o"] )

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -242,7 +242,7 @@ class _ParametersFooter( GafferUI.PlugValueWidget ) :
 			flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
 		)
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().addChild( plug )
 
 ##########################################################################
@@ -314,7 +314,7 @@ class _ErrorWidget( GafferUI.Widget ) :
 #  '.' unmatchable by '*'.
 def __deletePlug( plug ) :
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		plug.parent().removeChild( plug )
 
 def __plugPopupMenu( menuDefinition, plugValueWidget ) :

--- a/python/GafferSceneTest/GroupTest.py
+++ b/python/GafferSceneTest/GroupTest.py
@@ -646,7 +646,7 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 		s["g"] = GafferScene.Group()
 		s["g"]["__customPlug"] = Gaffer.V2fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s["g"]["in"][0].setInput( s["c"]["out"] )
 
 		self.assertTrue( "__customPlug" in s["g"] )

--- a/python/GafferSceneTest/PlaneTest.py
+++ b/python/GafferSceneTest/PlaneTest.py
@@ -140,7 +140,7 @@ class PlaneTest( GafferSceneTest.SceneTestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s["p"] = GafferScene.Plane()
 
 		self.assertTrue( isinstance( s["p"]["out"].object( "/plane" ), IECore.MeshPrimitive ) )

--- a/python/GafferSceneUI/CameraUI.py
+++ b/python/GafferSceneUI/CameraUI.py
@@ -102,7 +102,7 @@ Gaffer.Metadata.registerNode(
 
 def __copyCamera( node, camera ) :
 
-	with Gaffer.UndoContext( node.scriptNode() ) :
+	with Gaffer.UndoScope( node.scriptNode() ) :
 
 		s, h, r, t = camera.getTransform().transform().extractSHRT()
 		node["transform"]["translate"].setValue( t )

--- a/python/GafferSceneUI/CustomAttributesUI.py
+++ b/python/GafferSceneUI/CustomAttributesUI.py
@@ -80,7 +80,7 @@ Gaffer.Metadata.registerNode(
 
 def __setValue( plug, value, *unused ) :
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		plug.setValue( value )
 
 def __attributePopupMenu( menuDefinition, plugValueWidget ) :

--- a/python/GafferSceneUI/DeleteGlobalsUI.py
+++ b/python/GafferSceneUI/DeleteGlobalsUI.py
@@ -94,7 +94,7 @@ def __toggleName( plug, name, active ) :
 	else :
 		names.remove( name )
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		plug.setValue( " ".join( names ) )
 
 def __namesPopupMenu( menuDefinition, plugValueWidget ) :

--- a/python/GafferSceneUI/FilterPlugValueWidget.py
+++ b/python/GafferSceneUI/FilterPlugValueWidget.py
@@ -122,7 +122,7 @@ class FilterPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		filterNode = filterType()
 
-		with Gaffer.UndoContext( self.getPlug().node().scriptNode() ) :
+		with Gaffer.UndoScope( self.getPlug().node().scriptNode() ) :
 			self.getPlug().node().parent().addChild( filterNode )
 			self.getPlug().setInput( filterNode["out"] )
 

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -78,7 +78,7 @@ class _StatePlugValueWidget( GafferUI.PlugValueWidget ) :
 		with self.getContext() :
 			state = self.getPlug().getValue()
 
-		# When setting the plug value here, we deliberately don't use an UndoContext.
+		# When setting the plug value here, we deliberately don't use an UndoScope.
 		# Not enabling undo here is done so that users won't accidentally restart/stop their renderings.
 		if state != GafferScene.InteractiveRender.State.Running:
 			self.getPlug().setValue( GafferScene.InteractiveRender.State.Running )

--- a/python/GafferSceneUI/LightTweaksUI.py
+++ b/python/GafferSceneUI/LightTweaksUI.py
@@ -347,5 +347,5 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 		else :
 			plug = GafferScene.LightTweaks.TweakPlug( name, plugTypeOrValue() )
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().addChild( plug )

--- a/python/GafferSceneUI/OutputsUI.py
+++ b/python/GafferSceneUI/OutputsUI.py
@@ -251,7 +251,7 @@ class _ChildPlugWidget( GafferUI.PlugValueWidget ) :
 
 	def __deleteButtonClicked( self, button ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().parent().removeChild( self.getPlug() )
 
 ## \todo This regex is an interesting case to be considered during the string matching unification for #707. Once that

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -193,7 +193,7 @@ def __drop( nodeGadget, event ) :
 		paths.difference_update( event.data )
 		paths = sorted( paths )
 
-	with Gaffer.UndoContext( nodeGadget.node().ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( nodeGadget.node().ancestor( Gaffer.ScriptNode ) ) :
 
 		if pathsPlug is None :
 

--- a/python/GafferSceneUI/SceneReaderUI.py
+++ b/python/GafferSceneUI/SceneReaderUI.py
@@ -121,7 +121,7 @@ def __toggleTag( plug, tag, checked ) :
 	else :
 		tags.remove( tag )
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		plug.setValue( " ".join( tags ) )
 
 def __tagsPopupMenu( menuDefinition, plugValueWidget ) :

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -134,7 +134,7 @@ Gaffer.Metadata.registerNode(
 
 def __setValue( plug, value, *unused ) :
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		plug.setValue( value )
 
 def __setsPopupMenu( menuDefinition, plugValueWidget ) :

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -187,7 +187,7 @@ class _ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 		if hasattr( node, "shaderLoader" ) :
 			node.shaderLoader().clear()
 
-		with Gaffer.UndoContext( node.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
 			node.loadShader( node["name"].getValue(), keepExistingValues = True )
 
 ##########################################################################
@@ -291,7 +291,7 @@ def __shaderSubMenu( searchPaths, extensions, nodeCreator, matchExpression, sear
 
 def __setPlugMetadata( plug, key, value ) :
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		Gaffer.Metadata.registerValue( plug, key, value )
 
 def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :

--- a/python/GafferSceneUITest/ScaleToolTest.py
+++ b/python/GafferSceneUITest/ScaleToolTest.py
@@ -57,12 +57,12 @@ class ScaleToolTest( GafferUITest.TestCase ) :
 
 		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/plane" ] )
 
-		with Gaffer.UndoContext( script ) :
+		with Gaffer.UndoScope( script ) :
 			tool.scale( IECore.V3f( 2, 1, 1 ) )
 
 		self.assertEqual( script["plane"]["transform"]["scale"].getValue(), IECore.V3f( 2, 1, 1 ) )
 
-		with Gaffer.UndoContext( script ) :
+		with Gaffer.UndoScope( script ) :
 			tool.scale( IECore.V3f( 1, 0.5, 1 ) )
 
 		self.assertEqual( script["plane"]["transform"]["scale"].getValue(), IECore.V3f( 2, 0.5, 1 ) )

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -133,7 +133,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		tool["active"].setValue( True )
 		tool["orientation"].setValue( tool.Orientation.Local )
 
-		with Gaffer.UndoContext( script ) :
+		with Gaffer.UndoScope( script ) :
 			tool.translate( IECore.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
@@ -146,7 +146,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		script["plane"]["transform"]["rotate"]["y"].setValue( 90 )
 
-		with Gaffer.UndoContext( script ) :
+		with Gaffer.UndoScope( script ) :
 			tool.translate( IECore.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
@@ -227,7 +227,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		tool["orientation"].setValue( tool.Orientation.Local )
 
-		with Gaffer.UndoContext( script ) :
+		with Gaffer.UndoScope( script ) :
 			tool.translate( IECore.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
@@ -242,7 +242,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		tool["orientation"].setValue( tool.Orientation.Parent )
 
-		with Gaffer.UndoContext( script ) :
+		with Gaffer.UndoScope( script ) :
 			tool.translate( IECore.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
@@ -257,7 +257,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		tool["orientation"].setValue( tool.Orientation.World )
 
-		with Gaffer.UndoContext( script ) :
+		with Gaffer.UndoScope( script ) :
 			tool.translate( IECore.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
@@ -281,7 +281,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
 
-		with Gaffer.UndoContext( script ) :
+		with Gaffer.UndoScope( script ) :
 			tool.translate( IECore.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
@@ -295,7 +295,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		tool["orientation"].setValue( tool.Orientation.Local )
 
-		with Gaffer.UndoContext( script ) :
+		with Gaffer.UndoScope( script ) :
 			tool.translate( IECore.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(

--- a/python/GafferTest/AnimationTest.py
+++ b/python/GafferTest/AnimationTest.py
@@ -302,7 +302,7 @@ class AnimationTest( GafferTest.TestCase ) :
 
 		self.assertEqual( len( s.children( Gaffer.Node ) ), 1 )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			curve = Gaffer.Animation.acquire( s["n"]["user"]["f"] )
 			self.assertEqual( len( s.children( Gaffer.Node ) ), 2 )
 
@@ -325,11 +325,11 @@ class AnimationTest( GafferTest.TestCase ) :
 		key1 = Gaffer.Animation.Key( 1, 0 )
 		key2 = Gaffer.Animation.Key( 1, 1 )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			curve.addKey( key1 )
 			self.assertEqual( curve.getKey( 1 ), key1 )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			curve.addKey( key2 )
 			self.assertEqual( curve.getKey( 1 ), key2 )
 
@@ -357,7 +357,7 @@ class AnimationTest( GafferTest.TestCase ) :
 		curve.addKey( key )
 		self.assertEqual( curve.getKey( key.time ), key )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			curve.removeKey( key.time )
 			self.assertFalse( curve.hasKey( key.time ) )
 

--- a/python/GafferTest/ArrayPlugTest.py
+++ b/python/GafferTest/ArrayPlugTest.py
@@ -157,7 +157,7 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 		s["a"] = GafferTest.AddNode()
 		s["n"] = GafferTest.ArrayPlugNode()
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s["n"]["in"][0].setInput( s["a"]["sum"] )
 
 		self.assertEqual( len( s["n"]["in"] ), 2 )
@@ -221,7 +221,7 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 		self.assertTrue( s["n"]["in"]["e2"].getInput().isSame( s["a"]["sum"] ) )
 		self.assertTrue( s["n"]["in"]["e3"].getInput().isSame( s["a"]["sum"] ) )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s.deleteNodes( s, Gaffer.StandardSet( [ s["n"] ] ) )
 
 		self.assertFalse( "n" in s )
@@ -261,7 +261,7 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 		self.assertTrue( s["n"]["in"][1].getInput().isSame( s["a"]["sum"] ) )
 		self.assertTrue( s["n"]["in"][2].getInput().isSame( s["a"]["sum"] ) )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s.deleteNodes( s, Gaffer.StandardSet( [ s["a"] ] ) )
 
 		self.assertFalse( "a" in s )

--- a/python/GafferTest/BoxTest.py
+++ b/python/GafferTest/BoxTest.py
@@ -88,7 +88,7 @@ class BoxTest( GafferTest.TestCase ) :
 
 		assertPreConditions()
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n2"], s["n3"] ] ) )
 
 		def assertPostConditions() :
@@ -728,14 +728,14 @@ class BoxTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( b, "description" ), None )
 		self.assertEqual( Gaffer.Metadata.value( p, "description" ), None )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			Gaffer.Metadata.registerValue( b, "description", "d" )
 			Gaffer.Metadata.registerValue( p, "description", "dd" )
 
 		self.assertEqual( Gaffer.Metadata.value( b, "description" ), "d" )
 		self.assertEqual( Gaffer.Metadata.value( p, "description" ), "dd" )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			Gaffer.Metadata.registerValue( b, "description", "t" )
 			Gaffer.Metadata.registerValue( p, "description", "tt" )
 

--- a/python/GafferTest/CompoundDataPlugTest.py
+++ b/python/GafferTest/CompoundDataPlugTest.py
@@ -378,7 +378,7 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 
 		assertPreconditions( s )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 
 			p.addMember( "test", 10, "test" )
 

--- a/python/GafferTest/CompoundNumericPlugTest.py
+++ b/python/GafferTest/CompoundNumericPlugTest.py
@@ -370,19 +370,19 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 0 ) )
 		self.assertFalse( s.undoAvailable() )
 
-		with Gaffer.UndoContext( s, mergeGroup="test" ) :
+		with Gaffer.UndoScope( s, mergeGroup="test" ) :
 			s["n"]["p"].setValue( IECore.V3f( 1, 2, 3 ) )
 
 		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 1, 2, 3 ) )
 		self.assertTrue( s.undoAvailable() )
 
-		with Gaffer.UndoContext( s, mergeGroup="test" ) :
+		with Gaffer.UndoScope( s, mergeGroup="test" ) :
 			s["n"]["p"].setValue( IECore.V3f( 4, 5, 6 ) )
 
 		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 4, 5, 6 ) )
 		self.assertTrue( s.undoAvailable() )
 
-		with Gaffer.UndoContext( s, mergeGroup="test2" ) :
+		with Gaffer.UndoScope( s, mergeGroup="test2" ) :
 			s["n"]["p"].setValue( IECore.V3f( 7, 8, 9 ) )
 
 		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 7, 8, 9 ) )
@@ -407,13 +407,13 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 0 ) )
 		self.assertFalse( s.undoAvailable() )
 
-		with Gaffer.UndoContext( s, mergeGroup="test" ) :
+		with Gaffer.UndoScope( s, mergeGroup="test" ) :
 			s["n"]["p"].setValue( IECore.V3f( 1, 2, 0 ) )
 
 		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 1, 2, 0 ) )
 		self.assertTrue( s.undoAvailable() )
 
-		with Gaffer.UndoContext( s, mergeGroup="test" ) :
+		with Gaffer.UndoScope( s, mergeGroup="test" ) :
 			s["n"]["p"].setValue( IECore.V3f( 2, 4, 0 ) )
 
 		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 2, 4, 0 ) )

--- a/python/GafferTest/DependencyNodeTest.py
+++ b/python/GafferTest/DependencyNodeTest.py
@@ -415,14 +415,14 @@ class DependencyNodeTest( GafferTest.TestCase ) :
 
 		cs = GafferTest.CapturingSlot( s["n"].plugDirtiedSignal() )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 
 			s["n"]["op1"].setValue( 20 )
 			s["n"]["op2"].setValue( 21 )
 
 		# Even though we made two changes, we only want
 		# dirtiness to have been signalled once, because
-		# we grouped them logically in an UndoContext.
+		# we grouped them logically in an UndoScope.
 
 		self.assertEqual( len( cs ), 3 )
 		self.assertTrue( cs[0][0].isSame( s["n"]["op1"] ) )

--- a/python/GafferTest/DotTest.py
+++ b/python/GafferTest/DotTest.py
@@ -68,7 +68,7 @@ class DotTest( GafferTest.TestCase ) :
 		self.assertTrue( "in" not in s["d"] )
 		self.assertTrue( "out" not in s["d"] )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s["d"].setup( s["n2"]["op1"] )
 			s["d"]["in"].setInput( s["n1"]["sum"] )
 			s["n2"]["op1"].setInput( s["d"]["out"] )

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -574,7 +574,7 @@ class ExpressionTest( GafferTest.TestCase ) :
 		self.assertEqual( s["n"]["user"]["b"].getValue(), 2 )
 		self.assertEqual( s["n"]["user"]["c"].getValue(), 3 )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 
 			s["e"].setExpression( 'parent["n"]["user"]["c"] = 1; parent["n"]["user"]["b"] = 2; parent["n"]["user"]["a"] = 3' )
 
@@ -924,7 +924,7 @@ class ExpressionTest( GafferTest.TestCase ) :
 
 		c = s["e"].expressionChangedSignal().connect( f )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s["e"].setExpression( 'parent["n"]["user"]["p"] = 10' )
 			self.assertEqual( len( expressions ), 1 )
 			self.assertEqual( expressions[0], ( 'parent["n"]["user"]["p"] = 10', "python" ) )
@@ -1205,7 +1205,7 @@ class ExpressionTest( GafferTest.TestCase ) :
 			c.setFrame( 20 )
 			self.assertEqual( s["n"]["user"]["i"].getValue(), 20 )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 
 			self.assertRaisesRegexp(
 				Exception,

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -225,14 +225,14 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( s["n"], "undoTest" ), None )
 		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "undoTest" ), None )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			Gaffer.Metadata.registerValue( s["n"], "undoTest", "instanceNodeValue" )
 			Gaffer.Metadata.registerValue( s["n"]["op1"], "undoTest", "instancePlugValue" )
 
 		self.assertEqual( Gaffer.Metadata.value( s["n"], "undoTest" ), "instanceNodeValue" )
 		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "undoTest" ), "instancePlugValue" )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			Gaffer.Metadata.registerValue( s["n"], "undoTest", "instanceNodeValue2" )
 			Gaffer.Metadata.registerValue( s["n"]["op1"], "undoTest", "instancePlugValue2" )
 
@@ -632,14 +632,14 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		assertNonExistent()
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 
 			Gaffer.Metadata.registerValue( s["n"], "a", 1, persistent = True )
 			Gaffer.Metadata.registerValue( s["n"]["op1"], "b", 2, persistent = True )
 
 		assertPersistent()
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 
 			Gaffer.Metadata.registerValue( s["n"], "a", 1, persistent = False )
 			Gaffer.Metadata.registerValue( s["n"]["op1"], "b", 2, persistent = False )
@@ -727,7 +727,7 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		self.assertFalse( "test" in s.serialise() )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			Gaffer.Metadata.registerValue( s["n"], "test", 1 )
 
 		self.assertTrue( "test" in s.serialise() )
@@ -786,7 +786,7 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( s["n"], "deleteMe" ), 20 )
 		self.assertTrue( "Metadata" in s.serialise() )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			Gaffer.Metadata.deregisterValue( s["n"], "deleteMe" )
 			self.assertTrue( "deleteMe" not in s.serialise() )
 			self.assertEqual( Gaffer.Metadata.value( s["n"], "deleteMe" ), 10 )
@@ -830,7 +830,7 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "deleteMe" ), 20 )
 		self.assertTrue( "deleteMe" in s.serialise() )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			Gaffer.Metadata.deregisterValue( s["n"]["op1"], "deleteMe" )
 			self.assertTrue( "deleteMe" not in s.serialise() )
 			self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "deleteMe" ), 10 )

--- a/python/GafferTest/NumericPlugTest.py
+++ b/python/GafferTest/NumericPlugTest.py
@@ -286,12 +286,12 @@ class NumericPlugTest( GafferTest.TestCase ) :
 
 		self.assertFalse( s.undoAvailable() )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s["n"]["p"].setValue( 20 )
 
 		self.assertTrue( s.undoAvailable() )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s["n"]["p"].setValue( 30 )
 
 		self.assertTrue( s.undoAvailable() )
@@ -315,21 +315,21 @@ class NumericPlugTest( GafferTest.TestCase ) :
 
 		cs = GafferTest.CapturingSlot( s["n"].plugSetSignal() )
 
-		with Gaffer.UndoContext( s, mergeGroup="test" ) :
+		with Gaffer.UndoScope( s, mergeGroup="test" ) :
 			s["n"]["p"].setValue( 1 )
 
 		self.assertEqual( len( cs ), 1 )
 		self.assertEqual( s["n"]["p"].getValue(), 1 )
 		self.assertTrue( s.undoAvailable() )
 
-		with Gaffer.UndoContext( s, mergeGroup="test" ) :
+		with Gaffer.UndoScope( s, mergeGroup="test" ) :
 			s["n"]["p"].setValue( 2 )
 
 		self.assertEqual( len( cs ), 2 )
 		self.assertEqual( s["n"]["p"].getValue(), 2 )
 		self.assertTrue( s.undoAvailable() )
 
-		with Gaffer.UndoContext( s, mergeGroup="test2" ) :
+		with Gaffer.UndoScope( s, mergeGroup="test2" ) :
 			s["n"]["p"].setValue( 3 )
 
 		self.assertEqual( len( cs ), 3 )
@@ -382,14 +382,14 @@ class NumericPlugTest( GafferTest.TestCase ) :
 
 		self.assertFalse( s.undoAvailable() )
 
-		with Gaffer.UndoContext( s, mergeGroup="test" ) :
+		with Gaffer.UndoScope( s, mergeGroup="test" ) :
 			s["n"]["p1"].setValue( 20 )
 
 		self.assertTrue( s.undoAvailable() )
 		self.assertEqual( s["n"]["p1"].getValue(), 20 )
 		self.assertEqual( s["n"]["p2"].getValue(), 0 )
 
-		with Gaffer.UndoContext( s, mergeGroup="test" ) :
+		with Gaffer.UndoScope( s, mergeGroup="test" ) :
 			s["n"]["p2"].setValue( 30 )
 
 		self.assertTrue( s.undoAvailable() )

--- a/python/GafferTest/PlugTest.py
+++ b/python/GafferTest/PlugTest.py
@@ -229,7 +229,7 @@ class PlugTest( GafferTest.TestCase ) :
 		self.failUnless( s["n2"]["c"]["i"].getInput().isSame(  s["n1"]["o"] ) )
 		self.assertEqual( len( s["n1"]["o"].outputs() ), 2 )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 
 			del s["n2"]["i"]
 			del s["n2"]["c"]["i"]
@@ -258,7 +258,7 @@ class PlugTest( GafferTest.TestCase ) :
 		self.failUnless( s["n2"]["i"].getInput().isSame( s["n1"]["o"] ) )
 		self.assertEqual( len( s["n1"]["o"].outputs() ), 1 )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 
 			removedPlug = s["n1"]["o"]
 			del s["n1"]["o"]
@@ -630,7 +630,7 @@ class PlugTest( GafferTest.TestCase ) :
 
 		assertPreconditions()
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 
 			s["n1"]["c"].addChild( Gaffer.IntPlug( "i" ) )
 			s["n1"]["c"].addChild( Gaffer.FloatPlug( "f" ) )
@@ -679,7 +679,7 @@ class PlugTest( GafferTest.TestCase ) :
 
 		assertPreconditions()
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 
 			del s["n1"]["c"]["i"]
 			del s["n1"]["c"]["f"]
@@ -710,7 +710,7 @@ class PlugTest( GafferTest.TestCase ) :
 		self.assertFalse( s["n"]["user"]["p"].getFlags( Gaffer.Plug.Flags.ReadOnly ) )
 
 		cs = GafferTest.CapturingSlot( s["n"].plugFlagsChangedSignal() )
-		with Gaffer.UndoContext( s["n"]["user"]["p"].ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( s["n"]["user"]["p"].ancestor( Gaffer.ScriptNode ) ) :
 			s["n"]["user"]["p"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
 			self.assertTrue( s["n"]["user"]["p"].getFlags( Gaffer.Plug.Flags.ReadOnly ) )
 			self.assertEqual( len( cs ), 1 )
@@ -825,7 +825,7 @@ class PlugTest( GafferTest.TestCase ) :
 
 		assertPreconditions()
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 
 			s["n"]["in"].addChild( Gaffer.IntPlug( "i" ) )
 			s["n"]["in"].addChild( Gaffer.FloatPlug( "f" ) )

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -988,7 +988,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		c = s["r"].referenceLoadedSignal().connect( referenceLoaded )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( "p" in s["r"] )

--- a/python/GafferTest/UndoTest.py
+++ b/python/GafferTest/UndoTest.py
@@ -63,7 +63,7 @@ class UndoTest( GafferTest.TestCase ) :
 		self.assertEqual( s.redoAvailable(), False )
 		self.assertRaises( Exception, s.undo )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			n.setName( "c" )
 
 		self.assertEqual( s.undoAvailable(), True )
@@ -89,7 +89,7 @@ class UndoTest( GafferTest.TestCase ) :
 		s["n1"] = n1
 		s["n2"] = n2
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			n1["op1"].setInput( n2["sum"] )
 
 		self.assert_( n1["op1"].getInput().isSame( n2["sum"] ) )
@@ -107,7 +107,7 @@ class UndoTest( GafferTest.TestCase ) :
 
 		self.assertEqual( n.parent(), None )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s["n"] = n
 		self.assert_( n.parent().isSame( s ) )
 		s.undo()
@@ -135,7 +135,7 @@ class UndoTest( GafferTest.TestCase ) :
 		self.assert_( n3["op1"].getInput().isSame( n2["sum"] ) )
 		self.assert_( n3["op2"].getInput().isSame( n2["sum"] ) )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s.deleteNodes( filter = Gaffer.StandardSet( [ n2 ] ) )
 
 		self.assertEqual( n2["op1"].getInput(), None )
@@ -150,7 +150,7 @@ class UndoTest( GafferTest.TestCase ) :
 		self.assert_( n3["op1"].getInput().isSame( n2["sum"] ) )
 		self.assert_( n3["op2"].getInput().isSame( n2["sum"] ) )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s.deleteNodes( filter = Gaffer.StandardSet( [ n2 ] ), reconnect = False )
 
 		self.assertEqual( n2["op1"].getInput(), None )
@@ -170,13 +170,13 @@ class UndoTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["n"] = GafferTest.AddNode()
 
-		with Gaffer.UndoContext( s, Gaffer.UndoContext.State.Disabled ) :
+		with Gaffer.UndoScope( s, Gaffer.UndoScope.State.Disabled ) :
 			s["n"]["op1"].setValue( 10 )
 
 		self.assertFalse( s.undoAvailable() )
 
-		with Gaffer.UndoContext( s, Gaffer.UndoContext.State.Enabled ) :
-			with Gaffer.UndoContext( s, Gaffer.UndoContext.State.Disabled ) :
+		with Gaffer.UndoScope( s, Gaffer.UndoScope.State.Enabled ) :
+			with Gaffer.UndoScope( s, Gaffer.UndoScope.State.Disabled ) :
 				s["n"]["op1"].setValue( 20 )
 
 		self.assertFalse( s.undoAvailable() )

--- a/python/GafferUI/AnimationUI.py
+++ b/python/GafferUI/AnimationUI.py
@@ -77,13 +77,13 @@ def __setKey( plug, context ) :
 	with context :
 		value = plug.getValue()
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		curve = Gaffer.Animation.acquire( plug )
 		curve.addKey( Gaffer.Animation.Key( context.getTime(), value ) )
 
 def __removeKey( plug, time ) :
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		curve = Gaffer.Animation.acquire( plug )
 		curve.removeKey( time )
 

--- a/python/GafferUI/BackdropUI.py
+++ b/python/GafferUI/BackdropUI.py
@@ -52,7 +52,7 @@ def nodeMenuCreateCommand( menu ) :
 
 	script = nodeGraph.scriptNode()
 
-	with Gaffer.UndoContext( script ) :
+	with Gaffer.UndoScope( script ) :
 
 		backdrop = Gaffer.Backdrop()
 		Gaffer.NodeAlgo.applyUserDefaults( backdrop )

--- a/python/GafferUI/BoolPlugValueWidget.py
+++ b/python/GafferUI/BoolPlugValueWidget.py
@@ -95,7 +95,7 @@ class BoolPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __setPlugValue( self ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 
 			if Gaffer.Animation.isAnimated( self.getPlug() ) :
 				curve = Gaffer.Animation.acquire( self.getPlug() )

--- a/python/GafferUI/BoxUI.py
+++ b/python/GafferUI/BoxUI.py
@@ -170,7 +170,7 @@ def __importReference( menu, node ) :
 		closeLabel = "Oy vey",
 		parentWindow = window
 	) :
-		with Gaffer.UndoContext( scriptNode ) :
+		with Gaffer.UndoScope( scriptNode ) :
 			scriptNode.executeFile( str( path ), parent = node, continueOnError = True )
 
 # PlugValueWidget registrations
@@ -234,7 +234,7 @@ for nodeType in ( Gaffer.Box, Gaffer.Reference ) :
 
 def __deletePlug( plug ) :
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		plug.parent().removeChild( plug )
 
 def __appendPlugDeletionMenuItems( menuDefinition, plug, readOnly = False ) :
@@ -250,17 +250,17 @@ def __appendPlugDeletionMenuItems( menuDefinition, plug, readOnly = False ) :
 
 def __promote( plug ) :
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		Gaffer.PlugAlgo.promote( plug )
 
 def __unpromote( plug ) :
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		Gaffer.PlugAlgo.unpromote( plug )
 
 def __promoteToBoxEnabledPlug( box, plug ) :
 
-	with Gaffer.UndoContext( box.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( box.ancestor( Gaffer.ScriptNode ) ) :
 		enabledPlug = box.getChild( "enabled" )
 		if enabledPlug is None :
 			enabledPlug = Gaffer.BoolPlug( "enabled", defaultValue = True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
@@ -341,12 +341,12 @@ def __renamePlug( menu, plug ) :
 	if not name :
 		return
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		plug.setName( name )
 
 def __setPlugMetadata( plug, key, value ) :
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		Gaffer.Metadata.registerValue( plug, key, value )
 
 def __edgePlugs( nodeGraph, plug ) :
@@ -359,7 +359,7 @@ def __reorderPlugs( plugs, plug, newIndex ) :
 
 	plugs.remove( plug )
 	plugs.insert( newIndex, plug )
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		for index, plug in enumerate( plugs ) :
 			Gaffer.Metadata.registerValue( plug, "noduleLayout:index", index )
 

--- a/python/GafferUI/ColorSwatchPlugValueWidget.py
+++ b/python/GafferUI/ColorSwatchPlugValueWidget.py
@@ -180,7 +180,7 @@ class _ColorPlugValueDialogue( GafferUI.ColorChooserDialogue ) :
 			self.__mergeGroupId += 1
 		self.__lastChangedReason = reason
 
-		with Gaffer.UndoContext(
+		with Gaffer.UndoScope(
 			self.__plug.ancestor( Gaffer.ScriptNode ),
 			mergeGroup = "ColorPlugValueDialogue%d%d" % ( id( self, ), self.__mergeGroupId )
 		) :
@@ -191,7 +191,7 @@ class _ColorPlugValueDialogue( GafferUI.ColorChooserDialogue ) :
 	def __buttonClicked( self, button ) :
 
 		if button is self.cancelButton :
-			with Gaffer.UndoContext( self.__plug.ancestor( Gaffer.ScriptNode ) ) :
+			with Gaffer.UndoScope( self.__plug.ancestor( Gaffer.ScriptNode ) ) :
 				self.__plug.setValue( self.colorChooser().getInitialColor() )
 
 		# ideally we'd just remove ourselves from our parent immediately, but that would

--- a/python/GafferUI/CompoundDataPlugValueWidget.py
+++ b/python/GafferUI/CompoundDataPlugValueWidget.py
@@ -140,7 +140,7 @@ class CompoundDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __addItem( self, name, value ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode.staticTypeId() ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode.staticTypeId() ) ) :
 			self.getPlug().addOptionalMember( name, value, enabled=True )
 
 class _MemberPlugValueWidget( GafferUI.PlugValueWidget ) :
@@ -241,7 +241,7 @@ GafferUI.PlugValueWidget.registerType( Gaffer.CompoundDataPlug.MemberPlug, _Memb
 
 def __deletePlug( plug ) :
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		plug.parent().removeChild( plug )
 
 def __plugPopupMenu( menuDefinition, plugValueWidget ) :

--- a/python/GafferUI/CompoundNumericPlugValueWidget.py
+++ b/python/GafferUI/CompoundNumericPlugValueWidget.py
@@ -142,12 +142,12 @@ class CompoundNumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __gang( self ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().gang()
 
 	def __ungang( self ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().ungang()
 
 	@staticmethod

--- a/python/GafferUI/DotUI.py
+++ b/python/GafferUI/DotUI.py
@@ -135,7 +135,7 @@ def __insertDot( menu, destinationPlug ) :
 	gadgetWidget  = nodeGraph.graphGadgetWidget()
 	graphGadget = nodeGraph.graphGadget()
 
-	with Gaffer.UndoContext( destinationPlug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( destinationPlug.ancestor( Gaffer.ScriptNode ) ) :
 
 		node = Gaffer.Dot()
 		graphGadget.getRoot().addChild( node )
@@ -177,7 +177,7 @@ __connectionContextMenuConnection = GafferUI.NodeGraph.connectionContextMenuSign
 
 def __setPlugMetadata( plug, key, value ) :
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		Gaffer.Metadata.registerValue( plug, key, value )
 
 def __nodeGraphPlugContextMenu( nodeGraph, plug, menuDefinition ) :

--- a/python/GafferUI/EditMenu.py
+++ b/python/GafferUI/EditMenu.py
@@ -138,7 +138,7 @@ def redo( menu ) :
 def cut( menu ) :
 
 	s = scope( menu )
-	with Gaffer.UndoContext( s.script ) :
+	with Gaffer.UndoScope( s.script ) :
 		s.script.cut( s.parent, s.script.selection() )
 
 ## A function suitable as the command for an Edit/Copy menu item. It must
@@ -155,7 +155,7 @@ def paste( menu ) :
 	s = scope( menu )
 	originalSelection = Gaffer.StandardSet( iter( s.script.selection() ) )
 
-	with Gaffer.UndoContext( s.script ) :
+	with Gaffer.UndoScope( s.script ) :
 
 		s.script.paste( s.parent )
 
@@ -189,7 +189,7 @@ def paste( menu ) :
 def delete( menu ) :
 
 	s = scope( menu )
-	with Gaffer.UndoContext( s.script ) :
+	with Gaffer.UndoScope( s.script ) :
 		s.script.deleteNodes( s.parent, s.script.selection() )
 
 ## A function suitable as the command for an Edit/Find menu item.  It must
@@ -222,7 +222,7 @@ def arrange( menu ) :
 	if not nodes :
 		nodes = Gaffer.StandardSet( graph.getRoot().children( Gaffer.Node ) )
 
-	with Gaffer.UndoContext( s.script ) :
+	with Gaffer.UndoScope( s.script ) :
 		graph.getLayout().layoutNodes( graph, nodes )
 
 ## A function suitable as the command for an Edit/Select All menu item. It must

--- a/python/GafferUI/EnumPlugValueWidget.py
+++ b/python/GafferUI/EnumPlugValueWidget.py
@@ -72,6 +72,6 @@ class EnumPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __selectionChanged( self, selectionMenu ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			name = selectionMenu.getSelection()[0]
 			self.getPlug().setValue( self.__labelsAndValues[ selectionMenu.index(name) ][1] )

--- a/python/GafferUI/ExpressionUI.py
+++ b/python/GafferUI/ExpressionUI.py
@@ -93,7 +93,7 @@ def __createExpression( plug, language ) :
 	node = plug.node()
 	parentNode = node.ancestor( Gaffer.Node )
 
-	with Gaffer.UndoContext( node.scriptNode() ) :
+	with Gaffer.UndoScope( node.scriptNode() ) :
 
 		expressionNode = Gaffer.Expression()
 		parentNode.addChild( expressionNode )
@@ -294,7 +294,7 @@ class ExpressionWidget( GafferUI.Widget ) :
 	def __setExpression( self ) :
 
 		language = self.__node.getExpression()[1]
-		with Gaffer.UndoContext( self.__node.scriptNode() ) :
+		with Gaffer.UndoScope( self.__node.scriptNode() ) :
 			try :
 				self.__node.setExpression( self.__textWidget.getText(), language )
 				self.__messageWidget.setVisible( False )

--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -283,7 +283,7 @@ def importFile( menu ) :
 
 	newChildren = []
 	c = script.childAddedSignal().connect( lambda parent, child : newChildren.append( child ) )
-	with Gaffer.UndoContext( script ) :
+	with Gaffer.UndoScope( script ) :
 		## \todo We need to prevent the ScriptNode plugs themselves getting clobbered
 		# when importing an entire script.
 		script.executeFile( str( path ) )

--- a/python/GafferUI/GraphBookmarksUI.py
+++ b/python/GafferUI/GraphBookmarksUI.py
@@ -99,7 +99,7 @@ def appendPlugContextMenuDefinitions( nodeGraph, plug, menuDefinition ) :
 
 def __setBookmarked( node, bookmarked ) :
 
-	with Gaffer.UndoContext( node.scriptNode() ) :
+	with Gaffer.UndoScope( node.scriptNode() ) :
 		Gaffer.MetadataAlgo.setBookmarked( node, bookmarked )
 
 ## \todo Perhaps this functionality should be provided by the
@@ -145,5 +145,5 @@ def __connection( plug1, plug2 ) :
 
 def __connect( inPlug, outPlug ) :
 
-	with Gaffer.UndoContext( inPlug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( inPlug.ancestor( Gaffer.ScriptNode ) ) :
 		inPlug.setInput( outPlug )

--- a/python/GafferUI/IncrementingPlugValueWidget.py
+++ b/python/GafferUI/IncrementingPlugValueWidget.py
@@ -67,7 +67,7 @@ class IncrementingPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		assert( widget is self.__button )
 
-		undoState = Gaffer.UndoContext.State.Enabled if self.__undoable else Gaffer.UndoContext.State.Disabled
+		undoState = Gaffer.UndoScope.State.Enabled if self.__undoable else Gaffer.UndoScope.State.Disabled
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ), undoState ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ), undoState ) :
 			self.getPlug().setValue( self.getPlug().getValue() + self.__increment )

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -212,7 +212,7 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __labelEditingFinished( self, nameWidget ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			# Do what the NameWidget would have done for us anyway, so we
 			# can group it with the metadata deregistration in the undo queue.
 			self.getPlug().setName( nameWidget.getText() )

--- a/python/GafferUI/MultiLineStringPlugValueWidget.py
+++ b/python/GafferUI/MultiLineStringPlugValueWidget.py
@@ -112,5 +112,5 @@ class MultiLineStringPlugValueWidget( GafferUI.PlugValueWidget ) :
 			return
 
 		text = self.__textWidget.getText()
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().setValue( text )

--- a/python/GafferUI/NameWidget.py
+++ b/python/GafferUI/NameWidget.py
@@ -80,7 +80,7 @@ class NameWidget( GafferUI.TextWidget ) :
 		if self.__graphComponent is None :
 			return
 
-		with Gaffer.UndoContext( self.__graphComponent.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.__graphComponent.ancestor( Gaffer.ScriptNode ) ) :
 			self.setText( self.__graphComponent.setName( self.getText() ) )
 
 	def __setText( self, *unwantedArgs ) :

--- a/python/GafferUI/NodeEditor.py
+++ b/python/GafferUI/NodeEditor.py
@@ -207,7 +207,7 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 				applyDefaults( c )
 
 		node = self.nodeUI().node()
-		with Gaffer.UndoContext( node.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
 			applyDefaults( node )
 			Gaffer.NodeAlgo.applyUserDefaults( node )
 

--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -489,7 +489,7 @@ class NodeGraph( GafferUI.EditorWidget ) :
 	@classmethod
 	def __setNodeInputConnectionsVisible( cls, graphGadget, node, value ) :
 
-		with Gaffer.UndoContext( node.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
 			graphGadget.setNodeInputConnectionsMinimised( node, not value )
 
 	@classmethod
@@ -500,13 +500,13 @@ class NodeGraph( GafferUI.EditorWidget ) :
 	@classmethod
 	def __setNodeOutputConnectionsVisible( cls, graphGadget, node, value ) :
 
-		with Gaffer.UndoContext( node.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
 			graphGadget.setNodeOutputConnectionsMinimised( node, not value )
 
 	@classmethod
 	def __setEnabled( cls, node, value ) :
 
-		with Gaffer.UndoContext( node.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
 			node.enabledPlug().setValue( value )
 
 GafferUI.EditorWidget.registerType( "NodeGraph", NodeGraph )

--- a/python/GafferUI/NodeMenu.py
+++ b/python/GafferUI/NodeMenu.py
@@ -109,7 +109,7 @@ class NodeMenu( object ) :
 			with IECore.IgnoredExceptions( TypeError ) :
 				commandArgs = inspect.getargspec( nodeCreator )[0]
 
-			with Gaffer.UndoContext( script ) :
+			with Gaffer.UndoScope( script ) :
 
 				if "menu" in commandArgs :
 					node = nodeCreator( menu = menu )

--- a/python/GafferUI/NodeUI.py
+++ b/python/GafferUI/NodeUI.py
@@ -170,7 +170,7 @@ class NodeUI( GafferUI.Widget ) :
 
 def __deletePlug( plug ) :
 
-	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		plug.parent().removeChild( plug )
 
 def __plugPopupMenu( menuDefinition, plugValueWidget ) :

--- a/python/GafferUI/NumericPlugValueWidget.py
+++ b/python/GafferUI/NumericPlugValueWidget.py
@@ -147,7 +147,7 @@ class NumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __setPlugValue( self, mergeGroup="" ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ), mergeGroup=mergeGroup ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ), mergeGroup=mergeGroup ) :
 
 			with Gaffer.BlockedConnection( self._plugConnections() ) :
 				if Gaffer.Animation.isAnimated( self.getPlug() ) :

--- a/python/GafferUI/PathPlugValueWidget.py
+++ b/python/GafferUI/PathPlugValueWidget.py
@@ -156,7 +156,7 @@ class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if not self._editable() :
 			return
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self._setPlugFromPath( self.__path )
 
 		# now we've transferred the text changes to the global undo queue, we remove them

--- a/python/GafferUI/PathVectorDataPlugValueWidget.py
+++ b/python/GafferUI/PathVectorDataPlugValueWidget.py
@@ -66,6 +66,6 @@ class PathVectorDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		assert( widget is self.__dataWidget )
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			with Gaffer.BlockedConnection( self._plugConnections() ) :
 				self.getPlug().setValue( self.__dataWidget.getData()[0] )

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -554,7 +554,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 	def __setValue( self, value ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode.staticTypeId() ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode.staticTypeId() ) ) :
 			self.getPlug().setValue( value )
 
 	def __editInput( self ) :
@@ -571,12 +571,12 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 	def __removeInput( self ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode.staticTypeId() ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode.staticTypeId() ) ) :
 			self.getPlug().setInput( None )
 
 	def __applyUserDefault( self ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode.staticTypeId() ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode.staticTypeId() ) ) :
 			Gaffer.NodeAlgo.applyUserDefault( self.getPlug() )
 
 	def __presetsSubMenu( self ) :
@@ -598,7 +598,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 	def __applyPreset( self, presetName, *unused ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode.staticTypeId() ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode.staticTypeId() ) ) :
 			Gaffer.NodeAlgo.applyPreset( self.getPlug(), presetName )
 
 	def __applyReadOnly( self, readOnly ) :
@@ -608,7 +608,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 			for child in plug.children() :
 				clearFlags( child )
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode.staticTypeId() ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode.staticTypeId() ) ) :
 			# We used to use a plug flag, but we use metadata now
 			# instead. Clear the old flags so that metadata is in
 			# control.
@@ -649,7 +649,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		self.setHighlighted( False )
 
-		with Gaffer.UndoContext( self.getPlug().node().scriptNode() ) :
+		with Gaffer.UndoScope( self.getPlug().node().scriptNode() ) :
 			if isinstance( event.data, Gaffer.Plug ) :
 				self.getPlug().setInput( event.data )
 			else :

--- a/python/GafferUI/PresetsPlugValueWidget.py
+++ b/python/GafferUI/PresetsPlugValueWidget.py
@@ -82,5 +82,5 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __applyPreset( self, unused, preset ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			Gaffer.NodeAlgo.applyPreset( self.getPlug(), preset )

--- a/python/GafferUI/RampPlugValueWidget.py
+++ b/python/GafferUI/RampPlugValueWidget.py
@@ -115,7 +115,7 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__lastPositionChangedReason = reason
 
 		plug = self.getPlug()
-		with Gaffer.UndoContext(
+		with Gaffer.UndoScope(
 			plug.ancestor( Gaffer.ScriptNode ),
 			mergeGroup = "RampPlugValudWidget%d%d" % ( id( self, ), self.__positionsMergeGroupId )
 		) :
@@ -137,7 +137,7 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __indexRemoved( self, slider, index ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().removePoint( index )
 
 	def __selectedIndexChanged( self, slider ) :

--- a/python/GafferUI/RandomUI.py
+++ b/python/GafferUI/RandomUI.py
@@ -199,7 +199,7 @@ def __createRandom( plug ) :
 	node = plug.node()
 	parentNode = node.ancestor( Gaffer.Node )
 
-	with Gaffer.UndoContext( node.scriptNode() ) :
+	with Gaffer.UndoScope( node.scriptNode() ) :
 
 		randomNode = Gaffer.Random()
 		parentNode.addChild( randomNode )

--- a/python/GafferUI/ReferenceUI.py
+++ b/python/GafferUI/ReferenceUI.py
@@ -123,12 +123,12 @@ class _FileNameWidget( GafferUI.Widget ) :
 		if not fileName :
 			return
 
-		with Gaffer.UndoContext( self.__node.scriptNode() ) :
+		with Gaffer.UndoScope( self.__node.scriptNode() ) :
 			_load( self.__node, fileName, self.ancestor( GafferUI.Window ) )
 
 	def __reloadClicked( self, button ) :
 
-		with Gaffer.UndoContext( self.__node.scriptNode() ) :
+		with Gaffer.UndoScope( self.__node.scriptNode() ) :
 			_load( self.__node, self.__node.fileName(), self.ancestor( GafferUI.Window ) )
 
 	def __referenceLoaded( self, node ) :
@@ -172,7 +172,7 @@ def _load( node, fileName, parentWindow ) :
 def __duplicateAsBox( nodeGraph, node ) :
 
 	script = node.scriptNode()
-	with Gaffer.UndoContext( script ) :
+	with Gaffer.UndoScope( script ) :
 
 		box = Gaffer.Box( node.getName() + "Copy" )
 		script.addChild( box )

--- a/python/GafferUI/ScriptEditor.py
+++ b/python/GafferUI/ScriptEditor.py
@@ -111,7 +111,7 @@ class ScriptEditor( GafferUI.EditorWidget ) :
 
 		with Gaffer.OutputRedirection( stdOut = Gaffer.WeakMethod( self.__redirectOutput ), stdErr = Gaffer.WeakMethod( self.__redirectOutput ) ) :
 			with _MessageHandler( self.__outputWidget ) :
-				with Gaffer.UndoContext( self.scriptNode() ) :
+				with Gaffer.UndoScope( self.scriptNode() ) :
 					with self.getContext() :
 						try :
 							if len( parsed.body ) == 1 and isinstance( parsed.body[0], ast.Expr ) :

--- a/python/GafferUI/StringPlugValueWidget.py
+++ b/python/GafferUI/StringPlugValueWidget.py
@@ -115,7 +115,7 @@ class StringPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		if self._editable() :
 			text = self.__textWidget.getText()
-			with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 				self.getPlug().setValue( text )
 
 			# now we've transferred the text changes to the global undo queue, we remove them

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -236,7 +236,7 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 		dialogue = GafferUI.ColorChooserDialogue( color = color, useDisplayTransform = False )
 		color = dialogue.waitForColor( parentWindow = menu.ancestor( GafferUI.Window ) )
 		if color is not None :
-			with Gaffer.UndoContext( node.ancestor( Gaffer.ScriptNode ) ) :
+			with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
 				Gaffer.Metadata.registerValue( node, "nodeGadget:color", color )
 
 GafferUI.EditorWidget.registerType( "UIEditor", UIEditor )
@@ -362,7 +362,7 @@ class _MetadataWidget( GafferUI.Widget ) :
 		if self.__target is None :
 			return
 
-		with Gaffer.UndoContext( self.__target.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.__target.ancestor( Gaffer.ScriptNode ) ) :
 			Gaffer.Metadata.registerValue( self.__target, self.__key, value )
 
 	## May be called by derived classes to deregister the
@@ -372,7 +372,7 @@ class _MetadataWidget( GafferUI.Widget ) :
 		if self.__target is None :
 			return
 
-		with Gaffer.UndoContext( self.__target.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.__target.ancestor( Gaffer.ScriptNode ) ) :
 			Gaffer.Metadata.deregisterValue( self.__target, self.__key )
 
 	def __update( self ) :
@@ -1032,7 +1032,7 @@ class _PlugListing( GafferUI.Widget ) :
 		if self.__dragItem is None :
 			return False
 
-		with Gaffer.UndoContext( self.__parent.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.__parent.ancestor( Gaffer.ScriptNode ) ) :
 			self.__updateMetadata()
 		self.__dragItem = None
 
@@ -1150,7 +1150,7 @@ class _PlugListing( GafferUI.Widget ) :
 
 		Gaffer.Metadata.registerValue( plug, "layout:section", parentItem.fullName() )
 
-		with Gaffer.UndoContext( self.__parent.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.__parent.ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlugParent().addChild( plug )
 
 		self.__updatePathLazily.flush( self )
@@ -1171,7 +1171,7 @@ class _PlugListing( GafferUI.Widget ) :
 
 		self.__pathListing.getPath().pathChangedSignal()( self.__pathListing.getPath() )
 
-		with Gaffer.UndoContext( self.__parent.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.__parent.ancestor( Gaffer.ScriptNode ) ) :
 			self.__updateMetadata()
 
 		self.__pathListing.setSelectedPaths(
@@ -1204,7 +1204,7 @@ class _PlugListing( GafferUI.Widget ) :
 				for childItem in item :
 					deletePlugsWalk( childItem )
 
-		with Gaffer.UndoContext( self.__parent.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.__parent.ancestor( Gaffer.ScriptNode ) ) :
 			deletePlugsWalk( selectedItem )
 			self.__updateMetadata()
 
@@ -1362,7 +1362,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 
 		d = self.__pathListing.getPath().dict()
 		with Gaffer.BlockedConnection( self.__plugMetadataChangedConnection ) :
-			with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 				# reorder by removing everything and reregistering in the order we want
 				for item in d.items() :
 					Gaffer.Metadata.deregisterValue( self.getPlug(), "preset:" + item[0] )
@@ -1383,7 +1383,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 			name = "New Preset %d" % index
 			index += 1
 
-		with Gaffer.UndoContext( self.__plug.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.__plug.ancestor( Gaffer.ScriptNode ) ) :
 			Gaffer.Metadata.registerValue( self.__plug, "preset:" + name, self.__plug.getValue() )
 
 		self.__pathListing.setSelectedPaths(
@@ -1401,7 +1401,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 		selectedPreset = self.__pathListing.getSelectedPaths()[0][0]
 		selectedIndex = [ p[0] for p in paths ].index( selectedPreset )
 
-		with Gaffer.UndoContext( self.__plug.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.__plug.ancestor( Gaffer.ScriptNode ) ) :
 			Gaffer.Metadata.deregisterValue( self.__plug, "preset:" + selectedPreset )
 
 		del paths[selectedIndex]
@@ -1429,7 +1429,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 
 		items = self.__pathListing.getPath().dict().items()
 		with Gaffer.BlockedConnection( self.__plugMetadataChangedConnection ) :
-			with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 				# retain order by removing and reregistering everything
 				for item in items :
 					Gaffer.Metadata.deregisterValue( self.getPlug(), "preset:" + item[0] )
@@ -1449,7 +1449,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 		selectedPaths = self.__pathListing.getSelectedPaths()
 		preset = selectedPaths[0][0]
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			Gaffer.Metadata.registerValue( self.getPlug(), "preset:" + preset, plug.getValue() )
 
 ##########################################################################
@@ -1678,7 +1678,7 @@ class _PlugEditor( GafferUI.Widget ) :
 
 	def __registerOrDeregisterMetadata( self, unused, key, value ) :
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			if value is not None :
 				Gaffer.Metadata.registerValue( self.getPlug(), key, value )
 			else :
@@ -1793,7 +1793,7 @@ class _SectionEditor( GafferUI.Widget ) :
 			else :
 				return oldSection
 
-		with Gaffer.UndoContext( self.__plugParent.ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.__plugParent.ancestor( Gaffer.ScriptNode ) ) :
 
 			for plug in self.__plugParent.children( Gaffer.Plug ) :
 				s = Gaffer.Metadata.value( plug, "layout:section" )

--- a/python/GafferUI/UserPlugs.py
+++ b/python/GafferUI/UserPlugs.py
@@ -98,7 +98,7 @@ def plugCreationWidget( plugParent ) :
 
 def __addPlug( plugParent, plugCreator, **kw ) :
 
-	with Gaffer.UndoContext( plugParent.ancestor( Gaffer.ScriptNode ) ) :
+	with Gaffer.UndoScope( plugParent.ancestor( Gaffer.ScriptNode ) ) :
 		plug = plugCreator( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		Gaffer.Metadata.registerValue( plug, "nodule:type", "" )
 		plugParent.addChild( plug )

--- a/python/GafferUI/VectorDataPlugValueWidget.py
+++ b/python/GafferUI/VectorDataPlugValueWidget.py
@@ -86,7 +86,7 @@ class VectorDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		assert( widget is self.__dataWidget )
 
-		with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			with Gaffer.BlockedConnection( self._plugConnections() ) :
 				self.getPlug().setValue( self.__dataWidget.getData()[0] )
 

--- a/python/GafferUITest/GraphGadgetTest.py
+++ b/python/GafferUITest/GraphGadgetTest.py
@@ -441,7 +441,7 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 
 		self.failUnless( g.connectionGadget( script["n2"]["i"] ) is not None )
 
-		with Gaffer.UndoContext( script ) :
+		with Gaffer.UndoScope( script ) :
 
 			removedPlug = script["n2"]["i"]
 			del script["n2"]["i"]
@@ -468,7 +468,7 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 
 		self.failUnless( g.connectionGadget( script["n2"]["i"] ) is not None )
 
-		with Gaffer.UndoContext( script ) :
+		with Gaffer.UndoScope( script ) :
 
 			del script["n1"]["o"]
 

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -182,7 +182,7 @@ void Reference::loadInternal( const std::string &fileName )
 	// Disable undo for the actions we perform, because we ourselves
 	// are undoable anyway and will take care of everything as a whole
 	// when we are undone.
-	UndoContext undoDisabler( script, UndoContext::Disabled );
+	UndoScope undoDisabler( script, UndoScope::Disabled );
 
 	// if we're doing a reload, then we want to maintain any values and
 	// connections that our external plugs might have. but we also need to

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -366,7 +366,7 @@ const StandardSet *ScriptNode::selection() const
 	return m_selection.get();
 }
 
-void ScriptNode::pushUndoState( UndoContext::State state, const std::string &mergeGroup )
+void ScriptNode::pushUndoState( UndoScope::State state, const std::string &mergeGroup )
 {
 	if( m_undoStateStack.size() == 0 )
 	{
@@ -380,7 +380,7 @@ void ScriptNode::pushUndoState( UndoContext::State state, const std::string &mer
 void ScriptNode::addAction( ActionPtr action )
 {
 	action->doAction();
-	if( m_actionAccumulator && m_undoStateStack.top() == UndoContext::Enabled )
+	if( m_actionAccumulator && m_undoStateStack.top() == UndoScope::Enabled )
 	{
 		m_actionAccumulator->addAction( action );
 		actionSignal()( this, action.get(), Action::Do );
@@ -435,7 +435,7 @@ void ScriptNode::popUndoState()
 
 	if( haveUnsavedChanges )
 	{
-		UndoContext undoDisabled( this, UndoContext::Disabled );
+		UndoScope undoDisabled( this, UndoScope::Disabled );
 		unsavedChangesPlug()->setValue( true );
 	}
 
@@ -477,7 +477,7 @@ void ScriptNode::undo()
 	/// behaviour to the c++ slots.
 	m_currentActionStage = Action::Invalid;
 
-	UndoContext undoDisabled( this, UndoContext::Disabled );
+	UndoScope undoDisabled( this, UndoScope::Disabled );
 	unsavedChangesPlug()->setValue( true );
 }
 
@@ -502,7 +502,7 @@ void ScriptNode::redo()
 
 	m_currentActionStage = Action::Invalid;
 
-	UndoContext undoDisabled( this, UndoContext::Disabled );
+	UndoScope undoDisabled( this, UndoScope::Disabled );
 	unsavedChangesPlug()->setValue( true );
 }
 
@@ -677,7 +677,7 @@ bool ScriptNode::load( bool continueOnError)
 
 	const bool result = executeInternal( s, NULL, continueOnError, fileName );
 
-	UndoContext undoDisabled( this, UndoContext::Disabled );
+	UndoScope undoDisabled( this, UndoScope::Disabled );
 	unsavedChangesPlug()->setValue( false );
 
 	return result;
@@ -686,7 +686,7 @@ bool ScriptNode::load( bool continueOnError)
 void ScriptNode::save() const
 {
 	serialiseToFile( fileNamePlug()->getValue() );
-	UndoContext undoDisabled( const_cast<ScriptNode *>( this ), UndoContext::Disabled );
+	UndoScope undoDisabled( const_cast<ScriptNode *>( this ), UndoScope::Disabled );
 	const_cast<BoolPlug *>( unsavedChangesPlug() )->setValue( false );
 }
 

--- a/src/Gaffer/UndoScope.cpp
+++ b/src/Gaffer/UndoScope.cpp
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 //
 //  Copyright (c) 2011, John Haddon. All rights reserved.
+//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,14 +35,31 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERBINDINGS_UNDOCONTEXTBINDING_H
-#define GAFFERBINDINGS_UNDOCONTEXTBINDING_H
+#include "IECore/MessageHandler.h"
 
-namespace GafferBindings
+#include "Gaffer/UndoScope.h"
+#include "Gaffer/ScriptNode.h"
+#include "Gaffer/Action.h"
+
+using namespace Gaffer;
+
+UndoScope::UndoScope( ScriptNodePtr script, State state, const std::string &mergeGroup )
+	:	m_script( script )
 {
+	if( state==Invalid )
+	{
+		throw IECore::Exception( "Cannot construct UndoScope with Invalid state." );
+	}
+	if( m_script )
+	{
+		m_script->pushUndoState( state, mergeGroup );
+	}
+}
 
-void bindUndoContext();
-
-} // namespace GafferBindings
-
-#endif // GAFFERBINDINGS_UNDOCONTEXTBINDING_H
+UndoScope::~UndoScope()
+{
+	if( m_script )
+	{
+		m_script->popUndoState();
+	}
+}

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -55,7 +55,7 @@
 #include "GafferBindings/ScriptNodeBinding.h"
 #include "GafferBindings/ApplicationRootBinding.h"
 #include "GafferBindings/SetBinding.h"
-#include "GafferBindings/UndoContextBinding.h"
+#include "GafferBindings/UndoScopeBinding.h"
 #include "GafferBindings/CompoundPlugBinding.h"
 #include "GafferBindings/CompoundNumericPlugBinding.h"
 #include "GafferBindings/SplinePlugBinding.h"
@@ -166,7 +166,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindScriptNode();
 	bindApplicationRoot();
 	bindSet();
-	bindUndoContext();
+	bindUndoScope();
 	bindCompoundPlug();
 	bindCompoundNumericPlug();
 	bindSplinePlug();

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -39,7 +39,7 @@
 #include "IECore/NullObject.h"
 
 #include "Gaffer/BlockedConnection.h"
-#include "Gaffer/UndoContext.h"
+#include "Gaffer/UndoScope.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
 
@@ -490,7 +490,7 @@ void CropWindowTool::overlayRectangleChanged( unsigned reason )
 		)
 	);
 
-	UndoContext undoContext( m_cropWindowPlug->ancestor<ScriptNode>() );
+	UndoScope undoScope( m_cropWindowPlug->ancestor<ScriptNode>() );
 
 	if( m_cropWindowEnabledPlug && !m_cropWindowEnabledPlug->getValue() )
 	{

--- a/src/GafferSceneUI/ScaleTool.cpp
+++ b/src/GafferSceneUI/ScaleTool.cpp
@@ -36,7 +36,7 @@
 
 #include "boost/bind.hpp"
 
-#include "Gaffer/UndoContext.h"
+#include "Gaffer/UndoScope.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/MetadataAlgo.h"
 
@@ -149,7 +149,7 @@ IECore::RunTimeTypedPtr ScaleTool::dragBegin( GafferUI::Style::Axes axes )
 
 bool ScaleTool::dragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event )
 {
-	UndoContext undoContext( selection().transformPlug->ancestor<ScriptNode>(), UndoContext::Enabled, undoMergeGroup() );
+	UndoScope undoScope( selection().transformPlug->ancestor<ScriptNode>(), UndoScope::Enabled, undoMergeGroup() );
 	const float scale = static_cast<const ScaleHandle *>( gadget )->scaling( event );
 	applyScale( m_drag, scale );
 	return true;

--- a/src/GafferSceneUI/ShaderUI.cpp
+++ b/src/GafferSceneUI/ShaderUI.cpp
@@ -36,7 +36,7 @@
 
 #include "boost/bind.hpp"
 
-#include "Gaffer/UndoContext.h"
+#include "Gaffer/UndoScope.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/Metadata.h"
 #include "Gaffer/MetadataAlgo.h"
@@ -92,7 +92,7 @@ class ShaderPlugAdder : public PlugAdder
 				return;
 			}
 
-			UndoContext undoContext( m_shader->scriptNode() );
+			UndoScope undoScope( m_shader->scriptNode() );
 
 			Metadata::registerValue( plug, g_visibleKey, new IECore::BoolData( true ) );
 			plug->setInput( connectionEndPoint );
@@ -109,7 +109,7 @@ class ShaderPlugAdder : public PlugAdder
 				return false;
 			}
 
-			UndoContext undoContext( m_shader->scriptNode() );
+			UndoScope undoScope( m_shader->scriptNode() );
 			Metadata::registerValue( plug, g_visibleKey, new IECore::BoolData( true ) );
 			return true;
 		}

--- a/src/GafferSceneUI/TranslateTool.cpp
+++ b/src/GafferSceneUI/TranslateTool.cpp
@@ -38,7 +38,7 @@
 
 #include "OpenEXR/ImathMatrixAlgo.h"
 
-#include "Gaffer/UndoContext.h"
+#include "Gaffer/UndoScope.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/MetadataAlgo.h"
 
@@ -240,7 +240,7 @@ IECore::RunTimeTypedPtr TranslateTool::dragBegin( int axis )
 
 bool TranslateTool::dragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event )
 {
-	UndoContext undoContext( selection().transformPlug->ancestor<ScriptNode>(), UndoContext::Enabled, undoMergeGroup() );
+	UndoScope undoScope( selection().transformPlug->ancestor<ScriptNode>(), UndoScope::Enabled, undoMergeGroup() );
 	const float offset = static_cast<const TranslateHandle *>( gadget )->translation( event );
 	applyTranslation( m_drag, offset );
 	return true;

--- a/src/GafferUI/DotNodeGadget.cpp
+++ b/src/GafferUI/DotNodeGadget.cpp
@@ -40,7 +40,7 @@
 #include "IECoreGL/Selector.h"
 
 #include "Gaffer/Dot.h"
-#include "Gaffer/UndoContext.h"
+#include "Gaffer/UndoScope.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/MetadataAlgo.h"
@@ -276,7 +276,7 @@ bool DotNodeGadget::drop( const DragDropEvent &event )
 		return false;
 	}
 
-	Gaffer::UndoContext undoEnabler( node()->ancestor<ScriptNode>() );
+	Gaffer::UndoScope undoEnabler( node()->ancestor<ScriptNode>() );
 
 	dotNode()->setup( plug );
 	if( plug->direction() == Plug::In )

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -707,7 +707,7 @@ bool GraphGadget::keyPressed( GadgetPtr gadget, const KeyEvent &event )
 		/// rather than being hardcoded in here. For that to be done easily we
 		/// need a static keyPressSignal() in Widget, which needs figuring out
 		/// some more before we commit to it. In the meantime, this will do.
-		Gaffer::UndoContext undoContext( m_scriptNode );
+		Gaffer::UndoScope undoScope( m_scriptNode );
 		Gaffer::Set *selection = m_scriptNode->selection();
 		for( size_t i = 0, s = selection->size(); i != s; i++ )
 		{
@@ -1250,7 +1250,7 @@ bool GraphGadget::dragEnd( GadgetPtr gadget, const DragDropEvent &event )
 
 	if( dragMode == Moving && m_dragReconnectCandidate )
 	{
-		Gaffer::UndoContext undoContext( m_scriptNode );
+		Gaffer::UndoScope undoScope( m_scriptNode );
 
 		m_dragReconnectDstNodule->plug()->setInput( m_dragReconnectCandidate->srcNodule()->plug() );
 		m_dragReconnectCandidate->dstNodule()->plug()->setInput( m_dragReconnectSrcNodule->plug() );

--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -39,7 +39,6 @@
 #include "IECoreGL/Texture.h"
 #include "IECoreGL/Selector.h"
 
-#include "Gaffer/UndoContext.h"
 #include "Gaffer/Metadata.h"
 #include "Gaffer/ArrayPlug.h"
 

--- a/src/GafferUI/SplinePlugGadget.cpp
+++ b/src/GafferUI/SplinePlugGadget.cpp
@@ -38,7 +38,7 @@
 #include "GafferUI/SplinePlugGadget.h"
 #include "GafferUI/Style.h"
 
-#include "Gaffer/UndoContext.h"
+#include "Gaffer/UndoScope.h"
 #include "Gaffer/ScriptNode.h"
 
 #include "IECore/CurvesPrimitive.h"
@@ -278,7 +278,7 @@ bool SplinePlugGadget::buttonPress( GadgetPtr, const ButtonEvent &event )
 			return false;
 		}
 
-		UndoContext undoEnabler( spline->ancestor<ScriptNode>() );
+		UndoScope undoEnabler( spline->ancestor<ScriptNode>() );
 
 		unsigned pointIndex = spline->addPoint();
 		spline->pointXPlug( pointIndex )->setValue( intersection.x );
@@ -394,7 +394,7 @@ bool SplinePlugGadget::keyPress( GadgetPtr gadget, const KeyEvent &event )
 	if( event.key=="BackSpace" && m_selection->size() )
 	{
 		Plug *firstPlug = static_cast<Plug *>( m_selection->member( 0 ) );
-		UndoContext undoEnabler( firstPlug->ancestor<ScriptNode>() );
+		UndoScope undoEnabler( firstPlug->ancestor<ScriptNode>() );
 
 		for( size_t i = 0, e = m_selection->size(); i < e ; i++ )
 		{

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -41,7 +41,7 @@
 #include "OpenEXR/ImathFun.h"
 #include "OpenEXR/ImathBoxAlgo.h"
 
-#include "Gaffer/UndoContext.h"
+#include "Gaffer/UndoScope.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StandardSet.h"
 #include "Gaffer/Metadata.h"
@@ -306,7 +306,7 @@ bool StandardConnectionGadget::dragEnd( const DragDropEvent &event )
 	if( !event.destinationGadget || event.destinationGadget == this )
 	{
 		// noone wanted the drop so we'll disconnect
-		Gaffer::UndoContext undoEnabler( dstNodule()->plug()->ancestor<Gaffer::ScriptNode>() );
+		Gaffer::UndoScope undoEnabler( dstNodule()->plug()->ancestor<Gaffer::ScriptNode>() );
 		dstNodule()->plug()->setInput( NULL );
 	}
 	else

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -43,7 +43,7 @@
 #include "IECoreGL/Selector.h"
 
 #include "Gaffer/Plug.h"
-#include "Gaffer/UndoContext.h"
+#include "Gaffer/UndoScope.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/Metadata.h"
 #include "Gaffer/MetadataAlgo.h"
@@ -385,7 +385,7 @@ bool StandardNodule::drop( GadgetPtr gadget, const DragDropEvent &event )
 
 	if( input )
 	{
-		Gaffer::UndoContext undoEnabler( input->ancestor<Gaffer::ScriptNode>() );
+		Gaffer::UndoScope undoEnabler( input->ancestor<Gaffer::ScriptNode>() );
 
 			input->setInput( output );
 

--- a/src/GafferUI/SwitchUI.cpp
+++ b/src/GafferUI/SwitchUI.cpp
@@ -38,7 +38,7 @@
 
 #include "Gaffer/Switch.h"
 #include "Gaffer/ArrayPlug.h"
-#include "Gaffer/UndoContext.h"
+#include "Gaffer/UndoScope.h"
 #include "Gaffer/ScriptNode.h"
 
 #include "GafferUI/Nodule.h"
@@ -75,7 +75,7 @@ class SwitchPlugAdder : public PlugAdder
 
 		virtual void addPlug( Plug *connectionEndPoint )
 		{
-			UndoContext undoContext( m_switch->ancestor<ScriptNode>() );
+			UndoScope undoScope( m_switch->ancestor<ScriptNode>() );
 
 			m_switch->setup( connectionEndPoint );
 			ArrayPlug *inPlug = m_switch->getChild<ArrayPlug>( "in" );

--- a/startup/Gaffer/undoContextCompatibility.py
+++ b/startup/Gaffer/undoContextCompatibility.py
@@ -1,0 +1,37 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+Gaffer.UndoContext = Gaffer.UndoScope


### PR DESCRIPTION
The discussion over the naming of `Context::EditableScope` reminded me that we've been meaning to change this misleading UndoContext name for a long time now. It has nothing to do with Contexts in the Gaffer sense, and the UndoScope name makes it much clearer that it behaves like other scopes in gaffer.

This is a binary and source compatibility break, but I've included a startup file which provides temporary backwards compatibility for python scripts. In practice, I believe the IE codebase only has a single use of UndoContext from C++, in IEMayaRendering::PaintCommand. If it's not possible to update this I could provide a compatibility header, but I'm hoping that won't be necessary...

