### PR TITLE
Add "how to run" example for linux and link to the installation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,25 @@ More information can be found on the [project homepage](http://gafferhq.org).
 
 Developer notes are available on the [project wiki](https://github.com/GafferHQ/gaffer/wiki).
 
-Downloading
+Easy way - Downloading
 ===========
 
-Compiled binary releases are available for download from the [releases page](https://github.com/GafferHQ/gaffer/releases).
+If you want to give Gaffer a try, without going trough the complex building process, just download the latest compiled binary release from the [releases page](https://github.com/GafferHQ/gaffer/releases).
 
-Building
+To run it, extract the archive and run the `gaffer` executable you will find in the `bin` directory.
+
+For example, on linux (after you download it):
+
+```
+cd ~/apps
+tar -xzf ~/Downloads/gaffer-*-linux.tar.gz
+cd gaffer-*-linux
+./bin/gaffer
+```
+
+More in detail information can be found on the [installation page](http://gafferhq.org/documentation/Installation)
+
+Hard way - Building
 ========
 
 [![Build Status](https://travis-ci.org/GafferHQ/gaffer.svg?branch=master)](https://travis-ci.org/GafferHQ/gaffer)


### PR DESCRIPTION
Running the downloaded binary version is a very straightforward process, for an experimented user. Others can need a minute before they will be sure what is the sequence of commands to follow (for example, is it gaffer or gaffer.py the starting point?)

Also added the link to the installation documentation, where useful information can be found. Like which render engine is available and how I can connect my preferred one.