### PR TITLE
Travis : Add GCC 6 with C++14 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ addons:
         - doxygen
         - gcc-4.8
         - g++-4.8
-        - gcc-5
-        - g++-5
+        - gcc-6
+        - g++-6
 
 cache:
     directories:
@@ -89,6 +89,6 @@ matrix:
         - os: linux
           env: COMPILER=g++-4.8 CXXSTD=c++11 DEBUG=1
         - os: linux
-          env: COMPILER=g++-5 CXXSTD=c++11 DEBUG=0
+          env: COMPILER=g++-6 CXXSTD=c++14 DEBUG=0
         - os: osx
           env: COMPILER=clang++ CXXSTD=c++11 DEBUG=0


### PR DESCRIPTION
This is the build setup stipulated by VFXPlatform 2018. Removed the GCC 5 build since it doesn't correspond to any VFXPlatform setup, and we don't want to be too much of a burden on Travis, since it is a wonderful service provided for free and all.