### PR TITLE
Make GafferCortex optional

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -278,6 +278,15 @@ options.Add(
 # general variables
 
 options.Add(
+	BoolVariable(
+		"GAFFERCORTEX",
+		"Builds and installs the GafferCortex modules. These are deprecated and will "
+		"be removed completely in a future version.",
+		True
+	)
+)
+
+options.Add(
 	"ENV_VARS_TO_IMPORT",
 	"By default SCons ignores the environment it is run in, to avoid it contaminating the "
 	"build process. This can be problematic if some of the environment is critical for "
@@ -694,17 +703,22 @@ libraries = {
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferBindings", "GafferCortex", "GafferDispatch" ],
 		},
+		"requiredOptions" : [ "GAFFERCORTEX" ],
 	},
 
 	"GafferCortexTest" : {
 		"additionalFiles" : glob.glob( "python/GafferCortexTest/*/*" ) + glob.glob( "python/GafferCortexTest/*/*/*" ) + glob.glob( "python/GafferCortexTest/images/*" ),
+		"requiredOptions" : [ "GAFFERCORTEX" ],
 	},
 
 	"GafferCortexUI" : {
 		"apps" : [ "op" ],
+		"requiredOptions" : [ "GAFFERCORTEX" ],
 	},
 
-	"GafferCortexUITest" : {},
+	"GafferCortexUITest" : {
+		"requiredOptions" : [ "GAFFERCORTEX" ],
+	},
 
 	"GafferScene" : {
 		"envAppends" : {

--- a/SConstruct
+++ b/SConstruct
@@ -643,6 +643,7 @@ libraries = {
 			"LIBS" : [ "GafferTest", "GafferBindings" ],
 		},
 		"additionalFiles" : glob.glob( "python/GafferTest/*/*" ) + glob.glob( "python/GafferTest/*/*/*" ),
+		"apps" : [ "cli", "env", "license", "python", "stats", "test" ],
 	},
 
 	"GafferUI" : {
@@ -655,6 +656,7 @@ libraries = {
 			 # this if we move to boost::signals2.
 			 "CXXFLAGS" : [ "-DQT_NO_KEYWORDS" ],
 		},
+		"apps" : [ "browser", "gui", "screengrab", "view" ],
 	},
 
 	"GafferUITest" : {
@@ -670,6 +672,7 @@ libraries = {
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferBindings", "GafferDispatch" ],
 		},
+		"apps" : [ "execute" ],
 	},
 
 	"GafferDispatchTest" : {
@@ -678,7 +681,9 @@ libraries = {
 
 	},
 
-	"GafferDispatchUI" : {},
+	"GafferDispatchUI" : {
+		"apps" : [ "dispatch" ],
+	},
 
 	"GafferDispatchUITest" : {},
 
@@ -695,7 +700,9 @@ libraries = {
 		"additionalFiles" : glob.glob( "python/GafferCortexTest/*/*" ) + glob.glob( "python/GafferCortexTest/*/*/*" ) + glob.glob( "python/GafferCortexTest/images/*" ),
 	},
 
-	"GafferCortexUI" : {},
+	"GafferCortexUI" : {
+		"apps" : [ "op" ],
+	},
 
 	"GafferCortexUITest" : {},
 
@@ -892,16 +899,8 @@ libraries = {
 		"additionalFiles" : glob.glob( "python/GafferVDBUITest/*/*" ),
 	},
 
-	"apps" : {
-		"additionalFiles" : glob.glob( "apps/*/*-1.py" ),
-	},
-
 	"scripts" : {
 		"additionalFiles" : [ "bin/gaffer", "bin/gaffer.py" ],
-	},
-
-	"startupScripts" : {
-		"additionalFiles" : glob.glob( "startup/*/*.py" ),
 	},
 
 	"misc" : {
@@ -1076,6 +1075,19 @@ for libraryName, libraryDef in libraries.items() :
 	for pythonFile in pythonFiles :
 		pythonFileInstall = env.Command( "$BUILD_DIR/" + pythonFile, pythonFile, "sed \"" + sedSubstitutions + "\" $SOURCE > $TARGET" )
 		env.Alias( "build", pythonFileInstall )
+
+	# apps
+
+	for app in libraryDef.get( "apps", [] ) :
+		appInstall = env.InstallAs("$BUILD_DIR/apps/{app}/{app}-1.py".format( app=app ), "apps/{app}/{app}-1.py".format( app=app ) )
+		env.Alias( "build", appInstall )
+
+	# startup files
+
+	for startupDir in libraryDef.get( "apps", [] ) + [ libraryName ] :
+		for startupFile in glob.glob( "startup/{startupDir}/*.py".format( startupDir=startupDir ) ) :
+			startupFileInstall = env.InstallAs( "$BUILD_DIR/" + startupFile, startupFile )
+			env.Alias( "build", startupFileInstall )
 
 	# additional files
 

--- a/apps/browser/browser-1.py
+++ b/apps/browser/browser-1.py
@@ -40,9 +40,6 @@ import os
 import IECore
 import Gaffer
 import GafferUI
-import GafferCortexUI
-import GafferImageUI
-import GafferSceneUI # for alembic previews
 
 from Qt import QtWidgets
 

--- a/apps/view/view-1.py
+++ b/apps/view/view-1.py
@@ -39,9 +39,6 @@ import IECore
 
 import Gaffer
 import GafferUI
-import GafferCortexUI
-import GafferImageUI
-import GafferSceneUI
 
 class view( Gaffer.Application ) :
 

--- a/startup/Gaffer/gafferCortexCompatibility.py
+++ b/startup/Gaffer/gafferCortexCompatibility.py
@@ -35,11 +35,18 @@
 ##########################################################################
 
 import Gaffer
-import GafferCortex
 
-# Backwards compatibility - import classes from GafferCortex into
-# the Gaffer namespace.
-for name in dir( GafferCortex ) :
-	if name.endswith( "__" ) :
-		continue
-	setattr( Gaffer, name, getattr( GafferCortex, name ) )
+try :
+
+	import GafferCortex
+
+	# Backwards compatibility - import classes from GafferCortex into
+	# the Gaffer namespace.
+	for name in dir( GafferCortex ) :
+		if name.endswith( "__" ) :
+			continue
+		setattr( Gaffer, name, getattr( GafferCortex, name ) )
+
+except ImportError :
+
+	pass

--- a/startup/GafferUI/gafferCortexUICompatibility.py
+++ b/startup/GafferUI/gafferCortexUICompatibility.py
@@ -37,18 +37,25 @@
 import re
 
 import GafferUI
-import GafferCortexUI
 
-# Backwards compatibility - import things from GafferCortexUI into
-# the GafferUI namespace where appropriate.
+try :
 
-for name in dir( GafferCortexUI ) :
-	if name.endswith( "__" ) :
-		continue
-	setattr( GafferUI, name, getattr( GafferCortexUI, name ) )
+	import GafferCortexUI
 
-def __appendParameterisedHolders( self, path, parameterisedHolderType, searchPathEnvVar, matchExpression = re.compile( ".*" ) ) :
+	# Backwards compatibility - import things from GafferCortexUI into
+	# the GafferUI namespace where appropriate.
 
-	GafferCortexUI.ParameterisedHolderUI.appendParameterisedHolders( self.definition(), path, searchPathEnvVar, parameterisedHolderType, matchExpression )
+	for name in dir( GafferCortexUI ) :
+		if name.endswith( "__" ) :
+			continue
+		setattr( GafferUI, name, getattr( GafferCortexUI, name ) )
 
-GafferUI.NodeMenu.appendParameterisedHolders = __appendParameterisedHolders
+	def __appendParameterisedHolders( self, path, parameterisedHolderType, searchPathEnvVar, matchExpression = re.compile( ".*" ) ) :
+
+		GafferCortexUI.ParameterisedHolderUI.appendParameterisedHolders( self.definition(), path, searchPathEnvVar, parameterisedHolderType, matchExpression )
+
+	GafferUI.NodeMenu.appendParameterisedHolders = __appendParameterisedHolders
+
+except ImportError :
+
+	pass

--- a/startup/browser/previews.py
+++ b/startup/browser/previews.py
@@ -1,0 +1,43 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferImageUI # For ImageReaderPathPreview
+import GafferSceneUI # For SceneReaderPathPreview
+
+try :
+	import GafferCortexUI
+except ImportError :
+	pass

--- a/startup/view/previews.py
+++ b/startup/view/previews.py
@@ -1,0 +1,43 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferImageUI # For ImageReaderPathPreview
+import GafferSceneUI # For SceneReaderPathPreview
+
+try :
+	import GafferCortexUI
+except ImportError :
+	pass


### PR DESCRIPTION
We've long since hidden the legacy GafferCortex functionality from the UI in standard Gaffer builds, but the module itself lingers on because it is deeply embedded in the pipeline at Image Engine. The long-term plan is to remove it from Gaffer entirely, and this PR brings us one step closer by making it an optional component at build time. I intend to use this to exclude GafferCortex from the public builds to ensure that nobody else can become hooked on the legacy functionality before it is finally removed.

To be clear, the default build has not changed, and we'll still use Travis to ensure the health and wellbeing of GafferCortex until its final demise. I'm just planning to remove it from the official release builds.