### PR TITLE
Set expressions filter squashed

### DIFF
--- a/doc/source/Reference/ScriptingReference/SetExpressions/index.md
+++ b/doc/source/Reference/ScriptingReference/SetExpressions/index.md
@@ -22,13 +22,13 @@ A B C B C D C D E E
 The following operators are currently supported
 
 ```eval_rst
-=================== ====================================
-Operator            Behavior
-=================== ====================================
-\|                  OR, unites two sets
-&                   AND, intersects two sets
-\-                  ANDNOT, removes elements from sets
-=================== ====================================
+=================== ======================================
+Operator            Behaviour
+=================== ======================================
+\|                  Union, unites two sets
+&                   Intersection, intersects two sets
+\-                  Difference, removes elements from sets
+=================== ======================================
 ```
 
 Simple Examples
@@ -72,7 +72,7 @@ set1 \- (B C)        A
 Operator Precedence
 -------------------
 
-Operations in the expression are executed in the following order: ANDNOT before AND before OR. The following examples demonstrate this in action.
+Operations in the expression are executed in the following order: difference before intersection before union. The following examples demonstrate this in action.
 
 ```eval_rst
 ==================== ==============================

--- a/include/GafferScene/SetFilter.h
+++ b/include/GafferScene/SetFilter.h
@@ -64,8 +64,8 @@ class SetFilter : public Filter
 		SetFilter( const std::string &name=defaultName<SetFilter>() );
 		virtual ~SetFilter();
 
-		Gaffer::StringPlug *setPlug();
-		const Gaffer::StringPlug *setPlug() const;
+		Gaffer::StringPlug *setExpressionPlug();
+		const Gaffer::StringPlug *setExpressionPlug() const;
 
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 

--- a/include/GafferScene/SetFilter.h
+++ b/include/GafferScene/SetFilter.h
@@ -41,6 +41,7 @@
 
 #include "GafferScene/Filter.h"
 #include "GafferScene/PathMatcher.h"
+#include "GafferScene/PathMatcherDataPlug.h"
 
 namespace Gaffer
 {
@@ -72,10 +73,16 @@ class SetFilter : public Filter
 
 	protected :
 
+		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+
 		virtual void hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual unsigned computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const;
 
 	private :
+
+		GafferScene::PathMatcherDataPlug *expressionResultPlug();
+		const GafferScene::PathMatcherDataPlug *expressionResultPlug() const;
 
 		static size_t g_firstPlugIndex;
 

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -243,7 +243,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["sphere"]["sets"].setValue( "${wedge:value}" )
 
 		s["filter"] = GafferScene.SetFilter()
-		s["filter"]["set"].setValue( "hidden" )
+		s["filter"]["setExpression"].setValue( "hidden" )
 
 		s["attributes"] = GafferScene.StandardAttributes()
 		s["attributes"]["attributes"]["visibility"]["enabled"].setValue( True )

--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -672,7 +672,7 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s["sphere"]["sets"].setValue( "${wedge:value}" )
 
 		s["filter"] = GafferScene.SetFilter()
-		s["filter"]["set"].setValue( "hidden" )
+		s["filter"]["setExpression"].setValue( "hidden" )
 
 		s["attributes"] = GafferScene.StandardAttributes()
 		s["attributes"]["attributes"]["visibility"]["enabled"].setValue( True )

--- a/python/GafferSceneTest/DeleteSetsTest.py
+++ b/python/GafferSceneTest/DeleteSetsTest.py
@@ -140,7 +140,7 @@ class DeleteSetsTest( GafferSceneTest.SceneTestCase ) :
 		d["in"].setInput( p["out"] )
 
 		f = GafferScene.SetFilter()
-		f["set"].setValue( "test" )
+		f["setExpression"].setValue( "test" )
 
 		a = GafferScene.CustomAttributes()
 		a["in"].setInput( d["out"] )

--- a/python/GafferSceneTest/FilterResultsTest.py
+++ b/python/GafferSceneTest/FilterResultsTest.py
@@ -108,7 +108,7 @@ class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
 		p["sets"].setValue( "A" )
 
 		f = GafferScene.SetFilter()
-		f["set"].setValue( "A" )
+		f["setExpression"].setValue( "A" )
 
 		n = GafferScene.FilterResults()
 		n["scene"].setInput( p["out"] )
@@ -116,7 +116,7 @@ class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
 
 		cs = GafferTest.CapturingSlot( n.plugDirtiedSignal() )
 
-		f["set"].setValue( "planeSet" )
+		f["setExpression"].setValue( "planeSet" )
 		self.assertTrue( n["out"] in { x[0] for x in cs } )
 		del cs[:]
 

--- a/python/GafferSceneTest/FilterSwitchTest.py
+++ b/python/GafferSceneTest/FilterSwitchTest.py
@@ -76,7 +76,7 @@ class FilterSwitchTest( GafferSceneTest.SceneTestCase ) :
 		script["attributes"]["in"].setInput( script["planeSet"]["out"] )
 
 		script["setFilter"] = GafferScene.SetFilter()
-		script["setFilter"]["set"].setValue( "set" )
+		script["setFilter"]["setExpression"].setValue( "set" )
 
 		script["pathFilter"] = GafferScene.PathFilter()
 		script["pathFilter"]["paths"].setValue( IECore.StringVectorData( [ "/group/sphere" ] ) )

--- a/python/GafferSceneTest/IsolateTest.py
+++ b/python/GafferSceneTest/IsolateTest.py
@@ -474,7 +474,7 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 		sphere["sets"].setValue( "A" )
 
 		filter = GafferScene.SetFilter()
-		filter["set"].setValue( "A" )
+		filter["setExpression"].setValue( "A" )
 
 		isolate = GafferScene.Isolate()
 		isolate["in"].setInput( sphere["out"] )

--- a/python/GafferSceneTest/SceneFilterPathFilterTest.py
+++ b/python/GafferSceneTest/SceneFilterPathFilterTest.py
@@ -57,7 +57,7 @@ class SceneFilterPathFilterTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( set( [ str( c ) for c in path.children() ] ), { "/group/camera", "/group/plane" } )
 
 		setFilter = GafferScene.SetFilter()
-		setFilter["set"].setValue( "__cameras" )
+		setFilter["setExpression"].setValue( "__cameras" )
 		pathFilter = GafferScene.SceneFilterPathFilter( setFilter )
 
 		path.setFilter( pathFilter )
@@ -65,7 +65,7 @@ class SceneFilterPathFilterTest( GafferSceneTest.SceneTestCase ) :
 
 		cs = GafferTest.CapturingSlot( pathFilter.changedSignal() )
 
-		setFilter["set"].setValue( "" )
+		setFilter["setExpression"].setValue( "" )
 		self.assertEqual( len( cs ), 1 )
 		self.assertEqual( path.children(), [] )
 

--- a/python/GafferSceneTest/SetAlgoTest.py
+++ b/python/GafferSceneTest/SetAlgoTest.py
@@ -96,6 +96,8 @@ class SetAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		expressionCheck = functools.partial( self.assertCorrectEvaluation, group2["out"] )
 
+		expressionCheck( '', [] )
+
 		expressionCheck( 'setA', [ '/group/group/sphere1', '/group/group/sphere2' ] )
 		expressionCheck( '/group/sphere3', [ '/group/sphere3' ] )
 

--- a/python/GafferSceneTest/SetAlgoTest.py
+++ b/python/GafferSceneTest/SetAlgoTest.py
@@ -139,11 +139,8 @@ class SetAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual( str( e.exception ), 'Exception : Syntax error in indicated part of SetExpression.\nsetA - (/group/group/sphere2\n     |---------------------|\n.' )
 
-		# Test exception for invalid set names
-		with self.assertRaises( RuntimeError ) as e :
-			GafferScene.SetAlgo.evaluateSetExpression( 'A', group2["out"] )
-
-		self.assertEqual( str( e.exception ), 'Exception : Set A is not available in SetExpression.' )
+		# Sets that don't exist should be replaced with an empty PathMatcher
+		expressionCheck( 'A', [] )
 
 		# Test that changing set contents will result in an updated hash
 		h = GafferScene.SetAlgo.setExpressionHash( "setA", group2["out"] )

--- a/python/GafferSceneTest/SetFilterTest.py
+++ b/python/GafferSceneTest/SetFilterTest.py
@@ -59,7 +59,7 @@ class SetFilterTest( GafferSceneTest.SceneTestCase ) :
 		s["paths"].setValue( IECore.StringVectorData( [ "/group/plane" ] ) )
 
 		f = GafferScene.SetFilter()
-		f["set"].setValue( "set" )
+		f["setExpression"].setValue( "set" )
 
 		a = GafferScene.StandardAttributes()
 		a["in"].setInput( s["out"] )
@@ -134,7 +134,7 @@ class SetFilterTest( GafferSceneTest.SceneTestCase ) :
 		s2["paths"].setValue( IECore.StringVectorData( [ "/group/plane" ] ) )
 
 		f = GafferScene.SetFilter()
-		f["set"].setValue( "set" )
+		f["setExpression"].setValue( "set" )
 
 		a1 = GafferScene.StandardAttributes()
 		a1["in"].setInput( s1["out"] )
@@ -174,7 +174,7 @@ class SetFilterTest( GafferSceneTest.SceneTestCase ) :
 		s2["in"].setInput( s1["out"] )
 
 		f = GafferScene.SetFilter()
-		f["set"].setValue( "set1" )
+		f["setExpression"].setValue( "set1" )
 
 		i = GafferScene.Isolate()
 		i["in"].setInput( s2["out"] )
@@ -202,10 +202,10 @@ class SetFilterTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertFalse( "doubleSided" in a["out"].attributes( "/plane" ).keys() )
 
-		f["set"].setValue( "nonExistent" )
+		f["setExpression"].setValue( "nonExistent" )
 		self.assertFalse( "doubleSided" in a["out"].attributes( "/plane" ).keys() )
 
-		f["set"].setValue( "flatThings" )
+		f["setExpression"].setValue( "flatThings" )
 		self.assertTrue( "doubleSided" in a["out"].attributes( "/plane" ).keys() )
 
 	def testSetExpressionSupport( self ) :
@@ -238,25 +238,25 @@ class SetFilterTest( GafferSceneTest.SceneTestCase ) :
 		a1["attributes"]["doubleSided"]["enabled"].setValue( True )
 		a1["filter"].setInput( f["out"] )
 
-		f["set"].setValue( "set1 | set2" )  # /group, /group/plane, /group/plane1
+		f["setExpression"].setValue( "set1 | set2" )  # /group, /group/plane, /group/plane1
 
 		self.assertTrue( "doubleSided" in a1["out"].attributes( "/group" ) )
 		self.assertTrue( "doubleSided" in a1["out"].attributes( "/group/plane" ) )
 		self.assertTrue( "doubleSided" in a1["out"].attributes( "/group/plane1" ) )
 
-		f["set"].setValue( "set1 set2" )  # /group, /group/plane, /group/plane1
+		f["setExpression"].setValue( "set1 set2" )  # /group, /group/plane, /group/plane1
 
 		self.assertTrue( "doubleSided" in a1["out"].attributes( "/group" ) )
 		self.assertTrue( "doubleSided" in a1["out"].attributes( "/group/plane" ) )
 		self.assertTrue( "doubleSided" in a1["out"].attributes( "/group/plane1" ) )
 
-		f["set"].setValue( "set1 & set2" )  # sets don't intersect
+		f["setExpression"].setValue( "set1 & set2" )  # sets don't intersect
 
 		self.assertTrue( "doubleSided" not in a1["out"].attributes( "/group" ) )
 		self.assertTrue( "doubleSided" not in a1["out"].attributes( "/group/plane" ) )
 		self.assertTrue( "doubleSided" not in a1["out"].attributes( "/group/plane1" ) )
 
-		f["set"].setValue( "set1 & set3" )  # /group/plane
+		f["setExpression"].setValue( "set1 & set3" )  # /group/plane
 
 		self.assertTrue( "doubleSided" not in a1["out"].attributes( "/group" ) )
 		self.assertTrue( "doubleSided" in a1["out"].attributes( "/group/plane" ) )

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -302,10 +302,10 @@ class _LookThroughPlugValueWidget( GafferUI.PlugValueWidget ) :
 		# Must parent this filter to validFilter so it remains alive
 		# after returning from this method.
 		validFilter["__camerasFilter"] = GafferScene.SetFilter()
-		validFilter["__camerasFilter"]["set"].setValue( "__cameras" )
+		validFilter["__camerasFilter"]["setExpression"].setValue( "__cameras" )
 
 		validFilter["__lightsFilter"] = GafferScene.SetFilter()
-		validFilter["__lightsFilter"]["set"].setValue( "__lights" )
+		validFilter["__lightsFilter"]["setExpression"].setValue( "__lights" )
 
 		validFilter["in"][0].setInput( validFilter["__camerasFilter"]["out"] )
 		validFilter["in"][1].setInput( validFilter["__lightsFilter"]["out"] )

--- a/python/GafferSceneUI/SetFilterUI.py
+++ b/python/GafferSceneUI/SetFilterUI.py
@@ -77,7 +77,7 @@ Gaffer.Metadata.registerNode(
 			entries that help construct set expressions.
 			""",
 
-			"ui:scene:acceptsSetName", True,
+			"ui:scene:acceptsSetExpression", True,
 			"nodule:type", "",
 
 		],

--- a/python/GafferSceneUI/SetFilterUI.py
+++ b/python/GafferSceneUI/SetFilterUI.py
@@ -57,8 +57,24 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			The name of a set that defines the locations to
-			be matched.
+			A set expression that computes a set that defines
+			the locations to be matched.
+
+			For example, the expression "mySpheresSet | myCubesSet"
+			will create a set that contains all objects in
+			mySpheresSet and myCubesSet.
+
+			Gaffer supports the union operator (|) as shown in the
+			example and also provides intersection (&) and difference (-)
+			operations for set expressions. Names of locations
+			can be used to represent a set that contains only
+			that one location.
+
+			For more examples please consult the Scripting Reference
+			section in Gaffer's documentation.
+
+			The context menu of the set expression text field provides
+			entries that help construct set expressions.
 			""",
 
 			"ui:scene:acceptsSetName", True,

--- a/python/GafferSceneUI/SetFilterUI.py
+++ b/python/GafferSceneUI/SetFilterUI.py
@@ -53,7 +53,7 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
-		"set" : [
+		"setExpression" : [
 
 			"description",
 			"""

--- a/src/GafferScene/ScenePath.cpp
+++ b/src/GafferScene/ScenePath.cpp
@@ -221,7 +221,7 @@ Gaffer::PathFilterPtr ScenePath::createStandardFilter( const std::vector<std::st
 	{
 		SetFilterPtr setFilter = new SetFilter();
 		unionFilter->addChild( setFilter );
-		setFilter->setPlug()->setValue( *it );
+		setFilter->setExpressionPlug()->setValue( *it );
 		unionFilter->inPlugs()->getChild<Gaffer::Plug>( it - setNames.begin() )->setInput( setFilter->outPlug() );
 
 		if( it != setNames.begin() )

--- a/src/GafferScene/SetAlgo.cpp
+++ b/src/GafferScene/SetAlgo.cpp
@@ -294,6 +294,11 @@ struct AstHasher
 
 	void operator()( const SetName &n )
 	{
+		if( !m_scene )
+		{
+			throw IECore::Exception( "SetAlgo: Invalid scene given. Can not hash set expression." );
+		}
+
 		m_hash.append( m_scene->setHash( n.name ) );
 	}
 

--- a/src/GafferScene/SetAlgo.cpp
+++ b/src/GafferScene/SetAlgo.cpp
@@ -185,6 +185,10 @@ struct AstPrinter
 		boost::apply_visitor( *this, ast.expr );
 	}
 
+	void operator()( const Nil &nil ) const
+	{
+	}
+
 	void operator()( const BinaryOp &expr ) const
 	{
 		stream << "op:" << expr.op << "(";
@@ -242,6 +246,12 @@ struct AstEvaluator
 	result_type operator()( const ExpressionAst &ast ) const
 	{
 		return boost::apply_visitor( *this, ast.expr );
+	}
+
+	result_type operator()( const Nil &nil ) const
+	{
+		PathMatcher result;
+		return result;
 	}
 
 	result_type operator()( const BinaryOp &expr ) const
@@ -306,6 +316,10 @@ struct AstHasher
 		m_hash.append( expr.op );
 		boost::apply_visitor( *this, expr.left.expr );
 		boost::apply_visitor( *this, expr.right.expr );
+	}
+
+	void operator()( const Nil &nil )
+	{
 	}
 
 	const ScenePlug* m_scene;
@@ -386,6 +400,11 @@ struct ExpressionGrammar : qi::grammar<Iterator, ExpressionAst(), ascii::space_t
 
 void expressionToAST( const std::string &setExpression, ExpressionAst &ast)
 {
+	if( setExpression == "" )
+	{
+		return;
+	}
+
 	typedef std::string::const_iterator iterator_type;
 	typedef ExpressionGrammar<iterator_type> ExpressionGrammar;
 

--- a/src/GafferScene/SetAlgo.cpp
+++ b/src/GafferScene/SetAlgo.cpp
@@ -224,16 +224,7 @@ struct AstEvaluator
 
 	result_type operator()( const SetName &set ) const
 	{
-		IECore::ConstInternedStringVectorDataPtr setNames = m_scene->setNames();
-		const std::vector<IECore::InternedString> &setNamesReadable = setNames->readable();
-		if( std::find( setNamesReadable.begin(), setNamesReadable.end(), IECore::InternedString( set.name ) ) != setNamesReadable.end() )
-		{
-			return m_scene->set( set.name )->readable();
-		}
-		else
-		{
-			throw IECore::Exception( boost::str( boost::format( "Set %s is not available in SetExpression." ) % set.name ) );
-		}
+		return m_scene->set( set.name )->readable();
 	}
 
 	result_type operator()( const ObjectName &object ) const

--- a/src/GafferScene/SetFilter.cpp
+++ b/src/GafferScene/SetFilter.cpp
@@ -56,7 +56,7 @@ SetFilter::SetFilter( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 
-	addChild( new StringPlug( "set" ) );
+	addChild( new StringPlug( "setExpression" ) );
 	addChild( new PathMatcherDataPlug( "__expressionResult", Gaffer::Plug::Out, new PathMatcherData ) );
 }
 
@@ -64,12 +64,12 @@ SetFilter::~SetFilter()
 {
 }
 
-Gaffer::StringPlug *SetFilter::setPlug()
+Gaffer::StringPlug *SetFilter::setExpressionPlug()
 {
 	return getChild<StringPlug>( g_firstPlugIndex );
 }
 
-const Gaffer::StringPlug *SetFilter::setPlug() const
+const Gaffer::StringPlug *SetFilter::setExpressionPlug() const
 {
 	return getChild<StringPlug>( g_firstPlugIndex );
 }
@@ -88,7 +88,7 @@ void SetFilter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 {
 	Filter::affects( input, outputs );
 
-	if( input == setPlug() )
+	if( input == setExpressionPlug() )
 	{
 		outputs.push_back( expressionResultPlug() );
 	}
@@ -116,7 +116,7 @@ void SetFilter::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 
 	if( output == expressionResultPlug() )
 	{
-		SetAlgo::setExpressionHash( setPlug()->getValue(), getInputScene( context ), h );
+		SetAlgo::setExpressionHash( setExpressionPlug()->getValue(), getInputScene( context ), h );
 	}
 
 }
@@ -127,7 +127,7 @@ void SetFilter::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 
 	if( output == expressionResultPlug() )
 	{
-		PathMatcherDataPtr data = new PathMatcherData( SetAlgo::evaluateSetExpression( setPlug()->getValue(), getInputScene( context ) ) );
+		PathMatcherDataPtr data = new PathMatcherData( SetAlgo::evaluateSetExpression( setExpressionPlug()->getValue(), getInputScene( context ) ) );
 		static_cast<PathMatcherDataPlug *>( output )->setValue( data );
 	}
 }

--- a/src/GafferScene/SetFilter.cpp
+++ b/src/GafferScene/SetFilter.cpp
@@ -40,6 +40,7 @@
 #include "GafferScene/ScenePlug.h"
 #include "GafferScene/PathMatcherData.h"
 #include "GafferScene/SetFilter.h"
+#include "GafferScene/SetAlgo.h"
 
 using namespace GafferScene;
 using namespace Gaffer;
@@ -56,6 +57,7 @@ SetFilter::SetFilter( const std::string &name )
 	storeIndexOfNextChild( g_firstPlugIndex );
 
 	addChild( new StringPlug( "set" ) );
+	addChild( new PathMatcherDataPlug( "__expressionResult", Gaffer::Plug::Out, new PathMatcherData ) );
 }
 
 SetFilter::~SetFilter()
@@ -72,14 +74,30 @@ const Gaffer::StringPlug *SetFilter::setPlug() const
 	return getChild<StringPlug>( g_firstPlugIndex );
 }
 
+PathMatcherDataPlug *SetFilter::expressionResultPlug()
+{
+	return getChild<PathMatcherDataPlug>( g_firstPlugIndex + 1 );
+}
+
+const PathMatcherDataPlug *SetFilter::expressionResultPlug() const
+{
+	return getChild<PathMatcherDataPlug>( g_firstPlugIndex + 1 );
+}
+
 void SetFilter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	Filter::affects( input, outputs );
 
 	if( input == setPlug() )
 	{
+		outputs.push_back( expressionResultPlug() );
+	}
+
+	if( input == expressionResultPlug() )
+	{
 		outputs.push_back( outPlug() );
 	}
+
 }
 
 bool SetFilter::sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const
@@ -90,6 +108,28 @@ bool SetFilter::sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePl
 	}
 
 	return child == scene->setPlug();
+}
+
+void SetFilter::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	Filter::hash( output, context, h );
+
+	if( output == expressionResultPlug() )
+	{
+		SetAlgo::setExpressionHash( setPlug()->getValue(), getInputScene( context ), h );
+	}
+
+}
+
+void SetFilter::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const
+{
+	Filter::compute( output, context );
+
+	if( output == expressionResultPlug() )
+	{
+		PathMatcherDataPtr data = new PathMatcherData( SetAlgo::evaluateSetExpression( setPlug()->getValue(), getInputScene( context ) ) );
+		static_cast<PathMatcherDataPlug *>( output )->setValue( data );
+	}
 }
 
 void SetFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const
@@ -118,7 +158,10 @@ void SetFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *contex
 		h.append( &(path[0]), path.size() );
 	}
 
-	h.append( scene->setHash( setPlug()->getValue() ) );
+	Gaffer::Context::EditableScope expressionResultScope( context );
+	expressionResultScope.remove( ScenePlug::scenePathContextName );
+
+	expressionResultPlug()->hash( h );
 }
 
 unsigned SetFilter::computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const
@@ -129,7 +172,11 @@ unsigned SetFilter::computeMatch( const ScenePlug *scene, const Gaffer::Context 
 	}
 
 	const ScenePlug::ScenePath &path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
-	ConstPathMatcherDataPtr set = scene->set( setPlug()->getValue() );
+
+	Gaffer::Context::EditableScope expressionResultScope( context );
+	expressionResultScope.remove( ScenePlug::scenePathContextName );
+
+	ConstPathMatcherDataPtr set = expressionResultPlug()->getValue();
 
 	return set->readable().match( path );
 }

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -787,7 +787,7 @@ class SceneView::LookThrough : public boost::signals::trackable
 			// We use a LightToCamera node filtered to all lights to create camera standins so that we can
 			// look through lights
 			SetFilterPtr lightFilter = new SetFilter;
-			lightFilter->setPlug()->setValue( "__lights" );
+			lightFilter->setExpressionPlug()->setValue( "__lights" );
 
 			LightToCameraPtr lightConverter = new LightToCamera;
 			lightConverter->inPlug()->setInput( view->inPlug<ScenePlug>() );

--- a/startup/GafferScene/setFilterCompatibility.py
+++ b/startup/GafferScene/setFilterCompatibility.py
@@ -1,0 +1,52 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+# Provides backwards compatibility by allowing access to "setExpression" plug
+# using its old name of "set".
+def __setFilterGetItem( originalGetItem ) :
+
+	def getItem( self, key ) :
+
+		key = "setExpression" if key == "set" else key
+		return originalGetItem( self, key )
+
+	return getItem
+
+
+GafferScene.SetFilter.__getitem__ = __setFilterGetItem( GafferScene.SetFilter.__getitem__ )


### PR DESCRIPTION
This is Matti's #2037 with the squashing indicated by the commit messages done, the `SetFilter::setPlug()` accessors renamed, and a few missing "set" -> "setExpression" changed added. Just pushing up for a final run on Travis before merging.