### PR TITLE
GafferOSL : expand indexed primitive variables before shading.

### DIFF
--- a/include/GafferOSL/ShadingEngine.h
+++ b/include/GafferOSL/ShadingEngine.h
@@ -84,7 +84,7 @@ class GAFFEROSL_API ShadingEngine : public IECore::RefCounted
 		void hash( IECore::MurmurHash &h ) const;
 		IECore::CompoundDataPtr shade( const IECore::CompoundData *points, const Transforms &transforms = Transforms() ) const;
 
-		bool needsAttribute( const std::string &scope, const std::string &name ) const;
+		bool needsAttribute( const std::string &name ) const;
 
 	private :
 
@@ -95,7 +95,7 @@ class GAFFEROSL_API ShadingEngine : public IECore::RefCounted
 		bool m_timeNeeded;
 		std::vector<IECore::InternedString> m_contextVariablesNeeded;
 
-		typedef boost::container::flat_set<std::pair<std::string, std::string> > AttributesNeededContainer;
+		typedef boost::container::flat_set<std::string> AttributesNeededContainer;
 		AttributesNeededContainer m_attributesNeeded;
 
 		// Set to true if the shader reads attributes who's name is not know at compile time

--- a/python/GafferOSLTest/ShadingEngineTest.py
+++ b/python/GafferOSLTest/ShadingEngineTest.py
@@ -131,8 +131,8 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 			IECoreScene.Shader( shader, "osl:surface", { "name" : "doubleUserData" } ),
 		] ) )
 
-		self.assertEqual( e.needsAttribute( "", "floatUserData" ), False )
-		self.assertEqual( e.needsAttribute( "", "doubleUserData" ), True )
+		self.assertEqual( e.needsAttribute( "floatUserData" ), False )
+		self.assertEqual( e.needsAttribute( "doubleUserData" ), True )
 
 		p = e.shade( rp )
 
@@ -149,10 +149,10 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 			IECoreScene.Shader( shader, "osl:surface", { "name" : "floatUserData" } ),
 		] ) )
 
-		self.assertEqual( e.needsAttribute( "", "floatUserData" ), True )
-		self.assertEqual( e.needsAttribute( "", "doubleUserData" ), False )
-		self.assertEqual( e.needsAttribute( "", "colorUserData" ), False )
-		self.assertEqual( e.needsAttribute( "", "shading:index" ), False )
+		self.assertEqual( e.needsAttribute( "floatUserData" ), True )
+		self.assertEqual( e.needsAttribute( "doubleUserData" ), False )
+		self.assertEqual( e.needsAttribute( "colorUserData" ), False )
+		self.assertEqual( e.needsAttribute( "shading:index" ), False )
 
 		p = e.shade( rp )
 
@@ -160,10 +160,10 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 			IECoreScene.Shader( shader, "osl:surface", { "name" : "doubleUserData" } ),
 		] ) )
 
-		self.assertEqual( e.needsAttribute( "", "floatUserData" ), False )
-		self.assertEqual( e.needsAttribute( "", "doubleUserData" ), True )
-		self.assertEqual( e.needsAttribute( "", "colorUserData" ), False )
-		self.assertEqual( e.needsAttribute( "", "shading:index" ), False )
+		self.assertEqual( e.needsAttribute( "floatUserData" ), False )
+		self.assertEqual( e.needsAttribute( "doubleUserData" ), True )
+		self.assertEqual( e.needsAttribute( "colorUserData" ), False )
+		self.assertEqual( e.needsAttribute( "shading:index" ), False )
 
 		p = e.shade( rp )
 
@@ -174,10 +174,10 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 			IECoreScene.Shader( shader, "osl:surface", { "name" : "colorUserData" } ),
 		] ) )
 
-		self.assertEqual( e.needsAttribute( "", "floatUserData" ), False )
-		self.assertEqual( e.needsAttribute( "", "doubleUserData" ), False )
-		self.assertEqual( e.needsAttribute( "", "colorUserData" ), True )
-		self.assertEqual( e.needsAttribute( "", "shading:index" ), False )
+		self.assertEqual( e.needsAttribute( "floatUserData" ), False )
+		self.assertEqual( e.needsAttribute( "doubleUserData" ), False )
+		self.assertEqual( e.needsAttribute( "colorUserData" ), True )
+		self.assertEqual( e.needsAttribute( "shading:index" ), False )
 
 		p = e.shade( rp )
 
@@ -189,10 +189,10 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 			IECoreScene.Shader( shader, "osl:surface", { "name" : "shading:index" } ),
 		] ) )
 
-		self.assertEqual( e.needsAttribute( "", "floatUserData" ), False )
-		self.assertEqual( e.needsAttribute( "", "doubleUserData" ), False )
-		self.assertEqual( e.needsAttribute( "", "colorUserData" ), False )
-		self.assertEqual( e.needsAttribute( "", "shading:index" ), True )
+		self.assertEqual( e.needsAttribute( "floatUserData" ), False )
+		self.assertEqual( e.needsAttribute( "doubleUserData" ), False )
+		self.assertEqual( e.needsAttribute( "colorUserData" ), False )
+		self.assertEqual( e.needsAttribute( "shading:index" ), True )
 
 		p = e.shade( rp )
 
