### PR TITLE
Layered Gadget drawing followup

### DIFF
--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -290,6 +290,10 @@ class Gadget : public Gaffer::GraphComponent
 		/// for the specified layer. The default implementation just renders all
 		/// the visible child Gadgets.
 		virtual void doRenderLayer( Layer layer, const Style *style ) const;
+		/// May return false to indicate that neither this gadget nor any
+		/// of its children will render anything for the specified layer.
+		/// The default implementation returns true.
+		virtual bool hasLayer( Layer layer ) const;
 
 	private :
 

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -88,7 +88,6 @@ class Gadget : public Gaffer::GraphComponent
 			Main = 0,
 			MidFront = 1,
 			Front = 2,
-			Last = 3
 		};
 
 		/// Returns the Gadget with the specified name, where name has been retrieved
@@ -353,8 +352,6 @@ class Gadget : public Gaffer::GraphComponent
 
 typedef Gaffer::FilteredChildIterator<Gaffer::TypePredicate<Gadget> > GadgetIterator;
 typedef Gaffer::FilteredRecursiveChildIterator<Gaffer::TypePredicate<Gadget> > RecursiveGadgetIterator;
-
-inline Gadget::Layer &operator++( Gadget::Layer &x ) { return x = (Gadget::Layer)(((int)(x) + 1)); };
 
 } // namespace GafferUI
 

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -287,8 +287,8 @@ class Gadget : public Gaffer::GraphComponent
 		void requestRender();
 
 		/// Should be implemented by subclasses to draw themselves as appropriate
-		/// for the specified layer. The default implementation just renders all
-		/// the visible child Gadgets.
+		/// for the specified layer. Child gadgets will be drawn automatically
+		/// _after_ the parent gadget has been drawn.
 		virtual void doRenderLayer( Layer layer, const Style *style ) const;
 		/// May return false to indicate that neither this gadget nor any
 		/// of its children will render anything for the specified layer.

--- a/include/GafferUI/NoduleLayout.h
+++ b/include/GafferUI/NoduleLayout.h
@@ -45,6 +45,7 @@
 #include "Gaffer/StringAlgo.h"
 
 #include "GafferUI/Gadget.h"
