### PR TITLE
Merge tweaks

### DIFF
--- a/python/GafferImageUI/MergeUI.py
+++ b/python/GafferImageUI/MergeUI.py
@@ -110,6 +110,8 @@ Gaffer.Metadata.registerNode(
 			"preset:Min", GafferImage.Merge.Operation.Min,
 			"preset:Max", GafferImage.Merge.Operation.Max,
 
+			"userDefault", GafferImage.Merge.Operation.Over,
+
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
 		],


### PR DESCRIPTION
- Use "A/B" terminology on nodule labels.
- Default new Merge nodes to "over" mode by default.

I still think this node should be called Composite, but I've resisted the temptation to rename it for now.