### PR TITLE
UIEditor : Allow creation of custom buttons

### DIFF
--- a/python/GafferUI/ButtonPlugValueWidget.py
+++ b/python/GafferUI/ButtonPlugValueWidget.py
@@ -1,0 +1,113 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+
+import Gaffer
+import GafferUI
+
+## Supported metadata :
+#
+# buttonPlugValueWidget:clicked
+class ButtonPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug, **kw ) :
+
+		self.__button = GafferUI.Button()
+
+		GafferUI.PlugValueWidget.__init__( self, self.__button, plug, **kw )
+
+		self.__clickedConnection = self.__button.clickedSignal().connect( Gaffer.WeakMethod( self.__clicked ) )
+		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
+
+		self.setPlug( plug )
+
+	def hasLabel( self ) :
+
+		return True
+
+	def setPlug( self, plug ) :
+
+		GafferUI.PlugValueWidget.setPlug( self, plug )
+
+		self.__nameChangedConnection = None
+		if plug is not None :
+			self.__nameChangedConnection = plug.nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ) )
+
+		self.__updateLabel()
+
+	def _updateFromPlug( self ) :
+
+		self.__button.setEnabled( self._editable() )
+
+	def __nameChanged( self, plug ) :
+
+		self.__updateLabel()
+
+	def __updateLabel( self ) :
+
+		label = ""
+		if self.getPlug() :
+			label = self.getPlug().getName()
+			label = Gaffer.Metadata.value( self.getPlug(), "label" ) or label
+
+		self.__button.setText( label )
+
+	def __clicked( self, widget ) :
+
+		code = Gaffer.Metadata.value( self.getPlug(), "buttonPlugValueWidget:clicked" )
+		if not code :
+			return False
+
+		executionDict = {
+			"IECore" : IECore,
+			"Gaffer" : Gaffer,
+			"plug" : self.getPlug(),
+			"button" : self,
+		}
+
+		with GafferUI.ErrorDialogue.ErrorHandler( title = "Button Error", parentWindow = self.ancestor( GafferUI.Window ) ) :
+			with Gaffer.UndoContext( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+				with self.getContext() :
+					exec( code, executionDict, executionDict )
+
+	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
+
+		if self.getPlug() is None :
+			return
+
+		if key=="label" and Gaffer.MetadataAlgo.affectedByChange( self.getPlug(), nodeTypeId, plugPath, plug ) :
+			self.__updateLabel()

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -304,10 +304,13 @@ class PlugLayout( GafferUI.Widget ) :
 				section = section.subsection( sectionName )
 
 			if len( section.widgets ) and self.__itemMetadataValue( item, "accessory" ) :
-				row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
-				row.append( section.widgets[-1] )
-				row.append( widget )
-				section.widgets[-1] = row
+				if isinstance( section.widgets[-1], _AccessoryRow ) :
+					section.widgets[-1].append( widget )
+				else :
+					row = _AccessoryRow()
+					row.append( section.widgets[-1] )
+					row.append( widget )
+					section.widgets[-1] = row
 			else :
 				section.widgets.append( widget )
 
@@ -514,6 +517,13 @@ class PlugLayout( GafferUI.Widget ) :
 		self.__activationsDirty = True
 		self.__summariesDirty = True
 		self.__updateLazily()
+
+
+class _AccessoryRow( GafferUI.ListContainer ) :
+
+	def __init__( self, **kw ) :
+
+		GafferUI.ListContainer.__init__( self, GafferUI.ListContainer.Orientation.Horizontal, spacing = 4, **kw )
 
 # The _Section class provides a simple abstract representation of a hierarchical
 # layout. Each section contains a list of widgets to be displayed in that section,

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -470,9 +470,9 @@ class _StringMetadataWidget( _MetadataWidget ) :
 
 class _MultiLineStringMetadataWidget( _MetadataWidget ) :
 
-	def __init__( self, key, target = None, **kw ) :
+	def __init__( self, key, target = None, role = GafferUI.MultiLineTextWidget.Role.Text, **kw ) :
 
-		self.__textWidget = GafferUI.MultiLineTextWidget()
+		self.__textWidget = GafferUI.MultiLineTextWidget( role = role )
 		_MetadataWidget.__init__( self, self.__textWidget, key, target, **kw )
 
 		self.__editingFinishedConnection = self.__textWidget.editingFinishedSignal().connect(
@@ -1524,11 +1524,6 @@ class _PlugEditor( GafferUI.Widget ) :
 
 				with GafferUI.ListContainer( spacing = 4 ) :
 
-					with _Row() :
-
-						_Label( "Divider" )
-						self.__metadataWidgets["divider"] = _BoolMetadataWidget( key = "divider" )
-
 					for m in self.__metadataDefinitions :
 
 						with _Row() :
@@ -1632,7 +1627,7 @@ class _PlugEditor( GafferUI.Widget ) :
 
 		for m in self.__metadataDefinitions :
 			widget = self.__metadataWidgets[m.key]
-			widget.parent().setEnabled( Gaffer.StringAlgo.match( widgetType, m.plugValueWidgetType ) )
+			widget.parent().setVisible( Gaffer.StringAlgo.match( widgetType, m.plugValueWidgetType ) )
 
 		self.__metadataWidgets["connectionGadget:color"].parent().setEnabled(
 			self.getPlug() is not None and self.getPlug().direction() == Gaffer.Plug.Direction.In
@@ -1712,6 +1707,7 @@ class _PlugEditor( GafferUI.Widget ) :
 		__WidgetDefinition( "File Chooser", Gaffer.StringVectorDataPlug, "GafferUI.FileSystemPathVectorDataPlugValueWidget" ),
 		__WidgetDefinition( "Presets Menu", Gaffer.ValuePlug, "GafferUI.PresetsPlugValueWidget" ),
 		__WidgetDefinition( "Connection", Gaffer.Plug, "GafferUI.ConnectionPlugValueWidget" ),
+		__WidgetDefinition( "Button", Gaffer.Plug, "GafferUI.ButtonPlugValueWidget" ),
 		__WidgetDefinition( "None", Gaffer.Plug, "" ),
 	)
 
@@ -1725,6 +1721,15 @@ class _PlugEditor( GafferUI.Widget ) :
 		# Note that includeSequenceFrameRange is primarily used by GafferCortex.
 		# Think twice before using it elsewhere	as it may not exist in the future.
 		__MetadataDefinition( "fileSystemPath:includeSequenceFrameRange", "Sequences include frame range", _BoolMetadataWidget, "GafferUI.FileSystemPath*PlugValueWidget" ),
+		__MetadataDefinition(
+			"buttonPlugValueWidget:clicked",
+			"Button Click Code",
+			lambda key : _MultiLineStringMetadataWidget( key, role = GafferUI.MultiLineTextWidget.Role.Code ),
+			"GafferUI.ButtonPlugValueWidget"
+		),
+		__MetadataDefinition( "layout:accessory", "Inline", _BoolMetadataWidget,  "GafferUI.ButtonPlugValueWidget" ),
+		__MetadataDefinition( "divider", "Divider", _BoolMetadataWidget,  "*" ),
+
 	)
 
 	__GadgetDefinition = collections.namedtuple( "GadgetDefinition", ( "label", "plugType", "metadata" ) )

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -275,6 +275,7 @@ from SplinePlugValueWidget import SplinePlugValueWidget
 from RampPlugValueWidget import RampPlugValueWidget
 from NodeFinderDialogue import NodeFinderDialogue
 from ConnectionPlugValueWidget import ConnectionPlugValueWidget
+from ButtonPlugValueWidget import ButtonPlugValueWidget
 import ViewUI
 from Playback import Playback
 from UIEditor import UIEditor


### PR DESCRIPTION
The request for this has been around for a ages, so I thought it was about time we provided it. This allows the user to present any plug as a button in the NodeEditor, and to attach arbitrary python code to be executed when the button is clicked. The code has access to the plug itself (and therefore the containing node/script) and also the button itself (and therefore the entire containing UI). Below I've just used it to mock up a little Box with some custom buttons for loading and saving its own contents...

<img width="1219" alt="buttons" src="https://user-images.githubusercontent.com/1133871/32798868-e94acfcc-c96d-11e7-805a-200b527934af.png">
