### PR TITLE
DispatchDialogue : Small improvements

### DIFF
--- a/python/GafferDispatchUI/DispatchDialogue.py
+++ b/python/GafferDispatchUI/DispatchDialogue.py
@@ -127,12 +127,13 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 		self.__initiateSettings( self.__primaryButton )
 
 	@staticmethod
-	def createWithDefaultDispatchers( tasks, postDispatchBehaviour=PostDispatchBehaviour.Confirm, title="Dispatch Tasks", sizeMode=GafferUI.Window.SizeMode.Manual, **kw ) :
+	def createWithDefaultDispatchers( tasks, defaultDispatcherType=None, postDispatchBehaviour=PostDispatchBehaviour.Confirm, title="Dispatch Tasks", sizeMode=GafferUI.Window.SizeMode.Manual, **kw ) :
 
-		defaultType = GafferDispatch.Dispatcher.getDefaultDispatcherType()
+		defaultType = defaultDispatcherType if defaultDispatcherType else GafferDispatch.Dispatcher.getDefaultDispatcherType()
 		dispatcherTypes = list(GafferDispatch.Dispatcher.registeredDispatchers())
-		dispatcherTypes.remove( defaultType )
-		dispatcherTypes.insert( 0, defaultType )
+		if defaultType and defaultType in dispatcherTypes :
+			dispatcherTypes.remove( defaultType )
+			dispatcherTypes.insert( 0, defaultType )
 
 		dispatchers = []
 		for key in dispatcherTypes :

--- a/python/GafferDispatchUI/DispatchDialogue.py
+++ b/python/GafferDispatchUI/DispatchDialogue.py
@@ -56,6 +56,8 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 	# Confirm : The dialogue remains open confirming success, with a button for returning to the editing state.
 	PostDispatchBehaviour = IECore.Enum.create( "Close", "Confirm" )
 
+	__dispatchDialogueMenuDefinition = None
+
 	def __init__( self, tasks, dispatchers, postDispatchBehaviour=PostDispatchBehaviour.Confirm, title="Dispatch Tasks", sizeMode=GafferUI.Window.SizeMode.Manual, **kw ) :
 
 		GafferUI.Dialogue.__init__( self, title, sizeMode=sizeMode, **kw )
@@ -75,7 +77,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 		# build tabs for all the node, dispatcher, and context settings
 		with GafferUI.ListContainer() as self.__settings :
 
-			mainMenu = GafferUI.MenuBar( self.menuDefinition( self.__script.applicationRoot() ) )
+			mainMenu = GafferUI.MenuBar( self.menuDefinition() )
 			mainMenu.setVisible( False )
 
 			with GafferUI.TabbedContainer() as self.__tabs :
@@ -155,27 +157,17 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 
 		GafferUI.Window.setVisible( self, visible )
 
-	## Returns an IECore.MenuDefinition which is used to define the keyboard shortcuts for all DispatchDialogues
-	# created as part of the specified application. This can be edited at any time to modify subsequently
-	# created DispatchDialogues - typically editing would be done as part of gaffer startup. Note that
-	# this menu is never shown to users, but we need it in order to register keyboard shortcuts.
-	@staticmethod
-	def menuDefinition( applicationOrApplicationRoot ) :
+	## Returns an IECore.MenuDefinition which is used to define the keyboard shortcuts for all DispatchDialogues.
+	# This can be edited at any time to modify subsequently created DispatchDialogues.
+	# Typically editing would be done as part of gaffer startup. Note that this menu is never shown to users,
+	# but we need it in order to register keyboard shortcuts.
+	@classmethod
+	def menuDefinition( cls ) :
 
-		if isinstance( applicationOrApplicationRoot, Gaffer.Application ) :
-			applicationRoot = applicationOrApplicationRoot.root()
-		else :
-			assert( isinstance( applicationOrApplicationRoot, Gaffer.ApplicationRoot ) )
-			applicationRoot = applicationOrApplicationRoot
+		if cls.__dispatchDialogueMenuDefinition is None :
+			cls.__dispatchDialogueMenuDefinition = IECore.MenuDefinition()
 
-		menuDefinition = getattr( applicationRoot, "_dispatchDialogueMenuDefinition", None )
-		if menuDefinition :
-			return menuDefinition
-
-		menuDefinition = IECore.MenuDefinition()
-		applicationRoot._dispatchDialogueMenuDefinition = menuDefinition
-
-		return menuDefinition
+		return cls.__dispatchDialogueMenuDefinition
 
 	def __nodeEditor( self, node ) :
 

--- a/startup/dispatch/gui.py
+++ b/startup/dispatch/gui.py
@@ -61,5 +61,13 @@ if application["gui"].getTypedValue() :
 			__import__( module )
 
 	menu = GafferDispatchUI.DispatchDialogue.menuDefinition( application )
-	menu.append( "/Edit/Undo", { "command" : lambda menu : menu.ancestor( GafferDispatchUI.DispatchDialogue ).scriptNode().undo(), "shortCut" : "Ctrl+Z" } )
-	menu.append( "/Edit/Redo", { "command" : lambda menu : menu.ancestor( GafferDispatchUI.DispatchDialogue ).scriptNode().redo(), "shortCut" : "Shift+Ctrl+Z" } )
+	menu.append( "/Edit/Undo", {
+		"command" : lambda menu : menu.ancestor( GafferDispatchUI.DispatchDialogue ).scriptNode().undo(),
+		"shortCut" : "Ctrl+Z",
+		"active" : lambda menu : menu.ancestor( GafferDispatchUI.DispatchDialogue ).scriptNode().undoAvailable(),
+	} )
+	menu.append( "/Edit/Redo", {
+		"command" : lambda menu : menu.ancestor( GafferDispatchUI.DispatchDialogue ).scriptNode().redo(),
+		"shortCut" : "Shift+Ctrl+Z",
+		"active" : lambda menu : menu.ancestor( GafferDispatchUI.DispatchDialogue ).scriptNode().redoAvailable(),
+	} )

--- a/startup/dispatch/gui.py
+++ b/startup/dispatch/gui.py
@@ -60,7 +60,7 @@ if application["gui"].getTypedValue() :
 		with IECore.IgnoredExceptions( ImportError ) :
 			__import__( module )
 
-	menu = GafferDispatchUI.DispatchDialogue.menuDefinition( application )
+	menu = GafferDispatchUI.DispatchDialogue.menuDefinition()
 	menu.append( "/Edit/Undo", {
 		"command" : lambda menu : menu.ancestor( GafferDispatchUI.DispatchDialogue ).scriptNode().undo(),
 		"shortCut" : "Ctrl+Z",


### PR DESCRIPTION
I've made a couple of small changes to the DispatchDialogue and Dispatch app so that it will support Jabuka's requirements.

1) Added a argument to the `createWithDefaultDispatchers()` so that a `defaultDispatcherType` can be defined per dialogue instead of per session.
Jabuka actions would generally vary between a local and a farm as the default depending on the action being executed.

2) No longer storing the hotkey menu to the `ApplicationRoot`, using the class itself instead.
That seems cleaner to me, but more importantly it allows us to add the undo/redo shortcuts in the `DispatchDialogue` in Jabuka. That's because the scripts we create for running the actions are not related to the `ApplicationRoot` at all, where we have a different kind of graph.
And even in the case of running jabuka inside gaffer, adding the action scripts to the `ApplicationRoot` just so we could execute a dispatch seemed unnecessary and a potential source of problems.
