### PR TITLE
GafferUI : handle QAbstractTableModel::dataChanged signal API change

### DIFF
--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -44,6 +44,7 @@ from Qt import QtCore
 from Qt import QtGui
 from Qt import QtWidgets
 from Qt import QtCompat
+import Qt
 
 ## The VectorDataWidget provides a table view for the contents of
 # one or more IECore VectorData instances.
@@ -917,7 +918,11 @@ class _Model( QtCore.QAbstractTableModel ) :
 		if role == QtCore.Qt.EditRole :
 			column = self.__columns[index.column()]
 			column.accessor.setElement( index.row(), column.relativeColumnIndex, value )
-			self.dataChanged.emit( index, index, [ QtCore.Qt.DisplayRole, QtCore.Qt.EditRole ] )
+
+			if Qt.__binding__ in ( "PySide2", "PyQt5" ) :
+				self.dataChanged.emit( index, index, [ QtCore.Qt.DisplayRole, QtCore.Qt.EditRole ] )
+			else:
+				self.dataChanged.emit( index, index )
 
 		return True
 


### PR DESCRIPTION
I was getting the following issue when trying to add elements to a VectorDataWidget 

```Traceback (most recent call last):
  File "/home/donbo/apps/gaffer/0.34.0.0dev/cent7.x86_64/cortex/10/gaffer/python/GafferUI/VectorDataWidget.py", line 920, in setData
    self.dataChanged.emit( index, index, [ QtCore.Qt.DisplayRole, QtCore.Qt.EditRole ] )
TypeError: dataChanged(QModelIndex,QModelIndex) only accepts 2 arguments, 4 given!
```

and have hacked VectorDataWidget to ensure it still works in Qt4. I suspect what I've done here isn't the correct fix but it demonstrates the problem.

####  Details on Qt4 / Qt5 api change:

[Qt5:  dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)](
http://doc.qt.io/qt-5/qabstracttablemodel-members.html)

[Qt4 dataChanged(const QModelIndex &, const QModelIndex &)](http://doc.qt.io/qt-4.8/qabstracttablemodel-members.html)

  