### PR TITLE
Fixed bug with the Catalogue AsynchronousSaver

### DIFF
--- a/python/GafferImageTest/DisplayTest.py
+++ b/python/GafferImageTest/DisplayTest.py
@@ -105,7 +105,7 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 				self.__driver.imageClose()
 
 		@classmethod
-		def sendImage( cls, image, port, extraParameters = {} ) :
+		def sendImage( cls, image, port, extraParameters = {}, close = True ) :
 
 			dataWindow = image["dataWindow"].getValue()
 			channelNames = image["channelNames"].getValue()
@@ -128,7 +128,8 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 						channelData.append( image.channelData( channelName, tileOrigin ) )
 					driver.sendBucket( imath.Box2i( tileOrigin, tileOrigin + imath.V2i( tileSize ) ), channelData )
 
-			driver.close()
+			if close :
+				driver.close()
 
 			return driver
 

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -827,6 +827,17 @@ std::string Catalogue::generateFileName( const ImagePlug *image ) const
 	{
 		directory = script->context()->substitute( directory );
 	}
+	else if( Context::hasSubstitutions( directory ) )
+	{
+		// Its possible for a Catalogue to have been removed from its script
+		// and still receive an image. If it will attempt to save that image
+		// to a file which needed the script context to resolve properly, the
+		// saving will eventually error, so we return an empty string instead.
+		// Its likely this only occurs while the node is in the process of
+		// being deleted (perhaps inside python's garbage collector).
+		return "";
+	}
+
 	if( directory.empty() )
 	{
 		return "";


### PR DESCRIPTION
I experienced this issue during my documentation revamp, where the screengrab app is now loading multiple scripts which use Catalogues, all within a single session. A Catalogue which had been removed from the script was still trying to save images, despite the file it wanted to write being dependent on the script variables. We now prevent saving in this obscure case.

Note that while I didn't change `CatalogueTest.testDeleteBeforeSaveCompletes` here, as best I can tell it isn't doing what it claims. The async save happens so quickly that the save completes before the catalogue is deleted (confirmed via prints inside the saver), so I've taken an alternate approach in my new test case.