### PR TITLE
Initial docs restyling

### DIFF
--- a/doc/source/_static/.gitignore
+++ b/doc/source/_static/.gitignore
@@ -1,0 +1,2 @@
+GafferLogo.svg
+GafferLogoMini.svg

--- a/doc/source/_static/gaffer.css
+++ b/doc/source/_static/gaffer.css
@@ -1,0 +1,78 @@
+/* ===================================
+CSS overrides for Gaffer documentation
+==================================== */
+
+/* Match regular nav background to Gaffer brand colors */
+.wy-side-nav-search {
+    background-color: #343131;
+}
+
+/* Match mobile nav background to Gaffer brand colors */
+.wy-nav-top {
+    background-color: #b92227;
+}
+
+/* Increase nav version color visibility */
+.wy-side-nav-search > div.version {
+    color: inherit;
+}
+
+/* Add "Gaffer" in front of nav version (this sidesteps changing the Sphinx template) */
+.wy-side-nav-search > div.version::before {
+    content: "Gaffer ";
+}
+
+/* Make nav search simpler and a little duller when not focused */
+.wy-side-nav-search input[type="text"] {
+    border-width: 2px;
+    border-color: transparent;
+    background-color: lightgrey;
+    background-clip:  padding-box;
+    transition: all 0.3s linear;
+}
+
+/* Transition search bar to white bg with Gaffer red border on focus */
+.wy-side-nav-search input[type="text"]:focus {
+    border-color: #b92227;
+    background-color: white;
+}
+
+/* Make nav button color red on click */
+.wy-menu-vertical a:active {
+    background-color:#b92227;
+}
+
+/* Increase font size for mobile header title */
+.wy-nav-top a {
+    font-size: 120%;
+}
+
+/* Adjust the mobile menu button (and center-align mobile header title) */
+.wy-nav-top i {
+    display: block;
+    position: absolute;
+    left: 15px;
+    top: 15px;
+}
+
+/* Add icon after external links */
+a[href^="http"]:after {
+    content: " " url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAVklEQVR4Xn3PgQkAMQhDUXfqTu7kTtkpd5RA8AInfArtQ2iRXFWT2QedAfttj2FsPIOE1eCOlEuoWWjgzYaB/IkeGOrxXhqB+uA9Bfcm0lAZuh+YIeAD+cAqSz4kCMUAAAAASUVORK5CYII=);
+    color: #2980B9;
+}
+
+/* Fix fallback image text vertically alignment when inline */
+img {
+    vertical-align: initial;
+}
+
+/* Make nested and serial headers more distinguishable */
+h2 {
+    margin-top: 2em;
+    padding-bottom: 0.25em;
+    border-bottom: 1px solid #e1e4e5;
+}
+
+h3 {
+    font-size: 100%;
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -121,7 +121,9 @@ html_theme = "sphinx_rtd_theme"
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = {
+    'logo_only': True
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
@@ -135,7 +137,7 @@ html_theme = "sphinx_rtd_theme"
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+html_logo = "_static/GafferLogoMini.svg"
 
 # The name of an image file (relative to this directory) to use as a favicon of
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
@@ -159,7 +161,7 @@ html_static_path = [ "_static" ]
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}
@@ -178,7 +180,7 @@ html_static_path = [ "_static" ]
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True
@@ -381,3 +383,6 @@ def setup( app ) :
     app.add_transform( GafferTransform )
 
     app.connect( "source-read", gafferSourceSubstitutions )
+    
+    # Add the custom stylesheet; used in all .md and .rst files in source
+    app.add_stylesheet( 'gaffer.css' )

--- a/doc/source/generate.sh
+++ b/doc/source/generate.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+set -e
+
+cp ../../resources/GafferLogo.svg _static
+cp ../../resources/GafferLogoMini.svg _static


### PR DESCRIPTION
Initial docs restyling to better match Gaffer colors and branding.

**Changes**
- Add new stylesheet that adjusts navigation bar colors.
- Include Gaffer logos as static resources.
- Add Gaffer logo to navigation.
- Adjust the mobile header to have better spacing and readability.
- Some minor adjustments to article text classes.