### PR TITLE
Missing private headers when installing GafferScene headers

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -684,7 +684,7 @@ libraries = {
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferBindings", "GafferScene", "GafferDispatch", "IECoreScene$CORTEX_LIB_SUFFIX" ],
 		},
-		"additionalFiles" : glob.glob( "glsl/*.frag" ) + glob.glob( "glsl/*.vert" ) + ["include/GafferScene/Private/IECoreGLPreview/AttributeVisualiser.h"]
+		"additionalFiles" : glob.glob( "glsl/*.frag" ) + glob.glob( "glsl/*.vert" ) + glob.glob( "include/GafferScene/Private/*/*.h" )
 	},
 
 	"GafferSceneTest" : {


### PR DESCRIPTION
This is needed for building external renderers against the official releases.

Feel free to ignore if you plan to merge the renderer API into cortex eventually and don't want it installed, but this would be great as I am building/testing [GafferCycles]( https://github.com/boberfly/GafferCycles) externally and against the official releases...