### PR TITLE
catromFilterCompatibility: compatibility layer to filter renamed.(back port 0.34_maintenance)

### DIFF
--- a/startup/GafferImage/catromFilterCompatibility.py
+++ b/startup/GafferImage/catromFilterCompatibility.py
@@ -1,0 +1,64 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import types
+
+import IECore
+
+import GafferImage
+
+def __stringPlugSetValue( self, value ) :
+
+	if value == "catrom":
+		value = "catmull-rom"
+
+	self.__class__.setValue( self, value )
+
+def __stringPlugGetItem( originalGetItem ) :
+
+	def getItem( self, key ) :
+
+		result = originalGetItem( self, key )
+		if key == "filter" :
+			result.setValue = types.MethodType( __stringPlugSetValue, result )
+
+		return result
+
+	return getItem
+
+GafferImage.Resize.__getitem__ = __stringPlugGetItem( GafferImage.Resize.__getitem__ )
+GafferImage.ImageTransform.__getitem__ = __stringPlugGetItem( GafferImage.ImageTransform.__getitem__ )
+


### PR DESCRIPTION
Back port for 0.34_maintenance

Fixes
-----

- GafferImage Resize/ImageTransform:
  - a change in OIIO :
https://github.com/OpenImageIO/oiio/commit/b3962334f3d63272de58d5e6b1411036c993eb9e
create a compatibility problem for node using OIIO promoted filters.
This compatibility startup fix the problem by transforming from the old
filter name "catrom" to the new one "catmull-rom"