### PR TITLE
AnimationEditor fixes

### DIFF
--- a/include/GafferUI/AnimationGadget.h
+++ b/include/GafferUI/AnimationGadget.h
@@ -102,7 +102,7 @@ class GAFFERUI_API AnimationGadget : public Gadget
 
 		bool mouseMove( GadgetPtr gadget, const ButtonEvent &event );
 		IECore::RunTimeTypedPtr dragBegin( GadgetPtr gadget, const DragDropEvent &event );
-		bool dragEnter( GadgetPtr gadget, const DragDropEvent &event ); 
+		bool dragEnter( GadgetPtr gadget, const DragDropEvent &event );
 		bool dragMove( GadgetPtr gadget, const DragDropEvent &event );
 		bool dragEnd( GadgetPtr gadget, const DragDropEvent &event );
 

--- a/include/GafferUI/AnimationGadget.h
+++ b/include/GafferUI/AnimationGadget.h
@@ -105,6 +105,7 @@ class GAFFERUI_API AnimationGadget : public Gadget
 		bool dragEnter( GadgetPtr gadget, const DragDropEvent &event );
 		bool dragMove( GadgetPtr gadget, const DragDropEvent &event );
 		bool dragEnd( GadgetPtr gadget, const DragDropEvent &event );
+		bool leave();
 
 		// Find elements at certain positions
 		Gaffer::Animation::ConstKeyPtr keyAt( const IECore::LineSegment3f &position ) const;

--- a/python/Gaffer/GraphComponentPath.py
+++ b/python/Gaffer/GraphComponentPath.py
@@ -67,6 +67,17 @@ class GraphComponentPath( Gaffer.Path ) :
 
 		return GraphComponentPath( self.__rootComponent, self[:], self.root(), self.getFilter() )
 
+	def propertyNames( self ) :
+
+		return Gaffer.Path.propertyNames( self ) + [ "graphComponent:graphComponent" ]
+
+	def property( self, name ) :
+
+		if name == "graphComponent:graphComponent" :
+			return self.__graphComponent()
+		else :
+			return Gaffer.Path.property( self, name )
+
 	def _children( self ) :
 
 		try :

--- a/python/GafferTest/GraphComponentPathTest.py
+++ b/python/GafferTest/GraphComponentPathTest.py
@@ -65,9 +65,16 @@ class GraphComponentPathTest( GafferTest.TestCase ) :
 		r["d"] = Gaffer.GraphComponent()
 
 		p = Gaffer.GraphComponentPath( r, "/d" )
-		self.assertEqual( p.propertyNames(), [ "name", "fullName" ] )
+		self.assertEqual( p.propertyNames(), [ "name", "fullName", "graphComponent:graphComponent" ] )
 		self.assertEqual( p.property( "name" ), "d" )
 		self.assertEqual( p.property( "fullName" ), "/d" )
+		self.assertEqual( p.property( "graphComponent:graphComponent" ), r["d"] )
+
+		p = Gaffer.GraphComponentPath( r, "/" )
+		self.assertEqual( p.propertyNames(), [ "name", "fullName", "graphComponent:graphComponent" ] )
+		self.assertEqual( p.property( "name" ), "" )
+		self.assertEqual( p.property( "fullName" ), "/" )
+		self.assertEqual( p.property( "graphComponent:graphComponent" ), r )
 
 	def testChildrenInheritFilter( self ) :
 

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -176,7 +176,10 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 		self.__gadgetWidget.getViewportGadget().frame( bound )
 
 	def connectedCurvePlug( self, plug ) :
-		return plug.getInput().parent()
+
+		result = plug.source().parent()
+		assert( isinstance( result, Gaffer.Animation.CurvePlug ) )
+		return result
 
 	def _updateFromSet( self ) :
 
@@ -210,17 +213,13 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 
 		visible.clear()
 		for plug in plugList :
-			curvePlug = self.connectedCurvePlug( plug )
-			if curvePlug :
-				visible.add( curvePlug )
+			visible.add( self.connectedCurvePlug( plug ) )
 
 		with Gaffer.BlockedConnection( self.__editablePlugAddedConnection ) :
 
 			editable.clear()
 			for plug in ( self.__editablePlugs or set() ) & self.__visiblePlugs :
