### PR TITLE
Viewer : Add selection mask

### DIFF
--- a/include/GafferSceneUI/SceneGadget.h
+++ b/include/GafferSceneUI/SceneGadget.h
@@ -136,6 +136,12 @@ class GAFFERSCENEUI_API SceneGadget : public GafferUI::Gadget
 
 		Imath::Box3f bound() const override;
 
+		/// Specifies which object types are selectable via `objectAt()` and `objectsAt()`.
+		/// May be null, which means all object types are selectable. A copy of `typeNames`
+		/// is taken.
+		void setSelectionMask( const IECore::StringVectorData *typeNames );
+		const IECore::StringVectorData *getSelectionMask() const;
+
 		/// Finds the path of the frontmost object intersecting the specified line
 		/// through gadget space. Returns true on success and false if there is no
 		/// such object.
@@ -178,6 +184,8 @@ class GAFFERSCENEUI_API SceneGadget : public GafferUI::Gadget
 
 		IECore::ConstCompoundObjectPtr m_openGLOptions;
 		IECore::PathMatcher m_selection;
+
+		IECore::StringVectorDataPtr m_selectionMask;
 
 };
 

--- a/include/GafferSceneUI/SceneView.h
+++ b/include/GafferSceneUI/SceneView.h
@@ -127,6 +127,8 @@ class GAFFERSCENEUI_API SceneView : public GafferUI::View
 
 		SceneGadgetPtr m_sceneGadget;
 
+		class SelectionMask;
+		std::unique_ptr<SelectionMask> m_selectionMask;
 		class DrawingMode;
 		std::unique_ptr<DrawingMode> m_drawingMode;
 		class ShadingMode;

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -151,12 +151,12 @@
      borderopacity="1"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.8284272"
-     inkscape:cx="147.31936"
-     inkscape:cy="877.16963"
+     inkscape:zoom="5.656854"
+     inkscape:cx="139.10664"
+     inkscape:cy="862.15462"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
-     showgrid="true"
+     showgrid="false"
      inkscape:window-width="1920"
      inkscape:window-height="1016"
      inkscape:window-x="0"
@@ -2444,6 +2444,12 @@
            id="path3692"
            d="m 154.55204,244.8176 0,-11.87736 8.12095,9.01041 -3.24836,0 1.62418,2.86695 0,2.04782 -2.03024,0 -2.03022,-4.09564 z"
            style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m 154.55204,244.8176 0,-11.87736 8.12095,9.01041 -3.24836,0 1.62418,2.86695 0,2.04782 -2.03024,0 -2.03022,-4.09564 z"
+           id="path4761"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc" />
       </g>
     </g>
     <g
@@ -3665,6 +3671,115 @@
          cx="256.5"
          cy="255.86218"
          r="1" />
