### PR TITLE
ImageReaderPathPreview : Fix bug when viewing first image

### DIFF
--- a/python/GafferImageUI/ImageReaderPathPreview.py
+++ b/python/GafferImageUI/ImageReaderPathPreview.py
@@ -108,6 +108,7 @@ class ImageReaderPathPreview( GafferUI.PathPreviewWidget ) :
 
 		with self.__script.context() :
 			viewport = self.__viewer.viewGadgetWidget().getViewportGadget()
-			viewport.frame( viewport.getPrimaryChild().bound() )
+			if viewport.getPrimaryChild() is not None :
+				viewport.frame( viewport.getPrimaryChild().bound() )
 
 GafferUI.PathPreviewWidget.registerType( "Image", ImageReaderPathPreview )


### PR DESCRIPTION
Because the viewer updates lazily, the image gadget may not be there immediately. The viewer frames the first image automatically anyway, so as long as we reframe for subsequent images we're OK.

This fixes an error when running `gaffer view someImage.exr`.