### PR TITLE
GLWidget : Fix problems with text drawing in overlays

### DIFF
--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -114,11 +114,16 @@ class GLWidget( GafferUI.Widget ) :
 
 		self.__overlays.add( overlay )
 		overlay._setStyleSheet()
-		if sys.platform == "darwin" and Qt.__binding__ in ( "PySide2", "PyQt5" ) :
-			# Force Qt to use a raster drawing path for the overlays,
-			# to avoid "QMacCGContext:: Unsupported painter devtype type 1"
-			# errors. See https://bugreports.qt.io/browse/QTBUG-32639 for
-			# further details.
+		if Qt.__binding__ in ( "PySide2", "PyQt5" ) :
+			# Force Qt to use a raster drawing path for the overlays.
+			#
+			# - On Mac, this avoids "QMacCGContext:: Unsupported painter devtype type 1"
+			#   errors. See https://bugreports.qt.io/browse/QTBUG-32639 for
+			#   further details.
+			# - On Linux, this avoids an unknown problem which manifests as
+			#   a GL error that appears to occur inside Qt's code, and which
+			#   is accompanied by text drawing being scrambled in the overlay.
+			#
 			## \todo When we no longer need to support Qt4, we should be
 			# able to stop using a QGLWidget for the viewport, and this
 			# should no longer be needed.


### PR DESCRIPTION
This appears to reliably fix an intermittent problem we've been getting whereby Qt's overlays in our GL Widgets start drawing text all scrambled after emitting a GL error. It took a long time to track this down to something that reproduced reliably, so I've pasted my setup below, if you load that in Gaffer and follow the instructions in the backdrop hopefully it reproduces for you too. Would be good to check that this does reproduce at IE, and that this does fix it.

We've got a couple of folks at Cinesite testing this same approach but administered via a hacky config file. We should probably wait for feedback from them as well before merging.

