### PR TITLE
PathPlugValueWidget : Update and add missing shortcuts to tooltip

### DIFF
--- a/python/GafferUI/PathPlugValueWidget.py
+++ b/python/GafferUI/PathPlugValueWidget.py
@@ -93,9 +93,10 @@ class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		result = GafferUI.PlugValueWidget.getToolTip( self )
 
-		result += "\n\n<ul>"
-		result += "<li>Tab to auto-complete</li>"
-		result += "<li>Cursor down to list</li>"
+		result += "<ul>"
+		result += "<li><kbd>Tab</kbd> to autocomplete path component</li>"
+		result += "<li>Select path component (or hit <kbd>&darr;</kbd>) to show path-level contents menu</li>"
+		result += "<li>Select all to show path hierarchy menu</li>"
 		result += "</ul>"
 
 		return result


### PR DESCRIPTION
Add the missing path component shortcut for path plug widgets.

### Related Issues ###

- https://github.com/GafferHQ/gaffer/pull/2929#discussion_r239401703

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
