### PR TITLE
GraphEditor Annotations

### DIFF
--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -173,6 +173,15 @@ class stats( Gaffer.Application ) :
 					defaultValue = "",
 				),
 
+				IECore.FileNameParameter(
+					name = "annotatedScript",
+					description = "Filename used to save a copy of the script containing "
+						"annotations from the performance and context monitors.",
+					defaultValue = "",
+					allowEmptyString = True,
+					extensions = "gfr",
+				),
+
 				IECore.BoolParameter(
 					name = "vtune",
 					description = "Enables VTune instrumentation. When enabled, the VTune "
@@ -290,6 +299,16 @@ class stats( Gaffer.Application ) :
 		self.__output.write( "\n" )
 
 		self.__output.close()
+
+		if args["annotatedScript"].value :
+
+			if self.__performanceMonitor is not None :
+				Gaffer.MonitorAlgo.annotate( script, self.__performanceMonitor, Gaffer.MonitorAlgo.PerformanceMetric.TotalDuration )
+				Gaffer.MonitorAlgo.annotate( script, self.__performanceMonitor, Gaffer.MonitorAlgo.PerformanceMetric.HashCount )
+			if self.__contextMonitor is not None :
+				Gaffer.MonitorAlgo.annotate( script, self.__contextMonitor )
+
+			script.serialiseToFile( args["annotatedScript"].value )
 
 		return 0
 

--- a/include/Gaffer/MonitorAlgo.h
+++ b/include/Gaffer/MonitorAlgo.h
@@ -44,6 +44,7 @@
 namespace Gaffer
 {
 
+class ContextMonitor;
 class Node;
 class PerformanceMonitor;
 
@@ -71,6 +72,7 @@ GAFFER_API std::string formatStatistics( const PerformanceMonitor &monitor, Perf
 
 GAFFER_API void annotate( Node &root, const PerformanceMonitor &monitor );
 GAFFER_API void annotate( Node &root, const PerformanceMonitor &monitor, PerformanceMetric metric );
+GAFFER_API void annotate( Node &root, const ContextMonitor &monitor );
 
 } // namespace MonitorAlgo
 

--- a/include/Gaffer/MonitorAlgo.h
+++ b/include/Gaffer/MonitorAlgo.h
@@ -44,6 +44,7 @@
 namespace Gaffer
 {
 
+class Node;
 class PerformanceMonitor;
 
 namespace MonitorAlgo
@@ -67,6 +68,9 @@ enum PerformanceMetric
 
 GAFFER_API std::string formatStatistics( const PerformanceMonitor &monitor, size_t maxLinesPerMetric = 50 );
 GAFFER_API std::string formatStatistics( const PerformanceMonitor &monitor, PerformanceMetric metric, size_t maxLines = 50 );
+
+GAFFER_API void annotate( Node &root, const PerformanceMonitor &monitor );
+GAFFER_API void annotate( Node &root, const PerformanceMonitor &monitor, PerformanceMetric metric );
 
 } // namespace MonitorAlgo
 

--- a/include/GafferUI/AnnotationsGadget.h
+++ b/include/GafferUI/AnnotationsGadget.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2011-2012, John Haddon. All rights reserved.
-//  Copyright (c) 2011-2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2019, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,57 +34,73 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERUI_TYPEIDS_H
-#define GAFFERUI_TYPEIDS_H
+#ifndef GAFFERUI_ANNOTATIONSGADGET_H
+#define GAFFERUI_ANNOTATIONSGADGET_H
+
+#include "GafferUI/Gadget.h"
+
+#include <unordered_map>
+
+namespace Gaffer
+{
+
+class Plug;
+class Node;
+
+} // namespace Gaffer
 
 namespace GafferUI
 {
 
-enum TypeId
-{
-	GadgetTypeId = 110251,
-	NodeGadgetTypeId = 110252,
-	GraphGadgetTypeId = 110253,
-	ContainerGadgetTypeId = 110254,
-	AuxiliaryConnectionsGadgetTypeId = 110255,
-	TextGadgetTypeId = 110256,
-	NameGadgetTypeId = 110257,
-	IndividualContainerTypeId = 110258,
-	FrameTypeId = 110259,
-	StyleTypeId = 110260,
-	StandardStyleTypeId = 110261,
-	NoduleTypeId = 110262,
-	LinearContainerTypeId = 110263,
-	ConnectionGadgetTypeId = 110264,
-	StandardNodeGadgetTypeId = 110265,
-	AuxiliaryNodeGadgetTypeId = 110266,
-	StandardNoduleTypeId = 110267,
-	CompoundNoduleTypeId = 110268,
-	ImageGadgetTypeId = 110269,
-	ViewportGadgetTypeId = 110270,
-	ViewTypeId = 110271,
-	ConnectionCreatorTypeId = 110272,
-	CompoundNumericNoduleTypeId = 110273,
-	PlugGadgetTypeId = 110274,
-	GraphLayoutTypeId = 110275,
-	StandardGraphLayoutTypeId = 110276,
-	BackdropNodeGadgetTypeId = 110277,
-	SpacerGadgetTypeId = 110278,
-	StandardConnectionGadgetTypeId = 110279,
-	HandleTypeId = 110280,
-	ToolTypeId = 110281,
-	DotNodeGadgetTypeId = 110282,
-	PlugAdderTypeId = 110283,
-	NoduleLayoutTypeId = 110284,
-	TranslateHandleTypeId = 110285,
-	ScaleHandleTypeId = 110286,
-	RotateHandleTypeId = 110287,
-	AnimationGadgetTypeId = 110288,
-	AnnotationsGadgetTypeId = 110289,
+class GraphGadget;
+class NodeGadget;
 
-	LastTypeId = 110450
+class GAFFERUI_API AnnotationsGadget : public Gadget
+{
+
+	public :
+
+		~AnnotationsGadget() override;
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferUI::AnnotationsGadget, AnnotationsGadgetTypeId, Gadget );
+
+		bool acceptsParent( const GraphComponent *potentialParent ) const override;
+
+	protected :
+
+		// Protected constructor and friend status so only GraphGadget can
+		// construct us.
+		AnnotationsGadget();
+		friend class GraphGadget;
+
+		void parentChanging( Gaffer::GraphComponent *newParent ) override;
+		void doRenderLayer( Layer layer, const Style *style ) const override;
+
+	private :
+
+		GraphGadget *graphGadget();
+		const GraphGadget *graphGadget() const;
+
+		void graphGadgetChildAdded( GraphComponent *child );
+		void graphGadgetChildRemoved( const GraphComponent *child );
+		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, Gaffer::Node *node );
+
+		struct Annotations
+		{
+			bool dirty = true;
+			bool bookmarked = false;
+			IECore::InternedString numericBookmark;
+			bool renderable = false;
+		};
+
+		boost::signals::scoped_connection m_graphGadgetChildAddedConnection;
+		boost::signals::scoped_connection m_graphGadgetChildRemovedConnection;
+
+		using AnnotationsContainer = std::unordered_map<const NodeGadget *, Annotations>;
+		mutable AnnotationsContainer m_annotations;
+
 };
 
 } // namespace GafferUI
 
-#endif // GAFFERUI_TYPEIDS_H
+#endif // GAFFERUI_ANNOTATIONSGADGET_H

--- a/include/GafferUI/AnnotationsGadget.h
+++ b/include/GafferUI/AnnotationsGadget.h
@@ -39,6 +39,8 @@
 
 #include "GafferUI/Gadget.h"
 
+#include "IECore/SimpleTypedData.h"
+
 #include <unordered_map>
 
 namespace Gaffer
@@ -85,9 +87,16 @@ class GAFFERUI_API AnnotationsGadget : public Gadget
 		void graphGadgetChildRemoved( const GraphComponent *child );
 		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, Gaffer::Node *node );
 
