### PR TITLE
TaskParallel LRUCache Policy

### DIFF
--- a/include/Gaffer/Private/IECorePreview/LRUCache.h
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.h
@@ -58,6 +58,18 @@ class Serial;
 template<typename LRUCache>
 class Parallel;
 
+/// Threadsafe, `get()` collaborates on TBB tasks if another
+/// thread is already computing the value. Key type must have
+/// a `hash_value` implementation as described in the boost
+/// documentation.
+///
+/// > Note : There is measurable overhead in the task collaboration
+/// > mechanism, so if it is known that tasks will not be spawned for
+/// > `GetterFunction( getterKey )` you may define a `bool spawnsTasks( const GetterKey & )`
+/// > function that will be used to avoid the overhead.
+template<typename LRUCache>
+class TaskParallel;
+
 } // namespace LRUCachePolicy
 
 /// A mapping from keys to values, where values are computed from keys using a user

--- a/include/Gaffer/Private/IECorePreview/LRUCache.h
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.h
@@ -37,48 +37,64 @@
 
 #include "boost/function.hpp"
 #include "boost/noncopyable.hpp"
-#include "boost/unordered_map.hpp"
-
-#include "tbb/spin_mutex.h"
-#include "tbb/spin_rw_mutex.h"
-
-#include <functional>
-#include <memory>
-#include <vector>
+#include "boost/variant.hpp"
 
 namespace IECorePreview
 {
 
+namespace LRUCachePolicy
+{
+
+/// Not threadsafe. Either use from only a single thread
+/// or protect with an external mutex. Key type must have
+/// a `hash_value` implementation as described in the boost
+/// documentation.
+template<typename LRUCache>
+class Serial;
+
+/// Threadsafe, `get()` blocks if another thread is already
+/// computing the value. Key type must have a `hash_value`
+/// implementation as described in the boost documentation.
+template<typename LRUCache>
+class Parallel;
+
+} // namespace LRUCachePolicy
+
 /// A mapping from keys to values, where values are computed from keys using a user
 /// supplied function. Recently computed values are stored in the cache to accelerate
 /// subsequent lookups. Each value has a cost associated with it, and the cache has
-/// a maximum total cost above which it will remove the (approximately) least recently
-/// accessed items.
-///
-/// The Key type must be hashable using boost::hash().
+/// a maximum total cost above which it will remove the least recently accessed items.
 ///
 /// The Value type must be default constructible, copy constructible and assignable.
 /// Note that Values are returned by value, and erased by assigning a default constructed
 /// value. In practice this means that a smart pointer is the best choice of Value.
 ///
-/// \threading It is safe to call the methods of LRUCache from concurrent threads.
+/// The Policy determines the thread safety, eviction and performance characteristics
+/// of the cache. See the documentation for each individual policy in the LRUCachePolicy
+/// namespace.
+///
+/// The GetterKey may be used where the GetterFunction requires some auxiliary information
+/// in addition to the Key. It must be implicitly castable to Key, and all GetterKeys
+/// which yield the same Key must also yield the same results from the GetterFunction.
+///
 /// \ingroup utilityGroup
-template<typename Key, typename Value>
+template<typename Key, typename Value, template <typename> class Policy=LRUCachePolicy::Parallel, typename GetterKey=Key>
 class LRUCache : private boost::noncopyable
 {
 	public:
 
 		typedef size_t Cost;
+		typedef Key KeyType;
 
 		/// The GetterFunction is responsible for computing the value and cost for a cache entry
 		/// when given the key. It should throw a descriptive exception if it can't get the data for
-		/// any reason. It is unsafe to access the LRUCache itself from the GetterFunction.
-		typedef std::function<Value ( const Key &key, Cost &cost )> GetterFunction;
+		/// any reason.
+		typedef boost::function<Value ( const GetterKey &key, Cost &cost )> GetterFunction;
 		/// The optional RemovalCallback is called whenever an item is discarded from the cache.
-		///  It is unsafe to access the LRUCache itself from the RemovalCallback.
-		typedef std::function<void ( const Key &key, const Value &data )> RemovalCallback;
+		typedef boost::function<void ( const Key &key, const Value &data )> RemovalCallback;
 
-		LRUCache( GetterFunction getter, Cost maxCost = 500 );
+		LRUCache( GetterFunction getter );
+		LRUCache( GetterFunction getter, Cost maxCost );
 		LRUCache( GetterFunction getter, RemovalCallback removalCallback, Cost maxCost );
 		virtual ~LRUCache();
 
@@ -87,7 +103,7 @@ class LRUCache : private boost::noncopyable
 		/// cache at any time by operations on another thread, or may not
 		/// even be stored in the cache if it exceeds the maximum cost.
 		/// Throws if the item can not be computed.
-		Value get( const Key &key );
+		Value get( const GetterKey &key );
 
 		/// Adds an item to the cache directly, bypassing the GetterFunction.
 		/// Returns true for success and false on failure - failure can occur
@@ -125,6 +141,9 @@ class LRUCache : private boost::noncopyable
 		// Data
 		//////////////////////////////////////////////////////////////////////////
 
+		// Give Policy access to CacheEntry definitions.
+		friend class Policy<LRUCache>;
+
 		// A function for computing values, and one for notifying of removals.
 		GetterFunction m_getter;
 		RemovalCallback m_removalCallback;
@@ -132,244 +151,51 @@ class LRUCache : private boost::noncopyable
 		// Status of each item in the cache.
 		enum Status
 		{
-			New, // brand new unpopulated entry
-			Cached, // entry complete with value
-			TooCostly, // entry cost exceeds m_maxCost and therefore isn't stored
+			Uncached, // entry without valid value
+			Cached, // entry with valid value
 			Failed // m_getter failed when computing entry
 		};
 
-		// CacheEntry implementation - a single item of the cache.
+		// The type used to store a single cached item.
 		struct CacheEntry
 		{
-			CacheEntry(); // status == New
-			CacheEntry( const CacheEntry &other );
+			CacheEntry();
 
-			Value value; // value for this item
+			// We use a boost::variant to compactly store
+			// a union of the data needed for each Status.
+			//
+			// - Uncached : A boost::blank instance
+			// - Cached : The Value itself
+			// - Failed ; The exception thrown by the GetterFn
+			typedef boost::variant<boost::blank, Value, std::exception_ptr> State;
+
+			State state;
 			Cost cost; // the cost for this item
 
-			char status; // status of this item
-			bool recentlyUsed;
-		};
-
-		// Map from keys to items - this forms the basis of
-		// our cache.
-		typedef boost::unordered_map<Key, CacheEntry> Map;
-		typedef typename Map::value_type MapValue;
-
-		// In various use cases we need to support
-		// concurrent access from many threads, and it's
-		// important that we do this efficiently. Our
-		// map type is not threadsafe, and a global mutex
-		// would be inefficient, so we take a binned approach.
-		// We store N internal maps, and use the hash of the
-		// key to determine which particular map that key
-		// should be stored in. This means that provided
-		// different threads are accessing different map
-		// values, they don't contend for a mutex at all.
-		struct Bin
-		{
-			typedef tbb::spin_rw_mutex Mutex;
-			Map map;
-			Mutex mutex;
-		};
-
-		typedef std::vector<std::unique_ptr<Bin> > Bins;
-		Bins m_bins;
-
-		// Handle class to abstract away the binned
-		// storage strategy. Internally holds an iterator
-		// into one of the maps and holds the lock for
-		// that map. All access to the bins must be
-		// made through this class. Similar to an iterator
-		// interface, but without any copy or assignment
-		// operations, since those would require transfer
-		// of the internal lock, which is problematic.
-		class Handle : public boost::noncopyable
-		{
-
-			public :
-
-				Handle()
-					:	m_cache( nullptr ), m_binIndex( 0 )
-				{
-				}
-
-				~Handle()
-				{
-					release();
-				}
-
-				void begin( LRUCache *cache )
-				{
-					release();
-					m_cache = cache;
-					acquireBin( 0 );
-					m_it = map().begin();
-					whileAtEndMoveToNextBin();
-				}
-
-				// If write == false and createIfMissing == true, then a read lock is acquired
-				// if the item exists already, otherwise a write lock is acquired on a newly
-				// created item. Returns true if an item was created, false otherwise.
-				bool acquire( LRUCache *cache, const Key &key, bool write = true, bool createIfMissing = false )
-				{
-					release();
-					m_cache = cache;
-					acquireBin( binIndex( key ), write );
-
-					if( write && createIfMissing )
-					{
-						const std::pair<Iterator, bool> i = map().insert( MapValue( key, CacheEntry() ) );
-						m_it = i.first;
-						return i.second;
-					}
-					else
-					{
-						m_it = map().find( key );
-						if( m_it != map().end() )
-						{
-							return false;
-						}
-						else if( createIfMissing )
-						{
-							assert( write == false );
-							m_binLock.upgrade_to_writer();
-							m_it = map().insert( MapValue( key, CacheEntry() ) ).first;
-							return true;
-						}
-						else
-						{
-							release();
-							return false;
-						}
-					}
-				}
-
-				void upgradeToWriter()
-				{
-					const Key key = m_it->first;
-					if( m_binLock.upgrade_to_writer() )
-					{
-						// Clean upgrade to writer status
-						// without giving up read lock.
-						return;
-					}
-					else
-					{
-						// We have been upgraded to writer
-						// status, but we had to temporarily
-						// give up our lock to get there. Another
-						// thread may have invalidated our iterator,
-						// so get it again.
-						m_it = map().insert( MapValue( key, CacheEntry() ) ).first;
-					}
-				}
-
-				void release()
-				{
-					if( m_cache )
-					{
-						releaseBin();
-						m_cache = nullptr;
-					}
-				}
-
-				void increment()
-				{
-					m_it++;
-					whileAtEndMoveToNextBin();
-				}
-
-				void erase()
-				{
-					map().erase( m_it );
-				}
-
-				void eraseAndIncrement()
-				{
-					Iterator nextIt = m_it; nextIt++;
-					map().erase( m_it );
-					m_it = nextIt;
-					whileAtEndMoveToNextBin();
-				}
-
-				bool valid()
-				{
-					return m_cache && m_it != map().end();
-				}
-
-				MapValue &operator*()
-				{
-					return *m_it;
-				}
-
-				MapValue *operator->()
-				{
-					return &(*m_it);
-				}
-
-			private :
-
-				typedef typename Map::iterator Iterator;
-
-				LRUCache *m_cache;
-				size_t m_binIndex;
-				typename Bin::Mutex::scoped_lock m_binLock;
-				Iterator m_it;
-
-				Map &map()
-				{
-					return m_cache->m_bins[m_binIndex]->map;
-				}
-
-				void whileAtEndMoveToNextBin()
-				{
-					while( m_it == m_cache->m_bins[m_binIndex]->map.end() && m_binIndex < m_cache->m_bins.size() - 1 )
-					{
-						releaseBin();
-						acquireBin( m_binIndex + 1 );
-						m_it = map().begin();
-					}
-				}
-
-				void acquireBin( size_t binIndex, bool write = true )
-				{
-					m_binIndex = binIndex;
-					m_binLock.acquire( m_cache->m_bins[binIndex]->mutex, write );
-				}
-
-				void releaseBin()
-				{
-					m_binLock.release();
-				}
-
-				size_t binIndex( const Key &key ) const
-				{
-					return boost::hash<Key>()( key ) % m_cache->m_bins.size();
-				}
+			Status status() const;
 
 		};
 
-		// Total cost. We store the current cost atomically so it can be updated
-		// concurrently by multiple threads.
-		typedef tbb::atomic<Cost> AtomicCost;
-		AtomicCost m_currentCost;
+		// Policy. This is responsible for
+		// the internal storage for the cache.
+		Policy<LRUCache> m_policy;
+
 		Cost m_maxCost;
 
-		// These methods set/erase a cached value, updating the current
-		// cost appropriately. The caller must hold the lock for the bin
-		// containing the value.
-		bool setInternal( MapValue &mapValue, const Value &value, Cost cost );
-		bool eraseInternal( MapValue &mapValue );
+		// Methods
+		// =======
 
-		// When our current cost goes over the limit, we must discard
-		// cached values until the cost is back under the threshold.
-		// We do this by cycling through our cache using a "second chance"
-		// algorithm to determine what to remove. No locks must be held
-		// when calling limitCost().
-		tbb::spin_mutex m_limitCostMutex;
-		Key m_limitCostSweepPosition;
-		void limitCost();
+		// Updates the cached value and updates the current
+		// total cost.
+		bool setInternal( const Key &key, CacheEntry &cacheEntry, const Value &value, Cost cost );
+
+		// Removes any cached value and updates the current total
+		// cost.
+		bool eraseInternal( const Key &key, CacheEntry &cacheEntry );
+
+		// Removes items from the cache until the current cost is
+		// at or below the specified limit.
+		void limitCost( Cost cost );
 
 		static void nullRemovalCallback( const Key &key, const Value &value );
 

--- a/include/Gaffer/Private/IECorePreview/LRUCache.inl
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.inl
@@ -38,115 +38,627 @@
 
 #include "IECore/Exception.h"
 
+#include "boost/multi_index/hashed_index.hpp"
+#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/sequenced_index.hpp"
+#include "boost/multi_index_container.hpp"
+#include "boost/unordered_map.hpp"
+
+#include "tbb/spin_mutex.h"
+#include "tbb/spin_rw_mutex.h"
+#include "tbb/tbb_thread.h"
+
 #include <cassert>
-#include <thread>
+#include <iostream>
+#include <tuple>
+#include <vector>
 
 namespace IECorePreview
 {
 
-template<typename Key, typename Value>
-LRUCache<Key, Value>::CacheEntry::CacheEntry()
-	:	value(), cost( 0 ), status( New ), recentlyUsed( false )
+// Policies
+// =======================================================================
+//
+// The policies are responsible for implementing the principle
+// data structures of the cache. Conceptually they contain a mapping from
+// Key to CacheEntry and a separate list sorted in least-recently-used order.
+// In practice, any data structure can be used provided the interface
+// described below is presented. The required interface is documented
+// on the Serial policy only for simplicity.
+namespace LRUCachePolicy
+{
+
+enum AcquireMode
+{
+	FindReadable,
+	FindWritable,
+	// Writability of handle is determined
+	// by CacheEntry status - writable if
+	// Uncached and read only otherwise.
+	Insert,
+	InsertWritable
+};
+
+
+// Uses a boost::multi_index_container to implement a map
+// and list in a single container. This gives much improved
+// performance over separate containers because it halves the
+// allocations needed, and moving items within the list doesn't
+// require any allocation at all. We keep the list in exact LRU
+// order.
+template<typename LRUCache>
+class Serial
+{
+
+	public :
+
+		typedef typename LRUCache::CacheEntry CacheEntry;
+		typedef typename LRUCache::KeyType Key;
+
+		struct Item
+		{
+			Item( const Key &key )
+				:	key( key ), hasHandle( false )
+			{
+			}
+
+			Key key;
+			// multi_index_containers have const elements
+			// so you can't modify something being used as
+			// as key. we know that cacheEntry is not used
+			// as a key, so can safely make it mutable to
+			// get non-const access to it.
+			mutable CacheEntry cacheEntry;
+			mutable bool hasHandle;
+		};
+
+		typedef boost::multi_index_container<
+			Item,
+			boost::multi_index::indexed_by<
+				// First index is equivalent to std::unordered_map,
+				// using Item::key as the key.
+				boost::multi_index::hashed_unique<
+					boost::multi_index::member<Item, Key, &Item::key>
+				>,
+				// Second index is equivalent to std::list.
+				boost::multi_index::sequenced<>
+			>
+		> MapAndList;
+
+		typedef typename MapAndList::iterator MapIterator;
+		typedef typename MapAndList::template nth_index<1>::type List;
+
+		Serial()
+			:	currentCost( 0 )
+		{
+		}
+
+		// The Handle class provides controlled access to
+		// a CacheEntry stored within the policy. Handles
+		// provide read and possibly write access to the
+		// CacheEntry, depending on how they have been
+		// acquired. The Handle must be kept alive for as
+		// long as the CacheEntry is accessed.
+		struct Handle : private boost::noncopyable
+		{
+
+			Handle()
+				:	m_inited( false )
+			{
+			}
+
+			~Handle()
+			{
+				release();
+			}
+
+			// Read access to the underlying cache entry.
+			const CacheEntry &readable()
+			{
+				return m_it->cacheEntry;
+			}
+
+			// Write access to the underlying cache entry.
+			// Note that write access is not always permitted
+			// - see documentation for `acquire()` and
+			// AcquireMode.
+			CacheEntry &writable()
+			{
+				return m_it->cacheEntry;
+			}
+
+			void release()
+			{
+				if( m_inited )
+				{
+					assert( m_it->hasHandle );
+					m_it->hasHandle = false;
+					m_inited = false;
+				}
+			}
+
+			private :
+
+				void init( MapIterator it )
+				{
+					assert( !m_inited );
+					m_it = it;
+					assert( !m_it->hasHandle );
+					m_it->hasHandle = true;
+					m_inited = true;
+				}
+
+				friend class Serial;
+				MapIterator m_it;
+				bool m_inited;
+
+		};
+
+		// Acquires a handle for the given key. Whether the
+		// handle is writable or not is determined by the AcquireMode.
+		// Returns true on success and false if no entry was
+		// found.
+		bool acquire( const Key &key, Handle &handle, AcquireMode mode )
+		{
+			if( mode == Insert || mode == InsertWritable )
+			{
+				// Inserting via the map index automatically puts the new item
+				// at the back of the list.
+				std::pair<MapIterator, bool> i = m_mapAndList.insert( Item( key ) );
+				handle.init( i.first );
+				return true;
+			}
+			else
+			{
+				assert( mode == FindReadable || mode == FindWritable );
+				MapIterator it = m_mapAndList.find( key );
+				if( it == m_mapAndList.end() )
+				{
+					return false;
+				}
+				handle.init( it );
+				return true;
+			}
+		}
+
+		// Marks the CacheEntry referred to by the handle as recently
+		// used.
+		void push( Handle &handle )
+		{
+			List &list = m_mapAndList.template get<1>();
+			list.relocate( list.end(), list.iterator_to( *(handle.m_it) ) );
+		}
+
+		// Pops a copy of the least recently used CacheEntry from the policy,
+		// removing it from the internal storage. Returns true for success
+		// and false for failure.
+		bool pop( Key &key, CacheEntry &cacheEntry )
+		{
+			List &list = m_mapAndList.template get<1>();
+
+			// Find the first item that doesn't have a handle
+			// referring to it. Although we don't support threaded
+			// access, there may still be existing handles if the
+			// GetterFunction has reentered the cache with a call
+			// to `get( someOtherKey )`, and this inner call has
+			// then entered `limitCost()`.
+			typename List::iterator it = list.begin();
+			while( it != list.end() && it->hasHandle )
+			{
+				++it;
+			}
+
+			if( it == list.end() )
+			{
+				return false;
+			}
+
+			const Item &item = *it;
+
+			key = item.key;
+			cacheEntry = item.cacheEntry;
+
+			list.erase( it );
+
+			return true;
+		}
+
+		typename LRUCache::Cost currentCost;
+
+	private :
+
+		MapAndList m_mapAndList;
+
+};
+
+// Uses a binned map to allow concurrent map operations, and
+// uses a second-chance algorithm to avoid the serial operations
+// associated with managing an LRU list.
+template<typename LRUCache>
+class Parallel
+{
+
+	public :
+
+		typedef typename LRUCache::CacheEntry CacheEntry;
+		typedef typename LRUCache::KeyType Key;
+		typedef tbb::atomic<typename LRUCache::Cost> AtomicCost;
+
+		struct Item
+		{
+			Item() : recentlyUsed() {}
+			Item( const Key &key ) : key( key ), recentlyUsed() {}
+			Item( const Item &other ) : key( other.key ), cacheEntry( other.cacheEntry ), recentlyUsed() {}
+			Key key;
+			mutable CacheEntry cacheEntry;
+			// Mutex to protect cacheEntry.
+			typedef tbb::spin_rw_mutex Mutex;
+			mutable Mutex mutex;
+			// Flag used in second-chance algorithm.
+			mutable tbb::atomic<bool> recentlyUsed;
+		};
+
+		// We would love to use one of TBB's concurrent containers as
+		// our map, but we need the ability to insert, erase and iterate
+		// concurrently. The concurrent_unordered_map doesn't provide
+		// concurrent erase, and the concurrent_hash_map doesn't provide
+		// concurrent iteration. Instead we choose a non-threadsafe
+		// container, but split our storage into multiple bins with a
+		// container in each bin. This way concurrent operations do not
+		// contend on a lock unless they happen to target the same bin.
+		typedef boost::multi_index::multi_index_container<
+			Item,
+			boost::multi_index::indexed_by<
+				// Equivalent to std::unordered_map, using Item::key
+				// as the key. This actually has a couple of benefits
+				// over std::unordered_map :
+				//
+				// - Insertion does not invalidate existing iterators.
+				//   This allows us to store m_popIterator.
+				// - Lookup can be performed using types other than the
+				//   key. This provides the possibility of creating a
+				//   prehashed key prior to taking a Bin lock, although
+				//   this is not implemented here yet.
+				boost::multi_index::hashed_unique<
+					boost::multi_index::member<Item, Key, &Item::key>
+				>
+			>
+		> Map;
+
+		typedef typename Map::iterator MapIterator;
+
+		struct Bin
+		{
+			Bin() {}
+			Bin( const Bin &other ) : map( other.map ) {}
+			Bin &operator = ( const Bin &other ) { map = other.map; return *this; }
+			Map map;
+			typedef tbb::spin_rw_mutex Mutex;
+			Mutex mutex;
+		};
+
+		typedef std::vector<Bin> Bins;
+
+		Parallel()
+		{
+			m_bins.resize( tbb::tbb_thread::hardware_concurrency() );
+			m_popBinIndex = 0;
+			m_popIterator = m_bins[0].map.begin();
+			currentCost = 0;
+		}
+
+		struct Handle : private boost::noncopyable
+		{
+
+			Handle()
+				:	m_item( nullptr ), m_writable( false )
+			{
+			}
+
+			~Handle()
+			{
+			}
+
+			const CacheEntry &readable()
+			{
+				return m_item->cacheEntry;
+			}
+
+			CacheEntry &writable()
+			{
+				assert( m_writable );
+				return m_item->cacheEntry;
+			}
+
+			void release()
+			{
+				if( m_item )
+				{
+					m_itemLock.release();
+					m_item = nullptr;
+				}
+			}
+
+			private :
+
+				bool acquire( Bin &bin, const Key &key, AcquireMode mode )
+				{
+					assert( !m_item );
+
+					// Acquiring a handle requires taking two
+					// locks, first the lock for the Bin, and
+					// second the lock for the Item. We must be
+					// careful to avoid deadlock in the case of
+					// a GetterFunction which reenters the cache.
+
+					typename Bin::Mutex::scoped_lock binLock;
+					while( true )
+					{
+						// Acquire a lock on the bin, and get an iterator
+						// from the key. We optimistically assume the item
+						// may already be in the cache and first do a find()
+						// using a bin read lock. This gives us much better
+						// performance when many threads contend for items
+						// that are already in the cache.
+						binLock.acquire( bin.mutex, /* write = */ false );
+						MapIterator it = bin.map.find( key );
+						bool inserted = false;
+						if( it == bin.map.end() )
+						{
+							if( mode != Insert && mode != InsertWritable )
+							{
+								return false;
+							}
+							binLock.upgrade_to_writer();
+							std::tie<MapIterator, bool>( it, inserted ) = bin.map.insert( Item( key ) );
+						}
+						// Now try to get a lock on the item we want to
+						// acquire. When we've just inserted a new item
+						// we take a write lock directly, because we know
+						// we'll need to write to the new item. When insertion
+						// found a pre-existing item we optimistically take
+						// just a read lock, because it is faster when
+						// many threads just need to read from the same
+						// cached item.
+						m_writable = inserted || mode == FindWritable || mode == InsertWritable;
+
+						if( m_itemLock.try_acquire( it->mutex, /* write = */ m_writable ) )
+						{
+							if( !m_writable && mode == Insert && it->cacheEntry.status() == LRUCache::Uncached )
+							{
+								// We found an old item that doesn't have
+								// a value. This can either be because it
+								// was erased but hasn't been popped yet,
+								// or because the item was too big to fit
+								// in the cache. Upgrade to writer status
+								// so it can be updated in get().
+								m_itemLock.upgrade_to_writer();
+								m_writable = true;
+							}
+							// Success!
+							m_item = &*it;
+							return true;
+						}
+						else
+						{
+							// The Item lock is held by another thread.
+							// We must release the Bin lock and retry. This
+							// avoids deadlock when the GetterFunction holding
+							// the Item lock calls back into the cache and tries to
+							// access another item in the same Bin.
+							binLock.release();
+						}
+					}
+				}
+
+				friend class Parallel;
+
+				const Item *m_item;
+				typename Item::Mutex::scoped_lock m_itemLock;
+				bool m_writable;
+
+		};
+
+		bool acquire( const Key &key, Handle &handle, AcquireMode mode )
+		{
+			return handle.acquire( bin( key ), key, mode );
+		}
+
+		void push( Handle &handle )
+		{
+			// Simply mark the item as having been used
+			// recently. We will then give it a second chance
+			// in pop(), so it will not be evicted immediately.
+			// We don't need the handle to be writable to write
+			// here, because `recentlyUsed` is atomic.
+			handle.m_item->recentlyUsed = true;
+		}
+
+		bool pop( Key &key, CacheEntry &cacheEntry )
+		{
+			// Popping works by iterating the map until an item
+			// that has not been recently used is found. We store
+			// the current iteration position as m_popIterator and
+			// protect it with m_popMutex, taking the position that
+			// it is sufficient for only one thread to be limiting
+			// cost at any given time.
+			PopMutex::scoped_lock lock;
+			if( !lock.try_acquire( m_popMutex ) )
+			{
+				return false;
+			}
+
+			Bin *bin = &m_bins[m_popBinIndex];
+			typename Bin::Mutex::scoped_lock binLock( bin->mutex );
+
+			typename Item::Mutex::scoped_lock itemLock;
+			while( true )
+			{
+				// If we're at the end of this bin, advance to
+				// the next non-empty one.
+				const MapIterator emptySentinel = bin->map.end();
+				while( m_popIterator == bin->map.end() )
+				{
+					binLock.release();
+					m_popBinIndex = ( m_popBinIndex + 1 ) % m_bins.size();
+					bin = &m_bins[m_popBinIndex];
+					binLock.acquire( bin->mutex );
+					m_popIterator = bin->map.begin();
+					if( m_popIterator == emptySentinel )
+					{
+						// We've come full circle and all bins were empty.
+						return false;
+					}
+				}
+
+				if( itemLock.try_acquire( m_popIterator->mutex ) )
+				{
+					if( !m_popIterator->recentlyUsed )
+					{
+						// Pop this item.
+						key = m_popIterator->key;
+						cacheEntry = m_popIterator->cacheEntry;
+						// Now erase it from the bin.
+						// We must release the lock on the Item before erasing it,
+						// because we cannot release a lock on a mutex that is
+						// already destroyed. We know that no other thread can
+						// gain access to the item though, because they must
+						// acquire the Bin lock to do so, and we still hold the
+						// Bin lock.
+						itemLock.release();
+						m_popIterator = bin->map.erase( m_popIterator );
+						return true;
+					}
+					else
+					{
+						// Item has been used recently. Flag it so we
+						// can pop it next time round, unless another
+						// thread resets the flag.
+						m_popIterator->recentlyUsed = false;
+						itemLock.release();
+					}
+				}
+				else
+				{
+					// Failed to acquire the item lock. Some other
+					// thread is busy with this item, so we consider
+					// it to be recently used and just skip over it.
+				}
+
+				++m_popIterator;
+			}
+		}
+
+		AtomicCost currentCost;
+
+	private :
+
+		Bins m_bins;
+
+		Bin &bin( const Key &key )
+		{
+			size_t binIndex = boost::hash<Key>()( key ) % m_bins.size();
+			return m_bins[binIndex];
+		};
+
+		typedef tbb::spin_mutex PopMutex;
+		PopMutex m_popMutex;
+		size_t m_popBinIndex;
+		MapIterator m_popIterator;
+
+};
+
+} // namespace LRUCachePolicy
+
+// CacheEntry
+// =======================================================================
+
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::CacheEntry::CacheEntry()
+	:	cost( 0 )
 {
 }
 
-template<typename Key, typename Value>
-LRUCache<Key, Value>::CacheEntry::CacheEntry( const CacheEntry &other )
-	:	value( other.value ), cost( other.cost ), status( other.status ), recentlyUsed( other.recentlyUsed )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+typename LRUCache<Key, Value, Policy, GetterKey>::Status LRUCache<Key, Value, Policy, GetterKey>::CacheEntry::status() const
+{
+	return static_cast<Status>( state.which() );
+}
+
+// LRUCache
+// =======================================================================
+
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::LRUCache( GetterFunction getter )
+	:	m_getter( getter ), m_removalCallback( nullRemovalCallback ), m_maxCost( 500 )
 {
 }
 
-template<typename Key, typename Value>
-LRUCache<Key, Value>::LRUCache( GetterFunction getter, Cost maxCost )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::LRUCache( GetterFunction getter, Cost maxCost )
 	:	m_getter( getter ), m_removalCallback( nullRemovalCallback ), m_maxCost( maxCost )
 {
-	m_currentCost = 0;
-	for( size_t i = 0, e = std::thread::hardware_concurrency(); i < e; ++i )
-	{
-		m_bins.push_back( std::unique_ptr<Bin>( new Bin ) );
-	}
 }
 
-template<typename Key, typename Value>
-LRUCache<Key, Value>::LRUCache( GetterFunction getter, RemovalCallback removalCallback, Cost maxCost )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::LRUCache( GetterFunction getter, RemovalCallback removalCallback, Cost maxCost )
 	:	m_getter( getter ), m_removalCallback( removalCallback ), m_maxCost( maxCost )
 {
-	m_currentCost = 0;
-	for( size_t i = 0, e = std::thread::hardware_concurrency(); i < e; ++i )
+}
+
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::~LRUCache()
+{
+}
+
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+void LRUCache<Key, Value, Policy, GetterKey>::clear()
+{
+	Key key;
+	CacheEntry cacheEntry;
+	while( m_policy.pop( key, cacheEntry ) )
 	{
-		m_bins.push_back( std::unique_ptr<Bin>( new Bin ) );
+		eraseInternal( key, cacheEntry );
 	}
 }
 
-template<typename Key, typename Value>
-LRUCache<Key, Value>::~LRUCache()
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+void LRUCache<Key, Value, Policy, GetterKey>::setMaxCost( Cost maxCost )
 {
-}
-
-template<typename Key, typename Value>
-void LRUCache<Key, Value>::clear()
-{
-	Handle handle;
-	handle.begin( this );
-	while( handle.valid() )
+	if( maxCost >= m_maxCost )
 	{
-		eraseInternal( *handle );
-		handle.eraseAndIncrement();
+		m_maxCost = maxCost;
 	}
+	else
+	{
+		m_maxCost = maxCost;
+		limitCost( maxCost );
+	}
+
 }
 
-template<typename Key, typename Value>
-void LRUCache<Key, Value>::setMaxCost( Cost maxCost )
-{
-	m_maxCost = maxCost;
-	limitCost();
-}
-
-template<typename Key, typename Value>
-typename LRUCache<Key, Value>::Cost LRUCache<Key, Value>::getMaxCost() const
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+typename LRUCache<Key, Value, Policy, GetterKey>::Cost LRUCache<Key, Value, Policy, GetterKey>::getMaxCost() const
 {
 	return m_maxCost;
 }
 
-template<typename Key, typename Value>
-typename LRUCache<Key, Value>::Cost LRUCache<Key, Value>::currentCost() const
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+typename LRUCache<Key, Value, Policy, GetterKey>::Cost LRUCache<Key, Value, Policy, GetterKey>::currentCost() const
 {
-	return m_currentCost;
+	return m_policy.currentCost;
 }
 
-template<typename Key, typename Value>
-Value LRUCache<Key, Value>::get( const Key& key )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+Value LRUCache<Key, Value, Policy, GetterKey>::get( const GetterKey &key )
 {
-	Handle handle;
-	if( !handle.acquire( this, key, /* write = */ false, /* createIfMissing = */ true ) )
+	typename Policy<LRUCache>::Handle handle;
+	m_policy.acquire( key, handle, LRUCachePolicy::Insert );
+	const CacheEntry &cacheEntry = handle.readable();
+	const Status status = cacheEntry.status();
+
+	if( status==Uncached )
 	{
-		// We found an existing entry, and have a read lock for it.
-		// If the value is cached already and the recentlyUsed flag
-		// is already set, we have no need of a write lock at all.
-		// This gives us a significant performance boost when the
-		// cache is heavily contended on the same already-cached
-		// items.
-		const CacheEntry &cacheEntry = handle->second;
-		if( cacheEntry.status == Cached && cacheEntry.recentlyUsed )
-		{
-			return cacheEntry.value;
-		}
-		else
-		{
-			// Upgrade to writer and fall through to general case below.
-			handle.upgradeToWriter();
-		}
-	}
-
-	// We have a write lock, and the item may or may not be
-	// cached already.
-
-	CacheEntry &cacheEntry = handle->second;
-
-	if( cacheEntry.status==New || cacheEntry.status==TooCostly )
-	{
-		assert( cacheEntry.value==Value() );
-
 		Value value = Value();
 		Cost cost = 0;
 		try
@@ -155,181 +667,120 @@ Value LRUCache<Key, Value>::get( const Key& key )
 		}
 		catch( ... )
 		{
-			cacheEntry.status = Failed;
+			handle.writable().state = std::current_exception();
 			throw;
 		}
 
-		assert( cacheEntry.status != Cached ); // this would indicate that another thread somehow
-		assert( cacheEntry.status != Failed ); // loaded the same thing as us, which is not the intention.
+		assert( cacheEntry.status() != Cached ); // this would indicate that another thread somehow
+		assert( cacheEntry.status() != Failed ); // loaded the same thing as us, which is not the intention.
 
-		setInternal( *handle, value, cost );
-
-		assert( cacheEntry.status == Cached || cacheEntry.status == TooCostly );
+		setInternal( key, handle.writable(), value, cost );
+		m_policy.push( handle );
 
 		handle.release();
-		limitCost();
+		limitCost( m_maxCost );
 
 		return value;
 	}
-	else if( cacheEntry.status==Cached )
+	else if( status==Cached )
 	{
-		Value result = cacheEntry.value;
-		cacheEntry.recentlyUsed = true;
-		return result;
+		m_policy.push( handle );
+		return boost::get<Value>( cacheEntry.state );
 	}
 	else
 	{
-		assert( cacheEntry.status==Failed );
-		throw IECore::Exception( "Previous attempt to get item failed." );
+		std::rethrow_exception( boost::get<std::exception_ptr>( cacheEntry.state ) );
 	}
 }
 
-template<typename Key, typename Value>
-bool LRUCache<Key, Value>::set( const Key &key, const Value &value, Cost cost )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::set( const Key &key, const Value &value, Cost cost )
 {
-	Handle handle;
-	handle.acquire( this, key, /* write = */ true, /* createIfMissing = */ true );
-
-	const bool result = setInternal( *handle, value, cost );
-
+	typename Policy<LRUCache>::Handle handle;
+	m_policy.acquire( key, handle, LRUCachePolicy::InsertWritable );
+	bool result = setInternal( key, handle.writable(), value, cost );
+	m_policy.push( handle );
 	handle.release();
-	limitCost();
-
+	limitCost( m_maxCost );
 	return result;
 }
 
-template<typename Key, typename Value>
-bool LRUCache<Key, Value>::cached( const Key &key ) const
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::setInternal( const Key &key, CacheEntry &cacheEntry, const Value &value, Cost cost )
 {
-	Handle handle;
-	handle.acquire( const_cast<LRUCache *>( this ), key, /* write = */ false, /* createIfMissing = */ false );
-	return handle.valid() && handle->second.status == Cached;
+	eraseInternal( key, cacheEntry );
+
+	if( cost > m_maxCost )
+	{
+		return false;
+	}
+
+	cacheEntry.state = value;
+	cacheEntry.cost = cost;
+
+	m_policy.currentCost += cost;
+
+	return true;
 }
 
-template<typename Key, typename Value>
-bool LRUCache<Key, Value>::erase( const Key &key )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::cached( const Key &key ) const
 {
-	Handle handle;
-	handle.acquire( this, key, /* write = */ true, /* createIfMissing = */ false );
-	if( handle.valid() )
+	typename Policy<LRUCache>::Handle handle;
+	// Preferring const_cast over forcing all policies to implement
+	// a ConstHandle and const acquire() variant.
+	if( !const_cast<Policy<LRUCache> &>( m_policy ).acquire( key, handle, LRUCachePolicy::FindReadable ) )
 	{
-		eraseInternal( *handle );
-		handle.erase();
-		return true;
+		return false;
 	}
-	return false;
+
+	return handle.readable().status() == Cached;
 }
 
-template<typename Key, typename Value>
-bool LRUCache<Key, Value>::setInternal( MapValue &mapValue, const Value &value, Cost cost )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::erase( const Key &key )
 {
-	// Erase the old value, adjusting the current cost.
-	eraseInternal( mapValue );
-
-	// Store the new value if we can, and again adjust
-	// the current cost.
-	CacheEntry &cacheEntry = mapValue.second;
-	bool result = true;
-	if( cost <= m_maxCost )
+	typename Policy<LRUCache>::Handle handle;
+	if( !m_policy.acquire( key, handle, LRUCachePolicy::FindWritable ) )
 	{
-		cacheEntry.value = value;
-		cacheEntry.cost = cost;
-		cacheEntry.status = Cached;
-		cacheEntry.recentlyUsed = true;
-		m_currentCost += cost;
-	}
-	else
-	{
-		cacheEntry.status = TooCostly;
-		cacheEntry.recentlyUsed = false;
-		result = false;
+		return false;
 	}
 
-	return result;
+	return eraseInternal( key, handle.writable() );
 }
 
-template<typename Key, typename Value>
-bool LRUCache<Key, Value>::eraseInternal( MapValue &mapValue )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::eraseInternal( const Key &key, CacheEntry &cacheEntry )
 {
-	CacheEntry &cacheEntry = mapValue.second;
-	const Status originalStatus = (Status)cacheEntry.status;
-
-	if( originalStatus == Cached )
+	const Status status = cacheEntry.status();
+	if( status == Cached )
 	{
-		m_removalCallback( mapValue.first, cacheEntry.value );
-		m_currentCost -= cacheEntry.cost;
-		cacheEntry.value = Value();
+		m_removalCallback( key, boost::get<Value>( cacheEntry.state ) );
+		m_policy.currentCost -= cacheEntry.cost;
 	}
 
-	return originalStatus == Cached;
+	cacheEntry.state = boost::blank();
+	return status == Cached;
 }
 
-template<typename Key, typename Value>
-void LRUCache<Key, Value>::limitCost()
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+void LRUCache<Key, Value, Policy, GetterKey>::limitCost( Cost cost )
 {
-	tbb::spin_mutex::scoped_lock lock;
-	if( !lock.try_acquire( m_limitCostMutex ) )
+	Key key;
+	CacheEntry cacheEntry;
+	while( m_policy.currentCost > cost )
 	{
-		// Another thread is busy limiting the
-		// cost, so we don't need to.
-		return;
-	}
-
-	Handle handle;
-	handle.acquire( this, m_limitCostSweepPosition, /* write = */ true, /* createIfMissing = */ false );
-	if( !handle.valid() )
-	{
-		// This is our first sweep, or the entry
-		// was erased by clear() or erase(). Just
-		// start at the beginning.
-		handle.begin( this );
-	}
-
-	size_t numFullCycles = 0;
-	while( m_currentCost > m_maxCost && handle.valid() && numFullCycles < 100 )
-	{
-		if( !handle->second.recentlyUsed )
+		if( !m_policy.pop( key, cacheEntry ) )
 		{
-			eraseInternal( *handle );
-			handle.eraseAndIncrement();
+			break;
 		}
-		else
-		{
-			// We'll erase this guy text time round,
-			// if he hasn't been used by some other
-			// thread by then.
-			handle->second.recentlyUsed = false;
-			handle.increment();
-		}
-		if( !handle.valid() )
-		{
-			// We're at the end but may not have
-			// reduced the cost sufficiently yet,
-			// so wrap around.
-			handle.begin( this );
-			// In theory, our thread could end up
-			// in an endless cycle if other threads
-			// are busy pushing values into the cache
-			// faster than we can remove them. So we
-			// count the number of full cycles we've
-			// performed, and abort if it's getting
-			// costly - this will force another
-			// thread to pick up the work, so we can
-			// return to our caller.
-			numFullCycles++;
-		}
-	}
 
-	// Remember where we were so we can start in
-	// the same place next time around.
-	if( handle.valid() )
-	{
-		m_limitCostSweepPosition = handle->first;
+		eraseInternal( key, cacheEntry );
 	}
 }
 
-template<typename Key, typename Value>
-void LRUCache<Key, Value>::nullRemovalCallback( const Key &key, const Value &value )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+void LRUCache<Key, Value, Policy, GetterKey>::nullRemovalCallback( const Key &key, const Value &value )
 {
 }
 

--- a/include/Gaffer/Private/IECorePreview/LRUCache.inl
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.inl
@@ -98,7 +98,7 @@ class Serial
 		struct Item
 		{
 			Item( const Key &key )
-				:	key( key ), hasHandle( false )
+				:	key( key ), handleCount( 0 )
 			{
 			}
 
@@ -109,7 +109,7 @@ class Serial
 			// as a key, so can safely make it mutable to
 			// get non-const access to it.
 			mutable CacheEntry cacheEntry;
-			mutable bool hasHandle;
+			mutable size_t handleCount;
 		};
 
 		typedef boost::multi_index_container<
@@ -171,8 +171,8 @@ class Serial
 			{
 				if( m_inited )
 				{
-					assert( m_it->hasHandle );
-					m_it->hasHandle = false;
+					assert( m_it->handleCount );
+					m_it->handleCount--;
 					m_inited = false;
 				}
 			}
@@ -183,8 +183,7 @@ class Serial
 				{
 					assert( !m_inited );
 					m_it = it;
-					assert( !m_it->hasHandle );
-					m_it->hasHandle = true;
+					m_it->handleCount++;
 					m_inited = true;
 				}
 
@@ -243,7 +242,7 @@ class Serial
 			// to `get( someOtherKey )`, and this inner call has
 			// then entered `limitCost()`.
 			typename List::iterator it = list.begin();
-			while( it != list.end() && it->hasHandle )
+			while( it != list.end() && it->handleCount )
 			{
 				++it;
 			}

--- a/include/Gaffer/Private/IECorePreview/LRUCache.inl
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.inl
@@ -819,6 +819,7 @@ class TaskParallel
 								if( workAvailable )
 								{
 									assert( spawnsTasks );
+									(void)spawnsTasks;
 								}
 								// Release the bin lock prior to accepting work, because
 								// the work might involve recursion back into the cache,

--- a/include/Gaffer/Private/IECorePreview/LRUCache.inl
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.inl
@@ -36,6 +36,8 @@
 #ifndef IECOREPREVIEW_LRUCACHE_INL
 #define IECOREPREVIEW_LRUCACHE_INL
 
+#include "Gaffer/Private/IECorePreview/TaskMutex.h"
+
 #include "IECore/Exception.h"
 
 #include "boost/multi_index/hashed_index.hpp"
@@ -160,11 +162,32 @@ class Serial
 
 			// Write access to the underlying cache entry.
 			// Note that write access is not always permitted
-			// - see documentation for `acquire()` and
-			// AcquireMode.
+			// - see documentation for `isWritable()`.
 			CacheEntry &writable()
 			{
 				return m_it->cacheEntry;
+			}
+
+			// Returns true if it is OK to call `writable()`.
+			// This is typically determined by the AcquireMode
+			// passed to `acquire()`, with special cases for
+			// recursion.
+			bool isWritable() const
+			{
+				// Because this policy is serial, it would technically
+				// always be OK to write. But we return false for recursive
+				// calls to avoid unnecessary overhead updating the LRU list
+				// for inner calls.
+				return m_it->handleCount == 1;
+			}
+
+			// Executes the functor F. This is used to
+			// execute the GetterFunction, and allows the
+			// TaskParallel policy to support work sharing.
+			template<typename F>
+			void execute( F &&f )
+			{
+				f();
 			}
 
 			void release()
@@ -367,6 +390,17 @@ class Parallel
 			{
 				assert( m_writable );
 				return m_item->cacheEntry;
+			}
+
+			bool isWritable() const
+			{
+				return m_writable;
+			}
+
+			template<typename F>
+			void execute( F &&f )
+			{
+				f();
 			}
 
 			void release()
@@ -581,6 +615,385 @@ class Parallel
 
 };
 
+
+/// Used to determine if `GetterFunction( key )` will spawn tasks.
+/// If it is specialised to return false for certain keys, then
+/// some significant TBB task sharing overhead is avoided.
+template<typename Key>
+bool spawnsTasks( const Key &key )
+{
+	return true;
+}
+
+/// Thread-safe policy that uses TaskMutex so that threads waiting on
+/// the cache can still perform useful work.
+/// \todo This uses the same binned approach to map storage as the
+/// standard Parallel policy. Can we share the code by introducing some
+/// sort of ConcurrentBinnedMap? Alternatively, should we just replace
+/// the Parallel policy with the TaskParallel one?
+template<typename LRUCache>
+class TaskParallel
+{
+
+	public :
+
+		typedef typename LRUCache::CacheEntry CacheEntry;
+		typedef typename LRUCache::KeyType Key;
+		typedef tbb::atomic<typename LRUCache::Cost> AtomicCost;
+
+		struct Item
+		{
+			Item() : recentlyUsed() {}
+			Item( const Key &key ) : key( key ), recentlyUsed() {}
+			Item( const Item &other ) : key( other.key ), cacheEntry( other.cacheEntry ), recentlyUsed() {}
+			Key key;
+			mutable CacheEntry cacheEntry;
+			// Mutex to protect cacheEntry.
+			typedef TaskMutex Mutex;
+			mutable Mutex mutex;
+			// Flag used in second-chance algorithm.
+			mutable tbb::atomic<bool> recentlyUsed;
+		};
+
+		// We would love to use one of TBB's concurrent containers as
+		// our map, but we need the ability to insert, erase and iterate
+		// concurrently. The concurrent_unordered_map doesn't provide
+		// concurrent erase, and the concurrent_hash_map doesn't provide
+		// concurrent iteration. Instead we choose a non-threadsafe
+		// container, but split our storage into multiple bins with a
+		// container in each bin. This way concurrent operations do not
+		// contend on a lock unless they happen to target the same bin.
+		typedef boost::multi_index::multi_index_container<
+			Item,
+			boost::multi_index::indexed_by<
+				// Equivalent to std::unordered_map, using Item::key
+				// as the key. This actually has a couple of benefits
+				// over std::unordered_map :
+				//
+				// - Insertion does not invalidate existing iterators.
+				//   This allows us to store m_popIterator.
+				// - Lookup can be performed using types other than the
+				//   key. This provides the possibility of creating a
+				//   prehashed key prior to taking a Bin lock, although
+				//   this is not implemented here yet.
+				boost::multi_index::hashed_unique<
+					boost::multi_index::member<Item, Key, &Item::key>
+				>
+			>
+		> Map;
+
+		typedef typename Map::iterator MapIterator;
+
+		struct Bin
+		{
+			Bin() {}
+			Bin( const Bin &other ) : map( other.map ) {}
+			Bin &operator = ( const Bin &other ) { map = other.map; return *this; }
+			Map map;
+			typedef tbb::spin_rw_mutex Mutex;
+			Mutex mutex;
+		};
+
+		typedef std::vector<Bin> Bins;
+
+		TaskParallel()
+		{
+			m_bins.resize( tbb::tbb_thread::hardware_concurrency() );
+			m_popBinIndex = 0;
+			m_popIterator = m_bins[0].map.begin();
+			currentCost = 0;
+		}
+
+		struct Handle : private boost::noncopyable
+		{
+
+			Handle()
+				:	m_item( nullptr ), m_spawnsTasks( false )
+			{
+			}
+
+			~Handle()
+			{
+			}
+
+			const CacheEntry &readable()
+			{
+				return m_item->cacheEntry;
+			}
+
+			CacheEntry &writable()
+			{
+				assert( m_itemLock.lockType() == TaskMutex::ScopedLock::LockType::Write );
+				return m_item->cacheEntry;
+			}
+
+			// May return false for AcquireMode::Insert if a GetterFunction recurses.
+			bool isWritable() const
+			{
+				return m_itemLock.lockType() == Item::Mutex::ScopedLock::LockType::Write;
+			}
+
+			template<typename F>
+			void execute( F &&f )
+			{
+				if( m_spawnsTasks && m_itemLock.lockType() == TaskMutex::ScopedLock::LockType::Write )
+				{
+					// The getter function will spawn tasks. Execute
+					// it via the TaskMutex, so that other threads trying
+					// to access this cache item can help out. This also
+					// means that the getter is executed inside a task_arena,
+					// preventing it from stealing outer tasks that might try
+					// to get this item from the cache, leading to deadlock.
+					m_itemLock.execute( f );
+				}
+				else
+				{
+					// The getter won't do anything involving TBB tasks.
+					// Avoid the overhead of executing via the TaskMutex.
+					f();
+				}
+			}
+
+			void release()
+			{
+				if( m_item )
+				{
+					m_itemLock.release();
+					m_item = nullptr;
+				}
+			}
+
+			private :
+
+				bool acquire( Bin &bin, const Key &key, AcquireMode mode, bool spawnsTasks )
+				{
+					assert( !m_item );
+
+					// Acquiring a handle requires taking two
+					// locks, first the lock for the Bin, and
+					// second the lock for the Item. We must be
+					// careful to avoid deadlock in the case of
+					// a GetterFunction which reenters the cache.
+
+					typename Bin::Mutex::scoped_lock binLock;
+					while( true )
+					{
+						// Acquire a lock on the bin, and get an iterator
+						// from the key. We optimistically assume the item
+						// may already be in the cache and first do a find()
+						// using a bin read lock. This gives us much better
+						// performance when many threads contend for items
+						// that are already in the cache.
+						binLock.acquire( bin.mutex, /* write = */ false );
+						MapIterator it = bin.map.find( key );
+						bool inserted = false;
+						if( it == bin.map.end() )
+						{
+							if( mode != Insert && mode != InsertWritable )
+							{
+								return false;
+							}
+							binLock.upgrade_to_writer();
+							std::tie<MapIterator, bool>( it, inserted ) = bin.map.insert( Item( key ) );
+						}
+
+						// Now try to get a lock on the item we want to
+						// acquire. When we've just inserted a new item
+						// we take a write lock directly, because we know
+						// we'll need to write to the new item. When insertion
+						// found a pre-existing item we optimistically take
+						// just a read lock, because it is faster when
+						// many threads just need to read from the same
+						// cached item. We accept WorkerRead locks when necessary,
+						// to support Getter recursion.
+						TaskMutex::ScopedLock::LockType lockType = TaskMutex::ScopedLock::LockType::WorkerRead;
+						if( inserted || mode == FindWritable || mode == InsertWritable )
+						{
+							lockType = TaskMutex::ScopedLock::LockType::Write;
+						}
+
+						const bool acquired = m_itemLock.acquireOr(
+							it->mutex, lockType,
+							// Work accepter
+							[&binLock, &spawnsTasks] ( bool workAvailable ) {
+								if( workAvailable )
+								{
+									assert( spawnsTasks );
+								}
+								// Release the bin lock prior to accepting work, because
+								// the work might involve recursion back into the cache,
+								// thus requiring the bin lock.
+								binLock.release();
+								return true;
+							}
+						);
+
+						if( acquired )
+						{
+							if(
+								m_itemLock.lockType() == TaskMutex::ScopedLock::LockType::Read &&
+								mode == Insert && it->cacheEntry.status() == LRUCache::Uncached
+							)
+							{
+								// We found an old item that doesn't have
+								// a value. This can either be because it
+								// was erased but hasn't been popped yet,
+								// or because the item was too big to fit
+								// in the cache. Upgrade to writer status
+								// so it can be updated in get().
+								m_itemLock.upgradeToWriter();
+							}
+							// Success!
+							m_item = &*it;
+							m_spawnsTasks = spawnsTasks;
+							return true;
+						}
+					}
+				}
+
+				friend class TaskParallel;
+
+				const Item *m_item;
+				typename Item::Mutex::ScopedLock m_itemLock;
+				bool m_spawnsTasks;
+
+		};
+
+		/// Templated so that we can be called with the GetterKey as
+		/// well as the regular Key.
+		template<typename K>
+		bool acquire( const K &key, Handle &handle, AcquireMode mode )
+		{
+			return handle.acquire(
+				bin( key ), key, mode,
+				/// Only accept work for Insert mode, because that is
+				/// the one used by `get()`. We don't want to attempt
+				/// to do work in `set()`, because there will be no work
+				/// to do. `TaskMutex::ScopedLock::execute()` has significant
+				/// overhead, so we also want to avoid it if tasks won't
+				/// be spawned for a particular key.
+				mode == AcquireMode::Insert && spawnsTasks( key )
+			);
+		}
+
+		void push( Handle &handle )
+		{
+			// Simply mark the item as having been used
+			// recently. We will then give it a second chance
+			// in pop(), so it will not be evicted immediately.
+			// We don't need the handle to be writable to write
+			// here, because `recentlyUsed` is atomic.
+			handle.m_item->recentlyUsed = true;
+		}
+
+		bool pop( Key &key, CacheEntry &cacheEntry )
+		{
+			// Popping works by iterating the map until an item
+			// that has not been recently used is found. We store
+			// the current iteration position as m_popIterator and
+			// protect it with m_popMutex, taking the position that
+			// it is sufficient for only one thread to be limiting
+			// cost at any given time.
+			PopMutex::scoped_lock lock;
+			if( !lock.try_acquire( m_popMutex ) )
+			{
+				return false;
+			}
+
+			Bin *bin = &m_bins[m_popBinIndex];
+			typename Bin::Mutex::scoped_lock binLock( bin->mutex );
+
+			typename Item::Mutex::ScopedLock itemLock;
+			int numFullIterations = 0;
+			while( true )
+			{
+				// If we're at the end of this bin, advance to
+				// the next non-empty one.
+				const MapIterator emptySentinel = bin->map.end();
+				while( m_popIterator == bin->map.end() )
+				{
+					binLock.release();
+					m_popBinIndex = ( m_popBinIndex + 1 ) % m_bins.size();
+					bin = &m_bins[m_popBinIndex];
+					binLock.acquire( bin->mutex );
+					m_popIterator = bin->map.begin();
+					if( m_popIterator == emptySentinel )
+					{
+						// We've come full circle and all bins were empty.
+						return false;
+					}
+					else if( m_popBinIndex == 0 )
+					{
+						if( numFullIterations++ > 50 )
+						{
+							// We're not empty, but we've been around and around
+							// without finding anything to pop. This could happen
+							// if other threads are frantically setting
+							// the `recentlyUsed` flag or if `clear()` is
+							// called from `get()`, while `get()` holds the lock
+							// on the only item we could pop.
+							return false;
+						}
+					}
+				}
+
+				if( itemLock.tryAcquire( m_popIterator->mutex ) )
+				{
+					if( !m_popIterator->recentlyUsed )
+					{
+						// Pop this item.
+						key = m_popIterator->key;
+						cacheEntry = m_popIterator->cacheEntry;
+						// Now erase it from the bin.
+						// We must release the lock on the Item before erasing it,
+						// because we cannot release a lock on a mutex that is
+						// already destroyed. We know that no other thread can
+						// gain access to the item though, because they must
+						// acquire the Bin lock to do so, and we still hold the
+						// Bin lock.
+						itemLock.release();
+						m_popIterator = bin->map.erase( m_popIterator );
+						return true;
+					}
+					else
+					{
+						// Item has been used recently. Flag it so we
+						// can pop it next time round, unless another
+						// thread resets the flag.
+						m_popIterator->recentlyUsed = false;
+						itemLock.release();
+					}
+				}
+				else
+				{
+					// Failed to acquire the item lock. Some other
+					// thread is busy with this item, so we consider
+					// it to be recently used and just skip over it.
+				}
+
+				++m_popIterator;
+			}
+		}
+
+		AtomicCost currentCost;
+
+	private :
+
+		Bins m_bins;
+
+		Bin &bin( const Key &key )
+		{
+			size_t binIndex = boost::hash<Key>()( key ) % m_bins.size();
+			return m_bins[binIndex];
+		};
+
+		typedef tbb::spin_mutex PopMutex;
+		PopMutex m_popMutex;
+		size_t m_popBinIndex;
+		MapIterator m_popIterator;
+
+};
+
 } // namespace LRUCachePolicy
 
 // CacheEntry
