### PR TITLE
Async ImageView

### DIFF
--- a/include/Gaffer/Action.h
+++ b/include/Gaffer/Action.h
@@ -101,11 +101,17 @@ class GAFFER_API Action : public IECore::RunTimeTyped
 		/// circular reference. It is guaranteed that the subject will
 		/// remain alive for as long as the Functions are in use by the undo
 		/// system, so it is sufficient to bind only raw pointers to the subject.
-		static void enact( GraphComponentPtr subject, const Function &doFn, const Function &undoFn );
+		///
+		/// > Warning : Only pass `cancelBackgroundTasks = false` if you are
+		/// > _certain_ that there is no possible interaction between this Action
+		/// > and a concurrent background task. At the time of writing, the only
+		/// > known valid use is in the Metadata system (because computations are
+		/// > not allowed to depend on metadata).
+		static void enact( GraphComponentPtr subject, const Function &doFn, const Function &undoFn, bool cancelBackgroundTasks = true );
 
 	protected :
 
-		Action();
+		Action( bool cancelBackgroundTasks = true );
 		~Action() override;
 
 		/// Must be implemented by derived classes to
@@ -142,6 +148,7 @@ class GAFFER_API Action : public IECore::RunTimeTyped
 		friend class ScriptNode;
 
 		bool m_done;
+		const bool m_cancelBackgroundTasks;
 
 };
 

--- a/include/Gaffer/BackgroundTask.h
+++ b/include/Gaffer/BackgroundTask.h
@@ -105,10 +105,13 @@ class GAFFER_API BackgroundTask : public boost::noncopyable
 		friend class Action;
 		friend class ScriptNode;
 
-		IECore::Canceller m_canceller;
-		std::mutex m_mutex;
-		std::condition_variable m_conditionVariable;
-		bool m_done;
+		// Function to be executed.
+		Function m_function;
+
+		// Control structure for the TBB task we use to execute
+		// `m_function`. This is shared with the TBB task.
+		struct TaskData;
+		std::shared_ptr<TaskData> m_taskData;
 
 };
 

--- a/include/Gaffer/BackgroundTask.h
+++ b/include/Gaffer/BackgroundTask.h
@@ -103,6 +103,7 @@ class GAFFER_API BackgroundTask : public boost::noncopyable
 		// before an edit is made to `actionSubject`.
 		static void cancelAffectedTasks( const GraphComponent *actionSubject );
 		friend class Action;
+		friend class ScriptNode;
 
 		IECore::Canceller m_canceller;
 		std::mutex m_mutex;

--- a/include/Gaffer/BackgroundTask.h
+++ b/include/Gaffer/BackgroundTask.h
@@ -45,6 +45,7 @@
 
 #include <condition_variable>
 #include <functional>
+#include <memory>
 #include <mutex>
 
 namespace Gaffer

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -269,6 +269,10 @@ class GAFFER_API ScriptNode : public Node
 		const IntPlug *frameEndPlug() const;
 		//@}
 
+	protected :
+
+		void parentChanging( Gaffer::GraphComponent *newParent ) override;
+
 	private :
 
 		// Selection

--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -202,9 +202,20 @@ class GAFFERIMAGEUI_API ImageGadget : public GafferUI::Gadget
 			Tile() = default;
 			Tile( const Tile &other );
 
+			struct Update
+			{
+				Tile *tile;
+				IECore::ConstFloatVectorDataPtr channelData;
+				const IECore::MurmurHash channelDataHash;
+			};
+
 			// Called from a background thread with the context
 			// already set up appropriately for the tile.
-			void update( const GafferImage::ImagePlug *image );
+			Update computeUpdate( const GafferImage::ImagePlug *image );
+			// Applies previously computed updates for several tiles
+			// such that they become visible to the UI thread together.
+			static void applyUpdates( const std::vector<Update> &updates );
+
 			// Called from the UI thread.
 			const IECoreGL::Texture *texture();
 

