### PR TITLE
OSLObject FaceVarying and Uniform interpolation 

### DIFF
--- a/include/GafferOSL/OSLObject.h
+++ b/include/GafferOSL/OSLObject.h
@@ -39,6 +39,7 @@
 
 #include "GafferScene/SceneElementProcessor.h"
 #include "GafferScene/ShaderPlug.h"
+#include "Gaffer/NumericPlug.h"
 
 #include "GafferOSL/TypeIds.h"
 
@@ -57,6 +58,9 @@ class OSLObject : public GafferScene::SceneElementProcessor
 
 		GafferScene::ShaderPlug *shaderPlug();
 		const GafferScene::ShaderPlug *shaderPlug() const;
+
+		Gaffer::IntPlug *interpolationPlug();
+		const Gaffer::IntPlug *interpolationPlug() const;
 
 		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
 

--- a/include/GafferOSL/OSLObject.h
+++ b/include/GafferOSL/OSLObject.h
@@ -40,6 +40,7 @@
 #include "GafferScene/SceneElementProcessor.h"
 #include "GafferScene/ShaderPlug.h"
 #include "Gaffer/NumericPlug.h"
+#include "Gaffer/StringPlug.h"
 
 #include "GafferOSL/TypeIds.h"
 
@@ -76,7 +77,16 @@ class OSLObject : public GafferScene::SceneElementProcessor
 		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
 
+		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+
 	private :
+
+		GafferScene::ScenePlug *resampledInPlug();
+		const GafferScene::ScenePlug *resampledInPlug() const;
+
+		Gaffer::StringPlug *resampledNamesPlug();
+		const Gaffer::StringPlug *resampledNamesPlug() const;
 
 		static size_t g_firstPlugIndex;
 

