### PR TITLE
DeleteObject node and Viewer look-through visibility fix

### DIFF
--- a/include/GafferScene/DeleteObject.h
+++ b/include/GafferScene/DeleteObject.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2018, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,44 +34,45 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERSCENE_DELETEOBJECT_H
+#define GAFFERSCENE_DELETEOBJECT_H
 
-#include "ObjectProcessorBinding.h"
+#include "GafferScene/SceneElementProcessor.h"
 
-#include "GafferScene/DeleteCurves.h"
-#include "GafferScene/DeleteFaces.h"
-#include "GafferScene/DeleteObject.h"
-#include "GafferScene/DeletePoints.h"
-#include "GafferScene/LightToCamera.h"
-#include "GafferScene/MeshDistortion.h"
-#include "GafferScene/MeshTangents.h"
-#include "GafferScene/MeshToPoints.h"
-#include "GafferScene/MeshType.h"
-#include "GafferScene/Parameters.h"
-#include "GafferScene/PointsType.h"
-#include "GafferScene/ReverseWinding.h"
-
-#include "GafferBindings/DependencyNodeBinding.h"
-
-using namespace boost::python;
-using namespace Gaffer;
-using namespace GafferBindings;
-using namespace GafferScene;
-
-void GafferSceneModule::bindObjectProcessor()
+namespace GafferScene
 {
 
-	GafferBindings::DependencyNodeClass<GafferScene::DeletePoints>();
-	GafferBindings::DependencyNodeClass<GafferScene::DeleteFaces>();
-	GafferBindings::DependencyNodeClass<GafferScene::DeleteCurves>();
-	GafferBindings::DependencyNodeClass<GafferScene::MeshTangents>();
-	GafferBindings::DependencyNodeClass<GafferScene::PointsType>();
-	GafferBindings::DependencyNodeClass<GafferScene::MeshToPoints>();
-	GafferBindings::DependencyNodeClass<MeshType>();
-	GafferBindings::DependencyNodeClass<GafferScene::LightToCamera>();
-	GafferBindings::DependencyNodeClass<Parameters>();
-	GafferBindings::DependencyNodeClass<ReverseWinding>();
-	GafferBindings::DependencyNodeClass<GafferScene::MeshDistortion>();
-	GafferBindings::DependencyNodeClass<DeleteObject>();
+class GAFFERSCENE_API DeleteObject : public FilteredSceneProcessor
+{
 
-}
+	public :
+
+		DeleteObject( const std::string &name=defaultName<DeleteObject>() );
+		~DeleteObject() override;
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::DeleteObject, DeleteObjectTypeId, FilteredSceneProcessor );
+
+		Gaffer::BoolPlug *adjustBoundsPlug();
+		const Gaffer::BoolPlug *adjustBoundsPlug() const;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+
+		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( DeleteObject )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_DELETEOBJECT_H

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -124,7 +124,7 @@ enum TypeId
 	DeleteSetsTypeId = 110579,
 	ParametersTypeId = 110580,
 	SceneFilterPathFilterTypeId = 110581,
-	PathMatcherDataPlugTypeId = 110582, // Obsolete - available for reuse
+	DeleteObjectTypeId = 110582,
 	AttributeVisualiserTypeId = 110583,
 	SceneLoopTypeId = 110584,
 	RenderTypeId = 110585,

--- a/include/GafferSceneUI/SceneView.h
+++ b/include/GafferSceneUI/SceneView.h
@@ -114,8 +114,8 @@ class GAFFERSCENEUI_API SceneView : public GafferUI::View
 	private :
 
 		// The filter for a preprocessing node used to hide things.
-		GafferScene::PathFilter *hideFilter();
-		const GafferScene::PathFilter *hideFilter() const;
+		GafferScene::PathFilter *deleteObjectFilter();
+		const GafferScene::PathFilter *deleteObjectFilter() const;
 
 		Imath::Box3f framingBound() const;
 

