### PR TITLE
PythonCommand : Expose imath module

### DIFF
--- a/python/GafferDispatch/PythonCommand.py
+++ b/python/GafferDispatch/PythonCommand.py
@@ -37,6 +37,7 @@
 import ast
 
 import IECore
+import imath
 
 import Gaffer
 import GafferDispatch
@@ -104,6 +105,7 @@ class PythonCommand( GafferDispatch.TaskNode ) :
 		result = {
 			"IECore" : IECore,
 			"Gaffer" : Gaffer,
+			"imath" : imath,
 			"self" : self,
 			"context" : Gaffer.Context.current(),
 			"variables" : _VariablesDict(

--- a/python/GafferDispatchTest/PythonCommandTest.py
+++ b/python/GafferDispatchTest/PythonCommandTest.py
@@ -307,6 +307,14 @@ class PythonCommandTest( GafferTest.TestCase ) :
 
 		c["task"].execute()
 		self.assertEqual( c.test, 10 )
+	
+	def testImath( self ) :
+		
+		c = Gaffer.PythonCommand()
+		c["command"].setValue( "self.test = imath.V2i( 1, 2 )" )
+
+		c["task"].execute()
+		self.assertEqual( c.test, imath.V2i( 1, 2 ) )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This helps when executing scripts generated prior to our use of PyIlmBase. In c020f4ee908b18c60543cec2b2271a0f72b42da3 we deserialize old scripts and automatically substitute the imath namespace, but we don't auto import imath.