+		struct StandardAnnotation
+		{
+			IECore::ConstStringDataPtr text;
+			IECore::ConstColor3fDataPtr color;
+		};
+
 		struct Annotations
 		{
 			bool dirty = true;
+			std::vector<StandardAnnotation> standardAnnotations;
 			bool bookmarked = false;
 			IECore::InternedString numericBookmark;
 			bool renderable = false;

--- a/include/GafferUI/BackdropNodeGadget.h
+++ b/include/GafferUI/BackdropNodeGadget.h
@@ -90,7 +90,6 @@ class GAFFERUI_API BackdropNodeGadget : public NodeGadget
 		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node );
 
 		bool updateUserColor();
-		bool updateNumericBookmark();
 
 		Gaffer::Box2fPlug *boundPlug();
 		const Gaffer::Box2fPlug *boundPlug() const;
@@ -101,7 +100,7 @@ class GAFFERUI_API BackdropNodeGadget : public NodeGadget
 		int m_mergeGroupId;
 
 		boost::optional<Imath::Color3f> m_userColor;
-		boost::optional<std::string> m_numericBookmark;
+		boost::optional<std::string> m_unused;
 
 		static NodeGadgetTypeDescription<BackdropNodeGadget> g_nodeGadgetTypeDescription;
 

--- a/include/GafferUI/BackdropNodeGadget.h
+++ b/include/GafferUI/BackdropNodeGadget.h
@@ -100,7 +100,6 @@ class GAFFERUI_API BackdropNodeGadget : public NodeGadget
 		int m_mergeGroupId;
 
 		boost::optional<Imath::Color3f> m_userColor;
