### PR TITLE
Add ExtensionAlgo

### DIFF
--- a/include/GafferBindings/Serialisation.h
+++ b/include/GafferBindings/Serialisation.h
@@ -129,6 +129,7 @@ class GAFFERBINDINGS_API Serialisation
 		const Gaffer::GraphComponent *m_parent;
 		const std::string m_parentName;
 		const Gaffer::Set *m_filter;
+		const bool m_protectParentNamespace;
 
 		std::string m_hierarchyScript;
 		std::string m_connectionScript;

--- a/python/Gaffer/ExtensionAlgo.py
+++ b/python/Gaffer/ExtensionAlgo.py
@@ -1,0 +1,228 @@
+##########################################################################
+#
+#  Copyright (c) 2019, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import re
+
+import IECore
+
+import Gaffer
+
+## Creates a custom Gaffer extension by exporting one or more Boxes
+# as new node types defined in a python module. An associated startup
+# file is generated to add the nodes to the node menu. If `directory`
+# is placed on the GAFFER_EXTENSION_PATHS then the extension will be
+# loaded automatically by Gaffer.
+def exportExtension( name, boxes, directory ) :
+
+	pythonDir = os.path.join( directory, "python", name )
+	os.makedirs( pythonDir )
+
+	with open( os.path.join( pythonDir, "__init__.py" ), "w" ) as initFile :
+
+		for box in boxes :
+
+			with open( os.path.join( pythonDir, box.getName() + ".py" ), "w" ) as nodeFile :
+				nodeFile.write( __nodeDefinition( box, name ) )
+
+			initFile.write( "from {name} import {name}\n".format( name = box.getName() ) )
+
+	uiDir = os.path.join( directory, "python", name + "UI" )
+	os.makedirs( uiDir )
+
+	with open( os.path.join( uiDir, "__init__.py" ), "w" ) as initFile :
+
+		for box in boxes :
+
+			with open( os.path.join( uiDir, box.getName() + "UI.py" ), "w" ) as uiFile :
+				uiFile.write( __uiDefinition( box, name ) )
+
+			initFile.write( "import {name}UI\n".format( name = box.getName() ) )
+
+	startupDir = os.path.join( directory, "startup", "gui" )
+	os.makedirs( startupDir )
+
+	with open( os.path.join( startupDir, name + ".py" ), "w" ) as startupFile :
+
+		nodeMenuDefinition = []
+		for box in boxes :
+
+			nodeMenuPath = Gaffer.Metadata.value( box, "extension:nodeMenuItem" )
+			if not nodeMenuPath :
+				nodeMenuPath = "/{name}/{node}".format( name = name, node = box.getName() )
+
+			nodeMenuDefinition.append(
+				"nodeMenu.append( \"{nodeMenuPath}\", {name}.{node} )\n".format(
+					nodeMenuPath = nodeMenuPath,
+					name = name,
+					node = box.getName()
+				)
+			)
+
+		startupFile.write(
+			__startupTemplate.format(
+				name = name,
+				nodeMenuDefinition = "\n".join( nodeMenuDefinition )
+			)
+		)
+
+__startupTemplate = """\
+import GafferUI
+import {name}
+import {name}UI
+
+nodeMenu = GafferUI.NodeMenu.acquire( application )
+
+{nodeMenuDefinition}
+"""
+
+def __indent( text, n ) :
+
+	prefix = "\t" * n
+	return "\n".join( prefix + l for l in text.split( "\n" ) )
+
+__nodeTemplate = """\
+{imports}
+
+class {name}( Gaffer.SubGraph ) :
+
+	def __init__( self, name = "{name}" ) :
+
+		Gaffer.SubGraph.__init__( self, name )
+
+{constructor}
+
+IECore.registerRunTimeTyped( {name}, typeName = "{extension}::{name}" )
+"""
+
+def __nodeDefinition( box, extension ) :
+
+	invisiblePlug = re.compile( "^__.*$" )
+	children = Gaffer.StandardSet()
+	for child in box.children() :
+		if isinstance( child, Gaffer.Node ) :
+			children.add( child )
+		elif isinstance( child, Gaffer.Plug ) :
+			if not invisiblePlug.match( child.getName() ) and child != box["user"] :
+				children.add( child )
+
+	with Gaffer.Context() as context :
+		context["serialiser:includeVersionMetadata"] = IECore.BoolData( False )
+		context["serialiser:protectParentNamespace"] = IECore.BoolData( False )
+		context["valuePlugSerialiser:resetParentPlugDefaults"] = IECore.BoolData( True )
+		context["plugSerialiser:includeParentPlugMetadata"] = IECore.BoolData( False )
+		constructor = Gaffer.Serialisation( box, "self", children ).result()
+
+	imports = { "import IECore", "import Gaffer" }
+	constructorLines = []
+	for line in constructor.split( "\n" ) :
+		if line.startswith( "import" ) :
+			imports.add( line )
+		else :
+			constructorLines.append( line )
+
+	return __nodeTemplate.format(
+		imports = "\n".join( sorted( imports ) ),
+		name = box.getName(),
+		constructor = __indent( "\n".join( constructorLines ), 2 ),
+		extension = extension
+	)
+
+__uiTemplate = """\
+import imath
+import IECore
+import Gaffer
+import {extension}
+
+Gaffer.Metadata.registerNode(
+
+	{extension}.{name},
+
+{metadata}
+{plugMetadata}
+
+)
+"""
+
+def __uiDefinition( box, extension ) :
+
+	return __uiTemplate.format(
+
+		extension = extension,
+		name = box.getName(),
+		metadata = __indent( __metadata( box ), 1 ),
+		plugMetadata = __indent( __plugMetadata( box ), 1 )
+
+	)
+
+def __metadata( graphComponent ) :
+
+	items = []
+	for k in Gaffer.Metadata.registeredValues( graphComponent, instanceOnly = True, persistentOnly = True ) :
+
+		v = Gaffer.Metadata.value( graphComponent, k )
+		items.append(
+			"{k}, {v},".format( k = repr( k ), v = IECore.repr( v ) )
+		)
+
+	return "\n".join( items )
+
+def __plugMetadata( box ) :
+
+	items = []
+	def walkPlugs( graphComponent ) :
+
+		if isinstance( graphComponent, Gaffer.Plug ) :
+
+			m = __metadata( graphComponent )
+			if m :
+				items.append(
+					"\"{name}\" : [\n{m}\n],\n".format(
+						name = graphComponent.relativeName( graphComponent.node() ),
+						m = __indent( m, 1 )
+					)
+				)
+
+		for plug in graphComponent.children( Gaffer.Plug ) :
+			walkPlugs( plug )
+
+	walkPlugs( box )
+
+	if items :
+		return "plugs = {\n\n" + __indent( "\n".join( items ), 1 ) + "\n}\n"
+	else :
+		return ""
+

