### PR TITLE
TypedObjectPlugBinding : Release GIL in `setValue()`

### DIFF
--- a/include/GafferBindings/TypedObjectPlugBinding.inl
+++ b/include/GafferBindings/TypedObjectPlugBinding.inl
@@ -53,6 +53,7 @@ namespace Detail
 template<typename T>
 void setValue( typename T::Ptr p, typename T::ValuePtr v, bool copy=true )
 {
+	IECorePython::ScopedGILRelease r;
 	if( !v )
 	{
 		throw std::invalid_argument( "Value must not be None." );


### PR DESCRIPTION
Without the release we could get deadlocks while the calling thread waited for background tasks to cancel and background tasks waited for the GIL. This was demonstrated in a set of stack traces from a user who had encountered a hang when changing between AOVs in the ImageView.
