### PR TITLE
DataBinding : Fix `dataToPython()` for non-IECore data types

### DIFF
--- a/python/GafferImageTest/FormatDataTest.py
+++ b/python/GafferImageTest/FormatDataTest.py
@@ -91,5 +91,13 @@ class FormatDataTest( GafferImageTest.ImageTestCase ) :
 		d["f"] = f
 		self.assertEqual( d["f"], GafferImage.FormatData( f ) )
 
+	def testStoreInContext( self ) :
+
+		f = GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 200, 100 ) ), 0.5 )
+		d = GafferImage.FormatData( f )
+		c = Gaffer.Context()
+		c["f"] = d
+		self.assertEqual( c["f"], d )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferBindings/DataBinding.cpp
+++ b/src/GafferBindings/DataBinding.cpp
@@ -79,7 +79,18 @@ boost::python::object dataToPythonInternal( IECore::Data *data, bool copy, boost
 		return nullValue;
 	}
 
-	return dispatch( data, DataToPython( copy ) );
+	try
+	{
+		return dispatch( data, DataToPython( copy ) );
+	}
+	catch( ... )
+	{
+		// `dispatch()` doesn't know about our custom data types,
+		// so we deal with those here.
+		/// \todo Should `dispatch()` just call `Functor( Data * )`
+		/// for unknown types?
+		return object( DataPtr( data ) );
+	}
 }
 
 } // namespace


### PR DESCRIPTION
This was broken by ad07e064d04b9f2205632f26a98346eab14ef45f.