### PR TITLE
About : Fix reference to Qt license

### DIFF
--- a/python/Gaffer/About.py
+++ b/python/Gaffer/About.py
@@ -219,7 +219,7 @@ class About :
 			{
 				"name" : "Qt",
 				"url" : "http://qt.nokia.com/",
-				"license" : "$GAFFER_ROOT/doc/licenses/qt",
+				"license" : "$GAFFER_ROOT/doc/licenses/Qt",
 			},
 
 		]


### PR DESCRIPTION
Tiny fix for a change brought about by [updating Qt in the dependencies project](https://github.com/GafferHQ/dependencies/pull/118).