### PR TITLE
Render node : Don't clear cache for "scene:render:sceneTranslationOnly"

### DIFF
--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -300,6 +300,11 @@ void Render::execute() const
 	RendererAlgo::outputLights( adaptedInPlug(), globals.get(), renderSets, renderer.get() );
 	RendererAlgo::outputObjects( adaptedInPlug(), globals.get(), renderSets, renderer.get() );
 
+	if( renderScope.sceneTranslationOnly() )
+	{
+		return;
+	}
+
 	// Now we have generated the scene, flush Cortex and Gaffer caches to
 	// provide more memory to the renderer.
 	/// \todo This is not ideal. If dispatch is batched then multiple
@@ -312,11 +317,7 @@ void Render::execute() const
 	ObjectPool::defaultObjectPool()->clear();
 	ValuePlug::clearCache();
 
-	if( !renderScope.sceneTranslationOnly() )
-	{
-		renderer->render();
-	}
-
+	renderer->render();
 	renderer.reset();
 
 	if( performanceMonitor )


### PR DESCRIPTION
This means we still have useful cache statistics to report from the stats app, which is the main client of the "scene:render:sceneTranslationOnly" mode. This also means that the Render node no longer reports performance monitor statistics in this mode, which is likely what we want since the stats app does its own reporting.
