### PR TITLE
Catalogue : Fix shuffling of switch plugs during image delete (0.34 backport)

### DIFF
--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -847,7 +847,7 @@ void Catalogue::imageRemoved( GraphComponent *graphComponent )
 		{
 			if( i + offset < plug->children().size() - 1 )
 			{
-				element->setInput( plug->getChild<Plug>( i + offset )->source<Plug>() );
+				element->setInput( plug->getChild<Plug>( i + offset )->getInput<Plug>() );
 			}
 			else
 			{


### PR DESCRIPTION
We were producing connections from an internal node of the InternalImage, rather than from the external output plug.