### PR TITLE
Visualiser Attributes

### DIFF
--- a/include/GafferScene/Light.h
+++ b/include/GafferScene/Light.h
@@ -81,6 +81,9 @@ class GAFFERSCENE_API Light : public ObjectSource
 		virtual void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
 		virtual IECoreScene::ShaderNetworkPtr computeLight( const Gaffer::Context *context ) const = 0;
 
+		Gaffer::FloatPlug *visualiserScalePlug();
+		const Gaffer::FloatPlug *visualiserScalePlug() const;
+
 	private :
 
 		static size_t g_firstPlugIndex;

--- a/include/GafferSceneUI/LightVisualiser.h
+++ b/include/GafferSceneUI/LightVisualiser.h
@@ -43,6 +43,8 @@
 
 #include "IECoreScene/ShaderNetwork.h"
 
+#include "IECore/CompoundObject.h"
+
 namespace GafferSceneUI
 {
 
@@ -65,7 +67,7 @@ class GAFFERSCENEUI_API LightVisualiser : public IECore::RefCounted
 
 		/// Must be implemented by derived classes to visualise
 		/// the light contained within `shaderNetwork`.
-		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, IECoreGL::ConstStatePtr &state ) const = 0;
+		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const = 0;
 
 		/// Registers a visualiser to visualise a particular type of light.
 		/// For instance, `registerLightVisualiser( "ai:light", "point_light", visualiser )`

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -62,7 +62,7 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public LightVisualiser
 		StandardLightVisualiser();
 		~StandardLightVisualiser() override;
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, IECoreGL::ConstStatePtr &state ) const override;
+		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
 
 		static void spotlightParameters( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, float &innerAngle, float &outerAngle, float &lensRadius );
 

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -89,6 +89,17 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Light Linking",
 
+		],
+
+		"visualiserScale" : [
+
+			"description",
+			"""
+			The scale of the visualisation in the viewport.
+			""",
+
+			"layout:section", "Visualisation",
+
 		]
 
 	}

--- a/src/GafferSceneUI/LightVisualiser.cpp
+++ b/src/GafferSceneUI/LightVisualiser.cpp
@@ -149,7 +149,7 @@ IECoreGL::ConstRenderablePtr AttributeVisualiserForLights::visualise( const IECo
 		}
 
 		IECoreGL::ConstStatePtr curState = nullptr;
-		IECoreGL::ConstRenderablePtr curVis = visualiser->visualise( it->first, shaderNetwork, curState );
+		IECoreGL::ConstRenderablePtr curVis = visualiser->visualise( it->first, shaderNetwork, attributes, curState );
 
 		if( curVis )
 		{

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -240,19 +240,16 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::I
 
 	/// \todo This is problematic for a few reasons :
 	///
-	/// - The name "locatorScale" doesn't fit Gaffer's terminology - perhaps "visualiserScale"
-	///    would be better?
-	/// - It doesn't make much sense to have a shader parameter which affects only the visualisation
-	///   and not the rendering - no out-of-the-box light has one that I know of. Perhaps it should
-	///   be an attribute that the `GafferScene::light()` node sets?
 	/// - We don't actually want to apply it to the area light shapes created below for "quad" etc.
 	/// - We should find a better way to opt out of expensive visualisations (in particular for
 	///   large environment light textures)
 	///
 	/// Since this feature is only used by lights internal to Image Engine, we can ignore all this for
 	/// now, but it would be good to address in the future.
-	const float locatorScale = parameter<float>( metadataTarget, shaderParameters, "locatorScaleParameter", 1 );
-	if( locatorScale == 0 )
+	const FloatData *visualiserScaleData = attributes->member<FloatData>( "visualiser:scale" );
+	float visualiserScale = visualiserScaleData ? visualiserScaleData->readable() : 1.0;
+
+	if( visualiserScale == 0 )
 	{
 		return result;
 	}
@@ -262,7 +259,7 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::I
 	{
 		topTrans = orientation->readable();
 	}
-	topTrans.scale( V3f( locatorScale ) );
+	topTrans.scale( V3f( visualiserScale ) );
 	result->setTransform( topTrans );
 
 	if( type && type->readable() == "environment" )
@@ -274,7 +271,7 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::I
 	{
 		float innerAngle, outerAngle, lensRadius;
 		spotlightParameters( attributeName, shaderNetwork, innerAngle, outerAngle, lensRadius );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / locatorScale ) ) );
+		result->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / visualiserScale ) ) );
 		result->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
 		result->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
 	}

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -222,7 +222,7 @@ StandardLightVisualiser::~StandardLightVisualiser()
 {
 }
 
-IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, IECoreGL::ConstStatePtr &state ) const
+IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
 {
 	InternedString metadataTarget;
 	const IECore::CompoundData *shaderParameters = parametersAndMetadataTarget( attributeName, shaderNetwork, metadataTarget );

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -237,74 +237,75 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::I
 	const Color3f finalColor = color * intensity * pow( 2.0f, exposure );
 
 	GroupPtr result = new Group;
+	GroupPtr ornaments = new Group;  // Ornaments are affected by visualiser:scale while
+	GroupPtr geometry = new Group;   // geometry isn't as its size matters for rendering.
+	result->addChild( ornaments );
+	result->addChild( geometry );
 
-	/// \todo This is problematic for a few reasons :
-	///
-	/// - We don't actually want to apply it to the area light shapes created below for "quad" etc.
-	/// - We should find a better way to opt out of expensive visualisations (in particular for
-	///   large environment light textures)
-	///
-	/// Since this feature is only used by lights internal to Image Engine, we can ignore all this for
-	/// now, but it would be good to address in the future.
 	const FloatData *visualiserScaleData = attributes->member<FloatData>( "visualiser:scale" );
 	float visualiserScale = visualiserScaleData ? visualiserScaleData->readable() : 1.0;
 
+	/// \todo: We should find a better way to opt out of expensive visualisations
+	///        (in particular for large environment light textures)
 	if( visualiserScale == 0 )
 	{
 		return result;
 	}
 
-	Imath::M44f topTrans;
+	Imath::M44f topTransform;
 	if( orientation )
 	{
-		topTrans = orientation->readable();
+		topTransform = orientation->readable();
 	}
-	topTrans.scale( V3f( visualiserScale ) );
-	result->setTransform( topTrans );
+	result->setTransform( topTransform );
+
+	Imath::M44f ornamentsTransform;
+	ornamentsTransform.scale( V3f( visualiserScale ) );
+	ornaments->setTransform( ornamentsTransform );
 
 	if( type && type->readable() == "environment" )
 	{
 		const std::string textureName = parameter<std::string>( metadataTarget, shaderParameters, "textureNameParameter", "" );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( environmentSphere( finalColor, textureName ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( environmentSphere( finalColor, textureName ) ) );
 	}
 	else if( type && type->readable() == "spot" )
 	{
 		float innerAngle, outerAngle, lensRadius;
 		spotlightParameters( attributeName, shaderNetwork, innerAngle, outerAngle, lensRadius );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / visualiserScale ) ) );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / visualiserScale ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
 	}
 	else if( type && type->readable() == "distant" )
 	{
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( distantRays() ) );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( distantRays() ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
 	}
 	else if( type && type->readable() == "quad" )
 	{
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( quadShape() ) );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
+		geometry->addChild( const_pointer_cast<IECoreGL::Renderable>( quadShape() ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
 	}
 	else if( type && type->readable() == "disk" )
 	{
 		const float radius = parameter<float>( metadataTarget, shaderParameters, "radiusParameter", 1 );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( diskShape( radius ) ) );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
+		geometry->addChild( const_pointer_cast<IECoreGL::Renderable>( diskShape( radius ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
 	}
 	else if( type && type->readable() == "cylinder" )
 	{
 		const float radius = parameter<float>( metadataTarget, shaderParameters, "radiusParameter", 1 );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( cylinderShape( radius ) ) );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( cylinderRays( radius ) ) );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
+		geometry->addChild( const_pointer_cast<IECoreGL::Renderable>( cylinderShape( radius ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( cylinderRays( radius ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
 	}
 	else
 	{
 		// Treat everything else as a point light.
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( pointRays() ) );
-		result->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ true ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( pointRays() ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ true ) ) );
 	}
 
 	return result;


### PR DESCRIPTION
Hey John,

had a quick look at the visualisers as a follow-up to https://github.com/GafferHQ/gaffer/pull/3178. It's probably better to have this a little nicer on the gaffer side?

I assume this is roughly what you had in mind? Are you ok with the new section in the UI? Do you want me to add a new `Visualisation` section on `StandardAttributes` and add the scale there as well? If so, do we need to update other viewport elements like the camera visualisation so that they support this new mechanism, as well?

Are you ok with how I handled the area lights that have a size-sensitive element that shouldn't be scaled?

Once we're in a good spot here I'll update our internal code. I've left the comment about the environment light visualisations - could you point me to how you'd want me to handle the mip level bias feature? :) Would that be in Cortex's `TextureLoader` or can we handle that directly in Gaffer?

Matti.
