### PR TITLE
Component connections UI

### DIFF
--- a/include/GafferUI/AuxiliaryConnectionsGadget.h
+++ b/include/GafferUI/AuxiliaryConnectionsGadget.h
@@ -113,6 +113,9 @@ class GAFFERUI_API AuxiliaryConnectionsGadget : public Gadget
 
 		void updateConnections() const;
 
+		struct AuxiliaryConnection;
+		void renderConnection( const AuxiliaryConnection &connection, const Style *style ) const;
+
 		struct Connections
 		{
 			boost::signals::scoped_connection plugInputChangedConnection;

--- a/include/GafferUI/AuxiliaryConnectionsGadget.h
+++ b/include/GafferUI/AuxiliaryConnectionsGadget.h
@@ -39,7 +39,9 @@
 
 #include "GafferUI/Gadget.h"
 
-#include "boost/container/flat_set.hpp"
+#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/hashed_index.hpp"
+#include "boost/multi_index_container.hpp"
 
 #include <unordered_map>
 
@@ -59,7 +61,8 @@ class NodeGadget;
 class Nodule;
 
 /// Renders the "auxiliary" connections within a node graph. These
-/// are defined as connections into plugs which don't have a nodule.
+/// are defined as connections into plugs which don't have a nodule
+/// of their own (although their parent may have a nodule).
 class GAFFERUI_API AuxiliaryConnectionsGadget : public Gadget
 {
 
@@ -69,11 +72,12 @@ class GAFFERUI_API AuxiliaryConnectionsGadget : public Gadget
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::AuxiliaryConnectionsGadget, AuxiliaryConnectionsGadgetTypeId, Gadget );
 
-		bool hasConnection( const NodeGadget *srcNodeGadget, const NodeGadget *dstNodeGadget ) const;
+		/// Gadgets may either be NodeGadgets or Nodules.
+		bool hasConnection( const Gadget *srcGadget, const Gadget *dstGadget ) const;
 		bool hasConnection( const Gaffer::Node *srcNode, const Gaffer::Node *dstNode ) const;
 
-		std::pair<NodeGadget *, NodeGadget *> connectionAt( const IECore::LineSegment3f &position );
-		std::pair<const NodeGadget *, const NodeGadget *> connectionAt( const IECore::LineSegment3f &position ) const;
+		std::pair<Gadget *, Gadget *> connectionAt( const IECore::LineSegment3f &position );
+		std::pair<const Gadget *, const Gadget *> connectionAt( const IECore::LineSegment3f &position ) const;
 
 		bool acceptsParent( const GraphComponent *potentialParent ) const override;
 		std::string getToolTip( const IECore::LineSegment3f &position ) const override;
@@ -104,7 +108,8 @@ class GAFFERUI_API AuxiliaryConnectionsGadget : public Gadget
 		void noduleAdded( const NodeGadget *nodeGadget, const Nodule *nodule );
 		void noduleRemoved( const NodeGadget *nodeGadget, const Nodule *nodule );
 
-		void dirty( const NodeGadget *nodeGadget );
+		void dirtyInputConnections( const NodeGadget *nodeGadget );
+		void dirtyOutputConnections( const NodeGadget *nodeGadget );
 
 		void updateConnections() const;
 
@@ -114,18 +119,62 @@ class GAFFERUI_API AuxiliaryConnectionsGadget : public Gadget
 			boost::signals::scoped_connection noduleAddedConnection;
 			boost::signals::scoped_connection noduleRemovedConnection;
 			boost::signals::scoped_connection childRemovedConnection;
-			// The set of all NodeGadgets at the source end of the connections.
-			boost::container::flat_set<const NodeGadget *> sourceGadgets;
 			bool dirty = true;
 		};
 
 		boost::signals::scoped_connection m_graphGadgetChildAddedConnection;
 		boost::signals::scoped_connection m_graphGadgetChildRemovedConnection;
 
-		// Key is the NodeGadget at the destination end of the connections.
+		// Key is the NodeGadget at the destination end of the connections
+		// tracked by `Connections.dirty`.
 		typedef std::unordered_map<const NodeGadget *, Connections> NodeGadgetConnections;
 		mutable NodeGadgetConnections m_nodeGadgetConnections;
+
+		// An auxiliary connection that we will draw.
+		struct AuxiliaryConnection
+		{
+			const NodeGadget *srcNodeGadget;
+			const NodeGadget *dstNodeGadget;
+			// Endpoints may be srcNodeGadget/dstNodeGadget, or Nodules
+			// belonging to them.
+			std::pair<const Gadget *, const Gadget *> endpoints;
+		};
+
+		// Container for all our auxiliary connections.
+		using AuxiliaryConnections = boost::multi_index::multi_index_container<
+			AuxiliaryConnection,
+			boost::multi_index::indexed_by<
+				// Primary key is the unique pair of endpoint
+				// gadgets the connection represents.
+				boost::multi_index::hashed_unique<
+					boost::multi_index::member<AuxiliaryConnection, std::pair<const Gadget *, const Gadget *>, &AuxiliaryConnection::endpoints>
+				>,
+				// Access to the range of connections originating
+				// at `srcNodeGadget`. This will include all source
+				// endpoints which are either `srcNodeGadget` itself
+				// or are a nodule belonging to it.
+				boost::multi_index::hashed_non_unique<
+					boost::multi_index::member<AuxiliaryConnection, const NodeGadget *, &AuxiliaryConnection::srcNodeGadget>
+				>,
+				// Access to the range of connections ending at
+				// `dstNodeGadget`. This will include all destination
+				// endpoints which are either `dstNodeGadget` itself or
+				// are a nodule belonging to it.
+				boost::multi_index::hashed_non_unique<
+					boost::multi_index::member<AuxiliaryConnection, const NodeGadget *, &AuxiliaryConnection::dstNodeGadget>
+				>
+			>
+		>;
+
+		mutable AuxiliaryConnections m_auxiliaryConnections;
 		mutable bool m_dirty;
+
+		// Convenience accessors for the secondary indexes of `m_auxiliaryConnections`.
+
+		using SrcNodeGadgetIndex = AuxiliaryConnections::nth_index<1>::type;
+		using DstNodeGadgetIndex = AuxiliaryConnections::nth_index<2>::type;
+		SrcNodeGadgetIndex &srcNodeGadgetIndex() const;
+		DstNodeGadgetIndex &dstNodeGadgetIndex() const;
 
 };
 

--- a/include/GafferUI/CompoundNodule.h
+++ b/include/GafferUI/CompoundNodule.h
@@ -60,9 +60,8 @@ class GAFFERUI_API CompoundNodule : public Nodule
 
 		bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const override;
 
-		/// Returns a Nodule for a child of the plug being represented.
-		Nodule *nodule( const Gaffer::Plug *plug );
-		const Nodule *nodule( const Gaffer::Plug *plug ) const;
+		Nodule *nodule( const Gaffer::Plug *plug ) override;
+		const Nodule *nodule( const Gaffer::Plug *plug ) const override;
 
 		bool canCreateConnection( const Gaffer::Plug *endpoint ) const override;
 		void createConnection( Gaffer::Plug *endpoint ) override;

