### PR TITLE
Connection drag fix

### DIFF
--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -238,7 +238,7 @@ bool PlugAdder::dragEnter( const DragDropEvent &event )
 
 	if( event.sourceGadget == this )
 	{
-		updateDragEndPoint( event.line.p0, V3f( 0 ) );
+		updateDragEndPoint( V3f( event.line.p0.x, event.line.p0.y, 0 ), V3f( 0 ) );
 		return true;
 	}
 
@@ -268,7 +268,7 @@ bool PlugAdder::dragEnter( const DragDropEvent &event )
 
 bool PlugAdder::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 {
-	m_dragPosition = event.line.p0;
+	m_dragPosition = V3f( event.line.p0.x, event.line.p0.y, 0 );
 	requestRender();
 	return true;
 }

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -259,7 +259,7 @@ bool StandardNodule::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
 
 	if( event.sourceGadget == this )
 	{
-		updateDragEndPoint( event.line.p0, V3f( 0 ) );
+		updateDragEndPoint( V3f( event.line.p0.x, event.line.p0.y, 0 ), V3f( 0 ) );
 		return true;
 	}
 
@@ -321,7 +321,7 @@ bool StandardNodule::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
 
 bool StandardNodule::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 {
-	m_dragPosition = event.line.p0;
+	m_dragPosition = V3f( event.line.p0.x, event.line.p0.y, 0 );
  	requestRender();
 	return true;
 }

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -1010,8 +1010,8 @@ static const std::string &vertexSource()
 		"		float radius = effectiveEndPointSize * ( 1.0 + cosAngle ) / sqrt( 1.0 - cosAngle * cosAngle );"
 		"		float bendDir = sign( dot( endTangentPerp, straightDir ) );"
 
-		"		vec3 p = cosAngle > 0.9999 ? endPoint + 2.0 * t * effectiveEndPointSize * endTangent : endPoint + radius * ( ( 1.0 - cos( angle * t ) ) * bendDir * endTangentPerp + sin( angle * t ) * endTangent );"
-		"		vec3 uTangent = ( gl_MultiTexCoord0.y > 0.5 ? 1.0 : -1.0 ) * ( cosAngle > 0.9999 ? -endTangentPerp : bendDir * normalize( p - ( endPoint + radius * bendDir * endTangentPerp) ) );"
+		"		vec3 p = abs(cosAngle) > 0.9999 ? endPoint + 2.0 * t * effectiveEndPointSize * endTangent : endPoint + radius * ( ( 1.0 - cos( angle * t ) ) * bendDir * endTangentPerp + sin( angle * t ) * endTangent );"
+		"		vec3 uTangent = ( gl_MultiTexCoord0.y > 0.5 ? 1.0 : -1.0 ) * ( abs(cosAngle) > 0.9999 ? -endTangentPerp : bendDir * normalize( p - ( endPoint + radius * bendDir * endTangentPerp) ) );"
 
 		"		p += 0.5 * uTangent * ( gl_MultiTexCoord0.x - 0.5 );"
 


### PR DESCRIPTION
I'm not sure if this is the right solution to this issue - I'm not really sure why we store these nodule positions in 3 dimensions to start with.  The issue reported in #2156 is because my math for the new nodule shapes assumes that the tangents and endpoints of the connection lie in the same plane.

Currently, during mouse drags, depending on the camera position, we calculate drag end points with non-zero z components.  Simplest approach seems to be to zero these out at the source - but if we're supposed to keep the z information in the drag code, is it safe to throw it out in renderConnection?

The other commit is just to fix the connection not being rendered at all in a bad special case where you drag the node connected below a node to a position directly above it.  This now renders some weird straight handles sticking out - but I think this is fine - it's a really weird situation, it's good to have some visual indication that something weird is going on.