### PR TITLE
Docs : Fix "Script Performance" link in index.md

### DIFF
--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -23,7 +23,7 @@ To start, you should:
 If you are are looking to automate VFX processes or develop with Gaffer's API, you should also:
 
 * Complete the [Getting Started in Scripting tutorial](Tutorials/Scripting/GettingStarted/index.md)
-* Complete the [Managing Complexity tutorial](Tutorials/ManagingComplexity/index.md)
+* Familiarize yourself with the [Performance Best Practices](ScriptPerformance/PerformanceBestPractices/index.md) for node graphs.
 
 
 <!-- TOC -->


### PR DESCRIPTION
The link in the docs homepage points to an article that no longer exists.

### Related Issues ###
- https://github.com/gafferHQ/gaffer/issues/2856

### Checklist ###
- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
