### PR TITLE
StandardOptions : Added depthOfFieldBlur enable toggle

### DIFF
--- a/python/GafferSceneUI/CameraTweaksUI.py
+++ b/python/GafferSceneUI/CameraTweaksUI.py
@@ -83,7 +83,7 @@ def __populateMetadata():
 			"clippingPlanes" ] ] + [
 			("Render Overrides", i ) for i in [ "filmFit", "shutter", "resolution", "pixelAspectRatio",
 			"resolutionMultiplier", "overscan", "overscanLeft", "overscanRight", "overscanTop",
-			"overscanBottom", "cropWindow" ] ]
+			"overscanBottom", "cropWindow", "depthOfField" ] ]
 
 	for category, plugName in parameterCategories:
 		if category == "Render Overrides":

--- a/python/GafferSceneUI/CameraUI.py
+++ b/python/GafferSceneUI/CameraUI.py
@@ -448,6 +448,17 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"renderSettingOverrides.depthOfField" : [
+
+			"description",
+			"""
+			Override the "depthOfField" render option.  Forces depth of field to always ( or never )
+			be rendered.  To get depth of field, you must also set an appropriate f-stop on this
+			camera.
+			""",
+
+		],
+
 
 	}
 

--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -69,6 +69,8 @@ def __cameraSummary( plug ) :
 		info.append( "Crop %s,%s-%s,%s" % tuple( GafferUI.NumericWidget.valueToString( x ) for x in ( crop.min().x, crop.min().y, crop.max().x, crop.max().y ) ) )
 	if plug["overscan"]["enabled"].getValue() :
 		info.append( "Overscan %s" % ( "On" if plug["overscan"]["value"].getValue() else "Off" ) )
+	if plug["depthOfField"]["enabled"].getValue() :
+		info.append( "DOF " + ( "On" if plug["depthOfField"]["value"].getValue() else "Off" ) )
 
 	return ", ".join( info )
 
@@ -265,6 +267,18 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Camera",
 
+		],
+
+		"options.depthOfField" : [
+
+			"description",
+			"""
+			Enable rendering with depth of field blur.  To get blur, you
+			must enable this setting, and set an f-stop on the camera you
+			are rendering.
+			""",
+
+			"layout:section", "Camera",
 		],
 
 		# Motion blur plugs

--- a/src/GafferScene/Camera.cpp
+++ b/src/GafferScene/Camera.cpp
@@ -85,6 +85,7 @@ Camera::Camera( const std::string &name )
 	renderSettingOverridesPlug()->addOptionalMember( "overscanTop", new FloatData( 0.0f ), "overscanTop", Plug::Default );
 	renderSettingOverridesPlug()->addOptionalMember( "overscanBottom", new FloatData( 0.0f ), "overscanBottom", Plug::Default );
 	renderSettingOverridesPlug()->addOptionalMember( "cropWindow", new Box2fData( Box2f( V2f(0.0f), V2f(1.0f) ) ), "cropWindow", Plug::Default );
+	renderSettingOverridesPlug()->addOptionalMember( "depthOfField", new BoolData( false ), "depthOfField", Plug::Default );
 }
 
 Camera::~Camera()

--- a/src/GafferScene/Camera.cpp
+++ b/src/GafferScene/Camera.cpp
@@ -68,7 +68,7 @@ Camera::Camera( const std::string &name )
 	addChild( new FloatPlug( "focalLength", Plug::In, 35.0f, 0.0f ) );
 	addChild( new V2fPlug( "orthographicAperture", Plug::In, V2f( 2.0f, 2.0f ), V2f( 0.0f ) ) );
 	addChild( new V2fPlug( "apertureOffset", Plug::In, V2f( 0.0f ) ) );
-	addChild( new FloatPlug( "fStop", Plug::In, 0.0f, 0.0f ) );
+	addChild( new FloatPlug( "fStop", Plug::In, 5.6f, 0.0f ) );
 	addChild( new FloatPlug( "focalLengthWorldScale", Plug::In, 0.1f, 0.0f ) );
 	addChild( new FloatPlug( "focusDistance", Plug::In, 1.0f ) );
 	addChild( new V2fPlug( "clippingPlanes", Plug::In, V2f( 0.01, 100000 ), V2f( 0 ) ) );

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -1108,6 +1108,13 @@ void applyCameraGlobals( IECoreScene::Camera *camera, const IECore::CompoundObje
 		camera->setCropWindow( cropWindowData->readable() );
 	}
 
+	const BoolData *depthOfFieldData = globals->member<BoolData>( "option:render:depthOfField" );
+	bool depthOfField = depthOfFieldData && depthOfFieldData->readable();
+	if( !depthOfField )
+	{
+		camera->setFStop( 0.0f );
+	}
+
 	// Bake the shutter from the globals into the camera before passing it to the renderer backend
 	//
 	// Before this bake, the shutter is an optional render setting override, with the shutter start

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -1109,9 +1109,27 @@ void applyCameraGlobals( IECoreScene::Camera *camera, const IECore::CompoundObje
 	}
 
 	const BoolData *depthOfFieldData = globals->member<BoolData>( "option:render:depthOfField" );
-	bool depthOfField = depthOfFieldData && depthOfFieldData->readable();
+	/*if( !camera->hasDepthOfField() && depthOfFieldData )
+	{
+		camera->setDepthOfField( depthOfFieldData->readable() );
+	}*/
+	// \todo - switch to the form above once we have officially added the depthOfField parameter to Cortex.
+	// The plan then would be that the renderer backends should respect camera->getDepthOfField.
+	// For the moment we bake into fStop instead
+	bool depthOfField = false;	
+	if( depthOfFieldData )
+	{
+		// First set from render globals
+		depthOfField = depthOfFieldData->readable();
+	}
+	if( const BoolData *d = camera->parametersData()->member<BoolData>( "depthOfField" ) )
+	{
+		// Override based on camera setting
+		depthOfField = d->readable();
+	}
 	if( !depthOfField )
 	{
+		// If there is no depth of field, bake that into the fStop
 		camera->setFStop( 0.0f );
 	}
 

--- a/src/GafferScene/StandardOptions.cpp
+++ b/src/GafferScene/StandardOptions.cpp
@@ -63,6 +63,7 @@ StandardOptions::StandardOptions( const std::string &name )
 	options->addOptionalMember( "render:overscanBottom", new FloatPlug( "value", Plug::In, 0.1f, 0.0f, 1.0f ), "overscanBottom", false );
 	options->addOptionalMember( "render:overscanLeft", new FloatPlug( "value", Plug::In, 0.1f, 0.0f, 1.0f ), "overscanLeft", false );
 	options->addOptionalMember( "render:overscanRight", new FloatPlug( "value", Plug::In, 0.1f, 0.0f, 1.0f ), "overscanRight", false );
+	options->addOptionalMember( "render:depthOfField", new IECore::BoolData( false ), "depthOfField", Gaffer::Plug::Default, false );
 
 	// Motion blur
 


### PR DESCRIPTION
A quick attempt to resolve the issue described in the gaffer-dev topic on the new camera workflow : that many Alembic cameras have focal blur parameters, but we may not want to render focal blur by default.

This adds a toggle to StandardOptions, which defaults off, giving you no focal blur, but can be turned on.

This is technically a compatibility breaking change, or I suppose a fix.  The default behaviour matches Gaffer-0.51 ( never DOF ), not Gaffer-0.52 ( default DOF ).  If you want the same behaviour as 0.52, then turn on the toggle.

Implementation-wise, I guess baking this setting into the camera in applyCameraGlobals before passing it to Cortex matches how we handle everything else.