### PR TITLE
SConstruct : Install IECore*Preview headers

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -684,7 +684,7 @@ libraries = {
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferBindings", "GafferScene", "GafferDispatch", "IECoreScene$CORTEX_LIB_SUFFIX" ],
 		},
-		"additionalFiles" : glob.glob( "glsl/*.frag" ) + glob.glob( "glsl/*.vert" ) + ["include/GafferScene/Private/IECoreGLPreview/AttributeVisualiser.h"]
+		"additionalFiles" : glob.glob( "glsl/*.frag" ) + glob.glob( "glsl/*.vert" ) + glob.glob( "include/GafferScene/Private/IECore*Preview/*.h" )
 	},
 
 	"GafferSceneTest" : {


### PR DESCRIPTION
Although these are marked as private, they're private in the sense of "in flux, they'll be public in cortex one day", not "internal details never to be touched". So it's pragmatic to allow their use by interested parties, with the proviso that they can change at any time.
