### PR TITLE
Auxiliary Connections Round 2

### DIFF
--- a/include/GafferUI/AuxiliaryConnectionsGadget.h
+++ b/include/GafferUI/AuxiliaryConnectionsGadget.h
@@ -1,0 +1,127 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERUI_AUXILIARYCONNECTIONSGADGET_H
+#define GAFFERUI_AUXILIARYCONNECTIONSGADGET_H
+
+#include "GafferUI/Gadget.h"
+
+#include "boost/container/flat_set.hpp"
+
+#include <unordered_map>
+
+namespace Gaffer
+{
+
+class Plug;
+class Node;
+
+} // namespace Gaffer
+
+namespace GafferUI
+{
+
+class GraphGadget;
+class NodeGadget;
+class Nodule;
+
+/// Renders the "auxiliary" connections within a node graph. These
+/// are defined as connections into plugs which don't have a nodule.
+class GAFFERUI_API AuxiliaryConnectionsGadget : public Gadget
+{
+
+	public :
+
+		~AuxiliaryConnectionsGadget();
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::AuxiliaryConnectionsGadget, AuxiliaryConnectionsGadgetTypeId, Gadget );
+
+		bool hasConnection( const NodeGadget *srcNodeGadget, const NodeGadget *dstNodeGadget ) const;
+		bool hasConnection( const Gaffer::Node *srcNode, const Gaffer::Node *dstNode ) const;
+
+		std::pair<NodeGadget *, NodeGadget *> connectionAt( const IECore::LineSegment3f &position );
+		std::pair<const NodeGadget *, const NodeGadget *> connectionAt( const IECore::LineSegment3f &position ) const;
+
+		std::string getToolTip( const IECore::LineSegment3f &position ) const override;
+
+	protected :
+
+		// Constructor is protected because we only want
+		// GraphGadget to be able to construct these, which
+		// we allow by giving it friend access.
+		AuxiliaryConnectionsGadget( GraphGadget *graphGadget );
+
+		friend class GraphGadget;
+
+		void doRenderLayer( Layer layer, const Style *style ) const override;
+
+	private :
+
+		void graphGadgetChildAdded( GraphComponent *child );
+		void graphGadgetChildRemoved( const GraphComponent *child );
+
+		void plugInputChanged( const Gaffer::Plug *plug );
+		void childRemoved( const Gaffer::GraphComponent *node, const Gaffer::GraphComponent *child );
+
+		void noduleAdded( const NodeGadget *nodeGadget, const Nodule *nodule );
+		void noduleRemoved( const NodeGadget *nodeGadget, const Nodule *nodule );
+
+		void dirty( const NodeGadget *nodeGadget );
+
+		void updateConnections() const;
+
+		struct Connections
+		{
+			boost::signals::scoped_connection plugInputChangedConnection;
+			boost::signals::scoped_connection noduleAddedConnection;
+			boost::signals::scoped_connection noduleRemovedConnection;
+			boost::signals::scoped_connection childRemovedConnection;
+			// The set of all NodeGadgets at the source end of the connections.
+			boost::container::flat_set<const NodeGadget *> sourceGadgets;
+			bool dirty = true;
+		};
+
+		GraphGadget *m_graphGadget;
+		// Key is the NodeGadget at the destination end of the connections.
+		typedef std::unordered_map<const NodeGadget *, Connections> NodeGadgetConnections;
+		mutable NodeGadgetConnections m_nodeGadgetConnections;
+		mutable bool m_dirty;
+
+};
+
+} // namespace GafferUI
+
+#endif // GAFFERUI_AUXILIARYCONNECTIONSGADGET_H

--- a/include/GafferUI/AuxiliaryConnectionsGadget.h
+++ b/include/GafferUI/AuxiliaryConnectionsGadget.h
@@ -75,6 +75,7 @@ class GAFFERUI_API AuxiliaryConnectionsGadget : public Gadget
 		std::pair<NodeGadget *, NodeGadget *> connectionAt( const IECore::LineSegment3f &position );
 		std::pair<const NodeGadget *, const NodeGadget *> connectionAt( const IECore::LineSegment3f &position ) const;
 
+		bool acceptsParent( const GraphComponent *potentialParent ) const override;
 		std::string getToolTip( const IECore::LineSegment3f &position ) const override;
 
 	protected :
@@ -82,13 +83,17 @@ class GAFFERUI_API AuxiliaryConnectionsGadget : public Gadget
 		// Constructor is protected because we only want
 		// GraphGadget to be able to construct these, which
 		// we allow by giving it friend access.
-		AuxiliaryConnectionsGadget( GraphGadget *graphGadget );
+		AuxiliaryConnectionsGadget();
 
 		friend class GraphGadget;
 
+		void parentChanging( Gaffer::GraphComponent *newParent ) override;
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 
 	private :
+
+		GraphGadget *graphGadget();
+		const GraphGadget *graphGadget() const;
 
 		void graphGadgetChildAdded( GraphComponent *child );
 		void graphGadgetChildRemoved( const GraphComponent *child );
@@ -114,7 +119,9 @@ class GAFFERUI_API AuxiliaryConnectionsGadget : public Gadget
 			bool dirty = true;
 		};
 
-		GraphGadget *m_graphGadget;
+		boost::signals::scoped_connection m_graphGadgetChildAddedConnection;
+		boost::signals::scoped_connection m_graphGadgetChildRemovedConnection;
+
 		// Key is the NodeGadget at the destination end of the connections.
 		typedef std::unordered_map<const NodeGadget *, Connections> NodeGadgetConnections;
 		mutable NodeGadgetConnections m_nodeGadgetConnections;

