### PR TITLE
Viewer : Prioritise update of objects being manipulated

### DIFF
--- a/include/GafferScene/RenderController.h
+++ b/include/GafferScene/RenderController.h
@@ -82,7 +82,7 @@ class GAFFERSCENE_API RenderController : public boost::signals::trackable
 		typedef std::function<void ( Gaffer::BackgroundTask::Status progress )> ProgressCallback;
 
 		void update( const ProgressCallback &callback = ProgressCallback() );
-		std::shared_ptr<Gaffer::BackgroundTask> updateInBackground( const ProgressCallback &callback = ProgressCallback() );
+		std::shared_ptr<Gaffer::BackgroundTask> updateInBackground( const ProgressCallback &callback = ProgressCallback(), const IECore::PathMatcher &priorityPaths = IECore::PathMatcher()  );
 
 		void updateMatchingPaths( const IECore::PathMatcher &pathsToUpdate, const ProgressCallback &callback = ProgressCallback() );
 

--- a/include/GafferSceneUI/SceneGadget.h
+++ b/include/GafferSceneUI/SceneGadget.h
@@ -110,6 +110,11 @@ class GAFFERSCENEUI_API SceneGadget : public GafferUI::Gadget
 		void setBlockingPaths( const IECore::PathMatcher &blockingPaths );
 		const IECore::PathMatcher &getBlockingPaths() const;
 
+		/// Specifies a set of paths that are given priorty when performing
+		/// asynchronous updates.
+		void setPriorityPaths( const IECore::PathMatcher &priorityPaths );
+		const IECore::PathMatcher &getPriorityPaths() const;
+
 		enum State
 		{
 			Paused,
@@ -173,6 +178,7 @@ class GAFFERSCENEUI_API SceneGadget : public GafferUI::Gadget
 
 		bool m_paused;
 		IECore::PathMatcher m_blockingPaths;
+		IECore::PathMatcher m_priorityPaths;
 		SceneGadgetSignal m_stateChangedSignal;
 
 		IECoreScenePreview::RendererPtr m_renderer;

--- a/include/GafferSceneUI/TransformTool.h
+++ b/include/GafferSceneUI/TransformTool.h
@@ -197,6 +197,7 @@ class GAFFERSCENEUI_API TransformTool : public GafferSceneUI::SelectionTool
 		bool keyPress( const GafferUI::KeyEvent &event );
 
 		boost::signals::scoped_connection m_contextChangedConnection;
+		boost::signals::scoped_connection m_preRenderConnection;
 
 		GafferUI::GadgetPtr m_handles;
 		bool m_handlesDirty;

--- a/include/GafferSceneUI/TransformTool.h
+++ b/include/GafferSceneUI/TransformTool.h
@@ -204,6 +204,7 @@ class GAFFERSCENEUI_API TransformTool : public GafferSceneUI::SelectionTool
 
 		mutable std::vector<Selection> m_selection;
 		mutable bool m_selectionDirty;
+		bool m_priorityPathsDirty;
 		SelectionChangedSignal m_selectionChangedSignal;
 
 		bool m_dragging;

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -1067,7 +1067,7 @@ void RenderController::update( const ProgressCallback &callback )
 	updateInternal( callback );
 }
 
-std::shared_ptr<Gaffer::BackgroundTask> RenderController::updateInBackground( const ProgressCallback &callback )
+std::shared_ptr<Gaffer::BackgroundTask> RenderController::updateInBackground( const ProgressCallback &callback, const IECore::PathMatcher &priorityPaths )
 {
 	if( !m_scene || !m_context )
 	{
@@ -1083,7 +1083,11 @@ std::shared_ptr<Gaffer::BackgroundTask> RenderController::updateInBackground( co
 	m_backgroundTask = ParallelAlgo::callOnBackgroundThread(
 		// Subject
 		m_scene.get(),
-		[this, callback] {
+		[this, callback, priorityPaths] {
+			if( !priorityPaths.isEmpty() )
+			{
+				updateInternal( callback, &priorityPaths );
+			}
 			updateInternal( callback );
 		}
 	);

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -188,6 +188,22 @@ const IECore::PathMatcher &SceneGadget::getBlockingPaths() const
 	return m_blockingPaths;
 }
 
+void SceneGadget::setPriorityPaths( const IECore::PathMatcher &priorityPaths )
+{
+	if( m_updateTask )
+	{
+		m_updateTask->cancelAndWait();
+		m_updateTask.reset();
+	}
+	m_priorityPaths = priorityPaths;
+	requestRender();
+}
+
+const IECore::PathMatcher &SceneGadget::getPriorityPaths() const
+{
+	return m_priorityPaths;
+}
+
 SceneGadget::State SceneGadget::state() const
 {
 	if( m_paused )
@@ -505,7 +521,7 @@ void SceneGadget::updateRenderer()
 	}
 
 	m_updateErrored = false;
-	m_updateTask = m_controller.updateInBackground( progressCallback );
+	m_updateTask = m_controller.updateInBackground( progressCallback, m_priorityPaths );
 	stateChangedSignal()( this );
 
 	// Give ourselves a 0.1s grace period in which we block

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -333,6 +333,7 @@ TransformTool::TransformTool( SceneView *view, const std::string &name )
 		m_mergeGroupId( 0 )
 {
 	view->viewportGadget()->addChild( m_handles );
+	m_handles->setVisible( false );
 
 	storeIndexOfNextChild( g_firstPlugIndex );
 
@@ -341,7 +342,6 @@ TransformTool::TransformTool( SceneView *view, const std::string &name )
 
 	scenePlug()->setInput( view->inPlug<ScenePlug>() );
 
-	view->viewportGadget()->preRenderSignal().connect( boost::bind( &TransformTool::preRender, this ) );
 	view->viewportGadget()->keyPressSignal().connect( boost::bind( &TransformTool::keyPress, this, ::_2 ) );
 	plugDirtiedSignal().connect( boost::bind( &TransformTool::plugDirtied, this, ::_1 ) );
 
@@ -467,6 +467,19 @@ void TransformTool::plugDirtied( const Gaffer::Plug *plug )
 	if( affectsHandles( plug ) )
 	{
 		m_handlesDirty = true;
+	}
+
+	if( plug == activePlug() )
+	{
+		if( activePlug()->getValue() )
+		{
+			m_preRenderConnection = view()->viewportGadget()->preRenderSignal().connect( boost::bind( &TransformTool::preRender, this ) );
+		}
+		else
+		{
+			m_preRenderConnection.disconnect();
+			m_handles->setVisible( false );
+		}
 	}
 }
 


### PR DESCRIPTION
It's unfortunately not uncommon for us to spend a substantial amount of time updating things that the user isn't particularly concerned about, such as the bounding boxes of collapsed scene locations. And depending on scene processing order, that can mean a laggy update to the things the user does care about, often an object they are manipulating with a TransformTool. This improves responsiveness in such situations by prioritising the update of the objects being manipulated so that they are updated before all other objects. We will of course be optimising the slow updates too, but in the meantime this is an easy win.