### PR TITLE
New OSLObject Interface

### DIFF
--- a/include/GafferOSL/OSLObject.h
+++ b/include/GafferOSL/OSLObject.h
@@ -37,8 +37,11 @@
 #ifndef GAFFEROSL_OSLOBJECT_H
 #define GAFFEROSL_OSLOBJECT_H
 
+#include "GafferOSL/ClosurePlug.h"
 #include "GafferOSL/Export.h"
+#include "GafferOSL/OSLCode.h"
 #include "GafferOSL/TypeIds.h"
+
 
 #include "GafferScene/SceneElementProcessor.h"
 #include "GafferScene/ShaderPlug.h"
@@ -59,17 +62,15 @@ class GAFFEROSL_API OSLObject : public GafferScene::SceneElementProcessor
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferOSL::OSLObject, OSLObjectTypeId, GafferScene::SceneElementProcessor );
 
-		GafferScene::ShaderPlug *shaderPlug();
-		const GafferScene::ShaderPlug *shaderPlug() const;
-
 		Gaffer::IntPlug *interpolationPlug();
 		const Gaffer::IntPlug *interpolationPlug() const;
+
+		Gaffer::Plug *primitiveVariablesPlug();
+		const Gaffer::Plug *primitiveVariablesPlug() const;
 
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
-
-		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
 
 		bool processesBound() const override;
 		void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
@@ -84,11 +85,22 @@ class GAFFEROSL_API OSLObject : public GafferScene::SceneElementProcessor
 
 	private :
 
+		GafferScene::ShaderPlug *shaderPlug();
+		const GafferScene::ShaderPlug *shaderPlug() const;
+
 		GafferScene::ScenePlug *resampledInPlug();
 		const GafferScene::ScenePlug *resampledInPlug() const;
 
 		Gaffer::StringPlug *resampledNamesPlug();
 		const Gaffer::StringPlug *resampledNamesPlug() const;
