### PR TITLE
TransformTool : Fix crash in selection processing code

### DIFF
--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -578,7 +578,7 @@ void TransformTool::updateSelection() const
 			{
 				return false;
 			}
-			return a.path == lastSelectedPath;
+			return ( a.path != lastSelectedPath ) < ( b.path != lastSelectedPath );
 		}
 	);
 


### PR DESCRIPTION
The comparison function wasn't a "strict weak ordering", so we weren't meeting the [requirements](https://en.cppreference.com/w/cpp/named_req/Compare) of `std::sort()`. For specific selections, this could cause `sort()` to access invalid memory, causing crashes.

I've made this exact mistake [before](https://github.com/GafferHQ/gaffer/issues/1252), so next time you see me writing a comparison operator, ask me if I'm sure...
