### PR TITLE
cameraCompatibility : Fix error in corner case

### DIFF
--- a/startup/GafferScene/cameraCompatibility.py
+++ b/startup/GafferScene/cameraCompatibility.py
@@ -42,6 +42,7 @@ import GafferScene
 
 def __compatibilityFunc( node, oldParent ):
 	parentNode = node.ancestor( Gaffer.Node )
+	gafferVersion = None
 	while parentNode :
 		gafferVersion = (
 			Gaffer.Metadata.value( parentNode, "serialiser:milestoneVersion" ),


### PR DESCRIPTION
Michael found a case where this was getting called while the node was unparented, producing an error with gafferVersion being undefined.  I didn't fully understand all of what was happening - he can describe that case in more detail, but this is a simple fix for the obvious code path that leaves it undefined.