### PR TITLE
StandardConnectionGadget : drop Dot at mouse position

### DIFF
--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -301,7 +301,7 @@ bool StandardConnectionGadget::buttonPress( const ButtonEvent &event )
 			dot->setup( srcNodule()->plug() );
 
 			script->addChild( dot );
-			graphGadget->setNodePosition( dot, V2f(  m_dotPreviewLocation.x, m_dotPreviewLocation.y  ) );
+			graphGadget->setNodePosition( dot, V2f(  event.line.p0.x, event.line.p0.y ) );
 
 			dot->inPlug<Plug>()->setInput( srcNodule()->plug() );
 			dstNodule()->plug()->setInput( dot->outPlug<Plug>() );


### PR DESCRIPTION
I'm adding this as a PR so that you can test it easily, if you want to, John. Feel free to just close if we don't want to go down this path. For the record - this is to pick up the discussion we are having in https://github.com/GafferHQ/gaffer/pull/2072.

I left the snapped preview, but create the dot under the curser in `buttonPressed()` now. For the most part that is totally fine, I think. 
 - In the case of the user dragging the dot immediately, the initial position doesn't matter anyway. 
 - For connections that are not exactly vertical, the non-snapped position is good enough as it's a bit hard to read where the dot is anyway because the connections are curved.
 - Exactly vertical connection are the only ones for which it is very apparent that the dot hasn't been added directly on the connection, because you end up with two crooked connections.

Maybe that's fine? My OCD is freaking out a little when I get two crooked noodles, but maybe that's just me and I should get into the habit of click-dragging the dot to the correct location immediately. The snapping makes it jump to the right spot really quickly.