### PR TITLE
MetadataBinding : Remove overloads and avoid deprecated methods

### DIFF
--- a/include/GafferBindings/MetadataBinding.h
+++ b/include/GafferBindings/MetadataBinding.h
@@ -44,11 +44,8 @@
 namespace GafferBindings
 {
 
-GAFFERBINDINGS_API void metadataModuleDependencies( const Gaffer::Node *node, std::set<std::string> &modules );
-GAFFERBINDINGS_API void metadataModuleDependencies( const Gaffer::Plug *plug, std::set<std::string> &modules );
-
-GAFFERBINDINGS_API std::string metadataSerialisation( const Gaffer::Node *node, const std::string &identifier );
-GAFFERBINDINGS_API std::string metadataSerialisation( const Gaffer::Plug *plug, const std::string &identifier );
+GAFFERBINDINGS_API void metadataModuleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules );
+GAFFERBINDINGS_API std::string metadataSerialisation( const Gaffer::GraphComponent *graphComponent, const std::string &identifier );
 
 } // namespace GafferBindings
 


### PR DESCRIPTION
In #1882 we simplified the Metadata API so that there weren't separate method overloads for plugs and nodes. This carries the same idea through into the bindings. It also stops the serialisation of metadata values using the long-deprecated `registerNodeValue/registerPlugValue` methods, using the single `registerValue` method instead.