### PR TITLE
StandardLightVisualiser : early out if scale is set to 0 anyway

### DIFF
--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -246,10 +246,17 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::I
 	///   and not the rendering - no out-of-the-box light has one that I know of. Perhaps it should
 	///   be an attribute that the `GafferScene::light()` node sets?
 	/// - We don't actually want to apply it to the area light shapes created below for "quad" etc.
+	/// - We should find a better way to opt out of expensive visualisations (in particular for
+	///   large environment light textures)
 	///
 	/// Since this feature is only used by lights internal to Image Engine, we can ignore all this for
 	/// now, but it would be good to address in the future.
 	const float locatorScale = parameter<float>( metadataTarget, shaderParameters, "locatorScaleParameter", 1 );
+	if( locatorScale == 0 )
+	{
+		return result;
+	}
+
 	Imath::M44f topTrans;
 	if( orientation )
 	{


### PR DESCRIPTION
The context here is that for environment lights that load extremely large
textures, expanding the respective scene location triggering the visualiser is
taking a long time. Previously there was no way to switch this off as even a
visualiser scale of 0 would hand over the textures to the GPU.

Are you ok with this, John? I know that bit of code is considered a bit of a dirty corner, but I hope I'm not adding too much dirt there... I think ideally we should also add a mechanism that would let us keep the light but just switch off the texture visualisation. Maybe something to keep in mind for a later day. 