### PR TITLE
Screengrab Improvements

### DIFF
--- a/apps/screengrab/screengrab-1.py
+++ b/apps/screengrab/screengrab-1.py
@@ -288,13 +288,12 @@ class screengrab( Gaffer.Application ) :
 		for nodeEditor in scriptWindow.getLayout().editors( GafferUI.NodeEditor ) :
 
 			for name in args["nodeEditor"]["reveal"] :
-				plugValueWidget = nodeEditor.nodeUI().plugValueWidget( script.descendant( name ) )
-				plugValueWidget.reveal()
+				GafferUI.PlugValueWidget.acquire( script.descendant( name ) )
 
 			if args["nodeEditor"]["grab"].value :
-				grabWidget = nodeEditor.nodeUI().plugValueWidget( script.descendant( args["nodeEditor"]["grab"].value ) )
-				grabWidget = grabWidget.ancestor( GafferUI.PlugWidget ) or grabWidget
-				grabWidget.reveal()
+				grabWidget = GafferUI.PlugWidget.acquire( script.descendant( args["nodeEditor"]["grab"].value ) )
+				if not grabWidget :
+					grabWidget = GafferUI.PlugValueWidget.acquire( script.descendant( args["nodeEditor"]["grab"].value ) )
 				self.setGrabWidget( grabWidget )
 
 		# Set up the ScriptEditors as requested.

--- a/apps/screengrab/screengrab-1.py
+++ b/apps/screengrab/screengrab-1.py
@@ -69,7 +69,7 @@ class screengrab( Gaffer.Application ) :
 					description = "Where to save the resulting image",
 					defaultValue = "",
 					extensions = "png",
-					allowEmptyString = False,
+					allowEmptyString = True,
 				),
 
 				IECore.StringVectorParameter(
@@ -350,16 +350,9 @@ class screengrab( Gaffer.Application ) :
 
 		# Write the image, creating a directory for it if necessary.
 
-		self.__waitForIdle()
-
-		imageDir = os.path.dirname( args["image"].value )
-		if imageDir and not os.path.isdir( imageDir ) :
-			IECore.msg( IECore.Msg.Level.Info, "screengrab", "Creating target directory [ %s ]" % imageDir )
-			os.makedirs( imageDir )
-
-		pixmap = QtGui.QPixmap.grabWindow( self.getGrabWidget()._qtWidget().winId() )
-		IECore.msg( IECore.Msg.Level.Info, "screengrab", "Writing image [ %s ]" % args["image"].value )
-		pixmap.save( args["image"].value )
+		if args["image"].value :
+			IECore.msg( IECore.Msg.Level.Info, "screengrab", "Writing image [ %s ]" % args["image"].value )
+			GafferUI.WidgetAlgo.grab( widget = self.getGrabWidget(), imagePath = args["image"].value )
 
 		# Remove the script and any reference to the grab widget up so
 		# we can shut down cleanly.

--- a/apps/screengrab/screengrab-1.py
+++ b/apps/screengrab/screengrab-1.py
@@ -307,16 +307,12 @@ class screengrab( Gaffer.Application ) :
 
 		# Set up the Viewers as requested.
 
+		pathsToFrame = GafferScene.PathMatcher( list( args["viewer"]["framedObjects"] ) )
 		for viewer in scriptWindow.getLayout().editors( GafferUI.Viewer ) :
 			if isinstance( viewer.view(), GafferSceneUI.SceneView ) :
 				viewer.view()["minimumExpansionDepth"].setValue( args["viewer"]["minimumExpansionDepth"].value )
 				if args["viewer"]["framedObjects"] :
-					bound = IECore.Box3f()
-					for path in args["viewer"]["framedObjects"] :
-						objectBound = viewer.view()["in"].bound( path )
-						objectFullTransform = viewer.view()["in"].fullTransform( path )
-						bound.extendBy( objectBound.transform( objectFullTransform ) )
-					viewer.view().viewportGadget().frame( bound, args["viewer"]["viewDirection"].value.normalized() )
+					viewer.view().frame( pathsToFrame, args["viewer"]["viewDirection"].value.normalized() )
 
 		del viewer
 

--- a/apps/screengrab/screengrab-1.py
+++ b/apps/screengrab/screengrab-1.py
@@ -234,7 +234,7 @@ class screengrab( Gaffer.Application ) :
 		# Execute any commands we've been asked to, exposing the application
 		# and script as variables.
 
-		self.__waitForIdle()
+		GafferUI.EventLoop.waitForIdle()
 
 		d = {
 			"application" 	: self,
@@ -275,7 +275,7 @@ class screengrab( Gaffer.Application ) :
 
 		# Set up some default framing for the node graphs.
 
-		self.__waitForIdle()
+		GafferUI.EventLoop.waitForIdle()
 
 		for nodeGraph in scriptWindow.getLayout().editors( GafferUI.NodeGraph ) :
 			if args["nodeGraph"]["frame"] :
@@ -346,7 +346,7 @@ class screengrab( Gaffer.Application ) :
 
 		t = time.time() + args["delay"].value
 		while time.time() < t :
-			self.__waitForIdle( 1 )
+			GafferUI.EventLoop.waitForIdle( 1 )
 
 		# Write the image, creating a directory for it if necessary.
 
@@ -367,21 +367,5 @@ class screengrab( Gaffer.Application ) :
 		self.setGrabWidget( None )
 
 		return 0
-
-	def __waitForIdle( self, count = 1000 ) :
-
-		self.__idleCount = 0
-		def f() :
-
-			self.__idleCount += 1
-
-			if self.__idleCount >= count :
-				GafferUI.EventLoop.mainEventLoop().stop()
-				return False
-
-			return True
-
-		GafferUI.EventLoop.addIdleCallback( f )
-		GafferUI.EventLoop.mainEventLoop().start()
 
 IECore.registerRunTimeTyped( screengrab )

--- a/include/GafferSceneUI/ContextAlgo.h
+++ b/include/GafferSceneUI/ContextAlgo.h
@@ -81,6 +81,16 @@ namespace ContextAlgo
 void setExpandedPaths( Gaffer::Context *context, const GafferScene::PathMatcher &paths );
 GafferScene::PathMatcher getExpandedPaths( const Gaffer::Context *context );
 
+/// Path Selection
+/// ==============
+
+/// Similarly to Path Expansion, the UI components coordinate with each other
+/// to perform scene selection, again using the Context to store paths to the
+/// currently selected locations within the scene.
+
+void setSelectedPaths( Gaffer::Context *context, const GafferScene::PathMatcher &paths );
+GafferScene::PathMatcher getSelectedPaths( const Gaffer::Context *context );
+
 } // namespace ContextAlgo
 
 } // namespace GafferSceneUI

--- a/include/GafferSceneUI/ContextAlgo.h
+++ b/include/GafferSceneUI/ContextAlgo.h
@@ -81,6 +81,16 @@ namespace ContextAlgo
 void setExpandedPaths( Gaffer::Context *context, const GafferScene::PathMatcher &paths );
 GafferScene::PathMatcher getExpandedPaths( const Gaffer::Context *context );
 
