### PR TITLE
Qt5

### DIFF
--- a/apps/browser/browser-1.py
+++ b/apps/browser/browser-1.py
@@ -43,7 +43,7 @@ import GafferUI
 import GafferCortexUI
 import GafferSceneUI # for alembic previews
 
-QtGui = GafferUI._qtImport( "QtGui" )
+from Qt import QtWidgets
 
 class browser( Gaffer.Application ) :
 
@@ -95,7 +95,7 @@ class browser( Gaffer.Application ) :
 		# centre the window on the primary screen at 3/4 size.
 		## \todo Implement save/restore of geometry, and do all this without using Qt APIs
 		# in the app itself.
-		desktop = QtGui.QApplication.instance().desktop()
+		desktop = QtWidgets.QApplication.instance().desktop()
 		geometry = desktop.availableGeometry()
 		adjustment = geometry.size() / 8
 		geometry.adjust( adjustment.width(), adjustment.height(), -adjustment.width(), -adjustment.height() )

--- a/apps/gui/gui-1.py
+++ b/apps/gui/gui-1.py
@@ -121,7 +121,7 @@ class gui( Gaffer.Application ) :
 		# Perhaps we should abolish the ApplicationRoot clipboard and the ScriptNode cut/copy/paste routines, relegating
 		# them all to GafferUI functionality?
 
-		QtWidgets = GafferUI._qtImport( "QtWidgets" )
+		from Qt import QtWidgets
 
 		self.__clipboardContentsChangedConnection = self.root().clipboardContentsChangedSignal().connect( Gaffer.WeakMethod( self.__clipboardContentsChanged ) )
 		QtWidgets.QApplication.clipboard().dataChanged.connect( Gaffer.WeakMethod( self.__qtClipboardContentsChanged ) )
@@ -133,7 +133,7 @@ class gui( Gaffer.Application ) :
 
 		data = applicationRoot.getClipboardContents()
 
-		QtWidgets = GafferUI._qtImport( "QtWidgets" )
+		from Qt import QtWidgets
 		clipboard = QtWidgets.QApplication.clipboard()
 		try :
 			self.__ignoreQtClipboardContentsChanged = True # avoid triggering an unecessary copy back in __qtClipboardContentsChanged
@@ -146,7 +146,7 @@ class gui( Gaffer.Application ) :
 		if self.__ignoreQtClipboardContentsChanged :
 			return
 
-		QtWidgets = GafferUI._qtImport( "QtWidgets" )
+		from Qt import QtWidgets
 
 		text = str( QtWidgets.QApplication.clipboard().text() )
 		if text :

--- a/apps/gui/gui-1.py
+++ b/apps/gui/gui-1.py
@@ -121,10 +121,10 @@ class gui( Gaffer.Application ) :
 		# Perhaps we should abolish the ApplicationRoot clipboard and the ScriptNode cut/copy/paste routines, relegating
 		# them all to GafferUI functionality?
 
-		QtGui = GafferUI._qtImport( "QtGui" )
+		QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 		self.__clipboardContentsChangedConnection = self.root().clipboardContentsChangedSignal().connect( Gaffer.WeakMethod( self.__clipboardContentsChanged ) )
-		QtGui.QApplication.clipboard().dataChanged.connect( Gaffer.WeakMethod( self.__qtClipboardContentsChanged ) )
+		QtWidgets.QApplication.clipboard().dataChanged.connect( Gaffer.WeakMethod( self.__qtClipboardContentsChanged ) )
 		self.__ignoreQtClipboardContentsChanged = False
 
 	def __clipboardContentsChanged( self, applicationRoot ) :
@@ -133,8 +133,8 @@ class gui( Gaffer.Application ) :
 
 		data = applicationRoot.getClipboardContents()
 
-		QtGui = GafferUI._qtImport( "QtGui" )
-		clipboard = QtGui.QApplication.clipboard()
+		QtWidgets = GafferUI._qtImport( "QtWidgets" )
+		clipboard = QtWidgets.QApplication.clipboard()
 		try :
 			self.__ignoreQtClipboardContentsChanged = True # avoid triggering an unecessary copy back in __qtClipboardContentsChanged
 			clipboard.setText( str( data ) )
@@ -146,9 +146,9 @@ class gui( Gaffer.Application ) :
 		if self.__ignoreQtClipboardContentsChanged :
 			return
 
-		QtGui = GafferUI._qtImport( "QtGui" )
+		QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
-		text = str( QtGui.QApplication.clipboard().text() )
+		text = str( QtWidgets.QApplication.clipboard().text() )
 		if text :
 			with Gaffer.BlockedConnection( self.__clipboardContentsChangedConnection ) :
 				self.root().setClipboardContents( IECore.StringData( text ) )

--- a/apps/screengrab/screengrab-1.py
+++ b/apps/screengrab/screengrab-1.py
@@ -44,7 +44,7 @@ import GafferUI
 import GafferScene
 import GafferSceneUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+from Qt import QtGui
 
 class screengrab( Gaffer.Application ) :
 

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -178,6 +178,10 @@ else
 	fi
 fi
 
+if [[ -e $GAFFER_ROOT/qt/plugins ]] ; then
+	export QT_QPA_PLATFORM_PLUGIN_PATH="$GAFFER_ROOT/qt/plugins"
+fi
+
 # Get the executable path set up, for running child processes from Gaffer
 ##########################################################################
 

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -172,6 +172,10 @@ if [[ `uname` = "Linux" ]] ; then
 else
 	prependToPath "$GAFFER_ROOT/lib" DYLD_FRAMEWORK_PATH
 	prependToPath "$GAFFER_ROOT/lib" DYLD_LIBRARY_PATH
+	# PySide2 installs its libraries next to its python modules,
+	# and messes up the rpaths such that they can't be relocated.
+	# Work around this by putting them on the DYLD_LIBRARY_PATH.
+	prependToPath "$PYTHONHOME/lib/python2.7/site-packages/PySide2" DYLD_LIBRARY_PATH
 	prependToPath /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ImageIO.framework/Resources/ DYLD_LIBRARY_PATH
 	if [[ -n $DELIGHT ]] ; then
 		appendToPath "$DELIGHT/lib" DYLD_LIBRARY_PATH

--- a/config/ie/options
+++ b/config/ie/options
@@ -1,25 +1,25 @@
 ##########################################################################
-#  
+#
 #  Copyright (c) 2012-2015, Image Engine Design Inc. All rights reserved.
-#  
+#
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
 #  met:
-#  
+#
 #      * Redistributions of source code must retain the above
 #        copyright notice, this list of conditions and the following
 #        disclaimer.
-#  
+#
 #      * Redistributions in binary form must reproduce the above
 #        copyright notice, this list of conditions and the following
 #        disclaimer in the documentation and/or other materials provided with
 #        the distribution.
-#  
+#
 #      * Neither the name of John Haddon nor the names of
 #        any other contributors to this software may be used to endorse or
 #        promote products derived from this software without specific prior
 #        written permission.
-#  
+#
 #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 #  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
 #  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
@@ -31,7 +31,7 @@
 #  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 #  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#  
+#
 ##########################################################################
 
 import os
@@ -48,10 +48,10 @@ def getOption( name, default ) :
 	import sys
 	result = default
 	for a in sys.argv:
-		if a[:len(name)+1]==name+"=" :	
+		if a[:len(name)+1]==name+"=" :
 			result = a[len(name)+1:]
 
-	return result	
+	return result
 
 cortexMajorVersion = getOption( "CORTEX_MAJOR_VERSION", os.environ["CORTEX_MAJOR_VERSION"] )
 cortexVersion = getOption( "CORTEX_VERSION", os.environ["CORTEX_VERSION"] )
@@ -73,24 +73,24 @@ oslVersion = gafferReg["OpenShadingLanguage"]
 vdbVersion = gafferReg.get( "OpenVDB", "3.0.0" )
 
 if targetApp :
-	
+
 	if targetApp not in ( "nuke", "maya", "houdini" ) :
 		raise RuntimeError( "Check config logic applies to the new app and remove this exception." )
-	
+
 	if (compiler or compilerVersion) :
 		raise RuntimeError( "Must specify only one of COMPILER or APP" )
-		
+
 	targetAppVersion = getOption( "APP_VERSION", os.environ.get( targetApp.upper() + "_VERSION" ) )
-		
+
 	targetAppReg = IEEnv.registry["apps"][targetApp][targetAppVersion][IEEnv.platform()]
 	compiler = targetAppReg["compiler"]
 	compilerVersion = targetAppReg["compilerVersion"]
 	pythonVersion = targetAppReg["pythonVersion"]
 	targetAppMajorVersion = targetAppReg.get( "majorVersion", targetAppVersion )
-	
+
 	if "compilerFlags" in targetAppReg :
 		CXXFLAGS = CXXFLAGS + targetAppReg["compilerFlags"]
-	
+
 	if "linkerFlags" in targetAppReg :
 		targetAppLinkFlags = " ".join( targetAppReg["linkerFlags"] )
 		if LINKFLAGS :
@@ -161,7 +161,7 @@ BUILD_DIR = os.path.join( baseBuildDir, targetApp )
 INSTALL_DIR = os.path.join( baseInstallDir, targetApp )
 
 if targetAppVersion :
-	
+
 	BUILD_DIR = os.path.join( BUILD_DIR, targetAppMajorVersion )
 	INSTALL_DIR = os.path.join( INSTALL_DIR, targetAppMajorVersion )
 
@@ -193,12 +193,12 @@ LOCATE_DEPENDENCY_CPPPATH = [
 ]
 
 if getOption( "RELEASE", "0" )=="0" :
-	
+
 	LOCATE_DEPENDENCY_CPPPATH.insert(
 		0,
 		os.path.join( os.path.expanduser( "~" ), "apps", "cortex", cortexVersion, IEEnv.platform(), "base", "include" )
 	)
