### PR TITLE
IECoreGLPreview renderer backend

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -602,7 +602,7 @@ libraries = {
 
 	"GafferUI" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "Iex$OPENEXR_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "GLEW$GLEW_LIB_SUFFIX" ],
+			"LIBS" : [ "Gaffer", "Iex$OPENEXR_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "GafferUI", "GafferBindings" ],
@@ -675,7 +675,7 @@ libraries = {
 
 	"GafferSceneUI" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "GafferUI", "GafferImage", "GafferImageUI", "GafferScene", "Iex$OPENEXR_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "GLEW$GLEW_LIB_SUFFIX" ],
+			"LIBS" : [ "Gaffer", "GafferUI", "GafferImage", "GafferImageUI", "GafferScene", "Iex$OPENEXR_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "IECoreGL$CORTEX_LIB_SUFFIX", "GafferBindings", "GafferScene", "GafferUI", "GafferImageUI", "GafferSceneUI" ],
@@ -708,7 +708,7 @@ libraries = {
 
 	"GafferImageUI" : {
 		"envAppends" : {
-			"LIBS" : [ "IECoreGL$CORTEX_LIB_SUFFIX", "Gaffer", "GafferImage", "GafferUI", "GLEW$GLEW_LIB_SUFFIX" ],
+			"LIBS" : [ "IECoreGL$CORTEX_LIB_SUFFIX", "Gaffer", "GafferImage", "GafferUI" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferUI", "GafferImage", "GafferImageUI" ],
@@ -869,11 +869,12 @@ libraries = {
 }
 
 # Add on OpenGL libraries to definitions - these vary from platform to platform
-for library in ( "GafferUI", "GafferSceneUI", "GafferImageUI" ) :
+for library in ( "GafferUI", "GafferScene", "GafferSceneUI", "GafferImageUI" ) :
 	if env["PLATFORM"] == "darwin" :
 		libraries[library]["envAppends"].setdefault( "FRAMEWORKS", [] ).append( "OpenGL" )
 	else :
 		libraries[library]["envAppends"]["LIBS"].append( "GL" )
+	libraries[library]["envAppends"]["LIBS"].append( "GLEW$GLEW_LIB_SUFFIX" )
 
 # Add on Qt libraries to definitions - these vary from platform to platform
 

--- a/include/GafferScene/OpenGLRender.h
+++ b/include/GafferScene/OpenGLRender.h
@@ -37,12 +37,12 @@
 #ifndef GAFFERSCENE_OPENGLRENDER_H
 #define GAFFERSCENE_OPENGLRENDER_H
 
-#include "GafferScene/ExecutableRender.h"
+#include "GafferScene/Preview/Render.h"
 
 namespace GafferScene
 {
 
-class OpenGLRender : public ExecutableRender
+class OpenGLRender : public Preview::Render
 {
 
 	public :
@@ -50,11 +50,7 @@ class OpenGLRender : public ExecutableRender
 		OpenGLRender( const std::string &name=defaultName<OpenGLRender>() );
 		~OpenGLRender() override;
 
-		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::OpenGLRender, OpenGLRenderTypeId, ExecutableRender );
-
-	protected :
-
-		IECore::RendererPtr createRenderer() const override;
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::OpenGLRender, OpenGLRenderTypeId, Preview::Render );
 
 };
 

--- a/python/GafferSceneTest/IECoreGLPreviewTest/RendererTest.py
+++ b/python/GafferSceneTest/IECoreGLPreviewTest/RendererTest.py
@@ -1,0 +1,188 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import unittest
+
+import IECore
+import IECoreGL
+
+import GafferTest
+import GafferScene
+
+IECoreGL.init( False )
+
+class RendererTest( GafferTest.TestCase ) :
+
+	def testFactory( self ) :
+
+		self.assertTrue( "OpenGL" in GafferScene.Private.IECoreScenePreview.Renderer.types() )
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create( "OpenGL" )
+		self.assertTrue( isinstance( r, GafferScene.Private.IECoreScenePreview.Renderer ) )
+
+	def testOtherRendererAttributes( self ) :
+
+		# Attributes destined for other renderers should be silently ignored
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create( "OpenGL" )
+
+		with IECore.CapturingMessageHandler() as handler :
+
+			renderer.attributes(
+				IECore.CompoundObject( {
+					"ai:visibility:camera" : IECore.IntData( 0 )
+				} )
+			)
+
+		self.assertEqual( len( handler.messages ), 0 )
+
+	def testPrimVars( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create( "OpenGL" )
+		renderer.output( "test", IECore.Display( self.temporaryDirectory() + "/testPrimVars.tif", "tiff", "rgba", {} ) )
+
+		fragmentSource = """
+		uniform float red;
+		uniform float green;
+		uniform float blue;
+
+		void main()
+		{
+			gl_FragColor = vec4( red, green, blue, 1 );
+		}
+		"""
+
+		attributes = renderer.attributes(
+			IECore.CompoundObject( {
+				"gl:surface" : IECore.ObjectVector( [
+					IECore.Shader( "rgbColor", "surface", { "gl:fragmentSource" : fragmentSource } )
+				] )
+			} )
+		)
+
+		def sphere( red, green, blue ) :
+
+			s = IECore.SpherePrimitive()
+			s["red"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Constant, IECore.FloatData( red ) )
+			s["green"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Constant, IECore.FloatData( green ) )
+			s["blue"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Constant, IECore.FloatData( blue ) )
+
+			return s
+
+		renderer.object(
+			"redSphere",
+			sphere( 1, 0, 0 ),
+			attributes
+		).transform(
+			IECore.M44f().translate( IECore.V3f( 0, 0, -5 ) )
+		)
+
+		renderer.object(
+			"greenSphere",
+			sphere( 0, 1, 0 ),
+			attributes
+		).transform(
+			IECore.M44f().translate( IECore.V3f( -1, 0, -5 ) )
+		)
+
+		renderer.object(
+			"blueSphere",
+			sphere( 0, 0, 1 ),
+			attributes
+		).transform(
+			IECore.M44f().translate( IECore.V3f( 1, 0, -5 ) )
+		)
+
+		renderer.render()
+
+		image = IECore.Reader.create(  self.temporaryDirectory() + "/testPrimVars.tif" ).read()
+		dimensions = image.dataWindow.size() + IECore.V2i( 1 )
+		index = dimensions.x * int( dimensions.y * 0.5 )
+		self.assertEqual( image["R"][index], 0 )
+		self.assertEqual( image["G"][index], 1 )
+		self.assertEqual( image["B"][index], 0 )
+
+		index = dimensions.x * int(dimensions.y * 0.5) + int( dimensions.x * 0.5 )
+		self.assertEqual( image["R"][index], 1 )
+		self.assertEqual( image["G"][index], 0 )
+		self.assertEqual( image["B"][index], 0 )
+
+		index = dimensions.x * int(dimensions.y * 0.5) + int( dimensions.x * 1 ) - 1
+		self.assertEqual( image["R"][index], 0 )
+		self.assertEqual( image["G"][index], 0 )
+		self.assertEqual( image["B"][index], 1 )
+
+	def testShaderParameters( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create( "OpenGL" )
+		renderer.output( "test", IECore.Display( self.temporaryDirectory() + "/testShaderParameters.tif", "tiff", "rgba", {} ) )
+
+		fragmentSource = """
+		uniform vec3 colorValue;
+		void main()
+		{
+			gl_FragColor = vec4( colorValue, 1 );
+		}
+		"""
+
+		attributes = renderer.attributes(
+			IECore.CompoundObject( {
+				"gl:surface" : IECore.ObjectVector( [
+					IECore.Shader(
+						"color",
+						"surface",
+						{
+							"gl:fragmentSource" : fragmentSource,
+							"colorValue" : IECore.Color3f( 1, 0, 0 )
+						}
+					)
+				] )
+			} )
+		)
+
+		renderer.object(
+			"sphere",
+			IECore.SpherePrimitive(),
+			attributes
+		).transform(
+			IECore.M44f().translate( IECore.V3f( 0, 0, -5 ) )
+		)
+
+		renderer.render()
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/IECoreGLPreviewTest/__init__.py
+++ b/python/GafferSceneTest/IECoreGLPreviewTest/__init__.py
@@ -1,0 +1,41 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+from RendererTest import RendererTest
+
+if __name__ == "__main__":
+	import unittest
+	unittest.main()

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -1,0 +1,536 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include <unordered_map>
+
+#include "tbb/concurrent_vector.h"
+#include "tbb/concurrent_unordered_map.h"
+
+#include "boost/format.hpp"
+#include "boost/algorithm/string/predicate.hpp"
+
+#include "IECore/MessageHandler.h"
+#include "IECore/SimpleTypedData.h"
+#include "IECore/Writer.h"
+#include "IECore/CompoundParameter.h"
+
+#include "IECoreGL/GL.h"
+#include "IECoreGL/State.h"
+#include "IECoreGL/Renderable.h"
+#include "IECoreGL/OrthographicCamera.h"
+#include "IECoreGL/CachedConverter.h"
+#include "IECoreGL/ToGLCameraConverter.h"
+#include "IECoreGL/FrameBuffer.h"
+#include "IECoreGL/ColorTexture.h"
+#include "IECoreGL/DepthTexture.h"
+#include "IECoreGL/Exception.h"
+#include "IECoreGL/ShaderStateComponent.h"
+
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreGL;
+
+//////////////////////////////////////////////////////////////////////////
+// Utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+template<typename T>
+T *reportedCast( const IECore::RunTimeTyped *v, const char *type, const IECore::InternedString &name )
+{
+	T *t = IECore::runTimeCast<T>( v );
+	if( t )
+	{
+		return t;
+	}
+
+	IECore::msg( IECore::Msg::Warning, "IECoreGL::Renderer", boost::format( "Expected %s but got %s for %s \"%s\"." ) % T::staticTypeName() % v->typeName() % type % name.c_str() );
+	return nullptr;
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// OpenGLAttributes
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+class OpenGLAttributes : public IECoreScenePreview::Renderer::AttributesInterface
+{
+
+	public :
+
+		OpenGLAttributes( const IECore::CompoundObject *attributes )
+		{
+			m_state = static_pointer_cast<const State>(
+				CachedConverter::defaultCachedConverter()->convert( attributes )
+			);
+		}
+
+		const State *state() const
+		{
+			return m_state.get();
+		}
+
+	private :
+
+		ConstStatePtr m_state;
+
+};
+
+IE_CORE_DECLAREPTR( OpenGLAttributes )
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// OpenGLObject
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
+{
+
+	public :
+
+		OpenGLObject( const IECoreGL::ConstRenderablePtr &renderable )
+			:	m_renderable( renderable )
+		{
+		}
+
+		void transform( const Imath::M44f &transform ) override
+		{
+			m_transform = transform;
+		}
+
+		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override
+		{
+			transform( samples.front() );
+		}
+
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
+		{
+			m_attributes = static_cast<const OpenGLAttributes *>( attributes );
+			return true;
+		}
+
+		void render( IECoreGL::State *currentState )
+		{
+			const bool haveTransform = m_transform != M44f();
+			if( haveTransform )
+			{
+				glPushMatrix();
+				glMultMatrixf( m_transform.getValue() );
+			}
+
+			IECoreGL::State::ScopedBinding scope( *m_attributes->state(), *currentState );
+			m_renderable->render( currentState );
+
+			if( haveTransform )
+			{
+				glPopMatrix();
+			}
+		}
+
+	private :
+
+		M44f m_transform;
+		ConstOpenGLAttributesPtr m_attributes;
+		IECoreGL::ConstRenderablePtr m_renderable;
+
+};
+
+IE_CORE_FORWARDDECLARE( OpenGLObject )
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// OpenGLCamera
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+class OpenGLCamera : public IECoreScenePreview::Renderer::ObjectInterface
+{
+
+	public :
+
+		OpenGLCamera( const IECore::Camera *camera )
+		{
+			if( camera )
+			{
+				ToGLCameraConverterPtr converter = new ToGLCameraConverter( camera );
+				m_camera = static_pointer_cast<IECoreGL::Camera>( converter->convert() );
+			}
+			else
+			{
+				m_camera = new IECoreGL::OrthographicCamera;
+			}
+		}
+
+		void transform( const Imath::M44f &transform ) override
+		{
+			m_camera->setTransform( transform );
+		}
+
+		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override
+		{
+			transform( samples.front() );
+		}
+
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
+		{
+			m_attributes = static_cast<const OpenGLAttributes *>( attributes );
+			return true;
+		}
+
+		const IECoreGL::Camera *camera() const
+		{
+			return m_camera.get();
+		}
+
+	private :
+
+		IECoreGL::CameraPtr m_camera;
+		ConstOpenGLAttributesPtr m_attributes;
+
+};
+
+IE_CORE_FORWARDDECLARE( OpenGLCamera )
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// OpenGLRenderer
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+class OpenGLRenderer final : public IECoreScenePreview::Renderer
+{
+
+	public :
+
+		OpenGLRenderer( RenderType renderType, const std::string &fileName )
+			:	m_renderType( renderType )
+		{
+			if( renderType == SceneDescription )
+			{
+				throw IECore::Exception( "Unsupported render type" );
+			}
+		}
+
+		~OpenGLRenderer() override
+		{
+		}
+
+		void option( const IECore::InternedString &name, const IECore::Data *value ) override
+		{
+			if( name == "camera" )
+			{
+				if( value == nullptr )
+				{
+					m_camera = "";
+				}
+				else if( const IECore::StringData *d = reportedCast<const IECore::StringData>( value, "option", name ) )
+				{
+					m_camera = d->readable();
+
+				}
+				return;
+			}
+			else if( name == "frame" )
+			{
+				// We know what this means, we just have no use for it.
+				return;
+			}
+			else if( boost::contains( name.string(), ":" ) && !boost::starts_with( name.string(), "gl:" ) )
+			{
+				// Ignore options prefixed for some other renderer.
+				return;
+			}
+
+			IECore::msg( IECore::Msg::Warning, "IECoreGL::Renderer::option", boost::format( "Unknown option \"%s\"." ) % name.c_str() );
+		}
+
+		void output( const IECore::InternedString &name, const Output *output ) override
+		{
+			if( output )
+			{
+				m_outputs[name] = output;
+			}
+			else
+			{
+				m_outputs.erase( name );
+			}
+		}
+
+		Renderer::AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override
+		{
+			return new OpenGLAttributes( attributes );
+		}
+
+		ObjectInterfacePtr camera( const std::string &name, const IECore::Camera *camera, const AttributesInterface *attributes ) override
+		{
+			OpenGLCameraPtr result = new OpenGLCamera( camera );
+			result->attributes( attributes );
+			m_cameras[name] = result;
+			return result;
+		}
+
+		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		{
+			IECore::msg( IECore::Msg::Warning, "IECoreGL::Renderer::light", "Lights are not implemented" );
+			return nullptr;
+		}
+
+		Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		{
+			IECoreGL::ConstRenderablePtr renderable = runTimeCast<const IECoreGL::Renderable>(
+				CachedConverter::defaultCachedConverter()->convert( object )
+			);
+			if( !renderable )
+			{
+				return nullptr;
+			}
+			OpenGLObjectPtr result = new OpenGLObject( renderable );
+			result->attributes( attributes );
+			m_objects.push_back( result );
+			return result;
+		}
+
+		ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override
+		{
+			return object( name, samples.front(), attributes );
+		}
+
+		void render() override
+		{
+			if( m_renderType == Interactive )
+			{
+				renderInteractive();
+			}
+			else
+			{
+				renderBatch();
+			}
+		}
+
+		void pause() override
+		{
+			if( m_renderType != Interactive )
+			{
+				IECore::msg( IECore::Msg::Warning, "IECoreGL::Renderer::pause", "Cannot pause non-interactive renders" );
+			}
+		}
+
+	private :
+
+		void renderInteractive()
+		{
+			removeDeletedObjects();
+			CachedConverter::defaultCachedConverter()->clearUnused();
+
+			GLint prevProgram;
+			glGetIntegerv( GL_CURRENT_PROGRAM, &prevProgram );
+			glPushAttrib( GL_ALL_ATTRIB_BITS );
+
+				State::bindBaseState();
+				StatePtr state = new State( /* complete = */ true );
+				state->bind();
+
+				renderObjects( state.get() );
+
+			glPopAttrib();
+			glUseProgram( prevProgram );
+		}
+
+		void renderBatch()
+		{
+			CachedConverter::defaultCachedConverter()->clearUnused();
+
+			OpenGLCameraPtr camera;
+			if( m_camera != "" )
+			{
+				CameraMap::const_iterator it = m_cameras.find( m_camera );
+				if( it != m_cameras.end() )
+				{
+					camera = it->second;
+				}
+			}
+			else
+			{
+				camera = new OpenGLCamera( nullptr );
+			}
+
+			const V2i resolution = camera->camera()->getResolution();
+			IECoreGL::FrameBufferPtr frameBuffer = new FrameBuffer;
+			frameBuffer->setColor( new ColorTexture( resolution.x, resolution.y ) );
+			IECoreGL::Exception::throwIfError();
+			frameBuffer->setDepth( new DepthTexture( resolution.x, resolution.y ) );
+			IECoreGL::Exception::throwIfError();
+			frameBuffer->validate();
+			FrameBuffer::ScopedBinding frameBufferBinding( *frameBuffer );
+
+			GLint prevProgram;
+			glGetIntegerv( GL_CURRENT_PROGRAM, &prevProgram );
+			glPushAttrib( GL_ALL_ATTRIB_BITS );
+
+				glViewport( 0, 0, resolution.x, resolution.y );
+				glClearColor( 0.0, 0.0, 0.0, 0.0 );
+				glClearDepth( 1.0 );
+				glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
+
+				State::bindBaseState();
+				StatePtr state = new State( /* complete = */ true );
+				state->bind();
+
+				camera->camera()->render( state.get() );
+
+				renderObjects( state.get() );
+
+				writeOutputs( frameBuffer.get() );
+
+			glPopAttrib();
+			glUseProgram( prevProgram );
+		}
+
+		// During interactive renders, the client code controls the lifetime
+		// of objects by managing ObjectInterfacePtrs. But we also hold a
+		// reference to the objects ourselves so that we iterate to render them.
+		// Here we remove any objects with only a single reference - our own.
+		// This does mean we delete objects later than the client might expect,
+		// but this is actually necessary anyway, because we can only delete GL
+		// resources on the main thread.
+		void removeDeletedObjects()
+		{
+			for( auto it = m_cameras.begin(); it != m_cameras.end(); )
+			{
+				if( it->second->refCount() == 1 )
+				{
+					it = m_cameras.unsafe_erase( it );
+				}
+				else
+				{
+					++it;
+				}
+			}
+
+			OpenGLObjectVector objectsToKeep;
+			for( const auto &o : m_objects )
+			{
+				if( o->refCount() == 1 )
+				{
+					objectsToKeep.push_back( o );
+				}
+			}
+			m_objects.swap( objectsToKeep );
+		}
+
+		void renderObjects( IECoreGL::State *currentState )
+		{
+			for( const auto &o : m_objects )
+			{
+				o->render( currentState );
+			}
+		}
+
+		void writeOutputs( const FrameBuffer *frameBuffer )
+		{
+			for( const auto &namedOutput : m_outputs )
+			{
+				IECoreImage::ImagePrimitivePtr image = nullptr;
+				const string &data = namedOutput.second->getData();
+				if( data == "rgba" )
+				{
+					image = frameBuffer->getColor()->imagePrimitive();
+				}
+				else if( data == "rgb" )
+				{
+					image = frameBuffer->getColor()->imagePrimitive();
+					image->channels.erase( "A" );
+				}
+				else if( data == "z" )
+				{
+					image = frameBuffer->getDepth()->imagePrimitive();
+				}
+				else
+				{
+					IECore::msg( IECore::Msg::Warning, "IECoreGL::Renderer", boost::format( "Unsupported data format \"%s\"." ) % data );
+					return;
+				}
+
+				const string &type = namedOutput.second->getType();
+				IECore::WriterPtr writer = IECore::Writer::create( image, "tmp." + type );
+				if( !writer )
+				{
+					IECore::msg( IECore::Msg::Warning, "IECoreGL::Renderer", boost::format( "Unsupported display type \"%s\"." ) % type );
+					return;
+				}
+
+				writer->parameters()->parameter<IECore::FileNameParameter>( "fileName" )->setTypedValue( namedOutput.second->getName() );
+				writer->write();
+			}
+		}
+
+		RenderType m_renderType;
+
+		string m_camera;
+
+		unordered_map<InternedString, ConstDisplayPtr> m_outputs;
+		typedef tbb::concurrent_unordered_map<string, OpenGLCameraPtr> CameraMap;
+		CameraMap m_cameras;
+		typedef tbb::concurrent_vector<OpenGLObjectPtr> OpenGLObjectVector;
+		OpenGLObjectVector m_objects;
+
+		// Registration with factory
+		static Renderer::TypeDescription<OpenGLRenderer> g_typeDescription;
+
+};
+
+IECoreScenePreview::Renderer::TypeDescription<OpenGLRenderer> OpenGLRenderer::g_typeDescription( "OpenGL" );
+
+} // namespace

--- a/src/GafferScene/OpenGLRender.cpp
+++ b/src/GafferScene/OpenGLRender.cpp
@@ -47,7 +47,7 @@ using namespace GafferScene;
 IE_CORE_DEFINERUNTIMETYPED( OpenGLRender );
 
 OpenGLRender::OpenGLRender( const std::string &name )
-	:	ExecutableRender( name )
+	:	Render( "OpenGL", name )
 {
 }
 
@@ -55,10 +55,3 @@ OpenGLRender::~OpenGLRender()
 {
 }
 
-IECore::RendererPtr OpenGLRender::createRenderer() const
-{
-	IECoreGL::init( false );
-	IECore::RendererPtr result = new IECoreGL::Renderer();
-	result->setOption( "gl:mode", new IECore::StringData( "immediate" ) );
-	return result;
-}

--- a/src/GafferScene/Preview/RendererAlgo.cpp
+++ b/src/GafferScene/Preview/RendererAlgo.cpp
@@ -359,7 +359,7 @@ struct LocationOutput
 
 		void applyTransform( IECoreScenePreview::Renderer::ObjectInterface *objectInterface )
 		{
-			if( !m_transformSamples.size() )
+			if( !m_transformSamples.size() || !objectInterface )
 			{
 				return;
 			}

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -45,6 +45,7 @@
 #include "GafferScene/OpenGLRender.h"
 #include "GafferScene/InteractiveRender.h"
 #include "GafferScene/SceneProcedural.h"
+#include "GafferScene/ExecutableRender.h"
 #include "GafferScene/Preview/Render.h"
 #include "GafferScene/Preview/InteractiveRender.h"
 #include "GafferScene/Private/IECoreScenePreview/Renderer.h"
@@ -226,8 +227,6 @@ void GafferSceneModule::bindRender()
 
 	TaskNodeClass<ExecutableRender, ExecutableRenderWrapper>();
 
-	TaskNodeClass<OpenGLRender>();
-
 	{
 		scope s = GafferBindings::NodeClass<InteractiveRender>()
 			.def( "getContext", &interactiveRenderGetContext )
@@ -328,5 +327,7 @@ void GafferSceneModule::bindRender()
 		;
 
 	}
+
+	TaskNodeClass<OpenGLRender>();
 
 }


### PR DESCRIPTION
This implements a new-style renderer backend destined for IECoreGL, and updates the OpenGLRender node to use it. I haven't put much thought into the interactive render mode because it isn't used in Gaffer - I'll revisit when moving this over to Cortex 10, where it'll be needed for things like rendering IECoreMaya::SceneShapes.

Once we have this merged and we get the new NSI backend finalised for 3delight (I'm getting close), Gaffer will have no dependency on the legacy renderer backends, and the move to Cortex 10 can begin.