### PR TITLE
RotateTool

### DIFF
--- a/include/GafferSceneUI/RotateTool.h
+++ b/include/GafferSceneUI/RotateTool.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
+//  Copyright (c) 2017, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,27 +34,69 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERSCENEUI_TYPEIDS_H
-#define GAFFERSCENEUI_TYPEIDS_H
+#ifndef GAFFERSCENEUI_ROTATETOOL_H
+#define GAFFERSCENEUI_ROTATETOOL_H
+
+#include "GafferUI/Style.h"
+
+#include "GafferSceneUI/TransformTool.h"
 
 namespace GafferSceneUI
 {
 
-enum TypeId
+IE_CORE_FORWARDDECLARE( SceneView )
+
+class RotateTool : public TransformTool
 {
-	SceneViewTypeId = 110651,
-	SceneGadgetTypeId = 110652,
-	SelectionToolTypeId = 110653,
-	CropWindowToolTypeId = 110654,
-	ShaderViewTypeId = 110655,
-	ShaderNodeGadgetTypeId = 110656,
-	TransformToolTypeId = 110657,
-	TranslateToolTypeId = 110658,
-	ScaleToolTypeId = 110659,
-	RotateToolTypeId = 110660,
-	LastTypeId = 110700
+
+	public :
+
+		RotateTool( SceneView *view, const std::string &name = defaultName<RotateTool>() );
+		virtual ~RotateTool();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::RotateTool, RotateToolTypeId, TransformTool );
+
+		Gaffer::IntPlug *orientationPlug();
+		const Gaffer::IntPlug *orientationPlug() const;
+
+		/// Rotates the current selection as if the specified
+		/// handle had been dragged interactively. Exists mainly
+		/// for use in the unit tests.
+		void rotate( int axis, float degrees );
+
+	protected :
+
+		virtual bool affectsHandles( const Gaffer::Plug *input ) const;
+		virtual void updateHandles();
+
+	private :
+
+		// The guts of the rotation logic. This is factored out of the
+		// drag handling so it can be shared with the `rotate()` public
+		// method.
+		struct Rotation
+		{
+			Imath::V3f originalRotation;
+			Imath::V3f axis;
+		};
+
+		Rotation createRotation( int axis );
+		Imath::V3f rotation( const Rotation &rotation, float radians ) const;
+		void applyRotation( const Rotation &rotation, float radians );
+
+		// Drag handling.
+
+		IECore::RunTimeTypedPtr dragBegin( int axis );
+		bool dragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
+		bool dragEnd();
+
+		Rotation m_drag;
+
+		static ToolDescription<RotateTool, SceneView> g_toolDescription;
+		static size_t g_firstPlugIndex;
+
 };
 
 } // namespace GafferSceneUI
 
-#endif // GAFFERSCENEUI_TYPEIDS_H
+#endif // GAFFERSCENEUI_ROTATETOOL_H

--- a/include/GafferSceneUI/TransformTool.h
+++ b/include/GafferSceneUI/TransformTool.h
@@ -59,6 +59,13 @@ class TransformTool : public GafferSceneUI::SelectionTool
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::TransformTool, TransformToolTypeId, SelectionTool );
 
+		enum Orientation
+		{
+			Local,
+			Parent,
+			World
+		};
+
 		struct Selection
 		{
 			/// Viewed scene
@@ -129,6 +136,9 @@ class TransformTool : public GafferSceneUI::SelectionTool
 		/// transform and matching their enabled state to the editability
 		/// of the selection.
 		virtual void updateHandles() = 0;
+
+		/// Utility that may be used from updateHandles().
+		Imath::M44f orientedTransform( Orientation orientation );
 
 		/// Must be called by derived classes when they begin
 		/// a drag.

--- a/include/GafferSceneUI/TranslateTool.h
+++ b/include/GafferSceneUI/TranslateTool.h
@@ -57,13 +57,6 @@ class TranslateTool : public TransformTool
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::TranslateTool, TranslateToolTypeId, TransformTool );
 
-		enum Orientation
-		{
-			Local,
-			Parent,
-			World
-		};
-
 		Gaffer::IntPlug *orientationPlug();
 		const Gaffer::IntPlug *orientationPlug() const;
 

--- a/include/GafferSceneUIBindings/RotateToolBinding.h
+++ b/include/GafferSceneUIBindings/RotateToolBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEUIBINDINGS_ROTATETOOLBINDING_H
+#define GAFFERSCENEUIBINDINGS_ROTATETOOLBINDING_H
+
+namespace GafferSceneUIBindings
+{
+
+void bindRotateTool();
+
+} // namespace GafferSceneUIBindings
+
+#endif // GAFFERSCENEUIBINDINGS_ROTATETOOLBINDING_H

