### PR TITLE
Parent : Default "root" plug to value of "/"

### DIFF
--- a/python/GafferSceneUI/ParentUI.py
+++ b/python/GafferSceneUI/ParentUI.py
@@ -61,6 +61,8 @@ Gaffer.Metadata.registerNode(
 			The location which the child is parented under.
 			""",
 
+			"userDefault", "/",
+
 		],
 
 		"child" : [


### PR DESCRIPTION
Users found it confusing that the node did nothing by default. Using a userDefault metadata value rather than a change to the true default to preserve backwards compatibility with old scripts.