### PR TITLE
ScriptNode : Deter usage of `framePlug()`

### DIFF
--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -244,7 +244,8 @@ class GAFFER_API ScriptNode : public Node
 		/// > user, so that the "current frame" is saved within the
 		/// > script file. To perform a computation at a particular time,
 		/// > create your own context rather than change the value of
-		/// > this plug.
+		/// > this plug. Likewise, don't refer to this plug from an
+		/// > expression - always use `context.getFrame()` instead.
 		FloatPlug *framePlug();
 		const FloatPlug *framePlug() const;
 		/// Drives the framesPerSecond variable in the context.

--- a/python/GafferUI/ScriptNodeUI.py
+++ b/python/GafferUI/ScriptNodeUI.py
@@ -48,6 +48,8 @@ Gaffer.Metadata.registerNode(
 	saved to disk as a ".gfr" file and reloaded.
 	""",
 
+	"layout:visibilityActivator:hidden", lambda node : False,
+
 	plugs = {
 
 		"fileName" : (
@@ -125,7 +127,13 @@ Gaffer.Metadata.registerNode(
 			> 	c.setFrame( f )
 			>   ...
 			> ```
+			>
+			> Likewise, you should never refer to this plug from
+			> an expression. Always retrieve the frame with
+			> `context.getFrame()` instead.
 			""",
+
+			"layout:visibilityActivator", "hidden",
 
 		),
 


### PR DESCRIPTION
Document that not only should it not be _written_ to, but it also should not be _read from_. Also hide it from the UI so it takes some determined digging to find it.