### PR TITLE
GafferScene : Add SetVisualiser Node

### DIFF
--- a/include/GafferScene/SetVisualiser.h
+++ b/include/GafferScene/SetVisualiser.h
@@ -1,0 +1,117 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENE_SETVISUALISER_H
+#define GAFFERSCENE_SETVISUALISER_H
+
+#include "GafferScene/SceneElementProcessor.h"
+
+#include "Gaffer/NumericPlug.h"
+
+namespace Gaffer
+{
+
+IE_CORE_FORWARDDECLARE( StringPlug )
+IE_CORE_FORWARDDECLARE( CompoundDataPlug )
+
+} // namespace Gaffer
+
+namespace GafferScene
+{
+
+/// The SetVisualiser follows the Gaffer 'Visualiser Node' pattern, allowing
+/// users to see what sets an Object is a member of via flat-color shading in the
+/// viewport.
+///
+/// It uses a private plug containing lists of set names and colors used for
+/// display. This allows more efficient hashing/compute without the need for
+/// any internal state management, as well as permitting informative UIs that
+/// help the user understand the resultant color mappings.
+class GAFFERSCENE_API SetVisualiser : public SceneElementProcessor
+{
+
+	public :
+
+		SetVisualiser( const std::string &name=defaultName<SetVisualiser>() );
+		~SetVisualiser() override;
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::SetVisualiser, SetVisualiserTypeId, SceneElementProcessor );
+
+		Gaffer::StringPlug *setsPlug();
+		const Gaffer::StringPlug *setsPlug() const;
+
+		Gaffer::BoolPlug *includeInheritedPlug();
+		const Gaffer::BoolPlug *includeInheritedPlug() const;
+
+		Gaffer::FloatPlug *stripeWidthPlug();
+		const Gaffer::FloatPlug *stripeWidthPlug() const;
+
+		Gaffer::CompoundDataPlug *colorOverridesPlug();
+		const Gaffer::CompoundDataPlug *colorOverridesPlug() const;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+
+		bool processesAttributes() const override;
+		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const override;
+
+	private :
+
+		Gaffer::AtomicCompoundDataPlug *outSetsPlug();
+		const Gaffer::AtomicCompoundDataPlug *outSetsPlug() const;
+
+		/// Computes a filtered list of sets from the input ScenePlug, taking
+		/// into account filtering defined by the Node's plugs and masking of
+		/// Gaffer-internal sets, etc.
+		std::vector<IECore::InternedString> candidateSetNames() const;
+
+		/// Produces a stable list of colors for the supplied set names
+		std::vector<Imath::Color3f> colorsForSets( const std::vector<IECore::InternedString>& setNames ) const;
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( SetVisualiser )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_SETVISUALISER_H

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -105,7 +105,7 @@ enum TypeId
 	AttributeProcessorTypeId = 110560,
 	DeleteAttributesTypeId = 110561,
 	UnionFilterTypeId = 110562,
-	SceneSwitchTypeId = 110563, // Obsolete, available for reuse
+	SetVisualiserTypeId = 110563,
 	ShaderSwitchTypeId = 110564, // Obsolete, available for reuse
 	ParentConstraintTypeId = 110565,
 	ParentTypeId = 110566,

--- a/python/GafferSceneTest/SetVisualiserTest.py
+++ b/python/GafferSceneTest/SetVisualiserTest.py
@@ -1,0 +1,292 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+class SetVisualiserTest( GafferSceneTest.SceneTestCase ) :
+
+	def testDefaultAction ( self ) :
+
+		# Make sure we dont affect the scene by default
+
+		inScene = self.__basicSphereScene()
+		visualiser = GafferScene.SetVisualiser()
+		visualiser["sets"].setValue( '*' )
+		visualiser["in"].setInput( inScene["setC"]["out"] )
+
+		self.assertTrue( "gl:surface" not in visualiser["out"].attributes( "/group" ) )
+		self.assertTrue( "gl:surface" not in visualiser["out"].attributes( "/group/sphere" ) )
+		self.assertTrue( "gl:surface" not in visualiser["out"].attributes( "/group/sphere1" ) )
+		self.assertTrue( "gl:surface" not in visualiser["out"].attributes( "/group/sphere2" ) )
+
+	def testOutSets( self ) :
+
+		inScene = self.__basicSphereScene()
+
+		visualiser = GafferScene.SetVisualiser()
+		visualiser["sets"].setValue( "*" )
+		visualiser["in"].setInput( inScene["setC"]["out"] )
+		f = self.__addMatchAllFilter( visualiser )
+
+		outSets = visualiser["__outSets"].getValue()
+
+		# set names are interned strings which don't sort well as is
+		inSetNames = sorted([ str(s) for s in visualiser["out"].setNames() ])
+		self.assertListEqual( inSetNames, list(outSets["names"]) )
+
+		# Make sure we are returning unique colors for each set
+		colors = outSets["colors"]
+		for c in colors:
+			self.assertEqual( colors.count(c), 1 )
+
+	def testSetFilter( self ) :
+
+		inScene = self.__basicSphereScene()
+
+		visualiser = GafferScene.SetVisualiser()
+		visualiser["in"].setInput( inScene["setC"]["out"] )
+		f = self.__addMatchAllFilter( visualiser )
+
+		self.assertEqual( visualiser["sets"].getValue(), "" )
+		self.assertEqual( len(visualiser["__outSets"].getValue()["names"]), 0 )
+
+		visualiser["sets"].setValue( "setA setB setC" )
+		self.assertEqual( list(visualiser["__outSets"].getValue()["names"]), self.__testSetNames )
+
+		visualiser["sets"].setValue( "set*" )
+		self.assertEqual( list(visualiser["__outSets"].getValue()["names"]), self.__testSetNames )
+
+		visualiser["sets"].setValue( "set* setA" )
+		self.assertEqual( list(visualiser["__outSets"].getValue()["names"]), self.__testSetNames )
+
+		sceneSets = sorted([ str(s) for s in inScene["setC"]["out"].setNames() ])
+
+		visualiser["sets"].setValue( "*" )
+		self.assertEqual( list(visualiser["__outSets"].getValue()["names"]), sceneSets )
+
+	def testShadersAssignedToAllLocations( self ) :
+
+		inScene = self.__basicSphereScene()
+
+		self.assertTrue( "gl:surface" not in inScene["setC"]["out"].attributes( "/group" ) )
+		self.assertTrue( "gl:surface" not in inScene["setC"]["out"].attributes( "/group/sphere" ) )
+		self.assertTrue( "gl:surface" not in inScene["setC"]["out"].attributes( "/group/sphere1" ) )
+		self.assertTrue( "gl:surface" not in inScene["setC"]["out"].attributes( "/group/sphere2" ) )
+
+		visualiser = GafferScene.SetVisualiser()
+		visualiser["sets"].setValue( 'set*' )
+		visualiser["in"].setInput( inScene["setC"]["out"] )
+		f = self.__addMatchAllFilter( visualiser )
+
+		self.assertTrue( "gl:surface" in visualiser["out"].attributes( "/group" ) )
+		self.assertTrue( "gl:surface" in visualiser["out"].attributes( "/group/sphere" ) )
+		self.assertTrue( "gl:surface" in visualiser["out"].attributes( "/group/sphere1" ) )
+		self.assertTrue( "gl:surface" in visualiser["out"].attributes( "/group/sphere2" ) )
+
+	def testInherited( self ) :
+
+		inScene = self.__basicSphereScene()
+
+		visualiser = GafferScene.SetVisualiser()
+		visualiser["sets"].setValue( 'set*' )
+		visualiser["in"].setInput( inScene["setC"]["out"] )
+		f = self.__addMatchAllFilter( visualiser )
+
+		self.assertTrue( visualiser["includeInherited"].getValue() )
+
+		self.assertEqual( visualiser["out"].attributes( "/group" )["gl:surface"].outputShader().parameters["numColors"].value, 1 )
+		self.assertEqual( visualiser["out"].attributes( "/group/sphere" )["gl:surface"].outputShader().parameters["numColors"].value, 1 )
+		self.assertEqual( visualiser["out"].attributes( "/group/sphere1" )["gl:surface"].outputShader().parameters["numColors"].value, 2 )
+		self.assertEqual( visualiser["out"].attributes( "/group/sphere2" )["gl:surface"].outputShader().parameters["numColors"].value, 3 )
+
+		visualiser["includeInherited"].setValue( False )
+
+		self.assertEqual( visualiser["out"].attributes( "/group" )["gl:surface"].outputShader().parameters["numColors"].value, 1 )
+		self.assertEqual( visualiser["out"].attributes( "/group/sphere" )["gl:surface"].outputShader().parameters["numColors"].value, 0 )
+		self.assertEqual( visualiser["out"].attributes( "/group/sphere1" )["gl:surface"].outputShader().parameters["numColors"].value, 1 )
+		self.assertEqual( visualiser["out"].attributes( "/group/sphere2" )["gl:surface"].outputShader().parameters["numColors"].value, 2 )
+
+	def testColors( self ) :
+
+		red = imath.Color3f( 1.0, 0.0, 0.0 )
+		green = imath.Color3f( 0.0, 1.0, 0.0 )
+		blue = imath.Color3f( 0.0, 0.0, 1.0 )
+
+		inScene = self.__basicSphereScene()
+
+		visualiser = GafferScene.SetVisualiser()
+		visualiser["in"].setInput( inScene["setC"]["out"] )
+		visualiser["sets"].setValue( '*' )
+		f = self.__addMatchAllFilter( visualiser )
+
+		self.assertEqual( visualiser["includeInherited"].getValue(), True )
+
+		visualiser["colorOverrides"].addOptionalMember( "setA", red, enabled = True )
+		visualiser["colorOverrides"].addOptionalMember( "setB", green, enabled = True )
+		visualiser["colorOverrides"].addOptionalMember( "setC", blue, enabled = True )
+
+		self.assertEqual( visualiser["out"].attributes( "/group" )["gl:surface"].outputShader().parameters["colors"][0], red )
+		self.assertEqual( visualiser["out"].attributes( "/group/sphere" )["gl:surface"].outputShader().parameters["colors"][0], red )
+
+		self.assertEqual( visualiser["out"].attributes( "/group/sphere1" )["gl:surface"].outputShader().parameters["colors"][0], red )
+		self.assertEqual( visualiser["out"].attributes( "/group/sphere1" )["gl:surface"].outputShader().parameters["colors"][1], blue )
+
+		self.assertEqual( visualiser["out"].attributes( "/group/sphere2" )["gl:surface"].outputShader().parameters["colors"][0], red )
+		self.assertEqual( visualiser["out"].attributes( "/group/sphere2" )["gl:surface"].outputShader().parameters["colors"][1], green )
+		self.assertEqual( visualiser["out"].attributes( "/group/sphere2" )["gl:surface"].outputShader().parameters["colors"][2], blue )
+
+
+	def testColorOverrides( self ) :
+
+		inScene = self.__basicSphereScene()
+
+		visualiser = GafferScene.SetVisualiser()
+		visualiser["in"].setInput( inScene["setC"]["out"] )
+		visualiser["sets"].setValue( 'set*' )
+		f = self.__addMatchAllFilter( visualiser )
+
+		## We never generate white so we can use it as a safe test value
+		white = imath.Color3f( 1.0 )
+		self.assertNotIn( white, visualiser["__outSets"].getValue()["colors"] )
+
+		self.assertEqual( len(visualiser["colorOverrides"].children()), 0 )
+
+		def colorForSetName( name ):
+			d = visualiser["__outSets"].getValue()
+			i = d["names"].index( name )
+			return d["colors"][i]
+
+		visualiser["colorOverrides"].addOptionalMember( "setA", white, enabled = True )
+		self.assertEqual( colorForSetName( "setA" ), white )
+		self.assertNotEqual( colorForSetName( "setB" ), white )
+		self.assertNotEqual( colorForSetName( "setC" ), white )
+
+		visualiser["colorOverrides"].children()[0]["name"].setValue( "set*" )
+		self.assertEqual( colorForSetName( "setA" ), white )
+		self.assertEqual( colorForSetName( "setB" ), white )
+		self.assertEqual( colorForSetName( "setC" ), white )
+
+		sceneSets = inScene["setC"]["out"].setNames()
+		defaultSets = [ s for s in sceneSets if s not in self.__testSetNames ]
+		for s in defaultSets :
+			self.assertNotEqual(  colorForSetName( s ), white )
+
+		visualiser["colorOverrides"].children()[0]["enabled"].setValue( False )
+		self.assertNotEqual( colorForSetName( "setA" ), white )
+		self.assertNotEqual( colorForSetName( "setB" ), white )
+		self.assertNotEqual( colorForSetName( "setC" ), white )
+
+	def testOverrideValidation( self ) :
+
+		inScene = self.__basicSphereScene()
+
+		visualiser = GafferScene.SetVisualiser()
+		visualiser["in"].setInput( inScene["setC"]["out"] )
+		visualiser["sets"].setValue( 'set*' )
+		f = self.__addMatchAllFilter( visualiser )
+
+		# None of these should error as empty names or disabled should be fine
+
+		visualiser["colorOverrides"].addOptionalMember( "setA", imath.Color3f( 1.0 ), enabled = True )
+		visualiser["__outSets"].getValue()
+
+		visualiser["colorOverrides"].addOptionalMember( "setB", imath.Color3f( 1.0 ), enabled = False )
+		visualiser["__outSets"].getValue()
+
+		visualiser["colorOverrides"].addOptionalMember( "", imath.Color3f( 1.0 ), enabled = True )
+		visualiser["__outSets"].getValue()
+
+		# Non-color3f types should errror
+		visualiser["colorOverrides"].addOptionalMember( "setB", "notAColor", enabled = True )
+		self.assertRaises( RuntimeError, visualiser["__outSets"].getValue )
+
+	__testSetNames = [ 'setA', 'setB', 'setC' ]
+
+	def __basicSphereScene( self ) :
+
+		sphere = GafferScene.Sphere()
+		group = GafferScene.Group()
+		group["in"][0].setInput( sphere["out"] )
+		group["in"][1].setInput( sphere["out"] )
+		group["in"][2].setInput( sphere["out"] )
+
+		# For safety, make sure we don't already have any sets with our names
+		# creating any sets with our test names
+		defaultSetNames = group["out"].setNames()
+		for s in defaultSetNames :
+			self.assertFalse( s.startswith( "set" ), msg = "Default set '%s' conflicts with the test case" % s )
+
+		setA = GafferScene.Set()
+		setA["in"].setInput( group["out"] )
+		setA["name"].setValue( 'setA' )
+		setA["paths"].setValue( IECore.StringVectorData( [ '/group' ] ) )
+
+		setB = GafferScene.Set()
+		setB["in"].setInput( setA["out"] )
+		setB["name"].setValue( 'setB' )
+		setB["paths"].setValue( IECore.StringVectorData( [ '/group/sphere2' ] ) )
+
+		setC = GafferScene.Set()
+		setC["in"].setInput( setB["out"] )
+		setC["name"].setValue( 'setC' )
+		setC["paths"].setValue( IECore.StringVectorData( [ '/group/sphere1', '/group/sphere2' ] ) )
+
+		self.assertSceneValid( setC["out"] )
+
+		# So they don't all get deleted here
+		return {
+			"sphere" : sphere,
+			"group" : group,
+			"setA" : setA,
+			"setB" : setB,
+			"setC" : setC
+		}
+
+	def __addMatchAllFilter( self, node ):
+
+		f = GafferScene.PathFilter()
+		f["paths"].setValue( IECore.StringVectorData( [ '...' ] ) )
+		node["filter"].setInput( f["out"] )
+		return f
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -138,6 +138,7 @@ from UDIMQueryTest import UDIMQueryTest
 from WireframeTest import WireframeTest
 from TweakPlugTest import TweakPlugTest
 from ContextSanitiserTest import ContextSanitiserTest
+from SetVisualiserTest import SetVisualiserTest
 
 from IECoreGLPreviewTest import *
 

--- a/python/GafferSceneUI/SetVisualiserUI.py
+++ b/python/GafferSceneUI/SetVisualiserUI.py
@@ -1,0 +1,300 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+import GafferUI
+import GafferSceneUI
+
+import IECore
+import imath
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.SetVisualiser,
+
+	"description",
+	"""
+	Visualises Set membership values by applying a custom shader and coloring
+	based on which sets each object belongs to. Membership of more than one set
+	is visualised by a stripe pattern.
+	""",
+
+	"layout:customWidget:legend:widgetType", "GafferSceneUI.SetVisualiserUI._OutSetsPlugValueWidget",
+	"layout:customWidget:legend:section", "Settings.Legend",
+	"layout:section:Settings.Legend:collapsed", False,
+
+	plugs = {
+
+		"sets" : [
+
+			"description",
+			"""
+			A space separated list of sets to consider membership of. This
+			supports wild cards, eg: asset:* to allow membership display to
+			focus on a specific group of sets. Right-click to insert the name
+			of any sets in the input scene.
+			""",
+
+			"ui:scene:acceptsSetNames", True
+		],
+
+		"includeInherited" : [
+
+			"description",
+			"""
+			When enabled, objects that inherit Set membership from their parents
+			will also be coloured. Disabling this will only color objects that
+			are exactly matched by any given Set.
+			"""
+
+		],
+
+		"stripeWidth" : [
+
+			"description",
+			"""
+			The thickness (in pixels) of the stripes used to indicate an object
+			is in more than one set.
+			"""
+
+		],
+
+		"colorOverrides" : [
+
+			"description",
+			"""
+			Allows the randomly generated set colors to be overridden by
+			specific colors to use for Sets matching the supplied filter. This
+			can be a name, or a match string.
+			""",
+
+			"layout:section", "Settings.Color Overrides",
+
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
+			"layout:customWidget:footer:widgetType", "GafferSceneUI.SetVisualiserUI._OverridesFooter",
+			"layout:customWidget:footer:index", -1
+
+		],
+
+		"colorOverrides.*.name" : [
+
+			"description",
+			"""
+			Specifies which set or sets to apply the override to. This can be
+			a name, or a match string. Right-click to insert the name of any
+			set in the input scene.
+			""",
+
+			"ui:scene:acceptsSetName", True
+
+		]
+
+	}
+
+)
+
+# PlugValueWidget registrations
+#
+# NOTE: These are very specific implementations for this use case!
+##########################################################################
+
+# A 'legend' style presentation of the colors used for each set
+class _OutSetsPlugValueWidget( GafferUI.Widget ) :
+
+	def __init__( self, node, **kw ) :
+
+		self.__node = node
+		self.__plugDirtiedConnection = node.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ) )
+
+		self.__column = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing = 4 )
+		self.__swatches = []
+
+		GafferUI.Widget.__init__( self, self.__column, **kw )
+
+		self._update()
+
+	def _update( self ) :
+
+		with self.node().scriptNode().context() :
+			sets = self.node()["__outSets"].getValue()
+
+		names = sets["names"]
+		colors = sets["colors"]
+		numSets = len(names)
+
+		# Try to re-use existing child widgets where we can
+
+		while len( self.__swatches ) < numSets:
+			self.__swatches.append( _SetColorLedgendRowWidget() )
+		while len( self.__swatches ) > numSets:
+			self.__swatches.pop()
+
+		# List in Alphabetical order
+		for i in range( numSets ):
+			self.__swatches[i].setColorAndLabel( colors[ i ], str(names[ i ]) )
+
+		self.__column[:] = self.__swatches
+
+	@GafferUI.LazyMethod()
+	def __updateLazily( self ) :
+		self._update()
+
+	def __plugDirtied( self, plug ) :
+
+		if plug == self.node()["__outSets"] :
+			self.__updateLazily()
+
+	def node( self ):
+		return self.__node
+
+	def context( self ) :
+		return self.node().scriptNode().context()
+
+	# We make use of the full width of the editor, and parent this to a new
+	# tab so we don't need the built-in label or tool-tips
+
+	def hasLabel( self ) :
+		return True
+
+	def getToolTip( self ) :
+		return None
+
+# A simple 'Add' button that doesn't show all the data types listed in the
+# CompoundDataPlugValueWidget's Add MenuButton.
+# @TODO: Support type constraints in CompoundDataPlugValueWidget.
+class _OverridesFooter( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug ) :
+
+		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal )
+
+		GafferUI.PlugValueWidget.__init__( self, row, plug )
+
+		with row :
+
+			GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
+
+			self.__addButton = GafferUI.Button( image = "plus.png", hasFrame = False )
+			self.__addButtonClickedConnection = self.__addButton.clickedSignal().connect(
+				Gaffer.WeakMethod( self.__addOverride )
+			)
+
+			GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
+
+	def _updateFromPlug( self ) :
+
+		self.setEnabled( self._editable() )
+
+	def __addOverride( self, _ ) :
+
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			self.getPlug().addOptionalMember( "", imath.Color3f( 1.0 ) , enabled=True )
+
+# A single-row that holds a Color swatch and a text label
+class _SetColorLedgendRowWidget( GafferUI.ListContainer ) :
+
+	def __init__( self, **kw ) :
+
+		GafferUI.ListContainer.__init__( self, GafferUI.ListContainer.Orientation.Horizontal, spacing=4 )
+
+		self.__spacer =	GafferUI.Spacer( imath.V2i( 20, 1 ), imath.V2i( 20 , 1 ) )
+		self.addChild( self.__spacer )
+
+		self.__swatch = GafferUI.ColorSwatch()
+		# No easy way to manage size at present in GafferUI
+		self.__swatch._qtWidget().setFixedWidth( 40 )
+		self.__swatch._qtWidget().setFixedHeight( 20 )
+		self.addChild( self.__swatch )
+
+		self.__label = GafferUI.Label()
+		self.addChild( self.__label )
+
+		# Allow right-click to add an override for the target set
+		self.__menu = GafferUI.Menu( Gaffer.WeakMethod( self.__addMenuDefinition ) )
+		self.__contextMenuConnection = self.contextMenuSignal().connect( Gaffer.WeakMethod( self.__menu.popup ) )
+
+	def setColorAndLabel( self, color, label ) :
+
+		self.__swatch.setColor( color )
+		self.__label.setText( label )
+
+	def __colorOverridesPlug( self ) :
+
+		# We don't want to be storing any plug references here to avoid
+		# becoming stale, instead we trust our known widget hierarchy.
+		outSetsWidget = self.ancestor( _OutSetsPlugValueWidget )
+		return outSetsWidget.node()[ "colorOverrides" ], outSetsWidget.context()
+
+	def __hasExistingOverrideFor( self, name ) :
+
+		plug, context = self.__colorOverridesPlug()
+		with context :
+			for c in plug.children() :
+				if c["name"].getValue() == name:
+					return True
+
+		return False
+
+	def __addOverride( self ) :
+
+		targetPlug, _ = self.__colorOverridesPlug()
+		if targetPlug:
+			with Gaffer.UndoScope( targetPlug.ancestor( Gaffer.ScriptNode ) ) :
+				targetPlug.addOptionalMember( self.__label.getText(), imath.Color3f( 1.0 ) , enabled=True )
+			editor = self.ancestor( GafferUI.NodeUI )
+			if editor:
+				editor.plugValueWidget( targetPlug ).reveal()
+
+	def __selectMembers( self ) :
+
+		outSetsWidget = self.ancestor( _OutSetsPlugValueWidget )
+		inPlug = outSetsWidget.node()[ "in" ]
+		with outSetsWidget.context() :
+			matcher = inPlug.set( self.__label.getText() ).value
+			GafferSceneUI.ContextAlgo.setSelectedPaths( outSetsWidget.context(), matcher )
+
+	def __addMenuDefinition( self ) :
+
+		result = IECore.MenuDefinition()
+		result.append( "Add Color Override", {
+			"command" : Gaffer.WeakMethod( self.__addOverride ),
+			"active" : not self.__hasExistingOverrideFor( self.__label.getText() )
+		} )
+		result.append( "Select Members", {
+			"command" : Gaffer.WeakMethod( self.__selectMembers )
+		} )
+		return result

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -148,6 +148,7 @@ import PrimitiveVariableExistsUI
 import CollectTransformsUI
 import UDIMQueryUI
 import WireframeUI
