### PR TITLE
Protect startup configs with Gaffer compatibility versions

### DIFF
--- a/contrib/doc/GafferUserGuide/tutorials/commandHistoryAndCompletionForCLI.txt
+++ b/contrib/doc/GafferUserGuide/tutorials/commandHistoryAndCompletionForCLI.txt
@@ -5,7 +5,7 @@
 Out of the box, the gaffer command line app "gaffer cli" isn't particularly useable - there's no tab-to-complete or history or line editing. This is because the python module responsible for such things isn't compatible with the BSD license, and therefore can't be distributed with Gaffer. This short how-to provides a workaround for that.
 
 ==== Enabling readline and command completion
-Chances are you already have a system install of python, and it has the readline module. If so, the following startup script will locate it and set it up, along with some nice tab-based completion. Just cut and paste the text into a ~/gaffer/startup/cli/completion.py file. 
+Chances are you already have a system install of python, and it has the readline module. If so, the following startup script will locate it and set it up, along with some nice tab-based completion. Just cut and paste the text into a ~/gaffer/<gafferCompatibilityVersion>/startup/cli/completion.py file.
 
 [source,python]
 ---------------------------------------------------------------------------------------------------

--- a/contrib/doc/GafferUserGuide/tutorials/configurationFilesExample.txt
+++ b/contrib/doc/GafferUserGuide/tutorials/configurationFilesExample.txt
@@ -7,14 +7,14 @@ Gaffer applications are intended to be easily extensible and customisable, and t
 ==== Startup file locations
 The location of Gaffer's configuration files are specified using the `GAFFER_STARTUP_PATHS` environment variable. This is a colon separated list of paths to directories where the startup files reside. Config directories at the end of the list are executed first, allowing them to be overridden by config directories earlier in the list.
 
-Gaffer automatically adds the `~/gaffer/startup` config directory to the `GAFFER_STARTUP_PATHS` to allow users to create their own config files without having to faff around with the environment. This user level config is run last, allowing it to take precedence over all other configuration files.
+Gaffer automatically adds the `~/gaffer/<gafferCompatibilityVersion>/startup` config directory to the `GAFFER_STARTUP_PATHS` to allow users to create their own config files without having to faff around with the environment. This user level config is run last, allowing it to take precedence over all other configuration files.
 
 Within a startup directory, config files are stored in subdirectories by application name - each application only executes the files in the appropriate directory. So for instance, the browser app executes files from the `~/gaffer/startup/browser` directory.
 
 ==== Creating a simple startup file
 We can add a startup script for the main gaffer application by creating a file in the "gui" subdirectory of the user startup location : 
 --------------------------------------------------
-~/gaffer/startup/gui/startupTest.py
+~/gaffer/<gafferCompatibilityVersion>/startup/gui/startupTest.py
 --------------------------------------------------
 
 For now, let's just create a really simple script to provide a nice little distraction from work. 

--- a/contrib/doc/GafferUserGuide/tutorials/creatingNodesCodingExample.txt
+++ b/contrib/doc/GafferUserGuide/tutorials/creatingNodesCodingExample.txt
@@ -8,7 +8,7 @@ Rumour has it some other application has a feature for creating equestrian playt
 If you've already read the xref:configurationFilesExample[Configuration Files Example], then you'll know we can add features to Gaffer by creating files it runs automatically on startup. We'll create our script in the following file, and gaffer will load it each time it runs :
 
 ------------------------------------
-~/gaffer/startup/gui/iWantAPony.py
+~/gaffer/<gafferCompatibilityVersion>/startup/gui/iWantAPony.py
 ------------------------------------
 
 ==== Creating a menu item

--- a/contrib/doc/GafferUserGuide/tutorials/profilingWithGooglePerfTools.txt
+++ b/contrib/doc/GafferUserGuide/tutorials/profilingWithGooglePerfTools.txt
@@ -7,7 +7,7 @@ When developing stuff it's often beneficial to easily profile your running code 
 The http://code.google.com/p/gperftools[Google Performance] Tools provide a library called libprofiler which generates profiles rather easily. This page describes a simple configuration file to enable the use of the google profiler from menu items within gaffer.
 
 ==== Details
-Simply place the following in a file called ~/gaffer/startup/gui/profiler.py :
+Simply place the following in a file called ~/gaffer/<gafferCompatibilityVersion>/startup/gui/profiler.py :
 
 [source,python]
 ---------------------------------------------------------------------------------------------------

--- a/doc/source/Tutorials/Scripting/AddingAMenuItem/index.md
+++ b/doc/source/Tutorials/Scripting/AddingAMenuItem/index.md
@@ -14,7 +14,7 @@ If you’ve already read the [Configuration Files Tutorial][1], then you’ll kn
 files it runs automatically on startup. We’ll create our script in the following file, and gaffer will load it each time it
 runs :
 
-`~/gaffer/startup/gui/iWantAPony.py`
+`~/gaffer/<gafferCompatibilityVersion>/startup/gui/iWantAPony.py`
 
 Creating the menu item
 --------------------