-				curvePlug = self.connectedCurvePlug( plug )
-				if curvePlug :
-					editable.add( curvePlug )
+				editable.add( self.connectedCurvePlug( plug ) )
 
 	def __selectionChanged( self, pathListing ) :
 
@@ -248,12 +247,7 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 
 			editable.clear()
 			for plug in plugList :
-				if plug in editable :
-					continue
-
-				curvePlug = self.connectedCurvePlug( plug )
-				if curvePlug :
-					editable.add( curvePlug )
+				editable.add( self.connectedCurvePlug( plug ) )
 
 	def __editablePlugAdded( self, standardSet, curvePlug ) :
 

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -240,20 +240,14 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 
 	def __editablePlugAdded( self, standardSet, curvePlug ) :
 
-		curves = curvePlug.children()
-		if not curves :
-			return
+		selection = self.__curveList.getSelection()
+		for output in curvePlug["out"].outputs() :
+			selection.addPath(
+				output.relativeName( self.scriptNode() ).replace( ".", "/" )
+			)
 
-		connected = curves[0].outputs()
-
-		if not connected :
-			return
-
-		previousSelection = self.__curveList.getSelectedPaths()
-		newPath = Gaffer.GraphComponentPath( self.scriptNode(), connected[0].relativeName( self.scriptNode() ).replace( '.', '/' ) )
-		previousSelection.append( newPath )
-
-	 	self.__curveList.setSelectedPaths( previousSelection )
+		with Gaffer.BlockedConnection( self.__selectionChangedConnection ) :
+			self.__curveList.setSelection( selection )
 
 	def __sourceCurvePlug( self, plug ) :
 

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -112,10 +112,9 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 
 	def __init__( self, scriptNode, **kw ) :
 
-		self.__main = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, borderWidth = 5, spacing = 5 )
-		self.__scriptNode = scriptNode
+		mainRow = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, borderWidth = 5, spacing = 5 )
 
-		GafferUI.NodeSetEditor.__init__( self, self.__main, self.__scriptNode, **kw )
+		GafferUI.NodeSetEditor.__init__( self, mainRow, scriptNode, **kw )
 
 		# Set up widget for curve names on the left
 		self.__animationFilter = _AnimationPathFilter( scriptNode )
@@ -148,7 +147,7 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 
 		# Assemble UI
 		self.__splitter = GafferUI.SplitContainer( orientation=GafferUI.SplitContainer.Orientation.Horizontal )
-		self.__main.addChild( self.__splitter )
+		mainRow.addChild( self.__splitter )
 
 		self.__splitter.append( self.__curveList )
 		self.__splitter.append( self.__gadgetWidget )
@@ -193,7 +192,7 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 
 		visiblePlugs = set()
 		for path in paths:
-			graphComponent = self.__scriptNode.descendant( str( path ).replace( '/', '.' ) )
+			graphComponent = self.scriptNode().descendant( str( path ).replace( '/', '.' ) )
 			for child in graphComponent.children() :
 				if isinstance( child, Gaffer.ValuePlug ) and Gaffer.Animation.isAnimated( child ) :
 					visiblePlugs.add( child )
@@ -220,7 +219,7 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 		plugList = []
 
 		for path in paths :
-			graphComponent = self.__scriptNode.descendant( str( path ).replace( '/', '.' ) )
+			graphComponent = self.scriptNode().descendant( str( path ).replace( '/', '.' ) )
 
 			if isinstance( graphComponent, Gaffer.ValuePlug ) and Gaffer.Animation.isAnimated( graphComponent ) :
 				plugList.append( graphComponent )
@@ -251,7 +250,7 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 			return
 
 		previousSelection = self.__curveList.getSelectedPaths()
-		newPath =  Gaffer.GraphComponentPath( self.__scriptNode, connected[0].relativeName( self.__scriptNode ).replace( '.', '/' ) )
+		newPath = Gaffer.GraphComponentPath( self.scriptNode(), connected[0].relativeName( self.scriptNode() ).replace( '.', '/' ) )
 		previousSelection.append( newPath )
 
 	 	self.__curveList.setSelectedPaths( previousSelection )

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -67,8 +67,11 @@ class _AnimationPathFilter( Gaffer.PathFilter ) :
 			if isinstance( graphComponent, Gaffer.Node ) :
 
 				for selected in self.__selection :
