### PR TITLE
Support Arnold 5.2 in Tests

### DIFF
--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -50,6 +50,13 @@ import GafferScene
 
 class RendererTest( GafferTest.TestCase ) :
 
+	# \todo - delete all calls to this once we no longer need to support Arnold < 5.2
+	def arnoldCompat( self, a ):
+		if not arnold.AiCheckAPIVersion( "5", "2", "0" ):
+			return arnold.AtNode.from_address( a )
+		else:
+			return a
+
 	def testFactory( self ) :
 
 		self.assertTrue( "Arnold" in GafferScene.Private.IECoreScenePreview.Renderer.types() )
@@ -289,22 +296,22 @@ class RendererTest( GafferTest.TestCase ) :
 		with IECoreArnold.UniverseBlock( writable = True ) :
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
-			target = arnold.AtNode.from_address( arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "testPlane_scalarColor" ), "shader" ) )
+			target = self.arnoldCompat( arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "testPlane_scalarColor" ), "shader" ) )
 			source = arnold.AiNodeGetLink( target, "Kd_color" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( source ) ), "image" )
 
-			target = arnold.AtNode.from_address( arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "testPlane_scalarNode" ), "shader" ) )
+			target = self.arnoldCompat( arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "testPlane_scalarNode" ), "shader" ) )
 			sourcePtr = arnold.AiNodeGetPtr( target, "filtermap" )
-			source = arnold.AtNode.from_address( sourcePtr )
+			source = self.arnoldCompat( sourcePtr )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( source ) ), "gobo" )
 
-			#target = arnold.AtNode.from_address( arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "testPlane_vectorColor" ), "shader" ) )
+			#target = self.arnoldCompat( arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "testPlane_vectorColor" ), "shader" ) )
 			#source = arnold.AiNodeGetLink( target, "color[0]" )
 			#self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( source ) ), "image" )
 
-			target = arnold.AtNode.from_address( arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "testPlane_vectorNode" ), "shader" ) )
-			sourcePtr = arnold.AiNodeGetPtr( target, "filters" )
-			source = arnold.AtNode.from_address( sourcePtr )
+			target = self.arnoldCompat( arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "testPlane_vectorNode" ), "shader" ) )
+			sourcePtr = self.arnoldCompat( arnold.AiNodeGetPtr( target, "filters" ) )
+			source = sourcePtr
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( source ) ), "gobo" )
 
 	def testLightNames( self ) :
@@ -1082,8 +1089,8 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertEqual( arnold.AiNodeGetPtr( plane1, "node" ), arnold.AiNodeGetPtr( plane2, "node" ) )
 			self.assertNotEqual( arnold.AiNodeGetPtr( plane2, "node" ), arnold.AiNodeGetPtr( plane3, "node" ) )
 
-			polymesh1 = arnold.AtNode.from_address( arnold.AiNodeGetPtr( plane1, "node" ) )
-			polymesh2 = arnold.AtNode.from_address( arnold.AiNodeGetPtr( plane3, "node" ) )
+			polymesh1 = self.arnoldCompat( arnold.AiNodeGetPtr( plane1, "node" ) )
+			polymesh2 = self.arnoldCompat( arnold.AiNodeGetPtr( plane3, "node" ) )
 
 			self.assertTrue( arnold.AiNodeIs( polymesh1, "polymesh" ) )
 			self.assertTrue( arnold.AiNodeIs( polymesh2, "polymesh" ) )
@@ -1137,7 +1144,7 @@ class RendererTest( GafferTest.TestCase ) :
 					instance = arnold.AiNodeLookUpByName( interpolation + "-" + str( subdividePolygons ) )
 					self.assertTrue( arnold.AiNodeIs( instance, "ginstance" ) )
 
-					mesh = arnold.AtNode.from_address( arnold.AiNodeGetPtr( instance, "node" ) )
+					mesh = self.arnoldCompat( arnold.AiNodeGetPtr( instance, "node" ) )
 					self.assertTrue( arnold.AiNodeIs( mesh, "polymesh" ) )
 
 					if subdividePolygons and interpolation == "linear" :