+/// Appends paths to the current expansion, optionally adding all ancestor paths too.
+void expand( Gaffer::Context *context, const GafferScene::PathMatcher &paths, bool expandAncestors = true );
+
+/// Appends descendant paths to the current expansion up to a specified maximum depth.
+/// Returns a new PathMatcher containing the new leafs of this expansion.
+GafferScene::PathMatcher expandDescendants( Gaffer::Context *context, const GafferScene::PathMatcher &paths, const GafferScene::ScenePlug *scene, int depth = Imath::limits<int>::max() );
+
+/// Clears the currently expanded paths
+void clearExpansion( Gaffer::Context *context );
+
 /// Path Selection
 /// ==============
 

--- a/include/GafferSceneUI/ContextAlgo.h
+++ b/include/GafferSceneUI/ContextAlgo.h
@@ -1,0 +1,88 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEUI_CONTEXTALGO_H
+#define GAFFERSCENEUI_CONTEXTALGO_H
+
+namespace Gaffer
+{
+
+class Context;
+
+} // namespace Gaffer
+
+namespace GafferScene
+{
+
+class PathMatcher;
+
+} // namespace GafferScene
+
+namespace GafferSceneUI
+{
+
+namespace ContextAlgo
+{
+
+/// Path Expansion
+/// ==============
+
+/// The UI components coordinate with each other to perform on-demand scene
+/// generation by using the Context to store paths to the currently expanded
+/// locations within the scene. For instance, this allows the Viewer show the
+/// objects from locations exposed by expansion performed in the SceneHierarchy,
+/// and vice versa.
+///
+/// By convention, an expanded location is one whose children are visible,
+/// meaning that they are listed below it in the SceneHierarchy and their objects
+/// are drawn in the Viewer. Conversely, a collapsed location's children are
+/// not listed in the SceneHierarchy and the location itself is drawn as a
+/// the bounding box of the children.
+///
+/// As a consequence of this definition, it is not necessary to expand locations
+/// without children. For a simple node such as Sphere, it is only necessary
+/// to expand the root location ("/") to view the geometry. For nodes which
+/// construct a deeper hierarchy, if the name of a location is visible in
+/// the SceneHierarchy, then it's geometry will be displayed in the Viewer.
+
+void setExpandedPaths( Gaffer::Context *context, const GafferScene::PathMatcher &paths );
+GafferScene::PathMatcher getExpandedPaths( const Gaffer::Context *context );
+
+} // namespace ContextAlgo
+
+} // namespace GafferSceneUI
+
+#endif // GAFFERSCENEUI_CONTEXTALGO_H

--- a/include/GafferSceneUI/SceneView.h
+++ b/include/GafferSceneUI/SceneView.h
@@ -120,10 +120,6 @@ class SceneView : public GafferUI::View
 		void transferSelectionToContext();
 		void plugSet( Gaffer::Plug *plug );
 
-		GafferScene::PathMatcherData *expandedPaths();
-		// Returns true if the expansion or selection were modified, false otherwise.
-		bool expandWalk( const GafferScene::ScenePlug::ScenePath &path, size_t depth, GafferScene::PathMatcher &expanded, GafferScene::PathMatcher &selected );
-
 		boost::signals::scoped_connection m_selectionChangedConnection;
 
 		SceneGadgetPtr m_sceneGadget;

--- a/include/GafferSceneUI/SceneView.h
+++ b/include/GafferSceneUI/SceneView.h
@@ -86,6 +86,7 @@ class SceneView : public GafferUI::View
 		Gaffer::ValuePlug *gnomonPlug();
 		const Gaffer::ValuePlug *gnomonPlug() const;
 
+		void frame( const GafferScene::PathMatcher &filter, const Imath::V3f &direction = Imath::V3f( -0.64, -0.422, -0.64 ) );
 		void expandSelection( size_t depth = 1 );
 		void collapseSelection();
 

--- a/include/GafferSceneUI/SelectionTool.h
+++ b/include/GafferSceneUI/SelectionTool.h
@@ -73,7 +73,6 @@ class SelectionTool : public GafferUI::Tool
 		bool dragEnter( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
 		bool dragMove( const GafferUI::DragDropEvent &event );
 		bool dragEnd( const GafferUI::DragDropEvent &event );
-		void transferSelectionToContext();
 
 };
 

--- a/include/GafferSceneUIBindings/ContextAlgoBinding.h
+++ b/include/GafferSceneUIBindings/ContextAlgoBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEUIBINDINGS_CONTEXTALGOBINDING_H
+#define GAFFERSCENEUIBINDINGS_CONTEXTALGOBINDING_H
+
+namespace GafferSceneUIBindings
+{
+
+void bindContextAlgo();
+
+} // namespace GafferSceneUIBindings
+
+#endif // GAFFERSCENEUIBINDINGS_CONTEXTALGOBINDING_H

--- a/python/GafferSceneUI/CustomAttributesUI.py
+++ b/python/GafferSceneUI/CustomAttributesUI.py
@@ -40,6 +40,7 @@ import Gaffer
 import GafferUI
 
 import GafferScene
