### PR TITLE
Serialisation : Improve support for Python-based serialisers

### DIFF
--- a/include/GafferBindings/NodeBinding.h
+++ b/include/GafferBindings/NodeBinding.h
@@ -132,6 +132,8 @@ class GAFFERBINDINGS_API NodeSerialiser : public Serialisation::Serialiser
 
 	public :
 
+		IE_CORE_DECLAREMEMBERPTR( NodeSerialiser )
+
 		void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const override;
 		/// Implemented to serialise per-instance metadata.
 		std::string postHierarchy( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override;

--- a/include/GafferBindings/SerialisationBinding.h
+++ b/include/GafferBindings/SerialisationBinding.h
@@ -42,6 +42,7 @@
 #include "GafferBindings/Serialisation.h"
 
 #include "IECorePython/RefCountedBinding.h"
+#include "IECorePython/ExceptionAlgo.h"
 
 #include "boost/python/suite/indexing/container_utils.hpp"
 
@@ -73,14 +74,21 @@ class SerialiserWrapper : public IECorePython::RefCountedWrapper<WrappedType>
 			if( this->isSubclassed() )
 			{
 				IECorePython::ScopedGILLock gilLock;
-				boost::python::object f = this->methodOverride( "moduleDependencies" );
-				if( f )
+				try
 				{
-					boost::python::object mo = f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), serialisation );
-					std::vector<std::string> mv;
-					boost::python::container_utils::extend_container( mv, mo );
-					modules.insert( mv.begin(), mv.end() );
-					return;
+					boost::python::object f = this->methodOverride( "moduleDependencies" );
+					if( f )
+					{
+						boost::python::object mo = f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), serialisation );
+						std::vector<std::string> mv;
+						boost::python::container_utils::extend_container( mv, mo );
+						modules.insert( mv.begin(), mv.end() );
+						return;
+					}
+				}
+				catch( const boost::python::error_already_set &e )
+				{
+					IECorePython::ExceptionAlgo::translatePythonException();
 				}
 			}
 			WrappedType::moduleDependencies( graphComponent, modules, serialisation );
@@ -91,12 +99,19 @@ class SerialiserWrapper : public IECorePython::RefCountedWrapper<WrappedType>
 			if( this->isSubclassed() )
 			{
 				IECorePython::ScopedGILLock gilLock;
-				boost::python::object f = this->methodOverride( "constructor" );
-				if( f )
+				try
 				{
-					return boost::python::extract<std::string>(
-						f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), serialisation )
-					);
+					boost::python::object f = this->methodOverride( "constructor" );
+					if( f )
+					{
+						return boost::python::extract<std::string>(
+							f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), serialisation )
+						);
+					}
+				}
+				catch( const boost::python::error_already_set &e )
+				{
+					IECorePython::ExceptionAlgo::translatePythonException();
 				}
 			}
 			return WrappedType::constructor( graphComponent, serialisation );
@@ -107,12 +122,19 @@ class SerialiserWrapper : public IECorePython::RefCountedWrapper<WrappedType>
 			if( this->isSubclassed() )
 			{
 				IECorePython::ScopedGILLock gilLock;
-				boost::python::object f = this->methodOverride( "postConstructor" );
-				if( f )
+				try
 				{
-					return boost::python::extract<std::string>(
-						f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), identifier, serialisation )
-					);
+					boost::python::object f = this->methodOverride( "postConstructor" );
+					if( f )
+					{
+						return boost::python::extract<std::string>(
+							f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), identifier, serialisation )
+						);
+					}
+				}
+				catch( const boost::python::error_already_set &e )
+				{
+					IECorePython::ExceptionAlgo::translatePythonException();
 				}
 			}
 			return WrappedType::postConstructor( graphComponent, identifier, serialisation );
@@ -123,12 +145,19 @@ class SerialiserWrapper : public IECorePython::RefCountedWrapper<WrappedType>
 			if( this->isSubclassed() )
 			{
 				IECorePython::ScopedGILLock gilLock;
-				boost::python::object f = this->methodOverride( "postHierarchy" );
-				if( f )
+				try
 				{
-					return boost::python::extract<std::string>(
-						f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), identifier, serialisation )
-					);
+					boost::python::object f = this->methodOverride( "postHierarchy" );
+					if( f )
+					{
+						return boost::python::extract<std::string>(
+							f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), identifier, serialisation )
+						);
+					}
+				}
+				catch( const boost::python::error_already_set &e )
+				{
+					IECorePython::ExceptionAlgo::translatePythonException();
 				}
 			}
 			return WrappedType::postHierarchy( graphComponent, identifier, serialisation );
