### PR TITLE
Docs style : Readability and appearance updates

### DIFF
--- a/doc/source/_static/gaffer.css
+++ b/doc/source/_static/gaffer.css
@@ -1,8 +1,33 @@
-/* ===================================
-CSS overrides for Gaffer documentation
-==================================== */
+/* ========================================
+    CSS overrides for Gaffer documentation
+======================================== */
 
-/* Match regular nav background to Gaffer brand colors */
+/* As of 2019, the most up-to-date reset */
+@import url("normalize.css");
+
+body {
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    text-align: left;
+    background-color: #fff;
+}
+
+/* ========================================
+    Navigation sidebar
+======================================== */
+
+/* Remove nav link dotted outline */
+.wy-menu-vertical a {
+    outline: none;
+}
+
+/* Remove on-click active link BG colour */
+.wy-menu-vertical a:active {
+    background-color: initial;
+}
+
+/* Match nav main BG to Gaffer brand colors */
 .wy-side-nav-search {
     background-color: #343131;
 }
@@ -12,7 +37,7 @@ CSS overrides for Gaffer documentation
     background-color: #b92227;
 }
 
-/* Increase nav version color visibility */
+/* Increase nav version text color visibility */
 .wy-side-nav-search > div.version {
     color: inherit;
 }
@@ -37,9 +62,32 @@ CSS overrides for Gaffer documentation
     background-color: white;
 }
 
-/* Make nav button color red on click */
-.wy-menu-vertical a:active {
-    background-color:#b92227;
+/* Give all nav links a highlight on hover */
+.wy-menu-vertical li.current a:hover {
+    background-color: rgba(255, 255, 255, 0.6) !important;
+    transition: background-color 0.1s linear;
+}
+
+/* Make all unrolled nav links the same color */
+.wy-menu-vertical li.toctree-l1.current li.toctree-l2 > a,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l3 > a,
+.wy-menu-vertical li.toctree-l3.current li.toctree-l4 > a {
+    background-color: #dddddd;
+    border: none;
+}
+
+/* Active nav links: adjust text weight, make duller, remove unnecessary border */
+.wy-menu-vertical li.on a,
+.wy-menu-vertical li.current > a {
+    font-weight: bolder;
+    background-color: #dddddd !important;
+    border: none;
+}
+
+/* Current nav link: make same colour as article BG */
+.wy-menu-vertical li.on a[href="#"],
+.wy-menu-vertical li.current > a[href="#"] {
+    background-color: rgb(252, 252, 252) !important;
 }
 
 /* Increase font size for mobile header title */
@@ -55,26 +103,153 @@ CSS overrides for Gaffer documentation
     top: 15px;
 }
 
+/* ========================================
+    Links
+======================================== */
+
 /* Add icon after external links */
 a[href^="http"]:after {
-    content: " " url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAVklEQVR4Xn3PgQkAMQhDUXfqTu7kTtkpd5RA8AInfArtQ2iRXFWT2QedAfttj2FsPIOE1eCOlEuoWWjgzYaB/IkeGOrxXhqB+uA9Bfcm0lAZuh+YIeAD+cAqSz4kCMUAAAAASUVORK5CYII=);
-    color: #2980B9;
+    content: "\a0\f08e";
+    font-family: FontAwesome;
+    font-size: 0.625em;
 }
 
