### PR TITLE
Dispatcher tweaks

### DIFF
--- a/include/GafferDispatch/Dispatcher.h
+++ b/include/GafferDispatch/Dispatcher.h
@@ -254,7 +254,7 @@ class GAFFERDISPATCH_API Dispatcher : public Gaffer::Node
 			private :
 
 				TaskNode::ConstTaskPlugPtr m_plug;
-				Gaffer::ConstContextPtr m_context;
+				Gaffer::ContextPtr m_context;
 				IECore::CompoundDataPtr m_blindData;
 				std::vector<float> m_frames;
 				TaskBatches m_preTasks;

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -434,6 +434,8 @@ class Dispatcher::Batcher
 			// our current batches, or we may need to make a new one
 			// entirely if the current batch is full.
 
+			const bool requiresSequenceExecution = task.plug()->requiresSequenceExecution();
+
 			TaskBatchPtr batch = nullptr;
 			const MurmurHash batchMapHash = batchHash( task );
 			BatchMap::iterator bIt = m_currentBatches.find( batchMapHash );
@@ -445,7 +447,7 @@ class Dispatcher::Batcher
 				IntDataPtr batchSizeData = candidateBatch->blindData()->member<IntData>( g_sizeBlindDataName );
 				const IntPlug *batchSizePlug = task.node()->dispatcherPlug()->getChild<const IntPlug>( g_batchSize );
 				const int batchSizeLimit = ( batchSizePlug ) ? batchSizePlug->getValue() : 1;
-				if( task.plug()->requiresSequenceExecution() || ( batchSizeData->readable() < batchSizeLimit ) )
+				if( requiresSequenceExecution || ( batchSizeData->readable() < batchSizeLimit ) )
 				{
 					batch = candidateBatch;
 					batchSizeData->writable()++;
@@ -466,7 +468,7 @@ class Dispatcher::Batcher
 			{
 				float frame = task.context()->getFrame();
 				std::vector<float> &frames = batch->frames();
-				if( task.plug()->requiresSequenceExecution() )
+				if( requiresSequenceExecution )
 				{
 					frames.insert( std::lower_bound( frames.begin(), frames.end(), frame ), frame );
 				}

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -251,12 +251,16 @@ Dispatcher::TaskBatch::TaskBatch()
 }
 
 Dispatcher::TaskBatch::TaskBatch( TaskNode::ConstTaskPlugPtr plug, Gaffer::ConstContextPtr context )
-	:	m_plug( plug ), m_context( context ), m_blindData( new CompoundData )
+	:	m_plug( plug ), m_context( new Context( *context ) ), m_blindData( new CompoundData )
 {
+	// Frames must be determined by our `frames()` field, so
+	// remove any possibility of accidentally using the frame
+	// from the context.
+	m_context->remove( "frame" );
 }
 
 Dispatcher::TaskBatch::TaskBatch( ConstTaskNodePtr node, Gaffer::ConstContextPtr context )
-	:	m_plug( node->taskPlug() ), m_context( context ), m_blindData( new CompoundData )
+	:	TaskBatch( node->taskPlug(), context )
 {
 }
 


### PR DESCRIPTION
@andrewkaufman, @ivanimanishi : This does what we were talking about via email, removing the "frame" variable from TaskBatch contexts. This gives us an effect that we definitely want, which is that TaskBatch contexts are now meaningfully comparable.

The other visible effect is that `TaskNode::executeSequence()` is now performed in a context without a time. Conceptually I believe this is correct, but it's not implausible that a PythonCommand in sequence mode has been set up to pull on a time-dependent input without specifying the frame, and has been getting lucky thus far (getting the value for the first frame in the dispatch range). Such a node would now be greeted with an exception. Discuss!