### PR TITLE
DefaultLights Set

### DIFF
--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -262,7 +262,7 @@ class GAFFER_API Context : public IECore::RefCounted
 			public :
 
 				/// It is the caller's responsibility to
-				/// guarantee that `context` outlives the
+				/// guarantee that `context` outlives
 				/// the EditableScope.
 				EditableScope( const Context *context );
 				~EditableScope();

--- a/include/GafferScene/EvaluateLightLinks.h
+++ b/include/GafferScene/EvaluateLightLinks.h
@@ -42,6 +42,10 @@
 namespace GafferScene
 {
 
+// SceneProcessor that prepares light linking for the renderer backend by
+// resolving SetExpressions. If no SetExpression is given to determine the
+// lights to be linked, the default set of lights is used to
+// determine linking.
 class GAFFERSCENE_API EvaluateLightLinks : public GafferScene::SceneProcessor
 {
 
@@ -59,6 +63,15 @@ class GAFFERSCENE_API EvaluateLightLinks : public GafferScene::SceneProcessor
 		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+
+ private:
+
+		Gaffer::ObjectPlug *lightNamesPlug();
+		const Gaffer::ObjectPlug *lightNamesPlug() const;
+
+		static size_t g_firstPlugIndex;
 };
 
 IE_CORE_DECLAREPTR( EvaluateLightLinks )

--- a/include/GafferScene/Light.h
+++ b/include/GafferScene/Light.h
@@ -55,6 +55,9 @@ class GAFFERSCENE_API Light : public ObjectSource
 		Gaffer::Plug *parametersPlug();
 		const Gaffer::Plug *parametersPlug() const;
 
+		Gaffer::BoolPlug *defaultLightPlug();
+		const Gaffer::BoolPlug *defaultLightPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
@@ -68,6 +71,7 @@ class GAFFERSCENE_API Light : public ObjectSource
 		void hashBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		Imath::Box3f computeBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
+		void hashStandardSetNames( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const override;
 
 		/// Must be implemented by derived classes to hash and generate the light to be placed

--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -209,7 +209,8 @@ Gaffer.Metadata.registerNode(
 			"""
 			The lights that cause this object to cast shadows.
 			Accepts a set expression or a space separated list of
-			lights. Use __lights to refer to the set of all lights.
+			lights. Use \"defaultLights\" to refer to all lights that
+			contribute to illumination by default.
 			""",
 
 			"layout:section", "Visibility",

--- a/python/GafferSceneTest/EvaluateLightLinksTest.py
+++ b/python/GafferSceneTest/EvaluateLightLinksTest.py
@@ -109,3 +109,151 @@ class EvaluateLightLinksTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual(
 			set( map( str, evalNode["out"].attributes( "/group/sphere" )[ "linkedLights" ] ) ),
 			set( [ "/group/group/light" ] ) )
+
+		# Make sure the defaultLights set is treated correctly when no light linking is set by the user
+		attributes["attributes"]["linkedLights"]["enabled"].setValue( False )
+
+		# No attributes are assigned if the 'defaultLights' set is equal to '__lights'
+		self.assertEqual( evalNode["out"].setHash( "__lights" ), evalNode["out"].setHash( "defaultLights" ) )
+
+		self.assertNotIn( "linkedLights", evalNode["out"].attributes( "/group" ) )
+		self.assertNotIn( "linkedLights", evalNode["out"].attributes( "/group/sphere" ) )
+
+		# If the two sets are not equal, the group at root level gets an
+		# attribute assigned which is inherited by all children
+		light1["defaultLight"].setValue( False )
+
+		self.assertEqual( IECore.StringVectorData( [ "/group/group/light1" ] ), evalNode["out"].attributes( "/group" )["linkedLights"] )
+		self.assertNotIn( "linkedLights", evalNode["out"].attributes( "/group/sphere" ) )
+
+	def testHash( self ) :
+
+		sphere = GafferScene.Sphere( "Sphere" )
+
+		standardAttributes = GafferScene.StandardAttributes()
+		standardAttributes["in"].setInput( sphere["out"] )
+
+		customAttributes = GafferScene.CustomAttributes()
+		customAttributes["in"].setInput( standardAttributes["out"] )
+		customAttributes["attributes"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "member" ) )
+		customAttributes["attributes"]["member"].addChild( Gaffer.StringPlug( "name" ) )
+		customAttributes["attributes"]["member"]["name"].setValue( "ai:visibility:shadow_group" )
+		customAttributes["attributes"]["member"].addChild( Gaffer.StringPlug( "value" ) )
+		customAttributes["attributes"]["member"].addChild( Gaffer.BoolPlug( "enabled" ) )
+
+		sphereGroup = GafferScene.Group()
+		sphereGroup["in"].addChild( GafferScene.ScenePlug( "in1" ) )
+		sphereGroup["in"]["in1"].setInput( customAttributes["out"] )
+
+		light1 = GafferSceneTest.TestLight()
+		light2 = GafferSceneTest.TestLight()
+
+		group = GafferScene.Group()
+		group["in"].addChild( GafferScene.ScenePlug( "in1" ) )
+		group["in"].addChild( GafferScene.ScenePlug( "in2" ) )
+		group["in"].addChild( GafferScene.ScenePlug( "in3" ) )
+
+		group["in"]["in1"].setInput( light1["out"] )
+		group["in"]["in2"].setInput( light2["out"] )
+		group["in"]["in3"].setInput( sphereGroup["out"] )
+
+		lightSet = GafferScene.Set( "lightSet" )
+		lightSet["in"].setInput( group["out"] )
+		lightSet["mode"].setValue( 2 )  # Remove
+		lightSet["name"].setValue( '__lights' )
+		lightSet["paths"].setValue( IECore.StringVectorData( [ '/group/light1' ] ) )
+		lightSet["enabled"].setValue( False )
+
+		evalNode = GafferScene.EvaluateLightLinks()
+		evalNode["in"].setInput( lightSet["out"] )
+
+		# If the default light set and __lights are the same and no expression
+		# has been assigned, the hashes need to match
+
+		self.assertEqual(lightSet["out"].set( "__lights" ), lightSet["out"].set( "defaultLights" ) )
+
+		self.assertEqual( lightSet["out"].attributesHash( "/group/group" ), evalNode["out"].attributesHash( "/group/group" ) )
+
+		self.assertEqual( lightSet["out"].attributesHash( "/group/group/sphere" ), evalNode["out"].attributesHash( "/group/group/sphere" ) )
+
+		# If a shadow linking expression was assigned to the sphere, the
+		# attributeHash for the sphere needs to change
+
+		customAttributes["attributes"]["member"]["enabled"].setValue( True )
+
+		evalNodeHash = evalNode["out"].attributesHash( "/group/group/sphere" )  # expression being ""
+
+		self.assertNotEqual( lightSet["out"].attributesHash( "/group/group/sphere" ), evalNodeHash )
+
+		# Changing the expression changes the hash
+		customAttributes["attributes"]["member"]["value"].setValue( "/group/light" )
+
+		self.assertNotEqual( lightSet["out"].attributesHash( "/group/group/sphere" ), evalNode["out"].attributesHash( "/group/group/sphere" ) )
+
+		self.assertNotEqual( evalNodeHash, evalNode["out"].attributesHash( "/group/group/sphere" ) )
+
+		customAttributes["attributes"]["member"]["value"].setValue( "" )
+
+		# Changing the __lights set does as well
+		lightSet["enabled"].setValue( True )
+
+		self.assertNotEqual( lightSet["out"].attributesHash( "/group/group/sphere" ), evalNode["out"].attributesHash( "/group/group/sphere" ) )
+
+		self.assertNotEqual( evalNodeHash, evalNode["out"].attributesHash( "/group/group/sphere" ) )
+
+		lightSet["enabled"].setValue( False )
+
+		customAttributes["attributes"]["member"]["enabled"].setValue( False )
+
+		# If a light linking expression was assigned to the sphere, the
+		# attributeHashes for the sphere can't match
+
+		standardAttributes["attributes"]["linkedLights"]["enabled"].setValue( True )
+
+		evalNodeHash = evalNode["out"].attributesHash( "/group/group/sphere" )  # expression being ""
+
+		self.assertNotEqual( lightSet["out"].attributesHash( "/group/group/sphere" ), evalNodeHash )
+
+		# Changing the expression changes the hash
+		standardAttributes["attributes"]["linkedLights"]["value"].setValue( "/group/light" )
+
+		self.assertNotEqual( lightSet["out"].attributesHash( "/group/group/sphere" ), evalNode["out"].attributesHash( "/group/group/sphere" ) )
+
+		self.assertNotEqual( evalNodeHash, evalNode["out"].attributesHash( "/group/group/sphere" ) )
+
+		standardAttributes["attributes"]["linkedLights"]["value"].setValue( "" )
+
+		# Changing the __lights set does as well
+		lightSet["enabled"].setValue( True )
+
+		self.assertNotEqual( lightSet["out"].attributesHash( "/group/group/sphere" ), evalNode["out"].attributesHash( "/group/group/sphere" ) )
+
+		self.assertNotEqual( evalNodeHash, evalNode["out"].attributesHash( "/group/group/sphere" ) )
+
+		lightSet["enabled"].setValue( False )
+
+		standardAttributes["attributes"]["linkedLights"]["enabled"].setValue( False )
+
+		# If we remove a light from the defaultLights set, the attributeHash
+		# for the sphere's parent at root level needs to change, the sphere's
+		# attributeHash needs to stay the same. No expressions are assigned in
+		# this test.
+
+		light1["defaultLight"].setValue( False )  # changes defaultLights set
+
+		evalNodeHash = evalNode["out"].attributesHash( "/group" )
+		self.assertNotEqual( lightSet["out"].attributesHash( "/group" ), evalNodeHash )
+
+		self.assertEqual( lightSet["out"].attributesHash( "/group/group/sphere" ), evalNode["out"].attributesHash( "/group/group/sphere" ) )
+
+		# Changing the __lights set changes the hash as well
+		lightSet["enabled"].setValue( True )
+
+		self.assertNotEqual( lightSet["out"].attributesHash( "/group" ), evalNode["out"].attributesHash( "/group" ) )
+
+		self.assertNotEqual( evalNodeHash, evalNode["out"].attributesHash( "/group" ) )
+
+		lightSet["enabled"].setValue( False )
+
+		light1["defaultLight"].setValue( True )
+

--- a/python/GafferSceneTest/LightTest.py
+++ b/python/GafferSceneTest/LightTest.py
@@ -64,7 +64,7 @@ class LightTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( l["out"].transform( "/light" ), imath.M44f() )
 		self.assertEqual( l["out"].childNames( "/light" ), IECore.InternedStringVectorData() )
 
-		self.assertEqual( l["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights" ] ) )
+		self.assertEqual( l["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights", "defaultLights" ] ) )
 		lightSet = l["out"].set( "__lights" )
 		self.assertEqual(
 			lightSet,
@@ -72,6 +72,17 @@ class LightTest( GafferSceneTest.SceneTestCase ) :
 				IECore.PathMatcher( [ "/light" ] )
 			)
 		)
