### PR TITLE
"Edit Source Node..." menu item

### DIFF
--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -155,6 +155,27 @@ GAFFERSCENE_API IECore::ConstCompoundDataPtr sets( const ScenePlug *scene, const
 /// for other object types we must return a synthetic bound.
 GAFFERSCENE_API Imath::Box3f bound( const IECore::Object *object );
 
+/// History
+/// =======
+///
+/// Methods to query the tree of upstream computations involved in computing
+/// a property of the scene.
+
+struct History : public IECore::RefCounted
+{
+	IE_CORE_DECLAREMEMBERPTR( History )
+	typedef std::vector<Ptr> Predecessors;
+
+	History() = default;
+	History( const ScenePlugPtr &scene, const Gaffer::ContextPtr &context ) : scene( scene ), context( context ) {}
+
+	ScenePlugPtr scene;
+	Gaffer::ContextPtr context;
+	Predecessors predecessors;
+};
+
+GAFFERSCENE_API History::Ptr history( const Gaffer::ValuePlug *scenePlugChild, const ScenePlug::ScenePath &path );
+
 } // namespace SceneAlgo
 
 } // namespace GafferScene

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -176,6 +176,9 @@ struct History : public IECore::RefCounted
 
 GAFFERSCENE_API History::Ptr history( const Gaffer::ValuePlug *scenePlugChild, const ScenePlug::ScenePath &path );
 
+/// Returns the upstream scene originally responsible for generating the specified location.
+GAFFERSCENE_API ScenePlug *source( const ScenePlug *scene, const ScenePlug::ScenePath &path );
+
 } // namespace SceneAlgo
 
 } // namespace GafferScene

--- a/python/GafferSceneUI/SceneHistoryUI.py
+++ b/python/GafferSceneUI/SceneHistoryUI.py
@@ -1,0 +1,108 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import Gaffer
+import GafferUI
+import GafferScene
+import GafferSceneUI
+
+def appendViewContextMenuItems( viewer, view, menuDefinition ) :
+
+	if not isinstance( view, GafferSceneUI.SceneView ) :
+		return None
+
+	selectedPath = __sceneViewSelectedPath( view )
+
+	menuDefinition.append(
+		"/Edit Source Node...",
+		{
+			"active" : selectedPath is not None,
+			"command" : functools.partial( __editSourceNode, view["in"], selectedPath ),
+			"shortCut" : "Ctrl+E",
+		}
+	)
+
+def connectToEditor( editor ) :
+
+	if isinstance( editor, GafferUI.Viewer ) :
+		editor.keyPressSignal().connect( __viewerKeyPress, scoped = False )
+
+##########################################################################
+# Internal implementation
+##########################################################################
+
+def __sceneViewSelectedPath( sceneView ) :
+
+	sceneGadget = sceneView.viewportGadget().getPrimaryChild()
+	if sceneGadget.getSelection().size() == 1 :
+		return sceneGadget.getSelection().paths()[0]
+	else :
+		return None
+
+def __editSourceNode( scene, path ) :
+
+	source = GafferScene.SceneAlgo.source( scene, path )
+	if source is None :
+		return
+
+	node = source.node()
+	node = __ancestorWithReadOnlyChildNodes( node ) or node
+	GafferUI.NodeEditor.acquire( node, floating = True )
+
+def __ancestorWithReadOnlyChildNodes( node ) :
+
+	result = None
+	while isinstance( node, Gaffer.Node ) :
+		if Gaffer.MetadataAlgo.getChildNodesAreReadOnly( node ) :
+			result = node
+		node = node.parent()
+
+	return result
+
+def __viewerKeyPress( viewer, event ) :
+
+	view = viewer.view()
+	if not isinstance( view, GafferSceneUI.SceneView ) :
+		return False
+
+	if event.key == "E" and event.modifiers == event.modifiers.Control :
+		selectedPath = __sceneViewSelectedPath( view )
+		if selectedPath is not None :
+			__editSourceNode( view["in"], selectedPath )
+		return True
+

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -45,6 +45,7 @@ from PrimitiveInspector import PrimitiveInspector
 from FilterPlugValueWidget import FilterPlugValueWidget
 from ScenePathPlugValueWidget import ScenePathPlugValueWidget
 from TweakPlugValueWidget import TweakPlugValueWidget
