### PR TITLE
Wireframe node

### DIFF
--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -55,7 +55,7 @@ enum TypeId
 	GroupTypeId = 110510,
 	ShaderPlugTypeId = 110511,
 	UDIMQueryTypeId = 110512,
-	SceneTimeWarpTypeId = 110513, // Obsolete, available for reuse
+	WireframeTypeId = 110513,
 	ObjectSourceTypeId = 110514,
 	PlaneTypeId = 110515,
 	SeedsTypeId = 110516,
@@ -149,7 +149,6 @@ enum TypeId
 	PrimitiveVariableExistsTypeId = 110604,
 	CollectTransformsTypeId = 110605,
 	CameraTweaksTypeId = 110606,
-	WireframeTypeId = 110607,
 
 	PreviewGeometryTypeId = 110648,
 	PreviewProceduralTypeId = 110649,

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -149,6 +149,7 @@ enum TypeId
 	PrimitiveVariableExistsTypeId = 110604,
 	CollectTransformsTypeId = 110605,
 	CameraTweaksTypeId = 110606,
+	WireframeTypeId = 110607,
 
 	PreviewGeometryTypeId = 110648,
 	PreviewProceduralTypeId = 110649,

--- a/include/GafferScene/Wireframe.h
+++ b/include/GafferScene/Wireframe.h
@@ -69,6 +69,10 @@ class GAFFERSCENE_API Wireframe : public SceneElementProcessor
 
 	protected :
 
+		bool processesBound() const override;
+		void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const override;
+
 		bool processesObject() const override;
 		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;

--- a/include/GafferScene/Wireframe.h
+++ b/include/GafferScene/Wireframe.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2018, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,48 +34,53 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERSCENE_WIREFRAME_H
+#define GAFFERSCENE_WIREFRAME_H
 
-#include "ObjectProcessorBinding.h"
+#include "GafferScene/SceneElementProcessor.h"
 
