### PR TITLE
SceneGadget interactivity improvement

### DIFF
--- a/include/Gaffer/BackgroundTask.h
+++ b/include/Gaffer/BackgroundTask.h
@@ -91,6 +91,9 @@ class GAFFER_API BackgroundTask : public boost::noncopyable
 		/// Blocks until the background call returns, either through
 		/// cancellation or running to completion.
 		void wait();
+		/// As above, but times out after the specified number of
+		/// seconds. Returns true on success, and false on timeout.
+		bool waitFor( float seconds );
 		/// Utility to call `cancel()` then `wait()`.
 		void cancelAndWait();
 

--- a/include/GafferSceneUI/SceneGadget.h
+++ b/include/GafferSceneUI/SceneGadget.h
@@ -180,7 +180,6 @@ class GAFFERSCENEUI_API SceneGadget : public GafferUI::Gadget
 		mutable std::shared_ptr<Gaffer::BackgroundTask> m_updateTask;
 		bool m_updateErrored;
 		std::atomic_bool m_renderRequestPending;
-		std::chrono::steady_clock::time_point m_synchroniseTimePoint;
 
 		IECore::ConstCompoundObjectPtr m_openGLOptions;
 		IECore::PathMatcher m_selection;

--- a/python/GafferTest/BackgroundTaskTest.py
+++ b/python/GafferTest/BackgroundTaskTest.py
@@ -212,5 +212,26 @@ class BackgroundTaskTest( GafferTest.TestCase ) :
 
 		self.assertEqual( operations, [ "requesting explicit cancellation", "cancellation received" ] )
 
+	def testWaitFor( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = GafferTest.AddNode()
+
+		def f( canceller ) :
+
+			while True :
+				try :
+					IECore.Canceller.check( canceller )
+				except IECore.Cancelled :
+					return
+
+		t = Gaffer.BackgroundTask( s["n"]["sum"], f )
+
+		startTime = time.time()
+		self.assertFalse( t.waitFor( 0.2 ) )
+		self.assertGreaterEqual( time.time(), startTime + 0.2 )
+
+		t.cancelAndWait()
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferModule/ParallelAlgoBinding.cpp
+++ b/src/GafferModule/ParallelAlgoBinding.cpp
@@ -90,6 +90,12 @@ void backgroundTaskWait( BackgroundTask &b )
 	b.wait();
 }
 
+bool backgroundTaskWaitFor( BackgroundTask &b, float seconds )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return b.waitFor( seconds );
+}
+
 void backgroundTaskCancelAndWait( BackgroundTask &b )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -236,6 +242,7 @@ void GafferModule::bindParallelAlgo()
 			.def( "__init__", make_constructor( &backgroundTaskConstructor, default_call_policies() ) )
 			.def( "cancel", &backgroundTaskCancel )
 			.def( "wait", &backgroundTaskWait )
+			.def( "waitFor", &backgroundTaskWaitFor )
 			.def( "cancelAndWait", &backgroundTaskCancelAndWait )
 			.def( "status", &backgroundTaskStatus )
 		;

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -544,36 +544,6 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 			{
 				return querySelectedObjects( parameters );
 			}
-			else if( name == "gl:synchronise" )
-			{
-				// In interactive mode we need a way of allowing `render()`
-				// to be called before all edits have been completed, so we
-				// can show progressive results in Gaffer's SceneGadget.
-				// This doesn't really sit well in the current `pause()`/`render()`
-				// API, so we use this explicit synchronisation command to allow
-				// manual flushing of the edit queue. The downside is that a naive
-				// call to `render()` will appear to do nothing.
-				//
-				/// \todo Consider improving the base Renderer API as follows :
-				///
-				/// - Use an editBegin()/editEnd() pair to make it explicit when
-				///   all edits are completed. For the OpenGLRenderer, `editEnd()`
-				///   would perform the synchronisation.
-				/// - Make pause()/render() be purely about whether or not the renderer
-				///   is currently computing pixels, so it is OK to make edits without
-				///   calling `pause()` (provided `editBegin()` is called instead).
-				///
-				/// This would have the benefit that a naive client of OpenGLRenderer
-				/// gets the expected behaviour without needing to use custom commands.
-				/// Only if you wanted to preview edits-in-progress would you call
-				/// `command( "gl:synchronise" )` before the final `editEnd()`. It also
-				/// seems that this scheme might map better to other renderer APIs (pause/render
-				/// is very much based on Arnold).
-				processQueue();
-				removeDeletedObjects();
-				CachedConverter::defaultCachedConverter()->clearUnused();
-				return nullptr;
-			}
 
 			throw IECore::Exception( "Unknown command" );
 		}
