### PR TITLE
VTuneMonitor : monitor to annotate vtune profile with node processes (master)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -137,6 +137,12 @@ options.Add(
 )
 
 options.Add(
+	"VTUNE_ROOT",
+	"The directory in which VTune is installed.",
+	""
+)
+
+options.Add(
 	"ARNOLD_ROOT",
 	"The directory in which Arnold is installed. Used to build GafferArnold",
 	"",
@@ -564,10 +570,25 @@ else :
 # Definitions for the libraries we wish to build
 ###############################################################################################
 
+vTuneRoot = env.subst("$VTUNE_ROOT")
+
+gafferLib = {}
+
+if os.path.exists( vTuneRoot ):
+	gafferLib = {
+		"envAppends" : {
+			"CXXFLAGS" : [ "-isystem", "$VTUNE_ROOT/include", "-DGAFFER_VTUNE"],
+			"LIBPATH" : [ "$VTUNE_ROOT/lib64" ],
+			"LIBS" : [ "ittnotify" ]
+		},
+		"pythonEnvAppends" : {
+			"CXXFLAGS" : [ "-DGAFFER_VTUNE"]
+		}
+	}
+
 libraries = {
 
-	"Gaffer" : {
-	},
+	"Gaffer" : gafferLib,
 
 	"GafferTest" : {
 		"envAppends" : {
@@ -870,6 +891,7 @@ for library in ( "GafferUI", ) :
 	addQtLibrary( library, "OpenGL" )
 	if int( env["QT_VERSION"] ) > 4 :
 		addQtLibrary( library, "Widgets" )
+
 
 ###############################################################################################
 # The stuff that actually builds the libraries and python modules

--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -163,6 +163,12 @@ class stats( Gaffer.Application ) :
 						"context monitor. Statistics will only be captured for this root "
 						"downwards.",
 					defaultValue = "",
+				),
+
+				IECore.BoolParameter(
+					name = "vtune",
+					description = "enable vtune instrumentation. When enabled the VTune profile 'Tasks & Frames' view will be broken down by node type.",
+					defaultValue = False,
 				)
 
 			]
@@ -174,6 +180,8 @@ class stats( Gaffer.Application ) :
 				"flagless" : IECore.StringVectorData( [ "script" ] )
 			}
 		)
+
+		self.__vtuneMonitor = None
 
 	def _run( self, args ) :
 
@@ -206,6 +214,13 @@ class stats( Gaffer.Application ) :
 			self.__contextMonitor = Gaffer.ContextMonitor( contextMonitorRoot )
 		else :
 			self.__contextMonitor = None
+
+		if args["vtune"].value :
+			try:
+				self.__vtuneMonitor = Gaffer.VTuneMonitor()
+				self.__vtuneMonitor.setActive(True)
+			except AttributeError:
+				IECore.msg( IECore.Msg.Level.Error, "gui", "unable to create requested VTune monitor" )
 
 		self.__output = file( args["outputFile"].value, "w" ) if args["outputFile"].value else sys.stdout
 

--- a/config/ie/options
+++ b/config/ie/options
@@ -104,6 +104,9 @@ oslVersion = gafferReg["OpenShadingLanguage"]
 vdbVersion = gafferReg.get( "OpenVDB", "3.0.0" )
 qtPyVersion = gafferReg.get( "qtPyVersion", "1.0.0.b3" )
 
+vTuneVersion = getOption( "VTUNE_VERSION", os.environ["VTUNE_VERSION"] )
+VTUNE_ROOT = IEEnv.registry["apps"]["vtune"][vTuneVersion][IEEnv.platform()]["location"]
+
 if targetApp :
 
 	if targetApp not in ( "nuke", "maya", "houdini" ) :

--- a/include/Gaffer/VTuneMonitor.h
+++ b/include/Gaffer/VTuneMonitor.h
@@ -1,0 +1,70 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Image Engine Design Inc nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_VTUNEMONITOR_H
+#define GAFFER_VTUNEMONITOR_H
+
+#ifdef GAFFER_VTUNE
+
+#include "Gaffer/Monitor.h"
+
+namespace Gaffer
+{
+
+/// A monitor which provides instrumentation to annotate a vtune profile
+class VTuneMonitor : public Monitor
+{
+
+	public :
+
+		VTuneMonitor( bool monitorHashProcess = false );
+		~VTuneMonitor() override;
+
+	protected :
+
+		void processStarted( const Process *process ) override;
+		void processFinished( const Process *process ) override;
+
+	private :
+
+		bool m_monitorHashProcess;
+
+};
+
+} // namespace Gaffer
+
+#endif // GAFFER_VTUNE
+#endif // GAFFER_VTUNEMONITOR_H

--- a/src/Gaffer/VTuneMonitor.cpp
+++ b/src/Gaffer/VTuneMonitor.cpp
@@ -1,0 +1,95 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Image Engine Design Inc nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/VTuneMonitor.h"
+
+#ifdef GAFFER_VTUNE
+
+#include <stdio.h>
+
+#include "ittnotify.h"
+#include "Gaffer/Process.h"
+#include "Gaffer/Plug.h"
+#include "Gaffer/Node.h"
+
+namespace
+{
+	const IECore::InternedString hashProcessType( "computeNode:hash" );
+	__itt_domain* g_domain = NULL;
+}
+
+using namespace Gaffer;
+
+VTuneMonitor::VTuneMonitor(bool monitorHashProcess /* = false */ )
+: m_monitorHashProcess( monitorHashProcess )
+{
+	if (!g_domain)
+	{
+		g_domain = __itt_domain_create( "org.gafferhq.gaffer" );
+	}
+}
+
+VTuneMonitor::~VTuneMonitor()
+{
+}
+
+void VTuneMonitor::processStarted( const Process *process )
+{
+	if (!m_monitorHashProcess && process->type() != hashProcessType)
+	{
+		return;
+	}
+
+	const Node* node = process->plug()->node();
+
+	const char* typeName = node->typeName();
+	__itt_string_handle* handle = __itt_string_handle_create( typeName );
+	__itt_task_begin(g_domain, __itt_null, __itt_null, handle );
+}
+
+void VTuneMonitor::processFinished( const Process *process )
+{
+	if (!m_monitorHashProcess && process->type() != hashProcessType)
+	{
+		return;
+	}
+
+	__itt_task_end( g_domain);
+
+}
+
+
+#endif //GAFFER_VTUNE

--- a/src/GafferBindings/MonitorBinding.cpp
+++ b/src/GafferBindings/MonitorBinding.cpp
@@ -40,6 +40,7 @@
 #include "Gaffer/Monitor.h"
 #include "Gaffer/PerformanceMonitor.h"
 #include "Gaffer/ContextMonitor.h"
+#include "Gaffer/VTuneMonitor.h"
 #include "Gaffer/MonitorAlgo.h"
 #include "Gaffer/Plug.h"
 
@@ -219,5 +220,17 @@ void GafferBindings::bindMonitor()
 			.def( self != self )
 		;
 	}
+
+#ifdef GAFFER_VTUNE
+	{
+		scope s = class_<VTuneMonitor, bases<Monitor>, boost::noncopyable>( "VTuneMonitor" )
+			.def( init<bool>(
+					(
+						arg( "monitorHashProcess" ) = false )
+					)
+				);
+	}
+
+#endif //GAFFER_VTUNE
 
 }


### PR DESCRIPTION
This is Don's work from #2231 retargeted for master. I've done some mild C++11isation by using `override` for the virtual overrides, but I haven't actually compiled it due to lacking VTune (and it won't be compiled on Travis for the same reason). Perhaps someone could make sure I didn't mess anything up before merging? 