### PR TITLE
RenderController : remove light attributes

### DIFF
--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -403,6 +403,24 @@ class RenderController::SceneGraph
 			ConstCompoundObjectPtr attributes = attributesPlug->getValue( &attributesHash );
 			CompoundObject::ObjectMap &fullAttributes = m_fullAttributes->members();
 			fullAttributes = m_parent->m_fullAttributes->members();
+
+			// Light shaders are attributes that shouldn't be inherited
+			std::vector<IECore::InternedString> toRemove;
+			for( auto it = fullAttributes.begin(), eIt = fullAttributes.end(); it != eIt; ++it )
+			{
+				if( !boost::ends_with( it->first.string(), ":light" ) )
+				{
+					continue;
+				}
+
+				toRemove.push_back( it->first );
+			}
+
+			for( const IECore::InternedString &superfluous : toRemove )
+			{
+				fullAttributes.erase( superfluous );
+			}
+
 			for( CompoundObject::ObjectMap::const_iterator it = attributes->members().begin(), eIt = attributes->members().end(); it != eIt; ++it )
 			{
 				fullAttributes[it->first] = it->second;


### PR DESCRIPTION
Hey John,

There's a problem with light visualisation being duplicated when parenting something under a light and I'm trying to fix that in this PR. Whether I'm doing it in the right spot I'm not sure, but I'm curious to see what you think.

The problem is visible when you use a setup like this:

```
import Gaffer
import GafferArnold
import GafferScene
import IECore
import imath

__children = {}

__children["spot_light1"] = GafferArnold.ArnoldLight( "spot_light1" )
parent.addChild( __children["spot_light1"] )
__children["spot_light1"].loadShader( "spot_light" )
__children["spot_light1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Parent1"] = GafferScene.Parent( "Parent1" )
parent.addChild( __children["Parent1"] )
__children["Parent1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["CoordinateSystem1"] = GafferScene.CoordinateSystem( "CoordinateSystem1" )
parent.addChild( __children["CoordinateSystem1"] )
__children["CoordinateSystem1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["spot_light1"]["transform"]["translate"].setValue( imath.V3f( -1.5124402, 0, 2.64671493 ) )
__children["spot_light1"]["parameters"]["exposure"].setValue( 3.5299999713897705 )
__children["spot_light1"]["__uiPosition"].setValue( imath.V2f( -56.7998848, 14.6607533 ) )
__children["Parent1"]["in"].setInput( __children["spot_light1"]["out"] )
__children["Parent1"]["parent"].setValue( '/light' )
__children["Parent1"]["child"].setInput( __children["CoordinateSystem1"]["out"] )
__children["Parent1"]["__uiPosition"].setValue( imath.V2f( -48.83078, 6.49669123 ) )
__children["CoordinateSystem1"]["transform"]["translate"].setValue( imath.V3f( 3.12528014, 0, 0 ) )
__children["CoordinateSystem1"]["__uiPosition"].setValue( imath.V2f( -41.9283409, 14.6607523 ) )

del __children
```

This seems like it's generally a fair thing to do, but now the coordinate system is inheriting the shader the light is using. When rendering through our Arnold backend it doesn't matter. My understanding is that is because we only look at the shader when handling ArnoldLights, which we're only doing for locations that are in the `__lights` set (directly and not just through inheritance). Our system for visualising lights in the viewport does not differentiate between lights and other things, though. Hence the duplicated visualisation.

I think putting these checks somewhere before hitting the renderer backends makes sense because handing off "bogus" data like that is a little sloppy? Potentially it would be nicer to do this even earlier so that the user doesn't even see the inherited data in the SceneInspector? Since that's such a intrusive change, I've opted for cleaning up the attributes at this point in the chain... 
I've also looked at doing it locally in the GL backend, but the way it's structured is unhelpful in this case, I think. Directly on construction of the respective attributes representation, we're creating all the visualisers, so there's no way to remove one later on once we realize that we're not handling a light after all. Maybe I'm overlooking something, though. The way things fit together is quite sophisticated and jabbing in this cleanup code definitely doesn't feel too good ;)

Thanks and cheerio! :)

Matti.