+
+		defaultLightSet = l["out"].set( "defaultLights" )
+		self.assertEqual(
+			lightSet,
+			IECore.PathMatcherData(
+				IECore.PathMatcher( [ "/light" ] )
+			)
+		)
+
+		l["defaultLight"].setValue( False )
+		self.assertEqual( l["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights" ] ) )
 
 	def testGroupMaintainsLightSet( self ) :
 
@@ -112,10 +123,10 @@ class LightTest( GafferSceneTest.SceneTestCase ) :
 	def testAdditionalSets( self ) :
 
 		l = GafferSceneTest.TestLight()
-		self.assertEqual( l["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights" ] ) )
+		self.assertEqual( l["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights", "defaultLights" ] ) )
 
 		l["sets"].setValue( "A B")
-		self.assertEqual( l["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "A", "B", "__lights" ] ) )
+		self.assertEqual( l["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "A", "B", "__lights", "defaultLights" ] ) )
 
 		self.assertTrue( l["out"].set( "A", _copy = False ).isSame( l["out"].set( "B", _copy = False ) ) )
 		self.assertTrue( l["out"].set( "B", _copy = False ).isSame( l["out"].set( "__lights", _copy = False ) ) )
@@ -124,7 +135,7 @@ class LightTest( GafferSceneTest.SceneTestCase ) :
 
 		l = GafferSceneTest.TestLight()
 		l["sets"].setValue( "A B")
-		self.assertEqual( l["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "A", "B", "__lights" ] ) )
+		self.assertEqual( l["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "A", "B", "__lights", "defaultLights" ] ) )
 
 		l["enabled"].setValue( False )
 		self.assertEqual( l["out"]["setNames"].getValue(), IECore.InternedStringVectorData() )
@@ -133,7 +144,7 @@ class LightTest( GafferSceneTest.SceneTestCase ) :
 
 		l = GafferSceneTest.TestLight()
 		l["sets"].setValue( "A B")
-		self.assertEqual( l["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "A", "B", "__lights" ] ) )
+		self.assertEqual( l["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "A", "B", "__lights", "defaultLights" ] ) )
 
 		self.assertEqual( l["out"].set( "" ), IECore.PathMatcherData() )
 		self.assertEqual( l["out"].set( "nonexistent1" ), IECore.PathMatcherData() )

--- a/python/GafferSceneTest/ParentTest.py
+++ b/python/GafferSceneTest/ParentTest.py
@@ -198,7 +198,7 @@ class ParentTest( GafferSceneTest.SceneTestCase ) :
 		self.assertSceneValid( p["out"] )
 		self.assertEqual( p["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "light1", "light2" ] ) )
 
-		self.assertEqual( p["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights" ] ) )
+		self.assertEqual( p["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights", "defaultLights" ] ) )
 		self.assertEqual( set( p["out"].set( "__lights" ).value.paths() ), set( [ "/light1", "/light2" ] ) )
 
 	def testSetsUniqueToChild( self ) :
@@ -214,7 +214,7 @@ class ParentTest( GafferSceneTest.SceneTestCase ) :
 		self.assertSceneValid( p["out"] )
 		self.assertEqual( p["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "cube", "light" ] ) )
 
-		self.assertEqual( p["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights" ] ) )
+		self.assertEqual( p["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights", "defaultLights" ] ) )
 		self.assertEqual( p["out"].set( "__lights" ).value.paths(), [ "/light" ] )
 
 	def testSetsUniqueToParent( self ) :
@@ -230,7 +230,7 @@ class ParentTest( GafferSceneTest.SceneTestCase ) :
 		self.assertSceneValid( p["out"] )
 		self.assertEqual( p["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "light", "cube" ] ) )
 
-		self.assertEqual( p["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights" ] ) )
+		self.assertEqual( p["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights", "defaultLights" ] ) )
 		self.assertEqual( p["out"].set( "__lights" ).value.paths(), [ "/light" ] )
 
 	def testSetsWithNonRootParent( self ) :
@@ -246,7 +246,7 @@ class ParentTest( GafferSceneTest.SceneTestCase ) :
 		self.assertSceneValid( p["out"] )
 		self.assertEqual( p["out"].childNames( "/cube" ), IECore.InternedStringVectorData( [ "light" ] ) )
 
-		self.assertEqual( p["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights" ] ) )
+		self.assertEqual( p["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights", "defaultLights" ] ) )
 		self.assertEqual( p["out"].set( "__lights" ).value.paths(), [ "/cube/light" ] )
 
 	def testSetsWithDeepNesting( self ) :
@@ -266,7 +266,7 @@ class ParentTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertSceneValid( p["out"] )
 
-		self.assertEqual( p["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights" ] ) )
+		self.assertEqual( p["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights", "defaultLights" ] ) )
 		self.assertEqual( p["out"].set( "__lights" ).value.paths(), [ "/cube/group/group/light" ] )
 
 	def testSetsWithWithRenaming( self ) :
@@ -282,7 +282,7 @@ class ParentTest( GafferSceneTest.SceneTestCase ) :
 		self.assertSceneValid( p["out"] )
 		self.assertEqual( p["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "light", "light1" ] ) )
 
-		self.assertEqual( p["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights" ] ) )
+		self.assertEqual( p["out"]["setNames"].getValue(), IECore.InternedStringVectorData( [ "__lights", "defaultLights" ] ) )
 		self.assertEqual( set(  p["out"].set( "__lights" ).value.paths() ), set( [ "/light", "/light1" ] ) )
 
 	def testGlobalsPassThrough( self ) :

--- a/python/GafferSceneTest/RendererAlgoTest.py
+++ b/python/GafferSceneTest/RendererAlgoTest.py
@@ -47,11 +47,8 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		sphere = GafferScene.Sphere()
 
-		adaptors = GafferScene.createAdaptors()
-		adaptors["in"].setInput( sphere["out"] )
-
-		self.assertScenesEqual( sphere["out"], adaptors["out"] )
-		self.assertSceneHashesEqual( sphere["out"], adaptors["out"] )
+		defaultAdaptors = GafferScene.createAdaptors()
+		defaultAdaptors["in"].setInput( sphere["out"] )
 
 		def a() :
 
@@ -63,20 +60,20 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		GafferScene.registerAdaptor( "Test", a )
 
-		adaptors = GafferScene.createAdaptors()
-		adaptors["in"].setInput( sphere["out"] )
+		testAdaptors = GafferScene.createAdaptors()
+		testAdaptors["in"].setInput( sphere["out"] )
 
 		self.assertFalse( "doubleSided" in sphere["out"].attributes( "/sphere" ) )
-		self.assertTrue( "doubleSided" in adaptors["out"].attributes( "/sphere" ) )
-		self.assertEqual( adaptors["out"].attributes( "/sphere" )["doubleSided"].value, False )
+		self.assertTrue( "doubleSided" in testAdaptors["out"].attributes( "/sphere" ) )
+		self.assertEqual( testAdaptors["out"].attributes( "/sphere" )["doubleSided"].value, False )
 
 		GafferScene.deregisterAdaptor( "Test" )
 
-		adaptors = GafferScene.createAdaptors()
-		adaptors["in"].setInput( sphere["out"] )
+		defaultAdaptors2 = GafferScene.createAdaptors()
+		defaultAdaptors2["in"].setInput( sphere["out"] )
 
-		self.assertScenesEqual( sphere["out"], adaptors["out"] )
-		self.assertSceneHashesEqual( sphere["out"], adaptors["out"] )
+		self.assertScenesEqual( defaultAdaptors["out"], defaultAdaptors2["out"] )
+		self.assertSceneHashesEqual( defaultAdaptors["out"], defaultAdaptors2["out"] )
 
 	def tearDown( self ) :
 

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -157,13 +157,13 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		light["sets"].setValue( "A B C" )
 
 		sets = GafferScene.SceneAlgo.sets( light["out"] )
-		self.assertEqual( set( sets.keys() ), { "__lights", "A", "B", "C" } )
+		self.assertEqual( set( sets.keys() ), { "__lights", "defaultLights", "A", "B", "C" } )
 		for n in sets.keys() :
 			self.assertEqual( sets[n], light["out"].set( n ) )
 			self.assertFalse( sets[n].isSame( light["out"].set( n, _copy = False ) ) )
 
 		sets = GafferScene.SceneAlgo.sets( light["out"], _copy = False )
-		self.assertEqual( set( sets.keys() ), { "__lights", "A", "B", "C" } )
+		self.assertEqual( set( sets.keys() ), { "__lights", "defaultLights", "A", "B", "C" } )
 		for n in sets.keys() :
 			self.assertTrue( sets[n].isSame( light["out"].set( n, _copy = False ) ) )
 

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -77,6 +77,20 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"defaultLight" : [
+
+			"description",
+			"""
+			Whether this light illuminates all geometry by default. When
+			toggled, the light will be added to the \"defaultLights\" set, which
+			can be referenced in set expressions and manipulated by downstream
+			nodes.
+			""",
+
+			"layout:section", "Light Linking",
+
+		]
+
 	}
 
 )

--- a/python/GafferSceneUI/StandardAttributesUI.py
+++ b/python/GafferSceneUI/StandardAttributesUI.py
@@ -181,7 +181,8 @@ Gaffer.Metadata.registerNode(
 			"""
 			The lights to be linked to this object. Accepts a
 			set expression or a space separated list of lights.
-			Use __lights to refer to the set of all lights.
+			Use \"defaultLights\" to refer to all lights that
+			contribute to illumination by default.
 			""",
 
 			"layout:section", "Light Linking",

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -317,6 +317,7 @@ class ArnoldGlobals;
 class Instance;
 IE_CORE_FORWARDDECLARE( ShaderCache );
 IE_CORE_FORWARDDECLARE( InstanceCache );
+IE_CORE_FORWARDDECLARE( LightListCache );
 
 /// This class implements the basics of outputting attributes
 /// and objects to Arnold, but is not a complete implementation
@@ -346,6 +347,7 @@ class ArnoldRendererBase : public IECoreScenePreview::Renderer
 		NodeDeleter m_nodeDeleter;
 		ShaderCachePtr m_shaderCache;
 		InstanceCachePtr m_instanceCache;
+		LightListCachePtr m_lightListCache;
 
 	private :
 
@@ -678,6 +680,55 @@ class ShaderCache : public IECore::RefCounted
 
 IE_CORE_DECLAREPTR( ShaderCache )
 
+// The LightListCache stores std::vectors of AtNode pointers to lights.
+// We rely on lights getting handled before other objects and if
+// that were to change, we couldn't look up lights by name anymore.
+class LightListCache : public IECore::RefCounted
+{
+
+	public :
+
+		const std::vector<AtNode *> &get( const IECore::StringVectorData *nodeNamesData )
+		{
+			IECore::MurmurHash h = nodeNamesData->Object::hash();
+
+			Cache::accessor a;
+			m_cache.insert( a, h );
+
+			if( a->second.empty() )
+			{
+				const std::vector<string> &nodeNames = nodeNamesData->readable();
+				a->second.reserve( nodeNames.size() );
+
+				for( const std::string &name : nodeNames )
+				{
+					std::string nodeName = "light:" + name;
+					AtNode *node = AiNodeLookUpByName( AtString( nodeName.c_str() ) );
+					if( node )
+					{
+						a->second.push_back( node );
+					}
+				}
+
+				a->second.shrink_to_fit();
+			}
+
+			return a->second;
+		}
+
+		void clear()
+		{
+			m_cache.clear();
+		}
+
+	private :
+
+		typedef tbb::concurrent_hash_map<IECore::MurmurHash, std::vector<AtNode *>> Cache;
+		Cache m_cache;
+};
+
+IE_CORE_DECLAREPTR( LightListCache )
+
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -753,8 +804,8 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 	public :
 
-		ArnoldAttributes( const IECore::CompoundObject *attributes, ShaderCache *shaderCache )
-			:	m_visibility( AI_RAY_ALL ), m_sidedness( AI_RAY_ALL ), m_shadingFlags( Default ), m_stepSize( 0.0f ), m_stepScale( 1.0f ), m_volumePadding( 0.0f ), m_polyMesh( attributes ), m_displacement( attributes, shaderCache ), m_curves( attributes ), m_volume( attributes )
+		ArnoldAttributes( const IECore::CompoundObject *attributes, ShaderCache *shaderCache, LightListCache *lightLinkCache )
+			:	m_visibility( AI_RAY_ALL ), m_sidedness( AI_RAY_ALL ), m_shadingFlags( Default ), m_stepSize( 0.0f ), m_stepScale( 1.0f ), m_volumePadding( 0.0f ), m_polyMesh( attributes ), m_displacement( attributes, shaderCache ), m_curves( attributes ), m_volume( attributes ), m_lightListCache( lightLinkCache )
 		{
 			updateVisibility( g_cameraVisibilityAttributeName, AI_RAY_CAMERA, attributes );
 			updateVisibility( g_shadowVisibilityAttributeName, AI_RAY_SHADOW, attributes );
@@ -1068,11 +1119,9 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 				if( m_linkedLights )
 				{
-					std::vector<AtNode*> lightNodes;
-					lightNamesToNodes( m_linkedLights->readable(), lightNodes );
+					const std::vector<AtNode *> &linkedLightNodes = m_lightListCache->get( m_linkedLights.get() );
 
-					AtArray *linkedLightNodes = AiArrayConvert( lightNodes.size(), 1, AI_TYPE_NODE, lightNodes.data() );
-					AiNodeSetArray( node, g_lightGroupArnoldString, linkedLightNodes );
+					AiNodeSetArray( node, g_lightGroupArnoldString, AiArrayConvert( linkedLightNodes.size(), 1, AI_TYPE_NODE, linkedLightNodes.data() ) );
 					AiNodeSetBool( node, g_useLightGroupArnoldString, true );
 				}
 				else
@@ -1083,11 +1132,9 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 				if( m_shadowGroup )
 				{
-					std::vector<AtNode*> lightNodes;
-					lightNamesToNodes( m_shadowGroup->readable(), lightNodes );
+					const std::vector<AtNode *> &linkedLightNodes = m_lightListCache->get( m_linkedLights.get() );
 
-					AtArray *linkedLightNodes = AiArrayConvert( lightNodes.size(), 1, AI_TYPE_NODE, lightNodes.data() );
-					AiNodeSetArray( node, g_shadowGroupArnoldString, linkedLightNodes );
+					AiNodeSetArray( node, g_shadowGroupArnoldString, AiArrayConvert( linkedLightNodes.size(), 1, AI_TYPE_NODE, linkedLightNodes.data() ) );
 					AiNodeSetBool( node, g_useShadowGroupArnoldString, true );
 				}
 				else
@@ -1493,25 +1540,6 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			}
 		}
 
-		void lightNamesToNodes( const std::vector<std::string> &lightNames, std::vector<AtNode*> &lightNodes ) const
-		{
-			// NOTE : There is an awful lot of AtString conversion and AiNodeLookUpByName
-			// happening here if we have lots lights.  It seems like it would be great if there
-			// was some way of caching the evaluation of light expressions as a vector of node
-			// pointers, instead of a vector of strings - this might be tricky with how the
-			// baking of expressions currently happens in the EvaluateLightLinks node?
-
-			for ( IECore::StringVectorData::ValueType::const_iterator it = lightNames.begin(); it != lightNames.end(); ++it )
-			{
-				std::string lightName = "light:" + *(it);
-				AtNode *lightNode = AiNodeLookUpByName( AtString( lightName.c_str() ) );
-				if( lightNode )
-				{
-					lightNodes.push_back( lightNode );
-				}
-			}
-		}
-
 		unsigned char m_visibility;
 		unsigned char m_sidedness;
 		unsigned char m_shadingFlags;
@@ -1535,6 +1563,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 		IECore::ConstStringDataPtr m_sssSetName;
 
+		LightListCache *m_lightListCache;
 };
 
 IE_CORE_DECLAREPTR( ArnoldAttributes )
@@ -2831,6 +2860,7 @@ ArnoldRendererBase::ArnoldRendererBase( NodeDeleter nodeDeleter, AtNode *parentN
 	:	m_nodeDeleter( nodeDeleter ),
 		m_shaderCache( new ShaderCache( nodeDeleter, parentNode ) ),
 		m_instanceCache( new InstanceCache( nodeDeleter, parentNode ) ),
+		m_lightListCache( new LightListCache() ),
 		m_parentNode( parentNode )
 {
 }
@@ -2846,7 +2876,7 @@ IECore::InternedString ArnoldRendererBase::name() const
 
 ArnoldRendererBase::AttributesInterfacePtr ArnoldRendererBase::attributes( const IECore::CompoundObject *attributes )
 {
-	return new ArnoldAttributes( attributes, m_shaderCache.get() );
+	return new ArnoldAttributes( attributes, m_shaderCache.get(), m_lightListCache.get() );
 }
 
 ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes )
@@ -2928,6 +2958,7 @@ class ArnoldRenderer final : public ArnoldRendererBase
 		{
 			m_shaderCache->clearUnused();
 			m_instanceCache->clearUnused();
+			m_lightListCache->clear();
 			m_globals->render();
 		}
 

--- a/src/GafferScene/Light.cpp
+++ b/src/GafferScene/Light.cpp
@@ -50,6 +50,7 @@ using namespace Gaffer;
 using namespace GafferScene;
 
 static IECore::InternedString g_lightsSetName( "__lights" );
+static IECore::InternedString g_defaultLightsSetName( "defaultLights" );
 
 IE_CORE_DEFINERUNTIMETYPED( Light );
 
@@ -60,6 +61,7 @@ Light::Light( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new Plug( "parameters" ) );
+	addChild( new BoolPlug( "defaultLight", Gaffer::Plug::Direction::In, true ) );
 }
 
 Light::~Light()
@@ -76,6 +78,16 @@ const Gaffer::Plug *Light::parametersPlug() const
 	return getChild<Plug>( g_firstPlugIndex );
 }
 
+Gaffer::BoolPlug *Light::defaultLightPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::BoolPlug *Light::defaultLightPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 1 );
+}
+
 void Light::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	ObjectSource::affects( input, outputs );
@@ -85,6 +97,10 @@ void Light::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs 
 		outputs.push_back( outPlug()->attributesPlug() );
 	}
 
+	if( input == defaultLightPlug() )
+	{
+		outputs.push_back( outPlug()->setNamesPlug() );
+	}
 }
 
 void Light::hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const
