### PR TITLE
Basic support for nested dispatches

### DIFF
--- a/include/GafferDispatch/Dispatcher.h
+++ b/include/GafferDispatch/Dispatcher.h
@@ -278,7 +278,7 @@ class GAFFERDISPATCH_API Dispatcher : public Gaffer::Node
 
 	private :
 
-		std::string createJobDirectory( const Gaffer::Context *context ) const;
+		void createJobDirectory( const Gaffer::ScriptNode *script, Gaffer::Context *context ) const;
 		mutable std::string m_jobDirectory;
 
 		void executeAndPruneImmediateBatches( TaskBatch *batch, bool immediate = false ) const;

--- a/python/GafferDispatch/LocalDispatcher.py
+++ b/python/GafferDispatch/LocalDispatcher.py
@@ -64,7 +64,7 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 
 		Status = IECore.Enum.create( "Waiting", "Running", "Complete", "Failed", "Killed" )
 
-		def __init__( self, batch, dispatcher, name, jobId, directory ) :
+		def __init__( self, batch, dispatcher ) :
 
 			assert( isinstance( batch, GafferDispatch.Dispatcher._TaskBatch ) )
 			assert( isinstance( dispatcher, GafferDispatch.Dispatcher ) )
@@ -81,9 +81,9 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 			script = batch.preTasks()[0].plug().ancestor( Gaffer.ScriptNode )
 			self.__context = Gaffer.Context( script.context() )
 
-			self.__name = name
-			self.__id = jobId
-			self.__directory = directory
+			self.__name = Gaffer.Context.current().substitute( dispatcher["jobName"].getValue() )
+			self.__directory = Gaffer.Context.current()["dispatcher:jobDirectory"]
+			self.__id = os.path.basename( self.__directory )
 			self.__stats = {}
 			self.__ignoreScriptLoadErrors = dispatcher["ignoreScriptLoadErrors"].getValue()
 			## \todo Make `Dispatcher::dispatch()` use a Process, so we don't need to
@@ -442,9 +442,6 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 		job = LocalDispatcher.Job(
 			batch = batch,
 			dispatcher = self,
-			name = Gaffer.Context.current().substitute( self["jobName"].getValue() ),
-			jobId = os.path.basename( self.jobDirectory() ),
-			directory = self.jobDirectory(),
 		)
 
 		self.__jobPool._append( job )

--- a/python/GafferDispatch/LocalDispatcher.py
+++ b/python/GafferDispatch/LocalDispatcher.py
@@ -83,6 +83,7 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 
 			self.__name = Gaffer.Context.current().substitute( dispatcher["jobName"].getValue() )
 			self.__directory = Gaffer.Context.current()["dispatcher:jobDirectory"]
+			self.__scriptFile = Gaffer.Context.current()["dispatcher:scriptFileName"]
 			self.__id = os.path.basename( self.__directory )
 			self.__stats = {}
 			self.__ignoreScriptLoadErrors = dispatcher["ignoreScriptLoadErrors"].getValue()
@@ -94,10 +95,6 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 
 			self.__messageHandler = IECore.CapturingMessageHandler()
 			self.__messageTitle = "%s : Job %s %s" % ( self.__dispatcher.getName(), self.__name, self.__id )
-
-			scriptFileName = script["fileName"].getValue()
-			self.__scriptFile = os.path.join( self.__directory, os.path.basename( scriptFileName ) if scriptFileName else "untitled.gfr" )
-			script.serialiseToFile( self.__scriptFile )
 
 			self.__initBatchWalk( batch )
 

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -1228,6 +1228,7 @@ class DispatcherTest( GafferTest.TestCase ) :
 		s["nonImmediate2"]["preTasks"][0].setInput( s["immediate"]["task"] )
 
 		dispatcher = self.NullDispatcher()
+		dispatcher["jobsDirectory"].setValue( self.temporaryDirectory() )
 		dispatcher.dispatch( [ s["nonImmediate2"] ] )
 
 		self.assertEqual( [ l.node for l in log ], [ s["nonImmediate1"], s["immediate" ] ] )
@@ -1256,6 +1257,7 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 		# NullDispatcher dispatch should only execute the immediate nodes.
 		dispatcher = self.NullDispatcher()
