### PR TITLE
BoolPlugValueWidget : Use colour to indicate animation and errors

### DIFF
--- a/python/GafferUI/BoolWidget.py
+++ b/python/GafferUI/BoolWidget.py
@@ -111,6 +111,18 @@ class BoolWidget( GafferUI.Widget ) :
 			)
 		)
 
+	def setErrored( self, errored ) :
+
+		if errored == self.getErrored() :
+			return
+
+		self._qtWidget().setProperty( "gafferError", GafferUI._Variant.toVariant( bool( errored ) ) )
+		self._repolish()
+
+	def getErrored( self ) :
+
+		return GafferUI._Variant.fromVariant( self._qtWidget().property( "gafferError" ) ) or False
+
 	def stateChangedSignal( self ) :
 
 		return self.__stateChangedSignal

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -793,6 +793,7 @@ _styleSheet = string.Template(
 		width: 20px;
 		height: 20px;
 		background-color: transparent;
+		border-radius: 2px;
 	}
 
 	QCheckBox::indicator:unchecked {
@@ -820,6 +821,14 @@ _styleSheet = string.Template(
 
 	QCheckBox::indicator:unchecked:disabled {
 		image: url($GAFFER_ROOT/graphics/checkBoxUncheckedDisabled.png);
+	}
+
+	QCheckBox[gafferAnimated="true"]::indicator {
+		background-color: $animatedColor;
+	}
+
+	QCheckBox[gafferError="true"]::indicator {
+		background-color: $errorColor;
 	}
 
 	/* boolwidget drawn as switch */


### PR DESCRIPTION
This includes a new `setErrored()/getErrored()` pair of methods for the BoolWidget, mirroring those of the TextWidget.