### PR TITLE
Selection improvements

### DIFF
--- a/python/GafferCortexUI/FileIndexedIOPathPreview.py
+++ b/python/GafferCortexUI/FileIndexedIOPathPreview.py
@@ -103,7 +103,7 @@ class FileIndexedIOPathPreview( GafferUI.DeferredPathPreview ) :
 		with Gaffer.BlockedConnection( self.__pathListingSelectionChangedConnection ) :
 			## \todo This functionality might be nice in the PathChooserWidget. We could
 			# maybe even use a PathChooserWidget here anyway.
-			self.__pathListing.setSelectedPaths( [ pathCopy ], expandNonLeaf=False )
+			self.__pathListing.setSelection( IECore.PathMatcher( [ str( pathCopy ) ] ), expandNonLeaf=False )
 			# expand as people type forwards
 			if len( pathCopy ) > len( self.__prevPath ) :
 				self.__pathListing.setPathExpanded( pathCopy, True )
@@ -117,9 +117,9 @@ class FileIndexedIOPathPreview( GafferUI.DeferredPathPreview ) :
 
 	def __pathListingSelectionChanged( self, pathListing ) :
 
-		selection = pathListing.getSelectedPaths()
-		if len( selection ) :
+		selection = pathListing.getSelection()
+		if not selection.isEmpty() :
 			with Gaffer.BlockedConnection( self.__indexedIOPathChangedConnection ) :
-				self.__indexedIOPath[:] = selection[0][:]
+				self.__indexedIOPath.setFromString( selection.paths()[0] )
 
 GafferUI.PathPreviewWidget.registerType( "Indexed IO", FileIndexedIOPathPreview )

--- a/python/GafferCortexUI/OpBrowserMode.py
+++ b/python/GafferCortexUI/OpBrowserMode.py
@@ -78,11 +78,11 @@ class OpMode( GafferUI.BrowserEditor.Mode ) :
 
 	def __pathSelected( self, pathListing ) :
 
-		selectedPaths = pathListing.getSelectedPaths()
-		if not len( selectedPaths ) :
+		selection = pathListing.getSelection()
+		if selection.isEmpty() :
 			return
 
-		op = selectedPaths[0].classLoader().load( str( selectedPaths[0] )[1:] )()
+		op = self.__classLoader().load( str( selection.paths()[0] )[1:] )()
 		node = GafferCortex.ParameterisedHolderNode()
 		node.setParameterised( op )
 		GafferCortexUI.ParameterPresets.autoLoad( node )

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -277,12 +277,12 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 		with self.getContext() :
 			index = self.getPlug().getValue()
 
-		imagePaths = self.__pathListing.getPath().children()
-		if imagePaths :
-			index = index % len( imagePaths )
-			self.__pathListing.setSelectedPaths( imagePaths[index] )
-			self.__descriptionWidget.setPlug( self.__images()[index]["description"] )
-			self.__nameWidget.setGraphComponent( self.__images()[index] )
+		images = self.__images()
+		if len( images ) :
+			image = images[index % len( images )]
+			self.__pathListing.setSelection( IECore.PathMatcher( [ "/" + image.getName() ] ) )
+			self.__descriptionWidget.setPlug( image["description"] )
+			self.__nameWidget.setGraphComponent( image )
 		else :
 			self.__descriptionWidget.setPlug( None )
 			self.__nameWidget.setGraphComponent( None )
@@ -311,12 +311,9 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 
 	def __indexFromSelection( self ) :
 
-		paths = self.__pathListing.getSelectedPaths()
-		if len( paths ) != 1 :
-			return None
-
+		selection = self.__pathListing.getSelection()
 		for i, image in enumerate( self.__images() ) :
-			if image.getName() == paths[0][-1] :
+			if selection.match( "/" + image.getName() ) & selection.Result.ExactMatch :
 				return i
 
 		return None

--- a/python/GafferSceneUI/SceneHierarchy.py
+++ b/python/GafferSceneUI/SceneHierarchy.py
@@ -162,19 +162,15 @@ class SceneHierarchy( GafferUI.NodeSetEditor ) :
 
 		assert( pathListing is self.__pathListing )
 
-		paths = pathListing.getExpandedPaths()
-		paths = IECore.PathMatcher( [ "/" ] + [ str( path ) for path in paths ] )
 		with Gaffer.BlockedConnection( self._contextChangedConnection() ) :
-			ContextAlgo.setExpandedPaths( self.getContext(), paths )
+			ContextAlgo.setExpandedPaths( self.getContext(), pathListing.getExpansion() )
 
 	def __selectionChanged( self, pathListing ) :
 
 		assert( pathListing is self.__pathListing )
 
-		paths = pathListing.getSelectedPaths()
-		paths = IECore.PathMatcher( [ str(p) for p in paths ] )
 		with Gaffer.BlockedConnection( self._contextChangedConnection() ) :
