### PR TITLE
Autosave backups of open scripts

### DIFF
--- a/python/GafferUI/Backups.py
+++ b/python/GafferUI/Backups.py
@@ -1,0 +1,305 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+
+import IECore
+
+from Qt import QtCore
+
+import collections
+import os
+import stat
+import weakref
+
+class Backups( object ) :
+
+	def __init__( self, applicationRoot ) :
+
+		# \todo I wonder if it would make sense for this sort
+		# of "bolt on" component to be a GraphComponent that was
+		# parented under the ApplicationRoot somewhere, instead
+		# of manually tracking the "parent" like this?
+		self.__applicationRoot = weakref.ref( applicationRoot )
+
+		self.__settings = Gaffer.Plug()
+		self.__settings["enabled"] = Gaffer.BoolPlug( defaultValue = True )
+		self.__settings["frequency"] = Gaffer.IntPlug( defaultValue = 5, minValue = 0 )
+		self.__settings["fileName"] = Gaffer.StringPlug( defaultValue = "${script:directory}/.gafferBackups/${script:name}-backup${backup:number}.gfr" )
+		self.__settings["files"] = Gaffer.IntPlug( defaultValue = 10, minValue = 1 )
+
+		applicationRoot["preferences"]["backups"] = self.__settings
+
+		self.__plugSetConnection = applicationRoot["preferences"].plugSetSignal().connect( self.__plugSet )
+
+		self.__timer = QtCore.QTimer()
+		self.__timer.timeout.connect( Gaffer.WeakMethod( self.__timeout ) )
+
+		# Initialise the timer
+		self.__plugSet( self.__settings["enabled"] )
+
+	# Creates a backup for the specified script, returning the
+	# name of the backup file. This is really only public so we
+	# can call it from the unit tests.
+	def backup( self, script ) :
+
+		fileName = None
+		existingFiles = []
+		for f in self.__potentialFileNames( script ) :
+			if not os.path.exists( f ) :
+				fileName = f
+				break
+			else :
+				existingFiles.append( ( os.path.getmtime( f ), f ) )
+
+		if fileName is None :
+			# All files exist already, sort by modification
+			# time and choose the oldest.
+			existingFiles.sort()
+			fileName = existingFiles[0][1]
+
+		dirName = os.path.dirname( fileName )
+		try :
+			os.makedirs( dirName )
+		except OSError :
+			# makedirs very unhelpfully raises an exception if
+			# the directory already exists, but it might also
+			# raise if it fails. We reraise only in the latter case.
+			# We do this rather than test for existence _first_,
+			# because then we'd be in a race against other processes
+			# trying to create the same directory, and could still
+			# end up with an exception.
+			if not os.path.isdir( dirName ) :
+				raise
+
+		script.serialiseToFile( fileName )
+		return fileName
+
+	# Returns the filenames of all the backups that have
+	# been made for the specified script, ordered from
+	# oldest to most recent. Script may either be a ScriptNode
+	# or a filename.
+	def backups( self, script ) :
+
+		timesAndFiles = []
+		for f in self.__potentialFileNames( script ) :
+			if os.path.exists( f ) :
+				timesAndFiles.append( ( os.path.getmtime( f ), f ) )
+
+		timesAndFiles.sort()
+		return [ x[1] for x in timesAndFiles ]
+
+	def settings( self ) :
+
+		return self.__settings
+
+	@classmethod
+	def acquire( cls, application, createIfNecessary=True ) :
+
+		if isinstance( application, Gaffer.Application ) :
+			applicationRoot = application.root()
+		else :
+			assert( isinstance( application, Gaffer.ApplicationRoot ) )
+			applicationRoot = application
+
+		try :
+			return applicationRoot.__backups
+		except AttributeError :
+			if not createIfNecessary :
+				return None
+			applicationRoot.__backups = Backups( applicationRoot )
+			return applicationRoot.__backups
+
+	def __plugSet( self, plug ) :
+
+		if plug == self.__settings["fileName"] :
+			if plug.getValue() == "" :
+				self.__timer.stop()
+				return
+
+		if plug in ( self.__settings["enabled"], self.__settings["frequency"] ) :
+			frequency = self.__settings["frequency"].getValue()
+			if not self.__settings["enabled"].getValue() :
+				frequency = 0
+
+			if not frequency :
+				self.__timer.stop()
+			else :
+				self.__timer.start(
+					# Frequency is in minutes, Qt wants milliseconds
+					frequency * 60 * 1000
+				)
+
+	def __timeout( self ) :
+
+		for script in self.__applicationRoot()["scripts"] :
+			if script["fileName"].getValue() :
+				try :
+					backupFileName = self.backup( script )
+					IECore.msg(
+						IECore.Msg.Level.Info,
+						"GafferUI.Backups",
+						"Saved backup file \"{}\"".format( backupFileName )
+					)
+				except Exception as e :
+					IECore.msg(
+						IECore.Msg.Level.Error,
+						"GafferUI.Backups",
+						str( e )
+					)
+
+	def __potentialFileNames( self, script ) :
+
+		if isinstance( script, Gaffer.ScriptNode ) :
+			fileName = script["fileName"].getValue()
+		else :
+			assert( isinstance( script, str ) )
+			fileName = script
+
+		if not fileName :
+			return []
+
+		context = Gaffer.Context()
+		context["script:name"] = os.path.splitext( os.path.basename( fileName ) )[0]
+		context["script:directory"] = os.path.dirname( os.path.abspath( fileName ) )
+
+		pattern = self.__settings["fileName"].getValue()
+		fileNames = []
+		for i in range( self.__settings["files"].getValue() ) :
+			context["backup:number"] = i
+			context.setFrame( i )
+			fileNames.append( context.substitute( pattern ) )
+
+		# Make results unique while maintaining order
+		return collections.OrderedDict( [ ( x, x ) for x in fileNames ] ).keys()
+
+##########################################################################
+# UI
+##########################################################################
+
+def __backupsEnabled( plug ) :
+
+	return plug["enabled"].getValue()
+
+def __backupNumberEnabled( plug ) :
+
+	if not __backupsEnabled( plug ) :
+		return False
+
+	f = plug["fileName"].getValue()
+	return "${backup:number}" in f
+
+Gaffer.Metadata.registerNode(
+
+	Gaffer.Preferences,
+
+	plugs = {
+
+		"backups" : [
+
+			"description",
+			"""
+			Controls a mechanism used to create automatic
+			backup copies of scripts.
+			""",
+
+			"layout:section", "Backups",
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
+
+			"layout:activator:backupsEnabled", __backupsEnabled,
+			"layout:activator:backupNumberEnabled", __backupNumberEnabled,
+
+		],
+
+		"backups.enabled" : [
+
+			"description",
+			"""
+			Turns the backup system on and off.
+			""",
+
+		],
+
+		"backups.frequency" : [
+
+			"description",
+			"""
+			How often backups are made, measured in minutes.
+			""",
+
+			"layout:activator", "backupsEnabled",
+
+		],
+
+		"backups.fileName" : [
+
+			"description",
+			"""
+			The name of the backup file to be created. This may
+			use any of the following variables :
+
+			- `${script:directory}` : the directory that contains
+			  the script to be backed up.
+			- `${script:name}` : the current filename of the script
+			  to be backed up. Note that this variable _must_ be
+			  used, otherwise backups for different scripts will
+			  be saved over the top of each other.
+			- `${backup:number}` : the number of this backup, used
+			  to keep more than one backup per file.
+			- `#` : the same as `${backup:number}`.
+			""",
+
+			"layout:activator", "backupsEnabled",
+
+		],
+
+		"backups.files" : [
+
+			"description",
+			"""
+			The number of backups to keep for each script. Only
+			used if the backup filename includes `${backup:number}`.
+			When the backup limit is reached, the oldest backup
+			will be overwritten.
+			""",
+
+			"layout:activator", "backupNumberEnabled",
+
+		],
+
+	}
+
+)

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -282,6 +282,7 @@ from UIEditor import UIEditor
 import GraphBookmarksUI
 import DocumentationAlgo
 import _PlugAdder
