### PR TITLE
Spline Plug Editing Tweaks

### DIFF
--- a/python/GafferUI/RampPlugValueWidget.py
+++ b/python/GafferUI/RampPlugValueWidget.py
@@ -72,7 +72,10 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 				GafferUI.PlugWidget( GafferUI.PlugValueWidget.create( plug["interpolation"] ) )
 
 			self.__splineWidget = GafferUI.SplineWidget()
-			self.__splineWidget.setDrawMode( self.__splineWidget.DrawMode.Ramp )
+			if isinstance( plug, ( Gaffer.SplinefColor3fPlug, Gaffer.SplinefColor4fPlug ) ) :
+				self.__splineWidget.setDrawMode( self.__splineWidget.DrawMode.Ramp )
+			else:
+				self.__splineWidget.setDrawMode( self.__splineWidget.DrawMode.Splines )
 			self.__splineWidget._qtWidget().setMinimumHeight( 50 )
 
 			self.__slider = GafferUI.Slider()

--- a/python/GafferUI/SplineWidget.py
+++ b/python/GafferUI/SplineWidget.py
@@ -190,7 +190,7 @@ class SplineWidget( GafferUI.Widget ) :
 			for s in self.__splinesToDraw :
 				self.__splineBound = self.__splineBound.united( s.path.controlPointRect() )
 
-		# draw the splines
+		# Set view transform
 		rect = self._qtWidget().contentsRect()
 		transform = QtGui.QTransform()
 		if self.__splineBound.width() :
@@ -202,6 +202,26 @@ class SplineWidget( GafferUI.Widget ) :
 			transform.translate( 0, -self.__splineBound.top() )
 
 		painter.setTransform( transform )
+
+		# Draw axis lines at y=0 and y=1
+		painter.setCompositionMode( QtGui.QPainter.CompositionMode.CompositionMode_SourceOver )
+		pen = QtGui.QPen( self._qtColor( imath.Color3f( 0 ) ) )
+		pen.setCosmetic( True )
+		painter.setPen( pen )
+		zeroLine = QtGui.QPainterPath()
+		zeroLine.moveTo( 0, 0 )
+		zeroLine.lineTo( 1, 0 )
+		painter.drawPath( zeroLine )
+
+		pen = QtGui.QPen( self._qtColor( imath.Color3f( 0.4 ) ) )
+		pen.setCosmetic( True )
+		painter.setPen( pen )
+		oneLine = QtGui.QPainterPath()
+		oneLine.moveTo( 0, 1 )
+		oneLine.lineTo( 1, 1 )
+		painter.drawPath( oneLine )
+
+		# draw the splines
 		painter.setCompositionMode( QtGui.QPainter.CompositionMode.CompositionMode_Plus )
 		for s in self.__splinesToDraw :
 			pen = QtGui.QPen( self._qtColor( s.color ) )

--- a/python/GafferUI/SplineWidget.py
+++ b/python/GafferUI/SplineWidget.py
@@ -153,15 +153,13 @@ class SplineWidget( GafferUI.Widget ) :
 		numPoints = 200
 		if not self.__splinesToDraw :
 			self.__splinesToDraw = []
-			interval = self.__spline.interval()
 			if isinstance( self.__spline, IECore.Splineff ) :
 				spline = IECore.Struct()
 				spline.color = imath.Color3f( 1 )
 				spline.path = QtGui.QPainterPath()
 				for i in range( 0, numPoints ) :
 					t = float( i ) / ( numPoints - 1 )
-					tt = interval[0] + (interval[1] - interval[0]) * t
-					c = self.__spline( tt )
+					c = self.__spline( t )
 					if i==0 :
 						spline.path.moveTo( t, c )
 					else :
@@ -181,8 +179,7 @@ class SplineWidget( GafferUI.Widget ) :
 
 				for i in range( 0, numPoints ) :
 					t = float( i ) / ( numPoints - 1 )
-					tt = interval[0] + (interval[1] - interval[0]) * t
-					c = self.__spline( tt )
+					c = self.__spline( t )
 					for j in range( 0, c.dimensions() ) :
 						if i == 0 :
 							self.__splinesToDraw[j].path.moveTo( t, c[j] )

