### PR TITLE
SelectionTool : Fix modifier handling during mouse clicks

### DIFF
--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -196,7 +196,7 @@ bool SelectionTool::buttonPress( const GafferUI::ButtonEvent &event )
 
 	PathMatcher selection = sg->getSelection();
 
-	const bool shiftHeld = event.modifiers && ButtonEvent::Shift;
+	const bool shiftHeld = event.modifiers & ButtonEvent::Shift;
 	if( !objectUnderMouse.size() )
 	{
 		// background click - clear the selection unless


### PR DESCRIPTION
Updating Xcode to 10.2 brings with it a new Clang version (clang-1001.0.46.3). This caught an inadvertent operator mixup via `Wconstant-logical-operand`.

Fixing this doubles as a bug fix that has a potentially significant user-facing change:

The SelectionTool (in the Viewer) no longer treats all modifier presses as `Shift`.

Previously, holding down any modifier key whilst drag selecting or clicking an object in the Viewer would modify the current selection. 

This behaviour was only intended to be triggered by the Shift key.