+import SetVisualiserUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/SetVisualiser.cpp
+++ b/src/GafferScene/SetVisualiser.cpp
@@ -1,0 +1,414 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/SetVisualiser.h"
+
+#include "GafferScene/SceneAlgo.h"
+
+#include "Gaffer/CompoundDataPlug.h"
+#include "Gaffer/StringPlug.h"
+
+#include "IECoreScene/Shader.h"
+#include "IECoreScene/ShaderNetwork.h"
+#include "IECore/StringAlgo.h"
+
+#include "OpenEXR/ImathColorAlgo.h"
+#include "OpenEXR/ImathRandom.h"
+
+#include "boost/algorithm/string/predicate.hpp"
+
+
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+
+namespace
+{
+
+bool internedStringCompare( InternedString a, InternedString b )
+{
+    return a.string() < b.string();
+}
+
+typedef std::pair<StringAlgo::MatchPattern, ConstColor3fDataPtr> Override;
+std::vector<Override> unpackOverrides( const CompoundDataPlug *plug )
+{
+	std::vector<Override> overrides;
+
+	std::string name;
+	for( CompoundDataPlug::MemberPlugIterator it( plug ); !it.done(); ++it )
+	{
+		// This will fail if the member has been disabled, or has no name
+		if( ConstDataPtr plugData =  plug->memberDataAndName( it->get(), name ) )
+		{
+			if( ConstColor3fDataPtr asColor = runTimeCast<const Color3fData>( plugData ) )
+			{
+				overrides.push_back( Override( name, asColor ) );
+			}
+			else
+			{
+				throw IECore::Exception( boost::str( boost::format(
+					"Color Override value for \"%s\" is not a Color3f") % name )
+				);
+			}
+		}
+	}
+	return overrides;
+}
+
+Color3f colorForSetName( const InternedString &name, const std::vector<Override> &overrides )
+{
+	for( auto &override_ : overrides )
+	{
+		if( StringAlgo::matchMultiple( name, override_.first ) )
+		{
+			return override_.second->readable();
+		}
+	}
+
+	// If we didn't have an override, make up a color
+	Color3f color( 0.0f );
+	Rand32 r( boost::hash<std::string>()( name.string() ) );
+	// RGB generation seemed to yield many colours that were close
+	// together. HSL seems to give better distribution over smaller
+	// sample sizes... and then sometimes it doesn't.
+	color[0] = r.nextf();                     // hue
+	color[1] = 0.6f + ( r.nextf() * 0.25f );  // saturation
+	color[2] = 0.35f + ( r.nextf() * 0.25f ); // lightness
+	return hsv2rgb( color );
+}
+
+// We're limited in our target GLSL version to fixed size shader array params
+size_t g_maxShaderColors = 9;
+
+static const StringDataPtr fragmentSource()
+{
+	static StringDataPtr g_fragmentSource = new IECore::StringData(
+		"#if __VERSION__ <= 120\n"
+		"#define in varying\n"
+		"#endif\n"
+
+		"#include \"IECoreGL/ColorAlgo.h\"\n"
+
+		"uniform vec3 colors[" + std::to_string( g_maxShaderColors ) + "];"
+		"uniform int numColors;"
+		"uniform float stripeWidth;"
+
+		"in vec3 fragmentN;"
+		"in vec3 fragmentI;"
+
+		"void main()"
+		"{"
+		"	float f = abs( dot( normalize( fragmentI ), normalize( fragmentN ) ) );"
+		"	gl_FragColor = vec4( f, f, f, 1.0 );"
+		"	if( numColors > 0 )"
+		"	{"
+		"		float stripeIndex = floor( (gl_FragCoord.x - gl_FragCoord.y) / stripeWidth );"
+		"		stripeIndex = mod( stripeIndex, float(numColors) );"
+		"		gl_FragColor = ( gl_FragColor * 0.8 + 0.2 ) * vec4( ieLinToSRGB( colors[ int(stripeIndex) ] ), 1.0);"
+		"	}"
+		"}"
+	);
+	return g_fragmentSource;
+}
+
+ShaderNetworkPtr stripeShader( float stripeWidth, size_t numColorsUsed, const std::vector<Color3f> &colors )
+{
+	// The shader name isn't used as we provide the src inline
+	IECoreScene::ShaderPtr shader = new IECoreScene::Shader( "SetVisualiserSurface", "gl:surface" );
+	shader->parameters()["stripeWidth"] = new FloatData( stripeWidth );
+	shader->parameters()["numColors"] = new IntData( numColorsUsed );
+	shader->parameters()["colors"] = new Color3fVectorData( colors );
+	shader->parameters()["gl:fragmentSource"] = fragmentSource();
+
+	ShaderNetworkPtr shaderNetwork = new ShaderNetwork;
+	const InternedString handle = shaderNetwork->addShader( "surface", std::move( shader ) );
+	shaderNetwork->setOutput( handle );
+
+	return shaderNetwork;
+}
+
+
+} // end anon namespace
+
+
+IE_CORE_DEFINERUNTIMETYPED( SetVisualiser );
+
+size_t SetVisualiser::g_firstPlugIndex = 0;
+
+
+// NoMatch is the Gaffer standard default behaviour for nodes that accept
+// filters. It may seem more intuitive to have a visualisation node affect
+// everything by default - but consistency across Gaffer is more important.
+// Even at the expense of inconsistency with existing vis nodes.
+SetVisualiser::SetVisualiser( const std::string &name )
+	: SceneElementProcessor( name, PathMatcher::NoMatch )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new StringPlug( "sets" ) );
+	addChild( new BoolPlug( "includeInherited", Plug::In, true ) );
+	addChild( new FloatPlug( "stripeWidth", Plug::In, 10.0f, 1.0f /* min */ ) );
+
+	addChild( new CompoundDataPlug( "colorOverrides", Plug::In ) );
+	addChild( new AtomicCompoundDataPlug( "__outSets", Plug::Out, new CompoundData() ) );
+
+	// Fast pass-throughs for the things we don't alter.
+	outPlug()->objectPlug()->setInput( inPlug()->objectPlug() );
+	outPlug()->transformPlug()->setInput( inPlug()->transformPlug() );
+	outPlug()->boundPlug()->setInput( inPlug()->boundPlug() );
+}
+
+SetVisualiser::~SetVisualiser()
+{
+}
+
+Gaffer::StringPlug *SetVisualiser::setsPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::StringPlug *SetVisualiser::setsPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+Gaffer::BoolPlug *SetVisualiser::includeInheritedPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::BoolPlug *SetVisualiser::includeInheritedPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::FloatPlug *SetVisualiser::stripeWidthPlug()
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::FloatPlug *SetVisualiser::stripeWidthPlug() const
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::CompoundDataPlug *SetVisualiser::colorOverridesPlug()
+{
+	return getChild<CompoundDataPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::CompoundDataPlug *SetVisualiser::colorOverridesPlug() const
+{
+	return getChild<CompoundDataPlug>( g_firstPlugIndex + 3 );
+}
+
+Gaffer::AtomicCompoundDataPlug *SetVisualiser::outSetsPlug()
+{
+	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 4 );
+}
+
+const Gaffer::AtomicCompoundDataPlug *SetVisualiser::outSetsPlug() const
+{
+	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 4 );
+}
+
+void SetVisualiser::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	SceneElementProcessor::affects( input, outputs );
+
+	// Making attributes depend on outSets as much as possible (instead of
+	// the input plugs directly) allows us to better take advantage of Gaffers
+	// plug value caching and avoid some duplicate set processing work.
+
+	if(
+		input == setsPlug() ||
+		colorOverridesPlug()->isAncestorOf( input ) ||
+		input == inPlug()->setNamesPlug()
+	)
+	{
+		outputs.push_back( outSetsPlug() );
+	}
+	else if (
+		input == includeInheritedPlug() ||
+		input == stripeWidthPlug() ||
+		input == outSetsPlug() ||
+		input == inPlug()->setPlug()
+	)
+	{
+		outputs.push_back( outPlug()->attributesPlug() );
+	}
+}
+
+void SetVisualiser::hash( const ValuePlug *output, const Context *context, MurmurHash &h ) const
+{
+	SceneElementProcessor::hash( output, context, h );
+
+	if( output == outSetsPlug() )
+	{
+		setsPlug()->hash( h );
+		colorOverridesPlug()->hash( h );
+		// We don't care about a set's hash here as we're only computing which
+		// sets we will consider and their corresponding colors - which depends
+		// solely on their names.
+		h.append( inPlug()->setNamesHash() );
+	}
+}
+
+void SetVisualiser::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const
+{
+	if( output == outSetsPlug() )
+	{
+		const StringAlgo::MatchPattern requestedSetsPattern = setsPlug()->getValue();
+
+		std::vector<InternedString> names;
+		std::vector<Color3f> colors;
+
+		if( !requestedSetsPattern.empty() )
+		{
+			const std::vector<Override> overrides = unpackOverrides( colorOverridesPlug() );
+
+			ConstInternedStringVectorDataPtr allSetNamesData = inPlug()->setNames();
+
+			// Sorting now makes everything easier, otherwise you have to
+			// sort parallel arrays later, which is a pain.
+			std::vector<InternedString> allNames = allSetNamesData->readable();
+			std::sort( allNames.begin(), allNames.end(), internedStringCompare );
+
+			for( auto &name : allNames )
+			{
+				// Gaffer has some internal sets that begin with the '__'
+				// prefix. These are usually Lights, Cameras, etc... We filter
+				// these out as they most of their objects don't even draw in
+				// the viewer in a meaningful way for visualising set Membership
+				if( boost::starts_with( name.string(), "__" ) )
+				{
+					continue;
+				}
+
+				if( StringAlgo::matchMultiple( name, requestedSetsPattern ) )
+				{
+					names.push_back( name );
+					colors.push_back( colorForSetName( name, overrides ) );
+				}
+			}
+		}
+
+		CompoundDataPtr data = new CompoundData();
+		data->writable()["names"] = new InternedStringVectorData( names );
+		data->writable()["colors"] = new Color3fVectorData( colors );
+		static_cast<AtomicCompoundDataPlug *>( output )->setValue( data );
+	}
+	else
+	{
+		SceneElementProcessor::compute( output, context );
+	}
+}
+
+bool SetVisualiser::processesAttributes() const
+{
+	return true;
+}
+
+void SetVisualiser::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, MurmurHash &h ) const
+{
+	ConstCompoundDataPtr outSetsData = outSetsPlug()->getValue();
+
+	outSetsData->hash( h );
+	includeInheritedPlug()->hash( h );
+
+	// We also need to consider each of our candidate sets membership
+	// definition (which we didn't need to when computing outSets).
+	// outSetsData is map of names -> colors.
+	ConstInternedStringVectorDataPtr setNames = outSetsData->member<InternedStringVectorData>( "names" );
+	for( auto &setName : setNames->readable() )
+	{
+		h.append( inPlug()->setHash( setName ) );
+	}
+
+	h.append( path.data(), path.size() );
+	stripeWidthPlug()->hash( h );
+}
+
+ConstCompoundObjectPtr SetVisualiser::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, ConstCompoundObjectPtr inputAttributes ) const
+{
+	CompoundObjectPtr result = new CompoundObject;
+
+	// Since we're not going to modify any existing members (only add a new one),
+	// and our result becomes const on returning it, we can directly reference
+	// the input members in our result without copying. Be careful not to modify
+	// them though!
+	result->members() = inputAttributes->members();
+
+	ConstCompoundDataPtr outSetsData = outSetsPlug()->getValue();
+	const InternedStringVectorData *setNamesData = outSetsData->member<InternedStringVectorData>( "names" );
+	const Color3fVectorData *setColorsData = outSetsData->member<Color3fVectorData>( "colors" );
+
+	int matchResult = PathMatcher::ExactMatch;
+	if( includeInheritedPlug()->getValue() )
+	{
+		matchResult |= PathMatcher::AncestorMatch;
+	}
+
+	ConstCompoundDataPtr targetSets = SceneAlgo::sets( inPlug(), setNamesData->readable() );
+	std::vector<Color3f> shaderColors;
+
+	size_t index = 0;
+	for( auto &setName : setNamesData->readable() )
+	{
+		const PathMatcherData *pathMatchData = targetSets->member<const PathMatcherData>( setName );
+		if( pathMatchData->readable().match( path ) & matchResult )
+		{
+			shaderColors.push_back( setColorsData->readable()[ index ] );
+		}
+		// We need to pass our colors to the shader as a fixed size array
+		if( shaderColors.size() == g_maxShaderColors )
+		{
+			break;
+		}
+		++index;
+	}
+
+	// Avoids shader compilation errors as its expecting g_maxShaderColors elements
+	const size_t numColorsUsed = shaderColors.size();
+	shaderColors.resize( g_maxShaderColors );
+
+	result->members()["gl:surface"] = stripeShader( stripeWidthPlug()->getValue(), numColorsUsed, shaderColors );
+
+	return result;
+}

