### PR TITLE
GraphComponent optimisations

### DIFF
--- a/include/Gaffer/ArrayPlug.h
+++ b/include/Gaffer/ArrayPlug.h
@@ -79,9 +79,12 @@ class GAFFER_API ArrayPlug : public Plug
 		size_t minSize() const;
 		size_t maxSize() const;
 
+	protected :
+
+		void parentChanged( GraphComponent *oldParent ) override;
+
 	private :
 
-		void parentChanged();
 		void inputChanged( Gaffer::Plug *plug );
 
 		size_t m_minSize;

--- a/include/Gaffer/BoxIO.h
+++ b/include/Gaffer/BoxIO.h
@@ -157,6 +157,7 @@ class GAFFER_API BoxIO : public Node
 		const BoolPlug *enabledPlugInternal() const;
 
 		void parentChanging( Gaffer::GraphComponent *newParent ) override;
+		void parentChanged( Gaffer::GraphComponent *oldParent ) override;
 
 	private :
 
@@ -177,7 +178,6 @@ class GAFFER_API BoxIO : public Node
 		void setupBoxEnabledPlug();
 		void scriptExecuted( ScriptNode *script );
 		void plugSet( Plug *plug );
-		void parentChanged( GraphComponent *oldParent );
 		void plugInputChanged( Plug *plug );
 		void promotedPlugNameChanged( GraphComponent *graphComponent );
 		void promotedPlugParentChanged( GraphComponent *graphComponent );

--- a/include/Gaffer/GraphComponent.h
+++ b/include/Gaffer/GraphComponent.h
@@ -225,6 +225,21 @@ class GAFFER_API GraphComponent : public IECore::RunTimeTyped, public boost::sig
 		/// a protected signal is that there is less overhead in the virtual
 		/// function.
 		virtual void parentChanging( Gaffer::GraphComponent *newParent );
+		/// Called just after the parent of this GraphComponent is changed,
+		/// and just before `parentChangedSignal()` is emitted. This gives
+		/// derived classes a chance to make any necessary adjustments before
+		/// outside observers are notified of the change. In the special case
+		/// of a child being removed from the destructor of the parent,
+		/// `oldParent` will be null.
+		///
+		/// Implementations should call the base class implementation before
+		/// doing their own work.
+		///
+		/// The rationale for having this in addition to `parentChangedSignal()`
+		/// is that it has lower overhead than the signal, and allows GraphComponents
+		/// to maintain a consistent state even if badly behaved observers are
+		/// connected to the signal.
+		virtual void parentChanged( Gaffer::GraphComponent *oldParent );
 
 		/// It is common for derived classes to provide accessors for
 		/// constant-time access to specific children, as this can be

--- a/include/Gaffer/GraphComponent.h
+++ b/include/Gaffer/GraphComponent.h
@@ -46,6 +46,8 @@
 
 #include "boost/signals.hpp"
 
