### PR TITLE
ScriptNode : Fix isExecuting() when loading References

### DIFF
--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -706,6 +706,8 @@ bool ScriptNode::executeInternal( const std::string &serialisation, Node *parent
 	}
 	DirtyPropagationScope dirtyScope;
 	bool result = false;
+	bool wasExecuting = m_executing;
+
 	m_executing = true;
 	try
 	{
@@ -714,10 +716,10 @@ bool ScriptNode::executeInternal( const std::string &serialisation, Node *parent
 	}
 	catch( ... )
 	{
-		m_executing = false;
+		m_executing = wasExecuting;
 		throw;
 	}
-	m_executing = false;
+	m_executing = wasExecuting;
 	return result;
 }
 


### PR DESCRIPTION
ScriptNode.isExecuting() was switching from True to False during script loading
when the script included References.
This changes executeInternal() so that it reverts to the previous state,
as opposed to resetting it to False.