### PR TITLE
ImageWriter : Fix bug when writing jpg with blank scanlines.

### DIFF
--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -470,7 +470,7 @@ class FlatScanlineWriter
 			for(
 				int blankScanlinesBegin = yBegin, blankScanlinesEnd = std::min( yBegin + ImagePlug::tileSize(), yEnd );
 				blankScanlinesEnd <= yEnd;
-				blankScanlinesBegin += ImagePlug::tileSize(), blankScanlinesEnd += ImagePlug::tileSize()
+				blankScanlinesBegin += ImagePlug::tileSize(), blankScanlinesEnd += std::min( ImagePlug::tileSize(), std::abs( yEnd - blankScanlinesBegin ) )
 			)
 			{
 				writeScanlines( blankScanlinesBegin, std::min( blankScanlinesEnd, yEnd ) );


### PR DESCRIPTION
Backport of #2265 aimed at 0.35_maintenance.

Note that at Image Engine, I'm getting 4 test failures on this branch, but I'm getting them on 0.35_maintenance as well. I expect its been the case for a while, since cherry-picking https://github.com/GafferHQ/gaffer/pull/2258/commits/f41de70c20663127c6c2b801045a6e2736f6261e from master fixes 3 of them. The final failure I'm getting consistently on 0.35_maintenance, master, this branch, and its #2265 equivalent, thought Travis doesn't seem to have that failure.

```
======================================================================
FAIL: testExpectedResult (GafferImageTest.TextTest.TextTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/andrewk/apps/gaffer/0.34.1.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferImageTest/TextTest.py", line 114, in testExpectedResult
    self.assertImagesEqual( text["out"], reader["out"], ignoreMetadata = True, maxDifference = 0.001 )
  File "/home/andrewk/apps/gaffer/0.34.1.0dev/cent7.x86_64/cortex/9/gaffer/python/GafferImageTest/ImageTestCase.py", line 91, in assertImagesEqual
    self.assertLessEqual( stats["max"]["r"].getValue(), maxDifference, "Channel {0}".format( channelName ) )
AssertionError: Channel R

----------------------------------------------------------------------
```