### PR TITLE
Catalogue fixes

### DIFF
--- a/include/GafferImage/Display.h
+++ b/include/GafferImage/Display.h
@@ -79,8 +79,6 @@ class Display : public ImageNode
 		typedef boost::signal<void ( IECore::DisplayDriver *driver, const IECore::CompoundData *parameters )> DriverCreatedSignal;
 		static DriverCreatedSignal &driverCreatedSignal();
 
-		/// Emitted when a new bucket is received.
-		static UnaryPlugSignal &dataReceivedSignal();
 		/// Emitted when a complete image has been received.
 		static UnaryPlugSignal &imageReceivedSignal();
 

--- a/python/GafferImageTest/CatalogueTest.py
+++ b/python/GafferImageTest/CatalogueTest.py
@@ -46,40 +46,17 @@ import GafferImageTest
 
 class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
-	def setUp( self ) :
-
-		GafferImageTest.ImageTestCase.setUp( self )
-
-		# Emulate the UI
-		self.__executeOnUIThreadConnection = GafferImage.Display.executeOnUIThreadSignal().connect( lambda f : f() )
-
-	def tearDown( self ) :
-
-		self.__executeOnUIThreadConnection.disconnect()
-
 	@staticmethod
 	def sendImage( image, catalogue, extraParameters = {} ) :
+
+		driver = GafferImageTest.DisplayTest.Driver.sendImage( image, GafferImage.Catalogue.displayDriverServer().portNumber(), extraParameters )
 
 		if catalogue["directory"].getValue() :
 
 			# When the image has been received, the Catalogue will
 			# save it to disk on a background thread, and we need
-			# to wait for that to complete. The background thread uses
-			# executeOnUIThread to signal completion, so we can hook
-			# into that.
-			semaphore = threading.Semaphore( 0 )
-
-			def f( f ) :
-
-				if catalogue["images"][-1]["fileName"].getValue() :
-					semaphore.release()
-
-			c = GafferImage.Display.executeOnUIThreadSignal().connect( f )
-
-		GafferImageTest.DisplayTest.sendImage( image, GafferImage.Catalogue.displayDriverServer().portNumber(), extraParameters )
-
-		if catalogue["directory"].getValue() :
-			semaphore.acquire()
+			# to wait for that to complete.
+			driver.performExpectedUIThreadExecution()
 
 	def testImages( self ) :
 

--- a/python/GafferImageTest/DisplayTest.py
+++ b/python/GafferImageTest/DisplayTest.py
@@ -326,11 +326,7 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 
 		self.Driver.sendImage( imageReader["out"], port = 2500 )
 
-		# Display doesn't handle image metadata, so we must erase it before comparing the images
-		inImage = imageReader["out"].image()
-		inImage.blindData().clear()
-
-		self.assertEqual( inImage, node["out"].image() )
+		self.assertImagesEqual( imageReader["out"], node["out"], ignoreMetadata = True )
 
 		self.assertEqual( len( imagesReceived ), 1 )
 		self.assertEqual( imagesReceived[0][0], node["out"] )

--- a/python/GafferImageTest/DisplayTest.py
+++ b/python/GafferImageTest/DisplayTest.py
@@ -367,14 +367,11 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 
 	def __assertTilesChangedInRegion( self, t1, t2, region ) :
 
-		# Box2i.intersect assumes inclusive bounds, so make region inclusive
-		inclusiveRegion = IECore.Box2i( region.min, region.max - IECore.V2i( 1 ) )
-
 		for tileOriginTuple in t1.keys() :
 			tileOrigin = IECore.V2i( *tileOriginTuple )
-			tileRegion = IECore.Box2i( tileOrigin, tileOrigin + IECore.V2i( GafferImage.ImagePlug.tileSize() - 1 ) )
+			tileRegion = IECore.Box2i( tileOrigin, tileOrigin + IECore.V2i( GafferImage.ImagePlug.tileSize() ) )
 
-			if tileRegion.intersects( inclusiveRegion ) :
+			if GafferImage.BufferAlgo.intersects( tileRegion, region ) :
 				self.assertNotEqual( t1[tileOriginTuple], t2[tileOriginTuple] )
 			else :
 				self.assertEqual( t1[tileOriginTuple], t2[tileOriginTuple] )

--- a/python/GafferImageTest/DisplayTest.py
+++ b/python/GafferImageTest/DisplayTest.py
@@ -50,69 +50,122 @@ import GafferImageTest
 
 class DisplayTest( GafferImageTest.ImageTestCase ) :
 
-	@classmethod
-	def sendImage( cls, image, port, extraParameters = {} ) :
+	# Utility class for sending images to Display nodes.
+	# This does a couple of important things :
+	#
+	# - Abstracts away the different image orientations between
+	#   Gaffer and Cortex. All Driver methods expect data with the
+	#   usual Gaffer conventions.
+	# - Emulates the DisplayUI's connection to Display.executeOnUIThreadSignal().
+	class Driver( object ) :
 
-		semaphore = threading.Semaphore( 0 )
-		imageReceivedConnection = GafferImage.Display.imageReceivedSignal().connect( lambda plug : semaphore.release() )
+		def __init__( self, format, dataWindow, channelNames, port, extraParameters = {}  ) :
 
-		externalDisplayWindow = gafferDisplayWindow = image["format"].getValue().getDisplayWindow()
-		externalDisplayWindow.max -= IECore.V2i( 1 )
+			self.__executeOnUIThreadConnection = GafferImage.Display.executeOnUIThreadSignal().connect( Gaffer.WeakMethod( self.__executeOnUIThread ) )
+			self.__executeOnUIThreadCondition = threading.Condition()
+			self.__executeOnUIThreadCondition.toExecute = None
 
