### PR TITLE
Travis : Update 3Delight version to 1.1.12

### DIFF
--- a/config/travis/installDelight.sh
+++ b/config/travis/installDelight.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-version=1.1.7
-directory=free/beta/2018-10-05-Y88MpygF
+version=1.1.12
+directory=free/beta/2018-11-01-oIDoJTpO
 
 if [[ `uname` = "Linux" ]] ; then
 	package=3DelightNSI-$version-Linux-x86_64


### PR DESCRIPTION
The version we were using before appears to have disappeared from the internet. There are even more recent versions available, but I've chosen the one closest to the old version since I don't have time to add new features or deal with API/ABI changes right now.
