### PR TITLE
Remove dependency on `IECore::Light`

### DIFF
--- a/python/GafferSceneTest/SceneTestCase.py
+++ b/python/GafferSceneTest/SceneTestCase.py
@@ -126,12 +126,7 @@ class SceneTestCase( GafferTest.TestCase ) :
 		def walkScene( scenePath ) :
 
 			object = scenePlug.object( scenePath, _copy = False )
-			if isinstance( object, IECore.Light ) :
-				self.assertTrue(
-					lightSet.value.match( scenePath ) & GafferScene.Filter.Result.ExactMatch,
-					scenePath + " in __lights set"
-				)
-			elif isinstance( object, IECore.Camera ) :
+			if isinstance( object, IECore.Camera ) :
 				self.assertTrue(
 					cameraSet.value.match( scenePath ) & GafferScene.Filter.Result.ExactMatch,
 					scenePath + " in __cameras set"
@@ -140,6 +135,13 @@ class SceneTestCase( GafferTest.TestCase ) :
 				self.assertTrue(
 					coordinateSystemSet.value.match( scenePath ) & GafferScene.Filter.Result.ExactMatch,
 					scenePath + " in __coordinateSystems set"
+				 )
+
+			attributes = scenePlug.attributes( scenePath, _copy = False )
+			if any( [ n == "light" or n.endswith( ":light" ) for n in attributes.keys() ] ) :
+				self.assertTrue(
+					lightSet.value.match( scenePath ) & GafferScene.Filter.Result.ExactMatch,
+					scenePath + " in __lights set"
 				 )
 
 			childNames = scenePlug.childNames( scenePath, _copy = False )

--- a/python/GafferSceneUI/ParametersUI.py
+++ b/python/GafferSceneUI/ParametersUI.py
@@ -44,7 +44,7 @@ Gaffer.Metadata.registerNode(
 
 	"description",
 	"""
-	Modifies the parameters of lights, cameras and procedurals.
+	Modifies the parameters of cameras and procedurals.
 	Existing parameters can be tweaked and new parameters be added.
 	""",
 

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -1746,8 +1746,6 @@ class __ObjectSection( LocationSection ) :
 			object = target.object()
 			if isinstance( object, ( IECore.Camera, IECore.ExternalProcedural ) ) :
 				return object.parameters()
-			elif isinstance( object, IECore.Light ) :
-				return object.parameters
 
 			return None
 

--- a/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
+++ b/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
@@ -71,7 +71,6 @@
 #include "renderer/api/utility.h"
 
 #include "IECore/Camera.h"
-#include "IECore/Light.h"
 #include "IECore/MessageHandler.h"
 #include "IECore/Shader.h"
 #include "IECore/SimpleTypedData.h"
@@ -1468,14 +1467,6 @@ string getLightModel( const ObjectVector* lightShader )
 		{
 			return shader->getName();
 		}
-		else if( const Light *light = runTimeCast<const Light>( it->get() ) )
-		{
-			string lightModel = light->getName();
-			if( boost::starts_with( lightModel, "as:" ) )
-			{
-				return string( lightModel, 3, string::npos );
-			}
-		}
 	}
 
 	return string();
@@ -1488,10 +1479,6 @@ const CompoundDataMap *getLightParameters( const ObjectVector* lightShader )
 		if( const Shader *shader = runTimeCast<const Shader>( it->get() ) )
 		{
 			return &shader->parameters();
-		}
-		else if( const Light *light = runTimeCast<const Light>( it->get() ) )
-		{
-			return &light->parameters();
 		}
 	}
 

--- a/src/GafferArnold/IECoreArnoldPreview/ShaderAlgo.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/ShaderAlgo.cpp
@@ -39,7 +39,6 @@
 #include "boost/lexical_cast.hpp"
 
 #include "IECore/Shader.h"
-#include "IECore/Light.h"
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"
 #include "IECore/VectorTypedData.h"
@@ -139,19 +138,6 @@ std::vector<AtNode *> convert( const IECore::ObjectVector *shaderNetwork, const 
 				nodeType = shader->getName().c_str();
 			}
 			parameters = &shader->parameters();
-		}
-		else if( const Light *light = runTimeCast<const Light>( it->get() ) )
-		{
-			/// \todo We don't really have much need for IECore::Lights any more.
-			/// Just use shaders everywhere instead.
-			nodeType = light->getName().c_str();
-			if( boost::starts_with( nodeType, "ai:" ) )
-			{
-				/// \todo This is working around the addition of prefixes in Gaffer.
-				/// We should find a way of not needing the prefixes.
-				nodeType += 3;
-			}
-			parameters = &light->parameters();
 		}
 
 		if( !nodeType )

--- a/src/GafferScene/Light.cpp
+++ b/src/GafferScene/Light.cpp
@@ -36,7 +36,6 @@
 
 #include "IECore/NullObject.h"
 #include "IECore/Shader.h"
-#include "IECore/Light.h"
 #include "IECore/MessageHandler.h"
 
 #include "Gaffer/StringPlug.h"
@@ -97,7 +96,6 @@ IECore::ConstObjectPtr Light::computeSource( const Context *context ) const
 	return IECore::NullObject::defaultNullObject();
 }
 
-
 void Light::hashAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	hashLight( context, h );
