### PR TITLE
GraphEditor : Fix problems with `nodeDoubleClickSignal()`

### DIFF
--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -209,7 +209,7 @@ class GraphEditor( GafferUI.Editor ) :
 		menuDefinition.append( "/ContentsDivider", { "divider" : True } )
 		menuDefinition.append( "/Show Contents...", { "command" : functools.partial( cls.acquire, node ) } )
 
-	__nodeDoubleClickSignal = Gaffer.Signal2()
+	__nodeDoubleClickSignal = GafferUI.WidgetEventSignal()
 	## Returns a signal which is emitted whenever a node is double clicked.
 	# Slots should have the signature ( graphEditor, node ).
 	@classmethod

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -102,6 +102,7 @@ Gaffer.Metadata.registerValue( GafferScene.Shader, "...", "nodule:color", __shad
 def __nodeDoubleClick( graphEditor, node ) :
 
 	GafferUI.NodeEditor.acquire( node, floating = True )
+	return True
 
 GafferUI.GraphEditor.nodeDoubleClickSignal().connect( __nodeDoubleClick, scoped = False )
 


### PR DESCRIPTION
- The signal didn't respect slot return values, so a slot couldn't return True to signify that it had handled the event, and block other slots.
- The default slot wasn't returning True.

It is now possible to override the double click behaviour in your own configs as follows :

```
GafferUI.GraphEditor.nodeDoubleClickSignal().connect( 0, __myCallback, scoped = False )
```
