### PR TITLE
Arnold Renderer : Added aaMinInteractiveSamples option

### DIFF
--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -59,6 +59,8 @@ def __samplingSummary( plug ) :
 	info = []
 	if plug["aaSamples"]["enabled"].getValue() :
 		info.append( "AA %d" % plug["aaSamples"]["value"].getValue() )
+	if plug["aaMinInteractiveSamples"]["enabled"].getValue() :
+		info.append( "Min AA %d" % plug["aaMinInteractiveSamples"]["value"].getValue() )
 	if plug["giDiffuseSamples"]["enabled"].getValue() :
 		info.append( "Diffuse %d" % plug["giDiffuseSamples"]["value"].getValue() )
 	if plug["giSpecularSamples"]["enabled"].getValue() :
@@ -288,6 +290,22 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Sampling",
 			"label", "AA Samples",
+
+		],
+
+		"options.aaMinInteractiveSamples" : [
+
+			"description",
+			"""
+			Controls the number of rays per pixel
+			for the first low quality pass of
+			interactive rendering.  -5 will start
+			with large squares, 1 will start one
+			sample for every pixel.
+			""",
+
+			"layout:section", "Sampling",
+			"label", "AA Min Interactive Samples",
 
 		],
 

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -57,6 +57,7 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	// Sampling parameters
 
 	options->addOptionalMember( "ai:AA_samples", new IECore::IntData( 3 ), "aaSamples", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:AA_min_interactive_samples", new IECore::IntData( -5 ), "aaMinInteractiveSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:GI_diffuse_samples", new IECore::IntData( 2 ), "giDiffuseSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:GI_specular_samples", new IECore::IntData( 2 ), "giSpecularSamples", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:GI_transmission_samples", new IECore::IntData( 2 ), "giTransmissionSamples", Gaffer::Plug::Default, false );

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -2059,6 +2059,12 @@ class InteractiveRenderController
 		InteractiveRenderController()
 		{
 			m_rendering = false;
+			m_minSamples = -5;
+		}
+
+		void setMinSamples( int minSamples )
+		{
+			m_minSamples = minSamples;
 		}
 
 		void setRendering( bool rendering )
@@ -2098,7 +2104,7 @@ class InteractiveRenderController
 		{
 			AtNode *options = AiUniverseGetOptions();
 			const int finalAASamples = AiNodeGetInt( options, g_aaSamplesArnoldString );
-			const int startAASamples = min( -5, finalAASamples );
+			const int startAASamples = min( m_minSamples, finalAASamples );
 
 			for( int aaSamples = startAASamples; aaSamples <= finalAASamples; ++aaSamples )
 			{
@@ -2123,6 +2129,7 @@ class InteractiveRenderController
 
 		std::thread m_thread;
 		tbb::atomic<bool> m_rendering;
+		int m_minSamples;
 
 };
 
@@ -2144,6 +2151,7 @@ IECore::InternedString g_logFileNameOptionName( "ai:log:filename" );
 IECore::InternedString g_logMaxWarningsOptionName( "ai:log:max_warnings" );
 IECore::InternedString g_pluginSearchPathOptionName( "ai:plugin_searchpath" );
 IECore::InternedString g_aaSeedOptionName( "ai:AA_seed" );
+IECore::InternedString g_aaMinInteractiveSamplesOptionName( "ai:AA_min_interactive_samples" );
 IECore::InternedString g_sampleMotionOptionName( "sampleMotion" );
 IECore::InternedString g_atmosphereOptionName( "ai:atmosphere" );
 IECore::InternedString g_backgroundOptionName( "ai:background" );
@@ -2252,6 +2260,18 @@ class ArnoldGlobals
 				{
 					return;
 				}
+			}
+			else if( name == g_aaMinInteractiveSamplesOptionName )
+			{
+				if( value == nullptr )
+				{
+					m_aaMinInteractiveSamples = boost::none;
+				}
+				else if( const IECore::IntData *d = reportedCast<const IECore::IntData>( value, "option", name ) )
+				{
+					m_aaMinInteractiveSamples = d->readable();
+				}
+				return;
 			}
 			else if( name == g_aaSeedOptionName )
 			{
@@ -2462,6 +2482,7 @@ class ArnoldGlobals
 					AiASSWrite( m_assFileName.c_str(), AI_NODE_ALL );
 					break;
 				case IECoreScenePreview::Renderer::Interactive :
+					m_interactiveRenderController.setMinSamples( m_aaMinInteractiveSamples.get_value_or( -5 ) );
 					m_interactiveRenderController.setRendering( true );
 					break;
 			}
@@ -2705,6 +2726,7 @@ class ArnoldGlobals
 		int m_consoleFlags;
 		boost::optional<int> m_frame;
 		boost::optional<int> m_aaSeed;
+		boost::optional<int> m_aaMinInteractiveSamples;
 		boost::optional<bool> m_sampleMotion;
 		ShaderCache *m_shaderCache;
 


### PR DESCRIPTION
This is a small change that makes it possible for interactive renders to feel better by an incredible amount in a lot of cases.

The only issues I see are what to call it ( this name is clear, but perhaps overly verbose? ), and what the default should be.  I've left the default at -5, but in most cases, using 1 will give a better user experience - I haven't checked with lookdev on a heavy asset, but I suspect that in the slowest cases, you're better off seeing some buckets update in a legible way with your latest changes, next to some old buckets, rather than seeing the whole screen flash blockiness.  ( The next usability step would be red and green outlines for stale / currently updating buckets ).