--- a/python/Gaffer/__init__.py
+++ b/python/Gaffer/__init__.py
@@ -54,5 +54,6 @@ from GraphComponentPath import GraphComponentPath
 from OutputRedirection import OutputRedirection
 
 import NodeAlgo
+import ExtensionAlgo
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "Gaffer" )

--- a/python/GafferTest/ExtensionAlgoTest.py
+++ b/python/GafferTest/ExtensionAlgoTest.py
@@ -1,0 +1,92 @@
+##########################################################################
+#
+#  Copyright (c) 2019, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import sys
+import unittest
+import functools
+
+import Gaffer
+import GafferTest
+
+class ExtensionAlgoTest( GafferTest.TestCase ) :
+
+	def setUp( self ) :
+
+		GafferTest.TestCase.setUp( self )
+
+		self.addCleanup(
+			functools.partial( setattr, sys, "path", sys.path[:] )
+		)
+
+	def testExport( self ) :
+
+		box = Gaffer.Box( "AddOne" )
+
+		box["__add"] = GafferTest.AddNode()
+		box["__add"]["op2"].setValue( 1 )
+		Gaffer.PlugAlgo.promote( box["__add"]["op1"] ).setName( "in" )
+		Gaffer.PlugAlgo.promote( box["__add"]["sum"] ).setName( "out" )
+
+		Gaffer.Metadata.registerValue( box, "description", "Test" )
+		Gaffer.Metadata.registerValue( box["in"], "description", "The input" )
+		Gaffer.Metadata.registerValue( box["out"], "description", "The output" )
+		Gaffer.Metadata.registerValue( box["in"], "test", 1 )
+
+		Gaffer.ExtensionAlgo.exportExtension( "TestExtension", [ box ], self.temporaryDirectory() )
+		self.assertTrue( os.path.exists( os.path.join( self.temporaryDirectory(), "python", "TestExtension" ) ) )
+
+		sys.path.append( os.path.join( self.temporaryDirectory(), "python" ) )
+
+		import TestExtension
+
+		node = TestExtension.AddOne()
+		node["in"].setValue( 2 )
+		self.assertEqual( node["out"].getValue(), 3 )
+
+		import TestExtensionUI
+
+		self.assertEqual( Gaffer.Metadata.registeredValues( node, instanceOnly = True ), [] )
+		self.assertEqual( Gaffer.Metadata.registeredValues( node["in"], instanceOnly = True ), [] )
+		self.assertEqual( Gaffer.Metadata.registeredValues( node["out"], instanceOnly = True ), [] )
+
+		self.assertEqual( Gaffer.Metadata.value( node, "description" ), "Test" )
+		self.assertEqual( Gaffer.Metadata.value( node["in"], "description" ), "The input" )
+		self.assertEqual( Gaffer.Metadata.value( node["out"], "description" ), "The output" )
+		self.assertEqual( Gaffer.Metadata.value( node["in"], "test" ), 1 )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/PlugTest.py
+++ b/python/GafferTest/PlugTest.py
@@ -832,5 +832,24 @@ class PlugTest( GafferTest.TestCase ) :
 		self.failUnless( s["n2"]["c"]["i"].getInput().isSame(  s["n1"]["o"] ) )
 		self.assertEqual( len( s["n1"]["o"].outputs() ), 1 )
 
