### PR TITLE
CameraTool crash bandaid

### DIFF
--- a/src/GafferSceneUI/CameraTool.cpp
+++ b/src/GafferSceneUI/CameraTool.cpp
@@ -189,6 +189,7 @@ const TransformTool::Selection &CameraTool::cameraSelection()
 		);
 	}
 
+	m_cameraSelectionDirty = false;
 	return m_cameraSelection;
 }
 

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -130,7 +130,24 @@ class CapturingMonitor : public Monitor
 			if( process->parent() )
 			{
 				ProcessMap::const_iterator it = m_processMap.find( process->parent() );
-				it->second->children.push_back( std::move( capturedProcess ) );
+				if( it != m_processMap.end() )
+				{
+					it->second->children.push_back( std::move( capturedProcess ) );
+				}
+				else
+				{
+					// We've been called for a process whose parent we have not
+					// been called for. This shouldn't happen, but currently it
+					// can if another thread is doing unrelated computes while we're
+					// trying to capture the transform computes on the UI thread.
+					// We need our scope to be limited to processes that originate
+					// from the thread our Process::Scope is on, but that is not the
+					// case (see #2806). The best we can do is ignore this, but we
+					// could still crash if a background process accesses us after
+					// we're destroyed. Output a warning so we have a trail of
+					// breadcrumbs for the future.
+					IECore::msg( IECore::Msg::Warning, "CapturingMonitor", "Unscoped process encountered" );
+				}
 			}
 			else
 			{


### PR DESCRIPTION
This PR mitigates against crashes in the CameraTool that occur while the Catalogue is saving an image in the background. 2f9ffa5 is a genuine bugfix and simply means that we now perform far fewer updates in the CameraTool - before we were doing updates on every GL draw even when the tool wasn't active. This gives the remaining bug much less of a chance to rear its ugly head, and when it does, we have some mitigation against it via 0721556.

This will never truly go away until #2806 is fixed, but it's now far less likely, and will also be easier to track down should it occur again in the wild.

I'd like to get this into tomorrow's release, so would be good to get a review today.