### PR TITLE
Dispatch App : Change parameter semantics

### DIFF
--- a/apps/dispatch/dispatch-1.py
+++ b/apps/dispatch/dispatch-1.py
@@ -145,8 +145,12 @@ class dispatch( Gaffer.Application ) :
 	def _run( self, args ) :
 
 		if not len( args["tasks"] ) :
-			IECore.msg( IECore.Msg.Level.Error, "gaffer dispatch", "No task nodes were specified" )
-			return 1
+			# fallback to nodes for backwards compatibility
+			if len( args["nodes"] ) :
+				IECore.msg( IECore.Msg.Level.Error, "gaffer dispatch", "Use the \"tasks\" parameter to specify the dispatchable nodes. The \"nodes\" parameter is only for gui purposes." )
+			else :
+				IECore.msg( IECore.Msg.Level.Error, "gaffer dispatch", "No task nodes were specified" )
+				return 1
 
 		script = Gaffer.ScriptNode()
 
@@ -161,7 +165,8 @@ class dispatch( Gaffer.Application ) :
 		self.root()["scripts"].addChild( script )
 
 		tasks = []
-		for taskName in args["tasks"] :
+		# fallback to nodes for backwards compatibility
+		for taskName in args["tasks"] or args["nodes"] :
 			if args["script"].value :
 				task = script.descendant( taskName )
 				if task is None :

--- a/apps/dispatch/dispatch-1.py
+++ b/apps/dispatch/dispatch-1.py
@@ -147,7 +147,7 @@ class dispatch( Gaffer.Application ) :
 		if not len( args["tasks"] ) :
 			# fallback to nodes for backwards compatibility
 			if len( args["nodes"] ) :
-				IECore.msg( IECore.Msg.Level.Error, "gaffer dispatch", "Use the \"tasks\" parameter to specify the dispatchable nodes. The \"nodes\" parameter is only for gui purposes." )
+				IECore.msg( IECore.Msg.Level.Warning, "gaffer dispatch", "Use the \"tasks\" parameter to specify the dispatchable nodes. The \"nodes\" parameter is only for gui purposes." )
 			else :
 				IECore.msg( IECore.Msg.Level.Error, "gaffer dispatch", "No task nodes were specified" )
 				return 1

--- a/apps/dispatch/dispatch-1.py
+++ b/apps/dispatch/dispatch-1.py
@@ -171,8 +171,9 @@ class dispatch( Gaffer.Application ) :
 
 		nodesToShow = []
 		for nodeName in args["show"] :
-			node = self.__acquireNode( nodeName, script, args )
-			if not node :
+			node = script.descendant( nodeName )
+			if node is None :
+				IECore.msg( IECore.Msg.Level.Error, "gaffer dispatch", "\"%s\" does not exist." % nodeName )
 				return 1
 			nodesToShow.append( node )
 

--- a/python/GafferDispatchTest/DispatchApplicationTest.py
+++ b/python/GafferDispatchTest/DispatchApplicationTest.py
@@ -136,13 +136,6 @@ class DispatchApplicationTest( GafferTest.TestCase ) :
 		self.failUnless( "notANode" in "".join( error ) )
 		self.failUnless( p.returncode )
 
-		# nodes without script
-		p = self.waitForCommand( "gaffer dispatch -tasks GafferDispatchTest.TextWriter -nodes test" )
-		error = p.stderr.readlines()
-		self.failUnless( "gaffer dispatch" in "".join( error ) )
-		self.failUnless( "nodes" in "".join( error ) )
-		self.failUnless( p.returncode )
-
 		# bad plugs
 		p = self.waitForCommand( "gaffer dispatch -script {script} -tasks test -settings -test.notAPlug 1".format( script = self.__scriptFileName ) )
 		error = p.stderr.readlines()

--- a/python/GafferDispatchTest/DispatchApplicationTest.py
+++ b/python/GafferDispatchTest/DispatchApplicationTest.py
@@ -129,8 +129,8 @@ class DispatchApplicationTest( GafferTest.TestCase ) :
 		self.failUnless( "notANode" in "".join( error ) )
 		self.failUnless( p.returncode )
 
