### PR TITLE
ViewportGadget::SelectionScope : Don't leak GL attribute state

### DIFF
--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -1601,6 +1601,9 @@ void ViewportGadget::SelectionScope::begin( const ViewportGadget *viewportGadget
 
 void ViewportGadget::SelectionScope::begin( const ViewportGadget *viewportGadget, const Imath::Box2f &rasterRegion, const Imath::M44f &transform, IECoreGL::Selector::Mode mode )
 {
+	glPushAttrib( GL_ALL_ATTRIB_BITS );
+	glPushClientAttrib( GL_CLIENT_ALL_ATTRIB_BITS );
+
 	V2f viewport = viewportGadget->getViewport();
 	Box2f ndcRegion( rasterRegion.min / viewport, rasterRegion.max / viewport );
 
@@ -1629,6 +1632,9 @@ void ViewportGadget::SelectionScope::end()
 	glPopMatrix();
 	m_selector = SelectorPtr();
 
+	glPopClientAttrib();
+	glPopAttrib();
+
 	if( m_depthSort )
 	{
 		std::sort( m_selection.begin(), m_selection.end() );
@@ -1637,7 +1643,6 @@ void ViewportGadget::SelectionScope::end()
 	{
 		std::reverse( m_selection.begin(), m_selection.end() );
 	}
-
 }
 
 ViewportGadget::RasterScope::RasterScope( const ViewportGadget *viewportGadget )


### PR DESCRIPTION
This is an entirely speculative fix for a text corruption bug we see very intermittently in our GLWidget overlays. My hunch is that we've been leaking some attribute state that has then caused problems with Qt's own GL drawing. In 6f5e3d3 we fixed the equivalent problem for the drawing we do to the screen, but ViewportGadget::SelectionScope is also used for "drawing" when hit-testing, and until now has not done the same.