+#include "GafferUI/GraphGadget.h"
 
 namespace Gaffer
 {
@@ -96,6 +97,11 @@ class NoduleLayout : public Gadget
 		/// Registers a custom gadget type that can be added to the layout using
 		/// "noduleLayout:customGadget:*"" metadata entries.
 		static void registerCustomGadget( const std::string &gadgetType, CustomGadgetCreator creator );
+
+
+	protected :
+
+		bool hasLayer( Layer layer ) const override;
 
 	private :
 

--- a/include/GafferUI/StandardConnectionGadget.h
+++ b/include/GafferUI/StandardConnectionGadget.h
@@ -70,6 +70,7 @@ class StandardConnectionGadget : public ConnectionGadget
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		bool hasLayer( Layer layer ) const override;
 
 	private :
 

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -42,6 +42,7 @@
 
 #include "GafferUI/NodeGadget.h"
 #include "GafferUI/LinearContainer.h"
+#include "GafferUI/GraphGadget.h"
 
 namespace GafferUI
 {
@@ -105,6 +106,7 @@ class StandardNodeGadget : public NodeGadget
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		bool hasLayer( Layer layer ) const override;
 
 		const Imath::Color3f *userColor() const;
 

--- a/include/GafferUI/StandardNodule.h
+++ b/include/GafferUI/StandardNodule.h
@@ -41,6 +41,7 @@
 #include "Gaffer/StringAlgo.h"
 
 #include "GafferUI/Nodule.h"
+#include "GafferUI/GraphGadget.h"
 
 namespace Gaffer
 {
@@ -69,7 +70,9 @@ class StandardNodule : public Nodule
 
 	protected :
 
+		bool hasLayer( Layer layer ) const override;
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+
 		void renderLabel( const Style *style ) const;
 
 		void enter( GadgetPtr gadget, const ButtonEvent &event );

--- a/include/GafferUI/TextGadget.h
+++ b/include/GafferUI/TextGadget.h
@@ -63,6 +63,7 @@ class TextGadget : public Gadget
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		bool hasLayer( Layer layer ) const override { return layer == Layer::Main; };
 
 	private :
 

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -177,14 +177,12 @@ class ViewportGadget : public Gadget
 
 		};
 
+		void render() const;
+
 		/// A signal emitted just prior to rendering the viewport each time. This
 		/// provides an opportunity for clients to make last minute adjustments to
 		/// the viewport or its children.
 		UnarySignal &preRenderSignal();
-
-	protected :
-
-		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 	private :
 

--- a/include/GafferUIBindings/GadgetBinding.h
+++ b/include/GafferUIBindings/GadgetBinding.h
@@ -119,7 +119,7 @@ class GadgetWrapper : public GafferBindings::GraphComponentWrapper<WrappedType>
 				boost::python::object f = this->methodOverride( "doRenderLayer" );
 				if( f )
 				{
-					f( layer, style );
+					f( layer, GafferUI::StylePtr( const_cast<GafferUI::Style *>( style ) ) );
 					return;
 				}
 			}

--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -125,7 +125,6 @@ class GadgetWidget( GafferUI.GLWidget ) :
 
 	def _draw( self ) :
 
-		self.__viewportGadget.preRenderSignal()( self.__viewportGadget )
 		self.__viewportGadget.render()
 
 	def __enter( self, widget ) :

--- a/python/GafferUITest/GadgetTest.py
+++ b/python/GafferUITest/GadgetTest.py
@@ -82,9 +82,15 @@ class GadgetTest( GafferUITest.TestCase ) :
 
 				GafferUI.Gadget.__init__( self )
 
+				self.layersRendered = set()
+
 			def bound( self ) :
 
 				return IECore.Box3f( IECore.V3f( -20, 10, 2 ), IECore.V3f( 10, 15, 5 ) )
+
+			def doRenderLayer( self, layer, style ) :
+
+				self.layersRendered.add( layer )
 
 		mg = MyGadget()
 
@@ -97,6 +103,14 @@ class GadgetTest( GafferUITest.TestCase ) :
 		c.addChild( mg )
 
 		self.assertEqual( c.bound().size(), mg.bound().size() )
+
+		with GafferUI.Window() as w :
+			GafferUI.GadgetWidget( c )
+
+		w.setVisible( True )
+		self.waitForIdle( 1000 )
+
+		self.assertEqual( mg.layersRendered, set( GafferUI.Gadget.Layer.values.values() ) )
 
 	def testStyle( self ) :
 

--- a/src/GafferUI/Frame.cpp
+++ b/src/GafferUI/Frame.cpp
@@ -43,8 +43,6 @@
 #include "IECore/MeshPrimitive.h"
 #include "IECore/SimpleTypedData.h"
 
-#include "math.h"
-
 using namespace GafferUI;
 using namespace IECore;
 using namespace Imath;
@@ -75,14 +73,12 @@ Imath::Box3f Frame::bound() const
 
 void Frame::doRenderLayer( Layer layer, const Style *style ) const
 {
-	if( layer != GraphLayer::Nodes )
+	IndividualContainer::doRenderLayer( layer, style );
+	if( layer != Layer::Main )
 	{
 		return;
 	}
 
 	Imath::Box3f b = IndividualContainer::bound();
-
 	style->renderFrame( Box2f( V2f( b.min.x, b.min.y ), V2f( b.max.x, b.max.y ) ), m_border );
-
-	IndividualContainer::doRenderLayer( layer, style );
 }

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -256,9 +256,9 @@ Imath::M44f Gadget::fullTransform( const Gadget *ancestor ) const
 
 void Gadget::render() const
 {
-	for( Layer layer = Layer::Back; layer < Layer::Last; ++layer )
+	for( int layer = (int)Layer::Back; layer <= (int)Layer::Front; ++layer )
 	{
-		renderLayer( layer, /* currentStyle = */ nullptr );
+		renderLayer( (Layer)layer, /* currentStyle = */ nullptr );
 	}
 }
 

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -292,6 +292,20 @@ void Gadget::renderLayer( Layer layer, const Style *currentStyle ) const
 
 		doRenderLayer( layer, currentStyle );
 
+		for( ChildContainer::const_iterator it=children().begin(); it!=children().end(); it++ )
+		{
+			// Cast is safe because of the guarantees acceptsChild() gives us
+			const Gadget *c = static_cast<const Gadget *>( it->get() );
+			if( !c->getVisible() )
+			{
+				continue;
+			}
+			if( c->hasLayer( layer ) )
+			{
+				c->renderLayer( layer, currentStyle );
+			}
+		}
+
 	if( haveTransform )
 	{
 		glPopMatrix();
@@ -310,19 +324,6 @@ void Gadget::requestRender()
 
 void Gadget::doRenderLayer( Layer layer, const Style *style ) const
 {
-	for( ChildContainer::const_iterator it=children().begin(); it!=children().end(); it++ )
-	{
-		// cast is safe because of the guarantees acceptsChild() gives us
-		const Gadget *c = static_cast<const Gadget *>( it->get() );
-		if( !c->getVisible() )
-		{
-			continue;
-		}
-		if( c->hasLayer( layer ) )
-		{
-			c->renderLayer( layer, style );
-		}
-	}
 }
 
 bool Gadget::hasLayer( Layer layer ) const

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -312,8 +312,16 @@ void Gadget::doRenderLayer( Layer layer, const Style *style ) const
 		{
 			continue;
 		}
-		c->renderLayer( layer, style );
+		if( c->hasLayer( layer ) )
+		{
+			c->renderLayer( layer, style );
+		}
 	}
+}
+
+bool Gadget::hasLayer( Layer layer ) const
+{
+	return true;
 }
 
 Imath::Box3f Gadget::bound() const

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -264,9 +264,12 @@ void Gadget::render() const
 
 void Gadget::renderLayer( Layer layer, const Style *currentStyle ) const
 {
-	glPushMatrix();
-
+	const bool haveTransform = m_transform != M44f();
+	if( haveTransform )
+	{
+		glPushMatrix();
 		glMultMatrixf( m_transform.getValue() );
+	}
 
 		if( !currentStyle )
 		{
@@ -289,7 +292,10 @@ void Gadget::renderLayer( Layer layer, const Style *currentStyle ) const
 
 		doRenderLayer( layer, currentStyle );
 
-	glPopMatrix();
+	if( haveTransform )
+	{
+		glPopMatrix();
+	}
 }
 
 void Gadget::requestRender()

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -630,6 +630,8 @@ ConnectionGadget *GraphGadget::reconnectionGadgetAt( const NodeGadget *gadget, c
 
 void GraphGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
+	Gadget::doRenderLayer( layer, style );
+
 	glDisable( GL_DEPTH_TEST );
 
 	switch( layer )
@@ -682,8 +684,6 @@ void GraphGadget::doRenderLayer( Layer layer, const Style *style ) const
 	default:
 		break;
 	}
-
-	Gadget::doRenderLayer( layer, style );
 
 }
 

