### PR TITLE
GafferImage::Offset : Fix bug that could trigger hang

### DIFF
--- a/python/GafferImageTest/OffsetTest.py
+++ b/python/GafferImageTest/OffsetTest.py
@@ -174,5 +174,23 @@ class OffsetTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertTrue( o["out"]["dataWindow"] in { x[0] for x in cs } )
 
+	def testOffsetEmpty( self ) :
+
+		c = GafferImage.Text()
+		c["text"].setValue( "" )
+
+		self.assertTrue( c["out"]["dataWindow"].getValue().isEmpty() )
+
+		o = GafferImage.Offset()
+		o["in"].setInput( c["out"] )
+		o["offset"].setValue( imath.V2i( 100, 100 ) )
+
+		self.assertTrue( o["out"]["dataWindow"].getValue().isEmpty() )
+
+		o["offset"].setValue( imath.V2i( -100, -100 ) )
+
+		self.assertTrue( o["out"]["dataWindow"].getValue().isEmpty() )
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImage/Offset.cpp
+++ b/src/GafferImage/Offset.cpp
@@ -118,9 +118,12 @@ void Offset::hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer:
 Imath::Box2i Offset::computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const
 {
 	Box2i dataWindow = inPlug()->dataWindowPlug()->getValue();
-	const V2i offset = offsetPlug()->getValue();
-	dataWindow.min += offset;
-	dataWindow.max += offset;
+	if( !dataWindow.isEmpty() )
+	{
+		const V2i offset = offsetPlug()->getValue();
+		dataWindow.min += offset;
+		dataWindow.max += offset;
+	}
 	return dataWindow;
 }
 


### PR DESCRIPTION
This is a small fix for a bug in GafferImage::Offset - offsetting an emtpy data window could cause integer overflow, resulting in a data window around INT_MIN or INT_MAX.  Merging those would produce an enormous image.

This is particularly nasty because it results in a hang which seems to spend all it's time in `m_tiles.find` in `ImageGadget::renderTiles`, which hangs the UI with no opportunity to cancel.  ( I've attached a simple script which triggers this, simplified from a scene from @medubelko who seems to find all the weirdest bugs ).

I haven't audited for anywhere else this might happen, possibly renderTiles should be hardened against enormous images?

In any case, this small fix is needed for Offset anyway.

```
import Gaffer
import GafferImage
import IECore
import imath

Gaffer.Metadata.registerNodeValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
Gaffer.Metadata.registerNodeValue( parent, "serialiser:majorVersion", 48, persistent=False )
Gaffer.Metadata.registerNodeValue( parent, "serialiser:minorVersion", 1, persistent=False )
Gaffer.Metadata.registerNodeValue( parent, "serialiser:patchVersion", 0, persistent=False )

__children = {}

__children["Text1"] = GafferImage.Text( "Text1" )
parent.addChild( __children["Text1"] )
__children["Text1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Offset1"] = GafferImage.Offset( "Offset1" )
parent.addChild( __children["Offset1"] )
__children["Offset1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Offset2"] = GafferImage.Offset( "Offset2" )
parent.addChild( __children["Offset2"] )
__children["Offset2"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Merge"] = GafferImage.Merge( "Merge" )
parent.addChild( __children["Merge"] )
__children["Merge"]["in"].addChild( GafferImage.ImagePlug( "in2", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Merge"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Text1"]["out"].setInput( __children["Text1"]["__merge"]["out"] )
__children["Text1"]["text"].setValue( '' )
__children["Text1"]["area"].setValue( imath.Box2i( imath.V2i( 0, 0 ), imath.V2i( 1920, 1080 ) ) )
__children["Text1"]["__uiPosition"].setValue( imath.V2f( 103.721428, -84.8899765 ) )
__children["Offset1"]["in"].setInput( __children["Text1"]["out"] )
__children["Offset1"]["offset"].setValue( imath.V2i( -100, -100 ) )
__children["Offset1"]["__uiPosition"].setValue( imath.V2f( 97.2206268, -93.054039 ) )
__children["Offset2"]["in"].setInput( __children["Text1"]["out"] )
__children["Offset2"]["offset"].setValue( imath.V2i( 100, 100 ) )
__children["Offset2"]["__uiPosition"].setValue( imath.V2f( 110.220627, -93.054039 ) )
__children["Merge"]["in"]["in0"].setInput( __children["Offset1"]["out"] )
__children["Merge"]["in"]["in1"].setInput( __children["Offset2"]["out"] )
__children["Merge"]["operation"].setValue( 8 )
__children["Merge"]["__uiPosition"].setValue( imath.V2f( 105.219833, -101.218102 ) )


del __children
```