### PR TITLE
Light Filter Visualisation for 34-maintenance

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -713,7 +713,14 @@ libraries = {
 		"additionalFiles" : glob.glob( "python/GafferArnoldTest/volumes/*" ) + glob.glob( "python/GafferArnoldTest/metadata/*" ),
 	},
 
-	"GafferArnoldUI" : {},
+	"GafferArnoldUI" : {
+		"envAppends" : {
+			"LIBS" : [ "IECoreGL$CORTEX_LIB_SUFFIX", "GafferOSL", "GafferSceneUI" ],
+			},
+		"pythonEnvAppends" : {
+			"LIBS" : [ "GafferArnoldUI", "GafferSceneUI" ],
+		},
+	},
 
 	"GafferArnoldUITest" : {},
 

--- a/arnold/plugins/gaffer.mtd
+++ b/arnold/plugins/gaffer.mtd
@@ -79,6 +79,9 @@
 	shaderType STRING "lightFilter"
 	gaffer.nodeMenu.category STRING "Light"
 
+	[attr rotate]
+		gaffer.plugType STRING "FloatPlug"
+
 
 [node hair]
 

--- a/arnold/plugins/gaffer.mtd
+++ b/arnold/plugins/gaffer.mtd
@@ -44,6 +44,7 @@
 
 [node barndoor]
 
+	shaderType STRING "lightFilter"
 	gaffer.nodeMenu.category STRING "Light"
 
 
@@ -75,6 +76,7 @@
 
 [node gobo]
 
+	shaderType STRING "lightFilter"
 	gaffer.nodeMenu.category STRING "Light"
 
 
@@ -98,11 +100,13 @@
 
 [node light_blocker]
 
+	shaderType STRING "lightFilter"
 	gaffer.nodeMenu.category STRING "Light"
 
 
 [node light_decay]
 
+	shaderType STRING "lightFilter"
 	gaffer.nodeMenu.category STRING "Light"
 
 

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -79,6 +79,10 @@ class Shader : public Gaffer::DependencyNode
 		Gaffer::StringPlug *typePlug();
 		const Gaffer::StringPlug *typePlug() const;
 
+		/// A plug defining the suffix used for shader assignment attributes
+		Gaffer::StringPlug *attributeSuffixPlug();
+		const Gaffer::StringPlug *attributeSuffixPlug() const;
+
 		/// Plug under which the shader parameters are defined.
 		Gaffer::Plug *parametersPlug();
 		const Gaffer::Plug *parametersPlug() const;

--- a/include/GafferSceneUI/LightFilterVisualiser.h
+++ b/include/GafferSceneUI/LightFilterVisualiser.h
@@ -1,0 +1,87 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEUI_LIGHTFILTERVISUALISER_H
+#define GAFFERSCENEUI_LIGHTFILTERVISUALISER_H
+
+#include "IECore/ObjectVector.h"
+#include "IECore/Shader.h"
+#include "IECoreGL/Renderable.h"
+
+namespace GafferSceneUI
+{
+
+IE_CORE_FORWARDDECLARE( LightFilterVisualiser )
+
+/// Class for visualisation of light filters. All light filters in Gaffer are represented
+/// as IECore::Shader objects, but we need to visualise them differently
+/// depending on their shader name (accessed using `IECore::Shader::getName()`). A
+/// factory mechanism is provided to map from this name to a specialised
+/// LightFilterVisualiser.
+class LightFilterVisualiser : public IECore::RefCounted
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( LightFilterVisualiser )
+
+		LightFilterVisualiser();
+		virtual ~LightFilterVisualiser();
+
+		/// Must be implemented by derived classes to visualise
+		/// the light filter contained within shaderVector.
+		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *filterShaderVector, const IECore::ObjectVector *lightShaderVector, IECoreGL::ConstStatePtr &state ) const = 0;
+
+		/// Registers a visualiser to visualise a particular type of light filter.
+		/// For instance, `registerLightFilterVisualiser( "ai:lightFilter", "gobo", visualiser )`
+		/// would register a visualiser for an Arnold gobo light filter.
+		static void registerLightFilterVisualiser( const IECore::InternedString &attributeName, const IECore::InternedString &shaderName, ConstLightFilterVisualiserPtr visualiser );
+
+	protected :
+
+		template<typename FilterVisualiserType>
+		struct LightFilterVisualiserDescription
+		{
+			LightFilterVisualiserDescription( const IECore::InternedString &attributeName, const IECore::InternedString &shaderName )
+			{
+				registerLightFilterVisualiser( attributeName, shaderName, new FilterVisualiserType );
+			}
+		};
+};
+
+} // namespace GafferSceneUI
+
+#endif // GAFFERSCENEUI_LIGHTFILTERVISUALISER_H

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -62,6 +62,8 @@ class StandardLightVisualiser : public LightVisualiser
 
 		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, IECoreGL::ConstStatePtr &state ) const;
 
+		static void spotlightParameters( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, float &innerAngle, float &outerAngle, float &lensRadius );
+
 	protected :
 
 		static const char *faceCameraVertexSource();

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -363,6 +363,20 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual( a["out"].attributes( "/plane" ).keys(), [ "ai:surface"] )
 
+	def testLightFilterAssignmentAttributeName( self ) :
+
+		p = GafferScene.Plane()
+
+		s = GafferArnold.ArnoldShader( "light_blocker" )
+		s.loadShader( "light_blocker" )  # metadata sets type to ai:lightFilter
+
+		a = GafferScene.ShaderAssignment()
+		a["in"].setInput( p["out"] )
+		a["shader"].setInput( s["out"] )
+
+		self.assertEqual( s["attributeSuffix"].getValue(), "light_blocker" )
+		self.assertEqual( a["out"].attributes( "/plane" ).keys(), [ "ai:lightFilter:light_blocker"] )
+
 	def testDirtyPropagationThroughShaderAssignment( self ) :
 
 		n = GafferArnold.ArnoldShader()

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -445,6 +445,25 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		for name in [ "refraction", "diffuse", "glossy" ] :
 			self.assertTrue( isinstance( n["parameters"][name], Gaffer.Color4fPlug ) )
 
+	def testFloatParameterMetadata( self ) :
+
+		self.__forceArnoldRestart()
+
+		n = GafferArnold.ArnoldShader()
+		n.loadShader( "gobo" )
+
+		self.assertTrue( isinstance( n["parameters"]["slidemap"], Gaffer.Color3fPlug ) )
+
+		self.addCleanup( os.environ.__setitem__, "ARNOLD_PLUGIN_PATH", os.environ["ARNOLD_PLUGIN_PATH"] )
+		os.environ["ARNOLD_PLUGIN_PATH"] = os.environ["ARNOLD_PLUGIN_PATH"] + ":" + os.path.join( os.path.dirname( __file__ ), "metadata" )
+
+		self.__forceArnoldRestart()
+
+		n = GafferArnold.ArnoldShader()
+		n.loadShader( "gobo" )
+
+		self.assertTrue( isinstance( n["parameters"]["slidemap"], Gaffer.FloatPlug ) )
+
 	def testEmptyPlugTypeMetadata( self ) :
 
 		self.__forceArnoldRestart()

--- a/python/GafferArnoldTest/metadata/floatPlugType.mtd
+++ b/python/GafferArnoldTest/metadata/floatPlugType.mtd
@@ -1,0 +1,39 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+[node gobo]
+
+	[attr slidemap]
+
+		gaffer.plugType       STRING  "FloatPlug"

--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -400,3 +400,8 @@ for nodeType in ( GafferArnold.ArnoldShader, GafferArnold.ArnoldLight ) :
 		Gaffer.Metadata.registerValue( nodeType, "parameters.*", key, functools.partial( __plugMetadata, name = key ) )
 
 	Gaffer.Metadata.registerValue( nodeType, "description", __nodeDescription )
+
+
+Gaffer.Metadata.registerValue( GafferArnold.ArnoldShader, "attributeSuffix", "plugValueWidget:type", "GafferUI.StringPlugValueWidget" )
+Gaffer.Metadata.registerValue( GafferArnold.ArnoldShader, "layout:activator:suffixActivator", lambda parent : parent["type"].getValue() == "ai:lightFilter" )
+Gaffer.Metadata.registerValue( GafferArnold.ArnoldShader, "attributeSuffix", "layout:visibilityActivator", "suffixActivator" )

