### PR TITLE
Fixes for Houdini 17 compilation errors

### DIFF
--- a/include/Gaffer/Path.h
+++ b/include/Gaffer/Path.h
@@ -91,7 +91,7 @@ class GAFFER_API Path : public IECore::RunTimeTyped
 		const IECore::InternedString &root() const;
 
 		/// Returns true if this path is empty.
-		const bool isEmpty() const;
+		bool isEmpty() const;
 
 		/// Returns true if this path is valid - ie references something
 		/// which actually exists.

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -114,7 +114,7 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		/// constrained to the image plane during Alt+drag interaction.
 		/// To allow full 3D movement call `setOrthographic3D( true )`.
 		void setOrthographic3D( bool orthographic3D );
-		const bool getOrthographic3D() const;
+		bool getOrthographic3D() const;
 
 		void frame( const Imath::Box3f &box );
 		void frame( const Imath::Box3f &box, const Imath::V3f &viewDirection,

--- a/src/Gaffer/Path.cpp
+++ b/src/Gaffer/Path.cpp
@@ -95,7 +95,7 @@ const IECore::InternedString &Path::root() const
 	return m_root;
 }
 
-const bool Path::isEmpty() const
+bool Path::isEmpty() const
 {
 	return m_names.empty() && m_root.string().empty();
 }

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -580,48 +580,35 @@ OSL::ShadingSystem *shadingSystem()
 		g_textureSystem
 	);
 
-	struct ClosureDefinition{
-		const char *name;
-		int id;
-		ClosureParam parameters[32];
-		PrepareClosureFunc prepare;
+	ClosureParam emissionParams[] = {
+		CLOSURE_FINISH_PARAM( EmissionParameters ),
+	};
+	
+
+	ClosureParam debugParams[] = {
+		CLOSURE_STRING_PARAM( DebugParameters, name ),
+		CLOSURE_STRING_KEYPARAM( DebugParameters, type, "type" ),
+		CLOSURE_COLOR_KEYPARAM( DebugParameters, value, "value" ),
+		CLOSURE_MATRIX_KEYPARAM( DebugParameters, matrixValue, "matrixValue"),
+		CLOSURE_STRING_KEYPARAM( DebugParameters, stringValue, "stringValue"),
+		CLOSURE_FINISH_PARAM( DebugParameters )
 	};
 
-	ClosureDefinition closureDefinitions[] = {
-		{
-			"emission",
-			EmissionClosureId,
-			{
-				CLOSURE_FINISH_PARAM( EmissionParameters )
-			}
-		},
-		{
-			"debug",
-			DebugClosureId,
-			{
-				CLOSURE_STRING_PARAM( DebugParameters, name ),
-				CLOSURE_STRING_KEYPARAM( DebugParameters, type, "type" ),
-				CLOSURE_COLOR_KEYPARAM( DebugParameters, value, "value" ),
-				CLOSURE_MATRIX_KEYPARAM( DebugParameters, matrixValue, "matrixValue"),
-				CLOSURE_STRING_KEYPARAM( DebugParameters, stringValue, "stringValue"),
-				CLOSURE_FINISH_PARAM( DebugParameters )
-			},
-			DebugParameters::prepare
-		},
-		// end marker
-		{ nullptr, 0, {} }
-	};
+	g_shadingSystem->register_closure(
+		/* name */ "emission",
+		/* id */ EmissionClosureId,
+		/* params */ emissionParams,
+		/* prepare */ nullptr,
+		/* setup */ nullptr
+	);
 
-	for( int i = 0; closureDefinitions[i].name; ++i )
-	{
-		g_shadingSystem->register_closure(
-			closureDefinitions[i].name,
-			closureDefinitions[i].id,
-			closureDefinitions[i].parameters,
-			closureDefinitions[i].prepare,
-			nullptr
-		);
-	}
+	g_shadingSystem->register_closure(
+		/* name */ "debug",
+		/* id */ DebugClosureId,
+		/* params */ debugParams,
+		/* prepare */ DebugParameters::prepare,
+		/* setup */ nullptr
+	);
 
 	if( const char *searchPath = getenv( "OSL_SHADER_PATHS" ) )
 	{

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -713,7 +713,7 @@ class RenderController::SceneGraphUpdateTask : public tbb::task
 		task *execute() override
 		{
 
-			const unsigned pathsToUpdateMatch = m_pathsToUpdate ? m_pathsToUpdate->match( m_scenePath ) : PathMatcher::EveryMatch;
+			const unsigned pathsToUpdateMatch = m_pathsToUpdate ? m_pathsToUpdate->match( m_scenePath ) : (unsigned)PathMatcher::EveryMatch;
 			if( !pathsToUpdateMatch )
 			{
 				return nullptr;
@@ -792,7 +792,7 @@ class RenderController::SceneGraphUpdateTask : public tbb::task
 		}
 
 		/// \todo Fast path for when sets were not dirtied.
-		const unsigned sceneGraphMatch() const
+		unsigned sceneGraphMatch() const
 		{
 			switch( m_sceneGraphType )
 			{

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -794,7 +794,7 @@ void ViewportGadget::setOrthographic3D( bool orthographic3D )
 	m_cameraController->setOrthographic3D( orthographic3D );
 }
 
-const bool ViewportGadget::getOrthographic3D() const
+bool ViewportGadget::getOrthographic3D() const
 {
 	return m_cameraController->getOrthographic3D();
 }


### PR DESCRIPTION
These changes are necessary to compile Gaffer using the cxx flags that Houdini 17 expects.

I was uncertain if there is a more succinct c++11 way to implement 29bfd5e92a46436e00b31f53e2ec7efab5443903 and still avoid the `missing-field-initializers` error.

### Breaking Changes ###

- Path : Changed return type of a public method.
- ViewportGadget : Changed return type of a public method.