### PR TITLE
Layout improvements (backport)

### DIFF
--- a/python/GafferUI/LayoutMenu.py
+++ b/python/GafferUI/LayoutMenu.py
@@ -118,7 +118,7 @@ def layoutMenuCallable( menu ) :
 
 	menuDefinition = IECore.MenuDefinition()
 
-	layoutNames = layouts.names()
+	layoutNames = sorted( layouts.names() )
 
 	if layoutNames :
 

--- a/python/GafferUI/Layouts.py
+++ b/python/GafferUI/Layouts.py
@@ -132,7 +132,7 @@ class Layouts( object ) :
 
 		# finally write out the layouts
 		for name in namesToWrite :
-			fileObject.write( "layouts.add( \"%s\", \"%s\" )\n\n" % ( name, self.__namedLayouts[name] ) )
+			fileObject.write( "layouts.add( {0}, {1} )\n\n".format( repr( name ), repr( self.__namedLayouts[name] ) ) )
 
 		# tidy up by deleting the temporary variable, keeping the namespace clean for
 		# subsequently executed config files.


### PR DESCRIPTION
We were seeing issues with saved layouts using Jabuka Editors, which included an argument with double quotes as part of a string value.

We had previously tried to handle this on the Jabuka side, by escaping the double quotes there, in the `__repr()__` definition for the Editor, and that initially seems to work.

However, when a new layout was saved in Gaffer, the previously stored layouts would be serialised directly from the values read from the `layouts.py` file, which had the escape stripped, thus breaking the config file.

The effect was that it worked fine as long as you had only one layout with the Jabuka Editor, and you only ever updated it. As soon as you added a new layout, or updated a different one, your config file would be broken.

I think that the best approach is to escape the double quotes on the Gaffer side, which sound reasonable to me, and no longer try to handle that in Jabuka.

I've also added a commit to sort the layout menu entries, so that they are alphabetical.
