### PR TITLE
Display : Work around bizarre `hashFormat()` problem

### DIFF
--- a/src/GafferImage/Display.cpp
+++ b/src/GafferImage/Display.cpp
@@ -454,7 +454,8 @@ void Display::hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Co
 		format = FormatPlug::getDefaultFormat( Context::current() );
 	}
 
-	h.append( format.getDisplayWindow() );
+	h.append( format.getDisplayWindow().min );
+	h.append( format.getDisplayWindow().max );
 	h.append( format.getPixelAspect() );
 }
 


### PR DESCRIPTION
For a while now we've been seeing occasional errors like this on Travis :

> testSetDriver (GafferImageTest.DisplayTest.DisplayTest) ... FAIL
> No output has been received in the last 10m0s, this potentially indicates
>  a stalled build or something wrong with the build itself.

I've been unable to reproduce this locally until today when I did a build with
GCC 4.4.7 (I usually use 4.8.2 as mandated by the VFXPlatform). This is what
was happening :

- The test was failing because the format computed by the Display node was
  incorrect
- This meant an early exit from the test function
- This meant the DisplayDriverServer `server` was destroyed before the image
  had been closed
- The DisplayDriverServer destructor was then [waiting for the the background
  io_service thread to complete](https://github.com/ImageEngine/cortex/blob/deb23599c8c69eac5671e59fe1a8ca0d5e943a36/src/IECore/DisplayDriverServer.cpp#L110)
  before returning, but this never happened, because the image was never closed

Potentially the DisplayDriverServer destructor should force the background io
service to stop so it can join the background thread regardless, but here I've
just addressed the root problem with the hash computation.

I still don't understand exactly what was happening, but I observed the
following :

- In the failure case, the hash for the format was identical to the hash
  computed in a previous test, for an image with a different format.
  This meant that the wrong format was being pulled from the cache.
- The hash computed by GCC 4.4.7 was different to the hash computed
  by GCC 4.8.2. The hash computed by clang 3.4.2 was identical to the GCC
  4.8.2 hash.
- If all the `hash.append()` calls in `Display::hashFormat()` were
  removed, the resulting hash did not change - it was as if the append
  calls were just being omitted entirely by the compiler in the first
  place.
- A non-optimised build with GCC 4.4.7 produced the right hash,
  matching the other compilers.

I was concerned that it might have been a threading issue whereby
the members of the display driver created on the background thread were
not yet visible to the main thread, but I ruled that out by running the
same test with a display driver created directly, rather than via the
server. This yielded the same bad hashes from GCC 4.4.7.

To my layman's mind this all seems to indicate some sort of optimisation
bug in GCC 4.4.7. The "fix" is just to hash the min and max of the display
window in separate calls - this code now produces identical hashes on all
compilers tested.