+    </g>
+    <g
+       id="forExport:selectionMaskOff"
+       inkscape:label="#g4793">
+      <g
+         transform="translate(188,0)"
+         id="g4784">
+        <path
+           inkscape:connector-curvature="0"
+           id="path4741"
+           d="m -9.78125,163.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 -8.5,-2.5625 z"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -17.63339,176.49782 -0.710223,-10.45042 8.522673,3.39892 -0.177555,11.69331 -7.634895,-4.64181 z"
+           id="path4743"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -18.343613,166.0474 8.522673,3.39892 8.548039,-3.37356 -8.522674,-2.56187 -8.548038,2.53651 z"
+           id="path4745"
+           sodipodi:nodetypes="ccccc" />
+      </g>
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4718"
+         d="m 182.25033,179.48925 0,-8.31457 5.78532,6.3076 -2.31413,0 1.15706,2.00697 0,1.43354 -1.44633,0 -1.44633,-2.8671 z"
+         style="fill:#000000;fill-opacity:1;stroke:#f4f4f4;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <g
+         transform="matrix(0.57849085,0,0,0.57849085,192.70448,76.652237)"
+         id="g4789">
+        <path
+           inkscape:label="#path3352"
+           sodipodi:type="arc"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.72863579;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path4780"
+           sodipodi:cx="-40"
+           sodipodi:cy="172.36218"
+           sodipodi:rx="8.5310822"
+           sodipodi:ry="8.5310841"
+           d="m -31.468918,172.36218 a 8.5310822,8.5310841 0 0 1 -8.528973,8.53109 8.5310822,8.5310841 0 0 1 -8.53319,-8.52687 8.5310822,8.5310841 0 0 1 8.524755,-8.5353 8.5310822,8.5310841 0 0 1 8.537404,8.52265"
+           sodipodi:start="0"
+           sodipodi:end="6.2821966"
+           sodipodi:open="true" />
+        <path
+           sodipodi:nodetypes="csssc"
+           id="path4782"
+           d="m -42.555019,168.57203 c -2.092886,1.37871 -2.641656,4.33859 -3.535981,3.1401 -0.894324,-1.19849 0.405111,-3.97228 1.59811,-4.87074 1.192994,-0.89844 4.11797,-1.89376 5.012295,-0.69526 0.894325,1.19848 -1.122142,0.79291 -3.074424,2.4259 z"
+           style="fill:#aaaaaa;fill-opacity:1;stroke:none"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       inkscape:label="#g4793"
+       id="forExport:selectionMaskOn"
+       transform="translate(28,0)">
+      <g
+         id="g4805"
+         transform="translate(188,0)">
+        <path
+           style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -9.78125,163.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 -8.5,-2.5625 z"
+           id="path4807"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           id="path4809"
+           d="m -17.63339,176.49782 -0.710223,-10.45042 8.522673,3.39892 -0.177555,11.69331 -7.634895,-4.64181 z"
+           style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           id="path4811"
+           d="m -18.343613,166.0474 8.522673,3.39892 8.548039,-3.37356 -8.522674,-2.56187 -8.548038,2.53651 z"
+           style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:#f4f4f4;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         d="m 182.25033,179.48925 0,-8.31457 5.78532,6.3076 -2.31413,0 1.15706,2.00697 0,1.43354 -1.44633,0 -1.44633,-2.8671 z"
+         id="path4813"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+      <g
+         id="g4815"
+         transform="matrix(0.57849085,0,0,0.57849085,192.70448,76.652237)">
+        <path
+           sodipodi:open="true"
+           sodipodi:end="6.2821966"
+           sodipodi:start="0"
+           d="m -31.468918,172.36218 a 8.5310822,8.5310841 0 0 1 -8.528973,8.53109 8.5310822,8.5310841 0 0 1 -8.53319,-8.52687 8.5310822,8.5310841 0 0 1 8.524755,-8.5353 8.5310822,8.5310841 0 0 1 8.537404,8.52265"
+           sodipodi:ry="8.5310841"
+           sodipodi:rx="8.5310822"
+           sodipodi:cy="172.36218"
+           sodipodi:cx="-40"
+           id="path4817"
+           style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.72863579;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           sodipodi:type="arc"
+           inkscape:label="#path3352" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#efefef;fill-opacity:1;stroke:none"
+           d="m -42.555019,168.57203 c -2.092886,1.37871 -2.641656,4.33859 -3.535981,3.1401 -0.894324,-1.19849 0.405111,-3.97228 1.59811,-4.87074 1.192994,-0.89844 4.11797,-1.89376 5.012295,-0.69526 0.894325,1.19848 -1.122142,0.79291 -3.074424,2.4259 z"
+           id="path4819"
+           sodipodi:nodetypes="csssc" />
+      </g>
     </g>
   </g>
 </svg>

--- a/src/GafferSceneUIModule/SceneGadgetBinding.cpp
+++ b/src/GafferSceneUIModule/SceneGadgetBinding.cpp
@@ -90,6 +90,12 @@ IECore::CompoundObjectPtr getOpenGLOptions( const SceneGadget &g )
 	return g.getOpenGLOptions()->copy();
 }
 
+IECore::StringVectorDataPtr getSelectionMask( const SceneGadget &g )
+{
+	const IECore::StringVectorData *d = g.getSelectionMask();
+	return d ? d->copy() : nullptr;
+}
+
 IECore::InternedStringVectorDataPtr objectAt( SceneGadget &g, IECore::LineSegment3f &l )
 {
 	IECore::InternedStringVectorDataPtr result = new IECore::InternedStringVectorData;
@@ -122,6 +128,8 @@ void GafferSceneUIModule::bindSceneGadget()
 		.def( "waitForCompletion", &waitForCompletion )
 		.def( "setOpenGLOptions", &SceneGadget::setOpenGLOptions )
 		.def( "getOpenGLOptions", &getOpenGLOptions )
+		.def( "setSelectionMask", &SceneGadget::setSelectionMask )
+		.def( "getSelectionMask", &getSelectionMask )
 		.def( "objectAt", &objectAt )
 		.def( "objectsAt", &SceneGadget::objectsAt )
 		.def( "setSelection", &SceneGadget::setSelection )


### PR DESCRIPTION
This adds control over what object types are selectable in the Viewer. Particularly useful for making geometry non-selectable so it's easy to work on your lights.

![selectionmask](https://user-images.githubusercontent.com/1133871/43134842-4afb61f8-8f3b-11e8-9247-322ff3e71a7f.png)
