### PR TITLE
GafferOSLUI::OSLShaderUI : Use OSL parm label metadata to drive nodule label

### DIFF
--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -166,6 +166,7 @@ Gaffer.Metadata.registerNode(
 
 			"description", __plugDescription,
 			"label", __plugLabel,
+			"noduleLayout:label", __plugLabel,
 			"layout:divider", __plugDivider,
 			"layout:section", __plugPage,
 			"presetNames", __plugPresetNames,


### PR DESCRIPTION
There might be an argument in the future for offering a separate metadata to drive just the nodule label, but as a first pass, if you don't do any special overriding, the label given in the metadata defined by the OSL standard should affect both the plug value widget label and the nodule label.