--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -57,6 +57,7 @@ IE_CORE_FORWARDDECLARE( NodeGadget );
 IE_CORE_FORWARDDECLARE( Nodule );
 IE_CORE_FORWARDDECLARE( ConnectionGadget );
 IE_CORE_FORWARDDECLARE( GraphLayout );
+IE_CORE_FORWARDDECLARE( AuxiliaryConnectionsGadget );
 
 /// Aliases that define the intended use of each
 /// Gadget::Layer by the GraphGadget components.
@@ -121,10 +122,14 @@ class GAFFERUI_API GraphGadget : public ContainerGadget
 		size_t connectionGadgets( const Gaffer::Node *node, std::vector<ConnectionGadget *> &connections, const Gaffer::Set *excludedNodes = nullptr );
 		size_t connectionGadgets( const Gaffer::Node *node, std::vector<const ConnectionGadget *> &connections, const Gaffer::Set *excludedNodes = nullptr ) const;
 
+		/// Returns the Gadget responsible for representing auxiliary connections.
+		AuxiliaryConnectionsGadget *auxiliaryConnectionsGadget();
+		const AuxiliaryConnectionsGadget *auxiliaryConnectionsGadget() const;
+
 		/// Finds all the upstream NodeGadgets connected to the specified node
 		/// and appends them to the specified vector. Returns the new size of the vector.
 		/// \note Here "upstream" nodes are defined as nodes at the end of input
-		/// connections as shown in the graph - invisible connections and
+		/// connections as shown in the graph - auxiliary connections and
 		/// invisible nodes are not considered at all.
 		size_t upstreamNodeGadgets( const Gaffer::Node *node, std::vector<NodeGadget *> &upstreamNodeGadgets, size_t degreesOfSeparation = Imath::limits<size_t>::max() );
 		size_t upstreamNodeGadgets( const Gaffer::Node *node, std::vector<const NodeGadget *> &upstreamNodeGadgets, size_t degreesOfSeparation = Imath::limits<size_t>::max() ) const;
@@ -132,7 +137,7 @@ class GAFFERUI_API GraphGadget : public ContainerGadget
 		/// Finds all the downstream NodeGadgets connected to the specified node
 		/// and appends them to the specified vector. Returns the new size of the vector.
 		/// \note Here "downstream" nodes are defined as nodes at the end of output
-		/// connections as shown in the graph - invisible connections and
+		/// connections as shown in the graph - auxiliary connections and
 		/// invisible nodes are not considered at all.
 		size_t downstreamNodeGadgets( const Gaffer::Node *node, std::vector<NodeGadget *> &downstreamNodeGadgets, size_t degreesOfSeparation = Imath::limits<size_t>::max() );
 		size_t downstreamNodeGadgets( const Gaffer::Node *node, std::vector<const NodeGadget *> &downstreamNodeGadgets, size_t degreesOfSeparation = Imath::limits<size_t>::max() ) const;
@@ -140,7 +145,7 @@ class GAFFERUI_API GraphGadget : public ContainerGadget
 		/// Finds all the NodeGadgets connected to the specified node
 		/// and appends them to the specified vector. Returns the new size of the vector.
 		/// \note Here "connected" nodes are defined as nodes at the end of
-		/// connections as shown in the graph - invisible connections and
+		/// connections as shown in the graph - auxiliary connections and
 		/// invisible nodes are not considered at all.
 		size_t connectedNodeGadgets( const Gaffer::Node *node, std::vector<NodeGadget *> &connectedNodeGadgets, Gaffer::Plug::Direction direction = Gaffer::Plug::Invalid, size_t degreesOfSeparation = Imath::limits<size_t>::max() );
 		size_t connectedNodeGadgets( const Gaffer::Node *node, std::vector<const NodeGadget *> &connectedNodeGadgets, Gaffer::Plug::Direction direction = Gaffer::Plug::Invalid, size_t degreesOfSeparation = Imath::limits<size_t>::max() ) const;

--- a/include/GafferUI/StandardStyle.h
+++ b/include/GafferUI/StandardStyle.h
@@ -137,6 +137,7 @@ class GAFFERUI_API StandardStyle : public Style
 		static int g_v1Parameter;
 		static int g_t0Parameter;
 		static int g_t1Parameter;
+		static int g_lineWidthParameter;
 
 		Imath::Color3f colorForState( Color c, State s, const Imath::Color3f *userColor = nullptr ) const;
 		boost::array<Imath::Color3f, LastColor> m_colors;

