### PR TITLE
FileMenu : Fix premature exit when opening backup containing error

### DIFF
--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -109,7 +109,7 @@ def __addScript( application, fileName, dialogueParentWindow = None ) :
 			)
 			if not dialogue.waitForConfirmation( parentWindow = dialogueParentWindow ) :
 				recoveryFileName = None
-			del dialogue
+			dialogue.setVisible( False )
 
 	script = Gaffer.ScriptNode()
 	script["fileName"].setValue( recoveryFileName or fileName )


### PR DESCRIPTION
This occurred when opening a file with `gaffer somefile.gfr`, and the sequence of operations was this :

- Find backup, prompt to open it (in FileMenu.__addScript)
- Delete prompt dialogue
- QApplication decides it should quit, because the last top level window
  has been closed
- Load script and attempt to display error dialogue, but this
  closes immediately because the modal event loop returns
  immediately
- Application closes

This is fixed by not deleting the dialogue until exit from the function, and merely hiding it instead. An alternative would be to call `QApplication.setQuitOnLastWindowClosed( False )`, but that might affect existing applications.

Fixes #2526 

Note : Implemented and tested on MacOS - need to test on Linux before merging.