### PR TITLE
Docs : Add Bootstrap scrollspy

### DIFF
--- a/doc/source/Appendices/index.md
+++ b/doc/source/Appendices/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 Appendices
 ==========
 

--- a/doc/source/GettingStarted/InstallingGaffer/index.md
+++ b/doc/source/GettingStarted/InstallingGaffer/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 # Installing Gaffer #
 
 The Gaffer package is a self-contained directory, so you will need to manually install it, and later manually configure it, if necessary. Once extracted, the Gaffer directory contains the complete application, ready for use.

--- a/doc/source/GettingStarted/LaunchingGafferFirstTime/index.md
+++ b/doc/source/GettingStarted/LaunchingGafferFirstTime/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 # Launching Gaffer for the First Time #
 
 Once Gaffer has been installed, you will probably want to try it out right away before performing any additional configuration. To launch it, you can run its application file directly from the binary directory.

--- a/doc/source/GettingStarted/index.md
+++ b/doc/source/GettingStarted/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 # Getting Started #
 
 Here you can find information and instructions about how to install and configure Gaffer.

--- a/doc/source/Interface/index.md
+++ b/doc/source/Interface/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 # Interface #
 
 Here you can learn about Gaffer's interface and controls.

--- a/doc/source/Reference/ScriptingReference/Expressions/index.md
+++ b/doc/source/Reference/ScriptingReference/Expressions/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 Expressions
 ===========
 

--- a/doc/source/Reference/ScriptingReference/StringSubstitutionSyntax/index.md
+++ b/doc/source/Reference/ScriptingReference/StringSubstitutionSyntax/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 String Substitution Syntax
 ==========================
 

--- a/doc/source/Reference/ScriptingReference/index.md
+++ b/doc/source/Reference/ScriptingReference/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 Scripting Reference
 ===================
 

--- a/doc/source/Reference/index.md
+++ b/doc/source/Reference/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 Reference
 =========
 

