### PR TITLE
Quick access to ShaderTweaks from Viewer selection

### DIFF
--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -235,8 +235,9 @@ Tumble                                                 :kbd:`Alt` + click and dr
 Expand selection                                       :kbd:`↓`
 Fully expand selection                                 :kbd:`Shift` + :kbd:`↓`
 Collapse selection                                     :kbd:`↑`
-Edit source node of selection                          :kbd:`Ctrl` + :kbd:`E`
-Fit clipping planes to scene                           Right-click > *Clipping Planes* > *Fit 
+Edit source node of selection                          :kbd:`Alt` + :kbd:`E`
+Edit tweaks node for selection                         :kbd:`Alt` + :kbd:`Shift` + :kbd:`E`
+Fit clipping planes to scene                           Right-click > *Clipping Planes* > *Fit
                                                        To Scene*
 Fit clipping planes to selection                       Right-click > *Clipping Planes* > *Fit 
                                                        To Selection*

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -66,6 +66,8 @@ IE_CORE_FORWARDDECLARE( Camera )
 namespace GafferScene
 {
 
+class ShaderTweaks;
+
 namespace SceneAlgo
 {
 
@@ -178,6 +180,9 @@ GAFFERSCENE_API History::Ptr history( const Gaffer::ValuePlug *scenePlugChild, c
 
 /// Returns the upstream scene originally responsible for generating the specified location.
 GAFFERSCENE_API ScenePlug *source( const ScenePlug *scene, const ScenePlug::ScenePath &path );
+
+/// Returns the last ShaderTweaks node to edit the specified attribute.
+GAFFERSCENE_API ShaderTweaks *shaderTweaks( const ScenePlug *scene, const ScenePlug::ScenePath &path, const IECore::InternedString &attributeName );
 
 } // namespace SceneAlgo
 

--- a/python/GafferSceneUI/SceneHistoryUI.py
+++ b/python/GafferSceneUI/SceneHistoryUI.py
@@ -79,7 +79,7 @@ def __historySubMenu( menu, context, scene, selectedPath ) :
 		{
 			"active" : selectedPath is not None,
 			"command" : functools.partial( __editSourceNode, context, scene, selectedPath ),
-			"shortCut" : "Ctrl+E",
+			"shortCut" : "Alt+E",
 		}
 	)
 
@@ -88,7 +88,7 @@ def __historySubMenu( menu, context, scene, selectedPath ) :
 		{
 			"active" : selectedPath is not None,
 			"command" : functools.partial( __editTweaksNode, context, scene, selectedPath ),
-			"shortCut" : "Shift+Ctrl+E",
+			"shortCut" : "Alt+Shift+E",
 		}
 	)
 
@@ -150,12 +150,12 @@ def __viewerKeyPress( viewer, event ) :
 	if not isinstance( view, GafferSceneUI.SceneView ) :
 		return False
 
-	if event.key == "E" and event.modifiers == event.modifiers.Control :
+	if event.key == "E" and event.modifiers == event.modifiers.Alt :
 		selectedPath = __sceneViewSelectedPath( view )
 		if selectedPath is not None :
 			__editSourceNode( view.getContext(), view["in"], selectedPath )
 		return True
-	elif event.key == "E" and event.modifiers == event.modifiers.Control | event.modifiers.Shift :
+	elif event.key == "E" and event.modifiers == event.modifiers.Alt | event.modifiers.Shift :
 		selectedPath = __sceneViewSelectedPath( view )
 		if selectedPath is not None :
 			__editTweaksNode( view.getContext(), view["in"], selectedPath )

--- a/python/GafferSceneUI/SceneHistoryUI.py
+++ b/python/GafferSceneUI/SceneHistoryUI.py
@@ -36,6 +36,9 @@
 
 import functools
 
+import IECore
+import IECoreScene
+
 import Gaffer
 import GafferUI
 import GafferScene
@@ -46,14 +49,15 @@ def appendViewContextMenuItems( viewer, view, menuDefinition ) :
 	if not isinstance( view, GafferSceneUI.SceneView ) :
 		return None
 
-	selectedPath = __sceneViewSelectedPath( view )
-
 	menuDefinition.append(
-		"/Edit Source Node...",
+		"/History",
 		{
-			"active" : selectedPath is not None,
-			"command" : functools.partial( __editSourceNode, view.getContext(), view["in"], selectedPath ),
-			"shortCut" : "Ctrl+E",
+			"subMenu" : functools.partial(
+				__historySubMenu,
+				context = view.getContext(),
+				scene = view["in"],
+				selectedPath = __sceneViewSelectedPath( view )
+			)
 		}
 	)
 
@@ -65,6 +69,30 @@ def connectToEditor( editor ) :
 ##########################################################################
 # Internal implementation
 ##########################################################################
+
+def __historySubMenu( menu, context, scene, selectedPath ) :
+
+	menuDefinition = IECore.MenuDefinition()
+
+	menuDefinition.append(
+		"/Edit Source...",
+		{
+			"active" : selectedPath is not None,
+			"command" : functools.partial( __editSourceNode, context, scene, selectedPath ),
+			"shortCut" : "Ctrl+E",
+		}
+	)
+
+	menuDefinition.append(
+		"/Edit Tweaks...",
+		{
+			"active" : selectedPath is not None,
+			"command" : functools.partial( __editTweaksNode, context, scene, selectedPath ),
+			"shortCut" : "Shift+Ctrl+E",
+		}
+	)
+
+	return menuDefinition
 
 def __sceneViewSelectedPath( sceneView ) :
 
