### PR TITLE
StandardAttributesUI : mention __lights in the tooltip for light linking

### DIFF
--- a/python/GafferSceneUI/StandardAttributesUI.py
+++ b/python/GafferSceneUI/StandardAttributesUI.py
@@ -181,6 +181,7 @@ Gaffer.Metadata.registerNode(
 			"""
 			The lights to be linked to this object. Accepts a
 			set expression or a space separated list of lights.
+			Use __lights to refer to the set of all lights.
 			""",
 
 			"layout:section", "Light Linking",


### PR DESCRIPTION
We've had users wondering how to remove a single light from the set of lights affecting a mesh. For the record:

`__lights - /path/to/light`

will do that. Hopefully this addition to the tooltip will help people discover this feature more easily.