+import GafferSceneUI
 
 Gaffer.Metadata.registerNode(
 
@@ -94,7 +95,7 @@ def __attributePopupMenu( menuDefinition, plugValueWidget ) :
 	if not acceptsAttributeName and not acceptsAttributeNames :
 		return
 
-	selectedPaths = plugValueWidget.getContext().get( "ui:scene:selectedPaths" )
+	selectedPaths = GafferSceneUI.ContextAlgo.getSelectedPaths( plugValueWidget.getContext() ).paths()
 	if not selectedPaths :
 		return
 

--- a/python/GafferSceneUI/FilteredSceneProcessorUI.py
+++ b/python/GafferSceneUI/FilteredSceneProcessorUI.py
@@ -117,7 +117,7 @@ def __selectAffected( node, context ) :
 		for scene in scenes :
 			GafferScene.SceneAlgo.matchingPaths( filter, scene, pathMatcher )
 
-	context["ui:scene:selectedPaths"] = IECore.StringVectorData( pathMatcher.paths() )
+	GafferSceneUI.ContextAlgo.setSelectedPaths( context, pathMatcher )
 
 def appendNodeContextMenuDefinitions( nodeGraph, node, menuDefinition ) :
 

--- a/python/GafferSceneUI/LightTweaksUI.py
+++ b/python/GafferSceneUI/LightTweaksUI.py
@@ -41,6 +41,7 @@ import IECore
 import Gaffer
 import GafferUI
 import GafferScene
+import GafferSceneUI
 
 Gaffer.Metadata.registerNode(
 
@@ -268,7 +269,8 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 		paths = []
 		node = self.__lightTweaksNode()
 		if node is not None :
-			paths = self.getContext().get( "ui:scene:selectedPaths", [] )
+			paths = GafferSceneUI.ContextAlgo.getSelectedPaths( self.getContext() )
+			paths = paths.paths() if paths else []
 			paths = [ p for p in paths if GafferScene.SceneAlgo.exists( node["in"], p ) ]
 
 		return self.__addFromPathsMenuDefinition( paths )

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -47,6 +47,7 @@ import IECore
 import Gaffer
 import GafferScene
 import GafferUI
+import GafferSceneUI
 
 class SceneInspector( GafferUI.NodeSetEditor ) :
 
@@ -269,7 +270,7 @@ class SceneInspector( GafferUI.NodeSetEditor ) :
 			if self.__targetPaths is not None :
 				paths = self.__targetPaths
 			else :
-				paths = self.getContext().get( "ui:scene:selectedPaths", [] )
+				paths = GafferSceneUI.ContextAlgo.getSelectedPaths( self.getContext() ).paths()
 			paths = paths[:2] if len( self.__scenePlugs ) < 2 else paths[:1]
 			if not paths :
 				paths = [ "/" ]
@@ -1137,7 +1138,7 @@ class _InheritanceSection( Section ) :
 	def __labelButtonPress( self, label, event ) :
 
 		script = self.__target.scene.ancestor( Gaffer.ScriptNode )
-		script.context()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ label.getText() ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( script.context(), GafferScene.PathMatcher( [ label.getText() ] ) )
 
 ##########################################################################
 # History section
@@ -1966,7 +1967,7 @@ class _SetDiff( Diff ) :
 		editor = section.ancestor( SceneInspector )
 
 		context = editor.getContext()
-		context["ui:scene:selectedPaths"] = IECore.StringVectorData( widget.paths )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( context, GafferScene.PathMatcher( widget.paths ) )
 
 		return True
 

--- a/python/GafferSceneUITest/ContextAlgoTest.py
+++ b/python/GafferSceneUITest/ContextAlgoTest.py
@@ -93,6 +93,32 @@ class ContextAlgoTest( GafferUITest.TestCase ) :
 		GafferSceneUI.ContextAlgo.setExpandedPaths( context, GafferScene.PathMatcher( [ "/", "/A", "/A/C" ] ) )
 		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( context ), GafferScene.PathMatcher( [ "/", "/A", "/A/C" ] ) )
 
+		GafferSceneUI.ContextAlgo.clearExpansion( context )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( context ), GafferScene.PathMatcher() )
+		GafferSceneUI.ContextAlgo.expand( context, GafferScene.PathMatcher( [ "/A/B", "/A/C" ] ) )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( context ), GafferScene.PathMatcher( [ "/", "/A", "/A/B", "/A/C" ] ) )
+
+		GafferSceneUI.ContextAlgo.clearExpansion( context )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( context ), GafferScene.PathMatcher() )
+		GafferSceneUI.ContextAlgo.expand( context, GafferScene.PathMatcher( [ "/A/B", "/A/C" ] ), expandAncestors = False )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( context ), GafferScene.PathMatcher( [ "/A/B", "/A/C" ] ) )
+
+		GafferSceneUI.ContextAlgo.setExpandedPaths( context, GafferScene.PathMatcher( [ "/" ] ) )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( context ), GafferScene.PathMatcher( [ "/" ] ) )
+		newLeafs = GafferSceneUI.ContextAlgo.expandDescendants( context, GafferScene.PathMatcher( [ "/" ] ), A["out"] )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( context ), GafferScene.PathMatcher( [ "/", "/A", "/A/B", "/A/C" ] ) )
+		self.assertEqual( newLeafs, GafferScene.PathMatcher( [ "/A/B/D", "/A/B/E", "/A/C/G", "/A/C/F" ] ) )
+
+		GafferSceneUI.ContextAlgo.setExpandedPaths( context, GafferScene.PathMatcher( [ "/" ] ) )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( context ), GafferScene.PathMatcher( [ "/" ] ) )
+		newLeafs = GafferSceneUI.ContextAlgo.expandDescendants( context, GafferScene.PathMatcher( [ "/" ] ), A["out"], depth = 1 )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( context ), GafferScene.PathMatcher( [ "/", "/A" ] ) )
+		self.assertEqual( newLeafs, GafferScene.PathMatcher( [ "/A/B", "/A/C" ] ) )
+
+		newLeafs = GafferSceneUI.ContextAlgo.expandDescendants( context, GafferScene.PathMatcher( [ "/A/C" ] ), A["out"], depth = 1 )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( context ), GafferScene.PathMatcher( [ "/", "/A", "/A/C" ] ) )
+		self.assertEqual( newLeafs, GafferScene.PathMatcher( [ "/A/C/G", "/A/C/F" ] ) )
+
 	def testSelectedPaths( self ) :
 
 		# A

--- a/python/GafferSceneUITest/ContextAlgoTest.py
+++ b/python/GafferSceneUITest/ContextAlgoTest.py
@@ -93,5 +93,58 @@ class ContextAlgoTest( GafferUITest.TestCase ) :
 		GafferSceneUI.ContextAlgo.setExpandedPaths( context, GafferScene.PathMatcher( [ "/", "/A", "/A/C" ] ) )
 		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( context ), GafferScene.PathMatcher( [ "/", "/A", "/A/C" ] ) )
 
+	def testSelectedPaths( self ) :
+
+		# A
+		# |__B
+		#    |__D
+		#    |__E
+		# |__C
+		#    |__F
+		#    |__G
+
+		G = GafferScene.Sphere()
+		G["name"].setValue( "G" )
+
+		F = GafferScene.Sphere()
+		F["name"].setValue( "F" )
+
+		D = GafferScene.Sphere()
+		D["name"].setValue( "D" )
+
+		E = GafferScene.Sphere()
+		E["name"].setValue( "E" )
+
+		C = GafferScene.Group()
+		C["name"].setValue( "C" )
+
+		C["in"][0].setInput( F["out"] )
+		C["in"][1].setInput( G["out"] )
+
+		B = GafferScene.Group()
+		B["name"].setValue( "B" )
+
+		B["in"][0].setInput( D["out"] )
+		B["in"][1].setInput( E["out"] )
+
+		A = GafferScene.Group()
+		A["name"].setValue( "A" )
+		A["in"][0].setInput( B["out"] )
+		A["in"][1].setInput( C["out"] )
+
+		context = Gaffer.Context()
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( context, GafferScene.PathMatcher( [ "/" ] ) )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getSelectedPaths( context ), GafferScene.PathMatcher( [ "/" ] ) )
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( context, GafferScene.PathMatcher( [ "/", "/A" ] ) )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getSelectedPaths( context ), GafferScene.PathMatcher( [ "/", "/A" ] ) )
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( context, GafferScene.PathMatcher( [ "/", "/A", "/A/C" ] ) )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getSelectedPaths( context ), GafferScene.PathMatcher( [ "/", "/A", "/A/C" ] )  )
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( context, GafferScene.PathMatcher( [ "/A/C", "/A/B/D" ] ) )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getSelectedPaths( context ), GafferScene.PathMatcher( [ "/A/C", "/A/B/D" ] )  )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/ContextAlgoTest.py
+++ b/python/GafferSceneUITest/ContextAlgoTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,19 +34,64 @@
 #
 ##########################################################################
 
