### PR TITLE
ShadingEngine : Support more vector type conversions

### DIFF
--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -216,11 +216,14 @@ bool convertValue( void *dst, TypeDesc dstType, const void *src, TypeDesc srcTyp
 		srcType.arraylen = 2;
 	}
 
-	if( dstType.aggregate == TypeDesc::VEC2 && srcType.aggregate == TypeDesc::VEC3 )
+	if(
+		( dstType.aggregate == TypeDesc::VEC2 || dstType.aggregate == TypeDesc::VEC3 ) &&
+		srcType.aggregate > dstType.aggregate && srcType.aggregate <= TypeDesc::VEC4
+	)
 	{
-		// OSL doesn't know how to convert VEC3->VEC2, so we encourage it
-		// by truncating srcType.
-		srcType.aggregate = TypeDesc::VEC2;
+		// OSL doesn't know how to do truncating vector conversions, so we
+		// encourage it by truncating srcType.
+		srcType.aggregate = dstType.aggregate;
 	}
 
 	if( ShadingSystem::convert_value( dst, dstType, src, srcType ) )


### PR DESCRIPTION
Among other things, this allows us to read Color4fData as `color` values in OSLObject, by discarding the alpha channel.

Requires https://github.com/ImageEngine/cortex/pull/833