### PR TITLE
Follow up PR for Gaffer VDB support

### DIFF
--- a/include/GafferVDB/LevelSetOffset.h
+++ b/include/GafferVDB/LevelSetOffset.h
@@ -57,8 +57,8 @@ class LevelSetOffset : public GafferScene::SceneElementProcessor
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferVDB::LevelSetOffset, LevelSetOffsetTypeId, GafferScene::SceneElementProcessor );
 
-		Gaffer::StringPlug *gridNamePlug();
-		const Gaffer::StringPlug *gridNamePlug() const;
+		Gaffer::StringPlug *gridPlug();
+		const Gaffer::StringPlug *gridPlug() const;
 
 		Gaffer::FloatPlug *offsetPlug();
 		const Gaffer::FloatPlug *offsetPlug() const;

--- a/include/GafferVDB/LevelSetToMesh.h
+++ b/include/GafferVDB/LevelSetToMesh.h
@@ -56,8 +56,8 @@ class LevelSetToMesh : public GafferScene::SceneElementProcessor
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferVDB::LevelSetToMesh, LevelSetToMeshTypeId, GafferScene::SceneElementProcessor );
 
-		Gaffer::StringPlug *gridNamePlug();
-		const Gaffer::StringPlug *gridNamePlug() const;
+		Gaffer::StringPlug *gridPlug();
+		const Gaffer::StringPlug *gridPlug() const;
 
 		Gaffer::FloatPlug *isoValuePlug();
 		const Gaffer::FloatPlug *isoValuePlug() const;

--- a/include/GafferVDB/MeshToLevelSet.h
+++ b/include/GafferVDB/MeshToLevelSet.h
@@ -62,8 +62,8 @@ class MeshToLevelSet : public GafferScene::SceneElementProcessor
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferVDB::MeshToLevelSet, MeshToLevelSetTypeId, GafferScene::SceneElementProcessor );
 
-		Gaffer::StringPlug *gridNamePlug();
-		const Gaffer::StringPlug *gridNamePlug() const;
+		Gaffer::StringPlug *gridPlug();
+		const Gaffer::StringPlug *gridPlug() const;
 
 		Gaffer::FloatPlug *voxelSizePlug();
 		const Gaffer::FloatPlug *voxelSizePlug() const;

--- a/python/GafferVDB/__init__.py
+++ b/python/GafferVDB/__init__.py
@@ -36,7 +36,14 @@
 
 __import__( "GafferScene" )
 
-import pyopenvdb
+import warnings
+
+# the first import of pyopenvdb results in a duplicate c++ -> python
+# boost python type conversions warnings.
+# we use the warnings module to suppress these during the import
+with warnings.catch_warnings():
+	warnings.simplefilter("ignore")
+	import pyopenvdb
 
 from _GafferVDB import *
 

--- a/python/GafferVDBTest/LevelSetOffsetTest.py
+++ b/python/GafferVDBTest/LevelSetOffsetTest.py
@@ -57,22 +57,24 @@ class LevelSetOffsetTest( GafferVDBTest.VDBTestCase ) :
 		sphere["radius"].setValue( 5 )
 
 		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		self.setFilter( meshToLevelSet, path='/sphere')
 		meshToLevelSet["voxelSize"].setValue( 0.1 )
 		meshToLevelSet["in"].setInput( sphere["out"] )
 
 		levelSetOffset = GafferVDB.LevelSetOffset()
+		self.setFilter( levelSetOffset, path='/sphere' )
 		levelSetOffset["offset"].setValue( 0.0 )
 		levelSetOffset["in"].setInput( meshToLevelSet["out"] )
 
 		# sphere centred at the origin so we just take the x value of the max and it should equal the radius
 		# hopefully the leafCounts should go like the square of the radius.
 		self.assertEqualTolerance( 5.0, levelSetOffset['out'].bound( "sphere" ).max[0], 0.05 )
