### PR TITLE
GafferSceneUI : SceneInspector - Inform the user if a primvar is indexed

### DIFF
--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -614,6 +614,11 @@ class TextDiff( SideBySideDiff ) :
 			s += " " + value.data.typeName()
 			if hasattr( value.data, "getInterpretation" ) :
 				s += " (" + str( value.data.getInterpretation() ) + ")"
+
+			if value.indices :
+				numElements = len( value.data )
+				s += " ( Indexed : {0} element{1} )".format( numElements, '' if numElements == 1 else 's' )
+
 			result.append( s )
 
 		return result


### PR DESCRIPTION
Display if a primitive variable is indexed with its data array size in the SceneInspector. 

Notes for docs: 
All primitive variables ( but typically UVs and string ) can now be stored as two arrays of data, the data and indices into that data. The change shows the user if the primitive variable uses these indices and how many elements there are in the data array.