@@ -139,12 +168,19 @@ class SerialiserWrapper : public IECorePython::RefCountedWrapper<WrappedType>
 			if( this->isSubclassed() )
 			{
 				IECorePython::ScopedGILLock gilLock;
-				boost::python::object f = this->methodOverride( "postScript" );
-				if( f )
+				try
 				{
-					return boost::python::extract<std::string>(
-						f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), identifier, serialisation )
-					);
+					boost::python::object f = this->methodOverride( "postScript" );
+					if( f )
+					{
+						return boost::python::extract<std::string>(
+							f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), identifier, serialisation )
+						);
+					}
+				}
+				catch( const boost::python::error_already_set &e )
+				{
+					IECorePython::ExceptionAlgo::translatePythonException();
 				}
 			}
 			return WrappedType::postScript( graphComponent, identifier, serialisation );
@@ -155,10 +191,17 @@ class SerialiserWrapper : public IECorePython::RefCountedWrapper<WrappedType>
 			if( this->isSubclassed() )
 			{
 				IECorePython::ScopedGILLock gilLock;
-				boost::python::object f = this->methodOverride( "childNeedsSerialisation" );
-				if( f )
+				try
 				{
-					return f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( child ) ), serialisation );
+					boost::python::object f = this->methodOverride( "childNeedsSerialisation" );
+					if( f )
+					{
+						return f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( child ) ), serialisation );
+					}
+				}
+				catch( const boost::python::error_already_set &e )
+				{
+					IECorePython::ExceptionAlgo::translatePythonException();
 				}
 			}
 			return WrappedType::childNeedsSerialisation( child, serialisation );
@@ -169,10 +212,17 @@ class SerialiserWrapper : public IECorePython::RefCountedWrapper<WrappedType>
 			if( this->isSubclassed() )
 			{
 				IECorePython::ScopedGILLock gilLock;
-				boost::python::object f = this->methodOverride( "childNeedsConstruction" );
-				if( f )
+				try
 				{
-					return f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( child ) ), serialisation );
+					boost::python::object f = this->methodOverride( "childNeedsConstruction" );
+					if( f )
+					{
+						return f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( child ) ), serialisation );
+					}
+				}
+				catch( const boost::python::error_already_set &e )
+				{
+					IECorePython::ExceptionAlgo::translatePythonException();
 				}
 			}
 			return WrappedType::childNeedsConstruction( child, serialisation );

--- a/include/GafferBindings/SerialisationBinding.h
+++ b/include/GafferBindings/SerialisationBinding.h
@@ -1,0 +1,187 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERBINDINGS_SERIALISATIONBINDING_H
+#define GAFFERBINDINGS_SERIALISATIONBINDING_H
+
+#include "boost/python.hpp"
+
+#include "GafferBindings/Serialisation.h"
+
+#include "IECorePython/RefCountedBinding.h"
+
+#include "boost/python/suite/indexing/container_utils.hpp"
+
+namespace GafferBindings
+{
+
+template<typename T, typename Base, typename TWrapper=T>
+class SerialiserClass : public IECorePython::RefCountedClass<T, Base, TWrapper>
+{
+	public :
+
+		SerialiserClass( const char *name );
+
+};
+
+template<typename WrappedType>
+class SerialiserWrapper : public IECorePython::RefCountedWrapper<WrappedType>
+{
+
+	public :
+
+		SerialiserWrapper( PyObject *self )
+			:	IECorePython::RefCountedWrapper<WrappedType>( self )
+		{
+		}
+
+		void moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				boost::python::object f = this->methodOverride( "moduleDependencies" );
+				if( f )
+				{
+					boost::python::object mo = f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), serialisation );
+					std::vector<std::string> mv;
+					boost::python::container_utils::extend_container( mv, mo );
+					modules.insert( mv.begin(), mv.end() );
+					return;
+				}
+			}
+			WrappedType::moduleDependencies( graphComponent, modules, serialisation );
+		}
+
+		std::string constructor( const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation ) const override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				boost::python::object f = this->methodOverride( "constructor" );
+				if( f )
+				{
+					return boost::python::extract<std::string>(
+						f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), serialisation )
+					);
+				}
+			}
+			return WrappedType::constructor( graphComponent, serialisation );
+		}
+
+		std::string postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				boost::python::object f = this->methodOverride( "postConstructor" );
+				if( f )
+				{
+					return boost::python::extract<std::string>(
+						f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), identifier, serialisation )
+					);
+				}
+			}
+			return WrappedType::postConstructor( graphComponent, identifier, serialisation );
+		}
+
+		std::string postHierarchy( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				boost::python::object f = this->methodOverride( "postHierarchy" );
+				if( f )
+				{
+					return boost::python::extract<std::string>(
+						f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), identifier, serialisation )
+					);
+				}
+			}
+			return WrappedType::postHierarchy( graphComponent, identifier, serialisation );
+		}
+
+		std::string postScript( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				boost::python::object f = this->methodOverride( "postScript" );
+				if( f )
+				{
+					return boost::python::extract<std::string>(
+						f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( graphComponent ) ), identifier, serialisation )
+					);
+				}
+			}
+			return WrappedType::postScript( graphComponent, identifier, serialisation );
+		}
+
+		bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				boost::python::object f = this->methodOverride( "childNeedsSerialisation" );
+				if( f )
+				{
+					return f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( child ) ), serialisation );
+				}
+			}
+			return WrappedType::childNeedsSerialisation( child, serialisation );
+		}
+
+		bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				boost::python::object f = this->methodOverride( "childNeedsConstruction" );
+				if( f )
+				{
+					return f( Gaffer::GraphComponentPtr( const_cast<Gaffer::GraphComponent *>( child ) ), serialisation );
+				}
+			}
+			return WrappedType::childNeedsConstruction( child, serialisation );
+		}
+
+};
+
+} // namespace GafferBindings
+
+#include "GafferBindings/SerialisationBinding.inl"
+
+#endif // GAFFERBINDINGS_SERIALISATIONBINDING_H