-		boost::optional<std::string> m_unused;
 
 		static NodeGadgetTypeDescription<BackdropNodeGadget> g_nodeGadgetTypeDescription;
 

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -161,7 +161,7 @@ class GAFFERUI_API StandardNodeGadget : public NodeGadget
 		ConnectionCreator *m_dragDestination;
 		boost::optional<Imath::Color3f> m_userColor;
 		bool m_oval;
-		boost::optional<std::string> m_unused;
+
 };
 
 IE_CORE_DECLAREPTR( StandardNodeGadget )

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -145,7 +145,6 @@ class GAFFERUI_API StandardNodeGadget : public NodeGadget
 		void updateNodeEnabled( const Gaffer::Plug *dirtiedPlug = nullptr );
 		void updateIcon();
 		bool updateShape();
-		bool updateNumericBookmark();
 
 		IE_CORE_FORWARDDECLARE( ErrorGadget );
 		ErrorGadget *errorGadget( bool createIfMissing = true );
@@ -162,7 +161,7 @@ class GAFFERUI_API StandardNodeGadget : public NodeGadget
 		ConnectionCreator *m_dragDestination;
 		boost::optional<Imath::Color3f> m_userColor;
 		bool m_oval;
-		boost::optional<std::string> m_numericBookmark;
+		boost::optional<std::string> m_unused;
 };
 
 IE_CORE_DECLAREPTR( StandardNodeGadget )

--- a/python/GafferTest/MonitorAlgoTest.py
+++ b/python/GafferTest/MonitorAlgoTest.py
@@ -1,0 +1,95 @@
+##########################################################################
+#
+#  Copyright (c) 2019, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferTest
+
+class MonitorAlgoTest( GafferTest.TestCase ) :
+
+	def testAnnotate( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+
+		s["b"]["n1"] = GafferTest.AddNode()
+		s["b"]["n1"]["op1"].setValue( 10024 )
+
+		s["b"]["n2"] = GafferTest.AddNode()
+		s["b"]["n2"]["op1"].setValue( 10023 )
+
+		with Gaffer.PerformanceMonitor() as m :
+			with Gaffer.Context() as c :
+
+				s["b"]["n1"]["sum"].getValue()
+				s["b"]["n2"]["sum"].getValue()
+
+				c.setFrame( 2 )
+				s["b"]["n1"]["sum"].getValue()
+
+		Gaffer.MonitorAlgo.annotate( s, m, Gaffer.MonitorAlgo.PerformanceMetric.ComputeCount )
+
+		self.assertEqual(
+			Gaffer.Metadata.value( s["b"]["n1"], "annotation:performanceMonitor:computeCount:text" ),
+			"Compute count : 1"
+		)
+		self.assertEqual(
+			Gaffer.Metadata.value( s["b"]["n2"], "annotation:performanceMonitor:computeCount:text" ),
+			"Compute count : 1"
+		)
+		self.assertEqual(
+			Gaffer.Metadata.value( s["b"], "annotation:performanceMonitor:computeCount:text" ),
+			"Compute count : 2"
+		)
+
+		Gaffer.MonitorAlgo.annotate( s, m, Gaffer.MonitorAlgo.PerformanceMetric.HashesPerCompute )
+
+		self.assertEqual(
+			Gaffer.Metadata.value( s["b"]["n1"], "annotation:performanceMonitor:hashesPerCompute:text" ),
+			"Hashes per compute : 2"
+		)
+		self.assertEqual(
+			Gaffer.Metadata.value( s["b"]["n2"], "annotation:performanceMonitor:hashesPerCompute:text" ),
+			"Hashes per compute : 1"
+		)
+		self.assertEqual(
+			Gaffer.Metadata.value( s["b"], "annotation:performanceMonitor:hashesPerCompute:text" ),
+			"Hashes per compute : 1.5"
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -136,6 +136,7 @@ from BoxIOTest import BoxIOTest
 from ParallelAlgoTest import ParallelAlgoTest
 from BackgroundTaskTest import BackgroundTaskTest
 from ProcessMessageHandlerTest import ProcessMessageHandlerTest
+from MonitorAlgoTest import MonitorAlgoTest
 
 if __name__ == "__main__":
 	import unittest

--- a/src/Gaffer/MonitorAlgo.cpp
+++ b/src/Gaffer/MonitorAlgo.cpp
@@ -61,10 +61,7 @@ struct InvalidMetric
 		return 0;
 	}
 
-	const char *description() const
-	{
-		return "invalid";
-	}
+	const std::string description = "invalid";
 
 };
 
