### PR TITLE
ShaderPlug : Tighten up rules for receiving inputs from Switches

### DIFF
--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -509,5 +509,36 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 		assertContextCompatibility( False, envVar = "?" )
 		assertContextCompatibility( False, envVar = "1" )
 
+	def testInputRejectsNonShaderSwitch( self ) :
+
+		assignment = GafferScene.ShaderAssignment()
+
+		add = GafferTest.AddNode()
+		switch = Gaffer.Switch()
+		switch.setup( add["sum"] )
+
+		# We have to accept the input at this point, because all we know is
+		# that it's from a switch that provides ints. Later on a shader might
+		# be connected as an input.
+		self.assertTrue( assignment["shader"].acceptsInput( switch["out"] ) )
+
+		# But if the switch has a non-shader input, then we should
+		# reject the connection.
+		switch["in"][0].setInput( add["sum"] )
+		self.assertFalse( assignment["shader"].acceptsInput( switch["out"] ) )
+
+		# And this should hold true even if the switch has a context-varying
+		# index.
+		random = Gaffer.Random()
+		random["contextEntry"].setValue( "frame" )
+		switch["index"].setInput( random["outFloat"] )
+		self.assertFalse( assignment["shader"].acceptsInput( switch["out"] ) )
+
+		# Remove the switch input, and we should be able to connect.
+		# But once connected, the switch should reject a non-shader input.
+		switch["in"][0].setInput( None )
+		assignment["shader"].setInput( switch["out"] )
+		self.assertFalse( switch["in"][0].acceptsInput( add["sum"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/ShaderViewTest.py
+++ b/python/GafferSceneUITest/ShaderViewTest.py
@@ -41,6 +41,7 @@ import IECore
 import Gaffer
 import GafferUI
 import GafferUITest
+import GafferImage
 import GafferScene
 import GafferSceneTest
 import GafferSceneUI
@@ -193,6 +194,23 @@ class ShaderViewTest( GafferUITest.TestCase ) :
 
 		GafferSceneUI.ShaderView.registerScene( "test", "HiRes", functools.partial( shaderBallCreator, 4096 ) )
 		self.assertEqual( view.scene()["resolution"].getValue(), 4096 )
+
+	def testCannotViewCatalogue( self ) :
+
+		view = GafferSceneUI.ShaderView()
+		catalogue = GafferImage.Catalogue()
+		self.assertFalse( view["in"].acceptsInput( catalogue["out"] ) )
+
+	def testCannotViewSceneSwitch( self ) :
+
+		view = GafferSceneUI.ShaderView()
+
+		sphere = GafferScene.Sphere()
+		switch = Gaffer.Switch()
+		switch.setup( sphere["out"] )
+
+		self.assertFalse( view["in"].acceptsInput( sphere["out"] ) )
+		self.assertFalse( view["in"].acceptsInput( switch["out"] ) )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
In 267dbe01e588e0a497372d380e2530ef5bd5708e, we added support for plugging Switches straight into ShaderAssignments, by accepting them as inputs to ShaderPlugs. But we were too laissez-faire with this, accepting Switches with any inputs, and just ignoring non-shader inputs at evaluation time. This led to several unwanted side effects :

- Users could make meaningless graphs.
- The ShaderView claimed to be able to display scenes and images. This led to several issues, including one where renders to a Catalogue triggered an error of the form `Catalogue.__switch.in.in0" rejects input "gui.Catalogue.InternalImage.out`.

The simplest part of the fix is to reject connections from switches which have non-shader inputs already. But we also need to blacklist scene and image plugs so we don't accept inputs from disconnected switches which could never feasibly provide a shader connection in the future.

The blacklisting seems particularly inelegant, but I don't have any better ideas for a general way of answering "could this plug type ever be used as a shader output?". Maybe a whitelisting would be better?