### PR TITLE
ImageAlgo refactoring

### DIFF
--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -111,7 +111,8 @@ template <class ThreadableFunctor>
 void parallelProcessTiles(
 	const ImagePlug *imagePlug,
 	ThreadableFunctor &functor, // Signature : void functor( const ImagePlug *imagePlug, const V2i &tileOrigin )
-	const Imath::Box2i &window = Imath::Box2i() // Uses dataWindow if not specified.
+	const Imath::Box2i &window = Imath::Box2i(), // Uses dataWindow if not specified.
+	TileOrder tileOrder = Unordered
 );
 
 // Call the functor in parallel, once per tile per channel
@@ -120,7 +121,8 @@ void parallelProcessTiles(
 	const ImagePlug *imagePlug,
 	const std::vector<std::string> &channelNames,
 	ThreadableFunctor &functor, // Signature : void functor( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
-	const Imath::Box2i &window = Imath::Box2i() // Uses dataWindow if not specified.
+	const Imath::Box2i &window = Imath::Box2i(), // Uses dataWindow if not specified.
+	TileOrder tileOrder = Unordered
 );
 
 // Process all tiles in parallel using TileFunctor, passing the

--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -128,8 +128,8 @@ void parallelProcessTiles(
 template <class TileFunctor, class GatherFunctor>
 void parallelGatherTiles(
 	const ImagePlug *image,
-	TileFunctor &tileFunctor, // Signature : TileFunctor::Result tileFunctor( const ImagePlug *imagePlug, const V2i &tileOrigin )
-	GatherFunctor &gatherFunctor, // Signature : void gatherFunctor( const ImagePlug *imagePlug, const V2i &tileOrigin, TileFunctor::Result )
+	TileFunctor &tileFunctor, // Signature : T tileFunctor( const ImagePlug *imagePlug, const V2i &tileOrigin )
+	GatherFunctor &gatherFunctor, // Signature : void gatherFunctor( const ImagePlug *imagePlug, const V2i &tileOrigin, T &tileFunctorResult )
 	const Imath::Box2i &window = Imath::Box2i(), // Uses dataWindow if not specified.
 	TileOrder tileOrder = Unordered
 );
@@ -140,8 +140,8 @@ template <class TileFunctor, class GatherFunctor>
 void parallelGatherTiles(
 	const ImagePlug *image,
 	const std::vector<std::string> &channelNames,
-	TileFunctor &tileFunctor, // Signature : TileFunctor::Result tileFunctor( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
-	GatherFunctor &gatherFunctor, // Signature : void gatherFunctor( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin, TileFunctor::Result )
+	TileFunctor &tileFunctor, // Signature : T tileFunctor( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
+	GatherFunctor &gatherFunctor, // Signature : void gatherFunctor( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin, T &tileFunctorResult )
 	const Imath::Box2i &window = Imath::Box2i(), // Uses dataWindow if not specified.
 	TileOrder tileOrder = Unordered
 );

--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -107,20 +107,20 @@ enum TileOrder
 };
 
 // Call the functor in parallel, once per tile
-template <class ThreadableFunctor>
+template <class TileFunctor>
 void parallelProcessTiles(
 	const ImagePlug *imagePlug,
-	ThreadableFunctor &functor, // Signature : void functor( const ImagePlug *imagePlug, const V2i &tileOrigin )
+	TileFunctor &&functor, // Signature : void functor( const ImagePlug *imagePlug, const V2i &tileOrigin )
 	const Imath::Box2i &window = Imath::Box2i(), // Uses dataWindow if not specified.
 	TileOrder tileOrder = Unordered
 );
 
 // Call the functor in parallel, once per tile per channel
-template <class ThreadableFunctor>
+template <class TileFunctor>
 void parallelProcessTiles(
 	const ImagePlug *imagePlug,
 	const std::vector<std::string> &channelNames,
-	ThreadableFunctor &functor, // Signature : void functor( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
+	TileFunctor &&functor, // Signature : void functor( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
 	const Imath::Box2i &window = Imath::Box2i(), // Uses dataWindow if not specified.
 	TileOrder tileOrder = Unordered
 );
