### PR TITLE
SConstruct : Remove ABCToMDC class stub

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -804,16 +804,6 @@ libraries = {
 
 	},
 
-	"IECoreAlembic" : {
-
-		"classStubs" : [
-
-			( "ABCToMDC", "ops/files/abcToMDC" ),
-
-		],
-
-	},
-
 }
 
 # Add on OpenGL libraries to definitions - these vary from platform to platform


### PR DESCRIPTION
The MDC format no longer exists.