@@ -78,10 +75,7 @@ struct HashCountMetric
 		return s.hashCount;
 	}
 
-	const char *description() const
-	{
-		return "number of hash processes";
-	}
+	const std::string description = "number of hash processes";
 
 };
 
@@ -95,10 +89,7 @@ struct ComputeCountMetric
 		return s.computeCount;
 	}
 
-	const char *description() const
-	{
-		return "number of compute processes";
-	}
+	const std::string description = "number of compute processes";
 
 };
 
@@ -112,10 +103,7 @@ struct HashDurationMetric
 		return s.hashDuration;
 	}
 
-	const char *description() const
-	{
-		return "time spent in hash processes";
-	}
+	const std::string description = "time spent in hash processes";
 
 };
 
@@ -129,10 +117,7 @@ struct ComputeDurationMetric
 		return s.computeDuration;
 	}
 
-	const char *description() const
-	{
-		return "time spent in compute processes";
-	}
+	const std::string description = "time spent in compute processes";
 
 };
 
@@ -146,10 +131,7 @@ struct TotalDurationMetric
 		return s.hashDuration + s.computeDuration;
 	}
 
-	const char *description() const
-	{
-		return "sum of time spent in hash and compute processes";
-	}
+	const std::string description = "sum of time spent in hash and compute processes";
 
 };
 
@@ -163,10 +145,7 @@ struct PerHashDurationMetric
 		return ResultType( s.hashDuration ) / std::max( 1.0, static_cast<double>( s.hashCount ) );
 	}
 
-	const char *description() const
-	{
-		return "time spent per hash process";
-	}
+	const std::string description = "time spent per hash process";
 
 };
 
@@ -180,10 +159,7 @@ struct PerComputeDurationMetric
 		return ResultType( s.computeDuration ) / std::max( 1.0, static_cast<double>( s.computeCount ) );
 	}
 
-	const char *description() const
-	{
-		return "time spent per compute process";
-	}
+	const std::string description = "time spent per compute process";
 
 };
 
@@ -197,10 +173,7 @@ struct HashesPerComputeMetric
 		return static_cast<double>( s.hashCount ) / std::max( 1.0, static_cast<double>( s.computeCount ) );
 	}
 
-	const char *description() const
-	{
-		return "number of hash processes per compute process";
-	}
+	const std::string description = "number of hash processes per compute process";
 
 };
 
@@ -319,7 +292,7 @@ struct FormatStatistics
 		}
 
 		std::stringstream s;
-		s << "Top " << plugNames.size() << " plugs by " << metric.description() << " :\n\n";
+		s << "Top " << plugNames.size() << " plugs by " << metric.description << " :\n\n";
 
 		outputItems( plugNames, metrics, s );
 
@@ -348,7 +321,7 @@ struct FormatTotalStatistics
 
 		s << std::fixed << ": " <<  metric( combinedStatistics );
 
-		return ResultType( std::string( "Total " ) + metric.description(), s.str() );
+		return ResultType( "Total " + metric.description, s.str() );
 	}
 
 	const PerformanceMonitor::Statistics &combinedStatistics;