@@ -676,22 +1089,28 @@ Value LRUCache<Key, Value, Policy, GetterKey>::get( const GetterKey &key )
 		Cost cost = 0;
 		try
 		{
-			value = m_getter( key, cost );
+			handle.execute( [this, &value, &key, &cost] { value = m_getter( key, cost ); } );
 		}
 		catch( ... )
 		{
-			handle.writable().state = std::current_exception();
+			if( handle.isWritable() )
+			{
+				handle.writable().state = std::current_exception();
+			}
 			throw;
 		}
 
-		assert( cacheEntry.status() != Cached ); // this would indicate that another thread somehow
-		assert( cacheEntry.status() != Failed ); // loaded the same thing as us, which is not the intention.
+		if( handle.isWritable() )
+		{
+			assert( cacheEntry.status() != Cached ); // this would indicate that another thread somehow
+			assert( cacheEntry.status() != Failed ); // loaded the same thing as us, which is not the intention.
 
-		setInternal( key, handle.writable(), value, cost );
-		m_policy.push( handle );
+			setInternal( key, handle.writable(), value, cost );
+			m_policy.push( handle );
 
-		handle.release();
-		limitCost( m_maxCost );
+			handle.release();
+			limitCost( m_maxCost );
+		}
 
 		return value;
 	}
