### PR TITLE
SubGraph : Fix crash bug in `correspondingInput()`

### DIFF
--- a/python/GafferTest/SubGraphTest.py
+++ b/python/GafferTest/SubGraphTest.py
@@ -101,5 +101,18 @@ class SubGraphTest( GafferTest.TestCase ) :
 
 		self.assertIsNone( b.correspondingInput( b["out"] ) )
 
+	def testCorrespondingInputWithUnconnectedInternalInput( self ) :
+
+		b = Gaffer.Box()
+		b["n"] = GafferTest.AddNode()
+
+		b["o"] = Gaffer.BoxOut()
+		b["o"].setup( b["n"]["sum"] )
+		b["o"]["in"].setInput( b["n"]["sum"] )
+
+		Gaffer.PlugAlgo.promote( b["n"]["enabled"] )
+
+		self.assertIsNone( b.correspondingInput( b["out"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/SubGraph.cpp
+++ b/src/Gaffer/SubGraph.cpp
@@ -120,6 +120,11 @@ const Plug *SubGraph::correspondingInput( const Plug *output ) const
 	}
 
 	const Plug *input = internalInput->getInput();
+	if( !input )
+	{
+		return nullptr;
+	}
+
 	if( const BoxIn *boxIn = input->parent<BoxIn>() )
 	{
 		input = boxIn->promotedPlug();


### PR DESCRIPTION
This typically manifested itself as a crash when trying to delete or cut a box.
