### PR TITLE
TransformTool : Fix crash caused by selection deduplication

### DIFF
--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -544,7 +544,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		self.assertEqual( len( selection ), 1 )
 		self.assertEqual( selection[0].transformPlug, script["plane"]["transform"] )
 
-	def testHandesFollowLastSelected( self ) :
+	def testHandlesFollowLastSelected( self ) :
 
 		script = Gaffer.ScriptNode()
 
@@ -646,6 +646,40 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		Gaffer.PlugAlgo.promote( box["plane"]["out"] )
 		view["in"].setInput( box["out"] )
 		self.assertEqual( tool.selection()[0].scene, box["out"] )
+
+	def testLastSelectedObjectWithSharedTransformPlug( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["sphere"] = GafferScene.Sphere()
+		script["sphere"]["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
+
+		script["group"] = GafferScene.Group()
+		script["group"]["in"][0].setInput( script["sphere"]["out"] )
+		script["group"]["in"][1].setInput( script["sphere"]["out"] )
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["group"]["out"] )
+
+		tool = GafferSceneUI.TranslateTool( view )
+		tool["active"].setValue( True )
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/group/sphere" ] ) )
+		self.assertEqual( len( tool.selection() ), 1 )
+		self.assertEqual( tool.selection()[0].transformPlug, script["sphere"]["transform"] )
+		self.assertEqual( tool.selection()[0].path, "/group/sphere" )
+
+		GafferSceneUI.ContextAlgo.setLastSelectedPath( view.getContext(), "/group/sphere1" )
+		self.assertEqual( len( tool.selection() ), 1 )
+		self.assertEqual( tool.selection()[0].transformPlug, script["sphere"]["transform"] )
+		self.assertEqual( tool.selection()[0].path, "/group/sphere1" )
+
+		GafferSceneUI.ContextAlgo.setLastSelectedPath( view.getContext(), "/group/sphere" )
+		self.assertEqual( len( tool.selection() ), 1 )
+		self.assertEqual( tool.selection()[0].transformPlug, script["sphere"]["transform"] )
+		self.assertEqual( tool.selection()[0].path, "/group/sphere" )
+
+		self.assertEqual( tool.handlesTransform(), imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
When multiple paths are selected, it's possible that they are all affected by the same upstream transform plug, in which case we deduplicate the selection so that each transform plug is included only once. There was a bug in the way we were doing this though; the selection for `lastSelectedPath` could be skipped by the deduplication process, meaning `Selection lastSelection` was never initialised. This lead to us pushing an empty item on to the end of `m_selection`, which then caused null dereferences in `updateHandles()` :

```
Stack trace:
Gaffer::TransformPlug::pivotPlug()
GafferSceneUI::TransformTool::Selection::orientedTransform(GafferSceneUI::TransformTool::Orientation) const
GafferSceneUI::RotateTool::updateHandles(float)
GafferSceneUI::TransformTool::preRender()
```

We now deduplicate more carefully to avoid the problem.

> Note : The conditional/message for the case where we don't find `lastSelectedPath` is
> not a part of the fix. It just addresses a hypothetical situation that I originally thought
> may have been the cause, but was not.
