### PR TITLE
SceneInspector : Add tooltip to labels

### DIFF
--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -772,7 +772,8 @@ class DiffRow( Row ) :
 			label = GafferUI.Label(
 				inspector.name(),
 				horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right,
-				verticalAlignment = GafferUI.Label.VerticalAlignment.Top
+				verticalAlignment = GafferUI.Label.VerticalAlignment.Top,
+				toolTip = inspector.name()
 			)
 			label._qtWidget().setFixedWidth( 150 )
 


### PR DESCRIPTION
This just shows the same as the label, but can be useful in the case of extremely long names which don't fit fully on the label itself (same approach we use in the NodeEditor).