### PR TITLE
Render : Fix bug which prevented non-SceneNodes from rendering

### DIFF
--- a/python/GafferAppleseedTest/AppleseedRenderTest.py
+++ b/python/GafferAppleseedTest/AppleseedRenderTest.py
@@ -243,5 +243,32 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 		s["render"] = GafferAppleseed.AppleseedRender()
 		self.assertFalse( "__adaptedIn" in s.serialise() )
 
+	def testNoInput( self ) :
+
+		render = GafferAppleseed.AppleseedRender()
+		render["mode"].setValue( render.Mode.SceneDescriptionMode )
+		render["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.appleseed" ) )
+
+		self.assertEqual( render["task"].hash(), IECore.MurmurHash() )
+		render["task"].execute()
+		self.assertFalse( os.path.exists( render["fileName"].getValue() ) )
+
+	def testInputFromContextVariables( self ) :
+
+		plane = GafferScene.Plane()
+
+		variables = Gaffer.ContextVariables()
+		variables.setup( GafferScene.ScenePlug() )
+		variables["in"].setInput( plane["out"] )
+
+		render = GafferAppleseed.AppleseedRender()
+		render["in"].setInput( variables["out"] )
+		render["mode"].setValue( render.Mode.SceneDescriptionMode )
+		render["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.appleseed" ) )
+
+		self.assertNotEqual( render["task"].hash(), IECore.MurmurHash() )
+		render["task"].execute()
+		self.assertTrue( os.path.exists( render["fileName"].getValue() ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -194,7 +194,7 @@ void InteractiveRender::update()
 	// Stop the current render if we've been asked to, or if
 	// there is no real input scene.
 
-	if( requiredState == Stopped || !runTimeCast<SceneNode>( inPlug()->source()->node() ) )
+	if( requiredState == Stopped || inPlug()->source()->direction() != Plug::Out )
 	{
 		stop();
 		return;

--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -198,7 +198,7 @@ void Render::postTasks( const Gaffer::Context *context, Tasks &tasks ) const
 
 IECore::MurmurHash Render::hash( const Gaffer::Context *context ) const
 {
-	if( !IECore::runTimeCast<const SceneNode>( inPlug()->source()->node() ) )
+	if( inPlug()->source()->direction() != Plug::Out )
 	{
 		return IECore::MurmurHash();
 	}
@@ -231,7 +231,7 @@ IECore::MurmurHash Render::hash( const Gaffer::Context *context ) const
 
 void Render::execute() const
 {
-	if( !IECore::runTimeCast<const SceneNode>( inPlug()->source()->node() ) )
+	if( inPlug()->source()->direction() != Plug::Out )
 	{
 		return;
 	}


### PR DESCRIPTION
The node type is irrelevant, because a ScenePlug might belong to a generic node such as ContextVariables or Switch. What we care about is that the scene is an output from a node, because an unconnected input will always output an empty scene.
