### PR TITLE
OSLShaderUI : Improve node graph labels

### DIFF
--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -152,6 +152,18 @@ def __plugNoduleVisibility( plug ) :
 
 	return bool( visible ) if visible is not None else True
 
+def __plugNoduleLabel( plug ) :
+
+	label = __plugLabel( plug )
+	if label is None :
+		return None
+
+	page = __plugPage( plug )
+	if page is not None :
+		label = page + "." + label
+
+	return label
+
 Gaffer.Metadata.registerNode(
 
 	GafferOSL.OSLShader,
@@ -175,6 +187,7 @@ Gaffer.Metadata.registerNode(
 			"plugValueWidget:type", __plugWidgetType,
 			"nodule:type", __plugNoduleType,
 			"noduleLayout:visible", __plugNoduleVisibility,
+			"noduleLayout:label", __plugNoduleLabel,
 
 		],
 

--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -87,7 +87,7 @@ def __plugPresetNames( plug ) :
 	if not options :
 		return None
 
-	return IECore.StringVectorData( [ o.partition( ":" )[0] for o in options.split( "|" ) ] )
+	return IECore.StringVectorData( [ o.partition( ":" )[0] for o in options.split( "|" ) if o ] )
 
 def __plugPresetValues( plug ) :
 
@@ -95,7 +95,8 @@ def __plugPresetValues( plug ) :
 	if not options :
 		return None
 
-	values = [ o.rpartition( ":" )[2] for o in options.split( "|" ) ]
+	values = [ o.rpartition( ":" )[2] for o in options.split( "|" ) if o ]
+
 	if isinstance( plug, Gaffer.StringPlug ) :
 		return IECore.StringVectorData( values )
 	elif isinstance( plug, Gaffer.IntPlug ) :


### PR DESCRIPTION
A very typical use of labels is to remove a prefix which is already displayed via a section header in the NodeEditor. For instance, a `diffuseColor` parameter is often labelled as simply "Color" after placing the parameter in a "Diffuse" section. Sections do not apply in the NodeGraph, so this sort of labelling renders it impossible to find the right parameter among all the others labelled "Color".

<img width="771" alt="brokenlabels" src="https://user-images.githubusercontent.com/1133871/31493601-cf4de982-af47-11e7-8ae9-7d47fe7ec2ab.png">