-		self.assertTrue( 1020 <=levelSetOffset['out'].object( "sphere" ).findGrid( "levelset" ).leafCount() <= 1040 )
+		self.assertTrue( 1020 <= levelSetOffset['out'].object( "sphere" ).findGrid( "surface" ).leafCount() <= 1040 )
 
 		levelSetOffset["offset"].setValue( -1.0 )
 		self.assertEqualTolerance( 6.0, levelSetOffset['out'].bound( "sphere" ).max[0], 0.05 )
-		self.assertTrue( 1420 <= levelSetOffset['out'].object( "sphere" ).findGrid( "levelset" ).leafCount() <= 1450)
+		self.assertTrue( 1420 <= levelSetOffset['out'].object( "sphere" ).findGrid( "surface" ).leafCount() <= 1450)
 
 		levelSetOffset["offset"].setValue( 1.0 )
 		self.assertEqualTolerance( 4.0, levelSetOffset['out'].bound( "sphere" ).max[0], 0.05 )
-		self.assertTrue( 640 <= levelSetOffset['out'].object( "sphere" ).findGrid( "levelset" ).leafCount() <= 650)
+		self.assertTrue( 640 <= levelSetOffset['out'].object( "sphere" ).findGrid( "surface" ).leafCount() <= 650)

--- a/python/GafferVDBTest/LevelSetToMeshTest.py
+++ b/python/GafferVDBTest/LevelSetToMeshTest.py
@@ -53,6 +53,7 @@ class LevelSetToMeshTest( GafferVDBTest.VDBTestCase ) :
 	def testCanConvertLevelSetToMesh( self ) :
 		sphere = GafferScene.Sphere()
 		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		self.setFilter( meshToLevelSet, path='/sphere' )
 		meshToLevelSet["voxelSize"].setValue( 0.05 )
 		meshToLevelSet["in"].setInput( sphere["out"] )
 
@@ -60,10 +61,11 @@ class LevelSetToMeshTest( GafferVDBTest.VDBTestCase ) :
 
 		self.assertTrue( isinstance( obj, GafferVDB.VDBObject ) )
 
-		self.assertEqual( obj.gridNames(), ['levelset'] )
-		grid = obj.findGrid( "levelset" )
+		self.assertEqual( obj.gridNames(), ['surface'] )
+		grid = obj.findGrid( "surface" )
 
 		levelSetToMesh = GafferVDB.LevelSetToMesh()
+		self.setFilter( levelSetToMesh, path='/sphere' )
 		levelSetToMesh["in"].setInput( meshToLevelSet["out"] )
 
 		mesh = levelSetToMesh["out"].object( "sphere" )
@@ -74,12 +76,14 @@ class LevelSetToMeshTest( GafferVDBTest.VDBTestCase ) :
 		sphere["radius"].setValue( 5 )
 
 		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		self.setFilter( meshToLevelSet, path='/sphere' )
 		meshToLevelSet["voxelSize"].setValue( 0.05 )
 		meshToLevelSet["exteriorBandwidth"].setValue( 4.0 )
 		meshToLevelSet["interiorBandwidth"].setValue( 4.0 )
 		meshToLevelSet["in"].setInput( sphere["out"] )
 
 		levelSetToMesh = GafferVDB.LevelSetToMesh()
+		self.setFilter( levelSetToMesh, path='/sphere' )
 		levelSetToMesh["in"].setInput( meshToLevelSet["out"] )
 
 		self.assertEqualTolerance( 5.0, levelSetToMesh['out'].bound( "sphere" ).max[0], 0.05 )
@@ -95,12 +99,14 @@ class LevelSetToMeshTest( GafferVDBTest.VDBTestCase ) :
 		sphere["radius"].setValue( 5 )
 
 		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		self.setFilter( meshToLevelSet, path='/sphere' )
 		meshToLevelSet["voxelSize"].setValue( 0.05 )
 		meshToLevelSet["exteriorBandwidth"].setValue( 4.0 )
 		meshToLevelSet["interiorBandwidth"].setValue( 4.0 )
 		meshToLevelSet["in"].setInput( sphere["out"] )
 
 		levelSetToMesh = GafferVDB.LevelSetToMesh()
+		self.setFilter( levelSetToMesh, path='/sphere')
 		levelSetToMesh["in"].setInput( meshToLevelSet["out"] )
 
 		levelSetToMesh['adaptivity'].setValue(0.0)