@@ -1179,7 +1186,7 @@ class RendererTest( GafferTest.TestCase ) :
 				instance = arnold.AiNodeLookUpByName( "mesh-" + ( uvSmoothing or "default" ) )
 				self.assertTrue( arnold.AiNodeIs( instance, "ginstance" ) )
 
-				mesh = arnold.AtNode.from_address( arnold.AiNodeGetPtr( instance, "node" ) )
+				mesh = self.arnoldCompat( arnold.AiNodeGetPtr( instance, "node" ) )
 				self.assertTrue( arnold.AiNodeIs( mesh, "polymesh" ) )
 
 				self.assertEqual( arnold.AiNodeGetStr( mesh, "subdiv_uv_smoothing" ), uvSmoothing or "pin_corners" )
@@ -1215,7 +1222,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			instance = arnold.AiNodeLookUpByName( "myLight" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( instance ) ), "ginstance" )
-			mesh = arnold.AtNode.from_address( arnold.AiNodeGetPtr( instance, "node" ) )
+			mesh = self.arnoldCompat( arnold.AiNodeGetPtr( instance, "node" ) )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( mesh ) ), "polymesh" )
 
 			lights = self.__allNodes( type = arnold.AI_NODE_LIGHT )
@@ -1272,7 +1279,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			self.assertEqual( arnold.AiNodeGetPtr( instance1, "node" ), arnold.AiNodeGetPtr( instance2, "node" ) )
 
-			mesh = arnold.AtNode.from_address( arnold.AiNodeGetPtr( instance1, "node" ) )
+			mesh = self.arnoldCompat( arnold.AiNodeGetPtr( instance1, "node" ) )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( mesh ) ), "polymesh" )
 
 			lights = self.__allNodes( type = arnold.AI_NODE_LIGHT )
@@ -1349,7 +1356,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			n = arnold.AiNodeLookUpByName( "testPlane" )
 
-			add = arnold.AtNode.from_address( arnold.AiNodeGetPtr( n, "shader" ) )
+			add = self.arnoldCompat( arnold.AiNodeGetPtr( n, "shader" ) )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( add ) ), "add" )
 
 			spline = arnold.AiNodeGetLink( add, "input1" )
@@ -1402,7 +1409,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			n = arnold.AiNodeLookUpByName( "testPlane" )
 
-			noise = arnold.AtNode.from_address( arnold.AiNodeGetPtr( n, "shader" ) )
+			noise = self.arnoldCompat( arnold.AiNodeGetPtr( n, "shader" ) )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( noise ) ), "osl" )
 			self.assertEqual( arnold.AiNodeGetStr( noise, "shadername" ), "Pattern/Noise" )
 
@@ -1448,7 +1455,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			n = arnold.AiNodeLookUpByName( "testPlane" )
 
-			floatToColor = arnold.AtNode.from_address( arnold.AiNodeGetPtr( n, "shader" ) )
+			floatToColor = self.arnoldCompat( arnold.AiNodeGetPtr( n, "shader" ) )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( floatToColor ) ), "osl" )
 			self.assertEqual( arnold.AiNodeGetStr( floatToColor, "shadername" ), "Conversion/FloatToColor" )
 
@@ -1612,7 +1619,7 @@ class RendererTest( GafferTest.TestCase ) :
 				instance = arnold.AiNodeLookUpByName( name )
 				self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( instance ) ), "ginstance" )
 
-				shape = arnold.AtNode.from_address( arnold.AiNodeGetPtr( instance, "node" ) )
+				shape = self.arnoldCompat( arnold.AiNodeGetPtr( instance, "node" ) )
 				self.assertEqual( arnold.AiNodeGetFlt( shape, "min_pixel_width" ), minPixelWidth )
 				self.assertEqual( arnold.AiNodeGetStr( shape, "mode" ), mode )
 
@@ -1772,7 +1779,7 @@ class RendererTest( GafferTest.TestCase ) :
 				for an, a in attributes.items() :
 
 					instance = arnold.AiNodeLookUpByName( pn + "_" + an )
