### PR TITLE
Small fixes (GCC7-related)

### DIFF
--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -923,7 +923,7 @@ void SceneGadget::updateSceneGraph() const
 		UpdateTask *task = new( tbb::task::allocate_root() ) UpdateTask( this, m_sceneGraph.get(), m_dirtyFlags, ScenePlug::ScenePath() );
 		tbb::task::spawn_root_and_wait( *task );
 
-		if( m_dirtyFlags && UpdateTask::ChildNamesDirty )
+		if( m_dirtyFlags & UpdateTask::ChildNamesDirty )
 		{
 			m_sceneGraph->applySelection( m_selection );
 		}


### PR DESCRIPTION
Bitwise mask correction '&' instead of '&&'

This PR references this issue page: https://github.com/GafferHQ/gaffer/issues/2540