### PR TITLE
GafferScene : Restore FilterSwitch/UnionFilter compatibility

### DIFF
--- a/python/GafferSceneTest/FilterProcessorTest.py
+++ b/python/GafferSceneTest/FilterProcessorTest.py
@@ -1,0 +1,74 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+class FilterProcessorTest( GafferSceneTest.SceneTestCase ) :
+
+	def testLoadFromVersion0_27( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/filterProcessor-0.27.0.0.gfr" )
+		s.load()
+
+		self.assertEqual( len( s["FilterSwitch"]["in"] ), 3 )
+		for c in s["FilterSwitch"]["in"] :
+			self.assertIsInstance( c, GafferScene.FilterPlug )
+
+		self.assertEqual( len( s["UnionFilter"]["in"] ), 3 )
+		for c in s["UnionFilter"]["in"] :
+			self.assertIsInstance( c, GafferScene.FilterPlug )
+
+		self.assertEqual( s["FilterSwitch"]["in"][0].getInput(), s["PathFilter"]["out"] )
+		self.assertEqual( s["FilterSwitch"]["in"][1].getInput(), s["PathFilter1"]["out"] )
+		self.assertEqual( s["FilterSwitch"]["in"][2].getInput(), None )
+
+		self.assertEqual( s["UnionFilter"]["in"][0].getInput(), s["FilterSwitch"]["out"] )
+		self.assertEqual( s["UnionFilter"]["in"][1].getInput(), s["PathFilter2"]["out"] )
+		self.assertEqual( s["UnionFilter"]["in"][2].getInput(), None )
+		self.assertEqual( s["UnionFilter"]["in"][2].getValue(), IECore.PathMatcher.Result.NoMatch )
+
+		self.assertEqual( s["ShaderAssignment"]["filter"].getInput(), s["UnionFilter"]["out"] )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -133,6 +133,7 @@ from CollectPrimitiveVariablesTest import CollectPrimitiveVariablesTest
 from PrimitiveVariableExistsTest import PrimitiveVariableExistsTest
 from CollectTransformsTest import CollectTransformsTest
 from CameraTweaksTest import CameraTweaksTest
+from FilterProcessorTest import FilterProcessorTest
 
 from IECoreGLPreviewTest import *
 

--- a/python/GafferSceneTest/scripts/filterProcessor-0.27.0.0.gfr
+++ b/python/GafferSceneTest/scripts/filterProcessor-0.27.0.0.gfr
@@ -1,0 +1,57 @@
+import Gaffer
+import GafferScene
+import IECore
+
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:majorVersion", 27, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:minorVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectName", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:name', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectRootDirectory", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:rootDirectory', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["FilterSwitch"] = GafferScene.FilterSwitch( "FilterSwitch" )
+parent.addChild( __children["FilterSwitch"] )
+__children["FilterSwitch"]["in"].addChild( Gaffer.IntPlug( "in1", defaultValue = 0, minValue = 0, maxValue = 7, flags = ( Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) & ~Gaffer.Plug.Flags.Cacheable, ) )
+__children["FilterSwitch"]["in"].addChild( Gaffer.IntPlug( "in2", defaultValue = 0, minValue = 0, maxValue = 7, flags = ( Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) & ~Gaffer.Plug.Flags.Cacheable, ) )
+__children["FilterSwitch"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = IECore.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["FilterSwitch"]["__uiPosition"].setValue( IECore.V2f( 8.13020325, 7.3537488 ) )
+__children["UnionFilter"] = GafferScene.UnionFilter( "UnionFilter" )
+parent.addChild( __children["UnionFilter"] )
+__children["UnionFilter"]["in"].addChild( Gaffer.IntPlug( "in1", defaultValue = 0, minValue = 0, maxValue = 7, flags = ( Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) & ~Gaffer.Plug.Flags.Cacheable, ) )
+__children["UnionFilter"]["in"].addChild( Gaffer.IntPlug( "in2", defaultValue = 0, minValue = 0, maxValue = 7, flags = ( Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) & ~Gaffer.Plug.Flags.Cacheable, ) )
+__children["UnionFilter"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = IECore.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["UnionFilter"]["__uiPosition"].setValue( IECore.V2f( 16.1300735, -1.81031334 ) )
+__children["PathFilter"] = GafferScene.PathFilter( "PathFilter" )
+parent.addChild( __children["PathFilter"] )
+__children["PathFilter"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = IECore.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["PathFilter"]["__uiPosition"].setValue( IECore.V2f( 0.130414695, 16.5178165 ) )
+__children["PathFilter1"] = GafferScene.PathFilter( "PathFilter1" )
+parent.addChild( __children["PathFilter1"] )
+__children["PathFilter1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = IECore.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["PathFilter1"]["__uiPosition"].setValue( IECore.V2f( 13.130415, 16.5178108 ) )
+__children["PathFilter2"] = GafferScene.PathFilter( "PathFilter2" )
+parent.addChild( __children["PathFilter2"] )
+__children["PathFilter2"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = IECore.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["PathFilter2"]["__uiPosition"].setValue( IECore.V2f( 21.1302032, 7.35545874 ) )
+__children["ShaderAssignment"] = GafferScene.ShaderAssignment( "ShaderAssignment" )
+parent.addChild( __children["ShaderAssignment"] )
+__children["ShaderAssignment"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = IECore.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["ShaderAssignment"]["__uiPosition"].setValue( IECore.V2f( 4.35710764, -8.89234447 ) )
+parent["variables"]["projectName"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+parent["variables"]["projectRootDirectory"]["name"].setFlags( Gaffer.Plug.Flags.ReadOnly, True )
+__children["FilterSwitch"]["out"].setInput( __children["FilterSwitch"]["in"]["in0"] )
+__children["FilterSwitch"]["in"]["in0"].setInput( __children["PathFilter"]["out"] )
+__children["FilterSwitch"]["in"]["in1"].setInput( __children["PathFilter1"]["out"] )
+__children["UnionFilter"]["in"]["in0"].setInput( __children["FilterSwitch"]["out"] )
+__children["UnionFilter"]["in"]["in1"].setInput( __children["PathFilter2"]["out"] )
+__children["ShaderAssignment"]["filter"].setInput( __children["UnionFilter"]["out"] )
+
+
+del __children
+


### PR DESCRIPTION
This allows files from versions prior to 0.28.0.0 to continue to be loaded. We now auto-convert obsolete FilterProcessor IntPlug inputs into FilterPlug inputs during loading.