--- a/include/GafferUI/RotateHandle.h
+++ b/include/GafferUI/RotateHandle.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2011-2012, John Haddon. All rights reserved.
-//  Copyright (c) 2011-2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2017, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,55 +34,50 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERUI_TYPEIDS_H
-#define GAFFERUI_TYPEIDS_H
+#ifndef GAFFERUI_ROTATEHANDLE_H
+#define GAFFERUI_ROTATEHANDLE_H
+
+#include "GafferUI/Handle.h"
 
 namespace GafferUI
 {
 
-enum TypeId
+class RotateHandle : public Handle
 {
-	GadgetTypeId = 110251,
-	NodeGadgetTypeId = 110252,
-	GraphGadgetTypeId = 110253,
-	ContainerGadgetTypeId = 110254,
-	RenderableGadgetTypeId = 110255,
-	TextGadgetTypeId = 110256,
-	NameGadgetTypeId = 110257,
-	IndividualContainerTypeId = 110258,
-	FrameTypeId = 110259,
-	StyleTypeId = 110260,
-	StandardStyleTypeId = 110261,
-	NoduleTypeId = 110262,
-	LinearContainerTypeId = 110263,
-	ConnectionGadgetTypeId = 110264,
-	StandardNodeGadgetTypeId = 110265,
-	SplinePlugGadgetTypeId = 110266,
-	StandardNoduleTypeId = 110267,
-	CompoundNoduleTypeId = 110268,
-	ImageGadgetTypeId = 110269,
-	ViewportGadgetTypeId = 110270,
-	ViewTypeId = 110271,
-	View3DTypeId = 110272, // Obsolete - available for reuse
-	ObjectViewTypeId = 110273, // Obsolete - available for reuse
-	PlugGadgetTypeId = 110274,
-	GraphLayoutTypeId = 110275,
-	StandardGraphLayoutTypeId = 110276,
-	BackdropNodeGadgetTypeId = 110277,
-	SpacerGadgetTypeId = 110278,
-	StandardConnectionGadgetTypeId = 110279,
-	HandleTypeId = 110280,
-	ToolTypeId = 110281,
-	DotNodeGadgetTypeId = 110282,
-	PlugAdderTypeId = 110283,
-	NoduleLayoutTypeId = 110284,
-	TranslateHandleTypeId = 110285,
-	ScaleHandleTypeId = 110286,
-	RotateHandleTypeId = 110287,
 
-	LastTypeId = 110450
+	public :
+
+		RotateHandle( Style::Axes axes );
+		virtual ~RotateHandle();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::RotateHandle, RotateHandleTypeId, Handle );
+
+		void setAxes( Style::Axes axes );
+		Style::Axes getAxes() const;
+
+		// Measured in radians
+		float rotation( const DragDropEvent &event ) const;
+
+	protected :
+
+		virtual void renderHandle( const Style *style, Style::State state ) const;
+		virtual void dragBegin( const DragDropEvent &event );
+
+	private :
+
+		bool dragMove( const DragDropEvent &event );
+
+		Style::Axes m_axes;
+		PlanarDrag m_drag;
+		float m_rotation;
+
 };
+
+IE_CORE_DECLAREPTR( RotateHandle )
+
+typedef Gaffer::FilteredChildIterator<Gaffer::TypePredicate<RotateHandle> > RotateHandleIterator;
+typedef Gaffer::FilteredRecursiveChildIterator<Gaffer::TypePredicate<RotateHandle> > RecursiveRotateHandleIterator;
 
 } // namespace GafferUI
 
-#endif // GAFFERUI_TYPEIDS_H
+#endif // GAFFERUI_ROTATEHANDLE_H

--- a/include/GafferUI/StandardStyle.h
+++ b/include/GafferUI/StandardStyle.h
@@ -88,6 +88,7 @@ class StandardStyle : public Style
 		virtual void renderBackdrop( const Imath::Box2f &box, State state = NormalState, const Imath::Color3f *userColor = NULL ) const;
 
 		virtual void renderTranslateHandle( Axes axes, State state = NormalState ) const;
+		virtual void renderRotateHandle( Axes axes, State state = NormalState ) const;
 		virtual void renderScaleHandle( Axes axes, State state = NormalState ) const;
 
 		enum Color

--- a/include/GafferUI/Style.h
+++ b/include/GafferUI/Style.h
@@ -139,6 +139,7 @@ class Style : public IECore::RunTimeTyped
 			XYZ
 		};
 		virtual void renderTranslateHandle( Axes axes, State state = NormalState ) const = 0;
+		virtual void renderRotateHandle( Axes axes, State state = NormalState ) const = 0;
 		virtual void renderScaleHandle( Axes axes, State state = NormalState ) const = 0;
 		//@}
 

--- a/include/GafferUI/TranslateHandle.h
+++ b/include/GafferUI/TranslateHandle.h
@@ -71,10 +71,6 @@ class TranslateHandle : public Handle
 
 	private :
 
-		int axis() const;
-
-		float absoluteDragOffset( const DragDropEvent &event ) const;
-
 		Style::Axes m_axes;
 		LinearDrag m_drag;
 