+import SceneHistoryUI
 
 import SceneNodeUI
 import SceneReaderUI

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -460,3 +460,20 @@ SceneAlgo::History::Ptr SceneAlgo::history( const Gaffer::ValuePlug *scenePlugCh
 	return historyWalk( monitor.rootProcesses().front().get(), scenePlugChild->getName(), nullptr );
 }
 
+ScenePlug *SceneAlgo::source( const ScenePlug *scene, const ScenePlug::ScenePath &path )
+{
+	History::ConstPtr h = history( scene->objectPlug(), path );
+	const History *c = h.get();
+	while( c )
+	{
+		if( c->predecessors.empty() )
+		{
+			return c->scene.get();
+		}
+		else
+		{
+			c = c->predecessors.front().get();
+		}
+	}
+	return nullptr;
+}

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -40,6 +40,8 @@
 #include "GafferScene/ScenePlug.h"
 
 #include "Gaffer/Context.h"
+#include "Gaffer/Monitor.h"
+#include "Gaffer/Process.h"
 
 #include "IECoreScene/Camera.h"
 #include "IECoreScene/ClippingPlane.h"
@@ -47,9 +49,11 @@
 #include "IECoreScene/MatrixMotionTransform.h"
 #include "IECoreScene/VisibleRenderable.h"
 
+#include "IECore/MessageHandler.h"
 #include "IECore/NullObject.h"
 
 #include "boost/algorithm/string/predicate.hpp"
+#include "boost/unordered_map.hpp"
 
 #include "tbb/parallel_for.h"
 #include "tbb/spin_mutex.h"
@@ -303,3 +307,156 @@ Imath::Box3f GafferScene::SceneAlgo::bound( const IECore::Object *object )
 		return Imath::Box3f();
 	}
 }
