### PR TITLE
WidgetAlgo : Fix bug when calling `grab()` with the event loop running

### DIFF
--- a/python/GafferUI/WidgetAlgo.py
+++ b/python/GafferUI/WidgetAlgo.py
@@ -72,7 +72,13 @@ def joinEdges( listContainer ) :
 
 def grab( widget, imagePath ) :
 
-	GafferUI.EventLoop.waitForIdle()
+	if not GafferUI.EventLoop.mainEventLoop().running() :
+		# This is a hack to try to give Qt time to
+		# finish processing any events needed to get
+		# the widget ready for capture. Really we need
+		# a rock solid way that _guarantees_ this, and which
+		# we can also use when the event loop is running.
+		GafferUI.EventLoop.waitForIdle()
 
 	imageDir = os.path.dirname( imagePath )
 	if imageDir and not os.path.isdir( imageDir ) :

--- a/python/GafferUITest/WidgetAlgoTest.py
+++ b/python/GafferUITest/WidgetAlgoTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import os
 import unittest
 import imath
 
@@ -72,6 +73,24 @@ class WidgetAlgoTest( GafferUITest.TestCase ) :
 			expectedSize *= screen.devicePixelRatio()
 
 		self.assertEqual( imath.V2f( i.displayWindow.size() ) + imath.V2f( 1 ), expectedSize )
+
+	def testGrabWithEventLoopRunning( self ) :
+
+		with GafferUI.Window() as w :
+			b = GafferUI.Button( "HI!" )
+
+		w.setVisible( True )
+		self.waitForIdle( 100000 )
+
+		def grab() :
+
+			GafferUI.WidgetAlgo.grab( b, self.temporaryDirectory() + "/grab.png" )
+			GafferUI.EventLoop.mainEventLoop().stop()
+
+		GafferUI.EventLoop.addIdleCallback( grab )
+		GafferUI.EventLoop.mainEventLoop().start()
+
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/grab.png" ) )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Historically `grab()` has only been used from within the screengrab app, but we now want to use it from within an interactive GUI session.