### PR TITLE
Catalogue : Fix shuffling of switch plugs during image delete

### DIFF
--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -872,7 +872,7 @@ void Catalogue::imageRemoved( GraphComponent *graphComponent )
 		{
 			if( i + offset < plug->children().size() - 1 )
 			{
-				element->setInput( plug->getChild<Plug>( i + offset )->source() );
+				element->setInput( plug->getChild<Plug>( i + offset )->getInput() );
 			}
 			else
 			{


### PR DESCRIPTION
We were producing connections from an internal node of the InternalImage, rather than from the external output plug. The image below shows the internals of the catalogue after deleting an image :

<img width="442" alt="catalogueproblem" src="https://user-images.githubusercontent.com/1133871/28712003-6419ad56-7381-11e7-8b67-5912ff5b3896.png">

The stubbed connection on the second switch input should be going directly to the output of InternalImage2, but instead it is getting its connection from InternalImage2.ImageMetadata.out. This is fixed by this PR.
