### PR TITLE
Shader network caching

### DIFF
--- a/include/GafferOSL/OSLObject.h
+++ b/include/GafferOSL/OSLObject.h
@@ -49,6 +49,8 @@
 namespace GafferOSL
 {
 
+IE_CORE_FORWARDDECLARE( ShadingEngine )
+
 class GAFFEROSL_API OSLObject : public GafferScene::SceneElementProcessor
 {
 
@@ -89,6 +91,11 @@ class GAFFEROSL_API OSLObject : public GafferScene::SceneElementProcessor
 
 		Gaffer::StringPlug *resampledNamesPlug();
 		const Gaffer::StringPlug *resampledNamesPlug() const;
+
+		Gaffer::BoolPlug *contextCompatibilityPlug();
+		const Gaffer::BoolPlug *contextCompatibilityPlug() const;
+
+		ConstShadingEnginePtr shadingEngine( const Gaffer::Context *context ) const;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -43,8 +43,9 @@
 
 #include "Gaffer/ArrayPlug.h"
 #include "Gaffer/CompoundNumericPlug.h"
-#include "Gaffer/DependencyNode.h"
+#include "Gaffer/ComputeNode.h"
 #include "Gaffer/TypedPlug.h"
+#include "Gaffer/TypedObjectPlug.h"
 
 #include "IECoreScene/Shader.h"
 
@@ -63,7 +64,7 @@ IE_CORE_FORWARDDECLARE( StringPlug )
 namespace GafferScene
 {
 
-class GAFFERSCENE_API Shader : public Gaffer::DependencyNode
+class GAFFERSCENE_API Shader : public Gaffer::ComputeNode
 {
 
 	public :
@@ -71,7 +72,7 @@ class GAFFERSCENE_API Shader : public Gaffer::DependencyNode
 		Shader( const std::string &name=defaultName<Shader>() );
 		~Shader() override;
 
-		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Shader, ShaderTypeId, Gaffer::DependencyNode );
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::Shader, ShaderTypeId, Gaffer::ComputeNode );
 
 		/// A plug defining the name of the shader.
 		Gaffer::StringPlug *namePlug();
@@ -89,13 +90,6 @@ class GAFFERSCENE_API Shader : public Gaffer::DependencyNode
 		Gaffer::Plug *parametersPlug();
 		const Gaffer::Plug *parametersPlug() const;
 
-		/// Plug which defines the shader's output - this should
-		/// be connected to a ShaderAssignment::shaderPlug() or
-		/// in the case of shaders which support networking it may
-		/// be connected to a parameter plug of another shader.
-		Gaffer::Plug *outPlug();
-		const Gaffer::Plug *outPlug() const;
-
 		/// Shaders can be enabled and disabled. A disabled shader
 		/// returns an empty object from the state() method, causing
 		/// any downstream ShaderAssignments to act as if they've been
@@ -105,6 +99,13 @@ class GAFFERSCENE_API Shader : public Gaffer::DependencyNode
 		/// to allow disabled shaders to act as a pass-through instead.
 		Gaffer::BoolPlug *enabledPlug() override;
 		const Gaffer::BoolPlug *enabledPlug() const override;
+
+		/// Plug which defines the shader's output - this should
+		/// be connected to a ShaderAssignment::shaderPlug() or
+		/// in the case of shaders which support networking it may
+		/// be connected to a parameter plug of another shader.
+		Gaffer::Plug *outPlug();
+		const Gaffer::Plug *outPlug() const;
 
 		/// Implemented so that the children of parametersPlug() affect
 		/// outPlug().
@@ -130,6 +131,9 @@ class GAFFERSCENE_API Shader : public Gaffer::DependencyNode
 		IECore::ConstCompoundObjectPtr attributes() const;
 
 	protected :
+
+		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 		/// Called when computing the hash for this node. May be reimplemented in derived classes
 		/// to deal with special cases, in which case parameterValue() should be reimplemented too.
@@ -161,6 +165,11 @@ class GAFFERSCENE_API Shader : public Gaffer::DependencyNode
 		// during compute.
 		Gaffer::Color3fPlug *nodeColorPlug();
 		const Gaffer::Color3fPlug *nodeColorPlug() const;
+		/// Output plug where the shader network will be generated.
+		Gaffer::CompoundObjectPlug *outAttributesPlug();
+		const Gaffer::CompoundObjectPlug *outAttributesPlug() const;
+
+		static const IECore::InternedString g_outputParameterContextName;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferScene/ShaderAssignment.h
+++ b/include/GafferScene/ShaderAssignment.h
@@ -67,6 +67,9 @@ class GAFFERSCENE_API ShaderAssignment : public SceneElementProcessor
 
 	private :
 
+		Gaffer::BoolPlug *contextCompatibilityPlug();
+		const Gaffer::BoolPlug *contextCompatibilityPlug() const;
+
 		static size_t g_firstPlugIndex;
 
 };

--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -322,16 +322,8 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		outputClosure["parameters"]["e"]["r"].setValue( 10 )
 
-		self.assertEqual(
-			set( [ x[0].relativeName( x[0].node() ) for x in cs ] ),
-			set( [
-				"parameters.e.r",
-				"parameters.e",
-				"parameters",
-				"out.c",
-				"out",
-			] )
-		)
+		self.assertTrue( outputClosure["out"] in [ x[0] for x in cs ] )
+		self.assertTrue( outputClosure["out"]["c"] in [ x[0] for x in cs ] )
 
 	def testRepeatability( self ) :
 

--- a/src/GafferOSL/OSLImage.cpp
+++ b/src/GafferOSL/OSLImage.cpp
@@ -236,8 +236,13 @@ IECore::ConstFloatVectorDataPtr OSLImage::computeChannelData( const std::string 
 
 void OSLImage::hashShading( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	const OSLShader *shader = runTimeCast<const OSLShader>( shaderPlug()->source()->node() );
-	ConstShadingEnginePtr shadingEngine = shader ? shader->shadingEngine() : nullptr;
+	ConstShadingEnginePtr shadingEngine;
+	if( auto shader = runTimeCast<const OSLShader>( shaderPlug()->source()->node() ) )
+	{
+		ImagePlug::GlobalScope globalScope( context );
+		shadingEngine = shader->shadingEngine();
+	}
+
 	if( !shadingEngine )
 	{
 		h = shadingPlug()->defaultValue()->hash();
@@ -270,8 +275,12 @@ void OSLImage::hashShading( const Gaffer::Context *context, IECore::MurmurHash &
 
 IECore::ConstCompoundDataPtr OSLImage::computeShading( const Gaffer::Context *context ) const
 {
-	const OSLShader *shader = runTimeCast<const OSLShader>( shaderPlug()->source()->node() );
-	ConstShadingEnginePtr shadingEngine = shader ? shader->shadingEngine() : nullptr;
+	ConstShadingEnginePtr shadingEngine;
+	if( auto shader = runTimeCast<const OSLShader>( shaderPlug()->source()->node() ) )
+	{
+		ImagePlug::GlobalScope globalScope( context );
+		shadingEngine = shader->shadingEngine();
+	}
 
 	if( !shadingEngine )
 	{

--- a/src/GafferOSL/OSLObject.cpp
+++ b/src/GafferOSL/OSLObject.cpp
@@ -41,6 +41,8 @@
 
 #include "GafferScene/ResamplePrimitiveVariables.h"
 
+#include "Gaffer/Metadata.h"
+
 #include "IECoreScene/Primitive.h"
 
 using namespace Imath;
@@ -79,7 +81,22 @@ CompoundDataPtr prepareShadingPoints( const Primitive *primitive, const ShadingE
 	return shadingPoints;
 }
 
-};
+/// Historically, we evaluated `OSLObject::shaderPlug()` in a context containing "scene:path",
+/// but for performance reasons we now want to evaluate it using `ScenePlug::GlobalScope`.
+/// The GAFFEROSL_OSLOBJECT_CONTEXTCOMPATIBILITY environment variable provides temporary
+/// backwards compatibility for anyone who may have taken advantage of "scene:path". But for
+/// all newly created nodes we use a userDefault to turn off compatibility at the node level.
+/// See further comments in ShaderAssignment.cpp, where we adopt the same strategy.
+bool initContextCompatibility()
+{
+	Gaffer::Metadata::registerValue( OSLObject::staticTypeId(), "__contextCompatibility", "userDefault", new BoolData( false ) );
+	const char *e = getenv( "GAFFEROSL_OSLOBJECT_CONTEXTCOMPATIBILITY" );
+	return e && !strcmp( e, "1" );
+}
+
+const bool g_contextCompatibilityEnabled = initContextCompatibility();
+
+} // namespace
 
 OSLObject::OSLObject( const std::string &name )
 	:	SceneElementProcessor( name, IECore::PathMatcher::NoMatch )
@@ -88,8 +105,8 @@ OSLObject::OSLObject( const std::string &name )
 	addChild( new ShaderPlug( "shader" ) );
 	addChild( new IntPlug( "interpolation", Plug::In, PrimitiveVariable::Vertex, PrimitiveVariable::Invalid, PrimitiveVariable::FaceVarying ) );
 	addChild( new ScenePlug( "__resampledIn", Plug::In, Plug::Default & ~Plug::Serialisable ) );
-
 	addChild( new StringPlug( "__resampleNames", Plug::Out ) );
+	addChild( new BoolPlug( "__contextCompatibility", Plug::In, true, Plug::Default & ~Plug::AcceptsInputs ) );
 
 	GafferScene::ResamplePrimitiveVariablesPtr resample = new ResamplePrimitiveVariables( "__resample" );
 	addChild( resample );
@@ -150,6 +167,16 @@ const StringPlug *OSLObject::resampledNamesPlug() const
 	return getChild<StringPlug>( g_firstPlugIndex + 3 );
 }
 
+Gaffer::BoolPlug *OSLObject::contextCompatibilityPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
+}
+
+const Gaffer::BoolPlug *OSLObject::contextCompatibilityPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
+}
+
 void OSLObject::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	SceneElementProcessor::affects( input, outputs );
@@ -158,7 +185,8 @@ void OSLObject::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 		input == shaderPlug() ||
 		input == inPlug()->transformPlug() ||
 		input == interpolationPlug() ||
-		input == resampledInPlug()->objectPlug()
+		input == resampledInPlug()->objectPlug() ||
+		input == contextCompatibilityPlug()
 	)
 	{
 		outputs.push_back( outPlug()->objectPlug() );
@@ -167,6 +195,7 @@ void OSLObject::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 	if(
 		input == shaderPlug() ||
 		input == inPlug()->objectPlug() ||
+		input == contextCompatibilityPlug()
 	)
 	{
 		outputs.push_back( resampledNamesPlug() );
@@ -229,9 +258,7 @@ bool OSLObject::processesObject() const
 
 void OSLObject::hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	const OSLShader *shader = runTimeCast<const OSLShader>( shaderPlug()->source()->node() );
-	ConstShadingEnginePtr shadingEngine = shader ? shader->shadingEngine() : nullptr;
-
+	ConstShadingEnginePtr shadingEngine = this->shadingEngine( context );
 	if( !shadingEngine )
 	{
 		return;
@@ -253,9 +280,7 @@ IECore::ConstObjectPtr OSLObject::computeProcessedObject( const ScenePath &path,
 		return inputObject;
 	}
 
-	const OSLShader *shader = runTimeCast<const OSLShader>( shaderPlug()->source()->node() );
-	ConstShadingEnginePtr shadingEngine = shader ? shader->shadingEngine() : nullptr;
-
+	ConstShadingEnginePtr shadingEngine = this->shadingEngine( context );
 	if( !shadingEngine )
 	{
 		return inputObject;
@@ -293,7 +318,15 @@ void OSLObject::hash( const ValuePlug *output, const Context *context, IECore::M
 	if( output == resampledNamesPlug() )
 	{
 		inPlug()->objectPlug()->hash( h );
-		h.append( shaderPlug()->attributesHash() );
+		if( g_contextCompatibilityEnabled && contextCompatibilityPlug()->getValue() )
+		{
+			h.append( shaderPlug()->attributesHash() );
+		}
+		else
+		{
+			ScenePlug::GlobalScope globalScope( context );
+			h.append( shaderPlug()->attributesHash() );
+		}
 	}
 }
 
@@ -309,11 +342,9 @@ void OSLObject::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 			return;
 		}
 
+		ConstShadingEnginePtr shadingEngine = this->shadingEngine( context );
+
 		std::string primitiveVariablesToResample;
-
-		const OSLShader *shader = runTimeCast<const OSLShader>( shaderPlug()->source()->node() );
-		ConstShadingEnginePtr shadingEngine = shader ? shader->shadingEngine() : nullptr;
-
 		for( PrimitiveVariableMap::const_iterator it = prim->variables.begin(); it != prim->variables.end(); ++it )
 		{
 			if( it->second.interpolation == PrimitiveVariable::Constant )
@@ -334,4 +365,23 @@ void OSLObject::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 	}
 
 	SceneElementProcessor::compute( output, context );
+}
+
+ConstShadingEnginePtr OSLObject::shadingEngine( const Gaffer::Context *context ) const
+{
+	auto shader = runTimeCast<const OSLShader>( shaderPlug()->source()->node() );
+	if( !shader )
+	{
+		return nullptr;
+	}
+
+	if( g_contextCompatibilityEnabled && contextCompatibilityPlug()->getValue() )
+	{
+		return shader->shadingEngine();
+	}
+	else
+	{
+		ScenePlug::GlobalScope globalScope( context );
+		return shader->shadingEngine();
+	}
 }

--- a/src/GafferOSL/OSLObject.cpp
+++ b/src/GafferOSL/OSLObject.cpp
@@ -155,23 +155,25 @@ void OSLObject::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 {
 	SceneElementProcessor::affects( input, outputs );
 
-	if( input == shaderPlug() )
-	{
-		outputs.push_back( resampledNamesPlug() );
-		outputs.push_back( outPlug()->objectPlug() );
-	}
-	else if (input == inPlug()->transformPlug() ||
+	if(
+		input == shaderPlug() ||
+		input == inPlug()->transformPlug() ||
 		input == interpolationPlug() ||
 		input == resampledInPlug()->objectPlug()
-		)
+	)
 	{
 		outputs.push_back( outPlug()->objectPlug() );
 	}
-	else if( input == inPlug()->objectPlug() )
+
+	if(
+		input == shaderPlug() ||
+		input == inPlug()->objectPlug() ||
+	)
 	{
 		outputs.push_back( resampledNamesPlug() );
 	}
-	else if( input == outPlug()->objectPlug() )
+
+	if( input == outPlug()->objectPlug() )
 	{
 		outputs.push_back( outPlug()->boundPlug() );
 	}

--- a/src/GafferOSL/OSLObject.cpp
+++ b/src/GafferOSL/OSLObject.cpp
@@ -94,7 +94,6 @@ OSLObject::OSLObject( const std::string &name )
 	GafferScene::ResamplePrimitiveVariablesPtr resample = new ResamplePrimitiveVariables( "__resample" );
 	addChild( resample );
 
-	//todo only resample variables which we've read from in the OSL shader
 	resample->namesPlug()->setInput( resampledNamesPlug() );
 	resample->inPlug()->setInput( inPlug() );
 	resample->interpolationPlug()->setInput( interpolationPlug() );

--- a/src/GafferSceneTest/TestShader.cpp
+++ b/src/GafferSceneTest/TestShader.cpp
@@ -37,6 +37,7 @@
 #include "GafferSceneTest/TestShader.h"
 
 #include "Gaffer/CompoundNumericPlug.h"
+#include "Gaffer/StringPlug.h"
 
 using namespace IECore;
 using namespace Gaffer;
@@ -47,6 +48,12 @@ IE_CORE_DEFINERUNTIMETYPED( TestShader )
 TestShader::TestShader( const std::string &name )
 	:	Shader( name )
 {
+	// The base class expects us to serialise a `loadShader()`
+	// call to set the values for these, but we just represent
+	// a fixed shader. Turn serialisation back on.
+	namePlug()->setFlags( Plug::Serialisable, true );
+	typePlug()->setFlags( Plug::Serialisable, true );
+
 	addChild( new Color3fPlug( "out", Plug::Out ) );
 	parametersPlug()->addChild( new IntPlug( "i" ) );
 	parametersPlug()->addChild( new Color3fPlug( "c" ) );


### PR DESCRIPTION
Until now, the generation of IECoreScene::ShaderNetworks from node graphs has been performed outside of the standard ComputeNode framework. This means that the work was not cached, meaning that when the same network was assigned to many locations (a common occurrence), we were doing much more work than necessary. This PR remedies that situation, gaining some worthwhile performance improvements in the process.

I think there's a good case for applying the ShaderAssignment optimisation to OSLObject too, but I haven't done so here. I'm a little loathe to push it when the "use CustomAttributes and Random" advice we would give for ShaderAssignments doesn't work for OSLObject. But then again, we can recommend "use PrimitiveVariables and Random" instead - any thoughts?