### PR TITLE
PythonExpressionEngine : Support `"x" in context`

### DIFF
--- a/python/Gaffer/PythonExpressionEngine.py
+++ b/python/Gaffer/PythonExpressionEngine.py
@@ -275,6 +275,26 @@ class _Parser( ast.NodeVisitor ) :
 
 		ast.NodeVisitor.generic_visit( self, node )
 
+	def visit_Compare( self, node ) :
+
+		ast.NodeVisitor.generic_visit( self, node )
+
+		# Look for `"x" in context` and `"x" not in context`
+
+		if not isinstance( node.ops[0], ( ast.In, ast.NotIn ) ) :
+			return
+
+		if not isinstance( node.comparators[0], ast.Name ) :
+			return
+
+		if node.comparators[0].id != "context" :
+			return
+
+		if not isinstance( node.left, ast.Str ) :
+			raise SyntaxError( "Context name must be a string" )
+
+		self.contextReads.add( node.left.s )
+
 	def __path( self, node ) :
 
 		result = []
@@ -395,6 +415,10 @@ class _ContextProxy( object ) :
 	def __getitem__( self, key ) :
 
 		return self.__context[key]
+
+	def __contains__( self, key ) :
+
+		return key in self.__context
 
 	def __getattr__( self, name ) :
 

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1387,5 +1387,31 @@ class ExpressionTest( GafferTest.TestCase ) :
 		s2["n"]["c"][m1.getName()]["enabled"].setValue( True )
 		self.assertEqual( s2["n"]["s"].getValue(), "a:1,b:2" )
 
+	def testContextContains( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = GafferTest.AddNode()
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( inspect.cleandoc(
+			"""
+			parent["n"]["op1"] = 1 if "a" in context else 0
+			parent["n"]["op2"] = 1 if "a" not in context else 0
+			"""
+		) )
+
+		with Gaffer.Context() as c :
+
+			self.assertEqual( s["n"]["op1"].getValue(), 0 )
+			self.assertEqual( s["n"]["op2"].getValue(), 1 )
+
+			c["a"] = "a"
+			self.assertEqual( s["n"]["op1"].getValue(), 1 )
+			self.assertEqual( s["n"]["op2"].getValue(), 0 )
+
+			del c["a"]
+			self.assertEqual( s["n"]["op1"].getValue(), 0 )
+			self.assertEqual( s["n"]["op2"].getValue(), 1 )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
And similarly, support `"x" not in context`.

I ran into this while trying to make an expression that used `"scene:renderer" in context` to enable a node only at rendertime. It's already possible using `context.get( "scene:renderer" ) is not None`, but that's not as pretty, and since we support the `in` syntax in the regular scripting API, we should support it for expressions too.