### PR TITLE
GafferScene::RenderController : Fix bug when object removed from lights set

### DIFF
--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -478,7 +478,7 @@ class RenderController::SceneGraph
 			const bool hadObjectInterface = static_cast<bool>( m_objectInterface );
 			if( type == NoType )
 			{
-				m_objectInterface = nullptr;
+				clearObject();
 				return hadObjectInterface;
 			}
 


### PR DESCRIPTION
There is a regression in current Gaffer, introduced in Gaffer 0.48, where if you view a scene where a location is a light, and then view a scene where the same location isn't a light, but has the same object, the object will fail to render.

For example, in this scene:
```
import Gaffer
import GafferScene
import IECore
import imath

__children = {}

__children["Cube"] = GafferScene.Cube( "Cube" )
parent.addChild( __children["Cube"] )
__children["Set"] = GafferScene.Set( "Set" )
parent.addChild( __children["Set"] )
__children["Set"]["in"].setInput( __children["Cube"]["out"] )
__children["Set"]["name"].setValue( '__lights' )
__children["Set"]["paths"].setValue( IECore.StringVectorData( [ '/cube' ] ) )

del __children
```

If you select "Cube", then you see the cube.  If you select "Set" then you will still see the cube, but if you select "Cube" again, it's now disappeared.  In practice, this could happen if a mesh is converted to a mesh light, and then you select a node back up the chain.

The cause is that when /cube is a light, and SceneGraphUpdateTask is run with type = SceneGraph::ObjectType, m_sceneGraph->update() is run with type NoType for /cube ( since it doesn't match the type, since it's considered a light ).  When updateObject() is run with type NoType, it sets m_objectInterface to nullptr, but wasn't clearing m_objectHash, resulting in the null object being reused in the future.

Clearing m_objectHash brings this code more in line with the clearObject() method ( I don't actually fully understand why in this case we're not taking the branch on line 731 which calls clearObject() for things which are clearly not the right type ).  The comparison to clearObject makes me think that this is the right approach, but I really don't fully understand the performance implications of all this code, so we should definitely get John to look at this before merging.