### PR TITLE
SceneHierarchy : Don't clear selected paths when nothing is viewed

### DIFF
--- a/python/GafferSceneUI/SceneHierarchy.py
+++ b/python/GafferSceneUI/SceneHierarchy.py
@@ -173,11 +173,13 @@ class SceneHierarchy( GafferUI.NodeSetEditor ) :
 			contextCopy = Gaffer.Context( self.getContext() )
 			for f in self.__filter.getFilters() :
 				f.setContext( contextCopy )
-			self.__pathListing.setPath( GafferScene.ScenePath( self.__plug, contextCopy, "/", filter = self.__filter ) )
+			with Gaffer.BlockedConnection( self.__selectionChangedConnection ) :
+				self.__pathListing.setPath( GafferScene.ScenePath( self.__plug, contextCopy, "/", filter = self.__filter ) )
 			self.__transferExpansionFromContext()
 			self.__transferSelectionFromContext()
 		else :
-			self.__pathListing.setPath( Gaffer.DictPath( {}, "/" ) )
+			with Gaffer.BlockedConnection( self.__selectionChangedConnection ) :
+				self.__pathListing.setPath( Gaffer.DictPath( {}, "/" ) )
 
 	def __expansionChanged( self, pathListing ) :
 


### PR DESCRIPTION
This bug caused the following infuriating interaction :

- View a scene, select a bunch of objects
- Make a PathFilter, thinking you would drag the objects onto it
- Because PathFilter is not a SceneNode, SceneHierarchy clears itself
  and in the process accidentally clears the selection from the context
- Start over