### PR TITLE
SceneGadget : Apply selection after expanding

### DIFF
--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -923,7 +923,7 @@ void SceneGadget::updateSceneGraph() const
 		UpdateTask *task = new( tbb::task::allocate_root() ) UpdateTask( this, m_sceneGraph.get(), m_dirtyFlags, ScenePlug::ScenePath() );
 		tbb::task::spawn_root_and_wait( *task );
 
-		if( m_dirtyFlags & UpdateTask::ChildNamesDirty )
+		if( m_dirtyFlags & ( UpdateTask::ChildNamesDirty | UpdateTask::ExpansionDirty ) )
 		{
 			m_sceneGraph->applySelection( m_selection );
 		}


### PR DESCRIPTION
This was broken by `af3247ae90afd712821f2ddf093ca2589d817e24`, which by fixing one problem had exposed another error in the original code.