-			ContextAlgo.setSelectedPaths( self.getContext(), paths )
+			ContextAlgo.setSelectedPaths( self.getContext(), pathListing.getSelection() )
 
 	@GafferUI.LazyMethod( deferUntilPlaybackStops = True )
 	def __transferExpansionFromContext( self ) :
@@ -183,27 +179,15 @@ class SceneHierarchy( GafferUI.NodeSetEditor ) :
 		if expandedPaths is None :
 			return
 
-		p = self.__pathListing.getPath()
-		expandedPaths = [ p.copy().setFromString( s ) for s in expandedPaths.paths() ]
 		with Gaffer.BlockedConnection( self.__expansionChangedConnection ) :
-			self.__pathListing.setExpandedPaths( expandedPaths )
+			self.__pathListing.setExpansion( expandedPaths )
 
 	@GafferUI.LazyMethod( deferUntilPlaybackStops = True )
 	def __transferSelectionFromContext( self ) :
 
-		selection = ContextAlgo.getSelectedPaths( self.getContext() ).paths()
+		selection = ContextAlgo.getSelectedPaths( self.getContext() )
 		with Gaffer.BlockedConnection( self.__selectionChangedConnection ) :
-			## \todo Qt is dog slow with large non-contiguous selections,
-			# so we're only mirroring single selections currently. Rewrite
-			# PathListingWidget so it manages selection itself using a PathMatcher
-			# and we can refer to the same data structure everywhere, and reenable
-			# mirroring of multi-selection.
-			if len( selection ) == 1 :
-				p = self.__pathListing.getPath()
-				selection = [ p.copy().setFromString( s ) for s in selection ]
-				self.__pathListing.setSelectedPaths( selection, scrollToFirst=True, expandNonLeaf=False )
-			else :
-				self.__pathListing.setSelectedPaths( [] )
+			self.__pathListing.setSelection( selection, scrollToFirst=True, expandNonLeaf=False )
 
 GafferUI.EditorWidget.registerType( "SceneHierarchy", SceneHierarchy )
 

--- a/python/GafferSceneUI/SceneHierarchy.py
+++ b/python/GafferSceneUI/SceneHierarchy.py
@@ -80,6 +80,27 @@ class SceneHierarchy( GafferUI.NodeSetEditor ) :
 			self.__pathListing.setDragPointer( "objects" )
 			self.__pathListing.setSortable( False )
 
+			# Work around insanely slow selection of a range containing many
+			# objects (using a shift-click). The default selection behaviour
+			# is SelectRows and this triggers some terrible performance problems
+			# in Qt. Since we only have a single column, there is no difference
+			# between SelectItems and SelectRows other than the speed.
+			#
+			# This workaround isn't going to be sufficient when we come to add
+			# additional columns to the SceneHierarchy. What _might_ work instead
+			# is to override `QTreeView.setSelection()` in PathListingWidget.py,
+			# so that we manually expand the selected region to include full rows,
+			# and then don't have to pass the `QItemSelectionModel::Rows` flag to
+			# the subsequent `QItemSelectionModel::select()` call. This would be
+			# essentially the same method we used to speed up
+			# `PathListingWidget.setSelection()`.
+			#
+			# Alternatively we could avoid QItemSelectionModel entirely by managing
+			# the selection ourself as a persistent PathMatcher.
+			self.__pathListing._qtWidget().setSelectionBehavior(
+				self.__pathListing._qtWidget().SelectionBehavior.SelectItems
+			)
+
 			self.__selectionChangedConnection = self.__pathListing.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__selectionChanged ) )
 			self.__expansionChangedConnection = self.__pathListing.expansionChangedSignal().connect( Gaffer.WeakMethod( self.__expansionChanged ) )
 

--- a/python/GafferSceneUITest/SceneGadgetTest.py
+++ b/python/GafferSceneUITest/SceneGadgetTest.py
@@ -142,9 +142,10 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 			gw = GafferUI.GadgetWidget( sg )
 
 		w.setVisible( True )
-		self.waitForIdle( 1000 )
+		self.waitForIdle( 10000 )
 
 		gw.getViewportGadget().frame( sg.bound() )
+		self.waitForIdle( 10000 )
 
 		self.assertObjectAt( sg, imath.V2f( 0.5 ), None )
 		self.assertObjectsAt( sg, imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ), [ "/group" ] )

--- a/python/GafferSceneUITest/SceneGadgetTest.py
+++ b/python/GafferSceneUITest/SceneGadgetTest.py
@@ -285,6 +285,64 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 			self.assertFalse( sg.bound().isEmpty() )
 			self.assertObjectAt( sg, imath.V2f( 0.5 ), IECore.InternedStringVectorData( [ "bigSphere" ] ) )
 
