### PR TITLE
Tests : Don't use legacy shader names

### DIFF
--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -495,13 +495,13 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		utility = GafferArnold.ArnoldShader()
 		utility.loadShader( "utility" )
 
-		splitColor = GafferOSL.OSLShader()
-		splitColor.loadShader( "Utility/SplitColor" )
-		splitColor["parameters"]["c"].setInput( utility["out"] )
+		colorToFloat = GafferOSL.OSLShader()
+		colorToFloat.loadShader( "Conversion/ColorToFloat" )
+		colorToFloat["parameters"]["c"].setInput( utility["out"] )
 
 		colorSpline = GafferOSL.OSLShader()
 		colorSpline.loadShader( "Pattern/ColorSpline" )
-		colorSpline["parameters"]["x"].setInput( splitColor["out"]["r"] )
+		colorSpline["parameters"]["x"].setInput( colorToFloat["out"]["r"] )
 
 		flat = GafferArnold.ArnoldShader()
 		flat.loadShader( "flat" )
@@ -756,7 +756,7 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		arnoldOut.loadShader( "flat" )
 
 		oslOut = GafferOSL.OSLShader()
-		oslOut.loadShader( "Utility/SplitColor" )
+		oslOut.loadShader( "Conversion/ColorToFloat" )
 
 		arnoldOut["parameters"]["color"].setInput( switch1["out"] )
 		oslOut["parameters"]["c"].setInput( switch2["out"] )
@@ -773,7 +773,7 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( len( network2 ), 2 )
 
 			self.assertEqual( network1[1].name, "flat" )
-			self.assertEqual( network2[1].name, "Utility/SplitColor" )
+			self.assertEqual( network2[1].name, "Conversion/ColorToFloat" )
 
 			if i == 0 :
 

--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -1415,20 +1415,20 @@ class RendererTest( GafferTest.TestCase ) :
 
 		network = IECore.ObjectVector( [
 			IECoreScene.Shader(
-				"Utility/SplitColor",
+				"Conversion/ColorToFloat",
 				"osl:shader",
 				{
 					"c" : imath.Color3f( 0.1, 0.2, 0.3 ),
-					"__handle" : "splitHandle"
+					"__handle" : "colorToFloatHandle"
 				}
 			),
 			IECoreScene.Shader(
-				"Utility/BuildColor",
+				"Conversion/FloatToColor",
 				"osl:shader",
 				{
-					"r" : "link:splitHandle.r",
-					"g" : "link:splitHandle.g",
-					"b" : "link:splitHandle.b",
+					"r" : "link:colorToFloatHandle.r",
+					"g" : "link:colorToFloatHandle.g",
+					"b" : "link:colorToFloatHandle.b",
 				}
 			)
 		] )
@@ -1447,28 +1447,27 @@ class RendererTest( GafferTest.TestCase ) :
 
 			n = arnold.AiNodeLookUpByName( "testPlane" )
 
-			build = arnold.AtNode.from_address( arnold.AiNodeGetPtr( n, "shader" ) )
-			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( build ) ), "osl" )
-			self.assertEqual( arnold.AiNodeGetStr( build, "shadername" ), "Utility/BuildColor" )
+			floatToColor = arnold.AtNode.from_address( arnold.AiNodeGetPtr( n, "shader" ) )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( floatToColor ) ), "osl" )
+			self.assertEqual( arnold.AiNodeGetStr( floatToColor, "shadername" ), "Conversion/FloatToColor" )
 
