### PR TITLE
Arnold Surface Shader: put new parameters into separate section

### DIFF
--- a/arnold/plugins/gaffer.mtd
+++ b/arnold/plugins/gaffer.mtd
@@ -787,6 +787,38 @@
 	[attr indirect_specular]
 		page STRING "Advanced"
 
+	[attr aov_id1]
+		page STRING "AOV"
+	[attr aov_id2]
+		page STRING "AOV"
+	[attr aov_id3]
+		page STRING "AOV"
+	[attr aov_id4]
+		page STRING "AOV"
+	[attr aov_id5]
+		page STRING "AOV"
+	[attr aov_id6]
+		page STRING "AOV"
+	[attr aov_id7]
+		page STRING "AOV"
+	[attr aov_id8]
+		page STRING "AOV"
+	[attr id1]
+		page STRING "AOV"
+	[attr id2]
+		page STRING "AOV"
+	[attr id3]
+		page STRING "AOV"
+	[attr id4]
+		page STRING "AOV"
+	[attr id5]
+		page STRING "AOV"
+	[attr id6]
+		page STRING "AOV"
+	[attr id7]
+		page STRING "AOV"
+	[attr id8]
+		page STRING "AOV"
 
 [node standard_hair]
 


### PR DESCRIPTION
Hey John,

here's that mini PR regarding the new parameters on `aiStandardSurface`. I've called the section "AOV" in anticipation of more aov related parameters, but I'd be happy to rename it to "IDs" or whatever we think is more reasonable for the moment.

Cheerio :)

Matti.
