### PR TITLE
Fix BoxIO bug about initially invisible plugs

### DIFF
--- a/include/Gaffer/PlugAlgo.h
+++ b/include/Gaffer/PlugAlgo.h
@@ -39,6 +39,7 @@
 #define GAFFER_PLUGALGO_H
 
 #include "IECore/RefCounted.h"
+#include "IECore/InternedString.h"
 
 #include "Gaffer/StringAlgo.h"
 
@@ -73,6 +74,10 @@ bool canPromote( const Plug *plug, const Plug *parent = nullptr );
 /// argument.
 /// \undoable
 Plug *promote( Plug *plug, Plug *parent = nullptr, const StringAlgo::MatchPattern &excludeMetadata = "layout:*" );
+/// As `promote` but by providing the name argument, you can skip an additional
+/// renaming step after promoting.
+/// \undoable
+Plug *promoteWithName( Plug *plug, const IECore::InternedString &name, Plug *parent = nullptr, const StringAlgo::MatchPattern &excludeMetadata = "layout:*" );
 /// Returns true if the plug appears to have been promoted.
 bool isPromoted( const Plug *plug );
 /// Unpromotes a previously promoted plug, removing the

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -550,5 +550,16 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		self.assertTrue( "testPersistence" in Gaffer.Metadata.registeredValues( p ) )
 		self.assertTrue( "testPersistence" not in Gaffer.Metadata.registeredValues( p, persistentOnly = True ) )
 
+	def testPromoteWithName( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n1"] = GafferTest.AddNode()
+
+		p = Gaffer.PlugAlgo.promoteWithName( s["b"]["n1"]["op1"], 'newName' )
+
+		self.assertEqual( p.getName(), 'newName' )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/BoxIO.cpp
+++ b/src/Gaffer/BoxIO.cpp
@@ -191,8 +191,8 @@ void BoxIO::setup( const Plug *plug )
 	if( parent<Box>() )
 	{
 		Plug *toPromote = m_direction == Plug::In ? inPlugInternal() : outPlugInternal();
-		Plug *promoted = PlugAlgo::promote( toPromote );
-		promoted->setName( namePlug()->getValue() );
+		Plug *promoted = PlugAlgo::promoteWithName( toPromote, namePlug()->getValue() );
+		namePlug()->setValue( promoted->getName() );
 	}
 }
 

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -373,9 +373,14 @@ bool canPromote( const Plug *plug, const Plug *parent )
 
 Plug *promote( Plug *plug, Plug *parent, const StringAlgo::MatchPattern &excludeMetadata )
 {
+	return promoteWithName( plug, promotedName( plug ), parent, excludeMetadata );
+}
+
+Plug *promoteWithName( Plug *plug, const InternedString &name, Plug *parent, const StringAlgo::MatchPattern &excludeMetadata )
+{
 	validatePromotability( plug, parent, /* throwExceptions = */ true );
 
-	PlugPtr externalPlug = plug->createCounterpart( promotedName( plug ), plug->direction() );
+	PlugPtr externalPlug = plug->createCounterpart( name, plug->direction() );
 	if( externalPlug->direction() == Plug::In )
 	{
 		if( ValuePlug *externalValuePlug = IECore::runTimeCast<ValuePlug>( externalPlug.get() ) )

--- a/src/GafferModule/PlugAlgoBinding.cpp
+++ b/src/GafferModule/PlugAlgoBinding.cpp
@@ -57,6 +57,7 @@ void GafferModule::bindPlugAlgo()
 
 	def( "canPromote", &PlugAlgo::canPromote, ( arg( "plug" ), arg( "parent" ) = object() ) );
 	def( "promote", &PlugAlgo::promote, ( arg( "plug" ), arg( "parent" ) = object(), arg( "excludeMetadata" ) = "layout:*" ), return_value_policy<CastToIntrusivePtr>() );
+	def( "promoteWithName", &PlugAlgo::promoteWithName, ( arg( "plug" ), arg( "name" ), arg( "parent" ) = object(), arg( "excludeMetadata" ) = "layout:*" ), return_value_policy<CastToIntrusivePtr>() );
 	def( "isPromoted", &PlugAlgo::isPromoted, ( arg( "plug" ) ) );
 	def( "unpromote", &PlugAlgo::unpromote, ( arg( "plug" ) ) );
 


### PR DESCRIPTION
Hey John,

it took me a little to get to the bottom of this, but I think my fix is "correct", although probably not how you'd like this handled.

The problem I was seeing can be replicated by creating a `Box` in Gaffer and then running something along the lines of:

```
import GafferScene

b = script['Box']

b['g'] = GafferScene.Group()
Gaffer.BoxIO.promote( b['g']['in0'] )
```

I would expect that promoted plug to immediately appear on the box's `Gadget`, but it doesn't - it takes an action like diving into the box and going back out, or adding another plug to get the `Gadget` to update properly, even though the plug was added and is accessible through python. It seems that the problem is that the `BoxIn`'s plug gets added using it's internal name "__in" which will make `NoduleLayout` omit it when emitting signals for newly added nodules. Renaming it afterwards then doesn't currently cause a rerendering of the `Box`'s `Gadget`.

What I've done here is a little ugly and I'm increasing the surface area of the API instead of tagging on another keyword arg (default arg? Not sure what the cpp lingo is). The latter would require copying all the default values to the call site and I thought it might be nicer to have them close together in the `PlugAlgo` header.

I'm probably missing a nicer solution that you will be able to point me to :) I'm assuming there's a way to avoid all of this, but even in that case I'm wondering how you'd like things like this handled? Cpp doesn't allow specifying just one of the default args like python would, but replicating the default arguments to every call site seems potentially dangerous and introduces clutter at best? Do you have a best-practice for that kind of thing? :)

Thanks,

Matti.