--- a/python/GafferUI/SplineWidget.py
+++ b/python/GafferUI/SplineWidget.py
@@ -186,7 +186,7 @@ class SplineWidget( GafferUI.Widget ) :
 						else :
 							self.__splinesToDraw[j].path.lineTo( t, c[j] )
 
-			self.__splineBound = QtCore.QRectF()
+			self.__splineBound = QtCore.QRectF( 0, 0, 1, 1 )
 			for s in self.__splinesToDraw :
 				self.__splineBound = self.__splineBound.united( s.path.controlPointRect() )
 
@@ -203,23 +203,26 @@ class SplineWidget( GafferUI.Widget ) :
 
 		painter.setTransform( transform )
 
-		# Draw axis lines at y=0 and y=1
 		painter.setCompositionMode( QtGui.QPainter.CompositionMode.CompositionMode_SourceOver )
-		pen = QtGui.QPen( self._qtColor( imath.Color3f( 0 ) ) )
-		pen.setCosmetic( True )
-		painter.setPen( pen )
-		zeroLine = QtGui.QPainterPath()
-		zeroLine.moveTo( 0, 0 )
-		zeroLine.lineTo( 1, 0 )
-		painter.drawPath( zeroLine )
 
-		pen = QtGui.QPen( self._qtColor( imath.Color3f( 0.4 ) ) )
-		pen.setCosmetic( True )
-		painter.setPen( pen )
-		oneLine = QtGui.QPainterPath()
-		oneLine.moveTo( 0, 1 )
-		oneLine.lineTo( 1, 1 )
-		painter.drawPath( oneLine )
+		# Draw axis lines at y=0 and y=1
+		if self.__splineBound.top() < 0:
+			pen = QtGui.QPen( self._qtColor( imath.Color3f( 0.2 ) ) )
+			pen.setCosmetic( True )
+			painter.setPen( pen )
+			zeroLine = QtGui.QPainterPath()
+			zeroLine.moveTo( 0, 0 )
+			zeroLine.lineTo( 1, 0 )
+			painter.drawPath( zeroLine )
+
+		if self.__splineBound.bottom() > 1:
+			pen = QtGui.QPen( self._qtColor( imath.Color3f( 0.4 ) ) )
+			pen.setCosmetic( True )
+			painter.setPen( pen )
+			oneLine = QtGui.QPainterPath()
+			oneLine.moveTo( 0, 1 )
+			oneLine.lineTo( 1, 1 )
+			painter.drawPath( oneLine )
 
 		# draw the splines
 		painter.setCompositionMode( QtGui.QPainter.CompositionMode.CompositionMode_Plus )


### PR DESCRIPTION
I quickly adding support for editing float splines a while back when it turned out to be easy, but I never really finished cleaning this up.  These 3 small tweaks should make for a much nicer user experience, though they do require review.

* I removed the remapping of spline drawing to match the interval of the curve.  This was done in __paintSplines, but not in the corresponding __paintRamp.  When we display ramps to the user, the control points always range 0-1, so changing this range in the spline display is highly undesirable - it makes the control points not match the curve display while editing.  I may be missing some case where this behaviour is desirable, in which case we should add back this functionality, probably add matching functionality to __paintRamp, and then add some control to disable it when editing spline plugs on shaders.  ( I can see where you could want a spline over a range other than 0-1, if we want this, there's no reason not to have it for color-valued splines ).
* I added an indicator line for y=0 and y=1.  This makes it a lot easier to see if you've accidentally added undershoot using catmull-rom interpolation.
* I switched RampPlugValueWidget to use Splines draw mode by default when editing SplineffPlugs, instead of Ramp mode.  This is clearly more consistent for users, since it matches what we're doing in SplinePlugValueWidget.  This does expose some currently poor naming, since both SplinePlugValueWidget and RampPlugValueWidget can both be used for both splines and ramps.  If you want to fix this now, I would propose renaming RampPlugValueWidget to something like SplinePlugValueEditor?