+	def testSerialiseOmittingParentPlugMetadata( self ) :
+
+		n = Gaffer.Node()
+		n["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		n["a"] = GafferTest.AddNode()
+
+		Gaffer.Metadata.registerValue( n["p"], "test", 10 )
+		Gaffer.Metadata.registerValue( n["a"]["op1"], "test", 10 )
+
+		with Gaffer.Context() as c :
+			c["plugSerialiser:includeParentPlugMetadata"] = IECore.BoolData( False )
+			s = Gaffer.Serialisation( n ).result()
+
+		scope = { "parent" : Gaffer.Node() }
+		exec( s, scope, scope )
+
+		self.assertEqual( Gaffer.Metadata.value( scope["parent"]["p"], "test" ), None )
+		self.assertEqual( Gaffer.Metadata.value( scope["parent"]["a"]["op1"], "test" ), 10 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/SerialisationTest.py
+++ b/python/GafferTest/SerialisationTest.py
@@ -173,5 +173,30 @@ class SerialisationTest( GafferTest.TestCase ) :
 
 		self.assertEqual( Gaffer.Serialisation.classPath( self.Outer.Inner ), "GafferTest.SerialisationTest.Outer.Inner" )
 
+	def testVersionMetadata( self ) :
+
+		n = Gaffer.Node()
+		serialisationWithMetadata = Gaffer.Serialisation( n ).result()
+
+		with Gaffer.Context() as c :
+			c["serialiser:includeVersionMetadata"] = IECore.BoolData( False )
+			serialisationWithoutMetadata = Gaffer.Serialisation( n ).result()
+
+		scope = { "parent" : Gaffer.Node() }
+		exec( serialisationWithMetadata, scope, scope )
+
+		self.assertEqual( Gaffer.Metadata.value( scope["parent"], "serialiser:milestoneVersion" ), Gaffer.About.milestoneVersion() )
+		self.assertEqual( Gaffer.Metadata.value( scope["parent"], "serialiser:majorVersion" ), Gaffer.About.majorVersion() )
+		self.assertEqual( Gaffer.Metadata.value( scope["parent"], "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
+		self.assertEqual( Gaffer.Metadata.value( scope["parent"], "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
+
+		scope = { "parent" : Gaffer.Node() }
+		exec( serialisationWithoutMetadata, scope, scope )
+
+		self.assertEqual( Gaffer.Metadata.value( scope["parent"], "serialiser:milestoneVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.value( scope["parent"], "serialiser:majorVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.value( scope["parent"], "serialiser:minorVersion" ), None )
+		self.assertEqual( Gaffer.Metadata.value( scope["parent"], "serialiser:patchVersion" ), None )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -138,6 +138,7 @@ from BackgroundTaskTest import BackgroundTaskTest
 from ProcessMessageHandlerTest import ProcessMessageHandlerTest
 from MonitorAlgoTest import MonitorAlgoTest
 from NameValuePlugTest import NameValuePlugTest
+from ExtensionAlgoTest import ExtensionAlgoTest
 
 from IECorePreviewTest import *
 

--- a/src/GafferBindings/PlugBinding.cpp
+++ b/src/GafferBindings/PlugBinding.cpp
@@ -39,6 +39,7 @@
 
 #include "Gaffer/BoxIn.h"
 #include "Gaffer/BoxOut.h"
+#include "Gaffer/Context.h"
 #include "Gaffer/Dot.h"
 #include "Gaffer/Node.h"
 #include "Gaffer/Plug.h"
@@ -134,6 +135,8 @@ bool shouldSerialiseInput( const Plug *plug )
 	return true;
 }
 
+const IECore::InternedString g_includeParentPlugMetadata( "plugSerialiser:includeParentPlugMetadata" );
+
 } // namespace
 
 void PlugSerialiser::moduleDependencies( const Gaffer::GraphComponent *graphComponent, std::set<std::string> &modules, const Serialisation &serialisation ) const
@@ -161,7 +164,16 @@ std::string PlugSerialiser::postHierarchy( const Gaffer::GraphComponent *graphCo
 		}
 	}
 
-	result += metadataSerialisation( plug, identifier );
+	bool shouldSerialiseMetadata = true;
+	if( plug->node() == serialisation.parent() )
+	{
+		shouldSerialiseMetadata = Context::current()->get<bool>( g_includeParentPlugMetadata, true );
+	}
+	if( shouldSerialiseMetadata )
+	{
+		result += metadataSerialisation( plug, identifier );
+	}
+
 	return result;
 }
 

--- a/src/GafferBindings/Serialisation.cpp
+++ b/src/GafferBindings/Serialisation.cpp
@@ -63,7 +63,8 @@ using namespace boost::python;
 //////////////////////////////////////////////////////////////////////////
 
 Serialisation::Serialisation( const Gaffer::GraphComponent *parent, const std::string &parentName, const Gaffer::Set *filter )
-	:	m_parent( parent ), m_parentName( parentName ), m_filter( filter )
+	:	m_parent( parent ), m_parentName( parentName ), m_filter( filter ),
+		m_protectParentNamespace( Context::current()->get<bool>( "serialiser:protectParentNamespace", true ) )
 {
 	IECorePython::ScopedGILLock gilLock;
 	walk( parent, parentName, acquireSerialiser( parent ) );
@@ -110,7 +111,10 @@ std::string Serialisation::result() const
 		result += boost::str( formatter % m_parentName % "serialiser:patchVersion" % GAFFER_PATCH_VERSION );
 	}
 
-	result += "\n__children = {}\n\n";
+	if( m_protectParentNamespace )
+	{
+		result += "\n__children = {}\n\n";
+	}
 
 	result += m_hierarchyScript;
 
@@ -118,7 +122,10 @@ std::string Serialisation::result() const
 
 	result += m_postScript;
 
-	result += "\n\ndel __children\n\n";
+	if( m_protectParentNamespace )
+	{
+		result += "\n\ndel __children\n\n";
+	}
 
 	return result;
 }
@@ -242,7 +249,7 @@ void Serialisation::walk( const Gaffer::GraphComponent *parent, const std::strin
 		}
 
 		std::string childIdentifier;
-		if( parent == m_parent && childConstructor.size() )
+		if( parent == m_parent && childConstructor.size() && m_protectParentNamespace )
 		{
 			childIdentifier = "__children[\"" + child->getName().string() + "\"]";
 		}
@@ -253,10 +260,17 @@ void Serialisation::walk( const Gaffer::GraphComponent *parent, const std::strin
 
 		if( childConstructor.size() )
 		{
-			if( parent == m_parent)
+			if( parent == m_parent )
 			{
-				m_hierarchyScript += childIdentifier + " = " + childConstructor + "\n";
-				m_hierarchyScript += parentIdentifier + ".addChild( " + childIdentifier + " )\n";
+				if( m_protectParentNamespace )
+				{
+					m_hierarchyScript += childIdentifier + " = " + childConstructor + "\n";
+					m_hierarchyScript += parentIdentifier + ".addChild( " + childIdentifier + " )\n";
+				}
+				else
+				{
+					m_hierarchyScript += childIdentifier + " = " + childConstructor + "\n";
+				}
 			}
 			else
 			{
@@ -285,7 +299,7 @@ std::string Serialisation::identifier( const Gaffer::GraphComponent *graphCompon
 				return "";
 			}
 			const Serialiser *parentSerialiser = acquireSerialiser( parent );
-			if( parentSerialiser->childNeedsConstruction( graphComponent, *this ) )
+			if( m_protectParentNamespace && parentSerialiser->childNeedsConstruction( graphComponent, *this ) )
 			{
 				return "__children[\"" + graphComponent->getName().string() + "\"]" + result;
 			}

--- a/src/GafferBindings/Serialisation.cpp
+++ b/src/GafferBindings/Serialisation.cpp
@@ -97,7 +97,8 @@ std::string Serialisation::result() const
 	}
 
 	if(
-		runTimeCast<const Node>( m_parent )
+		runTimeCast<const Node>( m_parent ) &&
+		Context::current()->get<bool>( "serialiser:includeVersionMetadata", true )
 	)
 	{
 		boost::format formatter( "Gaffer.Metadata.registerValue( %s, \"%s\", %d, persistent=False )\n" );


### PR DESCRIPTION
This provides an `exportExtension()` method to allow Boxes to be exported as Gaffer extensions. These differ from references in that they define a new node type, and are integrated with the NodeMenu. This is is a prerequisite for the "GafferHub" we've been talking about, but it also provides studios with a more formal option for sharing internal tools.
