### PR TITLE
Use LRUCache for Hash Cache

### DIFF
--- a/include/Gaffer/Private/IECorePreview/LRUCache.h
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2007-2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2007-2017, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,48 +35,66 @@
 #ifndef IECOREPREVIEW_LRUCACHE_H
 #define IECOREPREVIEW_LRUCACHE_H
 
-#include <vector>
-
-#include "tbb/spin_mutex.h"
-#include "tbb/spin_rw_mutex.h"
-
 #include "boost/noncopyable.hpp"
 #include "boost/function.hpp"
-#include "boost/unordered_map.hpp"
+#include "boost/variant.hpp"
 
 namespace IECorePreview
 {
 
+namespace LRUCachePolicy
+{
+
+/// Not threadsafe. Either use from only a single thread
+/// or protect with an external mutex. Key type must have
+/// a `hash_value` implementation as described in the boost
+/// documentation.
+template<typename LRUCache>
+class Serial;
+
+/// Threadsafe, `get()` blocks if another thread is already
+/// computing the value. Key type must have a `hash_value`
+/// implementation as described in the boost documentation.
+template<typename LRUCache>
+class Parallel;
+
+} // namespace LRUCachePolicy
+
 /// A mapping from keys to values, where values are computed from keys using a user
 /// supplied function. Recently computed values are stored in the cache to accelerate
 /// subsequent lookups. Each value has a cost associated with it, and the cache has
-/// a maximum total cost above which it will remove the (approximately) least recently
-/// accessed items.
-///
-/// The Key type must be hashable using boost::hash().
+/// a maximum total cost above which it will remove the least recently accessed items.
 ///
 /// The Value type must be default constructible, copy constructible and assignable.
 /// Note that Values are returned by value, and erased by assigning a default constructed
 /// value. In practice this means that a smart pointer is the best choice of Value.
 ///
-/// \threading It is safe to call the methods of LRUCache from concurrent threads.
+/// The Policy determines the thread safety, eviction and performance characteristics
+/// of the cache. See the documentation for each individual policy in the LRUCachePolicy
+/// namespace.
+///
+///	The GetterKey may be used where the GetterFunction requires some auxiliary information
+/// in addition to the Key. It must be implicitly castable to Key, and all GetterKeys
+/// which yield the same Key must also yield the same results from the GetterFunction.
+///
 /// \ingroup utilityGroup
-template<typename Key, typename Value>
+template<typename Key, typename Value, template <typename> class Policy=LRUCachePolicy::Parallel, typename GetterKey=Key>
 class LRUCache : private boost::noncopyable
 {
 	public:
 
 		typedef size_t Cost;
+		typedef Key KeyType;
 
 		/// The GetterFunction is responsible for computing the value and cost for a cache entry
 		/// when given the key. It should throw a descriptive exception if it can't get the data for
-		/// any reason. It is unsafe to access the LRUCache itself from the GetterFunction.
-		typedef boost::function<Value ( const Key &key, Cost &cost )> GetterFunction;
+		/// any reason.
+		typedef boost::function<Value ( const GetterKey &key, Cost &cost )> GetterFunction;
 		/// The optional RemovalCallback is called whenever an item is discarded from the cache.
-		///  It is unsafe to access the LRUCache itself from the RemovalCallback.
 		typedef boost::function<void ( const Key &key, const Value &data )> RemovalCallback;
 
-		LRUCache( GetterFunction getter, Cost maxCost = 500 );
+		LRUCache( GetterFunction getter );
+		LRUCache( GetterFunction getter, Cost maxCost );
 		LRUCache( GetterFunction getter, RemovalCallback removalCallback, Cost maxCost );
 		virtual ~LRUCache();
 
@@ -85,7 +103,7 @@ class LRUCache : private boost::noncopyable
 		/// cache at any time by operations on another thread, or may not
 		/// even be stored in the cache if it exceeds the maximum cost.
 		/// Throws if the item can not be computed.
-		Value get( const Key &key );
+		Value get( const GetterKey &key );
 
 		/// Adds an item to the cache directly, bypassing the GetterFunction.
 		/// Returns true for success and false on failure - failure can occur
@@ -123,6 +141,9 @@ class LRUCache : private boost::noncopyable
 		// Data
 		//////////////////////////////////////////////////////////////////////////
 
+		// Give Policy access to CacheEntry definitions.
+		friend class Policy<LRUCache>;
+
 		// A function for computing values, and one for notifying of removals.
 		GetterFunction m_getter;
 		RemovalCallback m_removalCallback;
@@ -130,250 +151,57 @@ class LRUCache : private boost::noncopyable
 		// Status of each item in the cache.
 		enum Status
 		{
-			New, // brand new unpopulated entry
-			Cached, // entry complete with value
-			TooCostly, // entry cost exceeds m_maxCost and therefore isn't stored
+			Uncached, // entry without valid value
+			Cached, // entry with valid value
 			Failed // m_getter failed when computing entry
 		};
 
-		// CacheEntry implementation - a single item of the cache.
+		// The type used to store a single cached item.
 		struct CacheEntry
 		{
-			CacheEntry(); // status == New
-			CacheEntry( const CacheEntry &other );
+			CacheEntry();
 
-			Value value; // value for this item
+			// We use a boost::variant to compactly store
+			// a union of the data needed for each Status.
+			//
+			// - Uncached : A boost::blank instance
+			// - Cached : The Value itself
+			// - Failed ; A bool marker?  Will this work as a hack to get this to compile?
+			typedef boost::variant<boost::blank, Value, bool> State;
+
+			State state;
 			Cost cost; // the cost for this item
 
-			char status; // status of this item
-			bool recentlyUsed;
-		};
-
-		// Map from keys to items - this forms the basis of
-		// our cache.
-		typedef boost::unordered_map<Key, CacheEntry> Map;
-		typedef typename Map::value_type MapValue;
-
-		// In various use cases we need to support
-		// concurrent access from many threads, and it's
-		// important that we do this efficiently. Our
-		// map type is not threadsafe, and a global mutex
-		// would be inefficient, so we take a binned approach.
-		// We store N internal maps, and use the hash of the
-		// key to determine which particular map that key
-		// should be stored in. This means that provided
-		// different threads are accessing different map
-		// values, they don't contend for a mutex at all.
-		struct Bin
-		{
-			typedef tbb::spin_rw_mutex Mutex;
-			Map map;
-			Mutex mutex;
-		};
-
-		typedef std::vector<boost::shared_ptr<Bin> > Bins;
-		Bins m_bins;
-
-		// Handle class to abstract away the binned
-		// storage strategy. Internally holds an iterator
-		// into one of the maps and holds the lock for
-		// that map. All access to the bins must be
-		// made through this class. Similar to an iterator
-		// interface, but without any copy or assignment
-		// operations, since those would require transfer
-		// of the internal lock, which is problematic.
-		class Handle : public boost::noncopyable
-		{
-
-			public :
-
-				Handle()
-					:	m_cache( NULL ), m_binIndex( 0 )
-				{
-				}
-
-				~Handle()
-				{
-					release();
-				}
-
-				void begin( LRUCache *cache )
-				{
-					release();
-					m_cache = cache;
-					acquireBin( 0 );
-					m_it = map().begin();
-					whileAtEndMoveToNextBin();
-				}
-
-				// If write == false and createIfMissing == true, then a read lock is acquired
-				// if the item exists already, otherwise a write lock is acquired on a newly
-				// created item. Returns true if an item was created, false otherwise.
-				bool acquire( LRUCache *cache, const Key &key, bool write = true, bool createIfMissing = false )
-				{
-					release();
-					m_cache = cache;
-					acquireBin( binIndex( key ), write );
-
-					if( write && createIfMissing )
-					{
-						const std::pair<Iterator, bool> i = map().insert( MapValue( key, CacheEntry() ) );
-						m_it = i.first;
-						return i.second;
-					}
-					else
-					{
-						m_it = map().find( key );
-						if( m_it != map().end() )
-						{
-							return false;
-						}
-						else if( createIfMissing )
-						{
-							assert( write == false );
-							m_binLock.upgrade_to_writer();
-							m_it = map().insert( MapValue( key, CacheEntry() ) ).first;
-							return true;
-						}
-						else
-						{
-							release();
-							return false;
-						}
-					}
-				}
-
-				void upgradeToWriter()
-				{
-					const Key key = m_it->first;
-					if( m_binLock.upgrade_to_writer() )
-					{
-						// Clean upgrade to writer status
-						// without giving up read lock.
-						return;
-					}
-					else
-					{
-						// We have been upgraded to writer
-						// status, but we had to temporarily
-						// give up our lock to get there. Another
-						// thread may have invalidated our iterator,
-						// so get it again.
-						m_it = map().insert( MapValue( key, CacheEntry() ) ).first;
-					}
-				}
-
-				void release()
-				{
-					if( m_cache )
-					{
-						releaseBin();
-						m_cache = NULL;
-					}
-				}
-
-				void increment()
-				{
-					m_it++;
-					whileAtEndMoveToNextBin();
-				}
-
-				void erase()
-				{
-					map().erase( m_it );
-				}
-
-				void eraseAndIncrement()
-				{
-					Iterator nextIt = m_it; nextIt++;
-					map().erase( m_it );
-					m_it = nextIt;
-					whileAtEndMoveToNextBin();
-				}
-
-				bool valid()
-				{
-					return m_cache && m_it != map().end();
-				}
-
-				MapValue &operator*()
-				{
-					return *m_it;
-				}
-
-				MapValue *operator->()
-				{
-					return &(*m_it);
-				}
-
-			private :
-
-				typedef typename Map::iterator Iterator;
-
-				LRUCache *m_cache;
-				size_t m_binIndex;
-				typename Bin::Mutex::scoped_lock m_binLock;
-				Iterator m_it;
-
-				Map &map()
-				{
-					return m_cache->m_bins[m_binIndex]->map;
-				}
-
-				void whileAtEndMoveToNextBin()
-				{
-					while( m_it == m_cache->m_bins[m_binIndex]->map.end() && m_binIndex < m_cache->m_bins.size() - 1 )
-					{
-						releaseBin();
-						acquireBin( m_binIndex + 1 );
-						m_it = map().begin();
-					}
-				}
-
-				void acquireBin( size_t binIndex, bool write = true )
-				{
-					m_binIndex = binIndex;
-					m_binLock.acquire( m_cache->m_bins[binIndex]->mutex, write );
-				}
-
-				void releaseBin()
-				{
-					m_binLock.release();
-				}
-
-				size_t binIndex( const Key &key ) const
-				{
-					return boost::hash<Key>()( key ) % m_cache->m_bins.size();
-				}
+			Status status() const;
 
 		};
 
-		// Total cost. We store the current cost atomically so it can be updated
-		// concurrently by multiple threads.
-		typedef tbb::atomic<Cost> AtomicCost;
-		AtomicCost m_currentCost;
+		// Policy. This is responsible for
+		// the internal storage for the cache.
+		Policy<LRUCache> m_policy;
+
 		Cost m_maxCost;
 
-		// These methods set/erase a cached value, updating the current
-		// cost appropriately. The caller must hold the lock for the bin
-		// containing the value.
-		bool setInternal( MapValue &mapValue, const Value &value, Cost cost );
-		bool eraseInternal( MapValue &mapValue );
+		// Methods
+		// =======
 
-		// When our current cost goes over the limit, we must discard
-		// cached values until the cost is back under the threshold.
-		// We do this by cycling through our cache using a "second chance"
-		// algorithm to determine what to remove. No locks must be held
-		// when calling limitCost().
-		tbb::spin_mutex m_limitCostMutex;
-		Key m_limitCostSweepPosition;
-		void limitCost();
+		// Updates the cached value and updates the current
+		// total cost.
+		bool setInternal( const Key &key, CacheEntry &cacheEntry, const Value &value, Cost cost );
+
+		// Removes any cached value and updates the current total
+		// cost.
+		bool eraseInternal( const Key &key, CacheEntry &cacheEntry );
+
+		// Removes items from the cache until the current cost is
+		// at or below the specified limit.
+		void limitCost( Cost cost );
 
 		static void nullRemovalCallback( const Key &key, const Value &value );
 
 };
 
-} // namespace IECorePreview
+} // namespace IECore
 
 #include "Gaffer/Private/IECorePreview/LRUCache.inl"
 

