### PR TITLE
BoxIO : Fix undo/redo of `insert()` method

### DIFF
--- a/python/GafferTest/BoxIOTest.py
+++ b/python/GafferTest/BoxIOTest.py
@@ -1,0 +1,108 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferTest
+
+class BoxIOTest( GafferTest.TestCase ) :
+
+	def testInsertAndUndo( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n1"] = GafferTest.AddNode()
+		s["n2"] = GafferTest.AddNode()
+		s["n3"] = GafferTest.AddNode()
+
+		s["n2"]["op1"].setInput( s["n1"]["sum"] )
+		s["n3"]["op1"].setInput( s["n2"]["sum"] )
+
+		Gaffer.Metadata.registerValue( s["n1"]["sum"], "nodule:type", "GafferUI::StandardNodule" )
+		Gaffer.Metadata.registerValue( s["n2"]["op1"], "nodule:type", "GafferUI::StandardNodule" )
+		Gaffer.Metadata.registerValue( s["n2"]["sum"], "nodule:type", "GafferUI::StandardNodule" )
+		Gaffer.Metadata.registerValue( s["n3"]["op1"], "nodule:type", "GafferUI::StandardNodule" )
+
+		def assertPreconditions() :
+
+			self.assertTrue( "n1" in s )
+			self.assertTrue( "n2" in s )
+			self.assertTrue( "n3" in s )
+
+			self.assertTrue( s["n2"]["op1"].getInput().isSame( s["n1"]["sum"] ) )
+			self.assertTrue( s["n3"]["op1"].getInput().isSame( s["n2"]["sum"] ) )
+
+			self.assertEqual( s.children( Gaffer.Box ), () )
+
+		assertPreconditions()
+
+		with Gaffer.UndoScope( s ) :
+			b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n2"] ] ) )
+			Gaffer.BoxIO.insert( b )
+
+		def assertPostconditions() :
+
+			self.assertTrue( "n1" in s )
+			self.assertFalse( "n2" in s )
+			self.assertTrue( "n3" in s )
+
+			self.assertEqual( set( s["Box"].keys() ), { "user", "n2", "BoxIn", "BoxOut", "op1", "sum" } )
+
+			self.assertIsInstance( s["Box"]["n2"]["op1"].getInput().node(), Gaffer.BoxIn )
+			self.assertTrue( s["Box"]["n2"]["op1"].source().isSame( s["n1"]["sum"] ) )
+
+			self.assertEqual( len( s["Box"]["sum"].outputs() ), 1 )
+			self.assertIsInstance( s["Box"]["n2"]["sum"].outputs()[0].node(), Gaffer.BoxOut )
+
+			self.assertTrue( s["n3"]["op1"].source().isSame( s["Box"]["n2"]["sum"] ) )
+
+		assertPostconditions()
+
+		s.undo()
+		assertPreconditions()
+
+		s.redo()
+		assertPostconditions()
+
+		s.undo()
+		assertPreconditions()
+
+		s.redo()
+		assertPostconditions()
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/BoxIOTest.py
+++ b/python/GafferTest/BoxIOTest.py
@@ -104,5 +104,25 @@ class BoxIOTest( GafferTest.TestCase ) :
 		s.redo()
 		assertPostconditions()
 
+	def testInsertWithNonSerialisableOutput( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+		s["b"]["a"] = GafferTest.AddNode()
+		s["b"]["a"]["sum"].setFlags( Gaffer.Plug.Flags.Serialisable, False )
+
+		Gaffer.Metadata.registerValue( s["b"]["a"]["sum"], "nodule:type", "GafferUI::StandardNodule" )
+		Gaffer.PlugAlgo.promote( s["b"]["a"]["sum"] )
+		Gaffer.BoxIO.insert( s["b"] )
+
+		self.assertIsInstance( s["b"]["sum"].getInput().node(), Gaffer.BoxOut )
+		self.assertTrue( s["b"]["sum"].source().isSame( s["b"]["a"]["sum"] ) )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertIsInstance( s2["b"]["sum"].getInput().node(), Gaffer.BoxOut )
+		self.assertTrue( s2["b"]["sum"].source().isSame( s2["b"]["a"]["sum"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -578,5 +578,20 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		self.assertEqual( n["a"]["p"]["c"]["i"].getValue(), 10 )
 		self.assertEqual( n["a"]["p"]["c"]["v"].getValue(), IECore.V3f( 1, 2, 3 ) )
 
+	def testPromoteNonSerialisableOutput( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+		s["b"]["a"] = GafferTest.AddNode()
+		s["b"]["a"]["sum"].setFlags( Gaffer.Plug.Flags.Serialisable, False )
+
+		Gaffer.PlugAlgo.promote( s["b"]["a"]["sum"] )
+		self.assertTrue( s["b"]["sum"].getInput().isSame( s["b"]["a"]["sum"] ) )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertTrue( s2["b"]["sum"].getInput().isSame( s2["b"]["a"]["sum"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -134,6 +134,7 @@ from PlugAlgoTest import PlugAlgoTest
 from BoxInTest import BoxInTest
 from BoxOutTest import BoxOutTest
 from DirtyPropagationScopeTest import DirtyPropagationScopeTest
+from BoxIOTest import BoxIOTest
 
 if __name__ == "__main__":
 	import unittest

--- a/src/Gaffer/BoxIO.cpp
+++ b/src/Gaffer/BoxIO.cpp
@@ -523,13 +523,13 @@ void BoxIO::insert( Box *box )
 			BoxInPtr boxIn = new BoxIn;
 			boxIn->namePlug()->setValue( plug->getName() );
 			boxIn->setup( plug );
+			box->addChild( boxIn );
+
 			boxIn->inPlugInternal()->setInput( plug );
 			for( std::vector<Plug *>::const_iterator oIt = outputsNeedingBoxIn.begin(), oeIt = outputsNeedingBoxIn.end(); oIt != oeIt; ++oIt )
 			{
 				(*oIt)->setInput( boxIn->plug<Plug>() );
 			}
-
-			box->addChild( boxIn );
 		}
 		else
 		{
@@ -544,9 +544,10 @@ void BoxIO::insert( Box *box )
 			BoxOutPtr boxOut = new BoxOut;
 			boxOut->namePlug()->setValue( plug->getName() );
 			boxOut->setup( plug );
+			box->addChild( boxOut );
+
 			boxOut->plug<Plug>()->setInput( input );
 			plug->setInput( boxOut->outPlugInternal() );
-			box->addChild( boxOut );
 		}
 	}
 

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -411,6 +411,7 @@ Plug *promoteWithName( Plug *plug, const InternedString &name, Plug *parent, con
 	if( dynamic )
 	{
 		applyDynamicFlag( externalPlug.get() );
+		externalPlug->setFlags( Plug::Serialisable, true );
 	}
 
 	if( parent )


### PR DESCRIPTION
We need to make sure that the nodes have a parent when we perform actions we need to be replayed by the undo system. But we also need to make sure they _don't_ have a parent when we call `setup()`, because that would cause the creation of duplicate external plugs.