### PR TITLE
Arnold Default Metadata

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -789,7 +789,9 @@ libraries = {
 		},
 	},
 
-	"GafferArnoldUITest" : {},
+	"GafferArnoldUITest" : {
+		"additionalFiles" : glob.glob( "python/GafferArnoldUITest/metadata/*" ),
+	},
 
 	"GafferOSL" : {
 		"envAppends" : {

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -512,7 +512,9 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( n["parameters"]["start_channel"].defaultValue(), 42 )
 		self.assertAlmostEqual( n["parameters"]["sscale"].defaultValue(), 42.42, places = 5 )
 		self.assertEqual( n["parameters"]["multiply"].defaultValue(), imath.Color3f( 1.2, 3.4, 5.6 ) )
-		self.assertEqual( n["parameters"]["missing_texture_color"].defaultValue(), imath.Color4f( 1.2, 3.4, 5.6, 7.8 ) )
+		# RGBA metadata support added in Arnold 5.3.  Need to wait until we standardise on that 
+		# to add this declaration to the test metadata
+		#self.assertEqual( n["parameters"]["missing_texture_color"].defaultValue(), imath.Color4f( 1.2, 3.4, 5.6, 7.8 ) )
 		self.assertEqual( n["parameters"]["uvcoords"].defaultValue(), imath.V2f( 1.2, 3.4 ) )
 		self.assertEqual( n["parameters"]["filename"].defaultValue(), "overrideDefault" )
 		self.assertEqual( n["parameters"]["filter"].defaultValue(), "closest" )

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -484,6 +484,39 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		n.loadShader( "standard_surface" )
 		self.assertTrue( "diffuse_roughness" not in n["parameters"] )
 
+	def testDefaultOverrideMetadata( self ) :
+
+		self.__forceArnoldRestart()
+
+		n = GafferArnold.ArnoldShader()
+		n.loadShader( "image" )
+
+		self.assertEqual( n["parameters"]["single_channel"].defaultValue(), False )
+		self.assertEqual( n["parameters"]["mipmap_bias"].defaultValue(), 0 )
+		self.assertEqual( n["parameters"]["start_channel"].defaultValue(), 0 )
+		self.assertEqual( n["parameters"]["sscale"].defaultValue(), 1.0 )
+		self.assertEqual( n["parameters"]["multiply"].defaultValue(), imath.Color3f( 1.0 ) )
+		self.assertEqual( n["parameters"]["missing_texture_color"].defaultValue(), imath.Color4f( 0.0 ) )
+		self.assertEqual( n["parameters"]["uvcoords"].defaultValue(), imath.V2f( 0.0 ) )
+		self.assertEqual( n["parameters"]["filename"].defaultValue(), "" )
+		self.assertEqual( n["parameters"]["filter"].defaultValue(), "smart_bicubic" )
+
+		self.addCleanup( os.environ.__setitem__, "ARNOLD_PLUGIN_PATH", os.environ["ARNOLD_PLUGIN_PATH"] )
+		os.environ["ARNOLD_PLUGIN_PATH"] = os.environ["ARNOLD_PLUGIN_PATH"] + ":" + os.path.join( os.path.dirname( __file__ ), "metadata" )
+
+		self.__forceArnoldRestart()
+
+		n.loadShader( "image" )
+		self.assertEqual( n["parameters"]["single_channel"].defaultValue(), True )
+		self.assertEqual( n["parameters"]["mipmap_bias"].defaultValue(), 42 )
+		self.assertEqual( n["parameters"]["start_channel"].defaultValue(), 42 )
+		self.assertAlmostEqual( n["parameters"]["sscale"].defaultValue(), 42.42, places = 5 )
+		self.assertEqual( n["parameters"]["multiply"].defaultValue(), imath.Color3f( 1.2, 3.4, 5.6 ) )
+		self.assertEqual( n["parameters"]["missing_texture_color"].defaultValue(), imath.Color4f( 1.2, 3.4, 5.6, 7.8 ) )
+		self.assertEqual( n["parameters"]["uvcoords"].defaultValue(), imath.V2f( 1.2, 3.4 ) )
+		self.assertEqual( n["parameters"]["filename"].defaultValue(), "overrideDefault" )
+		self.assertEqual( n["parameters"]["filter"].defaultValue(), "closest" )
+
 	def testMixAndMatchWithOSLShaders( self ) :
 
 		utility = GafferArnold.ArnoldShader()

--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -2309,9 +2309,15 @@ class RendererTest( GafferTest.TestCase ) :
 
 		with open( self.temporaryDirectory() + "/test/test_stats.json", "r" ) as statsHandle:
 			stats = json.load( statsHandle )["render 0000"]
-			self.assertTrue( "scene creation time microseconds" in stats )
-			self.assertTrue( "frame time microseconds" in stats )
-			self.assertTrue( "memory consumed MB" in stats )
+			if arnold.AiCheckAPIVersion( "5", "3", "0" ):
+				self.assertTrue( "microseconds" in stats["scene creation time"] )
+				self.assertTrue( "microseconds" in stats["frame time"] )
+				self.assertTrue( "peak CPU memory used" in stats )
+			else:
+				self.assertTrue( "scene creation time microseconds" in stats )
+				self.assertTrue( "frame time microseconds" in stats )
+				self.assertTrue( "memory consumed MB" in stats )
+
 			self.assertTrue( "ray counts" in stats )
 
 	def testProcedural( self ) :

--- a/python/GafferArnoldTest/metadata/overrideDefaults.mtd
+++ b/python/GafferArnoldTest/metadata/overrideDefaults.mtd
@@ -44,8 +44,10 @@
 		gaffer.default       FLOAT  42.42
 	[attr multiply]
 		gaffer.default       RGB  1.2 3.4 5.6
-	[attr missing_texture_color]
-		gaffer.default       RGBA  1.2 3.4 5.6 7.8
+	# Until we get onto Arnold 5.3 and this is supported, declaring this breaks metadata parsing
+	# in general
+	#[attr missing_texture_color]
+	#	gaffer.default       RGBA  1.2 3.4 5.6 7.8
 	[attr uvcoords]
 		gaffer.default       VECTOR2  1.2 3.4
 	[attr filename]

--- a/python/GafferArnoldTest/metadata/overrideDefaults.mtd
+++ b/python/GafferArnoldTest/metadata/overrideDefaults.mtd
@@ -1,0 +1,54 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+[node image]
+
+	[attr single_channel]
+		gaffer.default       BOOL  true
+	[attr mipmap_bias]
+		gaffer.default       INT  42
+	[attr start_channel]
+		gaffer.default       INT  42
+	[attr sscale]
+		gaffer.default       FLOAT  42.42
+	[attr multiply]
+		gaffer.default       RGB  1.2 3.4 5.6
+	[attr missing_texture_color]
+		gaffer.default       RGBA  1.2 3.4 5.6 7.8
+	[attr uvcoords]
+		gaffer.default       VECTOR2  1.2 3.4
+	[attr filename]
+		gaffer.default       STRING  "overrideDefault"
+	[attr filter] 
+		gaffer.default       STRING  "closest"

--- a/python/GafferArnoldUITest/ArnoldShaderUITest.py
+++ b/python/GafferArnoldUITest/ArnoldShaderUITest.py
@@ -34,7 +34,13 @@
 #
 ##########################################################################
 
+import os
+import subprocess
+
 import IECore
+import imath
+
+import IECoreScene
 
 import Gaffer
 import GafferUITest
@@ -119,6 +125,71 @@ class ArnoldShaderUITest( GafferUITest.TestCase ) :
 			Gaffer.Metadata.value( light["parameters"]["format"], "presetValues" ),
 			Gaffer.Metadata.value( light["parameters"]["format"], "presetNames" ),
 		)
+
+	def testUserDefaultMetadata( self ) :
+
+		cacheFile =	os.path.join( self.temporaryDirectory(), "testShaderUserDefaults.scc" )
+		script = """
+import Gaffer
+import GafferScene
+import GafferArnold
+import GafferArnoldUI
+root = Gaffer.ScriptNode()
+root["image"] = GafferArnold.ArnoldShader( "image" )
+root["image"].loadShader( "image" )
+Gaffer.NodeAlgo.applyUserDefaults( root["image"] )
+root["Sphere"] = GafferScene.Sphere( "Sphere" )
+root["ShaderAssignment"] = GafferScene.ShaderAssignment( "ShaderAssignment" )
+root["SceneWriter"] = GafferScene.SceneWriter( "SceneWriter" )
+root["ShaderAssignment"]["in"].setInput( root["Sphere"]["out"] )
+root["ShaderAssignment"]["shader"].setInput( root["image"]["out"] )
+root["SceneWriter"]["in"].setInput( root["ShaderAssignment"]["out"] )
+root["SceneWriter"]["fileName"].setValue( "%s" )
+root["SceneWriter"].execute()
+		""" % cacheFile
+
+		env = os.environ.copy()
+		subprocess.check_call(
+			[ "gaffer", "env", "python","-c", script ],
+			env = env
+		)
+		scene = IECoreScene.SceneCache( cacheFile, IECore.IndexedIO.OpenMode.Read )
+		sphere = scene.child( "sphere" )
+		parms = sphere.readAttributeAtSample( "ai:surface", 0 ).outputShader().parameters
+
+		self.assertEqual( parms["single_channel"].value, False )
+		self.assertEqual( parms["mipmap_bias"].value, 0 )
+		self.assertEqual( parms["start_channel"].value, 0 )
+		self.assertEqual( parms["sscale"].value, 1.0 )
+		self.assertEqual( parms["multiply"].value, imath.Color3f( 1.0 ) )
+		self.assertEqual( parms["missing_texture_color"].value, imath.Color4f( 0.0 ) )
+		self.assertEqual( parms["uvcoords"].value, imath.V2f( 0.0 ) )
+		self.assertEqual( parms["filename"].value, "" )
+		self.assertEqual( parms["filter"].value, "smart_bicubic" )
+
+		env["ARNOLD_PLUGIN_PATH"] = os.path.join( os.path.dirname( __file__ ), "metadata" )
+		subprocess.check_call(
+			[ "gaffer", "env", "python","-c", script ],
+			env = env
+		)
+		scene = IECoreScene.SceneCache( cacheFile, IECore.IndexedIO.OpenMode.Read )
+		sphere = scene.child( "sphere" )
+		parms = sphere.readAttributeAtSample( "ai:surface", 0 ).outputShader().parameters
+
+		self.assertEqual( parms["single_channel"].value, True )
+		self.assertEqual( parms["mipmap_bias"].value, 84 )
+		self.assertEqual( parms["start_channel"].value, 84 )
+		self.assertAlmostEqual( parms["sscale"].value, 6.7, places = 5 )
+		self.assertEqual( parms["multiply"].value, imath.Color3f( 12, 13, 14 ) )
+
+		# SolidAngle does not appear to have wrapped AiMetaDataGetRGBA in Python, so we don't
+		# support the RGBA case
+        #self.assertEqual( parms["missing_texture_color"].value, imath.Color4f( 12, 13, 14, 15 ) )
+
+		self.assertEqual( parms["uvcoords"].value, imath.V2f( 12, 13 ) )
+		self.assertEqual( parms["filename"].value, "overrideUserDefault" )
+		self.assertEqual( parms["filter"].value, "bilinear" )
+		
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferArnoldUITest/metadata/overrideUserDefaults.mtd
+++ b/python/GafferArnoldUITest/metadata/overrideUserDefaults.mtd
@@ -1,0 +1,54 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+[node image]
+
+	[attr single_channel]
+		gaffer.userDefault       BOOL  true
+	[attr mipmap_bias]
+		gaffer.userDefault       INT  84
+	[attr start_channel]
+		gaffer.userDefault       INT  84
+	[attr sscale]
+		gaffer.userDefault       FLOAT  6.7
+	[attr multiply]
+		gaffer.userDefault       RGB  12.0 13.0 14.0
+	[attr missing_texture_color]
+		gaffer.userDefault       RGBA  12.0 13.0 14.0 15.0
+	[attr uvcoords]
+		gaffer.userDefault       VECTOR2  12.0 13.0
+	[attr filename]
+		gaffer.userDefault       STRING  "overrideUserDefault"
+	[attr filter] 
+		gaffer.userDefault       STRING  "bilinear"

--- a/src/GafferArnold/ParameterHandler.cpp
+++ b/src/GafferArnold/ParameterHandler.cpp
@@ -198,12 +198,14 @@ Gaffer::Plug *setupColorPlug( const AtNodeEntry *node, const AtParamEntry *param
 	bool defaultOverridden = false;
 	if( std::is_same< ValueType, Color4f >::value )
 	{
+		#if AI_VERSION_ARCH_NUM >= 6 || ( AI_VERSION_ARCH_NUM == 5 && AI_VERSION_MAJOR_NUM >= 3 )
 		AtRGBA metadataDefault;
 		if( AiMetaDataGetRGBA( node, name, g_gafferDefaultArnoldString, &metadataDefault ) )
 		{
 			memcpy( &defaultValue, &metadataDefault.r, sizeof( ValueType ) );
 			defaultOverridden = true;
 		}
+		#endif
 	}
 	else
 	{  

--- a/src/GafferArnold/ParameterHandler.cpp
+++ b/src/GafferArnold/ParameterHandler.cpp
@@ -60,6 +60,15 @@ using namespace GafferArnold;
 namespace
 {
 
+const AtString g_nameArnoldString( "name" );
+const AtString g_gafferPlugTypeArnoldString( "gaffer.plugType" );
+const AtString g_gafferDefaultArnoldString( "gaffer.default" );
+
+const AtString g_FloatPlugArnoldString( "FloatPlug" );
+const AtString g_Color3fPlugArnoldString( "Color3fPlug" );
+const AtString g_Color4fPlugArnoldString( "Color4fPlug" );
+const AtString g_ClosurePlugArnoldString( "ClosurePlug" );
+
 template<typename PlugType>
 Gaffer::Plug *setupNumericPlug( const AtNodeEntry *node, const AtParamEntry *parameter, Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction )
 {
@@ -69,27 +78,50 @@ Gaffer::Plug *setupNumericPlug( const AtNodeEntry *node, const AtParamEntry *par
 	ValueType minValue = Imath::limits<ValueType>::min();
 	ValueType maxValue = Imath::limits<ValueType>::max();
 
-	switch( AiParamGetType( parameter ) )
+	AtString name = AiParamGetName( parameter );
+	bool defaultOverridden = false;
+	if( std::is_same< ValueType, float >::value )
 	{
-		case AI_TYPE_BYTE :
-			defaultValue = (ValueType)AiParamGetDefault( parameter )->BYTE();
-			minValue = 0;
-			maxValue = 255;
-			break;
-		case AI_TYPE_INT :
-			defaultValue = (ValueType)AiParamGetDefault( parameter )->INT();
-			break;
-		case AI_TYPE_UINT :
-			defaultValue = (ValueType)AiParamGetDefault( parameter )->UINT();
-			minValue = 0;
-			break;
-		case AI_TYPE_FLOAT :
-			defaultValue = (ValueType)AiParamGetDefault( parameter )->FLT();
-			break;
+		float metadataDefault;
+		if( AiMetaDataGetFlt( node, name, g_gafferDefaultArnoldString, &metadataDefault ) )
+		{
+			defaultValue = metadataDefault;
+			defaultOverridden = true;
+		}
+	}
+	else
+	{  
+		int metadataDefault;
+		if( AiMetaDataGetInt( node, name, g_gafferDefaultArnoldString, &metadataDefault ) )
+		{
+			defaultValue = metadataDefault;
+			defaultOverridden = true;
+		}
 	}
 
-	const char *name = AiParamGetName( parameter );
-	PlugType *existingPlug = plugParent->getChild<PlugType>( name );
+	if( !defaultOverridden )
+	{
+		switch( AiParamGetType( parameter ) )
+		{
+			case AI_TYPE_BYTE :
+				defaultValue = (ValueType)AiParamGetDefault( parameter )->BYTE();
+				minValue = 0;
+				maxValue = 255;
+				break;
+			case AI_TYPE_INT :
+				defaultValue = (ValueType)AiParamGetDefault( parameter )->INT();
+				break;
+			case AI_TYPE_UINT :
+				defaultValue = (ValueType)AiParamGetDefault( parameter )->UINT();
+				minValue = 0;
+				break;
+			case AI_TYPE_FLOAT :
+				defaultValue = (ValueType)AiParamGetDefault( parameter )->FLT();
+				break;
+		}
+	}
+
+	PlugType *existingPlug = plugParent->getChild<PlugType>( name.c_str() );
 	if(
 		existingPlug &&
 		existingPlug->direction() == direction &&
@@ -102,7 +134,7 @@ Gaffer::Plug *setupNumericPlug( const AtNodeEntry *node, const AtParamEntry *par
 		return existingPlug;
 	}
 
-	typename PlugType::Ptr plug = new PlugType( name, direction, defaultValue, minValue, maxValue, Plug::Default );
+	typename PlugType::Ptr plug = new PlugType( name.c_str(), direction, defaultValue, minValue, maxValue, Plug::Default );
 	PlugAlgo::replacePlug( plugParent, plug );
 
 	return plug.get();
@@ -161,28 +193,52 @@ Gaffer::Plug *setupColorPlug( const AtNodeEntry *node, const AtParamEntry *param
 	typedef typename ValueType::BaseType BaseType;
 
 	ValueType defaultValue( 1 );
-	switch( AiParamGetType( parameter ) )
+
+	AtString name = AiParamGetName( parameter );
+	bool defaultOverridden = false;
+	if( std::is_same< ValueType, Color4f >::value )
 	{
-		case AI_TYPE_RGB :
-			defaultValue[0] = AiParamGetDefault( parameter )->RGB().r;
-			defaultValue[1] = AiParamGetDefault( parameter )->RGB().g;
-			defaultValue[2] = AiParamGetDefault( parameter )->RGB().b;
-			break;
-		case AI_TYPE_RGBA :
-			defaultValue[0] = AiParamGetDefault( parameter )->RGBA().r;
-			defaultValue[1] = AiParamGetDefault( parameter )->RGBA().g;
-			defaultValue[2] = AiParamGetDefault( parameter )->RGBA().b;
-			defaultValue[3] = AiParamGetDefault( parameter )->RGBA().a;
-			break;
-		default :
-			return nullptr;
+		AtRGBA metadataDefault;
+		if( AiMetaDataGetRGBA( node, name, g_gafferDefaultArnoldString, &metadataDefault ) )
+		{
+			memcpy( &defaultValue, &metadataDefault.r, sizeof( ValueType ) );
+			defaultOverridden = true;
+		}
+	}
+	else
+	{  
+		AtRGB metadataDefault;
+		if( AiMetaDataGetRGB( node, name, g_gafferDefaultArnoldString, &metadataDefault ) )
+		{
+			memcpy( &defaultValue, &metadataDefault.r, sizeof( ValueType ) );
+			defaultOverridden = true;
+		}
+	}
+
+	if( !defaultOverridden )
+	{
+		switch( AiParamGetType( parameter ) )
+		{
+			case AI_TYPE_RGB :
+				defaultValue[0] = AiParamGetDefault( parameter )->RGB().r;
+				defaultValue[1] = AiParamGetDefault( parameter )->RGB().g;
+				defaultValue[2] = AiParamGetDefault( parameter )->RGB().b;
+				break;
+			case AI_TYPE_RGBA :
+				defaultValue[0] = AiParamGetDefault( parameter )->RGBA().r;
+				defaultValue[1] = AiParamGetDefault( parameter )->RGBA().g;
+				defaultValue[2] = AiParamGetDefault( parameter )->RGBA().b;
+				defaultValue[3] = AiParamGetDefault( parameter )->RGBA().a;
+				break;
+			default :
+				return nullptr;
+		}
 	}
 
 	ValueType minValue( Imath::limits<BaseType>::min() );
 	ValueType maxValue( Imath::limits<BaseType>::max() );
 
-	const char *name = AiParamGetName( parameter );
-	PlugType *existingPlug = plugParent->getChild<PlugType>( name );
+	PlugType *existingPlug = plugParent->getChild<PlugType>( name.c_str() );
 	if(
 		existingPlug &&
 		existingPlug->direction() == direction &&
@@ -195,7 +251,7 @@ Gaffer::Plug *setupColorPlug( const AtNodeEntry *node, const AtParamEntry *param
 		return existingPlug;
 	}
 
-	typename PlugType::Ptr plug = new PlugType( name, direction, defaultValue, minValue, maxValue, Plug::Default );
+	typename PlugType::Ptr plug = new PlugType( name.c_str(), direction, defaultValue, minValue, maxValue, Plug::Default );
 	PlugAlgo::replacePlug( plugParent, plug );
 
 	return plug.get();
@@ -231,13 +287,6 @@ const string nodeName ( Gaffer::GraphComponent *plugParent )
 	return node->relativeName( node->scriptNode() );
 }
 
-const AtString g_nameArnoldString( "name" );
-const AtString g_gafferPlugTypeArnoldString( "gaffer.plugType" );
-
-const AtString g_FloatPlugArnoldString( "FloatPlug" );
-const AtString g_Color3fPlugArnoldString( "Color3fPlug" );
-const AtString g_Color4fPlugArnoldString( "Color4fPlug" );
-const AtString g_ClosurePlugArnoldString( "ClosurePlug" );
 
 } // namespace
 
@@ -353,14 +402,17 @@ Gaffer::Plug *ParameterHandler::setupPlug( const AtNodeEntry *node, const AtPara
 			break;
 
 		case AI_TYPE_BOOLEAN :
-
-			plug = setupTypedPlug<BoolPlug>(
-				node,
-				parameter,
-				plugParent,
-				direction,
-				AiParamGetDefault( parameter )->BOOL()
-			);
+			{
+				bool defaultValue = AiParamGetDefault( parameter )->BOOL();
+				AiMetaDataGetBool( node, name, g_gafferDefaultArnoldString, &defaultValue );
+				plug = setupTypedPlug<BoolPlug>(
+					node,
+					parameter,
+					plugParent,
+					direction,
+					defaultValue
+				);
+			}
 			break;
 
 		case AI_TYPE_RGB :
@@ -374,57 +426,72 @@ Gaffer::Plug *ParameterHandler::setupPlug( const AtNodeEntry *node, const AtPara
 			break;
 
 		case AI_TYPE_VECTOR2 :
+			{
+				AtVector2 defaultValue = AiParamGetDefault( parameter )->VEC2();
+				AiMetaDataGetVec2( node, name, g_gafferDefaultArnoldString, &defaultValue );
 
-			plug = setupTypedPlug<V2fPlug>(
-				node,
-				parameter,
-				plugParent,
-				direction,
-				V2f(
-					AiParamGetDefault( parameter )->VEC2().x,
-					AiParamGetDefault( parameter )->VEC2().y
-				)
-			);
+				plug = setupTypedPlug<V2fPlug>(
+					node,
+					parameter,
+					plugParent,
+					direction,
+					V2f( defaultValue.x, defaultValue.y )
+				);
+			}
 			break;
-
 		case AI_TYPE_VECTOR :
+			{
+				AtVector defaultValue = AiParamGetDefault( parameter )->VEC();
+				AiMetaDataGetVec( node, name, g_gafferDefaultArnoldString, &defaultValue );
 
-			plug = setupTypedPlug<V3fPlug>(
-				node,
-				parameter,
-				plugParent,
-				direction,
-				V3f(
-					AiParamGetDefault( parameter )->VEC().x,
-					AiParamGetDefault( parameter )->VEC().y,
-					AiParamGetDefault( parameter )->VEC().z
-				)
-			);
+				plug = setupTypedPlug<V3fPlug>(
+					node,
+					parameter,
+					plugParent,
+					direction,
+					V3f( defaultValue.x, defaultValue.y, defaultValue.z )
+				);
+			}
 			break;
-
 		case AI_TYPE_ENUM :
 
 			{
 				AtEnum e = AiParamGetEnum( parameter );
+
+				std::string defaultValue;
+				AtString metadataDefault;
+				if( AiMetaDataGetStr( node, name, g_gafferDefaultArnoldString, &metadataDefault ) )
+				{
+					defaultValue = metadataDefault.c_str();
+				}
+				else
+				{
+					defaultValue = AiEnumGetString( e, AiParamGetDefault( parameter )->INT() );
+				}
+
 				plug = setupTypedPlug<StringPlug>(
 					node,
 					parameter,
 					plugParent,
 					direction,
-					AiEnumGetString( e, AiParamGetDefault( parameter )->INT() )
+					defaultValue
 				);
 			}
 			break;
 
 		case AI_TYPE_STRING :
 
-			plug = setupTypedPlug<StringPlug>(
-				node,
-				parameter,
-				plugParent,
-				direction,
-				AiParamGetDefault( parameter )->STR().c_str()
-			);
+			{
+				AtString defaultValue = AiParamGetDefault( parameter )->STR();
+				AiMetaDataGetStr( node, name, g_gafferDefaultArnoldString, &defaultValue );
+				plug = setupTypedPlug<StringPlug>(
+					node,
+					parameter,
+					plugParent,
+					direction,
+					defaultValue.c_str()
+				);
+			}
 			break;
 
 		case AI_TYPE_MATRIX :


### PR DESCRIPTION
I thought we had a special label to use for exploratory work, but I can't find it now, so I've just tagged this revisionRequired.

This isn't done, but I think it's basically ready for review to make sure the approach is right:
* Support for "gaffer.userDefault" in ArnoldShaderUI:  Appears complete, should be documented somewhere, no tests yet ( only 1 type tested interactively, so the tests will likely catch actual bugs )
* Support for "gaffer.default" in GafferArnold.ParameterHandler:  Only supporting int and float, remainder of types will be handled similarly.
* Unit tests:  I had originally picture everything being tested in ArnoldShaderTest, but after looking into implementation, I see that this will be responsible just for the defaults, and userDefaults will have to be handled by ArnoldShaderUITest.  Unfortunately, because the UI metadata dict is built on startup, this test won't be able to use the same trick as ArnoldShaderTest where the ARNOLD_PLUGIN_PATH has a special test directory added to it, and has the results checked.  It looks like currently ArnoldShaderUITest is using all real metadata?  I feel like I probably have to hack a special mtd into the path while the tests are running, I don't think there is real metadata that will exercise all the different types.

Anyway, does this look about like what you were thinking?