### PR TITLE
ContextProcessor refactoring

### DIFF
--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -134,8 +134,9 @@ class Context : public IECore::RefCounted
 		/// Removes an entry from the context if it exists
 		void remove( const IECore::InternedString& name );
 
-		/// Removes an entry from the context if it exists
-		void removeMatching( const StringAlgo::MatchPattern& pattern );
+		/// Removes any entries whose names match the space separated patterns
+		/// provided. Matching is performed using `StringAlgo::matchMultiple()`.
+		void removeMatching( const StringAlgo::MatchPattern &pattern );
 
 		/// When a Shared or Borrowed value is changed behind the scenes, this method
 		/// must be called to notify the Context of the change.
@@ -263,6 +264,7 @@ class Context : public IECore::RefCounted
 				void setTime( float timeInSeconds );
 
 				void remove( const IECore::InternedString &name );
+				void removeMatching( const StringAlgo::MatchPattern &pattern );
 
 			private :
 

--- a/include/Gaffer/ContextProcessor.h
+++ b/include/Gaffer/ContextProcessor.h
@@ -38,6 +38,7 @@
 #define GAFFER_CONTEXTPROCESSOR_H
 
 #include "Gaffer/ComputeNode.h"
+#include "Gaffer/Context.h"
 
 namespace Gaffer
 {
@@ -79,8 +80,7 @@ class ContextProcessor : public BaseType
 		void appendAffectedPlugs( DependencyNode::AffectedPlugsContainer &outputs ) const;
 
 		/// Must be implemented to modify context in place.
-		/// \todo Pass `EditableScope` here in place of `Context`.
-		virtual void processContext( Context *context ) const = 0;
+		virtual void processContext( Context::EditableScope &context ) const = 0;
 
 	private :
 

--- a/include/Gaffer/ContextProcessor.h
+++ b/include/Gaffer/ContextProcessor.h
@@ -75,10 +75,8 @@ class ContextProcessor : public BaseType
 		virtual void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const;
 		virtual void compute( ValuePlug *output, const Context *context ) const;
 
-		/// Should be called by derived class affects() methods when the input
-		/// affects their implementation of processContext().
-		void appendAffectedPlugs( DependencyNode::AffectedPlugsContainer &outputs ) const;
-
+		/// Must be implemented to return true if the input is used in `processContext()`.
+		virtual bool affectsContext( const Plug *input ) const = 0;
 		/// Must be implemented to modify context in place.
 		virtual void processContext( Context::EditableScope &context ) const = 0;
 

--- a/include/Gaffer/ContextProcessor.inl
+++ b/include/Gaffer/ContextProcessor.inl
@@ -123,27 +123,26 @@ void ContextProcessor<BaseType>::affects( const Plug *input, DependencyNode::Aff
 			}
 		}
 	}
-}
 