```
import Gaffer
import GafferArnold
import GafferImage
import GafferScene
import IECore
import imath

Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 53, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )

__children = {}

parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "imageCataloguePort", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["imageCataloguePort"].addChild( Gaffer.StringPlug( "name", defaultValue = 'image:catalogue:port', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["imageCataloguePort"].addChild( Gaffer.IntPlug( "value", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectName", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:name', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectRootDirectory", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:rootDirectory', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format( 1920, 1080, 1.000 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
parent.addChild( __children["defaultFormat"] )
__children["ArnoldShaderBall"] = GafferArnold.ArnoldShaderBall( "ArnoldShaderBall" )
parent.addChild( __children["ArnoldShaderBall"] )
__children["ArnoldShaderBall"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["checkerboard"] = GafferArnold.ArnoldShader( "checkerboard" )
parent.addChild( __children["checkerboard"] )
__children["checkerboard"].loadShader( "checkerboard" )
__children["checkerboard"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"] = GafferScene.Outputs( "Outputs" )
parent.addChild( __children["Outputs"] )
__children["Outputs"]["outputs"].addChild( Gaffer.ValuePlug( "output1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"].addChild( Gaffer.StringPlug( "name", defaultValue = '', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"].addChild( Gaffer.BoolPlug( "active", defaultValue = True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"].addChild( Gaffer.StringPlug( "fileName", defaultValue = '', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"].addChild( Gaffer.StringPlug( "type", defaultValue = '', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"].addChild( Gaffer.StringPlug( "data", defaultValue = '', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"].addChild( Gaffer.CompoundDataPlug( "parameters", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "quantize", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"]["quantize"].addChild( Gaffer.StringPlug( "name", defaultValue = 'quantize', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"]["quantize"].addChild( Gaffer.IntVectorDataPlug( "value", defaultValue = IECore.IntVectorData( [ 0, 0, 0, 0 ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "driverType", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"]["driverType"].addChild( Gaffer.StringPlug( "name", defaultValue = 'driverType', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"]["driverType"].addChild( Gaffer.StringPlug( "value", defaultValue = 'ClientDisplayDriver', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "remoteDisplayType", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"]["remoteDisplayType"].addChild( Gaffer.StringPlug( "name", defaultValue = 'remoteDisplayType', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"]["remoteDisplayType"].addChild( Gaffer.StringPlug( "value", defaultValue = 'GafferImage::GafferDisplayDriver', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "displayPort", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"]["displayPort"].addChild( Gaffer.StringPlug( "name", defaultValue = 'displayPort', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"]["displayPort"].addChild( Gaffer.StringPlug( "value", defaultValue = '${image:catalogue:port}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "displayHost", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"]["displayHost"].addChild( Gaffer.StringPlug( "name", defaultValue = 'displayHost', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"]["outputs"]["output1"]["parameters"]["displayHost"].addChild( Gaffer.StringPlug( "value", defaultValue = 'localhost', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Outputs"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["ArnoldOptions"] = GafferArnold.ArnoldOptions( "ArnoldOptions" )
parent.addChild( __children["ArnoldOptions"] )
__children["ArnoldOptions"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Catalogue"] = GafferImage.Catalogue( "Catalogue" )
parent.addChild( __children["Catalogue"] )
__children["Catalogue"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Backdrop"] = Gaffer.Backdrop( "Backdrop" )
parent.addChild( __children["Backdrop"] )
__children["Backdrop"].addChild( Gaffer.Box2fPlug( "__uiBound", defaultValue = imath.Box2f( imath.V2f( -10, -10 ), imath.V2f( 10, 10 ) ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Backdrop"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["imageCataloguePort"]["value"].setValue( 38825 )
Gaffer.Metadata.registerValue( parent["variables"]["imageCataloguePort"], 'readOnly', True )
Gaffer.Metadata.registerValue( parent["variables"]["projectName"]["name"], 'readOnly', True )
Gaffer.Metadata.registerValue( parent["variables"]["projectRootDirectory"]["name"], 'readOnly', True )
__children["ArnoldShaderBall"]["shader"].setInput( __children["checkerboard"]["out"] )
__children["ArnoldShaderBall"]["__uiPosition"].setValue( imath.V2f( 1.62378144, 0.34999913 ) )
__children["checkerboard"]["parameters"]["u_frequency"].setValue( 40.0 )
__children["checkerboard"]["parameters"]["v_frequency"].setValue( 20.0 )
__children["checkerboard"]["__uiPosition"].setValue( imath.V2f( -14.0249004, 0.34999907 ) )
__children["Outputs"]["in"].setInput( __children["ArnoldShaderBall"]["out"] )
__children["Outputs"]["outputs"]["output1"]["name"].setValue( 'Interactive/Beauty' )
__children["Outputs"]["outputs"]["output1"]["fileName"].setValue( 'beauty' )
__children["Outputs"]["outputs"]["output1"]["type"].setValue( 'ieDisplay' )
__children["Outputs"]["outputs"]["output1"]["data"].setValue( 'rgba' )
__children["Outputs"]["__uiPosition"].setValue( imath.V2f( 1.62459278, -7.81406307 ) )
__children["ArnoldOptions"]["in"].setInput( __children["Outputs"]["out"] )
__children["ArnoldOptions"]["options"]["aaSamples"]["value"].setValue( 10 )
__children["ArnoldOptions"]["options"]["aaSamples"]["enabled"].setValue( True )
__children["ArnoldOptions"]["__uiPosition"].setValue( imath.V2f( 1.62548709, -15.9781256 ) )
__children["Catalogue"]["directory"].setValue( '${project:rootDirectory}/catalogues/${script:name}' )
__children["Catalogue"]["__uiPosition"].setValue( imath.V2f( 19.3000031, -10.5500002 ) )
__children["Backdrop"]["title"].setValue( 'Repro' )
__children["Backdrop"]["description"].setValue( '- Select checkerboard so it gets rendered\n- Middle drag to pin ArnoldShaderBall into Viewer\n- Split Viewer right\n- Select Catalogue\n- Make new Viewer in the new empty panel on the right\n- Move mouse around in the newf Viewer' )
__children["Backdrop"]["__uiBound"].setValue( imath.Box2f( imath.V2f( -8.5, -20.0893097 ), imath.V2f( 47.1833534, 11.0820312 ) ) )
__children["Backdrop"]["__uiPosition"].setValue( imath.V2f( 37.6000023, 0.25 ) )


del __children
```