### PR TITLE
Window : Fix crashes when reparenting child windows with Qt5/OSX

### DIFF
--- a/python/GafferUITest/WindowTest.py
+++ b/python/GafferUITest/WindowTest.py
@@ -119,15 +119,31 @@ class WindowTest( GafferUITest.TestCase ) :
 		self.failUnless( parentWindow2.parent() is None )
 		self.failUnless( childWindow.parent() is parentWindow1 )
 
+		parentWindow1.setVisible( True )
+		childWindow.setVisible( True )
+		self.waitForIdle( 1000 )
+
 		parentWindow2.addChildWindow( childWindow )
 		self.failUnless( parentWindow1.parent() is None )
 		self.failUnless( parentWindow2.parent() is None )
 		self.failUnless( childWindow.parent() is parentWindow2 )
 
+		parentWindow2.setVisible( True )
+		self.waitForIdle( 1000 )
+
 		parentWindow2.removeChild( childWindow )
 		self.failUnless( parentWindow1.parent() is None )
 		self.failUnless( parentWindow2.parent() is None )
 		self.failUnless( childWindow.parent() is None )
+
+		self.waitForIdle( 1000 )
+
+		parentWindow1.addChildWindow( childWindow )
+		self.failUnless( childWindow.parent() is parentWindow1 )
+
+		self.waitForIdle( 1000 )
+
+		parentWindow1.removeChild( childWindow )
 
 		del childWindow
 


### PR DESCRIPTION
The crashes were occuring when hitting Execute on a TaskNode and then hitting Dispatch in the dispatcher window, and the following error was displayed :

```
2017-07-13 20:37:13.221 Python[22204:2231217] *** Assertion failure in -[QNSPanel _validateCollectionBehavior:], /Library/Caches/com.apple.xbs/Sources/AppKit/AppKit-1504.83.101/AppKit.subproj/NSWindow.m:14741
```

The updated test gave a more revealing stacktrace, along these lines :

```
0   CoreFoundation                      0x00007fff82a942cb __exceptionPreprocess + 171
1   libobjc.A.dylib                     0x00007fff9789f48d objc_exception_throw + 48
2   CoreFoundation                      0x00007fff82a99042 +[NSException raise:format:arguments:] + 98
3   Foundation                          0x00007fff844e1c80 -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 195
4   AppKit                              0x00007fff80548dd7 -[NSWindow _validateCollectionBehavior:] + 298
5   AppKit                              0x00007fff80549099 -[NSWindow setCollectionBehavior:] + 33
6   libqcocoa.dylib                     0x00000001102cb4bb _ZN12QCocoaWindow14setWindowFlagsE6QFlagsIN2Qt10WindowTypeEE + 331
7   QtGui                               0x000000010b6dcc63 _ZN7QWindow8setFlagsE6QFlagsIN2Qt10WindowTypeEE + 35
8   QtWidgets                           0x000000010bce3a6f _ZN14QWidgetPrivate13setParent_sysEP7QWidget6QFlagsIN2Qt10WindowTypeEE + 239
9   QtWidgets                           0x000000010bccd795 _ZN7QWidget9setParentEPS_6QFlagsIN2Qt10WindowTypeEE + 725
10  QtWidgets.so                        0x000000010d00a527 _ZL25Sbk_QWidgetFunc_setParentP7_objectS0_ + 311
```

Looking at the Qt sources it appeared that the window flags are set before the new parent is, so I think the problem was that the flags specifying a tool window were being set while the window was still a top level window rather than after becoming a child, leading the underlying window system to balk that the flags were not valid.