### PR TITLE
Dispatcher : Recursive dispatches default to parent jobDirectory

### DIFF
--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -1623,5 +1623,24 @@ class DispatcherTest( GafferTest.TestCase ) :
 		with self.assertRaisesRegexp( Exception, "Python argument types in" ) :
 			d.frameRange( Gaffer.ScriptNode(), None )
 
+	def testRecursiveDispatch( self ) :
+
+		dispatcher = GafferDispatch.Dispatcher.create( "testDispatcher" )
+
+		s = Gaffer.ScriptNode()
+		s["n1"] = GafferDispatchTest.LoggingTaskNode()
+		command = "import GafferDispatch\nGafferDispatch.LocalDispatcher().dispatch( [ self.parent()['n1'] ] )"
+		s["ReDispatch1"] = GafferDispatch.PythonCommand()
+		s["ReDispatch1"]["command"].setValue( command )
+		s["ReDispatch2"] = GafferDispatch.PythonCommand()
+		s["ReDispatch2"]["command"].setValue( command )
+
+		#s["n2"] = GafferDispatchTest.LoggingTaskNode()
+		dispatcher.dispatch( [ s["ReDispatch1"], s["ReDispatch2"] ] )
+
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/000000" ) )
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/000000/000000" ) )
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/000000/000001" ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -135,6 +135,14 @@ std::string Dispatcher::createJobDirectory( const Context *context ) const
 	boost::filesystem::path jobDirectory( context->substitute( jobsDirectoryPlug()->getValue() ) );
 	jobDirectory /= context->substitute( jobNamePlug()->getValue() );
 
+	// If we have no directory set, first check if we're already inside a dispatch,
+	// and if so use the parent directory
+	if ( jobDirectory == "" )
+	{
+		jobDirectory = context->get<std::string>( "dispatcher:jobDirectory", "" );
+	}
+
+	// If we still have no directory, use the OS current working path
 	if ( jobDirectory == "" )
 	{
 		jobDirectory = boost::filesystem::current_path().string();


### PR DESCRIPTION
This was John's recommendation for dealing with wanting to run dispatchers inside a task ( this is currently the only way to create a Gaffer job that runs on the farm, but runs several tasks in the same process, which can be a huge performance benefit if the tasks require computing the same upstream network. )