+#include <memory>
+
 namespace Gaffer
 {
 
@@ -264,17 +266,10 @@ class GAFFER_API GraphComponent : public IECore::RunTimeTyped, public boost::sig
 		void removeChildInternal( GraphComponentPtr child, bool emitParentChanged );
 		size_t index() const;
 
-		/// \todo The memory overhead of all these signals may become too great.
-		/// At this point we need to reimplement the signal returning functions to
-		/// create the signals on the fly (and possibly to delete signals when they have
-		/// no connections). One method might be to store a static map from this to signal *.
-		/// Or alternatively we could make all the signals static. Both these trade off
-		/// reduced memory usage for slower execution.
-		UnarySignal m_nameChangedSignal;
-		BinarySignal m_childAddedSignal;
-		BinarySignal m_childRemovedSignal;
-		BinarySignal m_parentChangedSignal;
+		struct Signals;
+		Signals *signals();
 
+		std::unique_ptr<Signals> m_signals;
 		IECore::InternedString m_name;
 		GraphComponent *m_parent;
 		ChildContainer m_children;

--- a/include/Gaffer/Plug.h
+++ b/include/Gaffer/Plug.h
@@ -196,6 +196,7 @@ class GAFFER_API Plug : public GraphComponent
 	protected :
 
 		void parentChanging( Gaffer::GraphComponent *newParent ) override;
+		void parentChanged( Gaffer::GraphComponent *oldParent ) override;
 
 		/// Initiates the propagation of dirtiness from the specified
 		/// plug to its outputs and affected plugs (as defined by
@@ -212,7 +213,6 @@ class GAFFER_API Plug : public GraphComponent
 
 	private :
 
-		void parentChanged();
 		static void propagateDirtinessForParentChange( Plug *plugToDirty );
 
 		void setFlagsInternal( unsigned flags );

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -172,6 +172,8 @@ class GAFFER_API ValuePlug : public Plug
 		/// not be changed following the call.
 		void setObjectValue( IECore::ConstObjectPtr value );
 
+		/// Reimplemented to emit `plugSetSignal()` for the parent plugs.
+		void parentChanged( Gaffer::GraphComponent *oldParent ) override;
 		/// Reimplemented for cache management.
 		void dirty() override;
 

--- a/include/GafferBindings/GraphComponentBinding.h
+++ b/include/GafferBindings/GraphComponentBinding.h
@@ -133,6 +133,28 @@ class GraphComponentWrapper : public IECorePython::RunTimeTypedWrapper<WrappedTy
 			return WrappedType::parentChanging( newParent );
 		}
 
+		void parentChanged( Gaffer::GraphComponent *oldParent ) override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				try
+				{
+					boost::python::object f = this->methodOverride( "_parentChanged" );
+					if( f )
+					{
+						f( Gaffer::GraphComponentPtr( oldParent ) );
+						return;
+					}
+				}
+				catch( const boost::python::error_already_set &e )
+				{
+					IECorePython::ExceptionAlgo::translatePythonException();
+				}
+			}
+			WrappedType::parentChanged( oldParent );
+		}
+
 };
 
 } // namespace GafferBindings

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -280,6 +280,8 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		/// Emits renderRequestSignal() as necessary for this and all ancestors.
 		/// Use this rather than emit the signal manually.
 		void requestRender();
+		/// Implemented to request a render for both the old and the new parent.
+		void parentChanged( GraphComponent *oldParent ) override;
 
 		/// Should be implemented by subclasses to draw themselves as appropriate
 		/// for the specified layer. Child gadgets will be drawn automatically
@@ -297,7 +299,6 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		void renderLayer( Layer layer, const Style *currentStyle = nullptr ) const;
 
 		void styleChanged();
-		void parentChanged( GraphComponent *child, GraphComponent *oldParent );
 		void emitDescendantVisibilityChanged();
 
 		ConstStylePtr m_style;

--- a/python/GafferTest/GraphComponentTest.py
+++ b/python/GafferTest/GraphComponentTest.py
@@ -916,5 +916,50 @@ class GraphComponentTest( GafferTest.TestCase ) :
 		s.undo()
 		assertPreconditions()
 
+	def testParentChangedOverride( self ) :
+
+		class Child( Gaffer.GraphComponent ) :
+
+			def __init__( self, name = "Child" ) :
+
+				Gaffer.GraphComponent.__init__( self, name )
+
+				self.parentChanges = []
+
+			def _parentChanged( self, oldParent ) :
+
+				self.parentChanges.append( ( oldParent, self.parent() ) )
+
+		p1 = Gaffer.GraphComponent()
+		p2 = Gaffer.GraphComponent()
+
+		c = Child()
+		self.assertEqual( len( c.parentChanges ), 0 )
+
+		p1.addChild( c )
+		self.assertEqual( len( c.parentChanges ), 1 )
+		self.assertEqual( c.parentChanges[-1], ( None, p1 ) )
+
+		p1.removeChild( c )
+		self.assertEqual( len( c.parentChanges ), 2 )
+		self.assertEqual( c.parentChanges[-1], ( p1, None ) )
+
+		p1.addChild( c )
+		self.assertEqual( len( c.parentChanges ), 3 )
+		self.assertEqual( c.parentChanges[-1], ( None, p1 ) )
+
+		p2.addChild( c )
+		self.assertEqual( len( c.parentChanges ), 4 )
+		self.assertEqual( c.parentChanges[-1], ( p1, p2 ) )
+
+		# Cause a parent change by destroying the parent.
+		# We need to remove all references to the parent to do
+		# this, including those stored in the parentChanges list.
+		del p2
+		del c.parentChanges[:]
+
+		self.assertEqual( len( c.parentChanges ), 1 )
+		self.assertEqual( c.parentChanges[-1], ( None, None ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/ArrayPlug.cpp
+++ b/src/Gaffer/ArrayPlug.cpp
@@ -69,8 +69,6 @@ ArrayPlug::ArrayPlug( const std::string &name, Direction direction, PlugPtr elem
 			MetadataAlgo::copyColors( element.get() , p.get() , /* overwrite = */ false  );
 		}
 	}
-
-	parentChangedSignal().connect( boost::bind( &ArrayPlug::parentChanged, this ) );
 }
 
 ArrayPlug::~ArrayPlug()
