### PR TITLE
Build : Fix IE specific build issue for Houdini 16.5

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -36,6 +36,7 @@
 
 import os
 import sys
+import distutils
 
 import IEEnv
 
@@ -137,7 +138,8 @@ if targetApp :
 	qtVersion = targetAppReg.get( "qtVersion", qtVersion )
 	
 	if targetApp == "houdini" :
-		VDB_LIB_SUFFIX = "_sesi"
+		if distutils.version.LooseVersion(targetAppVersion) >= distutils.version.LooseVersion("17.0") :
+			VDB_LIB_SUFFIX = "_sesi"
 
 else :
 
@@ -234,7 +236,13 @@ LOCATE_DEPENDENCY_SYSTEMPATH = [
 ]
 
 if targetAppVersion :
-	LOCATE_DEPENDENCY_SYSTEMPATH[:0] = [ os.path.join( targetAppReg['location'], x ) for x in targetAppReg.get( 'includes', [] ) ]
+	# avoid the proper dependency order for Houdini 16.5 and earlier.
+	# this is not ideal, but we're too far along in the H16.5 lifecycle
+	##\ todo: Remove this clause once we're onto H17.0 across the studio.
+	if targetApp == "houdini" and distutils.version.LooseVersion(targetAppVersion) < distutils.version.LooseVersion("17.0") :
+		LOCATE_DEPENDENCY_SYSTEMPATH += [ os.path.join( targetAppReg['location'], x ) for x in targetAppReg.get( 'includes', [] ) ]
+	else :
+		LOCATE_DEPENDENCY_SYSTEMPATH[:0] = [ os.path.join( targetAppReg['location'], x ) for x in targetAppReg.get( 'includes', [] ) ]
 
 LOCATE_DEPENDENCY_CPPPATH = [
 	os.path.join( IEEnv.Environment.rootPath(), "apps", "cortex", cortexVersion, IEEnv.platform(), "base", "include" ),


### PR DESCRIPTION
When prepping Gaffer for Houdini 17, I prioritized DCC dependency headers (9f0f1e6898d2e07264d6e8a9d0fd89b3fab499a5), which inadvertently made Gaffer build against a different version of OpenVDB than we build Cortex (and everything else) against at IE.

This "fix" reverts that decision, just for H16.5 (and older), to solve an immediate production problem. I think its technically wrong, but still the most pragmatic thing at this point in the lifecycle of H16.5.