### PR TITLE
BoxIO : Fix promotion of ArrayPlugs

### DIFF
--- a/python/GafferTest/BoxInTest.py
+++ b/python/GafferTest/BoxInTest.py
@@ -406,5 +406,24 @@ class BoxInTest( GafferTest.TestCase ) :
 
 		self.assertTrue( s2["b"]["i"]["out"].source().isSame( s2["a"]["sum"] ) )
 
+	def testArrayPlugSerialisation( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = GafferTest.ArrayPlugNode()
+
+		s["b"]["i"] = Gaffer.BoxIn()
+		s["b"]["i"]["name"].setValue( "in" )
+		s["b"]["i"].setup( s["b"]["n"]["in"] )
+		s["b"]["n"]["in"].setInput( s["b"]["i"]["out"] )
+
+		print s.serialise()
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertTrue( s2["b"]["n"]["in"].source().isSame( s2["b"]["in"] ) )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Really I want to take the "abolish the Dynamic flag" approach noted in the comments, but for expedience I've gone with the same fix we use in PlugAlgo for now. I've avoided exposing the PlugAlgo version of `applyDynamicFlag()` so it could be shared, just to avoid having more public API associated with the thing I want to abolish.