@@ -116,8 +114,10 @@ size_t ArrayPlug::maxSize() const
 	return m_maxSize;
 }
 
-void ArrayPlug::parentChanged()
+void ArrayPlug::parentChanged( GraphComponent *oldParent )
 {
+	Plug::parentChanged( oldParent );
+
 	if( !node() )
 	{
 		return;

--- a/src/Gaffer/BoxIO.cpp
+++ b/src/Gaffer/BoxIO.cpp
@@ -183,8 +183,6 @@ BoxIO::BoxIO( Plug::Direction direction, const std::string &name )
 	// with the name of the promotedPlug().
 	plugSetSignal().connect( boost::bind( &BoxIO::plugSet, this, ::_1 ) );
 	plugInputChangedSignal().connect( boost::bind( &BoxIO::plugInputChanged, this, ::_1 ) );
-
-	parentChangedSignal().connect( boost::bind( &BoxIO::parentChanged, this, ::_2 ) );
 }
 
 BoxIO::~BoxIO()
@@ -407,6 +405,8 @@ void BoxIO::plugSet( Plug *plug )
 
 void BoxIO::parentChanged( GraphComponent *oldParent )
 {
+	Node::parentChanged( oldParent );
+
 	// Manage inputChanged connections on our parent box,
 	// so we can discover our promoted plug when an output
 	// connection is made to it.

--- a/src/Gaffer/GraphComponent.cpp
+++ b/src/Gaffer/GraphComponent.cpp
@@ -72,6 +72,7 @@ GraphComponent::~GraphComponent()
 	{
 		(*it)->m_parent = nullptr;
 		(*it)->parentChanging( nullptr );
+		(*it)->parentChanged( nullptr );
 		(*it)->parentChangedSignal()( (*it).get(), nullptr );
 	}
 }
@@ -307,6 +308,7 @@ void GraphComponent::addChildInternal( GraphComponentPtr child, size_t index )
 	child->m_parent = this;
 	child->setName( child->m_name.value() ); // to force uniqueness
 	childAddedSignal()( this, child.get() );
+	child->parentChanged( previousParent );
 	child->parentChangedSignal()( child.get(), previousParent );
 }
 
@@ -371,6 +373,7 @@ void GraphComponent::removeChildInternal( GraphComponentPtr child, bool emitPare
 	childRemovedSignal()( this, child.get() );
 	if( emitParentChanged )
 	{
+		child->parentChanged( this );
 		child->parentChangedSignal()( child.get(), this );
 	}
 }
@@ -470,6 +473,10 @@ GraphComponent::BinarySignal &GraphComponent::parentChangedSignal()
 }
 
 void GraphComponent::parentChanging( Gaffer::GraphComponent *newParent )
+{
+}
+
+void GraphComponent::parentChanged( Gaffer::GraphComponent *oldParent )
 {
 }
 

--- a/src/Gaffer/GraphComponent.cpp
+++ b/src/Gaffer/GraphComponent.cpp
@@ -54,6 +54,41 @@ using namespace Gaffer;
 using namespace IECore;
 using namespace std;
 
