### PR TITLE
Metadata improvements

### DIFF
--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -295,7 +295,7 @@ class stats( Gaffer.Application ) :
 
 	def __writeVersion( self, script ) :
 
-		numbers = [ Gaffer.Metadata.nodeValue( script, "serialiser:" + x + "Version" ) for x in ( "milestone", "major", "minor", "patch" ) ]
+		numbers = [ Gaffer.Metadata.value( script, "serialiser:" + x + "Version" ) for x in ( "milestone", "major", "minor", "patch" ) ]
 		if None not in numbers :
 			version = ".".join( str( x ) for x in numbers )
 		else :

--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -73,10 +73,10 @@ class GAFFER_API Metadata
 		/// Type for a signal emitted when new plug metadata is registered. The
 		/// plug argument will be null when generic (rather than per-instance)
 		/// metadata is registered.
-		typedef boost::signal<void ( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, Gaffer::Plug *plug ), CatchingSignalCombiner<void> > PlugValueChangedSignal;
+		typedef boost::signal<void ( IECore::TypeId typeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, Gaffer::Plug *plug ), CatchingSignalCombiner<void> > PlugValueChangedSignal;
 
 		typedef std::function<IECore::ConstDataPtr ()> ValueFunction;
-		typedef std::function<IECore::ConstDataPtr ( const Node *node )> NodeValueFunction;
+		typedef std::function<IECore::ConstDataPtr ( const GraphComponent *graphComponent )> GraphComponentValueFunction;
 		typedef std::function<IECore::ConstDataPtr ( const Plug *plug )> PlugValueFunction;
 
 		/// Value registration
@@ -88,11 +88,11 @@ class GAFFER_API Metadata
 		/// be called to compute it.
 		static void registerValue( IECore::InternedString target, IECore::InternedString key, ValueFunction value );
 
-		/// Registers a static metadata value for the specified node type.
-		static void registerValue( IECore::TypeId nodeTypeId, IECore::InternedString key, IECore::ConstDataPtr value );
-		/// Registers a dynamic metadata value for the specified node type. Each time the data is retrieved, the
-		/// NodeValueFunction will be called to compute it.
-		static void registerValue( IECore::TypeId nodeTypeId, IECore::InternedString key, NodeValueFunction value );
+		/// Registers a static metadata value for the specified GraphComponent type.
+		static void registerValue( IECore::TypeId typeId, IECore::InternedString key, IECore::ConstDataPtr value );
+		/// Registers a dynamic metadata value for the specified GraphComponent type. Each time the data is retrieved, the
+		/// GraphComponentValueFunction will be called to compute it.
+		static void registerValue( IECore::TypeId typeId, IECore::InternedString key, GraphComponentValueFunction value );
 
 		/// Registers a static metadata value for plugs with the specified path on the specified node type.
 		static void registerValue( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value );
@@ -128,7 +128,7 @@ class GAFFER_API Metadata
 		/// ====================
 
 		static void deregisterValue( IECore::InternedString target, IECore::InternedString key );
-		static void deregisterValue( IECore::TypeId nodeTypeId, IECore::InternedString key );
+		static void deregisterValue( IECore::TypeId typeId, IECore::InternedString key );
 		static void deregisterValue( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key );
 
 		/// \undoable
@@ -150,7 +150,7 @@ class GAFFER_API Metadata
 		///
 		/// These are emitted when the Metadata has been changed with one
 		/// of the register*() methods. If dynamic metadata is registered
-		/// with a NodeValueFunction or PlugValueFunction then it is the
+		/// with a GraphComponentValueFunction or PlugValueFunction then it is the
 		/// responsibility of the registrant to manually emit the signals
 		/// when necessary.
 		static ValueChangedSignal &valueChangedSignal();
@@ -172,8 +172,6 @@ class GAFFER_API Metadata
 
 		static IECore::ConstDataPtr valueInternal( IECore::InternedString target, IECore::InternedString key );
 		static IECore::ConstDataPtr valueInternal( const GraphComponent *target, IECore::InternedString key, bool instanceOnly );
-		static IECore::ConstDataPtr nodeValueInternal( const Node *node, IECore::InternedString key, bool instanceOnly );
-		static IECore::ConstDataPtr plugValueInternal( const Plug *plug, IECore::InternedString key, bool instanceOnly );
 
 };
 

--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -157,55 +157,6 @@ class GAFFER_API Metadata
 		static NodeValueChangedSignal &nodeValueChangedSignal();
 		static PlugValueChangedSignal &plugValueChangedSignal();
 
-		/// Deprecated
-		/// ==============
-
-		/// \deprecated
-		static void registerNodeValue( IECore::TypeId nodeTypeId, IECore::InternedString key, IECore::ConstDataPtr value );
-		/// \deprecated
-		static void registerNodeValue( IECore::TypeId nodeTypeId, IECore::InternedString key, NodeValueFunction value );
-		/// \deprecated
-		static void registerNodeValue( Node *node, IECore::InternedString key, IECore::ConstDataPtr value, bool persistent = true );
-		/// \deprecated
-		static void registeredNodeValues( const Node *node, std::vector<IECore::InternedString> &keys, bool inherit = true, bool instanceOnly = false, bool persistentOnly = false );
-		/// \deprecated
-		template<typename T>
-		static typename T::ConstPtr nodeValue( const Node *node, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
-		/// \deprecated
-		static void deregisterNodeValue( IECore::TypeId nodeTypeId, IECore::InternedString key );
-		/// \deprecated
-		static void deregisterNodeValue( Node *node, IECore::InternedString key );
-
-		/// \deprecated
-		static void registerPlugValue( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value );
-		/// \deprecated
-		static void registerPlugValue( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, PlugValueFunction value );
-		/// \deprecated
-		static void registerPlugValue( Plug *plug, IECore::InternedString key, IECore::ConstDataPtr value, bool persistent = true );
-		/// \deprecated
-		static void registeredPlugValues( const Plug *plug, std::vector<IECore::InternedString> &keys, bool inherit = true, bool instanceOnly = false, bool persistentOnly = false );
-		/// \deprecated
-		template<typename T>
-		static typename T::ConstPtr plugValue( const Plug *plug, IECore::InternedString key, bool inherit = true, bool instanceOnly = false );
-		/// \deprecated
-		static void deregisterPlugValue( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key );
-		/// \deprecated
-		static void deregisterPlugValue( Plug *plug, IECore::InternedString key );
-
-		/// \deprecated
-		static void registerNodeDescription( IECore::TypeId nodeTypeId, const std::string &description );
-		/// \deprecated
-		static void registerNodeDescription( IECore::TypeId nodeTypeId, NodeValueFunction description );
-		/// \deprecated
-		static std::string nodeDescription( const Node *node, bool inherit = true );
-
-		/// \deprecated
-		static void registerPlugDescription( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, const std::string &description );
-		/// \deprecated
-		static void registerPlugDescription( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, PlugValueFunction description );
-		/// \deprecated
-		static std::string plugDescription( const Plug *plug, bool inherit = true );
-
 	private :
 
 		/// Per-instance Metadata is stored as a mapping from GraphComponent * to the
@@ -221,8 +172,8 @@ class GAFFER_API Metadata
 
 		static IECore::ConstDataPtr valueInternal( IECore::InternedString target, IECore::InternedString key );
 		static IECore::ConstDataPtr valueInternal( const GraphComponent *target, IECore::InternedString key, bool instanceOnly );
-		static IECore::ConstDataPtr nodeValueInternal( const Node *node, IECore::InternedString key, bool inherit, bool instanceOnly );
-		static IECore::ConstDataPtr plugValueInternal( const Plug *plug, IECore::InternedString key, bool inherit, bool instanceOnly );
+		static IECore::ConstDataPtr nodeValueInternal( const Node *node, IECore::InternedString key, bool instanceOnly );
+		static IECore::ConstDataPtr plugValueInternal( const Plug *plug, IECore::InternedString key, bool instanceOnly );
 
 };
 

