### PR TITLE
SceneInspector : ignore creases for Cortex versions that don't support them

### DIFF
--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -2190,7 +2190,7 @@ class __ObjectSection( LocationSection ) :
 
 			result = [ self.__class__( "Interpolation" ) ]
 
-			if isinstance( object, IECoreScene.MeshPrimitive ) :
+			if isinstance( object, IECoreScene.MeshPrimitive ) and hasattr( object, "creaseIds" ):
 				result.append( self.__class__( "Corners" ) )
 				result.append( self.__class__( "Creases" ) )
 


### PR DESCRIPTION
I think this should be all that's needed for compatibility with Cortex versions that don't support creases.

We still have the new Subdivision section with a lonely "interpolation" entry in it if applicable, but I guess that's ok.