### PR TITLE
Protect against null Widgets

### DIFF
--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -1060,7 +1060,7 @@ class _EventFilter( QtCore.QObject ) :
 			return True
 
 		widget = Widget._owner( qObject )
-		if widget._mouseMoveSignal is not None :
+		if widget is not None and widget._mouseMoveSignal is not None :
 
 			event = GafferUI.ButtonEvent(
 				Widget._buttons( qEvent.button() ),

--- a/python/GafferUI/Window.py
+++ b/python/GafferUI/Window.py
@@ -359,20 +359,22 @@ class _WindowEventFilter( QtCore.QObject ) :
 
 		if type==QtCore.QEvent.Close :
 			widget = GafferUI.Widget._owner( qObject )
-			closed = widget.close()
-			if closed :
-				qEvent.accept()
-			else :
-				qEvent.ignore()
-			return True
+			if widget is not None :
+				closed = widget.close()
+				if closed :
+					qEvent.accept()
+				else :
+					qEvent.ignore()
+				return True
 		elif type==QtCore.QEvent.LayoutRequest :
 			widget = GafferUI.Widget._owner( qObject )
-			if widget.getSizeMode() == widget.SizeMode.Automatic :
+			if widget is not None and widget.getSizeMode() == widget.SizeMode.Automatic :
 				widget.resizeToFitChild()
 				return True
 		elif type==QtCore.QEvent.Resize :
 			widget = GafferUI.Widget._owner( qObject )
-			widget._Window__sizeValid = True
+			if widget is not None :
+				widget._Window__sizeValid = True
 
 		return False
 


### PR DESCRIPTION
We have been getting several errors when loading Gaffer inside Maya (2016.sp6, 2017.u5 and 2018.5). They're fairly innocuous but clutter Maya's ScriptEditor making it hard to debug more serious issues. The particular repro case was:

- Open Maya
- Launch Caribou (Gaffer in Maya)
- Open a Maya scene that also uses Caribou
- The scene open triggers a refresh of the panel, but these (presumably dying) widgets are still receiving events