### PR TITLE
Markdown support in tooltips

### DIFF
--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -198,9 +198,10 @@ class _TogglePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		result = GafferUI.PlugValueWidget.getToolTip( self )
 
-		result += "<ul>"
-		result += "<li>Click to toggle to/from default value</li>"
-		result += "<ul>"
+		if result :
+			result += "\n"
+		result += "## Actions\n\n"
+		result += "- Click to toggle to/from default value\n"
 
 		return result
 

--- a/python/GafferUI/ConnectionPlugValueWidget.py
+++ b/python/GafferUI/ConnectionPlugValueWidget.py
@@ -87,10 +87,11 @@ class ConnectionPlugValueWidget( GafferUI.PlugValueWidget ) :
 				srcNode = input.node()
 
 		if srcNode is not None :
-			result += "<ul>"
-			result += "<li>Left drag to drag source plug.</li>"
-			result += "<li>Left click to edit source node.</li>"
-			result += "<ul>"
+			if result :
+				result += "\n"
+			result += "## Actions\n\n"
+			result += " - Left drag to drag source plug\n"
+			result += " - Left click to edit source node\n"
 
 		return result
 

--- a/python/GafferUI/FileSystemPathPlugValueWidget.py
+++ b/python/GafferUI/FileSystemPathPlugValueWidget.py
@@ -65,7 +65,9 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 
 		extensions = self.__extensions()
 		if extensions :
-			result += "\n\nSupported file extensions : " + ", ".join( extensions )
+			if result :
+				result += "\n\n"
+			result += "## Supported file extensions\n\n " + "".join( "- {0}\n".format( e ) for e in extensions )
 
 		return result
 

--- a/python/GafferUI/FileSystemPathPlugValueWidget.py
+++ b/python/GafferUI/FileSystemPathPlugValueWidget.py
@@ -67,7 +67,7 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 		if extensions :
 			if result :
 				result += "\n\n"
-			result += "## Supported file extensions\n\n " + "".join( "- {0}\n".format( e ) for e in extensions )
+			result += "**Supported file extensions** : " + ", ".join( extensions )
 
 		return result
 

--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -321,6 +321,10 @@ class _EventFilter( QtCore.QObject ) :
 				)
 			 )
 
+			if not toolTip :
+				return False
+
+			toolTip = GafferUI.DocumentationAlgo.markdownToHTML( toolTip )
 			QtWidgets.QToolTip.showText( qEvent.globalPos(), toolTip, qObject )
 
 			return True

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -103,11 +103,12 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 		result = GafferUI.PlugValueWidget.getToolTip( self )
 
 		if self.getPlug() is not None :
-			result += "<ul>"
-			result += "<li>Left drag to connect</li>"
+			if result :
+				result += "\n"
+			result += "## Actions\n\n"
+			result += "- Left drag to connect\n"
 			if hasattr( self.getPlug(), "getValue" ) :
-				result += "<li>Shift-left or middle drag to transfer value</li>"
-			result += "<ul>"
+				result += "- Shift+left or middle drag to transfer value"
 
 		return result
 

--- a/python/GafferUI/NodeEditor.py
+++ b/python/GafferUI/NodeEditor.py
@@ -148,7 +148,7 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 							scoped = False
 						)
 
-				toolTip = "<h3>" + node.typeName().rpartition( ":" )[2] + "</h3>"
+				toolTip = "# " + node.typeName().rpartition( ":" )[2]
 				description = Gaffer.Metadata.value( node, "description" )
 				if description :
 					toolTip += "\n\n" + description

--- a/python/GafferUI/NumericPlugValueWidget.py
+++ b/python/GafferUI/NumericPlugValueWidget.py
@@ -85,9 +85,10 @@ class NumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 		result = GafferUI.PlugValueWidget.getToolTip( self )
 
 		if self.getPlug() is not None :
-			result += "<ul>"
-			result += "<li>Cursor up/down to increment/decrement</li>"
-			result += "<ul>"
+			if result :
+				result += "\n"
+			result += "## Actions\n"
+			result += " - Cursor up/down to increment/decrement\n"
 
 		return result
 

--- a/python/GafferUI/PathPlugValueWidget.py
+++ b/python/GafferUI/PathPlugValueWidget.py
@@ -93,11 +93,13 @@ class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		result = GafferUI.PlugValueWidget.getToolTip( self )
 
