### PR TITLE
ObjectReaderUI : Remove bogus widget registration

### DIFF
--- a/python/GafferCortexUI/ObjectReaderUI.py
+++ b/python/GafferCortexUI/ObjectReaderUI.py
@@ -87,13 +87,3 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
-
-##########################################################################
-# PlugValueWidgets
-##########################################################################
-
-def __createParameterWidget( plug ) :
-
-	return GafferCortexUI.CompoundParameterValueWidget( plug.node().parameterHandler(), collapsible=False )
-
-GafferUI.PlugValueWidget.registerCreator( GafferCortex.ObjectReader, "parameters", __createParameterWidget )


### PR DESCRIPTION
The parameters plug doesn't even exist any more.