--- a/python/GafferOSLTest/ShadingEngineTest.py
+++ b/python/GafferOSLTest/ShadingEngineTest.py
@@ -79,7 +79,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		s = self.compileShader( os.path.dirname( __file__ ) +  "/shaders/constant.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( s, "surface", { "Cs" : IECore.Color3f( 1, 0.5, 0.25 ) } )
+			IECore.Shader( s, "osl:surface", { "Cs" : IECore.Color3f( 1, 0.5, 0.25 ) } )
 		] ) )
 
 		p = e.shade( self.rectanglePoints() )
@@ -92,8 +92,8 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		input = self.compileShader( os.path.dirname( __file__ ) +  "/shaders/outputTypes.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( input, "shader", { "input" : 0.5, "__handle" : "h" } ),
-			IECore.Shader( constant, "surface", { "Cs" : "link:h.c" } ),
+			IECore.Shader( input, "osl:shader", { "input" : 0.5, "__handle" : "h" } ),
+			IECore.Shader( constant, "osl:surface", { "Cs" : "link:h.c" } ),
 		] ) )
 
 		p = e.shade( self.rectanglePoints() )
@@ -108,7 +108,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		for n in ( "P", "u", "v" ) :
 			e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-				IECore.Shader( shader, "surface", { "global" : n } )
+				IECore.Shader( shader, "osl:surface", { "global" : n } )
 			] ) )
 			p = e.shade( rp )
 			v1 = p["Ci"]
@@ -123,7 +123,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		rp = self.rectanglePoints()
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "name" : "floatUserData" } ),
+			IECore.Shader( shader, "osl:surface", { "name" : "floatUserData" } ),
 		] ) )
 
 		self.assertEqual( e.needsAttribute( "", "floatUserData" ), True )
@@ -136,7 +136,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 			self.assertEqual( c.r, rp["floatUserData"][i] )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "name" : "colorUserData" } ),
+			IECore.Shader( shader, "osl:surface", { "name" : "colorUserData" } ),
 		] ) )
 
 		self.assertEqual( e.needsAttribute( "", "floatUserData" ), False )
@@ -150,7 +150,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "name" : "shading:index" } ),
+			IECore.Shader( shader, "osl:surface", { "name" : "shading:index" } ),
 		] ) )
 
 		self.assertEqual( e.needsAttribute( "", "floatUserData" ), False )
@@ -167,7 +167,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/dynamicAttribute.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface" )
+			IECore.Shader( shader, "osl:surface" )
 		] ) )
 
 		self.assertEqual( e.needsAttribute( "", "foo" ), True )
@@ -179,8 +179,8 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		constant = self.compileShader( os.path.dirname( __file__ ) + "/shaders/constant.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "shader", { "s.c" : IECore.Color3f( 0.1, 0.2, 0.3 ), "__handle" : "h" } ),
-			IECore.Shader( constant, "surface", { "Cs" : "link:h.c" } ),
+			IECore.Shader( shader, "osl:shader", { "s.c" : IECore.Color3f( 0.1, 0.2, 0.3 ), "__handle" : "h" } ),
+			IECore.Shader( constant, "osl:surface", { "Cs" : "link:h.c" } ),
 		] ) )
 		p = e.shade( self.rectanglePoints() )
 
@@ -193,8 +193,8 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		inputClosure = self.compileShader( os.path.dirname( __file__ ) + "/shaders/inputClosure.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( outputClosure, "shader", { "e" : IECore.Color3f( 0.1, 0.2, 0.3 ), "__handle" : "h" } ),
-			IECore.Shader( inputClosure, "surface", { "i" : "link:h.c" } ),
+			IECore.Shader( outputClosure, "osl:shader", { "e" : IECore.Color3f( 0.1, 0.2, 0.3 ), "__handle" : "h" } ),
+			IECore.Shader( inputClosure, "osl:surface", { "i" : "link:h.c" } ),
 		] ) )
 		p = e.shade( self.rectanglePoints() )
 
@@ -206,7 +206,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/debugClosure.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "name" : "a", "weight" : IECore.Color3f( 1, 0, 0 ) } ),
+			IECore.Shader( shader, "osl:surface", { "name" : "a", "weight" : IECore.Color3f( 1, 0, 0 ) } ),
 		] ) )
 
 		points = self.rectanglePoints()
@@ -228,7 +228,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/multipleDebugClosures.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", {} ),
+			IECore.Shader( shader, "osl:surface", {} ),
 		] ) )
 
 		points = self.rectanglePoints()
@@ -243,7 +243,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/typedDebugClosure.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", {} ),
+			IECore.Shader( shader, "osl:surface", {} ),
 		] ) )
 
 		points = self.rectanglePoints()
@@ -273,7 +273,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/debugClosureWithInternalValue.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "value" : IECore.Color3f( 1, 0.5, 0.25 ) } ),
+			IECore.Shader( shader, "osl:surface", { "value" : IECore.Color3f( 1, 0.5, 0.25 ) } ),
 		] ) )
 
 		points = self.rectanglePoints()
@@ -301,7 +301,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/debugClosureWithInternalValue.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "value" : IECore.Color3f( 0 ) } ),
+			IECore.Shader( shader, "osl:surface", { "value" : IECore.Color3f( 0 ) } ),
 		] ) )
 
 		points = self.rectanglePoints()
@@ -338,7 +338,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		)
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "colorSpline" : spline } )
+			IECore.Shader( shader, "osl:surface", { "colorSpline" : spline } )
 		] ) )
 
 		rp = self.rectanglePoints()
@@ -351,7 +351,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/extractTranslate.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "m" : IECore.M44f().translate( IECore.V3f( 1, 2, 3 ) ) } )
+			IECore.Shader( shader, "osl:surface", { "m" : IECore.M44f().translate( IECore.V3f( 1, 2, 3 ) ) } )
 		] ) )
 
 		p = e.shade( self.rectanglePoints() )
@@ -362,7 +362,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/parameterTypes.osl" )
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", {
+			IECore.Shader( shader, "osl:surface", {
 				"f" : 1.0,
 				"i" : 2,
 				"s" : "three",
@@ -385,7 +385,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		s = self.compileShader( os.path.dirname( __file__ ) +  "/shaders/transform.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( s, "surface" )
+			IECore.Shader( s, "osl:surface" )
 		] ) )
 
 		p = e.shade( self.rectanglePoints() )
@@ -401,7 +401,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( p["Ci"], IECore.Color3fVectorData( [ IECore.Color3f( i + IECore.V3f( 2, 0, 0 ) ) for i in self.rectanglePoints()["P"] ] ) )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( s, "surface", { "backwards" : IECore.IntData( 1 ) } )
+			IECore.Shader( s, "osl:surface", { "backwards" : IECore.IntData( 1 ) } )
 		] ) )
 
 		p = e.shade( self.rectanglePoints(), { "world" : GafferOSL.ShadingEngine.Transform( worldMatrix ) } )
@@ -412,8 +412,8 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 	def testVectorToColorConnections( self ) :
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( "Utility/Globals", "shader", { "__handle" : "h" } ),
-			IECore.Shader( "Surface/Constant", "surface", { "Cs" : "link:h.globalP" } ),
+			IECore.Shader( "Utility/Globals", "osl:shader", { "__handle" : "h" } ),
+			IECore.Shader( "Surface/Constant", "osl:surface", { "Cs" : "link:h.globalP" } ),
 		] ) )
 
 		p = self.rectanglePoints()
@@ -421,6 +421,17 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		for i, c in enumerate( r["Ci"] ) :
 			self.assertEqual( IECore.V3f( *c ), p["P"][i] )
+
+	def testWarningForInvalidShaders( self ) :
+
+		with self.assertRaises( Exception ) as engineError :
+			e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
+				IECore.Shader( "aiImage", "shader", {} ),
+				IECore.Shader( "aiImage", "shader", {} ),
+				IECore.Shader( "Surface/Constant", "osl:surface", {} ),
+			] ) )
+
+		self.assertEqual( str(engineError.exception), "Exception : The following shaders can't be used as they are not OSL shaders: aiImage (shader), aiImage (shader)" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -135,6 +135,9 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( network[0].type, "test:shader" )
 		self.assertEqual( network[1].type, "test:surface" )
 
+		surface['attributeSuffix'].setValue( "TestSurface" )
+		self.assertIn( "test:surface:TestSurface", surface.attributes() )
+
 	def testDirtyPropagationThroughShaderAssignment( self ) :
 
 		n = GafferSceneTest.TestShader()

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -142,6 +142,19 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"attributeSuffix" : [
+
+			"description",
+			"""
+			Suffix for the attribute used for shader assignment.
+			""",
+
+			"nodule:type", "",
+			"plugValueWidget:type", "",
+			"layout:section", "",
+
+		],
+
 	}
 
 )

