### PR TITLE
ViewportGadget : Fix project

### DIFF
--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -350,12 +350,12 @@ class ViewportGadget::CameraController : public boost::noncopyable
 				);
 				if( m_sourceCamera->getProjection() == "perspective" )
 				{
-					cameraPosition = cameraPosition / cameraPosition.z;
+					cameraPosition = cameraPosition / -cameraPosition.z;
 				}
 
 				V2f ndcPosition(
-					lerpfactor( cameraPosition.x, normalizedScreenWindow.max.x, normalizedScreenWindow.min.x ),
-					lerpfactor( cameraPosition.y, normalizedScreenWindow.min.y, normalizedScreenWindow.max.y )
+					lerpfactor( cameraPosition.x, normalizedScreenWindow.min.x, normalizedScreenWindow.max.x ),
+					lerpfactor( cameraPosition.y, normalizedScreenWindow.max.y, normalizedScreenWindow.min.y )
 				);
 				return V2f(
 					ndcPosition.x * resolution.x,


### PR DESCRIPTION
This is a pretty embarrassing one - two simple math errors which happened to cancel out in the common case of a symmetric perspective projection, combined with a missing setting in the tests which meant that the tests weren't actually testing most cases.

The user facing consequence of this issue was the CropWindowTool failing on orthographic cameras, or perspective cameras with an aperture offset.