--- a/include/Gaffer/Private/IECorePreview/LRUCache.inl
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.inl
@@ -33,121 +33,623 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef IECOREPREVIEW_LRUCACHE_INL
-#define IECOREPREVIEW_LRUCACHE_INL
+#ifndef IECORE_LRUCACHE_INL
+#define IECORE_LRUCACHE_INL
 
 #include <cassert>
+#include <iostream>
+//#include <tuple>
 
+#include "tbb/spin_mutex.h"
+#include "tbb/spin_rw_mutex.h"
 #include "tbb/tbb_thread.h"
+
+#include "boost/multi_index_container.hpp"
+#include "boost/multi_index/hashed_index.hpp"
+#include "boost/multi_index/sequenced_index.hpp"
+#include "boost/multi_index/member.hpp"
+#include "boost/unordered_map.hpp"
 
 #include "IECore/Exception.h"
 
 namespace IECorePreview
 {
 
-template<typename Key, typename Value>
-LRUCache<Key, Value>::CacheEntry::CacheEntry()
-	:	value(), cost( 0 ), status( New ), recentlyUsed( false )
+// Policies
+// =======================================================================
+//
+// The policies are responsible for implementing the principle
+// data structures of the cache. Conceptually they contain a mapping from
+// Key to CacheEntry and a separate list sorted in least-recently-used order.
+// In practice, any data structure can be used provided the interface
+// described below is presented. The required interface is documented
+// on the Serial policy only for simplicity.
+namespace LRUCachePolicy
+{
+
+enum AcquireMode
+{
+	FindReadable,
+	FindWritable,
+	// Writability of handle is determined
+	// by CacheEntry status - writable if
+	// Uncached and read only otherwise.
+	Insert,
+	InsertWritable
+};
+
+
+// Uses a boost::multi_index_container to implement a map
+// and list in a single container. This gives much improved
+// performance over separate containers because it halves the
+// allocations needed, and moving items within the list doesn't
+// require any allocation at all. We keep the list in exact LRU
+// order.
+template<typename LRUCache>
+class Serial
+{
+
+	public :
+
+		typedef typename LRUCache::CacheEntry CacheEntry;
+		typedef typename LRUCache::KeyType Key;
+
+		struct Item
+		{
+			Item( const Key &key )
+				:	key( key ), hasHandle( false )
+			{
+			}
+
+			Key key;
+			// multi_index_containers have const elements
+			// so you can't modify something being used as
+			// as key. we know that cacheEntry is not used
+			// as a key, so can safely make it mutable to
+			// get non-const access to it.
+			mutable CacheEntry cacheEntry;
+			mutable bool hasHandle;
+		};
+
+		typedef boost::multi_index_container<
+			Item,
+			boost::multi_index::indexed_by<
+				// First index is equivalent to std::unordered_map,
+				// using Item::key as the key.
+				boost::multi_index::hashed_unique<
+					boost::multi_index::member<Item, Key, &Item::key>
+				>,
+				// Second index is equivalent to std::list.
+				boost::multi_index::sequenced<>
+			>
+		> MapAndList;
+
+		typedef typename MapAndList::iterator MapIterator;
+		typedef typename MapAndList::template nth_index<1>::type List;
+
+		Serial()
+			:	currentCost( 0 )
+		{
+		}
+
+		// The Handle class provides controlled access to
+		// a CacheEntry stored within the policy. Handles
+		// provide read and possibly write access to the
+		// CacheEntry, depending on how they have been
+		// acquired. The Handle must be kept alive for as
+		// long as the CacheEntry is accessed.
+		struct Handle : private boost::noncopyable
+		{
+
+			Handle()
+				:	m_inited( false )
+			{
+			}
+
+			~Handle()
+			{
+				release();
+			}
+
+			// Read access to the underlying cache entry.
+			const CacheEntry &readable()
+			{
+				return m_it->cacheEntry;
+			}
+
+			// Write access to the underlying cache entry.
+			// Note that write access is not always permitted
+			// - see documentation for `acquire()` and
+			// AcquireMode.
+			CacheEntry &writable()
+			{
+				return m_it->cacheEntry;
+			}
+
+			void release()
+			{
+				if( m_inited )
+				{
+					m_it->hasHandle = false;
+				}
+			}
+
+			private :
+
+				void init( MapIterator it )
+				{
+					assert( !m_inited );
+					m_it = it;
+					assert( !m_it->hasHandle );
+					m_it->hasHandle = true;
+					m_inited = true;
+				}
+
+				friend class Serial;
+				MapIterator m_it;
+				bool m_inited;
+
+		};
+
+		// Acquires a handle for the given key. Whether the
+		// handle is writable or not is determined by the AcquireMode.
+		// Returns true on success and false if no entry was
+		// found.
+		bool acquire( const Key &key, Handle &handle, AcquireMode mode )
+		{
+			if( mode == Insert || mode == InsertWritable )
+			{
+				// Inserting via the map index automatically puts the new item
+				// at the back of the list.
+				std::pair<MapIterator, bool> i = m_mapAndList.insert( Item( key ) );
+				handle.init( i.first );
+				return true;
+			}
+			else
+			{
+				assert( mode == FindReadable || mode == FindWritable );
+				MapIterator it = m_mapAndList.find( key );
+				if( it == m_mapAndList.end() )
+				{
+					return false;
+				}
+				handle.init( it );
+				return true;
+			}
+		}
+
+		// Marks the CacheEntry referred to by the handle as recently
+		// used.
+		void push( Handle &handle )
+		{
+			List &list = m_mapAndList.template get<1>();
+			list.relocate( list.end(), list.iterator_to( *(handle.m_it) ) );
+		}
+
+		// Pops a copy of the least recently used CacheEntry from the policy,
+		// removing it from the internal storage. Returns true for success
+		// and false for failure.
+		bool pop( Key &key, CacheEntry &cacheEntry )
+		{
+			List &list = m_mapAndList.template get<1>();
+
+			// Find the first item that doesn't have a handle
+			// referring to it. Although we don't support threaded
+			// access, there may still be existing handles if the
+			// GetterFunction has reentered the cache with a call
+			// to `get( someOtherKey )`, and this inner call has
+			// then entered `limitCost()`.
+			typename List::iterator it = list.begin();
+			while( it != list.end() && it->hasHandle )
+			{
+				++it;
+			}
+
+			if( it == list.end() )
+			{
+				return false;
+			}
+
+			const Item &item = *it;
+
+			key = item.key;
+			cacheEntry = item.cacheEntry;
+
+			list.erase( it );
+
+			return true;
+		}
+
+		typename LRUCache::Cost currentCost;
+
+	private :
+
+		MapAndList m_mapAndList;
+
+};
+
+// Uses a binned map to allow concurrent map operations, and
+// uses a second-chance algorithm to avoid the serial operations
+// associated with managing an LRU list.
+template<typename LRUCache>
+class Parallel
+{
+
+	public :
+
+		typedef typename LRUCache::CacheEntry CacheEntry;
+		typedef typename LRUCache::KeyType Key;
+		typedef tbb::atomic<typename LRUCache::Cost> AtomicCost;
+
+		struct Item
+		{
+			Item() : recentlyUsed() {}
+			Item( const Key &key ) : key( key ), recentlyUsed() {}
+			Item( const Item &other ) : key( other.key ), cacheEntry( other.cacheEntry ), recentlyUsed() {}
+			Key key;
+			mutable CacheEntry cacheEntry;
+			// Mutex to protect cacheEntry.
+			typedef tbb::spin_rw_mutex Mutex;
+			mutable Mutex mutex;
+			// Flag used in second-chance algorithm.
+			mutable tbb::atomic<bool> recentlyUsed;
+		};
+
+		// We would love to use one of TBB's concurrent containers as
+		// our map, but we need the ability to insert, erase and iterate
+		// concurrently. The concurrent_unordered_map doesn't provide
+		// concurrent erase, and the concurrent_hash_map doesn't provide
+		// concurrent iteration. Instead we choose a non-threadsafe
+		// container, but split our storage into multiple bins with a
+		// container in each bin. This way concurrent operations do not
+		// contend on a lock unless they happen to target the same bin.
+		typedef boost::multi_index::multi_index_container<
+			Item,
+			boost::multi_index::indexed_by<
+				// Equivalent to std::unordered_map, using Item::key
+				// as the key. This actually has a couple of benefits
+				// over std::unordered_map :
+				//
+				// - Insertion does not invalidate existing iterators.
+				//   This allows us to store m_popIterator.
+				// - Lookup can be performed using types other than the
+				//   key. This provides the possibility of creating a
+				//   prehashed key prior to taking a Bin lock, although
+				//   this is not implemented here yet.
+				boost::multi_index::hashed_unique<
+					boost::multi_index::member<Item, Key, &Item::key>
+				>
+			>
+		> Map;
+
+		typedef typename Map::iterator MapIterator;
+
+		struct Bin
+		{
+			Bin() {}
+			Bin( const Bin &other ) : map( other.map ) {}
+			Bin &operator = ( const Bin &other ) { map = other.map; return *this; }
+			Map map;
+			typedef tbb::spin_rw_mutex Mutex;
+			Mutex mutex;
+		};
+
+		typedef std::vector<Bin> Bins;
+
+		Parallel()
+		{
+			m_bins.resize( tbb::tbb_thread::hardware_concurrency() );
+			m_popBinIndex = 0;
+			m_popIterator = m_bins[0].map.begin();
+			currentCost = 0;
+		}
+
+		struct Handle : private boost::noncopyable
+		{
+
+			Handle()
+				:	m_item( NULL ), m_writable( false )
+			{
+			}
+
+			~Handle()
+			{
+			}
+
+			const CacheEntry &readable()
+			{
+				return m_item->cacheEntry;
+			}
+
+			CacheEntry &writable()
+			{
+				assert( m_writable );
+				return m_item->cacheEntry;
+			}
+
+			void release()
+			{
+				if( m_item )
+				{
+					m_itemLock.release();
+					m_item = NULL;
+				}
+			}
+
+			private :
+
+				bool acquire( Bin &bin, const Key &key, AcquireMode mode )
+				{
+					assert( !m_item );
+
+					// Acquiring a handle requires taking two
+					// locks, first the lock for the Bin, and
+					// second the lock for the Item. We must be
+					// careful to avoid deadlock in the case of
+					// a GetterFunction which reenters the cache.
+
+					typename Bin::Mutex::scoped_lock binLock;
+					while( true )
+					{
+						// Acquire a lock on the bin, and get an iterator
+						// from the key. We optimistically assume the item
+						// may already be in the cache and first do a find()
+						// using a bin read lock. This gives us much better
+						// performance when many threads contend for items
+						// that are already in the cache.
+						binLock.acquire( bin.mutex, /* write = */ false );
+						MapIterator it = bin.map.find( key );
+						bool inserted = false;
+						if( it == bin.map.end() )
+						{
+							if( mode != Insert && mode != InsertWritable )
+							{
+								return false;
+							}
+							binLock.upgrade_to_writer();
+							std::pair<MapIterator,bool> insertResult = bin.map.insert( Item( key ) );
+							it = insertResult.first;
+							inserted = insertResult.second;
+						}
+						// Now try to get a lock on the item we want to
+						// acquire. When we've just inserted a new item
+						// we take a write lock directly, because we know
+						// we'll need to write to the new item. When insertion
+						// found a pre-existing item we optimistically take
+						// just a read lock, because it is faster when
+						// many threads just need to read from the same
+						// cached item.
+						m_writable = inserted || mode == FindWritable || mode == InsertWritable;
+
+						if( m_itemLock.try_acquire( it->mutex, /* write = */ m_writable ) )
+						{
+							if( !m_writable && mode == Insert && it->cacheEntry.status() == LRUCache::Uncached )
+							{
+								// We found an old item that doesn't have
+								// a value. This can either be because it
+								// was erased but hasn't been popped yet,
+								// or because the item was too big to fit
+								// in the cache. Upgrade to writer status
+								// so it can be updated in get().
+								m_itemLock.upgrade_to_writer();
+								m_writable = true;
+							}
+							// Success!
+							m_item = &*it;
+							return true;
+						}
+						else
+						{
+							// The Item lock is held by another thread.
+							// We must release the Bin lock and retry. This
+							// avoids deadlock when the GetterFunction holding
+							// the Item lock calls back into the cache and tries to
+							// access another item in the same Bin.
+							binLock.release();
+						}
+					}
+				}
+
+				friend class Parallel;
+
+				const Item *m_item;
+				typename Item::Mutex::scoped_lock m_itemLock;
+				bool m_writable;
+
+		};
+
+		bool acquire( const Key &key, Handle &handle, AcquireMode mode )
+		{
+			return handle.acquire( bin( key ), key, mode );
+		}
+
+		void push( Handle &handle )
+		{
+			// Simply mark the item as having been used
+			// recently. We will then give it a second chance
+			// in pop(), so it will not be evicted immediately.
+			// We don't need the handle to be writable to write
+			// here, because `recentlyUsed` is atomic.
+			handle.m_item->recentlyUsed = true;
+		}
+
+		bool pop( Key &key, CacheEntry &cacheEntry )
+		{
+			// Popping works by iterating the map until an item
+			// that has not been recently used is found. We store
+			// the current iteration position as m_popIterator and
+			// protect it with m_popMutex, taking the position that
+			// it is sufficient for only one thread to be limiting
+			// cost at any given time.
+			PopMutex::scoped_lock lock;
+			if( !lock.try_acquire( m_popMutex ) )
+			{
+				return false;
+			}
+
+			Bin *bin = &m_bins[m_popBinIndex];
+			typename Bin::Mutex::scoped_lock binLock( bin->mutex );
+
+			typename Item::Mutex::scoped_lock itemLock;
+			while( true )
+			{
+				// If we're at the end of this bin, advance to
+				// the next non-empty one.
+				const MapIterator emptySentinel = bin->map.end();
+				while( m_popIterator == bin->map.end() )
+				{
+					binLock.release();
+					m_popBinIndex = ( m_popBinIndex + 1 ) % m_bins.size();
+					bin = &m_bins[m_popBinIndex];
+					binLock.acquire( bin->mutex );
+					m_popIterator = bin->map.begin();
+					if( m_popIterator == emptySentinel )
+					{
+						// We've come full circle and all bins were empty.
+						return false;
+					}
+				}
+
+				if( itemLock.try_acquire( m_popIterator->mutex ) )
+				{
+					if( !m_popIterator->recentlyUsed )
+					{
+						// Pop this item.
+						key = m_popIterator->key;
+						cacheEntry = m_popIterator->cacheEntry;
+						// Now erase it from the bin.
+						// We must release the lock on the Item before erasing it,
+						// because we cannot release a lock on a mutex that is
+						// already destroyed. We know that no other thread can
+						// gain access to the item though, because they must
+						// acquire the Bin lock to do so, and we still hold the
+						// Bin lock.
+						itemLock.release();
+						m_popIterator = bin->map.erase( m_popIterator );
+						return true;
+					}
+					else
+					{
+						// Item has been used recently. Flag it so we
+						// can pop it next time round, unless another
+						// thread resets the flag.
+						m_popIterator->recentlyUsed = false;
+						itemLock.release();
+					}
+				}
+				else
+				{
+					// Failed to acquire the item lock. Some other
+					// thread is busy with this item, so we consider
+					// it to be recently used and just skip over it.
+				}
+
+				++m_popIterator;
+			}
+		}
+
+		AtomicCost currentCost;
+
+	private :
+
+		Bins m_bins;
+
+		Bin &bin( const Key &key )
+		{
+			size_t binIndex = boost::hash<Key>()( key ) % m_bins.size();
+			return m_bins[binIndex];
+		};
+
+		typedef tbb::spin_mutex PopMutex;
+		PopMutex m_popMutex;
+		size_t m_popBinIndex;
+		MapIterator m_popIterator;
+
+};
+
+} // namespace LRUCachePolicy
+
+// CacheEntry
+// =======================================================================
+
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::CacheEntry::CacheEntry()
+	:	cost( 0 )
 {
 }
 
-template<typename Key, typename Value>
-LRUCache<Key, Value>::CacheEntry::CacheEntry( const CacheEntry &other )
-	:	value( other.value ), cost( other.cost ), status( other.status ), recentlyUsed( other.recentlyUsed )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+typename LRUCache<Key, Value, Policy, GetterKey>::Status LRUCache<Key, Value, Policy, GetterKey>::CacheEntry::status() const
+{
+	return static_cast<Status>( state.which() );
+}
+
+// LRUCache
+// =======================================================================
+
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::LRUCache( GetterFunction getter )
+	:	m_getter( getter ), m_removalCallback( nullRemovalCallback ), m_maxCost( 500 )
 {
 }
 
-template<typename Key, typename Value>
-LRUCache<Key, Value>::LRUCache( GetterFunction getter, Cost maxCost )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::LRUCache( GetterFunction getter, Cost maxCost )
 	:	m_getter( getter ), m_removalCallback( nullRemovalCallback ), m_maxCost( maxCost )
 {
-	m_currentCost = 0;
-	for( size_t i = 0, e = tbb::tbb_thread::hardware_concurrency(); i < e; ++i )
-	{
-		m_bins.push_back( boost::shared_ptr<Bin>( new Bin ) );
-	}
 }
 
-template<typename Key, typename Value>
-LRUCache<Key, Value>::LRUCache( GetterFunction getter, RemovalCallback removalCallback, Cost maxCost )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::LRUCache( GetterFunction getter, RemovalCallback removalCallback, Cost maxCost )
 	:	m_getter( getter ), m_removalCallback( removalCallback ), m_maxCost( maxCost )
 {
-	m_currentCost = 0;
-	for( size_t i = 0, e = tbb::tbb_thread::hardware_concurrency(); i < e; ++i )
-	{
-		m_bins.push_back( boost::shared_ptr<Bin>( new Bin ) );
-	}
 }
 
-template<typename Key, typename Value>
-LRUCache<Key, Value>::~LRUCache()
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::~LRUCache()
 {
 }
 
-template<typename Key, typename Value>
-void LRUCache<Key, Value>::clear()
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+void LRUCache<Key, Value, Policy, GetterKey>::clear()
 {
-	Handle handle;
-	handle.begin( this );
-	while( handle.valid() )
+	Key key;
+	CacheEntry cacheEntry;
+	while( m_policy.pop( key, cacheEntry ) )
 	{
-		eraseInternal( *handle );
-		handle.eraseAndIncrement();
+		eraseInternal( key, cacheEntry );
 	}
 }
 
-template<typename Key, typename Value>
-void LRUCache<Key, Value>::setMaxCost( Cost maxCost )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+void LRUCache<Key, Value, Policy, GetterKey>::setMaxCost( Cost maxCost )
 {
 	m_maxCost = maxCost;
-	limitCost();
+	limitCost( maxCost );
 }
 
-template<typename Key, typename Value>
-typename LRUCache<Key, Value>::Cost LRUCache<Key, Value>::getMaxCost() const
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+typename LRUCache<Key, Value, Policy, GetterKey>::Cost LRUCache<Key, Value, Policy, GetterKey>::getMaxCost() const
 {
 	return m_maxCost;
 }
 
-template<typename Key, typename Value>
-typename LRUCache<Key, Value>::Cost LRUCache<Key, Value>::currentCost() const
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+typename LRUCache<Key, Value, Policy, GetterKey>::Cost LRUCache<Key, Value, Policy, GetterKey>::currentCost() const
 {
-	return m_currentCost;
+	return m_policy.currentCost;
 }
 
-template<typename Key, typename Value>
-Value LRUCache<Key, Value>::get( const Key& key )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+Value LRUCache<Key, Value, Policy, GetterKey>::get( const GetterKey &key )
 {
-	Handle handle;
-	if( !handle.acquire( this, key, /* write = */ false, /* createIfMissing = */ true ) )
+	typename Policy<LRUCache>::Handle handle;
+	m_policy.acquire( key, handle, LRUCachePolicy::Insert );
+	const CacheEntry &cacheEntry = handle.readable();
+	const Status status = cacheEntry.status();
+
+	if( status==Uncached )
 	{
-		// We found an existing entry, and have a read lock for it.
-		// If the value is cached already and the recentlyUsed flag
-		// is already set, we have no need of a write lock at all.
-		// This gives us a significant performance boost when the
-		// cache is heavily contended on the same already-cached
-		// items.
-		const CacheEntry &cacheEntry = handle->second;
-		if( cacheEntry.status == Cached && cacheEntry.recentlyUsed )
-		{
-			return cacheEntry.value;
-		}
-		else
-		{
-			// Upgrade to writer and fall through to general case below.
-			handle.upgradeToWriter();
-		}
-	}
-
-	// We have a write lock, and the item may or may not be
-	// cached already.
-
-	CacheEntry &cacheEntry = handle->second;
-
-	if( cacheEntry.status==New || cacheEntry.status==TooCostly )
-	{
-		assert( cacheEntry.value==Value() );
-
 		Value value = Value();
 		Cost cost = 0;
 		try
@@ -156,184 +658,124 @@ Value LRUCache<Key, Value>::get( const Key& key )
 		}
 		catch( ... )
 		{
-			cacheEntry.status = Failed;
+			handle.writable().state = Failed;
 			throw;
 		}
 
-		assert( cacheEntry.status != Cached ); // this would indicate that another thread somehow
-		assert( cacheEntry.status != Failed ); // loaded the same thing as us, which is not the intention.
+		assert( cacheEntry.status() != Cached ); // this would indicate that another thread somehow
+		assert( cacheEntry.status() != Failed ); // loaded the same thing as us, which is not the intention.
 
-		setInternal( *handle, value, cost );
-
-		assert( cacheEntry.status == Cached || cacheEntry.status == TooCostly );
+		setInternal( key, handle.writable(), value, cost );
+		m_policy.push( handle );
 
 		handle.release();
-		limitCost();
+		limitCost( m_maxCost );
 
 		return value;
 	}
-	else if( cacheEntry.status==Cached )
+	else if( status==Cached )
 	{
-		Value result = cacheEntry.value;
-		cacheEntry.recentlyUsed = true;
-		return result;
+		m_policy.push( handle );
+		return boost::get<Value>( cacheEntry.state );
 	}
 	else
 	{
-		assert( cacheEntry.status==Failed );
+		// Had to switch back to this crappy solution due to not having std::exception_ptr in old C++
 		throw IECore::Exception( "Previous attempt to get item failed." );
 	}
 }
 