-					if graphComponent == selected or graphComponent.isAncestorOf( selected ) :
+					if graphComponent.isAncestorOf( selected ) :
 						return True
+					elif graphComponent == selected :
+						if self.__hasAnimation( graphComponent ) :
+							return True
 				return False
 
 			else :
@@ -92,12 +95,16 @@ class _AnimationPathFilter( Gaffer.PathFilter ) :
 
 		return result
 
-	def __hasAnimation( self, plug ) :
+	def __hasAnimation( self, graphComponent ) :
 
-		if isinstance( plug, Gaffer.ValuePlug ) and Gaffer.Animation.isAnimated( plug ) :
+		if isinstance( graphComponent, Gaffer.ValuePlug ) and Gaffer.Animation.isAnimated( graphComponent ) :
 			return True
 		else :
-			for childPlug in plug.children() :
+			# We recurse only to child plugs, because for our purposes we don't
+			# consider the presence of animated child nodes to mean that the parent
+			# node is animated. This makes the curve listing more intuitive, and avoids
+			# potentially huge recursion through deeply nested node graphs.
+			for childPlug in graphComponent.children( Gaffer.Plug ) :
 				if self.__hasAnimation( childPlug ) :
 					return True
 

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -165,7 +165,6 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 			self.__splitter.setSizes( betterSize )
 
 		# set initial state
-		self.__visiblePlugs = None
 		self.__editablePlugs = None
 		self._updateFromSet()
 		self._updateFromContext( [ "frame" ] )
@@ -192,27 +191,24 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 
 		paths = pathListing.getExpandedPaths()
 
-		plugList = []
-
+		visiblePlugs = set()
 		for path in paths:
 			graphComponent = self.__scriptNode.descendant( str( path ).replace( '/', '.' ) )
 			for child in graphComponent.children() :
 				if isinstance( child, Gaffer.ValuePlug ) and Gaffer.Animation.isAnimated( child ) :
-					plugList.append( child )
-
-		self.__visiblePlugs = set( plugList )
+					visiblePlugs.add( child )
 
 		visible = self.__animationGadget.visiblePlugs()
 		editable = self.__animationGadget.editablePlugs()
 
 		visible.clear()
-		for plug in plugList :
+		for plug in visiblePlugs :
 			visible.add( self.__sourceCurvePlug( plug ) )
 
 		with Gaffer.BlockedConnection( self.__editablePlugAddedConnection ) :
 
 			editable.clear()
-			for plug in ( self.__editablePlugs or set() ) & self.__visiblePlugs :
+			for plug in ( self.__editablePlugs or set() ) & visiblePlugs :
 				editable.add( self.__sourceCurvePlug( plug ) )
 
 	def __selectionChanged( self, pathListing ) :

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -175,12 +175,6 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 		bound = imath.Box3f( imath.V3f( -1, -1, 0 ), imath.V3f( 10, 10, 0 ) )
 		self.__gadgetWidget.getViewportGadget().frame( bound )
 
-	def connectedCurvePlug( self, plug ) :
-
-		result = plug.source().parent()
-		assert( isinstance( result, Gaffer.Animation.CurvePlug ) )
-		return result
-
 	def _updateFromSet( self ) :
 
 		GafferUI.NodeSetEditor._updateFromSet( self )
@@ -213,13 +207,13 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 
 		visible.clear()
 		for plug in plugList :
-			visible.add( self.connectedCurvePlug( plug ) )
+			visible.add( self.__sourceCurvePlug( plug ) )
 
 		with Gaffer.BlockedConnection( self.__editablePlugAddedConnection ) :
 
 			editable.clear()
 			for plug in ( self.__editablePlugs or set() ) & self.__visiblePlugs :
-				editable.add( self.connectedCurvePlug( plug ) )
+				editable.add( self.__sourceCurvePlug( plug ) )
 
 	def __selectionChanged( self, pathListing ) :
 
@@ -247,7 +241,7 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 
 			editable.clear()
 			for plug in plugList :
