### PR TITLE
GafferUI::ReferenceUI : __duplicateAsBox now works correctly inside boxes

### DIFF
--- a/python/GafferUI/ReferenceUI.py
+++ b/python/GafferUI/ReferenceUI.py
@@ -175,7 +175,7 @@ def __duplicateAsBox( nodeGraph, node ) :
 	with Gaffer.UndoScope( script ) :
 
 		box = Gaffer.Box( node.getName() + "Copy" )
-		script.addChild( box )
+		node.parent().addChild( box )
 
 		graphGadget = nodeGraph.graphGadget()
 		graphGadget.getLayout().positionNode(


### PR DESCRIPTION
Based on the succeeding call which positions the new box with a position next to the reference, I assume the new box should be placed under the same parent as the reference, rather than in the root of the script.  This confused me enough that I didn't realize it was even working.