### PR TITLE
Expression copy/paste bug fix

### DIFF
--- a/include/Gaffer/Expression.h
+++ b/include/Gaffer/Expression.h
@@ -216,6 +216,8 @@ class Expression : public ComputeNode
 
 		std::string transcribe( const std::string &expression, bool toInternalForm ) const;
 
+		void plugSet( const Plug *plug );
+
 		EnginePtr m_engine;
 		std::vector<IECore::InternedString> m_contextNames;
 

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -188,7 +188,7 @@ class ScriptNode : public Node
 		/// distinguishing between them.
 		bool isExecuting() const;
 		/// This signal is emitted following successful execution of a script.
-		typedef boost::signal<void ( ScriptNodePtr, const std::string )> ScriptExecutedSignal;
+		typedef boost::signal<void ( ScriptNode *, const std::string )> ScriptExecutedSignal;
 		ScriptExecutedSignal &scriptExecutedSignal();
 		//@}
 

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1290,5 +1290,44 @@ class ExpressionTest( GafferTest.TestCase ) :
 		self.assertEqual( s["e"].getExpression(), ( e, "python" ) )
 		self.assertEqual( s["n"]["user"]["p"]["m"]["value"].getValue(), 10 )
 
+	def testCopyPaste( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = GafferTest.AddNode()
+
+		expression = """parent["n"]["op2"] = parent["n"]["op1"] * 2 + context.getFrame()"""
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( expression )
+
+		s["n"]["op1"].setValue( 2 )
+		self.assertEqual( s["n"]["sum"].getValue(), 7 )
+		self.assertTrue( s["n"]["op1"].outputs()[0].node().isSame( s["e"] ) )
+		self.assertTrue( s["n"]["op2"].getInput().node().isSame( s["e"] ) )
+
+		s.execute( s.serialise( filter = Gaffer.StandardSet( [ s["n"], s["e"] ] ) ) )
+
+		self.assertEqual( s["n"]["sum"].getValue(), 7 )
+		self.assertTrue( s["n"]["op1"].outputs()[0].node().isSame( s["e"] ) )
+		self.assertTrue( s["n"]["op2"].getInput().node().isSame( s["e"] ) )
+
+		self.assertEqual( s["n1"]["sum"].getValue(), 7 )
+		self.assertTrue( s["n1"]["op1"].outputs()[0].node().isSame( s["e1"] ) )
+		self.assertTrue( s["n1"]["op2"].getInput().node().isSame( s["e1"] ) )
+
+		self.assertEqual( s["e"].getExpression(), ( expression, "python" ) )
+		self.assertEqual( s["e1"].getExpression(), ( expression.replace( '"n"', '"n1"' ), "python" ) )
+
+		s["n"]["op1"].setValue( 10 )
+		s["n1"]["op1"].setValue( 11 )
+
+		self.assertEqual( s["n"]["sum"].getValue(), 31 )
+		self.assertEqual( s["n1"]["sum"].getValue(), 34 )
+
+		with Gaffer.Context() as c :
+			c.setFrame( 2 )
+			self.assertEqual( s["n"]["sum"].getValue(), 32 )
+			self.assertEqual( s["n1"]["sum"].getValue(), 35 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -371,6 +371,24 @@ struct UndoAddedSlotCaller
 
 };
 
+struct ScriptExecutedSlotCaller
+{
+
+	boost::signals::detail::unusable operator()( boost::python::object slot, ScriptNode *script, const std::string &s )
+	{
+		try
+		{
+			slot( ScriptNodePtr( script ), s );
+		}
+		catch( const boost::python::error_already_set &e )
+		{
+			IECorePython::ExceptionAlgo::translatePythonException();
+		}
+		return boost::signals::detail::unusable();
+	}
+
+};
+
 } // namespace
 
 void GafferModule::bindScriptNode()
@@ -403,6 +421,6 @@ void GafferModule::bindScriptNode()
 	SignalClass<ScriptNode::ActionSignal, DefaultSignalCaller<ScriptNode::ActionSignal>, ActionSlotCaller>( "ActionSignal" );
 	SignalClass<ScriptNode::UndoAddedSignal, DefaultSignalCaller<ScriptNode::UndoAddedSignal>, UndoAddedSlotCaller>( "UndoAddedSignal" );
 
-	SignalClass<ScriptNode::ScriptExecutedSignal>( "ScriptExecutedSignal" );
+	SignalClass<ScriptNode::ScriptExecutedSignal, DefaultSignalCaller<ScriptNode::ScriptExecutedSignal>, ScriptExecutedSlotCaller>( "ScriptExecutedSignal" );
 
 }


### PR DESCRIPTION
This fixes a nasty bug which prevents expressions being copy/pasted back into the script they came from.

I've tried two approaches to fixing it (ff607f6 and 0c8ea9c), both of which work and pass the test suite. Both have the downside that we now serialise the internal values from the __engine and __expression plugs whereas before we serialised a nice `setExpression()` call that was more useful for folks using the file format to learn scripting. I don't see any way around this - the bug is fundamentally about the fact that we can't use `setExpression()` because we don't know how the plugs might be renamed to avoid conflicts when pasting. Given this, I think my preference is the latter approach because it is slightly simpler, and at least allows us to warn people if they appear to be trying to manipulate the internal __expression plug directly rather than calling `setExpression()`.

I've also included a fix for the ScriptNode::ScriptExecutedSignal signature because it tripped me up while writing this. This could be considered separately if you prefer.

