### PR TITLE
ArnoldTextureBake : Small Improvements

### DIFF
--- a/python/GafferArnold/ArnoldTextureBake.py
+++ b/python/GafferArnold/ArnoldTextureBake.py
@@ -265,10 +265,16 @@ class ArnoldTextureBake( GafferDispatch.TaskNode ) :
 		self["applyMedianFilter"] = Gaffer.BoolPlug( "applyMedianFilter", Gaffer.Plug.Direction.In, False )
 		self["medianRadius"] = Gaffer.IntPlug( "medianRadius", Gaffer.Plug.Direction.In, 1 )
 
+		# Set up connection to preTasks beforehand
+		self["__CleanPreTasks"] = GafferDispatch.TaskDeleteContextVariables()
+		self["__CleanPreTasks"]["preTasks"].setInput( self["preTasks"] )
+		self["__CleanPreTasks"]["variables"].setValue( "wedge:index wedge:value" )
+
 		# First, setup python commands which will dispatch a chunk of a render or image tasks as
 		# immediate execution once they reach the farm - this allows us to run multiple tasks in
 		# one farm process.
 		self["__RenderDispatcher"] = GafferDispatch.PythonCommand()
+		self["__RenderDispatcher"]["preTasks"][0].setInput( self["__CleanPreTasks"]["task"] )
 		self["__RenderDispatcher"]["command"].setValue( inspect.cleandoc(
 			"""
 			import GafferDispatch

--- a/python/GafferArnoldUI/ArnoldTextureBakeUI.py
+++ b/python/GafferArnoldUI/ArnoldTextureBakeUI.py
@@ -47,6 +47,7 @@ Gaffer.Metadata.registerNode(
 	Supports multiple meshes and UDIMs, and any AOVs output by Arnold.  The file name and
 	resolution can be overridden per mesh using the "bake:fileName" and "bake:resolution" attributes.
 	""",
+	"layout:activator:medianActivator", lambda parent : parent["applyMedianFilter"].getValue(),
 
 	plugs = {
 
@@ -155,8 +156,23 @@ Gaffer.Metadata.registerNode(
 			are present ).  We then combine them, fill in the background, and convert to textures.  This
 			causes all intermediate EXRs, and the index txt file to be removed, and just the final .tx to be kept.
 			""",
+			"divider", True,
 		],
 		
+		"applyMedianFilter" : [
+			"description",
+			"""
+			Adds a simple denoising filter to the texture bake. Mostly preserves high-contrast edges.
+			""",
+		],
+
+		"medianRadius" : [
+			"description",
+			"""
+			The radius of the median filter. Values greater than 1 will likely remove small details from the texture.
+			""",
+			"layout:activator", "medianActivator",
+		],
 
 
 	}

--- a/python/GafferDispatch/TaskContextProcessor.py
+++ b/python/GafferDispatch/TaskContextProcessor.py
@@ -53,7 +53,7 @@ class TaskContextProcessor( GafferDispatch.TaskNode ) :
 		for plug in self["preTasks"] :
 
 			source = plug.source()
-			if source.isSame( plug ) :
+			if source.isSame( plug ) or not source.direction() == Gaffer.Plug.Direction.Out:
 				continue
 
 			if not isinstance( source.node(), GafferDispatch.TaskNode ):

--- a/python/GafferDispatch/TaskDeleteContextVariables.py
+++ b/python/GafferDispatch/TaskDeleteContextVariables.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,21 +34,23 @@
 #
 ##########################################################################
 
-__import__( "GafferUI" )
+import IECore
 
-import DispatcherUI
-from DispatcherUI import DispatcherWindow
-from DispatchDialogue import DispatchDialogue
-import LocalDispatcherUI
-import TaskNodeUI
-import SystemCommandUI
-import TaskListUI
-import TaskContextProcessorUI
-import WedgeUI
-import TaskContextVariablesUI
-import TaskDeleteContextVariablesUI
-import TaskSwitchUI
-import PythonCommandUI
-import FrameMaskUI
+import Gaffer
+import GafferDispatch
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferDispatchUI" )
+class TaskDeleteContextVariables( GafferDispatch.TaskContextProcessor ) :
+
+	def __init__( self, name = "TaskDeleteContextVariables" ) :
+
+		GafferDispatch.TaskContextProcessor.__init__( self, name )
+
+		self["variables"] = Gaffer.StringPlug()
+
+	def _processedContexts( self, context ) :
+
+		context = Gaffer.Context( context )
+		context.removeMatching( self["variables"].getValue() )
+		return [ context ]
+
+IECore.registerRunTimeTyped( TaskDeleteContextVariables, typeName = "GafferDispatch::TaskDeleteContextVariables" )

--- a/python/GafferDispatch/TaskSwitch.py
+++ b/python/GafferDispatch/TaskSwitch.py
@@ -53,7 +53,7 @@ class TaskSwitch( GafferDispatch.TaskNode ) :
 		index = index % ( len( self["preTasks"] ) - 1 )
 
 		source = self["preTasks"][index].source()
-		if source.isSame( self["preTasks"][index] ) or not isinstance( source.node(), GafferDispatch.TaskNode ) :
+		if source.isSame( self["preTasks"][index] ) or not isinstance( source.node(), GafferDispatch.TaskNode ) or not source.direction() == Gaffer.Plug.Direction.Out:
 			return []
 
 		return [ self.Task( source.node(), context ) ]

--- a/python/GafferDispatch/__init__.py
+++ b/python/GafferDispatch/__init__.py
@@ -43,6 +43,7 @@ from TaskList import TaskList
 from TaskContextProcessor import TaskContextProcessor
 from Wedge import Wedge
 from TaskContextVariables import TaskContextVariables
+from TaskDeleteContextVariables import TaskDeleteContextVariables
 from TaskSwitch import TaskSwitch
 from PythonCommand import PythonCommand
 from FrameMask import FrameMask

--- a/python/GafferDispatchTest/TaskDeleteContextVariablesTest.py
+++ b/python/GafferDispatchTest/TaskDeleteContextVariablesTest.py
@@ -1,0 +1,104 @@
+##########################################################################
+#
+#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import glob
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferDispatch
+import GafferDispatchTest
+
+class TaskDeleteContextVariablesTest( GafferTest.TestCase ) :
+
+	def __dispatcher( self, frameRange = None ) :
+
+		result = GafferDispatch.LocalDispatcher( jobPool = GafferDispatch.LocalDispatcher.JobPool() )
+		result["jobsDirectory"].setValue( self.temporaryDirectory() + "/jobs" )
+
+		return result
+
+	def test( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["writer"] = GafferDispatchTest.TextWriter()
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() + "/${name}.txt" )
+
+		script["deleteVariables"] = GafferDispatch.TaskDeleteContextVariables()
+		script["deleteVariables"]["variables"].setValue( "unused n*me foo" ) # Space separated glob match for "name"
+		script["deleteVariables"]["preTasks"][0].setInput( script["writer"]["task"] )
+
+		script["variables"] = GafferDispatch.TaskContextVariables()
+		script["variables"]["preTasks"][0].setInput( script["deleteVariables"]["task"] )
+		script["variables"]["variables"].addMember( "name", "jimbob" )
+
+
+		self.__dispatcher().dispatch( [ script["variables"] ] )
+
+		self.assertEqual(
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
+			set()
+		)
+
+		script["deleteVariables"]["variables"].setValue( "" )
+		self.__dispatcher().dispatch( [ script["variables"] ] )
+
+		self.assertEqual(
+			set( glob.glob( self.temporaryDirectory() + "/*.txt" ) ),
+			{
+				self.temporaryDirectory() + "/jimbob.txt",
+			}
+		)
+
+
+	def testDirectCycles( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["deleteVariables"] = GafferDispatch.TaskDeleteContextVariables()
+
+		with IECore.CapturingMessageHandler() as mh :
+			s["deleteVariables"]["preTasks"][0].setInput( s["deleteVariables"]["task"] )
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertRegexpMatches( mh.messages[0].message, "Cycle detected between ScriptNode.deleteVariables.preTasks.preTask0 and ScriptNode.deleteVariables.task" )
+
+		d = self.__dispatcher()
+		self.assertRaisesRegexp( RuntimeError, "cannot have cyclic dependencies", d.dispatch, [ s["deleteVariables"] ] )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferDispatchTest/__init__.py
+++ b/python/GafferDispatchTest/__init__.py
@@ -52,6 +52,7 @@ from SystemCommandTest import SystemCommandTest
 from TaskListTest import TaskListTest
 from WedgeTest import WedgeTest
 from TaskContextVariablesTest import TaskContextVariablesTest
+from TaskDeleteContextVariablesTest import TaskDeleteContextVariablesTest
 from ExecuteApplicationTest import ExecuteApplicationTest
 from TaskPlugTest import TaskPlugTest
 from FrameMaskTest import FrameMaskTest

--- a/python/GafferDispatchUI/TaskDeleteContextVariablesUI.py
+++ b/python/GafferDispatchUI/TaskDeleteContextVariablesUI.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,21 +34,29 @@
 #
 ##########################################################################
 
-__import__( "GafferUI" )
+import Gaffer
+import GafferDispatch
 
-import DispatcherUI
-from DispatcherUI import DispatcherWindow
-from DispatchDialogue import DispatchDialogue
-import LocalDispatcherUI
-import TaskNodeUI
-import SystemCommandUI
-import TaskListUI
-import TaskContextProcessorUI
-import WedgeUI
-import TaskContextVariablesUI
-import TaskDeleteContextVariablesUI
-import TaskSwitchUI
-import PythonCommandUI
-import FrameMaskUI
+Gaffer.Metadata.registerNode(
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferDispatchUI" )
+	GafferDispatch.TaskDeleteContextVariables,
+
+	"description",
+	"""
+	Removes variables from the context so that they won't be visible to upstream nodes.
+	""",
+
+	plugs = {
+
+		"variables" : [
+
+			"description",
+			"""
+			The variables to be deleted.
+			""",
+
+		]
+
+	}
+
+)

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -467,6 +467,7 @@ nodeMenu.append( "/Dispatch/Task List", GafferDispatch.TaskList, searchText = "T
 nodeMenu.append( "/Dispatch/Task Switch", GafferDispatch.TaskSwitch, searchText = "TaskSwitch" )
 nodeMenu.append( "/Dispatch/Wedge", GafferDispatch.Wedge )
 nodeMenu.append( "/Dispatch/Variables", GafferDispatch.TaskContextVariables, searchText = "TaskContextVariables" )
+nodeMenu.append( "/Dispatch/Delete Variables", GafferDispatch.TaskDeleteContextVariables, searchText = "TaskDeleteContextVariables" )
 nodeMenu.append( "/Dispatch/Frame Mask", GafferDispatch.FrameMask, searchText = "FrameMask" )
 
 # Utility nodes


### PR DESCRIPTION
Two small improvements to ArnoldTextureBake:
* In testing at IE, we've found that a 1 pixel median filter sometimes makes bakes a lot more usable without cranking the samples way up.  I've added this as an option to the node.
* I've connected through the dispatch settings to the render task node.  I haven't connected through the settings to the image task node, since it is much faster and shouldn't need special settings - this matches how we've been handling denoise tasks as part of renders at IE, hopefully it feels reasonable.
