### PR TITLE
GIL management audit

### DIFF
--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -130,6 +130,8 @@ class GAFFER_API Metadata
 		static void deregisterValue( IECore::InternedString target, IECore::InternedString key );
 		static void deregisterValue( IECore::TypeId nodeTypeId, IECore::InternedString key );
 		static void deregisterValue( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key );
+
+		/// \undoable
 		static void deregisterValue( GraphComponent *target, IECore::InternedString key );
 
 		/// Utilities

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -80,12 +80,14 @@ namespace MetadataAlgo
 /// > hosted inside a Reference (because the index may be promoted). In this scenario, the API
 /// > must allow edits, although the UI should not.
 
+/// \undoable
 GAFFER_API void setReadOnly( GraphComponent *graphComponent, bool readOnly, bool persistent = true );
 GAFFER_API bool getReadOnly( const GraphComponent *graphComponent );
 
 /// The "childNodesAreReadOnly" metadata is similar to the "readOnly" metadata
 /// but only indicates the read-only-ness to the internal nodes of a node, and not its own plugs.
 
+/// \undoable
 GAFFER_API void setChildNodesAreReadOnly( Node *node, bool readOnly, bool persistent = true );
 GAFFER_API bool getChildNodesAreReadOnly( const Node *node );
 
@@ -107,6 +109,7 @@ GAFFER_API bool readOnlyAffectedByChange( const IECore::InternedString &changedK
 /// This metadata may be fetched by client code in order to provide convenient mechanisms for
 /// accessing the node and/or its plugs.
 
+/// \undoable
 GAFFER_API void setBookmarked( Node *node, bool bookmarked, bool persistent = true );
 GAFFER_API bool getBookmarked( const Node *node );
 GAFFER_API bool bookmarkedAffectedByChange( const IECore::InternedString &changedKey );
@@ -127,10 +130,12 @@ GAFFER_API bool ancestorAffectedByChange( const Plug *plug, IECore::TypeId chang
 GAFFER_API bool ancestorAffectedByChange( const GraphComponent *graphComponent, IECore::TypeId changedNodeTypeId, const Gaffer::Node *changedNode );
 
 /// Copies metadata from one target to another. The exclude pattern is used with StringAlgo::matchMultiple().
+/// \undoable
 GAFFER_API void copy( const GraphComponent *from, GraphComponent *to, const IECore::StringAlgo::MatchPattern &exclude = "", bool persistentOnly = true, bool persistent = true );
 
 /// Copy nodule and noodle color meta data from srcPlug to dstPlug
-GAFFER_API void copyColors( const Gaffer::Plug *srcPlug , Gaffer::Plug *dstPlug, bool overwrite );
+/// \undoable
+GAFFER_API void copyColors( const Gaffer::Plug *srcPlug, Gaffer::Plug *dstPlug, bool overwrite );
 
 } // namespace MetadataAlgo
 

--- a/src/GafferModule/BoxPlugBinding.cpp
+++ b/src/GafferModule/BoxPlugBinding.cpp
@@ -53,6 +53,13 @@ namespace
 {
 
 template<typename T>
+void setValue( T &plug, const typename T::ValueType &value )
+{
+	IECorePython::ScopedGILRelease r;
+	plug.setValue( value );
+}
+
+template<typename T>
 typename T::ValueType getValue( const T *plug )
 {
 	// Must release GIL in case computation spawns threads which need
@@ -94,7 +101,7 @@ void bind()
 		.def( "hasMaxValue", &T::hasMaxValue )
 		.def( "minValue", &T::minValue )
 		.def( "maxValue", &T::maxValue )
-		.def( "setValue", &T::setValue )
+		.def( "setValue", &setValue<T> )
 		.def( "getValue", &getValue<T> )
 	;
 }

--- a/src/GafferModule/DotBinding.cpp
+++ b/src/GafferModule/DotBinding.cpp
@@ -46,11 +46,22 @@ using namespace boost::python;
 using namespace GafferBindings;
 using namespace Gaffer;
 
+namespace
+{
+
+void setup( Dot &dot, const Plug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	dot.setup( &plug );
+}
+
+} // namespace
+
 void GafferModule::bindDot()
 {
 
 	scope s = DependencyNodeClass<Dot>()
-		.def( "setup", &Dot::setup )
+		.def( "setup", &setup )
 	;
 
 	enum_<Dot::LabelType>( "LabelType" )

--- a/src/GafferModule/GraphComponentBinding.cpp
+++ b/src/GafferModule/GraphComponentBinding.cpp
@@ -58,6 +58,7 @@ namespace
 
 const char *setName( GraphComponent &c, const IECore::InternedString &name )
 {
+	IECorePython::ScopedGILRelease gilRelease;
 	return c.setName( name ).c_str();
 }
 
@@ -129,6 +130,12 @@ void removeChild( GraphComponent &g, GraphComponentPtr c )
 {
 	IECorePython::ScopedGILRelease gilRelease;
 	g.removeChild( c );
+}
+
+void clearChildren( GraphComponent &g )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	g.clearChildren();
 }
 
 GraphComponentPtr getChild( GraphComponent &g, const IECore::InternedString &n )
@@ -285,7 +292,7 @@ void GafferModule::bindGraphComponent()
 		.def( "nameChangedSignal", &GraphComponent::nameChangedSignal, return_internal_reference<1>() )
 		.def( "addChild", &addChild )
 		.def( "removeChild", &removeChild )
-		.def( "clearChildren", &GraphComponent::clearChildren )
+		.def( "clearChildren", &clearChildren )
 		.def( "setChild", &setChild )
 		.def( "getChild", &getChild )
 		.def( "descendant", &descendant )

--- a/src/GafferModule/MetadataBinding.cpp
+++ b/src/GafferModule/MetadataBinding.cpp
@@ -322,6 +322,12 @@ void registerInstanceValue( GraphComponent &instance, InternedString key, ConstD
 	Metadata::registerValue( &instance, key, value, persistent );
 }
 
+void deregisterInstanceValue( GraphComponent &target, IECore::InternedString key )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	Metadata::deregisterValue( &target, key );
+}
+
 list keysToList( const std::vector<InternedString> &keys )
 {
 	list result;
@@ -434,7 +440,7 @@ void GafferModule::bindMetadata()
 		.def( "deregisterValue", (void (*)( IECore::InternedString, IECore::InternedString ) )&Metadata::deregisterValue )
 		.def( "deregisterValue", (void (*)( IECore::TypeId, IECore::InternedString ) )&Metadata::deregisterValue )
 		.def( "deregisterValue", (void (*)( IECore::TypeId, const StringAlgo::MatchPattern &, IECore::InternedString ) )&Metadata::deregisterValue )
-		.def( "deregisterValue", (void (*)( GraphComponent *, IECore::InternedString ) )&Metadata::deregisterValue )
+		.def( "deregisterValue", &deregisterInstanceValue )
 		.staticmethod( "deregisterValue" )
 
 		.def( "registerNodeValue", &registerNodeValue )

--- a/src/GafferModule/PlugAlgoBinding.cpp
+++ b/src/GafferModule/PlugAlgoBinding.cpp
@@ -47,18 +47,47 @@ using namespace boost::python;
 using namespace IECorePython;
 using namespace Gaffer;
 
+namespace
+{
+
+void replacePlug( GraphComponent &parent, Plug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	PlugAlgo::replacePlug( &parent, &plug );
+}
+
+PlugPtr promote( Plug &plug, Plug *parent, const IECore::StringAlgo::MatchPattern &excludeMetadata )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return PlugAlgo::promote( &plug, parent, excludeMetadata );
+}
+
+PlugPtr promoteWithName( Plug &plug, const IECore::InternedString &name, Plug *parent, const IECore::StringAlgo::MatchPattern &excludeMetadata )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return PlugAlgo::promoteWithName( &plug, name, parent, excludeMetadata );
+}
+
+void unpromote( Plug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	PlugAlgo::unpromote( &plug );
+}
+
+} // namespace
+
 void GafferModule::bindPlugAlgo()
 {
 	object module( borrowed( PyImport_AddModule( "Gaffer.PlugAlgo" ) ) );
 	scope().attr( "PlugAlgo" ) = module;
 	scope moduleScope( module );
 
-	def( "replacePlug", &PlugAlgo::replacePlug, ( arg( "parent" ), arg( "plug" ) ) );
+	def( "replacePlug", &replacePlug, ( arg( "parent" ), arg( "plug" ) ) );
 
 	def( "canPromote", &PlugAlgo::canPromote, ( arg( "plug" ), arg( "parent" ) = object() ) );
-	def( "promote", &PlugAlgo::promote, ( arg( "plug" ), arg( "parent" ) = object(), arg( "excludeMetadata" ) = "layout:*" ), return_value_policy<CastToIntrusivePtr>() );
-	def( "promoteWithName", &PlugAlgo::promoteWithName, ( arg( "plug" ), arg( "name" ), arg( "parent" ) = object(), arg( "excludeMetadata" ) = "layout:*" ), return_value_policy<CastToIntrusivePtr>() );
+	def( "promote", &promote, ( arg( "plug" ), arg( "parent" ) = object(), arg( "excludeMetadata" ) = "layout:*" ) );
+	def( "promoteWithName", &promoteWithName, ( arg( "plug" ), arg( "name" ), arg( "parent" ) = object(), arg( "excludeMetadata" ) = "layout:*" ) );
 	def( "isPromoted", &PlugAlgo::isPromoted, ( arg( "plug" ) ) );
-	def( "unpromote", &PlugAlgo::unpromote, ( arg( "plug" ) ) );
+	def( "unpromote", &unpromote, ( arg( "plug" ) ) );
 
 }

