### PR TITLE
ArrayPlug : Refuse non-array inputs

### DIFF
--- a/include/Gaffer/ArrayPlug.h
+++ b/include/Gaffer/ArrayPlug.h
@@ -73,6 +73,7 @@ class GAFFER_API ArrayPlug : public Plug
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::ArrayPlug, ArrayPlugTypeId, Plug );
 
 		bool acceptsChild( const GraphComponent *potentialChild ) const override;
+		bool acceptsInput( const Plug *input ) const override;
 		void setInput( PlugPtr input ) override;
 		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 

--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -540,5 +540,15 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 		assignment["shader"].setInput( switch["out"] )
 		self.assertFalse( switch["in"][0].acceptsInput( add["sum"] ) )
 
+	def testBogusSwitchConnections( self ) :
+
+		assignment = GafferScene.ShaderAssignment()
+
+		switch = Gaffer.Switch()
+		switch.setup( assignment["shader"] )
+
+		shader = GafferSceneTest.TestShader()
+		self.assertFalse( switch["in"].acceptsInput( shader["out"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ArrayPlugTest.py
+++ b/python/GafferTest/ArrayPlugTest.py
@@ -369,6 +369,7 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 		assertInput( n["b"], n["a"] )
 
 	def testArrayPlugCopiesColors( self ) :
+
 		n = Gaffer.Node()
 
 		n2 = Gaffer.Node()
@@ -393,6 +394,12 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 		p = Gaffer.ArrayPlug( element = Gaffer.IntPlug() )
 		self.assertTrue( p.acceptsChild( Gaffer.IntPlug() ) )
 		self.assertFalse( p.acceptsChild( Gaffer.FloatPlug() ) )
+
+	def testDenyInputFromNonArrayPlugs( self ) :
+
+		a = Gaffer.ArrayPlug( element = Gaffer.IntPlug() )
+		p = Gaffer.V2iPlug()
+		self.assertFalse( a.acceptsInput( p ) )
 
 	def tearDown( self ) :
 

--- a/src/Gaffer/ArrayPlug.cpp
+++ b/src/Gaffer/ArrayPlug.cpp
@@ -85,6 +85,15 @@ bool ArrayPlug::acceptsChild( const GraphComponent *potentialChild ) const
 	return children().size() == 0 || potentialChild->typeId() == children()[0]->typeId();
 }
 
+bool ArrayPlug::acceptsInput( const Plug *input ) const
+{
+	if( !Plug::acceptsInput( input ) )
+	{
+		return false;
+	}
+	return !input || IECore::runTimeCast<const ArrayPlug>( input );
+}
+
 void ArrayPlug::setInput( PlugPtr input )
 {
 	// Plug::setInput() will be managing the inputs of our children,


### PR DESCRIPTION
The default behaviour inherited from Plug is to accept any input as long as it has a child accepted by each of the children of the ArrayPlug. For instance, a Switch set up with a ShaderPlug and a single array element would merrily accept a Color3f output from a shader, because the input plug has a float child accepted by the ShaderPlug (plus two additional children which are ignored). This was particularly confusing for users interacting with a shader switch, because they could accidentally make a connection into the parent ArrayPlug rather than the child element they were aiming for. We tighten this up by only accepting inputs from other ArrayPlugs.

I've marked this as a breaking change out of an abundance of caution, although I can't think of any legitimate reason anyone would be using a non-array input.