-		gafferDataWindow = image["dataWindow"].getValue()
-		externalDataWindow = image["format"].getValue().toEXRSpace( gafferDataWindow )
+			self.__format = format
 
-		parameters = {
-			"displayHost" : "localHost",
-			"displayPort" : str( port ),
-			"remoteDisplayType" : "GafferImage::GafferDisplayDriver",
-		}
-		parameters.update( extraParameters )
+			parameters = {
+				"displayHost" : "localHost",
+				"displayPort" : str( port ),
+				"remoteDisplayType" : "GafferImage::GafferDisplayDriver",
+			}
+			parameters.update( extraParameters )
 
-		driver = IECore.ClientDisplayDriver(
-			externalDisplayWindow,
-			externalDataWindow,
-			list( image["channelNames"].getValue() ),
-			parameters,
-		)
+			self.__driver = IECore.ClientDisplayDriver(
+				self.__format.toEXRSpace( self.__format.getDisplayWindow() ),
+				self.__format.toEXRSpace( dataWindow ),
+				list( channelNames ),
+				parameters,
+			)
 
-		tileSize = GafferImage.ImagePlug.tileSize()
-		minTileOrigin = GafferImage.ImagePlug.tileOrigin( gafferDataWindow.min )
-		maxTileOrigin = GafferImage.ImagePlug.tileOrigin( gafferDataWindow.max - IECore.V2i( 1 ) )
-		for y in range( minTileOrigin.y, maxTileOrigin.y + 1, tileSize ) :
-			for x in range( minTileOrigin.x, maxTileOrigin.x + 1, tileSize ) :
-				tileOrigin = IECore.V2i( x, y )
-				channelData = []
-				for channelName in image["channelNames"].getValue() :
-					channelData.append( image.channelData( channelName, tileOrigin ) )
-				bucketData = IECore.FloatVectorData()
-				for by in range( tileSize - 1, -1, -1 ) :
-					for bx in range( 0, tileSize ) :
-						i = by * tileSize + bx
-						for c in channelData :
-							bucketData.append( c[i] )
+			# Wait for UI thread execution used to emit Display::driverCreatedSignal()
+			self.performExpectedUIThreadExecution()
 
-				bucketBound = IECore.Box2i( tileOrigin, tileOrigin + IECore.V2i( GafferImage.ImagePlug.tileSize() ) )
-				bucketBound = image["format"].getValue().toEXRSpace( bucketBound )
-				cls.__sendBucket( driver, bucketBound, bucketData )
+		# The channelData argument is a list of FloatVectorData
+		# per channel.
+		def sendBucket( self, bucketWindow, channelData ) :
 
-		driver.imageClose()
-		semaphore.acquire()
+			bucketSize = bucketWindow.size()
+			bucketData = IECore.FloatVectorData()
+			for by in range( bucketSize.y - 1, -1, -1 ) :
+				for bx in range( 0, bucketSize.x ) :
+					i = by * bucketSize.x + bx
+					for c in channelData :
+						bucketData.append( c[i] )
 
-	@classmethod
-	def __sendBucket( cls, driver, bound, data ) :
+			self.__driver.imageData(
+				self.__format.toEXRSpace( bucketWindow ),
+				bucketData
+			)
 
-		semaphore = threading.Semaphore( 0 )
-		dataReceivedConnection = GafferImage.Display.dataReceivedSignal().connect( lambda plug : semaphore.release() )
-		driver.imageData( bound, data )
-		semaphore.acquire()
+			# Wait for UI thread execution used to increment updateCount plug
+			self.performExpectedUIThreadExecution()
+
+		def close( self ) :
+
+			self.__driver.imageClose()
+
+			# Wait for UI thread execution used to emit Display::imageReceivedSignal()
+			self.performExpectedUIThreadExecution()
+
+		def performExpectedUIThreadExecution( self ) :
+
+			with self.__executeOnUIThreadCondition :
+
+				while self.__executeOnUIThreadCondition.toExecute is None :
+					self.__executeOnUIThreadCondition.wait()
+
+				self.__executeOnUIThreadCondition.toExecute()
+				self.__executeOnUIThreadCondition.toExecute = None
+
+		@classmethod
+		def sendImage( cls, image, port, extraParameters = {} ) :
+
+			dataWindow = image["dataWindow"].getValue()
+			channelNames = image["channelNames"].getValue()
+
+			driver = DisplayTest.Driver(
+				image["format"].getValue(),
+				dataWindow,
+				channelNames,
+				port, extraParameters
+			)
+
+			tileSize = GafferImage.ImagePlug.tileSize()
+			minTileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.min )
+			maxTileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.max - IECore.V2i( 1 ) )
+			for y in range( minTileOrigin.y, maxTileOrigin.y + 1, tileSize ) :
+				for x in range( minTileOrigin.x, maxTileOrigin.x + 1, tileSize ) :
+					tileOrigin = IECore.V2i( x, y )
+					channelData = []
+					for channelName in channelNames :
+						channelData.append( image.channelData( channelName, tileOrigin ) )
+					driver.sendBucket( IECore.Box2i( tileOrigin, tileOrigin + IECore.V2i( tileSize ) ), channelData )
+
+			driver.close()
+
+			return driver
+
+		def __executeOnUIThread( self, f ) :
+
+			with self.__executeOnUIThreadCondition :
+
+				self.__executeOnUIThreadCondition.toExecute = f
+				self.__executeOnUIThreadCondition.notify()
 
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )
 
