### PR TITLE
Display node tidy up

### DIFF
--- a/include/GafferImage/Display.h
+++ b/include/GafferImage/Display.h
@@ -51,7 +51,6 @@ namespace GafferImage
 
 IE_CORE_FORWARDDECLARE( GafferDisplayDriver )
 
-/// \todo Remove portPlug() and the internal server
 /// \todo Pass GafferDisplayDriver rather than IECore::DisplayDriver
 /// in setDriver/getDriver/driverCreatedSignal.
 class Display : public ImageNode
@@ -63,9 +62,6 @@ class Display : public ImageNode
 
 		Display( const std::string &name = defaultName<Display>() );
 		~Display() override;
-
-		Gaffer::IntPlug *portPlug();
-		const Gaffer::IntPlug *portPlug() const;
 
 		/// Sets the driver used to provide the
 		/// image to this node.
@@ -116,15 +112,11 @@ class Display : public ImageNode
 
 	private :
 
-		IECore::DisplayDriverServerPtr m_server;
 		GafferDisplayDriverPtr m_driver;
 
 		Gaffer::IntPlug *updateCountPlug();
 		const Gaffer::IntPlug *updateCountPlug() const;
 
-		void plugSet( Gaffer::Plug *plug );
-		void setupServer();
-		void driverCreated( IECore::DisplayDriver *driver );
 		void setupDriver( GafferDisplayDriverPtr driver );
 		void dataReceived();
 		void imageReceived();

--- a/include/GafferImage/Display.h
+++ b/include/GafferImage/Display.h
@@ -51,8 +51,6 @@ namespace GafferImage
 
 IE_CORE_FORWARDDECLARE( GafferDisplayDriver )
 
