### PR TITLE
FileSequenceParameterValueWidget: Support for typeHint:includeSequences

### DIFF
--- a/python/GafferCortexUI/FileSequenceParameterValueWidget.py
+++ b/python/GafferCortexUI/FileSequenceParameterValueWidget.py
@@ -56,6 +56,7 @@ class FileSequenceParameterValueWidget( GafferCortexUI.PathParameterValueWidget 
 		return Gaffer.FileSystemPath.createStandardFilter( includeSequenceFilter = True )
 
 GafferCortexUI.ParameterValueWidget.registerType( IECore.FileSequenceParameter, FileSequenceParameterValueWidget )
+GafferCortexUI.ParameterValueWidget.registerType( IECore.PathParameter, FileSequenceParameterValueWidget, uiTypeHint="includeSequences" )
 
 # we've copied this list of node types from
 # ParameterisedHolderUI because it seemed
@@ -78,7 +79,15 @@ def __isFileSequence( plug ) :
 	for p in plug.relativeName( plug.node() ).split( "." )[1:] :
 		parameter = parameter[p]
 
-	return isinstance( parameter, IECore.FileSequenceParameter )
+	if isinstance( parameter, IECore.FileSequenceParameter ) :
+		return True
+
+	if isinstance( parameter, IECore.PathParameter ) :
+		with IECore.IgnoredExceptions( KeyError ) :
+			return parameter.userData()["UI"]["typeHint"].value == "includeSequences"
+
+	return False
+
 
 def __includeFrameRange( plug ) :
 


### PR DESCRIPTION
This should enable us to use select either single files or file
sequences for any IECore.PathParameter, as long as the ui typeHint is
set to "includeSequences".

- FileSequenceParameterValueWidget: Support for typeHint:includeSequences

----

@johnhaddon, people here need to be able to select either a file sequence or a single file for the same `IECore.FileNameParameter`.

Currently, it looks like we only get the file sequence dialogue and options when using the `IECore.FileSequenceParameter`.

This PR is one way of addressing it, by adding support for a UI typeHint "includeSequences" metadata on the parameter.

Let me know if there is another way of achieving the same result, and we can try it here.

Thanks!

Ivan