-		# Emulate the work the UI will do when it is loaded.
-		self.__executeOnUIThreadConnection = GafferImage.Display.executeOnUIThreadSignal().connect( lambda f : f() )
+		# We just make this connection to force the display nodes to create servers,
+		# because if no connections exist they assume they're in a batch render and do
+		# nothing. The real UI thread execution is performed in the Driver class.
+		## \todo We can remove this when we remove all the server management from
+		# the Display node.
+		self.__executeOnUIThreadConnection = GafferImage.Display.executeOnUIThreadSignal().connect( lambda f : None )
 
 	def tearDown( self ) :
 
@@ -129,28 +182,15 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 
 	def testTileHashes( self ) :
 
-		semaphore = threading.Semaphore( 0 )
-		imageReceivedConnection = GafferImage.Display.imageReceivedSignal().connect( lambda plug : semaphore.release() )
-
 		node = GafferImage.Display()
 		node["port"].setValue( 2500 )
 
-		gafferDisplayWindow = IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 303, 557 ) )
-		gafferFormat = GafferImage.Format( gafferDisplayWindow, 1.0 )
-
-		externalDisplayWindow = gafferFormat.toEXRSpace( gafferDisplayWindow )
-
-		externalDataWindow = externalDisplayWindow
-		gafferDataWindow = gafferDisplayWindow
-		driver = IECore.ClientDisplayDriver(
-			externalDisplayWindow,
-			externalDataWindow,
+		dataWindow = IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 303, 557 ) )
+		driver = self.Driver(
+			GafferImage.Format( dataWindow ),
+			dataWindow,
 			[ "Y" ],
-			{
-				"displayHost" : "localHost",
-				"displayPort" : "2500",
-				"remoteDisplayType" : "GafferImage::GafferDisplayDriver",
-			}
+			port = 2500,
 		)
 
 		for i in range( 0, 1000 ) :
@@ -158,31 +198,28 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 			h1 = self.__tileHashes( node, "Y" )
 			t1 = self.__tiles( node, "Y" )
 
-			externalBucketWindow = IECore.Box2i()
-			for j in range( 0, 2 ) :
-				externalBucketWindow.extendBy(
+			bucketWindow = IECore.Box2i()
+			while GafferImage.BufferAlgo.empty( bucketWindow ) :
+				bucketWindow.extendBy(
 					IECore.V2i(
-						int( random.uniform( externalDisplayWindow.min.x, externalDisplayWindow.max.x ) ),
-						int( random.uniform( externalDisplayWindow.min.y, externalDisplayWindow.max.y ) ),
+						int( random.uniform( dataWindow.min.x, dataWindow.max.x ) ),
+						int( random.uniform( dataWindow.min.y, dataWindow.max.y ) ),
 					)
 				)
 
-			numPixels = ( externalBucketWindow.size().x + 1 ) * ( externalBucketWindow.size().y + 1 )
+			numPixels = ( bucketWindow.size().x + 1 ) * ( bucketWindow.size().y + 1 )
 			bucketData = IECore.FloatVectorData()
 			bucketData.resize( numPixels, i + 1 )
 
-			self.__sendBucket( driver, externalBucketWindow, bucketData )
+			driver.sendBucket( bucketWindow, [ bucketData ] )
 
 			h2 = self.__tileHashes( node, "Y" )
 			t2 = self.__tiles( node, "Y" )
 
-			gafferBucketWindow = gafferFormat.fromEXRSpace( externalBucketWindow )
+			self.__assertTilesChangedInRegion( t1, t2, bucketWindow )
+			self.__assertTilesChangedInRegion( h1, h2, bucketWindow )
 
-			self.__assertTilesChangedInRegion( t1, t2, gafferBucketWindow )
-			self.__assertTilesChangedInRegion( h1, h2, gafferBucketWindow )
-
-		driver.imageClose()
-		semaphore.acquire()
+		driver.close()
 
 	def testTransferChecker( self ) :
 
@@ -226,36 +263,30 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 
 	def testSetDriver( self ) :
 
-		semaphore = threading.Semaphore( 0 )
-		imageReceivedConnection = GafferImage.Display.imageReceivedSignal().connect( lambda plug : semaphore.release() )
-
 		driversCreated = GafferTest.CapturingSlot( GafferImage.Display.driverCreatedSignal() )
 
 		server = IECore.DisplayDriverServer()
-		cortexWindow = IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 99 ) )
-		gafferWindow = IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 100 ) )
-		driver = IECore.ClientDisplayDriver(
-			cortexWindow,
-			cortexWindow,
+		dataWindow = IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 100 ) )
+
+		driver = self.Driver(
+			GafferImage.Format( dataWindow ),
+			dataWindow,
 			[ "Y" ],
-			{
-				"displayHost" : "localHost",
-				"displayPort" : str( server.portNumber() ),
-				"remoteDisplayType" : "GafferImage::GafferDisplayDriver",
-			}
+			port = server.portNumber()
 		)
+
+		self.assertTrue( len( driversCreated ), 1 )
 
 		display = GafferImage.Display()
 		self.assertTrue( display.getDriver() is None )
 
-		self.assertTrue( len( driversCreated ), 1 )
 		display.setDriver( driversCreated[0][0] )
 		self.assertTrue( display.getDriver().isSame( driversCreated[0][0] ) )
 
-		self.__sendBucket( driver, cortexWindow, IECore.FloatVectorData( [ 0.5 ] * gafferWindow.size().x * gafferWindow.size().y ) )
+		driver.sendBucket( dataWindow, [ IECore.FloatVectorData( [ 0.5 ] * dataWindow.size().x * dataWindow.size().y ) ] )
 
