### PR TITLE
ImageNode cancellation

### DIFF
--- a/python/GafferImageTest/MedianTest.py
+++ b/python/GafferImageTest/MedianTest.py
@@ -156,9 +156,10 @@ class MedianTest( GafferImageTest.ImageTestCase ) :
 		time.sleep( 0.1 )
 
 		# Check that we can cancel them in reasonable time
+		acceptableCancellationDelay = 0.25 if "TRAVIS" not in os.environ else 4.0
 		t = time.time()
 		bt.cancelAndWait()
-		self.assertLess( time.time() - t, 0.2 )
+		self.assertLess( time.time() - t, acceptableCancellationDelay )
 
 		# Check that we can do the same when using a master
 		# channel.
@@ -169,7 +170,7 @@ class MedianTest( GafferImageTest.ImageTestCase ) :
 
 		t = time.time()
 		bt.cancelAndWait()
-		self.assertLess( time.time() - t, 0.2 )
+		self.assertLess( time.time() - t, acceptableCancellationDelay )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ResampleTest.py
+++ b/python/GafferImageTest/ResampleTest.py
@@ -196,9 +196,10 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 		time.sleep( 0.1 )
 
 		# Check that we can cancel them in reasonable time
+		acceptableCancellationDelay = 0.25 if "TRAVIS" not in os.environ else 4.0
 		t = time.time()
 		bt.cancelAndWait()
-		self.assertLess( time.time() - t, 0.2 )
+		self.assertLess( time.time() - t, acceptableCancellationDelay )
 
 		# Check that we can do the same when using a non-separable filter
 		r["filter"].setValue( "disk" )
@@ -208,7 +209,7 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 
 		t = time.time()
 		bt.cancelAndWait()
-		self.assertLess( time.time() - t, 0.2 )
+		self.assertLess( time.time() - t, acceptableCancellationDelay )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ResampleTest.py
+++ b/python/GafferImageTest/ResampleTest.py
@@ -181,9 +181,5 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 		r["filterScale"].setValue( imath.V2f( 10 ) )
 		self.assertEqual( r["out"]["dataWindow"].getValue(), imath.Box2i( d.min() - imath.V2i( 5 ), d.max() + imath.V2i( 5 ) ) )
 
-	def __matrix( self, inputDataWindow, outputDataWindow ) :
-
-		return imath.M33f()
-
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImage/RankFilter.cpp
+++ b/src/GafferImage/RankFilter.cpp
@@ -80,7 +80,7 @@ Gaffer::V2iPlug *RankFilter::radiusPlug()
 }
 
 const Gaffer::V2iPlug *RankFilter::radiusPlug() const
