### PR TITLE
Travis : Use SCons cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ addons:
         - gcc-5
         - g++-5
 
+cache:
+    directories:
+        - sconsCache
+
 before_install:
     - export DISPLAY=:99.0
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
@@ -40,7 +44,7 @@ install:
     - if [ -n "$COMPILER_VERSION" ]; then export CXX="${CXX}-${COMPILER_VERSION}"; fi
 
 script:
-    - scons -j 2 install CXX=$CXX CXXSTD=$CXXSTD DEBUG=$DEBUG ENV_VARS_TO_IMPORT=PATH RMAN_ROOT=$DELIGHT
+    - scons -j 2 install CXX=$CXX CXXSTD=$CXXSTD DEBUG=$DEBUG ENV_VARS_TO_IMPORT=PATH RMAN_ROOT=$DELIGHT BUILD_CACHEDIR=sconsCache
     # Preload libSegFault when running tests, so we get stack
     # traces from any crashes.
     - export LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
@@ -61,6 +65,13 @@ script:
     - source ./config/travis/runGafferTest GafferAppleseedTest
     - source ./config/travis/runGafferTest GafferAppleseedUITest
     - ./config/travis/printTestResults
+
+before_cache:
+    # This is run just before uploading the cache for next time.
+    # SCons caches grow without bound so we want to remove old
+    # files to prevent our caches becoming too big.
+    - python ./config/travis/limitCacheSize.py
+    - du -sh sconsCache
 
 # Default values for environment variables we use to
 # control the build.

--- a/config/travis/limitCacheSize.py
+++ b/config/travis/limitCacheSize.py
@@ -1,0 +1,30 @@
+import os
+import collections
+
+# 400 megabytes
+sizeLimit = 400 * 1024 * 1024
+
+CacheEntry = collections.namedtuple( "CacheEntry", [ "file", "size", "mtime" ] )
+
+totalSize = 0
+cacheEntries = []
+
+for root, dirs, files in os.walk( "./sconsCache" ) :
+	for file in files :
+		fileName = os.path.join( root, file )
+		size = os.path.getsize( fileName )
+		totalSize += size
+		cacheEntries.append(
+			CacheEntry(
+				fileName,
+				size,
+				os.path.getmtime( fileName ),
+			)
+		)
+
+cacheEntries = sorted( cacheEntries, key = lambda x : x.mtime )
+for c in cacheEntries :
+	if totalSize < sizeLimit :
+		break
+	os.remove( c.file )
+	totalSize -= c.size


### PR DESCRIPTION
This combines SCons' ability to use a build cache of previously compiled objects, and Travis' ability to squirrel away caches and reuse them for future builds. The Travis caches are separate per platform/compiler/environment so each row of our build matrix has a separate cache. This has a huge positive impact on our build times when only a few files have changed on a branch.