-	
+
 	if targetAppVersion :
 		LOCATE_DEPENDENCY_CPPPATH.insert(
 			0,
@@ -217,7 +217,7 @@ LOCATE_DEPENDENCY_LIBPATH = [
 	os.path.join( IEEnv.Environment.rootPath(), "apps", "cortex", cortexVersion, IEEnv.platform(), "base", "arnold", arnoldVersion, "lib", compiler, compilerVersion ),
 	os.path.join( IEEnv.Environment.rootPath(), "apps", "cortex", cortexVersion, IEEnv.platform(), "base", "appleseed", appleseedVersion, "lib", compiler, compilerVersion ),
 	os.path.join( IEEnv.Environment.rootPath(), "apps", "qt", qtVersion, IEEnv.platform(), compiler, compilerVersion, "lib" ),
-	os.path.join( OSLHOME, "lib" ),	
+	os.path.join( OSLHOME, "lib" ),
 	os.path.join( IEEnv.Environment.rootPath(), "apps", "OpenVDB", vdbVersion, IEEnv.platform(), compiler, compilerVersion, "lib" ),
 	os.path.join( IEEnv.Environment.rootPath(), "apps", "appleseed", appleseedVersion, IEEnv.platform(), "lib" ),
 
@@ -225,7 +225,7 @@ LOCATE_DEPENDENCY_LIBPATH = [
 
 LOCATE_DEPENDENCY_PYTHONPATH = [
 
-	os.path.join( IEEnv.Environment.rootPath(), "apps", "cortex", cortexVersion, IEEnv.platform(), "base", "python", pythonVersion, compiler, compilerVersion ),	
+	os.path.join( IEEnv.Environment.rootPath(), "apps", "cortex", cortexVersion, IEEnv.platform(), "base", "python", pythonVersion, compiler, compilerVersion ),
 	os.path.join( IEEnv.Environment.rootPath(), "apps", "cortex", cortexVersion, IEEnv.platform(), "base", "arnold", arnoldVersion, "python", pythonVersion, compiler, compilerVersion ),
 	os.path.join( IEEnv.Environment.rootPath(), "apps", "cortex", cortexVersion, IEEnv.platform(), "base", "appleseed", appleseedVersion, "python", pythonVersion, compiler, compilerVersion ),
 	os.path.join( IEEnv.Environment.rootPath(), "apps", "OpenColorIO", ocioVersion, IEEnv.platform(), compiler, compilerVersion, "lib", "python" + pythonVersion, "site-packages" ),
@@ -248,7 +248,7 @@ LOCATE_DEPENDENCY_RESOURCESPATH = [
 os.environ["IECOREGL_SHADER_INCLUDE_PATHS"] = os.path.join( IEEnv.Environment.rootPath(), "apps", "cortex", cortexVersion, IEEnv.platform(), "base", "glsl" )
 
 if targetAppVersion :
-	
+
 	targetAppLocation = targetAppReg["location"]
 	if targetApp != "nuke" :
 		# Include any library locations from the target application. We have to skip
@@ -267,7 +267,7 @@ if targetAppVersion :
 		0,
 		os.path.join( IEEnv.Environment.rootPath(), "apps", "cortex", cortexVersion, IEEnv.platform(), targetApp, targetAppMajorVersion, "lib" ),
 	)
-	
+
 	LOCATE_DEPENDENCY_LIBPATH.insert(
 		0,
 		os.path.join( IEEnv.Environment.rootPath(), "tools", targetApp, targetAppVersion, "lib", IEEnv.platform() ),
@@ -288,7 +288,7 @@ if getOption( "RELEASE", "0" )=="0" :
 	]
 
 	os.environ["IECOREGL_SHADER_INCLUDE_PATHS"] = os.path.join( os.path.expanduser( "~" ), "apps", "cortex", cortexVersion, IEEnv.platform(), "base", "glsl" ) + ":" + os.environ["IECOREGL_SHADER_INCLUDE_PATHS"]
-	
+
 	if targetAppVersion :
 		LOCATE_DEPENDENCY_LIBPATH.insert(
 			0,

--- a/config/ie/options
+++ b/config/ie/options
@@ -71,6 +71,7 @@ oiioVersion = gafferReg["OpenImageIO"]
 ocioVersion = gafferReg["OpenColorIO"]
 oslVersion = gafferReg["OpenShadingLanguage"]
 vdbVersion = gafferReg.get( "OpenVDB", "3.0.0" )
+qtPyVersion = gafferReg.get( "qtPyVersion", "1.0.0.b3" )
 
 if targetApp :
 
@@ -236,6 +237,7 @@ LOCATE_DEPENDENCY_PYTHONPATH = [
 	os.path.join( IEEnv.Environment.rootPath(), "tools", "python", pythonVersion, "noarch" ),
 	os.path.join( sphinxRoot, "lib", "python" + pythonVersion, "site-packages" ),
 	os.path.join( sphinxRoot, "lib64", "python" + pythonVersion, "site-packages" ),
+	os.path.join( IEEnv.Environment.rootPath(), "apps", "Qt.py", qtPyVersion ),
 
 ]
 

--- a/config/ie/options
+++ b/config/ie/options
@@ -98,6 +98,8 @@ if targetApp :
 		else :
 			LINKFLAGS = targetAppLinkFlags
 
+	qtVersion = targetAppReg.get( "qtVersion", qtVersion )
+
 else :
 
 	targetApp = "gaffer"

--- a/contrib/scripts/qt5.py
+++ b/contrib/scripts/qt5.py
@@ -1,0 +1,66 @@
+import os
+import re
+import functools
+
+import Qt
+
+def convert( fileName ) :
+
+	with open( fileName ) as f :
+		text = "".join( f.readlines() )
+		#print text
+
+	# Substitute QtWidgets for QtGui where needed
+
+	def replaceModule( match ) :
+
+		s = match.group( 0 ).split( "." )
+		if s[1] in Qt._common_members["QtWidgets"] :
+			s[0] = "QtWidgets"
+
+		return ".".join( s )
+
+	for name in Qt._common_members["QtWidgets"] :
+		newText = re.sub(
+			r"QtGui\.[A-Za-z0-9]+",
+			replaceModule,
+			text,
+		)
+
+	if newText != text :
+
+		# We'll need an import for QtWidgets,
+		# and previously we must have had one
+		# for QtGui, which we may or may not
+		# need still.
+
+		def replaceImport( match, needQtGui ) :
+
+			qtGuiImport = match.group( 0 )
+			qtWidgetsImport = qtGuiImport.replace( "QtGui", "QtWidgets" )
+			if needQtGui :
+				return qtGuiImport + "\n" + qtWidgetsImport
+			else :
+				return qtWidgetsImport
+
+		newText = re.sub(
+			r'QtGui\s*=\s*GafferUI\._qtImport(.*)',
+			functools.partial( replaceImport, needQtGui = re.search( r"QtGui\.", newText ) ),
+			newText
+		)
+
+	# Replace deprecated `_qtImport` calls with `from Qt import` calls
+
+	newText = re.sub(
+		r'(Qt\w*)\s*=\s*GafferUI._qtImport\(\s*["\'](Qt.*)["\']\s*\)',
+		r'from Qt import \2',
+		text
+	)
+
+	with open( fileName, "w" ) as f :
+		f.write( newText )
+
+for root, dirs, files in os.walk( "./python" ) :
+	for file in files :
+		if os.path.splitext( file )[1] == ".py" :
+			convert( os.path.join( root, file ) )

--- a/contrib/scripts/qt5Check.py
+++ b/contrib/scripts/qt5Check.py
@@ -1,0 +1,48 @@
+#! /usr/bin/env python
+
+import os
+import re
+import inspect
+import argparse
+import pydoc
+
+import Qt
+
+parser = argparse.ArgumentParser(
+	description = inspect.cleandoc(
+	"""
+	Attempts to search Python source files to assist
+	in the detection of Qt constructs that are not
+	supported directly by Qt.py. It finds some false
+	positives (for example QtGui.QApplication.instance)
+	but is generally fairly useful.
+	"""
+	)
+)
+
+parser.add_argument(
+	"source-directory",
+	help = "A directory containing python files. This will be searched recursively.",
+	nargs = "?",
+	default = "./",
+)
+
+def detect( fileName ) :
+
+	with open( fileName ) as f :
+		text = "".join( f.readlines() )
+
+	matches = re.findall( r"Qt[A-Za-z_]+\.[A-Za-z0-9\._]+", text )
+	if matches is None :
+		return
+
+	for match in matches :
+		if pydoc.locate( "Qt." + match ) is None :
+			print fileName + " : " + match
+
+args = parser.parse_args()
+directory = vars( args )["source-directory"]
+for root, dirs, files in os.walk( directory ) :
+	for file in files :
+		if os.path.splitext( file )[1] == ".py" :
+			detect( os.path.join( root, file ) )

--- a/python/GafferCortexUI/DateTimeParameterValueWidget.py
+++ b/python/GafferCortexUI/DateTimeParameterValueWidget.py
@@ -45,6 +45,7 @@ import GafferCortexUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class DateTimeParameterValueWidget( GafferCortexUI.ParameterValueWidget ) :
 
@@ -58,10 +59,10 @@ class _DateTimePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, **kw ) :
 
-		GafferUI.PlugValueWidget.__init__( self, QtGui.QDateTimeEdit(), plug, **kw )
+		GafferUI.PlugValueWidget.__init__( self, QtWidgets.QDateTimeEdit(), plug, **kw )
 
 		self._qtWidget().setCalendarPopup( True )
-		self._qtWidget().setSizePolicy( QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed )
+		self._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed )
 		self._qtWidget().calendarWidget().setGridVisible( True )
 
 		headerFormat = QtGui.QTextCharFormat()

--- a/python/GafferCortexUI/DateTimeParameterValueWidget.py
+++ b/python/GafferCortexUI/DateTimeParameterValueWidget.py
@@ -43,9 +43,9 @@ import Gaffer
 import GafferUI
 import GafferCortexUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 class DateTimeParameterValueWidget( GafferCortexUI.ParameterValueWidget ) :
 

--- a/python/GafferCortexUI/ParameterPresets.py
+++ b/python/GafferCortexUI/ParameterPresets.py
@@ -320,7 +320,7 @@ class LoadPresetDialogue( PresetDialogue ) :
 
 		PresetDialogue.__init__( self, "Load Preset", parameterHandler )
 
-		with GafferUI.SplitContainer( orientation = GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) as row :
+		with GafferUI.SplitContainer( orientation = GafferUI.ListContainer.Orientation.Horizontal ) as row :
 
 			with GafferUI.ListContainer( spacing=4 ) :
 

--- a/python/GafferDispatchUI/DispatcherUI.py
+++ b/python/GafferDispatchUI/DispatcherUI.py
@@ -43,7 +43,7 @@ import Gaffer
 import GafferUI
 import GafferDispatch
 
-QtCore = GafferUI._qtImport( "QtCore" )
+from Qt import QtCore
 
 Gaffer.Metadata.registerNode(
 

--- a/python/GafferDispatchUI/LocalDispatcherUI.py
+++ b/python/GafferDispatchUI/LocalDispatcherUI.py
@@ -40,8 +40,8 @@ import Gaffer
 import GafferUI
 import GafferDispatch
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
+from Qt import QtCore
+from Qt import QtGui
 
 Gaffer.Metadata.registerNode(
 

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -1035,7 +1035,7 @@ class _SectionWindow( GafferUI.Window ) :
 # Inheritance section
 ##########################################################################
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtWidgets
 
 class _Rail( GafferUI.ListContainer ) :
 

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -981,7 +981,7 @@ class Section( GafferUI.Widget ) :
 
 		if label is None :
 			label = GafferUI.Label()
-			label._qtWidget().setSizePolicy( QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Fixed )
+			label._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed )
 			self.__collapsible.setCornerWidget( label, True )
 
 		if summary :
@@ -1035,7 +1035,7 @@ class _SectionWindow( GafferUI.Window ) :
 # Inheritance section
 ##########################################################################
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class _Rail( GafferUI.ListContainer ) :
 
@@ -1052,7 +1052,7 @@ class _Rail( GafferUI.ListContainer ) :
 				## \todo Decide how we do this via the public API.
 				# Perhaps by putting the image in a Sizer? Or by
 				# adding stretch methods to the Image class?
-				image._qtWidget().setSizePolicy( QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Preferred )
+				image._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Preferred )
 				image._qtWidget().setScaledContents( True )
 			else :
 				GafferUI.Spacer( IECore.V2i( 1 ) )
@@ -1061,7 +1061,7 @@ class _Rail( GafferUI.ListContainer ) :
 
 			if type != self.Type.Bottom and type != self.Type.Single :
 				image = GafferUI.Image( "railLine.png" )
-				image._qtWidget().setSizePolicy( QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Preferred )
+				image._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Preferred )
 				image._qtWidget().setScaledContents( True )
 			else :
 				GafferUI.Spacer( IECore.V2i( 1 ) )

--- a/python/GafferSceneUITest/SceneViewTest.py
+++ b/python/GafferSceneUITest/SceneViewTest.py
@@ -267,7 +267,7 @@ class SceneViewTest( GafferUITest.TestCase ) :
 		self.waitForIdle()
 		self.assertEqual( getViewCameraTransform(), IECore.M44f.createTranslated( IECore.V3f( 200, 0, 0 ) ) )
 
-		# Work around "Internal C++ object (PySide.QtGui.QWidget) already deleted" error. In an
+		# Work around "Internal C++ object (PySide.QtWidgets.QWidget) already deleted" error. In an
 		# ideal world we'll fix this, but it's unrelated to what we're testing here.
 		window.removeChild( viewer )
 

--- a/python/GafferUI/BoolWidget.py
+++ b/python/GafferUI/BoolWidget.py
@@ -43,6 +43,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class BoolWidget( GafferUI.Widget ) :
 
@@ -118,13 +119,13 @@ class BoolWidget( GafferUI.Widget ) :
 
 		self.__stateChangedSignal( self )
 
-class _CheckBox( QtGui.QCheckBox ) :
+class _CheckBox( QtWidgets.QCheckBox ) :
 
 	HitMode = IECore.Enum.create( "Button", "CheckBox" )
 
 	def __init__( self, text, parent = None ) :
 
-		QtGui.QCheckBox.__init__( self, text, parent )
+		QtWidgets.QCheckBox.__init__( self, text, parent )
 
 		self.__hitMode = self.HitMode.CheckBox
 
@@ -139,9 +140,9 @@ class _CheckBox( QtGui.QCheckBox ) :
 	def hitButton( self, pos ) :
 
 		if self.__hitMode == self.HitMode.Button :
-			return QtGui.QAbstractButton.hitButton( self, pos )
+			return QtWidgets.QAbstractButton.hitButton( self, pos )
 		else :
-			return QtGui.QCheckBox.hitButton( self, pos )
+			return QtWidgets.QCheckBox.hitButton( self, pos )
 
 ## \todo Backwards compatibility - remove for version 1.0
 CheckBox = BoolWidget

--- a/python/GafferUI/BoolWidget.py
+++ b/python/GafferUI/BoolWidget.py
@@ -41,9 +41,9 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 class BoolWidget( GafferUI.Widget ) :
 

--- a/python/GafferUI/BusyWidget.py
+++ b/python/GafferUI/BusyWidget.py
@@ -41,6 +41,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class BusyWidget( GafferUI.Widget ) :
 
@@ -49,11 +50,11 @@ class BusyWidget( GafferUI.Widget ) :
 		GafferUI.Widget.__init__( self, _BusyWidget( None, size ), **kw )
 
 # qt implementation class
-class _BusyWidget( QtGui.QWidget ) :
+class _BusyWidget( QtWidgets.QWidget ) :
 
 	def __init__( self, parent = None , size = 50 ) :
 
-		QtGui.QWidget.__init__( self, parent )
+		QtWidgets.QWidget.__init__( self, parent )
 
 		self.__size = size
 		self.setMinimumSize( size, size )
@@ -61,14 +62,14 @@ class _BusyWidget( QtGui.QWidget ) :
 
 	def showEvent( self, event ) :
 
-		QtGui.QWidget.showEvent( self, event )
+		QtWidgets.QWidget.showEvent( self, event )
 
 		if self.__timer is None :
 			self.__timer = self.startTimer( 1000 / 25 )
 
 	def hideEvent( self, event ) :
 
-		QtGui.QWidget.hideEvent( self, event )
+		QtWidgets.QWidget.hideEvent( self, event )
 
 		if self.__timer is not None :
 			self.killTimer( self.__timer )

--- a/python/GafferUI/BusyWidget.py
+++ b/python/GafferUI/BusyWidget.py
@@ -39,9 +39,9 @@ import time
 
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 class BusyWidget( GafferUI.Widget ) :
 

--- a/python/GafferUI/Button.py
+++ b/python/GafferUI/Button.py
@@ -68,7 +68,7 @@ class Button( GafferUI.Widget ) :
 		# and we really don't like the etching. the only effective way of disabling it
 		# seems to be to apply this palette which makes the etched text transparent.
 		if Button.__palette is None :
-			Button.__palette = QtGui.QPalette( QtWidgets.QApplication.instance().palette() )
+			Button.__palette = QtGui.QPalette( QtWidgets.QApplication.instance().palette( self._qtWidget() ) )
 			Button.__palette.setColor( QtGui.QPalette.Disabled, QtGui.QPalette.Light, QtGui.QColor( 0, 0, 0, 0 ) )
 
 		self._qtWidget().setPalette( Button.__palette )

--- a/python/GafferUI/Button.py
+++ b/python/GafferUI/Button.py
@@ -39,6 +39,7 @@ import Gaffer
 import GafferUI
 
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 QtCore = GafferUI._qtImport( "QtCore" )
 
 class Button( GafferUI.Widget ) :
@@ -47,7 +48,7 @@ class Button( GafferUI.Widget ) :
 
 	def __init__( self, text="", image=None, hasFrame=True, highlightOnOver=True, **kw ) :
 
-		GafferUI.Widget.__init__( self, QtGui.QPushButton(), **kw )
+		GafferUI.Widget.__init__( self, QtWidgets.QPushButton(), **kw )
 
 		self._qtWidget().setAttribute( QtCore.Qt.WA_LayoutUsesWidgetRect )
 		# allow return and enter keys to click button
@@ -67,7 +68,7 @@ class Button( GafferUI.Widget ) :
 		# and we really don't like the etching. the only effective way of disabling it
 		# seems to be to apply this palette which makes the etched text transparent.
 		if Button.__palette is None :
-			Button.__palette = QtGui.QPalette( QtGui.QApplication.instance().palette() )
+			Button.__palette = QtGui.QPalette( QtWidgets.QApplication.instance().palette() )
 			Button.__palette.setColor( QtGui.QPalette.Disabled, QtGui.QPalette.Light, QtGui.QColor( 0, 0, 0, 0 ) )
 
 		self._qtWidget().setPalette( Button.__palette )
@@ -111,8 +112,8 @@ class Button( GafferUI.Widget ) :
 
 		self._qtWidget().setObjectName( "gafferWithFrame" if hasFrame else "gafferWithoutFrame" )
 		self._qtWidget().setSizePolicy(
-			QtGui.QSizePolicy.Minimum if hasFrame else QtGui.QSizePolicy.Fixed,
-			QtGui.QSizePolicy.Fixed
+			QtWidgets.QSizePolicy.Minimum if hasFrame else QtWidgets.QSizePolicy.Fixed,
+			QtWidgets.QSizePolicy.Fixed
 		)
 		self._repolish()
 
@@ -131,7 +132,7 @@ class Button( GafferUI.Widget ) :
 		# the op to run without the values the user sees in the ui. normally editingFinished is emitted by
 		# the text widget itself on a loss of focus, but unfortunately clicking on a button doesn't cause that
 		# focus loss. so we helpfully emit the signal ourselves here.
-		focusWidget = GafferUI.Widget._owner( QtGui.QApplication.focusWidget() )
+		focusWidget = GafferUI.Widget._owner( QtWidgets.QApplication.focusWidget() )
 		if focusWidget is not None and hasattr( focusWidget, "editingFinishedSignal" ) :
 			focusWidget.editingFinishedSignal()( focusWidget )
 

--- a/python/GafferUI/Button.py
+++ b/python/GafferUI/Button.py
@@ -38,9 +38,9 @@
 import Gaffer
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
-QtCore = GafferUI._qtImport( "QtCore" )
+from Qt import QtGui
+from Qt import QtWidgets
+from Qt import QtCore
 
 class Button( GafferUI.Widget ) :
 

--- a/python/GafferUI/Collapsible.py
+++ b/python/GafferUI/Collapsible.py
@@ -38,7 +38,7 @@
 import Gaffer
 import GafferUI
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtWidgets
 
 ## The Collapsible container provides an easy means of controlling the
 # visibility of a child Widget. A labelled heading is always visible

--- a/python/GafferUI/Collapsible.py
+++ b/python/GafferUI/Collapsible.py
@@ -38,7 +38,7 @@
 import Gaffer
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## The Collapsible container provides an easy means of controlling the
 # visibility of a child Widget. A labelled heading is always visible
@@ -48,21 +48,21 @@ class Collapsible( GafferUI.ContainerWidget ) :
 
 	def __init__( self, label="", child=None, collapsed=False, borderWidth=0, cornerWidget=None, cornerWidgetExpanded=False, **kw ) :
 
-		GafferUI.ContainerWidget.__init__( self, QtGui.QWidget(), **kw )
+		GafferUI.ContainerWidget.__init__( self, QtWidgets.QWidget(), **kw )
 
 		self._qtWidget().setObjectName( "gafferCollapsible" )
 
 		layout = _VBoxLayout()
 		self._qtWidget().setLayout( layout )
-		layout.setSizeConstraint( QtGui.QLayout.SetMinAndMaxSize )
+		layout.setSizeConstraint( QtWidgets.QLayout.SetMinAndMaxSize )
 		layout.setContentsMargins( borderWidth, borderWidth, borderWidth, borderWidth )
 
-		self.__headerLayout = QtGui.QHBoxLayout()
-		self.__headerLayout.setSizeConstraint( QtGui.QLayout.SetMinAndMaxSize )
+		self.__headerLayout = QtWidgets.QHBoxLayout()
+		self.__headerLayout.setSizeConstraint( QtWidgets.QLayout.SetMinAndMaxSize )
 		self.__headerLayout.setContentsMargins( 0, 0, 0, 0 )
 		self.__headerLayout.setSpacing(0)
 
-		self.__toggle = QtGui.QCheckBox()
+		self.__toggle = QtWidgets.QCheckBox()
 		self.__toggle.setObjectName( "gafferCollapsibleToggle" )
 		self.__headerLayout.addWidget( self.__toggle)
 
@@ -174,18 +174,18 @@ class Collapsible( GafferUI.ContainerWidget ) :
 
 		self.stateChangedSignal()( self )
 
-class _VBoxLayout( QtGui.QVBoxLayout ) :
+class _VBoxLayout( QtWidgets.QVBoxLayout ) :
 
 	def __init__( self ) :
 
-		QtGui.QVBoxLayout.__init__( self )
+		QtWidgets.QVBoxLayout.__init__( self )
 
 	## Reimplemented so that requested width takes account of the
 	# width of child items even if they are currently hidden. That
 	# way the width doesn't change when the child is shown.
 	def sizeHint( self ) :
 
-		s = QtGui.QVBoxLayout.sizeHint( self )
+		s = QtWidgets.QVBoxLayout.sizeHint( self )
 
 		maxWidth = 0
 		for i in range( 0, self.count() ) :

--- a/python/GafferUI/ColorChooser.py
+++ b/python/GafferUI/ColorChooser.py
@@ -42,7 +42,7 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+from Qt import QtGui
 
 # A custom slider for drawing the backgrounds.
 class _ComponentSlider( GafferUI.NumericSlider ) :

--- a/python/GafferUI/ColorPlugValueWidget.py
+++ b/python/GafferUI/ColorPlugValueWidget.py
@@ -40,7 +40,7 @@ import weakref
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
+from Qt import QtCore
 
 class ColorPlugValueWidget( GafferUI.CompoundNumericPlugValueWidget ) :
 

--- a/python/GafferUI/ColorSwatch.py
+++ b/python/GafferUI/ColorSwatch.py
@@ -40,9 +40,9 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 ## The ColorSwatch simply displays a flat patch of colour. By default, the colour
 # is specified in linear space and GafferUI.DisplayTransform is used to ensure it

--- a/python/GafferUI/ColorSwatch.py
+++ b/python/GafferUI/ColorSwatch.py
@@ -42,6 +42,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## The ColorSwatch simply displays a flat patch of colour. By default, the colour
 # is specified in linear space and GafferUI.DisplayTransform is used to ensure it
@@ -54,12 +55,12 @@ class ColorSwatch( GafferUI.Widget ) :
 
 	def __init__( self, color=IECore.Color4f( 1 ), useDisplayTransform = True, **kw ) :
 
-		GafferUI.Widget.__init__( self, QtGui.QWidget(), **kw )
+		GafferUI.Widget.__init__( self, QtWidgets.QWidget(), **kw )
 
 		self.__opaqueChecker = _Checker()
 		self.__transparentChecker = _Checker()
 
-		layout = QtGui.QVBoxLayout()
+		layout = QtWidgets.QVBoxLayout()
 		layout.setSpacing( 0 )
 		layout.setContentsMargins( 0, 0, 0, 0 )
 		layout.addWidget( self.__opaqueChecker )
@@ -134,11 +135,11 @@ class ColorSwatch( GafferUI.Widget ) :
 
 # Private implementation - a QWidget derived class which just draws a checker with
 # no knowledge of colour spaces or anything.
-class _Checker( QtGui.QWidget ) :
+class _Checker( QtWidgets.QWidget ) :
 
 	def __init__( self ) :
 
-		QtGui.QWidget.__init__( self )
+		QtWidgets.QWidget.__init__( self )
 
 	def paintEvent( self, event ) :
 

--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -44,6 +44,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## \todo Implement an option to float in a new window, and an option to anchor back - drag and drop of tabs?
 class CompoundEditor( GafferUI.EditorWidget ) :
@@ -185,7 +186,7 @@ class CompoundEditor( GafferUI.EditorWidget ) :
 			# the target container we want to modify, and the new state we want to put it in.
 			## \todo Decide how and where we provide this widget-under-the-cursor functionality in
 			# the public api.
-			qWidget = QtGui.QApplication.instance().widgetAt( QtGui.QCursor.pos() )
+			qWidget = QtWidgets.QApplication.instance().widgetAt( QtGui.QCursor.pos() )
 			widget = GafferUI.Widget._owner( qWidget )
 
 			State = IECore.Enum.create( "None", "Open", "Closed", "Opening", "Closing" )
@@ -280,7 +281,7 @@ class CompoundEditor( GafferUI.EditorWidget ) :
 				# generic rule for what SplitContainer should do in its __applySizePolicy() method.
 				if len( splitContainer[0] ) == 1 and isinstance( splitContainer[0][0], GafferUI.Timeline ) :
 					splitContainer[0]._qtWidget().setFixedHeight( splitContainer[0][0]._qtWidget().sizeHint().height() )
-					splitContainer._qtWidget().setSizePolicy( QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Fixed )
+					splitContainer._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed )
 
 	def __addChild( self, splitContainer, nameOrEditor ) :
 

--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -42,9 +42,9 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 ## \todo Implement an option to float in a new window, and an option to anchor back - drag and drop of tabs?
 class CompoundEditor( GafferUI.EditorWidget ) :

--- a/python/GafferUI/CompoundPlugValueWidget.py
+++ b/python/GafferUI/CompoundPlugValueWidget.py
@@ -42,7 +42,7 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## \deprecated. CompoundPlug itself will be removed in the future, as will this
 # class. Use LayoutPlugValueWidget instead.
@@ -75,7 +75,7 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__collapsible.setCornerWidget( GafferUI.Label(), True )
 			## \todo This is fighting the default sizing applied in the Label constructor. Really we need a standard
 			# way of controlling size behaviours for all widgets in the public API.
-			self.__collapsible.getCornerWidget()._qtWidget().setSizePolicy( QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Fixed )
+			self.__collapsible.getCornerWidget()._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed )
 			self.__collapseStateChangedConnection = self.__collapsible.stateChangedSignal().connect( Gaffer.WeakMethod( self.__collapseStateChanged ) )
 
 		GafferUI.PlugValueWidget.__init__(

--- a/python/GafferUI/CompoundPlugValueWidget.py
+++ b/python/GafferUI/CompoundPlugValueWidget.py
@@ -42,7 +42,7 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtWidgets
 
 ## \deprecated. CompoundPlug itself will be removed in the future, as will this
 # class. Use LayoutPlugValueWidget instead.

--- a/python/GafferUI/DeferredPathPreview.py
+++ b/python/GafferUI/DeferredPathPreview.py
@@ -41,7 +41,7 @@ import IECore
 
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
+from Qt import QtCore
 
 ## This abstract class provides a base for all PathPreviewWidgets which may
 # take some time in generating the preview, and would therefore like to do it

--- a/python/GafferUI/Dialogue.py
+++ b/python/GafferUI/Dialogue.py
@@ -91,7 +91,12 @@ class Dialogue( GafferUI.Window ) :
 			self.__closeConnection = None
 			self.__modalEventLoop = None
 
-			self._qtWidget().setWindowModality( QtCore.Qt.NonModal )
+			# Here we want to call `self._qtWidget().setWindowModality( QtCore.Qt.NonModal )`,
+			# but that causes crashes in Qt 5, because it doesn't support changing modality on
+			# the fly. See https://bugreports.qt.io/browse/QTBUG-47599. In practice, everywhere
+			# we use modal dialogues in Gaffer, we close the dialogue immediately after exiting
+			# the modal loop anyway, so at least for now we can get away with not switching the
+			# modality back.
 
 			if parentWindow is not None :
 				parentWindow.removeChild( self )

--- a/python/GafferUI/Dialogue.py
+++ b/python/GafferUI/Dialogue.py
@@ -38,7 +38,7 @@
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
+from Qt import QtCore
 
 class Dialogue( GafferUI.Window ) :
 

--- a/python/GafferUI/Divider.py
+++ b/python/GafferUI/Divider.py
@@ -38,7 +38,7 @@ import IECore
 
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class Divider( GafferUI.Widget ) :
 
@@ -46,7 +46,7 @@ class Divider( GafferUI.Widget ) :
 
 	def __init__( self, orientation = Orientation.Horizontal, **kw ) :
 
-		GafferUI.Widget.__init__( self, QtGui.QFrame(), **kw )
+		GafferUI.Widget.__init__( self, QtWidgets.QFrame(), **kw )
 
 		self._qtWidget().setObjectName( "gafferDivider" )
 
@@ -55,13 +55,13 @@ class Divider( GafferUI.Widget ) :
 	def setOrientation( self, orientation ) :
 
 		if orientation == self.Orientation.Horizontal :
-			self._qtWidget().setFrameShape( QtGui.QFrame.HLine )
+			self._qtWidget().setFrameShape( QtWidgets.QFrame.HLine )
 		else :
-			self._qtWidget().setFrameShape( QtGui.QFrame.VLine )
+			self._qtWidget().setFrameShape( QtWidgets.QFrame.VLine )
 
 	def getOrientation( self ) :
 
-		if self._qtWidget().frameShape() == QtGui.QFrame.HLine :
+		if self._qtWidget().frameShape() == QtWidgets.QFrame.HLine :
 			return self.Orientation.Horizontal
 		else :
 			return self.Orientation.Vertical

--- a/python/GafferUI/Divider.py
+++ b/python/GafferUI/Divider.py
@@ -38,7 +38,7 @@ import IECore
 
 import GafferUI
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtWidgets
 
 class Divider( GafferUI.Widget ) :
 

--- a/python/GafferUI/Enums.py
+++ b/python/GafferUI/Enums.py
@@ -37,7 +37,7 @@
 import IECore
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
+from Qt import QtCore
 
 ## \todo Move other enums here - ListContainer.Orientation for instance.
 __all__ = [ "HorizontalAlignment", "VerticalAlignment", "Edge" ]

--- a/python/GafferUI/EventLoop.py
+++ b/python/GafferUI/EventLoop.py
@@ -45,7 +45,7 @@ import IECore
 import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## This class provides the event loops used to run GafferUI based applications.
 class EventLoop( object ) :
@@ -64,7 +64,7 @@ class EventLoop( object ) :
 			self.__qtEventLoop = __qtEventLoop
 
 		self.__runStyle = self.__RunStyle.Normal
-		if isinstance( self.__qtEventLoop, QtGui.QApplication ) :
+		if isinstance( self.__qtEventLoop, QtWidgets.QApplication ) :
 			try :
 				import maya.OpenMaya
 				if maya.OpenMaya.MGlobal.apiVersion() < 201100 :
@@ -149,14 +149,14 @@ class EventLoop( object ) :
 
 	# if we're running embedded in an application which already uses qt (like maya 2011 or later)
 	# then there'll already be an application, which we'll share. if not we'll make our own.
-	if QtGui.QApplication.instance() :
-		__qtApplication = QtGui.QApplication.instance()
+	if QtWidgets.QApplication.instance() :
+		__qtApplication = QtWidgets.QApplication.instance()
 	else :
 		# set the style explicitly so we don't inherit one from the desktop
 		# environment, which could mess with our own style (on gnome for instance,
 		# our icons can come out the wrong size).
-		QtGui.QApplication.setStyle( "plastique" )
-		__qtApplication = QtGui.QApplication( [ "gaffer" ] )
+		QtWidgets.QApplication.setStyle( "plastique" )
+		__qtApplication = QtWidgets.QApplication( [ "gaffer" ] )
 
 	__mainEventLoop = None
 	## Returns the main event loop for the application. This should always

--- a/python/GafferUI/EventLoop.py
+++ b/python/GafferUI/EventLoop.py
@@ -44,8 +44,8 @@ import IECore
 
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtWidgets
 
 ## This class provides the event loops used to run GafferUI based applications.
 class EventLoop( object ) :

--- a/python/GafferUI/Frame.py
+++ b/python/GafferUI/Frame.py
@@ -39,7 +39,7 @@ import IECore
 
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class Frame( GafferUI.ContainerWidget ) :
 
@@ -48,11 +48,11 @@ class Frame( GafferUI.ContainerWidget ) :
 
 	def __init__( self, child=None, borderWidth=8, borderStyle=BorderStyle.Flat, **kw ) :
 
-		GafferUI.ContainerWidget.__init__( self, QtGui.QFrame(), **kw )
+		GafferUI.ContainerWidget.__init__( self, QtWidgets.QFrame(), **kw )
 
-		self._qtWidget().setLayout( QtGui.QGridLayout() )
+		self._qtWidget().setLayout( QtWidgets.QGridLayout() )
 		self._qtWidget().layout().setContentsMargins( borderWidth, borderWidth, borderWidth, borderWidth )
-		self._qtWidget().layout().setSizeConstraint( QtGui.QLayout.SetMinAndMaxSize )
+		self._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetMinAndMaxSize )
 
 		self.__child = None
 		self.setChild( child )