+//////////////////////////////////////////////////////////////////////////
+// GraphComponent::Signals
+//
+// We allocate these separately because they have a significant overhead
+// in both memory and construction time, and for many GraphComponent
+// instances they are never actually used.
+//////////////////////////////////////////////////////////////////////////
+
+struct GraphComponent::Signals : boost::noncopyable
+{
+
+	UnarySignal nameChangedSignal;
+	BinarySignal childAddedSignal;
+	BinarySignal childRemovedSignal;
+	BinarySignal parentChangedSignal;
+
+	// Utility to emit a signal if it has been created, but do nothing
+	// if it hasn't.
+	template<typename SignalMemberPointer, typename... Args>
+	static void emitLazily( Signals *signals, SignalMemberPointer signalMemberPointer, Args&&... args )
+	{
+		if( !signals )
+		{
+			return;
+		}
+		auto &signal = signals->*signalMemberPointer;
+		signal( std::forward<Args>( args )... );
+	}
+
+};
+
+//////////////////////////////////////////////////////////////////////////
+// GraphComponent
+//////////////////////////////////////////////////////////////////////////
+
 IE_CORE_DEFINERUNTIMETYPED( GraphComponent );
 
 GraphComponent::GraphComponent( const std::string &name )
@@ -73,7 +108,7 @@ GraphComponent::~GraphComponent()
 		(*it)->m_parent = nullptr;
 		(*it)->parentChanging( nullptr );
 		(*it)->parentChanged( nullptr );
-		(*it)->parentChangedSignal()( (*it).get(), nullptr );
+		Signals::emitLazily( (*it)->m_signals.get(), &Signals::parentChangedSignal, (*it).get(), nullptr );
 	}
 }
 
@@ -150,7 +185,7 @@ const IECore::InternedString &GraphComponent::setName( const IECore::InternedStr
 void GraphComponent::setNameInternal( const IECore::InternedString &name )
 {
 	m_name = name;
-	nameChangedSignal()( this );
+	Signals::emitLazily( m_signals.get(), &Signals::nameChangedSignal, this );
 }
 
 const IECore::InternedString &GraphComponent::getName() const
@@ -182,7 +217,7 @@ std::string GraphComponent::relativeName( const GraphComponent *ancestor ) const
 
 GraphComponent::UnarySignal &GraphComponent::nameChangedSignal()
 {
-	return m_nameChangedSignal;
+	return signals()->nameChangedSignal;
 }
 
 bool GraphComponent::acceptsChild( const GraphComponent *potentialChild ) const
@@ -307,9 +342,9 @@ void GraphComponent::addChildInternal( GraphComponentPtr child, size_t index )
 	m_children.insert( m_children.begin() + min( index, m_children.size() ), child );
 	child->m_parent = this;
 	child->setName( child->m_name.value() ); // to force uniqueness
-	childAddedSignal()( this, child.get() );
+	Signals::emitLazily( m_signals.get(), &Signals::childAddedSignal, this, child.get() );
 	child->parentChanged( previousParent );
-	child->parentChangedSignal()( child.get(), previousParent );
+	Signals::emitLazily( child->m_signals.get(), &Signals::parentChangedSignal, child.get(), previousParent );
 }
 
 void GraphComponent::removeChild( GraphComponentPtr child )
@@ -370,11 +405,11 @@ void GraphComponent::removeChildInternal( GraphComponentPtr child, bool emitPare
 	}
 	m_children.erase( it );
 	child->m_parent = nullptr;
-	childRemovedSignal()( this, child.get() );
+	Signals::emitLazily( m_signals.get(), &Signals::childRemovedSignal, this, child.get() );
 	if( emitParentChanged )
 	{
 		child->parentChanged( this );
-		child->parentChangedSignal()( child.get(), this );
+		Signals::emitLazily( child->m_signals.get(), &Signals::parentChangedSignal, child.get(), this );
 	}
 }
 
