### PR TITLE
Docs : Fix BuildTarget of two screengrabs

### DIFF
--- a/doc/source/ScriptPerformance/PerformanceBestPractices/screengrab.py
+++ b/doc/source/ScriptPerformance/PerformanceBestPractices/screengrab.py
@@ -1,4 +1,4 @@
-# BuildTarget: images/groupFirst.png
+# BuildTarget: images/graphEditorGroupFirst.png
 
 import os
 

--- a/doc/source/ScriptPerformance/UsingThePerformanceMonitor/screengrab.py
+++ b/doc/source/ScriptPerformance/UsingThePerformanceMonitor/screengrab.py
@@ -1,4 +1,4 @@
-# BuildTarget: images/performanceMonitor.png
+# BuildTarget: images/nodeEditorWindowPerformanceMonitor.png
 
 import Gaffer
 import GafferScene


### PR DESCRIPTION
Fixes the two screengrabs in the _Script Performance_ section that redundantly recreate screenshots every build.

### Checklist ###
- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.