### PR TITLE
PresetsOnlyParameterValueWidget: Cortex 10 compatibility

### DIFF
--- a/python/GafferCortexUI/PresetsOnlyParameterValueWidget.py
+++ b/python/GafferCortexUI/PresetsOnlyParameterValueWidget.py
@@ -105,5 +105,5 @@ class _PlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 
-			self.__parameterHandler.parameter().setValue( self.__parameterHandler.parameter().presets()[preset] )
+			self.__parameterHandler.parameter().setValue( self.__parameterHandler.parameter().getPresets()[preset] )
 			self.__parameterHandler.setPlugValue()


### PR DESCRIPTION
Cortex 10 renames the Parameter's `presets()` to `getPresets()`.