--- a/src/GafferUI/ImageGadget.cpp
+++ b/src/GafferUI/ImageGadget.cpp
@@ -172,9 +172,10 @@ IECoreGL::TextureLoader *ImageGadget::textureLoader()
 
 void ImageGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
+	Gadget::doRenderLayer( layer, style );
 	if( layer != Layer::Main )
 	{
-		return Gadget::doRenderLayer( layer, style );
+		return;
 	}
 
 	if( const Texture *texture = loadTexture( m_imageOrTextureOrFileName ) )

--- a/src/GafferUI/NoduleLayout.cpp
+++ b/src/GafferUI/NoduleLayout.cpp
@@ -461,6 +461,11 @@ void NoduleLayout::registerCustomGadget( const std::string &gadgetType, CustomGa
 	customGadgetCreators()[gadgetType] = creator;
 }
 
+bool NoduleLayout::hasLayer( Layer layer ) const
+{
+	return layer != GraphLayer::Backdrops;
+}
+
 LinearContainer *NoduleLayout::noduleContainer()
 {
 	return getChild<LinearContainer>( 0 );

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -212,6 +212,11 @@ void StandardConnectionGadget::doRenderLayer( Layer layer, const Style *style ) 
 	}
 }
 
+bool StandardConnectionGadget::hasLayer( Layer layer ) const
+{
+	return layer == GraphLayer::Connections;
+}
+
 Imath::V3f StandardConnectionGadget::closestPoint( const Imath::V3f& p ) const
 {
 	const_cast<StandardConnectionGadget *>( this )->setPositionsFromNodules();

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -350,6 +350,11 @@ void StandardNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 	}
 }
 
