### PR TITLE
Gaffer::ContextMonitor : Record context variables which are both set and unset

### DIFF
--- a/src/Gaffer/ContextMonitor.cpp
+++ b/src/Gaffer/ContextMonitor.cpp
@@ -84,6 +84,22 @@ ContextMonitor::Statistics & ContextMonitor::Statistics::operator += ( const Con
 		const Data *d = context->get<Data>( *it );
 		m_variables[*it][d->Object::hash()] += 1;
 	}
+	
+	for( VariableMap::iterator it = m_variables.begin(), eIt = m_variables.end(); it != eIt; ++it )
+	{
+		if( std::find( names.begin(), names.end(), it->first ) == names.end() )
+		{
+			// Record that we have seen a context where this variable was unset
+			// This helps to distinguish between a variable which is always set ( no impact on unique hashes )
+			// and a variable which is sometimes set ( may be doubling the number of unique hashes ).
+			//
+			// Note that this is not 100% accurate - if we happen to see all evaluations where the variable 
+			// is unset before the first evaluation where it is set, we would not capture this variation.
+			// Still seems better than nothing to me.
+			it->second[ IECore::MurmurHash() ] += 1;
+		}
+	}
+
 	return *this;
 }
 


### PR DESCRIPTION
This is a simple and handy addition to the context monitor, which I'm hoping you'll be willing to merge.  It just helped me cut down the total number of hashes in production scene by 30% ( which then didn't help performance significantly, for reasons that I will hopefully understand better tomorrow.  But anyway, seems handy.

It reports an additional "Unique value" for a context variable if the context sometimes has the variable unset, allowing you to spot variables which are sometimes set and sometimes unset, potentially doubling the number of unique hashes.  Previously, if a variable was always set to the same value, or was sometimes set and sometimes unset, both of these would be reported as 1 unique values.

The only downside to this is that I haven't covered the case where you somehow happen to get all the evaluations where the variable is unset before the first evaluations where it is set.  Do you think it's worth making the code more complex to handle this case?
