### PR TITLE
Window positions

### DIFF
--- a/python/GafferUI/NodeSetEditor.py
+++ b/python/GafferUI/NodeSetEditor.py
@@ -140,12 +140,12 @@ class NodeSetEditor( GafferUI.Editor ) :
 			scriptWindow.getLayout().addEditor( editor )
 		else :
 			window = _EditorWindow( scriptWindow, editor )
-			window.setVisible( True )
 			## \todo Can we do better using `window.resizeToFitChild()`?
 			# Our problem is that some NodeEditors (for GafferImage.Text for instance)
 			# are very large, whereas some (GafferScene.Shader) don't have
 			# a valid size until the UI has been built lazily.
 			window._qtWidget().resize( 400, 400 )
+			window.setVisible( True )
 
 		return editor
 

--- a/python/GafferUI/Window.py
+++ b/python/GafferUI/Window.py
@@ -373,6 +373,15 @@ class _WindowEventFilter( QtCore.QObject ) :
 		elif type==QtCore.QEvent.Resize :
 			widget = GafferUI.Widget._owner( qObject )
 			widget._Window__sizeValid = True
+		elif type==QtCore.QEvent.Move :
+			widget = GafferUI.Widget._owner( qObject )
+			if hasattr( widget, "_lastPosition" ) and widget._lastPosition is not None :
+				widget.setPosition( widget._lastPosition )
+				widget._lastPosition = None
+		elif type==QtCore.QEvent.Hide :
+			widget = GafferUI.Widget._owner( qObject )
+			if widget :
+				widget._lastPosition = widget.getPosition()
 
 		return False
 


### PR DESCRIPTION
With Qt5 (on CentOs7 in Mate) we are getting odd position behaviour for some child windows (specifically _Preferences_ and _Settings_). When they are hidden (usually via `GafferUI.Window.close()`), and their size is insufficient to display their contents, then the next time they are shown, they have lost their original position on screen and appear in the upper left corner of the leftmost monitor.

Similarly, floating _Node Editors_ (via double click in the _Node Graph_) always appear in the upper left corner of the leftmost monitor.

Here we fix both issues in slightly different ways. Unfortunately I don't really understand why either approach is necessary, but I'm not exactly a UI expert, so perhaps it makes sense.