### PR TITLE
AnimationEditor : only show FloatPlugs

### DIFF
--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -70,7 +70,8 @@ class _AnimationPathFilter( Gaffer.PathFilter ) :
 
 		for child in graphComponent.children() :
 
-			if isinstance( child, Gaffer.ValuePlug ) and Gaffer.Animation.isAnimated( child ) :
+			# \todo : shouldn't just work on floats
+			if isinstance( child, Gaffer.FloatPlug ) and Gaffer.Animation.isAnimated( child ) :
 				return True
 
 			if self.__hasAnimatedChild( child ) :
@@ -101,7 +102,8 @@ class _AnimationPathFilter( Gaffer.PathFilter ) :
 				if not candidateGraphComponent == selected and not selected.isAncestorOf( candidateGraphComponent ) and not candidateGraphComponent.isAncestorOf( selected ) :
 					continue
 
-				if ( isinstance( candidateGraphComponent, Gaffer.ValuePlug ) and Gaffer.Animation.isAnimated( candidateGraphComponent ) ) or self.__hasAnimatedChild( candidateGraphComponent ) :
+				# \todo : this shouldn't just work on floats
+				if ( isinstance( candidateGraphComponent, Gaffer.FloatPlug ) and Gaffer.Animation.isAnimated( candidateGraphComponent ) ) or self.__hasAnimatedChild( candidateGraphComponent ) :
 					# If we show this component, we should be aware when its name is changes.
 					self.__nameChangedConnections.append( candidateGraphComponent.nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ) ) )
 					result.append( path )


### PR DESCRIPTION
Hey John,

I had a quick look at addressing another bullet point from @medubelko's list of issues. Quoting him here:

> Setting keys on int plugs causes some odd behaviour:
> - Keys aren't snapped to int values.
> - Setting two keys at non-int values, setting the current frame between them, and then right-clicking the plug in the Node Editor (without selecting anything from the menu) creates a new key at that frame, set to the nearest int value.
> - Dragging curves of int plugs with non-int values (seems to need anywhere from 2 to 5 keys) crashes Gaffer.

I couldn't replicate the crash in my tests, but the rest is bad enough that it needs addressing, anyway. I hadn't considered non-float plugs at all it seems and both `IntPlugs` and `BoolPlugs` are no good at the moment. Drawing them properly (adding steps in the curve drawing and figuring out where they need to be) seems like a bit of a bigger issue and I'm not sure if I can get to it before Siggraph. As a shabby workaround I'm suggesting the code added to this PR that just lets FloatPlugs through the filter and doesn't even attempt to show anything for non-float plugs. It's bit of a lame cop-out, but maybe it's better than presenting an unfinished feature to the user?

We can just close this PR if you think we should do it properly - I just wanted to offer something that alleviates the oddness that ints and bools are adding at the moment.

Thanks,

Matti.