--- a/python/GafferVDBTest/MeshToLevelSetTest.py
+++ b/python/GafferVDBTest/MeshToLevelSetTest.py
@@ -53,14 +53,15 @@ class MeshToLevelSetTest( GafferVDBTest.VDBTestCase ) :
 	def testCanConvertMeshToLevelSetVolume( self ) :
 		sphere = GafferScene.Sphere()
 		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		self.setFilter( meshToLevelSet, path='/sphere' )
 		meshToLevelSet["voxelSize"].setValue( 0.05 )
 		meshToLevelSet["in"].setInput( sphere["out"] )
 
 		obj = meshToLevelSet['out'].object( "sphere" )
 		self.assertTrue( isinstance( obj, GafferVDB.VDBObject ) )
 
-		self.assertEqual( obj.gridNames(), ['levelset'] )
-		grid = obj.findGrid( "levelset" )
+		self.assertEqual( obj.gridNames(), ['surface'] )
+		grid = obj.findGrid( "surface" )
 
 		meshBounds = sphere['out'].bound( "sphere" )
 		vdbBounds = meshToLevelSet['out'].bound( "sphere" )
@@ -73,6 +74,7 @@ class MeshToLevelSetTest( GafferVDBTest.VDBTestCase ) :
 	def testDecreasingVoxelSizeIncreasesLeafCount( self ) :
 		sphere = GafferScene.Sphere()
 		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		self.setFilter( meshToLevelSet, path='/sphere' )
 		meshToLevelSet["voxelSize"].setValue( 0.1 )
 		meshToLevelSet["in"].setInput( sphere["out"] )
 
@@ -80,8 +82,8 @@ class MeshToLevelSetTest( GafferVDBTest.VDBTestCase ) :
 		meshToLevelSet["voxelSize"].setValue( 0.05 )
 		obj2 = meshToLevelSet['out'].object( "sphere" )
 
-		ls1 = obj1.findGrid( "levelset" )
-		ls2 = obj2.findGrid( "levelset" )
+		ls1 = obj1.findGrid( "surface" )
+		ls2 = obj2.findGrid( "surface" )
 
 		self.assertEqual( 56, ls1.leafCount() )
 		self.assertEqual( 158, ls2.leafCount() )
@@ -91,26 +93,28 @@ class MeshToLevelSetTest( GafferVDBTest.VDBTestCase ) :
 		sphere["radius"].setValue( 4.0 )
 
 		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		self.setFilter( meshToLevelSet, '/sphere' )
 		meshToLevelSet["voxelSize"].setValue( 0.1 )
 		meshToLevelSet["in"].setInput( sphere["out"] )
 
-		self.assertTrue( 640 <= meshToLevelSet['out'].object( "sphere" ).findGrid( "levelset" ).leafCount() <= 650 )
+		self.assertTrue( 640 <= meshToLevelSet['out'].object( "sphere" ).findGrid( "surface" ).leafCount() <= 650 )
 
 		meshToLevelSet["exteriorBandwidth"].setValue( 4.0 )
-		self.assertTrue( 685 <= meshToLevelSet['out'].object( "sphere" ).findGrid( "levelset" ).leafCount() <= 695 )
+		self.assertTrue( 685 <= meshToLevelSet['out'].object( "sphere" ).findGrid( "surface" ).leafCount() <= 695 )
 
 		meshToLevelSet["interiorBandwidth"].setValue( 4.0 )
-		self.assertTrue( 715 <= meshToLevelSet['out'].object( "sphere" ).findGrid( "levelset" ).leafCount() <= 725 )
+		self.assertTrue( 715 <= meshToLevelSet['out'].object( "sphere" ).findGrid( "surface" ).leafCount() <= 725 )
 
 	def testCanSpecifyLevelsetGridname( self ) :
 		sphere = GafferScene.Sphere()
 		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		self.setFilter( meshToLevelSet, path='/sphere' )
 		meshToLevelSet["voxelSize"].setValue( 0.1 )
 		meshToLevelSet["in"].setInput( sphere["out"] )
 
 		obj1 = meshToLevelSet['out'].object( "sphere" )
