### PR TITLE
DependencyNodeBinding : Guard against `None` from `affects()` overrides

### DIFF
--- a/include/GafferBindings/DependencyNodeBinding.h
+++ b/include/GafferBindings/DependencyNodeBinding.h
@@ -98,7 +98,11 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>
 					{
 						boost::python::object r = f( Gaffer::PlugPtr( const_cast<Gaffer::Plug *>( input ) ) );
 						boost::python::list pythonOutputs = boost::python::extract<boost::python::list>( r );
-						boost::python::container_utils::extend_container( outputs, pythonOutputs );
+						for( boost::python::ssize_t i = 0, e = boost::python::len( pythonOutputs ); i < e; ++i )
+						{
+							const Gaffer::Plug &p = boost::python::extract<const Gaffer::Plug &>( pythonOutputs[i] );
+							outputs.push_back( &p );
+						}
 						return;
 					}
 				}

--- a/python/GafferTest/DependencyNodeTest.py
+++ b/python/GafferTest/DependencyNodeTest.py
@@ -645,5 +645,35 @@ class DependencyNodeTest( GafferTest.TestCase ) :
 		self.assertEqual( mh.messages[0].context, "Plug dirty propagation" )
 		self.assertEqual( mh.messages[0].message, "Cycle detected between CycleNode.in and CycleNode.out" )
 
+	def testBadAffects( self ) :
+
+		class BadAffects( Gaffer.DependencyNode ) :
+
+			def __init__( self, name = "BadAffects" ) :
+
+				Gaffer.DependencyNode.__init__( self, name )
+
+				self["in"] = Gaffer.IntPlug()
+
+			def affects( self, input ) :
+
+				outputs = Gaffer.DependencyNode.affects( self, input )
+				if input == self["in"] :
+					outputs.append( None ) # Error!
+
+				return outputs
+
+		IECore.registerRunTimeTyped( BadAffects )
+
+		n = BadAffects()
+
+		with IECore.CapturingMessageHandler() as mh :
+			n["in"].setValue( 1 )
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Error )
+		self.assertEqual( mh.messages[0].context, "BadAffects::affects()" )
+		self.assertEqual( mh.messages[0].message, "TypeError: No registered converter was able to extract a C++ reference to type Gaffer::Plug from this Python object of type NoneType\n" )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
We don't want coding errors in Python to be able to take down the process.
