### PR TITLE
Wrappers : Provide templated variadic constructors

### DIFF
--- a/include/GafferBindings/ComputeNodeBinding.h
+++ b/include/GafferBindings/ComputeNodeBinding.h
@@ -59,20 +59,9 @@ class ComputeNodeWrapper : public DependencyNodeWrapper<WrappedType>
 {
 	public :
 
-		ComputeNodeWrapper( PyObject *self, const std::string &name )
-			:	DependencyNodeWrapper<WrappedType>( self, name )
-		{
-		}
-
-		template<typename Arg1, typename Arg2>
-		ComputeNodeWrapper( PyObject *self, Arg1 arg1, Arg2 arg2 )
-			:	DependencyNodeWrapper<WrappedType>( self, arg1, arg2 )
-		{
-		}
-
-		template<typename Arg1, typename Arg2, typename Arg3>
-		ComputeNodeWrapper( PyObject *self, Arg1 arg1, Arg2 arg2, Arg3 arg3 )
-			:	DependencyNodeWrapper<WrappedType>( self, arg1, arg2, arg3 )
+		template<typename... Args>
+		ComputeNodeWrapper( PyObject *self, Args&&... args )
+			:	DependencyNodeWrapper<WrappedType>( self, std::forward<Args>( args )... )
 		{
 		}
 

--- a/include/GafferBindings/DependencyNodeBinding.h
+++ b/include/GafferBindings/DependencyNodeBinding.h
@@ -70,20 +70,9 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 {
 	public :
 
-		DependencyNodeWrapper( PyObject *self, const std::string &name )
-			:	NodeWrapper<WrappedType>( self, name )
-		{
-		}
-
-		template<typename Arg1, typename Arg2>
-		DependencyNodeWrapper( PyObject *self, Arg1 arg1, Arg2 arg2 )
-			:	NodeWrapper<WrappedType>( self, arg1, arg2 )
-		{
-		}
-
-		template<typename Arg1, typename Arg2, typename Arg3>
-		DependencyNodeWrapper( PyObject *self, Arg1 arg1, Arg2 arg2, Arg3 arg3 )
-			:	NodeWrapper<WrappedType>( self, arg1, arg2, arg3 )
+		template<typename... Args>
+		DependencyNodeWrapper( PyObject *self, Args&&... args )
+			:	NodeWrapper<WrappedType>( self, std::forward<Args>( args )... )
 		{
 		}
 

--- a/include/GafferBindings/GraphComponentBinding.h
+++ b/include/GafferBindings/GraphComponentBinding.h
@@ -38,6 +38,8 @@
 #ifndef GAFFERBINDINGS_GRAPHCOMPONENTBINDING_H
 #define GAFFERBINDINGS_GRAPHCOMPONENTBINDING_H
 
+#include <utility>
+
 #include "IECorePython/RunTimeTypedBinding.h"
 
 #include "Gaffer/GraphComponent.h"
@@ -60,26 +62,9 @@ class GraphComponentWrapper : public IECorePython::RunTimeTypedWrapper<WrappedTy
 
 	public :
 
-		GraphComponentWrapper( PyObject *self )
-			:	IECorePython::RunTimeTypedWrapper<WrappedType>( self )
-		{
-		}
-
-		template<typename Arg1>
-		GraphComponentWrapper( PyObject *self, Arg1 arg1 )
-			:	IECorePython::RunTimeTypedWrapper<WrappedType>( self, arg1 )
-		{
-		}
-
-		template<typename Arg1, typename Arg2>
-		GraphComponentWrapper( PyObject *self, Arg1 arg1, Arg2 arg2 )
-			:	IECorePython::RunTimeTypedWrapper<WrappedType>( self, arg1, arg2 )
-		{
-		}
-
-		template<typename Arg1, typename Arg2, typename Arg3>
-		GraphComponentWrapper( PyObject *self, Arg1 arg1, Arg2 arg2, Arg3 arg3 )
-			:	IECorePython::RunTimeTypedWrapper<WrappedType>( self, arg1, arg2, arg3 )
+		template<typename... Args>
+		GraphComponentWrapper( PyObject *self, Args&&... args )
+			:	IECorePython::RunTimeTypedWrapper<WrappedType>( self, std::forward<Args>( args )... )
 		{
 		}
 

--- a/include/GafferBindings/NodeBinding.h
+++ b/include/GafferBindings/NodeBinding.h
@@ -38,6 +38,8 @@
 #ifndef GAFFERBINDINGS_NODEBINDING_H
 #define GAFFERBINDINGS_NODEBINDING_H
 
+#include <utility>
+
 #include "boost/python.hpp"
 
 #include "IECorePython/ScopedGILLock.h"
@@ -69,20 +71,9 @@ class NodeWrapper : public GraphComponentWrapper<T>
 
 		typedef T WrappedType;
 
-		NodeWrapper( PyObject *self, const std::string &name )
-			:	GraphComponentWrapper<T>( self, name )
-		{
-		}
-
-		template<typename Arg1, typename Arg2>
-		NodeWrapper( PyObject *self, Arg1 arg1, Arg2 arg2 )
-			:	GraphComponentWrapper<WrappedType>( self, arg1, arg2 )
-		{
-		}
-
-		template<typename Arg1, typename Arg2, typename Arg3>
-		NodeWrapper( PyObject *self, Arg1 arg1, Arg2 arg2, Arg3 arg3 )
-			:	GraphComponentWrapper<WrappedType>( self, arg1, arg2, arg3 )
+		template<typename... Args>
+		NodeWrapper( PyObject *self, Args&&... args )
+			:	GraphComponentWrapper<T>( self, std::forward<Args>( args )... )
 		{
 		}
 

--- a/include/GafferBindings/PlugBinding.h
+++ b/include/GafferBindings/PlugBinding.h
@@ -38,6 +38,8 @@
 #ifndef GAFFERBINDINGS_PLUGBINDING_H
 #define GAFFERBINDINGS_PLUGBINDING_H
 
+#include <utility>
+
 #include "IECorePython/ScopedGILRelease.h"
 
 #include "Gaffer/Plug.h"
@@ -64,8 +66,9 @@ class PlugWrapper : public GraphComponentWrapper<WrappedType>
 {
 	public :
 
-		PlugWrapper( PyObject *self, const std::string &name, Gaffer::Plug::Direction direction, unsigned flags )
-			:	GraphComponentWrapper<WrappedType>( self, name, direction, flags )
+		template<typename... Args>
+		PlugWrapper( PyObject *self, Args&&... args )
+			:	GraphComponentWrapper<WrappedType>( self, std::forward<Args>( args )... )
 		{
 		}
 

--- a/include/GafferDispatchBindings/TaskNodeBinding.h
+++ b/include/GafferDispatchBindings/TaskNodeBinding.h
@@ -37,6 +37,8 @@
 #ifndef GAFFERDISPATCHBINDINGS_TASKNODEBINDING_H
 #define GAFFERDISPATCHBINDINGS_TASKNODEBINDING_H
 
+#include <utility>
+
 #include "boost/python/suite/indexing/container_utils.hpp"
 
 #include "IECorePython/ScopedGILLock.h"
@@ -65,8 +67,9 @@ class TaskNodeWrapper : public GafferBindings::DependencyNodeWrapper<WrappedType
 {
 	public :
 
-		TaskNodeWrapper( PyObject *self, const std::string &name )
-			:	GafferBindings::DependencyNodeWrapper<WrappedType>( self, name )
+		template<typename... Args>
+		TaskNodeWrapper( PyObject *self, Args&&... args )
+			:	GafferBindings::DependencyNodeWrapper<WrappedType>( self, std::forward<Args>( args )... )
 		{
 		}
 

--- a/include/GafferUIBindings/GadgetBinding.h
+++ b/include/GafferUIBindings/GadgetBinding.h
@@ -38,6 +38,8 @@
 #ifndef GAFFERUIBINDINGS_GADGETBINDING_H
 #define GAFFERUIBINDINGS_GADGETBINDING_H
 
+#include <utility>
+
 #include "GafferUI/Gadget.h"
 #include "GafferUI/Style.h"
 
@@ -60,20 +62,9 @@ class GadgetWrapper : public GafferBindings::GraphComponentWrapper<WrappedType>
 {
 	public :
 
-		GadgetWrapper( PyObject *self )
-			:	GafferBindings::GraphComponentWrapper<WrappedType>( self )
-		{
-		}
-
-		template<typename Arg1>
-		GadgetWrapper( PyObject *self, Arg1 arg1 )
-			:	GafferBindings::GraphComponentWrapper<WrappedType>( self, arg1 )
-		{
-		}
-
-		template<typename Arg1, typename Arg2>
-		GadgetWrapper( PyObject *self, Arg1 arg1, Arg2 arg2 )
-			:	GafferBindings::GraphComponentWrapper<WrappedType>( self, arg1, arg2 )
+		template<typename... Args>
+		GadgetWrapper( PyObject *self, Args&&... args )
+			:	GafferBindings::GraphComponentWrapper<WrappedType>( self, std::forward<Args>( args )... )
 		{
 		}
 

--- a/include/GafferUIBindings/NodeGadgetBinding.h
+++ b/include/GafferUIBindings/NodeGadgetBinding.h
@@ -60,15 +60,9 @@ class NodeGadgetWrapper : public GadgetWrapper<WrappedType>
 
 	public :
 
-		template<typename Arg1>
-		NodeGadgetWrapper( PyObject *self, Arg1 arg1 )
-			:	GadgetWrapper<WrappedType>( self, arg1 )
-		{
-		}
-
-		template<typename Arg1, typename Arg2>
-		NodeGadgetWrapper( PyObject *self, Arg1 arg1, Arg2 arg2 )
-			:	GadgetWrapper<WrappedType>( self, arg1, arg2 )
+		template<typename... Args>
+		NodeGadgetWrapper( PyObject *self, Args&&... args )
+			:	GadgetWrapper<WrappedType>( self, std::forward<Args>( args )... )
 		{
 		}
 


### PR DESCRIPTION
Up till now we've just kept adding on new overloaded constructors each time we've needed one, but now C++11 allows us to do this properly once and for all.

I _think_ I've got my `&&`s and `...`s in the right places, but this is all new to me, so if anyone knows better, please say!