--- a/src/GafferModule/MonitorBinding.cpp
+++ b/src/GafferModule/MonitorBinding.cpp
@@ -41,6 +41,7 @@
 #include "Gaffer/ContextMonitor.h"
 #include "Gaffer/Monitor.h"
 #include "Gaffer/MonitorAlgo.h"
+#include "Gaffer/Node.h"
 #include "Gaffer/PerformanceMonitor.h"
 #include "Gaffer/Plug.h"
 #include "Gaffer/VTuneMonitor.h"
@@ -132,6 +133,18 @@ list contextMonitorVariableNames( const ContextMonitor::Statistics &s )
 	return result;
 }
 
+void annotateWrapper1( Node &root, const PerformanceMonitor &monitor )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	MonitorAlgo::annotate( root, monitor );
+}
+
+void annotateWrapper2( Node &root, const PerformanceMonitor &monitor, MonitorAlgo::PerformanceMetric metric )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	MonitorAlgo::annotate( root, monitor, metric );
+}
+
 } // namespace
 
 void GafferModule::bindMonitor()
@@ -171,6 +184,18 @@ void GafferModule::bindMonitor()
 				arg( "metric" ),
 				arg( "maxLines" ) = 50
 			)
+		);
+
+		def(
+			"annotate",
+			&annotateWrapper1,
+			( arg( "node" ), arg( "monitor" ) )
+		);
+
+		def(
+			"annotate",
+			&annotateWrapper2,
+			( arg( "node" ), arg( "monitor" ), arg( "metric" ) )
 		);
 	}
 

--- a/src/GafferModule/MonitorBinding.cpp
+++ b/src/GafferModule/MonitorBinding.cpp
@@ -145,6 +145,12 @@ void annotateWrapper2( Node &root, const PerformanceMonitor &monitor, MonitorAlg
 	MonitorAlgo::annotate( root, monitor, metric );
 }
 
+void annotateWrapper3( Node &root, const ContextMonitor &monitor )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	MonitorAlgo::annotate( root, monitor );
+}
+
 } // namespace
 
 void GafferModule::bindMonitor()
@@ -196,6 +202,12 @@ void GafferModule::bindMonitor()
 			"annotate",
 			&annotateWrapper2,
 			( arg( "node" ), arg( "monitor" ), arg( "metric" ) )
+		);
+
+		def(
+			"annotate",
+			&annotateWrapper3,
+			( arg( "node" ), arg( "monitor" ) )
 		);
 	}
 

