### PR TITLE
SConstruct : DEBUGINFO build option to generate debug info in release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
     - $COMPILER --version
 
 script:
-    - scons -j 2 install CXX=$COMPILER CXXSTD=$CXXSTD DEBUG=$DEBUG ENV_VARS_TO_IMPORT=PATH DELIGHT_ROOT=$DELIGHT BUILD_CACHEDIR=sconsCache
+    - scons -j 2 install CXX=$COMPILER CXXSTD=$CXXSTD BUILD_TYPE=$BUILD_TYPE ENV_VARS_TO_IMPORT=PATH DELIGHT_ROOT=$DELIGHT BUILD_CACHEDIR=sconsCache
     # Preload libSegFault when running tests, so we get stack
     # traces from any crashes.
     - export LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
@@ -81,10 +81,10 @@ matrix:
     # We can then simply list the exact builds we want.
     include:
         - os: linux
-          env: COMPILER=g++-4.8 CXXSTD=c++11 DEBUG=0
+          env: COMPILER=g++-4.8 CXXSTD=c++11 BUILD_TYPE=RELEASE
         - os: linux
-          env: COMPILER=g++-4.8 CXXSTD=c++11 DEBUG=1
+          env: COMPILER=g++-4.8 CXXSTD=c++11 BUILD_TYPE=DEBUG
         - os: linux
-          env: COMPILER=g++-6 CXXSTD=c++14 DEBUG=0
+          env: COMPILER=g++-6 CXXSTD=c++14 BUILD_TYPE=RELEASE
         - os: osx
-          env: COMPILER=clang++ CXXSTD=c++11 DEBUG=0
+          env: COMPILER=clang++ CXXSTD=c++11 BUILD_TYPE=RELEASE

--- a/SConstruct
+++ b/SConstruct
@@ -90,7 +90,12 @@ options.Add(
 )
 
 options.Add(
-	BoolVariable( "DEBUG", "Make a debug build", False )
+	EnumVariable(
+		"BUILD_TYPE",
+		"Optimisation and debug symbol configuration",
+		"RELEASE",
+		allowed_values = ('RELEASE', 'DEBUG', 'RELWITHDEBINFO')
+	)
 )
 
 options.Add(
@@ -402,10 +407,12 @@ elif env["PLATFORM"] == "posix" :
 
 env.Append( CXXFLAGS = [ "-std=$CXXSTD", "-fvisibility=hidden" ] )
 
-if env["DEBUG"] :
-	env.Append( CXXFLAGS = [ "-g", "-O0" ] )
-else :
-	env.Append( CXXFLAGS = [ "-DNDEBUG", "-DBOOST_DISABLE_ASSERTS" , "-O3" ] )
+if env["BUILD_TYPE"] == "DEBUG" :
+	env.Append( CXXFLAGS = ["-g", "-O0"] )
+elif env["BUILD_TYPE"] == "RELEASE" :
+	env.Append( CXXFLAGS = ["-DNDEBUG", "-DBOOST_DISABLE_ASSERTS", "-O3"] )
+elif env["BUILD_TYPE"] == "RELWITHDEBINFO" :
+	env.Append( CXXFLAGS = ["-DNDEBUG", "-DBOOST_DISABLE_ASSERTS", "-O3", "-g"] )
 
 if env["WARNINGS_AS_ERRORS"] :
 	env.Append(


### PR DESCRIPTION
Perhaps we should also add ```-fno-omit-frame-pointer``` if this feature is used by others

From the clang asan docs:
```
To get nicer stack traces in error messages add -fno-omit-frame-pointer. To get perfect stack traces you may need to disable inlining (just use -O1) and tail call elimination (-fno-optimize-sibling-calls).
```