--- a/python/GafferUI/Frame.py
+++ b/python/GafferUI/Frame.py
@@ -39,7 +39,7 @@ import IECore
 
 import GafferUI
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtWidgets
 
 class Frame( GafferUI.ContainerWidget ) :
 

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -53,9 +53,9 @@ import _GafferUI
 GL = Gaffer.lazyImport( "OpenGL.GL" )
 IECoreGL = Gaffer.lazyImport( "IECoreGL" )
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 QtOpenGL = GafferUI._qtImport( "QtOpenGL", lazy=True )
 
 ## The GLWidget is a base class for all widgets which wish to draw using OpenGL.

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -55,6 +55,7 @@ IECoreGL = Gaffer.lazyImport( "IECoreGL" )
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 QtOpenGL = GafferUI._qtImport( "QtOpenGL", lazy=True )
 
 ## The GLWidget is a base class for all widgets which wish to draw using OpenGL.
@@ -184,11 +185,11 @@ class GLWidget( GafferUI.Widget ) :
 
 		self._draw()
 
-class _GLGraphicsView( QtGui.QGraphicsView ) :
+class _GLGraphicsView( QtWidgets.QGraphicsView ) :
 
 	def __init__( self, format ) :
 
-		QtGui.QGraphicsView.__init__( self )
+		QtWidgets.QGraphicsView.__init__( self )
 
 		self.setObjectName( "gafferGLWidget" )
 		self.setHorizontalScrollBarPolicy( QtCore.Qt.ScrollBarAlwaysOff )
@@ -222,7 +223,7 @@ class _GLGraphicsView( QtGui.QGraphicsView ) :
 			# hid in our constructor.
 			self.viewport().show()
 
-		return QtGui.QGraphicsView.event( self, event )
+		return QtWidgets.QGraphicsView.event( self, event )
 
 	def resizeEvent( self, event ) :
 
@@ -262,11 +263,11 @@ class _GLGraphicsView( QtGui.QGraphicsView ) :
 		# passes unused events to QFrame, bypassing QAbstractScrollArea.
 
 		if self.scene() is not None and self.isInteractive() :
-			QtGui.QApplication.sendEvent( self.scene(), event )
+			QtWidgets.QApplication.sendEvent( self.scene(), event )
 			if event.isAccepted() :
 				return
 
-		QtGui.QFrame.keyPressEvent( self, event )
+		QtWidgets.QFrame.keyPressEvent( self, event )
 
 	# We keep a single hidden widget which owns the texture and display lists
 	# and then share those with all the widgets we really want to make.
@@ -345,13 +346,13 @@ class _GLGraphicsView( QtGui.QGraphicsView ) :
 		# Cortex version.
 		return QtOpenGL.QGLWidget( format, shareWidget = GafferUI._qtObject( IECoreHoudini.sharedGLWidget(), QtOpenGL.QGLWidget ) )
 
-class _GLGraphicsScene( QtGui.QGraphicsScene ) :
+class _GLGraphicsScene( QtWidgets.QGraphicsScene ) :
 
 	__Overlay = collections.namedtuple( "__Overlay", [ "widget", "proxy" ] )
 
 	def __init__( self, parent, backgroundDrawFunction ) :
 
-		QtGui.QGraphicsScene.__init__( self, parent )
+		QtWidgets.QGraphicsScene.__init__( self, parent )
 
 		self.__backgroundDrawFunction = backgroundDrawFunction
 		self.sceneRectChanged.connect( self.__sceneRectChanged )
@@ -363,7 +364,7 @@ class _GLGraphicsScene( QtGui.QGraphicsScene ) :
 		if widget._qtWidget().layout() is not None :
 			# removing the size constraint is necessary to keep the widget the
 			# size we tell it to be in __updateItemGeometry.
-			widget._qtWidget().layout().setSizeConstraint( QtGui.QLayout.SetNoConstraint )
+			widget._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetNoConstraint )
 
 		proxy = _OverlayProxyWidget()
 		proxy.setWidget( widget._qtWidget() )
@@ -406,11 +407,11 @@ class _GLGraphicsScene( QtGui.QGraphicsScene ) :
 # bounds of its child widgets. This allows our overlays to
 # pass through events in the regions where there isn't a
 # child widget.
-class _OverlayProxyWidget( QtGui.QGraphicsProxyWidget ) :
+class _OverlayProxyWidget( QtWidgets.QGraphicsProxyWidget ) :
 
 	def __init__( self ) :
 
-		QtGui.QGraphicsProxyWidget.__init__( self )
+		QtWidgets.QGraphicsProxyWidget.__init__( self )
 
 	def shape( self ) :
 

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -44,19 +44,18 @@ import collections
 logging.getLogger( "OpenGL" ).setLevel( logging.WARNING )
 
 import IECore
+import IECoreGL
 
 import Gaffer
 import GafferUI
 import _GafferUI
 
-# import lazily to improve startup of apps which don't use GL functionality
-GL = Gaffer.lazyImport( "OpenGL.GL" )
-IECoreGL = Gaffer.lazyImport( "IECoreGL" )
+import OpenGL.GL as GL
 
 from Qt import QtCore
 from Qt import QtGui
 from Qt import QtWidgets
-QtOpenGL = GafferUI._qtImport( "QtOpenGL", lazy=True )
+from Qt import QtOpenGL
 
 ## The GLWidget is a base class for all widgets which wish to draw using OpenGL.
 # Derived classes override the _draw() method to achieve this.

--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -47,7 +47,7 @@ GL = Gaffer.lazyImport( "OpenGL.GL" )
 IECoreGL = Gaffer.lazyImport( "IECoreGL" )
 
 QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## The GadgetWidget class provides a means of
 # hosting a Gadget within a Widget based interface.
@@ -138,7 +138,7 @@ class GadgetWidget( GafferUI.GLWidget ) :
 
 	def __enter( self, widget ) :
 
-		if not isinstance( QtGui.QApplication.focusWidget(), ( QtGui.QLineEdit, QtGui.QPlainTextEdit ) ) :
+		if not isinstance( QtWidgets.QApplication.focusWidget(), ( QtWidgets.QLineEdit, QtWidgets.QPlainTextEdit ) ) :
 			self._qtWidget().setFocus()
 
 	def __leave( self, widget ) :
@@ -296,7 +296,7 @@ class _EventFilter( QtCore.QObject ) :
 				)
 			 )
 
-			QtGui.QToolTip.showText( qEvent.globalPos(), toolTip, qObject )
+			QtWidgets.QToolTip.showText( qEvent.globalPos(), toolTip, qObject )
 
 			return True
 

--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -46,8 +46,8 @@ import GafferUI
 GL = Gaffer.lazyImport( "OpenGL.GL" )
 IECoreGL = Gaffer.lazyImport( "IECoreGL" )
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtWidgets
 
 ## The GadgetWidget class provides a means of
 # hosting a Gadget within a Widget based interface.

--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -38,13 +38,12 @@
 from __future__ import with_statement
 
 import IECore
+import IECoreGL
 
 import Gaffer
 import GafferUI
 
-# import lazily to improve startup of apps which don't use GL functionality
-GL = Gaffer.lazyImport( "OpenGL.GL" )
-IECoreGL = Gaffer.lazyImport( "IECoreGL" )
+import OpenGL.GL as GL
 
 from Qt import QtCore
 from Qt import QtWidgets
@@ -61,11 +60,6 @@ class GadgetWidget( GafferUI.GLWidget ) :
 		GafferUI.GLWidget.__init__( self, bufferOptions, **kw )
 
 		self._qtWidget().setFocusPolicy( QtCore.Qt.ClickFocus )
-
-		# Force the IECoreGL lazy loading to kick in /now/. Otherwise we can get IECoreGL objects
-		# being returned from the GafferUIBindings without the appropriate boost::python converters
-		# having been registered first.
-		IECoreGL.Renderer
 
 		self.__requestedDepthBuffer = self.BufferOptions.Depth in bufferOptions
 

--- a/python/GafferUI/GridContainer.py
+++ b/python/GafferUI/GridContainer.py
@@ -39,7 +39,7 @@ import IECore
 import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## The GridContainer holds a series of Widgets in a grid format, and provides
 # indexing using python's multidimensional array syntax to complement the list
@@ -59,12 +59,12 @@ class GridContainer( GafferUI.ContainerWidget ) :
 
 	def __init__( self, spacing=0, borderWidth=0, **kw ) :
 