--- a/python/GafferImageUITest/ImageGadgetTest.py
+++ b/python/GafferImageUITest/ImageGadgetTest.py
@@ -37,9 +37,8 @@
 import unittest
 import imath
 
-import IECore
-
 import Gaffer
+import GafferUI
 import GafferUITest
 import GafferImage
 import GafferImageUI
@@ -77,6 +76,29 @@ class ImageGadgetTest( GafferUITest.TestCase ) :
 		c = GafferImage.Constant()
 		g.setImage( c["out"] )
 		self.assertTrue( g.getImage().isSame( c["out"] ) )
+
+	def testDestroyWhileProcessing( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["c"] = GafferImage.Constant()
+		s["c"]["format"].setValue( GafferImage.Format( 2000, 2000 ) )
+
+		s["b"] = GafferImage.Blur()
+		s["b"]["in"].setInput( s["c"]["out"] )
+		s["b"]["radius"].setValue( imath.V2f( 400 ) )
+
+		g = GafferImageUI.ImageGadget()
+		g.setImage( s["b"]["out"] )
+
+		with GafferUI.Window() as w :
+			GafferUI.GadgetWidget( g )
+
+		w.setVisible( True )
+
+		self.waitForIdle( 1000 )
+
+		del g, w
+		del s
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/BackgroundTaskTest.py
+++ b/python/GafferTest/BackgroundTaskTest.py
@@ -83,6 +83,7 @@ class BackgroundTaskTest( GafferTest.TestCase ) :
 
 		s["n"]["op1"].setValue( 10 )
 		t = Gaffer.BackgroundTask( s["n"]["sum"], f )
+		time.sleep( 0.01 ) # Give task a chance to start before we cancel it
 		s["n"]["op1"].setValue( 20 )
 
 		self.assertEqual( operations, [ "set", "background", "set" ] )
@@ -108,6 +109,7 @@ class BackgroundTaskTest( GafferTest.TestCase ) :
 			lambda plug : operations.append( "undo" )
 		)
 		t = Gaffer.BackgroundTask( s["n"]["sum"], f )
+		time.sleep( 0.01 ) # Give task a chance to start before we cancel it
 		s.undo()
 
 		self.assertEqual( operations, [ "background", "undo" ] )
@@ -117,6 +119,7 @@ class BackgroundTaskTest( GafferTest.TestCase ) :
 			lambda plug : operations.append( "redo" )
 		)
 		t = Gaffer.BackgroundTask( s["n"]["sum"], f )
+		time.sleep( 0.01 ) # Give task a chance to start before we cancel it
 		s.redo()
 
 		self.assertEqual( operations, [ "background", "redo" ] )