-/// \todo Pass GafferDisplayDriver rather than IECore::DisplayDriver
-/// in setDriver/getDriver/driverCreatedSignal.
 class Display : public ImageNode
 {
 

--- a/include/GafferImage/Display.h
+++ b/include/GafferImage/Display.h
@@ -65,9 +65,7 @@ class Display : public ImageNode
 
 		/// Sets the driver used to provide the
 		/// image to this node.
-		void setDriver( IECore::DisplayDriverPtr driver );
-		/// \todo Default copy to false and remove method above
-		void setDriver( IECore::DisplayDriverPtr driver, bool copy );
+		void setDriver( IECore::DisplayDriverPtr driver, bool copy = false );
 		IECore::DisplayDriver *getDriver();
 		const IECore::DisplayDriver *getDriver() const;
 

--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -39,6 +39,8 @@
 
 #include <functional>
 
+#include "GafferImage/Display.h"
+
 #include "GafferImageUI/ImageView.h"
 
 #include "GafferSceneUI/TypeIds.h"
@@ -84,6 +86,9 @@ class ShaderView : public GafferImageUI::ImageView
 		typedef std::pair<std::string, std::string> PrefixAndName;
 		typedef std::map<PrefixAndName, Gaffer::NodePtr> Scenes;
 
+		GafferImage::Display *display();
+		const GafferImage::Display *display() const;
+
 		void viewportVisibilityChanged();
 
 		void plugSet( Gaffer::Plug *plug );
@@ -96,6 +101,8 @@ class ShaderView : public GafferImageUI::ImageView
 		void updateRendererState();
 		void updateScene();
 		void preRender();
+
+		void driverCreated( IECore::DisplayDriver *driver, const IECore::CompoundData *parameters );
 
 		bool m_framed;
 		Gaffer::NodePtr m_imageConverter;

--- a/python/GafferSceneTest/OutputsTest.py
+++ b/python/GafferSceneTest/OutputsTest.py
@@ -157,5 +157,15 @@ class OutputsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( g["output:Interactive/Beauty"].getName(), "beauty" )
 		self.assertTrue( g["output:Batch/Beauty"].getName().endswith( "displaysBeforePlugRename/beauty/beauty.0001.exr" ) )
 
+	def testColonInParameterName( self ) :
+
+		output = IECore.Display( "name", "type", "data", { "test:paramA" : 1 } )
+
+		outputs = GafferScene.Outputs()
+		outputs.addOutput( "test", output )
+		self.assertTrue( "test_paramA" in outputs["outputs"][0]["parameters"] )
+
+		self.assertEqual( outputs["out"]["globals"].getValue()["output:test"], output )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/CompoundDataPlugTest.py
+++ b/python/GafferTest/CompoundDataPlugTest.py
@@ -447,5 +447,20 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( v, d )
 		self.assertEqual( n, "test" )
 
+	def testNonAlphanumericNames( self ) :
+
+		p = Gaffer.CompoundDataPlug()
+		p.addMembers(
+			IECore.CompoundData( {
+				"test:A" : 10,
+				"@j" : 20
+			} ),
+			useNameAsPlugName = True,
+		)
+
+		self.assertEqual( set( p.keys() ), { "test_A", "_j" } )
+		self.assertEqual( p["test_A"]["value"].getValue(), 10 )
+		self.assertEqual( p["_j"]["value"].getValue(), 20 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/CompoundDataPlug.cpp
+++ b/src/Gaffer/CompoundDataPlug.cpp
@@ -205,6 +205,7 @@ void CompoundDataPlug::addMembers( const IECore::CompoundData *parameters, bool 
 		if( useNameAsPlugName )
 		{
 			plugName = it->first;
+			std::replace_if( plugName.begin(), plugName.end(), []( char c ) { return !::isalnum( c ); }, '_' );
 		}
 		addMember( it->first, it->second.get(), plugName );
 	}

--- a/src/GafferImage/Display.cpp
+++ b/src/GafferImage/Display.cpp
@@ -364,11 +364,6 @@ Node::UnaryPlugSignal &Display::imageReceivedSignal()
 	return s;
 }
 
-void Display::setDriver( IECore::DisplayDriverPtr driver )
-{
-	setDriver( driver, false );
-}
-
 void Display::setDriver( IECore::DisplayDriverPtr driver, bool copy )
 {
 	GafferDisplayDriver *gafferDisplayDriver = runTimeCast<GafferDisplayDriver>( driver.get() );

--- a/src/GafferImage/Display.cpp
+++ b/src/GafferImage/Display.cpp
@@ -37,13 +37,13 @@
 
 #include <memory>
 
+#include "tbb/spin_mutex.h"
+
 #include "boost/bind.hpp"
 #include "boost/bind/placeholders.hpp"
 #include "boost/lexical_cast.hpp"
 #include "boost/multi_array.hpp"
 
-#include "IECore/LRUCache.h"
-#include "IECore/DisplayDriverServer.h"
 #include "IECore/DisplayDriver.h"
 #include "IECore/MessageHandler.h"
 #include "IECore/BoxOps.h"
@@ -59,22 +59,6 @@ using namespace Imath;
 using namespace IECore;
 using namespace Gaffer;
 using namespace GafferImage;
-
-//////////////////////////////////////////////////////////////////////////
-// Implementation of a cache of DisplayDriverServers. We use the cache
-// as many nodes may want to use the same port number, and this allows us
-// to share the servers between the nodes.
-//////////////////////////////////////////////////////////////////////////
-
-typedef LRUCache<int, DisplayDriverServerPtr> DisplayDriverServerCache;
-
-static DisplayDriverServerPtr cacheGetter( int key, size_t &cost )
-{
-	cost = 1;
-	return new DisplayDriverServer( key );
-}
-
-static DisplayDriverServerCache g_serverCache( cacheGetter, 10 );
 
 //////////////////////////////////////////////////////////////////////////
 // Implementation of a DisplayDriver to support the node itself
@@ -327,21 +311,6 @@ Display::Display( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 
-	addChild(
-		new IntPlug(
-			"port",
-			Plug::In,
-			1559,
-			1,
-			65535,
-			// disabling input connections because they could be used
-			// to create a port number which changes with context. we
-			// can't allow that because we can only have a single server
-			// associated with a given node.
-			Plug::Default & ~Plug::AcceptsInputs
-		)
-	);
-
 	// This plug is incremented when new data is received, triggering dirty signals
 	// and prompting reevaluation in the viewer.
 	addChild(
@@ -354,41 +323,27 @@ Display::Display( const std::string &name )
 			Plug::Default & ~Plug::Serialisable
 		)
 	);
-
-	plugSetSignal().connect( boost::bind( &Display::plugSet, this, ::_1 ) );
-	driverCreatedSignal().connect( boost::bind( &Display::driverCreated, this, ::_1 ) );
-	setupServer();
 }
 
 Display::~Display()
 {
 }
 
-Gaffer::IntPlug *Display::portPlug()
-{
-	return getChild<IntPlug>( g_firstPlugIndex );
-}
-
-const Gaffer::IntPlug *Display::portPlug() const
-{
-	return getChild<IntPlug>( g_firstPlugIndex );
-}
-
 Gaffer::IntPlug *Display::updateCountPlug()
 {
-	return getChild<IntPlug>( g_firstPlugIndex + 1 );
+	return getChild<IntPlug>( g_firstPlugIndex );
 }
 
 const Gaffer::IntPlug *Display::updateCountPlug() const
 {
-	return getChild<IntPlug>( g_firstPlugIndex + 1 );
+	return getChild<IntPlug>( g_firstPlugIndex );
 }
 
 void Display::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	ImageNode::affects( input, outputs );
 
-	if( input == portPlug() || input == updateCountPlug() )
+	if( input == updateCountPlug() )
 	{
 		for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
 		{
@@ -539,60 +494,6 @@ IECore::ConstFloatVectorDataPtr Display::computeChannelData( const std::string &
 		);
 	}
 	return channelData;
-}
-
-void Display::plugSet( Gaffer::Plug *plug )
-{
-	if( plug == portPlug() )
-	{
-		setupServer();
-	}
-}
-
-void Display::setupServer()
-{
-	if( executeOnUIThreadSignal().empty() )
-	{
-		// If the executeOnUIThreadSignal is empty,
-		// it means that GafferImageUI hasn't
-		// been imported (see DisplayUI.py).
-		// If there's no UI then there's no point
-		// running a server because no-one will
-		// be looking anyway.
-		//
-		// This allows us to avoid confusing error output
-		// when the script is loaded in a separate process
-		// to do a local render dispatch, and the
-		// Display node trys to reuse the port that
-		// is already in use in the main GUI process.
-		return;
-	}
-
-	try
-	{
-		m_server = g_serverCache.get( portPlug()->getValue() );
-	}
-	catch( const std::exception &e )
-	{
-		m_server = nullptr;
-		g_serverCache.erase( portPlug()->getValue() );
-		msg( Msg::Error, "Display::setupServer", e.what() );
-	}
-}
-
-void Display::driverCreated( IECore::DisplayDriver *driver )
-{
-	GafferDisplayDriver *gafferDisplayDriver = runTimeCast<GafferDisplayDriver>( driver );
-	if( !gafferDisplayDriver )
-	{
-		return;
-	}
-
-	const StringData *portNumber = gafferDisplayDriver->parameters()->member<StringData>( "displayPort" );
-	if( portNumber && boost::lexical_cast<int>( portNumber->readable() ) == portPlug()->getValue() )
-	{
-		setupDriver( gafferDisplayDriver );
-	}
 }
 
 void Display::setupDriver( GafferDisplayDriverPtr driver )

--- a/src/GafferImageModule/CatalogueBinding.cpp
+++ b/src/GafferImageModule/CatalogueBinding.cpp
@@ -214,7 +214,7 @@ void GafferImageModule::bindCatalogue()
 
 	{
 		scope s = GafferBindings::DependencyNodeClass<Display>()
-			.def( "setDriver", (void (Display::*)( IECore::DisplayDriverPtr, bool ))&Display::setDriver, ( arg( "driver" ), arg( "copy" ) = false ) )
+			.def( "setDriver", &Display::setDriver, ( arg( "driver" ), arg( "copy" ) = false ) )
 			.def( "getDriver", (IECore::DisplayDriver *(Display::*)())&Display::getDriver, return_value_policy<CastToIntrusivePtr>() )
 			.def( "driverCreatedSignal", &Display::driverCreatedSignal, return_value_policy<reference_existing_object>() ).staticmethod( "driverCreatedSignal" )
 			.def( "imageReceivedSignal", &Display::imageReceivedSignal, return_value_policy<reference_existing_object>() ).staticmethod( "imageReceivedSignal" )


### PR DESCRIPTION
This is a followup to all the recent Catalogue work, cleaning up the few things that we couldn't change at the time due to needing to roll it out in the current major version. The main change is that Display nodes no longer manage DisplayDriverServers at all, removing any possibility of the dreaded resource clashes over port number of old (see #409).

This requires https://github.com/ImageEngine/cortex/pull/600.