--- a/src/GafferUI/AnnotationsGadget.cpp
+++ b/src/GafferUI/AnnotationsGadget.cpp
@@ -1,0 +1,259 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferUI/AnnotationsGadget.h"
+
+#include "GafferUI/GraphGadget.h"
+#include "GafferUI/ImageGadget.h"
+#include "GafferUI/NodeGadget.h"
+#include "GafferUI/Style.h"
+
+#include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
+
+#include "boost/bind.hpp"
+#include "boost/bind/placeholders.hpp"
+
+using namespace GafferUI;
+using namespace Gaffer;
+using namespace IECore;
+using namespace Imath;
+using namespace std;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+Box2f nodeFrame( const NodeGadget *nodeGadget )
+{
+	const Box3f b = nodeGadget->transformedBound( nullptr );
+	return Box2f(
+		V2f( b.min.x, b.min.y ),
+		V2f( b.max.x, b.max.y )
+	);
+}
+
+
+IECoreGL::Texture *bookmarkTexture()
+{
+	static IECoreGL::TexturePtr bookmarkTexture;
+
+	if( !bookmarkTexture )
+	{
+		bookmarkTexture = ImageGadget::textureLoader()->load( "bookmarkStar2.png" );
+
+		IECoreGL::Texture::ScopedBinding binding( *bookmarkTexture );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
+	}
+	return bookmarkTexture.get();
+}
+
+IECoreGL::Texture *numericBookmarkTexture()
+{
+	static IECoreGL::TexturePtr numericBookmarkTexture;
+
+	if( !numericBookmarkTexture )
+	{
+		numericBookmarkTexture = ImageGadget::textureLoader()->load( "bookmarkStar.png" );
+
+		IECoreGL::Texture::ScopedBinding binding( *numericBookmarkTexture );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
+		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
+	}
+	return numericBookmarkTexture.get();
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// AnnotationsGadget
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( AnnotationsGadget );
+
+AnnotationsGadget::AnnotationsGadget()
+	:	Gadget( "AnnotationsGadget" )
+{
+	Metadata::nodeValueChangedSignal().connect(
+		boost::bind( &AnnotationsGadget::nodeMetadataChanged, this, ::_1, ::_2, ::_3 )
+	);
+}
+
+AnnotationsGadget::~AnnotationsGadget()
+{
+}
+
+bool AnnotationsGadget::acceptsParent( const GraphComponent *potentialParent ) const
+{
+	return runTimeCast<const GraphGadget>( potentialParent );
+}
+
+void AnnotationsGadget::parentChanging( Gaffer::GraphComponent *newParent )
+{
+	m_annotations.clear();
+	m_graphGadgetChildAddedConnection.disconnect();
+	m_graphGadgetChildRemovedConnection.disconnect();
+	if( newParent )
+	{
+		m_graphGadgetChildAddedConnection = newParent->childAddedSignal().connect(
+			boost::bind( &AnnotationsGadget::graphGadgetChildAdded, this, ::_2 )
+		);
+		m_graphGadgetChildRemovedConnection = newParent->childRemovedSignal().connect(
+			boost::bind( &AnnotationsGadget::graphGadgetChildRemoved, this, ::_2 )
+		);
+	}
+}
+
+void AnnotationsGadget::doRenderLayer( Layer layer, const Style *style ) const
+{
+	if( layer != GraphLayer::Overlay )
+	{
+		return;
+	}
+
+	for( auto &ga : m_annotations )
+	{
+		const Node *node = ga.first->node();
+		Annotations &annotations = ga.second;
+
+		if( annotations.dirty )
+		{
+			annotations.renderable = false;
+
+			annotations.bookmarked = Gaffer::MetadataAlgo::getBookmarked( node );
+			annotations.renderable |= annotations.bookmarked;
+
+			if( int bookmark = MetadataAlgo::numericBookmark( node ) )
+			{
+				annotations.numericBookmark = std::to_string( bookmark );
+				annotations.renderable = true;
+			}
+			else
+			{
+				annotations.numericBookmark = InternedString();
+			}
+
+			annotations.dirty = false;
+		}
+
+		if( !annotations.renderable )
+		{
+			continue;
+		}
+
+		const Box2f b = nodeFrame( ga.first );
+		if( annotations.bookmarked )
+		{
+			style->renderImage( Box2f( V2f( b.min.x - 1.0, b.max.y - 1.0 ), V2f( b.min.x + 1.0, b.max.y + 1.0 ) ), bookmarkTexture() );
+		}
+
+		if( annotations.numericBookmark.string().size() )
+		{
+			if( !annotations.bookmarked )
+			{
+				style->renderImage( Box2f( V2f( b.min.x - 1.0, b.max.y - 1.0 ), V2f( b.min.x + 1.0, b.max.y + 1.0 ) ), numericBookmarkTexture() );
+			}
+
+			const Box3f textBounds = style->textBound( Style::LabelText, annotations.numericBookmark.string() );
+
+			const Imath::Color3f textColor( 1.0f );
+			glPushMatrix();
+				IECoreGL::glTranslate( V2f( b.min.x + 1.0 - textBounds.size().x * 0.5, b.max.y - textBounds.size().y * 0.5 - 0.7 ) );
+				style->renderText( Style::LabelText, annotations.numericBookmark.string(), Style::NormalState, &textColor );
+			glPopMatrix();
+		}
+	}
+}
+
+GraphGadget *AnnotationsGadget::graphGadget()
+{
+	return parent<GraphGadget>();
+}
+
+const GraphGadget *AnnotationsGadget::graphGadget() const
+{
+	return parent<GraphGadget>();
+}
+
+void AnnotationsGadget::graphGadgetChildAdded( GraphComponent *child )
+{
+	if( NodeGadget *nodeGadget = runTimeCast<NodeGadget>( child ) )
+	{
+		m_annotations[nodeGadget] = Annotations();
+	}
+}
+
+void AnnotationsGadget::graphGadgetChildRemoved( const GraphComponent *child )
+{
+	if( const NodeGadget *nodeGadget = runTimeCast<const NodeGadget>( child ) )
+	{
+		m_annotations.erase( nodeGadget );
+	}
+}
+
+void AnnotationsGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, Gaffer::Node *node )
+{
+	if( !node )
+	{
+		// We only expect annotations to be registered
+		// as per-instance metadate.
+		return;
+	}
+
+	if(
+		!MetadataAlgo::bookmarkedAffectedByChange( key ) &&
+		!MetadataAlgo::numericBookmarkAffectedByChange( key )
+	)
+	{
+		return;
+	}
+
+	if( auto gadget = graphGadget()->nodeGadget( node ) )
+	{
+		auto it = m_annotations.find( gadget );
+		assert( it != m_annotations.end() );
+		it->second.dirty = true;
+		requestRender();
+	}
+}

