### PR TITLE
Bookmark search

### DIFF
--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -302,8 +302,7 @@ class SceneInspector( GafferUI.NodeSetEditor ) :
 
 			for section in self.__sections :
 				section.update( targets )
-
-			self.setEnabled( bool( targets ) )
+				section.setEnabled( section.getEnabled() and bool( targets ) )
 
 			return False # remove idle callback
 

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -408,6 +408,18 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 		self.assertEqual( len( affected ), 5 )
 		self.assertEqual( affected[-1], set() )
 
+	def testUnbookmarkedNodesDontHaveMetadata( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.Node()
+		self.assertEqual( len( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True ) ), 0 )
+
+		Gaffer.MetadataAlgo.setBookmarked( s["n"], True )
+		self.assertEqual( len( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True ) ), 1 )
+
+		Gaffer.MetadataAlgo.setBookmarked( s["n"], False )
+		self.assertEqual( len( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True ) ), 0 )
+
 	def tearDown( self ) :
 
 		for n in ( Gaffer.Node, Gaffer.Box, GafferTest.AddNode ) :

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -35,6 +35,8 @@
 ##########################################################################
 
 import unittest
+import os
+
 import imath
 
 import IECore
@@ -419,6 +421,19 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 
 		Gaffer.MetadataAlgo.setBookmarked( s["n"], False )
 		self.assertEqual( len( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True ) ), 0 )
