### PR TITLE
Catalogue binding : Release GIL in `driverCreated` and `imageReceived`

### DIFF
--- a/include/GafferImage/Catalogue.h
+++ b/include/GafferImage/Catalogue.h
@@ -45,7 +45,6 @@
 
 #include "GafferImage/ImageNode.h"
 #include "GafferImage/ImageSwitch.h"
-#include "GafferImageBindings/CatalogueBinding.h" // To enable friend declaration for bindCatalogue()
 
 namespace GafferImage
 {
@@ -109,7 +108,7 @@ class Catalogue : public ImageNode
 		std::string generateFileName( const Image *image ) const;
 		std::string generateFileName( const ImagePlug *image ) const;
 
-	private :
+	protected :
 
 		// In an ideal world, the Catalogue would connect these to the relevant
 		// signals directly, but unfortunately the signals are not emitted on the
@@ -118,7 +117,8 @@ class Catalogue : public ImageNode
 		// call these "slots" from the UI thread.
 		static void driverCreated( IECore::DisplayDriver *driver, const IECore::CompoundData *parameters );
 		static void imageReceived( Gaffer::Plug *plug );
-		friend void GafferImageBindings::bindCatalogue();
+
+	private :
 
 		ImageSwitch *imageSwitch();
 		const ImageSwitch *imageSwitch() const;

--- a/include/GafferImageTest/ProcessTiles.h
+++ b/include/GafferImageTest/ProcessTiles.h
@@ -47,11 +47,14 @@ namespace GafferImage
 namespace GafferImageTest
 {
 
-
 /// Traverses the tiles and channels in an image, processing the channel data for each one, using
 /// parallel threads to process different tiles and channels. It's useful to use this in test
 // cases to exercise any thread related crashes, and also in profiling for performance improvement.
 void processTiles( const GafferImage::ImagePlug *imagePlug );
+
+/// Arranges for processTiles() to be called every time the image is dirtied. This is useful
+/// for exposing bugs, particularly with GIL management.
+boost::signals::connection connectProcessTilesToPlugDirtiedSignal( GafferImage::ConstImagePlugPtr image );
 
 } // namespace GafferImageTest
 

--- a/src/GafferImageBindings/CatalogueBinding.cpp
+++ b/src/GafferImageBindings/CatalogueBinding.cpp
@@ -129,6 +129,23 @@ std::string generateFileName2( Catalogue &catalogue, const ImagePlug *image )
 	return catalogue.generateFileName( image );
 }
 
+struct CatalogueWrapper : public Catalogue
+{
+
+	static void driverCreated( IECore::DisplayDriver *driver, const IECore::CompoundData *parameters )
+	{
+		IECorePython::ScopedGILRelease gilRelease;
+		Catalogue::driverCreated( driver, parameters );
+	}
+
+	static void imageReceived( Gaffer::Plug *plug )
+	{
+		IECorePython::ScopedGILRelease gilRelease;
+		Catalogue::imageReceived( plug );
+	}
+
+};
+
 } // namespace
 
 namespace GafferImageBindings
@@ -142,9 +159,9 @@ void bindCatalogue()
 		.def( "generateFileName", &generateFileName2 )
 		.def( "displayDriverServer", &Catalogue::displayDriverServer, return_value_policy<IECorePython::CastToIntrusivePtr>() )
 		.staticmethod( "displayDriverServer" )
-		.def( "driverCreated", &Catalogue::driverCreated )
+		.def( "driverCreated", &CatalogueWrapper::driverCreated )
 		.staticmethod( "driverCreated" )
-		.def( "imageReceived", &Catalogue::imageReceived )
+		.def( "imageReceived", &CatalogueWrapper::imageReceived )
 		.staticmethod( "imageReceived" )
 	;
 

--- a/src/GafferImageTestModule/GafferImageTestModule.cpp
+++ b/src/GafferImageTestModule/GafferImageTestModule.cpp
@@ -55,6 +55,7 @@ static void processTilesWrapper( GafferImage::ImagePlug *imagePlug )
 BOOST_PYTHON_MODULE( _GafferImageTest )
 {
 	def( "processTiles", &processTilesWrapper );
+	def( "connectProcessTilesToPlugDirtiedSignal", &connectProcessTilesToPlugDirtiedSignal );
 	def( "testOIIOJpgRead", &testOIIOJpgRead );
 	def( "testOIIOExrRead", &testOIIOExrRead );
 }


### PR DESCRIPTION
Otherwise we can end up in deadlock if the subsequent dirtying of the output plug triggers a multithreaded computation.