### PR TITLE
GraphGadget : allow moving without dragging frames nodes along

### DIFF
--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -932,7 +932,7 @@ bool GraphGadget::buttonPress( GadgetPtr gadget, const ButtonEvent &event )
 		if( nodeGadget )
 		{
 			Gaffer::Node *node = nodeGadget->node();
-			bool shiftHeld = event.modifiers && ButtonEvent::Shift;
+			bool shiftHeld = event.modifiers & ButtonEvent::Shift;
 			bool controlHeld = event.modifiers & ButtonEvent::Control;
 			bool nodeSelected = m_scriptNode->selection()->contains( node );
 

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -933,15 +933,19 @@ bool GraphGadget::buttonPress( GadgetPtr gadget, const ButtonEvent &event )
 		{
 			Gaffer::Node *node = nodeGadget->node();
 			bool shiftHeld = event.modifiers && ButtonEvent::Shift;
+			bool controlHeld = event.modifiers & ButtonEvent::Control;
 			bool nodeSelected = m_scriptNode->selection()->contains( node );
 
 			std::vector<Gaffer::Node *> affectedNodes;
 			if( const BackdropNodeGadget *backdrop = runTimeCast<BackdropNodeGadget>( nodeGadget ) )
 			{
-				backdrop->framed( affectedNodes );
+				if( !controlHeld )
+				{
+					backdrop->framed( affectedNodes );
+				}
 			}
 
-			if( ( event.modifiers & ButtonEvent::Alt ) || ( event.modifiers & ButtonEvent::Control ) )
+			if( ( event.modifiers & ButtonEvent::Alt ) || ( controlHeld ) )
 			{
 				std::vector<NodeGadget *> connected;
 				connectedNodeGadgets( node, connected, event.modifiers & ButtonEvent::Alt ? Gaffer::Plug::In : Gaffer::Plug::Out );


### PR DESCRIPTION
Hey John,

when adding a backdrop for a test, I noticed that it didn't behave the way I would have expected (being used to how Nuke does it). I find it useful - for placing it - to be able to drag the backdrop without causing everything inside to be selected and to be dragged along. 

Took a quick look to see what it would take to get that working. Not sure if you like this, but I thought I'd put up the PR for a short discussion.

Matti.

