### PR TITLE
Isolate : Fix filter match combination bug

### DIFF
--- a/src/GafferScene/Isolate.cpp
+++ b/src/GafferScene/Isolate.cpp
@@ -404,7 +404,7 @@ IECore::ConstPathMatcherDataPtr Isolate::computeSet( const IECore::InternedStrin
 	for( PathMatcher::RawIterator pIt = inputSet.begin(), peIt = inputSet.end(); pIt != peIt; )
 	{
 		sceneScope.set( ScenePlug::scenePathContextName, *pIt );
-		const int m = filterPlug()->getValue() || setsToKeep.match( *pIt );
+		const int m = filterPlug()->getValue() | setsToKeep.match( *pIt );
 		if( m & ( IECore::PathMatcher::ExactMatch | IECore::PathMatcher::AncestorMatch ) )
 		{
 			// We want to keep everything below this point, so


### PR DESCRIPTION
It's a bitmask, so we need to use bitwise or. I _think_ we were still getting correct results with the buggy code, but weren't hitting the pruning optimisation for `ExactMatch | AncestorMatch`.

