### PR TITLE
NodeMenu : Remove PrimitiveVariableExists node

### DIFF
--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -291,7 +291,6 @@ nodeMenu.append( "/Scene/Object/Primitive Variables", GafferScene.PrimitiveVaria
 nodeMenu.append( "/Scene/Object/Delete Primitive Variables", GafferScene.DeletePrimitiveVariables, searchText = "DeletePrimitiveVariables" )
 nodeMenu.append( "/Scene/Object/Resample Primitive Variables", GafferScene.ResamplePrimitiveVariables, searchText = "ResamplePrimitiveVariables" )
 nodeMenu.append( "/Scene/Object/Collect Primitive Variables", GafferScene.CollectPrimitiveVariables, searchText = "CollectPrimitiveVariables" )
-nodeMenu.append( "/Scene/Object/Primitive Variable Exists", GafferScene.PrimitiveVariableExists, searchText = "PrimitiveVariableExistts" )
 nodeMenu.append( "/Scene/Object/Mesh Type", GafferScene.MeshType, searchText = "MeshType" )
 nodeMenu.append( "/Scene/Object/Points Type", GafferScene.PointsType, searchText = "PointsType" )
 nodeMenu.append( "/Scene/Object/Mesh To Points", GafferScene.MeshToPoints, searchText = "MeshToPoints" )


### PR DESCRIPTION
This caught my eye because of a spelling mistake in the search text. But rather than fix that I've just removed the menu item completely, on the grounds that in future this node will be used via a revamped Expression setup.
