### PR TITLE
ImageReader fixes

### DIFF
--- a/include/GafferImage/ImageReader.h
+++ b/include/GafferImage/ImageReader.h
@@ -128,6 +128,21 @@ class ImageReader : public ImageNode
 		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
+		void hashFormat( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		GafferImage::Format computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+
+		void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+
+		void hashMetadata( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundDataPtr computeMetadata( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+
+		void hashChannelNames( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const override;
+
+		void hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const override;
+
 	private :
 
 		// We use internal nodes to do all the hard work,
@@ -148,9 +163,6 @@ class ImageReader : public ImageNode
 
 		GafferImage::ImagePlug *intermediateImagePlug();
 		const GafferImage::ImagePlug *intermediateImagePlug() const;
-
-		void hashMaskedOutput( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h, bool clampBlack = false ) const;
-		void computeMaskedOutput( Gaffer::ValuePlug *output, const Gaffer::Context *context, bool clampBlack = false ) const;
 
 		static DefaultColorSpaceFunction &defaultColorSpaceFunction();
 

--- a/include/GafferImage/ImageReader.h
+++ b/include/GafferImage/ImageReader.h
@@ -149,10 +149,8 @@ class ImageReader : public ImageNode
 		GafferImage::ImagePlug *intermediateImagePlug();
 		const GafferImage::ImagePlug *intermediateImagePlug() const;
 
-		void hashMaskedOutput( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h, bool alwaysClampToFrame = false ) const;
-		void computeMaskedOutput( Gaffer::ValuePlug *output, const Gaffer::Context *context, bool alwaysClampToFrame = false ) const;
-
-		bool computeFrameMask( const Gaffer::Context *context, Gaffer::ContextPtr &maskedContext ) const;
+		void hashMaskedOutput( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h, bool clampBlack = false ) const;
+		void computeMaskedOutput( Gaffer::ValuePlug *output, const Gaffer::Context *context, bool clampBlack = false ) const;
 
 		static DefaultColorSpaceFunction &defaultColorSpaceFunction();
 

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -453,5 +453,16 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( capturedArguments["dataType"], dataType )
 			self.assertEqual( capturedArguments["metadata"], r["out"]["metadata"].getValue() )
 
+	def testDisabling( self ) :
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( self.fileName )
+		reader["enabled"].setValue( False )
+
+		constant = GafferImage.Constant()
+		constant["enabled"].setValue( False )
+
+		self.assertImagesEqual( reader["out"], constant["out"] )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Over time I've been going through and replacing all uses of `new Context( context, Borrowed )`, with the improved `Context::EditableScope`, with a view to optimising performance of the latter once the former is all gone. The ImageReader had escaped until now because it had more complex logic that hurt my brain, but I think I've got it right this time. I've also fixed #2056, whereby disabling an ImageReader still read the image from disk, rather than displaying an empty image.