### PR TITLE
Adjust Snapping Distance?

### DIFF
--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -270,6 +270,7 @@ class GraphGadget : public ContainerGadget
 		Nodule *m_dragReconnectSrcNodule;
 		Nodule *m_dragReconnectDstNodule;
 		std::vector<float> m_dragSnapOffsets[2]; // offsets in x and y
+		std::vector<Imath::V2f> m_dragSnapPoints; // specific points that are also target for point snapping
 
 		GraphLayoutPtr m_layout;
 

--- a/python/GafferUITest/StandardGraphLayoutTest.py
+++ b/python/GafferUITest/StandardGraphLayoutTest.py
@@ -566,9 +566,9 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		s["t2"] = LayoutNode()
 		s["t3"] = LayoutNode()
 
-		s["t1"]["left1"].setInput( s["s"]["bottom1"] )
-		s["t2"]["left1"].setInput( s["s"]["bottom1"] )
-		s["t3"]["left1"].setInput( s["s"]["bottom1"] )
+		s["t1"]["left0"].setInput( s["s"]["bottom1"] )
+		s["t2"]["left0"].setInput( s["s"]["bottom1"] )
+		s["t3"]["left0"].setInput( s["s"]["bottom1"] )
 
 		g = GafferUI.GraphGadget( s )
 		g.getLayout().layoutNodes( g )

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -1341,7 +1341,7 @@ void GraphGadget::calculateDragSnapOffsets( Gaffer::Set *nodes )
 
 			m_dragSnapOffsets[snapAxis].push_back( offset );
 
-			// compute an offset that will position the node snugly next to its input
+			// compute an offset that will position the node neatly next to its input
 			// in the other axis.
 
 			Box3f srcNodeBound = srcNodeGadget->transformedBound( nullptr );
@@ -1350,11 +1350,11 @@ void GraphGadget::calculateDragSnapOffsets( Gaffer::Set *nodes )
 			const int otherAxis = snapAxis == 1 ? 0 : 1;
 			if( otherAxis == 1 )
 			{
-				offset = dstNodeBound.max[otherAxis] - srcNodeBound.min[otherAxis] + 1.0f;
+				offset = dstNodeBound.max[otherAxis] - srcNodeBound.min[otherAxis] + 4.0f;
 			}
 			else
 			{
-				offset = dstNodeBound.min[otherAxis] - srcNodeBound.max[otherAxis] - 1.0f;
+				offset = dstNodeBound.min[otherAxis] - srcNodeBound.max[otherAxis] - 4.0f;
 			}
 
 			if( dstNodule->plug()->node() == node )

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -96,6 +96,13 @@ const InternedString g_inputConnectionsMinimisedPlugName( "__uiInputConnectionsM
 const InternedString g_outputConnectionsMinimisedPlugName( "__uiOutputConnectionsMinimised" );
 const InternedString g_nodeGadgetTypeName( "nodeGadget:type" );
 
+struct CompareV2fX{
+	bool operator()(const Imath::V2f &a, const Imath::V2f &b) const
+	{   
+		return a[0] < b[0];
+	}   
+};
+
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -1090,8 +1097,11 @@ bool GraphGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 
 	if( m_dragMode == Moving )
 	{
+		const float snapThresh = 1.5;
+		
 		// snap the position using the offsets precomputed in calculateDragSnapOffsets()
-		V2f pos = V2f( i.x, i.y );
+		V2f startPos = V2f( i.x, i.y );
+		V2f pos = startPos;
 		for( int axis = 0; axis <= 1; ++axis )
 		{
 			const std::vector<float> &snapOffsets = m_dragSnapOffsets[axis];
@@ -1115,9 +1125,25 @@ bool GraphGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 				}
 			}
 
-			if( snappedDist < 1.5 )
+			if( snappedDist < snapThresh )
 			{
 				pos[axis] = snappedOffset + m_dragStartPosition[axis];
+			}
+		}
+
+		// We have sorted the snap points on the X axis, so we just need to check points that are within
+		// the right X range.
+		const std::vector<Imath::V2f> &snapPoints = m_dragSnapPoints;
+		V2f pOffset = startPos - m_dragStartPosition;
+		vector<V2f>::const_iterator pEnd = lower_bound( snapPoints.begin(), snapPoints.end(), pOffset + V2f( snapThresh ), CompareV2fX() );
+		vector<V2f>::const_iterator pIt = upper_bound( snapPoints.begin(), snapPoints.end(), pOffset - V2f( snapThresh ), CompareV2fX() );
+		for( ; pIt != pEnd; pIt++ )
+		{
+			if( fabs( pOffset[1] - (*pIt)[1] ) < snapThresh &&
+			    fabs( pOffset[0] - (*pIt)[0] ) < snapThresh )
+			{
+				pos = *pIt + m_dragStartPosition;
+				break;
 			}
 		}
 