-template<typename Key, typename Value>
-bool LRUCache<Key, Value>::set( const Key &key, const Value &value, Cost cost )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::set( const Key &key, const Value &value, Cost cost )
 {
-	Handle handle;
-	handle.acquire( this, key, /* write = */ true, /* createIfMissing = */ true );
-
-	const bool result = setInternal( *handle, value, cost );
-
+	typename Policy<LRUCache>::Handle handle;
+	m_policy.acquire( key, handle, LRUCachePolicy::InsertWritable );
+	bool result = setInternal( key, handle.writable(), value, cost );
+	m_policy.push( handle );
 	handle.release();
-	limitCost();
-
+	limitCost( m_maxCost );
 	return result;
 }
 
-template<typename Key, typename Value>
-bool LRUCache<Key, Value>::cached( const Key &key ) const
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::setInternal( const Key &key, CacheEntry &cacheEntry, const Value &value, Cost cost )
 {
-	Handle handle;
-	handle.acquire( const_cast<LRUCache *>( this ), key, /* write = */ false, /* createIfMissing = */ false );
-	return handle.valid() && handle->second.status == Cached;
+	eraseInternal( key, cacheEntry );
+
+	if( cost > m_maxCost )
+	{
+		return false;
+	}
+
+	cacheEntry.state = value;
+	cacheEntry.cost = cost;
+
+	m_policy.currentCost += cost;
+
+	return true;
 }
 
