### PR TITLE
Deal With Duplicate Ids In Instancer

### DIFF
--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -621,7 +621,15 @@ class RenderController::SceneGraph
 
 				if( it != oldChildrenRaw.end() && (*it)->m_name == name )
 				{
-					m_children.push_back( std::move( oldChildren[it-oldChildrenRaw.begin()] ) );
+					decltype( it )::difference_type index = it - oldChildrenRaw.begin();
+					if( !oldChildren[ index ] )
+					{
+						std::string path;
+						ScenePlug::pathToString( Context::current()->get<vector<InternedString> >( ScenePlug::scenePathContextName ), path );
+						path += "/" + name.string();
+						throw Exception( "RenderControllerSceneGraph::updateChildren() failed.  Duplicate children with name: " + path );
+					}
+					m_children.push_back( std::move( oldChildren[ index ] ) );
 				}
 				else
 				{


### PR DESCRIPTION
Previously, if you input duplicate ids to the instancer, you would get duplicate child names output, and this would crash in RenderController.

This PR first turns that crash into a more intelligible exception, and then fixes Instancer so it never illegally outputs duplicate child names.

In order to do this, I sort the ids as integers before converting to string.  This does technically change behaviour in previously valid scenes, but no one should be relying on the order of child names ( especilally not before when it wasn't in numerical order ).