### PR TITLE
Wrapper : Set PATH/PYTHONPATH/*_LIBRARY_PATH from ARNOLD_ROOT

### DIFF
--- a/bin/gaffer
+++ b/bin/gaffer
@@ -218,6 +218,19 @@ fi
 
 prependToPath "$GAFFER_ROOT/arnold/plugins" ARNOLD_PLUGIN_PATH
 
+if [[ $ARNOLD_ROOT ]] ; then
+
+	if [[ `uname` = "Linux" ]] ; then
+		appendToPath "$ARNOLD_ROOT/bin" LD_LIBRARY_PATH
+	else
+		appendToPath "$ARNOLD_ROOT/bin" DYLD_LIBRARY_PATH
+	fi
+
+	appendToPath "$ARNOLD_ROOT/bin" PATH
+	appendToPath "$ARNOLD_ROOT/python" PYTHONPATH
+
+fi
+
 # Run gaffer itself
 ##########################################################################
 

--- a/doc/source/Installation/index.md
+++ b/doc/source/Installation/index.md
@@ -41,9 +41,7 @@ Gaffer is shipped with the open source Appleseed renderer, ready to use with no 
 
 ### Arnold
 
-- Ensure `<ARNOLD_INSTALL_PATH>/bin` is in your `$PATH`.
-- Add `<ARNOLD_INSTALL_PATH>/bin` to the `$LD_LIBRARY_PATH` environment variable.
-- Add `<ARNOLD_INSTALL_PATH>/python` to the `$PYTHONPATH` environment variable
+- Ensure that `$ARNOLD_ROOT` points to the location where Arnold is installed.
 
 ### Tractor
 


### PR DESCRIPTION
On OSX with SIP enabled, bash does not inherit the DYLD_LIBRARY_PATH, so we must use an alternative approach. This way seems nicer anyway, since it's simpler for the user, and is the same on OSX and Linux.

Also update the installation docs to match.