### PR TITLE
Wrapper : Default to lldb for debugging on OSX

### DIFF
--- a/bin/gaffer
+++ b/bin/gaffer
@@ -223,10 +223,14 @@ prependToPath "$GAFFER_ROOT/arnold/plugins" ARNOLD_PLUGIN_PATH
 
 if [[ -n $GAFFER_DEBUG ]] ; then
 	if [[ -z $GAFFER_DEBUGGER ]] ; then
-		export GAFFER_DEBUGGER="gdb --args"
+		if [[ `uname` = "Linux" ]] ; then
+			export GAFFER_DEBUGGER="gdb --args"
+		else
+			export GAFFER_DEBUGGER="lldb -- "
+		fi
 	fi
-
-	exec $GAFFER_DEBUGGER python "$GAFFER_ROOT/bin/gaffer.py" "$@"
+	# Using `which` because lldb doesn't seem to respect $PATH
+	exec $GAFFER_DEBUGGER `which python` "$GAFFER_ROOT/bin/gaffer.py" "$@"
 else
 	exec python "$GAFFER_ROOT/bin/gaffer.py" "$@"
 fi


### PR DESCRIPTION
This has replaced gdb as the standard debugger.