### PR TITLE
SceneInspector : Fix for inspecting empty shader vector

### DIFF
--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -559,9 +559,18 @@ class TextDiff( SideBySideDiff ) :
 		formattedValues = []
 		for value in values :
 
-			shader = value[-1] if isinstance( value, IECore.ObjectVector ) else value
-			shaderName = shader.name
-			nodeName = shader.blindData().get( "gaffer:nodeName", None )
+			if isinstance( value, IECore.ObjectVector ):
+				if len( value ):
+					shader = value[-1]
+					shaderName = shader.name
+					nodeName = shader.blindData().get( "gaffer:nodeName", None )
+				else:
+					shaderName = "<NONE>"
+					nodeName = None
+			else:
+				shader = value
+				shaderName = shader.name
+				nodeName = shader.blindData().get( "gaffer:nodeName", None )
 
 			formattedValue = "<table cellspacing=2><tr>"
 			if nodeName is not None :


### PR DESCRIPTION
At IE, Don put together a "ShaderUnassignment" node for when you want a shader assigned at the root of a hierarchy, but to block inheritance at certain subpaths.

Currently, this node produces empty shader vectors, which appears to work correctly in the render backends, but causes an error in the SceneInspector.  Either we need to change how ShaderUnassignment works, or we need something like this fix.