### PR TITLE
StandardConnectionGadget : add dot to correct parent

### DIFF
--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -303,9 +303,10 @@ bool StandardConnectionGadget::buttonPress( const ButtonEvent &event )
 			Gaffer::UndoScope undoEnabler( script );
 
 			Gaffer::Dot *dot = new Gaffer::Dot();
-			dot->setup( srcNodule()->plug() );
+			Gaffer::Plug *srcPlug = srcNodule()->plug();
+			dot->setup( srcPlug );
 
-			script->addChild( dot );
+			srcPlug->node()->parent()->addChild( dot );
 			graphGadget->setNodePosition( dot, V2f(  event.line.p0.x, event.line.p0.y ) );
 
 			dot->inPlug<Plug>()->setInput( srcNodule()->plug() );

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -302,7 +302,7 @@ bool StandardConnectionGadget::buttonPress( const ButtonEvent &event )
 		{
 			Gaffer::UndoScope undoEnabler( script );
 
-			Gaffer::Dot *dot = new Gaffer::Dot();
+			Gaffer::DotPtr dot = new Gaffer::Dot();
 			Gaffer::Plug *srcPlug = srcNodule()->plug();
 			dot->setup( srcPlug );
 


### PR DESCRIPTION
Instead of to the `ScriptNode` we should add the dot to the parent of the plugs that are part of the connection. Otherwise the dot and connection disappear when adding a dot inside a `Box`.

John, anything I'm not considering here?

Thanks :)