### PR TITLE
CollectScenes : Add "root" plug

### DIFF
--- a/include/GafferScene/CollectScenes.h
+++ b/include/GafferScene/CollectScenes.h
@@ -65,6 +65,9 @@ class CollectScenes : public SceneProcessor
 		Gaffer::StringPlug *rootNameVariablePlug();
 		const Gaffer::StringPlug *rootNameVariablePlug() const;
 
+		Gaffer::StringPlug *sourceRootPlug();
+		const Gaffer::StringPlug *sourceRootPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :

--- a/python/GafferSceneTest/CollectScenesTest.py
+++ b/python/GafferSceneTest/CollectScenesTest.py
@@ -163,5 +163,96 @@ class CollectScenesTest( GafferSceneTest.SceneTestCase ) :
 			)
 		)
 
+	def testCollectObject( self ) :
+
+		sphere = GafferScene.Sphere()
+		sphere["sets"].setValue( "sphereSet" )
+
+		collect = GafferScene.CollectScenes()
+		collect["in"].setInput( sphere["out"] )
+		collect["rootNames"].setValue( IECore.StringVectorData( [ "test" ] ) )
+		collect["sourceRoot"].setValue( "sphere" )
+
+		self.assertPathHashesEqual( sphere["out"], "/sphere", collect["out"], "/test" )
+		self.assertEqual( sphere["out"].object( "/sphere" ), collect["out"].object( "/test" ) )
+
+		self.assertEqual( collect["out"].set( "sphereSet" ).value.paths(), [ "/test" ] )
+
+	def testRoot( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["sphere"] = GafferScene.Sphere()
+		script["sphere"]["sets"].setValue( "sphereSet" )
+
+		script["group"] = GafferScene.Group()
+		script["group"]["in"].setInput( script["sphere"]["out"] )
+
+		script["cube"] = GafferScene.Cube()
+		script["cube"]["sets"].setValue( "cubeSet" )
+
+		script["switch"] = GafferScene.SceneSwitch()
+		script["switch"]["in"][0].setInput( script["group"]["out"] )
+		script["switch"]["in"][1].setInput( script["cube"]["out"] )
+
+		script["collect"] = GafferScene.CollectScenes()
+		script["collect"]["in"].setInput( script["switch"]["out"] )
+		script["collect"]["rootNames"].setValue( IECore.StringVectorData( [ "0", "1", "2", "3" ] ) )
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression( inspect.cleandoc(
+			"""
+			root = context.get( "collect:rootName", "0" )
+			parent["switch"]["index"] = int( root ) > 1
+			parent["collect"]["sourceRoot"] = {
+				"0" : "",
+				"1" : "/group",
+				"2" : "/",
+				"3" : "/cube"
+			}[root]
+			"""
+		) )
+
+		self.assertEqual( script["collect"]["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "0", "1", "2", "3" ] ) )
+
+		self.assertEqual( script["collect"]["out"].childNames( "/0" ), IECore.InternedStringVectorData( [ "group" ] ) )
+		self.assertEqual( script["collect"]["out"].childNames( "/1" ), IECore.InternedStringVectorData( [ "sphere" ] ) )
+		self.assertEqual( script["collect"]["out"].childNames( "/2" ), IECore.InternedStringVectorData( [ "cube" ] ) )
+		self.assertEqual( script["collect"]["out"].childNames( "/3" ), IECore.InternedStringVectorData() )
+
+		self.assertEqual( script["collect"]["out"].object( "/0" ), IECore.NullObject() )
+		self.assertEqual( script["collect"]["out"].object( "/1" ), IECore.NullObject() )
+		self.assertEqual( script["collect"]["out"].object( "/2" ), IECore.NullObject() )
+		self.assertEqual( script["collect"]["out"].object( "/3" ), script["cube"]["out"].object( "/cube" ) )
+
+		self.assertEqual( script["collect"]["out"].childNames( "/0/group" ), IECore.InternedStringVectorData( [ "sphere" ] ) )
+		self.assertEqual( script["collect"]["out"].childNames( "/1/sphere" ), IECore.InternedStringVectorData() )
+		self.assertEqual( script["collect"]["out"].childNames( "/2/cube" ), IECore.InternedStringVectorData() )
+
+		self.assertEqual( script["collect"]["out"].object( "/0/group" ), IECore.NullObject() )
+		self.assertEqual( script["collect"]["out"].object( "/1/sphere" ), script["sphere"]["out"].object( "/sphere" ) )
+		self.assertEqual( script["collect"]["out"].object( "/2/cube" ), script["cube"]["out"].object( "/cube" ) )
+
+		self.assertEqual( script["collect"]["out"].childNames( "/0/group/sphere" ), IECore.InternedStringVectorData() )
+		self.assertEqual( script["collect"]["out"].object( "/0/group/sphere" ), script["sphere"]["out"].object( "/sphere" ) )
+
+		self.assertEqual( script["collect"]["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "sphereSet", "cubeSet" ] ) )
+
+		self.assertEqual(
+			set( script["collect"]["out"].set( "sphereSet" ).value.paths() ),
+			{
+				"/0/group/sphere",
+				"/1/sphere",
+			}
+		)
+
+		self.assertEqual(
+			set( script["collect"]["out"].set( "cubeSet" ).value.paths() ),
+			{
+				"/2/cube",
+				"/3",
+			}
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/CollectScenesUI.py
+++ b/python/GafferSceneUI/CollectScenesUI.py
@@ -85,6 +85,24 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"sourceRoot" : [
+
+			"description",
+			"""
+			Specifies the root of the subtree to be copied from the input
+			scene. The default value causes the whole scene to be collected.
+
+			The rootName variable may be used in expressions and string
+			substitutions for this plug, allowing different subtrees to be
+			collected for each root name in the output.
+
+			> Tip :
+			> By specifying a leaf location as the root, it is possible to
+			> collect single objects from the input scene.
+			"""
+
+		],
+
 	}
 
 )

--- a/src/GafferScene/CollectScenes.cpp
+++ b/src/GafferScene/CollectScenes.cpp
@@ -63,10 +63,10 @@ class SceneScope : public Context::EditableScope
 		{
 		}
 
-		SceneScope( const Context *context, const InternedString &rootNameVariable, const ScenePlug::ScenePath &downstreamPath )
+		SceneScope( const Context *context, const InternedString &rootNameVariable, const ScenePlug::ScenePath &downstreamPath, const StringPlug *sourceRootPlug )
 			:	EditableScope( context ), m_rootNameVariable( rootNameVariable )
 		{
-			setScenePath( downstreamPath );
+			setScenePath( downstreamPath, sourceRootPlug );
 		}
 
 		void setRootName( const InternedString &name )
@@ -74,10 +74,15 @@ class SceneScope : public Context::EditableScope
 			set( m_rootNameVariable, name.string() );
 		}
 
-		void setScenePath( const ScenePlug::ScenePath &downstreamPath )
+		void setScenePath( const ScenePlug::ScenePath &downstreamPath, const StringPlug *sourceRootPlug )
 		{
 			setRootName( downstreamPath[0] );
-			ScenePlug::ScenePath upstreamPath( downstreamPath.begin() + 1, downstreamPath.end() );
+			ScenePlug::ScenePath upstreamPath;
+			// We evaluate the sourceRootPlug _after_ setting the root name,
+			// so that users can use the root name in expressions and
+			// substitutions.
+			ScenePlug::stringToPath( sourceRootPlug->getValue(), upstreamPath );
+			upstreamPath.insert( upstreamPath.end(), downstreamPath.begin() + 1, downstreamPath.end() );
 			set( ScenePlug::scenePathContextName, upstreamPath );
 		}
 
@@ -104,6 +109,7 @@ CollectScenes::CollectScenes( const std::string &name )
 
 	addChild( new StringVectorDataPlug( "rootNames", Plug::In, new StringVectorData() ) );
 	addChild( new StringPlug( "rootNameVariable", Plug::In, "collect:rootName" ) );
+	addChild( new StringPlug( "sourceRoot", Plug::In, "/" ) );
 }
 
 CollectScenes::~CollectScenes()
@@ -130,6 +136,16 @@ const Gaffer::StringPlug *CollectScenes::rootNameVariablePlug() const
 	return getChild<StringPlug>( g_firstPlugIndex + 1 );
 }
 
+Gaffer::StringPlug *CollectScenes::sourceRootPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::StringPlug *CollectScenes::sourceRootPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
 void CollectScenes::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	SceneProcessor::affects( input, outputs );
@@ -138,7 +154,10 @@ void CollectScenes::affects( const Gaffer::Plug *input, AffectedPlugsContainer &
 	{
 		outputs.push_back( outPlug()->childNamesPlug() );
 	}
-	else if( input == rootNameVariablePlug() )
+	else if(
+		input == rootNameVariablePlug() ||
+		input == sourceRootPlug()
+	)
 	{
 		for( PlugIterator it( outPlug() ); !it.done(); ++it )
 		{
@@ -165,7 +184,7 @@ void CollectScenes::hashBound( const ScenePath &path, const Gaffer::Context *con
 	}
 	else
 	{
-		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path );
+		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path, sourceRootPlug() );
 		h = inPlug()->boundPlug()->hash();
 	}
 }
@@ -178,7 +197,7 @@ Imath::Box3f CollectScenes::computeBound( const ScenePath &path, const Gaffer::C
 	}
 	else
 	{
-		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path );
+		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path, sourceRootPlug() );
 		return inPlug()->boundPlug()->getValue();
 	}
 }