@@ -130,8 +130,8 @@ void parallelProcessTiles(
 template <class TileFunctor, class GatherFunctor>
 void parallelGatherTiles(
 	const ImagePlug *image,
-	TileFunctor &tileFunctor, // Signature : T tileFunctor( const ImagePlug *imagePlug, const V2i &tileOrigin )
-	GatherFunctor &gatherFunctor, // Signature : void gatherFunctor( const ImagePlug *imagePlug, const V2i &tileOrigin, T &tileFunctorResult )
+	const TileFunctor &tileFunctor, // Signature : T tileFunctor( const ImagePlug *imagePlug, const V2i &tileOrigin )
+	GatherFunctor &&gatherFunctor, // Signature : void gatherFunctor( const ImagePlug *imagePlug, const V2i &tileOrigin, T &tileFunctorResult )
 	const Imath::Box2i &window = Imath::Box2i(), // Uses dataWindow if not specified.
 	TileOrder tileOrder = Unordered
 );
@@ -142,8 +142,8 @@ template <class TileFunctor, class GatherFunctor>
 void parallelGatherTiles(
 	const ImagePlug *image,
 	const std::vector<std::string> &channelNames,
-	TileFunctor &tileFunctor, // Signature : T tileFunctor( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
-	GatherFunctor &gatherFunctor, // Signature : void gatherFunctor( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin, T &tileFunctorResult )
+	const TileFunctor &tileFunctor, // Signature : T tileFunctor( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
+	GatherFunctor &&gatherFunctor, // Signature : void gatherFunctor( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin, T &tileFunctorResult )
 	const Imath::Box2i &window = Imath::Box2i(), // Uses dataWindow if not specified.
 	TileOrder tileOrder = Unordered
 );

--- a/include/GafferImage/ImageAlgo.inl
+++ b/include/GafferImage/ImageAlgo.inl
@@ -57,29 +57,29 @@ class ProcessTiles
 {
 	public:
 		ProcessTiles(
-				ThreadableFunctor &functor,
-				const ImagePlug* imagePlug,
-				const Imath::V2i &tilesOrigin,
-				const Gaffer::Context *context
-			) :
-				m_functor( functor ),
-				m_imagePlug( imagePlug ),
-				m_tilesOrigin( tilesOrigin ),
-				m_parentContext( context )
+			ThreadableFunctor &functor,
+			const ImagePlug* imagePlug,
+			const Imath::V2i &tilesOrigin,
+			const Gaffer::Context *context
+		) :
+			m_functor( functor ),
+			m_imagePlug( imagePlug ),
+			m_tilesOrigin( tilesOrigin ),
+			m_parentContext( context )
 		{}
 
 		ProcessTiles(
-				ThreadableFunctor &functor,
-				const ImagePlug* imagePlug,
-				const std::vector<std::string> &channelNames,
-				const Imath::V2i &tilesOrigin,
-				const Gaffer::Context *context
-			) :
-				m_functor( functor ),
-				m_imagePlug( imagePlug ),
-				m_channelNames( channelNames ),
-				m_tilesOrigin( tilesOrigin ),
-				m_parentContext( context )
+			ThreadableFunctor &functor,
+			const ImagePlug* imagePlug,
+			const std::vector<std::string> &channelNames,
+			const Imath::V2i &tilesOrigin,
+			const Gaffer::Context *context
+		) :
+			m_functor( functor ),
+			m_imagePlug( imagePlug ),
+			m_channelNames( channelNames ),
+			m_tilesOrigin( tilesOrigin ),
+			m_parentContext( context )
 		{}
 
 		void operator()( const tbb::blocked_range2d<size_t>& r ) const
