### PR TITLE
GafferTractor : Remove dynamic flag from TaskNode plugs.

### DIFF
--- a/python/GafferTractor/TractorDispatcher.py
+++ b/python/GafferTractor/TractorDispatcher.py
@@ -194,9 +194,9 @@ class TractorDispatcher( GafferDispatch.Dispatcher ) :
 		if "tractor" in parentPlug :
 			return
 
-		parentPlug["tractor"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		parentPlug["tractor"]["service"] = Gaffer.StringPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		parentPlug["tractor"]["tags"] = Gaffer.StringPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		parentPlug["tractor"] = Gaffer.Plug()
+		parentPlug["tractor"]["service"] = Gaffer.StringPlug()
+		parentPlug["tractor"]["tags"] = Gaffer.StringPlug()
 
 IECore.registerRunTimeTyped( TractorDispatcher, typeName = "GafferTractor::TractorDispatcher" )
 

--- a/python/GafferTractorTest/TractorDispatcherTest.py
+++ b/python/GafferTractorTest/TractorDispatcherTest.py
@@ -197,6 +197,22 @@ class TractorDispatcherTest( GafferTest.TestCase ) :
 
 		self.assertTrue( isinstance( job.subtasks[0].subtasks[1].subtasks[0], author.Instance ) )
 
+	def testTaskPlugs( self ) :
+		
+		s = Gaffer.ScriptNode()
+		s["n"] = GafferDispatchTest.LoggingTaskNode()
+		self.assertTrue( "tractor" in [ x.getName() for x in s["n"]["dispatcher"].children() ] )
+		self.assertTrue( "tractor1" not in [ x.getName() for x in s["n"]["dispatcher"].children() ] )
+		s["n"]["dispatcher"]["tractor"]["service"].setValue( "myService" )
+		s["n"]["dispatcher"]["tractor"]["tags"].setValue( "myTag1 myTag2" )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+		self.assertTrue( "tractor" in [ x.getName() for x in s2["n"]["dispatcher"].children() ] )
+		self.assertTrue( "tractor1" not in [ x.getName() for x in s2["n"]["dispatcher"].children() ] )
+		self.assertEqual( s2["n"]["dispatcher"]["tractor"]["service"].getValue(), "myService" )
+		self.assertEqual( s2["n"]["dispatcher"]["tractor"]["tags"].getValue(), "myTag1 myTag2" )
+
 	def testTypeNamePrefixes( self ) :
 
 		self.assertTypeNamesArePrefixed( GafferTractor )


### PR DESCRIPTION
Its a bit of a special case, but those plugs are created during TaskNode construction, so don't need the dynamic flag. Otherwise they'd duplicate on copy/paste or scene deserialisation.