### PR TITLE
Gaffer: Add support for Reference node fileName search paths

### DIFF
--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -1156,31 +1156,36 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		referenceFile = "test.grf"
 
-		boxA = Gaffer.Box("BoxA")
-		s.addChild(boxA)
-		boxPathA = os.path.join(self.temporaryDirectory(), "a")
-		os.makedirs(boxPathA)
-		fileA = os.path.join(boxPathA, referenceFile)
-		boxA.exportForReference(fileA)
+		boxA = Gaffer.Box( "BoxA" )
+		boxA["p"] = Gaffer.StringPlug( defaultValue = "a", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s.addChild( boxA )
+		boxPathA = os.path.join( self.temporaryDirectory(), "a" )
+		os.makedirs( boxPathA )
+		fileA = os.path.join( boxPathA, referenceFile )
+		boxA.exportForReference( fileA )
 
-		boxB = Gaffer.Box("BoxB")
-		s.addChild(boxB)
+		boxB = Gaffer.Box( "BoxB" )
+		boxB["p"] = Gaffer.StringPlug( defaultValue = "b", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s.addChild( boxB )
 		boxPathB = os.path.join(self.temporaryDirectory(), "b")
-		os.makedirs(boxPathB)
-		fileB = os.path.join(boxPathB, referenceFile)
-		boxB.exportForReference(fileB)
+		os.makedirs( boxPathB )
+		fileB = os.path.join( boxPathB, referenceFile )
+		boxB.exportForReference( fileB )
 
+		searchPathA = ":".join( [boxPathA, boxPathB] )
+		searchPathB = ":".join( [boxPathB, boxPathA] )
+
+		os.environ["GAFFER_REFERENCE_PATHS"] = searchPathA
 		s["r"] = Gaffer.Reference()
 
-		searchPathA = ":".join([boxPathA, boxPathB])
-		os.environ["GAFFER_REFERENCE_PATHS"] = searchPathA
 		s["r"].load(referenceFile)
-		self.assertEqual(s["r"].fileName(), fileA)
+		self.assertEqual( s["r"].fileName(), referenceFile )
+		self.assertEqual( s["r"]["p"].getValue(), "a" )
 
-		searchPathB = ":".join([boxPathB, boxPathA])
 		os.environ["GAFFER_REFERENCE_PATHS"] = searchPathB
-		s["r"].load(referenceFile)
-		self.assertEqual(s["r"].fileName(), fileB)
+		s["r"].load( referenceFile )
+		self.assertEqual( s["r"].fileName(), referenceFile )
+		self.assertEqual( s["r"]["p"].getValue(), "b" )
 
 	def tearDown( self ) :
 

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -1187,6 +1187,14 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertEqual( s["r"].fileName(), referenceFile )
 		self.assertEqual( s["r"]["p"].getValue(), "b" )
 
+	def testLoadThrowsOnMissingFile( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["r"] = Gaffer.Reference()
+
+		with self.assertRaisesRegexp( Exception, "Could not find file 'thisFileDoesntExist.grf'" ) :
+			s["r"].load( "thisFileDoesntExist.grf" )
+
 	def tearDown( self ) :
 
 		GafferTest.TestCase.tearDown( self )

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -1150,6 +1150,38 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		assertReferenceConnections()
 
+	def testSearchPaths( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		referenceFile = "test.grf"
+
+		boxA = Gaffer.Box("BoxA")
+		s.addChild(boxA)
+		boxPathA = os.path.join(self.temporaryDirectory(), "a")
+		os.makedirs(boxPathA)
+		fileA = os.path.join(boxPathA, referenceFile)
+		boxA.exportForReference(fileA)
+
+		boxB = Gaffer.Box("BoxB")
+		s.addChild(boxB)
+		boxPathB = os.path.join(self.temporaryDirectory(), "b")
+		os.makedirs(boxPathB)
+		fileB = os.path.join(boxPathB, referenceFile)
+		boxB.exportForReference(fileB)
+
+		s["r"] = Gaffer.Reference()
+
+		searchPathA = ":".join([boxPathA, boxPathB])
+		os.environ["GAFFER_REFERENCE_PATHS"] = searchPathA
+		s["r"].load(referenceFile)
+		self.assertEqual(s["r"].fileName(), fileA)
+
+		searchPathB = ":".join([boxPathB, boxPathA])
+		os.environ["GAFFER_REFERENCE_PATHS"] = searchPathB
+		s["r"].load(referenceFile)
+		self.assertEqual(s["r"].fileName(), fileB)
+
 	def tearDown( self ) :
 
 		GafferTest.TestCase.tearDown( self )

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -154,6 +154,14 @@ Reference::~Reference()
 
 void Reference::load( const std::string &fileName )
 {
+	const char *s = getenv( "GAFFER_REFERENCE_PATHS" );
+	IECore::SearchPath sp( s ? s : "" );
+	boost::filesystem::path path = sp.find( fileName );
+	if( path.empty() )
+	{
+		throw Exception( "Could not find file '" + fileName + "'" );
+	}
+
 	ScriptNode *script = scriptNode();
 	if( !script )
 	{

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -44,6 +44,7 @@
 
 #include "IECore/Exception.h"
 #include "IECore/MessageHandler.h"
+#include "IECore/SearchPath.h"
 
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/bind.hpp"
@@ -153,6 +154,15 @@ Reference::~Reference()
 
 void Reference::load( const std::string &fileName )
 {
+	const char *s = getenv( "GAFFER_REFERENCE_PATHS" );
+	IECore::SearchPath sp( s ? s : "" );
+
+	boost::filesystem::path path = sp.find( fileName );
+	if( path.empty() )
+	{
+		throw Exception( "Could not find file '" + fileName + "'" );
+	}
+
 	ScriptNode *script = scriptNode();
 	if( !script )
 	{
@@ -161,7 +171,7 @@ void Reference::load( const std::string &fileName )
 
 	Action::enact(
 		this,
-		boost::bind( &Reference::loadInternal, ReferencePtr( this ), fileName ),
+		boost::bind( &Reference::loadInternal, ReferencePtr( this ), path.string() ),
 		boost::bind( &Reference::loadInternal, ReferencePtr( this ), m_fileName )
 	);
 }

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -154,15 +154,6 @@ Reference::~Reference()
 
 void Reference::load( const std::string &fileName )
 {
-	const char *s = getenv( "GAFFER_REFERENCE_PATHS" );
-	IECore::SearchPath sp( s ? s : "" );
-
-	boost::filesystem::path path = sp.find( fileName );
-	if( path.empty() )
-	{
-		throw Exception( "Could not find file '" + fileName + "'" );
-	}
-
 	ScriptNode *script = scriptNode();
 	if( !script )
 	{
@@ -171,7 +162,7 @@ void Reference::load( const std::string &fileName )
 
 	Action::enact(
 		this,
-		boost::bind( &Reference::loadInternal, ReferencePtr( this ), path.string() ),
+		boost::bind( &Reference::loadInternal, ReferencePtr( this ), fileName ),
 		boost::bind( &Reference::loadInternal, ReferencePtr( this ), m_fileName )
 	);
 }
@@ -250,9 +241,12 @@ void Reference::loadInternal( const std::string &fileName )
 	// exception that we throw.
 
 	bool errors = false;
-	if( !fileName.empty() )
+	const char *s = getenv( "GAFFER_REFERENCE_PATHS" );
+	IECore::SearchPath sp( s ? s : "" );
+	boost::filesystem::path path = sp.find( fileName );
+	if( !path.empty() )
 	{
-		errors = script->executeFile( fileName, this, /* continueOnError = */ true );
+		errors = script->executeFile( path.string(), this, /* continueOnError = */ true );
 	}
 
 	// Do a little bit of post processing on everything that was loaded.


### PR DESCRIPTION
Reference::load() resolves fileName by a IECore::SearchPath find() in a
GAFFER_REFERENCE_PATHS environment variable.

See discussion here: https://groups.google.com/forum/#!topic/gaffer-dev/Ao_Ql85zOMM

I haven't added a unit test for this but here is an example of it working..

Start with this gaffer script:
```
import Gaffer
import IECore
import imath

Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 54, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )

__children = {}

__children["BoxA"] = Gaffer.Box( "BoxA" )
parent.addChild( __children["BoxA"] )
__children["BoxA"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["BoxA"].addChild( Gaffer.StringPlug( "StringPlug", defaultValue = '', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["BoxB"] = Gaffer.Box( "BoxB" )
parent.addChild( __children["BoxB"] )
__children["BoxB"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["BoxB"].addChild( Gaffer.StringPlug( "StringPlug", defaultValue = '', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Reference"] = Gaffer.Reference( "Reference" )
parent.addChild( __children["Reference"] )
__children["Reference"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["BoxA"]["__uiPosition"].setValue( imath.V2f( 139.96199, 15.6264753 ) )
__children["BoxA"]["StringPlug"].setValue( 'A' )
Gaffer.Metadata.registerValue( __children["BoxA"]["StringPlug"], 'nodule:type', '' )
__children["BoxB"]["__uiPosition"].setValue( imath.V2f( 155.161987, 15.9264736 ) )
__children["BoxB"]["StringPlug"].setValue( 'B' )
Gaffer.Metadata.registerValue( __children["BoxB"]["StringPlug"], 'nodule:type', '' )
__children["Reference"]["__uiPosition"].setValue( imath.V2f( 149.18219, 6.81655264 ) )


del __children


```

run this code in the python editor, the comments explain the steps:

```
import os
# make paths to store boxes
os.makedirs('/tmp/boxpath/a')
os.makedirs('/tmp/boxpath/b')

# export 2 variations of test box
root['BoxA'].exportForReference('/tmp/boxpath/a/test.grf')
root['BoxB'].exportForReference('/tmp/boxpath/b/test.grf')

# set search path
os.environ['GAFFER_REFERENCE_PATHS'] = '/tmp/boxpath/a:/tmp/boxpath/b'

# load via file basename only
node = root['Reference']
node.load('test.grf')

# test load
print 'this should be "A"', node['StringPlug'].getValue()

# reorder search path
os.environ['GAFFER_REFERENCE_PATHS'] = '/tmp/boxpath/b:/tmp/boxpath/a'

# define function to reload a reference using basename only
def referenceReload(node):
	fileName = node.fileName()
	baseName = os.path.basename(fileName)
	node.load(baseName)

# call reload
referenceReload(node)

# test reload
print 'this should be "B"', node['StringPlug'].getValue()
```

### Related Issues ###

Closes #3048 

### Dependencies ###

None

### Breaking Changes ###

None

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