-#include "GafferScene/DeleteCurves.h"
-#include "GafferScene/DeleteFaces.h"
-#include "GafferScene/DeleteObject.h"
-#include "GafferScene/DeletePoints.h"
-#include "GafferScene/LightToCamera.h"
-#include "GafferScene/MeshDistortion.h"
-#include "GafferScene/MeshTangents.h"
-#include "GafferScene/MeshToPoints.h"
-#include "GafferScene/MeshType.h"
-#include "GafferScene/Parameters.h"
-#include "GafferScene/PointsType.h"
-#include "GafferScene/ReverseWinding.h"
-#include "GafferScene/UDIMQuery.h"
-#include "GafferScene/Wireframe.h"
-
-#include "GafferBindings/DependencyNodeBinding.h"
-
-using namespace boost::python;
-using namespace Gaffer;
-using namespace GafferBindings;
-using namespace GafferScene;
-
-void GafferSceneModule::bindObjectProcessor()
+namespace Gaffer
 {
 
-	GafferBindings::DependencyNodeClass<GafferScene::DeletePoints>();
-	GafferBindings::DependencyNodeClass<GafferScene::DeleteFaces>();
-	GafferBindings::DependencyNodeClass<GafferScene::DeleteCurves>();
-	GafferBindings::DependencyNodeClass<GafferScene::MeshTangents>();
-	GafferBindings::DependencyNodeClass<GafferScene::PointsType>();
-	GafferBindings::DependencyNodeClass<GafferScene::MeshToPoints>();
-	GafferBindings::DependencyNodeClass<MeshType>();
-	GafferBindings::DependencyNodeClass<GafferScene::LightToCamera>();
-	GafferBindings::DependencyNodeClass<Parameters>();
-	GafferBindings::DependencyNodeClass<ReverseWinding>();
-	GafferBindings::DependencyNodeClass<GafferScene::MeshDistortion>();
-	GafferBindings::DependencyNodeClass<DeleteObject>();
-	GafferBindings::DependencyNodeClass<UDIMQuery>();
-	GafferBindings::DependencyNodeClass<Wireframe>();
+IE_CORE_FORWARDDECLARE( StringPlug )
 
-}
+} // namespace Gaffer
+
+namespace GafferScene
+{
+
+class GAFFERSCENE_API Wireframe : public SceneElementProcessor
+{
+
+	public :
+
+		Wireframe( const std::string &name=defaultName<Wireframe>() );
+		~Wireframe() override;
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Wireframe, WireframeTypeId, SceneElementProcessor );
+
+		Gaffer::StringPlug *positionPlug();
+		const Gaffer::StringPlug *positionPlug() const;
+
+		Gaffer::FloatPlug *widthPlug();
+		const Gaffer::FloatPlug *widthPlug() const;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		bool processesObject() const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( Wireframe )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_WIREFRAME_H

--- a/python/GafferSceneTest/PointsTypeTest.py
+++ b/python/GafferSceneTest/PointsTypeTest.py
@@ -51,7 +51,10 @@ class PointsTypeTest( GafferSceneTest.SceneTestCase ) :
 		points = IECoreScene.PointsPrimitive( 1 )
 		points["P"] = IECoreScene.PrimitiveVariable(
 			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
-			IECore.V3fVectorData( [ imath.V3f( 1, 2, 3 ) ] ),
+			IECore.V3fVectorData(
+				[ imath.V3f( 1, 2, 3 ) ],
+				IECore.GeometricData.Interpretation.Point
+			),
 		)
 
 		objectToScene = GafferScene.ObjectToScene()

--- a/python/GafferSceneTest/SceneTestCase.py
+++ b/python/GafferSceneTest/SceneTestCase.py
@@ -61,6 +61,15 @@ class SceneTestCase( GafferTest.TestCase ) :
 			if isinstance( o, IECoreScene.VisibleRenderable ) :
 				 if not IECore.BoxAlgo.contains( thisBound, o.bound() ) :
 					self.fail( "Bound %s does not contain object %s at %s" % ( thisBound, o.bound(), scenePath ) )
+			if isinstance( o, IECoreScene.Primitive ) :
+				if "P" in o :
+					if not isinstance( o["P"].data, IECore.V3fVectorData ) :
+						self.fail( "Object %s has incorrect type %s for primitive variable \"P\"" % ( scenePath, o["P"].data.typeName() ) )
+					if o["P"].data.getInterpretation() != IECore.GeometricData.Interpretation.Point :
+						self.fail( "Object %s has primitive variable \"P\" with incorrect interpretation" % scenePath )
+				if not o.arePrimitiveVariablesValid() :
+					self.fail( "Object %s has invalid primitive variables" % scenePath )
+
 
 			unionOfTransformedChildBounds = imath.Box3f()
 			childNames = scenePlug.childNames( scenePath, _copy = False )

--- a/python/GafferSceneTest/WireframeTest.py
+++ b/python/GafferSceneTest/WireframeTest.py
@@ -1,0 +1,75 @@
+##########################################################################
+#
+#  Copyright (c) 2018, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+
+import IECore
+import IECoreScene
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+class WireframeTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		plane = GafferScene.Plane()
+		plane["divisions"].setValue( imath.V2i( 2, 1 ) ) # Two quads
+
+		filter = GafferScene.PathFilter()
+		filter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		wireframe = GafferScene.Wireframe()
+		wireframe["in"].setInput( plane["out"] )
+		wireframe["filter"].setInput( filter["out"] )
+		wireframe["width"].setValue( 2 )
+
+		self.assertSceneValid( wireframe["out"] )
+
+		curves = wireframe["out"].object( "/plane" )
+		self.assertIsInstance( curves, IECoreScene.CurvesPrimitive )
+		self.assertEqual( curves["width"].data.value, 2 )
+		self.assertEqual( curves.bound(), plane["out"].bound( "/plane" ) )
+
+		# Two quads gives 8 edges, but we don't want to repeat the
+		# shared edge, hence we expect 7 curves in the output.
+		self.assertEqual( len( curves.verticesPerCurve() ), 7 )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/WireframeTest.py
+++ b/python/GafferSceneTest/WireframeTest.py
@@ -71,5 +71,20 @@ class WireframeTest( GafferSceneTest.SceneTestCase ) :
 		# shared edge, hence we expect 7 curves in the output.
 		self.assertEqual( len( curves.verticesPerCurve() ), 7 )
 
+	def testUVs( self ) :
+
+		sphere = GafferScene.Sphere()
+		sphere["radius"].setValue( 0.1 )
+
+		filter = GafferScene.PathFilter()
+		filter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		wireframe = GafferScene.Wireframe()
+		wireframe["in"].setInput( sphere["out"] )
+		wireframe["filter"].setInput( filter["out"] )
+		wireframe["position"].setValue( "uv" )
+
+		self.assertSceneValid( wireframe["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -135,6 +135,7 @@ from CollectTransformsTest import CollectTransformsTest
 from CameraTweaksTest import CameraTweaksTest
 from FilterProcessorTest import FilterProcessorTest
 from UDIMQueryTest import UDIMQueryTest
+from WireframeTest import WireframeTest
 
 from IECoreGLPreviewTest import *
 

--- a/python/GafferSceneUI/WireframeUI.py
+++ b/python/GafferSceneUI/WireframeUI.py
@@ -1,0 +1,77 @@
+##########################################################################
+#
+#  Copyright (c) 2018, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.Wireframe,
+
+	"description",
+	"""
+	Creates a wireframe representation of a mesh. The wireframe
+	is created as a CurvesPrimitive.
+	""",
+
+	plugs = {
+
+		"position" : [
+
+			"description",
+			"""
+			The primitive variable containing the positions to use
+			for the wireframe. This must have either Vertex or FaceVarying
+			interpolation and contain either V3fVectorData or V2fVectorData.
+
+			> Tip : Use "uv" to create a wireframe representation of the
+			> UVs for a mesh.
+			"""
+
+		],
+
+		"width" : [
+
+			"description",
+			"""
+			The width of the curves used to represent the wireframe.
+			"""
+
+		],
+
+	}
+)

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -146,6 +146,7 @@ import CollectPrimitiveVariablesUI
 import PrimitiveVariableExistsUI
 import CollectTransformsUI
 import UDIMQueryUI
+import WireframeUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/Wireframe.cpp
+++ b/src/GafferScene/Wireframe.cpp
@@ -115,6 +115,7 @@ struct MakeWireframe
 			using Edge = std::pair<int, int>;
 			using EdgeSet = unordered_set<Edge, boost::hash<Edge>>;
 			EdgeSet edgesVisited;
+			edgesVisited.reserve( mesh->variableSize( PrimitiveVariable::FaceVarying ) );
 
 			int vertexIdsIndex = 0;
 			for( int numVertices : mesh->verticesPerFace()->readable() )

--- a/src/GafferScene/Wireframe.cpp
+++ b/src/GafferScene/Wireframe.cpp
@@ -180,7 +180,6 @@ Wireframe::Wireframe( const std::string &name )
 	addChild( new FloatPlug( "width", Plug::In, 1.0f, 0.0f ) );
 
 	// Fast pass-throughs for things we don't modify
-	outPlug()->boundPlug()->setInput( inPlug()->boundPlug() );
 	outPlug()->attributesPlug()->setInput( inPlug()->attributesPlug() );
 	outPlug()->transformPlug()->setInput( inPlug()->transformPlug() );
 }
@@ -220,6 +219,26 @@ void Wireframe::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 	{
 		outputs.push_back( outPlug()->objectPlug() );
 	}
+}
+
+bool Wireframe::processesBound() const
+{
+	return true;
+}
+
+void Wireframe::hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	outPlug()->objectPlug()->hash( h );
+}
+
+Imath::Box3f Wireframe::computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const
+{
+	ConstObjectPtr object = outPlug()->objectPlug()->getValue();
+	if( const CurvesPrimitive *wireframe = runTimeCast<const CurvesPrimitive>( object.get() ) )
+	{
+		return wireframe->bound();
+	}
+	return inputBound;
 }
 
 bool Wireframe::processesObject() const

