### PR TITLE
Support colon in set expressions

### DIFF
--- a/python/GafferSceneTest/SetAlgoTest.py
+++ b/python/GafferSceneTest/SetAlgoTest.py
@@ -147,6 +147,18 @@ class SetAlgoTest( GafferSceneTest.SceneTestCase ) :
 		setA["paths"].setValue( IECore.StringVectorData( [ '/group/sphere1' ] ) )
 		self.assertNotEqual( h, GafferScene.SetAlgo.setExpressionHash( "setA", group2["out"] ) )
 
+	def testColonInSetAndObjectNames( self ):
+
+		sphere1 = GafferScene.Sphere( "Sphere1" )
+		sphere1["name"].setValue( 'MyObject:sphere1' )
+
+		setA = GafferScene.Set( "SetA" )
+		setA["name"].setValue( "MySets:setA" )
+		setA["paths"].setValue( IECore.StringVectorData( [ "/MyObject:sphere1" ] ) )
+
+		self.assertCorrectEvaluation( setA["out"], "MySets:setA", [ "/MyObject:sphere1" ] )
+		self.assertCorrectEvaluation( setA["out"], "/MyObject:sphere1", [ "/MyObject:sphere1" ] )
+
 	def assertCorrectEvaluation( self, scenePlug, expression, expectedContents ) :
 
 		result = set( GafferScene.SetAlgo.evaluateSetExpression( expression, scenePlug ).paths() )

--- a/src/GafferScene/SetAlgo.cpp
+++ b/src/GafferScene/SetAlgo.cpp
@@ -373,10 +373,10 @@ struct ExpressionGrammar : qi::grammar<Iterator, ExpressionAst(), ascii::space_t
 
 
 		setName %= setNameToken;
-		setNameToken %= char_( "a-zA-Z_" ) >> *char_( "a-zA-Z_0-9" );
+		setNameToken %= char_( "a-zA-Z_" ) >> *char_( "a-zA-Z_0-9:" );
 
 		objectName %= objectNameToken;
-		objectNameToken %= char_( "/" ) >> *char_( "a-zA-Z_0-9/" );
+		objectNameToken %= char_( "/" ) >> *char_( "a-zA-Z_0-9/:" );
 
 
 		// these have no effect unless BOOST_SPIRIT_DEBUG is defined


### PR DESCRIPTION
The names of our sets often contain colons - this should fix parser errors we were seeing. I have also added support for colons to object names.

I guess I have two questions about this:

1. What other special characters do we want to support?
2. How do we want to handle set and object names that contain our set expression operators?

Maybe those two remaining questions boil down to: Do we want object names in gaffer to be more restricted than they currently are? "sphere*&|" is a perfectly valid name at the moment, but it feels like we should only allow [_a-zA-Z0-9][_a-zA-Z0-9:]* maybe? Having a convention like that would make it easier to keep the parser code in sync, I guess...