### PR TITLE
contrib/arnold : Add example metadata for Arnold 5.2 compatibility

### DIFF
--- a/contrib/arnold/arnoldBackwards52Defaults.mtd
+++ b/contrib/arnold/arnoldBackwards52Defaults.mtd
@@ -1,0 +1,63 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+# This allows using Arnold 5.3, but with the defaults overridden so that
+# node graphs produced with Arnold 5.2 still get the same default values,
+# instead of picking up the new Arnold default.
+
+# This is important if you want to upgrade to Arnold 5.3 part way through
+# a show, and don't want your shaders mysteriously changing.
+
+# Newly created shaders will get SolidAngle's intended new defaults
+# through a userDefault settings.  But if you're starting a new show,
+# it's better to not use this metadata, and just let the actual defaults
+# be what SolidAngle now intends.
+##########################################################################
+
+
+[node standard_surface]
+
+	[attr specular_roughness]
+		gaffer.default FLOAT 0.1
+		gaffer.userDefault FLOAT 0.2
+
+	[attr specular_IOR]
+		gaffer.default FLOAT 1.52
+		gaffer.userDefault FLOAT 1.5
+
+	[attr subsurface_type]
+		gaffer.default STRING "diffusion"
+		gaffer.userDefault STRING "randomwalk"


### PR DESCRIPTION
Once #3112 is merged, this provides an example of using the new features to maintain compatibility with Arnold versions before 5.3.