-		self.assertEqual( display["out"]["format"].getValue().getDisplayWindow(), gafferWindow )
-		self.assertEqual( display["out"]["dataWindow"].getValue(), gafferWindow )
+		self.assertEqual( display["out"]["format"].getValue().getDisplayWindow(), dataWindow )
+		self.assertEqual( display["out"]["dataWindow"].getValue(), dataWindow )
 		self.assertEqual( display["out"]["channelNames"].getValue(), IECore.StringVectorData( [ "Y" ] ) )
 		self.assertEqual(
 			display["out"].channelData( "Y", IECore.V2i( 0 ) ),
@@ -267,7 +298,7 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertImagesEqual( display["out"], display2["out"] )
 
-		self.__sendBucket( driver, cortexWindow, IECore.FloatVectorData( [ 1 ] * gafferWindow.size().x * gafferWindow.size().y ) )
+		driver.sendBucket( dataWindow, [ IECore.FloatVectorData( [ 1 ] * dataWindow.size().x * dataWindow.size().y ) ] )
 
 		self.assertEqual(
 			display["out"].channelData( "Y", IECore.V2i( 0 ) ),
@@ -279,8 +310,7 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 			IECore.FloatVectorData( [ 0.5 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
 		)
 
-		driver.imageClose()
-		semaphore.acquire()
+		driver.close()
 
 	def __testTransferImage( self, fileName ) :
 
@@ -290,7 +320,7 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 		node = GafferImage.Display()
 		node["port"].setValue( 2500 )
 
-		self.sendImage( imageReader["out"], port = 2500 )
+		self.Driver.sendImage( imageReader["out"], port = 2500 )
 
 		# Display doesn't handle image metadata, so we must erase it before comparing the images
 		inImage = imageReader["out"].image()

--- a/python/GafferImageTest/DisplayTest.py
+++ b/python/GafferImageTest/DisplayTest.py
@@ -317,8 +317,12 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 		imageReader = GafferImage.ImageReader()
 		imageReader["fileName"].setValue( os.path.expandvars( fileName ) )
 
+		imagesReceived = GafferTest.CapturingSlot( GafferImage.Display.imageReceivedSignal() )
+
 		node = GafferImage.Display()
 		node["port"].setValue( 2500 )
+
+		self.assertEqual( len( imagesReceived ), 0 )
 
 		self.Driver.sendImage( imageReader["out"], port = 2500 )
 
@@ -327,6 +331,9 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 		inImage.blindData().clear()
 
 		self.assertEqual( inImage, node["out"].image() )
+
+		self.assertEqual( len( imagesReceived ), 1 )
+		self.assertEqual( imagesReceived[0][0], node["out"] )
 
 		return node
 

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -192,7 +192,7 @@ class Catalogue::InternalImage : public ImageNode
 			}
 			else if( numDisplays )
 			{
-				m_saver = new AsynchronousSaver( this );
+				m_saver = AsynchronousSaver::create( this );
 			}
 
 			m_clientPID = -2; // Make sure insertDriver() will reject new drivers
@@ -276,7 +276,7 @@ class Catalogue::InternalImage : public ImageNode
 			// Save the image to disk. We do this in the background because
 			// saving large images with many AOVs takes several seconds.
 
-			m_saver = new AsynchronousSaver( this );
+			m_saver = AsynchronousSaver::create( this );
 		}
 
 	protected :
@@ -386,14 +386,15 @@ class Catalogue::InternalImage : public ImageNode
 		struct AsynchronousSaver : public IECore::RefCounted
 		{
 
-			IE_CORE_DECLAREMEMBERPTR( AsynchronousSaver )
+			typedef std::shared_ptr<AsynchronousSaver> Ptr;
+			typedef std::weak_ptr<AsynchronousSaver> WeakPtr;
 
-			AsynchronousSaver( InternalImage *client )
+			static Ptr create( InternalImage *client )
 			{
 				// We use a copy of the image to do the saving, because the original
 				// might be modified on the main thread while we save in the background.
 
-				m_imageCopy = new InternalImage;
+				InternalImagePtr imageCopy = new InternalImage;
 
 				size_t i = 0;
 				for( DisplayIterator it( client ); !it.done(); ++it )
@@ -401,38 +402,45 @@ class Catalogue::InternalImage : public ImageNode
 					Display *display = it->get();
 					DisplayPtr displayCopy = new Display;
 					displayCopy->setDriver( display->getDriver(), /* copy = */ true );
-					m_imageCopy->addChild( displayCopy );
-					m_imageCopy->copyChannels()->inPlugs()->getChild<Plug>( i++ )->setInput( displayCopy->outPlug() );
+					imageCopy->addChild( displayCopy );
+					imageCopy->copyChannels()->inPlugs()->getChild<Plug>( i++ )->setInput( displayCopy->outPlug() );
 				}
-				m_imageCopy->imageSwitch()->indexPlug()->setValue( 1 );
+				imageCopy->imageSwitch()->indexPlug()->setValue( 1 );
 
-				// Set up an ImageWriter to do the actual saving.
-				// We do all graph construction here in the main thread
-				// so that the background thread only does execution.
-
-				const string fileName = client->parent<Catalogue>()->generateFileName( m_imageCopy->outPlug() );
+				// If there's nowhere to save, then a saver is useless, so return null.
+				const string fileName = client->parent<Catalogue>()->generateFileName( imageCopy->outPlug() );
 				if( fileName.empty() )
 				{
-					return;
+					return nullptr;
 				}
 
-				m_writer = new ImageWriter;
-				m_writer->inPlug()->setInput( m_imageCopy->outPlug() );
-				m_writer->fileNamePlug()->setValue( fileName );
+				// Otherwise, make a saver and schedule its background execution.
+				Ptr saver = Ptr( new AsynchronousSaver( imageCopy, fileName ) );
+				saver->registerClient( client );
 
-				registerClient( client );
-
-				// And fire off a thread to do the actual work.
-				std::thread thread( boost::bind( &AsynchronousSaver::save, this ) );
-				m_thread.swap( thread );
+				// Note that the background thread doesn't own a reference to the saver -
+				// see ~AsychronousSaver for details.
+				std::thread thread( boost::bind( &AsynchronousSaver::save, saver.get(), WeakPtr( saver ) ) );
+				saver->m_thread.swap( thread );
+				return saver;
 			}
 
 			virtual ~AsynchronousSaver()
 			{
-				if( m_thread.joinable() )
-				{
-					m_thread.join();
-				}
+				// Wait for our background thread to complete. This achieves
+				// two things :
+				//
+				// - Makes sure our member data is not deleted until the background
+				//   thread has finished using it.
+				// - Ensures that the background thread finishes before program shutdown
+				//   reaches the stage of calling static destructors, at which point
+				//   it would crash as the libraries it relies on are torn down around it.
+				//
+				// Note that for this to work, the background thread must _not_ own a
+				// reference to `this`, as that would prevent destruction on the main
+				// thread and never give us an opportunity to wait for the background
+				// thread.
+				m_thread.join();
 			}
 
 			void registerClient( InternalImage *client )
@@ -462,6 +470,17 @@ class Catalogue::InternalImage : public ImageNode
 
 			private :
 
+				AsynchronousSaver( InternalImagePtr imageCopy, const std::string &fileName )
+					:	m_imageCopy( imageCopy )
+				{
+					// Set up an ImageWriter to do the actual saving.
+					// We do all graph construction here in the main thread
+					// so that the background thread only does execution.
+					m_writer = new ImageWriter;
+					m_writer->inPlug()->setInput( m_imageCopy->outPlug() );
+					m_writer->fileNamePlug()->setValue( fileName );
+				}
+
 				struct HashGatherer
 				{
 
@@ -488,7 +507,7 @@ class Catalogue::InternalImage : public ImageNode
 
 				};
 
-				void save()
+				void save( WeakPtr forWrapUp )
 				{
 					HashGatherer hashGatherer( channelDataHashes );
 					parallelGatherTiles(
@@ -499,7 +518,20 @@ class Catalogue::InternalImage : public ImageNode
 					);
 
 					m_writer->taskPlug()->execute();
-					Display::executeOnUIThread( boost::bind( &AsynchronousSaver::wrapUp, Ptr( this ) ) );
+
+					// Schedule execution of wrapUp() on the UI thread,
+					// to make our results visible to the user. Note that
+					// we absolutely _must not_ create a Ptr here on the
+					// background thread - ownership must be managed on
+					// the UI thread only (see ~AsynchronousSaver).
+					Display::executeOnUIThread(
+						[forWrapUp] {
+							if( Ptr that = forWrapUp.lock() )
+							{
+								that->wrapUp();
+							}
+						}
+					);
 				}
 
 				void wrapUp()

--- a/src/GafferImage/Display.cpp
+++ b/src/GafferImage/Display.cpp
@@ -403,12 +403,6 @@ Display::DriverCreatedSignal &Display::driverCreatedSignal()
 	return s;
 }
 
