### PR TITLE
Light Filter Visualisers (C++11 Edition)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -734,7 +734,14 @@ libraries = {
 		"additionalFiles" : glob.glob( "python/GafferArnoldTest/volumes/*" ) + glob.glob( "python/GafferArnoldTest/metadata/*" ),
 	},
 
-	"GafferArnoldUI" : {},
+	"GafferArnoldUI" : {
+		"envAppends" : {
+			"LIBS" : [ "IECoreGL$CORTEX_LIB_SUFFIX", "GafferOSL", "GafferSceneUI" ],
+			},
+		"pythonEnvAppends" : {
+			"LIBS" : [ "GafferArnoldUI", "GafferSceneUI" ],
+		},
+	},
 
 	"GafferArnoldUITest" : {},
 

--- a/include/GafferSceneUI/LightFilterVisualiser.h
+++ b/include/GafferSceneUI/LightFilterVisualiser.h
@@ -1,0 +1,87 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEUI_LIGHTFILTERVISUALISER_H
+#define GAFFERSCENEUI_LIGHTFILTERVISUALISER_H
+
+#include "IECore/ObjectVector.h"
+#include "IECore/Shader.h"
+#include "IECoreGL/Renderable.h"
+
+namespace GafferSceneUI
+{
+
+IE_CORE_FORWARDDECLARE( LightFilterVisualiser )
+
+/// Class for visualisation of light filters. All light filters in Gaffer are represented
+/// as IECore::Shader objects, but we need to visualise them differently
+/// depending on their shader name (accessed using `IECore::Shader::getName()`). A
+/// factory mechanism is provided to map from this name to a specialised
+/// LightFilterVisualiser.
+class LightFilterVisualiser : public IECore::RefCounted
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( LightFilterVisualiser )
+
+		LightFilterVisualiser();
+		virtual ~LightFilterVisualiser();
+
+		/// Must be implemented by derived classes to visualise
+		/// the light filter contained within shaderVector.
+		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *filterShaderVector, const IECore::ObjectVector *lightShaderVector, IECoreGL::ConstStatePtr &state ) const = 0;
+
+		/// Registers a visualiser to visualise a particular type of light filter.
+		/// For instance, `registerLightFilterVisualiser( "ai:lightFilter", "gobo", visualiser )`
+		/// would register a visualiser for an Arnold gobo light filter.
+		static void registerLightFilterVisualiser( const IECore::InternedString &attributeName, const IECore::InternedString &shaderName, ConstLightFilterVisualiserPtr visualiser );
+
+	protected :
+
+		template<typename FilterVisualiserType>
+		struct LightFilterVisualiserDescription
+		{
+			LightFilterVisualiserDescription( const IECore::InternedString &attributeName, const IECore::InternedString &shaderName )
+			{
+				registerLightFilterVisualiser( attributeName, shaderName, new FilterVisualiserType );
+			}
+		};
+};
+
+} // namespace GafferSceneUI
+
+#endif // GAFFERSCENEUI_LIGHTFILTERVISUALISER_H

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -62,6 +62,8 @@ class StandardLightVisualiser : public LightVisualiser
 
 		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, IECoreGL::ConstStatePtr &state ) const override;
 
+		static void spotlightParameters( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, float &innerAngle, float &outerAngle, float &lensRadius );
+
 	protected :
 
 		static const char *faceCameraVertexSource();

--- a/python/GafferOSLTest/ShadingEngineTest.py
+++ b/python/GafferOSLTest/ShadingEngineTest.py
@@ -79,7 +79,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		s = self.compileShader( os.path.dirname( __file__ ) +  "/shaders/constant.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( s, "surface", { "Cs" : IECore.Color3f( 1, 0.5, 0.25 ) } )
+			IECore.Shader( s, "osl:surface", { "Cs" : IECore.Color3f( 1, 0.5, 0.25 ) } )
 		] ) )
 
 		p = e.shade( self.rectanglePoints() )
@@ -92,8 +92,8 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		input = self.compileShader( os.path.dirname( __file__ ) +  "/shaders/outputTypes.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( input, "shader", { "input" : 0.5, "__handle" : "h" } ),
-			IECore.Shader( constant, "surface", { "Cs" : "link:h.c" } ),
+			IECore.Shader( input, "osl:shader", { "input" : 0.5, "__handle" : "h" } ),
+			IECore.Shader( constant, "osl:surface", { "Cs" : "link:h.c" } ),
 		] ) )
 
 		p = e.shade( self.rectanglePoints() )
@@ -108,7 +108,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		for n in ( "P", "u", "v" ) :
 			e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-				IECore.Shader( shader, "surface", { "global" : n } )
+				IECore.Shader( shader, "osl:surface", { "global" : n } )
 			] ) )
 			p = e.shade( rp )
 			v1 = p["Ci"]
@@ -123,7 +123,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		rp = self.rectanglePoints()
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "name" : "floatUserData" } ),
+			IECore.Shader( shader, "osl:surface", { "name" : "floatUserData" } ),
 		] ) )
 
 		self.assertEqual( e.needsAttribute( "", "floatUserData" ), True )
@@ -136,7 +136,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 			self.assertEqual( c.r, rp["floatUserData"][i] )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "name" : "colorUserData" } ),
+			IECore.Shader( shader, "osl:surface", { "name" : "colorUserData" } ),
 		] ) )
 
 		self.assertEqual( e.needsAttribute( "", "floatUserData" ), False )
@@ -150,7 +150,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "name" : "shading:index" } ),
+			IECore.Shader( shader, "osl:surface", { "name" : "shading:index" } ),
 		] ) )
 
 		self.assertEqual( e.needsAttribute( "", "floatUserData" ), False )
@@ -167,7 +167,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/dynamicAttribute.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface" )
+			IECore.Shader( shader, "osl:surface" )
 		] ) )
 
 		self.assertEqual( e.needsAttribute( "", "foo" ), True )
@@ -179,8 +179,8 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		constant = self.compileShader( os.path.dirname( __file__ ) + "/shaders/constant.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "shader", { "s.c" : IECore.Color3f( 0.1, 0.2, 0.3 ), "__handle" : "h" } ),
-			IECore.Shader( constant, "surface", { "Cs" : "link:h.c" } ),
+			IECore.Shader( shader, "osl:shader", { "s.c" : IECore.Color3f( 0.1, 0.2, 0.3 ), "__handle" : "h" } ),
+			IECore.Shader( constant, "osl:surface", { "Cs" : "link:h.c" } ),
 		] ) )
 		p = e.shade( self.rectanglePoints() )
 
