### PR TITLE
Layer Based Rendering of Gadgets

### DIFF
--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -113,7 +113,7 @@ class ImageGadget : public GafferUI::Gadget
 
 	protected :
 
-		void doRender( const GafferUI::Style *style ) const override;
+		void doRenderLayer( Layer layer, const GafferUI::Style *style ) const override;
 
 	private :
 

--- a/include/GafferSceneUI/SceneGadget.h
+++ b/include/GafferSceneUI/SceneGadget.h
@@ -114,7 +114,7 @@ class SceneGadget : public GafferUI::Gadget
 
 	protected :
 
-		void doRender( const GafferUI::Style *style ) const override;
+		void doRenderLayer( Layer layer, const GafferUI::Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/BackdropNodeGadget.h
+++ b/include/GafferUI/BackdropNodeGadget.h
@@ -68,7 +68,7 @@ class BackdropNodeGadget : public NodeGadget
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/DotNodeGadget.h
+++ b/include/GafferUI/DotNodeGadget.h
@@ -63,7 +63,7 @@ class DotNodeGadget : public StandardNodeGadget
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/Frame.h
+++ b/include/GafferUI/Frame.h
@@ -58,7 +58,7 @@ class Frame : public IndividualContainer
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -81,6 +81,16 @@ class Gadget : public Gaffer::GraphComponent
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::Gadget, GadgetTypeId, Gaffer::GraphComponent );
 
+		enum class Layer
+		{
+			Back = -2,
+			MidBack = -1,
+			Main = 0,
+			MidFront = 1,
+			Front = 2,
+			Last = 3
+		};
+
 		/// Returns the Gadget with the specified name, where name has been retrieved
 		/// from an IECoreGL::HitRecord after rendering some Gadget in GL_SELECT mode.
 		/// \todo Consider better mechanisms.
@@ -171,8 +181,8 @@ class Gadget : public Gaffer::GraphComponent
 		/// and will be used if and only if not overridden by a Style applied
 		/// specifically to this Gadget. Typically users will not pass currentStyle -
 		/// but it must be passed by Gadget implementations when rendering child
-		/// Gadgets in doRender().
-		void render( const Style *currentStyle = nullptr ) const;
+		/// Gadgets in doRenderLayer().
+		void render() const;
 		/// The bounding box of the Gadget before transformation. The default
 		/// implementation returns the union of the transformed bounding boxes
 		/// of all the children.
@@ -277,13 +287,16 @@ class Gadget : public Gaffer::GraphComponent
 		/// Use this rather than emit the signal manually.
 		void requestRender();
 
-		/// The subclass specific part of render(). The public render() method
-		/// sets the GL state up with the name attribute and transform for
-		/// this Gadget, makes sure the style is bound and then calls doRender().
-		/// The default implementation just renders all the visible child Gadgets.
-		virtual void doRender( const Style *style ) const;
+		/// Should be implemented by subclasses to draw themselves as appropriate
+		/// for the specified layer. The default implementation just renders all
+		/// the visible child Gadgets.
+		virtual void doRenderLayer( Layer layer, const Style *style ) const;
 
 	private :
+
+		// Sets the GL state up with the name attribute and transform for
+		// this Gadget, makes sure the style is bound and then calls doRenderLayer().
+		void renderLayer( Layer layer, const Style *currentStyle = nullptr ) const;
 
 		void styleChanged();
 		void parentChanged( GraphComponent *child, GraphComponent *oldParent );
@@ -340,6 +353,8 @@ class Gadget : public Gaffer::GraphComponent
 
 typedef Gaffer::FilteredChildIterator<Gaffer::TypePredicate<Gadget> > GadgetIterator;
 typedef Gaffer::FilteredRecursiveChildIterator<Gaffer::TypePredicate<Gadget> > RecursiveGadgetIterator;
+
+inline Gadget::Layer &operator++( Gadget::Layer &x ) { return x = (Gadget::Layer)(((int)(x) + 1)); };
 
 } // namespace GafferUI
 

--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -58,6 +58,17 @@ IE_CORE_FORWARDDECLARE( Nodule );
 IE_CORE_FORWARDDECLARE( ConnectionGadget );
 IE_CORE_FORWARDDECLARE( GraphLayout );
 
