### PR TITLE
PathListingWidgetBinding : Add missing GIL release

### DIFF
--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -907,6 +907,7 @@ IECore::PathMatcher getExpansion( uint64_t treeViewAddress )
 		return result;
 	}
 
+	IECorePython::ScopedGILRelease gilRelease;
 	getExpansionWalk( treeView, model, QModelIndex(), result );
 	return result;
 }


### PR DESCRIPTION
I don't fully understand this code, but it seems like a simple oversight that there was no GIL release here.  This accounted for a hang we were seeing at IE.

Double check my logic here, but the first half of this function seems safe ( it's just QT stuff that won't call into Gaffer ), but the actual getExpansionWalk does seem to trigger plug evaluations somehow.