### PR TITLE
Improved TaskNode error reporting

### DIFF
--- a/apps/execute/execute-1.py
+++ b/apps/execute/execute-1.py
@@ -160,6 +160,7 @@ class execute( Gaffer.Application ) :
 
 		with context :
 			for node in nodes :
+				errorConnection = node.errorSignal().connect( Gaffer.WeakMethod( self.__error ) )
 				try :
 					node["task"].executeSequence( frames )
 				except Exception as exception :
@@ -171,10 +172,19 @@ class execute( Gaffer.Application ) :
 					IECore.msg(
 						IECore.Msg.Level.Error,
 						"gaffer execute : executing %s" % node.relativeName( scriptNode ),
-						"".join( traceback.format_exception_only( *sys.exc_info()[:2] ) ),
+						"See previous message for details",
 					)
 					return 1
 
 		return 0
 
+	def __error( self, plug, source, message ) :
+
+		IECore.msg(
+			IECore.Msg.Level.Error,
+			source.relativeName( source.ancestor( Gaffer.ScriptNode ) ),
+			message
+		)
+
 IECore.registerRunTimeTyped( execute )
+

--- a/include/GafferDispatch/TaskNode.h
+++ b/include/GafferDispatch/TaskNode.h
@@ -39,7 +39,7 @@
 
 #include "IECore/MurmurHash.h"
 
-#include "Gaffer/Node.h"
+#include "Gaffer/DependencyNode.h"
 #include "Gaffer/Plug.h"
 
 #include "GafferDispatch/TypeIds.h"
@@ -73,7 +73,7 @@ IE_CORE_FORWARDDECLARE( TaskNode )
 /// TaskNode can be chained together with other TaskNodes to define a required execution
 /// order. Typically TaskNodes should be executed by Dispatcher classes that can query the
 /// required execution order and schedule Tasks appropriately.
-class TaskNode : public Gaffer::Node
+class TaskNode : public Gaffer::DependencyNode
 {
 
 	public :
@@ -123,7 +123,7 @@ class TaskNode : public Gaffer::Node
 
 		typedef std::vector<Task> Tasks;
 
-		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferDispatch::TaskNode, TaskNodeTypeId, Gaffer::Node );
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferDispatch::TaskNode, TaskNodeTypeId, Gaffer::DependencyNode );
 
 		TaskNode( const std::string &name=defaultName<TaskNode>() );
 		virtual ~TaskNode();
@@ -193,7 +193,14 @@ class TaskNode : public Gaffer::Node
 		Gaffer::Plug *dispatcherPlug();
 		const Gaffer::Plug *dispatcherPlug() const;
 
+		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+
 	protected :
+
+		/// The default implementation of `affects()` calls this and appends
+		/// `taskPlug()` to the outputs if it returns true. The default implementation
+		/// should be sufficient for most node types.
+		virtual bool affectsTask( const Gaffer::Plug *input ) const;
 
 		/// Called by `TaskPlug::preTasks()`. The default implementation collects
 		/// the upstream Tasks connected into the preTasksPlug().