--- a/src/GafferArnold/ArnoldShader.cpp
+++ b/src/GafferArnold/ArnoldShader.cpp
@@ -167,6 +167,11 @@ static IECore::ConstCompoundDataPtr metadataGetter( const std::string &key, size
 	{
 		shaderMetadata->writable()["primaryInput"] = new StringData( value );
 	}
+	const char* shaderType;
+	if( AiMetaDataGetStr( shader, /* look up metadata on node, not on parameter */ NULL , "shaderType", &shaderType ) )
+	{
+		shaderMetadata->writable()["shaderType"] = new StringData( shaderType );
+	}
 
 	return metadata;
 }

--- a/src/GafferArnold/ArnoldShader.cpp
+++ b/src/GafferArnold/ArnoldShader.cpp
@@ -128,12 +128,37 @@ void ArnoldShader::loadShader( const std::string &shaderName, bool keepExistingV
 
 	const bool isLightShader = AiNodeEntryGetType( shader ) == AI_NODE_LIGHT;
 	namePlug()->setValue( AiNodeEntryGetName( shader ) );
-	typePlug()->setValue(
-		isLightShader ? "ai:light" : "ai:surface"
-	);
+
+	int aiOutputType = AI_TYPE_POINTER;
+	string type = "ai:light";
+	if( !isLightShader )
+	{
+		const CompoundData *metadata = ArnoldShader::metadata();
+		const StringData *shaderTypeData = static_cast<const StringData*>( metadata->member<IECore::CompoundData>( "shader" )->member<IECore::Data>( "shaderType" ) );
+		if( shaderTypeData )
+		{
+			type = "ai:" + shaderTypeData->readable();
+		}
+		else
+		{
+			type = "ai:surface";
+		}
+
+		if( type == "ai:surface" )
+		{
+			aiOutputType = AiNodeEntryGetOutputType( shader );
+		}
+	}
+
+	if( !keepExistingValues && type == "ai:lightFilter" )
+	{
+		attributeSuffixPlug()->setValue( shaderName );
+	}
+
+	typePlug()->setValue( type );
 
 	ParameterHandler::setupPlugs( shader, parametersPlug() );
-	ParameterHandler::setupPlug( "out", isLightShader ? AI_TYPE_POINTER : AiNodeEntryGetOutputType( shader ), this, Plug::Out );
+	ParameterHandler::setupPlug( "out", aiOutputType, this, Plug::Out );
 
 }
 

--- a/src/GafferArnoldUI/BarndoorVisualiser.cpp
+++ b/src/GafferArnoldUI/BarndoorVisualiser.cpp
@@ -1,0 +1,252 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECore/MeshPrimitive.h"
+#include "IECoreGL/CurvesPrimitive.h"
+#include "IECore/Shader.h"
+#include "IECoreGL/Group.h"
+#include "IECoreGL/ToGLMeshConverter.h"
+#include "IECoreGL/ShaderStateComponent.h"
+#include "IECoreGL/ShaderLoader.h"
+#include "IECoreGL/TextureLoader.h"
+#include "IECore/ObjectVector.h"
+#include "IECoreGL/Renderable.h"
+
+#include "Gaffer/Metadata.h"
+#include "GafferSceneUI/StandardLightVisualiser.h"
+#include "GafferSceneUI/LightFilterVisualiser.h"
+
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreGL;
+using namespace GafferSceneUI;
+
+namespace
+{
+
+enum BarndoorLocation { Top, Right, Left, Bottom };
+
+float parameterOrDefault( const IECore::CompoundData *data, const char *key, const float def )
+{
+	ConstFloatDataPtr member = data->member<const FloatData>( key );
+	if( member )
+	{
+		return member->readable();
+	}
+	return def;
+}
+
+const char *barndoorFragSource()
+{
+	return
+		"void main()"
+		"{"
+		"if( mod( float( gl_FragCoord.x + gl_FragCoord.y ), 2.0) == 0.0 )"
+			"{"
+				"discard;"
+			"}"
+			"else"
+			"{"
+				"gl_FragColor = vec4(0, 0, 0, 1);"
+			"}"
+		"}"
+		;
+}
+
+void addBarndoor( IECoreGL::GroupPtr result, BarndoorLocation location, float cornerLeft, float cornerRight )
+{
+
+	if( !( cornerLeft > 0 || cornerRight > 0 ) )
+	{
+		return;
+	}
+
+	cornerLeft = 1 - cornerLeft * 2.0;
+	cornerRight = 1 - cornerRight * 2.0;
+
+	IntVectorDataPtr vertsPerPoly = new IntVectorData;
+	std::vector<int> &vertsPerPolyVec = vertsPerPoly->writable();
+	vertsPerPolyVec.push_back( 4 );
+
+	IntVectorDataPtr vertIds = new IntVectorData;
+	std::vector<int> &vertIdsVec = vertIds->writable();
+	vertIdsVec.push_back( 0 );
+	vertIdsVec.push_back( 1 );
+	vertIdsVec.push_back( 2 );
+	vertIdsVec.push_back( 3 );
+
+	V3fVectorDataPtr p = new V3fVectorData;
+	std::vector<V3f> &pVec = p->writable();
+	pVec.push_back( V3f( -1, 1, 0  ) );
+	pVec.push_back( V3f( 1, 1, 0  ) );
+	pVec.push_back( V3f( 1, cornerRight, 0  ) );
+	pVec.push_back( V3f( -1, cornerLeft, 0  ) );
+
+	IECore::MeshPrimitivePtr mesh = new IECore::MeshPrimitive( vertsPerPoly, vertIds, "linear", p );
+
+	Imath::M44f trans;
+	switch( location )
+	{
+	case Top:
+		break;
+	case Bottom:
+		trans.rotate( V3f( 0, 0, M_PI ) );
+		break;
+	case Left:
+		trans.rotate( V3f( 0, 0, M_PI / 2.0 ) );
+		break;
+	case Right:
+		trans.rotate( V3f( 0, 0, M_PI / -2.0 ) );
+		break;
+	}
+
+	ToGLMeshConverterPtr meshConverter = new ToGLMeshConverter( mesh );
+
+	IECoreGL::GroupPtr barndoorGroup = new IECoreGL::Group();
+	barndoorGroup->getState()->add( new IECoreGL::Primitive::Selectable( false ) );
+	barndoorGroup->addChild( IECore::runTimeCast<IECoreGL::Renderable>( meshConverter->convert() ) );
+	barndoorGroup->setTransform( trans );
+
+	result->addChild( barndoorGroup );
+}
+
+class BarndoorVisualiser : public LightFilterVisualiser
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( BarndoorVisualiser )
+
+		BarndoorVisualiser();
+		~BarndoorVisualiser();
+
+		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, const IECore::ObjectVector *lightShaderVector, IECoreGL::ConstStatePtr &state ) const;
+
+	protected :
+
+		static LightFilterVisualiser::LightFilterVisualiserDescription<BarndoorVisualiser> g_visualiserDescription;
+
+};
+
+IE_CORE_DECLAREPTR( BarndoorVisualiser )
+
+// register the new visualiser
+LightFilterVisualiser::LightFilterVisualiserDescription<BarndoorVisualiser> BarndoorVisualiser::g_visualiserDescription( "ai:lightFilter", "barndoor" );
+
+BarndoorVisualiser::BarndoorVisualiser()
+{
+}
+
+BarndoorVisualiser::~BarndoorVisualiser()
+{
+}
+
+IECoreGL::ConstRenderablePtr BarndoorVisualiser::visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, const IECore::ObjectVector *lightShaderVector, IECoreGL::ConstStatePtr &state ) const
+{
+	IECoreGL::GroupPtr result = new IECoreGL::Group();
+
+	if( !shaderVector || shaderVector->members().size() == 0 || !lightShaderVector || lightShaderVector->members().empty() )
+	{
+		return result;
+	}
+
+	const IECore::Shader *filterShader = IECore::runTimeCast<const IECore::Shader>( shaderVector->members().back().get() );
+	if( !filterShader )
+	{
+		return result;
+	}
+
+	const IECore::Shader *lightShader = IECore::runTimeCast<const IECore::Shader>( lightShaderVector->members().back().get() );
+	if( !lightShader )
+	{
+		return result;
+	}
+
+	const IECore::CompoundData *filterShaderParameters = filterShader->parametersData();
+
+	float topLeft = parameterOrDefault( filterShaderParameters, "barndoor_top_left", 0.0f );
+	float topRight = parameterOrDefault( filterShaderParameters, "barndoor_top_right", 0.0f );
+
+	float rightTop = parameterOrDefault( filterShaderParameters, "barndoor_right_top", 1.0f );
+	float rightBottom = parameterOrDefault( filterShaderParameters, "barndoor_right_bottom", 1.0f );
+
+	float bottomLeft = parameterOrDefault( filterShaderParameters, "barndoor_bottom_left", 1.0f );
+	float bottomRight = parameterOrDefault( filterShaderParameters, "barndoor_bottom_right", 1.0f );
+
+	float leftTop = parameterOrDefault( filterShaderParameters, "barndoor_left_top", 0.0f );
+	float leftBottom = parameterOrDefault( filterShaderParameters, "barndoor_left_bottom", 0.0f );
+
+
+	addBarndoor( result, Top, topLeft, topRight );
+	addBarndoor( result, Bottom, 1 - bottomRight, 1 - bottomLeft );
+	addBarndoor( result, Left, leftBottom, leftTop );
+	addBarndoor( result, Right, 1 - rightTop, 1 - rightBottom );
+
+	if( result->children().size() > 0 )
+	{
+		IECore::CompoundObjectPtr parameters = new CompoundObject;
+
+		result->getState()->add(
+			new IECoreGL::ShaderStateComponent(
+				ShaderLoader::defaultShaderLoader(),
+				TextureLoader::defaultTextureLoader(),
+				"",
+				"",
+				barndoorFragSource(),
+				parameters )
+		);
+
+		float innerAngle;
+		float coneAngle;
+		float lensRadius;
+
+		StandardLightVisualiser::spotlightParameters( "ai:light", lightShaderVector, innerAngle, coneAngle, lensRadius );
+
+		const float halfAngle = 0.5 * M_PI * coneAngle / 180.0;
+		const float baseRadius = sin( halfAngle ) + lensRadius;
+		const float baseDistance = cos( halfAngle );
+
+		Imath::M44f barndoorTrans;
+		barndoorTrans.translate( V3f( 0, 0, -baseDistance * .5f ) );
+		barndoorTrans.scale( V3f( baseRadius * .5f, baseRadius * .5f, 0 ) );
+		result->setTransform( barndoorTrans );
+	}
+
+	return result;
+}
+
+} // namespace
+