-{ 
+{
 	return getChild<V2iPlug>( g_firstPlugIndex );
 }
 
@@ -132,7 +132,7 @@ void RankFilter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &out
 	if(
 		input == expandDataWindowPlug() ||
 		input == inPlug()->dataWindowPlug() ||
-		input->parent<V2iPlug>() == radiusPlug() 
+		input->parent<V2iPlug>() == radiusPlug()
 	)
 	{
 		outputs.push_back( outPlug()->dataWindowPlug() );
@@ -142,7 +142,7 @@ void RankFilter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &out
 		input == inPlug()->channelDataPlug() ||
 		input->parent<V2iPlug>() == radiusPlug() ||
 		input == boundingModePlug() ||
-		input == masterChannelPlug() 
+		input == masterChannelPlug()
 	)
 	{
 		outputs.push_back( pixelOffsetsPlug() );
@@ -215,7 +215,7 @@ void RankFilter::compute( Gaffer::ValuePlug *output, const Gaffer::Context *cont
 		Sampler sampler(
 			inPlug(),
 			// This plug should only be evaluated with channel name already set to the driver channel
-			context->get<std::string>( ImagePlug::channelNameContextName ), 
+			context->get<std::string>( ImagePlug::channelNameContextName ),
 			inputBound,
 			(Sampler::BoundingMode)boundingModePlug()->getValue()
 		);
@@ -294,7 +294,7 @@ void RankFilter::compute( Gaffer::ValuePlug *output, const Gaffer::Context *cont
 					}
 				}
 
-				// One of the pixels must match the rank 
+				// One of the pixels must match the rank
 				assert( r != V2i( INT_MAX, INT_MAX ) );
 
 				result.push_back( r );
@@ -341,7 +341,7 @@ void RankFilter::hashChannelData( const GafferImage::ImagePlug *parent, const Ga
 	{
 		ImagePlug::ChannelDataScope pixelOffsetsScope( context );
 		pixelOffsetsScope.setChannelName( masterChannel );
-	
+
 		pixelOffsetsPlug()->hash( h );
 	}
 

--- a/src/GafferImage/RankFilter.cpp
+++ b/src/GafferImage/RankFilter.cpp
@@ -233,6 +233,8 @@ void RankFilter::compute( Gaffer::ValuePlug *output, const Gaffer::Context *cont
 		{
 			for( p.x = tileBound.min.x; p.x < tileBound.max.x; ++p.x )
 			{
+				IECore::Canceller::check( context->canceller() );
+
 				// Fill array with all nearby samples
 				V2i o;
 				vector<float>::iterator pixelsIt = pixels.begin();
@@ -403,6 +405,8 @@ IECore::ConstFloatVectorDataPtr RankFilter::computeChannelData( const std::strin
 	{
 		for( p.x = tileBound.min.x; p.x < tileBound.max.x; ++p.x )
 		{
+			IECore::Canceller::check( context->canceller() );
+
 			V2i o;
 			vector<float>::iterator pixelsIt = pixels.begin();
 			for( o.y = -radius.y; o.y <= radius.y; ++o.y )

--- a/src/GafferImage/Resample.cpp
+++ b/src/GafferImage/Resample.cpp
@@ -177,7 +177,7 @@ const OIIO::Filter2D *filterAndScale( const std::string &name, V2f ratio, V2f &i
 
 	// Convert the filter scale into input space
 	inputFilterScale = V2f( 1.0f ) / ratio;
-	
+
 	// Don't allow the filter scale to cover less than 1 pixel in input space
 	inputFilterScale = V2f( std::max( 1.0f, inputFilterScale.x ), std::max( 1.0f, inputFilterScale.y ) );
 
@@ -405,7 +405,7 @@ Imath::Box2i Resample::computeDataWindow( const Gaffer::Context *context, const 
 		V2f inputFilterScale;
 		const OIIO::Filter2D *filter = filterAndScale( filterPlug()->getValue(), ratio, inputFilterScale );
 		inputFilterScale *= filterScalePlug()->getValue();
-		
+
 		const V2f filterRadius = V2f( filter->width(), filter->height() ) * inputFilterScale * 0.5f;
 
 		dstDataWindow.min -= filterRadius * ratio;
@@ -571,7 +571,7 @@ IECore::ConstFloatVectorDataPtr Resample::computeChannelData( const std::string 
 				// center is actually within the filter support.  This fix should also be done to the
 				// seperable case.  Once that is done, we should probably also hoist the multiply by
 				// filterCoordinateMult out of the loop.
-				
+
 				V2i fP; // relative filter position
 				float v = 0.0f;
 				float totalW = 0.0f;

--- a/src/GafferImage/Resample.cpp
+++ b/src/GafferImage/Resample.cpp
@@ -545,6 +545,8 @@ IECore::ConstFloatVectorDataPtr Resample::computeChannelData( const std::string 
 
 			for( oP.x = tileBound.min.x; oP.x < tileBound.max.x; ++oP.x )
 			{
+				Canceller::check( context->canceller() );
+
 				iP.x = ( oP.x + 0.5 ) / ratio.x + offset.x;
 				iPF.x = OIIO::floorfrac( iP.x, &iPI.x );
 
@@ -622,6 +624,8 @@ IECore::ConstFloatVectorDataPtr Resample::computeChannelData( const std::string 
 
 		for( oP.y = tileBound.min.y; oP.y < tileBound.max.y; ++oP.y )
 		{
+			Canceller::check( context->canceller() );
+
 			std::vector<float>::const_iterator wIt = weights.begin();
 			for( oP.x = tileBound.min.x; oP.x < tileBound.max.x; ++oP.x )
 			{
@@ -666,6 +670,8 @@ IECore::ConstFloatVectorDataPtr Resample::computeChannelData( const std::string 
 
 		for( oP.y = tileBound.min.y; oP.y < tileBound.max.y; ++oP.y )
 		{
+			Canceller::check( context->canceller() );
+
 			iY = ( oP.y + 0.5 ) / ratio.y + offset.y;
 			OIIO::floorfrac( iY, &iYI );
 


### PR DESCRIPTION
This adds explicit cancellation checks for the RankFilter and Resample nodes, which makes the UI more responsive when they're used with large radii. In my testing, the other GafferImage nodes appear to be quick enough that the built-in per-tile cancellation is sufficient for them.