### PR TITLE
Metadata bindings : Fix crash passing `None` to `registerValue()`

### DIFF
--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -1129,5 +1129,10 @@ class MetadataTest( GafferTest.TestCase ) :
 					self.assertEqual( Gaffer.Metadata.value( plug, key ), None )
 					self.assertNotIn( key, Gaffer.Metadata.registeredValues( plug ) )
 
+	def testCantPassNoneForGraphComponent( self ) :
+
+		with self.assertRaisesRegexp( Exception, "Python argument types" ) :
+			Gaffer.Metadata.registerValue( None, "test", "test" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferModule/MetadataBinding.cpp
+++ b/src/GafferModule/MetadataBinding.cpp
@@ -316,10 +316,10 @@ struct ValueChangedSlotCaller
 
 };
 
-void registerInstanceValue( GraphComponent *instance, InternedString key, ConstDataPtr value, bool persistent )
+void registerInstanceValue( GraphComponent &instance, InternedString key, ConstDataPtr value, bool persistent )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	Metadata::registerValue( instance, key, value, persistent );
+	Metadata::registerValue( &instance, key, value, persistent );
 }
 
 list keysToList( const std::vector<InternedString> &keys )

--- a/src/GafferModule/MetadataBinding.cpp
+++ b/src/GafferModule/MetadataBinding.cpp
@@ -316,6 +316,12 @@ struct ValueChangedSlotCaller
 
 };
 
+void registerInstanceValue( GraphComponent *instance, InternedString key, ConstDataPtr value, bool persistent )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	Metadata::registerValue( instance, key, value, persistent );
+}
+
 list keysToList( const std::vector<InternedString> &keys )
 {
 	list result;
@@ -389,7 +395,7 @@ void GafferModule::bindMetadata()
 		.def( "registerValue", &registerValue )
 		.def( "registerValue", &registerNodeValue )
 		.def( "registerValue", &registerPlugValue )
-		.def( "registerValue", (void (*)( GraphComponent *, InternedString key, ConstDataPtr value, bool ))&Metadata::registerValue,
+		.def( "registerValue", &registerInstanceValue,
 			(
 				boost::python::arg( "target" ),
 				boost::python::arg( "value" ),

--- a/startup/gui/nodeGraph.py
+++ b/startup/gui/nodeGraph.py
@@ -51,37 +51,37 @@ import GafferDispatchUI
 # Colour
 ##########################################################################
 
-Gaffer.Metadata.registerNodeValue( GafferDispatch.TaskNode, "nodeGadget:color", imath.Color3f( 0.61, 0.1525, 0.1525 ) )
-Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "task", "nodule:color", imath.Color3f( 0.645, 0.2483, 0.2483 ) )
-Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "preTasks.*", "nodule:color", imath.Color3f( 0.645, 0.2483, 0.2483 ) )
-Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "postTasks.*", "nodule:color", imath.Color3f( 0.645, 0.2483, 0.2483 ) )
-Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "task", "connectionGadget:color", imath.Color3f( 0.315, 0.0787, 0.0787 ) )
-Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "preTasks.*", "connectionGadget:color", imath.Color3f( 0.315, 0.0787, 0.0787 ) )
-Gaffer.Metadata.registerPlugValue( GafferDispatch.TaskNode, "postTasks.*", "connectionGadget:color", imath.Color3f( 0.315, 0.0787, 0.0787 ) )
+Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "nodeGadget:color", imath.Color3f( 0.61, 0.1525, 0.1525 ) )
+Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "task", "nodule:color", imath.Color3f( 0.645, 0.2483, 0.2483 ) )
+Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "preTasks.*", "nodule:color", imath.Color3f( 0.645, 0.2483, 0.2483 ) )
+Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "postTasks.*", "nodule:color", imath.Color3f( 0.645, 0.2483, 0.2483 ) )
+Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "task", "connectionGadget:color", imath.Color3f( 0.315, 0.0787, 0.0787 ) )
+Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "preTasks.*", "connectionGadget:color", imath.Color3f( 0.315, 0.0787, 0.0787 ) )
+Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "postTasks.*", "connectionGadget:color", imath.Color3f( 0.315, 0.0787, 0.0787 ) )
 
-Gaffer.Metadata.registerNodeValue( Gaffer.SubGraph, "nodeGadget:color", imath.Color3f( 0.225 ) )
-Gaffer.Metadata.registerNodeValue( Gaffer.BoxIO, "nodeGadget:color", imath.Color3f( 0.225 ) )
+Gaffer.Metadata.registerValue( Gaffer.SubGraph, "nodeGadget:color", imath.Color3f( 0.225 ) )
+Gaffer.Metadata.registerValue( Gaffer.BoxIO, "nodeGadget:color", imath.Color3f( 0.225 ) )
 