-Node::UnaryPlugSignal &Display::dataReceivedSignal()
-{
-	static UnaryPlugSignal s;
-	return s;
-}
-
 Node::UnaryPlugSignal &Display::imageReceivedSignal()
 {
 	static UnaryPlugSignal s;
@@ -710,14 +704,6 @@ void Display::dataReceivedUI()
 				display->updateCountPlug()->setValue( display->updateCountPlug()->getValue() + 1 );
 			}
 		}
-	}
-
-	// Now that dirty propagation is complete, we can emit dataReceivedSignal()
-	// for any observers that wish to update that way.
-	/// \todo Do we even need this now? Could the tests just use plugDirtiedSignal()?
-	for( set<PlugPtr>::const_iterator it = batch->begin(), eIt = batch->end(); it != eIt; ++it )
-	{
-		dataReceivedSignal()( it->get() );
 	}
 }
 

--- a/src/GafferImageModule/CatalogueBinding.cpp
+++ b/src/GafferImageModule/CatalogueBinding.cpp
@@ -217,7 +217,6 @@ void GafferImageModule::bindCatalogue()
 			.def( "setDriver", (void (Display::*)( IECore::DisplayDriverPtr, bool ))&Display::setDriver, ( arg( "driver" ), arg( "copy" ) = false ) )
 			.def( "getDriver", (IECore::DisplayDriver *(Display::*)())&Display::getDriver, return_value_policy<CastToIntrusivePtr>() )
 			.def( "driverCreatedSignal", &Display::driverCreatedSignal, return_value_policy<reference_existing_object>() ).staticmethod( "driverCreatedSignal" )
-			.def( "dataReceivedSignal", &Display::dataReceivedSignal, return_value_policy<reference_existing_object>() ).staticmethod( "dataReceivedSignal" )
 			.def( "imageReceivedSignal", &Display::imageReceivedSignal, return_value_policy<reference_existing_object>() ).staticmethod( "imageReceivedSignal" )
 			.def( "executeOnUIThreadSignal", &DisplayWrapper::executeOnUIThreadSignal, return_value_policy<reference_existing_object>() ).staticmethod( "executeOnUIThreadSignal" )
 		;


### PR DESCRIPTION
This contains fixes for intermittent Catalogue/Display related failures which were seen on Travis, but were very reluctant to reproduce themselves anywhere else. I'm pretty confident that I have fixed genuine problems with genuine solutions here, but it'll need a good few runs through Travis before we can be sure I've fixed the right problems, since I failed to reproduce any of the problems locally.

For reference, here's a summary of the issues I'm hoping to address :

Crash in CatalogueTest.testCatalogueName
----------------------------------------

