### PR TITLE
ScriptNodeBinding : Fix imath switch compatibility

### DIFF
--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -263,7 +263,8 @@ std::string replaceImath( const std::string &serialisation )
 		}
 	)
 	{
-		boost::replace_all( result, std::string( "IECore." ) + x, std::string( "imath." ) + x );
+		boost::replace_all( result, std::string( "IECore." ) + x + "(", std::string( "imath." ) + x + "(" );
+		boost::replace_all( result, std::string( "IECore." ) + x + ".", std::string( "imath." ) + x + "." );
 	}
 
 	return result;


### PR DESCRIPTION
When I tried to open a production scene, I found that this was replacing IECore.Color3fData with imath.Color3fData, because the first part matches.  I was able to fix this by matching the open brace as well - is there any case I'm missing where we need to replace IECore.Color3f during script load, and it isn't followed by an open brace?