--- a/python/GafferUI/BackgroundMethod.py
+++ b/python/GafferUI/BackgroundMethod.py
@@ -1,0 +1,201 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import collections
+import functools
+import sys
+
+import IECore
+
+import Gaffer
+import GafferUI
+
+# Decorator to assist in Widget background processing.
+# Usage example :
+#
+# ```
+# class MyWidget( GafferUI.Widget ) :
+#
+# 	...
+#
+#	@GafferUI.BackgroundMethod()
+#	def updateInBackground( self ) :
+#
+#		# When `updateInBackground()` is called
+#		# on the UI thread, the decorator will
+#		# run the function body asynchronously on
+#		# a background thread.
+#
+#		result = heavyProcessing()
+#		return result
+#
+#	@updateInBackground.preCall
+#	def __updateInBackgroundPreCall( self )
+#
+#		# Will be called automatically on the UI
+#		# thread before background processing starts.
+#
+#		pass
+#
+#	@updateInBackground.postCall
+#	def __updateInBackgroundPreCall( self, result )
+#
+#		# Called on the UI thread with the result
+#		# of the background call. Typically used to
+#		# display the result.
+#
+#		pass
+# ```
+class BackgroundMethod( object ) :
+
+	__CurrentCall = collections.namedtuple( "__CurrentCall", [ "backgroundTask", "superceded" ] )
+
+	def __init__( self, cancelWhenHidden = True ) :
+
+		self.__cancelWhenHidden = cancelWhenHidden
+
+	# Called to return the decorated method.
+	def __call__( self, method ) :
+
+		method.__preCall = None
+		method.__postCall = None
+		method.__plug = self.__plug
+
+		def foregroundFunction( widget, result, superceded ) :
+
+			if superceded.get() :
+				return
+
+			delattr( widget, method.__name__ + "__CurrentCall" )
+
+			if method.__postCall is not None :
+				method.__postCall( widget, result )
+
+		def backgroundFunction( widget, superceded, *args, **kw ) :
+
+			try :
+				result = method( widget, *args, **kw )
+			except :
+				result = sys.exc_info()[1]
+
+			if not superceded.get() :
+				Gaffer.ParallelAlgo.callOnUIThread( functools.partial( foregroundFunction, widget, result, superceded ) )
+
+		@functools.wraps( method )
+		def wrapper( widget, *args, **kw ) :
+
+			assert( isinstance( widget, GafferUI.Widget ) )
+
+			currentCall = getattr( widget, method.__name__ + "__CurrentCall", None )
+			if currentCall is None :
+				if method.__preCall is not None :
+					method.__preCall( widget )
+			else :
+				# There's already a call in progress, but it has yet
+				# to run the postCall. Mark it as superceded so that
+				# it won't run the postCall. We can then "borrow" the
+				# preCall that was made for it, so we don't need to make
+				# one ourselves.
+				currentCall.superceded.set( True )
+				currentCall.backgroundTask.cancelAndWait()
+
+			plug = method.__plug( widget )
+			superceded = _ValueWrapper( False )
+
+			backgroundTask = Gaffer.ParallelAlgo.callOnBackgroundThread(
+				plug,
+				functools.partial( backgroundFunction, widget, superceded, *args, **kw )
+			)
+
+			setattr( widget, method.__name__ + "__CurrentCall", self.__CurrentCall( backgroundTask, superceded ) )
+
+			if self.__cancelWhenHidden :
+				setattr(
+					widget,
+					method.__name__ + "__VisibilityChangedConnection",
+					widget.visibilityChangedSignal().connect(
+						functools.partial( self.__visibilityChanged, method = method )
+					)
+				)
+
+		def preCall( f ) :
+			method.__preCall = f
+
+		def postCall( f ) :
+			method.__postCall = f
+
+		def plug( f ) :
+			method.__plug = f
+
+		def running( widget ) :
+			return hasattr( widget, method.__name__ + "__CurrentCall" )
+
+		wrapper.preCall = preCall
+		wrapper.postCall = postCall
+		wrapper.plug = plug
+		wrapper.running = running
+
+		return wrapper
+
+	@staticmethod
+	def __plug( widget ) :
+
+		if hasattr( widget, "getPlug" ) :
+			return widget.getPlug()
+		else :
+			return widget.plug()
+
+	@staticmethod
+	def __visibilityChanged( widget, method ) :
+
+		if not widget.visible() :
+			currentCall = getattr( widget, method.__name__ + "__CurrentCall", None )
+			if currentCall is not None :
+				currentCall.backgroundTask.cancel()
+
+class _ValueWrapper( object ) :
+
+	def __init__( self, value ) :
+
+		self.__value = value
+
+	def set( self, value ) :
+
+		self.__value = value
+
+	def get( self ) :
+
+		return self.__value

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -220,6 +220,7 @@ from DataPathPreview import DataPathPreview
 
 # then stuff specific to graph uis
 
+from BackgroundMethod import BackgroundMethod
 from PlugValueWidget import PlugValueWidget
 from StringPlugValueWidget import StringPlugValueWidget
 from NumericPlugValueWidget import NumericPlugValueWidget