--- a/include/GafferUI/CompoundNumericNodule.h
+++ b/include/GafferUI/CompoundNumericNodule.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2011-2012, John Haddon. All rights reserved.
-//  Copyright (c) 2011-2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,56 +34,58 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERUI_TYPEIDS_H
-#define GAFFERUI_TYPEIDS_H
+#ifndef GAFFERUI_COMPOUNDNUMERICNODULE_H
+#define GAFFERUI_COMPOUNDNUMERICNODULE_H
+
+#include "GafferUI/StandardNodule.h"
 
 namespace GafferUI
 {
 
-enum TypeId
-{
-	GadgetTypeId = 110251,
-	NodeGadgetTypeId = 110252,
-	GraphGadgetTypeId = 110253,
-	ContainerGadgetTypeId = 110254,
-	AuxiliaryConnectionsGadgetTypeId = 110255,
-	TextGadgetTypeId = 110256,
-	NameGadgetTypeId = 110257,
-	IndividualContainerTypeId = 110258,
-	FrameTypeId = 110259,
-	StyleTypeId = 110260,
-	StandardStyleTypeId = 110261,
-	NoduleTypeId = 110262,
-	LinearContainerTypeId = 110263,
-	ConnectionGadgetTypeId = 110264,
-	StandardNodeGadgetTypeId = 110265,
-	AuxiliaryNodeGadgetTypeId = 110266,
-	StandardNoduleTypeId = 110267,
-	CompoundNoduleTypeId = 110268,
-	ImageGadgetTypeId = 110269,
-	ViewportGadgetTypeId = 110270,
-	ViewTypeId = 110271,
-	ConnectionCreatorTypeId = 110272,
-	CompoundNumericNoduleTypeId = 110273,
-	PlugGadgetTypeId = 110274,
-	GraphLayoutTypeId = 110275,
-	StandardGraphLayoutTypeId = 110276,
-	BackdropNodeGadgetTypeId = 110277,
-	SpacerGadgetTypeId = 110278,
-	StandardConnectionGadgetTypeId = 110279,
-	HandleTypeId = 110280,
-	ToolTypeId = 110281,
-	DotNodeGadgetTypeId = 110282,
-	PlugAdderTypeId = 110283,
-	NoduleLayoutTypeId = 110284,
-	TranslateHandleTypeId = 110285,
-	ScaleHandleTypeId = 110286,
-	RotateHandleTypeId = 110287,
-	AnimationGadgetTypeId = 110288,
+class NoduleLayout;
 
-	LastTypeId = 110450
+/// A Nodule subclass to represent CompoundNumericPlugs
+/// so that connections can optionally be made to the
+/// child plugs.
+class GAFFERUI_API CompoundNumericNodule : public StandardNodule
+{
+
+	public :
+
+		CompoundNumericNodule( Gaffer::PlugPtr plug );
+		~CompoundNumericNodule() override;
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::CompoundNumericNodule, CompoundNumericNoduleTypeId, StandardNodule );
+
+		Nodule *nodule( const Gaffer::Plug *plug ) override;
+		const Nodule *nodule( const Gaffer::Plug *plug ) const override;
+
+		bool canCreateConnection( const Gaffer::Plug *endpoint ) const override;
+		void createConnection( Gaffer::Plug *endpoint ) override;
+
+		Imath::Box3f bound() const override;
+
+	protected :
+
+		void doRenderLayer( Layer layer, const Style *style ) const override;
+
+	private :
+
+		NoduleLayout *noduleLayout();
+		const NoduleLayout *noduleLayout() const;
+
+		void plugMetadataChanged( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
+		void updateChildNoduleVisibility();
+
+		static NoduleTypeDescription<CompoundNumericNodule> g_noduleTypeDescription;
+
 };
+
+IE_CORE_DECLAREPTR( CompoundNumericNodule );
+
+typedef Gaffer::FilteredChildIterator<Gaffer::TypePredicate<CompoundNumericNodule> > CompoundNumericNoduleIterator;
+typedef Gaffer::FilteredRecursiveChildIterator<Gaffer::TypePredicate<CompoundNumericNodule> > RecursiveCompoundNumericNoduleIterator;
 
 } // namespace GafferUI
 
-#endif // GAFFERUI_TYPEIDS_H
+#endif // GAFFERUI_COMPOUNDNUMERICNODULE_H

--- a/include/GafferUI/Nodule.h
+++ b/include/GafferUI/Nodule.h
@@ -65,6 +65,12 @@ class GAFFERUI_API Nodule : public ConnectionCreator
 		Gaffer::Plug *plug();
 		const Gaffer::Plug *plug() const;
 
+		/// Returns a nodule for a child of the plug being represented.
+		/// Default implementation returns `nullptr`. Derived classes that
+		/// manage nodules for child plugs should reimplement appropriately.
+		virtual Nodule *nodule( const Gaffer::Plug *plug );
+		virtual const Nodule *nodule( const Gaffer::Plug *plug ) const;
+
 		void updateDragEndPoint( const Imath::V3f position, const Imath::V3f &tangent ) override;
 
 		/// Creates a Nodule for the specified plug. The type of nodule created can be

--- a/include/GafferUI/StandardConnectionGadget.h
+++ b/include/GafferUI/StandardConnectionGadget.h
@@ -120,6 +120,7 @@ class GAFFERUI_API StandardConnectionGadget : public ConnectionGadget
 		Imath::V3f m_srcTangent;
 		Imath::V3f m_dstPos;
 		Imath::V3f m_dstTangent;
+		bool m_auxiliary;
 
 		Gaffer::Plug::Direction m_dragEnd;
 

--- a/include/GafferUI/StandardConnectionGadget.h
+++ b/include/GafferUI/StandardConnectionGadget.h
@@ -99,7 +99,7 @@ class GAFFERUI_API StandardConnectionGadget : public ConnectionGadget
 		// why we store it at all - we could just return it instead.
 		/// \todo Consider making the updates lazy based on events, or
 		/// just drop the state.
-		void setPositionsFromNodules();
+		void updateConnectionGeometry();
 		float distanceToNodeGadget( const IECore::LineSegment3f &line, const Nodule *nodule ) const;
 		Gaffer::Plug::Direction endAt( const IECore::LineSegment3f &line ) const;
 
@@ -120,6 +120,7 @@ class GAFFERUI_API StandardConnectionGadget : public ConnectionGadget
 
 		void updateDotPreviewLocation( const ButtonEvent &event );
 
+		// Connection geometry - computed by `updateConnectionGeometry()`.
 		Imath::V3f m_srcPos;
 		Imath::V3f m_srcTangent;
 		Imath::V3f m_dstPos;

--- a/include/GafferUI/StandardConnectionGadget.h
+++ b/include/GafferUI/StandardConnectionGadget.h
@@ -46,6 +46,8 @@
 namespace GafferUI
 {
 
+class NodeGadget;
+
 /// The standard implementation of the abstract ConnectionGadget base
 /// class. Connections endpoints may be dragged + dropped, and the tooltip
 /// displays the name of the source and destination plugs.
@@ -79,6 +81,19 @@ class GAFFERUI_API StandardConnectionGadget : public ConnectionGadget
 	private :
 
 		static ConnectionGadgetTypeDescription<StandardConnectionGadget> g_connectionGadgetTypeDescription;
+
+		// Returns the NodeGadget for the source end of the
+		// connection, even if `srcNodule()` is null. Will
+		// return null if the node is hidden though.
+		const NodeGadget *srcNodeGadget() const;
+		// Decides whether this connection should be highlighted,
+		// taking into account hovering, dragging, dot insertion
+		// and the highlighted state of the nodes at either end.
+		bool highlighted() const;
+		// `m_srcPos` and `m_srcTangent` are stored as if the
+		// connection is not minimised. This method returns them
+		// adjusted according to `getMinimised().
+		void minimisedPositionAndTangent( bool highlighted, Imath::V3f &position, Imath::V3f &tangent ) const;
 
 		void setPositionsFromNodules();
 		float distanceToNodeGadget( const IECore::LineSegment3f &line, const Nodule *nodule ) const;

--- a/include/GafferUI/StandardConnectionGadget.h
+++ b/include/GafferUI/StandardConnectionGadget.h
@@ -94,7 +94,11 @@ class GAFFERUI_API StandardConnectionGadget : public ConnectionGadget
 		// connection is not minimised. This method returns them
 		// adjusted according to `getMinimised().
 		void minimisedPositionAndTangent( bool highlighted, Imath::V3f &position, Imath::V3f &tangent ) const;
-
+		// Updates m_srcPos, m_srcTangent etc. We basically always
+		// call this before accessing that state, so I'm not sure
+		// why we store it at all - we could just return it instead.
+		/// \todo Consider making the updates lazy based on events, or
+		/// just drop the state.
 		void setPositionsFromNodules();
 		float distanceToNodeGadget( const IECore::LineSegment3f &line, const Nodule *nodule ) const;
 		Gaffer::Plug::Direction endAt( const IECore::LineSegment3f &line ) const;

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -225,6 +225,8 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		bool buttonPress( GadgetPtr gadget, const ButtonEvent &event );
 		bool buttonRelease( GadgetPtr gadget, const ButtonEvent &event );
 		bool buttonDoubleClick( GadgetPtr gadget, const ButtonEvent &event );
+		void enter( const ButtonEvent &event );
+		void leave( const ButtonEvent &event );
 		bool mouseMove( GadgetPtr gadget, const ButtonEvent &event );
 		IECore::RunTimeTypedPtr dragBegin( GadgetPtr gadget, const DragDropEvent &event );
 		bool dragEnter( GadgetPtr gadget, const DragDropEvent &event );
@@ -239,6 +241,7 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		void eventToGadgetSpace( Event &event, Gadget *gadget );
 		void eventToGadgetSpace( ButtonEvent &event, Gadget *gadget );
 
+		void updateGadgetUnderMouse( const ButtonEvent &event );
 		void emitEnterLeaveEvents( GadgetPtr newGadgetUnderMouse, GadgetPtr oldGadgetUnderMouse, const ButtonEvent &event );
 
 		GadgetPtr updatedDragDestination( std::vector<GadgetPtr> &gadgets, const DragDropEvent &event );

--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -144,7 +144,9 @@ def __plugNoduleType( plug ) :
 	elif plug.node().parameterMetadata( plug, "connectable" ) == 0 :
 		return ""
 	else :
-		return "GafferUI::StandardNodule"
+		# Causes `Nodule::create()` to choose nodule type
+		# based on plug type.
+		return None
 
 def __outPlugNoduleType( plug ) :
 
@@ -171,6 +173,15 @@ def __plugNoduleLabel( plug ) :
 
 	return label
 
+def __plugComponentNoduleLabel( plug ) :
+
+	parameterPlug = plug.parent()
+	label = __plugLabel( parameterPlug )
+	if label is None :
+		label = parameterPlug.getName()
+
+	return label + "." + plug.getName()
+
 Gaffer.Metadata.registerNode(
 
 	GafferOSL.OSLShader,
@@ -186,7 +197,6 @@ Gaffer.Metadata.registerNode(
 
 			"description", __plugDescription,
 			"label", __plugLabel,
-			"noduleLayout:label", __plugLabel,
 			"layout:divider", __plugDivider,
 			"layout:section", __plugPage,
 			"presetNames", __plugPresetNames,
@@ -195,6 +205,12 @@ Gaffer.Metadata.registerNode(
 			"nodule:type", __plugNoduleType,
 			"noduleLayout:visible", __plugNoduleVisibility,
 			"noduleLayout:label", __plugNoduleLabel,
+
+		],
+
+		"parameters.*.[rgbxyz]" : [
+
+			"noduleLayout:label", __plugComponentNoduleLabel,
 
 		],
 

--- a/python/GafferUI/CompoundNumericNoduleUI.py
+++ b/python/GafferUI/CompoundNumericNoduleUI.py
@@ -1,0 +1,87 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import Gaffer
+import GafferUI
+
+def __applyChildVisibility( plug, visible ) :
+
+	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+		if visible :
+			Gaffer.Metadata.registerValue( plug, "compoundNumericNodule:childrenVisible", True )
+		else :
+			Gaffer.Metadata.deregisterValue( plug, "compoundNumericNodule:childrenVisible" )
+
+def __plugContextMenuSignal( graphEditor, plug, menuDefinition ) :
+
+	# See if we've got a CompoundNodule. Early out if not.
+
+	nodeGadget = graphEditor.graphGadget().nodeGadget( plug.node() )
+	if not nodeGadget :
+		return
+
+	nodule = nodeGadget.nodule( plug )
+	if not isinstance( nodule, GafferUI.CompoundNumericNodule ) :
+		plug = plug.parent()
+		if isinstance( plug, Gaffer.Plug ) :
+			nodule = nodeGadget.nodule( plug )
+		if not isinstance( nodule, GafferUI.CompoundNumericNodule ) :
+			return
+
+	# Add menu items for showing/hiding the children.
+
+	childNames = "".join( c.getName() for c in plug ).upper()
+
+	if len( nodule ) > 0 :
+		menuDefinition.append(
+			"/Collapse {} Components".format( childNames ),
+			{
+				"command" : functools.partial( __applyChildVisibility, plug, False ),
+				"active" : not Gaffer.MetadataAlgo.readOnly( plug ),
+			}
+		)
+	else :
+		menuDefinition.append(
+			"/Expand {} Components".format( childNames ),
+			{
+				"command" : functools.partial( __applyChildVisibility, plug, True ),
+				"active" : not Gaffer.MetadataAlgo.readOnly( plug )
+			}
+		)
+
+GafferUI.GraphEditor.plugContextMenuSignal().connect( __plugContextMenuSignal, scoped = False )

--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -134,9 +134,35 @@ class GadgetWidget( GafferUI.GLWidget ) :
 		if not isinstance( QtWidgets.QApplication.focusWidget(), ( QtWidgets.QLineEdit, QtWidgets.QPlainTextEdit ) ) :
 			self._qtWidget().setFocus()
 
+		## \todo Widget.enterSignal() should be providing this
+		# event itself.
+		p = self.mousePosition( relativeTo = self )
+		event = GafferUI.ButtonEvent(
+			GafferUI.ButtonEvent.Buttons.None,
+			GafferUI.ButtonEvent.Buttons.None,
+			IECore.LineSegment3f(
+				imath.V3f( p.x, p.y, 1 ),
+				imath.V3f( p.x, p.y, 0 )
+			)
+		)
+
+		self.__viewportGadget.enterSignal()( self.__viewportGadget, event )
+
 	def __leave( self, widget ) :
 
 		self._qtWidget().clearFocus()
+
+		p = self.mousePosition( relativeTo = self )
+		event = GafferUI.ButtonEvent(
+			GafferUI.ButtonEvent.Buttons.None,
+			GafferUI.ButtonEvent.Buttons.None,
+			IECore.LineSegment3f(
+				imath.V3f( p.x, p.y, 1 ),
+				imath.V3f( p.x, p.y, 0 )
+			)
+		)
+
+		self.__viewportGadget.leaveSignal()( self.__viewportGadget, event )
 
 	def __renderRequest( self, gadget ) :
 

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -286,6 +286,7 @@ import DocumentationAlgo
 import _PlugAdder
 from Backups import Backups
 from AnimationEditor import AnimationEditor
+import CompoundNumericNoduleUI
 
 # and then specific node uis
 

--- a/python/GafferUITest/CompoundNumericNoduleTest.py
+++ b/python/GafferUITest/CompoundNumericNoduleTest.py
@@ -1,0 +1,68 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferTest
+import GafferUI
+import GafferUITest
+
+class CompoundNumericNoduleTest( GafferUITest.TestCase ) :
+
+	def testChildrenVisibleMetadata( self ) :
+
+		node = Gaffer.Node()
+		node["color"] = Gaffer.Color3fPlug()
+		nodeGadget = GafferUI.NodeGadget.create( node )
+
+		self.assertIsInstance( nodeGadget.nodule( node["color"] ), GafferUI.CompoundNumericNodule )
+		self.assertEqual( nodeGadget.nodule( node["color"]["r"] ), None )
+		self.assertEqual( nodeGadget.nodule( node["color"]["g"] ), None )
+		self.assertEqual( nodeGadget.nodule( node["color"]["b"] ), None )
+
+		Gaffer.Metadata.registerValue( node["color"], "compoundNumericNodule:childrenVisible", True )
+		self.assertIsInstance( nodeGadget.nodule( node["color"]["r"] ), GafferUI.StandardNodule )
+		self.assertIsInstance( nodeGadget.nodule( node["color"]["g"] ), GafferUI.StandardNodule )
+		self.assertIsInstance( nodeGadget.nodule( node["color"]["b"] ), GafferUI.StandardNodule )
+
+		Gaffer.Metadata.registerValue( node["color"], "compoundNumericNodule:childrenVisible", False )
+		self.assertEqual( nodeGadget.nodule( node["color"]["r"] ), None )
+		self.assertEqual( nodeGadget.nodule( node["color"]["g"] ), None )
+		self.assertEqual( nodeGadget.nodule( node["color"]["b"] ), None )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/GraphGadgetTest.py
+++ b/python/GafferUITest/GraphGadgetTest.py
@@ -1374,5 +1374,24 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 
 		assertBothVisible()
 
+	def testConnectionGadgetsIncludesDanglingConnections( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n1"] = Gaffer.Node()
+		s["n1"]["c"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["n2"] = Gaffer.Node()
+		s["n2"]["c"] = Gaffer.Color3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n2"]["c"]["r"].setInput( s["n1"]["c"]["r"] )
+
+		Gaffer.Metadata.registerValue( s["n2"]["c"], "compoundNumericNodule:childrenVisible", True )
+
+		g = GafferUI.GraphGadget( s )
+		c = g.connectionGadgets( s["n2"]["c"]["r"] )
+		self.assertEqual( len( c ), 1 )
+		self.assertEqual( c[0].dstNodule(), g.nodeGadget( s["n2"] ).nodule( s["n2"]["c"]["r"] ) )
+		self.assertIsNone( c[0].srcNodule() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -113,6 +113,7 @@ from ErrorDialogueTest import ErrorDialogueTest
 from WidgetAlgoTest import WidgetAlgoTest
 from BackupsTest import BackupsTest
 from LayoutsTest import LayoutsTest
+from CompoundNumericNoduleTest import CompoundNumericNoduleTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferUI/AuxiliaryConnectionsGadget.cpp
+++ b/src/GafferUI/AuxiliaryConnectionsGadget.cpp
@@ -38,6 +38,7 @@
 
 #include "GafferUI/GraphGadget.h"
 #include "GafferUI/NodeGadget.h"
+#include "GafferUI/Nodule.h"
 #include "GafferUI/Style.h"
 #include "GafferUI/ViewportGadget.h"
 
@@ -58,6 +59,19 @@ using namespace std;
 
 namespace
 {
+
+const Gadget *endGadget( const Plug *plug, const NodeGadget *nodeGadget )
+{
+	while( plug )
+	{
+		if( const Nodule *n = nodeGadget->nodule( plug ) )
+		{
+			return n;
+		}
+		plug = plug->parent<Plug>();
+	}
+	return nodeGadget;
+}
 
 template<typename Visitor>
 void visitAuxiliaryConnections( const GraphGadget *graphGadget, const NodeGadget *dstNodeGadget, Visitor visitor )
@@ -88,17 +102,35 @@ void visitAuxiliaryConnections( const GraphGadget *graphGadget, const NodeGadget
 			continue;
 		}
 
-		visitor( srcPlug, dstPlug, srcNodeGadget, dstNodeGadget );
+		visitor(
+			srcPlug, dstPlug,
+			srcNodeGadget, dstNodeGadget,
+			endGadget( srcPlug, srcNodeGadget ),
+			endGadget( dstPlug, dstNodeGadget )
+		);
 	}
 }
 
-Box2f nodeFrame( const NodeGadget *nodeGadget )
+Box2f gadgetFrame( const Gadget *gadget )
 {
-	const Box3f b = nodeGadget->transformedBound();
+	const Box3f b = gadget->transformedBound( nullptr );
 	return Box2f(
 		V2f( b.min.x, b.min.y ),
 		V2f( b.max.x, b.max.y )
 	);
+}
+
+string gadgetName( const Gadget *gadget )
+{
+	if( auto nodeGadget = runTimeCast<const NodeGadget>( gadget ) )
+	{
+		return nodeGadget->node()->getName().string();
+	}
+	else
+	{
+		auto plug = static_cast<const Nodule *>( gadget )->plug();
+		return plug->node()->getName().string() + "." + plug->relativeName( plug->node() );
+	}
 }
 
 } // namespace
@@ -118,11 +150,10 @@ AuxiliaryConnectionsGadget::~AuxiliaryConnectionsGadget()
 {
 }
 
-bool AuxiliaryConnectionsGadget::hasConnection( const NodeGadget *srcNodeGadget, const NodeGadget *dstNodeGadget ) const
+bool AuxiliaryConnectionsGadget::hasConnection( const Gadget *srcGadget, const Gadget *dstGadget ) const
 {
 	updateConnections();
-	auto it = m_nodeGadgetConnections.find( dstNodeGadget );
-	return it != m_nodeGadgetConnections.end() && it->second.sourceGadgets.count( srcNodeGadget );
+	return m_auxiliaryConnections.count( make_pair( srcGadget, dstGadget ) );
 }
 
 bool AuxiliaryConnectionsGadget::hasConnection( const Gaffer::Node *srcNode, const Gaffer::Node *dstNode ) const
@@ -133,21 +164,32 @@ bool AuxiliaryConnectionsGadget::hasConnection( const Gaffer::Node *srcNode, con
 	{
 		return false;
 	}
-	return hasConnection( srcNodeGadget, dstNodeGadget );
+
+	updateConnections();
+
+	auto srcRange = srcNodeGadgetIndex().equal_range( srcNodeGadget );
+	for( auto it = srcRange.first; it != srcRange.second; ++it )
+	{
+		if( it->dstNodeGadget == dstNodeGadget )
+		{
+			return true;
+		}
+	}
+	return false;
 }
 
-std::pair<NodeGadget *, NodeGadget *> AuxiliaryConnectionsGadget::connectionAt( const IECore::LineSegment3f &position )
+std::pair<Gadget *, Gadget *> AuxiliaryConnectionsGadget::connectionAt( const IECore::LineSegment3f &position )
 {
-	std::pair<const NodeGadget *, const NodeGadget *> c = const_cast<const AuxiliaryConnectionsGadget *>( this )->connectionAt( position );
-	return { const_cast<NodeGadget *>( c.first ), const_cast<NodeGadget *>( c.second ) };
+	std::pair<const Gadget *, const Gadget *> c = const_cast<const AuxiliaryConnectionsGadget *>( this )->connectionAt( position );
+	return { const_cast<Gadget *>( c.first ), const_cast<Gadget *>( c.second ) };
 }
 
-std::pair<const NodeGadget *, const NodeGadget *> AuxiliaryConnectionsGadget::connectionAt( const IECore::LineSegment3f &position ) const
+std::pair<const Gadget *, const Gadget *> AuxiliaryConnectionsGadget::connectionAt( const IECore::LineSegment3f &position ) const
 {
 	updateConnections();
 
 	vector<IECoreGL::HitRecord> selection;
-	vector<pair<const NodeGadget *, const NodeGadget *>> connections;
+	vector<pair<const Gadget *, const Gadget *>> connections;
 
 	{
 		ViewportGadget::SelectionScope selectionScope( position, this, selection, IECoreGL::Selector::IDRender );
@@ -155,16 +197,12 @@ std::pair<const NodeGadget *, const NodeGadget *> AuxiliaryConnectionsGadget::co
 		const Style *style = this->style();
 		style->bind();
 		GLuint name = 1; // Name 0 is invalid, so we start at 1
-		for( auto &x : m_nodeGadgetConnections )
+
+		for( auto &c : m_auxiliaryConnections )
 		{
-			const NodeGadget *dstNodeGadget = x.first;
-			const Box2f dstFrame = nodeFrame( dstNodeGadget );
-			for( auto &srcNodeGadget : x.second.sourceGadgets )
-			{
-				connections.push_back( { srcNodeGadget, dstNodeGadget } );
-				selector->loadName( name++ );
-				style->renderAuxiliaryConnection( nodeFrame( srcNodeGadget ), dstFrame, Style::NormalState );
-			}
+			connections.push_back( c.endpoints );
+			selector->loadName( name++ );
+			style->renderAuxiliaryConnection( gadgetFrame( c.endpoints.first ), gadgetFrame( c.endpoints.second ), Style::NormalState );
 		}
 	}
 
@@ -205,18 +243,21 @@ std::string AuxiliaryConnectionsGadget::getToolTip( const IECore::LineSegment3f 
 		return s;
 	}
 
-	pair<const NodeGadget *, const NodeGadget *> connection = connectionAt( position );
+	auto connection = connectionAt( position );
 	if( !connection.first )
 	{
 		return "";
 	}
 
-	s += "Auxiliary connections from " + connection.first->node()->getName().string() + " to " + connection.second->node()->getName().string() + " : \n\n";
+	auto dstNodeGadget = runTimeCast<const NodeGadget>( connection.second );
+	dstNodeGadget = dstNodeGadget ? dstNodeGadget : connection.second->ancestor<NodeGadget>();
+
+	s += "Auxiliary connections from " + gadgetName( connection.first ) + " to " + gadgetName( connection.second ) + " : \n\n";
 	visitAuxiliaryConnections(
-		graphGadget(), connection.second,
-		[ &s, &connection ] ( const Plug *srcPlug, const Plug *dstPlug, const NodeGadget *srcNodeGadget, const NodeGadget *dstNodeGadget )
+		graphGadget(), dstNodeGadget,
+		[ &s, &connection ] ( const Plug *srcPlug, const Plug *dstPlug, const NodeGadget *srcNodeGadget, const NodeGadget *dstNodeGadget, const Gadget *srcGadget, const Gadget *dstGadget )
 		{
-			if( srcNodeGadget == connection.first )
+			if( srcGadget == connection.first && dstGadget == connection.second )
 			{
 				s +=
 					"\t" +
@@ -240,15 +281,10 @@ void AuxiliaryConnectionsGadget::doRenderLayer( Layer layer, const Style *style 
 	}
 
 	updateConnections();
-	for( auto &x : m_nodeGadgetConnections )
+	for( auto &c : m_auxiliaryConnections )
 	{
-		bool dstHighlighted = x.first->getHighlighted();
-		const Box2f dstFrame = nodeFrame( x.first );
-		for( auto &srcNodeGadget : x.second.sourceGadgets )
-		{
-			Style::State state = dstHighlighted || srcNodeGadget->getHighlighted() ? Style::HighlightedState : Style::NormalState;
-			style->renderAuxiliaryConnection( nodeFrame( srcNodeGadget ), dstFrame, state );
-		}
+		const Style::State state = c.srcNodeGadget->getHighlighted() || c.dstNodeGadget->getHighlighted() ? Style::HighlightedState : Style::NormalState;
+		style->renderAuxiliaryConnection( gadgetFrame( c.endpoints.first ), gadgetFrame( c.endpoints.second ), state );
 	}
 }
 
@@ -290,6 +326,8 @@ void AuxiliaryConnectionsGadget::graphGadgetChildRemoved( const GraphComponent *
 {
 	if( const NodeGadget *nodeGadget = runTimeCast<const NodeGadget>( child ) )
 	{
+		dirtyInputConnections( nodeGadget );
+		dirtyOutputConnections( nodeGadget );
 		m_nodeGadgetConnections.erase( nodeGadget );
 	}
 }
@@ -298,7 +336,7 @@ void AuxiliaryConnectionsGadget::plugInputChanged( const Gaffer::Plug *plug )
 {
 	if( const NodeGadget *nodeGadget = graphGadget()->nodeGadget( plug->node() ) )
 	{
-		dirty( nodeGadget );
+		dirtyInputConnections( nodeGadget );
 	}
 }
 
@@ -310,21 +348,24 @@ void AuxiliaryConnectionsGadget::childRemoved( const Gaffer::GraphComponent *nod
 	}
 	if( const NodeGadget *nodeGadget = graphGadget()->nodeGadget( static_cast<const Node *>( node ) ) )
 	{
-		dirty( nodeGadget );
+		dirtyInputConnections( nodeGadget );
+		dirtyOutputConnections( nodeGadget );
 	}
 }
 
 void AuxiliaryConnectionsGadget::noduleAdded( const NodeGadget *nodeGadget, const Nodule *nodule )
 {
-	dirty( nodeGadget );
+	dirtyInputConnections( nodeGadget );
+	dirtyOutputConnections( nodeGadget );
 }
 
 void AuxiliaryConnectionsGadget::noduleRemoved( const NodeGadget *nodeGadget, const Nodule *nodule )
 {
-	dirty( nodeGadget );
+	dirtyInputConnections( nodeGadget );
+	dirtyOutputConnections( nodeGadget );
 }
 
-void AuxiliaryConnectionsGadget::dirty( const NodeGadget *nodeGadget )
+void AuxiliaryConnectionsGadget::dirtyInputConnections( const NodeGadget *nodeGadget )
 {
 	auto it = m_nodeGadgetConnections.find( nodeGadget );
 	// We only connect to signals for NodeGadgets we're tracking,
@@ -335,7 +376,33 @@ void AuxiliaryConnectionsGadget::dirty( const NodeGadget *nodeGadget )
 	{
 		return;
 	}
+
+	auto &dstIndex = dstNodeGadgetIndex();
+	auto dstRange = dstIndex.equal_range( nodeGadget );
+	dstIndex.erase( dstRange.first, dstRange.second );
 	it->second.dirty = true;
+
+	if( m_dirty )
+	{
+		return;
+	}
+	m_dirty = true;
+	requestRender();
+}
+
+void AuxiliaryConnectionsGadget::dirtyOutputConnections( const NodeGadget *nodeGadget )
+{
+	auto &srcIndex = srcNodeGadgetIndex();
+	auto srcRange = srcIndex.equal_range( nodeGadget );
+	for( auto it = srcRange.first; it != srcRange.second; ++it )
+	{
+		auto cIt = m_nodeGadgetConnections.find( it->dstNodeGadget );
+		assert( cIt != m_nodeGadgetConnections.end() );
+		cIt->second.dirty = true;
+	}
+
+	srcIndex.erase( srcRange.first, srcRange.second );
+
 	if( m_dirty )
 	{
 		return;
@@ -359,18 +426,26 @@ void AuxiliaryConnectionsGadget::updateConnections() const
 			continue;
 		}
 
-		connections.sourceGadgets.clear();
 		visitAuxiliaryConnections(
 			graphGadget(), x.first,
-			[&connections] ( const Plug *srcPlug, const Plug *dstPlug, const NodeGadget *srcNodeGadget, const NodeGadget *dstNodeGadget )
+			[this] ( const Plug *srcPlug, const Plug *dstPlug, const NodeGadget *srcNodeGadget, const NodeGadget *dstNodeGadget, const Gadget *srcGadget, const Gadget *dstGadget )
 			{
-				connections.sourceGadgets.insert( srcNodeGadget );
+				AuxiliaryConnection c = { srcNodeGadget, dstNodeGadget, { srcGadget, dstGadget } };
+				m_auxiliaryConnections.insert( c );
 			}
 		);
-
 		connections.dirty = false;
 	}
 
 	m_dirty = false;
 }
 
+AuxiliaryConnectionsGadget::SrcNodeGadgetIndex &AuxiliaryConnectionsGadget::srcNodeGadgetIndex() const
+{
+	return m_auxiliaryConnections.get<1>();
+}
+
+AuxiliaryConnectionsGadget::DstNodeGadgetIndex &AuxiliaryConnectionsGadget::dstNodeGadgetIndex() const
+{
+	return m_auxiliaryConnections.get<2>();
+}

--- a/src/GafferUI/CompoundNumericNodule.cpp
+++ b/src/GafferUI/CompoundNumericNodule.cpp
@@ -1,0 +1,316 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferUI/CompoundNumericNodule.h"
+
+#include "GafferUI/NoduleLayout.h"
+#include "GafferUI/PlugAdder.h"
+
+#include "Gaffer/CompoundNumericPlug.h"
+#include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
+
+#include "boost/bind.hpp"
+#include "boost/bind/placeholders.hpp"
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferUI;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+InternedString g_childrenVisibleKey( "compoundNumericNodule:childrenVisible" );
+
+bool canConnect( const Plug *p1, const Plug *p2 )
+{
+	if( p1->direction() == p2->direction() || p1->node() == p2->node() )
+	{
+		return false;
+	}
+	if( p1->direction() == Plug::In )
+	{
+		return p1->acceptsInput( p2 );
+	}
+	else
+	{
+		return p2->acceptsInput( p1 );
+	}
+}
+
+void connect( Plug *p1, Plug *p2 )
+{
+	if( p1->direction() == Plug::In )
+	{
+		p1->setInput( p2 );
+	}
+	else
+	{
+		p2->setInput( p1 );
+	}
+}
+
+IECore::TypeId g_compoundNumericTypeIds[] = {
+	V2fPlug::staticTypeId(), V3fPlug::staticTypeId(),
+	V2iPlug::staticTypeId(), V3iPlug::staticTypeId(),
+	Color3fPlug::staticTypeId(), Color4fPlug::staticTypeId()
+};
+
+struct TypeDescription
+{
+	TypeDescription()
+	{
+		for( auto t : g_compoundNumericTypeIds )
+		{
+			Nodule::registerNodule(
+				CompoundNumericNodule::staticTypeName(),
+				[]( PlugPtr p ) { return new CompoundNumericNodule( p ); },
+				t
+			);
+		}
+	}
+};
+
+static TypeDescription g_typeDescription;
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// CompoundNumericNodule
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( CompoundNumericNodule );
+
+CompoundNumericNodule::CompoundNumericNodule( Gaffer::PlugPtr plug )
+	:	StandardNodule( plug )
+{
+	Metadata::plugValueChangedSignal().connect( boost::bind( &CompoundNumericNodule::plugMetadataChanged, this, ::_1, ::_2, ::_3, ::_4 ) );
+	updateChildNoduleVisibility();
+}
+
+CompoundNumericNodule::~CompoundNumericNodule()
+{
+}
+
+Nodule *CompoundNumericNodule::nodule( const Gaffer::Plug *plug )
+{
+	if( plug->parent() == this->plug() )
+	{
+		if( NoduleLayout *l = noduleLayout() )
+		{
+			return l->nodule( plug );
+		}
+	}
+	return nullptr;
+}
+
+const Nodule *CompoundNumericNodule::nodule( const Gaffer::Plug *plug ) const
+{
+	if( plug->parent() == this->plug() )
+	{
+		if( const NoduleLayout *l = noduleLayout() )
+		{
+			return l->nodule( plug );
+		}
+	}
+	return nullptr;
+}
+
+bool CompoundNumericNodule::canCreateConnection( const Gaffer::Plug *endpoint ) const
+{
+	if( StandardNodule::canCreateConnection( endpoint ) )
+	{
+		return true;
+	}
+
+	if( noduleLayout() )
+	{
+		return false;
+	}
+
+	for( PlugIterator it( plug() ); !it.done(); ++it )
+	{
+		if( canConnect( endpoint, it->get() ) )
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+void CompoundNumericNodule::createConnection( Gaffer::Plug *endpoint )
+{
+	if( StandardNodule::canCreateConnection( endpoint ) )
+	{
+		StandardNodule::createConnection( endpoint );
+		return;
+	}
+
+	vector<Plug *> plugs;
+	string allName;
+	for( PlugIterator it( plug() ); !it.done(); ++it )
+	{
+		if( canConnect( endpoint, it->get() ) )
+		{
+			plugs.push_back( it->get() );
+			allName += (*it)->getName();
+		}
+	}
+
+	PlugPtr allProxy;
+	if( allName.size() && plug()->direction() == Plug::In )
+	{
+		allProxy = new Plug( allName );
+		plugs.push_back( allProxy.get() );
+	}
+
+	Plug *p = PlugAdder::plugMenuSignal()( "Connect To", plugs );
+	if( p )
+	{
+		if( p == allProxy )
+		{
+			for( const auto &p : plugs )
+			{
+				connect( p, endpoint );
+			}
+		}
+		else
+		{
+			connect( p, endpoint );
+		}
+
+		Gaffer::Metadata::registerValue( plug(), g_childrenVisibleKey, new BoolData( true ) );
+	}
+}
+
+Imath::Box3f CompoundNumericNodule::bound() const
+{
+	if( !noduleLayout() )
+	{
+		return StandardNodule::bound();
+	}
+	else
+	{
+		const V3f border( 0.1, 0.1, 0 );
+		Box3f b = Nodule::bound();
+		b.min -= border;
+		b.max += border;
+		return b;
+	}
+}
+
+void CompoundNumericNodule::doRenderLayer( Layer layer, const Style *style ) const
+{
+	if( !noduleLayout() )
+	{
+		StandardNodule::doRenderLayer( layer, style );
+	}
+}
+
+NoduleLayout *CompoundNumericNodule::noduleLayout()
+{
+	return children().size() ? getChild<NoduleLayout>( 0 ) : nullptr;
+}
+
+const NoduleLayout *CompoundNumericNodule::noduleLayout() const
+{
+	return children().size() ? getChild<NoduleLayout>( 0 ) : nullptr;
+}
+
+void CompoundNumericNodule::plugMetadataChanged( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
+{
+	if( !MetadataAlgo::affectedByChange( this->plug(), nodeTypeId, plugPath, plug ) )
+	{
+		return;
+	}
+
+	if( key == g_childrenVisibleKey )
+	{
+		updateChildNoduleVisibility();
+	}
+}
+
+void CompoundNumericNodule::updateChildNoduleVisibility()
+{
+	bool childrenVisible = false;
+	if( ConstBoolDataPtr d = Metadata::value<BoolData>( plug(), g_childrenVisibleKey ) )
+	{
+		childrenVisible = d->readable();
+	}
+
+	if( childrenVisible )
+	{
+		if( !noduleLayout() )
+		{
+			NoduleLayoutPtr layout = new NoduleLayout( plug() );
+			layout->setTransform( M44f().scale( V3f( 0.75 ) ) );
+			addChild( layout );
+			if( NodeGadget *nodeGadget = ancestor<NodeGadget>() )
+			{
+				for( PlugIterator it( plug() ); !it.done(); ++it )
+				{
+					if( Nodule *nodule = layout->nodule( it->get() ) )
+					{
+						nodeGadget->noduleAddedSignal()( nodeGadget, nodule );
+					}
+				}
+			}
+		}
+	}
+	else
+	{
+		if( NoduleLayoutPtr layout = noduleLayout() )
+		{
+			removeChild( layout );
+			if( NodeGadget *nodeGadget = ancestor<NodeGadget>() )
+			{
+				for( PlugIterator it( plug() ); !it.done(); ++it )
+				{
+					if( Nodule *nodule = layout->nodule( it->get() ) )
+					{
+						nodeGadget->noduleRemovedSignal()( nodeGadget, nodule );
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -278,8 +278,7 @@ size_t GraphGadget::connectionGadgets( const Gaffer::Plug *plug, std::vector<Con
 		{
 			if( !excludedNodes || !excludedNodes->contains( input->node() ) )
 			{
-				ConnectionGadget *connection = connectionGadget( plug );
-				if( connection && connection->srcNodule() )
+				if( ConnectionGadget *connection = connectionGadget( plug ) )
 				{
 					connections.push_back( connection );
 				}
@@ -295,8 +294,7 @@ size_t GraphGadget::connectionGadgets( const Gaffer::Plug *plug, std::vector<Con
 			{
 				continue;
 			}
-			ConnectionGadget *connection = connectionGadget( *it );
-			if( connection && connection->srcNodule() )
+			if( ConnectionGadget *connection = connectionGadget( *it ) )
 			{
 				connections.push_back( connection );
 			}
@@ -1326,6 +1324,11 @@ void GraphGadget::calculateDragSnapOffsets( Gaffer::Set *nodes )
 
 			const ConnectionGadget *connection = *it;
 			const Nodule *srcNodule = connection->srcNodule();
+			if( !srcNodule )
+			{
+				continue;
+			}
+
 			const Nodule *dstNodule = connection->dstNodule();
 			const NodeGadget *srcNodeGadget = srcNodule->ancestor<NodeGadget>();
 			const NodeGadget *dstNodeGadget = dstNodule->ancestor<NodeGadget>();

--- a/src/GafferUI/Nodule.cpp
+++ b/src/GafferUI/Nodule.cpp
@@ -68,6 +68,16 @@ const Gaffer::Plug *Nodule::plug() const
 	return m_plug.get();
 }
 
+Nodule *Nodule::nodule( const Gaffer::Plug *plug )
+{
+	return nullptr;
+}
+
+const Nodule *Nodule::nodule( const Gaffer::Plug *plug ) const
+{
+	return nullptr;
+}
+
 void Nodule::updateDragEndPoint( const Imath::V3f position, const Imath::V3f &tangent )
 {
 }

--- a/src/GafferUI/NoduleLayout.cpp
+++ b/src/GafferUI/NoduleLayout.cpp
@@ -37,7 +37,6 @@
 
 #include "GafferUI/NoduleLayout.h"
 
-#include "GafferUI/CompoundNodule.h"
 #include "GafferUI/LinearContainer.h"
 #include "GafferUI/NodeGadget.h"
 #include "GafferUI/Nodule.h"
@@ -426,10 +425,9 @@ Nodule *NoduleLayout::nodule( const Gaffer::Plug *plug )
 	}
 	else if( const Plug *parentPlug = IECore::runTimeCast<const Plug>( plugParent ) )
 	{
-		CompoundNodule *compoundNodule = IECore::runTimeCast<CompoundNodule>( nodule( parentPlug ) );
-		if( compoundNodule )
+		if( Nodule *parentNodule = nodule( parentPlug ) )
 		{
-			return compoundNodule->nodule( plug );
+			return parentNodule->nodule( plug );
 		}
 	}
 	return nullptr;

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -90,7 +90,7 @@ StandardConnectionGadget::~StandardConnectionGadget()
 void StandardConnectionGadget::setNodules( GafferUI::NodulePtr srcNodule, GafferUI::NodulePtr dstNodule )
 {
 	ConnectionGadget::setNodules( srcNodule, dstNodule );
-	setPositionsFromNodules();
+	updateConnectionGeometry();
 }
 
 const NodeGadget *StandardConnectionGadget::srcNodeGadget() const
@@ -137,7 +137,7 @@ void StandardConnectionGadget::minimisedPositionAndTangent( bool highlighted, Im
 	tangent = minimise ? -m_dstTangent : m_srcTangent;
 }
 
-void StandardConnectionGadget::setPositionsFromNodules()
+void StandardConnectionGadget::updateConnectionGeometry()
 {
 	const Gadget *p = parent<Gadget>();
 	if( !p )
@@ -221,7 +221,7 @@ void StandardConnectionGadget::setPositionsFromNodules()
 
 Imath::Box3f StandardConnectionGadget::bound() const
 {
-	const_cast<StandardConnectionGadget *>( this )->setPositionsFromNodules();
+	const_cast<StandardConnectionGadget *>( this )->updateConnectionGeometry();
 	Box3f r;
 	r.extendBy( m_srcPos );
 	r.extendBy( m_dstPos );
@@ -307,7 +307,7 @@ void StandardConnectionGadget::doRenderLayer( Layer layer, const Style *style ) 
 		return;
 	}
 
-	const_cast<StandardConnectionGadget *>( this )->setPositionsFromNodules();
+	const_cast<StandardConnectionGadget *>( this )->updateConnectionGeometry();
 	const Style::State state = highlighted() ? Style::HighlightedState : Style::NormalState;
 
 	V3f minimisedSrcPos, minimisedSrcTangent;
@@ -345,7 +345,7 @@ bool StandardConnectionGadget::hasLayer( Layer layer ) const
 
 Imath::V3f StandardConnectionGadget::closestPoint( const Imath::V3f& p ) const
 {
-	const_cast<StandardConnectionGadget *>( this )->setPositionsFromNodules();
+	const_cast<StandardConnectionGadget *>( this )->updateConnectionGeometry();
 
 	V3f minimisedSrcPos, minimisedSrcTangent;
 	minimisedPositionAndTangent( highlighted(), minimisedSrcPos, minimisedSrcTangent );
@@ -465,7 +465,7 @@ IECore::RunTimeTypedPtr StandardConnectionGadget::dragBegin( const DragDropEvent
 		return nullptr;
 	}
 
-	setPositionsFromNodules();
+	updateConnectionGeometry();
 	m_dragEnd = endAt( event.line );
 
 	// prepare for adding additional connection

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -184,6 +184,20 @@ void StandardConnectionGadget::setPositionsFromNodules()
 	if( m_dragEnd != Gaffer::Plug::Out )
 	{
 		const Nodule *srcNodule = this->srcNodule();
+		if( !srcNodule && srcNodeGadget )
+		{
+			// If we don't have a source nodule, try to find the nodule
+			// for the parent plug.
+			if( const Plug *srcParentPlug = dstNodule()->plug()->getInput()->parent<Plug>() )
+			{
+				srcNodule = srcNodeGadget->nodule( srcParentPlug );
+				if( srcNodule )
+				{
+					m_auxiliary = true;
+				}
+			}
+		}
+
 		if( srcNodule )
 		{
 			m_srcPos = V3f( 0 ) * srcNodule->fullTransform( p );;
@@ -191,6 +205,7 @@ void StandardConnectionGadget::setPositionsFromNodules()
 		}
 		else if( srcNodeGadget )
 		{
+			// Auxiliary connection to centre of node.
 			m_auxiliary = true;
 			m_srcPos = srcNodeGadget->transformedBound().center();
 			m_srcTangent = V3f( 0 );

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -101,7 +101,7 @@ void StandardConnectionGadget::setPositionsFromNodules()
 		return;
 	}
 
-	if( dstNodule() && m_dragEnd!=Gaffer::Plug::In )
+	if( m_dragEnd != Gaffer::Plug::In )
 	{
 		Gadget *dstNodeGadget = dstNodule()->ancestor<NodeGadget>();
 		if( dstNodeGadget )
@@ -315,7 +315,7 @@ Imath::V3f StandardConnectionGadget::closestPoint( const Imath::V3f& p ) const
 	const_cast<StandardConnectionGadget *>( this )->setPositionsFromNodules();
 
 	Style::State state = ( m_hovering || m_dragEnd ) ? Style::HighlightedState : Style::NormalState;
-	if( state != Style::HighlightedState && srcNodule() && dstNodule() )
+	if( state != Style::HighlightedState && srcNodule() )
 	{
 		const Gadget *srcNodeGadget = srcNodule()->ancestor<NodeGadget>();
 		if( srcNodeGadget && srcNodeGadget->getHighlighted() )

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -175,9 +175,13 @@ bool canConnect( const DragDropEvent &event, const ConnectionCreator *destinatio
 {
 	if( auto plug = IECore::runTimeCast<const Plug>( event.data.get() ) )
 	{
-		return destination->canCreateConnection( plug );
+		if( destination->canCreateConnection( plug ) )
+		{
+			return true;
+		}
 	}
-	else if( auto sourceCreator = IECore::runTimeCast<const ConnectionCreator>( event.sourceGadget.get() ) )
+
+	if( auto sourceCreator = IECore::runTimeCast<const ConnectionCreator>( event.sourceGadget.get() ) )
 	{
 		if( auto destinationNodule = IECore::runTimeCast<const Nodule>( destination ) )
 		{
@@ -191,10 +195,15 @@ void connect( const DragDropEvent &event, ConnectionCreator *destination )
 {
 	if( auto plug = IECore::runTimeCast<Plug>( event.data.get() ) )
 	{
-		UndoScope undoScope( plug->ancestor<ScriptNode>() );
-		destination->createConnection( plug );
+		if( destination->canCreateConnection( plug ) )
+		{
+			UndoScope undoScope( plug->ancestor<ScriptNode>() );
+			destination->createConnection( plug );
+			return;
+		}
 	}
-	else if( auto sourceCreator = IECore::runTimeCast<ConnectionCreator>( event.sourceGadget.get() ) )
+
+	if( auto sourceCreator = IECore::runTimeCast<ConnectionCreator>( event.sourceGadget.get() ) )
 	{
 		if( auto destinationNodule = IECore::runTimeCast<Nodule>( destination ) )
 		{

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -155,6 +155,11 @@ void StandardNodule::createConnection( Gaffer::Plug *endpoint )
 
 bool StandardNodule::hasLayer( Layer layer ) const
 {
+	if( children().size() )
+	{
+		return true;
+	}
+
 	switch( layer )
 	{
 		case GraphLayer::Connections :

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -99,7 +99,7 @@ V2f planarScaleFromCameraAndRes( const IECoreScene::Camera *cam, const V2i &res 
 	{
 		return V2f( 1.0f );
 	}
-	
+
 	return V2f( cam->getAperture()[0] / ((float)res[0] ), cam->getAperture()[1] / ((float)res[1] ) );
 }
 
@@ -592,6 +592,8 @@ ViewportGadget::ViewportGadget( GadgetPtr primaryChild )
 	buttonPressSignal().connect( boost::bind( &ViewportGadget::buttonPress, this, ::_1,  ::_2 ) );
 	buttonReleaseSignal().connect( boost::bind( &ViewportGadget::buttonRelease, this, ::_1,  ::_2 ) );
 	buttonDoubleClickSignal().connect( boost::bind( &ViewportGadget::buttonDoubleClick, this, ::_1,  ::_2 ) );
+	enterSignal().connect( boost::bind( &ViewportGadget::enter, this, ::_2 ) );
+	leaveSignal().connect( boost::bind( &ViewportGadget::leave, this, ::_2 ) );
 	mouseMoveSignal().connect( boost::bind( &ViewportGadget::mouseMove, this, ::_1,  ::_2 ) );
 	dragBeginSignal().connect( boost::bind( &ViewportGadget::dragBegin, this, ::_1, ::_2 ) );
 	dragEnterSignal().connect( boost::bind( &ViewportGadget::dragEnter, this, ::_1, ::_2 ) );
@@ -1002,57 +1004,8 @@ bool ViewportGadget::buttonDoubleClick( GadgetPtr gadget, const ButtonEvent &eve
 	return false;
 }
 
-void ViewportGadget::emitEnterLeaveEvents( GadgetPtr newGadgetUnderMouse, GadgetPtr oldGadgetUnderMouse, const ButtonEvent &event )
+void ViewportGadget::updateGadgetUnderMouse( const ButtonEvent &event )
 {
-	// figure out the lowest point in the hierarchy where the entered status is unchanged.
-	GadgetPtr lowestUnchanged = this;
-	if( oldGadgetUnderMouse && newGadgetUnderMouse )
-	{
-		if( oldGadgetUnderMouse->isAncestorOf( newGadgetUnderMouse.get() ) )
-		{
-			lowestUnchanged = oldGadgetUnderMouse;
-		}
-		else if( newGadgetUnderMouse->isAncestorOf( oldGadgetUnderMouse.get() ) )
-		{
-			lowestUnchanged = newGadgetUnderMouse;
-		}
-		else
-		{
-			lowestUnchanged = oldGadgetUnderMouse->commonAncestor<Gadget>( newGadgetUnderMouse.get() );
-		}
-	}
-
-	// emit leave events, innermost first
-	if( oldGadgetUnderMouse )
-	{
-		GadgetPtr leaveTarget = oldGadgetUnderMouse;
-		while( leaveTarget != lowestUnchanged )
-		{
-			dispatchEvent( leaveTarget.get(), &Gadget::leaveSignal, event );
-			leaveTarget = leaveTarget->parent<Gadget>();
-		}
-	}
-
-	// emit enter events, outermost first
-	if( newGadgetUnderMouse )
-	{
-		std::vector<GadgetPtr> enterTargets;
-		GadgetPtr enterTarget = newGadgetUnderMouse;
-		while( enterTarget != lowestUnchanged )
-		{
-			enterTargets.push_back( enterTarget );
-			enterTarget = enterTarget->parent<Gadget>();
-		}
-		for( std::vector<GadgetPtr>::const_reverse_iterator it = enterTargets.rbegin(); it!=enterTargets.rend(); it++ )
-		{
-			dispatchEvent( *it, &Gadget::enterSignal, event );
-		}
-	}
-};
-
-bool ViewportGadget::mouseMove( GadgetPtr gadget, const ButtonEvent &event )
-{
-	// find the gadget under the mouse
 	std::vector<GadgetPtr> gadgets;
 	gadgetsAt( V2f( event.line.p0.x, event.line.p0.y ), gadgets );
 
@@ -1067,6 +1020,79 @@ bool ViewportGadget::mouseMove( GadgetPtr gadget, const ButtonEvent &event )
 		emitEnterLeaveEvents( newGadgetUnderMouse, m_gadgetUnderMouse, event );
 		m_gadgetUnderMouse = newGadgetUnderMouse;
 	}
+}
+
+void ViewportGadget::emitEnterLeaveEvents( GadgetPtr newGadgetUnderMouse, GadgetPtr oldGadgetUnderMouse, const ButtonEvent &event )
+{
+
+	// figure out the lowest point in the hierarchy where the entered status is unchanged.
+	GadgetPtr lowestUnchanged = this;
+	if( oldGadgetUnderMouse && newGadgetUnderMouse )
+	{
+		if( oldGadgetUnderMouse->isAncestorOf( newGadgetUnderMouse.get() ) )
+		{
+			lowestUnchanged = oldGadgetUnderMouse;
+		}
+		else if( newGadgetUnderMouse->isAncestorOf( oldGadgetUnderMouse.get() ) )
+		{
+			lowestUnchanged = newGadgetUnderMouse;
+		}
+		else
+		{
+			if( Gadget *commonAncestor = oldGadgetUnderMouse->commonAncestor<Gadget>( newGadgetUnderMouse.get() ) )
+			{
+				lowestUnchanged = commonAncestor;
+			}
+		}
+	}
+
+	// emit leave events, innermost first
+	if( oldGadgetUnderMouse )
+	{
+		GadgetPtr leaveTarget = oldGadgetUnderMouse;
+		while( leaveTarget && leaveTarget != lowestUnchanged )
+		{
+			dispatchEvent( leaveTarget.get(), &Gadget::leaveSignal, event );
+			leaveTarget = leaveTarget->parent<Gadget>();
+		}
+	}
+
+	// emit enter events, outermost first
+	if( newGadgetUnderMouse )
+	{
+		std::vector<GadgetPtr> enterTargets;
+		GadgetPtr enterTarget = newGadgetUnderMouse;
+		while( enterTarget && enterTarget != lowestUnchanged )
+		{
+			enterTargets.push_back( enterTarget );
+			enterTarget = enterTarget->parent<Gadget>();
+		}
+		for( std::vector<GadgetPtr>::const_reverse_iterator it = enterTargets.rbegin(); it!=enterTargets.rend(); it++ )
+		{
+			dispatchEvent( *it, &Gadget::enterSignal, event );
+		}
+	}
+
+};
+
+void ViewportGadget::enter( const ButtonEvent &event )
+{
+	updateGadgetUnderMouse( event );
+}
+
+void ViewportGadget::leave( const ButtonEvent &event )
+{
+	if( m_gadgetUnderMouse )
+	{
+		emitEnterLeaveEvents( nullptr, m_gadgetUnderMouse, event );
+		m_gadgetUnderMouse = nullptr;
+	}
+}
+
+bool ViewportGadget::mouseMove( GadgetPtr gadget, const ButtonEvent &event )
+{
+	// find the gadget under the mouse
+	updateGadgetUnderMouse( event );
 
 	// pass the signal through
 	if( m_gadgetUnderMouse )

--- a/src/GafferUIModule/GraphGadgetBinding.cpp
+++ b/src/GafferUIModule/GraphGadgetBinding.cpp
@@ -222,7 +222,7 @@ void GafferUIModule::bindGraphGadget()
 	}
 
 	GadgetClass<AuxiliaryConnectionsGadget>()
-		.def( "hasConnection", (bool (AuxiliaryConnectionsGadget::*)( const NodeGadget *, const NodeGadget * ) const)&AuxiliaryConnectionsGadget::hasConnection )
+		.def( "hasConnection", (bool (AuxiliaryConnectionsGadget::*)( const Gadget *, const Gadget * ) const)&AuxiliaryConnectionsGadget::hasConnection )
 		.def( "hasConnection", (bool (AuxiliaryConnectionsGadget::*)( const Node *, const Node * ) const)&AuxiliaryConnectionsGadget::hasConnection )
 		.def( "connectionAt", &connectionAt )
 	;

--- a/src/GafferUIModule/NoduleBinding.cpp
+++ b/src/GafferUIModule/NoduleBinding.cpp
@@ -45,6 +45,7 @@
 #include "GafferUI/Nodule.h"
 #include "GafferUI/NoduleLayout.h"
 #include "GafferUI/StandardNodule.h"
+#include "GafferUI/CompoundNumericNodule.h"
 
 #include "Gaffer/Plug.h"
 
@@ -144,6 +145,10 @@ void GafferUIModule::bindNodule()
 	;
 
 	ConnectionCreatorClass<CompoundNodule>()
+		.def( init<Gaffer::PlugPtr>( ( arg( "plug" ) ) ) )
+	;
+
+	ConnectionCreatorClass<CompoundNumericNodule>()
 		.def( init<Gaffer::PlugPtr>( ( arg( "plug" ) ) ) )
 	;
 


### PR DESCRIPTION
In #2902, we gave the shader nodes and renderer backends the ability to deal with connections at the level of individual color/vector components. This PR follows on from that, adding the necessary support for making such connections from the UI.

Color parameters start out as they've always been - just a single connection point. But you can now drag connect them to and from float plugs, choosing what components to connect from a popup menu. This automatically expands the plug to show all the components :

![connect](https://user-images.githubusercontent.com/1133871/49817426-1543ef80-fd68-11e8-8511-4a16ba71bdb0.gif)

You can also use a plug context menu to manually expand colour plugs to show their children, allowing you to swizzle components between two colours :

![expand](https://user-images.githubusercontent.com/1133871/49817549-7075e200-fd68-11e8-8cda-c0a07f95d611.gif)

And you can collapse back using the same context menu. If you collapse a plug that has child connections, these are still drawn, but using the "auxiliary connection" style we use for expression connections :

![collapse](https://user-images.githubusercontent.com/1133871/49817639-b0d56000-fd68-11e8-947b-71e7bf3ad668.gif)

@mattigruener, I've added you as a reviewer since you're the most familiar with the GraphGadget code. The CompoundNumericNodule itself was pretty straightforward, but the updates to the StandardConnectionGadget and AuxiliaryConnectionsGadget got a bit fiddly. I've tried to refactor where I can rather than just shoehorn things in - hopefully it makes sense.
