### PR TITLE
Light linking on lights

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -982,7 +982,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 		// geometry attributes are compatible with those which were applied previously
 		// (and which cannot be changed now). Returns true if all is well and false
 		// if there is a clash (and the edit has therefore failed).
-		bool apply( AtNode *node, const ArnoldAttributes *previousAttributes ) const
+		bool apply( AtNode *node, const ArnoldAttributes *previousAttributes, bool applyLinkedLights ) const
 		{
 
 			// Check that we're not looking at an impossible request
@@ -1117,7 +1117,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 					AiNodeResetParameter( node, g_sssSetNameArnoldString );
 				}
 
-				if( m_linkedLights )
+				if( m_linkedLights && applyLinkedLights )
 				{
 					const std::vector<AtNode *> &linkedLightNodes = m_lightListCache->get( m_linkedLights.get() );
 
@@ -1130,7 +1130,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 					AiNodeResetParameter( node, g_useLightGroupArnoldString );
 				}
 
-				if( m_shadowGroup )
+				if( m_shadowGroup && applyLinkedLights )
 				{
 					const std::vector<AtNode *> &linkedLightNodes = m_lightListCache->get( m_linkedLights.get() );
 
@@ -1817,7 +1817,7 @@ class ArnoldObject : public IECoreScenePreview::Renderer::ObjectInterface
 	public :
 
 		ArnoldObject( const Instance &instance )
-			:	m_instance( instance ), m_attributes( nullptr )
+			:	m_instance( instance ), m_attributes( nullptr ), m_supportsLinkedLights( true )
 		{
 		}
 
@@ -1850,7 +1850,7 @@ class ArnoldObject : public IECoreScenePreview::Renderer::ObjectInterface
 			}
 
 			const ArnoldAttributes *arnoldAttributes = static_cast<const ArnoldAttributes *>( attributes );
-			if( arnoldAttributes->apply( node, m_attributes.get() ) )
+			if( arnoldAttributes->apply( node, m_attributes.get(), m_supportsLinkedLights ) )
 			{
 				m_attributes = arnoldAttributes;
 				return true;
@@ -1898,6 +1898,9 @@ class ArnoldObject : public IECoreScenePreview::Renderer::ObjectInterface
 		//    `attributes()`.
 		ConstArnoldAttributesPtr m_attributes;
 
+		// Derived classes are allowed to reject having lights linked to them
+		bool m_supportsLinkedLights;
+
 };
 
 IE_CORE_FORWARDDECLARE( ArnoldObject )
@@ -1919,6 +1922,9 @@ class ArnoldLight : public ArnoldObject
 		ArnoldLight( const std::string &name, const Instance &instance, NodeDeleter nodeDeleter, const AtNode *parentNode )
 			:	ArnoldObject( instance ), m_name( name ), m_nodeDeleter( nodeDeleter ), m_parentNode( parentNode )
 		{
+			// Explicitly opt out of being linked to lights. That feature only makes
+			// sense for shapes that aren't lights.
+			m_supportsLinkedLights = false;
 		}
 
 		void transform( const Imath::M44f &transform ) override


### PR DESCRIPTION
Hey John,

here's the fix for the bug Daniel and me described via email. I'll leave this PR in Daniel's capable hands now and hope we won't need too many changes to what I got here.

It all feels a bit bolted on, but maybe that's ok because it's a pretty specific thing and it should stand out a little.
I was wondering, as an alternative, about extending `apply()` by adding a list of attributes to skip to the function args which seems a tad more general. Similarly, in ArnoldObject::attributes, we could copy the attributes for lights and remove the ones we want to skip so that we don't have to change any function calls. None of these alternatives seem significantly better, though...

Thanks :)

Matti.