### PR TITLE
FormatPlug: fix hard crashes if None is passed through python binding

### DIFF
--- a/src/GafferImage/FormatPlug.cpp
+++ b/src/GafferImage/FormatPlug.cpp
@@ -147,6 +147,11 @@ void FormatPlug::setDefaultFormat( Gaffer::Context *context, const Format &forma
 
 FormatPlug *FormatPlug::acquireDefaultFormatPlug( Gaffer::ScriptNode *scriptNode )
 {
+	if( !scriptNode )
+	{
+		throw IECore::Exception( "Can't provide the default FormatPlug for an invalid ScriptNode" );
+	}
+
 	if( FormatPlug *p = scriptNode->getChild<FormatPlug>( g_defaultFormatPlugName ) )
 	{
 		return p;


### PR DESCRIPTION
Hey John,

I ran into a hard crash when trying to quickly squeeze in a fix for those hangs we were seeing. I described the problem in the commit message:

Problem can be replicated by executing

```
import GafferImage
GafferImage.FormatPlug.acquireDefaultFormatPlug( None )
```

in the ScriptEditor.

While that seems like a stupid thing to do, I had an issue with naively calling
`acquireDefaultFormatPlug` in a node's initializer, passing in `self.scriptNode()`
which obviously is `None` during node creation. Easy enough to fix, but the hard
crash is avoidable and the message gives a hint what went wrong.

Does this look ok to you, John? Do you want to change the message to something else?

Cheerio!

Matti.