### PR TITLE
GafferImage context sanitisation

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -745,7 +745,7 @@ libraries = {
 			"LIBS" : [ "Gaffer", "GafferImage", "OpenImageIO$OIIO_LIB_SUFFIX",  ],
 		},
 		"pythonEnvAppends" : {
-			"LIBS" : [ "GafferImage" ],
+			"LIBS" : [ "GafferImage", "GafferImageTest" ],
 		},
 		"additionalFiles" : glob.glob( "python/GafferImageTest/scripts/*" ) + glob.glob( "python/GafferImageTest/images/*" ) + glob.glob( "python/GafferImageTest/openColorIO/luts/*" ) + glob.glob( "python/GafferImageTest/openColorIO/*" ),
 	},

--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -512,6 +512,10 @@ class stats( Gaffer.Application ) :
 			IECore.msg( IECore.Msg.Level.Error, "stats", "Image \"%s\" does not exist" % args["image"].value )
 			return
 
+		contextSanitiser = _NullContextManager()
+		if args["contextSanitiser"].value :
+			contextSanitiser = GafferImageTest.ContextSanitiser()
+
 		def computeImage() :
 
 			with self.__context( script, args ) as context :
@@ -525,7 +529,8 @@ class stats( Gaffer.Application ) :
 		memory = _Memory.maxRSS()
 		with _Timer() as imageTimer :
 			with self.__performanceMonitor or _NullContextManager(), self.__contextMonitor or _NullContextManager() :
-				computeImage()
+				with contextSanitiser :
+					computeImage()
 
 		self.__timers["Image generation"] = imageTimer
 		self.__memory["Image generation"] = _Memory.maxRSS() - memory

