### PR TITLE
MeshTangents : Added different modes for tangent calculation.

### DIFF
--- a/include/GafferScene/MeshTangents.h
+++ b/include/GafferScene/MeshTangents.h
@@ -53,6 +53,15 @@ class GAFFERSCENE_API MeshTangents : public SceneElementProcessor
 		MeshTangents( const std::string &name=defaultName<MeshTangents>() );
 		~MeshTangents() override;
 
+		enum Mode
+		{
+			UV,
+			FirstEdge,
+			TwoEdges,
+			PrimitiveCentroid,
+			NumberOfModes
+		};
+
 		Gaffer::StringPlug *uvSetPlug();
 		const Gaffer::StringPlug *uvSetPlug() const;
 
@@ -67,6 +76,21 @@ class GAFFERSCENE_API MeshTangents : public SceneElementProcessor
 
 		Gaffer::BoolPlug *orthogonalPlug();
 		const Gaffer::BoolPlug *orthogonalPlug() const;
+
+		Gaffer::IntPlug *modePlug();
+		const Gaffer::IntPlug *modePlug() const;
+
+		Gaffer::BoolPlug *leftHandedPlug();
+		const Gaffer::BoolPlug *leftHandedPlug() const;
+
+		Gaffer::StringPlug *normalPlug();
+		const Gaffer::StringPlug *normalPlug() const;
+
+		Gaffer::StringPlug *tangentPlug();
+		const Gaffer::StringPlug *tangentPlug() const;
+
+		Gaffer::StringPlug *biTangentPlug();
+		const Gaffer::StringPlug *biTangentPlug() const;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::MeshTangents, MeshTangentsTypeId, SceneElementProcessor );
 

--- a/src/GafferScene/MeshTangents.cpp
+++ b/src/GafferScene/MeshTangents.cpp
@@ -51,11 +51,16 @@ size_t MeshTangents::g_firstPlugIndex = 0;
 MeshTangents::MeshTangents( const std::string &name ) : SceneElementProcessor( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	addChild( new StringPlug( "uvSet", Plug::In, "uv" ) );
+	addChild( new IntPlug( "mode", Plug::In, Mode::UV, /* min */ 0, /* max */ Mode::NumberOfModes ) );
+	addChild( new BoolPlug( "orthogonal", Plug::In, true ) );
+	addChild( new BoolPlug( "leftHanded", Plug::In, false ) );
 	addChild( new StringPlug( "position", Plug::In, "P" ) );
+	addChild( new StringPlug( "normal", Plug::In, "N" ) );
+	addChild( new StringPlug( "uvSet", Plug::In, "uv" ) );
 	addChild( new StringPlug( "uTangent", Plug::In, "uTangent" ) );
 	addChild( new StringPlug( "vTangent", Plug::In, "vTangent" ) );
-	addChild( new BoolPlug( "orthogonal", Plug::In, true ) );
+	addChild( new StringPlug( "tangent", Plug::In, "tangent" ) );
+	addChild( new StringPlug( "biTangent", Plug::In, "biTangent" ) );
 
 	// Fast pass-throughs for things we don't modify
 	outPlug()->attributesPlug()->setInput( inPlug()->attributesPlug() );
@@ -67,61 +72,111 @@ MeshTangents::~MeshTangents()
 {
 }
 
-Gaffer::StringPlug *MeshTangents::uvSetPlug()
+Gaffer::IntPlug *MeshTangents::modePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex );
+	return getChild<IntPlug>( g_firstPlugIndex );
 }
 