--- a/python/GafferSceneUI/RotateToolUI.py
+++ b/python/GafferSceneUI/RotateToolUI.py
@@ -1,0 +1,76 @@
+##########################################################################
+#
+#  Copyright (c) 2017, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferSceneUI
+
+Gaffer.Metadata.registerNode(
+
+	GafferSceneUI.RotateTool,
+
+	"description",
+	"""
+	Tool for editing object rotation.
+	""",
+
+	"nodeToolbar:bottom:type", "GafferUI.StandardNodeToolbar.bottom",
+
+	"viewer:shortCut", "E",
+	"order", 2,
+
+	plugs = {
+
+		"orientation" : [
+
+			"description",
+			"""
+			The space used to define the orientation of the XYZ
+			rotation handles. Note that this is independent
+			of the space setting on a Transform node - each
+			setting can be mixed and matched freely.
+			""",
+
+			"toolbarLayout:section", "Bottom",
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+			"preset:Local", GafferSceneUI.TransformTool.Orientation.Local,
+			"preset:Parent", GafferSceneUI.TransformTool.Orientation.Parent,
+			"preset:World", GafferSceneUI.TransformTool.Orientation.World,
+
+		],
+
+	}
+)

--- a/python/GafferSceneUI/TranslateToolUI.py
+++ b/python/GafferSceneUI/TranslateToolUI.py
@@ -66,9 +66,9 @@ Gaffer.Metadata.registerNode(
 			"toolbarLayout:section", "Bottom",
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
-			"preset:Local", GafferSceneUI.TranslateTool.Orientation.Local,
-			"preset:Parent", GafferSceneUI.TranslateTool.Orientation.Parent,
-			"preset:World", GafferSceneUI.TranslateTool.Orientation.World,
+			"preset:Local", GafferSceneUI.TransformTool.Orientation.Local,
+			"preset:Parent", GafferSceneUI.TransformTool.Orientation.Parent,
+			"preset:World", GafferSceneUI.TransformTool.Orientation.World,
 
 		],
 

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -132,6 +132,7 @@ import FilterResultsUI
 import TranslateToolUI
 import ScaleToolUI
 import EvaluateLightLinksUI
