### PR TITLE
CameraTool keyframe support

### DIFF
--- a/python/GafferTest/AnimationTest.py
+++ b/python/GafferTest/AnimationTest.py
@@ -557,5 +557,31 @@ class AnimationTest( GafferTest.TestCase ) :
 		self.assertTrue( k1.parent() is None )
 		self.assertTrue( k2.parent().isSame( curve ) )
 
+	def testSerialisationRoundTripsExactly( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["f"] = Gaffer.FloatPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		curve = Gaffer.Animation.acquire( s["n"]["user"]["f"] )
+
+		context = Gaffer.Context()
+		for frame in range( 0, 10000 ) :
+			context.setFrame( frame )
+			curve.addKey( Gaffer.Animation.Key( context.getTime(), context.getTime(), Gaffer.Animation.Type.Linear ) )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		curve = Gaffer.Animation.acquire( s2["n"]["user"]["f"] )
+
+		for frame in range( 0, 10000 ) :
+			context.setFrame( frame )
+			self.assertEqual(
+				curve.getKey( context.getTime() ),
+				Gaffer.Animation.Key( context.getTime(), context.getTime(), Gaffer.Animation.Type.Linear )
+			)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferModule/AnimationBinding.cpp
+++ b/src/GafferModule/AnimationBinding.cpp
@@ -93,7 +93,7 @@ const char *typeRepr( const Animation::Type &t )
 std::string keyRepr( const Animation::Key &k )
 {
 	return boost::str(
-		boost::format( "Gaffer.Animation.Key( %f, %f, %s )" ) % k.getTime() % k.getValue() % typeRepr( k.getType() )
+		boost::format( "Gaffer.Animation.Key( %.9g, %.9g, %s )" ) % k.getTime() % k.getValue() % typeRepr( k.getType() )
 	);
 };
 


### PR DESCRIPTION
This allows the CameraTool to work in the presence of keyframes - it now makes additional keys as you move the camera around, rather than refusing to move the camera. In the course of testing, I discovered a stupid Animation serialisation bug that meant serialised keyframes would be just off from their original positions on reloading, meaning that subsequent keys on the "same" frame wouldn't replace the old key. I've fixed that using the format specifier documented and tested thoroughly  [here](https://randomascii.wordpress.com/2013/02/07/float-precision-revisited-nine-digit-float-portability/).