### PR TITLE
0.53.6.0 Backports

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,23 @@
+0.53.6.0 (relative to 0.53.5.0)
+========
+
+Improvements
+------------
+
+- FileSequenceParameterValueWidget: Added support for typeHint:includeSequences
+
+Fixes
+-----
+
+- ViewportGadget::SelectionScope : Fixed bug causing GL attribute state to leak
+- GafferUI::PlugValueWidget : Fixed bug causing output plugs to be unaffected by context
+- GafferImage::BleedFill : Fixed bug regarding negative inputs
+- TransformTool
+  - Fixed issue causing unnecessary work when disabled
+  - Fixed crash in selection processing code
+- Stats app : Fixed context management bug when computing image properties
+- Docs : Fixed broken link in introduction
+
 0.53.5.0 (relative to 0.53.4.0)
 ========
 

--- a/SConstruct
+++ b/SConstruct
@@ -52,7 +52,7 @@ import subprocess
 
 gafferMilestoneVersion = 0 # for announcing major milestones - may contain all of the below
 gafferMajorVersion = 53 # backwards-incompatible changes
-gafferMinorVersion = 5 # new backwards-compatible features
+gafferMinorVersion = 6 # new backwards-compatible features
 gafferPatchVersion = 0 # bug fixes
 
 # All of the following must be considered when determining

--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -466,11 +466,12 @@ class stats( Gaffer.Application ) :
 		self.__timers["Image generation"] = imageTimer
 		self.__memory["Image generation"] = _Memory.maxRSS() - memory
 
-		items = [
-			( "Format", image["format"].getValue() ),
-			( "Data window", image["dataWindow"].getValue() ),
-			( "Channel names", image["channelNames"].getValue() ),
-		]
+		with self.__context( script, args ) as context :
+			items = [
+				( "Format", image["format"].getValue() ),
+				( "Data window", image["dataWindow"].getValue() ),
+				( "Channel names", image["channelNames"].getValue() ),
+			]
 
 		self.__output.write( "\nImage :\n\n" )
 		self.__writeItems( items )

