### PR TITLE
OSL ShadingEngine : add *_index* as user data

### DIFF
--- a/python/GafferOSLTest/ShadingEngineTest.py
+++ b/python/GafferOSLTest/ShadingEngineTest.py
@@ -138,6 +138,15 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		for i, c in enumerate( p["Ci"] ) :
 			self.assertEqual( c, rp["colorUserData"][i] )
 
+
+		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
+			IECore.Shader( shader, "surface", { "name" : "shading:index" } ),
+		] ) )
+		p = e.shade( rp )
+
+		for i, c in enumerate( p["Ci"] ) :
+			self.assertEqual( c, IECore.Color3f(i) )
+
 	def testStructs( self ) :
 
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/structs.osl" )


### PR DESCRIPTION
@andrewkaufman  mentioned it would be helpful if we had access the index of the vertex being shaded in OSLObject. 

Called the user data *_index* to reduce the chance of collisions with primvars called  *index*.  Considered only adding the variable if a prim var doesn't exist but thought this was more confusing. Not very happy with this underscore convention but couldn't come up with anything neater.

InFloat can read this new *_index* primvar but not if the source data is defined as u64 so I attempt to use s32 before falling back to u64