+/// Aliases that define the intended use of each
+/// Gadget::Layer by the GraphGadget components.
+namespace GraphLayer
+{
+	constexpr Gadget::Layer Backdrops = Gadget::Layer::Back;
+	constexpr Gadget::Layer Connections = Gadget::Layer::MidBack;
+	constexpr Gadget::Layer Nodes = Gadget::Layer::Main;
+	constexpr Gadget::Layer Highlighting = Gadget::Layer::MidFront;
+	constexpr Gadget::Layer Overlay = Gadget::Layer::Front;
+};
+
 /// The GraphGadget class provides a ui for connecting nodes together.
 class GraphGadget : public ContainerGadget
 {
@@ -173,7 +184,7 @@ class GraphGadget : public ContainerGadget
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/Handle.h
+++ b/include/GafferUI/Handle.h
@@ -66,7 +66,7 @@ class Handle : public Gadget
 
 		// Implemented to call renderHandle() after applying
 		// the raster scale.
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 		// Must be implemented by derived classes to draw their
 		// handle.

--- a/include/GafferUI/ImageGadget.h
+++ b/include/GafferUI/ImageGadget.h
@@ -79,7 +79,7 @@ class ImageGadget : public Gadget
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/LinearContainer.h
+++ b/include/GafferUI/LinearContainer.h
@@ -94,7 +94,7 @@ class LinearContainer : public ContainerGadget
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/PlugAdder.h
+++ b/include/GafferUI/PlugAdder.h
@@ -71,7 +71,7 @@ class PlugAdder : public Gadget
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 		void applyEdgeMetadata( Gaffer::Plug *plug, bool opposite = false ) const;
 

--- a/include/GafferUI/RenderableGadget.h
+++ b/include/GafferUI/RenderableGadget.h
@@ -120,7 +120,7 @@ class RenderableGadget : public Gadget
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/SpacerGadget.h
+++ b/include/GafferUI/SpacerGadget.h
@@ -62,7 +62,7 @@ class SpacerGadget : public Gadget
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/SplinePlugGadget.h
+++ b/include/GafferUI/SplinePlugGadget.h
@@ -69,7 +69,7 @@ class SplinePlugGadget : public Gadget
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/StandardConnectionGadget.h
+++ b/include/GafferUI/StandardConnectionGadget.h
@@ -69,7 +69,7 @@ class StandardConnectionGadget : public ConnectionGadget
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -104,7 +104,7 @@ class StandardNodeGadget : public NodeGadget
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 		const Imath::Color3f *userColor() const;
 

--- a/include/GafferUI/StandardNodule.h
+++ b/include/GafferUI/StandardNodule.h
@@ -69,7 +69,7 @@ class StandardNodule : public Nodule
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 		void renderLabel( const Style *style ) const;
 
 		void enter( GadgetPtr gadget, const ButtonEvent &event );

--- a/include/GafferUI/TextGadget.h
+++ b/include/GafferUI/TextGadget.h
@@ -62,7 +62,7 @@ class TextGadget : public Gadget
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -184,7 +184,7 @@ class ViewportGadget : public Gadget
 
 	protected :
 
-		void doRender( const Style *style ) const override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUIBindings/GadgetBinding.h
+++ b/include/GafferUIBindings/GadgetBinding.h
@@ -111,19 +111,19 @@ class GadgetWrapper : public GafferBindings::GraphComponentWrapper<WrappedType>
 			return WrappedType::getToolTip( line );
 		}
 
-		void doRender( const GafferUI::Style *style ) const override
+		void doRenderLayer( GafferUI::Gadget::Layer layer, const GafferUI::Style *style ) const override
 		{
 			if( this->isSubclassed() )
 			{
 				IECorePython::ScopedGILLock gilLock;
-				boost::python::object f = this->methodOverride( "doRender" );
+				boost::python::object f = this->methodOverride( "doRenderLayer" );
 				if( f )
 				{
-					f( style );
+					f( layer, style );
 					return;
 				}
 			}
-			WrappedType::doRender( style );
+			WrappedType::doRenderLayer( layer, style );
 		}
 
 };

--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -637,8 +637,13 @@ void ImageGadget::renderText( const std::string &text, const Imath::V2f &positio
 	style->renderText( Style::LabelText, text );
 }
 
