### PR TITLE
Metadata matching improvements

### DIFF
--- a/python/GafferCortexUI/FileSequenceParameterValueWidget.py
+++ b/python/GafferCortexUI/FileSequenceParameterValueWidget.py
@@ -100,5 +100,5 @@ def __includeFrameRange( plug ) :
 	return includeFrameRange
 
 for nodeType in __nodeTypes :
-	Gaffer.Metadata.registerValue( nodeType, "parameters.*", "fileSystemPath:includeSequences", __isFileSequence )
-	Gaffer.Metadata.registerValue( nodeType, "parameters.*", "fileSystemPath:includeSequenceFrameRange", __includeFrameRange )
+	Gaffer.Metadata.registerValue( nodeType, "parameters.*...", "fileSystemPath:includeSequences", __isFileSequence )
+	Gaffer.Metadata.registerValue( nodeType, "parameters.*...", "fileSystemPath:includeSequenceFrameRange", __includeFrameRange )

--- a/python/GafferCortexUI/ObjectWriterUI.py
+++ b/python/GafferCortexUI/ObjectWriterUI.py
@@ -91,6 +91,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "",
+			"plugValueWidget:type", "GafferCortexUI.ObjectWriterUI.__createParameterWidget",
 
 		],
 
@@ -98,12 +99,6 @@ Gaffer.Metadata.registerNode(
 
 )
 
-##########################################################################
-# PlugValueWidgets
-##########################################################################
-
 def __createParameterWidget( plug ) :
 
 	return GafferCortexUI.CompoundParameterValueWidget( plug.node().parameterHandler(), collapsible=False )
-
-GafferUI.PlugValueWidget.registerCreator( GafferCortex.ObjectWriter, "parameters", __createParameterWidget )

--- a/python/GafferCortexUI/ParameterisedHolderUI.py
+++ b/python/GafferCortexUI/ParameterisedHolderUI.py
@@ -272,7 +272,7 @@ for nodeType in __nodeTypes :
 
 			],
 
-			"parameters.*" : [
+			"parameters.*..." : [
 
 				"description", __plugDescription,
 				"presetNames", __plugPresetNames,

--- a/python/GafferCortexUI/StringParameterValueWidget.py
+++ b/python/GafferCortexUI/StringParameterValueWidget.py
@@ -101,4 +101,4 @@ def __fixedLineHeight( plug ) :
 	return fixedLineHeight
 
 for nodeType in __nodeTypes:
-	Gaffer.Metadata.registerValue( nodeType, "*", "fixedLineHeight", __fixedLineHeight )
+	Gaffer.Metadata.registerValue( nodeType, "parameters.*...", "fixedLineHeight", __fixedLineHeight )

--- a/python/GafferDispatchUI/TaskNodeUI.py
+++ b/python/GafferDispatchUI/TaskNodeUI.py
@@ -54,7 +54,7 @@ Gaffer.Metadata.registerNode(
 
 		"*" : [
 
-			"nodule:type", lambda plug : "GafferUI::StandardNodule" if isinstance( plug, GafferDispatch.TaskNode.TaskPlug ) else "",
+			"nodule:type", "",
 
 		],
 
@@ -112,6 +112,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "",
+			"nodule:type", "GafferUI::StandardNodule",
 
 		),
 

--- a/python/GafferSceneUI/OutputsUI.py
+++ b/python/GafferSceneUI/OutputsUI.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import re
 import functools
 import imath
 
@@ -74,6 +73,12 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferSceneUI.OutputsUI.OutputsPlugValueWidget",
+
+		],
+
+		"outputs.*" : [
+
+			"plugValueWidget:type", "GafferSceneUI.OutputsUI.ChildPlugValueWidget",
 
 		],
 
@@ -172,7 +177,7 @@ class OutputsPlugValueWidget( GafferUI.PlugValueWidget ) :
 		return m
 
 # A widget for representing an individual output.
-class _ChildPlugWidget( GafferUI.PlugValueWidget ) :
+class ChildPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, childPlug ) :
 
