### PR TITLE
Plug : Fix `setInput( nullptr )` to remove descendant inputs (0.35 backport)

### DIFF
--- a/python/GafferTest/ValuePlugTest.py
+++ b/python/GafferTest/ValuePlugTest.py
@@ -626,6 +626,19 @@ class ValuePlugTest( GafferTest.TestCase ) :
 
 		self.failUnless( n["p"] is p )
 
+	def testNullInputPropagatesToChildren( self ) :
+
+		n = Gaffer.Node()
+		n["user"]["c"] = Gaffer.ValuePlug()
+		n["user"]["c"]["o"] = Gaffer.IntPlug()
+		n["user"]["c"]["i"] = Gaffer.IntPlug()
+
+		n["user"]["c"]["i"].setInput( n["user"]["c"]["o"] )
+		self.assertTrue( n["user"]["c"]["i"].getInput().isSame( n["user"]["c"]["o"] ) )
+
+		n["user"]["c"].setInput( None )
+		self.assertTrue( n["user"]["c"]["i"].getInput() is None )
+
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -56,7 +56,7 @@ using namespace boost;
 using namespace Gaffer;
 
 //////////////////////////////////////////////////////////////////////////
-// ScopedAssignment utility class
+// Internal utilities
 //////////////////////////////////////////////////////////////////////////
 
 namespace
@@ -86,6 +86,18 @@ class ScopedAssignment : boost::noncopyable
 		T m_originalValue;
 
 };
+
+bool allDescendantInputsAreNull( const Plug *plug )
+{
+	for( RecursivePlugIterator it( plug ); !it.done(); ++it )
+	{
+		if( (*it)->getInput<Plug>() )
+		{
+			return false;
+		}
+	}
+	return true;
+}
 
 } // namespace
 
@@ -364,6 +376,11 @@ bool Plug::acceptsInputInternal( const Plug *input ) const
 	return true;
 }
 
+/// \todo Make this non-virtual - it is too error prone to allow derived classes to
+/// modify the mechanics of making connections. We could add a protected
+/// `virtual inputChanging()` method that ValuePlug uses to do what it currently does
+/// in `setInput()`, and we could rewrite ArrayPlug so that it only adds new plugs on
+/// explicit request, not automatically in `plugInputChanged()`.
 void Plug::setInput( PlugPtr input )
 {
 	setInput( input, /* setChildInputs = */ true, /* updateParentInput = */ true );
@@ -373,7 +390,21 @@ void Plug::setInput( PlugPtr input, bool setChildInputs, bool updateParentInput 
 {
 	if( input.get()==m_input )
 	{
-		return;
+		if(
+			// If the current input is non-null, we know that our
+			// children have the appropriate corresponding
+			// inputs too, so can exit early.
+			m_input ||
+			// But if the input is null, our children might
+			// still have inputs of their own that we're meant
+			// to be clearing, so we need to be careful about
+			// when we take the shortcut.
+			!setChildInputs ||
+			allDescendantInputsAreNull( this )
+		)
+		{
+			return;
+		}
 	}
 
 	if( input && !acceptsInput( input.get() ) )

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -561,11 +561,6 @@ bool ValuePlug::acceptsInput( const Plug *input ) const
 
 void ValuePlug::setInput( PlugPtr input )
 {
-	if( input.get() == getInput<Plug>() )
-	{
-		return;
-	}
-
 	// set value back to what it was before
 	// we received a connection. we do that
 	// before calling Plug::setInput, so that
@@ -574,7 +569,7 @@ void ValuePlug::setInput( PlugPtr input )
 	// in the setValueInternal call, because we don't
 	// want to double up on the signals that the Plug
 	// is emitting for us in Plug::setInput().
-	if( !input )
+	if( getInput<Plug>() && !input )
 	{
 		setValueInternal( m_staticValue, false );
 	}

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -361,6 +361,19 @@ static void loadCoshaderArrayParameter( Gaffer::Plug *parametersPlug, const std:
 	}
 
 	ArrayPlugPtr plug = new ArrayPlug( name, Plug::In, new Plug( elementName ), minSize, maxSize, Plug::Default | Plug::Dynamic );
+
+	// Remember existing inputs, because they will be disconnected
+	// automatically when we replace the existing plug, and we need
+	// to reconnect them afterwards.
+	vector<PlugPtr> existingInputs;
+	if( existingPlug )
+	{
+		for( PlugIterator it( existingPlug.get() ); !it.done(); ++it )
+		{
+			existingInputs.push_back( (*it)->getInput<Plug>() );
+		}
+	}
+
 	parametersPlug->setChild( name, plug );
 
 	if( existingPlug )
@@ -372,11 +385,12 @@ static void loadCoshaderArrayParameter( Gaffer::Plug *parametersPlug, const std:
 		{
 			if( i < plug->children().size() )
 			{
-				plug->getChild<Plug>( i )->setInput( existingPlug->getChild<Plug>( i )->getInput<Plug>() );
+				plug->getChild<Plug>( i )->setInput( existingInputs[i] );
 			}
 			else
 			{
 				plug->addChild( existingChildren[i] );
+				plug->getChild<Plug>( i )->setInput( existingInputs[i] );
 			}
 		}
 	}


### PR DESCRIPTION
Same as #2324, but with an additional commit to fix the RenderManShader loading problem. This was caused by the RenderManShader relying on the bug fixed in fdab9bf.