### PR TITLE
Serialisation fixes

### DIFF
--- a/include/Gaffer/BoxIO.h
+++ b/include/Gaffer/BoxIO.h
@@ -91,6 +91,11 @@ class GAFFER_API BoxIO : public Node
 		/// construction to determine what
 		/// sort of plug this node will promote.
 		void setup( const Plug *plug );
+		/// Sets up the promoted plug on the parent box.
+		/// This is called automatically by `setup()`, so
+		/// there is no need to call it unless `setup()`
+		/// was called before parenting the BoxIO to a Box.
+		void setupPromotedPlug();
 
 		/// The internal plug which
 		/// can be used within the box.
@@ -169,7 +174,6 @@ class GAFFER_API BoxIO : public Node
 		boost::signals::scoped_connection m_promotedPlugParentChangedConnection;
 
 		void setupPassThrough();
-		void setupPromotedPlug();
 		void setupBoxEnabledPlug();
 		void scriptExecuted( ScriptNode *script );
 		void plugSet( Plug *plug );

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -187,9 +187,6 @@ class GAFFER_API ScriptNode : public Node
 		/// sources of execution, and there is intentionally no way of
 		/// distinguishing between them.
 		bool isExecuting() const;
-		/// This signal is emitted following successful execution of a script.
-		typedef boost::signal<void ( ScriptNode *, const std::string )> ScriptExecutedSignal;
-		ScriptExecutedSignal &scriptExecutedSignal();
 		//@}
 
 		//! @name Saving and loading
@@ -318,7 +315,6 @@ class GAFFER_API ScriptNode : public Node
 		friend struct GafferModule::SerialiserRegistration;
 
 		bool m_executing;
-		ScriptExecutedSignal m_scriptExecutedSignal;
 
 		// Context and plugs
 		// =================

--- a/python/GafferTest/BoxInTest.py
+++ b/python/GafferTest/BoxInTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import os
 import unittest
 
 import IECore
@@ -458,6 +459,22 @@ class BoxInTest( GafferTest.TestCase ) :
 		self.assertNotIn( "setInput", ss )
 		self.assertNotIn( "__in", ss )
 		self.assertEqual( ss.count( "addChild" ), 1 )
+
+	def testSerialisationWithReferenceSibling( self ) :
+
+		s1 = Gaffer.ScriptNode()
+
+		s1["b"] = Gaffer.Box()
+		s1["b"]["i"] = Gaffer.BoxIn()
+		s1["b"]["i"].setup( Gaffer.IntPlug())
+
+		s1["r"] = Gaffer.Reference()
+		s1["r"].load( os.path.dirname( __file__ ) + "/references/empty.grf" )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s1.serialise() )
+
+		self.assertEqual( s1["b"].keys(), s2["b"].keys() )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/BoxInTest.py
+++ b/python/GafferTest/BoxInTest.py
@@ -476,5 +476,18 @@ class BoxInTest( GafferTest.TestCase ) :
 
 		self.assertEqual( s1["b"].keys(), s2["b"].keys() )
 
+	def testPlugMetadataSerialisation( self ) :
+
+		s1 = Gaffer.ScriptNode()
+		s1["b"] = Gaffer.BoxIn()
+		s1["b"].setup( Gaffer.IntPlug() )
+
+		Gaffer.Metadata.registerValue( s1["b"]["out"], "test", 1 )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s1.serialise() )
+
+		self.assertEqual( Gaffer.Metadata.value( s2["b"]["out"], "test" ), 1 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/DotTest.py
+++ b/python/GafferTest/DotTest.py
@@ -209,5 +209,20 @@ class DotTest( GafferTest.TestCase ) :
 		self.assertIsInstance( s2["d"]["in"], Gaffer.IntPlug )
 		self.assertIsInstance( s2["d"]["out"], Gaffer.IntPlug )
 
+	def testPlugMetadataSerialisation( self ) :
+
+		s1 = Gaffer.ScriptNode()
+		s1["d"] = Gaffer.Dot()
+		s1["d"].setup( Gaffer.IntPlug() )
+
+		Gaffer.Metadata.registerValue( s1["d"]["in"], "test", 1 )
+		Gaffer.Metadata.registerValue( s1["d"]["out"], "test", 2 )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s1.serialise() )
+
+		self.assertEqual( Gaffer.Metadata.value( s2["d"]["in"], "test" ), 1 )
+		self.assertEqual( Gaffer.Metadata.value( s2["d"]["out"], "test" ), 2 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -1150,5 +1150,10 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( n["user"]["p"]["r"], "testPlugAncestor" ), 10 )
 		self.assertIn( "testPlugAncestor", Gaffer.Metadata.registeredValues( n["user"]["p"]["r"] ) )
 
