### PR TITLE
Use Imath bindings from PyIlmBase

### DIFF
--- a/apps/screengrab/screengrab-1.py
+++ b/apps/screengrab/screengrab-1.py
@@ -36,6 +36,7 @@
 
 import os
 import time
+import imath
 
 import IECore
 
@@ -137,7 +138,7 @@ class screengrab( Gaffer.Application ) :
 						IECore.V3fParameter(
 							name = "viewDirection",
 							description = "The direction to view the framed objects in.",
-							defaultValue = IECore.V3f( -0.64, -0.422, -0.64 ),
+							defaultValue = imath.V3f( -0.64, -0.422, -0.64 ),
 						),
 					]
 				),

--- a/python/Gaffer/PythonExpressionEngine.py
+++ b/python/Gaffer/PythonExpressionEngine.py
@@ -324,7 +324,7 @@ def __boxPlugValueExtractor( plug, topLevelPlug, value ) :
 	vectorPlug = plug.parent()
 	index = vectorPlug.children().index( plug )
 
-	vector = value.value.min if vectorPlug.getName() == "min" else value.value.max
+	vector = value.value.min() if vectorPlug.getName() == "min" else value.value.max()
 
 	return vector[index]
 

--- a/python/Gaffer/PythonExpressionEngine.py
+++ b/python/Gaffer/PythonExpressionEngine.py
@@ -38,6 +38,8 @@
 import re
 import ast
 import functools
+import inspect
+import imath
 
 import IECore
 
@@ -76,7 +78,7 @@ class PythonExpressionEngine( Gaffer.Expression.Engine ) :
 			for p in plugPath.split( "." )[:-1] :
 				parentDict = parentDict.setdefault( p, {} )
 
-		executionDict = { "IECore" : IECore, "parent" : plugDict, "context" : _ContextProxy( context ) }
+		executionDict = { "imath" : imath, "IECore" : IECore, "parent" : plugDict, "context" : _ContextProxy( context ) }
 
 		exec( self.__expression, executionDict, executionDict )
 
@@ -183,7 +185,7 @@ class PythonExpressionEngine( Gaffer.Expression.Engine ) :
 		result += plug.relativeName( parentNode ).replace( ".", "\"][\"" )
 		result += "\"] = "
 
-		result += repr( value )
+		result += IECore.repr( value )
 
 		return result
 
@@ -341,6 +343,8 @@ def __defaultValueExtractor( plug, topLevelPlug, value ) :
 	for name in plug.relativeName( topLevelPlug ).split( "." ) :
 		try :
 			value = getattr( value, name )
+			if inspect.ismethod( value ) :
+				value = value()
 		except AttributeError :
 			accessor = getattr( value, "get" + name[0].upper() + name[1:], None )
 			if accessor is not None :

--- a/python/GafferAppleseed/AppleseedShaderBall.py
+++ b/python/GafferAppleseed/AppleseedShaderBall.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -50,7 +52,7 @@ class AppleseedShaderBall( GafferScene.ShaderBall ) :
 
 		# Appleseed doesn't support primitives spheres
 		self["__sphere"]["type"].setValue( self["__sphere"].Type.Mesh )
-		self["__sphere"]["divisions"].setValue( IECore.V2i( 60, 120 ) )
+		self["__sphere"]["divisions"].setValue( imath.V2i( 60, 120 ) )
 
 		self["__skyDome"] = GafferAppleseed.AppleseedLight()
 		self["__skyDome"].loadShader( "latlong_map_environment_edf" )

--- a/python/GafferAppleseedTest/AppleseedShaderAdaptorTest.py
+++ b/python/GafferAppleseedTest/AppleseedShaderAdaptorTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import imath
 
 import IECore
 
@@ -102,7 +103,7 @@ class AppleseedShaderAdaptorTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( len( network ), 2 )
 		self.assertEqual( network[0].name, "surface/as_emission_surface" )
 		self.assertEqual( network[0].type, "osl:shader" )
-		self.assertEqual( network[0].parameters["Color"].value, IECore.Color3f( 1, 0, 0 ) )
+		self.assertEqual( network[0].parameters["Color"].value, imath.Color3f( 1, 0, 0 ) )
 
 		self.assertEqual( network[1].name, "material/as_material_builder" )
 		self.assertEqual( network[1].type, "osl:surface" )

--- a/python/GafferArnoldTest/ArnoldLightTest.py
+++ b/python/GafferArnoldTest/ArnoldLightTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import arnold
+import imath
 
 import IECore
 import IECoreScene
@@ -85,7 +86,7 @@ class ArnoldLightTest( GafferSceneTest.SceneTestCase ) :
 		# it and is the preferred way
 		s2 = GafferArnold.ArnoldShader()
 		s2.loadShader( "matte" )
-		s2["parameters"]["color"].setValue( IECore.Color4f( 0, 1, 0, 0.5 ) )
+		s2["parameters"]["color"].setValue( imath.Color4f( 0, 1, 0, 0.5 ) )
 
 		l = GafferArnold.ArnoldLight()
 		l.loadShader( "skydome_light" )
@@ -97,7 +98,7 @@ class ArnoldLightTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( network[0].name, "physical_sky" )
 		self.assertEqual( network[0].parameters["intensity"].value, 2 )
 		self.assertEqual( network[1].name, "matte" )
-		self.assertEqual( network[1].parameters["color"].value, IECore.Color4f( 0, 1, 0, 0.5 ) )
+		self.assertEqual( network[1].parameters["color"].value, imath.Color4f( 0, 1, 0, 0.5 ) )
 		self.assertEqual( network[2].parameters["color"].value, "link:" + network[0].parameters["__handle"].value )
 		self.assertEqual( network[2].parameters["shader"].value, "link:" + network[1].parameters["__handle"].value )
 

--- a/python/GafferArnoldTest/ArnoldMeshLightTest.py
+++ b/python/GafferArnoldTest/ArnoldMeshLightTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -81,12 +83,12 @@ class ArnoldMeshLightTest( GafferSceneTest.SceneTestCase ) :
 		l["filter"].setInput( f["out"] )
 
 		l["parameters"]["intensity"].setValue( 10 )
-		l["parameters"]["color"].setValue( IECore.Color3f( 1, 0, 0 ) )
+		l["parameters"]["color"].setValue( imath.Color3f( 1, 0, 0 ) )
 
 		shaders = l["out"].attributes( "/sphere" )["ai:light"]
 		self.assertEqual( len( shaders ), 1 )
 		self.assertEqual( shaders[0].parameters["intensity"].value, 10 )
-		self.assertEqual( shaders[0].parameters["color"].value, IECore.Color3f( 1, 0, 0 ) )
+		self.assertEqual( shaders[0].parameters["color"].value, imath.Color3f( 1, 0, 0 ) )
 
 	def testCameraVisibility( self ) :
 

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -42,6 +42,7 @@ import subprocess32 as subprocess
 import threading
 
 import arnold
+import imath
 
 import IECore
 import IECoreScene
@@ -304,7 +305,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 	@staticmethod
 	def __m44f( m ) :
 
-		return IECore.M44f( *[ i for row in m.data for i in row ] )
+		return imath.M44f( *[ i for row in m.data for i in row ] )
 
 	def testTransformMotion( self ) :
 
@@ -487,7 +488,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["options"] = GafferScene.StandardOptions()
 		s["options"]["in"].setInput( s["camera"]["out"] )
 		s["options"]["options"]["renderResolution"]["enabled"].setValue( True )
-		s["options"]["options"]["renderResolution"]["value"].setValue( IECore.V2i( 200, 100 ) )
+		s["options"]["options"]["renderResolution"]["value"].setValue( imath.V2i( 200, 100 ) )
 		s["options"]["options"]["resolutionMultiplier"]["enabled"].setValue( True )
 		s["options"]["options"]["resolutionMultiplier"]["value"].setValue( 2 )
 
@@ -552,7 +553,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		# Apply Crop Window
 		s["options"]["options"]["renderCropWindow"]["enabled"].setValue( True )
-		s["options"]["options"]["renderCropWindow"]["value"].setValue( IECore.Box2f( IECore.V2f( 0.25, 0.5 ), IECore.V2f( 0.75, 1.0 ) ) )
+		s["options"]["options"]["renderCropWindow"]["value"].setValue( imath.Box2f( imath.V2f( 0.25, 0.5 ), imath.V2f( 0.75, 1.0 ) ) )
 
 		s["render"]["task"].execute()
 
@@ -568,7 +569,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( arnold.AiNodeGetInt( options, "region_max_y" ), 479 )
 
 		# Test Empty Crop Window
-		s["options"]["options"]["renderCropWindow"]["value"].setValue( IECore.Box2f() )
+		s["options"]["options"]["renderCropWindow"]["value"].setValue( imath.Box2f() )
 
 		s["render"]["task"].execute()
 

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -37,6 +37,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -89,14 +90,14 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		n.loadShader( "wireframe" )
 
 		n["parameters"]["line_width"].setValue( 10 )
-		n["parameters"]["fill_color"].setValue( IECore.Color3f( .25, .5, 1 ) )
+		n["parameters"]["fill_color"].setValue( imath.Color3f( .25, .5, 1 ) )
 		n["parameters"]["raster_space"].setValue( False )
 		n["parameters"]["edge_type"].setValue( "polygons" )
 
 		s = n.attributes()["ai:surface"][0]
 		self.assertEqual( s.parameters["line_width"], IECore.FloatData( 10 ) )
-		self.assertEqual( s.parameters["fill_color"], IECore.Color3fData( IECore.Color3f( .25, .5, 1 ) ) )
-		self.assertEqual( s.parameters["line_color"], IECore.Color3fData( IECore.Color3f( 0 ) ) )
+		self.assertEqual( s.parameters["fill_color"], IECore.Color3fData( imath.Color3f( .25, .5, 1 ) ) )
+		self.assertEqual( s.parameters["line_color"], IECore.Color3fData( imath.Color3f( 0 ) ) )
 		self.assertEqual( s.parameters["raster_space"], IECore.BoolData( False ) )
 		self.assertEqual( s.parameters["edge_type"], IECore.StringData( "polygons" ) )
 
@@ -168,7 +169,7 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 
 		f = GafferArnold.ArnoldShader()
 		f.loadShader( "flat" )
-		f["parameters"]["color"].setValue( IECore.Color3f( 1, 1, 0 ) )
+		f["parameters"]["color"].setValue( imath.Color3f( 1, 1, 0 ) )
 
 		s = GafferArnold.ArnoldShader()
 		s.loadShader( "utility" )
@@ -194,10 +195,10 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 
 		mesh = r.object(
 			"mesh",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes( s.attributes() )
 		)
-		mesh.transform( IECore.M44f().translate( IECore.V3f( 0, 0, -5 ) ) )
+		mesh.transform( imath.M44f().translate( imath.V3f( 0, 0, -5 ) ) )
 
 		r.render()
 
@@ -206,7 +207,7 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 
 		sampler = GafferImage.ImageSampler()
 		sampler["image"].setInput( image["out"] )
-		sampler["pixel"].setValue( IECore.V2f( 320, 240 ) )
+		sampler["pixel"].setValue( imath.V2f( 320, 240 ) )
 
 		self.assertAlmostEqual( sampler["color"]["r"].getValue(), 1, 5 )
 		self.assertAlmostEqual( sampler["color"]["g"].getValue(), 1, 5 )
@@ -294,13 +295,13 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		s = GafferArnold.ArnoldShader()
 		s.loadShader( "add" )
 
-		s["parameters"]["input1"].setValue( IECore.Color3f( 0.1, 0.2, 0.3 ) )
+		s["parameters"]["input1"].setValue( imath.Color3f( 0.1, 0.2, 0.3 ) )
 		s["parameters"]["input2"].setInput( s["parameters"]["input1"] )
 
 		shader = s.attributes()["ai:surface"][0]
 
-		self.assertEqual( shader.parameters["input1"].value, IECore.Color3f( 0.1, 0.2, 0.3 ) )
-		self.assertEqual( shader.parameters["input2"].value, IECore.Color3f( 0.1, 0.2, 0.3 ) )
+		self.assertEqual( shader.parameters["input1"].value, imath.Color3f( 0.1, 0.2, 0.3 ) )
+		self.assertEqual( shader.parameters["input2"].value, imath.Color3f( 0.1, 0.2, 0.3 ) )
 
 	def testDisabling( self ) :
 
@@ -512,8 +513,8 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		image.loadShader( "image" )
 
 		image["parameters"]["swap_st"].setValue( True )
-		image["parameters"]["uvcoords"].setValue( IECore.V2f( 0.5, 1 ) )
-		image["parameters"]["missing_texture_color"].setValue( IECore.Color4f( 0.25, 0.5, 0.75, 1 ) )
+		image["parameters"]["uvcoords"].setValue( imath.V2f( 0.5, 1 ) )
+		image["parameters"]["missing_texture_color"].setValue( imath.Color4f( 0.25, 0.5, 0.75, 1 ) )
 		image["parameters"]["start_channel"].setValue( 1 )
 		image["parameters"]["swrap"].setValue( "black" )
 
@@ -522,7 +523,7 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 
 		lambert["parameters"]["Kd"].setValue( 0.25 )
 		lambert["parameters"]["Kd_color"].setInput( image["out"] )
-		lambert["parameters"]["opacity"].setValue( IECore.Color3f( 0.1 ) )
+		lambert["parameters"]["opacity"].setValue( imath.Color3f( 0.1 ) )
 
 		originalImagePlugs = image.children()
 		originalImageParameterPlugs = image["parameters"].children()
@@ -535,8 +536,8 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		def assertValuesWereKept() :
 
 			self.assertEqual( image["parameters"]["swap_st"].getValue(), True )
-			self.assertEqual( image["parameters"]["uvcoords"].getValue(), IECore.V2f( 0.5, 1 ) )
-			self.assertEqual( image["parameters"]["missing_texture_color"].getValue(), IECore.Color4f( 0.25, 0.5, 0.75, 1 ) )
+			self.assertEqual( image["parameters"]["uvcoords"].getValue(), imath.V2f( 0.5, 1 ) )
+			self.assertEqual( image["parameters"]["missing_texture_color"].getValue(), imath.Color4f( 0.25, 0.5, 0.75, 1 ) )
 			self.assertEqual( image["parameters"]["start_channel"].getValue(), 1 )
 			self.assertEqual( image["parameters"]["swrap"].getValue(), "black" )
 
@@ -545,7 +546,7 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 
 			self.assertEqual( lambert["parameters"]["Kd"].getValue(), 0.25 )
 			self.assertTrue( lambert["parameters"]["Kd_color"].getInput().isSame( image["out"] ) )
-			self.assertEqual( lambert["parameters"]["opacity"].getValue(), IECore.Color3f( 0.1 ) )
+			self.assertEqual( lambert["parameters"]["opacity"].getValue(), imath.Color3f( 0.1 ) )
 
 			self.assertEqual( lambert.children(), originalLambertPlugs )
 			self.assertEqual( lambert["parameters"].children(), originalLambertParameterPlugs )
@@ -584,11 +585,11 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 
 		assertParametersEqual( shader, switch )
 
-		shader["parameters"]["input1"].setValue( IECore.Color4f( 0.25 ) )
+		shader["parameters"]["input1"].setValue( imath.Color4f( 0.25 ) )
 
 		shader.loadShader( "mix", keepExistingValues = True )
 		assertParametersEqual( shader, mix, ignore = [ "input1" ] )
-		self.assertEqual( shader["parameters"]["input1"].getValue(), IECore.Color4f( 0.25 ) )
+		self.assertEqual( shader["parameters"]["input1"].getValue(), imath.Color4f( 0.25 ) )
 
 		shader.loadShader( "switch_rgba", keepExistingValues = False )
 		assertParametersEqual( shader, switch )
@@ -616,7 +617,7 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 
 			n = GafferArnold.ArnoldShader()
 			n.loadShader( "flat" )
-			self.assertEqual( n["out"].defaultValue(), IECore.Color3f( 0 ) )
+			self.assertEqual( n["out"].defaultValue(), imath.Color3f( 0 ) )
 
 	def testRecoverFromIncorrectSerialisedDefaultValue( self ) :
 
@@ -633,12 +634,12 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		# bug introduced in 0.28.2.0.
 		s["n1"]["out"] = Gaffer.Color3fPlug(
 			direction = Gaffer.Plug.Direction.Out,
-			defaultValue = IECore.Color3f( -1 ),
+			defaultValue = imath.Color3f( -1 ),
 			flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
 		)
 		s["n2"]["out"] = Gaffer.Color3fPlug(
 			direction = Gaffer.Plug.Direction.Out,
-			defaultValue = IECore.Color3f( -1 ),
+			defaultValue = imath.Color3f( -1 ),
 			flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
 		)
 
@@ -650,7 +651,7 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 
-		self.assertEqual( s2["n1"]["out"].defaultValue(), IECore.Color3f( 0 ) )
+		self.assertEqual( s2["n1"]["out"].defaultValue(), imath.Color3f( 0 ) )
 		self.assertTrue( s2["n2"]["parameters"]["color"].getInput().isSame( s2["n1"]["out"] ) )
 		self.assertTrue( s2["a"]["shader"].getInput().isSame( s2["n2"]["out"] ) )
 
@@ -662,7 +663,7 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		f = GafferArnold.ArnoldShader()
 		f.loadShader( "flat" )
 
-		f["parameters"]["color"].setValue( IECore.Color3f( 1, 2, 3 ) )
+		f["parameters"]["color"].setValue( imath.Color3f( 1, 2, 3 ) )
 		s["parameters"]["specular_color"].setInput( f["out"] )
 
 		attributesHash = s.attributesHash()
@@ -700,15 +701,15 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 
 		f1 = GafferArnold.ArnoldShader( "f1" )
 		f1.loadShader( "flat" )
-		f1["parameters"]["color"].setValue( IECore.Color3f( 0 ) )
+		f1["parameters"]["color"].setValue( imath.Color3f( 0 ) )
 
 		f2 = GafferArnold.ArnoldShader( "f2" )
 		f2.loadShader( "flat" )
-		f2["parameters"]["color"].setValue( IECore.Color3f( 1 ) )
+		f2["parameters"]["color"].setValue( imath.Color3f( 1 ) )
 
 		f3 = GafferArnold.ArnoldShader( "f3" )
 		f3.loadShader( "flat" )
-		f3["parameters"]["color"].setValue( IECore.Color3f( 2 ) )
+		f3["parameters"]["color"].setValue( imath.Color3f( 2 ) )
 
 		for switchType in ( Gaffer.SwitchComputeNode, GafferScene.ShaderSwitch ) :
 
@@ -725,7 +726,7 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 
 				network = l.attributes()["ai:surface"]
 				self.assertEqual( len( network ), 2 )
-				self.assertEqual( network[0].parameters["color"].value, IECore.Color3f( index ) )
+				self.assertEqual( network[0].parameters["color"].value, imath.Color3f( index ) )
 
 			for i in range( 0, 3 ) :
 				s["index"].setValue( i )

--- a/python/GafferArnoldTest/ArnoldVDBTest.py
+++ b/python/GafferArnoldTest/ArnoldVDBTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import imath
 
 import IECore
 import IECoreScene
@@ -51,13 +52,13 @@ class ArnoldVDBTest( GafferSceneTest.SceneTestCase ) :
 		# Just an empty procedural at this point.
 		self.assertEqual( v["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "volume" ] ) )
 		self.assertSceneValid( v["out"] )
-		self.assertEqual( v["out"].bound( "/volume" ), IECore.Box3f( IECore.V3f( -0.5 ), IECore.V3f( 0.5 ) ) )
+		self.assertEqual( v["out"].bound( "/volume" ), imath.Box3f( imath.V3f( -0.5 ), imath.V3f( 0.5 ) ) )
 		self.assertTrue( isinstance( v["out"].object( "/volume" ), IECoreScene.ExternalProcedural ) )
 
 		# If we enter a valid vdb filename, then we should get something
 		# with the right bounds, and the right parameters in the procedural.
 		v["fileName"].setValue( os.path.join( os.path.dirname( __file__ ), "volumes", "sphere.vdb" ) )
-		self.assertEqual( v["out"].bound( "/volume" ), IECore.Box3f( IECore.V3f( -1.1, 1.1, -1.1 ), IECore.V3f( 1.1, 2.9, 1.1 ) ) )
+		self.assertEqual( v["out"].bound( "/volume" ), imath.Box3f( imath.V3f( -1.1, 1.1, -1.1 ), imath.V3f( 1.1, 2.9, 1.1 ) ) )
 
 		procedural = v["out"].object( "/volume" )
 		self.assertTrue( isinstance( procedural, IECoreScene.ExternalProcedural ) )

--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -39,6 +39,7 @@ import ctypes
 import unittest
 
 import arnold
+import imath
 
 import IECore
 import IECoreScene
@@ -66,10 +67,10 @@ class RendererTest( GafferTest.TestCase ) :
 
 		o = r.object(
 			"testPlane",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes( IECore.CompoundObject() ),
 		)
-		o.transform( IECore.M44f().translate( IECore.V3f( 1, 2, 3 ) ) )
+		o.transform( imath.M44f().translate( imath.V3f( 1, 2, 3 ) ) )
 		del o
 
 		r.render()
@@ -94,8 +95,8 @@ class RendererTest( GafferTest.TestCase ) :
 			"testCamera",
 			IECoreScene.Camera(
 				parameters = {
-					"resolution" : IECore.V2i( 2000, 1000 ),
-					"renderRegion" : IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 1999, 749 ) ),
+					"resolution" : imath.V2i( 2000, 1000 ),
+					"renderRegion" : imath.Box2i( imath.V2i( 0 ), imath.V2i( 1999, 749 ) ),
 				}
 			),
 			r.attributes( IECore.CompoundObject() )
@@ -135,7 +136,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			r.object(
 				"testPlane%d" % i,
-				IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+				IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 				# We keep specifying the same shader, but we'd like the renderer
 				# to be frugal and reuse a single arnold shader on the other side.
 				r.attributes( a )
@@ -169,7 +170,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		o = r.object(
 			"testPlane",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes( IECore.CompoundObject() )
 		)
 
@@ -202,7 +203,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.object(
 			"testPlane1",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes(
 				IECore.CompoundObject( {
 					"ai:surface" : shader1
@@ -217,7 +218,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.object(
 			"testPlane2",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes(
 				IECore.CompoundObject( {
 					"ai:surface" : shader2
@@ -273,7 +274,7 @@ class RendererTest( GafferTest.TestCase ) :
 		for name,s in [ ( "scalarColor", scalarColorShader ), ( "scalarNode", scalarNodeShader ), ( "vectorNode", vectorNodeShader ) ]:
 			r.object(
 				"testPlane_%s" % name,
-				IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+				IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 				r.attributes(
 					IECore.CompoundObject( {
 						"ai:surface" : s
@@ -352,11 +353,11 @@ class RendererTest( GafferTest.TestCase ) :
 		r.light( "untransformedLight", None, lightAttributes )
 
 		staticLight = r.light( "staticLight", None, lightAttributes )
-		staticLight.transform( IECore.M44f().translate( IECore.V3f( 1, 2, 3 ) ) )
+		staticLight.transform( imath.M44f().translate( imath.V3f( 1, 2, 3 ) ) )
 
 		movingLight = r.light( "movingLight", None, lightAttributes )
 		movingLight.transform(
-			[ IECore.M44f().translate( IECore.V3f( 1, 2, 3 ) ), IECore.M44f().translate( IECore.V3f( 4, 5, 6 ) ) ],
+			[ imath.M44f().translate( imath.V3f( 1, 2, 3 ) ), imath.M44f().translate( imath.V3f( 4, 5, 6 ) ) ],
 			[ 2.5, 3.5 ]
 		)
 
@@ -373,10 +374,10 @@ class RendererTest( GafferTest.TestCase ) :
 			movingLight = arnold.AiNodeLookUpByName( "light:movingLight" )
 
 			m = arnold.AiNodeGetMatrix( untransformedLight, "matrix" )
-			self.assertEqual( self.__m44f( m ), IECore.M44f() )
+			self.assertEqual( self.__m44f( m ), imath.M44f() )
 
 			m = arnold.AiNodeGetMatrix( staticLight, "matrix" )
-			self.assertEqual( self.__m44f( m ), IECore.M44f().translate( IECore.V3f( 1, 2, 3 ) ) )
+			self.assertEqual( self.__m44f( m ), imath.M44f().translate( imath.V3f( 1, 2, 3 ) ) )
 
 			self.assertEqual( arnold.AiNodeGetFlt( movingLight, "motion_start" ), 2.5 )
 			self.assertEqual( arnold.AiNodeGetFlt( movingLight, "motion_end" ), 3.5 )
@@ -384,9 +385,9 @@ class RendererTest( GafferTest.TestCase ) :
 			matrices = arnold.AiNodeGetArray( movingLight, "matrix" )
 
 			m = arnold.AiArrayGetMtx( matrices, 0 )
-			self.assertEqual( self.__m44f( m ), IECore.M44f().translate( IECore.V3f( 1, 2, 3 ) ) )
+			self.assertEqual( self.__m44f( m ), imath.M44f().translate( imath.V3f( 1, 2, 3 ) ) )
 			m = arnold.AiArrayGetMtx( matrices, 1 )
-			self.assertEqual( self.__m44f( m ), IECore.M44f().translate( IECore.V3f( 4, 5, 6 ) ) )
+			self.assertEqual( self.__m44f( m ), imath.M44f().translate( imath.V3f( 4, 5, 6 ) ) )
 
 	def testSharedLightAttributes( self ) :
 
@@ -428,7 +429,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.object(
 			"testMesh1",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes( IECore.CompoundObject( {
 				"doubleSided" : IECore.BoolData( True ),
 				"ai:visibility:camera" : IECore.BoolData( False ),
@@ -448,7 +449,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.object(
 			"testMesh2",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes( IECore.CompoundObject( {
 				"doubleSided" : IECore.BoolData( False ),
 				"ai:visibility:camera" : IECore.BoolData( True ),
@@ -468,7 +469,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.object(
 			"testMesh3",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes( IECore.CompoundObject() ),
 		)
 
@@ -569,7 +570,7 @@ class RendererTest( GafferTest.TestCase ) :
 				"rgba",
 				{
 					"filter" : "gaussian",
-					"filterwidth" : IECore.V2f( 3.5 ),
+					"filterwidth" : imath.V2f( 3.5 ),
 				}
 			)
 		)
@@ -657,7 +658,7 @@ class RendererTest( GafferTest.TestCase ) :
 				"rgba",
 				{
 					"filter" : "gaussian",
-					"filterwidth" : IECore.V2f( 3.5 ),
+					"filterwidth" : imath.V2f( 3.5 ),
 					"custom_attributes" : IECore.StringVectorData([ "string 'original data' test" ]),
 					"header:bar" : IECore.BoolData( True ),
 				}
@@ -672,18 +673,18 @@ class RendererTest( GafferTest.TestCase ) :
 				"rgba",
 				{
 					"filter" : "gaussian",
-					"filterwidth" : IECore.V2f( 3.5 ),
+					"filterwidth" : imath.V2f( 3.5 ),
 					"header:foo" : IECore.StringData( "bar" ),
 					"header:bar" : IECore.BoolData( True ),
 					"header:nobar" : IECore.BoolData( False ),
 					"header:floatbar" : IECore.FloatData( 1.618034 ),
 					"header:intbar" : IECore.IntData( 42 ),
-					"header:vec2i" : IECore.V2iData( IECore.V2i( 100 ) ),
-					"header:vec3i" : IECore.V3iData( IECore.V3i( 100 ) ),
-					"header:vec2f" : IECore.V2fData( IECore.V2f( 100 ) ),
-					"header:vec3f" : IECore.V3fData( IECore.V3f( 100 ) ),
-					"header:color3f" : IECore.Color3fData( IECore.Color3f( 100 ) ),
-					"header:color4f" : IECore.Color4fData( IECore.Color4f( 100 ) ),
+					"header:vec2i" : IECore.V2iData( imath.V2i( 100 ) ),
+					"header:vec3i" : IECore.V3iData( imath.V3i( 100 ) ),
+					"header:vec2f" : IECore.V2fData( imath.V2f( 100 ) ),
+					"header:vec3f" : IECore.V3fData( imath.V3f( 100 ) ),
+					"header:color3f" : IECore.Color3fData( imath.Color3f( 100 ) ),
+					"header:color4f" : IECore.Color4fData( imath.Color4f( 100 ) ),
 				}
 			)
 		)
@@ -698,7 +699,7 @@ class RendererTest( GafferTest.TestCase ) :
 					"rgba",
 					{
 						"filter" : "gaussian",
-						"filterwidth" : IECore.V2f( 3.5 ),
+						"filterwidth" : imath.V2f( 3.5 ),
 						"header:foo" : IECore.StringData( "bar" ),
 						"header:bar" : IECore.StringVectorData([ 'one', 'two', 'three' ])  # not supported and should print a warning
 					}
@@ -761,7 +762,7 @@ class RendererTest( GafferTest.TestCase ) :
 			self.temporaryDirectory() + "/test.ass"
 		)
 
-		polyPlane = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		polyPlane = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 		subdivPlane = polyPlane.copy()
 		subdivPlane.interpolation = "catmullClark"
 
@@ -869,7 +870,7 @@ class RendererTest( GafferTest.TestCase ) :
 			self.temporaryDirectory() + "/test.ass"
 		)
 
-		plane = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		plane = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 
 		r.object(
 			"planeDefault",
@@ -905,7 +906,7 @@ class RendererTest( GafferTest.TestCase ) :
 			self.temporaryDirectory() + "/test.ass"
 		)
 
-		subdivPlane = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		subdivPlane = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 		subdivPlane.interpolation = "catmullClark"
 
 		r.object(
@@ -942,7 +943,7 @@ class RendererTest( GafferTest.TestCase ) :
 			self.temporaryDirectory() + "/test.ass"
 		)
 
-		plane = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		plane = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 
 		r.object(
 			"plane",
@@ -973,13 +974,13 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.object(
 			"plane1",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes(
 				IECore.CompoundObject( {
 					"user:testInt" : IECore.IntData( 1 ),
 					"user:testFloat" : IECore.FloatData( 2.5 ),
-					"user:testV3f" : IECore.V3fData( IECore.V3f( 1, 2, 3 ) ),
-					"user:testColor3f" : IECore.Color3fData( IECore.Color3f( 4, 5, 6 ) ),
+					"user:testV3f" : IECore.V3fData( imath.V3f( 1, 2, 3 ) ),
+					"user:testColor3f" : IECore.Color3fData( imath.Color3f( 4, 5, 6 ) ),
 					"user:testString" : IECore.StringData( "we're all doomed" ),
 				} )
 			)
@@ -987,13 +988,13 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.object(
 			"plane2",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes(
 				IECore.CompoundObject( {
 					"user:testInt" : IECore.IntData( 2 ),
 					"user:testFloat" : IECore.FloatData( 25 ),
-					"user:testV3f" : IECore.V3fData( IECore.V3f( 0, 1, 0 ) ),
-					"user:testColor3f" : IECore.Color3fData( IECore.Color3f( 1, 0.5, 0 ) ),
+					"user:testV3f" : IECore.V3fData( imath.V3f( 0, 1, 0 ) ),
+					"user:testColor3f" : IECore.Color3fData( imath.Color3f( 1, 0.5, 0 ) ),
 					"user:testString" : IECore.StringData( "indeed" ),
 				} )
 			)
@@ -1028,7 +1029,7 @@ class RendererTest( GafferTest.TestCase ) :
 			self.temporaryDirectory() + "/test.ass"
 		)
 
-		plane = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		plane = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 		noise = IECore.ObjectVector( [ IECoreScene.Shader( "noise", "ai:displacement", {} ) ] )
 
 		sharedAttributes = r.attributes(
@@ -1105,7 +1106,7 @@ class RendererTest( GafferTest.TestCase ) :
 		)
 
 		meshes = {}
-		meshes["linear"] = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		meshes["linear"] = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 		meshes["catmullClark"] = meshes["linear"].copy()
 		meshes["catmullClark"].interpolation = "catmullClark"
 
@@ -1153,7 +1154,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		l = r.light(
 			"myLight",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes(
 				IECore.CompoundObject( {
 					"ai:light" : IECore.ObjectVector( [ IECoreScene.Shader( "mesh_light", "ai:light" ), ] )
@@ -1198,7 +1199,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		l1 = r.light(
 			"myLight1",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes( IECore.CompoundObject( {
 				"ai:light" : lightShaderNetwork,
 			} ) )
@@ -1207,7 +1208,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		l2 = r.light(
 			"myLight2",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes( IECore.CompoundObject( {
 				"ai:light" : lightShaderNetwork,
 			} ) )
@@ -1270,10 +1271,10 @@ class RendererTest( GafferTest.TestCase ) :
 					"spline" : IECore.SplinefColor3f(
 						IECore.CubicBasisf.bSpline(),
 						[
-							( 0, IECore.Color3f( 0.25 ) ),
-							( 0, IECore.Color3f( 0.25 ) ),
-							( 1, IECore.Color3f( 0.5 ) ),
-							( 1, IECore.Color3f( 0.5 ) ),
+							( 0, imath.Color3f( 0.25 ) ),
+							( 0, imath.Color3f( 0.25 ) ),
+							( 1, imath.Color3f( 0.5 ) ),
+							( 1, imath.Color3f( 0.5 ) ),
 						]
 					),
 					"__handle" : "splineHandle"
@@ -1291,7 +1292,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		o = r.object(
 			"testPlane",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes( IECore.CompoundObject( { "ai:surface" : network } ) )
 		)
 		del o
@@ -1345,7 +1346,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		o = r.object(
 			"testPlane",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes( IECore.CompoundObject( { "osl:shader" : network } ) )
 		)
 		del o
@@ -1390,7 +1391,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			r.object(
 				objectName,
-				IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
+				IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 				r.attributes( attributes ),
 			)
 
@@ -1421,7 +1422,7 @@ class RendererTest( GafferTest.TestCase ) :
 			self.temporaryDirectory() + "/test.ass"
 		)
 
-		curves = IECoreScene.CurvesPrimitive.createBox( IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ) )
+		curves = IECoreScene.CurvesPrimitive.createBox( imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
 
 		defaultAttributes = r.attributes( IECore.CompoundObject() )
 
@@ -1518,7 +1519,7 @@ class RendererTest( GafferTest.TestCase ) :
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
 		)
 
-		polygonMesh = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		polygonMesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 		subdivMesh = polygonMesh.copy()
 		subdivMesh.interpolation = "catmullClark"
 
@@ -1595,11 +1596,11 @@ class RendererTest( GafferTest.TestCase ) :
 
 		primitives = {
 			"sphere" : IECoreScene.SpherePrimitive(),
-			"mesh" : IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
-			"curves" : IECoreScene.CurvesPrimitive.createBox( IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ) ),
+			"mesh" : IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
+			"curves" : IECoreScene.CurvesPrimitive.createBox( imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) ),
 			"volumeProcedural" : IECoreScene.ExternalProcedural(
 				"volume",
-				IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ),
+				imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ),
 			),
 		}
 
@@ -1690,11 +1691,11 @@ class RendererTest( GafferTest.TestCase ) :
 
 		primitives = {
 			"sphere" : IECoreScene.SpherePrimitive(),
-			"mesh" : IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
-			"curves" : IECoreScene.CurvesPrimitive.createBox( IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ) ),
+			"mesh" : IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
+			"curves" : IECoreScene.CurvesPrimitive.createBox( imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) ),
 			"volumeProcedural" : IECoreScene.ExternalProcedural(
 				"volume",
-				IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ),
+				imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ),
 			),
 		}
 
@@ -1789,7 +1790,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			IECoreScene.ExternalProcedural(
 				"volume",
-				IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ),
+				imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ),
 				IECore.CompoundData( {
 					"ai:nodeType" : "volume",
 					"step_size" : 0.25,
@@ -1919,7 +1920,7 @@ class RendererTest( GafferTest.TestCase ) :
 						IECoreScene.SpherePrimitive(),
 						renderer.attributes( IECore.CompoundObject() ),
 					)
-					o.transform( IECore.M44f().translate( IECore.V3f( i, 0, 0 ) ) )
+					o.transform( imath.M44f().translate( imath.V3f( i, 0, 0 ) ) )
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
 			"Arnold",
@@ -2012,7 +2013,7 @@ class RendererTest( GafferTest.TestCase ) :
 	@staticmethod
 	def __m44f( m ) :
 
-		return IECore.M44f( *[ i for row in m.data for i in row ] )
+		return imath.M44f( *[ i for row in m.data for i in row ] )
 
 	def __allNodes( self, type = arnold.AI_NODE_ALL, ignoreBuiltIn = True, nodeEntryName = None ) :
 

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -37,6 +37,7 @@
 import os
 import time
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -100,7 +101,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		script = Gaffer.ScriptNode()
 
 		script["cube"] = GafferScene.Cube()
-		script["cube"]["dimensions"].setValue( IECore.V3f( 2 ) )
+		script["cube"]["dimensions"].setValue( imath.V3f( 2 ) )
 
 		script["meshType"] = GafferScene.MeshType()
 		script["meshType"]["in"].setInput( script["cube"]["out"] )
@@ -130,7 +131,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		script["imageStats"] = GafferImage.ImageStats()
 		script["imageStats"]["in"].setInput( script["objectToImage"]["out"] )
 		script["imageStats"]["channels"].setValue( IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
-		script["imageStats"]["area"].setValue( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 640, 480 ) ) )
+		script["imageStats"]["area"].setValue( imath.Box2i( imath.V2i( 0 ), imath.V2i( 640, 480 ) ) )
 
 		script["render"] = self._createInteractiveRender()
 		script["render"]["in"].setInput( script["outputs"]["out"] )

--- a/python/GafferArnoldTest/LightToCameraTest.py
+++ b/python/GafferArnoldTest/LightToCameraTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import GafferScene
@@ -76,10 +78,10 @@ class LightToCameraTest( GafferSceneTest.SceneTestCase ) :
 			lc["out"].object( "/group/spot1" ).parameters(),
 			IECore.CompoundData( {
 				'projection:fov':IECore.FloatData( 65 ),
-				'clippingPlanes':IECore.V2fData( IECore.V2f( 0.01, 100000 ) ),
+				'clippingPlanes':IECore.V2fData( imath.V2f( 0.01, 100000 ) ),
 				'projection':IECore.StringData( 'perspective' ),
-				'resolutionOverride':IECore.V2iData( IECore.V2i( 512, 512 ) ),
-				'screenWindow':IECore.Box2fData( IECore.Box2f( IECore.V2f( -1, -1 ), IECore.V2f( 1, 1 ) ) )
+				'resolutionOverride':IECore.V2iData( imath.V2i( 512, 512 ) ),
+				'screenWindow':IECore.Box2fData( imath.Box2f( imath.V2f( -1, -1 ), imath.V2f( 1, 1 ) ) )
 			} )
 		)
 
@@ -87,10 +89,10 @@ class LightToCameraTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual(
 			lc["out"].object( "/group/distant1" ).parameters(),
 			IECore.CompoundData( {
-				'clippingPlanes':IECore.V2fData( IECore.V2f( -100000, 100000 ) ),
+				'clippingPlanes':IECore.V2fData( imath.V2f( -100000, 100000 ) ),
 				'projection':IECore.StringData( 'orthographic' ),
-				'resolutionOverride':IECore.V2iData( IECore.V2i( 512, 512 ) ),
-				'screenWindow':IECore.Box2fData( IECore.Box2f( IECore.V2f( -1, -1 ), IECore.V2f( 1, 1 ) ) )
+				'resolutionOverride':IECore.V2iData( imath.V2i( 512, 512 ) ),
+				'screenWindow':IECore.Box2fData( imath.Box2f( imath.V2f( -1, -1 ), imath.V2f( 1, 1 ) ) )
 			} )
 		)
 
@@ -99,7 +101,7 @@ class LightToCameraTest( GafferSceneTest.SceneTestCase ) :
 			lc["out"].object( "/group/env1" ).parameters(),
 			IECore.CompoundData({
 				'projection':IECore.StringData( 'perspective' ),
-				'resolutionOverride':IECore.V2iData( IECore.V2i( 512, 512 ) )
+				'resolutionOverride':IECore.V2iData( imath.V2i( 512, 512 ) )
 			} )
 		)
 

--- a/python/GafferCortexTest/ParameterisedHolderTest.py
+++ b/python/GafferCortexTest/ParameterisedHolderTest.py
@@ -38,6 +38,7 @@
 import os
 import unittest
 import datetime
+import imath
 
 import IECore
 import IECoreImage
@@ -156,19 +157,19 @@ class ParameterisedHolderTest( GafferTest.TestCase ) :
 			parameters["iv"].setValue( IECore.IntVectorData( [ 1, 2, 3 ] ) )
 			parameters["fv"].setValue( IECore.FloatVectorData( [ 1 ] ) )
 			parameters["sv"].setValue( IECore.StringVectorData( [ "a" ] ) )
-			parameters["vv"].setValue( IECore.V3fVectorData( [ IECore.V3f( 1, 2, 3 ) ] ) )
+			parameters["vv"].setValue( IECore.V3fVectorData( [ imath.V3f( 1, 2, 3 ) ] ) )
 
 		self.assertEqual( ph["parameters"]["bv"].getValue(), IECore.BoolVectorData( [ True, False ] ) )
 		self.assertEqual( ph["parameters"]["iv"].getValue(), IECore.IntVectorData( [ 1, 2, 3 ] ) )
 		self.assertEqual( ph["parameters"]["fv"].getValue(), IECore.FloatVectorData( [ 1 ] ) )
 		self.assertEqual( ph["parameters"]["sv"].getValue(), IECore.StringVectorData( [ "a" ] ) )
-		self.assertEqual( ph["parameters"]["vv"].getValue(), IECore.V3fVectorData( [ IECore.V3f( 1, 2, 3 ) ] ) )
+		self.assertEqual( ph["parameters"]["vv"].getValue(), IECore.V3fVectorData( [ imath.V3f( 1, 2, 3 ) ] ) )
 
 		ph["parameters"]["bv"].setValue( IECore.BoolVectorData( [ True, True ] ) )
 		ph["parameters"]["iv"].setValue( IECore.IntVectorData( [ 2, 3, 4 ] ) )
 		ph["parameters"]["fv"].setValue( IECore.FloatVectorData( [ 2 ] ) )
 		ph["parameters"]["sv"].setValue( IECore.StringVectorData( [ "b" ] ) )
-		ph["parameters"]["vv"].setValue( IECore.V3fVectorData( [ IECore.V3f( 10, 20, 30 ) ] ) )
+		ph["parameters"]["vv"].setValue( IECore.V3fVectorData( [ imath.V3f( 10, 20, 30 ) ] ) )
 
 		ph.setParameterisedValues()
 
@@ -176,7 +177,7 @@ class ParameterisedHolderTest( GafferTest.TestCase ) :
 		self.assertEqual( parameters["iv"].getValue(), IECore.IntVectorData( [ 2, 3, 4 ] ) )
 		self.assertEqual( parameters["fv"].getValue(), IECore.FloatVectorData( [ 2 ] ) )
 		self.assertEqual( parameters["sv"].getValue(), IECore.StringVectorData( [ "b" ] ) )
-		self.assertEqual( parameters["vv"].getValue(), IECore.V3fVectorData( [ IECore.V3f( 10, 20, 30 ) ] ) )
+		self.assertEqual( parameters["vv"].getValue(), IECore.V3fVectorData( [ imath.V3f( 10, 20, 30 ) ] ) )
 
 	def testNoHostMapping( self ) :
 
@@ -221,9 +222,9 @@ class ParameterisedHolderTest( GafferTest.TestCase ) :
 		p.parameters().addParameters(
 
 			[
-				IECore.V2iParameter( "v2i", "", IECore.V2i( 1, 2 ) ),
-				IECore.V3fParameter( "v3f", "", IECore.V3f( 1, 2, 3 ) ),
-				IECore.Color4fParameter( "color4f", "", IECore.Color4f( 0.25, 0.5, 0.75, 1 ) ),
+				IECore.V2iParameter( "v2i", "", imath.V2i( 1, 2 ) ),
+				IECore.V3fParameter( "v3f", "", imath.V3f( 1, 2, 3 ) ),
+				IECore.Color4fParameter( "color4f", "", imath.Color4f( 0.25, 0.5, 0.75, 1 ) ),
 			]
 
 		)
@@ -231,23 +232,23 @@ class ParameterisedHolderTest( GafferTest.TestCase ) :
 		ph = GafferCortex.ParameterisedHolderNode()
 		ph.setParameterised( p )
 
-		self.assertEqual( ph["parameters"]["v2i"].defaultValue(), IECore.V2i( 1, 2 ) )
-		self.assertEqual( ph["parameters"]["v3f"].defaultValue(), IECore.V3f( 1, 2, 3 ) )
-		self.assertEqual( ph["parameters"]["color4f"].defaultValue(), IECore.Color4f( 0.25, 0.5, 0.75, 1 ) )
+		self.assertEqual( ph["parameters"]["v2i"].defaultValue(), imath.V2i( 1, 2 ) )
+		self.assertEqual( ph["parameters"]["v3f"].defaultValue(), imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( ph["parameters"]["color4f"].defaultValue(), imath.Color4f( 0.25, 0.5, 0.75, 1 ) )
 
-		self.assertEqual( ph["parameters"]["v2i"].getValue(), IECore.V2i( 1, 2 ) )
-		self.assertEqual( ph["parameters"]["v3f"].getValue(), IECore.V3f( 1, 2, 3 ) )
-		self.assertEqual( ph["parameters"]["color4f"].getValue(), IECore.Color4f( 0.25, 0.5, 0.75, 1 ) )
+		self.assertEqual( ph["parameters"]["v2i"].getValue(), imath.V2i( 1, 2 ) )
+		self.assertEqual( ph["parameters"]["v3f"].getValue(), imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( ph["parameters"]["color4f"].getValue(), imath.Color4f( 0.25, 0.5, 0.75, 1 ) )
 
-		ph["parameters"]["v2i"].setValue( IECore.V2i( 2, 3 ) )
-		ph["parameters"]["v3f"].setValue( IECore.V3f( 4, 5, 6 ) )
-		ph["parameters"]["color4f"].setValue( IECore.Color4f( 0.1, 0.2, 0.3, 0.5 ) )
+		ph["parameters"]["v2i"].setValue( imath.V2i( 2, 3 ) )
+		ph["parameters"]["v3f"].setValue( imath.V3f( 4, 5, 6 ) )
+		ph["parameters"]["color4f"].setValue( imath.Color4f( 0.1, 0.2, 0.3, 0.5 ) )
 
 		ph.setParameterisedValues()
 
-		self.assertEqual( p["v2i"].getTypedValue(), IECore.V2i( 2, 3 ) )
-		self.assertEqual( p["v3f"].getTypedValue(), IECore.V3f( 4, 5, 6 ) )
-		self.assertEqual( p["color4f"].getTypedValue(), IECore.Color4f( 0.1, 0.2, 0.3, 0.5 ) )
+		self.assertEqual( p["v2i"].getTypedValue(), imath.V2i( 2, 3 ) )
+		self.assertEqual( p["v3f"].getTypedValue(), imath.V3f( 4, 5, 6 ) )
+		self.assertEqual( p["color4f"].getTypedValue(), imath.Color4f( 0.1, 0.2, 0.3, 0.5 ) )
 
 	def testParameterHandlerMethod( self ) :
 
@@ -272,9 +273,9 @@ class ParameterisedHolderTest( GafferTest.TestCase ) :
 				IECore.Box3iParameter(
 					"b",
 					"",
-					IECore.Box3i(
-						IECore.V3i( -1, -2, -3 ),
-						IECore.V3i( 2, 1, 3 ),
+					imath.Box3i(
+						imath.V3i( -1, -2, -3 ),
+						imath.V3i( 2, 1, 3 ),
 					),
 				)
 			]
@@ -288,25 +289,25 @@ class ParameterisedHolderTest( GafferTest.TestCase ) :
 		self.failUnless( isinstance( ph["parameters"]["b"]["min"], Gaffer.V3iPlug ) )
 		self.failUnless( isinstance( ph["parameters"]["b"]["max"], Gaffer.V3iPlug ) )
 
-		self.assertEqual( ph["parameters"]["b"]["min"].getValue(), IECore.V3i( -1, -2, -3 ) )
-		self.assertEqual( ph["parameters"]["b"]["max"].getValue(), IECore.V3i( 2, 1, 3 ) )
+		self.assertEqual( ph["parameters"]["b"]["min"].getValue(), imath.V3i( -1, -2, -3 ) )
+		self.assertEqual( ph["parameters"]["b"]["max"].getValue(), imath.V3i( 2, 1, 3 ) )
 
-		ph["parameters"]["b"]["min"].setValue( IECore.V3i( -10, -20, -30 ) )
-		ph["parameters"]["b"]["max"].setValue( IECore.V3i( 10, 20, 30 ) )
+		ph["parameters"]["b"]["min"].setValue( imath.V3i( -10, -20, -30 ) )
+		ph["parameters"]["b"]["max"].setValue( imath.V3i( 10, 20, 30 ) )
 
 		ph.parameterHandler().setParameterValue()
 
 		self.assertEqual(
 			p["b"].getTypedValue(),
-			IECore.Box3i( IECore.V3i( -10, -20, -30 ), IECore.V3i( 10, 20, 30 ) )
+			imath.Box3i( imath.V3i( -10, -20, -30 ), imath.V3i( 10, 20, 30 ) )
 		)
 
 		with ph.parameterModificationContext() :
 
-			p["b"].setTypedValue( IECore.Box3i( IECore.V3i( -2, -4, -6 ), IECore.V3i( 2, 4, 6 ) ) )
+			p["b"].setTypedValue( imath.Box3i( imath.V3i( -2, -4, -6 ), imath.V3i( 2, 4, 6 ) ) )
 
-		self.assertEqual( ph["parameters"]["b"]["min"].getValue(), IECore.V3i( -2, -4, -6 ) )
-		self.assertEqual( ph["parameters"]["b"]["max"].getValue(), IECore.V3i( 2, 4, 6 ) )
+		self.assertEqual( ph["parameters"]["b"]["min"].getValue(), imath.V3i( -2, -4, -6 ) )
+		self.assertEqual( ph["parameters"]["b"]["max"].getValue(), imath.V3i( 2, 4, 6 ) )
 
 	def testAddAndRemoveParameters( self ) :
 

--- a/python/GafferCortexUI/ClassParameterValueWidget.py
+++ b/python/GafferCortexUI/ClassParameterValueWidget.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -76,7 +78,7 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 		result.append( label )
 
 		# space
-		result.append( GafferUI.Spacer( IECore.V2i( 8, 1 ) ) )
+		result.append( GafferUI.Spacer( imath.V2i( 8, 1 ) ) )
 
 		# class button
 		className, classVersion = self._parameter().getClass( True )[1:3]
@@ -92,7 +94,7 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 			result.append( versionButton )
 
 		# a spacer to stop the buttons expanding
-		result.append( GafferUI.Spacer( IECore.V2i( 1, 1 ), IECore.V2i( 9999999, 1 ) ), expand=True )
+		result.append( GafferUI.Spacer( imath.V2i( 1, 1 ), imath.V2i( 9999999, 1 ) ), expand=True )
 
 		return result
 

--- a/python/GafferCortexUI/ClassVectorParameterValueWidget.py
+++ b/python/GafferCortexUI/ClassVectorParameterValueWidget.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -72,7 +74,7 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 		self.__buttonRow.append(
 			GafferUI.MenuButton( image="plus.png", hasFrame=False, menu=GafferUI.Menu( self.__classMenuDefinition() ) )
 		)
-		self.__buttonRow.append( GafferUI.Spacer( IECore.V2i( 1 ), IECore.V2i( 999999, 1 ) ), expand = True )
+		self.__buttonRow.append( GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ) ), expand = True )
 
 		return self.__buttonRow
 
@@ -240,7 +242,7 @@ class _ChildParameterUI( CompoundPlugValueWidget ) :
 			collapseButton = GafferUI.Button( image = "collapsibleArrowRight.png", hasFrame=False )
 			self.__collapseButtonConnection = collapseButton.clickedSignal().connect( Gaffer.WeakMethod( self.__collapseButtonClicked ) )
 
-			GafferUI.Spacer( IECore.V2i( 2 ) )
+			GafferUI.Spacer( imath.V2i( 2 ) )
 
 			# find parameters which belong in the header
 			############################################
@@ -279,7 +281,7 @@ class _ChildParameterUI( CompoundPlugValueWidget ) :
 
 			layerButton.setMenu( GafferUI.Menu( IECore.curry( Gaffer.WeakMethod( compoundPlugValueWidget._layerMenuDefinition ), self.__parameterHandler.parameter().name ) ) )
 
-			GafferUI.Spacer( IECore.V2i( 2 ) )
+			GafferUI.Spacer( imath.V2i( 2 ) )
 
 			# the label
 
@@ -299,7 +301,7 @@ class _ChildParameterUI( CompoundPlugValueWidget ) :
 				GafferCortexUI.ParameterValueWidget.create( self.__parameterHandler.childParameterHandler( parameter ) )
 
 			# prevent things expanding in an unwanted way
-			GafferUI.Spacer( IECore.V2i( 1 ), IECore.V2i( 999999, 1 ), parenting = { "expand" : True } )
+			GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
 		return result
 

--- a/python/GafferCortexUI/CompoundVectorParameterValueWidget.py
+++ b/python/GafferCortexUI/CompoundVectorParameterValueWidget.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -208,7 +210,7 @@ class _PresetEditor( GafferUI.ListContainer ) :
 		self.__menu = GafferUI.Menu( m )
 
 		bound = self.bound()
-		self.__menu.popup( parent = self, position = IECore.V2i( bound.min.x, bound.max.y ) )
+		self.__menu.popup( parent = self, position = imath.V2i( bound.min().x, bound.max().y ) )
 
 		# necessary because the qt edit action tries to give us the focus, and we don't want it -
 		# we want the menu to have it so it can be navigated with the cursor keys.

--- a/python/GafferCortexUI/OpDialogue.py
+++ b/python/GafferCortexUI/OpDialogue.py
@@ -38,6 +38,7 @@
 import sys
 import threading
 import traceback
+import imath
 
 import IECore
 
@@ -158,7 +159,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 
 		with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing = 4 ) as self.__progressUI :
 
-			GafferUI.Spacer( IECore.V2i( 1 ), parenting = { "expand" : True } )
+			GafferUI.Spacer( imath.V2i( 1 ), parenting = { "expand" : True } )
 
 			self.__progressIconFrame = GafferUI.Frame(
 				borderStyle = GafferUI.Frame.BorderStyle.None,
@@ -174,7 +175,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 				}
 			)
 
-			GafferUI.Spacer( IECore.V2i( 250, 1 ), parenting = { "expand"  : True } )
+			GafferUI.Spacer( imath.V2i( 250, 1 ), parenting = { "expand"  : True } )
 
 			with GafferUI.Collapsible( "Details", collapsed = True ) as self.__messageCollapsible :
 

--- a/python/GafferCortexUI/OpPathPreview.py
+++ b/python/GafferCortexUI/OpPathPreview.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -51,7 +53,7 @@ class OpPathPreview( GafferUI.DeferredPathPreview ) :
 
 		with self.__column :
 			# we'll replace this with the op in _deferredUpdate()
-			GafferUI.Spacer( IECore.V2i( 1 ) )
+			GafferUI.Spacer( imath.V2i( 1 ) )
 			button = GafferUI.Button( "Launch" )
 			self.__executeClickedConnection = button.clickedSignal().connect( Gaffer.WeakMethod( self.__executeClicked ) )
 

--- a/python/GafferCortexUI/ParameterisedHolderUI.py
+++ b/python/GafferCortexUI/ParameterisedHolderUI.py
@@ -38,6 +38,7 @@
 import re
 import pipes
 import fnmatch
+import imath
 
 import IECore
 
@@ -78,7 +79,7 @@ class _ParameterisedHolderNodeUI( GafferUI.NodeUI ) :
 
 			if headerVisible :
 				with GafferUI.ListContainer( orientation = GafferUI.ListContainer.Orientation.Horizontal ) :
-					GafferUI.Spacer( IECore.V2i( 10 ), parenting = { "expand"  : True } )
+					GafferUI.Spacer( imath.V2i( 10 ), parenting = { "expand"  : True } )
 					toolButton = GafferCortexUI.ToolParameterValueWidget( self.node().parameterHandler() )
 					toolButton.plugValueWidget().setReadOnly( readOnly )
 					_InfoButton( node )

--- a/python/GafferCortexUITest/ParameterValueWidgetTest.py
+++ b/python/GafferCortexUITest/ParameterValueWidgetTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -84,7 +85,7 @@ class ParameterValueWidgetTest( GafferUITest.TestCase ) :
 	def testCreateAlwaysReturnsParameterValueWidgetInstance( self ) :
 
 		n = Gaffer.Node()
-		p = IECore.V2fParameter( "v", "", IECore.V2f( 1 ) )
+		p = IECore.V2fParameter( "v", "", imath.V2f( 1 ) )
 
 		h = GafferCortex.ParameterHandler.create( p )
 		h.setupPlug( n )

--- a/python/GafferDelightTest/IECoreDelightPreviewTest/RendererTest.py
+++ b/python/GafferDelightTest/IECoreDelightPreviewTest/RendererTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -80,7 +81,7 @@ class RendererTest( GafferTest.TestCase ) :
 				"rgba",
 				{
 					"filter" : "gaussian",
-					"filterwidth" : IECore.V2f( 3.5 ),
+					"filterwidth" : imath.V2f( 3.5 ),
 				}
 			)
 		)
@@ -145,7 +146,7 @@ class RendererTest( GafferTest.TestCase ) :
 					data,
 					{
 						"filter" : "gaussian",
-						"filterwidth" : IECore.V2f( 3.5 ),
+						"filterwidth" : imath.V2f( 3.5 ),
 					}
 				)
 			)
@@ -167,7 +168,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.object(
 			"testPlane",
-			IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ), IECore.V2i( 2, 1 ) ),
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ), imath.V2i( 2, 1 ) ),
 			r.attributes( IECore.CompoundObject() ),
 		)
 
@@ -192,8 +193,8 @@ class RendererTest( GafferTest.TestCase ) :
 		r.object(
 			"testPlane",
 			[
-				IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ),
-				IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -2 ), IECore.V2f( 2 ) ) ),
+				IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
+				IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -2 ), imath.V2f( 2 ) ) ),
 			],
 			[ 0, 1 ],
 			r.attributes( IECore.CompoundObject() ),
@@ -219,7 +220,7 @@ class RendererTest( GafferTest.TestCase ) :
 			self.temporaryDirectory() + "/test.nsi",
 		)
 
-		points = IECoreScene.PointsPrimitive( IECore.V3fVectorData( [ IECore.V3f( x ) for x in range( 0, 4 ) ] ) )
+		points = IECoreScene.PointsPrimitive( IECore.V3fVectorData( [ imath.V3f( x ) for x in range( 0, 4 ) ] ) )
 		points["width"] = IECoreScene.PrimitiveVariable(
 			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
 			IECore.FloatVectorData( [ x + 1 for x in range( 0, 4 ) ] )
@@ -246,7 +247,7 @@ class RendererTest( GafferTest.TestCase ) :
 			self.temporaryDirectory() + "/test.nsi",
 		)
 
-		points = IECoreScene.PointsPrimitive( IECore.V3fVectorData( [ IECore.V3f( x ) for x in range( 0, 4 ) ] ) )
+		points = IECoreScene.PointsPrimitive( IECore.V3fVectorData( [ imath.V3f( x ) for x in range( 0, 4 ) ] ) )
 
 		r.object(
 			"testPoints",
@@ -273,8 +274,8 @@ class RendererTest( GafferTest.TestCase ) :
 			IECore.CubicBasisf.bSpline(),
 			False,
 			IECore.V3fVectorData(
-				[ IECore.V3f( x ) for x in range( 0, 4 ) ] +
-				[ IECore.V3f( -x ) for x in range( 0, 4 ) ]
+				[ imath.V3f( x ) for x in range( 0, 4 ) ] +
+				[ imath.V3f( -x ) for x in range( 0, 4 ) ]
 			)
 		)
 
@@ -405,11 +406,11 @@ class RendererTest( GafferTest.TestCase ) :
 			"testCamera",
 			IECoreScene.Camera(
 				parameters = {
-					"resolution" : IECore.V2i( 2000, 1000 ),
+					"resolution" : imath.V2i( 2000, 1000 ),
 					"projection" : "perspective",
 					"perspective:fov" : 40,
-					"clippingPlanes" : IECore.V2f( 0.25, 10 ),
-					"shutter" : IECore.V2f( 0, 1 ),
+					"clippingPlanes" : imath.V2f( 0.25, 10 ),
+					"shutter" : imath.V2f( 0, 1 ),
 				}
 			),
 			r.attributes( IECore.CompoundObject() )
@@ -437,7 +438,7 @@ class RendererTest( GafferTest.TestCase ) :
 			self.temporaryDirectory() + "/test.nsi",
 		)
 
-		m = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		m = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 		a = r.attributes( IECore.CompoundObject() )
 
 		r.object( "testPlane1", m, a )
@@ -459,14 +460,14 @@ class RendererTest( GafferTest.TestCase ) :
 			self.temporaryDirectory() + "/test.nsi",
 		)
 
-		m = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		m = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 		a = r.attributes( IECore.CompoundObject() )
 
 		r.object( "untransformed", m, a )
-		r.object( "identity", m, a ).transform( IECore.M44f() )
-		r.object( "transformed", m, a ).transform( IECore.M44f().translate( IECore.V3f( 1, 0, 0 ) ) )
+		r.object( "identity", m, a ).transform( imath.M44f() )
+		r.object( "transformed", m, a ).transform( imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) )
 		r.object( "animated", m, a ).transform(
-			[ IECore.M44f().translate( IECore.V3f( x, 0, 0 ) ) for x in range( 0, 2 ) ],
+			[ imath.M44f().translate( imath.V3f( x, 0, 0 ) ) for x in range( 0, 2 ) ],
 			[ 0, 1 ]
 		)
 

--- a/python/GafferDispatch/Wedge.py
+++ b/python/GafferDispatch/Wedge.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import math
+import imath
 
 import IECore
 
@@ -76,10 +77,10 @@ class Wedge( GafferDispatch.TaskContextProcessor ) :
 			defaultValue = IECore.SplinefColor3f(
 				IECore.CubicBasisf.catmullRom(),
 				(
-					( 0, IECore.Color3f( 0 ) ),
-					( 0, IECore.Color3f( 0 ) ),
-					( 1, IECore.Color3f( 1 ) ),
-					( 1, IECore.Color3f( 1 ) ),
+					( 0, imath.Color3f( 0 ) ),
+					( 0, imath.Color3f( 0 ) ),
+					( 1, imath.Color3f( 1 ) ),
+					( 1, imath.Color3f( 1 ) ),
 				)
 			)
 		)

--- a/python/GafferDispatchTest/ExecuteApplicationTest.py
+++ b/python/GafferDispatchTest/ExecuteApplicationTest.py
@@ -38,6 +38,7 @@
 import os
 import subprocess32 as subprocess
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -152,7 +153,7 @@ class ExecuteApplicationTest( GafferTest.TestCase ) :
 
 		prim = IECore.ObjectReader( self.__outputFileSeq.fileNameForFrame( 1 ) ).read()
 		self.failUnless( prim.isInstanceOf( IECoreScene.SpherePrimitive.staticTypeId() ) )
-		self.assertEqual( prim.bound(), IECore.Box3f( IECore.V3f( -5 ), IECore.V3f( 5 ) ) )
+		self.assertEqual( prim.bound(), imath.Box3f( imath.V3f( -5 ), imath.V3f( 5 ) ) )
 		self.assertEqual( prim.thetaMax(), 180 )
 
 	def testErrorReturnStatusForBadContext( self ) :

--- a/python/GafferDispatchTest/PythonCommandTest.py
+++ b/python/GafferDispatchTest/PythonCommandTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import inspect
+import imath
 
 import IECore
 
@@ -79,7 +80,7 @@ class PythonCommandTest( GafferTest.TestCase ) :
 		n = GafferDispatch.PythonCommand()
 		n["variables"].addMember( "testInt", 1 )
 		n["variables"].addMember( "testFloat", 2.5 )
-		n["variables"].addMember( "testColor", IECore.Color3f( 1, 2, 3 ) )
+		n["variables"].addMember( "testColor", imath.Color3f( 1, 2, 3 ) )
 		n["command"].setValue( inspect.cleandoc(
 			"""
 			self.testInt = variables["testInt"]
@@ -92,7 +93,7 @@ class PythonCommandTest( GafferTest.TestCase ) :
 
 		self.assertEqual( n.testInt, 1 )
 		self.assertEqual( n.testFloat, 2.5 )
-		self.assertEqual( n.testColor, IECore.Color3f( 1, 2, 3 ) )
+		self.assertEqual( n.testColor, imath.Color3f( 1, 2, 3 ) )
 
 	def testContextAccess( self ) :
 

--- a/python/GafferDispatchUI/WedgeUI.py
+++ b/python/GafferDispatchUI/WedgeUI.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -296,8 +298,8 @@ class _ValuesPreview( GafferUI.Widget ) :
 		GafferUI.Widget.__init__( self, self.__grid, **kw )
 
 		self.__grid[0,0] =  GafferUI.Spacer(
-			IECore.V2i( GafferUI.PlugWidget.labelWidth(), 1 ),
-			IECore.V2i( GafferUI.PlugWidget.labelWidth(), 1 ),
+			imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ),
+			imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ),
 		)
 		self.__grid[1,0] = previewWidget
 
@@ -368,7 +370,7 @@ class _ColorValuesPreview( _ValuesPreview ) :
 			except :
 				return
 
-		if not len( values ) or not isinstance( values[0], IECore.Color3f ) :
+		if not len( values ) or not isinstance( values[0], imath.Color3f ) :
 			return
 
 		for i in range( 0, max( len( values ), len( self.__row ) ) ) :

--- a/python/GafferImageTest/AtomicFormatPlugTest.py
+++ b/python/GafferImageTest/AtomicFormatPlugTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -68,7 +69,7 @@ class AtomicFormatPlugTest( GafferImageTest.ImageTestCase ) :
 
 	def testOffsetSerialize( self ) :
 
-		format = GafferImage.Format( IECore.Box2i( IECore.V2i( -5, -11 ), IECore.V2i( 13, 19 ) ), .5 )
+		format = GafferImage.Format( imath.Box2i( imath.V2i( -5, -11 ), imath.V2i( 13, 19 ) ), .5 )
 		s = Gaffer.ScriptNode()
 		s["n"] = Gaffer.Node()
 		s["n"]["f"] = GafferImage.AtomicFormatPlug( "testPlug", defaultValue = format, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
@@ -99,13 +100,13 @@ class AtomicFormatPlugTest( GafferImageTest.ImageTestCase ) :
 		s = Gaffer.ScriptNode()
 		s["n"] = Gaffer.Node()
 		s["n"]["p"] = GafferImage.AtomicFormatPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		s["n"]["p"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) ), 2.0 ) )
+		s["n"]["p"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 10 ) ), 2.0 ) )
 		s["n"]["p"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 
-		self.assertEqual( s2["n"]["p"].getValue(), GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) ), 2.0 ) )
+		self.assertEqual( s2["n"]["p"].getValue(), GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 10 ) ), 2.0 ) )
 		self.assertTrue( s2["n"]["p"].getFlags( Gaffer.Plug.Flags.ReadOnly ) )
 
 	def testExpressions( self ) :
@@ -117,11 +118,11 @@ class AtomicFormatPlugTest( GafferImageTest.ImageTestCase ) :
 		s["n2"]["user"]["f"] = GafferImage.AtomicFormatPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
 		s["e"] = Gaffer.Expression()
-		s["e"].setExpression( 'f = parent["n1"]["user"]["f"]; b = f.getDisplayWindow(); b.min -= IECore.V2i( 10 ); b.max += IECore.V2i( 20 ); f.setPixelAspect( 0.5 ); f.setDisplayWindow( b ); parent["n2"]["user"]["f"] = f')
+		s["e"].setExpression( 'f = parent["n1"]["user"]["f"]; b = f.getDisplayWindow(); b.setMin( b.min() - imath.V2i( 10 ) ); b.setMax( b.max() + imath.V2i( 20 ) ); f.setPixelAspect( 0.5 ); f.setDisplayWindow( b ); parent["n2"]["user"]["f"] = f')
 
-		s["n1"]["user"]["f"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 20, 30 ), IECore.V2i( 100, 110 ) ), 1 ) )
+		s["n1"]["user"]["f"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 20, 30 ), imath.V2i( 100, 110 ) ), 1 ) )
 
-		self.assertEqual( s["n2"]["user"]["f"].getValue(), GafferImage.Format( IECore.Box2i( IECore.V2i( 10, 20 ), IECore.V2i( 120, 130 ) ), 0.5 ) )
+		self.assertEqual( s["n2"]["user"]["f"].getValue(), GafferImage.Format( imath.Box2i( imath.V2i( 10, 20 ), imath.V2i( 120, 130 ) ), 0.5 ) )
 
 	def testGetAndSetEmptyFormat( self ) :
 

--- a/python/GafferImageTest/BlurTest.py
+++ b/python/GafferImageTest/BlurTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -52,7 +53,7 @@ class BlurTest( GafferImageTest.ImageTestCase ) :
 
 		b = GafferImage.Blur()
 		b["in"].setInput( c["out"] )
-		b["radius"].setValue( IECore.V2f( 0 ) )
+		b["radius"].setValue( imath.V2f( 0 ) )
 
 		self.assertImageHashesEqual( c["out"], b["out"] )
 		self.assertImagesEqual( c["out"], b["out"] )
@@ -63,31 +64,31 @@ class BlurTest( GafferImageTest.ImageTestCase ) :
 
 		b = GafferImage.Blur()
 		b["in"].setInput( c["out"] )
-		b["radius"].setValue( IECore.V2f( 1 ) )
+		b["radius"].setValue( imath.V2f( 1 ) )
 
 		self.assertEqual( b["out"]["dataWindow"].getValue(), c["out"]["dataWindow"].getValue() )
 
 		b["expandDataWindow"].setValue( True )
 
-		self.assertEqual( b["out"]["dataWindow"].getValue().min, c["out"]["dataWindow"].getValue().min - IECore.V2i( 2 ) )
-		self.assertEqual( b["out"]["dataWindow"].getValue().max, c["out"]["dataWindow"].getValue().max + IECore.V2i( 2 ) )
+		self.assertEqual( b["out"]["dataWindow"].getValue().min(), c["out"]["dataWindow"].getValue().min() - imath.V2i( 2 ) )
+		self.assertEqual( b["out"]["dataWindow"].getValue().max(), c["out"]["dataWindow"].getValue().max() + imath.V2i( 2 ) )
 
 	def testOnePixelBlur( self ) :
 
 		constant = GafferImage.Constant()
-		constant["color"].setValue( IECore.Color4f( 1 ) )
+		constant["color"].setValue( imath.Color4f( 1 ) )
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput( constant["out"] )
-		crop["area"].setValue( IECore.Box2i( IECore.V2i( 10 ), IECore.V2i( 11 ) ) )
+		crop["area"].setValue( imath.Box2i( imath.V2i( 10 ), imath.V2i( 11 ) ) )
 		crop["affectDisplayWindow"].setValue( False )
 
 		blur = GafferImage.Blur()
 		blur["in"].setInput( crop["out"] )
-		blur["radius"].setValue( IECore.V2f( 1 ) )
+		blur["radius"].setValue( imath.V2f( 1 ) )
 		blur["expandDataWindow"].setValue( True )
 
-		sampler = GafferImage.Sampler( blur["out"], "R", IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 20 ) ) )
+		sampler = GafferImage.Sampler( blur["out"], "R", imath.Box2i( imath.V2i( 0 ), imath.V2i( 20 ) ) )
 
 		# Centre is brightest
 		self.assertGreater( sampler.sample( 10, 10 ), sampler.sample( 11, 10 ) )
@@ -108,11 +109,11 @@ class BlurTest( GafferImageTest.ImageTestCase ) :
 	def testEnergyPreservation( self ) :
 
 		constant = GafferImage.Constant()
-		constant["color"].setValue( IECore.Color4f( 1 ) )
+		constant["color"].setValue( imath.Color4f( 1 ) )
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput( constant["out"] )
-		crop["area"].setValue( IECore.Box2i( IECore.V2i( 10 ), IECore.V2i( 11 ) ) )
+		crop["area"].setValue( imath.Box2i( imath.V2i( 10 ), imath.V2i( 11 ) ) )
 		crop["affectDisplayWindow"].setValue( False )
 
 		blur = GafferImage.Blur()
@@ -121,23 +122,23 @@ class BlurTest( GafferImageTest.ImageTestCase ) :
 
 		stats = GafferImage.ImageStats()
 		stats["in"].setInput( blur["out"] )
-		stats["area"].setValue( IECore.Box2i( IECore.V2i( 5 ), IECore.V2i( 15 ) ) )
+		stats["area"].setValue( imath.Box2i( imath.V2i( 5 ), imath.V2i( 15 ) ) )
 
 		for i in range( 0, 10 ) :
 
-			blur["radius"].setValue( IECore.V2f( i * 0.5 ) )
+			blur["radius"].setValue( imath.V2f( i * 0.5 ) )
 			self.assertAlmostEqual( stats["average"]["r"].getValue(), 1 / 100., delta = 0.0001 )
 
 	def testBlurRange( self ):
 
 		constant = GafferImage.Constant()
 		constant["format"].setValue( GafferImage.Format( 5, 5, 1.000 ) )
-		constant["color"].setValue( IECore.Color4f( 1, 1, 1, 1 ) )
+		constant["color"].setValue( imath.Color4f( 1, 1, 1, 1 ) )
 
 
 
 		cropDot = GafferImage.Crop()
-		cropDot["area"].setValue( IECore.Box2i( IECore.V2i( 2, 2 ), IECore.V2i( 3, 3 ) ) )
+		cropDot["area"].setValue( imath.Box2i( imath.V2i( 2, 2 ), imath.V2i( 3, 3 ) ) )
 		cropDot["affectDisplayWindow"].setValue( False )
 		cropDot["in"].setInput( constant["out"] )
 
@@ -162,7 +163,7 @@ class BlurTest( GafferImageTest.ImageTestCase ) :
 		merge["in"]["in1"].setInput( imageLoop["previous"] )
 
 		offset = GafferImage.Offset()
-		offset["offset"].setValue( IECore.V2i( -5, 0 ) )
+		offset["offset"].setValue( imath.V2i( -5, 0 ) )
 		offset["in"].setInput( merge["out"] )
 
 		imageLoop["next"].setInput( offset["out"] )

--- a/python/GafferImageTest/BufferAlgoTest.py
+++ b/python/GafferImageTest/BufferAlgoTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -46,36 +47,36 @@ class BufferAlgoTest( GafferImageTest.ImageTestCase ) :
 
 	def testEmpty( self ) :
 
-		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i() ) )
-		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 0 ) ) ) )
-		self.assertFalse( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 1 ) ) ) )
-		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 2147483646 ), IECore.V2i( -2147483646 ) ) ) )
-		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( -2147483647 ) ) ) )
-		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 2147483647 ), IECore.V2i( 0 ) ) ) )
-		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( -1 ), IECore.V2i( -2147483647 ) ) ) )
-		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 2147483647 ), IECore.V2i( 1 ) ) ) )
-		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 1 ), IECore.V2i( -2147483647 ) ) ) )
-		self.assertTrue( GafferImage.BufferAlgo.empty( IECore.Box2i( IECore.V2i( 2147483647 ), IECore.V2i( -1 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( imath.Box2i() ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( imath.Box2i( imath.V2i( 0 ), imath.V2i( 0 ) ) ) )
+		self.assertFalse( GafferImage.BufferAlgo.empty( imath.Box2i( imath.V2i( 0 ), imath.V2i( 1 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( imath.Box2i( imath.V2i( 2147483646 ), imath.V2i( -2147483646 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( imath.Box2i( imath.V2i( 0 ), imath.V2i( -2147483647 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( imath.Box2i( imath.V2i( 2147483647 ), imath.V2i( 0 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( imath.Box2i( imath.V2i( -1 ), imath.V2i( -2147483647 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( imath.Box2i( imath.V2i( 2147483647 ), imath.V2i( 1 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( imath.Box2i( imath.V2i( 1 ), imath.V2i( -2147483647 ) ) ) )
+		self.assertTrue( GafferImage.BufferAlgo.empty( imath.Box2i( imath.V2i( 2147483647 ), imath.V2i( -1 ) ) ) )
 
 	def testIntersects( self ) :
 
 		self.assertFalse(
 			GafferImage.BufferAlgo.intersects(
-				IECore.Box2i(), IECore.Box2i()
+				imath.Box2i(), imath.Box2i()
 			)
 		)
 
 		self.assertFalse(
 			GafferImage.BufferAlgo.intersects(
-				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) ),
-				IECore.Box2i( IECore.V2i( 10 ), IECore.V2i( 20 ) ),
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( 10 ) ),
+				imath.Box2i( imath.V2i( 10 ), imath.V2i( 20 ) ),
 			)
 		)
 
 		self.assertTrue(
 			GafferImage.BufferAlgo.intersects(
-				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) ),
-				IECore.Box2i( IECore.V2i( 9 ), IECore.V2i( 20 ) ),
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( 10 ) ),
+				imath.Box2i( imath.V2i( 9 ), imath.V2i( 20 ) ),
 			)
 		)
 
@@ -83,12 +84,12 @@ class BufferAlgoTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual(
 			GafferImage.BufferAlgo.intersection(
-				IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 9, 10 ) ),
-				IECore.Box2i( IECore.V2i( 2, 0 ), IECore.V2i( 8, 29 ) ),
+				imath.Box2i( imath.V2i( 1, 2 ), imath.V2i( 9, 10 ) ),
+				imath.Box2i( imath.V2i( 2, 0 ), imath.V2i( 8, 29 ) ),
 			),
-			IECore.Box2i(
-				IECore.V2i( 2, 2 ),
-				IECore.V2i( 8, 10 )
+			imath.Box2i(
+				imath.V2i( 2, 2 ),
+				imath.V2i( 8, 10 )
 			)
 		)
 
@@ -96,29 +97,29 @@ class BufferAlgoTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertFalse(
 			GafferImage.BufferAlgo.contains(
-				IECore.Box2i(),
-				IECore.V2i( 0 )
+				imath.Box2i(),
+				imath.V2i( 0 )
 			)
 		)
 
 		self.assertFalse(
 			GafferImage.BufferAlgo.contains(
-				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 0 ) ),
-				IECore.V2i( 0 )
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( 0 ) ),
+				imath.V2i( 0 )
 			)
 		)
 
 		self.assertFalse(
 			GafferImage.BufferAlgo.contains(
-				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 1 ) ),
-				IECore.V2i( 1 )
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( 1 ) ),
+				imath.V2i( 1 )
 			)
 		)
 
 		self.assertTrue(
 			GafferImage.BufferAlgo.contains(
-				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 1 ) ),
-				IECore.V2i( 0 )
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( 1 ) ),
+				imath.V2i( 0 )
 			)
 		)
 
@@ -126,42 +127,42 @@ class BufferAlgoTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual(
 			GafferImage.BufferAlgo.clamp(
-				IECore.V2i( 5, 6 ),
-				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) )
+				imath.V2i( 5, 6 ),
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( 10 ) )
 			),
-			IECore.V2i( 5, 6 )
+			imath.V2i( 5, 6 )
 		)
 
 		self.assertEqual(
 			GafferImage.BufferAlgo.clamp(
-				IECore.V2i( 10, 6 ),
-				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) )
+				imath.V2i( 10, 6 ),
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( 10 ) )
 			),
-			IECore.V2i( 9, 6 )
+			imath.V2i( 9, 6 )
 		)
 
 		self.assertEqual(
 			GafferImage.BufferAlgo.clamp(
-				IECore.V2i( 0, 6 ),
-				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) )
+				imath.V2i( 0, 6 ),
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( 10 ) )
 			),
-			IECore.V2i( 0, 6 )
+			imath.V2i( 0, 6 )
 		)
 
 		self.assertEqual(
 			GafferImage.BufferAlgo.clamp(
-				IECore.V2i( 5, -1 ),
-				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) )
+				imath.V2i( 5, -1 ),
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( 10 ) )
 			),
-			IECore.V2i( 5, 0 )
+			imath.V2i( 5, 0 )
 		)
 
 		self.assertEqual(
 			GafferImage.BufferAlgo.clamp(
-				IECore.V2i( 5, 10 ),
-				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) )
+				imath.V2i( 5, 10 ),
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( 10 ) )
 			),
-			IECore.V2i( 5, 9 )
+			imath.V2i( 5, 9 )
 		)
 
 if __name__ == "__main__":

--- a/python/GafferImageTest/CDLTest.py
+++ b/python/GafferImageTest/CDLTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -59,17 +60,17 @@ class CDLTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual( n["out"].image(), o["out"].image() )
 
-		o['slope'].setValue( IECore.Color3f( 1, 2, 3 ) )
+		o['slope'].setValue( imath.Color3f( 1, 2, 3 ) )
 
 		slope = o["out"].image()
 		self.assertNotEqual( orig, slope )
 
-		o["offset"].setValue( IECore.Color3f( 1, 2, 3 ) )
+		o["offset"].setValue( imath.Color3f( 1, 2, 3 ) )
 		offset = o["out"].image()
 		self.assertNotEqual( orig, offset )
 		self.assertNotEqual( slope, offset )
 
-		o["power"].setValue( IECore.Color3f( 1, 2, 3 ) )
+		o["power"].setValue( imath.Color3f( 1, 2, 3 ) )
 		power = o["out"].image()
 		self.assertNotEqual( orig, power )
 		self.assertNotEqual( slope, power )
@@ -100,7 +101,7 @@ class CDLTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual( n["out"].image(), o["out"].image() )
 
-		o['slope'].setValue( IECore.Color3f( 1, 2, 3 ) )
+		o['slope'].setValue( imath.Color3f( 1, 2, 3 ) )
 
 		self.assertNotEqual( n["out"].image(), o["out"].image() )
 
@@ -130,7 +131,7 @@ class CDLTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual( i["out"].imageHash(), o["out"].imageHash() )
 
-		o['slope'].setValue( IECore.Color3f( 1, 2, 3 ) )
+		o['slope'].setValue( imath.Color3f( 1, 2, 3 ) )
 
 		self.assertNotEqual( i["out"].imageHash(), o["out"].imageHash() )
 
@@ -141,16 +142,16 @@ class CDLTest( GafferImageTest.ImageTestCase ) :
 
 		o = GafferImage.CDL()
 		o["in"].setInput( i["out"] )
-		o['slope'].setValue( IECore.Color3f( 1, 2, 3 ) )
+		o['slope'].setValue( imath.Color3f( 1, 2, 3 ) )
 
 		self.assertNotEqual(
-			o["out"].channelDataHash( "R", IECore.V2i( 0 ) ),
-			o["out"].channelDataHash( "G", IECore.V2i( 0 ) )
+			o["out"].channelDataHash( "R", imath.V2i( 0 ) ),
+			o["out"].channelDataHash( "G", imath.V2i( 0 ) )
 		)
 
 		self.assertNotEqual(
-			o["out"].channelData( "R", IECore.V2i( 0 ) ),
-			o["out"].channelData( "G", IECore.V2i( 0 ) )
+			o["out"].channelData( "R", imath.V2i( 0 ) ),
+			o["out"].channelData( "G", imath.V2i( 0 ) )
 		)
 
 	def testPassThrough( self ) :
@@ -160,7 +161,7 @@ class CDLTest( GafferImageTest.ImageTestCase ) :
 
 		o = GafferImage.CDL()
 		o["in"].setInput( i["out"] )
-		o['slope'].setValue( IECore.Color3f( 1, 2, 3 ) )
+		o['slope'].setValue( imath.Color3f( 1, 2, 3 ) )
 
 		self.assertEqual( i["out"]["format"].hash(), o["out"]["format"].hash() )
 		self.assertEqual( i["out"]["dataWindow"].hash(), o["out"]["dataWindow"].hash() )
@@ -175,10 +176,10 @@ class CDLTest( GafferImageTest.ImageTestCase ) :
 	def testMultipleLayers( self ) :
 
 		main = GafferImage.Constant()
-		main["color"].setValue( IECore.Color4f( 1, 0.5, 0.25, 1 ) )
+		main["color"].setValue( imath.Color4f( 1, 0.5, 0.25, 1 ) )
 
 		diffuse = GafferImage.Constant()
-		diffuse["color"].setValue( IECore.Color4f( 0.25, 0.5, 0.75, 1 ) )
+		diffuse["color"].setValue( imath.Color4f( 0.25, 0.5, 0.75, 1 ) )
 		diffuse["layer"].setValue( "diffuse" )
 
 		m = GafferImage.CopyChannels()
@@ -193,12 +194,12 @@ class CDLTest( GafferImageTest.ImageTestCase ) :
 
 		mainCDLSampler = GafferImage.ImageSampler()
 		mainCDLSampler["image"].setInput( cdl["out"] )
-		mainCDLSampler["pixel"].setValue( IECore.V2f( 0.5 ) )
+		mainCDLSampler["pixel"].setValue( imath.V2f( 0.5 ) )
 		mainCDLSampler["channels"].setValue( IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
 
 		diffuseCDLSampler = GafferImage.ImageSampler()
 		diffuseCDLSampler["image"].setInput( cdl["out"] )
-		diffuseCDLSampler["pixel"].setValue( IECore.V2f( 0.5 ) )
+		diffuseCDLSampler["pixel"].setValue( imath.V2f( 0.5 ) )
 		diffuseCDLSampler["channels"].setValue( IECore.StringVectorData( [ "diffuse." + x for x in "RGBA" ] ) )
 
 		self.assertEqual( mainCDLSampler["color"].getValue(), main["color"].getValue() )

--- a/python/GafferImageTest/CatalogueTest.py
+++ b/python/GafferImageTest/CatalogueTest.py
@@ -36,6 +36,7 @@
 
 import os
 import threading
+import imath
 
 import IECore
 
@@ -165,7 +166,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		c2["enabled"].setValue( False )
 		self.assertNotEqual( c2["out"]["format"].getValue(), c1["out"]["format"].getValue() )
 		self.assertNotEqual( c2["out"]["dataWindow"].getValue(), c1["out"]["dataWindow"].getValue() )
-		self.assertEqual( c2["out"]["dataWindow"].getValue(), IECore.Box2i() )
+		self.assertEqual( c2["out"]["dataWindow"].getValue(), imath.Box2i() )
 
 		disabledConstant = GafferImage.Constant()
 		disabledConstant["enabled"].setValue( False )
@@ -201,11 +202,11 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
 		aov1 = GafferImage.Constant()
 		aov1["format"].setValue( GafferImage.Format( 100, 100 ) )
-		aov1["color"].setValue( IECore.Color4f( 1, 0, 0, 1 ) )
+		aov1["color"].setValue( imath.Color4f( 1, 0, 0, 1 ) )
 
 		aov2 = GafferImage.Constant()
 		aov2["format"].setValue( GafferImage.Format( 100, 100 ) )
-		aov2["color"].setValue( IECore.Color4f( 0, 1, 0, 1 ) )
+		aov2["color"].setValue( imath.Color4f( 0, 1, 0, 1 ) )
 		aov2["layer"].setValue( "diffuse" )
 
 		self.sendImage( aov1["out"], c )
@@ -251,8 +252,8 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		constant2 = GafferImage.Constant()
 		constant1["format"].setValue( GafferImage.Format( 100, 100 ) )
 		constant2["format"].setValue( GafferImage.Format( 100, 100 ) )
-		constant1["color"].setValue( IECore.Color4f( 1, 0, 0, 1 ) )
-		constant2["color"].setValue( IECore.Color4f( 0, 1, 0, 1 ) )
+		constant1["color"].setValue( imath.Color4f( 1, 0, 0, 1 ) )
+		constant2["color"].setValue( imath.Color4f( 0, 1, 0, 1 ) )
 
 		self.sendImage(
 			constant1["out"],
@@ -493,12 +494,12 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		display.setDriver( drivers[0][0] )
 
 		self.assertEqual(
-			display["out"].channelDataHash( "R", IECore.V2i( 0 ) ),
-			c["out"].channelDataHash( "R", IECore.V2i( 0 ) )
+			display["out"].channelDataHash( "R", imath.V2i( 0 ) ),
+			c["out"].channelDataHash( "R", imath.V2i( 0 ) )
 		)
 		self.assertTrue(
-			display["out"].channelData( "R", IECore.V2i( 0 ), _copy = False ).isSame(
-				c["out"].channelData( "R", IECore.V2i( 0 ), _copy = False )
+			display["out"].channelData( "R", imath.V2i( 0 ), _copy = False ).isSame(
+				c["out"].channelData( "R", imath.V2i( 0 ), _copy = False )
 			)
 		)
 
@@ -510,12 +511,12 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
 		c["imageIndex"].setValue( 1 )
 		self.assertEqual(
-			display["out"].channelDataHash( "R", IECore.V2i( 0 ) ),
-			c["out"].channelDataHash( "R", IECore.V2i( 0 ) )
+			display["out"].channelDataHash( "R", imath.V2i( 0 ) ),
+			c["out"].channelDataHash( "R", imath.V2i( 0 ) )
 		)
 		self.assertTrue(
-			display["out"].channelData( "R", IECore.V2i( 0 ), _copy = False ).isSame(
-				c["out"].channelData( "R", IECore.V2i( 0 ), _copy = False )
+			display["out"].channelData( "R", imath.V2i( 0 ), _copy = False ).isSame(
+				c["out"].channelData( "R", imath.V2i( 0 ), _copy = False )
 			)
 		)
 

--- a/python/GafferImageTest/ClampTest.py
+++ b/python/GafferImageTest/ClampTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import os
+import imath
 
 import IECore
 
@@ -53,7 +54,7 @@ class ClampTest( GafferImageTest.ImageTestCase ) :
 
 		clamp = GafferImage.Clamp()
 		clamp["in"].setInput(i["out"])
-		clamp["max"].setValue( IECore.Color4f( .5, .5, .5, .5 ) )
+		clamp["max"].setValue( imath.Color4f( .5, .5, .5, .5 ) )
 
 		self.assertImagesEqual( i["out"], clamp["out"] )
 
@@ -65,17 +66,17 @@ class ClampTest( GafferImageTest.ImageTestCase ) :
 		clamp = GafferImage.Clamp()
 		clamp["in"].setInput(i["out"])
 
-		clamp["max"].setValue( IECore.Color4f( 1., 1., 1., 1. ) )
+		clamp["max"].setValue( imath.Color4f( 1., 1., 1., 1. ) )
 
-		redHash = clamp["out"].channelDataHash( "R", IECore.V2i( 0 ) )
-		greenHash = clamp["out"].channelDataHash( "G", IECore.V2i( 0 ) )
-		blueHash = clamp["out"].channelDataHash( "B", IECore.V2i( 0 ) )
+		redHash = clamp["out"].channelDataHash( "R", imath.V2i( 0 ) )
+		greenHash = clamp["out"].channelDataHash( "G", imath.V2i( 0 ) )
+		blueHash = clamp["out"].channelDataHash( "B", imath.V2i( 0 ) )
 
-		clamp["max"].setValue( IECore.Color4f( .25, 1., 1., 1. ) )
+		clamp["max"].setValue( imath.Color4f( .25, 1., 1., 1. ) )
 
-		redHash2 = clamp["out"].channelDataHash( "R", IECore.V2i( 0 ) )
-		greenHash2 = clamp["out"].channelDataHash( "G", IECore.V2i( 0 ) )
-		blueHash2 = clamp["out"].channelDataHash( "B", IECore.V2i( 0 ) )
+		redHash2 = clamp["out"].channelDataHash( "R", imath.V2i( 0 ) )
+		greenHash2 = clamp["out"].channelDataHash( "G", imath.V2i( 0 ) )
+		blueHash2 = clamp["out"].channelDataHash( "B", imath.V2i( 0 ) )
 
 		self.assertNotEqual(redHash, redHash2)
 		self.assertEqual(greenHash, greenHash2)
@@ -89,7 +90,7 @@ class ClampTest( GafferImageTest.ImageTestCase ) :
 		clamp["in"].setInput( r["out"] )
 
 		cs = GafferTest.CapturingSlot( clamp.plugDirtiedSignal() )
-		clamp["max"].setValue( IECore.Color4f( .25, 1., 1., 1. ) )
+		clamp["max"].setValue( imath.Color4f( .25, 1., 1., 1. ) )
 
 		dirtiedPlugs = set( [ x[0].relativeName( x[0].node() ) for x in cs ] )
 
@@ -108,10 +109,10 @@ class ClampTest( GafferImageTest.ImageTestCase ) :
 
 		clamp = GafferImage.Clamp()
 		clamp["in"].setInput(i["out"])
-		clamp["min"].setValue( IECore.Color4f( .0, .0, .0, .0 ) )
-		clamp["max"].setValue( IECore.Color4f( .0, .25, .25, .25 ) )
-		clamp["minClampTo"].setValue( IECore.Color4f( .0, .0, .0, .0 ) )
-		clamp["maxClampTo"].setValue( IECore.Color4f( 1., .5, .25, 1. ) )
+		clamp["min"].setValue( imath.Color4f( .0, .0, .0, .0 ) )
+		clamp["max"].setValue( imath.Color4f( .0, .25, .25, .25 ) )
+		clamp["minClampTo"].setValue( imath.Color4f( .0, .0, .0, .0 ) )
+		clamp["maxClampTo"].setValue( imath.Color4f( 1., .5, .25, 1. ) )
 		clamp["minEnabled"].setValue( True )
 		clamp["maxEnabled"].setValue( True )
 		clamp["minClampToEnabled"].setValue( False )
@@ -160,7 +161,7 @@ class ClampTest( GafferImageTest.ImageTestCase ) :
 
 		c = GafferImage.Clamp()
 		c["in"].setInput( i["out"] )
-		c["max"].setValue( IECore.Color4f( .5, .5, .5, .5 ) )
+		c["max"].setValue( imath.Color4f( .5, .5, .5, .5 ) )
 
 		self.assertEqual( i["out"]["format"].hash(), c["out"]["format"].hash() )
 		self.assertEqual( i["out"]["dataWindow"].hash(), c["out"]["dataWindow"].hash() )

--- a/python/GafferImageTest/CollectImagesTest.py
+++ b/python/GafferImageTest/CollectImagesTest.py
@@ -37,6 +37,7 @@
 import os
 import unittest
 import inspect
+import imath
 
 import IECore
 
@@ -58,7 +59,7 @@ class CollectImagesTest( GafferImageTest.ImageTestCase ) :
 
 		constant = GafferImage.Constant()
 		constant["format"].setValue( GafferImage.Format( 10, 10, 1.000 ) )
-		constant["color"].setValue( IECore.Color4f( 1, 0, 0, 1 ) )
+		constant["color"].setValue( imath.Color4f( 1, 0, 0, 1 ) )
 
 		crop = GafferImage.Crop()
 		crop["affectDisplayWindow"].setValue( False )
@@ -79,10 +80,10 @@ class CollectImagesTest( GafferImageTest.ImageTestCase ) :
 		layer = context.get( "collect:layerName", None )
 
 		if layer:
-			o = IECore.V2i(2, 2 ) * ( 1 + int( layer ) )
-			area = IECore.Box2i( o, IECore.V2i( 1, 1 ) + o )
+			o = imath.V2i(2, 2 ) * ( 1 + int( layer ) )
+			area = imath.Box2i( o, imath.V2i( 1, 1 ) + o )
 		else:
-			area = IECore.Box2i( IECore.V2i( 3, 1 ), IECore.V2i( 4, 2 ) )
+			area = imath.Box2i( imath.V2i( 3, 1 ), imath.V2i( 4, 2 ) )
 
 		parent["area"] = area
 		""" ), "python" )
@@ -97,7 +98,7 @@ class CollectImagesTest( GafferImageTest.ImageTestCase ) :
 	def testLayerMapping( self ) :
 
 		constant1 = GafferImage.Constant()
-		constant1['color'].setValue( IECore.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
+		constant1['color'].setValue( imath.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
 		constant1["format"].setValue( GafferImage.Format( 10, 10, 1.000 ) )
 
 		metadata1 = GafferImage.ImageMetadata()
@@ -105,7 +106,7 @@ class CollectImagesTest( GafferImageTest.ImageTestCase ) :
 		metadata1["metadata"].addMember( "test", 1 )
 
 		constant2 = GafferImage.Constant()
-		constant2['color'].setValue( IECore.Color4f( 0.2, 0.4, 0.6, 0.8 ) )
+		constant2['color'].setValue( imath.Color4f( 0.2, 0.4, 0.6, 0.8 ) )
 		constant2["format"].setValue( GafferImage.Format( 20, 20, 1.000 ) )
 
 		metadata2 = GafferImage.ImageMetadata()
@@ -138,7 +139,7 @@ class CollectImagesTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( collect["out"]["metadata"].getValue(), IECore.CompoundData() )
 
 		sampler = GafferImage.ImageSampler( "ImageSampler" )
-		sampler["pixel"].setValue( IECore.V2f( 1, 1 ) )
+		sampler["pixel"].setValue( imath.V2f( 1, 1 ) )
 		sampler["channels"].setValue( IECore.StringVectorData( [ "A.R", "A.G","A.B","A.A" ] ) )
 		sampler["image"].setInput( collect["out"] )
 
@@ -146,33 +147,33 @@ class CollectImagesTest( GafferImageTest.ImageTestCase ) :
 
 
 		self.assertEqual( list(collect["out"]["channelNames"].getValue()), [ "A.R", "A.G", "A.B", "A.A" ] )
-		self.assertEqual( sampler["color"].getValue(), IECore.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
+		self.assertEqual( sampler["color"].getValue(), imath.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
 
 		# Test simple duplicate
 		collect["rootLayers"].setValue( IECore.StringVectorData( [ 'A', 'A' ] ) )
 
 		self.assertEqual( list(collect["out"]["channelNames"].getValue()), [ "A.R", "A.G", "A.B", "A.A" ] )
-		self.assertEqual( sampler["color"].getValue(), IECore.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
+		self.assertEqual( sampler["color"].getValue(), imath.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
 
 		collect["rootLayers"].setValue( IECore.StringVectorData( [ 'A', 'B' ] ) )
 		self.assertEqual( list(collect["out"]["channelNames"].getValue()), [
 			"A.R", "A.G", "A.B", "A.A",
 			"B.R", "B.G", "B.B", "B.A" ] )
-		self.assertEqual( sampler["color"].getValue(), IECore.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
+		self.assertEqual( sampler["color"].getValue(), imath.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
 		sampler["channels"].setValue( IECore.StringVectorData( [ "B.R", "B.G","B.B","B.A" ] ) )
-		self.assertEqual( sampler["color"].getValue(), IECore.Color4f( 0.2, 0.4, 0.6, 0.8 ) )
+		self.assertEqual( sampler["color"].getValue(), imath.Color4f( 0.2, 0.4, 0.6, 0.8 ) )
 
 		# Test overlapping names take the first layer
 		constant1["layer"].setValue( "B" )
 		collect["rootLayers"].setValue( IECore.StringVectorData( [ 'A', 'A.B' ] ) )
 		sampler["channels"].setValue( IECore.StringVectorData( [ "A.B.R", "A.B.G","A.B.B","A.B.A" ] ) )
 		self.assertEqual( list(collect["out"]["channelNames"].getValue()), [ "A.B.R", "A.B.G", "A.B.B", "A.B.A" ] )
-		self.assertEqual( sampler["color"].getValue(), IECore.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
+		self.assertEqual( sampler["color"].getValue(), imath.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
 		collect["rootLayers"].setValue( IECore.StringVectorData( [ 'A.B', 'A' ] ) )
 		self.assertEqual( list(collect["out"]["channelNames"].getValue()), [ "A.B.R", "A.B.G", "A.B.B", "A.B.A" ] )
-		self.assertEqual( sampler["color"].getValue(), IECore.Color4f( 0.2, 0.4, 0.6, 0.8 ) )
+		self.assertEqual( sampler["color"].getValue(), imath.Color4f( 0.2, 0.4, 0.6, 0.8 ) )
 
-		
-		
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ColorSpaceTest.py
+++ b/python/GafferImageTest/ColorSpaceTest.py
@@ -38,6 +38,7 @@
 import os
 import unittest
 import subprocess32 as subprocess
+import imath
 
 import IECore
 
@@ -129,13 +130,13 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 		o["outputSpace"].setValue( "sRGB" )
 
 		self.assertNotEqual(
-			o["out"].channelDataHash( "R", IECore.V2i( 0 ) ),
-			o["out"].channelDataHash( "G", IECore.V2i( 0 ) )
+			o["out"].channelDataHash( "R", imath.V2i( 0 ) ),
+			o["out"].channelDataHash( "G", imath.V2i( 0 ) )
 		)
 
 		self.assertNotEqual(
-			o["out"].channelData( "R", IECore.V2i( 0 ) ),
-			o["out"].channelData( "G", IECore.V2i( 0 ) )
+			o["out"].channelData( "R", imath.V2i( 0 ) ),
+			o["out"].channelData( "G", imath.V2i( 0 ) )
 		)
 
 	def testPassThrough( self ) :

--- a/python/GafferImageTest/ConstantTest.py
+++ b/python/GafferImageTest/ConstantTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -49,11 +50,11 @@ class ConstantTest( GafferImageTest.ImageTestCase ) :
 	def testChannelData( self ) :
 
 		constant = GafferImage.Constant()
-		constant["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 511 ) ), 1 ) )
-		constant["color"].setValue( IECore.Color4f( 0, 0.25, 0.5, 1 ) )
+		constant["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 511 ) ), 1 ) )
+		constant["color"].setValue( imath.Color4f( 0, 0.25, 0.5, 1 ) )
 
 		for i, channel in enumerate( [ "R", "G", "B", "A" ] ) :
-			channelData = constant["out"].channelData( channel, IECore.V2i( 0 ) )
+			channelData = constant["out"].channelData( channel, imath.V2i( 0 ) )
 			self.assertEqual( len( channelData ), constant["out"].tileSize() * constant["out"].tileSize() )
 			expectedValue = constant["color"][i].getValue()
 			for value in channelData :
@@ -65,15 +66,15 @@ class ConstantTest( GafferImageTest.ImageTestCase ) :
 		# be affected by that particular channel of the colour plug.
 
 		constant = GafferImage.Constant()
-		constant["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 511 ) ), 1 ) )
-		constant["color"].setValue( IECore.Color4f( 0 ) )
+		constant["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 511 ) ), 1 ) )
+		constant["color"].setValue( imath.Color4f( 0 ) )
 
 		channels = [ "R", "G", "B", "A" ]
 		for i, channel in enumerate( channels ) :
 
-			h1 = [ constant["out"].channelDataHash( c, IECore.V2i( 0 ) ) for c in channels ]
+			h1 = [ constant["out"].channelDataHash( c, imath.V2i( 0 ) ) for c in channels ]
 			constant["color"][i].setValue( constant["color"][i].getValue() + .1 )
-			h2 = [ constant["out"].channelDataHash( c, IECore.V2i( 0 ) ) for c in channels ]
+			h2 = [ constant["out"].channelDataHash( c, imath.V2i( 0 ) ) for c in channels ]
 
 			for j in range( 0, len( channels ) ) :
 				if j == i :
@@ -86,9 +87,9 @@ class ConstantTest( GafferImageTest.ImageTestCase ) :
 		# Check that the data hash doesn't change when the format does.
 		c = GafferImage.Constant()
 		c["format"].setValue( GafferImage.Format( 2048, 1156, 1. ) )
-		h1 = c["out"].channelData( "R", IECore.V2i( 0 ) ).hash()
+		h1 = c["out"].channelData( "R", imath.V2i( 0 ) ).hash()
 		c["format"].setValue( GafferImage.Format( 1920, 1080, 1. ) )
-		h2 = c["out"].channelData( "R", IECore.V2i( 0 ) ).hash()
+		h2 = c["out"].channelData( "R", imath.V2i( 0 ) ).hash()
 		self.assertEqual( h1, h2 )
 
 	def testTileHashes( self ) :
@@ -99,8 +100,8 @@ class ConstantTest( GafferImageTest.ImageTestCase ) :
 		c["color"][0].setValue( .5 )
 
 		self.assertEqual(
-			c["out"].channelDataHash( "R", IECore.V2i( 0 ) ),
-			c["out"].channelDataHash( "R", IECore.V2i( GafferImage.ImagePlug().tileSize() ) ),
+			c["out"].channelDataHash( "R", imath.V2i( 0 ) ),
+			c["out"].channelDataHash( "R", imath.V2i( GafferImage.ImagePlug().tileSize() ) ),
 		)
 
 	def testTileIdentity( self ) :
@@ -111,16 +112,16 @@ class ConstantTest( GafferImageTest.ImageTestCase ) :
 		# The channelData() binding returns a copy by default, so we wouldn't
 		# expect two tiles to be referencing the same object.
 		self.assertFalse(
-			c["out"].channelData( "R", IECore.V2i( 0 ) ).isSame(
-				c["out"].channelData( "R", IECore.V2i( GafferImage.ImagePlug.tileSize() ) )
+			c["out"].channelData( "R", imath.V2i( 0 ) ).isSame(
+				c["out"].channelData( "R", imath.V2i( GafferImage.ImagePlug.tileSize() ) )
 			)
 		)
 
 		# But behind the scenes we do want them to be the same, so
 		# check that that is the case.
 		self.assertTrue(
-			c["out"].channelData( "R", IECore.V2i( 0 ), _copy = False ).isSame(
-				c["out"].channelData( "R", IECore.V2i( GafferImage.ImagePlug.tileSize() ), _copy = False )
+			c["out"].channelData( "R", imath.V2i( 0 ), _copy = False ).isSame(
+				c["out"].channelData( "R", imath.V2i( GafferImage.ImagePlug.tileSize() ), _copy = False )
 			)
 		)
 
@@ -136,7 +137,7 @@ class ConstantTest( GafferImageTest.ImageTestCase ) :
 
 		c = GafferImage.Constant()
 		h1 = c["out"]["channelNames"].hash()
-		c["color"].setValue( IECore.Color4f( 1, 0.5, 0.25, 1 ) )
+		c["color"].setValue( imath.Color4f( 1, 0.5, 0.25, 1 ) )
 		h2 = c["out"]["channelNames"].hash()
 
 		self.assertEqual( h1, h2 )
@@ -145,12 +146,12 @@ class ConstantTest( GafferImageTest.ImageTestCase ) :
 
 		s = Gaffer.ScriptNode()
 		s["c"] = GafferImage.Constant()
-		s["c"]["color"].setValue( IECore.Color4f( 0, 1, 0, 0 ) )
+		s["c"]["color"].setValue( imath.Color4f( 0, 1, 0, 0 ) )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 
-		self.assertEqual( s2["c"]["color"].getValue(), IECore.Color4f( 0, 1, 0, 0 ) )
+		self.assertEqual( s2["c"]["color"].getValue(), imath.Color4f( 0, 1, 0, 0 ) )
 
 	def testFormatDependencies( self ) :
 
@@ -170,8 +171,8 @@ class ConstantTest( GafferImageTest.ImageTestCase ) :
 		c1 = GafferImage.Constant()
 		c2 = GafferImage.Constant()
 
-		c1["color"].setValue( IECore.Color4f( 1, 0.5, 0.25, 1 ) )
-		c2["color"].setValue( IECore.Color4f( 1, 0.5, 0.25, 1 ) )
+		c1["color"].setValue( imath.Color4f( 1, 0.5, 0.25, 1 ) )
+		c2["color"].setValue( imath.Color4f( 1, 0.5, 0.25, 1 ) )
 		c2["layer"].setValue( "diffuse" )
 
 		self.assertEqual(
@@ -187,13 +188,13 @@ class ConstantTest( GafferImageTest.ImageTestCase ) :
 		for channelName in ( "R", "G", "B", "A" ) :
 
 			self.assertEqual(
-				c1["out"].channelDataHash( channelName, IECore.V2i( 0 ) ),
-				c2["out"].channelDataHash( "diffuse." + channelName, IECore.V2i( 0 ) )
+				c1["out"].channelDataHash( channelName, imath.V2i( 0 ) ),
+				c2["out"].channelDataHash( "diffuse." + channelName, imath.V2i( 0 ) )
 			)
 
 			self.assertEqual(
-				c1["out"].channelData( channelName, IECore.V2i( 0 ) ),
-				c2["out"].channelData( "diffuse." + channelName, IECore.V2i( 0 ) )
+				c1["out"].channelData( channelName, imath.V2i( 0 ) ),
+				c2["out"].channelData( "diffuse." + channelName, imath.V2i( 0 ) )
 			)
 
 	def testLayerAffectsChannelNames( self ) :

--- a/python/GafferImageTest/CopyChannelsTest.py
+++ b/python/GafferImageTest/CopyChannelsTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -45,10 +46,10 @@ import GafferImageTest
 
 class CopyChannelsTest( GafferImageTest.ImageTestCase ) :
 
-	def __constantLayer( self, layer, color, size = IECore.V2i( 512 ) ) :
+	def __constantLayer( self, layer, color, size = imath.V2i( 512 ) ) :
 
 		result = GafferImage.Constant()
-		result["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), size ), 1 ) )
+		result["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), size ), 1 ) )
 		result["color"].setValue( color )
 		result["layer"].setValue( layer )
 
@@ -59,8 +60,8 @@ class CopyChannelsTest( GafferImageTest.ImageTestCase ) :
 		# Set up a copy where the main layer comes from the first
 		# input and the diffuse layer is copied in from a second input.
 
-		main = self.__constantLayer( "", IECore.Color4f( 1, 0.5, 0.25, 1 ) )
-		diffuse = self.__constantLayer( "diffuse", IECore.Color4f( 0, 0.25, 0.5, 1 ) )
+		main = self.__constantLayer( "", imath.Color4f( 1, 0.5, 0.25, 1 ) )
+		diffuse = self.__constantLayer( "diffuse", imath.Color4f( 0, 0.25, 0.5, 1 ) )
 
 		copy = GafferImage.CopyChannels()
 		copy["in"][0].setInput( main["out"] )
@@ -84,13 +85,13 @@ class CopyChannelsTest( GafferImageTest.ImageTestCase ) :
 					channel = constant["layer"].getValue() + "." + channel
 
 				self.assertEqual(
-					copy["out"].channelDataHash( channel, IECore.V2i( 0 ) ),
-					constant["out"].channelDataHash( channel, IECore.V2i( 0 ) ),
+					copy["out"].channelDataHash( channel, imath.V2i( 0 ) ),
+					constant["out"].channelDataHash( channel, imath.V2i( 0 ) ),
 				)
 
 				self.assertTrue(
-					copy["out"].channelData( channel, IECore.V2i( 0 ), _copy = False ).isSame(
-						constant["out"].channelData( channel, IECore.V2i( 0 ), _copy = False )
+					copy["out"].channelData( channel, imath.V2i( 0 ), _copy = False ).isSame(
+						constant["out"].channelData( channel, imath.V2i( 0 ), _copy = False )
 					)
 				)
 
@@ -99,8 +100,8 @@ class CopyChannelsTest( GafferImageTest.ImageTestCase ) :
 		# Set up a situation where we're copying channels
 		# from an image with a smaller data window than the
 		# primary input.
-		main = self.__constantLayer( "", IECore.Color4f( 1 ), size = IECore.V2i( 64 ) )
-		diffuse = self.__constantLayer( "diffuse", IECore.Color4f( 0.5 ), size = IECore.V2i( 60 ) )
+		main = self.__constantLayer( "", imath.Color4f( 1 ), size = imath.V2i( 64 ) )
+		diffuse = self.__constantLayer( "diffuse", imath.Color4f( 0.5 ), size = imath.V2i( 60 ) )
 
 		copy = GafferImage.CopyChannels()
 		copy["in"][0].setInput( main["out"] )
@@ -121,17 +122,17 @@ class CopyChannelsTest( GafferImageTest.ImageTestCase ) :
 			diffuseDW = diffuse["out"]["dataWindow"].getValue()
 			copyDW = copy["out"]["dataWindow"].getValue()
 			sampler = GafferImage.Sampler( copy["out"], "diffuse." + channel, copyDW )
-			for x in range( copyDW.min.x, copyDW.max.x ) :
-				for y in range( copyDW.min.y, copyDW.max.y ) :
-					if GafferImage.BufferAlgo.contains( diffuseDW, IECore.V2i( x, y ) ) :
+			for x in range( copyDW.min().x, copyDW.max().x ) :
+				for y in range( copyDW.min().y, copyDW.max().y ) :
+					if GafferImage.BufferAlgo.contains( diffuseDW, imath.V2i( x, y ) ) :
 						self.assertEqual( sampler.sample( x, y ), 0.5 )
 					else :
 						self.assertEqual( sampler.sample( x, y ), 0 )
 
 	def testChannelsPlug( self ) :
 
-		main = self.__constantLayer( "", IECore.Color4f( 1, 0.5, 0.25, 1 ) )
-		diffuse = self.__constantLayer( "diffuse", IECore.Color4f( 0, 0.25, 0.5, 1 ) )
+		main = self.__constantLayer( "", imath.Color4f( 1, 0.5, 0.25, 1 ) )
+		diffuse = self.__constantLayer( "diffuse", imath.Color4f( 0, 0.25, 0.5, 1 ) )
 
 		copy = GafferImage.CopyChannels()
 		copy["in"][0].setInput( main["out"] )

--- a/python/GafferImageTest/CopyImageMetadataTest.py
+++ b/python/GafferImageTest/CopyImageMetadataTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import imath
 
 import IECore
 
@@ -159,7 +160,7 @@ class CopyImageMetadataTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( i["out"]["channelNames"].getValue(), m["out"]["channelNames"].getValue() )
 
 		context = Gaffer.Context()
-		context["image:tileOrigin"] = IECore.V2i( 0 )
+		context["image:tileOrigin"] = imath.V2i( 0 )
 		with context :
 			for c in [ "G", "B", "A" ] :
 				context["image:channelName"] = c

--- a/python/GafferImageTest/CropTest.py
+++ b/python/GafferImageTest/CropTest.py
@@ -37,6 +37,7 @@
 
 import unittest
 import os
+import imath
 
 import IECore
 
@@ -71,14 +72,14 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 		crop = GafferImage.Crop()
 		crop["in"].setInput(i["out"])
 		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Area )
-		crop["area"].setValue( IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
+		crop["area"].setValue( imath.Box2i( imath.V2i( 40 ), imath.V2i( 50 ) ) )
 		crop["affectDataWindow"].setValue( True )
 		crop["affectDisplayWindow"].setValue( True )
 		crop["resetOrigin"].setValue( False )
 
-		self.assertEqual(i['out'].channelDataHash( "R", IECore.V2i( 0 ) ), crop['out'].channelDataHash( "R", IECore.V2i( 0 ) ) )
-		self.assertEqual(i['out'].channelDataHash( "G", IECore.V2i( 0 ) ), crop['out'].channelDataHash( "G", IECore.V2i( 0 ) ) )
-		self.assertEqual(i['out'].channelDataHash( "B", IECore.V2i( 0 ) ), crop['out'].channelDataHash( "B", IECore.V2i( 0 ) ) )
+		self.assertEqual(i['out'].channelDataHash( "R", imath.V2i( 0 ) ), crop['out'].channelDataHash( "R", imath.V2i( 0 ) ) )
+		self.assertEqual(i['out'].channelDataHash( "G", imath.V2i( 0 ) ), crop['out'].channelDataHash( "G", imath.V2i( 0 ) ) )
+		self.assertEqual(i['out'].channelDataHash( "B", imath.V2i( 0 ) ), crop['out'].channelDataHash( "B", imath.V2i( 0 ) ) )
 
 		self.assertEqual( i["out"]["metadata"].hash(), crop["out"]["metadata"].hash() )
 		self.assertEqual( i["out"]["channelNames"].hash(), crop["out"]["channelNames"].hash() )
@@ -112,12 +113,12 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 		crop2 = GafferImage.Crop()
 		crop2['in'].setInput( constant['out'] )
 		crop2['areaSource'].setValue( GafferImage.Crop.AreaSource.Area )
-		crop2['area'].setValue( IECore.Box2i( IECore.V2i( 0, 0 ), IECore.V2i( 2048, 1152 ) ) )
+		crop2['area'].setValue( imath.Box2i( imath.V2i( 0, 0 ), imath.V2i( 2048, 1152 ) ) )
 
 		self.assertEqual( crop1['out']['dataWindow'].getValue(), crop2['out']['dataWindow'].getValue() )
 
 		crop1['formatCenter'].setValue( True )
-		crop2['area'].setValue( IECore.Box2i( IECore.V2i( -512, -288 ), IECore.V2i( 1536, 864 ) ) )
+		crop2['area'].setValue( imath.Box2i( imath.V2i( -512, -288 ), imath.V2i( 1536, 864 ) ) )
 		crop2['resetOrigin'].setValue( True )
 
 		self.assertEqual( crop1['out']['dataWindow'].getValue(), crop2['out']['dataWindow'].getValue() )
@@ -130,11 +131,11 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 		crop = GafferImage.Crop()
 		crop["in"].setInput(i["out"])
 		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Area )
-		crop["area"].setValue( IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
+		crop["area"].setValue( imath.Box2i( imath.V2i( 40 ), imath.V2i( 50 ) ) )
 		crop["affectDataWindow"].setValue( True )
 		crop["affectDisplayWindow"].setValue( False )
 
-		self.assertEqual( crop["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
+		self.assertEqual( crop["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( 40 ), imath.V2i( 50 ) ) )
 		self.assertEqual( i["out"]["format"].getValue(), crop["out"]["format"].getValue() )
 
 	def testAffectDisplayWindow( self ) :
@@ -145,18 +146,18 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 		crop = GafferImage.Crop()
 		crop["in"].setInput(i["out"])
 		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Area )
-		crop["area"].setValue( IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
+		crop["area"].setValue( imath.Box2i( imath.V2i( 40 ), imath.V2i( 50 ) ) )
 		crop["affectDataWindow"].setValue( False )
 		crop["affectDisplayWindow"].setValue( True )
 		crop["resetOrigin"].setValue( False )
 
-		self.assertEqual( crop["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 50 ) ) )
+		self.assertEqual( crop["out"]["format"].getValue().getDisplayWindow(), imath.Box2i( imath.V2i( 40 ), imath.V2i( 50 ) ) )
 		self.assertEqual( i["out"]["dataWindow"].getValue(), crop["out"]["dataWindow"].getValue() )
 
 		crop["resetOrigin"].setValue( True )
 
-		self.assertEqual( crop["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) ) )
-		self.assertEqual( crop["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( -10 ), IECore.V2i( 40 ) ) )
+		self.assertEqual( crop["out"]["format"].getValue().getDisplayWindow(), imath.Box2i( imath.V2i( 0 ), imath.V2i( 10 ) ) )
+		self.assertEqual( crop["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( -10 ), imath.V2i( 40 ) ) )
 
 	def testIntersectDataWindow( self ) :
 
@@ -166,11 +167,11 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 		crop = GafferImage.Crop()
 		crop["in"].setInput(i["out"])
 		crop["areaSource"].setValue( GafferImage.Crop.AreaSource.Area )
-		crop["area"].setValue( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 50 ) ) )
+		crop["area"].setValue( imath.Box2i( imath.V2i( 0 ), imath.V2i( 50 ) ) )
 		crop["affectDataWindow"].setValue( True )
 		crop["affectDisplayWindow"].setValue( False )
 
-		self.assertEqual( crop["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 30 ), IECore.V2i( 50 ) ) )
+		self.assertEqual( crop["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( 30 ), imath.V2i( 50 ) ) )
 
 	def testDataWindowToDisplayWindow( self ) :
 
@@ -189,8 +190,8 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 
 		crop["resetOrigin"].setValue( True )
 
-		self.assertEqual( crop["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 50 ) ) )
-		self.assertEqual( crop["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 50 ) ) )
+		self.assertEqual( crop["out"]["format"].getValue().getDisplayWindow(), imath.Box2i( imath.V2i( 0 ), imath.V2i( 50 ) ) )
+		self.assertEqual( crop["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( 0 ), imath.V2i( 50 ) ) )
 
 	def testDisplayWindowToDataWindow( self ) :
 
@@ -233,11 +234,11 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( crop["affectDataWindow"].getValue(), True )
 		self.assertEqual( crop["resetOrigin"].getValue(), True )
 
-		area = IECore.Box2i( IECore.V2i( 50 ), IECore.V2i( 100, 190 ) )
+		area = imath.Box2i( imath.V2i( 50 ), imath.V2i( 100, 190 ) )
 		crop["area"].setValue( area )
 
-		self.assertEqual( crop["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 0 ), area.size() ) )
-		self.assertEqual( crop["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 0 ), area.size() ) )
+		self.assertEqual( crop["out"]["format"].getValue().getDisplayWindow(), imath.Box2i( imath.V2i( 0 ), area.size() ) )
+		self.assertEqual( crop["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( 0 ), area.size() ) )
 
 		crop["resetOrigin"].setValue( False )
 
@@ -258,14 +259,14 @@ class CropTest( GafferImageTest.ImageTestCase ) :
 		crop["affectDisplayWindow"].setValue( True )
 		crop["affectDataWindow"].setValue( False )
 
-		self.assertEqual( crop["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 0 ), area.size() ) )
-		self.assertEqual( crop["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( -50 ), IECore.V2i( 50, 150 ) ) )
+		self.assertEqual( crop["out"]["format"].getValue().getDisplayWindow(), imath.Box2i( imath.V2i( 0 ), area.size() ) )
+		self.assertEqual( crop["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( -50 ), imath.V2i( 50, 150 ) ) )
 
 	def testEmptyInput( self ) :
 
 		crop = GafferImage.Crop()
 
-		crop["area"]["min"].setValue( IECore.V2i( 20 ) )
+		crop["area"]["min"].setValue( imath.V2i( 20 ) )
 		self.assertTrue( GafferImage.BufferAlgo.empty( crop["out"]["dataWindow"].getValue() ) )
 
 	def testFormatAffectsOutput( self ) :

--- a/python/GafferImageTest/DeleteChannelsTest.py
+++ b/python/GafferImageTest/DeleteChannelsTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -114,9 +115,9 @@ class DeleteChannelsTest( GafferImageTest.ImageTestCase ) :
 
 		# the channels that are passed through should have identical hashes to the input,
 		# so they can share cache entries.
-		self.assertEqual( r["out"].channelDataHash( "G", IECore.V2i( 0 ) ), d["out"].channelDataHash( "G", IECore.V2i( 0 ) ) )
-		self.assertEqual( r["out"].channelDataHash( "B", IECore.V2i( 0 ) ), d["out"].channelDataHash( "B", IECore.V2i( 0 ) ) )
-		self.assertEqual( r["out"].channelDataHash( "A", IECore.V2i( 0 ) ), d["out"].channelDataHash( "A", IECore.V2i( 0 ) ) )
+		self.assertEqual( r["out"].channelDataHash( "G", imath.V2i( 0 ) ), d["out"].channelDataHash( "G", imath.V2i( 0 ) ) )
+		self.assertEqual( r["out"].channelDataHash( "B", imath.V2i( 0 ) ), d["out"].channelDataHash( "B", imath.V2i( 0 ) ) )
+		self.assertEqual( r["out"].channelDataHash( "A", imath.V2i( 0 ) ), d["out"].channelDataHash( "A", imath.V2i( 0 ) ) )
 
 	def testHashChanged( self ) :
 
@@ -181,7 +182,7 @@ class DeleteChannelsTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( i["out"]["metadata"].getValue(), d["out"]["metadata"].getValue() )
 
 		context = Gaffer.Context()
-		context["image:tileOrigin"] = IECore.V2i( 0 )
+		context["image:tileOrigin"] = imath.V2i( 0 )
 		with context :
 			for c in [ "G", "B", "A" ] :
 				context["image:channelName"] = c

--- a/python/GafferImageTest/DilateTest.py
+++ b/python/GafferImageTest/DilateTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -52,7 +53,7 @@ class DilateTest( GafferImageTest.ImageTestCase ) :
 
 		m = GafferImage.Dilate()
 		m["in"].setInput( c["out"] )
-		m["radius"].setValue( IECore.V2i( 0 ) )
+		m["radius"].setValue( imath.V2i( 0 ) )
 
 		self.assertEqual( c["out"].imageHash(), m["out"].imageHash() )
 		self.assertImagesEqual( c["out"], m["out"] )
@@ -63,14 +64,14 @@ class DilateTest( GafferImageTest.ImageTestCase ) :
 
 		m = GafferImage.Dilate()
 		m["in"].setInput( c["out"] )
-		m["radius"].setValue( IECore.V2i( 1 ) )
+		m["radius"].setValue( imath.V2i( 1 ) )
 
 		self.assertEqual( m["out"]["dataWindow"].getValue(), c["out"]["dataWindow"].getValue() )
 
 		m["expandDataWindow"].setValue( True )
 
-		self.assertEqual( m["out"]["dataWindow"].getValue().min, c["out"]["dataWindow"].getValue().min - IECore.V2i( 1 ) )
-		self.assertEqual( m["out"]["dataWindow"].getValue().max, c["out"]["dataWindow"].getValue().max + IECore.V2i( 1 ) )
+		self.assertEqual( m["out"]["dataWindow"].getValue().min(), c["out"]["dataWindow"].getValue().min() - imath.V2i( 1 ) )
+		self.assertEqual( m["out"]["dataWindow"].getValue().max(), c["out"]["dataWindow"].getValue().max() + imath.V2i( 1 ) )
 
 	def testFilter( self ) :
 
@@ -81,7 +82,7 @@ class DilateTest( GafferImageTest.ImageTestCase ) :
 		m["in"].setInput( r["out"] )
 		self.assertImagesEqual( m["out"], r["out"] )
 
-		m["radius"].setValue( IECore.V2i( 12 ) )
+		m["radius"].setValue( imath.V2i( 12 ) )
 		m["boundingMode"].setValue( GafferImage.Sampler.BoundingMode.Clamp )
 
 		dataWindow = m["out"]["dataWindow"].getValue()
@@ -97,15 +98,15 @@ class DilateTest( GafferImageTest.ImageTestCase ) :
 		r = GafferImage.Grade()
 		r["in"].setInput( rRaw["out"] )
 		# Trim off the noise in the blacks so that areas with no visible color are actually flat
-		r["blackPoint"].setValue( IECore.Color4f( 0.03 ) )
+		r["blackPoint"].setValue( imath.Color4f( 0.03 ) )
 
 
 		masterDilate = GafferImage.Dilate()
 		masterDilate["in"].setInput( r["out"] )
-		masterDilate["radius"].setValue( IECore.V2i( 2 ) )
+		masterDilate["radius"].setValue( imath.V2i( 2 ) )
 
 		masterDilate["masterChannel"].setValue( "G" )
-		
+
 		expected = GafferImage.ImageReader()
 		expected["fileName"].setValue( os.path.dirname( __file__ ) + "/images/circlesGreenDilate.exr" )
 
@@ -115,10 +116,10 @@ class DilateTest( GafferImageTest.ImageTestCase ) :
 		# than just the green channel
 		self.assertImagesEqual( masterDilate["out"], expected["out"], ignoreMetadata = True, maxDifference=0.0005 )
 
-		
+
 		defaultDilate = GafferImage.Dilate()
 		defaultDilate["in"].setInput( r["out"] )
-		defaultDilate["radius"].setValue( IECore.V2i( 2 ) )
+		defaultDilate["radius"].setValue( imath.V2i( 2 ) )
 
 		masterDilateSingleChannel = GafferImage.DeleteChannels()
 		masterDilateSingleChannel["in"].setInput( masterDilate["out"] )

--- a/python/GafferImageTest/DisplayTest.py
+++ b/python/GafferImageTest/DisplayTest.py
@@ -39,6 +39,7 @@ import unittest
 import random
 import threading
 import subprocess32 as subprocess
+import imath
 
 import IECore
 import IECoreImage
@@ -136,15 +137,15 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 			)
 
 			tileSize = GafferImage.ImagePlug.tileSize()
-			minTileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.min )
-			maxTileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.max - IECore.V2i( 1 ) )
+			minTileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.min() )
+			maxTileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.max() - imath.V2i( 1 ) )
 			for y in range( minTileOrigin.y, maxTileOrigin.y + 1, tileSize ) :
 				for x in range( minTileOrigin.x, maxTileOrigin.x + 1, tileSize ) :
-					tileOrigin = IECore.V2i( x, y )
+					tileOrigin = imath.V2i( x, y )
 					channelData = []
 					for channelName in channelNames :
 						channelData.append( image.channelData( channelName, tileOrigin ) )
-					driver.sendBucket( IECore.Box2i( tileOrigin, tileOrigin + IECore.V2i( tileSize ) ), channelData )
+					driver.sendBucket( imath.Box2i( tileOrigin, tileOrigin + imath.V2i( tileSize ) ), channelData )
 
 			driver.close()
 
@@ -172,7 +173,7 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 		server = IECoreImage.DisplayDriverServer()
 		driverCreatedConnection = GafferImage.Display.driverCreatedSignal().connect( lambda driver, parameters : node.setDriver( driver ) )
 
-		dataWindow = IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 303, 557 ) )
+		dataWindow = imath.Box2i( imath.V2i( -100, -200 ), imath.V2i( 303, 557 ) )
 		driver = self.Driver(
 			GafferImage.Format( dataWindow ),
 			dataWindow,
@@ -185,12 +186,12 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 			h1 = self.__tileHashes( node, "Y" )
 			t1 = self.__tiles( node, "Y" )
 
-			bucketWindow = IECore.Box2i()
+			bucketWindow = imath.Box2i()
 			while GafferImage.BufferAlgo.empty( bucketWindow ) :
 				bucketWindow.extendBy(
-					IECore.V2i(
-						int( random.uniform( dataWindow.min.x, dataWindow.max.x ) ),
-						int( random.uniform( dataWindow.min.y, dataWindow.max.y ) ),
+					imath.V2i(
+						int( random.uniform( dataWindow.min().x, dataWindow.max().x ) ),
+						int( random.uniform( dataWindow.min().y, dataWindow.max().y ) ),
 					)
 				)
 
@@ -223,12 +224,12 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 		blackTile = IECore.FloatVectorData( [ 0 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
 
 		self.assertEqual(
-			node["out"].channelData( "R", -IECore.V2i( GafferImage.ImagePlug.tileSize() ) ),
+			node["out"].channelData( "R", -imath.V2i( GafferImage.ImagePlug.tileSize() ) ),
 			blackTile
 		)
 
 		self.assertEqual(
-			node["out"].channelData( "R", 10 * IECore.V2i( GafferImage.ImagePlug.tileSize() ) ),
+			node["out"].channelData( "R", 10 * imath.V2i( GafferImage.ImagePlug.tileSize() ) ),
 			blackTile
 		)
 
@@ -252,7 +253,7 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 		driversCreated = GafferTest.CapturingSlot( GafferImage.Display.driverCreatedSignal() )
 
 		server = IECoreImage.DisplayDriverServer()
-		dataWindow = IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 100 ) )
+		dataWindow = imath.Box2i( imath.V2i( 0 ), imath.V2i( 100 ) )
 
 		driver = self.Driver(
 			GafferImage.Format( dataWindow ),
@@ -275,7 +276,7 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( display["out"]["dataWindow"].getValue(), dataWindow )
 		self.assertEqual( display["out"]["channelNames"].getValue(), IECore.StringVectorData( [ "Y" ] ) )
 		self.assertEqual(
-			display["out"].channelData( "Y", IECore.V2i( 0 ) ),
+			display["out"].channelData( "Y", imath.V2i( 0 ) ),
 			IECore.FloatVectorData( [ 0.5 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
 		)
 
@@ -287,12 +288,12 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 		driver.sendBucket( dataWindow, [ IECore.FloatVectorData( [ 1 ] * dataWindow.size().x * dataWindow.size().y ) ] )
 
 		self.assertEqual(
-			display["out"].channelData( "Y", IECore.V2i( 0 ) ),
+			display["out"].channelData( "Y", imath.V2i( 0 ) ),
 			IECore.FloatVectorData( [ 1 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
 		)
 
 		self.assertEqual(
-			display2["out"].channelData( "Y", IECore.V2i( 0 ) ),
+			display2["out"].channelData( "Y", imath.V2i( 0 ) ),
 			IECore.FloatVectorData( [ 0.5 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
 		)
 
@@ -324,13 +325,13 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 
 		dataWindow = node["out"]["dataWindow"].getValue()
 
-		minTileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.min )
-		maxTileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.max )
+		minTileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.min() )
+		maxTileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.max() )
 
 		tiles = {}
 		for y in range( minTileOrigin.y, maxTileOrigin.y, GafferImage.ImagePlug.tileSize() ) :
 			for x in range( minTileOrigin.x, maxTileOrigin.x, GafferImage.ImagePlug.tileSize() ) :
-				tiles[( x, y )] = node["out"].channelData( channelName, IECore.V2i( x, y ) )
+				tiles[( x, y )] = node["out"].channelData( channelName, imath.V2i( x, y ) )
 
 		return tiles
 
@@ -338,21 +339,21 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 
 		dataWindow = node["out"]["dataWindow"].getValue()
 
-		minTileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.min )
-		maxTileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.max )
+		minTileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.min() )
+		maxTileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.max() )
 
 		hashes = {}
 		for y in range( minTileOrigin.y, maxTileOrigin.y, GafferImage.ImagePlug.tileSize() ) :
 			for x in range( minTileOrigin.x, maxTileOrigin.x, GafferImage.ImagePlug.tileSize() ) :
-				hashes[( x, y )] = node["out"].channelDataHash( channelName, IECore.V2i( x, y ) )
+				hashes[( x, y )] = node["out"].channelDataHash( channelName, imath.V2i( x, y ) )
 
 		return hashes
 
 	def __assertTilesChangedInRegion( self, t1, t2, region ) :
 
 		for tileOriginTuple in t1.keys() :
-			tileOrigin = IECore.V2i( *tileOriginTuple )
-			tileRegion = IECore.Box2i( tileOrigin, tileOrigin + IECore.V2i( GafferImage.ImagePlug.tileSize() ) )
+			tileOrigin = imath.V2i( *tileOriginTuple )
+			tileRegion = imath.Box2i( tileOrigin, tileOrigin + imath.V2i( GafferImage.ImagePlug.tileSize() ) )
 
 			if GafferImage.BufferAlgo.intersects( tileRegion, region ) :
 				self.assertNotEqual( t1[tileOriginTuple], t2[tileOriginTuple] )

--- a/python/GafferImageTest/DisplayTransformTest.py
+++ b/python/GafferImageTest/DisplayTransformTest.py
@@ -37,6 +37,7 @@
 import os
 import unittest
 import subprocess32 as subprocess
+import imath
 
 import IECore
 
@@ -141,13 +142,13 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 		o["inputColorSpace"].setValue( "linear" )
 
 		self.assertNotEqual(
-			o["out"].channelDataHash( "R", IECore.V2i( 0 ) ),
-			o["out"].channelDataHash( "G", IECore.V2i( 0 ) )
+			o["out"].channelDataHash( "R", imath.V2i( 0 ) ),
+			o["out"].channelDataHash( "G", imath.V2i( 0 ) )
 		)
 
 		self.assertNotEqual(
-			o["out"].channelData( "R", IECore.V2i( 0 ) ),
-			o["out"].channelData( "G", IECore.V2i( 0 ) )
+			o["out"].channelData( "R", imath.V2i( 0 ) ),
+			o["out"].channelData( "G", imath.V2i( 0 ) )
 		)
 
 	def testPassThrough( self ) :

--- a/python/GafferImageTest/ErodeTest.py
+++ b/python/GafferImageTest/ErodeTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -52,7 +53,7 @@ class ErodeTest( GafferImageTest.ImageTestCase ) :
 
 		m = GafferImage.Erode()
 		m["in"].setInput( c["out"] )
-		m["radius"].setValue( IECore.V2i( 0 ) )
+		m["radius"].setValue( imath.V2i( 0 ) )
 
 		self.assertEqual( c["out"].imageHash(), m["out"].imageHash() )
 		self.assertImagesEqual( c["out"], m["out"] )
@@ -63,14 +64,14 @@ class ErodeTest( GafferImageTest.ImageTestCase ) :
 
 		m = GafferImage.Erode()
 		m["in"].setInput( c["out"] )
-		m["radius"].setValue( IECore.V2i( 1 ) )
+		m["radius"].setValue( imath.V2i( 1 ) )
 
 		self.assertEqual( m["out"]["dataWindow"].getValue(), c["out"]["dataWindow"].getValue() )
 
 		m["expandDataWindow"].setValue( True )
 
-		self.assertEqual( m["out"]["dataWindow"].getValue().min, c["out"]["dataWindow"].getValue().min - IECore.V2i( 1 ) )
-		self.assertEqual( m["out"]["dataWindow"].getValue().max, c["out"]["dataWindow"].getValue().max + IECore.V2i( 1 ) )
+		self.assertEqual( m["out"]["dataWindow"].getValue().min(), c["out"]["dataWindow"].getValue().min() - imath.V2i( 1 ) )
+		self.assertEqual( m["out"]["dataWindow"].getValue().max(), c["out"]["dataWindow"].getValue().max() + imath.V2i( 1 ) )
 
 	def testFilter( self ) :
 
@@ -81,7 +82,7 @@ class ErodeTest( GafferImageTest.ImageTestCase ) :
 		m["in"].setInput( r["out"] )
 		self.assertImagesEqual( m["out"], r["out"] )
 
-		m["radius"].setValue( IECore.V2i( 8 ) )
+		m["radius"].setValue( imath.V2i( 8 ) )
 		m["boundingMode"].setValue( GafferImage.Sampler.BoundingMode.Clamp )
 
 		dataWindow = m["out"]["dataWindow"].getValue()
@@ -89,7 +90,7 @@ class ErodeTest( GafferImageTest.ImageTestCase ) :
 		s["in"].setInput( m["out"] )
 		s["area"].setValue( dataWindow )
 
-		self.assertEqual( s["max"].getValue(), IECore.Color4f( 0, 0, 0, 1 ) )
+		self.assertEqual( s["max"].getValue(), imath.Color4f( 0, 0, 0, 1 ) )
 
 	def testDriverChannel( self ) :
 
@@ -99,15 +100,15 @@ class ErodeTest( GafferImageTest.ImageTestCase ) :
 		r = GafferImage.Grade()
 		r["in"].setInput( rRaw["out"] )
 		# Trim off the noise in the blacks so that areas with no visible color are actually flat
-		r["blackPoint"].setValue( IECore.Color4f( 0.03 ) )
+		r["blackPoint"].setValue( imath.Color4f( 0.03 ) )
 
 
 		masterErode = GafferImage.Erode()
 		masterErode["in"].setInput( r["out"] )
-		masterErode["radius"].setValue( IECore.V2i( 2 ) )
+		masterErode["radius"].setValue( imath.V2i( 2 ) )
 
 		masterErode["masterChannel"].setValue( "G" )
-		
+
 		expected = GafferImage.ImageReader()
 		expected["fileName"].setValue( os.path.dirname( __file__ ) + "/images/circlesGreenErode.exr" )
 
@@ -117,10 +118,10 @@ class ErodeTest( GafferImageTest.ImageTestCase ) :
 		# than just the green channel
 		self.assertImagesEqual( masterErode["out"], expected["out"], ignoreMetadata = True, maxDifference=0.0005 )
 
-		
+
 		defaultErode = GafferImage.Erode()
 		defaultErode["in"].setInput( r["out"] )
-		defaultErode["radius"].setValue( IECore.V2i( 2 ) )
+		defaultErode["radius"].setValue( imath.V2i( 2 ) )
 
 		masterErodeSingleChannel = GafferImage.DeleteChannels()
 		masterErodeSingleChannel["in"].setInput( masterErode["out"] )

--- a/python/GafferImageTest/FilterAlgoTest.py
+++ b/python/GafferImageTest/FilterAlgoTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 import IECoreImage
@@ -58,32 +59,32 @@ class FilterAlgoTest( GafferImageTest.ImageTestCase ) :
 		# Each grid cell gets a dot in the middle
 		redDot = GafferImage.Constant()
 		redDot["format"].setValue( GafferImage.Format( 1, 1, 1.000 ) )
-		redDot["color"].setValue( IECore.Color4f( 10, 0, 0, 1 ) )
+		redDot["color"].setValue( imath.Color4f( 10, 0, 0, 1 ) )
 		redDotCentered = GafferImage.Crop( "Crop" )
 		redDotCentered["in"].setInput( redDot["out"] )
-		redDotCentered["area"].setValue( IECore.Box2i( IECore.V2i( -(subSize-1)/2 ), IECore.V2i( (subSize-1)/2 + 1 ) ) )
+		redDotCentered["area"].setValue( imath.Box2i( imath.V2i( -(subSize-1)/2 ), imath.V2i( (subSize-1)/2 + 1 ) ) )
 
 		borderForFilterWidth = 40
 		sampleRegion = redDotCentered["out"]["dataWindow"].getValue()
-		sampleRegion.min -= IECore.V2i( borderForFilterWidth )
-		sampleRegion.max += IECore.V2i( borderForFilterWidth )
+		sampleRegion.setMin( sampleRegion.min() - imath.V2i( borderForFilterWidth ) )
+		sampleRegion.setMax( sampleRegion.max() + imath.V2i( borderForFilterWidth ) )
 
 		s = GafferImage.Sampler( redDotCentered["out"], "R", sampleRegion, GafferImage.Sampler.BoundingMode.Black )
 
 		filters = GafferImage.FilterAlgo.filterNames()
 		dirs = [
-			(IECore.V2f(1,0), IECore.V2f(0,1)),
-			(IECore.V2f(5,0), IECore.V2f(0,1)),
-			(IECore.V2f(1,0), IECore.V2f(0,5)),
-			(IECore.V2f(5,0), IECore.V2f(0,5)) ]
+			(imath.V2f(1,0), imath.V2f(0,1)),
+			(imath.V2f(5,0), imath.V2f(0,1)),
+			(imath.V2f(1,0), imath.V2f(0,5)),
+			(imath.V2f(5,0), imath.V2f(0,5)) ]
 
 		for angle in range( 0, 91, 15 ):
 			sa = math.sin( angle / 180.0 * math.pi )
 			ca = math.cos( angle / 180.0 * math.pi )
-			dirs.append( ( IECore.V2f(ca * 5, sa * 5 ), IECore.V2f(-sa * 3, ca * 3 ) ) )
+			dirs.append( ( imath.V2f(ca * 5, sa * 5 ), imath.V2f(-sa * 3, ca * 3 ) ) )
 
-		size = subSize * IECore.V2i( len( dirs ), len( filters ) )
-		w = IECore.Box2i( IECore.V2i( 0 ), size - IECore.V2i( 1 ) )
+		size = subSize * imath.V2i( len( dirs ), len( filters ) )
+		w = imath.Box2i( imath.V2i( 0 ), size - imath.V2i( 1 ) )
 		parallelogramImage = IECoreImage.ImagePrimitive( w, w )
 		boxImage = IECoreImage.ImagePrimitive( w, w )
 
@@ -94,7 +95,7 @@ class FilterAlgoTest( GafferImageTest.ImageTestCase ) :
 			for y_sub, f in enumerate( filters ):
 				for y in range( subSize ):
 					for x in range( subSize ):
-						p = IECore.V2f( x + 0.5, y + 0.5 )
+						p = imath.V2f( x + 0.5, y + 0.5 )
 						inputDerivatives = GafferImage.FilterAlgo.derivativesToAxisAligned( p, d[0], d[1] )
 
 
@@ -133,7 +134,7 @@ class FilterAlgoTest( GafferImageTest.ImageTestCase ) :
 			reader["fileName"].setValue( inputFileName )
 
 			inSize = reader["out"]["format"].getValue().getDisplayWindow().size()
-			inSize = IECore.V2f( inSize.x, inSize.y )
+			inSize = imath.V2f( inSize.x, inSize.y )
 
 			deleteChannels = GafferImage.DeleteChannels()
 			deleteChannels["mode"].setValue( 1 )
@@ -141,28 +142,28 @@ class FilterAlgoTest( GafferImageTest.ImageTestCase ) :
 			deleteChannels["in"].setInput( reader["out"] )
 
 
-			scale = IECore.V2f( size.x, size.y ) / inSize
+			scale = imath.V2f( size.x, size.y ) / inSize
 
 			resample = GafferImage.Resample()
 			resample["in"].setInput( deleteChannels["out"] )
 			resample["matrix"].setValue(
-				IECore.M33f().scale( scale )
+				imath.M33f().scale( scale )
 			)
 			resample["filter"].setValue( filter )
 			resample["boundingMode"].setValue( GafferImage.Sampler.BoundingMode.Clamp )
 
 			crop = GafferImage.Crop()
 			crop["in"].setInput( resample["out"] )
-			crop["area"].setValue( IECore.Box2i( IECore.V2i( 0 ), size ) )
+			crop["area"].setValue( imath.Box2i( imath.V2i( 0 ), size ) )
 
 			borderForFilterWidth = 60
 			sampleRegion = reader["out"]["dataWindow"].getValue()
-			sampleRegion.min -= IECore.V2i( borderForFilterWidth )
-			sampleRegion.max += IECore.V2i( borderForFilterWidth )
+			sampleRegion.setMin( sampleRegion.min() - imath.V2i( borderForFilterWidth ) )
+			sampleRegion.setMax( sampleRegion.max() + imath.V2i( borderForFilterWidth ) )
 
 			s = GafferImage.Sampler( reader["out"], "R", sampleRegion, GafferImage.Sampler.BoundingMode.Clamp )
 
-			w = IECore.Box2i( IECore.V2i( 0 ), size - IECore.V2i( 1 ) )
+			w = imath.Box2i( imath.V2i( 0 ), size - imath.V2i( 1 ) )
 			boxImage = IECoreImage.ImagePrimitive( w, w )
 			parallelImage = IECoreImage.ImagePrimitive( w, w )
 
@@ -173,15 +174,15 @@ class FilterAlgoTest( GafferImageTest.ImageTestCase ) :
 				for x in range( size.x ):
 						boxR[ ( size.y - 1 - y ) * size.x + x ] = GafferImage.FilterAlgo.sampleBox(
 							s,
-							IECore.V2f( x + 0.5, y + 0.5 ) / scale,
+							imath.V2f( x + 0.5, y + 0.5 ) / scale,
 							max( 1.0 / scale[0], 1.0 ),
 							max( 1.0 / scale[1], 1.0 ),
 							filter )
 						parallelR[ ( size.y - 1 - y ) * size.x + x ] = GafferImage.FilterAlgo.sampleParallelogram(
 							s,
-							IECore.V2f( x + 0.5, y + 0.5 ) / scale,
-							IECore.V2f( 1.0 / scale[0], 0),
-							IECore.V2f( 0, 1.0 / scale[1]),
+							imath.V2f( x + 0.5, y + 0.5 ) / scale,
+							imath.V2f( 1.0 / scale[0], 0),
+							imath.V2f( 0, 1.0 / scale[1]),
 							filter )
 
 			boxImage["R"] = boxR
@@ -209,11 +210,11 @@ class FilterAlgoTest( GafferImageTest.ImageTestCase ) :
 			self.assertImagesEqual( crop["out"], imageNode["out"], maxDifference = 0.000011, ignoreMetadata = True )
 
 		tests = [
-			( "resamplePatterns.exr", IECore.V2i( 4 ), "lanczos3" ),
-			( "resamplePatterns.exr", IECore.V2i( 40 ), "box" ),
-			( "resamplePatterns.exr", IECore.V2i( 101 ), "gaussian" ),
-			( "resamplePatterns.exr", IECore.V2i( 119 ), "mitchell" ),
-			( "resamplePatterns.exr", IECore.V2i( 300 ), "sinc" ),
+			( "resamplePatterns.exr", imath.V2i( 4 ), "lanczos3" ),
+			( "resamplePatterns.exr", imath.V2i( 40 ), "box" ),
+			( "resamplePatterns.exr", imath.V2i( 101 ), "gaussian" ),
+			( "resamplePatterns.exr", imath.V2i( 119 ), "mitchell" ),
+			( "resamplePatterns.exr", imath.V2i( 300 ), "sinc" ),
 		]
 
 		for args in tests :

--- a/python/GafferImageTest/FormatDataTest.py
+++ b/python/GafferImageTest/FormatDataTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -46,8 +47,8 @@ class FormatDataTest( GafferImageTest.ImageTestCase ) :
 
 	def test( self ) :
 
-		f1 = GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200, 100 ) ), 0.5 )
-		f2 = GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200, 100 ) ), 1 )
+		f1 = GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 200, 100 ) ), 0.5 )
+		f2 = GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 200, 100 ) ), 1 )
 
 		fd1a = GafferImage.FormatData( f1 )
 		fd1b = GafferImage.FormatData( f1 )
@@ -69,7 +70,7 @@ class FormatDataTest( GafferImageTest.ImageTestCase ) :
 
 	def testSerialisation( self ) :
 
-		f = GafferImage.Format( IECore.Box2i( IECore.V2i( 10, 20 ), IECore.V2i( 200, 100 ) ), 0.5 )
+		f = GafferImage.Format( imath.Box2i( imath.V2i( 10, 20 ), imath.V2i( 200, 100 ) ), 0.5 )
 		fd = GafferImage.FormatData( f )
 
 		m = IECore.MemoryIndexedIO( IECore.CharVectorData(), [], IECore.IndexedIO.OpenMode.Write )
@@ -84,7 +85,7 @@ class FormatDataTest( GafferImageTest.ImageTestCase ) :
 
 	def testAutoConstructFromFormat( self ) :
 
-		f = GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200, 100 ) ), 0.5 )
+		f = GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 200, 100 ) ), 0.5 )
 
 		d = IECore.CompoundData()
 		d["f"] = f

--- a/python/GafferImageTest/FormatPlugTest.py
+++ b/python/GafferImageTest/FormatPlugTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import inspect
+import imath
 
 import IECore
 
@@ -78,7 +79,7 @@ class FormatPlugTest( GafferImageTest.ImageTestCase ) :
 	def testValue( self ) :
 
 		p = GafferImage.FormatPlug()
-		v = GafferImage.Format( IECore.Box2i( IECore.V2i( 11, 12 ), IECore.V2i( 100, 200 ) ), 2 )
+		v = GafferImage.Format( imath.Box2i( imath.V2i( 11, 12 ), imath.V2i( 100, 200 ) ), 2 )
 
 		p.setValue( v )
 		self.assertEqual( p.getValue(), v )
@@ -180,17 +181,17 @@ class FormatPlugTest( GafferImageTest.ImageTestCase ) :
 			"""
 			f = parent["n1"]["user"]["f"]
 			b = f.getDisplayWindow()
-			b.min -= IECore.V2i( 10 )
-			b.max += IECore.V2i( 20 )
+			b.setMin( b.min() - imath.V2i( 10 ) )
+			b.setMax( b.max() + imath.V2i( 20 ) )
 			f.setPixelAspect( 0.5 )
 			f.setDisplayWindow( b )
 			parent["n2"]["user"]["f"] = f
 			"""
 		) )
 
-		s["n1"]["user"]["f"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 20, 30 ), IECore.V2i( 100, 110 ) ), 1 ) )
+		s["n1"]["user"]["f"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 20, 30 ), imath.V2i( 100, 110 ) ), 1 ) )
 
-		self.assertEqual( s["n2"]["user"]["f"].getValue(), GafferImage.Format( IECore.Box2i( IECore.V2i( 10, 20 ), IECore.V2i( 120, 130 ) ), 0.5 ) )
+		self.assertEqual( s["n2"]["user"]["f"].getValue(), GafferImage.Format( imath.Box2i( imath.V2i( 10, 20 ), imath.V2i( 120, 130 ) ), 0.5 ) )
 
 	def testDefaultExpression( self ) :
 

--- a/python/GafferImageTest/FormatTest.py
+++ b/python/GafferImageTest/FormatTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import random
+import imath
 
 import IECore
 
@@ -49,7 +50,7 @@ class FormatTest( GafferImageTest.ImageTestCase ) :
 
 	def testOffsetDisplayWindow( self ) :
 
-		box = IECore.Box2i( IECore.V2i( 6, -4 ), IECore.V2i( 50, 150 ) )
+		box = imath.Box2i( imath.V2i( 6, -4 ), imath.V2i( 50, 150 ) )
 		f = GafferImage.Format( box, 1.1 )
 		self.assertEqual( f.getDisplayWindow(), box )
 		self.assertEqual( f.width(), 44 )
@@ -58,7 +59,7 @@ class FormatTest( GafferImageTest.ImageTestCase ) :
 
 	def testBoxAspectConstructor( self ) :
 
-		f = GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 50, 150 ) ), 1.3 )
+		f = GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 50, 150 ) ), 1.3 )
 		self.assertEqual( f.width(), 50 )
 		self.assertEqual( f.height(), 150 )
 		self.assertEqual( f.getPixelAspect(), 1.3 )
@@ -68,7 +69,7 @@ class FormatTest( GafferImageTest.ImageTestCase ) :
 		f = GafferImage.Format( 100, 100 )
 		self.assertEqual( f.getPixelAspect(), 1. )
 
-		f = GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 100, 100 ) ) )
+		f = GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 100, 100 ) ) )
 		self.assertEqual( f.getPixelAspect(), 1. )
 
 	def testWH( self ) :
@@ -83,76 +84,76 @@ class FormatTest( GafferImageTest.ImageTestCase ) :
 
 	def testEXRSpaceFormat( self ) :
 
-		f = GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 99 ) ), 1.0, True )
+		f = GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 99 ) ), 1.0, True )
 		self.assertEqual( f.width(), 100 )
 		self.assertEqual( f.height(), 100 )
 		self.assertEqual(
 			f.toEXRSpace( f.getDisplayWindow() ),
-			IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 99 ) ),
+			imath.Box2i( imath.V2i( 0 ), imath.V2i( 99 ) ),
 		)
 
-		f = GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 99 ) ), 1.0, fromEXRSpace = True )
+		f = GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 99 ) ), 1.0, fromEXRSpace = True )
 		self.assertEqual( f.width(), 100 )
 		self.assertEqual( f.height(), 100 )
 		self.assertEqual(
 			f.toEXRSpace( f.getDisplayWindow() ),
-			IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 99 ) ),
+			imath.Box2i( imath.V2i( 0 ), imath.V2i( 99 ) ),
 		)
 
-		f = GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 100 ) ), 1.0, fromEXRSpace = False )
+		f = GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 100 ) ), 1.0, fromEXRSpace = False )
 		self.assertEqual( f.width(), 100 )
 		self.assertEqual( f.height(), 100 )
 		self.assertEqual(
 			f.getDisplayWindow(),
-			IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 100 ) ),
+			imath.Box2i( imath.V2i( 0 ), imath.V2i( 100 ) ),
 		)
 
 	def testCoordinateSystemTransforms( self ) :
 
-		f = GafferImage.Format( IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, 301 ) ), 1 )
+		f = GafferImage.Format( imath.Box2i( imath.V2i( -100, -200 ), imath.V2i( 501, 301 ) ), 1 )
 
-		self.assertEqual( f.fromEXRSpace( IECore.V2i( -100, -200 ) ), IECore.V2i( -100, 300 ) )
-		self.assertEqual( f.fromEXRSpace( IECore.V2i( -100, 300 ) ), IECore.V2i( -100, -200 ) )
+		self.assertEqual( f.fromEXRSpace( imath.V2i( -100, -200 ) ), imath.V2i( -100, 300 ) )
+		self.assertEqual( f.fromEXRSpace( imath.V2i( -100, 300 ) ), imath.V2i( -100, -200 ) )
 
-		self.assertEqual( f.toEXRSpace( IECore.V2i( -100, -200 ) ), IECore.V2i( -100, 300 ) )
-		self.assertEqual( f.toEXRSpace( IECore.V2i( -100, 300 ) ), IECore.V2i( -100, -200 ) )
+		self.assertEqual( f.toEXRSpace( imath.V2i( -100, -200 ) ), imath.V2i( -100, 300 ) )
+		self.assertEqual( f.toEXRSpace( imath.V2i( -100, 300 ) ), imath.V2i( -100, -200 ) )
 
 		self.assertEqual(
 			f.toEXRSpace(
-				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, 301 ) )
+				imath.Box2i( imath.V2i( -100, -200 ), imath.V2i( 501, 301 ) )
 			),
-			IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 500, 300 ) )
+			imath.Box2i( imath.V2i( -100, -200 ), imath.V2i( 500, 300 ) )
 		)
 
 		self.assertEqual(
 			f.toEXRSpace(
-				IECore.Box2i( IECore.V2i( -100, -100 ), IECore.V2i( 501, 301 ) )
+				imath.Box2i( imath.V2i( -100, -100 ), imath.V2i( 501, 301 ) )
 			),
-			IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 500, 200 ) )
+			imath.Box2i( imath.V2i( -100, -200 ), imath.V2i( 500, 200 ) )
 		)
 
 		self.assertEqual(
 			f.toEXRSpace(
-				IECore.Box2i( IECore.V2i( -100, -200 ), IECore.V2i( 501, -100 ) )
+				imath.Box2i( imath.V2i( -100, -200 ), imath.V2i( 501, -100 ) )
 			),
-			IECore.Box2i( IECore.V2i( -100, 201 ), IECore.V2i( 500, 300 ) )
+			imath.Box2i( imath.V2i( -100, 201 ), imath.V2i( 500, 300 ) )
 		)
 
 		for i in range( 0, 1000 ) :
 
-			p = IECore.V2i( int( random.uniform( -500, 500 ) ), int( random.uniform( -500, 500 ) ) )
+			p = imath.V2i( int( random.uniform( -500, 500 ) ), int( random.uniform( -500, 500 ) ) )
 			pDown = f.toEXRSpace( p )
 			self.assertEqual( f.fromEXRSpace( pDown ), p )
 
-			b = IECore.Box2i()
-			b.extendBy( IECore.V2i( int( random.uniform( -500, 500 ) ), int( random.uniform( -500, 500 ) ) ) )
-			b.extendBy( IECore.V2i( int( random.uniform( -500, 500 ) ), int( random.uniform( -500, 500 ) ) ) )
+			b = imath.Box2i()
+			b.extendBy( imath.V2i( int( random.uniform( -500, 500 ) ), int( random.uniform( -500, 500 ) ) ) )
+			b.extendBy( imath.V2i( int( random.uniform( -500, 500 ) ), int( random.uniform( -500, 500 ) ) ) )
 
 			bDown = f.toEXRSpace( b )
 			if not GafferImage.BufferAlgo.empty( b ) :
 				self.assertEqual( f.fromEXRSpace( bDown ), b )
 			else :
-				self.assertEqual( f.fromEXRSpace( bDown ), IECore.Box2i() )
+				self.assertEqual( f.fromEXRSpace( bDown ), imath.Box2i() )
 
 	def testDisplayWindowCoordinateSystemTransforms( self ) :
 
@@ -166,11 +167,11 @@ class FormatTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual(
 			f.toEXRSpace( f.getDisplayWindow() ),
-			IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 9 ) )
+			imath.Box2i( imath.V2i( 0 ), imath.V2i( 9 ) )
 		)
 
 		self.assertEqual(
-			f.fromEXRSpace( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 9 ) ) ),
+			f.fromEXRSpace( imath.Box2i( imath.V2i( 0 ), imath.V2i( 9 ) ) ),
 			f.getDisplayWindow()
 		)
 
@@ -209,15 +210,15 @@ class FormatTest( GafferImageTest.ImageTestCase ) :
 		f = GafferImage.Format( 10, 20, 2 )
 		self.assertEqual( str( f ), "10x20, 2" )
 
-		f = GafferImage.Format( IECore.Box2i( IECore.V2i( 10 ), IECore.V2i( 20 ) ) )
+		f = GafferImage.Format( imath.Box2i( imath.V2i( 10 ), imath.V2i( 20 ) ) )
 		self.assertEqual( str( f ), "(10 10) - (20 20)" )
 
 	def testEmptyBoxCoordinateSystemTransforms( self ) :
 
 		f = GafferImage.Format( 100, 200 )
-		self.assertEqual( f.toEXRSpace( IECore.Box2i() ), IECore.Box2i() )
-		self.assertEqual( f.toEXRSpace( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 0 ) ) ), IECore.Box2i() )
-		self.assertEqual( f.fromEXRSpace( IECore.Box2i() ), IECore.Box2i() )
+		self.assertEqual( f.toEXRSpace( imath.Box2i() ), imath.Box2i() )
+		self.assertEqual( f.toEXRSpace( imath.Box2i( imath.V2i( 0 ), imath.V2i( 0 ) ) ), imath.Box2i() )
+		self.assertEqual( f.fromEXRSpace( imath.Box2i() ), imath.Box2i() )
 
 	def tearDown( self ) :
 

--- a/python/GafferImageTest/GradeTest.py
+++ b/python/GafferImageTest/GradeTest.py
@@ -37,6 +37,7 @@
 import os
 import inspect
 import unittest
+import imath
 
 import IECore
 
@@ -56,17 +57,17 @@ class GradeTest( GafferImageTest.ImageTestCase ) :
 		# Create a grade node and save the hash of a tile from each channel.
 		grade = GafferImage.Grade()
 		grade["in"].setInput(i["out"])
-		grade["gain"].setValue( IECore.Color3f( 2., 2., 2. ) )
-		hashRed = grade["out"].channelData( "R", IECore.V2i( 0 ) ).hash()
-		hashGreen = grade["out"].channelData( "G", IECore.V2i( 0 ) ).hash()
-		hashBlue = grade["out"].channelData( "B", IECore.V2i( 0 ) ).hash()
+		grade["gain"].setValue( imath.Color3f( 2., 2., 2. ) )
+		hashRed = grade["out"].channelData( "R", imath.V2i( 0 ) ).hash()
+		hashGreen = grade["out"].channelData( "G", imath.V2i( 0 ) ).hash()
+		hashBlue = grade["out"].channelData( "B", imath.V2i( 0 ) ).hash()
 
 		# Now we set the gamma on the green channel to 0 which should disable it's output.
 		# The red and blue channels should still be graded as before.
-		grade["gamma"].setValue( IECore.Color3f( 1., 0., 1. ) )
-		hashRed2 = grade["out"].channelData( "R", IECore.V2i( 0 ) ).hash()
-		hashGreen2 = grade["out"].channelData( "G", IECore.V2i( 0 ) ).hash()
-		hashBlue2 = grade["out"].channelData( "B", IECore.V2i( 0 ) ).hash()
+		grade["gamma"].setValue( imath.Color3f( 1., 0., 1. ) )
+		hashRed2 = grade["out"].channelData( "R", imath.V2i( 0 ) ).hash()
+		hashGreen2 = grade["out"].channelData( "G", imath.V2i( 0 ) ).hash()
+		hashBlue2 = grade["out"].channelData( "B", imath.V2i( 0 ) ).hash()
 
 		self.assertEqual( hashRed, hashRed2 )
 		self.assertNotEqual( hashGreen, hashGreen2 )
@@ -79,16 +80,16 @@ class GradeTest( GafferImageTest.ImageTestCase ) :
 
 		grade = GafferImage.Grade()
 		grade["in"].setInput(i["out"])
-		grade["gain"].setValue( IECore.Color3f( 2., 2., 2. ) )
+		grade["gain"].setValue( imath.Color3f( 2., 2., 2. ) )
 
-		h1 = grade["out"].channelData( "R", IECore.V2i( 0 ) ).hash()
-		h2 = grade["out"].channelData( "R", IECore.V2i( GafferImage.ImagePlug().tileSize() ) ).hash()
+		h1 = grade["out"].channelData( "R", imath.V2i( 0 ) ).hash()
+		h2 = grade["out"].channelData( "R", imath.V2i( GafferImage.ImagePlug().tileSize() ) ).hash()
 		self.assertNotEqual( h1, h2 )
 
 		# Test that two tiles within the same image have the same hash when disabled.
 		grade["enabled"].setValue(False)
-		h1 = grade["out"].channelData( "R", IECore.V2i( 0 ) ).hash()
-		h2 = grade["out"].channelData( "R", IECore.V2i( GafferImage.ImagePlug().tileSize() ) ).hash()
+		h1 = grade["out"].channelData( "R", imath.V2i( 0 ) ).hash()
+		h2 = grade["out"].channelData( "R", imath.V2i( GafferImage.ImagePlug().tileSize() ) ).hash()
 		self.assertNotEqual( h1, h2 )
 
 	def testEnableBehaviour( self ) :
@@ -107,7 +108,7 @@ class GradeTest( GafferImageTest.ImageTestCase ) :
 
 		g = GafferImage.Grade()
 		g["in"].setInput( i["out"] )
-		g["gain"].setValue( IECore.Color3f( 2., 2., 2. ) )
+		g["gain"].setValue( imath.Color3f( 2., 2., 2. ) )
 
 		self.assertEqual( i["out"]["format"].hash(), g["out"]["format"].hash() )
 		self.assertEqual( i["out"]["dataWindow"].hash(), g["out"]["dataWindow"].hash() )
@@ -132,9 +133,9 @@ class GradeTest( GafferImageTest.ImageTestCase ) :
 		channelNames = ( "R", "G", "B" )
 		for channelIndex, channelName in enumerate( channelNames ) :
 			for plugName in ( "blackPoint", "whitePoint", "lift", "gain", "multiply", "offset", "gamma" ) :
-				oldChannelHashes = [ s["g"]["out"].channelDataHash( c, IECore.V2i( 0 ) ) for c in channelNames ]
+				oldChannelHashes = [ s["g"]["out"].channelDataHash( c, imath.V2i( 0 ) ) for c in channelNames ]
 				s["g"][plugName][channelIndex].setValue( s["g"][plugName][channelIndex].getValue() + 0.01 )
-				newChannelHashes = [ s["g"]["out"].channelDataHash( c, IECore.V2i( 0 ) ) for c in channelNames ]
+				newChannelHashes = [ s["g"]["out"].channelDataHash( c, imath.V2i( 0 ) ) for c in channelNames ]
 				for hashChannelIndex in range( 0, 3 ) :
 					if channelIndex == hashChannelIndex :
 						self.assertNotEqual( oldChannelHashes[hashChannelIndex], newChannelHashes[hashChannelIndex] )
@@ -153,13 +154,13 @@ class GradeTest( GafferImageTest.ImageTestCase ) :
 
 		for channelName in ( "R", "G", "B", "A" ) :
 			self.assertEqual(
-				s["g"]["out"].channelDataHash( channelName, IECore.V2i( 0 ) ),
-				s["c"]["out"].channelDataHash( channelName, IECore.V2i( 0 ) ),
+				s["g"]["out"].channelDataHash( channelName, imath.V2i( 0 ) ),
+				s["c"]["out"].channelDataHash( channelName, imath.V2i( 0 ) ),
 			)
 
 			c = Gaffer.Context( s.context() )
 			c["image:channelName"] = channelName
-			c["image:tileOrigin"] = IECore.V2i( 0 )
+			c["image:tileOrigin"] = imath.V2i( 0 )
 			with c :
 				self.assertTrue(
 					s["g"]["out"]["channelData"].getValue( _copy=False ).isSame(
@@ -170,7 +171,7 @@ class GradeTest( GafferImageTest.ImageTestCase ) :
 	def testAllChannels( self ):
 		c = GafferImage.Constant()
 		c["format"].setValue( GafferImage.Format( 50, 50, 1.0 ) )
-		c["color"].setValue( IECore.Color4f( 0.125, 0.25, 0.5, 0.75 ) )
+		c["color"].setValue( imath.Color4f( 0.125, 0.25, 0.5, 0.75 ) )
 
 		s = GafferImage.Shuffle()
 		s["channels"].addChild( GafferImage.Shuffle.ChannelPlug( 'customChannel', '__white' ) )
@@ -196,7 +197,7 @@ class GradeTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual( sample( 25, 25 ), [ 0.125, 0.25, 0.5, 0.75, 1.0 ] )
 
-		g["offset"].setValue( IECore.Color4f( 3, 3, 3, 3 ) )
+		g["offset"].setValue( imath.Color4f( 3, 3, 3, 3 ) )
 		self.assertEqual( sample( 25, 25 ), [ 3.125, 3.25, 3.5, 0.75, 1.0 ] )
 
 		g["channels"].setValue( IECore.StringVectorData( [ "A" ] ) )
@@ -213,10 +214,10 @@ class GradeTest( GafferImageTest.ImageTestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["c1"] = GafferImage.Constant()
-		script["c1"]["color"].setValue( IECore.Color4f( 1 ) )
+		script["c1"]["color"].setValue( imath.Color4f( 1 ) )
 
 		script["c2"] = GafferImage.Constant()
-		script["c2"]["color"].setValue( IECore.Color4f( 1 ) )
+		script["c2"]["color"].setValue( imath.Color4f( 1 ) )
 		script["c2"]["layer"].setValue( "B" )
 
 		script["copyChannels"] = GafferImage.CopyChannels()
@@ -233,16 +234,16 @@ class GradeTest( GafferImageTest.ImageTestCase ) :
 			"""
 			import GafferImage
 			layerName = GafferImage.ImageAlgo.layerName( context["image:channelName" ] )
-			parent["grade"]["gain"] = IECore.Color4f( 1 if layerName == "B" else 0.5 )
+			parent["grade"]["gain"] = imath.Color4f( 1 if layerName == "B" else 0.5 )
 			"""
 		) )
 
 		sampler = GafferImage.ImageSampler()
 		sampler["image"].setInput( script["grade"]["out"] )
-		sampler["pixel"].setValue( IECore.V2f( 10.5 ) )
+		sampler["pixel"].setValue( imath.V2f( 10.5 ) )
 
 		sampler["channels"].setValue( IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
-		self.assertEqual( sampler["color"].getValue(), IECore.Color4f( 0.5 ) )
+		self.assertEqual( sampler["color"].getValue(), imath.Color4f( 0.5 ) )
 
 		sampler["channels"].setValue( IECore.StringVectorData( [ "B.R", "B.G", "B.B", "B.A" ] ) )
-		self.assertEqual( sampler["color"].getValue(), IECore.Color4f( 1 ) )
+		self.assertEqual( sampler["color"].getValue(), imath.Color4f( 1 ) )

--- a/python/GafferImageTest/ImageAlgoTest.py
+++ b/python/GafferImageTest/ImageAlgoTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -141,7 +142,7 @@ class ImageAlgoTest( GafferImageTest.ImageTestCase ) :
 	def testParallelProcessEmptyDataWindow( self ) :
 
 		d = GafferImage.Display()
-		self.assertEqual( d["out"]["dataWindow"].getValue(), IECore.Box2i() )
+		self.assertEqual( d["out"]["dataWindow"].getValue(), imath.Box2i() )
 
 		GafferImageTest.processTiles( d["out"] )
 		d["out"].image()

--- a/python/GafferImageTest/ImageLoopTest.py
+++ b/python/GafferImageTest/ImageLoopTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import inspect
+import imath
 
 import IECore
 
@@ -60,12 +61,12 @@ class ImageLoopTest( GafferImageTest.ImageTestCase ) :
 		script["loop"]["in"].setInput( script["c"]["out"] )
 
 		script["grade"] = GafferImage.Grade()
-		script["grade"]["offset"].setValue( IECore.Color3f( .1 ) )
+		script["grade"]["offset"].setValue( imath.Color3f( .1 ) )
 		script["grade"]["in"].setInput( script["loop"]["previous"] )
 		script["loop"]["next"].setInput( script["grade"]["out"] )
 
 		script["sampler"] = GafferImage.ImageSampler()
-		script["sampler"]["pixel"].setValue( IECore.V2f( 10 ) )
+		script["sampler"]["pixel"].setValue( imath.V2f( 10 ) )
 		script["sampler"]["image"].setInput( script["loop"]["out"] )
 
 		with script.context() :
@@ -96,12 +97,12 @@ class ImageLoopTest( GafferImageTest.ImageTestCase ) :
 		script["loop"]["in"].setInput( script["c"]["out"] )
 
 		script["grade"] = GafferImage.Grade()
-		script["grade"]["offset"].setValue( IECore.Color3f( .1 ) )
+		script["grade"]["offset"].setValue( imath.Color3f( .1 ) )
 		script["grade"]["in"].setInput( script["loop"]["previous"] )
 		script["loop"]["next"].setInput( script["grade"]["out"] )
 
 		script["sampler"] = GafferImage.ImageSampler()
-		script["sampler"]["pixel"].setValue( IECore.V2f( 10 ) )
+		script["sampler"]["pixel"].setValue( imath.V2f( 10 ) )
 		script["sampler"]["image"].setInput( script["loop"]["out"] )
 
 		script["expression"] = Gaffer.Expression()

--- a/python/GafferImageTest/ImageMetadataTest.py
+++ b/python/GafferImageTest/ImageMetadataTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import imath
 
 import IECore
 
@@ -64,12 +65,12 @@ class ImageMetadataTest( GafferImageTest.ImageTestCase ) :
 		# check that we can make metadata
 
 		m["metadata"].addMember( "comment", IECore.StringData( "my favorite image!" ) )
-		m["metadata"].addOptionalMember( "range", IECore.V2iData( IECore.V2i( 5, 10 ) ), enabled = True )
+		m["metadata"].addOptionalMember( "range", IECore.V2iData( imath.V2i( 5, 10 ) ), enabled = True )
 
 		metadata = m["out"]["metadata"].getValue()
 		self.assertEqual( len(metadata), len(inMetadata) + 2 )
 		self.assertEqual( metadata["comment"], IECore.StringData( "my favorite image!" ) )
-		self.assertEqual( metadata["range"], IECore.V2iData( IECore.V2i( 5, 10 ) ) )
+		self.assertEqual( metadata["range"], IECore.V2iData( imath.V2i( 5, 10 ) ) )
 		del metadata["comment"]
 		del metadata["range"]
 		self.assertEqual( metadata, inMetadata )
@@ -113,7 +114,7 @@ class ImageMetadataTest( GafferImageTest.ImageTestCase ) :
 		s = Gaffer.ScriptNode()
 		s["m"] = GafferImage.ImageMetadata()
 		s["m"]["metadata"].addMember( "comment", IECore.StringData( "my favorite image!" ) )
-		s["m"]["metadata"].addOptionalMember( "range", IECore.V2iData( IECore.V2i( 5, 10 ) ), enabled = True )
+		s["m"]["metadata"].addOptionalMember( "range", IECore.V2iData( imath.V2i( 5, 10 ) ), enabled = True )
 		names = s["m"]["metadata"].keys()
 
 		s2 = Gaffer.ScriptNode()
@@ -125,14 +126,14 @@ class ImageMetadataTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( s2["m"]["metadata"][names[0]]["value"].getValue(), "my favorite image!" )
 		self.assertEqual( s2["m"]["metadata"][names[1]]["name"].getValue(), "range" )
 		self.assertEqual( s2["m"]["metadata"][names[1]]["enabled"].getValue(), True )
-		self.assertEqual( s2["m"]["metadata"][names[1]]["value"].getValue(), IECore.V2i( 5, 10 ) )
+		self.assertEqual( s2["m"]["metadata"][names[1]]["value"].getValue(), imath.V2i( 5, 10 ) )
 
 	def testBoxPromotion( self ) :
 
 		s = Gaffer.ScriptNode()
 		s["m"] = GafferImage.ImageMetadata()
 		s["m"]["metadata"].addMember( "comment", IECore.StringData( "my favorite image!" ) )
-		s["m"]["metadata"].addOptionalMember( "range", IECore.V2iData( IECore.V2i( 5, 10 ) ), enabled = True )
+		s["m"]["metadata"].addOptionalMember( "range", IECore.V2iData( imath.V2i( 5, 10 ) ), enabled = True )
 
 		memberDataAndName = s["m"]["metadata"].memberDataAndName( s["m"]["metadata"]["member1"] )
 		memberDataAndName2 = s["m"]["metadata"].memberDataAndName( s["m"]["metadata"]["member2"] )
@@ -172,7 +173,7 @@ class ImageMetadataTest( GafferImageTest.ImageTestCase ) :
 		m = GafferImage.ImageMetadata()
 		m["in"].setInput( i["out"] )
 		m["metadata"].addMember( "comment", IECore.StringData( "my favorite image!" ) )
-		m["metadata"].addOptionalMember( "range", IECore.V2iData( IECore.V2i( 5, 10 ) ), enabled = True )
+		m["metadata"].addOptionalMember( "range", IECore.V2iData( imath.V2i( 5, 10 ) ), enabled = True )
 
 		self.assertEqual( i["out"]["format"].hash(), m["out"]["format"].hash() )
 		self.assertEqual( i["out"]["dataWindow"].hash(), m["out"]["dataWindow"].hash() )
@@ -183,7 +184,7 @@ class ImageMetadataTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( i["out"]["channelNames"].getValue(), m["out"]["channelNames"].getValue() )
 
 		context = Gaffer.Context()
-		context["image:tileOrigin"] = IECore.V2i( 0 )
+		context["image:tileOrigin"] = imath.V2i( 0 )
 		with context :
 			for c in [ "G", "B", "A" ] :
 				context["image:channelName"] = c

--- a/python/GafferImageTest/ImageNodeTest.py
+++ b/python/GafferImageTest/ImageNodeTest.py
@@ -37,6 +37,7 @@
 import os
 import unittest
 import threading
+import imath
 
 import IECore
 
@@ -53,12 +54,12 @@ class ImageNodeTest( GafferImageTest.ImageTestCase ) :
 		c["format"].setValue( GafferImage.Format( 200, 200, 1.0 ) )
 		g = GafferImage.Grade()
 		g["in"].setInput( c["out"] )
-		g["multiply"].setValue( IECore.Color3f( 0.4, 0.5, 0.6 ) )
+		g["multiply"].setValue( imath.Color3f( 0.4, 0.5, 0.6 ) )
 
 		gradedImage = g["out"].image()
 
 		# not enough for both images - will cause cache thrashing
-		Gaffer.ValuePlug.setCacheMemoryLimit( 2 * g["out"].channelData( "R", IECore.V2i( 0 ) ).memoryUsage() )
+		Gaffer.ValuePlug.setCacheMemoryLimit( 2 * g["out"].channelData( "R", imath.V2i( 0 ) ).memoryUsage() )
 
 		images = []
 		exceptions = []

--- a/python/GafferImageTest/ImagePlugTest.py
+++ b/python/GafferImageTest/ImagePlugTest.py
@@ -37,6 +37,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 import Gaffer
@@ -51,14 +52,14 @@ class ImagePlugTest( GafferImageTest.ImageTestCase ) :
 		ts = GafferImage.ImagePlug.tileSize()
 
 		testCases = [
-			( IECore.V2i( ts-1, ts-1 ), IECore.V2i( 0, 0 ) ),
-			( IECore.V2i( ts, ts-1 ), IECore.V2i( ts, 0 ) ),
-			( IECore.V2i( ts, ts ), IECore.V2i( ts, ts ) ),
-			( IECore.V2i( ts*3-1, ts+5 ), IECore.V2i( ts*2, ts ) ),
-			( IECore.V2i( ts*3, ts-5 ), IECore.V2i( ts*3, 0 ) ),
-			( IECore.V2i( -ts+ts/2, 0 ), IECore.V2i( -ts, 0 ) ),
-			( IECore.V2i( ts*5+ts/3, -ts*4 ), IECore.V2i( ts*5, -ts*4 ) ),
-			( IECore.V2i( -ts+1, -ts-1 ), IECore.V2i( -ts, -ts*2 ) )
+			( imath.V2i( ts-1, ts-1 ), imath.V2i( 0, 0 ) ),
+			( imath.V2i( ts, ts-1 ), imath.V2i( ts, 0 ) ),
+			( imath.V2i( ts, ts ), imath.V2i( ts, ts ) ),
+			( imath.V2i( ts*3-1, ts+5 ), imath.V2i( ts*2, ts ) ),
+			( imath.V2i( ts*3, ts-5 ), imath.V2i( ts*3, 0 ) ),
+			( imath.V2i( -ts+ts/2, 0 ), imath.V2i( -ts, 0 ) ),
+			( imath.V2i( ts*5+ts/3, -ts*4 ), imath.V2i( ts*5, -ts*4 ) ),
+			( imath.V2i( -ts+1, -ts-1 ), imath.V2i( -ts, -ts*2 ) )
 		]
 
 		for input, expectedResult in testCases :
@@ -72,11 +73,11 @@ class ImagePlugTest( GafferImageTest.ImageTestCase ) :
 		ts = GafferImage.ImagePlug.tileSize()
 
 		for position, tileIndex in [
-			( IECore.V2i( -ts ), IECore.V2i( -1 ) ),
-			( IECore.V2i( -ts -1 ), IECore.V2i( -2 ) ),
-			( IECore.V2i( 0 ), IECore.V2i( 0 ) ),
-			( IECore.V2i( ts ), IECore.V2i( 1 ) ),
-			( IECore.V2i( ts - 1 ), IECore.V2i( 0 ) ),
+			( imath.V2i( -ts ), imath.V2i( -1 ) ),
+			( imath.V2i( -ts -1 ), imath.V2i( -2 ) ),
+			( imath.V2i( 0 ), imath.V2i( 0 ) ),
+			( imath.V2i( ts ), imath.V2i( 1 ) ),
+			( imath.V2i( ts - 1 ), imath.V2i( 0 ) ),
 		] :
 			self.assertEqual(
 				GafferImage.ImagePlug.tileIndex( position ),
@@ -160,10 +161,10 @@ class ImagePlugTest( GafferImageTest.ImageTestCase ) :
 		with Gaffer.Context() as c :
 
 			GafferImage.FormatPlug.setDefaultFormat( c, GafferImage.Format( 100, 200 ) )
-			self.assertEqual( constant["out"].image().displayWindow, IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 99, 199 ) ) )
+			self.assertEqual( constant["out"].image().displayWindow, imath.Box2i( imath.V2i( 0 ), imath.V2i( 99, 199 ) ) )
 
 			GafferImage.FormatPlug.setDefaultFormat( c, GafferImage.Format( 200, 300 ) )
-			self.assertEqual( constant["out"].image().displayWindow, IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 199, 299 ) ) )
+			self.assertEqual( constant["out"].image().displayWindow, imath.Box2i( imath.V2i( 0 ), imath.V2i( 199, 299 ) ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -37,6 +37,7 @@
 import os
 import shutil
 import unittest
+import imath
 
 import IECore
 
@@ -74,21 +75,21 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( n["out"]["dataWindow"].getValue(), oiio["out"]["dataWindow"].getValue() )
 		self.assertEqual( n["out"]["metadata"].getValue(), oiio["out"]["metadata"].getValue() )
 		self.assertEqual( n["out"]["channelNames"].getValue(), oiio["out"]["channelNames"].getValue() )
-		self.assertEqual( n["out"].channelData( "R", IECore.V2i( 0 ) ),oiio["out"].channelData( "R", IECore.V2i( 0 ) ) )
+		self.assertEqual( n["out"].channelData( "R", imath.V2i( 0 ) ),oiio["out"].channelData( "R", imath.V2i( 0 ) ) )
 		self.assertImagesEqual( n["out"], oiio["out"] )
 
 	def testUnspecifiedFilename( self ) :
 
 		n = GafferImage.ImageReader()
 		n["out"]["channelNames"].getValue()
-		n["out"].channelData( "R", IECore.V2i( 0 ) )
+		n["out"].channelData( "R", imath.V2i( 0 ) )
 
 	def testChannelDataHashes( self ) :
 		# Test that two tiles within the same image have different hashes.
 		n = GafferImage.ImageReader()
 		n["fileName"].setValue( self.fileName )
-		h1 = n["out"].channelData( "R", IECore.V2i( 0 ) ).hash()
-		h2 = n["out"].channelData( "R", IECore.V2i( GafferImage.ImagePlug().tileSize() ) ).hash()
+		h1 = n["out"].channelData( "R", imath.V2i( 0 ) ).hash()
+		h2 = n["out"].channelData( "R", imath.V2i( GafferImage.ImagePlug().tileSize() ) ).hash()
 
 		self.assertNotEqual( h1, h2 )
 
@@ -148,7 +149,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		self.assertRaisesRegexp( RuntimeError, ".*wellIDontExist.exr.*", reader["out"]["dataWindow"].getValue )
 		self.assertRaisesRegexp( RuntimeError, ".*wellIDontExist.exr.*", reader["out"]["metadata"].getValue )
 		self.assertRaisesRegexp( RuntimeError, ".*wellIDontExist.exr.*", reader["out"]["channelNames"].getValue )
-		self.assertRaisesRegexp( RuntimeError, ".*wellIDontExist.exr.*", reader["out"].channelData, "R", IECore.V2i( 0 ) )
+		self.assertRaisesRegexp( RuntimeError, ".*wellIDontExist.exr.*", reader["out"].channelData, "R", imath.V2i( 0 ) )
 
 	def testMissingFrameMode( self ) :
 
@@ -168,7 +169,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), oiio["out"]["dataWindow"].getValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), oiio["out"]["metadata"].getValue() )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), oiio["out"]["channelNames"].getValue() )
-			self.assertEqual( reader["out"].channelData( "R", IECore.V2i( 0 ) ), oiio["out"].channelData( "R", IECore.V2i( 0 ) ) )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), oiio["out"].channelData( "R", imath.V2i( 0 ) ) )
 			self.assertImagesEqual( reader["out"], oiio["out"] )
 
 		context = Gaffer.Context()
@@ -184,7 +185,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["dataWindow"].getValue )
 			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["metadata"].getValue )
 			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["channelNames"].getValue )
-			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"].channelData, "R", IECore.V2i( 0 ) )
+			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"].channelData, "R", imath.V2i( 0 ) )
 
 		# Hold mode matches OpenImageIOReader
 		reader["missingFrameMode"].setValue( GafferImage.ImageReader.MissingFrameMode.Hold )
@@ -237,7 +238,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["dataWindow"].getValue )
 			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["metadata"].getValue )
 			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["channelNames"].getValue )
-			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"].channelData, "R", IECore.V2i( 0 ) )
+			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"].channelData, "R", imath.V2i( 0 ) )
 
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
 		oiio["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
@@ -247,7 +248,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), oiio["out"]["dataWindow"].getValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), oiio["out"]["metadata"].getValue() )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), oiio["out"]["channelNames"].getValue() )
-			self.assertEqual( reader["out"].channelData( "R", IECore.V2i( 0 ) ), oiio["out"].channelData( "R", IECore.V2i( 0 ) ) )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), oiio["out"].channelData( "R", imath.V2i( 0 ) ) )
 
 	def testFrameRangeMask( self ) :
 
@@ -273,7 +274,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		with context :
 			for i in range( 1, 11 ) :
 				context.setFrame( i )
-				self.assertNotEqual( reader["out"].channelData( "R", IECore.V2i( 0 ) ), blackTile )
+				self.assertNotEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), blackTile )
 
 		def assertBlack() :
 
@@ -285,7 +286,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( reader["out"]["metadata"].getValue(), reader["out"]["metadata"].defaultValue() )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), reader["out"]["channelNames"].defaultValue() )
 			# channel data is black
-			self.assertEqual( reader["out"].channelData( "R", IECore.V2i( 0 ) ), blackTile )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), blackTile )
 
 		def assertMatch() :
 
@@ -293,7 +294,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), oiio["out"]["dataWindow"].getValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), oiio["out"]["metadata"].getValue() )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), oiio["out"]["channelNames"].getValue() )
-			self.assertEqual( reader["out"].channelData( "R", IECore.V2i( 0 ) ), oiio["out"].channelData( "R", IECore.V2i( 0 ) ) )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), oiio["out"].channelData( "R", imath.V2i( 0 ) ) )
 			self.assertImagesEqual( reader["out"], oiio["out"] )
 
 		def assertHold( holdFrame ) :
@@ -306,13 +307,13 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 				holdDataWindow = reader["out"]["dataWindow"].getValue()
 				holdMetadata = reader["out"]["metadata"].getValue()
 				holdChannelNames = reader["out"]["channelNames"].getValue()
-				holdTile = reader["out"].channelData( "R", IECore.V2i( 0 ) )
+				holdTile = reader["out"].channelData( "R", imath.V2i( 0 ) )
 
 			self.assertEqual( reader["out"]["format"].getValue(), holdFormat )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), holdDataWindow )
 			self.assertEqual( reader["out"]["metadata"].getValue(), holdMetadata )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), holdChannelNames )
-			self.assertEqual( reader["out"].channelData( "R", IECore.V2i( 0 ) ), holdTile )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), holdTile )
 			self.assertEqual( reader["out"].image(), holdImage )
 
 		reader["start"]["frame"].setValue( 4 )
@@ -434,7 +435,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 			w.execute()
 
 			capturedArguments.clear()
-			r["out"].channelData( "R", IECore.V2i( 0 ) ) # Triggers call to color space function
+			r["out"].channelData( "R", imath.V2i( 0 ) ) # Triggers call to color space function
 
 			self.assertEqual( len( capturedArguments ), 4 )
 			self.assertEqual( capturedArguments["fileName"], w["fileName"].getValue() )

--- a/python/GafferImageTest/ImageSamplerTest.py
+++ b/python/GafferImageTest/ImageSamplerTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 import IECoreImage
 
@@ -46,7 +48,7 @@ class ImageSamplerTest( GafferImageTest.ImageTestCase ) :
 
 	def test( self ) :
 
-		dataWindow = IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 74 ) )
+		dataWindow = imath.Box2i( imath.V2i( 0 ), imath.V2i( 74 ) )
 		image = IECoreImage.ImagePrimitive( dataWindow, dataWindow )
 		red = IECore.FloatVectorData()
 		green = IECore.FloatVectorData()
@@ -69,10 +71,10 @@ class ImageSamplerTest( GafferImageTest.ImageTestCase ) :
 		hashes = set()
 		for x in range( 0, 75 ) :
 			for y in range( 0, 75 ) :
-				sampler["pixel"].setValue( IECore.V2f( x + 0.5, y + 0.5 ) )
+				sampler["pixel"].setValue( imath.V2f( x + 0.5, y + 0.5 ) )
 				# the flip in y is necessary as gaffer image coordinates run bottom->top and
 				# cortex image coordinates run top->bottom.
-				self.assertEqual( sampler["color"].getValue(), IECore.Color4f( x, 74 - y, 0, 0 ) )
+				self.assertEqual( sampler["color"].getValue(), imath.Color4f( x, 74 - y, 0, 0 ) )
 				hashes.add( str( sampler["color"].hash() ) )
 
 		self.assertEqual( len( hashes ), 75 * 75 )
@@ -81,15 +83,15 @@ class ImageSamplerTest( GafferImageTest.ImageTestCase ) :
 
 		constant = GafferImage.Constant()
 		constant["layer"].setValue( "diffuse" )
-		constant["color"].setValue( IECore.Color4f( 1, 0.5, 0.25, 1 ) )
+		constant["color"].setValue( imath.Color4f( 1, 0.5, 0.25, 1 ) )
 
 		sampler = GafferImage.ImageSampler()
 		sampler["image"].setInput( constant["out"] )
-		sampler["pixel"].setValue( IECore.V2f( 10.5 ) )
-		self.assertEqual( sampler["color"].getValue(), IECore.Color4f( 0, 0, 0, 0 ) )
+		sampler["pixel"].setValue( imath.V2f( 10.5 ) )
+		self.assertEqual( sampler["color"].getValue(), imath.Color4f( 0, 0, 0, 0 ) )
 
 		sampler["channels"].setValue( IECore.StringVectorData( [ "diffuse.R", "diffuse.G", "diffuse.B", "diffuse.A" ] ) )
-		self.assertEqual( sampler["color"].getValue(), IECore.Color4f( 1, 0.5, 0.25, 1 ) )
+		self.assertEqual( sampler["color"].getValue(), imath.Color4f( 1, 0.5, 0.25, 1 ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ImageStatsTest.py
+++ b/python/GafferImageTest/ImageStatsTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -58,14 +59,14 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		s["area"].setValue( r["out"]["format"].getValue().getDisplayWindow() )
 
 		s["channels"].setValue( IECore.StringVectorData( [ "", "G", "B" ] ) )
-		self.__assertColour( s["average"].getValue(), IECore.Color4f( 0., 0.0744, 0.1250, 1. ) )
-		self.__assertColour( s["min"].getValue(), IECore.Color4f( 0, 0, 0, 1. ) )
-		self.__assertColour( s["max"].getValue(), IECore.Color4f( 0, 0.5, 0.5, 1. ) )
+		self.__assertColour( s["average"].getValue(), imath.Color4f( 0., 0.0744, 0.1250, 1. ) )
+		self.__assertColour( s["min"].getValue(), imath.Color4f( 0, 0, 0, 1. ) )
+		self.__assertColour( s["max"].getValue(), imath.Color4f( 0, 0.5, 0.5, 1. ) )
 
 		s["channels"].setValue( IECore.StringVectorData( [ "R", "", "B" ] ) )
-		self.__assertColour( s["average"].getValue(), IECore.Color4f( 0.0544, 0, 0.1250, 1. ) )
-		self.__assertColour( s["min"].getValue(), IECore.Color4f( 0, 0, 0, 1. ) )
-		self.__assertColour( s["max"].getValue(), IECore.Color4f( 0.5, 0, 0.5, 1. ) )
+		self.__assertColour( s["average"].getValue(), imath.Color4f( 0.0544, 0, 0.1250, 1. ) )
+		self.__assertColour( s["min"].getValue(), imath.Color4f( 0, 0, 0, 1. ) )
+		self.__assertColour( s["max"].getValue(), imath.Color4f( 0.5, 0, 0.5, 1. ) )
 
 	def testDisconnectedDirty( self ) :
 
@@ -135,9 +136,9 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		s["channels"].setValue( IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
 
 		s["area"].setValue( r["out"]["format"].getValue().getDisplayWindow() )
-		self.__assertColour( s["average"].getValue(), IECore.Color4f( 0.0544, 0.0744, 0.1250, 0.2537 ) )
-		self.__assertColour( s["min"].getValue(), IECore.Color4f( 0, 0, 0, 0 ) )
-		self.__assertColour( s["max"].getValue(), IECore.Color4f( 0.5, 0.5, 0.5, 0.875 ) )
+		self.__assertColour( s["average"].getValue(), imath.Color4f( 0.0544, 0.0744, 0.1250, 0.2537 ) )
+		self.__assertColour( s["min"].getValue(), imath.Color4f( 0, 0, 0, 0 ) )
+		self.__assertColour( s["max"].getValue(), imath.Color4f( 0.5, 0.5, 0.5, 0.875 ) )
 
 	# Test that we can change the ROI and the outputs are correct.
 	def testROI( self ) :
@@ -149,15 +150,15 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		s["in"].setInput( r["out"] )
 		s["channels"].setValue( IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
 
-		s["area"].setValue( IECore.Box2i( IECore.V2i( 20, 20 ), IECore.V2i( 25, 25 ) ) )
-		self.__assertColour( s["average"].getValue(), IECore.Color4f( 0.5, 0, 0, 0.5 ) )
-		self.__assertColour( s["max"].getValue(), IECore.Color4f( 0.5, 0, 0, 0.5 ) )
-		self.__assertColour( s["min"].getValue(), IECore.Color4f( 0.5, 0, 0, 0.5 ) )
+		s["area"].setValue( imath.Box2i( imath.V2i( 20, 20 ), imath.V2i( 25, 25 ) ) )
+		self.__assertColour( s["average"].getValue(), imath.Color4f( 0.5, 0, 0, 0.5 ) )
+		self.__assertColour( s["max"].getValue(), imath.Color4f( 0.5, 0, 0, 0.5 ) )
+		self.__assertColour( s["min"].getValue(), imath.Color4f( 0.5, 0, 0, 0.5 ) )
 
-		s["area"].setValue( IECore.Box2i( IECore.V2i( 20, 20 ), IECore.V2i( 41, 30 ) ) )
-		self.__assertColour( s["average"].getValue(), IECore.Color4f( 0.4048, 0.1905, 0, 0.5952 ) )
-		self.__assertColour( s["min"].getValue(), IECore.Color4f( 0.25, 0, 0, 0.5 ) )
-		self.__assertColour( s["max"].getValue(), IECore.Color4f( 0.5, 0.5, 0, 0.75 ) )
+		s["area"].setValue( imath.Box2i( imath.V2i( 20, 20 ), imath.V2i( 41, 30 ) ) )
+		self.__assertColour( s["average"].getValue(), imath.Color4f( 0.4048, 0.1905, 0, 0.5952 ) )
+		self.__assertColour( s["min"].getValue(), imath.Color4f( 0.25, 0, 0, 0.5 ) )
+		self.__assertColour( s["max"].getValue(), imath.Color4f( 0.5, 0.5, 0, 0.75 ) )
 
 	def testMin( self ) :
 
@@ -183,8 +184,8 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		s["area"].setValue( c["out"]["format"].getValue().getDisplayWindow() )
 		s["channels"].setValue( IECore.StringVectorData( [ "A", "A", "A", "A" ] ) )
 
-		self.assertEqual( s["min"].getValue(), IECore.Color4f( 1 ) )
-		self.assertEqual( s["max"].getValue(), IECore.Color4f( 1 ) )
+		self.assertEqual( s["min"].getValue(), imath.Color4f( 1 ) )
+		self.assertEqual( s["max"].getValue(), imath.Color4f( 1 ) )
 
 	def __assertColour( self, colour1, colour2 ) :
 		for i in range( 0, 4 ):

--- a/python/GafferImageTest/ImageSwitchTest.py
+++ b/python/GafferImageTest/ImageSwitchTest.py
@@ -36,6 +36,7 @@
 
 import inspect
 import unittest
+import imath
 
 import IECore
 
@@ -93,10 +94,10 @@ class ImageSwitchTest( GafferImageTest.ImageTestCase ) :
 
 		in0 = GafferImage.Constant()
 		in0["format"].setValue( GafferImage.Format( 100, 100, 1.0 ) )
-		in0["color"].setValue( IECore.Color4f( 1, 0, 0, 1 ) )
+		in0["color"].setValue( imath.Color4f( 1, 0, 0, 1 ) )
 		in1 = GafferImage.Constant()
 		in1["format"].setValue( GafferImage.Format( 100, 100, 1.0 ) )
-		in0["color"].setValue( IECore.Color4f( 0, 1, 0, 1 ) )
+		in0["color"].setValue( imath.Color4f( 0, 1, 0, 1 ) )
 
 		switch = GafferImage.ImageSwitch()
 		switch["in"][0].setInput( in0["out"] )
@@ -144,9 +145,9 @@ class ImageSwitchTest( GafferImageTest.ImageTestCase ) :
 
 		script["switch"] = GafferImage.ImageSwitch()
 		script["in0"] = GafferImage.Constant()
-		script["in0"]["color"].setValue( IECore.Color4f( 1, 1, 1, 1 ) )
+		script["in0"]["color"].setValue( imath.Color4f( 1, 1, 1, 1 ) )
 		script["in1"] = GafferImage.Constant()
-		script["in0"]["color"].setValue( IECore.Color4f( 0, 0, 0, 0 ) )
+		script["in0"]["color"].setValue( imath.Color4f( 0, 0, 0, 0 ) )
 
 		script["switch"]["in"][0].setInput( script["in0"]["out"] )
 		script["switch"]["in"][1].setInput( script["in1"]["out"] )
@@ -160,7 +161,7 @@ class ImageSwitchTest( GafferImageTest.ImageTestCase ) :
 			"""
 		) )
 
-		self.assertEqual( script["switch"]["out"].channelData( "R", IECore.V2i( 0 ) )[0], 0 )
+		self.assertEqual( script["switch"]["out"].channelData( "R", imath.V2i( 0 ) )[0], 0 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ImageTestCase.py
+++ b/python/GafferImageTest/ImageTestCase.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 import IECoreImage
 
@@ -56,10 +58,10 @@ class ImageTestCase( GafferTest.TestCase ) :
 		channelNames = imageA["channelNames"].getValue()
 		self.assertEqual( channelNames, imageB["channelNames"].getValue() )
 
-		tileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.min )
-		while tileOrigin.y < dataWindow.max.y :
-			tileOrigin.x = GafferImage.ImagePlug.tileOrigin( dataWindow.min ).x
-			while tileOrigin.x < dataWindow.max.x :
+		tileOrigin = GafferImage.ImagePlug.tileOrigin( dataWindow.min() )
+		while tileOrigin.y < dataWindow.max().y :
+			tileOrigin.x = GafferImage.ImagePlug.tileOrigin( dataWindow.min() ).x
+			while tileOrigin.x < dataWindow.max().x :
 				for channelName in channelNames :
 					self.assertEqual(
 						imageA.channelDataHash( channelName, tileOrigin ),
@@ -95,7 +97,7 @@ class ImageTestCase( GafferTest.TestCase ) :
 	# verifying that nodes deal correctly with such inputs.
 	def emptyImage( self ) :
 
-		image = IECoreImage.ImagePrimitive( IECore.Box2i(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 100 ) ) )
+		image = IECoreImage.ImagePrimitive( imath.Box2i(), imath.Box2i( imath.V2i( 0 ), imath.V2i( 100 ) ) )
 		image["R"] = IECore.FloatVectorData()
 		image["G"] = IECore.FloatVectorData()
 		image["B"] = IECore.FloatVectorData()
@@ -104,6 +106,6 @@ class ImageTestCase( GafferTest.TestCase ) :
 		result = GafferImage.ObjectToImage()
 		result["object"].setValue( image )
 
-		self.assertEqual( result["out"]["dataWindow"].getValue(), IECore.Box2i() )
+		self.assertEqual( result["out"]["dataWindow"].getValue(), imath.Box2i() )
 
 		return result

--- a/python/GafferImageTest/ImageTimeWarpTest.py
+++ b/python/GafferImageTest/ImageTimeWarpTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import inspect
+import imath
 
 import IECore
 
@@ -111,9 +112,9 @@ class ImageTimeWarpTest( GafferImageTest.ImageTestCase ) :
 		script = Gaffer.ScriptNode()
 		script["constant"] = GafferImage.Constant()
 		script["constant"]["format"].setValue( GafferImage.Format( 1, 1, 1.0 ) )
-		
+
 		script["e"] = Gaffer.Expression()
-		script["e"].setExpression( 'parent["constant"]["color"] = IECore.Color4f( context["frame"] )' )
+		script["e"].setExpression( 'parent["constant"]["color"] = imath.Color4f( context["frame"] )' )
 
 		script["timeWarp"] = GafferImage.ImageTimeWarp()
 		script["timeWarp"]["in"].setInput( script["constant"]["out"] )
@@ -121,10 +122,10 @@ class ImageTimeWarpTest( GafferImageTest.ImageTestCase ) :
 		script["timeWarp"]["offset"].setValue( 3 )
 
 		script["sampler"] = GafferImage.ImageSampler()
-		script["sampler"]["pixel"].setValue( IECore.V2f( 0.5, 0.5 ) )
+		script["sampler"]["pixel"].setValue( imath.V2f( 0.5, 0.5 ) )
 		script["sampler"]["image"].setInput( script["timeWarp"]["out"] )
 
-		self.assertEqual( script["sampler"]["color"].getValue(), IECore.Color4f( 3 ) )
+		self.assertEqual( script["sampler"]["color"].getValue(), imath.Color4f( 3 ) )
 
 		script["e2"] = Gaffer.Expression()
 		script["e2"].setExpression( inspect.cleandoc(
@@ -135,7 +136,7 @@ class ImageTimeWarpTest( GafferImageTest.ImageTestCase ) :
 			"""
 		) )
 
-		self.assertEqual( script["sampler"]["color"].getValue(), IECore.Color4f( 5 ) )
+		self.assertEqual( script["sampler"]["color"].getValue(), imath.Color4f( 5 ) )
 
 	def testDisabling( self ) :
 

--- a/python/GafferImageTest/ImageTransformTest.py
+++ b/python/GafferImageTest/ImageTransformTest.py
@@ -37,6 +37,7 @@
 import unittest
 import random
 import os
+import imath
 
 import IECore
 
@@ -81,7 +82,7 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		t = GafferImage.ImageTransform()
 		t["in"].setInput( r["out"] )
 		t["transform"]["rotate"].setValue( -1. )
-		t["transform"]["scale"].setValue( IECore.V2f( 1.5, 1. ) )
+		t["transform"]["scale"].setValue( imath.V2f( 1.5, 1. ) )
 
 		r2 = GafferImage.ImageReader()
 		r2["fileName"].setValue( os.path.join( self.path, "knownTransformBug.exr" ) )
@@ -101,7 +102,7 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 			if isinstance( plug, Gaffer.FloatPlug ) :
 				plug.setValue( 1 )
 			else :
-				plug.setValue( IECore.V2f( 2 ) )
+				plug.setValue( imath.V2f( 2 ) )
 
 			hash = t["out"].imageHash()
 			self.assertNotEqual( hash, previousHash )
@@ -122,7 +123,7 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 			if isinstance( plug, Gaffer.FloatPlug ) :
 				plug.setValue( 1 )
 			else :
-				plug.setValue( IECore.V2f( 2 ) )
+				plug.setValue( imath.V2f( 2 ) )
 
 			dirtiedPlugs = { x[0] for x in cs }
 
@@ -141,7 +142,7 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 
 		t = GafferImage.ImageTransform()
 		t["in"].setInput( r["out"] )
-		t["transform"]["translate"].setValue( IECore.V2f( 2., 2. ) )
+		t["transform"]["translate"].setValue( imath.V2f( 2., 2. ) )
 
 		self.assertEqual( t["out"]["format"].hash(), r["out"]["format"].hash() )
 
@@ -153,7 +154,7 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		t = GafferImage.ImageTransform()
 		t["in"].setInput( r["out"] )
 
-		t["transform"]["translate"].setValue( IECore.V2f( 2., 2. ) )
+		t["transform"]["translate"].setValue( imath.V2f( 2., 2. ) )
 		t["transform"]["rotate"].setValue( 90 )
 		t["enabled"].setValue( True )
 		self.assertNotEqual( r["out"].imageHash(), t["out"].imageHash() )
@@ -166,7 +167,7 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		c = GafferImage.Constant()
 		t = GafferImage.ImageTransform()
 		t["in"].setInput( c["out"] )
-		t["transform"]["translate"].setValue( IECore.V2f( 1, 0 ) )
+		t["transform"]["translate"].setValue( imath.V2f( 1, 0 ) )
 
 		self.assertEqual( t["out"]["metadata"].hash(), c["out"]["metadata"].hash() )
 		self.assertEqual( t["out"]["format"].hash(), c["out"]["format"].hash() )
@@ -222,13 +223,13 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 			# to adjust our test to force it to do an actual resampling of
 			# the image, since that's what we want to test.
 			self.assertNotEqual(
-				r["out"].channelDataHash( "R", IECore.V2i( 0 ) ),
-				t["out"].channelDataHash( "R", IECore.V2i( 0 ) )
+				r["out"].channelDataHash( "R", imath.V2i( 0 ) ),
+				t["out"].channelDataHash( "R", imath.V2i( 0 ) )
 			)
 
 			# Check that the rotated image is basically the same as the input.
 			t["transform"]["pivot"].setValue(
-				IECore.V2f( random.uniform( -100, 100 ), random.uniform( -100, 100 ) ),
+				imath.V2f( random.uniform( -100, 100 ), random.uniform( -100, 100 ) ),
 			)
 			self.assertImagesEqual( r["out"], t["out"], maxDifference = 0.0001, ignoreDataWindow = True )
 
@@ -240,13 +241,13 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		# Use a Constant and a Crop to make a vertical line.
 		constant = GafferImage.Constant()
 		constant["format"].setValue( GafferImage.Format( 100, 100 ) )
-		constant["color"].setValue( IECore.Color4f( 1 ) )
+		constant["color"].setValue( imath.Color4f( 1 ) )
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput( constant["out"] )
 		crop["affectDataWindow"].setValue( True )
 		crop["affectDisplayWindow"].setValue( False )
-		crop["area"].setValue( IECore.Box2i( IECore.V2i( 10, 0 ), IECore.V2i( 11, 100 ) ) )
+		crop["area"].setValue( imath.Box2i( imath.V2i( 10, 0 ), imath.V2i( 11, 100 ) ) )
 
 		# Check it's where we expect
 
@@ -259,22 +260,22 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 			sampler = GafferImage.Sampler(
 				transform["out"],
 				"R",
-				IECore.Box2i( position, position + IECore.V2i( 1 ) )
+				imath.Box2i( position, position + imath.V2i( 1 ) )
 			)
 			return sampler.sample( position.x, position.y )
 
-		self.assertEqual( sample( IECore.V2i( 9, 10 ) ), 0 )
-		self.assertEqual( sample( IECore.V2i( 10, 10 ) ), 1 )
-		self.assertEqual( sample( IECore.V2i( 11, 10 ) ), 0 )
+		self.assertEqual( sample( imath.V2i( 9, 10 ) ), 0 )
+		self.assertEqual( sample( imath.V2i( 10, 10 ) ), 1 )
+		self.assertEqual( sample( imath.V2i( 11, 10 ) ), 0 )
 
 		# Move it a tiiny bit, and check it has moved
 		# a tiiny bit.
 
 		transform["transform"]["translate"]["x"].setValue( 0.1 )
 
-		self.assertEqual( sample( IECore.V2i( 9, 10 ) ), 0 )
-		self.assertGreater( sample( IECore.V2i( 10, 10 ) ), 0.9 )
-		self.assertGreater( sample( IECore.V2i( 11, 10 ) ), 0.09 )
+		self.assertEqual( sample( imath.V2i( 9, 10 ) ), 0 )
+		self.assertGreater( sample( imath.V2i( 10, 10 ) ), 0.9 )
+		self.assertGreater( sample( imath.V2i( 11, 10 ) ), 0.09 )
 
 	def testNegativeScale( self ) :
 
@@ -283,7 +284,7 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 
 		t = GafferImage.ImageTransform()
 		t["in"].setInput( r["out"] )
-		t["transform"]["pivot"].setValue( IECore.V2f( 1 ) )
+		t["transform"]["pivot"].setValue( imath.V2f( 1 ) )
 		t["transform"]["scale"]["x"].setValue( -1 )
 
 		sampler = GafferImage.Sampler(

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -40,6 +40,7 @@ import unittest
 import shutil
 import functools
 import datetime
+import imath
 
 import IECore
 
@@ -293,7 +294,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		self.failIf( os.path.exists( testTileFile ) )
 
 		GafferImage.FormatPlug.acquireDefaultFormatPlug( s ).setValue(
-			GafferImage.Format( IECore.Box2i( IECore.V2i( -7, -2 ), IECore.V2i( 23, 25 ) ), 1. )
+			GafferImage.Format( imath.Box2i( imath.V2i( -7, -2 ), imath.V2i( 23, 25 ) ), 1. )
 		)
 
 		w1["in"].setInput( g["out"] )
@@ -528,7 +529,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 	def testOffsetDisplayWindowWrite( self ) :
 
 		c = GafferImage.Constant()
-		format = GafferImage.Format( IECore.Box2i( IECore.V2i( -20, -15 ), IECore.V2i( 29, 14 ) ), 1. )
+		format = GafferImage.Format( imath.Box2i( imath.V2i( -20, -15 ), imath.V2i( 29, 14 ) ), 1. )
 		c["format"].setValue( format )
 
 		testFile = self.__testFile( "offsetDisplayWindow", "RGBA", "exr" )
@@ -790,12 +791,12 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		i["format"].setValue( GafferImage.Format( 4096, 2304, 1.000 ) )
 
 		overscanCrop = GafferImage.Crop()
-		overscanCrop["area"].setValue( IECore.Box2i( IECore.V2i( 300, 300 ), IECore.V2i( 2220, 1908 ) ) )
+		overscanCrop["area"].setValue( imath.Box2i( imath.V2i( 300, 300 ), imath.V2i( 2220, 1908 ) ) )
 		overscanCrop["affectDataWindow"].setValue( False )
 		overscanCrop["in"].setInput( i["out"] )
 
 		c = GafferImage.Crop()
-		c["area"].setValue( IECore.Box2i( IECore.V2i( -144, 1744 ), IECore.V2i( -143, 1745 ) ) )
+		c["area"].setValue( imath.Box2i( imath.V2i( -144, 1744 ), imath.V2i( -143, 1745 ) ) )
 		c["affectDisplayWindow"].setValue( False )
 		c["in"].setInput( overscanCrop["out"] )
 
@@ -813,16 +814,16 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		after = GafferImage.ImageReader()
 		after["fileName"].setValue( testFile )
 		# Check that the data window is the expected single pixel
-		self.assertEqual( after["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( -144, 1744 ), IECore.V2i( -143, 1745 ) ) )
+		self.assertEqual( after["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( -144, 1744 ), imath.V2i( -143, 1745 ) ) )
 
 	def testWriteEmptyImage( self ) :
 
 		i = GafferImage.Constant()
-		i["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 100 ) ), 1 ) )
+		i["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 100 ) ), 1 ) )
 
 		c = GafferImage.Crop()
 		c["areaSource"].setValue( GafferImage.Crop.AreaSource.Area )
-		c["area"].setValue( IECore.Box2i( IECore.V2i( 40 ), IECore.V2i( 40 ) ) )
+		c["area"].setValue( imath.Box2i( imath.V2i( 40 ), imath.V2i( 40 ) ) )
 		c["affectDisplayWindow"].setValue( False )
 		c["affectDataWindow"].setValue( True )
 		c["in"].setInput( i["out"] )
@@ -841,7 +842,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		after = GafferImage.ImageReader()
 		after["fileName"].setValue( testFile )
 		# Check that the data window is the expected single pixel
-		self.assertEqual( after["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 0, 99 ), IECore.V2i( 1, 100 ) ) )
+		self.assertEqual( after["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( 0, 99 ), imath.V2i( 1, 100 ) ) )
 
 	def testPixelAspectRatio( self ) :
 
@@ -1164,7 +1165,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 	def testDefaultColorSpace( self ) :
 
 		image = GafferImage.Constant()
-		image["color"].setValue( IECore.Color4f( 0.25, 0.5, 0.75, 1 ) )
+		image["color"].setValue( imath.Color4f( 0.25, 0.5, 0.75, 1 ) )
 
 		writer = GafferImage.ImageWriter()
 		writer["in"].setInput( image["out"] )
@@ -1226,8 +1227,8 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
 		# create a wide image
 		constant = GafferImage.Constant()
-		constant["color"].setValue( IECore.Color4f( 0.5, 0.5, 0.5, 1 ) )
-		constant["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 3000, 1080 ) ), 1. ) )
+		constant["color"].setValue( imath.Color4f( 0.5, 0.5, 0.5, 1 ) )
+		constant["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 3000, 1080 ) ), 1. ) )
 
 		# fit it such that we have several tiles of blank lines on top (and bottom)
 		resize = GafferImage.Resize()

--- a/python/GafferImageTest/LUTTest.py
+++ b/python/GafferImageTest/LUTTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -156,13 +157,13 @@ class LUTTest( GafferImageTest.ImageTestCase ) :
 		o["fileName"].setValue( self.lut )
 
 		self.assertNotEqual(
-			o["out"].channelDataHash( "R", IECore.V2i( 0 ) ),
-			o["out"].channelDataHash( "G", IECore.V2i( 0 ) )
+			o["out"].channelDataHash( "R", imath.V2i( 0 ) ),
+			o["out"].channelDataHash( "G", imath.V2i( 0 ) )
 		)
 
 		self.assertNotEqual(
-			o["out"].channelData( "R", IECore.V2i( 0 ) ),
-			o["out"].channelData( "G", IECore.V2i( 0 ) )
+			o["out"].channelData( "R", imath.V2i( 0 ) ),
+			o["out"].channelData( "G", imath.V2i( 0 ) )
 		)
 
 	def testPassThrough( self ) :

--- a/python/GafferImageTest/MedianTest.py
+++ b/python/GafferImageTest/MedianTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -52,7 +53,7 @@ class MedianTest( GafferImageTest.ImageTestCase ) :
 
 		m = GafferImage.Median()
 		m["in"].setInput( c["out"] )
-		m["radius"].setValue( IECore.V2i( 0 ) )
+		m["radius"].setValue( imath.V2i( 0 ) )
 
 		self.assertEqual( c["out"].imageHash(), m["out"].imageHash() )
 		self.assertImagesEqual( c["out"], m["out"] )
@@ -63,14 +64,14 @@ class MedianTest( GafferImageTest.ImageTestCase ) :
 
 		m = GafferImage.Median()
 		m["in"].setInput( c["out"] )
-		m["radius"].setValue( IECore.V2i( 1 ) )
+		m["radius"].setValue( imath.V2i( 1 ) )
 
 		self.assertEqual( m["out"]["dataWindow"].getValue(), c["out"]["dataWindow"].getValue() )
 
 		m["expandDataWindow"].setValue( True )
 
-		self.assertEqual( m["out"]["dataWindow"].getValue().min, c["out"]["dataWindow"].getValue().min - IECore.V2i( 1 ) )
-		self.assertEqual( m["out"]["dataWindow"].getValue().max, c["out"]["dataWindow"].getValue().max + IECore.V2i( 1 ) )
+		self.assertEqual( m["out"]["dataWindow"].getValue().min(), c["out"]["dataWindow"].getValue().min() - imath.V2i( 1 ) )
+		self.assertEqual( m["out"]["dataWindow"].getValue().max(), c["out"]["dataWindow"].getValue().max() + imath.V2i( 1 ) )
 
 	def testFilter( self ) :
 
@@ -81,7 +82,7 @@ class MedianTest( GafferImageTest.ImageTestCase ) :
 		m["in"].setInput( r["out"] )
 		self.assertImagesEqual( m["out"], r["out"] )
 
-		m["radius"].setValue( IECore.V2i( 1 ) )
+		m["radius"].setValue( imath.V2i( 1 ) )
 		m["boundingMode"].setValue( GafferImage.Sampler.BoundingMode.Clamp )
 
 		dataWindow = m["out"]["dataWindow"].getValue()
@@ -89,8 +90,8 @@ class MedianTest( GafferImageTest.ImageTestCase ) :
 
 		uStep = 1.0 / dataWindow.size().x
 		uMin = 0.5 * uStep
-		for y in range( dataWindow.min.y, dataWindow.max.y ) :
-			for x in range( dataWindow.min.x, dataWindow.max.x ) :
+		for y in range( dataWindow.min().y, dataWindow.max().y ) :
+			for x in range( dataWindow.min().x, dataWindow.max().x ) :
 				self.assertAlmostEqual( s.sample( x, y ), uMin + x * uStep, delta = 0.011 )
 
 	def testDriverChannel( self ) :
@@ -101,12 +102,12 @@ class MedianTest( GafferImageTest.ImageTestCase ) :
 		r = GafferImage.Grade()
 		r["in"].setInput( rRaw["out"] )
 		# Trim off the noise in the blacks so that areas with no visible color are actually flat
-		r["blackPoint"].setValue( IECore.Color4f( 0.03 ) )
+		r["blackPoint"].setValue( imath.Color4f( 0.03 ) )
 
 
 		masterMedian = GafferImage.Median()
 		masterMedian["in"].setInput( r["out"] )
-		masterMedian["radius"].setValue( IECore.V2i( 2 ) )
+		masterMedian["radius"].setValue( imath.V2i( 2 ) )
 
 		masterMedian["masterChannel"].setValue( "G" )
 
@@ -122,7 +123,7 @@ class MedianTest( GafferImageTest.ImageTestCase ) :
 
 		defaultMedian = GafferImage.Median()
 		defaultMedian["in"].setInput( r["out"] )
-		defaultMedian["radius"].setValue( IECore.V2i( 2 ) )
+		defaultMedian["radius"].setValue( imath.V2i( 2 ) )
 
 		masterMedianSingleChannel = GafferImage.DeleteChannels()
 		masterMedianSingleChannel["in"].setInput( masterMedian["out"] )

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -228,7 +229,7 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 		c = GafferImage.Constant()
 		f = GafferImage.Resize()
 		f["in"].setInput( c["out"] )
-		f["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) ), 1 ) )
+		f["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 10 ) ), 1 ) )
 		d = GafferImage.ImageMetadata()
 		d["metadata"].addMember( "comment", IECore.StringData( "reformated and metadata updated" ) )
 		d["in"].setInput( f["out"] )
@@ -268,22 +269,22 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 		self.assertTrue( "in2" not in s["m"] )
 
 		with s.context() :
-			self.assertEqual( s["m"]["out"].channelData( "R", IECore.V2i( 0 ) )[0], 0.75 )
+			self.assertEqual( s["m"]["out"].channelData( "R", imath.V2i( 0 ) )[0], 0.75 )
 
 	def testSmallDataWindowOverLarge( self ) :
 
 		b = GafferImage.Constant()
 		b["format"].setValue( GafferImage.Format( 500, 500, 1.0 ) )
-		b["color"].setValue( IECore.Color4f( 1, 0, 0, 1 ) )
+		b["color"].setValue( imath.Color4f( 1, 0, 0, 1 ) )
 
 		a = GafferImage.Constant()
 		a["format"].setValue( GafferImage.Format( 500, 500, 1.0 ) )
-		a["color"].setValue( IECore.Color4f( 0, 1, 0, 1 ) )
+		a["color"].setValue( imath.Color4f( 0, 1, 0, 1 ) )
 
 		aCrop = GafferImage.Crop()
 		aCrop["in"].setInput( a["out"] )
 		aCrop["areaSource"].setValue( aCrop.AreaSource.Area )
-		aCrop["area"].setValue( IECore.Box2i( IECore.V2i( 50 ), IECore.V2i( 162 ) ) )
+		aCrop["area"].setValue( imath.Box2i( imath.V2i( 50 ), imath.V2i( 162 ) ) )
 		aCrop["affectDisplayWindow"].setValue( False )
 
 		m = GafferImage.Merge()
@@ -297,7 +298,7 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 
 		def sample( x, y ) :
 
-			return IECore.Color3f(
+			return imath.Color3f(
 				redSampler.sample( x, y ),
 				greenSampler.sample( x, y ),
 				blueSampler.sample( x, y ),
@@ -307,25 +308,25 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 		# the data window of aCrop. Everywhere else we should have
 		# red still.
 
-		self.assertEqual( sample( 49, 49 ), IECore.Color3f( 1, 0, 0 ) )
-		self.assertEqual( sample( 50, 50 ), IECore.Color3f( 0, 1, 0 ) )
-		self.assertEqual( sample( 161, 161 ), IECore.Color3f( 0, 1, 0 ) )
-		self.assertEqual( sample( 162, 162 ), IECore.Color3f( 1, 0, 0 ) )
+		self.assertEqual( sample( 49, 49 ), imath.Color3f( 1, 0, 0 ) )
+		self.assertEqual( sample( 50, 50 ), imath.Color3f( 0, 1, 0 ) )
+		self.assertEqual( sample( 161, 161 ), imath.Color3f( 0, 1, 0 ) )
+		self.assertEqual( sample( 162, 162 ), imath.Color3f( 1, 0, 0 ) )
 
 	def testLargeDataWindowAddedToSmall( self ) :
 
 		b = GafferImage.Constant()
 		b["format"].setValue( GafferImage.Format( 500, 500, 1.0 ) )
-		b["color"].setValue( IECore.Color4f( 1, 0, 0, 1 ) )
+		b["color"].setValue( imath.Color4f( 1, 0, 0, 1 ) )
 
 		a = GafferImage.Constant()
 		a["format"].setValue( GafferImage.Format( 500, 500, 1.0 ) )
-		a["color"].setValue( IECore.Color4f( 0, 1, 0, 1 ) )
+		a["color"].setValue( imath.Color4f( 0, 1, 0, 1 ) )
 
 		bCrop = GafferImage.Crop()
 		bCrop["in"].setInput( b["out"] )
 		bCrop["areaSource"].setValue( bCrop.AreaSource.Area )
-		bCrop["area"].setValue( IECore.Box2i( IECore.V2i( 50 ), IECore.V2i( 162 ) ) )
+		bCrop["area"].setValue( imath.Box2i( imath.V2i( 50 ), imath.V2i( 162 ) ) )
 		bCrop["affectDisplayWindow"].setValue( False )
 
 		m = GafferImage.Merge()
@@ -339,7 +340,7 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 
 		def sample( x, y ) :
 
-			return IECore.Color3f(
+			return imath.Color3f(
 				redSampler.sample( x, y ),
 				greenSampler.sample( x, y ),
 				blueSampler.sample( x, y ),
@@ -348,10 +349,10 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 		# We should only have yellow in areas where the background exists,
 		# and should have just green everywhere else.
 
-		self.assertEqual( sample( 49, 49 ), IECore.Color3f( 0, 1, 0 ) )
-		self.assertEqual( sample( 50, 50 ), IECore.Color3f( 1, 1, 0 ) )
-		self.assertEqual( sample( 161, 161 ), IECore.Color3f( 1, 1, 0 ) )
-		self.assertEqual( sample( 162, 162 ), IECore.Color3f( 0, 1, 0 ) )
+		self.assertEqual( sample( 49, 49 ), imath.Color3f( 0, 1, 0 ) )
+		self.assertEqual( sample( 50, 50 ), imath.Color3f( 1, 1, 0 ) )
+		self.assertEqual( sample( 161, 161 ), imath.Color3f( 1, 1, 0 ) )
+		self.assertEqual( sample( 162, 162 ), imath.Color3f( 0, 1, 0 ) )
 
 	def testCrashWithResizedInput( self ) :
 
@@ -376,10 +377,10 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 	def testModes( self ) :
 
 		b = GafferImage.Constant()
-		b["color"].setValue( IECore.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
+		b["color"].setValue( imath.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
 
 		a = GafferImage.Constant()
-		a["color"].setValue( IECore.Color4f( 1, 0.3, 0.1, 0.2 ) )
+		a["color"].setValue( imath.Color4f( 1, 0.3, 0.1, 0.2 ) )
 
 		merge = GafferImage.Merge()
 		merge["in"][0].setInput( b["out"] )
@@ -387,7 +388,7 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 
 		sampler = GafferImage.ImageSampler()
 		sampler["image"].setInput( merge["out"] )
-		sampler["pixel"].setValue( IECore.V2f( 10 ) )
+		sampler["pixel"].setValue( imath.V2f( 10 ) )
 
 		self.longMessage = True
 		for operation, expected in [
@@ -416,7 +417,7 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 	def testChannelRequest( self ) :
 
 		a = GafferImage.Constant()
-		a["color"].setValue( IECore.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
+		a["color"].setValue( imath.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
 
 		ad = GafferImage.DeleteChannels()
 		ad["in"].setInput( a["out"] )
@@ -424,7 +425,7 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 		ad["channels"].setValue( "R" )
 
 		b = GafferImage.Constant()
-		b["color"].setValue( IECore.Color4f( 1.0, 0.3, 0.1, 0.2 ) )
+		b["color"].setValue( imath.Color4f( 1.0, 0.3, 0.1, 0.2 ) )
 
 		bd = GafferImage.DeleteChannels()
 		bd["in"].setInput( b["out"] )
@@ -438,7 +439,7 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 
 		sampler = GafferImage.ImageSampler()
 		sampler["image"].setInput( merge["out"] )
-		sampler["pixel"].setValue( IECore.V2f( 10 ) )
+		sampler["pixel"].setValue( imath.V2f( 10 ) )
 
 		self.assertAlmostEqual( sampler["color"]["r"].getValue(), 0.0 + 1.0 )
 		self.assertAlmostEqual( sampler["color"]["g"].getValue(), 0.2 + 0.0 )

--- a/python/GafferImageTest/MixTest.py
+++ b/python/GafferImageTest/MixTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -98,7 +99,7 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 		##########################################
 
 		self.assertNotEqual( mix["out"].imageHash(), input1Hash )
-		self.assertEqual( mix["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 20 ), IECore.V2i( 75 ) ) )
+		self.assertEqual( mix["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( 20 ), imath.V2i( 75 ) ) )
 
 		##########################################
 		# Test that if we disable the node the hash gets passed through.
@@ -106,7 +107,7 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 
 		mix["enabled"].setValue(False)
 		self.assertEqual( mix["out"].imageHash(), input1Hash )
-		self.assertEqual( mix["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 20 ), IECore.V2i( 70 ) ) )
+		self.assertEqual( mix["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( 20 ), imath.V2i( 70 ) ) )
 		self.assertImagesEqual( mix["out"], r["out"] )
 
 
@@ -117,7 +118,7 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 		mix["enabled"].setValue( True )
 		mix["mix"].setValue( 0 )
 		self.assertEqual( mix["out"].imageHash(), input1Hash )
-		self.assertEqual( mix["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 20 ), IECore.V2i( 70 ) ) )
+		self.assertEqual( mix["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( 20 ), imath.V2i( 70 ) ) )
 		self.assertImagesEqual( mix["out"], r["out"] )
 
 		##########################################
@@ -134,10 +135,10 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 		# Just check the first tile of the data to make sure hashes are passing through
 		with Gaffer.Context() as c :
 			c[ "image:channelName" ] = IECore.StringData( "G" )
-			c[ "image:tileOrigin" ] = IECore.V2iData( IECore.V2i( 0, 0 ) )
+			c[ "image:tileOrigin" ] = IECore.V2iData( imath.V2i( 0, 0 ) )
 			self.assertEqual( mix["out"]["channelData"].hash(), g["out"]["channelData"].hash() )
 
-		self.assertEqual( mix["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 25 ), IECore.V2i( 75 ) ) )
+		self.assertEqual( mix["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( 25 ), imath.V2i( 75 ) ) )
 		self.assertImagesEqual( mix["out"], g["out"], ignoreMetadata = True )
 
 	# Overlay a red and green tile of different data window sizes with a checkered mask and check the data window is expanded on the result and looks as we expect.
@@ -206,7 +207,7 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 		c = GafferImage.Constant()
 		f = GafferImage.Resize()
 		f["in"].setInput( c["out"] )
-		f["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) ), 1 ) )
+		f["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 10 ) ), 1 ) )
 		d = GafferImage.ImageMetadata()
 		d["metadata"].addMember( "comment", IECore.StringData( "reformated and metadata updated" ) )
 		d["in"].setInput( f["out"] )
@@ -234,20 +235,20 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 
 		b = GafferImage.Constant()
 		b["format"].setValue( GafferImage.Format( 500, 500, 1.0 ) )
-		b["color"].setValue( IECore.Color4f( 1, 0, 0, 1 ) )
+		b["color"].setValue( imath.Color4f( 1, 0, 0, 1 ) )
 
 		a = GafferImage.Constant()
 		a["format"].setValue( GafferImage.Format( 500, 500, 1.0 ) )
-		a["color"].setValue( IECore.Color4f( 0, 1, 0, 1 ) )
+		a["color"].setValue( imath.Color4f( 0, 1, 0, 1 ) )
 
 		mask = GafferImage.Constant()
 		mask["format"].setValue( GafferImage.Format( 500, 500, 1.0 ) )
-		mask["color"].setValue( IECore.Color4f( 0.75 ) )
+		mask["color"].setValue( imath.Color4f( 0.75 ) )
 
 		aCrop = GafferImage.Crop()
 		aCrop["in"].setInput( a["out"] )
 		aCrop["areaSource"].setValue( aCrop.AreaSource.Area )
-		aCrop["area"].setValue( IECore.Box2i( IECore.V2i( 50 ), IECore.V2i( 162 ) ) )
+		aCrop["area"].setValue( imath.Box2i( imath.V2i( 50 ), imath.V2i( 162 ) ) )
 		aCrop["affectDisplayWindow"].setValue( False )
 
 		m = GafferImage.Mix()
@@ -261,7 +262,7 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 
 		def sample( x, y ) :
 
-			return IECore.Color3f(
+			return imath.Color3f(
 				redSampler.sample( x, y ),
 				greenSampler.sample( x, y ),
 				blueSampler.sample( x, y ),
@@ -271,29 +272,29 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 		# the data window of aCrop. But we still only take 25%
 		# of the red everywhere
 
-		self.assertEqual( sample( 49, 49 ), IECore.Color3f( 0.25, 0, 0 ) )
-		self.assertEqual( sample( 50, 50 ), IECore.Color3f( 0.25, 0.75, 0 ) )
-		self.assertEqual( sample( 161, 161 ), IECore.Color3f( 0.25, 0.75, 0 ) )
-		self.assertEqual( sample( 162, 162 ), IECore.Color3f( 0.25, 0, 0 ) )
+		self.assertEqual( sample( 49, 49 ), imath.Color3f( 0.25, 0, 0 ) )
+		self.assertEqual( sample( 50, 50 ), imath.Color3f( 0.25, 0.75, 0 ) )
+		self.assertEqual( sample( 161, 161 ), imath.Color3f( 0.25, 0.75, 0 ) )
+		self.assertEqual( sample( 162, 162 ), imath.Color3f( 0.25, 0, 0 ) )
 
 	def testLargeDataWindowAddedToSmall( self ) :
 
 		b = GafferImage.Constant()
 		b["format"].setValue( GafferImage.Format( 500, 500, 1.0 ) )
-		b["color"].setValue( IECore.Color4f( 1, 0, 0, 1 ) )
+		b["color"].setValue( imath.Color4f( 1, 0, 0, 1 ) )
 
 		a = GafferImage.Constant()
 		a["format"].setValue( GafferImage.Format( 500, 500, 1.0 ) )
-		a["color"].setValue( IECore.Color4f( 0, 1, 0, 1 ) )
+		a["color"].setValue( imath.Color4f( 0, 1, 0, 1 ) )
 
 		mask = GafferImage.Constant()
 		mask["format"].setValue( GafferImage.Format( 500, 500, 1.0 ) )
-		mask["color"].setValue( IECore.Color4f( 0.5 ) )
+		mask["color"].setValue( imath.Color4f( 0.5 ) )
 
 		bCrop = GafferImage.Crop()
 		bCrop["in"].setInput( b["out"] )
 		bCrop["areaSource"].setValue( bCrop.AreaSource.Area )
-		bCrop["area"].setValue( IECore.Box2i( IECore.V2i( 50 ), IECore.V2i( 162 ) ) )
+		bCrop["area"].setValue( imath.Box2i( imath.V2i( 50 ), imath.V2i( 162 ) ) )
 		bCrop["affectDisplayWindow"].setValue( False )
 
 		m = GafferImage.Mix()
@@ -307,7 +308,7 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 
 		def sample( x, y ) :
 
-			return IECore.Color3f(
+			return imath.Color3f(
 				redSampler.sample( x, y ),
 				greenSampler.sample( x, y ),
 				blueSampler.sample( x, y ),
@@ -316,15 +317,15 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 		# We should only have yellow in areas where the background exists,
 		# and should have just green everywhere else.
 
-		self.assertEqual( sample( 49, 49 ), IECore.Color3f( 0, 0.5, 0 ) )
-		self.assertEqual( sample( 50, 50 ), IECore.Color3f( 0.5, 0.5, 0 ) )
-		self.assertEqual( sample( 161, 161 ), IECore.Color3f( 0.5, 0.5, 0 ) )
-		self.assertEqual( sample( 162, 162 ), IECore.Color3f( 0, 0.5, 0 ) )
+		self.assertEqual( sample( 49, 49 ), imath.Color3f( 0, 0.5, 0 ) )
+		self.assertEqual( sample( 50, 50 ), imath.Color3f( 0.5, 0.5, 0 ) )
+		self.assertEqual( sample( 161, 161 ), imath.Color3f( 0.5, 0.5, 0 ) )
+		self.assertEqual( sample( 162, 162 ), imath.Color3f( 0, 0.5, 0 ) )
 
 	def testChannelRequest( self ) :
 
 		a = GafferImage.Constant()
-		a["color"].setValue( IECore.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
+		a["color"].setValue( imath.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
 
 		ad = GafferImage.DeleteChannels()
 		ad["in"].setInput( a["out"] )
@@ -332,7 +333,7 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 		ad["channels"].setValue( IECore.StringVectorData( [ "R" ] ) )
 
 		b = GafferImage.Constant()
-		b["color"].setValue( IECore.Color4f( 1.0, 0.3, 0.1, 0.2 ) )
+		b["color"].setValue( imath.Color4f( 1.0, 0.3, 0.1, 0.2 ) )
 
 		bd = GafferImage.DeleteChannels()
 		bd["in"].setInput( b["out"] )
@@ -340,7 +341,7 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 		bd["channels"].setValue( IECore.StringVectorData( [ "G" ] ) )
 
 		m = GafferImage.Constant()
-		m["color"].setValue( IECore.Color4f( 0.5 ) )
+		m["color"].setValue( imath.Color4f( 0.5 ) )
 
 		mix = GafferImage.Mix()
 		mix["in"][0].setInput( ad["out"] )
@@ -349,7 +350,7 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 
 		sampler = GafferImage.ImageSampler()
 		sampler["image"].setInput( mix["out"] )
-		sampler["pixel"].setValue( IECore.V2f( 10 ) )
+		sampler["pixel"].setValue( imath.V2f( 10 ) )
 
 		self.assertAlmostEqual( sampler["color"]["r"].getValue(), ( 0.0 + 1.0 ) * 0.5 )
 		self.assertAlmostEqual( sampler["color"]["g"].getValue(), ( 0.2 + 0.0 ) * 0.5 )
@@ -382,15 +383,15 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 
 		b = GafferImage.Constant()
 		b["format"].setValue( GafferImage.Format( 50, 50, 1.0 ) )
-		b["color"].setValue( IECore.Color4f( 1, 0, 0, 1 ) )
+		b["color"].setValue( imath.Color4f( 1, 0, 0, 1 ) )
 
 		a = GafferImage.Constant()
 		a["format"].setValue( GafferImage.Format( 50, 50, 1.0 ) )
-		a["color"].setValue( IECore.Color4f( 0, 1, 0, 1 ) )
+		a["color"].setValue( imath.Color4f( 0, 1, 0, 1 ) )
 
 		mask = GafferImage.Constant()
 		mask["format"].setValue( GafferImage.Format( 50, 50, 1.0 ) )
-		mask["color"].setValue( IECore.Color4f( 0.5 ) )
+		mask["color"].setValue( imath.Color4f( 0.5 ) )
 
 		m = GafferImage.Mix()
 		m["in"][0].setInput( b["out"] )
@@ -402,7 +403,7 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 			greenSampler = GafferImage.Sampler( m["out"], "G", m["out"]["format"].getValue().getDisplayWindow() )
 			blueSampler = GafferImage.Sampler( m["out"], "B", m["out"]["format"].getValue().getDisplayWindow() )
 
-			return IECore.Color3f(
+			return imath.Color3f(
 				redSampler.sample( x, y ),
 				greenSampler.sample( x, y ),
 				blueSampler.sample( x, y ),
@@ -410,17 +411,17 @@ class MixTest( GafferImageTest.ImageTestCase ) :
 
 		# Using just mix
 		m["mix"].setValue( 0.75 )
-		self.assertEqual( sample( 49, 49 ), IECore.Color3f( 0.25, 0.75, 0 ) )
+		self.assertEqual( sample( 49, 49 ), imath.Color3f( 0.25, 0.75, 0 ) )
 		m["mix"].setValue( 0.25 )
-		self.assertEqual( sample( 49, 49 ), IECore.Color3f( 0.75, 0.25, 0 ) )
+		self.assertEqual( sample( 49, 49 ), imath.Color3f( 0.75, 0.25, 0 ) )
 
 		# Using mask multiplied with mix
 		m["mask"].setInput( mask["out"] )
-		self.assertEqual( sample( 49, 49 ), IECore.Color3f( 0.875, 0.125, 0 ) )
+		self.assertEqual( sample( 49, 49 ), imath.Color3f( 0.875, 0.125, 0 ) )
 
 		# Using invalid channel of mask defaults to just mix
 		m["maskChannel"].setValue( "DOES_NOT_EXIST" )
-		self.assertEqual( sample( 49, 49 ), IECore.Color3f( 0.75, 0.25, 0 ) )
+		self.assertEqual( sample( 49, 49 ), imath.Color3f( 0.75, 0.25, 0 ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ObjectToImageTest.py
+++ b/python/GafferImageTest/ObjectToImageTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -72,13 +73,13 @@ class ObjectToImageTest( GafferImageTest.ImageTestCase ) :
 		n["object"].setValue( IECore.Reader.create( self.fileName ).read() )
 
 		self.assertNotEqual(
-			n["out"].channelDataHash( "R", IECore.V2i( 0 ) ),
-			n["out"].channelDataHash( "G", IECore.V2i( 0 ) )
+			n["out"].channelDataHash( "R", imath.V2i( 0 ) ),
+			n["out"].channelDataHash( "G", imath.V2i( 0 ) )
 		)
 
 		self.assertNotEqual(
-			n["out"].channelDataHash( "R", IECore.V2i( 0 ) ),
-			n["out"].channelDataHash( "R", IECore.V2i( GafferImage.ImagePlug.tileSize() ) )
+			n["out"].channelDataHash( "R", imath.V2i( 0 ) ),
+			n["out"].channelDataHash( "R", imath.V2i( GafferImage.ImagePlug.tileSize() ) )
 		)
 
 if __name__ == "__main__":

--- a/python/GafferImageTest/OffsetTest.py
+++ b/python/GafferImageTest/OffsetTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -54,7 +55,7 @@ class OffsetTest( GafferImageTest.ImageTestCase ) :
 		o = GafferImage.Offset()
 		o["in"].setInput( c["out"] )
 
-		self.assertEqual( o["offset"].getValue(), IECore.V2i( 0 ) )
+		self.assertEqual( o["offset"].getValue(), imath.V2i( 0 ) )
 		self.assertImageHashesEqual( o["out"], c["out"] )
 		self.assertImagesEqual( o["out"], c["out"] )
 
@@ -65,16 +66,16 @@ class OffsetTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual(
 			c["out"]["dataWindow"].getValue(),
-			IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 2 ) )
+			imath.Box2i( imath.V2i( 0 ), imath.V2i( 2 ) )
 		)
 
 		o = GafferImage.Offset()
 		o["in"].setInput( c["out"] )
-		o["offset"].setValue( IECore.V2i( 1 ) )
+		o["offset"].setValue( imath.V2i( 1 ) )
 
 		self.assertEqual(
 			o["out"]["dataWindow"].getValue(),
-			IECore.Box2i( IECore.V2i( 1 ), IECore.V2i( 3 ) )
+			imath.Box2i( imath.V2i( 1 ), imath.V2i( 3 ) )
 		)
 
 	def testChannelData( self ) :
@@ -84,7 +85,7 @@ class OffsetTest( GafferImageTest.ImageTestCase ) :
 
 		o = GafferImage.Offset()
 		o["in"].setInput( c["out"] )
-		o["offset"].setValue( IECore.V2i( 1 ) )
+		o["offset"].setValue( imath.V2i( 1 ) )
 
 		def sample( image, channelName, pos ) :
 
@@ -94,14 +95,14 @@ class OffsetTest( GafferImageTest.ImageTestCase ) :
 		for yOffset in range( -10, 10 ) :
 			for xOffset in range( -10, 10 ) :
 
-				o["offset"].setValue( IECore.V2i( xOffset, yOffset ) )
+				o["offset"].setValue( imath.V2i( xOffset, yOffset ) )
 
 				for y in range( 0, 2 ) :
 					for x in range( 0, 2 ) :
 						for channelName in ( "R", "G", "B", "A" ) :
 							self.assertEqual(
-								sample( o["out"], channelName, IECore.V2i( x + xOffset, y + yOffset ) ),
-								sample( c["out"], channelName, IECore.V2i( x, y ) ),
+								sample( o["out"], channelName, imath.V2i( x + xOffset, y + yOffset ) ),
+								sample( c["out"], channelName, imath.V2i( x, y ) ),
 						)
 
 	def testMultipleOfTileSize( self ) :
@@ -113,13 +114,13 @@ class OffsetTest( GafferImageTest.ImageTestCase ) :
 		o["in"].setInput( c["out"] )
 
 		for offset in [
-			IECore.V2i( 0, 1 ),
-			IECore.V2i( 1, 0 ),
-			IECore.V2i( 2, 0 ),
-			IECore.V2i( 2, 1 ),
-			IECore.V2i( 2, -3 ),
-			IECore.V2i( -2, 3 ),
-			IECore.V2i( -1, -1 ),
+			imath.V2i( 0, 1 ),
+			imath.V2i( 1, 0 ),
+			imath.V2i( 2, 0 ),
+			imath.V2i( 2, 1 ),
+			imath.V2i( 2, -3 ),
+			imath.V2i( -2, 3 ),
+			imath.V2i( -1, -1 ),
 		] :
 
 			offset *= GafferImage.ImagePlug.tileSize()
@@ -127,11 +128,11 @@ class OffsetTest( GafferImageTest.ImageTestCase ) :
 
 			self.assertEqual(
 				o["out"].channelDataHash( "R", offset ),
-				c["out"].channelDataHash( "R", IECore.V2i( 0 ) ),
+				c["out"].channelDataHash( "R", imath.V2i( 0 ) ),
 			)
 			self.assertEqual(
 				o["out"].channelData( "R", offset ),
-				c["out"].channelData( "R", IECore.V2i( 0 ) ),
+				c["out"].channelData( "R", imath.V2i( 0 ) ),
 			)
 
 	def testOffsetBack( self ) :
@@ -141,11 +142,11 @@ class OffsetTest( GafferImageTest.ImageTestCase ) :
 
 		o1 = GafferImage.Offset()
 		o1["in"].setInput( c["out"] )
-		o1["offset"].setValue( IECore.V2i( 101, -45 ) )
+		o1["offset"].setValue( imath.V2i( 101, -45 ) )
 
 		o2 = GafferImage.Offset()
 		o2["in"].setInput( o1["out"] )
-		o2["offset"].setValue( IECore.V2i( -101, 45 ) )
+		o2["offset"].setValue( imath.V2i( -101, 45 ) )
 
 		self.assertImagesEqual( c["out"], o2["out"] )
 

--- a/python/GafferImageTest/OpenImageIOReaderTest.py
+++ b/python/GafferImageTest/OpenImageIOReaderTest.py
@@ -38,6 +38,7 @@
 import os
 import shutil
 import unittest
+import imath
 
 import IECore
 import IECoreImage
@@ -82,14 +83,14 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		n = GafferImage.OpenImageIOReader()
 		n["fileName"].setValue( self.fileName )
 
-		self.assertEqual( n["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200, 150 ) ) )
-		self.assertEqual( n["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200, 150 ) ) )
+		self.assertEqual( n["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( 0 ), imath.V2i( 200, 150 ) ) )
+		self.assertEqual( n["out"]["format"].getValue().getDisplayWindow(), imath.Box2i( imath.V2i( 0 ), imath.V2i( 200, 150 ) ) )
 
 		expectedMetadata = IECore.CompoundData( {
 			"oiio:ColorSpace" : IECore.StringData( 'Linear' ),
 			"compression" : IECore.StringData( 'zips' ),
 			"PixelAspectRatio" : IECore.FloatData( 1 ),
-			"screenWindowCenter" : IECore.V2fData( IECore.V2f( 0, 0 ) ),
+			"screenWindowCenter" : IECore.V2fData( imath.V2f( 0, 0 ) ),
 			"screenWindowWidth" : IECore.FloatData( 1 ),
 			"fileFormat" : IECore.StringData( "openexr" ),
 			"dataType" : IECore.StringData( "float" ),
@@ -117,8 +118,8 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		n["fileName"].setValue( self.negativeDisplayWindowFileName )
 		f = n["out"]["format"].getValue()
 		d = n["out"]["dataWindow"].getValue()
-		self.assertEqual( f.getDisplayWindow(), IECore.Box2i( IECore.V2i( -5, -5 ), IECore.V2i( 21, 21 ) ) )
-		self.assertEqual( d, IECore.Box2i( IECore.V2i( 2, -14 ), IECore.V2i( 36, 20 ) ) )
+		self.assertEqual( f.getDisplayWindow(), imath.Box2i( imath.V2i( -5, -5 ), imath.V2i( 21, 21 ) ) )
+		self.assertEqual( d, imath.Box2i( imath.V2i( 2, -14 ), imath.V2i( 36, 20 ) ) )
 
 		expectedImage = IECore.Reader.create( self.negativeDisplayWindowFileName ).read()
 		outImage = n["out"].image()
@@ -130,8 +131,8 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 
 		n = GafferImage.OpenImageIOReader()
 		n["fileName"].setValue( self.negativeDataWindowFileName )
-		self.assertEqual( n["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( -25, -30 ), IECore.V2i( 175, 120 ) ) )
-		self.assertEqual( n["out"]["format"].getValue().getDisplayWindow(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200, 150 ) ) )
+		self.assertEqual( n["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( -25, -30 ), imath.V2i( 175, 120 ) ) )
+		self.assertEqual( n["out"]["format"].getValue().getDisplayWindow(), imath.Box2i( imath.V2i( 0 ), imath.V2i( 200, 150 ) ) )
 
 		channelNames = n["out"]["channelNames"].getValue()
 		self.failUnless( isinstance( channelNames, IECore.StringVectorData ) )
@@ -154,7 +155,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		n = GafferImage.OpenImageIOReader()
 		n["fileName"].setValue( self.fileName )
 
-		tile = n["out"].channelData( "R", IECore.V2i( 0 ) )
+		tile = n["out"].channelData( "R", imath.V2i( 0 ) )
 		self.assertEqual( len( tile ), GafferImage.ImagePlug().tileSize() **2 )
 
 	def testNoCaching( self ) :
@@ -164,7 +165,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 
 		c = Gaffer.Context()
 		c["image:channelName"] = "R"
-		c["image:tileOrigin"] = IECore.V2i( 0 )
+		c["image:tileOrigin"] = imath.V2i( 0 )
 		with c :
 			# using _copy=False is not recommended anywhere outside
 			# of these tests.
@@ -180,7 +181,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 
 		n = GafferImage.OpenImageIOReader()
 		n["out"]["channelNames"].getValue()
-		n["out"].channelData( "R", IECore.V2i( 0 ) )
+		n["out"].channelData( "R", imath.V2i( 0 ) )
 
 	def testNoOIIOErrorBufferOverflows( self ) :
 
@@ -195,8 +196,8 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		# Test that two tiles within the same image have different hashes.
 		n = GafferImage.OpenImageIOReader()
 		n["fileName"].setValue( self.fileName )
-		h1 = n["out"].channelData( "R", IECore.V2i( 0 ) ).hash()
-		h2 = n["out"].channelData( "R", IECore.V2i( GafferImage.ImagePlug().tileSize() ) ).hash()
+		h1 = n["out"].channelData( "R", imath.V2i( 0 ) ).hash()
+		h2 = n["out"].channelData( "R", imath.V2i( GafferImage.ImagePlug().tileSize() ) ).hash()
 
 		self.assertNotEqual( h1, h2 )
 
@@ -205,8 +206,8 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		n = GafferImage.OpenImageIOReader()
 		n["fileName"].setValue( self.fileName )
 		n["enabled"].setValue( False )
-		h1 = n["out"].channelData( "R", IECore.V2i( 0 ) ).hash()
-		h2 = n["out"].channelData( "R", IECore.V2i( GafferImage.ImagePlug().tileSize() ) ).hash()
+		h1 = n["out"].channelData( "R", imath.V2i( 0 ) ).hash()
+		h2 = n["out"].channelData( "R", imath.V2i( GafferImage.ImagePlug().tileSize() ) ).hash()
 
 		self.assertEqual( h1, h2 )
 
@@ -286,7 +287,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		self.assertRaisesRegexp( RuntimeError, ".*wellIDontExist.exr.*", reader["out"]["dataWindow"].getValue )
 		self.assertRaisesRegexp( RuntimeError, ".*wellIDontExist.exr.*", reader["out"]["metadata"].getValue )
 		self.assertRaisesRegexp( RuntimeError, ".*wellIDontExist.exr.*", reader["out"]["channelNames"].getValue )
-		self.assertRaisesRegexp( RuntimeError, ".*wellIDontExist.exr.*", reader["out"].channelData, "R", IECore.V2i( 0 ) )
+		self.assertRaisesRegexp( RuntimeError, ".*wellIDontExist.exr.*", reader["out"].channelData, "R", imath.V2i( 0 ) )
 
 	def testAvailableFrames( self ) :
 
@@ -330,7 +331,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			f1DataWindow = reader["out"]["dataWindow"].getValue()
 			f1Metadata = reader["out"]["metadata"].getValue()
 			f1ChannelNames = reader["out"]["channelNames"].getValue()
-			f1Tile = reader["out"].channelData( "R", IECore.V2i( 0 ) )
+			f1Tile = reader["out"].channelData( "R", imath.V2i( 0 ) )
 
 		# make sure the tile we're comparing isn't black
 		# so we can tell if MissingFrameMode::Black is working.
@@ -348,7 +349,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["dataWindow"].getValue )
 			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["metadata"].getValue )
 			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["channelNames"].getValue )
-			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"].channelData, "R", IECore.V2i( 0 ) )
+			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"].channelData, "R", imath.V2i( 0 ) )
 
 		# everything matches frame 1
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
@@ -358,7 +359,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), f1DataWindow )
 			self.assertEqual( reader["out"]["metadata"].getValue(), f1Metadata )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), f1ChannelNames )
-			self.assertEqual( reader["out"].channelData( "R", IECore.V2i( 0 ) ), f1Tile )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), f1Tile )
 
 		# the windows match frame 1, but everything else is default
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
@@ -368,7 +369,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), reader["out"]["dataWindow"].defaultValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), reader["out"]["metadata"].defaultValue() )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), reader["out"]["channelNames"].defaultValue() )
-			self.assertEqual( reader["out"].channelData( "R", IECore.V2i( 0 ) ), blackTile )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), blackTile )
 
 		# get frame 3 data for comparison
 		context.setFrame( 3 )
@@ -378,7 +379,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			f3DataWindow = reader["out"]["dataWindow"].getValue()
 			f3Metadata = reader["out"]["metadata"].getValue()
 			f3ChannelNames = reader["out"]["channelNames"].getValue()
-			f3Tile = reader["out"].channelData( "R", IECore.V2i( 0 ) )
+			f3Tile = reader["out"].channelData( "R", imath.V2i( 0 ) )
 
 		# set to a different missing frame
 		context.setFrame( 4 )
@@ -392,13 +393,13 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertNotEqual( reader["out"]["metadata"].getValue(), f1Metadata )
 			# same channel names is fine
 			self.assertEqual( reader["out"]["channelNames"].getValue(), f1ChannelNames )
-			self.assertNotEqual( reader["out"].channelData( "R", IECore.V2i( 0 ) ), f1Tile )
+			self.assertNotEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), f1Tile )
 			self.assertEqual( reader["out"].image(), f3Image )
 			self.assertEqual( reader["out"]["format"].getValue(), f3Format )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), f3DataWindow )
 			self.assertEqual( reader["out"]["metadata"].getValue(), f3Metadata )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), f3ChannelNames )
-			self.assertEqual( reader["out"].channelData( "R", IECore.V2i( 0 ) ), f3Tile )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), f3Tile )
 
 		# the windows match frame 3, but everything else is default
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
@@ -408,7 +409,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), reader["out"]["dataWindow"].defaultValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), reader["out"]["metadata"].defaultValue() )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), reader["out"]["channelNames"].defaultValue() )
-			self.assertEqual( reader["out"].channelData( "R", IECore.V2i( 0 ) ), blackTile )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), blackTile )
 
 		# set to a missing frame before the start of the sequence
 		context.setFrame( 0 )
@@ -420,7 +421,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( reader["out"]["format"].getValue(), f1Format )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), f1DataWindow )
 			self.assertEqual( reader["out"]["metadata"].getValue(), f1Metadata )
-			self.assertEqual( reader["out"].channelData( "R", IECore.V2i( 0 ) ), f1Tile )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), f1Tile )
 
 		# the windows match frame 1, but everything else is default
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
@@ -429,7 +430,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), reader["out"]["dataWindow"].defaultValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), reader["out"]["metadata"].defaultValue() )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), reader["out"]["channelNames"].defaultValue() )
-			self.assertEqual( reader["out"].channelData( "R", IECore.V2i( 0 ) ), blackTile )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), blackTile )
 
 		# explicit fileNames do not support MissingFrameMode
 		reader["fileName"].setValue( testSequence.fileNameForFrame( 0 ) )
@@ -440,7 +441,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["dataWindow"].getValue )
 			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["metadata"].getValue )
 			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["channelNames"].getValue )
-			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"].channelData, "R", IECore.V2i( 0 ) )
+			self.assertRaisesRegexp( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"].channelData, "R", imath.V2i( 0 ) )
 
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
 		with context :
@@ -449,7 +450,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), reader["out"]["dataWindow"].defaultValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), reader["out"]["metadata"].defaultValue() )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), reader["out"]["channelNames"].defaultValue() )
-			self.assertEqual( reader["out"].channelData( "R", IECore.V2i( 0 ) ), blackTile )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), blackTile )
 
 	def testHashesFrame( self ) :
 

--- a/python/GafferImageTest/PremultiplyTest.py
+++ b/python/GafferImageTest/PremultiplyTest.py
@@ -37,6 +37,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -57,10 +58,10 @@ class PremultiplyTest( GafferImageTest.ImageTestCase ) :
 		premult["in"].setInput(i["out"])
 
 		premult["alphaChannel"].setValue("R")
-		h1 = premult["out"].channelData( "R", IECore.V2i( 0 ) ).hash()
+		h1 = premult["out"].channelData( "R", imath.V2i( 0 ) ).hash()
 
 		premult["alphaChannel"].setValue("B")
-		h2 = premult["out"].channelData( "R", IECore.V2i( 0 ) ).hash()
+		h2 = premult["out"].channelData( "R", imath.V2i( 0 ) ).hash()
 		self.assertNotEqual( h1, h2 )
 
 	def testEnableBehaviour( self ) :
@@ -96,7 +97,7 @@ class PremultiplyTest( GafferImageTest.ImageTestCase ) :
 		color = { "R": 1.0, "G": 2.0, "B": 0.0, "A": 0.5 }
 		s = Gaffer.ScriptNode()
 		s["c"] = GafferImage.Constant()
-		s["c"]["color"].setValue( IECore.Color4f( color["R"], color["G"], color["B"], color["A"] ) )
+		s["c"]["color"].setValue( imath.Color4f( color["R"], color["G"], color["B"], color["A"] ) )
 		s["p"] = GafferImage.Premultiply()
 		s["p"]["in"].setInput( s["c"]["out"] )
 		s["p"]["channels"].setValue( "R G B A" )
@@ -107,7 +108,7 @@ class PremultiplyTest( GafferImageTest.ImageTestCase ) :
 			for channelName in color.keys():
 				c = Gaffer.Context( s.context() )
 				c["image:channelName"] = channelName
-				c["image:tileOrigin"] = IECore.V2i( 0 )
+				c["image:tileOrigin"] = imath.V2i( 0 )
 				with c :
 					result = s["p"]["out"]["channelData"].getValue()[0]
 

--- a/python/GafferImageTest/ResampleTest.py
+++ b/python/GafferImageTest/ResampleTest.py
@@ -38,6 +38,7 @@ import os
 import shutil
 import unittest
 import subprocess
+import imath
 
 import IECore
 
@@ -52,19 +53,19 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 
 		c = GafferImage.Constant()
 		c["format"].setValue( GafferImage.Format( 100, 100 ) )
-		c["color"].setValue( IECore.Color4f( 1 ) )
+		c["color"].setValue( imath.Color4f( 1 ) )
 
 		r = GafferImage.Resample()
 		r["in"].setInput( c["out"] )
 		r["matrix"].setValue(
-			IECore.M33f().translate( IECore.V2f( 10.5, 11.5 ) ).scale( IECore.V2f( 0.1 ) )
+			imath.M33f().translate( imath.V2f( 10.5, 11.5 ) ).scale( imath.V2f( 0.1 ) )
 		)
 
 		self.assertEqual(
 			r["out"]["dataWindow"].getValue(),
-			IECore.Box2i(
-				IECore.V2i( 10, 11 ),
-				IECore.V2i( 21, 22 )
+			imath.Box2i(
+				imath.V2i( 10, 11 ),
+				imath.V2i( 21, 22 )
 			)
 		)
 
@@ -78,19 +79,19 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 			reader["fileName"].setValue( inputFileName )
 
 			inSize = reader["out"]["format"].getValue().getDisplayWindow().size()
-			inSize = IECore.V2f( inSize.x, inSize.y )
+			inSize = imath.V2f( inSize.x, inSize.y )
 
 			resample = GafferImage.Resample()
 			resample["in"].setInput( reader["out"] )
 			resample["matrix"].setValue(
-				IECore.M33f().scale( IECore.V2f( size.x, size.y ) / inSize )
+				imath.M33f().scale( imath.V2f( size.x, size.y ) / inSize )
 			)
 			resample["filter"].setValue( filter )
 			resample["boundingMode"].setValue( GafferImage.Sampler.BoundingMode.Clamp )
 
 			crop = GafferImage.Crop()
 			crop["in"].setInput( resample["out"] )
-			crop["area"].setValue( IECore.Box2i( IECore.V2i( 0 ), size ) )
+			crop["area"].setValue( imath.Box2i( imath.V2i( 0 ), size ) )
 
 			outputFileName = self.temporaryDirectory() + "/%s_%dx%d_%s.exr" % ( os.path.splitext( fileName )[0], size.x, size.y, filter )
 			writer = GafferImage.ImageWriter()
@@ -139,10 +140,10 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 				)
 
 		tests = [
-			( "resamplePatterns.exr", IECore.V2i( 4 ), "lanczos3" ),
-			( "resamplePatterns.exr", IECore.V2i( 40 ), "box" ),
-			( "resamplePatterns.exr", IECore.V2i( 101 ), "gaussian" ),
-			( "resamplePatterns.exr", IECore.V2i( 119 ), "mitchell" ),
+			( "resamplePatterns.exr", imath.V2i( 4 ), "lanczos3" ),
+			( "resamplePatterns.exr", imath.V2i( 40 ), "box" ),
+			( "resamplePatterns.exr", imath.V2i( 101 ), "gaussian" ),
+			( "resamplePatterns.exr", imath.V2i( 119 ), "mitchell" ),
 		]
 
 		for args in tests :
@@ -152,10 +153,10 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 
 		c = GafferImage.Constant()
 		c["format"].setValue( GafferImage.Format( 100, 100 ) )
-		c["color"].setValue( IECore.Color4f( 1 ) )
+		c["color"].setValue( imath.Color4f( 1 ) )
 
 		r = GafferImage.Resample()
-		r["matrix"].setValue( IECore.M33f().scale( IECore.V2f( 4 ) ) )
+		r["matrix"].setValue( imath.M33f().scale( imath.V2f( 4 ) ) )
 		r["boundingMode"].setValue( GafferImage.Sampler.BoundingMode.Clamp )
 		r["filter"].setValue( "sinc" )
 		r["in"].setInput( c["out"] )
@@ -165,7 +166,7 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 
 	def testExpandDataWindow( self ) :
 
-		d = IECore.Box2i( IECore.V2i( 5, 6 ), IECore.V2i( 101, 304 ) )
+		d = imath.Box2i( imath.V2i( 5, 6 ), imath.V2i( 101, 304 ) )
 		c = GafferImage.Constant()
 		c["format"].setValue( GafferImage.Format( d ) )
 
@@ -175,14 +176,14 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( r["out"]["dataWindow"].getValue(), d )
 
 		r["expandDataWindow"].setValue( True )
-		self.assertEqual( r["out"]["dataWindow"].getValue(), IECore.Box2i( d.min - IECore.V2i( 1 ), d.max + IECore.V2i( 1 ) ) )
+		self.assertEqual( r["out"]["dataWindow"].getValue(), imath.Box2i( d.min() - imath.V2i( 1 ), d.max() + imath.V2i( 1 ) ) )
 
-		r["filterScale"].setValue( IECore.V2f( 10 ) )
-		self.assertEqual( r["out"]["dataWindow"].getValue(), IECore.Box2i( d.min - IECore.V2i( 5 ), d.max + IECore.V2i( 5 ) ) )
+		r["filterScale"].setValue( imath.V2f( 10 ) )
+		self.assertEqual( r["out"]["dataWindow"].getValue(), imath.Box2i( d.min() - imath.V2i( 5 ), d.max() + imath.V2i( 5 ) ) )
 
 	def __matrix( self, inputDataWindow, outputDataWindow ) :
 
-		return IECore.M33f()
+		return imath.M33f()
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ResizeTest.py
+++ b/python/GafferImageTest/ResizeTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -50,8 +51,8 @@ class ResizeTest( GafferImageTest.ImageTestCase ) :
 		r = GafferImage.Resize()
 		self.assertTrue( r["format"].getValue().getDisplayWindow().isEmpty() )
 
-		f1 = GafferImage.Format( IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 11, 12 ) ), 1 )
-		f2 = GafferImage.Format( IECore.Box2i( IECore.V2i( 100, 200 ), IECore.V2i( 1100, 1200 ) ), 1 )
+		f1 = GafferImage.Format( imath.Box2i( imath.V2i( 1, 2 ), imath.V2i( 11, 12 ) ), 1 )
+		f2 = GafferImage.Format( imath.Box2i( imath.V2i( 100, 200 ), imath.V2i( 1100, 1200 ) ), 1 )
 
 		c1 = Gaffer.Context()
 		c2 = Gaffer.Context()
@@ -69,52 +70,52 @@ class ResizeTest( GafferImageTest.ImageTestCase ) :
 
 		# Resize to the same size as the input image.
 		c = GafferImage.Constant()
-		c["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 512 ) ), 1 ) )
-		c["color"].setValue( IECore.Color4f( 0.25, 0.5, 0.75, 1 ) )
+		c["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 512 ) ), 1 ) )
+		c["color"].setValue( imath.Color4f( 0.25, 0.5, 0.75, 1 ) )
 
 		r = GafferImage.Resize()
 		r["in"].setInput( c["out"] )
-		r["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 512 ) ), 1 ) )
+		r["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 512 ) ), 1 ) )
 
 		# Assert that the pixel data is passed clean through.
 		for channel in [ "R", "G", "B", "A" ] :
 			self.assertEqual(
-				c["out"].channelDataHash( channel, IECore.V2i( 0 ) ),
-				r["out"].channelDataHash( channel, IECore.V2i( 0 ) ),
+				c["out"].channelDataHash( channel, imath.V2i( 0 ) ),
+				r["out"].channelDataHash( channel, imath.V2i( 0 ) ),
 			)
 			self.assertTrue(
-				c["out"].channelData( channel, IECore.V2i( 0 ), _copy = False ).isSame(
-					r["out"].channelData( channel, IECore.V2i( 0 ), _copy = False )
+				c["out"].channelData( channel, imath.V2i( 0 ), _copy = False ).isSame(
+					r["out"].channelData( channel, imath.V2i( 0 ), _copy = False )
 				)
 			)
 
 	def testFit( self ) :
 
 		c = GafferImage.Constant()
-		c["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 256, 128 ) ), 1 ) )
-		c["color"].setValue( IECore.Color4f( 0.25, 0.5, 0.75, 1 ) )
+		c["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 256, 128 ) ), 1 ) )
+		c["color"].setValue( imath.Color4f( 0.25, 0.5, 0.75, 1 ) )
 
 		r = GafferImage.Resize()
 		r["in"].setInput( c["out"] )
-		r["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 1024, 256 ) ), 1 ) )
+		r["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 1024, 256 ) ), 1 ) )
 
 		self.assertEqual( r["fitMode"].getValue(), r.FitMode.Horizontal )
 
 		horizontalDataWindow = r["out"]["dataWindow"].getValue()
 		displayWindow = r["format"].getValue().getDisplayWindow()
 
-		self.assertEqual( horizontalDataWindow.min.x, displayWindow.min.x )
-		self.assertEqual( horizontalDataWindow.max.x, displayWindow.max.x )
-		self.assertTrue( horizontalDataWindow.min.y < displayWindow.min.y )
-		self.assertTrue( horizontalDataWindow.max.y > displayWindow.max.y )
+		self.assertEqual( horizontalDataWindow.min().x, displayWindow.min().x )
+		self.assertEqual( horizontalDataWindow.max().x, displayWindow.max().x )
+		self.assertTrue( horizontalDataWindow.min().y < displayWindow.min().y )
+		self.assertTrue( horizontalDataWindow.max().y > displayWindow.max().y )
 
 		r["fitMode"].setValue( r.FitMode.Vertical )
 		verticalDataWindow = r["out"]["dataWindow"].getValue()
 
-		self.assertTrue( verticalDataWindow.min.x > displayWindow.min.x )
-		self.assertTrue( verticalDataWindow.max.x < displayWindow.max.x )
-		self.assertEqual( verticalDataWindow.min.y, displayWindow.min.y )
-		self.assertEqual( verticalDataWindow.max.y, displayWindow.max.y )
+		self.assertTrue( verticalDataWindow.min().x > displayWindow.min().x )
+		self.assertTrue( verticalDataWindow.max().x < displayWindow.max().x )
+		self.assertEqual( verticalDataWindow.min().y, displayWindow.min().y )
+		self.assertEqual( verticalDataWindow.max().y, displayWindow.max().y )
 
 		r["fitMode"].setValue( r.FitMode.Fit )
 		self.assertEqual( r["out"]["dataWindow"].getValue(), verticalDataWindow )
@@ -128,28 +129,28 @@ class ResizeTest( GafferImageTest.ImageTestCase ) :
 	def testMismatchedDataWindow( self ) :
 
 		constant = GafferImage.Constant()
-		constant["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 256, 256 ) ), 1 ) )
+		constant["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 256, 256 ) ), 1 ) )
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput( constant["out"] )
 		crop["areaSource"].setValue( crop.AreaSource.Area )
-		crop["area"].setValue( IECore.Box2i( IECore.V2i( 64 ), IECore.V2i( 128 ) ) )
+		crop["area"].setValue( imath.Box2i( imath.V2i( 64 ), imath.V2i( 128 ) ) )
 		crop["affectDisplayWindow"].setValue( False )
 		crop["affectDataWindow"].setValue( True )
 
 		resize = GafferImage.Resize()
 		resize["in"].setInput( crop["out"] )
-		resize["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 512, 512 ) ), 1 ) )
+		resize["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 512, 512 ) ), 1 ) )
 
 		self.assertEqual(
 			resize["out"]["dataWindow"].getValue(),
-			IECore.Box2i( IECore.V2i( 128 ), IECore.V2i( 256 ) )
+			imath.Box2i( imath.V2i( 128 ), imath.V2i( 256 ) )
 		)
 
 	def testDataWindowRounding( self ) :
 
 		constant = GafferImage.Constant()
-		constant["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200, 150 ) ), 1 ) )
+		constant["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 200, 150 ) ), 1 ) )
 
 		resize = GafferImage.Resize()
 		resize["in"].setInput( constant["out"] )
@@ -157,15 +158,15 @@ class ResizeTest( GafferImageTest.ImageTestCase ) :
 		for width in range( 1, 2000 ) :
 			resize["format"].setValue( GafferImage.Format( width, 150, 1 ) )
 			dataWindow = resize["out"]["dataWindow"].getValue()
-			self.assertEqual( dataWindow.min.x, 0 )
-			self.assertEqual( dataWindow.max.x, width )
+			self.assertEqual( dataWindow.min().x, 0 )
+			self.assertEqual( dataWindow.max().x, width )
 
 		resize["fitMode"].setValue( resize.FitMode.Vertical )
 		for height in range( 1, 2000 ) :
 			resize["format"].setValue( GafferImage.Format( 200, height, 1 ) )
 			dataWindow = resize["out"]["dataWindow"].getValue()
-			self.assertEqual( dataWindow.min.y, 0 )
-			self.assertEqual( dataWindow.max.y, height )
+			self.assertEqual( dataWindow.min().y, 0 )
+			self.assertEqual( dataWindow.max().y, height )
 
 	def testFilterAffectsChannelData( self ) :
 
@@ -225,11 +226,11 @@ class ResizeTest( GafferImageTest.ImageTestCase ) :
 		r["format"].setValue( GafferImage.Format( 200, 200 ) )
 
 		self.assertEqual( r["out"]["format"].getValue(), GafferImage.Format( 200, 200 ) )
-		self.assertEqual( r["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200 ) ) )
+		self.assertEqual( r["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( 0 ), imath.V2i( 200 ) ) )
 
 		r["enabled"].setValue( False )
 		self.assertEqual( r["out"]["format"].getValue(), GafferImage.Format( 100, 100 ) )
-		self.assertEqual( r["out"]["dataWindow"].getValue(), IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 100 ) ) )
+		self.assertEqual( r["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( 0 ), imath.V2i( 100 ) ) )
 
 	def testEmptyDataWindow( self ) :
 
@@ -239,7 +240,7 @@ class ResizeTest( GafferImageTest.ImageTestCase ) :
 		r["in"].setInput( e["out"] )
 		r["format"].setValue( GafferImage.Format( 2121, 1012 ) )
 
-		self.assertEqual( r["out"]["dataWindow"].getValue(), IECore.Box2i() )
+		self.assertEqual( r["out"]["dataWindow"].getValue(), imath.Box2i() )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/SamplerTest.py
+++ b/python/GafferImageTest/SamplerTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -50,7 +51,7 @@ class SamplerTest( GafferImageTest.ImageTestCase ) :
 	def testOutOfBoundsSampleModeBlack( self ) :
 
 		c = GafferImage.Constant()
-		c["color"].setValue( IECore.Color4f( 1 ) )
+		c["color"].setValue( imath.Color4f( 1 ) )
 
 		dw = c["out"]["dataWindow"].getValue();
 		s = GafferImage.Sampler( c["out"], "R", dw, GafferImage.Sampler.BoundingMode.Black )
@@ -60,17 +61,17 @@ class SamplerTest( GafferImageTest.ImageTestCase ) :
 
 		# Pixels on corners of dataWindow should be white.
 
-		self.assertEqual( s.sample( dw.min.x, dw.min.y ), 1 )
-		self.assertEqual( s.sample( dw.max.x - 1, dw.min.y ), 1 )
-		self.assertEqual( s.sample( dw.max.x - 1, dw.max.y - 1 ), 1 )
-		self.assertEqual( s.sample( dw.min.x, dw.max.y - 1 ), 1 )
+		self.assertEqual( s.sample( dw.min().x, dw.min().y ), 1 )
+		self.assertEqual( s.sample( dw.max().x - 1, dw.min().y ), 1 )
+		self.assertEqual( s.sample( dw.max().x - 1, dw.max().y - 1 ), 1 )
+		self.assertEqual( s.sample( dw.min().x, dw.max().y - 1 ), 1 )
 
 		# Pixels just outside dataWindow should be white.
 
-		self.assertEqual( s.sample( dw.min.x - 1, dw.min.y - 1 ), 0 )
-		self.assertEqual( s.sample( dw.max.x, dw.min.y - 1 ), 0 )
-		self.assertEqual( s.sample( dw.max.x, dw.max.y ), 0 )
-		self.assertEqual( s.sample( dw.min.x - 1, dw.max.y ), 0 )
+		self.assertEqual( s.sample( dw.min().x - 1, dw.min().y - 1 ), 0 )
+		self.assertEqual( s.sample( dw.max().x, dw.min().y - 1 ), 0 )
+		self.assertEqual( s.sample( dw.max().x, dw.max().y ), 0 )
+		self.assertEqual( s.sample( dw.min().x - 1, dw.max().y ), 0 )
 
 		# Check interpolated sampling.
 		##############################
@@ -79,17 +80,17 @@ class SamplerTest( GafferImageTest.ImageTestCase ) :
 		# to black. Note that here we're sampling at the corners
 		# of pixels, not centers.
 
-		self.assertEqual( s.sample( float( dw.min.x ), float( dw.min.y ) ), 0.25 )
-		self.assertEqual( s.sample( float( dw.max.x ), float( dw.min.y ) ), 0.25 )
-		self.assertEqual( s.sample( float( dw.max.x ), float( dw.max.y ) ), 0.25 )
-		self.assertEqual( s.sample( float( dw.min.x ), float( dw.max.y ) ), 0.25 )
+		self.assertEqual( s.sample( float( dw.min().x ), float( dw.min().y ) ), 0.25 )
+		self.assertEqual( s.sample( float( dw.max().x ), float( dw.min().y ) ), 0.25 )
+		self.assertEqual( s.sample( float( dw.max().x ), float( dw.max().y ) ), 0.25 )
+		self.assertEqual( s.sample( float( dw.min().x ), float( dw.max().y ) ), 0.25 )
 
 		# Pixel centers at the corners of dataWindow should be white.
 
-		self.assertEqual( s.sample( float( dw.min.x + 0.5 ), float( dw.min.y + 0.5 ) ), 1 )
-		self.assertEqual( s.sample( float( dw.max.x - 0.5 ), float( dw.min.y + 0.5 ) ), 1 )
-		self.assertEqual( s.sample( float( dw.max.x - 0.5 ), float( dw.max.y - 0.5 ) ), 1 )
-		self.assertEqual( s.sample( float( dw.min.x + 0.5 ), float( dw.max.y - 0.5 ) ), 1 )
+		self.assertEqual( s.sample( float( dw.min().x + 0.5 ), float( dw.min().y + 0.5 ) ), 1 )
+		self.assertEqual( s.sample( float( dw.max().x - 0.5 ), float( dw.min().y + 0.5 ) ), 1 )
+		self.assertEqual( s.sample( float( dw.max().x - 0.5 ), float( dw.max().y - 0.5 ) ), 1 )
+		self.assertEqual( s.sample( float( dw.min().x + 0.5 ), float( dw.max().y - 0.5 ) ), 1 )
 
 	def testOutOfBoundsSampleModeClamp( self ) :
 
@@ -100,20 +101,20 @@ class SamplerTest( GafferImageTest.ImageTestCase ) :
 		s = GafferImage.Sampler( r["out"], "R", dw, GafferImage.Sampler.BoundingMode.Clamp )
 
 		# Get the exact values of the corner pixels.
-		bl = s.sample( dw.min.x, dw.min.y )
-		br = s.sample( dw.max.x - 1, dw.min.y  )
-		tr = s.sample( dw.max.x - 1, dw.max.y - 1 )
-		tl = s.sample( dw.min.x, dw.max.y - 1 )
+		bl = s.sample( dw.min().x, dw.min().y )
+		br = s.sample( dw.max().x - 1, dw.min().y  )
+		tr = s.sample( dw.max().x - 1, dw.max().y - 1 )
+		tl = s.sample( dw.min().x, dw.max().y - 1 )
 
 		# Sample out of bounds and assert that the same value as the nearest pixel is returned.
-		self.assertEqual( s.sample( dw.min.x-1, dw.min.y ), bl )
-		self.assertEqual( s.sample( dw.min.x, dw.min.y-1 ), bl )
-		self.assertEqual( s.sample( dw.max.x-1, dw.max.y ), tr )
-		self.assertEqual( s.sample( dw.max.x, dw.max.y-1 ), tr )
-		self.assertEqual( s.sample( dw.min.x-1, dw.max.y-1 ), tl )
-		self.assertEqual( s.sample( dw.min.x, dw.max.y ), tl )
-		self.assertEqual( s.sample( dw.max.x, dw.min.y ), br )
-		self.assertEqual( s.sample( dw.max.x-1, dw.min.y-1 ), br )
+		self.assertEqual( s.sample( dw.min().x-1, dw.min().y ), bl )
+		self.assertEqual( s.sample( dw.min().x, dw.min().y-1 ), bl )
+		self.assertEqual( s.sample( dw.max().x-1, dw.max().y ), tr )
+		self.assertEqual( s.sample( dw.max().x, dw.max().y-1 ), tr )
+		self.assertEqual( s.sample( dw.min().x-1, dw.max().y-1 ), tl )
+		self.assertEqual( s.sample( dw.min().x, dw.max().y ), tl )
+		self.assertEqual( s.sample( dw.max().x, dw.min().y ), br )
+		self.assertEqual( s.sample( dw.max().x-1, dw.min().y-1 ), br )
 
 	def test2x2Checker( self ) :
 
@@ -124,27 +125,27 @@ class SamplerTest( GafferImageTest.ImageTestCase ) :
 		# the pixels we're going to request, it should have no effect on our sampling.
 		# So test with a few such ranges.
 		sampleRegions = [
-			IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( GafferImage.ImagePlug.tileSize() ) ),
-			IECore.Box2i( -IECore.V2i( GafferImage.ImagePlug.tileSize() ), IECore.V2i( GafferImage.ImagePlug.tileSize() ) ),
-			IECore.Box2i( IECore.V2i( -1 ), IECore.V2i( 4 ) ),
+			imath.Box2i( imath.V2i( 0 ), imath.V2i( GafferImage.ImagePlug.tileSize() ) ),
+			imath.Box2i( -imath.V2i( GafferImage.ImagePlug.tileSize() ), imath.V2i( GafferImage.ImagePlug.tileSize() ) ),
+			imath.Box2i( imath.V2i( -1 ), imath.V2i( 4 ) ),
 		]
 
 		# List of positions inside and outside of the image, along
 		# with expected values if outside points are clamped inside.
 		samples = [
-			( IECore.V2i( 0, 0 ), 1 ),
-			( IECore.V2i( 1, 0 ), 0 ),
-			( IECore.V2i( 1, 1 ), 1 ),
-			( IECore.V2i( 0, 1 ), 0 ),
-			( IECore.V2i( -1, 0 ), 1 ),
-			( IECore.V2i( 2, 0 ), 0 ),
-			( IECore.V2i( 0, 3 ), 0 ),
-			( IECore.V2i( 0, -1 ), 1 ),
-			( IECore.V2i( 3, 3 ), 1 ),
-			( IECore.V2i( -1, -1 ), 1 ),
-			( IECore.V2i( -1, 2 ), 0 ),
-			( IECore.V2i( 2, 2 ), 1 ),
-			( IECore.V2f( 1, 1 ), 0.5 ),
+			( imath.V2i( 0, 0 ), 1 ),
+			( imath.V2i( 1, 0 ), 0 ),
+			( imath.V2i( 1, 1 ), 1 ),
+			( imath.V2i( 0, 1 ), 0 ),
+			( imath.V2i( -1, 0 ), 1 ),
+			( imath.V2i( 2, 0 ), 0 ),
+			( imath.V2i( 0, 3 ), 0 ),
+			( imath.V2i( 0, -1 ), 1 ),
+			( imath.V2i( 3, 3 ), 1 ),
+			( imath.V2i( -1, -1 ), 1 ),
+			( imath.V2i( -1, 2 ), 0 ),
+			( imath.V2i( 2, 2 ), 1 ),
+			( imath.V2f( 1, 1 ), 0.5 ),
 		]
 
 		# Assert all is as expected for all combos of region and sample.
@@ -157,39 +158,39 @@ class SamplerTest( GafferImageTest.ImageTestCase ) :
 
 		constant = GafferImage.Constant()
 		constant["format"].setValue( GafferImage.Format( 1000, 1000 ) )
-		constant["color"].setValue( IECore.Color4f( 1 ) )
+		constant["color"].setValue( imath.Color4f( 1 ) )
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput( constant["out"] )
 		crop["areaSource"].setValue( crop.AreaSource.Area )
-		crop["area"].setValue( IECore.Box2i( IECore.V2i( 135 ), IECore.V2i( 214 ) ) )
+		crop["area"].setValue( imath.Box2i( imath.V2i( 135 ), imath.V2i( 214 ) ) )
 		crop["affectDisplayWindow"].setValue( False )
 
-		sampler = GafferImage.Sampler( crop["out"], "R", IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 50 ) ), boundingMode = GafferImage.Sampler.BoundingMode.Clamp )
+		sampler = GafferImage.Sampler( crop["out"], "R", imath.Box2i( imath.V2i( 0 ), imath.V2i( 50 ) ), boundingMode = GafferImage.Sampler.BoundingMode.Clamp )
 		self.assertEqual( sampler.sample( 0, 0 ), 1 )
 
-		sampler = GafferImage.Sampler( crop["out"], "R", IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 50 ) ), boundingMode = GafferImage.Sampler.BoundingMode.Black )
+		sampler = GafferImage.Sampler( crop["out"], "R", imath.Box2i( imath.V2i( 0 ), imath.V2i( 50 ) ), boundingMode = GafferImage.Sampler.BoundingMode.Black )
 		self.assertEqual( sampler.sample( 0, 0 ), 0 )
 
 	def testHashIncludesBlackPixels( self ) :
 
 		constant = GafferImage.Constant()
 		constant["format"].setValue( GafferImage.Format( 1000, 1000 ) )
-		constant["color"].setValue( IECore.Color4f( 1 ) )
+		constant["color"].setValue( imath.Color4f( 1 ) )
 
 		crop = GafferImage.Crop()
 		crop["in"].setInput( constant["out"] )
 		crop["areaSource"].setValue( crop.AreaSource.Area )
-		crop["area"].setValue( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200 ) ) )
+		crop["area"].setValue( imath.Box2i( imath.V2i( 0 ), imath.V2i( 200 ) ) )
 		crop["affectDisplayWindow"].setValue( False )
 		crop["affectDataWindow"].setValue( False )
 
 		# Samples the whole data window
-		sampler1 = GafferImage.Sampler( crop["out"], "R", IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 200 ) ), boundingMode = GafferImage.Sampler.BoundingMode.Black )
+		sampler1 = GafferImage.Sampler( crop["out"], "R", imath.Box2i( imath.V2i( 0 ), imath.V2i( 200 ) ), boundingMode = GafferImage.Sampler.BoundingMode.Black )
 		# Samples the whole data window and then some.
-		sampler2 = GafferImage.Sampler( crop["out"], "R", IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 210 ) ), boundingMode = GafferImage.Sampler.BoundingMode.Black )
+		sampler2 = GafferImage.Sampler( crop["out"], "R", imath.Box2i( imath.V2i( 0 ), imath.V2i( 210 ) ), boundingMode = GafferImage.Sampler.BoundingMode.Black )
 		# Samples the whole data window and then some and then some more.
-		sampler3 = GafferImage.Sampler( crop["out"], "R", IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 220 ) ), boundingMode = GafferImage.Sampler.BoundingMode.Black )
+		sampler3 = GafferImage.Sampler( crop["out"], "R", imath.Box2i( imath.V2i( 0 ), imath.V2i( 220 ) ), boundingMode = GafferImage.Sampler.BoundingMode.Black )
 
 		# The hashes must take account of the additional pixels being sampled.
 		self.assertNotEqual( sampler1.hash(), sampler2.hash() )

--- a/python/GafferImageTest/ShuffleTest.py
+++ b/python/GafferImageTest/ShuffleTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -48,8 +49,8 @@ class ShuffleTest( GafferImageTest.ImageTestCase ) :
 	def test( self ) :
 
 		c = GafferImage.Constant()
-		c["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 511 ) ), 1 ) )
-		c["color"].setValue( IECore.Color4f( 1, 0.75, 0.25, 1 ) )
+		c["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 511 ) ), 1 ) )
+		c["color"].setValue( imath.Color4f( 1, 0.75, 0.25, 1 ) )
 
 		s = GafferImage.Shuffle()
 		s["in"].setInput( c["out"] )
@@ -58,12 +59,12 @@ class ShuffleTest( GafferImageTest.ImageTestCase ) :
 
 		for outName, inName in [ ( "R", "R" ), ( "G", "G" ), ( "B", "B" ), ( "A", "A" ) ] :
 			self.assertEqual(
-				s["out"].channelDataHash( outName, IECore.V2i( 0 ) ),
-				c["out"].channelDataHash( inName, IECore.V2i( 0 ) ),
+				s["out"].channelDataHash( outName, imath.V2i( 0 ) ),
+				c["out"].channelDataHash( inName, imath.V2i( 0 ) ),
 			)
 			self.assertTrue(
-				s["out"].channelData( outName, IECore.V2i( 0 ), _copy = False ).isSame(
-					c["out"].channelData( inName, IECore.V2i( 0 ), _copy = False )
+				s["out"].channelData( outName, imath.V2i( 0 ), _copy = False ).isSame(
+					c["out"].channelData( inName, imath.V2i( 0 ), _copy = False )
 				)
 			)
 
@@ -74,12 +75,12 @@ class ShuffleTest( GafferImageTest.ImageTestCase ) :
 
 		for outName, inName in [ ( "R", "G" ), ( "G", "B" ), ( "B", "A" ), ( "A", "R" ) ] :
 			self.assertEqual(
-				s["out"].channelDataHash( outName, IECore.V2i( 0 ) ),
-				c["out"].channelDataHash( inName, IECore.V2i( 0 ) ),
+				s["out"].channelDataHash( outName, imath.V2i( 0 ) ),
+				c["out"].channelDataHash( inName, imath.V2i( 0 ) ),
 			)
 			self.assertTrue(
-				s["out"].channelData( outName, IECore.V2i( 0 ), _copy = False ).isSame(
-					c["out"].channelData( inName, IECore.V2i( 0 ), _copy = False )
+				s["out"].channelData( outName, imath.V2i( 0 ), _copy = False ).isSame(
+					c["out"].channelData( inName, imath.V2i( 0 ), _copy = False )
 				)
 			)
 
@@ -91,10 +92,10 @@ class ShuffleTest( GafferImageTest.ImageTestCase ) :
 		s["channels"].addChild( s.ChannelPlug( "A", "__white" ) )
 		self.assertEqual( s["out"]["channelNames"].getValue(), IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
 
-		self.assertEqual( s["out"].channelData( "A", IECore.V2i( 0 ) )[0], 1 )
+		self.assertEqual( s["out"].channelData( "A", imath.V2i( 0 ) )[0], 1 )
 		self.assertTrue(
-			s["out"].channelData( "A", IECore.V2i( 0 ), _copy = False ).isSame(
-				s["out"].channelData( "A", IECore.V2i( s["out"].tileSize() ), _copy = False )
+			s["out"].channelData( "A", imath.V2i( 0 ), _copy = False ).isSame(
+				s["out"].channelData( "A", imath.V2i( s["out"].tileSize() ), _copy = False )
 			)
 		)
 

--- a/python/GafferImageTest/TextTest.py
+++ b/python/GafferImageTest/TextTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -56,7 +57,7 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 	def testPremultiplication( self ) :
 
 		constant = GafferImage.Constant()
-		constant["color"].setValue( IECore.Color4f( 0 ) )
+		constant["color"].setValue( imath.Color4f( 0 ) )
 
 		text = GafferImage.Text()
 		text["in"].setInput( constant["out"] )
@@ -65,13 +66,13 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 		stats["in"].setInput( text["out"] )
 		stats["area"].setValue( text["out"]["dataWindow"].getValue() )
 
-		self.assertEqual( stats["max"].getValue(), IECore.Color4f( 1, 1, 1, 1 ) )
+		self.assertEqual( stats["max"].getValue(), imath.Color4f( 1, 1, 1, 1 ) )
 
 		text["color"]["a"].setValue( 0.5 )
-		self.assertEqual( stats["max"].getValue(), IECore.Color4f( 0.5, 0.5, 0.5, 0.5 ) )
+		self.assertEqual( stats["max"].getValue(), imath.Color4f( 0.5, 0.5, 0.5, 0.5 ) )
 
-		text["color"].setValue( IECore.Color4f( 0.5, 0.25, 1, 0.5 ) )
-		self.assertEqual( stats["max"].getValue(), IECore.Color4f( 0.25, 0.125, 0.5, 0.5 ) )
+		text["color"].setValue( imath.Color4f( 0.5, 0.25, 1, 0.5 ) )
+		self.assertEqual( stats["max"].getValue(), imath.Color4f( 0.25, 0.125, 0.5, 0.5 ) )
 
 	def testDataWindow( self ) :
 
@@ -82,9 +83,9 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 		text["text"].setValue( "ab" )
 		w2 = text["out"]["dataWindow"].getValue()
 
-		self.assertEqual( w.min, w2.min )
-		self.assertGreater( w2.max.x, w.max.x )
-		self.assertGreater( w2.max.y, w.max.y )
+		self.assertEqual( w.min(), w2.min() )
+		self.assertGreater( w2.max().x, w.max().x )
+		self.assertGreater( w2.max().y, w.max().y )
 
 	def testDefaultFormat( self ) :
 
@@ -96,15 +97,15 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 	def testExpectedResult( self ) :
 
 		constant = GafferImage.Constant()
-		constant["color"].setValue( IECore.Color4f( 0.25, 0.5, 0.75, 1 ) )
+		constant["color"].setValue( imath.Color4f( 0.25, 0.5, 0.75, 1 ) )
 		constant["format"].setValue( GafferImage.Format( 100, 100 ) )
 
 		text = GafferImage.Text()
 		text["in"].setInput( constant["out"] )
-		text["color"].setValue( IECore.Color4f( 1, 0.75, 0.5, 1 ) )
-		text["size"].setValue( IECore.V2i( 20 ) )
-		text["area"].setValue( IECore.Box2i( IECore.V2i( 5 ), IECore.V2i( 95 ) ) )
-		text["transform"]["pivot"].setValue( IECore.V2f( 50 ) )
+		text["color"].setValue( imath.Color4f( 1, 0.75, 0.5, 1 ) )
+		text["size"].setValue( imath.V2i( 20 ) )
+		text["area"].setValue( imath.Box2i( imath.V2i( 5 ), imath.V2i( 95 ) ) )
+		text["transform"]["pivot"].setValue( imath.V2f( 50 ) )
 		text["transform"]["rotate"].setValue( 90 )
 
 		reader = GafferImage.ImageReader()
@@ -125,8 +126,8 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 		text["horizontalAlignment"].setValue( GafferImage.Text.HorizontalAlignment.Center )
 		centerDW = text["out"]["dataWindow"].getValue()
 
-		self.assertLess( leftDW.min.x, centerDW.min.x )
-		self.assertLess( centerDW.min.x, rightDW.min.x )
+		self.assertLess( leftDW.min().x, centerDW.min().x )
+		self.assertLess( centerDW.min().x, rightDW.min().x )
 
 		# Delta of 1 pixel is ok because layout is done in floating point space,
 		# and then must be rounded to pixel space to make the enclosing data window.
@@ -146,8 +147,8 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 		text["verticalAlignment"].setValue( GafferImage.Text.VerticalAlignment.Center )
 		centerDW = text["out"]["dataWindow"].getValue()
 
-		self.assertLess( bottomDW.min.y, centerDW.min.y )
-		self.assertLess( centerDW.min.y, topDW.min.y )
+		self.assertLess( bottomDW.min().y, centerDW.min().y )
+		self.assertLess( centerDW.min().y, topDW.min().y )
 
 		# Delta of 1 pixel is ok because layout is done in floating point space,
 		# and then must be rounded to pixel space to make the enclosing data window.
@@ -169,7 +170,7 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 	def testDisable( self ) :
 
 		c = GafferImage.Constant()
-		c["color"].setValue( IECore.Color4f( 1, 0, 0, 0.5, ) )
+		c["color"].setValue( imath.Color4f( 1, 0, 0, 0.5, ) )
 
 		t = GafferImage.Text()
 		t["in"].setInput( c["out"] )
@@ -186,21 +187,21 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 
 		t = GafferImage.Text()
 		dataWindow = t["out"]["dataWindow"].getValue()
-		tile = t["out"].channelData( "R", GafferImage.ImagePlug.tileOrigin( dataWindow.min ) )
+		tile = t["out"].channelData( "R", GafferImage.ImagePlug.tileOrigin( dataWindow.min() ) )
 
 		t["shadow"].setValue( True )
-		t["shadowColor"].setValue( IECore.Color4f( 0.5 ) )
+		t["shadowColor"].setValue( imath.Color4f( 0.5 ) )
 
 		shadowDataWindow = t["out"]["dataWindow"].getValue()
 
-		self.assertEqual( shadowDataWindow.min.x, dataWindow.min.x )
-		self.assertEqual( shadowDataWindow.max.y, dataWindow.max.y )
-		self.assertGreater( shadowDataWindow.max.x, dataWindow.max.x )
-		self.assertLess( shadowDataWindow.min.y, dataWindow.min.y )
+		self.assertEqual( shadowDataWindow.min().x, dataWindow.min().x )
+		self.assertEqual( shadowDataWindow.max().y, dataWindow.max().y )
+		self.assertGreater( shadowDataWindow.max().x, dataWindow.max().x )
+		self.assertLess( shadowDataWindow.min().y, dataWindow.min().y )
 
 		self.assertEqual( t["out"]["channelNames"].getValue(), IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
 
-		shadowTile = t["out"].channelData( "R", GafferImage.ImagePlug.tileOrigin( dataWindow.min ) )
+		shadowTile = t["out"].channelData( "R", GafferImage.ImagePlug.tileOrigin( dataWindow.min() ) )
 
 		self.assertNotEqual( shadowTile, tile )
 

--- a/python/GafferImageTest/UnpremultiplyTest.py
+++ b/python/GafferImageTest/UnpremultiplyTest.py
@@ -37,6 +37,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -57,10 +58,10 @@ class UnpremultiplyTest( GafferImageTest.ImageTestCase ) :
 		unpremult["in"].setInput(i["out"])
 
 		unpremult["alphaChannel"].setValue("R")
-		h1 = unpremult["out"].channelData( "R", IECore.V2i( 0 ) ).hash()
+		h1 = unpremult["out"].channelData( "R", imath.V2i( 0 ) ).hash()
 
 		unpremult["alphaChannel"].setValue("B")
-		h2 = unpremult["out"].channelData( "R", IECore.V2i( 0 ) ).hash()
+		h2 = unpremult["out"].channelData( "R", imath.V2i( 0 ) ).hash()
 		self.assertNotEqual( h1, h2 )
 
 	def testEnableBehaviour( self ) :
@@ -96,7 +97,7 @@ class UnpremultiplyTest( GafferImageTest.ImageTestCase ) :
 		color = { "R": 1.0, "G": 2.0, "B": 0.0, "A": 0.5 }
 		s = Gaffer.ScriptNode()
 		s["c"] = GafferImage.Constant()
-		s["c"]["color"].setValue( IECore.Color4f( color["R"], color["G"], color["B"], color["A"] ) )
+		s["c"]["color"].setValue( imath.Color4f( color["R"], color["G"], color["B"], color["A"] ) )
 		s["u"] = GafferImage.Unpremultiply()
 		s["u"]["in"].setInput( s["c"]["out"] )
 		s["u"]["channels"].setValue( "R G B A" )
@@ -107,7 +108,7 @@ class UnpremultiplyTest( GafferImageTest.ImageTestCase ) :
 			for channelName in color.keys():
 				c = Gaffer.Context( s.context() )
 				c["image:channelName"] = channelName
-				c["image:tileOrigin"] = IECore.V2i( 0 )
+				c["image:tileOrigin"] = imath.V2i( 0 )
 				with c :
 					result = s["u"]["out"]["channelData"].getValue()[0]
 

--- a/python/GafferImageTest/VectorWarpTest.py
+++ b/python/GafferImageTest/VectorWarpTest.py
@@ -37,6 +37,7 @@
 import os
 import unittest
 import math
+import imath
 
 import IECore
 import IECoreImage
@@ -90,12 +91,12 @@ class VectorWarpTest( GafferImageTest.ImageTestCase ) :
 		# (constant) warped output.
 		sampler2 = GafferImage.ImageSampler()
 		sampler2["image"].setInput( vectorWarp["out"] )
-		sampler2["pixel"].setValue( IECore.V2f( 5.5 ) )
+		sampler2["pixel"].setValue( imath.V2f( 5.5 ) )
 
 		for u in ( 0.0, 0.25, 0.5, 0.75, 1.0 ) :
 			for v in ( 0.0, 0.25, 0.5, 0.75, 1.0 ) :
-				constant["color"].setValue( IECore.Color4f( u, v, 0, 1 ) )
-				sampler1["pixel"].setValue( IECore.V2f( u * 2, v * 2 ) )
+				constant["color"].setValue( imath.Color4f( u, v, 0, 1 ) )
+				sampler1["pixel"].setValue( imath.V2f( u * 2, v * 2 ) )
 				self.assertEqual( sampler1["color"].getValue(), sampler2["color"].getValue() )
 
 	def testNegativeDataWindowOrigin( self ) :
@@ -104,11 +105,11 @@ class VectorWarpTest( GafferImageTest.ImageTestCase ) :
 		reader["fileName"].setValue( os.path.dirname( __file__ ) + "/images/checker.exr" )
 
 		constant = GafferImage.Constant()
-		constant["color"].setValue( IECore.Color4f( 0.5, 0, 0, 1 ) )
+		constant["color"].setValue( imath.Color4f( 0.5, 0, 0, 1 ) )
 
 		offset = GafferImage.Offset()
 		offset["in"].setInput( constant["out"] )
-		offset["offset"].setValue( IECore.V2i( -200, -250 ) )
+		offset["offset"].setValue( imath.V2i( -200, -250 ) )
 
 		vectorWarp = GafferImage.VectorWarp()
 		vectorWarp["in"].setInput( reader["out"] )
@@ -118,7 +119,7 @@ class VectorWarpTest( GafferImageTest.ImageTestCase ) :
 
 	def testWarpImage( self ):
 		def __warpImage( size, distortion, idistortStyle ):
-			w = IECore.Box2i( IECore.V2i( 0 ), size - IECore.V2i( 1 ) )
+			w = imath.Box2i( imath.V2i( 0 ), size - imath.V2i( 1 ) )
 			image = IECoreImage.ImagePrimitive( w, w )
 
 			R = IECore.FloatVectorData( size.x * size.y )
@@ -142,7 +143,7 @@ class VectorWarpTest( GafferImageTest.ImageTestCase ) :
 			return image
 
 		def __dotGrid( size ):
-			w = IECore.Box2i( IECore.V2i( 0 ), size - IECore.V2i( 1 ) )
+			w = imath.Box2i( imath.V2i( 0 ), size - imath.V2i( 1 ) )
 			image = IECoreImage.ImagePrimitive( w, w )
 
 			R = IECore.FloatVectorData( size.x * size.y )
@@ -165,7 +166,7 @@ class VectorWarpTest( GafferImageTest.ImageTestCase ) :
 
 
 		objectToImageSource = GafferImage.ObjectToImage()
-		objectToImageSource["object"].setValue( __dotGrid( IECore.V2i( 300 ) ) )
+		objectToImageSource["object"].setValue( __dotGrid( imath.V2i( 300 ) ) )
 
 		# TODO - reorder channels of our source image because ObjectToImage outputs in opposite order to
 		# the rest of Gaffer.  This probably should be fixed in ObjectToImage,
@@ -187,12 +188,12 @@ class VectorWarpTest( GafferImageTest.ImageTestCase ) :
 		vectorWarp["vector"].setInput( objectToImageVector["out"] )
 
 		# Test that a warp with no distortion and a box filter reproduces the input
-		objectToImageVector["object"].setValue( __warpImage( IECore.V2i( 300 ), 0, False ) )
+		objectToImageVector["object"].setValue( __warpImage( imath.V2i( 300 ), 0, False ) )
 		vectorWarp["filter"].setValue( "box" )
 		self.assertImagesEqual( vectorWarp["out"], sourceReorder["out"], maxDifference = 0.00001 )
 
 		# Test that a warp with distortion produces an expected output
-		objectToImageVector["object"].setValue( __warpImage( IECore.V2i( 300 ), 0.2, False ) )
+		objectToImageVector["object"].setValue( __warpImage( imath.V2i( 300 ), 0.2, False ) )
 		vectorWarp["filter"].setValue( "blackman-harris" )
 
 		# Enable to write out images for visual comparison
@@ -206,7 +207,7 @@ class VectorWarpTest( GafferImageTest.ImageTestCase ) :
 		expectedReader["fileName"].setValue( os.path.dirname( __file__ ) + "/images/dotGrid.warped.exr" )
 
 		# Test that we can get the same result using pixel offsets instead of normalized coordinates
-		objectToImageVector["object"].setValue( __warpImage( IECore.V2i( 300 ), 0.2, True ) )
+		objectToImageVector["object"].setValue( __warpImage( imath.V2i( 300 ), 0.2, True ) )
 		vectorWarp["vectorMode"].setValue( GafferImage.VectorWarp.VectorMode.Relative )
 		vectorWarp["vectorUnits"].setValue( GafferImage.VectorWarp.VectorUnits.Pixels )
 

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import functools
+import imath
 
 import IECore
 
@@ -248,7 +249,7 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 					Gaffer.WeakMethod( self.__extractClicked )
 				)
 
-				GafferUI.Spacer( IECore.V2i( 0 ), parenting = { "expand" : True } )
+				GafferUI.Spacer( imath.V2i( 0 ), parenting = { "expand" : True } )
 
 				self.__removeButton = GafferUI.Button( image = "delete.png", hasFrame = False, toolTip = "Remove selected image" )
 				self.__removeButton.setEnabled( False )

--- a/python/GafferImageUI/FormatPlugValueWidget.py
+++ b/python/GafferImageUI/FormatPlugValueWidget.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import functools
+import imath
 
 import IECore
 import Gaffer
@@ -112,7 +113,7 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.__menuButton.setText( text if mode != "custom" else "Custom" )
 
-		nonZeroOrigin = fmt.getDisplayWindow().min != IECore.V2i( 0 )
+		nonZeroOrigin = fmt.getDisplayWindow().min() != imath.V2i( 0 )
 		for widget in ( self.__minLabel, self.__minWidget ) :
 			widget.setVisible( mode == "custom" and nonZeroOrigin )
 

--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import functools
+import imath
 
 import IECore
 
@@ -253,7 +254,7 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 				self.__rgbLabel = GafferUI.Label()
 
-				GafferUI.Spacer( IECore.V2i( 20, 10 ), IECore.V2i( 20, 10 ) )
+				GafferUI.Spacer( imath.V2i( 20, 10 ), imath.V2i( 20, 10 ) )
 
 				self.__hsvLabel = GafferUI.Label()
 
@@ -272,17 +273,17 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 				color = self.getPlug()["color"].defaultValue()
 
 		if samplerChannels[3] not in channelNames :
-			color = IECore.Color3f( color[0], color[1], color[2] )
+			color = imath.Color3f( color[0], color[1], color[2] )
 
 		self.__positionLabel.setText( "<b>XY : %d %d</b>" % ( pixel.x, pixel.y ) )
 		self.__swatch.setColor( color )
 
-		if isinstance( color, IECore.Color4f ) :
+		if isinstance( color, imath.Color4f ) :
 			self.__rgbLabel.setText( "<b>RGBA : %.3f %.3f %.3f %.3f</b>" % ( color.r, color.g, color.b, color.a ) )
 		else :
 			self.__rgbLabel.setText( "<b>RGB : %.3f %.3f %.3f</b>" % ( color.r, color.g, color.b ) )
 
-		hsv = color.rgbToHSV()
+		hsv = color.rgb2hsv()
 		self.__hsvLabel.setText( "<b>HSV : %.3f %.3f %.3f</b>" % ( hsv.r, hsv.g, hsv.b ) )
 
 ##########################################################################

--- a/python/GafferImageUI/OpenColorIOTransformUI.py
+++ b/python/GafferImageUI/OpenColorIOTransformUI.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -89,7 +91,7 @@ class _ContextFooter( GafferUI.Widget ) :
 
 		with row :
 
-			GafferUI.Spacer( IECore.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
+			GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 
 			button = GafferUI.Button(
 				image = "plus.png",
@@ -101,7 +103,7 @@ class _ContextFooter( GafferUI.Widget ) :
 				Gaffer.WeakMethod( self.__clicked )
 			)
 
-			GafferUI.Spacer( IECore.V2i( 1 ), IECore.V2i( 999999, 1 ), parenting = { "expand" : True } )
+			GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
 		self.__node = node
 

--- a/python/GafferImageUITest/ImageGadgetTest.py
+++ b/python/GafferImageUITest/ImageGadgetTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -48,25 +49,25 @@ class ImageGadgetTest( GafferUITest.TestCase ) :
 	def testBound( self ) :
 
 		g = GafferImageUI.ImageGadget()
-		self.assertEqual( g.bound(), IECore.Box3f() )
+		self.assertEqual( g.bound(), imath.Box3f() )
 
 		c = GafferImage.Constant()
 		c["format"].setValue( GafferImage.Format( 200, 100 ) )
 
 		g.setImage( c["out"] )
-		self.assertEqual( g.bound(), IECore.Box3f( IECore.V3f( 0 ), IECore.V3f( 200, 100, 0) ) )
+		self.assertEqual( g.bound(), imath.Box3f( imath.V3f( 0 ), imath.V3f( 200, 100, 0) ) )
 
 		c["format"].setValue( GafferImage.Format( 200, 100, 2 ) )
-		self.assertEqual( g.bound(), IECore.Box3f( IECore.V3f( 0 ), IECore.V3f( 400, 100, 0) ) )
+		self.assertEqual( g.bound(), imath.Box3f( imath.V3f( 0 ), imath.V3f( 400, 100, 0) ) )
 
 		c2 = GafferImage.Constant()
 		g.setImage( c2["out"] )
 
 		f = GafferImage.FormatPlug.getDefaultFormat( g.getContext() ).getDisplayWindow()
-		self.assertEqual( g.bound(), IECore.Box3f( IECore.V3f( f.min.x, f.min.y, 0 ), IECore.V3f( f.max.x, f.max.y, 0 ) ) )
+		self.assertEqual( g.bound(), imath.Box3f( imath.V3f( f.min().x, f.min().y, 0 ), imath.V3f( f.max().x, f.max().y, 0 ) ) )
 
-		GafferImage.FormatPlug.setDefaultFormat( g.getContext(), GafferImage.Format( IECore.Box2i( IECore.V2i( 10, 20 ), IECore.V2i( 30, 40 ) ) ) )
-		self.assertEqual( g.bound(), IECore.Box3f( IECore.V3f( 10, 20, 0 ), IECore.V3f( 30, 40, 0 ) ) )
+		GafferImage.FormatPlug.setDefaultFormat( g.getContext(), GafferImage.Format( imath.Box2i( imath.V2i( 10, 20 ), imath.V2i( 30, 40 ) ) ) )
+		self.assertEqual( g.bound(), imath.Box3f( imath.V3f( 10, 20, 0 ), imath.V3f( 30, 40, 0 ) ) )
 
 	def testGetImage( self ) :
 

--- a/python/GafferOSLTest/OSLCodeTest.py
+++ b/python/GafferOSLTest/OSLCodeTest.py
@@ -39,6 +39,7 @@ import subprocess
 import shutil
 import unittest
 import functools
+import imath
 
 import IECore
 
@@ -182,10 +183,10 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 			defaultValue = IECore.SplinefColor3f(
 				IECore.CubicBasisf.catmullRom(),
 				(
-					( 0, IECore.Color3f( 0 ) ),
-					( 0, IECore.Color3f( 0 ) ),
-					( 1, IECore.Color3f( 1 ) ),
-					( 1, IECore.Color3f( 1 ) ),
+					( 0, imath.Color3f( 0 ) ),
+					( 0, imath.Color3f( 0 ) ),
+					( 1, imath.Color3f( 1 ) ),
+					( 1, imath.Color3f( 1 ) ),
 				)
 			),
 			flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic

--- a/python/GafferOSLTest/OSLExpressionEngineTest.py
+++ b/python/GafferOSLTest/OSLExpressionEngineTest.py
@@ -38,6 +38,7 @@ import unittest
 import inspect
 import math
 import os
+import imath
 
 import IECore
 
@@ -101,8 +102,8 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 		s["e"] = Gaffer.Expression()
 		s["e"].setExpression( "parent.n.user.o = parent.n.user.i * 2;", "OSL" )
 
-		s["n"]["user"]["i"].setValue( IECore.Color3f( 1, 2, 3 ) )
-		self.assertEqual( s["n"]["user"]["o"].getValue(), IECore.Color3f( 2, 4, 6 ) )
+		s["n"]["user"]["i"].setValue( imath.Color3f( 1, 2, 3 ) )
+		self.assertEqual( s["n"]["user"]["o"].getValue(), imath.Color3f( 2, 4, 6 ) )
 
 	def testV3fPlugs( self ) :
 
@@ -114,8 +115,8 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 		s["e"] = Gaffer.Expression()
 		s["e"].setExpression( "parent.n.user.o = parent.n.user.i * 2;", "OSL" )
 
-		s["n"]["user"]["i"].setValue( IECore.V3f( 1, 2, 3 ) )
-		self.assertEqual( s["n"]["user"]["o"].getValue(), IECore.V3f( 2, 4, 6 ) )
+		s["n"]["user"]["i"].setValue( imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( s["n"]["user"]["o"].getValue(), imath.V3f( 2, 4, 6 ) )
 
 	def testM44fPlugs( self ) :
 
@@ -127,8 +128,8 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 		s["e"] = Gaffer.Expression()
 		s["e"].setExpression( "parent.n.user.o = parent.n.user.i * 2;", "OSL" )
 
-		s["n"]["user"]["i"].setValue( IECore.M44f( range( 16 ) ) )
-		self.assertEqual( s["n"]["user"]["o"].getValue(), IECore.M44f( range( 0, 32, 2 ) ) )
+		s["n"]["user"]["i"].setValue( imath.M44f( *range( 16 ) ) )
+		self.assertEqual( s["n"]["user"]["o"].getValue(), imath.M44f( *range( 0, 32, 2 ) ) )
 
 	def testStringPlugs( self ) :
 
@@ -199,20 +200,20 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 
 			self.assertEqual( s["n"]["user"]["f"].getValue(), 1 )
 			self.assertEqual( s["n"]["user"]["i"].getValue(), 1 )
-			self.assertEqual( s["n"]["user"]["c"].getValue(), IECore.Color3f( 1, 2, 3 ) )
-			self.assertEqual( s["n"]["user"]["v"].getValue(), IECore.V3f( 0, 1, 2 ) )
+			self.assertEqual( s["n"]["user"]["c"].getValue(), imath.Color3f( 1, 2, 3 ) )
+			self.assertEqual( s["n"]["user"]["v"].getValue(), imath.V3f( 0, 1, 2 ) )
 			self.assertEqual( s["n"]["user"]["s"].getValue(), "default" )
 
 			c["f"] = 10
 			c["i"] = 11
-			c["c"] = IECore.Color3f( 4, 5, 6 )
-			c["v"] = IECore.V3f( 1, 2, 3 )
+			c["c"] = imath.Color3f( 4, 5, 6 )
+			c["v"] = imath.V3f( 1, 2, 3 )
 			c["s"] = "non-default"
 
 			self.assertEqual( s["n"]["user"]["f"].getValue(), 10 )
 			self.assertEqual( s["n"]["user"]["i"].getValue(), 11 )
-			self.assertEqual( s["n"]["user"]["c"].getValue(), IECore.Color3f( 4, 5, 6 ) )
-			self.assertEqual( s["n"]["user"]["v"].getValue(), IECore.V3f( 1, 2, 3 ) )
+			self.assertEqual( s["n"]["user"]["c"].getValue(), imath.Color3f( 4, 5, 6 ) )
+			self.assertEqual( s["n"]["user"]["v"].getValue(), imath.V3f( 1, 2, 3 ) )
 			self.assertEqual( s["n"]["user"]["s"].getValue(), "non-default" )
 
 	def testDefaultExpression( self ) :
@@ -227,8 +228,8 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		s["n"]["user"]["f"].setValue( 10 )
 		s["n"]["user"]["i"].setValue( 10 )
-		s["n"]["user"]["c"].setValue( IECore.Color3f( 1, 2, 3 ) )
-		s["n"]["user"]["v"].setValue( IECore.V3f( 1, 2, 3 ) )
+		s["n"]["user"]["c"].setValue( imath.Color3f( 1, 2, 3 ) )
+		s["n"]["user"]["v"].setValue( imath.V3f( 1, 2, 3 ) )
 		s["n"]["user"]["s"].setValue( "s" )
 
 		defaultExpressions = [ Gaffer.Expression.defaultExpression( p, "OSL" ) for p in s["n"]["user"].children() ]

--- a/python/GafferOSLTest/OSLImageTest.py
+++ b/python/GafferOSLTest/OSLImageTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import imath
 
 import IECore
 
@@ -261,7 +262,7 @@ class OSLImageTest( GafferOSLTest.OSLTestCase ) :
 	def testNegativeTileCoordinates( self ) :
 
 		constant = GafferImage.Constant()
-		constant["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( -128 ), IECore.V2i( 128 ) ) ) )
+		constant["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( -128 ), imath.V2i( 128 ) ) ) )
 
 		outR = GafferOSL.OSLShader()
 		outR.loadShader( "ImageProcessing/OutChannel" )
@@ -284,7 +285,7 @@ class OSLImageTest( GafferOSLTest.OSLTestCase ) :
 	def testGlobals( self ) :
 
 		constant = GafferImage.Constant()
-		constant["format"].setValue( GafferImage.Format( IECore.Box2i( IECore.V2i( -10 ), IECore.V2i( 10 ) ) ) )
+		constant["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( -10 ), imath.V2i( 10 ) ) ) )
 
 		globals = GafferOSL.OSLShader()
 		globals.loadShader( "Utility/Globals" )
@@ -321,18 +322,18 @@ class OSLImageTest( GafferOSLTest.OSLTestCase ) :
 		samplerU = GafferImage.Sampler( image["out"], "u", displayWindow )
 		samplerV = GafferImage.Sampler( image["out"], "v", displayWindow )
 
-		size = IECore.V2f( displayWindow.size() )
-		uvStep = IECore.V2f( 1.0 ) / size
+		size = imath.V2f( displayWindow.size() )
+		uvStep = imath.V2f( 1.0 ) / size
 		uvMin = 0.5 * uvStep
 
-		for y in range( displayWindow.min.y, displayWindow.max.y ) :
-			for x in range( displayWindow.min.x, displayWindow.max.x ) :
+		for y in range( displayWindow.min().y, displayWindow.max().y ) :
+			for x in range( displayWindow.min().x, displayWindow.max().x ) :
 
 				self.assertEqual( samplerR.sample( x, y ), x + 0.5, "Pixel {},{}".format( x, y ) )
 				self.assertEqual( samplerG.sample( x, y ), y + 0.5, "Pixel {},{}".format( x, y ) )
 				self.assertEqual( samplerB.sample( x, y ), 0, "Pixel {},{}".format( x, y ) )
 
-				uv = uvMin + uvStep * IECore.V2f( IECore.V2i( x, y ) - displayWindow.min )
+				uv = uvMin + uvStep * imath.V2f( imath.V2i( x, y ) - displayWindow.min() )
 				self.assertAlmostEqual( samplerU.sample( x, y ), uv.x, delta = 0.0000001, msg = "Pixel {},{}".format( x, y ) )
 				self.assertAlmostEqual( samplerV.sample( x, y ), uv.y, delta = 0.0000001, msg = "Pixel {},{}".format( x, y ) )
 

--- a/python/GafferOSLTest/OSLLightTest.py
+++ b/python/GafferOSLTest/OSLLightTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -59,7 +60,7 @@ class OSLLightTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( node["parameters"].keys(), [ "Cs" ] )
 
 		cs = GafferTest.CapturingSlot( node.plugDirtiedSignal() )
-		node["parameters"]["Cs"].setValue( IECore.Color3f( 1, 0, 0 ) )
+		node["parameters"]["Cs"].setValue( imath.Color3f( 1, 0, 0 ) )
 		self.assertIn( node["out"]["attributes"], { x[0] for x in cs } )
 
 		a = node["out"].attributes( "/light" )
@@ -72,7 +73,7 @@ class OSLLightTest( GafferOSLTest.OSLTestCase ) :
 		script = Gaffer.ScriptNode()
 		script["n"] = GafferOSL.OSLLight()
 		script["n"].loadShader( shader )
-		script["n"]["parameters"]["Cs"].setValue( IECore.Color3f( 0, 1, 0 ) )
+		script["n"]["parameters"]["Cs"].setValue( imath.Color3f( 0, 1, 0 ) )
 
 		script2 = Gaffer.ScriptNode()
 		script2.execute( script.serialise() )
@@ -94,16 +95,16 @@ class OSLLightTest( GafferOSLTest.OSLTestCase ) :
 
 		node["shape"].setValue( node.Shape.Geometry )
 		node["geometryType"].setValue( "teapot" )
-		node["geometryBound"].setValue( IECore.Box3f( IECore.V3f( -0.5 ), IECore.V3f( 0.5 ) ) )
-		m = node["geometryParameters"].addMember( "color", IECore.Color3f( 1, 0, 0 ) )
+		node["geometryBound"].setValue( imath.Box3f( imath.V3f( -0.5 ), imath.V3f( 0.5 ) ) )
+		m = node["geometryParameters"].addMember( "color", imath.Color3f( 1, 0, 0 ) )
 
 		self.assertEqual(
 			node["out"].object( "/light" ),
 			GafferScene.Private.IECoreScenePreview.Geometry(
 				"teapot",
-				IECore.Box3f( IECore.V3f( -0.5 ), IECore.V3f( 0.5 ) ),
+				imath.Box3f( imath.V3f( -0.5 ), imath.V3f( 0.5 ) ),
 				{
-					"color" : IECore.Color3f( 1, 0, 0 ),
+					"color" : imath.Color3f( 1, 0, 0 ),
 				}
 			)
 		)

--- a/python/GafferOSLTest/OSLObjectTest.py
+++ b/python/GafferOSLTest/OSLObjectTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import imath
 
 import IECore
 import IECoreScene
@@ -50,8 +51,8 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 	def test( self ) :
 
 		p = GafferScene.Plane()
-		p["dimensions"].setValue( IECore.V2f( 1, 2 ) )
-		p["divisions"].setValue( IECore.V2i( 10 ) )
+		p["dimensions"].setValue( imath.V2f( 1, 2 ) )
+		p["divisions"].setValue( imath.V2i( 10 ) )
 
 		self.assertSceneValid( p["out"] )
 
@@ -96,15 +97,15 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		boundIn = p["out"].bound( "/plane" )
 		boundOut = o["out"].bound( "/plane" )
 
-		self.assertEqual( boundIn.min.x, boundOut.min.y )
-		self.assertEqual( boundIn.max.x, boundOut.max.y )
-		self.assertEqual( boundIn.min.y, boundOut.min.x )
-		self.assertEqual( boundIn.max.y, boundOut.max.x )
+		self.assertEqual( boundIn.min().x, boundOut.min().y )
+		self.assertEqual( boundIn.max().x, boundOut.max().y )
+		self.assertEqual( boundIn.min().y, boundOut.min().x )
+		self.assertEqual( boundIn.max().y, boundOut.max().x )
 
 	def testTransform( self ) :
 
 		p = GafferScene.Plane()
-		p["transform"]["translate"].setValue( IECore.V3f( 2, 0, 0 ) )
+		p["transform"]["translate"].setValue( imath.V3f( 2, 0, 0 ) )
 
 		o = GafferOSL.OSLObject()
 		o["in"].setInput( p["out"] )
@@ -144,8 +145,8 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 
 		o["filter"].setInput( filter["out"] )
 
-		self.assertEqual( o["out"].object( "/plane" )["transformed"].data, IECore.Color3fVectorData( [ IECore.Color3f( 1.5, -0.5, 0 ), IECore.Color3f( 2.5, -0.5, 0 ), IECore.Color3f( 1.5, 0.5, 0 ), IECore.Color3f( 2.5, 0.5, 0 ) ] ) )
-		self.assertEqual( o["out"].object( "/plane" )["transformedBack"].data, IECore.Color3fVectorData( [ IECore.Color3f( -0.5, -0.5, 0 ), IECore.Color3f( 0.5, -0.5, 0 ), IECore.Color3f( -0.5, 0.5, 0 ), IECore.Color3f( 0.5, 0.5, 0 ) ] ) )
+		self.assertEqual( o["out"].object( "/plane" )["transformed"].data, IECore.Color3fVectorData( [ imath.Color3f( 1.5, -0.5, 0 ), imath.Color3f( 2.5, -0.5, 0 ), imath.Color3f( 1.5, 0.5, 0 ), imath.Color3f( 2.5, 0.5, 0 ) ] ) )
+		self.assertEqual( o["out"].object( "/plane" )["transformedBack"].data, IECore.Color3fVectorData( [ imath.Color3f( -0.5, -0.5, 0 ), imath.Color3f( 0.5, -0.5, 0 ), imath.Color3f( -0.5, 0.5, 0 ), imath.Color3f( 0.5, 0.5, 0 ) ] ) )
 
 	def testOnlyAcceptsSurfaceShaders( self ) :
 
@@ -192,15 +193,15 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		outPoint = GafferOSL.OSLShader()
 		outPoint.loadShader( "ObjectProcessing/OutPoint" )
 		outPoint["parameters"]["name"].setValue( "velocity" )
-		outPoint["parameters"]["value"].setValue( IECore.V3f( 0 ) )
+		outPoint["parameters"]["value"].setValue( imath.V3f( 0 ) )
 
 		primVarShader = GafferOSL.OSLShader()
 		primVarShader.loadShader( "ObjectProcessing/OutObject" )
 		primVarShader["parameters"]["in0"].setInput( outPoint["out"]["primitiveVariable"] )
 
 		p = GafferScene.Plane()
-		p["dimensions"].setValue( IECore.V2f( 1, 2 ) )
-		p["divisions"].setValue( IECore.V2i( 10 ) )
+		p["dimensions"].setValue( imath.V2f( 1, 2 ) )
+		p["divisions"].setValue( imath.V2i( 10 ) )
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
@@ -211,7 +212,7 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		o["filter"].setInput( filter["out"] )
 
 		for v in o["out"].object( "/plane" )["velocity"].data :
-			self.assertEqual( v, IECore.V3f( 0 ) )
+			self.assertEqual( v, imath.V3f( 0 ) )
 
 	def testShaderAffectsBoundAndObject( self ) :
 
@@ -273,7 +274,7 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		vectorAdd = GafferOSL.OSLShader( "VectorAdd" )
 		s.addChild( vectorAdd )
 		vectorAdd.loadShader( "Maths/VectorAdd" )
-		vectorAdd["parameters"]["b"].setValue( IECore.V3f( 1, 2, 3 ) )
+		vectorAdd["parameters"]["b"].setValue( imath.V3f( 1, 2, 3 ) )
 
 		vectorAdd["parameters"]["a"].setInput( inPoint["out"]["value"] )
 
@@ -296,19 +297,19 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		self.assertTrue( "P_copy" in cubeObject.keys() )
 		self.assertEqual( cubeObject["P_copy"].interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform)
 
-		self.assertEqual( cubeObject["P_copy"].data[0], IECore.V3f(  0.0,  0.0, -0.5 ) + IECore.V3f( 1, 2, 3 ))
-		self.assertEqual( cubeObject["P_copy"].data[1], IECore.V3f(  0.5,  0.0,  0.0 ) + IECore.V3f( 1, 2, 3 ))
-		self.assertEqual( cubeObject["P_copy"].data[2], IECore.V3f(  0.0,  0.0,  0.5 ) + IECore.V3f( 1, 2, 3 ))
-		self.assertEqual( cubeObject["P_copy"].data[3], IECore.V3f( -0.5,  0.0,  0.0 ) + IECore.V3f( 1, 2, 3 ))
-		self.assertEqual( cubeObject["P_copy"].data[4], IECore.V3f(  0.0,  0.5,  0.0 ) + IECore.V3f( 1, 2, 3 ))
-		self.assertEqual( cubeObject["P_copy"].data[5], IECore.V3f(  0.0, -0.5,  0.0 ) + IECore.V3f( 1, 2, 3 ))
+		self.assertEqual( cubeObject["P_copy"].data[0], imath.V3f(  0.0,  0.0, -0.5 ) + imath.V3f( 1, 2, 3 ))
+		self.assertEqual( cubeObject["P_copy"].data[1], imath.V3f(  0.5,  0.0,  0.0 ) + imath.V3f( 1, 2, 3 ))
+		self.assertEqual( cubeObject["P_copy"].data[2], imath.V3f(  0.0,  0.0,  0.5 ) + imath.V3f( 1, 2, 3 ))
+		self.assertEqual( cubeObject["P_copy"].data[3], imath.V3f( -0.5,  0.0,  0.0 ) + imath.V3f( 1, 2, 3 ))
+		self.assertEqual( cubeObject["P_copy"].data[4], imath.V3f(  0.0,  0.5,  0.0 ) + imath.V3f( 1, 2, 3 ))
+		self.assertEqual( cubeObject["P_copy"].data[5], imath.V3f(  0.0, -0.5,  0.0 ) + imath.V3f( 1, 2, 3 ))
 
 	def testCanShadeFaceVaryingInterpolatedPrimitiveVariablesAsVertex( self ) :
 
 		s = Gaffer.ScriptNode()
 
 		p = GafferScene.Plane()
-		p["divisions"].setValue( IECore.V2i( 2, 2 ) ) #  2x2 plane = 4 quads & 9 vertices
+		p["divisions"].setValue( imath.V2i( 2, 2 ) ) #  2x2 plane = 4 quads & 9 vertices
 		s.addChild( p )
 
 		o = GafferOSL.OSLObject()
@@ -347,22 +348,22 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		self.assertIn( "c", planeObject )
 		self.assertEqual( planeObject["c"].interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
 
-		self.assertEqual( planeObject["c"].data[0], IECore.Color3f( 0.0, 0.0, 0.0 ) )
-		self.assertEqual( planeObject["c"].data[1], IECore.Color3f( 0.5, 0.0, 0.0 ) )
-		self.assertEqual( planeObject["c"].data[2], IECore.Color3f( 1.0, 0.0, 0.0 ) )
-		self.assertEqual( planeObject["c"].data[3], IECore.Color3f( 0.0, 0.5, 0.0 ) )
-		self.assertEqual( planeObject["c"].data[4], IECore.Color3f( 0.5, 0.5, 0.0 ) )
-		self.assertEqual( planeObject["c"].data[5], IECore.Color3f( 1.0, 0.5, 0.0 ) )
-		self.assertEqual( planeObject["c"].data[6], IECore.Color3f( 0.0, 1.0, 0.0 ) )
-		self.assertEqual( planeObject["c"].data[7], IECore.Color3f( 0.5, 1.0, 0.0 ) )
-		self.assertEqual( planeObject["c"].data[8], IECore.Color3f( 1.0, 1.0, 0.0 ) )
+		self.assertEqual( planeObject["c"].data[0], imath.Color3f( 0.0, 0.0, 0.0 ) )
+		self.assertEqual( planeObject["c"].data[1], imath.Color3f( 0.5, 0.0, 0.0 ) )
+		self.assertEqual( planeObject["c"].data[2], imath.Color3f( 1.0, 0.0, 0.0 ) )
+		self.assertEqual( planeObject["c"].data[3], imath.Color3f( 0.0, 0.5, 0.0 ) )
+		self.assertEqual( planeObject["c"].data[4], imath.Color3f( 0.5, 0.5, 0.0 ) )
+		self.assertEqual( planeObject["c"].data[5], imath.Color3f( 1.0, 0.5, 0.0 ) )
+		self.assertEqual( planeObject["c"].data[6], imath.Color3f( 0.0, 1.0, 0.0 ) )
+		self.assertEqual( planeObject["c"].data[7], imath.Color3f( 0.5, 1.0, 0.0 ) )
+		self.assertEqual( planeObject["c"].data[8], imath.Color3f( 1.0, 1.0, 0.0 ) )
 
 	def testCanReadFromConstantPrimitiveVariables( self ) :
 
 		s = Gaffer.ScriptNode()
 
 		p = GafferScene.Plane()
-		p["divisions"].setValue( IECore.V2i( 2, 2 ) ) #  2x2 plane = 4 quads & 9 vertices
+		p["divisions"].setValue( imath.V2i( 2, 2 ) ) #  2x2 plane = 4 quads & 9 vertices
 		s.addChild( p )
 
 		o = GafferOSL.OSLObject()
@@ -442,7 +443,7 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		outObject["parameters"]["in0"].setInput( outColor["out"]["c"] )
 
 		plane = GafferScene.Plane()
-		plane["divisions"].setValue( IECore.V2i( 32 ) )
+		plane["divisions"].setValue( imath.V2i( 32 ) )
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
@@ -467,7 +468,7 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		s = Gaffer.ScriptNode()
 
 		p = GafferScene.Plane()
-		p["divisions"].setValue( IECore.V2i( 2, 2 ) )  # 2x2 plane = 4 quads & 9 vertices
+		p["divisions"].setValue( imath.V2i( 2, 2 ) )  # 2x2 plane = 4 quads & 9 vertices
 		s.addChild( p )
 
 		o = GafferOSL.OSLObject()
@@ -495,7 +496,7 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		inIntPlug = Gaffer.IntPlug( "inIndex", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
 		oslCode["parameters"].addChild( inIntPlug )
 		inIntPlug.setInput( inInt['out']['value'] )
-		oslCode["out"].addChild( Gaffer.M44fPlug( "outMat", direction = Gaffer.Plug.Direction.Out, defaultValue = IECore.M44f( 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 ),
+		oslCode["out"].addChild( Gaffer.M44fPlug( "outMat", direction = Gaffer.Plug.Direction.Out, defaultValue = imath.M44f( 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 ),
 			flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
 
 		outMatrix["parameters"]["value"].setInput( oslCode['out']['outMat'] )
@@ -509,7 +510,7 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 
 		matrixPrimvar = o['out'].object( "/plane" )["out_foo"]
 		for index, m in enumerate( matrixPrimvar.data ) :
-			self.assertEqual( m, IECore.M44f( index ) )
+			self.assertEqual( m, imath.M44f( index ) )
 
 		# check we can read the matrix44 primvar by reading and writing as out_foo2
 		inMatrix = GafferOSL.OSLShader( "InMatrix" )
@@ -536,7 +537,7 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 
 		matrixPrimvar = o2['out'].object( "/plane" )["out_foo2"]
 		for index, m in enumerate( matrixPrimvar.data ) :
-			self.assertEqual( m, IECore.M44f( index ) )
+			self.assertEqual( m, imath.M44f( index ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -68,9 +69,9 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		self.assertEqual( n["parameters"]["i"].defaultValue(), 10 )
 		self.assertEqual( n["parameters"]["f"].defaultValue(), 1 )
-		self.assertEqual( n["parameters"]["c"].defaultValue(), IECore.Color3f( 1, 2, 3 ) )
+		self.assertEqual( n["parameters"]["c"].defaultValue(), imath.Color3f( 1, 2, 3 ) )
 		self.assertEqual( n["parameters"]["s"].defaultValue(), "s" )
-		self.assertEqual( n["parameters"]["m"].defaultValue(), IECore.M44f() )
+		self.assertEqual( n["parameters"]["m"].defaultValue(), imath.M44f() )
 
 		self.assertEqual( n["out"].typeId(), Gaffer.Plug.staticTypeId() )
 
@@ -80,9 +81,9 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( network[0].type, "osl:surface" )
 		self.assertEqual( network[0].parameters["i"], IECore.IntData( 10 ) )
 		self.assertEqual( network[0].parameters["f"], IECore.FloatData( 1 ) )
-		self.assertEqual( network[0].parameters["c"], IECore.Color3fData( IECore.Color3f( 1, 2, 3 ) ) )
+		self.assertEqual( network[0].parameters["c"], IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ) )
 		self.assertEqual( network[0].parameters["s"], IECore.StringData( "s" ) )
-		self.assertEqual( network[0].parameters["m"], IECore.M44fData( IECore.M44f() ) )
+		self.assertEqual( network[0].parameters["m"], IECore.M44fData( imath.M44f() ) )
 
 	def testOutputTypes( self ) :
 
@@ -129,7 +130,7 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( network[1].type, "osl:surface" )
 		self.assertEqual( network[1].parameters["i"], IECore.StringData( "link:" + network[0].parameters["__handle"].value + ".i" ) )
 		self.assertEqual( network[1].parameters["f"], IECore.FloatData( 1 ) )
-		self.assertEqual( network[1].parameters["c"], IECore.Color3fData( IECore.Color3f( 1, 2, 3 ) ) )
+		self.assertEqual( network[1].parameters["c"], IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ) )
 		self.assertEqual( network[1].parameters["s"], IECore.StringData( "s" ) )
 		self.assertEqual( network[0].name, outputTypesShader )
 		self.assertEqual( network[0].type, "osl:shader" )
@@ -197,12 +198,12 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( n["parameters"]["s"].keys(), [ "i", "f", "c", "s" ] )
 		self.assertEqual( n["parameters"]["s"]["i"].defaultValue(), 1 )
 		self.assertEqual( n["parameters"]["s"]["f"].defaultValue(), 2 )
-		self.assertEqual( n["parameters"]["s"]["c"].defaultValue(), IECore.Color3f( 1, 2, 3 ) )
+		self.assertEqual( n["parameters"]["s"]["c"].defaultValue(), imath.Color3f( 1, 2, 3 ) )
 		self.assertEqual( n["parameters"]["s"]["s"].defaultValue(), "s" )
 
 		n["parameters"]["s"]["i"].setValue( 10 )
 		n["parameters"]["s"]["f"].setValue( 21 )
-		n["parameters"]["s"]["c"].setValue( IECore.Color3f( 3, 4, 5 ) )
+		n["parameters"]["s"]["c"].setValue( imath.Color3f( 3, 4, 5 ) )
 		n["parameters"]["s"]["s"].setValue( "ttt" )
 
 		network = n.attributes()["osl:shader"]
@@ -211,7 +212,7 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		self.assertTrue( network[0].parameters["f"], IECore.FloatData( 3 ) )
 		self.assertTrue( network[0].parameters["s.i"], IECore.IntData( 10 ) )
 		self.assertTrue( network[0].parameters["s.f"], IECore.FloatData( 21 ) )
-		self.assertTrue( network[0].parameters["s.c"], IECore.Color3fData( IECore.Color3f( 3, 4, 5 ) ) )
+		self.assertTrue( network[0].parameters["s.c"], IECore.Color3fData( imath.Color3f( 3, 4, 5 ) ) )
 		self.assertTrue( network[0].parameters["s.s"], IECore.StringData( "ttt" ) )
 		self.assertTrue( network[0].parameters["ss"], IECore.StringData( "ss" ) )
 
@@ -418,14 +419,14 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		self.assertAlmostEqual( n["parameters"]["b"].maxValue(), 4.7, delta = 0.00001 )
 		self.assertEqual( n["parameters"]["c"].minValue(), 23 )
 		self.assertEqual( n["parameters"]["c"].maxValue(), 47 )
-		self.assertEqual( n["parameters"]["d"].minValue(), IECore.Color3f( 1, 2, 3 ) )
-		self.assertEqual( n["parameters"]["d"].maxValue(), IECore.Color3f( 4, 5, 6 ) )
-		self.assertEqual( n["parameters"]["e"].minValue(), IECore.V3f( 1, 2, 3 ) )
-		self.assertEqual( n["parameters"]["e"].maxValue(), IECore.V3f( 4, 5, 6 ) )
-		self.assertEqual( n["parameters"]["f"].minValue(), IECore.V3f( 1, 2, 3 ) )
-		self.assertEqual( n["parameters"]["f"].maxValue(), IECore.V3f( 4, 5, 6 ) )
-		self.assertEqual( n["parameters"]["g"].minValue(), IECore.V3f( 1, 2, 3 ) )
-		self.assertEqual( n["parameters"]["g"].maxValue(), IECore.V3f( 4, 5, 6 ) )
+		self.assertEqual( n["parameters"]["d"].minValue(), imath.Color3f( 1, 2, 3 ) )
+		self.assertEqual( n["parameters"]["d"].maxValue(), imath.Color3f( 4, 5, 6 ) )
+		self.assertEqual( n["parameters"]["e"].minValue(), imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( n["parameters"]["e"].maxValue(), imath.V3f( 4, 5, 6 ) )
+		self.assertEqual( n["parameters"]["f"].minValue(), imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( n["parameters"]["f"].maxValue(), imath.V3f( 4, 5, 6 ) )
+		self.assertEqual( n["parameters"]["g"].minValue(), imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( n["parameters"]["g"].maxValue(), imath.V3f( 4, 5, 6 ) )
 
 		# Check default min/max if not specified
 		self.assertFalse( n["parameters"]["h"].hasMinValue() )
@@ -585,11 +586,11 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		values = {
 			"commonI" : 10,
 			"commonF" : 25,
-			"commonColor" : IECore.Color3f( 1 ),
+			"commonColor" : imath.Color3f( 1 ),
 			"commonString" : "test",
 			"commonStruct.commonI" : 11,
 			"commonStruct.commonF" : 2.5,
-			"commonStruct.commonColor" : IECore.Color3f( 0.5 ),
+			"commonStruct.commonColor" : imath.Color3f( 0.5 ),
 			"commonStruct.commonString" : "test2",
 			"commonArray" : IECore.FloatVectorData( [ 0, 1, 2 ] )
 		}
@@ -696,12 +697,12 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 			IECore.SplinefColor3f(
 				IECore.CubicBasisf.bSpline(),
 				[
-					( 0, IECore.Color3f( 0 ) ),
-					( 0, IECore.Color3f( 0 ) ),
-					( 0, IECore.Color3f( 0 ) ),
-					( 1, IECore.Color3f( 1 ) ),
-					( 1, IECore.Color3f( 1 ) ),
-					( 1, IECore.Color3f( 1 ) ),
+					( 0, imath.Color3f( 0 ) ),
+					( 0, imath.Color3f( 0 ) ),
+					( 0, imath.Color3f( 0 ) ),
+					( 1, imath.Color3f( 1 ) ),
+					( 1, imath.Color3f( 1 ) ),
+					( 1, imath.Color3f( 1 ) ),
 				]
 			)
 		)
@@ -726,12 +727,12 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 			IECore.SplinefColor3f(
 				IECore.CubicBasisf.bSpline(),
 				[
-					( 0, IECore.Color3f( 0 ) ),
-					( 0, IECore.Color3f( 0 ) ),
-					( 0, IECore.Color3f( 0 ) ),
-					( 1, IECore.Color3f( 1 ) ),
-					( 1, IECore.Color3f( 1 ) ),
-					( 1, IECore.Color3f( 1 ) ),
+					( 0, imath.Color3f( 0 ) ),
+					( 0, imath.Color3f( 0 ) ),
+					( 0, imath.Color3f( 0 ) ),
+					( 1, imath.Color3f( 1 ) ),
+					( 1, imath.Color3f( 1 ) ),
+					( 1, imath.Color3f( 1 ) ),
 				]
 			)
 		)
@@ -745,12 +746,12 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		n.loadShader( s )
 
 		points = [
-			( 0, IECore.Color3f( 0.5 ) ),
-			( 0.3, IECore.Color3f( 0.2 ) ),
-			( 0.6, IECore.Color3f( 1 ) ),
-			( 0.65, IECore.Color3f( 0.5 ) ),
-			( 0.9, IECore.Color3f( 0.7 ) ),
-			( 1, IECore.Color3f( 1 ) )
+			( 0, imath.Color3f( 0.5 ) ),
+			( 0.3, imath.Color3f( 0.2 ) ),
+			( 0.6, imath.Color3f( 1 ) ),
+			( 0.65, imath.Color3f( 0.5 ) ),
+			( 0.9, imath.Color3f( 0.7 ) ),
+			( 1, imath.Color3f( 1 ) )
 		]
 
 		constant = GafferImage.Constant( "Constant" )
@@ -799,14 +800,14 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( n["parameters"]["i"].defaultValue(), IECore.IntVectorData( [ 10, 11, 12 ] ) )
 		self.assertEqual( n["parameters"]["f"].defaultValue(), IECore.FloatVectorData( [ 1, 2 ] ) )
 		self.assertEqual( n["parameters"]["c"].defaultValue(), IECore.Color3fVectorData(
-			[ IECore.Color3f( 1, 2, 3 ), IECore.Color3f( 4, 5, 6 ) ] ) )
+			[ imath.Color3f( 1, 2, 3 ), imath.Color3f( 4, 5, 6 ) ] ) )
 		self.assertEqual( n["parameters"]["p"].defaultValue(), IECore.V3fVectorData(
-			[ IECore.V3f( 1, 2, 3 ), IECore.V3f( 4, 5, 6 ) ] ) )
+			[ imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) ] ) )
 		self.assertEqual( n["parameters"]["q"].defaultValue(), IECore.V3fVectorData(
-			[ IECore.V3f( 1, 2, 3 ), IECore.V3f( 4, 5, 6 ) ] ) )
+			[ imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) ] ) )
 		self.assertEqual( n["parameters"]["s"].defaultValue(), IECore.StringVectorData( [ "s", "t", "u", "v", "word" ] ) )
 		self.assertEqual( n["parameters"]["m"].defaultValue(), IECore.M44fVectorData(
-			[ IECore.M44f() * 1, IECore.M44f() * 0, IECore.M44f() * 1 ] ) )
+			[ imath.M44f() * 1, imath.M44f() * 0, imath.M44f() * 1 ] ) )
 
 		self.assertEqual( n["out"].typeId(), Gaffer.Plug.staticTypeId() )
 
@@ -817,14 +818,14 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( network[0].parameters["i"], IECore.IntVectorData( [ 10, 11, 12 ] ) )
 		self.assertEqual( network[0].parameters["f"], IECore.FloatVectorData( [ 1, 2 ] ) )
 		self.assertEqual( network[0].parameters["c"], IECore.Color3fVectorData(
-			[ IECore.Color3f( 1, 2, 3 ), IECore.Color3f( 4, 5, 6 ) ] ) )
+			[ imath.Color3f( 1, 2, 3 ), imath.Color3f( 4, 5, 6 ) ] ) )
 		self.assertEqual( network[0].parameters["p"], IECore.V3fVectorData(
-			[ IECore.V3f( 1, 2, 3 ), IECore.V3f( 4, 5, 6 ) ] ) )
+			[ imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) ] ) )
 		self.assertEqual( network[0].parameters["q"], IECore.V3fVectorData(
-			[ IECore.V3f( 1, 2, 3 ), IECore.V3f( 4, 5, 6 ) ] ) )
+			[ imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) ] ) )
 		self.assertEqual( network[0].parameters["s"], IECore.StringVectorData( [ "s", "t", "u", "v", "word" ] ) )
 		self.assertEqual( network[0].parameters["m"], IECore.M44fVectorData(
-			[ IECore.M44f() * 1, IECore.M44f() * 0, IECore.M44f() * 1 ] ) )
+			[ imath.M44f() * 1, imath.M44f() * 0, imath.M44f() * 1 ] ) )
 
 	def testUnload( self ) :
 
@@ -870,7 +871,7 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		n1 = GafferOSL.OSLShader()
 		n1.loadShader( "Maths/VectorAdd" )
-		n1["parameters"]["a"].setValue( IECore.V3f( 5, 7, 6 ) )
+		n1["parameters"]["a"].setValue( imath.V3f( 5, 7, 6 ) )
 
 		n2 = GafferOSL.OSLShader()
 		n2.loadShader( "Maths/VectorAdd" )
@@ -885,13 +886,13 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		network = n3.attributes()["osl:shader"]
 		self.assertEqual( len( network ), 2 )
 		self.assertEqual( network[1].parameters["a"].value, "link:" + network[0].parameters["__handle"].value + ".out" )
-		self.assertEqual( network[0].parameters["a"].value, IECore.V3f( 5, 7, 6 ) )
+		self.assertEqual( network[0].parameters["a"].value, imath.V3f( 5, 7, 6 ) )
 
 	def testDisabledShaderPassesThroughExternalValue( self ) :
 
 		n1 = Gaffer.Node()
 		n1["user"]["v"] = Gaffer.V3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		n1["user"]["v"].setValue( IECore.V3f( 12, 11, 10 ) )
+		n1["user"]["v"].setValue( imath.V3f( 12, 11, 10 ) )
 
 		n2 = GafferOSL.OSLShader()
 		n2.loadShader( "Maths/VectorAdd" )
@@ -905,7 +906,7 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		network = n3.attributes()["osl:shader"]
 		self.assertEqual( len( network ), 1 )
-		self.assertEqual( network[0].parameters["a"].value, IECore.V3f( 12, 11, 10 ) )
+		self.assertEqual( network[0].parameters["a"].value, imath.V3f( 12, 11, 10 ) )
 
 	def testDisabledShaderEvaluatesStateCorrectly( self ) :
 

--- a/python/GafferOSLTest/ShadingEngineTest.py
+++ b/python/GafferOSLTest/ShadingEngineTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import imath
 
 import IECore
 import IECoreScene
@@ -44,9 +45,9 @@ import GafferOSLTest
 
 class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
-	def rectanglePoints( self, bound = IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ), divisions = IECore.V2i( 10 ) ) :
+	def rectanglePoints( self, bound = imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ), divisions = imath.V2i( 10 ) ) :
 
-		r = IECore.Rand48()
+		r = imath.Rand48()
 
 		pData = IECore.V3fVectorData()
 		uData = IECore.FloatVectorData()
@@ -57,15 +58,15 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 			for x in range( 0, divisions.x ) :
 				u = float( x ) / float( divisions.x - 1 )
 				v = float( y ) / float( divisions.y - 1 )
-				pData.append( IECore.V3f(
-					bound.min.x + u * bound.size().x,
-					bound.min.y + v * bound.size().y,
+				pData.append( imath.V3f(
+					bound.min().x + u * bound.size().x,
+					bound.min().y + v * bound.size().y,
 					0
 				) )
 				uData.append( u )
 				vData.append( v )
 				floatUserData.append( r.nextf( 0, 1 ) )
-				colorUserData.append( r.nextColor3f() )
+				colorUserData.append( imath.Color3f( r.nextf(), r.nextf(), r.nextf() ) )
 
 		return IECore.CompoundData( {
 			"P" : pData,
@@ -80,12 +81,12 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		s = self.compileShader( os.path.dirname( __file__ ) +  "/shaders/constant.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECoreScene.Shader( s, "osl:surface", { "Cs" : IECore.Color3f( 1, 0.5, 0.25 ) } )
+			IECoreScene.Shader( s, "osl:surface", { "Cs" : imath.Color3f( 1, 0.5, 0.25 ) } )
 		] ) )
 
 		p = e.shade( self.rectanglePoints() )
 
-		self.assertEqual( p["Ci"], IECore.Color3fVectorData( [ IECore.Color3f( 1, 0.5, 0.25 ) ] * 100 ) )
+		self.assertEqual( p["Ci"], IECore.Color3fVectorData( [ imath.Color3f( 1, 0.5, 0.25 ) ] * 100 ) )
 
 	def testNetwork( self ) :
 
@@ -99,7 +100,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		p = e.shade( self.rectanglePoints() )
 
-		self.assertEqual( p["Ci"], IECore.Color3fVectorData( [ IECore.Color3f( 0.5 ) ] * 100 ) )
+		self.assertEqual( p["Ci"], IECore.Color3fVectorData( [ imath.Color3f( 0.5 ) ] * 100 ) )
 
 	def testGlobals( self ) :
 
@@ -115,7 +116,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 			v1 = p["Ci"]
 			v2 = rp[n]
 			for i in range( 0, len( v1 ) ) :
-				self.assertEqual( v1[i], IECore.Color3f( v2[i] ) )
+				self.assertEqual( v1[i], imath.Color3f( v2[i] ) )
 
 	def testUserDataViaGetAttribute( self ) :
 
@@ -161,7 +162,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		p = e.shade( rp )
 
 		for i, c in enumerate( p["Ci"] ) :
-			self.assertEqual( c, IECore.Color3f(i) )
+			self.assertEqual( c, imath.Color3f(i) )
 
 	def testDynamicAttributesAllAttributesAreNeeded( self ) :
 
@@ -180,13 +181,13 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		constant = self.compileShader( os.path.dirname( __file__ ) + "/shaders/constant.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECoreScene.Shader( shader, "osl:shader", { "s.c" : IECore.Color3f( 0.1, 0.2, 0.3 ), "__handle" : "h" } ),
+			IECoreScene.Shader( shader, "osl:shader", { "s.c" : imath.Color3f( 0.1, 0.2, 0.3 ), "__handle" : "h" } ),
 			IECoreScene.Shader( constant, "osl:surface", { "Cs" : "link:h.c" } ),
 		] ) )
 		p = e.shade( self.rectanglePoints() )
 
 		for c in p["Ci"] :
-			self.assertEqual( c, IECore.Color3f( 0.1, 0.2, 0.3 ) )
+			self.assertEqual( c, imath.Color3f( 0.1, 0.2, 0.3 ) )
 
 	def testClosureParameters( self ) :
 
@@ -194,20 +195,20 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		inputClosure = self.compileShader( os.path.dirname( __file__ ) + "/shaders/inputClosure.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECoreScene.Shader( outputClosure, "osl:shader", { "e" : IECore.Color3f( 0.1, 0.2, 0.3 ), "__handle" : "h" } ),
+			IECoreScene.Shader( outputClosure, "osl:shader", { "e" : imath.Color3f( 0.1, 0.2, 0.3 ), "__handle" : "h" } ),
 			IECoreScene.Shader( inputClosure, "osl:surface", { "i" : "link:h.c" } ),
 		] ) )
 		p = e.shade( self.rectanglePoints() )
 
 		for c in p["Ci"] :
-			self.assertEqual( c, IECore.Color3f( 0.1, 0.2, 0.3 ) )
+			self.assertEqual( c, imath.Color3f( 0.1, 0.2, 0.3 ) )
 
 	def testDebugClosure( self ) :
 
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/debugClosure.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECoreScene.Shader( shader, "osl:surface", { "name" : "a", "weight" : IECore.Color3f( 1, 0, 0 ) } ),
+			IECoreScene.Shader( shader, "osl:surface", { "name" : "a", "weight" : imath.Color3f( 1, 0, 0 ) } ),
 		] ) )
 
 		points = self.rectanglePoints()
@@ -219,10 +220,10 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( len( shading["a"] ), len( points["P"] ) )
 
 		for c in shading["Ci"] :
-			self.assertEqual( c, IECore.Color3f( 0 ) )
+			self.assertEqual( c, imath.Color3f( 0 ) )
 
 		for a in shading["a"] :
-			self.assertEqual( a, IECore.Color3f( 1, 0, 0 ) )
+			self.assertEqual( a, imath.Color3f( 1, 0, 0 ) )
 
 	def testMultipleDebugClosures( self ) :
 
@@ -237,7 +238,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		for n in ( "u", "v", "P" ) :
 			for i in range( 0, len( shading[n] ) ) :
-				self.assertEqual( shading[n][i], IECore.Color3f( points[n][i] ) )
+				self.assertEqual( shading[n][i], imath.Color3f( points[n][i] ) )
 
 	def testTypedDebugClosure( self ) :
 
@@ -274,7 +275,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/debugClosureWithInternalValue.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECoreScene.Shader( shader, "osl:surface", { "value" : IECore.Color3f( 1, 0.5, 0.25 ) } ),
+			IECoreScene.Shader( shader, "osl:surface", { "value" : imath.Color3f( 1, 0.5, 0.25 ) } ),
 		] ) )
 
 		points = self.rectanglePoints()
@@ -292,17 +293,17 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		for i in range( 0, len( points["P"] ) ) :
 			self.assertEqual( shading["f"][i], 1 )
-			self.assertEqual( shading["p"][i], IECore.V3f( 1, 0.5, 0.25 ) )
-			self.assertEqual( shading["v"][i], IECore.V3f( 1, 0.5, 0.25 ) )
-			self.assertEqual( shading["n"][i], IECore.V3f( 1, 0.5, 0.25 ) )
-			self.assertEqual( shading["c"][i], IECore.Color3f( 1, 0.5, 0.25 ) )
+			self.assertEqual( shading["p"][i], imath.V3f( 1, 0.5, 0.25 ) )
+			self.assertEqual( shading["v"][i], imath.V3f( 1, 0.5, 0.25 ) )
+			self.assertEqual( shading["n"][i], imath.V3f( 1, 0.5, 0.25 ) )
+			self.assertEqual( shading["c"][i], imath.Color3f( 1, 0.5, 0.25 ) )
 
 	def testDebugClosureWithZeroValue( self ) :
 
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/debugClosureWithInternalValue.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECoreScene.Shader( shader, "osl:surface", { "value" : IECore.Color3f( 0 ) } ),
+			IECoreScene.Shader( shader, "osl:surface", { "value" : imath.Color3f( 0 ) } ),
 		] ) )
 
 		points = self.rectanglePoints()
@@ -320,10 +321,10 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		for i in range( 0, len( points["P"] ) ) :
 			self.assertEqual( shading["f"][i], 0 )
-			self.assertEqual( shading["p"][i], IECore.V3f( 0 ) )
-			self.assertEqual( shading["v"][i], IECore.V3f( 0 ) )
-			self.assertEqual( shading["n"][i], IECore.V3f( 0 ) )
-			self.assertEqual( shading["c"][i], IECore.Color3f( 0 ) )
+			self.assertEqual( shading["p"][i], imath.V3f( 0 ) )
+			self.assertEqual( shading["v"][i], imath.V3f( 0 ) )
+			self.assertEqual( shading["n"][i], imath.V3f( 0 ) )
+			self.assertEqual( shading["c"][i], imath.Color3f( 0 ) )
 
 	def testSpline( self ) :
 
@@ -331,10 +332,10 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		spline =  IECore.SplinefColor3f(
 			IECore.CubicBasisf.bSpline(),
 			[
-				( 0, IECore.Color3f( 1 ) ),
-				( 0, IECore.Color3f( 1 ) ),
-				( 1, IECore.Color3f( 0 ) ),
-				( 1, IECore.Color3f( 0 ) ),
+				( 0, imath.Color3f( 1 ) ),
+				( 0, imath.Color3f( 1 ) ),
+				( 1, imath.Color3f( 0 ) ),
+				( 1, imath.Color3f( 0 ) ),
 			]
 		)
 
@@ -352,12 +353,12 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		shader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/extractTranslate.osl" )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
-			IECoreScene.Shader( shader, "osl:surface", { "m" : IECore.M44f().translate( IECore.V3f( 1, 2, 3 ) ) } )
+			IECoreScene.Shader( shader, "osl:surface", { "m" : imath.M44f().translate( imath.V3f( 1, 2, 3 ) ) } )
 		] ) )
 
 		p = e.shade( self.rectanglePoints() )
 		for i in range( 0, len( p["Ci"] ) ) :
-			self.assertEqual( p["translate"][i], IECore.V3f( 1, 2, 3 ) )
+			self.assertEqual( p["translate"][i], imath.V3f( 1, 2, 3 ) )
 
 	def testParameters( self ) :
 
@@ -367,11 +368,11 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 				"f" : 1.0,
 				"i" : 2,
 				"s" : "three",
-				"c" : IECore.Color3f( 4, 5, 6 ),
-				"vec" : IECore.V3fData( IECore.V3f( 7, 8, 9 ), IECore.GeometricData.Interpretation.Vector ),
-				"p" : IECore.V3fData( IECore.V3f( 10, 11, 12 ), IECore.GeometricData.Interpretation.Point ),
-				"n" : IECore.V3fData( IECore.V3f( 13, 14, 15 ), IECore.GeometricData.Interpretation.Normal ),
-				"noInterp" : IECore.V3f( 16, 17, 18 ),
+				"c" : imath.Color3f( 4, 5, 6 ),
+				"vec" : IECore.V3fData( imath.V3f( 7, 8, 9 ), IECore.GeometricData.Interpretation.Vector ),
+				"p" : IECore.V3fData( imath.V3f( 10, 11, 12 ), IECore.GeometricData.Interpretation.Point ),
+				"n" : IECore.V3fData( imath.V3f( 13, 14, 15 ), IECore.GeometricData.Interpretation.Normal ),
+				"noInterp" : imath.V3f( 16, 17, 18 ),
 
 			 } )
 		] ) )
@@ -379,7 +380,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		rp = self.rectanglePoints()
 		p = e.shade( rp )
 		for i in range( 0, len( p["Ci"] ) ) :
-			self.assertEqual( p["Ci"][i], IECore.Color3f( 0, 1, 0 ) )
+			self.assertEqual( p["Ci"][i], imath.Color3f( 0, 1, 0 ) )
 
 	def testTransform( self ) :
 
@@ -392,14 +393,14 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		p = e.shade( self.rectanglePoints() )
 
 		# Transform has no effect if world matrix not set
-		self.assertEqual( p["Ci"], IECore.Color3fVectorData( [ IECore.Color3f( i ) for i in self.rectanglePoints()["P"] ] ) )
+		self.assertEqual( p["Ci"], IECore.Color3fVectorData( [ imath.Color3f( i ) for i in self.rectanglePoints()["P"] ] ) )
 
-		worldMatrix = IECore.M44f()
-		worldMatrix.translate( IECore.V3f( 2, 0, 0 ) )
+		worldMatrix = imath.M44f()
+		worldMatrix.translate( imath.V3f( 2, 0, 0 ) )
 		p = e.shade( self.rectanglePoints(), { "world" : GafferOSL.ShadingEngine.Transform( worldMatrix ) } )
 
 		# Transform from object to world
-		self.assertEqual( p["Ci"], IECore.Color3fVectorData( [ IECore.Color3f( i + IECore.V3f( 2, 0, 0 ) ) for i in self.rectanglePoints()["P"] ] ) )
+		self.assertEqual( p["Ci"], IECore.Color3fVectorData( [ imath.Color3f( i + imath.V3f( 2, 0, 0 ) ) for i in self.rectanglePoints()["P"] ] ) )
 
 		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
 			IECoreScene.Shader( s, "osl:surface", { "backwards" : IECore.IntData( 1 ) } )
@@ -408,7 +409,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		p = e.shade( self.rectanglePoints(), { "world" : GafferOSL.ShadingEngine.Transform( worldMatrix ) } )
 
 		# Transform from world to object
-		self.assertEqual( p["Ci"], IECore.Color3fVectorData( [ IECore.Color3f( i + IECore.V3f( -2, 0, 0 ) ) for i in self.rectanglePoints()["P"] ] ) )
+		self.assertEqual( p["Ci"], IECore.Color3fVectorData( [ imath.Color3f( i + imath.V3f( -2, 0, 0 ) ) for i in self.rectanglePoints()["P"] ] ) )
 
 	def testVectorToColorConnections( self ) :
 
@@ -421,7 +422,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		r = e.shade( p )
 
 		for i, c in enumerate( r["Ci"] ) :
-			self.assertEqual( IECore.V3f( *c ), p["P"][i] )
+			self.assertEqual( imath.V3f( *c ), p["P"][i] )
 
 	def testCanReadV3iArrayUserData( self ) :
 
@@ -437,15 +438,15 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		p["v3i"] = IECore.V3iVectorData( numPoints )
 
 		for i in range( numPoints ) :
-			p["v3i"][i] = IECore.V3i( [i, i + 1 , i + 2 ] )
+			p["v3i"][i] = imath.V3i( [i, i + 1 , i + 2 ] )
 
 		r = e.shade( p )
 
 		for i, c in enumerate( r["Ci"] ) :
 			if i < 50:
-				expected = IECore.Color3f( 0.0, i / 100.0, i / 200.0 )
+				expected = imath.Color3f( 0.0, i / 100.0, i / 200.0 )
 			else:
-				expected = IECore.Color3f( 1.0, 0.0, 0.0 )
+				expected = imath.Color3f( 1.0, 0.0, 0.0 )
 
 			self.assertEqual( c, expected )
 
@@ -468,14 +469,14 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		] ) )
 
 		p = self.rectanglePoints()
-		p["v2f"] = IECore.V2fVectorData( [ IECore.V2f( x.x, x.y ) for x in p["P"] ] )
+		p["v2f"] = IECore.V2fVectorData( [ imath.V2f( x.x, x.y ) for x in p["P"] ] )
 
 		r = e.shade( p )
 
 		for i, c in enumerate( r["Ci"] ) :
 			self.assertEqual(
 				c,
-				IECore.Color3f( p["P"][i].x, p["P"][i].y, 0 )
+				imath.Color3f( p["P"][i].x, p["P"][i].y, 0 )
 			)
 
 	def testUVProvidedAsV2f( self ) :
@@ -484,7 +485,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		rp = self.rectanglePoints()
 		rp["uv"] = IECore.V2fVectorData(
-			[ IECore.V2f( u, v ) for u, v in zip( rp["u"], rp["v"] ) ]
+			[ imath.V2f( u, v ) for u, v in zip( rp["u"], rp["v"] ) ]
 		)
 		del rp["u"]
 		del rp["v"]
@@ -497,7 +498,7 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 			p = e.shade( rp )
 			for i, c in enumerate( p["Ci"] ) :
-				self.assertEqual( c, IECore.Color3f( rp["uv"][i][uvIndex] ) )
+				self.assertEqual( c, imath.Color3f( rp["uv"][i][uvIndex] ) )
 
 	def testTextureOrientation( self ) :
 

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -36,6 +36,7 @@
 
 import os
 import functools
+import imath
 
 import IECore
 
@@ -167,7 +168,7 @@ class _ParametersFooter( GafferUI.PlugValueWidget ) :
 
 		with row :
 
-				GafferUI.Spacer( IECore.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
+				GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 
 				menuButton = GafferUI.MenuButton(
 					image = "plus.png",
@@ -180,7 +181,7 @@ class _ParametersFooter( GafferUI.PlugValueWidget ) :
 				)
 				menuButton.setEnabled( not Gaffer.MetadataAlgo.readOnly( plug ) )
 
-				GafferUI.Spacer( IECore.V2i( 1 ), IECore.V2i( 999999, 1 ), parenting = { "expand" : True } )
+				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
 	def _updateFromPlug( self ) :
 
@@ -212,10 +213,10 @@ class _ParametersFooter( GafferUI.PlugValueWidget ) :
 						defaultValue = IECore.SplinefColor3f(
 							IECore.CubicBasisf.catmullRom(),
 							(
-								( 0, IECore.Color3f( 0 ) ),
-								( 0, IECore.Color3f( 0 ) ),
-								( 1, IECore.Color3f( 1 ) ),
-								( 1, IECore.Color3f( 1 ) ),
+								( 0, imath.Color3f( 0 ) ),
+								( 0, imath.Color3f( 0 ) ),
+								( 1, imath.Color3f( 1 ) ),
+								( 1, imath.Color3f( 1 ) ),
 							)
 						)
 					)

--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -105,13 +107,13 @@ def __plugPresetValues( plug ) :
 		return IECore.FloatVectorData( [ float( v ) for v in values ] )
 	elif isinstance( plug, Gaffer.Color3fPlug ) :
 		return IECore.Color3fVectorData( [
-			IECore.Color3f(
+			imath.Color3f(
 				*[ float( x ) for x in v.split( "," ) ]
 			) for v in values
 		] )
 	elif isinstance( plug, Gaffer.V3fPlug ) :
 		return IECore.V3fVectorData( [
-			IECore.V3f(
+			imath.V3f(
 				*[ float( x ) for x in v.split( "," ) ]
 			) for v in values
 		] )

--- a/python/GafferSceneTest/AimConstraintTest.py
+++ b/python/GafferSceneTest/AimConstraintTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -47,8 +48,8 @@ class AimConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 	def test( self ) :
 
-		targetTranslate = IECore.V3f( 1, 2, 3 )
-		constrainedTranslate = IECore.V3f( 10, 11, 12 )
+		targetTranslate = imath.V3f( 1, 2, 3 )
+		constrainedTranslate = imath.V3f( 10, 11, 12 )
 
 		plane1 = GafferScene.Plane()
 		plane1["transform"]["translate"].setValue( targetTranslate )
@@ -82,8 +83,8 @@ class AimConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 	def testConstrainedWithExistingRotation( self ) :
 
-		targetTranslate = IECore.V3f( 1, 2, 3 )
-		constrainedTranslate = IECore.V3f( 10, 11, 12 )
+		targetTranslate = imath.V3f( 1, 2, 3 )
+		constrainedTranslate = imath.V3f( 10, 11, 12 )
 
 		plane1 = GafferScene.Plane()
 		plane1["transform"]["translate"].setValue( targetTranslate )
@@ -91,7 +92,7 @@ class AimConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		plane2 = GafferScene.Plane()
 		plane2["transform"]["translate"].setValue( constrainedTranslate )
-		plane2["transform"]["rotate"].setValue( IECore.V3f( 90, 0, 0 ) )
+		plane2["transform"]["rotate"].setValue( imath.V3f( 90, 0, 0 ) )
 		plane2["name"].setValue( "constrained" )
 
 		group = GafferScene.Group()
@@ -118,8 +119,8 @@ class AimConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 	def testTargetMode( self ) :
 
-		targetTranslate = IECore.V3f( 1, 2, 3 )
-		constrainedTranslate = IECore.V3f( 10, 11, 12 )
+		targetTranslate = imath.V3f( 1, 2, 3 )
+		constrainedTranslate = imath.V3f( 10, 11, 12 )
 
 		plane1 = GafferScene.Plane()
 		plane1["transform"]["translate"].setValue( targetTranslate )
@@ -155,19 +156,19 @@ class AimConstraintTest( GafferSceneTest.SceneTestCase ) :
 		aim["targetMode"].setValue( aim.TargetMode.BoundMin )
 
 		direction = aim["out"].fullTransform( "/group/constrained" ).multDirMatrix( aim["aim"].getValue() )
-		expectedDirection = plane1["out"].bound( "/plane" ).min + targetTranslate - constrainedTranslate
+		expectedDirection = plane1["out"].bound( "/plane" ).min() + targetTranslate - constrainedTranslate
 		self.assertAlmostEqual( direction.normalized().dot( expectedDirection.normalized() ), 1, 6 )
 
 		aim["targetMode"].setValue( aim.TargetMode.BoundMax )
 
 		direction = aim["out"].fullTransform( "/group/constrained" ).multDirMatrix( aim["aim"].getValue() )
-		expectedDirection = plane1["out"].bound( "/plane" ).max + targetTranslate - constrainedTranslate
+		expectedDirection = plane1["out"].bound( "/plane" ).max() + targetTranslate - constrainedTranslate
 		self.assertAlmostEqual( direction.normalized().dot( expectedDirection.normalized() ), 1, 6 )
 
 	def testTargetOffset( self ) :
 
-		targetTranslate = IECore.V3f( 1, 2, 3 )
-		constrainedTranslate = IECore.V3f( 10, 11, 12 )
+		targetTranslate = imath.V3f( 1, 2, 3 )
+		constrainedTranslate = imath.V3f( 10, 11, 12 )
 
 		plane1 = GafferScene.Plane()
 		plane1["transform"]["translate"].setValue( targetTranslate )
@@ -200,7 +201,7 @@ class AimConstraintTest( GafferSceneTest.SceneTestCase ) :
 		expectedDirection = targetTranslate - constrainedTranslate
 		self.assertAlmostEqual( direction.normalized().dot( expectedDirection.normalized() ), 1, 6 )
 
-		aim["targetOffset"].setValue( IECore.V3f( 1, 2, 3 ) )
+		aim["targetOffset"].setValue( imath.V3f( 1, 2, 3 ) )
 
 		direction = aim["out"].fullTransform( "/group/constrained" ).multDirMatrix( aim["aim"].getValue() )
 		expectedDirection = aim["targetOffset"].getValue() + targetTranslate - constrainedTranslate

--- a/python/GafferSceneTest/AlembicSourceTest.py
+++ b/python/GafferSceneTest/AlembicSourceTest.py
@@ -38,6 +38,7 @@
 import os
 import shutil
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -57,26 +58,26 @@ class AlembicSourceTest( GafferSceneTest.SceneTestCase ) :
 		self.assertSceneValid( a["out"] )
 
 		self.assertEqual( a["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( a["out"].transform( "/" ), IECore.M44f() )
-		self.assertEqual( a["out"].bound( "/" ), IECore.Box3f( IECore.V3f( -2 ), IECore.V3f( 2 ) ) )
+		self.assertEqual( a["out"].transform( "/" ), imath.M44f() )
+		self.assertEqual( a["out"].bound( "/" ), imath.Box3f( imath.V3f( -2 ), imath.V3f( 2 ) ) )
 		self.assertEqual( a["out"].attributes( "/" ), IECore.CompoundObject() )
 		self.assertEqual( a["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "group1"] ) )
 
 		self.assertEqual( a["out"].object( "/group1" ), IECore.NullObject() )
-		self.assertEqual( a["out"].transform( "/group1" ), IECore.M44f.createScaled( IECore.V3f( 2 ) ) * IECore.M44f.createTranslated( IECore.V3f( 2, 0, 0 ) ) )
-		self.assertEqual( a["out"].bound( "/group1" ), IECore.Box3f( IECore.V3f( -2, -1, -1 ), IECore.V3f( 0, 1, 1 ) ) )
+		self.assertEqual( a["out"].transform( "/group1" ), imath.M44f().scale( imath.V3f( 2 ) ) * imath.M44f().translate( imath.V3f( 2, 0, 0 ) ) )
+		self.assertEqual( a["out"].bound( "/group1" ), imath.Box3f( imath.V3f( -2, -1, -1 ), imath.V3f( 0, 1, 1 ) ) )
 		self.assertEqual( a["out"].attributes( "/group1" ), IECore.CompoundObject() )
 		self.assertEqual( a["out"].childNames( "/group1" ), IECore.InternedStringVectorData( [ "pCube1"] ) )
 
 		self.assertEqual( a["out"].object( "/group1/pCube1" ), IECore.NullObject() )
-		self.assertEqual( a["out"].transform( "/group1/pCube1" ), IECore.M44f.createTranslated( IECore.V3f( -1, 0, 0 ) ) )
-		self.assertEqual( a["out"].bound( "/group1/pCube1" ), IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ) )
+		self.assertEqual( a["out"].transform( "/group1/pCube1" ), imath.M44f().translate( imath.V3f( -1, 0, 0 ) ) )
+		self.assertEqual( a["out"].bound( "/group1/pCube1" ), imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
 		self.assertEqual( a["out"].attributes( "/group1/pCube1" ), IECore.CompoundObject() )
 		self.assertEqual( a["out"].childNames( "/group1/pCube1" ), IECore.InternedStringVectorData( [ "pCubeShape1"] ) )
 
 		self.assertTrue( isinstance( a["out"].object( "/group1/pCube1/pCubeShape1" ), IECoreScene.MeshPrimitive ) )
-		self.assertEqual( a["out"].transform( "/group1/pCube1/pCubeShape1" ), IECore.M44f() )
-		self.assertEqual( a["out"].bound( "/group1/pCube1/pCubeShape1" ), IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ) )
+		self.assertEqual( a["out"].transform( "/group1/pCube1/pCubeShape1" ), imath.M44f() )
+		self.assertEqual( a["out"].bound( "/group1/pCube1/pCubeShape1" ), imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
 		self.assertEqual( a["out"].attributes( "/group1/pCube1/pCubeShape1" ), IECore.CompoundObject() )
 		self.assertEqual( a["out"].childNames( "/group1/pCube1/pCubeShape1" ), IECore.InternedStringVectorData( [] ) )
 
@@ -108,9 +109,9 @@ class AlembicSourceTest( GafferSceneTest.SceneTestCase ) :
 		a = GafferScene.AlembicSource()
 		a["fileName"].setValue( os.path.dirname( __file__ ) + "/alembicFiles/cube.abc" )
 
-		self.assertEqual( a["out"].fullTransform( "/" ), IECore.M44f() )
-		self.assertEqual( a["out"].fullTransform( "/group1" ), IECore.M44f.createScaled( IECore.V3f( 2 ) ) * IECore.M44f.createTranslated( IECore.V3f( 2, 0, 0 ) ) )
-		self.assertEqual( a["out"].fullTransform( "/group1/pCube1" ), IECore.M44f.createTranslated( IECore.V3f( -1, 0, 0 ) )  * a["out"].fullTransform( "/group1" ) )
+		self.assertEqual( a["out"].fullTransform( "/" ), imath.M44f() )
+		self.assertEqual( a["out"].fullTransform( "/group1" ), imath.M44f().scale( imath.V3f( 2 ) ) * imath.M44f().translate( imath.V3f( 2, 0, 0 ) ) )
+		self.assertEqual( a["out"].fullTransform( "/group1/pCube1" ), imath.M44f().translate( imath.V3f( -1, 0, 0 ) )  * a["out"].fullTransform( "/group1" ) )
 		self.assertEqual( a["out"].fullTransform( "/group1/pCube1/pCubeShape1" ), a["out"].fullTransform( "/group1/pCube1" ) )
 
 	def testRefresh( self ) :

--- a/python/GafferSceneTest/AttributeVisualiserTest.py
+++ b/python/GafferSceneTest/AttributeVisualiserTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -89,11 +91,11 @@ class AttributeVisualiserTest( GafferSceneTest.SceneTestCase ) :
 		self.assertTrue( "gl:surface" in visualiser["out"].attributes( "/group/sphere2" ) )
 		self.assertEqual(
 			visualiser["out"].attributes( "/group/sphere1" )["gl:surface"].parameters["Cs"].value,
-			IECore.Color3f( 1 ),
+			imath.Color3f( 1 ),
 		)
 		self.assertEqual(
 			visualiser["out"].attributes( "/group/sphere2" )["gl:surface"].parameters["Cs"].value,
-			IECore.Color3f( .5 ),
+			imath.Color3f( .5 ),
 		)
 
 	def testShaderNodeColorMode( self ) :
@@ -119,7 +121,7 @@ class AttributeVisualiserTest( GafferSceneTest.SceneTestCase ) :
 		shader2 = GafferSceneTest.TestShader()
 		shader2["name"].setValue( "test" )
 		shader2["type"].setValue( "gfr:surface" )
-		Gaffer.Metadata.registerValue( shader2, "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
+		Gaffer.Metadata.registerValue( shader2, "nodeGadget:color", imath.Color3f( 1, 0, 0 ) )
 
 		filter2 = GafferScene.PathFilter()
 		filter2["paths"].setValue( IECore.StringVectorData( [ "/group/sphere2" ] ) )
@@ -150,11 +152,11 @@ class AttributeVisualiserTest( GafferSceneTest.SceneTestCase ) :
 		self.assertTrue( "gl:surface" in visualiser["out"].attributes( "/group/sphere2" ) )
 		self.assertEqual(
 			visualiser["out"].attributes( "/group/sphere1" )["gl:surface"].parameters["Cs"].value,
-			IECore.Color3f( 0 ),
+			imath.Color3f( 0 ),
 		)
 		self.assertEqual(
 			visualiser["out"].attributes( "/group/sphere2" )["gl:surface"].parameters["Cs"].value,
-			IECore.Color3f( 1, 0, 0 ),
+			imath.Color3f( 1, 0, 0 ),
 		)
 
 if __name__ == "__main__":

--- a/python/GafferSceneTest/CameraTest.py
+++ b/python/GafferSceneTest/CameraTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -60,10 +61,10 @@ class CameraTest( GafferSceneTest.SceneTestCase ) :
 		p["fieldOfView"].setValue( 45 )
 
 		self.assertEqual( p["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( p["out"].transform( "/" ), IECore.M44f() )
+		self.assertEqual( p["out"].transform( "/" ), imath.M44f() )
 		self.assertEqual( p["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "camera" ] ) )
 
-		self.assertEqual( p["out"].transform( "/camera" ), IECore.M44f() )
+		self.assertEqual( p["out"].transform( "/camera" ), imath.M44f() )
 		self.assertEqual( p["out"].childNames( "/camera" ), IECore.InternedStringVectorData() )
 
 		o = p["out"].object( "/camera" )
@@ -107,11 +108,11 @@ class CameraTest( GafferSceneTest.SceneTestCase ) :
 
 		p = GafferScene.Camera()
 		o = p["out"].object( "/camera" )
-		self.assertEqual( o.parameters()["clippingPlanes"].value, IECore.V2f( 0.01, 100000 ) )
+		self.assertEqual( o.parameters()["clippingPlanes"].value, imath.V2f( 0.01, 100000 ) )
 
-		p["clippingPlanes"].setValue( IECore.V2f( 1, 10 ) )
+		p["clippingPlanes"].setValue( imath.V2f( 1, 10 ) )
 		o = p["out"].object( "/camera" )
-		self.assertEqual( o.parameters()["clippingPlanes"].value, IECore.V2f( 1, 10 ) )
+		self.assertEqual( o.parameters()["clippingPlanes"].value, imath.V2f( 1, 10 ) )
 
 	def testEnableBehaviour( self ) :
 

--- a/python/GafferSceneTest/ClippingPlaneTest.py
+++ b/python/GafferSceneTest/ClippingPlaneTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -49,7 +50,7 @@ class ClippingPlaneTest( GafferSceneTest.SceneTestCase ) :
 		c = GafferScene.ClippingPlane()
 		self.assertSceneValid( c["out"] )
 
-		self.assertEqual( c["out"].bound( "/clippingPlane" ), IECore.Box3f( IECore.V3f( -0.5, -0.5, 0 ), IECore.V3f( 0.5 ) ) )
+		self.assertEqual( c["out"].bound( "/clippingPlane" ), imath.Box3f( imath.V3f( -0.5, -0.5, 0 ), imath.V3f( 0.5 ) ) )
 
 		s = c["out"].set( "__clippingPlanes" )
 		self.assertEqual( s.value.paths(), [ "/clippingPlane" ] )

--- a/python/GafferSceneTest/CoordinateSystemTest.py
+++ b/python/GafferSceneTest/CoordinateSystemTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -51,7 +52,7 @@ class CoordinateSystemTest( GafferSceneTest.SceneTestCase ) :
 		c = GafferScene.CoordinateSystem()
 		self.assertSceneValid( c["out"] )
 
-		self.assertEqual( c["out"].bound( "/coordinateSystem" ), IECore.Box3f( IECore.V3f( 0 ), IECore.V3f( 1 ) ) )
+		self.assertEqual( c["out"].bound( "/coordinateSystem" ), imath.Box3f( imath.V3f( 0 ), imath.V3f( 1 ) ) )
 
 		o = c["out"].object( "/coordinateSystem" )
 		self.assertTrue( isinstance( o, IECoreScene.CoordinateSystem ) )

--- a/python/GafferSceneTest/CubeTest.py
+++ b/python/GafferSceneTest/CubeTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -56,24 +57,24 @@ class CubeTest( GafferSceneTest.SceneTestCase ) :
 		c = GafferScene.Cube()
 
 		self.assertEqual( c["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( c["out"].transform( "/" ), IECore.M44f() )
-		self.assertEqual( c["out"].bound( "/" ), IECore.Box3f( IECore.V3f( -0.5, -0.5, -0.5 ), IECore.V3f( 0.5, 0.5, 0.5 ) ) )
+		self.assertEqual( c["out"].transform( "/" ), imath.M44f() )
+		self.assertEqual( c["out"].bound( "/" ), imath.Box3f( imath.V3f( -0.5, -0.5, -0.5 ), imath.V3f( 0.5, 0.5, 0.5 ) ) )
 		self.assertEqual( c["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "cube" ] ) )
 
-		self.assertEqual( c["out"].object( "/cube" ), IECoreScene.MeshPrimitive.createBox( IECore.Box3f( IECore.V3f( -0.5 ), IECore.V3f( 0.5 ) ) ) )
-		self.assertEqual( c["out"].transform( "/cube" ), IECore.M44f() )
-		self.assertEqual( c["out"].bound( "/cube" ), IECore.Box3f( IECore.V3f( -0.5, -0.5, -0.5 ), IECore.V3f( 0.5, 0.5, 0.5 ) ) )
+		self.assertEqual( c["out"].object( "/cube" ), IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -0.5 ), imath.V3f( 0.5 ) ) ) )
+		self.assertEqual( c["out"].transform( "/cube" ), imath.M44f() )
+		self.assertEqual( c["out"].bound( "/cube" ), imath.Box3f( imath.V3f( -0.5, -0.5, -0.5 ), imath.V3f( 0.5, 0.5, 0.5 ) ) )
 		self.assertEqual( c["out"].childNames( "/cube" ), IECore.InternedStringVectorData() )
 
 	def testPlugs( self ) :
 
 		c = GafferScene.Cube()
-		m = IECoreScene.MeshPrimitive.createBox( IECore.Box3f( IECore.V3f( -0.5 ), IECore.V3f( 0.5 ) ) )
+		m = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -0.5 ), imath.V3f( 0.5 ) ) )
 		self.assertEqual( c["out"].object( "/cube" ), m )
 		h = c["out"].objectHash( "/cube" )
 
-		c["dimensions"].setValue( IECore.V3f( 2.5, 5, 6 ) )
-		m = IECoreScene.MeshPrimitive.createBox( IECore.Box3f( IECore.V3f( -1.25, -2.5, -3 ), IECore.V3f( 1.25, 2.5, 3 ) ) )
+		c["dimensions"].setValue( imath.V3f( 2.5, 5, 6 ) )
+		m = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -1.25, -2.5, -3 ), imath.V3f( 1.25, 2.5, 3 ) ) )
 		self.assertEqual( c["out"].object( "/cube" ), m )
 		self.assertNotEqual( c["out"].objectHash( "/cube" ), h )
 
@@ -102,13 +103,13 @@ class CubeTest( GafferSceneTest.SceneTestCase ) :
 	def testTransform( self ) :
 
 		c = GafferScene.Cube()
-		c["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+		c["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 
-		self.assertEqual( c["out"].transform( "/" ), IECore.M44f() )
-		self.assertEqual( c["out"].transform( "/cube" ), IECore.M44f.createTranslated( IECore.V3f( 1, 0, 0 ) ) )
+		self.assertEqual( c["out"].transform( "/" ), imath.M44f() )
+		self.assertEqual( c["out"].transform( "/cube" ), imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) )
 
-		self.assertEqual( c["out"].bound( "/" ), IECore.Box3f( IECore.V3f( 0.5, -0.5, -0.5 ), IECore.V3f( 1.5, 0.5, 0.5 ) ) )
-		self.assertEqual( c["out"].bound( "/cube" ), IECore.Box3f( IECore.V3f( -0.5, -0.5, -0.5 ), IECore.V3f( 0.5, 0.5, 0.5 ) ) )
+		self.assertEqual( c["out"].bound( "/" ), imath.Box3f( imath.V3f( 0.5, -0.5, -0.5 ), imath.V3f( 1.5, 0.5, 0.5 ) ) )
+		self.assertEqual( c["out"].bound( "/cube" ), imath.Box3f( imath.V3f( -0.5, -0.5, -0.5 ), imath.V3f( 0.5, 0.5, 0.5 ) ) )
 
 	def testEnabled( self ) :
 

--- a/python/GafferSceneTest/CustomOptionsTest.py
+++ b/python/GafferSceneTest/CustomOptionsTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -56,13 +57,13 @@ class CustomOptionsTest( GafferSceneTest.SceneTestCase ) :
 		# check that the scene hierarchy is passed through
 
 		self.assertEqual( options["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( options["out"].transform( "/" ), IECore.M44f() )
-		self.assertEqual( options["out"].bound( "/" ), IECore.Box3f( IECore.V3f( -0.5, -0.5, 0 ), IECore.V3f( 0.5, 0.5, 0 ) ) )
+		self.assertEqual( options["out"].transform( "/" ), imath.M44f() )
+		self.assertEqual( options["out"].bound( "/" ), imath.Box3f( imath.V3f( -0.5, -0.5, 0 ), imath.V3f( 0.5, 0.5, 0 ) ) )
 		self.assertEqual( options["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "plane" ] ) )
 
-		self.assertEqual( options["out"].object( "/plane" ), IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -0.5 ), IECore.V2f( 0.5 ) ) ) )
-		self.assertEqual( options["out"].transform( "/plane" ), IECore.M44f() )
-		self.assertEqual( options["out"].bound( "/plane" ), IECore.Box3f( IECore.V3f( -0.5, -0.5, 0 ), IECore.V3f( 0.5, 0.5, 0 ) ) )
+		self.assertEqual( options["out"].object( "/plane" ), IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -0.5 ), imath.V2f( 0.5 ) ) ) )
+		self.assertEqual( options["out"].transform( "/plane" ), imath.M44f() )
+		self.assertEqual( options["out"].bound( "/plane" ), imath.Box3f( imath.V3f( -0.5, -0.5, 0 ), imath.V3f( 0.5, 0.5, 0 ) ) )
 		self.assertEqual( options["out"].childNames( "/plane" ), IECore.InternedStringVectorData() )
 
 		# check that we can make options

--- a/python/GafferSceneTest/DeleteCurvesTest.py
+++ b/python/GafferSceneTest/DeleteCurvesTest.py
@@ -34,11 +34,12 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 import IECoreScene
 import GafferScene
 import GafferSceneTest
-
 
 class DeleteCurvesTest( GafferSceneTest.SceneTestCase ) :
 
@@ -51,21 +52,21 @@ class DeleteCurvesTest( GafferSceneTest.SceneTestCase ) :
 			False,
 			IECore.V3fVectorData(
 				[
-					IECore.V3f( 0, 0, 0 ),
-					IECore.V3f( 0, 1, 0 ),
-					IECore.V3f( 1, 1, 0 ),
-					IECore.V3f( 1, 0, 0 ),
-					IECore.V3f( 1, -1, 0 ),
-					IECore.V3f( 2, -1, 0 ),
-					IECore.V3f( 2, 0, 0 ),
+					imath.V3f( 0, 0, 0 ),
+					imath.V3f( 0, 1, 0 ),
+					imath.V3f( 1, 1, 0 ),
+					imath.V3f( 1, 0, 0 ),
+					imath.V3f( 1, -1, 0 ),
+					imath.V3f( 2, -1, 0 ),
+					imath.V3f( 2, 0, 0 ),
 
-					IECore.V3f( 0, 0, 0 ),
-					IECore.V3f( 0, 0, 1 ),
-					IECore.V3f( 1, 0, 1 ),
-					IECore.V3f( 1, 0, 0 ),
-					IECore.V3f( 1, 0, -1 ),
-					IECore.V3f( 2, 0, -1 ),
-					IECore.V3f( 2, 0, 0 )
+					imath.V3f( 0, 0, 0 ),
+					imath.V3f( 0, 0, 1 ),
+					imath.V3f( 1, 0, 1 ),
+					imath.V3f( 1, 0, 0 ),
+					imath.V3f( 1, 0, -1 ),
+					imath.V3f( 2, 0, -1 ),
+					imath.V3f( 2, 0, 0 )
 				]
 			)
 		)
@@ -103,13 +104,13 @@ class DeleteCurvesTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( curveDeletedObject.numCurves(), 1 )
 		self.assertEqual( curveDeletedObject["P"].data, IECore.V3fVectorData(
 			[
-				IECore.V3f( 0, 0, 0 ),
-				IECore.V3f( 0, 1, 0 ),
-				IECore.V3f( 1, 1, 0 ),
-				IECore.V3f( 1, 0, 0 ),
-				IECore.V3f( 1, -1, 0 ),
-				IECore.V3f( 2, -1, 0 ),
-				IECore.V3f( 2, 0, 0 )
+				imath.V3f( 0, 0, 0 ),
+				imath.V3f( 0, 1, 0 ),
+				imath.V3f( 1, 1, 0 ),
+				imath.V3f( 1, 0, 0 ),
+				imath.V3f( 1, -1, 0 ),
+				imath.V3f( 2, -1, 0 ),
+				imath.V3f( 2, 0, 0 )
 			] ) )
 
 		# verify the primvars are correct
@@ -134,7 +135,7 @@ class DeleteCurvesTest( GafferSceneTest.SceneTestCase ) :
 
 		actualOriginalBound = curvesScene["out"].bound( "/object" )
 
-		self.assertEqual(actualOriginalBound, IECore.Box3f( IECore.V3f( 0, -1, -1 ), IECore.V3f( 2, 1, 1 ) ) )
+		self.assertEqual(actualOriginalBound, imath.Box3f( imath.V3f( 0, -1, -1 ), imath.V3f( 2, 1, 1 ) ) )
 
 		deleteCurves = GafferScene.DeleteCurves()
 		deleteCurves["in"].setInput( curvesScene["out"] )
@@ -144,6 +145,6 @@ class DeleteCurvesTest( GafferSceneTest.SceneTestCase ) :
 		deleteCurves["filter"].setInput( pathFilter["out"] )
 
 		actualCurveDeletedBounds = deleteCurves["out"].bound( "/object" )
-		expectedBoundingBox = IECore.Box3f( IECore.V3f( 0, -1, 0 ), IECore.V3f( 2, 1, 0 ) )
+		expectedBoundingBox = imath.Box3f( imath.V3f( 0, -1, 0 ), imath.V3f( 2, 1, 0 ) )
 
 		self.assertEqual( actualCurveDeletedBounds, expectedBoundingBox )

--- a/python/GafferSceneTest/DeleteFacesTest.py
+++ b/python/GafferSceneTest/DeleteFacesTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 import IECoreScene
 import GafferScene
@@ -46,7 +48,7 @@ class DeleteFacesTest( GafferSceneTest.SceneTestCase ) :
 
 		verticesPerFace = IECore.IntVectorData( [4, 4] )
 		vertexIds = IECore.IntVectorData( [0, 1, 4, 3, 1, 2, 5, 4] )
-		p = IECore.V3fVectorData( [IECore.V3f( 0, 0, 0 ), IECore.V3f( 1, 0, 0 ), IECore.V3f( 2, 0, 0 ), IECore.V3f( 0, 1, 0 ), IECore.V3f( 1, 1, 0 ), IECore.V3f( 2, 1, 0 )] )
+		p = IECore.V3fVectorData( [imath.V3f( 0, 0, 0 ), imath.V3f( 1, 0, 0 ), imath.V3f( 2, 0, 0 ), imath.V3f( 0, 1, 0 ), imath.V3f( 1, 1, 0 ), imath.V3f( 2, 1, 0 )] )
 		deleteData = IECore.IntVectorData( [0, 1] )
 
 		mesh = IECoreScene.MeshPrimitive( verticesPerFace, vertexIds, "linear", p )
@@ -79,7 +81,7 @@ class DeleteFacesTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( faceDeletedObject.verticesPerFace, IECore.IntVectorData([4]) )
 		self.assertEqual( faceDeletedObject.vertexIds, IECore.IntVectorData([0, 1, 3, 2]) )
 		self.assertEqual( faceDeletedObject.numFaces(), 1 )
-		self.assertEqual( faceDeletedObject["P"].data, IECore.V3fVectorData( [IECore.V3f( 0, 0, 0 ), IECore.V3f( 1, 0, 0 ), IECore.V3f( 0, 1, 0 ), IECore.V3f( 1, 1, 0 )] ) )
+		self.assertEqual( faceDeletedObject["P"].data, IECore.V3fVectorData( [imath.V3f( 0, 0, 0 ), imath.V3f( 1, 0, 0 ), imath.V3f( 0, 1, 0 ), imath.V3f( 1, 1, 0 )] ) )
 
 		# verify the primvars are correct
 		self.assertEqual( faceDeletedObject["uniform"].data,  IECore.IntVectorData([10]) )
@@ -91,7 +93,7 @@ class DeleteFacesTest( GafferSceneTest.SceneTestCase ) :
 		rectangleScene = self.makeRectangleFromTwoSquaresScene()
 
 		expectedOriginalBound = rectangleScene["out"].bound( "/object" )
-		self.assertEqual(expectedOriginalBound, IECore.Box3f( IECore.V3f( 0, 0, 0 ), IECore.V3f( 2, 1, 0 ) ) )
+		self.assertEqual(expectedOriginalBound, imath.Box3f( imath.V3f( 0, 0, 0 ), imath.V3f( 2, 1, 0 ) ) )
 
 		deleteFaces = GafferScene.DeleteFaces()
 		deleteFaces["in"].setInput( rectangleScene["out"] )
@@ -101,6 +103,6 @@ class DeleteFacesTest( GafferSceneTest.SceneTestCase ) :
 		deleteFaces["filter"].setInput( pathFilter["out"] )
 
 		actualFaceDeletedBounds = deleteFaces["out"].bound( "/object" )
-		expectedBoundingBox = IECore.Box3f( IECore.V3f( 0, 0, 0 ), IECore.V3f( 1, 1, 0 ) )
+		expectedBoundingBox = imath.Box3f( imath.V3f( 0, 0, 0 ), imath.V3f( 1, 1, 0 ) )
 
 		self.assertEqual( actualFaceDeletedBounds, expectedBoundingBox )

--- a/python/GafferSceneTest/DeletePointsTest.py
+++ b/python/GafferSceneTest/DeletePointsTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 import IECoreScene
 import GafferScene
@@ -46,10 +48,10 @@ class DeletePointsTest( GafferSceneTest.SceneTestCase ) :
 		testObject = IECoreScene.PointsPrimitive(
 			IECore.V3fVectorData(
 				[
-					IECore.V3f( 0, 0, 0 ),
-					IECore.V3f( 0, 1, 0 ),
-					IECore.V3f( 1, 1, 0 ),
-					IECore.V3f( 1, 0, 0 )
+					imath.V3f( 0, 0, 0 ),
+					imath.V3f( 0, 1, 0 ),
+					imath.V3f( 1, 1, 0 ),
+					imath.V3f( 1, 0, 0 )
 
 				]
 			),
@@ -83,9 +85,9 @@ class DeletePointsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( pointsDeletedObject.numPoints, 2 )
 		self.assertEqual( pointsDeletedObject["P"].data, IECore.V3fVectorData(
 			[
-				IECore.V3f( 0, 0, 0 ),
+				imath.V3f( 0, 0, 0 ),
 				#IECore.V3f( 0, 1, 0 ),
-				IECore.V3f( 1, 1, 0 )
+				imath.V3f( 1, 1, 0 )
 				#IECore.V3f( 1, 0, 0 )
 			] ) )
 
@@ -106,7 +108,7 @@ class DeletePointsTest( GafferSceneTest.SceneTestCase ) :
 
 		actualOriginalBound = pointsScene["out"].bound( "/object" )
 
-		self.assertEqual(actualOriginalBound, IECore.Box3f( IECore.V3f( -0.5, -0.5, -0.5 ), IECore.V3f( 1.5, 1.5, 0.5 ) ) )
+		self.assertEqual(actualOriginalBound, imath.Box3f( imath.V3f( -0.5, -0.5, -0.5 ), imath.V3f( 1.5, 1.5, 0.5 ) ) )
 
 		deletePoints = GafferScene.DeletePoints()
 		deletePoints["in"].setInput( pointsScene["out"] )
@@ -117,7 +119,7 @@ class DeletePointsTest( GafferSceneTest.SceneTestCase ) :
 		deletePoints["points"].setValue("deletePoints2")
 
 		actualPointsDeletedBounds = deletePoints["out"].bound( "/object" )
-		expectedBoundingBox = IECore.Box3f( IECore.V3f( 0.5, -0.5, -0.5 ), IECore.V3f( 1.5, 1.5, 0.5 ) )
+		expectedBoundingBox = imath.Box3f( imath.V3f( 0.5, -0.5, -0.5 ), imath.V3f( 1.5, 1.5, 0.5 ) )
 
 		self.assertEqual( actualPointsDeletedBounds, expectedBoundingBox )
 

--- a/python/GafferSceneTest/DuplicateTest.py
+++ b/python/GafferSceneTest/DuplicateTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -49,14 +51,14 @@ class DuplicateTest( GafferSceneTest.SceneTestCase ) :
 		d = GafferScene.Duplicate()
 		d["in"].setInput( s["out"] )
 		d["target"].setValue( "/sphere" )
-		d["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+		d["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 
 		self.assertSceneValid( d["out"] )
 
 		self.assertEqual( d["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "sphere", "sphere1" ] ) )
 		self.assertPathHashesEqual( s["out"], "/sphere", d["out"], "/sphere" )
 		self.assertPathHashesEqual( d["out"], "/sphere", d["out"], "/sphere1", childPlugNamesToIgnore = ( "transform", ) )
-		self.assertEqual( d["out"].transform( "/sphere1" ), IECore.M44f.createTranslated( IECore.V3f( 1, 0, 0 ) ) )
+		self.assertEqual( d["out"].transform( "/sphere1" ), imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) )
 
 	def testMultipleCopies( self ) :
 
@@ -64,7 +66,7 @@ class DuplicateTest( GafferSceneTest.SceneTestCase ) :
 		d = GafferScene.Duplicate()
 		d["in"].setInput( s["out"] )
 		d["target"].setValue( "/sphere" )
-		d["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+		d["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 		d["copies"].setValue( 10 )
 
 		self.assertSceneValid( d["out"] )
@@ -79,7 +81,7 @@ class DuplicateTest( GafferSceneTest.SceneTestCase ) :
 		for i in range( 1, 11 ) :
 			path = "sphere%d" % i
 			self.assertPathHashesEqual( d["out"], "/sphere", d["out"], path, childPlugNamesToIgnore = ( "transform", ) )
-			self.assertEqual( d["out"].transform( path ), IECore.M44f.createTranslated( IECore.V3f( 1, 0, 0 ) * i ) )
+			self.assertEqual( d["out"].transform( path ), imath.M44f().translate( imath.V3f( 1, 0, 0 ) * i ) )
 
 	def testHierarchy( self ) :
 
@@ -194,7 +196,7 @@ class DuplicateTest( GafferSceneTest.SceneTestCase ) :
 		d = GafferScene.Duplicate()
 		d["in"].setInput( s["out"] )
 		d["target"].setValue( "/sphere" )
-		d["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+		d["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 
 		with Gaffer.PerformanceMonitor() as m :
 			self.assertEqual( s["out"]["setNames"].hash(), d["out"]["setNames"].hash() )

--- a/python/GafferSceneTest/ExternalProceduralTest.py
+++ b/python/GafferSceneTest/ExternalProceduralTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -51,7 +52,7 @@ class ExternalProceduralTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertSceneValid( n["out"] )
 
-		n["bound"].setValue( IECore.Box3f( IECore.V3f( 1, 2, 3 ), IECore.V3f( 4, 5, 6 ) ) )
+		n["bound"].setValue( imath.Box3f( imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) ) )
 		n["fileName"].setValue( "test.so" )
 		n["parameters"].addMember( "testFloat", 1.0 )
 
@@ -59,7 +60,7 @@ class ExternalProceduralTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertTrue( isinstance( p, IECoreScene.ExternalProcedural ) )
 		self.assertEqual( p.getFileName(), "test.so" )
-		self.assertEqual( p.getBound(), IECore.Box3f( IECore.V3f( 1, 2, 3 ), IECore.V3f( 4, 5, 6 ) ) )
+		self.assertEqual( p.getBound(), imath.Box3f( imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) ) )
 		self.assertEqual( p.parameters().keys(), [ "testFloat" ] )
 		self.assertEqual( p.parameters()["testFloat"], IECore.FloatData( 1.0 ) )
 

--- a/python/GafferSceneTest/FreezeTransformTest.py
+++ b/python/GafferSceneTest/FreezeTransformTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -47,27 +48,27 @@ class FreezeTransformTest( GafferSceneTest.SceneTestCase ) :
 	def test( self ) :
 
 		p = GafferScene.Plane()
-		p["transform"]["translate"].setValue( IECore.V3f( 1, 2, 3 ) )
+		p["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
 
 		t = GafferScene.FreezeTransform()
 		t["in"].setInput( p["out"] )
 
 		self.assertSceneValid( t["out"] )
 
-		self.assertEqual( t["out"].transform( "/plane" ), IECore.M44f() )
-		self.assertEqual( t["out"].bound( "/plane" ), IECore.Box3f( IECore.V3f( 0.5, 1.5, 3 ), IECore.V3f( 1.5, 2.5, 3 ) ) )
-		self.assertEqual( t["out"].object( "/plane" ).bound(), IECore.Box3f( IECore.V3f( 0.5, 1.5, 3 ), IECore.V3f( 1.5, 2.5, 3 ) ) )
+		self.assertEqual( t["out"].transform( "/plane" ), imath.M44f() )
+		self.assertEqual( t["out"].bound( "/plane" ), imath.Box3f( imath.V3f( 0.5, 1.5, 3 ), imath.V3f( 1.5, 2.5, 3 ) ) )
+		self.assertEqual( t["out"].object( "/plane" ).bound(), imath.Box3f( imath.V3f( 0.5, 1.5, 3 ), imath.V3f( 1.5, 2.5, 3 ) ) )
 
 	def testFilter( self ) :
 
 		p1 = GafferScene.Plane()
-		p1["transform"]["translate"].setValue( IECore.V3f( 1, 2, 3 ) )
+		p1["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
 
 		p2 = GafferScene.Plane()
-		p2["transform"]["translate"].setValue( IECore.V3f( 1, 2, 3 ) )
+		p2["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
 
 		g = GafferScene.Group()
-		g["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+		g["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 		g["in"][0].setInput( p1["out"] )
 		g["in"][1].setInput( p2["out"] )
 
@@ -80,26 +81,26 @@ class FreezeTransformTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertSceneValid( t["out"] )
 
-		self.assertEqual( t["out"].transform( "/group" ), IECore.M44f.createTranslated( IECore.V3f( 1, 0, 0 ) ) )
-		self.assertEqual( t["out"].transform( "/group/plane" ), IECore.M44f() )
-		self.assertEqual( t["out"].transform( "/group/plane1" ), IECore.M44f.createTranslated( IECore.V3f( 1, 2, 3 ) ) )
+		self.assertEqual( t["out"].transform( "/group" ), imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) )
+		self.assertEqual( t["out"].transform( "/group/plane" ), imath.M44f() )
+		self.assertEqual( t["out"].transform( "/group/plane1" ), imath.M44f().translate( imath.V3f( 1, 2, 3 ) ) )
 
-		self.assertEqual( t["out"].bound( "/group/plane" ), IECore.Box3f( IECore.V3f( 0.5, 1.5, 3 ), IECore.V3f( 1.5, 2.5, 3 ) ) )
-		self.assertEqual( t["out"].bound( "/group/plane1" ), IECore.Box3f( IECore.V3f( -0.5, -0.5, 0 ), IECore.V3f( 0.5, 0.5, 0 ) ) )
+		self.assertEqual( t["out"].bound( "/group/plane" ), imath.Box3f( imath.V3f( 0.5, 1.5, 3 ), imath.V3f( 1.5, 2.5, 3 ) ) )
+		self.assertEqual( t["out"].bound( "/group/plane1" ), imath.Box3f( imath.V3f( -0.5, -0.5, 0 ), imath.V3f( 0.5, 0.5, 0 ) ) )
 
-		self.assertEqual( t["out"].object( "/group/plane" ).bound(), IECore.Box3f( IECore.V3f( 0.5, 1.5, 3 ), IECore.V3f( 1.5, 2.5, 3 ) ) )
-		self.assertEqual( t["out"].object( "/group/plane1" ).bound(), IECore.Box3f( IECore.V3f( -0.5, -0.5, 0 ), IECore.V3f( 0.5, 0.5, 0 ) ) )
+		self.assertEqual( t["out"].object( "/group/plane" ).bound(), imath.Box3f( imath.V3f( 0.5, 1.5, 3 ), imath.V3f( 1.5, 2.5, 3 ) ) )
+		self.assertEqual( t["out"].object( "/group/plane1" ).bound(), imath.Box3f( imath.V3f( -0.5, -0.5, 0 ), imath.V3f( 0.5, 0.5, 0 ) ) )
 
 		f["paths"].setValue( IECore.StringVectorData( [ "/group", "/group/plane" ] ) )
 
 		self.assertSceneValid( t["out"] )
 
-		self.assertEqual( t["out"].transform( "/group" ), IECore.M44f() )
-		self.assertEqual( t["out"].transform( "/group/plane" ), IECore.M44f() )
-		self.assertEqual( t["out"].transform( "/group/plane1" ), IECore.M44f.createTranslated( IECore.V3f( 1, 2, 3 ) ) )
+		self.assertEqual( t["out"].transform( "/group" ), imath.M44f() )
+		self.assertEqual( t["out"].transform( "/group/plane" ), imath.M44f() )
+		self.assertEqual( t["out"].transform( "/group/plane1" ), imath.M44f().translate( imath.V3f( 1, 2, 3 ) ) )
 
-		self.assertEqual( t["out"].bound( "/group/plane" ), IECore.Box3f( IECore.V3f( 1.5, 1.5, 3 ), IECore.V3f( 2.5, 2.5, 3 ) ) )
-		self.assertEqual( t["out"].bound( "/group/plane1" ), IECore.Box3f( IECore.V3f( 0.5, -0.5, 0 ), IECore.V3f( 1.5, 0.5, 0 ) ) )
+		self.assertEqual( t["out"].bound( "/group/plane" ), imath.Box3f( imath.V3f( 1.5, 1.5, 3 ), imath.V3f( 2.5, 2.5, 3 ) ) )
+		self.assertEqual( t["out"].bound( "/group/plane1" ), imath.Box3f( imath.V3f( 0.5, -0.5, 0 ), imath.V3f( 1.5, 0.5, 0 ) ) )
 
 	def testAffects( self ) :
 

--- a/python/GafferSceneTest/GridTest.py
+++ b/python/GafferSceneTest/GridTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -51,7 +52,7 @@ class GridTest( GafferSceneTest.SceneTestCase ) :
 		g = GafferScene.Grid()
 		self.assertSceneValid( g["out"] )
 
-		g["dimensions"].setValue( IECore.V2f( 100, 5 ) )
+		g["dimensions"].setValue( imath.V2f( 100, 5 ) )
 		self.assertSceneValid( g["out"] )
 
 	def testChildNames( self ) :
@@ -71,7 +72,7 @@ class GridTest( GafferSceneTest.SceneTestCase ) :
 		g = GafferScene.Grid()
 
 		a = g["out"].attributes( "/grid" )
-		self.assertEqual( a["gl:surface"], IECoreScene.Shader( "Constant", "gl:surface", { "Cs" : IECore.Color3f( 1 ) } ) )
+		self.assertEqual( a["gl:surface"], IECoreScene.Shader( "Constant", "gl:surface", { "Cs" : imath.Color3f( 1 ) } ) )
 
 		g["centerPixelWidth"].setValue( 2 )
 		a2 = g["out"].attributes( "/grid/centerLines" )

--- a/python/GafferSceneTest/GroupTest.py
+++ b/python/GafferSceneTest/GroupTest.py
@@ -38,6 +38,7 @@
 import unittest
 import gc
 import os
+import imath
 
 import IECore
 import IECoreScene
@@ -77,22 +78,22 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( group["name"].getValue(), "topLevel" )
 
 		self.assertEqual( group["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( group["out"].transform( "/" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/" ), sphere.bound() )
 		self.assertEqual( group["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "topLevel" ] ) )
 
 		self.assertEqual( group["out"].object( "/topLevel" ), IECore.NullObject() )
-		self.assertEqual( group["out"].transform( "/topLevel" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/topLevel" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/topLevel" ), sphere.bound() )
 		self.assertEqual( group["out"].childNames( "/topLevel" ), IECore.InternedStringVectorData( [ "group" ] ) )
 
 		self.assertEqual( group["out"].object( "/topLevel/group" ), IECore.NullObject() )
-		self.assertEqual( group["out"].transform( "/topLevel/group" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/topLevel/group" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/topLevel/group" ), sphere.bound() )
 		self.assertEqual( group["out"].childNames( "/topLevel/group" ), IECore.InternedStringVectorData( [ "sphere" ] ) )
 
 		self.assertEqual( group["out"].object( "/topLevel/group/sphere" ), sphere )
-		self.assertEqual( group["out"].transform( "/topLevel/group/sphere" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/topLevel/group/sphere" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/topLevel/group/sphere" ), sphere.bound() )
 		self.assertEqual( group["out"].childNames( "/topLevel/group/sphere" ), IECore.InternedStringVectorData() )
 
@@ -100,8 +101,8 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 
 		sphere = IECoreScene.SpherePrimitive()
 		originalRootBound = sphere.bound()
-		originalRootBound.min += IECore.V3f( 1, 0, 0 )
-		originalRootBound.max += IECore.V3f( 1, 0, 0 )
+		originalRootBound.setMin( originalRootBound.min() + imath.V3f( 1, 0, 0 ) )
+		originalRootBound.setMax( originalRootBound.max() + imath.V3f( 1, 0, 0 ) )
 		input = GafferSceneTest.CompoundObjectSource()
 		input["in"].setValue(
 			IECore.CompoundObject( {
@@ -110,7 +111,7 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 					"sphere" : {
 						"object" : sphere,
 						"bound" : IECore.Box3fData( sphere.bound() ),
-						"transform" : IECore.M44fData( IECore.M44f.createTranslated( IECore.V3f( 1, 0, 0 ) ) ),
+						"transform" : IECore.M44fData( imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) ),
 					}
 				}
 			} )
@@ -118,26 +119,26 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 
 		group = GafferScene.Group()
 		group["in"][0].setInput( input["out"] )
-		group["transform"]["translate"].setValue( IECore.V3f( 0, 1, 0 ) )
+		group["transform"]["translate"].setValue( imath.V3f( 0, 1, 0 ) )
 
 		self.assertEqual( group["name"].getValue(), "group" )
 
-		groupedRootBound = IECore.Box3f( originalRootBound.min, originalRootBound.max )
-		groupedRootBound.min += IECore.V3f( 0, 1, 0 )
-		groupedRootBound.max += IECore.V3f( 0, 1, 0 )
+		groupedRootBound = imath.Box3f( originalRootBound.min(), originalRootBound.max() )
+		groupedRootBound.setMin( groupedRootBound.min() + imath.V3f( 0, 1, 0 ) )
+		groupedRootBound.setMax( groupedRootBound.max() + imath.V3f( 0, 1, 0 ) )
 
 		self.assertEqual( group["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( group["out"].transform( "/" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/" ), groupedRootBound )
 		self.assertEqual( group["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "group" ] ) )
 
 		self.assertEqual( group["out"].object( "/group" ), IECore.NullObject() )
-		self.assertEqual( group["out"].transform( "/group" ), IECore.M44f.createTranslated( IECore.V3f( 0, 1, 0 ) ) )
+		self.assertEqual( group["out"].transform( "/group" ), imath.M44f().translate( imath.V3f( 0, 1, 0 ) ) )
 		self.assertEqual( group["out"].bound( "/group" ), originalRootBound )
 		self.assertEqual( group["out"].childNames( "/group" ), IECore.InternedStringVectorData( [ "sphere" ] ) )
 
 		self.assertEqual( group["out"].object( "/group/sphere" ), sphere )
-		self.assertEqual( group["out"].transform( "/group/sphere" ), IECore.M44f.createTranslated( IECore.V3f( 1, 0, 0 ) ) )
+		self.assertEqual( group["out"].transform( "/group/sphere" ), imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) )
 		self.assertEqual( group["out"].bound( "/group/sphere" ), sphere.bound() )
 		self.assertEqual( group["out"].childNames( "/group/sphere" ), IECore.InternedStringVectorData() )
 
@@ -190,7 +191,7 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 			} ),
 		)
 
-		plane = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		plane = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 		input2 = GafferSceneTest.CompoundObjectSource()
 		input2["in"].setValue(
 			IECore.CompoundObject( {
@@ -218,32 +219,32 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 		group["in"][1].setInput( input2["out"] )
 
 		self.assertEqual( group["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( group["out"].transform( "/" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/" ), combinedBound )
 		self.assertEqual( group["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "topLevel" ] ) )
 
 		self.assertEqual( group["out"].object( "/topLevel" ), IECore.NullObject() )
-		self.assertEqual( group["out"].transform( "/topLevel" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/topLevel" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/topLevel" ), combinedBound )
 		self.assertEqual( group["out"].childNames( "/topLevel" ), IECore.InternedStringVectorData( [ "sphereGroup", "planeGroup" ] ) )
 
 		self.assertEqual( group["out"].object( "/topLevel/sphereGroup" ), IECore.NullObject() )
-		self.assertEqual( group["out"].transform( "/topLevel/sphereGroup" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/topLevel/sphereGroup" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/topLevel/sphereGroup" ), sphere.bound() )
 		self.assertEqual( group["out"].childNames( "/topLevel/sphereGroup" ), IECore.InternedStringVectorData( [ "sphere" ] ) )
 
 		self.assertEqual( group["out"].object( "/topLevel/sphereGroup/sphere" ), sphere )
-		self.assertEqual( group["out"].transform( "/topLevel/sphereGroup/sphere" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/topLevel/sphereGroup/sphere" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/topLevel/sphereGroup/sphere" ), sphere.bound() )
 		self.assertEqual( group["out"].childNames( "/topLevel/sphereGroup/sphere" ), IECore.InternedStringVectorData() )
 
 		self.assertEqual( group["out"].object( "/topLevel/planeGroup" ), IECore.NullObject() )
-		self.assertEqual( group["out"].transform( "/topLevel/planeGroup" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/topLevel/planeGroup" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/topLevel/planeGroup" ), plane.bound() )
 		self.assertEqual( group["out"].childNames( "/topLevel/planeGroup" ), IECore.InternedStringVectorData( [ "plane" ] ) )
 
 		self.assertEqual( group["out"].object( "/topLevel/planeGroup/plane" ), plane )
-		self.assertEqual( group["out"].transform( "/topLevel/planeGroup/plane" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/topLevel/planeGroup/plane" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/topLevel/planeGroup/plane" ), plane.bound() )
 		self.assertEqual( group["out"].childNames( "/topLevel/planeGroup/plane" ), IECore.InternedStringVectorData() )
 
@@ -263,7 +264,7 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 			} ),
 		)
 
-		plane = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		plane = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 		input2 = GafferSceneTest.CompoundObjectSource()
 		input2["in"].setValue(
 			IECore.CompoundObject( {
@@ -286,22 +287,22 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 		group["in"][1].setInput( input2["out"] )
 
 		self.assertEqual( group["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( group["out"].transform( "/" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/" ), combinedBound )
 		self.assertEqual( group["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "topLevel" ] ) )
 
 		self.assertEqual( group["out"].object( "/topLevel" ), IECore.NullObject() )
-		self.assertEqual( group["out"].transform( "/topLevel" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/topLevel" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/topLevel" ), combinedBound )
 		self.assertEqual( group["out"].childNames( "/topLevel" ), IECore.InternedStringVectorData( [ "myLovelyObject", "myLovelyObject1" ] ) )
 
 		self.assertEqual( group["out"].object( "/topLevel/myLovelyObject" ), sphere )
-		self.assertEqual( group["out"].transform( "/topLevel/myLovelyObject" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/topLevel/myLovelyObject" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/topLevel/myLovelyObject" ), sphere.bound() )
 		self.assertEqual( group["out"].childNames( "/topLevel/myLovelyObject" ), IECore.InternedStringVectorData() )
 
 		self.assertEqual( group["out"].object( "/topLevel/myLovelyObject1" ), plane )
-		self.assertEqual( group["out"].transform( "/topLevel/myLovelyObject1" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/topLevel/myLovelyObject1" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/topLevel/myLovelyObject1" ), plane.bound() )
 		self.assertEqual( group["out"].childNames( "/topLevel/myLovelyObject1" ), IECore.InternedStringVectorData() )
 
@@ -342,7 +343,7 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 			} ),
 		)
 
-		plane = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		plane = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 		input2 = GafferSceneTest.CompoundObjectSource()
 		input2["in"].setValue(
 			IECore.CompoundObject( {
@@ -365,22 +366,22 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 		group["in"][1].setInput( input2["out"] )
 
 		self.assertEqual( group["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( group["out"].transform( "/" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/" ), combinedBound )
 		self.assertEqual( group["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "topLevel" ] ) )
 
 		self.assertEqual( group["out"].object( "/topLevel" ), IECore.NullObject() )
-		self.assertEqual( group["out"].transform( "/topLevel" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/topLevel" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/topLevel" ), combinedBound )
 		self.assertEqual( group["out"].childNames( "/topLevel" ), IECore.InternedStringVectorData( [ "myLovelyObject1", "myLovelyObject2" ] ) )
 
 		self.assertEqual( group["out"].object( "/topLevel/myLovelyObject1" ), sphere )
-		self.assertEqual( group["out"].transform( "/topLevel/myLovelyObject1" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/topLevel/myLovelyObject1" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/topLevel/myLovelyObject1" ), sphere.bound() )
 		self.assertEqual( group["out"].childNames( "/topLevel/myLovelyObject1" ), IECore.InternedStringVectorData() )
 
 		self.assertEqual( group["out"].object( "/topLevel/myLovelyObject2" ), plane )
-		self.assertEqual( group["out"].transform( "/topLevel/myLovelyObject2" ), IECore.M44f() )
+		self.assertEqual( group["out"].transform( "/topLevel/myLovelyObject2" ), imath.M44f() )
 		self.assertEqual( group["out"].bound( "/topLevel/myLovelyObject2" ), plane.bound() )
 		self.assertEqual( group["out"].childNames( "/topLevel/myLovelyObject2" ), IECore.InternedStringVectorData() )
 
@@ -400,7 +401,7 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 			} ),
 		)
 
-		plane = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		plane = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 		input2 = GafferSceneTest.CompoundObjectSource()
 		input2["in"].setValue(
 			IECore.CompoundObject( {
@@ -454,7 +455,7 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 
  		self.assertSceneHashesEqual( g1["out"], g2["out"] )
 
-	 	g2["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+	 	g2["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 
  		self.assertSceneHashesEqual( g1["out"], g2["out"], pathsToIgnore = ( "/", "/group", ) )
  		self.assertSceneHashesEqual( g1["out"], g2["out"], childPlugNamesToIgnore = ( "transform", "bound" ) )

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 import IECoreScene
 
@@ -52,12 +54,12 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		instanceInput = GafferSceneTest.CompoundObjectSource()
 		instanceInput["in"].setValue(
 			IECore.CompoundObject( {
-				"bound" : IECore.Box3fData( IECore.Box3f( IECore.V3f( -2 ), IECore.V3f( 2 ) ) ),
+				"bound" : IECore.Box3fData( imath.Box3f( imath.V3f( -2 ), imath.V3f( 2 ) ) ),
 				"children" : {
 					"sphere" : {
 						"object" : sphere,
 						"bound" : IECore.Box3fData( sphere.bound() ),
-						"transform" : IECore.M44fData( IECore.M44f.createScaled( IECore.V3f( 2 ) ) ),
+						"transform" : IECore.M44fData( imath.M44f().scale( imath.V3f( 2 ) ) ),
 					},
 				}
 			} )
@@ -65,17 +67,17 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		seeds = IECoreScene.PointsPrimitive(
 			IECore.V3fVectorData(
-				[ IECore.V3f( 1, 0, 0 ), IECore.V3f( 1, 1, 0 ), IECore.V3f( 0, 1, 0 ), IECore.V3f( 0, 0, 0 ) ]
+				[ imath.V3f( 1, 0, 0 ), imath.V3f( 1, 1, 0 ), imath.V3f( 0, 1, 0 ), imath.V3f( 0, 0, 0 ) ]
 			)
 		)
 		seedsInput = GafferSceneTest.CompoundObjectSource()
 		seedsInput["in"].setValue(
 			IECore.CompoundObject( {
-				"bound" : IECore.Box3fData( IECore.Box3f( IECore.V3f( 1, 0, 0 ), IECore.V3f( 2, 1, 0 ) ) ),
+				"bound" : IECore.Box3fData( imath.Box3f( imath.V3f( 1, 0, 0 ), imath.V3f( 2, 1, 0 ) ) ),
 				"children" : {
 					"seeds" : {
 						"bound" : IECore.Box3fData( seeds.bound() ),
-						"transform" : IECore.M44fData( IECore.M44f.createTranslated( IECore.V3f( 1, 0, 0 ) ) ),
+						"transform" : IECore.M44fData( imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) ),
 						"object" : seeds,
 					},
 				},
@@ -89,18 +91,18 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		instancer["name"].setValue( "instances" )
 
 		self.assertEqual( instancer["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( instancer["out"].transform( "/" ), IECore.M44f() )
-		self.assertEqual( instancer["out"].bound( "/" ), IECore.Box3f( IECore.V3f( -1, -2, -2 ), IECore.V3f( 4, 3, 2 ) ) )
+		self.assertEqual( instancer["out"].transform( "/" ), imath.M44f() )
+		self.assertEqual( instancer["out"].bound( "/" ), imath.Box3f( imath.V3f( -1, -2, -2 ), imath.V3f( 4, 3, 2 ) ) )
 		self.assertEqual( instancer["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "seeds" ] ) )
 
 		self.assertEqual( instancer["out"].object( "/seeds" ), seeds )
-		self.assertEqual( instancer["out"].transform( "/seeds" ), IECore.M44f().createTranslated( IECore.V3f( 1, 0, 0 ) ) )
-		self.assertEqual( instancer["out"].bound( "/seeds" ), IECore.Box3f( IECore.V3f( -2, -2, -2 ), IECore.V3f( 3, 3, 2 ) ) )
+		self.assertEqual( instancer["out"].transform( "/seeds" ), imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) )
+		self.assertEqual( instancer["out"].bound( "/seeds" ), imath.Box3f( imath.V3f( -2, -2, -2 ), imath.V3f( 3, 3, 2 ) ) )
 		self.assertEqual( instancer["out"].childNames( "/seeds" ), IECore.InternedStringVectorData( [ "instances" ] ) )
 
 		self.assertEqual( instancer["out"].object( "/seeds/instances" ), IECore.NullObject() )
-		self.assertEqual( instancer["out"].transform( "/seeds/instances" ), IECore.M44f() )
-		self.assertEqual( instancer["out"].bound( "/seeds/instances" ), IECore.Box3f( IECore.V3f( -2, -2, -2 ), IECore.V3f( 3, 3, 2 ) ) )
+		self.assertEqual( instancer["out"].transform( "/seeds/instances" ), imath.M44f() )
+		self.assertEqual( instancer["out"].bound( "/seeds/instances" ), imath.Box3f( imath.V3f( -2, -2, -2 ), imath.V3f( 3, 3, 2 ) ) )
 		self.assertEqual( instancer["out"].childNames( "/seeds/instances" ), IECore.InternedStringVectorData( [ "0", "1", "2", "3" ] ) )
 
 		for i in range( 0, 4 ) :
@@ -108,12 +110,12 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 			instancePath = "/seeds/instances/%d" % i
 
 			self.assertEqual( instancer["out"].object( instancePath ), IECore.NullObject() )
-			self.assertEqual( instancer["out"].transform( instancePath ), IECore.M44f.createTranslated( seeds["P"].data[i] ) )
-			self.assertEqual( instancer["out"].bound( instancePath ), IECore.Box3f( IECore.V3f( -2 ), IECore.V3f( 2 ) ) )
+			self.assertEqual( instancer["out"].transform( instancePath ), imath.M44f().translate( seeds["P"].data[i] ) )
+			self.assertEqual( instancer["out"].bound( instancePath ), imath.Box3f( imath.V3f( -2 ), imath.V3f( 2 ) ) )
 			self.assertEqual( instancer["out"].childNames( instancePath ), IECore.InternedStringVectorData( [ "sphere" ] ) )
 
 			self.assertEqual( instancer["out"].object( instancePath + "/sphere" ), sphere )
-			self.assertEqual( instancer["out"].transform( instancePath + "/sphere" ), IECore.M44f.createScaled( IECore.V3f( 2 ) ) )
+			self.assertEqual( instancer["out"].transform( instancePath + "/sphere" ), imath.M44f().scale( imath.V3f( 2 ) ) )
 			self.assertEqual( instancer["out"].bound( instancePath + "/sphere" ), sphere.bound() )
 			self.assertEqual( instancer["out"].childNames( instancePath + "/sphere" ), IECore.InternedStringVectorData() )
 
@@ -123,12 +125,12 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		instanceInput = GafferSceneTest.CompoundObjectSource()
 		instanceInput["in"].setValue(
 			IECore.CompoundObject( {
-				"bound" : IECore.Box3fData( IECore.Box3f( IECore.V3f( -2 ), IECore.V3f( 2 ) ) ),
+				"bound" : IECore.Box3fData( imath.Box3f( imath.V3f( -2 ), imath.V3f( 2 ) ) ),
 				"children" : {
 					"sphere" : {
 						"object" : sphere,
 						"bound" : IECore.Box3fData( sphere.bound() ),
-						"transform" : IECore.M44fData( IECore.M44f.createScaled( IECore.V3f( 2 ) ) ),
+						"transform" : IECore.M44fData( imath.M44f().scale( imath.V3f( 2 ) ) ),
 					},
 				}
 			} )
@@ -136,17 +138,17 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		seeds = IECoreScene.PointsPrimitive(
 			IECore.V3fVectorData(
-				[ IECore.V3f( 1, 0, 0 ), IECore.V3f( 1, 1, 0 ), IECore.V3f( 0, 1, 0 ), IECore.V3f( 0, 0, 0 ) ]
+				[ imath.V3f( 1, 0, 0 ), imath.V3f( 1, 1, 0 ), imath.V3f( 0, 1, 0 ), imath.V3f( 0, 0, 0 ) ]
 			)
 		)
 		seedsInput = GafferSceneTest.CompoundObjectSource()
 		seedsInput["in"].setValue(
 			IECore.CompoundObject( {
-				"bound" : IECore.Box3fData( IECore.Box3f( IECore.V3f( 1, 0, 0 ), IECore.V3f( 2, 1, 0 ) ) ),
+				"bound" : IECore.Box3fData( imath.Box3f( imath.V3f( 1, 0, 0 ), imath.V3f( 2, 1, 0 ) ) ),
 				"children" : {
 					"seeds" : {
 						"bound" : IECore.Box3fData( seeds.bound() ),
-						"transform" : IECore.M44fData( IECore.M44f.createTranslated( IECore.V3f( 1, 0, 0 ) ) ),
+						"transform" : IECore.M44fData( imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) ),
 						"object" : seeds,
 					},
 				},
@@ -273,7 +275,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["plane"] = GafferScene.Plane()
-		script["plane"]["divisions"].setValue( IECore.V2i( 20 ) )
+		script["plane"]["divisions"].setValue( imath.V2i( 20 ) )
 
 		script["sphere"] = GafferScene.Sphere()
 
@@ -361,7 +363,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["plane"] = GafferScene.Plane()
-		script["plane"]["divisions"].setValue( IECore.V2i( 20 ) )
+		script["plane"]["divisions"].setValue( imath.V2i( 20 ) )
 
 		script["sphere"] = GafferScene.Sphere()
 
@@ -429,7 +431,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["plane"] = GafferScene.Plane()
-		script["plane"]["divisions"].setValue( IECore.V2i( 20 ) )
+		script["plane"]["divisions"].setValue( imath.V2i( 20 ) )
 
 		script["sphere"] = GafferScene.Sphere()
 
@@ -464,7 +466,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["plane"] = GafferScene.Plane()
-		script["plane"]["divisions"].setValue( IECore.V2i( 20 ) )
+		script["plane"]["divisions"].setValue( imath.V2i( 20 ) )
 
 		script["sphere"] = GafferScene.Sphere()
 
@@ -487,21 +489,21 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 			context.set( "a", 1 )
 			context.set( "a", 2.0 )
 			context.set( "a", "a" )
-			context.set( "a", IECore.V2i() )
-			context.set( "a", IECore.V3i() )
-			context.set( "a", IECore.V2f() )
-			context.set( "a", IECore.V3f() )
-			context.set( "a", IECore.Color3f() )
+			context.set( "a", imath.V2i() )
+			context.set( "a", imath.V3i() )
+			context.set( "a", imath.V2f() )
+			context.set( "a", imath.V3f() )
+			context.set( "a", imath.Color3f() )
 			context.set( "a", IECore.BoolData( True ) )
 
 			context["b"] = 1
 			context["b"] = 2.0
 			context["b"] = "b"
-			context["b"] = IECore.V2i()
-			context["b"] = IECore.V3i()
-			context["b"] = IECore.V2f()
-			context["b"] = IECore.V3f()
-			context["b"] = IECore.Color3f()
+			context["b"] = imath.V2i()
+			context["b"] = imath.V3i()
+			context["b"] = imath.V2f()
+			context["b"] = imath.V3f()
+			context["b"] = imath.Color3f()
 			context["b"] = IECore.BoolData( True )
 
 			with Gaffer.BlockedConnection( traverseConnection ) :
@@ -522,7 +524,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["plane"] = GafferScene.Plane()
-		script["plane"]["divisions"].setValue( IECore.V2i( 20 ) )
+		script["plane"]["divisions"].setValue( imath.V2i( 20 ) )
 
 		script["sphere"] = GafferScene.Sphere()
 

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -37,6 +37,7 @@
 import time
 import inspect
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -205,19 +206,19 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		s["s"]["enabled"].setValue( False )
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		s["s"]["enabled"].setValue( True )
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testAddAndRemoveObject( self ) :
 
@@ -261,7 +262,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Switch to the empty group.
 
@@ -269,7 +270,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Switch back to the sphere.
 
@@ -277,7 +278,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testEditObjectVisibility( self ) :
 
@@ -319,7 +320,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Visible to start with
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Hide /group/sphere
 
@@ -328,7 +329,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Tweak the sphere geometry - it should remain hidden
 
@@ -336,7 +337,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Show it again
 
@@ -344,7 +345,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Hide /group
 
@@ -353,7 +354,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Show it again
 
@@ -361,7 +362,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testEditCameraVisibility( self ) :
 
@@ -403,7 +404,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Visible to start with
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Hide /group/sphere
 
@@ -412,7 +413,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Show it again
 
@@ -420,7 +421,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Hide /group
 
@@ -429,7 +430,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Show it again
 
@@ -437,7 +438,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testEditObjectTransform( self ) :
 
@@ -469,7 +470,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Visible to start with
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Move to one side
 
@@ -477,7 +478,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Move back
 
@@ -485,7 +486,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testShaderEdits( self ) :
 
@@ -493,7 +494,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["s"] = GafferScene.Sphere()
 
 		s["shader"], colorPlug = self._createConstantShader()
-		colorPlug.setValue( IECore.Color3f( 1, 0, 0 ) )
+		colorPlug.setValue( imath.Color3f( 1, 0, 0 ) )
 
 		s["a"] = GafferScene.ShaderAssignment()
 		s["a"]["in"].setInput( s["s"]["out"] )
@@ -524,23 +525,23 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Render red sphere
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.__assertColorsAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ), IECore.Color4f( 1, 0, 0, 1 ), delta = 0.01 )
+		self.__assertColorsAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ), imath.Color4f( 1, 0, 0, 1 ), delta = 0.01 )
 
 		# Make it green
 
-		colorPlug.setValue( IECore.Color3f( 0, 1, 0 ) )
+		colorPlug.setValue( imath.Color3f( 0, 1, 0 ) )
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.__assertColorsAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ), IECore.Color4f( 0, 1, 0, 1 ), delta = 0.01 )
+		self.__assertColorsAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ), imath.Color4f( 0, 1, 0, 1 ), delta = 0.01 )
 
 		# Make it blue
 
-		colorPlug.setValue( IECore.Color3f( 0, 0, 1 ) )
+		colorPlug.setValue( imath.Color3f( 0, 0, 1 ) )
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.__assertColorsAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ), IECore.Color4f( 0, 0, 1, 1 ), delta = 0.01 )
+		self.__assertColorsAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ), imath.Color4f( 0, 0, 1, 1 ), delta = 0.01 )
 
 	def testEditCameraTransform( self ) :
 
@@ -583,7 +584,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Visible to start with
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Move to one side
 
@@ -591,7 +592,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Move back
 
@@ -599,7 +600,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testEditResolution( self ) :
 
@@ -648,30 +649,30 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 			self.assertEqual(
 				IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" ).displayWindow,
-				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 639, 479 ) )
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( 639, 479 ) )
 			)
 
 			# Now specify a resolution
 
 			s["options"]["options"]["renderResolution"]["enabled"].setValue( True )
-			s["options"]["options"]["renderResolution"]["value"].setValue( IECore.V2i( 200, 100 ) )
+			s["options"]["options"]["renderResolution"]["value"].setValue( imath.V2i( 200, 100 ) )
 
 			time.sleep( 0.5 )
 
 			self.assertEqual(
 				IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" ).displayWindow,
-				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 199, 99 ) )
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( 199, 99 ) )
 			)
 
 			# And specify another resolution
 
-			s["options"]["options"]["renderResolution"]["value"].setValue( IECore.V2i( 300, 100 ) )
+			s["options"]["options"]["renderResolution"]["value"].setValue( imath.V2i( 300, 100 ) )
 
 			time.sleep( 0.5 )
 
 			self.assertEqual(
 				IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" ).displayWindow,
-				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 299, 99 ) )
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( 299, 99 ) )
 			)
 
 			# And back to the default
@@ -682,7 +683,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 			self.assertEqual(
 				IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" ).displayWindow,
-				IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 639, 479 ) )
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( 639, 479 ) )
 			)
 
 	def testDeleteWhilePaused( self ) :
@@ -818,7 +819,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Visible to start with
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Move to one side
 
@@ -826,7 +827,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Move back
 
@@ -834,7 +835,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Repeat, using a context we set directly ourselves.
 
@@ -844,20 +845,20 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		c.setFrame( 1 )
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testLights( self ) :
 
 		s = Gaffer.ScriptNode()
 
 		s["l"], colorPlug = self._createPointLight()
-		colorPlug.setValue( IECore.Color3f( 1, 0.5, 0.25 ) )
+		colorPlug.setValue( imath.Color3f( 1, 0.5, 0.25 ) )
 		s["l"]["transform"]["translate"]["z"].setValue( 1 )
 
 		s["p"] = GafferScene.Plane()
@@ -907,34 +908,34 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		c = self.__color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
-			IECore.V2f( 0.5 ),
+			imath.V2f( 0.5 ),
 		)
-		self.assertEqual( c / c[0], IECore.Color3f( 1, 0.5, 0.25 ) )
+		self.assertEqual( c / c[0], imath.Color3f( 1, 0.5, 0.25 ) )
 
 		# Adjust a parameter, give it time to update, and check the output.
 
-		colorPlug.setValue( IECore.Color3f( 0.25, 0.5, 1 ) )
+		colorPlug.setValue( imath.Color3f( 0.25, 0.5, 1 ) )
 
 		time.sleep( 1 )
 
 		c = self.__color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
-			IECore.V2f( 0.5 ),
+			imath.V2f( 0.5 ),
 		)
-		self.assertEqual( c / c[2], IECore.Color3f( 0.25, 0.5, 1 ) )
+		self.assertEqual( c / c[2], imath.Color3f( 0.25, 0.5, 1 ) )
 
 		# Pause it, adjust a parameter, wait, and check that nothing changed.
 
 		s["r"]["state"].setValue( s["r"].State.Paused )
-		colorPlug.setValue( IECore.Color3f( 1, 0.5, 0.25 ) )
+		colorPlug.setValue( imath.Color3f( 1, 0.5, 0.25 ) )
 
 		time.sleep( 1 )
 
 		c = self.__color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
-			IECore.V2f( 0.5 ),
+			imath.V2f( 0.5 ),
 		)
-		self.assertEqual( c / c[2], IECore.Color3f( 0.25, 0.5, 1 ) )
+		self.assertEqual( c / c[2], imath.Color3f( 0.25, 0.5, 1 ) )
 
 		# Unpause it, wait, and check that the update happened.
 
@@ -943,28 +944,28 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		c = self.__color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
-			IECore.V2f( 0.5 ),
+			imath.V2f( 0.5 ),
 		)
-		self.assertEqual( c / c[0], IECore.Color3f( 1, 0.5, 0.25 ) )
+		self.assertEqual( c / c[0], imath.Color3f( 1, 0.5, 0.25 ) )
 
 		# Stop the render, tweak a parameter and check that nothing happened.
 
 		s["r"]["state"].setValue( s["r"].State.Stopped )
-		colorPlug.setValue( IECore.Color3f( 0.25, 0.5, 1 ) )
+		colorPlug.setValue( imath.Color3f( 0.25, 0.5, 1 ) )
 		time.sleep( 1 )
 
 		c = self.__color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
-			IECore.V2f( 0.5 ),
+			imath.V2f( 0.5 ),
 		)
-		self.assertEqual( c / c[0], IECore.Color3f( 1, 0.5, 0.25 ) )
+		self.assertEqual( c / c[0], imath.Color3f( 1, 0.5, 0.25 ) )
 
 	def testAddLight( self ) :
 
 		s = Gaffer.ScriptNode()
 
 		s["l"], colorPlug = self._createPointLight()
-		colorPlug.setValue( IECore.Color3f( 1, 0, 0 ) )
+		colorPlug.setValue( imath.Color3f( 1, 0, 0 ) )
 		s["l"]["transform"]["translate"]["z"].setValue( 1 )
 
 		s["p"] = GafferScene.Plane()
@@ -1014,14 +1015,14 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		c = self.__color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
-			IECore.V2f( 0.5 ),
+			imath.V2f( 0.5 ),
 		)
-		self.assertEqual( c / c[0], IECore.Color3f( 1, 0, 0 ) )
+		self.assertEqual( c / c[0], imath.Color3f( 1, 0, 0 ) )
 
 		# Add a light
 
 		s["l2"], colorPlug = self._createPointLight()
-		colorPlug.setValue( IECore.Color3f( 0, 1, 0 ) )
+		colorPlug.setValue( imath.Color3f( 0, 1, 0 ) )
 		s["l2"]["transform"]["translate"]["z"].setValue( 1 )
 
 		s["g"]["in"][3].setInput( s["l2"]["out"] )
@@ -1032,9 +1033,9 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		c = self.__color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
-			IECore.V2f( 0.5 ),
+			imath.V2f( 0.5 ),
 		)
-		self.assertEqual( c / c[0], IECore.Color3f( 1, 1, 0 ) )
+		self.assertEqual( c / c[0], imath.Color3f( 1, 1, 0 ) )
 
 	def testRemoveLight( self ) :
 
@@ -1090,7 +1091,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		c = self.__color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
-			IECore.V2f( 0.5 ),
+			imath.V2f( 0.5 ),
 		)
 		self.assertNotEqual( c[0], 0.0 )
 
@@ -1101,7 +1102,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		c = self.__color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
-			IECore.V2f( 0.5 ),
+			imath.V2f( 0.5 ),
 		)
 		self.assertEqual( c[0], 0.0 )
 
@@ -1112,7 +1113,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		c = self.__color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
-			IECore.V2f( 0.5 ),
+			imath.V2f( 0.5 ),
 		)
 		self.assertNotEqual( c[0], 0.0 )
 
@@ -1174,7 +1175,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		c = self.__color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
-			IECore.V2f( 0.5 ),
+			imath.V2f( 0.5 ),
 		)
 		self.assertNotEqual( c[0], 0.0 )
 
@@ -1185,7 +1186,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		c = self.__color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
-			IECore.V2f( 0.5 ),
+			imath.V2f( 0.5 ),
 		)
 		self.assertEqual( c[0], 0.0 )
 
@@ -1196,7 +1197,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		c = self.__color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
-			IECore.V2f( 0.5 ),
+			imath.V2f( 0.5 ),
 		)
 
 		self.assertNotEqual( c[0], 0.0 )
@@ -1239,7 +1240,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Visible to start with
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Hide
 
@@ -1247,7 +1248,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Show again
 
@@ -1255,7 +1256,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testGlobalCameraVisibility( self ) :
 
@@ -1295,7 +1296,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Visible to start with
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Hide
 
@@ -1303,7 +1304,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Show again
 
@@ -1311,7 +1312,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testEffectiveContext( self ) :
 
@@ -1400,11 +1401,11 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["reflector"] = GafferScene.Plane()
 		s["reflector"]["name"].setValue( "reflector" )
-		s["reflector"]["transform"]["translate"].setValue( IECore.V3f( 0, 0, -1 ) )
+		s["reflector"]["transform"]["translate"].setValue( imath.V3f( 0, 0, -1 ) )
 
 		s["reflected"] = GafferScene.Plane()
 		s["reflected"]["name"].setValue( "reflected" )
-		s["reflected"]["transform"]["translate"].setValue( IECore.V3f( 0, 0, 1 ) )
+		s["reflected"]["transform"]["translate"].setValue( imath.V3f( 0, 0, 1 ) )
 
 		s["group"] = GafferScene.Group()
 		s["group"]["in"][0].setInput( s["reflector"]["out"] )
@@ -1465,11 +1466,11 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		def assertReflected( reflected ) :
 
 			image = IECoreImage.ImageDisplayDriver.storedImage( "traceSetsTest" )
-			self.assertGreater( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).a, 0.9 )
+			self.assertGreater( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).a, 0.9 )
 			if reflected :
-				self.assertGreater( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0.9 )
+				self.assertGreater( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0.9 )
 			else :
-				self.assertLess( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ).r, 0.1 )
+				self.assertLess( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0.1 )
 
 		assertReflected( True )
 
@@ -1549,7 +1550,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 			result = GafferScene.SceneProcessor()
 
 			result["__shader"], colorPlug = self._createConstantShader()
-			colorPlug.setValue( IECore.Color3f( 1, 0, 0 ) )
+			colorPlug.setValue( imath.Color3f( 1, 0, 0 ) )
 
 			result["__assignment"] = GafferScene.ShaderAssignment()
 			result["__assignment"]["in"].setInput( result["in"] )
@@ -1586,7 +1587,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Render red sphere
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.__assertColorsAlmostEqual( self.__color4fAtUV( image, IECore.V2f( 0.5 ) ), IECore.Color4f( 1, 0, 0, 1 ), delta = 0.01 )
+		self.__assertColorsAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ), imath.Color4f( 1, 0, 0, 1 ), delta = 0.01 )
 
 	def tearDown( self ) :
 
@@ -1649,7 +1650,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		sampler = GafferImage.ImageSampler()
 		sampler["image"].setInput( objectToImage["out"] )
 		sampler["pixel"].setValue(
-			uv * IECore.V2f(
+			uv * imath.V2f(
 				image.displayWindow.size().x,
 				image.displayWindow.size().y
 			)
@@ -1660,7 +1661,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 	def __color3fAtUV( self, image, uv ) :
 
 		c = self.__color4fAtUV( image, uv )
-		return IECore.Color3f( c.r, c.g, c.b )
+		return imath.Color3f( c.r, c.g, c.b )
 
 	def __assertColorsAlmostEqual( self, c0, c1, **kw ) :
 

--- a/python/GafferSceneTest/LightTest.py
+++ b/python/GafferSceneTest/LightTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -54,13 +55,13 @@ class LightTest( GafferSceneTest.SceneTestCase ) :
 		self.assertSceneValid( l["out"] )
 
 		self.assertEqual( l["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( l["out"].transform( "/" ), IECore.M44f() )
+		self.assertEqual( l["out"].transform( "/" ), imath.M44f() )
 		self.assertEqual( l["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "light" ] ) )
 
 		self.assertTrue( isinstance( l["out"].object( "/light" ), IECore.NullObject ) )
 		self.assertTrue( isinstance( l["out"].attributes( "/light" )["light"][-1], IECoreScene.Shader ) )
 
-		self.assertEqual( l["out"].transform( "/light" ), IECore.M44f() )
+		self.assertEqual( l["out"].transform( "/light" ), imath.M44f() )
 		self.assertEqual( l["out"].childNames( "/light" ), IECore.InternedStringVectorData() )
 
 		self.assertEqual( l["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights" ] ) )

--- a/python/GafferSceneTest/LightTweaksTest.py
+++ b/python/GafferSceneTest/LightTweaksTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -47,7 +48,7 @@ class LightTweaksTest( GafferSceneTest.SceneTestCase ) :
 	def test( self ) :
 
 		l = GafferSceneTest.TestLight()
-		l["parameters"]["intensity"].setValue( IECore.Color3f( 1 ) )
+		l["parameters"]["intensity"].setValue( imath.Color3f( 1 ) )
 
 		t = GafferScene.LightTweaks()
 		t["in"].setInput( l["out"] )
@@ -55,7 +56,7 @@ class LightTweaksTest( GafferSceneTest.SceneTestCase ) :
 		self.assertSceneValid( t["out"] )
 		self.assertScenesEqual( t["out"], l["out"] )
 		self.assertSceneHashesEqual( t["out"], l["out"] )
-		self.assertEqual( l["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, IECore.Color3f( 1 ) )
+		self.assertEqual( l["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, imath.Color3f( 1 ) )
 
 		f = GafferScene.PathFilter()
 		f["paths"].setValue( IECore.StringVectorData( [ "/light" ] ) )
@@ -66,30 +67,30 @@ class LightTweaksTest( GafferSceneTest.SceneTestCase ) :
 		self.assertScenesEqual( t["out"], l["out"] )
 		self.assertSceneHashesEqual( t["out"], l["out"] )
 
-		intensityTweak = t.TweakPlug( "intensity", IECore.Color3f( 1, 0, 0 ) )
+		intensityTweak = t.TweakPlug( "intensity", imath.Color3f( 1, 0, 0 ) )
 		t["tweaks"].addChild( intensityTweak )
 
 		self.assertSceneValid( t["out"] )
 
-		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, IECore.Color3f( 1, 0, 0 ) )
+		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, imath.Color3f( 1, 0, 0 ) )
 
-		intensityTweak["value"].setValue( IECore.Color3f( 100 ) )
-		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, IECore.Color3f( 100 ) )
+		intensityTweak["value"].setValue( imath.Color3f( 100 ) )
+		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, imath.Color3f( 100 ) )
 
 		intensityTweak["enabled"].setValue( False )
-		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, IECore.Color3f( 1 ) )
+		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, imath.Color3f( 1 ) )
 
 		intensityTweak["enabled"].setValue( True )
 		intensityTweak["mode"].setValue( intensityTweak.Mode.Add )
-		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, IECore.Color3f( 101 ) )
+		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, imath.Color3f( 101 ) )
 
 		intensityTweak["mode"].setValue( intensityTweak.Mode.Subtract )
-		intensityTweak["value"].setValue( IECore.Color3f( 0.1, 0.2, 0.3 ) )
-		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, IECore.Color3f( 0.9, 0.8, 0.7 ) )
+		intensityTweak["value"].setValue( imath.Color3f( 0.1, 0.2, 0.3 ) )
+		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, imath.Color3f( 0.9, 0.8, 0.7 ) )
 
 		intensityTweak["mode"].setValue( intensityTweak.Mode.Multiply )
-		l["parameters"]["intensity"].setValue( IECore.Color3f( 2 ) )
-		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, IECore.Color3f( 0.2, 0.4, 0.6 ) )
+		l["parameters"]["intensity"].setValue( imath.Color3f( 2 ) )
+		self.assertEqual( t["out"].attributes( "/light" )["light"][0].parameters["intensity"].value, imath.Color3f( 0.2, 0.4, 0.6 ) )
 
 		t["type"].setValue( "" )
 		self.assertScenesEqual( t["out"], l["out"] )
@@ -99,7 +100,7 @@ class LightTweaksTest( GafferSceneTest.SceneTestCase ) :
 		s = Gaffer.ScriptNode()
 		s["t"] = GafferScene.LightTweaks()
 		s["t"]["tweaks"].addChild( GafferScene.LightTweaks.TweakPlug( "test", 1.0 ) )
-		s["t"]["tweaks"].addChild( GafferScene.LightTweaks.TweakPlug( "test", IECore.Color3f( 1, 2, 3 ) ) )
+		s["t"]["tweaks"].addChild( GafferScene.LightTweaks.TweakPlug( "test", imath.Color3f( 1, 2, 3 ) ) )
 
 		ss = Gaffer.ScriptNode()
 		ss.execute( s.serialise() )

--- a/python/GafferSceneTest/MapOffsetTest.py
+++ b/python/GafferSceneTest/MapOffsetTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -63,13 +64,13 @@ class MapOffsetTest( GafferSceneTest.SceneTestCase ) :
 		self.assertSceneValid( offset["out"] )
 
 		for i, uv in enumerate( offset["out"].object( "/plane" )["uv"].data ) :
-			self.assertEqual( uv, IECore.V2f( inputObject["uv"].data[i] + IECore.V2f( 1, 2 ) ) )
+			self.assertEqual( uv, imath.V2f( inputObject["uv"].data[i] + imath.V2f( 1, 2 ) ) )
 
-		offset["offset"].setValue( IECore.V2f( 0.5, 1.5 ) )
+		offset["offset"].setValue( imath.V2f( 0.5, 1.5 ) )
 		self.assertSceneValid( offset["out"] )
 
 		for i, uv in enumerate( offset["out"].object( "/plane" )["uv"].data ) :
-			self.assertEqual( uv, IECore.V2f( inputObject["uv"].data[i] + IECore.V2f( 1.5, 3.5 ) ) )
+			self.assertEqual( uv, imath.V2f( inputObject["uv"].data[i] + imath.V2f( 1.5, 3.5 ) ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/MeshTangentsTest.py
+++ b/python/GafferSceneTest/MeshTangentsTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -50,15 +51,15 @@ class MeshTangentsTest( GafferSceneTest.SceneTestCase ) :
 
 		verticesPerFace = IECore.IntVectorData( [3] )
 		vertexIds = IECore.IntVectorData( [0, 1, 2] )
-		p = IECore.V3fVectorData( [IECore.V3f( 0, 0, 0 ), IECore.V3f( 1, 0, 0 ), IECore.V3f( 0, 1, 0 )] )
-		prefData = IECore.V3fVectorData( [IECore.V3f( 0, 0, 0 ), IECore.V3f( 0, -1, 0 ), IECore.V3f( 1, 0, 0 )] )
+		p = IECore.V3fVectorData( [imath.V3f( 0, 0, 0 ), imath.V3f( 1, 0, 0 ), imath.V3f( 0, 1, 0 )] )
+		prefData = IECore.V3fVectorData( [imath.V3f( 0, 0, 0 ), imath.V3f( 0, -1, 0 ), imath.V3f( 1, 0, 0 )] )
 
 		mesh = IECoreScene.MeshPrimitive( verticesPerFace, vertexIds, "linear", p )
 
 		mesh["uv"] = IECoreScene.PrimitiveVariable(
 			IECoreScene.PrimitiveVariable.Interpolation.FaceVarying,
 			IECore.V2fVectorData(
-				[ IECore.V2f( 0, 0 ), IECore.V2f( 1, 0 ), IECore.V2f( 0, 1 ) ],
+				[ imath.V2f( 0, 0 ), imath.V2f( 1, 0 ), imath.V2f( 0, 1 ) ],
 				IECore.GeometricData.Interpretation.UV
 			)
 		)
@@ -66,7 +67,7 @@ class MeshTangentsTest( GafferSceneTest.SceneTestCase ) :
 		mesh["foo"] = IECoreScene.PrimitiveVariable(
 			IECoreScene.PrimitiveVariable.Interpolation.FaceVarying,
 			IECore.V2fVectorData(
-				[ IECore.V2f( 0, 0 ), IECore.V2f( 0, 1 ), IECore.V2f( 1, 0 ) ],
+				[ imath.V2f( 0, 0 ), imath.V2f( 0, 1 ), imath.V2f( 1, 0 ) ],
 				IECore.GeometricData.Interpretation.UV
 			)
 		)
@@ -99,10 +100,10 @@ class MeshTangentsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( vTangent.data ), 3 )
 
 		for v in uTangent.data :
-			self.failUnless( v.equalWithAbsError( IECore.V3f( 1, 0, 0 ), 0.000001 ) )
+			self.failUnless( v.equalWithAbsError( imath.V3f( 1, 0, 0 ), 0.000001 ) )
 
 		for v in vTangent.data :
-			self.failUnless( v.equalWithAbsError( IECore.V3f( 0, 1, 0 ), 0.000001 ) )
+			self.failUnless( v.equalWithAbsError( imath.V3f( 0, 1, 0 ), 0.000001 ) )
 
 	def testCanRenameOutputTangents( self ) :
 
@@ -127,10 +128,10 @@ class MeshTangentsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( vTangent.data ), 3 )
 
 		for v in uTangent.data :
-			self.failUnless( v.equalWithAbsError( IECore.V3f( 1, 0, 0 ), 0.000001 ) )
+			self.failUnless( v.equalWithAbsError( imath.V3f( 1, 0, 0 ), 0.000001 ) )
 
 		for v in vTangent.data :
-			self.failUnless( v.equalWithAbsError( IECore.V3f( 0, 1, 0 ), 0.000001 ) )
+			self.failUnless( v.equalWithAbsError( imath.V3f( 0, 1, 0 ), 0.000001 ) )
 
 	def testCanUseSecondUVSet( self ) :
 
@@ -155,12 +156,12 @@ class MeshTangentsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( vTangent.data ), 3 )
 
 		for v in uTangent.data :
-			self.failUnless( v.equalWithAbsError( IECore.V3f( 0, 1, 0 ), 0.000001 ) )
+			self.failUnless( v.equalWithAbsError( imath.V3f( 0, 1, 0 ), 0.000001 ) )
 
 		# really I'd expect the naive answer to the vTangent to be IECore.V3f( 1, 0, 0 )
 		# but the code forces the triple of n, uT, vT to flip the direction of vT if we don't have a correctly handed set of basis vectors
 		for v in vTangent.data :
-			self.failUnless( v.equalWithAbsError( IECore.V3f( -1, 0, 0 ), 0.000001 ) )
+			self.failUnless( v.equalWithAbsError( imath.V3f( -1, 0, 0 ), 0.000001 ) )
 
 	def testCanUsePref( self ) :
 
@@ -185,7 +186,7 @@ class MeshTangentsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( vTangent.data ), 3 )
 
 		for v in uTangent.data :
-			self.failUnless( v.equalWithAbsError( IECore.V3f( 0, -1, 0 ), 0.000001 ) )
+			self.failUnless( v.equalWithAbsError( imath.V3f( 0, -1, 0 ), 0.000001 ) )
 
 		for v in vTangent.data :
-			self.failUnless( v.equalWithAbsError( IECore.V3f( 1, 0, 0 ), 0.000001 ) )
+			self.failUnless( v.equalWithAbsError( imath.V3f( 1, 0, 0 ), 0.000001 ) )

--- a/python/GafferSceneTest/ObjectToSceneTest.py
+++ b/python/GafferSceneTest/ObjectToSceneTest.py
@@ -37,6 +37,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -51,15 +52,15 @@ class ObjectToSceneTest( GafferSceneTest.SceneTestCase ) :
 	def testMeshInput( self ) :
 
 		p = GafferScene.ObjectToScene()
-		p["object"].setValue( IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ) )
+		p["object"].setValue( IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ) )
 
 		self.assertSceneValid( p["out"] )
-		self.assertEqual( p["out"].object( "/object" ),  IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ) )
+		self.assertEqual( p["out"].object( "/object" ),  IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ) )
 
-		p["object"].setValue( IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -2 ), IECore.V2f( 2 ) ) ) )
+		p["object"].setValue( IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -2 ), imath.V2f( 2 ) ) ) )
 
 		self.assertSceneValid( p["out"] )
-		self.assertEqual( p["out"].object( "/object" ),  IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -2 ), IECore.V2f( 2 ) ) ) )
+		self.assertEqual( p["out"].object( "/object" ),  IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -2 ), imath.V2f( 2 ) ) ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/OpenGLRenderTest.py
+++ b/python/GafferSceneTest/OpenGLRenderTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -55,7 +56,7 @@ class OpenGLRenderTest( GafferSceneTest.SceneTestCase ) :
 		s = Gaffer.ScriptNode()
 
 		s["plane"] = GafferScene.Plane()
-		s["plane"]["transform"]["translate"].setValue( IECore.V3f( 0, 0, -5 ) )
+		s["plane"]["transform"]["translate"].setValue( imath.V3f( 0, 0, -5 ) )
 
 		s["image"] = GafferImage.ImageReader()
 		s["image"]["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" ) )
@@ -64,7 +65,7 @@ class OpenGLRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["shader"].loadShader( "Texture" )
 		s["shader"]["parameters"]["texture"].setInput( s["image"]["out"] )
 		s["shader"]["parameters"]["mult"].setValue( 1 )
-		s["shader"]["parameters"]["tint"].setValue( IECore.Color4f( 1 ) )
+		s["shader"]["parameters"]["tint"].setValue( imath.Color4f( 1 ) )
 
 		s["assignment"] = GafferScene.ShaderAssignment()
 		s["assignment"]["in"].setInput( s["plane"]["out"] )
@@ -97,7 +98,7 @@ class OpenGLRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		imageSampler = GafferImage.ImageSampler()
 		imageSampler["image"].setInput( imageReader["out"] )
-		imageSampler["pixel"].setValue( IECore.V2f( 320, 240 ) )
+		imageSampler["pixel"].setValue( imath.V2f( 320, 240 ) )
 
 		self.assertAlmostEqual( imageSampler["color"]["r"].getValue(), 0.666666, delta = 0.001 )
 		self.assertAlmostEqual( imageSampler["color"]["g"].getValue(), 0.666666, delta = 0.001 )

--- a/python/GafferSceneTest/OpenGLShaderTest.py
+++ b/python/GafferSceneTest/OpenGLShaderTest.py
@@ -37,6 +37,7 @@
 import os
 import sys
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -62,7 +63,7 @@ class OpenGLShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertTrue( isinstance( s["parameters"]["texture"], GafferImage.ImagePlug ) )
 
 		s["parameters"]["mult"].setValue( 0.5 )
-		s["parameters"]["tint"].setValue( IECore.Color4f( 1, 0.5, 0.25, 1 ) )
+		s["parameters"]["tint"].setValue( imath.Color4f( 1, 0.5, 0.25, 1 ) )
 
 		i = GafferImage.ImageReader()
 		i["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" ) )
@@ -75,7 +76,7 @@ class OpenGLShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( a["gl:surface"][0].name, "Texture" )
 		self.assertEqual( a["gl:surface"][0].type, "gl:surface" )
 		self.assertEqual( a["gl:surface"][0].parameters["mult"], IECore.FloatData( 0.5 ) )
-		self.assertEqual( a["gl:surface"][0].parameters["tint"].value, IECore.Color4f( 1, 0.5, 0.25, 1 ) )
+		self.assertEqual( a["gl:surface"][0].parameters["tint"].value, imath.Color4f( 1, 0.5, 0.25, 1 ) )
 		self.assertTrue( isinstance( a["gl:surface"][0].parameters["texture"], IECore.CompoundData ) )
 		self.failUnless( "displayWindow" in a["gl:surface"][0].parameters["texture"] )
 		self.failUnless( "dataWindow" in a["gl:surface"][0].parameters["texture"] )
@@ -109,7 +110,7 @@ class OpenGLShaderTest( GafferSceneTest.SceneTestCase ) :
 		h2 = s.attributesHash()
 		self.assertNotEqual( h2, h1 )
 
-		i["color"].setValue( IECore.Color4f( 1, 0, 1, 0 ) )
+		i["color"].setValue( imath.Color4f( 1, 0, 1, 0 ) )
 
 		h3 = s.attributesHash()
 		self.assertNotEqual( h3, h2 )

--- a/python/GafferSceneTest/OutputsTest.py
+++ b/python/GafferSceneTest/OutputsTest.py
@@ -37,6 +37,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -57,13 +58,13 @@ class OutputsTest( GafferSceneTest.SceneTestCase ) :
 		# check that the scene hierarchy is passed through
 
 		self.assertEqual( outputs["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( outputs["out"].transform( "/" ), IECore.M44f() )
-		self.assertEqual( outputs["out"].bound( "/" ), IECore.Box3f( IECore.V3f( -0.5, -0.5, 0 ), IECore.V3f( 0.5, 0.5, 0 ) ) )
+		self.assertEqual( outputs["out"].transform( "/" ), imath.M44f() )
+		self.assertEqual( outputs["out"].bound( "/" ), imath.Box3f( imath.V3f( -0.5, -0.5, 0 ), imath.V3f( 0.5, 0.5, 0 ) ) )
 		self.assertEqual( outputs["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "plane" ] ) )
 
-		self.assertEqual( outputs["out"].object( "/plane" ), IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -0.5 ), IECore.V2f( 0.5 ) ) ) )
-		self.assertEqual( outputs["out"].transform( "/plane" ), IECore.M44f() )
-		self.assertEqual( outputs["out"].bound( "/plane" ), IECore.Box3f( IECore.V3f( -0.5, -0.5, 0 ), IECore.V3f( 0.5, 0.5, 0 ) ) )
+		self.assertEqual( outputs["out"].object( "/plane" ), IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -0.5 ), imath.V2f( 0.5 ) ) ) )
+		self.assertEqual( outputs["out"].transform( "/plane" ), imath.M44f() )
+		self.assertEqual( outputs["out"].bound( "/plane" ), imath.Box3f( imath.V3f( -0.5, -0.5, 0 ), imath.V3f( 0.5, 0.5, 0 ) ) )
 		self.assertEqual( outputs["out"].childNames( "/plane" ), IECore.InternedStringVectorData() )
 
 		# check that we have some outputs

--- a/python/GafferSceneTest/ParentConstraintTest.py
+++ b/python/GafferSceneTest/ParentConstraintTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -48,9 +49,9 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 	def test( self ) :
 
 		plane1 = GafferScene.Plane()
-		plane1["transform"]["translate"].setValue( IECore.V3f( 1, 2, 3 ) )
-		plane1["transform"]["scale"].setValue( IECore.V3f( 1, 2, 3 ) )
-		plane1["transform"]["rotate"].setValue( IECore.V3f( 1000, 20, 39 ) )
+		plane1["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
+		plane1["transform"]["scale"].setValue( imath.V3f( 1, 2, 3 ) )
+		plane1["transform"]["rotate"].setValue( imath.V3f( 1000, 20, 39 ) )
 		plane1["name"].setValue( "target" )
 
 		plane2 = GafferScene.Plane()
@@ -77,8 +78,8 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 	def testRelativeTransform( self ) :
 
 		plane1 = GafferScene.Plane()
-		plane1["transform"]["translate"].setValue( IECore.V3f( 1, 2, 3 ) )
-		plane1["transform"]["rotate"].setValue( IECore.V3f( 0, 90, 0 ) )
+		plane1["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
+		plane1["transform"]["rotate"].setValue( imath.V3f( 0, 90, 0 ) )
 		plane1["name"].setValue( "target" )
 
 		plane2 = GafferScene.Plane()
@@ -93,7 +94,7 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 		constraint = GafferScene.ParentConstraint()
 		constraint["target"].setValue( "/group/target" )
 		constraint["in"].setInput( group["out"] )
-		constraint["relativeTransform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+		constraint["relativeTransform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/group/constrained" ] ) )
@@ -101,7 +102,7 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertSceneValid( constraint["out"] )
 
-		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ), IECore.M44f.createTranslated( IECore.V3f( 1, 0, 0 ) ) * group["out"].fullTransform( "/group/target" ) )
+		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ), imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) * group["out"].fullTransform( "/group/target" ) )
 
 	def testDirtyPropagation( self ) :
 

--- a/python/GafferSceneTest/ParentTest.py
+++ b/python/GafferSceneTest/ParentTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import GafferScene
@@ -118,7 +120,7 @@ class ParentTest( GafferSceneTest.SceneTestCase ) :
 		c = GafferScene.Cube()
 
 		cSmall = GafferScene.Cube()
-		cSmall["dimensions"].setValue( IECore.V3f( 0.1 ) )
+		cSmall["dimensions"].setValue( imath.V3f( 0.1 ) )
 
 		g = GafferScene.Group()
 		g["in"][0].setInput( c["out"] )
@@ -135,7 +137,7 @@ class ParentTest( GafferSceneTest.SceneTestCase ) :
 		c = GafferScene.Cube()
 
 		cLarge = GafferScene.Cube()
-		cLarge["dimensions"].setValue( IECore.V3f( 10 ) )
+		cLarge["dimensions"].setValue( imath.V3f( 10 ) )
 
 		g = GafferScene.Group()
 		g["in"][0].setInput( c["out"] )

--- a/python/GafferSceneTest/PlaneTest.py
+++ b/python/GafferSceneTest/PlaneTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -57,30 +58,30 @@ class PlaneTest( GafferSceneTest.SceneTestCase ) :
 		p = GafferScene.Plane()
 
 		self.assertEqual( p["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( p["out"].transform( "/" ), IECore.M44f() )
-		self.assertEqual( p["out"].bound( "/" ), IECore.Box3f( IECore.V3f( -0.5, -0.5, 0 ), IECore.V3f( 0.5, 0.5, 0 ) ) )
+		self.assertEqual( p["out"].transform( "/" ), imath.M44f() )
+		self.assertEqual( p["out"].bound( "/" ), imath.Box3f( imath.V3f( -0.5, -0.5, 0 ), imath.V3f( 0.5, 0.5, 0 ) ) )
 		self.assertEqual( p["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "plane" ] ) )
 
-		self.assertEqual( p["out"].object( "/plane" ), IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -0.5 ), IECore.V2f( 0.5 ) ) ) )
-		self.assertEqual( p["out"].transform( "/plane" ), IECore.M44f() )
-		self.assertEqual( p["out"].bound( "/plane" ), IECore.Box3f( IECore.V3f( -0.5, -0.5, 0 ), IECore.V3f( 0.5, 0.5, 0 ) ) )
+		self.assertEqual( p["out"].object( "/plane" ), IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -0.5 ), imath.V2f( 0.5 ) ) ) )
+		self.assertEqual( p["out"].transform( "/plane" ), imath.M44f() )
+		self.assertEqual( p["out"].bound( "/plane" ), imath.Box3f( imath.V3f( -0.5, -0.5, 0 ), imath.V3f( 0.5, 0.5, 0 ) ) )
 		self.assertEqual( p["out"].childNames( "/plane" ), IECore.InternedStringVectorData() )
 
 	def testPlugs( self ) :
 
 		p = GafferScene.Plane()
-		m = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -0.5 ), IECore.V2f( 0.5 ) ) )
+		m = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -0.5 ), imath.V2f( 0.5 ) ) )
 		self.assertEqual( p["out"].object( "/plane" ), m )
 		h = p["out"].objectHash( "/plane" )
 
-		p["dimensions"].setValue( IECore.V2f( 2.5, 5 ) )
-		m = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1.25, -2.5 ), IECore.V2f( 1.25, 2.5 ) ) )
+		p["dimensions"].setValue( imath.V2f( 2.5, 5 ) )
+		m = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1.25, -2.5 ), imath.V2f( 1.25, 2.5 ) ) )
 		self.assertEqual( p["out"].object( "/plane" ), m )
 		self.assertNotEqual( p["out"].objectHash( "/plane" ), h )
 		h = p["out"].objectHash( "/plane" )
 
-		p["divisions"].setValue( IECore.V2i( 5, 10 ) )
-		m = IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1.25, -2.5 ), IECore.V2f( 1.25, 2.5 ) ), IECore.V2i( 5, 10 ) )
+		p["divisions"].setValue( imath.V2i( 5, 10 ) )
+		m = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1.25, -2.5 ), imath.V2f( 1.25, 2.5 ) ), imath.V2i( 5, 10 ) )
 		self.assertEqual( p["out"].object( "/plane" ), m )
 		self.assertNotEqual( p["out"].objectHash( "/plane" ), h )
 
@@ -109,13 +110,13 @@ class PlaneTest( GafferSceneTest.SceneTestCase ) :
 	def testTransform( self ) :
 
 		p = GafferScene.Plane()
-		p["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+		p["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 
-		self.assertEqual( p["out"].transform( "/" ), IECore.M44f() )
-		self.assertEqual( p["out"].transform( "/plane" ), IECore.M44f.createTranslated( IECore.V3f( 1, 0, 0 ) ) )
+		self.assertEqual( p["out"].transform( "/" ), imath.M44f() )
+		self.assertEqual( p["out"].transform( "/plane" ), imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) )
 
-		self.assertEqual( p["out"].bound( "/" ), IECore.Box3f( IECore.V3f( 0.5, -0.5, 0 ), IECore.V3f( 1.5, 0.5, 0 ) ) )
-		self.assertEqual( p["out"].bound( "/plane" ), IECore.Box3f( IECore.V3f( -0.5, -0.5, 0 ), IECore.V3f( 0.5, 0.5, 0 ) ) )
+		self.assertEqual( p["out"].bound( "/" ), imath.Box3f( imath.V3f( 0.5, -0.5, 0 ), imath.V3f( 1.5, 0.5, 0 ) ) )
+		self.assertEqual( p["out"].bound( "/plane" ), imath.Box3f( imath.V3f( -0.5, -0.5, 0 ), imath.V3f( 0.5, 0.5, 0 ) ) )
 
 	def testEnabled( self ) :
 

--- a/python/GafferSceneTest/PointConstraintTest.py
+++ b/python/GafferSceneTest/PointConstraintTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -47,15 +48,15 @@ class PointConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 	def test( self ) :
 
-		targetTranslate = IECore.V3f( 1, 2, 3 )
-		constrainedTranslate = IECore.V3f( 10, 11, 12 )
-		constrainedScale = IECore.V3f( 1, 2, 3 )
-		constrainedRotate = IECore.V3f( 15, 45, 19 )
+		targetTranslate = imath.V3f( 1, 2, 3 )
+		constrainedTranslate = imath.V3f( 10, 11, 12 )
+		constrainedScale = imath.V3f( 1, 2, 3 )
+		constrainedRotate = imath.V3f( 15, 45, 19 )
 
 		plane1 = GafferScene.Plane()
 		plane1["transform"]["translate"].setValue( targetTranslate )
-		plane1["transform"]["scale"].setValue( IECore.V3f( 1, 2, 3 ) )
-		plane1["transform"]["rotate"].setValue( IECore.V3f( 1000, 20, 39 ) ) # shouldn't affect the result
+		plane1["transform"]["scale"].setValue( imath.V3f( 1, 2, 3 ) )
+		plane1["transform"]["rotate"].setValue( imath.V3f( 1000, 20, 39 ) ) # shouldn't affect the result
 		plane1["name"].setValue( "target" )
 
 		plane2 = GafferScene.Plane()
@@ -86,10 +87,15 @@ class PointConstraintTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( constraint["out"].fullTransform( "/group/target" ).translation(), targetTranslate )
 		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ).translation(), targetTranslate )
 
-		beforeSHRT = group["out"].fullTransform( "/group/constrained" ).extractSHRT()
-		afterSHRT = constraint["out"].fullTransform( "/group/constrained" ).extractSHRT()
+		beforeS, beforeH, beforeR, beforeT = imath.V3f(), imath.V3f(), imath.V3f(), imath.V3f()
+		group["out"].fullTransform( "/group/constrained" ).extractSHRT( beforeS, beforeH, beforeR, beforeT )
 
-		self.assertEqual( beforeSHRT[:-1], afterSHRT[:-1] )
+		afterS, afterH, afterR, afterT = imath.V3f(), imath.V3f(), imath.V3f(), imath.V3f()
+		constraint["out"].fullTransform( "/group/constrained" ).extractSHRT( afterS, afterH, afterR, afterT )
+
+		self.assertEqual( beforeS, afterS )
+		self.assertEqual( beforeH, afterH )
+		self.assertEqual( beforeR, afterR )
 
 		constraint["xEnabled"].setValue( False )
 

--- a/python/GafferSceneTest/PointsTypeTest.py
+++ b/python/GafferSceneTest/PointsTypeTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -50,7 +51,7 @@ class PointsTypeTest( GafferSceneTest.SceneTestCase ) :
 		points = IECoreScene.PointsPrimitive( 1 )
 		points["P"] = IECoreScene.PrimitiveVariable(
 			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
-			IECore.V3fVectorData( [ IECore.V3f( 1, 2, 3 ) ] ),
+			IECore.V3fVectorData( [ imath.V3f( 1, 2, 3 ) ] ),
 		)
 
 		objectToScene = GafferScene.ObjectToScene()

--- a/python/GafferSceneTest/PrimitiveVariablesTest.py
+++ b/python/GafferSceneTest/PrimitiveVariablesTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 import IECoreScene
 
@@ -75,9 +77,9 @@ class PrimitiveVariablesTest( GafferSceneTest.SceneTestCase ) :
 		p = GafferScene.PrimitiveVariables()
 		p["in"].setInput( s["out"] )
 
-		p["primitiveVariables"].addMember( "myFirstData", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Vector ) )
-		p["primitiveVariables"].addMember( "mySecondData", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Normal ) )
-		p["primitiveVariables"].addMember( "myThirdData", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Point ) )
+		p["primitiveVariables"].addMember( "myFirstData", IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Vector ) )
+		p["primitiveVariables"].addMember( "mySecondData", IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Normal ) )
+		p["primitiveVariables"].addMember( "myThirdData", IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Point ) )
 
 		o = p["out"].object( "/sphere" )
 
@@ -94,9 +96,9 @@ class PrimitiveVariablesTest( GafferSceneTest.SceneTestCase ) :
 		self.assertFalse( 'mySecondData' in o )
 		self.assertFalse( 'myThirdData' in o )
 
-		p["primitiveVariables"].addMember( "myFirstData", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Point ) )
-		p["primitiveVariables"].addMember( "mySecondData", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Vector ) )
-		p["primitiveVariables"].addMember( "myThirdData", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Normal ) )
+		p["primitiveVariables"].addMember( "myFirstData", IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Point ) )
+		p["primitiveVariables"].addMember( "mySecondData", IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Vector ) )
+		p["primitiveVariables"].addMember( "myThirdData", IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Normal ) )
 
 		o = p["out"].object( "/sphere" )
 

--- a/python/GafferSceneTest/ResamplePrimitiveVariablesTest.py
+++ b/python/GafferSceneTest/ResamplePrimitiveVariablesTest.py
@@ -33,6 +33,9 @@
 #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 ##########################################################################
+
+import imath
+
 import IECore
 import IECoreScene
 
@@ -45,7 +48,7 @@ class ResamplePrimitiveVariablesTest( GafferSceneTest.SceneTestCase ) :
 
 		verticesPerFace = IECore.IntVectorData( [4] )
 		vertexIds = IECore.IntVectorData( [0, 1, 2, 3] )
-		p = IECore.V3fVectorData( [IECore.V3f( 0, 0, 0 ), IECore.V3f( 1, 0, 0 ), IECore.V3f( 1, 1, 0 ), IECore.V3f( 0, 1, 0 )] )
+		p = IECore.V3fVectorData( [imath.V3f( 0, 0, 0 ), imath.V3f( 1, 0, 0 ), imath.V3f( 1, 1, 0 ), imath.V3f( 0, 1, 0 )] )
 		a = IECore.FloatVectorData( [0, 1, 2, 3] )
 		b = IECore.FloatVectorData( [4, 5, 6, 7] )
 

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -53,7 +54,7 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		group["in"][1].setInput( plane["out"] )
 
 		plane2 = GafferScene.Plane()
-		plane2["divisions"].setValue( IECore.V2i( 99, 99 ) ) # 10000 instances
+		plane2["divisions"].setValue( imath.V2i( 99, 99 ) ) # 10000 instances
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( plane2["out"] )

--- a/python/GafferSceneTest/SceneFilterPathFilterTest.py
+++ b/python/GafferSceneTest/SceneFilterPathFilterTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -72,7 +73,7 @@ class SceneFilterPathFilterTest( GafferSceneTest.SceneTestCase ) :
 	def testManyPaths( self ) :
 
 		plane = GafferScene.Plane()
-		plane["divisions"].setValue( IECore.V2i( 500 ) )
+		plane["divisions"].setValue( imath.V2i( 500 ) )
 
 		sphere = GafferScene.Sphere()
 

--- a/python/GafferSceneTest/SceneLoopTest.py
+++ b/python/GafferSceneTest/SceneLoopTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -68,19 +69,19 @@ class SceneLoopTest( GafferSceneTest.SceneTestCase ) :
 		script["loop"]["next"].setInput( script["transform"]["out"] )
 
 		script["loop"]["iterations"].setValue( 2 )
-		self.assertEqual( script["loop"]["out"].transform( "/sphere" ), IECore.M44f.createTranslated( IECore.V3f( 2, 0, 0 ) ) )
+		self.assertEqual( script["loop"]["out"].transform( "/sphere" ), imath.M44f().translate( imath.V3f( 2, 0, 0 ) ) )
 
 		script["loop"]["iterations"].setValue( 4 )
-		self.assertEqual( script["loop"]["out"].transform( "/sphere" ), IECore.M44f.createTranslated( IECore.V3f( 4, 0, 0 ) ) )
+		self.assertEqual( script["loop"]["out"].transform( "/sphere" ), imath.M44f().translate( imath.V3f( 4, 0, 0 ) ) )
 
 		script2 = Gaffer.ScriptNode()
 		script2.execute( script.serialise() )
 
 		script2["loop"]["iterations"].setValue( 3 )
-		self.assertEqual( script2["loop"]["out"].transform( "/sphere" ), IECore.M44f.createTranslated( IECore.V3f( 3, 0, 0 ) ) )
+		self.assertEqual( script2["loop"]["out"].transform( "/sphere" ), imath.M44f().translate( imath.V3f( 3, 0, 0 ) ) )
 
 		script2["loop"]["iterations"].setValue( 5 )
-		self.assertEqual( script2["loop"]["out"].transform( "/sphere" ), IECore.M44f.createTranslated( IECore.V3f( 5, 0, 0 ) ) )
+		self.assertEqual( script2["loop"]["out"].transform( "/sphere" ), imath.M44f().translate( imath.V3f( 5, 0, 0 ) ) )
 
 	def testEnabled( self ) :
 
@@ -100,10 +101,10 @@ class SceneLoopTest( GafferSceneTest.SceneTestCase ) :
 		script["loop"]["next"].setInput( script["transform"]["out"] )
 
 		script["loop"]["iterations"].setValue( 2 )
-		self.assertEqual( script["loop"]["out"].transform( "/sphere" ), IECore.M44f.createTranslated( IECore.V3f( 2, 0, 0 ) ) )
+		self.assertEqual( script["loop"]["out"].transform( "/sphere" ), imath.M44f().translate( imath.V3f( 2, 0, 0 ) ) )
 
 		script["loop"]["enabled"].setValue( False )
-		self.assertEqual( script["loop"]["out"].transform( "/sphere" ), IECore.M44f() )
+		self.assertEqual( script["loop"]["out"].transform( "/sphere" ), imath.M44f() )
 
 		self.assertScenesEqual( script["loop"]["out"], script["sphere"]["out"] )
 		self.assertSceneHashesEqual( script["loop"]["out"], script["sphere"]["out"] )
@@ -136,7 +137,7 @@ class SceneLoopTest( GafferSceneTest.SceneTestCase ) :
 			"""
 		) )
 
-		self.assertEqual( script["loop"]["out"].transform( "/sphere" ), IECore.M44f.createTranslated( IECore.V3f( 4, 0, 0 ) ) )
+		self.assertEqual( script["loop"]["out"].transform( "/sphere" ), imath.M44f().translate( imath.V3f( 4, 0, 0 ) ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/SceneNodeTest.py
+++ b/python/GafferSceneTest/SceneNodeTest.py
@@ -37,6 +37,7 @@
 
 import unittest
 import threading
+import imath
 
 import IECore
 import IECoreScene
@@ -71,11 +72,11 @@ class SceneNodeTest( GafferSceneTest.SceneTestCase ) :
 		node = GafferSceneTest.CompoundObjectSource()
 		node["in"].setValue(
 			IECore.CompoundObject( {
-				"transform" : IECore.M44fData( IECore.M44f.createTranslated( IECore.V3f( 1 ) ) )
+				"transform" : IECore.M44fData( imath.M44f().translate( imath.V3f( 1 ) ) )
 			} )
 		)
 
-		self.assertEqual( node["out"].transform( "/" ), IECore.M44f() )
+		self.assertEqual( node["out"].transform( "/" ), imath.M44f() )
 
 		node = GafferSceneTest.CompoundObjectSource()
 		node["in"].setValue(
@@ -141,7 +142,7 @@ class SceneNodeTest( GafferSceneTest.SceneTestCase ) :
 		context = Gaffer.Context()
 		context.set("scene:path", IECore.InternedStringVectorData(["sphere"]) )
 		with context:
-			self.assertEqual( sphere["out"]["transform"].getValue(), IECore.M44f.createTranslated( IECore.V3f( 1,2,3 ) ) )
+			self.assertEqual( sphere["out"]["transform"].getValue(), imath.M44f().translate( imath.V3f( 1,2,3 ) ) )
 
 		# right, now subtree it. If the cache is behaving itself, then the transform at the root of the
 		# resulting scene should be set to identity.
@@ -150,15 +151,15 @@ class SceneNodeTest( GafferSceneTest.SceneTestCase ) :
 		subTree["root"].setValue("sphere")
 		context.set("scene:path", IECore.InternedStringVectorData([]) )
 		with context:
-			self.assertEqual( subTree["out"]["transform"].getValue(), IECore.M44f() )
+			self.assertEqual( subTree["out"]["transform"].getValue(), imath.M44f() )
 
 	def testCacheThreadSafety( self ) :
 
 		p1 = GafferScene.Plane()
-		p1["divisions"].setValue( IECore.V2i( 50 ) )
+		p1["divisions"].setValue( imath.V2i( 50 ) )
 
 		p2 = GafferScene.Plane()
-		p2["divisions"].setValue( IECore.V2i( 51 ) )
+		p2["divisions"].setValue( imath.V2i( 51 ) )
 
 		g = GafferScene.Group()
 		g["in"][0].setInput( p1["out"] )

--- a/python/GafferSceneTest/ScenePlugTest.py
+++ b/python/GafferSceneTest/ScenePlugTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -65,8 +66,8 @@ class ScenePlugTest( GafferSceneTest.SceneTestCase ) :
 
 	def testFullTransform( self ) :
 
-		translation = IECore.M44f.createTranslated( IECore.V3f( 1 ) )
-		scaling = IECore.M44f.createScaled( IECore.V3f( 10 ) )
+		translation = imath.M44f().translate( imath.V3f( 1 ) )
+		scaling = imath.M44f().scale( imath.V3f( 10 ) )
 
 		n = GafferSceneTest.CompoundObjectSource()
 		n["in"].setValue(
@@ -84,16 +85,19 @@ class ScenePlugTest( GafferSceneTest.SceneTestCase ) :
 			} )
 		)
 
-		self.assertEqual( n["out"].transform( "/" ), IECore.M44f() )
+		self.assertEqual( n["out"].transform( "/" ), imath.M44f() )
 		self.assertEqual( n["out"].transform( "/group" ), translation )
 		self.assertEqual( n["out"].transform( "/group/ball" ), scaling )
 
-		self.assertEqual( n["out"].fullTransform( "/" ), IECore.M44f() )
+		self.assertEqual( n["out"].fullTransform( "/" ), imath.M44f() )
 		self.assertEqual( n["out"].fullTransform( "/group" ), translation )
 
 		m = n["out"].fullTransform( "/group/ball" )
-		self.assertEqual( m.translation(), IECore.V3f( 1 ) )
-		self.assertEqual( m.extractScaling(), IECore.V3f( 10 ) )
+		self.assertEqual( m.translation(), imath.V3f( 1 ) )
+
+		extractedScaling = imath.V3f()
+		m.extractScaling( extractedScaling )
+		self.assertEqual( extractedScaling, imath.V3f( 10 ) )
 		self.assertEqual( m, scaling * translation )
 
 	def testFullAttributes( self ) :

--- a/python/GafferSceneTest/SceneProcessorTest.py
+++ b/python/GafferSceneTest/SceneProcessorTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -83,13 +84,13 @@ class SceneProcessorTest( GafferTest.TestCase ) :
 
 				self["__red"] = GafferScene.StandardAttributes()
 				self["__red"]["in"].setInput( self["in"] )
-				self["__red"]["attributes"].addMember( "user:matteColor", IECore.Color3f( 1, 0, 0 ) )
+				self["__red"]["attributes"].addMember( "user:matteColor", imath.Color3f( 1, 0, 0 ) )
 				self["redFilter"] = self["__red"]["filter"].createCounterpart( "redFilter", Gaffer.Plug.Direction.In )
 				self["__red"]["filter"].setInput( self["redFilter"] )
 
 				self["__green"] = GafferScene.StandardAttributes()
 				self["__green"]["in"].setInput( self["__red"]["out"] )
-				self["__green"]["attributes"].addMember( "user:matteColor", IECore.Color3f( 0, 1, 0 ) )
+				self["__green"]["attributes"].addMember( "user:matteColor", imath.Color3f( 0, 1, 0 ) )
 				self["greenFilter"] = self["__green"]["filter"].createCounterpart( "greenFilter", Gaffer.Plug.Direction.In )
 				self["__green"]["filter"].setInput( self["greenFilter"] )
 
@@ -115,8 +116,8 @@ class SceneProcessorTest( GafferTest.TestCase ) :
 		a["greenFilter"].setInput( f2["out"] )
 
 		self.assertEqual( a["out"].attributes( "/group" ), IECore.CompoundObject() )
-		self.assertEqual( a["out"].attributes( "/group/sphere" )["user:matteColor"].value, IECore.Color3f( 1, 0, 0 ) )
-		self.assertEqual( a["out"].attributes( "/group/sphere1" )["user:matteColor"].value, IECore.Color3f( 0, 1, 0 ) )
+		self.assertEqual( a["out"].attributes( "/group/sphere" )["user:matteColor"].value, imath.Color3f( 1, 0, 0 ) )
+		self.assertEqual( a["out"].attributes( "/group/sphere1" )["user:matteColor"].value, imath.Color3f( 0, 1, 0 ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/SceneReaderTest.py
+++ b/python/GafferSceneTest/SceneReaderTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -57,7 +58,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		sc = IECoreScene.SceneCache( self.__testFile, IECore.IndexedIO.OpenMode.Write )
 
 		t = sc.createChild( "1" )
-		t.writeTransform( IECore.M44dData( IECore.M44d.createTranslated( IECore.V3d( 1, 0, 0 ) ) ), 0.0 )
+		t.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ), 0.0 )
 
 		s = t.createChild( "2" )
 		s.writeObject( IECoreScene.SpherePrimitive( 10 ), 0.0 )
@@ -76,7 +77,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		sc = IECoreScene.SceneCache( self.__testFile, IECore.IndexedIO.OpenMode.Write )
 
 		t = sc.createChild( "transform" )
-		t.writeTransform( IECore.M44dData( IECore.M44d.createTranslated( IECore.V3d( 1, 0, 0 ) ) ), 0.0 )
+		t.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ), 0.0 )
 
 		s = t.createChild( "shape" )
 		s.writeObject( IECoreScene.SpherePrimitive( 10 ), 0.0 )
@@ -97,7 +98,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		sc = IECoreScene.SceneCache( self.__testFile, IECore.IndexedIO.OpenMode.Write )
 
 		t = sc.createChild( "transform" )
-		t.writeTransform( IECore.M44dData( IECore.M44d.createTranslated( IECore.V3d( 1, 0, 0 ) ) ), 0.0 )
+		t.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ), 0.0 )
 
 		s = t.createChild( "shape" )
 		s.writeObject( IECoreScene.SpherePrimitive( 10 ), 0.0 )
@@ -114,7 +115,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		scene = reader["out"]
 		self.assertSceneValid( scene )
 
-		self.assertEqual( scene.transform( "transform" ), IECore.M44f.createTranslated( IECore.V3f( 1, 0, 0 ) ) )
+		self.assertEqual( scene.transform( "transform" ), imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) )
 		self.assertEqual( scene.object( "transform/shape" ), IECoreScene.SpherePrimitive( 10 ) )
 
 	def writeAnimatedSCC( self ) :
@@ -123,34 +124,34 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 		time = 0
 		sc1 = scene.createChild( str( 1 ) )
-		mesh = IECoreScene.MeshPrimitive.createBox(IECore.Box3f(IECore.V3f(0),IECore.V3f(1)))
-		mesh["Cd"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ IECore.V3f( 1, 0, 0 ) ] * 6 ) )
+		mesh = IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1)))
+		mesh["Cd"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ imath.V3f( 1, 0, 0 ) ] * 6 ) )
 		sc1.writeObject( mesh, time )
 		sc1.writeTransform( IECore.M44dData(), time )
 
 		sc2 = sc1.createChild( str( 2 ) )
-		mesh = IECoreScene.MeshPrimitive.createBox(IECore.Box3f(IECore.V3f(0),IECore.V3f(1)))
-		mesh["Cd"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ IECore.V3f( 0, 1, 0 ) ] * 6 ) )
+		mesh = IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1)))
+		mesh["Cd"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ imath.V3f( 0, 1, 0 ) ] * 6 ) )
 		sc2.writeObject( mesh, time )
 		sc2.writeTransform( IECore.M44dData(), time )
 
 		sc3 = sc2.createChild( str( 3 ) )
-		mesh = IECoreScene.MeshPrimitive.createBox(IECore.Box3f(IECore.V3f(0),IECore.V3f(1)))
-		mesh["Cd"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ IECore.V3f( 0, 0, 1 ) ] * 6 ) )
+		mesh = IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1)))
+		mesh["Cd"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ imath.V3f( 0, 0, 1 ) ] * 6 ) )
 		sc3.writeObject( mesh, time )
 		sc3.writeTransform( IECore.M44dData(), time )
 
 		for frame in [ 0.5, 1, 1.5, 2, 5, 10 ] :
 
-			matrix = IECore.M44d.createTranslated( IECore.V3d( 1, frame, 0 ) )
+			matrix = imath.M44d().translate( imath.V3d( 1, frame, 0 ) )
 			sc1.writeTransform( IECore.M44dData( matrix ), float( frame ) / 24 )
 
-			mesh["Cd"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ IECore.V3f( frame, 1, 0 ) ] * 6 ) )
+			mesh["Cd"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ imath.V3f( frame, 1, 0 ) ] * 6 ) )
 			sc2.writeObject( mesh, float( frame ) / 24 )
-			matrix = IECore.M44d.createTranslated( IECore.V3d( 2, frame, 0 ) )
+			matrix = imath.M44d().translate( imath.V3d( 2, frame, 0 ) )
 			sc2.writeTransform( IECore.M44dData( matrix ), float( frame ) / 24 )
 
-			matrix = IECore.M44d.createTranslated( IECore.V3d( 3, frame, 0 ) )
+			matrix = imath.M44d().translate( imath.V3d( 3, frame, 0 ) )
 			sc3.writeTransform( IECore.M44dData( matrix ), float( frame ) / 24 )
 
 	def testAnimatedScene( self ) :
@@ -167,28 +168,28 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		context.setFrame( 0 )
 
 		with context:
-			self.assertEqual( scene.transform( "/1" ), IECore.M44f() )
-			self.assertEqual( scene.transform( "/1/2" ), IECore.M44f() )
-			self.assertEqual( scene.transform( "/1/2/3" ), IECore.M44f() )
+			self.assertEqual( scene.transform( "/1" ), imath.M44f() )
+			self.assertEqual( scene.transform( "/1/2" ), imath.M44f() )
+			self.assertEqual( scene.transform( "/1/2/3" ), imath.M44f() )
 
 		for time in [ 0.5, 1, 1.5, 2, 5, 10 ] :
 
 			context.setFrame( time )
 
 			with context:
-				self.assertEqual( scene.transform( "/1" ), IECore.M44f.createTranslated( IECore.V3f( 1, time, 0 ) ) )
-				self.assertEqual( scene.transform( "/1/2" ), IECore.M44f.createTranslated( IECore.V3f( 2, time, 0 ) ) )
-				self.assertEqual( scene.transform( "/1/2/3" ), IECore.M44f.createTranslated( IECore.V3f( 3, time, 0 ) ) )
+				self.assertEqual( scene.transform( "/1" ), imath.M44f().translate( imath.V3f( 1, time, 0 ) ) )
+				self.assertEqual( scene.transform( "/1/2" ), imath.M44f().translate( imath.V3f( 2, time, 0 ) ) )
+				self.assertEqual( scene.transform( "/1/2/3" ), imath.M44f().translate( imath.V3f( 3, time, 0 ) ) )
 
 				mesh = scene.object( "/1/2" )
-				self.assertEqual( mesh["Cd"].data, IECore.V3fVectorData( [ IECore.V3f( time, 1, 0 ) ] * 6 ) )
+				self.assertEqual( mesh["Cd"].data, IECore.V3fVectorData( [ imath.V3f( time, 1, 0 ) ] * 6 ) )
 
 	def testEnabled( self ) :
 
 		sc = IECoreScene.SceneCache( self.__testFile, IECore.IndexedIO.OpenMode.Write )
 
 		t = sc.createChild( "transform" )
-		t.writeTransform( IECore.M44dData( IECore.M44d.createTranslated( IECore.V3d( 1, 0, 0 ) ) ), 0.0 )
+		t.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ), 0.0 )
 
 		s = t.createChild( "shape" )
 		s.writeObject( IECoreScene.SpherePrimitive( 10 ), 0.0 )
@@ -216,8 +217,8 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertSceneValid( s["out"] )
 		self.assertEqual( s["out"].childNames( "/" ), IECore.InternedStringVectorData() )
-		self.assertEqual( s["out"].bound( "/" ), IECore.Box3f() )
-		self.assertEqual( s["out"].transform( "/" ), IECore.M44f() )
+		self.assertEqual( s["out"].bound( "/" ), imath.Box3f() )
+		self.assertEqual( s["out"].transform( "/" ), imath.M44f() )
 		self.assertEqual( s["out"].attributes( "/" ), IECore.CompoundObject() )
 		self.assertEqual( s["out"].object( "/" ), IECore.NullObject() )
 
@@ -225,8 +226,8 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 		s = IECoreScene.SceneCache( "/tmp/test.scc", IECore.IndexedIO.OpenMode.Write )
 		sphereGroup = s.createChild( "sphereGroup" )
-		sphereGroup.writeTransform( IECore.M44dData( IECore.M44d.createTranslated( IECore.V3d( 1, 0, 0 ) ) ), 0.0 )
-		sphereGroup.writeTransform( IECore.M44dData( IECore.M44d.createTranslated( IECore.V3d( 2, 0, 0 ) ) ), 1.0 )
+		sphereGroup.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ), 0.0 )
+		sphereGroup.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 2, 0, 0 ) ) ), 1.0 )
 		sphere = sphereGroup.createChild( "sphere" )
 		sphere.writeObject( IECoreScene.SpherePrimitive(), 0 )
 
@@ -250,15 +251,15 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		s = IECoreScene.SceneCache( "/tmp/test.scc", IECore.IndexedIO.OpenMode.Write )
 
 		movingGroup = s.createChild( "movingGroup" )
-		movingGroup.writeTransform( IECore.M44dData( IECore.M44d.createTranslated( IECore.V3d( 1, 0, 0 ) ) ), 0.0 )
-		movingGroup.writeTransform( IECore.M44dData( IECore.M44d.createTranslated( IECore.V3d( 2, 0, 0 ) ) ), 1.0 )
+		movingGroup.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ), 0.0 )
+		movingGroup.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 2, 0, 0 ) ) ), 1.0 )
 
 		deformingSphere = movingGroup.createChild( "deformingSphere" )
 		deformingSphere.writeObject( IECoreScene.SpherePrimitive(), 0 )
 		deformingSphere.writeObject( IECoreScene.SpherePrimitive( 2 ), 1 )
 
 		staticGroup = s.createChild( "staticGroup" )
-		staticGroup.writeTransform( IECore.M44dData( IECore.M44d.createTranslated( IECore.V3d( 1, 0, 0 ) ) ), 0.0 )
+		staticGroup.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ), 0.0 )
 
 		staticSphere = staticGroup.createChild( "staticSphere" )
 		staticSphere.writeObject( IECoreScene.SpherePrimitive(), 0 )
@@ -321,7 +322,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		planeGroup = s.createChild( "planeGroup" )
 		plane = planeGroup.createChild( "plane" )
 		plane.writeTags( [ "wood", "something" ] )
-		plane.writeObject( IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ), 0 )
+		plane.writeObject( IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ), 0 )
 
 		del s, sphereGroup, sphere, planeGroup, plane
 
@@ -366,7 +367,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		planeGroup = s.createChild( "planeGroup" )
 		plane = planeGroup.createChild( "plane" )
 		plane.writeTags( [ "wood", "something" ] )
-		plane.writeObject( IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ), 0 )
+		plane.writeObject( IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ), 0 )
 
 		del s, sphereGroup, sphere, planeGroup, plane
 
@@ -433,7 +434,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		planeGroup = s.createChild( "planeGroup" )
 		plane = planeGroup.createChild( "plane" )
 		plane.writeTags( [ "wood", "something" ] )
-		plane.writeObject( IECoreScene.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) ), 0 )
+		plane.writeObject( IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ), 0 )
 
 		del s, sphereGroup, sphere, planeGroup, plane
 

--- a/python/GafferSceneTest/SceneTestCase.py
+++ b/python/GafferSceneTest/SceneTestCase.py
@@ -37,6 +37,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -58,10 +59,10 @@ class SceneTestCase( GafferTest.TestCase ) :
 
 			o = scenePlug.object( scenePath, _copy = False )
 			if isinstance( o, IECoreScene.VisibleRenderable ) :
-				 if not thisBound.contains( o.bound() ) :
+				 if not IECore.BoxAlgo.contains( thisBound, o.bound() ) :
 					self.fail( "Bound %s does not contain object %s at %s" % ( thisBound, o.bound(), scenePath ) )
 
-			unionOfTransformedChildBounds = IECore.Box3f()
+			unionOfTransformedChildBounds = imath.Box3f()
 			childNames = scenePlug.childNames( scenePath, _copy = False )
 			for childName in childNames :
 
@@ -70,18 +71,18 @@ class SceneTestCase( GafferTest.TestCase ) :
 
 				childBound = scenePlug.bound( childPath )
 				childTransform = scenePlug.transform( childPath )
-				childBound = childBound.transform( childTransform )
+				childBound = childBound * childTransform
 
 				unionOfTransformedChildBounds.extendBy( childBound )
 
 				walkScene( childPath )
 
-			if not thisBound.contains( unionOfTransformedChildBounds ) :
+			if not IECore.BoxAlgo.contains( thisBound, unionOfTransformedChildBounds ) :
 				self.fail( "Bound ( %s ) does not contain children ( %s ) at %s" % ( thisBound, unionOfTransformedChildBounds, scenePath ) )
 
 		# check that the root doesn't have any properties it shouldn't
 		self.assertEqual( scenePlug.attributes( "/" ), IECore.CompoundObject() )
-		self.assertEqual( scenePlug.transform( "/" ), IECore.M44f() )
+		self.assertEqual( scenePlug.transform( "/" ), imath.M44f() )
 		self.assertEqual( scenePlug.object( "/" ), IECore.NullObject() )
 
 		# then walk the scene to check the bounds
@@ -266,8 +267,8 @@ class SceneTestCase( GafferTest.TestCase ) :
 	def assertBoxesAlmostEqual( self, box1, box2, places ) :
 
 		for n in "min", "max" :
-			v1 = getattr( box1, n )
-			v2 = getattr( box1, n )
+			v1 = getattr( box1, n )()
+			v2 = getattr( box1, n )()
 			for i in range( 0, 3 ) :
 				self.assertAlmostEqual( v1[i], v2[i], places )
 

--- a/python/GafferSceneTest/SceneTimeWarpTest.py
+++ b/python/GafferSceneTest/SceneTimeWarpTest.py
@@ -37,6 +37,7 @@
 
 import unittest
 import inspect
+import imath
 
 import IECore
 
@@ -101,19 +102,19 @@ class SceneTimeWarpTest( GafferSceneTest.SceneTestCase ) :
 		self.assertTrue( "in1" not in n )
 
 	def testTimeContext( self ) :
+
 		s = Gaffer.ScriptNode()
 
 		s["cube"] = GafferScene.Cube()
 
 		s["e"] = Gaffer.Expression()
-		s["e"].setExpression( 'parent["cube"]["dimensions"] = IECore.V3f( context["frame"] )' )
-		
-		
+		s["e"].setExpression( 'parent["cube"]["dimensions"] = imath.V3f( context["frame"] )' )
+
 		s["n"] = GafferScene.SceneTimeWarp()
 		s["n"]["in"].setInput( s["cube"]["out"] )
 		s["n"]["speed"].setValue( 0 )
 		s["n"]["offset"].setValue( 3 )
-		self.assertEqual( s["n"]["out"].bound( "/cube" ), IECore.Box3f( IECore.V3f( -1.5 ), IECore.V3f( 1.5 ) ) )
+		self.assertEqual( s["n"]["out"].bound( "/cube" ), imath.Box3f( imath.V3f( -1.5 ), imath.V3f( 1.5 ) ) )
 
 		s["e2"] = Gaffer.Expression()
 		s["e2"].setExpression( inspect.cleandoc(
@@ -122,8 +123,8 @@ class SceneTimeWarpTest( GafferSceneTest.SceneTestCase ) :
 			parent["n"]["offset"] = 5
 			"""
 		) )
-		
-		self.assertEqual( s["n"]["out"].bound( "/cube" ), IECore.Box3f( IECore.V3f( -2.5 ), IECore.V3f( 2.5 ) ) )
+
+		self.assertEqual( s["n"]["out"].bound( "/cube" ), imath.Box3f( imath.V3f( -2.5 ), imath.V3f( 2.5 ) ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/SceneWriterTest.py
+++ b/python/GafferSceneTest/SceneWriterTest.py
@@ -37,6 +37,7 @@
 import os
 import unittest
 import threading
+import imath
 
 import IECore
 import IECoreScene
@@ -71,7 +72,7 @@ class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 
 		t = sc.child( "group" )
 
-		self.assertEqual( t.readTransformAsMatrix( 0 ), IECore.M44d.createTranslated( IECore.V3d( 5, 0, 2 ) ) )
+		self.assertEqual( t.readTransformAsMatrix( 0 ), imath.M44d().translate( imath.V3d( 5, 0, 2 ) ) )
 
 	def testWriteAnimation( self ) :
 
@@ -93,23 +94,23 @@ class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 		sc = IECoreScene.SceneCache( self.temporaryDirectory() + "/test.scc", IECore.IndexedIO.OpenMode.Read )
 		t = sc.child( "group" )
 
-		self.assertEqual( t.readTransformAsMatrix( 0 ), IECore.M44d.createTranslated( IECore.V3d( 1, 0, 2 ) ) )
-		self.assertEqual( t.readTransformAsMatrix( 1 / 24.0 ), IECore.M44d.createTranslated( IECore.V3d( 1, 0, 2 ) ) )
-		self.assertEqual( t.readTransformAsMatrix( 1.5 / 24.0 ), IECore.M44d.createTranslated( IECore.V3d( 1.5, 0, 3 ) ) )
-		self.assertEqual( t.readTransformAsMatrix( 2 / 24.0 ), IECore.M44d.createTranslated( IECore.V3d( 2, 0, 4 ) ) )
+		self.assertEqual( t.readTransformAsMatrix( 0 ), imath.M44d().translate( imath.V3d( 1, 0, 2 ) ) )
+		self.assertEqual( t.readTransformAsMatrix( 1 / 24.0 ), imath.M44d().translate( imath.V3d( 1, 0, 2 ) ) )
+		self.assertEqual( t.readTransformAsMatrix( 1.5 / 24.0 ), imath.M44d().translate( imath.V3d( 1.5, 0, 3 ) ) )
+		self.assertEqual( t.readTransformAsMatrix( 2 / 24.0 ), imath.M44d().translate( imath.V3d( 2, 0, 4 ) ) )
 
 	def testSceneCacheRoundtrip( self ) :
 
 		scene = IECoreScene.SceneCache( self.temporaryDirectory() + "/fromPython.scc", IECore.IndexedIO.OpenMode.Write )
 		sc = scene.createChild( "a" )
-		sc.writeObject( IECoreScene.MeshPrimitive.createBox(IECore.Box3f(IECore.V3f(0),IECore.V3f(1))), 0 )
-		matrix = IECore.M44d.createTranslated( IECore.V3d( 1, 0, 0 ) ).rotate( IECore.V3d( 0, 0, IECore.degreesToRadians( -30 ) ) )
+		sc.writeObject( IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1))), 0 )
+		matrix = imath.M44d().translate( imath.V3d( 1, 0, 0 ) ).rotate( imath.V3d( 0, 0, IECore.degreesToRadians( -30 ) ) )
 		sc.writeTransform( IECore.M44dData( matrix ), 0 )
 		sc = sc.createChild( "b" )
-		sc.writeObject( IECoreScene.MeshPrimitive.createBox(IECore.Box3f(IECore.V3f(0),IECore.V3f(1))), 0 )
+		sc.writeObject( IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1))), 0 )
 		sc.writeTransform( IECore.M44dData( matrix ), 0 )
 		sc = sc.createChild( "c" )
-		sc.writeObject( IECoreScene.MeshPrimitive.createBox(IECore.Box3f(IECore.V3f(0),IECore.V3f(1))), 0 )
+		sc.writeObject( IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1))), 0 )
 		sc.writeTransform( IECore.M44dData( matrix ), 0 )
 
 		del scene, sc

--- a/python/GafferSceneTest/ShaderSwitchTest.py
+++ b/python/GafferSceneTest/ShaderSwitchTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -107,8 +108,8 @@ class ShaderSwitchTest( GafferSceneTest.SceneTestCase ) :
 		shader1 = GafferSceneTest.TestShader()
 		shader2 = GafferSceneTest.TestShader()
 
-		shader1["parameters"]["c"].setValue( IECore.Color3f( 0 ) )
-		shader2["parameters"]["c"].setValue( IECore.Color3f( 1 ) )
+		shader1["parameters"]["c"].setValue( imath.Color3f( 0 ) )
+		shader2["parameters"]["c"].setValue( imath.Color3f( 1 ) )
 
 		switch = GafferScene.ShaderSwitch()
 		switch.setup( shader1["parameters"]["c"] )
@@ -126,7 +127,7 @@ class ShaderSwitchTest( GafferSceneTest.SceneTestCase ) :
 			network = shader3.attributes()["test:surface"]
 
 			self.assertEqual( len( network ), 2 )
-			self.assertEqual( network[0].parameters["c"].value, IECore.Color3f( i ) )
+			self.assertEqual( network[0].parameters["c"].value, imath.Color3f( i ) )
 
 	def testContextSensitiveIndex( self ) :
 

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -106,7 +107,7 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 
 		cs = GafferTest.CapturingSlot( s.plugDirtiedSignal() )
 
-		Gaffer.Metadata.registerValue( s, "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
+		Gaffer.Metadata.registerValue( s, "nodeGadget:color", imath.Color3f( 1, 0, 0 ) )
 
 		self.assertTrue( s["out"] in [ x[0] for x in cs ] )
 
@@ -115,8 +116,8 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 		s2 = s.attributes()["test:surface"]
 		self.assertNotEqual( s2, s1 )
 
-		self.assertEqual( s1[0].blindData()["gaffer:nodeColor"], IECore.Color3fData( IECore.Color3f( 0 ) ) )
-		self.assertEqual( s2[0].blindData()["gaffer:nodeColor"], IECore.Color3fData( IECore.Color3f( 1, 0, 0 ) ) )
+		self.assertEqual( s1[0].blindData()["gaffer:nodeColor"], IECore.Color3fData( imath.Color3f( 0 ) ) )
+		self.assertEqual( s2[0].blindData()["gaffer:nodeColor"], IECore.Color3fData( imath.Color3f( 1, 0, 0 ) ) )
 
 	def testShaderTypesInAttributes( self ) :
 

--- a/python/GafferSceneTest/SphereTest.py
+++ b/python/GafferSceneTest/SphereTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -57,13 +58,13 @@ class SphereTest( GafferSceneTest.SceneTestCase ) :
 		s["type"].setValue( GafferScene.Sphere.Type.Primitive )
 
 		self.assertEqual( s["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( s["out"].transform( "/" ), IECore.M44f() )
-		self.assertEqual( s["out"].bound( "/" ), IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ) )
+		self.assertEqual( s["out"].transform( "/" ), imath.M44f() )
+		self.assertEqual( s["out"].bound( "/" ), imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
 		self.assertEqual( s["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "sphere" ] ) )
 
 		self.assertEqual( s["out"].object( "/sphere" ), IECoreScene.SpherePrimitive( 1 ) )
-		self.assertEqual( s["out"].transform( "/sphere" ), IECore.M44f() )
-		self.assertEqual( s["out"].bound( "/sphere" ), IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ) )
+		self.assertEqual( s["out"].transform( "/sphere" ), imath.M44f() )
+		self.assertEqual( s["out"].bound( "/sphere" ), imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
 		self.assertEqual( s["out"].childNames( "/sphere" ), IECore.InternedStringVectorData() )
 
 	def testMesh( self ) :
@@ -99,8 +100,8 @@ class SphereTest( GafferSceneTest.SceneTestCase ) :
 		self.assertNotEqual( s["out"].objectHash( "/sphere" ), h )
 		h = s["out"].objectHash( "/sphere" )
 
-		s["divisions"].setValue( IECore.V2i( 5, 10 ) )
-		m = IECoreScene.MeshPrimitive.createSphere( 3, -0.75, 0.75, 300, IECore.V2i( 5, 10 ) )
+		s["divisions"].setValue( imath.V2i( 5, 10 ) )
+		m = IECoreScene.MeshPrimitive.createSphere( 3, -0.75, 0.75, 300, imath.V2i( 5, 10 ) )
 		self.assertEqual( s["out"].object( "/sphere" ), m )
 		self.assertNotEqual( s["out"].objectHash( "/sphere" ), h )
 
@@ -136,7 +137,7 @@ class SphereTest( GafferSceneTest.SceneTestCase ) :
 		self.assertNotEqual( s["out"].objectHash( "/sphere" ), h )
 		h = s["out"].objectHash( "/sphere" )
 
-		s["divisions"].setValue( IECore.V2i( 5, 10 ) )
+		s["divisions"].setValue( imath.V2i( 5, 10 ) )
 		# divisions don't affect SpherePrimitives
 		self.assertEqual( s["out"].object( "/sphere" ), m )
 		# divisions do affect the hash, since we don't check the value of type
@@ -168,13 +169,13 @@ class SphereTest( GafferSceneTest.SceneTestCase ) :
 
 		s = GafferScene.Sphere()
 		s["type"].setValue( GafferScene.Sphere.Type.Primitive )
-		s["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+		s["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 
-		self.assertEqual( s["out"].transform( "/" ), IECore.M44f() )
-		self.assertEqual( s["out"].transform( "/sphere" ), IECore.M44f.createTranslated( IECore.V3f( 1, 0, 0 ) ) )
+		self.assertEqual( s["out"].transform( "/" ), imath.M44f() )
+		self.assertEqual( s["out"].transform( "/sphere" ), imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) )
 
-		self.assertEqual( s["out"].bound( "/" ), IECore.Box3f( IECore.V3f( 0, -1, -1 ), IECore.V3f( 2, 1, 1 ) ) )
-		self.assertEqual( s["out"].bound( "/sphere" ), IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ) )
+		self.assertEqual( s["out"].bound( "/" ), imath.Box3f( imath.V3f( 0, -1, -1 ), imath.V3f( 2, 1, 1 ) ) )
+		self.assertEqual( s["out"].bound( "/sphere" ), imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
 
 	def testEnabled( self ) :
 

--- a/python/GafferSceneTest/StandardOptionsTest.py
+++ b/python/GafferSceneTest/StandardOptionsTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -60,12 +62,12 @@ class StandardOptionsTest( GafferSceneTest.SceneTestCase ) :
 
 		o = GafferScene.StandardOptions()
 
-		o["options"]["renderResolution"]["value"].setValue( IECore.V2i( 10 ) )
+		o["options"]["renderResolution"]["value"].setValue( imath.V2i( 10 ) )
 		o["options"]["renderResolution"]["enabled"].setValue( True )
-		self.assertEqual( o["out"]["globals"].getValue()["option:render:resolution"].value, IECore.V2i( 10 ) )
+		self.assertEqual( o["out"]["globals"].getValue()["option:render:resolution"].value, imath.V2i( 10 ) )
 
-		o["options"]["renderResolution"]["value"].setValue( IECore.V2i( 20 ) )
-		self.assertEqual( o["out"]["globals"].getValue()["option:render:resolution"].value, IECore.V2i( 20 ) )
+		o["options"]["renderResolution"]["value"].setValue( imath.V2i( 20 ) )
+		self.assertEqual( o["out"]["globals"].getValue()["option:render:resolution"].value, imath.V2i( 20 ) )
 
 	def testHashIncludesInputHash( self ) :
 
@@ -76,7 +78,7 @@ class StandardOptionsTest( GafferSceneTest.SceneTestCase ) :
 		h = o2["out"]["globals"].hash()
 
 		o1["options"]["renderResolution"]["enabled"].setValue( True )
-		o1["options"]["renderResolution"]["value"].setValue( IECore.V2i( 10 ) )
+		o1["options"]["renderResolution"]["value"].setValue( imath.V2i( 10 ) )
 
 		self.assertNotEqual( o2["out"]["globals"].hash(), h )
 

--- a/python/GafferSceneTest/SubTreeTest.py
+++ b/python/GafferSceneTest/SubTreeTest.py
@@ -250,7 +250,7 @@ class SubTreeTest( GafferSceneTest.SceneTestCase ) :
 			c.setFrame( 10 )
 
 			expectedRootBound = a["out"].bound( "/pCube1" )
-			expectedRootBound = expectedRootBound.transform( a["out"].transform( "/pCube1" ) )
+			expectedRootBound = expectedRootBound * a["out"].transform( "/pCube1" )
 
 			self.assertEqual( s["out"].bound( "/" ), expectedRootBound )
 

--- a/python/GafferSceneTest/TextTest.py
+++ b/python/GafferSceneTest/TextTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -58,7 +59,7 @@ class TextTest( GafferSceneTest.SceneTestCase ) :
  		t = GafferScene.Text()
 
 		self.assertEqual( t["out"].object( "/" ), IECore.NullObject() )
-		self.assertEqual( t["out"].transform( "/" ), IECore.M44f() )
+		self.assertEqual( t["out"].transform( "/" ), imath.M44f() )
 		self.assertEqual( t["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "text" ] ) )
 
 		m1 = t["out"].object( "/text" )

--- a/python/GafferSceneTest/TransformTest.py
+++ b/python/GafferSceneTest/TransformTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import math
+import imath
 
 import IECore
 import IECoreScene
@@ -82,7 +83,7 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 		# it requires a filter before operating (applying the same transform
 		# at every location is really not very useful).
 
-		transform["transform"]["translate"].setValue( IECore.V3f( 1, 2, 3 ) )
+		transform["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
 
 		self.assertSceneValid( transform["out"] )
 		self.assertScenesEqual( transform["out"], input["out"] )
@@ -95,12 +96,12 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertSceneValid( transform["out"] )
 
-		self.assertEqual( transform["out"].transform( "/group/sphere" ), IECore.M44f.createTranslated( IECore.V3f( 1, 2, 3 ) ) )
-		self.assertEqual( transform["out"].transform( "/group" ), IECore.M44f() )
+		self.assertEqual( transform["out"].transform( "/group/sphere" ), imath.M44f().translate( imath.V3f( 1, 2, 3 ) ) )
+		self.assertEqual( transform["out"].transform( "/group" ), imath.M44f() )
 
-		self.assertEqual( transform["out"].bound( "/group/sphere" ), IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ) )
-		self.assertEqual( transform["out"].bound( "/group" ), IECore.Box3f( IECore.V3f( 0, 1, 2 ), IECore.V3f( 2, 3, 4 ) ) )
-		self.assertEqual( transform["out"].bound( "/" ), IECore.Box3f( IECore.V3f( 0, 1, 2 ), IECore.V3f( 2, 3, 4 ) ) )
+		self.assertEqual( transform["out"].bound( "/group/sphere" ), imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
+		self.assertEqual( transform["out"].bound( "/group" ), imath.Box3f( imath.V3f( 0, 1, 2 ), imath.V3f( 2, 3, 4 ) ) )
+		self.assertEqual( transform["out"].bound( "/" ), imath.Box3f( imath.V3f( 0, 1, 2 ), imath.V3f( 2, 3, 4 ) ) )
 
 	def testEnableBehaviour( self ) :
 
@@ -113,7 +114,7 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 	def testSpace( self ) :
 
 		sphere = GafferScene.Sphere()
-		sphere["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+		sphere["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 
 		transform = GafferScene.Transform()
 		transform["in"].setInput( sphere["out"] )
@@ -128,24 +129,24 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 		self.assertSceneValid( transform["out"] )
 
 		self.assertTrue(
-			IECore.V3f( 1, 0, 0 ).equalWithAbsError(
-				IECore.V3f( 0 ) * transform["out"].fullTransform( "/sphere" ),
+			imath.V3f( 1, 0, 0 ).equalWithAbsError(
+				imath.V3f( 0 ) * transform["out"].fullTransform( "/sphere" ),
 				0.000001
 			)
 		)
 
 		transform["space"].setValue( GafferScene.Transform.Space.Parent )
 		self.assertTrue(
-			IECore.V3f( 0, 0, -1 ).equalWithAbsError(
-				IECore.V3f( 0 ) * transform["out"].fullTransform( "/sphere" ),
+			imath.V3f( 0, 0, -1 ).equalWithAbsError(
+				imath.V3f( 0 ) * transform["out"].fullTransform( "/sphere" ),
 				0.000001
 			)
 		)
 
 		transform["space"].setValue( GafferScene.Transform.Space.World )
 		self.assertTrue(
-			IECore.V3f( 0, 0, -1 ).equalWithAbsError(
-				IECore.V3f( 0 ) * transform["out"].fullTransform( "/sphere" ),
+			imath.V3f( 0, 0, -1 ).equalWithAbsError(
+				imath.V3f( 0 ) * transform["out"].fullTransform( "/sphere" ),
 				0.000001
 			)
 		)
@@ -156,7 +157,7 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 
 		group = GafferScene.Group()
 		group["in"][0].setInput( sphere["out"] )
-		group["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+		group["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 
 		transform = GafferScene.Transform()
 		transform["in"].setInput( group["out"] )
@@ -168,8 +169,8 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( transform["space"].getValue(), GafferScene.Transform.Space.Local )
 		self.assertSceneValid( transform["out"] )
 		self.assertTrue(
-			IECore.V3f( 1, 0, 0 ).equalWithAbsError(
-				IECore.V3f( 0 ) * transform["out"].fullTransform( "/group/sphere" ),
+			imath.V3f( 1, 0, 0 ).equalWithAbsError(
+				imath.V3f( 0 ) * transform["out"].fullTransform( "/group/sphere" ),
 				0.000001
 			)
 		)
@@ -177,8 +178,8 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 		transform["space"].setValue( GafferScene.Transform.Space.Parent )
 		self.assertSceneValid( transform["out"] )
 		self.assertTrue(
-			IECore.V3f( 1, 0, 0 ).equalWithAbsError(
-				IECore.V3f( 0 ) * transform["out"].fullTransform( "/group/sphere" ),
+			imath.V3f( 1, 0, 0 ).equalWithAbsError(
+				imath.V3f( 0 ) * transform["out"].fullTransform( "/group/sphere" ),
 				0.000001
 			)
 		)
@@ -186,8 +187,8 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 		transform["space"].setValue( GafferScene.Transform.Space.World )
 		transform["transform"]["rotate"]["y"].setValue( 90 )
 		self.assertTrue(
-			IECore.V3f( 0, 0, -1 ).equalWithAbsError(
-				IECore.V3f( 0 ) * transform["out"].fullTransform( "/group/sphere" ),
+			imath.V3f( 0, 0, -1 ).equalWithAbsError(
+				imath.V3f( 0 ) * transform["out"].fullTransform( "/group/sphere" ),
 				0.000001
 			)
 		)
@@ -195,11 +196,11 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 	def testResetLocal( self ) :
 
 		sphere = GafferScene.Sphere()
-		sphere["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+		sphere["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 
 		group = GafferScene.Group()
 		group["in"][0].setInput( sphere["out"] )
-		group["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+		group["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 
 		transform = GafferScene.Transform()
 		transform["in"].setInput( group["out"] )
@@ -212,30 +213,30 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 		transform["space"].setValue( GafferScene.Transform.Space.ResetLocal )
 		self.assertSceneValid( transform["out"] )
 		self.assertTrue(
-			IECore.V3f( 1, 0, 0 ).equalWithAbsError(
-				IECore.V3f( 0 ) * transform["out"].fullTransform( "/group/sphere" ),
+			imath.V3f( 1, 0, 0 ).equalWithAbsError(
+				imath.V3f( 0 ) * transform["out"].fullTransform( "/group/sphere" ),
 				0.000001
 			)
 		)
 		self.assertTrue(
-			IECore.V3f( 2, 0, 0 ).equalWithAbsError(
-				IECore.V3f( 0, 0, 1 ) * transform["out"].fullTransform( "/group/sphere" ),
+			imath.V3f( 2, 0, 0 ).equalWithAbsError(
+				imath.V3f( 0, 0, 1 ) * transform["out"].fullTransform( "/group/sphere" ),
 				0.000001
 			)
 		)
 		self.assertEqual(
 			transform["out"].transform( "/group/sphere" ),
-			IECore.M44f.createRotated( IECore.V3f( 0, math.radians( 90 ), 0 ) )
+			imath.M44f().rotate( imath.V3f( 0, math.radians( 90 ), 0 ) )
 		)
 
 	def testResetWorld( self ) :
 
 		sphere = GafferScene.Sphere()
-		sphere["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+		sphere["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 
 		group = GafferScene.Group()
 		group["in"][0].setInput( sphere["out"] )
-		group["transform"]["translate"].setValue( IECore.V3f( 1, 0, 0 ) )
+		group["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 
 		transform = GafferScene.Transform()
 		transform["in"].setInput( group["out"] )
@@ -248,20 +249,20 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 		transform["space"].setValue( GafferScene.Transform.Space.ResetWorld )
 		self.assertSceneValid( transform["out"] )
 		self.assertTrue(
-			IECore.V3f( 0, 0, 0 ).equalWithAbsError(
-				IECore.V3f( 0 ) * transform["out"].fullTransform( "/group/sphere" ),
+			imath.V3f( 0, 0, 0 ).equalWithAbsError(
+				imath.V3f( 0 ) * transform["out"].fullTransform( "/group/sphere" ),
 				0.000001
 			)
 		)
 		self.assertTrue(
-			IECore.V3f( 1, 0, 0 ).equalWithAbsError(
-				IECore.V3f( 0, 0, 1 ) * transform["out"].fullTransform( "/group/sphere" ),
+			imath.V3f( 1, 0, 0 ).equalWithAbsError(
+				imath.V3f( 0, 0, 1 ) * transform["out"].fullTransform( "/group/sphere" ),
 				0.000001
 			)
 		)
 		self.assertEqual(
 			transform["out"].fullTransform( "/group/sphere" ),
-			IECore.M44f.createRotated( IECore.V3f( 0, math.radians( 90 ), 0 ) )
+			imath.M44f().rotate( imath.V3f( 0, math.radians( 90 ), 0 ) )
 		)
 
 	def testWorldWithMatchingAncestors( self ) :
@@ -275,7 +276,7 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 
 		t = GafferScene.Transform()
 		t["in"].setInput( b["out"] )
-		t["transform"]["translate"].setValue( IECore.V3f( 1, 2, 3 ) )
+		t["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
 		t["space"].setValue( t.Space.World )
 
 		f = GafferScene.PathFilter()
@@ -285,7 +286,7 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 		self.assertSceneValid( t["out"] )
 		self.assertEqual(
 			t["out"].fullTransform( "/a" ),
-			IECore.M44f.createTranslated( IECore.V3f( 1, 2, 3 ) )
+			imath.M44f().translate( imath.V3f( 1, 2, 3 ) )
 		)
 
 		# We want it to be as if /a/b has been transformed
@@ -294,14 +295,14 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual(
 			t["out"].fullTransform( "/a/b" ),
-			IECore.M44f.createTranslated( IECore.V3f( 1, 2, 3 ) )
+			imath.M44f().translate( imath.V3f( 1, 2, 3 ) )
 		)
 
-		b["transform"]["translate"].setValue( IECore.V3f( 4, 5, 6 ) )
+		b["transform"]["translate"].setValue( imath.V3f( 4, 5, 6 ) )
 		self.assertSceneValid( t["out"] )
 		self.assertEqual(
 			t["out"].fullTransform( "/a/b" ),
-			IECore.M44f.createTranslated( IECore.V3f( 5, 7, 9 ) )
+			imath.M44f().translate( imath.V3f( 5, 7, 9 ) )
 		)
 
 	def testResetWorldWithMatchingAncestors( self ) :
@@ -319,7 +320,7 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 
 		t = GafferScene.Transform()
 		t["in"].setInput( a["out"] )
-		t["transform"]["translate"].setValue( IECore.V3f( 1, 2, 3 ) )
+		t["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
 		t["space"].setValue( t.Space.ResetWorld )
 
 		# Apply to /a and /a/b/c so that we must take into
@@ -337,40 +338,40 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual(
 			t["out"].fullTransform( "/a" ),
-			IECore.M44f.createTranslated( IECore.V3f( 1, 2, 3 ) )
+			imath.M44f().translate( imath.V3f( 1, 2, 3 ) )
 		)
 
 		self.assertEqual(
 			t["out"].fullTransform( "/a/b" ),
-			IECore.M44f.createTranslated( IECore.V3f( 1, 2, 3 ) )
+			imath.M44f().translate( imath.V3f( 1, 2, 3 ) )
 		)
 
 		self.assertEqual(
 			t["out"].fullTransform( "/a/b/c" ),
-			IECore.M44f.createTranslated( IECore.V3f( 1, 2, 3 ) )
+			imath.M44f().translate( imath.V3f( 1, 2, 3 ) )
 		)
 
 		# Change the transform on /a/b, and check that it is
 		# retained, but that /a/b/c adjusts for it and maintains
 		# the required absolute transform.
 
-		b["transform"]["translate"].setValue( IECore.V3f( 9, 7, 5 ) )
+		b["transform"]["translate"].setValue( imath.V3f( 9, 7, 5 ) )
 
 		self.assertSceneValid( t["out"] )
 
 		self.assertEqual(
 			t["out"].fullTransform( "/a" ),
-			IECore.M44f.createTranslated( IECore.V3f( 1, 2, 3 ) )
+			imath.M44f().translate( imath.V3f( 1, 2, 3 ) )
 		)
 
 		self.assertEqual(
 			t["out"].fullTransform( "/a/b" ),
-			IECore.M44f.createTranslated( IECore.V3f( 10, 9, 8 ) )
+			imath.M44f().translate( imath.V3f( 10, 9, 8 ) )
 		)
 
 		self.assertEqual(
 			t["out"].fullTransform( "/a/b/c" ),
-			IECore.M44f.createTranslated( IECore.V3f( 1, 2, 3 ) )
+			imath.M44f().translate( imath.V3f( 1, 2, 3 ) )
 		)
 
 	def testObjectBoundIncludedWhenDescendantsMatch( self ) :
@@ -383,10 +384,10 @@ class TransformTest( GafferSceneTest.SceneTestCase ) :
 		t = GafferScene.Transform()
 		t["in"].setInput( s["out"] )
 		t["filter"].setInput( f["out"] )
-		t["transform"]["translate"].setValue( IECore.V3f( 1 ) )
+		t["transform"]["translate"].setValue( imath.V3f( 1 ) )
 
 		self.assertSceneValid( t["out"] )
-		self.assertEqual( t["out"].bound( "/" ), IECore.Box3f( IECore.V3f( 0.5 ), IECore.V3f( 1.5 ) ) )
+		self.assertEqual( t["out"].bound( "/" ), imath.Box3f( imath.V3f( 0.5 ), imath.V3f( 1.5 ) ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/FilterPlugValueWidget.py
+++ b/python/GafferSceneUI/FilterPlugValueWidget.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -63,7 +65,7 @@ class FilterPlugValueWidget( GafferUI.PlugValueWidget ) :
 				self.__menuButton = GafferUI.MenuButton()
 				self.__menuButton.setMenu( GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ) )
 
-				GafferUI.Spacer( IECore.V2i( 1 ), IECore.V2i( 100000, 1 ), parenting = { "expand" : True } )
+				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 100000, 1 ), parenting = { "expand" : True } )
 
 			GafferUI.Divider()
 

--- a/python/GafferSceneUI/LightTweaksUI.py
+++ b/python/GafferSceneUI/LightTweaksUI.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import functools
+import imath
 
 import IECore
 import IECoreScene
@@ -216,7 +217,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 
 		with row :
 
-				GafferUI.Spacer( IECore.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
+				GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 
 				GafferUI.MenuButton(
 					image = "plus.png",
@@ -224,7 +225,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
 				)
 
-				GafferUI.Spacer( IECore.V2i( 1 ), IECore.V2i( 999999, 1 ), parenting = { "expand" : True } )
+				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
 	def _updateFromPlug( self ) :
 

--- a/python/GafferSceneUI/OutputsUI.py
+++ b/python/GafferSceneUI/OutputsUI.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import re
+import imath
 
 import IECore
 import IECoreScene
@@ -132,7 +133,7 @@ class OutputsPlugValueWidget( GafferUI.PlugValueWidget ) :
 					image="plus.png", hasFrame=False, menu = GafferUI.Menu( Gaffer.WeakMethod( self.__addMenuDefinition ) )
 				)
 
-				GafferUI.Spacer( IECore.V2i( 1 ), maximumSize = IECore.V2i( 100000, 1 ), parenting = { "expand" : True } )
+				GafferUI.Spacer( imath.V2i( 1 ), maximumSize = imath.V2i( 100000, 1 ), parenting = { "expand" : True } )
 
 	def hasLabel( self ) :
 
@@ -187,7 +188,7 @@ class _ChildPlugWidget( GafferUI.PlugValueWidget ) :
 				GafferUI.PlugValueWidget.create( childPlug["active"] )
 				self.__label = GafferUI.Label( self.__namePlug().getValue() )
 
-				GafferUI.Spacer( IECore.V2i( 1 ), maximumSize = IECore.V2i( 100000, 1 ), parenting = { "expand" : True } )
+				GafferUI.Spacer( imath.V2i( 1 ), maximumSize = imath.V2i( 100000, 1 ), parenting = { "expand" : True } )
 
 				self.__deleteButton = GafferUI.Button( image = "delete.png", hasFrame=False )
 				self.__deleteButton.__clickedConnection = self.__deleteButton.clickedSignal().connect( Gaffer.WeakMethod( self.__deleteButtonClicked ) )

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import types
+import imath
 
 import IECore
 
@@ -99,9 +100,9 @@ Gaffer.Metadata.registerNode(
 # NodeGadget drop handler
 ##########################################################################
 
-GafferUI.Pointer.registerPointer( "addObjects", GafferUI.Pointer( "addObjects.png", IECore.V2i( 36, 18 ) ) )
-GafferUI.Pointer.registerPointer( "removeObjects", GafferUI.Pointer( "removeObjects.png", IECore.V2i( 36, 18 ) ) )
-GafferUI.Pointer.registerPointer( "replaceObjects", GafferUI.Pointer( "replaceObjects.png", IECore.V2i( 36, 18 ) ) )
+GafferUI.Pointer.registerPointer( "addObjects", GafferUI.Pointer( "addObjects.png", imath.V2i( 36, 18 ) ) )
+GafferUI.Pointer.registerPointer( "removeObjects", GafferUI.Pointer( "removeObjects.png", imath.V2i( 36, 18 ) ) )
+GafferUI.Pointer.registerPointer( "replaceObjects", GafferUI.Pointer( "replaceObjects.png", imath.V2i( 36, 18 ) ) )
 
 __DropMode = IECore.Enum.create( "None", "Add", "Remove", "Replace" )
 

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -41,6 +41,7 @@ import difflib
 import itertools
 import collections
 import functools
+import imath
 
 import IECore
 import IECoreScene
@@ -160,7 +161,7 @@ class SceneInspector( GafferUI.NodeSetEditor ) :
 				mainColumn.append( section )
 				self.__sections.append( section )
 
-			mainColumn.append( GafferUI.Spacer( IECore.V2i( 0 ) ), expand = True )
+			mainColumn.append( GafferUI.Spacer( imath.V2i( 0 ) ), expand = True )
 
 		else :
 
@@ -182,7 +183,7 @@ class SceneInspector( GafferUI.NodeSetEditor ) :
 
 			for tab, column in columns.items() :
 				if tab is not None :
-					column.append( GafferUI.Spacer( IECore.V2i( 0 ) ), expand = True )
+					column.append( GafferUI.Spacer( imath.V2i( 0 ) ), expand = True )
 
 		self.__targetPaths = None
 		self._updateFromSet()
@@ -465,11 +466,11 @@ class TextDiff( SideBySideDiff ) :
 			return self.__formatValues( [ values[0] ] ) + self.__formatValues( [ values[1] ] )
 		elif isinstance( values[0], IECore.Data ) and hasattr( values[0], "value" ) :
 			return self.__formatValues( [ v.value for v in values ] )
-		elif isinstance( values[0], ( IECore.V3f, IECore.V3i, IECore.V2f, IECore.V2i ) ) :
+		elif isinstance( values[0], ( imath.V3f, imath.V3i, imath.V2f, imath.V2i ) ) :
 			return self.__formatVectors( values )
-		elif isinstance( values[0], ( IECore.M44f, IECore.M44d ) ) :
+		elif isinstance( values[0], ( imath.M44f, imath.M44d ) ) :
 			return self.__formatMatrices( values )
-		elif isinstance( values[0], ( IECore.Box3f, IECore.Box3d, IECore.Box3i, IECore.Box2f, IECore.Box2d, IECore.Box2i ) ) :
+		elif isinstance( values[0], ( imath.Box3f, imath.Box3d, imath.Box3i, imath.Box2f, imath.Box2d, imath.Box2i ) ) :
 			return self.__formatBoxes( values )
 		elif isinstance( values[0], ( IECoreScene.Shader, IECore.ObjectVector ) ) :
 			return self.__formatShaders( values )
@@ -492,8 +493,8 @@ class TextDiff( SideBySideDiff ) :
 		arrays = []
 		for matrix in matrices :
 			array = []
-			for i in range( 0, matrix.dimensions()[0] ) :
-				array.append( [ matrix[i,j] for j in range( 0, matrix.dimensions()[1] ) ] )
+			for i in range( 0, len( matrix ) ) :
+				array.append( [ matrix[i][j] for j in range( 0, len( matrix[i] ) ) ] )
 			arrays.append( array )
 
 		return self.__formatNumberArrays( arrays )
@@ -506,7 +507,7 @@ class TextDiff( SideBySideDiff ) :
 
 		arrays = []
 		for box in boxes :
-			arrays.append( [ box.min, box.max ] )
+			arrays.append( [ box.min(), box.max() ] )
 
 		return self.__formatNumberArrays( arrays )
 
@@ -787,7 +788,7 @@ class DiffRow( Row ) :
 					diffWidget.contextMenuSignal().connect( Gaffer.WeakMethod( self.__contextMenu ) ),
 				] )
 
-			GafferUI.Spacer( IECore.V2i( 1, 20 ), parenting = { "expand" : True } )
+			GafferUI.Spacer( imath.V2i( 1, 20 ), parenting = { "expand" : True } )
 
 			GafferUI.MenuButton(
 				image = "gear.png",
@@ -1134,7 +1135,7 @@ class _Rail( GafferUI.ListContainer ) :
 				image._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Preferred )
 				image._qtWidget().setScaledContents( True )
 			else :
-				GafferUI.Spacer( IECore.V2i( 1 ) )
+				GafferUI.Spacer( imath.V2i( 1 ) )
 
 			GafferUI.Image( "rail" + str( type ) + ".png" )
 
@@ -1143,7 +1144,7 @@ class _Rail( GafferUI.ListContainer ) :
 				image._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Preferred )
 				image._qtWidget().setScaledContents( True )
 			else :
-				GafferUI.Spacer( IECore.V2i( 1 ) )
+				GafferUI.Spacer( imath.V2i( 1 ) )
 
 class _InheritanceSection( Section ) :
 
@@ -1200,7 +1201,7 @@ class _InheritanceSection( Section ) :
 					else :
 						GafferUI.Label( "..." )
 
-					GafferUI.Spacer( IECore.V2i( 0 ), parenting = { "expand" : True } )
+					GafferUI.Spacer( imath.V2i( 0 ), parenting = { "expand" : True } )
 
 					if atEitherEnd or value is not None :
 						diff = self.__diffCreator()
@@ -1281,7 +1282,7 @@ class _HistorySection( Section ) :
 				else :
 					GafferUI.Label( "..." )
 
-				GafferUI.Spacer( IECore.V2i( 0 ), parenting = { "expand" : True } )
+				GafferUI.Spacer( imath.V2i( 0 ), parenting = { "expand" : True } )
 
 				values = [ history[i-1].value if i > 0 else None, history[i].value ]
 
@@ -1343,7 +1344,7 @@ class __NodeSection( Section ) :
 					label._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed )
 					self.__diff.setValueWidget( i, label )
 
-				GafferUI.Spacer( IECore.V2i( 0 ), parenting = { "expand" : True } )
+				GafferUI.Spacer( imath.V2i( 0 ), parenting = { "expand" : True } )
 
 	def update( self, targets ) :
 
@@ -1394,7 +1395,7 @@ class __PathSection( LocationSection ) :
 
 				self.__diff = TextDiff( highlightDiffs = False )
 
-				GafferUI.Spacer( IECore.V2i( 0 ), parenting = { "expand" : True } )
+				GafferUI.Spacer( imath.V2i( 0 ), parenting = { "expand" : True } )
 
 	def update( self, targets ) :
 
@@ -1547,8 +1548,7 @@ class __BoundSection( LocationSection ) :
 
 			bound = target.bound()
 			if self.__world :
-				transform = target.fullTransform()
-				bound = bound.transform( transform )
+				bound = bound * target.fullTransform()
 
 			return bound
 
@@ -1987,7 +1987,7 @@ class _OutputRow( Row ) :
 					collapseButton = GafferUI.Button( image = "collapsibleArrowRight.png", hasFrame=False )
 					collapseButton.__clickedConnection = collapseButton.clickedSignal().connect( Gaffer.WeakMethod( self.__collapseButtonClicked ) )
 					self.__label = TextDiff()
-					GafferUI.Spacer( IECore.V2i( 1 ), parenting = { "expand" : True } )
+					GafferUI.Spacer( imath.V2i( 1 ), parenting = { "expand" : True } )
 
 				self.__diffColumn = DiffColumn( self.__Inspector( name ) )
 				self.__diffColumn.setVisible( False )

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -39,6 +39,7 @@ import re
 import string
 import fnmatch
 import functools
+import imath
 
 import IECore
 
@@ -175,7 +176,7 @@ class _ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 			self.__label = GafferUI.Label( "" )
 
-			GafferUI.Spacer( IECore.V2i( 1 ), parenting = { "expand" : True } )
+			GafferUI.Spacer( imath.V2i( 1 ), parenting = { "expand" : True } )
 
 			self.__button = GafferUI.Button( "Reload" )
 			self.__buttonClickedConnection = self.__button.clickedSignal().connect( Gaffer.WeakMethod( self.__buttonClicked ) )

--- a/python/GafferSceneUI/ShaderViewUI.py
+++ b/python/GafferSceneUI/ShaderViewUI.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import functools
+import imath
 
 import IECore
 
@@ -127,7 +128,7 @@ class _SettingsWindow( GafferUI.Window ) :
 		with self :
 			with GafferUI.ListContainer() :
 				self.__frame = GafferUI.Frame( borderStyle = GafferUI.Frame.BorderStyle.None, borderWidth = 4 )
-				GafferUI.Spacer( IECore.V2i( 0 ), parenting = { "expand" : True } )
+				GafferUI.Spacer( imath.V2i( 0 ), parenting = { "expand" : True } )
 
 		self.__shaderView = shaderView
 		self.__sceneChangedConnection = shaderView.sceneChangedSignal().connect( Gaffer.WeakMethod( self.__sceneChanged ) )

--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -61,7 +61,7 @@ def __cameraSummary( plug ) :
 		info.append( "Mult %s" % GafferUI.NumericWidget.valueToString( resolutionMultiplier ) )
 	if plug["renderCropWindow"]["enabled"].getValue() :
 		crop = plug["renderCropWindow"]["value"].getValue()
-		info.append( "Crop %s,%s-%s,%s" % tuple( GafferUI.NumericWidget.valueToString( x ) for x in ( crop.min.x, crop.min.y, crop.max.x, crop.max.y ) ) )
+		info.append( "Crop %s,%s-%s,%s" % tuple( GafferUI.NumericWidget.valueToString( x ) for x in ( crop.min().x, crop.min().y, crop.max().x, crop.max().y ) ) )
 	if plug["overscan"]["enabled"].getValue() :
 		info.append( "Overscan %s" % ( "On" if plug["overscan"]["value"].getValue() else "Off" ) )
 

--- a/python/GafferSceneUITest/RotateToolTest.py
+++ b/python/GafferSceneUITest/RotateToolTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -87,14 +89,14 @@ class RotateToolTest( GafferUITest.TestCase ) :
 		# the Y axis in world space, and the local Y axis onto the world
 		# Z axis.
 		self.assertTrue(
-			IECore.V3f( 0, 1, 0 ).equalWithAbsError(
-				IECore.V3f( 1, 0, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
+			imath.V3f( 0, 1, 0 ).equalWithAbsError(
+				imath.V3f( 1, 0, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
 				0.000001
 			)
 		)
 		self.assertTrue(
-			IECore.V3f( 0, 0, 1 ).equalWithAbsError(
-				IECore.V3f( 0, 1, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
+			imath.V3f( 0, 0, 1 ).equalWithAbsError(
+				imath.V3f( 0, 1, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
 				0.000001
 			)
 		)
@@ -125,8 +127,8 @@ class RotateToolTest( GafferUITest.TestCase ) :
 			tool.rotate( 2, 90 )
 
 		self.assertTrue(
-			IECore.V3f( 0, 1, 0 ).equalWithAbsError(
-				IECore.V3f( 1, 0, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
+			imath.V3f( 0, 1, 0 ).equalWithAbsError(
+				imath.V3f( 1, 0, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
 				0.000001
 			)
 		)
@@ -140,8 +142,8 @@ class RotateToolTest( GafferUITest.TestCase ) :
 			tool.rotate( 0, 90 )
 
 		self.assertTrue(
-			IECore.V3f( 0, 1, 0 ).equalWithAbsError(
-				IECore.V3f( 1, 0, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
+			imath.V3f( 0, 1, 0 ).equalWithAbsError(
+				imath.V3f( 1, 0, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
 				0.000001
 			)
 		)
@@ -155,8 +157,8 @@ class RotateToolTest( GafferUITest.TestCase ) :
 			tool.rotate( 2, 90 )
 
 		self.assertTrue(
-			IECore.V3f( 0, -1, 0 ).equalWithAbsError(
-				IECore.V3f( 1, 0, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
+			imath.V3f( 0, -1, 0 ).equalWithAbsError(
+				imath.V3f( 1, 0, 0 ) * script["group"]["out"].fullTransform( "/group/cube" ),
 				0.000001
 			)
 		)
@@ -185,15 +187,15 @@ class RotateToolTest( GafferUITest.TestCase ) :
 		tool.rotate( 0, 90 )
 
 		self.assertTrue(
-			IECore.V3f( 0, 1, 0 ).equalWithAbsError(
-				IECore.V3f( 1, 0, 0 ) * script["transform"]["out"].fullTransform( "/plane" ),
+			imath.V3f( 0, 1, 0 ).equalWithAbsError(
+				imath.V3f( 1, 0, 0 ) * script["transform"]["out"].fullTransform( "/plane" ),
 				0.000001
 			)
 		)
 
 		self.assertTrue(
-			IECore.V3f( 0, 0, 1 ).equalWithAbsError(
-				IECore.V3f( 0, 1, 0 ) * script["transform"]["out"].fullTransform( "/plane" ),
+			imath.V3f( 0, 0, 1 ).equalWithAbsError(
+				imath.V3f( 0, 1, 0 ) * script["transform"]["out"].fullTransform( "/plane" ),
 				0.000001
 			)
 		)

--- a/python/GafferSceneUITest/ScaleToolTest.py
+++ b/python/GafferSceneUITest/ScaleToolTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -58,20 +60,20 @@ class ScaleToolTest( GafferUITest.TestCase ) :
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/plane" ] ) )
 
 		with Gaffer.UndoScope( script ) :
-			tool.scale( IECore.V3f( 2, 1, 1 ) )
+			tool.scale( imath.V3f( 2, 1, 1 ) )
 
-		self.assertEqual( script["plane"]["transform"]["scale"].getValue(), IECore.V3f( 2, 1, 1 ) )
+		self.assertEqual( script["plane"]["transform"]["scale"].getValue(), imath.V3f( 2, 1, 1 ) )
 
 		with Gaffer.UndoScope( script ) :
-			tool.scale( IECore.V3f( 1, 0.5, 1 ) )
+			tool.scale( imath.V3f( 1, 0.5, 1 ) )
 
-		self.assertEqual( script["plane"]["transform"]["scale"].getValue(), IECore.V3f( 2, 0.5, 1 ) )
-
-		script.undo()
-		self.assertEqual( script["plane"]["transform"]["scale"].getValue(), IECore.V3f( 2, 1, 1 ) )
+		self.assertEqual( script["plane"]["transform"]["scale"].getValue(), imath.V3f( 2, 0.5, 1 ) )
 
 		script.undo()
-		self.assertEqual( script["plane"]["transform"]["scale"].getValue(), IECore.V3f( 1, 1, 1 ) )
+		self.assertEqual( script["plane"]["transform"]["scale"].getValue(), imath.V3f( 2, 1, 1 ) )
+
+		script.undo()
+		self.assertEqual( script["plane"]["transform"]["scale"].getValue(), imath.V3f( 1, 1, 1 ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/SceneGadgetTest.py
+++ b/python/GafferSceneUITest/SceneGadgetTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 import IECoreScene
 import IECoreGL
@@ -66,7 +68,7 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 
 		viewportGadget = gadget.ancestor( GafferUI.ViewportGadget )
 
-		rasterPosition = ndcPosition * IECore.V2f( viewportGadget.getViewport() )
+		rasterPosition = ndcPosition * imath.V2f( viewportGadget.getViewport() )
 		gadgetLine = viewportGadget.rasterToGadgetSpace( rasterPosition, gadget )
 
 		self.assertEqual( gadget.objectAt( gadgetLine ), path )
@@ -75,8 +77,8 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 
 		viewportGadget = gadget.ancestor( GafferUI.ViewportGadget )
 
-		rasterMin = ndcBox.min * IECore.V2f( viewportGadget.getViewport() )
-		rasterMax = ndcBox.max * IECore.V2f( viewportGadget.getViewport() )
+		rasterMin = ndcBox.min() * imath.V2f( viewportGadget.getViewport() )
+		rasterMax = ndcBox.max() * imath.V2f( viewportGadget.getViewport() )
 
 		gadgetMin = viewportGadget.rasterToGadgetSpace( rasterMin, gadget ).p0
 		gadgetMax = viewportGadget.rasterToGadgetSpace( rasterMax, gadget ).p1
@@ -109,17 +111,17 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 
 		gw.getViewportGadget().frame( sg.bound() )
 
-		self.assertObjectAt( sg, IECore.V2f( 0.5 ), IECore.InternedStringVectorData( [ "group", "sphere" ] ) )
+		self.assertObjectAt( sg, imath.V2f( 0.5 ), IECore.InternedStringVectorData( [ "group", "sphere" ] ) )
 
 		s["a"]["attributes"]["visibility"]["enabled"].setValue( True )
 		s["a"]["attributes"]["visibility"]["value"].setValue( False )
 
-		self.assertObjectAt( sg, IECore.V2f( 0.5 ), None )
+		self.assertObjectAt( sg, imath.V2f( 0.5 ), None )
 
 		s["a"]["attributes"]["visibility"]["enabled"].setValue( True )
 		s["a"]["attributes"]["visibility"]["value"].setValue( True )
 
-		self.assertObjectAt( sg, IECore.V2f( 0.5 ), IECore.InternedStringVectorData( [ "group", "sphere" ] ) )
+		self.assertObjectAt( sg, imath.V2f( 0.5 ), IECore.InternedStringVectorData( [ "group", "sphere" ] ) )
 
 	def testExpansion( self ) :
 
@@ -141,18 +143,18 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 
 		gw.getViewportGadget().frame( sg.bound() )
 
-		self.assertObjectAt( sg, IECore.V2f( 0.5 ), None )
-		self.assertObjectsAt( sg, IECore.Box2f( IECore.V2f( 0 ), IECore.V2f( 1 ) ), [ "/group" ] )
+		self.assertObjectAt( sg, imath.V2f( 0.5 ), None )
+		self.assertObjectsAt( sg, imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ), [ "/group" ] )
 
 		sg.setExpandedPaths( GafferScene.PathMatcherData( GafferScene.PathMatcher( [ "/group" ] ) ) )
 
-		self.assertObjectAt( sg, IECore.V2f( 0.5 ), IECore.InternedStringVectorData( [ "group", "sphere" ] ) )
-		self.assertObjectsAt( sg, IECore.Box2f( IECore.V2f( 0 ), IECore.V2f( 1 ) ), [ "/group/sphere" ] )
+		self.assertObjectAt( sg, imath.V2f( 0.5 ), IECore.InternedStringVectorData( [ "group", "sphere" ] ) )
+		self.assertObjectsAt( sg, imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ), [ "/group/sphere" ] )
 
 		sg.setExpandedPaths( GafferScene.PathMatcherData( GafferScene.PathMatcher( [] ) ) )
 
-		self.assertObjectAt( sg, IECore.V2f( 0.5 ), None )
-		self.assertObjectsAt( sg, IECore.Box2f( IECore.V2f( 0 ), IECore.V2f( 1 ) ), [ "/group" ] )
+		self.assertObjectAt( sg, imath.V2f( 0.5 ), None )
+		self.assertObjectsAt( sg, imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ), [ "/group" ] )
 
 	def testExpressions( self ) :
 
@@ -258,17 +260,17 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 			# being displayed.
 
 			self.assertTrue( sg.bound().isEmpty() )
-			gw.getViewportGadget().frame( IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ) )
-			self.assertObjectAt( sg, IECore.V2f( 0.5 ), None )
+			gw.getViewportGadget().frame( imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
+			self.assertObjectAt( sg, imath.V2f( 0.5 ), None )
 
 			# And that redraws don't cause more fruitless attempts
 			# to compute the scene.
 
-			gw.getViewportGadget().frame( IECore.Box3f( IECore.V3f( -1.1 ), IECore.V3f( 1.1 ) ) )
+			gw.getViewportGadget().frame( imath.Box3f( imath.V3f( -1.1 ), imath.V3f( 1.1 ) ) )
 			self.waitForIdle( 1000 )
 
 			self.assertEqual( len( mh.messages ), 1 )
-			self.assertObjectAt( sg, IECore.V2f( 0.5 ), None )
+			self.assertObjectAt( sg, imath.V2f( 0.5 ), None )
 			self.assertTrue( sg.bound().isEmpty() )
 
 			# Fix the problem with the scene, and check that we can see something now
@@ -277,7 +279,7 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 
 			self.assertEqual( len( mh.messages ), 1 )
 			self.assertFalse( sg.bound().isEmpty() )
-			self.assertObjectAt( sg, IECore.V2f( 0.5 ), IECore.InternedStringVectorData( [ "bigSphere" ] ) )
+			self.assertObjectAt( sg, imath.V2f( 0.5 ), IECore.InternedStringVectorData( [ "bigSphere" ] ) )
 
 	def setUp( self ) :
 

--- a/python/GafferSceneUITest/ShaderAssignmentUITest.py
+++ b/python/GafferSceneUITest/ShaderAssignmentUITest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -61,8 +63,8 @@ class ShaderAssignmentUITest( GafferUITest.TestCase ) :
 
 		boxGadget = g.nodeGadget( box )
 
-		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["in"] ) ), IECore.V3f( 0, 1, 0 ) )
-		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["shader"] ) ), IECore.V3f( -1, 0, 0 ) )
+		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["in"] ) ), imath.V3f( 0, 1, 0 ) )
+		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["shader"] ) ), imath.V3f( -1, 0, 0 ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -72,7 +74,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		self.assertTrue( tool.selection().upstreamScene.isSame( script["plane"]["out"] ) )
 		self.assertEqual( tool.selection().upstreamPath, "/plane" )
 		self.assertTrue( tool.selection().transformPlug.isSame( script["plane"]["transform"] ) )
-		self.assertEqual( tool.selection().transformSpace, IECore.M44f() )
+		self.assertEqual( tool.selection().transformSpace, imath.M44f() )
 
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), GafferScene.PathMatcher( [ "/group" ] ) )
 		self.assertEqual( tool.selection().path, "/group" )
@@ -80,7 +82,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		self.assertTrue( tool.selection().upstreamScene.isSame( script["group"]["out"] ) )
 		self.assertEqual( tool.selection().upstreamPath, "/group" )
 		self.assertTrue( tool.selection().transformPlug.isSame( script["group"]["transform"] ) )
-		self.assertEqual( tool.selection().transformSpace, IECore.M44f() )
+		self.assertEqual( tool.selection().transformSpace, imath.M44f() )
 
 		script["transformFilter"]["paths"].setValue( IECore.StringVectorData( [ "/group" ] ) )
 		self.assertTrue( tool.selection().transformPlug.isSame( script["transform"]["transform"] ) )
@@ -94,7 +96,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		self.assertTrue( tool.selection().upstreamScene.isSame( script["transform"]["out"] ) )
 		self.assertEqual( tool.selection().upstreamPath, "/group" )
 		self.assertTrue( tool.selection().transformPlug.isSame( script["transform"]["transform"] ) )
-		self.assertEqual( tool.selection().transformSpace, IECore.M44f() )
+		self.assertEqual( tool.selection().transformSpace, imath.M44f() )
 
 		script["transform"]["enabled"].setValue( False )
 		self.assertTrue( tool.selection().transformPlug.isSame( script["group"]["transform"] ) )
@@ -112,11 +114,11 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
 
-		tool.translate( IECore.V3f( 1, 0, 0 ) )
+		tool.translate( imath.V3f( 1, 0, 0 ) )
 
 		self.assertEqual(
 			script["plane"]["out"].fullTransform( "/plane" ).translation(),
-			IECore.V3f( 1, 0, 0 ),
+			imath.V3f( 1, 0, 0 ),
 		)
 
 	def testInteractionWithRotation( self ) :
@@ -134,10 +136,10 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		tool["orientation"].setValue( tool.Orientation.Local )
 
 		with Gaffer.UndoScope( script ) :
-			tool.translate( IECore.V3f( 1, 0, 0 ) )
+			tool.translate( imath.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
-			IECore.V3f( 1, 0, 0 ).equalWithAbsError(
+			imath.V3f( 1, 0, 0 ).equalWithAbsError(
 				script["plane"]["out"].fullTransform( "/plane" ).translation(),
 				0.0000001
 			)
@@ -147,10 +149,10 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["plane"]["transform"]["rotate"]["y"].setValue( 90 )
 
 		with Gaffer.UndoScope( script ) :
-			tool.translate( IECore.V3f( 1, 0, 0 ) )
+			tool.translate( imath.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
-			IECore.V3f( 0, 0, -1 ).equalWithAbsError(
+			imath.V3f( 0, 0, -1 ).equalWithAbsError(
 				script["plane"]["out"].fullTransform( "/plane" ).translation(),
 				0.0000001
 			)
@@ -173,10 +175,10 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
 
-		tool.translate( IECore.V3f( 1, 0, 0 ) )
+		tool.translate( imath.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
-			IECore.V3f( 0, 0, -1 ).equalWithAbsError(
+			imath.V3f( 0, 0, -1 ).equalWithAbsError(
 				script["group"]["out"].fullTransform( "/group/plane" ).translation(),
 				0.0000001
 			)
@@ -189,7 +191,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["plane"] = GafferScene.Plane()
 		script["group"] = GafferScene.Group()
 		script["group"]["in"][0].setInput( script["plane"]["out"] )
-		script["group"]["transform"]["translate"].setValue( IECore.V3f( 1, 2, 3 ) )
+		script["group"]["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
 
 		view = GafferSceneUI.SceneView()
 		view["in"].setInput( script["group"]["out"] )
@@ -198,11 +200,11 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
 
-		tool.translate( IECore.V3f( -1, 0, 0 ) )
+		tool.translate( imath.V3f( -1, 0, 0 ) )
 
 		self.assertEqual(
 			script["group"]["out"].fullTransform( "/group/plane" ).translation(),
-			IECore.V3f( 0, 2, 3 ),
+			imath.V3f( 0, 2, 3 ),
 		)
 
 	def testOrientation( self ) :
@@ -228,10 +230,10 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		tool["orientation"].setValue( tool.Orientation.Local )
 
 		with Gaffer.UndoScope( script ) :
-			tool.translate( IECore.V3f( 1, 0, 0 ) )
+			tool.translate( imath.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
-			IECore.V3f( -1, 0, 0 ).equalWithAbsError(
+			imath.V3f( -1, 0, 0 ).equalWithAbsError(
 				script["group"]["out"].fullTransform( "/group/plane" ).translation(),
 				0.000001
 			)
@@ -243,10 +245,10 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		tool["orientation"].setValue( tool.Orientation.Parent )
 
 		with Gaffer.UndoScope( script ) :
-			tool.translate( IECore.V3f( 1, 0, 0 ) )
+			tool.translate( imath.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
-			IECore.V3f( 0, 0, -1 ).equalWithAbsError(
+			imath.V3f( 0, 0, -1 ).equalWithAbsError(
 				script["group"]["out"].fullTransform( "/group/plane" ).translation(),
 				0.0000001
 			)
@@ -258,10 +260,10 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		tool["orientation"].setValue( tool.Orientation.World )
 
 		with Gaffer.UndoScope( script ) :
-			tool.translate( IECore.V3f( 1, 0, 0 ) )
+			tool.translate( imath.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
-			IECore.V3f( 1, 0, 0 ).equalWithAbsError(
+			imath.V3f( 1, 0, 0 ).equalWithAbsError(
 				script["group"]["out"].fullTransform( "/group/plane" ).translation(),
 				0.0000001
 			)
@@ -272,7 +274,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 
 		script["plane"] = GafferScene.Plane()
-		script["plane"]["transform"]["scale"].setValue( IECore.V3f( 10 ) )
+		script["plane"]["transform"]["scale"].setValue( imath.V3f( 10 ) )
 
 		view = GafferSceneUI.SceneView()
 		view["in"].setInput( script["plane"]["out"] )
@@ -282,10 +284,10 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		tool["active"].setValue( True )
 
 		with Gaffer.UndoScope( script ) :
-			tool.translate( IECore.V3f( 1, 0, 0 ) )
+			tool.translate( imath.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
-			IECore.V3f( 1, 0, 0 ).equalWithAbsError(
+			imath.V3f( 1, 0, 0 ).equalWithAbsError(
 				script["plane"]["out"].fullTransform( "/plane" ).translation(),
 				0.0000001
 			)
@@ -296,10 +298,10 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		tool["orientation"].setValue( tool.Orientation.Local )
 
 		with Gaffer.UndoScope( script ) :
-			tool.translate( IECore.V3f( 1, 0, 0 ) )
+			tool.translate( imath.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
-			IECore.V3f( 1, 0, 0 ).equalWithAbsError(
+			imath.V3f( 1, 0, 0 ).equalWithAbsError(
 				script["plane"]["out"].fullTransform( "/plane" ).translation(),
 				0.0000001
 			)
@@ -318,11 +320,11 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
 
-		tool.translate( IECore.V3f( 1, 0, 0 ) )
+		tool.translate( imath.V3f( 1, 0, 0 ) )
 
 		self.assertEqual(
 			script["group"]["out"].fullTransform( "/group" ).translation(),
-			IECore.V3f( 1, 0, 0 ),
+			imath.V3f( 1, 0, 0 ),
 		)
 
 	def testTransform( self ) :
@@ -347,10 +349,10 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		tool["active"].setValue( True )
 		tool["orientation"].setValue( tool.Orientation.Local )
 
-		tool.translate( IECore.V3f( 1, 0, 0 ) )
+		tool.translate( imath.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
-			IECore.V3f( 0, 0, -1 ).equalWithAbsError(
+			imath.V3f( 0, 0, -1 ).equalWithAbsError(
 				script["transform"]["out"].fullTransform( "/plane" ).translation(),
 				0.0000001
 			)
@@ -378,10 +380,10 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		tool["active"].setValue( True )
 		tool["orientation"].setValue( tool.Orientation.Local )
 
-		tool.translate( IECore.V3f( 1, 0, 0 ) )
+		tool.translate( imath.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
-			IECore.V3f( 0, 0, -1 ).equalWithAbsError(
+			imath.V3f( 0, 0, -1 ).equalWithAbsError(
 				script["transform"]["out"].fullTransform( "/plane" ).translation(),
 				0.0000001
 			)

--- a/python/GafferTest/ApplicationRootTest.py
+++ b/python/GafferTest/ApplicationRootTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 import Gaffer
@@ -65,11 +66,11 @@ class ApplicationRootTest( GafferTest.TestCase ) :
 
 		p["category2"] = Gaffer.Plug()
 		p["category2"]["s"] = Gaffer.StringPlug( defaultValue = "apples" )
-		p["category2"]["v"] = Gaffer.V3fPlug( defaultValue = IECore.V3f( 1, 0, 0 ) )
+		p["category2"]["v"] = Gaffer.V3fPlug( defaultValue = imath.V3f( 1, 0, 0 ) )
 
 		p["category1"]["i"].setValue( 10 )
 		p["category2"]["s"].setValue( "oranges" )
-		p["category2"]["v"].setValue( IECore.V3f( 2, 3, 4 ) )
+		p["category2"]["v"].setValue( imath.V3f( 2, 3, 4 ) )
 
 		self.failIf( os.path.exists( self.__defaultPreferencesFile ) )
 		applicationRoot.savePreferences()
@@ -81,14 +82,14 @@ class ApplicationRootTest( GafferTest.TestCase ) :
 
 		p["category1"]["i"].setValue( 1 )
 		p["category2"]["s"].setValue( "beef" )
-		p["category2"]["v"].setValue( IECore.V3f( -10 ) )
+		p["category2"]["v"].setValue( imath.V3f( -10 ) )
 
 		executionContext = { "application" : application }
 		execfile( self.__preferencesFile, executionContext, executionContext )
 
 		self.assertEqual( p["category1"]["i"].getValue(), 10 )
 		self.assertEqual( p["category2"]["s"].getValue(), "oranges" )
-		self.assertEqual( p["category2"]["v"].getValue(), IECore.V3f( 2, 3, 4 ) )
+		self.assertEqual( p["category2"]["v"].getValue(), imath.V3f( 2, 3, 4 ) )
 
 	def testPreferencesPermissionsErrors( self ) :
 

--- a/python/GafferTest/ArrayPlugTest.py
+++ b/python/GafferTest/ArrayPlugTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import gc
+import imath
 
 import IECore
 
@@ -374,8 +375,8 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 
 		n2.addChild(Gaffer.IntPlug("test"))
 
-		connectionColor = IECore.Color3f( 0.1 , 0.2 , 0.3 )
-		noodleColor = IECore.Color3f( 0.4, 0.5 , 0.6 )
+		connectionColor = imath.Color3f( 0.1 , 0.2 , 0.3 )
+		noodleColor = imath.Color3f( 0.4, 0.5 , 0.6 )
 
 		element = Gaffer.IntPlug()
 		Gaffer.Metadata.registerValue( element, "connectionGadget:color", connectionColor )

--- a/python/GafferTest/BoxPlugTest.py
+++ b/python/GafferTest/BoxPlugTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -54,7 +55,7 @@ class BoxPlugTest( GafferTest.TestCase ) :
 
 	def testCreateCounterpart( self ) :
 
-		p1 = Gaffer.Box3fPlug( "b", Gaffer.Plug.Direction.Out, IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 1 ) ), Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		p1 = Gaffer.Box3fPlug( "b", Gaffer.Plug.Direction.Out, imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ), Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		p2 = p1.createCounterpart( "c", Gaffer.Plug.Direction.In )
 
 		self.assertEqual( p2.getName(), "c" )
@@ -65,8 +66,8 @@ class BoxPlugTest( GafferTest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 		s["n"] = Gaffer.Node()
-		s["n"]["p"] = Gaffer.Box3fPlug( minValue=IECore.V3f( -1 ), maxValue=IECore.V3f( 1 ), flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		s["n"]["p"].setValue( IECore.Box3f( IECore.V3f( -100 ), IECore.V3f( 1, 2, 3 ) ) )
+		s["n"]["p"] = Gaffer.Box3fPlug( minValue=imath.V3f( -1 ), maxValue=imath.V3f( 1 ), flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["p"].setValue( imath.Box3f( imath.V3f( -100 ), imath.V3f( 1, 2, 3 ) ) )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
@@ -77,7 +78,7 @@ class BoxPlugTest( GafferTest.TestCase ) :
 
 	def testMinMax( self ) :
 
-		b = Gaffer.Box3fPlug( "p", Gaffer.Plug.Direction.In, IECore.Box3f( IECore.V3f( -0.5 ), IECore.V3f( 0.5 ) ) )
+		b = Gaffer.Box3fPlug( "p", Gaffer.Plug.Direction.In, imath.Box3f( imath.V3f( -0.5 ), imath.V3f( 0.5 ) ) )
 		v = Gaffer.V3fPlug()
 
 		self.assertEqual( b.minValue(), v.minValue() )
@@ -87,17 +88,17 @@ class BoxPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( b.minValue(), v.minValue() )
 		self.assertEqual( b.maxValue(), v.maxValue() )
 
-		b = Gaffer.Box3fPlug( "p", minValue = IECore.V3f( -1, -2, -3 ), maxValue = IECore.V3f( 1, 2, 3 ) )
+		b = Gaffer.Box3fPlug( "p", minValue = imath.V3f( -1, -2, -3 ), maxValue = imath.V3f( 1, 2, 3 ) )
 		self.assertTrue( b.hasMinValue() )
 		self.assertTrue( b.hasMaxValue() )
-		self.assertEqual( b.minValue(), IECore.V3f( -1, -2, -3 ) )
-		self.assertEqual( b.maxValue(), IECore.V3f( 1, 2, 3 ) )
+		self.assertEqual( b.minValue(), imath.V3f( -1, -2, -3 ) )
+		self.assertEqual( b.maxValue(), imath.V3f( 1, 2, 3 ) )
 
 		c = b.createCounterpart( "c", Gaffer.Plug.Direction.In )
 		self.assertTrue( c.hasMinValue() )
 		self.assertTrue( c.hasMaxValue() )
-		self.assertEqual( c.minValue(), IECore.V3f( -1, -2, -3 ) )
-		self.assertEqual( c.maxValue(), IECore.V3f( 1, 2, 3 ) )
+		self.assertEqual( c.minValue(), imath.V3f( -1, -2, -3 ) )
+		self.assertEqual( c.maxValue(), imath.V3f( 1, 2, 3 ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/BoxTest.py
+++ b/python/GafferTest/BoxTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -316,7 +317,7 @@ class BoxTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["n"] = Gaffer.Node()
 		s["n"]["c"] = Gaffer.Color3fPlug()
-		s["n"]["c"].setValue( IECore.Color3f( 1, 0, 1 ) )
+		s["n"]["c"].setValue( imath.Color3f( 1, 0, 1 ) )
 
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n"] ] ) )
 
@@ -330,7 +331,7 @@ class BoxTest( GafferTest.TestCase ) :
 		self.assertTrue( b["n"]["c"]["r"].getInput().isSame( p["r"] ) )
 		self.assertTrue( b["n"]["c"]["g"].getInput().isSame( p["g"] ) )
 		self.assertTrue( b["n"]["c"]["b"].getInput().isSame( p["b"] ) )
-		self.assertEqual( p.getValue(), IECore.Color3f( 1, 0, 1 ) )
+		self.assertEqual( p.getValue(), imath.Color3f( 1, 0, 1 ) )
 
 	def testPromoteCompoundPlugAndSerialise( self ) :
 
@@ -373,7 +374,7 @@ class BoxTest( GafferTest.TestCase ) :
 		s["b"]["n"] = Gaffer.Random()
 
 		p = s["b"].promotePlug( s["b"]["n"]["baseColor"] )
-		p.setValue( IECore.Color3f( 1, 2, 3 ) )
+		p.setValue( imath.Color3f( 1, 2, 3 ) )
 		p.setName( "c" )
 
 		self.assertTrue( isinstance( s["b"]["c"], Gaffer.Color3fPlug ) )
@@ -381,7 +382,7 @@ class BoxTest( GafferTest.TestCase ) :
 		self.assertTrue( s["b"]["n"]["baseColor"]["r"].getInput().isSame( s["b"]["c"]["r"] ) )
 		self.assertTrue( s["b"]["n"]["baseColor"]["g"].getInput().isSame( s["b"]["c"]["g"] ) )
 		self.assertTrue( s["b"]["n"]["baseColor"]["b"].getInput().isSame( s["b"]["c"]["b"] ) )
-		self.assertEqual( s["b"]["c"].getValue(), IECore.Color3f( 1, 2, 3 ) )
+		self.assertEqual( s["b"]["c"].getValue(), imath.Color3f( 1, 2, 3 ) )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
@@ -391,7 +392,7 @@ class BoxTest( GafferTest.TestCase ) :
 		self.assertTrue( s2["b"]["n"]["baseColor"]["r"].getInput().isSame( s2["b"]["c"]["r"] ) )
 		self.assertTrue( s2["b"]["n"]["baseColor"]["g"].getInput().isSame( s2["b"]["c"]["g"] ) )
 		self.assertTrue( s2["b"]["n"]["baseColor"]["b"].getInput().isSame( s2["b"]["c"]["b"] ) )
-		self.assertEqual( s2["b"]["c"].getValue(), IECore.Color3f( 1, 2, 3 ) )
+		self.assertEqual( s2["b"]["c"].getValue(), imath.Color3f( 1, 2, 3 ) )
 
 	def testCantPromoteNonSerialisablePlugs( self ) :
 
@@ -840,7 +841,7 @@ class BoxTest( GafferTest.TestCase ) :
 		s["b"]["n"] = Gaffer.Node()
 
 		Gaffer.Metadata.registerValue( s["b"], "description", "Test description" )
-		Gaffer.Metadata.registerValue( s["b"], "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
+		Gaffer.Metadata.registerValue( s["b"], "nodeGadget:color", imath.Color3f( 1, 0, 0 ) )
 
 		ss = s.serialise( parent = s["b"] )
 
@@ -859,14 +860,14 @@ class BoxTest( GafferTest.TestCase ) :
 		s["b"]["n"]["p"] = Gaffer.Box2iPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
 		p = s["b"].promotePlug( s["b"]["n"]["p"] )
-		p.setValue( IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 3, 4 ) ) )
+		p.setValue( imath.Box2i( imath.V2i( 1, 2 ), imath.V2i( 3, 4 ) ) )
 		p.setName( "c" )
 
 		self.assertTrue( isinstance( s["b"]["c"], Gaffer.Box2iPlug ) )
 		self.assertTrue( s["b"]["n"]["p"].getInput().isSame( s["b"]["c"] ) )
 		self.assertTrue( s["b"]["n"]["p"]["min"].getInput().isSame( s["b"]["c"]["min"] ) )
 		self.assertTrue( s["b"]["n"]["p"]["max"].getInput().isSame( s["b"]["c"]["max"] ) )
-		self.assertEqual( s["b"]["c"].getValue(), IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 3, 4 ) ) )
+		self.assertEqual( s["b"]["c"].getValue(), imath.Box2i( imath.V2i( 1, 2 ), imath.V2i( 3, 4 ) ) )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
@@ -875,7 +876,7 @@ class BoxTest( GafferTest.TestCase ) :
 		self.assertTrue( s2["b"]["n"]["p"].getInput().isSame( s2["b"]["c"] ) )
 		self.assertTrue( s2["b"]["n"]["p"]["min"].getInput().isSame( s2["b"]["c"]["min"] ) )
 		self.assertTrue( s2["b"]["n"]["p"]["max"].getInput().isSame( s2["b"]["c"]["max"] ) )
-		self.assertEqual( s2["b"]["c"].getValue(), IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 3, 4 ) ) )
+		self.assertEqual( s2["b"]["c"].getValue(), imath.Box2i( imath.V2i( 1, 2 ), imath.V2i( 3, 4 ) ) )
 
 	def testPromoteStaticPlugsWithChildren( self ) :
 

--- a/python/GafferTest/CompoundDataPlugTest.py
+++ b/python/GafferTest/CompoundDataPlugTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -94,7 +95,7 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 
 		# test if creating a plug from data that has a geometric
 		# interpretation specified transfers that interpretation to the plug
-		m4 = p.addOptionalMember( "vector", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Vector ), plugName = "vector", enabled = True )
+		m4 = p.addOptionalMember( "vector", IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Vector ), plugName = "vector", enabled = True )
 		self.assertEqual( m4["value"].interpretation(), IECore.GeometricData.Interpretation.Vector )
 
 	def testVectorData( self ) :
@@ -122,61 +123,61 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( d, IECore.StringVectorData( [ "1", "2", "3" ] ) )
 		self.assertEqual( n, "c" )
 
-		m4 = p.addMember( "d", IECore.V3fVectorData( [ IECore.V3f( x ) for x in range( 1, 5 ) ] ) )
+		m4 = p.addMember( "d", IECore.V3fVectorData( [ imath.V3f( x ) for x in range( 1, 5 ) ] ) )
 		self.failUnless( isinstance( m4, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m4 )
-		self.assertEqual( d, IECore.V3fVectorData( [ IECore.V3f( x ) for x in range( 1, 5 ) ] ) )
+		self.assertEqual( d, IECore.V3fVectorData( [ imath.V3f( x ) for x in range( 1, 5 ) ] ) )
 		self.assertEqual( n, "d" )
 
-		m5 = p.addMember( "e", IECore.Color3fVectorData( [ IECore.Color3f( x ) for x in range( 1, 5 ) ] ) )
+		m5 = p.addMember( "e", IECore.Color3fVectorData( [ imath.Color3f( x ) for x in range( 1, 5 ) ] ) )
 		self.failUnless( isinstance( m5, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m5 )
-		self.assertEqual( d, IECore.Color3fVectorData( [ IECore.Color3f( x ) for x in range( 1, 5 ) ] ) )
+		self.assertEqual( d, IECore.Color3fVectorData( [ imath.Color3f( x ) for x in range( 1, 5 ) ] ) )
 		self.assertEqual( n, "e" )
 
-		m6 = p.addMember( "f", IECore.M44fVectorData( [ IECore.M44f() * x for x in range( 1, 5 ) ] ) )
+		m6 = p.addMember( "f", IECore.M44fVectorData( [ imath.M44f() * x for x in range( 1, 5 ) ] ) )
 		self.failUnless( isinstance( m6, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m6 )
-		self.assertEqual( d, IECore.M44fVectorData( [ IECore.M44f() * x for x in range( 1, 5 ) ] ) )
+		self.assertEqual( d, IECore.M44fVectorData( [ imath.M44f() * x for x in range( 1, 5 ) ] ) )
 		self.assertEqual( n, "f" )
 
-		m7 = p.addMember( "d", IECore.V2iVectorData( [ IECore.V2i( x ) for x in range( 1, 5 ) ] ) )
+		m7 = p.addMember( "d", IECore.V2iVectorData( [ imath.V2i( x ) for x in range( 1, 5 ) ] ) )
 		self.failUnless( isinstance( m7, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m7 )
-		self.assertEqual( d, IECore.V2iVectorData( [ IECore.V2i( x ) for x in range( 1, 5 ) ] ) )
+		self.assertEqual( d, IECore.V2iVectorData( [ imath.V2i( x ) for x in range( 1, 5 ) ] ) )
 		self.assertEqual( n, "d" )
 
 	def testImathVectorData( self ) :
 
 		p = Gaffer.CompoundDataPlug()
 
-		m1 = p.addMember( "a", IECore.V3fData( IECore.V3f( 1, 2, 3 ) ) )
+		m1 = p.addMember( "a", IECore.V3fData( imath.V3f( 1, 2, 3 ) ) )
 		self.failUnless( isinstance( m1, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m1 )
-		self.assertEqual( d, IECore.V3fData( IECore.V3f( 1, 2, 3 ) ) )
+		self.assertEqual( d, IECore.V3fData( imath.V3f( 1, 2, 3 ) ) )
 		self.assertEqual( n, "a" )
 
-		m2 = p.addMember( "b", IECore.V2fData( IECore.V2f( 1, 2 ) ) )
+		m2 = p.addMember( "b", IECore.V2fData( imath.V2f( 1, 2 ) ) )
 		self.failUnless( isinstance( m2, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m2 )
-		self.assertEqual( d, IECore.V2fData( IECore.V2f( 1, 2 ) ) )
+		self.assertEqual( d, IECore.V2fData( imath.V2f( 1, 2 ) ) )
 		self.assertEqual( n, "b" )
 
 	def testImathMatrixData( self ) :
 
 		p = Gaffer.CompoundDataPlug()
 
-		m1 = p.addMember( "a", IECore.M44fData( IECore.M44f( *range(16) ) ) )
+		m1 = p.addMember( "a", IECore.M44fData( imath.M44f( *range(16) ) ) )
 		self.failUnless( isinstance( m1, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m1 )
-		self.assertEqual( d, IECore.M44fData( IECore.M44f( *range(16) ) ) )
+		self.assertEqual( d, IECore.M44fData( imath.M44f( *range(16) ) ) )
 		self.assertEqual( n, "a" )
 
 	def testTransformPlugData( self ) :
@@ -184,27 +185,27 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 		p = Gaffer.CompoundDataPlug()
 
 		m1 = p.addMember( "a", Gaffer.TransformPlug() )
-		m1["value"]["translate"].setValue( IECore.V3f( 1,2,3 ) )
+		m1["value"]["translate"].setValue( imath.V3f( 1,2,3 ) )
 		self.failUnless( isinstance( m1, Gaffer.ValuePlug ) )
 
 		d, n = p.memberDataAndName( m1 )
-		self.assertEqual( d, IECore.M44fData( IECore.M44f( [
+		self.assertEqual( d, IECore.M44fData( imath.M44f(
 			1, 0, 0, 0,
 			0, 1, 0, 0,
 			0, 0, 1, 0,
 			1, 2, 3, 1,
-		] ) ) )
+		) ) )
 		self.assertEqual( n, "a" )
 
 	def testPlugFlags( self ) :
 
 		p = Gaffer.CompoundDataPlug()
-		m1 = p.addMember( "a", IECore.V3fData( IECore.V3f( 1, 2, 3 ) ), plugFlags = Gaffer.Plug.Flags.Default )
+		m1 = p.addMember( "a", IECore.V3fData( imath.V3f( 1, 2, 3 ) ), plugFlags = Gaffer.Plug.Flags.Default )
 		self.assertEqual( m1.getFlags(), Gaffer.Plug.Flags.Default )
 		self.assertEqual( m1["name"].getFlags(), Gaffer.Plug.Flags.Default)
 		self.assertEqual( m1["value"].getFlags(), Gaffer.Plug.Flags.Default )
 
-		m2 = p.addOptionalMember( "a", IECore.V3fData( IECore.V3f( 1, 2, 3 ) ), plugFlags = Gaffer.Plug.Flags.Default )
+		m2 = p.addOptionalMember( "a", IECore.V3fData( imath.V3f( 1, 2, 3 ) ), plugFlags = Gaffer.Plug.Flags.Default )
 		self.assertEqual( m2.getFlags(), Gaffer.Plug.Flags.Default )
 		self.assertEqual( m2["name"].getFlags(), Gaffer.Plug.Flags.Default )
 		self.assertEqual( m2["value"].getFlags(), Gaffer.Plug.Flags.Default )
@@ -213,7 +214,7 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 	def testCreateCounterpart( self ) :
 
 		p1 = Gaffer.CompoundDataPlug()
-		m1 = p1.addMember( "a", IECore.V3fData( IECore.V3f( 1, 2, 3 ) ), plugFlags = Gaffer.Plug.Flags.Default )
+		m1 = p1.addMember( "a", IECore.V3fData( imath.V3f( 1, 2, 3 ) ), plugFlags = Gaffer.Plug.Flags.Default )
 
 		p2 = p1.createCounterpart( "c", Gaffer.Plug.Direction.Out )
 		self.assertEqual( p2.typeName(), p1.typeName() )
@@ -338,10 +339,10 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 		p = Gaffer.CompoundDataPlug()
 
 		for name, value in [
-			( "b2f", IECore.Box2fData( IECore.Box2f( IECore.V2f( 0, 1 ), IECore.V2f( 1, 2 ) ) ) ),
-			( "b2i", IECore.Box2iData( IECore.Box2i( IECore.V2i( -1, 10 ), IECore.V2i( 11, 20 ) ) ) ),
-			( "b3f", IECore.Box3fData( IECore.Box3f( IECore.V3f( 0, 1, 2 ), IECore.V3f( 3, 4, 5 ) ) ) ),
-			( "b3i", IECore.Box3iData( IECore.Box3i( IECore.V3i( 0, 1, 2 ), IECore.V3i( 3, 4, 5 ) ) ) ),
+			( "b2f", IECore.Box2fData( imath.Box2f( imath.V2f( 0, 1 ), imath.V2f( 1, 2 ) ) ) ),
+			( "b2i", IECore.Box2iData( imath.Box2i( imath.V2i( -1, 10 ), imath.V2i( 11, 20 ) ) ) ),
+			( "b3f", IECore.Box3fData( imath.Box3f( imath.V3f( 0, 1, 2 ), imath.V3f( 3, 4, 5 ) ) ) ),
+			( "b3i", IECore.Box3iData( imath.Box3i( imath.V3i( 0, 1, 2 ), imath.V3i( 3, 4, 5 ) ) ) ),
 		] :
 			m = p.addMember( name, value )
 			self.assertEqual( p.memberDataAndName( m ), ( value, name ) )

--- a/python/GafferTest/CompoundNumericPlugTest.py
+++ b/python/GafferTest/CompoundNumericPlugTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -67,7 +68,7 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		p["y"].setValue( 2 )
 		p["z"].setValue( 3 )
 
-		self.assertEqual( p.getValue(), IECore.V3f( 1, 2, 3 ) )
+		self.assertEqual( p.getValue(), imath.V3f( 1, 2, 3 ) )
 
 	def testMinMaxValues( self ) :
 
@@ -79,8 +80,8 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 			self.failIf( p[a].hasMaxValue() )
 
 		p = Gaffer.V3fPlug(
-			minValue = IECore.V3f( -1, -2, -3 ),
-			maxValue = IECore.V3f( 1, 2, 3 )
+			minValue = imath.V3f( -1, -2, -3 ),
+			maxValue = imath.V3f( 1, 2, 3 )
 		)
 
 		self.failUnless( p.hasMinValue() )
@@ -91,8 +92,8 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 
 		minValue = p.minValue()
 		maxValue = p.maxValue()
-		self.assertEqual( minValue, IECore.V3f( -1, -2, -3 ) )
-		self.assertEqual( maxValue, IECore.V3f( 1, 2, 3 ) )
+		self.assertEqual( minValue, imath.V3f( -1, -2, -3 ) )
+		self.assertEqual( maxValue, imath.V3f( 1, 2, 3 ) )
 		i = 0
 		for a in ( "x", "y", "z" ) :
 			self.assertEqual( p[a].minValue(), minValue[i] )
@@ -101,8 +102,8 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 
 	def testDefaultValue( self ) :
 
-		p = Gaffer.V3fPlug( defaultValue = IECore.V3f( 1, 2, 3 ) )
-		self.assertEqual( p.defaultValue(), IECore.V3f( 1, 2, 3 ) )
+		p = Gaffer.V3fPlug( defaultValue = imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( p.defaultValue(), imath.V3f( 1, 2, 3 ) )
 		self.assertEqual( p["x"].defaultValue(), 1 )
 		self.assertEqual( p["y"].defaultValue(), 2 )
 		self.assertEqual( p["z"].defaultValue(), 3 )
@@ -111,7 +112,7 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 		n = GafferTest.CompoundNumericNode()
-		n["p"].setValue( IECore.V3f( 1, 2, 3 ) )
+		n["p"].setValue( imath.V3f( 1, 2, 3 ) )
 		s["n"] = n
 
 		ss = s.serialise()
@@ -119,7 +120,7 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s.execute( ss )
 
-		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 1, 2, 3 ) )
+		self.assertEqual( s["n"]["p"].getValue(), imath.V3f( 1, 2, 3 ) )
 
 	def testSerialisationWithConnection( self ) :
 
@@ -164,7 +165,7 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		n = Gaffer.Node()
 		n["p"] = Gaffer.V3fPlug( flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		n["p"].setValue( IECore.V3f( 1, 2, 3 ) )
+		n["p"].setValue( imath.V3f( 1, 2, 3 ) )
 		s["n"] = n
 
 		ss = s.serialise()
@@ -172,7 +173,7 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s.execute( ss )
 
-		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 1, 2, 3 ) )
+		self.assertEqual( s["n"]["p"].getValue(), imath.V3f( 1, 2, 3 ) )
 
 	def testDynamicSerialisationWithConnection( self ) :
 
@@ -206,19 +207,19 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 
 	def testSetToDefault( self ) :
 
-		p = Gaffer.V3fPlug( defaultValue = IECore.V3f( 1, 2, 3 ) )
-		self.assertEqual( p.getValue(), IECore.V3f( 1, 2, 3 ) )
+		p = Gaffer.V3fPlug( defaultValue = imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( p.getValue(), imath.V3f( 1, 2, 3 ) )
 
-		p.setValue( IECore.V3f( 4 ) )
-		self.assertEqual( p.getValue(), IECore.V3f( 4 ) )
+		p.setValue( imath.V3f( 4 ) )
+		self.assertEqual( p.getValue(), imath.V3f( 4 ) )
 
 		p.setToDefault()
-		self.assertEqual( p.getValue(), IECore.V3f( 1, 2, 3 ) )
+		self.assertEqual( p.getValue(), imath.V3f( 1, 2, 3 ) )
 
 	def testReadOnlySetValueRaises( self ) :
 
 		p = Gaffer.V3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.ReadOnly )
-		self.assertRaises( RuntimeError, p.setValue, IECore.V3f( 1 ) )
+		self.assertRaises( RuntimeError, p.setValue, imath.V3f( 1 ) )
 
 	def testColor3fAcceptsColor4fInput( self ) :
 
@@ -249,9 +250,9 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		p1 = Gaffer.V3fPlug(
 			"p",
 			Gaffer.Plug.Direction.Out,
-			IECore.V3f( 1, 2, 3 ),
-			IECore.V3f( -1, -2, -3 ),
-			IECore.V3f( 10, 20, 30 ),
+			imath.V3f( 1, 2, 3 ),
+			imath.V3f( -1, -2, -3 ),
+			imath.V3f( 10, 20, 30 ),
 			Gaffer.Plug.Flags.Default & ~Gaffer.Plug.Flags.AcceptsInputs,
 		)
 
@@ -275,9 +276,9 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		p1 = Gaffer.V3fPlug(
 			"p",
 			Gaffer.Plug.Direction.Out,
-			IECore.V3f( 1, 2, 3 ),
-			IECore.V3f( -1, -2, -3 ),
-			IECore.V3f( 10, 20, 30 ),
+			imath.V3f( 1, 2, 3 ),
+			imath.V3f( -1, -2, -3 ),
+			imath.V3f( 10, 20, 30 ),
 			Gaffer.Plug.Flags.Default & ~Gaffer.Plug.Flags.AcceptsInputs,
 		)
 
@@ -350,7 +351,7 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["n"] = Gaffer.Node()
 		s["n"]["p"] = Gaffer.V3fPlug()
-		s["n"]["p"].setValue( IECore.V3f( 1, 2, 3 ) )
+		s["n"]["p"].setValue( imath.V3f( 1, 2, 3 ) )
 
 		ss = s.serialise( filter = Gaffer.StandardSet( [ s["n"] ] ) )
 		self.assertEqual( ss.count( "setValue" ), 1 )
@@ -367,35 +368,35 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		s["n"] = Gaffer.Node()
 		s["n"]["p"] = Gaffer.V3fPlug()
 
-		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 0 ) )
+		self.assertEqual( s["n"]["p"].getValue(), imath.V3f( 0 ) )
 		self.assertFalse( s.undoAvailable() )
 
 		with Gaffer.UndoScope( s, mergeGroup="test" ) :
-			s["n"]["p"].setValue( IECore.V3f( 1, 2, 3 ) )
+			s["n"]["p"].setValue( imath.V3f( 1, 2, 3 ) )
 
-		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 1, 2, 3 ) )
+		self.assertEqual( s["n"]["p"].getValue(), imath.V3f( 1, 2, 3 ) )
 		self.assertTrue( s.undoAvailable() )
 
 		with Gaffer.UndoScope( s, mergeGroup="test" ) :
-			s["n"]["p"].setValue( IECore.V3f( 4, 5, 6 ) )
+			s["n"]["p"].setValue( imath.V3f( 4, 5, 6 ) )
 
-		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 4, 5, 6 ) )
+		self.assertEqual( s["n"]["p"].getValue(), imath.V3f( 4, 5, 6 ) )
 		self.assertTrue( s.undoAvailable() )
 
 		with Gaffer.UndoScope( s, mergeGroup="test2" ) :
-			s["n"]["p"].setValue( IECore.V3f( 7, 8, 9 ) )
+			s["n"]["p"].setValue( imath.V3f( 7, 8, 9 ) )
 
-		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 7, 8, 9 ) )
+		self.assertEqual( s["n"]["p"].getValue(), imath.V3f( 7, 8, 9 ) )
 		self.assertTrue( s.undoAvailable() )
 
 		s.undo()
 
-		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 4, 5, 6 ) )
+		self.assertEqual( s["n"]["p"].getValue(), imath.V3f( 4, 5, 6 ) )
 		self.assertTrue( s.undoAvailable() )
 
 		s.undo()
 
-		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 0 ) )
+		self.assertEqual( s["n"]["p"].getValue(), imath.V3f( 0 ) )
 		self.assertFalse( s.undoAvailable() )
 
 	def testUndoMergingWithUnchangingComponents( self ) :
@@ -404,24 +405,24 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		s["n"] = Gaffer.Node()
 		s["n"]["p"] = Gaffer.V3fPlug()
 
-		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 0 ) )
+		self.assertEqual( s["n"]["p"].getValue(), imath.V3f( 0 ) )
 		self.assertFalse( s.undoAvailable() )
 
 		with Gaffer.UndoScope( s, mergeGroup="test" ) :
-			s["n"]["p"].setValue( IECore.V3f( 1, 2, 0 ) )
+			s["n"]["p"].setValue( imath.V3f( 1, 2, 0 ) )
 
-		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 1, 2, 0 ) )
+		self.assertEqual( s["n"]["p"].getValue(), imath.V3f( 1, 2, 0 ) )
 		self.assertTrue( s.undoAvailable() )
 
 		with Gaffer.UndoScope( s, mergeGroup="test" ) :
-			s["n"]["p"].setValue( IECore.V3f( 2, 4, 0 ) )
+			s["n"]["p"].setValue( imath.V3f( 2, 4, 0 ) )
 
-		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 2, 4, 0 ) )
+		self.assertEqual( s["n"]["p"].getValue(), imath.V3f( 2, 4, 0 ) )
 		self.assertTrue( s.undoAvailable() )
 
 		s.undo()
 
-		self.assertEqual( s["n"]["p"].getValue(), IECore.V3f( 0 ) )
+		self.assertEqual( s["n"]["p"].getValue(), imath.V3f( 0 ) )
 		self.assertFalse( s.undoAvailable() )
 
 	def testSerialisationVerbosity( self ) :
@@ -429,7 +430,7 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["n"] = GafferTest.CompoundNumericNode()
 
-		s["n"]["p"].setValue( IECore.V3f( 9, 10, 11 ) )
+		s["n"]["p"].setValue( imath.V3f( 9, 10, 11 ) )
 
 		ss = s.serialise()
 		self.assertTrue( '["p"].setValue' in ss )
@@ -453,13 +454,13 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		n = GafferTest.CompoundNumericNode()
 		self.assertTrue( n["p"].isSetToDefault() )
 
-		n["p"].setValue( IECore.V3f( 4, 5, 6 ) )
+		n["p"].setValue( imath.V3f( 4, 5, 6 ) )
 		self.assertFalse( n["p"].isSetToDefault() )
 
 		n["p"].setToDefault()
 		self.assertTrue( n["p"].isSetToDefault() )
 
-		n["p"].setValue( IECore.V3f( 4, 5, 6 ) )
+		n["p"].setValue( imath.V3f( 4, 5, 6 ) )
 		self.assertFalse( n["p"].isSetToDefault() )
 
 		n["p"].setValue( n["p"].defaultValue() )

--- a/python/GafferTest/ContextTest.py
+++ b/python/GafferTest/ContextTest.py
@@ -37,6 +37,7 @@
 import unittest
 import threading
 import weakref
+import imath
 
 import IECore
 
@@ -117,33 +118,33 @@ class ContextTest( GafferTest.TestCase ) :
 		self.assertEqual( c["string"], "bye" )
 		self.failUnless( isinstance( c["string"], basestring ) )
 
-		c["v2i"] = IECore.V2i( 1, 2 )
-		self.assertEqual( c["v2i"], IECore.V2i( 1, 2 ) )
-		self.assertEqual( c.get( "v2i" ), IECore.V2i( 1, 2 ) )
-		c.set( "v2i", IECore.V2i( 1, 2 ) )
-		self.assertEqual( c["v2i"], IECore.V2i( 1, 2 ) )
-		self.failUnless( isinstance( c["v2i"], IECore.V2i ) )
+		c["v2i"] = imath.V2i( 1, 2 )
+		self.assertEqual( c["v2i"], imath.V2i( 1, 2 ) )
+		self.assertEqual( c.get( "v2i" ), imath.V2i( 1, 2 ) )
+		c.set( "v2i", imath.V2i( 1, 2 ) )
+		self.assertEqual( c["v2i"], imath.V2i( 1, 2 ) )
+		self.failUnless( isinstance( c["v2i"], imath.V2i ) )
 
-		c["v3i"] = IECore.V3i( 1, 2, 3 )
-		self.assertEqual( c["v3i"], IECore.V3i( 1, 2, 3 ) )
-		self.assertEqual( c.get( "v3i" ), IECore.V3i( 1, 2, 3 ) )
-		c.set( "v3i", IECore.V3i( 1, 2, 3 ) )
-		self.assertEqual( c["v3i"], IECore.V3i( 1, 2, 3 ) )
-		self.failUnless( isinstance( c["v3i"], IECore.V3i ) )
+		c["v3i"] = imath.V3i( 1, 2, 3 )
+		self.assertEqual( c["v3i"], imath.V3i( 1, 2, 3 ) )
+		self.assertEqual( c.get( "v3i" ), imath.V3i( 1, 2, 3 ) )
+		c.set( "v3i", imath.V3i( 1, 2, 3 ) )
+		self.assertEqual( c["v3i"], imath.V3i( 1, 2, 3 ) )
+		self.failUnless( isinstance( c["v3i"], imath.V3i ) )
 
-		c["v2f"] = IECore.V2f( 1, 2 )
-		self.assertEqual( c["v2f"], IECore.V2f( 1, 2 ) )
-		self.assertEqual( c.get( "v2f" ), IECore.V2f( 1, 2 ) )
-		c.set( "v2f", IECore.V2f( 1, 2 ) )
-		self.assertEqual( c["v2f"], IECore.V2f( 1, 2 ) )
-		self.failUnless( isinstance( c["v2f"], IECore.V2f ) )
+		c["v2f"] = imath.V2f( 1, 2 )
+		self.assertEqual( c["v2f"], imath.V2f( 1, 2 ) )
+		self.assertEqual( c.get( "v2f" ), imath.V2f( 1, 2 ) )
+		c.set( "v2f", imath.V2f( 1, 2 ) )
+		self.assertEqual( c["v2f"], imath.V2f( 1, 2 ) )
+		self.failUnless( isinstance( c["v2f"], imath.V2f ) )
 
-		c["v3f"] = IECore.V3f( 1, 2, 3 )
-		self.assertEqual( c["v3f"], IECore.V3f( 1, 2, 3 ) )
-		self.assertEqual( c.get( "v3f" ), IECore.V3f( 1, 2, 3 ) )
-		c.set( "v3f", IECore.V3f( 1, 2, 3 ) )
-		self.assertEqual( c["v3f"], IECore.V3f( 1, 2, 3 ) )
-		self.failUnless( isinstance( c["v3f"], IECore.V3f ) )
+		c["v3f"] = imath.V3f( 1, 2, 3 )
+		self.assertEqual( c["v3f"], imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( c.get( "v3f" ), imath.V3f( 1, 2, 3 ) )
+		c.set( "v3f", imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( c["v3f"], imath.V3f( 1, 2, 3 ) )
+		self.failUnless( isinstance( c["v3f"], imath.V3f ) )
 
 	def testCopying( self ) :
 

--- a/python/GafferTest/DotTest.py
+++ b/python/GafferTest/DotTest.py
@@ -38,6 +38,7 @@ import unittest
 
 import Gaffer
 import GafferTest
+import imath
 import IECore
 
 class DotTest( GafferTest.TestCase ) :
@@ -175,8 +176,8 @@ class DotTest( GafferTest.TestCase ) :
 
 		plug = s["n1"]["op1"]
 
-		connectionColor = IECore.Color3f( 0.1 , 0.2 , 0.3 )
-		noodleColor = IECore.Color3f( 0.4, 0.5 , 0.6 )
+		connectionColor = imath.Color3f( 0.1 , 0.2 , 0.3 )
+		noodleColor = imath.Color3f( 0.4, 0.5 , 0.6 )
 
 		Gaffer.Metadata.registerValue( plug, "connectionGadget:color", connectionColor )
 		Gaffer.Metadata.registerValue( plug, "nodule:color", noodleColor )

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -38,6 +38,7 @@
 import os
 import inspect
 import unittest
+import imath
 
 import IECore
 
@@ -407,22 +408,22 @@ class ExpressionTest( GafferTest.TestCase ) :
 		s["e"] = Gaffer.Expression()
 		s["e"].setExpression(
 			'import IECore;'
-			'parent["n"]["user"]["v2f"] = IECore.V2f( 1, 2 );'
-			'parent["n"]["user"]["v2i"] = IECore.V2i( 3, 4 );'
-			'parent["n"]["user"]["v3f"] = IECore.V3f( 4, 5, 6 );'
-			'parent["n"]["user"]["v3i"] = IECore.V3i( 6, 7, 8 );'
-			'parent["n"]["user"]["c3f"] = IECore.Color3f( 9, 10, 11 );'
-			'parent["n"]["user"]["c4f"] = IECore.Color4f( 12, 13, 14, 15 );'
+			'parent["n"]["user"]["v2f"] = imath.V2f( 1, 2 );'
+			'parent["n"]["user"]["v2i"] = imath.V2i( 3, 4 );'
+			'parent["n"]["user"]["v3f"] = imath.V3f( 4, 5, 6 );'
+			'parent["n"]["user"]["v3i"] = imath.V3i( 6, 7, 8 );'
+			'parent["n"]["user"]["c3f"] = imath.Color3f( 9, 10, 11 );'
+			'parent["n"]["user"]["c4f"] = imath.Color4f( 12, 13, 14, 15 );'
 		)
 
 		def assertExpectedValues( script ) :
 
-			self.assertEqual( script["n"]["user"]["v2f"].getValue(), IECore.V2f( 1, 2 ) )
-			self.assertEqual( script["n"]["user"]["v2i"].getValue(), IECore.V2i( 3, 4 ) )
-			self.assertEqual( script["n"]["user"]["v3f"].getValue(), IECore.V3f( 4, 5, 6 ) )
-			self.assertEqual( script["n"]["user"]["v3i"].getValue(), IECore.V3i( 6, 7, 8 ) )
-			self.assertEqual( script["n"]["user"]["c3f"].getValue(), IECore.Color3f( 9, 10, 11 ) )
-			self.assertEqual( script["n"]["user"]["c4f"].getValue(), IECore.Color4f( 12, 13, 14, 15 ) )
+			self.assertEqual( script["n"]["user"]["v2f"].getValue(), imath.V2f( 1, 2 ) )
+			self.assertEqual( script["n"]["user"]["v2i"].getValue(), imath.V2i( 3, 4 ) )
+			self.assertEqual( script["n"]["user"]["v3f"].getValue(), imath.V3f( 4, 5, 6 ) )
+			self.assertEqual( script["n"]["user"]["v3i"].getValue(), imath.V3i( 6, 7, 8 ) )
+			self.assertEqual( script["n"]["user"]["c3f"].getValue(), imath.Color3f( 9, 10, 11 ) )
+			self.assertEqual( script["n"]["user"]["c4f"].getValue(), imath.Color4f( 12, 13, 14, 15 ) )
 
 		assertExpectedValues( s )
 
@@ -443,19 +444,18 @@ class ExpressionTest( GafferTest.TestCase ) :
 
 		s["e"] = Gaffer.Expression()
 		s["e"].setExpression(
-			'import IECore;'
-			'parent["n"]["user"]["b2f"] = IECore.Box2f( IECore.V2f( 1, 2 ), IECore.V2f( 3, 4 ) );'
-			'parent["n"]["user"]["b2i"] = IECore.Box2i( IECore.V2i( 5, 6 ), IECore.V2i( 7, 8 ) );'
-			'parent["n"]["user"]["b3f"] = IECore.Box3f( IECore.V3f( 9, 10, 11 ), IECore.V3f( 12, 13, 14 ) );'
-			'parent["n"]["user"]["b3i"] = IECore.Box3i( IECore.V3i( 15, 16, 17 ), IECore.V3i( 18, 19, 20 ) );'
+			'parent["n"]["user"]["b2f"] = imath.Box2f( imath.V2f( 1, 2 ), imath.V2f( 3, 4 ) );'
+			'parent["n"]["user"]["b2i"] = imath.Box2i( imath.V2i( 5, 6 ), imath.V2i( 7, 8 ) );'
+			'parent["n"]["user"]["b3f"] = imath.Box3f( imath.V3f( 9, 10, 11 ), imath.V3f( 12, 13, 14 ) );'
+			'parent["n"]["user"]["b3i"] = imath.Box3i( imath.V3i( 15, 16, 17 ), imath.V3i( 18, 19, 20 ) );'
 		)
 
 		def assertExpectedValues( script ) :
 
-			self.assertEqual( script["n"]["user"]["b2f"].getValue(), IECore.Box2f( IECore.V2f( 1, 2 ), IECore.V2f( 3, 4 ) ) )
-			self.assertEqual( script["n"]["user"]["b2i"].getValue(), IECore.Box2i( IECore.V2i( 5, 6 ), IECore.V2i( 7, 8 ) ) )
-			self.assertEqual( script["n"]["user"]["b3f"].getValue(), IECore.Box3f( IECore.V3f( 9, 10, 11 ), IECore.V3f( 12, 13, 14 ) ) )
-			self.assertEqual( script["n"]["user"]["b3i"].getValue(), IECore.Box3i( IECore.V3i( 15, 16, 17 ), IECore.V3i( 18, 19, 20 ) ) )
+			self.assertEqual( script["n"]["user"]["b2f"].getValue(), imath.Box2f( imath.V2f( 1, 2 ), imath.V2f( 3, 4 ) ) )
+			self.assertEqual( script["n"]["user"]["b2i"].getValue(), imath.Box2i( imath.V2i( 5, 6 ), imath.V2i( 7, 8 ) ) )
+			self.assertEqual( script["n"]["user"]["b3f"].getValue(), imath.Box3f( imath.V3f( 9, 10, 11 ), imath.V3f( 12, 13, 14 ) ) )
+			self.assertEqual( script["n"]["user"]["b3i"].getValue(), imath.Box3i( imath.V3i( 15, 16, 17 ), imath.V3i( 18, 19, 20 ) ) )
 
 		assertExpectedValues( s )
 
@@ -605,24 +605,24 @@ class ExpressionTest( GafferTest.TestCase ) :
 
 		s["e"] = Gaffer.Expression()
 		s["e"].setExpression(
-			'parent["n"]["user"]["b2i"] = IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 3, 4 ) );'
-			'parent["n"]["user"]["b2f"] = IECore.Box2f( IECore.V2f( 1, 2 ), IECore.V2f( 3, 4 ) );'
-			'parent["n"]["user"]["b3f"] = IECore.Box3f( IECore.V3f( 1, 2, 3 ), IECore.V3f( 4, 5, 6 ) );',
+			'parent["n"]["user"]["b2i"] = imath.Box2i( imath.V2i( 1, 2 ), imath.V2i( 3, 4 ) );'
+			'parent["n"]["user"]["b2f"] = imath.Box2f( imath.V2f( 1, 2 ), imath.V2f( 3, 4 ) );'
+			'parent["n"]["user"]["b3f"] = imath.Box3f( imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) );',
 		)
 
 		self.assertEqual(
 			s["n"]["user"]["b2i"].getValue(),
-			IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 3, 4 ) )
+			imath.Box2i( imath.V2i( 1, 2 ), imath.V2i( 3, 4 ) )
 		)
 
 		self.assertEqual(
 			s["n"]["user"]["b2f"].getValue(),
-			IECore.Box2f( IECore.V2f( 1, 2 ), IECore.V2f( 3, 4 ) )
+			imath.Box2f( imath.V2f( 1, 2 ), imath.V2f( 3, 4 ) )
 		)
 
 		self.assertEqual(
 			s["n"]["user"]["b3f"].getValue(),
-			IECore.Box3f( IECore.V3f( 1, 2, 3 ), IECore.V3f( 4, 5, 6 ) )
+			imath.Box3f( imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) )
 		)
 
 	def testDisconnectOutput( self ) :
@@ -1131,10 +1131,10 @@ class ExpressionTest( GafferTest.TestCase ) :
 		s["n"]["user"].addChild( Gaffer.IntVectorDataPlug( defaultValue = IECore.IntVectorData( [ 0, 1 ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 		s["n"]["user"].addChild( Gaffer.FloatVectorDataPlug( defaultValue = IECore.FloatVectorData( [ 0, 1 ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 		s["n"]["user"].addChild( Gaffer.StringVectorDataPlug( defaultValue = IECore.StringVectorData( [ "a", "b" ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		s["n"]["user"].addChild( Gaffer.V3fVectorDataPlug( defaultValue = IECore.V3fVectorData( [ IECore.V3f( 1 ) ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		s["n"]["user"].addChild( Gaffer.Color3fVectorDataPlug( defaultValue = IECore.Color3fVectorData( [ IECore.Color3f( 1 ) ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		s["n"]["user"].addChild( Gaffer.M44fVectorDataPlug( defaultValue = IECore.M44fVectorData( [ IECore.M44f() ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		s["n"]["user"].addChild( Gaffer.V2iVectorDataPlug( defaultValue = IECore.V2iVectorData( [ IECore.V2i() ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		s["n"]["user"].addChild( Gaffer.V3fVectorDataPlug( defaultValue = IECore.V3fVectorData( [ imath.V3f( 1 ) ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		s["n"]["user"].addChild( Gaffer.Color3fVectorDataPlug( defaultValue = IECore.Color3fVectorData( [ imath.Color3f( 1 ) ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		s["n"]["user"].addChild( Gaffer.M44fVectorDataPlug( defaultValue = IECore.M44fVectorData( [ imath.M44f() ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		s["n"]["user"].addChild( Gaffer.V2iVectorDataPlug( defaultValue = IECore.V2iVectorData( [ imath.V2i() ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 
 		s["e"] = Gaffer.Expression()
 

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -38,6 +38,7 @@ import unittest
 
 import Gaffer
 import GafferTest
+import imath
 import IECore
 
 class MetadataAlgoTest( GafferTest.TestCase ) :
@@ -282,9 +283,9 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 		plug1 = Gaffer.IntPlug()
 		plug2 = Gaffer.IntPlug()
 
-		connectionColor = IECore.Color3f( 0.1 , 0.2 , 0.3 )
-		noodleColor = IECore.Color3f( 0.4, 0.5 , 0.6 )
-		noodleColorExisting = IECore.Color3f( 0.7, 0.8 , 0.9 )
+		connectionColor = imath.Color3f( 0.1 , 0.2 , 0.3 )
+		noodleColor = imath.Color3f( 0.4, 0.5 , 0.6 )
+		noodleColorExisting = imath.Color3f( 0.7, 0.8 , 0.9 )
 
 		Gaffer.Metadata.registerValue( plug1, "connectionGadget:color", connectionColor )
 		Gaffer.Metadata.registerValue( plug1, "nodule:color", noodleColor )
@@ -301,9 +302,9 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 		plug1 = Gaffer.IntPlug()
 		plug2 = Gaffer.IntPlug()
 
-		connectionColor = IECore.Color3f( 0.1 , 0.2 , 0.3 )
-		noodleColor =  IECore.Color3f( 0.4, 0.5 , 0.6 )
-		noodleColorExisting = IECore.Color3f( 0.7, 0.8 , 0.9 )
+		connectionColor = imath.Color3f( 0.1 , 0.2 , 0.3 )
+		noodleColor =  imath.Color3f( 0.4, 0.5 , 0.6 )
+		noodleColorExisting = imath.Color3f( 0.7, 0.8 , 0.9 )
 
 		Gaffer.Metadata.registerValue( plug1, "connectionGadget:color", connectionColor )
 		Gaffer.Metadata.registerValue( plug1, "nodule:color", noodleColor )

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -37,6 +37,7 @@
 import unittest
 import subprocess
 import os
+import imath
 
 import IECore
 
@@ -533,7 +534,7 @@ class MetadataTest( GafferTest.TestCase ) :
 			line description
 			""",
 
-			"nodeGadget:color", IECore.Color3f( 1, 0, 0 ),
+			"nodeGadget:color", imath.Color3f( 1, 0, 0 ),
 
 			plugs = {
 				"a" : [
@@ -561,7 +562,7 @@ class MetadataTest( GafferTest.TestCase ) :
 		n = MetadataTestNodeC()
 
 		self.assertEqual( Gaffer.Metadata.value( n, "description" ), "I am a multi\nline description" )
-		self.assertEqual( Gaffer.Metadata.value( n, "nodeGadget:color" ), IECore.Color3f( 1, 0, 0 ) )
+		self.assertEqual( Gaffer.Metadata.value( n, "nodeGadget:color" ), imath.Color3f( 1, 0, 0 ) )
 
 		self.assertEqual( Gaffer.Metadata.value( n["a"], "description" ), "Another multi\nline description" )
 		self.assertEqual( Gaffer.Metadata.value( n["a"], "preset:One" ), 1 )
@@ -973,10 +974,10 @@ class MetadataTest( GafferTest.TestCase ) :
 			1,
 			2.0,
 			True,
-			IECore.Color3f( 0 ),
-			IECore.V2f( 0 ),
-			IECore.V2i( 0 ),
-			IECore.V3i( 0 ),
+			imath.Color3f( 0 ),
+			imath.V2f( 0 ),
+			imath.V2i( 0 ),
+			imath.V3i( 0 ),
 			IECore.StringVectorData( [ "one", "two" ] ),
 			IECore.IntVectorData( [ 1, 2, 3 ] ),
 		] :

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -73,7 +74,7 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		s["b"] = Gaffer.Box()
 		s["b"]["n"] = Gaffer.Node()
 		s["b"]["n"]["c"] = Gaffer.Color3fPlug()
-		s["b"]["n"]["c"].setValue( IECore.Color3f( 1, 0, 1 ) )
+		s["b"]["n"]["c"].setValue( imath.Color3f( 1, 0, 1 ) )
 
 		self.assertTrue( Gaffer.PlugAlgo.canPromote( s["b"]["n"]["c"] ) )
 		self.assertFalse( Gaffer.PlugAlgo.isPromoted( s["b"]["n"]["c"] ) )
@@ -85,7 +86,7 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		self.assertTrue( s["b"]["n"]["c"]["r"].getInput().isSame( p["r"] ) )
 		self.assertTrue( s["b"]["n"]["c"]["g"].getInput().isSame( p["g"] ) )
 		self.assertTrue( s["b"]["n"]["c"]["b"].getInput().isSame( p["b"] ) )
-		self.assertEqual( p.getValue(), IECore.Color3f( 1, 0, 1 ) )
+		self.assertEqual( p.getValue(), imath.Color3f( 1, 0, 1 ) )
 
 	def testPromoteCompoundPlugAndSerialise( self ) :
 
@@ -128,7 +129,7 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		s["b"]["n"] = Gaffer.Random()
 
 		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["baseColor"] )
-		p.setValue( IECore.Color3f( 1, 2, 3 ) )
+		p.setValue( imath.Color3f( 1, 2, 3 ) )
 		p.setName( "c" )
 
 		self.assertTrue( isinstance( s["b"]["c"], Gaffer.Color3fPlug ) )
@@ -136,7 +137,7 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		self.assertTrue( s["b"]["n"]["baseColor"]["r"].getInput().isSame( s["b"]["c"]["r"] ) )
 		self.assertTrue( s["b"]["n"]["baseColor"]["g"].getInput().isSame( s["b"]["c"]["g"] ) )
 		self.assertTrue( s["b"]["n"]["baseColor"]["b"].getInput().isSame( s["b"]["c"]["b"] ) )
-		self.assertEqual( s["b"]["c"].getValue(), IECore.Color3f( 1, 2, 3 ) )
+		self.assertEqual( s["b"]["c"].getValue(), imath.Color3f( 1, 2, 3 ) )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
@@ -146,7 +147,7 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		self.assertTrue( s2["b"]["n"]["baseColor"]["r"].getInput().isSame( s2["b"]["c"]["r"] ) )
 		self.assertTrue( s2["b"]["n"]["baseColor"]["g"].getInput().isSame( s2["b"]["c"]["g"] ) )
 		self.assertTrue( s2["b"]["n"]["baseColor"]["b"].getInput().isSame( s2["b"]["c"]["b"] ) )
-		self.assertEqual( s2["b"]["c"].getValue(), IECore.Color3f( 1, 2, 3 ) )
+		self.assertEqual( s2["b"]["c"].getValue(), imath.Color3f( 1, 2, 3 ) )
 
 	def testCantPromoteNonSerialisablePlugs( self ) :
 
@@ -346,14 +347,14 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		s["b"]["n"]["p"] = Gaffer.Box2iPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
 		p = Gaffer.PlugAlgo.promote( s["b"]["n"]["p"] )
-		p.setValue( IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 3, 4 ) ) )
+		p.setValue( imath.Box2i( imath.V2i( 1, 2 ), imath.V2i( 3, 4 ) ) )
 		p.setName( "c" )
 
 		self.assertTrue( isinstance( s["b"]["c"], Gaffer.Box2iPlug ) )
 		self.assertTrue( s["b"]["n"]["p"].getInput().isSame( s["b"]["c"] ) )
 		self.assertTrue( s["b"]["n"]["p"]["min"].getInput().isSame( s["b"]["c"]["min"] ) )
 		self.assertTrue( s["b"]["n"]["p"]["max"].getInput().isSame( s["b"]["c"]["max"] ) )
-		self.assertEqual( s["b"]["c"].getValue(), IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 3, 4 ) ) )
+		self.assertEqual( s["b"]["c"].getValue(), imath.Box2i( imath.V2i( 1, 2 ), imath.V2i( 3, 4 ) ) )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
@@ -362,7 +363,7 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		self.assertTrue( s2["b"]["n"]["p"].getInput().isSame( s2["b"]["c"] ) )
 		self.assertTrue( s2["b"]["n"]["p"]["min"].getInput().isSame( s2["b"]["c"]["min"] ) )
 		self.assertTrue( s2["b"]["n"]["p"]["max"].getInput().isSame( s2["b"]["c"]["max"] ) )
-		self.assertEqual( s2["b"]["c"].getValue(), IECore.Box2i( IECore.V2i( 1, 2 ), IECore.V2i( 3, 4 ) ) )
+		self.assertEqual( s2["b"]["c"].getValue(), imath.Box2i( imath.V2i( 1, 2 ), imath.V2i( 3, 4 ) ) )
 
 	def testPromoteStaticPlugsWithChildren( self ) :
 
@@ -571,12 +572,12 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		n["a"]["p"]["c"]["v"] = Gaffer.V3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
 		n["a"]["p"]["c"]["i"].setValue( 10 )
-		n["a"]["p"]["c"]["v"].setValue( IECore.V3f( 1, 2, 3 ) )
+		n["a"]["p"]["c"]["v"].setValue( imath.V3f( 1, 2, 3 ) )
 
 		p = Gaffer.PlugAlgo.promote( n["a"]["p"] )
 
 		self.assertEqual( n["a"]["p"]["c"]["i"].getValue(), 10 )
-		self.assertEqual( n["a"]["p"]["c"]["v"].getValue(), IECore.V3f( 1, 2, 3 ) )
+		self.assertEqual( n["a"]["p"]["c"]["v"].getValue(), imath.V3f( 1, 2, 3 ) )
 
 	def testPromoteNonSerialisableOutput( self ) :
 

--- a/python/GafferTest/RandomTest.py
+++ b/python/GafferTest/RandomTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -59,7 +60,7 @@ class RandomTest( GafferTest.TestCase ) :
 
 		self.assertNotEqual( v1, v2 )
 
-		r["floatRange"].setValue( IECore.V2f( 2, 3 ) )
+		r["floatRange"].setValue( imath.V2f( 2, 3 ) )
 		v3 = r["outFloat"].getValue()
 
 		self.assertNotEqual( v2, v3 )
@@ -67,7 +68,7 @@ class RandomTest( GafferTest.TestCase ) :
 	def testOutFloatRange( self ) :
 
 		r = Gaffer.Random()
-		r["floatRange"].setValue( IECore.V2f( 10, 11 ) )
+		r["floatRange"].setValue( imath.V2f( 10, 11 ) )
 
 		for s in range( 0, 1000 ) :
 
@@ -98,7 +99,7 @@ class RandomTest( GafferTest.TestCase ) :
 		r = Gaffer.Random()
 		r["seed"].setValue( 1 )
 
-		r["baseColor"].setValue( IECore.Color3f( 0.25, 0.5, 0 ) )
+		r["baseColor"].setValue( imath.Color3f( 0.25, 0.5, 0 ) )
 
 		c1 = r["outColor"].getValue()
 		c2 = r.randomColor( 1 )
@@ -152,7 +153,7 @@ class RandomTest( GafferTest.TestCase ) :
 		r = Gaffer.Random()
 		r["seed"].setValue( -1 )
 		self.assertEqual( r["seed"].getValue(), 0 )
-		r["baseColor"].setValue( IECore.Color3f( 0.25, 0.5, 0 ) )
+		r["baseColor"].setValue( imath.Color3f( 0.25, 0.5, 0 ) )
 		c1 = r["outColor"].getValue()
 		c2 = r.randomColor( 0 )
 

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -38,6 +38,7 @@ import os
 import unittest
 import shutil
 import collections
+import imath
 
 import IECore
 
@@ -607,8 +608,8 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["b"] = Gaffer.Box()
 		s["b"]["p"] = Gaffer.IntPlug( defaultValue = 1, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["b"]["p"].setValue( 2 )
-		s["b"]["c"] = Gaffer.Color3fPlug( defaultValue = IECore.Color3f( 1 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		s["b"]["c"].setValue( IECore.Color3f( 0.5 ) )
+		s["b"]["c"] = Gaffer.Color3fPlug( defaultValue = imath.Color3f( 1 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"]["c"].setValue( imath.Color3f( 0.5 ) )
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
 		s["r"] = Gaffer.Reference()
@@ -623,9 +624,9 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertEqual( s["r"]["p"].defaultValue(), 2 )
 		self.assertEqual( s["b"]["p"].defaultValue(), 1 )
 
-		self.assertEqual( s["r"]["c"].getValue(), IECore.Color3f( 0.5 ) )
-		self.assertEqual( s["r"]["c"].defaultValue(), IECore.Color3f( 0.5 ) )
-		self.assertEqual( s["b"]["c"].defaultValue(), IECore.Color3f( 1 ) )
+		self.assertEqual( s["r"]["c"].getValue(), imath.Color3f( 0.5 ) )
+		self.assertEqual( s["r"]["c"].defaultValue(), imath.Color3f( 0.5 ) )
+		self.assertEqual( s["b"]["c"].defaultValue(), imath.Color3f( 1 ) )
 
 		# And we should be able to save and reload the script
 		# and have that still be the case.
@@ -639,17 +640,17 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertEqual( s["b"]["p"].getValue(), 2 )
 		self.assertEqual( s["b"]["p"].defaultValue(), 1 )
 
-		self.assertEqual( s["r"]["c"].getValue(), IECore.Color3f( 0.5 ) )
-		self.assertEqual( s["r"]["c"].defaultValue(), IECore.Color3f( 0.5 ) )
-		self.assertEqual( s["b"]["c"].getValue(), IECore.Color3f( 0.5 ) )
-		self.assertEqual( s["b"]["c"].defaultValue(), IECore.Color3f( 1 ) )
+		self.assertEqual( s["r"]["c"].getValue(), imath.Color3f( 0.5 ) )
+		self.assertEqual( s["r"]["c"].defaultValue(), imath.Color3f( 0.5 ) )
+		self.assertEqual( s["b"]["c"].getValue(), imath.Color3f( 0.5 ) )
+		self.assertEqual( s["b"]["c"].defaultValue(), imath.Color3f( 1 ) )
 
 		# If we change the value on the box and reexport,
 		# then the reference should pick up both the new value
 		# and the new default.
 
 		s["b"]["p"].setValue( 3 )
-		s["b"]["c"].setValue( IECore.Color3f( 0.25 ) )
+		s["b"]["c"].setValue( imath.Color3f( 0.25 ) )
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
@@ -658,10 +659,10 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertEqual( s["b"]["p"].getValue(), 3 )
 		self.assertEqual( s["b"]["p"].defaultValue(), 1 )
 
-		self.assertEqual( s["r"]["c"].getValue(), IECore.Color3f( 0.25 ) )
-		self.assertEqual( s["r"]["c"].defaultValue(), IECore.Color3f( 0.25 ) )
-		self.assertEqual( s["b"]["c"].getValue(), IECore.Color3f( 0.25 ) )
-		self.assertEqual( s["b"]["c"].defaultValue(), IECore.Color3f( 1 ) )
+		self.assertEqual( s["r"]["c"].getValue(), imath.Color3f( 0.25 ) )
+		self.assertEqual( s["r"]["c"].defaultValue(), imath.Color3f( 0.25 ) )
+		self.assertEqual( s["b"]["c"].getValue(), imath.Color3f( 0.25 ) )
+		self.assertEqual( s["b"]["c"].defaultValue(), imath.Color3f( 1 ) )
 
 		# And that should still hold after saving and reloading the script.
 
@@ -672,26 +673,26 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertEqual( s["b"]["p"].getValue(), 3 )
 		self.assertEqual( s["b"]["p"].defaultValue(), 1 )
 
-		self.assertEqual( s["r"]["c"].getValue(), IECore.Color3f( 0.25 ) )
-		self.assertEqual( s["r"]["c"].defaultValue(), IECore.Color3f( 0.25 ) )
-		self.assertEqual( s["b"]["c"].getValue(), IECore.Color3f( 0.25 ) )
-		self.assertEqual( s["b"]["c"].defaultValue(), IECore.Color3f( 1 ) )
+		self.assertEqual( s["r"]["c"].getValue(), imath.Color3f( 0.25 ) )
+		self.assertEqual( s["r"]["c"].defaultValue(), imath.Color3f( 0.25 ) )
+		self.assertEqual( s["b"]["c"].getValue(), imath.Color3f( 0.25 ) )
+		self.assertEqual( s["b"]["c"].defaultValue(), imath.Color3f( 1 ) )
 
 		# But if the user changes the value on the reference node,
 		# it should be kept.
 
 		s["r"]["p"].setValue( 100 )
-		s["r"]["c"].setValue( IECore.Color3f( 100 ) )
+		s["r"]["c"].setValue( imath.Color3f( 100 ) )
 
 		self.assertEqual( s["r"]["p"].getValue(), 100 )
 		self.assertEqual( s["r"]["p"].defaultValue(), 3 )
 		self.assertEqual( s["b"]["p"].getValue(), 3 )
 		self.assertEqual( s["b"]["p"].defaultValue(), 1 )
 
-		self.assertEqual( s["r"]["c"].getValue(), IECore.Color3f( 100 ) )
-		self.assertEqual( s["r"]["c"].defaultValue(), IECore.Color3f( 0.25 ) )
-		self.assertEqual( s["b"]["c"].getValue(), IECore.Color3f( 0.25 ) )
-		self.assertEqual( s["b"]["c"].defaultValue(), IECore.Color3f( 1 ) )
+		self.assertEqual( s["r"]["c"].getValue(), imath.Color3f( 100 ) )
+		self.assertEqual( s["r"]["c"].defaultValue(), imath.Color3f( 0.25 ) )
+		self.assertEqual( s["b"]["c"].getValue(), imath.Color3f( 0.25 ) )
+		self.assertEqual( s["b"]["c"].defaultValue(), imath.Color3f( 1 ) )
 
 		# And a save and load shouldn't change that.
 
@@ -703,17 +704,17 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertEqual( s["b"]["p"].getValue(), 3 )
 		self.assertEqual( s["b"]["p"].defaultValue(), 1 )
 
-		self.assertEqual( s["r"]["c"].getValue(), IECore.Color3f( 100 ) )
-		self.assertEqual( s["r"]["c"].defaultValue(), IECore.Color3f( 0.25 ) )
-		self.assertEqual( s["b"]["c"].getValue(), IECore.Color3f( 0.25 ) )
-		self.assertEqual( s["b"]["c"].defaultValue(), IECore.Color3f( 1 ) )
+		self.assertEqual( s["r"]["c"].getValue(), imath.Color3f( 100 ) )
+		self.assertEqual( s["r"]["c"].defaultValue(), imath.Color3f( 0.25 ) )
+		self.assertEqual( s["b"]["c"].getValue(), imath.Color3f( 0.25 ) )
+		self.assertEqual( s["b"]["c"].defaultValue(), imath.Color3f( 1 ) )
 
 		# And now the user has changed a value, only the
 		# default value should be updated if we load a new
 		# reference.
 
 		s["b"]["p"].setValue( 4 )
-		s["b"]["c"].setValue( IECore.Color3f( 4 ) )
+		s["b"]["c"].setValue( imath.Color3f( 4 ) )
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
@@ -722,10 +723,10 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertEqual( s["b"]["p"].getValue(), 4 )
 		self.assertEqual( s["b"]["p"].defaultValue(), 1 )
 
-		self.assertEqual( s["r"]["c"].getValue(), IECore.Color3f( 100 ) )
-		self.assertEqual( s["r"]["c"].defaultValue(), IECore.Color3f( 4 ) )
-		self.assertEqual( s["b"]["c"].getValue(), IECore.Color3f( 4 ) )
-		self.assertEqual( s["b"]["c"].defaultValue(), IECore.Color3f( 1 ) )
+		self.assertEqual( s["r"]["c"].getValue(), imath.Color3f( 100 ) )
+		self.assertEqual( s["r"]["c"].defaultValue(), imath.Color3f( 4 ) )
+		self.assertEqual( s["b"]["c"].getValue(), imath.Color3f( 4 ) )
+		self.assertEqual( s["b"]["c"].defaultValue(), imath.Color3f( 1 ) )
 
 		# And a save and load shouldn't change anything.
 
@@ -737,10 +738,10 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertEqual( s["b"]["p"].getValue(), 4 )
 		self.assertEqual( s["b"]["p"].defaultValue(), 1 )
 
-		self.assertEqual( s["r"]["c"].getValue(), IECore.Color3f( 100 ) )
-		self.assertEqual( s["r"]["c"].defaultValue(), IECore.Color3f( 4 ) )
-		self.assertEqual( s["b"]["c"].getValue(), IECore.Color3f( 4 ) )
-		self.assertEqual( s["b"]["c"].defaultValue(), IECore.Color3f( 1 ) )
+		self.assertEqual( s["r"]["c"].getValue(), imath.Color3f( 100 ) )
+		self.assertEqual( s["r"]["c"].defaultValue(), imath.Color3f( 4 ) )
+		self.assertEqual( s["b"]["c"].getValue(), imath.Color3f( 4 ) )
+		self.assertEqual( s["b"]["c"].defaultValue(), imath.Color3f( 1 ) )
 
 		# And since we know that all plugs in box exports
 		# have had their default values set to the current
@@ -784,7 +785,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["b"] = Gaffer.Box()
 
 		Gaffer.Metadata.registerValue( s["b"], "description", "Test description" )
-		Gaffer.Metadata.registerValue( s["b"], "nodeGadget:color", IECore.Color3f( 1, 0, 0 ) )
+		Gaffer.Metadata.registerValue( s["b"], "nodeGadget:color", imath.Color3f( 1, 0, 0 ) )
 
 		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
 
@@ -792,7 +793,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertEqual( Gaffer.Metadata.value( s["r"], "description" ), "Test description" )
-		self.assertEqual( Gaffer.Metadata.value( s["r"], "nodeGadget:color" ), IECore.Color3f( 1, 0, 0 ) )
+		self.assertEqual( Gaffer.Metadata.value( s["r"], "nodeGadget:color" ), imath.Color3f( 1, 0, 0 ) )
 
 	def testVersionMetadata( self ) :
 

--- a/python/GafferTest/SerialisationTest.py
+++ b/python/GafferTest/SerialisationTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -146,7 +148,7 @@ class SerialisationTest( GafferTest.TestCase ) :
 	def testIncludeParentMetadataWhenExcludingChildren( self ) :
 
 		n1 = Gaffer.Node()
-		Gaffer.Metadata.registerValue( n1, "test", IECore.Color3f( 1, 2, 3 ) )
+		Gaffer.Metadata.registerValue( n1, "test", imath.Color3f( 1, 2, 3 ) )
 
 		with Gaffer.Context() as c :
 			c["serialiser:includeParentMetadata"] = IECore.BoolData( True )
@@ -155,7 +157,7 @@ class SerialisationTest( GafferTest.TestCase ) :
 		scope = { "parent" : Gaffer.Node() }
 		exec( s.result(), scope, scope )
 
-		self.assertEqual( Gaffer.Metadata.value( scope["parent"], "test" ), IECore.Color3f( 1, 2, 3 ) )
+		self.assertEqual( Gaffer.Metadata.value( scope["parent"], "test" ), imath.Color3f( 1, 2, 3 ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/SignalsTest.py
+++ b/python/GafferTest/SignalsTest.py
@@ -40,6 +40,7 @@ import unittest
 import weakref
 import sys
 import gc
+import imath
 
 import IECore
 
@@ -96,11 +97,11 @@ class SignalsTest( GafferTest.TestCase ) :
 
 			return -1
 
-		class A( IECore.V3f ) :
+		class A( imath.V3f ) :
 
 			def __init__( self ) :
 
-				IECore.V3f.__init__( self )
+				imath.V3f.__init__( self )
 				self.signal = Gaffer.Signal1()
 
 			def f( self, n ) :
@@ -156,13 +157,13 @@ class SignalsTest( GafferTest.TestCase ) :
 
 	def testMany( self ) :
 
-		class S( IECore.V3f ) :
+		class S( imath.V3f ) :
 
 			instances = 0
 
 			def __init__( self, parent ) :
 
-				IECore.V3f.__init__( self )
+				imath.V3f.__init__( self )
 
 				S.instances += 1
 

--- a/python/GafferTest/SwitchTest.py
+++ b/python/GafferTest/SwitchTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import Gaffer
@@ -175,9 +176,9 @@ class SwitchTest( GafferTest.TestCase ) :
 	def testCompoundPlugs( self ) :
 
 		n = self.colorSwitch()
-		n["in"][0].setInput( self.colorPlug( IECore.Color3f( 0, 0.1, 0.2 ) ) )
-		n["in"][1].setInput( self.colorPlug( IECore.Color3f( 1, 1.1, 1.2 ) ) )
-		n["in"][2].setInput( self.colorPlug( IECore.Color3f( 2, 2.1, 2.2 ) ) )
+		n["in"][0].setInput( self.colorPlug( imath.Color3f( 0, 0.1, 0.2 ) ) )
+		n["in"][1].setInput( self.colorPlug( imath.Color3f( 1, 1.1, 1.2 ) ) )
+		n["in"][2].setInput( self.colorPlug( imath.Color3f( 2, 2.1, 2.2 ) ) )
 
 		n["index"].setValue( 0 )
 		self.assertEqual( n["out"].hash(), n["in"][0].hash() )
@@ -444,8 +445,8 @@ class SwitchTest( GafferTest.TestCase ) :
 
 		plug = s["n1"]["op1"]
 
-		connectionColor = IECore.Color3f( 0.1 , 0.2 , 0.3 )
-		noodleColor = IECore.Color3f( 0.4, 0.5 , 0.6 )
+		connectionColor = imath.Color3f( 0.1 , 0.2 , 0.3 )
+		noodleColor = imath.Color3f( 0.4, 0.5 , 0.6 )
 
 		Gaffer.Metadata.registerValue( plug, "connectionGadget:color", connectionColor )
 		Gaffer.Metadata.registerValue( plug, "nodule:color", noodleColor )

--- a/python/GafferTest/Transform2DPlugTest.py
+++ b/python/GafferTest/Transform2DPlugTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import Gaffer
@@ -46,20 +47,20 @@ class Transform2DPlugTest( GafferTest.TestCase ) :
 
 		p = Gaffer.Transform2DPlug()
 
-		p["pivot"].setValue( IECore.V2f( 1, 1 ) )
-		p["translate"].setValue( IECore.V2f( 1, 2 ) )
+		p["pivot"].setValue( imath.V2f( 1, 1 ) )
+		p["translate"].setValue( imath.V2f( 1, 2 ) )
 		p["rotate"].setValue( 45 )
-		p["scale"].setValue( IECore.V2f( 2, 3 ) )
+		p["scale"].setValue( imath.V2f( 2, 3 ) )
 
 		pivotValue = p["pivot"].getValue()
-		pivot = IECore.M33f.createTranslated( pivotValue )
+		pivot = imath.M33f().translate( pivotValue )
 
 		translateValue = p["translate"].getValue()
-		translate = IECore.M33f.createTranslated( translateValue )
+		translate = imath.M33f().translate( translateValue )
 
-		rotate = IECore.M33f.createRotated( IECore.degreesToRadians( p["rotate"].getValue() ) )
-		scale = IECore.M33f.createScaled( p["scale"].getValue() )
-		invPivot = IECore.M33f.createTranslated( pivotValue * IECore.V2f(-1.) )
+		rotate = imath.M33f().rotate( IECore.degreesToRadians( p["rotate"].getValue() ) )
+		scale = imath.M33f().scale( p["scale"].getValue() )
+		invPivot = imath.M33f().translate( pivotValue * imath.V2f(-1.) )
 
 		transforms = {
 			"p" : pivot,
@@ -69,7 +70,7 @@ class Transform2DPlugTest( GafferTest.TestCase ) :
 			"pi" : invPivot,
 		}
 
-		transform = IECore.M33f()
+		transform = imath.M33f()
 		for m in ( "pi", "s", "r", "t", "p" ) :
 			transform = transform * transforms[m]
 
@@ -79,13 +80,13 @@ class Transform2DPlugTest( GafferTest.TestCase ) :
 
 		plug = Gaffer.Transform2DPlug()
 
-		displayWindow = IECore.Box2i( IECore.V2i(0), IECore.V2i(9) )
+		displayWindow = imath.Box2i( imath.V2i(0), imath.V2i(9) )
 		pixelAspect = 1.
 
-		t =	IECore.V2f( 100, 0 )
+		t =	imath.V2f( 100, 0 )
 		r =	90
-		s =	IECore.V2f( 2, 2 )
-		p = IECore.V2f( 10, -10 )
+		s =	imath.V2f( 2, 2 )
+		p = imath.V2f( 10, -10 )
 		plug["translate"].setValue(  t )
 		plug["rotate"].setValue( r )
 		plug["scale"].setValue( s )
@@ -95,7 +96,7 @@ class Transform2DPlugTest( GafferTest.TestCase ) :
 		# This verifies that translation is not being affected by rotation and scale,
 		# which is what users will expect
 		self.assertTrue( plug.matrix().equalWithAbsError(
-			IECore.M33f(
+			imath.M33f(
 				0,   2, 0,
 				-2,  0, 0,
 				90, -30, 1),

--- a/python/GafferTest/TransformPlugTest.py
+++ b/python/GafferTest/TransformPlugTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import Gaffer
@@ -47,20 +48,20 @@ class TransformPlugTest( GafferTest.TestCase ) :
 
 		p = Gaffer.TransformPlug()
 
-		p["translate"].setValue( IECore.V3f( 1, 2, 3 ) )
-		p["rotate"].setValue( IECore.V3f( 90, 45, 0 ) )
-		p["scale"].setValue( IECore.V3f( 1, 2, 4 ) )
+		p["translate"].setValue( imath.V3f( 1, 2, 3 ) )
+		p["rotate"].setValue( imath.V3f( 90, 45, 0 ) )
+		p["scale"].setValue( imath.V3f( 1, 2, 4 ) )
 
-		translate = IECore.M44f.createTranslated( p["translate"].getValue() )
-		rotate = IECore.Eulerf( IECore.degreesToRadians( p["rotate"].getValue() ), IECore.Eulerf.Order.XYZ, IECore.Eulerf.InputLayout.XYZLayout )
+		translate = imath.M44f().translate( p["translate"].getValue() )
+		rotate = imath.Eulerf( IECore.degreesToRadians( p["rotate"].getValue() ), imath.Eulerf.Order.XYZ )
 		rotate = rotate.toMatrix44()
-		scale = IECore.M44f.createScaled( p["scale"].getValue() )
+		scale = imath.M44f().scale( p["scale"].getValue() )
 		transforms = {
 			"t" : translate,
 			"r" : rotate,
 			"s" : scale,
 		}
-		transform = IECore.M44f()
+		transform = imath.M44f()
 		for m in ( "s", "r", "t" ) :
 			transform = transform * transforms[m]
 
@@ -70,9 +71,9 @@ class TransformPlugTest( GafferTest.TestCase ) :
 
 		p = Gaffer.TransformPlug()
 
-		t =	IECore.V3f( 100, 0, 0 )
-		r =	IECore.V3f( 0, 90, 0 )
-		s =	IECore.V3f( 2, 2, 2 )
+		t =	imath.V3f( 100, 0, 0 )
+		r =	imath.V3f( 0, 90, 0 )
+		s =	imath.V3f( 2, 2, 2 )
 		p["translate"].setValue(  t )
 		p["rotate"].setValue( r )
 		p["scale"].setValue( s )
@@ -81,7 +82,7 @@ class TransformPlugTest( GafferTest.TestCase ) :
 		# This verifies that translation is not being affected by rotation and scale,
 		# which is what users will expect
 		self.assertTrue( p.matrix().equalWithAbsError(
-			IECore.M44f(
+			imath.M44f(
 				0,   0,  -2,   0,
 				0,   2,   0,   0,
 				2,   0,   0,   0,
@@ -108,39 +109,39 @@ class TransformPlugTest( GafferTest.TestCase ) :
 
 		p = Gaffer.TransformPlug()
 
-		p["rotate"].setValue( IECore.V3f( 0, 90, 0 ) )
+		p["rotate"].setValue( imath.V3f( 0, 90, 0 ) )
 
 		self.assertTrue(
-			IECore.V3f( 0, 0, -1 ).equalWithAbsError(
-				IECore.V3f( 1, 0, 0 ) * p.matrix(),
+			imath.V3f( 0, 0, -1 ).equalWithAbsError(
+				imath.V3f( 1, 0, 0 ) * p.matrix(),
 				1e-6
 			)
 		)
 
-		p["pivot"].setValue( IECore.V3f( 1, 0, 0 ) )
+		p["pivot"].setValue( imath.V3f( 1, 0, 0 ) )
 
 		self.assertTrue(
-			IECore.V3f( 1, 0, 0 ).equalWithAbsError(
-				IECore.V3f( 1, 0, 0 ) * p.matrix(),
+			imath.V3f( 1, 0, 0 ).equalWithAbsError(
+				imath.V3f( 1, 0, 0 ) * p.matrix(),
 				1e-6
 			)
 		)
 
-		p["pivot"].setValue( IECore.V3f( -1, 0, 0 ) )
+		p["pivot"].setValue( imath.V3f( -1, 0, 0 ) )
 
 		self.assertTrue(
-			IECore.V3f( -1, 0, -2 ).equalWithAbsError(
-				IECore.V3f( 1, 0, 0 ) * p.matrix(),
+			imath.V3f( -1, 0, -2 ).equalWithAbsError(
+				imath.V3f( 1, 0, 0 ) * p.matrix(),
 				1e-6
 			)
 		)
 
-		p["rotate"].setValue( IECore.V3f( 0, 0, 0 ) )
-		p["scale"].setValue( IECore.V3f( 2, 1, 1 ) )
+		p["rotate"].setValue( imath.V3f( 0, 0, 0 ) )
+		p["scale"].setValue( imath.V3f( 2, 1, 1 ) )
 
 		self.assertTrue(
-			IECore.V3f( 3, 0, 0 ).equalWithAbsError(
-				IECore.V3f( 1, 0, 0 ) * p.matrix(),
+			imath.V3f( 3, 0, 0 ).equalWithAbsError(
+				imath.V3f( 1, 0, 0 ) * p.matrix(),
 				1e-6
 			)
 		)
@@ -150,15 +151,15 @@ class TransformPlugTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["n"] = Gaffer.Node()
 		s["n"]["p"] = Gaffer.TransformPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		s["n"]["p"]["translate"].setValue( IECore.V3f( 1, 2, 3 ) )
-		s["n"]["p"]["rotate"].setValue( IECore.V3f( 4, 5, 6 ) )
+		s["n"]["p"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
+		s["n"]["p"]["rotate"].setValue( imath.V3f( 4, 5, 6 ) )
 		ss = s.serialise()
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( ss )
 
-		self.assertEqual( s2["n"]["p"]["translate"].getValue(), IECore.V3f( 1, 2, 3 ) )
-		self.assertEqual( s2["n"]["p"]["rotate"].getValue(), IECore.V3f( 4, 5, 6 ) )
+		self.assertEqual( s2["n"]["p"]["translate"].getValue(), imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( s2["n"]["p"]["rotate"].getValue(), imath.V3f( 4, 5, 6 ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/AboutWindow.py
+++ b/python/GafferUI/AboutWindow.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import os
+import imath
 
 import IECore
 
@@ -62,7 +63,7 @@ class AboutWindow( GafferUI.Window ) :
 				) :
 
 					GafferUI.Spacer(
-						IECore.V2i( 1 ),
+						imath.V2i( 1 ),
 						parenting = { "expand" : True }
 					)
 
@@ -84,7 +85,7 @@ class AboutWindow( GafferUI.Window ) :
 					)
 
 					GafferUI.Spacer(
-						IECore.V2i( 1 ),
+						imath.V2i( 1 ),
 						parenting = { "expand" : True }
 					)
 

--- a/python/GafferUI/BackdropUI.py
+++ b/python/GafferUI/BackdropUI.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -65,10 +67,10 @@ def nodeMenuCreateCommand( menu ) :
 		else :
 			menuPosition = menu.popupPosition( relativeTo = gadgetWidget )
 			nodePosition = gadgetWidget.getViewportGadget().rasterToGadgetSpace(
-				IECore.V2f( menuPosition.x, menuPosition.y ),
+				imath.V2f( menuPosition.x, menuPosition.y ),
 				gadget = graphGadget
 			).p0
-			graphGadget.setNodePosition( backdrop, IECore.V2f( nodePosition.x, nodePosition.y ) )
+			graphGadget.setNodePosition( backdrop, imath.V2f( nodePosition.x, nodePosition.y ) )
 
 	return backdrop
 

--- a/python/GafferUI/ColorChooser.py
+++ b/python/GafferUI/ColorChooser.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import sys
+import imath
 
 import IECore
 
@@ -81,14 +82,14 @@ class _ComponentSlider( GafferUI.NumericSlider ) :
 		displayTransform = GafferUI.DisplayTransform.get() if self.__useDisplayTransform else lambda x : x
 
 		if self.component == "a" :
-			c1 = IECore.Color3f( 0 )
-			c2 = IECore.Color3f( 1 )
+			c1 = imath.Color3f( 0 )
+			c2 = imath.Color3f( 1 )
 		else :
-			c1 = IECore.Color3f( self.color[0], self.color[1], self.color[2] )
-			c2 = IECore.Color3f( self.color[0], self.color[1], self.color[2] )
+			c1 = imath.Color3f( self.color[0], self.color[1], self.color[2] )
+			c2 = imath.Color3f( self.color[0], self.color[1], self.color[2] )
 			if self.component in "hsv" :
-				c1 = c1.rgbToHSV()
-				c2 = c2.rgbToHSV()
+				c1 = c1.rgb2hsv()
+				c2 = c2.rgb2hsv()
 			a = { "r" : 0, "g" : 1, "b" : 2, "h" : 0, "s" : 1, "v": 2 }[self.component]
 			c1[a] = 0
 			c2[a] = 1
@@ -99,7 +100,7 @@ class _ComponentSlider( GafferUI.NumericSlider ) :
 			t = float( i ) / (numStops-1)
 			c = c1 + (c2-c1) * t
 			if self.component in "hsv" :
-				c = c.hsvToRGB()
+				c = c.hsv2rgb()
 
 			grad.setColorAt( t, self._qtColor( displayTransform( c ) ) )
 
@@ -114,7 +115,7 @@ class ColorChooser( GafferUI.Widget ) :
 
 	ColorChangedReason = IECore.Enum.create( "Invalid", "SetColor", "Reset" )
 
-	def __init__( self, color=IECore.Color3f( 1 ), useDisplayTransform = True, **kw ) :
+	def __init__( self, color=imath.Color3f( 1 ), useDisplayTransform = True, **kw ) :
 
 		self.__column = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing = 4 )
 
@@ -155,7 +156,7 @@ class ColorChooser( GafferUI.Widget ) :
 				self.__initialColorSwatch = GafferUI.ColorSwatch( color, useDisplayTransform = useDisplayTransform, parenting = { "expand" : True } )
 				self.__initialColorPressConnection = self.__initialColorSwatch.buttonPressSignal().connect( Gaffer.WeakMethod( self.__initialColorPress ) )
 
-				GafferUI.Spacer( IECore.V2i( 4, 40 ) )
+				GafferUI.Spacer( imath.V2i( 4, 40 ) )
 
 				self.__colorSwatch = GafferUI.ColorSwatch( color, useDisplayTransform = useDisplayTransform, parenting = { "expand" : True } )
 
@@ -222,10 +223,10 @@ class ColorChooser( GafferUI.Widget ) :
 			a = { "r" : 0, "g" : 1, "b" : 2, "a" : 3 }[componentWidget.component]
 			newColor[a] = componentValue
 		else :
-			newColor = newColor.rgbToHSV()
+			newColor = newColor.rgb2hsv()
 			a = { "h" : 0, "s" : 1, "v" : 2 }[componentWidget.component]
 			newColor[a] = componentValue
-			newColor = newColor.hsvToRGB()
+			newColor = newColor.hsv2rgb()
 
 		self.__setColorInternal( newColor, reason )
 
@@ -271,7 +272,7 @@ class ColorChooser( GafferUI.Widget ) :
 			else :
 				self.__sliders["a"].parent().setVisible( False )
 
-			c = c.rgbToHSV()
+			c = c.rgb2hsv()
 			for component, index in ( ( "h", 0 ), ( "s", 1 ), ( "v", 2 ) ) :
 				self.__sliders[component].setValue( c[index] )
 				self.__numericWidgets[component].setValue( c[index] )

--- a/python/GafferUI/ColorChooserDialogue.py
+++ b/python/GafferUI/ColorChooserDialogue.py
@@ -35,13 +35,15 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import GafferUI
 
 class ColorChooserDialogue( GafferUI.Dialogue ) :
 
-	def __init__( self, title="Select color", color=IECore.Color3f( 1 ), cancelLabel="Cancel", confirmLabel="OK", useDisplayTransform = True, **kw ) :
+	def __init__( self, title="Select color", color=imath.Color3f( 1 ), cancelLabel="Cancel", confirmLabel="OK", useDisplayTransform = True, **kw ) :
 
 		GafferUI.Dialogue.__init__( self, title, **kw )
 

--- a/python/GafferUI/ColorSwatch.py
+++ b/python/GafferUI/ColorSwatch.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -50,10 +52,10 @@ from Qt import QtWidgets
 # space, pass `useDisplayTransform = False` to the constructor.
 class ColorSwatch( GafferUI.Widget ) :
 
-	__linearBackgroundColor0 = IECore.Color3f( 0.1 )
-	__linearBackgroundColor1 = IECore.Color3f( 0.2 )
+	__linearBackgroundColor0 = imath.Color3f( 0.1 )
+	__linearBackgroundColor1 = imath.Color3f( 0.2 )
 
-	def __init__( self, color=IECore.Color4f( 1 ), useDisplayTransform = True, **kw ) :
+	def __init__( self, color=imath.Color4f( 1 ), useDisplayTransform = True, **kw ) :
 
 		GafferUI.Widget.__init__( self, QtWidgets.QWidget(), **kw )
 
@@ -117,8 +119,8 @@ class ColorSwatch( GafferUI.Widget ) :
 			bg1 = self.__linearBackgroundColor1 if self.__useDisplayTransform else displayTransform( self.__linearBackgroundColor1 )
 			# Now composite the main colour with the background colour. This is happening in linear space
 			# if __useDisplayTransform is True, and in display space otherwise.
-			color0 = bg0 * ( 1.0 - c.a ) + IECore.Color3f( c.r, c.g, c.b ) * c.a
-			color1 = bg1 * ( 1.0 - c.a ) + IECore.Color3f( c.r, c.g, c.b ) * c.a
+			color0 = bg0 * ( 1.0 - c.a ) + imath.Color3f( c.r, c.g, c.b ) * c.a
+			color1 = bg1 * ( 1.0 - c.a ) + imath.Color3f( c.r, c.g, c.b ) * c.a
 
 			self.__transparentChecker.color0 = self._qtColor( effectiveDisplayTransform( color0 ) )
 			self.__transparentChecker.color1 = self._qtColor( effectiveDisplayTransform( color1 ) )
@@ -151,8 +153,8 @@ class _Checker( QtWidgets.QWidget ) :
 			# draw checkerboard if colours differ
 			checkSize = 6
 
-			min = IECore.V2i( rect.x() / checkSize, rect.y() / checkSize )
-			max = IECore.V2i( 1 + (rect.x() + rect.width()) / checkSize, 1 + (rect.y() + rect.height()) / checkSize )
+			min = imath.V2i( rect.x() / checkSize, rect.y() / checkSize )
+			max = imath.V2i( 1 + (rect.x() + rect.width()) / checkSize, 1 + (rect.y() + rect.height()) / checkSize )
 
 			for x in range( min.x, max.x ) :
 				for y in range( min.y, max.y ) :

--- a/python/GafferUI/CompoundDataPlugValueWidget.py
+++ b/python/GafferUI/CompoundDataPlugValueWidget.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import functools
+import imath
 
 import IECore
 
@@ -59,7 +60,7 @@ class CompoundDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal ) as self.__editRow :
 
-				GafferUI.Spacer( IECore.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
+				GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 
 				GafferUI.MenuButton(
 					image = "plus.png",
@@ -67,7 +68,7 @@ class CompoundDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__addMenuDefinition ) )
 				)
 
-				GafferUI.Spacer( IECore.V2i( 1 ), IECore.V2i( 999999, 1 ), parenting = { "expand" : True } )
+				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
 		self._updateFromPlug()
 
@@ -115,33 +116,33 @@ class CompoundDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 		result.append( "/Add/String", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.StringData( "" ) ) } )
 		result.append( "/Add/StringDivider", { "divider" : True } )
 
-		result.append( "/Add/V2i/Vector", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2iData( IECore.V2i( 0 ), IECore.GeometricData.Interpretation.Vector ) ) } )
-		result.append( "/Add/V2i/Normal", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2iData( IECore.V2i( 0 ), IECore.GeometricData.Interpretation.Normal ) ) } )
-		result.append( "/Add/V2i/Point", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2iData( IECore.V2i( 0 ), IECore.GeometricData.Interpretation.Point ) ) } )
+		result.append( "/Add/V2i/Vector", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2iData( imath.V2i( 0 ), IECore.GeometricData.Interpretation.Vector ) ) } )
+		result.append( "/Add/V2i/Normal", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2iData( imath.V2i( 0 ), IECore.GeometricData.Interpretation.Normal ) ) } )
+		result.append( "/Add/V2i/Point", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2iData( imath.V2i( 0 ), IECore.GeometricData.Interpretation.Point ) ) } )
 
-		result.append( "/Add/V3i/Vector", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3iData( IECore.V3i( 0 ), IECore.GeometricData.Interpretation.Vector ) ) } )
-		result.append( "/Add/V3i/Normal", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3iData( IECore.V3i( 0 ), IECore.GeometricData.Interpretation.Normal ) ) } )
-		result.append( "/Add/V3i/Point", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3iData( IECore.V3i( 0 ), IECore.GeometricData.Interpretation.Point ) ) } )
+		result.append( "/Add/V3i/Vector", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3iData( imath.V3i( 0 ), IECore.GeometricData.Interpretation.Vector ) ) } )
+		result.append( "/Add/V3i/Normal", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3iData( imath.V3i( 0 ), IECore.GeometricData.Interpretation.Normal ) ) } )
+		result.append( "/Add/V3i/Point", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3iData( imath.V3i( 0 ), IECore.GeometricData.Interpretation.Point ) ) } )
 
-		result.append( "/Add/V2f/Vector", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2fData( IECore.V2f( 0 ), IECore.GeometricData.Interpretation.Vector ) ) } )
-		result.append( "/Add/V2f/Normal", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2fData( IECore.V2f( 0 ), IECore.GeometricData.Interpretation.Normal ) ) } )
-		result.append( "/Add/V2f/Point", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2fData( IECore.V2f( 0 ), IECore.GeometricData.Interpretation.Point ) ) } )
+		result.append( "/Add/V2f/Vector", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2fData( imath.V2f( 0 ), IECore.GeometricData.Interpretation.Vector ) ) } )
+		result.append( "/Add/V2f/Normal", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2fData( imath.V2f( 0 ), IECore.GeometricData.Interpretation.Normal ) ) } )
+		result.append( "/Add/V2f/Point", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V2fData( imath.V2f( 0 ), IECore.GeometricData.Interpretation.Point ) ) } )
 
-		result.append( "/Add/V3f/Vector", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Vector ) ) } )
-		result.append( "/Add/V3f/Normal", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Normal ) ) } )
-		result.append( "/Add/V3f/Point", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3fData( IECore.V3f( 0 ), IECore.GeometricData.Interpretation.Point ) ) } )
+		result.append( "/Add/V3f/Vector", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Vector ) ) } )
+		result.append( "/Add/V3f/Normal", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Normal ) ) } )
+		result.append( "/Add/V3f/Point", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Point ) ) } )
 
 		result.append( "/Add/VectorDivider", { "divider" : True } )
 
-		result.append( "/Add/Color3f", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.Color3fData( IECore.Color3f( 0 ) ) ) } )
-		result.append( "/Add/Color4f", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.Color4fData( IECore.Color4f( 0, 0, 0, 1 ) ) ) } )
+		result.append( "/Add/Color3f", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.Color3fData( imath.Color3f( 0 ) ) ) } )
+		result.append( "/Add/Color4f", { "command" : functools.partial( Gaffer.WeakMethod( self.__addItem ), "", IECore.Color4fData( imath.Color4f( 0, 0, 0, 1 ) ) ) } )
 
 		result.append( "/Add/BoxDivider", { "divider" : True } )
 
-		result.append( "/Add/Box2i", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.Box2iData( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 1 ) ) ) ) } )
-		result.append( "/Add/Box2f", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.Box2fData( IECore.Box2f( IECore.V2f( 0 ), IECore.V2f( 1 ) ) ) ) } )
-		result.append( "/Add/Box3i", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.Box3iData( IECore.Box3i( IECore.V3i( 0 ), IECore.V3i( 1 ) ) ) ) } )
-		result.append( "/Add/Box3f", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.Box3fData( IECore.Box3f( IECore.V3f( 0 ), IECore.V3f( 1 ) ) ) ) } )
+		result.append( "/Add/Box2i", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.Box2iData( imath.Box2i( imath.V2i( 0 ), imath.V2i( 1 ) ) ) ) } )
+		result.append( "/Add/Box2f", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.Box2fData( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) ) ) } )
+		result.append( "/Add/Box3i", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.Box3iData( imath.Box3i( imath.V3i( 0 ), imath.V3i( 1 ) ) ) ) } )
+		result.append( "/Add/Box3f", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.Box3fData( imath.Box3f( imath.V3f( 0 ), imath.V3f( 1 ) ) ) ) } )
 
 		return result
 

--- a/python/GafferUI/CompoundPathFilterWidget.py
+++ b/python/GafferUI/CompoundPathFilterWidget.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -60,7 +62,7 @@ class CompoundPathFilterWidget( GafferUI.PathFilterWidget ) :
 		for y in range( self.__grid.gridSize().y - 1, -1, -1 ) :
 			self.__grid.removeRow( y )
 
-		gridPos = IECore.V2i( 0 )
+		gridPos = imath.V2i( 0 )
 		for filter in self.pathFilter().getFilters() :
 
 			filterWidget = GafferUI.PathFilterWidget.create( filter )

--- a/python/GafferUI/DeferredPathPreview.py
+++ b/python/GafferUI/DeferredPathPreview.py
@@ -37,6 +37,7 @@
 import weakref
 import threading
 import functools
+import imath
 
 import IECore
 
@@ -58,7 +59,7 @@ class DeferredPathPreview( GafferUI.PathPreviewWidget ) :
 		self.__tabbedContainer.setTabsVisible( False )
 		self.__tabbedContainer.append( GafferUI.BusyWidget( size = 25 ) ) # for when we're loading
 		self.__tabbedContainer.append( displayWidget ) # for when we loaded ok
-		self.__tabbedContainer.append( GafferUI.Spacer( size = IECore.V2i( 10 ) ) ) # for when we didn't load ok
+		self.__tabbedContainer.append( GafferUI.Spacer( size = imath.V2i( 10 ) ) ) # for when we didn't load ok
 
 		# a timer we use to display the busy status if loading takes too long
 		self.__busyTimer = QtCore.QTimer()

--- a/python/GafferUI/DotUI.py
+++ b/python/GafferUI/DotUI.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import functools
+import imath
 
 import IECore
 
@@ -146,11 +147,11 @@ def __insertDot( menu, destinationPlug ) :
 
 		menuPosition = menu.popupPosition( relativeTo = gadgetWidget )
 		position = gadgetWidget.getViewportGadget().rasterToGadgetSpace(
-			IECore.V2f( menuPosition.x, menuPosition.y ),
+			imath.V2f( menuPosition.x, menuPosition.y ),
 			gadget = graphGadget
 		).p0
 
-		graphGadget.setNodePosition( node, IECore.V2f( position.x, position.y ) )
+		graphGadget.setNodePosition( node, imath.V2f( position.x, position.y ) )
 
 def __connectionContextMenu( nodeGraph, destinationPlug, menuDefinition ) :
 

--- a/python/GafferUI/EditMenu.py
+++ b/python/GafferUI/EditMenu.py
@@ -37,6 +37,7 @@
 
 import sys
 import collections
+import imath
 
 import IECore
 
@@ -174,15 +175,15 @@ def paste( menu ) :
 		bound = s.nodeGraph.bound()
 		mousePosition = GafferUI.Widget.mousePosition()
 		if bound.intersects( mousePosition ) :
-			fallbackPosition = mousePosition - bound.min
+			fallbackPosition = mousePosition - bound.min()
 		else :
-			fallbackPosition = bound.center() - bound.min
+			fallbackPosition = bound.center() - bound.min()
 
 		fallbackPosition = s.nodeGraph.graphGadgetWidget().getViewportGadget().rasterToGadgetSpace(
-			IECore.V2f( fallbackPosition.x, fallbackPosition.y ),
+			imath.V2f( fallbackPosition.x, fallbackPosition.y ),
 			gadget = s.nodeGraph.graphGadget()
 		).p0
-		fallbackPosition = IECore.V2f( fallbackPosition.x, fallbackPosition.y )
+		fallbackPosition = imath.V2f( fallbackPosition.x, fallbackPosition.y )
 
 		s.nodeGraph.graphGadget().getLayout().positionNodes( s.nodeGraph.graphGadget(), s.script.selection(), fallbackPosition )
 

--- a/python/GafferUI/ErrorDialogue.py
+++ b/python/GafferUI/ErrorDialogue.py
@@ -36,6 +36,7 @@
 
 import sys
 import traceback
+import imath
 
 import IECore
 
@@ -63,7 +64,7 @@ class ErrorDialogue( GafferUI.Dialogue ) :
 				}
 			)
 
-			GafferUI.Spacer( IECore.V2i( 250, 1 ) )
+			GafferUI.Spacer( imath.V2i( 250, 1 ) )
 
 			if message is not None :
 				GafferUI.Label(

--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -38,6 +38,7 @@
 import re
 import os
 import functools
+import imath
 
 import IECore
 
@@ -302,10 +303,10 @@ def importFile( menu ) :
 
 			fallbackPosition = scope.nodeGraph.bound().size() / 2
 			fallbackPosition = scope.nodeGraph.graphGadgetWidget().getViewportGadget().rasterToGadgetSpace(
-				IECore.V2f( fallbackPosition.x, fallbackPosition.y ),
+				imath.V2f( fallbackPosition.x, fallbackPosition.y ),
 				gadget = scope.nodeGraph.graphGadget()
 			).p0
-			fallbackPosition = IECore.V2f( fallbackPosition.x, fallbackPosition.y )
+			fallbackPosition = imath.V2f( fallbackPosition.x, fallbackPosition.y )
 
 			scope.nodeGraph.graphGadget().getLayout().positionNodes(
 				scope.nodeGraph.graphGadget(), scope.script.selection(), fallbackPosition

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -43,6 +43,7 @@ import collections
 # when running in maya 2012 the default log level allows info messages through.
 # so we set a specific log level on the OpenGL logger to keep it quiet.
 logging.getLogger( "OpenGL" ).setLevel( logging.WARNING )
+import imath
 
 import IECore
 import IECoreGL
@@ -260,7 +261,7 @@ class _GLGraphicsView( QtWidgets.QGraphicsView ) :
 			# but it's safe.
 			IECoreGL.init( True )
 
-			owner._resize( IECore.V2i( event.size().width(), event.size().height() ) )
+			owner._resize( imath.V2i( event.size().width(), event.size().height() ) )
 
 	def keyPressEvent( self, event ) :
 

--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 import IECoreGL
 
@@ -282,8 +284,8 @@ class _EventFilter( QtCore.QObject ) :
 
 			toolTip = widget.getViewportGadget().getToolTip(
 				IECore.LineSegment3f(
-					IECore.V3f( qEvent.x(), qEvent.y(), 1 ),
-					IECore.V3f( qEvent.x(), qEvent.y(), 0 )
+					imath.V3f( qEvent.x(), qEvent.y(), 1 ),
+					imath.V3f( qEvent.x(), qEvent.y(), 0 )
 				)
 			 )
 

--- a/python/GafferUI/GridContainer.py
+++ b/python/GafferUI/GridContainer.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import GafferUI
@@ -73,19 +75,19 @@ class GridContainer( GafferUI.ContainerWidget ) :
 		# so we keep a track of the true dimensions (largest coordinate any widget
 		# currently has) ourselves. this is so we can implement gridSize() to return
 		# what we really want.
-		self.__maxCoordinate = IECore.V2i( -1 )
+		self.__maxCoordinate = imath.V2i( -1 )
 
 	def gridSize( self ) :
 
 		if self.__maxCoordinate is None :
-			self.__maxCoordinate = IECore.V2i( -1 )
+			self.__maxCoordinate = imath.V2i( -1 )
 			for x in range( 0, self.__qtLayout.columnCount() ) :
 				for y in range( 0, self.__qtLayout.rowCount() ) :
 					if self.__qtLayout.itemAtPosition( y, x ) is not None :
 						self.__maxCoordinate.x = max( self.__maxCoordinate.x, x )
 						self.__maxCoordinate.y = max( self.__maxCoordinate.y, y )
 
-		return self.__maxCoordinate + IECore.V2i( 1 )
+		return self.__maxCoordinate + imath.V2i( 1 )
 
 	def __setitem__( self, index, child ) :
 

--- a/python/GafferUI/Image.py
+++ b/python/GafferUI/Image.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import imath
 
 import IECore
 import IECoreImage
@@ -139,7 +140,7 @@ class Image( GafferUI.Widget ) :
 			targetType = IECore.UCharVectorData.staticTypeId(),
 		)
 
-		imageSize = image.dataWindow.size() + IECore.V2i( 1 )
+		imageSize = image.dataWindow.size() + imath.V2i( 1 )
 
 		s = interleaved.toString()
 		image = QtGui.QImage( s, imageSize.x, imageSize.y, format )

--- a/python/GafferUI/ListContainer.py
+++ b/python/GafferUI/ListContainer.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 import GafferUI
 
@@ -193,7 +195,7 @@ class ListContainer( GafferUI.ContainerWidget ) :
 
 	def addSpacer( self, width=0, height=0, expand=False, horizontalAlignment=None, verticalAlignment=None):
 
-		self.append( GafferUI.Spacer( IECore.V2i( width, height ) ), expand=expand, horizontalAlignment=horizontalAlignment, verticalAlignment=verticalAlignment )
+		self.append( GafferUI.Spacer( imath.V2i( width, height ) ), expand=expand, horizontalAlignment=horizontalAlignment, verticalAlignment=verticalAlignment )
 
 	def addChild( self, child, expand=False, horizontalAlignment=None, verticalAlignment=None ) :
 

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -126,7 +126,7 @@ class Menu( GafferUI.Widget ) :
 			return result
 
 		if relativeTo is not None :
-			result = result - relativeTo.bound().min
+			result = result - relativeTo.bound().min()
 
 		return result
 

--- a/python/GafferUI/MenuButton.py
+++ b/python/GafferUI/MenuButton.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -93,7 +95,7 @@ class MenuButton( GafferUI.Button ) :
 		b = self.bound()
 		self.__menu.popup(
 			parent = self,
-			position = IECore.V2i( b.min.x, b.max.y ),
+			position = imath.V2i( b.min().x, b.max().y ),
 		)
 
 	def __menuVisibilityChanged( self, menu ) :

--- a/python/GafferUI/MessageWidget.py
+++ b/python/GafferUI/MessageWidget.py
@@ -36,6 +36,7 @@
 
 import weakref
 import functools
+import imath
 
 import IECore
 
@@ -78,7 +79,7 @@ class MessageWidget( GafferUI.Widget ) :
 					button.setVisible( False )
 					button.setToolTip( buttonSpec[1] )
 
-				GafferUI.Spacer( IECore.V2i( 10 ) )
+				GafferUI.Spacer( imath.V2i( 10 ) )
 
 			self.__text = GafferUI.MultiLineTextWidget( editable=False )
 

--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import functools
+import imath
 
 import IECore
 
@@ -248,7 +249,7 @@ class NodeGraph( GafferUI.EditorWidget ) :
 			# mouse if possible.
 
 			viewport = self.__gadgetWidget.getViewportGadget()
-			gadgets = viewport.gadgetsAt( IECore.V2f( event.line.p1.x, event.line.p1.y ) )
+			gadgets = viewport.gadgetsAt( imath.V2f( event.line.p1.x, event.line.p1.y ) )
 			if len( gadgets ) :
 
 				overrideMenuDefinition = IECore.MenuDefinition()
@@ -286,7 +287,7 @@ class NodeGraph( GafferUI.EditorWidget ) :
 	def __nodeGadgetAt( self, position ) :
 
 		viewport = self.__gadgetWidget.getViewportGadget()
-		line = viewport.rasterToGadgetSpace( IECore.V2f( position.x, position.y ), gadget = self.graphGadget() )
+		line = viewport.rasterToGadgetSpace( imath.V2f( position.x, position.y ), gadget = self.graphGadget() )
 		return self.graphGadget().nodeGadgetAt( line )
 
 	def __keyPress( self, widget, event ) :
@@ -324,7 +325,7 @@ class NodeGraph( GafferUI.EditorWidget ) :
 		graphGadget = self.graphGadget()
 
 		# get the bounds of the nodes
-		bound = IECore.Box3f()
+		bound = imath.Box3f()
 		for node in nodes :
 			nodeGadget = graphGadget.nodeGadget( node )
 			if nodeGadget :
@@ -337,32 +338,32 @@ class NodeGraph( GafferUI.EditorWidget ) :
 
 		# if there's still nothing then an arbitrary area in the centre of the world
 		if bound.isEmpty() :
-			bound = IECore.Box3f( IECore.V3f( -10, -10, 0 ), IECore.V3f( 10, 10, 0 ) )
+			bound = imath.Box3f( imath.V3f( -10, -10, 0 ), imath.V3f( 10, 10, 0 ) )
 
 		# pad it a little bit so
 		# it sits nicer in the frame
-		bound.min -= IECore.V3f( 1, 1, 0 )
-		bound.max += IECore.V3f( 1, 1, 0 )
+		bound.setMin( bound.min() - imath.V3f( 1, 1, 0 ) )
+		bound.setMax( bound.max() + imath.V3f( 1, 1, 0 ) )
 
 		if extend :
 			# we're extending the existing framing, which we assume the
 			# user was happy with other than it not showing the nodes in question.
 			# so we just take the union of the existing frame and the one for the nodes.
 			cb = self.__currentFrame()
-			bound.extendBy( IECore.Box3f( IECore.V3f( cb.min.x, cb.min.y, 0 ), IECore.V3f( cb.max.x, cb.max.y, 0 ) ) )
+			bound.extendBy( imath.Box3f( imath.V3f( cb.min().x, cb.min().y, 0 ), imath.V3f( cb.max().x, cb.max().y, 0 ) ) )
 		else :
 			# we're reframing from scratch, so the frame for the nodes is all we need.
 			# we do however want to make sure that we don't zoom in too far if the node
 			# bounds are small, as having a single node filling the screen is of little use -
 			# it's better to see some context around it.
 			boundSize = bound.size()
-			widgetSize = IECore.V3f( self._qtWidget().width(), self._qtWidget().height(), 0 )
+			widgetSize = imath.V3f( self._qtWidget().width(), self._qtWidget().height(), 0 )
 			pixelsPerUnit = widgetSize / boundSize
 			adjustedPixelsPerUnit = min( pixelsPerUnit.x, pixelsPerUnit.y, 10 )
 			newBoundSize = widgetSize / adjustedPixelsPerUnit
 			boundCenter = bound.center()
-			bound.min = boundCenter - newBoundSize / 2.0
-			bound.max = boundCenter + newBoundSize / 2.0
+			bound.setMin( boundCenter - newBoundSize / 2.0 )
+			bound.setMax( boundCenter + newBoundSize / 2.0 )
 
 		self.__gadgetWidget.getViewportGadget().frame( bound )
 
@@ -411,8 +412,8 @@ class NodeGraph( GafferUI.EditorWidget ) :
 		camera = viewportGadget.getCamera()
 		frame = camera.parameters()["screenWindow"].value
 		translation = viewportGadget.getCameraTransform().translation()
-		frame.min += IECore.V2f( translation.x, translation.y )
-		frame.max += IECore.V2f( translation.x, translation.y )
+		frame.setMin( frame.min() + imath.V2f( translation.x, translation.y ) )
+		frame.setMax( frame.max() + imath.V2f( translation.x, translation.y ) )
 
 		return frame
 
@@ -426,7 +427,7 @@ class NodeGraph( GafferUI.EditorWidget ) :
 		frame = Gaffer.Metadata.value( self.graphGadget().getRoot(), "ui:nodeGraph:framing" )
 		if frame is not None :
 			self.graphGadgetWidget().getViewportGadget().frame(
-				IECore.Box3f( IECore.V3f( frame.min.x, frame.min.y, 0 ), IECore.V3f( frame.max.x, frame.max.y, 0 ) )
+				imath.Box3f( imath.V3f( frame.min().x, frame.min().y, 0 ), imath.V3f( frame.max().x, frame.max().y, 0 ) )
 			)
 		else :
 			self.__frame( self.graphGadget().getRoot().children( Gaffer.Node ) )
@@ -469,10 +470,10 @@ class NodeGraph( GafferUI.EditorWidget ) :
 
 		gadgetWidget = self.graphGadgetWidget()
 		fallbackPosition = gadgetWidget.getViewportGadget().rasterToGadgetSpace(
-			IECore.V2f( gadgetWidget.size() ) / 2.0,
+			imath.V2f( gadgetWidget.size() ) / 2.0,
 			gadget = graphGadget
 		).p0
-		fallbackPosition = IECore.V2f( fallbackPosition.x, fallbackPosition.y )
+		fallbackPosition = imath.V2f( fallbackPosition.x, fallbackPosition.y )
 
 		graphGadget.getLayout().positionNodes( graphGadget, nodes, fallbackPosition )
 		graphGadget.getLayout().layoutNodes( graphGadget, nodes )

--- a/python/GafferUI/NodeGraph.py
+++ b/python/GafferUI/NodeGraph.py
@@ -358,8 +358,10 @@ class NodeGraph( GafferUI.EditorWidget ) :
 			# it's better to see some context around it.
 			boundSize = bound.size()
 			widgetSize = imath.V3f( self._qtWidget().width(), self._qtWidget().height(), 0 )
-			pixelsPerUnit = widgetSize / boundSize
-			adjustedPixelsPerUnit = min( pixelsPerUnit.x, pixelsPerUnit.y, 10 )
+
+			pixelsPerUnit = min( widgetSize.x / boundSize.x, widgetSize.y / boundSize.y )
+			adjustedPixelsPerUnit = min( pixelsPerUnit, 10 )
+
 			newBoundSize = widgetSize / adjustedPixelsPerUnit
 			boundCenter = bound.center()
 			bound.setMin( boundCenter - newBoundSize / 2.0 )

--- a/python/GafferUI/NodeMenu.py
+++ b/python/GafferUI/NodeMenu.py
@@ -38,6 +38,7 @@
 import re
 import fnmatch
 import inspect
+import imath
 
 import IECore
 
@@ -132,10 +133,10 @@ class NodeMenu( object ) :
 			# the click location that opened the menu.
 			menuPosition = menu.popupPosition( relativeTo = gadgetWidget )
 			fallbackPosition = gadgetWidget.getViewportGadget().rasterToGadgetSpace(
-				IECore.V2f( menuPosition.x, menuPosition.y ),
+				imath.V2f( menuPosition.x, menuPosition.y ),
 				gadget = graphGadget
 			).p0
-			fallbackPosition = IECore.V2f( fallbackPosition.x, fallbackPosition.y )
+			fallbackPosition = imath.V2f( fallbackPosition.x, fallbackPosition.y )
 
 			graphGadget.getLayout().positionNode( graphGadget, node, fallbackPosition )
 

--- a/python/GafferUI/PathChooserWidget.py
+++ b/python/GafferUI/PathChooserWidget.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import functools
+import imath
 
 import IECore
 
@@ -81,7 +82,7 @@ class PathChooserWidget( GafferUI.Widget ) :
 				upButton.setToolTip( "Up one level" )
 				self.__upButtonClickedConnection = upButton.clickedSignal().connect( Gaffer.WeakMethod( self.__upButtonClicked ) )
 
-				GafferUI.Spacer( IECore.V2i( 2, 2 ) )
+				GafferUI.Spacer( imath.V2i( 2, 2 ) )
 
 				self.__dirPathWidget = GafferUI.PathWidget( tmpPath )
 

--- a/python/GafferUI/PathVectorDataWidget.py
+++ b/python/GafferUI/PathVectorDataWidget.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -111,7 +113,7 @@ class _Editor( GafferUI.ListContainer ) :
 			button = GafferUI.Button( image = "pathChooser.png", hasFrame = False )
 			self.__buttonClickedConnection = button.clickedSignal().connect( Gaffer.WeakMethod( self.__buttonClicked ) )
 
-			GafferUI.Spacer( IECore.V2i( 2 ) )
+			GafferUI.Spacer( imath.V2i( 2 ) )
 
 		# needed to give the focus to our main editable field when editing starts.
 		self._qtWidget().setFocusProxy( self.__pathWidget()._qtWidget() )

--- a/python/GafferUI/PathWidget.py
+++ b/python/GafferUI/PathWidget.py
@@ -38,6 +38,7 @@
 import os
 import warnings
 import functools
+import imath
 
 import IECore
 
@@ -223,7 +224,7 @@ class PathWidget( GafferUI.TextWidget ) :
 				break
 
 		bound = self.bound()
-		return IECore.V2i( bound.min.x + x, bound.max.y )
+		return imath.V2i( bound.min().x + x, bound.max().y )
 
 	def __pathChanged( self, path ) :
 

--- a/python/GafferUI/RampPlugValueWidget.py
+++ b/python/GafferUI/RampPlugValueWidget.py
@@ -36,6 +36,7 @@
 
 import Gaffer
 import GafferUI
+import imath
 import IECore
 
 from Qt import QtCore
@@ -58,7 +59,7 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 				drawModeWidget.setSelection( "Ramp" )
 				self.__drawModeChangedConnection = drawModeWidget.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__drawModeChanged ) )
 
-				GafferUI.Spacer( IECore.V2i( 0 ), parenting = { "expand" : True } )
+				GafferUI.Spacer( imath.V2i( 0 ), parenting = { "expand" : True } )
 
 				# TODO: Since we don't have a good way to register metadata on child plugs, we just write the
 				# metadata on this child plug right before constructing a widget for it.  There should probably

--- a/python/GafferUI/SplineWidget.py
+++ b/python/GafferUI/SplineWidget.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -136,9 +138,9 @@ class SplineWidget( GafferUI.Widget ) :
 				t = float( i + 0.5 ) / numStops
 				c = self.__spline( t )
 				if isinstance( c, float ) :
-					c = IECore.Color3f( c, c, c )
+					c = imath.Color3f( c, c, c )
 				else :
-					c = IECore.Color3f( c[0], c[1], c[2] )
+					c = imath.Color3f( c[0], c[1], c[2] )
 
 				c = displayTransform( c )
 				self.__gradientToDraw.setPixel( i, 0, self._qtColor( c ).rgb() )
@@ -154,7 +156,7 @@ class SplineWidget( GafferUI.Widget ) :
 			interval = self.__spline.interval()
 			if isinstance( self.__spline, IECore.Splineff ) :
 				spline = IECore.Struct()
-				spline.color = IECore.Color3f( 1 )
+				spline.color = imath.Color3f( 1 )
 				spline.path = QtGui.QPainterPath()
 				for i in range( 0, numPoints ) :
 					t = float( i ) / ( numPoints - 1 )
@@ -169,9 +171,9 @@ class SplineWidget( GafferUI.Widget ) :
 				for i in range( 0, self.__spline( 0 ).dimensions() ) :
 					spline = IECore.Struct()
 					if i==3 :
-						spline.color = IECore.Color3f( 1 )
+						spline.color = imath.Color3f( 1 )
 					else :
-						c = IECore.Color3f( 0 )
+						c = imath.Color3f( 0 )
 						c[i] = 1
 						spline.color = c
 					spline.path = QtGui.QPainterPath()

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -39,6 +39,7 @@ import functools
 import types
 import re
 import collections
+import imath
 
 import IECore
 
@@ -232,7 +233,7 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 	@classmethod
 	def __setColor( cls, menu, node ) :
 
-		color = Gaffer.Metadata.value( node, "nodeGadget:color" ) or IECore.Color3f( 1 )
+		color = Gaffer.Metadata.value( node, "nodeGadget:color" ) or imath.Color3f( 1 )
 		dialogue = GafferUI.ColorChooserDialogue( color = color, useDisplayTransform = False )
 		color = dialogue.waitForColor( parentWindow = menu.ancestor( GafferUI.Window ) )
 		if color is not None :
@@ -510,7 +511,7 @@ class _ColorSwatchMetadataWidget( _MetadataWidget ) :
 		if value is not None :
 			self.__swatch.setColor( value )
 		else :
-			self.__swatch.setColor( IECore.Color4f( 0, 0, 0, 0 ) )
+			self.__swatch.setColor( imath.Color4f( 0, 0, 0, 0 ) )
 
 		self.__value = value
 
@@ -519,7 +520,7 @@ class _ColorSwatchMetadataWidget( _MetadataWidget ) :
 		if event.button != event.Buttons.Left :
 			return False
 
-		color = self.__value if self.__value is not None else IECore.Color3f( 1 )
+		color = self.__value if self.__value is not None else imath.Color3f( 1 )
 		dialogue = GafferUI.ColorChooserDialogue( color = color, useDisplayTransform = False )
 		color = dialogue.waitForColor( parentWindow = self.ancestor( GafferUI.Window ) )
 
@@ -1272,7 +1273,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 				self.__nameWidget = GafferUI.TextWidget()
 				self.__nameEditingFinishedConnection = self.__nameWidget.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__nameEditingFinished ) )
 
-				GafferUI.Spacer( IECore.V2i( 4 ), maximumSize = IECore.V2i( 4 ) )
+				GafferUI.Spacer( imath.V2i( 4 ), maximumSize = imath.V2i( 4 ) )
 
 				GafferUI.Label( "Value" )
 
@@ -1297,7 +1298,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 
 		self.__editingColumn.append( plugValueWidget if plugValueWidget is not None else GafferUI.TextWidget() )
 
-		self.__editingColumn.append( GafferUI.Spacer( IECore.V2i( 0 ), parenting = { "expand" : True } ) )
+		self.__editingColumn.append( GafferUI.Spacer( imath.V2i( 0 ), parenting = { "expand" : True } ) )
 
 		self.__updatePath()
 
@@ -1565,7 +1566,7 @@ class _PlugEditor( GafferUI.Widget ) :
 						_Label( "Connection Color" )
 						self.__metadataWidgets["connectionGadget:color"] = _ColorSwatchMetadataWidget( key = "connectionGadget:color" )
 
-			GafferUI.Spacer( IECore.V2i( 0 ), parenting = { "expand" : True } )
+			GafferUI.Spacer( imath.V2i( 0 ), parenting = { "expand" : True } )
 
 		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
 

--- a/python/GafferUI/UserPlugs.py
+++ b/python/GafferUI/UserPlugs.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import functools
+import imath
 
 import IECore
 
@@ -89,10 +90,10 @@ def plugCreationWidget( plugParent ) :
 
 	with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal ) as row :
 
-		GafferUI.Spacer( IECore.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
+		GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 		button = GafferUI.MenuButton( image="plus.png", hasFrame=False, menu=GafferUI.Menu( functools.partial( __plugCreationMenuDefinition, plugParent ) ) )
 		button.setToolTip( "Click to add plugs" )
-		GafferUI.Spacer( IECore.V2i( 1 ), IECore.V2i( 999999, 1 ), parenting = { "expand" : True } )
+		GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
 	return row
 

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import functools
+import imath
 
 import IECore
 
@@ -124,7 +125,7 @@ class VectorDataWidget( GafferUI.Widget ) :
 		self.__removeButtonConnection = removeButton.clickedSignal().connect( Gaffer.WeakMethod( self.__removeSelection ) )
 		self.__buttonRow.append( removeButton )
 
-		self.__buttonRow.append( GafferUI.Spacer( size = IECore.V2i( 0 ), maximumSize = IECore.V2i( 100000, 1 ) ), expand=1 )
+		self.__buttonRow.append( GafferUI.Spacer( size = imath.V2i( 0 ), maximumSize = imath.V2i( 100000, 1 ) ), expand=1 )
 		self.__column.append( self.__buttonRow )
 
 		# stuff for drag enter/leave and drop

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -38,6 +38,7 @@
 import weakref
 import inspect
 import warnings
+import imath
 
 import IECore
 
@@ -366,7 +367,7 @@ class Widget( object ) :
 	## \deprecated Use bound().size() instead.
 	def size( self ) :
 
-		return IECore.V2i( self.__qtWidget.width(), self.__qtWidget.height() )
+		return imath.V2i( self.__qtWidget.width(), self.__qtWidget.height() )
 
 	## Returns the bounding box of the Widget as a Box2i. If relativeTo
 	# is None then the bound is provided in screen coordinates, if a
@@ -394,11 +395,11 @@ class Widget( object ) :
 					pos = q.mapToParent( pos )
 				q = parentWidget
 
-		pos = IECore.V2i( pos.x(), pos.y() )
+		pos = imath.V2i( pos.x(), pos.y() )
 		if relativeTo is not None :
-			pos -= relativeTo.bound().min
+			pos -= relativeTo.bound().min()
 
-		return IECore.Box2i( pos, pos + IECore.V2i( self.__qtWidget.width(), self.__qtWidget.height() ) )
+		return imath.Box2i( pos, pos + imath.V2i( self.__qtWidget.width(), self.__qtWidget.height() ) )
 
 	def keyPressSignal( self ) :
 
@@ -591,9 +592,9 @@ class Widget( object ) :
 	def mousePosition( relativeTo=None ) :
 
 		p = QtGui.QCursor.pos()
-		p = IECore.V2i( p.x(), p.y() )
+		p = imath.V2i( p.x(), p.y() )
 		if relativeTo is not None :
-			p = p - relativeTo.bound().min
+			p = p - relativeTo.bound().min()
 
 		return p
 
@@ -1199,7 +1200,7 @@ class _EventFilter( QtCore.QObject ) :
 
 	def __doDragEnterAndLeave( self, qObject, qEvent ) :
 
-		cursorPos = IECore.V2i( qEvent.globalPos().x(), qEvent.globalPos().y() )
+		cursorPos = imath.V2i( qEvent.globalPos().x(), qEvent.globalPos().y() )
 		candidateWidget = Widget.widgetAt( cursorPos )
 
 		if candidateWidget is self.__dragDropEvent.destinationWidget :
@@ -1209,7 +1210,7 @@ class _EventFilter( QtCore.QObject ) :
 		if candidateWidget is not None :
 			while candidateWidget is not None :
 				if candidateWidget._dragEnterSignal is not None :
-					self.__dragDropEvent.line = self.__positionToLine( cursorPos - candidateWidget.bound().min )
+					self.__dragDropEvent.line = self.__positionToLine( cursorPos - candidateWidget.bound().min() )
 					if candidateWidget._dragEnterSignal( candidateWidget, self.__dragDropEvent ) :
 						newDestinationWidget = candidateWidget
 						break
@@ -1226,7 +1227,7 @@ class _EventFilter( QtCore.QObject ) :
 			previousDestinationWidget = self.__dragDropEvent.destinationWidget
 			self.__dragDropEvent.destinationWidget = newDestinationWidget
 			if previousDestinationWidget is not None and previousDestinationWidget._dragLeaveSignal is not None :
-				self.__dragDropEvent.line = self.__positionToLine( cursorPos - previousDestinationWidget.bound().min )
+				self.__dragDropEvent.line = self.__positionToLine( cursorPos - previousDestinationWidget.bound().min() )
 				previousDestinationWidget._dragLeaveSignal( previousDestinationWidget, self.__dragDropEvent )
 
 	def __updateDrag( self, qObject, qEvent ) :
@@ -1244,8 +1245,8 @@ class _EventFilter( QtCore.QObject ) :
 
 		if dst._dragMoveSignal :
 
-			cursorPos = IECore.V2i( qEvent.globalPos().x(), qEvent.globalPos().y() )
-			self.__dragDropEvent.line = self.__positionToLine( cursorPos - dst.bound().min )
+			cursorPos = imath.V2i( qEvent.globalPos().x(), qEvent.globalPos().y() )
+			self.__dragDropEvent.line = self.__positionToLine( cursorPos - dst.bound().min() )
 
 			dst._dragMoveSignal( dst, self.__dragDropEvent )
 
@@ -1283,12 +1284,12 @@ class _EventFilter( QtCore.QObject ) :
 
 		# Emit dropSignal() on the destination.
 
-		cursorPos = IECore.V2i( qEvent.globalPos().x(), qEvent.globalPos().y() )
+		cursorPos = imath.V2i( qEvent.globalPos().x(), qEvent.globalPos().y() )
 
 		dst = dragDropEvent.destinationWidget
 		if dst is not None and dst._dropSignal :
 
-			dragDropEvent.line = self.__positionToLine( cursorPos - dst.bound().min )
+			dragDropEvent.line = self.__positionToLine( cursorPos - dst.bound().min() )
 			dragDropEvent.dropResult = dst._dropSignal( dst, dragDropEvent )
 
 		# Emit dragEndSignal() on source.
@@ -1296,7 +1297,7 @@ class _EventFilter( QtCore.QObject ) :
 		src = dragDropEvent.sourceWidget
 		if src._dragEndSignal :
 
-			dragDropEvent.line = self.__positionToLine( cursorPos - src.bound().min )
+			dragDropEvent.line = self.__positionToLine( cursorPos - src.bound().min() )
 
 			src._dragEndSignal(
 				src,
@@ -1307,14 +1308,14 @@ class _EventFilter( QtCore.QObject ) :
 
 	def __positionToLine( self, pos ) :
 
-		if isinstance( pos, IECore.V2i ) :
+		if isinstance( pos, imath.V2i ) :
 			x, y = pos.x, pos.y
 		else :
 			x, y = pos.x(), pos.y()
 
 		return IECore.LineSegment3f(
-			IECore.V3f( x, y, 1 ),
-			IECore.V3f( x, y, 0 )
+			imath.V3f( x, y, 1 ),
+			imath.V3f( x, y, 0 )
 		)
 
 # this single instance is used by all widgets

--- a/python/GafferUI/Window.py
+++ b/python/GafferUI/Window.py
@@ -37,6 +37,7 @@
 
 import sys
 import warnings
+import imath
 
 import IECore
 
@@ -267,7 +268,7 @@ class Window( GafferUI.ContainerWidget ) :
 
 	def getPosition( self ) :
 
-		return IECore.V2i( self._qtWidget().x(), self._qtWidget().y() )
+		return imath.V2i( self._qtWidget().x(), self._qtWidget().y() )
 
 	def setFullScreen( self, fullScreen ) :
 

--- a/python/GafferUITest/BoxUITest.py
+++ b/python/GafferUITest/BoxUITest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -72,8 +74,8 @@ class BoxUITest( GafferUITest.TestCase ) :
 
 		boxGadget = g.nodeGadget( box )
 
-		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["op1"] ) ), IECore.V3f( -1, 0, 0 ) )
-		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["sum"] ) ), IECore.V3f( 1, 0, 0 ) )
+		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["op1"] ) ), imath.V3f( -1, 0, 0 ) )
+		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( box["sum"] ) ), imath.V3f( 1, 0, 0 ) )
 
 		# Now test that a copy/paste of the box maintains the tangents in the copy.
 
@@ -85,8 +87,8 @@ class BoxUITest( GafferUITest.TestCase ) :
 		box2 = s2[box.getName()]
 		boxGadget2 = g2.nodeGadget( box2 )
 
-		self.assertEqual( boxGadget2.noduleTangent( boxGadget2.nodule( box2["op1"] ) ), IECore.V3f( -1, 0, 0 ) )
-		self.assertEqual( boxGadget2.noduleTangent( boxGadget2.nodule( box2["sum"] ) ), IECore.V3f( 1, 0, 0 ) )
+		self.assertEqual( boxGadget2.noduleTangent( boxGadget2.nodule( box2["op1"] ) ), imath.V3f( -1, 0, 0 ) )
+		self.assertEqual( boxGadget2.noduleTangent( boxGadget2.nodule( box2["sum"] ) ), imath.V3f( 1, 0, 0 ) )
 
 	def testNodulePositionsForPromotedPlugs( self ) :
 
@@ -101,8 +103,8 @@ class BoxUITest( GafferUITest.TestCase ) :
 		p1 = Gaffer.PlugAlgo.promote( s["b"]["n"]["op1"] )
 		p2 = Gaffer.PlugAlgo.promote( s["b"]["n"]["sum"] )
 
-		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( p1 ) ), IECore.V3f( -1, 0, 0 ) )
-		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( p2 ) ), IECore.V3f( 1, 0, 0 ) )
+		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( p1 ) ), imath.V3f( -1, 0, 0 ) )
+		self.assertEqual( boxGadget.noduleTangent( boxGadget.nodule( p2 ) ), imath.V3f( 1, 0, 0 ) )
 
 	def testDisabledNodulesForPromotedPlugs( self ) :
 

--- a/python/GafferUITest/ButtonTest.py
+++ b/python/GafferUITest/ButtonTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 
@@ -95,7 +96,7 @@ class ButtonTest( GafferUITest.TestCase ) :
 		w.setVisible( True )
 		self.waitForIdle()
 
-		self.assertEqual( b.bound().size(), IECore.V2i( 10 ) )
+		self.assertEqual( b.bound().size(), imath.V2i( 10 ) )
 
 		b.setHasFrame( True )
 		self.waitForIdle( 1000 )

--- a/python/GafferUITest/ColorSwatchTest.py
+++ b/python/GafferUITest/ColorSwatchTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -48,11 +49,11 @@ class ColorSwatchTest( GafferUITest.TestCase ) :
 
 		c = GafferUI.ColorSwatch()
 
-		self.assertEqual( c.getColor(), IECore.Color4f( 1 ) )
+		self.assertEqual( c.getColor(), imath.Color4f( 1 ) )
 
-		c.setColor( IECore.Color3f( 1, 2, 3 ) )
+		c.setColor( imath.Color3f( 1, 2, 3 ) )
 
-		self.assertEqual( c.getColor(), IECore.Color3f( 1, 2, 3 ) )
+		self.assertEqual( c.getColor(), imath.Color3f( 1, 2, 3 ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/DotNodeGadgetTest.py
+++ b/python/GafferUITest/DotNodeGadgetTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -60,8 +61,8 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		self.assertTrue( g.nodule( s["d"]["in"] ) is not None )
 		self.assertTrue( g.nodule( s["d"]["out"] ) is not None )
 
-		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["in"] ) ), IECore.V3f( 0, 1, 0 ) )
-		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["out"] ) ), IECore.V3f( 0, -1, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["in"] ) ), imath.V3f( 0, 1, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["out"] ) ), imath.V3f( 0, -1, 0 ) )
 
 	def testCustomNoduleTangentsFromInput( self ) :
 
@@ -79,8 +80,8 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		self.assertTrue( g.nodule( s["d"]["in"] ) is not None )
 		self.assertTrue( g.nodule( s["d"]["out"] ) is not None )
 
-		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["in"] ) ), IECore.V3f( -1, 0, 0 ) )
-		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["out"] ) ), IECore.V3f( 1, 0, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["in"] ) ), imath.V3f( -1, 0, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["out"] ) ), imath.V3f( 1, 0, 0 ) )
 
 	def testCustomNoduleTangentsFromOutput( self ) :
 
@@ -98,8 +99,8 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		self.assertTrue( g.nodule( s["d"]["in"] ) is not None )
 		self.assertTrue( g.nodule( s["d"]["out"] ) is not None )
 
-		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["in"] ) ), IECore.V3f( -1, 0, 0 ) )
-		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["out"] ) ), IECore.V3f( 1, 0, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["in"] ) ), imath.V3f( -1, 0, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["out"] ) ), imath.V3f( 1, 0, 0 ) )
 
 	def testCustomNoduleTangentsPreferInputIfAvailable( self ) :
 
@@ -120,8 +121,8 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		# as a way of conveniently making that output available at other places in the graph.
 		s["d"].setup( s["n2"]["op1"] )
 
-		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["in"] ) ), IECore.V3f( -1, 0, 0 ) )
-		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["out"] ) ), IECore.V3f( 1, 0, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["in"] ) ), imath.V3f( -1, 0, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( s["d"]["out"] ) ), imath.V3f( 1, 0, 0 ) )
 
 	def testCutAndPasteKeepsTangents( self ) :
 
@@ -138,12 +139,12 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 
 		dotNodeGadget = graphGadget.nodeGadget( s["d"] )
 
-		self.assertEqual( dotNodeGadget.noduleTangent( dotNodeGadget.nodule( s["d"]["in"] ) ), IECore.V3f( -1, 0, 0 ) )
+		self.assertEqual( dotNodeGadget.noduleTangent( dotNodeGadget.nodule( s["d"]["in"] ) ), imath.V3f( -1, 0, 0 ) )
 
 		s.execute( s.serialise( filter = Gaffer.StandardSet( [ s["n"], s["d"] ] ) ) )
 
 		dot1NodeGadget = graphGadget.nodeGadget( s["d1"] )
-		self.assertEqual( dot1NodeGadget.noduleTangent( dot1NodeGadget.nodule( s["d1"]["in"] ) ), IECore.V3f( -1, 0, 0 ) )
+		self.assertEqual( dot1NodeGadget.noduleTangent( dot1NodeGadget.nodule( s["d1"]["in"] ) ), imath.V3f( -1, 0, 0 ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/GLWidgetTest.py
+++ b/python/GafferUITest/GLWidgetTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -75,7 +77,7 @@ class GLWidgetTest( GafferUITest.TestCase ) :
 
 		self.waitForIdle( 1000 )
 
-		self.assertTrue( GafferUI.Widget.widgetAt( w.bound().min + IECore.V2i( 4 ) ) is b )
+		self.assertTrue( GafferUI.Widget.widgetAt( w.bound().min() + imath.V2i( 4 ) ) is b )
 
 	def testOverlayBound( self ) :
 
@@ -91,16 +93,16 @@ class GLWidgetTest( GafferUITest.TestCase ) :
 		w.setVisible( True )
 		self.waitForIdle( 1000 )
 
-		w.setPosition( IECore.V2i( 100 ) )
+		w.setPosition( imath.V2i( 100 ) )
 		self.waitForIdle( 1000 )
 		b1 = b.bound()
 
-		w.setPosition( IECore.V2i( 200 ) )
+		w.setPosition( imath.V2i( 200 ) )
 		self.waitForIdle( 1000 )
 		b2 = b.bound()
 
-		self.assertEqual( b2.min, b1.min + IECore.V2i( 100 ) )
-		self.assertEqual( b2.max, b1.max + IECore.V2i( 100 ) )
+		self.assertEqual( b2.min(), b1.min() + imath.V2i( 100 ) )
+		self.assertEqual( b2.max(), b1.max() + imath.V2i( 100 ) )
 
 	def testOverlayMousePosition( self ) :
 
@@ -115,7 +117,7 @@ class GLWidgetTest( GafferUITest.TestCase ) :
 
 		w.setVisible( True )
 
-		w.setPosition( IECore.V2i( 100 ) )
+		w.setPosition( imath.V2i( 100 ) )
 		self.waitForIdle( 1000 )
 
 		wBound = w.bound()
@@ -124,7 +126,7 @@ class GLWidgetTest( GafferUITest.TestCase ) :
 		wP = GafferUI.Widget.mousePosition( relativeTo = w )
 		bP = GafferUI.Widget.mousePosition( relativeTo = b )
 
-		self.assertEqual( bBound.min - wBound.min, wP - bP )
+		self.assertEqual( bBound.min() - wBound.min(), wP - bP )
 
 	def testOverlayAccessors( self ) :
 

--- a/python/GafferUITest/GadgetTest.py
+++ b/python/GafferUITest/GadgetTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -49,9 +50,9 @@ class GadgetTest( GafferUITest.TestCase ) :
 	def testTransform( self ) :
 
 		g = GafferUI.TextGadget( "hello" )
-		self.assertEqual( g.getTransform(), IECore.M44f() )
+		self.assertEqual( g.getTransform(), imath.M44f() )
 
-		t = IECore.M44f.createScaled( IECore.V3f( 2 ) )
+		t = imath.M44f().scale( imath.V3f( 2 ) )
 		g.setTransform( t )
 		self.assertEqual( g.getTransform(), t )
 
@@ -60,7 +61,7 @@ class GadgetTest( GafferUITest.TestCase ) :
 
 		c2 = GafferUI.LinearContainer()
 		c2.addChild( c1 )
-		t2 = IECore.M44f.createTranslated( IECore.V3f( 1, 2, 3 ) )
+		t2 = imath.M44f().translate( imath.V3f( 1, 2, 3 ) )
 		c2.setTransform( t2 )
 
 		self.assertEqual( g.fullTransform(), t * t2 )
@@ -86,7 +87,7 @@ class GadgetTest( GafferUITest.TestCase ) :
 
 			def bound( self ) :
 
-				return IECore.Box3f( IECore.V3f( -20, 10, 2 ), IECore.V3f( 10, 15, 5 ) )
+				return imath.Box3f( imath.V3f( -20, 10, 2 ), imath.V3f( 10, 15, 5 ) )
 
 			def doRenderLayer( self, layer, style ) :
 
@@ -156,7 +157,7 @@ class GadgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( len( cs ), 2 )
 		self.assertTrue( cs[1][0].isSame( g ) )
 
-		s2.setColor( GafferUI.StandardStyle.Color.BackgroundColor, IECore.Color3f( 1 ) )
+		s2.setColor( GafferUI.StandardStyle.Color.BackgroundColor, imath.Color3f( 1 ) )
 		self.assertEqual( len( cs ), 3 )
 		self.assertTrue( cs[2][0].isSame( g ) )
 
@@ -247,7 +248,7 @@ class GadgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( t.bound(), b )
 		# but we don't want it taken into account when computing
 		# the parent bound.
-		self.assertEqual( g.bound(), IECore.Box3f() )
+		self.assertEqual( g.bound(), imath.Box3f() )
 
 	def testVisibilityChangedSignal( self ) :
 

--- a/python/GafferUITest/GraphGadgetTest.py
+++ b/python/GafferUITest/GraphGadgetTest.py
@@ -37,6 +37,7 @@
 
 import unittest
 import threading
+import imath
 
 import IECore
 
@@ -495,16 +496,16 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 			g = GafferUI.GraphGadget( script )
 			c = g.connectionGadget( script["n2"]["i"] )
 
-			gb = IECore.Box3f()
+			gb = imath.Box3f()
 			gb.extendBy( g.nodeGadget( script["n1"] ).bound() )
 			gb.extendBy( g.nodeGadget( script["n2"] ).bound() )
-			gb.min -= IECore.V3f( 10 )
-			gb.max += IECore.V3f( 10 )
+			gb.setMin( gb.min() - imath.V3f( 10 ) )
+			gb.setMax( gb.max() + imath.V3f( 10 ) )
 
 			b = c.bound()
 			self.failIf( b.isEmpty() )
 
-			self.failUnless( gb.contains( b ) )
+			self.failUnless( IECore.BoxAlgo.contains( gb, b ) )
 
 	def testNoFilter( self ) :
 
@@ -599,8 +600,8 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		g = GafferUI.GraphGadget( s )
 
 		self.assertFalse( g.hasNodePosition( s["n"] ) )
-		g.setNodePosition( s["n"], IECore.V2f( -100, 2000 ) )
-		self.assertEqual( g.getNodePosition( s["n"] ), IECore.V2f( -100, 2000 ) )
+		g.setNodePosition( s["n"], imath.V2f( -100, 2000 ) )
+		self.assertEqual( g.getNodePosition( s["n"] ), imath.V2f( -100, 2000 ) )
 		self.assertTrue( g.hasNodePosition( s["n"] ) )
 
 	def testPlugConnectionGadgets( self ) :
@@ -1023,7 +1024,7 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		script["n"] = Gaffer.Node()
 
 		g = GafferUI.GraphGadget( script )
-		g.setNodePosition( script["n"], IECore.V2f( 1, 2 ) )
+		g.setNodePosition( script["n"], imath.V2f( 1, 2 ) )
 		self.assertTrue( g.hasNodePosition( script["n"] ) )
 
 		script.execute( script.serialise( script, Gaffer.StandardSet( [ script["n"] ] ) ) )
@@ -1253,7 +1254,7 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		s["n"] = Gaffer.Node()
 		self.assertEqual( g.unpositionedNodeGadgets(), [ g.nodeGadget( s["n"] ) ] )
 
-		g.setNodePosition( s["n"], IECore.V2f( 0 ) )
+		g.setNodePosition( s["n"], imath.V2f( 0 ) )
 		self.assertEqual( g.unpositionedNodeGadgets(), [] )
 
 	def testInputConnectionMaintainedOnNoduleMove( self ) :

--- a/python/GafferUITest/GridContainerTest.py
+++ b/python/GafferUITest/GridContainerTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -60,18 +61,18 @@ class GridContainerTest( GafferUITest.TestCase ) :
 		self.assertEqual( b3.parent(), None )
 		self.assertEqual( b4.parent(), None )
 
-		self.assertEqual( c.gridSize(), IECore.V2i( 0, 0 ) )
+		self.assertEqual( c.gridSize(), imath.V2i( 0, 0 ) )
 
 		c[0,0] = b1
 
-		self.assertEqual( c.gridSize(), IECore.V2i( 1, 1 ) )
+		self.assertEqual( c.gridSize(), imath.V2i( 1, 1 ) )
 
 		self.failUnless( b1.parent() is c )
 		self.failUnless( c[0,0] is b1 )
 
 		c[1,0] = b2
 
-		self.assertEqual( c.gridSize(), IECore.V2i( 2, 1 ) )
+		self.assertEqual( c.gridSize(), imath.V2i( 2, 1 ) )
 
 		self.failUnless( b1.parent() is c )
 		self.failUnless( b2.parent() is c )
@@ -80,7 +81,7 @@ class GridContainerTest( GafferUITest.TestCase ) :
 
 		c[0,1] = b3
 
-		self.assertEqual( c.gridSize(), IECore.V2i( 2, 2 ) )
+		self.assertEqual( c.gridSize(), imath.V2i( 2, 2 ) )
 
 		self.failUnless( b1.parent() is c )
 		self.failUnless( b2.parent() is c )
@@ -91,7 +92,7 @@ class GridContainerTest( GafferUITest.TestCase ) :
 
 		c[1,1] = b4
 
-		self.assertEqual( c.gridSize(), IECore.V2i( 2, 2 ) )
+		self.assertEqual( c.gridSize(), imath.V2i( 2, 2 ) )
 
 		self.failUnless( b1.parent() is c )
 		self.failUnless( b2.parent() is c )
@@ -176,31 +177,31 @@ class GridContainerTest( GafferUITest.TestCase ) :
 		b1 = GafferUI.Button( "b1" )
 		b2 = GafferUI.Button( "b2" )
 
-		self.assertEqual( c1.gridSize(), IECore.V2i( 0, 0 ) )
+		self.assertEqual( c1.gridSize(), imath.V2i( 0, 0 ) )
 
 		c1[0,0] = b1
 
-		self.assertEqual( c1.gridSize(), IECore.V2i( 1, 1 ) )
+		self.assertEqual( c1.gridSize(), imath.V2i( 1, 1 ) )
 
 		c1[1,0] = b2
 
-		self.assertEqual( c1.gridSize(), IECore.V2i( 2, 1 ) )
+		self.assertEqual( c1.gridSize(), imath.V2i( 2, 1 ) )
 
 		del c1[1,0]
 
-		self.assertEqual( c1.gridSize(), IECore.V2i( 1, 1 ) )
+		self.assertEqual( c1.gridSize(), imath.V2i( 1, 1 ) )
 
 		del c1[0,0]
 
-		self.assertEqual( c1.gridSize(), IECore.V2i( 0, 0 ) )
+		self.assertEqual( c1.gridSize(), imath.V2i( 0, 0 ) )
 
 		c1[1,0] = b2
 
-		self.assertEqual( c1.gridSize(), IECore.V2i( 2, 1 ) )
+		self.assertEqual( c1.gridSize(), imath.V2i( 2, 1 ) )
 
 		del c1[1,0]
 
-		self.assertEqual( c1.gridSize(), IECore.V2i( 0, 0 ) )
+		self.assertEqual( c1.gridSize(), imath.V2i( 0, 0 ) )
 
 	def testRemoveRow( self ) :
 
@@ -216,11 +217,11 @@ class GridContainerTest( GafferUITest.TestCase ) :
 		g[1,1] = b11
 		g[1,0] = b10
 
-		self.assertEqual( g.gridSize(), IECore.V2i( 2, 2 ) )
+		self.assertEqual( g.gridSize(), imath.V2i( 2, 2 ) )
 
 		g.removeRow( 0 )
 
-		self.assertEqual( g.gridSize(), IECore.V2i( 2, 1 ) )
+		self.assertEqual( g.gridSize(), imath.V2i( 2, 1 ) )
 
 		self.failUnless( g[0,0] is b01 )
 		self.failUnless( g[1,0] is b11 )
@@ -239,11 +240,11 @@ class GridContainerTest( GafferUITest.TestCase ) :
 		g[1,1] = b11
 		g[1,0] = b10
 
-		self.assertEqual( g.gridSize(), IECore.V2i( 2, 2 ) )
+		self.assertEqual( g.gridSize(), imath.V2i( 2, 2 ) )
 
 		g.removeColumn( 0 )
 
-		self.assertEqual( g.gridSize(), IECore.V2i( 1, 2 ) )
+		self.assertEqual( g.gridSize(), imath.V2i( 1, 2 ) )
 
 		self.failUnless( g[0,0] is b10 )
 		self.failUnless( g[0,1] is b11 )
@@ -262,11 +263,11 @@ class GridContainerTest( GafferUITest.TestCase ) :
 		g[1,1] = b11
 		g[1,0] = b10
 
-		self.assertEqual( g.gridSize(), IECore.V2i( 2, 2 ) )
+		self.assertEqual( g.gridSize(), imath.V2i( 2, 2 ) )
 
 		del g[0:2,0]
 
-		self.assertEqual( g.gridSize(), IECore.V2i( 2, 2 ) )
+		self.assertEqual( g.gridSize(), imath.V2i( 2, 2 ) )
 
 		self.failUnless( g[0,0] is None )
 		self.failUnless( g[1,0] is None )
@@ -285,7 +286,7 @@ class GridContainerTest( GafferUITest.TestCase ) :
 
 		self.failUnless( b1.parent() is g )
 
-		self.assertEqual( g.gridSize(), IECore.V2i( 2, 2 ) )
+		self.assertEqual( g.gridSize(), imath.V2i( 2, 2 ) )
 
 		self.failUnless( g[0,0] is b1 )
 		self.failUnless( g[0,1] is b1 )
@@ -295,7 +296,7 @@ class GridContainerTest( GafferUITest.TestCase ) :
 		del g[0,0]
 
 		self.failUnless( b1.parent() is None )
-		self.assertEqual( g.gridSize(), IECore.V2i( 0, 0 ) )
+		self.assertEqual( g.gridSize(), imath.V2i( 0, 0 ) )
 
 	def testSetChildOnTopOfMultiCellChild( self ) :
 
@@ -308,13 +309,13 @@ class GridContainerTest( GafferUITest.TestCase ) :
 
 		self.failUnless( b1.parent() is g )
 
-		self.assertEqual( g.gridSize(), IECore.V2i( 2, 2 ) )
+		self.assertEqual( g.gridSize(), imath.V2i( 2, 2 ) )
 
 		g[0,0] = b2
 
 		self.failUnless( b1.parent() is None )
 		self.failUnless( b2.parent() is g )
-		self.assertEqual( g.gridSize(), IECore.V2i( 1, 1 ) )
+		self.assertEqual( g.gridSize(), imath.V2i( 1, 1 ) )
 
 	def testRemoveRowContainingMultiCellChild( self ) :
 
@@ -324,12 +325,12 @@ class GridContainerTest( GafferUITest.TestCase ) :
 
 		g[0:2,0:2] = b1
 
-		self.assertEqual( g.gridSize(), IECore.V2i( 2, 2 ) )
+		self.assertEqual( g.gridSize(), imath.V2i( 2, 2 ) )
 
 		g.removeRow( 0 )
 
 		self.failUnless( b1.parent() is None )
-		self.assertEqual( g.gridSize(), IECore.V2i( 0, 0 ) )
+		self.assertEqual( g.gridSize(), imath.V2i( 0, 0 ) )
 
 	def testRemoveColumnContainingMultiCellChild( self ) :
 
@@ -339,12 +340,12 @@ class GridContainerTest( GafferUITest.TestCase ) :
 
 		g[0:2,0:2] = b1
 
-		self.assertEqual( g.gridSize(), IECore.V2i( 2, 2 ) )
+		self.assertEqual( g.gridSize(), imath.V2i( 2, 2 ) )
 
 		g.removeColumn( 0 )
 
 		self.failUnless( b1.parent() is None )
-		self.assertEqual( g.gridSize(), IECore.V2i( 0, 0 ) )
+		self.assertEqual( g.gridSize(), imath.V2i( 0, 0 ) )
 
 	def testAutomaticParenting( self ) :
 

--- a/python/GafferUITest/ImageGadgetTest.py
+++ b/python/GafferUITest/ImageGadgetTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import imath
 
 import IECore
 import IECoreImage
@@ -47,17 +48,17 @@ class ImageGadgetTest( GafferUITest.TestCase ) :
 
 	def testConstructFromImagePrimitive( self ) :
 
-		window = IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 255 ) )
-		imagePrimitive = IECoreImage.ImagePrimitive.createRGBFloat( IECore.Color3f( 0.25, .5, .75 ), window, window )
+		window = imath.Box2i( imath.V2i( 0 ), imath.V2i( 255 ) )
+		imagePrimitive = IECoreImage.ImagePrimitive.createRGBFloat( imath.Color3f( 0.25, .5, .75 ), window, window )
 
 		i = GafferUI.ImageGadget( imagePrimitive )
-		self.assertEqual( i.bound(), IECore.Box3f( IECore.V3f( -128, -128, 0 ), IECore.V3f( 128, 128, 0 ) ) )
+		self.assertEqual( i.bound(), imath.Box3f( imath.V3f( -128, -128, 0 ), imath.V3f( 128, 128, 0 ) ) )
 
 	def testConstructFromFile( self ) :
 
 		i = GafferUI.ImageGadget( "arrowRight10.png" )
 
-		self.assertEqual( i.bound(), IECore.Box3f( IECore.V3f( -5, -5, 0 ), IECore.V3f( 5, 5, 0 ) ) )
+		self.assertEqual( i.bound(), imath.Box3f( imath.V3f( -5, -5, 0 ), imath.V3f( 5, 5, 0 ) ) )
 
 	def testMissingFiles( self ) :
 

--- a/python/GafferUITest/LinearContainerTest.py
+++ b/python/GafferUITest/LinearContainerTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -93,124 +94,124 @@ class LinearContainerTest( GafferUITest.TestCase ) :
 
 	def testHorizontalCentred( self ) :
 
-		twoByFour = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( -1, -2, 0 ), IECore.V3f( 1, 2, 0 ) ) )
-		fourByFour = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( -2, -2, 0 ), IECore.V3f( 2, 2, 0 ) ) )
-		fourByTwo = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( -2, -1, 0 ), IECore.V3f( 2, 1, 0 ) ) )
+		twoByFour = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( -1, -2, 0 ), imath.V3f( 1, 2, 0 ) ) )
+		fourByFour = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( -2, -2, 0 ), imath.V3f( 2, 2, 0 ) ) )
+		fourByTwo = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( -2, -1, 0 ), imath.V3f( 2, 1, 0 ) ) )
 
 		c = GafferUI.LinearContainer()
 
 		c["c1"] = twoByFour
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -1, -2, 0 ), IECore.V3f( 1, 2, 0 ) ) )
-		self.assertEqual( twoByFour.getTransform(), IECore.M44f.createTranslated( IECore.V3f( 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -1, -2, 0 ), imath.V3f( 1, 2, 0 ) ) )
+		self.assertEqual( twoByFour.getTransform(), imath.M44f().translate( imath.V3f( 0 ) ) )
 
 		c["c2"] = fourByFour
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -3, -2, 0 ), IECore.V3f( 3, 2, 0 ) ) )
-		self.assertEqual( twoByFour.getTransform(), IECore.M44f.createTranslated( IECore.V3f( -2, 0, 0 ) ) )
-		self.assertEqual( fourByFour.getTransform(), IECore.M44f.createTranslated( IECore.V3f( 1, 0, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -3, -2, 0 ), imath.V3f( 3, 2, 0 ) ) )
+		self.assertEqual( twoByFour.getTransform(), imath.M44f().translate( imath.V3f( -2, 0, 0 ) ) )
+		self.assertEqual( fourByFour.getTransform(), imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) )
 
 		c["c3"] = fourByTwo
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -5, -2, 0 ), IECore.V3f( 5, 2, 0 ) ) )
-		self.assertEqual( twoByFour.getTransform(), IECore.M44f.createTranslated( IECore.V3f( -4, 0, 0 ) ) )
-		self.assertEqual( fourByFour.getTransform(), IECore.M44f.createTranslated( IECore.V3f( -1, 0, 0 ) ) )
-		self.assertEqual( fourByTwo.getTransform(), IECore.M44f.createTranslated( IECore.V3f( 3, 0, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -5, -2, 0 ), imath.V3f( 5, 2, 0 ) ) )
+		self.assertEqual( twoByFour.getTransform(), imath.M44f().translate( imath.V3f( -4, 0, 0 ) ) )
+		self.assertEqual( fourByFour.getTransform(), imath.M44f().translate( imath.V3f( -1, 0, 0 ) ) )
+		self.assertEqual( fourByTwo.getTransform(), imath.M44f().translate( imath.V3f( 3, 0, 0 ) ) )
 
 	def testVerticalMin( self ) :
 
-		twoByFour = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( -1, -2, 0 ), IECore.V3f( 1, 2, 0 ) ) )
-		fourByFour = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( -2, -2, 0 ), IECore.V3f( 2, 2, 0 ) ) )
-		fourByTwo = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( -2, -1, 0 ), IECore.V3f( 2, 1, 0 ) ) )
+		twoByFour = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( -1, -2, 0 ), imath.V3f( 1, 2, 0 ) ) )
+		fourByFour = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( -2, -2, 0 ), imath.V3f( 2, 2, 0 ) ) )
+		fourByTwo = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( -2, -1, 0 ), imath.V3f( 2, 1, 0 ) ) )
 
 		c = GafferUI.LinearContainer( orientation=GafferUI.LinearContainer.Orientation.Y, alignment=GafferUI.LinearContainer.Alignment.Min)
 
 		c["c1"] = twoByFour
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -1, -2, 0 ), IECore.V3f( 1, 2, 0 ) ) )
-		self.assertEqual( twoByFour.getTransform(), IECore.M44f.createTranslated( IECore.V3f( 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -1, -2, 0 ), imath.V3f( 1, 2, 0 ) ) )
+		self.assertEqual( twoByFour.getTransform(), imath.M44f().translate( imath.V3f( 0 ) ) )
 
 		c["c2"] = fourByFour
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -2, -4, 0 ), IECore.V3f( 2, 4, 0 ) ) )
-		self.assertEqual( twoByFour.getTransform(), IECore.M44f.createTranslated( IECore.V3f( -1, -2, 0 ) ) )
-		self.assertEqual( fourByFour.getTransform(), IECore.M44f.createTranslated( IECore.V3f( 0, 2, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -2, -4, 0 ), imath.V3f( 2, 4, 0 ) ) )
+		self.assertEqual( twoByFour.getTransform(), imath.M44f().translate( imath.V3f( -1, -2, 0 ) ) )
+		self.assertEqual( fourByFour.getTransform(), imath.M44f().translate( imath.V3f( 0, 2, 0 ) ) )
 
 		c["c3"] = fourByTwo
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -2, -5, 0 ), IECore.V3f( 2, 5, 0 ) ) )
-		self.assertEqual( twoByFour.getTransform(), IECore.M44f.createTranslated( IECore.V3f( -1, -3, 0 ) ) )
-		self.assertEqual( fourByFour.getTransform(), IECore.M44f.createTranslated( IECore.V3f( 0, 1, 0 ) ) )
-		self.assertEqual( fourByTwo.getTransform(), IECore.M44f.createTranslated( IECore.V3f( 0, 4, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -2, -5, 0 ), imath.V3f( 2, 5, 0 ) ) )
+		self.assertEqual( twoByFour.getTransform(), imath.M44f().translate( imath.V3f( -1, -3, 0 ) ) )
+		self.assertEqual( fourByFour.getTransform(), imath.M44f().translate( imath.V3f( 0, 1, 0 ) ) )
+		self.assertEqual( fourByTwo.getTransform(), imath.M44f().translate( imath.V3f( 0, 4, 0 ) ) )
 
 	def testPadding( self ) :
 
-		twoByFour = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( -1, -2, 0 ), IECore.V3f( 1, 2, 0 ) ) )
+		twoByFour = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( -1, -2, 0 ), imath.V3f( 1, 2, 0 ) ) )
 
 		c = GafferUI.LinearContainer( orientation=GafferUI.LinearContainer.Orientation.Y )
 		c.addChild( twoByFour )
 
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -1, -2, 0 ), IECore.V3f( 1, 2, 0 ) ) )
-		self.assertEqual( c.getPadding(), IECore.Box3f( IECore.V3f( 0 ), IECore.V3f( 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -1, -2, 0 ), imath.V3f( 1, 2, 0 ) ) )
+		self.assertEqual( c.getPadding(), imath.Box3f( imath.V3f( 0 ), imath.V3f( 0 ) ) )
 
-		c.setPadding( IECore.Box3f( IECore.V3f( -1, -2, -3 ), IECore.V3f( 1, 2, 3 ) ) )
-		self.assertEqual( c.getPadding(), IECore.Box3f( IECore.V3f( -1, -2, -3 ), IECore.V3f( 1, 2, 3 ) ) )
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -2, -4, -3 ), IECore.V3f( 2, 4, 3 ) ) )
+		c.setPadding( imath.Box3f( imath.V3f( -1, -2, -3 ), imath.V3f( 1, 2, 3 ) ) )
+		self.assertEqual( c.getPadding(), imath.Box3f( imath.V3f( -1, -2, -3 ), imath.V3f( 1, 2, 3 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -2, -4, -3 ), imath.V3f( 2, 4, 3 ) ) )
 
 	def testDirection( self ) :
 
-		first = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( -1, -2, 0 ), IECore.V3f( 1, 2, 0 ) ) )
-		second = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( -1, -2, 0 ), IECore.V3f( 1, 2, 0 ) ) )
+		first = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( -1, -2, 0 ), imath.V3f( 1, 2, 0 ) ) )
+		second = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( -1, -2, 0 ), imath.V3f( 1, 2, 0 ) ) )
 
 		c = GafferUI.LinearContainer( orientation=GafferUI.LinearContainer.Orientation.Y )
 
 		c["c1"] = first
 		c["c2"] = second
 
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -1, -4, 0 ), IECore.V3f( 1, 4, 0 ) ) )
-		self.assertEqual( first.getTransform(), IECore.M44f.createTranslated( IECore.V3f( 0, -2, 0 ) ) )
-		self.assertEqual( second.getTransform(), IECore.M44f.createTranslated( IECore.V3f( 0, 2, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -1, -4, 0 ), imath.V3f( 1, 4, 0 ) ) )
+		self.assertEqual( first.getTransform(), imath.M44f().translate( imath.V3f( 0, -2, 0 ) ) )
+		self.assertEqual( second.getTransform(), imath.M44f().translate( imath.V3f( 0, 2, 0 ) ) )
 
 		c.setDirection( GafferUI.LinearContainer.Direction.Decreasing )
 
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -1, -4, 0 ), IECore.V3f( 1, 4, 0 ) ) )
-		self.assertEqual( first.getTransform(), IECore.M44f.createTranslated( IECore.V3f( 0, 2, 0 ) ) )
-		self.assertEqual( second.getTransform(), IECore.M44f.createTranslated( IECore.V3f( 0, -2, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -1, -4, 0 ), imath.V3f( 1, 4, 0 ) ) )
+		self.assertEqual( first.getTransform(), imath.M44f().translate( imath.V3f( 0, 2, 0 ) ) )
+		self.assertEqual( second.getTransform(), imath.M44f().translate( imath.V3f( 0, -2, 0 ) ) )
 
 	def testDirectionAndSpacing( self ) :
 
 		c = GafferUI.LinearContainer( orientation = GafferUI.LinearContainer.Orientation.Y )
-		c["g1"] = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( -1, -1, 0 ), IECore.V3f( 1, 1, 0 ) ) )
-		c["g2"] = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( -1, -1, 0 ), IECore.V3f( 1, 1, 0 ) ) )
+		c["g1"] = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( -1, -1, 0 ), imath.V3f( 1, 1, 0 ) ) )
+		c["g2"] = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( -1, -1, 0 ), imath.V3f( 1, 1, 0 ) ) )
 
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -1, -2, 0 ), IECore.V3f( 1, 2, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -1, -2, 0 ), imath.V3f( 1, 2, 0 ) ) )
 
 		c.setSpacing( 2 )
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -1, -3, 0 ), IECore.V3f( 1, 3, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -1, -3, 0 ), imath.V3f( 1, 3, 0 ) ) )
 
 		c.setDirection( GafferUI.LinearContainer.Direction.Decreasing )
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -1, -3, 0 ), IECore.V3f( 1, 3, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -1, -3, 0 ), imath.V3f( 1, 3, 0 ) ) )
 
 	def testChildVisibility( self ) :
 
-		g1 = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( 0 ), IECore.V3f( 1, 1, 0 ) ) )
-		g2 = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( 0 ), IECore.V3f( 2, 1, 0 ) ) )
-		g3 = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( 0 ), IECore.V3f( 5, 1, 0 ) ) )
+		g1 = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( 0 ), imath.V3f( 1, 1, 0 ) ) )
+		g2 = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( 0 ), imath.V3f( 2, 1, 0 ) ) )
+		g3 = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( 0 ), imath.V3f( 5, 1, 0 ) ) )
 
 		c = GafferUI.LinearContainer( spacing = 1 )
 		c.addChild( g1 )
 
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -0.5, -0.5, 0 ), IECore.V3f( 0.5, 0.5, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -0.5, -0.5, 0 ), imath.V3f( 0.5, 0.5, 0 ) ) )
 
 		c.addChild( g2 )
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -2, -0.5, 0 ), IECore.V3f( 2, 0.5, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -2, -0.5, 0 ), imath.V3f( 2, 0.5, 0 ) ) )
 
 		g2.setVisible( False )
 		# should be as if the child didn't exist
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -0.5, -0.5, 0 ), IECore.V3f( 0.5, 0.5, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -0.5, -0.5, 0 ), imath.V3f( 0.5, 0.5, 0 ) ) )
 
 		g2.setVisible( True )
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -2, -0.5, 0 ), IECore.V3f( 2, 0.5, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -2, -0.5, 0 ), imath.V3f( 2, 0.5, 0 ) ) )
 
 		c.addChild( g3 )
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -5, -0.5, 0 ), IECore.V3f( 5, 0.5, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -5, -0.5, 0 ), imath.V3f( 5, 0.5, 0 ) ) )
 
 		g1.setVisible( False )
-		self.assertEqual( c.bound(), IECore.Box3f( IECore.V3f( -4, -0.5, 0 ), IECore.V3f( 4, 0.5, 0 ) ) )
+		self.assertEqual( c.bound(), imath.Box3f( imath.V3f( -4, -0.5, 0 ), imath.V3f( 4, 0.5, 0 ) ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/SpacerGadgetTest.py
+++ b/python/GafferUITest/SpacerGadgetTest.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import GafferUI
@@ -43,8 +45,8 @@ class SpacerGadgetTest( GafferUITest.TestCase ) :
 
 	def test( self ) :
 
-		s = GafferUI.SpacerGadget( IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 3 ) ) )
-		self.assertEqual( s.bound(), IECore.Box3f( IECore.V3f( -1 ), IECore.V3f( 3 ) ) )
+		s = GafferUI.SpacerGadget( imath.Box3f( imath.V3f( -1 ), imath.V3f( 3 ) ) )
+		self.assertEqual( s.bound(), imath.Box3f( imath.V3f( -1 ), imath.V3f( 3 ) ) )
 
 		t = GafferUI.TextGadget( "t" )
 		self.assertFalse( s.acceptsChild( t ) )

--- a/python/GafferUITest/StandardGraphLayoutTest.py
+++ b/python/GafferUITest/StandardGraphLayoutTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import weakref
+import imath
 
 import IECore
 
@@ -274,11 +275,11 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		s["bottom"]["top0"].setInput( s["top"]["bottom0"] )
 
 		g = GafferUI.GraphGadget( s )
-		g.setNodePosition( s["bottom"], IECore.V2f( 50, 60 ) )
+		g.setNodePosition( s["bottom"], imath.V2f( 50, 60 ) )
 
 		g.getLayout().layoutNodes( g, Gaffer.StandardSet( [ s["top"] ] ) )
 
-		self.assertEqual( g.getNodePosition( s["bottom"] ), IECore.V2f( 50, 60 ) )
+		self.assertEqual( g.getNodePosition( s["bottom"] ), imath.V2f( 50, 60 ) )
 		self.assertAlmostEqual( g.getNodePosition( s["top"] ).x, g.getNodePosition( s["bottom"] ).x, delta = 0.001 )
 		self.assertTrue( g.getNodePosition( s["top"] ).y > g.getNodePosition( s["bottom"] ).y )
 
@@ -291,11 +292,11 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		s["bottom"]["top0"].setInput( s["top"]["bottom0"] )
 
 		g = GafferUI.GraphGadget( s )
-		g.setNodePosition( s["bottom"], IECore.V2f( 50, -60 ) )
+		g.setNodePosition( s["bottom"], imath.V2f( 50, -60 ) )
 
 		g.getLayout().layoutNodes( g, Gaffer.StandardSet( [ s["top"] ] ) )
 
-		self.assertEqual( g.getNodePosition( s["bottom"] ), IECore.V2f( 50, -60 ) )
+		self.assertEqual( g.getNodePosition( s["bottom"] ), imath.V2f( 50, -60 ) )
 		self.assertAlmostEqual( g.getNodePosition( s["top"] ).x, g.getNodePosition( s["bottom"] ).x, delta=0.001 )
 		self.assertTrue( g.getNodePosition( s["top"] ).y > g.getNodePosition( s["bottom"] ).y )
 
@@ -310,11 +311,11 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		s["bottom"]["top0"].setInput( s["top"]["bottom0"] )
 
 		g = GafferUI.GraphGadget( s )
-		g.setNodePosition( s["top"], IECore.V2f( 50, 60 ) )
+		g.setNodePosition( s["top"], imath.V2f( 50, 60 ) )
 
 		g.getLayout().layoutNodes( g, Gaffer.StandardSet( [ s["bottom"] ] ) )
 
-		self.assertEqual( g.getNodePosition( s["top"] ), IECore.V2f( 50, 60 ) )
+		self.assertEqual( g.getNodePosition( s["top"] ), imath.V2f( 50, 60 ) )
 		self.assertAlmostEqual( g.getNodePosition( s["top"] ).x, g.getNodePosition( s["bottom"] ).x, delta = 0.001 )
 		self.assertTrue( g.getNodePosition( s["top"] ).y > g.getNodePosition( s["bottom"] ).y )
 
@@ -378,8 +379,8 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		s["topRight"] = LayoutNode()
 
 		g = GafferUI.GraphGadget( s )
-		g.setNodePosition( s["topLeft"], IECore.V2f( 10, 0 ) )
-		g.setNodePosition( s["topRight"], IECore.V2f( 40, 0 ) )
+		g.setNodePosition( s["topLeft"], imath.V2f( 10, 0 ) )
+		g.setNodePosition( s["topRight"], imath.V2f( 40, 0 ) )
 
 		s["new"] = LayoutNode()
 		s["new"]["top0"].setInput( s["topLeft"]["bottom1"] )
@@ -387,8 +388,8 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		g.getLayout().positionNode( g, s["new"] )
 
-		self.assertEqual( g.getNodePosition( s["topLeft"] ), IECore.V2f( 10, 0 ) )
-		self.assertEqual( g.getNodePosition( s["topRight"] ), IECore.V2f( 40, 0 ) )
+		self.assertEqual( g.getNodePosition( s["topLeft"] ), imath.V2f( 10, 0 ) )
+		self.assertEqual( g.getNodePosition( s["topRight"] ), imath.V2f( 40, 0 ) )
 
 		self.assertTrue( g.getNodePosition( s["new"] ).x > g.getNodePosition( s["topLeft"] ).x )
 		self.assertTrue( g.getNodePosition( s["new"] ).x < g.getNodePosition( s["topRight"] ).x )
@@ -403,12 +404,12 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		s["node2"] = LayoutNode()
 
 		g = GafferUI.GraphGadget( s )
-		g.setNodePosition( s["node1"], IECore.V2f( 10, 0 ) )
+		g.setNodePosition( s["node1"], imath.V2f( 10, 0 ) )
 
-		g.getLayout().positionNode( g, s["node2"], IECore.V2f( -10, -20 ) )
+		g.getLayout().positionNode( g, s["node2"], imath.V2f( -10, -20 ) )
 
-		self.assertEqual( g.getNodePosition( s["node1"] ), IECore.V2f( 10, 0 ) )
-		self.assertEqual( g.getNodePosition( s["node2"] ), IECore.V2f( -10, -20 ) )
+		self.assertEqual( g.getNodePosition( s["node1"] ), imath.V2f( 10, 0 ) )
+		self.assertEqual( g.getNodePosition( s["node2"] ), imath.V2f( -10, -20 ) )
 
 	def testPositionNodes( self ) :
 
@@ -428,9 +429,9 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		g = GafferUI.GraphGadget( s )
 
-		g.setNodePosition( s["node1"], IECore.V2f( 100, 1000 ) )
-		g.setNodePosition( s["node2"], IECore.V2f( -10, 500 ) )
-		g.setNodePosition( s["node3"], IECore.V2f( -5, 490 ) )
+		g.setNodePosition( s["node1"], imath.V2f( 100, 1000 ) )
+		g.setNodePosition( s["node2"], imath.V2f( -10, 500 ) )
+		g.setNodePosition( s["node3"], imath.V2f( -5, 490 ) )
 
 		o1 = g.getNodePosition( s["node3"] ) - g.getNodePosition( s["node2"] )
 
@@ -439,7 +440,7 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		o2 = g.getNodePosition( s["node3"] ) - g.getNodePosition( s["node2"] )
 		self.assertEqual( o1, o2 )
 
-		self.assertEqual( g.getNodePosition( s["node1"] ), IECore.V2f( 100, 1000 ) )
+		self.assertEqual( g.getNodePosition( s["node1"] ), imath.V2f( 100, 1000 ) )
 		self.assertTrue( g.getNodePosition( s["node2"] ).x > g.getNodePosition( s["node1"] ).x )
 		self.assertAlmostEqual( g.getNodePosition( s["node1"] ).y, g.getNodePosition( s["node2"] ).y, 2 )
 
@@ -454,19 +455,19 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		g = GafferUI.GraphGadget( s )
 
-		g.setNodePosition( s["node1"], IECore.V2f( 10, 12 ) )
-		g.setNodePosition( s["node2"], IECore.V2f( 50, 14 ) )
+		g.setNodePosition( s["node1"], imath.V2f( 10, 12 ) )
+		g.setNodePosition( s["node2"], imath.V2f( 50, 14 ) )
 
 		o1 = g.getNodePosition( s["node2"] ) - g.getNodePosition( s["node1"] )
 
-		g.getLayout().positionNodes( g, Gaffer.StandardSet( [ s["node1"], s["node2"] ] ), IECore.V2f( -100, -20 ) )
+		g.getLayout().positionNodes( g, Gaffer.StandardSet( [ s["node1"], s["node2"] ] ), imath.V2f( -100, -20 ) )
 
 		o2 = g.getNodePosition( s["node2"] ) - g.getNodePosition( s["node1"] )
 		self.assertEqual( o1, o2 )
 
 		self.assertEqual(
 			( g.getNodePosition( s["node1"] ) + g.getNodePosition( s["node2"] ) ) / 2.0,
-			IECore.V2f( -100, -20 )
+			imath.V2f( -100, -20 )
 		)
 
 	def testImpossibleSiblingOrdering( self ) :
@@ -667,9 +668,9 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 			bound = nodeGadget.transformedBound( graphGadget )
 			bounds.append(
-				IECore.Box2f(
-					IECore.V2f( bound.min.x, bound.min.y ),
-					IECore.V2f( bound.max.x, bound.max.y ),
+				imath.Box2f(
+					imath.V2f( bound.min().x, bound.min().y ),
+					imath.V2f( bound.max().x, bound.max().y ),
 				)
 			)
 
@@ -690,7 +691,7 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		g = GafferUI.GraphGadget( s )
 		backdropBound = g.nodeGadget( s["b"] ).transformedBound( g )
-		fallbackPosition = IECore.V2f( backdropBound.center().x, backdropBound.center().y )
+		fallbackPosition = imath.V2f( backdropBound.center().x, backdropBound.center().y )
 
 		g.getLayout().positionNode( g, s["n"], fallbackPosition )
 		self.assertEqual( g.getNodePosition( s["n"] ), fallbackPosition )

--- a/python/GafferUITest/StandardNodeGadgetTest.py
+++ b/python/GafferUITest/StandardNodeGadgetTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -117,21 +118,21 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 		n = GafferTest.AddNode()
 		g = GafferUI.StandardNodeGadget( n )
 
-		self.assertEqual( g.noduleTangent( g.nodule( n["op1"] ) ), IECore.V3f( 0, 1, 0 ) )
-		self.assertEqual( g.noduleTangent( g.nodule( n["op2"] ) ), IECore.V3f( 0, 1, 0 ) )
-		self.assertEqual( g.noduleTangent( g.nodule( n["sum"] ) ), IECore.V3f( 0, -1, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( n["op1"] ) ), imath.V3f( 0, 1, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( n["op2"] ) ), imath.V3f( 0, 1, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( n["sum"] ) ), imath.V3f( 0, -1, 0 ) )
 
 	def testNodulePositionMetadata( self ) :
 
 		n = GafferTest.MultiplyNode()
 
 		g = GafferUI.StandardNodeGadget( n )
-		self.assertEqual( g.noduleTangent( g.nodule( n["op1"] ) ), IECore.V3f( 0, 1, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( n["op1"] ) ), imath.V3f( 0, 1, 0 ) )
 
 		Gaffer.Metadata.registerValue( n.typeId(), "op1", "noduleLayout:section", "left" )
 
 		g = GafferUI.StandardNodeGadget( n )
-		self.assertEqual( g.noduleTangent( g.nodule( n["op1"] ) ), IECore.V3f( -1, 0, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( n["op1"] ) ), imath.V3f( -1, 0, 0 ) )
 
 	def testNameDoesntAffectHeight( self ) :
 
@@ -174,10 +175,10 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 		n = GafferTest.MultiplyNode()
 
 		g = GafferUI.StandardNodeGadget( n )
-		self.assertEqual( g.noduleTangent( g.nodule( n["op2"] ) ), IECore.V3f( 0, 1, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( n["op2"] ) ), imath.V3f( 0, 1, 0 ) )
 
 		Gaffer.Metadata.registerValue( n["op2"], "noduleLayout:section", "left" )
-		self.assertEqual( g.noduleTangent( g.nodule( n["op2"] ) ), IECore.V3f( -1, 0, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( n["op2"] ) ), imath.V3f( -1, 0, 0 ) )
 
 	def testRemoveNoduleAfterCreation( self ) :
 
@@ -185,7 +186,7 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 		n["p"] = Gaffer.IntPlug()
 
 		g = GafferUI.StandardNodeGadget( n )
-		self.assertEqual( g.noduleTangent( g.nodule( n["p"] ) ), IECore.V3f( 0, 1, 0 ) )
+		self.assertEqual( g.noduleTangent( g.nodule( n["p"] ) ), imath.V3f( 0, 1, 0 ) )
 
 		Gaffer.Metadata.registerValue( n["p"], "nodule:type", "" )
 		self.assertEqual( g.nodule( n["p"] ), None )

--- a/python/GafferUITest/StandardStyleTest.py
+++ b/python/GafferUITest/StandardStyleTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import IECoreGL
@@ -57,7 +58,7 @@ class StandardStyleTest( GafferUITest.TestCase ) :
 			if n=="LastColor" :
 				continue
 
-			c = IECore.Color3f( i )
+			c = imath.Color3f( i )
 			v = getattr( GafferUI.StandardStyle.Color, n )
 			s.setColor( v, c )
 			self.assertEqual( s.getColor( v ), c )
@@ -85,15 +86,15 @@ class StandardStyleTest( GafferUITest.TestCase ) :
 		cs = GafferTest.CapturingSlot( s.changedSignal() )
 		self.assertEqual( len( cs ), 0 )
 
-		s.setColor( GafferUI.StandardStyle.Color.BackgroundColor, IECore.Color3f( 0 ) )
+		s.setColor( GafferUI.StandardStyle.Color.BackgroundColor, imath.Color3f( 0 ) )
 		self.assertEqual( len( cs ), 1 )
 		self.assertTrue( cs[0][0].isSame( s ) )
 
-		s.setColor( GafferUI.StandardStyle.Color.BackgroundColor, IECore.Color3f( 1 ) )
+		s.setColor( GafferUI.StandardStyle.Color.BackgroundColor, imath.Color3f( 1 ) )
 		self.assertEqual( len( cs ), 2 )
 		self.assertTrue( cs[1][0].isSame( s ) )
 
-		s.setColor( GafferUI.StandardStyle.Color.BackgroundColor, IECore.Color3f( 1 ) )
+		s.setColor( GafferUI.StandardStyle.Color.BackgroundColor, imath.Color3f( 1 ) )
 		self.assertEqual( len( cs ), 2 )
 
 		f = IECoreGL.FontLoader.defaultFontLoader().load( "VeraMono.ttf" )

--- a/python/GafferUITest/VectorDataWidgetTest.py
+++ b/python/GafferUITest/VectorDataWidgetTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 
@@ -48,10 +49,10 @@ class VectorDataWidgetTest( GafferUITest.TestCase ) :
 
 		data = [
 			IECore.FloatVectorData( range( 0, 3 ) ),
-			IECore.Color3fVectorData( [ IECore.Color3f( x ) for x in range( 0, 3 ) ] ),
+			IECore.Color3fVectorData( [ imath.Color3f( x ) for x in range( 0, 3 ) ] ),
 			IECore.StringVectorData( [ str( x ) for x in range( 0, 3 ) ] ),
 			IECore.IntVectorData( range( 0, 3 ) ),
-			IECore.V3fVectorData( [ IECore.V3f( x ) for x in range( 0, 3 ) ] ),
+			IECore.V3fVectorData( [ imath.V3f( x ) for x in range( 0, 3 ) ] ),
 		]
 
 		w = GafferUI.VectorDataWidget( data )
@@ -84,7 +85,7 @@ class VectorDataWidgetTest( GafferUITest.TestCase ) :
 
 		data = [
 			IECore.FloatVectorData( range( 0, 3 ) ),
-			IECore.Color3fVectorData( [ IECore.Color3f( x ) for x in range( 0, 3 ) ] ),
+			IECore.Color3fVectorData( [ imath.Color3f( x ) for x in range( 0, 3 ) ] ),
 			IECore.StringVectorData( [ str( x ) for x in range( 0, 3 ) ] ),
 		]
 

--- a/python/GafferUITest/ViewportGadgetTest.py
+++ b/python/GafferUITest/ViewportGadgetTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -54,7 +55,7 @@ class ViewportGadgetTest( GafferUITest.TestCase ) :
 		v.setViewport( v.getViewport() )
 		self.assertEqual( len( cs ), 0 )
 
-		v.setViewport( v.getViewport() + IECore.V2i( 10 ) )
+		v.setViewport( v.getViewport() + imath.V2i( 10 ) )
 		self.assertEqual( len( cs ), 1 )
 		self.assertEqual( cs[0], ( v, ) )
 
@@ -83,142 +84,142 @@ class ViewportGadgetTest( GafferUITest.TestCase ) :
 	def testChangeResolutionPerspective( self ) :
 
 		v = GafferUI.ViewportGadget()
-		v.setViewport( IECore.V2i( 200, 100 ) )
+		v.setViewport( imath.V2i( 200, 100 ) )
 		v.setCamera(
 			IECoreScene.Camera( parameters = {
-				"resolution" : IECore.V2i( 200, 100 ),
-				"screenWindow" : IECore.Box2f( IECore.V2f( -2, -1 ), IECore.V2f( 2, 1 ) ),
+				"resolution" : imath.V2i( 200, 100 ),
+				"screenWindow" : imath.Box2f( imath.V2f( -2, -1 ), imath.V2f( 2, 1 ) ),
 				"projection" : "perspective",
 			} )
 		)
 
-		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -2, -1 ), IECore.V2f( 2, 1 ) ) )
+		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, imath.Box2f( imath.V2f( -2, -1 ), imath.V2f( 2, 1 ) ) )
 
-		v.setViewport( IECore.V2i( 200, 200 ) )
-		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -2 ), IECore.V2f( 2 ) ) )
+		v.setViewport( imath.V2i( 200, 200 ) )
+		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, imath.Box2f( imath.V2f( -2 ), imath.V2f( 2 ) ) )
 
-		v.setViewport( IECore.V2i( 200, 100 ) )
-		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -2, -1 ), IECore.V2f( 2, 1 ) ) )
+		v.setViewport( imath.V2i( 200, 100 ) )
+		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, imath.Box2f( imath.V2f( -2, -1 ), imath.V2f( 2, 1 ) ) )
 
 	def testChangeResolutionOrthographic( self ) :
 
 		v = GafferUI.ViewportGadget()
-		v.setViewport( IECore.V2i( 200, 100 ) )
+		v.setViewport( imath.V2i( 200, 100 ) )
 		v.setCamera(
 			IECoreScene.Camera( parameters = {
-				"resolution" : IECore.V2i( 200, 100 ),
-				"screenWindow" : IECore.Box2f( IECore.V2f( -2, -1 ), IECore.V2f( 2, 1 ) ),
+				"resolution" : imath.V2i( 200, 100 ),
+				"screenWindow" : imath.Box2f( imath.V2f( -2, -1 ), imath.V2f( 2, 1 ) ),
 				"projection" : "orthographic",
 			} )
 		)
 
-		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -2, -1 ), IECore.V2f( 2, 1 ) ) )
+		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, imath.Box2f( imath.V2f( -2, -1 ), imath.V2f( 2, 1 ) ) )
 
-		v.setViewport( IECore.V2i( 100, 100 ) )
-		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -1, -1 ), IECore.V2f( 1, 1 ) ) )
+		v.setViewport( imath.V2i( 100, 100 ) )
+		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, imath.Box2f( imath.V2f( -1, -1 ), imath.V2f( 1, 1 ) ) )
 
-		v.setViewport( IECore.V2i( 100, 200 ) )
-		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -1, -2 ), IECore.V2f( 1, 2 ) ) )
+		v.setViewport( imath.V2i( 100, 200 ) )
+		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, imath.Box2f( imath.V2f( -1, -2 ), imath.V2f( 1, 2 ) ) )
 
 	def testChangeResolutionOffsetOrthographic( self ) :
 
 		v = GafferUI.ViewportGadget()
-		v.setViewport( IECore.V2i( 200, 100 ) )
+		v.setViewport( imath.V2i( 200, 100 ) )
 		v.setCamera(
 			IECoreScene.Camera( parameters = {
-				"resolution" : IECore.V2i( 200, 100 ),
-				"screenWindow" : IECore.Box2f( IECore.V2f( -2, -1 ), IECore.V2f( 0, 0 ) ),
+				"resolution" : imath.V2i( 200, 100 ),
+				"screenWindow" : imath.Box2f( imath.V2f( -2, -1 ), imath.V2f( 0, 0 ) ),
 				"projection" : "orthographic",
 			} )
 		)
 
-		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -2, -1 ), IECore.V2f( 0, 0 ) ) )
+		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, imath.Box2f( imath.V2f( -2, -1 ), imath.V2f( 0, 0 ) ) )
 
-		v.setViewport( IECore.V2i( 100, 100 ) )
-		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -1.5, -1 ), IECore.V2f( -0.5, 0 ) ) )
+		v.setViewport( imath.V2i( 100, 100 ) )
+		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, imath.Box2f( imath.V2f( -1.5, -1 ), imath.V2f( -0.5, 0 ) ) )
 
-		v.setViewport( IECore.V2i( 100, 200 ) )
-		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -1.5, -1.5 ), IECore.V2f( -0.5, 0.5 ) ) )
+		v.setViewport( imath.V2i( 100, 200 ) )
+		self.assertEqual( v.getCamera().parameters()["screenWindow"].value, imath.Box2f( imath.V2f( -1.5, -1.5 ), imath.V2f( -0.5, 0.5 ) ) )
 
 	def testRasterToWorldOrthographic( self ) :
 
 		v = GafferUI.ViewportGadget()
-		v.setViewport( IECore.V2i( 500, 250 ) )
+		v.setViewport( imath.V2i( 500, 250 ) )
 		v.setCamera(
 			IECoreScene.Camera( parameters = {
-				"resolution" : IECore.V2i( 500, 250 ),
-				"screenWindow" : IECore.Box2f( IECore.V2f( -2, -1 ), IECore.V2f( 2, 1 ) ),
+				"resolution" : imath.V2i( 500, 250 ),
+				"screenWindow" : imath.Box2f( imath.V2f( -2, -1 ), imath.V2f( 2, 1 ) ),
 				"projection" : "orthographic",
-				"clippingPlanes" : IECore.V2f( .1, 10 ),
+				"clippingPlanes" : imath.V2f( .1, 10 ),
 			} )
 		)
 
 		self.assertEqual(
-			v.rasterToWorldSpace( IECore.V2f( 0 ) ),
-			IECore.LineSegment3f( IECore.V3f( -2, 1, -.1 ), IECore.V3f( -2, 1, -10 ) )
+			v.rasterToWorldSpace( imath.V2f( 0 ) ),
+			IECore.LineSegment3f( imath.V3f( -2, 1, -.1 ), imath.V3f( -2, 1, -10 ) )
 		)
 
 		self.assertEqual(
-			v.rasterToWorldSpace( IECore.V2f( 500, 250 ) ),
-			IECore.LineSegment3f( IECore.V3f( 2, -1, -.1 ), IECore.V3f( 2, -1, -10 ) )
+			v.rasterToWorldSpace( imath.V2f( 500, 250 ) ),
+			IECore.LineSegment3f( imath.V3f( 2, -1, -.1 ), imath.V3f( 2, -1, -10 ) )
 		)
 
 		self.assertEqual(
-			v.rasterToWorldSpace( IECore.V2f( 250, 125 ) ),
-			IECore.LineSegment3f( IECore.V3f( 0, 0, -.1 ), IECore.V3f( 0, 0, -10 ) )
+			v.rasterToWorldSpace( imath.V2f( 250, 125 ) ),
+			IECore.LineSegment3f( imath.V3f( 0, 0, -.1 ), imath.V3f( 0, 0, -10 ) )
 		)
 
 	def testRasterToWorldPerspective( self ) :
 
 		v = GafferUI.ViewportGadget()
-		v.setViewport( IECore.V2i( 500, 250 ) )
+		v.setViewport( imath.V2i( 500, 250 ) )
 		v.setCamera(
 			IECoreScene.Camera( parameters = {
-				"resolution" : IECore.V2i( 500, 250 ),
-				"screenWindow" : IECore.Box2f( IECore.V2f( -1, -.5 ), IECore.V2f( 1, .5 ) ),
+				"resolution" : imath.V2i( 500, 250 ),
+				"screenWindow" : imath.Box2f( imath.V2f( -1, -.5 ), imath.V2f( 1, .5 ) ),
 				"projection" : "perspective",
 				"projection:fox" : 90.0,
-				"clippingPlanes" : IECore.V2f( .1, 10 ),
+				"clippingPlanes" : imath.V2f( .1, 10 ),
 			} )
 		)
 
 		self.assertEqual(
-			v.rasterToWorldSpace( IECore.V2f( 0 ) ),
-			IECore.LineSegment3f( IECore.V3f( -.1, .05, -.1 ), IECore.V3f( -10, 5, -10 ) )
+			v.rasterToWorldSpace( imath.V2f( 0 ) ),
+			IECore.LineSegment3f( imath.V3f( -.1, .05, -.1 ), imath.V3f( -10, 5, -10 ) )
 		)
 
 		self.assertEqual(
-			v.rasterToWorldSpace( IECore.V2f( 500, 250 ) ),
-			IECore.LineSegment3f( IECore.V3f( .1, -.05, -.1 ), IECore.V3f( 10, -5, -10 ) )
+			v.rasterToWorldSpace( imath.V2f( 500, 250 ) ),
+			IECore.LineSegment3f( imath.V3f( .1, -.05, -.1 ), imath.V3f( 10, -5, -10 ) )
 		)
 
 		self.assertEqual(
-			v.rasterToWorldSpace( IECore.V2f( 250, 125 ) ),
-			IECore.LineSegment3f( IECore.V3f( 0, 0, -.1 ), IECore.V3f( 0, 0, -10 ) )
+			v.rasterToWorldSpace( imath.V2f( 250, 125 ) ),
+			IECore.LineSegment3f( imath.V3f( 0, 0, -.1 ), imath.V3f( 0, 0, -10 ) )
 		)
 
 	def testWorldToRasterOrthographic( self ) :
 
 		v = GafferUI.ViewportGadget()
-		v.setViewport( IECore.V2i( 500, 250 ) )
+		v.setViewport( imath.V2i( 500, 250 ) )
 		v.setCamera(
 			IECoreScene.Camera( parameters = {
-				"resolution" : IECore.V2i( 500, 250 ),
-				"screenWindow" : IECore.Box2f( IECore.V2f( -2, -1 ), IECore.V2f( 2, 1 ) ),
+				"resolution" : imath.V2i( 500, 250 ),
+				"screenWindow" : imath.Box2f( imath.V2f( -2, -1 ), imath.V2f( 2, 1 ) ),
 				"projection" : "orthographic",
-				"clippingPlanes" : IECore.V2f( .1, 10 ),
+				"clippingPlanes" : imath.V2f( .1, 10 ),
 			} )
 		)
 
-		r = IECore.Rand48()
+		r = imath.Rand48()
 		for i in range( 0, 100 ) :
-			rasterPosition = IECore.V2f( r.nexti() % 500, r.nexti() % 250 )
+			rasterPosition = imath.V2f( r.nexti() % 500, r.nexti() % 250 )
 			line = v.rasterToWorldSpace( rasterPosition )
 			nearProjected = v.worldToRasterSpace( line.p0 )
 			farProjected = v.worldToRasterSpace( line.p1 )
 			self.failUnless( nearProjected.equalWithAbsError( farProjected, 0.0001 ) )
 			self.failUnless(
-				IECore.V2f( rasterPosition.x, rasterPosition.y ).equalWithAbsError(
+				imath.V2f( rasterPosition.x, rasterPosition.y ).equalWithAbsError(
 					nearProjected, 0.0001
 				)
 			)
@@ -226,26 +227,26 @@ class ViewportGadgetTest( GafferUITest.TestCase ) :
 	def testWorldToRasterPerspective( self ) :
 
 		v = GafferUI.ViewportGadget()
-		v.setViewport( IECore.V2i( 500, 250 ) )
+		v.setViewport( imath.V2i( 500, 250 ) )
 		v.setCamera(
 			IECoreScene.Camera( parameters = {
-				"resolution" : IECore.V2i( 500, 250 ),
-				"screenWindow" : IECore.Box2f( IECore.V2f( -1, -.5 ), IECore.V2f( 1, .5 ) ),
+				"resolution" : imath.V2i( 500, 250 ),
+				"screenWindow" : imath.Box2f( imath.V2f( -1, -.5 ), imath.V2f( 1, .5 ) ),
 				"projection" : "perspective",
 				"projection:fov" : 50.0,
-				"clippingPlanes" : IECore.V2f( .1, 10 ),
+				"clippingPlanes" : imath.V2f( .1, 10 ),
 			} )
 		)
 
-		r = IECore.Rand48()
+		r = imath.Rand48()
 		for i in range( 0, 100 ) :
-			rasterPosition = IECore.V2f( r.nexti() % 500, r.nexti() % 250 )
+			rasterPosition = imath.V2f( r.nexti() % 500, r.nexti() % 250 )
 			line = v.rasterToWorldSpace( rasterPosition )
 			nearProjected = v.worldToRasterSpace( line.p0 )
 			farProjected = v.worldToRasterSpace( line.p1 )
 			self.failUnless( nearProjected.equalWithAbsError( farProjected, 0.0001 ) )
 			self.failUnless(
-				IECore.V2f( rasterPosition.x, rasterPosition.y ).equalWithAbsError(
+				imath.V2f( rasterPosition.x, rasterPosition.y ).equalWithAbsError(
 					nearProjected, 0.0001
 				)
 			)

--- a/python/GafferUITest/WidgetAlgoTest.py
+++ b/python/GafferUITest/WidgetAlgoTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import IECoreImage
@@ -62,7 +63,7 @@ class WidgetAlgoTest( GafferUITest.TestCase ) :
 		## \todo Should we have an official method for getting
 		# physical pixel size like this? Or should `grab()` downsize
 		# to return an image with the logical pixel size?
-		expectedSize = IECore.V2f( b.size() )
+		expectedSize = imath.V2f( b.size() )
 		if Qt.__binding__ in ( "PySide2", "PyQt5" ) :
 			screen= QtWidgets.QApplication.primaryScreen()
 			windowHandle = b._qtWidget().windowHandle()
@@ -70,7 +71,7 @@ class WidgetAlgoTest( GafferUITest.TestCase ) :
 				screen = windowHandle.screen()
 			expectedSize *= screen.devicePixelRatio()
 
-		self.assertEqual( IECore.V2f( i.displayWindow.size() ) + IECore.V2f( 1 ), expectedSize )
+		self.assertEqual( imath.V2f( i.displayWindow.size() ) + imath.V2f( 1 ), expectedSize )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/WidgetTest.py
+++ b/python/GafferUITest/WidgetTest.py
@@ -38,6 +38,7 @@
 import unittest
 import weakref
 import sys
+import imath
 
 import IECore
 
@@ -347,7 +348,7 @@ class WidgetTest( GafferUITest.TestCase ) :
 		w.setChild( b )
 		w.setVisible( True )
 
-		w.setPosition( IECore.V2i( 100 ) )
+		w.setPosition( imath.V2i( 100 ) )
 
 		self.waitForIdle( 1000 )
 
@@ -355,12 +356,12 @@ class WidgetTest( GafferUITest.TestCase ) :
 		bb = b.bound()
 		bbw = b.bound( relativeTo = w )
 
-		self.failUnless( isinstance( wb, IECore.Box2i ) )
-		self.failUnless( isinstance( bb, IECore.Box2i ) )
-		self.failUnless( isinstance( bbw, IECore.Box2i ) )
+		self.failUnless( isinstance( wb, imath.Box2i ) )
+		self.failUnless( isinstance( bb, imath.Box2i ) )
+		self.failUnless( isinstance( bbw, imath.Box2i ) )
 
 		self.assertEqual( bb.size(), bbw.size() )
-		self.assertEqual( bbw.min, bb.min - wb.min )
+		self.assertEqual( bbw.min(), bb.min() - wb.min() )
 		self.assertEqual( b.size(), bb.size() )
 
 	def testParentChangedSignal( self ) :
@@ -401,8 +402,8 @@ class WidgetTest( GafferUITest.TestCase ) :
 		w1.setVisible( True )
 		w2.setVisible( True )
 
-		w1.setPosition( IECore.V2i( 100 ) )
-		w2.setPosition( IECore.V2i( 300 ) )
+		w1.setPosition( imath.V2i( 100 ) )
+		w2.setPosition( imath.V2i( 300 ) )
 
 		self.waitForIdle( 1000 )
 
@@ -418,14 +419,14 @@ class WidgetTest( GafferUITest.TestCase ) :
 		w.setChild( b )
 		w.setVisible( True )
 
-		w.setPosition( IECore.V2i( 100 ) )
+		w.setPosition( imath.V2i( 100 ) )
 
 		self.waitForIdle( 1000 )
 
 		mouseGlobal = GafferUI.Widget.mousePosition()
 		mouseLocal = GafferUI.Widget.mousePosition( relativeTo = b )
 
-		self.assertEqual( mouseGlobal, mouseLocal + b.bound().min )
+		self.assertEqual( mouseGlobal, mouseLocal + b.bound().min() )
 
 	def testAddressAndObject( self ) :
 

--- a/python/GafferUITest/WindowTest.py
+++ b/python/GafferUITest/WindowTest.py
@@ -37,6 +37,7 @@
 
 import unittest
 import weakref
+import imath
 
 import IECore
 
@@ -275,8 +276,8 @@ class WindowTest( GafferUITest.TestCase ) :
 	def testPosition( self ) :
 
 		w = GafferUI.Window()
-		w.setPosition( IECore.V2i( 10, 20 ) )
-		self.assertEqual( w.getPosition(), IECore.V2i( 10, 20 ) )
+		w.setPosition( imath.V2i( 10, 20 ) )
+		self.assertEqual( w.getPosition(), imath.V2i( 10, 20 ) )
 
 	def testChildWindowsMethod( self ) :
 

--- a/python/GafferVDBTest/LevelSetOffsetTest.py
+++ b/python/GafferVDBTest/LevelSetOffsetTest.py
@@ -68,13 +68,13 @@ class LevelSetOffsetTest( GafferVDBTest.VDBTestCase ) :
 
 		# sphere centred at the origin so we just take the x value of the max and it should equal the radius
 		# hopefully the leafCounts should go like the square of the radius.
-		self.assertEqualTolerance( 5.0, levelSetOffset['out'].bound( "sphere" ).max[0], 0.05 )
+		self.assertEqualTolerance( 5.0, levelSetOffset['out'].bound( "sphere" ).max()[0], 0.05 )
 		self.assertTrue( 1020 <= levelSetOffset['out'].object( "sphere" ).findGrid( "surface" ).leafCount() <= 1040 )
 
 		levelSetOffset["offset"].setValue( -1.0 )
-		self.assertEqualTolerance( 6.0, levelSetOffset['out'].bound( "sphere" ).max[0], 0.05 )
+		self.assertEqualTolerance( 6.0, levelSetOffset['out'].bound( "sphere" ).max()[0], 0.05 )
 		self.assertTrue( 1420 <= levelSetOffset['out'].object( "sphere" ).findGrid( "surface" ).leafCount() <= 1450)
 
 		levelSetOffset["offset"].setValue( 1.0 )
-		self.assertEqualTolerance( 4.0, levelSetOffset['out'].bound( "sphere" ).max[0], 0.05 )
+		self.assertEqualTolerance( 4.0, levelSetOffset['out'].bound( "sphere" ).max()[0], 0.05 )
 		self.assertTrue( 640 <= levelSetOffset['out'].object( "sphere" ).findGrid( "surface" ).leafCount() <= 650)

--- a/python/GafferVDBTest/LevelSetToMeshTest.py
+++ b/python/GafferVDBTest/LevelSetToMeshTest.py
@@ -34,14 +34,16 @@
 #
 ##########################################################################
 
-import GafferTest
+import os
+import imath
 
-import GafferVDB
 import IECore
 import IECoreScene
-import GafferVDBTest
-import os
+
+import GafferTest
 import GafferScene
+import GafferVDB
+import GafferVDBTest
 
 class LevelSetToMeshTest( GafferVDBTest.VDBTestCase ) :
 
@@ -86,13 +88,13 @@ class LevelSetToMeshTest( GafferVDBTest.VDBTestCase ) :
 		self.setFilter( levelSetToMesh, path='/sphere' )
 		levelSetToMesh["in"].setInput( meshToLevelSet["out"] )
 
-		self.assertEqualTolerance( 5.0, levelSetToMesh['out'].bound( "sphere" ).max[0], 0.05 )
+		self.assertEqualTolerance( 5.0, levelSetToMesh['out'].bound( "sphere" ).max()[0], 0.05 )
 
 		levelSetToMesh['isoValue'].setValue(0.5)
-		self.assertEqualTolerance( 5.5, levelSetToMesh['out'].bound( "sphere" ).max[0], 0.05 )
+		self.assertEqualTolerance( 5.5, levelSetToMesh['out'].bound( "sphere" ).max()[0], 0.05 )
 
 		levelSetToMesh['isoValue'].setValue(-0.5)
-		self.assertEqualTolerance( 4.5, levelSetToMesh['out'].bound( "sphere" ).max[0], 0.05 )
+		self.assertEqualTolerance( 4.5, levelSetToMesh['out'].bound( "sphere" ).max()[0], 0.05 )
 
 	def testIncreasingAdapativityDecreasesPolyCount( self ) :
 		sphere = GafferScene.Sphere()

--- a/python/GafferVDBTest/SceneInterfaceTest.py
+++ b/python/GafferVDBTest/SceneInterfaceTest.py
@@ -34,13 +34,15 @@
 #
 ##########################################################################
 
-import GafferTest
+import os
+import imath
 
-import GafferVDB
 import IECore
 import IECoreScene
+
+import GafferTest
+import GafferVDB
 import GafferVDBTest
-import os
 
 class SceneInterfaceTest( GafferVDBTest.VDBTestCase ) :
 	def setUp( self ) :
@@ -71,7 +73,7 @@ class SceneInterfaceTest( GafferVDBTest.VDBTestCase ) :
 			0, 0, 0, 1
 		]
 
-		m44 = IECore.M44d( matrixArray )
+		m44 = imath.M44d( *matrixArray )
 		m44Data = IECore.M44dData( m44 )
 
 		transformData = self.sceneInterface.readTransform( 0.0 )
@@ -83,9 +85,9 @@ class SceneInterfaceTest( GafferVDBTest.VDBTestCase ) :
 	def testCanReadBounds( self ) :
 		bound = self.sceneInterface.readBound( 0.0 )
 
-		expectedBound = IECore.Box3d(
-			IECore.V3d( [-33.809524536132812, -12.380952835083008, -26.190475463867188] ),
-			IECore.V3d( [19.047618865966797, 93.333335876464844, 27.142856597900391] )
+		expectedBound = imath.Box3d(
+			imath.V3d( [-33.809524536132812, -12.380952835083008, -26.190475463867188] ),
+			imath.V3d( [19.047618865966797, 93.333335876464844, 27.142856597900391] )
 		)
 
 		self.assertEqual(bound, expectedBound)

--- a/python/GafferVDBTest/VDBObjectTest.py
+++ b/python/GafferVDBTest/VDBObjectTest.py
@@ -34,12 +34,14 @@
 #
 ##########################################################################
 
-import GafferTest
-
-import GafferVDB
-import IECore
-import GafferVDBTest
 import os
+import imath
+
+import IECore
+
+import GafferTest
+import GafferVDB
+import GafferVDBTest
 
 class VDBObjectTest( GafferVDBTest.VDBTestCase ) :
 
@@ -62,8 +64,8 @@ class VDBObjectTest( GafferVDBTest.VDBTestCase ) :
 			{
 				'name': IECore.StringData( 'ls_sphere' ),
 				'file_voxel_count': IECore.Int64Data( 270638 ),
-				'file_bbox_min': IECore.V3iData( IECore.V3i( -62, -62, -62 ) ),
-				'file_bbox_max': IECore.V3iData( IECore.V3i( 62, 62, 62 ) ),
+				'file_bbox_min': IECore.V3iData( imath.V3i( -62, -62, -62 ) ),
+				'file_bbox_max': IECore.V3iData( imath.V3i( 62, 62, 62 ) ),
 				'is_local_space': IECore.BoolData( 0 ),
 				'is_saved_as_half_float': IECore.BoolData( 1 ),
 				'value_type': IECore.StringData( 'float' ),

--- a/src/GafferImageModule/CoreBinding.cpp
+++ b/src/GafferImageModule/CoreBinding.cpp
@@ -120,7 +120,7 @@ std::string formatRepr( const GafferImage::Format &format )
 		Imath::Box2i box( format.getDisplayWindow() );
 		return std::string(
 			boost::str( boost::format(
-				"GafferImage.Format( IECore.Box2i( IECore.V2i( %d, %d ), IECore.V2i( %d, %d ) ), %.3f )" )
+				"GafferImage.Format( imath.Box2i( imath.V2i( %d, %d ), imath.V2i( %d, %d ) ), %.3f )" )
 				% box.min.x % box.min.y % box.max.x % box.max.y % format.getPixelAspect()
 			)
 		);
@@ -134,8 +134,9 @@ class AtomicFormatPlugSerialiser : public GafferBindings::ValuePlugSerialiser
 
 		void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const override
 		{
+			// Imath is needed when reloading Format values which reference Box2i.
 			ValuePlugSerialiser::moduleDependencies( graphComponent, modules, serialisation );
-			modules.insert( "IECore" );
+			modules.insert( "imath" );
 		}
 
 };
@@ -163,9 +164,9 @@ class FormatPlugSerialiser : public GafferBindings::ValuePlugSerialiser
 
 		void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const override
 		{
-			// IECore is needed when reloading Format values which reference Box2i.
+			// Imath is needed when reloading Format values which reference Box2i.
 			ValuePlugSerialiser::moduleDependencies( graphComponent, modules, serialisation );
-			modules.insert( "IECore" );
+			modules.insert( "imath" );
 		}
 
 };

--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -38,6 +38,9 @@
 #include <memory>
 
 #include "boost/python.hpp" // must be the first include
+#include "boost/algorithm/string/replace.hpp"
+#include "boost/regex.hpp"
+#include "boost/lexical_cast.hpp"
 
 #include "IECore/MessageHandler.h"
 
@@ -184,6 +187,9 @@ boost::python::object executionDict( ScriptNodePtr script, NodePtr parent )
 	boost::python::object gafferModule = boost::python::import( "Gaffer" );
 	result["Gaffer"] = gafferModule;
 
+	boost::python::object imathModule = boost::python::import( "imath" );
+	result["imath"] = imathModule;
+
 	result["script"] = boost::python::object( script );
 	result["parent"] = boost::python::object( parent );
 
@@ -211,12 +217,62 @@ std::string serialise( const Node *parent, const Set *filter )
 	return result;
 }
 
+std::string replaceImath( const std::string &serialisation )
+{
+	// Figure out the version of Gaffer which serialised the file.
+
+	int milestoneVersion = 0;
+	int majorVersion = 0;
+	boost::regex milestoneVersionRegex( R"(Gaffer\.Metadata\.registerNodeValue\( parent, "serialiser:milestoneVersion", ([0-9]+), )" );
+	boost::regex majorVersionRegex( R"(Gaffer\.Metadata\.registerNodeValue\( parent, "serialiser:majorVersion", ([0-9]+), )" );
+	boost::match_results<const char *> matchResults;
+	if( regex_search( serialisation.c_str(), matchResults, milestoneVersionRegex ) )
+	{
+		milestoneVersion = boost::lexical_cast<int>( matchResults.str( 1 ) );
+	}
+	if( regex_search( serialisation.c_str(), matchResults, majorVersionRegex ) )
+	{
+		majorVersion = boost::lexical_cast<int>( matchResults.str( 1 ) );
+	}
+
+	// If it's from a version which used the imath bindings
+	// then we have no work to do.
+
+	if( milestoneVersion > 0 || majorVersion >= 42 )
+	{
+		return serialisation;
+	}
+
+	// Otherwise we need to replace all references to imath
+	// types to use the imath module rather than IECore.
+
+	std::string result = serialisation;
+	for(
+		const auto &x : {
+			"V2i", "V2f",
+			"V3i", "V3f",
+			"Color3f", "Color4f",
+			"Box2i", "Box2f",
+			"Box3i", "Box3f"
+			"Box3i", "Box3f"
+			"M33f", "M44f"
+		}
+	)
+	{
+		boost::replace_all( result, std::string( "IECore." ) + x, std::string( "imath." ) + x );
+	}
+
+	return result;
+}
+
 bool execute( ScriptNode *script, const std::string &serialisation, Node *parent, bool continueOnError, const std::string &context = "" )
 {
 	if( !Py_IsInitialized() )
 	{
 		Py_Initialize();
 	}
+
+	const std::string toExecute = replaceImath( serialisation );
 
 	IECorePython::ScopedGILLock gilLock;
 	bool result = false;
@@ -228,7 +284,7 @@ bool execute( ScriptNode *script, const std::string &serialisation, Node *parent
 		{
 			try
 			{
-				exec( serialisation.c_str(), e, e );
+				exec( toExecute.c_str(), e, e );
 			}
 			catch( boost::python::error_already_set &e )
 			{
@@ -239,7 +295,7 @@ bool execute( ScriptNode *script, const std::string &serialisation, Node *parent
 		}
 		else
 		{
-			result = tolerantExec( serialisation.c_str(), e, e, context );
+			result = tolerantExec( toExecute.c_str(), e, e, context );
 		}
 	}
 	catch( boost::python::error_already_set &e )

--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -249,13 +249,16 @@ std::string replaceImath( const std::string &serialisation )
 	std::string result = serialisation;
 	for(
 		const auto &x : {
-			"V2i", "V2f",
-			"V3i", "V3f",
+			"V2i", "V2f", "V2d",
+			"V3i", "V3f", "V3d",
 			"Color3f", "Color4f",
-			"Box2i", "Box2f",
-			"Box3i", "Box3f"
-			"Box3i", "Box3f"
-			"M33f", "M44f"
+			"Box2i", "Box2f", "Box2d",
+			"Box3i", "Box3f", "Box3d",
+			"M33f", "M33d",
+			"M44f", "M44d",
+			"Eulerf", "Eulerd",
+			"Plane3f", "Plane3d",
+			"Quatf", "Quatd"
 		}
 	)
 	{

--- a/startup/GafferImage/formatCompatibility.py
+++ b/startup/GafferImage/formatCompatibility.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -54,7 +56,7 @@ def __convertFormat( graphComponent, format ):
 
 	if gafferVersion < ( 0, 17, 0, 0 ) :
 		displayWindow = format.getDisplayWindow()
-		displayWindow.max += IECore.V2i( 1 )
+		displayWindow.setMax( displayWindow.max() + imath.V2i( 1 ) )
 		return GafferImage.Format( displayWindow, format.getPixelAspect() )
 
 	return format

--- a/startup/GafferImage/gradeCompatibility.py
+++ b/startup/GafferImage/gradeCompatibility.py
@@ -36,6 +36,7 @@
 
 
 import types
+import imath
 
 import IECore
 
@@ -44,7 +45,7 @@ import GafferImage
 
 def __color4fPlugCompatSetValue( self, value ) :
 
-	if isinstance( value, IECore.Color3f ) :
+	if isinstance( value, imath.Color3f ) :
 		for i in range(3):
 			self[i].setValue( value[i] )
 	else:

--- a/startup/GafferScene/appleseedLights.py
+++ b/startup/GafferScene/appleseedLights.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import math
+import imath
 
 import IECore
 import Gaffer
@@ -43,7 +44,7 @@ Gaffer.Metadata.registerValue( "as:light:latlong_map_environment_edf", "type", "
 Gaffer.Metadata.registerValue( "as:light:latlong_map_environment_edf", "textureNameParameter", "radiance_map" )
 Gaffer.Metadata.registerValue( "as:light:latlong_map_environment_edf", "intensityParameter", "radiance_multiplier" )
 Gaffer.Metadata.registerValue( "as:light:latlong_map_environment_edf", "exposureParameter", "exposure" )
-Gaffer.Metadata.registerValue( "as:light:latlong_map_environment_edf", "visualiserOrientation", IECore.M44f().rotate( IECore.V3f( 0, 0.5 * math.pi, 0 ) ) )
+Gaffer.Metadata.registerValue( "as:light:latlong_map_environment_edf", "visualiserOrientation", imath.M44f().rotate( imath.V3f( 0, 0.5 * math.pi, 0 ) ) )
 
 Gaffer.Metadata.registerValue( "as:light:hosek_environment_edf", "type", "environment" )
 

--- a/startup/GafferScene/arnoldLights.py
+++ b/startup/GafferScene/arnoldLights.py
@@ -71,7 +71,7 @@ Gaffer.Metadata.registerValue( "ai:light:cylinder_light", "intensityParameter", 
 Gaffer.Metadata.registerValue( "ai:light:cylinder_light", "exposureParameter", "exposure" )
 Gaffer.Metadata.registerValue( "ai:light:cylinder_light", "colorParameter", "color" )
 Gaffer.Metadata.registerValue( "ai:light:cylinder_light", "radiusParameter", "radius" )
-Gaffer.Metadata.registerValue( "ai:light:cylinder_light", "visualiserOrientation", IECore.M44f().rotate( IECore.V3f( 0.5 * math.pi, 0 , 0 ) ) )
+Gaffer.Metadata.registerValue( "ai:light:cylinder_light", "visualiserOrientation", imath.M44f().rotate( imath.V3f( 0.5 * math.pi, 0 , 0 ) ) )
 
 Gaffer.Metadata.registerValue( "ai:light:skydome_light", "intensityParameter", "intensity" )
 Gaffer.Metadata.registerValue( "ai:light:skydome_light", "exposureParameter", "exposure" )

--- a/startup/GafferScene/delightLights.py
+++ b/startup/GafferScene/delightLights.py
@@ -61,5 +61,5 @@ Gaffer.Metadata.registerValue( "osl:light:maya/osl/environmentLight", "textureNa
 Gaffer.Metadata.registerValue( "osl:light:maya/osl/environmentLight", "intensityParameter", "intensity" )
 Gaffer.Metadata.registerValue( "osl:light:maya/osl/environmentLight", "exposureParameter", "exposure" )
 Gaffer.Metadata.registerValue( "osl:light:maya/osl/environmentLight", "colorParameter", "tint" )
-Gaffer.Metadata.registerValue( "osl:light:maya/osl/environmentLight", "visualiserOrientation", IECore.M44f().rotate( IECore.V3f( 0, math.pi, 0 ) ) )
+Gaffer.Metadata.registerValue( "osl:light:maya/osl/environmentLight", "visualiserOrientation", imath.M44f().rotate( imath.V3f( 0, math.pi, 0 ) ) )
 

--- a/startup/gui/nodeGraph.py
+++ b/startup/gui/nodeGraph.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import functools
+import imath
 
 import IECore
 
@@ -50,37 +51,37 @@ import GafferDispatchUI
 # Colour
 ##########################################################################
 
-Gaffer.Metadata.registerNodeValue( GafferDispatch.TaskNode, "nodeGadget:color", IECore.Color3f( 0.61, 0.1525, 0.1525 ) )
-Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "task", "nodule:color", IECore.Color3f( 0.645, 0.2483, 0.2483 ) )
-Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "preTasks.*", "nodule:color", IECore.Color3f( 0.645, 0.2483, 0.2483 ) )
-Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "postTasks.*", "nodule:color", IECore.Color3f( 0.645, 0.2483, 0.2483 ) )
-Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "task", "connectionGadget:color", IECore.Color3f( 0.315, 0.0787, 0.0787 ) )
-Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "preTasks.*", "connectionGadget:color", IECore.Color3f( 0.315, 0.0787, 0.0787 ) )
-Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "postTasks.*", "connectionGadget:color", IECore.Color3f( 0.315, 0.0787, 0.0787 ) )
+Gaffer.Metadata.registerNodeValue( GafferDispatch.TaskNode, "nodeGadget:color", imath.Color3f( 0.61, 0.1525, 0.1525 ) )
+Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "task", "nodule:color", imath.Color3f( 0.645, 0.2483, 0.2483 ) )
+Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "preTasks.*", "nodule:color", imath.Color3f( 0.645, 0.2483, 0.2483 ) )
+Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "postTasks.*", "nodule:color", imath.Color3f( 0.645, 0.2483, 0.2483 ) )
+Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "task", "connectionGadget:color", imath.Color3f( 0.315, 0.0787, 0.0787 ) )
+Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "preTasks.*", "connectionGadget:color", imath.Color3f( 0.315, 0.0787, 0.0787 ) )
+Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "postTasks.*", "connectionGadget:color", imath.Color3f( 0.315, 0.0787, 0.0787 ) )
 
-Gaffer.Metadata.registerNodeValue( Gaffer.SubGraph, "nodeGadget:color", IECore.Color3f( 0.225 ) )
-Gaffer.Metadata.registerNodeValue( Gaffer.BoxIO, "nodeGadget:color", IECore.Color3f( 0.225 ) )
+Gaffer.Metadata.registerNodeValue( Gaffer.SubGraph, "nodeGadget:color", imath.Color3f( 0.225 ) )
+Gaffer.Metadata.registerNodeValue( Gaffer.BoxIO, "nodeGadget:color", imath.Color3f( 0.225 ) )
 
-Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "in*", "nodule:color", IECore.Color3f( 0.2401, 0.3394, 0.485 ) )
-Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "out", "nodule:color", IECore.Color3f( 0.2401, 0.3394, 0.485 ) )
-Gaffer.Metadata.registerPlugValue( GafferScene.InteractiveRender, "in", "nodule:color", IECore.Color3f( 0.2346, 0.326, 0.46 ) )
-Gaffer.Metadata.registerPlugValue( GafferScene.Parent, "child", "nodule:color", IECore.Color3f( 0.2346, 0.326, 0.46 ) )
+Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "in*", "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
+Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "out", "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
+Gaffer.Metadata.registerPlugValue( GafferScene.InteractiveRender, "in", "nodule:color", imath.Color3f( 0.2346, 0.326, 0.46 ) )
+Gaffer.Metadata.registerPlugValue( GafferScene.Parent, "child", "nodule:color", imath.Color3f( 0.2346, 0.326, 0.46 ) )
 
-Gaffer.Metadata.registerNodeValue( GafferScene.SceneProcessor, "nodeGadget:color", IECore.Color3f( 0.495, 0.2376, 0.4229 ) )
-Gaffer.Metadata.registerNodeValue( GafferScene.SceneElementProcessor, "nodeGadget:color", IECore.Color3f( 0.1886, 0.2772, 0.41 ) )
+Gaffer.Metadata.registerNodeValue( GafferScene.SceneProcessor, "nodeGadget:color", imath.Color3f( 0.495, 0.2376, 0.4229 ) )
+Gaffer.Metadata.registerNodeValue( GafferScene.SceneElementProcessor, "nodeGadget:color", imath.Color3f( 0.1886, 0.2772, 0.41 ) )
 
-Gaffer.Metadata.registerPlugValue( GafferScene.FilteredSceneProcessor, "filter", "nodule:color", IECore.Color3f( 0.69, 0.5378, 0.2283 ) )
-Gaffer.Metadata.registerPlugValue( GafferScene.Filter, "out", "nodule:color", IECore.Color3f( 0.69, 0.5378, 0.2283 ) )
+Gaffer.Metadata.registerPlugValue( GafferScene.FilteredSceneProcessor, "filter", "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
+Gaffer.Metadata.registerPlugValue( GafferScene.Filter, "out", "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
 
-Gaffer.Metadata.registerNodeValue( GafferScene.Transform, "nodeGadget:color", IECore.Color3f( 0.485, 0.3112, 0.2255 ) )
-Gaffer.Metadata.registerNodeValue( GafferScene.Constraint, "nodeGadget:color", IECore.Color3f( 0.485, 0.3112, 0.2255 ) )
+Gaffer.Metadata.registerNodeValue( GafferScene.Transform, "nodeGadget:color", imath.Color3f( 0.485, 0.3112, 0.2255 ) )
+Gaffer.Metadata.registerNodeValue( GafferScene.Constraint, "nodeGadget:color", imath.Color3f( 0.485, 0.3112, 0.2255 ) )
 
-Gaffer.Metadata.registerNodeValue( GafferScene.GlobalsProcessor, "nodeGadget:color", IECore.Color3f( 0.255, 0.505, 0.28 ) )
+Gaffer.Metadata.registerNodeValue( GafferScene.GlobalsProcessor, "nodeGadget:color", imath.Color3f( 0.255, 0.505, 0.28 ) )
 
 __shaderNoduleColors = {
-	Gaffer.FloatPlug.staticTypeId() : IECore.Color3fData( IECore.Color3f( 0.2467, 0.3762, 0.47 ) ),
-	Gaffer.Color3fPlug.staticTypeId() : IECore.Color3fData( IECore.Color3f( 0.69, 0.5378, 0.2283 ) ),
-	Gaffer.V3fPlug.staticTypeId() : IECore.Color3fData( IECore.Color3f( 0.47, 0.181, 0.181 ) ),
+	Gaffer.FloatPlug.staticTypeId() : IECore.Color3fData( imath.Color3f( 0.2467, 0.3762, 0.47 ) ),
+	Gaffer.Color3fPlug.staticTypeId() : IECore.Color3fData( imath.Color3f( 0.69, 0.5378, 0.2283 ) ),
+	Gaffer.V3fPlug.staticTypeId() : IECore.Color3fData( imath.Color3f( 0.47, 0.181, 0.181 ) ),
 }
 
 def __shaderNoduleColor( plug ) :

--- a/startup/gui/ocio.py
+++ b/startup/gui/ocio.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import functools
+import imath
 
 import IECore
 
@@ -80,7 +81,7 @@ def __setDisplayTransform() :
 	def f( c ) :
 
 		cc = processor.applyRGB( [ c.r, c.g, c.b ] )
-		return IECore.Color3f( *cc )
+		return imath.Color3f( *cc )
 
 	GafferUI.DisplayTransform.set( f )
 

--- a/startup/gui/viewer.py
+++ b/startup/gui/viewer.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import functools
+import imath
 
 import IECore
 
@@ -47,7 +48,7 @@ import GafferSceneUI
 
 preferences = application.root()["preferences"]
 preferences["viewer"] = Gaffer.Plug()
-preferences["viewer"]["gridDimensions"] = Gaffer.V2fPlug( defaultValue = IECore.V2f( 10 ), minValue = IECore.V2f( 0 ) )
+preferences["viewer"]["gridDimensions"] = Gaffer.V2fPlug( defaultValue = imath.V2f( 10 ), minValue = imath.V2f( 0 ) )
 
 Gaffer.Metadata.registerValue( preferences["viewer"], "plugValueWidget:type", "GafferUI.LayoutPlugValueWidget", persistent = False )
 Gaffer.Metadata.registerValue( preferences["viewer"], "layout:section", "Viewer", persistent = False )


### PR DESCRIPTION
This is the companion PR for https://github.com/ImageEngine/cortex/pull/672. Mostly just a high volume of mechanical changes, but there are a few separate commits you might want to review more thoroughly. 

Probably the only contentious one is c020f4e, which is rather blunt in its approach. I discussed this with @donboie previously, and made the case that this is preferable to the only alternative I could see, which would be injecting fake Imath bindings into IECore during script execution. The latter wouldn't fix up python expressions as the current approach does, and risks folks continuing to rely on the fake bindings for their own uses of `ScriptNode::execute()`. We tried to think of pathological cases where the string substitution would do something problematic, and came to the conclusion that these were unlikely. Please do give this some thought though - perhaps there's something I missed.