### PR TITLE
Docs: Rework admonition icons and colours

### DIFF
--- a/apps/cli/cli-1.py
+++ b/apps/cli/cli-1.py
@@ -50,7 +50,7 @@ class cli( Gaffer.Application ) :
 			A python command line interpreter which has all the
 			Gaffer modules available to it.
 
-			> Warning : This application is deprecated.
+			> Caution : This application is deprecated.
 			> Use `gaffer env python` instead.
 			"""
 		)

--- a/apps/python/python-1.py
+++ b/apps/python/python-1.py
@@ -50,7 +50,7 @@ class python( Gaffer.Application ) :
 			Runs python scripts in an environment where all the
 			Gaffer modules are available.
 
-			> Warning : This application is deprecated.
+			> Caution : This application is deprecated.
 			> Use `gaffer env python` instead.
 			"""
 		)

--- a/doc/source/_static/gaffer.css
+++ b/doc/source/_static/gaffer.css
@@ -104,3 +104,56 @@ kbd, code.kbd {
     font-family: inherit;
     color: #404040 !important;
 }
+
+/* Change icon of "Note" admonition to paperclip */
+.admonition.note p.first.admonition-title::before {
+    content: "\f0c6";
+}
+
+/* Change color of "Note" admonition to muted blue */
+.admonition.note {
+    background-color: #f3f6f6;
+}
+
+.admonition.note p.first.admonition-title {
+    background-color: #7796ab;
+}
+
+/* Change icon of "Tip" admonition to pointing hand */
+.admonition.tip p.first.admonition-title::before {
+    content: "\f0a4";
+}
+
+/* Change icon of "Important" admonition to star */
+.admonition.important p.first.admonition-title::before {
+    content: "\f005";
+    color: #ffffcc;
+}
+
+/* Change color of "Important" admonition to standard blue */
+.admonition.important {
+    background-color: #e7f2fa;
+}
+
+.admonition.important p.first.admonition-title {
+    background-color:#6ab0de
+}
+
+/* Change icon of "Caution" admonition to triangular exclamation */
+.admonition.caution p.first.admonition-title::before {
+    content: "\f071";
+}
+
+/* Change icon of "Warning" admonition to "no" sign */
+.admonition.warning p.first.admonition-title::before {
+    content: "\f05e";
+}
+
+/* Change color of "Warning" admonition to Gaffer red */
+.admonition.warning {
+    background-color: #fff0f0;
+}
+
+.admonition.warning p.first.admonition-title {
+    background-color: #b92227;
+}

--- a/include/Gaffer/Action.h
+++ b/include/Gaffer/Action.h
@@ -63,7 +63,7 @@ IE_CORE_FORWARDDECLARE( Action );
 /// > method is called. Because Actions are essentially an implementation detail
 /// > of the undo system, subclasses shouldn't be exposed in the public headers.
 ///
-/// > Warning : Because Actions are held in the undo queue in the ScriptNode, it's
+/// > Caution : Because Actions are held in the undo queue in the ScriptNode, it's
 /// > essential that they do not themselves hold an intrusive pointer pointing
 /// > back to the ScriptNode - this would result in a circular reference,
 /// > preventing the ScriptNode from being deleted appropriately. It is essential
@@ -102,7 +102,7 @@ class GAFFER_API Action : public IECore::RunTimeTyped
 		/// remain alive for as long as the Functions are in use by the undo
 		/// system, so it is sufficient to bind only raw pointers to the subject.
 		///
-		/// > Warning : Only pass `cancelBackgroundTasks = false` if you are
+		/// > Caution : Only pass `cancelBackgroundTasks = false` if you are
 		/// > _certain_ that there is no possible interaction between this Action
 		/// > and a concurrent background task. At the time of writing, the only
 		/// > known valid use is in the Metadata system (because computations are

--- a/include/Gaffer/ParallelAlgo.h
+++ b/include/Gaffer/ParallelAlgo.h
@@ -58,7 +58,7 @@ namespace ParallelAlgo
 /// > Note : This function does nothing unless the GafferUI module has
 /// > been imported.
 ///
-/// > Warning : If calling a member function, you _must_ guarantee that
+/// > Caution : If calling a member function, you _must_ guarantee that
 /// > the class instance will still be alive when the member function is
 /// > called. Typically this means binding `this` via a smart pointer.
 typedef std::function<void ()> UIThreadFunction;

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -240,7 +240,7 @@ class GAFFER_API ScriptNode : public Node
 		const Context *context() const;
 		/// Drives the frame variable in the context.
 		///
-		/// > Warning : This exists primarily as a convenience for the
+		/// > Caution : This exists primarily as a convenience for the
 		/// > user, so that the "current frame" is saved within the
 		/// > script file. To perform a computation at a particular time,
 		/// > create your own context rather than change the value of

--- a/python/GafferSceneUI/FilterResultsUI.py
+++ b/python/GafferSceneUI/FilterResultsUI.py
@@ -46,7 +46,7 @@ Gaffer.Metadata.registerNode(
 	Searches an input scene for all locations matched
 	by a filter.
 
-	> Warning : This can be an arbitrarily expensive operation
+	> Caution : This can be an arbitrarily expensive operation
 	depending on the size of the input scene and the filter
 	used. In particular it should be noted that the usage of
 	`...` in a PathFilter will cause the entire input scene to

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -112,7 +112,7 @@ Gaffer.Metadata.registerNode(
 			A filter to define additional paths to be added to
 			or removed from the set.
 
-			> Warning : Using a filter can be very expensive.
+			> Caution : Using a filter can be very expensive.
 			It is advisable to limit use to filters with a
 			limited number of matches and/or sets which are
 			not used heavily downstream. Wherever possible,


### PR DESCRIPTION
A small QOL change that will help UX: distinguish the admonitions better and make them stand out more.

#### Changes
- Make Notes monochrome (they're the most frequent, so they shouldn't stand out as much) and use a paperclip icon.
- Make Tips green (for "go") and use a pointing hand icon (current version of FontAwesome's pen doesn't render well at this scale).
- Make Cautions use a caution icon.
- Make Warnings Gaffer red and use a "no" symbol (FontAwesome doesn't have a danger icon).