### PR TITLE
FileMenu : Fix Settings window initial size

### DIFF
--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -361,6 +361,10 @@ def showSettings( menu ) :
 		settingsWindow = GafferUI.Window( "Settings", borderWidth=8 )
 		settingsWindow._settingsEditor = True
 		settingsWindow.setChild( GafferUI.NodeUI.create( scriptWindow.scriptNode() ) )
+		# The NodeUI builds lazily, so we force it to build now so we can
+		# resize the window to fit.
+		settingsWindow.getChild().plugValueWidget( scriptWindow.scriptNode()["fileName"], lazy=False )
+		settingsWindow.resizeToFitChild()
 		scriptWindow.addChildWindow( settingsWindow )
 
 	settingsWindow.setVisible( True )


### PR DESCRIPTION
This improves the initial size of the Settings window, but as a side effect it also stops the settings window disappearing off to the top left corner of the screen, at least for me. I'll continue the discussion on #2627, which is what led me down this path...