### PR TITLE
Backup improvements

### DIFF
--- a/apps/gui/gui-1.py
+++ b/apps/gui/gui-1.py
@@ -37,6 +37,7 @@
 
 import os
 import gc
+import functools
 
 import IECore
 
@@ -85,14 +86,19 @@ class gui( Gaffer.Application ) :
 
 		GafferUI.ScriptWindow.connect( self.root() )
 
+		# Must start the event loop before adding scripts,
+		# because `FileMenu.addScript()` may launch
+		# interactive dialogues.
+		GafferUI.EventLoop.addIdleCallback( functools.partial( self.__addScripts, args ) )
+		GafferUI.EventLoop.mainEventLoop().start()
+
+		return 0
+
+	def __addScripts( self, args ) :
+
 		if len( args["scripts"] ) :
 			for fileName in args["scripts"] :
-				scriptNode = Gaffer.ScriptNode()
-				scriptNode["fileName"].setValue( os.path.abspath( fileName ) )
-				# \todo: Display load errors in a dialog, like in python/GafferUI/FileMenu.py
-				scriptNode.load( continueOnError = True )
-				self.root()["scripts"].addChild( scriptNode )
-				GafferUI.FileMenu.addRecentFile( self, fileName )
+				GafferUI.FileMenu.addScript( self.root(), fileName )
 		else :
 			scriptNode = Gaffer.ScriptNode()
 			Gaffer.NodeAlgo.applyUserDefaults( scriptNode )
@@ -103,9 +109,7 @@ class gui( Gaffer.Application ) :
 			primaryWindow = GafferUI.ScriptWindow.acquire( primaryScript )
 			primaryWindow.setFullScreen( True )
 
-		GafferUI.EventLoop.mainEventLoop().start()
-
-		return 0
+		return False # Remove idle callback
 
 	def __setupClipboardSync( self ) :
 

--- a/python/GafferUI/Backups.py
+++ b/python/GafferUI/Backups.py
@@ -106,7 +106,18 @@ class Backups( object ) :
 			if not os.path.isdir( dirName ) :
 				raise
 
+		# When overwriting a previous backup we need to
+		# temporarily make it writable. If this fails for
+		# any reason we leave it to `serialiseToFile()` to
+		# throw.
+		with IECore.IgnoredExceptions( OSError ) :
+			os.chmod( fileName, stat.S_IWUSR )
+
 		script.serialiseToFile( fileName )
+
+		# Protect file by making it read only.
+		os.chmod( fileName, stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH )
+
 		return fileName
 
 	# Returns the filenames of all the backups that have

--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -88,9 +88,13 @@ def open( menu ) :
 
 	__open( scriptWindow.scriptNode(), str( path ) )
 
-def __open( currentScript, fileName ) :
+## Opens a script and adds it to the application, as if the user
+# had done so via the File Open dialogue.
+def addScript( application, fileName ) :
 
-	application = currentScript.ancestor( Gaffer.ApplicationRoot )
+	return __addScript( application, fileName )
+
+def __addScript( application, fileName, dialogueParentWindow = None ) :
 
 	recoveryFileName = None
 	backups = GafferUI.Backups.acquire( application, createIfNecessary = False )
@@ -103,8 +107,9 @@ def __open( currentScript, fileName ) :
 				confirmLabel = "Open Backup",
 				cancelLabel = "Open",
 			)
-			if not dialogue.waitForConfirmation( parentWindow = GafferUI.ScriptWindow.acquire( currentScript ) ) :
+			if not dialogue.waitForConfirmation( parentWindow = dialogueParentWindow ) :
 				recoveryFileName = None
+			del dialogue
 
 	script = Gaffer.ScriptNode()
 	script["fileName"].setValue( recoveryFileName or fileName )
@@ -112,7 +117,7 @@ def __open( currentScript, fileName ) :
 	with GafferUI.ErrorDialogue.ErrorHandler(
 		title = "Errors Occurred During Loading",
 		closeLabel = "Oy vey",
-		parentWindow = GafferUI.ScriptWindow.acquire( currentScript )
+		parentWindow = dialogueParentWindow
 	) :
 		script.load( continueOnError = True )
 
@@ -126,12 +131,20 @@ def __open( currentScript, fileName ) :
 
 	addRecentFile( application, fileName )
 