--- a/include/GafferImage/FilterAlgo.inl
+++ b/include/GafferImage/FilterAlgo.inl
@@ -60,7 +60,6 @@ Imath::V2f FilterAlgo::derivativesToAxisAligned( const Imath::V2f &p, const Imat
 	{
 		minLength = 1.0f;
 		majorVector = Imath::V2f(0.0f);
-		
 	}
 	else if( dxLength > dyLength )
 	{

--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -173,9 +173,8 @@ class GAFFERIMAGE_API ImagePlug : public Gaffer::ValuePlug
 			return tileIndex( point ) * tileSize();
 		}
 
-
-
 	private :
+
 		static int tileSizeLog2() { return 6; };
 
 		static void compoundObjectToCompoundData( const IECore::CompoundObject *object, IECore::CompoundData *data );

--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -141,15 +141,35 @@ class GAFFERIMAGE_API ImagePlug : public Gaffer::ValuePlug
 		//@}
 
 		/// @name Convenience accessors
-		/// These functions create temporary Contexts specifying image:channelName
-		/// and image:tileOrigin, and use them to return useful output.
-		/// They therefore only make sense for output plugs or inputs which
-		/// have an input connection - if called on an unconnected input plug,
-		/// an Exception will be thrown.
+		/// These functions create a GlobalScope or ChannelDataScope
+		/// as appropriate, and return the value or hash from one of
+		/// the child plugs.
+		/// > Note : If you wish to evaluate multiple plugs in the same
+		/// > context, you can get improved performance by creating the
+		/// > the appropriate scope class manually and then calling
+		/// > `getValue()` or `hash()` directly.
 		////////////////////////////////////////////////////////////////////
 		//@{
+		/// Calls `channelDataPlug()->getValue()` using a ChannelDataScope.
 		IECore::ConstFloatVectorDataPtr channelData( const std::string &channelName, const Imath::V2i &tileOrigin ) const;
+		/// Calls `channelDataPlug()->hash()` using a ChannelDataScope.
 		IECore::MurmurHash channelDataHash( const std::string &channelName, const Imath::V2i &tileOrigin ) const;
+		/// Calls `formatPlug()->getValue()` using a GlobalScope.
+		GafferImage::Format format() const;
+		/// Calls `formatPlug()->hash()` using a GlobalScope.
+		IECore::MurmurHash formatHash() const;
+		/// Calls `dataWindowPlug()->getValue()` using a GlobalScope.
+		Imath::Box2i dataWindow() const;
+		/// Calls `dataWindowPlug()->hash()` using a GlobalScope.
+		IECore::MurmurHash dataWindowHash() const;
+		/// Calls `channelNamesPlug()->getValue()` using a GlobalScope.
+		IECore::ConstStringVectorDataPtr channelNames() const;
+		/// Calls `channelNamesPlug()->hash()` using a GlobalScope.
+		IECore::MurmurHash channelNamesHash() const;
+		/// Calls `metadataPlug()->getValue()` using a GlobalScope.
+		IECore::ConstCompoundDataPtr metadata() const;
+		/// Calls `metadataPlug()->hash()` using a GlobalScope.
+		IECore::MurmurHash metadataHash() const;
 		/// Returns a pointer to an IECore::ImagePrimitive. Note that the image's
 		/// coordinate system will be converted to the OpenEXR and Cortex specification
 		/// and have it's origin in the top left of it's display window with the positive

--- a/python/GafferImageTest/ImagePlugTest.py
+++ b/python/GafferImageTest/ImagePlugTest.py
@@ -179,5 +179,29 @@ class ImagePlugTest( GafferImageTest.ImageTestCase ) :
 			GafferImage.FormatPlug.setDefaultFormat( c, GafferImage.Format( 200, 300 ) )
 			self.assertEqual( constant["out"].image().displayWindow, imath.Box2i( imath.V2i( 0 ), imath.V2i( 199, 299 ) ) )
 
+	def testGlobalConvenienceMethods( self ) :
+
+		checker = GafferImage.Checkerboard()
+
+		metadata = GafferImage.ImageMetadata()
+		metadata["in"].setInput( checker["out"] )
+		metadata["metadata"].addMember( "test", 10 )
+
+		self.assertEqual( metadata["out"].format(), metadata["out"]["format"].getValue() )
+		self.assertEqual( metadata["out"].formatHash(), metadata["out"]["format"].hash() )
+
+		self.assertEqual( metadata["out"].dataWindow(), metadata["out"]["dataWindow"].getValue() )
+		self.assertEqual( metadata["out"].dataWindowHash(), metadata["out"]["dataWindow"].hash() )
+
+		self.assertEqual( metadata["out"].channelNames(), metadata["out"]["channelNames"].getValue() )
+		self.assertFalse( metadata["out"].channelNames().isSame( metadata["out"]["channelNames"].getValue( _copy = False ) ) )
+		self.assertTrue( metadata["out"].channelNames( _copy = False ).isSame( metadata["out"]["channelNames"].getValue( _copy = False ) ) )
+		self.assertEqual( metadata["out"].channelNamesHash(), metadata["out"]["channelNames"].hash() )
+
+		self.assertEqual( metadata["out"].metadata(), metadata["out"]["metadata"].getValue() )
+		self.assertFalse( metadata["out"].metadata().isSame( metadata["out"]["metadata"].getValue( _copy = False ) ) )
+		self.assertTrue( metadata["out"].metadata( _copy = False ).isSame( metadata["out"]["metadata"].getValue( _copy = False ) ) )
+		self.assertEqual( metadata["out"].metadataHash(), metadata["out"]["metadata"].hash() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ImageTestCase.py
+++ b/python/GafferImageTest/ImageTestCase.py
@@ -42,8 +42,18 @@ import IECoreImage
 import Gaffer
 import GafferTest
 import GafferImage
+import GafferImageTest
 
 class ImageTestCase( GafferTest.TestCase ) :
+
+
+	def setUp( self ) :
+
+		GafferTest.TestCase.setUp( self )
+
+		sanitiser = GafferImageTest.ContextSanitiser()
+		sanitiser.__enter__()
+		self.addCleanup( sanitiser.__exit__, None, None, None )
 
 	def assertImageHashesEqual( self, imageA, imageB ) :
 

--- a/src/GafferImage/FilterAlgo.cpp
+++ b/src/GafferImage/FilterAlgo.cpp
@@ -109,7 +109,7 @@ class SmoothGaussian2D : public OIIO::Filter2D
 
 };
 
-// OIIO's default cubic is a general one with a protected m_a member that can be 
+// OIIO's default cubic is a general one with a protected m_a member that can be
 // modified.  But when m_a is left at it's default value of 0, it is 0 over half
 // of it's width.  By specializing for this case, we get a filter that needs
 // half as many support pixels, but gives an identical result.
@@ -256,7 +256,7 @@ std::vector<FilterPair> getAllFilters()
 		}
 	}
 	filters.push_back( FilterPair("smoothGaussian", new SmoothGaussian2D( 3.0f, 3.0f ) ) );