+import RotateToolUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUITest/RotateToolTest.py
+++ b/python/GafferSceneUITest/RotateToolTest.py
@@ -1,0 +1,165 @@
+##########################################################################
+#
+#  Copyright (c) 2017, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+
+import Gaffer
+import GafferUITest
+import GafferScene
+import GafferSceneUI
+
+class RotateToolTest( GafferUITest.TestCase ) :
+
+	def testRotate( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["cube"] = GafferScene.Cube()
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["cube"]["out"] )
+		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/cube" ] )
+
+		tool = GafferSceneUI.RotateTool( view )
+		tool["active"].setValue( True )
+
+		for i in range( 0, 6 ) :
+			tool.rotate( 1, 90 )
+			self.assertEqual( script["cube"]["transform"]["rotate"]["y"].getValue(), (i + 1) * 90 )
+
+	def testInteractionWithGroupRotation( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["cube"] = GafferScene.Cube()
+		script["group"] = GafferScene.Group()
+		script["group"]["in"][0].setInput( script["cube"]["out"] )
+
+		# Rotates the X axis onto the negative Z axis
+		script["group"]["transform"]["rotate"]["y"].setValue( 90 )
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["group"]["out"] )
+		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/group/cube" ] )
+
+		tool = GafferSceneUI.RotateTool( view )
+		tool["active"].setValue( True )
+
+		# Rotates 90 degrees using the Z handle. This will
+		# rotate about the X axis in world space, because the
+		# handle orientation has been affected by the group
+		# transform (because default orientation is Parent).
+		tool.rotate( 2, 90 )
+
+		# We expect this to have aligned the cube's local X axis onto
+		# the Y axis in world space, and the local Y axis onto the world
+		# Z axis.
+		self.assertTrue(
+			IECore.V3f( 0, 1, 0 ).equalWithAbsError(
+				IECore.V3f( 1, 0, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
+				0.000001
+			)
+		)
+		self.assertTrue(
+			IECore.V3f( 0, 0, 1 ).equalWithAbsError(
+				IECore.V3f( 0, 1, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
+				0.000001
+			)
+		)
+
+	def testOrientation( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["cube"] = GafferScene.Cube()
+		script["cube"]["transform"]["rotate"]["y"].setValue( 90 )
+
+		script["group"] = GafferScene.Group()
+		script["group"]["in"][0].setInput( script["cube"]["out"] )
+		script["group"]["transform"]["rotate"]["y"].setValue( 90 )
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["group"]["out"] )
+		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/group/cube" ] )
+
+		tool = GafferSceneUI.RotateTool( view )
+		tool["active"].setValue( True )
+
+		# Local
+
+		tool["orientation"].setValue( tool.Orientation.Local )
+
+		with Gaffer.UndoContext( script ) :
+			tool.rotate( 2, 90 )
+
+		self.assertTrue(
+			IECore.V3f( 0, 1, 0 ).equalWithAbsError(
+				IECore.V3f( 1, 0, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
+				0.000001
+			)
+		)
+		script.undo()
+
+		# Parent
+
+		tool["orientation"].setValue( tool.Orientation.Parent )
+
+		with Gaffer.UndoContext( script ) :
+			tool.rotate( 0, 90 )
+
+		self.assertTrue(
+			IECore.V3f( 0, 1, 0 ).equalWithAbsError(
+				IECore.V3f( 1, 0, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
+				0.000001
+			)
+		)
+		script.undo()
+
+		# World
+
+		tool["orientation"].setValue( tool.Orientation.World )
+
+		with Gaffer.UndoContext( script ) :
+			tool.rotate( 2, 90 )
+
+		self.assertTrue(
+			IECore.V3f( 0, -1, 0 ).equalWithAbsError(
+				IECore.V3f( 1, 0, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
+				0.000001
+			)
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneUITest/__init__.py
+++ b/python/GafferSceneUITest/__init__.py
@@ -45,6 +45,7 @@ from ShaderViewTest import ShaderViewTest
 from ShaderUITest import ShaderUITest
 from TranslateToolTest import TranslateToolTest
 from ScaleToolTest import ScaleToolTest
+from RotateToolTest import RotateToolTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -142,16 +142,16 @@
      borderopacity="1"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.5"
-     inkscape:cx="202.86806"
-     inkscape:cy="591.31886"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="172.10891"
+     inkscape:cy="791.49594"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:window-width="1098"
      inkscape:window-height="868"
-     inkscape:window-x="122"
-     inkscape:window-y="25"
+     inkscape:window-x="344"
+     inkscape:window-y="95"
      inkscape:window-maximized="0"
      inkscape:snap-global="true"
      inkscape:snap-nodes="true"
@@ -3176,71 +3176,75 @@
          inkscape:connector-curvature="0" />
     </g>
     <g
-       transform="translate(120.59619,-75.596198)"
-       id="g4136"
-       style="opacity:0.66379311">
+       id="forExport:gafferSceneUIRotateTool"
+       inkscape:label="#g3299">
       <g
-         transform="matrix(0.78155202,0,0,0.78155202,-82.618747,215.66916)"
-         id="g5216"
-         style="opacity:0.71551723">
+         style="opacity:0.66379311"
+         id="g4136"
+         transform="translate(120.59619,-75.596198)">
+        <g
+           style="opacity:0.71551723"
+           id="g5216"
+           transform="matrix(0.78155202,0,0,0.78155202,-82.618747,215.66916)">
+          <path
+             inkscape:transform-center-y="-7.5"
+             inkscape:transform-center-x="7.5"
+             sodipodi:nodetypes="ccccc"
+             inkscape:connector-curvature="0"
+             d="m 149.5,152.86218 -15,0 0,15 15,0 z"
+             style="opacity:0.60344825;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.27950537;stroke-opacity:1"
+             id="path5125" />
+        </g>
         <path
-           id="path5125"
-           style="opacity:0.60344825;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.27950537;stroke-opacity:1"
-           d="m 149.5,152.86218 -15,0 0,15 15,0 z"
+           id="path5137"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+           d="M 39.268288,336.15243 28.55854,331.38414 23.790252,342.09389 34.5,346.86218 z"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccc"
-           inkscape:transform-center-x="7.5"
-           inkscape:transform-center-y="-7.5" />
+           inkscape:transform-center-x="3.801065"
+           inkscape:transform-center-y="-9.902115" />
       </g>
       <path
-         inkscape:transform-center-y="-9.902115"
-         inkscape:transform-center-x="3.801065"
+         inkscape:transform-center-y="-10.592065"
+         inkscape:transform-center-x="-0.555105"
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
-         d="M 39.268288,336.15243 28.55854,331.38414 23.790252,342.09389 34.5,346.86218 z"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-         id="path5137" />
-    </g>
-    <path
-       id="path5133"
-       style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-       d="m 163.80828,263.42159 -7.8444,-8.71209 -8.71209,7.8444 7.8444,8.7121 z"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc"
-       inkscape:transform-center-x="-0.555105"
-       inkscape:transform-center-y="-10.592065" />
-    <g
-       id="g4141"
-       transform="translate(122.66066,-76.595908)">
-      <path
-         style="fill:none;stroke:#3c3c3c;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-         d="m 18.919829,338.41825 c 1.609786,-3.50691 4.785185,-6.213 8.827138,-7.1893 1.068186,-0.25801 2.137435,-0.37646 3.18856,-0.36706"
-         id="path5184"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csc" />
-      <path
-         sodipodi:type="star"
-         style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.7932142;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         id="path5182"
-         sodipodi:sides="3"
-         sodipodi:cx="117.14286"
-         sodipodi:cy="578.07648"
-         sodipodi:r1="7.1428571"
-         sodipodi:r2="5.7786927"
-         sodipodi:arg1="1.0471976"
-         sodipodi:arg2="2.0943952"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
-         transform="matrix(-0.55936791,-0.00554531,-0.00567669,0.55589671,99.812034,10.284701)"
-         inkscape:label="#forExport:collapsibleArrowRightHover" />
-      <path
-         sodipodi:nodetypes="csc"
-         inkscape:connector-curvature="0"
-         id="path5169"
-         d="m 18.919829,338.41825 c 1.609786,-3.50691 4.785185,-6.213 8.827138,-7.1893 1.068186,-0.25801 2.137435,-0.37646 3.18856,-0.36706"
-         style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+         d="m 163.80828,263.42159 -7.8444,-8.71209 -8.71209,7.8444 7.8444,8.7121 z"
+         style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+         id="path5133" />
+      <g
+         transform="translate(122.66066,-76.595908)"
+         id="g4141">
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path5184"
+           d="m 18.919829,338.41825 c 1.609786,-3.50691 4.785185,-6.213 8.827138,-7.1893 1.068186,-0.25801 2.137435,-0.37646 3.18856,-0.36706"
+           style="fill:none;stroke:#3c3c3c;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+        <path
+           inkscape:label="#forExport:collapsibleArrowRightHover"
+           transform="matrix(-0.55936791,-0.00554531,-0.00567669,0.55589671,99.812034,10.284701)"
+           d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 0,12.37179 z"
+           inkscape:randomized="0"
+           inkscape:rounded="0"
+           inkscape:flatsided="true"
+           sodipodi:arg2="2.0943952"
+           sodipodi:arg1="1.0471976"
+           sodipodi:r2="5.7786927"
+           sodipodi:r1="7.1428571"
+           sodipodi:cy="578.07648"
+           sodipodi:cx="117.14286"
+           sodipodi:sides="3"
+           id="path5182"
+           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.7932142;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           sodipodi:type="star" />
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           d="m 18.919829,338.41825 c 1.609786,-3.50691 4.785185,-6.213 8.827138,-7.1893 1.068186,-0.25801 2.137435,-0.37646 3.18856,-0.36706"
+           id="path5169"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="csc" />
+      </g>
     </g>
     <g
        transform="translate(-1.40381,-0.596187)"

--- a/src/GafferSceneUI/RotateTool.cpp
+++ b/src/GafferSceneUI/RotateTool.cpp
@@ -1,0 +1,229 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/bind.hpp"
+
+#include "OpenEXR/ImathEuler.h"
+
+#include "IECore/AngleConversion.h"
+
+#include "Gaffer/UndoScope.h"
+#include "Gaffer/ScriptNode.h"
+#include "Gaffer/MetadataAlgo.h"
+
+#include "GafferUI/RotateHandle.h"
+
+#include "GafferSceneUI/RotateTool.h"
+#include "GafferSceneUI/SceneView.h"
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferUI;
+using namespace GafferScene;
+using namespace GafferSceneUI;
+
+IE_CORE_DEFINERUNTIMETYPED( RotateTool );
+
+RotateTool::ToolDescription<RotateTool, SceneView> RotateTool::g_toolDescription;
+
+size_t RotateTool::g_firstPlugIndex = 0;
+
+RotateTool::RotateTool( SceneView *view, const std::string &name )
+	:	TransformTool( view, name )
+{
+	static Style::Axes axes[] = { Style::X, Style::Y, Style::Z };
+	static const char *handleNames[] = { "x", "y", "z" };
+
+	for( int i = 0; i < 3; ++i )
+	{
+		RotateHandlePtr handle = new RotateHandle( axes[i] );
+		handle->setRasterScale( 75 );
+		handles()->setChild( handleNames[i], handle );
+		// connect with group 0, so we get called before the Handle's slot does.
+		handle->dragBeginSignal().connect( 0, boost::bind( &RotateTool::dragBegin, this, i ) );
+		handle->dragMoveSignal().connect( boost::bind( &RotateTool::dragMove, this, ::_1, ::_2 ) );
+		handle->dragEndSignal().connect( boost::bind( &RotateTool::dragEnd, this ) );
+	}
+
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new IntPlug( "orientation", Plug::In, Parent, Local, World ) );
+}
+
+RotateTool::~RotateTool()
+{
+}
+
+Gaffer::IntPlug *RotateTool::orientationPlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::IntPlug *RotateTool::orientationPlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex );
+}
+
+void RotateTool::rotate( int axis, float degrees )
+{
+	Rotation r = createRotation( axis );
+	applyRotation( r, degreesToRadians( degrees ) );
+}
+
+bool RotateTool::affectsHandles( const Gaffer::Plug *input ) const
+{
+	if( TransformTool::affectsHandles( input ) )
+	{
+		return true;
+	}
+
+	return
+		input == orientationPlug() ||
+		input == scenePlug()->transformPlug();
+}
+
+void RotateTool::updateHandles()
+{
+	handles()->setTransform(
+		orientedTransform( static_cast<Orientation>( orientationPlug()->getValue() ) )
+	);
+	for( int i = 0; i < 3; ++i )
+	{
+		const Rotation rotation = createRotation( i );
+		const V3f r = this->rotation( rotation, M_PI / 4.0 );
+		bool editable = true;
+		for( int j = 0; j < 3; ++j )
+		{
+			if( r[j] != rotation.originalRotation[j] )
+			{
+				ValuePlug *plug = selection().transformPlug->rotatePlug()->getChild( j );
+				if( !plug->settable() || MetadataAlgo::readOnly( plug ) )
+				{
+					editable = false;
+					break;
+				}
+			}
+		}
+		handles()->getChild<Gadget>( i )->setEnabled( editable );
+	}
+}
+
+RotateTool::Rotation RotateTool::createRotation( int axis )
+{
+	Context::Scope scopedContext( view()->getContext() );
+
+	const Selection &selection = this->selection();
+
+	Rotation result;
+	result.originalRotation = selection.transformPlug->rotatePlug()->getValue();
+
+	/// \todo Share this with TranslateTool somehow
+	V3f handleSpaceAxis( 0.0f );
+	handleSpaceAxis[axis] = 1.0f;
+	const M44f handlesTransform = orientedTransform( static_cast<Orientation>( orientationPlug()->getValue() ) );
+	V3f worldSpaceAxis;
+	handlesTransform.multDirMatrix( handleSpaceAxis, worldSpaceAxis );
+
+	const M44f downstreamMatrix = scenePlug()->fullTransform( selection.path );
+	M44f upstreamMatrix;
+	{
+		Context::Scope scopedContext( selection.context.get() );
+		upstreamMatrix = selection.upstreamScene->fullTransform( selection.upstreamPath );
+	}
+
+	V3f downstreamAxis;
+	downstreamMatrix.inverse().multDirMatrix( worldSpaceAxis, downstreamAxis );
+
+	V3f upstreamWorldAxis;
+	upstreamMatrix.multDirMatrix( downstreamAxis, upstreamWorldAxis );
+
+	selection.transformSpace.inverse().multDirMatrix( upstreamWorldAxis, result.axis );
+	return result;
+}
+
+Imath::V3f RotateTool::rotation( const Rotation &rotation, float radians ) const
+{
+	const Selection &selection = this->selection();
+
+	// Compose our new rotation with the original
+	Quatf q; q.setAxisAngle( rotation.axis, radians );
+	M44f m = q.toMatrix44();
+	m.rotate( degreesToRadians( rotation.originalRotation ) );
+
+	// Convert to the euler angles closest to
+	// those we currently have.
+	Eulerf e; e.extract( m );
+	e.makeNear( degreesToRadians( selection.transformPlug->rotatePlug()->getValue() ) );
+
+	return V3f( e );
+}
+
+void RotateTool::applyRotation( const Rotation &rotation, float radians )
+{
+	const Selection &selection = this->selection();
+	const V3f r = radiansToDegrees( this->rotation( rotation, radians ) );
+	for( int i = 0; i < 3; ++i )
+	{
+		FloatPlug *p = selection.transformPlug->rotatePlug()->getChild( i );
+		if( p->settable() && !MetadataAlgo::readOnly( p ) )
+		{
+			p->setValue( r[i] );
+		}
+	}
+}
+
+IECore::RunTimeTypedPtr RotateTool::dragBegin( int axis )
+{
+	m_drag = createRotation( axis );
+	TransformTool::dragBegin();
+	return NULL; // Let the handle start the drag.
+}
+
+bool RotateTool::dragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event )
+{
+	UndoScope undoScope( selection().transformPlug->ancestor<ScriptNode>(), UndoScope::Enabled, undoMergeGroup() );
+	const float r = static_cast<const RotateHandle *>( gadget )->rotation( event );
+	applyRotation( m_drag, r );
+	return true;
+}
+
+bool RotateTool::dragEnd()
+{
+	TransformTool::dragEnd();
+	return false;
+}

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -495,6 +495,36 @@ void TransformTool::preRender()
 	}
 }
 
