### PR TITLE
Added 'icon' OSL shader metadata to list of metadata auto-translated by gaffer

### DIFF
--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -57,6 +57,10 @@ def __nodeIcon ( node ) :
 
 	return node.shaderMetadata ( "icon" )
 
+def __nodeIconScale ( node ) :
+
+	return node.shaderMetadata ( "iconScale" )
+
 def __nodeUrl( node ) :
 
 	return node.shaderMetadata( "URL" )
@@ -154,6 +158,7 @@ Gaffer.Metadata.registerNode(
 	"description", __nodeDescription,
 	"documentation:url", __nodeUrl,
 	"icon", __nodeIcon,
+	"iconScale", __nodeIconScale,
 
 	plugs = {
 

--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -53,6 +53,10 @@ def __nodeDescription( node ) :
 	description = node.shaderMetadata( "help" )
 	return description or __defaultDescription
 
+def __nodeIcon ( node ) :
+
+	return node.shaderMetadata ( "icon" )
+
 def __nodeUrl( node ) :
 
 	return node.shaderMetadata( "URL" )
@@ -149,6 +153,7 @@ Gaffer.Metadata.registerNode(
 
 	"description", __nodeDescription,
 	"documentation:url", __nodeUrl,
+	"icon", __nodeIcon,
 
 	plugs = {
 

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -167,6 +167,7 @@ static IECore::InternedString g_paddingKey( "nodeGadget:padding"  );
 static IECore::InternedString g_colorKey( "nodeGadget:color" );
 static IECore::InternedString g_shapeKey( "nodeGadget:shape" );
 static IECore::InternedString g_iconKey( "icon" );
+static IECore::InternedString g_iconScaleKey( "iconScale" );
 static IECore::InternedString g_errorGadgetName( "__error" );
 
 StandardNodeGadget::StandardNodeGadget( Gaffer::NodePtr node )
@@ -744,7 +745,7 @@ void StandardNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore:
 	{
 		updatePadding();
 	}
-	else if( key == g_iconKey )
+	else if( key == g_iconKey || key == g_iconScaleKey )
 	{
 		updateIcon();
 	}
@@ -827,6 +828,13 @@ void StandardNodeGadget::updateNodeEnabled( const Gaffer::Plug *dirtiedPlug )
 
 void StandardNodeGadget::updateIcon()
 {
+	float scale = 1.5f;
+	if( IECore::ConstFloatDataPtr d = Metadata::value<IECore::FloatData>( node(), g_iconScaleKey ) )
+	{
+		scale = d->readable();
+	}
+
+
 	ImageGadgetPtr image;
 	if( IECore::ConstStringDataPtr d = Metadata::value<IECore::StringData>( node(), g_iconKey ) )
 	{
@@ -842,7 +850,7 @@ void StandardNodeGadget::updateIcon()
 
 	if( image )
 	{
-		image->setTransform( M44f().scale( V3f( 1.5 ) / image->bound().size().y ) );
+		image->setTransform( M44f().scale( V3f( scale ) / image->bound().size().y ) );
 	}
 
 	iconContainer()->setChild( image );


### PR DESCRIPTION
Re: the [shader node icon](https://groups.google.com/forum/#!topic/gaffer-dev/sHNmc-rWTAg) discussion on gaffer-dev, I created this pull request. It adds the following feature: Following the "description" and "url" metadata examples, if an OSL shader provides an 'icon' metadata entry, it will be auto-translated to a Gaffer node "icon" metadata entry. This should enable an OSL shader to set the default icon to be displayed in the gaffer node that wraps the OSL shader in the node graph.