### PR TITLE
ViewportGadget : Make setCameraTransform() update camera

### DIFF
--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -708,6 +708,7 @@ void ViewportGadget::setCameraTransform( const Imath::M44f &transform )
 	}
 	m_cameraController->setTransform( transform );
 	m_cameraChangedSignal( this );
+	requestRender();
 }
 
 ViewportGadget::UnarySignal &ViewportGadget::cameraChangedSignal()


### PR DESCRIPTION
While making screenshot scripts, Andrew and I noticed calling `setCameraTransform()` doesn't update the viewportGadget's camera.