@@ -193,8 +193,8 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		inputClosure = self.compileShader( os.path.dirname( __file__ ) + "/shaders/inputClosure.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( outputClosure, "shader", { "e" : IECore.Color3f( 0.1, 0.2, 0.3 ), "__handle" : "h" } ),
-			IECore.Shader( inputClosure, "surface", { "i" : "link:h.c" } ),
+			IECore.Shader( outputClosure, "osl:shader", { "e" : IECore.Color3f( 0.1, 0.2, 0.3 ), "__handle" : "h" } ),
+			IECore.Shader( inputClosure, "osl:surface", { "i" : "link:h.c" } ),
 		] ) )
 		p = e.shade( self.rectanglePoints() )
 
@@ -206,7 +206,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/debugClosure.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "name" : "a", "weight" : IECore.Color3f( 1, 0, 0 ) } ),
+			IECore.Shader( shader, "osl:surface", { "name" : "a", "weight" : IECore.Color3f( 1, 0, 0 ) } ),
 		] ) )
 
 		points = self.rectanglePoints()
@@ -228,7 +228,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/multipleDebugClosures.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", {} ),
+			IECore.Shader( shader, "osl:surface", {} ),
 		] ) )
 
 		points = self.rectanglePoints()
@@ -243,7 +243,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/typedDebugClosure.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", {} ),
+			IECore.Shader( shader, "osl:surface", {} ),
 		] ) )
 
 		points = self.rectanglePoints()
@@ -273,7 +273,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/debugClosureWithInternalValue.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "value" : IECore.Color3f( 1, 0.5, 0.25 ) } ),
+			IECore.Shader( shader, "osl:surface", { "value" : IECore.Color3f( 1, 0.5, 0.25 ) } ),
 		] ) )
 
 		points = self.rectanglePoints()
@@ -301,7 +301,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/debugClosureWithInternalValue.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "value" : IECore.Color3f( 0 ) } ),
+			IECore.Shader( shader, "osl:surface", { "value" : IECore.Color3f( 0 ) } ),
 		] ) )
 
 		points = self.rectanglePoints()
@@ -338,7 +338,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		)
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "colorSpline" : spline } )
+			IECore.Shader( shader, "osl:surface", { "colorSpline" : spline } )
 		] ) )
 
 		rp = self.rectanglePoints()
@@ -351,7 +351,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/extractTranslate.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", { "m" : IECore.M44f().translate( IECore.V3f( 1, 2, 3 ) ) } )
+			IECore.Shader( shader, "osl:surface", { "m" : IECore.M44f().translate( IECore.V3f( 1, 2, 3 ) ) } )
 		] ) )
 
 		p = e.shade( self.rectanglePoints() )
@@ -362,7 +362,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/parameterTypes.osl" )
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( shader, "surface", {
+			IECore.Shader( shader, "osl:surface", {
 				"f" : 1.0,
 				"i" : 2,
 				"s" : "three",
@@ -385,7 +385,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		s = self.compileShader( os.path.dirname( __file__ ) +  "/shaders/transform.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( s, "surface" )
+			IECore.Shader( s, "osl:surface" )
 		] ) )
 
 		p = e.shade( self.rectanglePoints() )
@@ -401,7 +401,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( p["Ci"], IECore.Color3fVectorData( [ IECore.Color3f( i + IECore.V3f( 2, 0, 0 ) ) for i in self.rectanglePoints()["P"] ] ) )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( s, "surface", { "backwards" : IECore.IntData( 1 ) } )
+			IECore.Shader( s, "osl:surface", { "backwards" : IECore.IntData( 1 ) } )
 		] ) )
 
 		p = e.shade( self.rectanglePoints(), { "world" : GafferOSL.ShadingEngine.Transform( worldMatrix ) } )
@@ -412,8 +412,8 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 	def testVectorToColorConnections( self ) :
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECore.Shader( "Utility/Globals", "shader", { "__handle" : "h" } ),
-			IECore.Shader( "Surface/Constant", "surface", { "Cs" : "link:h.globalP" } ),
+			IECore.Shader( "Utility/Globals", "osl:shader", { "__handle" : "h" } ),
+			IECore.Shader( "Surface/Constant", "osl:surface", { "Cs" : "link:h.globalP" } ),
 		] ) )
 
 		p = self.rectanglePoints()
@@ -448,6 +448,16 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 			self.assertEqual( c, expected )
 
