### PR TITLE
SubGraph : Fix crash in `correspondingInput()`

### DIFF
--- a/python/GafferTest/SubGraphTest.py
+++ b/python/GafferTest/SubGraphTest.py
@@ -93,5 +93,13 @@ class SubGraphTest( GafferTest.TestCase ) :
 
 		self.assertEqual( b.correspondingInput( b["o"].promotedPlug() ), b["i"].promotedPlug() )
 
+	def testCorrespondingInputWithUnconnectedBoxOut( self ) :
+
+		b = Gaffer.Box()
+		b["o"] = Gaffer.BoxOut()
+		b["o"].setup( Gaffer.IntPlug( "p" ) )
+
+		self.assertIsNone( b.correspondingInput( b["out"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/SubGraph.cpp
+++ b/src/Gaffer/SubGraph.cpp
@@ -84,6 +84,10 @@ const Plug *SubGraph::correspondingInput( const Plug *output ) const
 	if( const BoxOut *boxOut = internalOutput->parent<BoxOut>() )
 	{
 		internalOutput = boxOut->plug()->getInput();
+		if( !internalOutput )
+		{
+			return nullptr;
+		}
 	}
 
 	const DependencyNode *node = IECore::runTimeCast<const DependencyNode>( internalOutput->node() );


### PR DESCRIPTION
This manifested itself as crashes in the NodeGraph when dragging a Box with an unconnected BoxOut node over a connection.