### PR TITLE
CatalogueUI : fix crashes that occur when removing multiple images quickly

### DIFF
--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -366,6 +366,13 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 	def __removeClicked( self, *unused ) :
 
 		index = self.__indexFromSelection()
+
+		# If the user repeatedly clicks the delete button, we might end up in a
+		# state, where selection hasn't been restored yet. In that case we
+		# can't delete anything and will ignore the request.
+		if index is None :
+			return
+
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.__images().removeChild( self.__images()[index] )
 			self.getPlug().setValue( max( 0, index - 1 ) )


### PR DESCRIPTION
Hey John,

when playing with the Catalogue today, I noticed that we get crashes when repeatedly hitting the 'x' button in order to delete images. Doing it slowly is fine, doing it fast is no good. I had a look at what's happening and my guess is that it takes a while to assign the new selection in the list of images and if we trigger removal while the selection is invalid, we get `None` as selection index which in turn causes `GraphComponentBinding::getItem( GraphComponent, const char* )` to receive a `nullptr` which it doesn't seem to be able to handle properly - or the resulting exception can't be handled reliably. Eventually the crash happens when trying to construct an `InternedString` from a `nullptr` in `IECore::InternedString::internedString(char const*)`. I'll attach the last few bits of a stack trace below.

I can have a look if I can fix the problem a little bit more globally. What I've done here is a fairly superficial protection that we probably should do anyway, but maybe it's worth checking the exception handling so that we don't run into this again in the future.

Thanks :)

Matti.


```
*  0 0x00007f4489141847 [libai.so                               ] 
*  1 0x00007f450cb6a12f [libpthread.so.0                        ] _L_unlock_13 [funlockfile.c                                                    :                   ?]
>> 2 0x00007f45021305ec [libIECore-10.so                        ] IECore::Detail::Hash::operator() [InternedString.cpp                                               : 68 (discriminator 1]
*  3 0x00007f45021305ec [libIECore-10.so                        ] IECore::Detail::Hash::operator() [InternedString.cpp                                               : 68 (discriminator 1]
*  4 0x00007f4502130eb3 [libIECore-10.so                        ] boost::multi_index::detail::hashed_index_iterator<boost::multi_index::detail::hashed_index_node<boost::multi_index::detail::index_node_base<std::string, std::allocator<std::string> >, boost::multi_index::detail::hashed_unique_tag>, boost::multi_index::detail::bucket_array<std::allocator<std::string> >, boost::multi_index::detail::hashed_index_global_iterator_tag> boost::multi_index::detail::hashed_index<boost::multi_index::identity<std::string>, IECore::Detail::Hash, IECore::Detail::Equal, boost::multi_index::detail::nth_layer<1, std::string, boost::multi_index::indexed_by<boost::multi_index::hashed_unique<boost::multi_index::identity<std::string>, IECore::Detail::Hash, IECore::Detail::Equal, mpl_::na>, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, std::allocator<std::string> >, boost::mpl::vector0<mpl_::na>, boost::multi_index::detail::hashed_unique_tag>::find<char �{[��(char const* const&, IECore::Detail::Hash const&, IECore::Detail::Equal const&) [IECore::Detail::Hash, IECore::Detail::Equal> : 482]
*  5 0x00007f4502130971 [libIECore-10.so                        ] boost::multi_index::detail::hashed_index_iterator<boost::multi_index::detail::hashed_index_node<boost::multi_index::detail::index_node_base<std::string, std::allocator<std::string> >, boost::multi_index::detail::hashed_unique_tag>, boost::multi_index::detail::bucket_array<std::allocator<std::string> >, boost::multi_index::detail::hashed_index_global_iterator_tag> boost::multi_index::detail::hashed_index<boost::multi_index::identity<std::string>, IECore::Detail::Hash, IECore::Detail::Equal, boost::multi_index::detail::nth_layer<1, std::string, boost::multi_index::indexed_by<boost::multi_index::hashed_unique<boost::multi_index::identity<std::string>, IECore::Detail::Hash, IECore::Detail::Equal, mpl_::na>, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, std::allocator<std::string> >, boost::mpl::vector0<mpl_::na>, boost::multi_index::detail::hashed_unique_tag>::find<char ��[��(char const* const&) [char const* const& : 471]
*  6 0x00007f450212fff4 [libIECore-10.so                        ] IECore::InternedString::internedString(char const*)  

```