@@ -84,6 +112,26 @@ def __editSourceNode( context, scene, path ) :
 
 	node = source.node()
 	node = __ancestorWithReadOnlyChildNodes( node ) or node
+	GafferUI.NodeEditor.acquire( node, floating = True )
+
+def __editTweaksNode( context, scene, path ) :
+
+	with context :
+		attributes = scene.fullAttributes( path )
+
+	shaderAttributeNames = [ x[0] for x in attributes.items() if isinstance( x[1], IECoreScene.ShaderNetwork ) ]
+	# Just happens to order as Surface, Light, Displacement, which is what we want.
+	shaderAttributeNames = list( reversed( sorted( shaderAttributeNames ) ) )
+	if not len( shaderAttributeNames ) :
+		return
+
+	with context :
+		tweaks = GafferScene.SceneAlgo.shaderTweaks( scene, path, shaderAttributeNames[0] )
+
+	if tweaks is None :
+		return
+
+	node = __ancestorWithReadOnlyChildNodes( tweaks ) or tweaks
 	GafferUI.NodeEditor.acquire( node, floating = True )
 
 def __ancestorWithReadOnlyChildNodes( node ) :
@@ -107,4 +155,8 @@ def __viewerKeyPress( viewer, event ) :
 		if selectedPath is not None :
 			__editSourceNode( view.getContext(), view["in"], selectedPath )
 		return True
-
+	elif event.key == "E" and event.modifiers == event.modifiers.Control | event.modifiers.Shift :
+		selectedPath = __sceneViewSelectedPath( view )
+		if selectedPath is not None :
+			__editTweaksNode( view.getContext(), view["in"], selectedPath )
+		return True

--- a/python/GafferSceneUI/SceneHistoryUI.py
+++ b/python/GafferSceneUI/SceneHistoryUI.py
@@ -52,7 +52,7 @@ def appendViewContextMenuItems( viewer, view, menuDefinition ) :
 		"/Edit Source Node...",
 		{
 			"active" : selectedPath is not None,
-			"command" : functools.partial( __editSourceNode, view["in"], selectedPath ),
+			"command" : functools.partial( __editSourceNode, view.getContext(), view["in"], selectedPath ),
 			"shortCut" : "Ctrl+E",
 		}
 	)
@@ -74,9 +74,11 @@ def __sceneViewSelectedPath( sceneView ) :
 	else :
 		return None
 
-def __editSourceNode( scene, path ) :
+def __editSourceNode( context, scene, path ) :
 
-	source = GafferScene.SceneAlgo.source( scene, path )
+	with context :
+		source = GafferScene.SceneAlgo.source( scene, path )
+
 	if source is None :
 		return
 
@@ -103,6 +105,6 @@ def __viewerKeyPress( viewer, event ) :
 	if event.key == "E" and event.modifiers == event.modifiers.Control :
 		selectedPath = __sceneViewSelectedPath( view )
 		if selectedPath is not None :
-			__editSourceNode( view["in"], selectedPath )
+			__editSourceNode( view.getContext(), view["in"], selectedPath )
 		return True
 

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -41,6 +41,7 @@
 #include "GafferScene/Filter.h"
 #include "GafferScene/SceneAlgo.h"
 #include "GafferScene/ScenePlug.h"
+#include "GafferScene/ShaderTweaks.h"
 
 #include "IECoreScene/Camera.h"
 
@@ -153,6 +154,12 @@ ScenePlugPtr sourceWrapper( const ScenePlug &scene, const ScenePlug::ScenePath &
 	return SceneAlgo::source( &scene, path );
 }
 
+ShaderTweaksPtr shaderTweaksWrapper( const ScenePlug &scene, const ScenePlug::ScenePath &path, const InternedString &attributeName )
+{
+	IECorePython::ScopedGILRelease r;
+	return SceneAlgo::shaderTweaks( &scene, path, attributeName );
+}
+
 } // namespace
 
 namespace GafferSceneModule
@@ -200,6 +207,7 @@ void bindSceneAlgo()
 
 	def( "history", &historyWrapper );
 	def( "source", &sourceWrapper );
+	def( "shaderTweaks", &shaderTweaksWrapper );
 
 }
 


### PR DESCRIPTION
This adds a "History/Edit Tweaks..." menu item as a companion to the recently added "Edit Source Node..." menu item. For this initial version I've gone for the simplest possible mechanism, with just a single menu item that accesses the tweaks node for the "most obvious" shader assigned at the selected location. There are other approaches we could take, such as different menu items for each assigned shader, or doing the history trace upfront (rather than when the item is chosen) and then listing nodes by name. My impression though was that folks were most interested in a single shortcut that "just works", so that's what I've tried to implement. I'm definitely happy to iterate on this and add more items/features, but my feeling is we might get better feedback if we can show something to people first...