--- a/src/GafferModule/PlugBinding.cpp
+++ b/src/GafferModule/PlugBinding.cpp
@@ -73,6 +73,18 @@ NodePtr node( Plug &p )
 	return p.node();
 }
 
+void setFlags1( Plug &p, unsigned flags )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	p.setFlags( flags );
+}
+
+void setFlags2( Plug &p, unsigned flags, bool enable )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	p.setFlags( flags, enable );
+}
+
 PlugPtr getInput( Plug &p )
 {
 	return p.getInput();
@@ -122,8 +134,8 @@ void GafferModule::bindPlug()
 		.def( "direction", &Plug::direction )
 		.def( "getFlags", (unsigned (Plug::*)() const )&Plug::getFlags )
 		.def( "getFlags", (bool (Plug::*)( unsigned ) const )&Plug::getFlags )
-		.def( "setFlags", (void (Plug::*)( unsigned ) )&Plug::setFlags )
-		.def( "setFlags", (void (Plug::*)( unsigned, bool ) )&Plug::setFlags )
+		.def( "setFlags", &setFlags1 )
+		.def( "setFlags", &setFlags2 )
 		.def( "getInput", &getInput )
 		.def( "source", &source )
 		.def( "removeOutputs", &Plug::removeOutputs )

--- a/src/GafferModule/SplinePlugBinding.cpp
+++ b/src/GafferModule/SplinePlugBinding.cpp
@@ -167,12 +167,40 @@ typename T::YPlugType::Ptr pointYPlug( T &s, size_t index )
 }
 
 template<typename T>