+from Backups import Backups
 
 # and then specific node uis
 

--- a/python/GafferUITest/BackupsTest.py
+++ b/python/GafferUITest/BackupsTest.py
@@ -1,0 +1,138 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferUITest
+import GafferUI
+import GafferTest
+import Gaffer
+
+import os
+import time
+import weakref
+
+class BackupsTest( GafferUITest.TestCase ) :
+
+	def testAcquire( self ) :
+
+		a = Gaffer.ApplicationRoot()
+		self.assertIsNone( GafferUI.Backups.acquire( a, createIfNecessary = False ) )
+
+		b = GafferUI.Backups.acquire( a )
+		self.assertIsInstance( b, GafferUI.Backups )
+		self.assertIs( b, GafferUI.Backups.acquire( a ) )
+
+		wa = weakref.ref( a )
+		wb = weakref.ref( b )
+
+		del a
+		self.assertIsNone( wa() )
+		del b
+		self.assertIsNone( wb() )
+
+	def testSingleBackup( self ) :
+
+		a = Gaffer.ApplicationRoot()
+
+		b = GafferUI.Backups.acquire( a )
+		b.settings()["fileName"].setValue( self.temporaryDirectory() + "/backups/${script:name}.gfr" )
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
+		a["scripts"].addChild( s )
+		s.save()
+
+		backupFileName = self.temporaryDirectory() + "/backups/test.gfr"
+		self.assertFalse( os.path.exists( backupFileName ) )
+		self.assertEqual( b.backups( s ), [] )
+
+		self.assertEqual( b.backup( s ), backupFileName )
+		self.assertTrue( os.path.exists( backupFileName ) )
+		self.assertEqual( b.backups( s ), [ backupFileName ] )
+		self.__assertFilesEqual( s["fileName"].getValue(), backupFileName )
+
+		s.addChild( Gaffer.Node() )
+		s.save()
+
+		self.assertEqual( b.backup( s ), backupFileName )
+		self.assertEqual( b.backups( s ), [ backupFileName ] )
+		self.__assertFilesEqual( s["fileName"].getValue(), backupFileName )
+
+	def testMultipleBackups( self ) :
+
+		a = Gaffer.ApplicationRoot()
+
+		b = GafferUI.Backups.acquire( a )
+		b.settings()["fileName"].setValue( "${script:directory}/${script:name}-backup${backup:number}.gfr" )
+		b.settings()["files"].setValue( 3 )
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
+		s["add"] = GafferTest.AddNode()
+		a["scripts"].addChild( s )
+
+		expectedBackups = []
+		for i in range( 0, 50 ) :
+
+			s["add"]["op1"].setValue( i )
+			s.save()
+
+			backupFileName = "{0}/test-backup{1}.gfr".format( self.temporaryDirectory(), i % 3 )
+			if i < 3 :
+				self.assertFalse( os.path.exists( backupFileName ) )
+
+			self.assertEqual( b.backup( s ), backupFileName )
+			self.assertTrue( os.path.exists( backupFileName ) )
+			self.__assertFilesEqual( s["fileName"].getValue(), backupFileName )
+
+			expectedBackups.append( backupFileName )
+			if len( expectedBackups ) > 3 :
+				del expectedBackups[0]
+			self.assertEqual( b.backups( s ), expectedBackups )
+
+			time.sleep( 0.01 )
+
+	def __assertFilesEqual( self, f1, f2 ) :
+
+		with open( f1 ) as f1 :
+			l1 = f1.readlines()
+
+		with open( f2 ) as f2 :
+			l2 = f2.readlines()
+
+		self.assertEqual( l1, l2 )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/BackupsTest.py
+++ b/python/GafferUITest/BackupsTest.py
@@ -40,6 +40,7 @@ import GafferTest
 import Gaffer
 
 import os
