### PR TITLE
EvaluateLightLinks : Account for __lightSet change in hash

### DIFF
--- a/src/GafferScene/EvaluateLightLinks.cpp
+++ b/src/GafferScene/EvaluateLightLinks.cpp
@@ -126,6 +126,7 @@ void EvaluateLightLinks::hashAttributes( const ScenePath &path, const Gaffer::Co
 	{
 		h.append( SetAlgo::setExpressionHash( shadowExpressionData->readable(), inPlug() ) );
 	}
+	h.append( inPlug()->setHash( "__lights" ) );
 }
 
 IECore::ConstCompoundObjectPtr EvaluateLightLinks::computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const


### PR DESCRIPTION
EvaluateLightLinks wasn't taking __lightSet into account when hashing attributes, but it did while computing.  This meant that given two scenes with the same set expressions driving light links, but those set expressions including locations that are lights in one but not the other, the same hashes would be produced, results in incorrect results being retrieved from the cache.

This is particularly bad when replacing a light with a non-light during an interactive render, since the light links would not be updated, resulting in a light link referring to a now non-existent light, and a crash inside Arnold.

This fix seems to address the problem ( it fixes the scene reported in internal IE ticket 13790 ).  Matti should take a look at this to see if he has any performance concerns.