### PR TITLE
ImageGadget : Display data window max whenever it is non-default

### DIFF
--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -914,6 +914,10 @@ void ImageGadget::doRenderLayer( Layer layer, const GafferUI::Style *style ) con
 		if( dataWindow.min != displayWindow.min )
 		{
 			renderText( lexical_cast<string>( dataWindow.min ), dataWindowF.min, V2f( 1, 1.5 ), style );
+		}
+
+		if( dataWindow.max != displayWindow.max )
+		{
 			renderText( lexical_cast<string>( dataWindow.max ), dataWindowF.max, V2f( 0, -0.5 ), style );
 		}
 	}


### PR DESCRIPTION
Tiny fix to the overlay display of the data window.  Previously, if the min corner of the dataWindow was at default, but the max was non-standard, the max value wouldn't be displayed, and you couldn't see how big the data window was.

There are a few different possible approaches here ( I debated displaying both if either is different ), but currently I've just gone for displaying min and max if they are individually different from default.