@@ -139,12 +139,12 @@ class TileInputIterator
 		typedef boost::tuple<Imath::V2i> Result;
 
 		TileInputIterator(
-				const Imath::V2i &numTiles,
-				const ImageAlgo::TileOrder tileOrder
-			) :
-				m_numTiles( numTiles ),
-				m_tileOrder( tileOrder ),
-				nextTileId( Imath::V2i( 0 ) )
+			const Imath::V2i &numTiles,
+			const ImageAlgo::TileOrder tileOrder
+		) :
+			m_numTiles( numTiles ),
+			m_tileOrder( tileOrder ),
+			nextTileId( Imath::V2i( 0 ) )
 		{
 			if( m_tileOrder == ImageAlgo::TopToBottom )
 			{
@@ -197,15 +197,15 @@ class TileChannelInputIterator
 		typedef boost::tuple<size_t, Imath::V2i> Result;
 
 		TileChannelInputIterator(
-				const std::vector<std::string> &channelNames,
-				const Imath::V2i &numTiles,
-				const ImageAlgo::TileOrder tileOrder
-			) :
-				m_channelNames( channelNames ),
-				m_numTiles( numTiles ),
-				m_tileOrder( tileOrder ),
-				nextTileId( Imath::V2i( 0 ) ),
-				nextChannelIndex( 0 )
+			const std::vector<std::string> &channelNames,
+			const Imath::V2i &numTiles,
+			const ImageAlgo::TileOrder tileOrder
+		) :
+			m_channelNames( channelNames ),
+			m_numTiles( numTiles ),
+			m_tileOrder( tileOrder ),
+			nextTileId( Imath::V2i( 0 ) ),
+			nextChannelIndex( 0 )
 		{
 			if( m_tileOrder == ImageAlgo::TopToBottom )
 			{
@@ -266,8 +266,8 @@ template <class InputIterator>
 class TileInputFilter
 {
 	public:
-		TileInputFilter( InputIterator &it ) :
-				m_it( it )
+		TileInputFilter( InputIterator &it )
+			:	m_it( it )
 		{}
 
 		typename InputIterator::Result operator()( tbb::flow_control &fc ) const
@@ -289,29 +289,29 @@ class TileFunctorFilter
 {
 	public:
 		TileFunctorFilter(
-				TileFunctor &functor,
-				const ImagePlug *imagePlug,
-				const Imath::V2i &tilesOrigin,
-				const Gaffer::Context *context
-			) :
-				m_functor( functor ),
-				m_imagePlug( imagePlug ),
-				m_tilesOrigin( tilesOrigin ),
-				m_parentContext( context )
+			TileFunctor &functor,
+			const ImagePlug *imagePlug,
+			const Imath::V2i &tilesOrigin,
+			const Gaffer::Context *context
+		) :
+			m_functor( functor ),
+			m_imagePlug( imagePlug ),
+			m_tilesOrigin( tilesOrigin ),
+			m_parentContext( context )
 		{}
 
 		TileFunctorFilter(
-				TileFunctor &functor,
-				const ImagePlug *imagePlug,
-				const std::vector<std::string> &channelNames,
-				const Imath::V2i &tilesOrigin,
-				const Gaffer::Context *context
-			) :
-				m_functor( functor ),
-				m_imagePlug( imagePlug ),
-				m_channelNames( channelNames ),
-				m_tilesOrigin( tilesOrigin ),
-				m_parentContext( context )
+			TileFunctor &functor,
+			const ImagePlug *imagePlug,
+			const std::vector<std::string> &channelNames,
+			const Imath::V2i &tilesOrigin,
+			const Gaffer::Context *context
+		) :
+			m_functor( functor ),
+			m_imagePlug( imagePlug ),
+			m_channelNames( channelNames ),
+			m_tilesOrigin( tilesOrigin ),
+			m_parentContext( context )
 		{}
 
 		boost::tuple<size_t, Imath::V2i, typename TileFunctor::Result> operator()( boost::tuple<size_t, Imath::V2i> &it ) const
@@ -352,29 +352,29 @@ class GatherFunctorFilter
 {
 	public:
 		GatherFunctorFilter(
-				GatherFunctor &functor,
-				const ImagePlug *imagePlug,
-				const Imath::V2i &tilesOrigin,
-				const Gaffer::Context *context
-			) :
-				m_functor( functor ),
-				m_imagePlug( imagePlug ),
-				m_tilesOrigin( tilesOrigin ),
-				m_parentContext( context )
+			GatherFunctor &functor,
+			const ImagePlug *imagePlug,
+			const Imath::V2i &tilesOrigin,
+			const Gaffer::Context *context
+		) :
+			m_functor( functor ),
+			m_imagePlug( imagePlug ),
+			m_tilesOrigin( tilesOrigin ),
+			m_parentContext( context )
 		{}
 
 		GatherFunctorFilter(
-				GatherFunctor &functor,
-				const ImagePlug *imagePlug,
-				const std::vector<std::string> &channelNames,
-				const Imath::V2i &tilesOrigin,
-				const Gaffer::Context *context
-			) :
-				m_functor( functor ),
-				m_imagePlug( imagePlug ),
-				m_channelNames( channelNames ),
-				m_tilesOrigin( tilesOrigin ),
-				m_parentContext( context )
+			GatherFunctor &functor,
+			const ImagePlug *imagePlug,
+			const std::vector<std::string> &channelNames,
+			const Imath::V2i &tilesOrigin,
+			const Gaffer::Context *context
+		) :
+			m_functor( functor ),
+			m_imagePlug( imagePlug ),
+			m_channelNames( channelNames ),
+			m_tilesOrigin( tilesOrigin ),
+			m_parentContext( context )
 		{}
 
 		void operator()( boost::tuple<size_t, Imath::V2i, typename TileFunctor::Result> &it ) const
@@ -517,8 +517,10 @@ void parallelProcessTiles( const ImagePlug *imagePlug, ThreadableFunctor &functo
 	const Imath::V2i tilesOrigin = ImagePlug::tileOrigin( processWindow.min );
 	const Imath::V2i numTiles = ( ( ImagePlug::tileOrigin( processWindow.max - Imath::V2i( 1 ) ) - tilesOrigin ) / ImagePlug::tileSize() ) + Imath::V2i( 1 );
 
-	parallel_for( tbb::blocked_range2d<size_t>( 0, numTiles.x, 1, 0, numTiles.y, 1 ),
-			  GafferImage::Detail::ProcessTiles<ThreadableFunctor>( functor, imagePlug, tilesOrigin, Gaffer::Context::current() ) );
+	parallel_for(
+		tbb::blocked_range2d<size_t>( 0, numTiles.x, 1, 0, numTiles.y, 1 ),
+		GafferImage::Detail::ProcessTiles<ThreadableFunctor>( functor, imagePlug, tilesOrigin, Gaffer::Context::current() )
+	);
 }
 
 template <class ThreadableFunctor>
@@ -537,8 +539,10 @@ void parallelProcessTiles( const ImagePlug *imagePlug, const std::vector<std::st
 	const Imath::V2i tilesOrigin = ImagePlug::tileOrigin( processWindow.min );
 	Imath::V2i numTiles = ( ( ImagePlug::tileOrigin( processWindow.max - Imath::V2i( 1 ) ) - tilesOrigin ) / ImagePlug::tileSize() ) + Imath::V2i( 1 );
 
-	parallel_for( tbb::blocked_range3d<size_t>( 0, channelNames.size(), 1, 0, numTiles.x, 1, 0, numTiles.y, 1 ),
-			  GafferImage::Detail::ProcessTiles<ThreadableFunctor>( functor, imagePlug, channelNames, tilesOrigin, Gaffer::Context::current() ) );
+	parallel_for(
+		tbb::blocked_range3d<size_t>( 0, channelNames.size(), 1, 0, numTiles.x, 1, 0, numTiles.y, 1 ),
+		GafferImage::Detail::ProcessTiles<ThreadableFunctor>( functor, imagePlug, channelNames, tilesOrigin, Gaffer::Context::current() )
+	);
 }
 
 template <class TileFunctor, class GatherFunctor>

--- a/include/GafferImage/ImageAlgo.inl
+++ b/include/GafferImage/ImageAlgo.inl
@@ -307,8 +307,8 @@ inline bool channelExists( const std::vector<std::string> &channelNames, const s
 	return std::find( channelNames.begin(), channelNames.end(), channelName ) != channelNames.end();
 }
 
-template <class ThreadableFunctor>
-void parallelProcessTiles( const ImagePlug *imagePlug, ThreadableFunctor &functor, const Imath::Box2i &window, TileOrder tileOrder )
+template <class TileFunctor>
+void parallelProcessTiles( const ImagePlug *imagePlug, TileFunctor &&functor, const Imath::Box2i &window, TileOrder tileOrder )
 {
 	Imath::Box2i processWindow = window;
 	if( BufferAlgo::empty( processWindow ) )
@@ -347,8 +347,8 @@ void parallelProcessTiles( const ImagePlug *imagePlug, ThreadableFunctor &functo
 	);
 }
 
-template <class ThreadableFunctor>
-void parallelProcessTiles( const ImagePlug *imagePlug, const std::vector<std::string> &channelNames, ThreadableFunctor &functor, const Imath::Box2i &window, TileOrder tileOrder )
+template <class TileFunctor>
+void parallelProcessTiles( const ImagePlug *imagePlug, const std::vector<std::string> &channelNames, TileFunctor &&functor, const Imath::Box2i &window, TileOrder tileOrder )
 {
 	Imath::Box2i processWindow = window;
 	if( BufferAlgo::empty( processWindow ) )
@@ -391,7 +391,7 @@ void parallelProcessTiles( const ImagePlug *imagePlug, const std::vector<std::st
 }
 
 template <class TileFunctor, class GatherFunctor>
-void parallelGatherTiles( const ImagePlug *imagePlug, TileFunctor &tileFunctor, GatherFunctor &gatherFunctor, const Imath::Box2i &window, TileOrder tileOrder )
+void parallelGatherTiles( const ImagePlug *imagePlug, const TileFunctor &tileFunctor, GatherFunctor &&gatherFunctor, const Imath::Box2i &window, TileOrder tileOrder )
 {
 	Imath::Box2i processWindow = window;
 	if( BufferAlgo::empty( processWindow ) )
@@ -451,7 +451,7 @@ void parallelGatherTiles( const ImagePlug *imagePlug, TileFunctor &tileFunctor, 
 }
 
 template <class TileFunctor, class GatherFunctor>
-void parallelGatherTiles( const ImagePlug *imagePlug, const std::vector<std::string> &channelNames, TileFunctor &tileFunctor, GatherFunctor &gatherFunctor, const Imath::Box2i &window, TileOrder tileOrder )
+void parallelGatherTiles( const ImagePlug *imagePlug, const std::vector<std::string> &channelNames, const TileFunctor &tileFunctor, GatherFunctor &&gatherFunctor, const Imath::Box2i &window, TileOrder tileOrder )
 {
 	Imath::Box2i processWindow = window;
 	if( BufferAlgo::empty( processWindow ) )

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -491,8 +491,6 @@ class Catalogue::InternalImage : public ImageNode
 					{
 					}
 
-					typedef IECore::MurmurHash Result;
-
 					IECore::MurmurHash operator()( const ImagePlug *imagePlug, const std::string &channelName, const Imath::V2i &tileOrigin )
 					{
 						return imagePlug->channelDataPlug()->hash();

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -104,35 +104,6 @@ class CopyTile
 
 };
 
-struct HashTile
-{
-
-	MurmurHash operator()( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
-	{
-		return imagePlug->channelDataPlug()->hash();
-	}
-
-};
-
-struct AppendHash
-{
-
-	AppendHash( MurmurHash &hash )
-		:	m_hash( hash )
-	{
-	}
-
-	void operator()( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin, const IECore::MurmurHash &tileHash )
-	{
-		m_hash.append( tileHash );
-	}
-
-	private :
-
-		MurmurHash &m_hash;
-
-};
-
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -398,9 +369,21 @@ IECore::MurmurHash ImagePlug::imageHash() const
 	result.append( metadataPlug()->hash() );
 	result.append( channelNamesPlug()->hash() );
 
-	HashTile hashTile;
-	AppendHash appendHash( result );
-	ImageAlgo::parallelGatherTiles( this, channelNames, hashTile, appendHash, dataWindow, ImageAlgo::BottomToTop );
+	ImageAlgo::parallelGatherTiles(
+		this, channelNames,
+		// Tile
+		[] ( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
+		{
+			return imagePlug->channelDataPlug()->hash();
+		},
+		// Gather
+		[ &result ] ( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin, const IECore::MurmurHash &tileHash )
+		{
+			result.append( tileHash );
+		},
+		dataWindow,
+		ImageAlgo::BottomToTop
+	);
 
 	return result;
 }

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -107,9 +107,7 @@ class CopyTile
 struct HashTile
 {
 
-	typedef MurmurHash Result;
-
-	Result operator()( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
+	MurmurHash operator()( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
 	{
 		return imagePlug->channelDataPlug()->hash();
 	}

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -121,7 +121,7 @@ class TileProcessor
 
 		TileProcessor() {}
 
-		ConstFloatVectorDataPtr operator()( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
+		ConstFloatVectorDataPtr operator()( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin ) const
 		{
 			return imagePlug->channelDataPlug()->getValue();
 		}

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -118,11 +118,10 @@ typedef std::shared_ptr<ImageOutput> ImageOutputPtr;
 class TileProcessor
 {
 	public:
-		typedef ConstFloatVectorDataPtr Result;
 
 		TileProcessor() {}
 
-		Result operator()( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
+		ConstFloatVectorDataPtr operator()( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
 		{
 			return imagePlug->channelDataPlug()->getValue();
 		}


### PR DESCRIPTION
This simplifies the internal implementation of the `ImageAlgo::parallel*()` routines, and also makes them easier to use, and lambda-friendly. I've kept the commits as a series of small changes, but you may find it easier just to review as a whole. This is the final part of my preparation for the async ImageView.