--- a/python/GafferUITest/BackgroundMethodTest.py
+++ b/python/GafferUITest/BackgroundMethodTest.py
@@ -1,0 +1,214 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import thread
+import time
+
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferUI
+import GafferUITest
+
+class BackgroundMethodTest( GafferUITest.TestCase ) :
+
+	class TestWidget( GafferUI.NumericWidget ) :
+
+		def __init__( self, **kw ) :
+
+			GafferUI.NumericWidget.__init__( self, 0, **kw )
+
+			self.__script = Gaffer.ScriptNode()
+			self.__script["n"] = GafferTest.AddNode()
+
+			self.numPreCalls = 0
+			self.numBackgroundCalls = 0
+			self.numPostCalls = 0
+
+		def node( self ) :
+
+			return self.__script["n"]
+
+		@GafferUI.BackgroundMethod()
+		def updateInBackground( self, arg ) :
+
+			self.numBackgroundCalls += 1
+			self.backgroundCallArg = arg
+			self.backgroundCallThreadId = thread.get_ident()
+
+			canceller = Gaffer.Context.current().canceller()
+
+			# Give the main thread time to cancel, so we
+			# can test `cancelWhenHidden`.
+			for i in range( 0, 100 ) :
+				IECore.Canceller.check( canceller )
+				time.sleep( 0.01 )
+
+			# Simulate an error if we've been asked to.
+			if getattr( self, "throw", False ) :
+				raise Exception( "Oops!" )
+
+			return self.__script["n"]["sum"].getValue()
+
+		@updateInBackground.preCall
+		def __updateInBackgroundPreCall( self ) :
+
+			self.numPreCalls += 1
+			self.preCallThreadId = thread.get_ident()
+
+			self.setEnabled( False )
+
+		@updateInBackground.postCall
+		def __updateInBackgroundPostCall( self, value ) :
+
+			self.postCallArg = value
+			self.numPostCalls += 1
+			self.postCallThreadId = thread.get_ident()
+
+			self.setValue( value if isinstance( value, int ) else -1 )
+			self.setEnabled( True )
+
+		@updateInBackground.plug
+		def __setTextPlug( self ) :
+
+			return self.__script["n"]["sum"]
+
+	def __waitForSignal( self, signal ) :
+
+		c = GafferTest.CapturingSlot( signal )
+		while len( c ) == 0 :
+			self.waitForIdle()
+
+	def test( self ) :
+
+		with GafferUI.Window() as window :
+			w = self.TestWidget()
+
+		window.setVisible( True )
+
+		self.assertFalse( w.updateInBackground.running( w ) )
+		self.assertEqual( w.numPreCalls, 0 )
+		self.assertEqual( w.numBackgroundCalls, 0 )
+		self.assertEqual( w.numPostCalls, 0 )
+
+		w.node()["op1"].setValue( 1 )
+
+		w.updateInBackground( 100 )
+		self.assertEqual( w.getEnabled(), False )
+		self.assertEqual( w.getValue(), 0 )
+		self.assertTrue( w.updateInBackground.running( w ) )
+
+		self.__waitForSignal( w.valueChangedSignal() )
+		self.assertFalse( w.updateInBackground.running( w ) )
+
+		self.assertEqual( w.getValue(), 1 )
+
+		self.assertEqual( w.numPreCalls, 1 )
+		self.assertEqual( w.numBackgroundCalls, 1 )
+		self.assertEqual( w.numPostCalls, 1 )
+
+		self.assertEqual( w.postCallArg, 1 )
+		self.assertEqual( w.backgroundCallArg, 100 )
+
+		self.assertNotEqual( w.backgroundCallThreadId, thread.get_ident() )
+		self.assertEqual( w.preCallThreadId, thread.get_ident() )
+		self.assertEqual( w.postCallThreadId, thread.get_ident() )
+
+	def testCancelWhenHidden( self ) :
+
+		with GafferUI.Window() as window :
+			w = self.TestWidget()
+
+		window.setVisible( True )
+
+		w.updateInBackground( 1 )
+		window.setVisible( False )
+
+		self.__waitForSignal( w.valueChangedSignal() )
+		self.assertEqual( w.getValue(), -1 )
+
+		self.assertEqual( w.numPreCalls, 1 )
+		self.assertEqual( w.numBackgroundCalls, 1 )
+		self.assertEqual( w.numPostCalls, 1 )
+
+		self.assertIsInstance( w.postCallArg, IECore.Cancelled )
+
+	def testExceptions( self ) :
+
+		with GafferUI.Window() as window :
+			w = self.TestWidget()
+			w.throw = True
+
+		window.setVisible( True )
+		w.updateInBackground( 1000 )
+
+		self.__waitForSignal( w.valueChangedSignal() )
+		self.assertEqual( w.getValue(), -1 )
+
+		self.assertEqual( w.numPreCalls, 1 )
+		self.assertEqual( w.numBackgroundCalls, 1 )
+		self.assertEqual( w.numPostCalls, 1 )
+
+		self.assertIsInstance( w.postCallArg, Exception )
+
+	def testSecondCallSupercedesFirst( self ) :
+
+		with GafferUI.Window() as window :
+			w = self.TestWidget()
+
+		window.setVisible( True )
+
+		w.node()["op1"].setValue( 2 )
+
+		w.updateInBackground( 10 )
+		w.updateInBackground( 11 )
+
+		self.__waitForSignal( w.valueChangedSignal() )
+		self.assertEqual( w.getValue(), 2 )
+
+		# Second call re-uses the first precall
+		self.assertEqual( w.numPreCalls, 1 )
+		# Two background calls got started.
+		self.assertEqual( w.numBackgroundCalls, 2 )
+		# But the first call doesn't make it to
+		# the post-call stage.
+		self.assertEqual( w.numPostCalls, 1 )
+
+		self.assertEqual( w.backgroundCallArg, 11 )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -100,6 +100,7 @@ from VectorDataWidgetTest import VectorDataWidgetTest
 from DotNodeGadgetTest import DotNodeGadgetTest
 from DocumentationTest import DocumentationTest
 from LazyMethodTest import LazyMethodTest