--- a/src/GafferArnoldUI/DecayVisualiser.cpp
+++ b/src/GafferArnoldUI/DecayVisualiser.cpp
@@ -1,0 +1,266 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECore/MeshPrimitive.h"
+#include "IECore/CompoundObject.h"
+#include "IECoreGL/Group.h"
+#include "IECoreGL/Primitive.h"
+#include "IECoreGL/ToGLMeshConverter.h"
+#include "IECoreGL/ShaderStateComponent.h"
+#include "IECoreGL/ShaderLoader.h"
+#include "IECoreGL/TextureLoader.h"
+#include "IECore/ObjectVector.h"
+#include "IECoreGL/Renderable.h"
+
+#include "GafferSceneUI/LightFilterVisualiser.h"
+
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreGL;
+using namespace GafferSceneUI;
+
+namespace
+{
+typedef std::pair<float, V3f> Knot;
+typedef std::vector<Knot> KnotVector;
+
+const char *faceCameraVertexSource()
+{
+	return
+		"#version 120\n"
+		""
+		"#if __VERSION__ <= 120\n"
+		"#define in attribute\n"
+		"#endif\n"
+		""
+		"in vec3 vertexP;"
+		"void main()"
+		"{"
+			"vec3 aimedXAxis, aimedYAxis, aimedZAxis;"
+			""
+			"aimedXAxis = normalize( gl_ModelViewMatrixInverse * vec4( 0, 0, -1, 0 ) ).xyz;"
+			"aimedYAxis = normalize( gl_ModelViewMatrixInverse * vec4( 0, 1, 0, 0 ) ).xyz;"
+			"aimedZAxis = normalize( gl_ModelViewMatrixInverse * vec4( 1, 0, 0, 0 ) ).xyz;"
+			""
+			"vec3 pAimed = vertexP.x * aimedXAxis + vertexP.y * aimedYAxis + vertexP.z * aimedZAxis;"
+			"vec4 pCam = gl_ModelViewMatrix * vec4( pAimed, 1 );"
+			""
+			"gl_Position = gl_ProjectionMatrix * pCam;"
+		"}"
+		;
+}
+
+const char *knotFragSource()
+{
+	return
+		"uniform vec3 markerColor;"
+		""
+		"void main()"
+		"{"
+			"gl_FragColor = vec4(markerColor, 1);"
+		"}"
+		;
+}
+
+// \todo These should be consolidated with the function in BarndoorVisualiser into a templatized version
+//       Where should that live?
+float parameterOrDefault( const IECore::CompoundData *data, const char *key, const float def )
+{
+	ConstFloatDataPtr member = data->member<const FloatData>( key );
+	if( member )
+	{
+		return member->readable();
+	}
+	return def;
+}
+
+bool parameterOrDefault( const IECore::CompoundData *data, const char *key, const bool def )
+{
+	ConstBoolDataPtr member = data->member<const BoolData>( key );
+	if( member )
+	{
+		return member->readable();
+	}
+	return def;
+}
+
+void getKnotsToVisualize( const IECore::ObjectVector *shaderVector, KnotVector &knots )
+{
+	const IECore::Shader *filterShader = IECore::runTimeCast<const IECore::Shader>( shaderVector->members().back().get() );
+	if( !filterShader )
+	{
+		return;
+	}
+
+	const IECore::CompoundData *filterShaderParameters = filterShader->parametersData();
+
+	bool nearEnabled = parameterOrDefault( filterShaderParameters, "use_near_atten", false );
+	bool farEnabled = parameterOrDefault( filterShaderParameters, "use_far_atten", false );
+
+	if( nearEnabled )
+	{
+		float nearStart = parameterOrDefault( filterShaderParameters, "near_start", 0.0f );
+		float nearEnd = parameterOrDefault( filterShaderParameters, "near_end", 0.0f );
+
+		knots.push_back( Knot( nearStart, V3f( 0.0f ) ) );
+		knots.push_back( Knot( nearEnd, V3f( 1.0f ) ) );
+	}
+
+	if( farEnabled )
+	{
+		float farStart = parameterOrDefault( filterShaderParameters, "far_start", 0.0f );
+		float farEnd = parameterOrDefault( filterShaderParameters, "far_end", 0.0f );
+
+		knots.push_back( Knot( farStart, V3f( 1.0f ) ) );
+		knots.push_back( Knot( farEnd, V3f( 0.0f ) ) );
+	}
+}
+
+void addKnot( IECoreGL::GroupPtr group, const Knot &knot )
+{
+	IECoreGL::GroupPtr markerGroup = new IECoreGL::Group();
+
+	IntVectorDataPtr vertsPerPoly = new IntVectorData;
+	std::vector<int> &vertsPerPolyVec = vertsPerPoly->writable();
+	vertsPerPolyVec.push_back( 3 );
+
+	IntVectorDataPtr vertIds = new IntVectorData;
+	std::vector<int> &vertIdsVec = vertIds->writable();
+	vertIdsVec.push_back( 0 );
+	vertIdsVec.push_back( 1 );
+	vertIdsVec.push_back( 2 );
+
+	V3fVectorDataPtr p = new V3fVectorData;
+	std::vector<V3f> &pVec = p->writable();
+	pVec.push_back( V3f(  0, 0,  0  ) );
+	pVec.push_back( V3f(  0, 1, -1  ) );
+	pVec.push_back( V3f(  0, 1,  1  ) );
+
+	IECore::MeshPrimitivePtr mesh = new IECore::MeshPrimitive( vertsPerPoly, vertIds, "linear", p );
+	ToGLMeshConverterPtr meshConverter = new ToGLMeshConverter( mesh );
+	markerGroup->addChild( IECore::runTimeCast<IECoreGL::Renderable>( meshConverter->convert() ) );
+
+	Imath::M44f trans;
+	trans.translate( V3f( 0, 0, -knot.first ) );
+	trans.scale( V3f( 0.05 ) );
+	markerGroup->setTransform( trans );
+
+	IECore::CompoundObjectPtr shaderParameters = new CompoundObject;
+	shaderParameters->members()["markerColor"] = new IECore::Color3fData( knot.second );
+
+	markerGroup->getState()->add(
+		new IECoreGL::Primitive::Selectable( false ) );
+	markerGroup->getState()->add(
+		new IECoreGL::ShaderStateComponent(
+			ShaderLoader::defaultShaderLoader(),
+			TextureLoader::defaultTextureLoader(),
+			faceCameraVertexSource(),
+			"",
+			knotFragSource(), shaderParameters ) );
+
+	group->addChild( markerGroup );
+}
+
+class DecayVisualiser : public LightFilterVisualiser
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( DecayVisualiser )
+
+		DecayVisualiser();
+		~DecayVisualiser();
+
+		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, const IECore::ObjectVector *lightShaderVector, IECoreGL::ConstStatePtr &state ) const;
+
+	protected :
+
+		static LightFilterVisualiser::LightFilterVisualiserDescription<DecayVisualiser> g_visualiserDescription;
+
+};
+
+IE_CORE_DECLAREPTR( DecayVisualiser )
+
+// register the new visualiser
+LightFilterVisualiser::LightFilterVisualiserDescription<DecayVisualiser> DecayVisualiser::g_visualiserDescription( "ai:lightFilter", "light_decay" );
+
+DecayVisualiser::DecayVisualiser()
+{
+}
+
+DecayVisualiser::~DecayVisualiser()
+{
+}
+
+IECoreGL::ConstRenderablePtr DecayVisualiser::visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, const IECore::ObjectVector *lightShaderVector, IECoreGL::ConstStatePtr &state ) const
+{
+	IECoreGL::GroupPtr result = new IECoreGL::Group();
+
+	if( !shaderVector || shaderVector->members().size() == 0 || !lightShaderVector || lightShaderVector->members().empty() )
+	{
+		return result;
+	}
+
+	const IECore::Shader *filterShader = IECore::runTimeCast<const IECore::Shader>( shaderVector->members().back().get() );
+	if( !filterShader )
+	{
+		return result;
+	}
+
+	const IECore::Shader *lightShader = IECore::runTimeCast<const IECore::Shader>( lightShaderVector->members().back().get() );
+	if( !lightShader )
+	{
+		return result;
+	}
+
+	KnotVector knots;
+	getKnotsToVisualize( shaderVector, knots );
+
+	if( knots.empty() )
+	{
+		return result;
+	}
+
+
+	for( KnotVector::size_type i = 0; i < knots.size(); ++i )
+	{
+		addKnot( result, knots[i] );
+	}
+
+	return result;
+}
+
+} // namespace

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -311,14 +311,24 @@ IECoreGL::ConstRenderablePtr GoboVisualiser::visualise( const IECore::InternedSt
 
 		addSurfaceShader( oslNetwork, slidemap->readable() );
 
-		imageData = g_oslTextureCache.get( OSLTextureCacheKey( oslNetwork.get() ) );
+		try
+		{
+			imageData = g_oslTextureCache.get( OSLTextureCacheKey( oslNetwork.get() ) );
+		}
+		catch( const Exception &e )
+		{
+			// The osl evaluation system didn't work, but we just want to paint a
+			// white gobo in these cases instead of failing completely.
+			msg( Msg::Warning, "GoboVisualiser", e.what() );
+		}
 	}
