### PR TITLE
StandardConnectionGadget : prevent dot creation when node contents ar…

### DIFF
--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -593,6 +593,14 @@ void StandardConnectionGadget::updateDotPreviewLocation( const ButtonEvent &even
 
 bool StandardConnectionGadget::keyPressed( const KeyEvent &event )
 {
+	if(
+		MetadataAlgo::readOnly( dstNodule()->plug() ) ||
+		( srcNodule() && MetadataAlgo::readOnly( srcNodule()->plug() ) )
+	)
+	{
+		return false;
+	}
+
 	if( event.modifiers & ButtonEvent::Control && srcNodule() )
 	{
 		m_dotPreview = true;
@@ -616,6 +624,14 @@ bool StandardConnectionGadget::keyReleased( const KeyEvent &event )
 
 void StandardConnectionGadget::enter( const ButtonEvent &event )
 {
+	if(
+		MetadataAlgo::readOnly( dstNodule()->plug() ) ||
+		( srcNodule() && MetadataAlgo::readOnly( srcNodule()->plug() ) )
+	)
+	{
+		return;
+	}
+
 	if( event.modifiers & ButtonEvent::Control && srcNodule() )
 	{
 		m_dotPreview = true;


### PR DESCRIPTION
Hey John,

Murray brought to my attention that it's currently possible to add `Dots` via the ctrl-click feature to `Reference` and locked `Box` nodes. What I've done here is half the battle and handles readOnly nodes. I wasn't sure how we're usually handling these two different cases and thought I'd ask you how you want `References` handled before spending too much time on this.

Thanks :)

Matti.