+Imath::M44f TransformTool::orientedTransform( Orientation orientation )
+{
+	Context::Scope scopedContext( view()->getContext() );
+
+	const Selection &selection = this->selection();
+	const M44f localMatrix = scenePlug()->transform( selection.path );
+	M44f parentMatrix;
+	if( selection.path.size() )
+	{
+		const ScenePlug::ScenePath parentPath( selection.path.begin(), selection.path.end() - 1 );
+		parentMatrix = scenePlug()->fullTransform( parentPath );
+	}
+
+	M44f result;
+	switch( orientation )
+	{
+		case Local :
+			result = localMatrix * parentMatrix;
+			break;
+		case Parent :
+			result = M44f().setTranslation( localMatrix.translation() ) * parentMatrix;
+			break;
+		case World :
+			result.setTranslation( ( localMatrix * parentMatrix ).translation() );
+			break;
+	}
+
+	return sansScaling( result );
+}
+
 void TransformTool::dragBegin()
 {
 	m_dragging = true;

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -238,6 +238,35 @@ bool updateSelectionWalk( const CapturedProcess::PtrVector &processes, Transform
 	return false;
 }
 
+class HandlesGadget : public Gadget
+{
+
+	public :
+
+		HandlesGadget( const std::string &name="HandlesGadget" )
+			:	Gadget( name )
+		{
+		}
+
+	protected :
+
+		virtual void doRender( const Style *style ) const
+		{
+			glEnable( GL_DEPTH_TEST );
+			// Render with reversed depth test so
+			// the handles are visible even when
+			// behind an object.
+			glDepthFunc( GL_GREATER );
+			Gadget::doRender( style );
+			// The render with the regular depth
+			// test so that the handles occlude
+			// themselves appropriately.
+			glDepthFunc( GL_LESS );
+			Gadget::doRender( style );
+		}
+
+};
+
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -250,7 +279,7 @@ size_t TransformTool::g_firstPlugIndex = 0;
 
 TransformTool::TransformTool( SceneView *view, const std::string &name )
 	:	SelectionTool( view, name ),
-		m_handles( new Gadget() ),
+		m_handles( new HandlesGadget() ),
 		m_selectionDirty( true ),
 		m_handlesDirty( true ),
 		m_dragging( false ),

--- a/src/GafferSceneUIBindings/RotateToolBinding.cpp
+++ b/src/GafferSceneUIBindings/RotateToolBinding.cpp
@@ -1,0 +1,57 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferBindings/NodeBinding.h"
+
+#include "GafferUI/Gadget.h"
+
+#include "GafferSceneUI/SceneView.h"
+#include "GafferSceneUI/RotateTool.h"
+#include "GafferSceneUIBindings/RotateToolBinding.h"
+
+using namespace boost::python;
+using namespace GafferSceneUI;
+
+void GafferSceneUIBindings::bindRotateTool()
+{
+
+	scope s = GafferBindings::NodeClass<RotateTool>( NULL, no_init )
+		.def( init<SceneView *>() )
+		.def( "rotate", &RotateTool::rotate )
+	;
+
+}
+

--- a/src/GafferSceneUIBindings/TransformToolBinding.cpp
+++ b/src/GafferSceneUIBindings/TransformToolBinding.cpp
@@ -115,4 +115,10 @@ void GafferSceneUIBindings::bindTransformTool()
 
 	;
 
+	enum_<TransformTool::Orientation>( "Orientation" )
+		.value( "Local", TransformTool::Local )
+		.value( "Parent", TransformTool::Parent )
+		.value( "World", TransformTool::World )
+	;
+
 }

