### PR TITLE
Catalogue Improvements

### DIFF
--- a/include/GafferImage/Catalogue.h
+++ b/include/GafferImage/Catalogue.h
@@ -114,7 +114,15 @@ class Catalogue : public ImageNode
 		std::string generateFileName( const Image *image ) const;
 		std::string generateFileName( const ImagePlug *image ) const;
 
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
 	private :
+
+		Gaffer::IntPlug *internalImageIndexPlug();
+		const Gaffer::IntPlug *internalImageIndexPlug() const;
+
+		Gaffer::AtomicCompoundDataPlug *mappingPlug();
+		const Gaffer::AtomicCompoundDataPlug *mappingPlug() const;
 
 		ImageSwitch *imageSwitch();
 		const ImageSwitch *imageSwitch() const;
@@ -128,6 +136,11 @@ class Catalogue : public ImageNode
 
 		void driverCreated( IECoreImage::DisplayDriver *driver, const IECore::CompoundData *parameters );
 		void imageReceived( Gaffer::Plug *plug );
+
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+
+		void computeNameToIndexMapping();
 
 		static size_t g_firstPlugIndex;
 

--- a/python/GafferImage/CatalogueSelect.py
+++ b/python/GafferImage/CatalogueSelect.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -33,20 +33,25 @@
 #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 ##########################################################################
+import IECore
+import Gaffer
+import GafferImage
 
-__import__( "IECoreImage" )
-__import__( "Gaffer" )
-__import__( "GafferDispatch" )
 
-def __setupEnvironment() :
+class CatalogueSelect( GafferImage.ImageProcessor ) :
 
-	import os
-	if "OCIO" not in os.environ :
-		os.environ["OCIO"] = os.path.expandvars( "$GAFFER_ROOT/openColorIO/config.ocio" )
+	def __init__(self, name = 'CatalogueSelect' ) :
 
-__setupEnvironment()
+		GafferImage.ImageProcessor.__init__( self, name )
 
-from _GafferImage import *
-from CatalogueSelect import CatalogueSelect
+		self["imageName"] = Gaffer.StringPlug()
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferImage" )
+		self["context"] = GafferImage.ImageContextVariables()
+		self["context"]["variables"].addMember( "catalogue:imageName", "", "imageNameMember" )
+		self["context"]["variables"]["imageNameMember"]["value"].setInput( self["imageName"] )
+
+		self["context"]["in"].setInput( self["in"] )
+		self["out"].setInput( self["context"]["out"] )
+
+
+IECore.registerRunTimeTyped( CatalogueSelect, typeName = "GafferImage::CatalogueSelect" )

--- a/python/GafferImage/CatalogueSelect.py
+++ b/python/GafferImage/CatalogueSelect.py
@@ -47,12 +47,14 @@ class CatalogueSelect( GafferImage.ImageProcessor ) :
 
 		self["imageName"] = Gaffer.StringPlug()
 
-		self["context"] = GafferImage.ImageContextVariables()
-		self["context"]["variables"].addMember( "catalogue:imageName", "", "imageNameMember" )
-		self["context"]["variables"]["imageNameMember"]["value"].setInput( self["imageName"] )
+		self["__context"] = GafferImage.ImageContextVariables()
+		self["__context"]["variables"].addMember( "catalogue:imageName", "", "imageNameMember" )
+		self["__context"]["variables"]["imageNameMember"]["value"].setInput( self["imageName"] )
 
-		self["context"]["in"].setInput( self["in"] )
-		self["out"].setInput( self["context"]["out"] )
+		self["__context"]["in"].setInput( self["in"] )
+		self["out"].setInput( self["__context"]["out"] )
+
+		self['out'].setFlags(Gaffer.Plug.Flags.Serialisable, False)
 
 
 IECore.registerRunTimeTyped( CatalogueSelect, typeName = "GafferImage::CatalogueSelect" )

--- a/python/GafferImageTest/CatalogueSelectTest.py
+++ b/python/GafferImageTest/CatalogueSelectTest.py
@@ -48,7 +48,7 @@ class CatalogueSelectTest( GafferImageTest.ImageTestCase ) :
 		images = []
 		readers = []
 		fileNames = [ "checker.exr", "blurRange.exr", "noisyRamp.exr", "resamplePatterns.exr" ]
