### PR TITLE
RendererAlgo : Ignore root transform/attributes in `outputObjects()`

### DIFF
--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -510,7 +510,10 @@ struct LocationOutput
 
 	bool operator()( const ScenePlug *scene, const ScenePlug::ScenePath &path )
 	{
-		updateAttributes( scene, path );
+		if( path.size() > m_root.size() )
+		{
+			updateAttributes( scene, path );
+		}
 
 		if( const IECore::BoolData *d = m_attributes->member<IECore::BoolData>( g_visibleAttributeName ) )
 		{
@@ -520,7 +523,10 @@ struct LocationOutput
 			}
 		}
 
-		updateTransform( scene );
+		if( path.size() > m_root.size() )
+		{
+			updateTransform( scene );
+		}
 
 		return true;
 	}


### PR DESCRIPTION
When the root is `/`, it is guaranteed that these are empty anyway. The non-default root case is used by `Capsule::render()`, and in this case the root attributes and transform were applied to the Capsule itself already. We therefore need to skip them to avoid double transforms.