### PR TITLE
 OSLShaderUI : Hide spline parameters in NodeGraph

### DIFF
--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -137,7 +137,12 @@ def __plugWidgetType( plug ) :
 
 def __plugNoduleType( plug ) :
 
-	return "" if plug.node().parameterMetadata( plug, "connectable" ) == 0 else "GafferUI::StandardNodule"
+	if isinstance( plug, ( Gaffer.SplinefColor3fPlug, Gaffer.SplineffPlug ) ) :
+		return ""
+	elif plug.node().parameterMetadata( plug, "connectable" ) == 0 :
+		return ""
+	else :
+		return "GafferUI::StandardNodule"
 
 def __outPlugNoduleType( plug ) :
 

--- a/python/GafferTest/SplinePlugTest.py
+++ b/python/GafferTest/SplinePlugTest.py
@@ -45,6 +45,7 @@ import GafferTest
 class SplinePlugTest( GafferTest.TestCase ) :
 
 	def testSplineDefinition( self ) :
+
 		d = Gaffer.SplineDefinitionff( ((0, 0), (0,0), (0,0), (1,1), (1,1), (1,1)), Gaffer.SplineDefinitionInterpolation.Linear )
 		self.assertEqual( d.points(), ((0, 0), (0,0), (0,0), (1,1), (1,1), (1,1)) )
 		self.assertEqual( d.interpolation, Gaffer.SplineDefinitionInterpolation.Linear )
@@ -71,11 +72,10 @@ class SplinePlugTest( GafferTest.TestCase ) :
 
 		d = Gaffer.SplineDefinitionff( ((0, 0), (0,0), (1,1), (1,1)), Gaffer.SplineDefinitionInterpolation.BSpline )
 		self.assertFalse( d.trimEndPoints() ) # Not enough CVs for BSpline
-	
-		
+
+
 		d = Gaffer.SplineDefinitionff( ((0, 0), (0,0), (0,0), (1,1), (1,1), (1,1.1)), Gaffer.SplineDefinitionInterpolation.BSpline )
 		self.assertFalse( d.trimEndPoints() ) # Endpoints don't match
-		
 
 	def testConstructor( self ) :
 


### PR DESCRIPTION
There's nothing sensible to connect them to. This also fixes the following error when trying to promote a spline parameter :

```
RuntimeError: Exception : Cannot set value for plug "out.interpolation" except during computation.
```

The problem here was that when promoting via a BoxIn node (the code path if there's a nodule for the parameter), an output SplinePlug was created, and in the constructor `setValue()` was called.

@danieldresser, we might want to talk about fixing the latter problem at some point, but I think this is probably a useful improvement in its own right anyway?