### PR TITLE
TypedObjectPlug : Add esoteric `getValueIfCached()` method

### DIFF
--- a/include/Gaffer/TypedObjectPlug.h
+++ b/include/Gaffer/TypedObjectPlug.h
@@ -108,11 +108,11 @@ class TypedObjectPlug : public ValuePlug
 		/// This pattern is particularly effective because it not only
 		/// avoids unnecessary conversions, but it also avoids churn in
 		/// the ValuePlug cache.
-		///
-		/// If `cachedOnly` is true and the value is not in the cache, null will be
-		/// returned. This argument may be removed in a future version - use only if
-		/// absolutely necessary.
-		ConstValuePtr getValue( const IECore::MurmurHash *precomputedHash = nullptr, bool cachedOnly = false ) const;
+		ConstValuePtr getValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
+		/// As above, but returns null if the value is not already cached.
+		/// This method is likely to be removed in a future version - use only
+		/// if absolutely necessary.
+		ConstValuePtr getValueIfCached( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 
 		void setFrom( const ValuePlug *other ) override;
 

--- a/include/Gaffer/TypedObjectPlug.h
+++ b/include/Gaffer/TypedObjectPlug.h
@@ -108,7 +108,11 @@ class TypedObjectPlug : public ValuePlug
 		/// This pattern is particularly effective because it not only
 		/// avoids unnecessary conversions, but it also avoids churn in
 		/// the ValuePlug cache.
-		ConstValuePtr getValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
+		///
+		/// If `cachedOnly` is true and the value is not in the cache, null will be
+		/// returned. This argument may be removed in a future version - use only if
+		/// absolutely necessary.
+		ConstValuePtr getValue( const IECore::MurmurHash *precomputedHash = nullptr, bool cachedOnly = false ) const;
 
 		void setFrom( const ValuePlug *other ) override;
 

--- a/include/Gaffer/TypedObjectPlug.inl
+++ b/include/Gaffer/TypedObjectPlug.inl
@@ -96,9 +96,9 @@ void TypedObjectPlug<T>::setValue( ConstValuePtr value )
 }
 
 template<class T>
-typename TypedObjectPlug<T>::ConstValuePtr TypedObjectPlug<T>::getValue( const IECore::MurmurHash *precomputedHash ) const
+typename TypedObjectPlug<T>::ConstValuePtr TypedObjectPlug<T>::getValue( const IECore::MurmurHash *precomputedHash, bool cachedOnly ) const
 {
-	return boost::static_pointer_cast<const ValueType>( getObjectValue( precomputedHash ) );
+	return boost::static_pointer_cast<const ValueType>( getObjectValue( precomputedHash, cachedOnly ) );
 }
 
 template<class T>

--- a/include/Gaffer/TypedObjectPlug.inl
+++ b/include/Gaffer/TypedObjectPlug.inl
@@ -96,9 +96,15 @@ void TypedObjectPlug<T>::setValue( ConstValuePtr value )
 }
 
 template<class T>
-typename TypedObjectPlug<T>::ConstValuePtr TypedObjectPlug<T>::getValue( const IECore::MurmurHash *precomputedHash, bool cachedOnly ) const
+typename TypedObjectPlug<T>::ConstValuePtr TypedObjectPlug<T>::getValue( const IECore::MurmurHash *precomputedHash ) const
 {
-	return boost::static_pointer_cast<const ValueType>( getObjectValue( precomputedHash, cachedOnly ) );
+	return boost::static_pointer_cast<const ValueType>( getObjectValue( precomputedHash ) );
+}
+
+template<class T>
+typename TypedObjectPlug<T>::ConstValuePtr TypedObjectPlug<T>::getValueIfCached( const IECore::MurmurHash *precomputedHash ) const
+{
+	return boost::static_pointer_cast<const ValueType>( getObjectValueIfCached( precomputedHash ) );
 }
 
 template<class T>

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -150,7 +150,11 @@ class ValuePlug : public Plug
 		/// If a precomputed hash is available it may be passed to avoid computing
 		/// it again unnecessarily. Passing an incorrect hash has dire consequences, so
 		/// use with care.