--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -94,11 +94,11 @@ class GAFFER_API Metadata
 		/// GraphComponentValueFunction will be called to compute it.
 		static void registerValue( IECore::TypeId typeId, IECore::InternedString key, GraphComponentValueFunction value );
 
-		/// Registers a static metadata value for plugs with the specified path on the specified node type.
-		static void registerValue( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value );
+		/// Registers a static metadata value for plugs with the specified path relative to the ancestor type.
+		static void registerValue( IECore::TypeId ancestorTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, IECore::ConstDataPtr value );
 		/// Registers a dynamic metadata value for the specified plug. Each time the data is retrieved, the
 		/// PlugValueFunction will be called to compute it.
-		static void registerValue( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, PlugValueFunction value );
+		static void registerValue( IECore::TypeId ancestorTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, PlugValueFunction value );
 
 		/// Registers a metadata value specific to a single instance - this will take precedence over any
 		/// values registered above. If persistent is true, the value will be preserved across script save/load and cut/paste.
@@ -129,7 +129,7 @@ class GAFFER_API Metadata
 
 		static void deregisterValue( IECore::InternedString target, IECore::InternedString key );
 		static void deregisterValue( IECore::TypeId typeId, IECore::InternedString key );
-		static void deregisterValue( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key );
+		static void deregisterValue( IECore::TypeId ancestorTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key );
 
 		/// \undoable
 		static void deregisterValue( GraphComponent *target, IECore::InternedString key );

--- a/include/Gaffer/Metadata.inl
+++ b/include/Gaffer/Metadata.inl
@@ -52,18 +52,6 @@ typename T::ConstPtr Metadata::value( const GraphComponent *target, IECore::Inte
 	return IECore::runTimeCast<const T>( valueInternal( target, key, instanceOnly ) );
 }
 
