### PR TITLE
Docs : Sphinx 1.8.0 compatibility

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,1 @@
+.doctrees

--- a/doc/source/GettingStarted/ConfiguringGafferForThirdPartyTools/index.md
+++ b/doc/source/GettingStarted/ConfiguringGafferForThirdPartyTools/index.md
@@ -7,9 +7,7 @@ Gaffer is compatible with the following commercial and open-source third-party t
 - [3Delight](http://www.3delight.com/)
 - [Tractor](https://renderman.pixar.com/tractor)
 
-```eval_rst
-Gaffer comes with Appleseed, so it will require no additional configuration. For the rest of the tools in this list, you will need to set some additional :ref:`environment variables<Environment Variables>`.
-```
+Gaffer comes with Appleseed, so it will require no additional configuration. For the rest of the tools in this list, you will need to set some additional environment variables.
 
 > Note :
 > For the the following Linux instructions, we will assume you are using the _bash_ shell and are familiar with terminal commands. Other shells will have comparable methods for setting environment variables.

--- a/doc/source/ReleaseNotes/generate.py
+++ b/doc/source/ReleaseNotes/generate.py
@@ -4,6 +4,7 @@ import re
 import inspect
 
 changes = open( "../../../Changes" )
+# remove me
 
 versionFile = None
 
@@ -13,7 +14,7 @@ for line in changes :
 
 	m = re.match( r"^(Gaffer )?(([0-9]+\.){2,3}[0-9]+)", line )
 	if m :
-		versionIndex += ( "\n\t{0}.md".format( m.group( 2 ) ) )
+		versionIndex += ( "\n{}{}.md".format( " " * 4, m.group( 2 ) ) )
 		versionFile = open( m.group( 2 ) + ".md", "w" )
 		versionFile.write( m.group( 2 ) + "\n" )
 		continue

--- a/python/GafferUI/DocumentationAlgo.py
+++ b/python/GafferUI/DocumentationAlgo.py
@@ -87,7 +87,7 @@ def exportNodeReference( directory, modules = [], modulePath = "" ) :
 			__makeDirs( directory + "/" + module.__name__ )
 			with open( "%s/%s/%s.md" % ( directory, module.__name__, name ), "w" ) as f :
 				f.write( __nodeDocumentation( node ) )
-				moduleIndex += "\n\t%s.md" % name
+				moduleIndex += "\n{}{}.md".format( " " * 4, name )
 
 		if moduleIndex :
 
@@ -95,7 +95,7 @@ def exportNodeReference( directory, modules = [], modulePath = "" ) :
 				f.write( __heading( module.__name__ ) )
 				f.write( __tocString( ).format( moduleIndex ) )
 
-			tocIndex += "\n\t%s/index.md" % ( module.__name__ )
+			tocIndex += "\n{}{}/index.md".format( " " * 4, module.__name__ )
 
 	index.write( __tocString( ).format( tocIndex ) )
 
@@ -185,7 +185,7 @@ def exportCommandLineReference( directory, appPath = "$GAFFER_ROOT/apps", ignore
 		if appName in ignore :
 			continue
 
-		tocIndex += "\n\t%s.md" % appName
+		tocIndex += "\n{}{}.md".format( " " * 4, appName )
 		with open( "%s.md" % appName, "w" ) as f :
 
 			f.write( __appDocumentation( classLoader.load( appName )() ) )


### PR DESCRIPTION
This fixes the broken index in later versions of Sphinx, and should hopefully resolve the build failure that's blocking @themissingcow from building with Sphinx 1.8.2 at CineSite.

1. Make all the auto-generated `toctree` reST directives use spaces instead of tabs for indentation. While not part of the official spec, apparently the updated docutils can't handle tabs anymore. [Python recommends 3 spaces](https://devguide.python.org/documenting/#use-of-whitespace), but 4 works, and I prefer 4 for consistency and convention.
2. Add a `.gitignore` to skip the auto-genned `.doctrees` directory.
3. Remove an unused leftover `:ref:` directive from one of the articles. @themissingcow I couldn't reproduce the complete build failure you saw in your Docker build (maybe because I'm testing with 1.8.0?), but from the log it seems to be related to this. Let me know if this resolves it.

There are still a few broken links that updated Sphinx is picking up, but they shouldn't stop the build. I have several open PRs for which I don't want to create merge incompatibilities.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
