### PR TITLE
GafferScene : Delete Face/Point/Curve invert

### DIFF
--- a/include/GafferScene/DeleteCurves.h
+++ b/include/GafferScene/DeleteCurves.h
@@ -61,6 +61,9 @@ class GAFFERSCENE_API DeleteCurves : public SceneElementProcessor
 		Gaffer::StringPlug *curvesPlug();
 		const Gaffer::StringPlug *curvesPlug() const;
 
+		Gaffer::BoolPlug *invertPlug();
+		const Gaffer::BoolPlug *invertPlug() const;
+
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::DeleteCurves, DeleteCurvesTypeId, SceneElementProcessor );
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 

--- a/include/GafferScene/DeleteFaces.h
+++ b/include/GafferScene/DeleteFaces.h
@@ -61,6 +61,9 @@ class GAFFERSCENE_API DeleteFaces : public SceneElementProcessor
 		Gaffer::StringPlug *facesPlug();
 		const Gaffer::StringPlug *facesPlug() const;
 
+		Gaffer::BoolPlug *invertPlug();
+		const Gaffer::BoolPlug *invertPlug() const;
+
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::DeleteFaces, DeleteFacesTypeId, SceneElementProcessor );
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 

--- a/include/GafferScene/DeletePoints.h
+++ b/include/GafferScene/DeletePoints.h
@@ -61,6 +61,9 @@ class GAFFERSCENE_API DeletePoints : public SceneElementProcessor
 		Gaffer::StringPlug *pointsPlug();
 		const Gaffer::StringPlug *pointsPlug() const;
 
+		Gaffer::BoolPlug *invertPlug();
+		const Gaffer::BoolPlug *invertPlug() const;
+
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::DeletePoints, DeletePointsTypeId, SceneElementProcessor );
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 