-from SceneViewTest import SceneViewTest
-from ShaderAssignmentUITest import ShaderAssignmentUITest
-from StandardGraphLayoutTest import StandardGraphLayoutTest
-from SceneGadgetTest import SceneGadgetTest
-from SceneInspectorTest import SceneInspectorTest
-from SceneHierarchyTest import SceneHierarchyTest
-from DocumentationTest import DocumentationTest
-from ShaderViewTest import ShaderViewTest
-from ShaderUITest import ShaderUITest
-from TranslateToolTest import TranslateToolTest
-from ScaleToolTest import ScaleToolTest
-from RotateToolTest import RotateToolTest
-from ContextAlgoTest import ContextAlgoTest
+import IECore
+
+import Gaffer
+import GafferUITest
+import GafferScene
+import GafferSceneUI
+
+class ContextAlgoTest( GafferUITest.TestCase ) :
+
+	def testExpandedPaths( self ) :
+
+		# A
+		# |__B
+		#    |__D
+		#    |__E
+		# |__C
+		#    |__F
+		#    |__G
+
+		G = GafferScene.Sphere()
+		G["name"].setValue( "G" )
+
+		F = GafferScene.Sphere()
+		F["name"].setValue( "F" )
+
+		D = GafferScene.Sphere()
+		D["name"].setValue( "D" )
+
+		E = GafferScene.Sphere()
+		E["name"].setValue( "E" )
+
+		C = GafferScene.Group()
+		C["name"].setValue( "C" )
+
+		C["in"][0].setInput( F["out"] )
+		C["in"][1].setInput( G["out"] )
+
+		B = GafferScene.Group()
+		B["name"].setValue( "B" )
+
+		B["in"][0].setInput( D["out"] )
+		B["in"][1].setInput( E["out"] )
+
+		A = GafferScene.Group()
+		A["name"].setValue( "A" )
+		A["in"][0].setInput( B["out"] )
+		A["in"][1].setInput( C["out"] )
+
+		context = Gaffer.Context()
+
+		GafferSceneUI.ContextAlgo.setExpandedPaths( context, GafferScene.PathMatcher( [ "/" ] ) )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( context ), GafferScene.PathMatcher( [ "/" ] ) )
+
+		GafferSceneUI.ContextAlgo.setExpandedPaths( context, GafferScene.PathMatcher( [ "/", "/A" ] ) )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( context ), GafferScene.PathMatcher( [ "/", "/A" ] ) )
+
+		GafferSceneUI.ContextAlgo.setExpandedPaths( context, GafferScene.PathMatcher( [ "/", "/A", "/A/C" ] ) )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( context ), GafferScene.PathMatcher( [ "/", "/A", "/A/C" ] ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/RotateToolTest.py
+++ b/python/GafferSceneUITest/RotateToolTest.py
@@ -50,7 +50,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 
 		view = GafferSceneUI.SceneView()
 		view["in"].setInput( script["cube"]["out"] )
-		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/cube" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/cube" ] ) )
 
 		tool = GafferSceneUI.RotateTool( view )
 		tool["active"].setValue( True )
@@ -72,7 +72,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 
 		view = GafferSceneUI.SceneView()
 		view["in"].setInput( script["group"]["out"] )
-		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/group/cube" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/group/cube" ] ) )
 
 		tool = GafferSceneUI.RotateTool( view )
 		tool["active"].setValue( True )
@@ -112,7 +112,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 
 		view = GafferSceneUI.SceneView()
 		view["in"].setInput( script["group"]["out"] )
-		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/group/cube" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/group/cube" ] ) )
 
 		tool = GafferSceneUI.RotateTool( view )
 		tool["active"].setValue( True )

--- a/python/GafferSceneUITest/ScaleToolTest.py
+++ b/python/GafferSceneUITest/ScaleToolTest.py
@@ -55,7 +55,7 @@ class ScaleToolTest( GafferUITest.TestCase ) :
 		tool = GafferSceneUI.ScaleTool( view )
 		tool["active"].setValue( True )
 
-		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/plane" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/plane" ] ) )
 
 		with Gaffer.UndoScope( script ) :
 			tool.scale( IECore.V3f( 2, 1, 1 ) )

--- a/python/GafferSceneUITest/SceneHierarchyTest.py
+++ b/python/GafferSceneUITest/SceneHierarchyTest.py
@@ -47,7 +47,8 @@ class SceneHierarchyTest( GafferUITest.TestCase ) :
 
 		e = False
 		if "ui:scene:expandedPaths" in context :
-			if context["ui:scene:expandedPaths"].value.match( path ) & GafferScene.Filter.Result.ExactMatch :
+			expandePaths = GafferSceneUI.ContextAlgo.getExpandedPaths( context )
+			if expandePaths and ( expandePaths.match( path ) & GafferScene.Filter.Result.ExactMatch ) :
 				e = True
 
 		self.assertEqual( e, expanded )
@@ -70,8 +71,8 @@ class SceneHierarchyTest( GafferUITest.TestCase ) :
 
 		# Expand the root, and select /group.
 
-		script.context()["ui:scene:expandedPaths"] = GafferScene.PathMatcherData( GafferScene.PathMatcher( [ "/" ] ) )
-		script.context()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/group"] )
+		GafferSceneUI.ContextAlgo.setExpandedPaths( script.context(), GafferScene.PathMatcher( [ "/" ] ) )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( script.context(), GafferScene.PathMatcher( [ "/group" ] ) )
 
 		self.waitForIdle( 1000 )
 

--- a/python/GafferSceneUITest/SceneViewTest.py
+++ b/python/GafferSceneUITest/SceneViewTest.py
@@ -83,25 +83,19 @@ class SceneViewTest( GafferUITest.TestCase ) :
 		view = GafferUI.View.create( A["out"] )
 
 		def setSelection( paths ) :
-			view.getContext().set(
-				"ui:scene:selectedPaths",
-				IECore.StringVectorData( paths ),
-			)
+			GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( paths ) )
 
 		def getSelection() :
-			return set( view.getContext().get( "ui:scene:selectedPaths" ) )
+			return set( GafferSceneUI.ContextAlgo.getSelectedPaths( view.getContext() ).paths() )
 
 		setSelection( [ "/A" ] )
 		self.assertEqual( getSelection(), set( [ "/A" ] ) )
 
 		def setExpandedPaths( paths ) :
-			view.getContext().set(
-				"ui:scene:expandedPaths",
-				GafferScene.PathMatcherData( GafferScene.PathMatcher( paths ) ),
-			)
+			GafferSceneUI.ContextAlgo.setExpandedPaths( view.getContext(), GafferScene.PathMatcher( paths ) )
 
 		def getExpandedPaths() :
-			return set( view.getContext().get( "ui:scene:expandedPaths" ).value.paths() )
+			return set( GafferSceneUI.ContextAlgo.getExpandedPaths( view.getContext() ).paths() )
 
 		setExpandedPaths( [ "/" ] )
 		self.assertEqual( getExpandedPaths(), set( [ "/" ] ) )