-		result += "<ul>"
-		result += "<li><kbd>Tab</kbd> to autocomplete path component</li>"
-		result += "<li>Select path component (or hit <kbd>&darr;</kbd>) to show path-level contents menu</li>"
-		result += "<li>Select all to show path hierarchy menu</li>"
-		result += "</ul>"
+		if result :
+			result += "\n\n"
+
+		result += "## Actions\n\n"
+		result += "- <kbd>Tab</kbd> to autocomplete path component\n"
+		result += "- Select path component (or hit <kbd>&darr;</kbd>) to show path-level contents menu\n"
+		result += "- Select all to show path hierarchy menu\n"
 
 		return result
 

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -140,9 +140,9 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		inputText = ""
 		if input is not None :
-			inputText = " &lt;- " + input.relativeName( input.commonAncestor( plug, Gaffer.GraphComponent ) )
+			inputText = " <- " + input.relativeName( input.commonAncestor( plug, Gaffer.GraphComponent ) )
 
-		result = "<h3>" + plug.relativeName( plug.node() ) + inputText + "</h3>"
+		result = "# " + plug.relativeName( plug.node() ) + inputText
 		description = Gaffer.Metadata.value( plug, "description" )
 		if description :
 			result += "\n\n" + description

--- a/python/GafferUI/RampPlugValueWidget.py
+++ b/python/GafferUI/RampPlugValueWidget.py
@@ -65,7 +65,7 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 				# metadata on this child plug right before constructing a widget for it.  There should probably
 				# be some way to do this genericly during initialization
 				Gaffer.Metadata.registerValue( plug['interpolation'],
-					"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget", persistent=False )  
+					"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget", persistent=False )
 				for name, value in sorted( Gaffer.SplineDefinitionInterpolation.names.items() ):
 					Gaffer.Metadata.registerValue( plug['interpolation'], "preset:" + name, value, persistent=False )
 
@@ -116,12 +116,13 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 		result = GafferUI.PlugValueWidget.getToolTip( self )
 
 		if self.getPlug() is not None :
-			result += "<ul>"
-			result += "<li>Click empty space in slider to add handle"
-			result += "<li>Click handle to select"
-			result += "<li>Delete to remove selected handle"
-			result += "<li>Cursor left/right to nudge selected handle"
-			result += "<ul>"
+			if result :
+				result += "\n"
+			result += "## Actions\n\n"
+			result += "- Click empty space in slider to add handle\n"
+			result += "- Click handle to select\n"
+			result += "- Delete to remove selected handle\n"
+			result += "- Cursor left/right to nudge selected handle\n"
 
 		return result
 

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -171,8 +171,6 @@ class Widget( object ) :
 
  		self.__visible = not isinstance( self, GafferUI.Window )
 
-		self.setToolTip( toolTip )
-
 		# perform automatic parenting if necessary. we don't want to do this
 		# for menus, because they don't have the same parenting semantics. if other
 		# types end up with similar requirements then we should probably just have
@@ -194,6 +192,8 @@ class Widget( object ) :
 				self.__ensureEventFilter()
 				break
 			c = c.__bases__[0]
+
+		self.setToolTip( toolTip )
 
 	## Sets whether or not this Widget is visible. Widgets are
 	# visible by default, except for Windows which need to be made
@@ -584,6 +584,12 @@ class Widget( object ) :
 
 		self._qtWidget().setToolTip( toolTip )
 
+		if toolTip :
+			# Qt does have a default event handler for tooltips,
+			# but we install our own so we can support markdown
+			# formatting automatically.
+			self.__ensureEventFilter()
+
 	## Returns the current position of the mouse. If relativeTo
 	# is not specified, then the position will be in screen coordinates,
 	# otherwise it will be in the local coordinate system of the
@@ -944,6 +950,7 @@ class _EventFilter( QtCore.QObject ) :
 		widget = Widget._owner( qObject )
 		toolTip = widget.getToolTip()
 		if toolTip :
+			toolTip = GafferUI.DocumentationAlgo.markdownToHTML( toolTip )
 			QtWidgets.QToolTip.showText( qEvent.globalPos(), toolTip, qObject )
 			return True
 		else :