-			splitR = arnold.AiNodeGetLink( build, "param_r" )
-			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( splitR ) ), "osl" )
-			self.assertEqual( arnold.AiNodeGetStr( splitR, "output" ), "r" )
-			self.assertEqual( arnold.AiNodeGetStr( splitR, "shadername" ), "Utility/SplitColor" )
-			self.assertEqual( arnold.AiNodeGetRGB( splitR, "param_c" ),  arnold.AtRGB( 0.1, 0.2, 0.3 ))
+			colorToFloatR = arnold.AiNodeGetLink( floatToColor, "param_r" )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( colorToFloatR ) ), "osl" )
+			self.assertEqual( arnold.AiNodeGetStr( colorToFloatR, "output" ), "r" )
+			self.assertEqual( arnold.AiNodeGetStr( colorToFloatR, "shadername" ), "Conversion/ColorToFloat" )
+			self.assertEqual( arnold.AiNodeGetRGB( colorToFloatR, "param_c" ),  arnold.AtRGB( 0.1, 0.2, 0.3 ))
 
-			splitG = arnold.AiNodeGetLink( build, "param_g" )
-			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( splitG ) ), "osl" )
-			self.assertEqual( arnold.AiNodeGetStr( splitG, "output" ), "g" )
-			self.assertEqual( arnold.AiNodeGetStr( splitG, "shadername" ), "Utility/SplitColor" )
-			self.assertEqual( arnold.AiNodeGetRGB( splitG, "param_c" ),  arnold.AtRGB( 0.1, 0.2, 0.3 ))
+			colorToFloatG = arnold.AiNodeGetLink( floatToColor, "param_g" )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( colorToFloatG ) ), "osl" )
+			self.assertEqual( arnold.AiNodeGetStr( colorToFloatG, "output" ), "g" )
+			self.assertEqual( arnold.AiNodeGetStr( colorToFloatG, "shadername" ), "Conversion/ColorToFloat" )
+			self.assertEqual( arnold.AiNodeGetRGB( colorToFloatG, "param_c" ),  arnold.AtRGB( 0.1, 0.2, 0.3 ))
 
-			splitB = arnold.AiNodeGetLink( build, "param_b" )
-			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( splitB ) ), "osl" )
-			self.assertEqual( arnold.AiNodeGetStr( splitB, "output" ), "b" )
-			self.assertEqual( arnold.AiNodeGetStr( splitB, "shadername" ), "Utility/SplitColor" )
-			self.assertEqual( arnold.AiNodeGetRGB( splitB, "param_c" ),  arnold.AtRGB( 0.1, 0.2, 0.3 ))
-
+			colorToFloatB = arnold.AiNodeGetLink( floatToColor, "param_b" )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( colorToFloatB ) ), "osl" )
+			self.assertEqual( arnold.AiNodeGetStr( colorToFloatB, "output" ), "b" )
+			self.assertEqual( arnold.AiNodeGetStr( colorToFloatB, "shadername" ), "Conversion/ColorToFloat" )
+			self.assertEqual( arnold.AiNodeGetRGB( colorToFloatB, "param_c" ),  arnold.AtRGB( 0.1, 0.2, 0.3 ))
 
 	def testTraceSets( self ) :
 

--- a/python/GafferOSLTest/OSLImageTest.py
+++ b/python/GafferOSLTest/OSLImageTest.py
@@ -62,15 +62,15 @@ class OSLImageTest( GafferOSLTest.OSLTestCase ) :
 		getBlue.loadShader( "ImageProcessing/InChannel" )
 		getBlue["parameters"]["channelName"].setValue( "B" )
 
-		buildColor = GafferOSL.OSLShader()
-		buildColor.loadShader( "Utility/BuildColor" )
-		buildColor["parameters"]["r"].setInput( getBlue["out"]["channelValue"] )
-		buildColor["parameters"]["g"].setInput( getGreen["out"]["channelValue"] )
-		buildColor["parameters"]["b"].setInput( getRed["out"]["channelValue"] )
+		floatToColor = GafferOSL.OSLShader()
+		floatToColor.loadShader( "Conversion/FloatToColor" )
+		floatToColor["parameters"]["r"].setInput( getBlue["out"]["channelValue"] )
+		floatToColor["parameters"]["g"].setInput( getGreen["out"]["channelValue"] )
+		floatToColor["parameters"]["b"].setInput( getRed["out"]["channelValue"] )
 
 		outRGB = GafferOSL.OSLShader()
 		outRGB.loadShader( "ImageProcessing/OutLayer" )