-		GafferUI.ContainerWidget.__init__( self, QtGui.QWidget(), **kw )
+		GafferUI.ContainerWidget.__init__( self, QtWidgets.QWidget(), **kw )
 
 		self.__qtLayout = _GridLayout( self._qtWidget() )
 		self.__qtLayout.setSpacing( spacing )
 		self.__qtLayout.setContentsMargins( borderWidth, borderWidth, borderWidth, borderWidth )
-		self.__qtLayout.setSizeConstraint( QtGui.QLayout.SetMinAndMaxSize )
+		self.__qtLayout.setSizeConstraint( QtWidgets.QLayout.SetMinAndMaxSize )
 
 		self.__widgets = set()
 
@@ -227,15 +227,15 @@ class GridContainer( GafferUI.ContainerWidget ) :
 
 # Private implementation. A QGridLayout derived class which fixes problems
 # whereby maximumSize() would come out less than sizeHint().
-class _GridLayout( QtGui.QGridLayout ) :
+class _GridLayout( QtWidgets.QGridLayout ) :
 
 	def __init__( self, parent ) :
 
-		QtGui.QGridLayout.__init__( self, parent )
+		QtWidgets.QGridLayout.__init__( self, parent )
 
 	def maximumSize( self ) :
 
-		ms = QtGui.QGridLayout.maximumSize( self )
-		sh = QtGui.QGridLayout.sizeHint( self )
+		ms = QtWidgets.QGridLayout.maximumSize( self )
+		sh = QtWidgets.QGridLayout.sizeHint( self )
 
 		return QtCore.QSize( max( ms.width(), sh.width() ), max( ms.height(), sh.height() ) )

--- a/python/GafferUI/GridContainer.py
+++ b/python/GafferUI/GridContainer.py
@@ -38,8 +38,8 @@ import IECore
 
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtWidgets
 
 ## The GridContainer holds a series of Widgets in a grid format, and provides
 # indexing using python's multidimensional array syntax to complement the list

--- a/python/GafferUI/Image.py
+++ b/python/GafferUI/Image.py
@@ -40,9 +40,9 @@ import IECore
 
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 ## The Image widget displays an image. This can be specified
 # as either a filename, in which case the image is loaded using

--- a/python/GafferUI/Image.py
+++ b/python/GafferUI/Image.py
@@ -42,6 +42,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## The Image widget displays an image. This can be specified
 # as either a filename, in which case the image is loaded using
@@ -50,11 +51,11 @@ class Image( GafferUI.Widget ) :
 
 	def __init__( self, imagePrimitiveOrFileName, **kw ) :
 
-		GafferUI.Widget.__init__( self, QtGui.QLabel(), **kw )
+		GafferUI.Widget.__init__( self, QtWidgets.QLabel(), **kw )
 
 		# by default the widget would accept both shrinking and growing, but we'd rather it just stubbornly stayed
 		# the same size.
-		self._qtWidget().setSizePolicy( QtGui.QSizePolicy( QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed ) )
+		self._qtWidget().setSizePolicy( QtWidgets.QSizePolicy( QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed ) )
 
 		if isinstance( imagePrimitiveOrFileName, basestring ) :
 			pixmap = self._qtPixmapFromFile( str( imagePrimitiveOrFileName ) )
@@ -74,17 +75,17 @@ class Image( GafferUI.Widget ) :
 
 		pixmap = self._qtWidget().pixmap()
 
-		graphicsScene = QtGui.QGraphicsScene()
+		graphicsScene = QtWidgets.QGraphicsScene()
 		pixmapItem = graphicsScene.addPixmap( pixmap )
 		pixmapItem.setVisible( True )
 
-		effect = QtGui.QGraphicsColorizeEffect()
+		effect = QtWidgets.QGraphicsColorizeEffect()
 		effect.setColor( QtGui.QColor( 119, 156, 189, 255 ) )
 		effect.setStrength( 0.85 )
 		pixmapItem.setGraphicsEffect( effect )
 		pixmapItem.setShapeMode( pixmapItem.BoundingRectShape )
 
-		graphicsView = QtGui.QGraphicsView()
+		graphicsView = QtWidgets.QGraphicsView()
 		graphicsView.setScene( graphicsScene )
 
 		image = QtGui.QImage(

--- a/python/GafferUI/Label.py
+++ b/python/GafferUI/Label.py
@@ -38,7 +38,7 @@
 import Gaffer
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 QtCore = GafferUI._qtImport( "QtCore" )
 
 class Label( GafferUI.Widget ) :
@@ -49,13 +49,13 @@ class Label( GafferUI.Widget ) :
 
 	def __init__( self, text="", horizontalAlignment=HorizontalAlignment.Left, verticalAlignment=VerticalAlignment.Center, **kw ) :
 
-		GafferUI.Widget.__init__( self, QtGui.QLabel( text ), **kw )
+		GafferUI.Widget.__init__( self, QtWidgets.QLabel( text ), **kw )
 
 		# by default the widget would accept both shrinking and growing, but we'd rather it just stubbornly stayed
 		# the same size. it's particularly important that it doesn't accept growth vertically as then vertical ListContainers
 		# don't shrink properly when a child is hidden or shrunk - instead the container would distribute the extra height
 		# among all the labels.
-		self._qtWidget().setSizePolicy( QtGui.QSizePolicy( QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed ) )
+		self._qtWidget().setSizePolicy( QtWidgets.QSizePolicy( QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed ) )
 
 		self.setAlignment( horizontalAlignment, verticalAlignment )
 

--- a/python/GafferUI/Label.py
+++ b/python/GafferUI/Label.py
@@ -38,8 +38,8 @@
 import Gaffer
 import GafferUI
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
-QtCore = GafferUI._qtImport( "QtCore" )
+from Qt import QtWidgets
+from Qt import QtCore
 
 class Label( GafferUI.Widget ) :
 

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -37,7 +37,7 @@
 import Gaffer
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## A simple PlugValueWidget which just displays the name of the plug,
 # with the popup action menu for the plug.
@@ -49,11 +49,11 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, horizontalAlignment=GafferUI.Label.HorizontalAlignment.Left, verticalAlignment=GafferUI.Label.VerticalAlignment.Center, **kw ) :
 
-		GafferUI.PlugValueWidget.__init__( self, QtGui.QWidget(), plug, **kw )
+		GafferUI.PlugValueWidget.__init__( self, QtWidgets.QWidget(), plug, **kw )
 
-		layout = QtGui.QHBoxLayout()
+		layout = QtWidgets.QHBoxLayout()
 		layout.setContentsMargins( 0, 0, 0, 0 )
-		layout.setSizeConstraint( QtGui.QLayout.SetMinAndMaxSize )
+		layout.setSizeConstraint( QtWidgets.QLayout.SetMinAndMaxSize )
 		self._qtWidget().setLayout( layout )
 
 		self.__label = GafferUI.NameLabel(

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -37,7 +37,7 @@
 import Gaffer
 import GafferUI
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtWidgets
 
 ## A simple PlugValueWidget which just displays the name of the plug,
 # with the popup action menu for the plug.

--- a/python/GafferUI/ListContainer.py
+++ b/python/GafferUI/ListContainer.py
@@ -38,7 +38,7 @@
 import IECore
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 QtCore = GafferUI._qtImport( "QtCore" )
 
 ## The ListContainer holds a series of Widgets either in a column or a row.
@@ -51,16 +51,16 @@ class ListContainer( GafferUI.ContainerWidget ) :
 
 	def __init__( self, orientation=Orientation.Vertical, spacing=0, borderWidth=0, **kw ) :
 
-		GafferUI.ContainerWidget.__init__( self, QtGui.QWidget(), **kw )
+		GafferUI.ContainerWidget.__init__( self, QtWidgets.QWidget(), **kw )
 
 		if orientation==self.Orientation.Vertical :
-			self.__qtLayout = QtGui.QVBoxLayout()
+			self.__qtLayout = QtWidgets.QVBoxLayout()
 		else :
-			self.__qtLayout = QtGui.QHBoxLayout()
+			self.__qtLayout = QtWidgets.QHBoxLayout()
 
 		self.__qtLayout.setSpacing( spacing )
 		self.__qtLayout.setContentsMargins( borderWidth, borderWidth, borderWidth, borderWidth )
-		self.__qtLayout.setSizeConstraint( QtGui.QLayout.SetMinAndMaxSize )
+		self.__qtLayout.setSizeConstraint( QtWidgets.QLayout.SetMinAndMaxSize )
 
 		self._qtWidget().setLayout( self.__qtLayout )
 

--- a/python/GafferUI/ListContainer.py
+++ b/python/GafferUI/ListContainer.py
@@ -38,8 +38,8 @@
 import IECore
 import GafferUI
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
-QtCore = GafferUI._qtImport( "QtCore" )
+from Qt import QtWidgets
+from Qt import QtCore
 
 ## The ListContainer holds a series of Widgets either in a column or a row.
 # It attempts to provide a list like interface for manipulation of the widgets.

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -48,6 +48,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class Menu( GafferUI.Widget ) :
 
@@ -195,11 +196,11 @@ class Menu( GafferUI.Widget ) :
 			self.__initSearch( self._qtWidget().__definition )
 
 			# Searchable menus require an extra submenu to display the search results.
-			searchWidget = QtGui.QWidgetAction( self._qtWidget() )
+			searchWidget = QtWidgets.QWidgetAction( self._qtWidget() )
 			searchWidget.setObjectName( "GafferUI.Menu.__searchWidget" )
 			self.__searchMenu = _Menu( self._qtWidget(), "" )
 			self.__searchMenu.aboutToShow.connect( Gaffer.WeakMethod( self.__searchMenuShow ) )
-			self.__searchLine = QtGui.QLineEdit()
+			self.__searchLine = QtWidgets.QLineEdit()
 			self.__searchLine.textEdited.connect( Gaffer.WeakMethod( self.__updateSearchMenu ) )
 			self.__searchLine.returnPressed.connect( Gaffer.WeakMethod( self.__searchReturnPressed ) )
 			self.__searchLine.setObjectName( "search" )
@@ -288,10 +289,10 @@ class Menu( GafferUI.Widget ) :
 		# add a title if required.
 		if self.__title is not None and qtMenu is self._qtWidget() :
 
-			titleWidget = QtGui.QLabel( self.__title )
+			titleWidget = QtWidgets.QLabel( self.__title )
 			titleWidget.setIndent( 0 )
 			titleWidget.setObjectName( "gafferMenuTitle" )
-			titleWidgetAction = QtGui.QWidgetAction( qtMenu )
+			titleWidgetAction = QtWidgets.QWidgetAction( qtMenu )
 			titleWidgetAction.setDefaultWidget( titleWidget )
 			titleWidgetAction.setEnabled( False )
 			qtMenu.insertAction( qtMenu.actions()[0], titleWidgetAction )
@@ -299,9 +300,9 @@ class Menu( GafferUI.Widget ) :
 			# qt stylesheets ignore the padding-bottom for menus and
 			# use padding-top instead. we need padding-top to be 0 when
 			# we have a title, so we have to fake the bottom padding like so.
-			spacerWidget = QtGui.QWidget()
+			spacerWidget = QtWidgets.QWidget()
 			spacerWidget.setFixedSize( 5, 5 )
-			spacerWidgetAction = QtGui.QWidgetAction( qtMenu )
+			spacerWidgetAction = QtWidgets.QWidgetAction( qtMenu )
 			spacerWidgetAction.setDefaultWidget( spacerWidget )
 			spacerWidgetAction.setEnabled( False )
 			qtMenu.addAction( spacerWidgetAction )
@@ -312,7 +313,7 @@ class Menu( GafferUI.Widget ) :
 		with IECore.IgnoredExceptions( AttributeError ) :
 			label = item.label
 
-		qtAction = QtGui.QAction( label, parent )
+		qtAction = QtWidgets.QAction( label, parent )
 		qtAction.__item = item
 
 		if item.checkBox is not None :
@@ -505,13 +506,13 @@ class Menu( GafferUI.Widget ) :
 
 		self._qtWidget().hide()
 
-class _Menu( QtGui.QMenu ) :
+class _Menu( QtWidgets.QMenu ) :
 
 	KeyboardMode = IECore.Enum.create( "Grab", "Close", "Forward" )
 
 	def __init__( self, parent, title=None ) :
 
-		QtGui.QMenu.__init__( self, parent )
+		QtWidgets.QMenu.__init__( self, parent )
 
 		if title is not None :
 			self.setTitle( title )
@@ -523,10 +524,10 @@ class _Menu( QtGui.QMenu ) :
 		if qEvent.type() == QtCore.QEvent.ToolTip :
 			action = self.actionAt( qEvent.pos() )
 			if action and action.statusTip() :
-				QtGui.QToolTip.showText( qEvent.globalPos(), action.statusTip(), self )
+				QtWidgets.QToolTip.showText( qEvent.globalPos(), action.statusTip(), self )
 				return True
 
-		return QtGui.QMenu.event( self, qEvent )
+		return QtWidgets.QMenu.event( self, qEvent )
 
 	def keyPressEvent( self, qEvent ) :
 
@@ -547,9 +548,9 @@ class _Menu( QtGui.QMenu ) :
 					self.hide()
 
 				# pass the event on to the rightful recipient
-				app = QtGui.QApplication.instance()
+				app = QtWidgets.QApplication.instance()
 				if app.focusWidget() != self :
 					app.sendEvent( app.focusWidget(), qEvent )
 					return
 
-		QtGui.QMenu.keyPressEvent( self, qEvent )
+		QtWidgets.QMenu.keyPressEvent( self, qEvent )

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -46,9 +46,9 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 class Menu( GafferUI.Widget ) :
 

--- a/python/GafferUI/MenuBar.py
+++ b/python/GafferUI/MenuBar.py
@@ -40,9 +40,9 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 class MenuBar( GafferUI.Widget ) :
 

--- a/python/GafferUI/MenuBar.py
+++ b/python/GafferUI/MenuBar.py
@@ -42,13 +42,14 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class MenuBar( GafferUI.Widget ) :
 
 	def __init__( self, definition, **kw ) :
 
-		menuBar = QtGui.QMenuBar()
-		menuBar.setSizePolicy( QtGui.QSizePolicy( QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Fixed ) )
+		menuBar = QtWidgets.QMenuBar()
+		menuBar.setSizePolicy( QtWidgets.QSizePolicy( QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed ) )
 		menuBar.setNativeMenuBar( False )
 
 		GafferUI.Widget.__init__( self, menuBar, **kw )

--- a/python/GafferUI/MessageWidget.py
+++ b/python/GafferUI/MessageWidget.py
@@ -43,6 +43,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## The MessageWidget class displays a log of messages in the format specified by
 # IECore MessageHandlers.
@@ -153,7 +154,7 @@ class MessageWidget( GafferUI.Widget ) :
 					# there some way we can update the UI without triggering arbitrary
 					# code evaluation?
 					self._pushParent( None )
-					QtGui.QApplication.instance().processEvents( QtCore.QEventLoop.ExcludeUserInputEvents )
+					QtWidgets.QApplication.instance().processEvents( QtCore.QEventLoop.ExcludeUserInputEvents )
 					self._popParent()
 				finally :
 					self.__processingEvents = False

--- a/python/GafferUI/MessageWidget.py
+++ b/python/GafferUI/MessageWidget.py
@@ -41,9 +41,9 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 ## The MessageWidget class displays a log of messages in the format specified by
 # IECore MessageHandlers.

--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -40,9 +40,9 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
-QtCore = GafferUI._qtImport( "QtCore" )
+from Qt import QtGui
+from Qt import QtWidgets
+from Qt import QtCore
 
 class MultiLineTextWidget( GafferUI.Widget ) :
 

--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -41,6 +41,7 @@ import Gaffer
 import GafferUI
 
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 QtCore = GafferUI._qtImport( "QtCore" )
 
 class MultiLineTextWidget( GafferUI.Widget ) :
@@ -355,10 +356,10 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 
 		self.insertText( self.__dropText( event.data ) )
 
-class _PlainTextEdit( QtGui.QPlainTextEdit ) :
+class _PlainTextEdit( QtWidgets.QPlainTextEdit ) :
 
 	def __init__( self, parent = None ) :
-		QtGui.QPlainTextEdit.__init__( self, parent )
+		QtWidgets.QPlainTextEdit.__init__( self, parent )
 		self.__fixedLineHeight = None
 		self.__widgetFullyBuilt = False
 
@@ -368,7 +369,7 @@ class _PlainTextEdit( QtGui.QPlainTextEdit ) :
 
 		self.setSizePolicy(
 			self.sizePolicy().horizontalPolicy(),
-			QtGui.QSizePolicy.Expanding if self.__fixedLineHeight is None else QtGui.QSizePolicy.Fixed
+			QtWidgets.QSizePolicy.Expanding if self.__fixedLineHeight is None else QtWidgets.QSizePolicy.Fixed
 		)
 
 		self.updateGeometry()
@@ -398,13 +399,13 @@ class _PlainTextEdit( QtGui.QPlainTextEdit ) :
 
 	def sizeHint( self ) :
 
-		size = QtGui.QPlainTextEdit.sizeHint( self )
+		size = QtWidgets.QPlainTextEdit.sizeHint( self )
 
 		return self.__computeHeight( size )
 
 	def minimumSizeHint( self ) :
 
-		size = QtGui.QPlainTextEdit.minimumSizeHint( self )
+		size = QtWidgets.QPlainTextEdit.minimumSizeHint( self )
 
 		return self.__computeHeight( size )
 
@@ -418,7 +419,7 @@ class _PlainTextEdit( QtGui.QPlainTextEdit ) :
 			event.accept()
 			return True
 
-		return QtGui.QPlainTextEdit.event( self, event )
+		return QtWidgets.QPlainTextEdit.event( self, event )
 
 class _FocusOutEventFilter( QtCore.QObject ) :
 

--- a/python/GafferUI/NameWidget.py
+++ b/python/GafferUI/NameWidget.py
@@ -42,8 +42,8 @@ import re
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
+from Qt import QtCore
+from Qt import QtGui
 
 class NameWidget( GafferUI.TextWidget ) :
 

--- a/python/GafferUI/NodeSetEditor.py
+++ b/python/GafferUI/NodeSetEditor.py
@@ -40,7 +40,7 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
+from Qt import QtCore
 
 ## The NodeSetEditor is a base class for all Editors which focus their
 # editing on a subset of nodes beneath a ScriptNode. This set defaults

--- a/python/GafferUI/NotificationMessageHandler.py
+++ b/python/GafferUI/NotificationMessageHandler.py
@@ -39,7 +39,7 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+from Qt import QtGui
 
 class NotificationMessageHandler( IECore.MessageHandler ) :
 

--- a/python/GafferUI/NumericSlider.py
+++ b/python/GafferUI/NumericSlider.py
@@ -42,7 +42,7 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+from Qt import QtGui
 
 ## The NumericSlider extends the slider class to provide a mapping between the positions
 # and a range defined by a minimum and maximum value.

--- a/python/GafferUI/NumericWidget.py
+++ b/python/GafferUI/NumericWidget.py
@@ -42,7 +42,7 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+from Qt import QtGui
 
 ## \todo Fix bug when pressing up arrow with cursor to left of minus sign
 class NumericWidget( GafferUI.TextWidget ) :

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -47,6 +47,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## The PathListingWidget displays the contents of a Path, updating the Path to represent the
 # current directory as the user navigates around. It supports both a list and a tree view,
@@ -98,7 +99,7 @@ class PathListingWidget( GafferUI.Widget ) :
 
 		self._qtWidget().setAlternatingRowColors( True )
 		self._qtWidget().setUniformRowHeights( True )
-		self._qtWidget().setEditTriggers( QtGui.QTreeView.NoEditTriggers )
+		self._qtWidget().setEditTriggers( QtWidgets.QTreeView.NoEditTriggers )
 		self._qtWidget().activated.connect( Gaffer.WeakMethod( self.__activated ) )
 		self._qtWidget().header().setMovable( False )
 		self._qtWidget().header().setSortIndicator( 0, QtCore.Qt.AscendingOrder )
@@ -116,7 +117,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		self.__selectionChangedSlot = Gaffer.WeakMethod( self.__selectionChanged )
 		self._qtWidget().selectionModel().selectionChanged.connect( self.__selectionChangedSlot )
 		if allowMultipleSelection :
-			self._qtWidget().setSelectionMode( QtGui.QAbstractItemView.ExtendedSelection )
+			self._qtWidget().setSelectionMode( QtWidgets.QAbstractItemView.ExtendedSelection )
 
 		self.__pathSelectedSignal = GafferUI.WidgetSignal()
 		self.__selectionChangedSignal = GafferUI.WidgetSignal()
@@ -296,7 +297,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		if isinstance( pathOrPaths, Gaffer.Path ) :
 			paths = [ pathOrPaths ]
 
-		if self._qtWidget().selectionMode() != QtGui.QAbstractItemView.ExtendedSelection :
+		if self._qtWidget().selectionMode() != QtWidgets.QAbstractItemView.ExtendedSelection :
 			assert( len( paths ) <= 1 )
 
 		selectionModel = self._qtWidget().selectionModel()
@@ -550,7 +551,7 @@ class PathListingWidget( GafferUI.Widget ) :
 
 # Private implementation - a QTreeView with some specific size behaviour, and shift
 # clicking for recursive expand/collapse.
-class _TreeView( QtGui.QTreeView ) :
+class _TreeView( QtWidgets.QTreeView ) :
 
 	# This signal is called when some items are either collapsed or
 	# expanded. It can be preferable to use this over the expanded or
@@ -560,7 +561,7 @@ class _TreeView( QtGui.QTreeView ) :
 
 	def __init__( self ) :
 
-		QtGui.QTreeView.__init__( self )
+		QtWidgets.QTreeView.__init__( self )
 
 		self.setHorizontalScrollBarPolicy( QtCore.Qt.ScrollBarAlwaysOff )
 
@@ -580,7 +581,7 @@ class _TreeView( QtGui.QTreeView ) :
 
 	def setModel( self, model ) :
 
-		QtGui.QTreeView.setModel( self, model )
+		QtWidgets.QTreeView.setModel( self, model )
 
 		model.modelReset.connect( self.__recalculateColumnSizes )
 
@@ -608,7 +609,7 @@ class _TreeView( QtGui.QTreeView ) :
 
 	def sizeHint( self ) :
 
-		result = QtGui.QTreeView.sizeHint( self )
+		result = QtWidgets.QTreeView.sizeHint( self )
 
 		margins = self.contentsMargins()
 		result.setWidth( self.header().length() + margins.left() + margins.right() )
@@ -624,14 +625,14 @@ class _TreeView( QtGui.QTreeView ) :
 				event.accept()
 				return True
 
-		return QtGui.QTreeView.event( self, event )
+		return QtWidgets.QTreeView.event( self, event )
 
 	def mousePressEvent( self, event ) :
 
 		# we store the modifiers so that we can turn single
 		# expands/collapses into recursive ones in __propagateExpanded.
 		self.__currentEventModifiers = event.modifiers()
-		QtGui.QTreeView.mousePressEvent( self, event )
+		QtWidgets.QTreeView.mousePressEvent( self, event )
 		self.__currentEventModifiers = QtCore.Qt.NoModifier
 
 	def mouseReleaseEvent( self, event ) :
@@ -639,13 +640,13 @@ class _TreeView( QtGui.QTreeView ) :
 		# we store the modifiers so that we can turn single
 		# expands/collapses into recursive ones in __propagateExpanded.
 		self.__currentEventModifiers = event.modifiers()
-		QtGui.QTreeView.mouseReleaseEvent( self, event )
+		QtWidgets.QTreeView.mouseReleaseEvent( self, event )
 		self.__currentEventModifiers = QtCore.Qt.NoModifier
 
 	def mouseDoubleClickEvent( self, event ) :
 
 		self.__currentEventModifiers = event.modifiers()
-		QtGui.QTreeView.mouseDoubleClickEvent( self, event )
+		QtWidgets.QTreeView.mouseDoubleClickEvent( self, event )
 		self.__currentEventModifiers = QtCore.Qt.NoModifier
 
 	def __recalculateColumnSizes( self ) :

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -45,6 +45,7 @@ import Gaffer
 import _GafferUI
 import GafferUI
 
+import Qt
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
 QtWidgets = GafferUI._qtImport( "QtWidgets" )
@@ -101,7 +102,12 @@ class PathListingWidget( GafferUI.Widget ) :
 		self._qtWidget().setUniformRowHeights( True )
 		self._qtWidget().setEditTriggers( QtWidgets.QTreeView.NoEditTriggers )
 		self._qtWidget().activated.connect( Gaffer.WeakMethod( self.__activated ) )
-		self._qtWidget().header().setMovable( False )
+
+		if Qt.__binding__ in ( "PySide2", "PyQt5" ) :
+			self._qtWidget().header().setSectionsMovable( False )
+		else :
+			self._qtWidget().header().setMovable( False )
+
 		self._qtWidget().header().setSortIndicator( 0, QtCore.Qt.AscendingOrder )
 		self._qtWidget().setSortingEnabled( True )
 
@@ -112,7 +118,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		_GafferUI._pathListingWidgetUpdateModel( GafferUI._qtAddress( self._qtWidget() ), None )
 		_GafferUI._pathListingWidgetSetColumns( GafferUI._qtAddress( self._qtWidget() ), columns )
 
-		self.__selectionModel = QtGui.QItemSelectionModel( self._qtWidget().model() )
+		self.__selectionModel = QtCore.QItemSelectionModel( self._qtWidget().model() )
 		self._qtWidget().setSelectionModel( self.__selectionModel )
 		self.__selectionChangedSlot = Gaffer.WeakMethod( self.__selectionChanged )
 		self._qtWidget().selectionModel().selectionChanged.connect( self.__selectionChangedSlot )

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -46,9 +46,9 @@ import _GafferUI
 import GafferUI
 
 import Qt
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 ## The PathListingWidget displays the contents of a Path, updating the Path to represent the
 # current directory as the user navigates around. It supports both a list and a tree view,

--- a/python/GafferUI/PathWidget.py
+++ b/python/GafferUI/PathWidget.py
@@ -45,7 +45,7 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
+from Qt import QtCore
 
 class PathWidget( GafferUI.TextWidget ) :
 

--- a/python/GafferUI/Playback.py
+++ b/python/GafferUI/Playback.py
@@ -41,7 +41,7 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
+from Qt import QtCore
 
 ## The Playback class controls a Context to facilitate animation
 # playback. It provides methods for starting and stopping playback,

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -43,7 +43,7 @@ import collections
 import Gaffer
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## A class for laying out widgets to represent all the plugs held on a particular parent.
 #
@@ -677,7 +677,7 @@ class _CollapsibleLayout( _Layout ) :
 				collapsible.setCornerWidget( GafferUI.Label(), True )
 				## \todo This is fighting the default sizing applied in the Label constructor. Really we need a standard
 				# way of controlling size behaviours for all widgets in the public API.
-				collapsible.getCornerWidget()._qtWidget().setSizePolicy( QtGui.QSizePolicy.Ignored, QtGui.QSizePolicy.Fixed )
+				collapsible.getCornerWidget()._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Ignored, QtWidgets.QSizePolicy.Fixed )
 
 				if subsection.restoreState( "collapsed" ) is False :
 					collapsible.setCollapsed( False )

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -43,7 +43,7 @@ import collections
 import Gaffer
 import GafferUI
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtWidgets
 
 ## A class for laying out widgets to represent all the plugs held on a particular parent.
 #

