### PR TITLE
GafferImage::Grade : Can't pass-through channels if clamping is on

### DIFF
--- a/python/GafferImageTest/GradeTest.py
+++ b/python/GafferImageTest/GradeTest.py
@@ -145,11 +145,12 @@ class GradeTest( GafferImageTest.ImageTestCase ) :
 	def testChannelPassThrough( self ) :
 
 		# we should get a perfect pass-through without cache duplication when
-		# all the colour plugs are at their defaults.
+		# all the colour plugs are at their defaults and clamping is disabled
 
 		s = Gaffer.ScriptNode()
 		s["c"] = GafferImage.Constant()
 		s["g"] = GafferImage.Grade()
+		s["g"]["blackClamp"].setValue( False )
 		s["g"]["in"].setInput( s["c"]["out"] )
 
 		for channelName in ( "R", "G", "B", "A" ) :

--- a/src/GafferImage/Grade.cpp
+++ b/src/GafferImage/Grade.cpp
@@ -190,7 +190,7 @@ bool Grade::channelEnabled( const std::string &channel ) const
 		return false;
 	}
 
-	return gamma != 1.0f || a != 1.0f || b != 0.0f;
+	return gamma != 1.0f || a != 1.0f || b != 0.0f || blackClampPlug()->getValue() || whiteClampPlug()->getValue();
 }
 
 void Grade::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const


### PR DESCRIPTION
Grade passes through the input if the grade is a no-op - but if clamping is on, then it's not a no-op, and can't pass through.