@@ -582,6 +552,10 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 		void renderInteractive()
 		{
+			processQueue();
+			removeDeletedObjects();
+			CachedConverter::defaultCachedConverter()->clearUnused();
+
 			GLint prevProgram;
 			glGetIntegerv( GL_CURRENT_PROGRAM, &prevProgram );
 			glPushAttrib( GL_ALL_ATTRIB_BITS );

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -496,6 +496,14 @@ void SceneGadget::updateRenderer()
 	m_updateErrored = false;
 	m_updateTask = m_controller.updateInBackground( progressCallback );
 	stateChangedSignal()( this );
+
+	// Give ourselves a 0.1s grace period in which we block
+	// the UI while our updates occur. This means that for reasonably
+	// interactive animation or manipulation, we only show the final
+	// result, rathen than a series of partial intermediate results.
+	// It also prevents a "cancellation storm" where new UI events
+	// cancel our background updates faster than we can show them.
+	m_updateTask->waitFor( 0.1 );
 }
 
 void SceneGadget::renderScene() const

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -209,7 +209,6 @@ void SceneGadget::waitForCompletion()
 	if( m_updateTask )
 	{
 		m_updateTask->wait();
-		m_renderer->command( "gl:synchronise" );
 	}
 }
 
@@ -450,32 +449,25 @@ void SceneGadget::updateRenderer()
 		{
 			return;
 		}
-
-		const bool stateChanged =
+		bool shouldRequestRender = !m_renderRequestPending.exchange( true );
+		bool shouldEmitStateChange =
 			progress == BackgroundTask::Completed ||
 			progress == BackgroundTask::Errored
 		;
 
-		bool shouldRequestRender = false;
-		if( stateChanged || std::chrono::steady_clock::now() >= m_synchroniseTimePoint )
-		{
-			shouldRequestRender = !m_renderRequestPending.exchange( true );
-		}
-
-		if( shouldRequestRender || stateChanged )
+		if( shouldRequestRender || shouldEmitStateChange )
 		{
 			// Must hold a reference to stop us dying before our UI thread call is scheduled.
 			SceneGadgetPtr thisRef = this;
 			ParallelAlgo::callOnUIThread(
-				[thisRef, shouldRequestRender, stateChanged, progress] {
+				[thisRef, shouldRequestRender, shouldEmitStateChange, progress] {
 					if( progress == BackgroundTask::Errored )
 					{
 						thisRef->m_updateErrored = true;
 					}
-					if( stateChanged )
+					if( shouldEmitStateChange )
 					{
 						thisRef->stateChangedSignal()( thisRef.get() );
-						thisRef->m_synchroniseTimePoint = std::chrono::steady_clock::now();
 					}
 					if( shouldRequestRender )
 					{
@@ -499,14 +491,9 @@ void SceneGadget::updateRenderer()
 			// Leave it to the rest of the UI to report the error.
 			m_updateErrored = true;
 		}
-		m_renderer->command( "gl:synchronise" );
 	}
 
 	m_updateErrored = false;
-	// We don't show progressive updates until a small delay has elapsed. This
-	// avoids flickering partial updates when we can show the complete update
-	// in a reasonable period of time.
-	m_synchroniseTimePoint = std::chrono::steady_clock::now() + std::chrono::milliseconds( 100 );;
 	m_updateTask = m_controller.updateInBackground( progressCallback );
 	stateChangedSignal()( this );
 }
@@ -517,12 +504,6 @@ void SceneGadget::renderScene() const
 	{
 		return;
 	}
-
-	if( std::chrono::steady_clock::now() >= m_synchroniseTimePoint )
-	{
-		m_renderer->command( "gl:synchronise" );
-	}
-
 	m_renderer->render();
 }
 


### PR DESCRIPTION
In 876af54, we introduced a delay before showing the results of background updates in the SceneGadget (the main component of the 3D view). This improved the user experience when manipulating heavy scenes, but in doing that we inadvertently made things worse for very simple scenes. The delay introduced an artificial lag that caused objects to lag behind the transform handles as they were moved, for instance. This PR reverts the old commit, and introduces a simpler mechanism that works for both complex and simple scenes.