### PR TITLE
IECoreArnoldPreview::Renderer : Clear universe block earlier

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1582,6 +1582,15 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 		virtual ~ArnoldRenderer()
 		{
 			pause();
+
+			// If we start deleting objects from Arnold while the renderer thinks we might still need to
+			// start another render, Arnold will need to perform some sort of potentially costly index
+			// rebuilds. ( We're not sure of the exact cause, but in a scene with millions of objects, we
+			// saw it choking for hours trying to clean out all the objects ).
+			// Resetting the universe block pointer will free the universe block, calling AiEnd, and letting
+			// Arnold know that it doesn't need to do anything expensive when we delete all the objects in
+			// m_objects
+			m_universeBlock.reset();
 		}
 
 		virtual void option( const IECore::InternedString &name, const IECore::Data *value )


### PR DESCRIPTION
This fixes an issue where a Gaffer Arnold render with an extremely large number of objects in the scene could take hours to shutdown after the render finishes.  This was due to the m_objects member variable of ArnoldRender being destructed before the universe block, producing a huge number of AiNodeDestroy edits - from a brief look at the stack traces, it seems like Arnold was spending a lot of time rebuilding some sort of global index structure after the deletes - because AiEnd had not yet been called, and as far as it knew, we were about to start rendering again.

Releasing the universe block first appears to completely solve the problem - it could still be an issue in an InteractiveRender with millions of objects ( where we might actually want to delete everything and start a new render ), but we are much less concerned with interactive renders with millions of objects than with final renders.