### PR TITLE
GraphEditor bookmarks support

### DIFF
--- a/python/Gaffer/GraphComponentPath.py
+++ b/python/Gaffer/GraphComponentPath.py
@@ -67,6 +67,20 @@ class GraphComponentPath( Gaffer.Path ) :
 
 		return GraphComponentPath( self.__rootComponent, self[:], self.root(), self.getFilter() )
 
+	def propertyNames( self ) :
+
+		return Gaffer.Path.propertyNames( self ) + [ "graphComponent:graphComponent" ]
+
+	def property( self, name ) :
+
+		if name == "graphComponent:graphComponent" :
+			try :
+				return self.__graphComponent()
+			except :
+				return None
+
+		return Gaffer.Path.property( self, name )
+
 	def _children( self ) :
 
 		try :

--- a/python/GafferTest/GraphComponentPathTest.py
+++ b/python/GafferTest/GraphComponentPathTest.py
@@ -65,9 +65,13 @@ class GraphComponentPathTest( GafferTest.TestCase ) :
 		r["d"] = Gaffer.GraphComponent()
 
 		p = Gaffer.GraphComponentPath( r, "/d" )
-		self.assertEqual( p.propertyNames(), [ "name", "fullName" ] )
+		self.assertEqual( p.propertyNames(), [ "name", "fullName", "graphComponent:graphComponent" ] )
 		self.assertEqual( p.property( "name" ), "d" )
 		self.assertEqual( p.property( "fullName" ), "/d" )
+		self.assertEqual( p.property( "graphComponent:graphComponent" ), r["d"] )
+
+		p[:] = [ "non", "existent" ]
+		self.assertEqual( p.property( "graphComponent:graphComponent" ), None )
 
 	def testChildrenInheritFilter( self ) :
 

--- a/python/GafferUI/ScriptNodeUI.py
+++ b/python/GafferUI/ScriptNodeUI.py
@@ -50,6 +50,8 @@ Gaffer.Metadata.registerNode(
 
 	"layout:visibilityActivator:hidden", lambda node : False,
 
+	"graphEditor:childrenViewable", True,
+
 	plugs = {
 
 		"fileName" : (

--- a/python/GafferUITest/GraphGadgetTest.py
+++ b/python/GafferUITest/GraphGadgetTest.py
@@ -555,6 +555,9 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		self.assertTrue( g.nodeGadget( s["b"]["n"] ) )
 		self.assertFalse( g.nodeGadget( s["b"] ) )
 
+		with self.assertRaises( TypeError ) :
+			g.setRoot( None )
+
 	def testRootChangedSignal( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/src/GafferUIModule/GraphGadgetBinding.cpp
+++ b/src/GafferUIModule/GraphGadgetBinding.cpp
@@ -61,10 +61,10 @@ using namespace GafferUIBindings;
 namespace
 {
 
-void setRoot( GraphGadget &graphGadget, Gaffer::NodePtr root, Gaffer::SetPtr filter )
+void setRoot( GraphGadget &graphGadget, Gaffer::Node &root, Gaffer::SetPtr filter )
 {
 	ScopedGILRelease gilRelease;
-	graphGadget.setRoot( root, filter );
+	graphGadget.setRoot( &root, filter );
 }
 
 void setFilter( GraphGadget &graphGadget, Gaffer::SetPtr filter )

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -124,3 +124,9 @@ def __plugContextMenu( graphEditor, node, menuDefinition ) :
 	GafferUI.GraphBookmarksUI.appendPlugContextMenuDefinitions( graphEditor, node, menuDefinition )
 
 GafferUI.GraphEditor.plugContextMenuSignal().connect( __plugContextMenu, scoped = False )
+
+def __instanceCreated( graphEditor ) :
+
+	graphEditor.graphGadgetWidget().addOverlay( GafferUI.GraphEditor.RootWidget( graphEditor ) )
+
+GafferUI.GraphEditor.instanceCreatedSignal().connect( __instanceCreated, scoped = False )


### PR DESCRIPTION
This adds a small overlay widget to the GraphEditor, which can be used to navigate quickly to nodes that have been bookmarked by the existing bookmarks system. It also adds a sort of "URL bar" thingy which shows you the full name of the current root (the Box you're viewing). You can use tab complete to navigate quickly using this widget - when entering the name of a Box the GraphEditor dives inside it, and when entering the name of another node, it centres on it. I've wanted this behaviour for a long time, for quickly navigating to particular nodes when debugging big production networks.

I'm fairly happy with this, but would value other opinions. I want (need!) the capabilities the URL thingy provides, but do think it's a little bit ugly looking. I've tried to alleviate that a little by only having it visible by default when inside a box, and making it possible to toggle its visibility explicitly too. Whaddayareckon?