### PR TITLE
Volume step_scale

### DIFF
--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -2170,7 +2170,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.option( "ai:background", None )
 		self.assertEqual( arnold.AiNodeGetPtr( options, "background" ), None )
 
-	def testVDBs( self ) :
+	def __testVDB( self, stepSize = None, stepScale = 1.0, expectedSize = 0.0, expectedScale = 1.0 ) :
 
 		import IECoreVDB
 
@@ -2186,8 +2186,13 @@ class RendererTest( GafferTest.TestCase ) :
 			"ai:volume:velocity_scale" : IECore.FloatData( 10 ),
 			"ai:volume:velocity_fps" : IECore.FloatData( 25 ),
 			"ai:volume:velocity_outlier_threshold" : IECore.FloatData( 0.5 ),
-			"ai:volume:step_size" : IECore.FloatData( 0.75 ), 
-			"ai:volume:step_scale" : IECore.FloatData( 1.25 ) } )
+		} )
+
+		if stepSize is not None:
+			attributes["ai:volume:step_size"] = IECore.FloatData( stepSize )
+
+		if stepScale is not None:
+			attributes["ai:volume:step_scale"] = IECore.FloatData( stepScale )
 
 		# Camera needs to be added first as it's being used for translating the VDB.
 		# We are doing the same when translating actual Gaffer scenes here:
@@ -2232,8 +2237,15 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertEqual( arnold.AiNodeGetFlt( vdbShape, "motion_start" ), 10.75 )
 			self.assertEqual( arnold.AiNodeGetFlt( vdbShape, "motion_end" ), 11.25 )
 
-			self.assertEqual( arnold.AiNodeGetFlt( vdbShape, "step_size"), 0.75 )
-			self.assertEqual( arnold.AiNodeGetFlt( vdbShape, "step_scale"), 1.25 )
+			self.assertAlmostEqual( arnold.AiNodeGetFlt( vdbShape, "step_size"), expectedSize, 7 )
+			self.assertAlmostEqual( arnold.AiNodeGetFlt( vdbShape, "step_scale"), expectedScale, 7 )
+
+	def testVDBs( self ) :
+
+		self.__testVDB( stepSize = None, stepScale = 0.25, expectedSize = 0.0, expectedScale = 0.25 )
+		self.__testVDB( stepSize = 0.1, stepScale = None, expectedSize = 0.1, expectedScale = 1.0 )
+		self.__testVDB( stepSize = None, stepScale = None, expectedSize = 0.0, expectedScale = 1.0 )
+		self.__testVDB( stepSize = 1.0, stepScale = 0.5, expectedSize = 0.5, expectedScale = 1.0 )
 
 	@staticmethod
 	def __m44f( m ) :

--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -127,8 +127,14 @@ def __curvesSummary( plug ) :
 def __volumeSummary( plug ) :
 
 	info = []
+	if plug["volumeStepScale"]["enabled"].getValue() :
+		info.append( "Volume Step Scale %s" % GafferUI.NumericWidget.valueToString( plug["volumeStepScale"]["value"].getValue() ) )
 	if plug["volumeStepSize"]["enabled"].getValue() :
-		info.append( "Step %s" % GafferUI.NumericWidget.valueToString( plug["volumeStepSize"]["value"].getValue() ) )
+		info.append( "Volume Step Size %s" % GafferUI.NumericWidget.valueToString( plug["volumeStepSize"]["value"].getValue() ) )
+	if plug["shapeStepScale"]["enabled"].getValue() :
+		info.append( "Shape Step Scale %s" % GafferUI.NumericWidget.valueToString( plug["shapeStepScale"]["value"].getValue() ) )
+	if plug["shapeStepSize"]["enabled"].getValue() :
+		info.append( "Shape Step Size %s" % GafferUI.NumericWidget.valueToString( plug["shapeStepSize"]["value"].getValue() ) )
 	if plug["volumePadding"]["enabled"].getValue() :
 		info.append( "Padding %s" % GafferUI.NumericWidget.valueToString( plug["volumePadding"]["value"].getValue() ) )
 	if plug["velocityScale"]["enabled"].getValue() :