--- a/src/GafferSceneUIBindings/TranslateToolBinding.cpp
+++ b/src/GafferSceneUIBindings/TranslateToolBinding.cpp
@@ -48,15 +48,9 @@ using namespace GafferSceneUI;
 void GafferSceneUIBindings::bindTranslateTool()
 {
 
-	scope s = GafferBindings::NodeClass<TranslateTool>( NULL, no_init )
+	GafferBindings::NodeClass<TranslateTool>( NULL, no_init )
 		.def( init<SceneView *>() )
 		.def( "translate", &TranslateTool::translate )
-	;
-
-	enum_<TranslateTool::Orientation>( "Orientation" )
-		.value( "Local", TranslateTool::Local )
-		.value( "Parent", TranslateTool::Parent )
-		.value( "World", TranslateTool::World )
 	;
 
 }

--- a/src/GafferSceneUIModule/GafferSceneUIModule.cpp
+++ b/src/GafferSceneUIModule/GafferSceneUIModule.cpp
@@ -52,6 +52,7 @@
 #include "GafferSceneUIBindings/ShaderViewBinding.h"
 #include "GafferSceneUIBindings/TransformToolBinding.h"
 #include "GafferSceneUIBindings/TranslateToolBinding.h"
+#include "GafferSceneUIBindings/RotateToolBinding.h"
 #include "GafferSceneUIBindings/ScaleToolBinding.h"
 
 using namespace boost::python;
