### PR TITLE
OpenImageIOReader : Qualify `string_view` as `OIIO::string_view`

### DIFF
--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -185,7 +185,7 @@ class File
 					continue;
 				}
 
-				const string_view subImageName = currentSpec.get_string_attribute( "name", "" );
+				const OIIO::string_view subImageName = currentSpec.get_string_attribute( "name", "" );
 
 				for( const auto &n : currentSpec.channelnames )
 				{


### PR DESCRIPTION
The OSX builds on Travis have spontaneously started complaining that this is ambiguous with `std::string_view`, although we haven't changed our Travis config, and we're compiling with `-std=c++11` and `std::string_view` doesn't appear until C++17.