--- a/python/GafferSceneUITest/SceneViewTest.py
+++ b/python/GafferSceneUITest/SceneViewTest.py
@@ -170,6 +170,41 @@ class SceneViewTest( GafferUITest.TestCase ) :
 		self.assertEqual( getExpandedPaths(), set( [ "/", "/A", "/A/C" ] ) )
 		self.assertEqual( getSelection(), set( [ "/A/C/E" ] ) )
 
+		# try to collapse one level
+
+		view.collapseSelection()
+
+		self.assertEqual( getExpandedPaths(), set( [ "/", "/A" ] ) )
+		self.assertEqual( getSelection(), set( [ "/A/C" ] ) )
+
+		# try to collapse one more
+
+		view.collapseSelection()
+
+		self.assertEqual( getExpandedPaths(), set( [ "/" ] ) )
+		self.assertEqual( getSelection(), set( [ "/A" ] ) )
+
+		# now expand one level again
+
+		view.expandSelection( depth = 1 )
+
+		self.assertEqual( getExpandedPaths(), set( [ "/", "/A" ] ) )
+		self.assertEqual( getSelection(), set( [ "/A/B", "/A/C" ] ) )
+
+		# and expand again
+
+		view.expandSelection( depth = 1 )
+
+		self.assertEqual( getExpandedPaths(), set( [ "/", "/A", "/A/C" ] ) )
+		self.assertEqual( getSelection(), set( [ "/A/B", "/A/C/D", "/A/C/E" ] ) )
+
+		# and collapse
+
+		view.collapseSelection()
+
+		self.assertEqual( getExpandedPaths(), set( [ "/" ] ) )
+		self.assertEqual( getSelection(), set( [ "/A", "/A/C" ] ) )
+
 	def testLookThrough( self ) :
 
 		script = Gaffer.ScriptNode()

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -66,7 +66,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		self.assertTrue( tool.selection().transformPlug is None )
 
-		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/group/plane" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/group/plane" ] ) )
 		self.assertEqual( tool.selection().path, "/group/plane" )
 		self.assertEqual( tool.selection().context, view.getContext() )
 		self.assertTrue( tool.selection().upstreamScene.isSame( script["plane"]["out"] ) )
@@ -74,7 +74,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		self.assertTrue( tool.selection().transformPlug.isSame( script["plane"]["transform"] ) )
 		self.assertEqual( tool.selection().transformSpace, IECore.M44f() )
 
-		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/group" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/group" ] ) )
 		self.assertEqual( tool.selection().path, "/group" )
 		self.assertEqual( tool.selection().context, view.getContext() )
 		self.assertTrue( tool.selection().upstreamScene.isSame( script["group"]["out"] ) )
@@ -107,7 +107,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		view = GafferSceneUI.SceneView()
 		view["in"].setInput( script["plane"]["out"] )
-		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/plane" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/plane" ] ) )
 
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
@@ -127,7 +127,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		view = GafferSceneUI.SceneView()
 		view["in"].setInput( script["plane"]["out"] )
-		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/plane" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/plane" ] ) )
 
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
@@ -168,7 +168,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		view = GafferSceneUI.SceneView()
 		view["in"].setInput( script["group"]["out"] )
-		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/group/plane" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/group/plane" ] ) )
 
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
@@ -193,7 +193,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		view = GafferSceneUI.SceneView()
 		view["in"].setInput( script["group"]["out"] )
-		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/group/plane" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/group/plane" ] ) )
 
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
@@ -218,7 +218,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		view = GafferSceneUI.SceneView()
 		view["in"].setInput( script["group"]["out"] )
-		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/group/plane" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/group/plane" ] ) )
 
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
@@ -276,7 +276,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		view = GafferSceneUI.SceneView()
 		view["in"].setInput( script["plane"]["out"] )
-		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/plane" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/plane" ] ) )
 
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
@@ -313,7 +313,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		view = GafferSceneUI.SceneView()
 		view["in"].setInput( script["group"]["out"] )
-		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/group" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/group" ] ) )
 
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
@@ -341,7 +341,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		view = GafferSceneUI.SceneView()
 		view["in"].setInput( script["transform"]["out"] )
