### PR TITLE
GafferImage : Move default format plug creation to gui config

### DIFF
--- a/include/GafferImage/FormatPlug.h
+++ b/include/GafferImage/FormatPlug.h
@@ -120,10 +120,6 @@ class FormatPlug : public Gaffer::ValuePlug
 		/// to specify the default format for a particular script. When the
 		/// value of this plug is changed, the default format within
 		/// ScriptNode::context() will be updated automatically.
-		/// \todo This is currently called automatically in ImageNode::parentChanging(),
-		/// but it would be better to leave it to application config
-		/// files to call it, so each application can decide if it is
-		/// appropriate or not.
 		static FormatPlug *acquireDefaultFormatPlug( Gaffer::ScriptNode *scriptNode );
 		//@}
 

--- a/include/GafferImage/ImageNode.h
+++ b/include/GafferImage/ImageNode.h
@@ -124,9 +124,6 @@ class ImageNode : public Gaffer::ComputeNode
 		virtual IECore::ConstStringVectorDataPtr computeChannelNames( const Gaffer::Context *context, const ImagePlug *parent ) const;
 		virtual IECore::ConstFloatVectorDataPtr computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const;
 
-		/// Implemented to initialize the default format settings if they don't exist already.
-		void parentChanging( Gaffer::GraphComponent *newParent ) override;
-
 	private :
 
 		static size_t g_firstPlugIndex;

--- a/include/GafferImage/ImageStats.h
+++ b/include/GafferImage/ImageStats.h
@@ -90,9 +90,6 @@ class ImageStats : public Gaffer::ComputeNode
 
 		std::string channelName( int colorIndex ) const;
 
-		/// Implemented to initialize the default format settings if they don't exist already.
-		void parentChanging( Gaffer::GraphComponent *newParent ) override;
-
 		static size_t g_firstPlugIndex;
 
 };

--- a/python/GafferImageTest/FormatPlugTest.py
+++ b/python/GafferImageTest/FormatPlugTest.py
@@ -131,7 +131,7 @@ class FormatPlugTest( GafferImageTest.ImageTestCase ) :
 		self.assertFalse( "defaultFormat" in s )
 
 		s["c"] = GafferImage.Constant()
-		self.assertTrue( "defaultFormat" in s )
+		self.assertFalse( "defaultFormat" in s )
 
 		defaultFormatPlug = GafferImage.FormatPlug.acquireDefaultFormatPlug( s )
 		self.assertTrue( defaultFormatPlug.isSame( s["defaultFormat"] ) )
@@ -166,15 +166,6 @@ class FormatPlugTest( GafferImageTest.ImageTestCase ) :
 		s2.execute( s.serialise() )
 		with s2.context() :
 			self.assertEqual( s2["c"]["out"]["format"].getValue(), f )
-
-	def testDefaultFormatFromScriptWithBox( self ) :
-
-		s = Gaffer.ScriptNode()
-		self.assertFalse( "defaultFormat" in s )
-
-		s["b"] = Gaffer.Box()
-		s["b"]["c"] = GafferImage.Constant()
-		self.assertTrue( "defaultFormat" in s )
 
 	def testExpressions( self ) :
 

--- a/src/GafferImage/ImageNode.cpp
+++ b/src/GafferImage/ImageNode.cpp
@@ -176,24 +176,6 @@ void ImageNode::hashChannelData( const GafferImage::ImagePlug *parent, const Gaf
 	ComputeNode::hash( parent->channelDataPlug(), context, h );
 }
 
-void ImageNode::parentChanging( Gaffer::GraphComponent *newParent )
-{
-	ComputeNode::parentChanging( newParent );
-
-	// Set up the default format plug.
-	Node *parentNode = runTimeCast<Node>( newParent );
-	if( !parentNode )
-	{
-		return;
-	}
-
-	ScriptNode *scriptNode = parentNode->scriptNode();
-	if( scriptNode )
-	{
-		FormatPlug::acquireDefaultFormatPlug( scriptNode );
-	}
-}
-
 void ImageNode::compute( ValuePlug *output, const Context *context ) const
 {
 	ImagePlug *imagePlug = output->parent<ImagePlug>();

--- a/src/GafferImage/ImageStats.cpp
+++ b/src/GafferImage/ImageStats.cpp
@@ -165,24 +165,6 @@ const Color4fPlug *ImageStats::maxPlug() const
 	return getChild<Color4fPlug>( g_firstPlugIndex + 5 );
 }
 
-void ImageStats::parentChanging( Gaffer::GraphComponent *newParent )
-{
-	ComputeNode::parentChanging( newParent );
-
-	// Set up the default format plug.
-	Node *parentNode = IECore::runTimeCast<Node>( newParent );
-	if( !parentNode )
-	{
-		return;
-	}
-
-	ScriptNode *scriptNode = parentNode->scriptNode();
-	if( scriptNode )
-	{
-		FormatPlug::acquireDefaultFormatPlug( scriptNode );
-	}
-}
-
 void ImageStats::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	ComputeNode::affects( input, outputs );

--- a/startup/gui/project.py
+++ b/startup/gui/project.py
@@ -40,6 +40,7 @@ import functools
 import IECore
 
 import Gaffer
+import GafferImage
 import GafferUI
 import GafferDispatch
 
@@ -56,6 +57,8 @@ def __scriptAdded( container, script ) :
 	if "projectRootDirectory" not in variables :
 		projectRoot = variables.addMember( "project:rootDirectory", IECore.StringData( "$HOME/gaffer/projects/${project:name}" ), "projectRootDirectory" )
 		projectRoot["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+
+	GafferImage.FormatPlug.acquireDefaultFormatPlug( script )
 
 application.root()["scripts"].childAddedSignal().connect( __scriptAdded, scoped = False )
 


### PR DESCRIPTION
This means a few things :

- Applications are free to decide whether or not a default format plug makes sense for them.
- Scripts created by the GUI application will always have a default format plug, rather than waiting for the first image node to be created before creating one.
- The bug whereby a non-image node which embeds an image node doesn't trigger creation of the default format plug is now irrelevant/fixed.