+	def testWarningForInvalidShaders( self ) :
+
+		with self.assertRaises( Exception ) as engineError :
+			e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
+				IECore.Shader( "aiImage", "shader", {} ),
+				IECore.Shader( "aiImage", "shader", {} ),
+				IECore.Shader( "Surface/Constant", "osl:surface", {} ),
+			] ) )
+
+		self.assertEqual( str(engineError.exception), "Exception : The following shaders can't be used as they are not OSL shaders: aiImage (shader), aiImage (shader)" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferArnoldUI/BarndoorVisualiser.cpp
+++ b/src/GafferArnoldUI/BarndoorVisualiser.cpp
@@ -1,0 +1,252 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECore/MeshPrimitive.h"
+#include "IECoreGL/CurvesPrimitive.h"
+#include "IECore/Shader.h"
+#include "IECoreGL/Group.h"
+#include "IECoreGL/ToGLMeshConverter.h"
+#include "IECoreGL/ShaderStateComponent.h"
+#include "IECoreGL/ShaderLoader.h"
+#include "IECoreGL/TextureLoader.h"
+#include "IECore/ObjectVector.h"
+#include "IECoreGL/Renderable.h"
+
+#include "Gaffer/Metadata.h"
+#include "GafferSceneUI/StandardLightVisualiser.h"
+#include "GafferSceneUI/LightFilterVisualiser.h"
+
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreGL;
+using namespace GafferSceneUI;
+
+namespace
+{
+
+enum class BarndoorLocation { Top, Right, Left, Bottom };
+
+float parameterOrDefault( const IECore::CompoundData *data, const char *key, const float def )
+{
+	ConstFloatDataPtr member = data->member<const FloatData>( key );
+	if( member )
+	{
+		return member->readable();
+	}
+	return def;
+}
+
+const char *barndoorFragSource()
+{
+	return
+		"void main()"
+		"{"
+		"if( mod( float( gl_FragCoord.x + gl_FragCoord.y ), 2.0) == 0.0 )"
+			"{"
+				"discard;"
+			"}"
+			"else"
+			"{"
+				"gl_FragColor = vec4(0, 0, 0, 1);"
+			"}"
+		"}"
+		;
+}
+
+void addBarndoor( IECoreGL::GroupPtr result, BarndoorLocation location, float cornerLeft, float cornerRight )
+{
+
+	if( !( cornerLeft > 0 || cornerRight > 0 ) )
+	{
+		return;
+	}
+
+	cornerLeft = 1 - cornerLeft * 2.0;
+	cornerRight = 1 - cornerRight * 2.0;
+
+	IntVectorDataPtr vertsPerPoly = new IntVectorData;
+	std::vector<int> &vertsPerPolyVec = vertsPerPoly->writable();
+	vertsPerPolyVec.push_back( 4 );
+
+	IntVectorDataPtr vertIds = new IntVectorData;
+	std::vector<int> &vertIdsVec = vertIds->writable();
+	vertIdsVec.push_back( 0 );
+	vertIdsVec.push_back( 1 );
+	vertIdsVec.push_back( 2 );
+	vertIdsVec.push_back( 3 );
+
+	V3fVectorDataPtr p = new V3fVectorData;
+	std::vector<V3f> &pVec = p->writable();
+	pVec.push_back( V3f( -1, 1, 0  ) );
+	pVec.push_back( V3f( 1, 1, 0  ) );
+	pVec.push_back( V3f( 1, cornerRight, 0  ) );
+	pVec.push_back( V3f( -1, cornerLeft, 0  ) );
+
+	IECore::MeshPrimitivePtr mesh = new IECore::MeshPrimitive( vertsPerPoly, vertIds, "linear", p );
+
+	Imath::M44f trans;
+	switch( location )
+	{
+	case BarndoorLocation::Top:
+		break;
+	case BarndoorLocation::Bottom:
+		trans.rotate( V3f( 0, 0, M_PI ) );
+		break;
+	case BarndoorLocation::Left:
+		trans.rotate( V3f( 0, 0, M_PI / 2.0 ) );
+		break;
+	case BarndoorLocation::Right:
+		trans.rotate( V3f( 0, 0, M_PI / -2.0 ) );
+		break;
+	}
+
+	ToGLMeshConverterPtr meshConverter = new ToGLMeshConverter( mesh );
+
+	IECoreGL::GroupPtr barndoorGroup = new IECoreGL::Group();
+	barndoorGroup->getState()->add( new IECoreGL::Primitive::Selectable( false ) );
+	barndoorGroup->addChild( IECore::runTimeCast<IECoreGL::Renderable>( meshConverter->convert() ) );
+	barndoorGroup->setTransform( trans );
+
+	result->addChild( barndoorGroup );
+}
+
+class BarndoorVisualiser final : public LightFilterVisualiser
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( BarndoorVisualiser )
+
+		BarndoorVisualiser();
+		~BarndoorVisualiser();
+
+		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, const IECore::ObjectVector *lightShaderVector, IECoreGL::ConstStatePtr &state ) const override;
+
+	protected :
+
+		static LightFilterVisualiser::LightFilterVisualiserDescription<BarndoorVisualiser> g_visualiserDescription;
+
+};
+
+IE_CORE_DECLAREPTR( BarndoorVisualiser )
+
+// register the new visualiser
+LightFilterVisualiser::LightFilterVisualiserDescription<BarndoorVisualiser> BarndoorVisualiser::g_visualiserDescription( "ai:lightFilter", "barndoor" );
+
+BarndoorVisualiser::BarndoorVisualiser()
+{
+}
+
+BarndoorVisualiser::~BarndoorVisualiser()
+{
+}
+
+IECoreGL::ConstRenderablePtr BarndoorVisualiser::visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, const IECore::ObjectVector *lightShaderVector, IECoreGL::ConstStatePtr &state ) const
+{
+	IECoreGL::GroupPtr result = new IECoreGL::Group();
+
+	if( !shaderVector || shaderVector->members().size() == 0 || !lightShaderVector || lightShaderVector->members().empty() )
+	{
+		return result;
+	}
+
+	const IECore::Shader *filterShader = IECore::runTimeCast<const IECore::Shader>( shaderVector->members().back().get() );
+	if( !filterShader )
+	{
+		return result;
+	}
+
+	const IECore::Shader *lightShader = IECore::runTimeCast<const IECore::Shader>( lightShaderVector->members().back().get() );
+	if( !lightShader )
+	{
+		return result;
+	}
+
+	const IECore::CompoundData *filterShaderParameters = filterShader->parametersData();
+
+	float topLeft = parameterOrDefault( filterShaderParameters, "barndoor_top_left", 0.0f );
+	float topRight = parameterOrDefault( filterShaderParameters, "barndoor_top_right", 0.0f );
+
+	float rightTop = parameterOrDefault( filterShaderParameters, "barndoor_right_top", 1.0f );
+	float rightBottom = parameterOrDefault( filterShaderParameters, "barndoor_right_bottom", 1.0f );
+
+	float bottomLeft = parameterOrDefault( filterShaderParameters, "barndoor_bottom_left", 1.0f );
+	float bottomRight = parameterOrDefault( filterShaderParameters, "barndoor_bottom_right", 1.0f );
+
+	float leftTop = parameterOrDefault( filterShaderParameters, "barndoor_left_top", 0.0f );
+	float leftBottom = parameterOrDefault( filterShaderParameters, "barndoor_left_bottom", 0.0f );
+
+
+	addBarndoor( result, BarndoorLocation::Top, topLeft, topRight );
+	addBarndoor( result, BarndoorLocation::Bottom, 1 - bottomRight, 1 - bottomLeft );
+	addBarndoor( result, BarndoorLocation::Left, leftBottom, leftTop );
+	addBarndoor( result, BarndoorLocation::Right, 1 - rightTop, 1 - rightBottom );
+
+	if( result->children().size() > 0 )
+	{
+		IECore::CompoundObjectPtr parameters = new CompoundObject;
+
+		result->getState()->add(
+			new IECoreGL::ShaderStateComponent(
+				ShaderLoader::defaultShaderLoader(),
+				TextureLoader::defaultTextureLoader(),
+				"",
+				"",
+				barndoorFragSource(),
+				parameters )
+		);
+
+		float innerAngle;
+		float coneAngle;
+		float lensRadius;
+
+		StandardLightVisualiser::spotlightParameters( "ai:light", lightShaderVector, innerAngle, coneAngle, lensRadius );
+
+		const float halfAngle = 0.5 * M_PI * coneAngle / 180.0;
+		const float baseRadius = sin( halfAngle ) + lensRadius;
+		const float baseDistance = cos( halfAngle );
+
+		Imath::M44f barndoorTrans;
+		barndoorTrans.translate( V3f( 0, 0, -baseDistance * .5f ) );
+		barndoorTrans.scale( V3f( baseRadius * .5f, baseRadius * .5f, 0 ) );
+		result->setTransform( barndoorTrans );
+	}
+
+	return result;
+}
+
+} // namespace
+

