### PR TITLE
TransformTool : Support promoted plugs

### DIFF
--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -569,5 +569,24 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/group/plane" ] ) )
 		self.assertEqual( tool.handlesTransform(), imath.M44f() )
 
+	def testPromotedPlugs( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["box"] = Gaffer.Box()
+		script["box"]["sphere"] = GafferScene.Sphere()
+		Gaffer.PlugAlgo.promote( script["box"]["sphere"]["transform"] )
+		Gaffer.PlugAlgo.promote( script["box"]["sphere"]["out"] )
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["box"]["out"] )
+
+		tool = GafferSceneUI.TranslateTool( view )
+		tool["active"].setValue( True )
+
+		GafferSceneUI.ContextAlgo.setLastSelectedPath( view.getContext(), "/sphere" )
+
+		self.assertEqual( tool.selection()[0].transformPlug, script["box"]["transform"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/BoxUI.py
+++ b/python/GafferUI/BoxUI.py
@@ -234,6 +234,12 @@ def __appendPlugPromotionMenuItems( menuDefinition, plug, readOnly = False ) :
 	if box is None :
 		return
 
+	parentLabel = {
+		Gaffer.ArrayPlug : "Array",
+		Gaffer.TransformPlug : "Transform",
+		Gaffer.Transform2DPlug : "Transform",
+	}.get( type( plug.parent() ) )
+
 	if Gaffer.PlugAlgo.canPromote( plug ) :
 
 		if len( menuDefinition.items() ) :
@@ -244,8 +250,8 @@ def __appendPlugPromotionMenuItems( menuDefinition, plug, readOnly = False ) :
 			"active" : not readOnly,
 		} )
 
-		if isinstance( plug.parent(), Gaffer.ArrayPlug ) and Gaffer.PlugAlgo.canPromote( plug.parent() ) :
-			menuDefinition.append( "/Promote %s array to %s" % ( plug.parent().getName(), box.getName() ), {
+		if parentLabel and Gaffer.PlugAlgo.canPromote( plug.parent() ) :
+			menuDefinition.append( "/Promote %s to %s" % ( parentLabel, box.getName() ), {
 				"command" : functools.partial( __promote, plug.parent() ),
 				"active" : not readOnly,
 			} )
@@ -257,14 +263,15 @@ def __appendPlugPromotionMenuItems( menuDefinition, plug, readOnly = False ) :
 		if len( menuDefinition.items() ) :
 			menuDefinition.append( "/BoxDivider", { "divider" : True } )
 
-		if isinstance( plug.parent(), Gaffer.ArrayPlug ) and Gaffer.PlugAlgo.isPromoted( plug.parent() ) :
-			menuDefinition.append( "/Unpromote %s array from %s" % ( plug.parent().getName(), box.getName() ), {
+		if parentLabel and Gaffer.PlugAlgo.isPromoted( plug.parent() ) :
+			menuDefinition.append( "/Unpromote %s from %s" % ( parentLabel, box.getName() ), {
 				"command" : functools.partial( __unpromote, plug.parent() ),
 				"active" : not readOnly,
 			} )
 		else :
-			# we dont want to allow unpromoting for children of promoted arrays as it
-			# causes unpredicted behaviour, and it doesn't seem useful in general.
+			# We dont want to allow unpromoting for individual children of promoted
+			# parents because that would lead to ArrayPlugs and TransformPlugs with
+			# the unexpected number of children, which would cause crashes.
 			menuDefinition.append( "/Unpromote from %s" % box.getName(), {
 				"command" : functools.partial( __unpromote, plug ),
 				"active" : not readOnly,

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -249,6 +249,7 @@ bool updateSelection( const CapturedProcess *process, TransformTool::Selection &
 
 	if( selection.transformPlug )
 	{
+		selection.transformPlug = selection.transformPlug->source<TransformPlug>();
 		selection.upstreamScene = scenePlug;
 		selection.upstreamPath = process->context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
 		selection.upstreamContext = process->context;


### PR DESCRIPTION
This allows the author of a Box to promote transform plugs so that they can be edited via the TransformTools after referencing. 