### PR TITLE
ShadingEngine : Read userData aggregate as array if compatible.

### DIFF
--- a/python/GafferOSLTest/ShadingEngineTest.py
+++ b/python/GafferOSLTest/ShadingEngineTest.py
@@ -52,7 +52,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		vData = IECore.FloatVectorData()
 		floatUserData = IECore.FloatVectorData()
 		colorUserData = IECore.Color3fVectorData()
-		for y in range( 0, divisions. y ) :
+		for y in range( 0, divisions.y ) :
 			for x in range( 0, divisions.x ) :
 				u = float( x ) / float( divisions.x - 1 )
 				v = float( y ) / float( divisions.y - 1 )
@@ -421,6 +421,33 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		for i, c in enumerate( r["Ci"] ) :
 			self.assertEqual( IECore.V3f( *c ), p["P"][i] )
+
+	def testCanReadV3iArrayUserData( self ) :
+
+		s = self.compileShader( os.path.dirname( __file__ ) +  "/shaders/V3iArrayAttributeRead.osl" )
+
+		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
+			IECore.Shader( s, "surface" )
+		] ) )
+
+		p = self.rectanglePoints()
+
+		numPoints = len(p["P"])
+		p["v3i"] = IECore.V3iVectorData( numPoints )
+
+		for i in range( numPoints ) :
+			p["v3i"][i] = IECore.V3i( [i, i + 1 , i + 2 ] )
+
+		r = e.shade( p )
+
+		for i, c in enumerate( r["Ci"] ) :
+			if i < 50:
+				expected = IECore.Color3f( 0.0, i / 100.0, i / 200.0 )
+			else:
+				expected = IECore.Color3f( 1.0, 0.0, 0.0 )
+
+			self.assertEqual( c, expected )
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLTest/shaders/V3iArrayAttributeRead.osl
+++ b/python/GafferOSLTest/shaders/V3iArrayAttributeRead.osl
@@ -1,0 +1,52 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and//or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Image Engine Design Inc nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+shader ReadV3i()
+{
+	int ids[3];
+
+	if ( getattribute( "v3i", ids ) && ids[0] < 50 )
+	{
+
+		Ci = color( 0, (ids[1] - 1) / 100.0 , (ids[2] -2) / 200.0 ) * emission();
+
+	}
+	else
+	{
+		Ci = color( 1, 0, 0 ) * emission();
+	}
+
+}

--- a/src/GafferImage/OpenImageIOAlgo.cpp
+++ b/src/GafferImage/OpenImageIOAlgo.cpp
@@ -200,6 +200,15 @@ DataView::DataView( const IECore::Data *d, bool createUStrings )
 			);
 			data = static_cast<const V3fVectorData *>( d )->baseReadable();
 			break;
+		case V3iVectorDataTypeId :
+			type = TypeDesc(
+				TypeDesc::INT,
+				TypeDesc::VEC3,
+				vecSemantics( static_cast<const V3iVectorData *>( d )->getInterpretation() ),
+				static_cast<const V3iVectorData *>( d )->readable().size()
+			);
+			data = static_cast<const V3iVectorData *> ( d )->baseReadable();
+			break;
 		case Color3fVectorDataTypeId :
 			type = TypeDesc(
 				TypeDesc::FLOAT,

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -228,7 +228,18 @@ class RenderState
 				src += m_pointIndex * it->dataView.type.elementsize();
 			}
 
-			return ShadingSystem::convert_value( value, type, src, it->dataView.type );
+			bool result = ShadingSystem::convert_value( value, type, src, it->dataView.type );
+
+			//! If the convert_value fails then attempt to convert an aggregate (vec2, vec3, vec4, matrix33, matrix44) to an array with the same base type.
+			//! note the aggregate enum is the number of elements
+			//! todo create a PR for OSL
+			if (!result && it->dataView.type.basetype == type.basetype && it->dataView.type.aggregate == type.arraylen)
+			{
+				memcpy (value, src, type.size());
+				result = true;
+			}
+
+			return result;
 		}
 
 		void incrementPointIndex()
@@ -492,6 +503,7 @@ OSL::ShadingSystem *shadingSystem()
 }
 
 } // namespace
+
 
 //////////////////////////////////////////////////////////////////////////
 // ShadingResults


### PR DESCRIPTION
A couple of small changes to support V3i in OSLObject:

* Ensure arrays of V3i are handled in the DataView ctor otherwise they will not be readable in the OSL ShadingEngine. 
* In OSL getattribute  allow reading of aggregate types as arrays of a base type. 

