### PR TITLE
SceneViewUI : Fix display of nested lights in look-through menu 

### DIFF
--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -497,7 +497,7 @@ class _CameraPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		for abbreviatedPath, path in self.__abbreviatedPaths( set.value ) :
 			m.append(
-				"/{}".format( abbreviatedPath ),
+				abbreviatedPath,
 				{
 					"checkBox" : currentLookThrough == path,
 					"command" : functools.partial( Gaffer.WeakMethod( self.__lookThrough ), path )

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -485,21 +485,14 @@ class _CameraPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__lookThrough( event.data[0] )
 		return True
 
-	def __computeSet( self, setName ) :
-
-		sets = {}
-		with IECore.IgnoredExceptions( Exception ) :
-			with self.getContext() :
-				sets = GafferScene.SceneAlgo.sets( self.getPlug().node()["in"], [ setName ] )
-
-		return sets.get( setName )
-
 	def __setMenu( self, setName, currentLookThrough ) :
 
 		m = IECore.MenuDefinition()
 
-		set = self.__computeSet( setName )
-		if not set :
+		try :
+			with self.getContext() :
+				set = self.getPlug().node()["in"].set( setName )
+		except :
 			return m
 
 		for abbreviatedPath, path in self.__abbreviatedPaths( set.value ) :


### PR DESCRIPTION
Here's the script I was testing with in case you want to replicate the problem :

```
import Gaffer
import GafferArnold
import GafferImage
import GafferScene
import IECore
import imath

Gaffer.Metadata.registerNodeValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
Gaffer.Metadata.registerNodeValue( parent, "serialiser:majorVersion", 47, persistent=False )
Gaffer.Metadata.registerNodeValue( parent, "serialiser:minorVersion", 0, persistent=False )
Gaffer.Metadata.registerNodeValue( parent, "serialiser:patchVersion", 0, persistent=False )

__children = {}

parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "imageCataloguePort", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["imageCataloguePort"].addChild( Gaffer.StringPlug( "name", defaultValue = 'image:catalogue:port', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["imageCataloguePort"].addChild( Gaffer.IntPlug( "value", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectName", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:name', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectRootDirectory", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:rootDirectory', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format( 1920, 1080, 1.000 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
parent.addChild( __children["defaultFormat"] )
__children["distant_light"] = GafferArnold.ArnoldLight( "distant_light" )
parent.addChild( __children["distant_light"] )
__children["distant_light"].loadShader( "distant_light" )
__children["distant_light"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group"] = GafferScene.Group( "Group" )
parent.addChild( __children["Group"] )
__children["Group"]["in"].addChild( GafferScene.ScenePlug( "in1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group"]["in"].addChild( GafferScene.ScenePlug( "in2", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["spot_light"] = GafferArnold.ArnoldLight( "spot_light" )
parent.addChild( __children["spot_light"] )
__children["spot_light"].loadShader( "spot_light" )
__children["spot_light"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group1"] = GafferScene.Group( "Group1" )
parent.addChild( __children["Group1"] )
__children["Group1"]["in"].addChild( GafferScene.ScenePlug( "in1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["imageCataloguePort"]["value"].setValue( 44088 )
Gaffer.Metadata.registerValue( parent["variables"]["imageCataloguePort"], 'readOnly', True )
Gaffer.Metadata.registerValue( parent["variables"]["projectName"]["name"], 'readOnly', True )
Gaffer.Metadata.registerValue( parent["variables"]["projectRootDirectory"]["name"], 'readOnly', True )
__children["distant_light"]["name"].setValue( 'distantLight' )
__children["distant_light"]["__uiPosition"].setValue( imath.V2f( 4.67449236, 1.36815643 ) )
__children["Group"]["in"]["in0"].setInput( __children["Group1"]["out"] )
__children["Group"]["in"]["in1"].setInput( __children["distant_light"]["out"] )
__children["Group"]["__uiPosition"].setValue( imath.V2f( -0.325977564, -6.79617453 ) )
__children["spot_light"]["name"].setValue( 'spotLight' )
__children["spot_light"]["__uiPosition"].setValue( imath.V2f( -9.82383442, 9.53195 ) )
__children["Group1"]["in"]["in0"].setInput( __children["spot_light"]["out"] )
__children["Group1"]["__uiPosition"].setValue( imath.V2f( -8.32550812, 1.36788774 ) )


del __children
```