--- a/python/GafferSceneTest/DeleteCurvesTest.py
+++ b/python/GafferSceneTest/DeleteCurvesTest.py
@@ -129,6 +129,40 @@ class DeleteCurvesTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( curveDeletedObject["e"].data,  IECore.FloatVectorData(range( 0, 3 )) )
 		self.assertEqual( curveDeletedObject["e"].interpolation,  IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
 
+		# invert
+		# ======
+		deleteCurves["invert"].setValue( True )
+		curveDeletedObject = deleteCurves["out"].object( "/object" )
+
+		self.assertEqual( curveDeletedObject.verticesPerCurve(), IECore.IntVectorData([7]) )
+		self.assertEqual( curveDeletedObject.numCurves(), 1 )
+		self.assertEqual( curveDeletedObject["P"].data, IECore.V3fVectorData(
+			[
+				imath.V3f( 0, 0, 0 ),
+				imath.V3f( 0, 0, 1 ),
+				imath.V3f( 1, 0, 1 ),
+				imath.V3f( 1, 0, 0 ),
+				imath.V3f( 1, 0, -1 ),
+				imath.V3f( 2, 0, -1 ),
+				imath.V3f( 2, 0, 0 )
+			] ) )
+
+		# verify the primvars are correct
+		self.assertEqual( curveDeletedObject["a"].data,  IECore.FloatData(0.5) )
+		self.assertEqual( curveDeletedObject["a"].interpolation, IECoreScene.PrimitiveVariable.Interpolation.Constant)
+
+		self.assertEqual( curveDeletedObject["b"].data,  IECore.FloatVectorData( range( 7, 14 ) ) )
+		self.assertEqual( curveDeletedObject["b"].interpolation,  IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+
+		self.assertEqual( curveDeletedObject["c"].data,  IECore.FloatVectorData([1.0]) )
+		self.assertEqual( curveDeletedObject["c"].interpolation,  IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+
+		self.assertEqual( curveDeletedObject["d"].data,  IECore.FloatVectorData(range( 3, 6 )) )
+		self.assertEqual( curveDeletedObject["d"].interpolation,  IECoreScene.PrimitiveVariable.Interpolation.Varying )
+
+		self.assertEqual( curveDeletedObject["e"].data,  IECore.FloatVectorData(range( 3, 6 )) )
+		self.assertEqual( curveDeletedObject["e"].interpolation,  IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+
 	def testBoundsUpdate( self ) :
 
 		curvesScene = self.makeCurves()

--- a/python/GafferSceneTest/DeleteFacesTest.py
+++ b/python/GafferSceneTest/DeleteFacesTest.py
@@ -88,6 +88,22 @@ class DeleteFacesTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( faceDeletedObject["vertex"].data,  IECore.IntVectorData([100, 101, 103, 104]) )
 		self.assertEqual( faceDeletedObject["faceVarying"].data,  IECore.IntVectorData([20, 21, 22, 23]) )
 
+		# invert
+		# ======
+
+		deleteFaces["invert"].setValue( True )
+		faceDeletedObject = deleteFaces["out"].object( "/object" )
+
+		self.assertEqual( faceDeletedObject.verticesPerFace, IECore.IntVectorData([4]) )
+		self.assertEqual( faceDeletedObject.vertexIds, IECore.IntVectorData([0, 1, 3, 2]) )
+		self.assertEqual( faceDeletedObject.numFaces(), 1 )
+		self.assertEqual( faceDeletedObject["P"].data, IECore.V3fVectorData( [imath.V3f( 1, 0, 0 ), imath.V3f( 2, 0, 0 ), imath.V3f( 1, 1, 0 ), imath.V3f( 2, 1, 0 )] ) )
+
+		# verify the primvars are correct
+		self.assertEqual( faceDeletedObject["uniform"].data,  IECore.IntVectorData([11]) )
+		self.assertEqual( faceDeletedObject["vertex"].data,  IECore.IntVectorData([101, 102, 104, 105]) )
+		self.assertEqual( faceDeletedObject["faceVarying"].data,  IECore.IntVectorData([24, 25, 26, 27]) )
+
 	def testDeletingFacesUpdatesBounds( self ) :
 
 		rectangleScene = self.makeRectangleFromTwoSquaresScene()

--- a/python/GafferSceneTest/DeletePointsTest.py
+++ b/python/GafferSceneTest/DeletePointsTest.py
@@ -101,6 +101,32 @@ class DeletePointsTest( GafferSceneTest.SceneTestCase ) :
 				0, 0
 			] ) )
 
+		# invert
+		# ======
+
+		deletePoints["invert"].setValue( True )
+
+		pointsDeletedObject = deletePoints["out"].object( "/object" )
+
+		self.assertEqual( pointsDeletedObject.numPoints, 2 )
+		self.assertEqual( pointsDeletedObject["P"].data, IECore.V3fVectorData(
+			[
+				#imath.V3f( 0, 0, 0 ),
+				imath.V3f( 0, 1, 0 ),
+				#imath.V3f( 1, 1, 0 )
+				imath.V3f( 1, 0, 0 )
+			] ) )
+
+		self.assertEqual( pointsDeletedObject["r"].data, IECore.FloatVectorData(
+			[
+				1, 3
+			] ) )
+
+		self.assertEqual( pointsDeletedObject["deletePoints"].data, IECore.IntVectorData(
+			[
+				1, 1
+			] ) )
+
 
 	def testBoundsUpdate( self ) :
 

--- a/python/GafferSceneUI/DeleteCurvesUI.py
+++ b/python/GafferSceneUI/DeleteCurvesUI.py
@@ -53,7 +53,14 @@ Gaffer.Metadata.registerNode(
 			"""
 			Uniformly interpolated int, float or bool primitive variable to choose which curves to delete. Note a non-zero value indicates the curve will be deleted. 
 			"""
+		],
+		"invert" : [
+			"description",
+			"""
+			Invert the condition used to delete curves. If the primvar is zero then the curve will be deleted. 
+			"""
 		]
+
 	}
 
 )

--- a/python/GafferSceneUI/DeleteFacesUI.py
+++ b/python/GafferSceneUI/DeleteFacesUI.py
@@ -53,6 +53,12 @@ Gaffer.Metadata.registerNode(
 			"""
 			Uniformly interpolated int, float or bool primitive variable to choose which faces to delete. Note a non-zero value indicates the face will be deleted.  
 			"""
+		],
+		"invert" : [
+			"description",
+			"""
+			Invert the condition used to delete faces. If the primvar is zero then the face will be deleted. 
+			"""
 		]
 	}
 

--- a/python/GafferSceneUI/DeletePointsUI.py
+++ b/python/GafferSceneUI/DeletePointsUI.py
@@ -53,6 +53,12 @@ Gaffer.Metadata.registerNode(
 			"""
 			Vertex interpolated int, float or bool primitive variable to choose which points to delete. Note a non-zero value indicates the point will be deleted.  
 			"""
+		],
+		"invert" : [
+			"description",
+			"""
+			Invert the condition used to delete points. If the primvar is zero then the point will be deleted. 
+			"""
 		]
 	}
 

