### PR TITLE
Light Linking and the order of AtNode cleanup

### DIFF
--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -206,19 +206,19 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		s["s"]["enabled"].setValue( False )
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		s["s"]["enabled"].setValue( True )
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testAddAndRemoveObject( self ) :
 
@@ -263,7 +263,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Switch to the empty group.
 
@@ -271,7 +271,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Switch back to the sphere.
 
@@ -279,7 +279,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testEditObjectVisibility( self ) :
 
@@ -321,7 +321,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Visible to start with
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Hide /group/sphere
 
@@ -330,7 +330,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Tweak the sphere geometry - it should remain hidden
 
@@ -338,7 +338,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Show it again
 
@@ -346,7 +346,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Hide /group
 
@@ -355,7 +355,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Show it again
 
@@ -363,7 +363,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testEditCameraVisibility( self ) :
 
@@ -405,7 +405,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Visible to start with
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Hide /group/sphere
 
@@ -414,7 +414,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Show it again
 
@@ -422,7 +422,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Hide /group
 
@@ -431,7 +431,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Show it again
 
@@ -439,7 +439,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testEditObjectTransform( self ) :
 
@@ -471,7 +471,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Visible to start with
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Move to one side
 
@@ -479,7 +479,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Move back
 
@@ -487,7 +487,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testShaderEdits( self ) :
 
@@ -526,7 +526,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Render red sphere
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.__assertColorsAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ), imath.Color4f( 1, 0, 0, 1 ), delta = 0.01 )
+		self.__assertColorsAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ), imath.Color4f( 1, 0, 0, 1 ), delta = 0.01 )
 
 		# Make it green
 
@@ -534,7 +534,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.__assertColorsAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ), imath.Color4f( 0, 1, 0, 1 ), delta = 0.01 )
+		self.__assertColorsAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ), imath.Color4f( 0, 1, 0, 1 ), delta = 0.01 )
 
 		# Make it blue
 
@@ -542,7 +542,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.__assertColorsAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ), imath.Color4f( 0, 0, 1, 1 ), delta = 0.01 )
+		self.__assertColorsAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ), imath.Color4f( 0, 0, 1, 1 ), delta = 0.01 )
 
 	def testEditCameraTransform( self ) :
 
@@ -585,7 +585,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Visible to start with
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Move to one side
 
@@ -593,7 +593,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Move back
 
@@ -601,7 +601,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testEditResolution( self ) :
 
@@ -820,7 +820,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Visible to start with
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Move to one side
 
@@ -828,7 +828,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Move back
 
@@ -836,7 +836,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Repeat, using a context we set directly ourselves.
 
@@ -846,13 +846,13 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		c.setFrame( 1 )
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testLights( self ) :
 