@@ -207,8 +207,8 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 			IECoreScene.Shader( shader, "osl:surface" )
 		] ) )
 
-		self.assertEqual( e.needsAttribute( "", "foo" ), True )
-		self.assertEqual( e.needsAttribute( "", "bar" ), True )
+		self.assertEqual( e.needsAttribute( "foo" ), True )
+		self.assertEqual( e.needsAttribute( "bar" ), True )
 
 	def testStructs( self ) :
 
@@ -678,6 +678,44 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		assertCanReadVariable( e, "myVariable", imath.Color3f( 0, 0.5, 1 ) )
 		assertCanReadVariable( e, "myVariable", imath.Color3f( 1, 0.5, 0 ) )
+
+	def testGlobalAsNeededAttribute( self ) :
+
+		s = self.compileShader( os.path.dirname( __file__ ) + "/shaders/red.osl" )
+
+		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
+			IECoreScene.Shader( s, "osl:surface", { } ),
+		] ) )
+
+		self.assertTrue( e.needsAttribute( "P" ) )
+		self.assertFalse( e.needsAttribute( "N" ) )
+		self.assertFalse( e.needsAttribute( "u" ) )
+		self.assertFalse( e.needsAttribute( "v" ) )
+		self.assertFalse( e.needsAttribute( "time" ) )
+
+		s = self.compileShader( os.path.dirname( __file__ ) + "/shaders/globals.osl" )
+
+		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
+			IECoreScene.Shader( s, "osl:surface", { "global" : "P" } ),
+		] ) )
+
+		self.assertTrue( e.needsAttribute( "P" ) )
+		self.assertFalse( e.needsAttribute( "N" ) )
+		self.assertFalse( e.needsAttribute( "uv" ) )
+		self.assertFalse( e.needsAttribute( "u" ) )
+		self.assertFalse( e.needsAttribute( "v" ) )
+		self.assertFalse( e.needsAttribute( "time" ) )
+
+		e = GafferOSL.ShadingEngine( IECore.ObjectVector( [
+			IECoreScene.Shader( s, "osl:surface", { "global" : "u" } ),
+		] ) )
+
+		self.assertTrue( e.needsAttribute( "P" ) )
+		self.assertFalse( e.needsAttribute( "N" ) )
+		self.assertTrue( e.needsAttribute( "uv" ) )
+		self.assertTrue( e.needsAttribute( "u" ) )
+		self.assertFalse( e.needsAttribute( "v" ) )
+		self.assertFalse( e.needsAttribute( "time" ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferOSL/OSLImage.cpp
+++ b/src/GafferOSL/OSLImage.cpp
@@ -257,7 +257,7 @@ void OSLImage::hashShading( const Gaffer::Context *context, IECore::MurmurHash &
 		ImagePlug::ChannelDataScope c( context );
 		for( const auto &channelName : channelNamesData->readable() )
 		{
-			if( shadingEngine->needsAttribute( "", channelName ) )
+			if( shadingEngine->needsAttribute( channelName ) )
 			{
 				c.setChannelName( channelName );
 				inPlug()->channelDataPlug()->hash( h );
@@ -327,7 +327,7 @@ IECore::ConstCompoundDataPtr OSLImage::computeShading( const Gaffer::Context *co
 		ImagePlug::ChannelDataScope c( context );
 		for( const auto &channelName : channelNamesData->readable() )
 		{
-			if( shadingEngine->needsAttribute( "", channelName ) )
+			if( shadingEngine->needsAttribute( channelName ) )
 			{
 				c.setChannelName( channelName );
 				shadingPoints->writable()[channelName] = boost::const_pointer_cast<FloatVectorData>(

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -1071,6 +1071,8 @@ void ShadingEngine::queryContextVariablesAndAttributesNeeded()
 			{
 				m_timeNeeded = true;
 			}
+
+			m_attributesNeeded.insert( globalsNames[i].string() );
 		}
 	}
 
@@ -1097,7 +1099,7 @@ void ShadingEngine::queryContextVariablesAndAttributesNeeded()
 			}
 			else
 			{
-				m_attributesNeeded.insert( std::make_pair( scopeNames[i].string(), attributeNames[i].string() ) );
+				m_attributesNeeded.insert( attributeNames[i].string()  );
 			}
 		}
 	}
@@ -1290,12 +1292,26 @@ IECore::CompoundDataPtr ShadingEngine::shade( const IECore::CompoundData *points
 	return results.results();
 }
 
-bool ShadingEngine::needsAttribute( const std::string &scope, const std::string &name ) const
+bool ShadingEngine::needsAttribute( const std::string &name ) const
 {
+	if( name == "P" )
+	{
+		return true;
+	}
+
+	if( name == "uv" )
+	{
+		if ( m_attributesNeeded.find( "u" ) != m_attributesNeeded.end() || m_attributesNeeded.find( "v" ) != m_attributesNeeded.end() )
+		{
+			return true;
+		}
+	}
+
 	if( m_unknownAttributesNeeded )
 	{
 		return true;
 	}
 
-	return m_attributesNeeded.find( std::make_pair( scope, name ) ) != m_attributesNeeded.end();
+
+	return m_attributesNeeded.find(  name  ) != m_attributesNeeded.end();
 }


### PR DESCRIPTION
Bit of a bodge to fix a crash bug when processing indexed primvars in OSLObject. 



