### PR TITLE
ArnoldMeshLight : Fix defaultLights set bug

### DIFF
--- a/python/GafferArnoldTest/ArnoldMeshLightTest.py
+++ b/python/GafferArnoldTest/ArnoldMeshLightTest.py
@@ -128,5 +128,37 @@ class ArnoldMeshLightTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( s["l"]["parameters"].keys(), s2["l"]["parameters"].keys() )
 		self.assertEqual( s["l"]["out"].attributes( "/plane" ), s2["l"]["out"].attributes( "/plane" ) )
 
+	def testSets( self ) :
+
+		p = GafferScene.Plane()
+		f = GafferScene.PathFilter()
+		f["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+		l = GafferArnold.ArnoldMeshLight()
+		l["in"].setInput( p["out"] )
+		l["filter"].setInput( f["out"] )
+
+		self.assertEqual( l["defaultLight"].getValue(), True )
+		self.assertEqual( l["out"].set( "defaultLights" ).value.paths(), [ "/plane" ] )
+		self.assertEqual( l["out"].set( "__lights" ).value.paths(), [ "/plane" ] )
+
+		l["defaultLight"].setValue( False )
+		self.assertEqual( l["out"].set( "defaultLights" ).value.paths(), [] )
+		self.assertEqual( l["out"].set( "__lights" ).value.paths(), [ "/plane" ] )
+
+	def testDisabling( self ) :
+
+		p = GafferScene.Plane()
+		f = GafferScene.PathFilter()
+		f["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+		l = GafferArnold.ArnoldMeshLight()
+		l["in"].setInput( p["out"] )
+		l["filter"].setInput( f["out"] )
+
+		self.assertSceneValid( l["out"] )
+
+		l["enabled"].setValue( False )
+		self.assertScenesEqual( p["out"], l["out"] )
+		self.assertSceneHashesEqual( p["out"], l["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferArnoldUI/ArnoldMeshLightUI.py
+++ b/python/GafferArnoldUI/ArnoldMeshLightUI.py
@@ -100,6 +100,20 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"defaultLight" : [
+
+			"description",
+			"""
+			Whether this light illuminates all geometry by default. When
+			toggled, the light will be added to the \"defaultLights\" set, which
+			can be referenced in set expressions and manipulated by downstream
+			nodes.
+			""",
+
+			"layout:section", "Light Linking",
+
+		]
+
 	}
 
 )

--- a/src/GafferArnold/ArnoldMeshLight.cpp
+++ b/src/GafferArnold/ArnoldMeshLight.cpp
@@ -43,6 +43,7 @@
 #include "GafferScene/ShaderAssignment.h"
 
 #include "Gaffer/StringPlug.h"
+#include "Gaffer/Switch.h"
 
 #include "boost/algorithm/string/predicate.hpp"
 
@@ -66,7 +67,6 @@ ArnoldMeshLight::ArnoldMeshLight( const std::string &name )
 	ArnoldAttributesPtr attributes = new ArnoldAttributes( "__attributes" );
 	attributes->inPlug()->setInput( inPlug() );
 	attributes->filterPlug()->setInput( filterPlug() );
-	attributes->enabledPlug()->setInput( enabledPlug() );
 	for( CompoundDataPlug::MemberPlugIterator it( attributes->attributesPlug() ); !it.done(); ++it )
 	{
 		if( boost::ends_with( (*it)->getName().string(), "Visibility" ) && (*it)->getName() != "cameraVisibility" )
@@ -106,7 +106,6 @@ ArnoldMeshLight::ArnoldMeshLight( const std::string &name )
 	shaderAssignment->inPlug()->setInput( attributes->outPlug() );
 	shaderAssignment->filterPlug()->setInput( filterPlug() );
 	shaderAssignment->shaderPlug()->setInput( shader->outPlug() );
-	shaderAssignment->enabledPlug()->setInput( enabledPlug() );
 	addChild( shaderAssignment );
 
 	// Set node. This adds the objects into the __lights set,
@@ -115,12 +114,34 @@ ArnoldMeshLight::ArnoldMeshLight( const std::string &name )
 	SetPtr set = new Set( "__set" );
 	set->inPlug()->setInput( shaderAssignment->outPlug() );
 	set->filterPlug()->setInput( filterPlug() );
-	set->enabledPlug()->setInput( enabledPlug() );
 	set->namePlug()->setValue( "__lights" );
 	set->modePlug()->setValue( Set::Add );
 	addChild( set );
 
-	outPlug()->setInput( set->outPlug() );
+	// Default lights Set node.
+
+	BoolPlugPtr defaultLightPlug = new BoolPlug( "defaultLight", Plug::In, true );
+	addChild( defaultLightPlug );
+
+	SetPtr defaultLightsSet = new Set( "__defaultLightsSet" );
+	defaultLightsSet->inPlug()->setInput( set->outPlug() );
+	defaultLightsSet->filterPlug()->setInput( filterPlug() );
+	defaultLightsSet->enabledPlug()->setInput( defaultLightPlug.get() );
+	defaultLightsSet->namePlug()->setValue( "defaultLights" );
+	defaultLightsSet->modePlug()->setValue( Set::Add );
+	addChild( defaultLightsSet );
+
+	// Switch for enabling/disabling
+
+	SwitchPtr enabledSwitch = new Switch( "__switch" );
+	enabledSwitch->setup( inPlug() );
+	enabledSwitch->inPlugs()->getChild<ScenePlug>( 0 )->setInput( inPlug() );
+	enabledSwitch->inPlugs()->getChild<ScenePlug>( 1 )->setInput( defaultLightsSet->outPlug() );
+	enabledSwitch->indexPlug()->setValue( 1 );
+	enabledSwitch->enabledPlug()->setInput( enabledPlug() );
+	addChild( enabledSwitch );
+
+	outPlug()->setInput( enabledSwitch->outPlug() );
 	// We don't need to serialise the connection because we make
 	// it upon construction.
 	/// \todo Can we just do this in the SceneProcessor base class?


### PR DESCRIPTION
Because `ArnoldMeshLight` doesn't derive from `GafferScene::Light`, it completely escaped the recent addition of the defaultLights set. This meant that it became non-linked by default, breaking existing setups.
