### PR TITLE
GafferBindings : Bind DirtyPropagationScope

### DIFF
--- a/include/GafferBindings/DirtyPropagationScopeBinding.h
+++ b/include/GafferBindings/DirtyPropagationScopeBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERBINDINGS_DIRTYPROPAGATIONSCOPEBINDING_H
+#define GAFFERBINDINGS_DIRTYPROPAGATIONSCOPEBINDING_H
+
+namespace GafferBindings
+{
+
+void bindDirtyPropagationScope();
+
+} // namespace GafferBindings
+
+#endif // GAFFERBINDINGS_DIRTYPROPAGATIONSCOPEBINDING_H

--- a/python/GafferTest/DirtyPropagationScopeTest.py
+++ b/python/GafferTest/DirtyPropagationScopeTest.py
@@ -1,0 +1,64 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferTest
+
+class DirtyPropagationScopeTest( GafferTest.TestCase ) :
+
+	def test( self ) :
+
+		n = GafferTest.AddNode()
+		cs = GafferTest.CapturingSlot( n.plugDirtiedSignal() )
+
+		n["op1"].setValue( 10 )
+		n["op2"].setValue( 20 )
+
+		self.assertEqual( len( [ x[0] for x in cs if x[0].isSame( n["sum"] ) ] ), 2 )
+
+		del cs[:]
+
+		with Gaffer.DirtyPropagationScope() :
+
+			n["op1"].setValue( 11 )
+			n["op2"].setValue( 21 )
+
+		self.assertEqual( len( [ x[0] for x in cs if x[0].isSame( n["sum"] ) ] ), 1 )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -134,6 +134,7 @@ from ContextMonitorTest import ContextMonitorTest
 from PlugAlgoTest import PlugAlgoTest
 from BoxInTest import BoxInTest
 from BoxOutTest import BoxOutTest
+from DirtyPropagationScopeTest import DirtyPropagationScopeTest
 
 if __name__ == "__main__":
 	import unittest

--- a/src/GafferBindings/DirtyPropagationScopeBinding.cpp
+++ b/src/GafferBindings/DirtyPropagationScopeBinding.cpp
@@ -1,0 +1,114 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "IECorePython/ScopedGILRelease.h"
+
+#include "Gaffer/DirtyPropagationScope.h"
+
+#include "GafferBindings/DirtyPropagationScopeBinding.h"
+
+using namespace boost::python;
+using namespace GafferBindings;
+using namespace Gaffer;
+
+namespace
+{
+
+class DirtyPropagationScopeWrapper : boost::noncopyable
+{
+
+	public :
+
+		DirtyPropagationScopeWrapper()
+			:	m_scope( NULL )
+		{
+		}
+
+		~DirtyPropagationScopeWrapper()
+		{
+			reset();
+		}
+
+		void enter()
+		{
+			reset();
+			m_scope = new DirtyPropagationScope();
+		}
+
+		void exit( object type, object value, object traceback )
+		{
+			reset();
+		}
+
+	private :
+
+		void reset()
+		{
+			if( !m_scope )
+			{
+				return;
+			}
+
+			// The destructor for the scope may trigger a dirty
+			// propagation, and observers of plugDirtiedSignal() may
+			// well invoke a compute. We need to release the GIL so that
+			// if that compute is multithreaded, those threads can acquire
+			// the GIL for python based nodes and expressions.
+			IECorePython::ScopedGILRelease gilRelease;
+			delete m_scope;
+			m_scope = NULL;
+		}
+
+		DirtyPropagationScope *m_scope;
+
+};
+
+} // namespace
+
+namespace GafferBindings
+{
+
+void bindDirtyPropagationScope()
+{
+	class_<DirtyPropagationScopeWrapper, boost::noncopyable>( "DirtyPropagationScope" )
+		.def( "__enter__", &DirtyPropagationScopeWrapper::enter )
+		.def( "__exit__", &DirtyPropagationScopeWrapper::exit )
+	;
+}
+
+} // namespace GafferBindings

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -55,6 +55,7 @@
 #include "GafferBindings/ScriptNodeBinding.h"
 #include "GafferBindings/ApplicationRootBinding.h"
 #include "GafferBindings/SetBinding.h"
+#include "GafferBindings/DirtyPropagationScopeBinding.h"
 #include "GafferBindings/UndoScopeBinding.h"
 #include "GafferBindings/CompoundPlugBinding.h"
 #include "GafferBindings/CompoundNumericPlugBinding.h"
@@ -167,6 +168,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindScriptNode();
 	bindApplicationRoot();
 	bindSet();
+	bindDirtyPropagationScope();
 	bindUndoScope();
 	bindCompoundPlug();
 	bindCompoundNumericPlug();


### PR DESCRIPTION
I used this briefly on a branch where I was optimising Catalogue performance, but no longer need it there. Making a separate PR for it since the Catalogue PR is gonna be fairly large anyway.