### PR TITLE
Dot/ContextProcess/Switch/Loop : Serialise using `setup()` method

### DIFF
--- a/python/GafferTest/ContextVariablesTest.py
+++ b/python/GafferTest/ContextVariablesTest.py
@@ -181,5 +181,24 @@ class ContextVariablesTest( GafferTest.TestCase ) :
 		self.assertEqual( len( cs ), 2 )
 		self.assertEqual( { x[0] for x in cs }, { c["enabled"], c["out"] } )
 
+	def testSerialisationUsesSetup( self ) :
+
+		s1 = Gaffer.ScriptNode()
+		s1["c"] = Gaffer.ContextVariables()
+		s1["c"].setup( Gaffer.IntPlug() )
+
+		ss = s1.serialise()
+		self.assertIn( "setup", ss )
+		self.assertEqual( ss.count( "addChild" ), 1 )
+		self.assertNotIn( "Dynamic", ss )
+		self.assertNotIn( "setInput", ss )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( ss )
+		self.assertIn( "in", s2["c"] )
+		self.assertIn( "out", s2["c"] )
+		self.assertIsInstance( s2["c"]["in"], Gaffer.IntPlug )
+		self.assertIsInstance( s2["c"]["out"], Gaffer.IntPlug )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/DotTest.py
+++ b/python/GafferTest/DotTest.py
@@ -190,5 +190,24 @@ class DotTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( s["d"]["out"], "connectionGadget:color" ), connectionColor )
 		self.assertEqual( Gaffer.Metadata.value( s["d"]["out"], "nodule:color" ), noodleColor )
 
+	def testSerialisationUsesSetup( self ) :
+
+		s1 = Gaffer.ScriptNode()
+		s1["d"] = Gaffer.Dot()
+		s1["d"].setup( Gaffer.IntPlug() )
+
+		ss = s1.serialise()
+		self.assertIn( "setup", ss )
+		self.assertEqual( ss.count( "addChild" ), 1 )
+		self.assertNotIn( "Dynamic", ss )
+		self.assertNotIn( "setInput", ss )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( ss )
+		self.assertIn( "in", s2["d"] )
+		self.assertIn( "out", s2["d"] )
+		self.assertIsInstance( s2["d"]["in"], Gaffer.IntPlug )
+		self.assertIsInstance( s2["d"]["out"], Gaffer.IntPlug )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/LoopTest.py
+++ b/python/GafferTest/LoopTest.py
@@ -199,5 +199,27 @@ class LoopTest( GafferTest.TestCase ) :
 		self.assertIsInstance( n["previous"], Gaffer.StringPlug )
 		self.assertIsInstance( n["next"], Gaffer.StringPlug )
 
+	def testSerialisationUsesSetup( self ) :
+
+		s1 = Gaffer.ScriptNode()
+		s1["c"] = Gaffer.Loop()
+		s1["c"].setup( Gaffer.IntPlug() )
+
+		ss = s1.serialise()
+		self.assertIn( "setup", ss )
+		self.assertEqual( ss.count( "addChild" ), 1 )
+		self.assertNotIn( "Dynamic", ss )
+		self.assertNotIn( "Serialisable", ss )
+		self.assertNotIn( "setInput", ss )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( ss )
+		self.assertIn( "in", s2["c"] )
+		self.assertIn( "out", s2["c"] )
+		self.assertIsInstance( s2["c"]["in"], Gaffer.IntPlug )
+		self.assertIsInstance( s2["c"]["out"], Gaffer.IntPlug )
+		self.assertIsInstance( s2["c"]["previous"], Gaffer.IntPlug )
+		self.assertIsInstance( s2["c"]["next"], Gaffer.IntPlug )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/SwitchTest.py
+++ b/python/GafferTest/SwitchTest.py
@@ -486,6 +486,26 @@ class SwitchTest( GafferTest.TestCase ) :
 		n2["op1"].setValue( 10 )
 		self.assertNotIn( s["out"], { x[0] for x in cs } )
 
+	def testSerialisationUsesSetup( self ) :
+
+		s1 = Gaffer.ScriptNode()
+		s1["switch"] = Gaffer.Switch()
+		s1["switch"].setup( Gaffer.IntPlug() )
+
+		ss = s1.serialise()
+		self.assertIn( "setup", ss )
+		self.assertEqual( ss.count( "addChild" ), 1 )
+		self.assertNotIn( "Dynamic", ss )
+		self.assertNotIn( "Serialisable", ss )
+		self.assertNotIn( "setInput", ss )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( ss )
+		self.assertIn( "in", s2["switch"] )
+		self.assertIn( "out", s2["switch"] )
+		self.assertIsInstance( s2["switch"]["in"][0], Gaffer.IntPlug )
+		self.assertIsInstance( s2["switch"]["out"], Gaffer.IntPlug )
+
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )

--- a/src/Gaffer/ContextProcessor.cpp
+++ b/src/Gaffer/ContextProcessor.cpp
@@ -73,12 +73,11 @@ void ContextProcessor::setup( const ValuePlug *plug )
 
 	PlugPtr in = plug->createCounterpart( g_inPlugName, Plug::In );
 	MetadataAlgo::copyColors( plug , in.get() , /* overwrite = */ false  );
-	in->setFlags( Plug::Dynamic | Plug::Serialisable, true );
+	in->setFlags( Plug::Serialisable, true );
 	addChild( in );
 
 	PlugPtr out = plug->createCounterpart( g_outPlugName, Plug::Out );
 	MetadataAlgo::copyColors( plug , out.get() , /* overwrite = */ false  );
-	out->setFlags( Plug::Dynamic | Plug::Serialisable, true );
 	addChild( out );
 }
 

--- a/src/Gaffer/Dot.cpp
+++ b/src/Gaffer/Dot.cpp
@@ -80,8 +80,8 @@ void Dot::setup( const Plug *plug )
 	MetadataAlgo::copyColors( originalPlug , in.get() , /* overwrite = */ false );
 	MetadataAlgo::copyColors( originalPlug , out.get() , /* overwrite = */ false );
 
-	in->setFlags( Plug::Dynamic | Plug::Serialisable, true );
-	out->setFlags( Plug::Dynamic | Plug::Serialisable, true );
+	in->setFlags( Plug::Serialisable, true );
+	out->setFlags( Plug::Serialisable, false ); // Avoid serialising internal connection
 
 	// Set up Metadata so our plugs appear in the right place. We must do this now rather
 	// than later because the GraphEditor will add a Nodule for the plug as soon as the plug

--- a/src/Gaffer/Loop.cpp
+++ b/src/Gaffer/Loop.cpp
@@ -72,12 +72,11 @@ void Loop::setup( const ValuePlug *plug )
 
 	PlugPtr in = plug->createCounterpart( "in", Plug::In );
 	MetadataAlgo::copyColors( plug , in.get() , /* overwrite = */ false  );
-	in->setFlags( Plug::Dynamic | Plug::Serialisable, true );
+	in->setFlags( Plug::Serialisable, true );
 	addChild( in );
 
 	PlugPtr out = plug->createCounterpart( "out", Plug::Out );
 	MetadataAlgo::copyColors( plug , out.get() , /* overwrite = */ false  );
-	out->setFlags( Plug::Dynamic | Plug::Serialisable, true );
 	addChild( out );
 }
 

--- a/src/Gaffer/Switch.cpp
+++ b/src/Gaffer/Switch.cpp
@@ -83,19 +83,18 @@ void Switch::setup( const Plug *plug )
 
 	PlugPtr inElement = plug->createCounterpart( "in0", Plug::In );
 	MetadataAlgo::copyColors( plug , inElement.get() , /* overwrite = */ false  );
-	inElement->setFlags( Plug::Dynamic | Plug::Serialisable, true );
+	inElement->setFlags( Plug::Serialisable, true );
 	ArrayPlugPtr in = new ArrayPlug(
 		g_inPlugsName,
 		Plug::In,
 		inElement,
 		0,
-		Imath::limits<size_t>::max(),
-		Plug::Default | Plug::Dynamic
+		Imath::limits<size_t>::max()
 	);
 	addChild( in );
 
 	PlugPtr out = plug->createCounterpart( g_outPlugName, Plug::Out );
-	out->setFlags( Plug::Dynamic | Plug::Serialisable, true );
+	out->setFlags( Plug::Serialisable, false ); // Avoid serialising internal connection
 	MetadataAlgo::copyColors( plug , out.get() , /* overwrite = */ false  );
 	addChild( out );
 }


### PR DESCRIPTION
This makes the serialisations slightly shorter, but more importantly means they are a better example for folks using them to learn the Gaffer scripting API.

I've deliberately allowed some duplication of logic in the serialisers, because the logic is subtly different for Switch anyway, and I'd rather duplicate some small bits of private code than commit to a public API prematurely. Added todos to this effect, with some thoughts as to an alternative approach.
