### PR TITLE
StandardGraphLayout : no need for auxiliary member on Edges

### DIFF
--- a/src/GafferUI/StandardGraphLayout.cpp
+++ b/src/GafferUI/StandardGraphLayout.cpp
@@ -262,7 +262,6 @@ class LayoutEngine
 					m_graph[e].sourceTangent = direction( srcNoduleTangent );
 					m_graph[e].targetTangent = direction( dstNoduleTangent );
 					m_graph[e].idealDirection = direction( srcNoduleTangent - dstNoduleTangent );
-					m_graph[e].auxiliary = false;
 				}
 			}
 
@@ -713,9 +712,6 @@ class LayoutEngine
 			Direction sourceTangent;
 			Direction targetTangent;
 			Direction idealDirection;
-
-			// True if edge is representing an auxiliary connection
-			bool auxiliary;
 		};
 
 		typedef boost::adjacency_list<boost::listS, boost::listS, boost::bidirectionalS, Vertex, Edge> Graph;
@@ -1078,7 +1074,6 @@ class LayoutEngine
 			m_graph[e].idealDirection = idealDirection;
 			m_graph[e].sourceOffset = V2f( srcOffset.x, srcOffset.y );
 			m_graph[e].targetOffset = V2f( dstOffset.x, dstOffset.y );
-			m_graph[e].auxiliary = true;
 		}
 
 		// Defaulting to putting auxiliary nodes to the left, unless there are nodules


### PR DESCRIPTION
I'm offering this as an alternative to #2776.

When going through the PR where this was introduced, I saw that I've left this in in case we'll need it at some point for new layout operations. Since nothing like that has come up so far and it's causing trouble, maybe it's worth ripping it out.

@boberfly and @johnhaddon, what do you think? Alex, could you see if this fixes your compilation issues?

Thanks,

Matti.