--- a/src/GafferSceneModule/GlobalsBinding.cpp
+++ b/src/GafferSceneModule/GlobalsBinding.cpp
@@ -43,6 +43,7 @@
 #include "GafferScene/GlobalShader.h"
 #include "GafferScene/Outputs.h"
 #include "GafferScene/Set.h"
+#include "GafferScene/SetVisualiser.h"
 
 #include "GafferBindings/DependencyNodeBinding.h"
 
@@ -111,6 +112,7 @@ void GafferSceneModule::bindGlobals()
 			;
 	}
 
+	DependencyNodeClass<SetVisualiser>();
 	DependencyNodeClass<GlobalShader>();
 
 }

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -329,6 +329,7 @@ nodeMenu.append( "/Scene/Globals/Custom Options", GafferScene.CustomOptions, sea
 nodeMenu.append( "/Scene/Globals/Delete Options", GafferScene.DeleteOptions, searchText = "DeleteOptions" )
 nodeMenu.append( "/Scene/Globals/Copy Options", GafferScene.CopyOptions, searchText = "CopyOptions" )
 nodeMenu.append( "/Scene/Globals/Set", GafferScene.Set )
+nodeMenu.append( "/Scene/Globals/Set Visualiser", GafferScene.SetVisualiser, searchText = "SetVisualiser" )
 nodeMenu.append( "/Scene/OpenGL/Attributes", GafferScene.OpenGLAttributes, searchText = "OpenGLAttributes" )
 nodeMenu.definition().append( "/Scene/OpenGL/Shader", { "subMenu" : GafferSceneUI.OpenGLShaderUI.shaderSubMenu } )
 nodeMenu.append( "/Scene/OpenGL/Render", GafferScene.OpenGLRender, searchText = "OpenGLRender" )


### PR DESCRIPTION
Fixes #3109

The `SetVisualiser` follows the pattern established by `AttributeVisualiser`, allowing users to visualise Set membership in the Viewer.

![setVisWithLegend](https://user-images.githubusercontent.com/896779/56151942-56fcd500-5faa-11e9-946b-e6140d4e89b3.png)

Membership is expressed by constant-shading objects with colours based on the sets they are members of. If an object is a member of multiple sets, striped shading allows all applicable set colours to be seen simultaneously.

The Node can be focused to only consider sets in the scene that match a particular pattern. Custom colours can be specified by the user for any set or sets matching a pattern.

The Node is bound to python to allow users to specify custom Viewer Debug Shading modes in a startup file. For an example of how to do this, see `startup/gui/viewer.py`.

The outSets Plug on the node provides a `CompoundData` object mapping Set names to the colour used for display. This is used in the NodeEditor UI to present a Legend section. Right-click in the legend allows the user to easily add a color override for any given set.

All other string Plugs that reference Sets support the standard Gaffer right-click menu helpers for inserting set names from the incoming Scene.

User Facing Changes:
 - Adds SetVisualiser Node