--- a/python/GafferSceneTest/DeleteObjectTest.py
+++ b/python/GafferSceneTest/DeleteObjectTest.py
@@ -1,0 +1,83 @@
+##########################################################################
+#
+#  Copyright (c) 2018, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+
+import IECore
+import IECoreScene
+
+import GafferScene
+import GafferSceneTest
+
+class DeleteObjectTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		plane = GafferScene.Plane()
+
+		# Node should do nothing without a filter applied.
+
+		deleteObject = GafferScene.DeleteObject()
+		deleteObject["in"].setInput( plane["out"] )
+
+		self.assertScenesEqual( plane["out"], deleteObject["out"] )
+		self.assertSceneHashesEqual( plane["out"], deleteObject["out"] )
+
+		# Applying a filter should kick it into action.
+
+		f = GafferScene.PathFilter()
+		f["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+		deleteObject["filter"].setInput( f["out"] )
+
+		self.assertEqual( deleteObject["out"].object( "/plane" ), IECore.NullObject() )
+
+		# Bounds should be unchanged unless we ask for them to be adjusted
+
+		self.assertScenesEqual( plane["out"], deleteObject["out"], childPlugNamesToIgnore = { "object" } )
+		self.assertSceneHashesEqual( plane["out"], deleteObject["out"], childPlugNamesToIgnore = { "object" } )
+
+		deleteObject["adjustBounds"].setValue( True )
+
+		self.assertEqual( deleteObject["out"].bound( "/" ), imath.Box3f() )
+		self.assertEqual( deleteObject["out"].bound( "/plane" ), imath.Box3f() )
+
+		self.assertScenesEqual( plane["out"], deleteObject["out"], childPlugNamesToIgnore = { "object", "bound" } )
+		self.assertSceneHashesEqual( plane["out"], deleteObject["out"], childPlugNamesToIgnore = { "object", "bound" } )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -126,6 +126,7 @@ from EncapsulateTest import EncapsulateTest
 from FilterPlugTest import FilterPlugTest
 from ReverseWindingTest import ReverseWindingTest
 from MeshDistortionTest import MeshDistortionTest
+from DeleteObjectTest import DeleteObjectTest
 
 from IECoreGLPreviewTest import *
 

--- a/python/GafferSceneUI/DeleteObjectUI.py
+++ b/python/GafferSceneUI/DeleteObjectUI.py
@@ -1,0 +1,66 @@
+##########################################################################
+#
+#  Copyright (c) 2018, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.DeleteObject,
+
+	"description",
+	"""
+	Deletes the object at a location, keeping the location itself
+	intact. This is most useful when a location contains an unwanted object,
+	but the location also has children which need to be preserved.
+	""",
+
+	plugs = {
+
+		"adjustBounds" : [
+
+			"description",
+			"""
+			Computes new tightened bounding boxes taking into account
+			the removed objects. This can be an expensive operation -
+			turn on with care.
+			""",
+
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -144,6 +144,7 @@ import GlobalShaderUI
 import CameraToolUI
 import ReverseWindingUI
 import MeshDistortionUI
+import DeleteObjectUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/DeleteObject.cpp
+++ b/src/GafferScene/DeleteObject.cpp
@@ -1,0 +1,169 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/DeleteObject.h"
+
+#include "GafferScene/SceneAlgo.h"
+
+#include "IECore/NullObject.h"
+
+using namespace Imath;
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+
+IE_CORE_DEFINERUNTIMETYPED( DeleteObject );
+
+size_t DeleteObject::g_firstPlugIndex = 0;
+
+DeleteObject::DeleteObject( const std::string &name )
+	:	FilteredSceneProcessor( name, IECore::PathMatcher::NoMatch )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new BoolPlug( "adjustBounds", Plug::In, false ) );
+
+	// Fast pass-throughs for things we don't modify
+	outPlug()->childNamesPlug()->setInput( inPlug()->childNamesPlug() );
+	outPlug()->globalsPlug()->setInput( inPlug()->globalsPlug() );
+	outPlug()->setNamesPlug()->setInput( inPlug()->setNamesPlug() );
+	outPlug()->setPlug()->setInput( inPlug()->setPlug() );
+	outPlug()->attributesPlug()->setInput( inPlug()->attributesPlug() );
+	outPlug()->transformPlug()->setInput( inPlug()->transformPlug() );
+}
+
+DeleteObject::~DeleteObject()
+{
+}
+
+Gaffer::BoolPlug *DeleteObject::adjustBoundsPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::BoolPlug *DeleteObject::adjustBoundsPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex );
+}
+
+void DeleteObject::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	FilteredSceneProcessor::affects( input, outputs );
+
+	if(
+		input == filterPlug() ||
+		input == inPlug()->objectPlug()
+	)
+	{
+		outputs.push_back( outPlug()->objectPlug() );
+	}
+
+	if(
+		input == filterPlug() ||
+		input == adjustBoundsPlug() ||
+		input == inPlug()->boundPlug() ||
+		input == inPlug()->objectPlug()
+	)
+	{
+		outputs.push_back( outPlug()->boundPlug() );
+	}
+}
+
+void DeleteObject::hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	if( filterValue( context ) & IECore::PathMatcher::ExactMatch )
+	{
+		h = outPlug()->objectPlug()->defaultValue()->hash();
+	}
+	else
+	{
+		h = inPlug()->objectPlug()->hash();
+	}
+}
+
+IECore::ConstObjectPtr DeleteObject::computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
+{
+	if( filterValue( context ) & IECore::PathMatcher::ExactMatch )
+	{
+		return outPlug()->objectPlug()->defaultValue();
+	}
+	else
+	{
+		return inPlug()->objectPlug()->getValue();
+	}
+}
+
+void DeleteObject::hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	if( adjustBoundsPlug()->getValue() )
+	{
+		const IECore::PathMatcher::Result m = filterValue( context );
+		if( m & ( IECore::PathMatcher::ExactMatch | IECore::PathMatcher::DescendantMatch ) )
+		{
+			FilteredSceneProcessor::hashBound( path, context, parent, h );
+			h.append( hashOfTransformedChildBounds( path, outPlug() ) );
+			if( !(m & IECore::PathMatcher::ExactMatch) )
+			{
+				inPlug()->objectPlug()->hash( h );
+			}
+			return;
+		}
+	}
+	h = inPlug()->boundPlug()->hash();
+}
+
+Imath::Box3f DeleteObject::computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
+{
+	if( adjustBoundsPlug()->getValue() )
+	{
+		const IECore::PathMatcher::Result m = filterValue( context );
+		if( m & ( IECore::PathMatcher::ExactMatch | IECore::PathMatcher::DescendantMatch ) )
+		{
+			Box3f result = unionOfTransformedChildBounds( path, outPlug() );
+			if( !(m & IECore::PathMatcher::ExactMatch) )
+			{
+				ConstObjectPtr o = inPlug()->objectPlug()->getValue();
+				if( !runTimeCast<const NullObject>( o.get() ) )
+				{
+					result.extendBy( SceneAlgo::bound( o.get() ) );
+				}
+			}
+			return result;
+		}
+	}
+
+	return inPlug()->boundPlug()->getValue();
+}
+

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -301,6 +301,7 @@ nodeMenu.append( "/Scene/Object/Mesh Tangents", GafferScene.MeshTangents, search
 nodeMenu.append( "/Scene/Object/Delete Faces", GafferScene.DeleteFaces, searchText = "DeleteFaces" )
 nodeMenu.append( "/Scene/Object/Delete Curves", GafferScene.DeleteCurves, searchText = "DeleteCurves" )
 nodeMenu.append( "/Scene/Object/Delete Points", GafferScene.DeletePoints, searchText = "DeletePoints" )
+nodeMenu.append( "/Scene/Object/Delete Object", GafferScene.DeleteObject, searchText = "DeleteObject" )
 nodeMenu.append( "/Scene/Object/Reverse Winding", GafferScene.ReverseWinding, searchText = "ReverseWinding" )
 nodeMenu.append( "/Scene/Object/Mesh Distortion", GafferScene.MeshDistortion, searchText = "MeshDistortion" )
 nodeMenu.append( "/Scene/Attributes/Shader Assignment", GafferScene.ShaderAssignment, searchText = "ShaderAssignment" )


### PR DESCRIPTION
As [discussed on the developer list](https://groups.google.com/forum/#!topic/gaffer-dev/eriHZ8PWNQw), the Viewer hides the current look-through camera, so that it's visualisation isn't drawn over the scene, conflicting with the resolution gate that we're drawing separately. Until now, we hid the camera by using a StandardAttributes node to turn its visibility off. But this had the unwanted side effect of also hiding anything parented underneath the camera. This PR introduces a new DeleteObject node, and uses that to hide the camera while leaving the children intact.