### PR TITLE
ScriptNode : Don't allow failed correspondingInput to prevent deleting

### DIFF
--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -588,7 +588,20 @@ void ScriptNode::deleteNodes( Node *parent, const Set *filter, bool reconnect )
 			{
 				for( RecursiveOutputPlugIterator it( node ); !it.done(); ++it )
 				{
-					Plug *inPlug = dependencyNode->correspondingInput( it->get() );
+					Plug *inPlug = nullptr;
+					try
+					{
+						inPlug = dependencyNode->correspondingInput( it->get() );
+					}
+					catch( const std::exception &e )
+					{
+						msg(
+							IECore::Msg::Warning,
+							boost::str( boost::format( "correspondingInput error while deleting - cannot reconnect \"%s\"" ) % it->get()->fullName() ),
+							e.what()
+						);
+					}
+
 					if ( !inPlug )
 					{
 						continue;


### PR DESCRIPTION
Without this fix, a node with a failing correspondingInput ( such as a shader node where the shader can no longer be loaded ) cannot be deleted.