### PR TITLE
Menu : Fix search when user enters special regex characters

### DIFF
--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -460,11 +460,10 @@ class Menu( GafferUI.Widget ) :
 			self.__searchLine.setFocus()
 			self.__searchMenu.setUpdatesEnabled( True )
 
-	def __matchingActions( self, searchText, path = "" ) :
+	def __matchingActions( self, searchText ) :
 
 		results = {}
-		# find all actions matching a case-insensitive regex
-		matcher = re.compile( "".join( [ "[%s|%s]" % ( c.upper(), c.lower() ) for c in searchText ] ) )
+		matcher = re.compile( re.escape( searchText ), re.IGNORECASE )
 
 		for name in self.__searchStructure :
 


### PR DESCRIPTION
For instance, accidentally entering "\" was leading to the following error being reported to the shell :

```
Traceback (most recent call last):
  File "/Users/john/dev/build/gaffer/python/Gaffer/WeakMethod.py", line 67, in __call__
    return m( *args, **kwArgs )
  File "/Users/john/dev/build/gaffer/python/GafferUI/Menu.py", line 419, in __updateSearchMenu
    matched = self.__matchingActions( str(text) )
  File "/Users/john/dev/build/gaffer/python/GafferUI/Menu.py", line 467, in __matchingActions
    matcher = re.compile( "".join( [ "[%s|%s]" % ( c.upper(), c.lower() ) for c in searchText ] ) )
  File "/Users/john/dev/build/gaffer/lib/Python.framework/Versions/Current/lib/python2.7/re.py", line 194, in compile
    return _compile(pattern, flags)
  File "/Users/john/dev/build/gaffer/lib/Python.framework/Versions/Current/lib/python2.7/re.py", line 251, in _compile
    raise error, v # invalid expression
sre_constants.error: unexpected end of regular expression
```

Also removed unused argument to `__matchingActions()` method.