-template<typename Key, typename Value>
-bool LRUCache<Key, Value>::erase( const Key &key )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::cached( const Key &key ) const
 {
-	Handle handle;
-	handle.acquire( this, key, /* write = */ true, /* createIfMissing = */ false );
-	if( handle.valid() )
+	typename Policy<LRUCache>::Handle handle;
+	// Preferring const_cast over forcing all policies to implement
+	// a ConstHandle and const acquire() variant.
+	if( !const_cast<Policy<LRUCache> &>( m_policy ).acquire( key, handle, LRUCachePolicy::FindReadable ) )
 	{
-		eraseInternal( *handle );
-		handle.erase();
-		return true;
+		return false;
 	}
-	return false;
+
+	return handle.readable().status() == Cached;
 }
 
-template<typename Key, typename Value>
-bool LRUCache<Key, Value>::setInternal( MapValue &mapValue, const Value &value, Cost cost )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::erase( const Key &key )
 {
-	// Erase the old value, adjusting the current cost.
-	eraseInternal( mapValue );
-
-	// Store the new value if we can, and again adjust
-	// the current cost.
-	CacheEntry &cacheEntry = mapValue.second;
-	bool result = true;
-	if( cost <= m_maxCost )
+	typename Policy<LRUCache>::Handle handle;
+	if( !m_policy.acquire( key, handle, LRUCachePolicy::FindWritable ) )
 	{
-		cacheEntry.value = value;
-		cacheEntry.cost = cost;
-		cacheEntry.status = Cached;
-		cacheEntry.recentlyUsed = true;
-		m_currentCost += cost;
-	}
-	else
-	{
-		cacheEntry.status = TooCostly;
-		cacheEntry.recentlyUsed = false;
-		result = false;
+		return false;
 	}
 
-	return result;
+	return eraseInternal( key, handle.writable() );
 }
 