-	else // nothing connected - just visualise the current value if possible
+
+	if( imageData->readable().empty() )
 	{
-		const Color3fData *goboColor = IECore::runTimeCast<const Color3fData>( it->second.get() );
+		ConstColor3fDataPtr goboColor = IECore::runTimeCast<const Color3fData>( it->second.get() );
 		if( !goboColor )
 		{
-			return result;
+			goboColor = new Color3fData( Color3f( 1 ) );
 		}
 
 		// single-pixel windows

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -1,0 +1,394 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECore/Shader.h"
+#include "IECoreGL/Group.h"
+#include "IECoreGL/Primitive.h"
+#include "IECoreGL/ShaderStateComponent.h"
+#include "IECoreGL/ShaderLoader.h"
+#include "IECoreGL/TextureLoader.h"
+#include "IECoreGL/QuadPrimitive.h"
+#include "IECore/VectorTypedData.h"
+#include "IECore/ObjectVector.h"
+#include "IECoreGL/Renderable.h"
+#include "IECore/LRUCache.h"
+
+#include "Gaffer/Metadata.h"
+#include "GafferSceneUI/StandardLightVisualiser.h"
+#include "GafferSceneUI/LightFilterVisualiser.h"
+#include "GafferOSL/ShadingEngine.h"
+
+#include "boost/format.hpp"
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreGL;
+using namespace GafferSceneUI;
+
+namespace
+{
+
+	// \todo These should be consolidated with the functions in the other visualisers into a templatized version
+	//       Where should that live?
+float parameterOrDefault( const IECore::CompoundData *data, const char *key, const float def )
+{
+	ConstFloatDataPtr member = data->member<const FloatData>( key );
+	if( member )
+	{
+		return member->readable();
+	}
+	return def;
+}
+
+V2f parameterOrDefault( const IECore::CompoundData *data, const char *key, const V2f def )
+{
+	ConstV2fDataPtr member = data->member<const V2fData>( key );
+	if( member )
+	{
+		return member->readable();
+	}
+	return def;
+}
+
+CompoundDataPtr evalOSLTexture( IECore::ObjectVectorPtr shaderVector, int resolution );
+
+struct OSLTextureCacheKey
+{
+
+	OSLTextureCacheKey()
+		:	shaders( NULL )
+	{
+	}
+
+	OSLTextureCacheKey( IECore::ObjectVector *s )
+		:	shaders( s )
+	{
+		s->hash( hash );
+	}
+
+	bool operator == ( const OSLTextureCacheKey &other ) const
+	{
+		return hash == other.hash;
+	}
+
+	bool operator != ( const OSLTextureCacheKey &other ) const
+	{
+		return hash != other.hash;
+	}
+
+	bool operator < ( const OSLTextureCacheKey &other ) const
+	{
+		return hash < other.hash;
+	}
+
+	mutable IECore::ObjectVector *shaders;
+	MurmurHash hash;
+
+};
+
+inline size_t tbb_hasher( const OSLTextureCacheKey &cacheKey )
+{
+	return tbb_hasher( cacheKey.hash );
+}
+
+CompoundDataPtr getter( const OSLTextureCacheKey &key, size_t &cost )
+{
+	cost = 1;
+	return evalOSLTexture( key.shaders, 512 );
+}
+
+typedef LRUCache<OSLTextureCacheKey, CompoundDataPtr> OSLTextureCache;
+OSLTextureCache g_oslTextureCache( getter, 100 );
+
+const char *goboFragSource()
+{
+	return
+		"#if __VERSION__ <= 120\n"
+		"#define in varying\n"
+		"#endif\n"
+		""
+		"in vec2 fragmentst;"
+		""
+		"uniform sampler2D texture;"
+		""
+		"void main()"
+		"{"
+			"vec2 texCoords = vec2( fragmentst.x, fragmentst.y );"
+			"vec4 tx = texture2D( texture, texCoords );"
+			"gl_FragColor = tx;"
+		"}"
+		;
+}
+
+// OSLTextureEvaluation
+
+void addSurfaceShader( IECore::ObjectVectorPtr shaderVector, string surfaceInput )
+{
+	IECore::Shader *surfaceShader = new IECore::Shader( "Surface/Constant", "osl:shader" );
+	surfaceShader->parameters()["Cs"] = new StringData( surfaceInput );
+
+	shaderVector->members().push_back( surfaceShader );
+}
+
+CompoundDataPtr evalOSLTexture( IECore::ObjectVectorPtr shaderVector, int resolution )
+{
+	GafferOSL::ShadingEnginePtr shadingEngine = new GafferOSL::ShadingEngine( shaderVector.get() );
+
+	CompoundDataPtr shadingPoints = new CompoundData();
+
+	V3fVectorDataPtr pData = new V3fVectorData;
+	FloatVectorDataPtr uData = new FloatVectorData;
+	FloatVectorDataPtr vData = new FloatVectorData;
+
+	vector<V3f> &pWritable = pData->writable();
+	vector<float> &uWritable = uData->writable();
+	vector<float> &vWritable = vData->writable();
+
+	int numPoints = resolution * resolution;
+
+	pWritable.reserve( numPoints );
+	uWritable.reserve( numPoints );
+	vWritable.reserve( numPoints );
+
+	for( int x = 0; x < resolution; ++x )
+	{
+		for( int y = 0; y < resolution; ++y )
+		{
+			uWritable.push_back( (float)(x + 0.5f) / resolution );
+			vWritable.push_back( (float)(y + 0.5f) / resolution );
+			pWritable.push_back( V3f( x + 0.5f, y + 0.5f, 0.0f ) );
+		}
+	}
+
+	shadingPoints->writable()["P"] = pData;
+	shadingPoints->writable()["u"] = uData;
+	shadingPoints->writable()["v"] = vData;
+
+	CompoundDataPtr shadingResult = shadingEngine->shade( shadingPoints.get() );
+	ConstColor3fVectorDataPtr colors = shadingResult->member<Color3fVectorData>( "Ci" );
+
+	CompoundDataPtr result = new CompoundData();
+
+	if( colors )
+	{
+		Imath::Box2i dataWindow( Imath::V2i( 0.0f ), Imath::V2i( resolution - 1 ) );
+		Imath::Box2i displayWindow( Imath::V2i( 0.0f ), Imath::V2i( resolution - 1 ) );
+
+		result->writable()["dataWindow"] = new Box2iData( dataWindow );
+		result->writable()["displayWindow"] = new Box2iData( displayWindow );
+
+		FloatVectorDataPtr redChannelData = new FloatVectorData();
+		FloatVectorDataPtr greenChannelData = new FloatVectorData();
+		FloatVectorDataPtr blueChannelData = new FloatVectorData();
+		std::vector<float> &r = redChannelData->writable();
+		std::vector<float> &g = greenChannelData->writable();
+		std::vector<float> &b = blueChannelData->writable();
+
+		vector<Color3f>::size_type numColors = colors->readable().size();
+		r.reserve( numColors );
+		g.reserve( numColors );
+		b.reserve( numColors );
+
+		for( vector<Color3f>::size_type u = 0; u < numColors; ++u )
+		{
+			Color3f c = colors->readable()[u];
+
+			r.push_back( c[0] );
+			g.push_back( c[1] );
+			b.push_back( c[2] );
+		}
+
+		CompoundDataPtr channelData = new CompoundData;
+		channelData->writable()["R"] = redChannelData;
+		channelData->writable()["G"] = greenChannelData;
+		channelData->writable()["B"] = blueChannelData;
+
+		result->writable()["channels"] = channelData;
+	}
+
+	return result;
+}
+
+class GoboVisualiser : public LightFilterVisualiser
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( GoboVisualiser )
+
+		GoboVisualiser();
+		~GoboVisualiser();
+
+		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, const IECore::ObjectVector *lightShaderVector, IECoreGL::ConstStatePtr &state ) const;
+
+	protected :
+
+		static LightFilterVisualiser::LightFilterVisualiserDescription<GoboVisualiser> g_visualiserDescription;
+
+};
+
+IE_CORE_DECLAREPTR( GoboVisualiser )
+
+// register the new visualiser
+LightFilterVisualiser::LightFilterVisualiserDescription<GoboVisualiser> GoboVisualiser::g_visualiserDescription( "ai:lightFilter", "gobo" );
+
+GoboVisualiser::GoboVisualiser()
+{
+}
+
+GoboVisualiser::~GoboVisualiser()
+{
+}
+
+IECoreGL::ConstRenderablePtr GoboVisualiser::visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, const IECore::ObjectVector *lightShaderVector, IECoreGL::ConstStatePtr &state ) const
+{
+	IECoreGL::GroupPtr result = new IECoreGL::Group();
+
+	if( !shaderVector || shaderVector->members().empty() || !lightShaderVector || lightShaderVector->members().empty() )
+	{
+		return result;
+	}
+
+	const IECore::Shader *filterShader = IECore::runTimeCast<const IECore::Shader>( shaderVector->members().back().get() );
+	if( !filterShader )
+	{
+		return result;
+	}
+
+	const IECore::Shader *lightShader = IECore::runTimeCast<const IECore::Shader>( lightShaderVector->members().back().get() );
+	if( !lightShader )
+	{
+		return result;
+	}
+
+	CompoundDataMap::const_iterator it = filterShader->parameters().find( "slidemap" );
+	if( it == filterShader->parameters().end() )
+	{
+		return result;
+	}
+
+	CompoundDataPtr imageData = new CompoundData;
+
+	const StringData *slidemap = IECore::runTimeCast<const StringData>( it->second.get() );
+	if( slidemap )
+	{
+		IECore::ObjectVectorPtr oslNetwork = new IECore::ObjectVector();
+		oslNetwork->members().assign( shaderVector->members().begin(), shaderVector->members().end() - 1 );
+
+		addSurfaceShader( oslNetwork, slidemap->readable() );
+
+		imageData = g_oslTextureCache.get( OSLTextureCacheKey( oslNetwork.get() ) );
+	}
+	else // nothing connected - just visualise the current value if possible
+	{
+		const Color3fData *goboColor = IECore::runTimeCast<const Color3fData>( it->second.get() );
+		if( !goboColor )
+		{
+			return result;
+		}
+
+		// single-pixel windows
+		Imath::Box2i dataWindow( Imath::V2i( 0.0f ), Imath::V2i( 0.0f ) );
+		Imath::Box2i displayWindow( Imath::V2i( 0.0f ), Imath::V2i( 0.0f ) );
+
+		imageData->writable()["dataWindow"] = new Box2iData( dataWindow );
+		imageData->writable()["displayWindow"] = new Box2iData( displayWindow );
+
+		CompoundDataPtr channels = new CompoundData;
+
+		std::vector<float> r;
+		std::vector<float> g;
+		std::vector<float> b;
+		r.push_back( goboColor->readable()[0] );
+		g.push_back( goboColor->readable()[1] );
+		b.push_back( goboColor->readable()[2] );
+
+		channels->writable()["R"] = new FloatVectorData( r );
+		channels->writable()["G"] = new FloatVectorData( g );
+		channels->writable()["B"] = new FloatVectorData( b );
+
+		imageData->writable()["channels"] = channels;
+	}
+
+	result->getState()->add( new IECoreGL::Primitive::Selectable( false ) );
+
+	IECore::CompoundObjectPtr shaderParameters = new CompoundObject;
+	shaderParameters->members()["texture"] = imageData;
+
+	result->getState()->add(
+		new IECoreGL::ShaderStateComponent(
+			ShaderLoader::defaultShaderLoader(),
+			TextureLoader::defaultTextureLoader(),
+			"",
+			"",
+			goboFragSource(),
+			shaderParameters ) );
+
+	float innerAngle;
+	float coneAngle;
+	float lensRadius;
+
+	StandardLightVisualiser::spotlightParameters( "ai:light", lightShaderVector, innerAngle, coneAngle, lensRadius );
+
+	float halfPi = 0.5 * M_PI;
+
+	const float halfAngle = halfPi * coneAngle / 180.0;
+	const float baseRadius = sin( halfAngle ) + lensRadius;
+	const float baseDistance = cos( halfAngle );
+
+	const CompoundData *filterParameters = filterShader->parametersData();
+	float rotate = parameterOrDefault( filterParameters, "rotate", 0.0f );
+	float scaleS = parameterOrDefault( filterParameters, "scale_s", 1.0f );
+	float scaleT = parameterOrDefault( filterParameters, "scale_t", 1.0f );
+	V2f offset = parameterOrDefault( filterParameters, "offset", V2f( 0.0f ) );
+
+	Imath::M44f goboTrans;
+
+	goboTrans.translate( V3f( 0.0f, 0.0f, -baseDistance ) );
+	goboTrans.rotate( V3f( 0, 0, M_PI * rotate / 180.0 ) );
+	goboTrans.scale( V3f( 2 * baseRadius / scaleS, 2 * baseRadius / scaleT, 0 ) );
+	goboTrans.translate( V3f( offset.x, offset.y, 0.0f ) );
+	goboTrans.rotate( V3f( 0.0f, 0.0f, halfPi ) );
+
+	result->setTransform( goboTrans );
+
+	result->addChild( new IECoreGL::QuadPrimitive( 1.0f, 1.0f ) );
+
+	return result;
+}
+
+} // namespace

