### PR TITLE
SetVisualiser components : Avoid deprecated `addOptionalMember()`

### DIFF
--- a/python/GafferSceneTest/SetVisualiserTest.py
+++ b/python/GafferSceneTest/SetVisualiserTest.py
@@ -160,9 +160,9 @@ class SetVisualiserTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual( visualiser["includeInherited"].getValue(), True )
 
-		visualiser["colorOverrides"].addOptionalMember( "setA", red, enabled = True )
-		visualiser["colorOverrides"].addOptionalMember( "setB", green, enabled = True )
-		visualiser["colorOverrides"].addOptionalMember( "setC", blue, enabled = True )
+		visualiser["colorOverrides"].addChild( Gaffer.NameValuePlug( "setA", red, True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		visualiser["colorOverrides"].addChild( Gaffer.NameValuePlug( "setB", green, True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		visualiser["colorOverrides"].addChild( Gaffer.NameValuePlug( "setC", blue, True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 
 		self.assertEqual( visualiser["out"].attributes( "/group" )["gl:surface"].outputShader().parameters["colors"][0], red )
 		self.assertEqual( visualiser["out"].attributes( "/group/sphere" )["gl:surface"].outputShader().parameters["colors"][0], red )
@@ -173,7 +173,6 @@ class SetVisualiserTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( visualiser["out"].attributes( "/group/sphere2" )["gl:surface"].outputShader().parameters["colors"][0], red )
 		self.assertEqual( visualiser["out"].attributes( "/group/sphere2" )["gl:surface"].outputShader().parameters["colors"][1], green )
 		self.assertEqual( visualiser["out"].attributes( "/group/sphere2" )["gl:surface"].outputShader().parameters["colors"][2], blue )
-
 
 	def testColorOverrides( self ) :
 
@@ -195,7 +194,7 @@ class SetVisualiserTest( GafferSceneTest.SceneTestCase ) :
 			i = d["names"].index( name )
 			return d["colors"][i]
 
-		visualiser["colorOverrides"].addOptionalMember( "setA", white, enabled = True )
+		visualiser["colorOverrides"].addChild( Gaffer.NameValuePlug( "setA", white, True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 		self.assertEqual( colorForSetName( "setA" ), white )
 		self.assertNotEqual( colorForSetName( "setB" ), white )
 		self.assertNotEqual( colorForSetName( "setC" ), white )
@@ -226,17 +225,17 @@ class SetVisualiserTest( GafferSceneTest.SceneTestCase ) :
 
 		# None of these should error as empty names or disabled should be fine
 
-		visualiser["colorOverrides"].addOptionalMember( "setA", imath.Color3f( 1.0 ), enabled = True )
+		visualiser["colorOverrides"].addChild( Gaffer.NameValuePlug( "setA", imath.Color3f( 1.0 ), True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 		visualiser["__outSets"].getValue()
 
-		visualiser["colorOverrides"].addOptionalMember( "setB", imath.Color3f( 1.0 ), enabled = False )
+		visualiser["colorOverrides"].addChild( Gaffer.NameValuePlug( "setB", imath.Color3f( 1.0 ), False, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 		visualiser["__outSets"].getValue()
 
-		visualiser["colorOverrides"].addOptionalMember( "", imath.Color3f( 1.0 ), enabled = True )
+		visualiser["colorOverrides"].addChild( Gaffer.NameValuePlug( "", imath.Color3f( 1.0 ), True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 		visualiser["__outSets"].getValue()
 
-		# Non-color3f types should errror
-		visualiser["colorOverrides"].addOptionalMember( "setB", "notAColor", enabled = True )
+		# Non-color3f types should error
+		visualiser["colorOverrides"].addChild( Gaffer.NameValuePlug( "setB", "notAColor", True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 		self.assertRaises( RuntimeError, visualiser["__outSets"].getValue )
 
 	__testSetNames = [ 'setA', 'setB', 'setC' ]

--- a/python/GafferSceneUI/SetVisualiserUI.py
+++ b/python/GafferSceneUI/SetVisualiserUI.py
@@ -222,7 +222,7 @@ class _OverridesFooter( GafferUI.PlugValueWidget ) :
 	def __addOverride( self, _ ) :
 
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
-			self.getPlug().addOptionalMember( "", imath.Color3f( 1.0 ) , enabled=True )
+			self.getPlug().addChild( Gaffer.NameValuePlug( "", imath.Color3f( 1.0 ), True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 
 # A single-row that holds a Color swatch and a text label
 class _SetColorLedgendRowWidget( GafferUI.ListContainer ) :
@@ -274,7 +274,7 @@ class _SetColorLedgendRowWidget( GafferUI.ListContainer ) :
 		targetPlug, _ = self.__colorOverridesPlug()
 		if targetPlug:
 			with Gaffer.UndoScope( targetPlug.ancestor( Gaffer.ScriptNode ) ) :
-				targetPlug.addOptionalMember( self.__label.getText(), imath.Color3f( 1.0 ) , enabled=True )
+				targetPlug.addChild( Gaffer.NameValuePlug( self.__label.getText(), imath.Color3f( 1.0 ), True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 			editor = self.ancestor( GafferUI.NodeUI )
 			if editor:
 				editor.plugValueWidget( targetPlug ).reveal()


### PR DESCRIPTION
I think these just escaped the update because Tom's PR overlapped with Daniel's.