-		# nodes not in script
-		p = self.waitForCommand( "gaffer dispatch -script {script} -tasks test -nodes notANode".format( script = self.__scriptFileName ) )
+		# nodesToShow not in script
+		p = self.waitForCommand( "gaffer dispatch -script {script} -tasks test -show notANode".format( script = self.__scriptFileName ) )
 		error = p.stderr.readlines()
 		self.failUnless( "gaffer dispatch" in "".join( error ) )
 		self.failUnless( "notANode" in "".join( error ) )

--- a/python/GafferDispatchTest/DispatchApplicationTest.py
+++ b/python/GafferDispatchTest/DispatchApplicationTest.py
@@ -82,76 +82,90 @@ class DispatchApplicationTest( GafferTest.TestCase ) :
 
 	def testErrorReturnStatus( self ) :
 
-		# no nodes
+		# no tasks
 		p = self.waitForCommand( "gaffer dispatch" )
-		self.failUnless( "No nodes were specified" in "".join( p.stderr.readlines() ) )
+		self.failUnless( "No task nodes were specified" in "".join( p.stderr.readlines() ) )
 		self.failUnless( p.returncode )
 
-		# bad nodes
-		p = self.waitForCommand( "gaffer dispatch -nodes Gaffer" )
+		# bad tasks
+		p = self.waitForCommand( "gaffer dispatch -tasks Gaffer" )
 		error = p.stderr.readlines()
 		self.failUnless( "gaffer dispatch" in "".join( error ) )
 		self.failUnless( "Gaffer" in "".join( error ) )
 		self.failUnless( p.returncode )
 
-		# bad nodes in a module
-		p = self.waitForCommand( "gaffer dispatch -nodes Gaffer.NotANode" )
+		# bad tasks in a module
+		p = self.waitForCommand( "gaffer dispatch -tasks Gaffer.NotANode" )
 		error = p.stderr.readlines()
 		self.failUnless( "gaffer dispatch" in "".join( error ) )
 		self.failUnless( "NotANode" in "".join( error ) )
 		self.failUnless( p.returncode )
 
 		# no namespace
-		p = self.waitForCommand( "gaffer dispatch -nodes TextWriter" )
+		p = self.waitForCommand( "gaffer dispatch -tasks TextWriter" )
 		error = p.stderr.readlines()
 		self.failUnless( "gaffer dispatch" in "".join( error ) )
 		self.failUnless( "TextWriter" in "".join( error ) )
 		self.failUnless( p.returncode )
 
 		# bad dispatcher
-		p = self.waitForCommand( "gaffer dispatch -nodes GafferDispatchTest.TextWriter -dispatcher NotADispatcher" )
+		p = self.waitForCommand( "gaffer dispatch -tasks GafferDispatchTest.TextWriter -dispatcher NotADispatcher" )
 		error = p.stderr.readlines()
 		self.failUnless( "gaffer dispatch" in "".join( error ) )
 		self.failUnless( "NotADispatcher" in "".join( error ) )
 		self.failUnless( p.returncode )
 
 		# invalid script
-		p = self.waitForCommand( "gaffer dispatch -script thisScriptDoesNotExist -nodes GafferDispatch.SystemCommand" )
+		p = self.waitForCommand( "gaffer dispatch -script thisScriptDoesNotExist -tasks GafferDispatch.SystemCommand" )
 		self.failUnless( "thisScriptDoesNotExist" in "".join( p.stderr.readlines() ) )
 		self.failUnless( p.returncode )
 
 		self.writeSimpleScript()
 
-		# nodes not in script
-		p = self.waitForCommand( "gaffer dispatch -script {script} -nodes notANode".format( script = self.__scriptFileName ) )
+		# tasks not in script
+		p = self.waitForCommand( "gaffer dispatch -script {script} -tasks notANode".format( script = self.__scriptFileName ) )
 		error = p.stderr.readlines()
 		self.failUnless( "gaffer dispatch" in "".join( error ) )
 		self.failUnless( "notANode" in "".join( error ) )
 		self.failUnless( p.returncode )
 
