### PR TITLE
Fix format compatibility

### DIFF
--- a/startup/GafferImage/formatCompatibility.py
+++ b/startup/GafferImage/formatCompatibility.py
@@ -47,14 +47,23 @@ def __convertFormat( graphComponent, format ):
 	if scriptNode is None or not scriptNode.isExecuting() :
 		return format
 
-	gafferVersion = (
-		Gaffer.Metadata.nodeValue( scriptNode, "serialiser:milestoneVersion" ),
-		Gaffer.Metadata.nodeValue( scriptNode, "serialiser:majorVersion" ),
-		Gaffer.Metadata.nodeValue( scriptNode, "serialiser:minorVersion" ),
-		Gaffer.Metadata.nodeValue( scriptNode, "serialiser:patchVersion" )
-	)
+	parentNode = graphComponent.ancestor( Gaffer.Node )
+	while parentNode :
+		gafferVersion = (
+			Gaffer.Metadata.nodeValue( parentNode, "serialiser:milestoneVersion" ),
+			Gaffer.Metadata.nodeValue( parentNode, "serialiser:majorVersion" ),
+			Gaffer.Metadata.nodeValue( parentNode, "serialiser:minorVersion" ),
+			Gaffer.Metadata.nodeValue( parentNode, "serialiser:patchVersion" )
+		)
 
-	if gafferVersion < ( 0, 17, 0, 0 ) :
+		# only use the information if we have valid information from the node
+		if not filter( lambda x : x is None, gafferVersion ) :
+			break
+
+		gafferVersion = None
+		parentNode = parentNode.ancestor( Gaffer.Node )
+
+	if gafferVersion is not None and gafferVersion < ( 0, 17, 0, 0 ) :
 		displayWindow = format.getDisplayWindow()
 		displayWindow.setMax( displayWindow.max() + imath.V2i( 1 ) )
 		return GafferImage.Format( displayWindow, format.getPixelAspect() )

--- a/startup/GafferImage/formatCompatibility.py
+++ b/startup/GafferImage/formatCompatibility.py
@@ -72,7 +72,7 @@ def __formatPlugSetValue( self, *args, **kwargs ) :
 # the same file twice if the same path has been included twice. That would cause
 # havoc for us, because injecting the methods twice means infinite recursion when
 # calling the "original" methods.
-if not hasattr( GafferImage.Format, "__originalRegisterFormat" ) :
+if not hasattr( GafferImage.FormatPlug, "__originalSetValue" ) :
 
 	GafferImage.AtomicFormatPlug.__originalSetValue = GafferImage.AtomicFormatPlug.setValue
 	GafferImage.AtomicFormatPlug.setValue = __formatPlugSetValue


### PR DESCRIPTION
Hi @johnhaddon ,

This is actually fixing a problem that has existed likely since the compatibility script was first introduced.
However, it was noticed because of how we used to serialise format plugs by setting the values both at the top plug as well as the children plugs (min/max).

I'm actually more inclined to remove the script completely, since it deals with a very old gaffer version (0.17). What do you think about that?

If you want to keep the config, my PR is one of doing it.