+
+	def testLoadLegacyBookmarks( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/legacyBookmarks.gfr" )
+		s.load()
+
+		self.assertTrue( Gaffer.MetadataAlgo.getBookmarked( s["Bookmarked"] ) )
+		self.assertEqual( len( Gaffer.Metadata.registeredValues( s["Bookmarked"], instanceOnly = True ) ), 1 )
+		self.assertFalse( Gaffer.MetadataAlgo.getBookmarked( s["Unbookmarked"] ) )
+		self.assertEqual( len( Gaffer.Metadata.registeredValues( s["Unbookmarked"], instanceOnly = True ) ), 0 )
+		self.assertTrue( Gaffer.MetadataAlgo.getBookmarked( s["OldBookmarked"] ) )
+		self.assertEqual( len( Gaffer.Metadata.registeredValues( s["OldBookmarked"], instanceOnly = True ) ), 1 )
 
 	def tearDown( self ) :
 

--- a/python/GafferTest/scripts/legacyBookmarks.gfr
+++ b/python/GafferTest/scripts/legacyBookmarks.gfr
@@ -1,0 +1,30 @@
+import Gaffer
+import IECore
+import imath
+
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:majorVersion", 51, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:minorVersion", 0, persistent=False )
+Gaffer.Metadata.registerNodeValue( parent, "serialiser:patchVersion", 1, persistent=False )
+
+__children = {}
+
+__children["Bookmarked"] = Gaffer.Node( "Bookmarked" )
+parent.addChild( __children["Bookmarked"] )
+__children["Bookmarked"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Unbookmarked"] = Gaffer.Node( "Unbookmarked" )
+parent.addChild( __children["Unbookmarked"] )
+__children["Unbookmarked"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["OldBookmarked"] = Gaffer.Node( "OldBookmarked" )
+parent.addChild( __children["OldBookmarked"] )
+__children["OldBookmarked"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+Gaffer.Metadata.registerValue( __children["Bookmarked"], 'bookmarked', True )
+__children["Bookmarked"]["__uiPosition"].setValue( imath.V2f( -18, 3.20000172 ) )
+Gaffer.Metadata.registerValue( __children["Unbookmarked"], 'bookmarked', False )
+__children["Unbookmarked"]["__uiPosition"].setValue( imath.V2f( -5.90000057, 3.20000076 ) )
+Gaffer.Metadata.registerValue( __children["OldBookmarked"], 'graphBookmarks:bookmarked', True )
+__children["OldBookmarked"]["__uiPosition"].setValue( imath.V2f( 6.09999943, 3.10000157 ) )
+
+
+del __children
+

--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -173,6 +173,7 @@ class CompoundEditor( GafferUI.Editor ) :
 			tabbedContainer = GafferUI.Widget.widgetAt( GafferUI.Widget.mousePosition(), _TabbedContainer )
 			if tabbedContainer is not None :
 				tabbedContainer.setTabsVisible( not tabbedContainer.getTabsVisible() )
+				return True
 
 		return False
 

--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -38,6 +38,8 @@
 import functools
 import collections
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -102,6 +104,15 @@ class CompoundEditor( GafferUI.Editor ) :
 	def editorAddedSignal( self ) :
 
 		return self.__editorAddedSignal
+
+	__nodeSetMenuSignal = Gaffer.Signal2()
+	## A signal emitted to populate a menu for manipulating
+	# the node set of a NodeSetEditor - the signature is
+	# `slot( nodeSetEditor, menuDefinition )`.
+	@classmethod
+	def nodeSetMenuSignal( cls ) :
+
+		return CompoundEditor.__nodeSetMenuSignal
 
 	def __serialise( self, w ) :
 
@@ -286,6 +297,7 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 		self.setCornerWidget( cornerWidget )
 
 		self.__pinningButtonClickedConnection = self.__pinningButton.clickedSignal().connect( Gaffer.WeakMethod( self.__pinningButtonClicked ) )
+		self.__pinningButtonContextMenuConnection = self.__pinningButton.contextMenuSignal().connect( Gaffer.WeakMethod( self.__pinningButtonContextMenu ) )
 		self.__currentTabChangedConnection = self.currentChangedSignal().connect( Gaffer.WeakMethod( self.__currentTabChanged ) )
 		self.__dragEnterConnection = self.dragEnterSignal().connect( Gaffer.WeakMethod( self.__dragEnter ) )
 		self.__dragLeaveConnection = self.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__dragLeave ) )
@@ -409,6 +421,24 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 		else :
 			nodeSet = selectionSet
 		editor.setNodeSet( nodeSet )
+
+	def __pinningButtonContextMenu( self, button ) :
+
+		m = IECore.MenuDefinition()
+		CompoundEditor.nodeSetMenuSignal()( self.getCurrent(), m )
+
+		if not len( m.items() ) :
+			return False
+
+		self.__pinningMenu = GafferUI.Menu( m )
+
+		buttonBound = button.bound()
+		self.__pinningMenu.popup(
+			parent = self.ancestor( GafferUI.Window ),
+			position = imath.V2i( buttonBound.min().x, buttonBound.max().y )
+		)
+
+		return True
 
 	def __dragEnter( self, tabbedContainer, event ) :
 

--- a/python/GafferUI/Editor.py
+++ b/python/GafferUI/Editor.py
@@ -42,6 +42,9 @@ import IECore
 import Gaffer
 import GafferUI
 
+from Qt import QtCore
+from Qt import QtWidgets
+
 class _EditorMetaclass( type ) :
 
 	def __call__( cls, *args, **kw ) :
@@ -63,6 +66,8 @@ class Editor( GafferUI.Widget ) :
 
 		GafferUI.Widget.__init__( self, topLevelWidget, **kw )
 
+		self._qtWidget().setFocusPolicy( QtCore.Qt.ClickFocus )
+
 		assert( isinstance( scriptNode, Gaffer.ScriptNode ) )
 
 		self.__scriptNode = scriptNode
@@ -70,6 +75,9 @@ class Editor( GafferUI.Widget ) :
 
 		self.__title = ""
 		self.__titleChangedSignal = GafferUI.WidgetSignal()
+
+		self.__enterConnection = self.enterSignal().connect( Gaffer.WeakMethod( self.__enter ) )
+		self.__leaveConnection = self.leaveSignal().connect( Gaffer.WeakMethod( self.__leave ) )
 
 		self.__setContextInternal( scriptNode.context(), callUpdate=False )
 
@@ -196,3 +204,13 @@ class Editor( GafferUI.Widget ) :
 		s = Gaffer.Signal1()
 		setattr( cls, "__instanceCreatedSignal", s )
 		return s
+
+	def __enter( self, widget ) :
+
+		if not isinstance( QtWidgets.QApplication.focusWidget(), ( QtWidgets.QLineEdit, QtWidgets.QPlainTextEdit ) ) :
+			self._qtWidget().setFocus()
+
+	def __leave( self, widget ) :
+
+		self._qtWidget().clearFocus()
+

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -214,7 +214,8 @@ class Menu( GafferUI.Widget ) :
 			self.__searchLine.selectAll()
 			searchWidget.setDefaultWidget( self.__searchLine )
 
-			firstAction = self._qtWidget().actions()[0] if len( self._qtWidget().actions() ) else None
+			insertIndex = 1 if self.__title else 0
+			firstAction = self._qtWidget().actions()[insertIndex] if len( self._qtWidget().actions() ) > insertIndex else None
 			self._qtWidget().insertAction( firstAction, searchWidget )
 			self._qtWidget().insertSeparator( firstAction )
 			self._qtWidget().setActiveAction( searchWidget )

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -201,6 +201,7 @@ class Menu( GafferUI.Widget ) :
 			self.__searchMenu = _Menu( self._qtWidget(), "" )
 			self.__searchMenu.aboutToShow.connect( Gaffer.WeakMethod( self.__searchMenuShow ) )
 			self.__searchLine = QtWidgets.QLineEdit()
+			self.__searchLine.setAttribute( QtCore.Qt.WA_MacShowFocusRect, False )
 			self.__searchLine.textEdited.connect( Gaffer.WeakMethod( self.__updateSearchMenu ) )
 			self.__searchLine.returnPressed.connect( Gaffer.WeakMethod( self.__searchReturnPressed ) )
 			self.__searchLine.setObjectName( "search" )

--- a/python/GafferUI/NodeEditor.py
+++ b/python/GafferUI/NodeEditor.py
@@ -37,6 +37,8 @@
 
 import functools
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -102,6 +104,8 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 
 		node = self._lastAddedNode()
 		if not node :
+			with self.__column :
+				GafferUI.Spacer( imath.V2i( 0 ) )
 			return
 
 		with self.__column :

--- a/src/Gaffer/MetadataAlgo.cpp
+++ b/src/Gaffer/MetadataAlgo.cpp
@@ -52,8 +52,6 @@ namespace
 InternedString g_readOnlyName( "readOnly" );
 InternedString g_childNodesAreReadOnlyName( "childNodesAreReadOnly" );
 InternedString g_bookmarkedName( "bookmarked" );
-/// \todo: remove when we're no longer concerned with compatibility
-InternedString g_oldBookmarkedName( "graphBookmarks:bookmarked" );
 
 size_t findNth( const std::string &s, char c, int n )
 {
@@ -203,18 +201,12 @@ void setBookmarked( Node *node, bool bookmarked, bool persistent /* = true */ )
 bool getBookmarked( const Node *node )
 {
 	ConstBoolDataPtr d = Metadata::value<BoolData>( node, g_bookmarkedName );
-	if( !d )
-	{
-		/// \todo: remove when we're no longer concerned with compatibility
-		d = Metadata::value<BoolData>( node, g_oldBookmarkedName );
-	}
-
 	return d ? d->readable() : false;
 }
 
 bool bookmarkedAffectedByChange( const IECore::InternedString &changedKey )
 {
-	return changedKey == g_bookmarkedName || changedKey == g_oldBookmarkedName;
+	return changedKey == g_bookmarkedName;
 }
 
 void bookmarks( const Node *node, std::vector<NodePtr> &bookmarks )

--- a/src/Gaffer/MetadataAlgo.cpp
+++ b/src/Gaffer/MetadataAlgo.cpp
@@ -190,7 +190,14 @@ bool readOnlyAffectedByChange( const IECore::InternedString &changedKey )
 
 void setBookmarked( Node *node, bool bookmarked, bool persistent /* = true */ )
 {
-	Metadata::registerValue( node, g_bookmarkedName, new BoolData( bookmarked ), persistent );
+	if( bookmarked )
+	{
+		Metadata::registerValue( node, g_bookmarkedName, new BoolData( true ), persistent );
+	}
+	else
+	{
+		Metadata::deregisterValue( node, g_bookmarkedName );
+	}
 }
 
 bool getBookmarked( const Node *node )

--- a/startup/Gaffer/metadataCompatibility.py
+++ b/startup/Gaffer/metadataCompatibility.py
@@ -1,0 +1,54 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+
+def __registerValueWrapper( originalRegisterValue ) :
+
+	def registerValue( *args, **kw ) :
+
+		if len( args ) == 3 and isinstance( args[0], Gaffer.Node ) :
+			if args[1] == "graphBookmarks:bookmarked" :
+				args = list( args )
+				args[1] = "bookmarked"
+			if args[1] == "bookmarked" and not args[2] :
+				return # No need to explicitly store `bookmarked==False`
+
+		originalRegisterValue( *args, **kw )
+
+	return staticmethod( registerValue )
+
+Gaffer.Metadata.registerValue = __registerValueWrapper( Gaffer.Metadata.registerValue )

--- a/startup/gui/editor.py
+++ b/startup/gui/editor.py
@@ -1,0 +1,56 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferUI
+
+def __editorKeyPress( editor, event ) :
+
+	if event.key == "B" and event.modifiers == event.modifiers.Control :
+		return GafferUI.GraphBookmarksUI.popupFindBookmarkMenu( editor )
+
+	return False
+
+def __editorCreated( editor ) :
+
+	editor.keyPressSignal().connect( __editorKeyPress, scoped = False )
+
+GafferUI.Editor.instanceCreatedSignal().connect( __editorCreated, scoped = False )
+
+def __nodeSetMenu( editor, menuDefinition ) :
+
+	GafferUI.GraphBookmarksUI.appendNodeSetMenuDefinitions( editor, menuDefinition )
+
+GafferUI.CompoundEditor.nodeSetMenuSignal().connect( __nodeSetMenu, scoped = False )


### PR DESCRIPTION
This adds the following :

- A right click context menu to pinning icons. It can be customised completely via config files, but currently provides a menu item to bookmark the current node, and one to search for a bookmark to view. It can be customised by config files.
- A Ctrl+B shortcut for all NodeSetEditors and also the GraphEditor. This initiates a bookmark search for the editor under the pointer. Bookmark search operates in the same manner as the search in the node creation tab menu.

<img width="669" alt="findbookmark" src="https://user-images.githubusercontent.com/1133871/47621296-a3805100-daed-11e8-8755-093f7c534747.png">

This is based on suggestions made by Murray and Yuta during internal discussion of #2784. It also provides some groundwork for improving the implementation of #2729, particularly replacing the hardcoding and duplication of d97dd8f17c77558f468f8bcbfc62f9ee698a3508 with a simple bolt-on config for all editors.