+from BackgroundMethodTest import BackgroundMethodTest
 from ReferenceUITest import ReferenceUITest
 from CompoundDataPlugValueWidgetTest import CompoundDataPlugValueWidgetTest
 from GraphGadgetTest import GraphGadgetTest

--- a/src/Gaffer/BackgroundTask.cpp
+++ b/src/Gaffer/BackgroundTask.cpp
@@ -113,7 +113,9 @@ const ScriptNode *scriptNode( const GraphComponent *subject )
 struct ActiveTask
 {
 	BackgroundTask *task;
-	const ScriptNode *subject;
+	// Held via Ptr to keep the script alive
+	// for the duration of the task.
+	ConstScriptNodePtr subject;
 };
 
 typedef boost::multi_index::multi_index_container<
@@ -123,7 +125,7 @@ typedef boost::multi_index::multi_index_container<
 			boost::multi_index::member<ActiveTask, BackgroundTask *, &ActiveTask::task>
 		>,
 		boost::multi_index::hashed_non_unique<
-			boost::multi_index::member<ActiveTask, const ScriptNode *, &ActiveTask::subject>
+			boost::multi_index::member<ActiveTask, ConstScriptNodePtr, &ActiveTask::subject>
 		>
 	>
 > ActiveTasks;

--- a/src/Gaffer/BackgroundTask.cpp
+++ b/src/Gaffer/BackgroundTask.cpp
@@ -227,11 +227,19 @@ void BackgroundTask::cancelAffectedTasks( const GraphComponent *actionSubject )
 
 	const ScriptNode *s = scriptNode( actionSubject );
 	auto range = a.get<1>().equal_range( s );