+bool StandardNodeGadget::hasLayer( Layer layer ) const
+{
+	return layer != GraphLayer::Backdrops;
+}
+
 const Imath::Color3f *StandardNodeGadget::userColor() const
 {
 	return m_userColor.get_ptr();

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -314,39 +314,45 @@ Imath::Box3f StandardNodeGadget::bound() const
 
 void StandardNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
-	if( layer != GraphLayer::Nodes )
-	{
-		return NodeGadget::doRenderLayer( layer, style );
-	}
-
-	// decide what state we're rendering in
-	Style::State state = getHighlighted() ? Style::HighlightedState : Style::NormalState;
-
-	// draw our background frame
-	const Box3f b = bound();
-	float borderWidth = g_borderWidth;
-	if( m_oval )
-	{
-		const V3f s = b.size();
-		borderWidth = std::min( s.x, s.y ) / 2.0f;
-	}
-
-	style->renderNodeFrame(
-		Box2f( V2f( b.min.x, b.min.y ) + V2f( borderWidth ), V2f( b.max.x, b.max.y ) - V2f( borderWidth ) ),
-		borderWidth,
-		state,
-		m_userColor.get_ptr()
-	);
-
-	// draw our contents
 	NodeGadget::doRenderLayer( layer, style );
 
-	// draw a strikethrough if we're disabled
-	if( !m_nodeEnabled && !IECoreGL::Selector::currentSelector() )
+	switch( layer )
 	{
-		/// \todo Replace renderLine() with a specific method (renderNodeStrikeThrough?) on the Style class
-		/// so that styles can do customised drawing based on knowledge of what is being drawn.
-		style->renderLine( IECore::LineSegment3f( V3f( b.min.x, b.min.y, 0 ), V3f( b.max.x, b.max.y, 0 ) ) );
+		case GraphLayer::Nodes :
+		{
+			// decide what state we're rendering in
+			Style::State state = getHighlighted() ? Style::HighlightedState : Style::NormalState;
+
+			// draw our background frame
+			const Box3f b = bound();
+			float borderWidth = g_borderWidth;
+			if( m_oval )
+			{
+				const V3f s = b.size();
+				borderWidth = std::min( s.x, s.y ) / 2.0f;
+			}
+
+			style->renderNodeFrame(
+				Box2f( V2f( b.min.x, b.min.y ) + V2f( borderWidth ), V2f( b.max.x, b.max.y ) - V2f( borderWidth ) ),
+				borderWidth,
+				state,
+				m_userColor.get_ptr()
+			);
+			break;
+		}
+		case GraphLayer::Overlay :
+		{
+			if( !m_nodeEnabled && !IECoreGL::Selector::currentSelector() )
+			{
+				const Box3f b = bound();
+				/// \todo Replace renderLine() with a specific method (renderNodeStrikeThrough?) on the Style class
+				/// so that styles can do customised drawing based on knowledge of what is being drawn.
+				style->renderLine( IECore::LineSegment3f( V3f( b.min.x, b.min.y, 0 ), V3f( b.max.x, b.max.y, 0 ) ) );
+			}
+			break;
+		}
+		default :
+			break;
 	}
 }
 

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -119,6 +119,23 @@ void StandardNodule::updateDragEndPoint( const Imath::V3f position, const Imath:
  	requestRender();
 }
 
+bool StandardNodule::hasLayer( Layer layer ) const
+{
+	switch( layer )
+	{
+		case GraphLayer::Connections :
+			return m_draggingConnection;
+		case GraphLayer::Nodes :
+			return !getHighlighted();
+		case GraphLayer::Highlighting :
+			return getHighlighted();
+		case GraphLayer::Overlay :
+			return m_labelVisible && !IECoreGL::Selector::currentSelector();
+		default :
+			return false;
+	}
+}
+
 void StandardNodule::doRenderLayer( Layer layer, const Style *style ) const
 {
 	switch( layer )

--- a/src/GafferUIModule/ViewportGadgetBinding.cpp
+++ b/src/GafferUIModule/ViewportGadgetBinding.cpp
@@ -121,6 +121,7 @@ void GafferUIModule::bindViewportGadget()
 		.def( "gadgetToRasterSpace", &ViewportGadget::gadgetToRasterSpace, ( arg_( "gadgetPosition" ), arg_( "gadget" ) ) )
 		.def( "rasterToWorldSpace", &ViewportGadget::rasterToWorldSpace, ( arg_( "rasterPosition" ) ) )
 		.def( "worldToRasterSpace", &ViewportGadget::worldToRasterSpace, ( arg_( "worldPosition" ) ) )
+		.def( "render", &ViewportGadget::render )
 		.def( "preRenderSignal", &ViewportGadget::preRenderSignal, return_internal_reference<1>() )
 	;
 


### PR DESCRIPTION
This is a small followup to @mattigruener's recent layered gadget drawing work. It knocks about 25% off the time to render the NodeGraph on my Mac, fixes a bug, and simplifies the API slightly. The last three commits turned out to be fruitless in terms of optimisations I was aiming for, but I think they still represent a worthwhile change in terms of having flexibility to refactor the rendering in the future.

This doesn't get us all the way back to the performance we had before, but the trade off is looking much better now. One last thing we could do to shave off another significant chunk would be to merge the overlay/highlighting layers in the node graph into one, since currently we don't seem to need the distinction at all. Maybe it's worth keeping the flexibility for now though?

Other than that, I don't see much obvious to change with regards to the layering mechanism itself, I think any further optimisation will have to come from the StandardStyle and/or specific Gadgets...

@mattigruener, could you give this a once over when you get the chance?