### PR TITLE
Gaffer.Metadata : Leaking metadata signals

### DIFF
--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -35,6 +35,8 @@
 ##########################################################################
 
 import unittest
+import subprocess
+import os
 
 import IECore
 
@@ -1013,6 +1015,12 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		self.assertEqual( Gaffer.Metadata.registeredValues( n, instanceOnly = True ), [] )
 		self.assertEqual( Gaffer.Metadata.registeredValues( n["op1"], instanceOnly = True ), [] )
+
+	@staticmethod
+	def testPythonUnload() :
+
+		subprocess.check_call( [ "gaffer", "python", os.path.dirname( __file__ ) + "/pythonScripts/unloadExceptionScript.py" ] )
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/pythonScripts/unloadExceptionScript.py
+++ b/python/GafferTest/pythonScripts/unloadExceptionScript.py
@@ -1,0 +1,65 @@
+##########################################################################
+#
+#  Copyright (c) 2011, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+# This script is used by MetadataTest.py
+
+
+import Gaffer
+
+
+class TestNode( Gaffer.Node ) :
+
+	def __init__( self, name = "TestNode" ):
+		super( TestNode, self ).__init__( name=name )
+		self._nodeValueChangedConnection = Gaffer.Metadata.nodeValueChangedSignal().connect( Gaffer.WeakMethod( self.__nodeValueChanged ) )
+		self._plugValueChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
+		self._valueChangedConnection = Gaffer.Metadata.valueChangedSignal().connect( Gaffer.WeakMethod( self.__valueMetadataChanged ) )
+
+	def __nodeValueChanged( self, nodeTypeId, key, node ) :
+		pass
+
+	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
+		pass
+
+	def __valueMetadataChanged( self, target, key ) :
+		pass
+
+
+s = Gaffer.ScriptNode()
+n = TestNode()
+s.addChild(n)
+
+exit()

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -748,20 +748,20 @@ IECore::ConstDataPtr Metadata::valueInternal( const GraphComponent *target, IECo
 
 Metadata::ValueChangedSignal &Metadata::valueChangedSignal()
 {
-	static ValueChangedSignal s;
-	return s;
+	static ValueChangedSignal *s = new ValueChangedSignal;
+	return *s;
 }
 
 Metadata::NodeValueChangedSignal &Metadata::nodeValueChangedSignal()
 {
-	static NodeValueChangedSignal s;
-	return s;
+	static NodeValueChangedSignal *s = new NodeValueChangedSignal;
+	return *s;
 }
 
 Metadata::PlugValueChangedSignal &Metadata::plugValueChangedSignal()
 {
-	static PlugValueChangedSignal s;
-	return s;
+	static PlugValueChangedSignal *s = new PlugValueChangedSignal;
+	return *s;
 }
 
 void Metadata::clearInstanceMetadata( const GraphComponent *graphComponent )


### PR DESCRIPTION
"Leaking" Metadata signals so that python doesn't crash during shutdown.

Here is @johnhaddon 's explanation for the cause of the crashes:

> I think the issue here is that the nodeValueChangedSignal is static, and so gets deleted automatically during shutdown. When it is deleted, all the connected slots are deleted too, and in this case there is a python object connected as a slot. So we end up trying to delete a python object after/during python shutdown and python doesn't seem to like that. Python's shutdown process is a bit rubbish really, so I think we'll need to work around this on the Gaffer side.
> 
> I think the easiest approach might be to "leak" the signals so they don't get deleted during shutdown.