-template<typename T>
-typename T::ConstPtr Metadata::nodeValue( const Node *node, IECore::InternedString key, bool inherit, bool instanceOnly )
-{
-	return IECore::runTimeCast<const T>( nodeValueInternal( node, key, inherit, instanceOnly ) );
-}
-
-template<typename T>
-typename T::ConstPtr Metadata::plugValue( const Plug *plug, IECore::InternedString key, bool inherit, bool instanceOnly )
-{
-	return IECore::runTimeCast<const T>( plugValueInternal( plug, key, inherit, instanceOnly ) );
-}
-
 } // namespace Gaffer
 
 #endif // GAFFER_METADATA_INL

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -136,13 +136,13 @@ GAFFER_API bool numericBookmarkAffectedByChange( const IECore::InternedString &c
 
 /// Determines if a metadata value change (as signalled by `Metadata::plugValueChangedSignal()`
 /// or `Metadata:nodeValueChangedSignal()`) affects a given plug or node.
-GAFFER_API bool affectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const IECore::StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
+GAFFER_API bool affectedByChange( const Plug *plug, IECore::TypeId changedTypeId, const IECore::StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
 GAFFER_API bool affectedByChange( const Node *node, IECore::TypeId changedNodeTypeId, const Gaffer::Node *changedNode );
 /// As above, but determines if any child will be affected.
-GAFFER_API bool childAffectedByChange( const GraphComponent *parent, IECore::TypeId changedNodeTypeId, const IECore::StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
+GAFFER_API bool childAffectedByChange( const GraphComponent *parent, IECore::TypeId changedTypeId, const IECore::StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
 GAFFER_API bool childAffectedByChange( const GraphComponent *parent, IECore::TypeId changedNodeTypeId, const Gaffer::Node *changedNode );
 /// As above, but determines if any ancestor will be affected.
-GAFFER_API bool ancestorAffectedByChange( const Plug *plug, IECore::TypeId changedNodeTypeId, const IECore::StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
+GAFFER_API bool ancestorAffectedByChange( const Plug *plug, IECore::TypeId changedTypeId, const IECore::StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
 GAFFER_API bool ancestorAffectedByChange( const GraphComponent *graphComponent, IECore::TypeId changedNodeTypeId, const Gaffer::Node *changedNode );
 
 /// Copies metadata from one target to another. The exclude pattern is used with StringAlgo::matchMultiple().

--- a/python/GafferCortexUI/ParameterisedHolderUI.py
+++ b/python/GafferCortexUI/ParameterisedHolderUI.py
@@ -132,7 +132,7 @@ class _InfoButton( GafferUI.Button ) :
 		## and we should use those to get the proper context here.
 		context = self.__node.scriptNode().context() if self.__node.scriptNode() else Gaffer.Context.current()
 		with context :
-			result = Gaffer.Metadata.nodeDescription( self.__node )
+			result = Gaffer.Metadata.value( self.__node, "description" ) or ""
 			summary = Gaffer.Metadata.value( self.__node, "summary" )
 
 		if summary :

--- a/python/GafferSceneUI/TweakPlugValueWidget.py
+++ b/python/GafferSceneUI/TweakPlugValueWidget.py
@@ -36,6 +36,8 @@
 
 import functools
 
+import IECore
+
 import Gaffer
 import GafferUI
 import GafferScene
@@ -49,35 +51,9 @@ class TweakPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug ) :
 
-		# TODO - would be nice if this stuff didn't need to be added to the instance as metadata
-		# John has said that in the future we may be able to use match patterns to register metadata
-		# to children of a plug type, like we can do with nodes.
-		# This would allow us to use dynamic metadata to hide the value plug when in "Remove" mode
-
-		Gaffer.Metadata.registerValue( plug['name'], "description",
-			"The name of the parameter to apply the tweak to.", persistent=False
-		)
-		Gaffer.Metadata.registerValue( plug['mode'], "plugValueWidget:type",
-			"GafferUI.PresetsPlugValueWidget", persistent=False
-		)
-
-		presetNames = [ "Replace" ]
-
-		# Identify plugs which are derived from NumericPlug or CompoundNumericPlug
-		plugIsNumeric = hasattr( plug["value"], "hasMinValue" )
-		if plugIsNumeric:
-			presetNames += [ "Add", "Subtract", "Multiply" ]
-
-		if Gaffer.Metadata.value( plug, "tweakPlugValueWidget:allowRemove" ):
-			presetNames += [ "Remove" ]
-
-		for name in presetNames:
-			Gaffer.Metadata.registerValue( plug['mode'], "preset:" + name, GafferScene.TweakPlug.Mode.names[ name ], persistent = False )
-
 		self.__row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
 
 		GafferUI.PlugValueWidget.__init__( self, self.__row, plug )
-
 
 		nameWidget = GafferUI.StringPlugValueWidget( plug["name"] )
 		nameWidget.textWidget()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
@@ -164,3 +140,40 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ):
 __plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )
 
 GafferUI.PlugValueWidget.registerType( GafferScene.TweakPlug, TweakPlugValueWidget )
+
+# Metadata for child plugs
+
+Gaffer.Metadata.registerValue(
+	GafferScene.TweakPlug, "name",
+	"description", "The name of the parameter to apply the tweak to."
+)
+
+Gaffer.Metadata.registerValue(
+	GafferScene.TweakPlug, "mode",
+	"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget"
+)
+
+def __validModes( plug ) :
+
+	result = [ GafferScene.TweakPlug.Mode.Replace ]
+	if hasattr( plug.parent()["value"], "hasMinValue" ) :
+		result += [
+			GafferScene.TweakPlug.Mode.Add,
+			GafferScene.TweakPlug.Mode.Subtract,
+			GafferScene.TweakPlug.Mode.Multiply
+		]
+
+	if Gaffer.Metadata.value( plug.parent(), "tweakPlugValueWidget:allowRemove" ) :
+		result += [ GafferScene.TweakPlug.Mode.Remove ]
+
+	return result
+
+Gaffer.Metadata.registerValue(
+	GafferScene.TweakPlug, "mode",
+	"presetNames", lambda plug : IECore.StringVectorData( [ str( x ) for x in __validModes( plug ) ] )
+)
+
+Gaffer.Metadata.registerValue(
+	GafferScene.TweakPlug, "mode",
+	"presetValues", lambda plug : IECore.IntVectorData( [ int( x ) for x in __validModes( plug ) ] )
+)

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -486,6 +486,19 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 		self.assertTrue( Gaffer.MetadataAlgo.ancestorAffectedByChange( n["p"]["s"], Gaffer.Plug, changedPlugPath = "", changedPlug = None ) )
 		self.assertFalse( Gaffer.MetadataAlgo.ancestorAffectedByChange( n["p"]["s"], Gaffer.StringPlug, changedPlugPath = "", changedPlug = None ) )
 
+	def testAffectedByPlugRelativeMetadata( self ) :
+
+		n = GafferTest.CompoundNumericNode()
+
+		self.assertTrue( Gaffer.MetadataAlgo.affectedByChange( n["p"]["x"], Gaffer.V3fPlug, changedPlugPath = "*", changedPlug = None ) )
+		self.assertTrue( Gaffer.MetadataAlgo.affectedByChange( n["p"]["x"], Gaffer.V3fPlug, changedPlugPath = "[xyz]", changedPlug = None ) )
+		self.assertTrue( Gaffer.MetadataAlgo.affectedByChange( n["p"]["x"], Gaffer.V3fPlug, changedPlugPath = "...", changedPlug = None ) )
+		self.assertFalse( Gaffer.MetadataAlgo.affectedByChange( n["p"]["x"], Gaffer.V3fPlug, changedPlugPath = "x.c", changedPlug = None ) )
+		self.assertFalse( Gaffer.MetadataAlgo.affectedByChange( n["p"]["x"], Gaffer.V3fPlug, changedPlugPath = "c", changedPlug = None ) )
+
+		self.assertTrue( Gaffer.MetadataAlgo.childAffectedByChange( n["p"], Gaffer.V3fPlug, changedPlugPath = "[xyz]", changedPlug = None ) )
+		self.assertFalse( Gaffer.MetadataAlgo.childAffectedByChange( n["p"], Gaffer.V3fPlug, changedPlugPath = "x.c", changedPlug = None ) )
+
 	def tearDown( self ) :
 
 		for n in ( Gaffer.Node, Gaffer.Box, GafferTest.AddNode ) :

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -468,6 +468,24 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 		self.assertFalse( Gaffer.MetadataAlgo.numericBookmarkAffectedByChange( "numericBookmark10" ) )
 		self.assertFalse( Gaffer.MetadataAlgo.numericBookmarkAffectedByChange( "foo" ) )
 
+	def testAffectedByPlugTypeRegistration( self ) :
+
+		n = GafferTest.CompoundPlugNode()
+
+		self.assertTrue( Gaffer.MetadataAlgo.affectedByChange( n["p"]["s"], Gaffer.StringPlug, changedPlugPath = "", changedPlug = None ) )
+		self.assertFalse( Gaffer.MetadataAlgo.affectedByChange( n["p"]["s"], Gaffer.IntPlug, changedPlugPath = "", changedPlug = None ) )
+		self.assertTrue( Gaffer.MetadataAlgo.affectedByChange( n["p"], Gaffer.Plug, changedPlugPath = "", changedPlug = None ) )
+
+		self.assertTrue( Gaffer.MetadataAlgo.childAffectedByChange( n["p"], Gaffer.StringPlug, changedPlugPath = "", changedPlug = None ) )
+		self.assertTrue( Gaffer.MetadataAlgo.childAffectedByChange( n["p"], Gaffer.FloatPlug, changedPlugPath = "", changedPlug = None ) )
+		self.assertFalse( Gaffer.MetadataAlgo.childAffectedByChange( n["p"], Gaffer.IntPlug, changedPlugPath = "", changedPlug = None ) )
+		self.assertFalse( Gaffer.MetadataAlgo.childAffectedByChange( n["p"]["s"], Gaffer.StringPlug, changedPlugPath = "", changedPlug = None ) )
+
+		self.assertFalse( Gaffer.MetadataAlgo.ancestorAffectedByChange( n["p"], Gaffer.CompoundPlug, changedPlugPath = "", changedPlug = None ) )
+		self.assertTrue( Gaffer.MetadataAlgo.ancestorAffectedByChange( n["p"]["s"], Gaffer.CompoundPlug, changedPlugPath = "", changedPlug = None ) )
+		self.assertTrue( Gaffer.MetadataAlgo.ancestorAffectedByChange( n["p"]["s"], Gaffer.Plug, changedPlugPath = "", changedPlug = None ) )
+		self.assertFalse( Gaffer.MetadataAlgo.ancestorAffectedByChange( n["p"]["s"], Gaffer.StringPlug, changedPlugPath = "", changedPlug = None ) )
+
 	def tearDown( self ) :
 
 		for n in ( Gaffer.Node, Gaffer.Box, GafferTest.AddNode ) :

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -1139,5 +1139,16 @@ class MetadataTest( GafferTest.TestCase ) :
 		Gaffer.Metadata.deregisterValue( Gaffer.IntPlug, "typeRegistration" )
 		self.assertNotIn( "typeRegistration", Gaffer.Metadata.registeredValues( n["op1"] ) )
 
+	def testMetadataRelativeToAncestorPlug( self ) :
+
+		n = Gaffer.Node()
+		n["user"]["p"] = Gaffer.Color3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		self.assertEqual( Gaffer.Metadata.value( n["user"]["p"]["r"], "testPlugAncestor" ), None )
+		self.assertNotIn( "testPlugAncestor", Gaffer.Metadata.registeredValues( n["user"]["p"]["r"] ) )
+
+		Gaffer.Metadata.registerValue( Gaffer.Color3fPlug, "r", "testPlugAncestor", 10 )
+		self.assertEqual( Gaffer.Metadata.value( n["user"]["p"]["r"], "testPlugAncestor" ), 10 )
+		self.assertIn( "testPlugAncestor", Gaffer.Metadata.registeredValues( n["user"]["p"]["r"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -54,75 +54,27 @@ class MetadataTest( GafferTest.TestCase ) :
 
 	IECore.registerRunTimeTyped( DerivedAddNode )
 
-	def testNodeDescription( self ) :
-
-		add = GafferTest.AddNode()
-
-		self.assertEqual( Gaffer.Metadata.nodeDescription( add ), "" )
-
-		Gaffer.Metadata.registerNodeDescription( GafferTest.AddNode, "description" )
-		self.assertEqual( Gaffer.Metadata.nodeDescription( add ), "description" )
-
-		Gaffer.Metadata.registerNodeDescription( GafferTest.AddNode, lambda node : node.getName() )
-		self.assertEqual( Gaffer.Metadata.nodeDescription( add ), "AddNode" )
-
-		derivedAdd = self.DerivedAddNode()
-		self.assertEqual( Gaffer.Metadata.nodeDescription( derivedAdd ), "DerivedAddNode" )
-		self.assertEqual( Gaffer.Metadata.nodeDescription( derivedAdd, inherit=False ), "" )
-
-		Gaffer.Metadata.registerNodeDescription( self.DerivedAddNode.staticTypeId(), "a not very helpful description" )
-		self.assertEqual( Gaffer.Metadata.nodeDescription( derivedAdd ), "a not very helpful description" )
-		self.assertEqual( Gaffer.Metadata.nodeDescription( add ), "AddNode" )
-
-	def testExtendedNodeDescription( self ) :
-
-		multiply = GafferTest.MultiplyNode()
-
-		self.assertEqual( Gaffer.Metadata.nodeDescription( multiply ), "" )
-
-		Gaffer.Metadata.registerNodeDescription(
-
-			GafferTest.MultiplyNode,
-			"description",
-
-			"op1",
-			"op1 description",
-
-			"op2",
-			{
-				"description" : "op2 description",
-				"otherValue" : 100,
-			}
-
-		)
-
-		self.assertEqual( Gaffer.Metadata.nodeDescription( multiply ), "description" )
-		self.assertEqual( Gaffer.Metadata.plugDescription( multiply["op1"] ), "op1 description" )
-		self.assertEqual( Gaffer.Metadata.plugDescription( multiply["op2"] ), "op2 description" )
-		self.assertEqual( Gaffer.Metadata.value( multiply["op2"], "otherValue" ), 100 )
-
 	def testPlugDescription( self ) :
 
 		add = GafferTest.AddNode()
 
-		self.assertEqual( Gaffer.Metadata.plugDescription( add["op1"] ), "" )
+		self.assertEqual( Gaffer.Metadata.value( add["op1"], "description" ), None )
 
-		Gaffer.Metadata.registerPlugDescription( GafferTest.AddNode.staticTypeId(), "op1", "The first operand" )
-		self.assertEqual( Gaffer.Metadata.plugDescription( add["op1"] ), "The first operand" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "description", "The first operand" )
+		self.assertEqual( Gaffer.Metadata.value( add["op1"], "description" ), "The first operand" )
 
-		Gaffer.Metadata.registerPlugDescription( GafferTest.AddNode.staticTypeId(), "op1", lambda plug : plug.getName() + " description" )
-		self.assertEqual( Gaffer.Metadata.plugDescription( add["op1"] ), "op1 description" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "description", lambda plug : plug.getName() + " description" )
+		self.assertEqual( Gaffer.Metadata.value( add["op1"], "description" ), "op1 description" )
 
 		derivedAdd = self.DerivedAddNode()
-		self.assertEqual( Gaffer.Metadata.plugDescription( derivedAdd["op1"] ), "op1 description" )
-		self.assertEqual( Gaffer.Metadata.plugDescription( derivedAdd["op1"], inherit=False ), "" )
+		self.assertEqual( Gaffer.Metadata.value( derivedAdd["op1"], "description" ), "op1 description" )
 
-		Gaffer.Metadata.registerPlugDescription( self.DerivedAddNode, "op*", "derived class description" )
-		self.assertEqual( Gaffer.Metadata.plugDescription( derivedAdd["op1"] ), "derived class description" )
-		self.assertEqual( Gaffer.Metadata.plugDescription( derivedAdd["op2"] ), "derived class description" )
+		Gaffer.Metadata.registerValue( self.DerivedAddNode, "op*", "description", "derived class description" )
+		self.assertEqual( Gaffer.Metadata.value( derivedAdd["op1"], "description" ), "derived class description" )
+		self.assertEqual( Gaffer.Metadata.value( derivedAdd["op2"], "description" ), "derived class description" )
 
-		self.assertEqual( Gaffer.Metadata.plugDescription( add["op1"] ), "op1 description" )
-		self.assertEqual( Gaffer.Metadata.plugDescription( add["op2"] ), "" )
+		self.assertEqual( Gaffer.Metadata.value( add["op1"], "description" ), "op1 description" )
+		self.assertEqual( Gaffer.Metadata.value( add["op2"], "description" ), None )
 
 	def testArbitraryValues( self ) :
 
@@ -327,7 +279,7 @@ class MetadataTest( GafferTest.TestCase ) :
 		script2.execute( script.serialise() )
 
 		for p, s in zip( script2["n"]["user"].children(), trickyStrings ) :
-			self.assertEqual( Gaffer.Metadata.plugDescription( p ), s )
+			self.assertEqual( Gaffer.Metadata.value( p, "description" ), s )
 
 	def testRegisteredValues( self ) :
 

--- a/python/GafferUI/Backups.py
+++ b/python/GafferUI/Backups.py
@@ -156,6 +156,7 @@ class Backups( object ) :
 			# Commented lines, for instance a header.
 			r'#.*$',
 			# Version metadata.
+			r'Gaffer\.Metadata\.registerValue\( parent, "serialiser:.*Version", .* \)$',
 			r'Gaffer\.Metadata\.registerNodeValue\( parent, "serialiser:.*Version", .* \)$',
 			# Pesky catalogue port number, which is different each time we run.
 			r'parent\["variables"\]\["imageCataloguePort"\]\["value"\]\.setValue\( [0-9]* \)$',

--- a/python/GafferUI/NodeEditor.py
+++ b/python/GafferUI/NodeEditor.py
@@ -138,7 +138,7 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 						)
 
 				toolTip = "<h3>" + node.typeName().rpartition( ":" )[2] + "</h3>"
-				description = Gaffer.Metadata.nodeDescription( node )
+				description = Gaffer.Metadata.value( node, "description" )
 				if description :
 					toolTip += "\n\n" + description
 				infoSection.setToolTip( toolTip )

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -143,7 +143,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 			inputText = " &lt;- " + input.relativeName( input.commonAncestor( plug, Gaffer.GraphComponent ) )
 
 		result = "<h3>" + plug.relativeName( plug.node() ) + inputText + "</h3>"
-		description = Gaffer.Metadata.plugDescription( plug )
+		description = Gaffer.Metadata.value( plug, "description" )
 		if description :
 			result += "\n\n" + description
 

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -233,7 +233,7 @@ class Viewer( GafferUI.NodeSetEditor ) :
 			return False
 
 		for t in self.__toolChooser.tools() :
-			if Gaffer.Metadata.nodeValue( t, "viewer:shortCut" ) == event.key :
+			if Gaffer.Metadata.value( t, "viewer:shortCut" ) == event.key :
 				t["active"].setValue( True )
 				return True
 
@@ -311,7 +311,7 @@ class _ToolChooser( GafferUI.Frame ) :
 		def __init__( self, view ) :
 
 			self.tools = [ GafferUI.Tool.create( n, view ) for n in GafferUI.Tool.registeredTools( view.typeId() ) ]
-			self.tools.sort( key = lambda v : Gaffer.Metadata.nodeValue( v, "order" ) if Gaffer.Metadata.nodeValue( v, "order" ) is not None else 999 )
+			self.tools.sort( key = lambda v : Gaffer.Metadata.value( v, "order" ) if Gaffer.Metadata.value( v, "order" ) is not None else 999 )
 
 			self.__toolPlugSetConnections = [
 				t.plugSetSignal().connect( Gaffer.WeakMethod( self.__toolPlugSet, fallbackResult = lambda plug : None ) ) for t in self.tools
@@ -325,7 +325,7 @@ class _ToolChooser( GafferUI.Frame ) :
 				for tool in self.tools :
 
 					toolTip = tool.getName()
-					description = Gaffer.Metadata.nodeDescription( tool )
+					description = Gaffer.Metadata.value( tool, "description" )
 					if description :
 						toolTip += "\n\n" + IECore.StringUtil.wrap( description, 80 )
 

--- a/python/GafferUITest/AuxiliaryConnectionsGadgetTest.py
+++ b/python/GafferUITest/AuxiliaryConnectionsGadgetTest.py
@@ -55,8 +55,8 @@ class AuxiliaryConnectionsGadgetTest( GafferUITest.TestCase ) :
 		n1["o"] = Gaffer.Plug( direction=Gaffer.Plug.Direction.Out )
 		n2["i"] = Gaffer.Plug()
 
-		Gaffer.Metadata.registerPlugValue( n1["o"], "nodule:type", "" )
-		Gaffer.Metadata.registerPlugValue( n2["i"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( n1["o"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( n2["i"], "nodule:type", "" )
 
 		n2["i"].setInput( n1["o"] )
 
@@ -91,8 +91,8 @@ class AuxiliaryConnectionsGadgetTest( GafferUITest.TestCase ) :
 		script["n1"]["o"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
 		script["n2"]["i"] = Gaffer.IntPlug()
 
-		Gaffer.Metadata.registerPlugValue( script["n1"]["o"], "nodule:type", "" )
-		Gaffer.Metadata.registerPlugValue( script["n2"]["i"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( script["n1"]["o"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( script["n2"]["i"], "nodule:type", "" )
 
 		script["n2"]["i"].setInput( script["n1"]["o"] )
 
@@ -119,8 +119,8 @@ class AuxiliaryConnectionsGadgetTest( GafferUITest.TestCase ) :
 		script["n1"]["o"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
 		script["n2"]["i"] = Gaffer.IntPlug()
 
-		Gaffer.Metadata.registerPlugValue( script["n1"]["o"], "nodule:type", "" )
-		Gaffer.Metadata.registerPlugValue( script["n2"]["i"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( script["n1"]["o"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( script["n2"]["i"], "nodule:type", "" )
 
 		script["n2"]["i"].setInput( script["n1"]["o"] )
 
@@ -143,11 +143,11 @@ class AuxiliaryConnectionsGadgetTest( GafferUITest.TestCase ) :
 
 		script["n1"] = Gaffer.Node()
 		script["n1"]["p"] = Gaffer.Plug()
-		Gaffer.Metadata.registerPlugValue( script["n1"]["p"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( script["n1"]["p"], "nodule:type", "" )
 
 		script["n2"] = Gaffer.Node()
 		script["n2"]["p"] = Gaffer.Plug()
-		Gaffer.Metadata.registerPlugValue( script["n2"]["p"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( script["n2"]["p"], "nodule:type", "" )
 
 		script["n2"]["p"].setInput( script["n1"]["p"] )
 
@@ -167,12 +167,12 @@ class AuxiliaryConnectionsGadgetTest( GafferUITest.TestCase ) :
 
 		script["n1"] = Gaffer.Node()
 		script["n1"]["p"] = Gaffer.Plug()
-		Gaffer.Metadata.registerPlugValue( script["n1"]["p"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( script["n1"]["p"], "nodule:type", "" )
 
 		script["n2"] = Gaffer.Node()
 		script["n2"]["p"] = Gaffer.Plug()
 		script["n2"]["p"].setInput( script["n1"]["p"] )
-		Gaffer.Metadata.registerPlugValue( script["n2"]["p"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( script["n2"]["p"], "nodule:type", "" )
 
 		g = GafferUI.GraphGadget( script )
 		self.assertTrue( g.auxiliaryConnectionsGadget().hasConnection( script["n1"], script["n2"] ) )
@@ -188,11 +188,11 @@ class AuxiliaryConnectionsGadgetTest( GafferUITest.TestCase ) :
 
 		script["n1"] = Gaffer.Node()
 		script["n1"]["p"] = Gaffer.Plug()
-		Gaffer.Metadata.registerPlugValue( script["n1"]["p"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( script["n1"]["p"], "nodule:type", "" )
 
 		script["n2"] = Gaffer.Node()
 		script["n2"]["p"] = Gaffer.Plug()
-		Gaffer.Metadata.registerPlugValue( script["n2"]["p"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( script["n2"]["p"], "nodule:type", "" )
 
 		script["n2"]["p"].setInput( script["n1"]["p"] )
 
@@ -201,11 +201,11 @@ class AuxiliaryConnectionsGadgetTest( GafferUITest.TestCase ) :
 
 		self.assertTrue( acg.hasConnection( script["n1"], script["n2"] ) )
 
-		Gaffer.Metadata.registerPlugValue( script["n1"]["p"], "nodule:type", "GafferUI::StandardNodule" )
+		Gaffer.Metadata.registerValue( script["n1"]["p"], "nodule:type", "GafferUI::StandardNodule" )
 
 		self.assertTrue( acg.hasConnection( script["n1"], script["n2"] ) )
 
-		Gaffer.Metadata.registerPlugValue( script["n2"]["p"], "nodule:type", "GafferUI::StandardNodule" )
+		Gaffer.Metadata.registerValue( script["n2"]["p"], "nodule:type", "GafferUI::StandardNodule" )
 
 		self.assertFalse( acg.hasConnection( script["n1"], script["n2"] ) )
 

--- a/python/GafferUITest/StandardGraphLayoutTest.py
+++ b/python/GafferUITest/StandardGraphLayoutTest.py
@@ -738,7 +738,7 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 		s["n"] = LayoutNode()
-		Gaffer.Metadata.registerPlugValue( s["n"]["top0"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["n"]["top0"], "nodule:type", "" )
 
 		s["e"] = Gaffer.Expression()
 		s["e"].setExpression( "parent['n']['top0'] = 0" )
@@ -777,15 +777,15 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["n"] = LayoutNode()
 
-		Gaffer.Metadata.registerPlugValue( s["n"]["left0"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["n"]["left0"], "nodule:type", "" )
 
-		Gaffer.Metadata.registerPlugValue( s["n"]["top0"], "nodule:type", "" )
-		Gaffer.Metadata.registerPlugValue( s["n"]["top1"], "nodule:type", "" )
-		Gaffer.Metadata.registerPlugValue( s["n"]["top2"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["n"]["top0"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["n"]["top1"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["n"]["top2"], "nodule:type", "" )
 
-		Gaffer.Metadata.registerPlugValue( s["n"]["bottom0"], "nodule:type", "" )
-		Gaffer.Metadata.registerPlugValue( s["n"]["bottom1"], "nodule:type", "" )
-		Gaffer.Metadata.registerPlugValue( s["n"]["bottom2"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["n"]["bottom0"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["n"]["bottom1"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["n"]["bottom2"], "nodule:type", "" )
 
 		s["e"] = Gaffer.Expression()
 		s["e"].setExpression( "parent['n']['left0'] = 0" )
@@ -834,9 +834,9 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["n"] = LayoutNode()
 
-		Gaffer.Metadata.registerPlugValue( s["n"]["left0"], "nodule:type", "" )
-		Gaffer.Metadata.registerPlugValue( s["n"]["left1"], "nodule:type", "" )
-		Gaffer.Metadata.registerPlugValue( s["n"]["left2"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["n"]["left0"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["n"]["left1"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["n"]["left2"], "nodule:type", "" )
 
 		s["e1"] = Gaffer.Expression()
 		s["e1"].setExpression( "parent['n']['left0'] = 0" )
@@ -866,13 +866,13 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		s = Gaffer.ScriptNode()
 
 		s["o"] = LayoutNode()
-		Gaffer.Metadata.registerPlugValue( s["o"]["left0"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["o"]["left0"], "nodule:type", "" )
 
 		s["i1"] = LayoutNode()
-		Gaffer.Metadata.registerPlugValue( s["i1"]["left0"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["i1"]["left0"], "nodule:type", "" )
 
 		s["i2"] = LayoutNode()
-		Gaffer.Metadata.registerPlugValue( s["i2"]["left0"], "nodule:type", "" )
+		Gaffer.Metadata.registerValue( s["i2"]["left0"], "nodule:type", "" )
 
 		s["e"] = Gaffer.Expression()
 		s["e"].setExpression( "parent['i1']['left0'] = 0\nparent['i2']['left0'] = parent['o']['right0']" )

--- a/src/Gaffer/BoxIO.cpp
+++ b/src/Gaffer/BoxIO.cpp
@@ -559,7 +559,7 @@ bool hasNodule( const Plug *plug )
 {
 	for( const Plug *p = plug; p; p = p->parent<Plug>() )
 	{
-		ConstStringDataPtr d = Metadata::plugValue<StringData>( p, g_noduleTypeName );
+		ConstStringDataPtr d = Metadata::value<StringData>( p, g_noduleTypeName );
 		if( d && d->readable() == "" )
 		{
 			return false;

--- a/src/Gaffer/Loop.cpp
+++ b/src/Gaffer/Loop.cpp
@@ -269,8 +269,15 @@ bool Loop::setupPlugs()
 	previousPlug()->setFlags( Plug::Dynamic, false );
 
 	// Copy styling over from main plugs.
-	/// \todo It would be much better if colours could be registered once by
-	/// Plug TypeId, and then we wouldn't need to do this.
+	/// \todo We shouldn't really need to do this, because plug colours are
+	/// expected to be registered against plug type, so our plugs will get
+	/// the right colour automatically (and `copyColors()` will do nothing
+	/// because of the `overwrite = false` argument). We are keeping it for
+	/// now to accommodate proprietary extensions which are using custom colours
+	/// instead of introducing their own plug types, but some day we should
+	/// just remove this entirely. Note that the same applies for the Dot,
+	/// ContextProcessor, ArrayPlug and Switch nodes. See
+	/// https://github.com/GafferHQ/gaffer/pull/2953 for further discussion.
 	MetadataAlgo::copyColors( inPlug(), nextPlug() , /* overwrite = */ false  );
 	MetadataAlgo::copyColors( inPlug(), previousPlug() , /* overwrite = */ false  );
 

--- a/src/GafferBindings/Serialisation.cpp
+++ b/src/GafferBindings/Serialisation.cpp
@@ -100,7 +100,7 @@ std::string Serialisation::result() const
 		runTimeCast<const Node>( m_parent )
 	)
 	{
-		boost::format formatter( "Gaffer.Metadata.registerNodeValue( %s, \"%s\", %d, persistent=False )\n" );
+		boost::format formatter( "Gaffer.Metadata.registerValue( %s, \"%s\", %d, persistent=False )\n" );
 
 		result += "\n";
 		result += boost::str( formatter % m_parentName % "serialiser:milestoneVersion" % GAFFER_MILESTONE_VERSION );

--- a/src/GafferModule/MetadataBinding.cpp
+++ b/src/GafferModule/MetadataBinding.cpp
@@ -202,44 +202,7 @@ object graphComponentValue( const GraphComponent *graphComponent, const char *ke
 
 void registerNodeValue( IECore::TypeId nodeTypeId, IECore::InternedString key, object &value )
 {
-	Metadata::registerNodeValue( nodeTypeId, key, objectToNodeValueFunction( key, value ) );
-}
-
-object nodeValue( const Node *node, const char *key, bool inherit, bool instanceOnly, bool copy )
-{
-	ConstDataPtr d = Metadata::nodeValue<Data>( node, key, inherit, instanceOnly );
-	return dataToPython( d.get(), copy );
-}
-
-object registerNodeDescription( tuple args, dict kw )
-{
-	IECore::TypeId nodeTypeId = extract<IECore::TypeId>( args[0] );
-	Metadata::registerNodeDescription( nodeTypeId, objectToNodeValueFunction( g_descriptionName, args[1] ) );
-
-	for( size_t i = 2, e = len( args ); i < e; i += 2 )
-	{
-		StringAlgo::MatchPattern plugPath = extract<StringAlgo::MatchPattern>( args[i] )();
-		extract<dict> dictExtractor( args[i+1] );
-		if( dictExtractor.check() )
-		{
-			list dictItems = dictExtractor().items();
-			for( size_t di = 0, de = len( dictItems ); di < de; ++di )
-			{
-				InternedString name = extract<const char *>( dictItems[di][0] )();
-				Metadata::registerPlugValue(
-					nodeTypeId, plugPath,
-					name,
-					objectToPlugValueFunction( name, dictItems[di][1] )
-				);
-			}
-		}
-		else
-		{
-			Metadata::registerPlugDescription( nodeTypeId, plugPath, objectToPlugValueFunction( g_descriptionName, args[i+1] ) );
-		}
-	}
-
-	return object(); // none
+	Metadata::registerValue( nodeTypeId, key, objectToNodeValueFunction( key, value ) );
 }
 
 object registerNode( tuple args, dict kw )
@@ -249,7 +212,7 @@ object registerNode( tuple args, dict kw )
 	for( size_t i = 1, e = len( args ); i < e; i += 2 )
 	{
 		IECore::InternedString name = extract<IECore::InternedString>( args[i] )();
-		Metadata::registerNodeValue( nodeTypeId, name, objectToNodeValueFunction( name, args[i+1] ) );
+		Metadata::registerValue( nodeTypeId, name, objectToNodeValueFunction( name, args[i+1] ) );
 	}
 
 	object plugsObject = kw.get( "plugs" );
@@ -264,7 +227,7 @@ object registerNode( tuple args, dict kw )
 			for( size_t vi = 0, ve = len( plugValues ); vi < ve; vi += 2 )
 			{
 				InternedString name = extract<InternedString>( plugValues[vi] );
-				Metadata::registerPlugValue(
+				Metadata::registerValue(
 					nodeTypeId,
 					plugPath,
 					name,
@@ -279,18 +242,7 @@ object registerNode( tuple args, dict kw )
 
 void registerPlugValue( IECore::TypeId nodeTypeId, const char *plugPath, IECore::InternedString key, object &value )
 {
-	Metadata::registerPlugValue( nodeTypeId, plugPath, key, objectToPlugValueFunction( key, value ) );
-}
-
-object plugValue( const Plug *plug, const char *key, bool inherit, bool instanceOnly, bool copy )
-{
-	ConstDataPtr d = Metadata::plugValue<Data>( plug, key, inherit, instanceOnly );
-	return dataToPython( d.get(), copy );
-}
-
-void registerPlugDescription( IECore::TypeId nodeTypeId, const char *plugPath, object &description )
-{
-	Metadata::registerPlugDescription( nodeTypeId, plugPath, objectToPlugValueFunction( g_descriptionName, description ) );
+	Metadata::registerValue( nodeTypeId, plugPath, key, objectToPlugValueFunction( key, value ) );
 }
 
 struct ValueChangedSlotCaller
@@ -352,21 +304,6 @@ list registeredGraphComponentValues( const GraphComponent *target, bool instance
 	Metadata::registeredValues( target, keys, instanceOnly, persistentOnly );
 	return keysToList( keys );
 }
-
-list registeredNodeValues( const Node *node, bool inherit, bool instanceOnly, bool persistentOnly )
-{
-	std::vector<InternedString> keys;
-	Metadata::registeredNodeValues( node, keys, inherit, instanceOnly, persistentOnly );
-	return keysToList( keys );
-}
-
-list registeredPlugValues( const Plug *plug, bool inherit, bool instanceOnly, bool persistentOnly )
-{
-	std::vector<InternedString> keys;
-	Metadata::registeredPlugValues( plug, keys, inherit, instanceOnly, persistentOnly );
-	return keysToList( keys );
-}
-
 
 list plugsWithMetadata( GraphComponent *root, const std::string &key, bool instanceOnly )
 {
@@ -443,100 +380,8 @@ void GafferModule::bindMetadata()
 		.def( "deregisterValue", &deregisterInstanceValue )
 		.staticmethod( "deregisterValue" )
 
-		.def( "registerNodeValue", &registerNodeValue )
-		.def( "registerNodeValue", (void (*)( Node *, InternedString key, ConstDataPtr value, bool ))&Metadata::registerNodeValue,
-			(
-				boost::python::arg( "node" ),
-				boost::python::arg( "value" ),
-				boost::python::arg( "persistent" ) = true
-			)
-		)
-		.staticmethod( "registerNodeValue" )
-
-		.def( "registeredNodeValues", &registeredNodeValues,
-			(
-				boost::python::arg( "node" ),
-				boost::python::arg( "inherit" ) = true,
-				boost::python::arg( "instanceOnly" ) = false,
-				boost::python::arg( "persistentOnly" ) = false
-			)
-		)
-		.staticmethod( "registeredNodeValues" )
-
-		.def( "nodeValue", &nodeValue,
-			(
-				boost::python::arg( "node" ),
-				boost::python::arg( "key" ),
-				boost::python::arg( "inherit" ) = true,
-				boost::python::arg( "instanceOnly" ) = false,
-				boost::python::arg( "_copy" ) = true
-			)
-		)
-		.staticmethod( "nodeValue" )
-
-		.def( "deregisterNodeValue", (void (*)( IECore::TypeId, InternedString ))&Metadata::deregisterNodeValue )
-		.def( "deregisterNodeValue", (void (*)( Node *, InternedString ))&Metadata::deregisterNodeValue )
-		.staticmethod( "deregisterNodeValue" )
-
-		.def( "registerNodeDescription", boost::python::raw_function( &registerNodeDescription, 2 ) )
-		.staticmethod( "registerNodeDescription" )
-
 		.def( "registerNode", boost::python::raw_function( &registerNode, 1 ) )
 		.staticmethod( "registerNode" )
-
-		.def( "nodeDescription", &Metadata::nodeDescription,
-			(
-				boost::python::arg( "node" ),
-				boost::python::arg( "inherit" ) = true
-			)
-		)
-		.staticmethod( "nodeDescription" )
-
-		.def( "registerPlugValue", &registerPlugValue )
-		.def( "registerPlugValue", (void (*)( Plug *, InternedString key, ConstDataPtr value, bool ))&Metadata::registerPlugValue,
-			(
-				boost::python::arg( "plug" ),
-				boost::python::arg( "value" ),
-				boost::python::arg( "persistent" ) = true
-			)
-		)
-		.staticmethod( "registerPlugValue" )
-
-		.def( "registeredPlugValues", &registeredPlugValues,
-			(
-				boost::python::arg( "plug" ),
-				boost::python::arg( "inherit" ) = true,
-				boost::python::arg( "instanceOnly" ) = false,
-				boost::python::arg( "persistentOnly" ) = false
-			)
-		)
-		.staticmethod( "registeredPlugValues" )
-
-		.def( "plugValue", &plugValue,
-			(
-				boost::python::arg( "plug" ),
-				boost::python::arg( "key" ),
-				boost::python::arg( "inherit" ) = true,
-				boost::python::arg( "instanceOnly" ) = false,
-				boost::python::arg( "_copy" ) = true
-			)
-		)
-		.staticmethod( "plugValue" )
-
-		.def( "deregisterPlugValue", (void (*)( IECore::TypeId, const StringAlgo::MatchPattern &, InternedString ))&Metadata::deregisterPlugValue )
-		.def( "deregisterPlugValue", (void (*)( Plug *, InternedString ))&Metadata::deregisterPlugValue )
-		.staticmethod( "deregisterPlugValue" )
-
-		.def( "registerPlugDescription", &registerPlugDescription )
-		.staticmethod( "registerPlugDescription" )
-
-		.def( "plugDescription", &Metadata::plugDescription,
-			(
-				boost::python::arg( "plug" ),
-				boost::python::arg( "inherit" ) = true
-			)
-		)
-		.staticmethod( "plugDescription" )
 
 		.def( "valueChangedSignal", &Metadata::valueChangedSignal, return_value_policy<reference_existing_object>() )
 		.staticmethod( "valueChangedSignal" )

--- a/src/GafferUI/NodeGadget.cpp
+++ b/src/GafferUI/NodeGadget.cpp
@@ -196,10 +196,9 @@ std::string NodeGadget::getToolTip( const IECore::LineSegment3f &line ) const
 
 	result = "<h3>" + title + "</h3>";
 
-	std::string description = Gaffer::Metadata::nodeDescription( m_node );
-	if( description.size() )
+	if( ConstStringDataPtr description = Gaffer::Metadata::value<StringData>( m_node, "description" ) )
 	{
-		result += "\n\n" + description;
+		result += "\n\n" + description->readable();
 	}
 
 	if( ConstStringDataPtr summary = Gaffer::Metadata::value<StringData>( m_node, "summary" ) )

--- a/src/GafferUI/Nodule.cpp
+++ b/src/GafferUI/Nodule.cpp
@@ -44,6 +44,7 @@
 #include "IECore/SimpleTypedData.h"
 
 using namespace GafferUI;
+using namespace IECore;
 using namespace Imath;
 using namespace std;
 
@@ -154,10 +155,9 @@ std::string Nodule::getToolTip( const IECore::LineSegment3f &line ) const
 	}
 
 	result = "<h3>" + result + "</h3>";
-	std::string description = Gaffer::Metadata::plugDescription( m_plug.get() );
-	if( description.size() )
+	if( ConstStringDataPtr description = Gaffer::Metadata::value<StringData>( m_plug.get(), "description" ) )
 	{
-		result += "\n\n" + description;
+		result += "\n\n" + description->readable();
 	}
 
 	return result;

--- a/startup/Gaffer/metadataCompatibility.py
+++ b/startup/Gaffer/metadataCompatibility.py
@@ -52,3 +52,9 @@ def __registerValueWrapper( originalRegisterValue ) :
 	return staticmethod( registerValue )
 
 Gaffer.Metadata.registerValue = __registerValueWrapper( Gaffer.Metadata.registerValue )
+
+# Monkey patching for continued support of deprecated methods that are used in
+# legacy .gfr files.
+
+Gaffer.Metadata.registerNodeValue = staticmethod( Gaffer.Metadata.registerValue )
+Gaffer.Metadata.registerPlugValue = staticmethod( Gaffer.Metadata.registerValue )

--- a/startup/GafferScene/cameraCompatibility.py
+++ b/startup/GafferScene/cameraCompatibility.py
@@ -44,10 +44,10 @@ def __compatibilityFunc( node, oldParent ):
 	parentNode = node.ancestor( Gaffer.Node )
 	while parentNode :
 		gafferVersion = (
-			Gaffer.Metadata.nodeValue( parentNode, "serialiser:milestoneVersion" ),
-			Gaffer.Metadata.nodeValue( parentNode, "serialiser:majorVersion" ),
-			Gaffer.Metadata.nodeValue( parentNode, "serialiser:minorVersion" ),
-			Gaffer.Metadata.nodeValue( parentNode, "serialiser:patchVersion" )
+			Gaffer.Metadata.value( parentNode, "serialiser:milestoneVersion" ),
+			Gaffer.Metadata.value( parentNode, "serialiser:majorVersion" ),
+			Gaffer.Metadata.value( parentNode, "serialiser:minorVersion" ),
+			Gaffer.Metadata.value( parentNode, "serialiser:patchVersion" )
 		)
 
 		# only use the information if we have valid information from the node

--- a/startup/gui/cache.py
+++ b/startup/gui/cache.py
@@ -48,7 +48,7 @@ preferences["cache"]["memoryLimit"] = Gaffer.IntPlug( defaultValue = Gaffer.Valu
 Gaffer.Metadata.registerValue( preferences["cache"], "plugValueWidget:type", "GafferUI.LayoutPlugValueWidget", persistent = False )
 Gaffer.Metadata.registerValue( preferences["cache"], "layout:section", "Cache", persistent = False )
 
-Gaffer.Metadata.registerPlugValue(
+Gaffer.Metadata.registerValue(
 	preferences["cache"]["memoryLimit"],
 	"description",
 	"""

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -52,12 +52,8 @@ import GafferDispatchUI
 ##########################################################################
 
 Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "nodeGadget:color", imath.Color3f( 0.61, 0.1525, 0.1525 ) )
-Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "task", "nodule:color", imath.Color3f( 0.645, 0.2483, 0.2483 ) )
-Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "preTasks.*", "nodule:color", imath.Color3f( 0.645, 0.2483, 0.2483 ) )
-Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "postTasks.*", "nodule:color", imath.Color3f( 0.645, 0.2483, 0.2483 ) )
-Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "task", "connectionGadget:color", imath.Color3f( 0.315, 0.0787, 0.0787 ) )
-Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "preTasks.*", "connectionGadget:color", imath.Color3f( 0.315, 0.0787, 0.0787 ) )
-Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "postTasks.*", "connectionGadget:color", imath.Color3f( 0.315, 0.0787, 0.0787 ) )
+Gaffer.Metadata.registerValue( GafferDispatch.TaskNode.TaskPlug, "nodule:color", imath.Color3f( 0.645, 0.2483, 0.2483 ) )
+Gaffer.Metadata.registerValue( GafferDispatch.TaskNode.TaskPlug, "connectionGadget:color", imath.Color3f( 0.315, 0.0787, 0.0787 ) )
 
 Gaffer.Metadata.registerValue( Gaffer.SubGraph, "nodeGadget:color", imath.Color3f( 0.225 ) )
 Gaffer.Metadata.registerValue( Gaffer.BoxIO, "nodeGadget:color", imath.Color3f( 0.225 ) )
@@ -66,34 +62,21 @@ Gaffer.Metadata.registerValue( Gaffer.Random, "nodeGadget:color", imath.Color3f(
 Gaffer.Metadata.registerValue( Gaffer.Expression, "nodeGadget:color", imath.Color3f( 0.3, 0.45, 0.3 ) )
 Gaffer.Metadata.registerValue( Gaffer.Animation, "nodeGadget:color", imath.Color3f( 0.3, 0.3, 0.45 ) )
 
-Gaffer.Metadata.registerValue( GafferScene.SceneNode, "in...", "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
-Gaffer.Metadata.registerValue( GafferScene.SceneNode, "out", "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
-Gaffer.Metadata.registerValue( GafferScene.InteractiveRender, "in", "nodule:color", imath.Color3f( 0.2346, 0.326, 0.46 ) )
-Gaffer.Metadata.registerValue( GafferScene.Parent, "child", "nodule:color", imath.Color3f( 0.2346, 0.326, 0.46 ) )
+Gaffer.Metadata.registerValue( GafferScene.ScenePlug, "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
 
 Gaffer.Metadata.registerValue( GafferScene.SceneProcessor, "nodeGadget:color", imath.Color3f( 0.495, 0.2376, 0.4229 ) )
 Gaffer.Metadata.registerValue( GafferScene.SceneElementProcessor, "nodeGadget:color", imath.Color3f( 0.1886, 0.2772, 0.41 ) )
 
-Gaffer.Metadata.registerValue( GafferScene.FilteredSceneProcessor, "filter", "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
-Gaffer.Metadata.registerValue( GafferScene.Filter, "out", "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
-Gaffer.Metadata.registerValue( GafferScene.Filter, "in...", "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
+Gaffer.Metadata.registerValue( GafferScene.FilterPlug, "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
 
 Gaffer.Metadata.registerValue( GafferScene.Transform, "nodeGadget:color", imath.Color3f( 0.485, 0.3112, 0.2255 ) )
 Gaffer.Metadata.registerValue( GafferScene.Constraint, "nodeGadget:color", imath.Color3f( 0.485, 0.3112, 0.2255 ) )
 
 Gaffer.Metadata.registerValue( GafferScene.GlobalsProcessor, "nodeGadget:color", imath.Color3f( 0.255, 0.505, 0.28 ) )
 
-__shaderNoduleColors = {
-	Gaffer.FloatPlug.staticTypeId() : IECore.Color3fData( imath.Color3f( 0.2467, 0.3762, 0.47 ) ),
-	Gaffer.Color3fPlug.staticTypeId() : IECore.Color3fData( imath.Color3f( 0.69, 0.5378, 0.2283 ) ),
-	Gaffer.V3fPlug.staticTypeId() : IECore.Color3fData( imath.Color3f( 0.47, 0.181, 0.181 ) ),
-}
-
-def __shaderNoduleColor( plug ) :
-
-	return __shaderNoduleColors.get( plug.typeId(), None )
-
-Gaffer.Metadata.registerValue( GafferScene.Shader, "...", "nodule:color", __shaderNoduleColor )
+Gaffer.Metadata.registerValue( Gaffer.FloatPlug, "nodule:color", imath.Color3f( 0.2467, 0.3762, 0.47 ) )
+Gaffer.Metadata.registerValue( Gaffer.Color3fPlug, "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )
+Gaffer.Metadata.registerValue( Gaffer.V3fPlug, "nodule:color", imath.Color3f( 0.47, 0.181, 0.181 ) )
 
 ##########################################################################
 # Behaviour

--- a/startup/gui/localDispatcher.py
+++ b/startup/gui/localDispatcher.py
@@ -37,5 +37,5 @@
 import Gaffer
 import GafferDispatch
 
-Gaffer.Metadata.registerPlugValue( GafferDispatch.LocalDispatcher, "executeInBackground", "userDefault", True )
+Gaffer.Metadata.registerValue( GafferDispatch.LocalDispatcher, "executeInBackground", "userDefault", True )
 GafferDispatch.Dispatcher.setDefaultDispatcherType( "Local" )

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -188,7 +188,7 @@ if moduleSearchPath.find( "nsi.py" ) and moduleSearchPath.find( "GafferDelight" 
 				if shape == "distant" :
 					node["geometryParameters"].addMember( "angle", 0.0, plugName = "angle" )
 
-			Gaffer.Metadata.registerPlugValue( node["shape"], "plugValueWidget:type", "" )
+			Gaffer.Metadata.registerValue( node["shape"], "plugValueWidget:type", "" )
 
 			visibilityPlug = node["attributes"].addMember( "dl:visibility.camera", False, "cameraVisibility" )
 			Gaffer.MetadataAlgo.setReadOnly( visibilityPlug["name"], True )

--- a/startup/gui/project.py
+++ b/startup/gui/project.py
@@ -108,6 +108,6 @@ with IECore.IgnoredExceptions( ImportError ) :
 
 for dispatcher in dispatchers :
 
-	Gaffer.Metadata.registerPlugValue( dispatcher, "jobName", "userDefault", "${script:name}" )
+	Gaffer.Metadata.registerValue( dispatcher, "jobName", "userDefault", "${script:name}" )
 	directoryName = dispatcher.staticTypeName().rpartition( ":" )[2].replace( "Dispatcher", "" ).lower()
-	Gaffer.Metadata.registerPlugValue( dispatcher, "jobsDirectory", "userDefault", "${project:rootDirectory}/dispatcher/" + directoryName )
+	Gaffer.Metadata.registerValue( dispatcher, "jobsDirectory", "userDefault", "${project:rootDirectory}/dispatcher/" + directoryName )


### PR DESCRIPTION
This provides the ability to register metadata by plug type, and by name relative to an ancestor plug type. This allows us to remove some inelegant workarounds, and provides some opportunities for further improving the appearance of the component-level connections implemented in #2938. 