### PR TITLE
NoduleLayout : If using c++11, pass const_iterator to erase()

### DIFF
--- a/src/GafferUI/NoduleLayout.cpp
+++ b/src/GafferUI/NoduleLayout.cpp
@@ -668,7 +668,12 @@ void NoduleLayout::updateLayout()
 		if( itemsSet.find( it->first ) == itemsSet.end() )
 		{
 			removed.push_back( it->second.gadget );
+// In libc++11 and earlier, Map::erase didn't take an iterator, only a const_iterator
+#if ( defined( _LIBCPP_VERSION ) && _LIBCPP_VERSION <= 1101 )
+			m_gadgets.erase( GadgetMap::const_iterator( it ) );
+#else
 			m_gadgets.erase( it );
+#endif
 		}
 		it = next;
 	}


### PR DESCRIPTION
This ensures that, if using libc++11, a const_iterator is passed through to Map::erase rather than an iterator.

I checked through the [libc++ repository](https://github.com/llvm-mirror/libcxx) and found [this commit](https://github.com/llvm-mirror/libcxx/commit/488025c316ed7a54c205a977a7aeac51b187e176) which brought `erase(iterator)` back in. The previous release to this commit (the `release_36` branch) had _LIBCPP_VERSION as 1101. The following release (`release_37`) had _LIBCPP_VERSION as 3700, and they seem to have been taking the release number as the version ever since.

As such, I felt like saying <=1101 was a safe enough bet for this.
