### PR TITLE
Outputs : Add `deregisterOutput()` method

### DIFF
--- a/include/GafferScene/Outputs.h
+++ b/include/GafferScene/Outputs.h
@@ -65,6 +65,8 @@ class GAFFERSCENE_API Outputs : public GlobalsProcessor
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		static void registerOutput( const std::string &name, const IECoreScene::Output *output );
+		static void deregisterOutput( const std::string &name );
+
 		static void registeredOutputs( std::vector<std::string> &names );
 
 	protected :

--- a/python/GafferSceneTest/OutputsTest.py
+++ b/python/GafferSceneTest/OutputsTest.py
@@ -111,6 +111,22 @@ class OutputsTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual( GafferScene.Outputs.registeredOutputs(), ( "test", "test2" ) )
 
+		o = GafferScene.Outputs()
+		p = o.addOutput( "test" )
+		self.assertEqual( p["name"].getValue(), "test" )
+		self.assertEqual( p["fileName"].getValue(), "test.exr" )
+		self.assertEqual( p["data"].getValue(), "rgba" )
+
+		GafferScene.Outputs.deregisterOutput( "test" )
+		self.assertEqual( GafferScene.Outputs.registeredOutputs(), ( "test2", ) )
+
+		o = GafferScene.Outputs()
+		with self.assertRaisesRegexp( RuntimeError, "Output not registered" ) :
+			o.addOutput( "test" )
+
+		GafferScene.Outputs.deregisterOutput( "test2" )
+		self.assertEqual( GafferScene.Outputs.registeredOutputs(), () )
+
 	def testHashPassThrough( self ) :
 
 		# the hash of the per-object part of the output should be

--- a/src/GafferScene/Outputs.cpp
+++ b/src/GafferScene/Outputs.cpp
@@ -229,6 +229,11 @@ void Outputs::registerOutput( const std::string &name, const IECoreScene::Output
 	}
 }
 
+void Outputs::deregisterOutput( const std::string &name )
+{
+	outputMap().erase( name );
+}
+
 void Outputs::registeredOutputs( std::vector<std::string> &names )
 {
 	const OutputMap::nth_index<1>::type &index = outputMap().get<1>();

--- a/src/GafferSceneModule/GlobalsBinding.cpp
+++ b/src/GafferSceneModule/GlobalsBinding.cpp
@@ -97,6 +97,7 @@ void GafferSceneModule::bindGlobals()
 		.def( "addOutput", &addOutputWrapper )
 		.def( "addOutput", &addOutputWrapper2 )
 		.def( "registerOutput", &Outputs::registerOutput ).staticmethod( "registerOutput" )
+		.def( "deregisterOutput", &Outputs::deregisterOutput ).staticmethod( "deregisterOutput" )
 		.def( "registeredOutputs", &registeredOutputsWrapper ).staticmethod( "registeredOutputs" )
 	;
 


### PR DESCRIPTION
This allows a config file to remove any of Gaffer's standard output definitions.