### PR TITLE
GafferScene config : Make FilterProcessor compatibility work with Boxes

### DIFF
--- a/python/GafferSceneTest/FilterProcessorTest.py
+++ b/python/GafferSceneTest/FilterProcessorTest.py
@@ -70,5 +70,30 @@ class FilterProcessorTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual( s["ShaderAssignment"]["filter"].getInput(), s["UnionFilter"]["out"] )
 
+	def testLoadBoxedFromVersion0_27( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/filterProcessorBoxed-0.27.0.0.gfr" )
+		s.load()
+
+		self.assertEqual( len( s["Box"]["FilterSwitch"]["in"] ), 3 )
+		for c in s["Box"]["FilterSwitch"]["in"] :
+			self.assertIsInstance( c, GafferScene.FilterPlug )
+
+		self.assertEqual( len( s["Box"]["UnionFilter"]["in"] ), 3 )
+		for c in s["Box"]["UnionFilter"]["in"] :
+			self.assertIsInstance( c, GafferScene.FilterPlug )
+
+		self.assertEqual( s["Box"]["FilterSwitch"]["in"][0].getInput(), s["Box"]["PathFilter"]["out"] )
+		self.assertEqual( s["Box"]["FilterSwitch"]["in"][1].getInput(), s["Box"]["PathFilter1"]["out"] )
+		self.assertEqual( s["Box"]["FilterSwitch"]["in"][2].getInput(), None )
+
+		self.assertEqual( s["Box"]["UnionFilter"]["in"][0].getInput(), s["Box"]["FilterSwitch"]["out"] )
+		self.assertEqual( s["Box"]["UnionFilter"]["in"][1].getInput(), s["Box"]["PathFilter2"]["out"] )
+		self.assertEqual( s["Box"]["UnionFilter"]["in"][2].getInput(), None )
+		self.assertEqual( s["Box"]["UnionFilter"]["in"][2].getValue(), IECore.PathMatcher.Result.NoMatch )
+
+		self.assertEqual( s["Box"]["ShaderAssignment"]["filter"].getInput(), s["Box"]["UnionFilter"]["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/scripts/filterProcessorBoxed-0.27.0.0.gfr
+++ b/python/GafferSceneTest/scripts/filterProcessorBoxed-0.27.0.0.gfr
@@ -1,0 +1,48 @@
+import Gaffer
+import GafferScene
+import IECore
+import imath
+
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:majorVersion", 49, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:minorVersion", 1, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+__children["Box"] = Gaffer.Box( "Box" )
+parent.addChild( __children["Box"] )
+__children["Box"].addChild( GafferScene.FilterSwitch( "FilterSwitch" ) )
+__children["Box"]["FilterSwitch"]["in"].addChild( Gaffer.IntPlug( "in1", defaultValue = 0, minValue = 0, maxValue = 7, flags = ( Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) & ~Gaffer.Plug.Flags.Cacheable, ) )
+__children["Box"]["FilterSwitch"]["in"].addChild( Gaffer.IntPlug( "in2", defaultValue = 0, minValue = 0, maxValue = 7, flags = ( Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) & ~Gaffer.Plug.Flags.Cacheable, ) )
+__children["Box"]["FilterSwitch"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Box"].addChild( GafferScene.UnionFilter( "UnionFilter" ) )
+__children["Box"]["UnionFilter"]["in"].addChild( Gaffer.IntPlug( "in1", defaultValue = 0, minValue = 0, maxValue = 7, flags = ( Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) & ~Gaffer.Plug.Flags.Cacheable, ) )
+__children["Box"]["UnionFilter"]["in"].addChild( Gaffer.IntPlug( "in2", defaultValue = 0, minValue = 0, maxValue = 7, flags = ( Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) & ~Gaffer.Plug.Flags.Cacheable, ) )
+__children["Box"]["UnionFilter"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Box"].addChild( GafferScene.PathFilter( "PathFilter" ) )
+__children["Box"]["PathFilter"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Box"].addChild( GafferScene.PathFilter( "PathFilter1" ) )
+__children["Box"]["PathFilter1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Box"].addChild( GafferScene.PathFilter( "PathFilter2" ) )
+__children["Box"]["PathFilter2"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Box"].addChild( GafferScene.ShaderAssignment( "ShaderAssignment" ) )
+__children["Box"]["ShaderAssignment"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Box"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Box"]["FilterSwitch"]["out"].setInput( __children["Box"]["FilterSwitch"]["in"]["in0"] )
+__children["Box"]["FilterSwitch"]["in"]["in0"].setInput( __children["Box"]["PathFilter"]["out"] )
+__children["Box"]["FilterSwitch"]["in"]["in1"].setInput( __children["Box"]["PathFilter1"]["out"] )
+__children["Box"]["FilterSwitch"]["__uiPosition"].setValue( imath.V2f( -21.050106, 0.49101162 ) )
+__children["Box"]["UnionFilter"]["in"]["in0"].setInput( __children["Box"]["FilterSwitch"]["out"] )
+__children["Box"]["UnionFilter"]["in"]["in1"].setInput( __children["Box"]["PathFilter2"]["out"] )
+__children["Box"]["UnionFilter"]["__uiPosition"].setValue( imath.V2f( -13.0502367, -8.67304993 ) )
+__children["Box"]["PathFilter"]["__uiPosition"].setValue( imath.V2f( -29.0498962, 9.65507889 ) )
+__children["Box"]["PathFilter1"]["__uiPosition"].setValue( imath.V2f( -16.0498962, 9.65507317 ) )
+__children["Box"]["PathFilter2"]["__uiPosition"].setValue( imath.V2f( -8.050107, 0.492721558 ) )
+__children["Box"]["ShaderAssignment"]["filter"].setInput( __children["Box"]["UnionFilter"]["out"] )
+__children["Box"]["ShaderAssignment"]["__uiPosition"].setValue( imath.V2f( -24.8232021, -15.7550812 ) )
+__children["Box"]["__uiPosition"].setValue( imath.V2f( 1.89942265, -8.6056385 ) )
+
+
+del __children
+

--- a/startup/GafferScene/switchCompatibility.py
+++ b/startup/GafferScene/switchCompatibility.py
@@ -97,11 +97,12 @@ def __filterProcessorGetItemWrapper( originalGetItem ) :
 
 		result = originalGetItem( self, key )
 		if key == "in" and isinstance( result, Gaffer.ArrayPlug ) :
-			result.addChild = types.MethodType( __filterProcessorAddChild, result )
+			if len( result ) and isinstance( result[0], GafferScene.FilterPlug ) :
+				result.addChild = types.MethodType( __filterProcessorAddChild, result )
 
 		return result
 
 	return getItem
 
-GafferScene.FilterSwitch.__getitem__ = __filterProcessorGetItemWrapper( GafferScene.FilterSwitch.__getitem__ )
+Gaffer.Switch.__getitem__ = __filterProcessorGetItemWrapper( Gaffer.Switch.__getitem__ )
 GafferScene.FilterProcessor.__getitem__ = __filterProcessorGetItemWrapper( GafferScene.FilterProcessor.__getitem__ )


### PR DESCRIPTION
The previous fix only overrode `GafferScene.FilterSwitch.__getitem__`, but when a node is retrieved from a Box, it emerges as just a `Gaffer.Switch`. This is because the Python compatibility shim for `FilterSwitch` isn't a full wrapped class, so the Python part of the type is forgotten on a trip into C++ and back out again. We now override `Gaffer.Switch.__getitem__` and check to see if the first element of the array is a `FilterPlug`, performing the convert-on-load behaviour if it is.