@@ -191,7 +210,7 @@ void CollectScenes::hashTransform( const ScenePath &path, const Gaffer::Context 
 	}
 	else
 	{
-		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path );
+		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path, sourceRootPlug() );
 		h = inPlug()->transformPlug()->hash();
 	}
 }
@@ -204,7 +223,7 @@ Imath::M44f CollectScenes::computeTransform( const ScenePath &path, const Gaffer
 	}
 	else
 	{
-		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path );
+		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path, sourceRootPlug() );
 		return inPlug()->transformPlug()->getValue();
 	}
 }
@@ -217,7 +236,7 @@ void CollectScenes::hashAttributes( const ScenePath &path, const Gaffer::Context
 	}
 	else
 	{
-		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path );
+		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path, sourceRootPlug() );
 		h = inPlug()->attributesPlug()->hash();
 	}
 }
@@ -230,7 +249,7 @@ IECore::ConstCompoundObjectPtr CollectScenes::computeAttributes( const ScenePath
 	}
 	else
 	{
-		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path );
+		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path, sourceRootPlug() );
 		return inPlug()->attributesPlug()->getValue();
 	}
 }
@@ -243,7 +262,7 @@ void CollectScenes::hashObject( const ScenePath &path, const Gaffer::Context *co
 	}
 	else
 	{
-		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path );
+		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path, sourceRootPlug() );
 		h = inPlug()->objectPlug()->hash();
 	}
 }
