### PR TITLE
Arnold metadata : Don't hide geometry parameters in NodeEditor

### DIFF
--- a/arnold/plugins/gaffer.mtd
+++ b/arnold/plugins/gaffer.mtd
@@ -828,7 +828,6 @@
 		page STRING "Coat"
 	[attr coat_normal]
 		gaffer.graphEditorLayout.visible BOOL true
-		widget STRING "null"
 		page STRING "Coat"
 	[attr coat_affect_color]
 		page STRING "Coat"
@@ -858,11 +857,9 @@
 		page STRING "Geometry"
 	[attr normal]
 		gaffer.graphEditorLayout.visible BOOL true
-		widget STRING "null"
 		page STRING "Geometry"
 	[attr tangent]
 		gaffer.graphEditorLayout.visible BOOL true
-		widget STRING "null"
 		page STRING "Geometry"
 
 	[attr caustics]


### PR DESCRIPTION
The rationale for hiding them was that generally you wouldn't type values into them in the NodeEditor, you'd connect them in the GraphEditor. But folks were looking for them in the NodeEditor, and when they weren't there, were assuming that Gaffer didn't support them at all. The NodeEditor _can_ actually be used for making connections and querying them too, so it seems reasonable to just show them.