+	def testObjectsAt( self ) :
+
+		plane = GafferScene.Plane()
+
+		sphere = GafferScene.Sphere()
+		sphere["radius"].setValue( 0.25 )
+
+		instancer = GafferScene.Instancer()
+		instancer["in"].setInput( plane["out"] )
+		instancer["instance"].setInput( sphere["out"] )
+		instancer["parent"].setValue( "/plane" )
+
+		subTree = GafferScene.SubTree()
+		subTree["in"].setInput( instancer["out"] )
+		subTree["root"].setValue( "/plane" )
+
+		sg = GafferSceneUI.SceneGadget()
+		sg.setScene( subTree["out"] )
+		sg.setMinimumExpansionDepth( 100 )
+
+		with GafferUI.Window() as w :
+			gw = GafferUI.GadgetWidget( sg )
+		w.setVisible( True )
+		self.waitForIdle( 10000 )
+
+		gw.getViewportGadget().frame( sg.bound() )
+		self.waitForIdle( 10000 )
+
+		self.assertObjectsAt(
+			sg,
+			imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ),
+			[ "/instances/{}/sphere".format( i ) for i in range( 0, 4 ) ]
+		)
+
+		self.assertObjectsAt(
+			sg,
+			imath.Box2f( imath.V2f( 0 ), imath.V2f( 0.5 ) ),
+			[ "/instances/2/sphere" ]
+		)
+
+		self.assertObjectsAt(
+			sg,
+			imath.Box2f( imath.V2f( 0.5, 0 ), imath.V2f( 1, 0.5 ) ),
+			[ "/instances/3/sphere" ]
+		)
+
+		self.assertObjectsAt(
+			sg,
+			imath.Box2f( imath.V2f( 0, 0.5 ), imath.V2f( 0.5, 1 ) ),
+			[ "/instances/0/sphere" ]
+		)
+
+		self.assertObjectsAt(
+			sg,
+			imath.Box2f( imath.V2f( 0.5 ), imath.V2f( 1 ) ),
+			[ "/instances/1/sphere" ]
+		)
+
 	def setUp( self ) :
 
 		GafferUITest.TestCase.setUp( self )

--- a/python/GafferUI/PathChooserDialogue.py
+++ b/python/GafferUI/PathChooserDialogue.py
@@ -119,7 +119,8 @@ class PathChooserDialogue( GafferUI.Dialogue ) :
 
 	def __result( self ) :
 
-		result = self.__pathChooserWidget.pathListingWidget().getSelectedPaths()
+		result = self.__pathChooserWidget.pathListingWidget().getSelection()
+		result = [ self.__path.copy().setFromString( x ) for x in result.paths() ]
 		if not result and not self.__allowMultipleSelection :
 			result = [ self.__path.copy() ]
 		return result

--- a/python/GafferUI/PathChooserWidget.py
+++ b/python/GafferUI/PathChooserWidget.py
@@ -191,12 +191,12 @@ class PathChooserWidget( GafferUI.Widget ) :
 
 		assert( widget is self.__directoryListing )
 
-		selection = self.__directoryListing.getSelectedPaths()
-		if not selection :
+		selection = self.__directoryListing.getSelection()
+		if selection.isEmpty() :
 			return
 
 		with Gaffer.BlockedConnection( self.__pathChangedConnection ) :
-			self.__path[:] = selection[0][:]
+			self.__path.setFromString( selection.paths()[0] )
 
 	# This slot is connected to the pathSelectedSignals of the children and just forwards
 	# them to our own pathSelectedSignal.
@@ -268,9 +268,9 @@ class PathChooserWidget( GafferUI.Widget ) :
 
 		# and update the selection in the listing
 		if path.isLeaf() :
-			self.__directoryListing.setSelectedPaths( [ path ] )
+			self.__directoryListing.setSelection( IECore.PathMatcher( [ str( path ) ] ) )
 		else :
-			self.__directoryListing.setSelectedPaths( [] )
+			self.__directoryListing.setSelection( IECore.PathMatcher() )
 
 	def __dirPathChanged( self, dirPath ) :
 

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -37,6 +37,8 @@
 
 import unittest
 
+import IECore
+
 import Gaffer
 import GafferTest
 
@@ -80,6 +82,30 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 
 		w.setPath( Gaffer.DictPath( {}, "/" ) )
 		self.assertEqual( len( w.getExpandedPaths() ), 0 )
