### PR TITLE
GafferSceneModule : Bind with TaskNodeWrapper

### DIFF
--- a/src/GafferSceneModule/IOBinding.cpp
+++ b/src/GafferSceneModule/IOBinding.cpp
@@ -74,6 +74,6 @@ void GafferSceneModule::bindIO()
 		.staticmethod( "supportedExtensions" )
 	;
 
-	GafferDispatchBindings::TaskNodeClass<SceneWriter>();
-
+	typedef GafferDispatchBindings::TaskNodeWrapper<SceneWriter> SceneWriterWrapper;
+	GafferDispatchBindings::TaskNodeClass<SceneWriter, SceneWriterWrapper>();
 }


### PR DESCRIPTION
By defining `SceneWriterWrapper` as a `TaskNodeWrapper`, Python classes can now inherit from `SceneWriter` and override its methods. This is similar to how the bindings work for `ImageWriter`.

Would it be possible to backport to Gaffer 0.51 as well?