### PR TITLE
Auxiliary nodes : Move colour metadata to NodeGraph config

### DIFF
--- a/python/GafferUI/AnimationUI.py
+++ b/python/GafferUI/AnimationUI.py
@@ -53,7 +53,6 @@ Gaffer.Metadata.registerNode(
 	""",
 
 	"nodeGadget:type", "GafferUI::AuxiliaryNodeGadget",
-	"nodeGadget:color", imath.Color3f( 0.3, 0.3, 0.45 ),
 	"auxiliaryNodeGadget:label", "a",
 
 	plugs = {

--- a/python/GafferUI/ExpressionUI.py
+++ b/python/GafferUI/ExpressionUI.py
@@ -55,7 +55,6 @@ Gaffer.Metadata.registerNode(
 
 	"layout:customWidget:Expression:widgetType", "GafferUI.ExpressionUI.ExpressionWidget",
 	"nodeGadget:type", "GafferUI::AuxiliaryNodeGadget",
-	"nodeGadget:color", imath.Color3f( 0.3, 0.45, 0.3 ),
 	"auxiliaryNodeGadget:label", "e",
 
 	plugs = {

--- a/python/GafferUI/RandomUI.py
+++ b/python/GafferUI/RandomUI.py
@@ -57,7 +57,6 @@ Gaffer.Metadata.registerNode(
 	""",
 
 	"nodeGadget:type", "GafferUI::AuxiliaryNodeGadget",
-	"nodeGadget:color", imath.Color3f( 0.45, 0.3, 0.3 ),
 	"auxiliaryNodeGadget:label", "r",
 
 	plugs = {

--- a/startup/gui/nodeGraph.py
+++ b/startup/gui/nodeGraph.py
@@ -62,6 +62,10 @@ Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "postTasks.*", "conn
 Gaffer.Metadata.registerNodeValue( Gaffer.SubGraph, "nodeGadget:color", imath.Color3f( 0.225 ) )
 Gaffer.Metadata.registerNodeValue( Gaffer.BoxIO, "nodeGadget:color", imath.Color3f( 0.225 ) )
 
+Gaffer.Metadata.registerNodeValue( Gaffer.Random, "nodeGadget:color", imath.Color3f( 0.45, 0.3, 0.3 ) )
+Gaffer.Metadata.registerNodeValue( Gaffer.Expression, "nodeGadget:color", imath.Color3f( 0.3, 0.45, 0.3 ) )
+Gaffer.Metadata.registerNodeValue( Gaffer.Animation, "nodeGadget:color", imath.Color3f( 0.3, 0.3, 0.45 ) )
+
 Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "in*", "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
 Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "out", "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
 Gaffer.Metadata.registerPlugValue( GafferScene.InteractiveRender, "in", "nodule:color", imath.Color3f( 0.2346, 0.326, 0.46 ) )


### PR DESCRIPTION
After merging #2458 I realised that to date we've been setting node colours all in one place in nodeGraph.py, rather than in each individual UI file. This just moves the new registrations to be with the others.