### PR TITLE
Performance Tweaks For Large Scene

### DIFF
--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -51,7 +51,7 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 
 	options->addOptionalMember( "ai:bucket_size", new IECore::IntData( 64 ), "bucketSize", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:bucket_scanning", new IECore::StringData( "spiral" ), "bucketScanning", Gaffer::Plug::Default, false );
-	options->addOptionalMember( "ai:parallel_node_init", new IECore::BoolData( false ), "parallelNodeInit", Gaffer::Plug::Default, false );
+	options->addOptionalMember( "ai:parallel_node_init", new IECore::BoolData( true ), "parallelNodeInit", Gaffer::Plug::Default, false );
 	options->addOptionalMember( "ai:threads", new IECore::IntData( 0 ), "threads", Gaffer::Plug::Default, false );
 
 	// Sampling parameters

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -592,11 +592,23 @@ class ShaderCache : public IECore::RefCounted
 		// Can be called concurrently with other get() calls.
 		ArnoldShaderPtr get( const IECore::ObjectVector *shader )
 		{
+			// Rehashing shaders is expensive, so we keep a map of ObjectVector addresses
+			// to hash values.  In order to ensure there isn't a tiny risk of freeing one
+			// of these addresses and constructing a different ObjectVector at the same
+			// location, the hash keys are shared pointers which will keep these
+			// ObjectVectors alive.  We clear them out before the render starts in clearUnused()
+			HashCache::accessor ha;
+			m_hashCache.insert( ha, shader );
+			if( ha->second == IECore::MurmurHash() )
+			{
+				ha->second = shader->Object::hash();
+			}
+
 			Cache::accessor a;
-			m_cache.insert( a, shader->Object::hash() );
+			m_cache.insert( a, ha->second );
 			if( !a->second )
 			{
-				const std::string namePrefix = "shader:" + shader->Object::hash().toString() + ":";
+				const std::string namePrefix = "shader:" + ha->second.toString() + ":";
 				a->second = new ArnoldShader( shader, m_nodeDeleter, namePrefix, m_parentNode );
 			}
 			return a->second;
@@ -605,6 +617,23 @@ class ShaderCache : public IECore::RefCounted
 		// Must not be called concurrently with anything.
 		void clearUnused()
 		{
+			vector<IECore::ConstObjectVectorPtr> toEraseHash;
+			for( HashCache::iterator it = m_hashCache.begin(), eIt = m_hashCache.end(); it != eIt; ++it )
+			{
+				if( it->first->refCount() == 1 )
+				{
+					// Only one reference - this is ours, so
+					// nothing outside of the cache is using the
+					// object vector we're keeping alive to match
+					// the shader hash.
+					toEraseHash.push_back( it->first );
+				}
+			}
+			for( vector<IECore::ConstObjectVectorPtr>::const_iterator it = toEraseHash.begin(), eIt = toEraseHash.end(); it != eIt; ++it )
+			{
+				m_hashCache.erase( *it );
+			}
+
 			vector<IECore::MurmurHash> toErase;
 			for( Cache::iterator it = m_cache.begin(), eIt = m_cache.end(); it != eIt; ++it )
 			{
@@ -635,9 +664,11 @@ class ShaderCache : public IECore::RefCounted
 		NodeDeleter m_nodeDeleter;
 		AtNode *m_parentNode;
 
+		typedef tbb::concurrent_hash_map<IECore::ConstObjectVectorPtr, IECore::MurmurHash> HashCache;
+		HashCache m_hashCache;
+
 		typedef tbb::concurrent_hash_map<IECore::MurmurHash, ArnoldShaderPtr> Cache;
 		Cache m_cache;
-
 };
 
 IE_CORE_DECLAREPTR( ShaderCache )


### PR DESCRIPTION
A couple things that helped while looking into performance of a large scene:

* the first commit is pretty trivial - we can directly access the value of parentPlug, instead of triggering a compute of mappingPlug, which is a dramatic speedup if you're querying something which doesn't turn out to depend on the branch creator
* defaulting parallel_node_init to 1 matches the new default in Arnold 5.1 ( the only reason we wanted this off before was due to an old cryptomatte bug, which I've now tested, and appears fixed in Arnold5/alShaders2
* the third commit is a bit more complex.  It's not a lot of code, but it does have some potential memory cost.

In the scene I tested in, there are 68 shaders, and represented by 28371 object vectors ( quite a bit of duplication, suggesting that caching shader network computes could be a pretty big win ).  Summing all the memoryUsage values of the m_hashCache keys reports 500 megs - but I didn't see this big an increase in actual resident memory, suggesting that some of this memory is shared between entries, or with something else.  In any case, half a gig on a heavy scene seems like an acceptable cost for cutting out a minute of scene expansion, so I'm feeling like this is probably a reasonable approach for the moment ( the cache is dropped before rendering starts anyway ).