-	
+
 	return filters;
 }
 
@@ -311,7 +311,7 @@ const OIIO::Filter2D *GafferImage::FilterAlgo::acquireFilter( const std::string 
 	}
 	else
 	{
-		throw IECore::Exception( boost::str( boost::format( "Unknown filter \"%s\"" ) % name ) );	
+		throw IECore::Exception( boost::str( boost::format( "Unknown filter \"%s\"" ) % name ) );
 	}
 }
 
@@ -360,9 +360,9 @@ float GafferImage::FilterAlgo::sampleParallelogram( Sampler &sampler, const V2f 
 			// pixels within the bounding box, and another value for pixels actually touched
 			// by the filter, is a good way to check that the bounding box is correct
 			//w = w != 0.0f ? 1.0f : 0.1f;
-		
+
 			if( w != 0.0f )
-			{	
+			{
 				totalW += w;
 				v += w * sampler.sample( x, y );
 			}
@@ -420,7 +420,7 @@ float GafferImage::FilterAlgo::sampleBox( Sampler &sampler, const V2f &p, float 
 				// pixels within the bounding box, and another value for pixels actually touched
 				// by the filter, is a good way to check that the bounding box is correct
 				//w = w != 0.0f ? 1.0f : 0.1f;
-			
+
 				totalW += w;
 				v += w * sampler.sample( x, y );
 			}

--- a/src/GafferImage/Grade.cpp
+++ b/src/GafferImage/Grade.cpp
@@ -44,7 +44,7 @@ using namespace IECore;
 using namespace Gaffer;
 using namespace GafferImage;
 
-namespace 
+namespace
 {
 	struct GradeParametersScope : public Gaffer::Context::EditableScope
 	{
@@ -235,7 +235,7 @@ void Grade::hashChannelData( const GafferImage::ImagePlug *output, const Gaffer:
 	const std::string &channelName = context->get<std::string>( ImagePlug::channelNameContextName );
 	const int channelIndex = std::max( 0, ImageAlgo::colorIndex( channelName ) );
 
-	GradeParametersScope s( context );	
+	GradeParametersScope s( context );
 	blackPointPlug()->getChild( channelIndex )->hash( h );
 	whitePointPlug()->getChild( channelIndex )->hash( h );
 	liftPlug()->getChild( channelIndex )->hash( h );
@@ -256,7 +256,7 @@ void Grade::processChannelData( const Gaffer::Context *context, const ImagePlug 
 	float A, B, gamma;
 	bool whiteClamp, blackClamp;
 	{
-		GradeParametersScope s( context );	
+		GradeParametersScope s( context );
 		parameters( std::max( 0, ImageAlgo::colorIndex( channel ) ), A, B, gamma );
 		whiteClamp = whiteClampPlug()->getValue();
 		blackClamp = blackClampPlug()->getValue();

--- a/src/GafferImage/ImageNode.cpp
+++ b/src/GafferImage/ImageNode.cpp
@@ -118,31 +118,18 @@ void ImageNode::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 		}
 		else if( output == imagePlug->formatPlug() )
 		{
-			// The asserts in these 4 conditionals can be uncommented to catch anywhere that these
-			// global plugs are being hashed with unnecessary tile specific context.  This can be
-			// a performance hazard because it means we can't reuse hashes from the hash cache
-			// nearly as effectively
-
-			//assert( context->get<std::string>( ImagePlug::channelNameContextName, "UNDEF" ) == "UNDEF" );
-			//assert( context->get<Imath::V2i>( ImagePlug::tileOriginContextName, V2i( 42 ) ) == V2i( 42 ) );
 			hashFormat( imagePlug, context, h );
 		}
 		else if( output == imagePlug->dataWindowPlug() )
 		{
-			//assert( context->get<std::string>( ImagePlug::channelNameContextName, "UNDEF" ) == "UNDEF" );
-			//assert( context->get<Imath::V2i>( ImagePlug::tileOriginContextName, V2i( 42 ) ) == V2i( 42 ) );
 			hashDataWindow( imagePlug, context, h );
 		}
 		else if( output == imagePlug->metadataPlug() )
 		{
-			//assert( context->get<std::string>( ImagePlug::channelNameContextName, "UNDEF" ) == "UNDEF" );
-			//assert( context->get<Imath::V2i>( ImagePlug::tileOriginContextName, V2i( 42 ) ) == V2i( 42 ) );
 			hashMetadata( imagePlug, context, h );
 		}
 		else if( output == imagePlug->channelNamesPlug() )
 		{
-			//assert( context->get<std::string>( ImagePlug::channelNameContextName, "UNDEF" ) == "UNDEF" );
-			//assert( context->get<Imath::V2i>( ImagePlug::tileOriginContextName, V2i( 42 ) ) == V2i( 42 ) );
 			hashChannelNames( imagePlug, context, h );
 		}
 	}

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -323,6 +323,54 @@ IECore::MurmurHash ImagePlug::channelDataHash( const std::string &channelName, c
 	return channelDataPlug()->hash();
 }
 
+GafferImage::Format ImagePlug::format() const
+{
+	GlobalScope globalScope( Context::current() );
+	return formatPlug()->getValue();
+}
+
+IECore::MurmurHash ImagePlug::formatHash() const
+{
+	GlobalScope globalScope( Context::current() );
+	return formatPlug()->hash();
+}
+
+Imath::Box2i ImagePlug::dataWindow() const
+{
+	GlobalScope globalScope( Context::current() );
+	return dataWindowPlug()->getValue();
+}
+
+IECore::MurmurHash ImagePlug::dataWindowHash() const
+{
+	GlobalScope globalScope( Context::current() );
+	return dataWindowPlug()->hash();
+}
+
+IECore::ConstStringVectorDataPtr ImagePlug::channelNames() const
+{
+	GlobalScope globalScope( Context::current() );
+	return channelNamesPlug()->getValue();
+}
+
+IECore::MurmurHash ImagePlug::channelNamesHash() const
+{
+	GlobalScope globalScope( Context::current() );
+	return channelNamesPlug()->hash();
+}
+
+IECore::ConstCompoundDataPtr ImagePlug::metadata() const
+{
+	GlobalScope globalScope( Context::current() );
+	return metadataPlug()->getValue();
+}
+
+IECore::MurmurHash ImagePlug::metadataHash() const
+{
+	GlobalScope globalScope( Context::current() );
+	return metadataPlug()->hash();
+}
+
 IECoreImage::ImagePrimitivePtr ImagePlug::image() const
 {
 	Format format = formatPlug()->getValue();

--- a/src/GafferImage/Offset.cpp
+++ b/src/GafferImage/Offset.cpp
@@ -142,7 +142,7 @@ void Offset::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer
 	{
 		ImageProcessor::hashChannelData( parent, context, h );
 
-		Box2i inDataWindow = inPlug()->dataWindowPlug()->getValue();
+		const Box2i inDataWindow = inPlug()->dataWindow();
 
 		const Box2i outTileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
 		const Box2i inBound = BufferAlgo::intersection(
@@ -181,7 +181,7 @@ IECore::ConstFloatVectorDataPtr Offset::computeChannelData( const std::string &c
 	}
 	else
 	{
-		Box2i inDataWindow = inPlug()->dataWindowPlug()->getValue();
+		const Box2i inDataWindow = inPlug()->dataWindow();
 
 		const Box2i outTileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
 		const Box2i inBound = BufferAlgo::intersection(

--- a/src/GafferImage/Offset.cpp
+++ b/src/GafferImage/Offset.cpp
@@ -145,7 +145,7 @@ void Offset::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer
 		Box2i inDataWindow = inPlug()->dataWindowPlug()->getValue();
 
 		const Box2i outTileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
-		const Box2i inBound = BufferAlgo::intersection( 
+		const Box2i inBound = BufferAlgo::intersection(
 			inDataWindow,
 			Box2i( outTileBound.min - offset, outTileBound.max - offset )
 		);
@@ -184,7 +184,7 @@ IECore::ConstFloatVectorDataPtr Offset::computeChannelData( const std::string &c
 		Box2i inDataWindow = inPlug()->dataWindowPlug()->getValue();
 
 		const Box2i outTileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
-		const Box2i inBound = BufferAlgo::intersection( 
+		const Box2i inBound = BufferAlgo::intersection(
 			inDataWindow,
 			Box2i( outTileBound.min - offset, outTileBound.max - offset )
 		);

--- a/src/GafferImage/VectorWarp.cpp
+++ b/src/GafferImage/VectorWarp.cpp
@@ -82,7 +82,7 @@ struct VectorWarp::Engine : public Warp::Engine
 		else
 		{
 			V2f result = m_vectorMode == Relative ? outputPixel : V2f( 0.0f );
-			
+
 			result += m_vectorUnits == Screen ?
 				screenToPixel( V2f( m_x[i], m_y[i] ) ) :
 				V2f( m_x[i], m_y[i] );
@@ -231,7 +231,7 @@ const Warp::Engine *VectorWarp::computeEngine( const Imath::V2i &tileOrigin, con
 {
 	const Box2i tileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
 
-	
+
 	Box2i validTileBound;
 	ConstStringVectorDataPtr channelNames;
 	Box2i displayWindow;

--- a/src/GafferImageModule/CoreBinding.cpp
+++ b/src/GafferImageModule/CoreBinding.cpp
@@ -75,6 +75,56 @@ IECore::MurmurHash channelDataHash( const ImagePlug &plug, const std::string &ch
 	return plug.channelDataHash( channelName, tileOrigin );
 }
 
+GafferImage::Format format( const ImagePlug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.format();
+}
+
+IECore::MurmurHash formatHash( const ImagePlug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.formatHash();
+}
+
+Imath::Box2i dataWindow( const ImagePlug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.dataWindow();
+}
+
+IECore::MurmurHash dataWindowHash( const ImagePlug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.dataWindowHash();
+}
+
+IECore::StringVectorDataPtr channelNames( const ImagePlug &plug, bool copy )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	IECore::ConstStringVectorDataPtr d = plug.channelNames();
+	return copy ? d->copy() : boost::const_pointer_cast<IECore::StringVectorData>( d );
+}
+
+IECore::MurmurHash channelNamesHash( const ImagePlug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.channelNamesHash();
+}
+
+IECore::CompoundDataPtr metadata( const ImagePlug &plug, bool copy )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	IECore::ConstCompoundDataPtr d = plug.metadata();
+	return copy ? d->copy() : boost::const_pointer_cast<IECore::CompoundData>( d );
+}
+
+IECore::MurmurHash metadataHash( const ImagePlug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.metadataHash();
+}
+
 IECoreImage::ImagePrimitivePtr image( const ImagePlug &plug )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -189,6 +239,14 @@ void GafferImageModule::bindCore()
 		)
 		.def( "channelData", &channelData, ( arg( "_copy" ) = true ) )
 		.def( "channelDataHash", &channelDataHash )
+		.def( "format", &format )
+		.def( "formatHash", &formatHash )
+		.def( "dataWindow", &dataWindow )
+		.def( "dataWindowHash", &dataWindowHash )
+		.def( "channelNames", &channelNames, ( arg( "_copy" ) = true ) )
+		.def( "channelNamesHash", &channelNamesHash )
+		.def( "metadata", &metadata, ( arg( "_copy" ) = true ) )
+		.def( "metadataHash", &metadataHash )
 		.def( "image", &image )
 		.def( "imageHash", &imageHash )
 		.def( "tileSize", &ImagePlug::tileSize ).staticmethod( "tileSize" )

--- a/src/GafferImageTest/ContextSanitiser.cpp
+++ b/src/GafferImageTest/ContextSanitiser.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,71 +34,88 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
-
 #include "GafferImageTest/ContextSanitiser.h"
 
-#include "GafferImage/ImageAlgo.h"
 #include "GafferImage/ImagePlug.h"
 
-#include "Gaffer/Node.h"
+#include "Gaffer/Process.h"
+#include "Gaffer/ScriptNode.h"
 
-#include "IECorePython/ScopedGILRelease.h"
+#include "IECore/MessageHandler.h"
 
-using namespace boost::python;
+using namespace IECore;
 using namespace Gaffer;
 using namespace GafferImage;
 using namespace GafferImageTest;
 
-namespace
+namespace IECore
 {
 
-struct TilesEvaluateFunctor
+/// \todo Move to Cortex
+size_t tbb_hasher( const InternedString &s )
 {
-	bool operator()( const GafferImage::ImagePlug *imagePlug, const std::string &channelName, const Imath::V2i &tileOrigin )
+	return tbb::tbb_hasher( s.string() );
+}
+
+} // namespace IECore
+
+ContextSanitiser::ContextSanitiser()
+{
+}
+
+void ContextSanitiser::processStarted( const Gaffer::Process *process )
+{
+	if( const ImagePlug *image = process->plug()->parent<ImagePlug>() )
 	{
-		imagePlug->channelDataPlug()->getValue();
-		return true;
-	}
-};
+		if( process->plug() != image->channelDataPlug() )
+		{
+			if( process->context()->get<IECore::Data>( ImagePlug::channelNameContextName, nullptr ) )
+			{
+				warn( *process, ImagePlug::channelNameContextName );
+			}
+			if( process->context()->get<IECore::Data>( ImagePlug::tileOriginContextName, nullptr ) )
+			{
+				warn( *process, ImagePlug::tileOriginContextName );
+			}
+		}
 
-void processTiles( const GafferImage::ImagePlug *imagePlug )
-{
-	TilesEvaluateFunctor f;
-	ImageAlgo::parallelProcessTiles( imagePlug, imagePlug->channelNamesPlug()->getValue()->readable(), f );
+	}
 }
 
-void processTilesOnDirty( const Gaffer::Plug *dirtiedPlug, ConstImagePlugPtr image )
+void ContextSanitiser::processFinished( const Gaffer::Process *process )
 {
-	if( dirtiedPlug == image.get() )
+}
+
+void ContextSanitiser::warn( const Gaffer::Process &process, const IECore::InternedString &contextVariable )
+{
+	const Warning warning(
+		PlugPair( process.plug(), process.parent() ? process.parent()->plug() : nullptr ),
+		contextVariable
+	);
+
+	if( m_warningsEmitted.insert( warning ).second )
 	{
-		processTiles( image.get() );
+		std::string message = boost::str(
+			boost::format( "%s in context for %s %s" )
+				% contextVariable.string()
+				% process.plug()->relativeName(
+					process.plug()->ancestor<ScriptNode>()
+				)
+				% process.type()
+		);
+		if( process.parent() )
+		{
+			message += boost::str(
+				boost::format( " (called from %s %s)" )
+					% process.parent()->plug()->relativeName(
+						process.parent()->plug()->ancestor<ScriptNode>()
+					)
+					% process.parent()->type()
+			);
+		}
+		IECore::msg(
+			IECore::Msg::Warning, "ContextSanitiser",
+			message
+		);
 	}
-}
-
-void processTilesWrapper( GafferImage::ImagePlug *imagePlug )
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	processTiles( imagePlug );
-}
-
-boost::signals::connection connectProcessTilesToPlugDirtiedSignal( GafferImage::ConstImagePlugPtr image )
-{
-	const Node *node = image->node();
-	if( !node )
-	{
-		throw IECore::Exception( "Plug does not belong to a node." );
-	}
-
-	return const_cast<Node *>( node )->plugDirtiedSignal().connect( boost::bind( &processTilesOnDirty, ::_1, image ) );
-}
-
-} // namespace
-
-BOOST_PYTHON_MODULE( _GafferImageTest )
-{
-	class_<ContextSanitiser, bases<Gaffer::Monitor>, boost::noncopyable>( "ContextSanitiser" );
-
-	def( "processTiles", &processTilesWrapper );
-	def( "connectProcessTilesToPlugDirtiedSignal", &connectProcessTilesToPlugDirtiedSignal );
 }

--- a/src/GafferImageTestModule/GafferImageTestModule.cpp
+++ b/src/GafferImageTestModule/GafferImageTestModule.cpp
@@ -65,7 +65,12 @@ struct TilesEvaluateFunctor
 void processTiles( const GafferImage::ImagePlug *imagePlug )
 {
 	TilesEvaluateFunctor f;
-	ImageAlgo::parallelProcessTiles( imagePlug, imagePlug->channelNamesPlug()->getValue()->readable(), f );
+	ImageAlgo::parallelProcessTiles(
+		imagePlug, imagePlug->channelNamesPlug()->getValue()->readable(),
+		f,
+		imagePlug->dataWindowPlug()->getValue(),
+		ImageAlgo::TopToBottom
+	);
 }
 
 void processTilesOnDirty( const Gaffer::Plug *dirtiedPlug, ConstImagePlugPtr image )


### PR DESCRIPTION
This applies the principles from [GafferScene context sanitisation](#3060) to the GafferImage module. I've added a ContextSanitiser for images, added convenience methods to ImagePlug to make it easier to get contexts right, made the unit tests fail on unsanitised contexts, and fixed all bugs that triggered (which as it turns out, we only had one of).

I don't have any great performance leaps to report from this, but it's not harmful to my current optimisation goals (BleedFill), and it may well avoid the creation of performance problems in the future.