@@ -123,10 +139,21 @@ IECore::ConstCompoundObjectPtr Light::computeAttributes( const SceneNode::SceneP
 	return result;
 }
 
+void Light::hashStandardSetNames( const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	defaultLightPlug()->hash( h );
+}
+
 IECore::ConstInternedStringVectorDataPtr Light::computeStandardSetNames() const
 {
 	IECore::InternedStringVectorDataPtr result = new IECore::InternedStringVectorData();
 	result->writable().push_back( g_lightsSetName );
+
+	if( defaultLightPlug()->getValue() )
+	{
+		result->writable().push_back( g_defaultLightsSetName );
+	}
+
 	return result;
 }
 


### PR DESCRIPTION
_For anyone following along - this is meant to address a concern about light linking that was raised on the dev list recently. Currently we have no way of making a light not illuminate all geometry per default. This PR is trying to fix that._

Hey John,

here's a first implementation of the `defaultLights` feature I was outlining on that internal ticket. I'll stop where I'm at now so we can discuss if it is going in the right direction. There are a few performance implications that we should probably talk about... Also, I'm expecting some tests to fail at this point.

How do you feel about "abusing" the `EvaluateLightLinks` node for this? I'm doing it so that the `ArnoldAttributes` class in the Arnold backend doesn't need to know about sets. We're hitting every single location now, though. We might want to add a layer of caching, - both in `EvaluateLightLinks` and the backend that does the AtNode lookups? 

Thanks,

Matti.