-template<typename Key, typename Value>
-bool LRUCache<Key, Value>::eraseInternal( MapValue &mapValue )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::eraseInternal( const Key &key, CacheEntry &cacheEntry )
 {
-	CacheEntry &cacheEntry = mapValue.second;
-	const Status originalStatus = (Status)cacheEntry.status;
-
-	if( originalStatus == Cached )
+	const Status status = cacheEntry.status();
+	if( status == Cached )
 	{
-		m_removalCallback( mapValue.first, cacheEntry.value );
-		m_currentCost -= cacheEntry.cost;
-		cacheEntry.value = Value();
+		m_removalCallback( key, boost::get<Value>( cacheEntry.state ) );
+		m_policy.currentCost -= cacheEntry.cost;
 	}
 
-	return originalStatus == Cached;
+	cacheEntry.state = boost::blank();
+	return status == Cached;
 }
 
-template<typename Key, typename Value>
-void LRUCache<Key, Value>::limitCost()
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+void LRUCache<Key, Value, Policy, GetterKey>::limitCost( Cost cost )
 {
-	tbb::spin_mutex::scoped_lock lock;
-	if( !lock.try_acquire( m_limitCostMutex ) )
+	Key key;
+	CacheEntry cacheEntry;
+	while( m_policy.currentCost > cost )
 	{
-		// Another thread is busy limiting the
-		// cost, so we don't need to.
-		return;
-	}
-
-	Handle handle;
-	handle.acquire( this, m_limitCostSweepPosition, /* write = */ true, /* createIfMissing = */ false );
-	if( !handle.valid() )
-	{
-		// This is our first sweep, or the entry
-		// was erased by clear() or erase(). Just
-		// start at the beginning.
-		handle.begin( this );
-	}
-
-	size_t numFullCycles = 0;
-	while( m_currentCost > m_maxCost && handle.valid() && numFullCycles < 100 )
-	{
-		if( !handle->second.recentlyUsed )
+		if( !m_policy.pop( key, cacheEntry ) )
 		{
-			eraseInternal( *handle );
-			handle.eraseAndIncrement();
+			break;
 		}
-		else
-		{
-			// We'll erase this guy text time round,
-			// if he hasn't been used by some other
-			// thread by then.
-			handle->second.recentlyUsed = false;
-			handle.increment();
-		}
-		if( !handle.valid() )
-		{
-			// We're at the end but may not have
-			// reduced the cost sufficiently yet,
-			// so wrap around.
-			handle.begin( this );
-			// In theory, our thread could end up
-			// in an endless cycle if other threads
-			// are busy pushing values into the cache
-			// faster than we can remove them. So we
-			// count the number of full cycles we've
-			// performed, and abort if it's getting
-			// costly - this will force another
-			// thread to pick up the work, so we can
-			// return to our caller.
-			numFullCycles++;
-		}
-	}
 
-	// Remember where we were so we can start in
-	// the same place next time around.
-	if( handle.valid() )
-	{
-		m_limitCostSweepPosition = handle->first;
+		eraseInternal( key, cacheEntry );
 	}
 }
 
