### PR TITLE
Instancer reboot

### DIFF
--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -93,6 +93,12 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
+		void hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const override;
+
+		void hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const override;
+
 	private :
 
 		IE_CORE_FORWARDDECLARE( EngineData );

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -56,8 +56,11 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::StringPlug *namePlug();
 		const Gaffer::StringPlug *namePlug() const;
 
-		ScenePlug *instancePlug();
-		const ScenePlug *instancePlug() const;
+		ScenePlug *instancesPlug();
+		const ScenePlug *instancesPlug() const;
+
+		Gaffer::StringPlug *indexPlug();
+		const Gaffer::StringPlug *indexPlug() const;
 
 		Gaffer::StringPlug *positionPlug();
 		const Gaffer::StringPlug *positionPlug() const;
@@ -100,8 +103,14 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::ObjectPlug *enginePlug();
 		const Gaffer::ObjectPlug *enginePlug() const;
 
+		Gaffer::AtomicCompoundDataPlug *instanceChildNamesPlug();
+		const Gaffer::AtomicCompoundDataPlug *instanceChildNamesPlug() const;
+
 		ConstEngineDataPtr engine( const ScenePath &parentPath, const Gaffer::Context *context ) const;
 		void engineHash( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+
+		IECore::ConstCompoundDataPtr instanceChildNames( const ScenePath &parentPath, const Gaffer::Context *context ) const;
+		void instanceChildNamesHash( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 
 		static int instanceIndex( const ScenePath &branchPath );
 

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -59,9 +59,21 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		ScenePlug *instancePlug();
 		const ScenePlug *instancePlug() const;
 
+		Gaffer::StringPlug *positionPlug();
+		const Gaffer::StringPlug *positionPlug() const;
+
+		Gaffer::StringPlug *orientationPlug();
+		const Gaffer::StringPlug *orientationPlug() const;
+
+		Gaffer::StringPlug *scalePlug();
+		const Gaffer::StringPlug *scalePlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
+
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 		void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
@@ -83,7 +95,14 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		struct BoundHash;
 		struct BoundUnion;
 
-		IECore::ConstV3fVectorDataPtr sourcePoints( const ScenePath &parentPath ) const;
+		IE_CORE_FORWARDDECLARE( EngineData );
+
+		Gaffer::ObjectPlug *enginePlug();
+		const Gaffer::ObjectPlug *enginePlug() const;
+
+		ConstEngineDataPtr engine( const ScenePath &parentPath, const Gaffer::Context *context ) const;
+		void engineHash( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+
 		static int instanceIndex( const ScenePath &branchPath );
 
 		struct InstanceScope : public Gaffer::Context::EditableScope
@@ -93,8 +112,6 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 			void update( const ScenePath &branchPath );
 			void update( const ScenePath &branchPath, int instanceId );
 		};
-
-		Imath::M44f instanceTransform( const IECore::V3fVectorData *p, int instanceId ) const;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -95,9 +95,6 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 
 	private :
 
-		struct BoundHash;
-		struct BoundUnion;
-
 		IE_CORE_FORWARDDECLARE( EngineData );
 
 		Gaffer::ObjectPlug *enginePlug();
@@ -112,14 +109,12 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		IECore::ConstCompoundDataPtr instanceChildNames( const ScenePath &parentPath, const Gaffer::Context *context ) const;
 		void instanceChildNamesHash( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 
+		static int instanceIndex( const IECore::InternedString &name );
 		static int instanceIndex( const ScenePath &branchPath );
 
 		struct InstanceScope : public Gaffer::Context::EditableScope
 		{
-			InstanceScope( const Gaffer::Context *context );
 			InstanceScope( const Gaffer::Context *context, const ScenePath &branchPath );
-			void update( const ScenePath &branchPath );
-			void update( const ScenePath &branchPath, int instanceId );
 		};
 
 		static size_t g_firstPlugIndex;

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -74,6 +74,9 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::StringPlug *scalePlug();
 		const Gaffer::StringPlug *scalePlug() const;
 
+		Gaffer::StringPlug *attributesPlug();
+		const Gaffer::StringPlug *attributesPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -62,6 +62,9 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::StringPlug *indexPlug();
 		const Gaffer::StringPlug *indexPlug() const;
 
+		Gaffer::StringPlug *idPlug();
+		const Gaffer::StringPlug *idPlug() const;
+
 		Gaffer::StringPlug *positionPlug();
 		const Gaffer::StringPlug *positionPlug() const;
 
@@ -114,9 +117,6 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 
 		IECore::ConstCompoundDataPtr instanceChildNames( const ScenePath &parentPath, const Gaffer::Context *context ) const;
 		void instanceChildNamesHash( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-
-		static int instanceIndex( const IECore::InternedString &name );
-		static int instanceIndex( const ScenePath &branchPath );
 
 		struct InstanceScope : public Gaffer::Context::EditableScope
 		{

--- a/python/GafferSceneTest/FilterResultsTest.py
+++ b/python/GafferSceneTest/FilterResultsTest.py
@@ -133,11 +133,11 @@ class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
 
 		script["instancer"] = GafferScene.Instancer()
 		script["instancer"]["in"].setInput( script["plane"]["out"] )
-		script["instancer"]["instance"].setInput( script["sphere"]["out"] )
+		script["instancer"]["instances"].setInput( script["sphere"]["out"] )
 		script["instancer"]["parent"].setValue( "/plane" )
 
 		script["filter"] = GafferScene.PathFilter()
-		script["filter"]["paths"].setValue( IECore.StringVectorData( [ "/plane/instances/*/sphere" ] ) )
+		script["filter"]["paths"].setValue( IECore.StringVectorData( [ "/plane/instances/sphere/*" ] ) )
 
 		script["filterResults"] = GafferScene.FilterResults()
 		script["filterResults"]["scene"].setInput( script["instancer"]["out"] )
@@ -151,10 +151,10 @@ class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual(
 			script["filterResults"]["user"]["strings"].getValue(),
 			IECore.StringVectorData( [
-				"/plane/instances/0/sphere",
-				"/plane/instances/1/sphere",
-				"/plane/instances/2/sphere",
-				"/plane/instances/3/sphere",
+				"/plane/instances/sphere/0",
+				"/plane/instances/sphere/1",
+				"/plane/instances/sphere/2",
+				"/plane/instances/sphere/3",
 			] )
 		)
 

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -285,7 +285,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script["sphere"] = GafferScene.Sphere()
 
 		script["expression"] = Gaffer.Expression()
-		script["expression"].setExpression( "parent['sphere']['radius'] = context.getFrame() + float( context['instancer:id'] )" )
+		script["expression"].setExpression( "parent['sphere']['radius'] = context.getFrame()" )
 
 		script["instancer"] = GafferScene.Instancer()
 		script["instancer"]["in"].setInput( script["plane"]["out"] )
@@ -373,7 +373,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script["sphere"] = GafferScene.Sphere()
 
 		script["expression"] = Gaffer.Expression()
-		script["expression"].setExpression( "parent['sphere']['radius'] = context.getFrame() + float( context['instancer:id'] )" )
+		script["expression"].setExpression( "parent['sphere']['radius'] = context.getFrame()" )
 
 		script["instancer"] = GafferScene.Instancer()
 		script["instancer"]["in"].setInput( script["plane"]["out"] )
@@ -441,7 +441,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script["sphere"] = GafferScene.Sphere()
 
 		script["expression"] = Gaffer.Expression()
-		script["expression"].setExpression( "parent['sphere']['radius'] = 0.1 + context.getFrame() + float( context['instancer:id'] )" )
+		script["expression"].setExpression( "parent['sphere']['radius'] = 0.1 + context.getFrame()" )
 
 		script["instancer"] = GafferScene.Instancer()
 		script["instancer"]["in"].setInput( script["plane"]["out"] )
@@ -476,7 +476,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script["sphere"] = GafferScene.Sphere()
 
 		script["expression"] = Gaffer.Expression()
-		script["expression"].setExpression( "parent['sphere']['radius'] = context.get( 'minRadius', 0.1 ) + context.getFrame() + float( context['instancer:id'] )" )
+		script["expression"].setExpression( "parent['sphere']['radius'] = context.get( 'minRadius', 0.1 ) + context.getFrame()" )
 
 		script["instancer"] = GafferScene.Instancer()
 		script["instancer"]["in"].setInput( script["plane"]["out"] )
@@ -534,7 +534,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script["sphere"] = GafferScene.Sphere()
 
 		script["expression"] = Gaffer.Expression()
-		script["expression"].setExpression( "parent['sphere']['radius'] = context.get( 'minRadius', 0.1 ) + context.getFrame() + float( context['instancer:id'] )" )
+		script["expression"].setExpression( "parent['sphere']['radius'] = context.get( 'minRadius', 0.1 ) + context.getFrame()" )
 
 		script["instancer"] = GafferScene.Instancer()
 		script["instancer"]["in"].setInput( script["plane"]["out"] )

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -59,18 +59,18 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( plane2["out"] )
 		instancer["parent"].setValue( "/plane" )
-		instancer["instance"].setInput( group["out"] )
+		instancer["instances"].setInput( group["out"] )
 
 		filter = GafferScene.PathFilter()
-		filter["paths"].setValue( IECore.StringVectorData( [ "/plane/instances/*1/group/plane" ] ) )
+		filter["paths"].setValue( IECore.StringVectorData( [ "/plane/instances/group/*1/plane" ] ) )
 
 		matchingPaths = IECore.PathMatcher()
 		GafferScene.SceneAlgo.matchingPaths( filter, instancer["out"], matchingPaths )
 
 		self.assertEqual( len( matchingPaths.paths() ), 1000 )
-		self.assertEqual( matchingPaths.match( "/plane/instances/1/group/plane" ), IECore.PathMatcher.Result.ExactMatch )
-		self.assertEqual( matchingPaths.match( "/plane/instances/1121/group/plane" ), IECore.PathMatcher.Result.ExactMatch )
-		self.assertEqual( matchingPaths.match( "/plane/instances/1121/group/sphere" ), IECore.PathMatcher.Result.NoMatch )
+		self.assertEqual( matchingPaths.match( "/plane/instances/group/1/plane" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( matchingPaths.match( "/plane/instances/group/1121/plane" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( matchingPaths.match( "/plane/instances/group/1121/sphere" ), IECore.PathMatcher.Result.NoMatch )
 
 	def testExists( self ) :
 

--- a/python/GafferSceneTest/SceneFilterPathFilterTest.py
+++ b/python/GafferSceneTest/SceneFilterPathFilterTest.py
@@ -80,15 +80,15 @@ class SceneFilterPathFilterTest( GafferSceneTest.SceneTestCase ) :
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( plane["out"] )
 		instancer["parent"].setValue( "/plane" )
-		instancer["instance"].setInput( sphere["out"] )
+		instancer["instances"].setInput( sphere["out"] )
 
 		scenePathFilter = GafferScene.PathFilter()
-		scenePathFilter["paths"].setValue( IECore.StringVectorData( [ "/plane/instances/*" ] ) )
+		scenePathFilter["paths"].setValue( IECore.StringVectorData( [ "/plane/instances/sphere/*" ] ) )
 
 		path = GafferScene.ScenePath(
 			instancer["out"],
 			Gaffer.Context(),
-			"/plane/instances",
+			"/plane/instances/sphere",
 			GafferScene.SceneFilterPathFilter( scenePathFilter )
 		)
 

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -74,9 +74,10 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			The object on which to make the instances. This
-			must have a "P" primitive variable specifying the
-			location of each instance.
+			The object on which to make the instances. The
+			position, orientation and scale of the instances
+			are taken from per-vertex primitive variables on
+			this object.
 			"""
 
 		],
@@ -102,6 +103,39 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "",
+
+		],
+
+		"position" : [
+
+			"description",
+			"""
+			The name of the per-vertex primitive variable used
+			to specify the position of each instance.
+			""",
+
+		],
+
+		"orientation" : [
+
+			"description",
+			"""
+			The name of the per-vertex primitive variable used
+			to specify the orientation of each instance. The
+			orientation must be provided as a quaternion.
+			""",
+
+		],
+
+		"scale" : [
+
+			"description",
+			"""
+			The name of the per-vertex primitive variable used
+			to specify the scale of each instance. Scale can be
+			provided as a float for uniform scaling, or as a vector
+			to define different scaling in each axis.
+			""",
 
 		],
 

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -48,24 +48,11 @@ Gaffer.Metadata.registerNode(
 
 	"description",
 	"""
-	Instances an input scene onto the vertices of a target
-	object, making one copy per vertex. Note that in Gaffer,
-	the instances are not limited to being a single object,
-	and each instance need not be identical. Instances can
-	instead include entire hierarchies and can be varied
-	from point to point, and individual instances may be
-	modified downstream without affecting the others. Gaffer
-	ensure's that where instances happen to be identical,
-	they share memory, and performs automatic instancing at
-	the object level when exporting to the renderer (this
-	occurs for all nodes, not just the Instancer).
-
-	Per-instance variation can be achieved using the
-	${instancer:id} variable in the upstream instance graph.
-	A common use case is to use this to randomise the index
-	on a SceneSwitch node, to choose randomly between several
-	instances, but it can be used to drive _any_ property of
-	the upstream graph.
+	Copies from an input scene onto the vertices of a target
+	object, making one copy per vertex. Additional primitive
+	variables on the target object can be used to choose between
+	multiple instances, and to specify their orientation and
+	scale.
 	""",
 
 	plugs = {

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -160,6 +160,18 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"attributes" : [
+
+			"description",
+			"""
+			The names of per-vertex primitive variables to be
+			turned into per-instance attributes. Names should
+			be separated by spaces and can use Gaffer's
+			standard wildcards.
+			""",
+
+		],
+
 	}
 
 )

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -114,6 +114,19 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"id" : [
+
+			"description",
+			"""
+			The name of a per-vertex integer primitive variable
+			used to give each instance a unique identity. This
+			is useful when points are added and removed over time,
+			as is often the case in a particle simulation. The
+			id is used to name the instance in the output scene.
+			"""
+
+		],
+
 		"position" : [
 
 			"description",

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -93,16 +93,37 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"instance" : [
+		"instances" : [
 
 			"description",
 			"""
-			The scene to be instanced. Use the ${instancer:id}
-			variable in the upstream graph to create per-instance
-			variations.
+			The scene containing the instances to be applied to
+			each vertex. Specify multiple instances by parenting
+			them at the root of the scene :
+
+			- /instance0
+			- /instance1
+			- /instance2
+
+			Note that the instances are not limited to being a
+			single object : they can each have arbitrary child
+			hierarchies.
 			""",
 
 			"plugValueWidget:type", "",
+
+		],
+
+		"index" : [
+
+			"description",
+			"""
+			The name of a per-vertex integer primitive variable
+			used to determine which instance is applied to the
+			vertex. An index of 0 applies the first location from
+			the instances scene, an index of 1 applies the second
+			and so on.
+			"""
 
 		],
 

--- a/python/GafferSceneUITest/SceneGadgetTest.py
+++ b/python/GafferSceneUITest/SceneGadgetTest.py
@@ -294,7 +294,7 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( plane["out"] )
-		instancer["instance"].setInput( sphere["out"] )
+		instancer["instances"].setInput( sphere["out"] )
 		instancer["parent"].setValue( "/plane" )
 
 		subTree = GafferScene.SubTree()
@@ -316,31 +316,31 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 		self.assertObjectsAt(
 			sg,
 			imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ),
-			[ "/instances/{}/sphere".format( i ) for i in range( 0, 4 ) ]
+			[ "/instances/sphere/{}".format( i ) for i in range( 0, 4 ) ]
 		)
 
 		self.assertObjectsAt(
 			sg,
 			imath.Box2f( imath.V2f( 0 ), imath.V2f( 0.5 ) ),
-			[ "/instances/2/sphere" ]
+			[ "/instances/sphere/2" ]
 		)
 
 		self.assertObjectsAt(
 			sg,
 			imath.Box2f( imath.V2f( 0.5, 0 ), imath.V2f( 1, 0.5 ) ),
-			[ "/instances/3/sphere" ]
+			[ "/instances/sphere/3" ]
 		)
 
 		self.assertObjectsAt(
 			sg,
 			imath.Box2f( imath.V2f( 0, 0.5 ), imath.V2f( 0.5, 1 ) ),
-			[ "/instances/0/sphere" ]
+			[ "/instances/sphere/0" ]
 		)
 
 		self.assertObjectsAt(
 			sg,
 			imath.Box2f( imath.V2f( 0.5 ), imath.V2f( 1 ) ),
-			[ "/instances/1/sphere" ]
+			[ "/instances/sphere/1" ]
 		)
 
 	def testSetAndGetScene( self ) :

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -1006,9 +1006,13 @@ void Instancer::instanceChildNamesHash( const ScenePath &parentPath, const Gaffe
 Instancer::InstanceScope::InstanceScope( const Gaffer::Context *context, const ScenePath &branchPath )
 	:	EditableScope( context )
 {
-	assert( branchPath.size() >= 3 );
-	ScenePath instancePath; instancePath.reserve( branchPath.size() - 2 );
+	assert( branchPath.size() >= 2 );
+	ScenePath instancePath;
+	instancePath.reserve( 1 + ( branchPath.size() > 3 ? branchPath.size() - 3 : 0 ) );
 	instancePath.push_back( branchPath[1] );
-	instancePath.insert( instancePath.end(), branchPath.begin() + 3, branchPath.end() );
+	if( branchPath.size() > 3 )
+	{
+		instancePath.insert( instancePath.end(), branchPath.begin() + 3, branchPath.end() );
+	}
 	set( ScenePlug::scenePathContextName, instancePath );
 }

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -51,6 +51,8 @@
 #include "tbb/blocked_range.h"
 #include "tbb/parallel_reduce.h"
 
+#include <unordered_map>
+
 using namespace std;
 using namespace tbb;
 using namespace Imath;
@@ -74,11 +76,13 @@ class Instancer::EngineData : public Data
 		EngineData(
 			ConstObjectPtr object,
 			const std::string &index,
+			const std::string &id,
 			const std::string &position,
 			const std::string &orientation,
 			const std::string &scale
 		)
 			:	m_indices( nullptr ),
+				m_ids( nullptr ),
 				m_positions( nullptr ),
 				m_orientations( nullptr ),
 				m_scales( nullptr ),
@@ -93,16 +97,25 @@ class Instancer::EngineData : public Data
 			if( const IntVectorData *indices = m_primitive->variableData<IntVectorData>( index ) )
 			{
 				m_indices = &indices->readable();
-				if( m_indices->size() != numInstances() )
+				if( m_indices->size() != numPoints() )
 				{
 					throw IECore::Exception( "Index primitive variable has incorrect size" );
+				}
+			}
+
+			if( const IntVectorData *ids = m_primitive->variableData<IntVectorData>( id ) )
+			{
+				m_ids = &ids->readable();
+				if( m_ids->size() != numPoints() )
+				{
+					throw IECore::Exception( "Id primitive variable has incorrect size" );
 				}
 			}
 
 			if( const V3fVectorData *p = m_primitive->variableData<V3fVectorData>( position ) )
 			{
 				m_positions = &p->readable();
-				if( m_positions->size() != numInstances() )
+				if( m_positions->size() != numPoints() )
 				{
 					throw IECore::Exception( "Position primitive variable has incorrect size" );
 				}
@@ -111,7 +124,7 @@ class Instancer::EngineData : public Data
 			if( const QuatfVectorData *o = m_primitive->variableData<QuatfVectorData>( orientation ) )
 			{
 				m_orientations = &o->readable();
-				if( m_orientations->size() != numInstances() )
+				if( m_orientations->size() != numPoints() )
 				{
 					throw IECore::Exception( "Orientation primitive variable has incorrect size" );
 				}
@@ -120,7 +133,7 @@ class Instancer::EngineData : public Data
 			if( const V3fVectorData *s = m_primitive->variableData<V3fVectorData>( scale ) )
 			{
 				m_scales = &s->readable();
-				if( m_scales->size() != numInstances() )
+				if( m_scales->size() != numPoints() )
 				{
 					throw IECore::Exception( "Scale primitive variable has incorrect size" );
 				}
@@ -128,41 +141,71 @@ class Instancer::EngineData : public Data
 			else if( const FloatVectorData *s = m_primitive->variableData<FloatVectorData>( scale ) )
 			{
 				m_uniformScales = &s->readable();
-				if( m_uniformScales->size() != numInstances() )
+				if( m_uniformScales->size() != numPoints() )
 				{
 					throw IECore::Exception( "Scale primitive variable has incorrect size" );
 				}
 			}
+
+			if( m_ids )
+			{
+				for( size_t i = 0; i<numPoints(); ++i )
+				{
+					m_idsToPointIndices[(*m_ids)[i]] = i;
+				}
+			}
 		}
 
-		size_t numInstances() const
+		size_t numPoints() const
 		{
 			return m_primitive ? m_primitive->variableSize( PrimitiveVariable::Vertex ) : 0;
 		}
 
-		size_t instanceIndex( size_t instanceIndex ) const
+		size_t instanceId( size_t pointIndex ) const
 		{
-			return m_indices ? (*m_indices)[instanceIndex] : 0;
+			return m_ids ? (*m_ids)[pointIndex] : pointIndex;
 		}
 
-		M44f instanceTransform( size_t instanceIndex ) const
+		size_t pointIndex( const InternedString &name ) const
+		{
+			const size_t i = boost::lexical_cast<size_t>( name );
+			if( !m_ids )
+			{
+				return i;
+			}
+
+			IdsToPointIndices::const_iterator it = m_idsToPointIndices.find( i );
+			if( it == m_idsToPointIndices.end() )
+			{
+				throw IECore::Exception( "Invalid id" );
+			}
+
+			return it->second;
+		}
+
+		size_t instanceIndex( size_t pointIndex ) const
+		{
+			return m_indices ? (*m_indices)[pointIndex] : 0;
+		}
+
+		M44f instanceTransform( size_t pointIndex ) const
 		{
 			M44f result;
 			if( m_positions )
 			{
-				result.translate( (*m_positions)[instanceIndex] );
+				result.translate( (*m_positions)[pointIndex] );
 			}
 			if( m_orientations )
 			{
-				result = (*m_orientations)[instanceIndex].toMatrix44() * result;
+				result = (*m_orientations)[pointIndex].toMatrix44() * result;
 			}
 			if( m_scales )
 			{
-				result.scale( (*m_scales)[instanceIndex] );
+				result.scale( (*m_scales)[pointIndex] );
 			}
 			if( m_uniformScales )
 			{
-				result.scale( V3f( (*m_uniformScales)[instanceIndex] ) );
+				result.scale( V3f( (*m_uniformScales)[pointIndex] ) );
 			}
 			return result;
 		}
@@ -191,10 +234,14 @@ class Instancer::EngineData : public Data
 
 		IECoreScene::ConstPrimitivePtr m_primitive;
 		const std::vector<int> *m_indices;
+		const std::vector<int> *m_ids;
 		const std::vector<Imath::V3f> *m_positions;
 		const std::vector<Imath::Quatf> *m_orientations;
 		const std::vector<Imath::V3f> *m_scales;
 		const std::vector<float> *m_uniformScales;
+
+		typedef std::unordered_map <int, size_t> IdsToPointIndices;
+		IdsToPointIndices m_idsToPointIndices;
 
 };
 
@@ -215,6 +262,7 @@ Instancer::Instancer( const std::string &name )
 	addChild( new StringPlug( "name", Plug::In, "instances" ) );
 	addChild( new ScenePlug( "instances" ) );
 	addChild( new StringPlug( "index", Plug::In, "instanceIndex" ) );
+	addChild( new StringPlug( "id", Plug::In, "instanceId" ) );
 	addChild( new StringPlug( "position", Plug::In, "P" ) );
 	addChild( new StringPlug( "orientation", Plug::In ) );
 	addChild( new StringPlug( "scale", Plug::In ) );
@@ -256,54 +304,64 @@ const Gaffer::StringPlug *Instancer::indexPlug() const
 	return getChild<StringPlug>( g_firstPlugIndex + 2 );
 }
 
-Gaffer::StringPlug *Instancer::positionPlug()
+Gaffer::StringPlug *Instancer::idPlug()
 {
 	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::StringPlug *Instancer::idPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+}
+
+Gaffer::StringPlug *Instancer::positionPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 4 );
 }
 
 const Gaffer::StringPlug *Instancer::positionPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+	return getChild<StringPlug>( g_firstPlugIndex + 4 );
 }
 
 Gaffer::StringPlug *Instancer::orientationPlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+	return getChild<StringPlug>( g_firstPlugIndex + 5 );
 }
 
 const Gaffer::StringPlug *Instancer::orientationPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+	return getChild<StringPlug>( g_firstPlugIndex + 5 );
 }
 
 Gaffer::StringPlug *Instancer::scalePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 5 );
+	return getChild<StringPlug>( g_firstPlugIndex + 6 );
 }
 
 const Gaffer::StringPlug *Instancer::scalePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 5 );
+	return getChild<StringPlug>( g_firstPlugIndex + 6 );
 }
 
 Gaffer::ObjectPlug *Instancer::enginePlug()
 {
-	return getChild<ObjectPlug>( g_firstPlugIndex + 6 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 7 );
 }
 
 const Gaffer::ObjectPlug *Instancer::enginePlug() const
 {
-	return getChild<ObjectPlug>( g_firstPlugIndex + 6 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 7 );
 }
 
 Gaffer::AtomicCompoundDataPlug *Instancer::instanceChildNamesPlug()
 {
-	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 7 );
+	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 8 );
 }
 
 const Gaffer::AtomicCompoundDataPlug *Instancer::instanceChildNamesPlug() const
 {
-	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 7 );
+	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 8 );
 }
 
 void Instancer::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
@@ -312,6 +370,8 @@ void Instancer::affects( const Plug *input, AffectedPlugsContainer &outputs ) co
 
 	if(
 		input == inPlug()->objectPlug() ||
+		input == indexPlug() ||
+		input == idPlug() ||
 		input == positionPlug() ||
 		input == orientationPlug() ||
 		input == scalePlug()
@@ -374,6 +434,8 @@ void Instancer::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 	if( output == enginePlug() )
 	{
 		inPlug()->objectPlug()->hash( h );
+		indexPlug()->hash( h );
+		idPlug()->hash( h );
 		positionPlug()->hash( h );
 		orientationPlug()->hash( h );
 		scalePlug()->hash( h );
@@ -396,6 +458,7 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 			new EngineData(
 				inPlug()->objectPlug()->getValue(),
 				indexPlug()->getValue(),
+				idPlug()->getValue(),
 				positionPlug()->getValue(),
 				orientationPlug()->getValue(),
 				scalePlug()->getValue()
@@ -423,10 +486,10 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 			indexedInstanceChildNames.push_back( &instanceChildNames->writable() );
 		}
 
-		for( size_t i = 0, e = engine->numInstances(); i < e; ++i )
+		for( size_t i = 0, e = engine->numPoints(); i < e; ++i )
 		{
-			size_t index = engine->instanceIndex( i ) % indexedInstanceChildNames.size();
-			indexedInstanceChildNames[index]->push_back( InternedString( i ) );
+			size_t instanceIndex = engine->instanceIndex( i ) % indexedInstanceChildNames.size();
+			indexedInstanceChildNames[instanceIndex]->push_back( InternedString( engine->instanceId( i ) ) );
 		}
 
 		static_cast<AtomicCompoundDataPlug *>( output )->setValue( result );
@@ -515,8 +578,8 @@ Imath::Box3f Instancer::computeBranchBound( const ScenePath &parentPath, const S
 			[ &e, &childBound, &childTransform ] ( const Range &r, Box3f u ) {
 				for( Iterator i = r.begin(); i != r.end(); ++i )
 				{
-					const size_t index = instanceIndex( *i );
-					const M44f m = childTransform * e->instanceTransform( index );
+					const size_t pointIndex = e->pointIndex( *i );
+					const M44f m = childTransform * e->instanceTransform( pointIndex );
 					const Box3f b = transform( childBound, m );
 					u.extendBy( b );
 				}
@@ -557,7 +620,7 @@ void Instancer::hashBranchTransform( const ScenePath &parentPath, const ScenePat
 			instancesPlug()->transformPlug()->hash( h );
 		}
 		engineHash( parentPath, context, h );
-		h.append( instanceIndex( branchPath ) );
+		h.append( branchPath[2] );
 	}
 	else
 	{
@@ -583,8 +646,8 @@ Imath::M44f Instancer::computeBranchTransform( const ScenePath &parentPath, cons
 			result = instancesPlug()->transformPlug()->getValue();
 		}
 		ConstEngineDataPtr e = engine( parentPath, context );
-		const int index = instanceIndex( branchPath );
-		result = result * e->instanceTransform( index );
+		const size_t pointIndex = e->pointIndex( branchPath[2] );
+		result = result * e->instanceTransform( pointIndex );
 		return result;
 	}
 	else
@@ -791,16 +854,6 @@ void Instancer::instanceChildNamesHash( const ScenePath &parentPath, const Gaffe
 {
 	ScenePlug::PathScope scope( context, parentPath );
 	instanceChildNamesPlug()->hash( h );
-}
-
-int Instancer::instanceIndex( const IECore::InternedString &name )
-{
-	return boost::lexical_cast<int>( name );
-}
-
-int Instancer::instanceIndex( const ScenePath &branchPath )
-{
-	return instanceIndex( branchPath[2] );
 }
 
 Instancer::InstanceScope::InstanceScope( const Gaffer::Context *context, const ScenePath &branchPath )


### PR DESCRIPTION
Gaffer has had an Instancer node for almost as long as it has had scene processing, but it has never got beyond the proof-of-concept stage. In practice, Image Engine has instead relied on several proprietary instancer nodes for production use. This PR reworks Gaffer's native instancer node with the intention of making it viable for serious use. The main changes are :

- Removal of per-instance context entries. Although these were powerful, in practice they caused performance issues for huge scenes. They also provide a trap by allowing the creation of "instances" which are actually each unique, by making per-instance primitive variables for example.
- Support for specifying orientation and scale using per-vertex primvars on the target object. I've aimed to match the USD spec here, so there is only a single way of specifying orientation : a quaternion.
- Support for converting per-vertex primvars into attributes on the instances. This is a convenient way of driving shading variation.
- Support for id and index primitive variables.
- Support for sets.

I think this should cover most of the requirements for a canonical instancer. I'm still on the fence as to whether we should add additional features to the Instancer itself or provide them via accessory nodes. For example, orientation is not always conveniently specified as a quaternion - often you have an aim vector instead. We could either add additional options to the Instancer or we could add an Orientations node which provides various ways of generating the required quaternions. I'd like to get this minimal version merged first and then consider how to provide the rest. The changes here break compatibility and would benefit from inclusion in the next major release, but future enhancement should be backwards compatible and can come when they're needed/ready. Likewise, I think there are further opportunities for optimising performance, but those can also come later since they'll be backwards compatible.

I've tried to keep each commit logical and self-contained, but in practice so much has changed that it might be easier just to review the changes as a whole.