### PR TITLE
AuxiliaryConnectionsGadget : Fix connections to empty gadgets

### DIFF
--- a/src/GafferUI/AuxiliaryConnectionsGadget.cpp
+++ b/src/GafferUI/AuxiliaryConnectionsGadget.cpp
@@ -44,6 +44,8 @@
 
 #include "IECoreGL/Selector.h"
 
+#include "OpenEXR/ImathBoxAlgo.h"
+
 #include "boost/bind.hpp"
 #include "boost/bind/placeholders.hpp"
 
@@ -122,7 +124,12 @@ Box2f nodeFrame( const NodeGadget *nodeGadget )
 
 V2f gadgetCenter( const Gadget *gadget )
 {
-	const V3f c = gadget->transformedBound( nullptr ).center();
+	Box3f b = gadget->bound();
+	if( b.isEmpty() )
+	{
+		b = Box3f( V3f( 0 ) );
+	}
+	const V3f c = transform( b, gadget->fullTransform() ).center();
 	return V2f( c.x, c.y );
 }
 


### PR DESCRIPTION
These can occur when a nested plug has an input but no nodule, and the parent plug has a nodule and no children with nodules. Connections into the colour components of the OpenGL Constant shader meet these criteria.