-template<typename BaseType>
-void ContextProcessor<BaseType>::appendAffectedPlugs( DependencyNode::AffectedPlugsContainer &outputs ) const
-{
-	Node *n = const_cast<Node *>( static_cast<const Node *>( this ) );
-	for( OutputPlugIterator it( n ); !it.done(); ++it )
+	if( affectsContext( input ) )
 	{
-		const ValuePlug *valuePlug = IECore::runTimeCast<const ValuePlug>( it->get() );
-		if( 0 == valuePlug->getName().string().compare( 0, 3, "out" ) && oppositePlug( valuePlug ) )
+		Node *n = const_cast<Node *>( static_cast<const Node *>( this ) );
+		for( OutputPlugIterator it( n ); !it.done(); ++it )
 		{
-			if( valuePlug->children().size() )
+			const ValuePlug *valuePlug = IECore::runTimeCast<const ValuePlug>( it->get() );
+			if( 0 == valuePlug->getName().string().compare( 0, 3, "out" ) && oppositePlug( valuePlug ) )
 			{
-				for( ValuePlugIterator cIt( valuePlug ); !cIt.done(); ++cIt )
+				if( valuePlug->children().size() )
 				{
-					outputs.push_back( cIt->get() );
+					for( ValuePlugIterator cIt( valuePlug ); !cIt.done(); ++cIt )
+					{
+						outputs.push_back( cIt->get() );
+					}
 				}
-			}
-			else
-			{
-				outputs.push_back( valuePlug );
+				else
+				{
+					outputs.push_back( valuePlug );
+				}
 			}
 		}
 	}

--- a/include/Gaffer/ContextProcessor.inl
+++ b/include/Gaffer/ContextProcessor.inl
@@ -157,9 +157,8 @@ void ContextProcessor<BaseType>::hash( const ValuePlug *output, const Context *c
 	{
 		if( enabledPlug()->getValue() )
 		{
-			ContextPtr modifiedContext = new Context( *context, Context::Borrowed );
-			processContext( modifiedContext.get() );
-			Context::Scope scopedContext( modifiedContext.get() );
+			Context::EditableScope scope( context );
+			processContext( scope );
 			h = input->hash();
 		}
 		else
@@ -180,9 +179,8 @@ void ContextProcessor<BaseType>::compute( ValuePlug *output, const Context *cont
 	{
 		if( enabledPlug()->getValue() )
 		{
-			ContextPtr modifiedContext = new Context( *context, Context::Borrowed );
-			processContext( modifiedContext.get() );
-			Context::Scope scopedContext( modifiedContext.get() );
+			Context::EditableScope scope( context );
+			processContext( scope );
 			output->setFrom( input );
 		}
 		else

--- a/include/Gaffer/ContextVariables.h
+++ b/include/Gaffer/ContextVariables.h
@@ -62,10 +62,9 @@ class ContextVariables : public ContextProcessor<BaseType>
 		AtomicCompoundDataPlug *extraVariablesPlug();
 		const AtomicCompoundDataPlug *extraVariablesPlug() const;
 
-		void affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const;
-
 	protected :
 
+		virtual bool affectsContext( const Plug *input ) const;
 		virtual void processContext( Context::EditableScope &context ) const;
 
 	private :

--- a/include/Gaffer/ContextVariables.h
+++ b/include/Gaffer/ContextVariables.h
@@ -66,7 +66,7 @@ class ContextVariables : public ContextProcessor<BaseType>
 
 	protected :
 
-		virtual void processContext( Context *context ) const;
+		virtual void processContext( Context::EditableScope &context ) const;
 
 	private :
 

--- a/include/Gaffer/ContextVariables.inl
+++ b/include/Gaffer/ContextVariables.inl
@@ -109,7 +109,7 @@ void ContextVariables<BaseType>::affects( const Plug *input, DependencyNode::Aff
 }
 
 template<typename BaseType>
-void ContextVariables<BaseType>::processContext( Context *context ) const
+void ContextVariables<BaseType>::processContext( Context::EditableScope &context ) const
 {
 	std::string name;
 	for( CompoundDataPlug::MemberPlugIterator it( variablesPlug() ); !it.done(); ++it )
@@ -117,14 +117,14 @@ void ContextVariables<BaseType>::processContext( Context *context ) const
 		IECore::DataPtr data = variablesPlug()->memberDataAndName( it->get(), name );
 		if( data )
 		{
-			context->set( name, data.get() );
+			context.set( name, data.get() );
 		}
 	}
 	IECore::ConstCompoundDataPtr extraVariablesData = extraVariablesPlug()->getValue();
 	const IECore::CompoundDataMap &extraVariables = extraVariablesData->readable();
 	for( IECore::CompoundDataMap::const_iterator it = extraVariables.begin(), eIt = extraVariables.end(); it != eIt; ++it )
 	{
-		context->set( it->first, it->second.get() );
+		context.set( it->first, it->second.get() );
 	}
 }
 

--- a/include/Gaffer/ContextVariables.inl
+++ b/include/Gaffer/ContextVariables.inl
@@ -95,17 +95,9 @@ const AtomicCompoundDataPlug *ContextVariables<BaseType>::extraVariablesPlug() c
 }
 
 template<typename BaseType>
-void ContextVariables<BaseType>::affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const
+bool ContextVariables<BaseType>::affectsContext( const Plug *input ) const
 {
-	ContextProcessor<BaseType>::affects( input, outputs );
-
-	if(
-		variablesPlug()->isAncestorOf( input ) ||
-		input == extraVariablesPlug()
-	)
-	{
-		ContextProcessor<BaseType>::appendAffectedPlugs( outputs );
-	}
+	return variablesPlug()->isAncestorOf( input ) || input == extraVariablesPlug();
 }
 
 template<typename BaseType>

--- a/include/Gaffer/DeleteContextVariables.h
+++ b/include/Gaffer/DeleteContextVariables.h
@@ -57,13 +57,13 @@ class DeleteContextVariables : public ContextProcessor<BaseType>
 		virtual ~DeleteContextVariables();
 
 		StringPlug *variablesPlug();
-		const StringPlug *variablesPlug() const; 
+		const StringPlug *variablesPlug() const;
 
 		void affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const;
 
 	protected :
 
-		virtual void processContext( Context *context ) const;
+		virtual void processContext( Context::EditableScope &context ) const;
 
 	private :
 

--- a/include/Gaffer/DeleteContextVariables.h
+++ b/include/Gaffer/DeleteContextVariables.h
@@ -59,10 +59,9 @@ class DeleteContextVariables : public ContextProcessor<BaseType>
 		StringPlug *variablesPlug();
 		const StringPlug *variablesPlug() const;
 
-		void affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const;
-
 	protected :
 
+		virtual bool affectsContext( const Plug *input ) const;
 		virtual void processContext( Context::EditableScope &context ) const;
 
 	private :

--- a/include/Gaffer/DeleteContextVariables.inl
+++ b/include/Gaffer/DeleteContextVariables.inl
@@ -80,14 +80,9 @@ const StringPlug *DeleteContextVariables<BaseType>::variablesPlug() const
 }
 
 template<typename BaseType>
-void DeleteContextVariables<BaseType>::affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const
+bool DeleteContextVariables<BaseType>::affectsContext( const Plug *input ) const
 {
-	ContextProcessor<BaseType>::affects( input, outputs );
-
-	if( input == variablesPlug() )
-	{
-		ContextProcessor<BaseType>::appendAffectedPlugs( outputs );
-	}
+	return input == variablesPlug();
 }
 
 template<typename BaseType>

--- a/include/Gaffer/DeleteContextVariables.inl
+++ b/include/Gaffer/DeleteContextVariables.inl
@@ -91,9 +91,9 @@ void DeleteContextVariables<BaseType>::affects( const Plug *input, DependencyNod
 }
 
 template<typename BaseType>
-void DeleteContextVariables<BaseType>::processContext( Context *context ) const
+void DeleteContextVariables<BaseType>::processContext( Context::EditableScope &context ) const
 {
-	context->removeMatching( variablesPlug()->getValue() );
+	context.removeMatching( variablesPlug()->getValue() );
 }
 
 } // namespace Gaffer

--- a/include/Gaffer/TimeWarp.h
+++ b/include/Gaffer/TimeWarp.h
@@ -65,7 +65,7 @@ class TimeWarp : public ContextProcessor<BaseType>
 
 	protected :
 
-		virtual void processContext( Context *context ) const;
+		virtual void processContext( Context::EditableScope &context ) const;
 
 };
 

