### PR TITLE
Catalogue : Stop AsynchronousSaver deriving from RefCounted

### DIFF
--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -383,7 +383,7 @@ class Catalogue::InternalImage : public ImageNode
 			return getChild<ImageMetadata>( g_firstChildIndex + 6 );
 		}
 
-		struct AsynchronousSaver : public IECore::RefCounted
+		struct AsynchronousSaver
 		{
 
 			typedef std::shared_ptr<AsynchronousSaver> Ptr;


### PR DESCRIPTION
We're no longer using intrusive_ptr with it, so it makes no sense.