### PR TITLE
Dispatcher : Add `dispatchSignal()`

### DIFF
--- a/include/GafferDispatch/Dispatcher.h
+++ b/include/GafferDispatch/Dispatcher.h
@@ -106,19 +106,25 @@ class GAFFERDISPATCH_API Dispatcher : public Gaffer::Node
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferDispatch::Dispatcher, DispatcherTypeId, Gaffer::Node );
 
 		typedef boost::signal<bool (const Dispatcher *, const std::vector<TaskNodePtr> &), Detail::PreDispatchSignalCombiner> PreDispatchSignal;
+		typedef boost::signal<void (const Dispatcher *, const std::vector<TaskNodePtr> &)> DispatchSignal;
 		typedef boost::signal<void (const Dispatcher *, const std::vector<TaskNodePtr> &, bool)> PostDispatchSignal;
 
 		//! @name Dispatch Signals
 		/// These signals are emitted on dispatch events for any registered Dispatcher instance.
 		////////////////////////////////////////////////////////////////////////////////////////
 		//@{
-		/// Called when any dispatcher is about to dispatch nodes. Slots should have the
+		/// Called when any dispatcher might begin to dispatch nodes. Slots should have the
 		/// signature `bool slot( dispatcher, nodes )`, and may return True to cancel
 		/// the dispatch, or False to allow it to continue.
 		static PreDispatchSignal &preDispatchSignal();
-		/// Called after any dispatcher has finished dispatching nodes. Slots should have the
-		/// signature `void slot( dispatcher, nodes, bool )`. The third argument will be True
-		/// if the process was successful, and False otherwise.
+		/// Called when any dispatcher is going to dispatch nodes. Slots should have the
+		/// signature `bool slot( dispatcher, nodes )`. This differs from the preDispatchSignal
+		/// in that it is triggered when dispatching is imminent and non-cancellable.
+		static DispatchSignal &dispatchSignal();
+		/// Called after any dispatcher has finished dispatching nodes, or after a pending dispatch
+		/// has been cancelled by the preDispatchSignal slots. Slots should have the signature
+		/// `void slot( dispatcher, nodes, bool )`. The third argument will be True if the process
+		/// was successful, and False otherwise.
 		static PostDispatchSignal &postDispatchSignal();
 		//@}
 
@@ -279,6 +285,7 @@ class GAFFERDISPATCH_API Dispatcher : public Gaffer::Node
 
 		static size_t g_firstPlugIndex;
 		static PreDispatchSignal g_preDispatchSignal;
+		static DispatchSignal g_dispatchSignal;
 		static PostDispatchSignal g_postDispatchSignal;
 		static std::string g_defaultDispatcherType;
 

--- a/include/GafferDispatch/Dispatcher.h
+++ b/include/GafferDispatch/Dispatcher.h
@@ -40,6 +40,7 @@
 #include "GafferDispatch/Export.h"
 #include "GafferDispatch/TaskNode.h"
 
+#include "Gaffer/CatchingSignalCombiner.h"
 #include "Gaffer/NumericPlug.h"
 
 #include "IECore/CompoundData.h"
@@ -106,9 +107,8 @@ class GAFFERDISPATCH_API Dispatcher : public Gaffer::Node
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferDispatch::Dispatcher, DispatcherTypeId, Gaffer::Node );
 
 		typedef boost::signal<bool (const Dispatcher *, const std::vector<TaskNodePtr> &), Detail::PreDispatchSignalCombiner> PreDispatchSignal;
-		typedef boost::signal<void (const Dispatcher *, const std::vector<TaskNodePtr> &)> DispatchSignal;
-		typedef boost::signal<void (const Dispatcher *, const std::vector<TaskNodePtr> &, bool)> PostDispatchSignal;
-
+		typedef boost::signal<void (const Dispatcher *, const std::vector<TaskNodePtr> &), Gaffer::CatchingSignalCombiner<void> > DispatchSignal;
+		typedef boost::signal<void (const Dispatcher *, const std::vector<TaskNodePtr> &, bool), Gaffer::CatchingSignalCombiner<void> > PostDispatchSignal;
 		//! @name Dispatch Signals
 		/// These signals are emitted on dispatch events for any registered Dispatcher instance.
 		////////////////////////////////////////////////////////////////////////////////////////

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -170,6 +170,8 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 		preCs = GafferTest.CapturingSlot( GafferDispatch.Dispatcher.preDispatchSignal() )
 		self.assertEqual( len( preCs ), 0 )