-const Gaffer::StringPlug *MeshTangents::uvSetPlug() const
+const Gaffer::IntPlug *MeshTangents::modePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex );
-}
-
-Gaffer::StringPlug *MeshTangents::positionPlug()
-{
-	return getChild<StringPlug>( g_firstPlugIndex + 1 );
-}
-
-const Gaffer::StringPlug *MeshTangents::positionPlug() const
-{
-	return getChild<StringPlug>( g_firstPlugIndex + 1 );
-}
-
-Gaffer::StringPlug *MeshTangents::uTangentPlug()
-{
-	return getChild<StringPlug>( g_firstPlugIndex + 2 );
-}
-
-const Gaffer::StringPlug *MeshTangents::uTangentPlug() const
-{
-	return getChild<StringPlug>( g_firstPlugIndex + 2 );
-}
-
-Gaffer::StringPlug *MeshTangents::vTangentPlug()
-{
-	return getChild<StringPlug>( g_firstPlugIndex + 3 );
-}
-
-const Gaffer::StringPlug *MeshTangents::vTangentPlug() const
-{
-	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+	return getChild<IntPlug>( g_firstPlugIndex );
 }
 
 Gaffer::BoolPlug *MeshTangents::orthogonalPlug()
 {
-	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
+	return getChild<BoolPlug>( g_firstPlugIndex + 1 );
 }
 
 const Gaffer::BoolPlug *MeshTangents::orthogonalPlug() const
 {
-	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
+	return getChild<BoolPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::BoolPlug *MeshTangents::leftHandedPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::BoolPlug *MeshTangents::leftHandedPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::StringPlug *MeshTangents::positionPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::StringPlug *MeshTangents::positionPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+}
+
+Gaffer::StringPlug *MeshTangents::normalPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+}
+
+const Gaffer::StringPlug *MeshTangents::normalPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+}
+
+Gaffer::StringPlug *MeshTangents::uvSetPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 5 );
+}
+
+const Gaffer::StringPlug *MeshTangents::uvSetPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 5 );
+}
+
+Gaffer::StringPlug *MeshTangents::uTangentPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 6 );
+}
+
+const Gaffer::StringPlug *MeshTangents::uTangentPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 6 );
+}
+
+Gaffer::StringPlug *MeshTangents::vTangentPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 7 );
+}
+
+const Gaffer::StringPlug *MeshTangents::vTangentPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 7 );
+}
+
+Gaffer::StringPlug *MeshTangents::tangentPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 8 );
+}
+
+const Gaffer::StringPlug *MeshTangents::tangentPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 8 );
+}
+
+Gaffer::StringPlug *MeshTangents::biTangentPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 9 );
+}
+
+const Gaffer::StringPlug *MeshTangents::biTangentPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 9 );
 }
 
 void MeshTangents::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	SceneElementProcessor::affects( input, outputs );
 
-	if( input == uvSetPlug() || input == positionPlug() || input == orthogonalPlug() || input == uTangentPlug() || input == vTangentPlug() )
+	if( input == uvSetPlug() || input == positionPlug() || input == orthogonalPlug() || input == modePlug() || input == leftHandedPlug() || input == uTangentPlug() || input == vTangentPlug() || input == tangentPlug() || input == biTangentPlug() || input == normalPlug() )
 	{
 		outputs.push_back( outPlug()->objectPlug() );
 	}
@@ -137,8 +192,13 @@ void MeshTangents::hashProcessedObject( const ScenePath &path, const Gaffer::Con
 	uvSetPlug()->hash( h );
 	positionPlug()->hash( h );
 	orthogonalPlug()->hash( h );
+	leftHandedPlug()->hash( h );
+	modePlug()->hash( h );
 	uTangentPlug()->hash( h );
 	vTangentPlug()->hash( h );
+	tangentPlug()->hash( h );
+	biTangentPlug()->hash( h );
+	normalPlug()->hash( h );
 }
 
 IECore::ConstObjectPtr MeshTangents::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const
@@ -149,18 +209,47 @@ IECore::ConstObjectPtr MeshTangents::computeProcessedObject( const ScenePath &pa
 		return inputObject;
 	}
 
-	std::string uvSet = uvSetPlug()->getValue();
 	std::string position = positionPlug()->getValue();
 	bool ortho = orthogonalPlug()->getValue();
+	bool leftHanded = leftHandedPlug()->getValue();
+	Mode mode = (Mode) modePlug()->getValue();
 
-	std::string uTangent = uTangentPlug()->getValue();
-	std::string vTangent = vTangentPlug()->getValue();
-
-	std::pair<PrimitiveVariable, PrimitiveVariable> tangentPrimvars = MeshAlgo::calculateTangents( mesh, uvSet, ortho, position);
 	MeshPrimitivePtr meshWithTangents = runTimeCast<MeshPrimitive>( mesh->copy() );
+	std::pair<PrimitiveVariable, PrimitiveVariable> tangentPrimvars;
 
