### PR TITLE
CompoundNodule : Remove deprecated constructor arguments

### DIFF
--- a/include/GafferUI/CompoundNodule.h
+++ b/include/GafferUI/CompoundNodule.h
@@ -53,10 +53,7 @@ class CompoundNodule : public Nodule
 
 	public :
 
-		/// \deprecated All arguments except the plug are ignored -
-		/// use plug metadata instead.
-		CompoundNodule( Gaffer::PlugPtr plug, LinearContainer::Orientation orientation=LinearContainer::X,
-			float spacing = 0.0f, LinearContainer::Direction direction=LinearContainer::InvalidDirection );
+		CompoundNodule( Gaffer::PlugPtr plug );
 		virtual ~CompoundNodule();
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::CompoundNodule, CompoundNoduleTypeId, Nodule );

--- a/src/GafferUI/CompoundNodule.cpp
+++ b/src/GafferUI/CompoundNodule.cpp
@@ -50,8 +50,7 @@ IE_CORE_DEFINERUNTIMETYPED( CompoundNodule );
 
 Nodule::NoduleTypeDescription<CompoundNodule> CompoundNodule::g_noduleTypeDescription;
 
-CompoundNodule::CompoundNodule( Gaffer::PlugPtr plug, LinearContainer::Orientation orientation,
-	float spacing, LinearContainer::Direction direction )
+CompoundNodule::CompoundNodule( Gaffer::PlugPtr plug )
 	:	Nodule( plug )
 {
 	addChild( new NoduleLayout( plug ) );

--- a/src/GafferUIBindings/CompoundNoduleBinding.cpp
+++ b/src/GafferUIBindings/CompoundNoduleBinding.cpp
@@ -51,6 +51,6 @@ using namespace GafferUI;
 void GafferUIBindings::bindCompoundNodule()
 {
 	GadgetClass<CompoundNodule>()
-		.def( init<Gaffer::PlugPtr, LinearContainer::Orientation, float, LinearContainer::Direction>( ( arg( "plug" ), arg( "orientation" )=LinearContainer::X, arg( "spacing" ) = 0.0f, arg( "direction" )=LinearContainer::InvalidDirection ) ) )
+		.def( init<Gaffer::PlugPtr>( ( arg( "plug" ) ) ) )
 	;
 }


### PR DESCRIPTION
Breaking Changes :

- CompoundNodule : Removed deprecated constructor arguments.