### PR TITLE
PlugValueWidget/PresetsPlugValueWidget : Fix preset menu bug

### DIFF
--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -569,8 +569,9 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		result = IECore.MenuDefinition()
 		for presetName in Gaffer.NodeAlgo.presets( self.getPlug() ) :
+			menuPath = presetName if presetName.startswith( "/" ) else "/" + presetName
 			result.append(
-				presetName, {
+				menuPath, {
 					"command" : functools.partial( Gaffer.WeakMethod( self.__applyPreset ), presetName ),
 					"active" : self._editable(),
 					"checkBox" : presetName == currentPreset,

--- a/python/GafferUI/PresetsPlugValueWidget.py
+++ b/python/GafferUI/PresetsPlugValueWidget.py
@@ -96,8 +96,9 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 		allowCustom = Gaffer.Metadata.value( self.getPlug(), "presetsPlugValueWidget:allowCustom" )
 		isCustom = Gaffer.Metadata.value( self.getPlug(), "presetsPlugValueWidget:isCustom" )
 		for n in Gaffer.NodeAlgo.presets( self.getPlug() ) :
+			menuPath = n if n.startswith( "/" ) else "/" + n
 			result.append(
-				"/" + n,
+				menuPath,
 				{
 					"command" : functools.partial( Gaffer.WeakMethod( self.__applyPreset ), preset = n ),
 					"checkBox" : n == currentPreset and not isCustom,


### PR DESCRIPTION
The `IECore.MenuDefinition` class is particular about all entries needing to start with a '/'. The PresetsPlugValueWidget helpfully added one, but the regular PlugValueWidget menu did not. Since this means there may be both slash-prefixed and non-slash-prefixed presets in the wild, we ensure that both are supported by both widgets.
