### PR TITLE
GafferArnold: exposed abortOnError, and maxSubdivision options 

### DIFF
--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -96,6 +96,12 @@ def __rayDepthSummary( plug ) :
 		info.append( "Threshold %s" % GafferUI.NumericWidget.valueToString( plug["autoTransparencyThreshold"]["value"].getValue() ) )
 	return ", ".join( info )
 
+def __subdivisionSummary( plug ) :
+	info = []
+	if plug["maxSubdivisions"]["enabled"].getValue():
+		info.append( "Max Subdivisions  %d" % plug["maxSubdivisions"]["value"].getValue() )
+	return ", ".join( info )
+
 def __texturingSummary( plug ) :
 
 	info = []
@@ -136,9 +142,11 @@ def __searchPathsSummary( plug ) :
 
 	return ", ".join( info )
 
-def __errorColorsSummary( plug ) :
+def __errorHandlingSummary( plug ) :
 
 	info = []
+	if plug["abortOnError"]["enabled"].getValue() :
+		info.append( "Abort on Error " + ( "On" if plug['abortOnError']["value"].getValue() else "Off" ) )
 	for suffix in ( "Texture", "Pixel", "Shader" ) :
 		if plug["errorColorBad"+suffix]["enabled"].getValue() :
 			info.append( suffix )
@@ -187,10 +195,11 @@ Gaffer.Metadata.registerNode(
 			"layout:section:Rendering:summary", __renderingSummary,
 			"layout:section:Sampling:summary", __samplingSummary,
 			"layout:section:Ray Depth:summary", __rayDepthSummary,
+			"layout:section:Subdivision:summary", __subdivisionSummary,
 			"layout:section:Texturing:summary", __texturingSummary,
 			"layout:section:Features:summary", __featuresSummary,
 			"layout:section:Search Paths:summary", __searchPathsSummary,
-			"layout:section:Error Colors:summary", __errorColorsSummary,
+			"layout:section:Error Handling:summary", __errorHandlingSummary,
 			"layout:section:Logging:summary", __loggingSummary,
 			"layout:section:Licensing:summary", __licensingSummary,
 
@@ -493,6 +502,19 @@ Gaffer.Metadata.registerNode(
 			"label", "Opacity Threshold",
 		],
 
+		# Subdivision
+
+		"options.maxSubdivisions" : [
+
+			"description",
+			"""
+			A global override for the maximum polymesh.subdiv_iterations.
+			""",
+
+			"layout:section", "Subdivision", 
+			"label", "Max Subdivisions",
+		],
+
 		# Texturing
 
 		"options.textureMaxMemoryMB" : [
@@ -702,7 +724,18 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		# Error Colors
+		# Error Handling
+
+		"options.abortOnError" : [
+
+			"description", 
+			"""
+			Aborts the render if an error is encountered.
+			""",
+
+			"layout:section", "Error Handling"
+
+		],
 
 		"options.errorColorBadTexture" : [
 
@@ -712,7 +745,7 @@ Gaffer.Metadata.registerNode(
 			made to use a bad or non-existent texture.
 			""",
 
-			"layout:section", "Error Colors",
+			"layout:section", "Error Handling",
 			"label", "Bad Texture",
 
 		],
@@ -725,7 +758,7 @@ Gaffer.Metadata.registerNode(
 			a NaN is encountered.
 			""",
 
-			"layout:section", "Error Colors",
+			"layout:section", "Error Handling",
 			"label", "Bad Pixel",
 
 		],
@@ -738,7 +771,7 @@ Gaffer.Metadata.registerNode(
 			in a shader.
 			""",
 
-			"layout:section", "Error Colors",
+			"layout:section", "Error Handling",
 			"label", "Bad Shader",
 
 		],

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -76,6 +76,10 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	options->addOptionalMember( "ai:auto_transparency_depth", new IECore::IntData( 10 ), "autoTransparencyDepth", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:auto_transparency_threshold", new IECore::FloatData( 0.99 ), "autoTransparencyThreshold", Gaffer::Plug::Default, false );
 
+	// Subdivision
+
+	options->addOptionalMember( "ai:max_subdivisions", new IECore::IntData(999), "maxSubdivisions", Gaffer::Plug::Default, false );
+
 	// Texturing parameters
 
 	options->addOptionalMember( "ai:texture_max_memory_MB", new IECore::FloatData( 2048 ), "textureMaxMemoryMB", Gaffer::Plug::Default, false );
@@ -101,8 +105,9 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	options->addOptionalMember( "ai:procedural_searchpath", new IECore::StringData( "" ), "proceduralSearchPath", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:shader_searchpath", new IECore::StringData( "" ), "shaderSearchPath", Gaffer::Plug::Default, false );
 
-	// Error colours
+	// Error handling
 
+	options->addOptionalMember( "ai:abort_on_error", new IECore::BoolData( true ), "abortOnError", Gaffer::Plug::Default,  false);
 	options->addOptionalMember( "ai:error_color_bad_texture", new IECore::Color3fData( Color3f( 1, 0, 0 ) ), "errorColorBadTexture", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:error_color_bad_pixel", new IECore::Color3fData( Color3f( 0, 0, 1 ) ), "errorColorBadPixel", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:error_color_bad_shader", new IECore::Color3fData( Color3f( 1, 0, 1 ) ), "errorColorBadShader", Gaffer::Plug::Default, false );


### PR DESCRIPTION
This commit exposes the following two options on the ArnoldOptions node.

abortOnError: Can be useful when needing to push a render through with known errors. Also, if the renderer always aborts on error, then most likely the error colors won't do much good.

maxSubdivisions: Limits the total subdivisions of all objects in a scene. Can be useful for debugging, or when trying to speed up renders with unnecessarily high subdivisions on assets.

Sorry for hanging on to this commit for so long. Let me know if there is anything you'd like cleaned up, or altered to make it more useful.

-Brian