+import sys
 import time
 import weakref
 
@@ -103,8 +104,21 @@ class BackupsTest( GafferUITest.TestCase ) :
 		s["add"] = GafferTest.AddNode()
 		a["scripts"].addChild( s )
 
+		numBackups = 50
+		timeBetweenBackups = 0.01
+		if sys.platform == "darwin" :
+			# HFS+ only has second resolution, so
+			# we have to wait longer between backups
+			# otherwise all the backups have the
+			# same modification time and we can't
+			# tell which is the latest.
+			timeBetweenBackups = 1.1
+			# We also need to do fewer tests because
+			# otherwise it takes an age.
+			numBackups = 5
+
 		expectedBackups = []
-		for i in range( 0, 50 ) :
+		for i in range( 0, numBackups ) :
 
 			s["add"]["op1"].setValue( i )
 			s.save()
@@ -122,7 +136,7 @@ class BackupsTest( GafferUITest.TestCase ) :
 				del expectedBackups[0]
 			self.assertEqual( b.backups( s ), expectedBackups )
 
-			time.sleep( 0.01 )
+			time.sleep( timeBetweenBackups )
 
 	def __assertFilesEqual( self, f1, f2 ) :
 

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -110,6 +110,7 @@ from SwitchNodeGadgetTest import SwitchNodeGadgetTest
 from NoduleLayoutTest import NoduleLayoutTest
 from ErrorDialogueTest import ErrorDialogueTest
 from WidgetAlgoTest import WidgetAlgoTest
+from BackupsTest import BackupsTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -59,6 +59,10 @@ GafferUI.LayoutMenu.appendDefinitions( scriptWindowMenu, name="/Layout" )
 GafferUI.DispatcherUI.appendMenuDefinitions( scriptWindowMenu, prefix="/Execute" )
 GafferUI.LocalDispatcherUI.appendMenuDefinitions( scriptWindowMenu, prefix="/Execute" )
 
+# Turn on backups by default, so they are supported by the open functions
+# in the file menu. They can be turned off again in the preferences menu.
+GafferUI.Backups.acquire( application )
+
 ## Help menu
 ###########################################################################
 


### PR DESCRIPTION
You know, just in case Gaffer were to crash. If you want to test this interactively as well as review the code, you might find it useful to do the following :

- Hack the timer multiplier so that it works in seconds rather than minutes
- Run with `IECORE_LOG_LEVEL=Info`, to be notified of what backups are being made and when

@donboie, we'll need to give some thought to how this interacts with Caribou, where the script is embedded in a Maya session and Maya itself will be doing autosaves. It might be sufficient to simply have a Caribou config that turns off `["preferences"]["backups"]["enabled"]` and hides the plugs, but I haven't done any testing of that idea.