--- a/src/GafferArnoldUI/DecayVisualiser.cpp
+++ b/src/GafferArnoldUI/DecayVisualiser.cpp
@@ -1,0 +1,266 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECore/MeshPrimitive.h"
+#include "IECore/CompoundObject.h"
+#include "IECoreGL/Group.h"
+#include "IECoreGL/Primitive.h"
+#include "IECoreGL/ToGLMeshConverter.h"
+#include "IECoreGL/ShaderStateComponent.h"
+#include "IECoreGL/ShaderLoader.h"
+#include "IECoreGL/TextureLoader.h"
+#include "IECore/ObjectVector.h"
+#include "IECoreGL/Renderable.h"
+
+#include "GafferSceneUI/LightFilterVisualiser.h"
+
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreGL;
+using namespace GafferSceneUI;
+
+namespace
+{
+typedef std::pair<float, V3f> Knot;
+typedef std::vector<Knot> KnotVector;
+
+const char *faceCameraVertexSource()
+{
+	return
+		"#version 120\n"
+		""
+		"#if __VERSION__ <= 120\n"
+		"#define in attribute\n"
+		"#endif\n"
+		""
+		"in vec3 vertexP;"
+		"void main()"
+		"{"
+			"vec3 aimedXAxis, aimedYAxis, aimedZAxis;"
+			""
+			"aimedXAxis = normalize( gl_ModelViewMatrixInverse * vec4( 0, 0, -1, 0 ) ).xyz;"
+			"aimedYAxis = normalize( gl_ModelViewMatrixInverse * vec4( 0, 1, 0, 0 ) ).xyz;"
+			"aimedZAxis = normalize( gl_ModelViewMatrixInverse * vec4( 1, 0, 0, 0 ) ).xyz;"
+			""
+			"vec3 pAimed = vertexP.x * aimedXAxis + vertexP.y * aimedYAxis + vertexP.z * aimedZAxis;"
+			"vec4 pCam = gl_ModelViewMatrix * vec4( pAimed, 1 );"
+			""
+			"gl_Position = gl_ProjectionMatrix * pCam;"
+		"}"
+		;
+}
+
+const char *knotFragSource()
+{
+	return
+		"uniform vec3 markerColor;"
+		""
+		"void main()"
+		"{"
+			"gl_FragColor = vec4(markerColor, 1);"
+		"}"
+		;
+}
+
+// \todo These should be consolidated with the function in BarndoorVisualiser into a templatized version
+//       Where should that live?
+float parameterOrDefault( const IECore::CompoundData *data, const char *key, const float def )
+{
+	ConstFloatDataPtr member = data->member<const FloatData>( key );
+	if( member )
+	{
+		return member->readable();
+	}
+	return def;
+}
+
+bool parameterOrDefault( const IECore::CompoundData *data, const char *key, const bool def )
+{
+	ConstBoolDataPtr member = data->member<const BoolData>( key );
+	if( member )
+	{
+		return member->readable();
+	}
+	return def;
+}
+
+void getKnotsToVisualize( const IECore::ObjectVector *shaderVector, KnotVector &knots )
+{
+	const IECore::Shader *filterShader = IECore::runTimeCast<const IECore::Shader>( shaderVector->members().back().get() );
+	if( !filterShader )
+	{
+		return;
+	}
+
+	const IECore::CompoundData *filterShaderParameters = filterShader->parametersData();
+
+	bool nearEnabled = parameterOrDefault( filterShaderParameters, "use_near_atten", false );
+	bool farEnabled = parameterOrDefault( filterShaderParameters, "use_far_atten", false );
+
+	if( nearEnabled )
+	{
+		float nearStart = parameterOrDefault( filterShaderParameters, "near_start", 0.0f );
+		float nearEnd = parameterOrDefault( filterShaderParameters, "near_end", 0.0f );
+
+		knots.push_back( Knot( nearStart, V3f( 0.0f ) ) );
+		knots.push_back( Knot( nearEnd, V3f( 1.0f ) ) );
+	}
+
+	if( farEnabled )
+	{
+		float farStart = parameterOrDefault( filterShaderParameters, "far_start", 0.0f );
+		float farEnd = parameterOrDefault( filterShaderParameters, "far_end", 0.0f );
+
+		knots.push_back( Knot( farStart, V3f( 1.0f ) ) );
+		knots.push_back( Knot( farEnd, V3f( 0.0f ) ) );
+	}
+}
+
+void addKnot( IECoreGL::GroupPtr group, const Knot &knot )
+{
+	IECoreGL::GroupPtr markerGroup = new IECoreGL::Group();
+
+	IntVectorDataPtr vertsPerPoly = new IntVectorData;
+	std::vector<int> &vertsPerPolyVec = vertsPerPoly->writable();
+	vertsPerPolyVec.push_back( 3 );
+
+	IntVectorDataPtr vertIds = new IntVectorData;
+	std::vector<int> &vertIdsVec = vertIds->writable();
+	vertIdsVec.push_back( 0 );
+	vertIdsVec.push_back( 1 );
+	vertIdsVec.push_back( 2 );
+
+	V3fVectorDataPtr p = new V3fVectorData;
+	std::vector<V3f> &pVec = p->writable();
+	pVec.push_back( V3f(  0, 0,  0  ) );
+	pVec.push_back( V3f(  0, 1, -1  ) );
+	pVec.push_back( V3f(  0, 1,  1  ) );
+
+	IECore::MeshPrimitivePtr mesh = new IECore::MeshPrimitive( vertsPerPoly, vertIds, "linear", p );
+	ToGLMeshConverterPtr meshConverter = new ToGLMeshConverter( mesh );
+	markerGroup->addChild( IECore::runTimeCast<IECoreGL::Renderable>( meshConverter->convert() ) );
+
+	Imath::M44f trans;
+	trans.translate( V3f( 0, 0, -knot.first ) );
+	trans.scale( V3f( 0.05 ) );
+	markerGroup->setTransform( trans );
+
+	IECore::CompoundObjectPtr shaderParameters = new CompoundObject;
+	shaderParameters->members()["markerColor"] = new IECore::Color3fData( knot.second );
+
+	markerGroup->getState()->add(
+		new IECoreGL::Primitive::Selectable( false ) );
+	markerGroup->getState()->add(
+		new IECoreGL::ShaderStateComponent(
+			ShaderLoader::defaultShaderLoader(),
+			TextureLoader::defaultTextureLoader(),
+			faceCameraVertexSource(),
+			"",
+			knotFragSource(), shaderParameters ) );
+
+	group->addChild( markerGroup );
+}
+
+class DecayVisualiser final : public LightFilterVisualiser
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( DecayVisualiser )
+
+		DecayVisualiser();
+		~DecayVisualiser();
+
+		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, const IECore::ObjectVector *lightShaderVector, IECoreGL::ConstStatePtr &state ) const override;
+
+	protected :
+
+		static LightFilterVisualiser::LightFilterVisualiserDescription<DecayVisualiser> g_visualiserDescription;
+
+};
+
+IE_CORE_DECLAREPTR( DecayVisualiser )
+
+// register the new visualiser
+LightFilterVisualiser::LightFilterVisualiserDescription<DecayVisualiser> DecayVisualiser::g_visualiserDescription( "ai:lightFilter", "light_decay" );
+
+DecayVisualiser::DecayVisualiser()
+{
+}
+
+DecayVisualiser::~DecayVisualiser()
+{
+}
+
+IECoreGL::ConstRenderablePtr DecayVisualiser::visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, const IECore::ObjectVector *lightShaderVector, IECoreGL::ConstStatePtr &state ) const
+{
+	IECoreGL::GroupPtr result = new IECoreGL::Group();
+
+	if( !shaderVector || shaderVector->members().size() == 0 || !lightShaderVector || lightShaderVector->members().empty() )
+	{
+		return result;
+	}
+
+	const IECore::Shader *filterShader = IECore::runTimeCast<const IECore::Shader>( shaderVector->members().back().get() );
+	if( !filterShader )
+	{
+		return result;
+	}
+
+	const IECore::Shader *lightShader = IECore::runTimeCast<const IECore::Shader>( lightShaderVector->members().back().get() );
+	if( !lightShader )
+	{
+		return result;
+	}
+
+	KnotVector knots;
+	getKnotsToVisualize( shaderVector, knots );
+
+	if( knots.empty() )
+	{
+		return result;
+	}
+
+
+	for( KnotVector::size_type i = 0; i < knots.size(); ++i )
+	{
+		addKnot( result, knots[i] );
+	}
+
+	return result;
+}
+
+} // namespace

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -1,0 +1,395 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECore/Shader.h"
+#include "IECoreGL/Group.h"
+#include "IECoreGL/Primitive.h"
+#include "IECoreGL/ShaderStateComponent.h"
+#include "IECoreGL/ShaderLoader.h"
+#include "IECoreGL/TextureLoader.h"
+#include "IECoreGL/QuadPrimitive.h"
+#include "IECore/VectorTypedData.h"
+#include "IECore/ObjectVector.h"
+#include "IECoreGL/Renderable.h"
+#include "IECore/LRUCache.h"
+
+#include "Gaffer/Metadata.h"
+#include "GafferSceneUI/StandardLightVisualiser.h"
+#include "GafferSceneUI/LightFilterVisualiser.h"
+#include "GafferOSL/ShadingEngine.h"
+
+#include "boost/format.hpp"
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreGL;
+using namespace GafferSceneUI;
+
+namespace
+{
+
+	// \todo These should be consolidated with the functions in the other visualisers into a templatized version
+	//       Where should that live?
+float parameterOrDefault( const IECore::CompoundData *data, const char *key, const float def )
+{
+	ConstFloatDataPtr member = data->member<const FloatData>( key );
+	if( member )
+	{
+		return member->readable();
+	}
+	return def;
+}
+
+V2f parameterOrDefault( const IECore::CompoundData *data, const char *key, const V2f def )
+{
+	ConstV2fDataPtr member = data->member<const V2fData>( key );
+	if( member )
+	{
+		return member->readable();
+	}
+	return def;
+}
+
+CompoundDataPtr evalOSLTexture( IECore::ObjectVectorPtr shaderVector, int resolution );
+
+struct OSLTextureCacheKey
+{
+
+	OSLTextureCacheKey()
+		:	shaders( NULL )
+	{
+	}
+
+	OSLTextureCacheKey( IECore::ObjectVector *s )
+		:	shaders( s )
+	{
+		s->hash( hash );
+	}
+
+	bool operator == ( const OSLTextureCacheKey &other ) const
+	{
+		return hash == other.hash;
+	}
+
+	bool operator != ( const OSLTextureCacheKey &other ) const
+	{
+		return hash != other.hash;
+	}
+
+	bool operator < ( const OSLTextureCacheKey &other ) const
+	{
+		return hash < other.hash;
+	}
+
+	mutable IECore::ObjectVector *shaders;
+	MurmurHash hash;
+
+};
+
+inline size_t tbb_hasher( const OSLTextureCacheKey &cacheKey )
+{
+	return tbb_hasher( cacheKey.hash );
+}
+
+CompoundDataPtr getter( const OSLTextureCacheKey &key, size_t &cost )
+{
+	cost = 1;
+	return evalOSLTexture( key.shaders, 512 );
+}
+
+typedef LRUCache<OSLTextureCacheKey, CompoundDataPtr> OSLTextureCache;
+OSLTextureCache g_oslTextureCache( getter, 100 );
+
+const char *goboFragSource()
+{
+	return
+		"#if __VERSION__ <= 120\n"
+		"#define in varying\n"
+		"#endif\n"
+		""
+		"in vec2 fragmentst;"
+		""
+		"uniform sampler2D texture;"
+		""
+		"void main()"
+		"{"
+			"vec2 texCoords = vec2( fragmentst.x, fragmentst.y );"
+			"vec4 tx = texture2D( texture, texCoords );"
+			"gl_FragColor = tx;"
+		"}"
+		;
+}
+
+// OSLTextureEvaluation
+
+void addSurfaceShader( IECore::ObjectVectorPtr shaderVector, string surfaceInput )
+{
+	IECore::Shader *surfaceShader = new IECore::Shader( "Surface/Constant", "osl:shader" );
+	surfaceShader->parameters()["Cs"] = new StringData( surfaceInput );
+
+	shaderVector->members().push_back( surfaceShader );
+}
+
+CompoundDataPtr evalOSLTexture( IECore::ObjectVectorPtr shaderVector, int resolution )
+{
+	GafferOSL::ShadingEnginePtr shadingEngine = new GafferOSL::ShadingEngine( shaderVector.get() );
+
+	CompoundDataPtr shadingPoints = new CompoundData();
+
+	V3fVectorDataPtr pData = new V3fVectorData;
+	FloatVectorDataPtr uData = new FloatVectorData;
+	FloatVectorDataPtr vData = new FloatVectorData;
+
+	vector<V3f> &pWritable = pData->writable();
+	vector<float> &uWritable = uData->writable();
+	vector<float> &vWritable = vData->writable();
+
+	int numPoints = resolution * resolution;
+
+	pWritable.reserve( numPoints );
+	uWritable.reserve( numPoints );
+	vWritable.reserve( numPoints );
+
+	for( int x = 0; x < resolution; ++x )
+	{
+		for( int y = 0; y < resolution; ++y )
+		{
+			uWritable.push_back( (float)(x + 0.5f) / resolution );
+			vWritable.push_back( (float)(y + 0.5f) / resolution );
+			pWritable.push_back( V3f( x + 0.5f, y + 0.5f, 0.0f ) );
+		}
+	}
+
+	shadingPoints->writable()["P"] = pData;
+	shadingPoints->writable()["u"] = uData;
+	shadingPoints->writable()["v"] = vData;
+
+	CompoundDataPtr shadingResult = shadingEngine->shade( shadingPoints.get() );
+	ConstColor3fVectorDataPtr colors = shadingResult->member<Color3fVectorData>( "Ci" );
+
+	CompoundDataPtr result = new CompoundData();
+
+	if( colors )
+	{
+		Imath::Box2i dataWindow( Imath::V2i( 0.0f ), Imath::V2i( resolution - 1 ) );
+		Imath::Box2i displayWindow( Imath::V2i( 0.0f ), Imath::V2i( resolution - 1 ) );
+
+		result->writable()["dataWindow"] = new Box2iData( dataWindow );
+		result->writable()["displayWindow"] = new Box2iData( displayWindow );
+
+		FloatVectorDataPtr redChannelData = new FloatVectorData();
+		FloatVectorDataPtr greenChannelData = new FloatVectorData();
+		FloatVectorDataPtr blueChannelData = new FloatVectorData();
+		std::vector<float> &r = redChannelData->writable();
+		std::vector<float> &g = greenChannelData->writable();
+		std::vector<float> &b = blueChannelData->writable();
+
+		vector<Color3f>::size_type numColors = colors->readable().size();
+		r.reserve( numColors );
+		g.reserve( numColors );
+		b.reserve( numColors );
+
+		for( vector<Color3f>::size_type u = 0; u < numColors; ++u )
+		{
+			Color3f c = colors->readable()[u];
+
+			r.push_back( c[0] );
+			g.push_back( c[1] );
+			b.push_back( c[2] );
+		}
+
+		CompoundDataPtr channelData = new CompoundData;
+		channelData->writable()["R"] = redChannelData;
+		channelData->writable()["G"] = greenChannelData;
+		channelData->writable()["B"] = blueChannelData;
+
+		result->writable()["channels"] = channelData;
+	}
+
+	return result;
+}
+
+class GoboVisualiser : public LightFilterVisualiser
+class GoboVisualiser final : public LightFilterVisualiser
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( GoboVisualiser )
+
+		GoboVisualiser();
+		~GoboVisualiser();
+
+		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, const IECore::ObjectVector *lightShaderVector, IECoreGL::ConstStatePtr &state ) const;
+
+	protected :
+
+		static LightFilterVisualiser::LightFilterVisualiserDescription<GoboVisualiser> g_visualiserDescription;
+
+};
+
+IE_CORE_DECLAREPTR( GoboVisualiser )
+
+// register the new visualiser
+LightFilterVisualiser::LightFilterVisualiserDescription<GoboVisualiser> GoboVisualiser::g_visualiserDescription( "ai:lightFilter", "gobo" );
+
+GoboVisualiser::GoboVisualiser()
+{
+}
+
+GoboVisualiser::~GoboVisualiser()
+{
+}
+
+IECoreGL::ConstRenderablePtr GoboVisualiser::visualise( const IECore::InternedString &attributeName, const IECore::ObjectVector *shaderVector, const IECore::ObjectVector *lightShaderVector, IECoreGL::ConstStatePtr &state ) const
+{
+	IECoreGL::GroupPtr result = new IECoreGL::Group();
+
+	if( !shaderVector || shaderVector->members().empty() || !lightShaderVector || lightShaderVector->members().empty() )
+	{
+		return result;
+	}
+
+	const IECore::Shader *filterShader = IECore::runTimeCast<const IECore::Shader>( shaderVector->members().back().get() );
+	if( !filterShader )
+	{
+		return result;
+	}
+
+	const IECore::Shader *lightShader = IECore::runTimeCast<const IECore::Shader>( lightShaderVector->members().back().get() );
+	if( !lightShader )
+	{
+		return result;
+	}
+
+	CompoundDataMap::const_iterator it = filterShader->parameters().find( "slidemap" );
+	if( it == filterShader->parameters().end() )
+	{
+		return result;
+	}
+
+	CompoundDataPtr imageData = new CompoundData;
+
+	const StringData *slidemap = IECore::runTimeCast<const StringData>( it->second.get() );
+	if( slidemap )
+	{
+		IECore::ObjectVectorPtr oslNetwork = new IECore::ObjectVector();
+		oslNetwork->members().assign( shaderVector->members().begin(), shaderVector->members().end() - 1 );
+
+		addSurfaceShader( oslNetwork, slidemap->readable() );
+
+		imageData = g_oslTextureCache.get( OSLTextureCacheKey( oslNetwork.get() ) );
+	}
+	else // nothing connected - just visualise the current value if possible
+	{
+		const Color3fData *goboColor = IECore::runTimeCast<const Color3fData>( it->second.get() );
+		if( !goboColor )
+		{
+			return result;
+		}
+
+		// single-pixel windows
+		Imath::Box2i dataWindow( Imath::V2i( 0.0f ), Imath::V2i( 0.0f ) );
+		Imath::Box2i displayWindow( Imath::V2i( 0.0f ), Imath::V2i( 0.0f ) );
+
+		imageData->writable()["dataWindow"] = new Box2iData( dataWindow );
+		imageData->writable()["displayWindow"] = new Box2iData( displayWindow );
+
+		CompoundDataPtr channels = new CompoundData;
+
+		std::vector<float> r;
+		std::vector<float> g;
+		std::vector<float> b;
+		r.push_back( goboColor->readable()[0] );
+		g.push_back( goboColor->readable()[1] );
+		b.push_back( goboColor->readable()[2] );
+
+		channels->writable()["R"] = new FloatVectorData( r );
+		channels->writable()["G"] = new FloatVectorData( g );
+		channels->writable()["B"] = new FloatVectorData( b );
+
+		imageData->writable()["channels"] = channels;
+	}
+
+	result->getState()->add( new IECoreGL::Primitive::Selectable( false ) );
+
+	IECore::CompoundObjectPtr shaderParameters = new CompoundObject;
+	shaderParameters->members()["texture"] = imageData;
+
+	result->getState()->add(
+		new IECoreGL::ShaderStateComponent(
+			ShaderLoader::defaultShaderLoader(),
+			TextureLoader::defaultTextureLoader(),
+			"",
+			"",
+			goboFragSource(),
+			shaderParameters ) );
+
+	float innerAngle;
+	float coneAngle;
+	float lensRadius;
+
+	StandardLightVisualiser::spotlightParameters( "ai:light", lightShaderVector, innerAngle, coneAngle, lensRadius );
+
+	float halfPi = 0.5 * M_PI;
+
+	const float halfAngle = halfPi * coneAngle / 180.0;
+	const float baseRadius = sin( halfAngle ) + lensRadius;
+	const float baseDistance = cos( halfAngle );
+
+	const CompoundData *filterParameters = filterShader->parametersData();
+	float rotate = parameterOrDefault( filterParameters, "rotate", 0.0f );
+	float scaleS = parameterOrDefault( filterParameters, "scale_s", 1.0f );
+	float scaleT = parameterOrDefault( filterParameters, "scale_t", 1.0f );
+	V2f offset = parameterOrDefault( filterParameters, "offset", V2f( 0.0f ) );
+
+	Imath::M44f goboTrans;
+
+	goboTrans.translate( V3f( 0.0f, 0.0f, -baseDistance ) );
+	goboTrans.rotate( V3f( 0, 0, M_PI * rotate / 180.0 ) );
+	goboTrans.scale( V3f( 2 * baseRadius / scaleS, 2 * baseRadius / scaleT, 0 ) );
+	goboTrans.translate( V3f( offset.x, offset.y, 0.0f ) );
+	goboTrans.rotate( V3f( 0.0f, 0.0f, halfPi ) );
+
+	result->setTransform( goboTrans );
+
+	result->addChild( new IECoreGL::QuadPrimitive( 1.0f, 1.0f ) );
+
+	return result;
+}
+
+} // namespace

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -312,14 +312,24 @@ IECoreGL::ConstRenderablePtr GoboVisualiser::visualise( const IECore::InternedSt
 
 		addSurfaceShader( oslNetwork, slidemap->readable() );
 
-		imageData = g_oslTextureCache.get( OSLTextureCacheKey( oslNetwork.get() ) );
+		try
+		{
+			imageData = g_oslTextureCache.get( OSLTextureCacheKey( oslNetwork.get() ) );
+		}
+		catch( const Exception &e )
+		{
+			// The osl evaluation system didn't work, but we just want to paint a
+			// white gobo in these cases instead of failing completely.
+			msg( Msg::Warning, "GoboVisualiser", e.what() );
+		}
 	}