+	def testValueFromNoneRaises( self ) :
+
+		with self.assertRaisesRegexp( Exception, "did not match C\+\+ signature" ) :
+			Gaffer.Metadata.value( None, "test" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -70,17 +70,7 @@ class ScriptNodeTest( GafferTest.TestCase ) :
 	def testExecution( self ) :
 
 		s = Gaffer.ScriptNode()
-
-		def f( n, s ) :
-			ScriptNodeTest.lastNode = n
-			ScriptNodeTest.lastScript = s
-
-		c = s.scriptExecutedSignal().connect( f )
-
 		s.execute( "script.addChild( Gaffer.Node( 'child' ) )" )
-		self.assertEqual( ScriptNodeTest.lastNode, s )
-		self.assertEqual( ScriptNodeTest.lastScript, "script.addChild( Gaffer.Node( 'child' ) )" )
-
 		self.assert_( s["child"].typeName(), "Node" )
 
 	def testSelection( self ) :
@@ -1235,7 +1225,7 @@ class ScriptNodeTest( GafferTest.TestCase ) :
 		self.assertEqual( s["frameRange"]["end"].getValue(), 15 )
 		self.assertEqual( s.context().get( "frameRange:start" ), 15 )
 		self.assertEqual( s.context().get( "frameRange:end" ), 15 )
-		
+
 		s["frameRange"]["end"].setValue( 150 )
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )

--- a/python/GafferTest/SwitchTest.py
+++ b/python/GafferTest/SwitchTest.py
@@ -506,6 +506,21 @@ class SwitchTest( GafferTest.TestCase ) :
 		self.assertIsInstance( s2["switch"]["in"][0], Gaffer.IntPlug )
 		self.assertIsInstance( s2["switch"]["out"], Gaffer.IntPlug )
 
+	def testPlugMetadataSerialisation( self ) :
+
+		s1 = Gaffer.ScriptNode()
+		s1["switch"] = Gaffer.Switch()
+		s1["switch"].setup( Gaffer.IntPlug() )
+
+		Gaffer.Metadata.registerValue( s1["switch"]["in"], "test", 1 )
+		Gaffer.Metadata.registerValue( s1["switch"]["out"], "test", 2 )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s1.serialise() )
+
+		self.assertEqual( Gaffer.Metadata.value( s2["switch"]["in"], "test" ), 1 )
+		self.assertEqual( Gaffer.Metadata.value( s2["switch"]["out"], "test" ), 2 )
+
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )

--- a/src/Gaffer/BoxIO.cpp
+++ b/src/Gaffer/BoxIO.cpp
@@ -211,6 +211,7 @@ void BoxIO::setup( const Plug *plug )
 	addChild( plug->createCounterpart( outPlugName(), Plug::Out ) );
 
 	inPlugInternal()->setFlags( Plug::Serialisable, true );
+	outPlugInternal()->setFlags( Plug::Serialisable, true );
 	applyDynamicFlag( inPlugInternal() );
 	applyDynamicFlag( outPlugInternal() );
 

--- a/src/Gaffer/Dot.cpp
+++ b/src/Gaffer/Dot.cpp
@@ -81,7 +81,7 @@ void Dot::setup( const Plug *plug )
 	MetadataAlgo::copyColors( originalPlug , out.get() , /* overwrite = */ false );
 
 	in->setFlags( Plug::Serialisable, true );
-	out->setFlags( Plug::Serialisable, false ); // Avoid serialising internal connection
+	out->setFlags( Plug::Serialisable, true );
 
 	// Set up Metadata so our plugs appear in the right place. We must do this now rather
 	// than later because the GraphEditor will add a Nodule for the plug as soon as the plug

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -671,11 +671,6 @@ bool ScriptNode::isExecuting() const
 	return m_executing;
 }
 
-ScriptNode::ScriptExecutedSignal &ScriptNode::scriptExecutedSignal()
-{
-	return m_scriptExecutedSignal;
-}
-
 std::string ScriptNode::serialise( const Node *parent, const Set *filter ) const
 {
 	return serialiseInternal( parent, filter );
@@ -775,7 +770,6 @@ bool ScriptNode::executeInternal( const std::string &serialisation, Node *parent
 	try
 	{
 		result = g_executeFunction( this, serialisation, parent ? parent : this, continueOnError, context );
-		scriptExecutedSignal()( this, serialisation );
 	}
 	catch( ... )
 	{

--- a/src/Gaffer/Switch.cpp
+++ b/src/Gaffer/Switch.cpp
@@ -94,7 +94,7 @@ void Switch::setup( const Plug *plug )
 	addChild( in );
 
 	PlugPtr out = plug->createCounterpart( g_outPlugName, Plug::Out );
-	out->setFlags( Plug::Serialisable, false ); // Avoid serialising internal connection
+	out->setFlags( Plug::Serialisable, true );
 	MetadataAlgo::copyColors( plug , out.get() , /* overwrite = */ false  );
 	addChild( out );
 }

--- a/src/GafferModule/MetadataBinding.cpp
+++ b/src/GafferModule/MetadataBinding.cpp
@@ -188,15 +188,15 @@ void registerValue( IECore::InternedString target, IECore::InternedString key, o
 	Metadata::registerValue( target, key, objectToValueFunction( key, value ) );
 }
 
-object value( const char *target, const char *key, bool copy )
+object value( IECore::InternedString target, IECore::InternedString key, bool copy )
 {
 	ConstDataPtr d = Metadata::value( target, key );
 	return dataToPython( d.get(), copy );
 }
 
-object graphComponentValue( const GraphComponent *graphComponent, const char *key, bool instanceOnly, bool copy )
+object graphComponentValue( const GraphComponent &graphComponent, IECore::InternedString key, bool instanceOnly, bool copy )
 {
-	ConstDataPtr d = Metadata::value( graphComponent, key, instanceOnly );
+	ConstDataPtr d = Metadata::value( &graphComponent, key, instanceOnly );
 	return dataToPython( d.get(), copy );
 }
 

--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -474,24 +474,6 @@ struct UndoAddedSlotCaller
 
 };
 
-struct ScriptExecutedSlotCaller
-{
-
-	boost::signals::detail::unusable operator()( boost::python::object slot, ScriptNode *script, const std::string &s )
-	{
-		try
-		{
-			slot( ScriptNodePtr( script ), s );
-		}
-		catch( const boost::python::error_already_set &e )
-		{
-			IECorePython::ExceptionAlgo::translatePythonException();
-		}
-		return boost::signals::detail::unusable();
-	}
-
-};
-
 } // namespace
 
 void GafferModule::bindScriptNode()
