### PR TITLE
GafferScene : ResamplePrimitiveVariables requires filter

### DIFF
--- a/include/GafferScene/PrimitiveVariableProcessor.h
+++ b/include/GafferScene/PrimitiveVariableProcessor.h
@@ -59,7 +59,7 @@ class PrimitiveVariableProcessor : public SceneElementProcessor
 
 	public :
 
-		PrimitiveVariableProcessor( const std::string &name=defaultName<PrimitiveVariableProcessor>() );
+		PrimitiveVariableProcessor( const std::string &name=defaultName<PrimitiveVariableProcessor>(), Filter::Result filterDefault = Filter::EveryMatch );
 		virtual ~PrimitiveVariableProcessor();
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::PrimitiveVariableProcessor, PrimitiveVariableProcessorTypeId, SceneElementProcessor );

--- a/python/GafferSceneTest/ResamplePrimitiveVariablesTest.py
+++ b/python/GafferSceneTest/ResamplePrimitiveVariablesTest.py
@@ -80,6 +80,21 @@ class ResamplePrimitiveVariablesTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( IECore.PrimitiveVariable.Interpolation.Constant, actualObject["a"].interpolation )
 		self.assertEqual( actualObject["a"].data, IECore.FloatData( 1.5 ) )
 
+	def testNoFilterIsNOP( self ) :
+
+		quadScene = self.makeQuad()
+
+		resample = GafferScene.ResamplePrimitiveVariables()
+
+		resample["in"].setInput( quadScene["out"] )
+		resample["interpolation"].setValue( IECore.PrimitiveVariable.Interpolation.Constant ) # constant
+		resample['names'].setValue( "a" )
+
+		actualObject = resample["out"].object( "/object" )
+
+		self.assertEqual( actualObject["a"].interpolation, IECore.PrimitiveVariable.Interpolation.FaceVarying )
+		self.assertEqual( actualObject["a"].data, IECore.FloatVectorData( [0, 1, 2, 3] ) )
+
 	def testConstantToVertex( self ) :
 
 		quadScene = self.makeQuad()

--- a/src/GafferScene/PrimitiveVariableProcessor.cpp
+++ b/src/GafferScene/PrimitiveVariableProcessor.cpp
@@ -48,8 +48,8 @@ IE_CORE_DEFINERUNTIMETYPED( PrimitiveVariableProcessor );
 
 size_t PrimitiveVariableProcessor::g_firstPlugIndex = 0;
 
-PrimitiveVariableProcessor::PrimitiveVariableProcessor( const std::string &name )
-	:	SceneElementProcessor( name )
+PrimitiveVariableProcessor::PrimitiveVariableProcessor( const std::string &name, Filter::Result filterDefault )
+	:	SceneElementProcessor( name, filterDefault )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new StringPlug( "names" ) );

--- a/src/GafferScene/ResamplePrimitiveVariables.cpp
+++ b/src/GafferScene/ResamplePrimitiveVariables.cpp
@@ -53,7 +53,7 @@ IE_CORE_DEFINERUNTIMETYPED( ResamplePrimitiveVariables );
 
 size_t ResamplePrimitiveVariables::g_firstPlugIndex = 0;
 
-ResamplePrimitiveVariables::ResamplePrimitiveVariables( const std::string &name ) : PrimitiveVariableProcessor( name )
+ResamplePrimitiveVariables::ResamplePrimitiveVariables( const std::string &name ) : PrimitiveVariableProcessor( name, Filter::NoMatch )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 


### PR DESCRIPTION
Mentioned in PR https://github.com/GafferHQ/gaffer/pull/2118 that ResamplePrimitiveVariables should only process if a filter is specified. 