-void ImageGadget::doRender( const GafferUI::Style *style ) const
+void ImageGadget::doRenderLayer( Layer layer, const GafferUI::Style *style ) const
 {
+	if( layer != Layer::Main )
+	{
+		return;
+	}
+
 	if( IECoreGL::Selector::currentSelector() )
 	{
 		return;

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -158,8 +158,13 @@ class CropWindowTool::Rectangle : public GafferUI::Gadget
 
 	protected :
 
-		void doRender( const Style *style ) const override
+		void doRenderLayer( Layer layer, const Style *style ) const override
 		{
+			if( layer != Layer::Main )
+			{
+				return;
+			}
+
 			if( m_rectangle.isEmpty() )
 			{
 				return;

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -798,8 +798,13 @@ Imath::Box3f SceneGadget::bound() const
 	return m_sceneGraph->bound();
 }
 
-void SceneGadget::doRender( const GafferUI::Style *style ) const
+void SceneGadget::doRenderLayer( Layer layer, const GafferUI::Style *style ) const
 {
+	if( layer != Layer::Main )
+	{
+		return;
+	}
+
 	if( !m_scene || IECoreGL::Selector::currentSelector() )
 	{
 		return;

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -419,8 +419,13 @@ class GnomonPlane : public GafferUI::Gadget
 
 	protected :
 
-		void doRender( const Style *style ) const override
+		void doRenderLayer( Layer layer, const Style *style ) const override
 		{
+			if( layer != Layer::Main )
+			{
+				return;
+			}
+
 			if( m_hovering || IECoreGL::Selector::currentSelector() )
 			{
 				/// \todo Really the style should be choosing the colours.
@@ -458,8 +463,13 @@ class GnomonGadget : public GafferUI::Gadget
 
 	protected :
 
-		void doRender( const Style *style ) const override
+		void doRenderLayer( Layer layer, const Style *style ) const override
 		{
+			if( layer != Layer::Main )
+			{
+				return Gadget::doRenderLayer( layer, style );
+			}
+
 			const float pixelWidth = 30.0f;
 			const V2i viewport = ancestor<ViewportGadget>()->getViewport();
 
@@ -512,7 +522,7 @@ class GnomonGadget : public GafferUI::Gadget
 			style->renderTranslateHandle( Style::Y );
 			style->renderTranslateHandle( Style::Z );
 
-			Gadget::doRender( style );
+			Gadget::doRenderLayer( layer, style );
 
 			// and pop the matrices back to their original values
 
@@ -708,8 +718,13 @@ class CameraOverlay : public GafferUI::Gadget
 
 	protected :
 
-		void doRender( const Style *style ) const override
+		void doRenderLayer( Layer layer, const Style *style ) const override
 		{
+			if( layer != Layer::Main )
+			{
+				return Gadget::doRenderLayer( layer, style );
+			}
+
 			if( IECoreGL::Selector::currentSelector() || m_resolutionGate.isEmpty() )
 			{
 				return;

--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -104,8 +104,13 @@ class SelectionTool::DragOverlay : public GafferUI::Gadget
 
 	protected :
 
-		void doRender( const Style *style ) const override
+		void doRenderLayer( Layer layer, const Style *style ) const override
 		{
+			if( layer != Layer::Main )
+			{
+				return Gadget::doRenderLayer( layer, style );
+			}
+
 			if( IECoreGL::Selector::currentSelector() )
 			{
 				return;

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -254,19 +254,25 @@ class HandlesGadget : public Gadget
 
 	protected :
 
-		void doRender( const Style *style ) const override
+		void doRenderLayer( Layer layer, const Style *style ) const override
 		{
+			if( layer != Layer::Main )
+			{
+				return;
+			}
+			// TODO: can this be done via layers now?
+
 			glEnable( GL_DEPTH_TEST );
 			// Render with reversed depth test so
 			// the handles are visible even when
 			// behind an object.
 			glDepthFunc( GL_GREATER );
-			Gadget::doRender( style );
+			Gadget::doRenderLayer( layer, style );
 			// The render with the regular depth
 			// test so that the handles occlude
 			// themselves appropriately.
 			glDepthFunc( GL_LESS );
-			Gadget::doRender( style );
+			Gadget::doRenderLayer( layer, style );
 		}
 
 };

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -229,8 +229,13 @@ Imath::Box3f BackdropNodeGadget::bound() const
 	return Box3f( V3f( b.min.x, b.min.y, 0.0f ), V3f( b.max.x, b.max.y, 0.0f ) );
 }
 
-void BackdropNodeGadget::doRender( const Style *style ) const
+void BackdropNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
+	if( layer != GraphLayer::Backdrops )
+	{
+		return;
+	}
+
 	// this is our bound in gadget space
 	Box2f bound = boundPlug()->getValue();
 

--- a/src/GafferUI/DotNodeGadget.cpp
+++ b/src/GafferUI/DotNodeGadget.cpp
@@ -87,8 +87,13 @@ DotNodeGadget::~DotNodeGadget()
 {
 }
 
-void DotNodeGadget::doRender( const Style *style ) const
+void DotNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
+	if( layer != GraphLayer::Nodes )
+	{
+		return NodeGadget::doRenderLayer( layer, style );
+	}
+
 	Style::State state = getHighlighted() ? Style::HighlightedState : Style::NormalState;
 
 	const Box3f b = bound();
@@ -103,7 +108,7 @@ void DotNodeGadget::doRender( const Style *style ) const
 		glPopMatrix();
 	}
 
-	NodeGadget::doRender( style );
+	NodeGadget::doRenderLayer( layer, style );
 }
 
 Gaffer::Dot *DotNodeGadget::dotNode()

--- a/src/GafferUI/Frame.cpp
+++ b/src/GafferUI/Frame.cpp
@@ -37,6 +37,7 @@
 
 #include "GafferUI/Frame.h"
 #include "GafferUI/Style.h"
+#include "GafferUI/GraphGadget.h"
 
 #include "IECore/CurvesPrimitive.h"
 #include "IECore/MeshPrimitive.h"
@@ -72,11 +73,16 @@ Imath::Box3f Frame::bound() const
 	return b;
 }
 
-void Frame::doRender( const Style *style ) const
+void Frame::doRenderLayer( Layer layer, const Style *style ) const
 {
+	if( layer != GraphLayer::Nodes )
+	{
+		return;
+	}
+
 	Imath::Box3f b = IndividualContainer::bound();
 
 	style->renderFrame( Box2f( V2f( b.min.x, b.min.y ), V2f( b.max.x, b.max.y ) ), m_border );
 
-	IndividualContainer::doRender( style );
+	IndividualContainer::doRenderLayer( layer, style );
 }

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -254,7 +254,15 @@ Imath::M44f Gadget::fullTransform( const Gadget *ancestor ) const
 	return result;
 }
 
-void Gadget::render( const Style *currentStyle ) const
+void Gadget::render() const
+{
+	for( Layer layer = Layer::Back; layer < Layer::Last; ++layer )
+	{
+		renderLayer( layer, /* currentStyle = */ nullptr );
+	}
+}
+
+void Gadget::renderLayer( Layer layer, const Style *currentStyle ) const
 {
 	glPushMatrix();
 
@@ -279,7 +287,7 @@ void Gadget::render( const Style *currentStyle ) const
 			selector->loadName( m_glName );
 		}
 
-		doRender( currentStyle );
+		doRenderLayer( layer, currentStyle );
 
 	glPopMatrix();
 }
@@ -294,7 +302,7 @@ void Gadget::requestRender()
 	}
 }
 
-void Gadget::doRender( const Style *style ) const
+void Gadget::doRenderLayer( Layer layer, const Style *style ) const
 {
 	for( ChildContainer::const_iterator it=children().begin(); it!=children().end(); it++ )
 	{
@@ -304,7 +312,7 @@ void Gadget::doRender( const Style *style ) const
 		{
 			continue;
 		}
-		c->render( style );
+		c->renderLayer( layer, style );
 	}
 }
 

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -628,78 +628,62 @@ ConnectionGadget *GraphGadget::reconnectionGadgetAt( const NodeGadget *gadget, c
 	return nullptr;
 }
 
-void GraphGadget::doRender( const Style *style ) const
+void GraphGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
 	glDisable( GL_DEPTH_TEST );
 
-	// render backdrops before anything else
-	/// \todo Perhaps we need a more general layering system as part
-	/// of the Gadget system, to allow Gadgets to choose their own layering,
-	/// and perhaps to also allow one gadget to draw into multiple layers.
-	for( ChildContainer::const_iterator it=children().begin(); it!=children().end(); it++ )
+	switch( layer )
 	{
-		if( (*it)->isInstanceOf( (IECore::TypeId)BackdropNodeGadgetTypeId ) )
+
+	case GraphLayer::Connections :
+
+		// render the new drag connections if they exist
+		if ( m_dragReconnectCandidate )
 		{
-			static_cast<const Gadget *>( it->get() )->render( style );
+			if ( m_dragReconnectDstNodule )
+			{
+				const Nodule *srcNodule = m_dragReconnectCandidate->srcNodule();
+				const NodeGadget *srcNodeGadget = nodeGadget( srcNodule->plug()->node() );
+				const Imath::V3f srcP = srcNodule->fullTransform( this ).translation();
+				const Imath::V3f dstP = m_dragReconnectDstNodule->fullTransform( this ).translation();
+				const Imath::V3f dstTangent = nodeGadget( m_dragReconnectDstNodule->plug()->node() )->noduleTangent( m_dragReconnectDstNodule );
+				/// \todo: can there be a highlighted/dashed state?
+				style->renderConnection( srcP, srcNodeGadget->noduleTangent( srcNodule ), dstP, dstTangent, Style::HighlightedState );
+			}
+
+			if ( m_dragReconnectSrcNodule )
+			{
+				const Nodule *dstNodule = m_dragReconnectCandidate->dstNodule();
+				const NodeGadget *dstNodeGadget = nodeGadget( dstNodule->plug()->node() );
+				const Imath::V3f srcP = m_dragReconnectSrcNodule->fullTransform( this ).translation();
+				const Imath::V3f dstP = dstNodule->fullTransform( this ).translation();
+				const Imath::V3f srcTangent = nodeGadget( m_dragReconnectSrcNodule->plug()->node() )->noduleTangent( m_dragReconnectSrcNodule );
+				/// \todo: can there be a highlighted/dashed state?
+				style->renderConnection( srcP, srcTangent, dstP, dstNodeGadget->noduleTangent( dstNodule ), Style::HighlightedState );
+			}
 		}
+		break;
+
+	case GraphLayer::Overlay :
+
+		// render drag select thing if needed
+		if( m_dragMode == Selecting )
+		{
+			const ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
+			ViewportGadget::RasterScope rasterScope( viewportGadget );
+
+			Box2f b;
+			b.extendBy( viewportGadget->gadgetToRasterSpace( V3f( m_dragStartPosition.x, m_dragStartPosition.y, 0 ), this ) );
+			b.extendBy( viewportGadget->gadgetToRasterSpace( V3f( m_lastDragPosition.x, m_lastDragPosition.y, 0 ), this ) );
+			style->renderSelectionBox( b );
+		}
+		break;
+
+	default:
+		break;
 	}
 
-	// then render connections so they go underneath the nodes
-	for( ChildContainer::const_iterator it=children().begin(); it!=children().end(); it++ )
-	{
-		ConnectionGadget *c = IECore::runTimeCast<ConnectionGadget>( it->get() );
-		if ( c && c != m_dragReconnectCandidate )
-		{
-			c->render( style );
-		}
-	}
-
-	// render the new drag connections if they exist
-	if ( m_dragReconnectCandidate )
-	{
-		if ( m_dragReconnectDstNodule )
-		{
-			const Nodule *srcNodule = m_dragReconnectCandidate->srcNodule();
-			const NodeGadget *srcNodeGadget = nodeGadget( srcNodule->plug()->node() );
-			const Imath::V3f srcP = srcNodule->fullTransform( this ).translation();
-			const Imath::V3f dstP = m_dragReconnectDstNodule->fullTransform( this ).translation();
-			const Imath::V3f dstTangent = nodeGadget( m_dragReconnectDstNodule->plug()->node() )->noduleTangent( m_dragReconnectDstNodule );
-			/// \todo: can there be a highlighted/dashed state?
-			style->renderConnection( srcP, srcNodeGadget->noduleTangent( srcNodule ), dstP, dstTangent, Style::HighlightedState );
-		}
-
-		if ( m_dragReconnectSrcNodule )
-		{
-			const Nodule *dstNodule = m_dragReconnectCandidate->dstNodule();
-			const NodeGadget *dstNodeGadget = nodeGadget( dstNodule->plug()->node() );
-			const Imath::V3f srcP = m_dragReconnectSrcNodule->fullTransform( this ).translation();
-			const Imath::V3f dstP = dstNodule->fullTransform( this ).translation();
-			const Imath::V3f srcTangent = nodeGadget( m_dragReconnectSrcNodule->plug()->node() )->noduleTangent( m_dragReconnectSrcNodule );
-			/// \todo: can there be a highlighted/dashed state?
-			style->renderConnection( srcP, srcTangent, dstP, dstNodeGadget->noduleTangent( dstNodule ), Style::HighlightedState );
-		}
-	}
-
-	// then render the rest on top
-	for( ChildContainer::const_iterator it=children().begin(); it!=children().end(); it++ )
-	{
-		if( !((*it)->isInstanceOf( ConnectionGadget::staticTypeId() )) && !((*it)->isInstanceOf( (IECore::TypeId)BackdropNodeGadgetTypeId )) )
-		{
-			static_cast<const Gadget *>( it->get() )->render( style );
-		}
-	}
-
-	// render drag select thing if needed
-	if( m_dragMode == Selecting )
-	{
-		const ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
-		ViewportGadget::RasterScope rasterScope( viewportGadget );
-
-		Box2f b;
-		b.extendBy( viewportGadget->gadgetToRasterSpace( V3f( m_dragStartPosition.x, m_dragStartPosition.y, 0 ), this ) );
-		b.extendBy( viewportGadget->gadgetToRasterSpace( V3f( m_lastDragPosition.x, m_lastDragPosition.y, 0 ), this ) );
-		style->renderSelectionBox( b );
-	}
+	Gadget::doRenderLayer( layer, style );
 
 }
 
@@ -1166,6 +1150,10 @@ bool GraphGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 
 void GraphGadget::updateDragReconnectCandidate( const DragDropEvent &event )
 {
+	if( m_dragReconnectCandidate )
+	{
+		m_dragReconnectCandidate->setVisible( true );
+	}
 	m_dragReconnectCandidate = nullptr;
 	m_dragReconnectSrcNodule = nullptr;
 	m_dragReconnectDstNodule = nullptr;
@@ -1253,6 +1241,7 @@ void GraphGadget::updateDragReconnectCandidate( const DragDropEvent &event )
 			m_dragReconnectCandidate = connection;
 			m_dragReconnectDstNodule = inNodule;
 			m_dragReconnectSrcNodule = outNodule;
+			m_dragReconnectCandidate->setVisible( false );
 			return;
 		}
 	}

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -98,9 +98,9 @@ const InternedString g_nodeGadgetTypeName( "nodeGadget:type" );
 
 struct CompareV2fX{
 	bool operator()(const Imath::V2f &a, const Imath::V2f &b) const
-	{   
+	{
 		return a[0] < b[0];
-	}   
+	}
 };
 
 } // namespace