+
+//////////////////////////////////////////////////////////////////////////
+// History
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+struct CapturedProcess
+{
+
+	typedef std::unique_ptr<CapturedProcess> Ptr;
+	typedef vector<Ptr> PtrVector;
+
+	InternedString type;
+	ConstPlugPtr plug;
+	ContextPtr context;
+
+	PtrVector children;
+
+};
+
+/// \todo Perhaps add this to the Gaffer module as a
+/// public class, and expose it within the stats app?
+/// Give a bit more thought to the CapturedProcess
+/// class if doing this.
+class CapturingMonitor : public Monitor
+{
+
+	public :
+
+		CapturingMonitor()
+		{
+		}
+
+		~CapturingMonitor() override
+		{
+		}
+
+		const CapturedProcess::PtrVector &rootProcesses()
+		{
+			return m_rootProcesses;
+		}
+
+	protected :
+
+		void processStarted( const Process *process ) override
+		{
+			CapturedProcess::Ptr capturedProcess( new CapturedProcess );
+			capturedProcess->type = process->type();
+			capturedProcess->plug = process->plug();
+			capturedProcess->context = new Context( *process->context() );
+
+			Mutex::scoped_lock lock( m_mutex );
+
+			m_processMap[process] = capturedProcess.get();
+
+			if( process->parent() )
+			{
+				ProcessMap::const_iterator it = m_processMap.find( process->parent() );
+				if( it != m_processMap.end() )
+				{
+					it->second->children.push_back( std::move( capturedProcess ) );
+				}
+				else
+				{
+					// We've been called for a process whose parent we have not
+					// been called for. This shouldn't happen, but currently it
+					// can if another thread is doing unrelated computes while we're
+					// trying to capture the transform computes on the UI thread.
+					// We need our scope to be limited to processes that originate
+					// from the thread our Process::Scope is on, but that is not the
+					// case (see #2806). The best we can do is ignore this, but we
+					// could still crash if a background process accesses us after
+					// we're destroyed. Output a warning so we have a trail of
+					// breadcrumbs for the future.
+					IECore::msg( IECore::Msg::Warning, "CapturingMonitor", "Unscoped process encountered" );
+				}
+			}
+			else
+			{
+				m_rootProcesses.push_back( std::move( capturedProcess ) );
+			}
+		}
+
+		void processFinished( const Process *process ) override
+		{
+			Mutex::scoped_lock lock( m_mutex );
+			m_processMap.erase( process );
+		}
+
+	private :
+
+		typedef tbb::spin_mutex Mutex;
+
+		Mutex m_mutex;
+		typedef boost::unordered_map<const Process *, CapturedProcess *> ProcessMap;
+		ProcessMap m_processMap;
+		CapturedProcess::PtrVector m_rootProcesses;
+
+};
+
+InternedString g_contextUniquefierName = "__sceneAlgoHistory:uniquefier";
+uint64_t g_contextUniquefierValue = 0;
+
+SceneAlgo::History::Ptr historyWalk( const CapturedProcess *process, InternedString scenePlugChildName, SceneAlgo::History *parent )
+{
+	SceneAlgo::History::Ptr history;
+	ScenePlug *scene = const_cast<Plug *>( process->plug.get() )->parent<ScenePlug>();
+	if( scene && process->plug.get() == scene->getChild( scenePlugChildName ) )
+	{
+		history = new SceneAlgo::History( scene, process->context );
+	}
+
+	if( parent && history )
+	{
+		parent->predecessors.push_back( history );
+	}
+
+	parent = history ? history.get() : parent;
+	assert( parent );
+
+	for( const auto &p : process->children )
+	{
+		historyWalk( p.get(), scenePlugChildName, parent );
+	}
+
+	return history;
+}
+
+} // namespace
+
+SceneAlgo::History::Ptr SceneAlgo::history( const Gaffer::ValuePlug *scenePlugChild, const ScenePlug::ScenePath &path )
+{
+	if( !scenePlugChild->parent<ScenePlug>() )
+	{
+		throw IECore::Exception( boost::str(
+			boost::format( "Plug \"%1%\" is not a child of a ScenePlug." ) % scenePlugChild->fullName()
+		) );
+	}
+
+	CapturingMonitor monitor;
+	{
+		ScenePlug::PathScope pathScope( Context::current(), path );
+		// Trick to bypass the hash cache and get a full upstream evaluation.
+		pathScope.set( g_contextUniquefierName, g_contextUniquefierValue++ );
+		Monitor::Scope monitorScope( &monitor );
+		scenePlugChild->hash();
+	}
+	assert( monitor.rootProcesses().size() == 1 );
+	return historyWalk( monitor.rootProcesses().front().get(), scenePlugChild->getName(), nullptr );
+}
+

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -141,10 +141,16 @@ void historySetContext( SceneAlgo::History &h, const Gaffer::ContextPtr &c )
 	h.context = c;
 }
 
-SceneAlgo::History::Ptr historyWrapper( const ValuePlug *scenePlugChild, const ScenePlug::ScenePath &path )
+SceneAlgo::History::Ptr historyWrapper( const ValuePlug &scenePlugChild, const ScenePlug::ScenePath &path )
 {
 	IECorePython::ScopedGILRelease r;
-	return SceneAlgo::history( scenePlugChild, path );
+	return SceneAlgo::history( &scenePlugChild, path );
+}
+
+ScenePlugPtr sourceWrapper( const ScenePlug &scene, const ScenePlug::ScenePath &path )
+{
+	IECorePython::ScopedGILRelease r;
+	return SceneAlgo::source( &scene, path );
 }
 
 } // namespace
@@ -193,6 +199,7 @@ void bindSceneAlgo()
 	}
 
 	def( "history", &historyWrapper );
+	def( "source", &sourceWrapper );
 
 }
 

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -44,12 +44,15 @@
 
 #include "IECoreScene/Camera.h"
 