--- a/src/GafferScene/Wireframe.cpp
+++ b/src/GafferScene/Wireframe.cpp
@@ -111,6 +111,16 @@ struct MakeWireframe
 			IECore::V3fVectorDataPtr pData = new V3fVectorData;
 			pData->setInterpretation( GeometricData::Point );
 			vector<V3f> &p = pData->writable();
+			// We don't know upfront how many edges we will generate.
+			// `mesh->variableSize( PrimitiveVariable::FaceVarying )` gives us
+			// an upper bound, but edges can be shared by faces in which case
+			// we only add the edge once. For a fully closed mesh without border
+			// edges, we will only generate half of the edges from this upper bound.
+			// (For non-manifold meshes we could generate even fewer, but we assume
+			// we will not be given those).
+			const size_t minExpectedEdges = mesh->variableSize( PrimitiveVariable::FaceVarying ) / 2;
+			// Each edge we add will add 2 points to `p`.
+			p.reserve( minExpectedEdges * 2 );
 
 			using Edge = std::pair<int, int>;
 			using EdgeSet = unordered_set<Edge, boost::hash<Edge>>;

--- a/src/GafferScene/Wireframe.cpp
+++ b/src/GafferScene/Wireframe.cpp
@@ -1,0 +1,256 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/Wireframe.h"
+
+#include "Gaffer/StringPlug.h"
+
+#include "IECoreScene/MeshPrimitive.h"
+#include "IECoreScene/CurvesPrimitive.h"
+
+#include "IECore/DataAlgo.h"
+
+#include "boost/functional/hash.hpp"
+
+#include <unordered_set>
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+struct MakeWireframe
+{
+
+	CurvesPrimitivePtr operator() ( const V2fVectorData *positions, const vector<int> &verticesPerFace, const vector<int> &vertexIds )
+	{
+		return makeWireframe( positions->baseReadable(), 2, verticesPerFace, vertexIds );
+	}
+
+	CurvesPrimitivePtr operator() ( const V3fVectorData *positions, const vector<int> &verticesPerFace, const vector<int> &vertexIds )
+	{
+		return makeWireframe( positions->baseReadable(), 3, verticesPerFace, vertexIds );
+	}
+
+	CurvesPrimitivePtr operator() ( const Data *positions, const vector<int> &verticesPerFace, const vector<int> &vertexIds )
+	{
+		throw IECore::Exception( boost::str(
+			boost::format( "Position has unsupported type \"%1%\"" ) % positions->typeName()
+		) );
+	}
+
+	private :
+
+		V3f position( const float *positions, int dimensions, int index )
+		{
+			V3f result( 0.0f );
+			for( int i = 0; i < dimensions; ++i )
+			{
+				result[i] = positions[index*dimensions+i];
+			}
+			return result;
+		}
+
+		CurvesPrimitivePtr makeWireframe( const float *positions, int dimensions, const vector<int> &verticesPerFace, const vector<int> &vertexIds )
+		{
+			IECore::V3fVectorDataPtr pData = new V3fVectorData;
+			pData->setInterpretation( GeometricData::Point );
+			vector<V3f> &p = pData->writable();
+
+			using Edge = std::pair<int, int>;
+			using EdgeSet = unordered_set<Edge, boost::hash<Edge>>;
+			EdgeSet edgesVisited;
+
+			int vertexIdsIndex = 0;
+			for( int numVertices : verticesPerFace )
+			{
+				for( int i = 0; i < numVertices; ++i )
+				{
+					int index0 = vertexIds[vertexIdsIndex + i];
+					int index1 = vertexIds[vertexIdsIndex + (i + 1) % numVertices];
+					Edge edge( min( index0, index1 ), max( index0, index1 ) );
+					if( edgesVisited.insert( edge ).second )
+					{
+						p.push_back( position( positions, dimensions, index0 ) );
+						p.push_back( position( positions, dimensions, index1 ) );
+					}
+				}
+				vertexIdsIndex += numVertices;
+			}
+
+			IECore::IntVectorDataPtr vertsPerCurveData = new IntVectorData;
+			vertsPerCurveData->writable().resize( p.size() / 2, 2 );
+
+			CurvesPrimitivePtr result = new CurvesPrimitive( vertsPerCurveData );
+			result->variables["P"] = PrimitiveVariable( PrimitiveVariable::Vertex, pData );
+			return result;
+		}
+
+};
+
+/// \todo Perhaps this could go in IECoreScene::MeshAlgo
+CurvesPrimitivePtr wireframe( const MeshPrimitive *mesh, const std::string &position )
+{
+	auto it = mesh->variables.find( position );
+	if( it == mesh->variables.end() )
+	{
+		throw IECore::Exception( boost::str(
+			boost::format( "MeshPrimitive has no primitive variable \"%1%\"" ) % position
+		) );
+	}
+
+	const IntVectorData *indices = nullptr;
+	switch( it->second.interpolation )
+	{
+		case PrimitiveVariable::Vertex :
+			indices = mesh->vertexIds();
+			if( it->second.indices )
+			{
+				throw IECore::Exception( "Vertex primitive variable with indices not supported" );
+			}
+			break;
+		case PrimitiveVariable::FaceVarying :
+			indices = it->second.indices.get();
+			break;
+		default :
+			throw IECore::Exception( "Position must have Vertex or FaceVarying interpolation" );
+	}
+
+	CurvesPrimitivePtr result = dispatch( it->second.data.get(), MakeWireframe(), mesh->verticesPerFace()->readable(), indices->readable() );
+	return result;
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Wireframe
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( Wireframe );
+
+size_t Wireframe::g_firstPlugIndex = 0;
+
+Wireframe::Wireframe( const std::string &name )
+	:	SceneElementProcessor( name, PathMatcher::NoMatch )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new StringPlug( "position", Plug::In, "P" ) );
+	addChild( new FloatPlug( "width", Plug::In, 1.0f, 0.0f ) );
+
+	// Fast pass-throughs for things we don't modify
+	outPlug()->boundPlug()->setInput( inPlug()->boundPlug() );
+	outPlug()->attributesPlug()->setInput( inPlug()->attributesPlug() );
+	outPlug()->transformPlug()->setInput( inPlug()->transformPlug() );
+}
+
+Wireframe::~Wireframe()
+{
+}
+
+Gaffer::StringPlug *Wireframe::positionPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::StringPlug *Wireframe::positionPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+Gaffer::FloatPlug *Wireframe::widthPlug()
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::FloatPlug *Wireframe::widthPlug() const
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 1 );
+}
+
+void Wireframe::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	SceneElementProcessor::affects( input, outputs );
+
+	if(
+		input == positionPlug() ||
+		input == widthPlug()
+	)
+	{
+		outputs.push_back( outPlug()->objectPlug() );
+	}
+}
+
+bool Wireframe::processesObject() const
+{
+	return true;
+}
+
+void Wireframe::hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	positionPlug()->hash( h );
+	widthPlug()->hash( h );
+}
+
+IECore::ConstObjectPtr Wireframe::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const
+{
+	const MeshPrimitive *mesh = runTimeCast<const MeshPrimitive>( inputObject.get() );
+	if( !mesh )
+	{
+		return inputObject;
+	}
+
+	CurvesPrimitivePtr result = wireframe( mesh, positionPlug()->getValue() );
+	for( const auto &pv : mesh->variables )
+	{
+		if( pv.second.interpolation == PrimitiveVariable::Constant )
+		{
+			// OK to reference data directly, because result becomes const upon return.
+			result->variables.insert( pv );
+		}
+	}
+	result->variables["width"] = PrimitiveVariable( PrimitiveVariable::Constant, new FloatData( widthPlug()->getValue() ) );
+
+	return result;
+}

