### PR TITLE
 ImageTransform : Implement concatenation

### DIFF
--- a/include/GafferImage/ImageTransform.h
+++ b/include/GafferImage/ImageTransform.h
@@ -72,10 +72,16 @@ class GAFFERIMAGE_API ImageTransform : public FlatImageProcessor
 		Gaffer::BoolPlug *invertPlug();
 		const Gaffer::BoolPlug *invertPlug() const;
 
+		Gaffer::BoolPlug *concatenatePlug();
+		const Gaffer::BoolPlug *concatenatePlug() const;
+
 	protected :
 
 		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+
+		void hashDeep( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		bool computeDeep( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 		void hashDataWindow( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
@@ -99,6 +105,16 @@ class GAFFERIMAGE_API ImageTransform : public FlatImageProcessor
 		Resample *resample();
 		const Resample *resample() const;
 
+		// Plugs used to concatenate transforms through a
+		// chain of connected ImageTransforms.
+		Gaffer::M33fPlug *inTransformPlug();
+		const Gaffer::M33fPlug *inTransformPlug() const;
+		Gaffer::M33fPlug *outTransformPlug();
+		const Gaffer::M33fPlug *outTransformPlug() const;
+
+		class ChainingScope;
+		class CleanScope;
+
 		enum Operation
 		{
 			Identity = 0,
@@ -108,6 +124,7 @@ class GAFFERIMAGE_API ImageTransform : public FlatImageProcessor
 		};
 
 		unsigned operation( Imath::M33f &matrix, Imath::M33f &resampleMatrix ) const;
+		void plugInputChanged( Gaffer::Plug *plug );
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferImage/ImageTransform.h
+++ b/include/GafferImage/ImageTransform.h
@@ -108,7 +108,6 @@ class GAFFERIMAGE_API ImageTransform : public FlatImageProcessor
 		};
 
 		unsigned operation( Imath::M33f &matrix, Imath::M33f &resampleMatrix ) const;
-		Imath::Box2i sampler( unsigned op, const Imath::M33f &matrix, const Imath::M33f &resampleMatrix, const Imath::V2i &tileOrigin, const ImagePlug *&samplerImage, Imath::M33f &samplerMatrix ) const;
 
 		static size_t g_firstPlugIndex;
 

--- a/python/GafferImageTest/ImageTransformTest.py
+++ b/python/GafferImageTest/ImageTransformTest.py
@@ -345,5 +345,110 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertImagesEqual( r["out"], tInv["out"], maxDifference = 0.5, ignoreDataWindow=True )
 
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testRotationPerformance( self ) :
+
+		checker = GafferImage.Checkerboard()
+		checker["format"].setValue( GafferImage.Format( 3000, 3000 ) )
+
+		transform = GafferImage.ImageTransform()
+		transform["in"].setInput( checker["out"] )
+		transform["transform"]["pivot"].setValue( imath.V2f( 1500 ) )
+		transform["transform"]["rotate"].setValue( 2.5 )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( transform["out"] )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testTranslationPerformance( self ) :
+
+		checker = GafferImage.Checkerboard()
+		checker["format"].setValue( GafferImage.Format( 3000, 3000 ) )
+
+		transform = GafferImage.ImageTransform()
+		transform["in"].setInput( checker["out"] )
+		transform["transform"]["translate"].setValue( imath.V2f( 2.2 ) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( transform["out"] )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testDownsizingPerformance( self ) :
+
+		checker = GafferImage.Checkerboard()
+		checker["format"].setValue( GafferImage.Format( 3000, 3000 ) )
+
+		transform = GafferImage.ImageTransform()
+		transform["in"].setInput( checker["out"] )
+		transform["transform"]["scale"].setValue( imath.V2f( 0.1 ) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( transform["out"] )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testUpsizingPerformance( self ) :
+
+		checker = GafferImage.Checkerboard()
+		checker["format"].setValue( GafferImage.Format( 1000, 1000 ) )
+
+		transform = GafferImage.ImageTransform()
+		transform["in"].setInput( checker["out"] )
+		transform["transform"]["scale"].setValue( imath.V2f( 3 ) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( transform["out"] )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testRotationAndScalingPerformance( self ) :
+
+		checker = GafferImage.Checkerboard()
+		checker["format"].setValue( GafferImage.Format( 3000, 3000 ) )
+
+		transform = GafferImage.ImageTransform()
+		transform["in"].setInput( checker["out"] )
+		transform["transform"]["pivot"].setValue( imath.V2f( 1500 ) )
+		transform["transform"]["rotate"].setValue( 2.5 )
+		transform["transform"]["scale"].setValue( imath.V2f( 0.75 ) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( transform["out"] )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testConcatenationPerformance1( self ) :
+
+		checker = GafferImage.Checkerboard()
+		checker["format"].setValue( GafferImage.Format( 3000, 3000 ) )
+
+		transform1 = GafferImage.ImageTransform( "Transform1" )
+		transform1["in"].setInput( checker["out"] )
+		transform1["transform"]["pivot"].setValue( imath.V2f( 1500 ) )
+		transform1["transform"]["rotate"].setValue( 2.5 )
+
+		transform2 = GafferImage.ImageTransform( "Transform2" )
+		transform2["in"].setInput( transform1["out"] )
+		transform2["transform"]["translate"].setValue( imath.V2f( 10 ) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( transform2["out"] )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testConcatenationPerformance2( self ) :
+
+		checker = GafferImage.Checkerboard()
+		checker["format"].setValue( GafferImage.Format( 3000, 3000 ) )
+
+		transform1 = GafferImage.ImageTransform( "Transform1" )
+		transform1["in"].setInput( checker["out"] )
+		transform1["transform"]["pivot"].setValue( imath.V2f( 1500 ) )
+		transform1["transform"]["rotate"].setValue( 2.5 )
+		transform1["transform"]["scale"].setValue( imath.V2f( 1.1 ) )
+
+		transform2 = GafferImage.ImageTransform( "Transform2" )
+		transform2["in"].setInput( transform1["out"] )
+		transform2["transform"]["translate"].setValue( imath.V2f( 10 ) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( transform2["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageUI/ImageTransformUI.py
+++ b/python/GafferImageUI/ImageTransformUI.py
@@ -92,7 +92,25 @@ Gaffer.Metadata.registerNode(
 			"""
 			Apply the inverse transformation to the image.
 			"""
-		]
+		],
+
+		"concatenate" : [
+
+			"description",
+
+			"""
+			Combines the processing for a series of ImageTransforms so that
+			transformation and filtering is only applied once. This gives better
+			image quality and performance.
+
+			> Note : When concatenation is in effect, the filter settings on upstream
+			> ImageTransforms are ignored.
+			""",
+
+			"layout:section", "Node",
+			"layout:index", -1,
+
+		],
 
 	}
 


### PR DESCRIPTION
This is a slight rejig of @lucienfostier's #2751.

- Removed the `scoped_connection` member, because it's not necessary.
- Used ContextMonitor to simplify the context leakage test. This revealed some additional bugs.
- Refactored the context logic into the ChainingScope utility class. This makes the changes to the various hash/compute quite a bit simpler, and also fixes the context leakage bug. Another reason I did this is because I'm interested in using the concatenation pattern for other nodes, and this seemed like a standardisable approach.
- Fixed a bug whereby the private __inTransform plug had its connection serialised into the script.
- Fixed a nasty hashing bug that took me ages to track down (rotate must now be taken into account for the resampleMatrixPlug).
- Fixed another hashing bug (must call base class first, not last).
- Made the no-op chaining operations perfect pass-throughs (identical hashes) so that they share the same cache entries, rather than populate the cache with duplicate tiles.
- Added some additional tests.

Lucien, despite these changes, your original concatenation scheme is still very much intact; it's just the details of the implementation that have changed. I'm pleased to say that it is an impressive improvement both in performance and filtering, so thanks very much for taking the initiative with it!

Question for the gallery : what do you think to the representation of the concatenation in the GraphEditor?

![concat](https://user-images.githubusercontent.com/1133871/46868957-20d77080-ce22-11e8-9a70-5209427e56ab.png)

I've found it really handy to have a visualisation for it, but it's a little odd that we're showing auxiliary connections for private plugs. I believe we're doing that because our primary usage of auxiliary connections is the Expression node, and the connections we want to see there are to private plugs (for now, they'll become public in the planned refactor). So, should we hide the concatentation connections, keep 'em as is, or add a different visualisation? Bear in mind I don't really have any time available for spending on the latter...
