### PR TITLE
GafferArnold : Support multiple outputs on OSL shaders ( backport )

### DIFF
--- a/python/GafferArnoldTest/ArnoldVDBTest.py
+++ b/python/GafferArnoldTest/ArnoldVDBTest.py
@@ -67,12 +67,12 @@ class ArnoldVDBTest( GafferSceneTest.SceneTestCase ) :
 
 		# Invalid grid names should create errors.
 		v["grids"].setValue( "notAGrid" )
-		self.assertRaisesRegexp( RuntimeError, "has no grid named \"notAGrid\"", v["out"].bound, "/volume" )
+		self.assertRaisesRegexp( KeyError, "has no grid named \"notAGrid\"", v["out"].bound, "/volume" )
 
 		# As should invalid file names.
 		v["grids"].setValue( "density" )
 		v["fileName"].setValue( "notAFile.vdb" )
-		self.assertRaisesRegexp( RuntimeError, "No such file or directory", v["out"].bound, "/volume" )
+		self.assertRaisesRegexp( IOError, "No such file or directory", v["out"].bound, "/volume" )
 
 	def testStepSize( self ) :
 

--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -1362,6 +1362,71 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( noise ) ), "osl" )
 			self.assertEqual( arnold.AiNodeGetStr( noise, "shadername" ), "Pattern/Noise" )
 
