### PR TITLE
Threading utilities

### DIFF
--- a/include/Gaffer/Private/IECorePreview/ParallelAlgo.h
+++ b/include/Gaffer/Private/IECorePreview/ParallelAlgo.h
@@ -1,0 +1,68 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREPREVIEW_PARALLELALGO_H
+#define IECOREPREVIEW_PARALLELALGO_H
+
+#include "tbb/task_arena.h"
+
+namespace IECorePreview
+{
+
+namespace ParallelAlgo
+{
+
+// Calls `f` such that any TBB tasks it spawns will run in isolation,
+// and cannot steal work from outer tasks. This is of fundamental importance
+// if you hold a lock while running any TBB code. See :
+//
+//  https://software.intel.com/en-us/blogs/2018/08/16/the-work-isolation-functionality-in-intel-threading-building-blocks-intel-tbb
+template<typename F>
+void isolate( const F &f )
+{
+#if TBB_INTERFACE_VERSION >= 10000
+	tbb::this_task_arena::isolate( f );
+#else
+	tbb::task_arena arena;
+	arena.execute( f );
+#endif
+}
+
+} // namespace ParallelAlgo
+
+} // namespace IECorePreview
+
+#endif // IECOREPREVIEW_PARALLELALGO_H

--- a/include/Gaffer/Private/IECorePreview/TaskMutex.h
+++ b/include/Gaffer/Private/IECorePreview/TaskMutex.h
@@ -1,0 +1,357 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREPREVIEW_TASKMUTEX_H
+#define IECOREPREVIEW_TASKMUTEX_H
+
+#include "boost/container/flat_set.hpp"
+#include "boost/noncopyable.hpp"
+
+#include "tbb/spin_mutex.h"
+#include "tbb/spin_rw_mutex.h"
+
+#include "tbb/task_arena.h"
+#include "tbb/task_group.h"
+// Enable preview feature that allows us to construct a `task_scheduler_observer`
+// for a specific `task_arena`. This feature becomes officially supported in
+// Intel TBB 2019 Update 5, so it is not going to be removed.
+#define TBB_PREVIEW_LOCAL_OBSERVER 1
+#include "tbb/task_scheduler_observer.h"
+
+#include <thread>
+
+namespace IECorePreview
+{
+
+/// Mutex where threads waiting for access can collaborate on TBB tasks
+/// spawned by the holder. Useful for performing expensive delayed
+/// initialisation of shared resources.
+///
+/// Based on an example posted by "Alex (Intel)" on the following thread :
+///
+/// https://software.intel.com/en-us/forums/intel-threading-building-blocks/topic/703652
+///
+/// Simple usage :
+///
+/// 	```
+/// 	void performExpensiveInitialisationUsingTBB();
+/// 	static bool g_initialised;
+/// 	static TaskMutex g_mutex;
+/// 	...
+/// 	TaskMutex::ScopedLock lock( g_mutex );
+/// 	if( !g_initialised )
+/// 	{
+/// 		lock.execute( []{ performExpensiveInitialisationUsingTBB(); } );
+/// 		g_initialised = true;
+/// 	}
+/// 	// Use resource here, while lock is still held.
+/// ```
+///
+/// Improved performance via reader locks :
+///
+/// 	```
+/// 	...
+/// 	// Optimistically take a reader lock, sufficient to allow us
+/// 	// to read from the resource if it is already initialised.
+/// 	TaskMutex::ScopedLock lock( g_mutex, /* write = */ false );
+/// 	if( !g_initialised )
+/// 	{
+/// 		// Upgrade to writer lock, so we can initialise the shared resource.
+/// 		lock.upgradeToWriter();
+/// 		if( !g_initialised ) // Check again, we may not be the first to get a write lock
+/// 		{
+/// 			lock.execute( []{ performExpensiveInitialisationUsingTBB(); } );
+/// 			g_initialised = true;
+///			}
+/// 	}
+/// 	// Use resource here, while lock is still held.
+/// ```
+class TaskMutex : boost::noncopyable
+{
+
+	typedef tbb::spin_rw_mutex InternalMutex;
+
+	public :
+
+		TaskMutex()
+		{
+		}
+
+		/// Used to acquire a lock on the mutex and release it
+		/// automatically in an exception-safe way. Equivalent to
+		/// the `scoped_lock` of the standard TBB mutexes.
+		class ScopedLock : boost::noncopyable
+		{
+
+			public :
+
+				ScopedLock()
+					:	m_mutex( nullptr ), m_writer( false ), m_recursive( false )
+				{
+				}
+
+				ScopedLock( TaskMutex &mutex, bool write = true, bool acceptWork = true )
+					:	ScopedLock()
+				{
+					acquire( mutex, write, acceptWork );
+				}
+
+				~ScopedLock()
+				{
+					if( m_mutex )
+					{
+						release();
+					}
+				}
+
+				/// Acquires a lock on `mutex`. If `acceptWork` is true, then may perform
+				/// work on behalf of `execute()` while waiting.
+				void acquire( TaskMutex &mutex, bool write = true, bool acceptWork = true )
+				{
+					tbb::internal::atomic_backoff backoff;
+					while( !acquireOr( mutex, write, [acceptWork]( bool workAvailable ){ return acceptWork; } ) )
+					{
+						backoff.pause();
+					}
+				}
+
+				/// Upgrades a previously-acquired reader lock to a full writer
+				/// lock.
+				bool upgradeToWriter()
+				{
+					assert( m_mutex && !m_writer && !m_recursive );
+					m_writer = true;
+					return m_lock.upgrade_to_writer();
+				}
+
+				/// Calls `f` in a way that allows threads waiting for the lock to perform
+				/// TBB tasks on its behalf. Should only be called by the holder of a write lock.
+				template<typename F>
+				void execute( F &&f )
+				{
+					assert( m_mutex && m_writer && !m_recursive );
+
+					ExecutionStateMutex::scoped_lock executionStateLock( m_mutex->m_executionStateMutex );
+					assert( !m_mutex->m_executionState );
+					m_mutex->m_executionState = std::make_shared<ExecutionState>();
+					executionStateLock.release();
+
+					m_mutex->m_executionState->arena.execute(
+						[this, &f] {
+							// Note : We deliberately call `run()` and `wait()` separately
+							// instead of calling `run_and_wait()`. The latter is buggy until
+							// TBB 2018 Update 3, causing calls to `wait()` on other threads to
+							// return immediately rather than do the work we want.
+							m_mutex->m_executionState->taskGroup.run( f );
+							m_mutex->m_executionState->taskGroup.wait();
+						}
+					);
+
+					executionStateLock.acquire( m_mutex->m_executionStateMutex );
+					m_mutex->m_executionState = nullptr;
+				}
+
+				/// Acquires mutex or returns false. Never does TBB tasks.
+				bool tryAcquire( TaskMutex &mutex, bool write = true )
+				{
+					return acquireOr( mutex, write, []( bool workAvailable ){ return false; } );
+				}
+
+				/// Releases the lock. This will be done automatically
+				/// by ~ScopedLock, but may be called explicitly to release
+				/// the lock early.
+				void release()
+				{
+					assert( m_mutex );
+					if( !m_recursive )
+					{
+						m_lock.release();
+					}
+					m_mutex = nullptr;
+				}
+
+				/// Advanced API
+				/// ============
+				///
+				/// These methods provide advanced usage required by complex requirements
+				/// in Gaffer's LRUCache. They should not be considered part of the canonical
+				/// API.
+
+				/// Returns true if `acquire()` obtained a recursive lock rather
+				/// than a unique lock. Recursive locks are available to any thread
+				/// performing work on behalf of `execute()`.
+				bool recursive() const
+				{
+					return m_recursive;
+				}
+
+				/// Tries to acquire the mutex, returning true on success. On failure,
+				/// calls `workNotifier( bool workAvailable )`. If work is available and
+				/// `workNotifier` returns true, then this thread will perform TBB tasks
+				/// spawned by `execute()` until the work is complete. Returns false on
+				/// failure regardless of whether or not work is done.
+				template<typename WorkNotifier>
+				bool acquireOr( TaskMutex &mutex, bool write, WorkNotifier &&workNotifier )
+				{
+					assert( !m_mutex );
+					if( m_lock.try_acquire( mutex.m_mutex, write ) )
+					{
+						// Success!
+						m_mutex = &mutex;
+						m_recursive = false;
+						m_writer = write;
+						return true;
+					}
+
+					ExecutionStateMutex::scoped_lock executionStateLock( mutex.m_executionStateMutex );
+					if( mutex.m_executionState && mutex.m_executionState->arenaObserver.containsThisThread() )
+					{
+						m_mutex = &mutex;
+						m_writer = false;
+						m_recursive = true;
+						return true;
+					}
+
+					const bool workAvailable = mutex.m_executionState.get();
+					if( !workNotifier( workAvailable ) || !workAvailable )
+					{
+						return false;
+					}
+
+					ExecutionStatePtr executionState = mutex.m_executionState;
+					executionStateLock.release();
+
+					executionState->arena.execute(
+						[&executionState]{ executionState->taskGroup.wait(); }
+					);
+					return false;
+				}
+
+			private :
+
+				InternalMutex::scoped_lock m_lock;
+				TaskMutex *m_mutex;
+				bool m_writer;
+				bool m_recursive;
+
+		};
+
+	private :
+
+		// The actual mutex that is held
+		// by the scoped_lock.
+		InternalMutex m_mutex;
+
+		// Tracks worker threads as they enter and exit an arena, so we can determine
+		// whether or not the current thread is inside the arena. We use this to detect
+		// recursion and allow any worker thread to obtain a recursive lock provided
+		// they are currently performing work in service of `ScopedLock::execute()`.
+		class ArenaObserver : public tbb::task_scheduler_observer
+		{
+
+			public :
+
+				ArenaObserver( tbb::task_arena &arena )
+					:	tbb::task_scheduler_observer( arena )
+				{
+					observe( true );
+				}
+
+				~ArenaObserver()
+				{
+					observe( false );
+				}
+
+				bool containsThisThread()
+				{
+					Mutex::scoped_lock lock( m_mutex );
+					return m_threadIdSet.find( std::this_thread::get_id() ) != m_threadIdSet.end();
+				}
+
+			private :
+
+				void on_scheduler_entry( bool isWorker ) override
+				{
+					assert( !containsThisThread() );
+					Mutex::scoped_lock lock( m_mutex );
+					m_threadIdSet.insert( std::this_thread::get_id() );
+				}
+
+				void on_scheduler_exit( bool isWorker ) override
+				{
+					assert( containsThisThread() );
+					Mutex::scoped_lock lock( m_mutex );
+					m_threadIdSet.erase( std::this_thread::get_id() );
+				}
+
+				using Mutex = tbb::spin_mutex;
+				using ThreadIdSet = boost::container::flat_set<std::thread::id>;
+				Mutex m_mutex;
+				ThreadIdSet m_threadIdSet;
+
+		};
+
+		// The mechanism we use to allow waiting threads
+		// to participate in the work done by `execute()`.
+		struct ExecutionState : private boost::noncopyable
+		{
+			ExecutionState()
+				:	arenaObserver( arena )
+			{
+			}
+
+			// Work around https://bugs.llvm.org/show_bug.cgi?id=32978
+			~ExecutionState() noexcept( true )
+			{
+			}
+
+			// Arena and task group used to allow
+			// waiting threads to participate in work.
+			tbb::task_arena arena;
+			tbb::task_group taskGroup;
+			// Observer used to track which threads are
+			// currently inside the arena.
+			ArenaObserver arenaObserver;
+		};
+		typedef std::shared_ptr<ExecutionState> ExecutionStatePtr;
+
+		typedef tbb::spin_mutex ExecutionStateMutex;
+		ExecutionStateMutex m_executionStateMutex;
+		ExecutionStatePtr m_executionState;
+
+};
+
+} // namespace IECorePreview
+
+#endif // IECOREPREVIEW_TASKMUTEX_H