--- a/doc/source/Tutorials/Scripting/CreatingConfigurationFiles/index.md
+++ b/doc/source/Tutorials/Scripting/CreatingConfigurationFiles/index.md
@@ -11,7 +11,7 @@ Startup file locations
 
 The location of Gaffer’s configuration files are specified using the `GAFFER_STARTUP_PATHS` environment variable. This is a colon separated list of paths to directories where the startup files reside. Config directories at the end of the list are executed first, allowing them to be overridden by config directories earlier in the list.
 
-Gaffer automatically adds the `~/gaffer/startup` config directory to the `GAFFER_STARTUP_PATHS` to allow users to create their own config files without having to faff around with the environment. This user level config is run last, allowing it to take precedence over all other configuration files.
+Gaffer automatically adds the `~/gaffer/<gafferCompatibilityVersion>/startup` config directory to the `GAFFER_STARTUP_PATHS` to allow users to create their own config files without having to faff around with the environment. This user level config is run last, allowing it to take precedence over all other configuration files.
 
 Within a startup directory, config files are stored in subdirectories by application name - each application only executes the files in the appropriate directory. So for instance, the browser app executes files from the `~/gaffer/startup/browser` directory.
 
@@ -20,7 +20,7 @@ Creating a simple startup file
 
 We can add a startup script for the main gaffer application by creating a file in the "gui" subdirectory of the user startup location :
 
-`~/gaffer/startup/gui/startupTest.py`
+`~/gaffer/<gafferCompatibilityVersion>/startup/gui/startupTest.py`
 
 
 For now, let’s just create a really simple script to provide a nice little distraction from work.

--- a/include/Gaffer/ApplicationRoot.h
+++ b/include/Gaffer/ApplicationRoot.h
@@ -99,10 +99,10 @@ class GAFFER_API ApplicationRoot : public GraphComponent
 		void savePreferences() const;
 		/// Saves the current preferences value to the specified file.
 		virtual void savePreferences( const std::string &fileName ) const;
-		/// Returns ~/gaffer/startup/appName - the directory in which preferences are
-		/// stored, and ensures that the directory exists. Other application components
-		/// may use this location to store settings they wish to persist across invocations.
-		/// \todo Perhaps this should include a major version number in the future.
+		/// Returns ~/gaffer/<gafferCompatibilityVersion>/startup/appName - the directory
+		/// in which preferences are stored, and ensures that the directory exists. Other
+		/// application components may use this location to store settings they wish to
+		/// persist across invocations.
 		std::string preferencesLocation() const;
 		//@}
 

--- a/python/Gaffer/About.py
+++ b/python/Gaffer/About.py
@@ -74,6 +74,11 @@ class About :
 		return "%d.%d.%d.%d" % ( About.milestoneVersion(), About.majorVersion(), About.minorVersion(), About.patchVersion() )
 
 	@staticmethod
+	def compatibilityVersionString() :
+
+		return "%d.%d" % ( About.milestoneVersion(), About.majorVersion() )
+
+	@staticmethod
 	def copyright() :
 
 		return "Copyright (c) 2011-2018 John Haddon, Copyright (c) 2011-2018 Image Engine Design Inc."

--- a/python/GafferTest/ApplicationRootTest.py
+++ b/python/GafferTest/ApplicationRootTest.py
@@ -44,7 +44,7 @@ import GafferTest
 
 class ApplicationRootTest( GafferTest.TestCase ) :
 
-	__defaultPreferencesFile = os.path.expanduser( "~/gaffer/startup/testApp/preferences.py" )
+	__defaultPreferencesFile = os.path.expanduser( "~/gaffer/{version}/startup/testApp/preferences.py".format( version = Gaffer.About.compatibilityVersionString() ) )
 	__preferencesFile = "/tmp/testPreferences.py"
 
 	def testPreferences( self ) :

--- a/src/Gaffer/ApplicationRoot.cpp
+++ b/src/Gaffer/ApplicationRoot.cpp
@@ -130,7 +130,7 @@ std::string ApplicationRoot::preferencesLocation() const
 	}
 
 	std::string result = home;
-	result += "/gaffer/startup/" + getName().string();
+	result += "/gaffer/" + std::to_string( GAFFER_MILESTONE_VERSION ) + "." + std::to_string( GAFFER_MAJOR_VERSION ) + "/startup/" + getName().string();
 
 	boost::filesystem::create_directories( result );
 

--- a/startup/gui/layouts.py
+++ b/startup/gui/layouts.py
@@ -57,7 +57,7 @@ layouts.registerEditor( "PrimitiveInspector")
 # > Note : The easiest way to edit these layouts is to :
 # >
 # >  - Edit the layout in Gaffer itself
-# >  - Save the layout so that it is serialised to `${HOME}/gaffer/startup/gui/layouts.py`
+# >  - Save the layout so that it is serialised to `${HOME}/gaffer/<gafferCompatibilityVersion>/startup/gui/layouts.py`
 # >  - Copy the layout back into this file
 #
 # > Caution : You _must_ omit the `persistent = True` argument when copying layouts into


### PR DESCRIPTION
This should help prevent errors introduced when a user is jumping between two versions of Gaffer.

Note the logic in `bin/gaffer.py` is considerably more complex than I'd originally thought it'd be... could it be simpler? Would I have been better off trying this in the bash wrapper instead?