### PR TITLE
Arnold Renderer : Throw exception if render fails

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1924,8 +1924,14 @@ class ArnoldRenderer final : public IECoreScenePreview::Renderer
 			switch( m_renderType )
 			{
 				case Batch :
-					AiRender( AI_RENDER_MODE_CAMERA );
+				{
+					const int result = AiRender( AI_RENDER_MODE_CAMERA );
+					if( result != AI_SUCCESS )
+					{
+						throwError( result );
+					}
 					break;
+				}
 				case SceneDescription :
 					AiASSWrite( m_assFileName.c_str(), AI_NODE_ALL );
 					break;
@@ -1941,6 +1947,37 @@ class ArnoldRenderer final : public IECoreScenePreview::Renderer
 		}
 
 	private :
+
+		void throwError( int errorCode )
+		{
+			switch( errorCode )
+			{
+				case AI_ABORT :
+					throw IECore::Exception( "Render aborted" );
+				case AI_ERROR_WRONG_OUTPUT :
+					throw IECore::Exception( "Can't open output file" );
+				case AI_ERROR_NO_CAMERA :
+					throw IECore::Exception( "Camera not defined" );
+				case AI_ERROR_BAD_CAMERA :
+					throw IECore::Exception( "Bad camera" );
+				case AI_ERROR_VALIDATION :
+					throw IECore::Exception( "Usage not validated" );
+				case AI_ERROR_RENDER_REGION :
+					throw IECore::Exception( "Invalid render region" );
+				case AI_ERROR_OUTPUT_EXISTS :
+					throw IECore::Exception( "Output file already exists" );
+				case AI_ERROR_OPENING_FILE :
+					throw IECore::Exception( "Can't open file" );
+				case AI_INTERRUPT :
+					throw IECore::Exception( "Render interrupted by user" );
+				case AI_ERROR_UNRENDERABLE_SCENEGRAPH :
+					throw IECore::Exception( "Unrenderable scenegraph" );
+				case AI_ERROR_NO_OUTPUTS :
+					throw IECore::Exception( "No outputs" );
+				case AI_ERROR :
+					throw IECore::Exception( "Generic Arnold error" );
+			}
+		}
 
 		bool updateLogFlags( const std::string name, const IECore::Data *value, bool console )
 		{


### PR DESCRIPTION
Otherwise dispatchers will assume the render succeeded and continue. I'm really surprised we haven't noticed this until now - perhaps everyone has been turning off `abort_on_error`?