--- a/src/GafferScene/Wireframe.cpp
+++ b/src/GafferScene/Wireframe.cpp
@@ -64,27 +64,27 @@ namespace
 struct MakeWireframe
 {
 
-	CurvesPrimitivePtr operator() ( const V2fVectorData *data, const MeshPrimitive *mesh, const PrimitiveVariable &primitiveVariable )
+	CurvesPrimitivePtr operator() ( const V2fVectorData *data, const MeshPrimitive *mesh, const string &name, const PrimitiveVariable &primitiveVariable )
 	{
-		return makeWireframe<V2fVectorData>( data, mesh, primitiveVariable );
+		return makeWireframe<V2fVectorData>( data, mesh, name, primitiveVariable );
 	}
 
-	CurvesPrimitivePtr operator() ( const V3fVectorData *data, const MeshPrimitive *mesh, const PrimitiveVariable &primitiveVariable )
+	CurvesPrimitivePtr operator() ( const V3fVectorData *data, const MeshPrimitive *mesh, const string &name, const PrimitiveVariable &primitiveVariable )
 	{
-		return makeWireframe<V3fVectorData>( data, mesh, primitiveVariable );
+		return makeWireframe<V3fVectorData>( data, mesh, name, primitiveVariable );
 	}
 
-	CurvesPrimitivePtr operator() ( const Data *data, const MeshPrimitive *mesh, const PrimitiveVariable &primitiveVariable )
+	CurvesPrimitivePtr operator() ( const Data *data, const MeshPrimitive *mesh, const string &name, const PrimitiveVariable &primitiveVariable )
 	{
 		throw IECore::Exception( boost::str(
-			boost::format( "Position has unsupported type \"%1%\"" ) % data->typeName()
+			boost::format( "PrimitiveVariable \"%1%\" has unsupported type \"%2%\"" ) % name % data->typeName()
 		) );
 	}
 
 	private :
 
 		template<typename T>
-		CurvesPrimitivePtr makeWireframe( const T *data, const MeshPrimitive *mesh, const PrimitiveVariable &primitiveVariable )
+		CurvesPrimitivePtr makeWireframe( const T *data, const MeshPrimitive *mesh, const string &name, const PrimitiveVariable &primitiveVariable )
 		{
 			using Vec = typename T::ValueType::value_type;
 			using DataView = PrimitiveVariable::IndexedView<Vec>;
@@ -103,7 +103,9 @@ struct MakeWireframe
 					dataView = DataView( data->readable(), nullptr );
 					break;
 				default :
-					throw IECore::Exception( "Position must have Vertex, Varying or FaceVarying interpolation" );
+					throw IECore::Exception( boost::str(
+						boost::format( "Primitive variable \"%1%\" must have Vertex, Varying or FaceVarying interpolation" ) % name
+					) );
 			}
 
 			IECore::V3fVectorDataPtr pData = new V3fVectorData;
@@ -164,11 +166,11 @@ CurvesPrimitivePtr wireframe( const MeshPrimitive *mesh, const std::string &posi
 	if( it == mesh->variables.end() )
 	{
 		throw IECore::Exception( boost::str(
-			boost::format( "MeshPrimitive has no primitive variable \"%1%\"" ) % position
+			boost::format( "MeshPrimitive has no primitive variable named \"%1%\"" ) % position
 		) );
 	}
 
-	CurvesPrimitivePtr result = dispatch( it->second.data.get(), MakeWireframe(), mesh, it->second );
+	CurvesPrimitivePtr result = dispatch( it->second.data.get(), MakeWireframe(), mesh, it->first, it->second );
 	return result;
 }
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -294,6 +294,7 @@ nodeMenu.append( "/Scene/Object/Collect Primitive Variables", GafferScene.Collec
 nodeMenu.append( "/Scene/Object/Mesh Type", GafferScene.MeshType, searchText = "MeshType" )
 nodeMenu.append( "/Scene/Object/Points Type", GafferScene.PointsType, searchText = "PointsType" )
 nodeMenu.append( "/Scene/Object/Mesh To Points", GafferScene.MeshToPoints, searchText = "MeshToPoints" )
+nodeMenu.append( "/Scene/Object/Wireframe", GafferScene.Wireframe )
 nodeMenu.append( "/Scene/Object/Light To Camera", GafferScene.LightToCamera, searchText = "LightToCamera" )
 nodeMenu.append( "/Scene/Object/Map Projection", GafferScene.MapProjection, searchText = "MapProjection" )
 nodeMenu.append( "/Scene/Object/Map Offset", GafferScene.MapOffset, searchText = "MapOffset"  )


### PR DESCRIPTION
This add a new Wireframe node, which converts an input mesh into a CurvesPrimitive containing all the edges. It supports the generation of wireframes for UVs as well as 3D positions.