--- a/src/GafferUI/AnnotationsGadget.cpp
+++ b/src/GafferUI/AnnotationsGadget.cpp
@@ -236,7 +236,7 @@ void AnnotationsGadget::doRenderLayer( Layer layer, const Style *style ) const
 			const Color3f midGrey( 0.65 );
 			const Color3f darkGrey( 0.05 );
 			float previousHeight = 0;
-			for( auto &a : annotations.standardAnnotations )
+			for( const auto &a : annotations.standardAnnotations )
 			{
 				Box3f textBounds = style->textBound( Style::BodyText, a.text->readable() );
 

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -79,40 +79,6 @@ void titleAndDescriptionFromPlugs( const StringPlug *titlePlug, const StringPlug
 	}
 }
 
-IECoreGL::Texture *bookmarkTexture()
-{
-	static IECoreGL::TexturePtr bookmarkTexture;
-
-	if( !bookmarkTexture )
-	{
-		bookmarkTexture = ImageGadget::textureLoader()->load( "bookmarkStar2.png" );
-
-		IECoreGL::Texture::ScopedBinding binding( *bookmarkTexture );
-		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR );
-		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
-		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
-		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
-	}
-	return bookmarkTexture.get();
-}
-
-IECoreGL::Texture *numericBookmarkTexture()
-{
-	static IECoreGL::TexturePtr numericBookmarkTexture;
-
-	if( !numericBookmarkTexture )
-	{
-		numericBookmarkTexture = ImageGadget::textureLoader()->load( "bookmarkStar.png" );
-
-		IECoreGL::Texture::ScopedBinding binding( *numericBookmarkTexture );
-		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR );
-		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
-		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
-		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
-	}
-	return numericBookmarkTexture.get();
-}
-
 } // namespace
 
 IE_CORE_DEFINERUNTIMETYPED( BackdropNodeGadget );
@@ -155,16 +121,7 @@ BackdropNodeGadget::BackdropNodeGadget( Gaffer::NodePtr node )
 
 	Metadata::nodeValueChangedSignal().connect( boost::bind( &BackdropNodeGadget::nodeMetadataChanged, this, ::_1, ::_2, ::_3 ) );
 
-	// handle existing metadata that changes the way the node looks
-	///////////////////////////////////////////////////////////////
-	int bookmark = MetadataAlgo::numericBookmark( this->node() );
-	if( bookmark )
-	{
-		m_numericBookmark = std::to_string( bookmark );
-	}
-
 	updateUserColor();
-	updateNumericBookmark();
 }
 
 BackdropNodeGadget::~BackdropNodeGadget()
@@ -355,30 +312,6 @@ void BackdropNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 		{
 			style->renderWrappedText( Style::BodyText, description, textBound );
 		}
-	}
-
-	// render bookmark information on top
-
-	bool isBookmarked = MetadataAlgo::getBookmarked( node() );
-	if( isBookmarked )
-	{
-		style->renderImage( Box2f( V2f( bound.min.x + 1.0, bound.max.y - 1.0 ), V2f( bound.min.x + 3.0, bound.max.y + 1.0 ) ), bookmarkTexture() );
-	}
-
-	if( m_numericBookmark )
-	{
-		if( !isBookmarked )
-		{
-			style->renderImage( Box2f( V2f( bound.min.x + 1.0, bound.max.y - 1.0 ), V2f( bound.min.x + 3.0, bound.max.y + 1.0 ) ), numericBookmarkTexture() );
-		}
-
-		Box3f textBounds = style->textBound( Style::LabelText, *m_numericBookmark );
-
-		Imath::Color3f textColor( 1.0f );
-		glPushMatrix();
-		IECoreGL::glTranslate( V2f( bound.min.x + 3.0 - textBounds.size().x * 0.5, bound.max.y - textBounds.size().y * 0.5 - 0.7 ) );
-		style->renderText( Style::LabelText, *m_numericBookmark, Style::NormalState, &textColor );
-		glPopMatrix();
 	}
 
 	glPopMatrix();