-	else // nothing connected - just visualise the current value if possible
+
+	if( imageData->readable().empty() )
 	{
-		const Color3fData *goboColor = IECore::runTimeCast<const Color3fData>( it->second.get() );
+		ConstColor3fDataPtr goboColor = IECore::runTimeCast<const Color3fData>( it->second.get() );
 		if( !goboColor )
 		{
-			return result;
+			goboColor = new Color3fData( Color3f( 1 ) );
 		}
 
 		// single-pixel windows

--- a/src/GafferArnoldUIModule/GafferArnoldUIModule.cpp
+++ b/src/GafferArnoldUIModule/GafferArnoldUIModule.cpp
@@ -1,0 +1,44 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+// Despite being empty, this module is still necessary because importing it
+// loads libGafferArnolUI, which registers visualisers.
+
+BOOST_PYTHON_MODULE( _GafferArnoldUI )
+{
+}

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -44,6 +44,7 @@
 #include "boost/algorithm/string/split.hpp"
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/algorithm/string/classification.hpp"
+#include "boost/algorithm/string/join.hpp"
 #include "boost/unordered_map.hpp"
 
 #include "OSL/oslclosure.h"
@@ -859,7 +860,9 @@ ShadingEngine::ShadingEngine( const IECore::ObjectVector *shaderNetwork )
 	: m_unknownAttributesNeeded( false )
 {
 	ShadingSystem *shadingSystem = ::shadingSystem();
-	{
+
+	std::vector<std::string> invalidShaders;
+ 	{
 		ShadingSystemWriteMutex::scoped_lock shadingSystemWriteLock( g_shadingSystemWriteMutex );
 
 		m_shaderGroupRef = new ShaderGroupRef( shadingSystem->ShaderGroupBegin() );
@@ -868,6 +871,18 @@ ShadingEngine::ShadingEngine( const IECore::ObjectVector *shaderNetwork )
 		{
 			const Shader *shader = runTimeCast<const Shader>( it->get() );
 			if( !shader )
+			{
+				continue;
+			}
+
+			string type = shader->getType();
+			if( !boost::starts_with( type, "osl:" ) )
+			{
+				invalidShaders.push_back( shader->getName() + " (" + type + ")" );
+				continue;
+			}
+
+			if( !invalidShaders.empty() )
 			{
 				continue;
 			}
@@ -891,6 +906,12 @@ ShadingEngine::ShadingEngine( const IECore::ObjectVector *shaderNetwork )
 		}
 
 		shadingSystem->ShaderGroupEnd();
+
+		if( !invalidShaders.empty() )
+		{
+			std::string exceptionMessage = "The following shaders can't be used as they are not OSL shaders: ";
+			throw Exception( exceptionMessage + boost::algorithm::join( invalidShaders, ", " ) );
+		}
 	}
 
 	queryAttributesNeeded();

--- a/src/GafferSceneUI/LightFilterVisualiser.cpp
+++ b/src/GafferSceneUI/LightFilterVisualiser.cpp
@@ -1,0 +1,213 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/container/flat_map.hpp"
+#include "boost/algorithm/string/predicate.hpp"
+#include "boost/algorithm/string.hpp"
+
+#include "IECore/Light.h"
+#include "IECore/Shader.h"
+
+#include "IECoreGL/Group.h"
+#include "IECoreGL/Primitive.h"
+
+#include "GafferSceneUI/LightFilterVisualiser.h"
+#include "GafferSceneUI/AttributeVisualiser.h"
+
+using namespace std;
+using namespace Imath;
+using namespace GafferSceneUI;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal implementation details
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+typedef std::pair<IECore::InternedString, IECore::InternedString> AttributeAndShaderNames;
+
+typedef boost::container::flat_map<AttributeAndShaderNames, ConstLightFilterVisualiserPtr> LightFilterVisualisers;
+LightFilterVisualisers &lightFilterVisualisers()
+{
+	static LightFilterVisualisers l;
+	return l;
+}
+
+/// Class for visualisation of light filters. All light filters in Gaffer are represented
+/// as IECore::Shader objects, but we need to visualise them differently
+/// depending on their shader name (accessed using `IECore::Shader::getName()`). A
+/// factory mechanism is provided to map from this type to a specialised
+/// LightFilterVisualiser.
+class AttributeVisualiserForLightFilters : public AttributeVisualiser
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( AttributeVisualiserForLightFilters )
+
+		/// Uses a custom visualisation registered via `registerLightFilterVisualiser()` if one
+		/// is available, if not falls back to a basic visualisation.
+		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const;
+
+	protected :
+
+		static AttributeVisualiser::AttributeVisualiserDescription<AttributeVisualiserForLightFilters> g_visualiserDescription;
+
+};
+
+} // namespace
+
+IECoreGL::ConstRenderablePtr AttributeVisualiserForLightFilters::visualise( const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
+{
+	if( !attributes )
+	{
+		return nullptr;
+	}
+
+	IECoreGL::GroupPtr resultGroup = nullptr;
+	IECoreGL::StatePtr resultState = nullptr;
+
+	/// This seems pretty expensive to do everywhere.
+	/// The alternative would be to register attribute visualisers to specific attributes.
+	/// But then we wouldn't be able to have a visualiser that is influenced by multiple attributes simultaneously
+	for( const auto& it : attributes->members() )
+	{
+		const std::string &attributeName = it.first.string();
+		if( attributeName.find( ":lightFilter" ) == std::string::npos )
+		{
+			continue;
+		}
+
+		const IECore::ObjectVector *filterShaderVector = IECore::runTimeCast<const IECore::ObjectVector>( it.second.get() );
+		if( !filterShaderVector || filterShaderVector->members().empty() )
+		{
+			continue;
+		}
+
+		IECore::InternedString filterShaderName;
+		if( const IECore::Shader *filterShader = IECore::runTimeCast<const IECore::Shader>( filterShaderVector->members().back().get() ) )
+		{
+			filterShaderName = filterShader->getName();
+		}
+
+		if( filterShaderName.string().empty() )
+		{
+			continue;
+		}
+
+		// find the light shader influenced by the filter
+
+		std::vector<std::string> tokens;
+		boost::split( tokens, attributeName, boost::is_any_of(":") );
+		auto lightIt = attributes->members().find( tokens.front() + ":light" );
+
+		if( lightIt == attributes->members().end() )
+		{
+			continue;
+		}
+
+		const IECore::ObjectVector *lightShaderVector = IECore::runTimeCast<const IECore::ObjectVector>( lightIt->second.get() );
+		if( !lightShaderVector || lightShaderVector->members().empty() )
+		{
+			continue;
+		}
+
+		const LightFilterVisualisers &l = lightFilterVisualisers();
+
+		// light filters are stored in attributes following this syntax:
+		// renderer:lightFilter:optionalName. Visualisers get registered to
+		// renderer:lightFilter only, though. It's therefore necessary to strip off
+		// the optional part
+		std::string attrLookup = tokens[0] + ":" + tokens[1];
+
+		const LightFilterVisualiser *visualiser = nullptr;
+		auto visIt = l.find( AttributeAndShaderNames( attrLookup, filterShaderName ) );
+		if( visIt != l.end() )
+		{
+			visualiser = visIt->second.get();
+		}
+		else
+		{
+			continue;
+		}
+
+		IECoreGL::ConstStatePtr curState = nullptr;
+		IECoreGL::ConstRenderablePtr curVis = visualiser->visualise( attributeName, filterShaderVector, lightShaderVector, curState );
+
+		if( curVis )
+		{
+			if( !resultGroup )
+			{
+				resultGroup = new IECoreGL::Group();
+			}
+			// resultGroup will be returned as const, so const-casting the children in order to add them is safe
+			resultGroup->addChild( const_cast<IECoreGL::Renderable*>( curVis.get() ) );
+		}
+
+		if( curState )
+		{
+			if( !resultState )
+			{
+				resultState = new IECoreGL::State( false );
+			}
+			resultState->add( const_cast<IECoreGL::State*>( curState.get() ) );
+		}
+	}
+
+	state = resultState;
+	return resultGroup;
+}
+
+AttributeVisualiser::AttributeVisualiserDescription<AttributeVisualiserForLightFilters> AttributeVisualiserForLightFilters::g_visualiserDescription;
+
+//////////////////////////////////////////////////////////////////////////
+// LightVisualiser class
+//////////////////////////////////////////////////////////////////////////
+
+
+LightFilterVisualiser::LightFilterVisualiser()
+{
+}
+
+LightFilterVisualiser::~LightFilterVisualiser()
+{
+}
+
+void LightFilterVisualiser::registerLightFilterVisualiser( const IECore::InternedString &attributeName, const IECore::InternedString &shaderName, ConstLightFilterVisualiserPtr visualiser )
+{
+	lightFilterVisualisers()[AttributeAndShaderNames( attributeName, shaderName )] = visualiser;
+}

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -329,7 +329,7 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::I
 	else if( type && type->readable() == "spot" )
 	{
 		float innerAngle, outerAngle, lensRadius;
-		spotlightParameters( metadataTarget, shaderParameters, innerAngle, outerAngle, lensRadius );
+		spotlightParameters( attributeName, shaderVector, innerAngle, outerAngle, lensRadius );
 		result->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / locatorScale ) ) );
 		result->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
 		result->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