@@ -711,6 +1130,7 @@ bool LRUCache<Key, Value, Policy, GetterKey>::set( const Key &key, const Value &
 {
 	typename Policy<LRUCache>::Handle handle;
 	m_policy.acquire( key, handle, LRUCachePolicy::InsertWritable );
+	assert( handle.isWritable() );
 	bool result = setInternal( key, handle.writable(), value, cost );
 	m_policy.push( handle );
 	handle.release();
@@ -759,6 +1179,7 @@ bool LRUCache<Key, Value, Policy, GetterKey>::erase( const Key &key )
 		return false;
 	}
 
+	assert( handle.isWritable() );
 	return eraseInternal( key, handle.writable() );
 }
 

--- a/include/Gaffer/Private/IECorePreview/TaskMutex.h
+++ b/include/Gaffer/Private/IECorePreview/TaskMutex.h
@@ -167,7 +167,7 @@ class TaskMutex : boost::noncopyable
 
 					ExecutionStateMutex::scoped_lock executionStateLock( m_mutex->m_executionStateMutex );
 					assert( !m_mutex->m_executionState );
-					m_mutex->m_executionState = std::make_shared<ExecutionState>();
+					m_mutex->m_executionState = new ExecutionState;
 					executionStateLock.release();
 
 					// Wrap `f` to capture any exceptions it throws. If we allow
