### PR TITLE
Catalogue optimisations

### DIFF
--- a/include/GafferImage/Catalogue.h
+++ b/include/GafferImage/Catalogue.h
@@ -114,7 +114,8 @@ class Catalogue : public ImageNode
 		const ImageSwitch *imageSwitch() const;
 
 		IE_CORE_FORWARDDECLARE( InternalImage );
-		InternalImage *imageNode( const Image *image ) const;
+		static InternalImage *imageNode( Image *image );
+		static const InternalImage *imageNode( const Image *image );
 
 		void imageAdded( GraphComponent *graphComponent );
 		void imageRemoved( GraphComponent *graphComponent );

--- a/include/GafferImage/Catalogue.h
+++ b/include/GafferImage/Catalogue.h
@@ -75,6 +75,12 @@ class Catalogue : public ImageNode
 				Gaffer::StringPlug *descriptionPlug();
 				const Gaffer::StringPlug *descriptionPlug() const;
 
+				/// Primarily used to take a snapshot of a live render.
+				/// This image must have have been added to a Catalogue
+				/// before calling. The snapshot will be saved to disk
+				/// asynchronously.
+				void copyFrom( const Image *other );
+
 				static Ptr load( const std::string &fileName );
 				void save( const std::string &fileName ) const;
 

--- a/include/GafferImage/Catalogue.h
+++ b/include/GafferImage/Catalogue.h
@@ -108,16 +108,6 @@ class Catalogue : public ImageNode
 		std::string generateFileName( const Image *image ) const;
 		std::string generateFileName( const ImagePlug *image ) const;
 
-	protected :
-
-		// In an ideal world, the Catalogue would connect these to the relevant
-		// signals directly, but unfortunately the signals are not emitted on the
-		// UI thread where it is permissible to modify the internal graph. We
-		// therefore rely on CatalogueUI.py to connect to the signals and then
-		// call these "slots" from the UI thread.
-		static void driverCreated( IECore::DisplayDriver *driver, const IECore::CompoundData *parameters );
-		static void imageReceived( Gaffer::Plug *plug );
-
 	private :
 
 		ImageSwitch *imageSwitch();
@@ -128,6 +118,9 @@ class Catalogue : public ImageNode
 
 		void imageAdded( GraphComponent *graphComponent );
 		void imageRemoved( GraphComponent *graphComponent );
+
+		void driverCreated( IECore::DisplayDriver *driver, const IECore::CompoundData *parameters );
+		void imageReceived( Gaffer::Plug *plug );
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferImage/Display.h
+++ b/include/GafferImage/Display.h
@@ -84,6 +84,12 @@ class Display : public ImageNode
 
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 
+		/// Used to trigger UI updates when image data is received
+		/// via a driver on a background thread. Exposed publicly
+		/// for the use of the Catalogue node.
+		typedef boost::function<void ()> UIThreadFunction;
+		static void executeOnUIThread( UIThreadFunction function );
+
 	protected :
 
 		virtual void hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
@@ -101,6 +107,11 @@ class Display : public ImageNode
 		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
 
+		// Signal used to request the execution of a function on the UI thread.
+		// We service these requests in DisplayUI.py.
+		typedef boost::signal<void ( UIThreadFunction )> ExecuteOnUIThreadSignal;
+		static ExecuteOnUIThreadSignal &executeOnUIThreadSignal();
+
 	private :
 
 		IECore::DisplayDriverServerPtr m_server;
@@ -113,8 +124,10 @@ class Display : public ImageNode
 		void setupServer();
 		void driverCreated( IECore::DisplayDriver *driver );
 		void setupDriver( GafferDisplayDriverPtr driver );
-		void dataReceived( GafferDisplayDriver *driver, const Imath::Box2i &bound );
-		void imageReceived( GafferDisplayDriver *driver );
+		void dataReceived();
+		void imageReceived();
+		static void dataReceivedUI();
+		static void imageReceivedUI( Ptr display );
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferImage/Display.h
+++ b/include/GafferImage/Display.h
@@ -68,6 +68,8 @@ class Display : public ImageNode
 		/// Sets the driver used to provide the
 		/// image to this node.
 		void setDriver( IECore::DisplayDriverPtr driver );
