### PR TITLE
AuxiliaryConnectionsGadget : Fix intermittent crash when exiting Boxes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -652,7 +652,11 @@ libraries = {
 		},
 	},
 
-	"GafferUITest" : {},
+	"GafferUITest" : {
+
+		"additionalFiles" : glob.glob( "python/GafferUITest/scripts/*.gfr" ),
+
+	},
 
 	"GafferDispatch" : {
 		"envAppends" : {

--- a/python/GafferUITest/AuxiliaryConnectionsGadgetTest.py
+++ b/python/GafferUITest/AuxiliaryConnectionsGadgetTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import os
 import unittest
 
 import IECore
@@ -335,6 +336,22 @@ class AuxiliaryConnectionsGadgetTest( GafferUITest.TestCase ) :
 
 		self.assertIsNone( g.connectionGadget( s["n2"]["c"]["r"] ) )
 		self.assertIsNone( g.connectionGadget( s["n2"]["c"]["g"] ) )
+
+	def testBoxExitCrash( self ) :
+
+		for i in range( 0, 20 ) :
+
+			s = Gaffer.ScriptNode()
+			s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/auxiliaryConnectionBoxExitCrash.gfr" )
+			s.load()
+
+			g = GafferUI.GraphGadget( s )
+			g.setRoot( s["Box"] )
+
+			acg = g.auxiliaryConnectionsGadget()
+			self.assertTrue( acg.hasConnection( s["Box"]["CameraMatrixAveraged"], s["Box"]["OutputCameraMatrices"] ) )
+
+			g.setRoot( s )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/scripts/auxiliaryConnectionBoxExitCrash.gfr
+++ b/python/GafferUITest/scripts/auxiliaryConnectionBoxExitCrash.gfr
@@ -1,0 +1,51 @@
+import Gaffer
+import GafferImage
+import GafferScene
+import IECore
+import imath
+
+Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 53, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 0, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "imageCataloguePort", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"].addChild( Gaffer.StringPlug( "name", defaultValue = 'image:catalogue:port', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"].addChild( Gaffer.IntPlug( "value", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectName", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:name', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectRootDirectory", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:rootDirectory', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format( 1920, 1080, 1.000 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["defaultFormat"] )
+__children["Box"] = Gaffer.Box( "Box" )
+parent.addChild( __children["Box"] )
+__children["Box"].addChild( Gaffer.TimeWarp( "CameraMatrixAveraged" ) )
+__children["Box"]["CameraMatrixAveraged"].setup( Gaffer.FloatPlug( "in", defaultValue = 0.0, ) )
+__children["Box"]["CameraMatrixAveraged"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Box"].addChild( Gaffer.TimeWarp( "TimeWarpCameraNext" ) )
+__children["Box"]["TimeWarpCameraNext"].setup( Gaffer.FloatPlug( "in", defaultValue = 0.0, ) )
+__children["Box"]["TimeWarpCameraNext"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Box"].addChild( GafferScene.Transform( "OutputCameraMatrices" ) )
+__children["Box"]["OutputCameraMatrices"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Box"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"]["value"].setValue( 43342 )
+Gaffer.Metadata.registerValue( parent["variables"]["imageCataloguePort"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectName"]["name"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectRootDirectory"]["name"], 'readOnly', True )
+__children["Box"]["CameraMatrixAveraged"]["__uiPosition"].setValue( imath.V2f( -14.4271536, 4.08203125 ) )
+__children["Box"]["TimeWarpCameraNext"]["in"].setInput( __children["Box"]["CameraMatrixAveraged"]["out"] )
+__children["Box"]["TimeWarpCameraNext"]["__uiPosition"].setValue( imath.V2f( 6.44369316, -4.08203125 ) )
+__children["Box"]["OutputCameraMatrices"]["transform"]["translate"]["x"].setInput( __children["Box"]["CameraMatrixAveraged"]["out"] )
+__children["Box"]["OutputCameraMatrices"]["transform"]["translate"]["y"].setInput( __children["Box"]["CameraMatrixAveraged"]["out"] )
+__children["Box"]["OutputCameraMatrices"]["transform"]["translate"]["z"].setInput( __children["Box"]["TimeWarpCameraNext"]["out"] )
+__children["Box"]["OutputCameraMatrices"]["__uiPosition"].setValue( imath.V2f( 21.8615837, 4.08203125 ) )
+__children["Box"]["__uiPosition"].setValue( imath.V2f( -9.04999924, 2.25000024 ) )
+
+
+del __children
+

--- a/src/GafferUI/AuxiliaryConnectionsGadget.cpp
+++ b/src/GafferUI/AuxiliaryConnectionsGadget.cpp
@@ -407,10 +407,6 @@ void AuxiliaryConnectionsGadget::dirtyInputConnections( const NodeGadget *nodeGa
 	// so we have a logic error somewhere if we don't already have
 	// an entry for this particular node gadget.
 	assert( it != m_nodeGadgetConnections.end() );
-	if( it->second.dirty )
-	{
-		return;
-	}
 
 	auto &dstIndex = dstNodeGadgetIndex();
 	auto dstRange = dstIndex.equal_range( nodeGadget );


### PR DESCRIPTION
In release builds we'd get a crash stack traces like the following :

```
2 0x00007fd7e1303563 [libGafferUI.so                      ] GafferUI::AuxiliaryConnectionsGadget::dirtyOutputConnections(GafferUI::NodeGadget const*)
3 0x00007fd7e1303563 [libGafferUI.so                      ] GafferUI::AuxiliaryConnectionsGadget::dirtyOutputConnections(GafferUI::NodeGadget const*)
4 0x00007fd7e4bcb0ed [libGaffer.so                        ] boost::signal2<void, Gaffer::GraphComponent*, Gaffer::GraphComponent*, boost::last_value<void>, int, std::less<int>, boost::function<void (Gaffer::GraphComponent*, Gaffer::GraphComponent*) [                      :   ?]
5 0x00007fd7e4bc81ab [libGaffer.so                        ] Gaffer::GraphComponent::removeChildInternal(boost::intrusive_ptrj<Gaffer::GraphComponent>, bool)
6 0x00007fd7e4bc9b8a [libGaffer.so                        ] Gaffer::GraphComponent::removeChildInternal(boost::intrusive_ptr<Gaffer::GraphComponent>, bool)
7 0x00007fd7e4b6d410 [libGaffer.so                        ] Gaffer::Action::enact(boost::intrusive_ptr<Gaffer::Action>)
8 0x00007fd7e4b6d64a [libGaffer.so                        ] Gaffer::Action::enact(boost::intrusive_ptr<Gaffer::GraphComponent>, std::function<void ()
9 0x00007fd7e4bc8544 [libGaffer.so                        ] Gaffer::GraphComponent::removeChild(boost::intrusive_ptr<Gaffer::GraphComponent>)
10 0x00007fd7e1335e08 [libGafferUI.so                      ] GafferUI::GraphGadget::removeNodeGadget(Gaffer::Node const*)
11 0x00007fd7e133790e [libGafferUI.so                      ] GafferUI::GraphGadget::updateGraph()
12 0x00007fd7e1338fb7 [libGafferUI.so                      ] GafferUI::GraphGadget::setRoot(boost::intrusive_ptr<Gaffer::Node>, boost::intrusive_ptr<Gaffer::Set>)
```

And in debug builds this assertion was triggered :

```
gaffer: src/GafferUI/AuxiliaryConnectionsGadget.cpp:441: void GafferUI::AuxiliaryConnectionsGadget::dirtyOutputConnections(const GafferUI::NodeGadget*): Assertion `cIt != m_nodeGadgetConnections.end()' failed.
```

As the assertion states, our intention is that all connections in
`m_auxiliaryConnections` must have corresponding entries in
`m_nodeGadgetConnections`. To achieve this, in `AuxiliaryConnectionsGadget::graphGadgetChildRemoved()`
we call `dirty[Input|Output]Connections()` to remove any connections for the node about to be removed.
But an erroneous early-exit optimisation was preventing us from removing output connections if a node
had previously been dirtied by the removal of an input connection from another node.