-template<typename Key, typename Value>
-void LRUCache<Key, Value>::nullRemovalCallback( const Key &key, const Value &value )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+void LRUCache<Key, Value, Policy, GetterKey>::nullRemovalCallback( const Key &key, const Value &value )
 {
 }
 
-} // namespace IECorePreview
+} // namespace IECore
 
-#endif // IECOREPREVIEW_LRUCACHE_INL
+#endif // IECORE_LRUCACHE_INL

--- a/include/Gaffer/Private/IECorePreview/LRUCache.inl
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.inl
@@ -624,8 +624,15 @@ void LRUCache<Key, Value, Policy, GetterKey>::clear()
 template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
 void LRUCache<Key, Value, Policy, GetterKey>::setMaxCost( Cost maxCost )
 {
-	m_maxCost = maxCost;
-	limitCost( maxCost );
+	if( maxCost >= m_maxCost )
+	{
+		m_maxCost = maxCost;
+	}
+	else
+	{
+		m_maxCost = maxCost;
+		limitCost( maxCost );
+	}
 }
 
 template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>


### PR DESCRIPTION
I've already discussed this with John a fair bit.  Because of the need to make sure the hash is big enough to fit an entire root computation, the memory is still dependent on scene complexity, which we were hoping to fix.

However, I can now size the hash to fit 10 root computations, instead of 3200 root computations, and in my tests so far, this runs significantly faster.  ( Up to 2X ).  So this appears strictly better than before, and is probably worth using currently.

Also, the last commit with the early out in setMaxCost when cost is increased didn't actually seem necessary from timing with and without, I just didn't like the look of repeatedly calling limitCost and initializing a CacheEntry.