### PR TITLE
MatchPatternPathFilter : Make exception-safe

### DIFF
--- a/python/GafferTest/MatchPatternPathFilterTest.py
+++ b/python/GafferTest/MatchPatternPathFilterTest.py
@@ -37,6 +37,8 @@
 import unittest
 import itertools
 
+import IECore
+
 import Gaffer
 import GafferTest
 
@@ -112,6 +114,30 @@ class MatchPatternPathFilterTest( GafferTest.TestCase ) :
 
 		f.setMatchPatterns( [ "c*", "d*" ] )
 		self.assertEqual( f.getMatchPatterns(), [ "c*", "d*" ] )
+
+	def testExceptionSafety( self ) :
+
+		p = Gaffer.DictPath(
+			{
+				"a" : "aardvark",
+				"b" : 10,
+			},
+			"/"
+		)
+
+		f = Gaffer.MatchPatternPathFilter( [ "a*" ], "dict:value" )
+		p.setFilter( f )
+
+		with IECore.CapturingMessageHandler() as mh :
+			c = p.children()
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].context, "MatchPatternPathFilter" )
+		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Error )
+		self.assertEqual( mh.messages[0].message, "Expected StringData" )
+
+		self.assertEqual( len( c ), 1 )
+		self.assertEqual( str( c[0] ), "/a" )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
`std::remove_if()` has undefined behaviour if an exception is thrown, and in practice we end up with a child vector containing null pointers. This was causing the file browser to crash if pointed at files with strange permissions.

The fix is to catch the exception and turn it into an error. The alternatives would be to allow the exception to be thrown but to use something more robust than `remove_if()`. This doesn't seem at all useful to client code : it wants to be able to show what it can, rather than allow a single bad file to prevent use listing all the others.

Fixes #2798.