+		/// \todo Default copy to false and remove method above
+		void setDriver( IECore::DisplayDriverPtr driver, bool copy );
 		IECore::DisplayDriver *getDriver();
 		const IECore::DisplayDriver *getDriver() const;
 

--- a/include/GafferImage/Display.h
+++ b/include/GafferImage/Display.h
@@ -49,6 +49,9 @@ namespace GafferImage
 
 IE_CORE_FORWARDDECLARE( GafferDisplayDriver )
 
+/// \todo Remove portPlug() and the internal server
+/// \todo Pass GafferDisplayDriver rather than IECore::DisplayDriver
+/// in setDriver/getDriver/driverCreatedSignal.
 class Display : public ImageNode
 {
 
@@ -71,9 +74,6 @@ class Display : public ImageNode
 		/// Emitted when a new driver has been created. This can
 		/// then be passed to `Display::setDriver()` to populate
 		/// a Display with an incoming image.
-		/// \todo This should really go on IECore::DisplayDriverServer,
-		/// but we need to move all Gaffer's signal binding logic
-		/// to IECore as well so we can bind it.
 		typedef boost::signal<void ( IECore::DisplayDriver *driver, const IECore::CompoundData *parameters )> DriverCreatedSignal;
 		static DriverCreatedSignal &driverCreatedSignal();
 

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -128,7 +128,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		# Emulate the connection the UI makes, so the Display knows someone is listening and
 		# it needs to actually make servers.
-		dataReceivedConnection = GafferImage.Display.dataReceivedSignal().connect( lambda plug : None )
+		executeOnUIThreadConnection = GafferImage.Display.executeOnUIThreadSignal().connect( lambda f : f() )
 
 		script["display"] = GafferImage.Display()
 		script["display"]["port"].setValue( 2500 )

--- a/python/GafferImageTest/CatalogueTest.py
+++ b/python/GafferImageTest/CatalogueTest.py
@@ -49,16 +49,12 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
 		GafferImageTest.ImageTestCase.setUp( self )
 
-		# Emulate the UI by making the same connections it will
+		# Emulate the UI
 		self.__executeOnUIThreadConnection = GafferImage.Display.executeOnUIThreadSignal().connect( lambda f : f() )
-		self.__driverCreatedConnection = GafferImage.Display.driverCreatedSignal().connect( GafferImage.Catalogue.driverCreated )
-		self.__imageReceivedConnection = GafferImage.Display.imageReceivedSignal().connect( GafferImage.Catalogue.imageReceived )
 
 	def tearDown( self ) :
 
 		self.__executeOnUIThreadConnection.disconnect()
-		self.__driverCreatedConnection.disconnect()
-		self.__imageReceivedConnection.disconnect()
 
 	def testImages( self ) :
 

--- a/python/GafferImageTest/CatalogueTest.py
+++ b/python/GafferImageTest/CatalogueTest.py
@@ -50,13 +50,15 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		GafferImageTest.ImageTestCase.setUp( self )
 
 		# Emulate the UI by making the same connections it will
+		self.__executeOnUIThreadConnection = GafferImage.Display.executeOnUIThreadSignal().connect( lambda f : f() )
 		self.__driverCreatedConnection = GafferImage.Display.driverCreatedSignal().connect( GafferImage.Catalogue.driverCreated )
 		self.__imageReceivedConnection = GafferImage.Display.imageReceivedSignal().connect( GafferImage.Catalogue.imageReceived )
 
 	def tearDown( self ) :
 
-		self.__driverCreatedConnection = None
-		self.__imageReceivedConnection = None
+		self.__executeOnUIThreadConnection.disconnect()
+		self.__driverCreatedConnection.disconnect()
+		self.__imageReceivedConnection.disconnect()
 
 	def testImages( self ) :
 

--- a/python/GafferImageTest/CatalogueTest.py
+++ b/python/GafferImageTest/CatalogueTest.py
@@ -523,5 +523,34 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 			)
 		)
 
