### PR TITLE
AuxiliaryConnections to Nodules

### DIFF
--- a/include/GafferUI/StandardStyle.h
+++ b/include/GafferUI/StandardStyle.h
@@ -91,6 +91,7 @@ class GAFFERUI_API StandardStyle : public Style
 		void renderConnection( const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const override;
 		Imath::V3f closestPointOnConnection( const Imath::V3f &p, const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent ) const override;
 		void renderAuxiliaryConnection( const Imath::Box2f &srcNodeFrame, const Imath::Box2f &dstNodeFrame, State state ) const override;
+		void renderAuxiliaryConnection( const Imath::V2f &srcPosition, const Imath::V2f &srcTangent, const Imath::V2f &dstPosition, const Imath::V2f &dstTangent, State state ) const override;
 
 		void renderBackdrop( const Imath::Box2f &box, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const override;
 

--- a/include/GafferUI/Style.h
+++ b/include/GafferUI/Style.h
@@ -132,6 +132,7 @@ class GAFFERUI_API Style : public IECore::RunTimeTyped
 		virtual void renderConnection( const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const = 0;
 		virtual Imath::V3f closestPointOnConnection( const Imath::V3f &p, const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent ) const = 0;
 		virtual void renderAuxiliaryConnection( const Imath::Box2f &srcNodeFrame, const Imath::Box2f &dstNodeFrame, State state ) const = 0;
+		virtual void renderAuxiliaryConnection( const Imath::V2f &srcPosition, const Imath::V2f &srcTangent, const Imath::V2f &dstPosition, const Imath::V2f &dstTangent, State state ) const = 0;
 
 		virtual void renderBackdrop( const Imath::Box2f &box, State state = NormalState, const Imath::Color3f *userColor = nullptr ) const = 0;
 		//@}

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -676,7 +676,6 @@ void StandardStyle::renderConnection( const Imath::V3f &srcPosition, const Imath
 
 	V3f dir = ( dstPosition - srcPosition ).normalized();
 
-
 	glUniform3fv( g_v0Parameter, 1, srcPosition.getValue() );
 	glUniform3fv( g_v1Parameter, 1, dstPosition.getValue() );
 	glUniform3fv( g_t0Parameter, 1, ( srcTangent != V3f( 0 ) ? srcTangent :  dir ).getValue() );
@@ -741,6 +740,34 @@ void StandardStyle::renderAuxiliaryConnection( const Imath::Box2f &srcNodeFrame,
 
 	glCallList( connectionDisplayList() );
 
+}
+
+void StandardStyle::renderAuxiliaryConnection( const Imath::V2f &srcPosition, const Imath::V2f &srcTangent, const Imath::V2f &dstPosition, const Imath::V2f &dstTangent, State state ) const
+{
+	glUniform1i( g_isCurveParameter, 1 );
+	glUniform1i( g_borderParameter, 0 );
+	glUniform1i( g_edgeAntiAliasingParameter, 1 );
+	glUniform1i( g_textureTypeParameter, 0 );
+	glUniform1f( g_lineWidthParameter, 0.2 );
+
+	glColor( colorForState( AuxiliaryConnectionColor, state ) );
+
+	const V3f p0( srcPosition.x, srcPosition.y, 0 );
+	const V3f p1( dstPosition.x, dstPosition.y, 0 );
+
+	V3f dir = ( V3f( dstPosition.x, dstPosition.y, 0 ) - V3f( srcPosition.x, srcPosition.y, 0 ) ).normalized();
+
+	const V3f t0 = srcTangent != V2f( 0 ) ? V3f( srcTangent.x, dstTangent.y, 0 ) : dir;
+	const V3f t1 = dstTangent != V2f( 0 ) ? V3f( dstTangent.x, dstTangent.y, 0 ) : -dir;
+
+	glUniform3fv( g_v0Parameter, 1, p0.getValue() );
+	glUniform3fv( g_v1Parameter, 1, p1.getValue() );
+	glUniform3fv( g_t0Parameter, 1, t0.getValue() );
+	glUniform3fv( g_t1Parameter, 1, t1.getValue() );
+
+	glUniform1f( g_endPointSizeParameter, g_endPointSize );
+
+	glCallList( connectionDisplayList() );
 }
 
 Imath::V3f StandardStyle::closestPointOnConnection( const Imath::V3f &p, const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent ) const


### PR DESCRIPTION
Hey John,

I took a stab at implementing what we had discussed about the `plugWithoutNodule->plugWithNodule` case. I think what I have now is very close to your suggestion. You had drawn an image using straight lines and instead I'm abusing @danieldresser's noodle rendering code to render the connection more similarly to what our other noodles look like. Integrates a little better with the look of the node gadgets and the other noodles?

![Foo](https://github.com/GafferHQ/gaffer/blob/b242a9e08bd04e04c6de97df9cf768399b461c89/auxConnection.png?raw=true)

I am unsure if you like what I've done in the first half of the commits here. Messing with the shader code was much easier when I was able to reload it. I've committed the changes I've made in that regard so that the next person's life gets a little easier. Are you opposed to 
- keeping the shaders in separate files and 
- exposing a way to trigger shader reloading?

Moving shaders and then modifying them is in separate commits to make reviewing easier.

The rest is hopefully fairly close? It's a little messy to convert everything from *3f to *2f and back only to pass the data through the Style API. We're moving towards a 2D API though, right? It's correct to have the Style accept 2D data even if that's creating some overhead in the caller and the callee?

Cheerio! :)

Matti.