-		self.assertEqual( obj1.gridNames(), ["levelset"] )
+		self.assertEqual( obj1.gridNames(), ["surface"] )
 
-		meshToLevelSet["gridName"].setValue( "fooBar" )
+		meshToLevelSet["grid"].setValue( "fooBar" )
 		obj2 = meshToLevelSet['out'].object( "sphere" )
 		self.assertEqual( obj2.gridNames(), ["fooBar"] )

--- a/python/GafferVDBTest/VDBTestCase.py
+++ b/python/GafferVDBTest/VDBTestCase.py
@@ -37,7 +37,8 @@
 import os
 import subprocess32 as subprocess
 
-
+import IECore
+import GafferScene
 import GafferSceneTest
 
 class VDBTestCase( GafferSceneTest.SceneTestCase ) :
@@ -48,3 +49,13 @@ class VDBTestCase( GafferSceneTest.SceneTestCase ) :
 	def setUp( self ) :
 		GafferSceneTest.SceneTestCase.setUp( self )
 		self.dataDir = os.path.join( os.path.dirname( __file__ ),  "data")
+		self.filters = [] # need to keep hold of the filters for the duration of the test
+
+	def setFilter(self, node, path = '/vdb'):
+
+		pathFilter = GafferScene.PathFilter( "PathFilter" )
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ path ] ) )
+		self.filters.append( pathFilter )
+
+		node["filter"].setInput( pathFilter["out"] )
+