--- a/doc/source/ReleaseNotes/generate.py
+++ b/doc/source/ReleaseNotes/generate.py
@@ -31,6 +31,8 @@ index = open( "./index.md", "w" )
 index.write( inspect.cleandoc(
 	
 	"""
+	<!-- !NO_SCROLLSPY -->
+
 	# Release Notes #
 
 	```eval_rst

--- a/doc/source/Tutorials/Scripting/index.md
+++ b/doc/source/Tutorials/Scripting/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 Scripting
 =========
 

--- a/doc/source/Tutorials/index.md
+++ b/doc/source/Tutorials/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 Tutorials
 =========
 

--- a/doc/source/WorkingWithImages/index.md
+++ b/doc/source/WorkingWithImages/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 # Working with Images #
 
 Here you can find information on how to read and manipulate 2d images, and how Gaffer interprets image data.

--- a/doc/source/WorkingWithScenes/index.md
+++ b/doc/source/WorkingWithScenes/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 # Working with Scenes #
 
 Here you can find information on how to read, manipulate, and construct 3D scenes, and how Gaffer interprets scene data.

--- a/doc/source/WorkingWithTheNodeGraph/UsingThePerformanceMonitor/index.md
+++ b/doc/source/WorkingWithTheNodeGraph/UsingThePerformanceMonitor/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 # Using the Performance Monitor #
 
 Gaffer contains a built-in performance monitor, which can help diagnose and optimize a node graph's performance. With the monitor active, performance statistics will be sent to the standard output (stdout) during dispatched renders.

--- a/doc/source/WorkingWithTheNodeGraph/index.md
+++ b/doc/source/WorkingWithTheNodeGraph/index.md
@@ -1,3 +1,5 @@
+<!-- !NO_SCROLLSPY -->
+
 # Working with the Node Graph #
 
 Here you can learn the fundamentals of constructing and editing node graphs in Gaffer.

--- a/doc/source/_static/gaffer.css
+++ b/doc/source/_static/gaffer.css
@@ -104,6 +104,107 @@ body {
 }
 
 /* ========================================
+    Scrollspy navigation
+======================================== */
+
+/* Remove grey BG in article negative space */
+.wy-nav-content-wrap {
+    background-color: unset;
+}
+
+#nav-scroll {
+    visibility: hidden;
+    position: fixed;
+    padding: 1rem;
+    right: 0;
+    width: 287px;
+    height: 100%;
+    overflow-y: auto;
+    box-shadow: 0 1px 15px 0 rgba(128,128,128,0.15);
+}
+
+/* Show scrollspy only on desktop */
+@media only screen and (min-width: 1400px) {
+    #nav-scroll {
+        visibility: visible;
+    }
+}
+
+#nav-scroll a {
+    outline: none;
+}
+
+#nav-scroll h1 {
+    font-size: 1rem;
+    margin: 0 0 0.5rem 0;
+}
+
+#nav-scroll .nav {
+    font-size: 0.8125rem;
+}
+
+#nav-scroll .nav ul {
+    list-style-type: none;
+    margin-bottom: 0.5rem;
+}
+
+#nav-scroll .nav ul li {
+    padding-left: 1rem;
+    margin-bottom: 0.5rem;
+}
+
+/* No padding on H2 level */
+#nav-scroll .nav > ul > li {
+    padding-left: 0;
+}
+
+#nav-scroll .nav li:first-child {
+    margin-top: 0.5rem;
+}
+
+#nav-scroll .nav a {
+    display: block;
+    padding-left: 0.5rem;
+    border-left: 2px solid transparent;
+    text-decoration: none;
+    color: #b0b0b0;
+    line-height: 1.5;
+}
+
+#nav-scroll .nav li.active > a {
+    color: #404040;
+    border-left-color: #808080;
+}
+
+/* Hide the lists under H2-level links until active */
+#nav-scroll .nav > ul > li > ul {
+    /* visibility: hidden; */
+    display: none;
+    height: 0;
+}
+
+#nav-scroll .nav > ul > li.active > ul {
+    /* visibility: visible; */
+    display: initial;
+    height: initial;
+}
+
+/* Make sure the lists under H2-level links don't appear on mobile */
+@media only screen and (max-width: 1399px) {
+    #nav-scroll .nav > ul > li > ul {
+        visibility: hidden !important;
+    }
+}
+
+#nav-scroll .nav a:hover {
+    color: #b92227 !important;
+}
+
+#nav-scroll .nav li.active > a:hover {
+    border-left-color: #b92227;
+}
+
+/* ========================================
     Links
 ======================================== */
 

--- a/doc/source/_static/scrollspy.js
+++ b/doc/source/_static/scrollspy.js
@@ -1,0 +1,263 @@
+/*!
+ * Bootstrap v3.4.1 (https://getbootstrap.com/)
+ * Copyright 2011-2019 Twitter, Inc.
+ * Licensed under the MIT license
+ */
+
+if (typeof jQuery === 'undefined') {
+    throw new Error('Bootstrap\'s JavaScript requires jQuery')
+}
+  
++function ($) {
+    'use strict';
+    var version = $.fn.jquery.split(' ')[0].split('.')
+    if ((version[0] < 2 && version[1] < 9) || (version[0] == 1 && version[1] == 9 && version[2] < 1) || (version[0] > 3)) {
+    throw new Error('Bootstrap\'s JavaScript requires jQuery version 1.9.1 or higher, but lower than version 4')
+    }
+}(jQuery);
+  
+  
+/* ========================================================================
+* Bootstrap: scrollspy.js v3.4.1
+* https://getbootstrap.com/docs/3.4/javascript/#scrollspy
+* ========================================================================
+* Copyright 2011-2019 Twitter, Inc.
+* Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+* ======================================================================== */
+
++function ($) {
+    'use strict';
+
+    // SCROLLSPY CLASS DEFINITION
+    // ==========================
+
+    function ScrollSpy(element, options) {
+        this.$body          = $(document.body)
+        this.$scrollElement = $(element).is(document.body) ? $(window) : $(element)
+        this.options        = $.extend({}, ScrollSpy.DEFAULTS, options)
+        this.selector       = (this.options.target || '') + ' .nav li > a'
+        this.offsets        = []
+        this.targets        = []
+        this.activeTarget   = null
+        this.scrollHeight   = 0
+
+        this.$scrollElement.on('scroll.bs.scrollspy', $.proxy(this.process, this))
+        this.refresh()
+        this.process()
+    }
+
+    ScrollSpy.VERSION  = '3.4.1'
+
+    ScrollSpy.DEFAULTS = {
+        offset: 10
+    }
+
+    ScrollSpy.prototype.getScrollHeight = function () {
+        return this.$scrollElement[0].scrollHeight || Math.max(this.$body[0].scrollHeight, document.documentElement.scrollHeight)
+    }
+
+    ScrollSpy.prototype.refresh = function () {
+    var that          = this
+    var offsetMethod  = 'offset'
+    var offsetBase    = 0
+
+    this.offsets      = []
+    this.targets      = []
+    this.scrollHeight = this.getScrollHeight()
+
+    if (!$.isWindow(this.$scrollElement[0])) {
+    offsetMethod = 'position'
+    offsetBase   = this.$scrollElement.scrollTop()
+    }
+
+    this.$body
+    .find(this.selector)
+    .map(function () {
+        var $el   = $(this)
+        var href  = $el.data('target') || $el.attr('href')
+        var $href = /^#./.test(href) && $(href)
+
+        return ($href
+        && $href.length
+        && $href.is(':visible')
+        && [[$href[offsetMethod]().top + offsetBase, href]]) || null
+    })
+    .sort(function (a, b) { return a[0] - b[0] })
+    .each(function () {
+        that.offsets.push(this[0])
+        that.targets.push(this[1])
+    })
+}
+
+ScrollSpy.prototype.process = function () {
+    var scrollTop    = this.$scrollElement.scrollTop() + this.options.offset
+    var scrollHeight = this.getScrollHeight()
+    var maxScroll    = this.options.offset + scrollHeight - this.$scrollElement.height()
+    var offsets      = this.offsets
+    var targets      = this.targets
+    var activeTarget = this.activeTarget
+    var i
+
+    if (this.scrollHeight != scrollHeight) {
+    this.refresh()
+    }
+
+    if (scrollTop >= maxScroll) {
+    return activeTarget != (i = targets[targets.length - 1]) && this.activate(i)
+    }
+
+    if (activeTarget && scrollTop < offsets[0]) {
+    this.activeTarget = null
+    return this.clear()
+    }
+
+    for (i = offsets.length; i--;) {
+    activeTarget != targets[i]
+        && scrollTop >= offsets[i]
+        && (offsets[i + 1] === undefined || scrollTop < offsets[i + 1])
+        && this.activate(targets[i])
+    }
+}
+
+ScrollSpy.prototype.activate = function (target) {
+    this.activeTarget = target
+
+    this.clear()
+
+    var selector = this.selector +
+    '[data-target="' + target + '"],' +
+    this.selector + '[href="' + target + '"]'
+
+    var active = $(selector)
+    .parents('li')
+    .addClass('active')
+
+    if (active.parent('.dropdown-menu').length) {
+    active = active
+        .closest('li.dropdown')
+        .addClass('active')
+    }
+
+    active.trigger('activate.bs.scrollspy')
+}
+
+ScrollSpy.prototype.clear = function () {
+    var test = $(this.selector)
+    .parentsUntil(this.options.target, '.active')
+    .removeClass('active')
+}
+
+
+// SCROLLSPY PLUGIN DEFINITION
+// ===========================
+
+function Plugin(option) {
+    return this.each(function () {
+    var $this   = $(this)
+    var data    = $this.data('bs.scrollspy')
+    var options = typeof option == 'object' && option
+
+    if (!data) $this.data('bs.scrollspy', (data = new ScrollSpy(this, options)))
+    if (typeof option == 'string') data[option]()
+    })
+}
+
+var old = $.fn.scrollspy
+
+$.fn.scrollspy             = Plugin
+$.fn.scrollspy.Constructor = ScrollSpy
+
+
+// SCROLLSPY NO CONFLICT
+// =====================
+
+$.fn.scrollspy.noConflict = function () {
+    $.fn.scrollspy = old
+    return this
+}
+
+
+// SCROLLSPY DATA-API
+// ==================
+
+$(window).on('load.bs.scrollspy.data-api', function () {
+    $('[data-spy="scroll"]').each(function () {
+    var $spy = $(this)
+    Plugin.call($spy, $spy.data())
+    })
+})
+
+}(jQuery);
+
+/* ====================================================================
+* Function for generating a hierarchical TOC in pure JS. Assembles a
+* list of links based on Sphinx headings, then injects them into a
+* Bootstrap-compliant #nav-scroll container.
+* ================================================================== */
+
+function GenerateTOC() {
+    /* Grab the main Sphinx article and heading anchors */
+    var page = document.querySelector('div.wy-nav-content');
+    var article = page.querySelector('div[itemprop="articleBody"]');
+    /* Exit if the article starts with a !NO_SCROLLSPY comment */
+    var testNode = article.childNodes[1];
+    if (testNode.nodeType == 8 && testNode.textContent.includes("!NO_SCROLLSPY")) {
+        return false;
+    };
+
+    /* Sphinx uses the .headerlink class for its article headers.
+    Convert to an array because the HTMLCollection type doesn't support
+    array methods. */
+    var anchors = Array.from(article.getElementsByClassName('headerlink'));
+    /* Remove the title from the anchor array, since it won't be in
+    the scrollspy hierarchy */
+    anchors.splice(0, 1);
+    var TOCHTML = "";
+    var prevLevel = 1;
+
+    /* Compose scrollspy nav container */
+    var navScrollHTML = '<div id="nav-scroll"><h1>In this article</h1><div class="nav"></div></div>';
+    /* Inject scrollspy into page */
+    page.insertAdjacentHTML('beforebegin', navScrollHTML);
+
+    /* Build the TOC */
+    anchors.forEach(
+        function(anchor) {
+            /* Grab the bookmark */
+            var bookmark = anchor.getAttribute('href');
+            /* Clone the heading, since we must manipulate its nodes in
+            order to guarantee preservation of its non-anchor HTML */
+            var heading = anchor.parentNode.cloneNode(true);
+            /* Remove the anchor (and pilcrow) from the cloned node */
+            heading.removeChild(heading.lastChild);
+            var headingHTML = heading.innerHTML;
+            var curLevel = heading.nodeName.replace('H', '');
+
+            if (curLevel > prevLevel) {
+                TOCHTML += (new Array(curLevel - prevLevel + 1)).join('<ul>');
+            } else if (curLevel < prevLevel) {
+                TOCHTML += (new Array(prevLevel - curLevel + 1)).join('</li></ul>');
+            } else {
+                TOCHTML += (new Array(prevLevel + 1)).join('</li>');
+            }
+
+            prevLevel = Number(curLevel);
+            TOCHTML += '<li><a href="' + bookmark + '">' + headingHTML + '</a>';
+        }
+    );
+
+    TOCHTML += (new Array(prevLevel + 1)).join('</ul>');
+    /* Add to scrollspy's inner .nav container */
+    page.previousSibling.childNodes[1].insertAdjacentHTML('beforeend', TOCHTML);
+    return true;
+};
+
+document.addEventListener('DOMContentLoaded',
+    function() {
+        hasTOC = GenerateTOC();
+        /* If a TOC was made, call scrollspy on it */
+        if (hasTOC) {
+            $('body').scrollspy({ target: '#nav-scroll', offset: 150 });
+        }; 
+    }
+);

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -422,3 +422,4 @@ def setup( app ) :
     
     # Add the custom stylesheet; used in all .md and .rst files in source
     app.add_stylesheet( 'gaffer.css' )
+    app.add_javascript( 'scrollspy.js' )

--- a/python/GafferUI/DocumentationAlgo.py
+++ b/python/GafferUI/DocumentationAlgo.py
@@ -61,6 +61,7 @@ def exportNodeReference( directory, modules = [], modulePath = "" ) :
 				modules.append( module )
 
 	index = open( "%s/index.md" % directory, "w" )
+	index.write( "<!-- !NO_SCROLLSPY -->\n\n" )
 	index.write( __heading( "Node Reference" ) )
 
 	tocIndex = ""
@@ -92,6 +93,7 @@ def exportNodeReference( directory, modules = [], modulePath = "" ) :
 		if moduleIndex :
 
 			with open( "%s/%s/index.md" % ( directory, module.__name__ ), "w" ) as f :
+				f.write( "<!-- !NO_SCROLLSPY -->\n\n" )
 				f.write( __heading( module.__name__ ) )
 				f.write( __tocString( ).format( moduleIndex ) )
 
@@ -139,6 +141,7 @@ def exportCommandLineReference( directory, appPath = "$GAFFER_ROOT/apps", ignore
 	__makeDirs( directory )
 
 	index = open( "%s/index.md" % directory, "w" )
+	index.write( "<!-- !NO_SCROLLSPY -->\n\n" )
 	index.write( __heading( "Command Line Reference" ) )
 
 	index.write( inspect.cleandoc(


### PR DESCRIPTION
In an effort to improve UX on the docs after I removed the in-article indexes, I've put together a draft scrollspy implementation based on Bootstrap. The intention is to provide signposting and a mini-nav for article contents. For comparison: [Bootstrap](https://getbootstrap.com/docs/3.4/javascript/), [Microsoft](https://docs.microsoft.com/en-us/powershell/scripting/getting-started/starting-windows-powershell?view=powershell-6), and [IBM](https://cloud.ibm.com/docs/bare-metal?topic=bare-metal-about-bm#about-bm).

Obviously it won't work for every article, so I've limited it to articles that have more than 3 headings or are taller than 1600px. It's also only visible on desktop.

Short article preview:
```
~michaeldu/dev/gafferDocsBuilds/docsScrollspy/html/WorkingWithScenes/AnatomyOfAScene/index.html
```

Long article preview:
```
~michaeldu/dev/gafferDocsBuilds/docsScrollspy/html/WorkingWithTheNodeGraph/Box/index.html
```

Items I'd like feedback on:
- Should we keep the conditional presence based on article length? It creates an inconsistency, but to me having the scrollspy appear in articles that have 2 headings or 10 words seems silly. In such cases the links wouldn't be useful, anyway.
- Should it show H3-H6s at all? In some articles it's fine, but in others it makes the scrollspy quite long. Some of the reference articles (`~michaeldu/dev/gafferDocsBuilds/docsScrollspy/html/Reference/ScriptingReference/CommonOperations/index.html`) have a series of H3s in a row that are all a sentence or two.
    - If we keep them in, one way to improve them would be to make the scrollspy a collapsible [accordion](https://en.wikipedia.org/wiki/Accordion_(GUI)). My main reason against doing this was that it hampers the signposting and duplicates the behaviour of the main nav. It would take a bit more effort, but it's doable.
    - Another would be to ignore any individual sections shorter than a certain length, but I can imagine that would seem fickle and confusing.
- Scrollspies don't work on smaller devices. Should I put the effort into moving the container under the article title on mobile, and make it a static index? If I did this, I would have to add accordion functionality; the container would usually be too long otherwise.
- How frustrating is it that short sections at the bottoms of articles can't properly be spied/linked (c.f. the end of _Anatomy of a Scene_)? I can solve this by adding a chunk of negative space to the article bottoms.
- @themissingcow How does the contrast look on a retina monitor?