+#include "IECorePython/RefCountedBinding.h"
 #include "IECorePython/ScopedGILRelease.h"
 
 #include "boost/python/suite/indexing/container_utils.hpp"
+#include "boost/python/suite/indexing/vector_indexing_suite.hpp"
 
 using namespace boost::python;
 using namespace IECore;
+using namespace Gaffer;
 using namespace GafferScene;
 
 namespace
@@ -118,6 +121,32 @@ IECore::CompoundDataPtr setsWrapper2( const ScenePlug *scene, object pythonSetNa
 	return copy ? result->copy() : boost::const_pointer_cast<IECore::CompoundData>( result );
 }
 
+ScenePlugPtr historyGetScene( SceneAlgo::History &h )
+{
+	return h.scene;
+}
+
+void historySetScene( SceneAlgo::History &h, const ScenePlugPtr &s )
+{
+	h.scene = s;
+}
+
+Gaffer::ContextPtr historyGetContext( SceneAlgo::History &h )
+{
+	return h.context;
+}
+
+void historySetContext( SceneAlgo::History &h, const Gaffer::ContextPtr &c )
+{
+	h.context = c;
+}
+
+SceneAlgo::History::Ptr historyWrapper( const ValuePlug *scenePlugChild, const ScenePlug::ScenePath &path )
+{
+	IECorePython::ScopedGILRelease r;
+	return SceneAlgo::history( scenePlugChild, path );
+}
+
 } // namespace
 
 namespace GafferSceneModule
@@ -146,6 +175,25 @@ void bindSceneAlgo()
 		&setsWrapper2,
 		( arg( "scene" ), arg( "setNames" ), arg( "_copy" ) = true )
 	);
+
+	// History
+
+	{
+		scope s = IECorePython::RefCountedClass<SceneAlgo::History, IECore::RefCounted>( "History" )
+			.def( init<>() )
+			.def( init<ScenePlugPtr, Gaffer::ContextPtr>() )
+			.add_property( "scene", &historyGetScene, &historySetScene )
+			.add_property( "context", &historyGetContext, &historySetContext )
+			.def_readonly( "predecessors", &SceneAlgo::History::predecessors )
+		;
+
+		class_<SceneAlgo::History::Predecessors>( "Predecessors" )
+			.def( vector_indexing_suite<SceneAlgo::History::Predecessors, true>() )
+		;
+	}
+
+	def( "history", &historyWrapper );
+
 }
 
 } // namespace GafferSceneModule

--- a/startup/gui/editor.py
+++ b/startup/gui/editor.py
@@ -35,10 +35,12 @@
 ##########################################################################
 
 import GafferUI
+import GafferSceneUI
 
 def __editorCreated( editor ) :
 
 	GafferUI.GraphBookmarksUI.connectToEditor( editor )
+	GafferSceneUI.SceneHistoryUI.connectToEditor( editor )
 
 GafferUI.Editor.instanceCreatedSignal().connect( __editorCreated, scoped = False )
 

--- a/startup/gui/viewer.py
+++ b/startup/gui/viewer.py
@@ -65,6 +65,14 @@ def __sceneView( plug ) :
 
 GafferUI.View.registerView( GafferScene.ScenePlug.staticTypeId(), __sceneView )
 
+# Add items to the viewer's right click menu
+
+def __viewContextMenu( viewer, view, menuDefinition ) :
+
+	GafferSceneUI.SceneHistoryUI.appendViewContextMenuItems( viewer, view, menuDefinition )
+
+GafferUI.Viewer.viewContextMenuSignal().connect( __viewContextMenu, scoped = False )
+
 # register shading modes
 
 def __createNode( nodeType, plugValues ) :


### PR DESCRIPTION
This adds a menu item and shortcut for easily editing the source node for the current selection in the viewer. There's a lot of scope for additional features (selecting the latest tweaks node rather than the source, editing the associated shader etc), but since this is sufficient to cover the initial request in #2717, I'm making a PR for it on its own.

![editsource](https://user-images.githubusercontent.com/1133871/51391976-84f98700-1b2b-11e9-823e-35a42cb59752.gif)
