### PR TITLE
SceneInspector : Don't fail on null shaders

### DIFF
--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -558,6 +558,9 @@ class TextDiff( SideBySideDiff ) :
 		for value in values :
 
 			shader = value.outputShader() if isinstance( value, IECoreScene.ShaderNetwork ) else value
+			if not shader:
+				formattedValues.append( "Missing output shader" )
+				continue
 			shaderName = shader.name
 			nodeName = shader.blindData().get( "gaffer:nodeName", None )
 


### PR DESCRIPTION
Tiny fix that allows using SceneInspector to debug scenes where shaders have been set null.  ( I don't think this should necessarily be possible for users to do, but a bad node can do this, and this change makes it easier to debug. )