-		for i, fileName in enumerate( fileNames ) :
+		for fileName in fileNames :
 			images.append( GafferImage.Catalogue.Image.load( "${GAFFER_ROOT}/python/GafferImageTest/images/" + fileName ) )
 			readers.append( GafferImage.ImageReader() )
 			readers[-1]["fileName"].setValue( images[-1]["fileName"].getValue() )
@@ -65,7 +65,7 @@ class CatalogueSelectTest( GafferImageTest.ImageTestCase ) :
 			catalogueSelect["in"].setInput( c["out"] )
 			catalogueSelect["imageName"].setValue( fileName.split( "." )[0] )
 
-			self.assertTrue( catalogueSelect["out"].image() == c["__switch"]["in"][i].image() )
+			self.assertImagesEqual( catalogueSelect["out"], readers[i]["out"], ignoreMetadata = True )
 
 		# Pulling out image that is selected in the Catalogue UI
 
@@ -73,8 +73,7 @@ class CatalogueSelectTest( GafferImageTest.ImageTestCase ) :
 		catalogueSelect["in"].setInput( c["out"] )
 		catalogueSelect["imageName"].setValue( "" )
 
-		selectionIndex = c['__imageIndex'].getValue()
-		self.assertTrue( catalogueSelect["out"].image() == c["__switch"]["in"][ selectionIndex ].image() )
+		self.assertImagesEqual( catalogueSelect["out"], c["out"] )
 
 		# Pulling out invalid image
 

--- a/python/GafferImageTest/CatalogueSelectTest.py
+++ b/python/GafferImageTest/CatalogueSelectTest.py
@@ -1,0 +1,85 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+import IECore
+
+import GafferImage
+import GafferImageTest
+
+
+class CatalogueSelectTest( GafferImageTest.ImageTestCase ) :
+
+	def testSelection( self ):
+
+		# Set up Catalogue with images that we can select
+
+		images = []
+		readers = []
+		fileNames = [ "checker.exr", "blurRange.exr", "noisyRamp.exr", "resamplePatterns.exr" ]
+		for i, fileName in enumerate( fileNames ) :
+			images.append( GafferImage.Catalogue.Image.load( "${GAFFER_ROOT}/python/GafferImageTest/images/" + fileName ) )
+			readers.append( GafferImage.ImageReader() )
+			readers[-1]["fileName"].setValue( images[-1]["fileName"].getValue() )
+
+		c = GafferImage.Catalogue()
+
+		for image in images :
+			c["images"].addChild( image )
+
+		# Pulling out images by name
+
+		for i, fileName in enumerate( fileNames ) :
+			catalogueSelect = GafferImage.CatalogueSelect()
+			catalogueSelect["in"].setInput( c["out"] )
+			catalogueSelect["imageName"].setValue( fileName.split( "." )[0] )
+
+			self.assertTrue( catalogueSelect["out"].image() == c["__switch"]["in"][i].image() )
+
+		# Pulling out image that is selected in the Catalogue UI
+
+		catalogueSelect = GafferImage.CatalogueSelect()
+		catalogueSelect["in"].setInput( c["out"] )
+		catalogueSelect["imageName"].setValue( "" )
+
+		selectionIndex = c['__imageIndex'].getValue()
+		self.assertTrue( catalogueSelect["out"].image() == c["__switch"]["in"][ selectionIndex ].image() )
+
+		# Pulling out invalid image
+
+		catalogueSelect["imageName"].setValue("nope")
+		with self.assertRaises( Exception ) as cm:
+			catalogueSelect["out"].image()
+
+		self.assertEqual( str( cm.exception ), "Exception : Unknown image name." )

--- a/python/GafferImageTest/__init__.py
+++ b/python/GafferImageTest/__init__.py
@@ -91,6 +91,7 @@ from DilateTest import DilateTest
 from MixTest import MixTest
 from CatalogueTest import CatalogueTest
 from CollectImagesTest import CollectImagesTest
+from CatalogueSelectTest import CatalogueSelectTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferImageUI/CatalogueSelectUI.py
+++ b/python/GafferImageUI/CatalogueSelectUI.py
@@ -38,11 +38,16 @@ import Gaffer
 import GafferImage
 
 def __imageNames( plug ) :
