### PR TITLE
MultiLineTextWidget : Fix unicode handling in `selectedText()`

### DIFF
--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -175,9 +175,8 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 	def selectedText( self ) :
 
 		cursor = self._qtWidget().textCursor()
-		text = cursor.selectedText()
-		text = text.replace( u"\u2029", "\n" )
-		return str( text )
+		text = cursor.selection().toPlainText()
+		return text.encode( "utf-8" )
 
 	def linkAt( self, position ) :
 


### PR DESCRIPTION
In 62de6cccf34110b79719079aae66469cc8646287, we provided unicode support in `getText()`, but neglected to add it for `selectedText()` too. This fixes that, which in turn fixes problems with unicode handling in the PythonEditor.

I'll repeat some of the comments from that commit to explain our approach :

> Our eventual aim is to standardise on representing text using UTF8-encoded
> `std::string` objects on the C++ side of things, and `unicode` objects on
> the Python side (see #1208). But here we're using UTF8 encoded `str` (bytes)
> objects on the Python side as well. Rationale :
>
>    - Returning unicode from `getText()` now would be too much of a breaking
>      change, potentially affecting a _lot_ of client code. The better time to
>      make this change will be when we transition to Python 3, when `str`
>      objects _are_ unicode, and everything will be breaking left right and
>      centre anyway.
>    - We've already got de facto use of UTF8 in Python anyway, because that's what we get from things like `os.listdir()` and `glob.glob()`.

Fixes #3182.
