### PR TITLE
Bindings : Add explicit std::move to avoid copy-on-return.

### DIFF
--- a/include/GafferBindings/PathBinding.inl
+++ b/include/GafferBindings/PathBinding.inl
@@ -143,7 +143,7 @@ boost::python::object info( boost::python::object o )
 		result[it->c_str()] = propertyToPython( a );
 	}
 
-	return result;
+	return std::move( result );
 }
 
 template<typename T>

--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -194,7 +194,7 @@ boost::python::object executionDict( ScriptNodePtr script, NodePtr parent )
 	result["script"] = boost::python::object( script );
 	result["parent"] = boost::python::object( parent );
 
-	return result;
+	return std::move( result );
 }
 
 std::string serialise( const Node *parent, const Set *filter )


### PR DESCRIPTION
Updating Xcode to 10.2 brings with it a new Clang version (clang-1001.0.46.3). This includes `-Wreturn-std-move` (see: https://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-std-move). As we treat warnings as errors, this was breaking the build. 

In practice there should be no overhead here as the objects question are just the boost::python wrappers.