+void setValue( T &plug, const typename T::ValueType &value )
+{
+	IECorePython::ScopedGILRelease r;
+	return plug.setValue( value );
+}
+
+template<typename T>
 typename T::ValueType getValue( const T &plug )
 {
 	// Must release GIL in case computation spawns threads which need
 	// to reenter Python.
 	IECorePython::ScopedGILRelease r;
 	return plug.getValue();
+}
+
+template<typename T>
+unsigned addPoint( T &plug )
+{
+	IECorePython::ScopedGILRelease r;
+	return plug.addPoint();
+}
+
+template<typename T>
+void removePoint( T &plug, unsigned pointIndex )
+{
+	IECorePython::ScopedGILRelease r;
+	plug.removePoint( pointIndex );
+}
+
+template<typename T>
+void clearPoints( T &plug )
+{
+	IECorePython::ScopedGILRelease r;
+	plug.clearPoints();
 }
 
 template<typename T>
@@ -189,12 +217,12 @@ void bind()
 			)
 		)
 		.def( "defaultValue", &T::defaultValue, return_value_policy<copy_const_reference>() )
-		.def( "setValue", &T::setValue )
+		.def( "setValue", &setValue<T> )
 		.def( "getValue", &getValue<T> )
 		.def( "numPoints", &T::numPoints )
-		.def( "addPoint", &T::addPoint )
-		.def( "removePoint", &T::removePoint )
-		.def( "clearPoints", &T::clearPoints )
+		.def( "addPoint", &addPoint<T> )
+		.def( "removePoint", &removePoint<T> )
+		.def( "clearPoints", &clearPoints<T> )
 		.def( "pointPlug",  &pointPlug<T> )
 		.def( "pointXPlug", &pointXPlug<T> )
 		.def( "pointYPlug", &pointYPlug<T> )

--- a/src/GafferModule/SubGraphBinding.cpp
+++ b/src/GafferModule/SubGraphBinding.cpp
@@ -121,6 +121,12 @@ class BoxIOSerialiser : public NodeSerialiser
 
 };
 
