### PR TITLE
Seeds : Add densityPrimitiveVariable plug

### DIFF
--- a/include/GafferScene/Seeds.h
+++ b/include/GafferScene/Seeds.h
@@ -59,6 +59,9 @@ class Seeds : public BranchCreator
 		Gaffer::FloatPlug *densityPlug();
 		const Gaffer::FloatPlug *densityPlug() const;
 
+		Gaffer::StringPlug *densityPrimitiveVariablePlug();
+		const Gaffer::StringPlug *densityPrimitiveVariablePlug() const;
+
 		Gaffer::StringPlug *pointTypePlug();
 		const Gaffer::StringPlug *pointTypePlug() const;
 

--- a/python/GafferSceneTest/SeedsTest.py
+++ b/python/GafferSceneTest/SeedsTest.py
@@ -193,5 +193,35 @@ class SeedsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( s["in"]["globals"].hash(), s["out"]["globals"].hash() )
 		self.assertEqual( s["in"]["globals"].getValue(), s["out"]["globals"].getValue() )
 
+	def testDensityPrimitiveVariable( self ) :
+
+		plane = GafferScene.Plane()
+
+		filter = GafferScene.PathFilter()
+		filter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		primitiveVariables = GafferScene.PrimitiveVariables()
+		primitiveVariables["in"].setInput( plane["out"] )
+		primitiveVariables["filter"].setInput( filter["out"] )
+
+		seeds = GafferScene.Seeds()
+		seeds["in"].setInput( primitiveVariables["out"] )
+		seeds["parent"].setValue( "/plane" )
+		seeds["name"].setValue( "seeds" )
+		seeds["density"].setValue( 100 )
+
+		p = seeds["out"].object( "/plane/seeds" )
+
+		# Density variable doesn't exist, result should be
+		# the same.
+
+		seeds["densityPrimitiveVariable"].setValue( "d" )
+		self.assertEqual( seeds["out"].object( "/plane/seeds" ), p )
+
+		# Add the primitive variable, it should take effect.
+
+		primitiveVariables["primitiveVariables"].addMember( "d", IECore.FloatData( 0.5 ) )
+		self.assertLessEqual( seeds["out"].object( "/plane/seeds" ).numPoints, p.numPoints )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/SeedsUI.py
+++ b/python/GafferSceneUI/SeedsUI.py
@@ -84,6 +84,17 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"densityPrimitiveVariable" : [
+
+			"description",
+			"""
+			A float primitive variable used to specify a varying
+			point density across the surface of the mesh. Multiplied
+			with the density setting above.
+			""",
+
+		],
+
 		"pointType" : [
 
 			"description",


### PR DESCRIPTION
Here's a simple example using an OSLObject node to apply a noise pattern as a per-vertex primitive variable, and then using that to control the density of a seeds node...
![density](https://cloud.githubusercontent.com/assets/1133871/26326629/ea7518b8-3f33-11e7-89dd-b85af1d9b877.png)
