### PR TITLE
Text node : Support non-ASCII characters 

### DIFF
--- a/apps/gui/gui-1.py
+++ b/apps/gui/gui-1.py
@@ -153,7 +153,7 @@ class gui( Gaffer.Application ) :
 
 		from Qt import QtWidgets
 
-		text = str( QtWidgets.QApplication.clipboard().text().encode( 'ascii', 'ignore' ) )
+		text = QtWidgets.QApplication.clipboard().text().encode( "utf-8" )
 		if text :
 			with Gaffer.BlockedConnection( self.__clipboardContentsChangedConnection ) :
 				self.root().setClipboardContents( IECore.StringData( text ) )

--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -82,7 +82,7 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 
 	def getText( self ) :
 
-		return str( self._qtWidget().toPlainText() )
+		return self._qtWidget().toPlainText().encode( "utf-8" )
 
 	def setText( self, text ) :
 

--- a/python/GafferUI/TextWidget.py
+++ b/python/GafferUI/TextWidget.py
@@ -65,7 +65,7 @@ class TextWidget( GafferUI.Widget ) :
 
 	def getText( self ) :
 
-		return str( self._qtWidget().text() )
+		return self._qtWidget().text().encode( "utf-8" )
 
 	def setEditable( self, editable ) :
 


### PR DESCRIPTION
Accompanying the changes to the Text node are some changes to the UI so that we also support non-ASCII characters in TextWidget and MultiLineTextWidget. I'm feeling my way here, so please take the time to read the rationale for my approach in 62de6cc, and call me out on anything that doesn't make sense.