### PR TITLE
SceneViewUI LookThrough menu : Defer camera and light set computation until required

### DIFF
--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -357,20 +357,13 @@ class _CameraPlugValueWidget( GafferUI.PlugValueWidget ) :
 			}
 		)
 
-		sets = {}
-		with IECore.IgnoredExceptions( Exception ) :
-			with self.getContext() :
-				sets = GafferScene.SceneAlgo.sets( self.getPlug().node()["in"], ( "__cameras", "__lights" ) )
-
-		for setName in sorted( sets.keys() ) :
-			for abbreviatedPath, path in self.__abbreviatedPaths( sets[setName].value ) :
-				m.append(
-					"/{}{}".format( setName[2:-1].title(), abbreviatedPath ),
-					{
-						"checkBox" : currentLookThrough == path,
-						"command" : functools.partial( Gaffer.WeakMethod( self.__lookThrough ), path )
-					}
-				)
+		for setName in ( "__cameras", "__lights" ) :
+			m.append(
+				"/{}".format( setName[2:-1].title() ),
+				{
+					"subMenu" : functools.partial( Gaffer.WeakMethod( self.__setMenu ), setName, currentLookThrough ),
+				}
+			)
 
 		m.append( "/BrowseDivider", { "divider" : True } )
 
@@ -483,17 +476,6 @@ class _CameraPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if len( event.data ) != 1 :
 			return False
 
-		sets = {}
-		with IECore.IgnoredExceptions( Exception ) :
-			with self.getContext() :
-				sets = GafferScene.SceneAlgo.sets( self.getPlug().node()["in"], ( "__cameras", "__lights" ) )
-
-		if not any(
-			s.value.match( event.data[0] ) & IECore.PathMatcher.Result.ExactMatch
-			for s in sets.values()
-		) :
-			return False
-
 		self.setHighlighted( True )
 		return True
 
@@ -502,6 +484,34 @@ class _CameraPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.setHighlighted( False )
 		self.__lookThrough( event.data[0] )
 		return True
+
+	def __computeSet( self, setName ) :
+
+		sets = {}
+		with IECore.IgnoredExceptions( Exception ) :
+			with self.getContext() :
+				sets = GafferScene.SceneAlgo.sets( self.getPlug().node()["in"], [ setName ] )
+
+		return sets.get( setName )
+
+	def __setMenu( self, setName, currentLookThrough ) :
+
+		m = IECore.MenuDefinition()
+
+		set = self.__computeSet( setName )
+		if not set :
+			return m
+
+		for abbreviatedPath, path in self.__abbreviatedPaths( set.value ) :
+			m.append(
+				"/{}".format( abbreviatedPath ),
+				{
+					"checkBox" : currentLookThrough == path,
+					"command" : functools.partial( Gaffer.WeakMethod( self.__lookThrough ), path )
+				}
+			)
+
+		return m
 
 	## \todo Would this be useful as PathMatcherAlgo
 	# somewhere (implemented in C++ using iterators)?


### PR DESCRIPTION
Large production scenes can have expensive set computations, and several uses of the LookThrough tool menu don't require that expense. Hopefully the first commit is non-contentious. The 2nd commit is more-so, but I'd argue the excessively permissive drag/drop is worth the computation savings, especially now that we have a visual indication in the viewer itself:

https://github.com/GafferHQ/gaffer/blob/16a970c425bc5c01ef25381215638900a37c020a/sphereCam.png