--- a/src/GafferScene/DeleteCurves.cpp
+++ b/src/GafferScene/DeleteCurves.cpp
@@ -58,6 +58,7 @@ DeleteCurves::DeleteCurves( const std::string &name ) : SceneElementProcessor( n
 	storeIndexOfNextChild( g_firstPlugIndex );
 
 	addChild( new StringPlug( "curves", Plug::In, "deleteCurves" ) );
+	addChild( new BoolPlug( "invert", Plug::In, false ) );
 
 	// Fast pass-through for things we don't modify
 	outPlug()->attributesPlug()->setInput( inPlug()->attributesPlug() );
@@ -78,11 +79,23 @@ const Gaffer::StringPlug *DeleteCurves::curvesPlug() const
 	return getChild<StringPlug>( g_firstPlugIndex );
 }
 
+
+Gaffer::BoolPlug *DeleteCurves::invertPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 1);
+}
+
+const Gaffer::BoolPlug *DeleteCurves::invertPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 1);
+}
+
+
 void DeleteCurves::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	SceneElementProcessor::affects( input, outputs );
 
-	if( input == curvesPlug() )
+	if( input == curvesPlug() || input == invertPlug() )
 	{
 		outputs.push_back( outPlug()->objectPlug() );
 	}
@@ -120,6 +133,7 @@ bool DeleteCurves::processesObject() const
 void DeleteCurves::hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	curvesPlug()->hash( h );
+	invertPlug()->hash( h );
 }
 
 IECore::ConstObjectPtr DeleteCurves::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const
@@ -143,5 +157,5 @@ IECore::ConstObjectPtr DeleteCurves::computeProcessedObject( const ScenePath &pa
 		throw InvalidArgumentException( boost::str( boost::format( "DeleteCurves : No primitive variable \"%s\" found" ) % deletePrimVarName ) );
 	}
 
-	return CurvesAlgo::deleteCurves(curves, it->second);
+	return CurvesAlgo::deleteCurves(curves, it->second, invertPlug()->getValue());
 }

--- a/src/GafferScene/DeletePoints.cpp
+++ b/src/GafferScene/DeletePoints.cpp
@@ -59,6 +59,7 @@ DeletePoints::DeletePoints( const std::string &name ) : SceneElementProcessor( n
 	storeIndexOfNextChild( g_firstPlugIndex );
 
 	addChild( new StringPlug( "points", Plug::In, "deletePoints" ) );
+	addChild( new BoolPlug( "invert", Plug::In, false ) );
 
 	// Fast pass-through for things we don't modify
 	outPlug()->attributesPlug()->setInput( inPlug()->attributesPlug() );
@@ -79,11 +80,22 @@ const Gaffer::StringPlug *DeletePoints::pointsPlug() const
 	return getChild<StringPlug>( g_firstPlugIndex );
 }
 
+
+Gaffer::BoolPlug *DeletePoints::invertPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 1);
+}
+
+const Gaffer::BoolPlug *DeletePoints::invertPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 1);
+}
+
 void DeletePoints::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	SceneElementProcessor::affects( input, outputs );
 
-	if( input == pointsPlug() )
+	if( input == pointsPlug() || input == invertPlug() )
 	{
 		outputs.push_back( outPlug()->objectPlug() );
 	}
@@ -122,6 +134,7 @@ bool DeletePoints::processesObject() const
 void DeletePoints::hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	pointsPlug()->hash( h );
+	invertPlug()->hash( h );
 }
 
 IECore::ConstObjectPtr DeletePoints::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const
@@ -145,5 +158,5 @@ IECore::ConstObjectPtr DeletePoints::computeProcessedObject( const ScenePath &pa
 		throw InvalidArgumentException( boost::str( boost::format( "DeletePoints : No primitive variable \"%s\" found" ) % deletePrimVarName ) );
 	}
 
-	return PointsAlgo::deletePoints( points, it->second );
+	return PointsAlgo::deletePoints( points, it->second, invertPlug()->getValue() );
 }


### PR DESCRIPTION
The Cortex geometry algo delete functions suport inverting the sense of the flag in the primvar but this wasn't exposed to the nodes.