### PR TITLE
StandardNodule : do rendering in separate matrix on the stack

### DIFF
--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -233,6 +233,7 @@ void StandardNodule::renderLabel( const Style *style ) const
 	}
 
 	// now we can actually do the rendering.
+	glPushMatrix();
 
 	if( getHighlighted() )
 	{
@@ -243,6 +244,8 @@ void StandardNodule::renderLabel( const Style *style ) const
 	glTranslatef( -anchor.x, -anchor.y, 0.0f );
 
 	style->renderText( Style::LabelText, *label );
+
+	glPopMatrix();
 }
 
 void StandardNodule::enter( GadgetPtr gadget, const ButtonEvent &event )


### PR DESCRIPTION
We have an optimization introduced in 6ca416a that messes things up a little
when rendering a nodule that hasn't been moved. Its GL calls don't get wrapped
in glPushMatrix() and glPopMatrix() when rendering.

There's a [PR](https://github.com/GafferHQ/gaffer/pull/2201) that moves nodule rendering between classes and this problem will have to be addressed there, as well. 