### PR TITLE
NodeGraph : Avoid confusing box navigation

### DIFF
--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -296,16 +296,13 @@ class NodeGraph( GafferUI.EditorWidget ) :
 			return True
 		elif event.key == "Down" :
 			selection = self.scriptNode().selection()
-			if selection.size() == 1 and self.graphGadget().getRoot().isAncestorOf( selection[0] ) :
-				newRoot = selection[0]
-				while newRoot.parent() != self.graphGadget().getRoot() :
-					newRoot = newRoot.parent()
-				needsModifiers = not Gaffer.Metadata.value( newRoot, "nodeGraph:childrenViewable" )
+			if selection.size() == 1 and selection[0].parent() == self.graphGadget().getRoot() :
+				needsModifiers = not Gaffer.Metadata.value( selection[0], "nodeGraph:childrenViewable" )
 				if (
 					( needsModifiers and event.modifiers == event.modifiers.Shift | event.modifiers.Control ) or
 					( not needsModifiers and event.modifiers == event.modifiers.None )
 				) :
-					self.graphGadget().setRoot( newRoot )
+					self.graphGadget().setRoot( selection[0] )
 					return True
 		elif event.key == "Up" :
 			root = self.graphGadget().getRoot()

--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -296,13 +296,16 @@ class NodeGraph( GafferUI.EditorWidget ) :
 			return True
 		elif event.key == "Down" :
 			selection = self.scriptNode().selection()
-			if selection.size() :
-				needsModifiers = not Gaffer.Metadata.value( selection[0], "nodeGraph:childrenViewable" )
+			if selection.size() == 1 and self.graphGadget().getRoot().isAncestorOf( selection[0] ) :
+				newRoot = selection[0]
+				while newRoot.parent() != self.graphGadget().getRoot() :
+					newRoot = newRoot.parent()
+				needsModifiers = not Gaffer.Metadata.value( newRoot, "nodeGraph:childrenViewable" )
 				if (
 					( needsModifiers and event.modifiers == event.modifiers.Shift | event.modifiers.Control ) or
 					( not needsModifiers and event.modifiers == event.modifiers.None )
 				) :
-					self.graphGadget().setRoot( selection[0] )
+					self.graphGadget().setRoot( newRoot )
 					return True
 		elif event.key == "Up" :
 			root = self.graphGadget().getRoot()


### PR DESCRIPTION
Previously we would happily dive down into any box, even if it was totally unrelated to the current root, or several nesting levels deep. We now only jump if the new root is a descendant of the current root, and if it is nested several levels deep we step towards it one level at a time.

Fixes #2343