@@ -579,18 +585,56 @@ Gaffer.Metadata.registerNode(
 
 		# Volume
 
+		"attributes.volumeStepScale" : [
+
+			"description",
+			"""
+			Raymarching step size is calculated using this value 
+			multiplied by the volume voxel size or volumeStepSize if set.
+			""",
+
+			"layout:section", "Volume",
+			"label", "Volume Step Scale",
+
+		],
+
 		"attributes.volumeStepSize" : [
 
 			"description",
 			"""
-			The step size to take when raymarching volumes.
-			A non-zero value causes an object to be treated
-			as a volume container, and a value of 0 causes
-			an object to be treated as regular geometry.
+			Override the step size taken when raymarching volumes. 
+			If this value is disabled or zero then value is calculated from the voxel size.  
 			""",
 
 			"layout:section", "Volume",
-			"label", "Step Size",
+			"label", "Volume Step Size",
+
+		],
+
+		"attributes.shapeStepScale" : [
+
+			"description",
+			"""
+			Raymarching step size is calculated using this value 
+			multiplied by the shapeStepSize.
+			""",
+
+			"layout:section", "Volume",
+			"label", "Shape Step Scale",
+
+		],
+
+		"attributes.shapeStepSize" : [
+
+			"description",
+			"""
+			A non-zero value causes an object to be treated
+			as a volume container, and a value of 0 causes
+			an object to be treated as regular geometry.  
+			""",
+
+			"layout:section", "Volume",
+			"label", "Shape Step Size",
 
 		],
 

--- a/src/GafferArnold/ArnoldAttributes.cpp
+++ b/src/GafferArnold/ArnoldAttributes.cpp
@@ -89,9 +89,13 @@ ArnoldAttributes::ArnoldAttributes( const std::string &name )
 
 	// Volume parameters
 
-	attributes->addOptionalMember( "ai:shape:step_size", new FloatPlug( "value", Plug::In, 0.0f, 0.0f ), "volumeStepSize", false );
-	attributes->addOptionalMember( "ai:shape:volume_padding", new FloatPlug( "value", Plug::In, 0.0f, 0.0f ), "volumePadding", false );
+	attributes->addOptionalMember( "ai:volume:step_size", new FloatPlug( "value", Plug::In, 0.0f, 0.0f ), "volumeStepSize", false );
+	attributes->addOptionalMember( "ai:volume:step_scale", new FloatPlug( "value", Plug::In, 1.0f, 0.0f ), "volumeStepScale", false );
 
+	attributes->addOptionalMember( "ai:shape:step_size", new FloatPlug( "value", Plug::In, 0.0f, 0.0f ), "shapeStepSize", false );
+	attributes->addOptionalMember( "ai:shape:step_scale", new FloatPlug( "value", Plug::In, 1.0f, 0.0f ), "shapeStepScale", false );
+
+	attributes->addOptionalMember( "ai:shape:volume_padding", new FloatPlug( "value", Plug::In, 0.0f, 0.0f ), "volumePadding", false );
 	attributes->addOptionalMember( "ai:volume:velocity_scale", new FloatPlug( "value", Plug::In, 1.0f, 0.0f ), "velocityScale", false );
 	attributes->addOptionalMember( "ai:volume:velocity_fps", new FloatPlug( "value", Plug::In, 24.0f, 0.0f ), "velocityFPS", false );
 	attributes->addOptionalMember( "ai:volume:velocity_outlier_threshold", new FloatPlug( "value", Plug::In, 0.001f, 0.0f ), "velocityOutlierThreshold", false );

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1317,7 +1317,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			h.append( velocityScale.get_value_or( 1.0f ) );
 			h.append( velocityFPS.get_value_or( 24.0f ) );
 			h.append( velocityOutlierThreshold.get_value_or( 0.001f ) );
-			h.append( stepSize.get_value_or( 1.0f ) );
+			h.append( stepSize.get_value_or( 0.0f ) );
 			h.append( stepScale.get_value_or( 1.0f ) );
 		}
 
@@ -1371,14 +1371,12 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 			if ( stepSize )
 			{
-				AiNodeSetFlt( node, g_stepSizeArnoldString, stepSize.get() );
+				AiNodeSetFlt( node, g_stepSizeArnoldString, stepSize.get() * stepScale.get_value_or( 1.0f ) );
 			}
-
-			if ( stepScale )
+			else if ( stepScale )
 			{
 				AiNodeSetFlt( node, g_stepScaleArnoldString, stepScale.get() );
 			}
-
 		}
 	};
 


### PR DESCRIPTION
The volume procedural in Arnold 5 supports step_scale which expresses the raymarching step size to use in terms of the vdb voxel size.