### PR TITLE
TransformTool : Add `selectionChangedSignal()`

### DIFF
--- a/include/GafferSceneUI/TransformTool.h
+++ b/include/GafferSceneUI/TransformTool.h
@@ -139,6 +139,9 @@ class GAFFERSCENEUI_API TransformTool : public GafferSceneUI::SelectionTool
 
 		const std::vector<Selection> &selection() const;
 
+		using SelectionChangedSignal = boost::signal<void (TransformTool &)>;
+		SelectionChangedSignal &selectionChangedSignal();
+
 		/// Returns the transform of the handles. Throws
 		/// if the selection is invalid because then the
 		/// transform would be meaningless. This is
@@ -196,9 +199,11 @@ class GAFFERSCENEUI_API TransformTool : public GafferSceneUI::SelectionTool
 		boost::signals::scoped_connection m_contextChangedConnection;
 
 		GafferUI::GadgetPtr m_handles;
+		bool m_handlesDirty;
+
 		mutable std::vector<Selection> m_selection;
 		mutable bool m_selectionDirty;
-		bool m_handlesDirty;
+		SelectionChangedSignal m_selectionChangedSignal;
 
 		bool m_dragging;
 		int m_mergeGroupId;
@@ -206,6 +211,8 @@ class GAFFERSCENEUI_API TransformTool : public GafferSceneUI::SelectionTool
 		static size_t g_firstPlugIndex;
 
 };
+
+IE_CORE_DECLAREPTR( TransformTool )
 
 } // namespace GafferSceneUI
 

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -42,6 +42,7 @@ import imath
 import IECore
 
 import Gaffer
+import GafferTest
 import GafferUITest
 import GafferScene
 import GafferSceneUI
@@ -587,6 +588,22 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		GafferSceneUI.ContextAlgo.setLastSelectedPath( view.getContext(), "/sphere" )
 
 		self.assertEqual( tool.selection()[0].transformPlug, script["box"]["transform"] )
+
+	def testSelectionChangedSignal( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["plane"] = GafferScene.Plane()
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["plane"]["out"] )
+
+		tool = GafferSceneUI.TranslateTool( view )
+		tool["active"].setValue( True )
+
+		cs = GafferTest.CapturingSlot( tool.selectionChangedSignal() )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/plane" ] ) )
+		self.assertTrue( len( cs ) )
+		self.assertEqual( cs[0][0], tool )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This is the underlying basis of https://github.com/GafferHQ/gaffer/issues/2753. It would be great to squeeze this into 0.51 because it contains an ABI break.