@@ -375,7 +375,7 @@ class TaskMutex : boost::noncopyable
 
 		// The mechanism we use to allow waiting threads
 		// to participate in the work done by `execute()`.
-		struct ExecutionState : private boost::noncopyable
+		struct ExecutionState : public IECore::RefCounted
 		{
 			ExecutionState()
 				:	arenaObserver( arena )
@@ -395,7 +395,7 @@ class TaskMutex : boost::noncopyable
 			// currently inside the arena.
 			ArenaObserver arenaObserver;
 		};
-		typedef std::shared_ptr<ExecutionState> ExecutionStatePtr;
+		IE_CORE_DECLAREPTR( ExecutionState );
 
 		typedef tbb::spin_mutex ExecutionStateMutex;
 		ExecutionStateMutex m_executionStateMutex; // Protects m_executionState

--- a/python/GafferTest/IECorePreviewTest/LRUCacheTest.py
+++ b/python/GafferTest/IECorePreviewTest/LRUCacheTest.py
@@ -1,0 +1,175 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import GafferTest
+
+class LRUCacheTest( GafferTest.TestCase ) :
+
+	def test100PercentOfWorkingSetSerial( self ) :
+
+		GafferTest.testLRUCache( "serial", numIterations = 100000, numValues = 100, maxCost = 100 )
+
+	def test100PercentOfWorkingSetParallel( self ) :
+
+		GafferTest.testLRUCache( "parallel", numIterations = 100000, numValues = 100, maxCost = 100 )
+
+	def test100PercentOfWorkingSetTaskParallel( self ) :
+
+		GafferTest.testLRUCache( "taskParallel", numIterations = 100000, numValues = 100, maxCost = 100 )
+
+	def test90PercentOfWorkingSetSerial( self ) :
+
+		GafferTest.testLRUCache( "serial", numIterations = 100000, numValues = 100, maxCost = 90 )
+
+	def test90PercentOfWorkingSetParallel( self ) :
+
+		GafferTest.testLRUCache( "parallel", numIterations = 100000, numValues = 100, maxCost = 90 )
+
+	def test90PercentOfWorkingSetTaskParallel( self ) :
+
+		GafferTest.testLRUCache( "taskParallel", numIterations = 100000, numValues = 100, maxCost = 90 )
+
+	def test2PercentOfWorkingSetSerial( self ) :
+
+		GafferTest.testLRUCache( "serial", numIterations = 100000, numValues = 100, maxCost = 2 )
+
+	def test2PercentOfWorkingSetParallel( self ) :
+
+		GafferTest.testLRUCache( "parallel", numIterations = 100000, numValues = 100, maxCost = 2 )
+
+	def test2PercentOfWorkingSetTaskParallel( self ) :
+
+		GafferTest.testLRUCache( "taskParallel", numIterations = 10000, numValues = 100, maxCost = 2 )
+
+	def testRemovalCallbackSerial( self ) :
+
+		GafferTest.testLRUCacheRemovalCallback( "serial" )
+
+	def testRemovalCallbackParallel( self ) :
+
+		GafferTest.testLRUCacheRemovalCallback( "parallel" )
+
+	def testRemovalCallbackTaskParallel( self ) :
+
+		GafferTest.testLRUCacheRemovalCallback( "taskParallel" )
+
+	def testClearAndGetSerial( self ) :
+
+		GafferTest.testLRUCache( "serial", numIterations = 100000, numValues = 1000, maxCost = 90, clearFrequency = 20 )
+
+	def testClearAndGetParallel( self ) :
+
+		GafferTest.testLRUCache( "parallel", numIterations = 100000, numValues = 1000, maxCost = 90, clearFrequency = 20 )
+
+	def testClearAndGetTaskParallel( self ) :
+
+		GafferTest.testLRUCache( "taskParallel", numIterations = 10000, numValues = 1000, maxCost = 90, clearFrequency = 20 )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testContentionForOneItemSerial( self ) :
+
+		GafferTest.testLRUCacheContentionForOneItem( "serial" )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testContentionForOneItemParallel( self ) :
+
+		GafferTest.testLRUCacheContentionForOneItem( "parallel" )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testContentionForOneItemTaskParallel( self ) :
+
+		GafferTest.testLRUCacheContentionForOneItem( "taskParallel" )
+
+	def testRecursionSerial( self ) :
+
+		GafferTest.testLRUCacheRecursion( "serial", numIterations = 100000, numValues = 10000, maxCost = 10000 )
+
+	def testRecursionParallel( self ) :
+
+		GafferTest.testLRUCacheRecursion( "parallel", numIterations = 100000, numValues = 10000, maxCost = 10000 )
+
+	def testRecursionTaskParallel( self ) :
+
+		GafferTest.testLRUCacheRecursion( "taskParallel", numIterations = 100000, numValues = 10000, maxCost = 10000 )
+
+	def testRecursionWithEvictionsSerial( self ) :
+
+		GafferTest.testLRUCacheRecursion( "serial", numIterations = 100000, numValues = 1000, maxCost = 100 )
+
+	def testRecursionWithEvictionsParallel( self ) :
+
+		GafferTest.testLRUCacheRecursion( "parallel", numIterations = 100000, numValues = 1000, maxCost = 100 )
+
+	def testRecursionWithEvictionsTaskParallel( self ) :
+
+		GafferTest.testLRUCacheRecursion( "taskParallel", numIterations = 100000, numValues = 1000, maxCost = 100 )
+
+	def testRecursionOnOneItemSerial( self ) :
+
+		GafferTest.testLRUCacheRecursionOnOneItem( "serial" )
+
+	def testRecursionOnOneItemTaskParallel( self ) :
+
+		GafferTest.testLRUCacheRecursionOnOneItem( "taskParallel" )
+
+	def testClearFromGetSerial( self ) :
+
+		GafferTest.testLRUCacheClearFromGet( "serial" )
+
+	def testClearFromGetParallel( self ) :
+
+		GafferTest.testLRUCacheClearFromGet( "parallel" )
+
+	def testClearFromGetTaskParallel( self ) :
+
+		GafferTest.testLRUCacheClearFromGet( "taskParallel" )
+
+	def testExceptionsSerial( self ) :
+
+		GafferTest.testLRUCacheExceptions( "serial" )
+
+	def testExceptionsParallel( self ) :
+
+		GafferTest.testLRUCacheExceptions( "parallel" )
+
+	def testExceptionsTaskParallel( self ) :
+
+		GafferTest.testLRUCacheExceptions( "taskParallel" )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/IECorePreviewTest/TaskMutexTest.py
+++ b/python/GafferTest/IECorePreviewTest/TaskMutexTest.py
@@ -70,5 +70,13 @@ class TaskMutexTest( GafferTest.TestCase ) :
 
 		GafferTest.testTaskMutexAcquireOr()
 
