### PR TITLE
SConstruct : Use C++03 ABI with GCC 5.1 and greater

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -339,6 +339,9 @@ elif env["PLATFORM"] == "posix" :
 		if gccVersion >= [ 4, 2 ] :
 			env.Append( CXXFLAGS = [ "-Wno-error=strict-overflow" ] )
 
+		if gccVersion >= [ 5, 1 ] :
+			env.Append( CXXFLAGS = [ "-D_GLIBCXX_USE_CXX11_ABI=0" ] )
+
 	env["GAFFER_PLATFORM"] = "linux"
 
 env.Append( CXXFLAGS = [ "-std=$CXXSTD" ] )

--- a/config/jh/options
+++ b/config/jh/options
@@ -46,5 +46,5 @@ ARNOLD_ROOT = os.environ["ARNOLD_ROOT"]
 DOXYGEN = "/usr/local/bin/doxygen"
 PYTHON_LINK_FLAGS = [ "-lpython$PYTHON_VERSION" ]
 
-if sys.platform.startswith( "linux" ) :
+if os.path.exists( "/opt/rh/devtoolset-2/root/usr/bin/g++" ) :
 	CXX="/opt/rh/devtoolset-2/root/usr/bin/g++"


### PR DESCRIPTION
Our standard compiler is GCC 4.8.2 (as mandated by VFXPlatform 2017), and this only has the C++03 ABI, which the precompiled dependencies are compiled with. As of version 5.1, GCC started using a C++11 compatible ABI by default, which leads to linking errors when used with the precompiled dependencies.

More details here :

https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html