### PR TITLE
gui app : Fix keypress handling of Ctrl+B

### DIFF
--- a/startup/gui/editor.py
+++ b/startup/gui/editor.py
@@ -39,7 +39,8 @@ import GafferUI
 def __editorKeyPress( editor, event ) :
 
 	if event.key == "B" and event.modifiers == event.modifiers.Control :
-		return GafferUI.GraphBookmarksUI.popupFindBookmarkMenu( editor )
+		GafferUI.GraphBookmarksUI.popupFindBookmarkMenu( editor )
+		return True
 
 	return False
 


### PR DESCRIPTION
`GafferUI.GraphBookmarksUI.popupFindBookmarkMenu()` returns None regardless of whether it found bookmarks, so isn't appropriate for determining if the Editor should handle the event.

We instead unconditionally handle Ctrl+B so it isn't forwarded on to other widgets (eg a host application like Maya).

This is a backport of #2972 