### PR TITLE
GafferUI::NodeSetEditor : "Edit..." menu option now consistently pops up editor

### DIFF
--- a/python/GafferUI/NodeSetEditor.py
+++ b/python/GafferUI/NodeSetEditor.py
@@ -148,6 +148,25 @@ class NodeSetEditor( GafferUI.EditorWidget ) :
 
 		return editor
 
+	## Consistently create a floating window with a new editor of this class type
+	@classmethod
+	def create( cls, node ) :
+
+		if isinstance( node, Gaffer.ScriptNode ) :
+			script = node
+		else :
+			script = node.scriptNode()
+
+		scriptWindow = GafferUI.ScriptWindow.acquire( script )
+
+		editor = cls( script )
+		editor.setNodeSet( Gaffer.StandardSet( [ node ] ) )
+
+		window = _EditorWindow( scriptWindow, editor )
+		window.setVisible( True )
+
+		return editor
+
 	def _lastAddedNode( self ) :
 
 		if len( self.__nodeSet ) :

--- a/startup/gui/nodeGraph.py
+++ b/startup/gui/nodeGraph.py
@@ -101,7 +101,7 @@ GafferUI.NodeGraph.nodeDoubleClickSignal().connect( __nodeDoubleClick, scoped = 
 
 def __nodeContextMenu( nodeGraph, node, menuDefinition ) :
 
-	menuDefinition.append( "/Edit...", { "command" : IECore.curry( GafferUI.NodeEditor.acquire, node ) } )
+	menuDefinition.append( "/Edit...", { "command" : IECore.curry( GafferUI.NodeEditor.create, node ) } )
 
 	GafferUI.NodeGraph.appendEnabledPlugMenuDefinitions( nodeGraph, node, menuDefinition )
 	GafferUI.NodeGraph.appendConnectionVisibilityMenuDefinitions( nodeGraph, node, menuDefinition )


### PR DESCRIPTION
From this morning's meeting where some people went through some small UI annoyances, here's a tiny one of mine that got a chorus of agreement when I mentioned it bugged me.

I've switched the "Edit..." right click option on a node to always pop up an editor window, instead of the current behaviour of "maybe pop up an editor window, or maybe change tabs in your existing UI if I can find an existing window".  It seems desirable to make the UI behave more consistently, and everyone I've talked to wants "Edit..." to always pop up.

I've currently added a new create() method, and not touched the existing acquire(), although I'm not sure if there is any situation when we would really want to use this.   It is currently bound to double clicking on a node, though I don't think anyone is using that.  We actually had a request this morning that double-clicking on a node jump inside so that you don't need the keyboard to hit down while browsing through a hierarchical network ( Houdini users are all used to this ), and this seems like a reasonable idea to me.