### PR TITLE
Appleseed 1.9 update

### DIFF
--- a/bin/gaffer
+++ b/bin/gaffer
@@ -220,6 +220,7 @@ if [[ $APPLESEED ]] ; then
 	done
 
 	prependToPath "$APPLESEED/shaders/gaffer" OSL_SHADER_PATHS
+	prependToPath "$APPLESEED/shaders/appleseed" OSL_SHADER_PATHS
 	prependToPath "$GAFFER_ROOT/appleseedDisplays" APPLESEED_SEARCHPATH
 	prependToPath "$OSL_SHADER_PATHS" APPLESEED_SEARCHPATH
 

--- a/python/GafferAppleseedUI/AppleseedOptionsUI.py
+++ b/python/GafferAppleseedUI/AppleseedOptionsUI.py
@@ -153,6 +153,20 @@ def __sppmSummary( plug ) :
 
 	return ", ".join( info )
 
+def __denoiserSummary( plug ) :
+
+	info = []
+	if plug["denoiserMode"]["enabled"].getValue() :
+		info.append( "Denoiser %s" % plug["denoiserMode"]["value"].getValue() )
+	if plug["denoiserSkipPixels"]["enabled"].getValue() :
+		info.append( "Skip Pixels %s" % plug["denoiserSkipPixels"]["value"].getValue() )
+	if plug["denoiserRandomPixelOrder"]["enabled"].getValue() :
+		info.append( "Random Order %s" % plug["denoiserRandomPixelOrder"]["value"].getValue() )
+	if plug["denoiserScales"]["enabled"].getValue() :
+		info.append( "Scales %s" % plug["denoiserScales"]["value"].getValue() )
+
+	return ", ".join( info )
+
 def __systemSummary( plug ) :
 
 	info = []
@@ -200,6 +214,7 @@ Gaffer.Metadata.registerNode(
 			"layout:section:Environment:summary", __environmentSummary,
 			"layout:section:Unidirectional Path Tracer:summary", __ptSummary,
 			"layout:section:SPPM:summary", __sppmSummary,
+			"layout:section:Denoiser:summary", __denoiserSummary,
 			"layout:section:System:summary", __systemSummary,
 			"layout:section:Logging:summary", __loggingSummary,
 
@@ -591,6 +606,71 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "SPPM",
 			"label", "Alpha",
+
+		],
+
+		# Denoiser
+
+		"options.denoiserMode" : [
+
+			"description",
+			"""
+			Enable the denoiser.
+			When choosing Write Outputs, two EXR images with denoising AOVs
+			will be written in the same directory as the beauty image.
+			The command line denoiser in appleseed can be used with the EXR files
+			to produce denoised images.
+			""",
+
+			"layout:section", "Denoiser",
+			"label", "Denoiser",
+		],
+
+		"options.denoiserMode.value" : [
+
+			"preset:Off", "off",
+			"preset:On", "on",
+			"preset:Write Outputs", "write_outputs",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+		],
+
+		"options.denoiserSkipPixels" : [
+
+			"description",
+			"""
+			Disabling this option will produce better results 
+			at the expense of slower processing time.
+			""",
+
+			"layout:section", "Denoiser",
+			"label", "Skip Denoised Pixels",
+
+		],
+
+		"options.denoiserRandomPixelOrder" : [
+
+			"description",
+			"""
+			Process pixels in random order.
+			Enabling this option can help reducing artifacts.
+			""",
+
+			"layout:section", "Denoiser",
+			"label", "Random Pixel Order",
+
+		],
+
+		"options.denoiserScales" : [
+
+			"description",
+			"""
+			Number of resolution scales used for denoising.
+			""",
+
+			"layout:section", "Denoiser",
+			"label", "Denoise Scales",
 
 		],
 

--- a/src/GafferAppleseed/AppleseedOptions.cpp
+++ b/src/GafferAppleseed/AppleseedOptions.cpp
@@ -83,6 +83,12 @@ AppleseedOptions::AppleseedOptions( const std::string &name )
 	options->addOptionalMember( "as:cfg:sppm:max_photons_per_estimate", new IECore::IntData( 100 ), "sppmMaxPhotons", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:sppm:alpha", new IECore::FloatData( 0.7f ), "sppmAlpha", Gaffer::Plug::Default, false );
 
+	// denoiser
+	options->addOptionalMember( "as:frame:denoiser", new IECore::StringData( "off" ), "denoiserMode", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:frame:skip_denoised", new IECore::BoolData( true ), "denoiserSkipPixels", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:frame:random_pixel_order", new IECore::BoolData( true ), "denoiserRandomPixelOrder", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "as:frame:denoise_scales", new IECore::IntData( 3 ), "denoiserScales", Gaffer::Plug::Default, false );
+
 	// system parameters
 	options->addOptionalMember( "as:searchpath", new IECore::StringData( "" ), "searchPath", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "as:cfg:rendering_threads", new IECore::IntData( 0 ), "numThreads", Gaffer::Plug::Default, false );

--- a/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
+++ b/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
@@ -2592,6 +2592,29 @@ class AppleseedRenderer final : public AppleseedRendererBase
 				return;
 			}
 
+			// appleseed frame settings.
+			if( boost::starts_with( name.c_str(), "as:frame:" ) )
+			{
+				// remove the option prefix.
+				string optName( name.string(), 9, string::npos );
+
+				asr::Frame* frame = m_project->get_frame();
+
+				const IECore::Data *dataValue = IECore::runTimeCast<const IECore::Data>( value );
+
+				if( dataValue == nullptr )
+				{
+					frame->get_parameters().remove_path( optName.c_str() );
+				}
+				else
+				{
+					string valueStr = ParameterAlgo::dataToString( dataValue );
+					frame->get_parameters().insert( optName.c_str(), valueStr.c_str() );
+				}
+
+				return;
+			}
+
 			// other appleseed options.
 			if( boost::starts_with( name.c_str(), "as:" ) )
 			{

--- a/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
+++ b/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
@@ -2297,10 +2297,6 @@ void AppleseedRendererBase::createProject()
 	asf::auto_release_ptr<asr::Frame> frame( asr::FrameFactory::create( "beauty", asr::ParamArray().insert( "resolution", "640 480" ) ) );
 	m_project->set_frame( frame );
 
-	// 16 bits float (half) is the default pixel format in appleseed.
-	// Force the pixel format to float to avoid half -> float conversions in the display driver.
-	m_project->get_frame()->get_parameters().insert( "pixel_format", "float" );
-
 	// Create the scene
 	asf::auto_release_ptr<asr::Scene> scene = asr::SceneFactory::create();
 	m_project->set_scene( scene );

--- a/startup/gui/outputs.py
+++ b/startup/gui/outputs.py
@@ -205,7 +205,8 @@ with IECore.IgnoredExceptions( ImportError ) :
 		"indirect_glossy",
 		"depth",
 		"normal",
-		"uv"
+		"uv",
+		"pixel_time"
 	] :
 
 		label = aov.replace( "_", " " ).title().replace( " ", "_" )


### PR DESCRIPTION
Depends on ImageEngine/cortex#790.

appleseed 1.9 (and Gaffer) builds with OSL 1.9.8, OIIO 1.8.9 and LLVM 5.0.1 without changes.
Building appleseed with LLVM 3.4 and older OSL versions still works, but I have frequent LLVM crashes on computers with recent intel CPUs. Switching to LLVM 5.0.1 fixed the issues for me.