### PR TITLE
GafferScene::Group and BranchCreator : Use GlobalScope for accessing mappingPlug

### DIFF
--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -382,7 +382,11 @@ IECore::ConstInternedStringVectorDataPtr BranchCreator::computeSetNames( const G
 
 void BranchCreator::hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
-	ConstCompoundDataPtr mapping = boost::static_pointer_cast<const CompoundData>( mappingPlug()->getValue() );
+	ConstCompoundDataPtr mapping;
+	{
+		ScenePlug::GlobalScope s( context );
+		mapping = boost::static_pointer_cast<const CompoundData>( mappingPlug()->getValue() );
+	}
 	if( !mapping->readable().size() )
 	{
 		h = inPlug()->setPlug()->hash();
@@ -407,7 +411,11 @@ GafferScene::ConstPathMatcherDataPtr BranchCreator::computeSet( const IECore::In
 {
 	ConstPathMatcherDataPtr inputSetData = inPlug()->set( setName );
 
-	ConstCompoundDataPtr mapping = boost::static_pointer_cast<const CompoundData>( mappingPlug()->getValue() );
+	ConstCompoundDataPtr mapping;
+	{
+		ScenePlug::GlobalScope s( context );
+		mapping = boost::static_pointer_cast<const CompoundData>( mappingPlug()->getValue() );
+	}
 	if( !mapping->readable().size() )
 	{
 		return inputSetData;

--- a/src/GafferScene/Group.cpp
+++ b/src/GafferScene/Group.cpp
@@ -366,6 +366,7 @@ IECore::ConstInternedStringVectorDataPtr Group::computeChildNames( const ScenePa
 	}
 	else if( path.size() == 1 )
 	{
+		ScenePlug::GlobalScope s( context );
 		ConstCompoundObjectPtr mapping = boost::static_pointer_cast<const CompoundObject>( mappingPlug()->getValue() );
 		return mapping->member<InternedStringVectorData>( "__GroupChildNames" );
 	}
@@ -416,15 +417,24 @@ void Group::hashSet( const IECore::InternedString &setName, const Gaffer::Contex
 	{
 		(*it)->setPlug()->hash( h );
 	}
+
+	ScenePlug::GlobalScope s( context );
 	mappingPlug()->hash( h );
 	namePlug()->hash( h );
 }
 
 GafferScene::ConstPathMatcherDataPtr Group::computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	InternedString groupName = namePlug()->getValue();
+	InternedString groupName;
 
-	ConstCompoundObjectPtr mapping = boost::static_pointer_cast<const CompoundObject>( mappingPlug()->getValue() );
+	ConstCompoundObjectPtr mapping;
+
+	{
+		ScenePlug::GlobalScope s( context );
+		groupName = namePlug()->getValue();
+
+		mapping = boost::static_pointer_cast<const CompoundObject>( mappingPlug()->getValue() );
+	}
 	const ObjectVector *forwardMappings = mapping->member<ObjectVector>( "__GroupForwardMappings", true /* throw if missing */ );
 
 	PathMatcherDataPtr resultData = new PathMatcherData;
@@ -533,7 +543,11 @@ SceneNode::ScenePath Group::sourcePath( const ScenePath &outputPath, const Scene
 {
 	const InternedString mappedChildName = outputPath[1];
 
-	ConstCompoundObjectPtr mapping = boost::static_pointer_cast<const CompoundObject>( mappingPlug()->getValue() );
+	ConstCompoundObjectPtr mapping;
+	{
+		ScenePlug::GlobalScope s( Context::current() );
+		mapping = boost::static_pointer_cast<const CompoundObject>( mappingPlug()->getValue() );
+	}
 	const CompoundObject *entry = mapping->member<CompoundObject>( mappedChildName );
 	if( !entry )
 	{


### PR DESCRIPTION
This had a very significant positive affect on performance of a heavy production layout - total hash processes reduced by 72% and total runtime reduced by 48%.

Let me know if there are tests you need me to run to measure whether the extra context creation causes problems in simple cases.