### PR TITLE
AnimationEditor : Remove GafferScene import

### DIFF
--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -33,11 +33,11 @@
 #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 ##########################################################################
-import imath
 
 import Gaffer
-import GafferScene
 import GafferUI
+
+import imath
 
 from Qt import QtWidgets
 


### PR DESCRIPTION
This wasn't needed, and GafferUI must not have a dependency on any of the higher level modules.