--- a/include/GafferTest/Assert.h
+++ b/include/GafferTest/Assert.h
@@ -52,6 +52,18 @@ namespace GafferTest
 		) ); \
 	}
 
+#define GAFFERTEST_ASSERTEQUAL( x, y ) \
+	{ \
+		const auto xx = x; /* evaluate macro arguments */ \
+		const auto yy = y; /* only once */ \
+		if( xx != yy ) \
+		{ \
+			throw IECore::Exception( boost::str( \
+				boost::format( "Failed assertion \"%1% == %2%\" : %3% line %4%" ) % (xx) % (yy) % __FILE__ % __LINE__ \
+			) ); \
+		} \
+	}
+
 } // namespace GafferTest
 
 #endif // GAFFERTEST_ASSERT_H

--- a/python/Gaffer/Application.py
+++ b/python/Gaffer/Application.py
@@ -133,8 +133,9 @@ class Application( IECore.Parameterised ) :
 
 		threads = self.parameters()["threads"].getTypedValue()
 
-		with IECore.tbb_task_scheduler_init(
-			IECore.tbb_task_scheduler_init.automatic if threads == 0 else threads
+		with IECore.tbb_global_control(
+			IECore.tbb_global_control.parameter.max_allowed_parallelism,
+			IECore.hardwareConcurrency() if threads == 0 else threads
 		) :
 
 			self._executeStartupFiles( self.root().getName() )

--- a/python/GafferTest/IECorePreviewTest/TaskMutexTest.py
+++ b/python/GafferTest/IECorePreviewTest/TaskMutexTest.py
@@ -1,0 +1,78 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import GafferTest
+
+class TaskMutexTest( GafferTest.TestCase ) :
+
+	def test( self ) :
+
+		GafferTest.testTaskMutex()
+
+	def testWithinIsolate( self ) :
+
+		GafferTest.testTaskMutexWithinIsolate()
+
+	def testJoiningOuterTasks( self ) :
+
+		GafferTest.testTaskMutexJoiningOuterTasks()
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testHeavyContentionWithWorkAcceptance( self ) :
+
+		GafferTest.testTaskMutexHeavyContention( True )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testHeavyContentionWithoutWorkAcceptance( self ) :
+
+		GafferTest.testTaskMutexHeavyContention( False )
+
+	def testRecursion( self ) :
+
+		GafferTest.testTaskMutexRecursion()
+
+	def testWorkerRecursion( self ) :
+
+		GafferTest.testTaskMutexWorkerRecursion()
+
+	def testAcquireOr( self ) :
+
+		GafferTest.testTaskMutexAcquireOr()
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/IECorePreviewTest/TaskMutexTest.py
+++ b/python/GafferTest/IECorePreviewTest/TaskMutexTest.py
@@ -62,10 +62,6 @@ class TaskMutexTest( GafferTest.TestCase ) :
 
 		GafferTest.testTaskMutexHeavyContention( False )
 
-	def testRecursion( self ) :
-
-		GafferTest.testTaskMutexRecursion()
-
 	def testWorkerRecursion( self ) :
 
 		GafferTest.testTaskMutexWorkerRecursion()

--- a/python/GafferTest/IECorePreviewTest/__init__.py
+++ b/python/GafferTest/IECorePreviewTest/__init__.py
@@ -1,0 +1,41 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+from TaskMutexTest import TaskMutexTest
+
+if __name__ == "__main__":
+	import unittest
+	unittest.main()

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -138,6 +138,8 @@ from BackgroundTaskTest import BackgroundTaskTest
 from ProcessMessageHandlerTest import ProcessMessageHandlerTest
 from MonitorAlgoTest import MonitorAlgoTest
 
+from IECorePreviewTest import *
+
 if __name__ == "__main__":
 	import unittest
 	unittest.main()

--- a/src/GafferTestModule/TaskMutexTest.cpp
+++ b/src/GafferTestModule/TaskMutexTest.cpp
@@ -1,0 +1,338 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "TaskMutexTest.h"
+
+#include "GafferTest/Assert.h"
+
+#include "Gaffer/Private/IECorePreview/ParallelAlgo.h"
+#include "Gaffer/Private/IECorePreview/TaskMutex.h"
+
+#include "boost/make_unique.hpp"
+
+#include "tbb/enumerable_thread_specific.h"
+#include "tbb/parallel_for.h"
+
+#include <thread>
+
+using namespace IECorePreview;
+using namespace boost::python;
+
+namespace
+{
+
+void testTaskMutex()
+{
+	// Mutex and bool used to model lazy initialisation.
+	TaskMutex mutex;
+	bool initialised = false;
+
+	// Tracking to see what various threads get up to.
+	tbb::enumerable_thread_specific<int> didInitialisation;
+	tbb::enumerable_thread_specific<int> didInitialisationTasks;
+	tbb::enumerable_thread_specific<int> gotLock;
+
+	// Lazy initialisation function, using an optimistic read lock
+	// and only upgrading to a write lock to perform initialisation.
+
+	auto initialise = [&]() {
+
+		TaskMutex::ScopedLock lock( mutex, /* write = */ false );
+		gotLock.local() = true;
+
+		if( !initialised )
+		{
+			lock.upgradeToWriter();
+			if( !initialised ) // Check again, because upgrading to writer may lose the lock temporarily.
+			{
+				// Simulate an expensive multithreaded
+				// initialisation process.
+				lock.execute(
+					[&]() {
+						tbb::parallel_for(
+							tbb::blocked_range<size_t>( 0, 1000000 ),
+							[&]( const tbb::blocked_range<size_t> &r ) {
+								didInitialisationTasks.local() = true;
+								std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
+							}
+						);
+					}
+				);
+				initialised = true;
+				didInitialisation.local() = true;
+			}
+		}
+	};
+
+	// Generate a bunch of tasks that will each try to
+	// do the lazy initialisation. Only one should do it,
+	// but the rest should help out in doing the work.
+
+	tbb::parallel_for(
+		tbb::blocked_range<size_t>( 0, 1000000 ),
+		[&]( const tbb::blocked_range<size_t> &r ) {
+			for( size_t i = r.begin(); i < r.end(); ++i )
+			{
+				initialise();
+			}
+		}
+	);
+
+	// Only one thread should have done the initialisation,
+	// but everyone should have got the lock, and everyone should
+	// have done some work.
+	GAFFERTEST_ASSERTEQUAL( didInitialisation.size(), 1 );
+	GAFFERTEST_ASSERTEQUAL( gotLock.size(), tbb::tbb_thread::hardware_concurrency() );
+	GAFFERTEST_ASSERTEQUAL( didInitialisationTasks.size(), tbb::tbb_thread::hardware_concurrency() );
+
+}
+
+void testTaskMutexWithinIsolate()
+{
+	TaskMutex mutex;
+
+	auto getMutexWithinIsolate = [&mutex]() {
+
+		ParallelAlgo::isolate(
+			[&mutex]() {
+				TaskMutex::ScopedLock lock( mutex );
+				std::this_thread::sleep_for( std::chrono::milliseconds( 1 ) );
+			}
+		);
+
+	};
+
+	ParallelAlgo::isolate(
+		[&]() {
+			tbb::parallel_for(
+				tbb::blocked_range<size_t>( 0, 1000000 ),
+				[&]( const tbb::blocked_range<size_t> &r ) {
+					getMutexWithinIsolate();
+				}
+			);
+		}
+	);
+
+	// This test was written to guard against deadlocks
+	// caused by an early version of TaskMutex. Hence
+	// it doesn't assert anything; instead we're just very
+	// happy if it gets this far.
+
+}
+
+void testTaskMutexJoiningOuterTasks()
+{
+	// Mutex and bool used to model lazy initialisation.
+	TaskMutex mutex;
+	bool initialised = false;
+
+	// Tracking to see what various threads get up to.
+	tbb::enumerable_thread_specific<int> didInitialisation;
+	tbb::enumerable_thread_specific<int> didInitialisationTasks;
+	tbb::enumerable_thread_specific<int> gotLock;
+
+	// Lazy initialisation function
+	auto initialise = [&]() {
+
+		TaskMutex::ScopedLock lock( mutex );
+		gotLock.local() = true;
+
+		if( !initialised )
+		{
+			// Simulate an expensive multithreaded
+			// initialisation process.
+			lock.execute(
+				[&]() {
+					tbb::parallel_for(
+						tbb::blocked_range<size_t>( 0, 1000000 ),
+						[&]( const tbb::blocked_range<size_t> &r ) {
+							didInitialisationTasks.local() = true;
+							std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
+						}
+					);
+				}
+			);
+			initialised = true;
+			didInitialisation.local() = true;
+		}
+	};
+
+	// Outer tasks which are performed within a TaskMutex of their own,
+	// but want to collaborate on the inner initialisation.
+
+	using TaskMutexPtr = std::unique_ptr<TaskMutex>;
+	std::vector<TaskMutexPtr> independentTasks;
+	for( size_t i = 0; i < tbb::tbb_thread::hardware_concurrency() * 1000; ++i )
+	{
+		independentTasks.push_back( boost::make_unique<TaskMutex>() );
+	}
+
+	tbb::parallel_for(
+		tbb::blocked_range<size_t>( 0, independentTasks.size() ),
+		[&]( const tbb::blocked_range<size_t> &r ) {
+			for( size_t i = r.begin(); i < r.end(); ++i )
+			{
+				TaskMutex::ScopedLock lock( *independentTasks[i] );
+				lock.execute(
+					[&]() {
+						initialise();
+					}
+				);
+			}
+		}
+	);
+
+	// Only one thread should have done the initialisation,
+	// but everyone should have got the lock, and everyone should
+	// have done some work.
+	GAFFERTEST_ASSERTEQUAL( didInitialisation.size(), 1 );
+	GAFFERTEST_ASSERTEQUAL( gotLock.size(), tbb::tbb_thread::hardware_concurrency() );
+	GAFFERTEST_ASSERTEQUAL( didInitialisationTasks.size(), tbb::tbb_thread::hardware_concurrency() );
+
+}
+
+void testTaskMutexHeavyContention( bool acceptWork )
+{
+	// Model what happens when initialisation has already occurred,
+	// and we just have lots of threads hammering away on the mutex,
+	// wanting to get in and out with just read access as quickly as
+	// possible.
+	TaskMutex mutex;
+	bool initialised = true;
+
+	tbb::parallel_for(
+		tbb::blocked_range<size_t>( 0, 1000000 ),
+		[&]( const tbb::blocked_range<size_t> &r ) {
+			for( size_t i = r.begin(); i < r.end(); ++i )
+			{
+				TaskMutex::ScopedLock lock( mutex, /* write = */ false, acceptWork );
+				GAFFERTEST_ASSERTEQUAL( initialised, true );
+			}
+		}
+	);
+}
+
+void testTaskMutexRecursion()
+{
+	TaskMutex mutex;
+
+	std::function<void ( int )> recurse;
+	recurse = [&mutex, &recurse]( int depth ) {
+		TaskMutex::ScopedLock lock( mutex );
+		GAFFERTEST_ASSERT( lock.recursive() );
+		if( depth > 100 )
+		{
+			return;
+		}
+		else
+		{
+			recurse( depth + 1 );
+		}
+	};
+
+	TaskMutex::ScopedLock lock( mutex );
+	lock.execute(
+		[&recurse] { recurse( 0 ); }
+	);
+}
+
+void testTaskMutexWorkerRecursion()
+{
+	TaskMutex mutex;
+	tbb::enumerable_thread_specific<int> gotLock;
+
+	std::function<void ( int )> recurse;
+	recurse = [&mutex, &gotLock, &recurse] ( int depth ) {
+
+		TaskMutex::ScopedLock lock( mutex );
+		GAFFERTEST_ASSERT( lock.recursive() );
+		gotLock.local() = true;
+
+		if( depth > 4 )
+		{
+			std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
+		}
+		else
+		{
+			tbb::parallel_for(
+				0, 4,
+				[&recurse, depth] ( int i ) {
+					recurse( depth + 1 );
+				}
+			);
+		}
+
+	};
+
+	TaskMutex::ScopedLock lock( mutex );
+	lock.execute(
+		[&recurse] { recurse( 0 ); }
+	);
+
+	GAFFERTEST_ASSERTEQUAL( gotLock.size(), tbb::tbb_thread::hardware_concurrency() );
+}
+
+void testTaskMutexAcquireOr()
+{
+	TaskMutex mutex;
+	TaskMutex::ScopedLock lock1( mutex );
+
+	TaskMutex::ScopedLock lock2;
+	bool workAvailable = true;
+	const bool acquired = lock2.acquireOr(
+		mutex, /* write = */ true,
+		[&workAvailable] ( bool wa ) { workAvailable = wa; return true; }
+	);
+
+	GAFFERTEST_ASSERT( !acquired );
+	GAFFERTEST_ASSERT( !workAvailable );
+
+}
+
+} // namespace
+
+void GafferTestModule::bindTaskMutexTest()
+{
+	def( "testTaskMutex", &testTaskMutex );
+	def( "testTaskMutexWithinIsolate", &testTaskMutexWithinIsolate );
+	def( "testTaskMutexJoiningOuterTasks", &testTaskMutexJoiningOuterTasks );
+	def( "testTaskMutexHeavyContention", &testTaskMutexHeavyContention );
+	def( "testTaskMutexRecursion", &testTaskMutexRecursion );
+	def( "testTaskMutexWorkerRecursion", &testTaskMutexWorkerRecursion );
+	def( "testTaskMutexAcquireOr", &testTaskMutexAcquireOr );
+}

--- a/src/GafferTestModule/TaskMutexTest.h
+++ b/src/GafferTestModule/TaskMutexTest.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
-//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,46 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GafferBindings/DependencyNodeBinding.h"
+#ifndef GAFFERTESTMODULE_TASKMUTEXTEST_H
+#define GAFFERTESTMODULE_TASKMUTEXTEST_H
 
-#include "GafferTest/ComputeNodeTest.h"
-#include "GafferTest/ContextTest.h"
-#include "GafferTest/DownstreamIteratorTest.h"
-#include "GafferTest/FilteredRecursiveChildIteratorTest.h"
-#include "GafferTest/MetadataTest.h"
-#include "GafferTest/MultiplyNode.h"
-#include "GafferTest/RecursiveChildIteratorTest.h"
-
-#include "TaskMutexTest.h"
-
-#include "IECorePython/ScopedGILRelease.h"
-
-using namespace boost::python;
-using namespace GafferTest;
-using namespace GafferTestModule;
-
-static void testMetadataThreadingWrapper()
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	testMetadataThreading();
-}
-
-BOOST_PYTHON_MODULE( _GafferTest )
+namespace GafferTestModule
 {
 
-	GafferBindings::DependencyNodeClass<MultiplyNode>();
+void bindTaskMutexTest();
 
-	def( "testRecursiveChildIterator", &testRecursiveChildIterator );
-	def( "testFilteredRecursiveChildIterator", &testFilteredRecursiveChildIterator );
-	def( "testMetadataThreading", &testMetadataThreadingWrapper );
-	def( "testManyContexts", &testManyContexts );
-	def( "testManySubstitutions", &testManySubstitutions );
-	def( "testManyEnvironmentSubstitutions", &testManyEnvironmentSubstitutions );
-	def( "testScopingNullContext", &testScopingNullContext );
-	def( "testEditableScope", &testEditableScope );
-	def( "testComputeNodeThreading", &testComputeNodeThreading );
-	def( "testDownstreamIterator", &testDownstreamIterator );
+} // namespace GafferTestModule
 
-	bindTaskMutexTest();
-
-}
+#endif // GAFFERTESTMODULE_TASKMUTEXTEST_H


### PR DESCRIPTION
This provides the foundations of a revamped caching scheme that I'll be introducing in a followup PR. The key addition is the TaskMutex class, which allows multiple waiting threads to collaborate on TBB tasks spawned by the holder of the mutex. This provides a mechanism for the lazy initialisation of shared resources.

I've put the new functionality in a private IECorePreview namespace, because although it definitely belongs in Cortex in the long run, I anticipate needing to iterate on it further before it is ready for that.

I've invited everyone to the review party, because I've been through enough botched iterations of this that I need all the help I can get. 