### PR TITLE
 ArnoldAttributes : Clarify usage of subdividePolygons attribute 

### DIFF
--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -375,16 +375,6 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"attributes.subdivType.value" : [
-
-			"preset:None", "none",
-			"preset:Linear", "linear",
-			"preset:Catclark", "catclark",
-
-			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
-
-		],
-
 		"attributes.subdivIterations" : [
 
 			"description",

--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -90,8 +90,6 @@ def __shadingSummary( plug ) :
 def __subdivisionSummary( plug ) :
 
 	info = []
-	if plug["subdividePolygons"]["enabled"].getValue() :
-		info.append( "Subdivide Polygons " + ( "On" if plug["subdividePolygons"]["value"].getValue() else "Off" ) )
 	if plug["subdivIterations"]["enabled"].getValue() :
 		info.append( "Iterations %d" % plug["subdivIterations"]["value"].getValue() )
 	if plug["subdivAdaptiveError"]["enabled"].getValue() :
@@ -111,6 +109,8 @@ def __subdivisionSummary( plug ) :
 		)
 	if plug["subdivSmoothDerivs"]["enabled"].getValue() :
 		info.append( "Smooth Derivs " + ( "On" if plug["subdivSmoothDerivs"]["value"].getValue() else "Off" ) )
+	if plug["subdividePolygons"]["enabled"].getValue() :
+		info.append( "Subdivide Polygons " + ( "On" if plug["subdividePolygons"]["value"].getValue() else "Off" ) )
 
 	return ", ".join( info )
 
@@ -359,22 +359,6 @@ Gaffer.Metadata.registerNode(
 
 		# Subdivision
 
-		"attributes.subdividePolygons" : [
-
-			"description",
-			"""
-			Causes polygon meshes to be rendered with Arnold's
-			subdiv_type parameter set to "linear" rather than
-			"none". This can be used to increase detail when
-			using polygons with displacement shaders and/or mesh
-			lights.
-			""",
-
-			"layout:section", "Subdivision",
-			"label", "Subdivide Polygons",
-
-		],
-
 		"attributes.subdivIterations" : [
 
 			"description",
@@ -518,6 +502,27 @@ Gaffer.Metadata.registerNode(
 			from anisotropic specular and other shading effects
 			that use the derivatives.
 			""",
+
+		],
+
+		"attributes.subdividePolygons" : [
+
+			"description",
+			"""
+			Causes polygon meshes to be rendered with Arnold's
+			subdiv_type parameter set to "linear" rather than
+			"none". This can be used to increase detail when
+			using polygons with displacement shaders and/or mesh
+			lights.
+
+			> Caution : This is not equivalent to converting a polygon
+			> mesh into a subdivision surface. To render with Arnold's
+			> subdiv_type set to "catclark", you must use the MeshType
+			> node to convert polygon meshes into subdivision surfaces.
+			""",
+
+			"layout:section", "Subdivision",
+			"label", "Subdivide Polygons (Linear)",
 
 		],
 

--- a/src/GafferArnold/ArnoldAttributes.cpp
+++ b/src/GafferArnold/ArnoldAttributes.cpp
@@ -74,13 +74,13 @@ ArnoldAttributes::ArnoldAttributes( const std::string &name )
 
 	// Subdivision parameters
 
-	attributes->addOptionalMember( "ai:polymesh:subdivide_polygons", new BoolPlug( "value" ), "subdividePolygons", false );
 	attributes->addOptionalMember( "ai:polymesh:subdiv_iterations", new IntPlug( "value", Plug::In, 1, 1 ), "subdivIterations", false );
 	attributes->addOptionalMember( "ai:polymesh:subdiv_adaptive_error", new FloatPlug( "value", Plug::In, 0.0f, 0.0f ), "subdivAdaptiveError", false );
 	attributes->addOptionalMember( "ai:polymesh:subdiv_adaptive_metric", new StringPlug( "value", Plug::In, "auto" ), "subdivAdaptiveMetric", false );
 	attributes->addOptionalMember( "ai:polymesh:subdiv_adaptive_space", new StringPlug( "value", Plug::In, "raster" ), "subdivAdaptiveSpace", false );
 	attributes->addOptionalMember( "ai:polymesh:subdiv_uv_smoothing", new StringPlug( "value", Plug::In, "pin_corners" ), "subdivUVSmoothing", false );
 	attributes->addOptionalMember( "ai:polymesh:subdiv_smooth_derivs", new BoolPlug( "value" ), "subdivSmoothDerivs", false );
+	attributes->addOptionalMember( "ai:polymesh:subdivide_polygons", new BoolPlug( "value" ), "subdividePolygons", false );
 
 	// Curves parameters
 


### PR DESCRIPTION
- Move to the bottom of the section, since it's one of the more esoteric options.
- Caution that the MeshType node is the only way to convert polygons to true subdivision surfaces.