### PR TITLE
appleseed: fix object instance interactive updates

### DIFF
--- a/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
+++ b/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
@@ -1163,9 +1163,9 @@ class AppleseedPrimitive : public AppleseedEntity
 		{
 			if( isInteractiveRender() )
 			{
+				clearMaterial();
 				removeAssemblyInstance( m_objectAssemblyInstance );
 				removeAssembly( m_objectAssembly );
-				clearMaterial();
 				return;
 			}
 
@@ -1299,6 +1299,21 @@ class AppleseedPrimitive : public AppleseedEntity
 			m_objectInstance->get_parameters().insert( "visibility", appleseedAttributes->m_visibilityDictionary );
 
 			// todo: support edits of smooth normals and tangents attribute.
+
+			if( isInteractiveRender() )
+			{
+				// We need to re-create object instances after edits.
+				asr::ObjectInstance *objI = m_objectAssembly->object_instances().get_by_name( m_objectInstance->get_name() );
+				asf::auto_release_ptr<asr::ObjectInstance> oi = m_objectAssembly->object_instances().remove( objI );
+
+				oi = asr::ObjectInstanceFactory::create( oi->get_name(), oi->get_parameters(), oi->get_object_name(), oi->get_transform(), oi->get_front_material_mappings(), oi->get_back_material_mappings() );
+				m_objectInstance = oi.get();
+				m_objectAssembly->object_instances().insert( oi );
+
+				// Tell appleseed that we updated the contents of the object assembly.
+				m_objectAssembly->bump_version_id();
+			}
+
 			return true;
 		}
 
@@ -1331,6 +1346,9 @@ class AppleseedPrimitive : public AppleseedEntity
 				removeMaterial( m_material );
 				m_material = nullptr;
 			}
+
+			m_objectInstance->clear_front_materials();
+			m_objectInstance->clear_back_materials();
 		}
 
 		void computeSmoothNormalsAndTangents( bool normals, bool tangents )


### PR DESCRIPTION
Proposed fix for appleseed IPR crashes or wrong material assignments when shaders are disconnected.
Also fixed interactive editing of object visibility flags. 

### Related Issues ###

Fixes #2700

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
