### PR TITLE
ColorProcessor/Shuffle : Don't pull on invalid input channels

### DIFF
--- a/python/GafferImageTest/ColorSpaceTest.py
+++ b/python/GafferImageTest/ColorSpaceTest.py
@@ -231,5 +231,28 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 		# check override produce expected output
 		self.assertImagesEqual( expected, context, ignoreMetadata = True )
 
+	def testSingleChannelImage( self ) :
+
+		r = GafferImage.ImageReader()
+		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/blurRange.exr" )
+		self.assertEqual( r["out"]["channelNames"].getValue(), IECore.StringVectorData( [ "R" ] ) )
+
+		s = GafferImage.Shuffle()
+		s["in"].setInput( r["out"] )
+		s["channels"].addChild( s.ChannelPlug( "G", "R" ) )
+		s["channels"].addChild( s.ChannelPlug( "B", "R" ) )
+
+		c1 = GafferImage.ColorSpace()
+		c1["in"].setInput( r["out"] )
+		c1["inputSpace"].setValue( "linear" )
+		c1["outputSpace"].setValue( "sRGB" )
+
+		c2 = GafferImage.ColorSpace()
+		c2["in"].setInput( s["out"] )
+		c2["inputSpace"].setValue( "linear" )
+		c2["outputSpace"].setValue( "sRGB" )
+
+		self.assertEqual( c2["out"].channelData( "R", imath.V2i( 0 ) ), c1["out"].channelData( "R", imath.V2i( 0 ) ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ShuffleTest.py
+++ b/python/GafferImageTest/ShuffleTest.py
@@ -147,5 +147,25 @@ class ShuffleTest( GafferImageTest.ImageTestCase ) :
 		s["channels"].addChild( s.ChannelPlug( "R", "G" ) )
 		self.assertEqual( s.affects( s["channels"][0]["out"] ), [ s["out"]["channelNames"], s["out"]["channelData"] ] )
 
+	def testMissingInputChannel( self ) :
+
+		r = GafferImage.ImageReader()
+		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/blurRange.exr" )
+		self.assertEqual( r["out"]["channelNames"].getValue(), IECore.StringVectorData( [ "R" ] ) )
+
+		s = GafferImage.Shuffle()
+		s["in"].setInput( r["out"] )
+		s["channels"].addChild( s.ChannelPlug( "R", "A" ) )
+		s["channels"].addChild( s.ChannelPlug( "G", "B" ) )
+		s["channels"].addChild( s.ChannelPlug( "B", "G" ) )
+		s["channels"].addChild( s.ChannelPlug( "A", "R" ) )
+
+		black = IECore.FloatVectorData( [ 0 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
+
+		self.assertEqual( s["out"].channelData( "R", imath.V2i( 0 ) ), black )
+		self.assertEqual( s["out"].channelData( "G", imath.V2i( 0 ) ), black )
+		self.assertEqual( s["out"].channelData( "B", imath.V2i( 0 ) ), black )
+		self.assertEqual( s["out"].channelData( "A", imath.V2i( 0 ) ), r["out"].channelData( "R", imath.V2i( 0 ) ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImage/Shuffle.cpp
+++ b/src/GafferImage/Shuffle.cpp
@@ -36,6 +36,8 @@
 
 #include "GafferImage/Shuffle.h"
 
+#include "GafferImage/ImageAlgo.h"
+
 using namespace std;
 using namespace IECore;
 using namespace Gaffer;
@@ -136,7 +138,7 @@ void Shuffle::affects( const Gaffer::Plug *input, AffectedPlugsContainer &output
 	{
 		outputs.push_back( outPlug()->channelNamesPlug() );
 	}
-	else if( input == inPlug()->channelDataPlug() )
+	else if( input == inPlug()->channelDataPlug() || input == inPlug()->channelNamesPlug() )
 	{
 		outputs.push_back( outPlug()->channelDataPlug() );
 	}
@@ -221,7 +223,15 @@ std::string Shuffle::inChannelName( const std::string &outChannelName ) const
 	{
 		if( (*it)->outPlug()->getValue() == outChannelName )
 		{
-			return (*it)->inPlug()->getValue();
+			const string inChannelName = (*it)->inPlug()->getValue();
+			if( inChannelName == "__white" || ImageAlgo::channelExists( inPlug(), inChannelName ) )
+			{
+				return inChannelName;
+			}
+			else
+			{
+				return "__black";
+			}
 		}
 	}
 	return outChannelName;


### PR DESCRIPTION
ImageNode clients are responsible for verifying that any channels they request do actually exist, but neither of these nodes did so. As far as I can tell, the errors this produced were being masked by the old Viewer implementation, but the asynchronous Viewer is not so forgiving.