+		dispatcher["jobsDirectory"].setValue( self.temporaryDirectory() )
 		dispatcher.dispatch( [ s["n2"] ] )
 		self.assertEqual( [ l.node for l in log ], [ s["n1"], s["i1" ], s["i2"] ] )
 
@@ -1288,6 +1290,7 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 		# NullDispatcher dispatch should only execute the immediate nodes.
 		dispatcher = self.NullDispatcher()
+		dispatcher["jobsDirectory"].setValue( self.temporaryDirectory() )
 		dispatcher.dispatch( [ s["n3"] ] )
 		self.assertEqual( [ l.node for l in log ], [ s["n1"], s["i1" ] ] )
 
@@ -1438,7 +1441,7 @@ class DispatcherTest( GafferTest.TestCase ) :
 			lastTask = perSequence
 
 		d = self.TestDispatcher()
-
+		d["jobsDirectory"].setValue( self.temporaryDirectory() )
 		d["framesMode"].setValue( d.FramesMode.CustomRange )
 		d["frameRange"].setValue( "1-1000" )
 
@@ -1596,6 +1599,7 @@ class DispatcherTest( GafferTest.TestCase ) :
 		s["n"]["command"].setValue( "echo #" )
 
 		dispatcher = self.NullDispatcher()
+		dispatcher["jobsDirectory"].setValue( self.temporaryDirectory() )
 		dispatcher["framesMode"].setValue( dispatcher.FramesMode.CustomRange )
 		dispatcher["frameRange"].setValue( "1-10" )
 		dispatcher.dispatch( [ s["n"] ] )

--- a/python/GafferDispatchTest/TaskNodeTest.py
+++ b/python/GafferDispatchTest/TaskNodeTest.py
@@ -576,6 +576,7 @@ class TaskNodeTest( GafferTest.TestCase ) :
 		self.assertEqual( postTasks[0].node(), s["n2"] )
 
 		dispatcher = GafferDispatchTest.DispatcherTest.TestDispatcher()
+		dispatcher["jobsDirectory"].setValue( self.temporaryDirectory() )
 		dispatcher.dispatch( [ s["n3"] ] )
 
 		self.assertEqual( len( log ), 3 )

--- a/python/GafferTractor/TractorDispatcher.py
+++ b/python/GafferTractor/TractorDispatcher.py
@@ -75,10 +75,8 @@ class TractorDispatcher( GafferDispatch.Dispatcher ) :
 		# might just be member data for a subclass of one of those.
 		dispatchData = {}
 		dispatchData["scriptNode"] = rootBatch.preTasks()[0].node().scriptNode()
-		dispatchData["scriptFile"] = os.path.join( self.jobDirectory(), os.path.basename( dispatchData["scriptNode"]["fileName"].getValue() ) or "untitled.gfr" )
+		dispatchData["scriptFile"] = Gaffer.Context.current()["dispatcher:scriptFileName"]
 		dispatchData["batchesToTasks"] = {}
-
-		dispatchData["scriptNode"].serialiseToFile( dispatchData["scriptFile"] )
 
 		# Create a Tractor job and set its basic properties.
 


### PR DESCRIPTION
Our dispatchers have always supported the batching of multiple tasks from the same node, executing several tasks in the same process. This amortises process startup times and allows the tasks to share the same computation cache. But we now have several use cases where we want to batch together tasks from _different_ nodes. We're thinking the way to model this is as a nested local dispatch inside a wider farm dispatch, and one day expect to allow users to place dispatcher nodes directly into their task graphs to achieve this. We think this will have other uses too, for instance using a Wedge node to dispatch multiple farm jobs in one go.

This PR represents modest progress in this direction by allowing an inner dispatch to "borrow" the job directory for the outer dispatch, reusing the same saved script and scratch space. This allows the creation of nested dispatches manually by using a LocalDispatcher within a PythonCommand. Once we have some experience with this, we'll hopefully move forward with something a bit more user friendly.

@ivanimanishi, I've added you as a reviewer since you're regularly writing dispatch code, and @danieldresser-ie I've added you so you can test this with your ArnoldTextureBake setup.

I've also done a mild spring clean on some of the code I touched as I went - this is all done in separate commits...

Cheers...
John