+	def testExceptions( self ) :
+
+		GafferTest.testTaskMutexExceptions()
+
+	def testWorkerExceptions( self ) :
+
+		GafferTest.testTaskMutexWorkerExceptions()
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/IECorePreviewTest/__init__.py
+++ b/python/GafferTest/IECorePreviewTest/__init__.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+from LRUCacheTest import LRUCacheTest
 from TaskMutexTest import TaskMutexTest
 
 if __name__ == "__main__":

--- a/src/GafferTestModule/LRUCacheTest.cpp
+++ b/src/GafferTestModule/LRUCacheTest.cpp
@@ -1,0 +1,509 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "LRUCacheTest.h"
+
+#include "GafferTest/Assert.h"
+
+#include "Gaffer/Private/IECorePreview/LRUCache.h"
+
+#include "tbb/parallel_for.h"
+
+using namespace IECorePreview;
+using namespace boost::python;
+
+namespace
+{
+
+// Nasty template jiggery-pokery that allows us to dispatch the same
+// test code for difference LRUCache policies.
+template<template<template<typename> class> class F>
+struct DispatchTest
+{
+
+	template<typename... Args>
+	void operator()( const std::string &policy, Args&&... args )
+	{
+		if( policy == "serial" )
+		{
+			F<LRUCachePolicy::Serial> f( std::forward<Args>( args )... );
+			// Use an arena to limit any parallel TBB work to 1
+			// thread, since Serial policy is not threadsafe.
+			tbb::task_arena arena( 1 );
+			arena.execute(
+				[&f]{ f(); }
+			);
+		}
+		else if( policy == "parallel" )
+		{
+			F<LRUCachePolicy::Parallel> f( std::forward<Args>( args )... ); f();
+		}
+		else if( policy == "taskParallel" )
+		{
+			F<LRUCachePolicy::TaskParallel> f( std::forward<Args>( args )... ); f();
+		}
+		else
+		{
+			GAFFERTEST_ASSERT( false );
+		}
+	}
+
+};
+
+template<template<typename> class Policy>
+struct TestLRUCache
+{
+
+	TestLRUCache( int numIterations, int numValues, int maxCost, int clearFrequency )
+		:	m_numIterations( numIterations ), m_numValues( numValues ), m_maxCost( maxCost ), m_clearFrequency( clearFrequency )
+	{
+	}
+
+	void operator()()
+	{
+		typedef LRUCache<int, int, Policy> Cache;
+		Cache cache(
+			[]( int key, size_t &cost ) { cost = 1; return key; },
+			m_maxCost
+		);
+
+		tbb::parallel_for(
+			tbb::blocked_range<size_t>( 0, m_numIterations ),
+			[&]( const tbb::blocked_range<size_t> &r ) {
+				for( size_t i=r.begin(); i!=r.end(); ++i )
+				{
+					const int k = i % m_numValues;
+					const int v = cache.get( k );
+					GAFFERTEST_ASSERTEQUAL( v, k );
+
+					if( m_clearFrequency && (i % m_clearFrequency == 0) )
+					{
+						cache.clear();
+					}
+				}
+			}
+		);
+	}
+
+	private :
+
+		const int m_numIterations;
+		const int m_numValues;
+		const int m_maxCost;
+		const int m_clearFrequency;
+
+};
+
+void testLRUCache( const std::string &policy, int numIterations, int numValues, int maxCost, int clearFrequency )
+{
+	DispatchTest<TestLRUCache>()( policy, numIterations, numValues, maxCost, clearFrequency );
+}
+
+template<template<typename> class Policy>
+struct TestLRUCacheRemovalCallback
+{
+
+	void operator()()
+	{
+		std::vector<std::pair<int, int>> removed;
+
+		typedef LRUCache<int, int, Policy> Cache;
+		Cache cache(
+			// Getter
+			[]( int key, size_t &cost ) {
+				cost = 1; return key * 2;
+			},
+			// Removal callback
+			[&removed]( int key, int value ) {
+				removed.push_back(
+					std::make_pair( key, value )
+				);
+			},
+			/* maxCost = */ 5
+		);
+
+		GAFFERTEST_ASSERTEQUAL( cache.get( 1 ), 2 );
+		GAFFERTEST_ASSERTEQUAL( removed.size(), 0 );
+
+		GAFFERTEST_ASSERTEQUAL( cache.get( 2 ), 4 );
+		GAFFERTEST_ASSERTEQUAL( removed.size(), 0 );
+
+		GAFFERTEST_ASSERTEQUAL( cache.get( 3 ), 6 );
+		GAFFERTEST_ASSERTEQUAL( removed.size(), 0 );
+
+		GAFFERTEST_ASSERTEQUAL( cache.get( 4 ), 8 );
+		GAFFERTEST_ASSERTEQUAL( removed.size(), 0 );
+
+		GAFFERTEST_ASSERTEQUAL( cache.get( 5 ), 10 );
+		GAFFERTEST_ASSERTEQUAL( removed.size(), 0 );
+
+		GAFFERTEST_ASSERTEQUAL( cache.get( 6 ), 12 );
+		GAFFERTEST_ASSERTEQUAL( removed.size(), 1 );
+
+		GAFFERTEST_ASSERTEQUAL( cache.get( 7 ), 14 );
+		GAFFERTEST_ASSERTEQUAL( removed.size(), 2 );
+
+		cache.clear();
+
+		GAFFERTEST_ASSERTEQUAL( removed.size(), 7 );
+
+		for( int i = 1; i < 8; ++i )
+		{
+			GAFFERTEST_ASSERTEQUAL(
+				std::count(
+					removed.begin(), removed.end(),
+					std::make_pair( i, i * 2 )
+				),
+				1
+			);
+		}
+	}
+
+};
+
+void testLRUCacheRemovalCallback( const std::string &policy )
+{
+	DispatchTest<TestLRUCacheRemovalCallback>()( policy );
+}
+
+template<template<typename> class Policy>
+struct TestLRUCacheContentionForOneItem
+{
+
+	void operator()()
+	{
+		typedef LRUCache<int, int, Policy> Cache;
+		Cache cache(
+			[]( int key, size_t &cost ) { cost = 1; return key; },
+			100
+		);
+
+		tbb::parallel_for(
+			tbb::blocked_range<size_t>( 0, 10000000 ),
+			[&]( const tbb::blocked_range<size_t> &r ) {
+				for( size_t i = r.begin(); i < r.end(); ++i )
+				{
+					GAFFERTEST_ASSERTEQUAL( cache.get( 1 ), 1 );
+				}
+			}
+		);
+	}
+
+
+};
+
+void testLRUCacheContentionForOneItem( const std::string &policy )
+{
+	DispatchTest<TestLRUCacheContentionForOneItem>()( policy );
+}
+
+template<template<typename> class Policy>
+struct TestLRUCacheRecursion
+{
+
+	TestLRUCacheRecursion( int numIterations, int numValues, int maxCost )
+		:	m_numIterations( numIterations ), m_numValues( numValues ), m_maxCost( maxCost )
+	{
+	}
+
+	void operator()()
+	{
+		typedef LRUCache<int, int, Policy> Cache;
+		typedef std::unique_ptr<Cache> CachePtr;
+
+		CachePtr cache;
+		cache.reset(
+			new Cache(
+				// Getter that calls back into the cache with a different key.
+				[&cache]( int key, size_t &cost ) {
+					cost = 1;
+					switch( key )
+					{
+						case 0 :
+							return 0;
+						case 1 :
+						case 2 :
+							return 1;
+						default :
+							return cache->get( key - 1 ) + cache->get( key - 2 );
+					}
+				},
+				m_maxCost
+			)
+		);
+
+		GAFFERTEST_ASSERTEQUAL( cache->get( 40 ), 102334155 );
+		cache->clear();
+
+		tbb::parallel_for(
+			tbb::blocked_range<size_t>( 0, m_numIterations ),
+			[&]( const tbb::blocked_range<size_t> &r ) {
+				for( size_t i = r.begin(); i < r.end(); ++i )
+				{
+					cache->get( i % m_numValues );
+				}
+			}
+		);
+
+	}
+
+	private :
+
+		const int m_numIterations;
+		const int m_numValues;
+		const int m_maxCost;
+
+};
+
+void testLRUCacheRecursion( const std::string &policy, int numIterations, size_t numValues, int maxCost )
+{
+	DispatchTest<TestLRUCacheRecursion>()( policy, numIterations, numValues, maxCost );
+}
+
+template<template<typename> class Policy>
+struct TestLRUCacheRecursionOnOneItem
+{
+
+	void operator()()
+	{
+		typedef LRUCache<int, int, Policy> Cache;
+		typedef std::unique_ptr<Cache> CachePtr;
+		int recursionDepth = 0;
+
+		CachePtr cache;
+		cache.reset(
+			new Cache(
+				// Getter that calls back into the cache with the _same_
+				// key, up to a certain limit, and then actually returns
+				// a value. This is basically insane, but it models
+				// situations that can occur in Gaffer.
+				[&cache, &recursionDepth]( int key, size_t &cost ) {
+					cost = 1;
+					if( ++recursionDepth == 100 )
+					{
+					return key;
+					}
+					else
+					{
+					return cache->get( key );
+					}
+				},
+				// Max cost is small enough that we'll be trying to evict
+				// keys while unwinding the recursion.
+				20
+			)
+		);
+
+		for( int i = 0; i < 100000; ++i )
+		{
+			recursionDepth = 0;
+			cache->clear();
+			GAFFERTEST_ASSERTEQUAL( cache->currentCost(), 0 );
+			GAFFERTEST_ASSERTEQUAL( cache->get( i ), i );
+			GAFFERTEST_ASSERTEQUAL( recursionDepth, 100 );
+			GAFFERTEST_ASSERTEQUAL( cache->currentCost(), 1 );
+		}
+	}
+
+};
+
+void testLRUCacheRecursionOnOneItem( const std::string &policy )
+{
+	DispatchTest<TestLRUCacheRecursionOnOneItem>()( policy );
+}
+
+template<template<typename> class Policy>
+struct TestLRUCacheClearFromGet
+{
+
+	void operator()()
+	{
+
+		typedef IECorePreview::LRUCache<int, int, Policy> Cache;
+		typedef std::unique_ptr<Cache> CachePtr;
+
+		CachePtr cache;
+		cache.reset(
+			new Cache(
+				// Calling `clear()` from inside a getter is basically insane. But it can happen
+				// in Gaffer, because `get()` might trigger arbitrary python, arbitrary python
+				// might trigger garbage collection, garbage collection might destroy a plug,
+				// and destroying a plug clears the cache.
+				[&cache]( int key, size_t &cost ) { cache->clear(); cost = 1; return key; },
+				100
+			)
+		);
+
+		for( int i = 0; i < 100000; ++i )
+		{
+			GAFFERTEST_ASSERTEQUAL( cache->get( i ), i );
+		}
+
+	}
+
+};
+
+void testLRUCacheClearFromGet( const std::string &policy )
+{
+	DispatchTest<TestLRUCacheClearFromGet>()( policy );
+}
+
+template<template<typename> class Policy>
+struct TestLRUCacheExceptions
+{
+
+	void operator()()
+	{
+		std::vector<int> calls;
+
+		typedef IECorePreview::LRUCache<int, int, Policy> Cache;
+		Cache cache(
+			[&calls]( int key, size_t &cost ) {
+				calls.push_back( key );
+				throw IECore::Exception( boost::str(
+					boost::format( "Get failed for %1%" ) % key
+				) );
+				return 0;
+			},
+			1000
+		);
+
+		// Check that the exception thrown by the getter propagates back out to us.
+
+		bool caughtException = false;
+		try
+		{
+			cache.get( 10 );
+		}
+		catch( const IECore::Exception &e )
+		{
+			caughtException = true;
+			GAFFERTEST_ASSERTEQUAL(
+				e.what(),
+				std::string( "Get failed for 10" )
+			);
+		}
+
+		GAFFERTEST_ASSERT( caughtException );
+		GAFFERTEST_ASSERTEQUAL( calls.size(), 1 );
+		GAFFERTEST_ASSERTEQUAL( calls.back(), 10 );
+
+		// Check that calling a second time gives us the same error, but without
+		// calling the getter again.
+
+		caughtException = false;
+		try
+		{
+			cache.get( 10 );
+		}
+		catch( const IECore::Exception &e )
+		{
+			caughtException = true;
+			GAFFERTEST_ASSERTEQUAL(
+				e.what(),
+				std::string( "Get failed for 10" )
+			);
+		}
+
+		GAFFERTEST_ASSERT( caughtException );
+		GAFFERTEST_ASSERTEQUAL( calls.size(), 1 );
+
+		// Check that clear erases exceptions, so that the getter will be called again.
+
+		cache.clear();
+
+		caughtException = false;
+		try
+		{
+			cache.get( 10 );
+		}
+		catch( const IECore::Exception &e )
+		{
+			caughtException = true;
+			GAFFERTEST_ASSERTEQUAL(
+				e.what(),
+				std::string( "Get failed for 10" )
+			);
+		}
+
+		GAFFERTEST_ASSERT( caughtException );
+		GAFFERTEST_ASSERTEQUAL( calls.size(), 2 );
+		GAFFERTEST_ASSERTEQUAL( calls.back(), 10 );
+
+		// And check that erase does the same.
+		cache.erase( 10 );
+
+		caughtException = false;
+		try
+		{
+			cache.get( 10 );
+		}
+		catch( const IECore::Exception &e )
+		{
+			caughtException = true;
+			GAFFERTEST_ASSERTEQUAL(
+				e.what(),
+				std::string( "Get failed for 10" )
+			);
+		}
+
+		GAFFERTEST_ASSERT( caughtException );
+		GAFFERTEST_ASSERTEQUAL( calls.size(), 3 );
+		GAFFERTEST_ASSERTEQUAL( calls.back(), 10 );
+
+	}
+
+};
+
+void testLRUCacheExceptions( const std::string &policy )
+{
+	DispatchTest<TestLRUCacheExceptions>()( policy );
+}
+
+} // namespace
+
+void GafferTestModule::bindLRUCacheTest()
+{
+	def( "testLRUCache", &testLRUCache, ( arg( "numIterations" ), arg( "numValues" ), arg( "maxCost" ), arg( "clearFrequency" ) = 0 ) );
+	def( "testLRUCacheRemovalCallback", &testLRUCacheRemovalCallback );
+	def( "testLRUCacheContentionForOneItem", &testLRUCacheContentionForOneItem );
+	def( "testLRUCacheRecursion", &testLRUCacheRecursion, ( arg( "numIterations" ), arg( "numValues" ), arg( "maxCost" ) ) );
+	def( "testLRUCacheRecursionOnOneItem", &testLRUCacheRecursionOnOneItem );
+	def( "testLRUCacheClearFromGet", &testLRUCacheClearFromGet );
+	def( "testLRUCacheExceptions", &testLRUCacheExceptions );
+}

