### PR TITLE
Application : Set process name/args to `gaffer ...`

### DIFF
--- a/bin/gaffer.py
+++ b/bin/gaffer.py
@@ -53,6 +53,9 @@ signal.signal( signal.SIGINT, signal.SIG_DFL )
 warnings.simplefilter( "default", DeprecationWarning )
 
 import IECore
+from Gaffer._Gaffer import _nameProcess
+
+_nameProcess()
 
 helpText = """Usage :
 

--- a/python/GafferTest/ApplicationTest.py
+++ b/python/GafferTest/ApplicationTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import time
 import subprocess32 as subprocess
 
 import Gaffer
@@ -62,6 +63,17 @@ class ApplicationTest( GafferTest.TestCase ) :
 
 		self.assertEqual( externalEnv["GAFFER_STARTUP_PATHS"], os.environ["GAFFER_STARTUP_PATHS"] )
 		self.assertEqual( externalEnv["GAFFER_APP_PATHS"], os.environ["GAFFER_APP_PATHS"] )
+
+	def testProcessName( self ) :
+
+		process = subprocess.Popen( [ "gaffer", "env", "sleep", "100" ] )
+		time.sleep( 1 )
+		command = subprocess.check_output( [ "ps", "-p", str( process.pid ), "-o", "command=" ] ).strip()
+		name = subprocess.check_output( [ "ps", "-p", str( process.pid ), "-o", "comm=" ] ).strip()
+		process.kill()
+
+		self.assertEqual( command, "gaffer env sleep 100" )
+		self.assertEqual( name, "gaffer" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -84,6 +84,10 @@
 
 #include "tbb/tbb.h"
 
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
+
 using namespace boost::python;
 using namespace Gaffer;
 using namespace GafferModule;
@@ -133,6 +137,74 @@ bool isDebug()
 	return false;
 #else
 	return true;
+#endif
+}
+
+// This is documented as being for the use of extension
+// modules, but then isn't declared in the Python headers,
+// so we declare it ourselves.
+extern "C" void Py_GetArgcArgv( int *argc, char ***argv );
+
+void clobberArgv()
+{
+	// Get the original argc/argv that was passed to
+	// `main()`. We will modify this in place.
+	int argc;
+	char **argv;
+	Py_GetArgcArgv( &argc, &argv );
+
+	// A typical command line looks like this :
+	//
+	// `gaffer arg1 arg2 arg3`
+	//
+	// But will look like this once the wrapper
+	// has launched Gaffer via Python :
+	//
+	// `python gaffer.py arg1 arg2 arg3`
+	//
+	// Replace the `python` bit with `gaffer` and
+	// shuffle all the arguments around so that
+	// the `gaffer.py` argument disappears and we
+	// get back to the original.
+	char *end = argv[argc-1] + strlen( argv[argc-1] );
+	strncpy( argv[0], "gaffer", strlen( argv[0] ) );
+	strncpy( argv[1], "", strlen( argv[1] ) );
+	char *emptyString = argv[1];
+	for( int i = 1; i < argc - 1; ++i )
+	{
+		argv[i] = argv[i+1];
+	}
+	argv[argc-1] = emptyString;
+
+	// We've just shuffled the pointers so far, but
+	// in practice the original strings were contiguous
+	// in the same chunk of memory, and `ps` uses that fact
+	// rather than actually use the argv pointers. See
+	// https://stackoverflow.com/a/23400588.
+	//
+	// Pack everything back down so `ps` sees what it
+	// expects.
+	char *c = argv[0];
+	for( int i = 0; i < argc - 1; ++i )
+	{
+		const size_t l = strlen( argv[i] ) + 1;
+		memmove( c, argv[i], l );
+		argv[i] = c;
+		c += l;
+	}
+	argv[argc-1] = c;
+	memset( c, 0, end - c );
+}
+
+void nameProcess()
+{
+	// Some things (for instance, `ps` in default mode) look at `argv` to get
+	// the name.
+	clobberArgv();
+	// Others (for instance, `top` in default mode) use other methods.
+	// Cater to everyone as best we can.
+#ifdef __linux__
+	prctl( PR_SET_NAME, "gaffer", 0, 0, 0 );
 #endif
 }
 
@@ -196,6 +268,8 @@ BOOST_PYTHON_MODULE( _Gaffer )
 		.def( "__exit__", &TaskSchedulerInitWrapper::exit )
 	;
 	tsi.attr( "automatic" ) = int( tbb::task_scheduler_init::automatic );
+
+	def( "_nameProcess", &nameProcess );
 
 	// Various parts of gaffer create new threads from C++, and those
 	// threads may call back into Python via wrapped classes at any time.


### PR DESCRIPTION
This makes Gaffer show up sensibly in `ps` (and `top` on Linux), rather than appearing as just any old python program. If anyone knows the magic incantations to get it working in `top` on OSX then let me know!