-		outRGB["parameters"]["layerColor"].setInput( buildColor["out"]["c"] )
+		outRGB["parameters"]["layerColor"].setInput( floatToColor["out"]["c"] )
 
 		imageShader = GafferOSL.OSLShader()
 		imageShader.loadShader( "ImageProcessing/OutImage" )
@@ -122,7 +122,7 @@ class OSLImageTest( GafferOSLTest.OSLTestCase ) :
 
 		del cs[:]
 
-		buildColor["parameters"]["r"].setInput( getRed["out"]["channelValue"] )
+		floatToColor["parameters"]["r"].setInput( getRed["out"]["channelValue"] )
 
 		self.assertEqual( len( cs ), 5 )
 		self.assertTrue( cs[0][0].isSame( image["shader"] ) )

--- a/python/GafferOSLTest/OSLObjectTest.py
+++ b/python/GafferOSLTest/OSLObjectTest.py
@@ -66,18 +66,18 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		inPoint = GafferOSL.OSLShader()
 		inPoint.loadShader( "ObjectProcessing/InPoint" )
 
-		splitPoint = GafferOSL.OSLShader()
-		splitPoint.loadShader( "Utility/SplitPoint" )
-		splitPoint["parameters"]["p"].setInput( inPoint["out"]["value"] )
+		vectorToFloat = GafferOSL.OSLShader()
+		vectorToFloat.loadShader( "Conversion/VectorToFloat" )
+		vectorToFloat["parameters"]["p"].setInput( inPoint["out"]["value"] )
 
-		buildPoint = GafferOSL.OSLShader()
-		buildPoint.loadShader( "Utility/BuildPoint" )
-		buildPoint["parameters"]["x"].setInput( splitPoint["out"]["y"] )
-		buildPoint["parameters"]["y"].setInput( splitPoint["out"]["x"] )
+		floatToVector = GafferOSL.OSLShader()
+		floatToVector.loadShader( "Conversion/FloatToVector" )
+		floatToVector["parameters"]["x"].setInput( vectorToFloat["out"]["y"] )
+		floatToVector["parameters"]["y"].setInput( vectorToFloat["out"]["x"] )
 
 		outPoint = GafferOSL.OSLShader()
 		outPoint.loadShader( "ObjectProcessing/OutPoint" )
-		outPoint["parameters"]["value"].setInput( buildPoint["out"]["p"] )
+		outPoint["parameters"]["value"].setInput( floatToVector["out"]["p"] )
 
 		primVarShader = GafferOSL.OSLShader()
 		primVarShader.loadShader( "ObjectProcessing/OutObject" )
@@ -271,19 +271,19 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		s.addChild( inPoint )
 		inPoint.loadShader( "ObjectProcessing/InPoint" )
 
-		vectorAdd = GafferOSL.OSLShader( "VectorAdd" )
-		s.addChild( vectorAdd )
-		vectorAdd.loadShader( "Maths/VectorAdd" )
-		vectorAdd["parameters"]["b"].setValue( imath.V3f( 1, 2, 3 ) )
+		addVector = GafferOSL.OSLShader( "AddVector" )
+		s.addChild( addVector )
+		addVector.loadShader( "Maths/AddVector" )
+		addVector["parameters"]["b"].setValue( imath.V3f( 1, 2, 3 ) )
 
-		vectorAdd["parameters"]["a"].setInput( inPoint["out"]["value"] )
+		addVector["parameters"]["a"].setInput( inPoint["out"]["value"] )
 
 		outPoint = GafferOSL.OSLShader( "OutPoint" )
 		s.addChild( outPoint )
 		outPoint.loadShader( "ObjectProcessing/OutPoint" )
 		outPoint['parameters']['name'].setValue("P_copy")
 