-				editable.add( self.connectedCurvePlug( plug ) )
+				editable.add( self.__sourceCurvePlug( plug ) )
 
 	def __editablePlugAdded( self, standardSet, curvePlug ) :
 
@@ -265,6 +259,12 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 		previousSelection.append( newPath )
 
 	 	self.__curveList.setSelectedPaths( previousSelection )
+
+	def __sourceCurvePlug( self, plug ) :
+
+		result = plug.source().parent()
+		assert( isinstance( result, Gaffer.Animation.CurvePlug ) )
+		return result
 
 	def __repr__( self ) :
 

--- a/src/GafferUI/AnimationGadget.cpp
+++ b/src/GafferUI/AnimationGadget.cpp
@@ -241,8 +241,6 @@ IE_CORE_DEFINERUNTIMETYPED( AnimationGadget );
 AnimationGadget::AnimationGadget()
 	: m_context( nullptr ), m_visiblePlugs( new StandardSet() ), m_editablePlugs( new StandardSet() ), m_dragStartPosition( 0 ), m_lastDragPosition( 0 ), m_dragMode( DragMode::None ), m_moveAxis( MoveAxis::Both ), m_snappingClosestKey( nullptr ), m_highlightedKey( nullptr ), m_highlightedCurve( nullptr ), m_mergeGroupId( 0 ), m_keyPreview( false ), m_keyPreviewLocation( 0 ), m_xMargin( 60 ), m_yMargin( 20 ), m_textScale( 10 ), m_labelPadding( 5 ), m_frameIndicatorPreviewFrame( boost::none )
 {
-	// parentChangedSignal().connect( boost::bind( &AnimationGadget::parentChanged, this, ::_1, ::_2 ) );
-
 	buttonPressSignal().connect( boost::bind( &AnimationGadget::buttonPress, this, ::_1,  ::_2 ) );
 	buttonReleaseSignal().connect( boost::bind( &AnimationGadget::buttonRelease, this, ::_1,  ::_2 ) );
 

--- a/src/GafferUI/AnimationGadget.cpp
+++ b/src/GafferUI/AnimationGadget.cpp
@@ -252,6 +252,7 @@ AnimationGadget::AnimationGadget()
 	dragEnterSignal().connect( boost::bind( &AnimationGadget::dragEnter, this, ::_1, ::_2 ) );
 	dragMoveSignal().connect( boost::bind( &AnimationGadget::dragMove, this, ::_1, ::_2 ) );
 	dragEndSignal().connect( boost::bind( &AnimationGadget::dragEnd, this, ::_1, ::_2 ) );
+	leaveSignal().connect( boost::bind( &AnimationGadget::leave, this ) );
 
 	m_editablePlugs->memberAcceptanceSignal().connect( boost::bind( &AnimationGadget::plugSetAcceptor, this, ::_1, ::_2 ) );
 	m_editablePlugs->memberAddedSignal().connect( boost::bind( &AnimationGadget::editablePlugAdded, this, ::_1, ::_2 ) );
@@ -1072,6 +1073,16 @@ bool AnimationGadget::dragEnd( GadgetPtr gadget, const DragDropEvent &event )
 
 	requestRender();
 
+	return true;
+}
+
+bool AnimationGadget::leave()
+{
+	if( m_frameIndicatorPreviewFrame )
+	{
+		m_frameIndicatorPreviewFrame = boost::none;
+		requestRender();
+	}
 	return true;
 }
 


### PR DESCRIPTION
This primarily fixes a `RuntimeError: Exception : Member is not eligible for inclusion in StandardSet.` error when viewing a promoted plug that has been animated. It also includes other small bits of refactoring and a fix for a minor drawing glitch in the AnimationGadget.

I think there remains a broader discussion about how we want to display animated promoted plugs. Currently we show both the internal plug _and_ the external plug in the plug listing, as a side effect of the fact that the listing shows nodes-within-nodes to any depth. But I seem to recall I raised performance concerns with this in the original review (`_AnimationPathFilter.__hasAnimatedChild()` could recurse 10s of 1000s of nodes). I'm now wondering if we shouldn't just display plugs on the immediately selected nodes (_not_ their child nodes), which would remove the performance concern and also make the display of animated promoted plugs less confusing. Thoughts? Is there a good use case for displaying animation to arbitrary levels of nesting?