### PR TITLE
AnimationEditor precision issues

### DIFF
--- a/include/GafferUI/AnimationGadget.h
+++ b/include/GafferUI/AnimationGadget.h
@@ -131,6 +131,7 @@ class GAFFERUI_API AnimationGadget : public Gadget
 		Gaffer::StandardSetPtr m_editablePlugs;
 
 		std::set<Gaffer::Animation::KeyPtr> m_selectedKeys;
+		std::map<const Gaffer::Animation::Key*, std::pair<float, float> > m_originalKeyValues;
 
 		Imath::V2f m_dragStartPosition;
 		Imath::V2f m_lastDragPosition;
@@ -159,7 +160,6 @@ class GAFFERUI_API AnimationGadget : public Gadget
 		Gaffer::Animation::KeyPtr m_highlightedKey;
 		Gaffer::Animation::CurvePlugPtr m_highlightedCurve;
 
-		double m_xSnappingPreviousOffset;
 		std::set<std::pair<Gaffer::Animation::KeyPtr, Gaffer::Animation::CurvePlugPtr> > m_overwrittenKeys;
 
 		int m_mergeGroupId;

--- a/src/GafferUI/AnimationGadget.cpp
+++ b/src/GafferUI/AnimationGadget.cpp
@@ -826,12 +826,18 @@ IECore::RunTimeTypedPtr AnimationGadget::dragBegin( GadgetPtr gadget, const Drag
 		// Clean up selection so that we operate on valid Keys only. Also, store
 		// current positions so that updating during drag can be done without many
 		// small incremental updates.
-		for( auto &key : m_selectedKeys )
+		for( auto it = m_selectedKeys.begin(); it != m_selectedKeys.end(); )
 		{
+			auto key = (*it);
+
 			if( !key->parent() )
 			{
-				m_selectedKeys.erase( key );
+				it = m_selectedKeys.erase( it );
 				continue;
+			}
+			else
+			{
+				++it;
 			}
 
 			m_originalKeyValues[key.get()] = std::make_pair( key->getTime(), key->getValue() );


### PR DESCRIPTION
Hey John,

here's what I mentioned earlier today. In #2756 you had flagged two of these as things that need fixing independently of where we're going with the chrono/ticks question:

1. don't use small increments to compute new values (d5d99ce)
2. respect fps settings in conversion functions (4875db6)

I've also added a small change that aligns how selection dragging works in conjunction with highlighting of to-be-selected objects (496d317).

Thanks,

Matti.