### PR TITLE
GUI App : Sync with system clipboard on startup

### DIFF
--- a/apps/gui/gui-1.py
+++ b/apps/gui/gui-1.py
@@ -130,6 +130,7 @@ class gui( Gaffer.Application ) :
 		self.__clipboardContentsChangedConnection = self.root().clipboardContentsChangedSignal().connect( Gaffer.WeakMethod( self.__clipboardContentsChanged ) )
 		QtWidgets.QApplication.clipboard().dataChanged.connect( Gaffer.WeakMethod( self.__qtClipboardContentsChanged ) )
 		self.__ignoreQtClipboardContentsChanged = False
+		self.__qtClipboardContentsChanged() # Trigger initial sync
 
 	def __clipboardContentsChanged( self, applicationRoot ) :
 


### PR DESCRIPTION
This allows you to copy a script prior to loading Gaffer, and then successfully paste it via the GraphEditor.