@@ -1275,6 +1301,7 @@ void GraphGadget::calculateDragSnapOffsets( Gaffer::Set *nodes )
 {
 	m_dragSnapOffsets[0].clear();
 	m_dragSnapOffsets[1].clear();
+	m_dragSnapPoints.clear();
 
 	std::vector<const ConnectionGadget *> connections;
 	for( size_t i = 0, s = nodes->size(); i < s; ++i )
@@ -1332,14 +1359,14 @@ void GraphGadget::calculateDragSnapOffsets( Gaffer::Set *nodes )
 
 			V3f srcNodePosition = V3f( 0 ) * srcNodeGadget->fullTransform();
 			V3f dstNodePosition = V3f( 0 ) * dstNodeGadget->fullTransform();
-			offset = srcNodePosition[snapAxis] - dstNodePosition[snapAxis];
+			float nodeOffset = srcNodePosition[snapAxis] - dstNodePosition[snapAxis];
 
 			if( dstNodule->plug()->node() != node )
 			{
-				offset *= -1;
+				nodeOffset *= -1;
 			}
 
-			m_dragSnapOffsets[snapAxis].push_back( offset );
+			m_dragSnapOffsets[snapAxis].push_back( nodeOffset );
 
 			// compute an offset that will position the node neatly next to its input
 			// in the other axis.
@@ -1348,21 +1375,35 @@ void GraphGadget::calculateDragSnapOffsets( Gaffer::Set *nodes )
 			Box3f dstNodeBound = dstNodeGadget->transformedBound( nullptr );
 
 			const int otherAxis = snapAxis == 1 ? 0 : 1;
+			float baseOffsetOtherAxis;
+			float offsetDirectionOtherAxis;
 			if( otherAxis == 1 )
 			{
-				offset = dstNodeBound.max[otherAxis] - srcNodeBound.min[otherAxis] + 4.0f;
+				baseOffsetOtherAxis = dstNodeBound.max[otherAxis] - srcNodeBound.min[otherAxis];
+				offsetDirectionOtherAxis = 1.0f;
 			}
 			else
 			{
-				offset = dstNodeBound.min[otherAxis] - srcNodeBound.max[otherAxis] - 4.0f;
+				baseOffsetOtherAxis = dstNodeBound.min[otherAxis] - srcNodeBound.max[otherAxis];
+				offsetDirectionOtherAxis = -1.0f;
 			}
 
 			if( dstNodule->plug()->node() == node )
 			{
-				offset *= -1;
+				baseOffsetOtherAxis *= -1;
+				offsetDirectionOtherAxis *= -1;
 			}
 
-			m_dragSnapOffsets[otherAxis].push_back( offset );
+			m_dragSnapOffsets[otherAxis].push_back( baseOffsetOtherAxis + 4.0f * offsetDirectionOtherAxis );
+
+			if( snapAxis == 0 )
+			{
+				m_dragSnapPoints.push_back( Imath::V2f( offset, baseOffsetOtherAxis + 1.5f * offsetDirectionOtherAxis ) );
+			}
+			else
+			{
+				m_dragSnapPoints.push_back( Imath::V2f( baseOffsetOtherAxis + 1.5f * offsetDirectionOtherAxis, offset ) );
+			}
 		}
 	}
 
@@ -1374,6 +1415,8 @@ void GraphGadget::calculateDragSnapOffsets( Gaffer::Set *nodes )
 		std::sort( m_dragSnapOffsets[axis].begin(), m_dragSnapOffsets[axis].end() );
 		m_dragSnapOffsets[axis].erase( std::unique( m_dragSnapOffsets[axis].begin(), m_dragSnapOffsets[axis].end()), m_dragSnapOffsets[axis].end() );
 	}
+
+	std::sort( m_dragSnapPoints.begin(), m_dragSnapPoints.end(), CompareV2fX() );
 
 }
 

--- a/src/GafferUI/StandardGraphLayout.cpp
+++ b/src/GafferUI/StandardGraphLayout.cpp
@@ -181,7 +181,7 @@ class LayoutEngine
 
 		LayoutEngine( GraphGadget *graphGadget, float edgeLengthScale, float nodeSeparationScale )
 			:	m_graphGadget( graphGadget ),
-				m_edgeLength( 5.0f * edgeLengthScale ),
+				m_edgeLength( 4.0f * edgeLengthScale ),
 				m_nodeSeparation( 2.0f * nodeSeparationScale ),
 				m_springStiffness( 0.1 ),
 				m_maxIterations( 10000 ),


### PR DESCRIPTION
I'm not sure if this is going to have to become a big conversation, but I thought I might start by trying the simple thing, and seeing what you think - if this seems good to you, I might just survey a couple users to make sure they're OK with this, and then just do it.

Currently, the way that nodes snap together looks like:
![oldSnapDistance](https://raw.githubusercontent.com/danieldresser-ie/gaffer/7f11ebccbbfb9fb4e8abd36492d45f840133c5b7/oldSnapDistance.png)

The noodles pointing sideways are quite ugly looking, and I also really don't like not being able to see any connections inside a chain of nodes ( for example, you cannot tell how many connections there are between Box and Box1.

The simplest fix would be the current code for this PR, which produces this:
![newSnapDistance](https://raw.githubusercontent.com/GafferHQ/gaffer/7f11ebccbbfb9fb4e8abd36492d45f840133c5b7/newSnapDistance.png)

This is quite simple and clean looking.  The only question is whether it consumes too much space.  I feel like in practice, graphs usually end up feeling nicer with some space in them anyway, and I would be happy with this simple option.

If we want to keep a more compact option, I guess we could add a new snapping feature that snaps only to a particular point instead of a whole axis, so that when lining something up off to the side, you get the new further out snap edge, but you could also snap to the exact point right next to the node, if you are actually right next to it both horizontally and vertically.  I'm not sure whether this would be nicer to use or not - it would definitely be more work though.

The other commit here is to reduce the default spacing in the autolayout from 5.0 to 4.0 - it seems like the autolayout distance and the snap distance should match.