### PR TITLE
Auxiliary Layouting

### DIFF
--- a/src/Gaffer/Set.cpp
+++ b/src/Gaffer/Set.cpp
@@ -56,3 +56,23 @@ Set::MemberSignal &Set::memberRemovedSignal()
 {
 	return m_memberRemovedSignal;
 }
+
+Set::Iterator Set::begin()
+{
+	return Iterator( this, 0 );
+}
+
+Set::Iterator Set::end()
+{
+	return Iterator( this, size() );
+}
+
+Set::ConstIterator Set::begin() const
+{
+	return ConstIterator( this, 0 );
+}
+
+Set::ConstIterator Set::end() const
+{
+	return ConstIterator( this, size() );
+}

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -412,8 +412,8 @@ IECoreGL::StatePtr disabledState()
 	return s;
 }
 
-// - p is connection destination ( guaranteed to be contained within the frame)
-// - v is the normalized direction of the connection ( towards the source )
+// - p is connection destination (guaranteed to be contained within the frame)
+// - v is the vector between source and destination
 V3f auxiliaryConnectionArrowPosition( const Box2f &dstNodeFrame, const V3f &p, const V3f &v )
 {
 	const float offset = 1.0;
@@ -438,7 +438,7 @@ V3f auxiliaryConnectionArrowPosition( const Box2f &dstNodeFrame, const V3f &p, c
 		yT = ( offset + p.y - dstNodeFrame.min.y ) / -v.y;
 	}
 
-	const float t = min( xT, yT );
+	const float t = min( min( xT, yT ), 1.0f );
 	return p + v * t;
 }
 
@@ -708,8 +708,8 @@ void StandardStyle::renderAuxiliaryConnection( const Imath::Box2f &srcNodeFrame,
 	// Offset the line slightly to one side. This separates connections
 	// going in opposite directions between the same two nodes.
 
-	p0 += normal * 0.5f;
-	p1 += normal * 0.5f;
+	p0 += normal * 0.3f;
+	p1 += normal * 0.3f;
 
 	// Draw the line
 
@@ -722,19 +722,19 @@ void StandardStyle::renderAuxiliaryConnection( const Imath::Box2f &srcNodeFrame,
 
 	// Draw a little arrow to indicate connection direction.
 
-	const V3f tip = auxiliaryConnectionArrowPosition( dstNodeFrame, p1, -direction );
+	const V3f tip = auxiliaryConnectionArrowPosition( dstNodeFrame, p1, p0 - p1 );
 
 	const V3f leftDir = -direction + normal * 0.5f;
 	const V3f rightDir = -direction - normal * 0.5f;
 
 	glUniform3fv( g_v0Parameter, 1, ( tip ).getValue() );
-	glUniform3fv( g_v1Parameter, 1, ( tip + leftDir ).getValue() );
+	glUniform3fv( g_v1Parameter, 1, ( tip + leftDir * 0.75 ).getValue() );
 	glUniform3fv( g_t0Parameter, 1, ( leftDir ).getValue() );
 	glUniform3fv( g_t1Parameter, 1, ( -leftDir ).getValue() );
 
 	glCallList( connectionDisplayList() );
 
-	glUniform3fv( g_v1Parameter, 1, ( tip + rightDir ).getValue() );
+	glUniform3fv( g_v1Parameter, 1, ( tip + rightDir * 0.75 ).getValue() );
 	glUniform3fv( g_t0Parameter, 1, ( rightDir ).getValue() );
 	glUniform3fv( g_t1Parameter, 1, ( -rightDir ).getValue() );
 


### PR DESCRIPTION
Hey John,

not done yet, but I thought I'd ask you about the general direction as to not waste too much time on this.

I've looked into setting up the general framework for getting these new node gadgets handled and added a first set of constraints that will place auxiliary nodes that affect a single node only.

The code in d616278 is just me poking at some new cpp stuff because it was fun to look into it and something I though was worth doing once. Just tell me to "Stop that nonsense!", if you feel like we don't want any of this :) I'm using it in a loop in 40cf4d8, but that's easy enough to change.

What I have here currently will create something like this:

![img](https://github.com/GafferHQ/gaffer/blob/4999608f37d6890ff3c03e132465369eb8a10c49/auxLayoutFoo.png?raw=true)

The arrows should be improved by https://github.com/GafferHQ/gaffer/pull/2476 in case we want to do something similar. What I've done so far is just a proof of concept I guess and we should discuss where to really put things. I kind of like the overlap of the nodes to show that they belong together, but if we want to do something like that there's obviously some stuff to sort out like respecting node size, nodules/plugAdders and draw order of nodes.

Thanks :)

Matti.

