### PR TITLE
 ArnoldLight : Fix performance problem

### DIFF
--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -214,6 +214,8 @@ class stats( Gaffer.Application ) :
 			script.load( continueOnError = True )
 		self.__timers["Loading"] = loadingTimer
 
+		self.root()["scripts"].addChild( script )
+
 		self.__memory["Script"] = _Memory.maxRSS() - self.__memory["Application"]
 
 		if args["performanceMonitor"].value :

--- a/src/GafferArnold/ArnoldLight.cpp
+++ b/src/GafferArnold/ArnoldLight.cpp
@@ -88,7 +88,7 @@ void ArnoldLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash 
 {
 	for( ValuePlugIterator it( parametersPlug() ); !it.done(); ++it )
 	{
-		if( const Shader *shader = (*it)->source()->ancestor<Shader>() )
+		if( const Shader *shader = IECore::runTimeCast<const Shader>( (*it)->source()->node() ) )
 		{
 			shader->attributesHash( h );
 		}
@@ -106,7 +106,7 @@ IECore::ObjectVectorPtr ArnoldLight::computeLight( const Gaffer::Context *contex
 	IECoreScene::ShaderPtr lightShader = new IECoreScene::Shader( shaderNamePlug()->getValue(), "ai:light" );
 	for( InputPlugIterator it( parametersPlug() ); !it.done(); ++it )
 	{
-		if( const Shader *shader = (*it)->source<Plug>()->ancestor<Shader>() )
+		if( const Shader *shader = IECore::runTimeCast<const Shader>( (*it)->source()->node() ) )
 		{
 			/// \todo We should generalise Shader::NetworkBuilder so we can
 			/// use it directly to do the whole of the light generation, instead


### PR DESCRIPTION
This gives a greater than 5x speedup in scene generation for a synthetic scene consisting of lots of Arnold lights. In the production scene that prompted this investigation, the GIL locks I've removed were the third most expensive thing in the profile, so I expect a decent win there too.