### PR TITLE
Remove `from __future__ import with_statement`

### DIFF
--- a/python/GafferCortex/ObjectReader.py
+++ b/python/GafferCortex/ObjectReader.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import IECore
 
 import Gaffer

--- a/python/GafferCortex/ObjectWriter.py
+++ b/python/GafferCortex/ObjectWriter.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import os
 
 import IECore

--- a/python/GafferCortexTest/ParameterHandlerTest.py
+++ b/python/GafferCortexTest/ParameterHandlerTest.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import unittest
 
 import IECore

--- a/python/GafferCortexTest/ParameterisedHolderTest.py
+++ b/python/GafferCortexTest/ParameterisedHolderTest.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import os
 import unittest
 import datetime

--- a/python/GafferCortexUI/CompoundParameterValueWidget.py
+++ b/python/GafferCortexUI/CompoundParameterValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import IECore
 
 import GafferUI

--- a/python/GafferCortexUI/CompoundVectorParameterValueWidget.py
+++ b/python/GafferCortexUI/CompoundVectorParameterValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import IECore
 
 import Gaffer

--- a/python/GafferCortexUI/DateTimeParameterValueWidget.py
+++ b/python/GafferCortexUI/DateTimeParameterValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import IECore
 
 import Gaffer

--- a/python/GafferCortexUI/OpDialogue.py
+++ b/python/GafferCortexUI/OpDialogue.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import sys
 import threading
 import traceback

--- a/python/GafferCortexUI/ParameterValueWidget.py
+++ b/python/GafferCortexUI/ParameterValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import IECore
 
 import Gaffer

--- a/python/GafferCortexUI/ParameterisedHolderUI.py
+++ b/python/GafferCortexUI/ParameterisedHolderUI.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import re
 import pipes
 import fnmatch

--- a/python/GafferCortexUI/PresetsOnlyParameterValueWidget.py
+++ b/python/GafferCortexUI/PresetsOnlyParameterValueWidget.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import functools
 
 import IECore

--- a/python/GafferCortexUI/StringParameterValueWidget.py
+++ b/python/GafferCortexUI/StringParameterValueWidget.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import IECore
 
 import Gaffer

--- a/python/GafferScene/ScriptProcedural.py
+++ b/python/GafferScene/ScriptProcedural.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import sys
 
 import IECore

--- a/python/GafferSceneUI/OutputsUI.py
+++ b/python/GafferSceneUI/OutputsUI.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import re
 
 import IECore

--- a/python/GafferTest/ContextVariablesTest.py
+++ b/python/GafferTest/ContextVariablesTest.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import unittest
 import inspect
 

--- a/python/GafferTest/DeleteContextVariablesTest.py
+++ b/python/GafferTest/DeleteContextVariablesTest.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import unittest
 
 import IECore

--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import unittest
 import time
 import datetime

--- a/python/GafferTest/PlugTest.py
+++ b/python/GafferTest/PlugTest.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import unittest
 
 import IECore

--- a/python/GafferTest/StringPlugTest.py
+++ b/python/GafferTest/StringPlugTest.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import os
 import inspect
 import unittest

--- a/python/GafferTest/UndoTest.py
+++ b/python/GafferTest/UndoTest.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import unittest
 
 import IECore

--- a/python/GafferUI/BoolPlugValueWidget.py
+++ b/python/GafferUI/BoolPlugValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import IECore
 
 import Gaffer

--- a/python/GafferUI/CompoundDataPlugValueWidget.py
+++ b/python/GafferUI/CompoundDataPlugValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import IECore
 
 import Gaffer

--- a/python/GafferUI/CompoundPlugValueWidget.py
+++ b/python/GafferUI/CompoundPlugValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import IECore
 
 import Gaffer

--- a/python/GafferUI/EditMenu.py
+++ b/python/GafferUI/EditMenu.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import sys
 import collections
 

--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import IECore
 import IECoreGL
 

--- a/python/GafferUI/IncrementingPlugValueWidget.py
+++ b/python/GafferUI/IncrementingPlugValueWidget.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import Gaffer
 import GafferUI
 

--- a/python/GafferUI/MultiLineStringPlugValueWidget.py
+++ b/python/GafferUI/MultiLineStringPlugValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import Gaffer
 import GafferUI
 

--- a/python/GafferUI/NameWidget.py
+++ b/python/GafferUI/NameWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import re
 
 import Gaffer

--- a/python/GafferUI/NodeMenu.py
+++ b/python/GafferUI/NodeMenu.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import re
 import fnmatch
 import inspect

--- a/python/GafferUI/NumericPlugValueWidget.py
+++ b/python/GafferUI/NumericPlugValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import Gaffer
 import GafferUI
 

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import warnings
 
 import IECore

--- a/python/GafferUI/PathPlugValueWidget.py
+++ b/python/GafferUI/PathPlugValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import IECore
 
 import Gaffer

--- a/python/GafferUI/PathVectorDataPlugValueWidget.py
+++ b/python/GafferUI/PathVectorDataPlugValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import Gaffer
 import GafferUI
 

--- a/python/GafferUI/PathVectorDataWidget.py
+++ b/python/GafferUI/PathVectorDataWidget.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import IECore
 
 import Gaffer

--- a/python/GafferUI/PathWidget.py
+++ b/python/GafferUI/PathWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import os
 import warnings
 

--- a/python/GafferUI/RefreshPlugValueWidget.py
+++ b/python/GafferUI/RefreshPlugValueWidget.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import Gaffer
 import GafferUI
 

--- a/python/GafferUI/StandardNodeUI.py
+++ b/python/GafferUI/StandardNodeUI.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import Gaffer
 import GafferUI
 

--- a/python/GafferUI/StringPlugValueWidget.py
+++ b/python/GafferUI/StringPlugValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import Gaffer
 import GafferUI
 

--- a/python/GafferUI/VectorDataPlugValueWidget.py
+++ b/python/GafferUI/VectorDataPlugValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import Gaffer
 import GafferUI
 

--- a/python/GafferUITest/ContainerWidgetTest.py
+++ b/python/GafferUITest/ContainerWidgetTest.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import unittest
 
 import Gaffer

--- a/python/GafferUITest/StandardGraphLayoutTest.py
+++ b/python/GafferUITest/StandardGraphLayoutTest.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-from __future__ import with_statement
-
 import unittest
 import weakref
 


### PR DESCRIPTION
This was necessary in Python 2.5, but not in 2.6 or later. We now expect a minimum of 2.7.