@@ -603,9 +603,6 @@ ConnectionGadget *GraphGadget::reconnectionGadgetAt( const NodeGadget *gadget, c
 	{
 		ViewportGadget::SelectionScope selectionScope( corner0, corner1, this, selection, IECoreGL::Selector::IDRender );
 
-		const Style *s = style();
-		s->bind();
-
 		for ( ChildContainer::const_iterator it = children().begin(); it != children().end(); ++it )
 		{
 			if ( ConnectionGadget *c = IECore::runTimeCast<ConnectionGadget>( it->get() ) )
@@ -613,7 +610,7 @@ ConnectionGadget *GraphGadget::reconnectionGadgetAt( const NodeGadget *gadget, c
 				// don't consider the node's own connections, or connections without a source nodule
 				if ( c->srcNodule() && gadget->node() != c->srcNodule()->plug()->node() && gadget->node() != c->dstNodule()->plug()->node() )
 				{
-					c->render( s );
+					c->render();
 				}
 			}
 		}
@@ -1098,7 +1095,7 @@ bool GraphGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 	if( m_dragMode == Moving )
 	{
 		const float snapThresh = 1.5;
-		
+
 		// snap the position using the offsets precomputed in calculateDragSnapOffsets()
 		V2f startPos = V2f( i.x, i.y );
 		V2f pos = startPos;

--- a/src/GafferUI/Handle.cpp
+++ b/src/GafferUI/Handle.cpp
@@ -101,8 +101,13 @@ Imath::Box3f Handle::bound() const
 	return Box3f( V3f( -1 ), V3f( 1 ) );
 }
 
-void Handle::doRender( const Style *style ) const
+void Handle::doRenderLayer( Layer layer, const Style *style ) const
 {
+	if( layer != Layer::Main )
+	{
+		return;
+	}
+
 	if( m_rasterScale > 0.0f )
 	{
 		// We want our handles to be a constant length in

--- a/src/GafferUI/ImageGadget.cpp
+++ b/src/GafferUI/ImageGadget.cpp
@@ -170,15 +170,20 @@ IECoreGL::TextureLoader *ImageGadget::textureLoader()
 	return loader.get();
 }
 
-void ImageGadget::doRender( const Style *style ) const
+void ImageGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
+	if( layer != Layer::Main )
+	{
+		return Gadget::doRenderLayer( layer, style );
+	}
+
 	if( const Texture *texture = loadTexture( m_imageOrTextureOrFileName ) )
 	{
 		Box2f b( V2f( m_bound.min.x, m_bound.min.y ), V2f( m_bound.max.x, m_bound.max.y ) );
 		style->renderImage( b, texture );
 	}
 
-	Gadget::doRender( style );
+	Gadget::doRenderLayer( layer, style );
 }
 
 Imath::Box3f ImageGadget::bound() const

--- a/src/GafferUI/LinearContainer.cpp
+++ b/src/GafferUI/LinearContainer.cpp
@@ -159,10 +159,10 @@ Imath::Box3f LinearContainer::bound() const
 	return ContainerGadget::bound();
 }
 
-void LinearContainer::doRender( const Style *style ) const
+void LinearContainer::doRenderLayer( Layer layer, const Style *style ) const
 {
 	calculateChildTransforms();
-	ContainerGadget::doRender( style );
+	ContainerGadget::doRenderLayer( layer, style );
 }
 
 void LinearContainer::calculateChildTransforms() const

--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -47,6 +47,7 @@
 #include "GafferUI/PlugAdder.h"
 #include "GafferUI/Style.h"
 #include "GafferUI/ConnectionGadget.h"
+#include "GafferUI/GraphGadget.h"
 
 using namespace Imath;
 using namespace IECore;
@@ -182,25 +183,37 @@ PlugAdder::PlugMenuSignal &PlugAdder::plugMenuSignal()
 	return s;
 }
 