-		outPoint["parameters"]["value"].setInput( vectorAdd["out"]["out"] )
+		outPoint["parameters"]["value"].setInput( addVector["out"]["out"] )
 
 		outObject = GafferOSL.OSLShader( "OutObject" )
 		s.addChild( outObject )

--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -160,6 +160,7 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		self.assertRaises( RuntimeError, n.loadShader,  "nonexistent" )
 
 	def testSearchPaths( self ) :
+
 		standardShaderPaths = os.environ["OSL_SHADER_PATHS"]
 		try:
 			s = self.compileShader( os.path.dirname( __file__ ) + "/shaders/types.osl" )
@@ -171,23 +172,22 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 			self.assertEqual( n["parameters"].keys(), [ "i", "f", "c", "s", "m" ] )
 		finally:
 			os.environ["OSL_SHADER_PATHS"] = standardShaderPaths
-			
 
 	def testNoConnectionToParametersPlug( self ) :
 
-		splitPoint = GafferOSL.OSLShader()
-		splitPoint.loadShader( "Utility/SplitPoint" )
+		vectorToFloat = GafferOSL.OSLShader()
+		vectorToFloat.loadShader( "Conversion/VectorToFloat" )
 
 		globals = GafferOSL.OSLShader()
 		globals.loadShader( "Utility/Globals" )
 
-		splitPoint["parameters"]["p"].setInput( globals["out"]["globalP"] )
+		vectorToFloat["parameters"]["p"].setInput( globals["out"]["globalP"] )
 
-		self.assertTrue( splitPoint["parameters"]["p"].getInput().isSame( globals["out"]["globalP"] ) )
-		self.assertTrue( splitPoint["parameters"]["p"][0].getInput().isSame( globals["out"]["globalP"][0] ) )
-		self.assertTrue( splitPoint["parameters"]["p"][1].getInput().isSame( globals["out"]["globalP"][1] ) )
-		self.assertTrue( splitPoint["parameters"]["p"][2].getInput().isSame( globals["out"]["globalP"][2] ) )
-		self.assertTrue( splitPoint["parameters"].getInput() is None )
+		self.assertTrue( vectorToFloat["parameters"]["p"].getInput().isSame( globals["out"]["globalP"] ) )
+		self.assertTrue( vectorToFloat["parameters"]["p"][0].getInput().isSame( globals["out"]["globalP"][0] ) )
+		self.assertTrue( vectorToFloat["parameters"]["p"][1].getInput().isSame( globals["out"]["globalP"][1] ) )
+		self.assertTrue( vectorToFloat["parameters"]["p"][2].getInput().isSame( globals["out"]["globalP"][2] ) )
+		self.assertTrue( vectorToFloat["parameters"].getInput() is None )
 
 	def testStructs( self ) :
 
@@ -241,14 +241,14 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		globals = GafferOSL.OSLShader()
 		globals.loadShader( "Utility/Globals" )
 
-		buildColor = GafferOSL.OSLShader()
-		buildColor.loadShader( "Utility/BuildColor" )
+		floatToColor = GafferOSL.OSLShader()
+		floatToColor.loadShader( "Conversion/FloatToColor" )
 
-		buildColor["parameters"]["r"].setInput( globals["out"]["globalU"] )
-		h1 = buildColor.attributesHash()
+		floatToColor["parameters"]["r"].setInput( globals["out"]["globalU"] )
+		h1 = floatToColor.attributesHash()
 
-		buildColor["parameters"]["r"].setInput( globals["out"]["globalV"] )
-		h2 = buildColor.attributesHash()
+		floatToColor["parameters"]["r"].setInput( globals["out"]["globalV"] )
+		h2 = floatToColor.attributesHash()
 
 		self.assertNotEqual( h1, h2 )
 
