### PR TITLE
StandardConnectionGadget : Fix connection drawing glitch

### DIFF
--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -359,7 +359,7 @@ bool StandardConnectionGadget::dragEnter( const DragDropEvent &event )
 
 bool StandardConnectionGadget::dragMove( const DragDropEvent &event )
 {
-	updateDragEndPoint( event.line.p0, V3f( 0 ) );
+	updateDragEndPoint( V3f( event.line.p0.x, event.line.p0.y, 0.0f ), V3f( 0 ) );
 	return true;
 }
 


### PR DESCRIPTION
This was fixed for connections drawn by PlugAdders and StandardNodules in  5c46f0cd2b8f54ec7fe6b4c49c5b761b594dd3c2, but remained in StandardConnectionGadget. This should finally fix #2156.

We should probably change the connection rendering API to work with V2f, and then this bug would have been impossible.