### PR TITLE
Rectangle node

### DIFF
--- a/include/GafferImage/Rectangle.h
+++ b/include/GafferImage/Rectangle.h
@@ -1,0 +1,96 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERIMAGE_RECTANGLE_H
+#define GAFFERIMAGE_RECTANGLE_H
+
+#include "GafferImage/Shape.h"
+
+#include "Gaffer/BoxPlug.h"
+
+namespace Gaffer
+{
+
+class Transform2DPlug;
+
+} // namespace Gaffer
+
+namespace GafferImage
+{
+
+class GAFFERIMAGE_API Rectangle : public Shape
+{
+
+	public :
+
+		Rectangle( const std::string &name=defaultName<Rectangle>() );
+		~Rectangle() override;
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferImage::Rectangle, RectangleTypeId, Shape );
+
+		Gaffer::Box2fPlug *areaPlug();
+		const Gaffer::Box2fPlug *areaPlug() const;
+
+		Gaffer::FloatPlug *lineWidthPlug();
+		const Gaffer::FloatPlug *lineWidthPlug() const;
+
+		Gaffer::FloatPlug *cornerRadiusPlug();
+		const Gaffer::FloatPlug *cornerRadiusPlug() const;
+
+		Gaffer::Transform2DPlug *transformPlug();
+		const Gaffer::Transform2DPlug *transformPlug() const;
+
+	protected :
+
+		bool affectsShapeDataWindow( const Gaffer::Plug *input ) const override;
+		void hashShapeDataWindow( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box2i computeShapeDataWindow( const Gaffer::Context *context ) const override;
+
+		bool affectsShapeChannelData( const Gaffer::Plug *input ) const override;
+		void hashShapeChannelData( const Imath::V2i &tileOrigin, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstFloatVectorDataPtr computeShapeChannelData(  const Imath::V2i &tileOrigin, const Gaffer::Context *context ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( Rectangle )
+
+} // namespace GafferImage
+
+#endif // GAFFERIMAGE_RECTANGLE_H

--- a/include/GafferImage/TypeIds.h
+++ b/include/GafferImage/TypeIds.h
@@ -117,6 +117,7 @@ enum TypeId
 	ErodeTypeId = 110821,
 	DilateTypeId = 110822,
 	RampTypeId = 110823,
+	RectangleTypeId = 110824,
 
 	LastTypeId = 110849
 };

--- a/python/GafferImageTest/RectangleTest.py
+++ b/python/GafferImageTest/RectangleTest.py
@@ -1,0 +1,80 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+import imath
+
+import IECore
+
+import Gaffer
+import GafferImage
+import GafferImageTest
+
+class RectangleTest( GafferImageTest.ImageTestCase ) :
+
+	def testDataWindow( self ) :
+
+		a = imath.Box2f( imath.V2f( 10 ), imath.V2f( 100 ) )
+
+		r = GafferImage.Rectangle()
+		r["area"].setValue( a )
+		r["lineWidth"].setValue( 10 )
+
+		dw = r["out"]["dataWindow"].getValue()
+		self.assertEqual( dw.min(), imath.V2i( a.min() ) - imath.V2i( 5 ) )
+		self.assertEqual( dw.max(), imath.V2i( a.max() ) + imath.V2i( 5 ) )
+
+	def testChannelData( self ) :
+
+		a = imath.Box2f( imath.V2f( 0.5 ), imath.V2f( 49.5 ) )
+
+		r = GafferImage.Rectangle()
+		r["area"].setValue( a )
+		r["lineWidth"].setValue( 1 )
+
+		w = r["out"]["dataWindow"].getValue()
+		s = GafferImage.Sampler( r["out"], "R", w )
+
+		for y in range( w.min().y, w.max().y ) :
+			for x in range( w.min().x, w.max().x ) :
+				v = s.sample( x, y )
+				if x == 0 or x == 49 or y == 0 or y == 49 :
+					self.assertEqual( v, 1 )
+				else :
+					self.assertEqual( v, 0 )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferImageTest/__init__.py
+++ b/python/GafferImageTest/__init__.py
@@ -95,6 +95,7 @@ from CatalogueTest import CatalogueTest
 from CollectImagesTest import CollectImagesTest
 from CatalogueSelectTest import CatalogueSelectTest
 from BleedFillTest import BleedFillTest
+from RectangleTest import RectangleTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferImageUI/RectangleUI.py
+++ b/python/GafferImageUI/RectangleUI.py
@@ -1,7 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
-#  Copyright (c) 2012-2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2018, John Haddon. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -35,68 +34,102 @@
 #
 ##########################################################################
 
-__import__( "GafferUI" )
+import imath
 
-from _GafferImageUI import *
+import IECore
 
-import DisplayUI
-from FormatPlugValueWidget import FormatPlugValueWidget
-from ChannelMaskPlugValueWidget import ChannelMaskPlugValueWidget
-from RGBAChannelsPlugValueWidget import RGBAChannelsPlugValueWidget
-from ChannelPlugValueWidget import ChannelPlugValueWidget
+import Gaffer
+import GafferImage
 
-import ImageReaderPathPreview
+## A function suitable as the postCreator in a NodeMenu.append() call. It
+# sets the rectangle area relative to the input format.
+def postCreate( node, menu ) :
 
-import OpenImageIOReaderUI
-import ImageReaderUI
-import ImageViewUI
-import ImageTransformUI
-import ConstantUI
-import CheckerboardUI
-import RampUI
-import ColorSpaceUI
-import ImageStatsUI
-import DeleteChannelsUI
-import ObjectToImageUI
-import ClampUI
-import ImageWriterUI
-import GradeUI
-import ImageSamplerUI
-import MergeUI
-import ImageNodeUI
-import ChannelDataProcessorUI
-import ImageProcessorUI
-import ImageMetadataUI
-import DeleteImageMetadataUI
-import CopyImageMetadataUI
-import ShuffleUI
-import PremultiplyUI
-import UnpremultiplyUI
-import CropUI
-import ResizeUI
-import ResampleUI
-import LUTUI
-import CDLUI
-import DisplayTransformUI
-import OpenColorIOTransformUI
-import OffsetUI
-import BlurUI
-import ShapeUI
-import TextUI
-import WarpUI
-import VectorWarpUI
-import MirrorUI
-import CopyChannelsUI
-import MedianUI
-import RankFilterUI
-import ErodeUI
-import DilateUI
-import ColorProcessorUI
-import MixUI
-import CatalogueUI
-import CollectImagesUI
-import CatalogueSelectUI
-import BleedFillUI
-import RectangleUI
+	with node.scriptNode().context() :
+		if node["in"].getInput() :
+			format = node["in"]["format"].getValue()
+		else:
+			format = GafferImage.FormatPlug.getDefaultFormat( node.scriptNode().context() )
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferImageUI" )
+	node["area"].setValue(
+		imath.Box2f(
+			imath.V2f( format.getDisplayWindow().min() ) + imath.V2f( 10 ),
+			imath.V2f( format.getDisplayWindow().max() ) - imath.V2f( 10 ),
+		)
+	)
+
+Gaffer.Metadata.registerNode(
+
+	GafferImage.Rectangle,
+
+	"description",
+	"""
+	Renders a rectangle with adjustable line width, corner radius,
+	drop shadow and transform.
+	""",
+
+	plugs = {
+
+		"color" : [
+
+			"description",
+			"""
+			The colour of the rectangle.
+			""",
+
+		],
+
+		"area" : [
+
+			"description",
+			"""
+			The area of the rectangle before the transform is applied.
+			""",
+
+		],
+
+		"lineWidth" : [
+
+			"description",
+			"""
+			The width of the outline, measured in pixels.
+			""",
+
+		],
+
+		"cornerRadius" : [
+
+			"description",
+			"""
+			Used to give the rectangle rounded corners. A radius of
+			0 gives square corners.
+			""",
+
+		],
+
+		"transform" : [
+
+			"description",
+			"""
+			Transformation applied to the rectangle.
+			""",
+
+		],
+
+		"transform" : [
+
+			"description",
+			"""
+			A transformation applied to the rectangle. The translate and
+			pivot values are specified in pixels, and the rotate value is
+			specified in degrees.
+			""",
+
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
+			"layout:section", "Transform",
+
+		],
+
+	}
+
+)

--- a/src/GafferImage/Checkerboard.cpp
+++ b/src/GafferImage/Checkerboard.cpp
@@ -262,12 +262,14 @@ IECore::ConstFloatVectorDataPtr Checkerboard::computeChannelData( const std::str
 	const float valueB = colorBPlug()->getChild( channelIndex )->getValue();
 	const V2f size = sizePlug()->getValue();
 	const M33f transform = transformPlug()->matrix();
+	const M33f inverseTransform = transform.inverse();
+
 	V2f baseA( 1, 0 );
 	V2f filterWidthA;
 	V2f baseB( 0, 1 );
 	V2f filterWidthB;
-	transform.inverse().multDirMatrix( baseA, filterWidthA );
-	transform.inverse().multDirMatrix( baseB, filterWidthB );
+	inverseTransform.multDirMatrix( baseA, filterWidthA );
+	inverseTransform.multDirMatrix( baseB, filterWidthB );
 	V2f filterWidth( fabs( filterWidthA.x ) + fabs( filterWidthB.x ), fabs( filterWidthA.y ) + fabs( filterWidthB.y ) );
 
 	FloatVectorDataPtr resultData = new FloatVectorData;
@@ -283,7 +285,7 @@ IECore::ConstFloatVectorDataPtr Checkerboard::computeChannelData( const std::str
 		for( int x = 0; x < ImagePlug::tileSize(); ++x )
 		{
 			V2f p( tileOrigin.x + x + .5f, tileOrigin.y + y + .5f );
-			p *= transform.inverse();
+			p *= inverseTransform;
 
 			w0 = filteredStripes( p.x, size.x, filterWidth.x );
 			h0 = filteredStripes( p.y, size.y, filterWidth.y );

--- a/src/GafferImage/Rectangle.cpp
+++ b/src/GafferImage/Rectangle.cpp
@@ -1,0 +1,296 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferImage/Rectangle.h"
+
+#include "Gaffer/Transform2DPlug.h"
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferImage;
+
+//////////////////////////////////////////////////////////////////////////
+// Utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+// Rounds min down, and max up, while converting from float to int.
+Box2i box2fToBox2i( const Box2f &b )
+{
+	return Box2i(
+		V2i( floor( b.min.x ), floor( b.min.y ) ),
+		V2i( ceil( b.max.x ), ceil( b.max.y ) )
+	);
+}
+
+Box2f transform( const Box2f &b, const M33f &m )
+{
+	if( b.isEmpty() )
+	{
+		return b;
+	}
+
+	Box2f r;
+	r.extendBy( V2f( b.min.x, b.min.y ) * m );
+	r.extendBy( V2f( b.max.x, b.min.y ) * m );
+	r.extendBy( V2f( b.max.x, b.max.y ) * m );
+	r.extendBy( V2f( b.min.x, b.max.y ) * m );
+	return r;
+}
+
+float filteredPulse( float edge0, float edge1, float x, float w )
+{
+	float x0 = x - w / 2.0;
+	float x1 = x + w / 2.0;
+	return std::max( 0.0f, ( std::min( x1, edge1 ) - std::max( x0, edge0 ) ) / w );
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Rectangle
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( Rectangle );
+
+size_t Rectangle::g_firstPlugIndex = 0;
+
+Rectangle::Rectangle( const std::string &name )
+	:	Shape( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new Box2fPlug( "area", Plug::In, Box2f( V2f( 0 ), V2f( 100 ) ) ) );
+	addChild( new FloatPlug( "lineWidth", Plug::In, 4.0f, 0.0f ) );
+	addChild( new FloatPlug( "cornerRadius", Plug::In, 0.0f, 0.0f ) );
+	addChild( new Transform2DPlug( "transform" ) );
+}
+
+Rectangle::~Rectangle()
+{
+}
+
+Gaffer::Box2fPlug *Rectangle::areaPlug()
+{
+	return getChild<Box2fPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::Box2fPlug *Rectangle::areaPlug() const
+{
+	return getChild<Box2fPlug>( g_firstPlugIndex );
+}
+
+Gaffer::FloatPlug *Rectangle::lineWidthPlug()
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::FloatPlug *Rectangle::lineWidthPlug() const
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::FloatPlug *Rectangle::cornerRadiusPlug()
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::FloatPlug *Rectangle::cornerRadiusPlug() const
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::Transform2DPlug *Rectangle::transformPlug()
+{
+	return getChild<Transform2DPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::Transform2DPlug *Rectangle::transformPlug() const
+{
+	return getChild<Transform2DPlug>( g_firstPlugIndex + 3 );
+}
+
+bool Rectangle::affectsShapeDataWindow( const Gaffer::Plug *input ) const
+{
+	if( Shape::affectsShapeDataWindow( input ) )
+	{
+		return true;
+	}
+
+	return
+		areaPlug()->isAncestorOf( input ) ||
+		input == lineWidthPlug() ||
+		transformPlug()->isAncestorOf( input )
+	;
+}
+
+void Rectangle::hashShapeDataWindow( const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	Shape::hashShapeDataWindow( context, h );
+
+	areaPlug()->hash( h );
+	lineWidthPlug()->hash( h );
+	transformPlug()->hash( h );
+}
+
+Imath::Box2i Rectangle::computeShapeDataWindow( const Gaffer::Context *context ) const
+{
+	Box2f b;
+	b.extendBy( areaPlug()->minPlug()->getValue() );
+	b.extendBy( areaPlug()->maxPlug()->getValue() );
+
+	const float lineWidth = lineWidthPlug()->getValue();
+	b.min -= V2f( lineWidth / 2.0f );
+	b.max += V2f( lineWidth / 2.0f );
+
+	b = transform( b, transformPlug()->matrix() );
+
+	return box2fToBox2i( b );
+}
+
+bool Rectangle::affectsShapeChannelData( const Gaffer::Plug *input ) const
+{
+	if( Shape::affectsShapeChannelData( input ) )
+	{
+		return true;
+	}
+
+	return
+		areaPlug()->isAncestorOf( input ) ||
+		input == lineWidthPlug() ||
+		input == cornerRadiusPlug() ||
+		transformPlug()->isAncestorOf( input )
+	;
+}
+
+void Rectangle::hashShapeChannelData( const Imath::V2i &tileOrigin, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	Shape::hashShapeChannelData( tileOrigin, context, h );
+
+	h.append( tileOrigin );
+	areaPlug()->hash( h );
+	lineWidthPlug()->hash( h );
+	cornerRadiusPlug()->hash( h );
+	transformPlug()->hash( h );
+}
+
+IECore::ConstFloatVectorDataPtr Rectangle::computeShapeChannelData(  const Imath::V2i &tileOrigin, const Gaffer::Context *context ) const
+{
+	// Get our inputs
+
+	Box2f area;
+	area.extendBy( areaPlug()->minPlug()->getValue() );
+	area.extendBy( areaPlug()->maxPlug()->getValue() );
+	const V2f halfSize = area.size() / 2.0f;
+
+	const float lineWidth = lineWidthPlug()->getValue();
+
+	const M33f transform = transformPlug()->matrix();
+	const M33f inverseTransform = transform.inverse();
+
+	float cornerRadius = cornerRadiusPlug()->getValue();
+	cornerRadius = std::min( cornerRadius, halfSize.x );
+	cornerRadius = std::min( cornerRadius, halfSize.y );
+	const V2f radiusCenter = area.max - area.center() - V2f( cornerRadius );
+
+	// Figure out a filter width to use later.
+	// See https://renderman.pixar.com/resources/RenderMan_20/basicAntialiasing.html.
+
+	V2f du( 1.0f, 0.0f );
+	V2f dv( 0.0f, 1.0f );
+	inverseTransform.multDirMatrix( du, du );
+	inverseTransform.multDirMatrix( dv, dv );
+
+	const float filterWidth = sqrt( du.cross( dv ) );
+
+	// Prepare data to return
+
+	FloatVectorDataPtr resultData = new FloatVectorData();
+	vector<float> &result = resultData->writable();
+	result.reserve( ImagePlug::tileSize() * ImagePlug::tileSize() );
+	const Box2i tileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
+
+	// Generate the pixels. The general idea is to make a signed
+	// distance field from the edge of the shape, and then use
+	// `filteredPulse()` to draw an antialised line within it.
+
+	V2i pi;
+	for( pi.y = tileBound.min.y; pi.y < tileBound.max.y; ++pi.y )
+	{
+		for( pi.x = tileBound.min.x; pi.x < tileBound.max.x; ++pi.x )
+		{
+			// Convert from pixel position into
+			// the coordinate system of the rectangle.
+			V2f p = V2f( pi ) + V2f( 0.5 );
+			p *= inverseTransform;
+
+			// Flip into positive quadrant, relative
+			// to rectangle center.
+			p = V2f(
+				fabs( p.x - area.center().x ),
+				fabs( p.y - area.center().y )
+			);
+
+			// Get signed distance for basic rectangle.
+			// We use manhattan distance because it gives
+			// square corners.
+
+			const float xd = p.x - area.size().x / 2.0f;
+			const float yd = p.y - area.size().y / 2.0f;
+			float d = max( xd, yd );
+
+			// Adjust to account for rounded corners if
+			// we want them.
+
+			if( cornerRadius > 0 )
+			{
+				if( p.x > radiusCenter.x && p.y > radiusCenter.y )
+				{
+					const V2f v = p - radiusCenter;
+					d = max( d, v.length() - cornerRadius );
+				}
+			}
+
+			// Draw line
+			result.push_back( filteredPulse( -lineWidth / 2.0f, lineWidth / 2.0f, d, filterWidth ) );
+		}
+	}
+
+	return resultData;
+}

--- a/src/GafferImageModule/ShapeBinding.cpp
+++ b/src/GafferImageModule/ShapeBinding.cpp
@@ -38,6 +38,7 @@
 
 #include "GafferImage/Shape.h"
 #include "GafferImage/Text.h"
+#include "GafferImage/Rectangle.h"
 
 #include "GafferBindings/DependencyNodeBinding.h"
 
@@ -49,6 +50,7 @@ void GafferImageModule::bindShape()
 {
 
 	DependencyNodeClass<Shape>();
+	DependencyNodeClass<Rectangle>();
 
 	{
 		scope s = GafferBindings::DependencyNodeClass<Text>();

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -350,6 +350,7 @@ import GafferImageUI
 
 nodeMenu.append( "/Image/File/Reader", GafferImage.ImageReader, searchText = "ImageReader" )
 nodeMenu.append( "/Image/File/Writer", GafferImage.ImageWriter, searchText = "ImageWriter" )
+nodeMenu.append( "/Image/Shape/Rectangle", GafferImage.Rectangle, postCreator = GafferImageUI.RectangleUI.postCreate )
 nodeMenu.append( "/Image/Shape/Text", GafferImage.Text, postCreator = GafferImageUI.TextUI.postCreate )
 nodeMenu.append( "/Image/Pattern/Constant", GafferImage.Constant )
 nodeMenu.append( "/Image/Pattern/Checkerboard", GafferImageUI.CheckerboardUI.nodeMenuCreateCommand )


### PR DESCRIPTION
This adds a simple node for drawing a rectangle over an image. It derives from the Shape class, which gives it the ability to have a drop shadow and stuff. There's probably a good case for giving it an optional fill colour, but this isn't something the base class supports, or something I need right now, so I'm leaving that as future work. I've put this together to be used in adding annotations to images, with the aim of using it to improve the automated screen grabs we use in the documentation. I'd like to make something where you can add "annotate me" metadata to nodes and plugs, so that you can save a script as a recipe for its own screenshot and then let the documentation build do the rest.
<img width="811" alt="rectangle" src="https://user-images.githubusercontent.com/1133871/48962063-a185a280-ef72-11e8-9e50-3442d57f9772.png">