@@ -294,7 +294,7 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		inputClosure.loadShader( inputClosureShader )
 
 		outputColor = GafferOSL.OSLShader()
-		outputColor.loadShader( "Utility/VectorToColor" )
+		outputColor.loadShader( "Conversion/VectorToColor" )
 
 		self.assertTrue( inputClosure["parameters"]["i"].acceptsInput( outputClosure["out"]["c"] ) )
 		self.assertFalse( inputClosure["parameters"]["i"].acceptsInput( outputColor["out"]["c"] ) )
@@ -490,13 +490,13 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		globals.loadShader( "Utility/Globals" )
 
 		point = GafferOSL.OSLShader( "Point" )
-		point.loadShader( "Utility/BuildPoint" )
+		point.loadShader( "Conversion/FloatToVector" )
 
 		noise = GafferOSL.OSLShader( "Noise" )
 		noise.loadShader( "Pattern/Noise" )
 
 		color = GafferOSL.OSLShader( "Color" )
-		color.loadShader( "Utility/BuildColor" )
+		color.loadShader( "Conversion/FloatToColor" )
 
 		point["parameters"]["x"].setInput( globals["out"]["globalU"] )
 		point["parameters"]["y"].setInput( globals["out"]["globalV"] )
@@ -858,13 +858,13 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		s = Gaffer.ScriptNode()
 
 		s["n1"] = GafferOSL.OSLShader()
-		s["n1"].loadShader( "Maths/VectorAdd" )
+		s["n1"].loadShader( "Maths/AddVector" )
 
 		s["n2"] = GafferOSL.OSLShader()
-		s["n2"].loadShader( "Maths/VectorAdd" )
+		s["n2"].loadShader( "Maths/AddVector" )
 
 		s["n3"] = GafferOSL.OSLShader()
-		s["n3"].loadShader( "Maths/VectorAdd" )
+		s["n3"].loadShader( "Maths/AddVector" )
 
 		s["n2"]["parameters"]["a"].setInput( s["n1"]["out"]["out"] )
 		s["n3"]["parameters"]["a"].setInput( s["n2"]["out"]["out"] )
@@ -875,14 +875,14 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 	def testDisablingShader( self ) :
 
 		n1 = GafferOSL.OSLShader()
-		n1.loadShader( "Maths/VectorAdd" )
+		n1.loadShader( "Maths/AddVector" )
 		n1["parameters"]["a"].setValue( imath.V3f( 5, 7, 6 ) )
 
 		n2 = GafferOSL.OSLShader()
-		n2.loadShader( "Maths/VectorAdd" )
+		n2.loadShader( "Maths/AddVector" )
 
 		n3 = GafferOSL.OSLShader()
-		n3.loadShader( "Maths/VectorAdd" )
+		n3.loadShader( "Maths/AddVector" )
 
 		n2["parameters"]["a"].setInput( n1["out"]["out"] )
 		n3["parameters"]["a"].setInput( n2["out"]["out"] )
@@ -900,11 +900,11 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		n1["user"]["v"].setValue( imath.V3f( 12, 11, 10 ) )
 
 		n2 = GafferOSL.OSLShader()
-		n2.loadShader( "Maths/VectorAdd" )
+		n2.loadShader( "Maths/AddVector" )
 		n2["parameters"]["a"].setInput( n1["user"]["v"] )
 
 		n3 = GafferOSL.OSLShader()
-		n3.loadShader( "Maths/VectorAdd" )
+		n3.loadShader( "Maths/AddVector" )
 		n3["parameters"]["a"].setInput( n2["parameters"]["a"] )
 
 		n2["enabled"].setValue( False )
@@ -983,7 +983,7 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
-		
+
 		self.assertEqual( s2['n2']['parameters']['scale'].getInput(), s2['n']['out']['n'] )
 
 	def testSplineParameterSerialisation( self ) :


### PR DESCRIPTION
In the case of the GafferArnold tests, this was actually causing test failures.