+	node = plug.node()
+	imagePlug = node["in"]
 
-	nodeInput = plug.node()["in"].getInput()
-	if( nodeInput and isinstance( nodeInput.node(), GafferImage.Catalogue ) ) :
-		return nodeInput.node()["images"].keys()
-	return []
+	while imagePlug is not None and not isinstance( imagePlug.node(), GafferImage.Catalogue ) :
+		imagePlug = imagePlug.getInput()
+
+	if imagePlug is None :
+		return []
+
+	return imagePlug.node()["images"].keys()
 
 def __imagePresetNames( plug ) :
 
@@ -69,7 +74,6 @@ Gaffer.Metadata.registerNode(
 			"presetNames", __imagePresetNames,
 			"presetValues", __imagePresetValues,
 
-			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 		]
 	}
 )

--- a/python/GafferImageUI/CatalogueSelectUI.py
+++ b/python/GafferImageUI/CatalogueSelectUI.py
@@ -34,25 +34,42 @@
 #
 ##########################################################################
 import IECore
-
 import Gaffer
 import GafferImage
 
+def __imageNames( plug ) :
 
-class CatalogueSelect( GafferImage.ImageProcessor ) :
+	nodeInput = plug.node()["in"].getInput()
+	if( nodeInput and isinstance( nodeInput.node(), GafferImage.Catalogue ) ) :
+		return nodeInput.node()["images"].keys()
+	return []
 
-	def __init__(self, name = 'CatalogueSelect' ) :
+def __imagePresetNames( plug ) :
 
-		GafferImage.ImageProcessor.__init__( self, name )
+	return IECore.StringVectorData( [ "Selected" ] + __imageNames( plug ) )
 
-		self["imageName"] = Gaffer.StringPlug()
+def __imagePresetValues( plug ) :
 
-		self["context"] = GafferImage.ImageContextVariables()
-		self["context"]["variables"].addMember( "catalogue:imageName", "", "imageNameMember" )
-		self["context"]["variables"]["imageNameMember"]["value"].setInput( self["imageName"] )
+	return IECore.StringVectorData( [ "" ] + __imageNames( plug ) )
 
-		self["context"]["in"].setInput( self["in"] )
-		self["out"].setInput( self["context"]["out"] )
+Gaffer.Metadata.registerNode(
 
+	GafferImage.CatalogueSelect,
 
-IECore.registerRunTimeTyped( CatalogueSelect, typeName = "GafferImage::CatalogueSelect" )
+	"description",
+	"Finds an image in a directly connected Catalogue by name.",
+
+	plugs = {
+
+		"imageName" : [
+
+			"description",
+			"The name of the image to extract.",
+
+			"presetNames", __imagePresetNames,
+			"presetValues", __imagePresetValues,
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		]
+	}
+)

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -242,6 +242,12 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 					Gaffer.WeakMethod( self.__exportClicked )
 				)
 
+				self.__extractButton = GafferUI.Button( image = "extract.png", hasFrame = False, toolTip = "Create CatalogueSelect node for selected image" )
+				self.__extractButton.setEnabled( False )
+				self.__extractButtonClickedConnection = self.__extractButton.clickedSignal().connect(
+					Gaffer.WeakMethod( self.__extractClicked )
+				)
+
 				GafferUI.Spacer( IECore.V2i( 0 ), parenting = { "expand" : True } )
 
 				self.__removeButton = GafferUI.Button( image = "delete.png", hasFrame = False, toolTip = "Remove selected image" )
@@ -319,6 +325,7 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 		index = self.__indexFromSelection()
 
 		self.__removeButton.setEnabled( index is not None )
+		self.__extractButton.setEnabled( index is not None )
 		self.__exportButton.setEnabled( index is not None )
 		self.__duplicateButton.setEnabled( index is not None )
 
@@ -376,6 +383,17 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.__images().removeChild( self.__images()[index] )
 			self.getPlug().setValue( max( 0, index - 1 ) )
