### PR TITLE
StandardNodeGadget : Fix bookmark drawing update bug

### DIFF
--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -109,6 +109,7 @@ GAFFER_API bool readOnlyAffectedByChange( const IECore::InternedString &changedK
 
 GAFFER_API void setBookmarked( Node *node, bool bookmarked, bool persistent = true );
 GAFFER_API bool getBookmarked( const Node *node );
+GAFFER_API bool bookmarkedAffectedByChange( const IECore::InternedString &changedKey );
 GAFFER_API void bookmarks( const Node *node, std::vector<NodePtr> &bookmarks );
 
 /// Utilities

--- a/src/Gaffer/MetadataAlgo.cpp
+++ b/src/Gaffer/MetadataAlgo.cpp
@@ -205,6 +205,11 @@ bool getBookmarked( const Node *node )
 	return d ? d->readable() : false;
 }
 
+bool bookmarkedAffectedByChange( const IECore::InternedString &changedKey )
+{
+	return changedKey == g_bookmarkedName || changedKey == g_oldBookmarkedName;
+}
+
 void bookmarks( const Node *node, std::vector<NodePtr> &bookmarks )
 {
 	bookmarks.clear();

--- a/src/GafferModule/MetadataAlgoBinding.cpp
+++ b/src/GafferModule/MetadataAlgoBinding.cpp
@@ -95,6 +95,7 @@ void GafferModule::bindMetadataAlgo()
 
 	def( "setBookmarked", &setBookmarked, ( arg( "graphComponent" ), arg( "bookmarked"), arg( "persistent" ) = true ) );
 	def( "getBookmarked", &getBookmarked );
+	def( "bookmarkedAffectedByChange", &bookmarkedAffectedByChange );
 	def( "bookmarks", &bookmarksWrapper );
 	def(
 		"affectedByChange",

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -792,6 +792,10 @@ void StandardNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore:
 			requestRender();
 		}
 	}
+	else if( MetadataAlgo::bookmarkedAffectedByChange( key ) )
+	{
+		requestRender();
+	}
 }
 
 bool StandardNodeGadget::updateUserColor()


### PR DESCRIPTION
I'm not sure why this has gone unnoticed until now. Perhaps it always worked on Linux because the closing of the menu used to change the metadata also triggered a redraw of the window below? In any case, it didn't work on Mac, and this fixes it.