### PR TITLE
Docs: Increase control over TOC generation

### DIFF
--- a/doc/source/Appendices/index.md
+++ b/doc/source/Appendices/index.md
@@ -1,4 +1,11 @@
 Appendices
 ==========
 
-- [License](License/index.md)
+<!-- TOC -->
+
+```eval_rst
+.. toctree::
+    :titlesonly:
+
+    License/index.md
+```

--- a/doc/source/Reference/ScriptingReference/index.md
+++ b/doc/source/Reference/ScriptingReference/index.md
@@ -1,8 +1,15 @@
 Scripting Reference
 ===================
 
-- [Common Operations](CommonOperations/index.md)
-- [String Substitution Syntax](StringSubstitutionSyntax/index.md)
-- [Expressions](Expressions/index.md)
-- [Set Expressions](SetExpressions/index.md)
-- [Metadata](Metadata/index.md)
+<!-- TOC -->
+
+```eval_rst
+.. toctree::
+    :titlesonly:
+
+    CommonOperations/index.md
+    StringSubstitutionSyntax/index.md
+    Expressions/index.md
+    SetExpressions/index.md
+    Metadata/index.md
+```

--- a/doc/source/Reference/UIReference/index.md
+++ b/doc/source/Reference/UIReference/index.md
@@ -1,7 +1,13 @@
 UI Reference
 ============
 
-- [Node Graph](NodeGraph.md)
-- [Viewer](Viewer.md)
-- [Script Editor](ScriptEditor.md)
+<!-- TOC -->
 
+```eval_rst
+.. toctree::
+    :titlesonly:
+
+    NodeGraph.md
+    Viewer.md
+    ScriptEditor.md
+```

--- a/doc/source/Reference/index.md
+++ b/doc/source/Reference/index.md
@@ -1,7 +1,14 @@
 Reference
 =========
 
-- [UI Reference](UIReference/index.md)
-- [Node Reference](NodeReference/index.md)
-- [Scripting Reference](ScriptingReference/index.md)
-- [Command Line Reference](CommandLineReference/index.md)
+<!-- TOC -->
+
+```eval_rst
+.. toctree::
+    :titlesonly:
+
+    UIReference/index.md
+    NodeReference/index.md
+    ScriptingReference/index.md
+    CommandLineReference/index.md
+```

--- a/doc/source/ReleaseNotes/generate.py
+++ b/doc/source/ReleaseNotes/generate.py
@@ -1,18 +1,17 @@
 import re
-
-index = open( "./index.md", "w" )
-index.write( "Release Notes\n" )
-index.write( "=============\n\n" )
+import inspect
 
 changes = open( "../../../Changes" )
 
 versionFile = None
 
+versionIndex = ""
+
 for line in changes :
 
 	m = re.match( r"^(Gaffer )?(([0-9]+\.){2,3}[0-9]+)", line )
 	if m :
-		index.write( "- [{0}]({0}.md)\n".format( m.group( 2 ) ) )
+		versionIndex += ( "\t{0}.md\n".format( m.group( 2 ) ) )
 		versionFile = open( m.group( 2 ) + ".md", "w" )
 		versionFile.write( m.group( 2 ) + "\n" )
 		continue
@@ -23,3 +22,21 @@ for line in changes :
 	versionFile.write(
 		re.sub( r"#([0-9]+)", r"[#\1](https://github.com/GafferHQ/gaffer/issues/\1)", line )
 	)
+
+index = open( "./index.md", "w" )
+
+index.write( inspect.cleandoc(
+	
+	"""
+	# Release Notes #
+
+	```eval_rst
+	.. toctree::
+	    :titlesonly:
+	    :glob:
+
+	    *
+	```
+	"""
+
+) )

--- a/doc/source/Tutorials/Scripting/index.md
+++ b/doc/source/Tutorials/Scripting/index.md
@@ -5,8 +5,15 @@ All of Gaffer’s core functionality is available to be scripted using Python - 
 
 There is a direct one to one correspondence between the C++ and Python APIs for Gaffer, so if you start out using one, you can easily transfer to the other. This makes it relatively straightforward to prototype in Python, but convert to C++ if performance becomes an issue, or to spend most of your time hacking away in C++ but still be comfortable writing some GUI code in Python.
 
-- [Getting Started](GettingStarted/index.md)
-- [Creating Configuration Files](CreatingConfigurationFiles/index.md)
-- [Adding a Menu Item](AddingAMenuItem/index.md)
-- [Querying a Scene](QueryingAScene/index.md)
-- [Using the OSLCode Node](UsingTheOSLCodeNode/index.md)
+<!-- TOC -->
+
+```eval_rst
+.. toctree::
+    :titlesonly:
+
+    GettingStarted/index.md
+    CreatingConfigurationFiles/index.md
+    AddingAMenuItem/index.md
+    QueryingAScene/index.md
+    UsingTheOSLCodeNode/index.md
+```

--- a/doc/source/Tutorials/index.md
+++ b/doc/source/Tutorials/index.md
@@ -1,6 +1,13 @@
 Tutorials
 =========
 
