### PR TITLE
ProcessMessageHandler : Don't error if "frame" not in Context

### DIFF
--- a/python/GafferTest/ProcessMessageHandlerTest.py
+++ b/python/GafferTest/ProcessMessageHandlerTest.py
@@ -112,5 +112,21 @@ class ProcessMessageHandlerTest( GafferTest.TestCase ) :
 				self.assertEqual( capturingMessageHandler.messages[1].context, "Gaffer::Process" )
 				self.assertEqual( capturingMessageHandler.messages[1].message, "[ plug: 'ScriptNode.Expression.__execute', frame: 1, path: '/a/b' ]" )
 
+				del capturingMessageHandler.messages[:]
+
+				del context["frame"]
+				context["scene:path"] = IECore.InternedStringVectorData( [ "a", "b", "c" ] )
+
+				self.assertEqual( node['user']['test'].getValue(), 3 )
+				self.assertEqual( len( capturingMessageHandler.messages ), 2 )
+
+				self.assertEqual( capturingMessageHandler.messages[0].level, IECore.MessageHandler.Level.Error )
+				self.assertEqual( capturingMessageHandler.messages[0].context, "testA" )
+				self.assertEqual( capturingMessageHandler.messages[0].message, "testB" )
+
+				self.assertEqual( capturingMessageHandler.messages[1].level, IECore.MessageHandler.Level.Debug )
+				self.assertEqual( capturingMessageHandler.messages[1].context, "Gaffer::Process" )
+				self.assertEqual( capturingMessageHandler.messages[1].message, "[ plug: 'ScriptNode.Expression.__execute', path: '/a/b/c' ]" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/ProcessMessageHandler.cpp
+++ b/src/Gaffer/ProcessMessageHandler.cpp
@@ -57,9 +57,10 @@ using boost::algorithm::join;
 namespace
 {
 
+IECore::InternedString g_frame( "frame" );
 IECore::InternedString g_scenePath( "scene:path" );
 
-}
+} // namespace
 
 ProcessMessageHandler::ProcessMessageHandler( IECore::MessageHandlerPtr handler ) : IECore::FilteredMessageHandler( handler )
 {
@@ -77,8 +78,12 @@ void ProcessMessageHandler::handle( Level level, const string &context, const st
 	{
 		stringstream ss;
 
-		ss << "[ plug: '" << p->plug()->fullName() << "', ";
-		ss << "frame: " << p->context()->getFrame();
+		ss << "[ plug: '" << p->plug()->fullName() << "'";
+
+		if( auto frame = p->context()->get<IECore::FloatData>( g_frame, nullptr ) )
+		{
+			ss << ", frame: " << frame->readable();
+		}
 
 		if( auto path = p->context()->get<IECore::InternedStringVectorData>( g_scenePath, nullptr ) )
 		{


### PR DESCRIPTION
To my shame, in the review for #2915, I claimed that this situation could not occur. But it does occur, specifically for PythonCommands in sequence mode, where we require the command itself to iterate over the frames. It was even I who made it this way, in 57136469af9eece77827f298388bbdaa19914fba.