+		# This applies to copies too
+
+		c["images"].addChild( GafferImage.Catalogue.Image( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		self.assertEqual( len( c["images"] ), 2 )
+		c["images"][1].copyFrom( c["images"][0] )
+
+		c["imageIndex"].setValue( 1 )
+		self.assertEqual(
+			display["out"].channelDataHash( "R", IECore.V2i( 0 ) ),
+			c["out"].channelDataHash( "R", IECore.V2i( 0 ) )
+		)
+		self.assertTrue(
+			display["out"].channelData( "R", IECore.V2i( 0 ), _copy = False ).isSame(
+				c["out"].channelData( "R", IECore.V2i( 0 ), _copy = False )
+			)
+		)
+
+	def testCopyFrom( self ) :
+
+		c = GafferImage.Catalogue()
+		c["images"].addChild( c.Image.load( "${GAFFER_ROOT}/python/GafferImageTest/images/checker.exr" ) )
+		c["images"][0]["description"].setValue( "test" )
+
+		c["images"].addChild( c.Image( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		c["images"][1].copyFrom( c["images"][0] )
+
+		self.assertEqual( c["images"][1]["description"].getValue(), c["images"][0]["description"].getValue() )
+		self.assertEqual( c["images"][1]["fileName"].getValue(), c["images"][0]["fileName"].getValue() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/DisplayTest.py
+++ b/python/GafferImageTest/DisplayTest.py
@@ -254,9 +254,6 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 
 		self.__sendBucket( driver, cortexWindow, IECore.FloatVectorData( [ 0.5 ] * gafferWindow.size().x * gafferWindow.size().y ) )
 
-		driver.imageClose()
-		semaphore.acquire()
-
 		self.assertEqual( display["out"]["format"].getValue().getDisplayWindow(), gafferWindow )
 		self.assertEqual( display["out"]["dataWindow"].getValue(), gafferWindow )
 		self.assertEqual( display["out"]["channelNames"].getValue(), IECore.StringVectorData( [ "Y" ] ) )
@@ -264,6 +261,26 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 			display["out"].channelData( "Y", IECore.V2i( 0 ) ),
 			IECore.FloatVectorData( [ 0.5 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
 		)
+
+		display2 = GafferImage.Display()
+		display2.setDriver( display.getDriver(), copy = True )
+
+		self.assertImagesEqual( display["out"], display2["out"] )
+
+		self.__sendBucket( driver, cortexWindow, IECore.FloatVectorData( [ 1 ] * gafferWindow.size().x * gafferWindow.size().y ) )
+
+		self.assertEqual(
+			display["out"].channelData( "Y", IECore.V2i( 0 ) ),
+			IECore.FloatVectorData( [ 1 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
+		)
+
+		self.assertEqual(
+			display2["out"].channelData( "Y", IECore.V2i( 0 ) ),
+			IECore.FloatVectorData( [ 0.5 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
+		)
+
+		driver.imageClose()
+		semaphore.acquire()
 
 	def __testTransferImage( self, fileName ) :
 

--- a/python/GafferImageTest/TextTest.py
+++ b/python/GafferImageTest/TextTest.py
@@ -167,5 +167,19 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 		self.assertImageHashesEqual( t1["out"], t2["out"] )
 		self.assertImagesEqual( t1["out"], t2["out"] )
 
+	def testDisable( self ) :
+
+		c = GafferImage.Constant()
+		c["color"].setValue( IECore.Color4f( 1, 0, 0, 0.5, ) )
+
+		t = GafferImage.Text()
+		t["in"].setInput( c["out"] )
+		t["enabled"].setValue( False )
+
+		self.assertImagesEqual( c["out"], t["out"] )
+
+		t["shadow"].setValue( True )
+		self.assertImagesEqual( c["out"], t["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -470,30 +470,3 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 		return True
 
 GafferUI.Pointer.registerPointer( "plus", GafferUI.Pointer( "plus.png" ) )
-
-##########################################################################
-# Display server management. This would all be in Catalogue.cpp if it
-# were not for the need to operate on the UI thread.
-##########################################################################
-
-def __driverCreated( driver, parameters ) :
-
-	# The driverCreatedSignal() is emitted on the server thread,
-	# but we can only make node graph edits from the UI thread,
-	# so we must use `executeOnUIThread()`.
-	GafferUI.EventLoop.executeOnUIThread( functools.partial( __driverCreatedUI, driver, parameters ) )
-
-def __driverCreatedUI( driver, parameters ) :
-
-	GafferImage.Catalogue.driverCreated( driver, parameters )
-
-def __imageReceived( plug ) :
-
-	GafferUI.EventLoop.executeOnUIThread( functools.partial( __imageReceivedUI, plug ) )
-
-def __imageReceivedUI( plug ) :
-
-	GafferImage.Catalogue.imageReceived( plug )
-
-GafferImage.Display.driverCreatedSignal().connect( functools.partial( __driverCreated ), scoped = False )
-GafferImage.Display.imageReceivedSignal().connect( functools.partial( __imageReceived ), scoped = False )

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -398,22 +398,11 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 		index = self.__indexFromSelection()
 		image = self.__images()[index]
 
-		with self.getContext() :
-			fileName = image["fileName"].getValue()
-			directory = self.__catalogue()["directory"].getValue()
-			directory = self.getContext().substitute( directory )
-
-		if not fileName :
-			# It's a render
-			fileName = self.__catalogue().generateFileName( image )
-			image.save( fileName )
-
-		duplicateImage = GafferImage.Catalogue.Image.load( fileName )
-		duplicateImage.setName( image.getName() + "Copy" )
-
+		imageCopy = GafferImage.Catalogue.Image( image.getName() + "Copy",  flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
-			self.__images().addChild( duplicateImage )
+			self.__images().addChild( imageCopy )
 			self.getPlug().setValue( len( self.__images() ) - 1 )
+			imageCopy.copyFrom( image )
 
 	def __dropImage( self, eventData ) :
 

--- a/python/GafferImageUI/__init__.py
+++ b/python/GafferImageUI/__init__.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+__import__( "GafferUI" )
+
 from _GafferImageUI import *
 
 import DisplayUI

--- a/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
+++ b/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
@@ -680,17 +680,11 @@ class InteractiveRenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 
 		s["d"]["in"].setInput( s["g"]["out"] )
 
+		# Emulate the connection the UI makes, so the Display knows someone is listening and
+		# it needs to actually make servers.
+		executeOnUIThreadConnection = GafferImage.Display.executeOnUIThreadSignal().connect( lambda f : f() )
+
 		s["m"] = GafferImage.Display()
-
-		# connect a python function to the Display node image and data
-		# received signals. this emulates what the UI does.
-		def __displayCallback( plug ) :
-			pass
-
-		c = (
-			s["m"].imageReceivedSignal().connect( __displayCallback ),
-			s["m"].dataReceivedSignal().connect( __displayCallback ),
-		)
 
 		s["o"] = GafferScene.StandardOptions()
 		s["o"]["in"].setInput( s["d"]["out"] )

--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -386,16 +386,8 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		)
 		s["outputs"]["in"].setInput( s["sphere"]["out"] )
 
-		s["display"] = GafferImage.Display()
-		def __displayCallback( plug ) :
-			pass
-
-		# connect a python function to the Display node image and data
-		# received signals. this emulates what the UI does.
-		c = (
-			s["display"].imageReceivedSignal().connect( __displayCallback ),
-			s["display"].dataReceivedSignal().connect( __displayCallback ),
-		)
+		# Emulate the connection the UI makes
+		executeOnUIThreadConnection = GafferImage.Display.executeOnUIThreadSignal().connect( lambda f : f() )
 
 		s["render"] = GafferRenderMan.RenderManRender()
 		s["render"]["ribFileName"].setValue( self.temporaryDirectory() + "/test.rib" )
@@ -405,8 +397,8 @@ class RenderManRenderTest( GafferRenderManTest.RenderManTestCase ) :
 		s.save()
 
 		# dispatch the render on the foreground thread. if we don't manage
-		# the GIL appropriately, we'll get a deadlock when the Display signals
-		# above try to enter python on the background thread.
+		# the GIL appropriately, we'll get a deadlock when the Display signal
+		# above tries to enter python on the background thread.
 		dispatcher = GafferDispatch.LocalDispatcher()
 		dispatcher["jobsDirectory"].setValue( self.temporaryDirectory() + "/testJobDirectory" )
 		dispatcher["framesMode"].setValue( GafferDispatch.Dispatcher.FramesMode.CurrentFrame )

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -107,7 +107,17 @@ class Catalogue::InternalImage : public ImageNode
 			return getChild<StringPlug>( g_firstChildIndex );
 		}
 
+		const StringPlug *fileNamePlug() const
+		{
+			return getChild<StringPlug>( g_firstChildIndex );
+		}
+
 		StringPlug *descriptionPlug()
+		{
+			return getChild<StringPlug>( g_firstChildIndex + 1 );
+		}
+
+		const StringPlug *descriptionPlug() const
 		{
 			return getChild<StringPlug>( g_firstChildIndex + 1 );
 		}
@@ -230,7 +240,17 @@ class Catalogue::InternalImage : public ImageNode
 			return getChild<ImageReader>( g_firstChildIndex + 2 );
 		}
 
+		const ImageReader *imageReader() const
+		{
+			return getChild<ImageReader>( g_firstChildIndex + 2 );
+		}
+
 		CopyChannels *copyChannels()
+		{
+			return getChild<CopyChannels>( g_firstChildIndex + 3 );
+		}
+
+		const CopyChannels *copyChannels() const
 		{
 			return getChild<CopyChannels>( g_firstChildIndex + 3 );
 		}
@@ -240,14 +260,23 @@ class Catalogue::InternalImage : public ImageNode
 			return getChild<ImageSwitch>( g_firstChildIndex + 4 );
 		}
 
+		const ImageSwitch *imageSwitch() const
+		{
+			return getChild<ImageSwitch>( g_firstChildIndex + 4 );
+		}
+
 		ImageMetadata *imageMetadata()
+		{
+			return getChild<ImageMetadata>( g_firstChildIndex + 5 );
+		}
+
+		const ImageMetadata *imageMetadata() const
 		{
 			return getChild<ImageMetadata>( g_firstChildIndex + 5 );
 		}
 
 		int m_clientPID;
 		size_t m_numDriversClosed;
-
 		static size_t g_firstChildIndex;
 
 };

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -865,6 +865,15 @@ IECore::DisplayDriverServer *Catalogue::displayDriverServer()
 
 void Catalogue::driverCreated( IECore::DisplayDriver *driver, const IECore::CompoundData *parameters )
 {
+	// Check the image is destined for catalogues in general
+	if( const StringData *portNumberData = parameters->member<StringData>( "displayPort" ) )
+	{
+		if( boost::lexical_cast<int>( portNumberData->readable() ) != displayDriverServer()->portNumber() )
+		{
+			return;
+		}
+	}
+
 	// Check the image is destined for this catalogue
 	string catalogueName = "";
 	if( const StringData *catalogueNameData = parameters->member<StringData>( "catalogue:name" ) )
@@ -881,7 +890,6 @@ void Catalogue::driverCreated( IECore::DisplayDriver *driver, const IECore::Comp
 	{
 		return;
 	}
-
 
 	// Try to find an existing InternalImage from
 	// the same render, so we can just combine all

--- a/src/GafferImage/Display.cpp
+++ b/src/GafferImage/Display.cpp
@@ -47,6 +47,7 @@
 #include "IECore/BoxOps.h"
 
 #include "Gaffer/Context.h"
+#include "Gaffer/DirtyPropagationScope.h"
 
 #include "GafferImage/Display.h"
 #include "GafferImage/FormatPlug.h"
@@ -112,7 +113,10 @@ class GafferDisplayDriver : public IECore::DisplayDriver
 				m_gafferFormat.setPixelAspect( pixelAspect->readable() );
 			}
 
-			Display::driverCreatedSignal()( this, parameters.get() );
+			// This is a bit sketchy. By creating `Ptr( this )` we're adding a reference to ourselves from within
+			// our own constructor - if that reference is dropped before we return, we'll be double deleted. We rely
+			// on the fact that executeOnUIThreadl() will keep us alive long enough for this not to occur.
+			Display::executeOnUIThread( boost::bind( &GafferDisplayDriver::emitDriverCreated, Ptr( this ), m_parameters ) );
 		}
 
 		virtual ~GafferDisplayDriver()
@@ -235,6 +239,11 @@ class GafferDisplayDriver : public IECore::DisplayDriver
 
 		static const DisplayDriverDescription<GafferDisplayDriver> g_description;
 
+		static void emitDriverCreated( Ptr driver, IECore::ConstCompoundDataPtr parameters )
+		{
+			Display::driverCreatedSignal()( driver.get(), parameters.get() );
+		}
+
 		ConstFloatVectorDataPtr getTile( const V2i &tileOrigin, size_t channelIndex )
 		{
 			V2i tileIndex = tileOrigin / ImagePlug::tileSize();
@@ -313,10 +322,8 @@ Display::Display( const std::string &name )
 		)
 	);
 
-	// this plug is incremented when new data is received, triggering dirty signals
-	// and prompting reevaluation in the viewer. see GafferImageUI.DisplayUI for
-	// details of how it is set (we can't set it from dataReceived() because we're
-	// not on the ui thread at that point.
+	// This plug is incremented when new data is received, triggering dirty signals
+	// and prompting reevaluation in the viewer.
 	addChild(
 		new IntPlug(
 			"__updateCount",
@@ -524,9 +531,9 @@ void Display::plugSet( Gaffer::Plug *plug )
 
 void Display::setupServer()
 {
-	if( dataReceivedSignal().empty() )
+	if( executeOnUIThreadSignal().empty() )
 	{
-		// If the dataReceivedSignal is empty,
+		// If the executeOnUIThreadSignal is empty,
 		// it means that GafferImageUI hasn't
 		// been imported (see DisplayUI.py).
 		// If there's no UI then there's no point
@@ -572,29 +579,134 @@ void Display::setupDriver( GafferDisplayDriverPtr driver )
 {
 	if( m_driver )
 	{
-		m_driver->dataReceivedSignal().disconnect( boost::bind( &Display::dataReceived, this, _1, _2 ) );
-		m_driver->imageReceivedSignal().disconnect( boost::bind( &Display::imageReceived, this, _1 ) );
+		m_driver->dataReceivedSignal().disconnect( boost::bind( &Display::dataReceived, this) );
+		m_driver->imageReceivedSignal().disconnect( boost::bind( &Display::imageReceived, this ) );
 	}
 
 	m_driver = driver;
 	if( m_driver )
 	{
-		m_driver->dataReceivedSignal().connect( boost::bind( &Display::dataReceived, this, _1, _2 ) );
-		m_driver->imageReceivedSignal().connect( boost::bind( &Display::imageReceived, this, _1 ) );
+		m_driver->dataReceivedSignal().connect( boost::bind( &Display::dataReceived, this ) );
+		m_driver->imageReceivedSignal().connect( boost::bind( &Display::imageReceived, this ) );
 	}
 }
 
-void Display::dataReceived( GafferDisplayDriver *driver, const Imath::Box2i &bound )
+//////////////////////////////////////////////////////////////////////////
+// Signalling and update mechanism
+//////////////////////////////////////////////////////////////////////////
+
+namespace
 {
-	dataReceivedSignal()( outPlug() );
+
+typedef set<PlugPtr> PlugSet;
+typedef auto_ptr<PlugSet> PlugSetPtr;
+
+struct PendingUpdates
+{
+
+	tbb::spin_mutex mutex;
+	PlugSetPtr plugs;
+
+};
+
+PendingUpdates &pendingUpdates()
+{
+	static PendingUpdates *p = new PendingUpdates;
+	return *p;
 }
 
-void Display::imageReceived( GafferDisplayDriver *driver )
+};
+
+void Display::executeOnUIThread( UIThreadFunction function )
 {
-	// The nefarious Catalogue deletes Display nodes when renders
-	// are completed. We keep a reference to ourselves while emitting
-	// so that any slots connected after the Catalogue's won't be
-	// passed an already-deleted plug.
-	DisplayPtr owner( this );
-	imageReceivedSignal()( outPlug() );
+	executeOnUIThreadSignal()( function );
+}
+
+// Called on a background thread when data is received on the driver.
+// We need to increment `updateCountPlug()`, but all graph edits must
+// be performed on the UI thread, so we can't do it directly.
+void Display::dataReceived()
+{
+	bool scheduleUpdate = false;
+	{
+		// To minimise overhead we perform updates in batches by storing
+		// a set of plugs which are pending update. If we're the creator
+		// of a new batch then we are responsible for scheduling a call
+		// to `dataReceivedUI()` to process the batch. Otherwise we just
+		// add to the current batch.
+		PendingUpdates &pending = pendingUpdates();
+		tbb::spin_mutex::scoped_lock lock( pending.mutex );
+		if( !pending.plugs.get() )
+		{
+			scheduleUpdate = true;
+			pending.plugs.reset( new PlugSet );
+		}
+		pending.plugs->insert( outPlug() );
+	}
+	if( scheduleUpdate )
+	{
+		executeOnUIThread( &Display::dataReceivedUI );
+	}
+}
+
+// Called on the UI thread after being scheduled by `dataReceived()`.
+void Display::dataReceivedUI()
+{
+	// Get the batch of plugs to trigger updates for. We want to hold
+	// g_plugsPendingUpdateMutex for the shortest duration possible,
+	// because it causes contention between the background rendering
+	// thread and the UI thread, and can significantly affect performance.
+	// We do this by "stealing" the current batch, so the background
+	// thread will create a new batch and we are safe to iterate our
+	// batch without holding the lock.
+	PlugSetPtr batch;
+	{
+		PendingUpdates &pending = pendingUpdates();
+		tbb::spin_mutex::scoped_lock lock( pending.mutex );
+		batch = pending.plugs; // Resets pending.plugs to NULL
+	}
+
+	// Now increment the update count for the Display nodes
+	// that have received data. This gives them a new hash
+	// and also propagates dirtiness to the output image.
+	{
+		// Use a DirtyPropgationScope to batch up dirty propagation
+		// for improved performance.
+		DirtyPropagationScope dirtyPropagationScope;
+		for( set<PlugPtr>::const_iterator it = batch->begin(), eIt = batch->end(); it != eIt; ++it )
+		{
+			PlugPtr plug = *it;
+			// Because `dataReceivedUI()` is deferred to the UI thread,
+			// it's possible that the node has actually been deleted by
+			// the time we're called, so we must check.
+			if( Display *display = runTimeCast<Display>( plug->node() ) )
+			{
+				display->updateCountPlug()->setValue( display->updateCountPlug()->getValue() + 1 );
+			}
+		}
+	}
+
+	// Now that dirty propagation is complete, we can emit dataReceivedSignal()
+	// for any observers that wish to update that way.
+	/// \todo Do we even need this now? Could the tests just use plugDirtiedSignal()?
+	for( set<PlugPtr>::const_iterator it = batch->begin(), eIt = batch->end(); it != eIt; ++it )
+	{
+		dataReceivedSignal()( it->get() );
+	}
+}
+
+void Display::imageReceived()
+{
+	executeOnUIThread( boost::bind( &Display::imageReceivedUI, DisplayPtr( this ) ) );
+}
+
+void Display::imageReceivedUI( Ptr display )
+{
+	imageReceivedSignal()( display->outPlug() );
+}
+
+Display::ExecuteOnUIThreadSignal &Display::executeOnUIThreadSignal()
+{
+	static ExecuteOnUIThreadSignal s;
+	return s;
 }

--- a/src/GafferImage/Shape.cpp
+++ b/src/GafferImage/Shape.cpp
@@ -95,12 +95,14 @@ Shape::Shape( const std::string &name )
 	shadowSwitch->inPlugs()->getChild<ImagePlug>( 0 )->setInput( inPlug() );
 	shadowSwitch->inPlugs()->getChild<ImagePlug>( 1 )->setInput( shadowMerge->outPlug() );
 	shadowSwitch->indexPlug()->setInput( shadowPlug() );
+	shadowSwitch->enabledPlug()->setInput( enabledPlug() );
 
 	MergePtr merge = new Merge( "__merge" );
 	addChild( merge );
 
 	merge->inPlugs()->getChild<ImagePlug>( 0 )->setInput( shadowSwitch->outPlug() );
 	merge->inPlugs()->getChild<ImagePlug>( 1 )->setInput( shapePlug() );
+	merge->enabledPlug()->setInput( enabledPlug() );
 	merge->operationPlug()->setValue( Merge::Over );
 
 	outPlug()->setInput( merge->outPlug() );

--- a/src/GafferImageBindings/CatalogueBinding.cpp
+++ b/src/GafferImageBindings/CatalogueBinding.cpp
@@ -129,23 +129,6 @@ std::string generateFileName2( Catalogue &catalogue, const ImagePlug *image )
 	return catalogue.generateFileName( image );
 }
 
-struct CatalogueWrapper : public Catalogue
-{
-
-	static void driverCreated( IECore::DisplayDriver *driver, const IECore::CompoundData *parameters )
-	{
-		IECorePython::ScopedGILRelease gilRelease;
-		Catalogue::driverCreated( driver, parameters );
-	}
-
-	static void imageReceived( Gaffer::Plug *plug )
-	{
-		IECorePython::ScopedGILRelease gilRelease;
-		Catalogue::imageReceived( plug );
-	}
-
-};
-
 } // namespace
 
 namespace GafferImageBindings
@@ -159,10 +142,6 @@ void bindCatalogue()
 		.def( "generateFileName", &generateFileName2 )
 		.def( "displayDriverServer", &Catalogue::displayDriverServer, return_value_policy<IECorePython::CastToIntrusivePtr>() )
 		.staticmethod( "displayDriverServer" )
-		.def( "driverCreated", &CatalogueWrapper::driverCreated )
-		.staticmethod( "driverCreated" )
-		.def( "imageReceived", &CatalogueWrapper::imageReceived )
-		.staticmethod( "imageReceived" )
 	;
 
 	GafferBindings::PlugClass<Catalogue::Image>()

--- a/src/GafferImageBindings/CatalogueBinding.cpp
+++ b/src/GafferImageBindings/CatalogueBinding.cpp
@@ -111,6 +111,12 @@ class CatalogueSerialiser : public NodeSerialiser
 
 };
 
+void copyFrom( Catalogue::Image &image, const Catalogue::Image *other )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	image.copyFrom( other );
+}
+
 void save( Catalogue::Image &image, const std::string &fileName )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -155,6 +161,7 @@ void bindCatalogue()
 			)
 		)
 		.def( "__repr__", repr )
+		.def( "copyFrom", &copyFrom )
 		.def( "load", Catalogue::Image::load )
 		.def( "save", &save )
 		.staticmethod( "load" )

--- a/src/GafferImageBindings/DisplayBinding.cpp
+++ b/src/GafferImageBindings/DisplayBinding.cpp
@@ -122,7 +122,7 @@ void GafferImageBindings::bindDisplay()
 {
 
 	scope s = GafferBindings::DependencyNodeClass<Display>()
-		.def( "setDriver", &Display::setDriver )
+		.def( "setDriver", (void (Display::*)( IECore::DisplayDriverPtr, bool ))&Display::setDriver, ( arg( "driver" ), arg( "copy" ) = false ) )
 		.def( "getDriver", (IECore::DisplayDriver *(Display::*)())&Display::getDriver, return_value_policy<CastToIntrusivePtr>() )
 		.def( "driverCreatedSignal", &Display::driverCreatedSignal, return_value_policy<reference_existing_object>() ).staticmethod( "driverCreatedSignal" )
 		.def( "dataReceivedSignal", &Display::dataReceivedSignal, return_value_policy<reference_existing_object>() ).staticmethod( "dataReceivedSignal" )


### PR DESCRIPTION
When I wrote the catalogue, I tested mostly by rendering just the beauty AOV. Big mistake. Naturally, as soon as it hit production, folks started hitting it with many, many, many, many more AOVs in a single render. This exposed performance issues - snapshotting a render to disk took so long it appeared that Gaffer had frozen, and the overhead of dealing with viewer updates slowed down IPR renders significantly. This overhead was at its worst when the render was lightweight, because then the overhead of updates was higher than the work done by the renderer itself.

In conjunction with https://github.com/ImageEngine/cortex/pull/574, and testing with a fast 20+ AOV 2K render, this PR does the following :

- Speeds up IPR renders by a factor of 3x
- Enables an additional 2x speedup for IPR renders if outputs are configured to go direct to the Display node and not via a DisplayDriverServer. The server is needed for local renders done in a separate process, but is not needed for in-process IPR renders. I haven't adjusted Gaffer's standard output configs to take advantage of this because those are intended to work for both local and IPR renders, but it's trivial to enable for anyone with more control over their pipeline
- Speeds up viewer framerate 3-4x, and then limits it back to 30fps to avoid unnecessary overhead
- Uses a background thread to do all snapshotting of renders and saving to disk, so the UI never stalls
- Adds a naughty cheat to avoid having to reload snapshotted renders from disk as long as the buckets from the display driver persist in Gaffer's cache

@est77, I remember at one point you were limiting the rate at which Appleseed sent buckets to Gaffer because it was overwhelming the UI - if you have time you might want to revisit that as I think we're in much better shape to deal with it now.

I've deliberately avoided any breaking changes here so it can be included in the 0.33 series if desired, and added a few todo items for cleanup we can do once we hit 0.34.

Profiling shows that there's probably more performance to be squeezed out in `GafferDisplayDriver::imageData()`, but I think this represents a big enough leap to roll out on its own first.