+	def testOSLMultipleOutputs( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			self.temporaryDirectory() + "/test.ass"
+		)
+
+		network = IECore.ObjectVector( [
+			IECoreScene.Shader(
+				"Utility/SplitColor",
+				"osl:shader",
+				{
+					"c" : imath.Color3f( 0.1, 0.2, 0.3 ),
+					"__handle" : "splitHandle"
+				}
+			),
+			IECoreScene.Shader(
+				"Utility/BuildColor",
+				"osl:shader",
+				{
+					"r" : "link:splitHandle.r",
+					"g" : "link:splitHandle.g",
+					"b" : "link:splitHandle.b",
+				}
+			)
+		] )
+
+		r.object(
+			"testPlane",
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
+			r.attributes( IECore.CompoundObject( { "ai:surface" : network } ) )
+		)
+
+		r.render()
+		del r
+
+		with IECoreArnold.UniverseBlock( writable = True ) :
+			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+
+			n = arnold.AiNodeLookUpByName( "testPlane" )
+
+			build = arnold.AtNode.from_address( arnold.AiNodeGetPtr( n, "shader" ) )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( build ) ), "osl" )
+			self.assertEqual( arnold.AiNodeGetStr( build, "shadername" ), "Utility/BuildColor" )
+
+			splitR = arnold.AiNodeGetLink( build, "param_r" )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( splitR ) ), "osl" )
+			self.assertEqual( arnold.AiNodeGetStr( splitR, "output" ), "r" )
+			self.assertEqual( arnold.AiNodeGetStr( splitR, "shadername" ), "Utility/SplitColor" )
+			self.assertEqual( arnold.AiNodeGetRGB( splitR, "param_c" ),  arnold.AtRGB( 0.1, 0.2, 0.3 ))
+
+			splitG = arnold.AiNodeGetLink( build, "param_g" )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( splitG ) ), "osl" )
+			self.assertEqual( arnold.AiNodeGetStr( splitG, "output" ), "g" )
+			self.assertEqual( arnold.AiNodeGetStr( splitG, "shadername" ), "Utility/SplitColor" )
+			self.assertEqual( arnold.AiNodeGetRGB( splitG, "param_c" ),  arnold.AtRGB( 0.1, 0.2, 0.3 ))
+
+			splitB = arnold.AiNodeGetLink( build, "param_b" )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( splitB ) ), "osl" )
+			self.assertEqual( arnold.AiNodeGetStr( splitB, "output" ), "b" )
+			self.assertEqual( arnold.AiNodeGetStr( splitB, "shadername" ), "Utility/SplitColor" )
+			self.assertEqual( arnold.AiNodeGetRGB( splitB, "param_c" ),  arnold.AtRGB( 0.1, 0.2, 0.3 ))
+
+
 	def testTraceSets( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(

--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -1927,7 +1927,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.option( "ai:aov_shader:test", IECore.ObjectVector( [
 			IECore.Shader( "float_to_rgb", "ai:shader", { "__handle":IECore.StringData( "rgbSource" ) } ),
-			IECore.Shader( "aov_write_rgb", "ai:shader", { "aov_input":IECore.StringData( "link:rgbSource.out" ) } ),
+			IECore.Shader( "aov_write_rgb", "ai:shader", { "aov_input":IECore.StringData( "link:rgbSource" ) } ),
 		] ) )
 
 		self.assertEqual( self.__aovShaders().keys(), [ "aov_write_rgb" ] )

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -2021,8 +2021,6 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 			{
 				case AI_ABORT :
 					throw IECore::Exception( "Render aborted" );
-				case AI_ERROR_WRONG_OUTPUT :
-					throw IECore::Exception( "Can't open output file" );
 				case AI_ERROR_NO_CAMERA :
 					throw IECore::Exception( "Camera not defined" );
 				case AI_ERROR_BAD_CAMERA :
@@ -2031,14 +2029,8 @@ class ArnoldRenderer : public IECoreScenePreview::Renderer
 					throw IECore::Exception( "Usage not validated" );
 				case AI_ERROR_RENDER_REGION :
 					throw IECore::Exception( "Invalid render region" );
-				case AI_ERROR_OUTPUT_EXISTS :
-					throw IECore::Exception( "Output file already exists" );
-				case AI_ERROR_OPENING_FILE :
-					throw IECore::Exception( "Can't open file" );
 				case AI_INTERRUPT :
 					throw IECore::Exception( "Render interrupted by user" );
-				case AI_ERROR_UNRENDERABLE_SCENEGRAPH :
-					throw IECore::Exception( "Unrenderable scenegraph" );
 				case AI_ERROR_NO_OUTPUTS :
 					throw IECore::Exception( "No outputs" );
 				case AI_ERROR :

--- a/src/GafferArnold/IECoreArnoldPreview/ShaderAlgo.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/ShaderAlgo.cpp
@@ -57,6 +57,8 @@ using namespace IECoreArnold;
 namespace
 {
 
+const IECore::InternedString g_handleString( "__handle" );
+
 template<typename Spline>
 void setSplineParameter( AtNode *node, const InternedString &name, const Spline &spline )
 {
@@ -151,11 +153,29 @@ std::vector<AtNode *> convert( const IECore::ObjectVector *shaderNetwork, const 
 			continue;
 		}
 
-		AtNode *node = AiNode( nodeType );
+		std::string nodeName = boost::lexical_cast<string>( result.size() );
+		CompoundDataMap::const_iterator handleIt = parameters->find( g_handleString );
+		const StringData *handleData = NULL;
+		if( handleIt != parameters->end() )
+		{
+			handleData = runTimeCast<const StringData>( handleIt->second.get() );
+			if( handleData )
+			{
+				nodeName = handleData->readable();
+			}
+		}
+
+		AtNode *node = AiNode( nodeType, AtString( (namePrefix + nodeName).c_str() ) );
+
 		if( !node )
 		{
 			msg( Msg::Warning, "IECoreArnold::ShaderAlgo", boost::format( "Couldn't load shader \"%s\"" ) % nodeType );
 			continue;
+		}
+
+		if( handleData )
+		{
+			shaderMap[nodeName] = node;
 		}
 
 		if( oslShaderName )
@@ -163,7 +183,6 @@ std::vector<AtNode *> convert( const IECore::ObjectVector *shaderNetwork, const 
 			AiNodeSetStr( node, "shadername", oslShaderName );
 		}
 
-		std::string nodeName = boost::lexical_cast<string>( result.size() );
 		for( CompoundDataMap::const_iterator pIt = parameters->begin(), peIt = parameters->end(); pIt != peIt; ++pIt )
 		{
 			std::string parameterName = pIt->first;
@@ -211,8 +230,6 @@ std::vector<AtNode *> convert( const IECore::ObjectVector *shaderNetwork, const 
 				}
 				else if( pIt->first.value() == "__handle" )
 				{
-					shaderMap[value] = node;
-					nodeName = value;
 					continue;
 				}
 			}
@@ -281,8 +298,6 @@ std::vector<AtNode *> convert( const IECore::ObjectVector *shaderNetwork, const 
 			ParameterAlgo::setParameter( node, parameterName.c_str(), pIt->second.get() );
 		}
 
-		nodeName = namePrefix + nodeName;
-		AiNodeSetStr( node, "name", nodeName.c_str() );
 		result.push_back( node );
 	}
 


### PR DESCRIPTION
This was a pretty ugly and fairly manual backport.  While trying to figure out if I could get it to merge nicely, I backported a tiny piece of the commit "IECoreArnoldPreview : Node creation should pass nodeName and parent".  In retrospect, this may have been unnecessary, but it seems to have come out OK.  It compiles now and the tests all pass so hopefully I haven't broken anything.