--- a/python/GafferOSLUI/OSLObjectUI.py
+++ b/python/GafferOSLUI/OSLObjectUI.py
@@ -75,8 +75,9 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Interpolation mode in which to process the object. 
-			All primitive variables are resampled to match the selected interpolation. 
+			The interpolation type of the primitive variables created by this node.
+			For instance, Uniform interpolation means that the shader is run once per face on a mesh, allowing it to output primitive variables with a value per face. 
+			All non-constant input primitive variables are resampled to match the selected interpolation so that they can be accessed from the shader.
 			""",
 
 			"preset:Uniform", IECore.PrimitiveVariable.Interpolation.Uniform,
@@ -84,6 +85,7 @@ Gaffer.Metadata.registerNode(
 			"preset:FaceVarying", IECore.PrimitiveVariable.Interpolation.FaceVarying,
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
 
 		]
 

--- a/python/GafferOSLUI/OSLObjectUI.py
+++ b/python/GafferOSLUI/OSLObjectUI.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import IECore
 import Gaffer
 import GafferUI
 
@@ -70,7 +71,23 @@ Gaffer.Metadata.registerNode(
 			"noduleLayout:section", "left",
 
 		],
+		"interpolation" : [
+
+			"description",
+			"""
+			Interpolation mode in which to process the object. 
+			All primitive variables are resampled to match the selected interpolation. 
+			""",
+
+			"preset:Uniform", IECore.PrimitiveVariable.Interpolation.Uniform,
+			"preset:Vertex", IECore.PrimitiveVariable.Interpolation.Vertex,
+			"preset:FaceVarying", IECore.PrimitiveVariable.Interpolation.FaceVarying,
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+		]
 
 	}
 
 )
+

--- a/src/GafferOSL/OSLObject.cpp
+++ b/src/GafferOSL/OSLObject.cpp
@@ -36,7 +36,7 @@
 
 #include "IECore/Primitive.h"
 
-#include "Gaffer/StringPlug.h"
+#include "GafferScene/ResamplePrimitiveVariables.h"
 
 #include "GafferOSL/OSLShader.h"
 #include "GafferOSL/OSLObject.h"
@@ -52,12 +52,44 @@ IE_CORE_DEFINERUNTIMETYPED( OSLObject );
 
 size_t OSLObject::g_firstPlugIndex;
 
+namespace
+{
+
+CompoundDataPtr prepareShadingPoints( const Primitive *primitive )
+{
+	CompoundDataPtr shadingPoints = new CompoundData;
+	for( PrimitiveVariableMap::const_iterator it = primitive->variables.begin(), eIt = primitive->variables.end(); it != eIt; ++it )
+	{
+		// cast is ok - we're only using it to be able to reference the data from the shadingPoints,
+		// but nothing will modify the data itself.
+		shadingPoints->writable()[it->first] = boost::const_pointer_cast<Data>( it->second.data );
+	}
+
+	return shadingPoints;
+}
+
+};
+
 OSLObject::OSLObject( const std::string &name )
 	:	SceneElementProcessor( name, Filter::NoMatch )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new ShaderPlug( "shader" ) );
-	addChild( new IntPlug( "interpolation", Plug::In, PrimitiveVariable::Invalid, PrimitiveVariable::FaceVarying ) );
+	addChild( new IntPlug( "interpolation", Plug::In, PrimitiveVariable::Vertex, PrimitiveVariable::Invalid, PrimitiveVariable::FaceVarying ) );
+	addChild( new ScenePlug( "__resampledIn", Plug::In, Plug::Default & ~Plug::Serialisable ) );
+
+	addChild( new StringPlug( "__resampleNames", Plug::Out ) );
+
+	GafferScene::ResamplePrimitiveVariablesPtr resample = new ResamplePrimitiveVariables( "__resample" );
+	addChild( resample );
+
+	//todo only resample variables which we've read from in the OSL shader
+	resample->namesPlug()->setInput( resampledNamesPlug() );
+	resample->inPlug()->setInput( inPlug() );
+	resample->interpolationPlug()->setInput( interpolationPlug() );
+	resample->filterPlug()->setInput( filterPlug() );
+
+	resampledInPlug()->setInput( resample->outPlug() );
 
 	// Pass-throughs for things we don't want to modify
 	outPlug()->attributesPlug()->setInput( inPlug()->attributesPlug() );
@@ -88,21 +120,41 @@ const Gaffer::IntPlug *OSLObject::interpolationPlug() const
 	return getChild<IntPlug>( g_firstPlugIndex + 1 );
 }
 
+ScenePlug *OSLObject::resampledInPlug()
+{
+	return getChild<ScenePlug>( g_firstPlugIndex + 2 );
+}
+
+const ScenePlug *OSLObject::resampledInPlug() const
+{
+	return getChild<ScenePlug>( g_firstPlugIndex + 2 );
+}
+
+StringPlug *OSLObject::resampledNamesPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+}
+
+const StringPlug *OSLObject::resampledNamesPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+}
+
 void OSLObject::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	SceneElementProcessor::affects( input, outputs );
 
-	if( input == shaderPlug() )
+	if( input == shaderPlug() ||
+		input == inPlug()->transformPlug() ||
+		input == interpolationPlug() ||
+		input == resampledInPlug()->objectPlug()
+		)
 	{
 		outputs.push_back( outPlug()->objectPlug() );
 	}
-	else if( input == inPlug()->transformPlug() )
+	else if( input == inPlug()->objectPlug() )
 	{
-		outputs.push_back( outPlug()->objectPlug() );
-	}
-	else if ( input == interpolationPlug() )
-	{
-		outputs.push_back( outPlug()->objectPlug() );
+		outputs.push_back( resampledNamesPlug() );
 	}
 	else if( input == outPlug()->objectPlug() )
 	{
@@ -169,6 +221,7 @@ void OSLObject::hashProcessedObject( const ScenePath &path, const Gaffer::Contex
 
 	interpolationPlug()->hash( h );
 	h.append( inPlug()->fullTransformHash( path ) );
+	h.append( resampledInPlug()->objectPlug()->hash() );
 }
 
 static const IECore::InternedString g_world("world");
@@ -181,11 +234,6 @@ IECore::ConstObjectPtr OSLObject::computeProcessedObject( const ScenePath &path,
 		return inputObject;
 	}
 
-	if( !inputPrimitive->variableData<V3fVectorData>( "P", PrimitiveVariable::Vertex ) )
-	{
-		return inputObject;
-	}
-
 	ConstOSLShaderPtr shader = runTimeCast<const OSLShader>( shaderPlug()->source<Plug>()->node() );
 	ConstShadingEnginePtr shadingEngine = shader ? shader->shadingEngine() : NULL;
 
@@ -194,16 +242,10 @@ IECore::ConstObjectPtr OSLObject::computeProcessedObject( const ScenePath &path,
 		return inputObject;
 	}
 
-	CompoundDataPtr shadingPoints = new CompoundData;
-	for( PrimitiveVariableMap::const_iterator it = inputPrimitive->variables.begin(), eIt = inputPrimitive->variables.end(); it != eIt; ++it )
-	{
-		if( it->second.interpolation == PrimitiveVariable::Vertex )
-		{
-			// cast is ok - we're only using it to be able to reference the data from the shadingPoints,
-			// but nothing will modify the data itself.
-			shadingPoints->writable()[it->first] = boost::const_pointer_cast<Data>( it->second.data );
-		}
-	}
+	PrimitiveVariable::Interpolation interpolation = static_cast<PrimitiveVariable::Interpolation>( interpolationPlug()->getValue() );
+
+	IECore::ConstPrimitivePtr resampledObject = IECore::runTimeCast<const IECore::Primitive>( resampledInPlug()->objectPlug()->getValue() );
+	CompoundDataPtr shadingPoints = prepareShadingPoints( resampledObject.get() );
 
 	PrimitivePtr outputPrimitive = inputPrimitive->copy();
 
@@ -218,9 +260,50 @@ IECore::ConstObjectPtr OSLObject::computeProcessedObject( const ScenePath &path,
 		// Ignore the output color closure as the debug closures are used to define what is 'exported' from the shader
 		if( it->first != "Ci" )
 		{
-			outputPrimitive->variables[it->first] = PrimitiveVariable( PrimitiveVariable::Vertex, it->second );
+			outputPrimitive->variables[it->first] = PrimitiveVariable( interpolation, it->second );
 		}
 	}
 
 	return outputPrimitive;
+}
+
+void OSLObject::hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const
+{
+	SceneElementProcessor::hash( output, context, h );
+
+	if( output == resampledNamesPlug() )
+	{
+		inPlug()->objectPlug()->hash( h );
+	}
+}
+
+void OSLObject::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const
+{
+	if( output == resampledNamesPlug() )
+	{
+		ConstPrimitivePtr prim = runTimeCast<const IECore::Primitive>( inPlug()->objectPlug()->getValue() );
+
+		if (!prim)
+		{
+			static_cast<StringPlug *>( output )->setToDefault();
+			return;
+		}
+
+		std::string nonConstantPrimitiveVariables;
+
+		for( PrimitiveVariableMap::const_iterator it = prim->variables.begin(); it != prim->variables.end(); ++it )
+		{
+			if( it->second.interpolation == PrimitiveVariable::Constant )
+			{
+				continue;
+			}
+
+			nonConstantPrimitiveVariables += " " + it->first;
+		}
+
+		static_cast<StringPlug *>( output )->setValue( nonConstantPrimitiveVariables );
+		return;
+	}
+
+	SceneElementProcessor::compute( output, context );
 }


### PR DESCRIPTION
This PR allows OSLObject to shade using _Uniform_ and _FaceVarying_ interpolations in addition to the preexisting  _Vertex_  mode.

I'm concerned with the performance regression when only reading already vertex interpolated variables. I have another branch were I query the variables read in the shader but I'm unsure at what point I should read these and set the names plug on the internal resample node. Hopefully performance hit is acceptable and we can address the performance in a subsequent PR?



