### PR TITLE
More Complete Shader Reloading For OSL

### DIFF
--- a/include/GafferOSL/OSLShader.h
+++ b/include/GafferOSL/OSLShader.h
@@ -63,6 +63,8 @@ class OSLShader : public GafferScene::Shader
 		/// \undoable.
 		virtual void loadShader( const std::string &shaderName, bool keepExistingValues=false );
 
+		virtual void reloadShader();
+
 		ConstShadingEnginePtr shadingEngine() const;
 
 		/// Returns an OSL metadata item from the shader.

--- a/include/GafferRenderMan/RenderManShader.h
+++ b/include/GafferRenderMan/RenderManShader.h
@@ -66,6 +66,8 @@ class RenderManShader : public GafferScene::Shader
 		/// \undoable.
 		virtual void loadShader( const std::string &shaderName, bool keepExistingValues=false );
 
+		virtual void reloadShader();
+
 		/// The loader used by loadShader() - this is exposed so that the ui
 		/// can use it too.
 		static IECore::CachedReader *shaderLoader();

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -109,6 +109,10 @@ class Shader : public Gaffer::DependencyNode
 		/// plug
 		virtual void loadShader( const std::string &shaderName, bool keepExistingValues=false );
 
+		/// Subclasses of Shader should do any extra cache clearing required, and then call the
+		/// base class implementation
+		virtual void reloadShader();
+
 		/// \deprecated Use ShaderPlug::attributesHash() instead.
 		/// \todo Protect these methods, and enforce access via the
 		/// ShaderPlug methods - this would be consistent with our

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -181,13 +181,9 @@ class _ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__button.setEnabled( not Gaffer.MetadataAlgo.readOnly( self.getPlug() ) )
 
 	def __buttonClicked( self, button ) :
-
 		node = self.getPlug().node()
-		if hasattr( node, "shaderLoader" ) :
-			node.shaderLoader().clear()
-
 		with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
-			node.loadShader( node["name"].getValue(), keepExistingValues = True )
+			node.reloadShader()
 
 ##########################################################################
 # NodeFinderDialogue mode

--- a/src/GafferOSL/OSLShader.cpp
+++ b/src/GafferOSL/OSLShader.cpp
@@ -1251,3 +1251,12 @@ const IECore::Data *OSLShader::parameterMetadata( const Gaffer::Plug *plug, cons
 
 	return p->member<IECore::Data>( key );
 }
+
+void OSLShader::reloadShader()
+{
+	// Remove any metadata cache entry for the given shader name, allowing
+	// it to be reloaded fresh if it has changed
+	g_metadataCache.erase( namePlug()->getValue() );
+	Shader::reloadShader();
+}
+

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -161,6 +161,12 @@ void RenderManShader::loadShader( const std::string &shaderName, bool keepExisti
 	}
 }
 
+void RenderManShader::reloadShader()
+{
+	shaderLoader()->clear();
+	Shader::reloadShader();
+}
+
 bool RenderManShader::acceptsInput( const Plug *plug, const Plug *inputPlug ) const
 {
 	if( !Shader::acceptsInput( plug, inputPlug ) )

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -706,6 +706,13 @@ void Shader::loadShader( const std::string &shaderName, bool keepExistingValues 
 	// doesn't need a loadShader override because it's not really a shader.
 }
 
+void Shader::reloadShader()
+{
+	// Sub-classes should take care of any necessary cache clearing before calling this
+
+	loadShader( namePlug()->getValue(), true );
+}
+
 void Shader::parameterHash( const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h ) const
 {
 	const ValuePlug *vplug = IECore::runTimeCast<const ValuePlug>( parameterPlug );

--- a/src/GafferSceneBindings/ShaderBinding.cpp
+++ b/src/GafferSceneBindings/ShaderBinding.cpp
@@ -89,6 +89,15 @@ void loadShader( Shader &shader, const std::string &shaderName, bool keepExistin
 	shader.loadShader( shaderName, keepExistingValues );
 }
 
+void reloadShader( Shader &shader )
+{
+	// Reloading a shader modifies the graph, which can trigger dirty propagation,
+	// which can trigger computations, which can launch threads. 
+	// So we need a GIL release here.
+	IECorePython::ScopedGILRelease gilRelease;
+	shader.reloadShader();
+}
+
 
 
 class ShaderSerialiser : public GafferBindings::NodeSerialiser
@@ -121,6 +130,7 @@ void GafferSceneBindings::bindShader()
 		.def( "stateHash", (void (Shader::*)( IECore::MurmurHash &h ) const )&Shader::stateHash )
 		.def( "state", &state, ( boost::python::arg_( "_copy" ) = true ) )
 		.def( "loadShader", &loadShader, ( arg_( "shaderName" ), arg_( "keepExistingValues" ) = false ) )
+		.def( "reloadShader", &reloadShader )
 
 	;
 


### PR DESCRIPTION
My urgent OSL task turned out to be less urgent than originally thought, so I had a bit of time to improve workflow stuff.

This PR is half explorational, to see if this is about how you might want it done, and half because this is already making my life nicer.

The first commit feels quite nice to me - the refreshCache optional argument to loadShader seems quite reasonable, and this allows reloading the metadata.  If we wanted to clean up the RenderMan case, we could make RenderManShader::loadShader responsible for calling shaderLoader().clear() itself if refreshCache is passed, instead of the current:
```
        if hasattr( node, "shaderLoader" ) :
            node.shaderLoader().clear()
```
in ShaderUI.py

The API of the second commit is perhaps less obvious, but seems reasonably clean, and allows reloading shaders while previewing them with OSLImage ( which is super slick for developing texture patterns ).

If this seems like a good direction to you, the final piece of the puzzle to make it all work perfectly would be for OSLShader::loadShader() to when it receives the "refreshCache" parameter, add a special non-serialisable and invisible parameter with a special name like "__gafferRefreshCount" which the ShadingEngine wouldn't pass to OSL, but would cause the Gaffer hash cache to immediately invalidate plugs which depend on the shader.

After that, the only big thing I'm missing from what we had working for RSL is activators in the UI, which would be really nice - but I guess this is now dependent on the bigger picture issue of serializing activators?  I'm assuming you wouldn't want me to just port across how the RSL ones used to work?