@@ -459,17 +494,17 @@ bool GraphComponent::isAncestorOf( const GraphComponent *other ) const
 
 GraphComponent::BinarySignal &GraphComponent::childAddedSignal()
 {
-	return m_childAddedSignal;
+	return signals()->childAddedSignal;
 }
 
 GraphComponent::BinarySignal &GraphComponent::childRemovedSignal()
 {
-	return m_childRemovedSignal;
+	return signals()->childRemovedSignal;
 }
 
 GraphComponent::BinarySignal &GraphComponent::parentChangedSignal()
 {
-	return m_parentChangedSignal;
+	return signals()->parentChangedSignal;
 }
 
 void GraphComponent::parentChanging( Gaffer::GraphComponent *newParent )
@@ -504,4 +539,13 @@ std::string GraphComponent::unprefixedTypeName( const char *typeName )
 		result.erase( 0, colonPos + 1 );
 	}
 	return result;
+}
+
+GraphComponent::Signals *GraphComponent::signals()
+{
+	if( !m_signals )
+	{
+		m_signals.reset( new Signals );
+	}
+	return m_signals.get();
 }

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -112,7 +112,6 @@ Plug::Plug( const std::string &name, Direction direction, unsigned flags )
 	:	GraphComponent( name ), m_direction( direction ), m_input( nullptr ), m_flags( None ), m_skipNextUpdateInputFromChildInputs( false )
 {
 	setFlags( flags );
-	parentChangedSignal().connect( boost::bind( &Plug::parentChanged, this ) );
 }
 
 Plug::~Plug()
@@ -688,8 +687,10 @@ void Plug::parentChanging( Gaffer::GraphComponent *newParent )
 
 }
 
-void Plug::parentChanged()
+void Plug::parentChanged( Gaffer::GraphComponent *oldParent )
 {
+	GraphComponent::parentChanged( oldParent );
+
 	if( getFlags( Dynamic ) )
 	{
 		if( node() )

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -61,8 +61,6 @@ Gadget::Gadget( const std::string &name )
 {
 	std::string n = "__Gaffer::Gadget::" + boost::lexical_cast<std::string>( (size_t)this );
 	m_glName = IECoreGL::NameStateComponent::glNameFromName( n, true );
-
-	parentChangedSignal().connect( boost::bind( &Gadget::parentChanged, this, ::_1, ::_2 ) );
 }
 
 GadgetPtr Gadget::select( GLuint id )
@@ -470,14 +468,15 @@ void Gadget::styleChanged()
 	requestRender();
 }
 
-void Gadget::parentChanged( GraphComponent *child, GraphComponent *oldParent )
+void Gadget::parentChanged( GraphComponent *oldParent )
 {
-	assert( child==this );
+	GraphComponent::parentChanged( oldParent );
+
 	if( Gadget *oldParentGadget = IECore::runTimeCast<Gadget>( oldParent ) )
 	{
 		oldParentGadget->requestRender();
 	}
-	if( Gadget *parentGadget = child->parent<Gadget>() )
+	if( Gadget *parentGadget = parent<Gadget>() )
 	{
 		parentGadget->requestRender();
 	}

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -93,7 +93,7 @@ class StandardNodeGadget::ErrorGadget : public Gadget
 			entry.error = error;
 			if( !entry.parentChangedConnection.connected() )
 			{
-				entry.parentChangedConnection = plug->parentChangedSignal().connect( boost::bind( &ErrorGadget::parentChanged, this, ::_1 ) );
+				entry.parentChangedConnection = plug->parentChangedSignal().connect( boost::bind( &ErrorGadget::plugParentChanged, this, ::_1 ) );
 			}
 			m_image->setVisible( true );
 		}
@@ -130,7 +130,7 @@ class StandardNodeGadget::ErrorGadget : public Gadget
 
 	private :
 
-		void parentChanged( GraphComponent *plug )
+		void plugParentChanged( GraphComponent *plug )
 		{
 			if( !plug->parent() )
 			{


### PR DESCRIPTION
This PR substantially reduces the memory footprint for large node graphs by reducing the use of GraphComponent signals, and constructing the signals lazily on demand. The key here is that when we're launching a render process via `gaffer execute`, no GraphComponent signals are needed at all. And even when using the GUI, only a subset of GraphComponents will ever have observers, and even then, we can spread the cost out as the user navigates the graph, rather than constructing everything upfront.