### PR TITLE
TabbedContainer : Fix bug with QPalette

### DIFF
--- a/python/GafferUI/TabbedContainer.py
+++ b/python/GafferUI/TabbedContainer.py
@@ -62,7 +62,7 @@ class TabbedContainer( GafferUI.ContainerWidget ) :
 
 		# See comments in Button.py
 		if TabbedContainer.__palette is None :
-			TabbedContainer.__palette = QtGui.QPalette( QtWidgets.QApplication.instance().palette() )
+			TabbedContainer.__palette = QtGui.QPalette( QtWidgets.QApplication.instance().palette( self.__tabBar._qtWidget() ) )
 			TabbedContainer.__palette.setColor( QtGui.QPalette.Disabled, QtGui.QPalette.Light, QtGui.QColor( 0, 0, 0, 0 ) )
 
 		self.__tabBar._qtWidget().setPalette( TabbedContainer.__palette )


### PR DESCRIPTION
I'm not sure if/when this worked, or what its doing really, but adding the argument allows a TabbedContainer to load in Houdini 16.5 using Qt5, and matches the syntax in Button.py, which this code appears to be copied from.