### PR TITLE
Update issue templates to include new feature template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,23 @@
+---
+name: Feature
+about: Define a new Gaffer feature
+title: ''
+labels: 'type-enhancement'
+assignees: ''
+
+---
+
+## What I'd like ##
+
+As a `<User|Developer>` I would like `<something>` so that `<reason>`.
+
+Ideally this bit shouldn't contain implementation details.
+
+## Specifics ##
+
+* Given `<situation>`, `<then>`.
+* Given `<situation>`, when `<action>` `<then>` .
+
+## Technical/Implementation Notes ##
+
+Optionally add any useful comments, notes or technical requirements.


### PR DESCRIPTION
To help seprate the 'what' from the 'how' in the first instance.

This approach can make it easier to circulate a design to users for sanity-checking