### PR TITLE
Numeric hotkeys

### DIFF
--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -25,6 +25,7 @@ Frame selected nodes                  :kbd:`F`
 Enter `Box` node (subgraph)	          :kbd:`↓`
 Leave `Box` node (subgraph)           :kbd:`↑`
 Search for nodes                      :kbd:`Ctrl` + :kbd:`F`
+Frame to numeric bookmark             :kbd:`1` … :kbd:`9`
 ===================================== =============================================
 ```
 
@@ -114,6 +115,8 @@ Action			                      Control or Shortcut
 Bookmark node                         Right-click node > *Bookmark*
 Connect to bookmarked node            Right-click plug > *Connect Bookmark* > select
                                       node
+Assign numeric bookmark               :kbd:`Ctrl` + :kbd:`1` … :kbd:`9`
+Remove numeric bookmark               :kbd:`Ctrl` + :kbd:`0`
 ===================================== =============================================
 ```
 
@@ -138,6 +141,7 @@ Zoom/dolly                            :kbd:`Alt` + right-click and drag
                                       Mouse wheel up/down
 Frame view to contents                :kbd:`F`
 Pause processing                      :kbd:`Escape`
+Pin to numeric bookmark               :kbd:`1` … :kbd:`9`
 ===================================== =============================================
 ```
 

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -115,6 +115,22 @@ GAFFER_API bool getBookmarked( const Node *node );
 GAFFER_API bool bookmarkedAffectedByChange( const IECore::InternedString &changedKey );
 GAFFER_API void bookmarks( const Node *node, std::vector<NodePtr> &bookmarks );
 
+/// Numeric Bookmarks
+/// =================
+///
+/// Each script has a set of numeric bookmarks numbered 1-9, each of which can
+//  have a single node assigned. Reassigning a numeric bookmark will
+/// consequently remove it from another node. Nodes can be assigned to a
+/// single numeric bookmark at a time.
+/// The following functions throw if given bookmark is not in {1, ..., 9}.
+
+/// \undoable, pass a nullptr to remove the bookmark.
+GAFFER_API void setNumericBookmark( ScriptNode *script, int bookmark, Node *node );
+GAFFER_API Node *getNumericBookmark( ScriptNode *script, int bookmark );
+/// Returns 0 if the node isn't assigned, the bookmark otherwise.
+GAFFER_API int numericBookmark( const Node *node );
+GAFFER_API bool numericBookmarkAffectedByChange( const IECore::InternedString &changedKey );
+
 /// Utilities
 /// =========
 

--- a/include/GafferUI/BackdropNodeGadget.h
+++ b/include/GafferUI/BackdropNodeGadget.h
@@ -90,6 +90,7 @@ class GAFFERUI_API BackdropNodeGadget : public NodeGadget
 		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node );
 
 		bool updateUserColor();
+		bool updateNumericBookmark();
 
 		Gaffer::Box2fPlug *boundPlug();
 		const Gaffer::Box2fPlug *boundPlug() const;
@@ -100,6 +101,7 @@ class GAFFERUI_API BackdropNodeGadget : public NodeGadget
 		int m_mergeGroupId;
 
 		boost::optional<Imath::Color3f> m_userColor;
+		boost::optional<std::string> m_numericBookmark;
 
 		static NodeGadgetTypeDescription<BackdropNodeGadget> g_nodeGadgetTypeDescription;
 

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -145,6 +145,7 @@ class GAFFERUI_API StandardNodeGadget : public NodeGadget
 		void updateNodeEnabled( const Gaffer::Plug *dirtiedPlug = nullptr );
 		void updateIcon();
 		bool updateShape();
+		bool updateNumericBookmark();
 
 		IE_CORE_FORWARDDECLARE( ErrorGadget );
 		ErrorGadget *errorGadget( bool createIfMissing = true );
@@ -161,7 +162,7 @@ class GAFFERUI_API StandardNodeGadget : public NodeGadget
 		ConnectionCreator *m_dragDestination;
 		boost::optional<Imath::Color3f> m_userColor;
 		bool m_oval;
-
+		boost::optional<std::string> m_numericBookmark;
 };
 
 IE_CORE_DECLAREPTR( StandardNodeGadget )

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -435,6 +435,39 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 		self.assertTrue( Gaffer.MetadataAlgo.getBookmarked( s["OldBookmarked"] ) )
 		self.assertEqual( len( Gaffer.Metadata.registeredValues( s["OldBookmarked"], instanceOnly = True ) ), 1 )
 
+	def testNumericBookmarks( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n1"] = Gaffer.Node()
+		s["n2"] = Gaffer.Node()
+
+		Gaffer.MetadataAlgo.setNumericBookmark( s, 1, s["n1"] )
+
+		self.assertEqual( Gaffer.MetadataAlgo.getNumericBookmark( s, 1 ), s["n1"] )
+		self.assertEqual( Gaffer.MetadataAlgo.numericBookmark( s["n1"] ), 1 )
+
+		Gaffer.MetadataAlgo.setNumericBookmark( s, 1, s["n2"] )  # moving the bookmark
+
+		self.assertEqual( Gaffer.MetadataAlgo.numericBookmark( s["n1"] ), 0 )
+		self.assertEqual( Gaffer.MetadataAlgo.getNumericBookmark( s, 1 ), s["n2"] )
+		self.assertEqual( Gaffer.MetadataAlgo.numericBookmark( s["n2"] ), 1 )
+
+		Gaffer.MetadataAlgo.setNumericBookmark( s, 1, None )
+
+		self.assertEqual( Gaffer.MetadataAlgo.getNumericBookmark( s, 1 ), None )
+		self.assertEqual( Gaffer.MetadataAlgo.numericBookmark( s["n2"] ), 0 )
+
+	def testNumericBookmarkAffectedByChange( self ) :
+
+		# The naming convention for valid numeric bookmarks is "numericBookmark<1-9>"
+		for i in range( 1, 10 ) :
+			self.assertTrue( Gaffer.MetadataAlgo.numericBookmarkAffectedByChange( "numericBookmark%s" % i ) )
+
+		self.assertFalse( Gaffer.MetadataAlgo.numericBookmarkAffectedByChange( "numericBookmark0" ) )
+		self.assertFalse( Gaffer.MetadataAlgo.numericBookmarkAffectedByChange( "numericBookmark-1" ) )
+		self.assertFalse( Gaffer.MetadataAlgo.numericBookmarkAffectedByChange( "numericBookmark10" ) )
+		self.assertFalse( Gaffer.MetadataAlgo.numericBookmarkAffectedByChange( "foo" ) )
+
 	def tearDown( self ) :
 
 		for n in ( Gaffer.Node, Gaffer.Box, GafferTest.AddNode ) :

--- a/python/GafferUI/GraphBookmarksUI.py
+++ b/python/GafferUI/GraphBookmarksUI.py
@@ -60,6 +60,24 @@ def appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition ) :
 		}
 	)
 
+	for i in range( 1, 10 ) :
+	  menuDefinition.append(
+		  "/Numeric Bookmark/%s" % i,
+		  {
+			  "command" : functools.partial( __assignNumericBookmark, node, i ),
+			  "shortCut" : "Ctrl+%i" % i,
+		  }
+	  )
+
+	menuDefinition.append(
+		"/Numeric Bookmark/Remove",
+		{
+			"command" : functools.partial( __assignNumericBookmark, node, 0 ),
+			"shortCut" : "Ctrl+0",
+			"active" : Gaffer.MetadataAlgo.numericBookmark( node )
+		}
+	)
+
 def appendPlugContextMenuDefinitions( graphEditor, plug, menuDefinition ) :
 
 	parent = graphEditor.graphGadget().getRoot()
@@ -113,6 +131,15 @@ def appendNodeSetMenuDefinitions( editor, menuDefinition ) :
 		}
 	)
 
+	for i in range( 1, 10 ) :
+	  menuDefinition.append(
+		  "/Numeric Bookmark/%s" % i,
+		  {
+			  "command" : functools.partial( __findNumericBookmark, editor, i ),
+			  "active" : Gaffer.MetadataAlgo.getNumericBookmark( editor.scriptNode(), i ) is not None,
+		  }
+	  )
+
 	bookmarks = __findableBookmarks( editor )
 	menuDefinition.append(
 		"/Find Bookmark...",
@@ -123,9 +150,9 @@ def appendNodeSetMenuDefinitions( editor, menuDefinition ) :
 		}
 	)
 
-def popupFindBookmarkMenu( editor ) :
+def connectToEditor( editor ) :
 
-	__findBookmark( editor )
+	editor.keyPressSignal().connect( __editorKeyPress, scoped = False )
 
 ##########################################################################
 # Internal implementation
@@ -206,7 +233,7 @@ def __findBookmark( editor, bookmarks = None ) :
 
 	# Don't modify the contents of floating windows, because these are
 	# expected to be locked to one node.
-	if editor.ancestor( GafferUI.CompoundEditor ) is  None :
+	if editor.ancestor( GafferUI.CompoundEditor ) is None :
 		return False
 
 	if bookmarks is None :
@@ -243,4 +270,77 @@ def __findBookmark( editor, bookmarks = None ) :
 	editor.__findBookmarksMenu.popup()
 
 	return True
+
+def __assignNumericBookmark( node, numericBookmark ) :
+
+	with Gaffer.UndoScope( node.scriptNode() ) :
+		if numericBookmark == 0 : # Remove the current numeric bookmark from selection
+			current = Gaffer.MetadataAlgo.numericBookmark( node )
+			if current :
+				Gaffer.MetadataAlgo.setNumericBookmark( node.scriptNode(), current, None )
+		else :
+			Gaffer.MetadataAlgo.setNumericBookmark( node.scriptNode(), numericBookmark, node )
+
+def __findNumericBookmark( editor, numericBookmark ) :
+
+	if not isinstance( editor, ( GafferUI.NodeSetEditor, GafferUI.GraphEditor ) ) :
+		return False
+
+	# Don't modify the contents of floating windows, because these are
+	# expected to be locked to one node.
+	if editor.ancestor( GafferUI.CompoundEditor ) is None :
+		return False
+
+	node = Gaffer.MetadataAlgo.getNumericBookmark( editor.scriptNode(), numericBookmark )
+	if not node :
+		return False
+
+	if isinstance( editor, GafferUI.GraphEditor ) :
+		editor.graphGadget().setRoot( node.parent() )
+		editor.frame( [ node ] )
+	else :
+		editor.setNodeSet( Gaffer.StandardSet( [ node ] ) )
+
+	return True
+
+def __editorKeyPress( editor, event ) :
+
+	if event.key == "B" and event.modifiers == event.modifiers.Control :
+		return __findBookmark( editor )
+
+	if event.key in [ str( x ) for x in range( 0, 10 ) ] :
+
+		numericBookmark = int( event.key )
+
+		if event.modifiers == event.modifiers.Control :
+
+			# Assign
+
+			node = None
+			if isinstance( editor, GafferUI.GraphEditor ) :
+				selection = editor.scriptNode().selection()
+				if len( selection ) == 1 :
+					node = selection[0]
+				else :
+					backdrops = [ n for n in selection if isinstance( n, Gaffer.Backdrop ) ]
+					if len( backdrops ) == 1 :
+						node = backdrops[0]
+			elif isinstance( editor, GafferUI.NodeSetEditor ) :
+				nodeSet = editor.getNodeSet()
+				node = nodeSet[-1] if len( nodeSet ) else None
+
+			if node is not None :
+				__assignNumericBookmark( node, numericBookmark )
+
+		elif not event.modifiers :
+
+			# Find
+
+			if numericBookmark != 0 :
+				__findNumericBookmark( editor, numericBookmark )
+			elif isinstance( editor, GafferUI.NodeSetEditor ) :
+				editor.setNodeSet( editor.scriptNode().selection() )
+
+		return True
+
 

--- a/python/GafferUI/GraphBookmarksUI.py
+++ b/python/GafferUI/GraphBookmarksUI.py
@@ -229,18 +229,18 @@ def __findableBookmarks( editor ) :
 def __findBookmark( editor, bookmarks = None ) :
 
 	if not isinstance( editor, ( GafferUI.NodeSetEditor, GafferUI.GraphEditor ) ) :
-		return False
+		return
 
 	# Don't modify the contents of floating windows, because these are
 	# expected to be locked to one node.
 	if editor.ancestor( GafferUI.CompoundEditor ) is None :
-		return False
+		return
 
 	if bookmarks is None :
 		bookmarks = __findableBookmarks( editor )
 
 	if not bookmarks :
-		return False
+		return
 
 	scriptNode = editor.scriptNode()
 	pathsAndNodes = [
@@ -268,8 +268,6 @@ def __findBookmark( editor, bookmarks = None ) :
 
 	editor.__findBookmarksMenu = GafferUI.Menu( menuDefinition, title = "Find Bookmark", searchable = True )
 	editor.__findBookmarksMenu.popup()
-
-	return True
 
 def __assignNumericBookmark( node, numericBookmark ) :
 
@@ -306,7 +304,8 @@ def __findNumericBookmark( editor, numericBookmark ) :
 def __editorKeyPress( editor, event ) :
 
 	if event.key == "B" and event.modifiers == event.modifiers.Control :
-		return __findBookmark( editor )
+		__findBookmark( editor )
+		return True
 
 	if event.key in [ str( x ) for x in range( 0, 10 ) ] :
 

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -151,12 +151,12 @@
      borderopacity="1"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="22.627417"
-     inkscape:cx="23.177134"
-     inkscape:cy="902.03181"
+     inkscape:zoom="2"
+     inkscape:cx="567.80162"
+     inkscape:cy="207.82982"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
-     showgrid="false"
+     showgrid="true"
      inkscape:window-width="1920"
      inkscape:window-height="1016"
      inkscape:window-x="0"
@@ -3534,24 +3534,6 @@
          style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     </g>
     <g
-       id="forExport:bookmark"
-       inkscape:label="#g3320">
-      <path
-         inkscape:label="#path6329"
-         sodipodi:nodetypes="cccccc"
-         inkscape:connector-curvature="0"
-         id="bookmark"
-         d="m 420,572.36218 0,170 39.77385,-42.92785 40.22615,42.92785 0,-170 z"
-         style="fill:#bb2b2b;fill-opacity:1;stroke:#262626;stroke-width:20;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <rect
-         y="561.36218"
-         x="409"
-         height="192"
-         width="102"
-         id="rect3318"
-         style="fill:none;stroke:none" />
-    </g>
-    <g
        id="forExport:gafferSceneUICameraTool"
        inkscape:label="#g5318">
       <g
@@ -3887,5 +3869,39 @@
        height="1.5"
        x="26"
        y="147.36218" />
+    <path
+       sodipodi:type="star"
+       style="fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:#262626;stroke-width:0.49690737;stroke-linejoin:round;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="forExport:bookmarkStar"
+       sodipodi:sides="5"
+       sodipodi:cx="298.875"
+       sodipodi:cy="13.687498"
+       sodipodi:r1="5.8454323"
+       sodipodi:r2="2.2924397"
+       sodipodi:arg1="0.94448073"
+       sodipodi:arg2="1.5727992"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 302.30138,18.423424 -3.43097,-2.443491 -3.44073,2.429728 1.26367,-4.018128 -3.37406,-2.521504 4.21197,-0.03985 1.35545,-3.9881025 1.33946,3.9935005 4.21177,0.05672 -3.38412,2.507967 z"
+       transform="matrix(15.92185,0,0,16.279294,-4268.7575,656.02335)"
+       inkscape:label="#path3064" />
+    <path
+       sodipodi:type="star"
+       style="fill:#efc618;fill-opacity:0.99215686;fill-rule:nonzero;stroke:#262626;stroke-width:0.49683791;stroke-linejoin:round;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="forExport:bookmarkStar2"
+       sodipodi:sides="5"
+       sodipodi:cx="298.875"
+       sodipodi:cy="13.687498"
+       sodipodi:r1="5.8454323"
+       sodipodi:r2="2.2924397"
+       sodipodi:arg1="0.94448073"
+       sodipodi:arg2="1.5727992"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 302.30138,18.423424 -3.43097,-2.443491 -3.44073,2.429728 1.26367,-4.018128 -3.37406,-2.521504 4.21197,-0.03985 1.35545,-3.9881025 1.33946,3.9935005 4.21177,0.05672 -3.38412,2.507967 z"
+       transform="matrix(15.926225,0,0,16.279373,-4039.9249,656.02277)"
+       inkscape:label="#path3064" />
   </g>
 </svg>

--- a/src/GafferModule/MetadataAlgoBinding.cpp
+++ b/src/GafferModule/MetadataAlgoBinding.cpp
@@ -42,6 +42,7 @@
 #include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/Node.h"
 #include "Gaffer/Plug.h"
+#include "Gaffer/ScriptNode.h"
 
 #include "IECorePython/ScopedGILRelease.h"
 
@@ -82,6 +83,17 @@ boost::python::list bookmarksWrapper( const Node *node )
 	}
 
 	return result;
+}
+
+void setNumericBookmarkWrapper( ScriptNode &scriptNode, int bookmark, NodePtr node )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	setNumericBookmark( &scriptNode, bookmark, node.get() );
+}
+
+NodePtr getNumericBookmarkWrapper( ScriptNode &scriptNode, int bookmark )
+{
+	return getNumericBookmark( &scriptNode, bookmark );
 }
 
 void copyWrapper( const GraphComponent &from, GraphComponent &to, const IECore::StringAlgo::MatchPattern &exclude, bool persistentOnly, bool persistent )
@@ -129,6 +141,12 @@ void GafferModule::bindMetadataAlgo()
 	def( "getBookmarked", &getBookmarked );
 	def( "bookmarkedAffectedByChange", &bookmarkedAffectedByChange );
 	def( "bookmarks", &bookmarksWrapper );
+
+	def( "setNumericBookmark", &setNumericBookmarkWrapper, ( arg( "scriptNode" ), arg( "bookmark" ), arg( "node" ) ) );
+	def( "getNumericBookmark", &getNumericBookmarkWrapper, ( arg( "scriptNode" ), arg( "bookmark" ) ) );
+	def( "numericBookmark", &numericBookmark, ( arg( "node" ) ) );
+	def( "numericBookmarkAffectedByChange", &numericBookmarkAffectedByChange, ( arg( "changedKey" ) ) );
+
 	def(
 		"affectedByChange",
 		(bool (*)( const Plug *, IECore::TypeId, const IECore::StringAlgo::MatchPattern &, const Plug * ))&affectedByChange,

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -440,6 +440,13 @@ void StandardNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 				style->renderLine( IECore::LineSegment3f( V3f( b.min.x, b.min.y, 0 ), V3f( b.max.x, b.max.y, 0 ) ) );
 			}
 
+			/// \todo This bookmark drawing code is duplicated in the BackdropNodeGadget.
+			/// Consolidate into a NodeAnnotationsGadget that operates a bit like the
+			/// AuxiliaryConnectionsGadget, drawing annotations for all nodes using a single
+			/// gadget. This could also render arbitrary annotations defined by metadata
+			/// matching "annotation:*", which we could then use to display things like
+			/// monitor statistics, asset management information etc.
+
 			bool isBookmarked = MetadataAlgo::getBookmarked( node() );
 			if( isBookmarked )
 			{

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -160,7 +160,7 @@ IECoreGL::Texture *bookmarkTexture()
 
 	if( !bookmarkTexture )
 	{
-		bookmarkTexture = ImageGadget::textureLoader()->load( "bookmark.png" );
+		bookmarkTexture = ImageGadget::textureLoader()->load( "bookmarkStar2.png" );
 
 		IECoreGL::Texture::ScopedBinding binding( *bookmarkTexture );
 		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR );
@@ -169,6 +169,23 @@ IECoreGL::Texture *bookmarkTexture()
 		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
 	}
 	return bookmarkTexture.get();
+}
+
+IECoreGL::Texture *numericBookmarkTexture()
+{
+	static IECoreGL::TexturePtr numericBookmarkTexture;
+
+	if( !numericBookmarkTexture )
+	{
+		numericBookmarkTexture = ImageGadget::textureLoader()->load( "bookmarkStar.png" );
+
+		IECoreGL::Texture::ScopedBinding binding( *numericBookmarkTexture );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
+	}
+	return numericBookmarkTexture.get();
 }
 
 bool canConnect( const DragDropEvent &event, const ConnectionCreator *destination )
@@ -363,6 +380,7 @@ StandardNodeGadget::StandardNodeGadget( Gaffer::NodePtr node )
 	updateNodeEnabled();
 	updateIcon();
 	updateShape();
+	updateNumericBookmark();
 }
 
 StandardNodeGadget::~StandardNodeGadget()
@@ -409,22 +427,42 @@ void StandardNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 				m_userColor.get_ptr()
 			);
 
-			if( MetadataAlgo::getBookmarked( node() ) )
-			{
-				style->renderImage( Box2f( V2f( b.min.x + 1.125, b.max.y - 1.25 ), V2f( b.min.x + 1.875, b.max.y + 0.25 ) ), bookmarkTexture() );
-			}
-
 			break;
 		}
 		case GraphLayer::Overlay :
 		{
+			const Box3f b = bound();
+
 			if( !m_nodeEnabled && !IECoreGL::Selector::currentSelector() )
 			{
-				const Box3f b = bound();
 				/// \todo Replace renderLine() with a specific method (renderNodeStrikeThrough?) on the Style class
 				/// so that styles can do customised drawing based on knowledge of what is being drawn.
 				style->renderLine( IECore::LineSegment3f( V3f( b.min.x, b.min.y, 0 ), V3f( b.max.x, b.max.y, 0 ) ) );
 			}
+
+			bool isBookmarked = MetadataAlgo::getBookmarked( node() );
+			if( isBookmarked )
+			{
+				style->renderImage( Box2f( V2f( b.min.x - 1.0, b.max.y - 1.0 ), V2f( b.min.x + 1.0, b.max.y + 1.0 ) ), bookmarkTexture() );
+			}
+
+			if( m_numericBookmark )
+			{
+
+				if( !isBookmarked )
+				{
+					style->renderImage( Box2f( V2f( b.min.x - 1.0, b.max.y - 1.0 ), V2f( b.min.x + 1.0, b.max.y + 1.0 ) ), numericBookmarkTexture() );
+				}
+
+				Box3f textBounds = style->textBound( Style::LabelText, *m_numericBookmark );
+
+				Imath::Color3f textColor( 1.0f );
+				glPushMatrix();
+				IECoreGL::glTranslate( V2f( b.min.x + 1.0 - textBounds.size().x * 0.5, b.max.y - textBounds.size().y * 0.5 - 0.7 ) );
+				style->renderText( Style::LabelText, *m_numericBookmark, Style::NormalState, &textColor );
+				glPopMatrix();
+			}
+
 			break;
 		}
 		default :
@@ -809,6 +847,13 @@ void StandardNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore:
 	{
 		requestRender();
 	}
+	else if( MetadataAlgo::numericBookmarkAffectedByChange( key ) )
+	{
+		if( updateNumericBookmark() )
+		{
+			requestRender();
+		}
+	}
 }
 
 bool StandardNodeGadget::updateUserColor()
@@ -921,6 +966,28 @@ bool StandardNodeGadget::updateShape()
 		return false;
 	}
 	m_oval = oval;
+	return true;
+}
+
+bool StandardNodeGadget::updateNumericBookmark()
+{
+	int cached = m_numericBookmark ? stoi( *m_numericBookmark ) : 0;
+	int bookmark = MetadataAlgo::numericBookmark( this->node() );
+
+	if( cached == bookmark )
+	{
+		return false;
+	}
+
+	if( bookmark )
+	{
+		m_numericBookmark = std::to_string( bookmark );
+	}
+	else
+	{
+		m_numericBookmark = boost::none;
+	}
+
 	return true;
 }
 

--- a/startup/gui/editor.py
+++ b/startup/gui/editor.py
@@ -36,16 +36,9 @@
 
 import GafferUI
 
-def __editorKeyPress( editor, event ) :
-
-	if event.key == "B" and event.modifiers == event.modifiers.Control :
-		return GafferUI.GraphBookmarksUI.popupFindBookmarkMenu( editor )
-
-	return False
-
 def __editorCreated( editor ) :
 
-	editor.keyPressSignal().connect( __editorKeyPress, scoped = False )
+	GafferUI.GraphBookmarksUI.connectToEditor( editor )
 
 GafferUI.Editor.instanceCreatedSignal().connect( __editorCreated, scoped = False )
 


### PR DESCRIPTION
This is a slight reworking of #2729, to back out of a dead end I'd sent @mattigruener down. I've also included @andrewkaufman's fix from #2972 because it inevitably conflicts with this work either way. Matti, I've basically just shuffled the code around in GraphBookmarksUI as follows :

- Kept the previous public API for appending menu items. This was the cause of the dead-end, because the configs need greater control over ordering than a single `connect()` method could provide.
- Replaced the old `popupFindBookmarksMenu()` function with a `connectToEditor()` function that gives GraphBookmarksUI the leeway it needs to add more keypress handling. It felt wrong to manage the keypresses on the config side as we were doing before, because the GraphBookmarksUI code is where we advertise them via the shortcuts on the menu items. Now they can't be out of sync because a config chose different keypresses.
- Fixed right-click menu to operate on the clicked-upon node, not the selection.
- Greyed out inactive bookmarks in the pinning menu.

Could you give it a quick once over so we can finally put this to rest? Thanks for bearing with me through all this...