### PR TITLE
OSLImage backports

### DIFF
--- a/python/GafferOSLTest/OSLImageTest.py
+++ b/python/GafferOSLTest/OSLImageTest.py
@@ -320,8 +320,8 @@ class OSLImageTest( GafferOSLTest.OSLTestCase ) :
 		for y in range( displayWindow.min.y, displayWindow.max.y ) :
 			for x in range( displayWindow.min.x, displayWindow.max.x ) :
 
-				self.assertEqual( samplerR.sample( x, y ), x, "Pixel {},{}".format( x, y ) )
-				self.assertEqual( samplerG.sample( x, y ), y, "Pixel {},{}".format( x, y ) )
+				self.assertEqual( samplerR.sample( x, y ), x + 0.5, "Pixel {},{}".format( x, y ) )
+				self.assertEqual( samplerG.sample( x, y ), y + 0.5, "Pixel {},{}".format( x, y ) )
 				self.assertEqual( samplerB.sample( x, y ), 0, "Pixel {},{}".format( x, y ) )
 
 				uv = uvMin + uvStep * IECore.V2f( IECore.V2i( x, y ) - displayWindow.min )

--- a/src/GafferOSL/OSLImage.cpp
+++ b/src/GafferOSL/OSLImage.cpp
@@ -295,21 +295,18 @@ IECore::ConstCompoundDataPtr OSLImage::computeShading( const Gaffer::Context *co
 	uWritable.reserve( tileSize * tileSize );
 	vWritable.reserve( tileSize * tileSize );
 
-	/// \todo Non-zero display window origins - do we have those?
-	const float uStep = 1.0f / format.width();
-	const float uMin = 0.5f * uStep;
-
-	const float vStep = 1.0f / format.height();
-	const float vMin = 0.5f * vStep;
+	const V2f uvStep = V2f( 1.0f ) / format.getDisplayWindow().size();
+	// UV value for the pixel at 0,0
+	const V2f uvOrigin = (V2f(0.5) - format.getDisplayWindow().min) * uvStep;
 
 	const V2i pMax = tileOrigin + V2i( tileSize );
 	V2i p;
 	for( p.y = tileOrigin.y; p.y < pMax.y; ++p.y )
 	{
-		const float v = vMin + p.y * vStep;
+		const float v = uvOrigin.y + p.y * uvStep.y;
 		for( p.x = tileOrigin.x; p.x < pMax.x; ++p.x )
 		{
-			uWritable.push_back( uMin + p.x * uStep );
+			uWritable.push_back( uvOrigin.x + p.x * uvStep.x );
 			vWritable.push_back( v );
 			pWritable.push_back( V3f( p.x, p.y, 0.0f ) );
 		}

--- a/src/GafferOSL/OSLImage.cpp
+++ b/src/GafferOSL/OSLImage.cpp
@@ -308,7 +308,7 @@ IECore::ConstCompoundDataPtr OSLImage::computeShading( const Gaffer::Context *co
 		{
 			uWritable.push_back( uvOrigin.x + p.x * uvStep.x );
 			vWritable.push_back( v );
-			pWritable.push_back( V3f( p.x, p.y, 0.0f ) );
+			pWritable.push_back( V3f( p.x + 0.5f, p.y + 0.5f, 0.0f ) );
 		}
 	}
 

--- a/src/GafferOSL/OSLImage.cpp
+++ b/src/GafferOSL/OSLImage.cpp
@@ -302,16 +302,16 @@ IECore::ConstCompoundDataPtr OSLImage::computeShading( const Gaffer::Context *co
 	const float vStep = 1.0f / format.height();
 	const float vMin = 0.5f * vStep;
 
-	const size_t xMax = tileOrigin.x + tileSize;
-	const size_t yMax = tileOrigin.y + tileSize;
-	for( size_t y = tileOrigin.y; y < yMax; ++y )
+	const V2i pMax = tileOrigin + V2i( tileSize );
+	V2i p;
+	for( p.y = tileOrigin.y; p.y < pMax.y; ++p.y )
 	{
-		const float v = vMin + y * vStep;
-		for( size_t x = tileOrigin.x; x < xMax; ++x )
+		const float v = vMin + p.y * vStep;
+		for( p.x = tileOrigin.x; p.x < pMax.x; ++p.x )
 		{
-			uWritable.push_back( uMin + x * uStep );
+			uWritable.push_back( uMin + p.x * uStep );
 			vWritable.push_back( v );
-			pWritable.push_back( V3f( x, y, 0.0f ) );
+			pWritable.push_back( V3f( p.x, p.y, 0.0f ) );
 		}
 	}
 


### PR DESCRIPTION
We definitely want 85b11b0, and 7548c73, but I wonder if anyone thinks that 88c1f0e, despite being a legitimate bugfix, might be something we want to hold back till the next major version in case anyone is relying on the current behaviour?