### PR TITLE
Move loadShader() into base Shader class

### DIFF
--- a/include/GafferArnold/ArnoldShader.h
+++ b/include/GafferArnold/ArnoldShader.h
@@ -60,10 +60,7 @@ class ArnoldShader : public GafferScene::Shader
 		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output );
 		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
 
-		/// \todo Remove this version, and add `keepExistingValues = false` default
-		/// to version below.
-		void loadShader( const std::string &shaderName );
-		void loadShader( const std::string &shaderName, bool keepExistingValues );
+		virtual void loadShader( const std::string &shaderName, bool keepExistingValues=false );
 
 	private :
 

--- a/include/GafferOSL/OSLCode.h
+++ b/include/GafferOSL/OSLCode.h
@@ -72,6 +72,11 @@ class OSLCode : public OSLShader
 		/// combo we use everywhere else.
 		ShaderCompiledSignal &shaderCompiledSignal();
 
+		// This is implemented to do nothing, because OSLCode node generates the shader from
+		// the plugs, and not the other way around.  We don't want to inherit the loading behaviour
+		// from OSLShader which tries to match the plugs to a shader on disk
+		virtual void loadShader( const std::string &shaderName, bool keepExistingValues=false );
+
 	private :
 
 		void updateShader();

--- a/include/GafferOSL/OSLShader.h
+++ b/include/GafferOSL/OSLShader.h
@@ -61,8 +61,7 @@ class OSLShader : public GafferScene::Shader
 		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
 
 		/// \undoable.
-		/// \todo Make this method virtual and define it on the Shader base class.
-		void loadShader( const std::string &shaderName, bool keepExistingValues=false );
+		virtual void loadShader( const std::string &shaderName, bool keepExistingValues=false );
 
 		ConstShadingEnginePtr shadingEngine() const;
 

--- a/include/GafferRenderMan/RenderManShader.h
+++ b/include/GafferRenderMan/RenderManShader.h
@@ -64,8 +64,7 @@ class RenderManShader : public GafferScene::Shader
 		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
 
 		/// \undoable.
-		/// \todo Make this method virtual and define it on the Shader base class.
-		void loadShader( const std::string &shaderName, bool keepExistingValues=false );
+		virtual void loadShader( const std::string &shaderName, bool keepExistingValues=false );
 
 		/// The loader used by loadShader() - this is exposed so that the ui
 		/// can use it too.

--- a/include/GafferScene/OpenGLShader.h
+++ b/include/GafferScene/OpenGLShader.h
@@ -52,7 +52,7 @@ class OpenGLShader : public GafferScene::Shader
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::OpenGLShader, OpenGLShaderTypeId, GafferScene::Shader );
 
-		void loadShader( const std::string &shaderName );
+		virtual void loadShader( const std::string &shaderName, bool keepExistingValues=false );
 
 	protected :
 

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -104,6 +104,11 @@ class Shader : public Gaffer::DependencyNode
 		/// outPlug().
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 
+		/// \undoable
+		/// Subclasses of Shader should define how to load a given shader name, and populate the parameters
+		/// plug
+		virtual void loadShader( const std::string &shaderName, bool keepExistingValues=false );
+
 		/// \deprecated Use ShaderPlug::attributesHash() instead.
 		/// \todo Protect these methods, and enforce access via the
 		/// ShaderPlug methods - this would be consistent with our

--- a/python/GafferSceneTest/OpenGLShaderTest.py
+++ b/python/GafferSceneTest/OpenGLShaderTest.py
@@ -114,6 +114,23 @@ class OpenGLShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertNotEqual( h3, h2 )
 		self.assertNotEqual( h3, h1 )
 
+	def testLoadShader( self ) :
+
+		s = GafferScene.OpenGLShader()
+		s.loadShader( "Texture" )
+		self.assertEqual( s["parameters"].keys(), ['mult', 'texture', 'tint'] )
+		s["parameters"]["mult"].setValue( 3 )
+
+		s.loadShader( "Texture", keepExistingValues = True )
+		self.assertEqual( s["parameters"].keys(), ['mult', 'texture', 'tint'] )
+		self.assertEqual( s["parameters"]["mult"].getValue(), 3 )
+
+		s.loadShader( "Texture" )
+		self.assertEqual( s["parameters"].keys(), ['mult', 'texture', 'tint'] )
+
+		# By default we don't keep existing values
+		self.assertEqual( s["parameters"]["mult"].getValue(), 0 )
+
 if sys.platform == "darwin" :
 	# The Texture shader used in the test provides only a .frag file, which
 	# means that it gets the default vertex shader. The default vertex shader

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -178,8 +178,7 @@ class _ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 		with self.getContext() :
 			shaderName = self.getPlug().getValue()
 			self.__label.setText( "<h3>Shader : " + shaderName + "</h3>" )
-			## \todo Disable the type check once we've got OpenGLShader implementing reloading properly.
-			self.__button.setEnabled( not Gaffer.MetadataAlgo.readOnly( self.getPlug() ) and not isinstance( self.getPlug().node(), GafferScene.OpenGLShader ) )
+			self.__button.setEnabled( not Gaffer.MetadataAlgo.readOnly( self.getPlug() ) )
 
 	def __buttonClicked( self, button ) :
 

--- a/src/GafferArnold/ArnoldShader.cpp
+++ b/src/GafferArnold/ArnoldShader.cpp
@@ -107,11 +107,6 @@ const Gaffer::Plug *ArnoldShader::correspondingInput( const Gaffer::Plug *output
 	return result;
 }
 
