### PR TITLE
Misc : Prefer UndoScope to UndoContext

### DIFF
--- a/python/GafferSceneUITest/RotateToolTest.py
+++ b/python/GafferSceneUITest/RotateToolTest.py
@@ -121,7 +121,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 
 		tool["orientation"].setValue( tool.Orientation.Local )
 
-		with Gaffer.UndoContext( script ) :
+		with Gaffer.UndoScope( script ) :
 			tool.rotate( 2, 90 )
 
 		self.assertTrue(
@@ -136,7 +136,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 
 		tool["orientation"].setValue( tool.Orientation.Parent )
 
-		with Gaffer.UndoContext( script ) :
+		with Gaffer.UndoScope( script ) :
 			tool.rotate( 0, 90 )
 
 		self.assertTrue(
@@ -151,7 +151,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 
 		tool["orientation"].setValue( tool.Orientation.World )
 
-		with Gaffer.UndoContext( script ) :
+		with Gaffer.UndoScope( script ) :
 			tool.rotate( 2, 90 )
 
 		self.assertTrue(

--- a/python/GafferTest/BoxInTest.py
+++ b/python/GafferTest/BoxInTest.py
@@ -74,7 +74,7 @@ class BoxInTest( GafferTest.TestCase ) :
 		self.assertEqual( s["b"]["i"]["name"].getValue(), "test" )
 		self.assertEqual( promoted.getName(), s["b"]["i"]["name"].getValue() )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			promoted.setName( "bob" )
 
 		self.assertEqual( promoted.getName(), "bob" )
@@ -85,7 +85,7 @@ class BoxInTest( GafferTest.TestCase ) :
 		self.assertEqual( s["b"]["i"]["name"].getValue(), "test" )
 		self.assertEqual( promoted.getName(), s["b"]["i"]["name"].getValue() )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s["b"]["i"]["name"].setValue( "jim" )
 
 		self.assertEqual( promoted.getName(), "jim" )
@@ -128,7 +128,7 @@ class BoxInTest( GafferTest.TestCase ) :
 		self.assertTrue( "op1" in s["b"] )
 		self.assertTrue( s["b"]["n"]["op1"].source().isSame( s["b"]["op1"] ) )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			del s["b"]["i"]
 
 		self.assertFalse( "op1" in s["b"] )
@@ -240,7 +240,7 @@ class BoxInTest( GafferTest.TestCase ) :
 
 		assertPreconditions()
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			del s["b"]["op1"]
 
 		def assertPostconditions() :
@@ -280,7 +280,7 @@ class BoxInTest( GafferTest.TestCase ) :
 
 		assertPreconditions()
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			del s["b"]["in"]
 
 		def assertPostconditions() :
@@ -314,7 +314,7 @@ class BoxInTest( GafferTest.TestCase ) :
 
 		assertPreconditions()
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 
 			s["b"]["i"] = Gaffer.BoxIn()
 			s["b"]["i"].setup( s["a"]["sum"] )

--- a/python/GafferTest/BoxOutTest.py
+++ b/python/GafferTest/BoxOutTest.py
@@ -74,7 +74,7 @@ class BoxOutTest( GafferTest.TestCase ) :
 		self.assertEqual( s["b"]["o"]["name"].getValue(), "test" )
 		self.assertEqual( promoted.getName(), s["b"]["o"]["name"].getValue() )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			promoted.setName( "bob" )
 
 		self.assertEqual( promoted.getName(), "bob" )
@@ -85,7 +85,7 @@ class BoxOutTest( GafferTest.TestCase ) :
 		self.assertEqual( s["b"]["o"]["name"].getValue(), "test" )
 		self.assertEqual( promoted.getName(), s["b"]["o"]["name"].getValue() )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			s["b"]["o"]["name"].setValue( "jim" )
 
 		self.assertEqual( promoted.getName(), "jim" )
@@ -110,7 +110,7 @@ class BoxOutTest( GafferTest.TestCase ) :
 		self.assertTrue( "out" in s["b"] )
 		self.assertTrue( s["b"]["out"].source().isSame( s["b"]["n"]["sum"] ) )
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			del s["b"]["o"]
 
 		self.assertFalse( "out" in s["b"] )
@@ -199,7 +199,7 @@ class BoxOutTest( GafferTest.TestCase ) :
 
 		assertPreconditions()
 
-		with Gaffer.UndoContext( s ) :
+		with Gaffer.UndoScope( s ) :
 			del s["b"]["sum"]
 
 		def assertPostconditions() :


### PR DESCRIPTION
This code was written in parallel to the UndoContext rename, and the compatibility configs were hiding the use of the old name.