### PR TITLE
Known Window position fixes

### DIFF
--- a/python/GafferUI/ApplicationMenu.py
+++ b/python/GafferUI/ApplicationMenu.py
@@ -123,6 +123,12 @@ def preferences( menu ) :
 
 		__preferencesWindows[application] = weakref.ref( window )
 
+		# The NodeUI builds lazily, so we force it to build now so we can
+		# resize the window to fit. Since the plugs are configured per
+		# application, we need to build them all.
+		for plug in application["preferences"].children( Gaffer.Plug ) :
+			window._getWidget().plugValueWidget( plug, lazy=False )
+		window.resizeToFitChild()
 		scriptWindow.addChildWindow( window )
 
 	window.setVisible( True )

--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -361,6 +361,10 @@ def showSettings( menu ) :
 		settingsWindow = GafferUI.Window( "Settings", borderWidth=8 )
 		settingsWindow._settingsEditor = True
 		settingsWindow.setChild( GafferUI.NodeUI.create( scriptWindow.scriptNode() ) )
+		# The NodeUI builds lazily, so we force it to build now so we can
+		# resize the window to fit.
+		settingsWindow.getChild().plugValueWidget( scriptWindow.scriptNode()["fileName"], lazy=False )
+		settingsWindow.resizeToFitChild()
 		scriptWindow.addChildWindow( settingsWindow )
 
 	settingsWindow.setVisible( True )

--- a/python/GafferUI/NodeSetEditor.py
+++ b/python/GafferUI/NodeSetEditor.py
@@ -140,12 +140,12 @@ class NodeSetEditor( GafferUI.Editor ) :
 			scriptWindow.getLayout().addEditor( editor )
 		else :
 			window = _EditorWindow( scriptWindow, editor )
-			window.setVisible( True )
 			## \todo Can we do better using `window.resizeToFitChild()`?
 			# Our problem is that some NodeEditors (for GafferImage.Text for instance)
 			# are very large, whereas some (GafferScene.Shader) don't have
 			# a valid size until the UI has been built lazily.
 			window._qtWidget().resize( 400, 400 )
+			window.setVisible( True )
 
 		return editor
 


### PR DESCRIPTION
This fixes the initial window positions for popup _Node Editors_, the script _Settings_ window, and the application _Preferences_ window. This covers all the current production complaints about window positions.

I've tested with Qt5 on CentOS 7 with Mate. Only the last commit is untested on OSX. Since we haven't been able to find a more general solution that works on both window managers after quite a bit of back and forth, I propose we merge this somewhat unsatisfactory fix and close #2627 for now.