--- a/include/Gaffer/TimeWarp.h
+++ b/include/Gaffer/TimeWarp.h
@@ -61,10 +61,9 @@ class TimeWarp : public ContextProcessor<BaseType>
 		FloatPlug *offsetPlug();
 		const FloatPlug *offsetPlug() const;
 
-		void affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const;
-
 	protected :
 
+		virtual bool affectsContext( const Plug *input ) const;
 		virtual void processContext( Context::EditableScope &context ) const;
 
 };

--- a/include/Gaffer/TimeWarp.inl
+++ b/include/Gaffer/TimeWarp.inl
@@ -94,14 +94,9 @@ const FloatPlug *TimeWarp<BaseType>::offsetPlug() const
 }
 
 template<typename BaseType>
-void TimeWarp<BaseType>::affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const
+bool TimeWarp<BaseType>::affectsContext( const Plug *input ) const
 {
-	ContextProcessor<BaseType>::affects( input, outputs );
-
-	if( input == speedPlug() || input == offsetPlug() )
-	{
-		ContextProcessor<BaseType>::appendAffectedPlugs( outputs );
-	}
+	return input == speedPlug() || input == offsetPlug();
 }
 
 template<typename BaseType>

--- a/include/Gaffer/TimeWarp.inl
+++ b/include/Gaffer/TimeWarp.inl
@@ -105,14 +105,15 @@ void TimeWarp<BaseType>::affects( const Plug *input, DependencyNode::AffectedPlu
 }
 
 template<typename BaseType>
-void TimeWarp<BaseType>::processContext( Context *context ) const
+void TimeWarp<BaseType>::processContext( Context::EditableScope &context ) const
 {
 	float frame;
 	{
-		typename TimeWarpTraits<BaseType>::TimeScope timeScope( context );
-		frame = context->getFrame() * speedPlug()->getValue() + offsetPlug()->getValue();
+		const Context *c = Context::current();
+		typename TimeWarpTraits<BaseType>::TimeScope timeScope( c );
+		frame = c->getFrame() * speedPlug()->getValue() + offsetPlug()->getValue();
 	}
-	context->setFrame( frame );
+	context.setFrame( frame );
 }
 
 } // namespace Gaffer

--- a/src/Gaffer/Context.cpp
+++ b/src/Gaffer/Context.cpp
@@ -586,6 +586,11 @@ void Context::EditableScope::remove( const IECore::InternedString &name )
 	m_context->remove( name );
 }
 
+void Context::EditableScope::removeMatching( const StringAlgo::MatchPattern &pattern )
+{
+	m_context->removeMatching( pattern );
+}
+
 const Context *Context::current()
 {
 	ContextStack &stack = g_threadContexts.local();


### PR DESCRIPTION
This tidies things up a little, and moves us closer to being able to remove the deprecated `Ownership` argument from the Context copy constructor. Once we can do that, we can look at optimising `Context::EditableScope` further.