@@ -367,6 +367,52 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::I
 	}
 
 	return result;
+}
+
+void StandardLightVisualiser::spotlightParameters( const InternedString &attributeName, const IECore::ObjectVector *shaderVector, float &innerAngle, float &outerAngle, float &lensRadius )
+{
+
+	InternedString metadataTarget;
+	const IECore::CompoundData *shaderParameters = parametersAndMetadataTarget( attributeName, shaderVector, metadataTarget );
+
+	float coneAngle = parameter<float>( metadataTarget, shaderParameters, "coneAngleParameter", 0.0f );
+	float penumbraAngle = parameter<float>( metadataTarget, shaderParameters, "penumbraAngleParameter", 0.0f );
+	if( ConstStringDataPtr angleUnit = Metadata::value<StringData>( metadataTarget, "angleUnit" ) )
+	{
+		if( angleUnit->readable() == "radians" )
+		{
+			coneAngle *= 180.0 / M_PI;
+			penumbraAngle *= 180 / M_PI;
+		}
+	}
+
+	innerAngle = 0;
+	outerAngle = 0;
+
+	ConstStringDataPtr penumbraTypeData = Metadata::value<StringData>( metadataTarget, "penumbraType" );
+	const std::string *penumbraType = penumbraTypeData ? &penumbraTypeData->readable() : NULL;
+
+	if( !penumbraType || *penumbraType == "inset" )
+	{
+		outerAngle = coneAngle;
+		innerAngle = coneAngle - 2.0f * penumbraAngle;
+	}
+	else if( *penumbraType == "outset" )
+	{
+		outerAngle = coneAngle + 2.0f * penumbraAngle;
+		innerAngle = coneAngle ;
+	}
+	else if( *penumbraType == "absolute" )
+	{
+		outerAngle = coneAngle;
+		innerAngle = penumbraAngle;
+	}
+
+	lensRadius = 0.0f;
+	if( parameter<bool>( metadataTarget, shaderParameters, "lensRadiusEnableParameter", true ) )
+	{
+		lensRadius = parameter<float>( metadataTarget, shaderParameters, "lensRadiusParameter", 0.0f );
+	}
 }
 
 const char *StandardLightVisualiser::faceCameraVertexSource()


### PR DESCRIPTION
Hey John,

I took the light filter stuff from the maintenance branch and fixed it up for master. I guess there's a few things you might want to look at.

- I had to switch the caching in the `GoboVisualiser` to the new-style `LRUCaches`
- added `override` to `visualise()` methods in the *Visualiser classes
- `final`'d those classes too (do we want to use `final`? I think we should?)
- sprinkled some `auto` where useful
- switched a for loop to a foreach loop (in LightFilterVisualiser.cpp:L107)

Other than that it should still be the same as what we merged into the maintenance branch.

Thanks :)

Matti.

