### PR TITLE
IECoreArnoldPreview : Remove unused lambda captures

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -2527,7 +2527,7 @@ void LightFilterConnections::update()
 
 	parallel_for(
 		m_connections.range(),
-		[this, &deregistered]( ConnectionsMap::range_type &range )
+		[&deregistered]( ConnectionsMap::range_type &range )
 		{
 			for( auto it = range.begin(); it != range.end(); ++it )
 			{


### PR DESCRIPTION
Fixes OSX build:

 src/GafferArnold/IECoreArnoldPreview/Renderer.cpp:2530:4: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