--- a/src/GafferArnoldUIModule/GafferArnoldUIModule.cpp
+++ b/src/GafferArnoldUIModule/GafferArnoldUIModule.cpp
@@ -1,0 +1,44 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+// Despite being empty, this module is still necessary because importing it
+// loads libGafferArnolUI, which registers visualisers.
+
+BOOST_PYTHON_MODULE( _GafferArnoldUI )
+{
+}

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -41,6 +41,7 @@
 #include "boost/algorithm/string/split.hpp"
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/algorithm/string/classification.hpp"
+#include "boost/algorithm/string/join.hpp"
 #include "boost/unordered_map.hpp"
 
 #include "OSL/oslclosure.h"
@@ -787,7 +788,9 @@ ShadingEngine::ShadingEngine( const IECore::ObjectVector *shaderNetwork )
 	: m_unknownAttributesNeeded( false )
 {
 	ShadingSystem *shadingSystem = ::shadingSystem();
-	{
+
+	std::vector<std::string> invalidShaders;
+ 	{
 		ShadingSystemWriteMutex::scoped_lock shadingSystemWriteLock( g_shadingSystemWriteMutex );
 
 		m_shaderGroupRef = new ShaderGroupRef( shadingSystem->ShaderGroupBegin() );
@@ -796,6 +799,18 @@ ShadingEngine::ShadingEngine( const IECore::ObjectVector *shaderNetwork )
 		{
 			const Shader *shader = runTimeCast<const Shader>( it->get() );
 			if( !shader )
+			{
+				continue;
+			}
+
+			string type = shader->getType();
+			if( !boost::starts_with( type, "osl:" ) )
+			{
+				invalidShaders.push_back( shader->getName() + " (" + type + ")" );
+				continue;
+			}
+
+			if( !invalidShaders.empty() )
 			{
 				continue;
 			}
@@ -819,6 +834,12 @@ ShadingEngine::ShadingEngine( const IECore::ObjectVector *shaderNetwork )
 		}
 
 		shadingSystem->ShaderGroupEnd();
+
+		if( !invalidShaders.empty() )
+		{
+			std::string exceptionMessage = "The following shaders can't be used as they are not OSL shaders: ";
+			throw Exception( exceptionMessage + boost::algorithm::join( invalidShaders, ", " ) );
+		}
 	}
 
 	queryAttributesNeeded();

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -522,6 +522,7 @@ Shader::Shader( const std::string &name )
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new StringPlug( "name" ) );
 	addChild( new StringPlug( "type" ) );
+	addChild( new StringPlug( "attributeSuffix", Gaffer::Plug::In, "" ) );
 	addChild( new Plug( "parameters", Plug::In, Plug::Default & ~Plug::AcceptsInputs ) );
 	addChild( new BoolPlug( "enabled", Gaffer::Plug::In, true ) );
 	addChild( new StringPlug( "__nodeName", Gaffer::Plug::In, name, Plug::Default & ~(Plug::Serialisable | Plug::AcceptsInputs), Context::NoSubstitutions ) );
@@ -556,14 +557,25 @@ const Gaffer::StringPlug *Shader::typePlug() const
 	return getChild<StringPlug>( g_firstPlugIndex + 1 );
 }
 