-		view.getContext()["ui:scene:selectedPaths"] = IECore.StringVectorData( [ "/plane" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/plane" ] ) )
 
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )

--- a/python/GafferUI/EventLoop.py
+++ b/python/GafferUI/EventLoop.py
@@ -198,6 +198,25 @@ class EventLoop( object ) :
 
 		cls.__idleCallbacks.remove( callback )
 
+	## Convenience method to introduce a delay on the mainEventLoop().
+	@classmethod
+	def waitForIdle( cls, count = 1000 ) :
+
+		cls.__idleCount = 0
+
+		def f() :
+
+			cls.__idleCount += 1
+
+			if cls.__idleCount >= count :
+				EventLoop.mainEventLoop().stop()
+				return False
+
+			return True
+
+		EventLoop.addIdleCallback( f )
+		EventLoop.mainEventLoop().start()
+
 	## Widgets may only be manipulated on the thread where mainEventLoop() is running. It
 	# is common to want to perform some background processing on a secondary thread, and
 	# to update the UI during processing or upon completion. This function can be used from

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -157,6 +157,21 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		return None
 
+	## Ensures that the specified plug has a visible PlugValueWidget,
+	# creating one if necessary.
+	@classmethod
+	def acquire( cls, plug ) :
+
+		editor = GafferUI.NodeEditor.acquire( plug.node() )
+
+		plugValueWidget = editor.nodeUI().plugValueWidget( plug, lazy=False )
+		if not plugValueWidget :
+			return None
+
+		plugValueWidget.reveal()
+
+		return plugValueWidget
+
 	## Must be implemented by subclasses so that the widget reflects the current
 	# status of the plug. To temporarily suspend calls to this function, use
 	# Gaffer.BlockedConnection( self._plugConnections() ).

--- a/python/GafferUI/PlugWidget.py
+++ b/python/GafferUI/PlugWidget.py
@@ -121,6 +121,23 @@ class PlugWidget( GafferUI.Widget ) :
 
 		return 150
 
+	## Ensures that the specified plug has a visible PlugWidget,
+	# creating one if necessary.
+	@classmethod
+	def acquire( cls, plug ) :
+
+		plugValueWidget = GafferUI.PlugValueWidget.acquire( plug )
+		if not plugValueWidget :
+			return None
+
+		plugWidget = plugValueWidget.ancestor( GafferUI.PlugWidget )
+		if not plugWidget :
+			return None
+
+		plugWidget.reveal()
+
+		return plugWidget
+
 	def __labelDragEnter( self, label, event ) :
 
 		return self.plugValueWidget().dragEnterSignal()( self.plugValueWidget(), event )

--- a/python/GafferUI/WidgetAlgo.py
+++ b/python/GafferUI/WidgetAlgo.py
@@ -34,6 +34,12 @@
 #
 ##########################################################################
 
+import os
+
+import GafferUI
+
+QtGui = GafferUI._qtImport( "QtGui" )
+
 def joinEdges( listContainer ) :
 
 	if listContainer.orientation() == listContainer.Orientation.Horizontal :
@@ -48,3 +54,14 @@ def joinEdges( listContainer ) :
 	for i in range( 0, l ) :
 		visibleWidgets[i]._qtWidget().setProperty( lowProperty, i > 0 )
 		visibleWidgets[i]._qtWidget().setProperty( highProperty, i < l - 1 )
+
+def grab( widget, imagePath ) :
+
+	GafferUI.EventLoop.waitForIdle()
+
+	imageDir = os.path.dirname( imagePath )
+	if imageDir and not os.path.isdir( imageDir ) :
+		os.makedirs( imageDir )
+
+	pixmap = QtGui.QPixmap.grabWindow( widget._qtWidget().winId() )
+	pixmap.save( imagePath )

--- a/python/GafferUITest/EventLoopTest.py
+++ b/python/GafferUITest/EventLoopTest.py
@@ -38,6 +38,7 @@
 import unittest
 import threading
 import time
+import functools
 
 import IECore
 
@@ -72,6 +73,23 @@ class EventLoopTest( GafferUITest.TestCase ) :
 		GafferUI.EventLoop.mainEventLoop().start()
 
 		self.assertEqual( self.__idleCalls, 2 )
+
+	def testWaitForIdle( self ) :
+
+		self.__idleCalls = 0
+
+		def idle( total ) :
+
+			self.__idleCalls += 1
+			return self.__idleCalls < total
+
+		GafferUI.EventLoop.addIdleCallback( functools.partial( idle, 1000 ) )
+		GafferUI.EventLoop.waitForIdle()
+		self.assertEqual( self.__idleCalls, 1000 )
+
+		GafferUI.EventLoop.addIdleCallback( functools.partial( idle, 1005 ) )
+		GafferUI.EventLoop.waitForIdle( 5 )
+		self.assertEqual( self.__idleCalls, 1005 )
 
 	def testExecuteOnUITheadAndWaitForResult( self ) :
 

--- a/python/GafferUITest/PlugValueWidgetTest.py
+++ b/python/GafferUITest/PlugValueWidgetTest.py
@@ -100,5 +100,25 @@ class PlugValueWidgetTest( unittest.TestCase ) :
 		self.assertTrue( isinstance( w, GafferUI.ConnectionPlugValueWidget ) )
 		self.assertTrue( w.getPlug().isSame( n["p"] ) )
 
+	def testAcquire( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.Node()
+		s["n"]["p"] = Gaffer.IntPlug()
+
+		# hold a reference to the ScriptWindow
+		# to make sure it stays alive
+		sw = GafferUI.ScriptWindow.acquire( s )
+
+		w = GafferUI.PlugValueWidget.acquire( s["n"]["p"] )
+		self.assertTrue( isinstance( w, GafferUI.NumericPlugValueWidget ) )
+		self.assertTrue( w.getPlug().isSame( s["n"]["p"] ) )
+		self.assertTrue( GafferUI.PlugValueWidget.acquire( s["n"]["p"] ) is w )
+
+		pw = GafferUI.PlugWidget.acquire( s["n"]["p"] )
+		self.assertTrue( isinstance( pw, GafferUI.PlugWidget ) )
+		self.assertTrue( pw.plugValueWidget() is w )
+		self.assertTrue( GafferUI.PlugWidget.acquire( s["n"]["p"] ) is pw )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneUI/ContextAlgo.cpp
+++ b/src/GafferSceneUI/ContextAlgo.cpp
@@ -34,6 +34,8 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include "IECore/VectorTypedData.h"
+
 #include "Gaffer/Context.h"
 
 #include "GafferScene/PathMatcherData.h"
@@ -46,6 +48,7 @@ namespace
 {
 
 InternedString g_expandedPathsName( "ui:scene:expandedPaths" );
+InternedString g_selectedPathsName( "ui:scene:selectedPaths" );
 
 } // namespace
 
@@ -68,6 +71,29 @@ PathMatcher getExpandedPaths( const Gaffer::Context *context )
 	}
 
 	return PathMatcher();
+}
+
+void setSelectedPaths( Context *context, const PathMatcher &paths )
+{
+	/// \todo: Switch to storing PathMatcherData after some thorough
+	/// testing and a major version break.
+	StringVectorDataPtr s = new StringVectorData;
+	paths.paths( s->writable() );
+
+	context->set( g_selectedPathsName, s.get() );
+}
+
+PathMatcher getSelectedPaths( const Gaffer::Context *context )
+{
+	PathMatcher result;
+
+	if( const StringVectorData *selection = context->get<StringVectorData>( g_selectedPathsName, NULL ) )
+	{
+		const std::vector<std::string> &values = selection->readable();
+		result.init( values.begin(), values.end() );
+	}
+
+	return result;
 }
 
 } // namespace ContextAlgo

--- a/src/GafferSceneUI/ContextAlgo.cpp
+++ b/src/GafferSceneUI/ContextAlgo.cpp
@@ -1,0 +1,75 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/Context.h"
+
+#include "GafferScene/PathMatcherData.h"
+
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+
+namespace
+{
+
+InternedString g_expandedPathsName( "ui:scene:expandedPaths" );
+
+} // namespace
+
+namespace GafferSceneUI
+{
+
+namespace ContextAlgo
+{
+
+void setExpandedPaths( Context *context, const PathMatcher &paths )
+{
+	context->set( g_expandedPathsName, new PathMatcherData( paths ) );
+}
+
+PathMatcher getExpandedPaths( const Gaffer::Context *context )
+{
+	if( const PathMatcherData *expandedPaths = context->get<PathMatcherData>( g_expandedPathsName, NULL ) )
+	{
+		return expandedPaths->readable();
+	}
+
+	return PathMatcher();
+}
+
+} // namespace ContextAlgo
+
+} // namespace GafferSceneUI

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -1313,6 +1313,26 @@ bool SceneView::keyPress( GafferUI::GadgetPtr gadget, const GafferUI::KeyEvent &
 	return false;
 }
 