@@ -907,7 +907,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		time.sleep( 2 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -919,7 +919,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		time.sleep( 1 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -932,7 +932,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		time.sleep( 1 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -943,7 +943,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["r"]["state"].setValue( s["r"].State.Running )
 		time.sleep( 1 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -955,7 +955,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		colorPlug.setValue( imath.Color3f( 0.25, 0.5, 1 ) )
 		time.sleep( 1 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -1014,7 +1014,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		time.sleep( 2 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -1032,7 +1032,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		time.sleep( 1 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -1090,7 +1090,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		time.sleep( 2 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -1101,7 +1101,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["l"]["enabled"].setValue( False )
 		time.sleep( 2 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -1112,7 +1112,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["l"]["enabled"].setValue( True )
 		time.sleep( 2 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -1174,7 +1174,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		time.sleep( 2 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -1185,7 +1185,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["v"]["attributes"]["visibility"]["value"].setValue( False )
 		time.sleep( 2 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -1196,7 +1196,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["v"]["attributes"]["visibility"]["value"].setValue( True )
 		time.sleep( 2 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -1241,7 +1241,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Visible to start with
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Hide
 
@@ -1249,7 +1249,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Show again
 
@@ -1257,7 +1257,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testGlobalCameraVisibility( self ) :
 
@@ -1297,7 +1297,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Visible to start with
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 		# Hide
 
@@ -1305,7 +1305,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0, delta = 0.01 )
 
 		# Show again
 
@@ -1313,7 +1313,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 0.5 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
+		self.assertAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
 	def testEffectiveContext( self ) :
 
@@ -1467,11 +1467,11 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		def assertReflected( reflected ) :
 
 			image = IECoreImage.ImageDisplayDriver.storedImage( "traceSetsTest" )
-			self.assertGreater( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).a, 0.9 )
+			self.assertGreater( self._color4fAtUV( image, imath.V2f( 0.5 ) ).a, 0.9 )
 			if reflected :
-				self.assertGreater( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0.9 )
+				self.assertGreater( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0.9 )
 			else :
-				self.assertLess( self.__color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0.1 )
+				self.assertLess( self._color4fAtUV( image, imath.V2f( 0.5 ) ).r, 0.1 )
 
 		assertReflected( True )
 
@@ -1588,7 +1588,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Render red sphere
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.__assertColorsAlmostEqual( self.__color4fAtUV( image, imath.V2f( 0.5 ) ), imath.Color4f( 1, 0, 0, 1 ), delta = 0.01 )
+		self.__assertColorsAlmostEqual( self._color4fAtUV( image, imath.V2f( 0.5 ) ), imath.Color4f( 1, 0, 0, 1 ), delta = 0.01 )
 
 	def testLightLinking( self ) :
 
@@ -1643,7 +1643,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		time.sleep( 2 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -1655,7 +1655,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		time.sleep( 1 )
 
-		c = self.__color3fAtUV(
+		c = self._color3fAtUV(
 			IECoreImage.ImageDisplayDriver.storedImage( "myLovelyPlane" ),
 			imath.V2f( 0.5 ),
 		)
@@ -1717,7 +1717,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		raise NotImplementedError
 
-	def __color4fAtUV( self, image, uv ) :
+	def _color4fAtUV( self, image, uv ) :
 
 		objectToImage = GafferImage.ObjectToImage()
 		objectToImage["object"].setValue( image )
@@ -1733,9 +1733,9 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		return sampler["color"].getValue()
 
-	def __color3fAtUV( self, image, uv ) :
+	def _color3fAtUV( self, image, uv ) :
 
-		c = self.__color4fAtUV( image, uv )
+		c = self._color4fAtUV( image, uv )
 		return imath.Color3f( c.r, c.g, c.b )
 
 	def __assertColorsAlmostEqual( self, c0, c1, **kw ) :

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -561,7 +561,7 @@ class ArnoldShader : public IECore::RefCounted
 
 		~ArnoldShader() override
 		{
-			for( std::vector<AtNode *>::const_iterator it = m_nodes.begin(), eIt = m_nodes.end(); it != eIt; ++it )
+			for( std::vector<AtNode *>::const_reverse_iterator it = m_nodes.rbegin(), eIt = m_nodes.rend(); it != eIt; ++it )
 			{
 				m_nodeDeleter( *it );
 			}
@@ -1963,7 +1963,28 @@ class ArnoldLight : public ArnoldObject
 
 			// Update light shader.
 
+			// Delete current light shader, destroying all AtNodes it owns. It
+			// is crucial that we do this _before_ constructing a new
+			// ArnoldShader (and therefore AtNodes) below, because we are
+			// relying on a specific behaviour of the Arnold node allocator.
+			// When we destroy the light node, Arnold does not remove it from
+			// any of the `light_group` arrays we have assigned to geometry,
+			// meaning they will contain a dangling pointer. If we destroy the
+			// old AtNode first, we get lucky, and Arnold will allocate the new
+			// one at the _exact same address_ as the old one, keeping our
+			// arrays valid. We have been accidentally relying on this behaviour
+			// for some time, and for now continue to rely on it in lieu of a
+			// more complex fix. One subtlety is that when the light shader
+			// contains more than one node, we must destroy them in reverse
+			// order - see ~ArnoldShader. A future fix might involve a
+			// `LightLinkManager` that is able to track and patch up any
+			// affected light links. Because of the extra bookkeeping involved
+			// in such an approach, we would want to keep its use to a minimum.
+			// We could achieve that for the common case by editing the light
+			// node's parameters in place, only creating a new light node when
+			// the type has changed.
 			m_lightShader = nullptr;
+
 			if( !arnoldAttributes->lightShader() )
 			{
 				return true;


### PR DESCRIPTION
Hey John,

this is for the _0.52_maintenance_ branch and I'll put up a version for _master_ once we get this merged.

Could you look through my comment in 11ef863 and the regression test in 923713a? Regarding the test - how do you feel about making the `__color4fAtUV` method in `InteractiveRenderTest` a bit more public by removing the first underscore?

The test fails without b011462 and succeeds with it.

Cheers :)

Matti.