### PR TITLE
GafferCortex : Fix explicit template instantiation errors (backport)

### DIFF
--- a/src/GafferCortex/NumericParameterHandler.cpp
+++ b/src/GafferCortex/NumericParameterHandler.cpp
@@ -115,5 +115,5 @@ void NumericParameterHandler<T>::setPlugValue()
 
 // explicit instantiations
 
-template class NumericParameterHandler<float>;
-template class NumericParameterHandler<int>;
+template class GafferCortex::NumericParameterHandler<float>;
+template class GafferCortex::NumericParameterHandler<int>;

--- a/src/GafferCortex/ParameterisedHolder.cpp
+++ b/src/GafferCortex/ParameterisedHolder.cpp
@@ -264,20 +264,19 @@ ParameterisedHolder<BaseType>::ParameterModificationContext::~ParameterModificat
 	}
 }
 
-// specialisation
-
 namespace GafferCortex
 {
 
+// specialisation
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( GafferCortex::ParameterisedHolderNode, ParameterisedHolderNodeTypeId )
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( GafferCortex::ParameterisedHolderDependencyNode, ParameterisedHolderDependencyNodeTypeId )
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( GafferCortex::ParameterisedHolderComputeNode, ParameterisedHolderComputeNodeTypeId )
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( GafferCortex::ParameterisedHolderTaskNode, ParameterisedHolderTaskNodeTypeId )
-
-} // namespace GafferCortex
 
 // explicit instantiation
 template class ParameterisedHolder<Gaffer::Node>;
 template class ParameterisedHolder<Gaffer::DependencyNode>;
 template class ParameterisedHolder<Gaffer::ComputeNode>;
 template class ParameterisedHolder<GafferDispatch::TaskNode>;
+
+} // namespace GafferCortex

--- a/src/GafferCortex/TypedParameterHandler.cpp
+++ b/src/GafferCortex/TypedParameterHandler.cpp
@@ -123,20 +123,20 @@ void TypedParameterHandler<T>::setPlugValue()
 
 // explicit instantiations
 
-template class TypedParameterHandler<std::string>;
-template class TypedParameterHandler<bool>;
+template class GafferCortex::TypedParameterHandler<std::string>;
+template class GafferCortex::TypedParameterHandler<bool>;
 
-template class TypedParameterHandler<Imath::Box2f>;
-template class TypedParameterHandler<Imath::Box3f>;
+template class GafferCortex::TypedParameterHandler<Imath::Box2f>;
+template class GafferCortex::TypedParameterHandler<Imath::Box3f>;
 
-template class TypedParameterHandler<Imath::Box2i>;
-template class TypedParameterHandler<Imath::Box3i>;
+template class GafferCortex::TypedParameterHandler<Imath::Box2i>;
+template class GafferCortex::TypedParameterHandler<Imath::Box3i>;
 
-template class TypedParameterHandler<Imath::V2f>;
-template class TypedParameterHandler<Imath::V3f>;
+template class GafferCortex::TypedParameterHandler<Imath::V2f>;
+template class GafferCortex::TypedParameterHandler<Imath::V3f>;
 
-template class TypedParameterHandler<Imath::V2i>;
-template class TypedParameterHandler<Imath::V3i>;
+template class GafferCortex::TypedParameterHandler<Imath::V2i>;
+template class GafferCortex::TypedParameterHandler<Imath::V3i>;
 
-template class TypedParameterHandler<Imath::Color3f>;
-template class TypedParameterHandler<Imath::Color4f>;
+template class GafferCortex::TypedParameterHandler<Imath::Color3f>;
+template class GafferCortex::TypedParameterHandler<Imath::Color4f>;

--- a/src/GafferCortex/VectorTypedParameterHandler.cpp
+++ b/src/GafferCortex/VectorTypedParameterHandler.cpp
@@ -121,8 +121,8 @@ void VectorTypedParameterHandler<ParameterType>::setPlugValue()
 
 // explicit instantiations
 
-template class VectorTypedParameterHandler<IECore::BoolVectorParameter>;
-template class VectorTypedParameterHandler<IECore::IntVectorParameter>;
-template class VectorTypedParameterHandler<IECore::FloatVectorParameter>;
-template class VectorTypedParameterHandler<IECore::StringVectorParameter>;
-template class VectorTypedParameterHandler<IECore::V3fVectorParameter>;
+template class GafferCortex::VectorTypedParameterHandler<IECore::BoolVectorParameter>;
+template class GafferCortex::VectorTypedParameterHandler<IECore::IntVectorParameter>;
+template class GafferCortex::VectorTypedParameterHandler<IECore::FloatVectorParameter>;
+template class GafferCortex::VectorTypedParameterHandler<IECore::StringVectorParameter>;
+template class GafferCortex::VectorTypedParameterHandler<IECore::V3fVectorParameter>;


### PR DESCRIPTION
These occurred with Clang on OSX in C++11 mode, and were of the following form :

> error: explicit instantiation of 'GafferCortex::ParameterisedHolder' must occur in namespace 'GafferCortex'

More details of the C++ standard change that required this behaviour here :

https://wg21.cmeerw.net/cwg/issue275