@@ -513,7 +495,6 @@ void GafferModule::bindScriptNode()
 		.def( "execute", &executeWrapper, ( boost::python::arg( "parent" ) = boost::python::object(), boost::python::arg( "continueOnError" ) = false ) )
 		.def( "executeFile", &executeFile, ( boost::python::arg( "fileName" ), boost::python::arg( "parent" ) = boost::python::object(), boost::python::arg( "continueOnError" ) = false ) )
 		.def( "isExecuting", &ScriptNode::isExecuting )
-		.def( "scriptExecutedSignal", &ScriptNode::scriptExecutedSignal, boost::python::return_internal_reference<1>() )
 		.def( "serialise", &ScriptNode::serialise, ( boost::python::arg( "parent" ) = boost::python::object(), boost::python::arg( "filter" ) = boost::python::object() ) )
 		.def( "serialiseToFile", &ScriptNode::serialiseToFile, ( boost::python::arg( "fileName" ), boost::python::arg( "parent" ) = boost::python::object(), boost::python::arg( "filter" ) = boost::python::object() ) )
 		.def( "save", &save )
@@ -524,7 +505,5 @@ void GafferModule::bindScriptNode()
 
 	SignalClass<ScriptNode::ActionSignal, DefaultSignalCaller<ScriptNode::ActionSignal>, ActionSlotCaller>( "ActionSignal" );
 	SignalClass<ScriptNode::UndoAddedSignal, DefaultSignalCaller<ScriptNode::UndoAddedSignal>, UndoAddedSlotCaller>( "UndoAddedSignal" );
-
-	SignalClass<ScriptNode::ScriptExecutedSignal, DefaultSignalCaller<ScriptNode::ScriptExecutedSignal>, ScriptExecutedSlotCaller>( "ScriptExecutedSignal" );
 
 }

--- a/src/GafferModule/SubGraphBinding.cpp
+++ b/src/GafferModule/SubGraphBinding.cpp
@@ -92,18 +92,6 @@ namespace GafferModule
 class BoxIOSerialiser : public NodeSerialiser
 {
 
-	bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override
-	{
-		const BoxIO *boxIO = child->parent<BoxIO>();
-		if( child == boxIO->outPlugInternal() )
-		{
-			// Avoid having our internal connection serialised. This will
-			// be recreated in `setup()` anyway.
-			return false;
-		}
-		return NodeSerialiser::childNeedsSerialisation( child, serialisation );
-	}
-
 	bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override
 	{
 		const BoxIO *boxIO = child->parent<BoxIO>();

--- a/startup/Gaffer/boxIOCompatibility.py
+++ b/startup/Gaffer/boxIOCompatibility.py
@@ -44,8 +44,8 @@ def __setupWrapper( originalSetup ) :
 			script = self.scriptNode()
 			if script is not None and script.isExecuting() :
 				# We used to use a bogus `setup()` call without
-				# a plug to trigger reconnection after serialisation.
-				# We no longer do that, so ignore it.
+				# a plug as a proxy for `setupPromotedPlug()`.
+				self.setupPromotedPlug()
 				return
 
 		return originalSetup( self, plug )


### PR DESCRIPTION
This fixes several serialisation issues discovered while testing for the upcoming release of 0.53. Thanks to @andrewkaufman and @danieldresser-ie for doing the hard work of isolating them down to reproducible test cases. I've managed to keep the improved results we wanted (using `setup()`, not exposing internal connections etc), but there remain some open questions about how this could be implemented better in the future. The internal serialisation code isn't pretty, and I haven't done anything to improve that situation. But I also feel fairly strongly that now isn't the time to commit to API changes that may or may not turn out to be helpful or necessary in the long run. Instead I've contented myself that we've at least beefed up our unit tests in preparation for the potential future refactoring I've discussed in the comments.