+		# nodes not in script
+		p = self.waitForCommand( "gaffer dispatch -script {script} -tasks test -nodes notANode".format( script = self.__scriptFileName ) )
+		error = p.stderr.readlines()
+		self.failUnless( "gaffer dispatch" in "".join( error ) )
+		self.failUnless( "notANode" in "".join( error ) )
+		self.failUnless( p.returncode )
+
+		# nodes without script
+		p = self.waitForCommand( "gaffer dispatch -tasks GafferDispatchTest.TextWriter -nodes test" )
+		error = p.stderr.readlines()
+		self.failUnless( "gaffer dispatch" in "".join( error ) )
+		self.failUnless( "nodes" in "".join( error ) )
+		self.failUnless( p.returncode )
+
 		# bad plugs
-		p = self.waitForCommand( "gaffer dispatch -script {script} -nodes test -settings -test.notAPlug 1".format( script = self.__scriptFileName ) )
+		p = self.waitForCommand( "gaffer dispatch -script {script} -tasks test -settings -test.notAPlug 1".format( script = self.__scriptFileName ) )
 		error = p.stderr.readlines()
 		self.failUnless( "gaffer dispatch" in "".join( error ) )
 		self.failUnless( "notAPlug" in "".join( error ) )
 		self.failUnless( p.returncode )
 
 		# bad values (text is a string so needs quotations)
-		p = self.waitForCommand( "gaffer dispatch -script {script} -nodes test -settings -test.text 1".format( script = self.__scriptFileName ) )
+		p = self.waitForCommand( "gaffer dispatch -script {script} -tasks test -settings -test.text 1".format( script = self.__scriptFileName ) )
 		error = p.stderr.readlines()
 		self.failUnless( "gaffer dispatch" in "".join( error ) )
 		self.failUnless( "test.text" in "".join( error ) )
 		self.failUnless( p.returncode )
 
 		# bad dispatcher plugs
-		p = self.waitForCommand( "gaffer dispatch -script {script} -nodes test -settings -LocalDispatcher.notAPlug 1".format( script = self.__scriptFileName ) )
+		p = self.waitForCommand( "gaffer dispatch -script {script} -tasks test -settings -LocalDispatcher.notAPlug 1".format( script = self.__scriptFileName ) )
 		error = p.stderr.readlines()
 		self.failUnless( "gaffer dispatch" in "".join( error ) )
 		self.failUnless( "notAPlug" in "".join( error ) )
 		self.failUnless( p.returncode )
 
 		# bad dispatcher values
-		p = self.waitForCommand( "gaffer dispatch -script {script} -nodes test -settings -LocalDispatcher.executeInBackground '\"its a bool\"'".format( script = self.__scriptFileName ) )
+		p = self.waitForCommand( "gaffer dispatch -script {script} -tasks test -settings -LocalDispatcher.executeInBackground '\"its a bool\"'".format( script = self.__scriptFileName ) )
 		error = p.stderr.readlines()
 		self.failUnless( "gaffer dispatch" in "".join( error ) )
 		self.failUnless( "executeInBackground" in "".join( error ) )
