### PR TITLE
Fix minor node graph drawing issues

### DIFF
--- a/include/GafferUI/StandardStyle.h
+++ b/include/GafferUI/StandardStyle.h
@@ -124,6 +124,7 @@ class GAFFERUI_API StandardStyle : public Style
 
 	private :
 
+		void renderConnectionInternal( const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent ) const;
 		static unsigned int connectionDisplayList();
 
 		static IECoreGL::Shader *shader();

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -770,7 +770,16 @@ void StandardStyle::renderAuxiliaryConnection( const Imath::V2f &srcPosition, co
 	const V3f p0( srcPosition.x, srcPosition.y, 0 );
 	const V3f p1( dstPosition.x, dstPosition.y, 0 );
 
-	V3f dir = ( V3f( dstPosition.x, dstPosition.y, 0 ) - V3f( srcPosition.x, srcPosition.y, 0 ) ).normalized();
+	// To guarantee straight curve sections we add an offset when computing
+	// tangents. This is done because the effective end point is slightly shifted
+	// due to how we draw curves at where they hit a node.
+	V2f adjustedDstPosition( dstPosition );
+	if( srcTangent == V2f( 0 ) && dstTangent != V2f( 0 ) )
+	{
+		adjustedDstPosition += dstTangent * g_endPointSize;
+	}
+
+	V3f dir = ( V3f( adjustedDstPosition.x, adjustedDstPosition.y, 0 ) - V3f( srcPosition.x, srcPosition.y, 0 ) ).normalized();
 
 	const V3f t0 = srcTangent != V2f( 0 ) ? V3f( srcTangent.x, dstTangent.y, 0 ) : dir;
 	const V3f t1 = dstTangent != V2f( 0 ) ? V3f( dstTangent.x, dstTangent.y, 0 ) : -dir;

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -674,7 +674,22 @@ void StandardStyle::renderConnection( const Imath::V3f &srcPosition, const Imath
 
 	glColor( colorForState( ConnectionColor, state, userColor ) );
 
-	V3f dir = ( dstPosition - srcPosition ).normalized();
+	// To guarantee straight curve sections we add an offset when computing
+	// tangents. This is done because the effective end point is slightly shifted
+	// due to how we draw curves at where they hit a node.
+	V3f adjustedSrcPosition( srcPosition );
+	if( dstTangent == V3f( 0 ) && srcTangent != V3f( 0 ) )
+	{
+		adjustedSrcPosition += srcTangent * g_endPointSize;
+	}
+
+	V3f adjustedDstPosition( dstPosition );
+	if( srcTangent == V3f( 0 ) && dstTangent != V3f( 0 ) )
+	{
+		adjustedDstPosition += dstTangent * g_endPointSize;
+	}
+
+	V3f dir = ( adjustedDstPosition - adjustedSrcPosition ).normalized();
 
 	glUniform3fv( g_v0Parameter, 1, srcPosition.getValue() );
 	glUniform3fv( g_v1Parameter, 1, dstPosition.getValue() );

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -666,44 +666,14 @@ void StandardStyle::renderNodule( float radius, State state, const Imath::Color3
 
 void StandardStyle::renderConnection( const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent, State state, const Imath::Color3f *userColor ) const
 {
-	glUniform1i( g_isCurveParameter, 1 );
-	glUniform1i( g_borderParameter, 0 );
-	glUniform1i( g_edgeAntiAliasingParameter, 1 );
-	glUniform1i( g_textureTypeParameter, 0 );
 	glUniform1f( g_lineWidthParameter, 0.5 );
-
 	glColor( colorForState( ConnectionColor, state, userColor ) );
 
-	// To guarantee straight curve sections we add an offset when computing
-	// tangents. This is done because the effective end point is slightly shifted
-	// due to how we draw curves at where they hit a node.
-	V3f adjustedSrcPosition( srcPosition );
-	if( dstTangent == V3f( 0 ) && srcTangent != V3f( 0 ) )
-	{
-		adjustedSrcPosition += srcTangent * g_endPointSize;
-	}
-
-	V3f adjustedDstPosition( dstPosition );
-	if( srcTangent == V3f( 0 ) && dstTangent != V3f( 0 ) )
-	{
-		adjustedDstPosition += dstTangent * g_endPointSize;
-	}
-
-	V3f dir = ( adjustedDstPosition - adjustedSrcPosition ).normalized();
-
-	glUniform3fv( g_v0Parameter, 1, srcPosition.getValue() );
-	glUniform3fv( g_v1Parameter, 1, dstPosition.getValue() );
-	glUniform3fv( g_t0Parameter, 1, ( srcTangent != V3f( 0 ) ? srcTangent :  dir ).getValue() );
-	glUniform3fv( g_t1Parameter, 1, ( dstTangent != V3f( 0 ) ? dstTangent : -dir ).getValue() );
-
-	glUniform1f( g_endPointSizeParameter, g_endPointSize );
-
-	glCallList( connectionDisplayList() );
+	renderConnectionInternal( srcPosition, srcTangent, dstPosition, dstTangent );
 }
 
 void StandardStyle::renderAuxiliaryConnection( const Imath::Box2f &srcNodeFrame, const Imath::Box2f &dstNodeFrame, State state ) const
 {
-
 	glUniform1i( g_isCurveParameter, 1 );
 	glUniform1i( g_borderParameter, 0 );
 	glUniform1i( g_edgeAntiAliasingParameter, 1 );
@@ -759,39 +729,15 @@ void StandardStyle::renderAuxiliaryConnection( const Imath::Box2f &srcNodeFrame,
 
 void StandardStyle::renderAuxiliaryConnection( const Imath::V2f &srcPosition, const Imath::V2f &srcTangent, const Imath::V2f &dstPosition, const Imath::V2f &dstTangent, State state ) const
 {
-	glUniform1i( g_isCurveParameter, 1 );
-	glUniform1i( g_borderParameter, 0 );
-	glUniform1i( g_edgeAntiAliasingParameter, 1 );
-	glUniform1i( g_textureTypeParameter, 0 );
 	glUniform1f( g_lineWidthParameter, 0.2 );
-
 	glColor( colorForState( AuxiliaryConnectionColor, state ) );
 
 	const V3f p0( srcPosition.x, srcPosition.y, 0 );
 	const V3f p1( dstPosition.x, dstPosition.y, 0 );
+	const V3f t0( srcTangent.x, srcTangent.y, 0 );
+	const V3f t1( dstTangent.x, dstTangent.y, 0 );
 
-	// To guarantee straight curve sections we add an offset when computing
-	// tangents. This is done because the effective end point is slightly shifted
-	// due to how we draw curves at where they hit a node.
-	V2f adjustedDstPosition( dstPosition );
-	if( srcTangent == V2f( 0 ) && dstTangent != V2f( 0 ) )
-	{
-		adjustedDstPosition += dstTangent * g_endPointSize;
-	}
-
-	V3f dir = ( V3f( adjustedDstPosition.x, adjustedDstPosition.y, 0 ) - V3f( srcPosition.x, srcPosition.y, 0 ) ).normalized();
-
-	const V3f t0 = srcTangent != V2f( 0 ) ? V3f( srcTangent.x, dstTangent.y, 0 ) : dir;
-	const V3f t1 = dstTangent != V2f( 0 ) ? V3f( dstTangent.x, dstTangent.y, 0 ) : -dir;
-
-	glUniform3fv( g_v0Parameter, 1, p0.getValue() );
-	glUniform3fv( g_v1Parameter, 1, p1.getValue() );
-	glUniform3fv( g_t0Parameter, 1, t0.getValue() );
-	glUniform3fv( g_t1Parameter, 1, t1.getValue() );
-
-	glUniform1f( g_endPointSizeParameter, g_endPointSize );
-
-	glCallList( connectionDisplayList() );
+	renderConnectionInternal( p0, t0, p1, t1 );
 }
 
 Imath::V3f StandardStyle::closestPointOnConnection( const Imath::V3f &p, const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent ) const
@@ -1057,6 +1003,40 @@ void StandardStyle::setFontScale( TextType textType, float scale )
 float StandardStyle::getFontScale( TextType textType ) const
 {
 	return m_fontScales[textType];
+}
+
+void StandardStyle::renderConnectionInternal( const Imath::V3f &srcPosition, const Imath::V3f &srcTangent, const Imath::V3f &dstPosition, const Imath::V3f &dstTangent ) const
+{
+	glUniform1i( g_isCurveParameter, 1 );
+	glUniform1i( g_borderParameter, 0 );
+	glUniform1i( g_edgeAntiAliasingParameter, 1 );
+	glUniform1i( g_textureTypeParameter, 0 );
+
+	// To guarantee straight curve sections we add an offset when computing
+	// tangents. This is done because the effective end point is slightly shifted
+	// due to how we draw curves at where they hit a node.
+	V3f adjustedSrcPosition( srcPosition );
+	if( dstTangent == V3f( 0 ) && srcTangent != V3f( 0 ) )
+	{
+		adjustedSrcPosition += srcTangent * g_endPointSize;
+	}
+
+	V3f adjustedDstPosition( dstPosition );
+	if( srcTangent == V3f( 0 ) && dstTangent != V3f( 0 ) )
+	{
+		adjustedDstPosition += dstTangent * g_endPointSize;
+	}
+
+	V3f dir = ( adjustedDstPosition - adjustedSrcPosition ).normalized();
+
+	glUniform3fv( g_v0Parameter, 1, srcPosition.getValue() );
+	glUniform3fv( g_v1Parameter, 1, dstPosition.getValue() );
+	glUniform3fv( g_t0Parameter, 1, ( srcTangent != V3f( 0 ) ? srcTangent :  dir ).getValue() );
+	glUniform3fv( g_t1Parameter, 1, ( dstTangent != V3f( 0 ) ? dstTangent : -dir ).getValue() );
+
+	glUniform1f( g_endPointSizeParameter, g_endPointSize );
+
+	glCallList( connectionDisplayList() );
 }
 
 unsigned int StandardStyle::connectionDisplayList()

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -1225,6 +1225,11 @@ static const std::string &fragmentSource()
 		"		OUTCOLOR.a *= ieFilteredPulse( 0.2, 0.8, gl_TexCoord[0].x );"
 		"	}"
 
+		"	if( OUTCOLOR.a == 0.0 )"
+		"	{"
+		"		discard;"
+		"	}"
+
 		/// \todo Deal with all colourspace nonsense outside of the shader. Ideally the shader would accept only linear"
 		/// textures and output only linear data."
 


### PR DESCRIPTION
Hey John,

in https://github.com/GafferHQ/gaffer/pull/2497 we had identified two little issues that were not exclusive to our new auxiliary gadgets:

- Nodes get selected even though we click into space not covered by them (but covered by their bounding box).
- (Auxiliary) Connections have tangents that are slightly off when one of the given tangents is invalid (during a drag for example).

I've tried to fix both of them in the code I'm putting up here.

Discarding fragments like you suggested seems to do the trick for the first issue. The second is solved by adding a little offset.

Cheerio :)

Matti.