### PR TITLE
Added script frame range to the context

### DIFF
--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -248,6 +248,13 @@ class GAFFER_API ScriptNode : public Node
 		/// > expression - always use `context.getFrame()` instead.
 		FloatPlug *framePlug();
 		const FloatPlug *framePlug() const;
+		/// The ScriptNode defines the valid frame range using two numeric plugs.
+		/// These drive the "frameRange:start" and "frameRange:end" variables
+		/// in the context.
+		IntPlug *frameStartPlug();
+		const IntPlug *frameStartPlug() const;
+		IntPlug *frameEndPlug();
+		const IntPlug *frameEndPlug() const;
 		/// Drives the framesPerSecond variable in the context.
 		FloatPlug *framesPerSecondPlug();
 		const FloatPlug *framesPerSecondPlug() const;
@@ -255,18 +262,6 @@ class GAFFER_API ScriptNode : public Node
 		/// in the context.
 		CompoundDataPlug *variablesPlug();
 		const CompoundDataPlug *variablesPlug() const;
-		//@}
-
-		//! @name Frame range
-		/// The ScriptNode defines the valid frame range using two numeric plugs.
-		/// \todo Perhaps these should also drive context variables? It might
-		/// be useful to use the frame range in expressions etc.
-		////////////////////////////////////////////////////////////////////
-		//@{
-		IntPlug *frameStartPlug();
-		const IntPlug *frameStartPlug() const;
-		IntPlug *frameEndPlug();
-		const IntPlug *frameEndPlug() const;
 		//@}
 
 	protected :

--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -1216,6 +1216,34 @@ class ScriptNodeTest( GafferTest.TestCase ) :
 		self.assertEqual( s2["frame"].getValue(), 4.0 )
 		self.assertEqual( s2.context().getFrame(), 4.0 )
 
+	def testFrameRange( self ) :
+
+		s = Gaffer.ScriptNode()
+		self.assertEqual( s["frameRange"]["start"].getValue(), 1 )
+		self.assertEqual( s["frameRange"]["end"].getValue(), 100 )
+		self.assertEqual( s.context().get( "frameRange:start" ), 1 )
+		self.assertEqual( s.context().get( "frameRange:end" ), 100 )
+
+		s["frameRange"]["start"].setValue( 20 )
+		s["frameRange"]["end"].setValue( 50 )
+		self.assertEqual( s.context().get( "frameRange:start" ), 20 )
+		self.assertEqual( s.context().get( "frameRange:end" ), 50 )
+
+		# frame range remains valid
+		s["frameRange"]["end"].setValue( 15 )
+		self.assertEqual( s["frameRange"]["start"].getValue(), 15 )
+		self.assertEqual( s["frameRange"]["end"].getValue(), 15 )
+		self.assertEqual( s.context().get( "frameRange:start" ), 15 )
+		self.assertEqual( s.context().get( "frameRange:end" ), 15 )
+		
+		s["frameRange"]["end"].setValue( 150 )
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+		self.assertEqual( s2["frameRange"]["start"].getValue(), 15 )
+		self.assertEqual( s2["frameRange"]["end"].getValue(), 150 )
+		self.assertEqual( s2.context().get( "frameRange:start" ), 15 )
+		self.assertEqual( s2.context().get( "frameRange:end" ), 150 )
+
 	def testLineNumberForExecutionSyntaxError( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -230,6 +230,8 @@ std::string readFile( const std::string &fileName )
 
 const IECore::InternedString g_scriptName( "script:name" );
 const IECore::InternedString g_frame( "frame" );
+const IECore::InternedString g_frameStart( "frameRange:start" );
+const IECore::InternedString g_frameEnd( "frameRange:end" );
 const IECore::InternedString g_framesPerSecond( "framesPerSecond" );
 
 } // namespace
@@ -270,6 +272,8 @@ ScriptNode::ScriptNode( const std::string &name )
 	addChild( new CompoundDataPlug( "variables" ) );
 
 	m_context->set( g_scriptName, std::string( "" ) );
+	m_context->set( g_frameStart, 1 );
+	m_context->set( g_frameEnd, 100 );
 
 	m_selection->memberAcceptanceSignal().connect( boost::bind( &ScriptNode::selectionSetAcceptor, this, ::_1, ::_2 ) );
 
@@ -797,10 +801,12 @@ void ScriptNode::plugSet( Plug *plug )
 	if( plug == frameStartPlug() )
 	{
 		frameEndPlug()->setValue( std::max( frameEndPlug()->getValue(), frameStartPlug()->getValue() ) );
+		context()->set( g_frameStart, frameStartPlug()->getValue() );
 	}
 	else if( plug == frameEndPlug() )
 	{
 		frameStartPlug()->setValue( std::min( frameStartPlug()->getValue(), frameEndPlug()->getValue() ) );
+		context()->set( g_frameEnd, frameEndPlug()->getValue() );
 	}
 	else if( plug == framePlug() )
 	{

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -228,6 +228,10 @@ std::string readFile( const std::string &fileName )
 	return s;
 }
 
+const IECore::InternedString g_scriptName( "script:name" );
+const IECore::InternedString g_frame( "frame" );
+const IECore::InternedString g_framesPerSecond( "framesPerSecond" );
+
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -265,7 +269,7 @@ ScriptNode::ScriptNode( const std::string &name )
 	addChild( new FloatPlug( "framesPerSecond", Plug::In, 24.0f, 0.0f ) );
 	addChild( new CompoundDataPlug( "variables" ) );
 
-	m_context->set( "script:name", std::string( "" ) );
+	m_context->set( g_scriptName, std::string( "" ) );
 
 	m_selection->memberAcceptanceSignal().connect( boost::bind( &ScriptNode::selectionSetAcceptor, this, ::_1, ::_2 ) );
 
@@ -818,7 +822,7 @@ void ScriptNode::plugSet( Plug *plug )
 	else if( plug == fileNamePlug() )
 	{
 		const boost::filesystem::path fileName( fileNamePlug()->getValue() );
-		context()->set( "script:name", fileName.stem().string() );
+		context()->set( g_scriptName, fileName.stem().string() );
 		MetadataAlgo::setReadOnly(
 			this,
 			boost::filesystem::exists( fileName ) && 0 != access( fileName.c_str(), W_OK ),
@@ -829,11 +833,11 @@ void ScriptNode::plugSet( Plug *plug )
 
 void ScriptNode::contextChanged( const Context *context, const IECore::InternedString &name )
 {
-	if( name == "frame" )
+	if( name == g_frame )
 	{
 		framePlug()->setValue( context->getFrame() );
 	}
-	else if( name == "framesPerSecond" )
+	else if( name == g_framesPerSecond )
 	{
 		framesPerSecondPlug()->setValue( context->getFramesPerSecond() );
 	}


### PR DESCRIPTION
Added the script's frame start and frame end plug values to the script's context. Note that these are integers not floats to match the plug type.

I wasn't sure if this matches user expectations exactly. The UI presents frameRange as a unified thing. Perhaps we should call these context entries "frameRange:start" and "frameRange:end"? Or a single "frameRange" entry containing both ints (as V2i or IntVectorData)? I was also wondering if they should be floats to match the other frame values in the context rather than ints to match the plugs...

### Related Issues ###

- Fixes #2739 