### PR TITLE
CollectScenes : Replace bogus ArrayPlug input with ScenePlug

### DIFF
--- a/python/GafferSceneTest/CollectScenesTest.py
+++ b/python/GafferSceneTest/CollectScenesTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import inspect
+import os
 import unittest
 
 import IECore
@@ -253,6 +254,19 @@ class CollectScenesTest( GafferSceneTest.SceneTestCase ) :
 				"/3",
 			}
 		)
+
+	def testInPlug( self ) :
+
+		c = GafferScene.CollectScenes()
+		self.assertIsInstance( c["in"], GafferScene.ScenePlug )
+
+	def testLoadFromVersion0_48( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/collectScenes-0.48.0.0.gfr" )
+		s.load()
+
+		self.assertTrue( s["CollectScenes"]["in"].getInput(), s["Sphere"]["out"] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/scripts/collectScenes-0.48.0.0.gfr
+++ b/python/GafferSceneTest/scripts/collectScenes-0.48.0.0.gfr
@@ -1,0 +1,42 @@
+import Gaffer
+import GafferImage
+import GafferScene
+import IECore
+import imath
+
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:majorVersion", 48, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:minorVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "imageCataloguePort", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"].addChild( Gaffer.StringPlug( "name", defaultValue = 'image:catalogue:port', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"].addChild( Gaffer.IntPlug( "value", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectName", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:name', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectRootDirectory", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:rootDirectory', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format( 1920, 1080, 1.000 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["defaultFormat"] )
+__children["Sphere"] = GafferScene.Sphere( "Sphere" )
+parent.addChild( __children["Sphere"] )
+__children["Sphere"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["CollectScenes"] = GafferScene.CollectScenes( "CollectScenes" )
+parent.addChild( __children["CollectScenes"] )
+__children["CollectScenes"]["in"].addChild( GafferScene.ScenePlug( "in1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["CollectScenes"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"]["value"].setValue( 46490 )
+Gaffer.Metadata.registerValue( parent["variables"]["imageCataloguePort"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectName"]["name"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectRootDirectory"]["name"], 'readOnly', True )
+__children["Sphere"]["__uiPosition"].setValue( imath.V2f( 5.55000305, 12.0500011 ) )
+__children["CollectScenes"]["in"]["in0"].setInput( __children["Sphere"]["out"] )
+__children["CollectScenes"]["__uiPosition"].setValue( imath.V2f( 7.04915667, 3.88593864 ) )
+
+
+del __children
+

--- a/src/GafferScene/CollectScenes.cpp
+++ b/src/GafferScene/CollectScenes.cpp
@@ -103,7 +103,7 @@ IE_CORE_DEFINERUNTIMETYPED( CollectScenes );
 size_t CollectScenes::g_firstPlugIndex = 0;
 
 CollectScenes::CollectScenes( const std::string &name )
-	:	SceneProcessor( name, 1 )
+	:	SceneProcessor( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 

--- a/startup/GafferScene/collectScenesCompatibility.py
+++ b/startup/GafferScene/collectScenesCompatibility.py
@@ -1,0 +1,84 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import types
+
+import GafferScene
+
+# The CollectScenes node used to have an ArrayPlug as its "in" plug,
+# but only ever used the first input. Now it correctly has a single
+# ScenePlug called "in". Here we monkey patch the API so we can silently
+# load scripts which were serialised in the bad version.
+
+def __collectScenesInAddChild( self, child ) :
+
+	# Serialisation may have an `addChild()` call to add a second plug
+	# to the old ArrayPlug. We just ignore it.
+	pass
+
+def __collectScenesGetItem( originalGetItem ) :
+
+	def getItem( self, key ) :
+
+		result = originalGetItem( self, key )
+		if key == "in" :
+			result.addChild = types.MethodType( __collectScenesInAddChild, result )
+
+		return result
+
+	return getItem
+
+def __collectScenesInGetItem( originalGetItem ) :
+
+	def getItem( self, key ) :
+
+		if not isinstance( self.parent(), GafferScene.CollectScenes ) or self.getName() != "in" :
+			return originalGetItem( self, key )
+
+		# We're getting a child of CollectScenes.in.
+
+		if key == "in0" :
+			# First element of old ArrayPlug - redirect to self.
+			return self
+		else :
+			# Any other element of old ArrayPlug - this should not
+			# have been used.
+			return None
+
+	return getItem
+
+GafferScene.CollectScenes.__getitem__ = __collectScenesGetItem( GafferScene.CollectScenes.__getitem__ )
+GafferScene.ScenePlug.__getitem__ = __collectScenesInGetItem( GafferScene.ScenePlug.__getitem__ )


### PR DESCRIPTION
We appear to have got away with this egregious mistake due to a compatibility config allowing us to perform the expected `collectScenes["in"].setInput( otherNode["out"] )`. The fix is a single line in CollectScenes.cpp, but requires another compatibility config to allow us to load old scripts, which have serialisations referring to children of the old ArrayPlug.