--- a/src/GafferTestModule/LRUCacheTest.cpp
+++ b/src/GafferTestModule/LRUCacheTest.cpp
@@ -316,11 +316,11 @@ struct TestLRUCacheRecursionOnOneItem
 					cost = 1;
 					if( ++recursionDepth == 100 )
 					{
-					return key;
+						return key;
 					}
 					else
 					{
-					return cache->get( key );
+						return cache->get( key );
 					}
 				},
 				// Max cost is small enough that we'll be trying to evict
@@ -329,15 +329,10 @@ struct TestLRUCacheRecursionOnOneItem
 			)
 		);
 
-		for( int i = 0; i < 100000; ++i )
-		{
-			recursionDepth = 0;
-			cache->clear();
-			GAFFERTEST_ASSERTEQUAL( cache->currentCost(), 0 );
-			GAFFERTEST_ASSERTEQUAL( cache->get( i ), i );
-			GAFFERTEST_ASSERTEQUAL( recursionDepth, 100 );
-			GAFFERTEST_ASSERTEQUAL( cache->currentCost(), 1 );
-		}
+		GAFFERTEST_ASSERTEQUAL( cache->currentCost(), 0 );
+		GAFFERTEST_ASSERTEQUAL( cache->get( 1 ), 1 );
+		GAFFERTEST_ASSERTEQUAL( recursionDepth, 100 );
+		GAFFERTEST_ASSERTEQUAL( cache->currentCost(), 1 );
 	}
 
 };