+		dispatchCs = GafferTest.CapturingSlot( GafferDispatch.Dispatcher.dispatchSignal() )
+		self.assertEqual( len( dispatchCs ), 0 )
 		postCs = GafferTest.CapturingSlot( GafferDispatch.Dispatcher.postDispatchSignal() )
 		self.assertEqual( len( postCs ), 0 )
 
@@ -182,6 +184,10 @@ class DispatcherTest( GafferTest.TestCase ) :
 		self.assertEqual( len( preCs ), 1 )
 		self.failUnless( preCs[0][0].isSame( dispatcher ) )
 		self.assertEqual( preCs[0][1], [ s["n1"] ] )
+
+		self.assertEqual( len( dispatchCs ), 1 )
+		self.failUnless( dispatchCs[0][0].isSame( dispatcher ) )
+		self.assertEqual( dispatchCs[0][1], [ s["n1"] ] )
 
 		self.assertEqual( len( postCs ), 1 )
 		self.failUnless( postCs[0][0].isSame( dispatcher ) )
@@ -196,7 +202,8 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 			return False
 
-		connection = GafferDispatch.Dispatcher.preDispatchSignal().connect( onlyRunOnce )
+		preConnection = GafferDispatch.Dispatcher.preDispatchSignal().connect( onlyRunOnce )
+		connection = GafferTest.CapturingSlot( GafferDispatch.Dispatcher.dispatchSignal() )
 
 		dispatcher = GafferDispatch.Dispatcher.create( "testDispatcher" )
 
@@ -205,14 +212,17 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 		# never run
 		self.assertEqual( len( s["n1"].log ), 0 )
+		self.assertEqual( len( connection ), 0 )
 
 		# runs the first time
 		dispatcher.dispatch( [ s["n1"] ] )
 		self.assertEqual( len( s["n1"].log ), 1 )
+		self.assertEqual( len( connection ), 1 )
 
 		# never runs again
 		dispatcher.dispatch( [ s["n1"] ] )
 		self.assertEqual( len( s["n1"].log ), 1 )
+		self.assertEqual( len( connection ), 1 )
 
 	def testPlugs( self ) :
 

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -168,18 +168,7 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 	def testDispatcherSignals( self ) :
 
-		class CapturingSlot2( list ) :
-
-			def __init__( self, *signals ) :
-
-				self.__connections = []
-				for s in signals :
-					self.__connections.append( s.connect( Gaffer.WeakMethod( self.__slot ) ) )
-
-			def __slot( self, d, nodes ) :
-				self.append( (d,nodes) )
-
-		preCs = CapturingSlot2( GafferDispatch.Dispatcher.preDispatchSignal() )
+		preCs = GafferTest.CapturingSlot( GafferDispatch.Dispatcher.preDispatchSignal() )
 		self.assertEqual( len( preCs ), 0 )
 		postCs = GafferTest.CapturingSlot( GafferDispatch.Dispatcher.postDispatchSignal() )
 		self.assertEqual( len( postCs ), 0 )

--- a/python/GafferDispatchTest/LocalDispatcherTest.py
+++ b/python/GafferDispatchTest/LocalDispatcherTest.py
@@ -317,6 +317,8 @@ class LocalDispatcherTest( GafferTest.TestCase ) :
 
 		preCs = GafferTest.CapturingSlot( GafferDispatch.Dispatcher.preDispatchSignal() )
 		self.assertEqual( len( preCs ), 0 )
+		dispatchCs = GafferTest.CapturingSlot( GafferDispatch.Dispatcher.preDispatchSignal() )
+		self.assertEqual( len( dispatchCs ), 0 )
 		postCs = GafferTest.CapturingSlot( GafferDispatch.Dispatcher.postDispatchSignal() )
 		self.assertEqual( len( postCs ), 0 )
 