+	return script
+
+def __open( currentScript, fileName ) :
+
+	application = currentScript.ancestor( Gaffer.ApplicationRoot )
+	currentWindow = GafferUI.ScriptWindow.acquire( currentScript )
+
+	script = __addScript( application, fileName, dialogueParentWindow = currentWindow )
+
 	removeCurrentScript = False
 	if not currentScript["fileName"].getValue() and not currentScript["unsavedChanges"].getValue() :
 		# the current script is empty - the user will think of the operation as loading
 		# the new script into the current window, rather than adding a new window. so make it
 		# look like that.
-		currentWindow = GafferUI.ScriptWindow.acquire( currentScript )
 		newWindow = GafferUI.ScriptWindow.acquire( script )
 		## \todo We probably want a way of querying and setting geometry in the public API
 		newWindow._qtWidget().restoreGeometry( currentWindow._qtWidget().saveGeometry() )

--- a/python/GafferUITest/BackupsTest.py
+++ b/python/GafferUITest/BackupsTest.py
@@ -188,6 +188,23 @@ class BackupsTest( GafferUITest.TestCase ) :
 		b.backup( s )
 		self.assertEqual( b.recoveryFile( s ), self.temporaryDirectory() + "/test-backup1.gfr" )
 
+	def testReadOnly( self ) :
+
+		a = Gaffer.ApplicationRoot()
+		b = GafferUI.Backups.acquire( a )
+		b.settings()["fileName"].setValue( self.temporaryDirectory() + "/backups/${script:name}.gfr" )
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
+
+		def assertBackupsReadOnly() :
+
+			for f in b.backups( s ) :
+				self.assertFalse( os.access( f, os.W_OK ) )
+
+		b.backup( s )
+		assertBackupsReadOnly()
+
 	def __assertFilesEqual( self, f1, f2 ) :
 
 		with open( f1 ) as f1 :

--- a/python/GafferUITest/BackupsTest.py
+++ b/python/GafferUITest/BackupsTest.py
@@ -138,6 +138,56 @@ class BackupsTest( GafferUITest.TestCase ) :
 
 			time.sleep( timeBetweenBackups )
 
+	def testRecoveryFile( self ) :
+
+		a = Gaffer.ApplicationRoot()
+
+		b = GafferUI.Backups.acquire( a )
+		b.settings()["fileName"].setValue( "${script:directory}/${script:name}-backup${backup:number}.gfr" )
+		b.settings()["files"].setValue( 3 )
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
+		self.assertEqual( b.recoveryFile( s ), None )
+
+		timeBetweenBackups = 0.01 if sys.platform != "darwin" else 1.1
+
+		# Script hasn't even been saved - always choose the recovery file
+
+		b.backup( s )
+		self.assertEqual( b.recoveryFile( s ), self.temporaryDirectory() + "/test-backup0.gfr" )
+
+		time.sleep( timeBetweenBackups )
+		b.backup( s )
+		self.assertEqual( b.recoveryFile( s ), self.temporaryDirectory() + "/test-backup1.gfr" )
+
+		# Script has been saved, and backups are identical. No need for recovery.
+
+		s.save()
+		self.assertEqual( b.recoveryFile( s ), None )
+
+		time.sleep( timeBetweenBackups )
+		b.backup( s )
+		self.assertEqual( b.recoveryFile( s ), None )
+
+		# Script has node added, but has not been saved. We need the recovery file.
+
+		time.sleep( timeBetweenBackups )
+		s.addChild( Gaffer.Node() )
+		b.backup( s )
+		self.assertEqual( b.recoveryFile( s ), self.temporaryDirectory() + "/test-backup0.gfr" )
+
+		# Script saved again, no need for recovery.
+
+		s.save()
+		self.assertEqual( b.recoveryFile( s ), None )
+
+		# Node deleted, script not saved. We need recovery.
+
+		del s["Node"]
+		b.backup( s )
+		self.assertEqual( b.recoveryFile( s ), self.temporaryDirectory() + "/test-backup1.gfr" )
+
 	def __assertFilesEqual( self, f1, f2 ) :
 
 		with open( f1 ) as f1 :


### PR DESCRIPTION
This refines the recently added backups feature :

- Don't offer to load a newer backup unless it differs meaningfully from the original file
- Prompt to load backups when loading via `gaffer script.gfr`

273c8e3 is kindof filthy, but it is important to the user experience. Other than exposing a mechanism to register custom ignore patterns I don't see any way of doing better, and I'd rather not expose the filth publicly this way unless we have a clear need for it. 
