### PR TITLE
GafferArnold/ParameterHandler : support 'out' plugs of additional types

### DIFF
--- a/src/GafferArnold/ParameterHandler.cpp
+++ b/src/GafferArnold/ParameterHandler.cpp
@@ -274,6 +274,10 @@ Gaffer::Plug *ParameterHandler::setupPlug( const IECore::InternedString &paramet
 
 			return setupClosurePlug( parameterName, plugParent, direction );
 
+		case AI_TYPE_STRING :
+
+			return setupTypedPlug<StringPlug>( parameterName, plugParent, direction, "" );
+
 		default :
 
 			msg(

--- a/src/GafferArnold/ParameterHandler.cpp
+++ b/src/GafferArnold/ParameterHandler.cpp
@@ -278,6 +278,10 @@ Gaffer::Plug *ParameterHandler::setupPlug( const IECore::InternedString &paramet
 
 			return setupTypedPlug<StringPlug>( parameterName, plugParent, direction, "" );
 
+		case AI_TYPE_BOOLEAN :
+
+			return setupTypedPlug<BoolPlug>( parameterName, plugParent, direction, false );
+
 		default :
 
 			msg(


### PR DESCRIPTION
Done so that the Arnold shader "user_data_string" can be represented properly. Shader description as per `kick -info` below. Was there a reason the StringPlug was missing before? I've seen that it was added in the other `ParameterHandler::setupPlug()`.

Cheerio! :)

Matti.


```
node:         user_data_string
type:         shader
output:       STRING
parameters:   3
filename:     <built-in>
version:      5.0.2.0

Type          Name                              Default
------------  --------------------------------  --------------------------------
STRING        attribute                         
STRING        default                           
STRING        name  
```