### PR TITLE
GafferOSL : ThreadContext can be default constructed

### DIFF
--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -1202,14 +1202,11 @@ IECore::CompoundDataPtr ShadingEngine::shade( const IECore::CompoundData *points
 
 	// Iterate over the input points, doing the shading as we go
 
-	ShadingSystem *shadingSystem = ::shadingSystem();
-	ShaderGroup &shaderGroup = **static_cast<ShaderGroupRef *>( m_shaderGroupRef );
-
 	struct ThreadContext
 	{
 
-		ThreadContext( ShadingSystem *shadingSystem )
-			:	m_shadingSystem( shadingSystem ), m_shadingContext( shadingSystem->get_context() )
+		ThreadContext()
+			:	m_shadingSystem( ::shadingSystem() ), m_shadingContext( m_shadingSystem->get_context() )
 		{
 		}
 
@@ -1220,7 +1217,7 @@ IECore::CompoundDataPtr ShadingEngine::shade( const IECore::CompoundData *points
 
 		ShadingResults::DebugResultsMap results;
 
-		ShadingContext *shadingContext() { return m_shadingContext; }
+		ShadingContext *shadingContext() const { return m_shadingContext; }
 
 		private :
 
@@ -1230,9 +1227,12 @@ IECore::CompoundDataPtr ShadingEngine::shade( const IECore::CompoundData *points
 	};
 
 	typedef tbb::enumerable_thread_specific<ThreadContext> ThreadContextType;
-	ThreadContextType contexts( shadingSystem );
+	ThreadContextType contexts;
 
 	const IECore::Canceller *canceller = context->canceller();
+
+	ShadingSystem *shadingSystem = ::shadingSystem();
+	ShaderGroup &shaderGroup = **static_cast<ShaderGroupRef *>( m_shaderGroupRef );
 
 	auto f = [&shadingSystem, &renderState, &results, &shaderGlobals, &p, &u, &v, &uv, &n, &shaderGroup, &contexts, canceller]( const tbb::blocked_range<size_t> &r )
 	{


### PR DESCRIPTION
When compiling with clang 5.0.1 the probable implicit construction of a ThreadContext from a ShadingSystem * was failing with the following message:

```
/software/tools/include/cent7.x86_64/tbb/4.4/tbb/enumerable_thread_specific.h:621:55: error: called object type 'OSL_v1_9::ShadingSystem *' is not a function or function pointer
void construct(void* where) {new(where) T(f());}
^
/software/tools/include/cent7.x86_64/tbb/4.4/tbb/enumerable_thread_specific.h:676:30: note: in instantiation of member function 'tbb::interface6::internal::construct_by_finit<ThreadContext, OSL_v1_9::ShadingSystem *>::construct' requested
	here
Constructor::construct(where);
^
/software/tools/include/cent7.x86_64/tbb/4.4/tbb/enumerable_thread_specific.h:661:34: note: in instantiation of member function 'tbb::interface6::internal::callback_leaf<ThreadContext,
tbb::interface6::internal::construct_by_finit<ThreadContext, OSL_v1_9::ShadingSystem *> >::construct' requested here
template<typename X> callback_leaf( const X& x ) : Constructor(x) {}
^
/software/tools/include/cent7.x86_64/tbb/4.4/tbb/enumerable_thread_specific.h:689:35: note: in instantiation of function template specialization 'tbb::interface6::internal::callback_leaf<ThreadContext,
tbb::interface6::internal::construct_by_finit<ThreadContext, OSL_v1_9::ShadingSystem *> >::callback_leaf<OSL_v1_9::ShadingSystem *>' requested here
return new(where) callback_leaf(x);
^
/software/tools/include/cent7.x86_64/tbb/4.4/tbb/enumerable_thread_specific.h:864:80: note: in instantiation of function template specialization 'tbb::interface6::internal::callback_leaf<ThreadContext,
tbb::interface6::internal::construct_by_finit<ThreadContext, OSL_v1_9::ShadingSystem *> >::make<OSL_v1_9::ShadingSystem *>' requested here
internal::callback_leaf<T,internal::construct_by_finit<T,Finit> >::make( tbb::internal::move(finit) )
^
src/GafferOSL/ShadingEngine.cpp:1233:20: note: in instantiation of function template specialization 'tbb::interface6::enumerable_thread_specific<ThreadContext, tbb::cache_aligned_allocator<ThreadContext>,
tbb::ets_key_usage_type::ets_no_key>::enumerable_thread_specific<OSL_v1_9::ShadingSystem *>' requested here
ThreadContextType contexts( shadingSystem );
```

Offering this sub-awesome PR as I'm trying to offer a solution rather than just report a problem.  I tried using the other *enumerable_thread_specific* constructors without luck but perhaps I just messed up my implementation. 

The following two attempts resulted in inexplicable crashes:
- Explicitly constructing a *ThreadContext* and passing into the *tbb::enumerable_thread_specific* with an updated copy constructor to get a new context on copy.
- also failed at using the ctor which accepts a template functor. 



