### PR TITLE
Dispatcher : Support generic Switch and ContextProcessor nodes

### DIFF
--- a/include/Gaffer/ContextProcessor.h
+++ b/include/Gaffer/ContextProcessor.h
@@ -57,13 +57,13 @@ class IECORE_EXPORT ContextProcessor : public ComputeNode
 		~ContextProcessor() override;
 
 		/// \undoable
-		void setup( const ValuePlug *plug );
+		void setup( const Plug *plug );
 
-		ValuePlug *inPlug();
-		const ValuePlug *inPlug() const;
+		Plug *inPlug();
+		const Plug *inPlug() const;
 
-		ValuePlug *outPlug();
-		const ValuePlug *outPlug() const;
+		Plug *outPlug();
+		const Plug *outPlug() const;
 
 		BoolPlug *enabledPlug() override;
 		const BoolPlug *enabledPlug() const override;
@@ -92,10 +92,10 @@ class IECORE_EXPORT ContextProcessor : public ComputeNode
 
 	private :
 
-		static const ValuePlug *correspondingDescendant( const ValuePlug *plug, const ValuePlug *plugAncestor, const ValuePlug *oppositeAncestor );
+		static const Plug *correspondingDescendant( const Plug *plug, const Plug *plugAncestor, const Plug *oppositeAncestor );
 
 		/// Returns the input corresponding to the output and vice versa.
-		const ValuePlug *oppositePlug( const ValuePlug *plug ) const;
+		const Plug *oppositePlug( const Plug *plug ) const;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/Gaffer/ContextProcessor.h
+++ b/include/Gaffer/ContextProcessor.h
@@ -73,6 +73,10 @@ class IECORE_EXPORT ContextProcessor : public ComputeNode
 
 		void affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const override;
 
+		/// Returns the context that `inPlug()` will be evaluated in
+		/// when `outPlug()` is evaluated in the current context.
+		ContextPtr inPlugContext() const;
+
 	protected :
 
 		/// Implemented to return the hash of the matching input using a context modified by

--- a/include/GafferDispatch/TaskNode.h
+++ b/include/GafferDispatch/TaskNode.h
@@ -82,8 +82,7 @@ class GAFFERDISPATCH_API TaskNode : public Gaffer::DependencyNode
 		IE_CORE_FORWARDDECLARE( TaskPlug )
 
 		/// Defines a task for dispatch by storing a TaskPlug and
-		/// the context in which it should be executed. This is
-		/// primarily for the use of Dispatcher classes. See TaskPlug
+		/// the context in which it should be executed. See TaskPlug
 		/// for the main public interface for the execution of
 		/// individual tasks.
 		class Task
@@ -99,15 +98,8 @@ class GAFFERDISPATCH_API TaskNode : public Gaffer::DependencyNode
 				const TaskPlug *plug() const;
 				/// Returns the Context component of the task.
 				const Gaffer::Context *context() const;
-				/// Returns a hash uniquely representing the side effects
-				/// of the task. This is stored from `plug->hash()`
-				/// during construction, so editing the node or upstream
-				/// graph will invalidate the hash (and therefore the task).
-				const IECore::MurmurHash hash() const;
-				/// Compares hashes.
+
 				bool operator == ( const Task &rhs ) const;
-				/// Compares hashes.
-				bool operator < ( const Task &rhs ) const;
 
 				/// \deprecated
 				Task( TaskNodePtr n, const Gaffer::Context *c );
@@ -118,7 +110,6 @@ class GAFFERDISPATCH_API TaskNode : public Gaffer::DependencyNode
 
 				ConstTaskPlugPtr m_plug;
 				Gaffer::ConstContextPtr m_context;
-				IECore::MurmurHash m_hash;
 
 		};
 

--- a/python/GafferCortexTest/ExecutableOpHolderTest.py
+++ b/python/GafferCortexTest/ExecutableOpHolderTest.py
@@ -155,23 +155,18 @@ class ExecutableOpHolderTest( GafferTest.TestCase ) :
 		n1["preTasks"][0].setInput( n2["task"] )
 		n2["preTasks"][0].setInput( n2a["task"] )
 
-		r2 = Gaffer.Plug( name = "r2" )
 		n2["preTasks"][1].setInput( n2b["task"] )
 
 		with Gaffer.Context() as c :
 
 			self.assertEqual( n2a["task"].preTasks(), [] )
 			self.assertEqual( n2b["task"].preTasks(), [] )