-	meshWithTangents->variables[uTangent] = tangentPrimvars.first;
-	meshWithTangents->variables[vTangent] = tangentPrimvars.second;
+	if ( mode == Mode::UV )
+	{
+		std::string uvSet = uvSetPlug()->getValue();
+		std::string uTangent = uTangentPlug()->getValue();
+		std::string vTangent = vTangentPlug()->getValue();
+
+		tangentPrimvars = MeshAlgo::calculateTangentsFromUV( mesh, uvSet, position, ortho, leftHanded );
+
+		meshWithTangents->variables[uTangent] = tangentPrimvars.first;
+		meshWithTangents->variables[vTangent] = tangentPrimvars.second;
+	}
+	else
+	{
+		std::string normal = normalPlug()->getValue();
+		std::string tangent = tangentPlug()->getValue();
+		std::string biTangent = biTangentPlug()->getValue();
+
+		if ( mode == Mode::FirstEdge )
+		{
+			tangentPrimvars = MeshAlgo::calculateTangentsFromFirstEdge( mesh, position, normal, ortho, leftHanded  );
+		}
+		else if ( mode == Mode::TwoEdges )
+		{
+			tangentPrimvars = MeshAlgo::calculateTangentsFromTwoEdges( mesh, position, normal, ortho, leftHanded  );
+		}
+		else
+		{
+			tangentPrimvars = MeshAlgo::calculateTangentsFromPrimitiveCentroid( mesh, position, normal, ortho, leftHanded  );
+		}
+
+		meshWithTangents->variables[tangent] = tangentPrimvars.first;
+		meshWithTangents->variables[biTangent] = tangentPrimvars.second;
+	}
 
 	return meshWithTangents;
 }

--- a/src/GafferSceneModule/ObjectProcessorBinding.cpp
+++ b/src/GafferSceneModule/ObjectProcessorBinding.cpp
@@ -66,7 +66,6 @@ void GafferSceneModule::bindObjectProcessor()
 	GafferBindings::DependencyNodeClass<GafferScene::DeletePoints>();
 	GafferBindings::DependencyNodeClass<GafferScene::DeleteFaces>();
 	GafferBindings::DependencyNodeClass<GafferScene::DeleteCurves>();
-	GafferBindings::DependencyNodeClass<GafferScene::MeshTangents>();
 	GafferBindings::DependencyNodeClass<GafferScene::PointsType>();
 	GafferBindings::DependencyNodeClass<GafferScene::MeshToPoints>();
 	GafferBindings::DependencyNodeClass<MeshType>();
@@ -77,5 +76,14 @@ void GafferSceneModule::bindObjectProcessor()
 	GafferBindings::DependencyNodeClass<DeleteObject>();
 	GafferBindings::DependencyNodeClass<UDIMQuery>();
 	GafferBindings::DependencyNodeClass<Wireframe>();
+
+	scope s = GafferBindings::DependencyNodeClass<GafferScene::MeshTangents>();
+
+	enum_<GafferScene::MeshTangents::Mode>( "Mode" )
+		.value( "UV", GafferScene::MeshTangents::Mode::UV )
+		.value( "FirstEdge", GafferScene::MeshTangents::Mode::FirstEdge )
+		.value( "TwoEdges", GafferScene::MeshTangents::Mode::TwoEdges )
+		.value( "PrimitiveCentroid", GafferScene::MeshTangents::Mode::PrimitiveCentroid )
+		;
 
 }

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -289,7 +289,7 @@ nodeMenu.append( "/Scene/Object/Light To Camera", GafferScene.LightToCamera, sea
 nodeMenu.append( "/Scene/Object/Map Projection", GafferScene.MapProjection, searchText = "MapProjection" )
 nodeMenu.append( "/Scene/Object/Map Offset", GafferScene.MapOffset, searchText = "MapOffset"  )
 nodeMenu.append( "/Scene/Object/Parameters", GafferScene.Parameters )
-nodeMenu.append( "/Scene/Object/Mesh Tangents", GafferScene.MeshTangents, searchText = "MeshTangents" )
+nodeMenu.append( "/Scene/Object/Mesh Tangents", GafferScene.MeshTangents, searchText = "MeshTangents", postCreator = GafferSceneUI.MeshTangentsUI.postCreate )
 nodeMenu.append( "/Scene/Object/Delete Faces", GafferScene.DeleteFaces, searchText = "DeleteFaces" )
 nodeMenu.append( "/Scene/Object/Delete Curves", GafferScene.DeleteCurves, searchText = "DeleteCurves" )
 nodeMenu.append( "/Scene/Object/Delete Points", GafferScene.DeletePoints, searchText = "DeletePoints" )


### PR DESCRIPTION
This adds the new Cortex MeshAlgoTangents computation methods from https://github.com/ImageEngine/cortex/pull/925.
We can now compute tangents not only based on UVs but also from the first edge of the vertex, the average of the fist two edges or the primitive centroid, make them orthogonal and flip the handedness.

### Dependencies ###

- Depends on: https://github.com/ImageEngine/cortex/pull/925

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