--- a/include/GafferBindings/SerialisationBinding.inl
+++ b/include/GafferBindings/SerialisationBinding.inl
@@ -1,0 +1,213 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERBINDINGS_SERIALISATIONBINDING_INL
+#define GAFFERBINDINGS_SERIALISATIONBINDING_INL
+
+namespace GafferBindings
+{
+
+namespace Detail
+{
+
+// Method wrappers
+// ===============
+//
+// These functions are used to wrap the methods of the Serialisers
+// that we bind. For instance, when `serialiser.moduleDependencies()`
+// is called in Python, the `moduleDependencies()` function below will
+// be called, and it will make the call to the actual C++ method.
+//
+// The functions are called in two scenarios :
+//
+// 1. The `self` argument was constructed in Python,
+//    and therefore is an instance of the `Wrapper` type.
+//    Typically these are instances of a derived class
+//    implemented in Python. If we naively call `self->method()`,
+//    it would forward back into Python via the override
+//    handler in SerialiserWrapper, causing an infinite loop
+//    as the Python override calls the base class which calls
+//    the Python override again. We must therefore statically
+//    call `self->T::method()` instead.
+//
+// 2. The self argument was constructed in C++, and may well
+//    be a derived class of T that hasn't even been exposed
+//    to Python. Here we must call `self->method()` the usual
+//    way, so that we dispatch to the correct virtual override
+//    implemented in C++.
+//
+// All these functions therefore take the following form :
+//
+// ```
+// template<typename T, typename Wrapper>
+// foo( const T *self, ... )
+// {
+//     if( dynamic_cast<const Wrapper *>( self ) )
+//     {
+//         // Self was constructed in Python. Dispatch statically,
+//         // to allow Python overrides to safely call the base
+//         // class implementation.
+//         self->T::foo( ... );
+//     }
+//     else
+//     {
+//         // Self was constructed in C++. Dispatch
+//         // dynamically, so we call the virtual
+//         // override for the most derived class.
+//         self->foo( ... );
+//     }
+// }
+// ```
+
+template<typename T, typename Wrapper>
+boost::python::object moduleDependencies( const T *self, const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation )
+{
+	std::set<std::string> modules;
+	if( dynamic_cast<const Wrapper *>( self ) )
+	{
+		self->T::moduleDependencies( graphComponent, modules, serialisation );
+	}
+	else
+	{
+		self->moduleDependencies( graphComponent, modules, serialisation );
+	}
+
+	boost::python::list modulesList;
+	for( std::set<std::string>::const_iterator it = modules.begin(); it != modules.end(); ++it )
+	{
+		modulesList.append( *it );
+	}
+	PyObject *modulesSet = PySet_New( modulesList.ptr() );
+	return boost::python::object( boost::python::handle<>( modulesSet ) );
+}
+
+template<typename T, typename Wrapper>
+std::string constructor( const T *self, const Gaffer::GraphComponent *graphComponent, const Serialisation &serialisation )
+{
+	if( dynamic_cast<const Wrapper *>( self ) )
+	{
+		return self->T::constructor( graphComponent, serialisation );
+	}
+	else
+	{
+		return self->constructor( graphComponent, serialisation );
+	}
+}
+
+template<typename T, typename Wrapper>
+std::string postConstructor( const T *self, const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation )
+{
+	if( dynamic_cast<const Wrapper *>( self ) )
+	{
+		return self->T::postConstructor( graphComponent, identifier, serialisation );
+	}
+	else
+	{
+		return self->postConstructor( graphComponent, identifier, serialisation );
+	}
+}
+
+template<typename T, typename Wrapper>
+std::string postHierarchy( const T *self, const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation )
+{
+	if( dynamic_cast<const Wrapper *>( self ) )
+	{
+		return self->T::postHierarchy( graphComponent, identifier, serialisation );
+	}
+	else
+	{
+		return self->postHierarchy( graphComponent, identifier, serialisation );
+	}
+}
+
+template<typename T, typename Wrapper>
+std::string postScript( const T *self, const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation )
+{
+	if( dynamic_cast<const Wrapper *>( self ) )
+	{
+		return self->T::postScript( graphComponent, identifier, serialisation );
+	}
+	else
+	{
+		return self->postScript( graphComponent, identifier, serialisation );
+	}
+}
+
+template<typename T, typename Wrapper>
+bool childNeedsSerialisation( const T *self, const Gaffer::GraphComponent *child, const Serialisation &serialisation )
+{
+	if( dynamic_cast<const Wrapper *>( self ) )
+	{
+		return self->T::childNeedsSerialisation( child, serialisation );
+	}
+	else
+	{
+		return self->childNeedsSerialisation( child, serialisation );
+	}
+}
+
+template<typename T, typename Wrapper>
+bool childNeedsConstruction( const T *self, const Gaffer::GraphComponent *child, const Serialisation &serialisation )
+{
+	if( dynamic_cast<const Wrapper *>( self ) )
+	{
+		return self->T::childNeedsConstruction( child, serialisation );
+	}
+	else
+	{
+		return self->childNeedsConstruction( child, serialisation );
+	}
+}
+
+} // namespace Detail
+
+template<typename T, typename Base, typename TWrapper>
+SerialiserClass<T, Base, TWrapper>::SerialiserClass( const char *name )
+	:	IECorePython::RefCountedClass<T, Base, TWrapper>( name )
+{
+	this->def( boost::python::init<>() );
+	this->def( "moduleDependencies", &Detail::moduleDependencies<T, TWrapper> );
+	this->def( "constructor", &Detail::constructor<T, TWrapper> );
+	this->def( "postConstructor", &Detail::postConstructor<T, TWrapper> );
+	this->def( "postHierarchy", &Detail::postHierarchy<T, TWrapper> );
+	this->def( "postScript", &Detail::postScript<T, TWrapper> );
+	this->def( "childNeedsSerialisation", &Detail::childNeedsSerialisation<T, TWrapper> );
+	this->def( "childNeedsConstruction", &Detail::childNeedsConstruction<T, TWrapper> );
+}
+
+} // namespace GafferBindings
+
+#endif // GAFFERBINDINGS_SERIALISATIONBINDING_INL