This manifested on Travis as follows :

```
testCatalogueName (GafferImageTest.CatalogueTest.CatalogueTest) ... terminate called after throwing an instance of 'std::runtime_error'
 what():  tbb_thread::join: Resource deadlock avoided
```

Instrumentation showed that the internal AsynchronousSaver object in the Catalogue was being destructed from the background thread that it spawned to do the work, rather than the main thread it was constructed from and from where the tests were running :

```
testCacheReuse (GafferImageTest.CatalogueTest.CatalogueTest) ... CATALOGUE CONSTRUCTED ON THREAD 139797758088960
ASYNCHRONOUSSAVER SAVING FROM THREAD 139796236252928
WAITING
ASYNCHRONOUSSAVER WRAPPING UP FROM THREAD 139796236252928
ASYNCHRONOUSSAVER WRAPPED UP FROM THREAD 139796236252928
WAITED
ok
testCatalogueName (GafferImageTest.CatalogueTest.CatalogueTest) ... CATALOGUE CONSTRUCTED ON THREAD 139797758088960
CATALOGUE CONSTRUCTED ON THREAD 139797758088960
ASYNCHRONOUSSAVER WRAPPING UP FROM THREAD 139796236252928
ASYNCHRONOUSSAVER WRAPPED UP FROM THREAD 139796236252928
ASYNCHRONOUSSAVER JOINING FROM THREAD 139796236252928
terminate called after throwing an instance of 'std::runtime_error'
  what():  tbb_thread::join: Resource deadlock avoided
```

Crash in CatalogueTest.testGILManagement
----------------------------------------

This one was rarer, and manifested on Travis as follows :

testGILManagement (GafferImageTest.CatalogueTest.CatalogueTest) ... *** Segmentation fault

With the following stacktrace :

