### PR TITLE
ArnoldOptions : Add "ai:parallel_node_init" and enable it by default.

### DIFF
--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -48,6 +48,8 @@ def __renderingSummary( plug ) :
 		info.append( "Bucket Size %d" % plug["bucketSize"]["value"].getValue() )
 	if plug["bucketScanning"]["enabled"].getValue() :
 		info.append( "Bucket Scanning %s" % plug["bucketScanning"]["value"].getValue().capitalize() )
+	if plug["parallelNodeInit"]["enabled"].getValue() :
+		info.append( "Parallel Init %s" % plug["parallelNodeInit"]["value"].getValue() )
 	if plug["threads"]["enabled"].getValue() :
 		info.append( "Threads %d" % plug["threads"]["value"].getValue() )
 	return ", ".join( info )
@@ -233,6 +235,21 @@ Gaffer.Metadata.registerNode(
 			"plugValueWidget:type", 'GafferUI.PresetsPlugValueWidget',
 			"presetNames", IECore.StringVectorData( ["Top", "Bottom", "Left", "Right", "Random", "Woven", "Spiral", "Spiral"] ),
 			"presetValues", IECore.StringVectorData( ["top", "bottom", "left", "right", "random", "woven", "spiral", "spiral"] ),
+		],
+
+		"options.parallelNodeInit" : [
+
+			"description",
+			"""
+			Enables Arnold's parallel node initialization.
+			Note that some Arnold features may not be
+			thread-safe, in which case enabling this option
+			can cause crashes. One such example is Cryptomatte
+			and its use in the AlSurface shader.
+			""",
+
+			"layout:section", "Rendering",
+
 		],
 
 		"options.threads" : [

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -51,6 +51,7 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 
 	options->addOptionalMember( "ai:bucket_size", new IECore::IntData( 64 ), "bucketSize", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:bucket_scanning", new IECore::StringData( "spiral" ), "bucketScanning", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:parallel_node_init", new IECore::BoolData( false ), "parallelNodeInit", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:threads", new IECore::IntData( 0 ), "threads", Gaffer::Plug::Default, false );
 
 	// Sampling parameters


### PR DESCRIPTION
On a production scene which generates 99857 AiNodes, this reduced AiNode initialization from 1:01.96 to 0:08.17.

Note that anyoe using AlShaders with Cryptomatte enabled may want to disable this option with a userDefault.