### PR TITLE
UIEditor : Sanitize new preset names

### DIFF
--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -1449,6 +1449,9 @@ class _PresetsEditor( GafferUI.Widget ) :
 			nameWidget.setText( oldName )
 			return True
 
+		# Sanitize name
+		newName = newName.replace( "/", "_")
+
 		items = self.__pathListing.getPath().dict().items()
 		with Gaffer.BlockedConnection( self.__plugMetadataChangedConnection ) :
 			with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :


### PR DESCRIPTION
Hey John,

quick one to address SG14300. Ticket text:

"if i add a preset value to a plug with a name like
something / something
it seems to interpret the / as a submenu and i can no longer edit items in the preset list"

Would you rather have this replace the / with a space or something else?

Matti.