@@ -256,7 +275,7 @@ IECore::ConstObjectPtr CollectScenes::computeObject( const ScenePath &path, cons
 	}
 	else
 	{
-		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path );
+		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path, sourceRootPlug() );
 		return inPlug()->objectPlug()->getValue();
 	}
 }
@@ -270,7 +289,7 @@ void CollectScenes::hashChildNames( const ScenePath &path, const Gaffer::Context
 	}
 	else
 	{
-		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path );
+		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path, sourceRootPlug() );
 		h = inPlug()->childNamesPlug()->hash();
 	}
 }
@@ -302,7 +321,7 @@ IECore::ConstInternedStringVectorDataPtr CollectScenes::computeChildNames( const
 	}
 	else
 	{
-		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path );
+		SceneScope sceneScope( context, rootNameVariablePlug()->getValue(), path, sourceRootPlug() );
 		return inPlug()->childNamesPlug()->getValue();
 	}
 }
@@ -392,12 +411,14 @@ void CollectScenes::hashSet( const IECore::InternedString &setName, const Gaffer
 	const vector<InternedString> &rootNames = rootNamesData->readable();
 
 	const PathMatcherDataPlug *inSetPlug = inPlug()->setPlug();
+	const StringPlug *sourceRootPlug = this->sourceRootPlug();
 
 	SceneScope sceneScope( context, rootNameVariablePlug()->getValue() );
 	for( vector<InternedString>::const_iterator it = rootNames.begin(), eIt = rootNames.end(); it != eIt; ++it )
 	{
 		sceneScope.setRootName( *it );
 		inSetPlug->hash( h );
+		sourceRootPlug->hash( h );
 	}
 }
 
@@ -410,6 +431,7 @@ GafferScene::ConstPathMatcherDataPtr CollectScenes::computeSet( const IECore::In
 	const vector<InternedString> &rootNames = rootNamesData->readable();
 
 	const PathMatcherDataPlug *inSetPlug = inPlug()->setPlug();
+	const StringPlug *sourceRootPlug = this->sourceRootPlug();
 
 	SceneScope sceneScope( context, rootNameVariablePlug()->getValue() );
 	vector<InternedString> prefix( 1 );
@@ -421,7 +443,15 @@ GafferScene::ConstPathMatcherDataPtr CollectScenes::computeSet( const IECore::In
 		if( !inSet.isEmpty() )
 		{
 			prefix[0] = *it;
-			set.addPaths( inSet, prefix );
+			const string root = sourceRootPlug->getValue();
+			if( !root.empty() )
+			{
+				set.addPaths( inSet.subTree( root ), prefix );
+			}
+			else
+			{
+				set.addPaths( inSet, prefix );
+			}
 		}
 	}
 


### PR DESCRIPTION
This allows subtrees to be collected from the input scene. The implementation for this was pretty straightforward - it was harder trying to come up with a plug name and writing the description for the docs. I'm not sure I've got that right - would "inputRoot" or "sourceRoot" or "subTree" have been better names perhaps? Any suggestions welcome...