### PR TITLE
FilterPlugValueWidget : Remove unnecessary node placement code

### DIFF
--- a/python/GafferSceneUI/FilterPlugValueWidget.py
+++ b/python/GafferSceneUI/FilterPlugValueWidget.py
@@ -126,14 +126,6 @@ class FilterPlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.getPlug().node().parent().addChild( filterNode )
 			self.getPlug().setInput( filterNode["out"] )
 
-		# position the node appropriately.
-		scriptWindow = self.ancestor( GafferUI.ScriptWindow )
-		if scriptWindow is not None :
-			nodeGraphs = scriptWindow.getLayout().editors( GafferUI.NodeGraph )
-			if nodeGraphs :
-				graphGadget = nodeGraphs[0].graphGadget()
-				graphGadget.getLayout().positionNode( graphGadget, filterNode )
-
 	def __menuDefinition( self ) :
 
 		filterNode = self.__filterNode()


### PR DESCRIPTION
This was made unnecessary when we updated the NodeGraph to automatically position all unpositioned nodes before drawing. It was also buggy, since the first NodeGraph it found might not even contain the node to be positioned, in which case the positioning would fail, leaving the node at the origin.