### PR TITLE
Dot and BoxIO : Serialise ".setup" only when construction needed

### DIFF
--- a/src/GafferModule/DotBinding.cpp
+++ b/src/GafferModule/DotBinding.cpp
@@ -83,6 +83,13 @@ class DotSerialiser : public NodeSerialiser
 			return result;
 		}
 
+		// Only serialise a call to setup() when we need to construct this node
+		if( !Serialisation::acquireSerialiser( graphComponent->parent() )->childNeedsConstruction(
+			graphComponent, serialisation ) )
+		{
+			return result;
+		}
+
 		if( result.size() )
 		{
 			result += "\n";

--- a/src/GafferModule/SubGraphBinding.cpp
+++ b/src/GafferModule/SubGraphBinding.cpp
@@ -126,6 +126,13 @@ class BoxIOSerialiser : public NodeSerialiser
 			return result;
 		}
 
+		// Only serialise a call to setup() when we need to construct this node
+		if( !Serialisation::acquireSerialiser( graphComponent->parent() )->childNeedsConstruction(
+			graphComponent, serialisation ) )
+		{
+			return result;
+		}
+
 		if( result.size() )
 		{
 			result += "\n";


### PR DESCRIPTION
I don't fully understand all this stuff, but this seems like the change John was suggesting, and it works for getting the internal node with built-in BoxIOs working again, so it seems good to go.