### PR TITLE
OSL Shader Serialisation Bug

### DIFF
--- a/python/GafferOSLTest/OSLObjectTest.py
+++ b/python/GafferOSLTest/OSLObjectTest.py
@@ -592,6 +592,34 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 
 		pv = outputPlane["name"]
 		self.assertEqual( pv.data, IECore.StringVectorData( ["even", "odd", "even", "odd"] ) )
+	
+	def testShaderSerialisation( self ) :
+
+		s = Gaffer.ScriptNode()
+		s['shader'] = GafferOSL.OSLShader()
+		s['shader'].loadShader( "ObjectProcessing/OutObject" )
+		s['object'] = GafferOSL.OSLObject()
+		s['object']['shader'].setInput( s['shader']['out'] )
+		self.assertEqual( s['object']['shader'].getInput(), s['shader']['out'] )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+		
+		self.assertEqual( s2['object']['shader'].getInput(), s2['shader']['out'] )
+		
+		# same network as above, but reverse the order of node construction
+
+		s3 = Gaffer.ScriptNode()
+		s3['object'] = GafferOSL.OSLObject()
+		s3['shader'] = GafferOSL.OSLShader()
+		s3['shader'].loadShader( "ObjectProcessing/OutObject" )
+		s3['object']['shader'].setInput( s3['shader']['out'] )
+		self.assertEqual( s3['object']['shader'].getInput(), s3['shader']['out'] )
+
+		s4 = Gaffer.ScriptNode()
+		s4.execute( s3.serialise() )
+		
+		self.assertEqual( s4['object']['shader'].getInput(), s4['shader']['out'] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -966,5 +966,20 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		self.assertTrue( script["OutObject"]["parameters"]["in1"].getInput().isSame( script["Box"]["out_primitiveVariable"] ) )
 		self.assertTrue( script["OutObject"]["parameters"]["in1"].source().isSame( script["Box"]["OutFloat"]["out"]["primitiveVariable"] ) )
 
+	def testShaderSerialisation( self ) :
+
+		s = Gaffer.ScriptNode()
+		s['n'] = GafferOSL.OSLShader()
+		s['n'].loadShader( "Pattern/Noise" )
+		s['n2'] = GafferOSL.OSLShader()
+		s['n2'].loadShader( "Pattern/Noise" )
+		s['n2']['scale'].setInput( s['n']['n'] )
+		self.assertEqual( s['n2']['scale'].getInput(), s['n']['n'] )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+		
+		self.assertEqual( s2['n2']['scale'].getInput(), s2['n']['n'] )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
These tests fail on master and when cherry-picked ontop of my backport branch (#2447), but do not fail on 0.3X_experimental_ai5 itself. As best I can guess, the ValuePlug serialisation change is the culprit, since nothing else on my backport branch seems related.

For reference, the difference in serialisation is the order of the "type" plug's `setValue` relative to the `setInput` between the two shaders. This causes the connection to be rejected by this clause in [`OSLShader::acceptsInput`](https://github.com/GafferHQ/gaffer/blob/master/src/GafferOSL/OSLShader.cpp#L201-L205). In the OSLObject test, it shows that reversing the order of node construction works around the issue (ie. if first shader drives second shader it works, but not the other way around).

On master and #2447 when first shader drives second shader we get:

```
__children["shader"]["name"].setValue( 'ObjectProcessing/OutObject' )
__children["shader"]["type"].setValue( 'osl:surface' )
__children["object"]["shader"].setInput( __children["shader"]["out"] )
__children["shader"].loadShader( "ObjectProcessing/OutObject", keepExistingValues=True )
```

On master and #2447 when second shader drives first shader we get:

```
__children["object"]["shader"].setInput( __children["shader"]["out"] )
__children["shader"]["name"].setValue( 'ObjectProcessing/OutObject' )
__children["shader"]["type"].setValue( 'osl:surface' )
__children["shader"].loadShader( "ObjectProcessing/OutObject", keepExistingValues=True )
```

and on 0.3X_experimental_ai5 we get:

```
__children["shader"]["name"].setValue( 'ObjectProcessing/OutObject' )
__children["shader"]["type"].setValue( 'osl:surface' )
__children["shader"]["parameters"].addChild( GafferOSL.ClosurePlug( "in0", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
....
__children["object"]["shader"].setInput( __children["shader"]["out"] )
__children["shader"].loadShader( "ObjectProcessing/OutObject", keepExistingValues=True )
```