### PR TITLE
GraphComponent binding : Fix crashes caused by `None` arguments

### DIFF
--- a/python/GafferTest/GraphComponentTest.py
+++ b/python/GafferTest/GraphComponentTest.py
@@ -760,5 +760,15 @@ class GraphComponentTest( GafferTest.TestCase ) :
 		self.assertRaisesRegexp( KeyError, "'a' is not a child of 'GraphComponent'", g.__getitem__, "a" )
 		self.assertRaisesRegexp( KeyError, "'a' is not a child of 'GraphComponent'", g.__delitem__, "a" )
 
+	def testNoneIsNotAString( self ) :
+
+		g = Gaffer.GraphComponent()
+		self.assertRaises( TypeError, g.getChild, None )
+		self.assertRaises( TypeError, g.__getitem__, None )
+		self.assertRaises( TypeError, g.__delitem__, None )
+		self.assertRaises( TypeError, g.descendant, None )
+		self.assertRaises( TypeError, g.__contains__, None )
+		self.assertRaises( TypeError, g.setName, None )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferModule/GraphComponentBinding.cpp
+++ b/src/GafferModule/GraphComponentBinding.cpp
@@ -55,7 +55,7 @@ using namespace Gaffer;
 namespace
 {
 
-const char *setName( GraphComponent &c, const char *name )
+const char *setName( GraphComponent &c, const IECore::InternedString &name )
 {
 	return c.setName( name ).c_str();
 }
@@ -130,26 +130,26 @@ void removeChild( GraphComponent &g, GraphComponentPtr c )
 	g.removeChild( c );
 }
 
-GraphComponentPtr getChild( GraphComponent &g, const char *n )
+GraphComponentPtr getChild( GraphComponent &g, const IECore::InternedString &n )
 {
 	return g.getChild( n );
 }
 
-GraphComponentPtr descendant( GraphComponent &g, const char *n )
+GraphComponentPtr descendant( GraphComponent &g, const std::string &n )
 {
 	return g.descendant( n );
 }
 
-void throwKeyError( const GraphComponent &g, const char *n )
+void throwKeyError( const GraphComponent &g, const IECore::InternedString &n )
 {
 	const std::string error = boost::str(
-		boost::format( "'%s' is not a child of '%s'" ) % n % g.getName()
+		boost::format( "'%s' is not a child of '%s'" ) % n.string() % g.getName()
 	);
 	PyErr_SetString( PyExc_KeyError, error.c_str() );
 	throw_error_already_set();
 }
 
-GraphComponentPtr getItem( GraphComponent &g, const char *n )
+GraphComponentPtr getItem( GraphComponent &g, const IECore::InternedString &n )
 {
 	GraphComponentPtr c = g.getChild( n );
 	if( c )
@@ -179,7 +179,7 @@ GraphComponentPtr getItem( GraphComponent &g, long index )
 	return g.getChild( index );
 }
 
-void delItem( GraphComponent &g, const char *n )
+void delItem( GraphComponent &g, const IECore::InternedString &n )
 {
 	{
 		IECorePython::ScopedGILRelease gilRelease;
@@ -203,7 +203,7 @@ bool nonZero( GraphComponent &g )
 	return true;
 }
 
-bool contains( GraphComponent &g, const char *n )
+bool contains( GraphComponent &g, const IECore::InternedString &n )
 {
 	return g.getChild( n );
 }
@@ -281,7 +281,7 @@ void GafferModule::bindGraphComponent()
 		.def( "setChild", &setChild )
 		.def( "getChild", &getChild )
 		.def( "descendant", &descendant )
-		.def( "__getitem__", (GraphComponentPtr (*)( GraphComponent &, const char * ))&getItem )
+		.def( "__getitem__", (GraphComponentPtr (*)( GraphComponent &, const IECore::InternedString & ))&getItem )
 		.def( "__getitem__", (GraphComponentPtr (*)( GraphComponent &, long ))&getItem )
 		.def( "__setitem__", &setChild )
 		.def( "__delitem__", delItem )


### PR DESCRIPTION
In all these functions we want either a string or InternedString argument, but had bound them with wrappers taking `const char *`. But boost python will happily convert `None` to null and pass it to such methods, which resulted in crashes when subsequently passing null to the string or InternedString constructors.

This is a follow-up to #2337.