-void PlugAdder::doRender( const Style *style ) const
+void PlugAdder::doRenderLayer( Layer layer, const Style *style ) const
 {
-	if( m_dragging )
+	switch( layer )
 	{
-		if( !IECoreGL::Selector::currentSelector() )
-		{
-			V3f srcTangent( 0.0f, 0.0f, 0.0f );
-			style->renderConnection( V3f( 0 ), srcTangent, m_dragPosition, m_dragTangent, Style::HighlightedState );
-		}
+		case GraphLayer::Connections :
+			if( m_dragging )
+			{
+				if( !IECoreGL::Selector::currentSelector() )
+				{
+					V3f srcTangent( 0.0f, 0.0f, 0.0f );
+					style->renderConnection( V3f( 0 ), srcTangent, m_dragPosition, m_dragTangent, Style::HighlightedState );
+				}
+			}
+			break;
+		case GraphLayer::Nodes :
+			if( !getHighlighted() )
+			{
+				const float radius = 0.75f;
+				style->renderImage( Box2f( V2f( -radius ), V2f( radius ) ), texture( Style::NormalState ) );
+			}
+			break;
+		case GraphLayer::Highlighting :
+			if( getHighlighted() )
+			{
+				const float radius = 1.25f;
+				style->renderImage( Box2f( V2f( -radius ), V2f( radius ) ), texture( Style::HighlightedState ) );
+			}
+			break;
+		default:
+			break;
 	}
-
-	float radius = 0.75f;
-	Style::State state = Style::NormalState;
-	if( getHighlighted() )
-	{
-		radius = 1.25f;
-		state = Style::HighlightedState;
-	}
-	style->renderImage( Box2f( V2f( -radius ), V2f( radius ) ), texture( state ) );
 }
 
 void PlugAdder::applyEdgeMetadata( Gaffer::Plug *plug, bool opposite ) const