+void setup( BoxIO &b, const Plug *plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	b.setup( plug );
+}
+
 PlugPtr plug( BoxIO &b )
 {
 	return b.plug();
@@ -196,7 +202,7 @@ void GafferModule::bindSubGraph()
 	Serialisation::registerSerialiser( Box::staticTypeId(), new BoxSerialiser );
 
 	NodeClass<BoxIO>( nullptr, no_init )
-		.def( "setup", &BoxIO::setup, ( arg( "plug" ) = object() ) )
+		.def( "setup", &setup, ( arg( "plug" ) = object() ) )
 		.def( "plug", &plug )
 		.def( "promotedPlug", &promotedPlug )
 		.def( "promote", &BoxIO::promote, return_value_policy<CastToIntrusivePtr>() )

--- a/src/GafferModule/SwitchBinding.cpp
+++ b/src/GafferModule/SwitchBinding.cpp
@@ -51,10 +51,17 @@ namespace
 {
 
 template<typename T>
+void setup( T &s, const Plug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	s.setup( &plug );
+}
+
+template<typename T>
 void bind()
 {
 	DependencyNodeClass<T>()
-		.def( "setup", &T::setup )
+		.def( "setup", &setup<T> )
 		.def( "activeInPlug", (Plug *(T::*)())&T::activeInPlug, return_value_policy<CastToIntrusivePtr>() )
 	;
 }

--- a/src/GafferUIModule/GraphGadgetBinding.cpp
+++ b/src/GafferUIModule/GraphGadgetBinding.cpp
@@ -160,6 +160,24 @@ list unpositionedNodeGadgets( GraphGadget &graphGadget )
 	return l;
 }
 
+void setNodePosition( GraphGadget &graphGadget, Gaffer::Node &node, const Imath::V2f &position )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	graphGadget.setNodePosition( &node, position );
+}
+
+void setNodeInputConnectionsMinimised( GraphGadget &graphGadget, Gaffer::Node &node, bool minimised )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	graphGadget.setNodeInputConnectionsMinimised( &node, minimised );
+}
+
+void setNodeOutputConnectionsMinimised( GraphGadget &graphGadget, Gaffer::Node &node, bool minimised )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	graphGadget.setNodeOutputConnectionsMinimised( &node, minimised );
+}
+
 tuple connectionAt( AuxiliaryConnectionsGadget &g, IECore::LineSegment3f position )
 {
 	auto nodeGadgets = g.connectionAt( position );
@@ -187,12 +205,12 @@ void GafferUIModule::bindGraphGadget()
 			.def( "downstreamNodeGadgets", &downstreamNodeGadgets, ( arg( "node" ), arg( "degreesOfSeparation" ) = Imath::limits<size_t>::max() ) )
 			.def( "connectedNodeGadgets", &connectedNodeGadgets, ( arg( "node" ), arg( "direction" ) = Gaffer::Plug::Invalid, arg( "degreesOfSeparation" ) = Imath::limits<size_t>::max() ) )
 			.def( "unpositionedNodeGadgets", &unpositionedNodeGadgets )
-			.def( "setNodePosition", &GraphGadget::setNodePosition )
+			.def( "setNodePosition", &setNodePosition )
 			.def( "getNodePosition", &GraphGadget::getNodePosition )
 			.def( "hasNodePosition", &GraphGadget::hasNodePosition )
-			.def( "setNodeInputConnectionsMinimised", &GraphGadget::setNodeInputConnectionsMinimised )
+			.def( "setNodeInputConnectionsMinimised", &setNodeInputConnectionsMinimised )
 			.def( "getNodeInputConnectionsMinimised", &GraphGadget::getNodeInputConnectionsMinimised )
-			.def( "setNodeOutputConnectionsMinimised", &GraphGadget::setNodeOutputConnectionsMinimised )
+			.def( "setNodeOutputConnectionsMinimised", &setNodeOutputConnectionsMinimised )
 			.def( "getNodeOutputConnectionsMinimised", &GraphGadget::getNodeOutputConnectionsMinimised )
 			.def( "setLayout", &GraphGadget::setLayout )
 			.def( "getLayout", (GraphLayout *(GraphGadget::*)())&GraphGadget::getLayout, return_value_policy<CastToIntrusivePtr>() )

--- a/src/GafferUIModule/NodeGadgetBinding.cpp
+++ b/src/GafferUIModule/NodeGadgetBinding.cpp
@@ -134,6 +134,7 @@ GadgetPtr getEdgeGadget( StandardNodeGadget &g, StandardNodeGadget::Edge edge )
 
 void frame( BackdropNodeGadget &b, object nodes )
 {
+	IECorePython::ScopedGILRelease gilRelease;
 	std::vector<Node *> n;
 	boost::python::container_utils::extend_container( n, nodes );
 	b.frame( n );


### PR DESCRIPTION
After finding another bug in the vein of #2765 and #2780, I've been through and added GIL releases for all bindings that trigger Actions internally. From the previous PR :

> Now we have asynchronous compute, it is critical that any graph editing operation releases the GIL. This is because the edit will cancel all background tasks and wait for them before proceeding. If the background task is implemented in Python, it will need to acquire the GIL before it can be cancelled, therefore the edit must release the GIL first.