--- a/python/GafferTest/NumericPlugTest.py
+++ b/python/GafferTest/NumericPlugTest.py
@@ -480,5 +480,22 @@ class NumericPlugTest( GafferTest.TestCase ) :
 		n["op1"].setValue( n["op1"].defaultValue() )
 		self.assertTrue( n["op1"].isSetToDefault() )
 
+	def testSerialiser( self ) :
+
+		p = Gaffer.IntPlug()
+		p.setValue( 10 )
+
+		s = Gaffer.Serialisation.acquireSerialiser( p )
+		# Behind the scenes the serialiser will actually be a
+		# ValuePlugSerialiser, but we haven't exposed that
+		# subclass to Python. Therefore we expect to get an
+		# instance of the base class here.
+		self.assertTrue( type( s ) is Gaffer.Serialisation.Serialiser )
+
+		# When we call a method of the serialiser, we should
+		# still be calling the most-derived override in C++.
+		ss = Gaffer.Serialisation( Gaffer.Node() )
+		self.assertIn( "setValue", s.postHierarchy( p, "x", ss ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/SerialisationTest.py
+++ b/python/GafferTest/SerialisationTest.py
@@ -58,11 +58,11 @@ class SerialisationTest( GafferTest.TestCase ) :
 
 	def testCustomSerialiser( self ) :
 
-		class CustomSerialiser( Gaffer.Serialisation.Serialiser ) :
+		class CustomSerialiser( Gaffer.NodeSerialiser ) :
 
 			def moduleDependencies( self, node, serialisation ) :
 
-				return ( "GafferTest", )
+				return { "GafferTest" } | Gaffer.NodeSerialiser.moduleDependencies( self, node, serialisation )
 
 			def constructor( self, node, serialisation ) :
 
@@ -70,33 +70,35 @@ class SerialisationTest( GafferTest.TestCase ) :
 
 			def postConstructor( self, node, identifier, serialisation ) :
 
-				return identifier + ".postConstructorWasHere = True\n"
+				result = Gaffer.NodeSerialiser.postConstructor( self, node, identifier, serialisation )
+				result += identifier + ".postConstructorWasHere = True\n"
+				return result
 
 			def postHierarchy( self, node, identifier, serialisation ) :
 
-				return identifier + ".postHierarchyWasHere = True\n"
+				result = Gaffer.NodeSerialiser.postHierarchy( self, node, identifier, serialisation )
+				result += identifier + ".postHierarchyWasHere = True\n"
+				return result
 
 			def postScript( self, node, identifier, serialisation ) :
 
-				return identifier + ".postScriptWasHere = True\n"
+				result = Gaffer.NodeSerialiser.postScript( self, node, identifier, serialisation )
+				result += identifier + ".postScriptWasHere = True\n"
+				return result
 
 			def childNeedsSerialisation( self, child, serialisation ) :
 
-				if isinstance( child, Gaffer.Node ) :
-					return child.getName() == "childNodeNeedingSerialisation"
-				elif isinstance( child, Gaffer.Plug ) :
-					return child.getFlags( Gaffer.Plug.Flags.Serialisable )
+				if isinstance( child, Gaffer.Node ) and child.getName() == "childNodeNeedingSerialisation" :
+					return True
 
-				return False
+				return Gaffer.NodeSerialiser.childNeedsSerialisation( self, child, serialisation )
 
 			def childNeedsConstruction( self, child, serialisation ) :
 
 				if isinstance( child, Gaffer.Node ) :
 					return False
-				elif isinstance( child, Gaffer.Plug ) :
-					return child.getFlags( Gaffer.Plug.Flags.Dynamic )
 
-				return False
+				return Gaffer.NodeSerialiser.childNeedsConstruction( self, child, serialisation )
 
 		customSerialiser = CustomSerialiser()
 		Gaffer.Serialisation.registerSerialiser( self.SerialisationTestNode, customSerialiser )

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -145,6 +145,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindSignal();
 	bindGraphComponent();
 	bindContext();
+	bindSerialisation();
 	bindNode();
 	bindPlug();
 	bindValuePlug();
@@ -168,7 +169,6 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindSubGraph();
 	bindAction();
 	bindArrayPlug();
-	bindSerialisation();
 	bindMetadata();
 	bindStringAlgo();
 	bindDot();

--- a/src/GafferModule/NodeBinding.cpp
+++ b/src/GafferModule/NodeBinding.cpp
@@ -42,6 +42,7 @@
 #include "GafferBindings/NodeBinding.h"
 #include "GafferBindings/DependencyNodeBinding.h"
 #include "GafferBindings/ComputeNodeBinding.h"
+#include "GafferBindings/SerialisationBinding.h"
 #include "GafferBindings/SignalBinding.h"
 #include "GafferBindings/MetadataBinding.h"
 
@@ -128,6 +129,9 @@ void GafferModule::bindNode()
 	}
 
 	Serialisation::registerSerialiser( Node::staticTypeId(), new NodeSerialiser() );
+
+	typedef SerialiserWrapper<NodeSerialiser> NodeSerialiserWrapper;
+	SerialiserClass<NodeSerialiser, Serialisation::Serialiser, NodeSerialiserWrapper>( "NodeSerialiser" );
 
 	typedef DependencyNodeWrapper<DependencyNode> DependencyNodeWrapper;
 	DependencyNodeClass<DependencyNode, DependencyNodeWrapper>();


### PR DESCRIPTION
- Allow Python method overrides to call the base class implementation
- Allow subclassing of NodeSerialiser

Because neither of these things were possible before, some downstream projects have had to resort to implementing serialisers which duplicate the logic of the NodeSerialiser. This adds unnecessary complexity and makes them prone to breaking when the details of Gaffer's own serialisers change.

The key change here is documented at some length in SerialisationBinding.inl. This is the first time we've successfully allowed subclassing in Python while still allowing some C++ subclasses to remain completely private. Hopefully we can now use this same technique to improve our wrapping of classes such as ComputeNode and Gadget.