+
+	def __extractClicked( self, *unused ) :
+
+		index = self.__indexFromSelection()
+		image = self.__images()[index]
+
+		extractNode = GafferImage.CatalogueSelect()
+		extractNode["in"].setInput( self.__catalogue()["out"] )
+		extractNode["imageName"].setValue( image.getName() )
+
+		self.__catalogue().parent().addChild( extractNode )
 
 	def __exportClicked( self, *unused ) :
 

--- a/python/GafferImageUI/__init__.py
+++ b/python/GafferImageUI/__init__.py
@@ -98,5 +98,6 @@ import ColorProcessorUI
 import MixUI
 import CatalogueUI
 import CollectImagesUI
+import CatalogueSelectUI
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferImageUI" )

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -151,16 +151,16 @@
      borderopacity="1"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.8284271"
-     inkscape:cx="434.03256"
-     inkscape:cy="385.03851"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="439.58886"
+     inkscape:cy="334.75017"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:window-width="1920"
-     inkscape:window-height="1177"
-     inkscape:window-x="1920"
-     inkscape:window-y="0"
+     inkscape:window-height="1127"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
      inkscape:window-maximized="1"
      inkscape:snap-global="true"
      inkscape:snap-nodes="true"
@@ -190,7 +190,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -41,6 +41,7 @@
 #include "boost/filesystem/path.hpp"
 #include "boost/filesystem/operations.hpp"
 #include "boost/unordered_map.hpp"
+#include "boost/algorithm/string.hpp"
 
 #include "Gaffer/Context.h"
 #include "Gaffer/StringPlug.h"
@@ -621,7 +622,11 @@ void Catalogue::Image::copyFrom( const Image *other )
 
 Catalogue::Image::Ptr Catalogue::Image::load( const std::string &fileName )
 {
-	Ptr image = new Image( boost::filesystem::path( fileName ).stem().string(), Plug::In, Plug::Default | Plug::Dynamic );
+	// Names of Plugs can not contain '.' - we want to load files like 'test.1001.exr', though
+	std::string name = boost::filesystem::path( fileName ).stem().string();
+	boost::replace_all( name, ".", "_" );
+
+	Ptr image = new Image( name, Plug::In, Plug::Default | Plug::Dynamic );
 	image->fileNamePlug()->setValue( fileName );
 
 	ImageReaderPtr reader = new ImageReader;

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -381,6 +381,7 @@ nodeMenu.append( "/Image/Utility/Copy Metadata", GafferImage.CopyImageMetadata, 
 nodeMenu.append( "/Image/Utility/Stats", GafferImage.ImageStats, searchText = "ImageStats", postCreator = GafferImageUI.ImageStatsUI.postCreate  )
 nodeMenu.append( "/Image/Utility/Sampler", GafferImage.ImageSampler, searchText = "ImageSampler" )
 nodeMenu.append( "/Image/Utility/Catalogue", GafferImage.Catalogue )
+nodeMenu.append( "/Image/Utility/CatalogueSelect", GafferImage.CatalogueSelect )
 
 # OSL nodes
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -381,7 +381,7 @@ nodeMenu.append( "/Image/Utility/Copy Metadata", GafferImage.CopyImageMetadata, 
 nodeMenu.append( "/Image/Utility/Stats", GafferImage.ImageStats, searchText = "ImageStats", postCreator = GafferImageUI.ImageStatsUI.postCreate  )
 nodeMenu.append( "/Image/Utility/Sampler", GafferImage.ImageSampler, searchText = "ImageSampler" )
 nodeMenu.append( "/Image/Utility/Catalogue", GafferImage.Catalogue )
-nodeMenu.append( "/Image/Utility/CatalogueSelect", GafferImage.CatalogueSelect )
+nodeMenu.append( "/Image/Utility/Catalogue Select", GafferImage.CatalogueSelect )
 
 # OSL nodes
 


### PR DESCRIPTION
This contains two things:

- Allow filepaths that contain dots ( test.1001.exr for instance )
- Add new node that allows selecting an image from a Catalogue

The idea for the latter is that we will eventually build an A|B tool for the ImageView that allows switching between selected nodes. In order for that to work for images in the Catalogue as well, we need to be able to pull them out of the Catalogue.

There's a new icon in the CatalogueUI as well that simplifies this process a little.