+void SceneView::frame( const GafferScene::PathMatcher &filter, const Imath::V3f &direction )
+{
+	Imath::Box3f bound;
+
+	Context::Scope scope( getContext() );
+
+	PathMatcher paths;
+	const ScenePlug *scene = inPlug<const ScenePlug>();
+	SceneAlgo::matchingPaths( filter, scene, paths );
+
+	for( PathMatcher::Iterator it = paths.begin(); it != paths.end(); ++it )
+	{
+		Imath::Box3f objectBound = scene->bound( *it );
+		Imath::M44f objectFullTransform = scene->fullTransform( *it );
+		bound.extendBy( transform( objectBound, objectFullTransform ) );
+	}
+
+	viewportGadget()->frame( bound, direction );
+}
+
 void SceneView::expandSelection( size_t depth )
 {
 	Context::Scope scopedContext( getContext() );

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -66,6 +66,7 @@
 #include "GafferScene/StandardOptions.h"
 #include "GafferScene/LightToCamera.h"
 
+#include "GafferSceneUI/ContextAlgo.h"
 #include "GafferSceneUI/SceneView.h"
 
 using namespace std;
@@ -1259,11 +1260,10 @@ void SceneView::contextChanged( const IECore::InternedString &name )
 	{
 		// If only the selection has changed then we can just update the selection
 		// on our existing scene representation.
-		const StringVectorData *sc = getContext()->get<StringVectorData>( "ui:scene:selectedPaths" );
+		PathMatcher selection = ContextAlgo::getSelectedPaths( getContext() );
 		/// \todo Store selection as PathMatcherData within the context, so we don't need
-		/// this conversion.
-		GafferScene::PathMatcherDataPtr sg = new GafferScene::PathMatcherData;
-		sg->writable().init( sc->readable().begin(), sc->readable().end() );
+		/// to contruct a new one.
+		GafferScene::PathMatcherDataPtr sg = new GafferScene::PathMatcherData( selection );
 		m_sceneGadget->setSelection( sg );
 		return;
 	}
@@ -1335,77 +1335,12 @@ void SceneView::frame( const GafferScene::PathMatcher &filter, const Imath::V3f 
 
 void SceneView::expandSelection( size_t depth )
 {
-	Context::Scope scopedContext( getContext() );
-
 	PathMatcher &selection = const_cast<GafferScene::PathMatcherData *>( m_sceneGadget->getSelection() )->writable();
-	PathMatcher &expanded = expandedPaths()->writable();
 
-	std::vector<string> toExpand;
-	selection.paths( toExpand );
+	Context::Scope scope( getContext() );
+	selection = ContextAlgo::expandDescendants( getContext(), selection, preprocessedInPlug<ScenePlug>(), depth - 1 );
 
-	bool needUpdate = false;
-	for( std::vector<string>::const_iterator it = toExpand.begin(), eIt = toExpand.end(); it != eIt; ++it )
-	{
-		/// \todo It would be nice to be able to get ScenePaths out of
-		/// PathMatcher::paths() directly.
-		ScenePlug::ScenePath path;
-		ScenePlug::stringToPath( *it, path );
-		needUpdate |= expandWalk( path, depth, expanded, selection );
-	}
-
-	if( needUpdate )
-	{
-		// We modified the expanded paths in place to avoid unecessary copying,
-		// so the context doesn't know they've changed. So we emit the changed
-		// signal ourselves - this will then update the SceneGadget via contextChanged().
-		getContext()->changedSignal()( getContext(), "ui:scene:expandedPaths" );
-		// Transfer the new selection to the context - we'd like to use the same
-		// trick as above for that, but can't yet because the context selection isn't
-		// stored as PathMatcherData.
-		transferSelectionToContext();
-	}
-}
-
-bool SceneView::expandWalk( const GafferScene::ScenePlug::ScenePath &path, size_t depth, PathMatcher &expanded, PathMatcher &selected )
-{
-	bool result = false;
-
-	ConstInternedStringVectorDataPtr childNamesData = preprocessedInPlug<ScenePlug>()->childNames( path );
-	const vector<InternedString> &childNames = childNamesData->readable();
-
-	if( childNames.size() )
-	{
-		// expand ourselves to show our children, and make sure we're
-		// not selected - we only want selection at the leaf levels of
-		// our expansion.
-		result |= expanded.addPath( path );
-		result |= selected.removePath( path );
-
-		ScenePlug::ScenePath childPath = path;
-		childPath.push_back( InternedString() ); // room for the child name
-		for( vector<InternedString>::const_iterator cIt = childNames.begin(), ceIt = childNames.end(); cIt != ceIt; cIt++ )
-		{
-			childPath.back() = *cIt;
-			if( depth == 1 )
-			{
-				// at the bottom of the expansion - just select the child
-				result |= selected.addPath( childPath );
-			}
-			else
-			{
-				// continue the expansion
-				result |= expandWalk( childPath, depth - 1, expanded, selected );
-			}
-		}
-	}
-	else
-	{
-		// we have no children, just make sure we're selected to mark the
-		// leaf of the expansion.
-		result |= selected.addPath( path );
-	}
-
-	return result;
+	ContextAlgo::setSelectedPaths( getContext(), selection );
 }
 
 void SceneView::collapseSelection()
@@ -1420,8 +1355,7 @@ void SceneView::collapseSelection()
 		return;
 	}
 
-	GafferScene::PathMatcherData *expandedData = expandedPaths();
-	PathMatcher &expanded = expandedData->writable();
+	PathMatcher expanded = ContextAlgo::getExpandedPaths( getContext() );
 
 	for( vector<string>::const_iterator it = toCollapse.begin(), eIt = toCollapse.end(); it != eIt; ++it )
 	{
@@ -1443,34 +1377,9 @@ void SceneView::collapseSelection()
 		}
 	}
 
-	// See comment in expandSelection().
-	getContext()->changedSignal()( getContext(), "ui:scene:expandedPaths" );
-	// See comment in expandSelection().
-	transferSelectionToContext();
-}
-
-void SceneView::transferSelectionToContext()
-{
-	/// \todo Use PathMatcherData for the context variable so we don't need
-	/// to do this copying into StringVectorData. See related comments
-	/// in SceneHierarchy.__transferSelectionFromContext
-	StringVectorDataPtr s = new StringVectorData();
-	m_sceneGadget->getSelection()->readable().paths( s->writable() );
-	getContext()->set( "ui:scene:selectedPaths", s.get() );
-}
-
-GafferScene::PathMatcherData *SceneView::expandedPaths()
-{
-	const GafferScene::PathMatcherData *m = getContext()->get<GafferScene::PathMatcherData>( "ui:scene:expandedPaths", 0 );
-	if( !m )
-	{
-		GafferScene::PathMatcherDataPtr rootOnly = new GafferScene::PathMatcherData;
-		rootOnly->writable().addPath( "/" );
-		BlockedConnection blockedConnection( contextChangedConnection() );
-		getContext()->set( "ui:scene:expandedPaths", rootOnly.get() );
-		m = getContext()->get<GafferScene::PathMatcherData>( "ui:scene:expandedPaths", 0 );
-	}
-	return const_cast<GafferScene::PathMatcherData *>( m );
+	// \todo: add ContextAlgo::collapse() so we can do the collapse in-place
+	ContextAlgo::setExpandedPaths( getContext(), expanded );
+	ContextAlgo::setSelectedPaths( getContext(), m_sceneGadget->getSelection()->readable() );
 }
 
 void SceneView::plugSet( Gaffer::Plug *plug )

--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -41,6 +41,7 @@
 
 #include "GafferScene/ScenePlug.h"
 
+#include "GafferSceneUI/ContextAlgo.h"
 #include "GafferSceneUI/SelectionTool.h"
 #include "GafferSceneUI/SceneView.h"
 
@@ -227,7 +228,7 @@ bool SelectionTool::buttonPress( const GafferUI::ButtonEvent &event )
 
 	if( selectionChanged )
 	{
-		transferSelectionToContext();
+		ContextAlgo::setSelectedPaths( view()->getContext(), sceneGadget()->getSelection()->readable() );
 	}
 
 	return true;
@@ -287,15 +288,8 @@ bool SelectionTool::dragEnd( const GafferUI::DragDropEvent &event )
 
 	if( sg->objectsAt( dragOverlay()->getStartPosition(), dragOverlay()->getEndPosition(), selection ) )
 	{
-		transferSelectionToContext();
+		ContextAlgo::setSelectedPaths( view()->getContext(), sceneGadget()->getSelection()->readable() );
 	}
 
 	return true;
