### PR TITLE
GafferImage::Catalogue : Fix hang when adding image with downsteam network

### DIFF
--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -805,6 +805,16 @@ const Catalogue::InternalImage *Catalogue::imageNode( const Image *image )
 				result = internalImage;
 			}
 		}
+
+		if( !it->isInstanceOf( StringPlug::staticTypeId() ) )
+		{
+			// We only want to follow the chain leading to the name plug of the InternalImage,
+			// we don't want to follow off into some other output network that could be costly
+			// to spider ( If we follow the output image of the InternalImage off into a large
+			// comp network, this could get extraordinarily costly, due to DownstreamIterator
+			// not pruning when revisiting nodes ).
+			it.prune();
+		}
 	}
 
 	if( !result )


### PR DESCRIPTION
Using DownstreamIterator to find the  InternalImage in Catalogue is extremely dangerous, because DownstreamIterator visits absolutely everything affected by the plug, in a very inefficient manner ( visiting some downstream nodes many times ).  In production scenes, we've seen up to 20 second hangs resulting from this.

This fix is quite conservative - by limiting the traversal to only string plugs, we at least prevent the traversal to leaking out into a downstream image comp network.  I wondered whether we should make sure that we never follow through a compute node, but maybe someone could stick an expression in the middle at some point?

Anyway, this seems adequate in practice to make sure that our artists don't get inexplicable hangs.