### PR TITLE
ImageWriter : Fix bug when writing jpg with blank scanlines.

### DIFF
--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -1192,5 +1192,31 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		writer["fileName"].setValue( "test.png" )
 		self.assertIn( writer["task"], { x[0] for x in cs } )
 
+	def testBlankScanlines( self ) :
+
+		# create a wide image
+		constant = GafferImage.Constant()
+		constant["color"].setValue( IECore.Color4f( 0.5, 0.5, 0.5, 1 ) )
+		constant["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 3000, 1080 ) ), 1. ) )
+
+		# fit it such that we have several tiles of blank lines on top (and bottom)
+		resize = GafferImage.Resize()
+		resize["in"].setInput( constant["out"] )
+		resize["fitMode"].setValue( GafferImage.Resize.FitMode.Horizontal )
+
+		# write to a file format that requires consecutive scanlines
+		writer = GafferImage.ImageWriter()
+		writer["in"].setInput( resize["out"] )
+		writer["fileName"].setValue( "{0}/blankScanlines.jpg".format( self.temporaryDirectory() ) )
+		writer["task"].execute()
+
+		# ensure we wrote the file successfully
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setInput( writer["fileName"] )
+		cleanOutput = GafferImage.DeleteChannels()
+		cleanOutput["in"].setInput( writer["in"] )
+		cleanOutput["channels"].setValue( "A" )
+		self.assertImagesEqual( reader["out"], cleanOutput["out"], ignoreMetadata=True, ignoreDataWindow=True, maxDifference=0.05 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -473,7 +473,7 @@ class FlatScanlineWriter
 			for(
 				int blankScanlinesBegin = yBegin, blankScanlinesEnd = std::min( yBegin + ImagePlug::tileSize(), yEnd );
 				blankScanlinesEnd <= yEnd;
-				blankScanlinesBegin += ImagePlug::tileSize(), blankScanlinesEnd += ImagePlug::tileSize()
+				blankScanlinesBegin += ImagePlug::tileSize(), blankScanlinesEnd += std::min( ImagePlug::tileSize(), std::abs( yEnd - blankScanlinesBegin ) )
 			)
 			{
 				writeScanlines( blankScanlinesBegin, std::min( blankScanlinesEnd, yEnd ) );


### PR DESCRIPTION
If the initial blank scanlines were not an exact multiplier of the tileSize, writing would fail with the following message:

RuntimeError: Could not write scanline to "/tmp/test.jpg", error = Attempt to write scanlines out of order to /tmp/test.jpg