--- a/python/GafferUITest/DocumentationAlgoTest.py
+++ b/python/GafferUITest/DocumentationAlgoTest.py
@@ -1,0 +1,50 @@
+##########################################################################
+#
+#  Copyright (c) 2019, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferUI
+import GafferUITest
+
+class DocumentationAlgoTest( GafferUITest.TestCase ) :
+
+	def testMarkdownToHTML( self ) :
+
+		self.assertEqual(
+			GafferUI.DocumentationAlgo.markdownToHTML( "# Heading" ),
+			"<h1>Heading</h1>\n"
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/WidgetTest.py
+++ b/python/GafferUITest/WidgetTest.py
@@ -146,6 +146,16 @@ class WidgetTest( GafferUITest.TestCase ) :
 		w.setToolTip( "a" )
 		self.assertEqual( w.getToolTip(), "a" )
 
+	def testMarkdownToolTips( self ) :
+
+		markdownToolTip = "# header\n\n- list 1\nlist 2"
+
+		w = TestWidget()
+		w.setToolTip( markdownToolTip )
+		# We don't want any conversion to HTML to be "baked in" - we expect
+		# to get back exactly the same thing as we saved.
+		self.assertEqual( w.getToolTip(), markdownToolTip )
+
 	def testEnabledState( self ) :
 
 		w = TestWidget()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -114,6 +114,7 @@ from WidgetAlgoTest import WidgetAlgoTest
 from BackupsTest import BackupsTest
 from LayoutsTest import LayoutsTest
 from CompoundNumericNoduleTest import CompoundNumericNoduleTest
+from DocumentationAlgoTest import DocumentationAlgoTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -147,7 +147,7 @@ std::string BackdropNodeGadget::getToolTip( const IECore::LineSegment3f &line ) 
 
 	if( title.size() )
 	{
-		result += "<h3>" + title + "</h3>";
+		result += "# " + title;
 	}
 	if( description.size() )
 	{
@@ -155,7 +155,6 @@ std::string BackdropNodeGadget::getToolTip( const IECore::LineSegment3f &line ) 
 		{
 			result += "\n\n";
 		}
-		boost::replace_all( description, "\n", "<br>" );
 		result += description;
 	}
 

--- a/src/GafferUI/NodeGadget.cpp
+++ b/src/GafferUI/NodeGadget.cpp
@@ -194,7 +194,7 @@ std::string NodeGadget::getToolTip( const IECore::LineSegment3f &line ) const
 		title = &*(r.end());
 	}
 
-	result = "<h3>" + title + "</h3>";
+	result = "# " + title;
 
 	if( ConstStringDataPtr description = Gaffer::Metadata::value<StringData>( m_node, "description" ) )
 	{

--- a/src/GafferUI/Nodule.cpp
+++ b/src/GafferUI/Nodule.cpp
@@ -154,7 +154,7 @@ std::string Nodule::getToolTip( const IECore::LineSegment3f &line ) const
 		result = m_plug->relativeName( node->parent<Gaffer::GraphComponent>() );
 	}
 
-	result = "<h3>" + result + "</h3>";
+	result = "# " + result;
 	if( ConstStringDataPtr description = Gaffer::Metadata::value<StringData>( m_plug.get(), "description" ) )
 	{
 		result += "\n\n" + description->readable();

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -117,6 +117,10 @@ class StandardNodeGadget::ErrorGadget : public Gadget
 			{
 				if( reported.find( it->second.error ) == reported.end() )
 				{
+					if( result.size() )
+					{
+						result += "\n";
+					}
 					result += it->second.error;
 					reported.insert( it->second.error );
 				}
@@ -936,7 +940,7 @@ void StandardNodeGadget::error( const Gaffer::Plug *plug, const Gaffer::Plug *so
 	{
 		header = "Error on upstream node " + source->node()->relativeName( source->ancestor<ScriptNode>() );
 	}
-	header = "<h3>" + header + "</h3>";
+	header = "# " + header + "\n\n";
 
 	// We could be on any thread at this point, so we
 	// use an idle callback to do the work of displaying the error


### PR DESCRIPTION
This allows markdown to be returned from `Widget.getToolTip()`, automatically formatting it into HTML for display in Qt's tooltips. This is important, because our node/plug metadata descriptions often use Markdown because that is the format used to generate the node reference.