--- a/src/GafferUI/RenderableGadget.cpp
+++ b/src/GafferUI/RenderableGadget.cpp
@@ -107,8 +107,13 @@ Imath::Box3f RenderableGadget::bound() const
 	}
 }
 
-void RenderableGadget::doRender( const Style *style ) const
+void RenderableGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
+	if( layer != Layer::Main )
+	{
+		return;
+	}
+
 	if( IECoreGL::Selector::currentSelector() )
 	{
 		// our scene may contain shaders which don't work with

--- a/src/GafferUI/SpacerGadget.cpp
+++ b/src/GafferUI/SpacerGadget.cpp
@@ -49,7 +49,7 @@ SpacerGadget::~SpacerGadget()
 {
 }
 
-void SpacerGadget::doRender( const Style *style ) const
+void SpacerGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
 }
 

--- a/src/GafferUI/SplinePlugGadget.cpp
+++ b/src/GafferUI/SplinePlugGadget.cpp
@@ -122,8 +122,13 @@ Imath::Box3f SplinePlugGadget::bound() const
 	return result;
 }
 
-void SplinePlugGadget::doRender( const Style *style ) const
+void SplinePlugGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
+	if( layer != Layer::Main)
+	{
+		return;
+	}
+
 	for( size_t i = 0, e = m_splines->size(); i < e ; i++ )
 	{
 		SplineffPlugPtr spline = IECore::runTimeCast<SplineffPlug>( m_splines->member( i ) );

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -177,8 +177,14 @@ void StandardConnectionGadget::updateDragEndPoint( const Imath::V3f position, co
  	requestRender();
 }
 
-void StandardConnectionGadget::doRender( const Style *style ) const
+void StandardConnectionGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
+	// Connections get rendered below NodeGadgets but over BackdropGadgets
+	if( layer != GraphLayer::Connections )
+	{
+		return;
+	}
+
 	const_cast<StandardConnectionGadget *>( this )->setPositionsFromNodules();
 
 	Style::State state = ( m_hovering || m_dragEnd || m_dotPreview ) ? Style::HighlightedState : Style::NormalState;

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -62,6 +62,7 @@
 #include "GafferUI/ImageGadget.h"
 #include "GafferUI/PlugAdder.h"
 #include "GafferUI/NoduleLayout.h"
+#include "GafferUI/GraphGadget.h"
 
 using namespace std;
 using namespace Imath;
@@ -320,8 +321,13 @@ Imath::Box3f StandardNodeGadget::bound() const
 	return b;
 }
 
