### PR TITLE
RenderManRenderTest : Mark expected failure on Mac

### DIFF
--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -872,5 +872,13 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		rib = file( self.temporaryDirectory() + "/test.rib" ).read()
 		self.assertTrue( '"int samplemotion" [ 0 ]' in rib )
 
+if sys.platform == "darwin" :
+	# This test currently fails intermittently on Mac, and tests a
+	# code path which is encountered only when doing REYES rendering.
+	# Since we plan to entirely replace GafferRenderMan with an NSI
+	# backend, we don't intend to spend resources fixing this issue,
+	# so mark it as an expected failure to avoid noise.
+	RenderManRenderTest.testBoundsAndImageOutput = unittest.expectedFailure( RenderManRenderTest.testBoundsAndImageOutput )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This only affects a platform we don't use in production, using a hider that was long since unused in production even on unaffected platforms, and in a renderer backend we intend to replace shortly anyway. If anyone is affected and wants to provide a fix it would be gratefully accepted, but we don't have the resources to address this ourselves.