### PR TITLE
GafferArnold : Support multiple outputs on OSL shaders

### DIFF
--- a/python/GafferArnoldTest/ArnoldVDBTest.py
+++ b/python/GafferArnoldTest/ArnoldVDBTest.py
@@ -69,12 +69,12 @@ class ArnoldVDBTest( GafferSceneTest.SceneTestCase ) :
 
 		# Invalid grid names should create errors.
 		v["grids"].setValue( "notAGrid" )
-		self.assertRaisesRegexp( RuntimeError, "has no grid named \"notAGrid\"", v["out"].bound, "/volume" )
+		self.assertRaisesRegexp( KeyError, "has no grid named \"notAGrid\"", v["out"].bound, "/volume" )
 
 		# As should invalid file names.
 		v["grids"].setValue( "density" )
 		v["fileName"].setValue( "notAFile.vdb" )
-		self.assertRaisesRegexp( RuntimeError, "No such file or directory", v["out"].bound, "/volume" )
+		self.assertRaisesRegexp( IOError, "No such file or directory", v["out"].bound, "/volume" )
 
 	def testStepSize( self ) :
 

--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -1987,7 +1987,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.option( "ai:aov_shader:test", IECore.ObjectVector( [
 			IECoreScene.Shader( "float_to_rgb", "ai:shader", { "__handle":IECore.StringData( "rgbSource" ) } ),
-			IECoreScene.Shader( "aov_write_rgb", "ai:shader", { "aov_input":IECore.StringData( "link:rgbSource.out" ) } ),
+			IECoreScene.Shader( "aov_write_rgb", "ai:shader", { "aov_input":IECore.StringData( "link:rgbSource" ) } ),
 		] ) )
 
 		self.assertEqual( self.__aovShaders().keys(), [ "aov_write_rgb" ] )

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -2480,8 +2480,6 @@ class ArnoldGlobals
 			{
 				case AI_ABORT :
 					throw IECore::Exception( "Render aborted" );
-				case AI_ERROR_WRONG_OUTPUT :
-					throw IECore::Exception( "Can't open output file" );
 				case AI_ERROR_NO_CAMERA :
 					throw IECore::Exception( "Camera not defined" );
 				case AI_ERROR_BAD_CAMERA :
@@ -2490,14 +2488,8 @@ class ArnoldGlobals
 					throw IECore::Exception( "Usage not validated" );
 				case AI_ERROR_RENDER_REGION :
 					throw IECore::Exception( "Invalid render region" );
-				case AI_ERROR_OUTPUT_EXISTS :
-					throw IECore::Exception( "Output file already exists" );
-				case AI_ERROR_OPENING_FILE :
-					throw IECore::Exception( "Can't open file" );
 				case AI_INTERRUPT :
 					throw IECore::Exception( "Render interrupted by user" );
-				case AI_ERROR_UNRENDERABLE_SCENEGRAPH :
-					throw IECore::Exception( "Unrenderable scenegraph" );
 				case AI_ERROR_NO_OUTPUTS :
 					throw IECore::Exception( "No outputs" );
 				case AI_ERROR :

--- a/src/GafferArnold/IECoreArnoldPreview/ShaderAlgo.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/ShaderAlgo.cpp
@@ -65,6 +65,7 @@ const AtString g_catmullRomArnoldString( "catmull-rom" );
 const AtString g_bezierArnoldString( "bezier" );
 const AtString g_bsplineArnoldString( "bspline" );
 const AtString g_linearArnoldString( "linear" );
+const AtString g_outputArnoldString( "output" );
 const AtString g_shaderNameArnoldString( "shadername" );
 
 template<typename Spline>
@@ -124,12 +125,56 @@ std::vector<AtNode *> convert( const IECore::ObjectVector *shaderNetwork, const 
 	ShaderMap shaderMap; // Maps handles to nodes
 
 	vector<AtNode *> result;
-	for( ObjectVector::MemberContainer::const_iterator it = shaderNetwork->members().begin(), eIt = shaderNetwork->members().end(); it != eIt; ++it )
+
+	// \todo - We need to hack around Arnold's lack of support for multiple outputs by outputting
+	// nodes multiple times if they have multiple outputs that are used.  For this reason, we first
+	// collect a list of all outputs that are used.  If in the future Arnold makes it possible to
+	// just use all the outputs of OSL nodes, we can remove all this.
+	std::vector<std::string> usedHandles;
+	for( const ObjectPtr &it : shaderNetwork->members() )
+	{
+		const Shader *shader = runTimeCast<const Shader>( it.get() );
+		if( !shader )
+		{
+			continue;
+		}
+		for( const auto &pIt : shader->parameters() )
+		{
+			if( const StringData *stringData = runTimeCast<const StringData>( pIt.second.get() ) )
+			{
+				const string &value = stringData->readable();
+				if( boost::starts_with( value, "link:" ) )
+				{
+					usedHandles.push_back( value.c_str() + 5 );
+				}
+			}
+			else if( const StringVectorData *stringVectorData = runTimeCast<const StringVectorData>( pIt.second.get() ) )
+			{
+				const vector<string> &values = stringVectorData->readable();
+
+				vector<AtNode *> nodes;
+				for( unsigned int i = 0; i < values.size(); i++ )
+				{
+					const string &value = values[i];
+					if( boost::starts_with( value, "link:" ) )
+					{
+						usedHandles.push_back( value.c_str() + 5 );
+					}
+				}
+			}
+		}
+	}
+
+	// Sort and remove duplicates using silly std syntax
+	std::sort( usedHandles.begin(), usedHandles.end() );
+	usedHandles.erase( std::unique( usedHandles.begin(), usedHandles.end() ), usedHandles.end() );
+
+	for( const ObjectPtr &it : shaderNetwork->members() )
 	{
 		const char *nodeType = nullptr;
 		const char *oslShaderName = nullptr;
 		const CompoundDataMap *parameters = nullptr;
-		if( const Shader *shader = runTimeCast<const Shader>( it->get() ) )
+		if( const Shader *shader = runTimeCast<const Shader>( it.get() ) )
 		{
 			if( boost::starts_with( shader->getType(), "osl:" ) )
 			{
@@ -160,141 +205,168 @@ std::vector<AtNode *> convert( const IECore::ObjectVector *shaderNetwork, const 
 			}
 		}
 
-		AtNode *node = AiNode( AtString( nodeType ), AtString( (namePrefix + nodeName).c_str() ), parentNode );
-
-		if( !node )
-		{
-			msg( Msg::Warning, "IECoreArnold::ShaderAlgo", boost::format( "Couldn't load shader \"%s\"" ) % nodeType );
-			continue;
-		}
-
-		if( handleData )
-		{
-			shaderMap[nodeName] = node;
-		}
-
+		std::vector<std::string> outputNames;
 		if( oslShaderName )
 		{
-			AiNodeSetStr( node, g_shaderNameArnoldString, AtString( oslShaderName ) );
+			// Find all outputs of this node which are used
+			std::string outputPrefix = nodeName + ".";
+			std::vector<std::string>::iterator matchStart = std::lower_bound(usedHandles.begin(), usedHandles.end(), outputPrefix );
+			while( matchStart != usedHandles.end() && boost::starts_with( *matchStart, outputPrefix ) )
+			{
+				outputNames.push_back( matchStart->c_str() + outputPrefix.length() );
+				matchStart++;
+			}
 		}
 
-		for( CompoundDataMap::const_iterator pIt = parameters->begin(), peIt = parameters->end(); pIt != peIt; ++pIt )
+		if( outputNames.size() == 0 )
 		{
-			std::string parameterNameString = pIt->first;
+			// Either not an OSL shader, or the final shader in the chain
+			outputNames.push_back( "" );
+		}
+
+		// Output the node repeatedly for each output, because Arnold does not currently support
+		// multiple outputs from a node
+		for( const std::string &outputName : outputNames )
+		{
+			AtNode *node = AiNode( AtString( nodeType ), AtString( (namePrefix + nodeName + outputName).c_str() ), parentNode );
+
+			if( !node )
+			{
+				msg( Msg::Warning, "IECoreArnold::ShaderAlgo", boost::format( "Couldn't load shader \"%s\"" ) % nodeType );
+				continue;
+			}
+
+			if( handleData )
+			{
+				if( outputName == "" )
+				{
+					shaderMap[nodeName] = node;
+				}
+				else
+				{
+					shaderMap[nodeName + "." + outputName] = node;
+				}
+			}
+
+			if( outputName != "" )
+			{
+				AiNodeDeclare( node, g_outputArnoldString, "constant STRING" );
+				AiNodeSetStr( node, g_outputArnoldString, AtString( outputName.c_str() ) );
+			}
+
 			if( oslShaderName )
 			{
-				parameterNameString = "param_" + parameterNameString;
+				AiNodeSetStr( node, g_shaderNameArnoldString, AtString( oslShaderName ) );
 			}
-			AtString parameterName( parameterNameString.c_str() );
 
-			if( const StringData *stringData = runTimeCast<const StringData>( pIt->second.get() ) )
+			for( const auto &pIt : *parameters )
 			{
-				const string &value = stringData->readable();
-				if( boost::starts_with( value, "link:" ) )
+				std::string parameterNameString = pIt.first;
+				if( oslShaderName )
 				{
-					string linkHandle = value.c_str() + 5;
-					const size_t dotIndex = linkHandle.find_first_of( '.' );
-					if( dotIndex != string::npos )
-					{
-						// Arnold does not support multiple outputs from OSL
-						// shaders, so we must strip off any suffix specifying
-						// a specific output.
-						linkHandle = linkHandle.substr( 0, dotIndex );
-					}
-
-					ShaderMap::const_iterator shaderIt = shaderMap.find( linkHandle );
-					if( shaderIt != shaderMap.end() )
-					{
-						const AtParamEntry *parmEntry = AiNodeEntryLookUpParameter( AiNodeGetNodeEntry( node ), parameterName );
-						// If the parameter is a node pointer, we just set it to the source node.
-						// Otherwise we assume that it is of a matching type to the output of the
-						// source node, and try to link it
-						if( AiParamGetType( parmEntry ) == AI_TYPE_NODE )
-						{
-							AiNodeSetPtr( node, parameterName, shaderIt->second );
-						}
-						else
-						{
-							AiNodeLinkOutput( shaderIt->second, "", node, parameterName );
-						}
-					}
-					else
-					{
-						msg( Msg::Warning, "IECoreArnold::ShaderAlgo", boost::format( "Couldn't find shader handle \"%s\" for linking" ) % linkHandle );
-					}
-					continue;
+					parameterNameString = "param_" + parameterNameString;
 				}
-				else if( pIt->first.value() == "__handle" )
-				{
-					continue;
-				}
-			}
-			else if( const StringVectorData *stringVectorData = runTimeCast<const StringVectorData>( pIt->second.get() ) )
-			{
-				const vector<string> &values = stringVectorData->readable();
+				AtString parameterName( parameterNameString.c_str() );
 
-				vector<AtNode *> nodes;
-				for( unsigned int i = 0; i < values.size(); i++ )
+				if( const StringData *stringData = runTimeCast<const StringData>( pIt.second.get() ) )
 				{
-					const string &value = values[i];
+					const string &value = stringData->readable();
 					if( boost::starts_with( value, "link:" ) )
 					{
-						const string linkHandle = value.c_str() + 5;
+						string linkHandle = value.c_str() + 5;
 						ShaderMap::const_iterator shaderIt = shaderMap.find( linkHandle );
 						if( shaderIt != shaderMap.end() )
 						{
-							nodes.push_back( shaderIt->second );
+							const AtParamEntry *parmEntry = AiNodeEntryLookUpParameter( AiNodeGetNodeEntry( node ), parameterName );
+							// If the parameter is a node pointer, we just set it to the source node.
+							// Otherwise we assume that it is of a matching type to the output of the
+							// source node, and try to link it
+							if( AiParamGetType( parmEntry ) == AI_TYPE_NODE )
+							{
+								AiNodeSetPtr( node, parameterName, shaderIt->second );
+							}
+							else
+							{
+								AiNodeLinkOutput( shaderIt->second, "", node, parameterName );
+							}
 						}
 						else
 						{
 							msg( Msg::Warning, "IECoreArnold::ShaderAlgo", boost::format( "Couldn't find shader handle \"%s\" for linking" ) % linkHandle );
 						}
+						continue;
 					}
-				}
-
-				if( nodes.size() )
-				{
-					const AtParamEntry *parmEntry = AiNodeEntryLookUpParameter( AiNodeGetNodeEntry( node ), parameterName );
-					if( AiParamGetType( parmEntry ) == AI_TYPE_ARRAY )
+					else if( pIt.first.value() == "__handle" )
 					{
-						const AtParamValue *def = AiParamGetDefault( parmEntry );
-
-						// Appropriately use SetArray vs LinkOutput depending on target type, as above
-						if( AiArrayGetType( def->ARRAY() ) == AI_TYPE_NODE )
-						{
-							AtArray *nodesArray = AiArrayConvert( nodes.size(), 1, AI_TYPE_POINTER, &nodes[0] );
-							AiNodeSetArray( node, parameterName, nodesArray );
-						}
-						else
-						{
-							for( unsigned int i = 0; i < nodes.size(); i++ )
-							{
-								AiNodeLinkOutput(
-									nodes[i], "", node,
-									( parameterNameString + "[" + boost::lexical_cast<string>( i ) + "]" ).c_str()
-								);
-							}
-						}
-
 						continue;
 					}
 				}
-			}
-			else if( const SplineffData *splineData = runTimeCast<const SplineffData>( pIt->second.get() ) )
-			{
-				setSplineParameter( node, parameterNameString, splineData->readable() );
-				continue;
-			}
-			else if( const SplinefColor3fData *splineData = runTimeCast<const SplinefColor3fData>( pIt->second.get() ) )
-			{
-				setSplineParameter( node, parameterNameString, splineData->readable() );
-				continue;
+				else if( const StringVectorData *stringVectorData = runTimeCast<const StringVectorData>( pIt.second.get() ) )
+				{
+					const vector<string> &values = stringVectorData->readable();
+
+					vector<AtNode *> nodes;
+					for( const string &value : values )
+					{
+						if( boost::starts_with( value, "link:" ) )
+						{
+							const string linkHandle = value.c_str() + 5;
+							ShaderMap::const_iterator shaderIt = shaderMap.find( linkHandle );
+							if( shaderIt != shaderMap.end() )
+							{
+								nodes.push_back( shaderIt->second );
+							}
+							else
+							{
+								msg( Msg::Warning, "IECoreArnold::ShaderAlgo", boost::format( "Couldn't find shader handle \"%s\" for linking" ) % linkHandle );
+							}
+						}
+					}
+
+					if( nodes.size() )
+					{
+						const AtParamEntry *parmEntry = AiNodeEntryLookUpParameter( AiNodeGetNodeEntry( node ), parameterName );
+						if( AiParamGetType( parmEntry ) == AI_TYPE_ARRAY )
+						{
+							const AtParamValue *def = AiParamGetDefault( parmEntry );
+
+							// Appropriately use SetArray vs LinkOutput depending on target type, as above
+							if( AiArrayGetType( def->ARRAY() ) == AI_TYPE_NODE )
+							{
+								AtArray *nodesArray = AiArrayConvert( nodes.size(), 1, AI_TYPE_POINTER, &nodes[0] );
+								AiNodeSetArray( node, parameterName, nodesArray );
+							}
+							else
+							{
+								for( unsigned int i = 0; i < nodes.size(); i++ )
+								{
+									AiNodeLinkOutput(
+										nodes[i], "", node,
+										( parameterNameString + "[" + boost::lexical_cast<string>( i ) + "]" ).c_str()
+									);
+								}
+							}
+
+							continue;
+						}
+					}
+				}
+				else if( const SplineffData *splineData = runTimeCast<const SplineffData>( pIt.second.get() ) )
+				{
+					setSplineParameter( node, parameterNameString, splineData->readable() );
+					continue;
+				}
+				else if( const SplinefColor3fData *splineData = runTimeCast<const SplinefColor3fData>( pIt.second.get() ) )
+				{
+					setSplineParameter( node, parameterNameString, splineData->readable() );
+					continue;
+				}
+
+				ParameterAlgo::setParameter( node, parameterName, pIt.second.get() );
 			}
 
-			ParameterAlgo::setParameter( node, parameterName, pIt->second.get() );
+			result.push_back( node );
 		}
-
-		result.push_back( node );
 	}
 
 	return result;


### PR DESCRIPTION
Arnold does not yet directly support multiple outputs from OSL shaders, but it does allow us to select which output we want, so we can output multiple copies of a shader node, one for each output used.

There are some pretty ugly looking for-loops in here - I wrote it without using C++11 so that it can be backported.  If this approach looks correct, I'll backport it, then update this to C++11.