--- a/include/GafferUI/StandardStyle.h
+++ b/include/GafferUI/StandardStyle.h
@@ -90,6 +90,7 @@ class GAFFERUI_API StandardStyle : public Style
 		void renderNodule( float radius, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const override;
 		void renderConnection( const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const override;
 		Imath::V3f closestPointOnConnection( const Imath::V3f &p, const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent ) const override;
+		void renderAuxiliaryConnection( const Imath::Box2f &srcNodeFrame, const Imath::Box2f &dstNodeFrame ) const override;
 
 		void renderBackdrop( const Imath::Box2f &box, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const override;
 
@@ -105,9 +106,9 @@ class GAFFERUI_API StandardStyle : public Style
 			ForegroundColor,
 			HighlightColor,
 			ConnectionColor,
+			AuxiliaryConnectionColor,
 			LastColor
 		};
-
 
 		void setColor( Color c, Imath::Color3f v );
 		const Imath::Color3f &getColor( Color c ) const;

--- a/include/GafferUI/Style.h
+++ b/include/GafferUI/Style.h
@@ -131,6 +131,7 @@ class GAFFERUI_API Style : public IECore::RunTimeTyped
 		/// The tangents give an indication of which direction is "out" from a node.
 		virtual void renderConnection( const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const = 0;
 		virtual Imath::V3f closestPointOnConnection( const Imath::V3f &p, const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent ) const = 0;
+		virtual void renderAuxiliaryConnection( const Imath::Box2f &srcNodeFrame, const Imath::Box2f &dstNodeFrame ) const = 0;
 
 		virtual void renderBackdrop( const Imath::Box2f &box, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const = 0;
 		//@}

--- a/include/GafferUI/TypeIds.h
+++ b/include/GafferUI/TypeIds.h
@@ -47,7 +47,7 @@ enum TypeId
 	NodeGadgetTypeId = 110252,
 	GraphGadgetTypeId = 110253,
 	ContainerGadgetTypeId = 110254,
-	RenderableGadgetTypeId = 110255, // Obsolete - available for reuse
+	AuxiliaryConnectionsGadgetTypeId = 110255,
 	TextGadgetTypeId = 110256,
 	NameGadgetTypeId = 110257,
 	IndividualContainerTypeId = 110258,

--- a/python/GafferUITest/AuxiliaryConnectionsGadgetTest.py
+++ b/python/GafferUITest/AuxiliaryConnectionsGadgetTest.py
@@ -1,0 +1,224 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferUI
+import GafferUITest
+
+class AuxiliaryConnectionsGadgetTest( GafferUITest.TestCase ) :
+
+	def testRemovedNodesDontHaveAuxiliaryConnections( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		n1 = Gaffer.Node()
+		n2 = Gaffer.Node()
+
+		n1["o"] = Gaffer.Plug( direction=Gaffer.Plug.Direction.Out )
+		n2["i"] = Gaffer.Plug()
+
+		Gaffer.Metadata.registerPlugValue( n1["o"], "nodule:type", "" )
+		Gaffer.Metadata.registerPlugValue( n2["i"], "nodule:type", "" )
+
+		n2["i"].setInput( n1["o"] )
+
+		s["n1"] = n1
+		s["n2"] = n2
+
+		g = GafferUI.GraphGadget( s )
+		self.assertTrue( g.auxiliaryConnectionsGadget().hasConnection( n1, n2 ) )
+		self.assertFalse( g.auxiliaryConnectionsGadget().hasConnection( n2, n1 ) )
+
+		with Gaffer.UndoScope( s ) :
+			del s["n1"]
+
+		self.assertFalse( g.auxiliaryConnectionsGadget().hasConnection( n1, n2 ) )
+		self.assertFalse( g.auxiliaryConnectionsGadget().hasConnection( n2, n1 ) )
+
+		s.undo()
+		self.assertTrue( g.auxiliaryConnectionsGadget().hasConnection( n1, n2 ) )
+		self.assertFalse( g.auxiliaryConnectionsGadget().hasConnection( n2, n1 ) )
+
+		del s["n2"]
+		self.assertFalse( g.auxiliaryConnectionsGadget().hasConnection( n1, n2 ) )
+		self.assertFalse( g.auxiliaryConnectionsGadget().hasConnection( n2, n1 ) )
+
+	def testRemovePlugWithAuxiliaryInputConnection( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["n1"] = Gaffer.Node()
+		script["n2"] = Gaffer.Node()
+
+		script["n1"]["o"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
+		script["n2"]["i"] = Gaffer.IntPlug()
+
+		Gaffer.Metadata.registerPlugValue( script["n1"]["o"], "nodule:type", "" )
+		Gaffer.Metadata.registerPlugValue( script["n2"]["i"], "nodule:type", "" )
+
+		script["n2"]["i"].setInput( script["n1"]["o"] )
+
+		g = GafferUI.GraphGadget( script )
+
+		self.assertTrue( g.auxiliaryConnectionsGadget().hasConnection( script["n1"], script["n2"] ) )
+
+		with Gaffer.UndoScope( script ) :
+			del script["n2"]["i"]
+
+		self.assertFalse( g.auxiliaryConnectionsGadget().hasConnection( script["n1"], script["n2"] ) )
+
+		script.undo()
+
+		self.assertTrue( g.auxiliaryConnectionsGadget().hasConnection( script["n1"], script["n2"] ) )
+
+	def testRemovePlugWithAuxiliaryOutputConnection( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["n1"] = Gaffer.Node()
+		script["n2"] = Gaffer.Node()
+
+		script["n1"]["o"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
+		script["n2"]["i"] = Gaffer.IntPlug()
+
+		Gaffer.Metadata.registerPlugValue( script["n1"]["o"], "nodule:type", "" )
+		Gaffer.Metadata.registerPlugValue( script["n2"]["i"], "nodule:type", "" )
+
+		script["n2"]["i"].setInput( script["n1"]["o"] )
+
+		g = GafferUI.GraphGadget( script )
+
+		self.assertTrue( g.auxiliaryConnectionsGadget().hasConnection( script["n1"], script["n2"] ) )
+
+		with Gaffer.UndoScope( script ) :
+			del script["n1"]["o"]
+
+		self.assertFalse( g.auxiliaryConnectionsGadget().hasConnection( script["n1"], script["n2"] ) )
+
+		script.undo()
+
+		self.assertTrue( g.auxiliaryConnectionsGadget().hasConnection( script["n1"], script["n2"] ) )
+
+	def testMovePlugWithAuxiliaryInputConnection( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["n1"] = Gaffer.Node()
+		script["n1"]["p"] = Gaffer.Plug()
+		Gaffer.Metadata.registerPlugValue( script["n1"]["p"], "nodule:type", "" )
+
+		script["n2"] = Gaffer.Node()
+		script["n2"]["p"] = Gaffer.Plug()
+		Gaffer.Metadata.registerPlugValue( script["n2"]["p"], "nodule:type", "" )
+
+		script["n2"]["p"].setInput( script["n1"]["p"] )
+
+		g = GafferUI.GraphGadget( script )
+		acg = g.auxiliaryConnectionsGadget()
+		self.assertTrue( acg.hasConnection( script["n1"], script["n2"] ) )
+
+		script["n3"] = Gaffer.Node()
+		script["n3"]["p"] = script["n2"]["p"]
+
+		self.assertFalse( acg.hasConnection( script["n1"], script["n2"] ) )
+		self.assertTrue( acg.hasConnection( script["n1"], script["n3"] ) )
+
+	def testMovePlugWithAuxiliaryInputConnectionOutsideGraph( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["n1"] = Gaffer.Node()
+		script["n1"]["p"] = Gaffer.Plug()
+		Gaffer.Metadata.registerPlugValue( script["n1"]["p"], "nodule:type", "" )
+
+		script["n2"] = Gaffer.Node()
+		script["n2"]["p"] = Gaffer.Plug()
+		script["n2"]["p"].setInput( script["n1"]["p"] )
+		Gaffer.Metadata.registerPlugValue( script["n2"]["p"], "nodule:type", "" )
+
+		g = GafferUI.GraphGadget( script )
+		self.assertTrue( g.auxiliaryConnectionsGadget().hasConnection( script["n1"], script["n2"] ) )
+
+		n3 = Gaffer.Node()
+		n3["p"] = script["n2"]["p"]
+
+		self.assertFalse( g.auxiliaryConnectionsGadget().hasConnection( script["n1"], script["n2"] ) )
+
+	def testAddNoduleToPlugsWithAuxiliaryConnection( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["n1"] = Gaffer.Node()
+		script["n1"]["p"] = Gaffer.Plug()
+		Gaffer.Metadata.registerPlugValue( script["n1"]["p"], "nodule:type", "" )
+
+		script["n2"] = Gaffer.Node()
+		script["n2"]["p"] = Gaffer.Plug()
+		Gaffer.Metadata.registerPlugValue( script["n2"]["p"], "nodule:type", "" )
+
+		script["n2"]["p"].setInput( script["n1"]["p"] )
+
+		g = GafferUI.GraphGadget( script )
+		acg = g.auxiliaryConnectionsGadget()
+
+		self.assertTrue( acg.hasConnection( script["n1"], script["n2"] ) )
+
+		Gaffer.Metadata.registerPlugValue( script["n1"]["p"], "nodule:type", "GafferUI::StandardNodule" )
+
+		self.assertTrue( acg.hasConnection( script["n1"], script["n2"] ) )
+
+		Gaffer.Metadata.registerPlugValue( script["n2"]["p"], "nodule:type", "GafferUI::StandardNodule" )
+
+		self.assertFalse( acg.hasConnection( script["n1"], script["n2"] ) )
+
+	def testIgnoreConnectionsFromSelf( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["n"] = Gaffer.Node()
+		script["n"]["p1"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		script["n"]["p2"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		script["n"]["p2"].setInput( script["n"]["p1"] )
+
+		g = GafferUI.GraphGadget( script )
+		self.assertFalse( g.auxiliaryConnectionsGadget().hasConnection( script["n"], script["n"] ) )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -91,6 +91,7 @@ from PlaybackTest import PlaybackTest
 from SpacerGadgetTest import SpacerGadgetTest
 from BoxUITest import BoxUITest
 from ConnectionGadgetTest import ConnectionGadgetTest
+from AuxiliaryConnectionsGadgetTest import AuxiliaryConnectionsGadgetTest
 from MessageWidgetTest import MessageWidgetTest
 from ModuleTest import ModuleTest
 from PlugLayoutTest import PlugLayoutTest

--- a/src/GafferUI/AuxiliaryConnectionsGadget.cpp
+++ b/src/GafferUI/AuxiliaryConnectionsGadget.cpp
@@ -1,0 +1,345 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferUI/AuxiliaryConnectionsGadget.h"
+
+#include "GafferUI/GraphGadget.h"
+#include "GafferUI/NodeGadget.h"
+#include "GafferUI/Style.h"
+#include "GafferUI/ViewportGadget.h"
+
+#include "IECoreGL/Selector.h"
+
+#include "boost/bind.hpp"
+#include "boost/bind/placeholders.hpp"
+
+using namespace GafferUI;
+using namespace Gaffer;
+using namespace IECore;
+using namespace Imath;
+using namespace std;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+template<typename Visitor>
+void visitAuxiliaryConnections( const GraphGadget *graphGadget, const NodeGadget *dstNodeGadget, Visitor visitor )
+{
+	const Gaffer::Node *dstNode = dstNodeGadget->node();
+	for( Gaffer::RecursivePlugIterator it( dstNode ); !it.done(); ++it )
+	{
+		const Gaffer::Plug *dstPlug = it->get();
+		const Gaffer::Plug *srcPlug = dstPlug->getInput();
+		if( !srcPlug )
+		{
+			continue;
+		}
+
+		it.prune();
+		if( srcPlug->node() == dstNode )
+		{
+			continue;
+		}
+
+		const NodeGadget *srcNodeGadget = graphGadget->nodeGadget( srcPlug->node() );
+		if( !srcNodeGadget )
+		{
+			continue;
+		}
+		if( dstNodeGadget->nodule( dstPlug ) )
+		{
+			continue;
+		}
+
+		visitor( srcPlug, dstPlug, srcNodeGadget, dstNodeGadget );
+	}
+}
+
+Box2f nodeFrame( const NodeGadget *nodeGadget )
+{
+	const Box3f b = nodeGadget->transformedBound();
+	return Box2f(
+		V2f( b.min.x, b.min.y ),
+		V2f( b.max.x, b.max.y )
+	);
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// AuxiliaryConnectionsGadget
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( AuxiliaryConnectionsGadget );
+
+AuxiliaryConnectionsGadget::AuxiliaryConnectionsGadget( GraphGadget *graphGadget )
+	:	Gadget( "AuxiliaryConnections" ), m_graphGadget( graphGadget ), m_dirty( false )
+{
+	m_graphGadget->childAddedSignal().connect( boost::bind( &AuxiliaryConnectionsGadget::graphGadgetChildAdded, this, ::_2 ) );
+	m_graphGadget->childRemovedSignal().connect( boost::bind( &AuxiliaryConnectionsGadget::graphGadgetChildRemoved, this, ::_2 ) );
+}
+
+AuxiliaryConnectionsGadget::~AuxiliaryConnectionsGadget()
+{
+}
+
+bool AuxiliaryConnectionsGadget::hasConnection( const NodeGadget *srcNodeGadget, const NodeGadget *dstNodeGadget ) const
+{
+	updateConnections();
+	auto it = m_nodeGadgetConnections.find( dstNodeGadget );
+	return it != m_nodeGadgetConnections.end() && it->second.sourceGadgets.count( srcNodeGadget );
+}
+
+bool AuxiliaryConnectionsGadget::hasConnection( const Gaffer::Node *srcNode, const Gaffer::Node *dstNode ) const
+{
+	const NodeGadget *srcNodeGadget = m_graphGadget->nodeGadget( srcNode );
+	const NodeGadget *dstNodeGadget = m_graphGadget->nodeGadget( dstNode );
+	if( !srcNodeGadget || !dstNodeGadget )
+	{
+		return false;
+	}
+	return hasConnection( srcNodeGadget, dstNodeGadget );
+}
+
+std::pair<NodeGadget *, NodeGadget *> AuxiliaryConnectionsGadget::connectionAt( const IECore::LineSegment3f &position )
+{
+	std::pair<const NodeGadget *, const NodeGadget *> c = const_cast<const AuxiliaryConnectionsGadget *>( this )->connectionAt( position );
+	return { const_cast<NodeGadget *>( c.first ), const_cast<NodeGadget *>( c.second ) };
+}
+
+std::pair<const NodeGadget *, const NodeGadget *> AuxiliaryConnectionsGadget::connectionAt( const IECore::LineSegment3f &position ) const
+{
+	updateConnections();
+
+	vector<IECoreGL::HitRecord> selection;
+	vector<pair<const NodeGadget *, const NodeGadget *>> connections;
+
+	{
+		ViewportGadget::SelectionScope selectionScope( position, this, selection, IECoreGL::Selector::IDRender );
+		IECoreGL::Selector *selector = IECoreGL::Selector::currentSelector();
+		const Style *style = this->style();
+		style->bind();
+		GLuint name = 1; // Name 0 is invalid, so we start at 1
+		for( auto &x : m_nodeGadgetConnections )
+		{
+			const NodeGadget *dstNodeGadget = x.first;
+			const Box2f dstFrame = nodeFrame( dstNodeGadget );
+			for( auto &srcNodeGadget : x.second.sourceGadgets )
+			{
+				connections.push_back( { srcNodeGadget, dstNodeGadget } );
+				selector->loadName( name++ );
+				style->renderAuxiliaryConnection( nodeFrame( srcNodeGadget ), dstFrame );
+			}
+		}
+	}
+
+	if( !selection.size() )
+	{
+		return { nullptr, nullptr };
+	}
+
+	return connections[selection[0].name-1];
+}
+
+std::string AuxiliaryConnectionsGadget::getToolTip( const IECore::LineSegment3f &position ) const
+{
+	string s = Gadget::getToolTip( position );
+	if( !s.empty() )
+	{
+		return s;
+	}
+
+	pair<const NodeGadget *, const NodeGadget *> connection = connectionAt( position );
+	if( !connection.first )
+	{
+		return "";
+	}
+
+	s += "Auxiliary connections from " + connection.first->node()->getName().string() + " to " + connection.second->node()->getName().string() + " : \n\n";
+	visitAuxiliaryConnections(
+		m_graphGadget, connection.second,
+		[ &s, &connection ] ( const Plug *srcPlug, const Plug *dstPlug, const NodeGadget *srcNodeGadget, const NodeGadget *dstNodeGadget )
+		{
+			if( srcNodeGadget == connection.first )
+			{
+				s +=
+					"\t" +
+					srcPlug->relativeName( srcNodeGadget->node() ) +
+					" -> " +
+					dstPlug->relativeName( dstNodeGadget->node() ) +
+					"\n"
+				;
+			}
+		}
+	);
+
+	return s;
+}
+
+void AuxiliaryConnectionsGadget::doRenderLayer( Layer layer, const Style *style ) const
+{
+	if( layer != GraphLayer::Connections )
+	{
+		return;
+	}
+
+	updateConnections();
+	for( auto &x : m_nodeGadgetConnections )
+	{
+		const Box2f dstFrame = nodeFrame( x.first );
+		for( auto &srcNodeGadget : x.second.sourceGadgets )
+		{
+			style->renderAuxiliaryConnection( nodeFrame( srcNodeGadget ), dstFrame );
+		}
+	}
+}
+
+void AuxiliaryConnectionsGadget::graphGadgetChildAdded( GraphComponent *child )
+{
+	if( NodeGadget *nodeGadget = runTimeCast<NodeGadget>( child ) )
+	{
+		Connections &connections = m_nodeGadgetConnections[nodeGadget];
+
+		connections.plugInputChangedConnection = nodeGadget->node()->plugInputChangedSignal().connect(
+			boost::bind( &AuxiliaryConnectionsGadget::plugInputChanged, this, ::_1 )
+		);
+		connections.noduleAddedConnection = nodeGadget->noduleAddedSignal().connect(
+			boost::bind( &AuxiliaryConnectionsGadget::noduleAdded, this, ::_1, ::_2 )
+		);
+		connections.noduleRemovedConnection = nodeGadget->noduleRemovedSignal().connect(
+			boost::bind( &AuxiliaryConnectionsGadget::noduleRemoved, this, ::_1, ::_2 )
+		);
+		connections.childRemovedConnection = nodeGadget->node()->childRemovedSignal().connect(
+			boost::bind( &AuxiliaryConnectionsGadget::childRemoved, this, ::_1, ::_2 )
+		);
+
+		connections.dirty = true;
+		m_dirty = true;
+	}
+}
+
+void AuxiliaryConnectionsGadget::graphGadgetChildRemoved( const GraphComponent *child )
+{
+	if( const NodeGadget *nodeGadget = runTimeCast<const NodeGadget>( child ) )
+	{
+		m_nodeGadgetConnections.erase( nodeGadget );
+	}
+}
+
+void AuxiliaryConnectionsGadget::plugInputChanged( const Gaffer::Plug *plug )
+{
+	if( const NodeGadget *nodeGadget = m_graphGadget->nodeGadget( plug->node() ) )
+	{
+		dirty( nodeGadget );
+	}
+}
+
+void AuxiliaryConnectionsGadget::childRemoved( const Gaffer::GraphComponent *node, const Gaffer::GraphComponent *child )
+{
+	if( !runTimeCast<const Plug>( child ) )
+	{
+		return;
+	}
+	if( const NodeGadget *nodeGadget = m_graphGadget->nodeGadget( static_cast<const Node *>( node ) ) )
+	{
+		dirty( nodeGadget );
+	}
+}
+
+void AuxiliaryConnectionsGadget::noduleAdded( const NodeGadget *nodeGadget, const Nodule *nodule )
+{
+	dirty( nodeGadget );
+}
+
+void AuxiliaryConnectionsGadget::noduleRemoved( const NodeGadget *nodeGadget, const Nodule *nodule )
+{
+	dirty( nodeGadget );
+}
+
+void AuxiliaryConnectionsGadget::dirty( const NodeGadget *nodeGadget )
+{
+	auto it = m_nodeGadgetConnections.find( nodeGadget );
+	// We only connect to signals for NodeGadgets we're tracking,
+	// so we have a logic error somewhere if we don't already have
+	// an entry for this particular node gadget.
+	assert( it != m_nodeGadgetConnections.end() );
+	if( it->second.dirty )
+	{
+		return;
+	}
+	it->second.dirty = true;
+	if( m_dirty )
+	{
+		return;
+	}
+	m_dirty = true;
+	requestRender();
+}
+
+void AuxiliaryConnectionsGadget::updateConnections() const
+{
+	if( !m_dirty )
+	{
+		return;
+	}
+
+	for( auto &x : m_nodeGadgetConnections )
+	{
+		Connections &connections = x.second;
+		if( !connections.dirty )
+		{
+			continue;
+		}
+
+		connections.sourceGadgets.clear();
+		visitAuxiliaryConnections(
+			m_graphGadget, x.first,
+			[&connections] ( const Plug *srcPlug, const Plug *dstPlug, const NodeGadget *srcNodeGadget, const NodeGadget *dstNodeGadget )
+			{
+				connections.sourceGadgets.insert( srcNodeGadget );
+			}
+		);
+
+		connections.dirty = false;
+	}
+
+	m_dirty = false;
+}
+

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -134,7 +134,7 @@ GraphGadget::GraphGadget( Gaffer::NodePtr root, Gaffer::SetPtr filter )
 
 	m_layout = new StandardGraphLayout;
 
-	setChild( g_auxiliaryConnectionsGadgetName, new AuxiliaryConnectionsGadget( this ) );
+	setChild( g_auxiliaryConnectionsGadgetName, new AuxiliaryConnectionsGadget() );
 
 	setRoot( root, filter );
 }

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -37,6 +37,7 @@
 
 #include "GafferUI/GraphGadget.h"
 
+#include "GafferUI/AuxiliaryConnectionsGadget.h"
 #include "GafferUI/BackdropNodeGadget.h"
 #include "GafferUI/ButtonEvent.h"
 #include "GafferUI/ConnectionGadget.h"
@@ -99,6 +100,7 @@ const InternedString g_positionPlugName( "__uiPosition" );
 const InternedString g_inputConnectionsMinimisedPlugName( "__uiInputConnectionsMinimised" );
 const InternedString g_outputConnectionsMinimisedPlugName( "__uiOutputConnectionsMinimised" );
 const InternedString g_nodeGadgetTypeName( "nodeGadget:type" );
+const InternedString g_auxiliaryConnectionsGadgetName( "__auxiliaryConnections" );
 
 struct CompareV2fX{
 	bool operator()(const Imath::V2f &a, const Imath::V2f &b) const
@@ -132,11 +134,14 @@ GraphGadget::GraphGadget( Gaffer::NodePtr root, Gaffer::SetPtr filter )
 
 	m_layout = new StandardGraphLayout;
 
+	setChild( g_auxiliaryConnectionsGadgetName, new AuxiliaryConnectionsGadget( this ) );
+
 	setRoot( root, filter );
 }
 
 GraphGadget::~GraphGadget()
 {
+	removeChild( auxiliaryConnectionsGadget() );
 }
 
 Gaffer::Node *GraphGadget::getRoot()
@@ -324,6 +329,16 @@ size_t GraphGadget::connectionGadgets( const Gaffer::Node *node, std::vector<con
 	}
 
 	return connections.size();
+}
+
+AuxiliaryConnectionsGadget *GraphGadget::auxiliaryConnectionsGadget()
+{
+	return getChild<AuxiliaryConnectionsGadget>( g_auxiliaryConnectionsGadgetName );
+}
+
+const AuxiliaryConnectionsGadget *GraphGadget::auxiliaryConnectionsGadget() const
+{
+	return getChild<AuxiliaryConnectionsGadget>( g_auxiliaryConnectionsGadgetName );
 }
 
 size_t GraphGadget::upstreamNodeGadgets( const Gaffer::Node *node, std::vector<NodeGadget *> &upstreamNodeGadgets, size_t degreesOfSeparation )

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -639,6 +639,7 @@ void StandardStyle::renderConnection( const Imath::V3f &srcPosition, const Imath
 	glUniform1i( g_borderParameter, 0 );
 	glUniform1i( g_edgeAntiAliasingParameter, 1 );
 	glUniform1i( g_textureTypeParameter, 0 );
+	glUniform1f( g_lineWidthParameter, 0.5 );
 
 	glColor( colorForState( ConnectionColor, state, userColor ) );
 
@@ -661,7 +662,7 @@ Imath::V3f StandardStyle::closestPointOnConnection( const Imath::V3f &p, const I
 
 	V3f offsetCenter0 = srcPosition + ( srcTangent != V3f( 0 ) ? srcTangent :  dir ) * g_endPointSize;
 	V3f offsetCenter1 = dstPosition + ( dstTangent != V3f( 0 ) ? dstTangent :  -dir ) * g_endPointSize;
-	
+
 	float straightSegmentLength = ( offsetCenter0 - offsetCenter1 ).length();
 
 	if( straightSegmentLength < 2.0f * g_endPointSize )
@@ -678,9 +679,9 @@ Imath::V3f StandardStyle::closestPointOnConnection( const Imath::V3f &p, const I
 		V3f straightSegmentDir = ( offsetCenter0 - offsetCenter1 ).normalized();
 
 		float alongSegment = ( p - straightSegmentCenter ).dot( straightSegmentDir );
-		float clampDist = straightSegmentLength * 0.5f - g_endPointSize; 
+		float clampDist = straightSegmentLength * 0.5f - g_endPointSize;
 		alongSegment = std::max( -clampDist, std::min( clampDist, alongSegment ) );
-		
+
 		return straightSegmentCenter + alongSegment * straightSegmentDir;
 	}
 
@@ -855,6 +856,7 @@ void StandardStyle::renderLine( const IECore::LineSegment3f &line ) const
 	glUniform1i( g_borderParameter, 0 );
 	glUniform1i( g_edgeAntiAliasingParameter, 1 );
 	glUniform1i( g_textureTypeParameter, 0 );
+	glUniform1f( g_lineWidthParameter, 0.5 );
 
 	glColor( getColor( BackgroundColor ) );
 
@@ -977,6 +979,7 @@ static const std::string &vertexSource()
 		"uniform vec3 t0;"
 		"uniform vec3 t1;"
 		"uniform float endPointSize;"
+		"uniform float lineWidth;"
 
 		"void main()"
 		"{"
@@ -1015,7 +1018,7 @@ static const std::string &vertexSource()
 		"		vec3 p = abs(cosAngle) > 0.9999 ? endPoint + 2.0 * t * effectiveEndPointSize * endTangent : endPoint + radius * ( ( 1.0 - cos( angle * t ) ) * bendDir * endTangentPerp + sin( angle * t ) * endTangent );"
 		"		vec3 uTangent = ( gl_MultiTexCoord0.y > 0.5 ? 1.0 : -1.0 ) * ( abs(cosAngle) > 0.9999 ? -endTangentPerp : bendDir * normalize( p - ( endPoint + radius * bendDir * endTangentPerp) ) );"
 
-		"		p += 0.5 * uTangent * ( gl_MultiTexCoord0.x - 0.5 );"
+		"		p += lineWidth * uTangent * ( gl_MultiTexCoord0.x - 0.5 );"
 
 		"		gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * vec4( p, 1 );"
 		"	}"
@@ -1125,6 +1128,7 @@ int StandardStyle::g_v0Parameter;
 int StandardStyle::g_v1Parameter;
 int StandardStyle::g_t0Parameter;
 int StandardStyle::g_t1Parameter;
+int StandardStyle::g_lineWidthParameter;
 
 IECoreGL::Shader *StandardStyle::shader()
 {
@@ -1146,6 +1150,7 @@ IECoreGL::Shader *StandardStyle::shader()
 		g_v1Parameter = g_shader->uniformParameter( "v1" )->location;
 		g_t0Parameter = g_shader->uniformParameter( "t0" )->location;
 		g_t1Parameter = g_shader->uniformParameter( "t1" )->location;
+		g_lineWidthParameter = g_shader->uniformParameter( "lineWidth" )->location;
 	}
 
 	return g_shader.get();

--- a/src/GafferUIModule/GraphGadgetBinding.cpp
+++ b/src/GafferUIModule/GraphGadgetBinding.cpp
@@ -41,6 +41,7 @@
 
 #include "GafferUIBindings/GadgetBinding.h"
 
+#include "GafferUI/AuxiliaryConnectionsGadget.h"
 #include "GafferUI/ConnectionGadget.h"
 #include "GafferUI/GraphGadget.h"
 #include "GafferUI/GraphLayout.h"
@@ -53,6 +54,7 @@
 
 using namespace boost::python;
 using namespace IECorePython;
+using namespace Gaffer;
 using namespace GafferUI;
 using namespace GafferUIBindings;
 
@@ -158,6 +160,12 @@ list unpositionedNodeGadgets( GraphGadget &graphGadget )
 	return l;
 }
 
+tuple connectionAt( AuxiliaryConnectionsGadget &g, IECore::LineSegment3f position )
+{
+	auto nodeGadgets = g.connectionAt( position );
+	return make_tuple( nodeGadgets.first, nodeGadgets.second );
+}
+
 } // namespace
 
 void GafferUIModule::bindGraphGadget()
@@ -174,6 +182,7 @@ void GafferUIModule::bindGraphGadget()
 			.def( "connectionGadget", (ConnectionGadget *(GraphGadget::*)( const Gaffer::Plug * ))&GraphGadget::connectionGadget, return_value_policy<CastToIntrusivePtr>() )
 			.def( "connectionGadgets", &connectionGadgets1, ( arg_( "plug" ), arg_( "excludedNodes" ) = object() ) )
 			.def( "connectionGadgets", &connectionGadgets2, ( arg_( "node" ), arg_( "excludedNodes" ) = object() ) )
+			.def( "auxiliaryConnectionsGadget", (AuxiliaryConnectionsGadget *(GraphGadget::*)())&GraphGadget::auxiliaryConnectionsGadget, return_value_policy<CastToIntrusivePtr>() )
 			.def( "upstreamNodeGadgets", &upstreamNodeGadgets, ( arg( "node" ), arg( "degreesOfSeparation" ) = Imath::limits<size_t>::max() ) )
 			.def( "downstreamNodeGadgets", &downstreamNodeGadgets, ( arg( "node" ), arg( "degreesOfSeparation" ) = Imath::limits<size_t>::max() ) )
 			.def( "connectedNodeGadgets", &connectedNodeGadgets, ( arg( "node" ), arg( "direction" ) = Gaffer::Plug::Invalid, arg( "degreesOfSeparation" ) = Imath::limits<size_t>::max() ) )
@@ -193,6 +202,12 @@ void GafferUIModule::bindGraphGadget()
 
 		GafferBindings::SignalClass<GraphGadget::RootChangedSignal, GafferBindings::DefaultSignalCaller<GraphGadget::RootChangedSignal>, RootChangedSlotCaller>( "RootChangedSignal" );
 	}
+
+	GadgetClass<AuxiliaryConnectionsGadget>()
+		.def( "hasConnection", (bool (AuxiliaryConnectionsGadget::*)( const NodeGadget *, const NodeGadget * ) const)&AuxiliaryConnectionsGadget::hasConnection )
+		.def( "hasConnection", (bool (AuxiliaryConnectionsGadget::*)( const Node *, const Node * ) const)&AuxiliaryConnectionsGadget::hasConnection )
+		.def( "connectionAt", &connectionAt )
+	;
 
 	IECorePython::RunTimeTypedClass<GraphLayout>()
 		.def( "connectNode", &GraphLayout::connectNode )


### PR DESCRIPTION
Hi @mattigruener, here's my stab at refactoring the auxiliary connections along the lines we discussed. On the whole I think this approach is a definite improvement - it has resulted in significantly less code than before, with less indirection, and with all the responsibility for the connections in a single place.

I've totally removed the individual AuxiliaryConnectionGadgets, moving all the rendering into a single AuxiliaryConnectionsGadget. This [generates dynamic tooltips](https://github.com/GafferHQ/gaffer/commit/9f5a0fe30d892b27b9a1cad232c2e6bfde456eab#diff-51f9a60021f2e73ed0d082c8e2e752dfR181) based on the position of the mouse pointer. I also decoupled the AuxiliaryConnectionsGadget from the GraphGadget, so that it does all its own signal handling. This does mean a little more overhead, but it also makes it easier to understand and verify the behaviour - all the relevant code for auxiliary connections is now in one file/class.

I also made the change we discussed whereby the Style is totally responsible for the drawing of the connection, and is passed the bounds of the NodeGadgets rather than the location of a direction indicator. While I was doing that I took a stab at a simpler direction indicator that avoids some of the extra complication in the StandardStyle class. While I think everything else in this PR is a definite improvement, this one might be more a matter of taste.

The tests are pretty much as they were before, except moved out in AuxiliaryConnectionsGadgetTest. I also fixed the bug I'd mentioned in my previous review.

Let us know what you think...
Cheers...
John 


