### PR TITLE
StandardGraphLayout : Compile fix for gcc 7.3.0 (Ubuntu 18.04 default compiler)

### DIFF
--- a/src/GafferUI/StandardGraphLayout.cpp
+++ b/src/GafferUI/StandardGraphLayout.cpp
@@ -715,7 +715,7 @@ class LayoutEngine
 			Direction idealDirection;
 
 			// True if edge is representing an auxiliary connection
-			bool auxiliary;
+			bool auxiliary = false;
 		};
 
 		typedef boost::adjacency_list<boost::listS, boost::listS, boost::bidirectionalS, Vertex, Edge> Graph;


### PR DESCRIPTION
https://github.com/GafferHQ/gaffer/issues/2540

Fixes:
```
src/GafferUI/StandardGraphLayout.cpp: In member function 'virtual void GafferUI::StandardGraphLayout::positionNodes(GafferUI::GraphGadget*, Gaffer::Set*, const V2f&) const':
src/GafferUI/StandardGraphLayout.cpp:706:10: error: 'p.{anonymous}::LayoutEngine::Edge::auxiliary' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   struct Edge
```