### PR TITLE
Fix crash related to ShaderTweaksUI

### DIFF
--- a/include/GafferScene/TweakPlug.h
+++ b/include/GafferScene/TweakPlug.h
@@ -68,7 +68,7 @@ class GAFFERSCENE_API TweakPlug : public Gaffer::ValuePlug
 		TweakPlug( const std::string &tweakName, Gaffer::ValuePlugPtr valuePlug, Mode mode = Replace, bool enabled = true );
 		TweakPlug( const std::string &tweakName, const IECore::Data *value, Mode mode = Replace, bool enabled = true );
 		/// Primarily used for serialisation.
-		TweakPlug( const std::string &name=defaultName<TweakPlug>(), Direction direction=In, unsigned flags=Default );
+		TweakPlug( Gaffer::ValuePlugPtr valuePlug, const std::string &name=defaultName<TweakPlug>(), Direction direction=In, unsigned flags=Default );
 
 		Gaffer::StringPlug *namePlug();
 		const Gaffer::StringPlug *namePlug() const;

--- a/python/GafferSceneTest/TweakPlugTest.py
+++ b/python/GafferSceneTest/TweakPlugTest.py
@@ -145,5 +145,10 @@ class TweakPlugTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( p2.direction(), Gaffer.Plug.Direction.In )
 		self.assertEqual( p2.keys(), p.keys() )
 
+	def testOldSerialisation( self ) :
+
+		# Old scripts call a constructor with an outdated signature as below.
+		plug = GafferScene.TweakPlug( "exposure", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/TweakPlug.cpp
+++ b/src/GafferScene/TweakPlug.cpp
@@ -66,12 +66,8 @@ using namespace GafferScene;
 IE_CORE_DEFINERUNTIMETYPED( TweakPlug );
 
 TweakPlug::TweakPlug( const std::string &tweakName, Gaffer::ValuePlugPtr valuePlug, Mode mode, bool enabled )
-	:	TweakPlug( "tweak", In, Default | Dynamic )
+	:	TweakPlug( valuePlug, "tweak", In, Default | Dynamic )
 {
-	valuePlug->setName( "value" );
-	valuePlug->setFlags( Dynamic, true );
-	addChild( valuePlug );
-
 	namePlug()->setValue( tweakName );
 	modePlug()->setValue( mode );
 	enabledPlug()->setValue( enabled );
@@ -82,12 +78,18 @@ TweakPlug::TweakPlug( const std::string &tweakName, const IECore::Data *value, M
 {
 }
 
-TweakPlug::TweakPlug( const std::string &name, Direction direction, unsigned flags )
+TweakPlug::TweakPlug( Gaffer::ValuePlugPtr valuePlug, const std::string &name, Direction direction, unsigned flags )
 	:	ValuePlug( name, direction, flags )
 {
 	addChild( new StringPlug( "name" ) );
 	addChild( new BoolPlug( "enabled", Plug::In, true ) );
 	addChild( new IntPlug( "mode", Plug::In, Replace, Replace, Remove ) );
+
+	if( valuePlug )
+	{
+		valuePlug->setName( "value" );
+		addChild( valuePlug );
+	}
 }
 
 Gaffer::StringPlug *TweakPlug::namePlug()
@@ -185,12 +187,10 @@ bool TweakPlug::acceptsChild( const Gaffer::GraphComponent *potentialChild ) con
 
 Gaffer::PlugPtr TweakPlug::createCounterpart( const std::string &name, Direction direction ) const
 {
-	PlugPtr result = new TweakPlug( name, direction, getFlags() );
-	if( const Plug *p = valuePlug() )
-	{
-		result->addChild( p->createCounterpart( p->getName(), direction ) );
-	}
-	return result;
+	const Plug *p = valuePlug();
+	PlugPtr plugCounterpart = p->createCounterpart( p->getName(), direction );
+
+	return new TweakPlug( runTimeCast<ValuePlug>( plugCounterpart.get() ), name, direction, getFlags() );
 }
 
 IECore::MurmurHash TweakPlug::hash() const

--- a/src/GafferScene/TweakPlug.cpp
+++ b/src/GafferScene/TweakPlug.cpp
@@ -122,11 +122,21 @@ const Gaffer::IntPlug *TweakPlug::modePlug() const
 
 Gaffer::ValuePlug *TweakPlug::valuePlugInternal()
 {
+	if( children().size() <= 3 )
+	{
+		return nullptr;
+	}
+
 	return getChild<ValuePlug>( 3 );
 }
 
 const Gaffer::ValuePlug *TweakPlug::valuePlugInternal() const
 {
+	if( children().size() <= 3 )
+	{
+		return nullptr;
+	}
+
 	return getChild<ValuePlug>( 3 );
 }
 

--- a/src/GafferSceneUI/ShaderTweaksUI.cpp
+++ b/src/GafferSceneUI/ShaderTweaksUI.cpp
@@ -134,7 +134,17 @@ class TweakPlugAdder : public PlugAdder
 				{
 					continue;
 				}
-				if( MetadataAlgo::readOnly( tweakPlug->valuePlug() ) )
+
+				ValuePlug *valuePlug = tweakPlug->valuePlug();
+				if( !valuePlug )
+				{
+					// It's possible that the TweakPlug is in an invalid state
+					// when we're getting called here. Ignore the plug if that's
+					// the case.
+					continue;
+				}
+
+				if( MetadataAlgo::readOnly( valuePlug ) )
 				{
 					continue;
 				}

--- a/startup/GafferScene/tweakPlugCompatibility.py
+++ b/startup/GafferScene/tweakPlugCompatibility.py
@@ -1,0 +1,56 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+originalInit = GafferScene.TweakPlug.__init__
+
+def initSupportingOldSerialisation( self, *args, **kwargs ) :
+
+	if len( args ) == 1 and isinstance( args[0], basestring ) :
+
+		# Constructor calls that provide only a name but no value plug or
+		# data need to be rerouted. These calls occur when
+		# deserialising old scripts.
+
+		originalInit( self, None, args[0], **kwargs )
+
+	else :
+
+		originalInit( self, *args, **kwargs )
+
+GafferScene.TweakPlug.__init__ = initSupportingOldSerialisation


### PR DESCRIPTION
When deserialising these TweakPlugs we add them to their new parent before explicitly adding the "value" plug. If a callback connected to the parent's `childAdded` signal tried to access the value plug, we got some undefined behaviour because we'd try to access a non-existing element in a vector.

~This PR fixes this issue and should be suitable for backporting, as well. I'll try to put up another PR soon that cleans up the serialisation of TweakPlugs a little.~

John, this is hopefully a good first step to at least avoid the crashes? :)