@@ -574,15 +507,6 @@ void BackdropNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore:
 			requestRender();
 		}
 	}
-
-	if( MetadataAlgo::numericBookmarkAffectedByChange( key ) )
-	{
-		if( updateNumericBookmark() )
-		{
-			requestRender();
-		}
-	}
-
 }
 
 bool BackdropNodeGadget::updateUserColor()
@@ -599,27 +523,5 @@ bool BackdropNodeGadget::updateUserColor()
 	}
 
 	m_userColor = c;
-	return true;
-}
-
-bool BackdropNodeGadget::updateNumericBookmark()
-{
-	int cached = m_numericBookmark ? stoi( *m_numericBookmark ) : 0;
-	int bookmark = MetadataAlgo::numericBookmark( this->node() );
-
-	if( cached == bookmark )
-	{
-		return false;
-	}
-
-	if( bookmark )
-	{
-		m_numericBookmark = std::to_string( bookmark );
-	}
-	else
-	{
-		m_numericBookmark = boost::none;
-	}
-
 	return true;
 }

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -37,6 +37,7 @@
 
 #include "GafferUI/GraphGadget.h"
 
+#include "GafferUI/AnnotationsGadget.h"
 #include "GafferUI/AuxiliaryConnectionsGadget.h"
 #include "GafferUI/BackdropNodeGadget.h"
 #include "GafferUI/ButtonEvent.h"
@@ -101,6 +102,7 @@ const InternedString g_inputConnectionsMinimisedPlugName( "__uiInputConnectionsM
 const InternedString g_outputConnectionsMinimisedPlugName( "__uiOutputConnectionsMinimised" );
 const InternedString g_nodeGadgetTypeName( "nodeGadget:type" );
 const InternedString g_auxiliaryConnectionsGadgetName( "__auxiliaryConnections" );
+const InternedString g_annotationsGadgetName( "__annotations" );
 
 struct CompareV2fX{
 	bool operator()(const Imath::V2f &a, const Imath::V2f &b) const
@@ -135,6 +137,7 @@ GraphGadget::GraphGadget( Gaffer::NodePtr root, Gaffer::SetPtr filter )
 	m_layout = new StandardGraphLayout;
 
 	setChild( g_auxiliaryConnectionsGadgetName, new AuxiliaryConnectionsGadget() );
+	setChild( g_annotationsGadgetName, new AnnotationsGadget() );
 
 	setRoot( root, filter );
 }

--- a/src/GafferUIModule/GraphGadgetBinding.cpp
+++ b/src/GafferUIModule/GraphGadgetBinding.cpp
@@ -41,6 +41,7 @@
 
 #include "GafferUIBindings/GadgetBinding.h"
 
+#include "GafferUI/AnnotationsGadget.h"
 #include "GafferUI/AuxiliaryConnectionsGadget.h"
 #include "GafferUI/ConnectionGadget.h"
 #include "GafferUI/GraphGadget.h"
@@ -255,6 +256,9 @@ void GafferUIModule::bindGraphGadget()
 		.def( "hasConnection", (bool (AuxiliaryConnectionsGadget::*)( const Gadget *, const Gadget * ) const)&AuxiliaryConnectionsGadget::hasConnection )
 		.def( "hasConnection", (bool (AuxiliaryConnectionsGadget::*)( const Node *, const Node * ) const)&AuxiliaryConnectionsGadget::hasConnection )
 		.def( "connectionAt", &connectionAt )
+	;
+
+	GadgetClass<AnnotationsGadget>()
 	;
 
 	IECorePython::RunTimeTypedClass<GraphLayout>()


### PR DESCRIPTION
This fixes the rendering of bookmark annotations for non-standard NodeGadgets, adds support for rendering arbitrary annotations for nodes, and for annotating nodes with monitor statistics. 