+
+		GafferOSL::OSLCode *outputCombineOSLCode();
+		const GafferOSL::OSLCode *outputCombineOSLCode() const;
+
+		void primitiveVariableAdded( const Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
+		void primitiveVariableRemoved( const Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
+
+		void updatePrimitiveVariables();
 
 		static size_t g_firstPlugIndex;
 

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -723,6 +723,43 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( n["a"], "test" ), "exact" )
 		self.assertEqual( Gaffer.Metadata.value( n["b"], "test" ), "wildcard" )
 
+	def testPreferSpecificWildcards( self ) :
+
+		class MetadataTestNodeE( Gaffer.Node ) :
+
+			def __init__( self, name = "MetadataTestNodeE" ) :
+
+				Gaffer.Node.__init__( self, name )
+
+				self["a"] = Gaffer.Plug()
+				self["a"]["c"] = Gaffer.IntPlug()
+				self["b"] = Gaffer.Plug()
+				self["b"]["d"] = Gaffer.IntPlug()
+
+		IECore.registerRunTimeTyped( MetadataTestNodeE )
+
+		Gaffer.Metadata.registerNode(
+
+			MetadataTestNodeE,
+
+			plugs = {
+				"*" : [
+					"test", "general",
+				],
+				"*.c" : [
+					"test", "specific",
+				],
+			}
+
+		)
+
+		n = MetadataTestNodeE()
+
+		self.assertEqual( Gaffer.Metadata.value( n["a"], "test" ), "general" )
+		self.assertEqual( Gaffer.Metadata.value( n["a"]["c"], "test" ), "specific" )
+		self.assertEqual( Gaffer.Metadata.value( n["b"], "test" ), "general" )
+		self.assertEqual( Gaffer.Metadata.value( n["b"]["d"], "test" ), "general" )
+
 	def testNoSerialiseAfterUndo( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/shaders/ObjectProcessing/OutObject.osl
+++ b/shaders/ObjectProcessing/OutObject.osl
@@ -34,7 +34,7 @@
 //  
 //////////////////////////////////////////////////////////////////////////
 
-surface OutObject
+shader OutObject
 (
 	closure color in0 = 0,
 	closure color in1 = 0,
@@ -51,10 +51,11 @@ surface OutObject
 	closure color in12 = 0,
 	closure color in13 = 0,
 	closure color in14 = 0,
-	closure color in15 = 0
+	closure color in15 = 0,
+	output closure color out = 0
 )
 {
-	Ci =
+	out =
 		in0 +
 		in1 +
 		in2 +

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -107,7 +107,25 @@ struct NodeMetadata
 		>
 	> PlugValues;
 
-	typedef map<StringAlgo::MatchPattern, PlugValues> PlugPathsToValues;
+	struct MatchPatternComparator
+	{
+		bool operator()(const StringAlgo::MatchPattern& a, const StringAlgo::MatchPattern& b) const
+		{
+			if( a.length() != b.length() )
+			{
+				// Sort longer match pattern first, so that if we search from the beginning of
+				// the list for wildcard matches, we will match a more specific pattern before
+				// a more general one
+				return a.length() > b.length();
+			}
+			else
+			{
+				return a < b;
+			}
+		}
+	};
+
+	typedef map<StringAlgo::MatchPattern, PlugValues, MatchPatternComparator > PlugPathsToValues;
 
 	NodeValues nodeValues;
 	PlugPathsToValues plugPathsToValues;

--- a/startup/GafferOSL/oslObjectCompatibility.py
+++ b/startup/GafferOSL/oslObjectCompatibility.py
@@ -1,0 +1,64 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferOSL
+
+class __DummyShaderPlug:
+	def __init__( self, node ):
+		self._node = node
+
+	def setInput( self, plug ):
+		if not isinstance( plug.node(), GafferOSL.OSLShader ) or not plug.node()["name"].getValue() == "ObjectProcessing/OutObject":
+			raise RuntimeError( "Failed to load deprecated connection from " + plug.fullName() + " to " + self._node.fullName() )
+
+		closurePlug = GafferOSL.ClosurePlug( "closure" )
+		self._node["primitiveVariables"].addChild( closurePlug )
+		closurePlug.setInput( plug.node()["out"]["out"] )
+
+
+# Provides backwards compatibility by allowing access to "multiInput" plug
+# using its old name of "shader".
+def __oslObjectGetItem( originalGetItem ) :
+
+	def getItem( self, key ) :
+		if key == "shader":
+			return __DummyShaderPlug( self )
+		else:
+			return originalGetItem( self, key )
+
+	return getItem
+
+GafferOSL.OSLObject.__getitem__ = __oslObjectGetItem( GafferOSL.OSLObject.__getitem__ )


### PR DESCRIPTION
This is still somewhat experimental, but after chatting about it a bit, it's probably time to get you to look through some code.

Known incomplete:
* Need to add PlugAdder that accepts drags to add primVars ( offering selection of matching options, for example dragging on a color plug should offer adding Cs ( if not yet present ) or customColor ).  Would be really nice if this could be done in Python, since it should share code with _PrimitiveVariablesFooter, but I guess currently PlugAdders must be C++?
* Need to update tests
* Need to figure out correct name for input closure plugs ( In our email thread, we had somehow decided on "custom", which seems like an incredibly vague name ).  I've currently just gone with "closure".

I'm pretty happy with how the interface is coming together.  The remaining hard part is dealing with backwards compatibility.  I had been thinking I just had to support closure connections, but the old "shader" input is a surface shader, not a closure.  This is more of a problem, since we don't have any way to merge surface shaders, so it's harder to merge old and new.

At the moment, I've thrown in some untested code where I switch the output type of OutObject to be a closure, and have a compatibility config to connect it to a new closure connection ... but this will fail if there is a dot or boxIn between the OutObject and the OSLCode.

So, it seems like this would be a very nice improvement in usability, but still some stuff to get sorted.  Once we figure it out, I should probably do OSLImage as part of the same PR.