@@ -162,9 +176,9 @@ class DispatchApplicationTest( GafferTest.TestCase ) :
 		self.writeSimpleScript()
 
 		p = self.waitForCommand(
-			"gaffer dispatch -script {script} -nodes {node}".format(
+			"gaffer dispatch -script {script} -tasks {task}".format(
 				script = self.__scriptFileName,
-				node = "test",
+				task = "test",
 			)
 		)
 		error = "".join( p.stderr.readlines() )
@@ -183,9 +197,9 @@ class DispatchApplicationTest( GafferTest.TestCase ) :
 		s.save()
 
 		p = self.waitForCommand(
-			"gaffer dispatch -script {script} -nodes {node}".format(
+			"gaffer dispatch -script {script} -tasks {task}".format(
 				script = self.__scriptFileName,
-				node = "test",
+				task = "test",
 			)
 		)
 		error = "".join( p.stderr.readlines() )
@@ -196,9 +210,9 @@ class DispatchApplicationTest( GafferTest.TestCase ) :
 		self.failIf( os.path.exists( self.__outputTextFile ) )
 
 		p = self.waitForCommand(
-			"gaffer dispatch -ignoreScriptLoadErrors -script {script} -nodes {node}".format(
+			"gaffer dispatch -ignoreScriptLoadErrors -script {script} -tasks {task}".format(
 				script = self.__scriptFileName,
-				node = "test",
+				task = "test",
 			)
 		)
 		error = "".join( p.stderr.readlines() )
@@ -211,8 +225,8 @@ class DispatchApplicationTest( GafferTest.TestCase ) :
 	def testNodesWithoutScript( self ) :
 
 		p = self.waitForCommand(
-			"gaffer dispatch -nodes {node} -settings -TextWriter.fileName '\"{output}\"' -TextWriter.text '\"{text}\"'".format(
-				node = "GafferDispatchTest.TextWriter",
+			"gaffer dispatch -tasks {task} -settings -TextWriter.fileName '\"{output}\"' -TextWriter.text '\"{text}\"'".format(
+				task = "GafferDispatchTest.TextWriter",
 				output = self.__outputTextFile,
 				text = "command line test",
 			)
@@ -226,8 +240,8 @@ class DispatchApplicationTest( GafferTest.TestCase ) :
 	def testApplyUserDefaults( self ) :
 
 		p = self.waitForCommand(
-			"gaffer dispatch -nodes {node} -applyUserDefaults -settings -TextWriter.fileName '\"{output}\"' -TextWriter.text '\"{text}\"'".format(
-				node = "GafferDispatchTest.TextWriter",
+			"gaffer dispatch -tasks {task} -applyUserDefaults -settings -TextWriter.fileName '\"{output}\"' -TextWriter.text '\"{text}\"'".format(
+				task = "GafferDispatchTest.TextWriter",
 				output = self.__outputTextFile,
 				text = "userDefault test ${dispatcher:jobDirectory}",
 			)
@@ -250,9 +264,9 @@ class DispatchApplicationTest( GafferTest.TestCase ) :
 		# this can be done as there aren't other dispatchers available to test with.
 
 		p = self.waitForCommand(
-			"gaffer dispatch -script {script} -nodes {node} -dispatcher Local -settings -dispatcher.framesMode {mode}".format(
+			"gaffer dispatch -script {script} -tasks {task} -dispatcher Local -settings -dispatcher.framesMode {mode}".format(
 				script = self.__scriptFileName,
-				node = "test",
+				task = "test",
 				mode = int(GafferDispatch.Dispatcher.FramesMode.FullRange),
 			)
 		)
@@ -265,8 +279,8 @@ class DispatchApplicationTest( GafferTest.TestCase ) :
 	def testContextVariables( self ) :
 
 		p = self.waitForCommand(
-			"gaffer dispatch -nodes {node} -settings -TextWriter.fileName '\"{output}\"' -TextWriter.text '\"{text}\"' -context.myVar 1.25".format(
-				node = "GafferDispatchTest.TextWriter",
+			"gaffer dispatch -tasks {task} -settings -TextWriter.fileName '\"{output}\"' -TextWriter.text '\"{text}\"' -context.myVar 1.25".format(
+				task = "GafferDispatchTest.TextWriter",
 				output = self.__outputTextFile,
 				text = "context ${myVar} test",
 			)
@@ -286,9 +300,9 @@ class DispatchApplicationTest( GafferTest.TestCase ) :
 		s.save()
 
 		p = self.waitForCommand(
-			"gaffer dispatch -script {script} -nodes {node} -settings -box.test.text '\"{text}\"'".format(
+			"gaffer dispatch -script {script} -tasks {task} -settings -box.test.text '\"{text}\"'".format(
 				script = self.__scriptFileName,
-				node = "box",
+				task = "box",
 				text = "test inside a box",
 			)
 		)
@@ -307,10 +321,10 @@ class DispatchApplicationTest( GafferTest.TestCase ) :
 		s.save()
 
 		p = self.waitForCommand(
-			"gaffer dispatch -script {script} -nodes {nodeA} {nodeB}".format(
+			"gaffer dispatch -script {script} -tasks {taskA} {taskB}".format(
 				script = self.__scriptFileName,
-				nodeA = "test",
-				nodeB = "test2",
+				taskA = "test",
+				taskB = "test2",
 			)
 		)
 		error = "".join( p.stderr.readlines() )

--- a/python/GafferDispatchUI/DispatchDialogue.py
+++ b/python/GafferDispatchUI/DispatchDialogue.py
@@ -58,7 +58,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 
 	__dispatchDialogueMenuDefinition = None
 
-	def __init__( self, tasks, dispatchers, nodes, postDispatchBehaviour=PostDispatchBehaviour.Confirm, title="Dispatch Tasks", sizeMode=GafferUI.Window.SizeMode.Manual, **kw ) :
+	def __init__( self, tasks, dispatchers, nodesToShow, postDispatchBehaviour=PostDispatchBehaviour.Confirm, title="Dispatch Tasks", sizeMode=GafferUI.Window.SizeMode.Manual, **kw ) :
 
 		GafferUI.Dialogue.__init__( self, title, sizeMode=sizeMode, **kw )
 
@@ -66,7 +66,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 
 		self.__dispatchers = dispatchers
 		self.__tasks = tasks
-		self.__nodes = nodes
+		self.__nodesToShow = nodesToShow
 		self.__script = tasks[0].scriptNode()
 		# hold a reference to the script window so plugs which launch child windows work properly.
 		# this is necessary for PlugValueWidgets like color swatches and ramps. Ideally those widgets
@@ -83,7 +83,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 
 			with GafferUI.TabbedContainer() as self.__tabs :
 
-				for node in self.__nodes :
+				for node in self.__nodesToShow :
 					nodeFrame = GafferUI.Frame( borderStyle=GafferUI.Frame.BorderStyle.None, borderWidth=0 )
 					nodeFrame.addChild( self.__nodeEditor( node ) )
 					# remove the per-node execute button
@@ -130,7 +130,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 		self.__initiateSettings( self.__primaryButton )
 
 	@staticmethod
-	def createWithDefaultDispatchers( tasks, nodes, defaultDispatcherType=None, postDispatchBehaviour=PostDispatchBehaviour.Confirm, title="Dispatch Tasks", sizeMode=GafferUI.Window.SizeMode.Manual, **kw ) :
+	def createWithDefaultDispatchers( tasks, nodesToShow, defaultDispatcherType=None, postDispatchBehaviour=PostDispatchBehaviour.Confirm, title="Dispatch Tasks", sizeMode=GafferUI.Window.SizeMode.Manual, **kw ) :
 
 		defaultType = defaultDispatcherType if defaultDispatcherType else GafferDispatch.Dispatcher.getDefaultDispatcherType()
 		dispatcherTypes = list(GafferDispatch.Dispatcher.registeredDispatchers())
@@ -144,7 +144,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 			Gaffer.NodeAlgo.applyUserDefaults( dispatcher )
 			dispatchers.append( dispatcher )
 
-		return DispatchDialogue( tasks, dispatchers, nodes, postDispatchBehaviour=postDispatchBehaviour, title = title, sizeMode = sizeMode, **kw )
+		return DispatchDialogue( tasks, dispatchers, nodesToShow, postDispatchBehaviour=postDispatchBehaviour, title = title, sizeMode = sizeMode, **kw )
 
 	def scriptNode( self ) :
 

--- a/python/GafferDispatchUI/DispatchDialogue.py
+++ b/python/GafferDispatchUI/DispatchDialogue.py
@@ -58,7 +58,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 
 	__dispatchDialogueMenuDefinition = None
 
-	def __init__( self, tasks, dispatchers, postDispatchBehaviour=PostDispatchBehaviour.Confirm, title="Dispatch Tasks", sizeMode=GafferUI.Window.SizeMode.Manual, **kw ) :
+	def __init__( self, tasks, dispatchers, nodes, postDispatchBehaviour=PostDispatchBehaviour.Confirm, title="Dispatch Tasks", sizeMode=GafferUI.Window.SizeMode.Manual, **kw ) :
 
 		GafferUI.Dialogue.__init__( self, title, sizeMode=sizeMode, **kw )
 
@@ -66,6 +66,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 
 		self.__dispatchers = dispatchers
 		self.__tasks = tasks
+		self.__nodes = nodes
 		self.__script = tasks[0].scriptNode()
 		# hold a reference to the script window so plugs which launch child windows work properly.
 		# this is necessary for PlugValueWidgets like color swatches and ramps. Ideally those widgets
@@ -82,12 +83,12 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 
 			with GafferUI.TabbedContainer() as self.__tabs :
 
-				for task in self.__tasks :
-					taskFrame = GafferUI.Frame( borderStyle=GafferUI.Frame.BorderStyle.None, borderWidth=0 )
-					taskFrame.addChild( self.__nodeEditor( task ) )
+				for node in self.__nodes :
+					nodeFrame = GafferUI.Frame( borderStyle=GafferUI.Frame.BorderStyle.None, borderWidth=0 )
+					nodeFrame.addChild( self.__nodeEditor( node ) )
 					# remove the per-node execute button
-					Gaffer.Metadata.registerValue( task, "layout:customWidget:dispatchButton:widgetType", "", persistent = False )
-					self.__tabs.setLabel( taskFrame, task.relativeName( self.__script ) )
+					Gaffer.Metadata.registerValue( node, "layout:customWidget:dispatchButton:widgetType", "", persistent = False )
+					self.__tabs.setLabel( nodeFrame, node.relativeName( self.__script ) )
 
 				with GafferUI.ListContainer() as dispatcherTab :
 
@@ -129,7 +130,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 		self.__initiateSettings( self.__primaryButton )
 
 	@staticmethod
-	def createWithDefaultDispatchers( tasks, defaultDispatcherType=None, postDispatchBehaviour=PostDispatchBehaviour.Confirm, title="Dispatch Tasks", sizeMode=GafferUI.Window.SizeMode.Manual, **kw ) :
+	def createWithDefaultDispatchers( tasks, nodes, defaultDispatcherType=None, postDispatchBehaviour=PostDispatchBehaviour.Confirm, title="Dispatch Tasks", sizeMode=GafferUI.Window.SizeMode.Manual, **kw ) :
 
 		defaultType = defaultDispatcherType if defaultDispatcherType else GafferDispatch.Dispatcher.getDefaultDispatcherType()
 		dispatcherTypes = list(GafferDispatch.Dispatcher.registeredDispatchers())
@@ -143,7 +144,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 			Gaffer.NodeAlgo.applyUserDefaults( dispatcher )
 			dispatchers.append( dispatcher )
 
-		return DispatchDialogue( tasks, dispatchers, postDispatchBehaviour=postDispatchBehaviour, title = title, sizeMode = sizeMode, **kw )
+		return DispatchDialogue( tasks, dispatchers, nodes, postDispatchBehaviour=postDispatchBehaviour, title = title, sizeMode = sizeMode, **kw )
 
 	def scriptNode( self ) :
 


### PR DESCRIPTION
It seems reasonable to use the `DispatchDialogue` with no visible task nodes, in the case of a pre-made script. This allows the user to differentiate between tasks to dispatch and nodes to display.

- Added `-tasks` for specifying the task nodes to dispatch.
- Changed `-nodes` to specify which node UIs should be shown in `-gui` mode.

I've provided backwards compatibility since we have a few instances of the `gaffer dispatch` commandline in production, but I think its contained enough at IE that I could drop those commits if we'd rather just move on. I will probably need to backport this to 0.51 though.