### PR TITLE
.gitignore: Add .sconf_temp to the ignore list (backport)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ doc/html
 doc/python
 config.log
 .idea
+.sconf_temp


### PR DESCRIPTION
`.sconf_temp` is created during build, and should be ignored by git.
