### PR TITLE
Two One Line Fixes

### DIFF
--- a/python/GafferImage/BleedFill.py
+++ b/python/GafferImage/BleedFill.py
@@ -107,6 +107,7 @@ class BleedFill( GafferImage.ImageProcessor ) :
 		self["__grade"] = GafferImage.Grade( "Grade" )
 		self["__grade"]['channels'].setValue( "*" )
 		self["__grade"]['multiply'].setValue( imath.Color4f( 0.1 ) )
+		self["__grade"]['blackClamp'].setValue( False )
 		self["__grade"]["in"].setInput( self["__downsample"]["out"] )
 
 		self["__blurLoop"]["next"].setInput( self["__grade"]["out"] )

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -486,7 +486,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		context = self.__context
 		plug = self.getPlug()
-		if plug is None or plug.getInput() is None :
+		if plug is None or ( plug.getInput() is None and plug.direction() == Gaffer.Plug.Direction.In ):
 			context = None
 
 		if context is not None :


### PR DESCRIPTION
I thought these were both image specific when I started this branch, they ended up being completely unrelated, so I can break this into two PRs if necessary.

The first one is totally trivial - blackClamp defaults on on the grade node, which I always forget about when using Grade as a basic multiply in a larger piece of math.  The symptom of this was the BleedFill failed completely when the input was negative.  Easy fix.

The second one has a much wider effect, but I think is also pretty obviously correct.  We don't send a dirty signal when the frame changes, we rely on contextChanged to update any widgets that are showing frame dependent values.  We were failing to hook up the context connection on widgets for output plugs however - I assume when this code was written, it was just considering input plugs, which can only depend on the context if they have inputs.

I didn't see any tests that would be appropriate for verifying this behaviour - let me know how to tackle it if you think it's necessary.  The place I noticed it interactively was using an ImageStats node connected to an ImageReader reading a sequence using the "####" substitution.  Changing frames changes the stats, but the widgets wouldn't be updated unless you click off and on the node to manually refresh widgets.