-		IECore::ConstObjectPtr getObjectValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
+		///
+		/// If `cachedOnly` is true and the value is not in the cache, null will be
+		/// returned. This argument may be removed in a future version - use only if
+		/// absolutely necessary.
+		IECore::ConstObjectPtr getObjectValue( const IECore::MurmurHash *precomputedHash = nullptr, bool cachedOnly = false ) const;
 		/// Should be called by derived classes when they wish to set the plug
 		/// value - the value is referenced directly (not copied) and so must
 		/// not be changed following the call.

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -154,7 +154,11 @@ class ValuePlug : public Plug
 		/// If `cachedOnly` is true and the value is not in the cache, null will be
 		/// returned. This argument may be removed in a future version - use only if
 		/// absolutely necessary.
-		IECore::ConstObjectPtr getObjectValue( const IECore::MurmurHash *precomputedHash = nullptr, bool cachedOnly = false ) const;
+		IECore::ConstObjectPtr getObjectValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
+		/// As above, but returns null if the value is not already cached.
+		/// This method is likely to be removed in a future version - use only
+		/// if absolutely necessary.
+		IECore::ConstObjectPtr getObjectValueIfCached( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 		/// Should be called by derived classes when they wish to set the plug
 		/// value - the value is referenced directly (not copied) and so must
 		/// not be changed following the call.

--- a/include/GafferBindings/TypedObjectPlugBinding.inl
+++ b/include/GafferBindings/TypedObjectPlugBinding.inl
@@ -76,13 +76,13 @@ void setValue( typename T::Ptr p, typename T::ValuePtr v, bool copy=true )
 // Likewise, we expose the precomputedHash argument prefixed with an underscore to
 // discourage its use - again it is mainly exposed for use only in the tests.
 template<typename T>
-IECore::ObjectPtr getValue( typename T::Ptr p, const IECore::MurmurHash *precomputedHash=nullptr, bool copy=true )
+IECore::ObjectPtr getValue( typename T::Ptr p, const IECore::MurmurHash *precomputedHash=nullptr, bool copy=true, bool cachedOnly=false )
 {
 	// Must release GIL in case computation spawns threads which need
 	// to reenter Python.
 	IECorePython::ScopedGILRelease r;
 
-	typename IECore::ConstObjectPtr v = p->getValue( precomputedHash );
+	typename IECore::ConstObjectPtr v = p->getValue( precomputedHash, cachedOnly );
 	if( v )
 	{
 		if( copy )
@@ -142,7 +142,7 @@ TypedObjectPlugClass<T, TWrapper>::TypedObjectPlugClass( const char *docString )
 	);
 	this->def( "defaultValue", &Detail::defaultValue<T>, ( boost::python::arg_( "_copy" ) = true ) );
 	this->def( "setValue", Detail::setValue<T>, ( boost::python::arg_( "value" ), boost::python::arg_( "_copy" ) = true ) );
-	this->def( "getValue", Detail::getValue<T>, ( boost::python::arg_( "_precomputedHash" ) = boost::python::object(), boost::python::arg_( "_copy" ) = true ) );
+	this->def( "getValue", Detail::getValue<T>, ( boost::python::arg_( "_precomputedHash" ) = boost::python::object(), boost::python::arg_( "_copy" ) = true, boost::python::arg_( "_cachedOnly" ) = false ) );
 
 	boost::python::scope s = *this;
 

--- a/include/GafferBindings/TypedObjectPlugBinding.inl
+++ b/include/GafferBindings/TypedObjectPlugBinding.inl
@@ -76,13 +76,35 @@ void setValue( typename T::Ptr p, typename T::ValuePtr v, bool copy=true )
 // Likewise, we expose the precomputedHash argument prefixed with an underscore to
 // discourage its use - again it is mainly exposed for use only in the tests.
 template<typename T>
-IECore::ObjectPtr getValue( typename T::Ptr p, const IECore::MurmurHash *precomputedHash=nullptr, bool copy=true, bool cachedOnly=false )
+IECore::ObjectPtr getValue( typename T::Ptr p, const IECore::MurmurHash *precomputedHash=nullptr, bool copy=true )
 {
 	// Must release GIL in case computation spawns threads which need
 	// to reenter Python.
 	IECorePython::ScopedGILRelease r;
 
-	typename IECore::ConstObjectPtr v = p->getValue( precomputedHash, cachedOnly );
+	typename IECore::ConstObjectPtr v = p->getValue( precomputedHash );
+	if( v )
+	{
+		if( copy )
+		{
+			return v->copy();
+		}
+		else
+		{
+			return boost::const_pointer_cast<IECore::Object>( v );
+		}
+	}
+	return nullptr;
+}
+
+template<typename T>
+IECore::ObjectPtr getValueIfCached( typename T::Ptr p, const IECore::MurmurHash *precomputedHash=nullptr, bool copy=true )
+{
+	// Must release GIL in case computation spawns threads which need
+	// to reenter Python.
+	IECorePython::ScopedGILRelease r;
+
+	typename IECore::ConstObjectPtr v = p->getValueIfCached( precomputedHash );
 	if( v )
 	{
 		if( copy )
@@ -142,7 +164,8 @@ TypedObjectPlugClass<T, TWrapper>::TypedObjectPlugClass( const char *docString )
 	);
 	this->def( "defaultValue", &Detail::defaultValue<T>, ( boost::python::arg_( "_copy" ) = true ) );
 	this->def( "setValue", Detail::setValue<T>, ( boost::python::arg_( "value" ), boost::python::arg_( "_copy" ) = true ) );
-	this->def( "getValue", Detail::getValue<T>, ( boost::python::arg_( "_precomputedHash" ) = boost::python::object(), boost::python::arg_( "_copy" ) = true, boost::python::arg_( "_cachedOnly" ) = false ) );
+	this->def( "getValue", Detail::getValue<T>, ( boost::python::arg_( "_precomputedHash" ) = boost::python::object(), boost::python::arg_( "_copy" ) = true ) );
+	this->def( "getValueIfCached", Detail::getValueIfCached<T>, ( boost::python::arg_( "_precomputedHash" ) = boost::python::object(), boost::python::arg_( "_copy" ) = true ) );
 
 	boost::python::scope s = *this;
 

--- a/python/GafferTest/TypedObjectPlugTest.py
+++ b/python/GafferTest/TypedObjectPlugTest.py
@@ -221,16 +221,16 @@ class TypedObjectPlugTest( GafferTest.TestCase ) :
 		self.assertFalse( p1.acceptsChild( p2 ) )
 		self.assertRaises( RuntimeError, p1.addChild, p2 )
 
-	def testGetValueCachedOnly( self ) :
+	def testGetValueIfCached( self ) :
 
 		n = GafferTest.CachingTestNode()
-		n["in"].setValue( "TypedObjectPlugTest.testGetValueCachedOnly" )
+		n["in"].setValue( "TypedObjectPlugTest.testGetValueIfCached" )
 
-		self.assertTrue( n["out"].getValue( _cachedOnly = True ) is None )
+		self.assertTrue( n["out"].getValueIfCached() is None )
 		v = n["out"].getValue()
 		self.assertIsInstance( v, IECore.StringData )
 		self.assertEqual( v.value, n["in"].getValue() )
-		self.assertEqual( n["out"].getValue( _cachedOnly = True ), v )
+		self.assertEqual( n["out"].getValueIfCached(), v )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/TypedObjectPlugTest.py
+++ b/python/GafferTest/TypedObjectPlugTest.py
@@ -221,5 +221,16 @@ class TypedObjectPlugTest( GafferTest.TestCase ) :
 		self.assertFalse( p1.acceptsChild( p2 ) )
 		self.assertRaises( RuntimeError, p1.addChild, p2 )
 
+	def testGetValueCachedOnly( self ) :
+
+		n = GafferTest.CachingTestNode()
+		n["in"].setValue( "TypedObjectPlugTest.testGetValueCachedOnly" )
+
+		self.assertTrue( n["out"].getValue( _cachedOnly = True ) is None )
+		v = n["out"].getValue()
+		self.assertIsInstance( v, IECore.StringData )
+		self.assertEqual( v.value, n["in"].getValue() )
+		self.assertEqual( n["out"].getValue( _cachedOnly = True ), v )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -270,7 +270,7 @@ class ValuePlug::ComputeProcess : public Process
 			g_cache.clear();
 		}
 
-		static IECore::ConstObjectPtr value( const ValuePlug *plug, const IECore::MurmurHash *precomputedHash )
+		static IECore::ConstObjectPtr value( const ValuePlug *plug, const IECore::MurmurHash *precomputedHash, bool cachedOnly )
 		{
 			const ValuePlug *p = sourcePlug( plug );
 
@@ -294,7 +294,7 @@ class ValuePlug::ComputeProcess : public Process
 				// result if we have.
 				IECore::MurmurHash hash = precomputedHash ? *precomputedHash : p->hash();
 				IECore::ConstObjectPtr result = g_cache.get( hash );
-				if( result )
+				if( result || cachedOnly )
 				{
 					return result;
 				}
@@ -322,7 +322,14 @@ class ValuePlug::ComputeProcess : public Process
 			{
 				// Plug has requested no caching, so we compute from scratch every
 				// time.
-				return ComputeProcess( p, plug ).m_result;
+				if( !cachedOnly )
+				{
+					return ComputeProcess( p, plug ).m_result;
+				}
+				else
+				{
+					return nullptr;
+				}
 			}
 		}
 
@@ -664,9 +671,9 @@ const IECore::Object *ValuePlug::defaultObjectValue() const
 	return m_defaultValue.get();
 }
 
-IECore::ConstObjectPtr ValuePlug::getObjectValue( const IECore::MurmurHash *precomputedHash ) const
+IECore::ConstObjectPtr ValuePlug::getObjectValue( const IECore::MurmurHash *precomputedHash, bool cachedOnly ) const
 {
-	return ComputeProcess::value( this, precomputedHash );
+	return ComputeProcess::value( this, precomputedHash, cachedOnly );
 }
 
 void ValuePlug::setObjectValue( IECore::ConstObjectPtr value )

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -671,9 +671,14 @@ const IECore::Object *ValuePlug::defaultObjectValue() const
 	return m_defaultValue.get();
 }
 
-IECore::ConstObjectPtr ValuePlug::getObjectValue( const IECore::MurmurHash *precomputedHash, bool cachedOnly ) const
+IECore::ConstObjectPtr ValuePlug::getObjectValue( const IECore::MurmurHash *precomputedHash ) const
 {
-	return ComputeProcess::value( this, precomputedHash, cachedOnly );
+	return ComputeProcess::value( this, precomputedHash, /* cachedOnly = */ false );
+}
+
+IECore::ConstObjectPtr ValuePlug::getObjectValueIfCached( const IECore::MurmurHash *precomputedHash ) const
+{
+	return ComputeProcess::value( this, precomputedHash, /* cachedOnly = */ true );
 }
 
 void ValuePlug::setObjectValue( IECore::ConstObjectPtr value )


### PR DESCRIPTION
This provides functionality to assist Daniel's work on the OpenImageIOReader, but is not intended for wider use. It is intended as a stopgap measure until we can make some planned improvements to the underlying ValuePlug caching mechanism.