-					shape = arnold.AtNode.from_address( arnold.AiNodeGetPtr( instance, "node" ) )
+					shape = self.arnoldCompat( arnold.AiNodeGetPtr( instance, "node" ) )
 
 					stepSize = a.get( "ai:shape:step_size" )
 					stepSize = stepSize.value if stepSize is not None else 0
@@ -1872,7 +1879,7 @@ class RendererTest( GafferTest.TestCase ) :
 				for an, a in attributes.items() :
 
 					instance = arnold.AiNodeLookUpByName( pn + "_" + an )
-					shape = arnold.AtNode.from_address( arnold.AiNodeGetPtr( instance, "node" ) )
+					shape = self.arnoldCompat( arnold.AiNodeGetPtr( instance, "node" ) )
 
 					volumePadding = a.get( "ai:shape:volume_padding" )
 					volumePadding = volumePadding.value if volumePadding is not None else 0
@@ -1926,7 +1933,7 @@ class RendererTest( GafferTest.TestCase ) :
 			instance = arnold.AiNodeLookUpByName( "test" )
 			self.assertTrue( arnold.AiNodeIs( instance, "ginstance" ) )
 
-			shape = arnold.AtNode.from_address( arnold.AiNodeGetPtr( instance, "node" ) )
+			shape = self.arnoldCompat( arnold.AiNodeGetPtr( instance, "node" ) )
 			self.assertTrue( arnold.AiNodeIs( shape, "volume" ) )
 			self.assertEqual( arnold.AiNodeGetFlt( shape, "step_size" ), 0.25 )
 
@@ -2138,7 +2145,7 @@ class RendererTest( GafferTest.TestCase ) :
 			IECore.ObjectVector( [ IECoreScene.Shader( "atmosphere_volume", "ai:shader" ) ] )
 		)
 
-		shader = arnold.AtNode.from_address( arnold.AiNodeGetPtr( options, "atmosphere" ) )
+		shader = self.arnoldCompat( arnold.AiNodeGetPtr( options, "atmosphere" ) )
 		self.assertEqual(
 			arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( shader ) ),
 			"atmosphere_volume",
@@ -2162,7 +2169,7 @@ class RendererTest( GafferTest.TestCase ) :
 			IECore.ObjectVector( [ IECoreScene.Shader( "flat", "ai:shader" ) ] )
 		)
 
-		shader = arnold.AtNode.from_address( arnold.AiNodeGetPtr( options, "background" ) )
+		shader = self.arnoldCompat( arnold.AiNodeGetPtr( options, "background" ) )
 		self.assertEqual(
 			arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( shader ) ),
 			"flat",
@@ -2228,7 +2235,7 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertEqual( numVDBs, 1 )
 
 			vdbInstance = arnold.AiNodeLookUpByName( "test_vdb" )
-			vdbShape = arnold.AtNode.from_address( arnold.AiNodeGetPtr( vdbInstance, "node" ) )
+			vdbShape = self.arnoldCompat( arnold.AiNodeGetPtr( vdbInstance, "node" ) )
 
 			self.assertEqual( arnold.AiNodeGetFlt( vdbShape, "velocity_scale" ), 10 )
 			self.assertEqual( arnold.AiNodeGetFlt( vdbShape, "velocity_fps" ), 25 )
@@ -2277,7 +2284,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			nodePtr = arnold.AiNodeGetPtr( instanceNode, "node" )
 			self.assertEqual( nodePtr, arnold.AiNodeGetPtr( firstInstanceNode, "node" ) )
-			self.assertEqual( arnold.AiNodeGetByte( arnold.AtNode.from_address( nodePtr ), "visibility" ), 0 )
+			self.assertEqual( arnold.AiNodeGetByte( self.arnoldCompat( nodePtr ), "visibility" ), 0 )
 
 	def __assertNotInstanced( self, *names ) :
 


### PR DESCRIPTION
For initial discussion:  it looks like everything works fine when compiling with Arnold 5.2, but a bunch of tests were broken by a Python API change.

This would update the tests to work with Arnold 5.2 - though thinking about it, if this is the only changes, it might be worth adding a runtime check of Arnold version to trigger a switch to the old way.  Or do we want to immediately start taking advantage of the new APIs anyway, so we shouldn't worry about backwards compatibility.