--- a/include/GafferDispatchBindings/TaskNodeBinding.inl
+++ b/include/GafferDispatchBindings/TaskNodeBinding.inl
@@ -51,6 +51,12 @@ struct TaskNodeAccessor
 {
 
 template<typename T>
+static bool affectsTask( T &n, const Gaffer::Plug *plug )
+{
+	return n.T::affectsTask( plug );
+}
+
+template<typename T>
 static boost::python::list preTasks( T &n, Gaffer::Context *context )
 {
 	GafferDispatch::TaskNode::Tasks tasks;
@@ -110,8 +116,9 @@ static bool requiresSequenceExecution( T &n )
 
 template<typename T, typename Ptr>
 TaskNodeClass<T, Ptr>::TaskNodeClass( const char *docString )
-	:	GafferBindings::NodeClass<T, Ptr>( docString )
+	:	GafferBindings::DependencyNodeClass<T, Ptr>( docString )
 {
+	this->def( "affectsTask", &Detail::TaskNodeAccessor::affectsTask<T> );
 	this->def( "preTasks", &Detail::TaskNodeAccessor::preTasks<T> );
 	this->def( "postTasks", &Detail::TaskNodeAccessor::postTasks<T> );
 	this->def( "hash", &Detail::TaskNodeAccessor::hash<T> );

--- a/python/GafferDispatchTest/ErroringTaskNode.py
+++ b/python/GafferDispatchTest/ErroringTaskNode.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,26 +34,38 @@
 #
 ##########################################################################
 
-# Utility classes
+import IECore
 
-from TextWriter import TextWriter
-from LoggingTaskNode import LoggingTaskNode
-from DebugDispatcher import DebugDispatcher
-from ErroringTaskNode import ErroringTaskNode
+import GafferDispatch
 
-# Test cases
+class ErroringTaskNode( GafferDispatch.TaskNode ) :
 
-from DispatcherTest import DispatcherTest
-from LocalDispatcherTest import LocalDispatcherTest
-from TaskNodeTest import TaskNodeTest
-from TaskSwitchTest import TaskSwitchTest
-from PythonCommandTest import PythonCommandTest
-from SystemCommandTest import SystemCommandTest
-from TaskListTest import TaskListTest
-from WedgeTest import WedgeTest
-from TaskContextVariablesTest import TaskContextVariablesTest
-from ExecuteApplicationTest import ExecuteApplicationTest
+	def __init__( self, name = "ErroringTaskNode" ) :
 
-if __name__ == "__main__":
-	import unittest
-	unittest.main()
+		GafferDispatch.TaskNode.__init__( self, name )
+
+	def execute( self ) :
+
+		raise RuntimeError( "Error in execute" )
+
+	def executeSequence( self, frames ) :
+
+		raise RuntimeError( "Error in executeSequence" )
+
+	def hash( self, context ) :
+
+		raise RuntimeError( "Error in hash" )
+
+	def requiresSequenceExecution( self ) :
+
+		raise RuntimeError( "Error in requiresSequenceExecution" )
+
+	def preTasks( self, context ) :
+
+		raise RuntimeError( "Error in preTasks" )
+
+	def postTasks( self, context ) :
+
+		raise RuntimeError( "Error in postTasks" )
+
+IECore.registerRunTimeTyped( ErroringTaskNode, typeName = "GafferDispatchTest::ErroringTaskNode" )

--- a/python/GafferDispatchTest/TaskContextVariablesTest.py
+++ b/python/GafferDispatchTest/TaskContextVariablesTest.py
@@ -37,6 +37,8 @@
 import glob
 import unittest
 
+import IECore
+
 import Gaffer
 import GafferTest
 import GafferDispatch
@@ -123,7 +125,11 @@ class TaskContextVariablesTest( GafferTest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 		s["variables"] = GafferDispatch.TaskContextVariables()
-		s["variables"]["preTasks"][0].setInput( s["variables"]["task"] )
+
+		with IECore.CapturingMessageHandler() as mh :
+			s["variables"]["preTasks"][0].setInput( s["variables"]["task"] )
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertRegexpMatches( mh.messages[0].message, "The graph must be a DAG" )
 
 		d = self.__dispatcher()
 		self.assertRaisesRegexp( RuntimeError, "cannot have cyclic dependencies", d.dispatch, [ s["variables"] ] )

--- a/python/GafferDispatchTest/TaskNodeTest.py
+++ b/python/GafferDispatchTest/TaskNodeTest.py
@@ -452,5 +452,35 @@ class TaskNodeTest( GafferTest.TestCase ) :
 		n["task"].executeSequence( itertools.chain( [ 1, 2, 3 ], [ 4, 5, 6 ] ) )
 		self.assertEqual( len( n.log ), 9 )
 
+	def testErrorSignal( self ) :
+
+		n = GafferDispatchTest.ErroringTaskNode()
+
+		for f, args in [
+			( "execute", [] ),
+			( "executeSequence", [ ( 1, 2, 3 ) ] ),
+			( "hash", [] ),
+			( "requiresSequenceExecution", [] ),
+			( "preTasks", [] ),
+			( "postTasks", [] ),
+		] :
+
+			cs = GafferTest.CapturingSlot( n.errorSignal() )
+
+			self.assertRaisesRegexp(
+				RuntimeError,
+				"Error in {}".format( f ),
+				getattr( n["task"], f ),
+				*args
+			)
+
+			self.assertEqual( len( cs ), 1 )
+			self.assertEqual( cs[0][0], n["task"] )
+			self.assertEqual( cs[0][1], n["task"] )
+			self.assertIn(
+				"Error in {}".format( f ),
+				cs[0][2]
+			)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDispatchTest/TaskSwitchTest.py
+++ b/python/GafferDispatchTest/TaskSwitchTest.py
@@ -36,6 +36,8 @@
 
 import unittest
 
+import IECore
+
 import Gaffer
 import GafferTest
 import GafferDispatch
@@ -152,7 +154,11 @@ class TaskSwitchTest( GafferTest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 		s["s"] = GafferDispatch.TaskSwitch()
-		s["s"]["preTasks"][0].setInput( s["s"]["task"] )
+
+		with IECore.CapturingMessageHandler() as mh :
+			s["s"]["preTasks"][0].setInput( s["s"]["task"] )
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertRegexpMatches( mh.messages[0].message, "The graph must be a DAG" )
 
 		d = self.__dispatcher()
 		self.assertRaisesRegexp( RuntimeError, "cannot have cyclic dependencies", d.dispatch, [ s["s"] ] )

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -44,6 +44,7 @@ import datetime
 import IECore
 
 import Gaffer
+import GafferTest
 import GafferDispatch
 import GafferImage
 import GafferImageTest
@@ -1180,6 +1181,16 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
 			resultReader["colorSpace"].setValue( colorSpace )
 			self.assertImagesEqual( resultReader["out"], reader["out"], ignoreMetadata=True, maxDifference=0.0007 )
+
+	def testDependencyNode( self ) :
+
+		writer = GafferImage.ImageWriter()
+		self.assertTrue( isinstance( writer, Gaffer.DependencyNode ) )
+		self.assertTrue( writer.isInstanceOf( Gaffer.DependencyNode.staticTypeId() ) )
+
+		cs = GafferTest.CapturingSlot( writer.plugDirtiedSignal() )
+		writer["fileName"].setValue( "test.png" )
+		self.assertIn( writer["task"], { x[0] for x in cs } )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferDispatch/TaskNode.cpp
+++ b/src/GafferDispatch/TaskNode.cpp
@@ -295,7 +295,7 @@ IE_CORE_DEFINERUNTIMETYPED( TaskNode )
 size_t TaskNode::g_firstPlugIndex;
 
 TaskNode::TaskNode( const std::string &name )
-	:	Node( name )
+	:	DependencyNode( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new ArrayPlug( "preTasks", Plug::In, new TaskPlug( "preTask0" ) ) );
@@ -350,6 +350,30 @@ Plug *TaskNode::dispatcherPlug()
 const Plug *TaskNode::dispatcherPlug() const
 {
 	return getChild<Plug>( g_firstPlugIndex + 3 );
+}
+
+void TaskNode::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	DependencyNode::affects( input, outputs );
+
+	if( affectsTask( input ) )
+	{
+		outputs.push_back( taskPlug() );
+	}
+}
+
+bool TaskNode::affectsTask( const Plug *input ) const
+{
+	if(
+		input->direction() != Plug::In ||
+		userPlug()->isAncestorOf( input ) ||
+		postTasksPlug()->isAncestorOf( input ) ||
+		input == taskPlug()
+	)
+	{
+		return false;
+	}
+	return true;
 }
 
 void TaskNode::preTasks( const Context *context, Tasks &tasks ) const

--- a/src/GafferDispatch/TaskNode.cpp
+++ b/src/GafferDispatch/TaskNode.cpp
@@ -125,6 +125,11 @@ class TaskNodeProcess : public Gaffer::Process
 			return n;
 		}
 
+		void handleException()
+		{
+			Gaffer::Process::handleException();
+		}
+
 		static InternedString hashProcessType;
 		static InternedString executeProcessType;
 		static InternedString executeSequenceProcessType;
@@ -200,37 +205,85 @@ PlugPtr TaskNode::TaskPlug::createCounterpart( const std::string &name, Directio
 IECore::MurmurHash TaskNode::TaskPlug::hash() const
 {
 	TaskNodeProcess p( TaskNodeProcess::hashProcessType, this );
-	return p.taskNode()->hash( Context::current() );
+	try
+	{
+		return p.taskNode()->hash( Context::current() );
+	}
+	catch( ... )
+	{
+		p.handleException();
+		return MurmurHash();
+	}
 }
 
 void TaskNode::TaskPlug::execute() const
 {
 	TaskNodeProcess p( TaskNodeProcess::executeProcessType, this );
-	return p.taskNode()->execute();
+	try
+	{
+		p.taskNode()->execute();
+	}
+	catch( ... )
+	{
+		p.handleException();
+		return;
+	}
 }
 
 void TaskNode::TaskPlug::executeSequence( const std::vector<float> &frames ) const
 {
 	TaskNodeProcess p( TaskNodeProcess::executeSequenceProcessType, this );
-	return p.taskNode()->executeSequence( frames );
+	try
+	{
+		p.taskNode()->executeSequence( frames );
+	}
+	catch( ... )
+	{
+		p.handleException();
+		return;
+	}
 }
 
 bool TaskNode::TaskPlug::requiresSequenceExecution() const
 {
 	TaskNodeProcess p( TaskNodeProcess::requiresSequenceExecutionProcessType, this );
-	return p.taskNode()->requiresSequenceExecution();
+	try
+	{
+		return p.taskNode()->requiresSequenceExecution();
+	}
+	catch( ... )
+	{
+		p.handleException();
+		return false;
+	}
 }
 
 void TaskNode::TaskPlug::preTasks( Tasks &tasks ) const
 {
 	TaskNodeProcess p( TaskNodeProcess::preTasksProcessType, this );
-	return p.taskNode()->preTasks( Context::current(), tasks );
+	try
+	{
+		p.taskNode()->preTasks( Context::current(), tasks );
+	}
+	catch( ... )
+	{
+		p.handleException();
+		return;
+	}
 }
 
 void TaskNode::TaskPlug::postTasks( Tasks &tasks ) const
 {
 	TaskNodeProcess p( TaskNodeProcess::postTasksProcessType, this );
-	return p.taskNode()->postTasks( Context::current(), tasks );
+	try
+	{
+		p.taskNode()->postTasks( Context::current(), tasks );
+	}
+	catch( ... )
+	{
+		p.handleException();
+		return;
+	}
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This reports errors on TaskNodes via `Node::errorSignal()` and uses that to ensure that any errors output by the `gaffer execute` app include the name of the plug which was being computed when the error occurred. @lucienfostier, I'm hoping this addresses the root cause of what you describe in #2160. Example output now looks something like this, with the name of the node/plug being the first thing in the error message :

```
ERROR : MyExpression.__execute : Traceback (most recent call last):
  File "/Users/john/dev/build/gaffer/python/GafferDispatchTest/TextWriter.py", line 79, in executeSequence
    GafferDispatch.TaskNode.executeSequence( self, frames )
RuntimeError: Exception : Traceback (most recent call last):
  File "/Users/john/dev/build/gaffer/python/GafferDispatchTest/TextWriter.py", line 72, in execute
    text = self.__processText( context )
  File "/Users/john/dev/build/gaffer/python/GafferDispatchTest/TextWriter.py", line 109, in __processText
    text = self["text"].getValue()
RuntimeError: Exception : Traceback (most recent call last):
  File "/Users/john/dev/build/gaffer/python/Gaffer/PythonExpressionEngine.py", line 81, in execute
    exec( self.__expression, executionDict, executionDict )
  File "<string>", line 1, in <module>
NameError: name 'thisVariableDoesntExist' is not defined

ERROR : gaffer execute : executing MyTextWriter : See previous message for details
```

I'd love to get rid of the noise from the traceback too so you only see the traceback within the exception itself, but I'll have to save that for another time.