### PR TITLE
Fix crash when starting Gaffer with unicode in the clipboard.

### DIFF
--- a/apps/gui/gui-1.py
+++ b/apps/gui/gui-1.py
@@ -153,7 +153,7 @@ class gui( Gaffer.Application ) :
 
 		from Qt import QtWidgets
 
-		text = str( QtWidgets.QApplication.clipboard().text() )
+		text = str( QtWidgets.QApplication.clipboard().text().encode( 'ascii', 'ignore' ) )
 		if text :
 			with Gaffer.BlockedConnection( self.__clipboardContentsChangedConnection ) :
 				self.root().setClipboardContents( IECore.StringData( text ) )


### PR DESCRIPTION
We just skip the unsupported characters.

Before this change, copying unicode (like 🤠) and starting gaffer would crash with the following:

```
Traceback (most recent call last):
  File "/software/apps/gaffer/0.52.3.0/cent7.x86_64/cortex/10/gaffer/bin/gaffer.py", line 162, in <module>
    app = loadApp( appName )
  File "/software/apps/gaffer/0.52.3.0/cent7.x86_64/cortex/10/gaffer/bin/gaffer.py", line 71, in loadApp
    return appLoader.load( appName )()
  File "/software/apps/gaffer/0.52.3.0/cent7.x86_64/cortex/10/gaffer/apps/gui/gui-1.py", line 83, in __init__
    self.__setupClipboardSync()
  File "/software/apps/gaffer/0.52.3.0/cent7.x86_64/cortex/10/gaffer/apps/gui/gui-1.py", line 133, in __setupClipboardSync
    self.__qtClipboardContentsChanged() # Trigger initial sync
  File "/software/apps/gaffer/0.52.3.0/cent7.x86_64/cortex/10/gaffer/apps/gui/gui-1.py", line 156, in __qtClipboardContentsChanged
    text = str( QtWidgets.QApplication.clipboard().text() )
UnicodeEncodeError: 'ascii' codec can't encode character u'\U0001f602' in position 0: ordinal not in range(128)
```

I could alternatively catch `UnicodeEncodeError` and not copy anything to the clipboard, but this seemed to be the suggested approach on the interwebs.