-void ArnoldShader::loadShader( const std::string &shaderName )
-{
-	loadShader( shaderName, false );
-}
-
 void ArnoldShader::loadShader( const std::string &shaderName, bool keepExistingValues )
 {
 	IECoreArnold::UniverseBlock arnoldUniverse( /* writable = */ false );

--- a/src/GafferArnoldModule/GafferArnoldModule.cpp
+++ b/src/GafferArnoldModule/GafferArnoldModule.cpp
@@ -55,25 +55,6 @@ using namespace GafferArnold;
 namespace
 {
 
-/// \todo Move this serialisation to the bindings for GafferScene::Shader, once we've made Shader::loadShader() virtual
-/// and implemented it so reloading works in OpenGLShader.
-class ArnoldShaderSerialiser : public GafferBindings::NodeSerialiser
-{
-
-	virtual std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const GafferBindings::Serialisation &serialisation ) const
-	{
-		const ArnoldShader *shader = static_cast<const ArnoldShader *>( graphComponent );
-		std::string shaderName = shader->namePlug()->getValue();
-		if( shaderName.size() )
-		{
-			return boost::str( boost::format( "%s.loadShader( \"%s\", keepExistingValues=True )\n" ) % identifier % shaderName );
-		}
-
-		return "";
-	}
-
-};
-
 void flushCaches( int flags )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -85,17 +66,7 @@ void flushCaches( int flags )
 BOOST_PYTHON_MODULE( _GafferArnold )
 {
 
-	GafferBindings::DependencyNodeClass<ArnoldShader>()
-		.def(
-			"loadShader", (void (ArnoldShader::*)( const std::string &, bool ))&ArnoldShader::loadShader,
-			(
-				arg( "shaderName" ),
-				arg( "keepExistingValues" ) = false
-			)
-		)
-	;
-
-	GafferBindings::Serialisation::registerSerialiser( ArnoldShader::staticTypeId(), new ArnoldShaderSerialiser() );
+	GafferBindings::DependencyNodeClass<ArnoldShader>();
 
 	GafferBindings::NodeClass<ArnoldLight>()
 		.def( "loadShader", (void (ArnoldLight::*)( const std::string & ) )&ArnoldLight::loadShader )

--- a/src/GafferOSL/OSLCode.cpp
+++ b/src/GafferOSL/OSLCode.cpp
@@ -398,6 +398,10 @@ std::string OSLCode::source( const std::string shaderName ) const
 	return generate( this, shaderNameCopy );
 }
 
+void OSLCode::loadShader( const std::string &shaderName, bool keepExistingValues )
+{
+}
+
 OSLCode::ShaderCompiledSignal &OSLCode::shaderCompiledSignal()
 {
 	return m_shaderCompiledSignal;

--- a/src/GafferScene/OpenGLShader.cpp
+++ b/src/GafferScene/OpenGLShader.cpp
@@ -69,14 +69,13 @@ OpenGLShader::~OpenGLShader()
 {
 }
 
-void OpenGLShader::loadShader( const std::string &shaderName )
+void OpenGLShader::loadShader( const std::string &shaderName, bool keepExistingValues )
 {
 	IECoreGL::init( false );
 
 	IECoreGL::ShaderLoaderPtr loader = IECoreGL::ShaderLoader::defaultShaderLoader();
 	IECoreGL::ShaderPtr shader = loader->load( shaderName );
 
-	bool keepExistingValues = false; // Temporary declaration before we add this parameter in the next commit
 	if( !keepExistingValues )
 	{
 		// If we're not preserving existing values then remove all existing

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -695,6 +695,17 @@ void Shader::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs
 	}
 }
 
+void Shader::loadShader( const std::string &shaderName, bool keepExistingValues )
+{
+	// A base shader doesn't know anything about what sort of parameters you might want to load.
+	//
+	// The only reason why this isn't pure virtual is because it is occasionally useful to
+	// manually create a shader type which doesn't actually correspond to any real shader on disk.
+	// IERendering using this to create a generic mesh light shader which is later translated into
+	// the correct shader type for whichever renderer you are using.  Similarly, ArnoldDisplacement
+	// doesn't need a loadShader override because it's not really a shader.
+}
+
 void Shader::parameterHash( const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h ) const
 {
 	const ValuePlug *vplug = IECore::runTimeCast<const ValuePlug>( parameterPlug );

--- a/src/GafferSceneModule/GafferSceneModule.cpp
+++ b/src/GafferSceneModule/GafferSceneModule.cpp
@@ -160,9 +160,7 @@ BOOST_PYTHON_MODULE( _GafferScene )
 	GafferBindings::DependencyNodeClass<MapProjection>();
 	GafferBindings::DependencyNodeClass<MapOffset>();
 
-	GafferBindings::NodeClass<OpenGLShader>()
-		.def( "loadShader", &OpenGLShader::loadShader )
-	;
+	GafferBindings::NodeClass<OpenGLShader>();
 
 	{
 		scope s = GafferBindings::DependencyNodeClass<Sphere>();


### PR DESCRIPTION
This in accordance with some TODOs from John, and lays the groundwork for fully functional shader reloading.  I haven't reviewed all these changes myself yet to double check if I've missed anything, but since the default ganging stuff we talked about would potentially sit on top of this, I thought I should put up what I have so John can offer initial feedback.

As far as I can recall, the only vaguely sketchy thing that I did is instead of a custom serialiser for OSLCode that doesn't emit loadShader(), I implemented loadShader on OSLCode to do nothing.  This seems reasonably clear - loadShader is called on all shaders, but OSLCode doesn't create parameters on load.