@@ -103,6 +104,7 @@ BOOST_PYTHON_MODULE( _GafferSceneUI )
 
 	bindTransformTool();
 	bindTranslateTool();
+	bindRotateTool();
 	bindScaleTool();
 	bindObjectVisualiser();
 	bindLightVisualiser();

--- a/src/GafferUI/RotateHandle.cpp
+++ b/src/GafferUI/RotateHandle.cpp
@@ -1,0 +1,130 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/bind.hpp"
+
+#include "OpenEXR/ImathEuler.h"
+
+#include "IECore/Exception.h"
+
+#include "GafferUI/RotateHandle.h"
+
+using namespace Imath;
+using namespace IECore;
+using namespace GafferUI;
+
+//////////////////////////////////////////////////////////////////////////
+//
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+float closestRotation( const V2f &p, float targetRotation )
+{
+	const float r = atan2( p.y, p.x );
+	return Eulerf::angleMod( r - targetRotation ) + targetRotation;
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// RotateHandle
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( RotateHandle );
+
+RotateHandle::RotateHandle( Style::Axes axes )
+	:	Handle( defaultName<RotateHandle>() ), m_axes( Style::X )
+{
+	setAxes( axes );
+	dragMoveSignal().connect( boost::bind( &RotateHandle::dragMove, this, ::_2 ) );
+}
+
+RotateHandle::~RotateHandle()
+{
+}
+
+void RotateHandle::setAxes( Style::Axes axes )
+{
+	if( axes == m_axes )
+	{
+		return;
+	}
+
+	if( axes > Style::Z )
+	{
+		throw IECore::Exception( "Unsupported axes" );
+	}
+
+	m_axes = axes;
+	requestRender();
+}
+
+Style::Axes RotateHandle::getAxes() const
+{
+	return m_axes;
+}
+
+float RotateHandle::rotation( const DragDropEvent &event ) const
+{
+	return closestRotation( m_drag.position( event ), m_rotation ) - closestRotation( m_drag.startPosition(), 0.0f );
+}
+
+void RotateHandle::renderHandle( const Style *style, Style::State state ) const
+{
+	style->renderRotateHandle( m_axes, state );
+}
+
+void RotateHandle::dragBegin( const DragDropEvent &event )
+{
+	V3f axis0( 0.0f );
+	V3f axis1( 0.0f );
+	axis0[(m_axes+1)%3] = 1.0f;
+	axis1[(m_axes+2)%3] = 1.0f;
+	m_drag = PlanarDrag( this, V3f( 0 ), axis0, axis1, event );
+	m_rotation = closestRotation( m_drag.position( event ), 0.0f );
+}
+
+bool RotateHandle::dragMove( const DragDropEvent &event )
+{
+	// We can only recover an angle in the range -PI, PI from the 2d position
+	// that our drag gives us, but we want to be able to support continuous
+	// values and multiple revolutions. Here we keep track of the current rotation
+	// position so that we can adjust correctly in `RotateHandle::rotation()`.
+	m_rotation = closestRotation( m_drag.position( event ), m_rotation );
+	return false;
+}

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -298,7 +298,6 @@ IECoreGL::GroupPtr translateHandle( Style::Axes axes )
 	group->addChild( cylinder() );
 	group->addChild( coneGroup );
 
-	group->getState()->add( new IECoreGL::DepthTestStateComponent( false ) );
 	group->getState()->add( new IECoreGL::Color( colorForAxes( axes ) ) );
 	group->getState()->add(
 		new IECoreGL::ShaderStateComponent( ShaderLoader::defaultShaderLoader(), TextureLoader::defaultTextureLoader(), "", "", IECoreGL::Shader::constantFragmentSource(), new CompoundObject )
@@ -334,7 +333,6 @@ IECoreGL::GroupPtr rotateHandle( Style::Axes axes )
 	IECoreGL::GroupPtr group = new IECoreGL::Group;
 	group->addChild( torus() );
 
-	group->getState()->add( new IECoreGL::DepthTestStateComponent( false ) );
 	group->getState()->add( new IECoreGL::Color( colorForAxes( axes ) ) );
 	group->getState()->add(
 		new IECoreGL::ShaderStateComponent( ShaderLoader::defaultShaderLoader(), TextureLoader::defaultTextureLoader(), "", "", IECoreGL::Shader::constantFragmentSource(), new CompoundObject )
@@ -378,7 +376,6 @@ IECoreGL::GroupPtr scaleHandle( Style::Axes axes )
 	}
 	group->addChild( cubeGroup );
 
-	group->getState()->add( new IECoreGL::DepthTestStateComponent( false ) );
 	group->getState()->add( new IECoreGL::Color( colorForAxes( axes ) ) );
 	group->getState()->add(
 		new IECoreGL::ShaderStateComponent( ShaderLoader::defaultShaderLoader(), TextureLoader::defaultTextureLoader(), "", "", IECoreGL::Shader::constantFragmentSource(), new CompoundObject )

--- a/src/GafferUIBindings/StyleBinding.cpp
+++ b/src/GafferUIBindings/StyleBinding.cpp
@@ -85,6 +85,8 @@ void GafferUIBindings::bindStyle()
 		.def( "renderBackdrop", &Style::renderBackdrop )
 
 		.def( "renderTranslateHandle", &Style::renderTranslateHandle )
+		.def( "renderRotateHandle", &Style::renderRotateHandle )
+		.def( "renderScaleHandle", &Style::renderScaleHandle )
 
 		.def( "changedSignal", &Style::changedSignal, return_internal_reference<1>() )
 		.def( "getDefaultStyle", &Style::getDefaultStyle ).staticmethod( "getDefaultStyle" )


### PR DESCRIPTION
This adds a basic tool for rotating objects interactively.

![rotatetool](https://cloud.githubusercontent.com/assets/1133871/25177102/9528c81e-24f8-11e7-9b9e-f2df0758259d.png)

Full disclosure : in last minute testing I've found a bug when using this with a Transform node (rather than Group, Light etc), whereby we're not correctly evaluating the orientation with respect to the Transform node's existing transform. The TranslateTool on master has the same problem and it has apparently gone unnoticed so far. I'd still like to get this PR merged for the next release as it is still useful in this state, and I'd rather follow up with a patch version than have to force a second major version change shortly after this one.