### PR TITLE
Layer Selector : Don't create submenus for layers with default channels

### DIFF
--- a/python/GafferImageUI/RGBAChannelsPlugValueWidget.py
+++ b/python/GafferImageUI/RGBAChannelsPlugValueWidget.py
@@ -92,6 +92,9 @@ class RGBAChannelsPlugValueWidget( GafferUI.PlugValueWidget ) :
 			return result
 
 		added = set()
+		nonStandardLayers = set( [ GafferImage.ImageAlgo.layerName( x ) for x in channelNames
+			if GafferImage.ImageAlgo.baseName( x ) not in [ "R", "G", "B", "A" ] ] )
+
 		for channelName in sorted( channelNames, key = GafferImage.ImageAlgo.layerName ) :
 
 			if GafferImage.ImageAlgo.baseName( channelName ) in [ "R", "G", "B", "A" ] :
@@ -105,6 +108,12 @@ class RGBAChannelsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 			if text in added :
 				continue
+
+			added.add( text )
+
+			if not GafferImage.ImageAlgo.layerName( text ) in nonStandardLayers: 
+				# If there are only the standard channels, we don't need a submenu
+				text = text.replace( ".RGBA", "" )
 
 			result.append(
 				"/" + text.replace( ".", "/" ),


### PR DESCRIPTION
After getting layers working in the catalog, the menu for selecting layers was really bugging me.

This cleans it up some.  You can now directly click on the name of a layer to select it, unless there is a non-standard channel in that layer ( in which case it gets a submenu like before ).

As a handy side effect, you can now glance at the list of layers, and see which ones have non-standard channels, where as before you would just see submenus everywhere.

I've added a reference image, this commit should be dropped before merging.