+Gaffer::StringPlug *Shader::attributeSuffixPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::StringPlug *Shader::attributeSuffixPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+
 Gaffer::Plug *Shader::parametersPlug()
 {
-	return getChild<Plug>( g_firstPlugIndex + 2 );
+	return getChild<Plug>( g_firstPlugIndex + 3 );
 }
 
 const Gaffer::Plug *Shader::parametersPlug() const
 {
-	return getChild<Plug>( g_firstPlugIndex + 2 );
+	return getChild<Plug>( g_firstPlugIndex + 3 );
 }
 
 Gaffer::Plug *Shader::outPlug()
@@ -580,32 +592,32 @@ const Gaffer::Plug *Shader::outPlug() const
 
 Gaffer::BoolPlug *Shader::enabledPlug()
 {
-	return getChild<BoolPlug>( g_firstPlugIndex + 3 );
+	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
 }
 
 const Gaffer::BoolPlug *Shader::enabledPlug() const
 {
-	return getChild<BoolPlug>( g_firstPlugIndex + 3 );
+	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
 }
 
 Gaffer::StringPlug *Shader::nodeNamePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+	return getChild<StringPlug>( g_firstPlugIndex + 5 );
 }
 
 const Gaffer::StringPlug *Shader::nodeNamePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+	return getChild<StringPlug>( g_firstPlugIndex + 5 );
 }
 
 Gaffer::Color3fPlug *Shader::nodeColorPlug()
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex + 5 );
+	return getChild<Color3fPlug>( g_firstPlugIndex + 6 );
 }
 
 const Gaffer::Color3fPlug *Shader::nodeColorPlug() const
 {
-	return getChild<Color3fPlug>( g_firstPlugIndex + 5 );
+	return getChild<Color3fPlug>( g_firstPlugIndex + 6 );
 }
 
 IECore::MurmurHash Shader::attributesHash() const
@@ -627,6 +639,8 @@ IECore::ConstCompoundObjectPtr Shader::attributes() const
 
 void Shader::attributesHash( const Gaffer::Plug *output, IECore::MurmurHash &h ) const
 {
+	attributeSuffixPlug()->hash( h );
+
 	NetworkBuilder networkBuilder( output );
 	h.append( networkBuilder.stateHash() );
 }
@@ -637,9 +651,13 @@ IECore::ConstCompoundObjectPtr Shader::attributes( const Gaffer::Plug *output ) 
 	NetworkBuilder networkBuilder( output );
 	if( !networkBuilder.state()->members().empty() )
 	{
-		result->members()[typePlug()->getValue()] = boost::const_pointer_cast<IECore::ObjectVector>(
-			networkBuilder.state()
-		);
+		std::string attr = typePlug()->getValue();
+		std::string postfix = attributeSuffixPlug()->getValue();
+		if( postfix != "" )
+		{
+			attr += ":" + postfix;
+		}
+		result->members()[attr] = boost::const_pointer_cast<IECore::ObjectVector>(networkBuilder.state());
 	}
 	return result;
 }