@@ -332,6 +334,10 @@ class LocalDispatcherTest( GafferTest.TestCase ) :
 		self.failUnless( preCs[0][0].isSame( dispatcher ) )
 		self.assertEqual( preCs[0][1], [ s["n1"] ] )
 
+		self.assertEqual( len( dispatchCs ), 1 )
+		self.failUnless( dispatchCs[0][0].isSame( dispatcher ) )
+		self.assertEqual( dispatchCs[0][1], [ s["n1"] ] )
+
 		self.assertEqual( len( postCs ), 1 )
 		self.failUnless( postCs[0][0].isSame( dispatcher ) )
 		self.assertEqual( postCs[0][1], [ s["n1"] ] )
@@ -340,6 +346,8 @@ class LocalDispatcherTest( GafferTest.TestCase ) :
 
 		preCs = GafferTest.CapturingSlot( GafferDispatch.LocalDispatcher.preDispatchSignal() )
 		self.assertEqual( len( preCs ), 0 )
+		dispatchCs = GafferTest.CapturingSlot( GafferDispatch.LocalDispatcher.dispatchSignal() )
+		self.assertEqual( len( dispatchCs ), 0 )
 		postCs = GafferTest.CapturingSlot( GafferDispatch.LocalDispatcher.postDispatchSignal() )
 		self.assertEqual( len( postCs ), 0 )
 
@@ -354,6 +362,7 @@ class LocalDispatcherTest( GafferTest.TestCase ) :
 
 		# the dispatching started and finished
 		self.assertEqual( len( preCs ), 1 )
+		self.assertEqual( len( dispatchCs ), 1 )
 		self.assertEqual( len( postCs ), 1 )
 
 		# but the execution hasn't finished yet
@@ -370,6 +379,8 @@ class LocalDispatcherTest( GafferTest.TestCase ) :
 
 		preCs = GafferTest.CapturingSlot( GafferDispatch.LocalDispatcher.preDispatchSignal() )
 		self.assertEqual( len( preCs ), 0 )
+		dispatchCs = GafferTest.CapturingSlot( GafferDispatch.LocalDispatcher.dispatchSignal() )
+		self.assertEqual( len( dispatchCs ), 0 )
 		postCs = GafferTest.CapturingSlot( GafferDispatch.LocalDispatcher.postDispatchSignal() )
 		self.assertEqual( len( postCs ), 0 )
 
@@ -412,6 +423,7 @@ class LocalDispatcherTest( GafferTest.TestCase ) :
 
 		# the dispatching started and finished
 		self.assertEqual( len( preCs ), 1 )
+		self.assertEqual( len( dispatchCs ), 1 )
 		self.assertEqual( len( postCs ), 1 )
 
 		# all the foreground execution has finished

--- a/python/GafferDispatchTest/LocalDispatcherTest.py
+++ b/python/GafferDispatchTest/LocalDispatcherTest.py
@@ -315,18 +315,7 @@ class LocalDispatcherTest( GafferTest.TestCase ) :
 
 	def testDispatcherSignals( self ) :
 
-		class CapturingSlot2( list ) :
-
-			def __init__( self, *signals ) :
-
-				self.__connections = []
-				for s in signals :
-					self.__connections.append( s.connect( Gaffer.WeakMethod( self.__slot ) ) )
-
-			def __slot( self, d, nodes ) :
-				self.append( (d,nodes) )
-
-		preCs = CapturingSlot2( GafferDispatch.Dispatcher.preDispatchSignal() )
+		preCs = GafferTest.CapturingSlot( GafferDispatch.Dispatcher.preDispatchSignal() )
 		self.assertEqual( len( preCs ), 0 )
 		postCs = GafferTest.CapturingSlot( GafferDispatch.Dispatcher.postDispatchSignal() )
 		self.assertEqual( len( postCs ), 0 )

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -586,14 +586,7 @@ class DispatcherSignalGuard
 
 		~DispatcherSignalGuard()
 		{
-			try
-			{
-				Dispatcher::postDispatchSignal()( m_dispatcher, m_taskNodes, (m_dispatchSuccessful && ( !m_cancelledByPreDispatch )) );
-			}
-			catch( const std::exception& e )
-			{
-				IECore::msg( IECore::Msg::Error, "postDispatchSignal exception:", e.what() );
-			}
+			Dispatcher::postDispatchSignal()( m_dispatcher, m_taskNodes, (m_dispatchSuccessful && ( !m_cancelledByPreDispatch )) );
 		}
 
 		bool cancelledByPreDispatch( )
