### PR TITLE
 Stats app : Support render output profiling via `-scene` argument

### DIFF
--- a/include/GafferScene/Render.h
+++ b/include/GafferScene/Render.h
@@ -89,6 +89,8 @@ class GAFFERSCENE_API Render : public GafferDispatch::TaskNode
 		// loading of the module which registers the required renderer type.
 		Render( const IECore::InternedString &rendererType, const std::string &name );
 
+		void preTasks( const Gaffer::Context *context, Tasks &tasks ) const override;
+		void postTasks( const Gaffer::Context *context, Tasks &tasks ) const override;
 		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
 		void execute() const override;
 

--- a/include/GafferScene/Render.h
+++ b/include/GafferScene/Render.h
@@ -81,9 +81,6 @@ class GAFFERSCENE_API Render : public GafferDispatch::TaskNode
 		ScenePlug *outPlug();
 		const ScenePlug *outPlug() const;
 
-		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
-		void execute() const override;
-
 	protected :
 
 		// Constructor for derived classes which wish to hardcode the renderer type. Perhaps
@@ -92,12 +89,18 @@ class GAFFERSCENE_API Render : public GafferDispatch::TaskNode
 		// loading of the module which registers the required renderer type.
 		Render( const IECore::InternedString &rendererType, const std::string &name );
 
+		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
+		void execute() const override;
+
 	private :
 
 		ScenePlug *adaptedInPlug();
 		const ScenePlug *adaptedInPlug() const;
 
 		static size_t g_firstPlugIndex;
+
+		// Friendship for the bindings
+		friend struct GafferDispatchBindings::Detail::TaskNodeAccessor;
 
 };
 

--- a/python/GafferDelightTest/DelightRenderTest.py
+++ b/python/GafferDelightTest/DelightRenderTest.py
@@ -80,5 +80,30 @@ class DelightRenderTest( GafferSceneTest.SceneTestCase ) :
 		render["task"].execute()
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/test.exr" ) )
 
+	def testSceneTranslationOnly( self ) :
+
+		plane = GafferScene.Plane()
+
+		outputs = GafferScene.Outputs()
+		outputs.addOutput(
+			"beauty",
+			IECoreScene.Output(
+				self.temporaryDirectory() + "/test.exr",
+				"exr",
+				"rgba",
+				{}
+			)
+		)
+
+		render = GafferDelight.DelightRender()
+		render["in"].setInput( outputs["out"] )
+		render["mode"].setValue( render.Mode.RenderMode )
+
+		with Gaffer.Context() as context :
+			context["scene:render:sceneTranslationOnly"] = IECore.BoolData( True )
+			render["task"].execute()
+
+		self.assertFalse( os.path.exists( self.temporaryDirectory() + "/test.exr" ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDelightTest/DelightRenderTest.py
+++ b/python/GafferDelightTest/DelightRenderTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2017, John Haddon. All rights reserved.
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,11 +34,51 @@
 #
 ##########################################################################
 
-from IECoreDelightPreviewTest import *
+import os
+import unittest
 
-from DelightRenderTest import DelightRenderTest
-from InteractiveDelightRenderTest import InteractiveDelightRenderTest
+import IECore
+import IECoreScene
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+import GafferDelight
+
+class DelightRenderTest( GafferSceneTest.SceneTestCase ) :
+
+	def testSceneDescriptionMode( self ) :
+
+		plane = GafferScene.Plane()
+		render = GafferDelight.DelightRender()
+		render["in"].setInput( plane["out"] )
+		render["mode"].setValue( render.Mode.SceneDescriptionMode )
+		render["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.nsi" ) )
+
+		render["task"].execute()
+		self.assertTrue( os.path.exists( render["fileName"].getValue() ) )
+
+	def testRenderMode( self ) :
+
+		plane = GafferScene.Plane()
+
+		outputs = GafferScene.Outputs()
+		outputs.addOutput(
+			"beauty",
+			IECoreScene.Output(
+				self.temporaryDirectory() + "/test.exr",
+				"exr",
+				"rgba",
+				{}
+			)
+		)
+
+		render = GafferDelight.DelightRender()
+		render["in"].setInput( outputs["out"] )
+		render["mode"].setValue( render.Mode.RenderMode )
+
+		render["task"].execute()
+		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/test.exr" ) )
 
 if __name__ == "__main__":
-	import unittest
 	unittest.main()


### PR DESCRIPTION
This provides profiling more representative of the performance we care about most. It differs from our usual `GafferSceneTest.traverseScene()` call in that it doesn't need to compute bounds, but it does need to compute motion blur , translate objects to the renderer, perform light linking etc.