+
 			n2PreTasks = n2["task"].preTasks()
-			self.assertEqual( n2PreTasks[0].node(), n2a )
-			self.assertEqual( n2PreTasks[0].context(), c )
-			self.assertEqual( n2PreTasks[1].node(), n2b )
-			self.assertEqual( n2PreTasks[1].context(), c )
-			t1 = GafferDispatch.TaskNode.Task(n2a,c)
-			t2 = GafferDispatch.TaskNode.Task(n2b,c)
-			self.assertEqual( n2PreTasks[0], t1 )
-			self.assertEqual( n2PreTasks[1], t2 )
-			self.assertEqual( len( set( n2["task"].preTasks() ).difference( [ t1, t2] ) ), 0 )
+			self.assertEqual( len( n2PreTasks ), 2 )
+			self.assertEqual( n2PreTasks[0], GafferDispatch.TaskNode.Task( n2a, c ) )
+			self.assertEqual( n2PreTasks[1], GafferDispatch.TaskNode.Task( n2b, c ) )
+
 			self.assertEqual( n1["task"].preTasks(), [ GafferDispatch.TaskNode.Task( n2, c ) ] )
 
 	def testSerialise( self ) :

--- a/python/GafferDispatch/TaskContextProcessor.py
+++ b/python/GafferDispatch/TaskContextProcessor.py
@@ -56,10 +56,7 @@ class TaskContextProcessor( GafferDispatch.TaskNode ) :
 			if source.isSame( plug ) :
 				continue
 
-			if not isinstance( source.node(), GafferDispatch.TaskNode ):
-				continue
-
-			result.extend( [ self.Task( source.node(), c ) for c in contexts ] )
+			result.extend( [ self.Task( source, c ) for c in contexts ] )
 
 		return result
 

--- a/python/GafferDispatch/TaskContextProcessor.py
+++ b/python/GafferDispatch/TaskContextProcessor.py
@@ -39,6 +39,10 @@ import IECore
 import Gaffer
 import GafferDispatch
 
+## \todo Since we can now use regular Gaffer.ContextProcessors
+# with TaskNodes, the only legitimate subclass of TaskContextProcessor
+# is the Wedge node. So we could probably just remove the
+# TaskContextProcessor class entirely.
 class TaskContextProcessor( GafferDispatch.TaskNode ) :
 
 	def __init__( self, name = "TaskContextProcessor" ) :

--- a/python/GafferDispatch/TaskContextVariables.py
+++ b/python/GafferDispatch/TaskContextVariables.py
@@ -39,6 +39,9 @@ import IECore
 import Gaffer
 import GafferDispatch
 
+## \deprecated Use `Gaffer.ContextVariables` instead.
+# \todo Move to a compatibility config, perhaps reimplemented
+# as a ContextVariables node embedded inside a TaskNode.
 class TaskContextVariables( GafferDispatch.TaskContextProcessor ) :
 
 	def __init__( self, name = "TaskContextVariables" ) :

--- a/python/GafferDispatch/TaskSwitch.py
+++ b/python/GafferDispatch/TaskSwitch.py
@@ -53,10 +53,10 @@ class TaskSwitch( GafferDispatch.TaskNode ) :
 		index = index % ( len( self["preTasks"] ) - 1 )
 
 		source = self["preTasks"][index].source()
-		if source.isSame( self["preTasks"][index] ) or not isinstance( source.node(), GafferDispatch.TaskNode ) :
+		if source.isSame( self["preTasks"][index] ) :
 			return []
 
-		return [ self.Task( source.node(), context ) ]
+		return [ self.Task( source, context ) ]
 
 	def hash( self, context ) :
 

--- a/python/GafferDispatch/TaskSwitch.py
+++ b/python/GafferDispatch/TaskSwitch.py
@@ -39,6 +39,9 @@ import IECore
 import Gaffer
 import GafferDispatch
 
+## \deprecated Use `Gaffer.Switch` instead.
+# \todo Move to a compatibility config, perhaps reimplemented
+# as a Switch node embedded inside a TaskNode.
 class TaskSwitch( GafferDispatch.TaskNode ) :
 
 	def __init__( self, name = "TaskSwitch" ) :

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -1627,5 +1627,63 @@ class DispatcherTest( GafferTest.TestCase ) :
 		with self.assertRaisesRegexp( Exception, "Python argument types in" ) :
 			d.frameRange( Gaffer.ScriptNode(), None )
 
