### PR TITLE
SplineWidget : Fix drawing width

### DIFF
--- a/python/GafferUI/SplineWidget.py
+++ b/python/GafferUI/SplineWidget.py
@@ -207,6 +207,7 @@ class SplineWidget( GafferUI.Widget ) :
 		painter.setTransform( transform )
 		for s in self.__splinesToDraw :
 			pen = QtGui.QPen( self._qtColor( s.color ) )
+			pen.setCosmetic( True )
 			painter.setPen( pen )
 			painter.drawPath( s.path )
 


### PR DESCRIPTION
Qt 5 seems to be defaulting to a non-cosmetic pen, whereas Qt 4 presumably defaulted to a cosmetic one.

@danieldresser, I guess you're using Qt 4 still since you didn't notice this problem? Could you check that this change is OK there too, since I'm no longer very well set up for Qt 4 development here...