-void StandardNodeGadget::doRender( const Style *style ) const
+void StandardNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
+	if( layer != GraphLayer::Nodes )
+	{
+		return NodeGadget::doRenderLayer( layer, style );
+	}
+
 	// decide what state we're rendering in
 	Style::State state = getHighlighted() ? Style::HighlightedState : Style::NormalState;
 
@@ -342,7 +348,7 @@ void StandardNodeGadget::doRender( const Style *style ) const
 	);
 
 	// draw our contents
-	NodeGadget::doRender( style );
+	NodeGadget::doRenderLayer( layer, style );
 
 	// draw a strikethrough if we're disabled
 	if( !m_nodeEnabled && !IECoreGL::Selector::currentSelector() )

--- a/src/GafferUI/TextGadget.cpp
+++ b/src/GafferUI/TextGadget.cpp
@@ -82,7 +82,12 @@ Imath::Box3f TextGadget::bound() const
 	return m_bound;
 }
 
-void TextGadget::doRender( const Style *style ) const
+void TextGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
+	if( layer != Layer::Main )
+	{
+		return;
+	}
+
 	style->renderText( Style::LabelText, m_text );
 }

--- a/src/GafferUIModule/GadgetBinding.cpp
+++ b/src/GafferUIModule/GadgetBinding.cpp
@@ -185,10 +185,10 @@ void setEnabled( Gadget &g, bool enabled )
 	g.setEnabled( enabled );
 }
 
