### PR TITLE
Arnold Shadow Linking

### DIFF
--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -61,6 +61,9 @@ def __visibilitySummary( plug ) :
 		if plug[childName+"Visibility"]["enabled"].getValue() :
 			info.append( label + ( " On" if plug[childName+"Visibility"]["value"].getValue() else " Off" ) )
 
+	if plug["shadowGroup"]["enabled"].getValue() :
+		info.append( "ShadowGroup Applied" )
+
 	return ", ".join( info )
 
 __transformTypeEnumNames = { "linear" : "Linear", "rotate_about_origin" : "RotateAboutOrigin",
@@ -199,6 +202,20 @@ Gaffer.Metadata.registerNode(
 			"label", "Shadow",
 
 		],
+
+		"attributes.shadowGroup" : [
+
+			"description",
+			"""
+			The lights that cause this object to cast shadows.
+			Accepts a set expression or a space separated list of
+			lights. Use __lights to refer to the set of all lights.
+			""",
+
+			"layout:section", "Visibility",
+			"label", "Shadow Group",
+		],
+
 		"attributes.diffuseReflectionVisibility" : [
 
 			"description",

--- a/src/GafferArnold/ArnoldAttributes.cpp
+++ b/src/GafferArnold/ArnoldAttributes.cpp
@@ -54,6 +54,7 @@ ArnoldAttributes::ArnoldAttributes( const std::string &name )
 
 	attributes->addOptionalMember( "ai:visibility:camera", new IECore::BoolData( true ), "cameraVisibility", Gaffer::Plug::Default, false );
 	attributes->addOptionalMember( "ai:visibility:shadow", new IECore::BoolData( true ), "shadowVisibility", Gaffer::Plug::Default, false );
+	attributes->addOptionalMember( "ai:visibility:shadow_group", new IECore::StringData( "" ), "shadowGroup", Gaffer::Plug::Default, false );
 	attributes->addOptionalMember( "ai:visibility:diffuse_reflect", new IECore::BoolData( true ), "diffuseReflectionVisibility", Gaffer::Plug::Default, false );
 	attributes->addOptionalMember( "ai:visibility:specular_reflect", new IECore::BoolData( true ), "specularReflectionVisibility", Gaffer::Plug::Default, false );
 	attributes->addOptionalMember( "ai:visibility:diffuse_transmit", new IECore::BoolData( true ), "diffuseTransmissionVisibility", Gaffer::Plug::Default, false );
@@ -62,6 +63,7 @@ ArnoldAttributes::ArnoldAttributes( const std::string &name )
 	attributes->addOptionalMember( "ai:visibility:subsurface", new IECore::BoolData( true ), "subsurfaceVisibility", Gaffer::Plug::Default, false );
 
 	// Transform parameters
+
 	attributes->addOptionalMember( "ai:transform_type", new StringPlug( "value", Plug::In, "rotate_about_center" ), "transformType", false );
 
 	// Shading parameters

--- a/src/GafferScene/EvaluateLightLinks.cpp
+++ b/src/GafferScene/EvaluateLightLinks.cpp
@@ -89,9 +89,9 @@ void EvaluateLightLinks::hashAttributes( const ScenePath &path, const Gaffer::Co
 	ConstStringDataPtr expressionData = attributes->member<StringData>( m_lightLinkAttrName );
 	if( !expressionData )
 	{
-    // Pass through.
-    h = inputHash;
-    return;
+		// Pass through.
+		h = inputHash;
+		return;
 	}
 
 	SceneProcessor::hashAttributes( path, context, parent, h );

--- a/src/GafferScene/EvaluateLightLinks.cpp
+++ b/src/GafferScene/EvaluateLightLinks.cpp
@@ -49,6 +49,24 @@ using namespace GafferScene;
 IE_CORE_DEFINERUNTIMETYPED( EvaluateLightLinks );
 
 IECore::InternedString m_lightLinkAttrName = "linkedLights";
+IECore::InternedString m_shadowGroupAttrName = "ai:visibility:shadow_group";
+
+namespace{
+
+IECore::StringVectorDataPtr expressionToLightNames( const std::string &expression, const ScenePlug *in, const PathMatcher &allLights )
+{
+	IECore::StringVectorDataPtr lightNames = new IECore::StringVectorData();
+	std::vector<std::string> &lightNamesWritable = lightNames->writable();
+
+	PathMatcher linkedIlluminationSet = SetAlgo::evaluateSetExpression( expression, in );
+	linkedIlluminationSet = linkedIlluminationSet.intersection( allLights );
+	linkedIlluminationSet.paths( lightNamesWritable );
+
+	return lightNames;
+}
+
+} // namespace
+
 
 EvaluateLightLinks::EvaluateLightLinks( const std::string &name )
 	:	SceneProcessor( name )
@@ -86,8 +104,11 @@ void EvaluateLightLinks::hashAttributes( const ScenePath &path, const Gaffer::Co
 {
 	const MurmurHash inputHash = inPlug()->attributesPlug()->hash();
 	ConstCompoundObjectPtr attributes = inPlug()->attributesPlug()->getValue( & inputHash );
-	ConstStringDataPtr expressionData = attributes->member<StringData>( m_lightLinkAttrName );
-	if( !expressionData )
+
+	ConstStringDataPtr illuminationExpressionData = attributes->member<StringData>( m_lightLinkAttrName );
+	ConstStringDataPtr shadowExpressionData = attributes->member<StringData>( m_shadowGroupAttrName );
+
+	if( !illuminationExpressionData && !shadowExpressionData )
 	{
 		// Pass through.
 		h = inputHash;
@@ -96,14 +117,25 @@ void EvaluateLightLinks::hashAttributes( const ScenePath &path, const Gaffer::Co
 
 	SceneProcessor::hashAttributes( path, context, parent, h );
 	h.append( inputHash );
-	h.append( SetAlgo::setExpressionHash( expressionData->readable(), inPlug() ) );
+	if( illuminationExpressionData )
+	{
+		h.append( SetAlgo::setExpressionHash( illuminationExpressionData->readable(), inPlug() ) );
+	}
+
+	if( shadowExpressionData )
+	{
+		h.append( SetAlgo::setExpressionHash( shadowExpressionData->readable(), inPlug() ) );
+	}
 }
 
 IECore::ConstCompoundObjectPtr EvaluateLightLinks::computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
 	IECore::ConstCompoundObjectPtr inputAttributes = inPlug()->attributesPlug()->getValue();
-	ConstStringDataPtr expressionData = inputAttributes->member<StringData>( m_lightLinkAttrName );
-	if(!expressionData)
+
+	ConstStringDataPtr illuminationExpressionData = inputAttributes->member<StringData>( m_lightLinkAttrName );
+	ConstStringDataPtr shadowExpressionData = inputAttributes->member<StringData>( m_shadowGroupAttrName );
+
+	if( !illuminationExpressionData && !shadowExpressionData )
 	{
 		// Pass through
 		return inputAttributes;
@@ -112,12 +144,18 @@ IECore::ConstCompoundObjectPtr EvaluateLightLinks::computeAttributes( const Scen
 	CompoundObjectPtr result = new CompoundObject;
 	result->members() = inputAttributes->members();
 
-	IECore::StringVectorDataPtr lightNames = new IECore::StringVectorData();
-	std::vector<std::string> &lightNamesWritable = lightNames->writable();
-	PathMatcher linkedlightsSet = SetAlgo::evaluateSetExpression( expressionData->readable(), inPlug() );
-	linkedlightsSet = linkedlightsSet.intersection( inPlug()->set( "__lights" )->readable() );
-	linkedlightsSet.paths( lightNamesWritable );
-	result->members()[ m_lightLinkAttrName ] = lightNames;
+	ConstPathMatcherDataPtr lightsSetData = inPlug()->set( "__lights" );
+	const PathMatcher &lightsSet = lightsSetData->readable();
+
+	if( illuminationExpressionData )
+	{
+		result->members()[ m_lightLinkAttrName ] = expressionToLightNames( illuminationExpressionData->readable(), inPlug(), lightsSet );
+	}
+
+	if( shadowExpressionData )
+	{
+		result->members()[ m_shadowGroupAttrName ] = expressionToLightNames( shadowExpressionData->readable(), inPlug(), lightsSet );
+	}
 
 	return result;
 }


### PR DESCRIPTION
We have a request from artists to support Arnold's shadow linking in addition to the light linking support that was implemented in https://github.com/GafferHQ/pull/1985.

Most of this is copy pasting, really. There's a few spots in there now where variable naming is a little odd, I think. Shadow linking is a form of light linking as well, I guess, and there is a little weirdness in the naming now regarding the concepts of linking a light, its illumination and its shadow. @johnhaddon , would you have a look and tell me where you'd like things to be renamed? Maybe it's fine because Arnold also calls its attributes `light_group` and `shadow_group`... 

Also, do you want me to look into caching the light node lookups in the renderer backend or postpone that until it actually becomes an issue? What we're doing at the moment seems unnecessarily expensive.

Thanks :)

Matti.

