### PR TITLE
ImageView : Give internal node a unique TypeId

### DIFF
--- a/include/GafferImageUI/TypeIds.h
+++ b/include/GafferImageUI/TypeIds.h
@@ -44,6 +44,7 @@ enum TypeId
 {
 	ImageViewTypeId = 110850,
 	ImageGadgetTypeId = 110851,
+	V2fContextVariableTypeId = 110852,
 
 	LastTypeId = 110899
 };

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -203,8 +203,7 @@ class V2fContextVariable : public Gaffer::ComputeNode
 			addChild( new V2fPlug( "out", Plug::Out ) );
 		}
 
-		// Deliberately omitting RunTimeTyped macros because this
-		// is just a private class and doesn't need its own type.
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( V2fContextVariable, V2fContextVariableTypeId, ComputeNode );
 
 		StringPlug *namePlug()
 		{
@@ -271,6 +270,7 @@ class V2fContextVariable : public Gaffer::ComputeNode
 };
 
 size_t V2fContextVariable::g_firstPlugIndex = 0;
+IE_CORE_DEFINERUNTIMETYPED( V2fContextVariable )
 
 IE_CORE_DECLAREPTR( V2fContextVariable )
 


### PR DESCRIPTION
The comment was bogus. Node TypeIds are used in generating the hash, so it is not acceptable to omit one. I think it's unlikely this is the cause of the color inspector update bug we've been hunting (the symtoms would likely be more severe), but it's another thing to rule out.
