### PR TITLE
TaskNode : Fix bugs preventing implementation via internal network

### DIFF
--- a/src/GafferDispatch/TaskNode.cpp
+++ b/src/GafferDispatch/TaskNode.cpp
@@ -388,7 +388,7 @@ void TaskNode::preTasks( const Context *context, Tasks &tasks ) const
 	for( PlugIterator cIt( preTasksPlug() ); !cIt.done(); ++cIt )
 	{
 		Plug *source = (*cIt)->source();
-		if( source != *cIt )
+		if( source != *cIt && source->direction() == Plug::Out )
 		{
 			if( TaskNodePtr n = runTimeCast<TaskNode>( source->node() ) )
 			{
@@ -403,7 +403,7 @@ void TaskNode::postTasks( const Context *context, Tasks &tasks ) const
 	for( PlugIterator cIt( postTasksPlug() ); !cIt.done(); ++cIt )
 	{
 		Plug *source = (*cIt)->source();
-		if( source != *cIt )
+		if( source != *cIt && source->direction() == Plug::Out )
 		{
 			if( TaskNodePtr n = runTimeCast<TaskNode>( source->node() ) )
 			{


### PR DESCRIPTION
Just as with SceneProcessor and ImageProcessor, we want to allow TaskNode to be subclassed in Python, with the implementation being provided entirely by an internal subnet built in the constructor. This provides the convenience of Python for setup, but without the overhead of actually running Python code during dispatch.

The bug here was that the `preTasks()` and `postTasks()` methods for the internal node were creating tasks not only for the connected external plugs, but also for the unconnected last element of the array. This led to an attempt to create a task for the TaskSubnet node itself, which led to cyclic evaluation. The solution is to only create tasks for output plugs, which we know to be the task outputs from other nodes.
