### PR TITLE
SetAlgo : Allow '.' in set and object names

### DIFF
--- a/python/GafferSceneTest/SetAlgoTest.py
+++ b/python/GafferSceneTest/SetAlgoTest.py
@@ -147,19 +147,23 @@ class SetAlgoTest( GafferSceneTest.SceneTestCase ) :
 		setA["paths"].setValue( IECore.StringVectorData( [ '/group/sphere1' ] ) )
 		self.assertNotEqual( h, GafferScene.SetAlgo.setExpressionHash( "setA", group2["out"] ) )
 
-	def testColonInSetAndObjectNames( self ):
+	def testColonAndDotInSetAndObjectNames( self ):
 
 		sphere1 = GafferScene.Sphere( "Sphere1" )
-		sphere1["name"].setValue( 'MyObject:sphere1' )
+		sphere1["name"].setValue( 'MyObject:sphere1.model' )
 
 		setA = GafferScene.Set( "SetA" )
-		setA["name"].setValue( "MySets:setA" )
-		setA["paths"].setValue( IECore.StringVectorData( [ "/MyObject:sphere1" ] ) )
+		setA["name"].setValue( "MySets:setA.set" )
+		setA["paths"].setValue( IECore.StringVectorData( [ "/MyObject:sphere1.model" ] ) )
 
-		self.assertCorrectEvaluation( setA["out"], "MySets:setA", [ "/MyObject:sphere1" ] )
-		self.assertCorrectEvaluation( setA["out"], "/MyObject:sphere1", [ "/MyObject:sphere1" ] )
+		self.assertCorrectEvaluation( setA["out"], "MySets:setA.set", [ "/MyObject:sphere1.model" ] )
+		self.assertCorrectEvaluation( setA["out"], "/MyObject:sphere1.model", [ "/MyObject:sphere1.model" ] )
 
 	def assertCorrectEvaluation( self, scenePlug, expression, expectedContents ) :
 
 		result = set( GafferScene.SetAlgo.evaluateSetExpression( expression, scenePlug ).paths() )
 		self.assertEqual( result, set( expectedContents ) )
+
+if __name__ == "__main__":
+	unittest.main()
+

--- a/src/GafferScene/SetAlgo.cpp
+++ b/src/GafferScene/SetAlgo.cpp
@@ -373,10 +373,10 @@ struct ExpressionGrammar : qi::grammar<Iterator, ExpressionAst(), ascii::space_t
 
 
 		setName %= setNameToken;
-		setNameToken %= char_( "a-zA-Z_" ) >> *char_( "a-zA-Z_0-9:" );
+		setNameToken %= char_( "a-zA-Z_" ) >> *char_( "a-zA-Z_0-9:." );
 
 		objectName %= objectNameToken;
-		objectNameToken %= char_( "/" ) >> *char_( "a-zA-Z_0-9/:" );
+		objectNameToken %= char_( "/" ) >> *char_( "a-zA-Z_0-9/:." );
 
 
 		// these have no effect unless BOOST_SPIRIT_DEBUG is defined


### PR DESCRIPTION
I wonder if we should make this even more flexible and just accept any non-whitespace character that doesn't conflict with the rest of the syntax, but this is sufficient to cover current requests. Any thoughts @mattigruener?

My only other thought is that one thing that it'd be really useful to have is a "match descendants" operation. It's pretty common to want to say something like `model:truck & material:rubber`, but this doesn't work if the `model:truck` set just has the root of the truck in it, and the `material:rubber` set has leaf objects in it. The most natural syntax I can think of for this is `model:truck... & material:rubber`, borrowing the `...` syntax from PathFilters. I think we could still disambiguate this in the parser though?