-Gaffer.Metadata.registerNodeValue( Gaffer.Random, "nodeGadget:color", imath.Color3f( 0.45, 0.3, 0.3 ) )
-Gaffer.Metadata.registerNodeValue( Gaffer.Expression, "nodeGadget:color", imath.Color3f( 0.3, 0.45, 0.3 ) )
-Gaffer.Metadata.registerNodeValue( Gaffer.Animation, "nodeGadget:color", imath.Color3f( 0.3, 0.3, 0.45 ) )
+Gaffer.Metadata.registerValue( Gaffer.Random, "nodeGadget:color", imath.Color3f( 0.45, 0.3, 0.3 ) )
+Gaffer.Metadata.registerValue( Gaffer.Expression, "nodeGadget:color", imath.Color3f( 0.3, 0.45, 0.3 ) )
+Gaffer.Metadata.registerValue( Gaffer.Animation, "nodeGadget:color", imath.Color3f( 0.3, 0.3, 0.45 ) )
 
-Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "in...", "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
-Gaffer.Metadata.registerPlugValue( GafferScene.SceneNode, "out", "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
-Gaffer.Metadata.registerPlugValue( GafferScene.InteractiveRender, "in", "nodule:color", imath.Color3f( 0.2346, 0.326, 0.46 ) )
-Gaffer.Metadata.registerPlugValue( GafferScene.Parent, "child", "nodule:color", imath.Color3f( 0.2346, 0.326, 0.46 ) )
+Gaffer.Metadata.registerValue( GafferScene.SceneNode, "in...", "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
+Gaffer.Metadata.registerValue( GafferScene.SceneNode, "out", "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
+Gaffer.Metadata.registerValue( GafferScene.InteractiveRender, "in", "nodule:color", imath.Color3f( 0.2346, 0.326, 0.46 ) )
+Gaffer.Metadata.registerValue( GafferScene.Parent, "child", "nodule:color", imath.Color3f( 0.2346, 0.326, 0.46 ) )
 
-Gaffer.Metadata.registerNodeValue( GafferScene.SceneProcessor, "nodeGadget:color", imath.Color3f( 0.495, 0.2376, 0.4229 ) )
-Gaffer.Metadata.registerNodeValue( GafferScene.SceneElementProcessor, "nodeGadget:color", imath.Color3f( 0.1886, 0.2772, 0.41 ) )
+Gaffer.Metadata.registerValue( GafferScene.SceneProcessor, "nodeGadget:color", imath.Color3f( 0.495, 0.2376, 0.4229 ) )
+Gaffer.Metadata.registerValue( GafferScene.SceneElementProcessor, "nodeGadget:color", imath.Color3f( 0.1886, 0.2772, 0.41 ) )
 
-Gaffer.Metadata.registerPlugValue( GafferScene.FilteredSceneProcessor, "filter", "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
-Gaffer.Metadata.registerPlugValue( GafferScene.Filter, "out", "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
-Gaffer.Metadata.registerPlugValue( GafferScene.Filter, "in...", "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
+Gaffer.Metadata.registerValue( GafferScene.FilteredSceneProcessor, "filter", "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
+Gaffer.Metadata.registerValue( GafferScene.Filter, "out", "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
+Gaffer.Metadata.registerValue( GafferScene.Filter, "in...", "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
 
-Gaffer.Metadata.registerNodeValue( GafferScene.Transform, "nodeGadget:color", imath.Color3f( 0.485, 0.3112, 0.2255 ) )
-Gaffer.Metadata.registerNodeValue( GafferScene.Constraint, "nodeGadget:color", imath.Color3f( 0.485, 0.3112, 0.2255 ) )
+Gaffer.Metadata.registerValue( GafferScene.Transform, "nodeGadget:color", imath.Color3f( 0.485, 0.3112, 0.2255 ) )
+Gaffer.Metadata.registerValue( GafferScene.Constraint, "nodeGadget:color", imath.Color3f( 0.485, 0.3112, 0.2255 ) )
 
-Gaffer.Metadata.registerNodeValue( GafferScene.GlobalsProcessor, "nodeGadget:color", imath.Color3f( 0.255, 0.505, 0.28 ) )
+Gaffer.Metadata.registerValue( GafferScene.GlobalsProcessor, "nodeGadget:color", imath.Color3f( 0.255, 0.505, 0.28 ) )
 
 __shaderNoduleColors = {
 	Gaffer.FloatPlug.staticTypeId() : IECore.Color3fData( imath.Color3f( 0.2467, 0.3762, 0.47 ) ),
@@ -93,7 +93,7 @@ def __shaderNoduleColor( plug ) :
 
 	return __shaderNoduleColors.get( plug.typeId(), None )
 
-Gaffer.Metadata.registerPlugValue( GafferScene.Shader, "...", "nodule:color", __shaderNoduleColor )
+Gaffer.Metadata.registerValue( GafferScene.Shader, "...", "nodule:color", __shaderNoduleColor )
 
 ##########################################################################
 # Behaviour


### PR DESCRIPTION
This fixes a crash Alex ran into. Note that 998093e is cherry-picked from #2578, since I needed to build on top of it here. Probably best to merge #2578 first and then I'll rebase this.