-}
-
-void SelectionTool::transferSelectionToContext()
-{
-	StringVectorDataPtr s = new StringVectorData();
-	sceneGadget()->getSelection()->readable().paths( s->writable() );
-	view()->getContext()->set( "ui:scene:selectedPaths", s.get() );
 }

--- a/src/GafferSceneUIBindings/ContextAlgoBinding.cpp
+++ b/src/GafferSceneUIBindings/ContextAlgoBinding.cpp
@@ -36,14 +36,30 @@
 
 #include "boost/python.hpp"
 
+#include "IECorePython/ScopedGILRelease.h"
+
 #include "GafferScene/PathMatcher.h"
+#include "GafferScene/ScenePlug.h"
 
 #include "GafferSceneUI/ContextAlgo.h"
 
 #include "GafferSceneUIBindings/ContextAlgoBinding.h"
 
 using namespace boost::python;
+using namespace Gaffer;
+using namespace GafferScene;
 using namespace GafferSceneUI::ContextAlgo;
+
+namespace
+{
+
+PathMatcher expandDescendantsWrapper( Context &context, PathMatcher &paths, ScenePlug &scene, int depth )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return expandDescendants( &context, paths, &scene, depth );
+}
+
+} // namespace
 
 void GafferSceneUIBindings::bindContextAlgo()
 {
@@ -53,6 +69,9 @@ void GafferSceneUIBindings::bindContextAlgo()
 
 	def( "setExpandedPaths", &setExpandedPaths );
 	def( "getExpandedPaths", &getExpandedPaths );
+	def( "expand", &expand, ( arg( "expandAncestors" ) = true ) );
+	def( "expandDescendants", &expandDescendantsWrapper, ( arg( "context" ), arg( "paths" ), arg( "scene" ), arg( "depth" ) = Imath::limits<int>::max() ) );
+	def( "clearExpansion", &clearExpansion );
 	def( "setSelectedPaths", &setSelectedPaths );
 	def( "getSelectedPaths", &getSelectedPaths );
 

--- a/src/GafferSceneUIBindings/ContextAlgoBinding.cpp
+++ b/src/GafferSceneUIBindings/ContextAlgoBinding.cpp
@@ -53,5 +53,7 @@ void GafferSceneUIBindings::bindContextAlgo()
 
 	def( "setExpandedPaths", &setExpandedPaths );
 	def( "getExpandedPaths", &getExpandedPaths );
+	def( "setSelectedPaths", &setSelectedPaths );
+	def( "getSelectedPaths", &getSelectedPaths );
 
 }

--- a/src/GafferSceneUIBindings/ContextAlgoBinding.cpp
+++ b/src/GafferSceneUIBindings/ContextAlgoBinding.cpp
@@ -1,0 +1,57 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "GafferScene/PathMatcher.h"
+
+#include "GafferSceneUI/ContextAlgo.h"
+
+#include "GafferSceneUIBindings/ContextAlgoBinding.h"
+
+using namespace boost::python;
+using namespace GafferSceneUI::ContextAlgo;
+
+void GafferSceneUIBindings::bindContextAlgo()
+{
+	object module( borrowed( PyImport_AddModule( "GafferSceneUI.ContextAlgo" ) ) );
+	scope().attr( "ContextAlgo" ) = module;
+	scope moduleScope( module );
+
+	def( "setExpandedPaths", &setExpandedPaths );
+	def( "getExpandedPaths", &getExpandedPaths );
+
+}

--- a/src/GafferSceneUIBindings/SceneViewBinding.cpp
+++ b/src/GafferSceneUIBindings/SceneViewBinding.cpp
@@ -89,12 +89,19 @@ boost::python::list registeredShadingModes()
 	return result;
 }
 
+void frame( SceneView &view, PathMatcher &filter, Imath::V3f &direction )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	view.frame( filter, direction );
+}
+
 } // namespace
 
 void GafferSceneUIBindings::bindSceneView()
 {
 
 	GafferBindings::NodeClass<SceneView>()
+		.def( "frame", &frame, ( boost::python::arg_( "filter" ), boost::python::arg_( "direction" ) = Imath::V3f( -0.64, -0.422, -0.64 ) ) )
 		.def( "expandSelection", &SceneView::expandSelection, ( boost::python::arg_( "depth" ) = 1 ) )
 		.def( "collapseSelection", &SceneView::collapseSelection )
 		.def( "registerShadingMode", &registerShadingMode )

--- a/src/GafferSceneUIModule/GafferSceneUIModule.cpp
+++ b/src/GafferSceneUIModule/GafferSceneUIModule.cpp
@@ -54,6 +54,7 @@
 #include "GafferSceneUIBindings/TranslateToolBinding.h"
 #include "GafferSceneUIBindings/RotateToolBinding.h"
 #include "GafferSceneUIBindings/ScaleToolBinding.h"
+#include "GafferSceneUIBindings/ContextAlgoBinding.h"
 
 using namespace boost::python;
 using namespace IECorePython;
@@ -110,5 +111,6 @@ BOOST_PYTHON_MODULE( _GafferSceneUI )
 	bindLightVisualiser();
 	bindStandardLightVisualiser();
 	bindSceneHierarchy();
+	bindContextAlgo();
 
 }


### PR DESCRIPTION
This started out as some small-ish improvements to the Screengrab App, but it's ended up as quite a lot more. I've tested as best I can, and verified that it does the things I need for my external documentaion project that started all of this. But I might as well point out some possible concerns:

- `SceneView::frame()` (ed8a0c4)
  - I've set a default direction based on the default from the Screengrab App. Not sure that's desirable, though it does give a decent framing for my external docs.
  - The test is a bit odd, but I do think it proves the thing is working.
- `ContextAlgo::clearExpansion()` (08923ed) : We didn't discuss this one offline, but I found it useful in the tests anyways, and I'm using it the Screengrab App too.
- `ContextAlgo::collapse()` (e67cb04)
  - We didn't discuss this either, but I needed it to re-implement `SceneView::collapseSelection()` (7fb2d9e). I've left these commits separate in case we want to drop them.
  - I'm not sure I've got this one right either... I don't totally follow that pop parent stuff that's going on. The tests are passing though, and interactively I didn't notice anything odd.
- Screengrab App expansion (4de04bf) : I think this is right, but I'm not getting the same SceneHierarchy expansion for the GettingStarted tutorial as we have in the docs from Gaffer 0.33.2.0 at IE. I'm not totally convinced they're deterministic in the first place, but I could have screwed something up here. Take a close look.
- `CustomAttributesUI` (60b851b) : I couldn't figure out how to engage this menu interactively...
- There are a handful of spots outside of `ContextAlgo` that are still referring to "ui:scene:expandedPaths" or "ui:scene:selectedPaths". I don't really like that they have to know about the context variable name, but I didn't see a way to change that other than providing some accessors like `ContextAlgo::expandedPathsName()` and that seemed a bit over the top maybe...