### PR TITLE
ExpressionUI : Fix initial UI state

### DIFF
--- a/python/GafferUI/ExpressionUI.py
+++ b/python/GafferUI/ExpressionUI.py
@@ -265,10 +265,11 @@ class ExpressionWidget( GafferUI.Widget ) :
 
 	def __update( self ) :
 
-		expression = self.__node.getExpression()
+		expression, language = self.__node.getExpression()
 
-		self.__textWidget.setText( expression[0] )
-		self.__languageMenu.setText( IECore.CamelCase.toSpaced( expression[1] ) )
+		self.__textWidget.setText( expression )
+		self.__textWidget.setEnabled( bool( language ) )
+		self.__languageMenu.setText( IECore.CamelCase.toSpaced( language ) if language else "Choose..." )
 
 		self.__messageWidget.clear()
 		self.__messageWidget.setVisible( False )


### PR DESCRIPTION
When an Expression node is made directly via the Node menu, it starts out without either the expression or language set. If you entered an expression _before_ choosing the language, then this would do nothing, and then when choosing the language you'd lose the expression! I presume this hasn't been spotted until now because most people create expressions via the NodeEditor right click menu which sets the language upfront.

The fix applied here is simple : if the language isn't set, label the menu to prompt the user to set it, and don't enabled the expression text field until that is done.