### PR TITLE
Application loader : Don't modify `sys` module's dlopenflags

### DIFF
--- a/bin/gaffer.py
+++ b/bin/gaffer.py
@@ -38,12 +38,8 @@
 
 import os
 import sys
-import ctypes
 import signal
 import warnings
-
-# Work around cross module rtti errors on linux.
-sys.setdlopenflags( sys.getdlopenflags() | ctypes.RTLD_GLOBAL )
 
 # Get rid of the annoying signal handler which turns Ctrl-C into a KeyboardInterrupt exception
 signal.signal( signal.SIGINT, signal.SIG_DFL )


### PR DESCRIPTION
This is [getting done](https://github.com/ImageEngine/cortex/blob/2d10fd9c8acbfe89c8f07627aa92dda55e05c904/python/IECore/__init__.py#L51
) in `import IECore` anyway.

I think we should merge this now, and then take a more cautious approach with https://github.com/ImageEngine/cortex/pull/810, which will actually be in the driving seat at that point.