--- a/config/travis/installDelight.sh
+++ b/config/travis/installDelight.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-version=1.1.7
-directory=free/beta/2018-10-05-Y88MpygF
+version=1.1.12
+directory=free/beta/2018-11-01-oIDoJTpO
 
 if [[ `uname` = "Linux" ]] ; then
 	package=3DelightNSI-$version-Linux-x86_64

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -17,7 +17,7 @@ Gaffer is open source software hosted and maintained on GitHub: [https://github.
 
 To start, you should:
 
-* [Install Gaffer](Installation/index.md)
+* [Install Gaffer](GettingStarted/InstallingGaffer/index.md)
 * Complete the [Getting Started tutorial](Tutorials/BeginnerTutorial/index.md)
 
 If you are are looking to automate VFX processes or develop with Gaffer's API, you should also:

--- a/python/GafferCortexUI/FileSequenceParameterValueWidget.py
+++ b/python/GafferCortexUI/FileSequenceParameterValueWidget.py
@@ -56,6 +56,7 @@ class FileSequenceParameterValueWidget( GafferCortexUI.PathParameterValueWidget 
 		return Gaffer.FileSystemPath.createStandardFilter( includeSequenceFilter = True )
 
 GafferCortexUI.ParameterValueWidget.registerType( IECore.FileSequenceParameter, FileSequenceParameterValueWidget )
+GafferCortexUI.ParameterValueWidget.registerType( IECore.PathParameter, FileSequenceParameterValueWidget, uiTypeHint="includeSequences" )
 
 # we've copied this list of node types from
 # ParameterisedHolderUI because it seemed
@@ -78,7 +79,15 @@ def __isFileSequence( plug ) :
 	for p in plug.relativeName( plug.node() ).split( "." )[1:] :
 		parameter = parameter[p]
 
-	return isinstance( parameter, IECore.FileSequenceParameter )
+	if isinstance( parameter, IECore.FileSequenceParameter ) :
+		return True
+
+	if isinstance( parameter, IECore.PathParameter ) :
+		with IECore.IgnoredExceptions( KeyError ) :
+			return parameter.userData()["UI"]["typeHint"].value == "includeSequences"
+
+	return False
+
 
 def __includeFrameRange( plug ) :
 

--- a/python/GafferImage/BleedFill.py
+++ b/python/GafferImage/BleedFill.py
@@ -107,6 +107,7 @@ class BleedFill( GafferImage.ImageProcessor ) :
 		self["__grade"] = GafferImage.Grade( "Grade" )
 		self["__grade"]['channels'].setValue( "*" )
 		self["__grade"]['multiply'].setValue( imath.Color4f( 0.1 ) )
+		self["__grade"]['blackClamp'].setValue( False )
 		self["__grade"]["in"].setInput( self["__downsample"]["out"] )
 
 		self["__blurLoop"]["next"].setInput( self["__grade"]["out"] )

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -486,7 +486,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		context = self.__context
 		plug = self.getPlug()
-		if plug is None or plug.getInput() is None :
+		if plug is None or ( plug.getInput() is None and plug.direction() == Gaffer.Plug.Direction.In ):
 			context = None
 
 		if context is not None :

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -578,7 +578,7 @@ void TransformTool::updateSelection() const
 			{
 				return false;
 			}
-			return a.path == lastSelectedPath;
+			return ( a.path != lastSelectedPath ) < ( b.path != lastSelectedPath );
 		}
 	);
 

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -333,6 +333,7 @@ TransformTool::TransformTool( SceneView *view, const std::string &name )
 		m_mergeGroupId( 0 )
 {
 	view->viewportGadget()->addChild( m_handles );
+	m_handles->setVisible( false );
 
 	storeIndexOfNextChild( g_firstPlugIndex );
 
@@ -341,7 +342,6 @@ TransformTool::TransformTool( SceneView *view, const std::string &name )
 
 	scenePlug()->setInput( view->inPlug<ScenePlug>() );
 
-	view->viewportGadget()->preRenderSignal().connect( boost::bind( &TransformTool::preRender, this ) );
 	view->viewportGadget()->keyPressSignal().connect( boost::bind( &TransformTool::keyPress, this, ::_2 ) );
 	plugDirtiedSignal().connect( boost::bind( &TransformTool::plugDirtied, this, ::_1 ) );
 
@@ -467,6 +467,19 @@ void TransformTool::plugDirtied( const Gaffer::Plug *plug )
 	if( affectsHandles( plug ) )
 	{
 		m_handlesDirty = true;
+	}
+
+	if( plug == activePlug() )
+	{
+		if( activePlug()->getValue() )
+		{
+			view()->viewportGadget()->preRenderSignal().connect( boost::bind( &TransformTool::preRender, this ) );
+		}
+		else
+		{
+			view()->viewportGadget()->preRenderSignal().disconnect( boost::bind( &TransformTool::preRender, this ) );
+			m_handles->setVisible( false );
+		}
 	}
 }
 

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -1601,6 +1601,9 @@ void ViewportGadget::SelectionScope::begin( const ViewportGadget *viewportGadget
 
 void ViewportGadget::SelectionScope::begin( const ViewportGadget *viewportGadget, const Imath::Box2f &rasterRegion, const Imath::M44f &transform, IECoreGL::Selector::Mode mode )
 {
+	glPushAttrib( GL_ALL_ATTRIB_BITS );
+	glPushClientAttrib( GL_CLIENT_ALL_ATTRIB_BITS );
+
 	V2f viewport = viewportGadget->getViewport();
 	Box2f ndcRegion( rasterRegion.min / viewport, rasterRegion.max / viewport );
 
@@ -1629,6 +1632,9 @@ void ViewportGadget::SelectionScope::end()
 	glPopMatrix();
 	m_selector = SelectorPtr();
 
+	glPopClientAttrib();
+	glPopAttrib();
+
 	if( m_depthSort )
 	{
 		std::sort( m_selection.begin(), m_selection.end() );
@@ -1637,7 +1643,6 @@ void ViewportGadget::SelectionScope::end()
 	{
 		std::reverse( m_selection.begin(), m_selection.end() );
 	}
-
 }
 
 ViewportGadget::RasterScope::RasterScope( const ViewportGadget *viewportGadget )


### PR DESCRIPTION
Hey guys,

first attempt at backporting some fixes for the 53.x line of Gaffer. Am I missing anything we want to add?

John, can you take a look at 091b58c, please? I'm trying to avoid the ABI compatibility break there and it looks to me like we don't need to add a member variable, if we do the disconnecting this way. I've tried to make sure by doing these:
- Adding a print in `preRender()`
- Leaving the connection as a test and adding `assert( !m_preRenderConnection.connected() )` after disconnecting via the new way and `assert( m_preRenderConnection.connected() )` after making the connection.

I've then compiled it in debug and played with moving a sphere. Prints where showing up only when the tool was active and I never got any assertion errors. Am I missing anything else that could go wrong?

Does the change log look alright?

Cheers,

Matti.
