### PR TITLE
Travis : Remove `sudo: false`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: cpp
 
 os:


### PR DESCRIPTION
According to the [Travis blog](https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures?utm_source=changelog&utm_medium=web&utm_campaign=single_linux_stage_1) this is being taken away from us soon anyway.
