### PR TITLE
OSL ShadingEngine : make global "time" available

### DIFF
--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -34,8 +34,9 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GafferOSL/ShadingEngine.h"
+#include "Gaffer/Context.h"
 
+#include "GafferOSL/ShadingEngine.h"
 #include "GafferOSL/OSLShader.h"
 
 #include "IECoreScene/Shader.h"
@@ -1082,6 +1083,9 @@ IECore::CompoundDataPtr ShadingEngine::shade( const IECore::CompoundData *points
 
 	shaderGlobals.dPdu = uniformValue<V3f>( points, "dPdu" );
 	shaderGlobals.dPdv = uniformValue<V3f>( points, "dPdv" );
+
+	const Gaffer::Context *context = Gaffer::Context::current();
+	shaderGlobals.time = context->getTime();
 
 	// Add a RenderState to the ShaderGlobals. This will
 	// get passed to our RendererServices queries.


### PR DESCRIPTION
How is this, John? 

Don mentioned that it would be nice to have all context variables available, but maybe that's for another day? :)