-void render( const Gadget &g, const Style *currentStyle )
+void render( const Gadget &g )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	g.render( currentStyle );
+	g.render();
 }
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS( fullTransformOverloads, fullTransform, 0, 1 );

--- a/src/GafferUIModule/GadgetBinding.cpp
+++ b/src/GafferUIModule/GadgetBinding.cpp
@@ -246,6 +246,14 @@ void GafferUIModule::bindGadget()
 		.def( "select", &Gadget::select ).staticmethod( "select" )
 	;
 
+	enum_<Gadget::Layer>( "Layer" )
+		.value( "Back", Gadget::Layer::Back )
+		.value( "MidBack", Gadget::Layer::MidBack )
+		.value( "Main", Gadget::Layer::Main )
+		.value( "MidFront", Gadget::Layer::MidFront )
+		.value( "Front", Gadget::Layer::Front )
+	;
+
 	SignalClass<Gadget::RenderRequestSignal, DefaultSignalCaller<Gadget::RenderRequestSignal>, RenderRequestSlotCaller>( "RenderRequestSignal" );
 	SignalClass<Gadget::ButtonSignal, DefaultSignalCaller<Gadget::ButtonSignal>, ButtonSlotCaller>( "ButtonSignal" );
 	SignalClass<Gadget::KeySignal, DefaultSignalCaller<Gadget::KeySignal>, KeySlotCaller>( "KeySignal" );


### PR DESCRIPTION
Hey John,

Here is the first attempt regarding rejiggering the Gadget rendering order. I think it pretty much follows what we discussed? A few things to note:

- The `GraphGadget` implementation isn't as clean as we'd like. `Backdrops` mess a little with our plan, don't they? I've updated the comment in the code accordingly, but maybe I'm missing a simple solution.
- I've updated the rendering bits for `PlugAdders` and `StandardNodules` and I think they behave much better now? :) I checked for other spots in the code where we are looking for the highlighting state of `Gadgets` because I'm assuming that whenever something is highlighted it should get rendered last, but couldn't find anything else. Probably worth keeping in mind for the future.
- There's potential to be a bit more DRY, especially in `Gadget`'s `render*` methods. Not sure if it's worth pulling out some of the duplicated code.
- I wasn't sure about C++11 features, I'm using both auto and range-based for in GraphGadget's rendering code. That's probably ok?

For anyone following along - this PR is meant to be the foundation for some of the additional work we're doing in the never-ending https://github.com/GafferHQ/gaffer/pull/2201. In that PR we'll update the label rendering and some of work done here will help with that.

Thanks :)

Matti.
