### PR TITLE
StandardConnectionGadget : highlight connections across dots and switches

### DIFF
--- a/include/GafferUI/ConnectionGadget.h
+++ b/include/GafferUI/ConnectionGadget.h
@@ -90,6 +90,10 @@ class ConnectionGadget : public Gadget
 		void setMinimised( bool minimised );
 		bool getMinimised() const;
 
+		/// Setter and getter for highlighting state
+		void setHighlighted( bool state );
+		bool getHighlighted() const;
+
 		/// May be called by the recipient of a drag to set a more appropriate position
 		/// and tangent for the connection as the drag progresses within the destination.
 		/// Throws if this connection is not currently the source of a connection.
@@ -130,6 +134,7 @@ class ConnectionGadget : public Gadget
 		NodulePtr m_dstNodule;
 
 		bool m_minimised;
+		bool m_highlighted;
 
 		typedef std::map<IECore::TypeId, ConnectionGadgetCreator> CreatorMap;
 		static CreatorMap &creators();

--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -229,6 +229,9 @@ class GraphGadget : public ContainerGadget
 
 		void connectedNodeGadgetsWalk( NodeGadget *gadget, std::set<NodeGadget *> &connectedGadgets, Gaffer::Plug::Direction direction, size_t degreesOfSeparation );
 
+		void updateConnectionGadgetsHighlighting( const Gaffer::Node *node );
+		void setConnectionGadgetsHighlightingWalk( const Gaffer::Node *node, bool state );
+
 		Gaffer::NodePtr m_root;
 		Gaffer::ScriptNodePtr m_scriptNode;
 		RootChangedSignal m_rootChangedSignal;

--- a/src/GafferUI/ConnectionGadget.cpp
+++ b/src/GafferUI/ConnectionGadget.cpp
@@ -130,6 +130,21 @@ bool ConnectionGadget::getMinimised() const
 	return m_minimised;
 }
 
+void ConnectionGadget::setHighlighted( bool state )
+{
+	if( state == m_highlighted )
+	{
+		return;
+	}
+	m_highlighted = state;
+	requestRender();
+}
+
+bool ConnectionGadget::getHighlighted() const
+{
+	return m_highlighted;
+}
+
 ConnectionGadgetPtr ConnectionGadget::create( NodulePtr srcNodule, NodulePtr dstNodule )
 {
 	const Gaffer::Plug *plug = dstNodule->plug();

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -182,13 +182,6 @@ void StandardConnectionGadget::doRender( const Style *style ) const
 	const_cast<StandardConnectionGadget *>( this )->setPositionsFromNodules();
 
 	Style::State state = ( m_hovering || m_dragEnd || m_dotPreview || getHighlighted() ) ? Style::HighlightedState : Style::NormalState;
-	if( state != Style::HighlightedState )
-	{
-		if( nodeSelected( srcNodule() ) || nodeSelected( dstNodule() ) )
-		{
-			state = Style::HighlightedState;
-		}
-	}
 
 	V3f adjustedSrcPos = m_srcPos;
 	V3f adjustedSrcTangent = m_srcTangent;

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -181,7 +181,7 @@ void StandardConnectionGadget::doRender( const Style *style ) const
 {
 	const_cast<StandardConnectionGadget *>( this )->setPositionsFromNodules();
 
-	Style::State state = ( m_hovering || m_dragEnd || m_dotPreview ) ? Style::HighlightedState : Style::NormalState;
+	Style::State state = ( m_hovering || m_dragEnd || m_dotPreview || getHighlighted() ) ? Style::HighlightedState : Style::NormalState;
 	if( state != Style::HighlightedState )
 	{
 		if( nodeSelected( srcNodule() ) || nodeSelected( dstNodule() ) )


### PR DESCRIPTION
Here is that commit as a separate PR.

I ran it in a fairly large production scene and that seemed fine, but I'd rather go for a cleaner solution and maybe I should just have a look at your suggestion regarding an explicit signal for highlighting.