### PR TITLE
PlugAdder : Fix crash when dragging from a plug without a nodule.

### DIFF
--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -250,6 +250,11 @@ bool PlugAdder::dragEnter( const DragDropEvent &event )
 
 	setHighlighted( true );
 
+	if( !event.sourceGadget )
+	{
+		return true;
+	}
+
 	V3f center = V3f( 0.0f ) * fullTransform();
 	center = center * event.sourceGadget->fullTransform().inverse();
 	const V3f tangent = edgeTangent( m_edge );


### PR DESCRIPTION
We still highlight the PlugAdder and accept the connection, which creates an auxilary connection since there are no nodules.