### PR TITLE
Parameter UserDefault

### DIFF
--- a/include/GafferCortex/ParameterHandler.h
+++ b/include/GafferCortex/ParameterHandler.h
@@ -97,6 +97,9 @@ class GAFFERCORTEX_API ParameterHandler : public IECore::RefCounted
 		/// Should be called by derived classes in setupPlug().
 		void setupPlugFlags( Gaffer::Plug *plug, unsigned flags );
 
+		/// Should be called by derived classes in setupPlug().
+		void setupPlugMetadata( Gaffer::Plug *plug );
+
 		/// Create a static instance of this to automatically register a derived class
 		/// with the factory mechanism. Derived class must have a constructor of the form
 		/// Derived( ParameterType::Ptr parameter, GraphComponentPtr plugParent ).

--- a/python/GafferCortexTest/ParameterHandlerTest.py
+++ b/python/GafferCortexTest/ParameterHandlerTest.py
@@ -238,5 +238,43 @@ class ParameterHandlerTest( GafferTest.TestCase ) :
 		self.assertNotEqual( hash1, hash3 )
 		self.assertNotEqual( hash2, hash3 )
 
+	def testUserDefault( self ) :
+
+		# IntPlug
+
+		p = IECore.IntParameter( "i", "d", 10 )
+
+		n = Gaffer.Node()
+		h = GafferCortex.ParameterHandler.create( p )
+		h.setupPlug( n )
+
+		self.assertEqual( Gaffer.Metadata.value( h.plug(), "userDefault" ), None )
+
+		p.userData()["gaffer"] = IECore.CompoundObject( {
+			"userDefault" : IECore.IntData( 42 ),
+		} )
+
+		h.setupPlug( n )
+
+		self.assertEqual( Gaffer.Metadata.value( h.plug(), "userDefault" ), 42 )
+
+		# BoolPlug
+
+		p = IECore.BoolParameter( "i", "d", True )
+
+		n = Gaffer.Node()
+		h = GafferCortex.ParameterHandler.create( p )
+		h.setupPlug( n )
+
+		self.assertEqual( Gaffer.Metadata.value( h.plug(), "userDefault" ), None )
+
+		p.userData()["gaffer"] = IECore.CompoundObject( {
+			"userDefault" : IECore.BoolData( False ),
+		} )
+
+		h.setupPlug( n )
+
+		self.assertEqual( Gaffer.Metadata.value( h.plug(), "userDefault" ), False )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferCortex/NumericParameterHandler.cpp
+++ b/src/GafferCortex/NumericParameterHandler.cpp
@@ -85,6 +85,7 @@ Gaffer::Plug *NumericParameterHandler<T>::setupPlug( Gaffer::GraphComponent *plu
 	}
 
 	setupPlugFlags( m_plug.get(), flags );
+	setupPlugMetadata( m_plug.get() );
 
 	return m_plug.get();
 }

--- a/src/GafferCortex/ParameterHandler.cpp
+++ b/src/GafferCortex/ParameterHandler.cpp
@@ -37,6 +37,7 @@
 #include "GafferCortex/ParameterHandler.h"
 
 #include "Gaffer/GraphComponent.h"
+#include "Gaffer/Metadata.h"
 #include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/ValuePlug.h"
 
@@ -78,6 +79,19 @@ void ParameterHandler::setupPlugFlags( Gaffer::Plug *plug, unsigned flags )
 		if( readOnly )
 		{
 			Gaffer::MetadataAlgo::setReadOnly( plug, readOnly->readable() );
+		}
+	}
+}
+
+void ParameterHandler::setupPlugMetadata( Gaffer::Plug *plug )
+{
+	const CompoundObject *ud = parameter()->userData()->member<CompoundObject>( "gaffer" );
+	if( ud )
+	{
+		const Data *userDefault = ud->member<Data>( "userDefault" );
+		if( userDefault )
+		{
+			Gaffer::Metadata::registerValue( plug, "userDefault", userDefault );
 		}
 	}
 }

--- a/src/GafferCortex/TypedParameterHandler.cpp
+++ b/src/GafferCortex/TypedParameterHandler.cpp
@@ -103,6 +103,7 @@ Gaffer::Plug *TypedParameterHandler<T>::setupPlug( Gaffer::GraphComponent *plugP
 	}
 
 	setupPlugFlags( m_plug.get(), flags );
+	setupPlugMetadata( m_plug.get() );
 
 	return m_plug.get();
 }


### PR DESCRIPTION
Hey John,

hopefully a quick one - how do you feel about these changes?

The reason why I looked into it is a problem where one of our plugs doesn't serialise properly. The (bool) plug gets set up through a CompoundParameter and a config then overrides its value. When people set it back to its original value in gaffer and copy/paste or save/load the node, the new value isn't preserved. I _think_ that what I've done here would give us a way to, in that config file, set the userDefault alongside the actual value and make Gaffer serialise the plug if people change the value.

Did any of that make sense? :) I'm assuming that something like this is better than adding a `setDefaultValue` to the Parameters in cortex?

Thanks,

Matti.