-- [Getting Started](GettingStarted/index.md)
-- [Scripting](Scripting/index.md)
-- [Managing Complexity](ManagingComplexity/index.md)
+<!-- TOC -->
+
+```eval_rst
+.. toctree::
+    :titlesonly:
+
+    GettingStarted/index.md
+    Scripting/index.md
+    ManagingComplexity/index.md
+```

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -122,7 +122,8 @@ html_theme = "sphinx_rtd_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    'logo_only': True
+    'logo_only': True,
+    'collapse_navigation': False
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
@@ -376,6 +377,9 @@ def setup( app ) :
     app.add_config_value(
     	'recommonmark_config',
     	{
+            # Disable general automatic TOC parsing. Prevents Autostructify
+            # from turning all Markdown list items with links into TOC items
+            'enable_auto_toc_tree': False
         },
         True
     )

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -12,3 +12,29 @@ In addition to itself being highly extensible, Gaffer's underlying frameworks ar
 - [Reference](Reference/index.md)
 - [Release Notes](ReleaseNotes/index.md)
 - [Appendices](Appendices/index.md)
+
+<!-- TOC -->
+
+```eval_rst
+.. toctree::
+    :hidden:
+    :titlesonly:
+    :maxdepth: 1
+    :caption: User Documentation
+
+    Installation/index.md
+    Tutorials/index.md
+
+```
+
+```eval_rst
+.. toctree::
+    :hidden:
+    :titlesonly:
+    :maxdepth: 1
+    :caption: Supplemental Material
+
+    Reference/index.md
+    ReleaseNotes/index.md
+    Appendices/index.md
+```

--- a/python/GafferUI/DocumentationAlgo.py
+++ b/python/GafferUI/DocumentationAlgo.py
@@ -61,6 +61,8 @@ def exportNodeReference( directory, modules = [], modulePath = "" ) :
 	index = open( "%s/index.md" % directory, "w" )
 	index.write( __heading( "Node Reference" ) )
 
+	tocIndex = ""
+
 	for module in sorted( modules, key = lambda x : getattr( x, "__name__" ) ) :
 
 		moduleIndex = ""
@@ -83,15 +85,17 @@ def exportNodeReference( directory, modules = [], modulePath = "" ) :
 			__makeDirs( directory + "/" + module.__name__ )
 			with open( "%s/%s/%s.md" % ( directory, module.__name__, name ), "w" ) as f :
 				f.write( __nodeDocumentation( node ) )
-				moduleIndex += "- [%s](%s.md)\n" % ( name, name )
+				moduleIndex += "\t%s.md\n" % name
 
 		if moduleIndex :
 
 			with open( "%s/%s/index.md" % ( directory, module.__name__ ), "w" ) as f :
 				f.write( __heading( module.__name__ ) )
-				f.write( moduleIndex )
+				f.write( __tocString( ).format( moduleIndex ) )
 
-			index.write( "- [%s](%s/index.md)\n" % ( module.__name__, module.__name__ ) )
+			tocIndex += "\t%s/index.md\n" % ( module.__name__ )
+
+	index.write( __tocString( ).format( tocIndex ) )
 
 def exportLicenseReference( directory, about ) :
 
@@ -172,15 +176,19 @@ def exportCommandLineReference( directory, appPath = "$GAFFER_ROOT/apps", ignore
 
 	index.write( "\n\n" )
 
+	tocIndex = ""
+
 	for appName in classLoader.classNames() :
 
 		if appName in ignore :
 			continue
 
-		index.write( "- [%s](%s.md)\n" % ( appName, appName ) )
+		tocIndex += "\t%s.md\n" % appName
 		with open( "%s.md" % appName, "w" ) as f :
 
 			f.write( __appDocumentation( classLoader.load( appName )() ) )
+
+	index.write( __tocString( ).format( tocIndex ) )
 
 def __nodeDocumentation( node ) :
 
@@ -255,3 +263,20 @@ def __makeDirs( directory ) :
 		# raise if it fails. We reraise only in the latter case.
 		if not os.path.isdir( directory ) :
 			raise
+
+def __tocString( ) :
+
+	tocString = inspect.cleandoc(
+
+		"""
+		```eval_rst
+		.. toctree::
+		    :titlesonly:
+
+		{0}
+		```
+		"""
+
+	)
+
+	return tocString


### PR DESCRIPTION
This PR will disable the autotoctree functionality for static documentation, but retain it for autogenerated material. It will also make the full TOC appear in every article, improving UX for browsing. 

#### Rationale
With RecommonMark's autotoctree feature, _any_ list of links at the end of an article in Markdown is converted into a reST TOCTree. This limits our control over, and the flexibility of, the TOC. It requires every section's index to redundantly contain links to every child article, when the reader can already see those articles in the nav bar. Critically, it prevents "See Also" link lists at the ends of articles, making guided documentation impossible.

Making TOC indexing verbose enables users to browse the nav bar's contents without leaving the current page, making them more likely to use it. (Note: it increases build times and file sizes, but not critically, I would argue. The top index remains <100 kB)

#### Changes
- Disable RecommonMark's autotoctree feature.
~~- Headers named "Contents" will use autotoctree conversion (reserved for reference material that requires automatic indexing).~~
~~- Make reference material scripts add "Contents" headers to the reference section indexes.~~
    **Edit:**
    - Make reference material scripts add Sphinx TOCs.
- Enable verbose TOC indexing.
- Add Sphinx TOCs to static indexes.