### PR TITLE
Docs: Minor TOC adjustments

### DIFF
--- a/doc/source/Reference/ScriptingReference/index.md
+++ b/doc/source/Reference/ScriptingReference/index.md
@@ -6,6 +6,7 @@ Scripting Reference
 ```eval_rst
 .. toctree::
     :titlesonly:
+    :maxdepth: 1
 
     CommonOperations/index.md
     StringSubstitutionSyntax/index.md

--- a/doc/source/Reference/index.md
+++ b/doc/source/Reference/index.md
@@ -6,6 +6,7 @@ Reference
 ```eval_rst
 .. toctree::
     :titlesonly:
+    :maxdepth: 1
 
     NodeReference/index.md
     ScriptingReference/index.md

--- a/doc/source/Tutorials/index.md
+++ b/doc/source/Tutorials/index.md
@@ -6,6 +6,7 @@ Tutorials
 ```eval_rst
 .. toctree::
     :titlesonly:
+    :maxdepth: 1
 
     GettingStarted/index.md
     Scripting/index.md

--- a/python/GafferUI/DocumentationAlgo.py
+++ b/python/GafferUI/DocumentationAlgo.py
@@ -85,7 +85,7 @@ def exportNodeReference( directory, modules = [], modulePath = "" ) :
 			__makeDirs( directory + "/" + module.__name__ )
 			with open( "%s/%s/%s.md" % ( directory, module.__name__, name ), "w" ) as f :
 				f.write( __nodeDocumentation( node ) )
-				moduleIndex += "\t%s.md\n" % name
+				moduleIndex += "\n\t%s.md" % name
 
 		if moduleIndex :
 
@@ -93,7 +93,7 @@ def exportNodeReference( directory, modules = [], modulePath = "" ) :
 				f.write( __heading( module.__name__ ) )
 				f.write( __tocString( ).format( moduleIndex ) )
 
-			tocIndex += "\t%s/index.md\n" % ( module.__name__ )
+			tocIndex += "\n\t%s/index.md" % ( module.__name__ )
 
 	index.write( __tocString( ).format( tocIndex ) )
 
@@ -183,7 +183,7 @@ def exportCommandLineReference( directory, appPath = "$GAFFER_ROOT/apps", ignore
 		if appName in ignore :
 			continue
 
-		tocIndex += "\t%s.md\n" % appName
+		tocIndex += "\n\t%s.md" % appName
 		with open( "%s.md" % appName, "w" ) as f :
 
 			f.write( __appDocumentation( classLoader.load( appName )() ) )
@@ -272,7 +272,7 @@ def __tocString( ) :
 		```eval_rst
 		.. toctree::
 		    :titlesonly:
-
+		    :maxdepth: 1
 		{0}
 		```
 		"""


### PR DESCRIPTION
Low-priority fix to minor mistake: I forgot to make all the TOCs walk only one level deep in the intitial TOC PR.

@andrewkaufman You asked earlier why we're not indexing article headers anymore:

My goal is to keep the navigation sidebar as clear and succinct as possible, and I don't think signposting every header is a level of granularity that's useful or necessary (maybe in the article itself – possible to implement with JS). It mostly just clutters the navigation up, which will become a bigger issue when the doc grows bigger.

This PR works in a similar vein: the root index of each section doesn't need every sub-article listed. For instance, the Node Reference index doesn't need to list every node of every module: that's what the nav is there for. In fact, as it stands, the autogenerated indexes themselves don't serve much semantic function, as they're just articles comprised of a list of links. In the future, I'd like to add a brief blurb about each module to the index – hence the disabling of autotoctree – but that'll happen later.

#### Changes
- Add `:maxdepth: 1` to static TOCs.
- Add `:maxdepth: 1` to dynamic TOCs.
- Slight formatting improvement to dynamic TOCs.