### PR TITLE
C++11 : nullptr and override

### DIFF
--- a/contrib/scripts/buildCompileCommands.py
+++ b/contrib/scripts/buildCompileCommands.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import json
+import subprocess
+
+# This builds a compile_commands.json file in the format
+# required by run-clang-tidy.py. It is expected to be run
+# from the root of the gaffer repository, after doing a
+# successful scons build.
+#
+# Example usage :
+#
+# > python contrib/scripts/buildCompileCommands.py
+# > run-clang-tidy.py -header-filter='.*' -checks='-*,modernize-use-override' -fix
+
+# Make SCons tell us everything it would do to build Gaffer
+
+subprocess.check_call( [ "scons", "--clean" ] )
+sconsOutput = subprocess.check_output( [ "scons", "build", "--dry-run", "--no-cache" ] )
+
+# Write that into a "compile_commands.json" file
+
+data = []
+
+for line in sconsOutput.split( "\n" ) :
+
+	line = line.strip()
+	if not line.endswith( ".cpp" ) :
+		continue
+
+	file = line.split()[-1]
+	data.append(
+		{
+			"directory" : "/Users/john/dev/gaffer",
+			"command" : line,
+			"file" : file,
+		}
+	)
+
+with open( "compile_commands.json", "w" ) as f :
+
+	json.dump( data, f )

--- a/include/Gaffer/Action.h
+++ b/include/Gaffer/Action.h
@@ -101,7 +101,7 @@ class Action : public IECore::RunTimeTyped
 	protected :
 
 		Action();
-		virtual ~Action();
+		~Action() override;
 
 		/// Must be implemented by derived classes to
 		/// return the subject of the work they perform -

--- a/include/Gaffer/Animation.h
+++ b/include/Gaffer/Animation.h
@@ -50,7 +50,7 @@ class Animation : public ComputeNode
 	public :
 
 		Animation( const std::string &name=defaultName<Animation>() );
-		virtual ~Animation();
+		~Animation() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Animation, AnimationTypeId, ComputeNode );
 
@@ -158,12 +158,12 @@ class Animation : public ComputeNode
 		/// to aid in the production of a tidy graph.
 		static CurvePlug *acquire( ValuePlug *plug );
 
-		virtual void affects( const Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( ValuePlug *output, const Context *context ) const;
+		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
+		void compute( ValuePlug *output, const Context *context ) const override;
 
 	private :
 

--- a/include/Gaffer/ApplicationRoot.h
+++ b/include/Gaffer/ApplicationRoot.h
@@ -51,14 +51,14 @@ class ApplicationRoot : public GraphComponent
 	public :
 
 		ApplicationRoot( const std::string &name = defaultName<ApplicationRoot>() );
-		virtual ~ApplicationRoot();
+		~ApplicationRoot() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::ApplicationRoot, ApplicationRootTypeId, GraphComponent );
 
 		/// Accepts no user added children.
-		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
+		bool acceptsChild( const GraphComponent *potentialChild ) const override;
 		/// Accepts no parent.
-		virtual bool acceptsParent( const GraphComponent *potentialParent ) const;
+		bool acceptsParent( const GraphComponent *potentialParent ) const override;
 
 		ScriptContainer *scripts();
 		const ScriptContainer *scripts() const;

--- a/include/Gaffer/ArrayPlug.h
+++ b/include/Gaffer/ArrayPlug.h
@@ -68,13 +68,13 @@ class ArrayPlug : public Plug
 			unsigned flags = Default
 		);
 
-		virtual ~ArrayPlug();
+		~ArrayPlug() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::ArrayPlug, ArrayPlugTypeId, Plug );
 
-		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
-		virtual void setInput( PlugPtr input );
-		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsChild( const GraphComponent *potentialChild ) const override;
+		void setInput( PlugPtr input ) override;
+		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		size_t minSize() const;
 		size_t maxSize() const;

--- a/include/Gaffer/Backdrop.h
+++ b/include/Gaffer/Backdrop.h
@@ -53,7 +53,7 @@ class Backdrop : public Node
 	public :
 
 		Backdrop( const std::string &name=defaultName<Backdrop>() );
-		virtual ~Backdrop();
+		~Backdrop() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Backdrop, BackdropTypeId, Node );
 

--- a/include/Gaffer/Box.h
+++ b/include/Gaffer/Box.h
@@ -53,7 +53,7 @@ class Box : public SubGraph
 	public :
 
 		Box( const std::string &name=defaultName<Box>() );
-		virtual ~Box();
+		~Box() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Box, BoxTypeId, SubGraph );
 

--- a/include/Gaffer/BoxIO.h
+++ b/include/Gaffer/BoxIO.h
@@ -69,7 +69,7 @@ class BoxIO : public Node
 
 	public :
 
-		virtual ~BoxIO();
+		~BoxIO() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::BoxIO, BoxIOTypeId, Node );
 
@@ -135,7 +135,7 @@ class BoxIO : public Node
 		Gaffer::Plug *outPlugInternal();
 		const Gaffer::Plug *outPlugInternal() const;
 
-		virtual void parentChanging( Gaffer::GraphComponent *newParent );
+		void parentChanging( Gaffer::GraphComponent *newParent ) override;
 
 	private :
 

--- a/include/Gaffer/BoxIn.h
+++ b/include/Gaffer/BoxIn.h
@@ -48,7 +48,7 @@ class BoxIn : public BoxIO
 	public :
 
 		BoxIn( const std::string &name=defaultName<BoxIn>() );
-		virtual ~BoxIn();
+		~BoxIn() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::BoxIn, BoxInTypeId, BoxIO );
 

--- a/include/Gaffer/BoxOut.h
+++ b/include/Gaffer/BoxOut.h
@@ -48,7 +48,7 @@ class BoxOut : public BoxIO
 	public :
 
 		BoxOut( const std::string &name=defaultName<BoxOut>() );
-		virtual ~BoxOut();
+		~BoxOut() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::BoxOut, BoxOutTypeId, BoxIO );
 

--- a/include/Gaffer/BoxPlug.h
+++ b/include/Gaffer/BoxPlug.h
@@ -75,11 +75,11 @@ class BoxPlug : public ValuePlug
 			unsigned flags = Default
 		);
 
-		virtual ~BoxPlug();
+		~BoxPlug() override;
 
 		/// Accepts no children following construction.
-		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
-		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsChild( const GraphComponent *potentialChild ) const override;
+		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		ChildType *minPlug();
 		const ChildType *minPlug() const;

--- a/include/Gaffer/ChildSet.h
+++ b/include/Gaffer/ChildSet.h
@@ -50,17 +50,17 @@ class ChildSet : public Gaffer::Set
 	public :
 
 		ChildSet( GraphComponentPtr parent );
-		virtual ~ChildSet();
+		~ChildSet() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::ChildSet, ChildSetTypeId, Gaffer::Set );
 
 		/// @name Implementation of the Set interface
 		////////////////////////////////////////////////////////////////////
 		//@{
-		virtual bool contains( const Member *object ) const;
-		virtual Member *member( size_t index );
-		virtual const Member *member( size_t index ) const;
-		virtual size_t size() const;
+		bool contains( const Member *object ) const override;
+		Member *member( size_t index ) override;
+		const Member *member( size_t index ) const override;
+		size_t size() const override;
 		//@}
 
 	private :

--- a/include/Gaffer/CompoundDataPlug.h
+++ b/include/Gaffer/CompoundDataPlug.h
@@ -61,13 +61,13 @@ class CompoundDataPlug : public Gaffer::ValuePlug
 			Direction direction=In,
 			unsigned flags = Default
 		);
-		virtual ~CompoundDataPlug();
+		~CompoundDataPlug() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::CompoundDataPlug, CompoundDataPlugTypeId, Gaffer::ValuePlug );
 
 		/// Accepts only children that can generate values for the CompoundData.
-		virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
-		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const override;
+		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		/// The plug type used to represent the data members.
 		class MemberPlug : public ValuePlug
@@ -92,8 +92,8 @@ class CompoundDataPlug : public Gaffer::ValuePlug
 				BoolPlug *enabledPlug();
 				const BoolPlug *enabledPlug() const;
 
-				virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
-				virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+				bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const override;
+				PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		};
 
@@ -128,7 +128,7 @@ class CompoundDataPlug : public Gaffer::ValuePlug
 		/// Extracts a Data value from a plug previously created with createPlugFromData().
 		static IECore::DataPtr extractDataFromPlug( const ValuePlug *plug );
 
-		virtual IECore::MurmurHash hash() const;
+		IECore::MurmurHash hash() const override;
 		void hash( IECore::MurmurHash &h ) const;
 
 	private :

--- a/include/Gaffer/CompoundNumericPlug.h
+++ b/include/Gaffer/CompoundNumericPlug.h
@@ -68,10 +68,10 @@ class CompoundNumericPlug : public ValuePlug
 			unsigned flags = Default,
 			IECore::GeometricData::Interpretation interpretation = IECore::GeometricData::None
 		);
-		virtual ~CompoundNumericPlug();
+		~CompoundNumericPlug() override;
 		/// Accepts no children following construction.
-		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
-		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsChild( const GraphComponent *potentialChild ) const override;
+		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		using GraphComponent::getChild;
 		ChildType *getChild( size_t index );
@@ -95,7 +95,7 @@ class CompoundNumericPlug : public ValuePlug
 
 		/// Returns a hash to represent the value of this plug
 		/// in the current context.
-		virtual IECore::MurmurHash hash() const;
+		IECore::MurmurHash hash() const override;
 		/// Convenience function to append the hash to h.
 		void hash( IECore::MurmurHash &h ) const;
 

--- a/include/Gaffer/CompoundPathFilter.h
+++ b/include/Gaffer/CompoundPathFilter.h
@@ -52,7 +52,7 @@ class CompoundPathFilter : public Gaffer::PathFilter
 		typedef std::vector<PathFilterPtr> Filters;
 
 		CompoundPathFilter( IECore::CompoundDataPtr userData = nullptr );
-		virtual ~CompoundPathFilter();
+		~CompoundPathFilter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::CompoundPathFilter, CompoundPathFilterTypeId, PathFilter );
 
@@ -64,7 +64,7 @@ class CompoundPathFilter : public Gaffer::PathFilter
 
 	protected :
 
-		virtual void doFilter( std::vector<PathPtr> &paths ) const;
+		void doFilter( std::vector<PathPtr> &paths ) const override;
 
 	private :
 

--- a/include/Gaffer/CompoundPlug.h
+++ b/include/Gaffer/CompoundPlug.h
@@ -56,11 +56,11 @@ class CompoundPlug : public ValuePlug
 	public :
 
 		CompoundPlug( const std::string &name=defaultName<CompoundPlug>(), Direction direction=In, unsigned flags=Default );
-		virtual ~CompoundPlug();
+		~CompoundPlug() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::CompoundPlug, CompoundPlugTypeId, ValuePlug );
 
-		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 };
 

--- a/include/Gaffer/ComputeNode.h
+++ b/include/Gaffer/ComputeNode.h
@@ -59,7 +59,7 @@ class ComputeNode : public DependencyNode
 	public :
 
 		ComputeNode( const std::string &name=defaultName<ComputeNode>() );
-		virtual ~ComputeNode();
+		~ComputeNode() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::ComputeNode, ComputeNodeTypeId, DependencyNode );
 

--- a/include/Gaffer/Container.h
+++ b/include/Gaffer/Container.h
@@ -49,15 +49,15 @@ class Container : public Base
 		IE_CORE_DECLAREMEMBERPTR( Container );
 
 		Container();
-		virtual ~Container();
+		~Container() override;
 
 		//! @name RunTimeTyped interface
 		////////////////////////////////////////////////////////////
 		//@{
-		virtual IECore::TypeId typeId() const;
-		virtual const char *typeName() const;
-		virtual bool isInstanceOf( IECore::TypeId typeId ) const;
-		virtual bool isInstanceOf( const char *typeName ) const;
+		IECore::TypeId typeId() const override;
+		const char *typeName() const override;
+		bool isInstanceOf( IECore::TypeId typeId ) const override;
+		bool isInstanceOf( const char *typeName ) const override;
 		static IECore::TypeId staticTypeId();
 		static const char *staticTypeName();
 		static bool inheritsFrom( IECore::TypeId typeId );
@@ -66,7 +66,7 @@ class Container : public Base
 		//@}
 
 		/// Accepts only type T.
-		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
+		bool acceptsChild( const GraphComponent *potentialChild ) const override;
 
 	private :
 

--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -107,7 +107,7 @@ class Context : public IECore::RefCounted
 		/// Copy constructor. The ownership argument is deprecated - use
 		/// an EditableScope instead of Borrowed ownership.
 		Context( const Context &other, Ownership ownership = Copied );
-		~Context();
+		~Context() override;
 
 		IE_CORE_DECLAREMEMBERPTR( Context )
 

--- a/include/Gaffer/ContextMonitor.h
+++ b/include/Gaffer/ContextMonitor.h
@@ -67,7 +67,7 @@ class ContextMonitor : public Monitor
 		/// Statistics are only collected for the root and its
 		/// descendants.
 		ContextMonitor( const GraphComponent *root = nullptr );
-		virtual ~ContextMonitor();
+		~ContextMonitor() override;
 
 		struct Statistics
 		{
@@ -101,8 +101,8 @@ class ContextMonitor : public Monitor
 
 	protected :
 
-		virtual void processStarted( const Process *process );
-		virtual void processFinished( const Process *process );
+		void processStarted( const Process *process ) override;
+		void processFinished( const Process *process ) override;
 
 	private :
 

--- a/include/Gaffer/ContextProcessor.h
+++ b/include/Gaffer/ContextProcessor.h
@@ -57,23 +57,23 @@ class ContextProcessor : public BaseType
 		IE_CORE_DECLARERUNTIMETYPEDDESCRIPTION( ContextProcessor<BaseType> );
 
 		ContextProcessor( const std::string &name=GraphComponent::defaultName<ContextProcessor>() );
-		virtual ~ContextProcessor();
+		~ContextProcessor() override;
 
-		virtual BoolPlug *enabledPlug();
-		virtual const BoolPlug *enabledPlug() const;
+		BoolPlug *enabledPlug() override;
+		const BoolPlug *enabledPlug() const override;
 
-		virtual Plug *correspondingInput( const Plug *output );
-		virtual const Plug *correspondingInput( const Plug *output ) const;
+		Plug *correspondingInput( const Plug *output ) override;
+		const Plug *correspondingInput( const Plug *output ) const override;
 
-		virtual void affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const;
+		void affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		/// Implemented to return the hash of the matching input using a context modified by
 		/// processContext() - derived class should therefore not need to reimplement hash(),
 		/// and should only implement processContext().
-		virtual void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( ValuePlug *output, const Context *context ) const;
+		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
+		void compute( ValuePlug *output, const Context *context ) const override;
 
 		/// Must be implemented to return true if the input is used in `processContext()`.
 		virtual bool affectsContext( const Plug *input ) const = 0;

--- a/include/Gaffer/ContextProcessor.inl
+++ b/include/Gaffer/ContextProcessor.inl
@@ -240,7 +240,7 @@ const ValuePlug *ContextProcessor<BaseType>::oppositePlug( const ValuePlug *plug
 
 	if( !( outPlug && inPlug ) )
 	{
-		return 0;
+		return nullptr;
 	}
 
 	if( plug->direction() == Plug::Out )

--- a/include/Gaffer/ContextVariables.h
+++ b/include/Gaffer/ContextVariables.h
@@ -54,7 +54,7 @@ class ContextVariables : public ContextProcessor<BaseType>
 		IE_CORE_DECLARERUNTIMETYPEDDESCRIPTION( ContextVariables<BaseType> );
 
 		ContextVariables( const std::string &name=GraphComponent::defaultName<ContextVariables>() );
-		virtual ~ContextVariables();
+		~ContextVariables() override;
 
 		CompoundDataPlug *variablesPlug();
 		const CompoundDataPlug *variablesPlug() const;
@@ -64,8 +64,8 @@ class ContextVariables : public ContextProcessor<BaseType>
 
 	protected :
 
-		virtual bool affectsContext( const Plug *input ) const;
-		virtual void processContext( Context::EditableScope &context ) const;
+		bool affectsContext( const Plug *input ) const override;
+		void processContext( Context::EditableScope &context ) const override;
 
 	private :
 

--- a/include/Gaffer/DeleteContextVariables.h
+++ b/include/Gaffer/DeleteContextVariables.h
@@ -54,15 +54,15 @@ class DeleteContextVariables : public ContextProcessor<BaseType>
 		IE_CORE_DECLARERUNTIMETYPEDDESCRIPTION( DeleteContextVariables<BaseType> );
 
 		DeleteContextVariables( const std::string &name=GraphComponent::defaultName<DeleteContextVariables>() );
-		virtual ~DeleteContextVariables();
+		~DeleteContextVariables() override;
 
 		StringPlug *variablesPlug();
 		const StringPlug *variablesPlug() const;
 
 	protected :
 
-		virtual bool affectsContext( const Plug *input ) const;
-		virtual void processContext( Context::EditableScope &context ) const;
+		bool affectsContext( const Plug *input ) const override;
+		void processContext( Context::EditableScope &context ) const override;
 
 	private :
 

--- a/include/Gaffer/DependencyNode.h
+++ b/include/Gaffer/DependencyNode.h
@@ -56,7 +56,7 @@ class DependencyNode : public Node
 	public :
 
 		DependencyNode( const std::string &name=defaultName<DependencyNode>() );
-		virtual ~DependencyNode();
+		~DependencyNode() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::DependencyNode, DependencyNodeTypeId, Node );
 

--- a/include/Gaffer/Dot.h
+++ b/include/Gaffer/Dot.h
@@ -53,7 +53,7 @@ class Dot : public DependencyNode
 	public :
 
 		Dot( const std::string &name=defaultName<Dot>() );
-		virtual ~Dot();
+		~Dot() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Dot, DotTypeId, DependencyNode );
 
@@ -93,9 +93,9 @@ class Dot : public DependencyNode
 		StringPlug *labelPlug();
 		const StringPlug *labelPlug() const;
 
-		virtual void affects( const Plug *input, AffectedPlugsContainer &outputs ) const;
-		virtual Plug *correspondingInput( const Plug *output );
-		virtual const Plug *correspondingInput( const Plug *output ) const;
+		void affects( const Plug *input, AffectedPlugsContainer &outputs ) const override;
+		Plug *correspondingInput( const Plug *output ) override;
+		const Plug *correspondingInput( const Plug *output ) const override;
 
 	private :
 

--- a/include/Gaffer/Expression.h
+++ b/include/Gaffer/Expression.h
@@ -52,7 +52,7 @@ class Expression : public ComputeNode
 	public :
 
 		Expression( const std::string &name=defaultName<Expression>() );
-		virtual ~Expression();
+		~Expression() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Expression, ExpressionTypeId, ComputeNode );
 
@@ -170,12 +170,12 @@ class Expression : public ComputeNode
 
 		};
 
-		virtual void affects( const Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( ValuePlug *output, const Context *context ) const;
+		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
+		void compute( ValuePlug *output, const Context *context ) const override;
 
 	private :
 

--- a/include/Gaffer/FileSequencePathFilter.h
+++ b/include/Gaffer/FileSequencePathFilter.h
@@ -68,7 +68,7 @@ class FileSequencePathFilter : public PathFilter
 		};
 
 		FileSequencePathFilter( Keep mode = Concise, IECore::CompoundDataPtr userData = nullptr );
-		virtual ~FileSequencePathFilter();
+		~FileSequencePathFilter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::FileSequencePathFilter, FileSequencePathFilterTypeId, Gaffer::PathFilter );
 
@@ -77,7 +77,7 @@ class FileSequencePathFilter : public PathFilter
 
 	protected :
 
-		virtual void doFilter( std::vector<PathPtr> &paths ) const;
+		void doFilter( std::vector<PathPtr> &paths ) const override;
 
 	private :
 

--- a/include/Gaffer/FileSystemPath.h
+++ b/include/Gaffer/FileSystemPath.h
@@ -56,11 +56,11 @@ class FileSystemPath : public Path
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::FileSystemPath, FileSystemPathTypeId, Path );
 
-		virtual ~FileSystemPath();
+		~FileSystemPath() override;
 
-		virtual bool isValid() const;
-		virtual bool isLeaf() const;
-		virtual void propertyNames( std::vector<IECore::InternedString> &names ) const;
+		bool isValid() const override;
+		bool isLeaf() const override;
+		void propertyNames( std::vector<IECore::InternedString> &names ) const override;
 		/// Supported properties :
 		///
 		/// "fileSystem:owner" -> StringData
@@ -68,8 +68,8 @@ class FileSystemPath : public Path
 		/// "fileSystem:modificationTime" -> DateTimeData, in UTC time
 		/// "fileSystem:size" -> UInt64Data, in bytes
 		/// "fileSystem:frameRange" -> StringData
-		virtual IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name ) const;
-		virtual PathPtr copy() const;
+		IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name ) const override;
+		PathPtr copy() const override;
 
 		// Returns true if this FileSystemPath includes FileSequences
 		bool getIncludeSequences() const;
@@ -86,7 +86,7 @@ class FileSystemPath : public Path
 
 	protected :
 
-		virtual void doChildren( std::vector<PathPtr> &children ) const;
+		void doChildren( std::vector<PathPtr> &children ) const override;
 
 	private :
 

--- a/include/Gaffer/GraphComponent.h
+++ b/include/Gaffer/GraphComponent.h
@@ -65,7 +65,7 @@ class GraphComponent : public IECore::RunTimeTyped, public boost::signals::track
 	public :
 
 		GraphComponent( const std::string &name=GraphComponent::defaultName<GraphComponent>() );
-		virtual ~GraphComponent();
+		~GraphComponent() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::GraphComponent, GraphComponentTypeId, IECore::RunTimeTyped );
 

--- a/include/Gaffer/GraphComponent.inl
+++ b/include/Gaffer/GraphComponent.inl
@@ -60,7 +60,7 @@ const T *GraphComponent::getChild( const IECore::InternedString &name ) const
 			return IECore::runTimeCast<const T>( it->get() );
 		}
 	}
-	return 0;
+	return nullptr;
 }
 
 template<typename T>
@@ -87,7 +87,7 @@ const T *GraphComponent::descendant( const std::string &relativePath ) const
 {
 	if( !relativePath.size() )
 	{
-		return 0;
+		return nullptr;
 	}
 
 	typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
@@ -96,7 +96,7 @@ const T *GraphComponent::descendant( const std::string &relativePath ) const
 	const GraphComponent *result = this;
 	for( Tokenizer::iterator tIt=t.begin(); tIt!=t.end(); tIt++ )
 	{
-		const GraphComponent *child = 0;
+		const GraphComponent *child = nullptr;
 		IECore::InternedString internedName( *tIt );
 		for( ChildContainer::const_iterator it=result->m_children.begin(), eIt=result->m_children.end(); it!=eIt; it++ )
 		{
@@ -108,7 +108,7 @@ const T *GraphComponent::descendant( const std::string &relativePath ) const
 		}
 		if( !child )
 		{
-			return 0;
+			return nullptr;
 		}
 		result = child;
 	}

--- a/include/Gaffer/LeafPathFilter.h
+++ b/include/Gaffer/LeafPathFilter.h
@@ -53,13 +53,13 @@ class LeafPathFilter : public Gaffer::PathFilter
 		/// If leafOnly is true then directories will always be passed
 		/// through.
 		LeafPathFilter( IECore::CompoundDataPtr userData = nullptr );
-		virtual ~LeafPathFilter();
+		~LeafPathFilter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::LeafPathFilter, LeafPathFilterTypeId, PathFilter );
 
 	protected :
 
-		virtual void doFilter( std::vector<PathPtr> &paths ) const;
+		void doFilter( std::vector<PathPtr> &paths ) const override;
 
 	private :
 

--- a/include/Gaffer/Loop.h
+++ b/include/Gaffer/Loop.h
@@ -59,7 +59,7 @@ class Loop : public BaseType
 		IECORE_RUNTIMETYPED_DECLARETEMPLATE( Loop<BaseType>, BaseType );
 
 		Loop( const std::string &name=GraphComponent::defaultName<Loop>() );
-		virtual ~Loop();
+		~Loop() override;
 
 		ValuePlug *nextPlug();
 		const ValuePlug *nextPlug() const;
@@ -73,18 +73,18 @@ class Loop : public BaseType
 		StringPlug *indexVariablePlug();
 		const StringPlug *indexVariablePlug() const;
 
-		virtual Gaffer::BoolPlug *enabledPlug();
-		virtual const Gaffer::BoolPlug *enabledPlug() const;
+		Gaffer::BoolPlug *enabledPlug() override;
+		const Gaffer::BoolPlug *enabledPlug() const override;
 
-		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output );
-		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
+		Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) override;
+		const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const override;
 
-		void affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const;
+		void affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( ValuePlug *output, const Context *context ) const;
+		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
+		void compute( ValuePlug *output, const Context *context ) const override;
 
 	private :
 

--- a/include/Gaffer/MatchPatternPathFilter.h
+++ b/include/Gaffer/MatchPatternPathFilter.h
@@ -55,7 +55,7 @@ class MatchPatternPathFilter : public Gaffer::PathFilter
 		/// If leafOnly is true then directories will always be passed
 		/// through.
 		MatchPatternPathFilter( const std::vector<StringAlgo::MatchPattern> &patterns, IECore::InternedString propertyName = "name", bool leafOnly = true, IECore::CompoundDataPtr userData = nullptr );
-		virtual ~MatchPatternPathFilter();
+		~MatchPatternPathFilter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::MatchPatternPathFilter, MatchPatternPathFilterTypeId, PathFilter );
 
@@ -73,7 +73,7 @@ class MatchPatternPathFilter : public Gaffer::PathFilter
 
 	protected :
 
-		virtual void doFilter( std::vector<PathPtr> &paths ) const;
+		void doFilter( std::vector<PathPtr> &paths ) const override;
 
 	private :
 

--- a/include/Gaffer/Node.h
+++ b/include/Gaffer/Node.h
@@ -60,7 +60,7 @@ class Node : public GraphComponent
 	public :
 
 		Node( const std::string &name=defaultName<Node>() );
-		virtual ~Node();
+		~Node() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Node, NodeTypeId, GraphComponent );
 
@@ -126,9 +126,9 @@ class Node : public GraphComponent
 		const ScriptNode *scriptNode() const;
 
 		/// Accepts only Nodes and Plugs.
-		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
+		bool acceptsChild( const GraphComponent *potentialChild ) const override;
 		/// Accepts only Nodes.
-		virtual bool acceptsParent( const GraphComponent *potentialParent ) const;
+		bool acceptsParent( const GraphComponent *potentialParent ) const override;
 
 		/// Signal type for communicating errors. The plug argument is the
 		/// plug being processed when the error occurred. The source argument
@@ -170,7 +170,7 @@ class Node : public GraphComponent
 
 		/// Implemented to remove all connections when the node is being
 		/// unparented.
-		virtual void parentChanging( Gaffer::GraphComponent *newParent );
+		void parentChanging( Gaffer::GraphComponent *newParent ) override;
 
 	private :
 

--- a/include/Gaffer/NumericPlug.h
+++ b/include/Gaffer/NumericPlug.h
@@ -65,11 +65,11 @@ class NumericPlug : public ValuePlug
 			T maxValue = Imath::limits<T>::max(),
 			unsigned flags = Default
 		);
-		virtual ~NumericPlug();
+		~NumericPlug() override;
 
 		/// Accepts other NumericPlugs, including those of different types, and BoolPlugs.
-		virtual bool acceptsInput( const Plug *input ) const;
-		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsInput( const Plug *input ) const override;
+		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		T defaultValue() const;
 
@@ -87,7 +87,7 @@ class NumericPlug : public ValuePlug
 		/// the optional precomputedHash argument - and use with care!
 		T getValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 
-		virtual void setFrom( const ValuePlug *other );
+		void setFrom( const ValuePlug *other ) override;
 
 	private :
 

--- a/include/Gaffer/Path.h
+++ b/include/Gaffer/Path.h
@@ -83,7 +83,7 @@ class Path : public IECore::RunTimeTyped
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Path, PathTypeId, IECore::RunTimeTyped );
 
-		virtual ~Path();
+		~Path() override;
 
 		/// Returns the root of the path - this will be "/" for absolute
 		/// paths and "" for relative paths.

--- a/include/Gaffer/PathFilter.h
+++ b/include/Gaffer/PathFilter.h
@@ -61,7 +61,7 @@ class PathFilter : public IECore::RunTimeTyped
 	public :
 
 		PathFilter( IECore::CompoundDataPtr userData = nullptr );
-		virtual ~PathFilter();
+		~PathFilter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::PathFilter, PathFilterTypeId, IECore::RunTimeTyped );
 

--- a/include/Gaffer/PerformanceMonitor.h
+++ b/include/Gaffer/PerformanceMonitor.h
@@ -61,7 +61,7 @@ class PerformanceMonitor : public Monitor
 	public :
 
 		PerformanceMonitor();
-		virtual ~PerformanceMonitor();
+		~PerformanceMonitor() override;
 
 		struct Statistics
 		{
@@ -94,8 +94,8 @@ class PerformanceMonitor : public Monitor
 
 	protected :
 
-		virtual void processStarted( const Process *process );
-		virtual void processFinished( const Process *process );
+		void processStarted( const Process *process ) override;
+		void processFinished( const Process *process ) override;
 
 	private :
 

--- a/include/Gaffer/Plug.h
+++ b/include/Gaffer/Plug.h
@@ -125,7 +125,7 @@ class Plug : public GraphComponent
 		};
 
 		Plug( const std::string &name=defaultName<Plug>(), Direction direction=In, unsigned flags=Default );
-		virtual ~Plug();
+		~Plug() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Plug, PlugTypeId, GraphComponent );
 
@@ -133,9 +133,9 @@ class Plug : public GraphComponent
 		//////////////////////////////////////////////////////////////////////
 		//@{
 		/// Accepts only Plugs with the same direction.
-		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
+		bool acceptsChild( const GraphComponent *potentialChild ) const override;
 		/// Accepts only Nodes or Plugs as a parent.
-		virtual bool acceptsParent( const GraphComponent *potentialParent ) const;
+		bool acceptsParent( const GraphComponent *potentialParent ) const override;
 		/// Just returns ancestor<Node>() as a syntactic convenience.
 		Node *node();
 		/// Just returns ancestor<Node>() as a syntactic convenience.
@@ -208,7 +208,7 @@ class Plug : public GraphComponent
 
 	protected :
 
-		virtual void parentChanging( Gaffer::GraphComponent *newParent );
+		void parentChanging( Gaffer::GraphComponent *newParent ) override;
 
 		/// Initiates the propagation of dirtiness from the specified
 		/// plug to its outputs and affected plugs (as defined by

--- a/include/Gaffer/Preferences.h
+++ b/include/Gaffer/Preferences.h
@@ -49,14 +49,14 @@ class Preferences : public Node
 	public :
 
 		Preferences( const std::string &name=defaultName<Preferences>() );
-		virtual ~Preferences();
+		~Preferences() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Preferences, PreferencesTypeId, Node );
 
 		/// Accepts only Plugs.
-		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
+		bool acceptsChild( const GraphComponent *potentialChild ) const override;
 		/// Accepts only ApplicationRoots.
-		virtual bool acceptsParent( const GraphComponent *potentialParent ) const;
+		bool acceptsParent( const GraphComponent *potentialParent ) const override;
 
 };
 

--- a/include/Gaffer/Random.h
+++ b/include/Gaffer/Random.h
@@ -53,7 +53,7 @@ class Random : public ComputeNode
 	public :
 
 		Random( const std::string &name=defaultName<Random>() );
-		virtual ~Random();
+		~Random() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Random, RandomTypeId, ComputeNode );
 
@@ -78,14 +78,14 @@ class Random : public ComputeNode
 		Color3fPlug *outColorPlug();
 		const Color3fPlug *outColorPlug() const;
 
-		virtual void affects( const Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		Imath::Color3f randomColor( unsigned long int seed ) const;
 
 	protected :
 
-		virtual void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( ValuePlug *output, const Context *context ) const;
+		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
+		void compute( ValuePlug *output, const Context *context ) const override;
 
 	private :
 

--- a/include/Gaffer/Reference.h
+++ b/include/Gaffer/Reference.h
@@ -50,7 +50,7 @@ class Reference : public SubGraph
 	public :
 
 		Reference( const std::string &name=defaultName<Reference>() );
-		virtual ~Reference();
+		~Reference() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Reference, ReferenceTypeId, SubGraph );
 

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -71,12 +71,12 @@ class ScriptNode : public Node
 	public :
 
 		ScriptNode( const std::string &name=defaultName<Node>() );
-		virtual ~ScriptNode();
+		~ScriptNode() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::ScriptNode, ScriptNodeTypeId, Node );
 
 		/// Accepts parenting only to a ScriptContainer.
-		virtual bool acceptsParent( const GraphComponent *potentialParent ) const;
+		bool acceptsParent( const GraphComponent *potentialParent ) const override;
 
 		/// Convenience function which simply returns ancestor<ApplicationRoot>().
 		ApplicationRoot *applicationRoot();

--- a/include/Gaffer/Set.h
+++ b/include/Gaffer/Set.h
@@ -54,7 +54,7 @@ class Set : public IECore::RunTimeTyped, public boost::signals::trackable
 	public :
 
 		Set();
-		virtual ~Set();
+		~Set() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Set, SetTypeId, IECore::RunTimeTyped );
 

--- a/include/Gaffer/SplinePlug.h
+++ b/include/Gaffer/SplinePlug.h
@@ -78,16 +78,16 @@ class SplinePlug : public ValuePlug
 			const T &defaultValue = T(),
 			unsigned flags = Default
 		);
-		virtual ~SplinePlug();
+		~SplinePlug() override;
 
 		/// Implemented to only accept children which are suitable for use as points
 		/// in the spline.
-		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
-		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsChild( const GraphComponent *potentialChild ) const override;
+		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		const T &defaultValue() const;
-		virtual void setToDefault();
-		virtual bool isSetToDefault() const;
+		void setToDefault() override;
+		bool isSetToDefault() const override;
 
 		/// Sets the value of all the child plugs by decomposing
 		/// the passed spline and storing it in the basis, points,

--- a/include/Gaffer/StandardSet.h
+++ b/include/Gaffer/StandardSet.h
@@ -83,7 +83,7 @@ class StandardSet : public Gaffer::Set
 	public :
 
 		StandardSet( bool removeOrphans = false );
-		virtual ~StandardSet();
+		~StandardSet() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::StandardSet, StandardSetTypeId, Gaffer::Set );
 
@@ -140,10 +140,10 @@ class StandardSet : public Gaffer::Set
 		/// @name Implementation of the Set interface
 		////////////////////////////////////////////////////////////////////
 		//@{
-		virtual bool contains( const Member *object ) const;
-		virtual Member *member( size_t index );
-		virtual const Member *member( size_t index ) const;
-		virtual size_t size() const;
+		bool contains( const Member *object ) const override;
+		Member *member( size_t index ) override;
+		const Member *member( size_t index ) const override;
+		size_t size() const override;
 		//@}
 
 	private :

--- a/include/Gaffer/StringPlug.h
+++ b/include/Gaffer/StringPlug.h
@@ -95,13 +95,13 @@ class StringPlug : public ValuePlug
 			unsigned flags = Default,
 			unsigned substitutions = Context::AllSubstitutions
 		);
-		virtual ~StringPlug();
+		~StringPlug() override;
 
 		unsigned substitutions() const;
 
 		/// Accepts only instances of StringPlug or derived classes.
-		virtual bool acceptsInput( const Plug *input ) const;
-		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsInput( const Plug *input ) const override;
+		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		const std::string &defaultValue() const;
 
@@ -112,9 +112,9 @@ class StringPlug : public ValuePlug
 		/// with care!
 		std::string getValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 
-		virtual void setFrom( const ValuePlug *other );
+		void setFrom( const ValuePlug *other ) override;
 
-		virtual IECore::MurmurHash hash() const;
+		IECore::MurmurHash hash() const override;
 		/// Ensures the method above doesn't mask
 		/// ValuePlug::hash( h )
 		using ValuePlug::hash;

--- a/include/Gaffer/SubGraph.h
+++ b/include/Gaffer/SubGraph.h
@@ -48,16 +48,16 @@ class SubGraph : public DependencyNode
 	public :
 
 		SubGraph( const std::string &name=defaultName<SubGraph>() );
-		virtual ~SubGraph();
+		~SubGraph() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::SubGraph, SubGraphTypeId, DependencyNode );
 
 		/// Does nothing
-		void affects( const Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		/// Returns getChild<BoolPlug>( "enabled" ).
-		virtual BoolPlug *enabledPlug();
-		virtual const BoolPlug *enabledPlug() const;
+		BoolPlug *enabledPlug() override;
+		const BoolPlug *enabledPlug() const override;
 
 		/// Implemented to allow a user to define a pass-through behaviour
 		/// by wiring the nodes inside this sub graph up appropriately. The
@@ -65,8 +65,8 @@ class SubGraph : public DependencyNode
 		/// the sub graph, where that node itself has its enabled plug driven
 		/// by the external enabled plug, and the correspondingInput for the
 		/// node comes from one of the inputs to the sub graph.
-		virtual Plug *correspondingInput( const Plug *output );
-		virtual const Plug *correspondingInput( const Plug *output ) const;
+		Plug *correspondingInput( const Plug *output ) override;
+		const Plug *correspondingInput( const Plug *output ) const override;
 
 };
 

--- a/include/Gaffer/Switch.h
+++ b/include/Gaffer/Switch.h
@@ -117,16 +117,16 @@ class Switch : public BaseType
 		// The internal implementation for hash(). Does nothing when BaseType is not a ComputeNode,
 		// and passes through the hash from the appropriate input when it is.
 		template<typename T>
-		void hashInternal( const ValuePlug *output, const Context *context, IECore::MurmurHash &h, typename boost::enable_if<boost::is_base_of<ComputeNode, T> >::type *enabler = 0 ) const;
+		void hashInternal( const ValuePlug *output, const Context *context, IECore::MurmurHash &h, typename boost::enable_if<boost::is_base_of<ComputeNode, T> >::type *enabler = nullptr ) const;
 		template<typename T>
-		void hashInternal( const ValuePlug *output, const Context *context, IECore::MurmurHash &h, typename boost::disable_if<boost::is_base_of<ComputeNode, T> >::type *enabler = 0 ) const;
+		void hashInternal( const ValuePlug *output, const Context *context, IECore::MurmurHash &h, typename boost::disable_if<boost::is_base_of<ComputeNode, T> >::type *enabler = nullptr ) const;
 
 		// The internal implementation for compute(). Does nothing when BaseType is not a ComputeNode,
 		// and passes through the value from the appropriate input when it is.
 		template<typename T>
-		void computeInternal( ValuePlug *output, const Context *context, typename boost::enable_if<boost::is_base_of<ComputeNode, T> >::type *enabler = 0 ) const;
+		void computeInternal( ValuePlug *output, const Context *context, typename boost::enable_if<boost::is_base_of<ComputeNode, T> >::type *enabler = nullptr ) const;
 		template<typename T>
-		void computeInternal( ValuePlug *output, const Context *context, typename boost::disable_if<boost::is_base_of<ComputeNode, T> >::type *enabler = 0 ) const;
+		void computeInternal( ValuePlug *output, const Context *context, typename boost::disable_if<boost::is_base_of<ComputeNode, T> >::type *enabler = nullptr ) const;
 
 		void childAdded( GraphComponent *child );
 		void plugSet( Plug *plug );

--- a/include/Gaffer/TimeWarp.h
+++ b/include/Gaffer/TimeWarp.h
@@ -53,7 +53,7 @@ class TimeWarp : public ContextProcessor<BaseType>
 		IE_CORE_DECLARERUNTIMETYPEDDESCRIPTION( TimeWarp<BaseType> );
 
 		TimeWarp( const std::string &name=GraphComponent::defaultName<TimeWarp>() );
-		virtual ~TimeWarp();
+		~TimeWarp() override;
 
 		FloatPlug *speedPlug();
 		const FloatPlug *speedPlug() const;
@@ -63,8 +63,8 @@ class TimeWarp : public ContextProcessor<BaseType>
 
 	protected :
 
-		virtual bool affectsContext( const Plug *input ) const;
-		virtual void processContext( Context::EditableScope &context ) const;
+		bool affectsContext( const Plug *input ) const override;
+		void processContext( Context::EditableScope &context ) const override;
 
 };
 

--- a/include/Gaffer/Transform2DPlug.h
+++ b/include/Gaffer/Transform2DPlug.h
@@ -48,12 +48,12 @@ class Transform2DPlug : public ValuePlug
 	public :
 
 		Transform2DPlug( const std::string &name = defaultName<Transform2DPlug>(), Direction direction=In, unsigned flags = Default );
-		virtual ~Transform2DPlug();
+		~Transform2DPlug() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Transform2DPlug, Transform2DPlugTypeId, ValuePlug );
 
-		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
-		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsChild( const GraphComponent *potentialChild ) const override;
+		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		V2fPlug *pivotPlug();
 		const V2fPlug *pivotPlug() const;

--- a/include/Gaffer/TransformPlug.h
+++ b/include/Gaffer/TransformPlug.h
@@ -49,12 +49,12 @@ class TransformPlug : public ValuePlug
 	public :
 
 		TransformPlug( const std::string &name = defaultName<TransformPlug>(), Direction direction=In, unsigned flags = Default );
-		virtual ~TransformPlug();
+		~TransformPlug() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::TransformPlug, TransformPlugTypeId, ValuePlug );
 
-		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
-		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsChild( const GraphComponent *potentialChild ) const override;
+		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		V3fPlug *translatePlug();
 		const V3fPlug *translatePlug() const;

--- a/include/Gaffer/TypedObjectPlug.h
+++ b/include/Gaffer/TypedObjectPlug.h
@@ -69,11 +69,11 @@ class TypedObjectPlug : public ValuePlug
 			ConstValuePtr defaultValue,
 			unsigned flags = Default
 		);
-		virtual ~TypedObjectPlug();
+		~TypedObjectPlug() override;
 
 		/// Accepts only instances of TypedObjectPlug<T>, or derived classes.
-		virtual bool acceptsInput( const Plug *input ) const;
-		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsInput( const Plug *input ) const override;
+		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		const ValueType *defaultValue() const;
 
@@ -110,7 +110,7 @@ class TypedObjectPlug : public ValuePlug
 		/// the ValuePlug cache.
 		ConstValuePtr getValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 
-		virtual void setFrom( const ValuePlug *other );
+		void setFrom( const ValuePlug *other ) override;
 
 	private :
 

--- a/include/Gaffer/TypedPlug.h
+++ b/include/Gaffer/TypedPlug.h
@@ -63,12 +63,12 @@ class TypedPlug : public ValuePlug
 			const T &defaultValue = T(),
 			unsigned flags = Default
 		);
-		virtual ~TypedPlug();
+		~TypedPlug() override;
 
 		/// Accepts only instances of TypedPlug<T> or derived classes.
 		/// In addition, BoolPlug accepts inputs from NumericPlug.
-		virtual bool acceptsInput( const Plug *input ) const;
-		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsInput( const Plug *input ) const override;
+		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		const T &defaultValue() const;
 
@@ -79,11 +79,11 @@ class TypedPlug : public ValuePlug
 		/// with care!
 		T getValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 
-		virtual void setFrom( const ValuePlug *other );
+		void setFrom( const ValuePlug *other ) override;
 
 		/// Implemented to just return ValuePlug::hash(),
 		/// but may be specialised in particular instantiations.
-		virtual IECore::MurmurHash hash() const;
+		IECore::MurmurHash hash() const override;
 		/// Ensures the method above doesn't mask
 		/// ValuePlug::hash( h )
 		using ValuePlug::hash;

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -59,20 +59,20 @@ class ValuePlug : public Plug
 
 		/// Constructs a ValuePlug which can be used as a parent for other ValuePlugs.
 		ValuePlug( const std::string &name=defaultName<ValuePlug>(), Direction direction=In, unsigned flags=Default );
-		virtual ~ValuePlug();
+		~ValuePlug() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::ValuePlug, ValuePlugTypeId, Plug );
 
-		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
+		bool acceptsChild( const GraphComponent *potentialChild ) const override;
 		/// Accepts the input only if it is derived from ValuePlug.
 		/// Derived classes may accept more types provided they
 		/// derive from ValuePlug too, and they can deal with them
 		/// in setFrom().
-		virtual bool acceptsInput( const Plug *input ) const;
+		bool acceptsInput( const Plug *input ) const override;
 		/// Reimplemented so that values can be propagated from inputs.
-		virtual void setInput( PlugPtr input );
+		void setInput( PlugPtr input ) override;
 
-		virtual PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		/// Returns true if it is valid to call setFrom(), setToDefault(),
 		/// or setValue() on this plug. False will be returned if the plug
@@ -157,7 +157,7 @@ class ValuePlug : public Plug
 		void setObjectValue( IECore::ConstObjectPtr value );
 
 		/// Reimplemented for cache management.
-		virtual void dirty();
+		void dirty() override;
 
 	private :
 

--- a/include/GafferAppleseed/AppleseedAttributes.h
+++ b/include/GafferAppleseed/AppleseedAttributes.h
@@ -50,7 +50,7 @@ class AppleseedAttributes : public GafferScene::Attributes
 	public :
 
 		AppleseedAttributes( const std::string &name=defaultName<AppleseedAttributes>() );
-		virtual ~AppleseedAttributes();
+		~AppleseedAttributes() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferAppleseed::AppleseedAttributes, AppleseedAttributesTypeId, GafferScene::Attributes );
 

--- a/include/GafferAppleseed/AppleseedLight.h
+++ b/include/GafferAppleseed/AppleseedLight.h
@@ -54,14 +54,14 @@ class AppleseedLight : public GafferScene::Light
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferAppleseed::AppleseedLight, AppleseedLightTypeId, GafferScene::Light );
 
 		AppleseedLight( const std::string &name=defaultName<AppleseedLight>() );
-		virtual ~AppleseedLight();
+		~AppleseedLight() override;
 
 		void loadShader( const std::string &shaderName );
 
 	protected :
 
-		virtual void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ObjectVectorPtr computeLight( const Gaffer::Context *context ) const;
+		void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ObjectVectorPtr computeLight( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferAppleseed/AppleseedRender.h
+++ b/include/GafferAppleseed/AppleseedRender.h
@@ -50,7 +50,7 @@ class AppleseedRender : public GafferScene::Preview::Render
 	public :
 
 		AppleseedRender( const std::string &name=defaultName<AppleseedRender>() );
-		virtual ~AppleseedRender();
+		~AppleseedRender() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferAppleseed::AppleseedRender, AppleseedRenderTypeId, GafferScene::Preview::Render );
 

--- a/include/GafferAppleseed/AppleseedShaderAdaptor.h
+++ b/include/GafferAppleseed/AppleseedShaderAdaptor.h
@@ -53,12 +53,12 @@ class AppleseedShaderAdaptor : public GafferScene::SceneProcessor
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferAppleseed::AppleseedShaderAdaptor, AppleseedShaderAdaptorTypeId, GafferScene::SceneProcessor );
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const;
+		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const override;
 
 };
 

--- a/include/GafferAppleseed/InteractiveAppleseedRender.h
+++ b/include/GafferAppleseed/InteractiveAppleseedRender.h
@@ -50,7 +50,7 @@ class InteractiveAppleseedRender : public GafferScene::Preview::InteractiveRende
 	public :
 
 		InteractiveAppleseedRender( const std::string &name=defaultName<InteractiveAppleseedRender>() );
-		virtual ~InteractiveAppleseedRender();
+		~InteractiveAppleseedRender() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferAppleseed::InteractiveAppleseedRender, InteractiveAppleseedRenderTypeId, GafferScene::Preview::InteractiveRender );
 

--- a/include/GafferArnold/ArnoldAttributes.h
+++ b/include/GafferArnold/ArnoldAttributes.h
@@ -50,7 +50,7 @@ class ArnoldAttributes : public GafferScene::Attributes
 	public :
 
 		ArnoldAttributes( const std::string &name=defaultName<ArnoldAttributes>() );
-		virtual ~ArnoldAttributes();
+		~ArnoldAttributes() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferArnold::ArnoldAttributes, ArnoldAttributesTypeId, GafferScene::Attributes );
 

--- a/include/GafferArnold/ArnoldDisplacement.h
+++ b/include/GafferArnold/ArnoldDisplacement.h
@@ -57,7 +57,7 @@ class ArnoldDisplacement : public GafferScene::Shader
 	public :
 
 		ArnoldDisplacement( const std::string &name=defaultName<ArnoldDisplacement>() );
-		virtual ~ArnoldDisplacement();
+		~ArnoldDisplacement() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferArnold::ArnoldDisplacement, ArnoldDisplacementTypeId, GafferScene::Shader );
 
@@ -79,14 +79,14 @@ class ArnoldDisplacement : public GafferScene::Shader
 		Gaffer::Plug *outPlug();
 		const Gaffer::Plug *outPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void attributesHash( const Gaffer::Plug *output, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr attributes( const Gaffer::Plug *output ) const;
+		void attributesHash( const Gaffer::Plug *output, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr attributes( const Gaffer::Plug *output ) const override;
 
-		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
 
 	private :
 

--- a/include/GafferArnold/ArnoldLight.h
+++ b/include/GafferArnold/ArnoldLight.h
@@ -52,14 +52,14 @@ class ArnoldLight : public GafferScene::Light
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferArnold::ArnoldLight, ArnoldLightTypeId, GafferScene::Light );
 
 		ArnoldLight( const std::string &name=defaultName<ArnoldLight>() );
-		virtual ~ArnoldLight();
+		~ArnoldLight() override;
 
 		void loadShader( const std::string &shaderName );
 
 	protected :
 
-		virtual void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ObjectVectorPtr computeLight( const Gaffer::Context *context ) const;
+		void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ObjectVectorPtr computeLight( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferArnold/ArnoldMeshLight.h
+++ b/include/GafferArnold/ArnoldMeshLight.h
@@ -48,7 +48,7 @@ class ArnoldMeshLight : public GafferScene::FilteredSceneProcessor
 	public :
 
 		ArnoldMeshLight( const std::string &name=defaultName<ArnoldMeshLight>() );
-		virtual ~ArnoldMeshLight();
+		~ArnoldMeshLight() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferArnold::ArnoldMeshLight, ArnoldMeshLightTypeId, FilteredSceneProcessor );
 

--- a/include/GafferArnold/ArnoldOptions.h
+++ b/include/GafferArnold/ArnoldOptions.h
@@ -50,7 +50,7 @@ class ArnoldOptions : public GafferScene::Options
 	public :
 
 		ArnoldOptions( const std::string &name=defaultName<ArnoldOptions>() );
-		virtual ~ArnoldOptions();
+		~ArnoldOptions() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferArnold::ArnoldOptions, ArnoldOptionsTypeId, GafferScene::Options );
 

--- a/include/GafferArnold/ArnoldRender.h
+++ b/include/GafferArnold/ArnoldRender.h
@@ -50,7 +50,7 @@ class ArnoldRender : public GafferScene::Preview::Render
 	public :
 
 		ArnoldRender( const std::string &name=defaultName<ArnoldRender>() );
-		virtual ~ArnoldRender();
+		~ArnoldRender() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferArnold::ArnoldRender, ArnoldRenderTypeId, GafferScene::Preview::Render );
 

--- a/include/GafferArnold/ArnoldShader.h
+++ b/include/GafferArnold/ArnoldShader.h
@@ -51,16 +51,16 @@ class ArnoldShader : public GafferScene::Shader
 	public :
 
 		ArnoldShader( const std::string &name=defaultName<ArnoldShader>() );
-		virtual ~ArnoldShader();
+		~ArnoldShader() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferArnold::ArnoldShader, ArnoldShaderTypeId, GafferScene::Shader );
 
 		/// Implemented for outPlug(), returning the parameter named in the "primaryInput"
 		/// shader annotation if it has been specified.
-		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output );
-		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
+		Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) override;
+		const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const override;
 
-		virtual void loadShader( const std::string &shaderName, bool keepExistingValues=false );
+		void loadShader( const std::string &shaderName, bool keepExistingValues=false ) override;
 
 	private :
 

--- a/include/GafferArnold/ArnoldVDB.h
+++ b/include/GafferArnold/ArnoldVDB.h
@@ -52,7 +52,7 @@ class ArnoldVDB : public GafferScene::ObjectSource
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferArnold::ArnoldVDB, ArnoldVDBTypeId, GafferScene::ObjectSource );
 
 		ArnoldVDB( const std::string &name=defaultName<ArnoldVDB>() );
-		virtual ~ArnoldVDB();
+		~ArnoldVDB() override;
 
 		Gaffer::StringPlug *fileNamePlug();
 		const Gaffer::StringPlug *fileNamePlug() const;
@@ -75,12 +75,12 @@ class ArnoldVDB : public GafferScene::ObjectSource
 		Gaffer::StringPlug *dsoPlug();
 		const Gaffer::StringPlug *dsoPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
+		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferArnold/InteractiveArnoldRender.h
+++ b/include/GafferArnold/InteractiveArnoldRender.h
@@ -50,7 +50,7 @@ class InteractiveArnoldRender : public GafferScene::Preview::InteractiveRender
 	public :
 
 		InteractiveArnoldRender( const std::string &name=defaultName<InteractiveArnoldRender>() );
-		virtual ~InteractiveArnoldRender();
+		~InteractiveArnoldRender() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferArnold::InteractiveArnoldRender, InteractiveArnoldRenderTypeId, GafferScene::Preview::InteractiveRender );
 

--- a/include/GafferBindings/CompoundPlugBinding.h
+++ b/include/GafferBindings/CompoundPlugBinding.h
@@ -53,7 +53,7 @@ class CompoundPlugSerialiser : public ValuePlugSerialiser
 		// Always returns false - since some children may have input connections, storing the whole value for
 		// the compound may be inappropriate. Derived classes are free to reimplement this to return true in
 		// the event that they can determine that it is appropriate to store the value at the compound level.
-		virtual bool valueNeedsSerialisation( const Gaffer::ValuePlug *plug, const Serialisation &serialisation ) const;
+		bool valueNeedsSerialisation( const Gaffer::ValuePlug *plug, const Serialisation &serialisation ) const override;
 
 };
 

--- a/include/GafferBindings/ComputeNodeBinding.h
+++ b/include/GafferBindings/ComputeNodeBinding.h
@@ -76,7 +76,7 @@ class ComputeNodeWrapper : public DependencyNodeWrapper<WrappedType>
 		{
 		}
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override
 		{
 			/// \todo Stop calling the base class unconditionally - if an override
 			/// exists then the override should call the base class explicitly itself
@@ -107,7 +107,7 @@ class ComputeNodeWrapper : public DependencyNodeWrapper<WrappedType>
 			}
 		}
 
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override
 		{
 			if( this->isSubclassed() )
 			{

--- a/include/GafferBindings/DependencyNodeBinding.h
+++ b/include/GafferBindings/DependencyNodeBinding.h
@@ -87,7 +87,7 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 		{
 		}
 
-		virtual bool isInstanceOf( IECore::TypeId typeId ) const
+		bool isInstanceOf( IECore::TypeId typeId ) const override
 		{
 			if( typeId == (IECore::TypeId)Gaffer::DependencyNodeTypeId )
 			{
@@ -98,7 +98,7 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 			return NodeWrapper<WrappedType>::isInstanceOf( typeId );
 		}
 
-		virtual void affects( const Gaffer::Plug *input, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const
+		void affects( const Gaffer::Plug *input, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -122,7 +122,7 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 			WrappedType::affects( input, outputs );
 		}
 
-		virtual Gaffer::BoolPlug *enabledPlug()
+		Gaffer::BoolPlug *enabledPlug() override
 		{
 			if( this->isSubclassed() )
 			{
@@ -143,13 +143,13 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 			return WrappedType::enabledPlug();
 		}
 
-		virtual const Gaffer::BoolPlug *enabledPlug() const
+		const Gaffer::BoolPlug *enabledPlug() const override
 		{
 			// Better to make an ugly cast than repeat the implementation of the non-const version.
 			return const_cast<DependencyNodeWrapper *>( this )->enabledPlug();
 		}
 
-		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output )
+		Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) override
 		{
 			if( this->isSubclassed() )
 			{
@@ -173,7 +173,7 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 			return WrappedType::correspondingInput( output );
 		}
 
-		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const
+		const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const override
 		{
 			// Better to make an ugly cast than repeat the implementation of the non-const version.
 			return const_cast<DependencyNodeWrapper *>( this )->correspondingInput( output );

--- a/include/GafferBindings/DependencyNodeBinding.h
+++ b/include/GafferBindings/DependencyNodeBinding.h
@@ -60,7 +60,7 @@ class DependencyNodeClass : public NodeClass<T, TWrapper>
 {
 	public :
 
-		DependencyNodeClass( const char *docString = 0 );
+		DependencyNodeClass( const char *docString = nullptr );
 		DependencyNodeClass( const char *docString, boost::python::no_init_t );
 
 };

--- a/include/GafferBindings/GraphComponentBinding.h
+++ b/include/GafferBindings/GraphComponentBinding.h
@@ -50,7 +50,7 @@ class GraphComponentClass : public IECorePython::RunTimeTypedClass<T, TWrapper>
 {
 	public :
 
-		GraphComponentClass( const char *docString = 0 );
+		GraphComponentClass( const char *docString = nullptr );
 
 };
 

--- a/include/GafferBindings/GraphComponentBinding.h
+++ b/include/GafferBindings/GraphComponentBinding.h
@@ -83,7 +83,7 @@ class GraphComponentWrapper : public IECorePython::RunTimeTypedWrapper<WrappedTy
 		{
 		}
 
-		virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const
+		bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -97,7 +97,7 @@ class GraphComponentWrapper : public IECorePython::RunTimeTypedWrapper<WrappedTy
 			return WrappedType::acceptsChild( potentialChild );
 		}
 
-		virtual bool acceptsParent( const Gaffer::GraphComponent *potentialParent ) const
+		bool acceptsParent( const Gaffer::GraphComponent *potentialParent ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -111,7 +111,7 @@ class GraphComponentWrapper : public IECorePython::RunTimeTypedWrapper<WrappedTy
 			return WrappedType::acceptsParent( potentialParent );
 		}
 
-		virtual void parentChanging( Gaffer::GraphComponent *newParent )
+		void parentChanging( Gaffer::GraphComponent *newParent ) override
 		{
 			if( this->isSubclassed() )
 			{

--- a/include/GafferBindings/NodeBinding.h
+++ b/include/GafferBindings/NodeBinding.h
@@ -86,7 +86,7 @@ class NodeWrapper : public GraphComponentWrapper<T>
 		{
 		}
 
-		virtual bool isInstanceOf( IECore::TypeId typeId ) const
+		bool isInstanceOf( IECore::TypeId typeId ) const override
 		{
 			// Optimise for common queries we know should fail.
 			// The standard wrapper implementation of isInstanceOf()
@@ -115,7 +115,7 @@ class NodeWrapper : public GraphComponentWrapper<T>
 			return GraphComponentWrapper<T>::isInstanceOf( typeId );
 		}
 
-		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -136,15 +136,15 @@ class NodeSerialiser : public Serialisation::Serialiser
 
 	public :
 
-		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const;
+		void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const override;
 		/// Implemented to serialise per-instance metadata.
-		virtual std::string postHierarchy( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const;
+		std::string postHierarchy( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override;
 		/// Implemented so that only plugs are serialised - child nodes are expected to
 		/// be a part of the implementation of the node rather than something the user
 		/// has created themselves.
-		virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const;
+		bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override;
 		/// Implemented so that dynamic plugs are constructed appropriately.
-		virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const;
+		bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override;
 
 };
 

--- a/include/GafferBindings/NodeBinding.inl
+++ b/include/GafferBindings/NodeBinding.inl
@@ -47,13 +47,13 @@ namespace Detail
 // node constructor bindings
 
 template<typename T, typename TWrapper>
-void defNodeConstructor( NodeClass<T, TWrapper> &cls, typename boost::enable_if<boost::mpl::not_< boost::is_abstract<TWrapper> > >::type *enabler = 0 )
+void defNodeConstructor( NodeClass<T, TWrapper> &cls, typename boost::enable_if<boost::mpl::not_< boost::is_abstract<TWrapper> > >::type *enabler = nullptr )
 {
 	cls.def( boost::python::init< const std::string & >( boost::python::arg( "name" ) = Gaffer::GraphComponent::defaultName<T>() ) );
 }
 
 template<typename T, typename TWrapper>
-void defNodeConstructor( NodeClass<T, TWrapper> &cls, typename boost::enable_if<boost::is_abstract<TWrapper> >::type *enabler = 0 )
+void defNodeConstructor( NodeClass<T, TWrapper> &cls, typename boost::enable_if<boost::is_abstract<TWrapper> >::type *enabler = nullptr )
 {
 	// nothing to bind for abstract classes
 }

--- a/include/GafferBindings/PlugBinding.h
+++ b/include/GafferBindings/PlugBinding.h
@@ -55,7 +55,7 @@ class PlugClass : public GraphComponentClass<T, TWrapper>
 {
 	public :
 
-		PlugClass( const char *docString = 0 );
+		PlugClass( const char *docString = nullptr );
 
 };
 

--- a/include/GafferBindings/PlugBinding.h
+++ b/include/GafferBindings/PlugBinding.h
@@ -69,7 +69,7 @@ class PlugWrapper : public GraphComponentWrapper<WrappedType>
 		{
 		}
 
-		virtual bool isInstanceOf( IECore::TypeId typeId ) const
+		bool isInstanceOf( IECore::TypeId typeId ) const override
 		{
 			// Optimise for common queries we know should fail.
 			// The standard wrapper implementation of isInstanceOf()
@@ -90,7 +90,7 @@ class PlugWrapper : public GraphComponentWrapper<WrappedType>
 			return GraphComponentWrapper<WrappedType>::isInstanceOf( typeId );
 		}
 
-		virtual bool acceptsInput( const Gaffer::Plug *input ) const
+		bool acceptsInput( const Gaffer::Plug *input ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -104,7 +104,7 @@ class PlugWrapper : public GraphComponentWrapper<WrappedType>
 			return WrappedType::acceptsInput( input );
 		}
 
-		virtual void setInput( Gaffer::PlugPtr input )
+		void setInput( Gaffer::PlugPtr input ) override
 		{
 			if( this->isSubclassed() )
 			{
@@ -119,7 +119,7 @@ class PlugWrapper : public GraphComponentWrapper<WrappedType>
 			WrappedType::setInput( input );
 		}
 
-		virtual Gaffer::PlugPtr createCounterpart( const std::string &name, Gaffer::Plug::Direction direction ) const
+		Gaffer::PlugPtr createCounterpart( const std::string &name, Gaffer::Plug::Direction direction ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -141,11 +141,11 @@ class PlugSerialiser : public Serialisation::Serialiser
 
 	public :
 
-		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const;
-		virtual std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const;
-		virtual std::string postHierarchy( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const;
-		virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const;
-		virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const;
+		void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const override;
+		std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const override;
+		std::string postHierarchy( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override;
+		bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override;
+		bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override;
 
 		static std::string directionRepr( Gaffer::Plug::Direction direction );
 		static std::string flagsRepr( unsigned flags );

--- a/include/GafferBindings/Serialisation.h
+++ b/include/GafferBindings/Serialisation.h
@@ -49,7 +49,7 @@ class Serialisation
 
 	public :
 
-		Serialisation( const Gaffer::GraphComponent *parent, const std::string &parentName = "parent", const Gaffer::Set *filter = 0 );
+		Serialisation( const Gaffer::GraphComponent *parent, const std::string &parentName = "parent", const Gaffer::Set *filter = nullptr );
 
 		/// Returns the parent passed to the constructor.
 		const Gaffer::GraphComponent *parent() const;

--- a/include/GafferBindings/TypedPlugBinding.h
+++ b/include/GafferBindings/TypedPlugBinding.h
@@ -49,7 +49,7 @@ class TypedPlugClass : public PlugClass<T, TWrapper>
 {
 	public :
 
-		TypedPlugClass( const char *docString = 0 );
+		TypedPlugClass( const char *docString = nullptr );
 
 };
 

--- a/include/GafferBindings/ValuePlugBinding.h
+++ b/include/GafferBindings/ValuePlugBinding.h
@@ -58,9 +58,9 @@ class ValuePlugSerialiser : public PlugSerialiser
 
 	public :
 
-		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const;
-		virtual std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const;
-		virtual std::string postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const;
+		void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const override;
+		std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const override;
+		std::string postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override;
 
 		static std::string repr( const Gaffer::ValuePlug *plug, unsigned flagsMask = Gaffer::Plug::All, const std::string &extraArguments = "", const Serialisation *serialisation = nullptr );
 

--- a/include/GafferCortex/CompoundParameterHandler.h
+++ b/include/GafferCortex/CompoundParameterHandler.h
@@ -60,16 +60,16 @@ class CompoundParameterHandler : public ParameterHandler
 		IE_CORE_DECLAREMEMBERPTR( CompoundParameterHandler );
 
 		CompoundParameterHandler( IECore::CompoundParameterPtr parameter );
-		virtual ~CompoundParameterHandler();
+		~CompoundParameterHandler() override;
 
-		virtual IECore::Parameter *parameter();
-		virtual const IECore::Parameter *parameter() const;
-		virtual void restore( Gaffer::GraphComponent *plugParent );
-		virtual Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction=Gaffer::Plug::In, unsigned flags = Gaffer::Plug::Default | Gaffer::Plug::Dynamic );
-		virtual Gaffer::Plug *plug();
-		virtual const Gaffer::Plug *plug() const;
-		virtual void setParameterValue();
-		virtual void setPlugValue();
+		IECore::Parameter *parameter() override;
+		const IECore::Parameter *parameter() const override;
+		void restore( Gaffer::GraphComponent *plugParent ) override;
+		Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction=Gaffer::Plug::In, unsigned flags = Gaffer::Plug::Default | Gaffer::Plug::Dynamic ) override;
+		Gaffer::Plug *plug() override;
+		const Gaffer::Plug *plug() const override;
+		void setParameterValue() override;
+		void setPlugValue() override;
 
 		ParameterHandler *childParameterHandler( IECore::Parameter *childParameter );
 		const ParameterHandler *childParameterHandler( IECore::Parameter *childParameter ) const;

--- a/include/GafferCortex/DateTimeParameterHandler.h
+++ b/include/GafferCortex/DateTimeParameterHandler.h
@@ -59,16 +59,16 @@ class DateTimeParameterHandler : public ParameterHandler
 		IE_CORE_DECLAREMEMBERPTR( DateTimeParameterHandler );
 
 		DateTimeParameterHandler( IECore::DateTimeParameterPtr parameter );
-		virtual ~DateTimeParameterHandler();
+		~DateTimeParameterHandler() override;
 
-		virtual IECore::Parameter *parameter();
-		virtual const IECore::Parameter *parameter() const;
-		virtual void restore( Gaffer::GraphComponent *plugParent );
-		virtual Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction=Gaffer::Plug::In, unsigned flags = Gaffer::Plug::Default | Gaffer::Plug::Dynamic );
-		virtual Gaffer::Plug *plug();
-		virtual const Gaffer::Plug *plug() const;
-		virtual void setParameterValue();
-		virtual void setPlugValue();
+		IECore::Parameter *parameter() override;
+		const IECore::Parameter *parameter() const override;
+		void restore( Gaffer::GraphComponent *plugParent ) override;
+		Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction=Gaffer::Plug::In, unsigned flags = Gaffer::Plug::Default | Gaffer::Plug::Dynamic ) override;
+		Gaffer::Plug *plug() override;
+		const Gaffer::Plug *plug() const override;
+		void setParameterValue() override;
+		void setPlugValue() override;
 
 	private :
 

--- a/include/GafferCortex/ExecutableOpHolder.h
+++ b/include/GafferCortex/ExecutableOpHolder.h
@@ -66,8 +66,8 @@ class ExecutableOpHolder : public ParameterisedHolderTaskNode
 		/// Convenience function which calls setParameterised( className, classVersion, "IECORE_OP_PATHS", keepExistingValues )
 		void setOp( const std::string &className, int classVersion, bool keepExistingValues=false );
 		/// Convenience function which returns runTimeCast<Op>( getParameterised() );
-		IECore::Op *getOp( std::string *className = 0, int *classVersion = 0 );
-		const IECore::Op *getOp( std::string *className = 0, int *classVersion = 0 ) const;
+		IECore::Op *getOp( std::string *className = nullptr, int *classVersion = nullptr );
+		const IECore::Op *getOp( std::string *className = nullptr, int *classVersion = nullptr ) const;
 
 		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
 		void execute() const override;

--- a/include/GafferCortex/ExecutableOpHolder.h
+++ b/include/GafferCortex/ExecutableOpHolder.h
@@ -61,7 +61,7 @@ class ExecutableOpHolder : public ParameterisedHolderTaskNode
 
 		ExecutableOpHolder( const std::string &name=defaultName<ExecutableOpHolder>() );
 
-		virtual void setParameterised( IECore::RunTimeTypedPtr parameterised, bool keepExistingValues=false );
+		void setParameterised( IECore::RunTimeTypedPtr parameterised, bool keepExistingValues=false ) override;
 
 		/// Convenience function which calls setParameterised( className, classVersion, "IECORE_OP_PATHS", keepExistingValues )
 		void setOp( const std::string &className, int classVersion, bool keepExistingValues=false );
@@ -69,8 +69,8 @@ class ExecutableOpHolder : public ParameterisedHolderTaskNode
 		IECore::Op *getOp( std::string *className = 0, int *classVersion = 0 );
 		const IECore::Op *getOp( std::string *className = 0, int *classVersion = 0 ) const;
 
-		virtual IECore::MurmurHash hash( const Gaffer::Context *context ) const;
-		virtual void execute() const;
+		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
+		void execute() const override;
 
 };
 

--- a/include/GafferCortex/NumericParameterHandler.h
+++ b/include/GafferCortex/NumericParameterHandler.h
@@ -57,16 +57,16 @@ class NumericParameterHandler : public ParameterHandler
 		typedef Gaffer::NumericPlug<T> PlugType;
 
 		NumericParameterHandler( typename ParameterType::Ptr parameter );
-		virtual ~NumericParameterHandler();
+		~NumericParameterHandler() override;
 
-		virtual IECore::Parameter *parameter();
-		virtual const IECore::Parameter *parameter() const;
-		virtual void restore( Gaffer::GraphComponent *plugParent );
-		virtual Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction=Gaffer::Plug::In, unsigned flags = Gaffer::Plug::Default | Gaffer::Plug::Dynamic );
-		virtual Gaffer::Plug *plug();
-		virtual const Gaffer::Plug *plug() const;
-		virtual void setParameterValue();
-		virtual void setPlugValue();
+		IECore::Parameter *parameter() override;
+		const IECore::Parameter *parameter() const override;
+		void restore( Gaffer::GraphComponent *plugParent ) override;
+		Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction=Gaffer::Plug::In, unsigned flags = Gaffer::Plug::Default | Gaffer::Plug::Dynamic ) override;
+		Gaffer::Plug *plug() override;
+		const Gaffer::Plug *plug() const override;
+		void setParameterValue() override;
+		void setPlugValue() override;
 
 	private :
 

--- a/include/GafferCortex/ObjectParameterHandler.h
+++ b/include/GafferCortex/ObjectParameterHandler.h
@@ -58,16 +58,16 @@ class ObjectParameterHandler : public ParameterHandler
 		IE_CORE_DECLAREMEMBERPTR( ObjectParameterHandler );
 
 		ObjectParameterHandler( IECore::ObjectParameter::Ptr parameter );
-		virtual ~ObjectParameterHandler();
+		~ObjectParameterHandler() override;
 
-		virtual IECore::Parameter *parameter();
-		virtual const IECore::Parameter *parameter() const;
-		virtual void restore( Gaffer::GraphComponent *plugParent );
-		virtual Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction=Gaffer::Plug::In, unsigned flags = Gaffer::Plug::Default | Gaffer::Plug::Dynamic );
-		virtual Gaffer::Plug *plug();
-		virtual const Gaffer::Plug *plug() const;
-		virtual void setParameterValue();
-		virtual void setPlugValue();
+		IECore::Parameter *parameter() override;
+		const IECore::Parameter *parameter() const override;
+		void restore( Gaffer::GraphComponent *plugParent ) override;
+		Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction=Gaffer::Plug::In, unsigned flags = Gaffer::Plug::Default | Gaffer::Plug::Dynamic ) override;
+		Gaffer::Plug *plug() override;
+		const Gaffer::Plug *plug() const override;
+		void setParameterValue() override;
+		void setPlugValue() override;
 
 	private :
 

--- a/include/GafferCortex/OpHolder.h
+++ b/include/GafferCortex/OpHolder.h
@@ -60,7 +60,7 @@ class OpHolder : public ParameterisedHolderComputeNode
 
 		OpHolder( const std::string &name=defaultName<OpHolder>() );
 
-		virtual void setParameterised( IECore::RunTimeTypedPtr parameterised, bool keepExistingValues=false );
+		void setParameterised( IECore::RunTimeTypedPtr parameterised, bool keepExistingValues=false ) override;
 
 		/// Convenience function which calls setParameterised( className, classVersion, "IECORE_OP_PATHS", keepExistingValues )
 		void setOp( const std::string &className, int classVersion, bool keepExistingValues=false );
@@ -68,12 +68,12 @@ class OpHolder : public ParameterisedHolderComputeNode
 		IECore::Op *getOp( std::string *className = 0, int *classVersion = 0 );
 		const IECore::Op *getOp( std::string *className = 0, int *classVersion = 0 ) const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferCortex/OpHolder.h
+++ b/include/GafferCortex/OpHolder.h
@@ -65,8 +65,8 @@ class OpHolder : public ParameterisedHolderComputeNode
 		/// Convenience function which calls setParameterised( className, classVersion, "IECORE_OP_PATHS", keepExistingValues )
 		void setOp( const std::string &className, int classVersion, bool keepExistingValues=false );
 		/// Convenience function which returns runTimeCast<Op>( getParameterised() );
-		IECore::Op *getOp( std::string *className = 0, int *classVersion = 0 );
-		const IECore::Op *getOp( std::string *className = 0, int *classVersion = 0 ) const;
+		IECore::Op *getOp( std::string *className = nullptr, int *classVersion = nullptr );
+		const IECore::Op *getOp( std::string *className = nullptr, int *classVersion = nullptr ) const;
 
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 

--- a/include/GafferCortex/ParameterHandler.h
+++ b/include/GafferCortex/ParameterHandler.h
@@ -58,7 +58,7 @@ class ParameterHandler : public IECore::RefCounted
 
 		IE_CORE_DECLAREMEMBERPTR( ParameterHandler );
 
-		virtual ~ParameterHandler();
+		~ParameterHandler() override;
 
 		virtual IECore::Parameter *parameter() = 0;
 		virtual const IECore::Parameter *parameter() const = 0;

--- a/include/GafferCortex/ParameterisedHolder.h
+++ b/include/GafferCortex/ParameterisedHolder.h
@@ -72,9 +72,9 @@ class ParameterisedHolder : public BaseType
 		/// first.
 		virtual void setParameterised( IECore::RunTimeTypedPtr parameterised, bool keepExistingValues=false );
 		void setParameterised( const std::string &className, int classVersion, const std::string &searchPathEnvVar, bool keepExistingValues=false );
-		IECore::RunTimeTyped *getParameterised( std::string *className = 0, int *classVersion = 0, std::string *searchPathEnvVar = 0 ) const;
+		IECore::RunTimeTyped *getParameterised( std::string *className = nullptr, int *classVersion = nullptr, std::string *searchPathEnvVar = nullptr ) const;
 		/// Convenience method to return dynamic_cast<const IECore::ParameterisedInterface *>( getParameterised().get() )
-		IECore::ParameterisedInterface *parameterisedInterface( std::string *className = 0, int *classVersion = 0, std::string *searchPathEnvVar = 0 );
+		IECore::ParameterisedInterface *parameterisedInterface( std::string *className = nullptr, int *classVersion = nullptr, std::string *searchPathEnvVar = nullptr );
 
 		CompoundParameterHandler *parameterHandler();
 		const CompoundParameterHandler *parameterHandler() const;

--- a/include/GafferCortex/ParameterisedHolder.h
+++ b/include/GafferCortex/ParameterisedHolder.h
@@ -66,7 +66,7 @@ class ParameterisedHolder : public BaseType
 		IE_CORE_DECLARERUNTIMETYPEDDESCRIPTION( ParameterisedHolder<BaseType> );
 
 		ParameterisedHolder( const std::string &name=Gaffer::GraphComponent::defaultName<ParameterisedHolder>() );
-		virtual ~ParameterisedHolder();
+		~ParameterisedHolder() override;
 
 		/// May be overridden by derived classes, but they must call the base class implementation
 		/// first.

--- a/include/GafferCortex/ProceduralHolder.h
+++ b/include/GafferCortex/ProceduralHolder.h
@@ -58,7 +58,7 @@ class ProceduralHolder : public ParameterisedHolderComputeNode
 
 		ProceduralHolder( const std::string &name=defaultName<ProceduralHolder>() );
 
-		virtual void setParameterised( IECore::RunTimeTypedPtr parameterised, bool keepExistingValues=false );
+		void setParameterised( IECore::RunTimeTypedPtr parameterised, bool keepExistingValues=false ) override;
 
 		/// Convenience function which calls setParameterised( className, classVersion, "IECORE_PROCEDURAL_PATHS" )
 		void setProcedural( const std::string &className, int classVersion );
@@ -66,12 +66,12 @@ class ProceduralHolder : public ParameterisedHolderComputeNode
 		IECore::ParameterisedProcedural *getProcedural( std::string *className = 0, int *classVersion = 0 );
 		const IECore::ParameterisedProcedural *getProcedural( std::string *className = 0, int *classVersion = 0 ) const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 };
 

--- a/include/GafferCortex/ProceduralHolder.h
+++ b/include/GafferCortex/ProceduralHolder.h
@@ -63,8 +63,8 @@ class ProceduralHolder : public ParameterisedHolderComputeNode
 		/// Convenience function which calls setParameterised( className, classVersion, "IECORE_PROCEDURAL_PATHS" )
 		void setProcedural( const std::string &className, int classVersion );
 		/// Convenience function which returns runTimeCast<ParameterisedProcedural>( getParameterised() );
-		IECore::ParameterisedProcedural *getProcedural( std::string *className = 0, int *classVersion = 0 );
-		const IECore::ParameterisedProcedural *getProcedural( std::string *className = 0, int *classVersion = 0 ) const;
+		IECore::ParameterisedProcedural *getProcedural( std::string *className = nullptr, int *classVersion = nullptr );
+		const IECore::ParameterisedProcedural *getProcedural( std::string *className = nullptr, int *classVersion = nullptr ) const;
 
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 

--- a/include/GafferCortex/TimeCodeParameterHandler.h
+++ b/include/GafferCortex/TimeCodeParameterHandler.h
@@ -54,16 +54,16 @@ class TimeCodeParameterHandler : public ParameterHandler
 		IE_CORE_DECLAREMEMBERPTR( TimeCodeParameterHandler );
 
 		TimeCodeParameterHandler( IECore::TimeCodeParameterPtr parameter );
-		virtual ~TimeCodeParameterHandler();
+		~TimeCodeParameterHandler() override;
 
-		virtual IECore::Parameter *parameter();
-		virtual const IECore::Parameter *parameter() const;
-		virtual void restore( Gaffer::GraphComponent *plugParent );
-		virtual Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction=Gaffer::Plug::In, unsigned flags = Gaffer::Plug::Default | Gaffer::Plug::Dynamic );
-		virtual Gaffer::Plug *plug();
-		virtual const Gaffer::Plug *plug() const;
-		virtual void setParameterValue();
-		virtual void setPlugValue();
+		IECore::Parameter *parameter() override;
+		const IECore::Parameter *parameter() const override;
+		void restore( Gaffer::GraphComponent *plugParent ) override;
+		Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction=Gaffer::Plug::In, unsigned flags = Gaffer::Plug::Default | Gaffer::Plug::Dynamic ) override;
+		Gaffer::Plug *plug() override;
+		const Gaffer::Plug *plug() const override;
+		void setParameterValue() override;
+		void setPlugValue() override;
 
 	private :
 

--- a/include/GafferCortex/TypedParameterHandler.h
+++ b/include/GafferCortex/TypedParameterHandler.h
@@ -57,16 +57,16 @@ class TypedParameterHandler : public ParameterHandler
 		typedef typename Gaffer::PlugType<T>::Type PlugType;
 
 		TypedParameterHandler( typename ParameterType::Ptr parameter );
-		virtual ~TypedParameterHandler();
+		~TypedParameterHandler() override;
 
-		virtual IECore::Parameter *parameter();
-		virtual const IECore::Parameter *parameter() const;
-		virtual void restore( Gaffer::GraphComponent *plugParent );
-		virtual Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction=Gaffer::Plug::In, unsigned flags = Gaffer::Plug::Default | Gaffer::Plug::Dynamic );
-		virtual Gaffer::Plug *plug();
-		virtual const Gaffer::Plug *plug() const;
-		virtual void setParameterValue();
-		virtual void setPlugValue();
+		IECore::Parameter *parameter() override;
+		const IECore::Parameter *parameter() const override;
+		void restore( Gaffer::GraphComponent *plugParent ) override;
+		Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction=Gaffer::Plug::In, unsigned flags = Gaffer::Plug::Default | Gaffer::Plug::Dynamic ) override;
+		Gaffer::Plug *plug() override;
+		const Gaffer::Plug *plug() const override;
+		void setParameterValue() override;
+		void setPlugValue() override;
 
 	private :
 

--- a/include/GafferCortex/VectorTypedParameterHandler.h
+++ b/include/GafferCortex/VectorTypedParameterHandler.h
@@ -57,16 +57,16 @@ class VectorTypedParameterHandler : public ParameterHandler
 		typedef Gaffer::TypedObjectPlug<DataType> PlugType;
 
 		VectorTypedParameterHandler( typename ParameterType::Ptr parameter );
-		virtual ~VectorTypedParameterHandler();
+		~VectorTypedParameterHandler() override;
 
-		virtual IECore::Parameter *parameter();
-		virtual const IECore::Parameter *parameter() const;
-		virtual void restore( Gaffer::GraphComponent *plugParent );
-		virtual Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction=Gaffer::Plug::In, unsigned flags = Gaffer::Plug::Default | Gaffer::Plug::Dynamic );
-		virtual Gaffer::Plug *plug();
-		virtual const Gaffer::Plug *plug() const;
-		virtual void setParameterValue();
-		virtual void setPlugValue();
+		IECore::Parameter *parameter() override;
+		const IECore::Parameter *parameter() const override;
+		void restore( Gaffer::GraphComponent *plugParent ) override;
+		Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction=Gaffer::Plug::In, unsigned flags = Gaffer::Plug::Default | Gaffer::Plug::Dynamic ) override;
+		Gaffer::Plug *plug() override;
+		const Gaffer::Plug *plug() const override;
+		void setParameterValue() override;
+		void setPlugValue() override;
 
 	private :
 

--- a/include/GafferCortexBindings/ParameterisedHolderBinding.h
+++ b/include/GafferCortexBindings/ParameterisedHolderBinding.h
@@ -105,7 +105,7 @@ class ParameterisedHolderClass : public BaseType
 
 	public :
 
-		ParameterisedHolderClass( const char *docString = 0 )
+		ParameterisedHolderClass( const char *docString = nullptr )
 			:	BaseType( docString )
 		{
 

--- a/include/GafferCortexBindings/ParameterisedHolderBinding.h
+++ b/include/GafferCortexBindings/ParameterisedHolderBinding.h
@@ -61,7 +61,7 @@ class ParameterisedHolderWrapper : public BaseType
 		{
 		}
 
-		virtual IECore::RunTimeTypedPtr loadClass( const std::string &className, int classVersion, const std::string &searchPathEnvVar ) const
+		IECore::RunTimeTypedPtr loadClass( const std::string &className, int classVersion, const std::string &searchPathEnvVar ) const override
 		{
 			IECorePython::ScopedGILLock gilLock;
 			boost::python::dict scopeDict;
@@ -75,7 +75,7 @@ class ParameterisedHolderWrapper : public BaseType
 			return boost::python::extract<IECore::RunTimeTypedPtr>( result );
 		}
 
-		virtual void parameterChanged( IECore::RunTimeTyped *parameterised, IECore::Parameter *parameter )
+		void parameterChanged( IECore::RunTimeTyped *parameterised, IECore::Parameter *parameter ) override
 		{
 			IECorePython::ScopedGILLock gilLock;
 			IECore::RunTimeTypedPtr parameterisedPtr( parameterised );

--- a/include/GafferDispatch/Dispatcher.h
+++ b/include/GafferDispatch/Dispatcher.h
@@ -100,7 +100,7 @@ class Dispatcher : public Gaffer::Node
 	public :
 
 		Dispatcher( const std::string &name=defaultName<Dispatcher>() );
-		virtual ~Dispatcher();
+		~Dispatcher() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferDispatch::Dispatcher, DispatcherTypeId, Gaffer::Node );
 

--- a/include/GafferDispatch/Dispatcher.h
+++ b/include/GafferDispatch/Dispatcher.h
@@ -191,7 +191,7 @@ class Dispatcher : public Gaffer::Node
 		static const std::string &getDefaultDispatcherType();
 		static void setDefaultDispatcherType( const std::string &dispatcherType );
 		/// Register a Dispatcher creation function.
-		static void registerDispatcher( const std::string &dispatcherType, Creator creator, SetupPlugsFn setupPlugsFn = 0 );
+		static void registerDispatcher( const std::string &dispatcherType, Creator creator, SetupPlugsFn setupPlugsFn = nullptr );
 		/// Fills the vector with the names of all the registered Dispatcher creators.
 		static void registeredDispatchers( std::vector<std::string> &dispatcherTypes );
 		//@}

--- a/include/GafferDispatch/TaskNode.h
+++ b/include/GafferDispatch/TaskNode.h
@@ -126,7 +126,7 @@ class TaskNode : public Gaffer::DependencyNode
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferDispatch::TaskNode, TaskNodeTypeId, Gaffer::DependencyNode );
 
 		TaskNode( const std::string &name=defaultName<TaskNode>() );
-		virtual ~TaskNode();
+		~TaskNode() override;
 
 		/// Plug type used to represent tasks within the
 		/// node graph. This provides the primary public
@@ -140,9 +140,9 @@ class TaskNode : public Gaffer::DependencyNode
 
 				TaskPlug( const std::string &name=defaultName<TaskPlug>(), Direction direction=In, unsigned flags=Default );
 
-				virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
-				virtual bool acceptsInput( const Gaffer::Plug *input ) const;
-				virtual Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+				bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const override;
+				bool acceptsInput( const Gaffer::Plug *input ) const override;
+				Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 				/// Returns a hash representing the side effects of
 				/// calling `execute()` in the current context.
@@ -193,7 +193,7 @@ class TaskNode : public Gaffer::DependencyNode
 		Gaffer::Plug *dispatcherPlug();
 		const Gaffer::Plug *dispatcherPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 

--- a/include/GafferDispatchBindings/TaskNodeBinding.h
+++ b/include/GafferDispatchBindings/TaskNodeBinding.h
@@ -70,7 +70,7 @@ class TaskNodeWrapper : public GafferBindings::DependencyNodeWrapper<WrappedType
 		{
 		}
 
-		virtual bool affectsTask( const Gaffer::Plug *input ) const
+		bool affectsTask( const Gaffer::Plug *input ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -93,7 +93,7 @@ class TaskNodeWrapper : public GafferBindings::DependencyNodeWrapper<WrappedType
 			return WrappedType::affectsTask( input );
 		}
 
-		virtual void preTasks( const Gaffer::Context *context, GafferDispatch::TaskNode::Tasks &tasks ) const
+		void preTasks( const Gaffer::Context *context, GafferDispatch::TaskNode::Tasks &tasks ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -124,7 +124,7 @@ class TaskNodeWrapper : public GafferBindings::DependencyNodeWrapper<WrappedType
 			WrappedType::preTasks( context, tasks );
 		}
 
-		virtual void postTasks( const Gaffer::Context *context, GafferDispatch::TaskNode::Tasks &tasks ) const
+		void postTasks( const Gaffer::Context *context, GafferDispatch::TaskNode::Tasks &tasks ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -149,7 +149,7 @@ class TaskNodeWrapper : public GafferBindings::DependencyNodeWrapper<WrappedType
 			WrappedType::postTasks( context, tasks );
 		}
 
-		virtual IECore::MurmurHash hash( const Gaffer::Context *context ) const
+		IECore::MurmurHash hash( const Gaffer::Context *context ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -172,7 +172,7 @@ class TaskNodeWrapper : public GafferBindings::DependencyNodeWrapper<WrappedType
 			return WrappedType::hash( context );
 		}
 
-		virtual void execute() const
+		void execute() const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -194,7 +194,7 @@ class TaskNodeWrapper : public GafferBindings::DependencyNodeWrapper<WrappedType
 			WrappedType::execute();
 		}
 
-		virtual void executeSequence( const std::vector<float> &frames ) const
+		void executeSequence( const std::vector<float> &frames ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -221,7 +221,7 @@ class TaskNodeWrapper : public GafferBindings::DependencyNodeWrapper<WrappedType
 			WrappedType::executeSequence( frames );
 		}
 
-		virtual bool requiresSequenceExecution() const
+		bool requiresSequenceExecution() const override
 		{
 			if( this->isSubclassed() )
 			{

--- a/include/GafferImage/Blur.h
+++ b/include/GafferImage/Blur.h
@@ -51,7 +51,7 @@ class Blur : public ImageProcessor
 	public :
 
 		Blur( const std::string &name=defaultName<Blur>() );
-		virtual ~Blur();
+		~Blur() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Blur, BlurTypeId, ImageProcessor );
 
@@ -64,7 +64,7 @@ class Blur : public ImageProcessor
 		Gaffer::BoolPlug *expandDataWindowPlug();
 		const Gaffer::BoolPlug *expandDataWindowPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
@@ -84,14 +84,14 @@ class Blur : public ImageProcessor
 		Resample *resample();
 		const Resample *resample() const;
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-		virtual void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferImage/CDL.h
+++ b/include/GafferImage/CDL.h
@@ -51,7 +51,7 @@ class CDL : public OpenColorIOTransform
 	public :
 
 		CDL( const std::string &name=defaultName<CDL>() );
-		virtual ~CDL();
+		~CDL() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::CDL, CDLTypeId, OpenColorIOTransform );
 
@@ -72,9 +72,9 @@ class CDL : public OpenColorIOTransform
 
 	protected :
 
-		virtual bool affectsTransform( const Gaffer::Plug *input ) const;
-		virtual void hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual OpenColorIO::ConstTransformRcPtr transform() const;
+		bool affectsTransform( const Gaffer::Plug *input ) const override;
+		void hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		OpenColorIO::ConstTransformRcPtr transform() const override;
 
 	private :
 

--- a/include/GafferImage/Catalogue.h
+++ b/include/GafferImage/Catalogue.h
@@ -57,7 +57,7 @@ class Catalogue : public ImageNode
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Catalogue, CatalogueTypeId, ImageNode );
 
 		Catalogue( const std::string &name = defaultName<Catalogue>() );
-		virtual ~Catalogue();
+		~Catalogue() override;
 
 		/// Plug type used to represent an image in the catalogue.
 		class Image : public Gaffer::Plug
@@ -84,7 +84,7 @@ class Catalogue : public ImageNode
 				static Ptr load( const std::string &fileName );
 				void save( const std::string &fileName ) const;
 
-				virtual Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+				Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		};
 

--- a/include/GafferImage/ChannelDataProcessor.h
+++ b/include/GafferImage/ChannelDataProcessor.h
@@ -53,11 +53,11 @@ class ChannelDataProcessor : public ImageProcessor
 	public :
 
 		ChannelDataProcessor( const std::string &name=defaultName<ChannelDataProcessor>() );
-		virtual ~ChannelDataProcessor();
+		~ChannelDataProcessor() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::ChannelDataProcessor, ChannelDataProcessorTypeId, ImageProcessor );
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		Gaffer::StringPlug *channelsPlug();
 		const Gaffer::StringPlug *channelsPlug() const;
@@ -65,11 +65,11 @@ class ChannelDataProcessor : public ImageProcessor
 	protected :
 
 		/// This implementation queries whether or not the requested channel is masked by the channelMaskPlug().
-		virtual bool channelEnabled( const std::string &channel ) const;
+		bool channelEnabled( const std::string &channel ) const override;
 
 		/// Implemented to initialize the output tile and then call processChannelData()
 		/// All other ImagePlug children are passed through via direct connection to the input values.
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 		/// Should be implemented by derived classes to processes each channel's data.
 		/// @param context The context that the channel data is being requested for.

--- a/include/GafferImage/Clamp.h
+++ b/include/GafferImage/Clamp.h
@@ -57,7 +57,7 @@ class Clamp : public ChannelDataProcessor
 	public :
 
 		Clamp( const std::string &name=defaultName<Clamp>() );
-		virtual ~Clamp();
+		~Clamp() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Clamp, ClampTypeId, ChannelDataProcessor );
 
@@ -84,14 +84,14 @@ class Clamp : public ChannelDataProcessor
 		const Gaffer::BoolPlug *maxClampToEnabledPlug() const;
 		//@}
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool enabled() const;
+		bool enabled() const override;
 
-		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void processChannelData( const Gaffer::Context *context, const ImagePlug *parent, const std::string &channelName, IECore::FloatVectorDataPtr outData ) const;
+		void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void processChannelData( const Gaffer::Context *context, const ImagePlug *parent, const std::string &channelName, IECore::FloatVectorDataPtr outData ) const override;
 
 	private :
 

--- a/include/GafferImage/CollectImages.h
+++ b/include/GafferImage/CollectImages.h
@@ -50,7 +50,7 @@ class CollectImages : public ImageProcessor
 	public :
 
 		CollectImages( const std::string &name=defaultName<CollectImages>() );
-		virtual ~CollectImages();
+		~CollectImages() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::CollectImages, CollectImagesTypeId, ImageProcessor );
 
@@ -60,24 +60,24 @@ class CollectImages : public ImageProcessor
 		Gaffer::StringPlug *layerVariablePlug();
 		const Gaffer::StringPlug *layerVariablePlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		virtual void hashMetadata( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundDataPtr computeMetadata( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashMetadata( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundDataPtr computeMetadata( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		virtual void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		virtual void hashChannelNames( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hashChannelNames( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
-		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferImage/ColorProcessor.h
+++ b/include/GafferImage/ColorProcessor.h
@@ -52,25 +52,25 @@ class ColorProcessor : public ImageProcessor
 	public :
 
 		ColorProcessor( const std::string &name=defaultName<ColorProcessor>() );
-		virtual ~ColorProcessor();
+		~ColorProcessor() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::ColorProcessor, ColorProcessorTypeId, ImageProcessor );
 
 		Gaffer::StringPlug *channelsPlug();
 		const Gaffer::StringPlug *channelsPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
 		/// Implemented to process the color data and stash the results on colorDataPlug()
 		/// format, dataWindow, metadata, and channelNames are passed through via direct connection to the input values.
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 		/// Implemented to use the results of colorDataPlug() via processColorData()
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 		/// May be implemented by derived classes to return true if the specified input is used in processColorData().
 		/// Must first call the base class implementation and return true if it does.

--- a/include/GafferImage/ColorSpace.h
+++ b/include/GafferImage/ColorSpace.h
@@ -56,7 +56,7 @@ class ColorSpace : public OpenColorIOTransform
 	public :
 
 		ColorSpace( const std::string &name=defaultName<ColorSpace>() );
-		virtual ~ColorSpace();
+		~ColorSpace() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::ColorSpace, ColorSpaceTypeId, OpenColorIOTransform );
 
@@ -68,9 +68,9 @@ class ColorSpace : public OpenColorIOTransform
 
 	protected :
 
-		virtual bool affectsTransform( const Gaffer::Plug *input ) const;
-		virtual void hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual OpenColorIO::ConstTransformRcPtr transform() const;
+		bool affectsTransform( const Gaffer::Plug *input ) const override;
+		void hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		OpenColorIO::ConstTransformRcPtr transform() const override;
 
 	private :
 

--- a/include/GafferImage/Constant.h
+++ b/include/GafferImage/Constant.h
@@ -52,7 +52,7 @@ class Constant : public ImageNode
 	public :
 
 		Constant( const std::string &name=defaultName<Constant>() );
-		virtual ~Constant();
+		~Constant() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Constant, ConstantTypeId, ImageNode );
 
@@ -65,20 +65,20 @@ class Constant : public ImageNode
 		Gaffer::StringPlug *layerPlug();
 		const Gaffer::StringPlug *layerPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
-		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstCompoundDataPtr computeMetadata( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstCompoundDataPtr computeMetadata( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferImage/CopyChannels.h
+++ b/include/GafferImage/CopyChannels.h
@@ -50,28 +50,28 @@ class CopyChannels : public ImageProcessor
 	public :
 
 		CopyChannels( const std::string &name=defaultName<CopyChannels>() );
-		virtual ~CopyChannels();
+		~CopyChannels() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::CopyChannels, CopyChannelsTypeId, ImageProcessor );
 
 		Gaffer::StringPlug *channelsPlug();
 		const Gaffer::StringPlug *channelsPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-		virtual void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		virtual void hashChannelNames( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hashChannelNames( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
-		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferImage/CopyImageMetadata.h
+++ b/include/GafferImage/CopyImageMetadata.h
@@ -48,7 +48,7 @@ class CopyImageMetadata : public MetadataProcessor
 	public :
 
 		CopyImageMetadata( const std::string &name=defaultName<CopyImageMetadata>() );
-		virtual ~CopyImageMetadata();
+		~CopyImageMetadata() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::CopyImageMetadata, CopyImageMetadataTypeId, MetadataProcessor );
 
@@ -63,12 +63,12 @@ class CopyImageMetadata : public MetadataProcessor
 		Gaffer::BoolPlug *invertNamesPlug();
 		const Gaffer::BoolPlug *invertNamesPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashProcessedMetadata( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundDataPtr computeProcessedMetadata( const Gaffer::Context *context, const IECore::CompoundData *inputMetadata ) const;
+		void hashProcessedMetadata( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundDataPtr computeProcessedMetadata( const Gaffer::Context *context, const IECore::CompoundData *inputMetadata ) const override;
 
 	private :
 

--- a/include/GafferImage/Crop.h
+++ b/include/GafferImage/Crop.h
@@ -50,7 +50,7 @@ class Crop : public ImageProcessor
 	public :
 
 		Crop( const std::string &name=defaultName<Crop>() );
-		virtual ~Crop();
+		~Crop() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Crop, CropTypeId, ImageProcessor );
 
@@ -83,18 +83,18 @@ class Crop : public ImageProcessor
 		Gaffer::BoolPlug *resetOriginPlug();
 		const Gaffer::BoolPlug *resetOriginPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
-		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferImage/DeleteChannels.h
+++ b/include/GafferImage/DeleteChannels.h
@@ -57,7 +57,7 @@ class DeleteChannels : public ImageProcessor
 		};
 
 		DeleteChannels( const std::string &name=defaultName<DeleteChannels>() );
-		virtual ~DeleteChannels();
+		~DeleteChannels() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::DeleteChannels, DeleteChannelsTypeId, ImageProcessor );
 
@@ -71,13 +71,13 @@ class DeleteChannels : public ImageProcessor
 		const Gaffer::StringPlug *channelsPlug() const;
 		//@}
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		// Reimplemented to perform the deletion.
-		virtual void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferImage/DeleteImageMetadata.h
+++ b/include/GafferImage/DeleteImageMetadata.h
@@ -48,7 +48,7 @@ class DeleteImageMetadata : public MetadataProcessor
 	public :
 
 		DeleteImageMetadata( const std::string &name=defaultName<DeleteImageMetadata>() );
-		virtual ~DeleteImageMetadata();
+		~DeleteImageMetadata() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::DeleteImageMetadata, DeleteImageMetadataTypeId, MetadataProcessor );
 
@@ -58,12 +58,12 @@ class DeleteImageMetadata : public MetadataProcessor
 		Gaffer::BoolPlug *invertNamesPlug();
 		const Gaffer::BoolPlug *invertNamesPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashProcessedMetadata( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundDataPtr computeProcessedMetadata( const Gaffer::Context *context, const IECore::CompoundData *inputMetadata ) const;
+		void hashProcessedMetadata( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundDataPtr computeProcessedMetadata( const Gaffer::Context *context, const IECore::CompoundData *inputMetadata ) const override;
 
 	private :
 

--- a/include/GafferImage/Dilate.h
+++ b/include/GafferImage/Dilate.h
@@ -48,7 +48,7 @@ class Dilate : public RankFilter
 	public :
 
 		Dilate( const std::string &name=defaultName<Dilate>() );
-		virtual ~Dilate();
+		~Dilate() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Dilate, DilateTypeId, RankFilter );
 

--- a/include/GafferImage/Display.h
+++ b/include/GafferImage/Display.h
@@ -60,7 +60,7 @@ class Display : public ImageNode
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Display, DisplayTypeId, ImageNode );
 
 		Display( const std::string &name = defaultName<Display>() );
-		virtual ~Display();
+		~Display() override;
 
 		Gaffer::IntPlug *portPlug();
 		const Gaffer::IntPlug *portPlug() const;
@@ -82,7 +82,7 @@ class Display : public ImageNode
 		/// Emitted when a complete image has been received.
 		static UnaryPlugSignal &imageReceivedSignal();
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		/// Used to trigger UI updates when image data is received
 		/// via a driver on a background thread. Exposed publicly
@@ -92,20 +92,20 @@ class Display : public ImageNode
 
 	protected :
 
-		virtual void hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		virtual void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		virtual void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 		// Don't need to re-implement hashMetadata() because we always return the same value.
-		virtual IECore::ConstCompoundDataPtr computeMetadata( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		IECore::ConstCompoundDataPtr computeMetadata( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 		// Signal used to request the execution of a function on the UI thread.
 		// We service these requests in DisplayUI.py.

--- a/include/GafferImage/DisplayTransform.h
+++ b/include/GafferImage/DisplayTransform.h
@@ -55,7 +55,7 @@ class DisplayTransform : public OpenColorIOTransform
 	public :
 
 		DisplayTransform( const std::string &name=defaultName<DisplayTransform>() );
-		virtual ~DisplayTransform();
+		~DisplayTransform() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::DisplayTransform, DisplayTransformTypeId, OpenColorIOTransform );
 
@@ -70,9 +70,9 @@ class DisplayTransform : public OpenColorIOTransform
 
 	protected :
 
-		virtual bool affectsTransform( const Gaffer::Plug *input ) const;
-		virtual void hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual OpenColorIO::ConstTransformRcPtr transform() const;
+		bool affectsTransform( const Gaffer::Plug *input ) const override;
+		void hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		OpenColorIO::ConstTransformRcPtr transform() const override;
 
 	private :
 

--- a/include/GafferImage/Erode.h
+++ b/include/GafferImage/Erode.h
@@ -48,7 +48,7 @@ class Erode : public RankFilter
 	public :
 
 		Erode( const std::string &name=defaultName<Erode>() );
-		virtual ~Erode();
+		~Erode() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Erode, ErodeTypeId, RankFilter );
 

--- a/include/GafferImage/FormatPlug.h
+++ b/include/GafferImage/FormatPlug.h
@@ -71,11 +71,11 @@ class FormatPlug : public Gaffer::ValuePlug
 			unsigned flags = Default
 		);
 
-		virtual ~FormatPlug();
+		~FormatPlug() override;
 
 		/// Accepts no children following construction.
-		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
-		virtual Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsChild( const GraphComponent *potentialChild ) const override;
+		Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		Gaffer::Box2iPlug *displayWindowPlug();
 		const Gaffer::Box2iPlug *displayWindowPlug() const;
@@ -95,7 +95,7 @@ class FormatPlug : public Gaffer::ValuePlug
 		Format getValue() const;
 
 		/// Reimplemented to account for the substitutions performed in getValue().
-		virtual IECore::MurmurHash hash() const;
+		IECore::MurmurHash hash() const override;
 		/// Ensures the method above doesn't mask
 		/// ValuePlug::hash( h )
 		using ValuePlug::hash;
@@ -129,7 +129,7 @@ class FormatPlug : public Gaffer::ValuePlug
 
 	private :
 
-		virtual void parentChanging( Gaffer::GraphComponent *newParent );
+		void parentChanging( Gaffer::GraphComponent *newParent ) override;
 		void plugDirtied( Gaffer::Plug *plug );
 
 		Format m_defaultValue;

--- a/include/GafferImage/Grade.h
+++ b/include/GafferImage/Grade.h
@@ -56,7 +56,7 @@ class Grade : public ChannelDataProcessor
 	public :
 
 		Grade( const std::string &name=defaultName<Grade>() );
-		virtual ~Grade();
+		~Grade() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Grade, GradeTypeId, ChannelDataProcessor );
 
@@ -84,14 +84,14 @@ class Grade : public ChannelDataProcessor
 		const Gaffer::BoolPlug *whiteClampPlug() const;
         //@}
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool channelEnabled( const std::string &channel ) const;
+		bool channelEnabled( const std::string &channel ) const override;
 
-		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void processChannelData( const Gaffer::Context *context, const ImagePlug *parent, const std::string &channelIndex, IECore::FloatVectorDataPtr outData ) const;
+		void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void processChannelData( const Gaffer::Context *context, const ImagePlug *parent, const std::string &channelIndex, IECore::FloatVectorDataPtr outData ) const override;
 
 	private :
 

--- a/include/GafferImage/ImageMetadata.h
+++ b/include/GafferImage/ImageMetadata.h
@@ -50,19 +50,19 @@ class ImageMetadata : public MetadataProcessor
 	public :
 
 		ImageMetadata( const std::string &name=defaultName<ImageMetadata>() );
-		virtual ~ImageMetadata();
+		~ImageMetadata() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::ImageMetadata, ImageMetadataTypeId, MetadataProcessor );
 
 		Gaffer::CompoundDataPlug *metadataPlug();
 		const Gaffer::CompoundDataPlug *metadataPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashProcessedMetadata( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundDataPtr computeProcessedMetadata( const Gaffer::Context *context, const IECore::CompoundData *inputMetadata ) const;
+		void hashProcessedMetadata( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundDataPtr computeProcessedMetadata( const Gaffer::Context *context, const IECore::CompoundData *inputMetadata ) const override;
 
 	private :
 

--- a/include/GafferImage/ImageNode.h
+++ b/include/GafferImage/ImageNode.h
@@ -53,7 +53,7 @@ class ImageNode : public Gaffer::ComputeNode
 	public :
 
 		ImageNode( const std::string &name=defaultName<ImageNode>() );
-		virtual ~ImageNode();
+		~ImageNode() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::ImageNode, ImageNodeTypeId, Gaffer::ComputeNode );
 
@@ -64,10 +64,10 @@ class ImageNode : public Gaffer::ComputeNode
 
 		/// The enabled plug provides a mechanism for turning the effect of a node on and off.
 		/// When disabled the node will just pass through the plug's default values.
-		virtual Gaffer::BoolPlug *enabledPlug();
-		virtual const Gaffer::BoolPlug *enabledPlug() const;
+		Gaffer::BoolPlug *enabledPlug() override;
+		const Gaffer::BoolPlug *enabledPlug() const override;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
@@ -91,7 +91,7 @@ class ImageNode : public Gaffer::ComputeNode
 		virtual bool enabled() const;
 
 		/// Implemented to call the hash*() methods below whenever output is part of an ImagePlug.
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		/// Hash methods for the individual children of outPlug(). A derived class must either :
 		///
 		///    * Implement the method to call the base class implementation and then append to the hash.
@@ -115,7 +115,7 @@ class ImageNode : public Gaffer::ComputeNode
 
 		/// Implemented to call the compute*() methods below whenever output is part of an ImagePlug.
 		/// Derived classes should reimplement the specific compute*() methods rather than compute() itself.
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 		/// Compute methods for the individual children of outPlug() - these must be implemented by derived classes, or
 		/// an input connection must be made to the plug, so that the method is not called.
 		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
@@ -125,7 +125,7 @@ class ImageNode : public Gaffer::ComputeNode
 		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
 
 		/// Implemented to initialize the default format settings if they don't exist already.
-		void parentChanging( Gaffer::GraphComponent *newParent );
+		void parentChanging( Gaffer::GraphComponent *newParent ) override;
 
 	private :
 

--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -82,14 +82,14 @@ class ImagePlug : public Gaffer::ValuePlug
 	public :
 
 		ImagePlug( const std::string &name=defaultName<ImagePlug>(), Direction direction=In, unsigned flags=Default );
-		virtual ~ImagePlug();
+		~ImagePlug() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::ImagePlug, ImagePlugTypeId, ValuePlug );
 
-		virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
-		virtual Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const override;
+		Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 		/// Only accepts ImagePlug inputs.
-		virtual bool acceptsInput( const Gaffer::Plug *input ) const;
+		bool acceptsInput( const Gaffer::Plug *input ) const override;
 
 		/// @name Child plugs
 		/// Different aspects of the image are passed through different

--- a/include/GafferImage/ImagePrimitiveSource.h
+++ b/include/GafferImage/ImagePrimitiveSource.h
@@ -55,9 +55,9 @@ class ImagePrimitiveSource : public BaseType
 		IECORE_RUNTIMETYPED_DECLARETEMPLATE( ImagePrimitiveSource<BaseType>, BaseType );
 		IE_CORE_DECLARERUNTIMETYPEDDESCRIPTION( ImagePrimitiveSource<BaseType> );
 
-		virtual ~ImagePrimitiveSource();
+		~ImagePrimitiveSource() override;
 
-		virtual void affects( const Gaffer::Plug *input, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
@@ -70,19 +70,19 @@ class ImagePrimitiveSource : public BaseType
 		/// It is ok to return 0 if no ImagePrimitive is available.
 		virtual IECore::ConstImagePrimitivePtr computeImagePrimitive( const Gaffer::Context *context ) const = 0;
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashMetadata( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashMetadata( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
-		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstCompoundDataPtr computeMetadata( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+		GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstCompoundDataPtr computeMetadata( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferImage/ImageProcessor.h
+++ b/include/GafferImage/ImageProcessor.h
@@ -65,7 +65,7 @@ class ImageProcessor : public ImageNode
 		/// convenience for accessing the first child in the array, and use
 		/// inPlugs() to access the array itself.
 		ImageProcessor( const std::string &name, size_t minInputs, size_t maxInputs = Imath::limits<size_t>::max() );
-		virtual ~ImageProcessor();
+		~ImageProcessor() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::ImageProcessor, ImageProcessorTypeId, ImageNode );
 
@@ -81,15 +81,15 @@ class ImageProcessor : public ImageNode
 		Gaffer::ArrayPlug *inPlugs();
 		const Gaffer::ArrayPlug *inPlugs() const;
 
-		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output );
-		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
+		Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) override;
+		const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const override;
 
 	protected :
 
 		/// Reimplemented to pass through the hashes of the inPlug() when the node is disabled.
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		/// Reimplemented from ImageNode to pass through the inPlug() computations when the node is disabled.
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferImage/ImageReader.h
+++ b/include/GafferImage/ImageReader.h
@@ -60,7 +60,7 @@ class ImageReader : public ImageNode
 	public :
 
 		ImageReader( const std::string &name=defaultName<ImageReader>() );
-		virtual ~ImageReader();
+		~ImageReader() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::ImageReader, ImageReaderTypeId, ImageNode );
 
@@ -110,7 +110,7 @@ class ImageReader : public ImageNode
 		Gaffer::StringPlug *colorSpacePlug();
 		const Gaffer::StringPlug *colorSpacePlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		static size_t supportedExtensions( std::vector<std::string> &extensions );
 
@@ -123,8 +123,8 @@ class ImageReader : public ImageNode
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferImage/ImageSampler.h
+++ b/include/GafferImage/ImageSampler.h
@@ -55,7 +55,7 @@ class ImageSampler : public Gaffer::ComputeNode
 	public :
 
 		ImageSampler( const std::string &name=defaultName<ImageSampler>() );
-		virtual ~ImageSampler();
+		~ImageSampler() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::ImageSampler, ImageSamplerTypeId, ComputeNode );
 
@@ -71,12 +71,12 @@ class ImageSampler : public Gaffer::ComputeNode
 		Gaffer::Color4fPlug *colorPlug();
 		const Gaffer::Color4fPlug *colorPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferImage/ImageStats.h
+++ b/include/GafferImage/ImageStats.h
@@ -54,11 +54,11 @@ class ImageStats : public Gaffer::ComputeNode
 	public :
 
 		ImageStats( const std::string &name=staticTypeName() );
-		virtual ~ImageStats();
+		~ImageStats() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::ImageStats, ImageStatsTypeId, Gaffer::ComputeNode );
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		GafferImage::ImagePlug *inPlug();
 		const GafferImage::ImagePlug *inPlug() const;
@@ -81,17 +81,17 @@ class ImageStats : public Gaffer::ComputeNode
 	protected :
 
 		/// Implemented to hash the area we are sampling along with the channel context and regionOfInterest.
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
 		/// Computes the min, max and average plugs by analyzing the input ImagePlug.
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 	private :
 
 		std::string channelName( int colorIndex ) const;
 
 		/// Implemented to initialize the default format settings if they don't exist already.
-		void parentChanging( Gaffer::GraphComponent *newParent );
+		void parentChanging( Gaffer::GraphComponent *newParent ) override;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferImage/ImageTransform.h
+++ b/include/GafferImage/ImageTransform.h
@@ -57,11 +57,11 @@ class ImageTransform : public ImageProcessor
 	public :
 
 		ImageTransform( const std::string &name=defaultName<ImageTransform>() );
-		virtual ~ImageTransform();
+		~ImageTransform() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::ImageTransform, ImageTransformTypeId, ImageProcessor );
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		Gaffer::Transform2DPlug *transformPlug();
 		const Gaffer::Transform2DPlug *transformPlug() const;
@@ -71,14 +71,14 @@ class ImageTransform : public ImageProcessor
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-		virtual void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferImage/ImageWriter.h
+++ b/include/GafferImage/ImageWriter.h
@@ -67,7 +67,7 @@ class ImageWriter : public GafferDispatch::TaskNode
 		};
 
 		ImageWriter( const std::string &name=defaultName<ImageWriter>() );
-		virtual ~ImageWriter();
+		~ImageWriter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::ImageWriter, ImageWriterTypeId, TaskNode );
 
@@ -89,9 +89,9 @@ class ImageWriter : public GafferDispatch::TaskNode
 		Gaffer::ValuePlug *fileFormatSettingsPlug( const std::string &fileFormat );
 		const Gaffer::ValuePlug *fileFormatSettingsPlug( const std::string &fileFormat ) const;
 
-		virtual IECore::MurmurHash hash( const Gaffer::Context *context ) const;
+		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
 
-		virtual void execute() const;
+		void execute() const override;
 
 		const std::string currentFileFormat() const;
 

--- a/include/GafferImage/LUT.h
+++ b/include/GafferImage/LUT.h
@@ -57,7 +57,7 @@ class LUT : public OpenColorIOTransform
 	public :
 
 		LUT( const std::string &name=defaultName<LUT>() );
-		virtual ~LUT();
+		~LUT() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::LUT, LUTTypeId, OpenColorIOTransform );
 
@@ -90,9 +90,9 @@ class LUT : public OpenColorIOTransform
 
 	protected :
 
-		virtual bool affectsTransform( const Gaffer::Plug *input ) const;
-		virtual void hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual OpenColorIO::ConstTransformRcPtr transform() const;
+		bool affectsTransform( const Gaffer::Plug *input ) const override;
+		void hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		OpenColorIO::ConstTransformRcPtr transform() const override;
 
 	private :
 

--- a/include/GafferImage/Median.h
+++ b/include/GafferImage/Median.h
@@ -48,7 +48,7 @@ class Median : public RankFilter
 	public :
 
 		Median( const std::string &name=defaultName<Median>() );
-		virtual ~Median();
+		~Median() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Median, MedianTypeId, RankFilter );
 

--- a/include/GafferImage/Merge.h
+++ b/include/GafferImage/Merge.h
@@ -62,7 +62,7 @@ class Merge : public ImageProcessor
 	public :
 
 		Merge( const std::string &name=defaultName<Merge>() );
-		virtual ~Merge();
+		~Merge() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Merge, MergeTypeId, ImageProcessor );
 
@@ -87,21 +87,21 @@ class Merge : public ImageProcessor
 		Gaffer::IntPlug *operationPlug();
 		const Gaffer::IntPlug *operationPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		/// Reimplemented to hash the connected input plugs
-		virtual void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
 		/// Sets the data window to the union of all of the data windows.
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 		/// Creates a union of all of the connected inputs channelNames.
-		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 		/// Implemented to call doMergeOperation according to operationPlug()
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferImage/MetadataProcessor.h
+++ b/include/GafferImage/MetadataProcessor.h
@@ -52,18 +52,18 @@ class MetadataProcessor : public ImageProcessor
 	public :
 
 		MetadataProcessor( const std::string &name=defaultName<MetadataProcessor>() );
-		virtual ~MetadataProcessor();
+		~MetadataProcessor() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::MetadataProcessor, MetadataProcessorTypeId, ImageProcessor );
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		// Reimplemented to call hashProcessedMetadata()
-		virtual void hashMetadata( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hashMetadata( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		// Reimplemented to call computeProcessedMetadata()
-		virtual IECore::ConstCompoundDataPtr computeMetadata( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		IECore::ConstCompoundDataPtr computeMetadata( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 		/// Must be implemented by derived classes to compute the hash for the work done in computeProcessedMetadata().
 		virtual void hashProcessedMetadata( const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;

--- a/include/GafferImage/Mirror.h
+++ b/include/GafferImage/Mirror.h
@@ -50,7 +50,7 @@ class Mirror : public ImageProcessor
 	public :
 
 		Mirror( const std::string &name=defaultName<Mirror>() );
-		virtual ~Mirror();
+		~Mirror() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Mirror, MirrorTypeId, ImageProcessor );
 
@@ -60,15 +60,15 @@ class Mirror : public ImageProcessor
 		Gaffer::BoolPlug *verticalPlug();
 		const Gaffer::BoolPlug *verticalPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferImage/Mix.h
+++ b/include/GafferImage/Mix.h
@@ -55,7 +55,7 @@ class Mix : public ImageProcessor
 	public :
 
 		Mix( const std::string &name=defaultName<Mix>() );
-		virtual ~Mix();
+		~Mix() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Mix, MixTypeId, ImageProcessor );
 
@@ -69,21 +69,21 @@ class Mix : public ImageProcessor
 		const Gaffer::StringPlug *maskChannelPlug() const;
 
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		/// Reimplemented to hash the connected input plugs
-		virtual void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
 		/// Sets the data window to the union of all of the data windows.
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 		/// Creates a union of all of the connected inputs channelNames.
-		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferImage/ObjectToImage.h
+++ b/include/GafferImage/ObjectToImage.h
@@ -50,17 +50,17 @@ class ObjectToImage : public ImagePrimitiveNode
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::ObjectToImage, ObjectToImageTypeId, ImagePrimitiveNode );
 
 		ObjectToImage( const std::string &name = defaultName<ObjectToImage>() );
-		virtual ~ObjectToImage();
+		~ObjectToImage() override;
 
 		Gaffer::ObjectPlug *objectPlug();
 		const Gaffer::ObjectPlug *objectPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashImagePrimitive( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstImagePrimitivePtr computeImagePrimitive( const Gaffer::Context *context ) const;
+		void hashImagePrimitive( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstImagePrimitivePtr computeImagePrimitive( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferImage/Offset.h
+++ b/include/GafferImage/Offset.h
@@ -49,22 +49,22 @@ class Offset : public ImageProcessor
 	public :
 
 		Offset( const std::string &name=defaultName<Offset>() );
-		virtual ~Offset();
+		~Offset() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Offset, OffsetTypeId, ImageProcessor );
 
 		Gaffer::V2iPlug *offsetPlug();
 		const Gaffer::V2iPlug *offsetPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferImage/OpenColorIOTransform.h
+++ b/include/GafferImage/OpenColorIOTransform.h
@@ -52,7 +52,7 @@ class OpenColorIOTransform : public ColorProcessor
 
 	public :
 
-		virtual ~OpenColorIOTransform();
+		~OpenColorIOTransform() override;
 
 		/// Fills the vector will the available color spaces,
 		/// as defined by the current OpenColorIO config.
@@ -73,20 +73,20 @@ class OpenColorIOTransform : public ColorProcessor
 		/// hashTransform() to return a default hash if the
 		/// node should be in a disabled state.
 		/// \todo: rework ColorProcessor so we can remove this.
-		virtual bool enabled() const;
+		bool enabled() const override;
 
 		/// Implemented to call affectsTransform() if the base class
 		/// does not affect the color data for this input. Derived
 		/// classes should implement affectsTransform() instead.
-		virtual bool affectsColorData( const Gaffer::Plug *input ) const;
+		bool affectsColorData( const Gaffer::Plug *input ) const override;
 		/// Implemented to call hashTransform() after hashing the
 		/// affect of the base class. Derived classes should
 		/// implement hashTransform() instead.
-		virtual void hashColorData( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hashColorData( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		/// Implemented to fetch an OpenColorIO Processor from the
 		/// OpenColorIO Config and apply it to the output channels.
 		/// Derived classes should implement transform() instead.
-		virtual void processColorData( const Gaffer::Context *context, IECore::FloatVectorData *r, IECore::FloatVectorData *g, IECore::FloatVectorData *b ) const;
+		void processColorData( const Gaffer::Context *context, IECore::FloatVectorData *r, IECore::FloatVectorData *g, IECore::FloatVectorData *b ) const override;
 
 		/// Derived classes must implement this to return true if the specified input
 		/// is used in transform().

--- a/include/GafferImage/OpenImageIOReader.h
+++ b/include/GafferImage/OpenImageIOReader.h
@@ -58,7 +58,7 @@ class OpenImageIOReader : public ImageNode
 	public :
 
 		OpenImageIOReader( const std::string &name=defaultName<OpenImageIOReader>() );
-		virtual ~OpenImageIOReader();
+		~OpenImageIOReader() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::OpenImageIOReader, OpenImageIOReaderTypeId, ImageNode );
 
@@ -82,7 +82,7 @@ class OpenImageIOReader : public ImageNode
 		Gaffer::IntVectorDataPlug *availableFramesPlug();
 		const Gaffer::IntVectorDataPlug *availableFramesPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		static size_t supportedExtensions( std::vector<std::string> &extensions );
 
@@ -97,20 +97,20 @@ class OpenImageIOReader : public ImageNode
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-		virtual void hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashMetadata( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hashFormat( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashMetadata( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
-		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstCompoundDataPtr computeMetadata( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstCompoundDataPtr computeMetadata( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferImage/Premultiply.h
+++ b/include/GafferImage/Premultiply.h
@@ -51,7 +51,7 @@ class Premultiply : public ChannelDataProcessor
 	public :
 
 		Premultiply( const std::string &name=defaultName<Premultiply>() );
-		virtual ~Premultiply();
+		~Premultiply() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Premultiply, PremultiplyTypeId, ChannelDataProcessor );
 
@@ -63,12 +63,12 @@ class Premultiply : public ChannelDataProcessor
 		const Gaffer::StringPlug *alphaChannelPlug() const;
 		//@}
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void processChannelData( const Gaffer::Context *context, const ImagePlug *parent, const std::string &channelIndex, IECore::FloatVectorDataPtr outData ) const;
+		void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void processChannelData( const Gaffer::Context *context, const ImagePlug *parent, const std::string &channelIndex, IECore::FloatVectorDataPtr outData ) const override;
 
 	private :
 

--- a/include/GafferImage/RankFilter.h
+++ b/include/GafferImage/RankFilter.h
@@ -51,7 +51,7 @@ class RankFilter : public ImageProcessor
 
 	public :
 
-		virtual ~RankFilter();
+		~RankFilter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::RankFilter, RankFilterTypeId, ImageProcessor );
 
@@ -67,7 +67,7 @@ class RankFilter : public ImageProcessor
 		Gaffer::StringPlug *masterChannelPlug();
 		const Gaffer::StringPlug *masterChannelPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
@@ -80,14 +80,14 @@ class RankFilter : public ImageProcessor
 
 		RankFilter( const std::string &name=defaultName<RankFilter>(), Mode mode=MedianRank );
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-		virtual void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 
 	private:

--- a/include/GafferImage/Resample.h
+++ b/include/GafferImage/Resample.h
@@ -62,7 +62,7 @@ class Resample : public ImageProcessor
 	public :
 
 		Resample( const std::string &name=defaultName<Resample>() );
-		virtual ~Resample();
+		~Resample() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Resample, ResampleTypeId, ImageProcessor );
 
@@ -95,15 +95,15 @@ class Resample : public ImageProcessor
 		Gaffer::IntPlug *debugPlug();
 		const Gaffer::IntPlug *debugPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferImage/Resize.h
+++ b/include/GafferImage/Resize.h
@@ -59,7 +59,7 @@ class Resize : public ImageProcessor
 	public :
 
 		Resize( const std::string &name=defaultName<Resize>() );
-		virtual ~Resize();
+		~Resize() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Resize, ResizeTypeId, ImageProcessor );
 
@@ -81,21 +81,21 @@ class Resize : public ImageProcessor
 		Gaffer::StringPlug *filterPlug();
 		const Gaffer::StringPlug *filterPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-		virtual void hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		virtual void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferImage/Shape.h
+++ b/include/GafferImage/Shape.h
@@ -58,7 +58,7 @@ class Shape : public ImageProcessor
 	public :
 
 		Shape( const std::string &name=defaultName<Shape>() );
-		virtual ~Shape();
+		~Shape() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Shape, ShapeTypeId, ImageProcessor );
 
@@ -77,17 +77,17 @@ class Shape : public ImageProcessor
 		Gaffer::FloatPlug *shadowBlurPlug();
 		const Gaffer::FloatPlug *shadowBlurPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelNames( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelNames( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
-		virtual Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 		/// Must be implemented to return true if the input plug affects the computation of the
 		/// data window for the shape.

--- a/include/GafferImage/Shuffle.h
+++ b/include/GafferImage/Shuffle.h
@@ -50,7 +50,7 @@ class Shuffle : public ImageProcessor
 	public :
 
 		Shuffle( const std::string &name=defaultName<Shuffle>() );
-		virtual ~Shuffle();
+		~Shuffle() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Shuffle, ShuffleTypeId, ImageProcessor );
 
@@ -80,8 +80,8 @@ class Shuffle : public ImageProcessor
 				Gaffer::StringPlug *inPlug();
 				const Gaffer::StringPlug *inPlug() const;
 
-				virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
-				virtual Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+				bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const override;
+				Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		};
 
@@ -92,15 +92,15 @@ class Shuffle : public ImageProcessor
 		Gaffer::ValuePlug *channelsPlug();
 		const Gaffer::ValuePlug *channelsPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashChannelNames( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hashChannelNames( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
-		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferImage/Text.h
+++ b/include/GafferImage/Text.h
@@ -58,7 +58,7 @@ class Text : public Shape
 	public :
 
 		Text( const std::string &name=defaultName<Text>() );
-		virtual ~Text();
+		~Text() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Text, TextTypeId, Shape );
 
@@ -97,24 +97,24 @@ class Text : public Shape
 		Gaffer::Transform2DPlug *transformPlug();
 		const Gaffer::Transform2DPlug *transformPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 		bool affectsLayout( const Gaffer::Plug *input ) const;
 		void hashLayout( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		IECore::ConstCompoundObjectPtr computeLayout( const Gaffer::Context *context ) const;
 
-		virtual bool affectsShapeDataWindow( const Gaffer::Plug *input ) const;
-		virtual void hashShapeDataWindow( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box2i computeShapeDataWindow( const Gaffer::Context *context ) const;
+		bool affectsShapeDataWindow( const Gaffer::Plug *input ) const override;
+		void hashShapeDataWindow( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box2i computeShapeDataWindow( const Gaffer::Context *context ) const override;
 
-		virtual bool affectsShapeChannelData( const Gaffer::Plug *input ) const;
-		virtual void hashShapeChannelData( const Imath::V2i &tileOrigin, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeShapeChannelData(  const Imath::V2i &tileOrigin, const Gaffer::Context *context ) const;
+		bool affectsShapeChannelData( const Gaffer::Plug *input ) const override;
+		void hashShapeChannelData( const Imath::V2i &tileOrigin, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstFloatVectorDataPtr computeShapeChannelData(  const Imath::V2i &tileOrigin, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferImage/Unpremultiply.h
+++ b/include/GafferImage/Unpremultiply.h
@@ -51,7 +51,7 @@ class Unpremultiply : public ChannelDataProcessor
 	public :
 
 		Unpremultiply( const std::string &name=defaultName<Unpremultiply>() );
-		virtual ~Unpremultiply();
+		~Unpremultiply() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Unpremultiply, UnpremultiplyTypeId, ChannelDataProcessor );
 
@@ -63,12 +63,12 @@ class Unpremultiply : public ChannelDataProcessor
 		const Gaffer::StringPlug *alphaChannelPlug() const;
 		//@}
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void processChannelData( const Gaffer::Context *context, const ImagePlug *parent, const std::string &channelIndex, IECore::FloatVectorDataPtr outData ) const;
+		void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void processChannelData( const Gaffer::Context *context, const ImagePlug *parent, const std::string &channelIndex, IECore::FloatVectorDataPtr outData ) const override;
 
 	private :
 

--- a/include/GafferImage/VectorWarp.h
+++ b/include/GafferImage/VectorWarp.h
@@ -47,7 +47,7 @@ class VectorWarp : public Warp
 	public :
 
 		VectorWarp( const std::string &name=defaultName<Warp>() );
-		virtual ~VectorWarp();
+		~VectorWarp() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::VectorWarp, VectorWarpTypeId, Warp );
 
@@ -74,9 +74,9 @@ class VectorWarp : public Warp
 
 	protected :
 
-		virtual bool affectsEngine( const Gaffer::Plug *input ) const;
-		virtual void hashEngine( const Imath::V2i &tileOrigin, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual const Engine *computeEngine( const Imath::V2i &tileOrigin, const Gaffer::Context *context ) const;
+		bool affectsEngine( const Gaffer::Plug *input ) const override;
+		void hashEngine( const Imath::V2i &tileOrigin, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		const Engine *computeEngine( const Imath::V2i &tileOrigin, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferImage/Warp.h
+++ b/include/GafferImage/Warp.h
@@ -62,7 +62,7 @@ class Warp : public ImageProcessor
 	public :
 
 		Warp( const std::string &name=defaultName<Warp>() );
-		virtual ~Warp();
+		~Warp() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Warp, WarpTypeId, ImageProcessor );
 
@@ -75,15 +75,15 @@ class Warp : public ImageProcessor
 		Gaffer::BoolPlug *useDerivativesPlug();
 		const Gaffer::BoolPlug *useDerivativesPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
+		void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 		/// Abstract base class for implementing the warp function.
 		struct Engine

--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -79,11 +79,11 @@ class ImageGadget : public GafferUI::Gadget
 	public :
 
 		ImageGadget();
-		virtual ~ImageGadget();
+		~ImageGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImageUI::ImageGadget, ImageGadgetTypeId, Gadget );
 
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 		void setImage( GafferImage::ConstImagePlugPtr image );
 		const GafferImage::ImagePlug *getImage() const;
@@ -113,7 +113,7 @@ class ImageGadget : public GafferUI::Gadget
 
 	protected :
 
-		virtual void doRender( const GafferUI::Style *style ) const;
+		void doRender( const GafferUI::Style *style ) const override;
 
 	private :
 

--- a/include/GafferImageUI/ImageView.h
+++ b/include/GafferImageUI/ImageView.h
@@ -80,7 +80,7 @@ class ImageView : public GafferUI::View
 	public :
 
 		ImageView( const std::string &name = defaultName<ImageView>() );
-		virtual ~ImageView();
+		~ImageView() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImageUI::ImageView, ImageViewTypeId, GafferUI::View );
 
@@ -97,7 +97,7 @@ class ImageView : public GafferUI::View
 		Gaffer::StringPlug *displayTransformPlug();
 		const Gaffer::StringPlug *displayTransformPlug() const;
 
-		virtual void setContext( Gaffer::ContextPtr context );
+		void setContext( Gaffer::ContextPtr context ) override;
 
 		typedef boost::function<GafferImage::ImageProcessorPtr ()> DisplayTransformCreator;
 

--- a/include/GafferOSL/OSLCode.h
+++ b/include/GafferOSL/OSLCode.h
@@ -52,7 +52,7 @@ class OSLCode : public OSLShader
 	public :
 
 		OSLCode( const std::string &name=defaultName<OSLCode>() );
-		virtual ~OSLCode();
+		~OSLCode() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferOSL::OSLCode, OSLCodeTypeId, OSLShader );
 
@@ -75,7 +75,7 @@ class OSLCode : public OSLShader
 		// This is implemented to do nothing, because OSLCode node generates the shader from
 		// the plugs, and not the other way around.  We don't want to inherit the loading behaviour
 		// from OSLShader which tries to match the plugs to a shader on disk
-		virtual void loadShader( const std::string &shaderName, bool keepExistingValues=false );
+		void loadShader( const std::string &shaderName, bool keepExistingValues=false ) override;
 
 	private :
 

--- a/include/GafferOSL/OSLImage.h
+++ b/include/GafferOSL/OSLImage.h
@@ -53,28 +53,28 @@ class OSLImage : public GafferImage::ImageProcessor
 	public :
 
 		OSLImage( const std::string &name=defaultName<OSLImage>() );
-		virtual ~OSLImage();
+		~OSLImage() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferOSL::OSLImage, OSLImageTypeId, GafferImage::ImageProcessor );
 
 		GafferScene::ShaderPlug *shaderPlug();
 		const GafferScene::ShaderPlug *shaderPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
 
-		virtual bool enabled() const;
+		bool enabled() const override;
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelNames( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
-		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const GafferImage::ImagePlug *parent ) const;
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const GafferImage::ImagePlug *parent ) const;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+		IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const GafferImage::ImagePlug *parent ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const GafferImage::ImagePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferOSL/OSLObject.h
+++ b/include/GafferOSL/OSLObject.h
@@ -53,7 +53,7 @@ class OSLObject : public GafferScene::SceneElementProcessor
 	public :
 
 		OSLObject( const std::string &name=defaultName<SceneElementProcessor>() );
-		virtual ~OSLObject();
+		~OSLObject() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferOSL::OSLObject, OSLObjectTypeId, GafferScene::SceneElementProcessor );
 
@@ -63,22 +63,22 @@ class OSLObject : public GafferScene::SceneElementProcessor
 		Gaffer::IntPlug *interpolationPlug();
 		const Gaffer::IntPlug *interpolationPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
 
-		virtual bool processesBound() const;
-		virtual void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const;
+		bool processesBound() const override;
+		void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const override;
 
-		virtual bool processesObject() const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferOSL/OSLShader.h
+++ b/include/GafferOSL/OSLShader.h
@@ -52,18 +52,18 @@ class OSLShader : public GafferScene::Shader
 	public :
 
 		OSLShader( const std::string &name=defaultName<OSLShader>() );
-		virtual ~OSLShader();
+		~OSLShader() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferOSL::OSLShader, OSLShaderTypeId, GafferScene::Shader );
 
 		/// Returns a plug based on the "correspondingInput" metadata of each output plug
-		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output );
-		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
+		Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) override;
+		const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const override;
 
 		/// \undoable.
-		virtual void loadShader( const std::string &shaderName, bool keepExistingValues=false );
+		void loadShader( const std::string &shaderName, bool keepExistingValues=false ) override;
 
-		virtual void reloadShader();
+		void reloadShader() override;
 
 		ConstShadingEnginePtr shadingEngine() const;
 
@@ -74,7 +74,7 @@ class OSLShader : public GafferScene::Shader
 
 	protected :
 
-		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
 
 	private :
 

--- a/include/GafferOSL/Private/CapturingErrorHandler.h
+++ b/include/GafferOSL/Private/CapturingErrorHandler.h
@@ -52,7 +52,7 @@ class CapturingErrorHandler : public OIIO::ErrorHandler
 
 		CapturingErrorHandler();
 
-		virtual void operator()( int errorCode, const std::string &message );
+		void operator()( int errorCode, const std::string &message ) override;
 
 		const std::string &errors();
 

--- a/include/GafferOSL/ShadingEngine.h
+++ b/include/GafferOSL/ShadingEngine.h
@@ -53,7 +53,7 @@ class ShadingEngine : public IECore::RefCounted
 		IE_CORE_DECLAREMEMBERPTR( ShadingEngine )
 
 		ShadingEngine( const IECore::ObjectVector *shaderNetwork );
-		~ShadingEngine();
+		~ShadingEngine() override;
 
 		struct Transform
 		{

--- a/include/GafferRenderMan/InteractiveRenderManRender.h
+++ b/include/GafferRenderMan/InteractiveRenderManRender.h
@@ -50,14 +50,14 @@ class InteractiveRenderManRender : public GafferScene::InteractiveRender
 	public :
 
 		InteractiveRenderManRender( const std::string &name=defaultName<InteractiveRenderManRender>() );
-		virtual ~InteractiveRenderManRender();
+		~InteractiveRenderManRender() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferRenderMan::InteractiveRenderManRender, InteractiveRenderManRenderTypeId, GafferScene::InteractiveRender );
 
 	protected :
 
 		/// Must be implemented by derived classes to return the renderer that will be used.
-		virtual IECore::RendererPtr createRenderer() const;
+		IECore::RendererPtr createRenderer() const override;
 
 };
 

--- a/include/GafferRenderMan/RenderManAttributes.h
+++ b/include/GafferRenderMan/RenderManAttributes.h
@@ -50,7 +50,7 @@ class RenderManAttributes : public GafferScene::Attributes
 	public :
 
 		RenderManAttributes( const std::string &name=defaultName<RenderManAttributes>() );
-		virtual ~RenderManAttributes();
+		~RenderManAttributes() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferRenderMan::RenderManAttributes, RenderManAttributesTypeId, GafferScene::Attributes );
 

--- a/include/GafferRenderMan/RenderManLight.h
+++ b/include/GafferRenderMan/RenderManLight.h
@@ -52,14 +52,14 @@ class RenderManLight : public GafferScene::Light
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferRenderMan::RenderManLight, RenderManLightTypeId, GafferScene::Light );
 
 		RenderManLight( const std::string &name=defaultName<RenderManLight>() );
-		virtual ~RenderManLight();
+		~RenderManLight() override;
 
 		void loadShader( const std::string &shaderName );
 
 	protected :
 
-		virtual void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ObjectVectorPtr computeLight( const Gaffer::Context *context ) const;
+		void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ObjectVectorPtr computeLight( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferRenderMan/RenderManOptions.h
+++ b/include/GafferRenderMan/RenderManOptions.h
@@ -50,7 +50,7 @@ class RenderManOptions : public GafferScene::Options
 	public :
 
 		RenderManOptions( const std::string &name=defaultName<RenderManOptions>() );
-		virtual ~RenderManOptions();
+		~RenderManOptions() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferRenderMan::RenderManOptions, RenderManOptionsTypeId, GafferScene::Options );
 

--- a/include/GafferRenderMan/RenderManShader.h
+++ b/include/GafferRenderMan/RenderManShader.h
@@ -54,19 +54,19 @@ class RenderManShader : public GafferScene::Shader
 	public :
 
 		RenderManShader( const std::string &name=defaultName<RenderManShader>() );
-		virtual ~RenderManShader();
+		~RenderManShader() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferRenderMan::RenderManShader, RenderManShaderTypeId, GafferScene::Shader );
 
 		/// Implemented for outPlug(), returning the parameter named in the "primaryInput"
 		/// shader annotation if it has been specified.
-		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output );
-		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
+		Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) override;
+		const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const override;
 
 		/// \undoable.
-		virtual void loadShader( const std::string &shaderName, bool keepExistingValues=false );
+		void loadShader( const std::string &shaderName, bool keepExistingValues=false ) override;
 
-		virtual void reloadShader();
+		void reloadShader() override;
 
 		/// The loader used by loadShader() - this is exposed so that the ui
 		/// can use it too.
@@ -74,7 +74,7 @@ class RenderManShader : public GafferScene::Shader
 
 	protected :
 
-		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
 
 		const IECore::ConstCompoundDataPtr annotations() const;
 

--- a/include/GafferScene/AimConstraint.h
+++ b/include/GafferScene/AimConstraint.h
@@ -48,7 +48,7 @@ class AimConstraint : public Constraint
 	public :
 
 		AimConstraint( const std::string &name=defaultName<AimConstraint>() );
-		virtual ~AimConstraint();
+		~AimConstraint() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::AimConstraint, AimConstraintTypeId, Constraint );
 
@@ -60,9 +60,9 @@ class AimConstraint : public Constraint
 
 	protected :
 
-		virtual bool affectsConstraint( const Gaffer::Plug *input ) const;
-		virtual void hashConstraint( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const;
+		bool affectsConstraint( const Gaffer::Plug *input ) const override;
+		void hashConstraint( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const override;
 
 	private :
 

--- a/include/GafferScene/AlembicSource.h
+++ b/include/GafferScene/AlembicSource.h
@@ -58,7 +58,7 @@ class AlembicSource : public SceneNode
 	public :
 
 		AlembicSource( const std::string &name=defaultName<AlembicSource>() );
-		virtual ~AlembicSource();
+		~AlembicSource() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::AlembicSource, AlembicSourceTypeId, SceneNode )
 
@@ -71,29 +71,29 @@ class AlembicSource : public SceneNode
 		const Gaffer::IntPlug *refreshCountPlug() const;
 
 		/// Implemented to specify that fileNamePlug() affects all the scene output.
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	private :
 
 		void plugSet( Gaffer::Plug *plug );
 
-		virtual void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 
-		virtual Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 		IECoreAlembic::AlembicInputPtr inputForPath( const ScenePath &path ) const;
 

--- a/include/GafferScene/AttributeProcessor.h
+++ b/include/GafferScene/AttributeProcessor.h
@@ -57,7 +57,7 @@ class AttributeProcessor : public SceneElementProcessor
 	public :
 
 		AttributeProcessor( const std::string &name=defaultName<AttributeProcessor>() );
-		virtual ~AttributeProcessor();
+		~AttributeProcessor() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::AttributeProcessor, AttributeProcessorTypeId, SceneElementProcessor );
 
@@ -68,13 +68,13 @@ class AttributeProcessor : public SceneElementProcessor
 		const Gaffer::BoolPlug *invertNamesPlug() const;
 
 		/// Implemented so that namesPlug() affects outPlug()->attributesPlug().
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesAttributes() const;
-		virtual void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const;
+		bool processesAttributes() const override;
+		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const override;
 
 		/// Must be implemented by subclasses to process the attribute.
 		virtual IECore::ConstObjectPtr processAttribute( const ScenePath &path, const Gaffer::Context *context, const IECore::InternedString &attributeName, const IECore::Object *inputAttribute ) const = 0;

--- a/include/GafferScene/AttributeVisualiser.h
+++ b/include/GafferScene/AttributeVisualiser.h
@@ -58,7 +58,7 @@ class AttributeVisualiser : public SceneElementProcessor
 	public :
 
 		AttributeVisualiser( const std::string &name=defaultName<AttributeVisualiser>() );
-		virtual ~AttributeVisualiser();
+		~AttributeVisualiser() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::AttributeVisualiser, AttributeVisualiserTypeId, SceneElementProcessor );
 
@@ -94,13 +94,13 @@ class AttributeVisualiser : public SceneElementProcessor
 		Gaffer::StringPlug *shaderParameterPlug();
 		const Gaffer::StringPlug *shaderParameterPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesAttributes() const;
-		virtual void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const;
+		bool processesAttributes() const override;
+		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const override;
 
 	private :
 

--- a/include/GafferScene/Attributes.h
+++ b/include/GafferScene/Attributes.h
@@ -51,7 +51,7 @@ class Attributes : public SceneElementProcessor
 	public :
 
 		Attributes( const std::string &name=defaultName<Attributes>() );
-		virtual ~Attributes();
+		~Attributes() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Attributes, AttributesTypeId, SceneElementProcessor );
 
@@ -61,16 +61,16 @@ class Attributes : public SceneElementProcessor
 		Gaffer::BoolPlug *globalPlug();
 		const Gaffer::BoolPlug *globalPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
-		virtual bool processesAttributes() const;
-		virtual void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const;
+		bool processesAttributes() const override;
+		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const override;
 
 	private :
 

--- a/include/GafferScene/BranchCreator.h
+++ b/include/GafferScene/BranchCreator.h
@@ -58,7 +58,7 @@ class BranchCreator : public SceneProcessor
 
 	public :
 
-		virtual ~BranchCreator();
+		~BranchCreator() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::BranchCreator, BranchCreatorTypeId, SceneProcessor );
 
@@ -66,35 +66,35 @@ class BranchCreator : public SceneProcessor
 		Gaffer::StringPlug *parentPlug();
 		const Gaffer::StringPlug *parentPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		BranchCreator( const std::string &name=defaultName<BranchCreator>() );
 
 		/// Implemented for mappingPlug().
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 		/// Implemented in terms of the hashBranch*() methods below - derived classes must implement those methods
 		/// rather than these ones.
-		virtual void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 
 		/// Implemented in terms of the computeBranch*() methods below - derived classes must implement those methods
 		/// rather than these ones.
-		virtual Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 		/// @name Branch evaluation methods
 		/// These must be implemented by derived classes. The hashBranch*() methods must either :

--- a/include/GafferScene/Camera.h
+++ b/include/GafferScene/Camera.h
@@ -51,7 +51,7 @@ class Camera : public ObjectSource
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Camera, CameraTypeId, ObjectSource );
 
 		Camera( const std::string &name=defaultName<Camera>() );
-		virtual ~Camera();
+		~Camera() override;
 
 		Gaffer::StringPlug *projectionPlug();
 		const Gaffer::StringPlug *projectionPlug() const;
@@ -62,14 +62,14 @@ class Camera : public ObjectSource
 		Gaffer::V2fPlug *clippingPlanesPlug();
 		const Gaffer::V2fPlug *clippingPlanesPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
+		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
 
-		virtual IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const;
+		IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const override;
 
 	private :
 

--- a/include/GafferScene/ClippingPlane.h
+++ b/include/GafferScene/ClippingPlane.h
@@ -50,14 +50,14 @@ class ClippingPlane : public ObjectSource
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ClippingPlane, ClippingPlaneTypeId, ObjectSource );
 
 		ClippingPlane( const std::string &name=defaultName<ClippingPlane>() );
-		virtual ~ClippingPlane();
+		~ClippingPlane() override;
 
 	protected :
 
-		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
+		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
 
-		virtual IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const;
+		IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const override;
 
 };
 

--- a/include/GafferScene/CollectScenes.h
+++ b/include/GafferScene/CollectScenes.h
@@ -55,7 +55,7 @@ class CollectScenes : public SceneProcessor
 	public :
 
 		CollectScenes( const std::string &name=defaultName<CollectScenes>() );
-		virtual ~CollectScenes();
+		~CollectScenes() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::CollectScenes, CollectScenesTypeId, SceneProcessor );
 
@@ -65,33 +65,33 @@ class CollectScenes : public SceneProcessor
 		Gaffer::StringPlug *rootNameVariablePlug();
 		const Gaffer::StringPlug *rootNameVariablePlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
-		virtual void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
-		virtual void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
-		virtual void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
-		virtual void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
-		virtual void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
-		virtual void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
-		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferScene/Constraint.h
+++ b/include/GafferScene/Constraint.h
@@ -55,7 +55,7 @@ class Constraint : public SceneElementProcessor
 	public :
 
 		Constraint( const std::string &name=defaultName<Constraint>() );
-		virtual ~Constraint();
+		~Constraint() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Constraint, ConstraintTypeId, SceneElementProcessor );
 
@@ -76,14 +76,14 @@ class Constraint : public SceneElementProcessor
 		Gaffer::V3fPlug *targetOffsetPlug();
 		const Gaffer::V3fPlug *targetOffsetPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		/// Reimplemented from SceneElementProcessor to call the constraint functions below.
-		virtual bool processesTransform() const;
-		virtual void hashProcessedTransform( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::M44f computeProcessedTransform( const ScenePath &path, const Gaffer::Context *context, const Imath::M44f &inputTransform ) const;
+		bool processesTransform() const override;
+		void hashProcessedTransform( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeProcessedTransform( const ScenePath &path, const Gaffer::Context *context, const Imath::M44f &inputTransform ) const override;
 
 		/// Must be implemented to return true if the specified plug affects the computation of the constraint.
 		virtual bool affectsConstraint( const Gaffer::Plug *input ) const = 0;

--- a/include/GafferScene/CoordinateSystem.h
+++ b/include/GafferScene/CoordinateSystem.h
@@ -50,14 +50,14 @@ class CoordinateSystem : public ObjectSource
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::CoordinateSystem, CoordinateSystemTypeId, ObjectSource );
 
 		CoordinateSystem( const std::string &name=defaultName<CoordinateSystem>() );
-		virtual ~CoordinateSystem();
+		~CoordinateSystem() override;
 
 	protected :
 
-		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
+		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
 
-		virtual IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const;
+		IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const override;
 };
 
 IE_CORE_DECLAREPTR( CoordinateSystem )

--- a/include/GafferScene/CopyOptions.h
+++ b/include/GafferScene/CopyOptions.h
@@ -50,7 +50,7 @@ namespace GafferScene
 	public :
 
 		CopyOptions( const std::string &name=defaultName<CopyOptions>() );
-		virtual ~CopyOptions();
+		~CopyOptions() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::CopyOptions, CopyOptionsTypeId, GlobalsProcessor );
 
@@ -60,12 +60,12 @@ namespace GafferScene
 		Gaffer::StringPlug *namesPlug();
 		const Gaffer::StringPlug *namesPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const;
+		void hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const override;
 
 	private :
 

--- a/include/GafferScene/Cube.h
+++ b/include/GafferScene/Cube.h
@@ -52,17 +52,17 @@ class Cube : public ObjectSource
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Cube, CubeTypeId, ObjectSource );
 
 		Cube( const std::string &name=defaultName<Cube>() );
-		virtual ~Cube();
+		~Cube() override;
 
 		Gaffer::V3fPlug *dimensionsPlug();
 		const Gaffer::V3fPlug *dimensionsPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
+		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/CustomAttributes.h
+++ b/include/GafferScene/CustomAttributes.h
@@ -48,7 +48,7 @@ class CustomAttributes : public GafferScene::Attributes
 	public :
 
 		CustomAttributes( const std::string &name=defaultName<CustomAttributes>() );
-		virtual ~CustomAttributes();
+		~CustomAttributes() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::CustomAttributes,CustomAttributesTypeId, Attributes );
 

--- a/include/GafferScene/CustomOptions.h
+++ b/include/GafferScene/CustomOptions.h
@@ -50,19 +50,19 @@ class CustomOptions : public GafferScene::Options
 	public :
 
 		CustomOptions( const std::string &name=defaultName<CustomOptions>() );
-		virtual ~CustomOptions();
+		~CustomOptions() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::CustomOptions, CustomOptionsTypeId, Options );
 
 		Gaffer::StringPlug *prefixPlug();
 		const Gaffer::StringPlug *prefixPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashPrefix( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual std::string computePrefix( const Gaffer::Context *context ) const;
+		void hashPrefix( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		std::string computePrefix( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/DeleteAttributes.h
+++ b/include/GafferScene/DeleteAttributes.h
@@ -48,13 +48,13 @@ class DeleteAttributes : public AttributeProcessor
 	public :
 
 		DeleteAttributes( const std::string &name=defaultName<DeleteAttributes>() );
-		virtual ~DeleteAttributes();
+		~DeleteAttributes() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::DeleteAttributes, DeleteAttributesTypeId, AttributeProcessor );
 
 	protected :
 
-		virtual IECore::ConstObjectPtr processAttribute( const ScenePath &path, const Gaffer::Context *context, const IECore::InternedString &attributeName, const IECore::Object *inputAttribute ) const;
+		IECore::ConstObjectPtr processAttribute( const ScenePath &path, const Gaffer::Context *context, const IECore::InternedString &attributeName, const IECore::Object *inputAttribute ) const override;
 
 };
 

--- a/include/GafferScene/DeleteCurves.h
+++ b/include/GafferScene/DeleteCurves.h
@@ -56,23 +56,23 @@ class DeleteCurves : public SceneElementProcessor
 	public :
 
 		DeleteCurves( const std::string &name = defaultName<DeleteCurves>() );
-		virtual ~DeleteCurves();
+		~DeleteCurves() override;
 
 		Gaffer::StringPlug *curvesPlug();
 		const Gaffer::StringPlug *curvesPlug() const;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::DeleteCurves, DeleteCurvesTypeId, SceneElementProcessor );
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesBound() const;
-		virtual void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const;
+		bool processesBound() const override;
+		void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const override;
 
-		virtual bool processesObject() const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
 
 	private :
 

--- a/include/GafferScene/DeleteFaces.h
+++ b/include/GafferScene/DeleteFaces.h
@@ -56,23 +56,23 @@ class DeleteFaces : public SceneElementProcessor
 	public :
 
 		DeleteFaces( const std::string &name = defaultName<DeleteFaces>() );
-		virtual ~DeleteFaces();
+		~DeleteFaces() override;
 
 		Gaffer::StringPlug *facesPlug();
 		const Gaffer::StringPlug *facesPlug() const;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::DeleteFaces, DeleteFacesTypeId, SceneElementProcessor );
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesBound() const;
-		virtual void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const;
+		bool processesBound() const override;
+		void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const override;
 
-		virtual bool processesObject() const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
 
 	private :
 

--- a/include/GafferScene/DeleteGlobals.h
+++ b/include/GafferScene/DeleteGlobals.h
@@ -62,7 +62,7 @@ class DeleteGlobals : public GlobalsProcessor
 	public :
 
 		DeleteGlobals( const std::string &name=defaultName<DeleteGlobals>() );
-		virtual ~DeleteGlobals();
+		~DeleteGlobals() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::DeleteGlobals, DeleteGlobalsTypeId, GlobalsProcessor );
 
@@ -72,14 +72,14 @@ class DeleteGlobals : public GlobalsProcessor
 		Gaffer::BoolPlug *invertNamesPlug();
 		const Gaffer::BoolPlug *invertNamesPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		virtual std::string namePrefix() const;
 
-		virtual void hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const;
+		void hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const override;
 
 	private :
 

--- a/include/GafferScene/DeleteOptions.h
+++ b/include/GafferScene/DeleteOptions.h
@@ -48,13 +48,13 @@ class DeleteOptions : public DeleteGlobals
 	public :
 
 		DeleteOptions( const std::string &name=defaultName<DeleteOptions>() );
-		virtual ~DeleteOptions();
+		~DeleteOptions() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::DeleteOptions, DeleteOptionsTypeId, DeleteGlobals );
 
 	protected :
 
-		virtual std::string namePrefix() const;
+		std::string namePrefix() const override;
 
 };
 

--- a/include/GafferScene/DeleteOutputs.h
+++ b/include/GafferScene/DeleteOutputs.h
@@ -48,13 +48,13 @@ class DeleteOutputs : public DeleteGlobals
 	public :
 
 		DeleteOutputs( const std::string &name=defaultName<DeleteOutputs>() );
-		virtual ~DeleteOutputs();
+		~DeleteOutputs() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::DeleteOutputs, DeleteOutputsTypeId, DeleteGlobals );
 
 	protected :
 
-		virtual std::string namePrefix() const;
+		std::string namePrefix() const override;
 
 };
 

--- a/include/GafferScene/DeletePoints.h
+++ b/include/GafferScene/DeletePoints.h
@@ -56,23 +56,23 @@ class DeletePoints : public SceneElementProcessor
 	public :
 
 		DeletePoints( const std::string &name = defaultName<DeletePoints>() );
-		virtual ~DeletePoints();
+		~DeletePoints() override;
 
 		Gaffer::StringPlug *pointsPlug();
 		const Gaffer::StringPlug *pointsPlug() const;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::DeletePoints, DeletePointsTypeId, SceneElementProcessor );
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesBound() const;
-		virtual void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const;
+		bool processesBound() const override;
+		void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const override;
 
-		virtual bool processesObject() const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
 
 	private :
 

--- a/include/GafferScene/DeletePrimitiveVariables.h
+++ b/include/GafferScene/DeletePrimitiveVariables.h
@@ -48,13 +48,13 @@ class DeletePrimitiveVariables : public PrimitiveVariableProcessor
 	public :
 
 		DeletePrimitiveVariables( const std::string &name=defaultName<DeletePrimitiveVariables>() );
-		virtual ~DeletePrimitiveVariables();
+		~DeletePrimitiveVariables() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::DeletePrimitiveVariables, DeletePrimitiveVariablesTypeId, PrimitiveVariableProcessor );
 
 	protected :
 
-		virtual void processPrimitiveVariable( const ScenePath &path, const Gaffer::Context *context, IECore::ConstPrimitivePtr inputGeometry, IECore::PrimitiveVariable &inputVariable ) const;
+		void processPrimitiveVariable( const ScenePath &path, const Gaffer::Context *context, IECore::ConstPrimitivePtr inputGeometry, IECore::PrimitiveVariable &inputVariable ) const override;
 
 };
 

--- a/include/GafferScene/DeleteSets.h
+++ b/include/GafferScene/DeleteSets.h
@@ -55,7 +55,7 @@ class DeleteSets : public SceneProcessor
 	public :
 
 		DeleteSets( const std::string &name=defaultName<DeleteSets>() );
-		virtual ~DeleteSets();
+		~DeleteSets() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::DeleteSets, DeleteSetsTypeId, SceneProcessor );
 
@@ -65,15 +65,15 @@ class DeleteSets : public SceneProcessor
 		Gaffer::BoolPlug *invertNamesPlug();
 		const Gaffer::BoolPlug *invertNamesPlug() const;
 
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
-		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferScene/Duplicate.h
+++ b/include/GafferScene/Duplicate.h
@@ -50,7 +50,7 @@ class Duplicate : public BranchCreator
 	public :
 
 		Duplicate( const std::string &name=defaultName<Duplicate>() );
-		virtual ~Duplicate();
+		~Duplicate() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Duplicate, DuplicateTypeId, BranchCreator );
 
@@ -66,30 +66,30 @@ class Duplicate : public BranchCreator
 		Gaffer::TransformPlug *transformPlug();
 		const Gaffer::TransformPlug *transformPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const;
+		void hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/EvaluateLightLinks.h
+++ b/include/GafferScene/EvaluateLightLinks.h
@@ -48,16 +48,16 @@ class EvaluateLightLinks : public GafferScene::SceneProcessor
 	public :
 
 		EvaluateLightLinks( const std::string &name=defaultName<EvaluateLightLinks>() );
-		virtual ~EvaluateLightLinks();
+		~EvaluateLightLinks() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::EvaluateLightLinks, EvaluateLightLinksTypeId, SceneProcessor );
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected:
 
-		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 };
 

--- a/include/GafferScene/ExecutableRender.h
+++ b/include/GafferScene/ExecutableRender.h
@@ -58,7 +58,7 @@ class ExecutableRender : public GafferDispatch::TaskNode
 	public :
 
 		ExecutableRender( const std::string &name=defaultName<ExecutableRender>() );
-		virtual ~ExecutableRender();
+		~ExecutableRender() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ExecutableRender, ExecutableRenderTypeId, GafferDispatch::TaskNode );
 
@@ -70,9 +70,9 @@ class ExecutableRender : public GafferDispatch::TaskNode
 		ScenePlug *outPlug();
 		const ScenePlug *outPlug() const;
 
-		virtual IECore::MurmurHash hash( const Gaffer::Context *context ) const;
+		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
 		/// Implemented to perform the render.
-		virtual void execute() const;
+		void execute() const override;
 
 	protected :
 

--- a/include/GafferScene/ExternalProcedural.h
+++ b/include/GafferScene/ExternalProcedural.h
@@ -52,7 +52,7 @@ class ExternalProcedural : public ObjectSource
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ExternalProcedural, ExternalProceduralTypeId, ObjectSource );
 
 		ExternalProcedural( const std::string &name=defaultName<ExternalProcedural>() );
-		virtual ~ExternalProcedural();
+		~ExternalProcedural() override;
 
 		Gaffer::StringPlug *fileNamePlug();
 		const Gaffer::StringPlug *fileNamePlug() const;
@@ -63,12 +63,12 @@ class ExternalProcedural : public ObjectSource
 		Gaffer::CompoundDataPlug *parametersPlug();
 		const Gaffer::CompoundDataPlug *parametersPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
+		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/Filter.h
+++ b/include/GafferScene/Filter.h
@@ -68,15 +68,15 @@ class Filter : public Gaffer::ComputeNode
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Filter, FilterTypeId, Gaffer::ComputeNode );
 
 		Filter( const std::string &name=defaultName<Filter>() );
-		virtual ~Filter();
+		~Filter() override;
 
-		virtual Gaffer::BoolPlug *enabledPlug();
-		virtual const Gaffer::BoolPlug *enabledPlug() const;
+		Gaffer::BoolPlug *enabledPlug() override;
+		const Gaffer::BoolPlug *enabledPlug() const override;
 
 		FilterPlug *outPlug();
 		const FilterPlug *outPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 		virtual bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const;
 
 		/// \deprecated Use FilterPlug::SceneScope instead.
@@ -89,9 +89,9 @@ class Filter : public Gaffer::ComputeNode
 	protected :
 
 		/// Implemented to call hashMatch() below when computing the hash for outPlug().
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		/// Implemented to call computeMatch() below when computing the value of outPlug().
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 		/// Hash method for outPlug(). A derived class must either :
 		///

--- a/include/GafferScene/FilterPlug.h
+++ b/include/GafferScene/FilterPlug.h
@@ -73,12 +73,12 @@ class FilterPlug : public Gaffer::IntPlug
 			unsigned flags
 		);
 
-		virtual ~FilterPlug();
+		~FilterPlug() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::FilterPlug, FilterPlugTypeId, Gaffer::IntPlug );
 
-		virtual bool acceptsInput( const Gaffer::Plug *input ) const;
-		virtual Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsInput( const Gaffer::Plug *input ) const override;
+		Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 		/// Name of a context variable used to provide the input
 		/// scene to the filter

--- a/include/GafferScene/FilterProcessor.h
+++ b/include/GafferScene/FilterProcessor.h
@@ -64,7 +64,7 @@ class FilterProcessor : public Filter
 		/// inPlugs() to access the array itself.
 		FilterProcessor( const std::string &name, size_t minInputs, size_t maxInputs = Imath::limits<size_t>::max() );
 
-		virtual ~FilterProcessor();
+		~FilterProcessor() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::FilterProcessor, FilterProcessorTypeId, Filter );
 
@@ -81,18 +81,18 @@ class FilterProcessor : public Filter
 		Gaffer::ArrayPlug *inPlugs();
 		const Gaffer::ArrayPlug *inPlugs() const;
 
-		virtual bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const;
+		bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const override;
 
 		/// Returns inPlug() as the correspondingInput of outPlug();
-		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output );
-		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
+		Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) override;
+		const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const override;
 
 	protected :
 
 		/// Reimplemented to pass through the inPlug() hash when the node is disabled.
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		/// Reimplemented to pass through the inPlug() result when the node is disabled.
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/FilterResults.h
+++ b/include/GafferScene/FilterResults.h
@@ -54,7 +54,7 @@ class FilterResults : public Gaffer::ComputeNode
 	public :
 
 		FilterResults( const std::string &name=defaultName<FilterResults>() );
-		virtual ~FilterResults();
+		~FilterResults() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::FilterResults, FilterResultsTypeId, ComputeNode );
 
@@ -67,12 +67,12 @@ class FilterResults : public Gaffer::ComputeNode
 		PathMatcherDataPlug *outPlug();
 		const PathMatcherDataPlug *outPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/FilteredSceneProcessor.h
+++ b/include/GafferScene/FilteredSceneProcessor.h
@@ -53,14 +53,14 @@ class FilteredSceneProcessor : public SceneProcessor
 	public :
 
 		FilteredSceneProcessor( const std::string &name=defaultName<FilteredSceneProcessor>(), Filter::Result filterDefault = Filter::EveryMatch );
-		virtual ~FilteredSceneProcessor();
+		~FilteredSceneProcessor() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::FilteredSceneProcessor, FilteredSceneProcessorTypeId, SceneProcessor );
 
 		FilterPlug *filterPlug();
 		const FilterPlug *filterPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 

--- a/include/GafferScene/FreezeTransform.h
+++ b/include/GafferScene/FreezeTransform.h
@@ -48,24 +48,24 @@ class FreezeTransform : public FilteredSceneProcessor
 	public :
 
 		FreezeTransform( const std::string &name=defaultName<FreezeTransform>() );
-		virtual ~FreezeTransform();
+		~FreezeTransform() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::FreezeTransform, FreezeTransformTypeId, FilteredSceneProcessor );
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-		virtual void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 
-		virtual Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferScene/GlobalsProcessor.h
+++ b/include/GafferScene/GlobalsProcessor.h
@@ -51,19 +51,19 @@ class GlobalsProcessor : public SceneProcessor
 	public :
 
 		GlobalsProcessor( const std::string &name=defaultName<GlobalsProcessor>() );
-		virtual ~GlobalsProcessor();
+		~GlobalsProcessor() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::GlobalsProcessor, GlobalsProcessorTypeId, SceneProcessor );
 
 		/// Implemented so that each child of inPlug() affects the corresponding child of outPlug()
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		/// Implemented to call hashProcessedGlobals().
-		virtual void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		/// Implemented to call computeProcessedGlobals().
-		virtual IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const;
+		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 		/// Must be implemented by derived classes to compute the hash for the work done in processGlobals().
 		virtual void hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;

--- a/include/GafferScene/Grid.h
+++ b/include/GafferScene/Grid.h
@@ -59,7 +59,7 @@ class Grid : public SceneNode
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Grid, GridTypeId, SceneNode );
 
 		Grid( const std::string &name=defaultName<Grid>() );
-		virtual ~Grid();
+		~Grid() override;
 
 		Gaffer::StringPlug *namePlug();
 		const Gaffer::StringPlug *namePlug() const;
@@ -91,27 +91,27 @@ class Grid : public SceneNode
 		Gaffer::FloatPlug *borderPixelWidthPlug();
 		const Gaffer::FloatPlug *borderPixelWidthPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashTransform( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashObject( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashChildNames( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashTransform( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashObject( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashChildNames( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 
-		virtual Imath::Box3f computeBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual Imath::M44f computeTransform( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstCompoundObjectPtr computeAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstObjectPtr computeObject( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeChildNames( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		Imath::Box3f computeBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		Imath::M44f computeTransform( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstObjectPtr computeObject( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeChildNames( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferScene/Group.h
+++ b/include/GafferScene/Group.h
@@ -57,7 +57,7 @@ class Group : public SceneProcessor
 	public :
 
 		Group( const std::string &name=defaultName<Group>() );
-		virtual ~Group();
+		~Group() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Group, GroupTypeId, SceneProcessor );
 
@@ -71,28 +71,28 @@ class Group : public SceneProcessor
 		Gaffer::TransformPlug *transformPlug();
 		const Gaffer::TransformPlug *transformPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 		virtual IECore::ObjectPtr computeMapping( const Gaffer::Context *context ) const;
-		virtual Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -49,7 +49,7 @@ class Instancer : public BranchCreator
 	public :
 
 		Instancer( const std::string &name=defaultName<Instancer>() );
-		virtual ~Instancer();
+		~Instancer() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Instancer, InstancerTypeId, BranchCreator );
 
@@ -59,24 +59,24 @@ class Instancer : public BranchCreator
 		ScenePlug *instancePlug();
 		const ScenePlug *instancePlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/InteractiveRender.h
+++ b/include/GafferScene/InteractiveRender.h
@@ -63,7 +63,7 @@ class InteractiveRender : public Gaffer::Node
 	public :
 
 		InteractiveRender( const std::string &name=defaultName<InteractiveRender>() );
-		virtual ~InteractiveRender();
+		~InteractiveRender() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::InteractiveRender, InteractiveRenderTypeId, Gaffer::Node );
 

--- a/include/GafferScene/Isolate.h
+++ b/include/GafferScene/Isolate.h
@@ -55,7 +55,7 @@ class Isolate : public FilteredSceneProcessor
 	public :
 
 		Isolate( const std::string &name=defaultName<Isolate>() );
-		virtual ~Isolate();
+		~Isolate() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Isolate, IsolateTypeId, FilteredSceneProcessor );
 
@@ -71,19 +71,19 @@ class Isolate : public FilteredSceneProcessor
 		Gaffer::BoolPlug *adjustBoundsPlug();
 		const Gaffer::BoolPlug *adjustBoundsPlug() const;
 
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
 
-		virtual void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 
-		virtual Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferScene/Light.h
+++ b/include/GafferScene/Light.h
@@ -50,25 +50,25 @@ class Light : public ObjectSource
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Light, LightTypeId, ObjectSource );
 
 		Light( const std::string &name=defaultName<Light>() );
-		virtual ~Light();
+		~Light() override;
 
 		Gaffer::Plug *parametersPlug();
 		const Gaffer::Plug *parametersPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
+		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
 
-		virtual void hashAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void hashAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
-		virtual void hashBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual Imath::Box3f computeBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void hashBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
-		virtual IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const;
+		IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const override;
 
 		/// Must be implemented by derived classes to hash and generate the light to be placed
 		/// in the scene graph.

--- a/include/GafferScene/LightToCamera.h
+++ b/include/GafferScene/LightToCamera.h
@@ -48,32 +48,32 @@ class LightToCamera : public SceneElementProcessor
 	public :
 
 		LightToCamera( const std::string &name=defaultName<LightToCamera>() );
-		virtual ~LightToCamera();
+		~LightToCamera() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::LightToCamera, LightToCameraTypeId, SceneElementProcessor );
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
-		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
 
 	protected :
 
-		virtual bool processesAttributes() const;
-		virtual void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const;
+		bool processesAttributes() const override;
+		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const override;
 
-		virtual bool processesObject() const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
 
-		virtual bool processesTransform() const;
-		virtual void hashProcessedTransform( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::M44f computeProcessedTransform( const ScenePath &path, const Gaffer::Context *context, const Imath::M44f &inputTransform ) const;
+		bool processesTransform() const override;
+		void hashProcessedTransform( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeProcessedTransform( const ScenePath &path, const Gaffer::Context *context, const Imath::M44f &inputTransform ) const override;
 
-		virtual void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 
-		virtual IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferScene/LightTweaks.h
+++ b/include/GafferScene/LightTweaks.h
@@ -50,7 +50,7 @@ class LightTweaks : public SceneElementProcessor
 	public :
 
 		LightTweaks( const std::string &name=defaultName<LightTweaks>() );
-		virtual ~LightTweaks();
+		~LightTweaks() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::LightTweaks, LightTweaksTypeId, SceneElementProcessor );
 
@@ -91,8 +91,8 @@ class LightTweaks : public SceneElementProcessor
 				template<typename T>
 				const T *valuePlug() const;
 
-				virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
-				virtual Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+				bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const override;
+				Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 			private :
 
@@ -109,13 +109,13 @@ class LightTweaks : public SceneElementProcessor
 		Gaffer::Plug *tweaksPlug();
 		const Gaffer::Plug *tweaksPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesAttributes() const;
-		virtual void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const;
+		bool processesAttributes() const override;
+		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const override;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferScene/MapOffset.h
+++ b/include/GafferScene/MapOffset.h
@@ -56,7 +56,7 @@ class MapOffset : public SceneElementProcessor
 	public :
 
 		MapOffset( const std::string &name=defaultName<MapOffset>() );
-		virtual ~MapOffset();
+		~MapOffset() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::MapOffset, MapOffsetTypeId, SceneElementProcessor );
 
@@ -72,13 +72,13 @@ class MapOffset : public SceneElementProcessor
 		Gaffer::StringPlug *tNamePlug();
 		const Gaffer::StringPlug *tNamePlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesObject() const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
 
 	private :
 

--- a/include/GafferScene/MapProjection.h
+++ b/include/GafferScene/MapProjection.h
@@ -61,7 +61,7 @@ class MapProjection : public SceneElementProcessor
 	public :
 
 		MapProjection( const std::string &name=defaultName<MapProjection>() );
-		virtual ~MapProjection();
+		~MapProjection() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::MapProjection, MapProjectionTypeId, SceneElementProcessor );
 
@@ -74,13 +74,13 @@ class MapProjection : public SceneElementProcessor
 		Gaffer::StringPlug *tNamePlug();
 		const Gaffer::StringPlug *tNamePlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesObject() const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
 
 	private :
 

--- a/include/GafferScene/MeshTangents.h
+++ b/include/GafferScene/MeshTangents.h
@@ -50,7 +50,7 @@ class MeshTangents : public SceneElementProcessor
 	public :
 
 		MeshTangents( const std::string &name=defaultName<MeshTangents>() );
-		virtual ~MeshTangents();
+		~MeshTangents() override;
 
 		Gaffer::StringPlug *uvSetPlug();
 		const Gaffer::StringPlug *uvSetPlug() const;
@@ -69,13 +69,13 @@ class MeshTangents : public SceneElementProcessor
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::MeshTangents, MeshTangentsTypeId, SceneElementProcessor );
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesObject() const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
 
 	private :
 

--- a/include/GafferScene/MeshToPoints.h
+++ b/include/GafferScene/MeshToPoints.h
@@ -55,24 +55,24 @@ class MeshToPoints : public SceneElementProcessor
 	public :
 
 		MeshToPoints( const std::string &name=defaultName<MeshToPoints>() );
-		virtual ~MeshToPoints();
+		~MeshToPoints() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::MeshToPoints, MeshToPointsTypeId, SceneElementProcessor );
 
 		Gaffer::StringPlug *typePlug();
 		const Gaffer::StringPlug *typePlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesBound() const;
-		virtual void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const;
+		bool processesBound() const override;
+		void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const override;
 
-		virtual bool processesObject() const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
 
 	private :
 

--- a/include/GafferScene/MeshType.h
+++ b/include/GafferScene/MeshType.h
@@ -56,7 +56,7 @@ class MeshType : public SceneElementProcessor
 	public :
 
 		MeshType( const std::string &name=defaultName<MeshType>() );
-		virtual ~MeshType();
+		~MeshType() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::MeshType, MeshTypeTypeId, SceneElementProcessor );
 
@@ -69,13 +69,13 @@ class MeshType : public SceneElementProcessor
 		Gaffer::BoolPlug *overwriteExistingNormalsPlug();
 		const Gaffer::BoolPlug *overwriteExistingNormalsPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesObject() const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
 
 	private :
 

--- a/include/GafferScene/ObjectSource.h
+++ b/include/GafferScene/ObjectSource.h
@@ -60,7 +60,7 @@ class ObjectSource : public SceneNode
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ObjectSource, ObjectSourceTypeId, SceneNode );
 
-		virtual ~ObjectSource();
+		~ObjectSource() override;
 
 		Gaffer::StringPlug *namePlug();
 		const Gaffer::StringPlug *namePlug() const;
@@ -71,7 +71,7 @@ class ObjectSource : public SceneNode
 		Gaffer::TransformPlug *transformPlug();
 		const Gaffer::TransformPlug *transformPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
@@ -80,25 +80,25 @@ class ObjectSource : public SceneNode
 		Gaffer::ObjectPlug *sourcePlug();
 		const Gaffer::ObjectPlug *sourcePlug() const;
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void hashBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashTransform( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashObject( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashChildNames( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void hashBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashTransform( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashObject( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashChildNames( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
-		virtual Imath::Box3f computeBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual Imath::M44f computeTransform( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstCompoundObjectPtr computeAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstObjectPtr computeObject( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeChildNames( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+		Imath::Box3f computeBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		Imath::M44f computeTransform( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstObjectPtr computeObject( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeChildNames( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 		/// Must be implemented by derived classes.
 		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;

--- a/include/GafferScene/ObjectToScene.h
+++ b/include/GafferScene/ObjectToScene.h
@@ -50,17 +50,17 @@ class ObjectToScene : public ObjectSource
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ObjectToScene, ObjectToSceneTypeId, ObjectSource );
 
 		ObjectToScene( const std::string &name=defaultName<ObjectToScene>() );
-		virtual ~ObjectToScene();
+		~ObjectToScene() override;
 
 		Gaffer::ObjectPlug *objectPlug();
 		const Gaffer::ObjectPlug *objectPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
+		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/OpenGLAttributes.h
+++ b/include/GafferScene/OpenGLAttributes.h
@@ -48,7 +48,7 @@ class OpenGLAttributes : public GafferScene::Attributes
 	public :
 
 		OpenGLAttributes( const std::string &name=defaultName<OpenGLAttributes>() );
-		virtual ~OpenGLAttributes();
+		~OpenGLAttributes() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::OpenGLAttributes, OpenGLAttributesTypeId, Attributes );
 

--- a/include/GafferScene/OpenGLRender.h
+++ b/include/GafferScene/OpenGLRender.h
@@ -48,13 +48,13 @@ class OpenGLRender : public ExecutableRender
 	public :
 
 		OpenGLRender( const std::string &name=defaultName<OpenGLRender>() );
-		virtual ~OpenGLRender();
+		~OpenGLRender() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::OpenGLRender, OpenGLRenderTypeId, ExecutableRender );
 
 	protected :
 
-		virtual IECore::RendererPtr createRenderer() const;
+		IECore::RendererPtr createRenderer() const override;
 
 };
 

--- a/include/GafferScene/OpenGLShader.h
+++ b/include/GafferScene/OpenGLShader.h
@@ -48,17 +48,17 @@ class OpenGLShader : public GafferScene::Shader
 	public :
 
 		OpenGLShader( const std::string &name=defaultName<OpenGLShader>() );
-		virtual ~OpenGLShader();
+		~OpenGLShader() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::OpenGLShader, OpenGLShaderTypeId, GafferScene::Shader );
 
-		virtual void loadShader( const std::string &shaderName, bool keepExistingValues=false );
+		void loadShader( const std::string &shaderName, bool keepExistingValues=false ) override;
 
 	protected :
 
 		/// Reimplemented to allow ImageNodes to be plugged in to texture parameters.
-		virtual void parameterHash( const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h ) const;
-		virtual IECore::DataPtr parameterValue( const Gaffer::Plug *parameterPlug ) const;
+		void parameterHash( const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h ) const override;
+		IECore::DataPtr parameterValue( const Gaffer::Plug *parameterPlug ) const override;
 
 };
 

--- a/include/GafferScene/Options.h
+++ b/include/GafferScene/Options.h
@@ -51,19 +51,19 @@ class Options : public GlobalsProcessor
 	public :
 
 		Options( const std::string &name=defaultName<Options>() );
-		virtual ~Options();
+		~Options() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Options, OptionsTypeId, GlobalsProcessor );
 
 		Gaffer::CompoundDataPlug *optionsPlug();
 		const Gaffer::CompoundDataPlug *optionsPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const;
+		void hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const override;
 
 		virtual void hashPrefix( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		virtual std::string computePrefix( const Gaffer::Context *context ) const;

--- a/include/GafferScene/Outputs.h
+++ b/include/GafferScene/Outputs.h
@@ -51,7 +51,7 @@ class Outputs : public GlobalsProcessor
 	public :
 
 		Outputs( const std::string &name=defaultName<Outputs>() );
-		virtual ~Outputs();
+		~Outputs() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Outputs, OutputsTypeId, GlobalsProcessor );
 
@@ -62,15 +62,15 @@ class Outputs : public GlobalsProcessor
 		Gaffer::ValuePlug *addOutput( const std::string &name );
 		Gaffer::ValuePlug *addOutput( const std::string &name, const IECore::Display *output );
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		static void registerOutput( const std::string &name, const IECore::Display *output );
 		static void registeredOutputs( std::vector<std::string> &names );
 
 	protected :
 
-		virtual void hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const;
+		void hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const override;
 
 	private :
 

--- a/include/GafferScene/Parameters.h
+++ b/include/GafferScene/Parameters.h
@@ -50,20 +50,20 @@ class Parameters : public SceneElementProcessor
 	public :
 
 		Parameters( const std::string &name=defaultName<Parameters>() );
-		virtual ~Parameters();
+		~Parameters() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Parameters, ParametersTypeId, SceneElementProcessor );
 
 		Gaffer::CompoundDataPlug *parametersPlug();
 		const Gaffer::CompoundDataPlug *parametersPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesObject() const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
 
 	private :
 

--- a/include/GafferScene/Parent.h
+++ b/include/GafferScene/Parent.h
@@ -48,37 +48,37 @@ class Parent : public BranchCreator
 	public :
 
 		Parent( const std::string &name=defaultName<Parent>() );
-		virtual ~Parent();
+		~Parent() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Parent, ParentTypeId, BranchCreator );
 
 		ScenePlug *childPlug();
 		const ScenePlug *childPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const;
+		void hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const;
+		void hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/ParentConstraint.h
+++ b/include/GafferScene/ParentConstraint.h
@@ -50,7 +50,7 @@ class ParentConstraint : public Constraint
 	public :
 
 		ParentConstraint( const std::string &name=defaultName<ParentConstraint>() );
-		virtual ~ParentConstraint();
+		~ParentConstraint() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ParentConstraint, ParentConstraintTypeId, Constraint );
 
@@ -59,9 +59,9 @@ class ParentConstraint : public Constraint
 
 	protected :
 
-		virtual bool affectsConstraint( const Gaffer::Plug *input ) const;
-		virtual void hashConstraint( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const;
+		bool affectsConstraint( const Gaffer::Plug *input ) const override;
+		void hashConstraint( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const override;
 
 	private :
 

--- a/include/GafferScene/PathFilter.h
+++ b/include/GafferScene/PathFilter.h
@@ -54,20 +54,20 @@ class PathFilter : public Filter
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::PathFilter, PathFilterTypeId, Filter );
 
 		PathFilter( const std::string &name=defaultName<PathFilter>() );
-		virtual ~PathFilter();
+		~PathFilter() override;
 
 		Gaffer::StringVectorDataPlug *pathsPlug();
 		const Gaffer::StringVectorDataPlug *pathsPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-		virtual void hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual unsigned computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const;
+		void hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		unsigned computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/PathMatcher.h
+++ b/include/GafferScene/PathMatcher.h
@@ -184,7 +184,7 @@ class PathMatcher
 				Node( bool terminator = false );
 				// Shallow copy.
 				Node( const Node &other );
-				~Node();
+				~Node() override;
 
 				// Returns an iterator to the first child whose name contains wildcards.
 				// All children between here and children.end() will also contain wildcards.

--- a/include/GafferScene/Plane.h
+++ b/include/GafferScene/Plane.h
@@ -53,7 +53,7 @@ class Plane : public ObjectSource
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Plane, PlaneTypeId, ObjectSource );
 
 		Plane( const std::string &name=defaultName<Plane>() );
-		virtual ~Plane();
+		~Plane() override;
 
 		Gaffer::V2fPlug *dimensionsPlug();
 		const Gaffer::V2fPlug *dimensionsPlug() const;
@@ -61,12 +61,12 @@ class Plane : public ObjectSource
 		Gaffer::V2iPlug *divisionsPlug();
 		const Gaffer::V2iPlug *divisionsPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
+		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/PointConstraint.h
+++ b/include/GafferScene/PointConstraint.h
@@ -48,7 +48,7 @@ class PointConstraint : public Constraint
 	public :
 
 		PointConstraint( const std::string &name=defaultName<PointConstraint>() );
-		virtual ~PointConstraint();
+		~PointConstraint() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::PointConstraint, PointConstraintTypeId, Constraint );
 
@@ -66,9 +66,9 @@ class PointConstraint : public Constraint
 
 	protected :
 
-		virtual bool affectsConstraint( const Gaffer::Plug *input ) const;
-		virtual void hashConstraint( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const;
+		bool affectsConstraint( const Gaffer::Plug *input ) const override;
+		void hashConstraint( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const override;
 
 	private :
 

--- a/include/GafferScene/PointsType.h
+++ b/include/GafferScene/PointsType.h
@@ -55,24 +55,24 @@ class PointsType : public SceneElementProcessor
 	public :
 
 		PointsType( const std::string &name=defaultName<PointsType>() );
-		virtual ~PointsType();
+		~PointsType() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::PointsType, PointsTypeTypeId, SceneElementProcessor );
 
 		Gaffer::StringPlug *typePlug();
 		const Gaffer::StringPlug *typePlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesBound() const;
-		virtual void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const;
+		bool processesBound() const override;
+		void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const override;
 
-		virtual bool processesObject() const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
 
 	private :
 

--- a/include/GafferScene/Preview/InteractiveRender.h
+++ b/include/GafferScene/Preview/InteractiveRender.h
@@ -63,7 +63,7 @@ class InteractiveRender : public Gaffer::Node
 	public :
 
 		InteractiveRender( const std::string &name=defaultName<InteractiveRender>() );
-		virtual ~InteractiveRender();
+		~InteractiveRender() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Preview::InteractiveRender, GafferScene::PreviewInteractiveRenderTypeId, Gaffer::Node );
 

--- a/include/GafferScene/Preview/Render.h
+++ b/include/GafferScene/Preview/Render.h
@@ -57,7 +57,7 @@ class Render : public GafferDispatch::TaskNode
 	public :
 
 		Render( const std::string &name=defaultName<Render>() );
-		virtual ~Render();
+		~Render() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Preview::Render, GafferScene::RenderTypeId, GafferDispatch::TaskNode );
 
@@ -82,8 +82,8 @@ class Render : public GafferDispatch::TaskNode
 		ScenePlug *outPlug();
 		const ScenePlug *outPlug() const;
 
-		virtual IECore::MurmurHash hash( const Gaffer::Context *context ) const;
-		virtual void execute() const;
+		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
+		void execute() const override;
 
 	protected :
 

--- a/include/GafferScene/PrimitiveVariableProcessor.h
+++ b/include/GafferScene/PrimitiveVariableProcessor.h
@@ -60,7 +60,7 @@ class PrimitiveVariableProcessor : public SceneElementProcessor
 	public :
 
 		PrimitiveVariableProcessor( const std::string &name=defaultName<PrimitiveVariableProcessor>(), Filter::Result filterDefault = Filter::EveryMatch );
-		virtual ~PrimitiveVariableProcessor();
+		~PrimitiveVariableProcessor() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::PrimitiveVariableProcessor, PrimitiveVariableProcessorTypeId, SceneElementProcessor );
 
@@ -71,14 +71,14 @@ class PrimitiveVariableProcessor : public SceneElementProcessor
 		const Gaffer::BoolPlug *invertNamesPlug() const;
 
 		/// Implemented so that namesPlug() affects outPlug()->objectPlug().
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		/// Implemented to call processPrimitiveVariable() for the appropriate variables of inputObject.
-		virtual bool processesObject() const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
 
 		/// Must be implemented by subclasses to process the primitive variable in place.
 		virtual void processPrimitiveVariable( const ScenePath &path, const Gaffer::Context *context, IECore::ConstPrimitivePtr inputGeometry, IECore::PrimitiveVariable &inputVariable ) const = 0;

--- a/include/GafferScene/PrimitiveVariables.h
+++ b/include/GafferScene/PrimitiveVariables.h
@@ -50,20 +50,20 @@ class PrimitiveVariables : public SceneElementProcessor
 	public :
 
 		PrimitiveVariables( const std::string &name=defaultName<PrimitiveVariables>() );
-		virtual ~PrimitiveVariables();
+		~PrimitiveVariables() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::PrimitiveVariables, PrimitiveVariablesTypeId, SceneElementProcessor );
 
 		Gaffer::CompoundDataPlug *primitiveVariablesPlug();
 		const Gaffer::CompoundDataPlug *primitiveVariablesPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesObject() const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const;
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
 
 	private :
 

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -123,7 +123,7 @@ class Renderer : public IECore::RefCounted
 
 			protected :
 
-				virtual ~AttributesInterface();
+				~AttributesInterface() override;
 
 		};
 
@@ -188,7 +188,7 @@ class Renderer : public IECore::RefCounted
 
 			protected :
 
-				virtual ~ObjectInterface();
+				~ObjectInterface() override;
 
 		};
 
@@ -271,7 +271,7 @@ class Renderer : public IECore::RefCounted
 	protected :
 
 		Renderer();
-		virtual ~Renderer();
+		~Renderer() override;
 
 		/// Construct a static instance of this to register a
 		/// renderer implementation.

--- a/include/GafferScene/Prune.h
+++ b/include/GafferScene/Prune.h
@@ -48,26 +48,26 @@ class Prune : public FilteredSceneProcessor
 	public :
 
 		Prune( const std::string &name=defaultName<Prune>() );
-		virtual ~Prune();
+		~Prune() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Prune, PruneTypeId, FilteredSceneProcessor );
 
 		Gaffer::BoolPlug *adjustBoundsPlug();
 		const Gaffer::BoolPlug *adjustBoundsPlug() const;
 
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const;
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
 
-		virtual void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 
-		virtual Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferScene/ResamplePrimitiveVariables.h
+++ b/include/GafferScene/ResamplePrimitiveVariables.h
@@ -48,19 +48,19 @@ class ResamplePrimitiveVariables : public PrimitiveVariableProcessor
 	public :
 
 		ResamplePrimitiveVariables( const std::string &name = defaultName<ResamplePrimitiveVariables>() );
-		virtual ~ResamplePrimitiveVariables();
+		~ResamplePrimitiveVariables() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ResamplePrimitiveVariables, ResamplePrimitiveVariablesTypeId, PrimitiveVariableProcessor );
 
 		Gaffer::IntPlug *interpolationPlug();
 		const Gaffer::IntPlug *interpolationPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void processPrimitiveVariable( const ScenePath &path, const Gaffer::Context *context, IECore::ConstPrimitivePtr inputGeometry, IECore::PrimitiveVariable &inputVariable ) const;
-		virtual void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void processPrimitiveVariable( const ScenePath &path, const Gaffer::Context *context, IECore::ConstPrimitivePtr inputGeometry, IECore::PrimitiveVariable &inputVariable ) const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 	private :
 
 		static size_t g_firstPlugIndex;

--- a/include/GafferScene/SceneAlgo.inl
+++ b/include/GafferScene/SceneAlgo.inl
@@ -58,11 +58,11 @@ class TraverseTask : public tbb::task
 		{
 		}
 
-		virtual ~TraverseTask()
+		~TraverseTask() override
 		{
 		}
 
-		virtual task *execute()
+		task *execute() override
 		{
 			ScenePlug::PathScope pathScope( m_context, m_path );
 
@@ -122,11 +122,11 @@ class LocationTask : public tbb::task
 		{
 		}
 
-		virtual ~LocationTask()
+		~LocationTask() override
 		{
 		}
 
-		virtual task *execute()
+		task *execute() override
 		{
 			ScenePlug::PathScope pathScope( m_context, m_path );
 

--- a/include/GafferScene/SceneElementProcessor.h
+++ b/include/GafferScene/SceneElementProcessor.h
@@ -55,32 +55,32 @@ class SceneElementProcessor : public FilteredSceneProcessor
 	public :
 
 		SceneElementProcessor( const std::string &name=defaultName<SceneElementProcessor>(), Filter::Result filterDefault = Filter::EveryMatch );
-		virtual ~SceneElementProcessor();
+		~SceneElementProcessor() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::SceneElementProcessor, SceneElementProcessorTypeId, FilteredSceneProcessor );
 
 		/// Implemented so that each child of inPlug() affects the corresponding child of outPlug()
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		/// Implemented to call hashProcessedBound() where appropriate.
-		virtual void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		/// Implemented to call hashProcessedTransform() where appropriate.
-		virtual void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		/// Implemented to call hashProcessedAttributes() where appropriate.
-		virtual void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		/// Implemented to call hashProcessedObject() where appropriate.
-		virtual void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 
 		/// Implemented to call computeProcessedBound() where appropriate.
-		virtual Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 		/// Implemented to call computeProcessedTransform() where appropriate.
-		virtual Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 		/// Implemented to call computeProcessedAttributes() where appropriate.
-		virtual IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 		/// Implemented to call computeProcessedObject() where appropriate.
-		virtual IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 		/// @name Scene processing methods
 		/// These methods should be reimplemented by derived classes to process the input scene - they will be called as

--- a/include/GafferScene/SceneFilterPathFilter.h
+++ b/include/GafferScene/SceneFilterPathFilter.h
@@ -54,13 +54,13 @@ class SceneFilterPathFilter : public Gaffer::PathFilter
 	public :
 
 		SceneFilterPathFilter( FilterPtr sceneFilter, IECore::CompoundDataPtr userData = nullptr );
-		virtual ~SceneFilterPathFilter();
+		~SceneFilterPathFilter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::SceneFilterPathFilter, SceneFilterPathFilterTypeId, Gaffer::PathFilter );
 
 	protected :
 
-		virtual void doFilter( std::vector<Gaffer::PathPtr> &paths ) const;
+		void doFilter( std::vector<Gaffer::PathPtr> &paths ) const override;
 
 	private :
 

--- a/include/GafferScene/SceneNode.h
+++ b/include/GafferScene/SceneNode.h
@@ -54,7 +54,7 @@ class SceneNode : public Gaffer::ComputeNode
 	public :
 
 		SceneNode( const std::string &name=defaultName<SceneNode>() );
-		virtual ~SceneNode();
+		~SceneNode() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::SceneNode, SceneNodeTypeId, Gaffer::ComputeNode );
 
@@ -64,18 +64,18 @@ class SceneNode : public Gaffer::ComputeNode
 		const ScenePlug *outPlug() const;
 
 		/// The enabled plug provides a mechanism for turning the effect of the node on and off.
-		virtual Gaffer::BoolPlug *enabledPlug();
-		virtual const Gaffer::BoolPlug *enabledPlug() const;
+		Gaffer::BoolPlug *enabledPlug() override;
+		const Gaffer::BoolPlug *enabledPlug() const override;
 
 		/// Implemented so that enabledPlug() affects outPlug().
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		typedef ScenePlug::ScenePath ScenePath;
 
 		/// Implemented to call the hash*() methods below whenever output is part of a ScenePlug and the node is enabled.
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 
 		/// Hash methods for the individual children of outPlug(). A derived class must either :
 		///
@@ -102,7 +102,7 @@ class SceneNode : public Gaffer::ComputeNode
 		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
 
 		/// Implemented to call the compute*() methods below whenever output is part of a ScenePlug and the node is enabled.
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 		/// Compute methods for the individual children of outPlug() - these must be implemented by derived classes, or
 		/// an input connection must be made to the plug, so that the method is not called.

--- a/include/GafferScene/ScenePath.h
+++ b/include/GafferScene/ScenePath.h
@@ -67,7 +67,7 @@ class ScenePath : public Gaffer::Path
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ScenePath, ScenePathTypeId, Gaffer::Path );
 
-		virtual ~ScenePath();
+		~ScenePath() override;
 
 		void setScene( ScenePlugPtr scene );
 		ScenePlug *getScene();
@@ -77,16 +77,16 @@ class ScenePath : public Gaffer::Path
 		Gaffer::Context *getContext();
 		const Gaffer::Context *getContext() const;
 
-		virtual bool isValid() const;
-		virtual bool isLeaf() const;
-		virtual Gaffer::PathPtr copy() const;
+		bool isValid() const override;
+		bool isLeaf() const override;
+		Gaffer::PathPtr copy() const override;
 
 		static Gaffer::PathFilterPtr createStandardFilter( const std::vector<std::string> &setNames = std::vector<std::string>(), const std::string &setsLabel = "" );
 
 	protected :
 
-		virtual void doChildren( std::vector<Gaffer::PathPtr> &children ) const;
-		virtual void pathChangedSignalCreated();
+		void doChildren( std::vector<Gaffer::PathPtr> &children ) const override;
+		void pathChangedSignalCreated() override;
 
 	private :
 

--- a/include/GafferScene/ScenePlug.h
+++ b/include/GafferScene/ScenePlug.h
@@ -57,14 +57,14 @@ class ScenePlug : public Gaffer::ValuePlug
 	public :
 
 		ScenePlug( const std::string &name=defaultName<ScenePlug>(), Direction direction=In, unsigned flags=Default );
-		virtual ~ScenePlug();
+		~ScenePlug() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ScenePlug, ScenePlugTypeId, ValuePlug );
 
-		virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
-		virtual Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
+		bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const override;
+		Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 		/// Only accepts ScenePlug inputs.
-		virtual bool acceptsInput( const Gaffer::Plug *input ) const;
+		bool acceptsInput( const Gaffer::Plug *input ) const override;
 
 		/// @name Child plugs
 		/// Different aspects of the scene are passed through different

--- a/include/GafferScene/SceneProcedural.h
+++ b/include/GafferScene/SceneProcedural.h
@@ -71,14 +71,14 @@ class SceneProcedural : public IECore::Renderer::Procedural
 
 		/// A copy of context is taken.
 		SceneProcedural( ConstScenePlugPtr scenePlug, const Gaffer::Context *context, const ScenePlug::ScenePath &scenePath=ScenePlug::ScenePath(), bool computeBound = true );
-		virtual ~SceneProcedural();
+		~SceneProcedural() override;
 
-		virtual IECore::MurmurHash hash() const;
+		IECore::MurmurHash hash() const override;
 		/// Returns an accurate computed bound if `computeBound=true`
 		/// was passed to the constructor, otherwise returns
 		/// Procedural::noBound.
-		virtual Imath::Box3f bound() const;
-		virtual void render( IECore::Renderer *renderer ) const;
+		Imath::Box3f bound() const override;
+		void render( IECore::Renderer *renderer ) const override;
 
 		typedef boost::signal<void ( void )> AllRenderedSignal;
 

--- a/include/GafferScene/SceneProcessor.h
+++ b/include/GafferScene/SceneProcessor.h
@@ -65,7 +65,7 @@ class SceneProcessor : public SceneNode
 		/// inPlugs() to access the array itself.
 		SceneProcessor( const std::string &name, size_t minInputs, size_t maxInputs = Imath::limits<size_t>::max() );
 
-		virtual ~SceneProcessor();
+		~SceneProcessor() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::SceneProcessor, SceneProcessorTypeId, SceneNode );
 
@@ -82,15 +82,15 @@ class SceneProcessor : public SceneNode
 		Gaffer::ArrayPlug *inPlugs();
 		const Gaffer::ArrayPlug *inPlugs() const;
 
-		virtual Gaffer::Plug *correspondingInput( const Gaffer::Plug *output );
-		virtual const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const;
+		Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) override;
+		const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const override;
 
 	protected :
 
 		/// Reimplemented from SceneNode to pass through the inPlug() hashes when the node is disabled.
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		/// Reimplemented from SceneNode to pass through the inPlug() computations when the node is disabled.
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/SceneReader.h
+++ b/include/GafferScene/SceneReader.h
@@ -59,7 +59,7 @@ class SceneReader : public SceneNode
 	public :
 
 		SceneReader( const std::string &name=defaultName<SceneReader>() );
-		virtual ~SceneReader();
+		~SceneReader() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::SceneReader, SceneReaderTypeId, SceneNode )
 
@@ -74,7 +74,7 @@ class SceneReader : public SceneNode
 		Gaffer::StringPlug *tagsPlug();
 		const Gaffer::StringPlug *tagsPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		static size_t supportedExtensions( std::vector<std::string> &extensions );
 
@@ -85,23 +85,23 @@ class SceneReader : public SceneNode
 		/// implementation of SceneCache::hash() - it should hash the filename and modification time, but instead
 		/// it hashes some pointer value which isn't guaranteed to be unique (see sceneHash() in IECore/SceneCache.cpp).
 		/// Additionally, we don't have a way of hashing in the tags, which we would need in hashChildNames().
-		virtual void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 
-		virtual Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferScene/SceneWriter.h
+++ b/include/GafferScene/SceneWriter.h
@@ -55,7 +55,7 @@ class SceneWriter : public GafferDispatch::TaskNode
 	public :
 
 		SceneWriter( const std::string &name=defaultName<SceneWriter>() );
-		virtual ~SceneWriter();
+		~SceneWriter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::SceneWriter, SceneWriterTypeId, GafferDispatch::TaskNode );
 
@@ -68,16 +68,16 @@ class SceneWriter : public GafferDispatch::TaskNode
 		ScenePlug *outPlug();
 		const ScenePlug *outPlug() const;
 
-		virtual IECore::MurmurHash hash( const Gaffer::Context *context ) const;
+		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
 
-		virtual void execute() const;
+		void execute() const override;
 
 		/// Re-implemented to open the file for writing, then iterate through the
 		/// frames, modifying the current Context and calling writeLocation().
-		virtual void executeSequence( const std::vector<float> &frames ) const;
+		void executeSequence( const std::vector<float> &frames ) const override;
 
 		/// Re-implemented to return true, since the entire file must be written at once.
-		virtual bool requiresSequenceExecution() const;
+		bool requiresSequenceExecution() const override;
 
 	private :
 

--- a/include/GafferScene/Seeds.h
+++ b/include/GafferScene/Seeds.h
@@ -49,7 +49,7 @@ class Seeds : public BranchCreator
 	public :
 
 		Seeds( const std::string &name=defaultName<Seeds>() );
-		virtual ~Seeds();
+		~Seeds() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Seeds, SeedsTypeId, BranchCreator );
 
@@ -65,24 +65,24 @@ class Seeds : public BranchCreator
 		Gaffer::StringPlug *pointTypePlug();
 		const Gaffer::StringPlug *pointTypePlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
-		virtual void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const;
+		void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/Set.h
+++ b/include/GafferScene/Set.h
@@ -59,7 +59,7 @@ class Set : public FilteredSceneProcessor
 	public :
 
 		Set( const std::string &name=defaultName<Set>() );
-		virtual ~Set();
+		~Set() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Set, SetTypeId, FilteredSceneProcessor );
 
@@ -79,18 +79,18 @@ class Set : public FilteredSceneProcessor
 		Gaffer::StringVectorDataPlug *pathsPlug();
 		const Gaffer::StringVectorDataPlug *pathsPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-		virtual void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashSetNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 
-		virtual IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferScene/SetFilter.h
+++ b/include/GafferScene/SetFilter.h
@@ -62,22 +62,22 @@ class SetFilter : public Filter
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::SetFilter, SetFilterTypeId, Filter );
 
 		SetFilter( const std::string &name=defaultName<SetFilter>() );
-		virtual ~SetFilter();
+		~SetFilter() override;
 
 		Gaffer::StringPlug *setExpressionPlug();
 		const Gaffer::StringPlug *setExpressionPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
-		virtual bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const;
+		bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-		virtual void hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual unsigned computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const;
+		void hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		unsigned computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -67,7 +67,7 @@ class Shader : public Gaffer::DependencyNode
 	public :
 
 		Shader( const std::string &name=defaultName<Shader>() );
-		virtual ~Shader();
+		~Shader() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Shader, ShaderTypeId, Gaffer::DependencyNode );
 
@@ -101,12 +101,12 @@ class Shader : public Gaffer::DependencyNode
 		/// then by default its output connections are ignored on any
 		/// downstream nodes. Derived classes may implement correspondingInput( outPlug() )
 		/// to allow disabled shaders to act as a pass-through instead.
-		virtual Gaffer::BoolPlug *enabledPlug();
-		virtual const Gaffer::BoolPlug *enabledPlug() const;
+		Gaffer::BoolPlug *enabledPlug() override;
+		const Gaffer::BoolPlug *enabledPlug() const override;
 
 		/// Implemented so that the children of parametersPlug() affect
 		/// outPlug().
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		/// \undoable
 		/// Subclasses of Shader should define how to load a given shader name, and populate the parameters

--- a/include/GafferScene/ShaderAssignment.h
+++ b/include/GafferScene/ShaderAssignment.h
@@ -50,20 +50,20 @@ class ShaderAssignment : public SceneElementProcessor
 	public :
 
 		ShaderAssignment( const std::string &name=defaultName<ShaderAssignment>() );
-		virtual ~ShaderAssignment();
+		~ShaderAssignment() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ShaderAssignment, ShaderAssignmentTypeId, SceneElementProcessor );
 
 		GafferScene::ShaderPlug *shaderPlug();
 		const GafferScene::ShaderPlug *shaderPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesAttributes() const;
-		virtual void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const;
+		bool processesAttributes() const override;
+		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const override;
 
 	private :
 

--- a/include/GafferScene/ShaderPlug.h
+++ b/include/GafferScene/ShaderPlug.h
@@ -54,13 +54,13 @@ class ShaderPlug : public Gaffer::Plug
 	public :
 
 		ShaderPlug( const std::string &name=defaultName<ShaderPlug>(), Direction direction=In, unsigned flags=Default );
-		virtual ~ShaderPlug();
+		~ShaderPlug() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ShaderPlug, ShaderPlugTypeId, Plug );
 
-		virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
-		virtual Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const;
-		virtual bool acceptsInput( const Gaffer::Plug *input ) const;
+		bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const override;
+		Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
+		bool acceptsInput( const Gaffer::Plug *input ) const override;
 
 		/// Returns a hash representing the shading network generated
 		/// by the input shader.

--- a/include/GafferScene/ShaderSwitch.h
+++ b/include/GafferScene/ShaderSwitch.h
@@ -50,7 +50,7 @@ class ShaderSwitch : public Gaffer::SwitchComputeNode
 	public :
 
 		ShaderSwitch( const std::string &name=defaultName<ShaderSwitch>() );
-		virtual ~ShaderSwitch();
+		~ShaderSwitch() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::ShaderSwitch, ShaderSwitchTypeId, Gaffer::SwitchComputeNode );
 

--- a/include/GafferScene/Sphere.h
+++ b/include/GafferScene/Sphere.h
@@ -52,7 +52,7 @@ class Sphere : public ObjectSource
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Sphere, SphereTypeId, ObjectSource );
 
 		Sphere( const std::string &name=defaultName<Sphere>() );
-		virtual ~Sphere();
+		~Sphere() override;
 
 		enum Type
 		{
@@ -78,12 +78,12 @@ class Sphere : public ObjectSource
 		Gaffer::V2iPlug *divisionsPlug();
 		const Gaffer::V2iPlug *divisionsPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
+		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/StandardAttributes.h
+++ b/include/GafferScene/StandardAttributes.h
@@ -48,7 +48,7 @@ class StandardAttributes : public Attributes
 	public :
 
 		StandardAttributes( const std::string &name=defaultName<StandardAttributes>() );
-		virtual ~StandardAttributes();
+		~StandardAttributes() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::StandardAttributes, StandardAttributesTypeId, Attributes );
 

--- a/include/GafferScene/StandardOptions.h
+++ b/include/GafferScene/StandardOptions.h
@@ -49,7 +49,7 @@ class StandardOptions : public Options
 	public :
 
 		StandardOptions( const std::string &name=defaultName<StandardOptions>() );
-		virtual ~StandardOptions();
+		~StandardOptions() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::StandardOptions, StandardOptionsTypeId, Options );
 

--- a/include/GafferScene/SubTree.h
+++ b/include/GafferScene/SubTree.h
@@ -53,7 +53,7 @@ class SubTree : public SceneProcessor
 	public :
 
 		SubTree( const std::string &name=defaultName<SubTree>() );
-		virtual ~SubTree();
+		~SubTree() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::SubTree, SubTreeTypeId, SceneProcessor );
 
@@ -63,23 +63,23 @@ class SubTree : public SceneProcessor
 		Gaffer::BoolPlug *includeRootPlug();
 		const Gaffer::BoolPlug *includeRootPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 
-		virtual Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
+		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 	private :
 

--- a/include/GafferScene/Text.h
+++ b/include/GafferScene/Text.h
@@ -50,7 +50,7 @@ class Text : public ObjectSource
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Text, TextTypeId, ObjectSource );
 
 		Text( const std::string &name=defaultName<Text>() );
-		virtual ~Text();
+		~Text() override;
 
 		Gaffer::StringPlug *textPlug();
 		const Gaffer::StringPlug *textPlug() const;
@@ -58,12 +58,12 @@ class Text : public ObjectSource
 		Gaffer::StringPlug *fontPlug();
 		const Gaffer::StringPlug *fontPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const;
+		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/Transform.h
+++ b/include/GafferScene/Transform.h
@@ -50,7 +50,7 @@ class Transform : public SceneElementProcessor
 	public :
 
 		Transform( const std::string &name=defaultName<Transform>() );
-		virtual ~Transform();
+		~Transform() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Transform, TransformTypeId, SceneElementProcessor );
 
@@ -69,13 +69,13 @@ class Transform : public SceneElementProcessor
 		Gaffer::TransformPlug *transformPlug();
 		const Gaffer::TransformPlug *transformPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual bool processesTransform() const;
-		virtual void hashProcessedTransform( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual Imath::M44f computeProcessedTransform( const ScenePath &path, const Gaffer::Context *context, const Imath::M44f &inputTransform ) const;
+		bool processesTransform() const override;
+		void hashProcessedTransform( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeProcessedTransform( const ScenePath &path, const Gaffer::Context *context, const Imath::M44f &inputTransform ) const override;
 
 	private :
 

--- a/include/GafferScene/UnionFilter.h
+++ b/include/GafferScene/UnionFilter.h
@@ -51,14 +51,14 @@ class UnionFilter : public FilterProcessor
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::UnionFilter, UnionFilterTypeId, FilterProcessor );
 
 		UnionFilter( const std::string &name=defaultName<UnionFilter>() );
-		virtual ~UnionFilter();
+		~UnionFilter() override;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual unsigned computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const;
+		void hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		unsigned computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const override;
 
 };
 

--- a/include/GafferSceneTest/CompoundObjectSource.h
+++ b/include/GafferSceneTest/CompoundObjectSource.h
@@ -55,34 +55,34 @@ class CompoundObjectSource : public GafferScene::SceneNode
 	public :
 
 		CompoundObjectSource( const std::string &name=defaultName<CompoundObjectSource>() );
-		virtual ~CompoundObjectSource();
+		~CompoundObjectSource() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneTest::CompoundObjectSource, CompoundObjectSourceTypeId, GafferScene::SceneNode );
 
 		Gaffer::ObjectPlug *inPlug();
 		const Gaffer::ObjectPlug *inPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hashBound( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashTransform( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashObject( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashGlobals( const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSetNames( const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const;
-		virtual void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const;
+		void hashBound( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashTransform( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashObject( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashGlobals( const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSetNames( const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const override;
 
-		virtual Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const;
-		virtual Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const;
-		virtual IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const;
-		virtual IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const;
-		virtual IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const;
-		virtual GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const;
+		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const override;
+		Imath::M44f computeTransform( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const override;
+		IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const override;
+		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeSetNames( const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const override;
+		GafferScene::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const override;
 
 		IECore::ConstCompoundObjectPtr inObject() const;
 		IECore::ConstCompoundObjectPtr entryForPath( const ScenePath &path ) const;

--- a/include/GafferSceneTest/TestLight.h
+++ b/include/GafferSceneTest/TestLight.h
@@ -50,14 +50,14 @@ class TestLight : public GafferScene::Light
 	public :
 
 		TestLight( const std::string &name=defaultName<TestLight>() );
-		virtual ~TestLight();
+		~TestLight() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneTest::TestLight, TestLightTypeId, GafferScene::Light );
 
 	protected :
 
-		virtual void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ObjectVectorPtr computeLight( const Gaffer::Context *context ) const;
+		void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ObjectVectorPtr computeLight( const Gaffer::Context *context ) const override;
 
 };
 

--- a/include/GafferSceneTest/TestShader.h
+++ b/include/GafferSceneTest/TestShader.h
@@ -50,7 +50,7 @@ class TestShader : public GafferScene::Shader
 	public :
 
 		TestShader( const std::string &name=defaultName<TestShader>() );
-		virtual ~TestShader();
+		~TestShader() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneTest::TestShader, TestShaderTypeId, GafferScene::Shader );
 

--- a/include/GafferSceneUI/AttributeVisualiser.h
+++ b/include/GafferSceneUI/AttributeVisualiser.h
@@ -53,7 +53,7 @@ class AttributeVisualiser : public IECore::RefCounted
 	public :
 
 		IE_CORE_DECLAREMEMBERPTR( AttributeVisualiser )
-		virtual ~AttributeVisualiser();
+		~AttributeVisualiser() override;
 
 		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::CompoundObject *attributes,
 			IECoreGL::ConstStatePtr &state ) const = 0;

--- a/include/GafferSceneUI/CropWindowTool.h
+++ b/include/GafferSceneUI/CropWindowTool.h
@@ -56,7 +56,7 @@ class CropWindowTool : public GafferUI::Tool
 
 		CropWindowTool( SceneView *view, const std::string &name = defaultName<CropWindowTool>() );
 
-		virtual ~CropWindowTool();
+		~CropWindowTool() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::CropWindowTool, CropWindowToolTypeId, GafferUI::Tool );
 

--- a/include/GafferSceneUI/LightVisualiser.h
+++ b/include/GafferSceneUI/LightVisualiser.h
@@ -58,7 +58,7 @@ class LightVisualiser : public IECore::RefCounted
 		IE_CORE_DECLAREMEMBERPTR( LightVisualiser )
 
 		LightVisualiser();
-		virtual ~LightVisualiser();
+		~LightVisualiser() override;
 
 		/// Must be implemented by derived classes to visualise
 		/// the light contained within shaderVector.

--- a/include/GafferSceneUI/ObjectVisualiser.h
+++ b/include/GafferSceneUI/ObjectVisualiser.h
@@ -59,7 +59,7 @@ class ObjectVisualiser : public IECore::RefCounted
 
 		IE_CORE_DECLAREMEMBERPTR( ObjectVisualiser )
 
-		virtual ~ObjectVisualiser();
+		~ObjectVisualiser() override;
 
 		/// Must be implemented by derived classes to return a suitable
 		/// visualisation of the object.

--- a/include/GafferSceneUI/RotateTool.h
+++ b/include/GafferSceneUI/RotateTool.h
@@ -52,7 +52,7 @@ class RotateTool : public TransformTool
 	public :
 
 		RotateTool( SceneView *view, const std::string &name = defaultName<RotateTool>() );
-		virtual ~RotateTool();
+		~RotateTool() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::RotateTool, RotateToolTypeId, TransformTool );
 
@@ -66,8 +66,8 @@ class RotateTool : public TransformTool
 
 	protected :
 
-		virtual bool affectsHandles( const Gaffer::Plug *input ) const;
-		virtual void updateHandles();
+		bool affectsHandles( const Gaffer::Plug *input ) const override;
+		void updateHandles() override;
 
 	private :
 

--- a/include/GafferSceneUI/ScaleTool.h
+++ b/include/GafferSceneUI/ScaleTool.h
@@ -52,7 +52,7 @@ class ScaleTool : public TransformTool
 	public :
 
 		ScaleTool( SceneView *view, const std::string &name = defaultName<ScaleTool>() );
-		virtual ~ScaleTool();
+		~ScaleTool() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::ScaleTool, ScaleToolTypeId, TransformTool );
 
@@ -63,8 +63,8 @@ class ScaleTool : public TransformTool
 
 	protected :
 
-		virtual bool affectsHandles( const Gaffer::Plug *input ) const;
-		virtual void updateHandles();
+		bool affectsHandles( const Gaffer::Plug *input ) const override;
+		void updateHandles() override;
 
 	private :
 

--- a/include/GafferSceneUI/SceneGadget.h
+++ b/include/GafferSceneUI/SceneGadget.h
@@ -62,11 +62,11 @@ class SceneGadget : public GafferUI::Gadget
 	public :
 
 		SceneGadget();
-		virtual ~SceneGadget();
+		~SceneGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::SceneGadget, SceneGadgetTypeId, Gadget );
 
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 		void setScene( GafferScene::ConstScenePlugPtr scene );
 		const GafferScene::ScenePlug *getScene() const;
@@ -110,11 +110,11 @@ class SceneGadget : public GafferUI::Gadget
 		Imath::Box3f selectionBound() const;
 
 		/// Implemented to return the name of the object under the mouse.
-		virtual std::string getToolTip( const IECore::LineSegment3f &line ) const;
+		std::string getToolTip( const IECore::LineSegment3f &line ) const override;
 
 	protected :
 
-		virtual void doRender( const GafferUI::Style *style ) const;
+		void doRender( const GafferUI::Style *style ) const override;
 
 	private :
 

--- a/include/GafferSceneUI/SceneView.h
+++ b/include/GafferSceneUI/SceneView.h
@@ -70,7 +70,7 @@ class SceneView : public GafferUI::View
 	public :
 
 		SceneView( const std::string &name = defaultName<SceneView>() );
-		virtual ~SceneView();
+		~SceneView() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::SceneView, SceneViewTypeId, GafferUI::View );
 
@@ -90,7 +90,7 @@ class SceneView : public GafferUI::View
 		void expandSelection( size_t depth = 1 );
 		void collapseSelection();
 
-		virtual void setContext( Gaffer::ContextPtr context );
+		void setContext( Gaffer::ContextPtr context ) override;
 
 		/// If the view is locked to a particular camera,
 		/// this returns the bound of the resolution gate
@@ -107,8 +107,8 @@ class SceneView : public GafferUI::View
 
 	protected :
 
-		virtual void contextChanged( const IECore::InternedString &name );
-		virtual Imath::Box3f framingBound() const;
+		void contextChanged( const IECore::InternedString &name ) override;
+		Imath::Box3f framingBound() const override;
 
 	private :
 

--- a/include/GafferSceneUI/SelectionTool.h
+++ b/include/GafferSceneUI/SelectionTool.h
@@ -55,7 +55,7 @@ class SelectionTool : public GafferUI::Tool
 
 		SelectionTool( SceneView *view, const std::string &name = defaultName<SelectionTool>() );
 
-		virtual ~SelectionTool();
+		~SelectionTool() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::SelectionTool, SelectionToolTypeId, GafferUI::Tool );
 

--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -50,7 +50,7 @@ class ShaderView : public GafferImageUI::ImageView
 	public :
 
 		ShaderView( const std::string &name = defaultName<ShaderView>() );
-		virtual ~ShaderView();
+		~ShaderView() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::ShaderView, ShaderViewTypeId, GafferImageUI::ImageView );
 
@@ -67,7 +67,7 @@ class ShaderView : public GafferImageUI::ImageView
 		typedef boost::signal<void ( ShaderView * )> SceneChangedSignal;
 		SceneChangedSignal &sceneChangedSignal();
 
-		virtual void setContext( Gaffer::ContextPtr context );
+		void setContext( Gaffer::ContextPtr context ) override;
 
 		typedef boost::function<Gaffer::NodePtr ()> RendererCreator;
 		static void registerRenderer( const std::string &shaderPrefix, RendererCreator rendererCreator );

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -58,9 +58,9 @@ class StandardLightVisualiser : public LightVisualiser
 		IE_CORE_DECLAREMEMBERPTR( StandardLightVisualiser )
 
 		StandardLightVisualiser();
-		virtual ~StandardLightVisualiser();
+		~StandardLightVisualiser() override;
 
-		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, IECoreGL::ConstStatePtr &state ) const;
+		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, IECoreGL::ConstStatePtr &state ) const override;
 
 	protected :
 

--- a/include/GafferSceneUI/TransformTool.h
+++ b/include/GafferSceneUI/TransformTool.h
@@ -55,7 +55,7 @@ class TransformTool : public GafferSceneUI::SelectionTool
 
 	public :
 
-		virtual ~TransformTool();
+		~TransformTool() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::TransformTool, TransformToolTypeId, SelectionTool );
 

--- a/include/GafferSceneUI/TranslateTool.h
+++ b/include/GafferSceneUI/TranslateTool.h
@@ -53,7 +53,7 @@ class TranslateTool : public TransformTool
 	public :
 
 		TranslateTool( SceneView *view, const std::string &name = defaultName<TranslateTool>() );
-		virtual ~TranslateTool();
+		~TranslateTool() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::TranslateTool, TranslateToolTypeId, TransformTool );
 
@@ -68,8 +68,8 @@ class TranslateTool : public TransformTool
 
 	protected :
 
-		virtual bool affectsHandles( const Gaffer::Plug *input ) const;
-		virtual void updateHandles();
+		bool affectsHandles( const Gaffer::Plug *input ) const override;
+		void updateHandles() override;
 
 	private :
 

--- a/include/GafferTest/MultiplyNode.h
+++ b/include/GafferTest/MultiplyNode.h
@@ -51,7 +51,7 @@ class MultiplyNode : public Gaffer::ComputeNode
 	public :
 
 		MultiplyNode( const std::string &name=defaultName<MultiplyNode>() );
-		virtual ~MultiplyNode();
+		~MultiplyNode() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferTest::MultiplyNode, MultiplyNodeTypeId, Gaffer::ComputeNode );
 
@@ -64,12 +64,12 @@ class MultiplyNode : public Gaffer::ComputeNode
 		Gaffer::IntPlug *productPlug();
 		const Gaffer::IntPlug *productPlug() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferUI/BackdropNodeGadget.h
+++ b/include/GafferUI/BackdropNodeGadget.h
@@ -52,11 +52,11 @@ class BackdropNodeGadget : public NodeGadget
 	public :
 
 		BackdropNodeGadget( Gaffer::NodePtr node );
-		virtual ~BackdropNodeGadget();
+		~BackdropNodeGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::BackdropNodeGadget, BackdropNodeGadgetTypeId, NodeGadget );
 
-		virtual std::string getToolTip( const IECore::LineSegment3f &line ) const;
+		std::string getToolTip( const IECore::LineSegment3f &line ) const override;
 
 		/// Resizes the backdrop to frame the specified nodes.
 		/// \undoable
@@ -64,11 +64,11 @@ class BackdropNodeGadget : public NodeGadget
 		/// Fills nodes with all the nodes currently enclosed by the backdrop.
 		void framed( std::vector<Gaffer::Node *> &nodes ) const;
 
-		Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 	protected :
 
-		virtual void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/CompoundNodule.h
+++ b/include/GafferUI/CompoundNodule.h
@@ -54,11 +54,11 @@ class CompoundNodule : public Nodule
 	public :
 
 		CompoundNodule( Gaffer::PlugPtr plug );
-		virtual ~CompoundNodule();
+		~CompoundNodule() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::CompoundNodule, CompoundNoduleTypeId, Nodule );
 
-		virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
+		bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const override;
 
 		/// Returns a Nodule for a child of the plug being represented.
 		Nodule *nodule( const Gaffer::Plug *plug );

--- a/include/GafferUI/ConnectionGadget.h
+++ b/include/GafferUI/ConnectionGadget.h
@@ -64,12 +64,12 @@ class ConnectionGadget : public Gadget
 
 	public :
 
-		virtual ~ConnectionGadget();
+		~ConnectionGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::ConnectionGadget, ConnectionGadgetTypeId, Gadget );
 
 		/// Accepts only GraphGadgets as parent.
-		virtual bool acceptsParent( const Gaffer::GraphComponent *potentialParent ) const;
+		bool acceptsParent( const Gaffer::GraphComponent *potentialParent ) const override;
 
 		/// Returns the Nodule representing the source plug in the connection.
 		/// Note that this may be null if the source plug belongs to a node which

--- a/include/GafferUI/ContainerGadget.h
+++ b/include/GafferUI/ContainerGadget.h
@@ -56,7 +56,7 @@ class ContainerGadget : public Gadget
 	public :
 
 		ContainerGadget( const std::string &name=defaultName<ContainerGadget>() );
-		virtual ~ContainerGadget();
+		~ContainerGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::ContainerGadget, ContainerGadgetTypeId, Gadget );
 
@@ -69,7 +69,7 @@ class ContainerGadget : public Gadget
 
 		/// Applies the padding to the default union-of-children
 		/// bounding box.
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 	private :
 

--- a/include/GafferUI/DotNodeGadget.h
+++ b/include/GafferUI/DotNodeGadget.h
@@ -59,11 +59,11 @@ class DotNodeGadget : public StandardNodeGadget
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::DotNodeGadget, DotNodeGadgetTypeId, StandardNodeGadget );
 
 		DotNodeGadget( Gaffer::NodePtr node );
-		virtual ~DotNodeGadget();
+		~DotNodeGadget() override;
 
 	protected :
 
-		virtual void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/DragDropEvent.h
+++ b/include/GafferUI/DragDropEvent.h
@@ -55,7 +55,7 @@ struct DragDropEvent : public ButtonEvent
 		const IECore::LineSegment3f &Line=IECore::LineSegment3f(),
 		Modifiers m = ModifiableEvent::None
 	)
-		:	ButtonEvent( button, buttons, Line, 0, m ), sourceGadget( 0 ), data( 0 ), destinationGadget( 0 ), dropResult( false )
+		:	ButtonEvent( button, buttons, Line, 0, m ), sourceGadget( nullptr ), data( nullptr ), destinationGadget( nullptr ), dropResult( false )
 	{
 	};
 

--- a/include/GafferUI/Frame.h
+++ b/include/GafferUI/Frame.h
@@ -50,15 +50,15 @@ class Frame : public IndividualContainer
 	public :
 
 		Frame( GadgetPtr child );
-		virtual ~Frame();
+		~Frame() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::Frame, FrameTypeId, IndividualContainer );
 
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 	protected :
 
-		virtual void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -158,7 +158,7 @@ class Gadget : public Gaffer::GraphComponent
 		/// Returns the full transform of this Gadget relative to the
 		/// specified ancestor. If ancestor is not specified then the
 		/// transform from the root of the hierarchy is returned.
-		Imath::M44f fullTransform( const Gadget *ancestor = 0 ) const;
+		Imath::M44f fullTransform( const Gadget *ancestor = nullptr ) const;
 		//@}
 
 		/// @name Display
@@ -170,7 +170,7 @@ class Gadget : public Gaffer::GraphComponent
 		/// specifically to this Gadget. Typically users will not pass currentStyle -
 		/// but it must be passed by Gadget implementations when rendering child
 		/// Gadgets in doRender().
-		void render( const Style *currentStyle = 0 ) const;
+		void render( const Style *currentStyle = nullptr ) const;
 		/// The bounding box of the Gadget before transformation. The default
 		/// implementation returns the union of the transformed bounding boxes
 		/// of all the children.

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -75,7 +75,7 @@ class Gadget : public Gaffer::GraphComponent
 	public :
 
 		Gadget( const std::string &name=defaultName<Gadget>() );
-		virtual ~Gadget();
+		~Gadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::Gadget, GadgetTypeId, Gaffer::GraphComponent );
 
@@ -89,9 +89,9 @@ class Gadget : public Gaffer::GraphComponent
 		//@{
 		/// Gadgets accept any number of other Gadgets as children. Derived classes
 		/// may further restrict this if they wish, but they must not accept non-Gadget children.
-		virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
+		bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const override;
 		/// Gadgets only accept other Gadgets as parent.
-		virtual bool acceptsParent( const Gaffer::GraphComponent *potentialParent ) const;
+		bool acceptsParent( const Gaffer::GraphComponent *potentialParent ) const override;
 		//@}
 
 		/// @name Style

--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -69,7 +69,7 @@ class GraphGadget : public ContainerGadget
 		/// they are both a child of root and a member of filter.
 		GraphGadget( Gaffer::NodePtr root, Gaffer::SetPtr filter = nullptr );
 
-		virtual ~GraphGadget();
+		~GraphGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::GraphGadget, GraphGadgetTypeId, ContainerGadget );
 
@@ -173,7 +173,7 @@ class GraphGadget : public ContainerGadget
 
 	protected :
 
-		void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/GraphLayout.h
+++ b/include/GafferUI/GraphLayout.h
@@ -69,7 +69,7 @@ class GraphLayout : public IECore::RunTimeTyped
 
 	public :
 
-		virtual ~GraphLayout();
+		~GraphLayout() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::GraphLayout, GraphLayoutTypeId, IECore::RunTimeTyped );
 

--- a/include/GafferUI/Handle.h
+++ b/include/GafferUI/Handle.h
@@ -49,7 +49,7 @@ class Handle : public Gadget
 
 	public :
 
-		virtual ~Handle();
+		~Handle() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::Handle, HandleTypeId, Gadget );
 
@@ -58,7 +58,7 @@ class Handle : public Gadget
 		void setRasterScale( float rasterScale );
 		float getRasterScale() const;
 
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 	protected :
 
@@ -66,7 +66,7 @@ class Handle : public Gadget
 
 		// Implemented to call renderHandle() after applying
 		// the raster scale.
-		virtual void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 		// Must be implemented by derived classes to draw their
 		// handle.

--- a/include/GafferUI/ImageGadget.h
+++ b/include/GafferUI/ImageGadget.h
@@ -65,11 +65,11 @@ class ImageGadget : public Gadget
 		ImageGadget( const std::string &fileName );
 		/// A copy of the image is taken.
 		ImageGadget( const IECore::ConstImagePrimitivePtr image );
-		virtual ~ImageGadget();
+		~ImageGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::ImageGadget, ImageGadgetTypeId, Gadget );
 
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 		/// Returns the texture loader used for converting images
 		/// on disk into textures for rendering. This is exposed
@@ -79,7 +79,7 @@ class ImageGadget : public Gadget
 
 	protected :
 
-		virtual void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/IndividualContainer.h
+++ b/include/GafferUI/IndividualContainer.h
@@ -51,12 +51,12 @@ class IndividualContainer : public ContainerGadget
 	public :
 
 		IndividualContainer( GadgetPtr child=0 );
-		virtual ~IndividualContainer();
+		~IndividualContainer() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::IndividualContainer, IndividualContainerTypeId, ContainerGadget );
 
 		/// Accepts the child only if there are currently no children.
-		virtual bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const;
+		bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const override;
 
 		/// Removes the current child if there is one, and replaces it
 		/// with the specified gadget.

--- a/include/GafferUI/IndividualContainer.h
+++ b/include/GafferUI/IndividualContainer.h
@@ -50,7 +50,7 @@ class IndividualContainer : public ContainerGadget
 
 	public :
 
-		IndividualContainer( GadgetPtr child=0 );
+		IndividualContainer( GadgetPtr child=nullptr );
 		~IndividualContainer() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::IndividualContainer, IndividualContainerTypeId, ContainerGadget );

--- a/include/GafferUI/IndividualContainer.inl
+++ b/include/GafferUI/IndividualContainer.inl
@@ -48,7 +48,7 @@ T *IndividualContainer::getChild()
 {
 	if( !children().size() )
 	{
-		return 0;
+		return nullptr;
 	}
 	return Gaffer::GraphComponent::getChild<T>( 0 );
 }
@@ -58,7 +58,7 @@ const T *IndividualContainer::getChild() const
 {
 	if( !children().size() )
 	{
-		return 0;
+		return nullptr;
 	}
 	return Gaffer::GraphComponent::getChild<T>( 0 );
 }

--- a/include/GafferUI/LinearContainer.h
+++ b/include/GafferUI/LinearContainer.h
@@ -74,7 +74,7 @@ class LinearContainer : public ContainerGadget
 		LinearContainer( const std::string &name=defaultName<LinearContainer>(), Orientation orientation=X,
 			Alignment alignment=Centre, float spacing = 0.0f, Direction=Increasing );
 
-		virtual ~LinearContainer();
+		~LinearContainer() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::LinearContainer, LinearContainerTypeId, ContainerGadget );
 
@@ -90,11 +90,11 @@ class LinearContainer : public ContainerGadget
 		void setDirection( Direction direction );
 		Direction getDirection() const;
 
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 	protected :
 
-		virtual void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/NameGadget.h
+++ b/include/GafferUI/NameGadget.h
@@ -50,7 +50,7 @@ class NameGadget : public TextGadget
 	public :
 
 		NameGadget( Gaffer::GraphComponentPtr object );
-		virtual ~NameGadget();
+		~NameGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::NameGadget, NameGadgetTypeId, TextGadget );
 

--- a/include/GafferUI/NodeGadget.h
+++ b/include/GafferUI/NodeGadget.h
@@ -54,7 +54,7 @@ class NodeGadget : public Gadget
 
 	public :
 
-		virtual ~NodeGadget();
+		~NodeGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::NodeGadget, NodeGadgetTypeId, Gadget );
 
@@ -97,7 +97,7 @@ class NodeGadget : public Gadget
 		/// \deprecated Use the function above, or register "nodeGadget:type" metadata instead.
 		static void registerNodeGadget( IECore::TypeId nodeType, NodeGadgetCreator creator );
 
-		virtual std::string getToolTip( const IECore::LineSegment3f &line ) const;
+		std::string getToolTip( const IECore::LineSegment3f &line ) const override;
 
 	protected :
 

--- a/include/GafferUI/Nodule.h
+++ b/include/GafferUI/Nodule.h
@@ -60,7 +60,7 @@ class Nodule : public Gadget
 	public :
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::Nodule, NoduleTypeId, Gadget );
-		virtual ~Nodule();
+		~Nodule() override;
 
 		Gaffer::Plug *plug();
 		const Gaffer::Plug *plug() const;
@@ -80,7 +80,7 @@ class Nodule : public Gadget
 		/// nodule type for a particular type of plug.
 		static void registerNodule( const std::string &noduleTypeName, NoduleCreator creator, IECore::TypeId plugType = IECore::InvalidTypeId );
 
-		virtual std::string getToolTip( const IECore::LineSegment3f &line ) const;
+		std::string getToolTip( const IECore::LineSegment3f &line ) const override;
 
 	protected :
 

--- a/include/GafferUI/NoduleLayout.h
+++ b/include/GafferUI/NoduleLayout.h
@@ -80,7 +80,7 @@ class NoduleLayout : public Gadget
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::NoduleLayout, NoduleLayoutTypeId, Gadget );
 
 		NoduleLayout( Gaffer::GraphComponentPtr parent, IECore::InternedString section = IECore::InternedString() );
-		virtual ~NoduleLayout();
+		~NoduleLayout() override;
 
 		/// \todo These do not need to be virtual, since this is
 		/// not intended to be used as a base class.

--- a/include/GafferUI/PlugAdder.h
+++ b/include/GafferUI/PlugAdder.h
@@ -50,9 +50,9 @@ class PlugAdder : public Gadget
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::PlugAdder, PlugAdderTypeId, Gadget );
 
 		PlugAdder( StandardNodeGadget::Edge edge );
-		virtual ~PlugAdder();
+		~PlugAdder() override;
 
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 		void updateDragEndPoint( const Imath::V3f position, const Imath::V3f &tangent );
 
@@ -71,7 +71,7 @@ class PlugAdder : public Gadget
 
 	protected :
 
-		virtual void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 		void applyEdgeMetadata( Gaffer::Plug *plug, bool opposite = false ) const;
 

--- a/include/GafferUI/PlugGadget.h
+++ b/include/GafferUI/PlugGadget.h
@@ -60,7 +60,7 @@ class PlugGadget : public ContainerGadget
 	public :
 
 		PlugGadget( Gaffer::PlugPtr plug );
-		virtual ~PlugGadget();
+		~PlugGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::PlugGadget, PlugGadgetTypeId, Gadget );
 

--- a/include/GafferUI/RenderableGadget.h
+++ b/include/GafferUI/RenderableGadget.h
@@ -63,7 +63,7 @@ class RenderableGadget : public Gadget
 
 	public :
 
-		RenderableGadget( IECore::VisibleRenderablePtr renderable = 0 );
+		RenderableGadget( IECore::VisibleRenderablePtr renderable = nullptr );
 		~RenderableGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::RenderableGadget, RenderableGadgetTypeId, Gadget );
@@ -130,7 +130,7 @@ class RenderableGadget : public Gadget
 		bool dragMove( GadgetPtr gadget, const DragDropEvent &event );
 		bool dragEnd( GadgetPtr gadget, const DragDropEvent &event );
 
-		void applySelection( IECoreGL::Group *group = 0 );
+		void applySelection( IECoreGL::Group *group = nullptr );
 		Imath::Box3f selectionBound( IECoreGL::Group *group ) const;
 
 		IECore::ConstVisibleRenderablePtr m_renderable;

--- a/include/GafferUI/RenderableGadget.h
+++ b/include/GafferUI/RenderableGadget.h
@@ -64,11 +64,11 @@ class RenderableGadget : public Gadget
 	public :
 
 		RenderableGadget( IECore::VisibleRenderablePtr renderable = 0 );
-		virtual ~RenderableGadget();
+		~RenderableGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::RenderableGadget, RenderableGadgetTypeId, Gadget );
 
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 		void setRenderable( IECore::ConstVisibleRenderablePtr renderable );
 		IECore::ConstVisibleRenderablePtr getRenderable() const;
@@ -116,11 +116,11 @@ class RenderableGadget : public Gadget
 
 		/// Implemented to return the name of the object under the mouse as
 		/// a tooltip.
-		virtual std::string getToolTip( const IECore::LineSegment3f &line ) const;
+		std::string getToolTip( const IECore::LineSegment3f &line ) const override;
 
 	protected :
 
-		virtual void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/RotateHandle.h
+++ b/include/GafferUI/RotateHandle.h
@@ -48,7 +48,7 @@ class RotateHandle : public Handle
 	public :
 
 		RotateHandle( Style::Axes axes );
-		virtual ~RotateHandle();
+		~RotateHandle() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::RotateHandle, RotateHandleTypeId, Handle );
 
@@ -60,8 +60,8 @@ class RotateHandle : public Handle
 
 	protected :
 
-		virtual void renderHandle( const Style *style, Style::State state ) const;
-		virtual void dragBegin( const DragDropEvent &event );
+		void renderHandle( const Style *style, Style::State state ) const override;
+		void dragBegin( const DragDropEvent &event ) override;
 
 	private :
 

--- a/include/GafferUI/ScaleHandle.h
+++ b/include/GafferUI/ScaleHandle.h
@@ -49,7 +49,7 @@ class ScaleHandle : public Handle
 	public :
 
 		ScaleHandle( Style::Axes axes );
-		virtual ~ScaleHandle();
+		~ScaleHandle() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::ScaleHandle, ScaleHandleTypeId, Handle );
 
@@ -60,8 +60,8 @@ class ScaleHandle : public Handle
 
 	protected :
 
-		virtual void renderHandle( const Style *style, Style::State state ) const;
-		virtual void dragBegin( const DragDropEvent &event );
+		void renderHandle( const Style *style, Style::State state ) const override;
+		void dragBegin( const DragDropEvent &event ) override;
 
 	private :
 

--- a/include/GafferUI/SpacerGadget.h
+++ b/include/GafferUI/SpacerGadget.h
@@ -48,21 +48,21 @@ class SpacerGadget : public Gadget
 	public :
 
 		SpacerGadget( const Imath::Box3f &size );
-		virtual ~SpacerGadget();
+		~SpacerGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::SpacerGadget, SpacerGadgetTypeId, Gadget );
 
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 		const Imath::Box3f &getSize() const;
 		void setSize( const Imath::Box3f &size );
 
 		/// Rejects all children.
-		virtual bool acceptsChild( const GraphComponent *potentialChild ) const;
+		bool acceptsChild( const GraphComponent *potentialChild ) const override;
 
 	protected :
 
-		virtual void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/SplinePlugGadget.h
+++ b/include/GafferUI/SplinePlugGadget.h
@@ -53,7 +53,7 @@ class SplinePlugGadget : public Gadget
 	public :
 
 		SplinePlugGadget( const std::string &name=defaultName<SplinePlugGadget>() );
-		virtual ~SplinePlugGadget();
+		~SplinePlugGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::SplinePlugGadget, SplinePlugGadgetTypeId, Gadget );
 
@@ -65,11 +65,11 @@ class SplinePlugGadget : public Gadget
 		Gaffer::StandardSetPtr selection();
 		Gaffer::ConstStandardSetPtr selection() const;
 
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 	protected :
 
-		virtual void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/StandardConnectionGadget.h
+++ b/include/GafferUI/StandardConnectionGadget.h
@@ -53,23 +53,23 @@ class StandardConnectionGadget : public ConnectionGadget
 	public :
 
 		StandardConnectionGadget( GafferUI::NodulePtr srcNodule, GafferUI::NodulePtr dstNodule );
-		virtual ~StandardConnectionGadget();
+		~StandardConnectionGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::StandardConnectionGadget, StandardConnectionGadgetTypeId, ConnectionGadget );
 
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
-		virtual void setNodules( GafferUI::NodulePtr srcNodule, GafferUI::NodulePtr dstNodule );
+		void setNodules( GafferUI::NodulePtr srcNodule, GafferUI::NodulePtr dstNodule ) override;
 
-		virtual void updateDragEndPoint( const Imath::V3f position, const Imath::V3f &tangent );
+		void updateDragEndPoint( const Imath::V3f position, const Imath::V3f &tangent ) override;
 
-		virtual Imath::V3f closestPoint( const Imath::V3f &p ) const;
+		Imath::V3f closestPoint( const Imath::V3f &p ) const override;
 
-		virtual std::string getToolTip( const IECore::LineSegment3f &line ) const;
+		std::string getToolTip( const IECore::LineSegment3f &line ) const override;
 
 	protected :
 
-		void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/StandardGraphLayout.h
+++ b/include/GafferUI/StandardGraphLayout.h
@@ -59,17 +59,17 @@ class StandardGraphLayout : public GraphLayout
 	public :
 
 		StandardGraphLayout();
-		virtual ~StandardGraphLayout();
+		~StandardGraphLayout() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::StandardGraphLayout, StandardGraphLayoutTypeId, GraphLayout );
 
-		virtual bool connectNode( GraphGadget *graph, Gaffer::Node *node, Gaffer::Set *potentialInputs ) const;
-		virtual bool connectNodes( GraphGadget *graph, Gaffer::Set *nodes, Gaffer::Set *potentialInputs ) const;
+		bool connectNode( GraphGadget *graph, Gaffer::Node *node, Gaffer::Set *potentialInputs ) const override;
+		bool connectNodes( GraphGadget *graph, Gaffer::Set *nodes, Gaffer::Set *potentialInputs ) const override;
 
-		virtual void positionNode( GraphGadget *graph, Gaffer::Node *node, const Imath::V2f &fallbackPosition = Imath::V2f( 0 ) ) const;
-		virtual void positionNodes( GraphGadget *graph, Gaffer::Set *nodes, const Imath::V2f &fallbackPosition = Imath::V2f( 0 ) ) const;
+		void positionNode( GraphGadget *graph, Gaffer::Node *node, const Imath::V2f &fallbackPosition = Imath::V2f( 0 ) ) const override;
+		void positionNodes( GraphGadget *graph, Gaffer::Set *nodes, const Imath::V2f &fallbackPosition = Imath::V2f( 0 ) ) const override;
 
-		virtual void layoutNodes( GraphGadget *graph, Gaffer::Set *nodes ) const;
+		void layoutNodes( GraphGadget *graph, Gaffer::Set *nodes ) const override;
 
 		/// @name Layout algorithm parameters
 		////////////////////////////////////////////////////////////////////

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -79,11 +79,11 @@ class StandardNodeGadget : public NodeGadget
 		};
 
 		StandardNodeGadget( Gaffer::NodePtr node );
-		virtual ~StandardNodeGadget();
+		~StandardNodeGadget() override;
 
-		virtual Nodule *nodule( const Gaffer::Plug *plug );
-		virtual const Nodule *nodule( const Gaffer::Plug *plug ) const;
-		virtual Imath::V3f noduleTangent( const Nodule *nodule ) const;
+		Nodule *nodule( const Gaffer::Plug *plug ) override;
+		const Nodule *nodule( const Gaffer::Plug *plug ) const override;
+		Imath::V3f noduleTangent( const Nodule *nodule ) const override;
 
 		/// The central content of the Gadget may be customised. By default
 		/// the contents is a simple NameGadget for the node, but any Gadget or
@@ -100,11 +100,11 @@ class StandardNodeGadget : public NodeGadget
 		void setLabelsVisibleOnHover( bool labelsVisible );
 		bool getLabelsVisibleOnHover() const;
 
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 	protected :
 
-		virtual void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 		const Imath::Color3f *userColor() const;
 

--- a/include/GafferUI/StandardNodule.h
+++ b/include/GafferUI/StandardNodule.h
@@ -56,20 +56,20 @@ class StandardNodule : public Nodule
 	public :
 
 		StandardNodule( Gaffer::PlugPtr plug );
-		virtual ~StandardNodule();
+		~StandardNodule() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::StandardNodule, StandardNoduleTypeId, Nodule );
 
 		void setLabelVisible( bool labelVisible );
 		bool getLabelVisible() const;
 
-		virtual void updateDragEndPoint( const Imath::V3f position, const Imath::V3f &tangent );
+		void updateDragEndPoint( const Imath::V3f position, const Imath::V3f &tangent ) override;
 
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 	protected :
 
-		void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 		void renderLabel( const Style *style ) const;
 
 		void enter( GadgetPtr gadget, const ButtonEvent &event );

--- a/include/GafferUI/StandardStyle.h
+++ b/include/GafferUI/StandardStyle.h
@@ -66,7 +66,7 @@ class StandardStyle : public Style
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::StandardStyle, StandardStyleTypeId, Style );
 
-		void bind( const Style *currentStyle=0 ) const override;
+		void bind( const Style *currentStyle=nullptr ) const override;
 
 		void renderImage( const Imath::Box2f &box, const IECoreGL::Texture *texture ) const override;
 		void renderLine( const IECore::LineSegment3f &line ) const override;

--- a/include/GafferUI/StandardStyle.h
+++ b/include/GafferUI/StandardStyle.h
@@ -62,36 +62,36 @@ class StandardStyle : public Style
 	public :
 
 		StandardStyle();
-		virtual ~StandardStyle();
+		~StandardStyle() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::StandardStyle, StandardStyleTypeId, Style );
 
-		virtual void bind( const Style *currentStyle=0 ) const;
+		void bind( const Style *currentStyle=0 ) const override;
 
-		virtual void renderImage( const Imath::Box2f &box, const IECoreGL::Texture *texture ) const;
-		virtual void renderLine( const IECore::LineSegment3f &line ) const;
-		virtual void renderSolidRectangle( const Imath::Box2f &box ) const;
-		virtual void renderRectangle( const Imath::Box2f &box ) const;
+		void renderImage( const Imath::Box2f &box, const IECoreGL::Texture *texture ) const override;
+		void renderLine( const IECore::LineSegment3f &line ) const override;
+		void renderSolidRectangle( const Imath::Box2f &box ) const override;
+		void renderRectangle( const Imath::Box2f &box ) const override;
 
-		virtual Imath::Box3f characterBound( TextType textType ) const;
-		virtual Imath::Box3f textBound( TextType type, const std::string &text ) const;
-		virtual void renderText( TextType type, const std::string &text, State state = NormalState ) const;
-		virtual void renderWrappedText( TextType textType, const std::string &text, const Imath::Box2f &bound, State state = NormalState ) const;
+		Imath::Box3f characterBound( TextType textType ) const override;
+		Imath::Box3f textBound( TextType type, const std::string &text ) const override;
+		void renderText( TextType type, const std::string &text, State state = NormalState ) const override;
+		void renderWrappedText( TextType textType, const std::string &text, const Imath::Box2f &bound, State state = NormalState ) const override;
 
-		virtual void renderFrame( const Imath::Box2f &frame, float borderWidth, State state = NormalState ) const;
-		virtual void renderSelectionBox( const Imath::Box2f &box ) const;
-		virtual void renderHorizontalRule( const Imath::V2f &center, float length, State state = NormalState ) const;
+		void renderFrame( const Imath::Box2f &frame, float borderWidth, State state = NormalState ) const override;
+		void renderSelectionBox( const Imath::Box2f &box ) const override;
+		void renderHorizontalRule( const Imath::V2f &center, float length, State state = NormalState ) const override;
 
-		virtual void renderNodeFrame( const Imath::Box2f &contents, float borderWidth, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const;
-		virtual void renderNodule( float radius, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const;
-		virtual void renderConnection( const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const;
-		virtual Imath::V3f closestPointOnConnection( const Imath::V3f &p, const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent ) const;
+		void renderNodeFrame( const Imath::Box2f &contents, float borderWidth, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const override;
+		void renderNodule( float radius, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const override;
+		void renderConnection( const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const override;
+		Imath::V3f closestPointOnConnection( const Imath::V3f &p, const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent ) const override;
 
-		virtual void renderBackdrop( const Imath::Box2f &box, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const;
+		void renderBackdrop( const Imath::Box2f &box, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const override;
 
-		virtual void renderTranslateHandle( Axes axes, State state = NormalState ) const;
-		virtual void renderRotateHandle( Axes axes, State state = NormalState ) const;
-		virtual void renderScaleHandle( Axes axes, State state = NormalState ) const;
+		void renderTranslateHandle( Axes axes, State state = NormalState ) const override;
+		void renderRotateHandle( Axes axes, State state = NormalState ) const override;
+		void renderScaleHandle( Axes axes, State state = NormalState ) const override;
 
 		enum Color
 		{

--- a/include/GafferUI/Style.h
+++ b/include/GafferUI/Style.h
@@ -66,7 +66,7 @@ class Style : public IECore::RunTimeTyped
 	public :
 
 		Style();
-		virtual ~Style();
+		~Style() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::Style, StyleTypeId, IECore::RunTimeTyped );
 

--- a/include/GafferUI/Style.h
+++ b/include/GafferUI/Style.h
@@ -80,7 +80,7 @@ class Style : public IECore::RunTimeTyped
 		/// Must be called once to allow the Style to set up any necessary state before calling
 		/// any of the render* methods below. The currently bound style is passed as it may
 		/// be possible to use it to optimise the binding of a new style of the same type.
-		virtual void bind( const Style *currentStyle=0 ) const = 0;
+		virtual void bind( const Style *currentStyle=nullptr ) const = 0;
 
 		enum TextType
 		{

--- a/include/GafferUI/TextGadget.h
+++ b/include/GafferUI/TextGadget.h
@@ -51,18 +51,18 @@ class TextGadget : public Gadget
 	public :
 
 		TextGadget( const std::string &text );
-		virtual ~TextGadget();
+		~TextGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::TextGadget, TextGadgetTypeId, Gadget );
 
 		const std::string &getText() const;
 		void setText( const std::string &text );
 
-		virtual Imath::Box3f bound() const;
+		Imath::Box3f bound() const override;
 
 	protected :
 
-		virtual void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/Tool.h
+++ b/include/GafferUI/Tool.h
@@ -73,7 +73,7 @@ class Tool : public Gaffer::Node
 
 	public :
 
-		virtual ~Tool();
+		~Tool() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::Tool, ToolTypeId, Gaffer::Node );
 

--- a/include/GafferUI/TranslateHandle.h
+++ b/include/GafferUI/TranslateHandle.h
@@ -49,7 +49,7 @@ class TranslateHandle : public Handle
 	public :
 
 		TranslateHandle( Style::Axes axes );
-		virtual ~TranslateHandle();
+		~TranslateHandle() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::TranslateHandle, TranslateHandleTypeId, Handle );
 
@@ -66,8 +66,8 @@ class TranslateHandle : public Handle
 
 	protected :
 
-		virtual void renderHandle( const Style *style, Style::State state ) const;
-		virtual void dragBegin( const DragDropEvent &event );
+		void renderHandle( const Style *style, Style::State state ) const override;
+		void dragBegin( const DragDropEvent &event ) override;
 
 	private :
 

--- a/include/GafferUI/View.h
+++ b/include/GafferUI/View.h
@@ -65,7 +65,7 @@ class View : public Gaffer::Node
 
 	public :
 
-		virtual ~View();
+		~View() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::View, ViewTypeId, Gaffer::Node );
 

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -62,13 +62,13 @@ class ViewportGadget : public Gadget
 		typedef boost::signal<void (ViewportGadget *)> UnarySignal;
 
 		ViewportGadget( GadgetPtr primaryChild = nullptr );
-		virtual ~ViewportGadget();
+		~ViewportGadget() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::ViewportGadget, ViewportGadgetTypeId, Gadget );
 
 		/// Accepts no parents - the ViewportGadget must always be the topmost Gadget.
-		virtual bool acceptsParent( const Gaffer::GraphComponent *potentialParent ) const;
-		virtual std::string getToolTip( const IECore::LineSegment3f &position ) const;
+		bool acceptsParent( const Gaffer::GraphComponent *potentialParent ) const override;
+		std::string getToolTip( const IECore::LineSegment3f &position ) const override;
 
 		/// Typically mouse event signals are emitted for the gadget under
 		/// the mouse, but in the case that there is no such gadget, they
@@ -184,7 +184,7 @@ class ViewportGadget : public Gadget
 
 	protected :
 
-		virtual void doRender( const Style *style ) const;
+		void doRender( const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUIBindings/GadgetBinding.h
+++ b/include/GafferUIBindings/GadgetBinding.h
@@ -51,7 +51,7 @@ class GadgetClass : public GafferBindings::GraphComponentClass<T, TWrapper>
 {
 	public :
 
-		GadgetClass( const char *docString = 0 );
+		GadgetClass( const char *docString = nullptr );
 
 };
 

--- a/include/GafferUIBindings/GadgetBinding.h
+++ b/include/GafferUIBindings/GadgetBinding.h
@@ -77,7 +77,7 @@ class GadgetWrapper : public GafferBindings::GraphComponentWrapper<WrappedType>
 		{
 		}
 
-		virtual void setHighlighted( bool highlighted )
+		void setHighlighted( bool highlighted ) override
 		{
 			if( this->isSubclassed() )
 			{
@@ -92,7 +92,7 @@ class GadgetWrapper : public GafferBindings::GraphComponentWrapper<WrappedType>
 			WrappedType::setHighlighted( highlighted );
 		}
 
-		virtual Imath::Box3f bound() const
+		Imath::Box3f bound() const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -106,7 +106,7 @@ class GadgetWrapper : public GafferBindings::GraphComponentWrapper<WrappedType>
 			return WrappedType::bound();
 		}
 
-		virtual std::string getToolTip( const IECore::LineSegment3f &line ) const
+		std::string getToolTip( const IECore::LineSegment3f &line ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -120,7 +120,7 @@ class GadgetWrapper : public GafferBindings::GraphComponentWrapper<WrappedType>
 			return WrappedType::getToolTip( line );
 		}
 
-		virtual void doRender( const GafferUI::Style *style ) const
+		void doRender( const GafferUI::Style *style ) const override
 		{
 			if( this->isSubclassed() )
 			{

--- a/include/GafferUIBindings/NodeGadgetBinding.h
+++ b/include/GafferUIBindings/NodeGadgetBinding.h
@@ -50,7 +50,7 @@ class NodeGadgetClass : public GadgetClass<T, TWrapper>
 {
 	public :
 
-		NodeGadgetClass( const char *docString = 0 );
+		NodeGadgetClass( const char *docString = nullptr );
 
 };
 

--- a/include/GafferUIBindings/NodeGadgetBinding.h
+++ b/include/GafferUIBindings/NodeGadgetBinding.h
@@ -72,7 +72,7 @@ class NodeGadgetWrapper : public GadgetWrapper<WrappedType>
 		{
 		}
 
-		virtual GafferUI::Nodule *nodule( const Gaffer::Plug *plug )
+		GafferUI::Nodule *nodule( const Gaffer::Plug *plug ) override
 		{
 			if( this->isSubclassed() )
 			{
@@ -88,13 +88,13 @@ class NodeGadgetWrapper : public GadgetWrapper<WrappedType>
 			return WrappedType::nodule( plug );
 		}
 
-		virtual const GafferUI::Nodule *nodule( const Gaffer::Plug *plug ) const
+		const GafferUI::Nodule *nodule( const Gaffer::Plug *plug ) const override
 		{
 			// naughty cast is better than repeating the above logic.
 			return const_cast<NodeGadgetWrapper *>( this )->nodule( plug );
 		}
 
-		virtual Imath::V3f noduleTangent( const GafferUI::Nodule *nodule ) const
+		Imath::V3f noduleTangent( const GafferUI::Nodule *nodule ) const override
 		{
 			if( this->isSubclassed() )
 			{

--- a/src/Gaffer/Action.cpp
+++ b/src/Gaffer/Action.cpp
@@ -130,7 +130,7 @@ class SimpleAction : public Action
 			}
 		}
 
-		virtual ~SimpleAction()
+		~SimpleAction() override
 		{
 			if( !m_subject->isInstanceOf( Gaffer::ScriptNode::staticTypeId() ) )
 			{
@@ -142,12 +142,12 @@ class SimpleAction : public Action
 
 	protected :
 
-		virtual GraphComponent *subject() const
+		GraphComponent *subject() const override
 		{
 			return m_subject;
 		}
 
-		void doAction()
+		void doAction() override
 		{
 			Action::doAction();
 			if( !m_doFn.empty() )
@@ -156,7 +156,7 @@ class SimpleAction : public Action
 			}
 		}
 
-		void undoAction()
+		void undoAction() override
 		{
 			Action::undoAction();
 			if( !m_undoFn.empty() )
@@ -165,12 +165,12 @@ class SimpleAction : public Action
 			}
 		}
 
-		bool canMerge( const Action *other ) const
+		bool canMerge( const Action *other ) const override
 		{
 			return false;
 		}
 
-		void merge( const Action *other )
+		void merge( const Action *other ) override
 		{
 		}
 

--- a/src/Gaffer/BlockedConnection.cpp
+++ b/src/Gaffer/BlockedConnection.cpp
@@ -39,7 +39,7 @@
 using namespace Gaffer;
 
 BlockedConnection::BlockedConnection( boost::signals::connection &connection, bool block )
-	:	m_connection( 0 )
+	:	m_connection( nullptr )
 {
 	if( block && connection.connected() )
 	{

--- a/src/Gaffer/CompoundDataPlug.cpp
+++ b/src/Gaffer/CompoundDataPlug.cpp
@@ -267,7 +267,7 @@ IECore::DataPtr CompoundDataPlug::memberDataAndName( const MemberPlug *parameter
 	{
 		if( !parameterPlug->getChild<BoolPlug>( 2 )->getValue() )
 		{
-			return 0;
+			return nullptr;
 		}
 	}
 
@@ -276,13 +276,13 @@ IECore::DataPtr CompoundDataPlug::memberDataAndName( const MemberPlug *parameter
 		// we can end up here either if someone has very naughtily deleted
 		// some plugs, or if we're being called during loading and the
 		// child plugs haven't been fully constructed.
-		return 0;
+		return nullptr;
 	}
 
 	name = parameterPlug->getChild<StringPlug>( 0 )->getValue();
 	if( !name.size() )
 	{
-		return 0;
+		return nullptr;
 	}
 
 	const ValuePlug *valuePlug = parameterPlug->getChild<ValuePlug>( 1 );

--- a/src/Gaffer/CompoundNumericPlug.cpp
+++ b/src/Gaffer/CompoundNumericPlug.cpp
@@ -253,7 +253,7 @@ void CompoundNumericPlug<T>::ungang()
 		{
 			if( input->parent<Plug>() == this )
 			{
-				child->setInput( 0 );
+				child->setInput( nullptr );
 			}
 		}
 	}

--- a/src/Gaffer/DependencyNode.cpp
+++ b/src/Gaffer/DependencyNode.cpp
@@ -61,20 +61,20 @@ void DependencyNode::affects( const Plug *input, AffectedPlugsContainer &outputs
 
 BoolPlug *DependencyNode::enabledPlug()
 {
-	return 0;
+	return nullptr;
 }
 
 const BoolPlug *DependencyNode::enabledPlug() const
 {
-	return 0;
+	return nullptr;
 }
 
 Plug *DependencyNode::correspondingInput( const Plug *output )
 {
-	return 0;
+	return nullptr;
 }
 
 const Plug *DependencyNode::correspondingInput( const Plug *output ) const
 {
-	return 0;
+	return nullptr;
 }

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -303,7 +303,7 @@ void Expression::hash( const ValuePlug *output, const Context *context, IECore::
 
 		for( std::vector<IECore::InternedString>::const_iterator it = m_contextNames.begin(); it != m_contextNames.end(); it++ )
 		{
-			const IECore::Data *d = context->get<IECore::Data>( *it, 0 );
+			const IECore::Data *d = context->get<IECore::Data>( *it, nullptr );
 			if( d )
 			{
 				d->hash( h );

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -96,7 +96,7 @@ class ScopedAssignment : boost::noncopyable
 IE_CORE_DEFINERUNTIMETYPED( Plug );
 
 Plug::Plug( const std::string &name, Direction direction, unsigned flags )
-	:	GraphComponent( name ), m_direction( direction ), m_input( 0 ), m_flags( None ), m_skipNextUpdateInputFromChildInputs( false )
+	:	GraphComponent( name ), m_direction( direction ), m_input( nullptr ), m_flags( None ), m_skipNextUpdateInputFromChildInputs( false )
 {
 	setFlags( flags );
 	parentChangedSignal().connect( boost::bind( &Plug::parentChanged, this ) );
@@ -104,13 +104,13 @@ Plug::Plug( const std::string &name, Direction direction, unsigned flags )
 
 Plug::~Plug()
 {
-	setInputInternal( 0, false );
+	setInputInternal( nullptr, false );
 	for( OutputContainer::iterator it=m_outputs.begin(); it!=m_outputs.end(); )
 	{
 	 	// get the next iterator now, as the call to setInputInternal invalidates
 		// the current iterator.
 		OutputContainer::iterator next = it; next++;
-		(*it)->setInputInternal( 0, true );
+		(*it)->setInputInternal( nullptr, true );
 		it = next;
 	}
 	Metadata::clearInstanceMetadata( this );
@@ -545,7 +545,7 @@ void Plug::removeOutputs()
 	for( OutputContainer::iterator it = m_outputs.begin(); it!=m_outputs.end();  )
 	{
 		Plug *p = *it++;
-		p->setInput( 0 );
+		p->setInput( nullptr );
 	}
 }
 
@@ -607,7 +607,7 @@ void Plug::parentChanging( Gaffer::GraphComponent *newParent )
 		// We're losing our parent - remove all our connections first.
 		// this must be done here (rather than in a parentChangedSignal() slot)
 		// because we need a current parent for the operation to be undoable.
-		setInput( 0 );
+		setInput( nullptr );
 		// Deal with outputs whose parent is an output of our parent.
 		// For these we actually remove the destination plug itself,
 		// so that the parent plugs may remain connected.

--- a/src/Gaffer/Random.cpp
+++ b/src/Gaffer/Random.cpp
@@ -276,7 +276,7 @@ void Random::hashSeed( const Context *context, IECore::MurmurHash &h ) const
 	std::string contextEntry = contextEntryPlug()->getValue();
 	if( contextEntry.size() )
 	{
-		const IECore::Data *contextData = 0;
+		const IECore::Data *contextData = nullptr;
 		try
 		{
 			contextData = context->get<IECore::Data>( contextEntry );
@@ -297,7 +297,7 @@ unsigned long int Random::computeSeed( const Context *context ) const
 	std::string contextEntry = contextEntryPlug()->getValue();
 	if( contextEntry.size() )
 	{
-		const IECore::Data *contextData = 0;
+		const IECore::Data *contextData = nullptr;
 		try
 		{
 			contextData = context->get<IECore::Data>( contextEntry );

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -100,12 +100,12 @@ class ScriptNode::CompoundAction : public Gaffer::Action
 
 		friend class ScriptNode;
 
-		virtual GraphComponent *subject() const
+		GraphComponent *subject() const override
 		{
 			return m_subject;
 		}
 
-		virtual void doAction()
+		void doAction() override
 		{
 			for( std::vector<ActionPtr>::const_iterator it = m_actions.begin(), eIt = m_actions.end(); it != eIt; ++it )
 			{
@@ -116,7 +116,7 @@ class ScriptNode::CompoundAction : public Gaffer::Action
 			}
 		}
 
-		virtual void undoAction()
+		void undoAction() override
 		{
 			for( std::vector<ActionPtr>::const_reverse_iterator it = m_actions.rbegin(), eIt = m_actions.rend(); it != eIt; ++it )
 			{
@@ -125,7 +125,7 @@ class ScriptNode::CompoundAction : public Gaffer::Action
 			}
 		}
 
-		virtual bool canMerge( const Action *other ) const
+		bool canMerge( const Action *other ) const override
 		{
 			if( !Action::canMerge( other ) )
 			{
@@ -146,7 +146,7 @@ class ScriptNode::CompoundAction : public Gaffer::Action
 			return m_mergeGroup == compoundAction->m_mergeGroup;
 		}
 
-		virtual void merge( const Action *other )
+		void merge( const Action *other ) override
 		{
 			const CompoundAction *compoundAction = static_cast<const CompoundAction *>( other );
 

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -419,22 +419,22 @@ class ValuePlug::SetValueAction : public Gaffer::Action
 
 	protected :
 
-		virtual GraphComponent *subject() const
+		GraphComponent *subject() const override
 		{
 			return m_plug.get();
 		}
 
-		virtual void doAction()
+		void doAction() override
 		{
 			m_plug->setValueInternal( m_doValue, true );
 		}
 
-		virtual void undoAction()
+		void undoAction() override
 		{
 			m_plug->setValueInternal( m_undoValue, true );
 		}
 
-		virtual bool canMerge( const Action *other ) const
+		bool canMerge( const Action *other ) const override
 		{
 			if( !Action::canMerge( other ) )
 			{
@@ -444,7 +444,7 @@ class ValuePlug::SetValueAction : public Gaffer::Action
 			return setValueAction && setValueAction->m_plug == m_plug;
 		}
 
-		virtual void merge( const Action *other )
+		void merge( const Action *other ) override
 		{
 			const SetValueAction *setValueAction = static_cast<const SetValueAction *>( other );
 			m_doValue = setValueAction->m_doValue;

--- a/src/GafferAppleseed/AppleseedLight.cpp
+++ b/src/GafferAppleseed/AppleseedLight.cpp
@@ -138,7 +138,7 @@ void AppleseedLight::setupPlugs( const std::string &shaderName, const asf::Dicti
 		std::string inputName = inputMetadata.get( "name" );
 		std::string inputType = inputMetadata.get( "type" );
 
-		Gaffer::Plug *plug = 0;
+		Gaffer::Plug *plug = nullptr;
 
 		// some environment lights need their radiance color input
 		// replaced by a texture input: latlong map and mirrorball map.

--- a/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
+++ b/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
@@ -869,7 +869,7 @@ class InstanceMaster : public IECore::RefCounted
 
 			// Move the object into its own assembly if needed, so that it can be instanced.
 			const string assemblyName = m_name + "_assembly";
-			if( m_mainAssembly->assemblies().get_by_name( assemblyName.c_str() ) == 0 )
+			if( m_mainAssembly->assemblies().get_by_name( assemblyName.c_str() ) == nullptr )
 			{
 				// Create an assembly for the object.
 				asf::auto_release_ptr<asr::Assembly> ass( asr::AssemblyFactory().create( assemblyName.c_str() ) );
@@ -1589,7 +1589,7 @@ class AppleseedEnvironmentLight : public AppleseedLight
 				removeEnvironmentEDF( m_environment );
 				removeSceneTextures();
 				removeSceneColors();
-				m_environment = 0;
+				m_environment = nullptr;
 			}
 		}
 
@@ -2386,7 +2386,7 @@ class AppleseedRenderer : public IECoreScenePreview::Renderer
 
 			// Render progress logging.
 			ProgressTileCallbackFactory tileCallbackFactory;
-			asr::ITileCallbackFactory *tileCallbackFactoryPtr = 0;
+			asr::ITileCallbackFactory *tileCallbackFactoryPtr = nullptr;
 
 			if( m_project->get_display() == nullptr )
 			{

--- a/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
+++ b/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
@@ -509,19 +509,19 @@ class AppleseedNullObject : public AppleseedEntity
 		{
 		}
 
-		virtual ~AppleseedNullObject()
+		~AppleseedNullObject() override
 		{
 		}
 
-		virtual void transform( const M44f &transform )
+		void transform( const M44f &transform ) override
 		{
 		}
 
-		virtual void transform( const vector<M44f> &samples, const vector<float> &times )
+		void transform( const vector<M44f> &samples, const vector<float> &times ) override
 		{
 		}
 
-		virtual bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes )
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
 		{
 			return true;
 		}
@@ -552,7 +552,7 @@ class AppleseedShader : public AppleseedEntity
 			insertShaderGroup( shaderGroup );
 		}
 
-		virtual ~AppleseedShader()
+		~AppleseedShader() override
 		{
 			if( isInteractiveRender() )
 			{
@@ -560,15 +560,15 @@ class AppleseedShader : public AppleseedEntity
 			}
 		}
 
-		virtual void transform( const M44f &transform )
+		void transform( const M44f &transform ) override
 		{
 		}
 
-		virtual void transform( const vector<M44f> &samples, const vector<float> &times )
+		void transform( const vector<M44f> &samples, const vector<float> &times ) override
 		{
 		}
 
-		virtual bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes )
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
 		{
 			return true;
 		}
@@ -808,7 +808,7 @@ class AppleseedCamera : public AppleseedEntity
 			}
 		}
 
-		virtual ~AppleseedCamera()
+		~AppleseedCamera() override
 		{
 			if( isInteractiveRender() )
 			{
@@ -821,17 +821,17 @@ class AppleseedCamera : public AppleseedEntity
 			}
 		}
 
-		virtual void transform( const M44f &transform )
+		void transform( const M44f &transform ) override
 		{
 			TransformAlgo::makeTransformSequence( transform, m_camera->transform_sequence() );
 		}
 
-		virtual void transform( const vector<M44f> &samples, const vector<float> &times )
+		void transform( const vector<M44f> &samples, const vector<float> &times ) override
 		{
 			TransformAlgo::makeTransformSequence( times, samples, m_camera->transform_sequence() );
 		}
 
-		virtual bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes )
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
 		{
 			// todo: check if this has to be implemented...
 			return true;
@@ -919,7 +919,7 @@ class AppleseedInstance : public AppleseedEntity
 		{
 		}
 
-		virtual ~AppleseedInstance()
+		~AppleseedInstance() override
 		{
 			// Create an instance of the master primitive assembly and add it to the main assembly.
 			string assemblyName = m_masterName + "_assembly";
@@ -929,17 +929,17 @@ class AppleseedInstance : public AppleseedEntity
 			insertAssemblyInstance( assInstance );
 		}
 
-		virtual void transform( const M44f &transform )
+		void transform( const M44f &transform ) override
 		{
 			TransformAlgo::makeTransformSequence( transform, m_transformSequence );
 		}
 
-		virtual void transform( const vector<M44f> &samples, const vector<float> &times )
+		void transform( const vector<M44f> &samples, const vector<float> &times ) override
 		{
 			TransformAlgo::makeTransformSequence( times, samples, m_transformSequence );
 		}
 
-		virtual bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes )
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
 		{
 			// We reuse the attributes of the master primitive.
 			return true;
@@ -1087,7 +1087,7 @@ class AppleseedPrimitive : public AppleseedEntity
 			}
 		}
 
-		virtual ~AppleseedPrimitive()
+		~AppleseedPrimitive() override
 		{
 			if( isInteractiveRender() )
 			{
@@ -1136,7 +1136,7 @@ class AppleseedPrimitive : public AppleseedEntity
 			}
 		}
 
-		virtual void transform( const M44f &transform )
+		void transform( const M44f &transform ) override
 		{
 			if( isInteractiveRender() )
 			{
@@ -1149,7 +1149,7 @@ class AppleseedPrimitive : public AppleseedEntity
 			}
 		}
 
-		virtual void transform( const vector<M44f> &samples, const vector<float> &times )
+		void transform( const vector<M44f> &samples, const vector<float> &times ) override
 		{
 			if( isInteractiveRender() )
 			{
@@ -1162,7 +1162,7 @@ class AppleseedPrimitive : public AppleseedEntity
 			}
 		}
 
-		virtual bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes )
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
 		{
 			if( isInteractiveRender() )
 			{
@@ -1524,7 +1524,7 @@ class AppleseedEnvironmentLight : public AppleseedLight
 			AppleseedEnvironmentLight::attributes( attributes );
 		}
 
-		virtual ~AppleseedEnvironmentLight()
+		~AppleseedEnvironmentLight() override
 		{
 			if( isInteractiveRender() )
 			{
@@ -1532,7 +1532,7 @@ class AppleseedEnvironmentLight : public AppleseedLight
 			}
 		}
 
-		virtual void transform( const M44f &transform )
+		void transform( const M44f &transform ) override
 		{
 			TransformAlgo::makeTransformSequence( transform, m_transformSequence );
 
@@ -1542,7 +1542,7 @@ class AppleseedEnvironmentLight : public AppleseedLight
 			}
 		}
 
-		virtual void transform( const vector<M44f> &samples, const vector<float> &times )
+		void transform( const vector<M44f> &samples, const vector<float> &times ) override
 		{
 			TransformAlgo::makeTransformSequence( times, samples, m_transformSequence );
 
@@ -1552,7 +1552,7 @@ class AppleseedEnvironmentLight : public AppleseedLight
 			}
 		}
 
-		virtual bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes )
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
 		{
 			// Remove any previously created environment.
 			removeEnvironmentEntities();
@@ -1608,7 +1608,7 @@ class AppleseedDeltaLight : public AppleseedLight
 			AppleseedDeltaLight::attributes( attributes );
 		}
 
-		virtual ~AppleseedDeltaLight()
+		~AppleseedDeltaLight() override
 		{
 			if( isInteractiveRender() )
 			{
@@ -1616,7 +1616,7 @@ class AppleseedDeltaLight : public AppleseedLight
 			}
 		}
 
-		virtual void transform( const M44f &transform )
+		void transform( const M44f &transform ) override
 		{
 			TransformAlgo::makeTransform( transform, m_transform );
 
@@ -1626,13 +1626,13 @@ class AppleseedDeltaLight : public AppleseedLight
 			}
 		}
 
-		virtual void transform( const vector<M44f> &samples, const vector<float> &times )
+		void transform( const vector<M44f> &samples, const vector<float> &times ) override
 		{
 			// appleseed does not support light transform motion blur yet.
 			transform(samples[0]);
 		}
 
-		virtual bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes )
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
 		{
 			// Remove any previously created light.
 			removeLightEntities();
@@ -1753,13 +1753,13 @@ class AppleseedRenderer : public IECoreScenePreview::Renderer
 			}
 		}
 
-		virtual ~AppleseedRenderer()
+		~AppleseedRenderer() override
 		{
 			pause();
 			delete m_rendererController;
 		}
 
-		virtual void option( const InternedString &name, const Data *value )
+		void option( const InternedString &name, const Data *value ) override
 		{
 			if( name == g_cameraOptionName )
 			{
@@ -2030,7 +2030,7 @@ class AppleseedRenderer : public IECoreScenePreview::Renderer
 			msg( Msg::Warning, "AppleseedRenderer::option", boost::format( "Unknown option \"%s\"." ) % name.c_str() );
 		}
 
-		virtual void output( const InternedString &name, const Output *output )
+		void output( const InternedString &name, const Output *output ) override
 		{
 			if( output == nullptr )
 			{
@@ -2070,12 +2070,12 @@ class AppleseedRenderer : public IECoreScenePreview::Renderer
 			}
 		}
 
-		virtual Renderer::AttributesInterfacePtr attributes( const CompoundObject *attributes )
+		Renderer::AttributesInterfacePtr attributes( const CompoundObject *attributes ) override
 		{
 			return new AppleseedAttributes( attributes, m_shaderCache.get() );
 		}
 
-		virtual ObjectInterfacePtr camera( const string &name, const Camera *camera, const AttributesInterface *attributes )
+		ObjectInterfacePtr camera( const string &name, const Camera *camera, const AttributesInterface *attributes ) override
 		{
 			CameraPtr cameraCopy = camera->copy();
 			cameraCopy->addStandardParameters();
@@ -2095,7 +2095,7 @@ class AppleseedRenderer : public IECoreScenePreview::Renderer
 			return new AppleseedCamera( *m_project, name, cameraCopy.get(), attributes, activeCamera, isInteractiveRender() );
 		}
 
-		virtual ObjectInterfacePtr light( const string &name, const Object *object, const AttributesInterface *attributes )
+		ObjectInterfacePtr light( const string &name, const Object *object, const AttributesInterface *attributes ) override
 		{
 			// For now we only do area lights using OSL emission().
 			if( object == nullptr )
@@ -2118,7 +2118,7 @@ class AppleseedRenderer : public IECoreScenePreview::Renderer
 			return new AppleseedNullObject( *m_project, name, isInteractiveRender() );
 		}
 
-		virtual ObjectInterfacePtr object( const string &name, const Object *object, const AttributesInterface *attributes )
+		ObjectInterfacePtr object( const string &name, const Object *object, const AttributesInterface *attributes ) override
 		{
 			if( !ObjectAlgo::isPrimitiveSupported( object ) )
 			{
@@ -2150,7 +2150,7 @@ class AppleseedRenderer : public IECoreScenePreview::Renderer
 			}
 		}
 
-		virtual ObjectInterfacePtr object( const string &name, const vector<const Object *> &samples, const vector<float> &times, const AttributesInterface *attributes )
+		ObjectInterfacePtr object( const string &name, const vector<const Object *> &samples, const vector<float> &times, const AttributesInterface *attributes ) override
 		{
 			if( !ObjectAlgo::isPrimitiveSupported( samples[0] ) )
 			{
@@ -2186,7 +2186,7 @@ class AppleseedRenderer : public IECoreScenePreview::Renderer
 			}
 		}
 
-		virtual void render()
+		void render() override
 		{
 			// Create a default camera if needed.
 			if( m_project->get_uncached_active_camera() == nullptr )
@@ -2254,7 +2254,7 @@ class AppleseedRenderer : public IECoreScenePreview::Renderer
 			}
 		}
 
-		virtual void pause()
+		void pause() override
 		{
 			m_rendererController->set_status( asr::IRendererController::AbortRendering );
 

--- a/src/GafferArnold/ArnoldShader.cpp
+++ b/src/GafferArnold/ArnoldShader.cpp
@@ -193,7 +193,7 @@ static IECore::ConstCompoundDataPtr metadataGetter( const std::string &key, size
 		shaderMetadata->writable()["primaryInput"] = new StringData( value );
 	}
 	const char* shaderType;
-	if( AiMetaDataGetStr( shader, /* look up metadata on node, not on parameter */ NULL , "shaderType", &shaderType ) )
+	if( AiMetaDataGetStr( shader, /* look up metadata on node, not on parameter */ nullptr , "shaderType", &shaderType ) )
 	{
 		shaderMetadata->writable()["shaderType"] = new StringData( shaderType );
 	}

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -392,7 +392,7 @@ class ArnoldShader : public IECore::RefCounted
 			m_nodes = ShaderAlgo::convert( shaderNetwork, namePrefix );
 		}
 
-		virtual ~ArnoldShader()
+		~ArnoldShader() override
 		{
 			for( std::vector<AtNode *>::const_iterator it = m_nodes.begin(), eIt = m_nodes.end(); it != eIt; ++it )
 			{
@@ -1311,7 +1311,7 @@ class ArnoldObject : public IECoreScenePreview::Renderer::ObjectInterface
 		{
 		}
 
-		virtual void transform( const Imath::M44f &transform )
+		void transform( const Imath::M44f &transform ) override
 		{
 			AtNode *node = m_instance.node();
 			if( !node )
@@ -1321,7 +1321,7 @@ class ArnoldObject : public IECoreScenePreview::Renderer::ObjectInterface
 			applyTransform( node, transform );
 		}
 
-		virtual void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times )
+		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override
 		{
 			AtNode *node = m_instance.node();
 			if( !node )
@@ -1331,7 +1331,7 @@ class ArnoldObject : public IECoreScenePreview::Renderer::ObjectInterface
 			applyTransform( node, samples, times );
 		}
 
-		virtual bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes )
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
 		{
 			AtNode *node = m_instance.node();
 			if( !node )
@@ -1409,7 +1409,7 @@ class ArnoldLight : public ArnoldObject
 		{
 		}
 
-		virtual void transform( const Imath::M44f &transform )
+		void transform( const Imath::M44f &transform ) override
 		{
 			ArnoldObject::transform( transform );
 			m_transformMatrices.clear();
@@ -1418,7 +1418,7 @@ class ArnoldLight : public ArnoldObject
 			applyLightTransform();
 		}
 
-		virtual void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times )
+		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override
 		{
 			ArnoldObject::transform( samples, times );
 			m_transformMatrices = samples;
@@ -1426,7 +1426,7 @@ class ArnoldLight : public ArnoldObject
 			applyLightTransform();
 		}
 
-		virtual bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes )
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
 		{
 			if( !ArnoldObject::attributes( attributes ) )
 			{
@@ -1640,12 +1640,12 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 			option( g_shaderSearchPathOptionName, new IECore::StringData( "" ) );
 		}
 
-		virtual ~ArnoldRenderer()
+		~ArnoldRenderer() override
 		{
 			pause();
 		}
 
-		virtual void option( const IECore::InternedString &name, const IECore::Data *value )
+		void option( const IECore::InternedString &name, const IECore::Data *value ) override
 		{
 			AtNode *options = AiUniverseGetOptions();
 			if( name == g_frameOptionName )
@@ -1823,7 +1823,7 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 			IECore::msg( IECore::Msg::Warning, "IECoreArnold::Renderer::option", boost::format( "Unknown option \"%s\"." ) % name.c_str() );
 		}
 
-		virtual void output( const IECore::InternedString &name, const Output *output )
+		void output( const IECore::InternedString &name, const Output *output ) override
 		{
 			m_outputs.erase( name );
 			if( output )
@@ -1847,12 +1847,12 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 			IECoreArnold::ParameterAlgo::setParameter( AiUniverseGetOptions(), "outputs", outputs.get() );
 		}
 
-		virtual Renderer::AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes )
+		Renderer::AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override
 		{
 			return new ArnoldAttributes( attributes, m_shaderCache.get() );
 		}
 
-		virtual ObjectInterfacePtr camera( const std::string &name, const IECore::Camera *camera, const AttributesInterface *attributes )
+		ObjectInterfacePtr camera( const std::string &name, const IECore::Camera *camera, const AttributesInterface *attributes ) override
 		{
 			IECore::CameraPtr cameraCopy = camera->copy();
 			cameraCopy->addStandardParameters();
@@ -1869,7 +1869,7 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		virtual ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
+		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
 		{
 			Instance instance = m_instanceCache->get( object, attributes );
 			if( AtNode *node = instance.node() )
@@ -1882,7 +1882,7 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		virtual Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
+		Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
 		{
 			Instance instance = m_instanceCache->get( object, attributes );
 			if( AtNode *node = instance.node() )
@@ -1895,7 +1895,7 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		virtual ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes )
+		ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override
 		{
 			Instance instance = m_instanceCache->get( samples, times, attributes );
 			if( AtNode *node = instance.node() )
@@ -1908,7 +1908,7 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		virtual void render()
+		void render() override
 		{
 			updateCamera();
 			AiNodeSetInt(
@@ -1935,7 +1935,7 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 			}
 		}
 
-		virtual void pause()
+		void pause() override
 		{
 			m_interactiveRenderController.setRendering( false );
 		}

--- a/src/GafferArnold/ParameterHandler.cpp
+++ b/src/GafferArnold/ParameterHandler.cpp
@@ -264,7 +264,7 @@ Gaffer::Plug *ParameterHandler::setupPlug( const AtNodeEntry *node, const AtPara
 
 	int parameterType = AiParamGetType( parameter );
 
-	const char *plugTypeOverride = NULL;
+	const char *plugTypeOverride = nullptr;
 	std::string name = AiParamGetName( parameter );
 	if( AiMetaDataGetStr( node, name.c_str(), "gaffer.plugType", &plugTypeOverride ) )
 	{

--- a/src/GafferBindings/AnimationBinding.cpp
+++ b/src/GafferBindings/AnimationBinding.cpp
@@ -80,7 +80,7 @@ class CurvePlugSerialiser : public ValuePlugSerialiser
 
 	public :
 
-		virtual std::string postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const
+		std::string postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override
 		{
 			std::string result = ValuePlugSerialiser::postConstructor( graphComponent, identifier, serialisation );
 			const Animation::CurvePlug *curve = static_cast<const Animation::CurvePlug *>( graphComponent );

--- a/src/GafferBindings/ApplicationRootBinding.cpp
+++ b/src/GafferBindings/ApplicationRootBinding.cpp
@@ -65,7 +65,7 @@ class ApplicationRootWrapper : public IECorePython::RunTimeTypedWrapper<Applicat
 		{
 		}
 
-		virtual void savePreferences( const std::string &fileName ) const
+		void savePreferences( const std::string &fileName ) const override
 		{
 			IECorePython::ScopedGILLock gilLock;
 

--- a/src/GafferBindings/ApplicationRootBinding.cpp
+++ b/src/GafferBindings/ApplicationRootBinding.cpp
@@ -104,7 +104,7 @@ static IECore::ObjectPtr getClipboardContents( ApplicationRoot &a )
 	{
 		return o->copy();
 	}
-	return 0;
+	return nullptr;
 }
 
 struct ClipboardSlotCaller

--- a/src/GafferBindings/ArrayPlugBinding.cpp
+++ b/src/GafferBindings/ArrayPlugBinding.cpp
@@ -88,7 +88,7 @@ class ArrayPlugSerialiser : public PlugSerialiser
 
 	public :
 
-		virtual std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const
+		std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const override
 		{
 			return maskedRepr( static_cast<const ArrayPlug *>( graphComponent ), Plug::All & ~Plug::ReadOnly );
 		}

--- a/src/GafferBindings/BoxBinding.cpp
+++ b/src/GafferBindings/BoxBinding.cpp
@@ -53,7 +53,7 @@ namespace
 class BoxSerialiser : public NodeSerialiser
 {
 
-	virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
+	bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override
 	{
 		if( child->isInstanceOf( Node::staticTypeId() ) )
 		{
@@ -62,7 +62,7 @@ class BoxSerialiser : public NodeSerialiser
 		return NodeSerialiser::childNeedsSerialisation( child, serialisation );
 	}
 
-	virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
+	bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override
 	{
 		if( child->isInstanceOf( Node::staticTypeId() ) )
 		{

--- a/src/GafferBindings/BoxIOBinding.cpp
+++ b/src/GafferBindings/BoxIOBinding.cpp
@@ -55,7 +55,7 @@ namespace
 class BoxIOSerialiser : public NodeSerialiser
 {
 
-	virtual std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const
+	std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override
 	{
 		std::string result = NodeSerialiser::postScript( graphComponent, identifier, serialisation );
 

--- a/src/GafferBindings/CompoundDataPlugBinding.cpp
+++ b/src/GafferBindings/CompoundDataPlugBinding.cpp
@@ -143,12 +143,12 @@ class MemberPlugSerialiser : public ValuePlugSerialiser
 
 	public :
 
-		virtual std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const
+		std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const override
 		{
 			return maskedMemberPlugRepr( static_cast<const CompoundDataPlug::MemberPlug *>( graphComponent ), Plug::All & ~Plug::ReadOnly );
 		}
 
-		virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
+		bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override
 		{
 			// if the parent is dynamic then all the children will need construction.
 			const Plug *parent = child->parent<Plug>();

--- a/src/GafferBindings/CompoundNumericPlugBinding.cpp
+++ b/src/GafferBindings/CompoundNumericPlugBinding.cpp
@@ -84,7 +84,7 @@ class CompoundNumericPlugSerialiser : public ValuePlugSerialiser
 {
   public:
 
-	virtual std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const
+	std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const override
 	{
 		return maskedCompoundNumericPlugRepr( static_cast<const T *>( graphComponent ), Plug::All & ~Plug::ReadOnly, &serialisation );
 	}
@@ -93,7 +93,7 @@ class CompoundNumericPlugSerialiser : public ValuePlugSerialiser
 
 		// Ideally we'll serialise the value as a single getValue() call for this plug,
 		// but we can't do that if any of the children have input connections.
-		virtual bool valueNeedsSerialisation( const Gaffer::ValuePlug *plug, const Serialisation &serialisation ) const
+		bool valueNeedsSerialisation( const Gaffer::ValuePlug *plug, const Serialisation &serialisation ) const override
 		{
 			if( !ValuePlugSerialiser::valueNeedsSerialisation( plug, serialisation ) )
 			{

--- a/src/GafferBindings/ExpressionBinding.cpp
+++ b/src/GafferBindings/ExpressionBinding.cpp
@@ -113,7 +113,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 		{
 		}
 
-		virtual void parse( Expression *node, const std::string &expression, std::vector<ValuePlug *> &inputs, std::vector<ValuePlug *> &outputs, std::vector<IECore::InternedString> &contextVariables )
+		void parse( Expression *node, const std::string &expression, std::vector<ValuePlug *> &inputs, std::vector<ValuePlug *> &outputs, std::vector<IECore::InternedString> &contextVariables ) override
 		{
 			if( isSubclassed() )
 			{
@@ -141,7 +141,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 			throw IECore::Exception( "Engine::parse() python method not defined" );
 		}
 
-		virtual IECore::ConstObjectVectorPtr execute( const Context *context, const std::vector<const ValuePlug *> &proxyInputs ) const
+		IECore::ConstObjectVectorPtr execute( const Context *context, const std::vector<const ValuePlug *> &proxyInputs ) const override
 		{
 			if( isSubclassed() )
 			{
@@ -170,7 +170,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 			throw IECore::Exception( "Engine::execute() python method not defined" );
 		}
 
-		virtual void apply( ValuePlug *proxyOutput, const ValuePlug *topLevelProxyOutput, const IECore::Object *value ) const
+		void apply( ValuePlug *proxyOutput, const ValuePlug *topLevelProxyOutput, const IECore::Object *value ) const override
 		{
 			if( isSubclassed() )
 			{
@@ -193,7 +193,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 			throw IECore::Exception( "Engine::apply() python method not defined" );
 		}
 
-		virtual std::string identifier( const Expression *node, const ValuePlug *plug ) const
+		std::string identifier( const Expression *node, const ValuePlug *plug ) const override
 		{
 			if( isSubclassed() )
 			{
@@ -216,7 +216,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 			throw IECore::Exception( "Engine::identifier() python method not defined" );
 		}
 
-		virtual std::string replace( const Expression *node, const std::string &expression, const std::vector<const ValuePlug *> &oldPlugs, const std::vector<const ValuePlug *> &newPlugs ) const
+		std::string replace( const Expression *node, const std::string &expression, const std::vector<const ValuePlug *> &oldPlugs, const std::vector<const ValuePlug *> &newPlugs ) const override
 		{
 			if( isSubclassed() )
 			{
@@ -249,7 +249,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 			throw IECore::Exception( "Engine::replace() python method not defined" );
 		}
 
-		virtual std::string defaultExpression( const ValuePlug *output ) const
+		std::string defaultExpression( const ValuePlug *output ) const override
 		{
 			if( isSubclassed() )
 			{
@@ -307,7 +307,7 @@ static tuple languages()
 class ExpressionSerialiser : public NodeSerialiser
 {
 
-	virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const
+	void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const override
 	{
 		const Expression *e = static_cast<const Expression *>( graphComponent );
 		std::string language;
@@ -320,7 +320,7 @@ class ExpressionSerialiser : public NodeSerialiser
 		}
 	}
 
-	virtual std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const
+	std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override
 	{
 		const Expression *e = static_cast<const Expression *>( graphComponent );
 

--- a/src/GafferBindings/GraphComponentBinding.cpp
+++ b/src/GafferBindings/GraphComponentBinding.cpp
@@ -156,7 +156,7 @@ GraphComponentPtr getItem( GraphComponent &g, const char *n )
 	}
 
 	throwKeyError( g, n );
-	return 0; // shouldn't get here
+	return nullptr; // shouldn't get here
 }
 
 GraphComponentPtr getItem( GraphComponent &g, long index )

--- a/src/GafferBindings/PathBinding.cpp
+++ b/src/GafferBindings/PathBinding.cpp
@@ -123,7 +123,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 		}
 
 
-		virtual bool isValid() const
+		bool isValid() const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -144,7 +144,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 			return WrappedType::isValid();
 		}
 
-		virtual bool isLeaf() const
+		bool isLeaf() const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -165,7 +165,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 			return WrappedType::isLeaf();
 		}
 
-		virtual void propertyNames( std::vector<IECore::InternedString> &names ) const
+		void propertyNames( std::vector<IECore::InternedString> &names ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -198,7 +198,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 			WrappedType::propertyNames( names );
 		}
 
-		virtual IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name ) const
+		IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -231,7 +231,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 			return WrappedType::property( name );
 		}
 
-		virtual PathPtr copy() const
+		PathPtr copy() const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -256,7 +256,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 			return WrappedType::copy();
 		}
 
-		virtual void doChildren( std::vector<PathPtr> &children ) const
+		void doChildren( std::vector<PathPtr> &children ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -279,7 +279,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 			WrappedType::doChildren( children );
 		}
 
-		virtual void pathChangedSignalCreated()
+		void pathChangedSignalCreated() override
 		{
 			if( this->isSubclassed() )
 			{

--- a/src/GafferBindings/PathFilterBinding.cpp
+++ b/src/GafferBindings/PathFilterBinding.cpp
@@ -64,7 +64,7 @@ class PathFilterWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 		{
 		}
 
-		virtual void doFilter( std::vector<PathPtr> &paths ) const
+		void doFilter( std::vector<PathPtr> &paths ) const override
 		{
 			if( this->isSubclassed() )
 			{

--- a/src/GafferBindings/PlugBinding.cpp
+++ b/src/GafferBindings/PlugBinding.cpp
@@ -152,7 +152,7 @@ std::string PlugSerialiser::directionRepr( Plug::Direction direction )
 std::string PlugSerialiser::flagsRepr( unsigned flags )
 {
 	static const Plug::Flags values[] = { Plug::Dynamic, Plug::Serialisable, Plug::AcceptsInputs, Plug::PerformsSubstitutions, Plug::Cacheable, Plug::ReadOnly, Plug::AcceptsDependencyCycles, Plug::None };
-	static const char *names[] = { "Dynamic", "Serialisable", "AcceptsInputs", "PerformsSubstitutions", "Cacheable", "ReadOnly", "AcceptsDependencyCycles", 0 };
+	static const char *names[] = { "Dynamic", "Serialisable", "AcceptsInputs", "PerformsSubstitutions", "Cacheable", "ReadOnly", "AcceptsDependencyCycles", nullptr };
 
 	int defaultButOffCount = 0;
 	std::string defaultButOff;

--- a/src/GafferBindings/ReferenceBinding.cpp
+++ b/src/GafferBindings/ReferenceBinding.cpp
@@ -72,7 +72,7 @@ struct ReferenceLoadedSlotCaller
 class ReferenceSerialiser : public NodeSerialiser
 {
 
-	virtual std::string postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const
+	std::string postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override
 	{
 		const Reference *r = static_cast<const Reference *>( graphComponent );
 

--- a/src/GafferBindings/ScriptNodeBinding.cpp
+++ b/src/GafferBindings/ScriptNodeBinding.cpp
@@ -276,11 +276,11 @@ class ScriptNodeWrapper : public NodeWrapper<ScriptNode>
 		{
 		}
 
-		virtual ~ScriptNodeWrapper()
+		~ScriptNodeWrapper() override
 		{
 		}
 
-		virtual bool isInstanceOf( IECore::TypeId typeId ) const
+		bool isInstanceOf( IECore::TypeId typeId ) const override
 		{
 			if( typeId == (IECore::TypeId)Gaffer::ScriptNodeTypeId )
 			{

--- a/src/GafferBindings/Serialisation.cpp
+++ b/src/GafferBindings/Serialisation.cpp
@@ -372,7 +372,7 @@ class SerialiserWrapper : public IECorePython::RefCountedWrapper<Serialisation::
 		{
 		}
 
-		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const
+		void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -390,7 +390,7 @@ class SerialiserWrapper : public IECorePython::RefCountedWrapper<Serialisation::
 			Serialiser::moduleDependencies( graphComponent, modules, serialisation );
 		}
 
-		virtual std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const
+		std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -406,7 +406,7 @@ class SerialiserWrapper : public IECorePython::RefCountedWrapper<Serialisation::
 			return Serialiser::constructor( graphComponent, serialisation );
 		}
 
-		virtual std::string postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const
+		std::string postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -422,7 +422,7 @@ class SerialiserWrapper : public IECorePython::RefCountedWrapper<Serialisation::
 			return Serialiser::postConstructor( graphComponent, identifier, serialisation );
 		}
 
-		virtual std::string postHierarchy( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const
+		std::string postHierarchy( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -438,7 +438,7 @@ class SerialiserWrapper : public IECorePython::RefCountedWrapper<Serialisation::
 			return Serialiser::postHierarchy( graphComponent, identifier, serialisation );
 		}
 
-		virtual std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const
+		std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -454,7 +454,7 @@ class SerialiserWrapper : public IECorePython::RefCountedWrapper<Serialisation::
 			return Serialiser::postScript( graphComponent, identifier, serialisation );
 		}
 
-		virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
+		bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -468,7 +468,7 @@ class SerialiserWrapper : public IECorePython::RefCountedWrapper<Serialisation::
 			return Serialiser::childNeedsSerialisation( child, serialisation );
 		}
 
-		virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
+		bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override
 		{
 			if( this->isSubclassed() )
 			{

--- a/src/GafferBindings/SplinePlugBinding.cpp
+++ b/src/GafferBindings/SplinePlugBinding.cpp
@@ -59,7 +59,7 @@ class SplinePlugSerialiser : public ValuePlugSerialiser
 
 	public :
 
-		virtual std::string postConstructor( const Gaffer::GraphComponent *child, const std::string &identifier, const Serialisation &serialisation ) const
+		std::string postConstructor( const Gaffer::GraphComponent *child, const std::string &identifier, const Serialisation &serialisation ) const override
 		{
 			// this isn't ideal, but the newly constructed spline plug will already have child plugs representing the points for the
 			// default value - so we get rid of those so the real value can be loaded appropriately (using the usual mechanism for

--- a/src/GafferBindings/StringPlugBinding.cpp
+++ b/src/GafferBindings/StringPlugBinding.cpp
@@ -114,7 +114,7 @@ class StringPlugSerialiser : public ValuePlugSerialiser
 
 	public :
 
-		virtual std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const
+		std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const override
 		{
 			return maskedRepr( static_cast<const StringPlug *>( graphComponent ), Plug::All & ~Plug::ReadOnly, &serialisation );
 		}

--- a/src/GafferCortex/CompoundParameterHandler.cpp
+++ b/src/GafferCortex/CompoundParameterHandler.cpp
@@ -215,7 +215,7 @@ const ParameterHandler *CompoundParameterHandler::childParameterHandler( IECore:
 
 IECore::RunTimeTyped *CompoundParameterHandler::childParameterProvider( IECore::Parameter *childParameter )
 {
-	return 0;
+	return nullptr;
 }
 
 ParameterHandler *CompoundParameterHandler::handler( Parameter *child, bool createIfMissing )
@@ -226,7 +226,7 @@ ParameterHandler *CompoundParameterHandler::handler( Parameter *child, bool crea
 		return it->second.get();
 	}
 
-	ParameterHandlerPtr h = 0;
+	ParameterHandlerPtr h = nullptr;
 	if( createIfMissing )
 	{
 		IECore::ConstBoolDataPtr noHostMapping = child->userData()->member<BoolData>( "noHostMapping" );

--- a/src/GafferCortex/OpHolder.cpp
+++ b/src/GafferCortex/OpHolder.cpp
@@ -48,7 +48,7 @@ using namespace GafferCortex;
 IE_CORE_DEFINERUNTIMETYPED( OpHolder )
 
 OpHolder::OpHolder( const std::string &name )
-	:	ParameterisedHolderComputeNode( name ), m_resultParameterHandler( 0 )
+	:	ParameterisedHolderComputeNode( name ), m_resultParameterHandler( nullptr )
 {
 }
 

--- a/src/GafferCortex/ParameterHandler.cpp
+++ b/src/GafferCortex/ParameterHandler.cpp
@@ -81,7 +81,7 @@ ParameterHandlerPtr ParameterHandler::create( IECore::ParameterPtr parameter )
 		}
 		typeId = RunTimeTyped::baseTypeId( typeId );
 	}
-	return 0;
+	return nullptr;
 }
 
 void ParameterHandler::registerParameterHandler( IECore::TypeId parameterType, Creator creator )

--- a/src/GafferCortex/ParameterisedHolder.cpp
+++ b/src/GafferCortex/ParameterisedHolder.cpp
@@ -55,7 +55,7 @@ const IECore::RunTimeTyped::TypeDescription<ParameterisedHolder<BaseType> > Para
 
 template<typename BaseType>
 ParameterisedHolder<BaseType>::ParameterisedHolder( const std::string &name )
-	:	BaseType( name ), m_parameterised( 0 ), m_parameterHandler( 0 )
+	:	BaseType( name ), m_parameterised( nullptr ), m_parameterHandler( nullptr )
 {
 	BaseType::addChild( new Gaffer::StringPlug( "__className" ) );
 	BaseType::addChild( new Gaffer::IntPlug( "__classVersion", Gaffer::Plug::In, -1 ) );

--- a/src/GafferCortexBindings/CompoundParameterHandlerBinding.cpp
+++ b/src/GafferCortexBindings/CompoundParameterHandlerBinding.cpp
@@ -64,7 +64,7 @@ class CompoundParameterHandlerWrapper : public IECorePython::RefCountedWrapper<C
 		{
 		}
 
-		virtual void restore( Gaffer::GraphComponent *plugParent )
+		void restore( Gaffer::GraphComponent *plugParent ) override
 		{
 			IECorePython::ScopedGILLock gilLock;
 			object o = methodOverride( "restore" );
@@ -78,7 +78,7 @@ class CompoundParameterHandlerWrapper : public IECorePython::RefCountedWrapper<C
 			}
 		}
 
-		virtual Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction, unsigned flags )
+		Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction, unsigned flags ) override
 		{
 			IECorePython::ScopedGILLock gilLock;
 			object o = methodOverride( "setupPlug" );
@@ -92,7 +92,7 @@ class CompoundParameterHandlerWrapper : public IECorePython::RefCountedWrapper<C
 			}
 		}
 
-		virtual void setParameterValue()
+		void setParameterValue() override
 		{
 			IECorePython::ScopedGILLock gilLock;
 			object o = methodOverride( "setParameterValue" );
@@ -106,7 +106,7 @@ class CompoundParameterHandlerWrapper : public IECorePython::RefCountedWrapper<C
 			}
 		}
 
-		virtual void setPlugValue()
+		void setPlugValue() override
 		{
 			IECorePython::ScopedGILLock gilLock;
 			object o = methodOverride( "setPlugValue" );
@@ -120,7 +120,7 @@ class CompoundParameterHandlerWrapper : public IECorePython::RefCountedWrapper<C
 			}
 		}
 
-		virtual IECore::RunTimeTyped *childParameterProvider( IECore::Parameter *childParameter )
+		IECore::RunTimeTyped *childParameterProvider( IECore::Parameter *childParameter ) override
 		{
 			IECorePython::ScopedGILLock gilLock;
 			object o = methodOverride( "childParameterProvider" );

--- a/src/GafferCortexBindings/ParameterHandlerBinding.cpp
+++ b/src/GafferCortexBindings/ParameterHandlerBinding.cpp
@@ -60,56 +60,56 @@ class ParameterHandlerWrapper : public IECorePython::RefCountedWrapper<Parameter
 		{
 		}
 
-		virtual IECore::Parameter *parameter()
+		IECore::Parameter *parameter() override
 		{
 			IECorePython::ScopedGILLock gilLock;
 			object o = methodOverride( "parameter" );
 			return extract<IECore::Parameter *>( o() );
 		}
 
-		virtual const IECore::Parameter *parameter() const
+		const IECore::Parameter *parameter() const override
 		{
 			IECorePython::ScopedGILLock gilLock;
 			object o = methodOverride( "parameter" );
 			return extract<IECore::Parameter *>( o() );
 		}
 
-		virtual void restore( Gaffer::GraphComponent *plugParent )
+		void restore( Gaffer::GraphComponent *plugParent ) override
 		{
 			/// \todo Implement this to call through to python. We're not
 			/// doing that right now to maintain compatibility with existing
 			/// python-based parameter handlers in other packages.
 		}
 
-		virtual Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction, unsigned flags )
+		Gaffer::Plug *setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction, unsigned flags ) override
 		{
 			IECorePython::ScopedGILLock gilLock;
 			object o = methodOverride( "setupPlug" );
 			return extract<Gaffer::Plug *>( o( Gaffer::GraphComponentPtr( plugParent ), direction, flags ) );
 		}
 
-		virtual Gaffer::Plug *plug()
+		Gaffer::Plug *plug() override
 		{
 			IECorePython::ScopedGILLock gilLock;
 			object o = methodOverride( "plug" );
 			return extract<Gaffer::Plug *>( o() );
 		}
 
-		virtual const Gaffer::Plug *plug() const
+		const Gaffer::Plug *plug() const override
 		{
 			IECorePython::ScopedGILLock gilLock;
 			object o = methodOverride( "plug" );
 			return extract<Gaffer::Plug *>( o() );
 		}
 
-		virtual void setParameterValue()
+		void setParameterValue() override
 		{
 			IECorePython::ScopedGILLock gilLock;
 			object o = methodOverride( "setParameterValue" );
 			o();
 		}
 
-		virtual void setPlugValue()
+		void setPlugValue() override
 		{
 			IECorePython::ScopedGILLock gilLock;
 			object o = methodOverride( "setPlugValue" );

--- a/src/GafferCortexBindings/ParameterisedHolderBinding.cpp
+++ b/src/GafferCortexBindings/ParameterisedHolderBinding.cpp
@@ -67,7 +67,7 @@ template<typename T>
 class ParameterisedHolderSerialiser : public NodeSerialiser
 {
 
-	virtual std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const
+	std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override
 	{
 		const T *parameterisedHolder = static_cast<const T *>( graphComponent );
 

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -721,7 +721,7 @@ DispatcherPtr Dispatcher::create( const std::string &dispatcherType )
 	CreatorMap::const_iterator it = m.find( dispatcherType );
 	if( it == m.end() )
 	{
-		return 0;
+		return nullptr;
 	}
 
 	return it->second.first();

--- a/src/GafferDispatchBindings/DispatcherBinding.cpp
+++ b/src/GafferDispatchBindings/DispatcherBinding.cpp
@@ -136,7 +136,7 @@ class DispatcherWrapper : public NodeWrapper<Dispatcher>
 			{
 				return boost::const_pointer_cast<TaskNode>( node );
 			}
-			return 0;
+			return nullptr;
 		}
 
 		static TaskNode::TaskPlugPtr taskBatchPlug( const Dispatcher::TaskBatchPtr &batch )
@@ -160,7 +160,7 @@ class DispatcherWrapper : public NodeWrapper<Dispatcher>
 				return boost::const_pointer_cast<Context>( context );
 			}
 
-			return 0;
+			return nullptr;
 		}
 
 		static boost::python::list taskBatchGetFrames( const Dispatcher::TaskBatchPtr &batch )
@@ -211,7 +211,7 @@ struct DispatcherHelper
 			ExceptionAlgo::translatePythonException();
 		}
 
-		return 0;
+		return nullptr;
 	}
 
 	void operator()( Plug *parentPlug )

--- a/src/GafferDispatchBindings/DispatcherBinding.cpp
+++ b/src/GafferDispatchBindings/DispatcherBinding.cpp
@@ -68,11 +68,11 @@ class DispatcherWrapper : public NodeWrapper<Dispatcher>
 		{
 		}
 
-		virtual ~DispatcherWrapper()
+		~DispatcherWrapper() override
 		{
 		}
 
-		virtual void doDispatch( const TaskBatch *batch ) const
+		void doDispatch( const TaskBatch *batch ) const override
 		{
 			ScopedGILLock gilLock;
 
@@ -94,7 +94,7 @@ class DispatcherWrapper : public NodeWrapper<Dispatcher>
 			}
 		}
 
-		virtual FrameListPtr frameRange( const ScriptNode *script, const Context *context ) const
+		FrameListPtr frameRange( const ScriptNode *script, const Context *context ) const override
 		{
 			ScopedGILLock gilLock;
 

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -138,7 +138,7 @@ class Catalogue::InternalImage : public ImageNode
 			outPlug()->setInput( imageMetadata()->outPlug() );
 		}
 
-		virtual ~InternalImage()
+		~InternalImage() override
 		{
 			if( m_saver )
 			{
@@ -281,7 +281,7 @@ class Catalogue::InternalImage : public ImageNode
 
 	protected :
 
-		virtual void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+		void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override
 		{
 			assert( m_saver );
 			AsynchronousSaver::ChannelDataHashes::const_iterator it = m_saver->channelDataHashes.find(
@@ -300,7 +300,7 @@ class Catalogue::InternalImage : public ImageNode
 			}
 		}
 
-		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override
 		{
 			return imageReader()->outPlug()->channelDataPlug()->getValue();
 		}

--- a/src/GafferImage/Display.cpp
+++ b/src/GafferImage/Display.cpp
@@ -574,7 +574,7 @@ void Display::setupServer()
 	}
 	catch( const std::exception &e )
 	{
-		m_server = 0;
+		m_server = nullptr;
 		g_serverCache.erase( portPlug()->getValue() );
 		msg( Msg::Error, "Display::setupServer", e.what() );
 	}

--- a/src/GafferImage/Display.cpp
+++ b/src/GafferImage/Display.cpp
@@ -139,7 +139,7 @@ class GafferDisplayDriver : public IECore::DisplayDriver
 			m_tiles = other.m_tiles;
 		}
 
-		virtual ~GafferDisplayDriver()
+		~GafferDisplayDriver() override
 		{
 		}
 
@@ -158,7 +158,7 @@ class GafferDisplayDriver : public IECore::DisplayDriver
 			return m_parameters.get();
 		}
 
-		virtual void imageData( const Imath::Box2i &box, const float *data, size_t dataSize )
+		void imageData( const Imath::Box2i &box, const float *data, size_t dataSize ) override
 		{
 			Box2i gafferBox = m_gafferFormat.fromEXRSpace( box );
 
@@ -209,17 +209,17 @@ class GafferDisplayDriver : public IECore::DisplayDriver
 			dataReceivedSignal()( this, box );
 		}
 
-		virtual void imageClose()
+		void imageClose() override
 		{
 			imageReceivedSignal()( this );
 		}
 
-		virtual bool scanLineOrderOnly() const
+		bool scanLineOrderOnly() const override
 		{
 			return false;
 		}
 
-		virtual bool acceptsRepeatedData() const
+		bool acceptsRepeatedData() const override
 		{
 			return true;
 		}

--- a/src/GafferImage/FilterAlgo.cpp
+++ b/src/GafferImage/FilterAlgo.cpp
@@ -66,32 +66,32 @@ class SmoothGaussian2D : public OIIO::Filter2D
 		{
 		}
 
-		~SmoothGaussian2D()
+		~SmoothGaussian2D() override
 		{
 		}
 
-		virtual float operator()( float x, float y ) const
+		float operator()( float x, float y ) const override
 		{
 			return gauss1d( x * m_radiusInverse.x ) *
 			       gauss1d( y * m_radiusInverse.y );
 		}
 
-		virtual bool separable() const
+		bool separable() const override
 		{
 			return true;
 		}
 
-		virtual float xfilt( float x ) const
+		float xfilt( float x ) const override
 		{
 			return gauss1d( x * m_radiusInverse.x );
 		}
 
-		virtual float yfilt( float y ) const
+		float yfilt( float y ) const override
 		{
 			return gauss1d( y * m_radiusInverse.y );
 		}
 
-		OIIO::string_view name() const
+		OIIO::string_view name() const override
 		{
 			return "smoothGaussian";
 		}
@@ -122,32 +122,32 @@ class FilterCubicSimple2D : public OIIO::Filter2D
 		{
 		}
 
-		~FilterCubicSimple2D( void )
+		~FilterCubicSimple2D( void ) override
 		{
 		}
 
-		float operator()( float x, float y ) const
+		float operator()( float x, float y ) const override
 		{
 			return cubicSimple( x * m_wrad_inv )
 				 * cubicSimple( y * m_hrad_inv );
 		}
 
-		bool separable() const
+		bool separable() const override
 		{
 			return true;
 		}
 
-		float xfilt( float x ) const
+		float xfilt( float x ) const override
 		{
 			return cubicSimple( x * m_wrad_inv );
 		}
 
-		float yfilt( float y ) const
+		float yfilt( float y ) const override
 		{
 			return cubicSimple( y * m_hrad_inv );
 		}
 
-		virtual OIIO::string_view name() const
+		OIIO::string_view name() const override
 		{
 			return "cubic";
 		}

--- a/src/GafferImage/OpenColorIOTransform.cpp
+++ b/src/GafferImage/OpenColorIOTransform.cpp
@@ -219,7 +219,7 @@ void OpenColorIOTransform::processColorData( const Gaffer::Context *context, IEC
 		r->baseWritable(),
 		g->baseWritable(),
 		b->baseWritable(),
-		0, // alpha
+		nullptr, // alpha
 		ImagePlug::tileSize(), // width
 		ImagePlug::tileSize() // height
 	);

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -75,8 +75,8 @@ spin_rw_mutex g_imageCacheMutex;
 ImageCache *imageCache()
 {
 	spin_rw_mutex::scoped_lock lock( g_imageCacheMutex, false );
-	static ImageCache *cache = 0;
-	if( cache == 0 )
+	static ImageCache *cache = nullptr;
+	if( cache == nullptr )
 	{
 		if( lock.upgrade_to_writer() )
 		{

--- a/src/GafferImage/VectorWarp.cpp
+++ b/src/GafferImage/VectorWarp.cpp
@@ -68,7 +68,7 @@ struct VectorWarp::Engine : public Warp::Engine
 	{
 	}
 
-	virtual Imath::V2f inputPixel( const Imath::V2f &outputPixel ) const
+	Imath::V2f inputPixel( const Imath::V2f &outputPixel ) const override
 	{
 		const V2i outputPixelI( (int)floorf( outputPixel.x ), (int)floorf( outputPixel.y ) );
 		const size_t i = BufferAlgo::index( outputPixelI, m_tileBound );

--- a/src/GafferImage/Warp.cpp
+++ b/src/GafferImage/Warp.cpp
@@ -145,7 +145,7 @@ class Warp::EngineData : public Data
 		{
 		}
 
-		virtual ~EngineData()
+		~EngineData() override
 		{
 			delete engine;
 		}
@@ -154,19 +154,19 @@ class Warp::EngineData : public Data
 
 	protected :
 
-		virtual void copyFrom( const Object *other, CopyContext *context )
+		void copyFrom( const Object *other, CopyContext *context ) override
 		{
 			Data::copyFrom( other, context );
 			msg( Msg::Warning, "EngineData::copyFrom", "Not implemented" );
 		}
 
-		virtual void save( SaveContext *context ) const
+		void save( SaveContext *context ) const override
 		{
 			Data::save( context );
 			msg( Msg::Warning, "EngineData::save", "Not implemented" );
 		}
 
-		virtual void load( LoadContextPtr context )
+		void load( LoadContextPtr context ) override
 		{
 			Data::load( context );
 			msg( Msg::Warning, "EngineData::load", "Not implemented" );

--- a/src/GafferImageModule/CatalogueBinding.cpp
+++ b/src/GafferImageModule/CatalogueBinding.cpp
@@ -152,7 +152,7 @@ std::string repr( const Catalogue::Image *plug )
 class ImageSerialiser : public PlugSerialiser
 {
 
-	virtual std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const
+	std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const override
 	{
 		return maskedRepr( static_cast<const Catalogue::Image *>( graphComponent ), Plug::All & ~Plug::ReadOnly );
 	}
@@ -162,7 +162,7 @@ class ImageSerialiser : public PlugSerialiser
 class CatalogueSerialiser : public NodeSerialiser
 {
 
-	virtual bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
+	bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override
 	{
 		if( child == child->parent<Catalogue>()->outPlug() )
 		{

--- a/src/GafferImageModule/CoreBinding.cpp
+++ b/src/GafferImageModule/CoreBinding.cpp
@@ -132,7 +132,7 @@ class AtomicFormatPlugSerialiser : public GafferBindings::ValuePlugSerialiser
 
 	public :
 
-		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const
+		void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const override
 		{
 			ValuePlugSerialiser::moduleDependencies( graphComponent, modules, serialisation );
 			modules.insert( "IECore" );
@@ -161,7 +161,7 @@ class FormatPlugSerialiser : public GafferBindings::ValuePlugSerialiser
 
 	public :
 
-		virtual void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const
+		void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const override
 		{
 			// IECore is needed when reloading Format values which reference Box2i.
 			ValuePlugSerialiser::moduleDependencies( graphComponent, modules, serialisation );

--- a/src/GafferImageModule/ImageProcessorBinding.cpp
+++ b/src/GafferImageModule/ImageProcessorBinding.cpp
@@ -88,7 +88,7 @@ class ChannelPlugSerialiser : public ValuePlugSerialiser
 
 	public :
 
-		virtual std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const
+		std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const override
 		{
 			return maskedChannelPlugRepr( static_cast<const Shuffle::ChannelPlug *>( graphComponent ), Plug::All & ~Plug::ReadOnly );
 		}

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -97,27 +97,27 @@ class RendererServices : public OSL::RendererServices
 		{
 		}
 
-		virtual bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, TransformationPtr xform, float time )
+		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, TransformationPtr xform, float time ) override
 		{
 			return false;
 		}
 
-		virtual bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, TransformationPtr xform )
+		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, TransformationPtr xform ) override
 		{
 			return false;
 		}
 
-		virtual bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring from, float time )
+		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring from, float time ) override
 		{
 			return false;
 		}
 
-		virtual bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring from )
+		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring from ) override
 		{
 			return false;
 		}
 
-		virtual bool get_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustring object, TypeDesc type, ustring name, void *value )
+		bool get_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustring object, TypeDesc type, ustring name, void *value ) override
 		{
 			const RenderState *renderState = sg ? static_cast<RenderState *>( sg->renderstate ) : nullptr;
 			if( !renderState )
@@ -139,14 +139,14 @@ class RendererServices : public OSL::RendererServices
 			return ShadingSystem::convert_value( value, type, dataView.data, dataView.type );
 		}
 
-		virtual bool get_array_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustring object, TypeDesc type, ustring name, int index, void *value )
+		bool get_array_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustring object, TypeDesc type, ustring name, int index, void *value ) override
 		{
 			return false;
 		}
 
 		// OSL tries to populate shader parameter values per-object by calling this method.
 		// So we implement it to search for an appropriate input plug and get its value.
-		virtual bool get_userdata( bool derivatives, ustring name, TypeDesc type, OSL::ShaderGlobals *sg, void *value )
+		bool get_userdata( bool derivatives, ustring name, TypeDesc type, OSL::ShaderGlobals *sg, void *value ) override
 		{
 			const RenderState *renderState = sg ? static_cast<RenderState *>( sg->renderstate ) : nullptr;
 			if( !renderState )
@@ -224,7 +224,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 		{
 		}
 
-		virtual void parse( Expression *node, const std::string &expression, std::vector<ValuePlug *> &inputs, std::vector<ValuePlug *> &outputs, std::vector<IECore::InternedString> &contextVariables )
+		void parse( Expression *node, const std::string &expression, std::vector<ValuePlug *> &inputs, std::vector<ValuePlug *> &outputs, std::vector<IECore::InternedString> &contextVariables ) override
 		{
 			m_inParameters.clear();
 			m_outSymbols.clear();
@@ -314,7 +314,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 
 		}
 
-		virtual IECore::ConstObjectVectorPtr execute( const Gaffer::Context *context, const std::vector<const Gaffer::ValuePlug *> &proxyInputs ) const
+		IECore::ConstObjectVectorPtr execute( const Gaffer::Context *context, const std::vector<const Gaffer::ValuePlug *> &proxyInputs ) const override
 		{
 			ShadingSystem *s = shadingSystem();
 			OSL::ShadingContext *shadingContext = s->get_context();
@@ -377,7 +377,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 			return result;
 		}
 
-		virtual void apply( Gaffer::ValuePlug *proxyOutput, const Gaffer::ValuePlug *topLevelProxyOutput, const IECore::Object *value ) const
+		void apply( Gaffer::ValuePlug *proxyOutput, const Gaffer::ValuePlug *topLevelProxyOutput, const IECore::Object *value ) const override
 		{
 			switch( value->typeId() )
 			{
@@ -433,7 +433,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 			}
 		}
 
-		virtual std::string identifier( const Expression *node, const ValuePlug *plug ) const
+		std::string identifier( const Expression *node, const ValuePlug *plug ) const override
 		{
 			switch( (Gaffer::TypeId)plug->typeId() )
 			{
@@ -462,7 +462,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 			return "parent." + relativeName;
 		}
 
-		virtual std::string replace( const Expression *node, const std::string &expression, const std::vector<const ValuePlug *> &oldPlugs, const std::vector<const ValuePlug *> &newPlugs ) const
+		std::string replace( const Expression *node, const std::string &expression, const std::vector<const ValuePlug *> &oldPlugs, const std::vector<const ValuePlug *> &newPlugs ) const override
 		{
 			vector<Replacement> replacements;
 
@@ -505,7 +505,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 			return result;
 		}
 
-		virtual std::string defaultExpression( const ValuePlug *output ) const
+		std::string defaultExpression( const ValuePlug *output ) const override
 		{
 			const Node *parentNode = output->node() ? output->node()->ancestor<Node>() : nullptr;
 			if( !parentNode )

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -321,17 +321,17 @@ class RendererServices : public OSL::RendererServices
 		{
 		}
 
-		virtual bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, TransformationPtr xform, float time )
+		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, TransformationPtr xform, float time ) override
 		{
 			return false;
 		}
 
-		virtual bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, TransformationPtr xform )
+		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, TransformationPtr xform ) override
 		{
 			return false;
 		}
 
-		virtual bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring from, float time )
+		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring from, float time ) override
 		{
 			const RenderState *renderState = sg ? static_cast<RenderState *>( sg->renderstate ) : nullptr;
 			if( renderState )
@@ -342,7 +342,7 @@ class RendererServices : public OSL::RendererServices
 			return false;
 		}
 
-		virtual bool get_inverse_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring to, float time )
+		bool get_inverse_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring to, float time ) override
 		{
 			const RenderState *renderState = sg ? static_cast<RenderState *>( sg->renderstate ) : nullptr;
 			if( renderState )
@@ -353,12 +353,12 @@ class RendererServices : public OSL::RendererServices
 			return false;
 		}
 
-		virtual bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring from )
+		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring from ) override
 		{
 			return false;
 		}
 
-		virtual bool get_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustring object, TypeDesc type, ustring name, void *value )
+		bool get_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustring object, TypeDesc type, ustring name, void *value ) override
 		{
 			const RenderState *renderState = sg ? static_cast<RenderState *>( sg->renderstate ) : nullptr;
 			if( !renderState )
@@ -370,12 +370,12 @@ class RendererServices : public OSL::RendererServices
 			return get_userdata( derivatives, name, type, sg, value );
 		}
 
-		virtual bool get_array_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustring object, TypeDesc type, ustring name, int index, void *value )
+		bool get_array_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustring object, TypeDesc type, ustring name, int index, void *value ) override
 		{
 			return false;
 		}
 
-		virtual bool get_userdata( bool derivatives, ustring name, TypeDesc type, OSL::ShaderGlobals *sg, void *value )
+		bool get_userdata( bool derivatives, ustring name, TypeDesc type, OSL::ShaderGlobals *sg, void *value ) override
 		{
 			const RenderState *renderState = sg ? static_cast<RenderState *>( sg->renderstate ) : nullptr;
 			if( !renderState )

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -873,7 +873,7 @@ IECore::CompoundDataPtr ShadingEngine::shade( const IECore::CompoundData *points
 
 	size_t numPoints = 0;
 
-	const OSL::Vec3 *p = 0;
+	const OSL::Vec3 *p = nullptr;
 	if( const V3fVectorData *pData = points->member<V3fVectorData>( "P" ) )
 	{
 		numPoints = pData->readable().size();

--- a/src/GafferScene/DeletePrimitiveVariables.cpp
+++ b/src/GafferScene/DeletePrimitiveVariables.cpp
@@ -53,5 +53,5 @@ DeletePrimitiveVariables::~DeletePrimitiveVariables()
 void DeletePrimitiveVariables::processPrimitiveVariable( const ScenePath &path, const Gaffer::Context *context, IECore::ConstPrimitivePtr inputGeometry, IECore::PrimitiveVariable &variable ) const
 {
 	variable.interpolation = IECore::PrimitiveVariable::Invalid;
-	variable.data = 0;
+	variable.data = nullptr;
 }

--- a/src/GafferScene/Group.cpp
+++ b/src/GafferScene/Group.cpp
@@ -206,7 +206,7 @@ void Group::hashBound( const ScenePath &path, const Gaffer::Context *context, co
 	else // "/group/..."
 	{
 		// pass through
-		const ScenePlug *sourcePlug = 0;
+		const ScenePlug *sourcePlug = nullptr;
 		ScenePath source = sourcePath( path, &sourcePlug );
 		h = sourcePlug->boundHash( source );
 	}
@@ -233,7 +233,7 @@ Imath::Box3f Group::computeBound( const ScenePath &path, const Gaffer::Context *
 	}
 	else
 	{
-		const ScenePlug *sourcePlug = 0;
+		const ScenePlug *sourcePlug = nullptr;
 		ScenePath source = sourcePath( path, &sourcePlug );
 		return sourcePlug->bound( source );
 	}
@@ -253,7 +253,7 @@ void Group::hashTransform( const ScenePath &path, const Gaffer::Context *context
 	else if( path.size() > 1 ) // "/group/..."
 	{
 		// pass through
-		const ScenePlug *sourcePlug = 0;
+		const ScenePlug *sourcePlug = nullptr;
 		ScenePath source = sourcePath( path, &sourcePlug );
 		h = sourcePlug->transformHash( source );
 	}
@@ -271,7 +271,7 @@ Imath::M44f Group::computeTransform( const ScenePath &path, const Gaffer::Contex
 	}
 	else
 	{
-		const ScenePlug *sourcePlug = 0;
+		const ScenePlug *sourcePlug = nullptr;
 		ScenePath source = sourcePath( path, &sourcePlug );
 		return sourcePlug->transform( source );
 	}
@@ -286,7 +286,7 @@ void Group::hashAttributes( const ScenePath &path, const Gaffer::Context *contex
 	else // "/group/..."
 	{
 		// pass through
-		const ScenePlug *sourcePlug = 0;
+		const ScenePlug *sourcePlug = nullptr;
 		ScenePath source = sourcePath( path, &sourcePlug );
 		h = sourcePlug->attributesHash( source );
 	}
@@ -300,7 +300,7 @@ IECore::ConstCompoundObjectPtr Group::computeAttributes( const ScenePath &path, 
 	}
 	else
 	{
-		const ScenePlug *sourcePlug = 0;
+		const ScenePlug *sourcePlug = nullptr;
 		ScenePath source = sourcePath( path, &sourcePlug );
 		return sourcePlug->attributes( source );
 	}
@@ -315,7 +315,7 @@ void Group::hashObject( const ScenePath &path, const Gaffer::Context *context, c
 	else // "/group/..."
 	{
 		// pass through
-		const ScenePlug *sourcePlug = 0;
+		const ScenePlug *sourcePlug = nullptr;
 		ScenePath source = sourcePath( path, &sourcePlug );
 		h = sourcePlug->objectHash( source );
 	}
@@ -329,7 +329,7 @@ IECore::ConstObjectPtr Group::computeObject( const ScenePath &path, const Gaffer
 	}
 	else
 	{
-		const ScenePlug *sourcePlug = 0;
+		const ScenePlug *sourcePlug = nullptr;
 		ScenePath source = sourcePath( path, &sourcePlug );
 		return sourcePlug->object( source );
 	}
@@ -350,7 +350,7 @@ void Group::hashChildNames( const ScenePath &path, const Gaffer::Context *contex
 	else // "/group/..."
 	{
 		// pass through
-		const ScenePlug *sourcePlug = 0;
+		const ScenePlug *sourcePlug = nullptr;
 		ScenePath source = sourcePath( path, &sourcePlug );
 		h = sourcePlug->childNamesHash( source );
 	}
@@ -371,7 +371,7 @@ IECore::ConstInternedStringVectorDataPtr Group::computeChildNames( const ScenePa
 	}
 	else
 	{
-		const ScenePlug *sourcePlug = 0;
+		const ScenePlug *sourcePlug = nullptr;
 		ScenePath source = sourcePath( path, &sourcePlug );
 		return sourcePlug->childNames( source );
 	}

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -447,7 +447,7 @@ ConstV3fVectorDataPtr Instancer::sourcePoints( const ScenePath &parentPath ) con
 	ConstPrimitivePtr primitive = runTimeCast<const Primitive>( inPlug()->object( parentPath ) );
 	if( !primitive )
 	{
-		return 0;
+		return nullptr;
 	}
 
 	return primitive->variableData<V3fVectorData>( "P" );

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -252,11 +252,11 @@ class InteractiveRender::ChildNamesUpdateTask : public tbb::task
 		{
 		}
 
-		~ChildNamesUpdateTask()
+		~ChildNamesUpdateTask() override
 		{
 		}
 
-		virtual task *execute()
+		task *execute() override
 		{
 			ScenePlug::PathScope pathScope( m_context, m_scenePath );
 
@@ -455,11 +455,11 @@ class InteractiveRender::SceneGraphBuildTask : public tbb::task
 		{
 		}
 
-		~SceneGraphBuildTask()
+		~SceneGraphBuildTask() override
 		{
 		}
 
-		virtual task *execute()
+		task *execute() override
 		{
 			ScenePlug::PathScope pathScope( m_context, m_scenePath );
 
@@ -563,7 +563,7 @@ class InteractiveRender::SceneGraphIteratorFilter : public tbb::filter
 			m_childIndices.push_back( 0 );
 		}
 
-		virtual void *operator()( void *item )
+		void *operator()( void *item ) override
 		{
 			if( m_childIndices.empty() )
 			{
@@ -639,7 +639,7 @@ class InteractiveRender::SceneGraphEvaluatorFilter : public tbb::filter
 		{
 		}
 
-		virtual void *operator()( void *item )
+		void *operator()( void *item ) override
 		{
 			SceneGraph *s = (SceneGraph*)item;
 			ScenePlug::ScenePath path;
@@ -711,7 +711,7 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 		{
 		}
 
-		virtual ~SceneGraphOutputFilter()
+		~SceneGraphOutputFilter() override
 		{
 			// close pending attribute blocks:
 			while( m_attrBlockCounter )
@@ -721,7 +721,7 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 			}
 		}
 
-		virtual void *operator()( void *item )
+		void *operator()( void *item ) override
 		{
 			SceneGraph *s = (SceneGraph*)item;
 			ScenePlug::ScenePath path;

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -787,7 +787,7 @@ class InteractiveRender::SceneGraphOutputFilter : public tbb::thread_bound_filte
 					{
 						renderable->render( m_renderer );
 					}
-					s->m_object = 0;
+					s->m_object = nullptr;
 				}
 			}
 			catch( const std::exception &e )

--- a/src/GafferScene/Preview/InteractiveRender.cpp
+++ b/src/GafferScene/Preview/InteractiveRender.cpp
@@ -529,7 +529,7 @@ class InteractiveRender::SceneGraphUpdateTask : public tbb::task
 		{
 		}
 
-		virtual task *execute()
+		task *execute() override
 		{
 
 			// Figure out if this location belongs in the type

--- a/src/GafferScene/SetFilter.cpp
+++ b/src/GafferScene/SetFilter.cpp
@@ -151,7 +151,7 @@ void SetFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *contex
 	/// of filters. If we manage that, then we should go back to throwing an exception here if
 	/// the context doesn't contain a path. We should then do the same in the PathFilter.
 	typedef IECore::TypedData<ScenePlug::ScenePath> ScenePathData;
-	const ScenePathData *pathData = context->get<ScenePathData>( ScenePlug::scenePathContextName, 0 );
+	const ScenePathData *pathData = context->get<ScenePathData>( ScenePlug::scenePathContextName, nullptr );
 	if( pathData )
 	{
 		const ScenePlug::ScenePath &path = pathData->readable();

--- a/src/GafferSceneModule/LightTweaksBinding.cpp
+++ b/src/GafferSceneModule/LightTweaksBinding.cpp
@@ -88,12 +88,12 @@ class TweakPlugSerialiser : public PlugSerialiser
 
 	public :
 
-		virtual std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const
+		std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const override
 		{
 			return maskedTweakPlugRepr( static_cast<const LightTweaks::TweakPlug *>( graphComponent ), Plug::All & ~Plug::ReadOnly );
 		}
 
-		virtual bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const
+		bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override
 		{
 			// If the parent is dynamic then all the children will need construction.
 			const Plug *parent = child->parent<Plug>();

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -72,7 +72,7 @@ class ExecutableRenderWrapper : public TaskNodeWrapper<ExecutableRender>
 		{
 		}
 
-		virtual IECore::RendererPtr createRenderer() const
+		IECore::RendererPtr createRenderer() const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -86,7 +86,7 @@ class ExecutableRenderWrapper : public TaskNodeWrapper<ExecutableRender>
 			throw IECore::Exception( "No _createRenderer method defined in Python." );
 		}
 
-		virtual void outputWorldProcedural( const ScenePlug *scene, IECore::Renderer *renderer ) const
+		void outputWorldProcedural( const ScenePlug *scene, IECore::Renderer *renderer ) const override
 		{
 			if( this->isSubclassed() )
 			{

--- a/src/GafferSceneModule/ShaderBinding.cpp
+++ b/src/GafferSceneModule/ShaderBinding.cpp
@@ -106,7 +106,7 @@ void reloadShader( Shader &shader )
 class ShaderSerialiser : public GafferBindings::NodeSerialiser
 {
 
-	virtual std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const
+	std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override
 	{
 		const Shader *shader = static_cast<const Shader *>( graphComponent );
 		const std::string shaderName = shader->namePlug()->getValue();

--- a/src/GafferSceneUI/CameraVisualiser.cpp
+++ b/src/GafferSceneUI/CameraVisualiser.cpp
@@ -61,11 +61,11 @@ class CameraVisualiser : public ObjectVisualiser
 		{
 		}
 
-		virtual ~CameraVisualiser()
+		~CameraVisualiser() override
 		{
 		}
 
-		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const
+		IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const override
 		{
 			const IECore::Camera *camera = IECore::runTimeCast<const IECore::Camera>( object );
 			if( !camera )

--- a/src/GafferSceneUI/ClippingPlaneVisualiser.cpp
+++ b/src/GafferSceneUI/ClippingPlaneVisualiser.cpp
@@ -94,11 +94,11 @@ class ClippingPlaneVisualiser : public ObjectVisualiser
 			m_group->addChild( curves );
 		}
 
-		virtual ~ClippingPlaneVisualiser()
+		~ClippingPlaneVisualiser() override
 		{
 		}
 
-		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const
+		IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const override
 		{
 			return m_group;
 		}

--- a/src/GafferSceneUI/CoordinateSystemVisualiser.cpp
+++ b/src/GafferSceneUI/CoordinateSystemVisualiser.cpp
@@ -83,11 +83,11 @@ class CoordinateSystemVisualiser : public ObjectVisualiser
 			m_group->addChild( curves );
 		}
 
-		virtual ~CoordinateSystemVisualiser()
+		~CoordinateSystemVisualiser() override
 		{
 		}
 
-		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const
+		IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const override
 		{
 			return m_group;
 		}

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -94,7 +94,7 @@ class CropWindowTool::Rectangle : public GafferUI::Gadget
 			leaveSignal().connect( boost::bind( &Rectangle::leave, this ) );
 		}
 
-		virtual Imath::Box3f bound() const
+		Imath::Box3f bound() const override
 		{
 			// We draw in raster space so don't have a sensible bound
 			return Box3f();
@@ -158,7 +158,7 @@ class CropWindowTool::Rectangle : public GafferUI::Gadget
 
 	protected :
 
-		virtual void doRender( const Style *style ) const
+		void doRender( const Style *style ) const override
 		{
 			if( m_rectangle.isEmpty() )
 			{

--- a/src/GafferSceneUI/ExternalProceduralVisualiser.cpp
+++ b/src/GafferSceneUI/ExternalProceduralVisualiser.cpp
@@ -59,11 +59,11 @@ class ExternalProceduralVisualiser : public ObjectVisualiser
 		{
 		}
 
-		virtual ~ExternalProceduralVisualiser()
+		~ExternalProceduralVisualiser() override
 		{
 		}
 
-		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const
+		IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const override
 		{
 			const IECore::ExternalProcedural *externalProcedural = IECore::runTimeCast<const IECore::ExternalProcedural>( object );
 

--- a/src/GafferSceneUI/LightVisualiser.cpp
+++ b/src/GafferSceneUI/LightVisualiser.cpp
@@ -87,8 +87,8 @@ class AttributeVisualiserForLights : public AttributeVisualiser
 
 		/// Uses a custom visualisation registered via `registerLightVisualiser()` if one
 		/// is available, if not falls back to a basic point light visualisation.
-		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::CompoundObject *attributes,
-			IECoreGL::ConstStatePtr &state ) const;
+		IECoreGL::ConstRenderablePtr visualise( const IECore::CompoundObject *attributes,
+			IECoreGL::ConstStatePtr &state ) const override;
 
 	protected :
 

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -399,7 +399,7 @@ class SceneGadget::UpdateTask : public tbb::task
 		{
 		}
 
-		virtual task *execute()
+		task *execute() override
 		{
 			ScenePlug::PathScope pathScope( m_sceneGadget->m_context.get(), m_scenePath );
 

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -412,14 +412,14 @@ class GnomonPlane : public GafferUI::Gadget
 			leaveSignal().connect( boost::bind( &GnomonPlane::leave, this ) );
 		}
 
-		Imath::Box3f bound() const
+		Imath::Box3f bound() const override
 		{
 			return Box3f( V3f( 0 ), V3f( 1, 1, 0 ) );
 		}
 
 	protected :
 
-		virtual void doRender( const Style *style ) const
+		void doRender( const Style *style ) const override
 		{
 			if( m_hovering || IECoreGL::Selector::currentSelector() )
 			{
@@ -458,7 +458,7 @@ class GnomonGadget : public GafferUI::Gadget
 
 	protected :
 
-		virtual void doRender( const Style *style ) const
+		void doRender( const Style *style ) const override
 		{
 			const float pixelWidth = 30.0f;
 			const V2i viewport = ancestor<ViewportGadget>()->getViewport();
@@ -653,7 +653,7 @@ class CameraOverlay : public GafferUI::Gadget
 		{
 		}
 
-		virtual Imath::Box3f bound() const
+		Imath::Box3f bound() const override
 		{
 			// we draw in raster space so don't have a sensible bound
 			return Box3f();
@@ -708,7 +708,7 @@ class CameraOverlay : public GafferUI::Gadget
 
 	protected :
 
-		virtual void doRender( const Style *style ) const
+		void doRender( const Style *style ) const override
 		{
 			if( IECoreGL::Selector::currentSelector() || m_resolutionGate.isEmpty() )
 			{

--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -66,7 +66,7 @@ class SelectionTool::DragOverlay : public GafferUI::Gadget
 		{
 		}
 
-		virtual Imath::Box3f bound() const
+		Imath::Box3f bound() const override
 		{
 			// we draw in raster space so don't have a sensible bound
 			return Box3f();
@@ -104,7 +104,7 @@ class SelectionTool::DragOverlay : public GafferUI::Gadget
 
 	protected :
 
-		virtual void doRender( const Style *style ) const
+		void doRender( const Style *style ) const override
 		{
 			if( IECoreGL::Selector::currentSelector() )
 			{

--- a/src/GafferSceneUI/ShaderUI.cpp
+++ b/src/GafferSceneUI/ShaderUI.cpp
@@ -77,13 +77,13 @@ class ShaderPlugAdder : public PlugAdder
 
 	protected :
 
-		bool acceptsPlug( const Plug *plug ) const
+		bool acceptsPlug( const Plug *plug ) const override
 		{
 			vector<Plug *> plugs = showablePlugs( plug );
 			return !plugs.empty();
 		}
 
-		void addPlug( Plug *connectionEndPoint )
+		void addPlug( Plug *connectionEndPoint ) override
 		{
 			vector<Plug *> plugs = showablePlugs( connectionEndPoint );
 			Plug *plug = plugMenuSignal()( "Connect To", plugs );

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -100,7 +100,7 @@ class CapturingMonitor : public Monitor
 		{
 		}
 
-		virtual ~CapturingMonitor()
+		~CapturingMonitor() override
 		{
 		}
 
@@ -111,7 +111,7 @@ class CapturingMonitor : public Monitor
 
 	protected :
 
-		virtual void processStarted( const Process *process )
+		void processStarted( const Process *process ) override
 		{
 			CapturedProcess::Ptr capturedProcess( new CapturedProcess );
 			capturedProcess->type = process->type();
@@ -133,7 +133,7 @@ class CapturingMonitor : public Monitor
 			}
 		}
 
-		virtual void processFinished( const Process *process )
+		void processFinished( const Process *process ) override
 		{
 			Mutex::scoped_lock lock( m_mutex );
 			m_processMap.erase( process );
@@ -254,7 +254,7 @@ class HandlesGadget : public Gadget
 
 	protected :
 
-		virtual void doRender( const Style *style ) const
+		void doRender( const Style *style ) const override
 		{
 			glEnable( GL_DEPTH_TEST );
 			// Render with reversed depth test so

--- a/src/GafferSceneUIModule/SceneHierarchyBinding.cpp
+++ b/src/GafferSceneUIModule/SceneHierarchyBinding.cpp
@@ -248,7 +248,7 @@ class SceneHierarchySetFilter : public SceneHierarchyFilter
 
 	protected :
 
-		virtual void sceneDirtied( const ValuePlug *child )
+		void sceneDirtied( const ValuePlug *child ) override
 		{
 			if(
 				child == getScene()->setNamesPlug() ||
@@ -260,7 +260,7 @@ class SceneHierarchySetFilter : public SceneHierarchyFilter
 			}
 		}
 
-		virtual void contextChanged( const IECore::InternedString &variableName )
+		void contextChanged( const IECore::InternedString &variableName ) override
 		{
 			if( !boost::starts_with( variableName.c_str(), "ui:" ) )
 			{
@@ -269,7 +269,7 @@ class SceneHierarchySetFilter : public SceneHierarchyFilter
 			}
 		}
 
-		virtual void doFilter( vector<Gaffer::PathPtr> &paths ) const
+		void doFilter( vector<Gaffer::PathPtr> &paths ) const override
 		{
 			if( paths.empty() )
 			{
@@ -394,7 +394,7 @@ class SceneHierarchySearchFilter : public SceneHierarchyFilter
 
 	protected :
 
-		virtual void sceneDirtied( const ValuePlug *child )
+		void sceneDirtied( const ValuePlug *child ) override
 		{
 			if( child == getScene()->childNamesPlug() )
 			{
@@ -403,7 +403,7 @@ class SceneHierarchySearchFilter : public SceneHierarchyFilter
 			}
 		}
 
-		virtual void contextChanged( const IECore::InternedString &variableName )
+		void contextChanged( const IECore::InternedString &variableName ) override
 		{
 			if( !boost::starts_with( variableName.c_str(), "ui:" ) )
 			{
@@ -412,7 +412,7 @@ class SceneHierarchySearchFilter : public SceneHierarchyFilter
 			}
 		}
 
-		virtual void doFilter( vector<Gaffer::PathPtr> &paths ) const
+		void doFilter( vector<Gaffer::PathPtr> &paths ) const override
 		{
 			if( m_matchPattern.empty() || paths.empty() )
 			{

--- a/src/GafferUI/BoxIONodeGadget.cpp
+++ b/src/GafferUI/BoxIONodeGadget.cpp
@@ -74,12 +74,12 @@ class BoxIOPlugAdder : public PlugAdder
 
 	protected :
 
-		virtual bool acceptsPlug( const Plug *connectionEndPoint ) const
+		bool acceptsPlug( const Plug *connectionEndPoint ) const override
 		{
 			return connectionEndPoint->direction() == m_boxIO->direction();
 		}
 
-		virtual void addPlug( Plug *connectionEndPoint )
+		void addPlug( Plug *connectionEndPoint ) override
 		{
 			UndoScope undoScope( m_boxIO->ancestor<ScriptNode>() );
 

--- a/src/GafferUI/BoxUI.cpp
+++ b/src/GafferUI/BoxUI.cpp
@@ -65,12 +65,12 @@ class BoxPlugAdder : public PlugAdder
 
 	protected :
 
-		virtual bool acceptsPlug( const Plug *connectionEndPoint ) const
+		bool acceptsPlug( const Plug *connectionEndPoint ) const override
 		{
 			return true;
 		}
 
-		virtual void addPlug( Plug *connectionEndPoint )
+		void addPlug( Plug *connectionEndPoint ) override
 		{
 			UndoScope undoScope( m_box->ancestor<ScriptNode>() );
 

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -56,7 +56,7 @@ using namespace std;
 IE_CORE_DEFINERUNTIMETYPED( Gadget );
 
 Gadget::Gadget( const std::string &name )
-	:	GraphComponent( name ), m_style( 0 ), m_visible( true ), m_enabled( true ), m_highlighted( false ), m_toolTip( "" )
+	:	GraphComponent( name ), m_style( nullptr ), m_visible( true ), m_enabled( true ), m_highlighted( false ), m_toolTip( "" )
 {
 	std::string n = "__Gaffer::Gadget::" + boost::lexical_cast<std::string>( (size_t)this );
 	m_glName = IECoreGL::NameStateComponent::glNameFromName( n, true );
@@ -69,7 +69,7 @@ GadgetPtr Gadget::select( GLuint id )
 	const std::string &name = IECoreGL::NameStateComponent::nameFromGLName( id );
 	if( name.compare( 0, 18, "__Gaffer::Gadget::" ) )
 	{
-		return 0;
+		return nullptr;
 	}
 	std::string address = name.c_str() + 18;
 	size_t a = boost::lexical_cast<size_t>( address );

--- a/src/GafferUI/NodeGadget.cpp
+++ b/src/GafferUI/NodeGadget.cpp
@@ -155,12 +155,12 @@ const Gaffer::Node *NodeGadget::node() const
 
 Nodule *NodeGadget::nodule( const Gaffer::Plug *plug )
 {
-	return 0;
+	return nullptr;
 }
 
 const Nodule *NodeGadget::nodule( const Gaffer::Plug *plug ) const
 {
-	return 0;
+	return nullptr;
 }
 
 Imath::V3f NodeGadget::noduleTangent( const Nodule *nodule ) const

--- a/src/GafferUI/Nodule.cpp
+++ b/src/GafferUI/Nodule.cpp
@@ -117,7 +117,7 @@ NodulePtr Nodule::create( Gaffer::PlugPtr plug )
 		t = IECore::RunTimeTyped::baseTypeId( t );
 	}
 
-	return 0;
+	return nullptr;
 }
 
 void Nodule::registerNodule( const std::string &noduleTypeName, NoduleCreator creator, IECore::TypeId plugType )

--- a/src/GafferUI/PlugGadget.cpp
+++ b/src/GafferUI/PlugGadget.cpp
@@ -48,7 +48,7 @@ using namespace Gaffer;
 IE_CORE_DEFINERUNTIMETYPED( PlugGadget );
 
 PlugGadget::PlugGadget( Gaffer::PlugPtr plug )
-	:	ContainerGadget( defaultName<PlugGadget>() ), m_plug( 0 )
+	:	ContainerGadget( defaultName<PlugGadget>() ), m_plug( nullptr )
 {
 	setPlug( plug );
 }
@@ -127,7 +127,7 @@ void PlugGadget::updateContextConnection()
 		// we only want to be notified of context changes if the plug has an incoming
 		// connection. otherwise context changes are irrelevant and we'd just be slowing
 		// things down by asking for notifications.
-		context = 0;
+		context = nullptr;
 	}
 
 	if( context )

--- a/src/GafferUI/RenderableGadget.cpp
+++ b/src/GafferUI/RenderableGadget.cpp
@@ -72,8 +72,8 @@ static IECore::InternedString g_drawWireframeName( "renderableGadget:drawWirefra
 
 RenderableGadget::RenderableGadget( IECore::VisibleRenderablePtr renderable )
 	: Gadget( defaultName<RenderableGadget>() ),
-	  m_renderable( 0 ),
-	  m_scene( 0 ),
+	  m_renderable( nullptr ),
+	  m_scene( nullptr ),
 	  m_baseState( new IECoreGL::State( true ) ),
 	  m_selectionColor( new IECoreGL::WireframeColorStateComponent( Color4f( 0.466f, 0.612f, 0.741f, 1.0f ) ) ),
 	  m_wireframeOn( new IECoreGL::Primitive::DrawWireframe( true ) ),
@@ -142,7 +142,7 @@ void RenderableGadget::setRenderable( IECore::ConstVisibleRenderablePtr renderab
 	if( renderable!=m_renderable )
 	{
 		m_renderable = renderable;
-		m_scene = 0;
+		m_scene = nullptr;
 		if( m_renderable )
 		{
 			IECoreGL::RendererPtr renderer = new IECoreGL::Renderer;
@@ -152,7 +152,7 @@ void RenderableGadget::setRenderable( IECore::ConstVisibleRenderablePtr renderab
 				m_renderable->render( renderer.get() );
 			}
 			m_scene = renderer->scene();
-			m_scene->setCamera( 0 );
+			m_scene->setCamera( nullptr );
 			applySelection();
 		}
  		requestRender();
@@ -331,7 +331,7 @@ IECore::RunTimeTypedPtr RenderableGadget::dragBegin( GadgetPtr gadget, const Dra
 {
 	if( !m_scene )
 	{
-		return 0;
+		return nullptr;
 	}
 
 	std::string objectUnderMouse = objectAt( event.line );
@@ -354,7 +354,7 @@ IECore::RunTimeTypedPtr RenderableGadget::dragBegin( GadgetPtr gadget, const Dra
 			return dragData;
 		}
 	}
-	return 0;
+	return nullptr;
 }
 
 bool RenderableGadget::dragEnter( GadgetPtr gadget, const DragDropEvent &event )

--- a/src/GafferUI/SplinePlugGadget.cpp
+++ b/src/GafferUI/SplinePlugGadget.cpp
@@ -347,12 +347,12 @@ IECore::RunTimeTypedPtr SplinePlugGadget::dragBegin( GadgetPtr gadget, const But
 {
 	if( gadget!=this )
 	{
-		return 0;
+		return nullptr;
 	}
 
 	if( !m_selection->size() )
 	{
-		return 0;
+		return nullptr;
 	}
 
 	V3f i;
@@ -362,7 +362,7 @@ IECore::RunTimeTypedPtr SplinePlugGadget::dragBegin( GadgetPtr gadget, const But
 		return m_selection;
 	}
 
-	return 0;
+	return nullptr;
 }
 
 bool SplinePlugGadget::dragMove( GadgetPtr gadget, const ButtonEvent &event )

--- a/src/GafferUI/StandardGraphLayout.cpp
+++ b/src/GafferUI/StandardGraphLayout.cpp
@@ -1074,7 +1074,7 @@ bool StandardGraphLayout::connectNodeInternal( GraphGadget *graph, Gaffer::Node 
 	// iterate over the output plugs, connecting them in to the node if we can
 
 	size_t numConnectionsMade = 0;
-	Plug *firstConnectionSrc = 0, *firstConnectionDst = 0;
+	Plug *firstConnectionSrc = nullptr, *firstConnectionDst = nullptr;
 	vector<Plug *> inputPlugs;
 	unconnectedInputPlugs( nodeGadget, inputPlugs );
 	for( vector<Plug *>::const_iterator oIt = outputPlugs.begin(), oEIt = outputPlugs.end(); oIt != oEIt; oIt++ )
@@ -1183,7 +1183,7 @@ size_t StandardGraphLayout::unconnectedInputPlugs( NodeGadget *nodeGadget, std::
 	plugs.clear();
 	for( RecursiveInputPlugIterator it( nodeGadget->node() ); !it.done(); it++ )
 	{
-		if( (*it)->getInput() == 0 and nodeGadget->nodule( it->get() ) )
+		if( (*it)->getInput() == nullptr and nodeGadget->nodule( it->get() ) )
 		{
 			plugs.push_back( it->get() );
 		}
@@ -1199,7 +1199,7 @@ Gaffer::Plug *StandardGraphLayout::correspondingOutput( const Gaffer::Plug *inpu
 	const DependencyNode *dependencyNode = IECore::runTimeCast<const DependencyNode>( input->node() );
 	if( !dependencyNode )
 	{
-		return 0;
+		return nullptr;
 	}
 
 	for( RecursiveOutputPlugIterator it( dependencyNode ); !it.done(); ++it )
@@ -1210,7 +1210,7 @@ Gaffer::Plug *StandardGraphLayout::correspondingOutput( const Gaffer::Plug *inpu
 		}
 	}
 
-	return 0;
+	return nullptr;
 }
 
 void StandardGraphLayout::setConnectionScale( float scale )

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -174,7 +174,7 @@ StandardNodeGadget::StandardNodeGadget( Gaffer::NodePtr node )
 	:	NodeGadget( node ),
 		m_nodeEnabled( true ),
 		m_labelsVisibleOnHover( true ),
-		m_dragDestinationProxy( 0 ),
+		m_dragDestinationProxy( nullptr ),
 		m_userColor( 0 ),
 		m_oval( false )
 {
@@ -638,7 +638,7 @@ Gadget *StandardNodeGadget::closestDragDestinationProxy( const DragDropEvent &ev
 		return nullptr;
 	}
 
-	Gadget *result = 0;
+	Gadget *result = nullptr;
 	float maxDist = Imath::limits<float>::max();
 	for( RecursiveGadgetIterator it( this ); !it.done(); it++ )
 	{

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -110,7 +110,7 @@ class StandardNodeGadget::ErrorGadget : public Gadget
 			m_image->setVisible( m_errors.size() );
 		}
 
-		virtual std::string getToolTip( const IECore::LineSegment3f &position ) const
+		std::string getToolTip( const IECore::LineSegment3f &position ) const override
 		{
 			std::string result = Gadget::getToolTip( position );
 			if( !result.empty() )

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -398,7 +398,7 @@ bool StandardNodule::drop( GadgetPtr gadget, const DragDropEvent &event )
 				// see issue #302.
 				if( connection->dstNodule()->plug() != input )
 				{
-					connection->dstNodule()->plug()->setInput( 0 );
+					connection->dstNodule()->plug()->setInput( nullptr );
 				}
 			}
 
@@ -435,7 +435,7 @@ void StandardNodule::connection( const DragDropEvent &event, Gaffer::PlugPtr &in
 		}
 	}
 
-	input = output = 0;
+	input = output = nullptr;
 	return;
 }
 

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -1127,7 +1127,7 @@ int StandardStyle::g_t1Parameter;
 IECoreGL::Shader *StandardStyle::shader()
 {
 
-	static ShaderPtr g_shader = 0;
+	static ShaderPtr g_shader = nullptr;
 
 	if( !g_shader )
 	{

--- a/src/GafferUI/SwitchUI.cpp
+++ b/src/GafferUI/SwitchUI.cpp
@@ -68,12 +68,12 @@ class SwitchPlugAdder : public PlugAdder
 
 	protected :
 
-		virtual bool acceptsPlug( const Plug *connectionEndPoint ) const
+		bool acceptsPlug( const Plug *connectionEndPoint ) const override
 		{
 			return true;
 		}
 
-		virtual void addPlug( Plug *connectionEndPoint )
+		void addPlug( Plug *connectionEndPoint ) override
 		{
 			UndoScope undoScope( m_switch->ancestor<ScriptNode>() );
 

--- a/src/GafferUI/View.cpp
+++ b/src/GafferUI/View.cpp
@@ -190,7 +190,7 @@ ViewPtr View::create( Gaffer::PlugPtr plug )
 		t = IECore::RunTimeTyped::baseTypeId( t );
 	}
 
-	return 0;
+	return nullptr;
 }
 
 void View::registerView( IECore::TypeId plugType, ViewCreator creator )

--- a/src/GafferUIBindings/GraphGadgetBinding.cpp
+++ b/src/GafferUIBindings/GraphGadgetBinding.cpp
@@ -66,7 +66,7 @@ struct RootChangedSlotCaller
 	}
 };
 
-list connectionGadgets1( GraphGadget &graphGadget, const Gaffer::Plug *plug, const Gaffer::Set *excludedNodes = 0 )
+list connectionGadgets1( GraphGadget &graphGadget, const Gaffer::Plug *plug, const Gaffer::Set *excludedNodes = nullptr )
 {
 	std::vector<ConnectionGadget *> connections;
 	graphGadget.connectionGadgets( plug, connections, excludedNodes );
@@ -79,7 +79,7 @@ list connectionGadgets1( GraphGadget &graphGadget, const Gaffer::Plug *plug, con
 	return l;
 }
 
-list connectionGadgets2( GraphGadget &graphGadget, const Gaffer::Node *node, const Gaffer::Set *excludedNodes = 0 )
+list connectionGadgets2( GraphGadget &graphGadget, const Gaffer::Node *node, const Gaffer::Set *excludedNodes = nullptr )
 {
 	std::vector<ConnectionGadget *> connections;
 	graphGadget.connectionGadgets( node, connections, excludedNodes );

--- a/src/GafferUIBindings/PathListingWidgetBinding.cpp
+++ b/src/GafferUIBindings/PathListingWidgetBinding.cpp
@@ -111,7 +111,7 @@ class StandardColumn : public Column
 		{
 		}
 
-		virtual QVariant data( const Path *path, int role = Qt::DisplayRole ) const
+		QVariant data( const Path *path, int role = Qt::DisplayRole ) const override
 		{
 			switch( role )
 			{
@@ -122,7 +122,7 @@ class StandardColumn : public Column
 			}
 		}
 
-		virtual QVariant headerData( int role = Qt::DisplayRole ) const
+		QVariant headerData( int role = Qt::DisplayRole ) const override
 		{
 			if( role == Qt::DisplayRole )
 			{
@@ -207,7 +207,7 @@ class IconColumn : public Column
 		{
 		}
 
-		virtual QVariant data( const Path *path, int role = Qt::DisplayRole ) const
+		QVariant data( const Path *path, int role = Qt::DisplayRole ) const override
 		{
 			if( role == Qt::DecorationRole )
 			{
@@ -243,7 +243,7 @@ class IconColumn : public Column
 			return QVariant();
 		}
 
-		virtual QVariant headerData( int role = Qt::DisplayRole ) const
+		QVariant headerData( int role = Qt::DisplayRole ) const override
 		{
 			if( role == Qt::DisplayRole )
 			{
@@ -295,7 +295,7 @@ class FileIconColumn : public Column
 		{
 		}
 
-		virtual QVariant data( const Path *path, int role = Qt::DisplayRole ) const
+		QVariant data( const Path *path, int role = Qt::DisplayRole ) const override
 		{
 			if( role == Qt::DecorationRole )
 			{
@@ -321,7 +321,7 @@ class FileIconColumn : public Column
 			return QVariant();
 		}
 
-		virtual QVariant headerData( int role = Qt::DisplayRole ) const
+		QVariant headerData( int role = Qt::DisplayRole ) const override
 		{
 			if( role == Qt::DisplayRole )
 			{
@@ -364,7 +364,7 @@ class PathModel : public QAbstractItemModel
 		{
 		}
 
-		~PathModel()
+		~PathModel() override
 		{
 			delete m_rootItem;
 		}
@@ -471,7 +471,7 @@ class PathModel : public QAbstractItemModel
 		// QAbstractItemModel implementation - this is what Qt cares about
 		///////////////////////////////////////////////////////////////////
 
-		virtual QVariant data( const QModelIndex &index, int role ) const
+		QVariant data( const QModelIndex &index, int role ) const override
 		{
 			if( !index.isValid() )
 			{
@@ -482,7 +482,7 @@ class PathModel : public QAbstractItemModel
 			return item->data( index.column(), role, m_columns );
 		}
 
-		virtual QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const
+		QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const override
 		{
 			if( orientation != Qt::Horizontal )
 			{
@@ -491,7 +491,7 @@ class PathModel : public QAbstractItemModel
 			return m_columns[section]->headerData( role );
 		}
 
-		virtual QModelIndex index( int row, int column, const QModelIndex &parentIndex = QModelIndex() ) const
+		QModelIndex index( int row, int column, const QModelIndex &parentIndex = QModelIndex() ) const override
 		{
 			Item *item = parentIndex.isValid() ? static_cast<Item *>( parentIndex.internalPointer() ) : m_rootItem;
 			if( row >=0 and row < (int)item->childItems( this ).size() and column >=0 and column < (int)m_columns.size() )
@@ -504,7 +504,7 @@ class PathModel : public QAbstractItemModel
 			}
 		}
 
-		virtual QModelIndex parent( const QModelIndex &index ) const
+		QModelIndex parent( const QModelIndex &index ) const override
 		{
 			if( !index.isValid() )
 			{
@@ -520,7 +520,7 @@ class PathModel : public QAbstractItemModel
 			return createIndex( item->parent()->row(), 0, item->parent() );
 		}
 
-		virtual int rowCount( const QModelIndex &parentIndex = QModelIndex() ) const
+		int rowCount( const QModelIndex &parentIndex = QModelIndex() ) const override
 		{
 			Item *item = parentIndex.isValid() ? static_cast<Item *>( parentIndex.internalPointer() ) : m_rootItem;
 			if( item == m_rootItem || !m_flat )
@@ -530,7 +530,7 @@ class PathModel : public QAbstractItemModel
 			return 0;
 		}
 
-		virtual int columnCount( const QModelIndex &parent = QModelIndex() ) const
+		int columnCount( const QModelIndex &parent = QModelIndex() ) const override
 		{
 			return m_columns.size();
 		}
@@ -540,7 +540,7 @@ class PathModel : public QAbstractItemModel
 		// this is how you should sort all other stuff you might generate later".
 		// So that's what we do. We also use a column of < 0 to say "turn off
 		// sorting".
-		virtual void sort( int column, Qt::SortOrder order = Qt::AscendingOrder )
+		void sort( int column, Qt::SortOrder order = Qt::AscendingOrder ) override
 		{
 			m_sortColumn = column;
 			m_sortOrder = order;

--- a/src/GafferUIBindings/PlugAdderBinding.cpp
+++ b/src/GafferUIBindings/PlugAdderBinding.cpp
@@ -99,7 +99,7 @@ struct PlugAdderWrapper : public GadgetWrapper<PlugAdder>
 	{
 	}
 
-	virtual bool acceptsPlug( const Gaffer::Plug *connectionEndPoint ) const
+	bool acceptsPlug( const Gaffer::Plug *connectionEndPoint ) const override
 	{
 		if( this->isSubclassed() )
 		{
@@ -120,7 +120,7 @@ struct PlugAdderWrapper : public GadgetWrapper<PlugAdder>
 		throw IECore::Exception( "No acceptsPlug method defined in Python." );
 	}
 
-	virtual void addPlug( Gaffer::Plug *connectionEndPoint )
+	void addPlug( Gaffer::Plug *connectionEndPoint ) override
 	{
 		if( this->isSubclassed() )
 		{


### PR DESCRIPTION
This PR uses clang-tidy to bring the code up to date with respect to C++11's nullptr and override features. Clang-tidy is ace.