@@ -676,14 +669,7 @@ void Dispatcher::dispatch( const std::vector<NodePtr> &nodes ) const
 		return;
 	}
 
-	try
-	{
-		dispatchSignal()( this, taskNodes );
-	}
-	catch( const std::exception& e )
-	{
-		IECore::msg( IECore::Msg::Error, "dispatchSignal exception:", e.what() );
-	}
+	dispatchSignal()( this, taskNodes );
 
 	std::vector<FrameList::Frame> frames;
 	FrameListPtr frameList = frameRange( script, Context::current() );

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -655,8 +655,9 @@ void Dispatcher::dispatch( const std::vector<NodePtr> &nodes ) const
 		}
 	}
 
-	// create the job directory now, so it's available in preDispatchSignal().
 	Context::EditableScope jobScope( Context::current() );
+	// create the job directory now, so it's available in preDispatchSignal().
+	/// \todo: move directory creation between preDispatchSignal() and dispatchSignal()
 	m_jobDirectory = createJobDirectory( Context::current() );
 	jobScope.set( g_jobDirectoryContextEntry, m_jobDirectory );
 

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -575,14 +575,14 @@ class DispatcherSignalGuard
 
 		DispatcherSignalGuard( const Dispatcher* d, const std::vector<TaskNodePtr> &taskNodes ) : m_dispatchSuccessful( false ), m_taskNodes( taskNodes ), m_dispatcher( d )
 		{
-			m_cancelledByPreDispatch = m_dispatcher->preDispatchSignal()( m_dispatcher, m_taskNodes );
+			m_cancelledByPreDispatch = Dispatcher::preDispatchSignal()( m_dispatcher, m_taskNodes );
 		}
 
 		~DispatcherSignalGuard()
 		{
 			try
 			{
-				m_dispatcher->postDispatchSignal()( m_dispatcher, m_taskNodes, (m_dispatchSuccessful && ( !m_cancelledByPreDispatch )) );
+				Dispatcher::postDispatchSignal()( m_dispatcher, m_taskNodes, (m_dispatchSuccessful && ( !m_cancelledByPreDispatch )) );
 			}
 			catch( const std::exception& e )
 			{

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -64,6 +64,7 @@ static IECore::BoolDataPtr g_trueBoolData = new BoolData( true );
 
 size_t Dispatcher::g_firstPlugIndex = 0;
 Dispatcher::PreDispatchSignal Dispatcher::g_preDispatchSignal;
+Dispatcher::DispatchSignal Dispatcher::g_dispatchSignal;
 Dispatcher::PostDispatchSignal Dispatcher::g_postDispatchSignal;
 std::string Dispatcher::g_defaultDispatcherType = "";
 
@@ -177,6 +178,11 @@ std::string Dispatcher::createJobDirectory( const Context *context ) const
 Dispatcher::PreDispatchSignal &Dispatcher::preDispatchSignal()
 {
 	return g_preDispatchSignal;
+}
+
+Dispatcher::DispatchSignal &Dispatcher::dispatchSignal()
+{
+	return g_dispatchSignal;
 }
 
 Dispatcher::PostDispatchSignal &Dispatcher::postDispatchSignal()
@@ -668,6 +674,15 @@ void Dispatcher::dispatch( const std::vector<NodePtr> &nodes ) const
 	if ( signalGuard.cancelledByPreDispatch() )
 	{
 		return;
+	}
+
+	try
+	{
+		dispatchSignal()( this, taskNodes );
+	}
+	catch( const std::exception& e )
+	{
+		IECore::msg( IECore::Msg::Error, "dispatchSignal exception:", e.what() );
 	}
 
 	std::vector<FrameList::Frame> frames;

--- a/src/GafferDispatchModule/DispatcherBinding.cpp
+++ b/src/GafferDispatchModule/DispatcherBinding.cpp
@@ -294,6 +294,28 @@ struct PreDispatchSlotCaller
 	}
 };
 
