### PR TITLE
GadgetWidget : Fix GL context handling for enter/leave events

### DIFF
--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -146,6 +146,9 @@ class GadgetWidget( GafferUI.GLWidget ) :
 			)
 		)
 
+		if not self._makeCurrent() :
+			return False
+
 		self.__viewportGadget.enterSignal()( self.__viewportGadget, event )
 
 	def __leave( self, widget ) :
@@ -161,6 +164,9 @@ class GadgetWidget( GafferUI.GLWidget ) :
 				imath.V3f( p.x, p.y, 0 )
 			)
 		)
+
+		if not self._makeCurrent() :
+			return False
 
 		self.__viewportGadget.leaveSignal()( self.__viewportGadget, event )
 


### PR DESCRIPTION
As for all other events, we need to make our GL context current before delegating to the ViewportGadget's handlers, because those handlers will use GL to perform selection.
