### PR TITLE
Make it safe to drive Backdrop text with expressions

### DIFF
--- a/python/GafferUI/ExpressionUI.py
+++ b/python/GafferUI/ExpressionUI.py
@@ -332,6 +332,11 @@ class ExpressionWidget( GafferUI.Widget ) :
 
 		return None
 
+	# An error in the expression could occur during a compute triggered by a repaint.
+	# ( For example, if a user uses an expression to drive Backdrop text )
+	# If we forced a repaint right away, this would be a recursive repaint which could cause
+	# a Qt crash, so we wait for idle.
+	@GafferUI.LazyMethod()
 	def __error( self, plug, source, error ) :
 
 		self.__messageWidget.setVisible( True )

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -57,6 +57,26 @@ using namespace IECore;
 using namespace Gaffer;
 using namespace GafferUI;
 
+namespace
+{
+
+void titleAndDescriptionFromPlugs( const StringPlug *titlePlug, const StringPlug *descriptionPlug,
+	std::string &title, std::string &description )
+{
+	title = "ERROR : Getting title";
+	try
+	{
+		title = titlePlug->getValue();
+		description = descriptionPlug->getValue();
+	}
+	catch( const std::exception &e )
+	{
+		description = std::string( "ERROR:\n" ) + e.what();
+	}
+}
+
+} // namespace
+
 IE_CORE_DEFINERUNTIMETYPED( BackdropNodeGadget );
 
 static const float g_margin = 3.0f;
@@ -113,8 +133,8 @@ std::string BackdropNodeGadget::getToolTip( const IECore::LineSegment3f &line ) 
 	}
 
 	const Backdrop *backdrop = static_cast<const Backdrop *>( node() );
-	std::string title = backdrop->titlePlug()->getValue();
-	std::string description = backdrop->descriptionPlug()->getValue();
+	std::string title, description;
+	titleAndDescriptionFromPlugs( backdrop->titlePlug(), backdrop->descriptionPlug(), title, description );
 
 	if( !title.size() && !description.size() )
 	{
@@ -255,7 +275,9 @@ void BackdropNodeGadget::doRender( const Style *style ) const
 
 		style->renderBackdrop( bound, getHighlighted() ? Style::HighlightedState : Style::NormalState, m_userColor.get_ptr() );
 
-		const std::string title = backdrop->titlePlug()->getValue();
+		std::string title, description;
+		titleAndDescriptionFromPlugs( backdrop->titlePlug(), backdrop->descriptionPlug(), title, description );
+
 		if( title.size() )
 		{
 			Box3f titleBound = style->textBound( Style::HeadingText, title );
@@ -279,7 +301,6 @@ void BackdropNodeGadget::doRender( const Style *style ) const
 		textBound.max = V2f( textBound.max.x - g_margin, titleBaseline - g_margin );
 		if( textBound.hasVolume() )
 		{
-			std::string description = backdrop->descriptionPlug()->getValue();
 			style->renderWrappedText( Style::BodyText, description, textBound );
 		}
 	}


### PR DESCRIPTION
Driving Backdrop text with an expression feels like a somewhat reasonable thing for a user to want to do.  I'm not entirely confident on how bad the performance implications might get, but for the moment, we have users who are happily doing it in production.

It currently works fine until you trigger an exception in the Expression, and then really bad things happen.

The most obvious problem is the redraw of the backdrop failing in the middle of a GL render.  This seems like a straightforward fix - catch the exception, display error text.

The more complex problem is that the expression node updates it's UI to display a message when an error occurs with the evaluation of that expression.  If the expression node is running during a repaint, this causes a recursive repaint in Qt, which crashes.  I was able to work around this by deferring to the message update to the next idle - does this seem reasonable?