### PR TITLE
GafferUI tests : Fix for Qt5/OSX (backport)

### DIFF
--- a/python/GafferUITest/ButtonTest.py
+++ b/python/GafferUITest/ButtonTest.py
@@ -98,7 +98,7 @@ class ButtonTest( GafferUITest.TestCase ) :
 		self.assertEqual( b.bound().size(), IECore.V2i( 10 ) )
 
 		b.setHasFrame( True )
-		self.waitForIdle( 20 )
+		self.waitForIdle( 1000 )
 
 		self.assertGreater( b.bound().size().x, 10 )
 		self.assertGreater( b.bound().size().y, 10 )

--- a/python/GafferUITest/MultiLineTextWidgetTest.py
+++ b/python/GafferUITest/MultiLineTextWidgetTest.py
@@ -122,7 +122,7 @@ class MultiLineTextWidgetTest( GafferUITest.TestCase ) :
 		# changing initial value
 		widget.setFixedLineHeight( 2 )
 
-		self.waitForIdle()
+		self.waitForIdle( 1000 )
 
 		newHeight = widget.size().y
 

--- a/python/GafferUITest/TextWidgetTest.py
+++ b/python/GafferUITest/TextWidgetTest.py
@@ -152,7 +152,7 @@ class TextWidgetTest( GafferUITest.TestCase ) :
 		# changing the initial value
 		textWidget.setFixedCharacterWidth( 2 )
 
-		self.waitForIdle()
+		self.waitForIdle( 1000 )
 
 		newWidth = textWidget.size().x
 


### PR DESCRIPTION
We need to wait a little longer for Qt to have caught up before asserting that the sizes are as want them to be. I've accompanied this change with manual verification that we're getting the desired results when using these methods in the UI.