-/* Fix fallback image text vertically alignment when inline */
-img {
-    vertical-align: initial;
+/* ========================================
+    Headings
+======================================== */
+
+/* Restyle headings. Objectives are:
+  1. Keep font sizes as small as possible.
+  2. Avoid Roboto-Slab (inappropriate as a heading font).
+  3. Make H2-H4 (most common) easily distinguishable without being distracting.
+  4. Make H5-H6 distinct, but assume they'll be used rarely (if ever).
+  */
+h1, h2, h3, h4, h5, h6 {
+    font-family: inherit;
+    font-weight: bolder;
+    margin: 2rem 0 0.5rem;
 }
 
-/* Make nested and serial headers more distinguishable */
+h1 {
+    font-size: 2rem;
+}
+
 h2 {
-    margin-top: 2em;
-    padding-bottom: 0.25em;
+    margin-bottom: 1rem;
     border-bottom: 1px solid #e1e4e5;
+    font-size: 1.5rem;
 }
 
 h3 {
-    font-size: 100%;
+    font-size: 1.25rem;
+}
+
+h4 {
+    font-size: 1rem;
+}
+
+h5, h6 {
+    color: #808080;
+}
+
+h5 {
+    font-size: 1rem;
+    letter-spacing: 1px;
+}
+
+h6 {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
+/* ========================================
+    Paragraphs
+======================================== */
+
+/* Override paragraph settings to conform to body */
+.rst-content p {
+    font-size: inherit;
+    line-height: 1.5;
+    margin-bottom: 1.5rem;
+}
+
+/* ========================================
+    Lists
+======================================== */
+
+/* Balance spacing of lists, nested lists, and their contents. Objectives are:
+  1. The same 1.5rem spacing between two <p>s before and after a top-level list (but not nested lists).
+  2. Consistent margins for images inside lists. Unfortunately, all images in Markdown are inline, making it impossible to distinguish between large and small images in pure CSS.
+  3. Small but noticeable spacing between each <li>.
+  4. Make line-height consistent with <body>.
+  */
+.rst-content .section ol,
+.rst-content .section ul {
+    margin-bottom: 1.5rem;
+    line-height: 1.5;
+}
+
+.rst-content .section ol ol, .rst-content .section ol ul,
+.rst-content .section ul ul, .rst-content .section ul ol {
+    margin-bottom: 0;
+}
+
+.rst-content .section ol p,
+.rst-content .section ul p {
+    margin-bottom: 0.5rem;
+}
+
+.rst-content .section ol li,
+.rst-content .section ul li {
+    margin-bottom: 0.5rem;
+}
+
+.rst-content .section ol > li:first-of-type,
+.rst-content .section ul > li:first-of-type {
+    margin-top: 0.5rem;
+}
+
+/* Adjust margins of admonitions inside lists */
+.rst-content .section ol .admonition,
+.rst-content .section ul .admonition {
+    margin-bottom: 0;
+}
+
+/* ========================================
+    Images
+======================================== */
+
+/* Conform reST figure bottom margin */
+.rst-content div.figure {
+    margin-bottom: 1.5rem;
+}
+
+/* Add border to figures */
+.rst-content .figure img {
+    border: 1px solid #e8e8e8;
+    border-radius: 2px;
+}
+
+/* Shrink caption text, adjust line height */
+p.caption {
+    margin-top: 0.5rem;
+    font-size: 0.875em;
+    line-height: 1.4em;
+}
+
+/* ========================================
+    Tables
+======================================== */
+
+/* Conform table font size */
+.wy-table td,
+.rst-content table.docutils td,
+.rst-content table.field-list td,
+.wy-table th,
+.rst-content table.docutils th,
+.rst-content table.field-list th {
+    font-size: 0.9375em;
 }
 
 /* Enable word-wrapping and multiple lines for table cells */
@@ -86,7 +261,7 @@ table.docutils td {
 /* Fix font size and spacing with multi-line table cells */
 table.docutils td p {
     font-size: inherit;
-    margin-bottom: 12px;
+    margin-bottom: 0.75rem;
 }
 
 /* Fix erroneous black middle borders in table headers */
@@ -94,16 +269,61 @@ table.docutils th.head {
     border-color: #e1e4e5;
 }
 
-/* Add custom keystroke class */
-kbd, code.kbd {
-    font-size: 0.9em;
-    border: 1px solid #888888;
-    border-radius: 3px;
-    background: #f5f5f5;
-    padding: 0 3px 1px 3px;
-    font-family: inherit;
+/* ========================================
+    Code formatting
+======================================== */
+
+/* Adjust code block */
+div[class^='highlight'] pre {
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.875em;
+}
+
+/* Adjust inline code */
+code.literal {
     color: #404040 !important;
 }
+
+/* Make inline code text dark with slightly dark bg */
+.rst-content code {
+    border: none;
+    background-color: rgba(255, 128, 128, 0.1);
+    padding: 2px 2px 1px 2px;
+    line-height: 0;
+    border-radius: 1px;
+    font-size: 0.875em;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+/* Add custom keystroke class */
+kbd, code.kbd {
+    display: inline-block;
+    line-height: 1.25;
+    font-size: 0.875em;
+    border: 1px solid #a0a0a0;
+    border-bottom-width: 2px;
+    border-radius: 3px;
+    background-color: #fcfcfc;
+    padding: 0 3px 1px;
+    min-width: 1.5em;
+    font-family: inherit;
+    color: #404040 !important;
+    vertical-align: text-bottom;
+    text-align: center;
+}
+
+/* Since we've made <kbd> inline-block, force the text to stick to the baseline */
+kbd > *, code.kbd > * {
+    vertical-align: baseline;
+}
+
+.rst-content .tip, .rst-content .note, .rst-content .important, .rst-content .caution,  .rst-content .warning {
+    margin-bottom: 1.5rem;
+}
+
+/* ========================================
+    Admonitions
+======================================== */
 
 /* Change icon of "Note" admonition to paperclip */
 .admonition.note p.first.admonition-title::before {

--- a/doc/source/_static/normalize.css
+++ b/doc/source/_static/normalize.css
@@ -1,0 +1,353 @@
+/*!
+ * normalize.css v8.0.1 (https://github.com/necolas/normalize.css)
+ * Copyright Nicolas Gallagher and Jonathan Neal
+ * Licensed under MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md)
+ */
+
+/* Document
+   ========================================================================== */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+
+ html {
+    line-height: 1.15; /* 1 */
+    -webkit-text-size-adjust: 100%; /* 2 */
+  }
+  
+  /* Sections
+     ========================================================================== */
+  
+  /**
+   * Remove the margin in all browsers.
+   */
+  
+  body {
+    margin: 0;
+  }
+  
+  /**
+   * Render the `main` element consistently in IE.
+   */
+  
+  main {
+    display: block;
+  }
+  
+  /**
+   * Correct the font size and margin on `h1` elements within `section` and
+   * `article` contexts in Chrome, Firefox, and Safari.
+   */
+  
+  h1 {
+    font-size: 2em;
+    margin: 0.67em 0;
+  }
+  
+  /* Grouping content
+     ========================================================================== */
+  
+  /**
+   * 1. Add the correct box sizing in Firefox.
+   * 2. Show the overflow in Edge and IE.
+   */
+  
+  hr {
+    box-sizing: content-box; /* 1 */
+    height: 0; /* 1 */
+    overflow: visible; /* 2 */
+  }
+  
+  /**
+   * 1. Correct the inheritance and scaling of font size in all browsers.
+   * 2. Correct the odd `em` font sizing in all browsers.
+   */
+  
+  pre {
+    font-family: monospace, monospace; /* 1 */
+    font-size: 1em; /* 2 */
+  }
+  
+  /* Text-level semantics
+     ========================================================================== */
+  
+  /**
+   * Remove the gray background on active links in IE 10.
+   */
+  
+  a {
+    background-color: transparent;
+  }
+  
+  /**
+   * 1. Remove the bottom border in Chrome 57-
+   * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+   */
+  
+  abbr[title] {
+    border-bottom: none; /* 1 */
+    text-decoration: underline; /* 2 */
+    text-decoration: underline dotted; /* 2 */
+  }
+  
+  /**
+   * Add the correct font weight in Chrome, Edge, and Safari.
+   */
+  
+  b,
+  strong {
+    font-weight: bolder;
+  }
+  
+  /**
+   * 1. Correct the inheritance and scaling of font size in all browsers.
+   * 2. Correct the odd `em` font sizing in all browsers.
+   */
+  
+  code,
+  kbd,
+  samp {
+    font-family: monospace, monospace; /* 1 */
+    font-size: 1em; /* 2 */
+  }
+  
+  /**
+   * Add the correct font size in all browsers.
+   */
+  
+  small {
+    font-size: 80%;
+  }
+  
+  /**
+   * Prevent `sub` and `sup` elements from affecting the line height in
+   * all browsers.
+   */
+  
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  
+  sub {
+    bottom: -0.25em;
+  }
+  
+  sup {
+    top: -0.5em;
+  }
+  
+  /* Embedded content
+     ========================================================================== */
+  
+  /**
+   * Remove the border on images inside links in IE 10.
+   */
+  
+  img {
+    border-style: none;
+  }
+  
+  /* Forms
+     ========================================================================== */
+  
+  /**
+   * 1. Change the font styles in all browsers.
+   * 2. Remove the margin in Firefox and Safari.
+   */
+  
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font-family: inherit; /* 1 */
+    font-size: 100%; /* 1 */
+    line-height: 1.15; /* 1 */
+    margin: 0; /* 2 */
+  }
+  
+  /**
+   * Show the overflow in IE.
+   * 1. Show the overflow in Edge.
+   */
+  
+  button,
+  input { /* 1 */
+    overflow: visible;
+  }
+  
+  /**
+   * Remove the inheritance of text transform in Edge, Firefox, and IE.
+   * 1. Remove the inheritance of text transform in Firefox.
+   */
+  
+  button,
+  select { /* 1 */
+    text-transform: none;
+  }
+  
+  /**
+   * Correct the inability to style clickable types in iOS and Safari.
+   */
+  
+  button,
+  [type="button"],
+  [type="reset"],
+  [type="submit"] {
+    -webkit-appearance: button;
+  }
+  
+  /**
+   * Remove the inner border and padding in Firefox.
+   */
+  
+  button::-moz-focus-inner,
+  [type="button"]::-moz-focus-inner,
+  [type="reset"]::-moz-focus-inner,
+  [type="submit"]::-moz-focus-inner {
+    border-style: none;
+    padding: 0;
+  }
+  
+  /**
+   * Restore the focus styles unset by the previous rule.
+   */
+  
+  button:-moz-focusring,
+  [type="button"]:-moz-focusring,
+  [type="reset"]:-moz-focusring,
+  [type="submit"]:-moz-focusring {
+    outline: 1px dotted ButtonText;
+  }
+  
+  /**
+   * Correct the padding in Firefox.
+   */
+  
+  fieldset {
+    padding: 0.35em 0.75em 0.625em;
+  }
+  
+  /**
+   * 1. Correct the text wrapping in Edge and IE.
+   * 2. Correct the color inheritance from `fieldset` elements in IE.
+   * 3. Remove the padding so developers are not caught out when they zero out
+   *    `fieldset` elements in all browsers.
+   */
+  
+  legend {
+    box-sizing: border-box; /* 1 */
+    color: inherit; /* 2 */
+    display: table; /* 1 */
+    max-width: 100%; /* 1 */
+    padding: 0; /* 3 */
+    white-space: normal; /* 1 */
+  }
+  
+  /**
+   * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+   */
+  
+  progress {
+    vertical-align: baseline;
+  }
+  
+  /**
+   * Remove the default vertical scrollbar in IE 10+.
+   */
+  
+  textarea {
+    overflow: auto;
+  }
+  
+  /**
+   * 1. Add the correct box sizing in IE 10.
+   * 2. Remove the padding in IE 10.
+   */
+  
+  [type="checkbox"],
+  [type="radio"] {
+    box-sizing: border-box; /* 1 */
+    padding: 0; /* 2 */
+  }
+  
+  /**
+   * Correct the cursor style of increment and decrement buttons in Chrome.
+   */
+  
+  [type="number"]::-webkit-inner-spin-button,
+  [type="number"]::-webkit-outer-spin-button {
+    height: auto;
+  }
+  
+  /**
+   * 1. Correct the odd appearance in Chrome and Safari.
+   * 2. Correct the outline style in Safari.
+   */
+  
+  [type="search"] {
+    -webkit-appearance: textfield; /* 1 */
+    outline-offset: -2px; /* 2 */
+  }
+  
+  /**
+   * Remove the inner padding in Chrome and Safari on macOS.
+   */
+  
+  [type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  
+  /**
+   * 1. Correct the inability to style clickable types in iOS and Safari.
+   * 2. Change font properties to `inherit` in Safari.
+   */
+  
+  ::-webkit-file-upload-button {
+    -webkit-appearance: button; /* 1 */
+    font: inherit; /* 2 */
+  }
+  
+  /* Interactive
+     ========================================================================== */
+  
+  /*
+   * Add the correct display in Edge, IE 10+, and Firefox.
+   */
+  
+  details {
+    display: block;
+  }
+  
+  /*
+   * Add the correct display in all browsers.
+   */
+  
+  summary {
+    display: list-item;
+  }
+  
+  /* Misc
+     ========================================================================== */
+  
+  /**
+   * Add the correct display in IE 10+.
+   */
+  
+  template {
+    display: none;
+  }
+  
+  /**
+   * Add the correct display in IE 10.
+   */
+  
+  [hidden] {
+    display: none;
+  }


### PR DESCRIPTION
General improvements to readability and appearance in the stylesheet. Most notably, this makes the  headings consistent, and the spacing between elements uniform.

- General : Improve style documentation
- General : Add normalize.css reset stylesheet
- General: Switch length units to `rem` where appropriate
- Nav : Clean up leftovers and inconsistencies with sphinx-rtd-theme
- Nav : Make current link more distinguishable
- Nav : Make active and inactive links more distinguishable
- Links : Switch to Font Awesome icon for external links
- Headings : Revamp headings to be consistent, distinguishable, and
  appropriate
- Lists : Conform margins so that lists flow properly with paragraphs
  and images
- Images : Add light border to figures
- Code : Reduce salience, color more like GitHub's code
- Keyboard visualizers: Give them a minimum width to appear more like
  real keys

Preview the changes as a whole: 
```
/home/michaeldu/dev/gafferDocsBuilds/docsStyleUpdates/html/index.html
```
Preview generic test page: 
```
/home/michaeldu/dev/gafferDocsBuilds/docsStyleUpdates/html/testpage.html
```

### Checklist ###
- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