+struct DispatchSlotCaller
+{
+	boost::signals::detail::unusable operator()( boost::python::object slot, const Dispatcher *d, const std::vector<TaskNodePtr> &nodes )
+	{
+		try
+		{
+			list nodeList;
+			for( std::vector<TaskNodePtr>::const_iterator nIt = nodes.begin(); nIt != nodes.end(); nIt++ )
+			{
+				nodeList.append( *nIt );
+			}
+			DispatcherPtr dd = const_cast<Dispatcher*>(d);
+			slot( dd, nodeList );
+		}
+		catch( const boost::python::error_already_set &e )
+		{
+			ExceptionAlgo::translatePythonException();
+		}
+		return boost::signals::detail::unusable();
+	}
+};
+
 struct PostDispatchSlotCaller
 {
 	boost::signals::detail::unusable operator()( boost::python::object slot, const Dispatcher *d, const std::vector<TaskNodePtr> &nodes, bool success )
@@ -330,6 +352,7 @@ void GafferDispatchModule::bindDispatcher()
 		.def( "registerDispatcher", &registerDispatcher, ( arg( "dispatcherType" ), arg( "creator" ), arg( "setupPlugsFn" ) = 0 ) ).staticmethod( "registerDispatcher" )
 		.def( "registeredDispatchers", &registeredDispatchersWrapper ).staticmethod( "registeredDispatchers" )
 		.def( "preDispatchSignal", &Dispatcher::preDispatchSignal, return_value_policy<reference_existing_object>() ).staticmethod( "preDispatchSignal" )
+		.def( "dispatchSignal", &Dispatcher::dispatchSignal, return_value_policy<reference_existing_object>() ).staticmethod( "dispatchSignal" )
 		.def( "postDispatchSignal", &Dispatcher::postDispatchSignal, return_value_policy<reference_existing_object>() ).staticmethod( "postDispatchSignal" )
 	;
 
@@ -350,5 +373,6 @@ void GafferDispatchModule::bindDispatcher()
 	;
 
 	SignalClass<Dispatcher::PreDispatchSignal, DefaultSignalCaller<Dispatcher::PreDispatchSignal>, PreDispatchSlotCaller >( "PreDispatchSignal" );
+	SignalClass<Dispatcher::DispatchSignal, DefaultSignalCaller<Dispatcher::DispatchSignal>, DispatchSlotCaller >( "DispatchSignal" );
 	SignalClass<Dispatcher::PostDispatchSignal, DefaultSignalCaller<Dispatcher::PostDispatchSignal>, PostDispatchSlotCaller >( "PostDispatchSignal" );
 }

--- a/src/GafferDispatchModule/DispatcherBinding.cpp
+++ b/src/GafferDispatchModule/DispatcherBinding.cpp
@@ -286,9 +286,9 @@ struct PreDispatchSlotCaller
 			DispatcherPtr dd = const_cast<Dispatcher*>(d);
 			return slot( dd, nodeList );
 		}
-		catch( const error_already_set &e )
+		catch( const boost::python::error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // clears the error status
+			ExceptionAlgo::translatePythonException();
 		}
 		return false;
 	}
@@ -308,9 +308,9 @@ struct PostDispatchSlotCaller
 			DispatcherPtr dd = const_cast<Dispatcher*>(d);
 			slot( dd, nodeList, success );
 		}
-		catch( const error_already_set &e )
+		catch( const boost::python::error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // clears the error status
+			ExceptionAlgo::translatePythonException();
 		}
 		return boost::signals::detail::unusable();
 	}


### PR DESCRIPTION
This can be useful when the graph needs modification with assurance that the result will be dispatched. For example, an Asset Management system might want to hook into this signal to finalize database transactions prior to task execution.