--- a/python/GafferUI/PlugWidget.py
+++ b/python/GafferUI/PlugWidget.py
@@ -40,7 +40,7 @@ import warnings
 import Gaffer
 import GafferUI
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtWidgets
 
 ## The PlugWidget combines a LabelPlugValueWidget with a second PlugValueWidget
 ## suitable for editing the plug.

--- a/python/GafferUI/PlugWidget.py
+++ b/python/GafferUI/PlugWidget.py
@@ -40,7 +40,7 @@ import warnings
 import Gaffer
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## The PlugWidget combines a LabelPlugValueWidget with a second PlugValueWidget
 ## suitable for editing the plug.
@@ -52,12 +52,12 @@ class PlugWidget( GafferUI.Widget ) :
 
 	def __init__( self, plugOrWidget, label=None, description=None, **kw ) :
 
-		GafferUI.Widget.__init__( self, QtGui.QWidget(), **kw )
+		GafferUI.Widget.__init__( self, QtWidgets.QWidget(), **kw )
 
-		layout = QtGui.QHBoxLayout()
+		layout = QtWidgets.QHBoxLayout()
 		layout.setContentsMargins( 0, 0, 0, 0 )
 		layout.setSpacing( 4 )
-		layout.setSizeConstraint( QtGui.QLayout.SetMinAndMaxSize )
+		layout.setSizeConstraint( QtWidgets.QLayout.SetMinAndMaxSize )
 		self._qtWidget().setLayout( layout )
 
 		if isinstance( plugOrWidget, Gaffer.Plug ) :

--- a/python/GafferUI/PopupWindow.py
+++ b/python/GafferUI/PopupWindow.py
@@ -37,9 +37,9 @@
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 class PopupWindow( GafferUI.Window ) :
 

--- a/python/GafferUI/PopupWindow.py
+++ b/python/GafferUI/PopupWindow.py
@@ -39,6 +39,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class PopupWindow( GafferUI.Window ) :
 
@@ -168,10 +169,10 @@ class PopupWindow( GafferUI.Window ) :
 			return
 
 		if self.__cursor is not None :
-			QtGui.QApplication.restoreOverrideCursor()
+			QtWidgets.QApplication.restoreOverrideCursor()
 
 		if cursor is not None :
-			QtGui.QApplication.setOverrideCursor( QtGui.QCursor( cursor ) )
+			QtWidgets.QApplication.setOverrideCursor( QtGui.QCursor( cursor ) )
 
 		self.__cursor = cursor
 

--- a/python/GafferUI/ProgressBar.py
+++ b/python/GafferUI/ProgressBar.py
@@ -36,7 +36,7 @@
 
 import GafferUI
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtWidgets
 
 class ProgressBar( GafferUI.Widget ) :
 

--- a/python/GafferUI/ProgressBar.py
+++ b/python/GafferUI/ProgressBar.py
@@ -36,13 +36,13 @@
 
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class ProgressBar( GafferUI.Widget ) :
 
 	def __init__( self, progress = 0, range = ( 0, 100 ), text = "%p%", **kw ) :
 
-		GafferUI.Widget.__init__( self, QtGui.QProgressBar(), **kw )
+		GafferUI.Widget.__init__( self, QtWidgets.QProgressBar(), **kw )
 
 		self._qtWidget().setRange( range[0], range[1] )
 

--- a/python/GafferUI/RampPlugValueWidget.py
+++ b/python/GafferUI/RampPlugValueWidget.py
@@ -38,8 +38,8 @@ import Gaffer
 import GafferUI
 import IECore
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
+from Qt import QtCore
+from Qt import QtGui
 
 class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 

--- a/python/GafferUI/ScriptEditor.py
+++ b/python/GafferUI/ScriptEditor.py
@@ -44,7 +44,7 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 QtCore = GafferUI._qtImport( "QtCore" )
 
 ## \todo Custom right click menu with script load, save, execute file, undo, redo etc.
@@ -183,7 +183,7 @@ class ScriptEditor( GafferUI.EditorWidget ) :
 			self.__outputWidget.appendText( output )
 			# update the gui so messages are output as they occur, rather than all getting queued
 			# up till the end.
-			QtGui.QApplication.instance().processEvents( QtCore.QEventLoop.ExcludeUserInputEvents )
+			QtWidgets.QApplication.instance().processEvents( QtCore.QEventLoop.ExcludeUserInputEvents )
 
 GafferUI.EditorWidget.registerType( "ScriptEditor", ScriptEditor )
 
@@ -206,4 +206,4 @@ class _MessageHandler( IECore.MessageHandler ) :
 		self.__textWidget.appendHTML( html )
 		# update the gui so messages are output as they occur, rather than all getting queued
 		# up till the end.
-		QtGui.QApplication.instance().processEvents( QtCore.QEventLoop.ExcludeUserInputEvents )
+		QtWidgets.QApplication.instance().processEvents( QtCore.QEventLoop.ExcludeUserInputEvents )

--- a/python/GafferUI/ScriptEditor.py
+++ b/python/GafferUI/ScriptEditor.py
@@ -44,8 +44,8 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
-QtCore = GafferUI._qtImport( "QtCore" )
+from Qt import QtWidgets
+from Qt import QtCore
 
 ## \todo Custom right click menu with script load, save, execute file, undo, redo etc.
 ## \todo Standard way for users to customise all menus

--- a/python/GafferUI/ScrolledContainer.py
+++ b/python/GafferUI/ScrolledContainer.py
@@ -39,9 +39,9 @@ import IECore
 
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 class ScrolledContainer( GafferUI.ContainerWidget ) :
 

--- a/python/GafferUI/ScrolledContainer.py
+++ b/python/GafferUI/ScrolledContainer.py
@@ -41,6 +41,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class ScrolledContainer( GafferUI.ContainerWidget ) :
 
@@ -129,11 +130,11 @@ class ScrolledContainer( GafferUI.ContainerWidget ) :
 # Private implementation - a QScrollArea derived class which is a bit more
 # forceful aboout claiming size - it always asks for enough to completely show
 # the contained widget.
-class _ScrollArea( QtGui.QScrollArea ) :
+class _ScrollArea( QtWidgets.QScrollArea ) :
 
 	def __init__( self ) :
 
-		QtGui.QScrollArea.__init__( self )
+		QtWidgets.QScrollArea.__init__( self )
 
 		self.__marginLeft = 0
 		self.__marginRight = 0
@@ -142,12 +143,12 @@ class _ScrollArea( QtGui.QScrollArea ) :
 
 	def setWidget( self, widget ) :
 
-		QtGui.QScrollArea.setWidget( self, widget )
+		QtWidgets.QScrollArea.setWidget( self, widget )
 		widget.installEventFilter( self )
 
 	def setViewportMargins( self, left, top, right, bottom ) :
 
-		QtGui.QScrollArea.setViewportMargins( self, left, top, right, bottom )
+		QtWidgets.QScrollArea.setViewportMargins( self, left, top, right, bottom )
 
 		self.__marginLeft = left
 		self.__marginRight = right
@@ -158,7 +159,7 @@ class _ScrollArea( QtGui.QScrollArea ) :
 
 		w = self.widget()
 		if not w :
-			return QtGui.QScrollArea.sizeHint( self )
+			return QtWidgets.QScrollArea.sizeHint( self )
 
 		wSize = w.sizeHint()
 

--- a/python/GafferUI/SelectionMenu.py
+++ b/python/GafferUI/SelectionMenu.py
@@ -40,6 +40,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## \todo Support cascading menus using "/" in labels. Rework API to
 # better match the rest of GafferUI - ditch index based methods, and
@@ -54,7 +55,7 @@ class SelectionMenu( GafferUI.Widget ) :
 
 		warnings.warn( "GafferUI.SelectionMenu is deprecated, use MultiSelectionMenu instead.", DeprecationWarning, 2 )
 
-		GafferUI.Widget.__init__( self, QtGui.QComboBox(), **kw )
+		GafferUI.Widget.__init__( self, QtWidgets.QComboBox(), **kw )
 
 		self._qtWidget().currentIndexChanged.connect( Gaffer.WeakMethod( self.__changed ) )
 		self._qtWidget().activated.connect( Gaffer.WeakMethod( self.__selected ) )