@@ -353,7 +348,6 @@ struct TestLRUCacheClearFromGet
 
 	void operator()()
 	{
-
 		typedef IECorePreview::LRUCache<int, int, Policy> Cache;
 		typedef std::unique_ptr<Cache> CachePtr;
 
@@ -369,11 +363,7 @@ struct TestLRUCacheClearFromGet
 			)
 		);
 
-		for( int i = 0; i < 100000; ++i )
-		{
-			GAFFERTEST_ASSERTEQUAL( cache->get( i ), i );
-		}
-
+		GAFFERTEST_ASSERTEQUAL( cache->get( 0 ), 0 );
 	}
 
 };

--- a/src/GafferTestModule/LRUCacheTest.h
+++ b/src/GafferTestModule/LRUCacheTest.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
-//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,48 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GafferBindings/DependencyNodeBinding.h"
+#ifndef GAFFERTESTMODULE_LRUCACHETEST_H
+#define GAFFERTESTMODULE_LRUCACHETEST_H
 
-#include "GafferTest/ComputeNodeTest.h"
-#include "GafferTest/ContextTest.h"
-#include "GafferTest/DownstreamIteratorTest.h"
-#include "GafferTest/FilteredRecursiveChildIteratorTest.h"
-#include "GafferTest/MetadataTest.h"
-#include "GafferTest/MultiplyNode.h"
-#include "GafferTest/RecursiveChildIteratorTest.h"
-
-#include "LRUCacheTest.h"
-#include "TaskMutexTest.h"
-
-#include "IECorePython/ScopedGILRelease.h"
-
-using namespace boost::python;
-using namespace GafferTest;
-using namespace GafferTestModule;
-
-static void testMetadataThreadingWrapper()
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	testMetadataThreading();
-}
-
-BOOST_PYTHON_MODULE( _GafferTest )
+namespace GafferTestModule
 {
 
-	GafferBindings::DependencyNodeClass<MultiplyNode>();
+void bindLRUCacheTest();
 
-	def( "testRecursiveChildIterator", &testRecursiveChildIterator );
-	def( "testFilteredRecursiveChildIterator", &testFilteredRecursiveChildIterator );
-	def( "testMetadataThreading", &testMetadataThreadingWrapper );
-	def( "testManyContexts", &testManyContexts );
-	def( "testManySubstitutions", &testManySubstitutions );
-	def( "testManyEnvironmentSubstitutions", &testManyEnvironmentSubstitutions );
-	def( "testScopingNullContext", &testScopingNullContext );
-	def( "testEditableScope", &testEditableScope );
-	def( "testComputeNodeThreading", &testComputeNodeThreading );
-	def( "testDownstreamIterator", &testDownstreamIterator );
+} // namespace GafferTestModule
 
-	bindTaskMutexTest();
-	bindLRUCacheTest();
-
-}
+#endif // GAFFERTESTMODULE_LRUCACHETEST_H


### PR DESCRIPTION
This builds on #3133, using the new TaskMutex class to build a TaskParallel policy for the LRUCache, whereby multiple threads calling `cache.get()` for the same item can all collaborate on the TBB tasks spawned to do the work.

I wouldn't recommend looking at the overall diff or the diff for 57a5291, because the copy of the latest Cortex code is pretty meaningless. This is probably best reviewed commit by commit.

I apologise for not having found a nice way of sharing code between the Parallel and TaskParallel policies; I've been a bit short of mental bandwidth on this problem. I'm now wondering if it would make sense to just replace the Parallel policy entirely and use `spawnsTasks()` to avoid the overhead when you don't need the task collaboration. The main downside would be that TaskMutex is bigger than `spin_rw_mutex` so the cache entries are slightly larger, but since cached items are generally substantial, I'm not sure that's really an issue. Thoughts?