### PR TITLE
BoolPlugValueWidget : Fix displayMode metadata handling

### DIFF
--- a/python/GafferUI/BoolPlugValueWidget.py
+++ b/python/GafferUI/BoolPlugValueWidget.py
@@ -88,12 +88,13 @@ class BoolPlugValueWidget( GafferUI.PlugValueWidget ) :
 					self.__boolWidget.setState( value )
 
 			displayMode = Gaffer.Metadata.value( self.getPlug(), "boolPlugValueWidget:displayMode" )
-			displayMode = {
-				"switch" : self.__boolWidget.DisplayMode.Switch,
-				"checkBox" : self.__boolWidget.DisplayMode.CheckBox,
-				"tool" : self.__boolWidget.DisplayMode.Tool,
-			}.get( displayMode, self.__boolWidget.DisplayMode.CheckBox )
-			self.__boolWidget.setDisplayMode( displayMode )
+			if displayMode is not None :
+				displayMode = {
+					"switch" : self.__boolWidget.DisplayMode.Switch,
+					"checkBox" : self.__boolWidget.DisplayMode.CheckBox,
+					"tool" : self.__boolWidget.DisplayMode.Tool,
+				}.get( displayMode, self.__boolWidget.DisplayMode.CheckBox )
+				self.__boolWidget.setDisplayMode( displayMode )
 
 		self.__boolWidget.setEnabled( self._editable( canEditAnimation = True ) )
 


### PR DESCRIPTION
This restores the little switches on the Attributes nodes and elsewhere, which were lost in 739fa78ca222a8301e55beae56b00460dae018c0.