### PR TITLE
Serialisation Fixes

### DIFF
--- a/include/GafferBindings/ValuePlugBinding.h
+++ b/include/GafferBindings/ValuePlugBinding.h
@@ -58,15 +58,9 @@ class ValuePlugSerialiser : public PlugSerialiser
 
 		void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const override;
 		std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const override;
-		std::string postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override;
+		std::string postHierarchy( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override;
 
 		static std::string repr( const Gaffer::ValuePlug *plug, unsigned flagsMask = Gaffer::Plug::All, const std::string &extraArguments = "", const Serialisation *serialisation = nullptr );
-
-	protected :
-
-		/// May be implemented by derived classes to control whether or not a setValue() call is emitted by postConstructor().
-		/// The default implementation returns true only for input plugs without an incoming connection.
-		virtual bool valueNeedsSerialisation( const Gaffer::ValuePlug *plug, const Serialisation &serialisation ) const;
 
 };
 

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1333,8 +1333,8 @@ class ExpressionTest( GafferTest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 		s["n1"] = GafferTest.AddNode()
-		s["n1"]["op1"].setValue( 10 )
-		s["n1"]["op2"].setValue( 20 )
+		s["n1"]["op1"].setValue( 101 )
+		s["n1"]["op2"].setValue( 201 )
 		s["n1"]["sum"].setFlags( Gaffer.Plug.Flags.Serialisable, False )
 		s["n2"] = GafferTest.AddNode()
 
@@ -1344,7 +1344,7 @@ class ExpressionTest( GafferTest.TestCase ) :
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 
-		self.assertEqual( s2["n2"]["op1"].getValue(), 30 )
+		self.assertEqual( s2["n2"]["op1"].getValue(), 302 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1329,5 +1329,22 @@ class ExpressionTest( GafferTest.TestCase ) :
 			self.assertEqual( s["n"]["sum"].getValue(), 32 )
 			self.assertEqual( s["n1"]["sum"].getValue(), 35 )
 
+	def testNonSerialisableInput( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n1"] = GafferTest.AddNode()
+		s["n1"]["op1"].setValue( 10 )
+		s["n1"]["op2"].setValue( 20 )
+		s["n1"]["sum"].setFlags( Gaffer.Plug.Flags.Serialisable, False )
+		s["n2"] = GafferTest.AddNode()
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( """parent["n2"]["op1"] = parent["n1"]["sum"]""" )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( s2["n2"]["op1"].getValue(), 30 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -423,7 +423,7 @@ void Expression::updatePlug( ValuePlug *parentPlug, size_t childIndex, ValuePlug
 	// Finally we can add the plug we need.
 
 	PlugPtr childPlug = plug->createCounterpart( "p0", parentPlug->direction() );
-	childPlug->setFlags( Plug::Dynamic, true );
+	childPlug->setFlags( Plug::Dynamic | Plug::Serialisable, true );
 	parentPlug->addChild( childPlug );
 	if( childPlug->direction() == Plug::In )
 	{

--- a/src/GafferModule/CompoundNumericPlugBinding.cpp
+++ b/src/GafferModule/CompoundNumericPlugBinding.cpp
@@ -83,12 +83,13 @@ std::string compoundNumericPlugRepr( const T *plug )
 template<typename T>
 class CompoundNumericPlugSerialiser : public ValuePlugSerialiser
 {
-  public:
 
-	std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const override
-	{
-		return maskedCompoundNumericPlugRepr( static_cast<const T *>( graphComponent ), Plug::All & ~Plug::ReadOnly, &serialisation );
-	}
+	public :
+
+		std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const override
+		{
+			return maskedCompoundNumericPlugRepr( static_cast<const T *>( graphComponent ), Plug::All & ~Plug::ReadOnly, &serialisation );
+		}
 
 	protected :
 

--- a/src/GafferModule/CompoundNumericPlugBinding.cpp
+++ b/src/GafferModule/CompoundNumericPlugBinding.cpp
@@ -91,27 +91,6 @@ class CompoundNumericPlugSerialiser : public ValuePlugSerialiser
 			return maskedCompoundNumericPlugRepr( static_cast<const T *>( graphComponent ), Plug::All & ~Plug::ReadOnly, &serialisation );
 		}
 
-	protected :
-
-		// Ideally we'll serialise the value as a single getValue() call for this plug,
-		// but we can't do that if any of the children have input connections.
-		bool valueNeedsSerialisation( const Gaffer::ValuePlug *plug, const Serialisation &serialisation ) const override
-		{
-			if( !ValuePlugSerialiser::valueNeedsSerialisation( plug, serialisation ) )
-			{
-				return false;
-			}
-
-			for( PlugIterator it( plug ); !it.done(); ++it )
-			{
-				if( (*it)->getInput() )
-				{
-					return false;
-				}
-			}
-			return true;
-		}
-
 };
 
 template<typename T>


### PR DESCRIPTION
This contains a couple of fixes for nasty serialisation problems that affected a very common usage pattern when creating image networks to be dispatched. Users wanted to build networks that operated on image files which didn't exist at the point of dispatch, for instance to composite images that are generated by a render further up the task tree. They also wanted to create an expression that refers to the format from an ImageReader that loads one of these soon-to-be-generated images. We were trying to evaluate such expressions when saving the script for dispatch, leading to failures because the files don't exist at that point. We now correctly serialise the script without evaluating the expression, and the expression only evaluates during task execution, at which point the files do exist.