--- a/python/GafferVDBUI/LevelSetOffsetUI.py
+++ b/python/GafferVDBUI/LevelSetOffsetUI.py
@@ -42,7 +42,7 @@ GafferUI.Metadata.registerNode(
 	'description',
 	"""Erodes or dilates a level set VDB.""",
 	plugs={
-		'gridName' : [
+		'grid' : [
 			'description',
 			"""
 			Name of the level set grid to offset in the VDB object.

--- a/python/GafferVDBUI/LevelSetToMeshUI.py
+++ b/python/GafferVDBUI/LevelSetToMeshUI.py
@@ -40,10 +40,10 @@ import GafferVDB
 GafferUI.Metadata.registerNode(
 	GafferVDB.LevelSetToMesh,
 	'description',
-	"""Converts a mesh primitive to a level set VDB object.""",
+	"""Converts a level set VDB object to a mesh primitive .""",
 
 	plugs={
-		'gridName' : [
+		'grid' : [
 			'description',
 			"""
 			Name of the level set grid to create a mesh primitive from.

--- a/python/GafferVDBUI/MeshToLevelSetUI.py
+++ b/python/GafferVDBUI/MeshToLevelSetUI.py
@@ -40,9 +40,9 @@ import GafferVDB
 GafferUI.Metadata.registerNode(
 	GafferVDB.MeshToLevelSet,
 	'description',
-	"""Converts a level set VDB object to a mesh primitive.""",
+	"""Converts a mesh primitive to a level set VDB object.""",
 	plugs={
-		'gridName' : [
+		'grid' : [
 			'description',
 			"""
 			Name of the level set grid to create in the VDB object.

--- a/src/GafferVDB/LevelSetOffset.cpp
+++ b/src/GafferVDB/LevelSetOffset.cpp
@@ -53,11 +53,11 @@ IE_CORE_DEFINERUNTIMETYPED( LevelSetOffset );
 size_t LevelSetOffset::g_firstPlugIndex = 0;
 
 LevelSetOffset::LevelSetOffset( const std::string &name )
-	:	SceneElementProcessor( name )
+	:	SceneElementProcessor( name, GafferScene::Filter::NoMatch )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 
-	addChild( new StringPlug( "gridName", Plug::In, "levelset") );
+	addChild( new StringPlug( "grid", Plug::In, "surface") );
 	addChild( new FloatPlug( "offset", Plug::In, 0.5) );
 }
 
@@ -65,12 +65,12 @@ LevelSetOffset::~LevelSetOffset()
 {
 }
 
-Gaffer::StringPlug *LevelSetOffset::gridNamePlug()
+Gaffer::StringPlug *LevelSetOffset::gridPlug()
 {
 	return  getChild<StringPlug>( g_firstPlugIndex );
 }
 
-const Gaffer::StringPlug *LevelSetOffset::gridNamePlug() const
+const Gaffer::StringPlug *LevelSetOffset::gridPlug() const
 {
 	return  getChild<StringPlug>( g_firstPlugIndex );
 }
@@ -89,7 +89,7 @@ void LevelSetOffset::affects( const Gaffer::Plug *input, AffectedPlugsContainer 
 {
 	SceneElementProcessor::affects( input, outputs );
 
-	if( input == gridNamePlug() || input == offsetPlug() )
+	if( input == gridPlug() || input == offsetPlug() )
 	{
 		outputs.push_back( outPlug()->objectPlug() );
 		outputs.push_back( outPlug()->boundPlug() );
@@ -105,7 +105,7 @@ void LevelSetOffset::hashProcessedObject( const ScenePath &path, const Gaffer::C
 {
 	SceneElementProcessor::hashProcessedObject( path, context, h );
 
-	gridNamePlug()->hash( h );
+	gridPlug()->hash( h );
 	offsetPlug()->hash( h );
 }
 
@@ -117,7 +117,7 @@ IECore::ConstObjectPtr LevelSetOffset::computeProcessedObject( const ScenePath &
 		return inputObject;
 	}
 
-	std::string gridName = gridNamePlug()->getValue();
+	std::string gridName = gridPlug()->getValue();
 
 	openvdb::GridBase::ConstPtr gridBase = vdbObject->findGrid( gridName );
 
@@ -164,7 +164,7 @@ void LevelSetOffset::hashProcessedBound( const ScenePath &path, const Gaffer::Co
 {
 	SceneElementProcessor::hashProcessedBound( path, context, h );
 
-	gridNamePlug()->hash( h );
+	gridPlug()->hash( h );
 	offsetPlug()->hash( h );
 }
 

--- a/src/GafferVDB/LevelSetToMesh.cpp
+++ b/src/GafferVDB/LevelSetToMesh.cpp
@@ -173,11 +173,11 @@ IE_CORE_DEFINERUNTIMETYPED( LevelSetToMesh );
 size_t LevelSetToMesh::g_firstPlugIndex = 0;
 
 LevelSetToMesh::LevelSetToMesh( const std::string &name )
-	:	SceneElementProcessor( name )
+	:	SceneElementProcessor( name, GafferScene::Filter::NoMatch )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 
-	addChild( new StringPlug( "gridName", Plug::In, "levelset" ) );
+	addChild( new StringPlug( "grid", Plug::In, "surface" ) );
 	addChild( new FloatPlug( "isoValue", Plug::In, 0.0f ) );
 	addChild( new FloatPlug( "adaptivity", Plug::In, 0.0f, 0.0f, 1.0f ) );
 
@@ -187,12 +187,12 @@ LevelSetToMesh::~LevelSetToMesh()
 {
 }
 
-Gaffer::StringPlug *LevelSetToMesh::gridNamePlug()
+Gaffer::StringPlug *LevelSetToMesh::gridPlug()
 {
 	return  getChild<StringPlug>( g_firstPlugIndex );
 }
 
-const Gaffer::StringPlug *LevelSetToMesh::gridNamePlug() const
+const Gaffer::StringPlug *LevelSetToMesh::gridPlug() const
 {
 	return  getChild<StringPlug>( g_firstPlugIndex );
 }
@@ -225,7 +225,7 @@ void LevelSetToMesh::affects( const Gaffer::Plug *input, AffectedPlugsContainer 
 	if(
 		input == isoValuePlug() ||
 		input == adaptivityPlug() ||
-		input == gridNamePlug()
+		input == gridPlug()
 	)
 	{
 		outputs.push_back( outPlug()->objectPlug() );
@@ -241,7 +241,7 @@ void LevelSetToMesh::hashProcessedObject( const ScenePath &path, const Gaffer::C
 {
 	SceneElementProcessor::hashProcessedObject( path, context, h );
 
-	gridNamePlug()->hash( h );
+	gridPlug()->hash( h );
 	isoValuePlug()->hash( h );
 	adaptivityPlug()->hash( h );
 }
@@ -254,7 +254,7 @@ IECore::ConstObjectPtr LevelSetToMesh::computeProcessedObject( const ScenePath &
 		return inputObject;
 	}
 
-	openvdb::GridBase::ConstPtr grid = vdbObject->findGrid( gridNamePlug()->getValue() );
+	openvdb::GridBase::ConstPtr grid = vdbObject->findGrid( gridPlug()->getValue() );
 
 	if (!grid)
 	{
@@ -273,7 +273,7 @@ void LevelSetToMesh::hashProcessedBound( const ScenePath &path, const Gaffer::Co
 {
 	SceneElementProcessor::hashProcessedBound( path, context, h );
 
-	gridNamePlug()->hash( h );
+	gridPlug()->hash( h );
 	isoValuePlug()->hash( h );
 }
 

--- a/src/GafferVDB/MeshToLevelSet.cpp
+++ b/src/GafferVDB/MeshToLevelSet.cpp
@@ -126,11 +126,11 @@ IE_CORE_DEFINERUNTIMETYPED( MeshToLevelSet );
 size_t MeshToLevelSet::g_firstPlugIndex = 0;
 
 MeshToLevelSet::MeshToLevelSet( const std::string &name )
-	:	SceneElementProcessor( name )
+	:	SceneElementProcessor( name, GafferScene::Filter::NoMatch )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 
-	addChild( new StringPlug( "gridName", Plug::In, "levelset") );
+	addChild( new StringPlug( "grid", Plug::In, "surface") );
 	addChild( new FloatPlug( "voxelSize", Plug::In, 0.1f, 0.0001f ) );
 	addChild( new FloatPlug( "exteriorBandwidth", Plug::In, 3.0f, 0.0001f ) );
 	addChild( new FloatPlug( "interiorBandwidth", Plug::In, 3.0f, 0.0001f ) );
@@ -140,12 +140,12 @@ MeshToLevelSet::~MeshToLevelSet()
 {
 }
 
-Gaffer::StringPlug *MeshToLevelSet::gridNamePlug()
+Gaffer::StringPlug *MeshToLevelSet::gridPlug()
 {
 	return  getChild<StringPlug>( g_firstPlugIndex );
 }
 
-const Gaffer::StringPlug *MeshToLevelSet::gridNamePlug() const
+const Gaffer::StringPlug *MeshToLevelSet::gridPlug() const
 {
 	return  getChild<StringPlug>( g_firstPlugIndex );
 }
@@ -184,7 +184,7 @@ void MeshToLevelSet::affects( const Gaffer::Plug *input, AffectedPlugsContainer 
 {
 	SceneElementProcessor::affects( input, outputs );
 
-	if( input == voxelSizePlug() || input == gridNamePlug() )
+	if( input == voxelSizePlug() || input == gridPlug() )
 	{
 		outputs.push_back( outPlug()->objectPlug() );
 	}
@@ -199,7 +199,7 @@ void MeshToLevelSet::hashProcessedObject( const ScenePath &path, const Gaffer::C
 {
 	SceneElementProcessor::hashProcessedObject( path, context, h );
 
-	gridNamePlug()->hash( h );
+	gridPlug()->hash( h );
 	voxelSizePlug()->hash( h );
 	exteriorBandwidthPlug()->hash ( h );
 	interiorBandwidthPlug()->hash ( h );
@@ -228,7 +228,7 @@ IECore::ConstObjectPtr MeshToLevelSet::computeProcessedObject( const ScenePath &
 		//primitiveIndexGrid.get()
 	);
 
-	grid->setName( gridNamePlug()->getValue() );
+	grid->setName( gridPlug()->getValue() );
 
 	VDBObjectPtr newVDBObject =  new VDBObject();
 	newVDBObject->insertGrid( grid );


### PR DESCRIPTION
- suppressed boost python registration warnings when importing pyopenvdb
- rename 'gridName' plug to 'grid'
- filter has to specified for 'LevelSetOffset', 'LevelSetToMesh' & 'MeshToLevelSet' nodes
- default level set name changed from 'levelset' to 'surface'