--- a/src/GafferSceneUI/LightFilterVisualiser.cpp
+++ b/src/GafferSceneUI/LightFilterVisualiser.cpp
@@ -1,0 +1,212 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/container/flat_map.hpp"
+#include "boost/algorithm/string/predicate.hpp"
+#include "boost/algorithm/string.hpp"
+
+#include "IECore/Light.h"
+#include "IECore/Shader.h"
+
+#include "IECoreGL/Group.h"
+#include "IECoreGL/Primitive.h"
+
+#include "GafferSceneUI/LightFilterVisualiser.h"
+#include "GafferSceneUI/AttributeVisualiser.h"
+
+using namespace std;
+using namespace Imath;
+using namespace GafferSceneUI;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal implementation details
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+typedef std::pair<IECore::InternedString, IECore::InternedString> AttributeAndShaderNames;
+
+typedef boost::container::flat_map<AttributeAndShaderNames, ConstLightFilterVisualiserPtr> LightFilterVisualisers;
+LightFilterVisualisers &lightFilterVisualisers()
+{
+	static LightFilterVisualisers l;
+	return l;
+}
+
+/// Class for visualisation of light filters. All light filters in Gaffer are represented
+/// as IECore::Shader objects, but we need to visualise them differently
+/// depending on their shader name (accessed using `IECore::Shader::getName()`). A
+/// factory mechanism is provided to map from this type to a specialised
+/// LightFilterVisualiser.
+class AttributeVisualiserForLightFilters : public AttributeVisualiser
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( AttributeVisualiserForLightFilters )
+
+		/// Uses a custom visualisation registered via `registerLightFilterVisualiser()` if one
+		/// is available, if not falls back to a basic visualisation.
+		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const;
+
+	protected :
+
+		static AttributeVisualiser::AttributeVisualiserDescription<AttributeVisualiserForLightFilters> g_visualiserDescription;
+
+};
+
+} // namespace
+
+IECoreGL::ConstRenderablePtr AttributeVisualiserForLightFilters::visualise( const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
+{
+	if( !attributes )
+	{
+		return NULL;
+	}
+
+	IECoreGL::GroupPtr resultGroup = NULL;
+	IECoreGL::StatePtr resultState = NULL;
+
+	/// This seems pretty expensive to do everywhere.
+	/// The alternative would be to register attribute visualisers to specific attributes.  But then we wouldn't be able to have a visualiser that is influenced by multiple attributes simultaneously
+	for( IECore::CompoundObject::ObjectMap::const_iterator it = attributes->members().begin();
+		it != attributes->members().end(); it++ )
+	{
+		const std::string &attributeName = it->first.string();
+		if( attributeName.find( ":lightFilter" ) == std::string::npos )
+		{
+			continue;
+		}
+
+		const IECore::ObjectVector *filterShaderVector = IECore::runTimeCast<const IECore::ObjectVector>( it->second.get() );
+		if( !filterShaderVector || filterShaderVector->members().empty() )
+		{
+			continue;
+		}
+
+		IECore::InternedString filterShaderName;
+		if( const IECore::Shader *filterShader = IECore::runTimeCast<const IECore::Shader>( filterShaderVector->members().back().get() ) )
+		{
+			filterShaderName = filterShader->getName();
+		}
+
+		if( filterShaderName.string().empty() )
+		{
+			continue;
+		}
+
+		// find the light shader influenced by the filter
+
+		std::vector<std::string> tokens;
+		boost::split( tokens, attributeName, boost::is_any_of(":") );
+		IECore::CompoundObject::ObjectMap::const_iterator lightIt = attributes->members().find( tokens.front() + ":light" );
+		if( lightIt == attributes->members().end() )
+		{
+			continue;
+		}
+
+		const IECore::ObjectVector *lightShaderVector = IECore::runTimeCast<const IECore::ObjectVector>( lightIt->second.get() );
+		if( !lightShaderVector || lightShaderVector->members().empty() )
+		{
+			continue;
+		}
+
+		const LightFilterVisualisers &l = lightFilterVisualisers();
+
+		// light filters are stored in attributes following this syntax:
+		// renderer:lightFilter:optionalName. Visualisers get registered to
+		// renderer:lightFilter only, though. It's therefore necessary to strip off
+		// the optional part
+		std::string attrLookup = tokens[0] + ":" + tokens[1];
+
+		const LightFilterVisualiser *visualiser = NULL;
+		LightFilterVisualisers::const_iterator visIt = l.find( AttributeAndShaderNames( attrLookup, filterShaderName ) );
+		if( visIt != l.end() )
+		{
+			visualiser = visIt->second.get();
+		}
+		else
+		{
+			continue;
+		}
+
+		IECoreGL::ConstStatePtr curState = NULL;
+		IECoreGL::ConstRenderablePtr curVis = visualiser->visualise( attributeName, filterShaderVector, lightShaderVector, curState );
+
+		if( curVis )
+		{
+			if( !resultGroup )
+			{
+				resultGroup = new IECoreGL::Group();
+			}
+			// resultGroup will be returned as const, so const-casting the children in order to add them is safe
+			resultGroup->addChild( const_cast<IECoreGL::Renderable*>( curVis.get() ) );
+		}
+
+		if( curState )
+		{
+			if( !resultState )
+			{
+				resultState = new IECoreGL::State( false );
+			}
+			resultState->add( const_cast<IECoreGL::State*>( curState.get() ) );
+		}
+	}
+
+	state = resultState;
+	return resultGroup;
+}
+
+AttributeVisualiser::AttributeVisualiserDescription<AttributeVisualiserForLightFilters> AttributeVisualiserForLightFilters::g_visualiserDescription;
+
+//////////////////////////////////////////////////////////////////////////
+// LightVisualiser class
+//////////////////////////////////////////////////////////////////////////
+
+
+LightFilterVisualiser::LightFilterVisualiser()
+{
+}
+
+LightFilterVisualiser::~LightFilterVisualiser()
+{
+}
+
+void LightFilterVisualiser::registerLightFilterVisualiser( const IECore::InternedString &attributeName, const IECore::InternedString &shaderName, ConstLightFilterVisualiserPtr visualiser )
+{
+	lightFilterVisualisers()[AttributeAndShaderNames( attributeName, shaderName )] = visualiser;
+}

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -109,48 +109,6 @@ T parameter( InternedString metadataTarget, const IECore::CompoundData *paramete
 	return defaultValue;
 }
 
-void spotlightParameters( InternedString metadataTarget, const IECore::CompoundData *parameters, float &innerAngle, float &outerAngle, float &lensRadius )
-{
-	float coneAngle = parameter<float>( metadataTarget, parameters, "coneAngleParameter", 0.0f );
-	float penumbraAngle = parameter<float>( metadataTarget, parameters, "penumbraAngleParameter", 0.0f );
-	if( ConstStringDataPtr angleUnit = Metadata::value<StringData>( metadataTarget, "angleUnit" ) )
-	{
-		if( angleUnit->readable() == "radians" )
-		{
-			coneAngle *= 180.0 / M_PI;
-			penumbraAngle *= 180 / M_PI;
-		}
-	}
-
-	innerAngle = 0;
-	outerAngle = 0;
-
-	ConstStringDataPtr penumbraTypeData = Metadata::value<StringData>( metadataTarget, "penumbraType" );
-	const std::string *penumbraType = penumbraTypeData ? &penumbraTypeData->readable() : NULL;
-
-	if( !penumbraType || *penumbraType == "inset" )
-	{
-		outerAngle = coneAngle;
-		innerAngle = coneAngle - 2.0f * penumbraAngle;
-	}
-	else if( *penumbraType == "outset" )
-	{
-		outerAngle = coneAngle + 2.0f * penumbraAngle;
-		innerAngle = coneAngle ;
-	}
-	else if( *penumbraType == "absolute" )
-	{
-		outerAngle = coneAngle;
-		innerAngle = penumbraAngle;
-	}
-
-	lensRadius = 0.0f;
-	if( parameter<bool>( metadataTarget, parameters, "lensRadiusEnableParameter", true ) )
-	{
-		lensRadius = parameter<float>( metadataTarget, parameters, "lensRadiusParameter", 0.0f );
-	}
-}
-
 void addWireframeCurveState( IECoreGL::Group *group )
 {
 	group->getState()->add( new IECoreGL::Primitive::DrawWireframe( false ) );
@@ -329,7 +287,7 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::I
 	else if( type && type->readable() == "spot" )
 	{
 		float innerAngle, outerAngle, lensRadius;
-		spotlightParameters( metadataTarget, shaderParameters, innerAngle, outerAngle, lensRadius );
+		spotlightParameters( attributeName, shaderVector, innerAngle, outerAngle, lensRadius );
 		result->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / locatorScale ) ) );
 		result->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
 		result->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
@@ -367,6 +325,52 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::I
 	}
 
 	return result;
+}
+
+void StandardLightVisualiser::spotlightParameters( const InternedString &attributeName, const IECore::ObjectVector *shaderVector, float &innerAngle, float &outerAngle, float &lensRadius )
+{
+
+	InternedString metadataTarget;
+	const IECore::CompoundData *shaderParameters = parametersAndMetadataTarget( attributeName, shaderVector, metadataTarget );
+
+	float coneAngle = parameter<float>( metadataTarget, shaderParameters, "coneAngleParameter", 0.0f );
+	float penumbraAngle = parameter<float>( metadataTarget, shaderParameters, "penumbraAngleParameter", 0.0f );
+	if( ConstStringDataPtr angleUnit = Metadata::value<StringData>( metadataTarget, "angleUnit" ) )
+	{
+		if( angleUnit->readable() == "radians" )
+		{
+			coneAngle *= 180.0 / M_PI;
+			penumbraAngle *= 180 / M_PI;
+		}
+	}
+
+	innerAngle = 0;
+	outerAngle = 0;
+
+	ConstStringDataPtr penumbraTypeData = Metadata::value<StringData>( metadataTarget, "penumbraType" );
+	const std::string *penumbraType = penumbraTypeData ? &penumbraTypeData->readable() : NULL;
+
+	if( !penumbraType || *penumbraType == "inset" )
+	{
+		outerAngle = coneAngle;
+		innerAngle = coneAngle - 2.0f * penumbraAngle;
+	}
+	else if( *penumbraType == "outset" )
+	{
+		outerAngle = coneAngle + 2.0f * penumbraAngle;
+		innerAngle = coneAngle ;
+	}
+	else if( *penumbraType == "absolute" )
+	{
+		outerAngle = coneAngle;
+		innerAngle = penumbraAngle;
+	}
+
+	lensRadius = 0.0f;
+	if( parameter<bool>( metadataTarget, shaderParameters, "lensRadiusEnableParameter", true ) )
+	{
+		lensRadius = parameter<float>( metadataTarget, shaderParameters, "lensRadiusParameter", 0.0f );
+	}
 }
 
 const char *StandardLightVisualiser::faceCameraVertexSource()


### PR DESCRIPTION
Hey John,

sorry, I got distracted by debugging a crash yesterday. Here's the PR moved from my repo to GafferHQ.

For anyone following along, we've added light filters to master recently. This contains all those commits with additional ones that add visualisers for decays, barndoors and gobos. Arnold's light filters only at the moment, but the general mechanism allows adding more later.

I am happy to put in some more work to get this c++11 ready so that we can merge the visualisers into master, too.

Thanks,

Matti.
