### PR TITLE
IECoreArnoldPreview/Renderer : fix crash bug

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1132,7 +1132,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 				if( m_shadowGroup )
 				{
-					const std::vector<AtNode *> &linkedLightNodes = m_lightListCache->get( m_linkedLights.get() );
+					const std::vector<AtNode *> &linkedLightNodes = m_lightListCache->get( m_shadowGroup.get() );
 
 					AiNodeSetArray( node, g_shadowGroupArnoldString, AiArrayConvert( linkedLightNodes.size(), 1, AI_TYPE_NODE, linkedLightNodes.data() ) );
 					AiNodeSetBool( node, g_useShadowGroupArnoldString, true );


### PR DESCRIPTION
Hey John,

Just a quick bug fix this time. Seems to have been just an annoying copy/paste mistake that slipped through the cracks. Our `LightListCache` was getting a `nullptr` because we were looking at the wrong attribute.

Thanks,

Matti.
