### PR TITLE
Tracked hash cache

### DIFF
--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -112,7 +112,7 @@ class GAFFER_API ValuePlug : public Plug
 		static void setCacheMemoryLimit( size_t bytes );
 		/// Returns the current memory usage of the cache in bytes.
 		static size_t cacheMemoryUsage();
-		/// Clears the cache.
+		/// Clears the compute & hash caches.
 		static void clearCache();
 		//@}
 

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -162,7 +162,7 @@ class ValuePlug::HashProcess : public Process
 			return process.m_result;
 		}
 
-		static void clearCache()
+		static void clearCache( bool immediate = false )
 		{
 			// The docs for enumerable_thread_specific aren't particularly clear
 			// on whether or not it's ok to iterate an e_t_s while concurrently using
@@ -179,7 +179,15 @@ class ValuePlug::HashProcess : public Process
 				// a graph while a computation is being performed with it, and
 				// we know that the plug requesting the clear will be removed
 				// from the cache before the next computation starts.
-				it->clearCache = 1;
+				if ( immediate )
+				{
+					Cache empty;
+					it->cache.swap( empty );
+				}
+				else
+				{
+					it->clearCache = 1;
+				}
 			}
 		}
 
@@ -784,4 +792,5 @@ size_t ValuePlug::cacheMemoryUsage()
 void ValuePlug::clearCache()
 {
 	ComputeProcess::clearCache();
+	HashProcess::clearCache( true /* immediate */ );
 }


### PR DESCRIPTION
Proposal to force clear the hashcache when it reaches a user override-able number of elements. 

This isn't ideal but the previous hash cache clear criterion resulted in unexpected and unbounded memory usage. 

Also the hash cache is cleared just prior to rendering.

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
