### PR TITLE
 SceneReader : Add transform plug

### DIFF
--- a/include/GafferScene/SceneReader.h
+++ b/include/GafferScene/SceneReader.h
@@ -47,6 +47,7 @@ namespace Gaffer
 {
 
 IE_CORE_FORWARDDECLARE( StringPlug )
+IE_CORE_FORWARDDECLARE( TransformPlug )
 
 } // namespace Gaffer
 
@@ -73,6 +74,9 @@ class GAFFERSCENE_API SceneReader : public SceneNode
 
 		Gaffer::StringPlug *tagsPlug();
 		const Gaffer::StringPlug *tagsPlug() const;
+
+		Gaffer::TransformPlug *transformPlug();
+		const Gaffer::TransformPlug *transformPlug() const;
 
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 

--- a/python/GafferSceneTest/SceneReaderTest.py
+++ b/python/GafferSceneTest/SceneReaderTest.py
@@ -500,5 +500,15 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		r["fileName"].setValue( os.path.dirname( __file__ ) + "/alembicFiles/cube.abc" )
 		self.assertSceneValid( r["out"] )
 
+	def testTransform( self ) :
+
+		r = GafferScene.SceneReader()
+		r["fileName"].setValue( os.path.dirname( __file__ ) + "/alembicFiles/groupedPlane.abc" )
+		self.assertEqual( r["out"].transform( "/group" ), imath.M44f() )
+
+		r["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( r["out"].transform( "/group" ), r["transform"].matrix() )
+		self.assertSceneValid( r["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/SceneReaderUI.py
+++ b/python/GafferSceneUI/SceneReaderUI.py
@@ -102,6 +102,18 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"transform" : [
+
+			"description",
+			"""
+			The transform used to position the cache. This is applied to
+			all children of the cache root.
+			""",
+
+			"layout:section", "Transform",
+
+		],
+
 	}
 
 )

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -42,6 +42,7 @@
 #include "GafferScene/Group.h"
 #include "GafferScene/ObjectSource.h"
 #include "GafferScene/SceneAlgo.h"
+#include "GafferScene/SceneReader.h"
 #include "GafferScene/Transform.h"
 
 #include "Gaffer/Animation.h"
@@ -216,6 +217,15 @@ bool updateSelection( const CapturedProcess *process, TransformTool::Selection &
 					break;
 			}
 			selection.transformSpace = transform->inPlug()->fullTransform( spacePath );
+		}
+	}
+	else if( const GafferScene::SceneReader *sceneReader = runTimeCast<const GafferScene::SceneReader>( node ) )
+	{
+		const ScenePlug::ScenePath &path = process->context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+		if( path.size() == 1 )
+		{
+			selection.transformPlug = const_cast<TransformPlug *>( sceneReader->transformPlug() );
+			selection.transformSpace = M44f();
 		}
 	}
 


### PR DESCRIPTION
This makes it possible to position a cache without needing a separate Transform node, so SceneReaders can be used more like Light and ObjectSource nodes.