@@ -67,12 +68,12 @@ class SelectionMenu( GafferUI.Widget ) :
 		## \todo When we extend the Style classes to deal with Widgets, this should be
 		# done there. The same code exists in the Button class too.
 		if SelectionMenu.__palette is None :
-			SelectionMenu.__palette = QtGui.QPalette( QtGui.QApplication.instance().palette() )
+			SelectionMenu.__palette = QtGui.QPalette( QtWidgets.QApplication.instance().palette() )
 			SelectionMenu.__palette.setColor( QtGui.QPalette.Disabled, QtGui.QPalette.Light, QtGui.QColor( 0, 0, 0, 0 ) )
 
 		self._qtWidget().setPalette( SelectionMenu.__palette )
 
-		self._qtWidget().setView( QtGui.QListView() )
+		self._qtWidget().setView( QtWidgets.QListView() )
 
 	def selectedSignal( self ):
 		return self.__selectedSignal

--- a/python/GafferUI/SelectionMenu.py
+++ b/python/GafferUI/SelectionMenu.py
@@ -38,9 +38,9 @@ import warnings
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 ## \todo Support cascading menus using "/" in labels. Rework API to
 # better match the rest of GafferUI - ditch index based methods, and

--- a/python/GafferUI/SelectionMenu.py
+++ b/python/GafferUI/SelectionMenu.py
@@ -68,7 +68,7 @@ class SelectionMenu( GafferUI.Widget ) :
 		## \todo When we extend the Style classes to deal with Widgets, this should be
 		# done there. The same code exists in the Button class too.
 		if SelectionMenu.__palette is None :
-			SelectionMenu.__palette = QtGui.QPalette( QtWidgets.QApplication.instance().palette() )
+			SelectionMenu.__palette = QtGui.QPalette( QtWidgets.QApplication.instance().palette( self._qtWidget() ) )
 			SelectionMenu.__palette.setColor( QtGui.QPalette.Disabled, QtGui.QPalette.Light, QtGui.QColor( 0, 0, 0, 0 ) )
 
 		self._qtWidget().setPalette( SelectionMenu.__palette )

--- a/python/GafferUI/ShowURL.py
+++ b/python/GafferUI/ShowURL.py
@@ -37,6 +37,7 @@
 
 import os
 import sys
+import distutils.spawn
 
 import GafferUI
 
@@ -45,7 +46,13 @@ QtGui = GafferUI._qtImport( "QtGui" )
 
 def showURL( url ) :
 
+	opener = None
 	if sys.platform == "darwin" :
-		os.system( "open \"" + url + "\"" )
+		opener = "open"
+	elif "linux" in sys.platform :
+		opener = distutils.spawn.find_executable( "xdg-open" )
+
+	if opener :
+		os.system( "{0} \"{1}\"".format( opener, url ) )
 	else :
 		QtGui.QDesktopServices.openUrl( QtCore.QUrl( url, QtCore.QUrl.TolerantMode ) )

--- a/python/GafferUI/ShowURL.py
+++ b/python/GafferUI/ShowURL.py
@@ -41,8 +41,8 @@ import distutils.spawn
 
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
+from Qt import QtCore
+from Qt import QtGui
 
 def showURL( url ) :
 

--- a/python/GafferUI/Slider.py
+++ b/python/GafferUI/Slider.py
@@ -42,9 +42,9 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 ## The Slider class allows a user to specify a number of positions on a scale of 0.0 at one end
 # of the Widget and 1.0 at the other. Positions off the ends of the widget are mapped

--- a/python/GafferUI/Slider.py
+++ b/python/GafferUI/Slider.py
@@ -44,6 +44,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## The Slider class allows a user to specify a number of positions on a scale of 0.0 at one end
 # of the Widget and 1.0 at the other. Positions off the ends of the widget are mapped
@@ -427,13 +428,13 @@ class Slider( GafferUI.Widget ) :
 		if signal is not None :
 			signal( self, reason )
 
-class _Widget( QtGui.QWidget ) :
+class _Widget( QtWidgets.QWidget ) :
 
 	def __init__( self, parent=None ) :
 
-		QtGui.QWidget.__init__( self, parent )
+		QtWidgets.QWidget.__init__( self, parent )
 
-		self.setSizePolicy( QtGui.QSizePolicy( QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum ) )
+		self.setSizePolicy( QtWidgets.QSizePolicy( QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum ) )
 		self.setFocusPolicy( QtCore.Qt.ClickFocus )
 
 	def sizeHint( self ) :
@@ -477,4 +478,4 @@ class _Widget( QtGui.QWidget ) :
 					event.accept()
 					return True
 
-		return QtGui.QWidget.event( self, event )
+		return QtWidgets.QWidget.event( self, event )

--- a/python/GafferUI/Spacer.py
+++ b/python/GafferUI/Spacer.py
@@ -37,7 +37,7 @@
 
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## \todo Size accessors
 class Spacer( GafferUI.Widget ) :
@@ -46,7 +46,7 @@ class Spacer( GafferUI.Widget ) :
 	# for backwards compatibility for now.
 	def __init__( self, size, maximumSize=None, **kw ) :
 
-		GafferUI.Widget.__init__( self, QtGui.QWidget(), **kw )
+		GafferUI.Widget.__init__( self, QtWidgets.QWidget(), **kw )
 
 		self._qtWidget().setMinimumWidth( size.x )
 		self._qtWidget().setMinimumHeight( size.y )

--- a/python/GafferUI/Spacer.py
+++ b/python/GafferUI/Spacer.py
@@ -37,7 +37,7 @@
 
 import GafferUI
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtWidgets
 
 ## \todo Size accessors
 class Spacer( GafferUI.Widget ) :

--- a/python/GafferUI/SplineWidget.py
+++ b/python/GafferUI/SplineWidget.py
@@ -42,6 +42,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## This Widget simply displays an IECore.Spline object. For representation and editing
 # of SplinePlugs use a SplineEditor instead.
@@ -53,9 +54,9 @@ class SplineWidget( GafferUI.Widget ) :
 
 		# using QFrame rather than QWidget because it supports computing the contentsRect() based on
 		# the stylesheet.
-		GafferUI.Widget.__init__( self, QtGui.QFrame(), **kw )
+		GafferUI.Widget.__init__( self, QtWidgets.QFrame(), **kw )
 
-		self._qtWidget().setSizePolicy( QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding )
+		self._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding )
 		self._qtWidget().setObjectName( "gafferSplineWidget" )
 
 		self.setDrawMode( drawMode )
@@ -114,9 +115,9 @@ class SplineWidget( GafferUI.Widget ) :
 		painter = QtGui.QPainter( self._qtWidget() )
 		painter.setRenderHint( QtGui.QPainter.Antialiasing )
 
-		o = QtGui.QStyleOption()
+		o = QtWidgets.QStyleOption()
 		o.initFrom( self._qtWidget() )
-		self._qtWidget().style().drawPrimitive( QtGui.QStyle.PE_Widget, o, painter, self._qtWidget() )
+		self._qtWidget().style().drawPrimitive( QtWidgets.QStyle.PE_Widget, o, painter, self._qtWidget() )
 
 		if self.__drawMode == self.DrawMode.Ramp :
 			self.__paintRamp( painter )

--- a/python/GafferUI/SplineWidget.py
+++ b/python/GafferUI/SplineWidget.py
@@ -40,9 +40,9 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 ## This Widget simply displays an IECore.Spline object. For representation and editing
 # of SplinePlugs use a SplineEditor instead.

--- a/python/GafferUI/SplineWidget.py
+++ b/python/GafferUI/SplineWidget.py
@@ -145,7 +145,7 @@ class SplineWidget( GafferUI.Widget ) :
 
 		rect = self._qtWidget().contentsRect()
 		brush = QtGui.QBrush( self.__gradientToDraw )
-		brush.setMatrix( QtGui.QMatrix( float( rect.width() ) / numStops, 0, 0, 1, 0, 0 ) )
+		brush.setTransform( QtGui.QTransform( float( rect.width() ) / numStops, 0, 0, 1, 0, 0 ) )
 		painter.fillRect( rect, brush )
 
 	def __paintSplines( self, painter ) :

--- a/python/GafferUI/SplitContainer.py
+++ b/python/GafferUI/SplitContainer.py
@@ -39,8 +39,8 @@ import IECore
 
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtWidgets
 
 ## \todo Support other list operations for child access
 class SplitContainer( GafferUI.ContainerWidget ) :

--- a/python/GafferUI/SplitContainer.py
+++ b/python/GafferUI/SplitContainer.py
@@ -40,7 +40,7 @@ import IECore
 import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## \todo Support other list operations for child access
 class SplitContainer( GafferUI.ContainerWidget ) :
@@ -206,16 +206,16 @@ class SplitContainer( GafferUI.ContainerWidget ) :
 		# stay at a minimum size and then suddenly collapse to nothing when moving the splitter all
 		# the way. we store the original size policy on the widget and reapply it in removeChild().
 		widget.__originalSizePolicy = widget._qtWidget().sizePolicy()
-		widget._qtWidget().setSizePolicy( QtGui.QSizePolicy.Ignored, QtGui.QSizePolicy.Ignored )
+		widget._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Ignored, QtWidgets.QSizePolicy.Ignored )
 
 # We inherit from QSplitter purely so that the handles can be created
 # in Python rather than C++. This seems to help PyQt and PySide in tracking
 # the lifetimes of the splitter and handles.
-class _Splitter( QtGui.QSplitter ) :
+class _Splitter( QtWidgets.QSplitter ) :
 
 	def __init__( self ) :
 
-		QtGui.QSplitter.__init__( self )
+		QtWidgets.QSplitter.__init__( self )
 
 		# There seems to be an odd interaction between this and the stylesheet, and
 		# setting this to the desired size and then using the stylesheet to divide it into
@@ -226,7 +226,7 @@ class _Splitter( QtGui.QSplitter ) :
 
 	def createHandle( self ) :
 
-		return QtGui.QSplitterHandle( self.orientation(), self )
+		return QtWidgets.QSplitterHandle( self.orientation(), self )
 
 class _SizeAnimation( QtCore.QVariantAnimation ) :
 

--- a/python/GafferUI/TabbedContainer.py
+++ b/python/GafferUI/TabbedContainer.py
@@ -40,9 +40,9 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 class TabbedContainer( GafferUI.ContainerWidget ) :
 

--- a/python/GafferUI/TabbedContainer.py
+++ b/python/GafferUI/TabbedContainer.py
@@ -42,6 +42,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class TabbedContainer( GafferUI.ContainerWidget ) :
 
@@ -51,7 +52,7 @@ class TabbedContainer( GafferUI.ContainerWidget ) :
 
 		GafferUI.ContainerWidget.__init__( self, _TabWidget(), **kw )
 
-		self.__tabBar = GafferUI.Widget( QtGui.QTabBar() )
+		self.__tabBar = GafferUI.Widget( QtWidgets.QTabBar() )
 		self.__tabBar._qtWidget().setDrawBase( False )
 		self.__tabBarDragEnterConnection = self.__tabBar.dragEnterSignal().connect( Gaffer.WeakMethod( self.__tabBarDragEnter ) )
 		self.__tabBarDragMoveConnection = self.__tabBar.dragMoveSignal().connect( Gaffer.WeakMethod( self.__tabBarDragMove ) )
@@ -224,7 +225,7 @@ class TabbedContainer( GafferUI.ContainerWidget ) :
 
 		# we delay the tab switch a little to make sure that the user isn't just passing through
 		self.__tabBarDragState = self.__DragState.Waiting
-		QtCore.QTimer.singleShot( QtGui.QApplication.doubleClickInterval(), self.__tabBarDragActivate )
+		QtCore.QTimer.singleShot( QtWidgets.QApplication.doubleClickInterval(), self.__tabBarDragActivate )
 		return True
 
 	def __tabBarDragMove( self, widget, event ) :
@@ -251,17 +252,17 @@ class TabbedContainer( GafferUI.ContainerWidget ) :
 			self._qtWidget().setCurrentIndex( tab )
 
 # Private implementation - a QTabWidget with custom size behaviour.
-class _TabWidget( QtGui.QTabWidget ) :
+class _TabWidget( QtWidgets.QTabWidget ) :
 
 	def __init__( self, parent = None ) :
 
-		QtGui.QTabWidget.__init__( self, parent )
+		QtWidgets.QTabWidget.__init__( self, parent )
 
 	# Reimplemented so that the tabs aren't taken into
 	# account when they're not visible.
 	def sizeHint( self ) :
 
-		result = QtGui.QTabWidget.sizeHint( self )
+		result = QtWidgets.QTabWidget.sizeHint( self )
 		if self.tabBar().isHidden() :
 			if self.tabPosition() in ( self.North, self.South ) :
 				result.setHeight( result.height() - self.tabBar().sizeHint().height() )
@@ -274,7 +275,7 @@ class _TabWidget( QtGui.QTabWidget ) :
 	# account when they're not visible.
 	def minimumSizeHint( self ) :
 
-		result = QtGui.QTabWidget.minimumSizeHint( self )
+		result = QtWidgets.QTabWidget.minimumSizeHint( self )
 		if self.tabBar().isHidden() :
 			if self.tabPosition() in ( self.North, self.South ) :
 				result.setHeight( result.height() - self.tabBar().minimumSizeHint().height() )

--- a/python/GafferUI/TextWidget.py
+++ b/python/GafferUI/TextWidget.py
@@ -42,9 +42,9 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 class TextWidget( GafferUI.Widget ) :
 

--- a/python/GafferUI/TextWidget.py
+++ b/python/GafferUI/TextWidget.py
@@ -381,7 +381,7 @@ class _LineEdit( QtWidgets.QLineEdit ) :
 		width = self.fontMetrics().boundingRect( "M" * numChars ).width()
 		width += contentsMargins[0] + contentsMargins[2] + textMargins[0] + textMargins[2]
 