@@ -254,9 +259,3 @@ class _ChildPlugWidget( GafferUI.PlugValueWidget ) :
 
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().parent().removeChild( self.getPlug() )
-
-## \todo This regex is an interesting case to be considered during the string matching unification for #707. Once that
-# is done, intuitively we want to use an "outputs.*" glob expression, but because the "*" will match anything
-# at all, including ".", it will match the children of what we want too. We might want to prevent wildcards from
-# matching "." when we come to use them in this context.
-GafferUI.PlugValueWidget.registerCreator( GafferScene.Outputs, re.compile( "outputs\.[^\.]+$" ), _ChildPlugWidget )

--- a/python/GafferUI/NodeUI.py
+++ b/python/GafferUI/NodeUI.py
@@ -89,7 +89,7 @@ Gaffer.Metadata.registerNode(
 
 		"*" : (
 
-			"layout:section", lambda plug : "Settings" if isinstance( plug.parent(), Gaffer.Node ) else ""
+			"layout:section", "Settings"
 
 		),
 

--- a/python/GafferUITest/StandardNodeGadgetTest.py
+++ b/python/GafferUITest/StandardNodeGadgetTest.py
@@ -86,7 +86,7 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 			else :
 				return "GafferUI::StandardNodule"
 
-		Gaffer.Metadata.registerValue( DeeplyNestedNode, "*", "nodule:type", noduleType )
+		Gaffer.Metadata.registerValue( DeeplyNestedNode, "...", "nodule:type", noduleType )
 
 		g = GafferUI.StandardNodeGadget( n )
 

--- a/startup/gui/nodeGraph.py
+++ b/startup/gui/nodeGraph.py
@@ -66,7 +66,7 @@ Gaffer.Metadata.registerNodeValue( Gaffer.Random, "nodeGadget:color", imath.Colo
 Gaffer.Metadata.registerNodeValue( Gaffer.Expression, "nodeGadget:color", imath.Color3f( 0.3, 0.45, 0.3 ) )
 Gaffer.Metadata.registerNodeValue( Gaffer.Animation, "nodeGadget:color", imath.Color3f( 0.3, 0.3, 0.45 ) )
 
-Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "in*", "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
+Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "in...", "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
 Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "out", "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
 Gaffer.Metadata.registerPlugValue( GafferScene.InteractiveRender, "in", "nodule:color", imath.Color3f( 0.2346, 0.326, 0.46 ) )
 Gaffer.Metadata.registerPlugValue( GafferScene.Parent, "child", "nodule:color", imath.Color3f( 0.2346, 0.326, 0.46 ) )
@@ -76,6 +76,7 @@ Gaffer.Metadata.registerNodeValue( GafferScene.SceneElementProcessor, "nodeGadge
 
 Gaffer.Metadata.registerPlugValue( GafferScene.FilteredSceneProcessor, "filter", "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
 Gaffer.Metadata.registerPlugValue( GafferScene.Filter, "out", "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
+Gaffer.Metadata.registerPlugValue( GafferScene.Filter, "in...", "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
 
 Gaffer.Metadata.registerNodeValue( GafferScene.Transform, "nodeGadget:color", imath.Color3f( 0.485, 0.3112, 0.2255 ) )
 Gaffer.Metadata.registerNodeValue( GafferScene.Constraint, "nodeGadget:color", imath.Color3f( 0.485, 0.3112, 0.2255 ) )
@@ -92,7 +93,7 @@ def __shaderNoduleColor( plug ) :
 
 	return __shaderNoduleColors.get( plug.typeId(), None )
 
-Gaffer.Metadata.registerPlugValue( GafferScene.Shader, "*", "nodule:color", __shaderNoduleColor )
+Gaffer.Metadata.registerPlugValue( GafferScene.Shader, "...", "nodule:color", __shaderNoduleColor )
 
 ##########################################################################
 # Behaviour


### PR DESCRIPTION
This implements the changes Daniel needs for #2508 and also removes the deprecated `PlugValueWidget.registerCreator()` method whose removal had been blocked by a similar problem. There are some legacy PlugValueWidget registrations in the IE codebase that will need updating. I can split this PR in two if you'd prefer to deal with those separately, but since this has been deprecated for years I think now might be the time...