```
Backtrace:
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libboost_signals.so.1.61.0(_ZN5boost7signals6detail14named_slot_map25remove_disconnected_slotsEv+0x48)[0x7ffa6a0d9c08]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libboost_signals.so.1.61.0(_ZN5boost7signals6detail17call_notificationD1Ev+0x45)[0x7ffa6a0dd4b5]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGaffer.so(_ZN5boost7signal1IvPN6Gaffer4PlugENS_10last_valueIvEEiSt4lessIiENS_8functionIFvS3_EEEEclES3_+0x17d)[0x7ffa65dbd5d9]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN11GafferImage7Display14dataReceivedUIEv+0x1b4)[0x7ffa60f87166]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN5boost6detail8function22void_function_invoker0IPFvvEvE6invokeERNS1_15function_bufferE+0x1d)[0x7ffa60f959bb]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGaffer.so(_ZNK5boost9function0IvEclEv+0x52)[0x7ffa65cec692]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/python/GafferImage/_GafferImage.so(+0x99139d)[0x7ffa5ec4539d]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/python/GafferImage/_GafferImage.so(+0x995432)[0x7ffa5ec49432]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/python/GafferImage/_GafferImage.so(+0x99535d)[0x7ffa5ec4935d]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/python/GafferImage/_GafferImage.so(+0x995287)[0x7ffa5ec49287]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libboost_python.so.1.61.0(_ZNK5boost6python7objects8function4callEP7_objectS4_+0xca)[0x7ffa6e74eeca]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libboost_python.so.1.61.0(+0x29238)[0x7ffa6e74f238]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libboost_python.so.1.61.0(_ZNK5boost6python6detail17exception_handlerclERKNS_9function0IvEE+0x43)[0x7ffa6e7597b3]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libIECorePython.so(_ZN5boost6detail8function21function_obj_invoker2INS_3_bi6bind_tIbNS_6python6detail19translate_exceptionIN6IECore9ExceptionEPFvRKS9_EEENS3_5list3INS_3argILi1EEENSG_ILi2EEENS3_5valueISD_EEEEEEbRKNS6_17exception_handlerERKNS_9function0IvEEE6invokeERNS1_15function_bufferESP_ST_+0x17)[0x7ffa6c5d0557]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libboost_python.so.1.61.0(_ZN5boost6python21handle_exception_implENS_9function0IvEE+0x2d)[0x7ffa6e75957d]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libboost_python.so.1.61.0(+0x27b43)[0x7ffa6e74db43]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libpython2.7.so.1.0(PyObject_Call+0x43)[0x7ffa723cddf3]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libpython2.7.so.1.0(PyEval_EvalFrameEx+0x3aa6)[0x7ffa724834c6]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libpython2.7.so.1.0(PyEval_EvalCodeEx+0x80d)[0x7ffa724890dd]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libpython2.7.so.1.0(+0x85eb0)[0x7ffa723ffeb0]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libpython2.7.so.1.0(PyObject_Call+0x43)[0x7ffa723cddf3]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libpython2.7.so.1.0(PyEval_CallObjectWithKeywords+0x47)[0x7ffa7247f437]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libpython2.7.so.1.0(PyEval_CallFunction+0xa7)[0x7ffa724ae537]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferBindings.so(_ZN5boost6python4callINS0_3api6objectES3_EENS0_6detail10returnableIT_E4typeEP7_objectRKT0_PNS_4typeIS6_EE+0x52)[0x7ffa650d2e46]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferBindings.so(_ZNK5boost6python3api16object_operatorsINS1_6objectEEclIS3_EENS0_6detail9dependentIS3_T_E4typeERKS8_+0x45)[0x7ffa65220e89]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/python/GafferImage/_GafferImage.so(+0x99149e)[0x7ffa5ec4549e]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/python/GafferImage/_GafferImage.so(+0x9947ec)[0x7ffa5ec487ec]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/python/GafferImage/_GafferImage.so(+0x99446b)[0x7ffa5ec4846b]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZNK5boost9function1IvNS_8functionIFvvEEEEclES3_+0x70)[0x7ffa60f9c71c]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZNK5boost7signals6detail11call_bound1IvE6callerINS_8functionIFvvEEENS5_IFvS7_EEEEclINS1_20connection_slot_pairEEENS1_8unusableERKT_+0x51)[0x7ffa60f9bd15]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZNK5boost7signals6detail18slot_call_iteratorINS1_11call_bound1IvE6callerINS_8functionIFvvEEENS6_IFvS8_EEEEENS1_23named_slot_map_iteratorEE11dereferenceEv+0x42)[0x7ffa60f9ac44]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN5boost9iterators20iterator_core_access11dereferenceINS_7signals6detail18slot_call_iteratorINS4_11call_bound1IvE6callerINS_8functionIFvvEEENS9_IFvSB_EEEEENS4_23named_slot_map_iteratorEEEEENT_9referenceERKSH_+0x18)[0x7ffa60f997d2]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZNK5boost9iterators6detail20iterator_facade_baseINS_7signals6detail18slot_call_iteratorINS4_11call_bound1IvE6callerINS_8functionIFvvEEENS9_IFvSB_EEEEENS4_23named_slot_map_iteratorEEENS4_8unusableENS0_25single_pass_traversal_tagERKSH_lLb0ELb0EEdeEv+0x20)[0x7ffa60f97d0e]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN5boost9iterators6detail23postfix_increment_proxyINS_7signals6detail18slot_call_iteratorINS4_11call_bound1IvE6callerINS_8functionIFvvEEENS9_IFvSB_EEEEENS4_23named_slot_map_iteratorEEEEC1ERKSG_+0x1c)[0x7ffa60f95672]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN5boost9iteratorsppINS_7signals6detail18slot_call_iteratorINS3_11call_bound1IvE6callerINS_8functionIFvvEEENS8_IFvSA_EEEEENS3_23named_slot_map_iteratorEEENS3_8unusableENS0_25single_pass_traversal_tagERKSG_lEENS0_6detail24postfix_increment_resultIT_T0_T2_T1_E4typeERNS0_15iterator_facadeISM_SN_SP_SO_T3_EEi+0x23)[0x7ffa60f92fbf]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZNK5boost10last_valueIvEclINS_7signals6detail18slot_call_iteratorINS4_11call_bound1IvE6callerINS_8functionIFvvEEENS9_IFvSB_EEEEENS4_23named_slot_map_iteratorEEEEEvT_SH_+0x27)[0x7ffa60f90339]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN5boost7signal1IvNS_8functionIFvvEEENS_10last_valueIvEEiSt4lessIiENS1_IFvS3_EEEEclES3_+0x18d)[0x7ffa60f8ca33]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN11GafferImage7Display17executeOnUIThreadEN5boost8functionIFvvEEE+0x34)[0x7ffa60f86dde]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN11GafferImage7Display12dataReceivedEv+0x136)[0x7ffa60f86f42]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZNK5boost4_mfi3mf0IvN11GafferImage7DisplayEEclEPS3_+0x58)[0x7ffa60f9bc02]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN5boost3_bi5list1INS0_5valueIPN11GafferImage7DisplayEEEEclINS_4_mfi3mf0IvS4_EENS0_5list2IRPNS3_19GafferDisplayDriverERKN9Imath_2_23BoxINSG_4Vec2IiEEEEEEEEvNS0_4typeIvEERT_RT0_i+0x4a)[0x7ffa60f9aa9e]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN5boost3_bi6bind_tIvNS_4_mfi3mf0IvN11GafferImage7DisplayEEENS0_5list1INS0_5valueIPS5_EEEEEclIPNS4_19GafferDisplayDriverEN9Imath_2_23BoxINSG_4Vec2IiEEEEEEvRT_RKT0_+0x4c)[0x7ffa60f994cc]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN5boost6detail8function26void_function_obj_invoker2INS_3_bi6bind_tIvNS_4_mfi3mf0IvN11GafferImage7DisplayEEENS3_5list1INS3_5valueIPS8_EEEEEEvPNS7_19GafferDisplayDriverERKN9Imath_2_23BoxINSI_4Vec2IiEEEEE6invokeERNS1_15function_bufferESH_SO_+0x33)[0x7ffa60f97a5a]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZNK5boost9function2IvPN11GafferImage19GafferDisplayDriverERKN9Imath_2_23BoxINS4_4Vec2IiEEEEEclES3_SA_+0x62)[0x7ffa60f9c4b6]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZNK5boost7signals6detail11call_bound2IvE6callerIPN11GafferImage19GafferDisplayDriverERKN9Imath_2_23BoxINS8_4Vec2IiEEEENS_8functionIFvS7_SE_EEEEclINS1_20connection_slot_pairEEENS1_8unusableERKT_+0x49)[0x7ffa60f9b4ab]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZNK5boost7signals6detail18slot_call_iteratorINS1_11call_bound2IvE6callerIPN11GafferImage19GafferDisplayDriverERKN9Imath_2_23BoxINS9_4Vec2IiEEEENS_8functionIFvS8_SF_EEEEENS1_23named_slot_map_iteratorEE11dereferenceEv+0x42)[0x7ffa60f9a54e]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN5boost9iterators20iterator_core_access11dereferenceINS_7signals6detail18slot_call_iteratorINS4_11call_bound2IvE6callerIPN11GafferImage19GafferDisplayDriverERKN9Imath_2_23BoxINSC_4Vec2IiEEEENS_8functionIFvSB_SI_EEEEENS4_23named_slot_map_iteratorEEEEENT_9referenceERKSP_+0x18)[0x7ffa60f98dfc]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZNK5boost9iterators6detail20iterator_facade_baseINS_7signals6detail18slot_call_iteratorINS4_11call_bound2IvE6callerIPN11GafferImage19GafferDisplayDriverERKN9Imath_2_23BoxINSC_4Vec2IiEEEENS_8functionIFvSB_SI_EEEEENS4_23named_slot_map_iteratorEEENS4_8unusableENS0_25single_pass_traversal_tagERKSP_lLb0ELb0EEdeEv+0x20)[0x7ffa60f96e54]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN5boost9iterators6detail23postfix_increment_proxyINS_7signals6detail18slot_call_iteratorINS4_11call_bound2IvE6callerIPN11GafferImage19GafferDisplayDriverERKN9Imath_2_23BoxINSC_4Vec2IiEEEENS_8functionIFvSB_SI_EEEEENS4_23named_slot_map_iteratorEEEEC1ERKSO_+0x1c)[0x7ffa60f9493a]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN5boost9iteratorsppINS_7signals6detail18slot_call_iteratorINS3_11call_bound2IvE6callerIPN11GafferImage19GafferDisplayDriverERKN9Imath_2_23BoxINSB_4Vec2IiEEEENS_8functionIFvSA_SH_EEEEENS3_23named_slot_map_iteratorEEENS3_8unusableENS0_25single_pass_traversal_tagERKSO_lEENS0_6detail24postfix_increment_resultIT_T0_T2_T1_E4typeERNS0_15iterator_facadeISU_SV_SX_SW_T3_EEi+0x23)[0x7ffa60f92081]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZNK5boost10last_valueIvEclINS_7signals6detail18slot_call_iteratorINS4_11call_bound2IvE6callerIPN11GafferImage19GafferDisplayDriverERKN9Imath_2_23BoxINSC_4Vec2IiEEEENS_8functionIFvSB_SI_EEEEENS4_23named_slot_map_iteratorEEEEEvT_SP_+0x27)[0x7ffa60f8e9b5]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN5boost7signal2IvPN11GafferImage19GafferDisplayDriverERKN9Imath_2_23BoxINS4_4Vec2IiEEEENS_10last_valueIvEEiSt4lessIiENS_8functionIFvS3_SA_EEEEclES3_SA_+0x173)[0x7ffa60f8af03]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libGafferImage.so(_ZN11GafferImage19GafferDisplayDriver9imageDataERKN9Imath_2_23BoxINS1_4Vec2IiEEEEPKfm+0x415)[0x7ffa60f88fcd]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libIECore.so(_ZN6IECore19DisplayDriverServer7Session24handleReadDataParametersERKN5boost6system10error_codeE+0x9a)[0x7ffa6de8891a]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libIECore.so(_ZN5boost4asio6detail7read_opINS0_19basic_stream_socketINS0_2ip3tcpENS0_21stream_socket_serviceIS5_EEEENS0_17mutable_buffers_1ENS1_14transfer_all_tENS_3_bi6bind_tIvNS_4_mfi3mf1IvN6IECore19DisplayDriverServer7SessionERKNS_6system10error_codeEEENSB_5list2INSB_5valueINS_13intrusive_ptrISH_EEEEPFNS_3argILi1EEEvEEEEEEclESL_mi+0x5b)[0x7ffa6de8b4cb]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libIECore.so(_ZN5boost4asio6detail23reactive_socket_recv_opINS0_17mutable_buffers_1ENS1_7read_opINS0_19basic_stream_socketINS0_2ip3tcpENS0_21stream_socket_serviceIS7_EEEES3_NS1_14transfer_all_tENS_3_bi6bind_tIvNS_4_mfi3mf1IvN6IECore19DisplayDriverServer7SessionERKNS_6system10error_codeEEENSC_5list2INSC_5valueINS_13intrusive_ptrISI_EEEEPFNS_3argILi1EEEvEEEEEEEE11do_completeEPNS1_15task_io_serviceEPNS1_25task_io_service_operationESM_m+0x133)[0x7ffa6de8baa3]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libIECore.so(_ZN6IECore19DisplayDriverServer12serverThreadEv+0x2ae)[0x7ffa6de870ae]
/home/travis/build/GafferHQ/gaffer/install/gaffer-0.34.0.0-linux/lib/libIECore.so(_ZN3tbb8internal16thread_closure_0IN5boost3_bi6bind_tIvNS2_4_mfi3mf0IvN6IECore19DisplayDriverServerEEENS3_5list1INS3_5valueIPS8_EEEEEEE13start_routineEPv+0x15)[0x7ffa6de89f55]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x7e9a)[0x7ffa72164e9a]
/lib/x86_64-linux-gnu/libc.so.6(clone+0x6d)[0x7ffa7178f2ed]
```

Deadlock in DisplayTest.testSetDriver
-------------------------------------

This appeared on Travis as follows :

```
testSetDriver (GafferImageTest.DisplayTest.DisplayTest) ... FAIL
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
The build has been terminated
```

Note that the FAIL message is output before the deadlock occurs. Instrumentation showed that the failure was on this line :

```
  File "/home/travis/build/johnhaddon/gaffer/install/gaffer-0.34.0.0-linux/python/GafferImageTest/DisplayTest.py", line 274, in testSetDriver
    IECore.FloatVectorData( [ 1 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
```

Deadlock occurs because the destructor of IECore::DisplayDriver servers waits to join the background thread, but the background thread can't complete because the client display driver has not been closed. I suspect this is a bug in itself, and that the server should stop the io service before joining the background thread from the destructor. Nevertheless, the deadlock would not occur if the test didn't fail in the first place.