-		options = QtGui.QStyleOptionFrameV2()
+		options = QtWidgets.QStyleOptionFrame()
 		self.initStyleOption( options )
 		size = self.style().sizeFromContents(
 			QtWidgets.QStyle.CT_LineEdit,

--- a/python/GafferUI/TextWidget.py
+++ b/python/GafferUI/TextWidget.py
@@ -44,6 +44,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class TextWidget( GafferUI.Widget ) :
 
@@ -82,16 +83,16 @@ class TextWidget( GafferUI.Widget ) :
 
 		self._qtWidget().setEchoMode(
 			{
-				self.DisplayMode.Normal : QtGui.QLineEdit.Normal,
-				self.DisplayMode.Password : QtGui.QLineEdit.Password,
+				self.DisplayMode.Normal : QtWidgets.QLineEdit.Normal,
+				self.DisplayMode.Password : QtWidgets.QLineEdit.Password,
 			}[displayMode]
 		)
 
 	def getDisplayMode( self ) :
 
 		return {
-			QtGui.QLineEdit.Normal : self.DisplayMode.Normal,
-			QtGui.QLineEdit.Password : self.DisplayMode.Password,
+			QtWidgets.QLineEdit.Normal : self.DisplayMode.Normal,
+			QtWidgets.QLineEdit.Password : self.DisplayMode.Password,
 		}[self._qtWidget().echoMode()]
 
 	def setErrored( self, errored ) :
@@ -309,7 +310,7 @@ class TextWidget( GafferUI.Widget ) :
 	def __startSelectionFinishedTimer( self ) :
 
 		self.__numSelectionPossiblyFinishedEvents += 1
-		QtCore.QTimer.singleShot( QtGui.QApplication.doubleClickInterval(), self.__selectionPossiblyFinished )
+		QtCore.QTimer.singleShot( QtWidgets.QApplication.doubleClickInterval(), self.__selectionPossiblyFinished )
 
 	def __selectionPossiblyFinished( self ) :
 
@@ -326,11 +327,11 @@ class TextWidget( GafferUI.Widget ) :
 # fixed/preferred widths measured in characters. It is necessary to implement
 # these using sizeHint() so that they can adjust automatically to changes in
 # the style.
-class _LineEdit( QtGui.QLineEdit ) :
+class _LineEdit( QtWidgets.QLineEdit ) :
 
 	def __init__( self, parent = None ) :
 
-		QtGui.QLineEdit.__init__( self )
+		QtWidgets.QLineEdit.__init__( self )
 
 		self.__preferredCharacterWidth = 20
 		self.__fixedCharacterWidth = None
@@ -355,8 +356,8 @@ class _LineEdit( QtGui.QLineEdit ) :
 
 		self.__fixedCharacterWidth = numCharacters
 		self.setSizePolicy(
-			QtGui.QSizePolicy.Expanding if self.__fixedCharacterWidth is None else QtGui.QSizePolicy.Fixed,
-			QtGui.QSizePolicy.Fixed
+			QtWidgets.QSizePolicy.Expanding if self.__fixedCharacterWidth is None else QtWidgets.QSizePolicy.Fixed,
+			QtWidgets.QSizePolicy.Fixed
 		)
 
 		# we need to make sure that the geometry is up-to-date with the current character width
@@ -370,7 +371,7 @@ class _LineEdit( QtGui.QLineEdit ) :
 	def sizeHint( self ) :
 
 		# call the base class to get the height
-		result = QtGui.QLineEdit.sizeHint( self )
+		result = QtWidgets.QLineEdit.sizeHint( self )
 
 		# but then calculate our own width
 		numChars = self.__fixedCharacterWidth if self.__fixedCharacterWidth is not None else self.__preferredCharacterWidth
@@ -383,7 +384,7 @@ class _LineEdit( QtGui.QLineEdit ) :
 		options = QtGui.QStyleOptionFrameV2()
 		self.initStyleOption( options )
 		size = self.style().sizeFromContents(
-			QtGui.QStyle.CT_LineEdit,
+			QtWidgets.QStyle.CT_LineEdit,
 			options,
 			QtCore.QSize( width, 20 ),
 			self
@@ -402,4 +403,4 @@ class _LineEdit( QtGui.QLineEdit ) :
 				if not self.isModified() or not self.isRedoAvailable() :
 					return False
 
-		return QtGui.QLineEdit.event( self, event )
+		return QtWidgets.QLineEdit.event( self, event )

--- a/python/GafferUI/Timeline.py
+++ b/python/GafferUI/Timeline.py
@@ -42,6 +42,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## The Timeline presents a time slider which edits the frame
 # entry of a context.
@@ -101,10 +102,10 @@ class Timeline( GafferUI.EditorWidget ) :
 
 		self.__scriptNodePlugSetConnection = scriptNode.plugSetSignal().connect( Gaffer.WeakMethod( self.__scriptNodePlugSet ) )
 
-		frameIncrementShortcut = QtGui.QShortcut( QtGui.QKeySequence( "Right" ), self._qtWidget() )
+		frameIncrementShortcut = QtWidgets.QShortcut( QtGui.QKeySequence( "Right" ), self._qtWidget() )
 		frameIncrementShortcut.activated.connect( Gaffer.WeakMethod( self.__incrementFrame ) )
 
-		frameDecrementShortcut = QtGui.QShortcut( QtGui.QKeySequence( "Left" ), self._qtWidget() )
+		frameDecrementShortcut = QtWidgets.QShortcut( QtGui.QKeySequence( "Left" ), self._qtWidget() )
 		frameDecrementShortcut.activated.connect( IECore.curry( Gaffer.WeakMethod( self.__incrementFrame ), -1 ) )
 
 		self.__playback = None

--- a/python/GafferUI/Timeline.py
+++ b/python/GafferUI/Timeline.py
@@ -40,9 +40,9 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 ## The Timeline presents a time slider which edits the frame
 # entry of a context.

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -1181,7 +1181,8 @@ class _BoolDelegate( _Delegate ) :
 
 		# in PyQt, option is passed to us correctly as a QStyleOptionViewItemV4,
 		# but in PySide it is merely a QStyleOptionViewItem and we must "cast" it.
-		option = QtGui.QStyleOptionViewItemV4( option )
+		if hasattr( QtGui, "QStyleOptionViewItemV4" ) :
+			option = QtGui.QStyleOptionViewItemV4( option )
 
 		# in PyQt, we can access the widget with option.widget, but in PySide it
 		# is always None for some reason, so we jump through some hoops to get the

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -42,6 +42,7 @@ import GafferUI
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## The VectorDataWidget provides a table view for the contents of
 # one or more IECore VectorData instances.
@@ -90,13 +91,13 @@ class VectorDataWidget( GafferUI.Widget ) :
 		self.__tableView.horizontalHeader().setMinimumSectionSize( 70 )
 
 		self.__tableView.verticalHeader().setVisible( showIndices )
-		self.__tableView.verticalHeader().setResizeMode( QtGui.QHeaderView.Fixed )
+		self.__tableView.verticalHeader().setResizeMode( QtWidgets.QHeaderView.Fixed )
 		self.__tableView.verticalHeader().setObjectName( "vectorDataWidgetVerticalHeader" )
 
 		self.__tableView.setHorizontalScrollBarPolicy( QtCore.Qt.ScrollBarAlwaysOff )
 		self.__tableView.setVerticalScrollBarPolicy( QtCore.Qt.ScrollBarAsNeeded )
 
-		self.__tableView.setSelectionBehavior( QtGui.QAbstractItemView.SelectItems )
+		self.__tableView.setSelectionBehavior( QtWidgets.QAbstractItemView.SelectItems )
 		self.__tableView.setCornerButtonEnabled( False )
 
 		self.__tableView.setContextMenuPolicy( QtCore.Qt.CustomContextMenu )
@@ -223,13 +224,13 @@ class VectorDataWidget( GafferUI.Widget ) :
 					columnIndex += 1
 
 			self.__tableView.horizontalHeader().setResizeMode(
-				QtGui.QHeaderView.ResizeToContents if haveResizeableContents else QtGui.QHeaderView.Fixed
+				QtWidgets.QHeaderView.ResizeToContents if haveResizeableContents else QtWidgets.QHeaderView.Fixed
 			)
 			self.__tableView.horizontalHeader().setStretchLastSection( canStretch )
 			self.__tableView.setSizePolicy(
-				QtGui.QSizePolicy(
-					QtGui.QSizePolicy.Expanding if canStretch else QtGui.QSizePolicy.Fixed,
-					QtGui.QSizePolicy.Maximum
+				QtWidgets.QSizePolicy(
+					QtWidgets.QSizePolicy.Expanding if canStretch else QtWidgets.QSizePolicy.Fixed,
+					QtWidgets.QSizePolicy.Maximum
 				)
 			)
 
@@ -718,11 +719,11 @@ class VectorDataWidget( GafferUI.Widget ) :
 			self.__emittingButtonPress = False
 
 # Private implementation - a QTableView with custom size behaviour.
-class _TableView( QtGui.QTableView ) :
+class _TableView( QtWidgets.QTableView ) :
 
 	def __init__( self, minimumVisibleRows ) :
 
-		QtGui.QTableView.__init__( self )
+		QtWidgets.QTableView.__init__( self )
 
 		self.__minimumVisibleRows = minimumVisibleRows
 
@@ -734,7 +735,7 @@ class _TableView( QtGui.QTableView ) :
 			prevModel.rowsRemoved.disconnect( self.__sizeShouldChange )
 			prevModel.dataChanged.connect( self.__sizeShouldChange )
 
-		QtGui.QTableView.setModel( self, model )
+		QtWidgets.QTableView.setModel( self, model )
 
 		if model :
 			model.rowsInserted.connect( self.__sizeShouldChange )
@@ -1038,15 +1039,15 @@ _DataAccessor.registerType( IECore.InternedStringVectorData.staticTypeId(), _Int
 # The _Delegate classes are used to decide how the different types of data are
 # displayed. They derive from QStyledItemDelegate for drawing and event handling,
 # but also have additional methods to specify sizing.
-class _Delegate( QtGui.QStyledItemDelegate ) :
+class _Delegate( QtWidgets.QStyledItemDelegate ) :
 
 	def __init__( self ) :
 
-		QtGui.QStyledItemDelegate.__init__( self )
+		QtWidgets.QStyledItemDelegate.__init__( self )
 
 		# The closeEditor signal is used to tell the view that editing is complete,
 		# at which point it will destroy the QWidget used for editing.
-		# It is emitted from QtGui.QAbstractItemDelegate.eventFilter() and also from
+		# It is emitted from QtWidgets.QAbstractItemDelegate.eventFilter() and also from
 		# our own eventFilter() to stop editing. We connect to it here so that we can
 		# drop our reference to self.__editor (a GafferUI.Widget) when editing finishes -
 		# otherwise it would live on but with its Qt half already destroyed, which would
@@ -1073,25 +1074,25 @@ class _Delegate( QtGui.QStyledItemDelegate ) :
 			self.__editor._qtWidget().setParent( parent )
 			return self.__editor._qtWidget()
 		else :
-			return QtGui.QStyledItemDelegate.createEditor( self, parent, option, index )
+			return QtWidgets.QStyledItemDelegate.createEditor( self, parent, option, index )
 
 	def setEditorData( self, editor, index ) :
 
 		if self.__editor is not None :
 			self.__editor.setValue( GafferUI._Variant.fromVariant( index.data() ) )
 		else :
-			QtGui.QStyledItemDelegate.setEditorData( self, editor, index )
+			QtWidgets.QStyledItemDelegate.setEditorData( self, editor, index )
 
  	def setModelData( self, editor, model, index ) :
 
  		if self.__editor is not None :
  			model.setData( index, GafferUI._Variant.toVariant( self.__editor.getValue() ), QtCore.Qt.EditRole )
 		else :
-			QtGui.QStyledItemDelegate.setModelData( self, editor, model, index )
+			QtWidgets.QStyledItemDelegate.setModelData( self, editor, model, index )
 
  	def eventFilter( self, object, event ) :
 
- 		if QtGui.QStyledItemDelegate.eventFilter( self, object, event ) :
+ 		if QtWidgets.QStyledItemDelegate.eventFilter( self, object, event ) :
  			return True
 
  		if event.type() == event.Hide and self.__editor is not None :
@@ -1185,21 +1186,21 @@ class _BoolDelegate( _Delegate ) :
 
 		# draw the background
 
-		widget.style().drawControl( QtGui.QStyle.CE_ItemViewItem, option, painter, widget )
+		widget.style().drawControl( QtWidgets.QStyle.CE_ItemViewItem, option, painter, widget )
 
 		# draw the checkbox.
 
-		styleOption = QtGui.QStyleOptionButton()
+		styleOption = QtWidgets.QStyleOptionButton()
 		styleOption.state = option.state
-		styleOption.state |= QtGui.QStyle.State_Enabled
+		styleOption.state |= QtWidgets.QStyle.State_Enabled
 
 		if self.__toBool( index ) :
-			styleOption.state |= QtGui.QStyle.State_On
+			styleOption.state |= QtWidgets.QStyle.State_On
 		else :
-			styleOption.state |= QtGui.QStyle.State_Off
+			styleOption.state |= QtWidgets.QStyle.State_Off
 
 		styleOption.rect = self.__checkBoxRect( widget, option.rect )
-		widget.style().drawControl( QtGui.QStyle.CE_CheckBox, styleOption, painter, widget )
+		widget.style().drawControl( QtWidgets.QStyle.CE_CheckBox, styleOption, painter, widget )
 
 	def createEditor( self, parent, option, index ) :
 
@@ -1231,8 +1232,8 @@ class _BoolDelegate( _Delegate ) :
 
 	def __checkBoxRect( self, widget, viewItemRect ) :
 
-		checkBoxStyleOption = QtGui.QStyleOptionButton()
-		r = widget.style().subElementRect( QtGui.QStyle.SE_CheckBoxIndicator, checkBoxStyleOption )
+		checkBoxStyleOption = QtWidgets.QStyleOptionButton()
+		r = widget.style().subElementRect( QtWidgets.QStyle.SE_CheckBoxIndicator, checkBoxStyleOption )
 
 		return QtCore.QRect(
 			viewItemRect.center() - ( QtCore.QPoint( r.width(), r.height() ) / 2 ),

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -40,10 +40,10 @@ import IECore
 import Gaffer
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
-QtCompat = GafferUI._qtImport( "QtCompat" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
+from Qt import QtCompat
 
 ## The VectorDataWidget provides a table view for the contents of
 # one or more IECore VectorData instances.

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -45,9 +45,9 @@ import Gaffer
 import GafferUI
 from _StyleSheet import _styleSheet
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 ## The Widget class provides a base class for all widgets in GafferUI.
 #

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -47,6 +47,7 @@ from _StyleSheet import _styleSheet
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 ## The Widget class provides a base class for all widgets in GafferUI.
 #
@@ -99,10 +100,10 @@ QtGui = GafferUI._qtImport( "QtGui" )
 # for the tool tips.
 class Widget( object ) :
 
-	## All GafferUI.Widget instances must hold a corresponding QtGui.QWidget instance
+	## All GafferUI.Widget instances must hold a corresponding QtWidgets.QWidget instance
 	# which provides the top level implementation for the widget, and to which other
 	# widgets may be parented. This QWidget is created during __init__, and cannot be
-	# replaced later. Derived classes may pass either a QtGui.QWidget directly, or if
+	# replaced later. Derived classes may pass either a QtWidgets.QWidget directly, or if
 	# they prefer may pass a GafferUI.Widget, in which case a top level QWidget will be
 	# created automatically, with the GafferUI.Widget being parented to it. The top level
 	# QWidget can be accessed at any time using the _qtWidget() method. Note that this is
@@ -113,9 +114,9 @@ class Widget( object ) :
 	# automatic `parent.addChild()` call.
 	def __init__( self, topLevelWidget, toolTip="", parenting = None ) :
 
-		assert( isinstance( topLevelWidget, ( QtGui.QWidget, Widget ) ) )
+		assert( isinstance( topLevelWidget, ( QtWidgets.QWidget, Widget ) ) )
 
-		if isinstance( topLevelWidget, QtGui.QWidget ) :
+		if isinstance( topLevelWidget, QtWidgets.QWidget ) :
 			assert( Widget.__qtWidgetOwners.get( topLevelWidget ) is None )
 			self.__qtWidget = topLevelWidget
 
@@ -127,17 +128,17 @@ class Widget( object ) :
 			# behavior from Qt when using PySide.
 			# more details:
 			# http://stackoverflow.com/questions/32313469/stylesheet-in-pyside-not-working
-			if type( topLevelWidget ) == QtGui.QWidget :
+			if type( topLevelWidget ) == QtWidgets.QWidget :
 				self.__qtWidget.setAttribute( QtCore.Qt.WA_StyledBackground, True )
 		else :
 			self.__gafferWidget = topLevelWidget
-			self.__qtWidget = QtGui.QWidget()
-			self.__qtWidget.setLayout( QtGui.QGridLayout() )
+			self.__qtWidget = QtWidgets.QWidget()
+			self.__qtWidget.setLayout( QtWidgets.QGridLayout() )
 			## We need to set the size constraint to prevent widgets expanding in an unwanted
 			# way. However we may want other types to expand in the future. I think what we
 			# really need to do is somehow make __qtWidget without a layout, and just have
 			# it's size etc. dictated directly by self.__gafferWidget._qtWidget() somehow.
-			self.__qtWidget.layout().setSizeConstraint( QtGui.QLayout.SetMinAndMaxSize )
+			self.__qtWidget.layout().setSizeConstraint( QtWidgets.QLayout.SetMinAndMaxSize )
 			self.__qtWidget.layout().setContentsMargins( 0, 0, 0, 0 )
 			self.__qtWidget.layout().addWidget( self.__gafferWidget._qtWidget(), 0, 0 )
 
@@ -605,16 +606,16 @@ class Widget( object ) :
 		if widgetType is None :
 			widgetType = GafferUI.Widget
 
-		qWidget = QtGui.QApplication.instance().widgetAt( position[0], position[1] )
+		qWidget = QtWidgets.QApplication.instance().widgetAt( position[0], position[1] )
 		widget = GafferUI.Widget._owner( qWidget )
 
-		if widget is not None and isinstance( widget._qtWidget(), QtGui.QGraphicsView ) :
+		if widget is not None and isinstance( widget._qtWidget(), QtWidgets.QGraphicsView ) :
 			# if the widget is a QGraphicsView, then we have to dive into it ourselves
 			# to find any widgets embedded within it - qt won't do that for us.
 			graphicsView = widget._qtWidget()
 			localPosition = graphicsView.mapFromGlobal( QtCore.QPoint( position[0], position[1] ) )
 			graphicsItem = graphicsView.itemAt( localPosition )
-			if isinstance( graphicsItem, QtGui.QGraphicsProxyWidget ) :
+			if isinstance( graphicsItem, QtWidgets.QGraphicsProxyWidget ) :
 				localPosition = graphicsView.mapToScene( localPosition )
 				localPosition = graphicsItem.mapFromScene( localPosition )
 				qWidget = graphicsItem.widget().childAt( localPosition.x(), localPosition.y() )
@@ -631,7 +632,7 @@ class Widget( object ) :
 
 		return self.__qtWidget
 
-	## Returns the GafferUI.Widget that owns the specified QtGui.QWidget
+	## Returns the GafferUI.Widget that owns the specified QtWidgets.QWidget
 	@classmethod
 	def _owner( cls, qtWidget ) :
 
@@ -786,13 +787,13 @@ class Widget( object ) :
 
 		if not self.__eventFilterInstalled :
 			self._qtWidget().installEventFilter( _eventFilter )
-			if isinstance( self._qtWidget(), QtGui.QAbstractScrollArea ) :
+			if isinstance( self._qtWidget(), QtWidgets.QAbstractScrollArea ) :
 				self._qtWidget().viewport().installEventFilter( _eventFilter )
 			self.__eventFilterInstalled = True
 
 	def __ensureMouseTracking( self ) :
 
-		if isinstance( self._qtWidget(), QtGui.QAbstractScrollArea ) :
+		if isinstance( self._qtWidget(), QtWidgets.QAbstractScrollArea ) :
 			self._qtWidget().viewport().setMouseTracking( True )
 		else :
 			self._qtWidget().setMouseTracking( True )
@@ -804,7 +805,7 @@ class Widget( object ) :
 	def __ensureFocusChangedConnection( cls ) :
 
 		if not cls.__focusChangedConnected :
-			QtGui.QApplication.instance().focusChanged.connect( cls.__focusChanged )
+			QtWidgets.QApplication.instance().focusChanged.connect( cls.__focusChanged )
 			cls.__focusChangedConnected = True
 
 	@classmethod
@@ -816,7 +817,7 @@ class Widget( object ) :
 			# if nothing's connected to the signal currently, then disconnect, because
 			# we don't want the overhead of dealing with focus changes when no-one is
 			# interested.
-			QtGui.QApplication.instance().focusChanged.disconnect( cls.__focusChanged )
+			QtWidgets.QApplication.instance().focusChanged.disconnect( cls.__focusChanged )
 			cls.__focusChangedConnected = False
 
 	def _repolish( self, qtWidget=None ) :
@@ -827,7 +828,7 @@ class Widget( object ) :
 		style = qtWidget.style()
 		style.unpolish( qtWidget )
 		for child in qtWidget.children() :
-			if isinstance( child, QtGui.QWidget ) :
+			if isinstance( child, QtWidgets.QWidget ) :
 				self._repolish( child )
 		style.polish( qtWidget )
 
@@ -942,7 +943,7 @@ class _EventFilter( QtCore.QObject ) :
 		widget = Widget._owner( qObject )
 		toolTip = widget.getToolTip()
 		if toolTip :
-			QtGui.QToolTip.showText( qEvent.globalPos(), toolTip, qObject )
+			QtWidgets.QToolTip.showText( qEvent.globalPos(), toolTip, qObject )
 			return True
 		else :
 			return False

--- a/python/GafferUI/WidgetAlgo.py
+++ b/python/GafferUI/WidgetAlgo.py
@@ -63,5 +63,11 @@ def grab( widget, imagePath ) :
 	if imageDir and not os.path.isdir( imageDir ) :
 		os.makedirs( imageDir )
 
-	pixmap = QtGui.QPixmap.grabWindow( widget._qtWidget().winId() )
+	# This emits a deprecation warning in Qt5, but the recommended
+	# `QScreen.grabWindow()` alternative is not available in PySide2,
+	# and the alternative `QWidget.grab()` method does not capture
+	# OpenGL content. We could in theory silence the deprecation warning
+	# by temporarily installing a Qt message handler, but surprise surprise,
+	# we can't do that in PySide2 either.
+	pixmap = QtGui.QPixmap.grabWindow( long( widget._qtWidget().winId() ) )
 	pixmap.save( imagePath )

--- a/python/GafferUI/WidgetAlgo.py
+++ b/python/GafferUI/WidgetAlgo.py
@@ -38,7 +38,7 @@ import os
 
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
+from Qt import QtGui
 
 def joinEdges( listContainer ) :
 

--- a/python/GafferUI/Window.py
+++ b/python/GafferUI/Window.py
@@ -45,6 +45,7 @@ import Gaffer
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class Window( GafferUI.ContainerWidget ) :
 
@@ -54,14 +55,14 @@ class Window( GafferUI.ContainerWidget ) :
 	def __init__( self, title="GafferUI.Window", borderWidth=0, resizeable=None, child=None, sizeMode=SizeMode.Manual, icon="GafferLogoMini.png", **kw ) :
 
 		GafferUI.ContainerWidget.__init__(
-			self, QtGui.QWidget( None, QtCore.Qt.WindowFlags( QtCore.Qt.Window ), **kw )
+			self, QtWidgets.QWidget( None, QtCore.Qt.WindowFlags( QtCore.Qt.Window ), **kw )
 		)
 
 		self.__child = None
 		self.__childWindows = set()
-		self.__qtLayout = QtGui.QGridLayout()
+		self.__qtLayout = QtWidgets.QGridLayout()
 		self.__qtLayout.setContentsMargins( borderWidth, borderWidth, borderWidth, borderWidth )
-		self.__qtLayout.setSizeConstraint( QtGui.QLayout.SetMinAndMaxSize )
+		self.__qtLayout.setSizeConstraint( QtWidgets.QLayout.SetMinAndMaxSize )
 
 		# The initial size of a widget in qt "depends on the user's platform and screen geometry".
 		# In other words, it is useless. We use this flag to determine whether or not our size is
@@ -224,9 +225,9 @@ class Window( GafferUI.ContainerWidget ) :
 
 		self.__sizeMode = sizeMode
 		if sizeMode == self.SizeMode.Manual :
-			self.__qtLayout.setSizeConstraint( QtGui.QLayout.SetDefaultConstraint )
+			self.__qtLayout.setSizeConstraint( QtWidgets.QLayout.SetDefaultConstraint )
 		else :
-			self.__qtLayout.setSizeConstraint( QtGui.QLayout.SetFixedSize )
+			self.__qtLayout.setSizeConstraint( QtWidgets.QLayout.SetFixedSize )
 
 	def getSizeMode( self ) :
 

--- a/python/GafferUI/Window.py
+++ b/python/GafferUI/Window.py
@@ -43,9 +43,9 @@ import IECore
 import GafferUI
 import Gaffer
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 class Window( GafferUI.ContainerWidget ) :
 

--- a/python/GafferUI/_Pointer.py
+++ b/python/GafferUI/_Pointer.py
@@ -36,8 +36,8 @@
 
 import GafferUI
 
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtGui
+from Qt import QtWidgets
 
 # The pointer is specified via the C++ Pointer class, but to actually change
 # the qt pointer we use this python code which is triggered by Pointer::changedSignal().

--- a/python/GafferUI/_Pointer.py
+++ b/python/GafferUI/_Pointer.py
@@ -37,6 +37,7 @@
 import GafferUI
 
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 # The pointer is specified via the C++ Pointer class, but to actually change
 # the qt pointer we use this python code which is triggered by Pointer::changedSignal().
@@ -47,7 +48,7 @@ def __pointerChanged() :
 	global __cursorOverridden
 
 	pointer = GafferUI.Pointer.getCurrent()
-	application = QtGui.QApplication.instance()
+	application = QtWidgets.QApplication.instance()
 
 	if pointer is None :
 		if __cursorOverridden :

--- a/python/GafferUI/_Variant.py
+++ b/python/GafferUI/_Variant.py
@@ -37,7 +37,7 @@
 
 import GafferUI
 
-QtCore = GafferUI._qtImport( "QtCore" )
+from Qt import QtCore
 
 ## PyQt and PySide differ in their bindings of functions using the
 # QVariant type. PySide doesn't expose QVariant and instead uses

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -45,13 +45,43 @@
 # namespace.
 __import__( "uuid" )
 
-## Deprecated - use Qt.py instead. Also note that the lazy
-# argument no longer works, because Qt.py imports all modules
-# at startup.
+## Deprecated. This legacy function only supports use with Qt4. For
+# combined Qt4/Qt5 support use `from Qt import name` instead.
+# Also note that the lazy argument is no longer effective, because Qt.py
+# imports all modules at startup.
+__qtModuleName = None
 def _qtImport( name, lazy=False ) :
 
-	import Qt
-	return getattr( Qt, name )
+	# decide which qt bindings to use, and apply any fix-ups we need
+	# to shield us from PyQt/PySide differences.
+	global __qtModuleName
+	if __qtModuleName is None :
+		import os
+		if "GAFFERUI_QT_BINDINGS" in os.environ :
+			__qtModuleName = os.environ["GAFFERUI_QT_BINDINGS"]
+		else :
+			# no preference stated via environment - see what we shipped with
+			if os.path.exists( os.environ["GAFFER_ROOT"] + "/python/PySide" ) :
+				__qtModuleName = "PySide"
+			else :
+				__qtModuleName = "PyQt4"
+
+		# PyQt unfortunately uses an implementation-specific
+		# naming scheme for its new-style signal and slot classes.
+		# We use this to make it compatible with PySide, according to :
+		#
+		#     http://qt-project.org/wiki/Differences_Between_PySide_and_PyQt
+		if "PyQt" in __qtModuleName :
+			QtCore = __import__( __qtModuleName + ".QtCore" ).QtCore
+			QtCore.Signal = QtCore.pyqtSignal
+
+	# import the submodule from those bindings and return it
+	if lazy :
+		import Gaffer
+		return Gaffer.lazyImport( __qtModuleName + "." + name )
+	else :
+		qtModule = __import__( __qtModuleName + "." + name )
+		return getattr( qtModule, name )
 
 ##########################################################################
 # Function to return the C++ address of a wrapped Qt object. This can

--- a/python/GafferUITest/EventLoopTest.py
+++ b/python/GafferUITest/EventLoopTest.py
@@ -46,8 +46,8 @@ import Gaffer
 import GafferUI
 import GafferUITest
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtWidgets
 
 class EventLoopTest( GafferUITest.TestCase ) :
 

--- a/python/GafferUITest/EventLoopTest.py
+++ b/python/GafferUITest/EventLoopTest.py
@@ -47,7 +47,7 @@ import GafferUI
 import GafferUITest
 
 QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class EventLoopTest( GafferUITest.TestCase ) :
 
@@ -97,7 +97,7 @@ class EventLoopTest( GafferUITest.TestCase ) :
 
 			GafferUI.EventLoop.mainEventLoop().stop()
 			self.__uiThreadFunctionCalled = True
-			self.__uiThreadCalledOnCorrectThread = QtCore.QThread.currentThread() == QtGui.QApplication.instance().thread()
+			self.__uiThreadCalledOnCorrectThread = QtCore.QThread.currentThread() == QtWidgets.QApplication.instance().thread()
 			return 101
 
 		def t() :
@@ -121,7 +121,7 @@ class EventLoopTest( GafferUITest.TestCase ) :
 			time.sleep( 2 )
 			GafferUI.EventLoop.mainEventLoop().stop()
 			self.__uiThreadFunctionCalled = True
-			self.__uiThreadCalledOnCorrectThread = QtCore.QThread.currentThread() == QtGui.QApplication.instance().thread()
+			self.__uiThreadCalledOnCorrectThread = QtCore.QThread.currentThread() == QtWidgets.QApplication.instance().thread()
 			return 101
 
 		def t() :

--- a/python/GafferUITest/GLWidgetTest.py
+++ b/python/GafferUITest/GLWidgetTest.py
@@ -89,6 +89,7 @@ class GLWidgetTest( GafferUITest.TestCase ) :
 		f.setChild( b )
 
 		w.setVisible( True )
+		self.waitForIdle( 1000 )
 
 		w.setPosition( IECore.V2i( 100 ) )
 		self.waitForIdle( 1000 )

--- a/python/GafferUITest/GridContainerTest.py
+++ b/python/GafferUITest/GridContainerTest.py
@@ -42,7 +42,7 @@ import Gaffer
 import GafferUI
 import GafferUITest
 
-QtGui = GafferUI._qtImport( "QtGui" )
+from Qt import QtGui
 
 class GridContainerTest( GafferUITest.TestCase ) :
 

--- a/python/GafferUITest/ListContainerTest.py
+++ b/python/GafferUITest/ListContainerTest.py
@@ -43,7 +43,7 @@ import Gaffer
 import GafferUI
 import GafferUITest
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtWidgets
 
 class TestWidget( GafferUI.Widget ) :
 

--- a/python/GafferUITest/ListContainerTest.py
+++ b/python/GafferUITest/ListContainerTest.py
@@ -43,13 +43,13 @@ import Gaffer
 import GafferUI
 import GafferUITest
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class TestWidget( GafferUI.Widget ) :
 
 	def __init__( self, s, **kw ) :
 
-		GafferUI.Widget.__init__( self, QtGui.QLabel( s ), **kw )
+		GafferUI.Widget.__init__( self, QtWidgets.QLabel( s ), **kw )
 
 		self.s = s
 

--- a/python/GafferUITest/MenuBarTest.py
+++ b/python/GafferUITest/MenuBarTest.py
@@ -46,6 +46,7 @@ import GafferUITest
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class MenuBarTest( GafferUITest.TestCase ) :
 
@@ -206,12 +207,12 @@ class MenuBarTest( GafferUITest.TestCase ) :
 
 	def __simulateShortcut( self, widget ) :
 
-		QtGui.QApplication.instance().notify(
+		QtWidgets.QApplication.instance().notify(
 			widget._qtWidget(),
 			QtGui.QKeyEvent( QtCore.QEvent.KeyPress, QtCore.Qt.Key_A, QtCore.Qt.ControlModifier )
 		)
 
-		QtGui.QApplication.instance().notify(
+		QtWidgets.QApplication.instance().notify(
 			widget._qtWidget(),
 			QtGui.QKeyEvent( QtCore.QEvent.KeyRelease, QtCore.Qt.Key_A, QtCore.Qt.ControlModifier )
 		)

--- a/python/GafferUITest/MenuBarTest.py
+++ b/python/GafferUITest/MenuBarTest.py
@@ -45,9 +45,9 @@ import GafferUI
 import GafferUITest
 
 import Qt
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 class MenuBarTest( GafferUITest.TestCase ) :
 

--- a/python/GafferUITest/MenuBarTest.py
+++ b/python/GafferUITest/MenuBarTest.py
@@ -44,6 +44,7 @@ import Gaffer
 import GafferUI
 import GafferUITest
 
+import Qt
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
 QtWidgets = GafferUI._qtImport( "QtWidgets" )
@@ -206,6 +207,26 @@ class MenuBarTest( GafferUITest.TestCase ) :
 		self.assertEqual( len( commandInvocations ), 2 )
 
 	def __simulateShortcut( self, widget ) :
+
+		if Qt.__binding__ in ( "PySide2", "PyQt5" ) :
+
+			# Qt5's handling of key events appears to have
+			# changed, such that we must manually send the
+			# ShortcutOverride event before simulating the
+			# keypress, whereas in Qt4 simulating the keypress
+			# automatically sent the ShortcutOverride event.
+			#
+			# This new approach matches broadly what happens
+			# in Qt5's QTest::sendKeyEvent(), so I think
+			# what we're doing is kosher. Of course, it would
+			# be nice to just use QTest directly instead, but
+			# it appears not to be supported by PySide2 at
+			# present.
+
+			QtWidgets.QApplication.instance().notify(
+				widget._qtWidget(),
+				QtGui.QKeyEvent( QtCore.QEvent.ShortcutOverride, QtCore.Qt.Key_A, QtCore.Qt.ControlModifier )
+			)
 
 		QtWidgets.QApplication.instance().notify(
 			widget._qtWidget(),

--- a/python/GafferUITest/WidgetTest.py
+++ b/python/GafferUITest/WidgetTest.py
@@ -49,12 +49,13 @@ import GafferUITest
 
 QtCore = GafferUI._qtImport( "QtCore" )
 QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class TestWidget( GafferUI.Widget ) :
 
 	def __init__( self, **kw ) :
 
-		GafferUI.Widget.__init__( self, QtGui.QLabel( "hello" ), **kw )
+		GafferUI.Widget.__init__( self, QtWidgets.QLabel( "hello" ), **kw )
 
 class TestWidget2( GafferUI.Widget ) :
 
@@ -172,15 +173,15 @@ class WidgetTest( GafferUITest.TestCase ) :
 
 		event = QtGui.QMouseEvent( QtCore.QEvent.MouseButtonPress, QtCore.QPoint( 0, 0 ), QtCore.Qt.LeftButton, QtCore.Qt.LeftButton, QtCore.Qt.NoModifier )
 
-		QtGui.QApplication.instance().sendEvent( w._qtWidget(), event )
+		QtWidgets.QApplication.instance().sendEvent( w._qtWidget(), event )
 		self.assertEqual( WidgetTest.signalsEmitted, 1 )
 
 		w.setEnabled( False )
-		QtGui.QApplication.instance().sendEvent( w._qtWidget(), event )
+		QtWidgets.QApplication.instance().sendEvent( w._qtWidget(), event )
 		self.assertEqual( WidgetTest.signalsEmitted, 1 )
 
 		w.setEnabled( True )
-		QtGui.QApplication.instance().sendEvent( w._qtWidget(), event )
+		QtWidgets.QApplication.instance().sendEvent( w._qtWidget(), event )
  		self.assertEqual( WidgetTest.signalsEmitted, 2 )
 
 	def testCanDieAfterUsingSignals( self ) :
@@ -431,8 +432,8 @@ class WidgetTest( GafferUITest.TestCase ) :
 		button = GafferUI.Button()
 		address = GafferUI._qtAddress( button._qtWidget() )
 		self.assertTrue( isinstance( address, int ) )
-		widget = GafferUI._qtObject( address, QtGui.QPushButton )
-		self.assertTrue( isinstance( widget, QtGui.QPushButton ) )
+		widget = GafferUI._qtObject( address, QtWidgets.QPushButton )
+		self.assertTrue( isinstance( widget, QtWidgets.QPushButton ) )
 
 	def testSetVisibleWithNonBool( self ) :
 

--- a/python/GafferUITest/WidgetTest.py
+++ b/python/GafferUITest/WidgetTest.py
@@ -47,9 +47,9 @@ import GafferTest
 import GafferUI
 import GafferUITest
 
-QtCore = GafferUI._qtImport( "QtCore" )
-QtGui = GafferUI._qtImport( "QtGui" )
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
 
 class TestWidget( GafferUI.Widget ) :
 

--- a/python/GafferUITest/WindowTest.py
+++ b/python/GafferUITest/WindowTest.py
@@ -44,13 +44,13 @@ import Gaffer
 import GafferUI
 import GafferUITest
 
-QtGui = GafferUI._qtImport( "QtGui" )
+QtWidgets = GafferUI._qtImport( "QtWidgets" )
 
 class TestWidget( GafferUI.Widget ) :
 
 	def __init__( self ) :
 
-		GafferUI.Widget.__init__( self, QtGui.QLabel( "hello" ) )
+		GafferUI.Widget.__init__( self, QtWidgets.QLabel( "hello" ) )
 
 class WindowTest( GafferUITest.TestCase ) :
 

--- a/python/GafferUITest/WindowTest.py
+++ b/python/GafferUITest/WindowTest.py
@@ -44,7 +44,7 @@ import Gaffer
 import GafferUI
 import GafferUITest
 
-QtWidgets = GafferUI._qtImport( "QtWidgets" )
+from Qt import QtWidgets
 
 class TestWidget( GafferUI.Widget ) :
 

--- a/src/GafferUIBindings/PathListingWidgetBinding.cpp
+++ b/src/GafferUIBindings/PathListingWidgetBinding.cpp
@@ -44,8 +44,18 @@
 #include "QtCore/QModelIndex"
 #include "QtCore/QVariant"
 #include "QtCore/QDateTime"
-#include "QtGui/QTreeView"
-#include "QtGui/QFileIconProvider"
+
+#if QT_VERSION >= 0x050000
+
+	#include "QtWidgets/QTreeView"
+	#include "QtWidgets/QFileIconProvider"
+
+#else
+
+	#include "QtGui/QTreeView"
+	#include "QtGui/QFileIconProvider"
+
+#endif
 
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"


### PR DESCRIPTION
This makes Gaffer compatible with both Qt 4 and Qt 5, using [Qt.py](https://github.com/mottosso/Qt.py) to deal with some of the compatibility issues. I haven't updated the dependencies packages to include that yet, so the Travis build will fail here at first, but I wanted to get this PR up now so we can start testing at IE (I'll update the internal ticket with IE-specific details). 