@@ -115,19 +113,6 @@ IECore::ConstCompoundObjectPtr Light::computeAttributes( const SceneNode::SceneP
 		if( const IECore::Shader *shader = IECore::runTimeCast<const IECore::Shader>( lightShaders->members().back().get() ) )
 		{
 			lightAttribute = shader->getType();
-		}
-		else if( const IECore::Light *light = IECore::runTimeCast<const IECore::Light>( lightShaders->members().back().get() ) )
-		{
-			/// \todo We are phasing out the use of IECore::Light and replacing
-			/// it with IECore::Shader everywhere. Make sure no derived classes
-			/// are using it and then remove this special case code.
-			IECore::msg( IECore::Msg::Warning, "Light::computeAttributes", "The use of IECore::Light is deprecated - please use IECore::Shader instead." );
-			const std::string &lightName = light->getName();
-			size_t colon = lightName.find( ":" );
-			if( colon != std::string::npos )
-			{
-				lightAttribute = lightName.substr( 0, colon ) + ":light";
-			}
 		}
 	}
 

--- a/src/GafferScene/Parameters.cpp
+++ b/src/GafferScene/Parameters.cpp
@@ -35,7 +35,6 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "IECore/Camera.h"
-#include "IECore/Light.h"
 #include "IECore/ExternalProcedural.h"
 
 #include "GafferScene/Parameters.h"
@@ -109,12 +108,6 @@ IECore::ConstObjectPtr Parameters::computeProcessedObject( const ScenePath &path
 		CameraPtr cameraCopy = camera->copy();
 		outputParameters = cameraCopy->parametersData();
 		outputObject = cameraCopy;
-	}
-	else if( const Light *light = runTimeCast<const Light>( inputObject.get() ) )
-	{
-		LightPtr lightCopy = light->copy();
-		outputParameters = lightCopy->parametersData().get();
-		outputObject = lightCopy;
 	}
 	else if( const ExternalProcedural *procedural = runTimeCast<const ExternalProcedural>( inputObject.get() ) )
 	{

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -44,7 +44,6 @@
 #include "IECore/PreWorldRenderable.h"
 #include "IECore/Camera.h"
 #include "IECore/WorldBlock.h"
-#include "IECore/Light.h"
 #include "IECore/Shader.h"
 #include "IECore/AttributeBlock.h"
 #include "IECore/Display.h"

--- a/src/GafferSceneUI/LightFilterVisualiser.cpp
+++ b/src/GafferSceneUI/LightFilterVisualiser.cpp
@@ -38,7 +38,6 @@
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/algorithm/string.hpp"
 
-#include "IECore/Light.h"
 #include "IECore/Shader.h"
 
 #include "IECoreGL/Group.h"

--- a/src/GafferSceneUI/LightVisualiser.cpp
+++ b/src/GafferSceneUI/LightVisualiser.cpp
@@ -37,7 +37,6 @@
 #include "boost/container/flat_map.hpp"
 #include "boost/algorithm/string/predicate.hpp"
 
-#include "IECore/Light.h"
 #include "IECore/Shader.h"
 
 #include "IECoreGL/CurvesPrimitive.h"
@@ -130,12 +129,6 @@ IECoreGL::ConstRenderablePtr AttributeVisualiserForLights::visualise( const IECo
 		if( const IECore::Shader *shader = IECore::runTimeCast<const IECore::Shader>( shaderVector->members().back().get() ) )
 		{
 			shaderName = shader->getName();
-		}
-		else if( const IECore::Light *light = IECore::runTimeCast<const IECore::Light>( shaderVector->members().back().get() ) )
-		{
-			/// \todo Remove once all Light node derived classes are
-			/// creating only shaders.
-			shaderName = light->getName();
 		}
 
 		if( shaderName.string().empty() )

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -37,7 +37,6 @@
 #include "IECore/MeshPrimitive.h"
 #include "IECore/Shader.h"
 #include "IECore/ObjectVector.h"
-#include "IECore/Light.h"
 
 #include "IECoreGL/CurvesPrimitive.h"
 #include "IECoreGL/SpherePrimitive.h"
@@ -79,13 +78,6 @@ const IECore::CompoundData *parametersAndMetadataTarget( const IECore::InternedS
 	{
 		metadataTarget = attributeName.string() + ":" + shader->getName();
 		return shader->parametersData();
-	}
-	else if( const IECore::Light *light = IECore::runTimeCast<const IECore::Light>( shaderVector->members().back().get() ) )
-	{
-		/// \todo Remove once all Light node derived classes are
-		/// creating only shaders.
-		metadataTarget = attributeName.string() + ":" + light->getName();
-		return light->parametersData().get();
 	}
 
 	return nullptr;


### PR DESCRIPTION
For a long time now we've used attributes containing `IECore::Shader` to represent lights, so that we can assign lights to geometry for area lights, and so we have a natural representation of lights with input shader networks. Before that, we used `IECore::Light`, which was a bit problematic in that it's built-in transform and name was at odds with Gaffer's scene graph, and there was no natural representation for arbitrary area lights. This PR removes code that supports the old use of `IECore::Light`, in preparation for removing it from Cortex 10.

@danieldresser, I hope I'm right in thinking that the IE lights are no longer relying on this?