### PR TITLE
Adding attributes that control the motion blur when rendering VDBs in Arnold

### DIFF
--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -120,6 +120,12 @@ def __volumeSummary( plug ) :
 		info.append( "Step %s" % GafferUI.NumericWidget.valueToString( plug["volumeStepSize"]["value"].getValue() ) )
 	if plug["volumePadding"]["enabled"].getValue() :
 		info.append( "Padding %s" % GafferUI.NumericWidget.valueToString( plug["volumePadding"]["value"].getValue() ) )
+	if plug["velocityScale"]["enabled"].getValue() :
+		info.append( "Velocity Scale %s" % GafferUI.NumericWidget.valueToString( plug["velocityScale"]["value"].getValue() ) )
+	if plug["velocityFPS"]["enabled"].getValue() :
+		info.append( "Velocity FPS %s" % GafferUI.NumericWidget.valueToString( plug["velocityFPS"]["value"].getValue() ) )
+	if plug["velocityOutlierThreshold"]["enabled"].getValue() :
+		info.append( "Velocity Outlier Threshold %s" % GafferUI.NumericWidget.valueToString( plug["velocityOutlierThreshold"]["value"].getValue() ) )
 
 	return ", ".join( info )
 
@@ -569,6 +575,45 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Volume",
 			"label", "Padding",
+
+		],
+
+		"attributes.velocityScale" : [
+
+			"description",
+			"""
+			Scales the vector used in VDB motion blur computation.
+			""",
+
+			"layout:section", "Volume",
+			"label", "Velocity Scale",
+
+		],
+
+		"attributes.velocityFPS" : [
+
+			"description",
+			"""
+			Sets the frame rate used in VDB motion blur computation.
+			""",
+
+			"layout:section", "Volume",
+			"label", "Velocity FPS",
+
+		],
+
+		"attributes.velocityOutlierThreshold" : [
+
+			"description",
+			"""
+			Sets the outlier threshold used in VDB motion blur computation.
+
+			When rendering physics simulations resulting velocities are
+			potentially noisy and require some filtering for faster rendering.
+			""",
+
+			"layout:section", "Volume",
+			"label", "Velocity Outlier Threshold",
 
 		],
 

--- a/python/GafferUI/CompoundDataPlugValueWidget.py
+++ b/python/GafferUI/CompoundDataPlugValueWidget.py
@@ -144,6 +144,19 @@ class CompoundDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 		result.append( "/Add/Box3i", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.Box3iData( imath.Box3i( imath.V3i( 0 ), imath.V3i( 1 ) ) ) ) } )
 		result.append( "/Add/Box3f", { "command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", IECore.Box3fData( imath.Box3f( imath.V3f( 0 ), imath.V3f( 1 ) ) ) ) } )
 
+		result.append( "/Add/BoxDivider", { "divider" : True } )
+
+		for label, plugType in [
+			( "Float", Gaffer.FloatVectorDataPlug ),
+			( "Int", Gaffer.IntVectorDataPlug),
+			( "NumericDivider", None ),
+			( "String", Gaffer.StringVectorDataPlug ),
+		] :
+			if plugType is not None :
+				result.append( "/Add/Array/" + label, {"command" : IECore.curry( Gaffer.WeakMethod( self.__addItem ), "", plugType.ValueType() ) } )
+			else :
+				result.append( "/Add/Array/" + label, { "divider" : True } )
+
 		return result
 
 	def __addItem( self, name, value ) :

--- a/src/GafferArnold/ArnoldAttributes.cpp
+++ b/src/GafferArnold/ArnoldAttributes.cpp
@@ -91,6 +91,10 @@ ArnoldAttributes::ArnoldAttributes( const std::string &name )
 	attributes->addOptionalMember( "ai:shape:step_size", new FloatPlug( "value", Plug::In, 0.0f, 0.0f ), "volumeStepSize", false );
 	attributes->addOptionalMember( "ai:shape:volume_padding", new FloatPlug( "value", Plug::In, 0.0f, 0.0f ), "volumePadding", false );
 
+	attributes->addOptionalMember( "ai:volume:velocity_scale", new FloatPlug( "value", Plug::In, 1.0f, 0.0f ), "velocityScale", false );
+	attributes->addOptionalMember( "ai:volume:velocity_fps", new FloatPlug( "value", Plug::In, 24.0f, 0.0f ), "velocityFPS", false );
+	attributes->addOptionalMember( "ai:volume:velocity_outlier_threshold", new FloatPlug( "value", Plug::In, 0.001f, 0.0f ), "velocityOutlierThreshold", false );
+
 }
 
 ArnoldAttributes::~ArnoldAttributes()


### PR DESCRIPTION
I have added:
- velocity_scale
- velocity_fps

There are two more that Arnold provides:
- velocity_grids
- velocity_outlier_threshold

John, do you want me to add them all while I'm at it? For now I've added just the ones that we've deemed useful in an internal project. Not sure if we or someone else will ever need the other two. `velocity_grids` is only useful if you want to store motion vectors in a grid with a different name than the ones Arnold detects by default.

I'm copying descriptions from the [mtoa docs](https://support.solidangle.com/display/A5AFMUG/Volume):

**Velocity Grids**
Either 1 vector grid (eg. v or vel) or 3 float grids (eg. vel.x, vel.y, vel.z) representing the velocity field, to be used for motion blur. No motion blur will occur if an invalid combination of grids or if no grids are specified. Note that all velocity grids declared here are also available as channels in the shading context.

**Velocity Scale**
A scale factor for the velocity field. A value of 0 disables motion blur.

**Velocity FPS**
A scale factor for the velocity field. A value of 0 disables motion blur.

**Velocity Threshold**
Controls filtering of noisy velocities resulting in the faster rendering of motion blur from physics simulations. The default value 0.001 should have little to no visual impact. Setting it to zero disables filtering entirely. 

