### PR TITLE
Adding `roles` as color space name preset

### DIFF
--- a/include/GafferImage/OpenColorIOTransform.h
+++ b/include/GafferImage/OpenColorIOTransform.h
@@ -57,6 +57,9 @@ class OpenColorIOTransform : public ColorProcessor
 		/// Fills the vector will the available color spaces,
 		/// as defined by the current OpenColorIO config.
 		static void availableColorSpaces( std::vector<std::string> &colorSpaces );
+		/// Fills the vector will the available roles,
+		/// as defined by the current OpenColorIO config.
+		static void availableRoles( std::vector<std::string> &Roles );
 
 		/// May return null if the derived class does not
 		/// request OCIO context variable support.

--- a/python/GafferImageUI/ColorSpaceUI.py
+++ b/python/GafferImageUI/ColorSpaceUI.py
@@ -39,14 +39,7 @@ import IECore
 import Gaffer
 import GafferUI
 import GafferImage
-
-def __colorSpacePresetNames( plug ) :
-
-	return IECore.StringVectorData( [ "None" ] + GafferImage.OpenColorIOTransform.availableColorSpaces() )
-
-def __colorSpacePresetValues( plug ) :
-
-	return IECore.StringVectorData( [ "" ] + GafferImage.OpenColorIOTransform.availableColorSpaces() )
+import OpenColorIOTransformUI
 
 Gaffer.Metadata.registerNode(
 
@@ -69,8 +62,8 @@ Gaffer.Metadata.registerNode(
 			The colour space of the input image.
 			""",
 
-			"presetNames", __colorSpacePresetNames,
-			"presetValues", __colorSpacePresetValues,
+			"presetNames", OpenColorIOTransformUI.colorSpacePresetNames,
+			"presetValues", OpenColorIOTransformUI.colorSpacePresetValues,
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
@@ -83,8 +76,8 @@ Gaffer.Metadata.registerNode(
 			The colour space of the output image.
 			""",
 
-			"presetNames", __colorSpacePresetNames,
-			"presetValues", __colorSpacePresetValues,
+			"presetNames", OpenColorIOTransformUI.colorSpacePresetNames,
+			"presetValues", OpenColorIOTransformUI.colorSpacePresetValues,
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 

--- a/python/GafferImageUI/DisplayTransformUI.py
+++ b/python/GafferImageUI/DisplayTransformUI.py
@@ -41,14 +41,8 @@ import IECore
 import Gaffer
 import GafferUI
 import GafferImage
+import OpenColorIOTransformUI
 
-def __colorSpacePresetNames( plug ) :
-
-	return IECore.StringVectorData( [ "None" ] + GafferImage.OpenColorIOTransform.availableColorSpaces() )
-
-def __colorSpacePresetValues( plug ) :
-
-	return IECore.StringVectorData( [ "" ] + GafferImage.OpenColorIOTransform.availableColorSpaces() )
 
 def __displayPresetNames( plug ) :
 
@@ -95,8 +89,8 @@ Gaffer.Metadata.registerNode(
 			The colour space of the input image.
 			""",
 
-			"presetNames", __colorSpacePresetNames,
-			"presetValues", __colorSpacePresetValues,
+			"presetNames", OpenColorIOTransformUI.colorSpacePresetNames,
+			"presetValues", OpenColorIOTransformUI.colorSpacePresetValues,
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 		],

--- a/python/GafferImageUI/ImageReaderUI.py
+++ b/python/GafferImageUI/ImageReaderUI.py
@@ -39,14 +39,7 @@ import IECore
 import Gaffer
 import GafferUI
 import GafferImage
-
-def __colorSpacePresetNames( plug ) :
-
-	return IECore.StringVectorData( [ "Default" ] + GafferImage.OpenColorIOTransform.availableColorSpaces() )
-
-def __colorSpacePresetValues( plug ) :
-
-	return IECore.StringVectorData( [ "" ] + GafferImage.OpenColorIOTransform.availableColorSpaces() )
+import OpenColorIOTransformUI
 
 Gaffer.Metadata.registerNode(
 
@@ -209,8 +202,8 @@ Gaffer.Metadata.registerNode(
 			registered with `ImageReader::setDefaultColorSpaceFunction()`.
 			""",
 
-			"presetNames", __colorSpacePresetNames,
-			"presetValues", __colorSpacePresetValues,
+			"presetNames", OpenColorIOTransformUI.colorSpacePresetNames,
+			"presetValues", OpenColorIOTransformUI.colorSpacePresetValues,
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 

--- a/python/GafferImageUI/ImageWriterUI.py
+++ b/python/GafferImageUI/ImageWriterUI.py
@@ -40,14 +40,7 @@ import Gaffer
 import GafferUI
 import GafferImageUI
 import GafferImage
-
-def __colorSpacePresetNames( plug ) :
-
-	return IECore.StringVectorData( [ "Default" ] + GafferImage.OpenColorIOTransform.availableColorSpaces() )
-
-def __colorSpacePresetValues( plug ) :
-
-	return IECore.StringVectorData( [ "" ] + GafferImage.OpenColorIOTransform.availableColorSpaces() )
+import OpenColorIOTransformUI
 
 Gaffer.Metadata.registerNode(
 
@@ -116,8 +109,8 @@ Gaffer.Metadata.registerNode(
 			calling the function registered with `ImageWriter::setDefaultColorSpaceFunction()`.
 			""",
 
-			"presetNames", __colorSpacePresetNames,
-			"presetValues", __colorSpacePresetValues,
+			"presetNames", OpenColorIOTransformUI.colorSpacePresetNames,
+			"presetValues", OpenColorIOTransformUI.colorSpacePresetValues,
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 		],

--- a/python/GafferImageUI/OpenColorIOTransformUI.py
+++ b/python/GafferImageUI/OpenColorIOTransformUI.py
@@ -40,6 +40,15 @@ import Gaffer
 import GafferUI
 import GafferImage
 
+def colorSpacePresetNames( plug ) :
+
+	return IECore.StringVectorData( [ "None" ] + sorted( map( lambda x: "Roles/{0}".format( x.replace( "_", " ").title() ), GafferImage.OpenColorIOTransform.availableRoles() ) ) + sorted( GafferImage.OpenColorIOTransform.availableColorSpaces() )  )
+
+
+def colorSpacePresetValues( plug ) :
+
+	return IECore.StringVectorData( [ "" ] + sorted( GafferImage.OpenColorIOTransform.availableRoles() ) + sorted( GafferImage.OpenColorIOTransform.availableColorSpaces() ) )
+
 Gaffer.Metadata.registerNode(
 
 	GafferImage.OpenColorIOTransform,

--- a/src/GafferImage/OpenColorIOTransform.cpp
+++ b/src/GafferImage/OpenColorIOTransform.cpp
@@ -239,3 +239,16 @@ void OpenColorIOTransform::availableColorSpaces( std::vector<std::string> &color
 		colorSpaces.push_back( config->getColorSpaceNameByIndex( i ) );
 	}
 }
+
+void OpenColorIOTransform::availableRoles( std::vector<std::string> &roles )
+{
+	OpenColorIO::ConstConfigRcPtr config = OpenColorIO::GetCurrentConfig();
+
+	roles.clear();
+	roles.reserve( config->getNumRoles() );
+
+	for( int i = 0; i < config->getNumRoles(); ++i )
+	{
+		roles.push_back( config->getRoleName( i ) );
+	}
+}

--- a/src/GafferImageModule/OpenColorIOTransformBinding.cpp
+++ b/src/GafferImageModule/OpenColorIOTransformBinding.cpp
@@ -66,6 +66,20 @@ boost::python::list availableColorSpaces()
 	return result;
 }
 
+boost::python::list availableRoles()
+{
+	std::vector<std::string> e;
+	OpenColorIOTransform::availableRoles( e );
+
+	boost::python::list result;
+	for( std::vector<std::string>::const_iterator it = e.begin(), eIt = e.end(); it != eIt; ++it )
+	{
+		result.append( *it );
+	}
+
+	return result;
+}
+
 boost::python::list supportedExtensions()
 {
 	std::vector<std::string> e;
@@ -89,6 +103,7 @@ void GafferImageModule::bindOpenColorIOTransform()
 
 	GafferBindings::DependencyNodeClass<OpenColorIOTransform>()
 		.def( "availableColorSpaces", &availableColorSpaces ).staticmethod( "availableColorSpaces" )
+		.def( "availableRoles", &availableRoles ).staticmethod( "availableRoles" )
 	;
 
 	GafferBindings::DependencyNodeClass<ColorSpace>();


### PR DESCRIPTION
Improvements
--

- OpenColorIOTransform: Added `availablesRoles` to query the list of `role` names.
- ImageReaderUI / ImageWriterUI / DisplayTransformUI / ColorSpaceUI: Added `role` as color space preset.