+	def testSwitch( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n1"] = GafferDispatchTest.LoggingTaskNode()
+		s["n2"] = GafferDispatchTest.LoggingTaskNode()
+
+		s["switch"] = Gaffer.Switch()
+		s["switch"].setup( s["n1"]["task"] )
+		s["switch"]["in"][0].setInput( s["n1"]["task"] )
+		s["switch"]["in"][1].setInput( s["n2"]["task"] )
+
+		s["n3"] = GafferDispatchTest.LoggingTaskNode()
+		s["n3"]["preTasks"][0].setInput( s["switch"]["out"] )
+
+		dispatcher = GafferDispatch.Dispatcher.create( "testDispatcher" )
+
+		s["switch"]["index"].setValue( 1 )
+		dispatcher.dispatch( [ s["n3"] ] )
+
+		self.assertEqual( len( s["n1"].log ), 0 )
+		self.assertEqual( len( s["n2"].log ), 1 )
+		self.assertEqual( len( s["n3"].log ), 1 )
+
+		s["switch"]["index"].setValue( 0 )
+		dispatcher.dispatch( [ s["n3"] ] )
+
+		self.assertEqual( len( s["n1"].log ), 1 )
+		self.assertEqual( len( s["n2"].log ), 1 )
+		self.assertEqual( len( s["n3"].log ), 2 )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( "parent['switch']['index'] = context.getFrame()" )
+
+		with Gaffer.Context() as c :
+
+			c.setFrame( 0 )
+			dispatcher.dispatch( [ s["n3"] ] )
+
+			self.assertEqual( len( s["n1"].log ), 2 )
+			self.assertEqual( len( s["n2"].log ), 1 )
+			self.assertEqual( len( s["n3"].log ), 3 )
+
+			c.setFrame( 1 )
+			dispatcher.dispatch( [ s["n3"] ] )
+
+			self.assertEqual( len( s["n1"].log ), 2 )
+			self.assertEqual( len( s["n2"].log ), 2 )
+			self.assertEqual( len( s["n3"].log ), 4 )
+
+			c.setFrame( 0 )
+			s["switch"]["in"][0].setInput( None )
+			dispatcher.dispatch( [ s["n3"] ] )
+
+			self.assertEqual( len( s["n1"].log ), 2 )
+			self.assertEqual( len( s["n2"].log ), 2 )
+			self.assertEqual( len( s["n3"].log ), 5 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -1685,5 +1685,29 @@ class DispatcherTest( GafferTest.TestCase ) :
 			self.assertEqual( len( s["n2"].log ), 2 )
 			self.assertEqual( len( s["n3"].log ), 5 )
 
+	def testContextProcessor( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n1"] = GafferDispatchTest.LoggingTaskNode()
+
+		s["cv"] = Gaffer.ContextVariables()
+		s["cv"].setup( s["n1"]["task"] )
+		s["cv"]["in"].setInput( s["n1"]["task"] )
+		s["cv"]["variables"].addMember( "test", 10 )
+
+		s["n2"] = GafferDispatchTest.LoggingTaskNode()
+		s["n2"]["preTasks"][0].setInput( s["cv"]["out"] )
+
+		dispatcher = GafferDispatch.Dispatcher.create( "testDispatcher" )
+		dispatcher.dispatch( [ s["n2"] ] )
+
+		self.assertEqual( len( s["n1"].log ), 1 )
+		self.assertEqual( len( s["n2"].log ), 1 )
+
+		self.assertNotIn( "test", s["n2"].log[0].context )
+		self.assertIn( "test", s["n1"].log[0].context )
+		self.assertEqual( s["n1"].log[0].context["test"], 10 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDispatchTest/TaskNodeTest.py
+++ b/python/GafferDispatchTest/TaskNodeTest.py
@@ -237,68 +237,6 @@ class TaskNodeTest( GafferTest.TestCase ) :
 		self.assertNotEqual( t3, t4 )
 		self.assertNotEqual( t4, t3 )
 
-	def testTaskSet( self ) :
-
-		# A no-op TaskNode doesn't actually compute anything, so all tasks are the same
-		c = Gaffer.Context()
-		n = GafferDispatchTest.LoggingTaskNode()
-		n["noOp"].setValue( True )
-		t1 = GafferDispatch.TaskNode.Task( n, c )
-		t2 = GafferDispatch.TaskNode.Task( n, c )
-		self.assertEqual( t1, t2 )
-		c2 = Gaffer.Context()
-		c2["a"] = 2
-		t3 = GafferDispatch.TaskNode.Task( n, c2 )
-		self.assertEqual( t1, t3 )
-		n2 = GafferDispatchTest.LoggingTaskNode()
-		n2["noOp"].setValue( True )
-		t4 = GafferDispatch.TaskNode.Task( n2, c2 )
-		self.assertEqual( t1, t4 )
-		t5 = GafferDispatch.TaskNode.Task( n2, c )
-		self.assertEqual( t1, t5 )
-
-		s = set( [ t1, t2, t3, t4, t4, t4, t1, t2, t4, t3, t2 ] )
-		# there should only be 1 task because they all have identical results
-		self.assertEqual( len(s), 1 )
-		self.assertEqual( s, set( [ t1 ] ) )
-		self.assertTrue( t1 in s )
-		self.assertTrue( t2 in s )
-		self.assertTrue( t3 in s )
-		self.assertTrue( t4 in s )
-		# even t5 is in there, because it's really the same task
-		self.assertTrue( t5 in s )
-
-		# MyNode.hash() depends on the context time, so tasks will vary
-		my = GafferDispatchTest.LoggingTaskNode()
-		my["frameSensitivePlug"] = Gaffer.StringPlug( defaultValue = "####" )
-		c.setFrame( 1 )
-		t1 = GafferDispatch.TaskNode.Task( my, c )
-		t2 = GafferDispatch.TaskNode.Task( my, c )
-		self.assertEqual( t1, t2 )
-		c2 = Gaffer.Context()
-		c2.setFrame( 2 )
-		t3 = GafferDispatch.TaskNode.Task( my, c2 )
-		self.assertNotEqual( t1, t3 )
-		my2 = GafferDispatchTest.LoggingTaskNode()
-		my2["frameSensitivePlug"] = Gaffer.StringPlug( defaultValue = "####" )
-		t4 = GafferDispatch.TaskNode.Task( my2, c2 )
-		self.assertNotEqual( t1, t4 )
-		self.assertEqual( t3, t4 )
-		t5 = GafferDispatch.TaskNode.Task( my2, c )
-		self.assertEqual( t1, t5 )
-		self.assertNotEqual( t3, t5 )
-
-		s = set( [ t1, t2, t3, t4, t4, t4, t1, t2, t4, t3, t2 ] )
-		# t1 and t3 are the only distinct tasks
-		self.assertEqual( len(s), 2 )
-		self.assertEqual( s, set( [ t1, t3 ] ) )
-		# but they still all have equivalent tasks in the set
-		self.assertTrue( t1 in s )
-		self.assertTrue( t2 in s )
-		self.assertTrue( t3 in s )
-		self.assertTrue( t4 in s )
-		self.assertTrue( t5 in s )
-
 	def testInputAcceptanceInsideBoxes( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferDispatchTest/TaskNodeTest.py
+++ b/python/GafferDispatchTest/TaskNodeTest.py
@@ -202,13 +202,20 @@ class TaskNodeTest( GafferTest.TestCase ) :
 		t = GafferDispatch.TaskNode.Task( n, c )
 		t2 = GafferDispatch.TaskNode.Task( n, c )
 		t3 = GafferDispatch.TaskNode.Task( t2 )
+		t4 = GafferDispatch.TaskNode.Task( n["task"], c )
 
+		self.assertEqual( t.plug(), n["task"] )
 		self.assertEqual( t.node(), n )
 		self.assertEqual( t.context(), c )
+		self.assertEqual( t2.plug(), n["task"] )
 		self.assertEqual( t2.node(), n )
 		self.assertEqual( t2.context(), c )
+		self.assertEqual( t3.plug(), n["task"] )
 		self.assertEqual( t3.node(), n )
 		self.assertEqual( t3.context(), c )
+		self.assertEqual( t4.plug(), n["task"] )
+		self.assertEqual( t4.node(), n )
+		self.assertEqual( t4.context(), c )
 
 	def testTaskComparison( self ) :
 

--- a/python/GafferTest/TimeWarpTest.py
+++ b/python/GafferTest/TimeWarpTest.py
@@ -142,5 +142,19 @@ class TimeWarpTest( GafferTest.TestCase ) :
 				self.assertEqual( s["m"]["product"].getValue(), s["w"]["out"].getValue() )
 				self.assertEqual( s["m"]["product"].hash(), s["w"]["out"].hash() )
 
+	def testInPlugContext( self ) :
+
+		n = Gaffer.TimeWarp()
+		n.setup( Gaffer.Plug() )
+
+		with Gaffer.Context() as c :
+
+			c.setFrame( 10 )
+			n["offset"].setValue( 1 )
+			self.assertEqual( n.inPlugContext().getFrame(), 11 )
+
+			n["enabled"].setValue( False )
+			self.assertEqual( n.inPlugContext().getFrame(), 10 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/ContextVariablesUI.py
+++ b/python/GafferUI/ContextVariablesUI.py
@@ -48,6 +48,18 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+		"in" : [
+
+			"plugValueWidget:type", "",
+
+		],
+
+		"out" : [
+
+			"plugValueWidget:type", "",
+
+		],
+
 		"variables" : [
 
 			"description",

--- a/src/Gaffer/ContextProcessor.cpp
+++ b/src/Gaffer/ContextProcessor.cpp
@@ -167,6 +167,20 @@ void ContextProcessor::affects( const Plug *input, DependencyNode::AffectedPlugs
 	}
 }
 
+ContextPtr ContextProcessor::inPlugContext() const
+{
+	if( enabledPlug()->getValue() )
+	{
+		Context::EditableScope scope( Context::current() );
+		processContext( scope );
+		return new Context( *Context::current() );
+	}
+	else
+	{
+		return new Context( *Context::current() );
+	}
+}
+
 void ContextProcessor::hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const
 {
 	const ValuePlug *input = oppositePlug( output );

--- a/src/Gaffer/ContextProcessor.cpp
+++ b/src/Gaffer/ContextProcessor.cpp
@@ -60,7 +60,7 @@ ContextProcessor::~ContextProcessor()
 {
 }
 
-void ContextProcessor::setup( const ValuePlug *plug )
+void ContextProcessor::setup( const Plug *plug )
 {
 	if( inPlug() )
 	{
@@ -81,24 +81,24 @@ void ContextProcessor::setup( const ValuePlug *plug )
 	addChild( out );
 }
 
-ValuePlug *ContextProcessor::inPlug()
+Plug *ContextProcessor::inPlug()
 {
-	return getChild<ValuePlug>( g_inPlugName );
+	return getChild<Plug>( g_inPlugName );
 }
 
-const ValuePlug *ContextProcessor::inPlug() const
+const Plug *ContextProcessor::inPlug() const
 {
-	return getChild<ValuePlug>( g_inPlugName );
+	return getChild<Plug>( g_inPlugName );
 }
 
-ValuePlug *ContextProcessor::outPlug()
+Plug *ContextProcessor::outPlug()
 {
-	return getChild<ValuePlug>( g_outPlugName );
+	return getChild<Plug>( g_outPlugName );
 }
 
-const ValuePlug *ContextProcessor::outPlug() const
+const Plug *ContextProcessor::outPlug() const
 {
-	return getChild<ValuePlug>( g_outPlugName );
+	return getChild<Plug>( g_outPlugName );
 }
 
 BoolPlug *ContextProcessor::enabledPlug()
@@ -135,13 +135,9 @@ void ContextProcessor::affects( const Plug *input, DependencyNode::AffectedPlugs
 
 	if( input->direction() == Plug::In )
 	{
-		if( const ValuePlug *inputValuePlug = IECore::runTimeCast<const ValuePlug>( input ) )
+		if( const Plug *output = oppositePlug( input ) )
 		{
-			const ValuePlug *output = oppositePlug( inputValuePlug );
-			if( output )
-			{
-				outputs.push_back( output );
-			}
+			outputs.push_back( output );
 		}
 	}
 
@@ -183,7 +179,7 @@ ContextPtr ContextProcessor::inPlugContext() const
 
 void ContextProcessor::hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const
 {
-	const ValuePlug *input = oppositePlug( output );
+	auto input = IECore::runTimeCast<const ValuePlug>( oppositePlug( output ) );
 	if( input )
 	{
 		if( enabledPlug()->getValue() )
@@ -204,7 +200,7 @@ void ContextProcessor::hash( const ValuePlug *output, const Context *context, IE
 
 void ContextProcessor::compute( ValuePlug *output, const Context *context ) const
 {
-	const ValuePlug *input = oppositePlug( output );
+	auto input = IECore::runTimeCast<const ValuePlug>( oppositePlug( output ) );
 	if( input )
 	{
 		if( enabledPlug()->getValue() )
@@ -223,7 +219,7 @@ void ContextProcessor::compute( ValuePlug *output, const Context *context ) cons
 	return ComputeNode::compute( output, context );
 }
 
-const ValuePlug *ContextProcessor::correspondingDescendant( const ValuePlug *plug, const ValuePlug *plugAncestor, const ValuePlug *oppositeAncestor )
+const Plug *ContextProcessor::correspondingDescendant( const Plug *plug, const Plug *plugAncestor, const Plug *oppositeAncestor )
 {
 	// this method recursively computes oppositeAncestor->descendant( plug->relativeName( plugAncestor ) ).
 	// ie it finds the relative path from plugAncestor to plug, and follows it from oppositeAncestor.
@@ -239,7 +235,7 @@ const ValuePlug *ContextProcessor::correspondingDescendant( const ValuePlug *plu
 	// return its child with the same name as "plug" (if either of those things exist):
 
 	// get parent of this plug:
-	const ValuePlug *plugParent = plug->parent<ValuePlug>();
+	const Plug *plugParent = plug->parent<Plug>();
 	if( !plugParent )
 	{
 		// looks like the "plug" we initially called this function with wasn't
@@ -249,7 +245,7 @@ const ValuePlug *ContextProcessor::correspondingDescendant( const ValuePlug *plu
 	}
 
 	// find the corresponding plug for the parent:
-	const ValuePlug *oppositeParent = correspondingDescendant( plugParent, plugAncestor, oppositeAncestor );
+	const Plug *oppositeParent = correspondingDescendant( plugParent, plugAncestor, oppositeAncestor );
 	if( !oppositeParent )
 	{
 		return nullptr;
@@ -259,10 +255,10 @@ const ValuePlug *ContextProcessor::correspondingDescendant( const ValuePlug *plu
 	return oppositeParent->getChild<ValuePlug>( plug->getName() );
 }
 
-const ValuePlug *ContextProcessor::oppositePlug( const ValuePlug *plug ) const
+const Plug *ContextProcessor::oppositePlug( const Plug *plug ) const
 {
-	const ValuePlug *inPlug = this->inPlug();
-	const ValuePlug *outPlug = this->outPlug();
+	const Plug *inPlug = this->inPlug();
+	const Plug *outPlug = this->outPlug();
 
 	if( !( outPlug && inPlug ) )
 	{

--- a/src/GafferDispatch/TaskNode.cpp
+++ b/src/GafferDispatch/TaskNode.cpp
@@ -387,13 +387,15 @@ void TaskNode::preTasks( const Context *context, Tasks &tasks ) const
 {
 	for( PlugIterator cIt( preTasksPlug() ); !cIt.done(); ++cIt )
 	{
-		Plug *source = (*cIt)->source();
-		if( source != *cIt && source->direction() == Plug::Out )
+		/// \todo Use all plugs unconditionally, and leave TaskPlug/Dispatcher
+		/// to worry about unconnected plugs and plug direction. We can't do
+		/// this currently because we are using PlugIterator rather than TaskPlugIterator,
+		/// to support plugs created long ago, when TaskPlug didn't even exist.
+		/// See related hack in `ArrayPlug::acceptsChild()`.
+		TaskPlug *source = (*cIt)->source<TaskPlug>();
+		if( source && source != *cIt && source->direction() == Plug::Out )
 		{
-			if( TaskNodePtr n = runTimeCast<TaskNode>( source->node() ) )
-			{
-				tasks.push_back( Task( n, context ) );
-			}
+			tasks.push_back( Task( source, context ) );
 		}
 	}
 }
@@ -402,13 +404,15 @@ void TaskNode::postTasks( const Context *context, Tasks &tasks ) const
 {
 	for( PlugIterator cIt( postTasksPlug() ); !cIt.done(); ++cIt )
 	{
-		Plug *source = (*cIt)->source();
-		if( source != *cIt && source->direction() == Plug::Out )
+		/// \todo Use all plugs unconditionally, and leave TaskPlug/Dispatcher
+		/// to worry about unconnected plugs and plug direction. We can't do
+		/// this currently because we are using PlugIterator rather than TaskPlugIterator,
+		/// to support plugs created long ago, when TaskPlug didn't even exist.
+		/// See related hack in `ArrayPlug::acceptsChild()`.
+		TaskPlug *source = (*cIt)->source<TaskPlug>();
+		if( source && source != *cIt && source->direction() == Plug::Out )
 		{
-			if( TaskNodePtr n = runTimeCast<TaskNode>( source->node() ) )
-			{
-				tasks.push_back( Task( n, context ) );
-			}
+			tasks.push_back( Task( source, context ) );
 		}
 	}
 }

--- a/src/GafferDispatch/TaskNode.cpp
+++ b/src/GafferDispatch/TaskNode.cpp
@@ -56,18 +56,14 @@ using namespace GafferDispatch;
 TaskNode::Task::Task( ConstTaskPlugPtr plug, const Gaffer::Context *context )
 	:	m_plug( plug ), m_context( new Context( *context ) )
 {
-	Context::Scope scopedContext( m_context.get() );
-	m_hash = m_plug->hash();
 }
 
-TaskNode::Task::Task( const Task &t ) : m_plug( t.m_plug ), m_context( t.m_context ), m_hash( t.m_hash )
+TaskNode::Task::Task( const Task &t ) : m_plug( t.m_plug ), m_context( t.m_context )
 {
 }
 
 TaskNode::Task::Task( TaskNodePtr n, const Context *c ) : m_plug( n->taskPlug() ), m_context( new Context( *c ) )
 {
-	Context::Scope scopedContext( m_context.get() );
-	m_hash = m_plug->hash();
 }
 
 const TaskNode::TaskPlug *TaskNode::Task::plug() const
@@ -85,19 +81,9 @@ const Context *TaskNode::Task::context() const
 	return m_context.get();
 }
 
-const MurmurHash TaskNode::Task::hash() const
-{
-	return m_hash;
-}
-
 bool TaskNode::Task::operator == ( const Task &rhs ) const
 {
-	return ( m_hash == rhs.m_hash );
-}
-
-bool TaskNode::Task::operator < ( const Task &rhs ) const
-{
-	return ( m_hash < rhs.m_hash );
+	return m_plug == rhs.m_plug && *m_context == *rhs.m_context;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/GafferDispatchModule/TaskNodeBinding.cpp
+++ b/src/GafferDispatchModule/TaskNodeBinding.cpp
@@ -59,12 +59,6 @@ using namespace GafferDispatchBindings;
 namespace
 {
 
-unsigned long taskHash( const TaskNode::Task &t )
-{
-	const IECore::MurmurHash h = t.hash();
-	return tbb::tbb_hasher( h.toString() );
-}
-
 ContextPtr taskContext( const TaskNode::Task &t, bool copy = true )
 {
 	if ( ConstContextPtr context = t.context() )
@@ -161,7 +155,6 @@ void GafferDispatchModule::bindTaskNode()
 		.def( "plug", &taskPlug )
 		.def( "context", &taskContext, ( boost::python::arg_( "_copy" ) = true ) )
 		.def("__eq__", &TaskNode::Task::operator== )
-		.def("__hash__", &taskHash )
 	;
 
 	PlugClass<TaskNode::TaskPlug>()

--- a/src/GafferDispatchModule/TaskNodeBinding.cpp
+++ b/src/GafferDispatchModule/TaskNodeBinding.cpp
@@ -90,6 +90,11 @@ TaskNodePtr taskNode( const TaskNode::Task &t )
 	return nullptr;
 }
 
+TaskNode::TaskPlugPtr taskPlug( const TaskNode::Task &t )
+{
+	return const_cast<TaskNode::TaskPlug *>( t.plug() );
+}
+
 IECore::MurmurHash taskPlugHash( const TaskNode::TaskPlug &t )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -150,8 +155,10 @@ void GafferDispatchModule::bindTaskNode()
 
 	class_<TaskNode::Task>( "Task", no_init )
 		.def( init<TaskNode::Task>() )
+		.def( init<GafferDispatch::TaskNode::TaskPlugPtr, const Gaffer::Context *>() )
 		.def( init<GafferDispatch::TaskNodePtr, const Gaffer::Context *>() )
 		.def( "node", &taskNode )
+		.def( "plug", &taskPlug )
 		.def( "context", &taskContext, ( boost::python::arg_( "_copy" ) = true ) )
 		.def("__eq__", &TaskNode::Task::operator== )
 		.def("__hash__", &taskHash )

--- a/src/GafferModule/ContextProcessorBinding.cpp
+++ b/src/GafferModule/ContextProcessorBinding.cpp
@@ -63,6 +63,12 @@ void setup( T &n, const ValuePlug &plug )
 	n.setup( &plug );
 }
 
+ContextPtr inPlugContext( const ContextProcessor &n )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return n.inPlugContext();
+}
+
 class SetupBasedNodeSerialiser : public NodeSerialiser
 {
 
@@ -118,6 +124,7 @@ void GafferModule::bindContextProcessor()
 
 	DependencyNodeClass<ContextProcessor>()
 		.def( "setup", &setup<ContextProcessor> )
+		.def( "inPlugContext", &inPlugContext )
 	;
 
 	DependencyNodeClass<TimeWarp>();

--- a/src/GafferModule/ContextProcessorBinding.cpp
+++ b/src/GafferModule/ContextProcessorBinding.cpp
@@ -56,8 +56,13 @@ namespace
 IECore::InternedString g_inPlugName( "in" );
 IECore::InternedString g_outPlugName( "out" );
 
-template<typename T>
-void setup( T &n, const ValuePlug &plug )
+void setupContextProcessor( ContextProcessor &n, const Plug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	n.setup( &plug );
+}
+
+void setupLoop( Loop &n, const ValuePlug &plug )
 {
 	IECorePython::ScopedGILRelease gilRelease;
 	n.setup( &plug );
@@ -119,11 +124,11 @@ void GafferModule::bindContextProcessor()
 {
 
 	DependencyNodeClass<Loop>()
-		.def( "setup", &setup<Loop> )
+		.def( "setup", &setupLoop )
 	;
 
 	DependencyNodeClass<ContextProcessor>()
-		.def( "setup", &setup<ContextProcessor> )
+		.def( "setup", &setupContextProcessor )
 		.def( "inPlugContext", &inPlugContext )
 	;
 

--- a/src/GafferUI/ContextProcessorUI.cpp
+++ b/src/GafferUI/ContextProcessorUI.cpp
@@ -64,18 +64,9 @@ class ContextProcessorPlugAdder : public PlugAdder
 
 	protected :
 
-		bool canCreateConnection( const Plug *endpoint ) const override
-		{
-			if( !PlugAdder::canCreateConnection( endpoint ) )
-			{
-				return false;
-			}
-			return runTimeCast<const ValuePlug>( endpoint );
-		}
-
 		void createConnection( Plug *endpoint ) override
 		{
-			m_node->setup( static_cast<const ValuePlug *>( endpoint ) );
+			m_node->setup( endpoint );
 
 			bool inOpposite = false;
 			if( endpoint->direction() == Plug::Out )

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -464,9 +464,7 @@ import GafferDispatchUI
 nodeMenu.append( "/Dispatch/System Command", GafferDispatch.SystemCommand, searchText = "SystemCommand" )
 nodeMenu.append( "/Dispatch/Python Command", GafferDispatch.PythonCommand, searchText = "PythonCommand" )
 nodeMenu.append( "/Dispatch/Task List", GafferDispatch.TaskList, searchText = "TaskList" )
-nodeMenu.append( "/Dispatch/Task Switch", GafferDispatch.TaskSwitch, searchText = "TaskSwitch" )
 nodeMenu.append( "/Dispatch/Wedge", GafferDispatch.Wedge )
-nodeMenu.append( "/Dispatch/Variables", GafferDispatch.TaskContextVariables, searchText = "TaskContextVariables" )
 nodeMenu.append( "/Dispatch/Frame Mask", GafferDispatch.FrameMask, searchText = "FrameMask" )
 
 # Utility nodes


### PR DESCRIPTION
In 0.53, we removed the various specialised switches and context processors for scenes and images,  advertising that our shiny revamped generic nodes could be used in any scenario. Except that wasn't quite true, because although you could construct a TaskNode network utilising Switches and ContextProcessors, they wouldn't dispatch correctly. This puts that right, and deprecates TaskSwitch and TaskContextVariables, with an aim to eventually removing them.