### PR TITLE
GLWidget : Support Qt5 builds of Houdini

### DIFF
--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -344,17 +344,16 @@ class _GLGraphicsView( QtWidgets.QGraphicsView ) :
 
 		import IECoreHoudini
 
-		# Prior to Houdini 14 we are running embedded on the hou.ui idle loop,
-		# so we needed to force the Houdini GL context to be current, and share
-		# it, similar to how we do this in Maya.
-		if hou.applicationVersion()[0] < 14 :
-			IECoreHoudini.makeMainGLContextCurrent()
-			return cls.__createHostedQGLWidget( format )
+		if hasattr( IECoreHoudini, "sharedGLWidget" ) :
+			# In Houdini 14 and 15, Qt is the native UI, and we can access
+			# Houdini's shared QGLWidget directly.
+			return QtOpenGL.QGLWidget( format, shareWidget = GafferUI._qtObject( IECoreHoudini.sharedGLWidget(), QtOpenGL.QGLWidget ) )
 
-		# In Houdini 14 and beyond, Qt is the native UI, and we can access
-		# Houdini's shared QGLWidget directly, provided we are using a recent
-		# Cortex version.
-		return QtOpenGL.QGLWidget( format, shareWidget = GafferUI._qtObject( IECoreHoudini.sharedGLWidget(), QtOpenGL.QGLWidget ) )
+		# While Qt is the native UI in Houdini 16.0, they have moved away
+		# from QGLWidgets for their Qt5 builds, so we need to force the
+		# Houdini GL context to be current, and share it.
+		IECoreHoudini.makeMainGLContextCurrent()
+		return cls.__createHostedQGLWidget( format )
 
 class _GLGraphicsScene( QtWidgets.QGraphicsScene ) :
 


### PR DESCRIPTION
Requires https://github.com/ImageEngine/cortex/pull/740.

I could alternatively use `hasattr( IECoreHoudini, "sharedGLWidget" )` rather than testing qtVersion and houdini version if we want to avoid the Cortex requirement.

Note this is a backport PR. I'll make one for master once we get this settled.