### PR TITLE
Shape : Fix crashes caused by invalid assertions

### DIFF
--- a/python/GafferImageTest/TextTest.py
+++ b/python/GafferImageTest/TextTest.py
@@ -181,5 +181,29 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 		t["shadow"].setValue( True )
 		self.assertImagesEqual( c["out"], t["out"] )
 
+	def testShadowAssertions( self ) :
+
+		# This used to trigger invalid assertions
+
+		t = GafferImage.Text()
+		dataWindow = t["out"]["dataWindow"].getValue()
+		tile = t["out"].channelData( "R", GafferImage.ImagePlug.tileOrigin( dataWindow.min ) )
+
+		t["shadow"].setValue( True )
+		t["shadowColor"].setValue( IECore.Color4f( 0.5 ) )
+
+		shadowDataWindow = t["out"]["dataWindow"].getValue()
+
+		self.assertEqual( shadowDataWindow.min.x, dataWindow.min.x )
+		self.assertEqual( shadowDataWindow.max.y, dataWindow.max.y )
+		self.assertGreater( shadowDataWindow.max.x, dataWindow.max.x )
+		self.assertLess( shadowDataWindow.min.y, dataWindow.min.y )
+
+		self.assertEqual( t["out"]["channelNames"].getValue(), IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
+
+		shadowTile = t["out"].channelData( "R", GafferImage.ImagePlug.tileOrigin( dataWindow.min ) )
+
+		self.assertNotEqual( shadowTile, tile )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImage/Shape.cpp
+++ b/src/GafferImage/Shape.cpp
@@ -72,6 +72,9 @@ Shape::Shape( const std::string &name )
 	addChild( new ImagePlug( "__shape", Gaffer::Plug::Out, Plug::Default & ~Plug::Serialisable ) );
 	addChild( new ImagePlug( "__shadowShape", Gaffer::Plug::Out, Plug::Default & ~Plug::Serialisable ) );
 
+	shadowShapePlug()->setInput( shapePlug() );
+	shadowShapePlug()->channelDataPlug()->setInput( nullptr );
+
 	BlurPtr shadowBlur = new Blur( "__shadowBlur" );
 	addChild( shadowBlur );
 	shadowBlur->inPlug()->setInput( shadowShapePlug() );
@@ -249,7 +252,7 @@ IECore::ConstStringVectorDataPtr Shape::computeChannelNames( const Gaffer::Conte
 
 void Shape::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	assert( parent == shapePlug() );
+	assert( parent == shapePlug() || parent == shadowShapePlug()  );
 	const std::string &channelName = context->get<std::string>( ImagePlug::channelNameContextName );
 	if( channelName == g_shapeChannelName )
 	{
@@ -275,7 +278,7 @@ void Shape::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer:
 
 IECore::ConstFloatVectorDataPtr Shape::computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const
 {
-	assert( parent == shapePlug() );
+	assert( parent == shapePlug() || parent == shadowShapePlug()  );
 	if( channelName == g_shapeChannelName )
 	{
 		// Private channel we use for caching the shape but don't advertise via channelNames.


### PR DESCRIPTION
The compute* and hash* methods were actually being used to compute the shadow shape as well as the main shape. In fact, the only thing different about the shadow shape is the colour, so we can share cache entries by driving the shadow shape with a connection from the main shape, and then fix the assertion to allow computing the shadow shape in the channelData methods.

Thanks to @est77 for reporting this problem.