+
+	// Call cancel for everything first.
+	for( auto it = range.first; it != range.second; ++it )
+	{
+		it->task->cancel();
+	}
+	// And then perform all the waits. This way the wait on one
+	// task doesn't delay the start of cancellation for the next.
 	for( auto it = range.first; it != range.second; )
 	{
-		// Cancellation invalidates iterator, so must increment first.
+		// Wait invalidates iterator, so must increment first.
 		auto nextIt = std::next( it );
-		it->task->cancelAndWait();
+		it->task->wait();
 		it = nextIt;
 	}
 }

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -353,7 +353,10 @@ void registerInstanceValue( GraphComponent *instance, IECore::InternedString key
 		// ok to bind raw pointers to instance, because enact() guarantees
 		// the lifetime of the subject.
 		boost::bind( &registerInstanceValueAction, instance, key, value, persistent ),
-		boost::bind( &registerInstanceValueAction, instance, key, currentValue, currentPersistent )
+		boost::bind( &registerInstanceValueAction, instance, key, currentValue, currentPersistent ),
+		// Metadata may not be used in computation, so cancellation of
+		// background tasks isn't necessary.
+		false
 	);
 }
 

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -39,6 +39,7 @@
 
 #include "Gaffer/Action.h"
 #include "Gaffer/ApplicationRoot.h"
+#include "Gaffer/BackgroundTask.h"
 #include "Gaffer/CompoundDataPlug.h"
 #include "Gaffer/Context.h"
 #include "Gaffer/DependencyNode.h"
@@ -359,6 +360,14 @@ ApplicationRoot *ScriptNode::applicationRoot()
 const ApplicationRoot *ScriptNode::applicationRoot() const
 {
 	return ancestor<ApplicationRoot>();
+}
+
+void ScriptNode::parentChanging( Gaffer::GraphComponent *newParent )
+{
+	if( !newParent )
+	{
+		BackgroundTask::cancelAffectedTasks( this );
+	}
 }
 
 bool ScriptNode::selectionSetAcceptor( const Set *s, const Set::Member *m )

--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -396,6 +396,12 @@ void deleteNodes( ScriptNode &s, Node *parent, const Set *filter, bool reconnect
 	s.deleteNodes( parent, filter, reconnect );
 }
 
+void save( ScriptNode &s )
+{
+	IECorePython::ScopedGILRelease r;
+	s.save();
+}
+
 struct ActionSlotCaller
 {
 
@@ -474,7 +480,7 @@ void GafferModule::bindScriptNode()
 		.def( "scriptExecutedSignal", &ScriptNode::scriptExecutedSignal, boost::python::return_internal_reference<1>() )
 		.def( "serialise", &ScriptNode::serialise, ( boost::python::arg( "parent" ) = boost::python::object(), boost::python::arg( "filter" ) = boost::python::object() ) )
 		.def( "serialiseToFile", &ScriptNode::serialiseToFile, ( boost::python::arg( "fileName" ), boost::python::arg( "parent" ) = boost::python::object(), boost::python::arg( "filter" ) = boost::python::object() ) )
-		.def( "save", &ScriptNode::save )
+		.def( "save", &save )
 		.def( "load", &ScriptNode::load, ( boost::python::arg( "continueOnError" ) = false ) )
 		.def( "importFile", &ScriptNode::importFile, ( boost::python::arg( "fileName" ), boost::python::arg( "parent" ) = boost::python::object(), boost::python::arg( "continueOnError" ) = false ) )
 		.def( "context", &context )


### PR DESCRIPTION
This builds on the API foundations laid in #2559 to make Gaffer's ImageView asynchronous; The UI now remains responsive while image tiles are being computed in parallel on background threads, and the viewer is updated progressively as new tiles become available.

I talked before about having a spiral tile order, but I haven't implemented that just yet because I'm keen to get a review and some testing before worrying about further details. During my own testing I uncovered various synchronisation issues which I've included fixes for here, and I'm feeling reasonably confident, but some testing in a production environment would be beneficial.

The implementation details of the BackgroundMethod are quite complex, but I think it justifies itself in the same way that LazyMethod does; it makes it much much easier to write performance-oriented UIs, and it lifts a lot of the logic out into a module that can be unit tested much more effectively than the widgets themselves.