### PR TITLE
BackdropNodeGadget : Fix GIL management for `frame()` method

### DIFF
--- a/src/GafferUIModule/NodeGadgetBinding.cpp
+++ b/src/GafferUIModule/NodeGadgetBinding.cpp
@@ -134,9 +134,10 @@ GadgetPtr getEdgeGadget( StandardNodeGadget &g, StandardNodeGadget::Edge edge )
 
 void frame( BackdropNodeGadget &b, object nodes )
 {
-	IECorePython::ScopedGILRelease gilRelease;
 	std::vector<Node *> n;
 	boost::python::container_utils::extend_container( n, nodes );
+
+	IECorePython::ScopedGILRelease gilRelease;
 	b.frame( n );
 }
 


### PR DESCRIPTION
`extend_container()` uses the Python API, so we can't release the GIL until after we call it.