+
+	def testExpansion( self ) :
+
+		d = {}
+		for i in range( 0, 10 ) :
+			dd = {}
+			for j in range( 0, 10 ) :
+				dd[str(j)] = j
+			d[str(i)] = dd
+
+		p = Gaffer.DictPath( d, "/" )
+
+		w = GafferUI.PathListingWidget( p )
+		self.assertTrue( w.getExpansion().isEmpty() )
+
+		cs = GafferTest.CapturingSlot( w.expansionChangedSignal() )
+		e = IECore.PathMatcher( [ "/1", "/2", "/2" ] )
+
+		w.setExpansion( e )
+		self.assertEqual( w.getExpansion(), e )
+		self.assertEqual( len( cs ), 1 )
+
+		w.setPath( Gaffer.DictPath( {}, "/" ) )
+		self.assertTrue( w.getExpansion().isEmpty() )
 
 	def testExpansionSignalFrequency( self ) :
 

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -139,6 +139,30 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		w.setExpandedPaths( e )
 		self.assertEqual( len( c ), 4 )
 
+	def testSelection( self ) :
+
+		d = {}
+		for i in range( 0, 10 ) :
+			dd = {}
+			for j in range( 0, 10 ) :
+				dd[str(j)] = j
+			d[str(i)] = dd
+
+		p = Gaffer.DictPath( d, "/" )
+
+		w = GafferUI.PathListingWidget( p, allowMultipleSelection = True )
+		self.assertTrue( w.getSelection().isEmpty() )
+
+		cs = GafferTest.CapturingSlot( w.selectionChangedSignal() )
+		s = IECore.PathMatcher( [ "/1", "/2/5", "/3/1" ] )
+
+		w.setSelection( s )
+		self.assertEqual( w.getSelection(), s )
+		self.assertEqual( len( cs ), 1 )
+
+		w.setPath( Gaffer.DictPath( {}, "/" ) )
+		self.assertTrue( w.getSelection().isEmpty() )
+
 	def testSelectionSignalFrequency( self ) :
 
 		d = {

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -985,7 +985,7 @@ IECore::PathMatcher getSelection( uint64_t treeViewAddress )
 	QTreeView *treeView = reinterpret_cast<QTreeView *>( treeViewAddress );
 	PathModel *model = dynamic_cast<PathModel *>( treeView->model() );
 
-	QModelIndexList selectedIndices = treeView->selectionModel()->selectedRows();
+	QModelIndexList selectedIndices = treeView->selectionModel()->selectedIndexes();
 	IECore::PathMatcher result;
 	for( const auto &index : selectedIndices )
 	{

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -954,19 +954,22 @@ void setSelection( uint64_t treeViewAddress, const IECore::PathMatcher &paths, b
 		throw IECore::InvalidArgumentException( "More than one path selected" );
 	}
 
-	QItemSelectionModel *selectionModel = treeView->selectionModel();
+	QItemSelection itemSelection;
 	for( const auto &modelIndex : indices )
 	{
 		if( !modelIndex.isValid() )
 		{
 			continue;
 		}
-		selectionModel->select( modelIndex, QItemSelectionModel::Select | QItemSelectionModel::Rows );
+		itemSelection.select( modelIndex, modelIndex.sibling( modelIndex.row(), model->columnCount() - 1 ) );
 		if( expandNonLeaf && !model->pathForIndex( modelIndex )->isLeaf() )
 		{
 			treeView->setExpanded( modelIndex, true );
 		}
 	}
+
+	QItemSelectionModel *selectionModel = treeView->selectionModel();
+	selectionModel->select( itemSelection, QItemSelectionModel::Select );
 
 	if( scrollToFirst && !indices.empty() )
 	{


### PR DESCRIPTION
This massively improves performance when manipulating the selection/expansion of many paths in the SceneHierarchy and Viewer, which allows us to finally mirror the full selection from the Viewer into the SceneHierarchy. There were several performance problems to deal with here, both in our code and in Qt's internals.

The key change on our side is to use `IECore.PathMatcher` objects to represent selection and expansion in the PathListingWidget API, because the fast lookups they provide allow us to implement several operations more efficiently. These are the same objects we were already using to represent selection and expansion in the Viewer, so we also eliminate some conversions there.

The key change on the Qt side was to realise that `QItemSelectionModel` has some massive performance traps related to non-contiguous selections and row selections, and to avoid those traps wherever we can. As you can see in the comment for 51dddcf2ee91c26d1a31d59b2f9391a043471031, there may be more work to do here in future. It does feel like we're fighting Qt in order to get a treeview with the features and performance we want, so I'm not sure where we'll end up. At some point I wouldn't be surprised if we end up managing/drawing the selection entirely ourselves, or even just writing our own widget from scratch. That's a bigger endeavour though.

The new PathListingWidget methods I've added are intended to eventually replace the old ones, which I've deprecated. I don't anticipate removing the deprecated methods for a long while though. Although the new methods are a huge step forward for performance they're not always more convenient, in particular for managing single selections where performance isn't an issue anyway. I've updated client code to use the new methods where it was straightforward, but have refrained where it seemed more painful (the UIEditor in particular). I intend to add some methods specific to single selection at some point, but I want to see how the internals evolve first.