### PR TITLE
ParallelAlgo : Refactor `callOnUIThread()` internals

### DIFF
--- a/include/Gaffer/ParallelAlgo.h
+++ b/include/Gaffer/ParallelAlgo.h
@@ -55,7 +55,7 @@ namespace ParallelAlgo
 
 /// Runs the specified function asynchronously on the main UI thread.
 ///
-/// > Note : This function does nothing unless the GafferUI module has
+/// > Note : This function will throw unless the GafferUI module has
 /// > been imported.
 ///
 /// > Caution : If calling a member function, you _must_ guarantee that
@@ -64,14 +64,14 @@ namespace ParallelAlgo
 typedef std::function<void ()> UIThreadFunction;
 GAFFER_API void callOnUIThread( const UIThreadFunction &function );
 
-/// Signal used to request the calling of a function on the UI thread.
-/// We service these requests in GafferUI.EventLoop.py.
+/// Registers a handler to service requests made to `callOnUIThread()`. We
+/// register the default handler in GafferUI.EventLoop.py.
 ///
 /// > Note : This is an implementation detail. It is only exposed to allow
 /// > emulation of the UI in unit tests, and theoretically to allow an
 /// > alternative UI framework to be connected.
-typedef boost::signal<void ( UIThreadFunction )> CallOnUIThreadSignal;
-GAFFER_API CallOnUIThreadSignal &callOnUIThreadSignal();
+typedef std::function<void ( const UIThreadFunction & )> UIThreadCallHandler;
+GAFFER_API void registerUIThreadCallHandler( const UIThreadCallHandler &handler );
 
 /// Runs the specified function asynchronously on a background thread,
 /// using a copy of the current Context from the calling thread. This

--- a/python/GafferTest/ParallelAlgoTest.py
+++ b/python/GafferTest/ParallelAlgoTest.py
@@ -50,11 +50,23 @@ class ParallelAlgoTest( GafferTest.TestCase ) :
 	# made by GafferUI.EventLoop.
 	class ExpectedUIThreadCall( object ) :
 
+		__conditionStack = []
+		__conditionStackMutex = threading.Lock()
+		__callHandlerRegistered = False
+
 		def __enter__( self ) :
 
 			self.__condition = threading.Condition()
 			self.__condition.toCall = None
-			self.__pushCondition( self.__condition )
+
+			with self.__conditionStackMutex :
+				self.__conditionStack.append( self.__condition )
+
+			self.__registeredCallHandler = False
+			if not self.__class__.__callHandlerRegistered :
+				Gaffer.ParallelAlgo.registerUIThreadCallHandler( self.__callOnUIThread )
+				self.__class__.__callHandlerRegistered = True
+				self.__registeredCallHandler = True
 
 		def __exit__( self, type, value, traceBack ) :
 
@@ -66,30 +78,17 @@ class ParallelAlgoTest( GafferTest.TestCase ) :
 				self.__condition.toCall()
 				self.__condition.toCall = None
 
-		__conditionStack = []
-		__conditionMutex = threading.Lock()
-		@classmethod
-		def __pushCondition( cls, condition ) :
-
-			with cls.__conditionMutex :
-				if len( cls.__conditionStack ) == 0 :
-					cls.__callOnUIThreadConnection = Gaffer.ParallelAlgo.callOnUIThreadSignal().connect( cls.__callOnUIThread )
-				cls.__conditionStack.append( condition )
-
-		@classmethod
-		def __popCondition( cls ) :
-
-			with cls.__conditionMutex :
-				result = cls.__conditionStack.pop()
-				if len( cls.__conditionStack ) == 0 :
-					cls.__callOnUIThreadConnection = None
-
-			return result
+			if self.__registeredCallHandler :
+				assert( self.__class__.__callHandlerRegistered == True )
+				Gaffer.ParallelAlgo.registerUIThreadCallHandler( None )
+				self.__class__.__callHandlerRegistered = False
 
 		@classmethod
 		def __callOnUIThread( cls, f ) :
 
-			condition = cls.__popCondition()
+			with cls.__conditionStackMutex :
+				condition = cls.__conditionStack.pop()
+
 			with condition :
 				assert( condition.toCall is None )
 				condition.toCall = f
@@ -114,6 +113,45 @@ class ParallelAlgoTest( GafferTest.TestCase ) :
 
 		self.assertEqual( s.getName(), "test" )
 		self.assertEqual( s.uiThreadId, thread.get_ident() )
+
+	def testNestedCallOnUIThread( self ) :
+
+		# This is testing our `ExpectedUIThreadCall` utility
+		# class more than it's testing `ParallelAlgo`.
+
+		s = Gaffer.ScriptNode()
+
+		def uiThreadFunction1() :
+
+			s.setName( "test" )
+			s.uiThreadId1 = thread.get_ident()
+
+		def uiThreadFunction2() :
+
+			s["fileName"].setValue( "test" )
+			s.uiThreadId2 = thread.get_ident()
+
+		with self.ExpectedUIThreadCall() :
+
+			t1 = threading.Thread(
+				target = lambda : Gaffer.ParallelAlgo.callOnUIThread( uiThreadFunction1 )
+			)
+			t1.start()
+
+			with self.ExpectedUIThreadCall() :
+
+				t2 = threading.Thread(
+					target = lambda : Gaffer.ParallelAlgo.callOnUIThread( uiThreadFunction2 )
+				)
+				t2.start()
+
+		self.assertEqual( s.getName(), "test" )
+		self.assertEqual( s.uiThreadId1, thread.get_ident() )
+		self.assertEqual( s["fileName"].getValue(), "test" )
+		self.assertEqual( s.uiThreadId2, thread.get_ident() )
+
+		t1.join()
+		t2.join()
 
 	def testCallOnBackgroundThread( self ) :
 

--- a/python/GafferUI/EventLoop.py
+++ b/python/GafferUI/EventLoop.py
@@ -344,4 +344,4 @@ class _UIThreadExecutor( QtCore.QObject ) :
 		return False
 
 # Service the requests made to `ParallelAlgo::callOnUIThread()`.
-Gaffer.ParallelAlgo.callOnUIThreadSignal().connect( EventLoop.executeOnUIThread, scoped = False )
+Gaffer.ParallelAlgo.registerUIThreadCallHandler( EventLoop.executeOnUIThread )


### PR DESCRIPTION
This has been working perfectly well in the real world, but continuing to cause problems when running the Catalogue unit tests on Travis.

The issue was related to the lack of thread safety in `CallOnUIThreadSignal` and the `ParallelAlgoTest.ExpectedUIThreadCall` we use to emulate the UI for testing purposes. The `ExpectedUIThreadCall` class was sometimes modifying its connection while the signal was still being emitted, with the most common symptom being that a slot was called twice (once by the old connection, once by the new one), or the `CallOnUIThreadSignal` block exited before all expected work was done. This could manifest as either hangs or test failures.

Since using a signal didn't make that much sense anyway (we only want one thing connected at any time) I've replaced it with a simple `registerUIThreadCallHandler()` function, which allows us to manage an internal mutex around the handler.

> Tip : For a long time these problems never manifested locally, only on Travis.
> Using `taskset 0x01 gaffer test ...` made them appear locally too, as it forces
> Gaffer onto a single CPU, which I presume yields threading patterns closer to
> those seen on Travis.

