### PR TITLE
Wedge : Avoid deprecated SplinePlug init

### DIFF
--- a/python/GafferDispatch/Wedge.py
+++ b/python/GafferDispatch/Wedge.py
@@ -74,14 +74,12 @@ class Wedge( GafferDispatch.TaskContextProcessor ) :
 		# color range
 
 		self["ramp"] = Gaffer.SplinefColor3fPlug(
-			defaultValue = IECore.SplinefColor3f(
-				IECore.CubicBasisf.catmullRom(),
+			defaultValue = Gaffer.SplineDefinitionfColor3f(
 				(
 					( 0, imath.Color3f( 0 ) ),
-					( 0, imath.Color3f( 0 ) ),
 					( 1, imath.Color3f( 1 ) ),
-					( 1, imath.Color3f( 1 ) ),
-				)
+				),
+				Gaffer.SplineDefinitionInterpolation.CatmullRom
 			)
 		)
 


### PR DESCRIPTION
Little fix for some out of date code that has only been working because the compatibility configs cover over it.