### PR TITLE
NameValuePlug : Accept regular Plugs for the value component

### DIFF
--- a/include/Gaffer/NameValuePlug.h
+++ b/include/Gaffer/NameValuePlug.h
@@ -66,7 +66,7 @@ class GAFFER_API NameValuePlug : public Gaffer::ValuePlug
 
 		NameValuePlug(
 			const std::string &nameDefault,
-			Gaffer::ValuePlugPtr valuePlug,
+			Gaffer::PlugPtr valuePlug,
 			const std::string &name=defaultName<NameValuePlug>()
 		);
 
@@ -83,7 +83,7 @@ class GAFFER_API NameValuePlug : public Gaffer::ValuePlug
 
 		NameValuePlug(
 			const std::string &nameDefault,
-			Gaffer::ValuePlugPtr valuePlug,
+			Gaffer::PlugPtr valuePlug,
 			bool defaultEnabled,
 			const std::string &name=defaultName<NameValuePlug>()
 		);
@@ -100,9 +100,9 @@ class GAFFER_API NameValuePlug : public Gaffer::ValuePlug
 		Gaffer::StringPlug *namePlug();
 		const Gaffer::StringPlug *namePlug() const;
 
-		template<typename T = Gaffer::ValuePlug>
+		template<typename T = Gaffer::Plug>
 		T *valuePlug();
-		template<typename T = Gaffer::ValuePlug>
+		template<typename T = Gaffer::Plug>
 		const T *valuePlug() const;
 
 		Gaffer::BoolPlug *enabledPlug();

--- a/python/GafferTest/CompoundDataPlugTest.py
+++ b/python/GafferTest/CompoundDataPlugTest.py
@@ -475,5 +475,17 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( p["test_A"]["value"].getValue(), 10 )
 		self.assertEqual( p["_j"]["value"].getValue(), 20 )
 
+	def testNonValuePlugs( self ) :
+
+		p = Gaffer.CompoundDataPlug()
+		p["test"] = Gaffer.NameValuePlug( "name", Gaffer.Plug() )
+
+		with self.assertRaisesRegexp( RuntimeError, "Not a ValuePlug" ) :
+			p.hash()
+
+		d = IECore.CompoundData()
+		with self.assertRaisesRegexp( RuntimeError, "Not a ValuePlug" ) :
+			p.fillCompoundData( d )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/NameValuePlugTest.py
+++ b/python/GafferTest/NameValuePlugTest.py
@@ -232,5 +232,38 @@ class NameValuePlugTest( GafferTest.TestCase ) :
 		self.assertTrue( m["name"].defaultValue(), "c" )
 		self.assertTrue( m["name"].getValue(), "c" )
 
+	def testNonValuePlugs( self ) :
+
+		p1 = Gaffer.NameValuePlug( "name", Gaffer.Plug(), name = "p1", defaultEnabled = False )
+		p2 = p1.createCounterpart( "p2", Gaffer.Plug.Direction.In )
+
+		self.assertTrue( p1.settable() )
+		self.assertTrue( p2.settable() )
+
+		p2.setInput( p1 )
+		self.assertEqual( p2["name"].getInput(), p1["name"] )
+		self.assertEqual( p2["value"].getInput(), p1["value"] )
+		self.assertTrue( p1.settable() )
+		self.assertFalse( p2.settable() )
+
+		p2.setInput( None )
+		self.assertTrue( p2.settable() )
+
+		self.assertTrue( p1.isSetToDefault() )
+		p1["name"].setValue( "nonDefault" )
+		self.assertFalse( p1.isSetToDefault() )
+		p1.setToDefault()
+		self.assertTrue( p1.isSetToDefault() )
+
+		p1["name"].setValue( "nonDefault" )
+		p1["enabled"].setValue( True )
+		p2.setFrom( p1 )
+		self.assertEqual( p2["name"].getValue(), p1["name"].getValue() )
+		self.assertEqual( p2["enabled"].getValue(), p1["enabled"].getValue() )
+
+		self.assertEqual( p1.hash(), p2.hash() )
+		p2["enabled"].setValue( False )
+		self.assertNotEqual( p1.hash(), p2.hash() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/CompoundDataPlug.cpp
+++ b/src/Gaffer/CompoundDataPlug.cpp
@@ -113,14 +113,14 @@ IECore::MurmurHash CompoundDataPlug::hash() const
 	{
 		const NameValuePlug *plug = it->get();
 		bool active = true;
-		if( plug->children().size() == 3 )
+		if( auto enabledPlug = plug->enabledPlug() )
 		{
-			active = plug->getChild<BoolPlug>( 2 )->getValue();
+			active = enabledPlug->getValue();
 		}
 		if( active )
 		{
-			plug->getChild<ValuePlug>( 0 )->hash( h );
-			plug->getChild<ValuePlug>( 1 )->hash( h );
+			plug->namePlug()->hash( h );
+			plug->valuePlug()->hash( h );
 		}
 	}
 	return h;
@@ -146,9 +146,9 @@ void CompoundDataPlug::fillCompoundObject( IECore::CompoundObject::ObjectMap &co
 
 IECore::DataPtr CompoundDataPlug::memberDataAndName( const NameValuePlug *parameterPlug, std::string &name ) const
 {
-	if( parameterPlug->children().size() == 3 )
+	if( auto enabledPlug = parameterPlug->enabledPlug() )
 	{
-		if( !parameterPlug->getChild<BoolPlug>( 2 )->getValue() )
+		if( !enabledPlug->getValue() )
 		{
 			return nullptr;
 		}
@@ -156,19 +156,19 @@ IECore::DataPtr CompoundDataPlug::memberDataAndName( const NameValuePlug *parame
 
 	if( parameterPlug->children().size() < 2 )
 	{
-		// we can end up here either if someone has very naughtily deleted
-		// some plugs, or if we're being called during loading and the
-		// child plugs haven't been fully constructed.
+		// Serialisations made prior to the introduction of NameValuePlug
+		// add the child plugs _after_ the NameValuePlug has been parented
+		// to us, exposing us to incomplete plugs. Ignore them. More recent
+		// serialisations do not have this problem.
 		return nullptr;
 	}
 
-	name = parameterPlug->getChild<StringPlug>( 0 )->getValue();
+	name = parameterPlug->namePlug()->getValue();
 	if( !name.size() )
 	{
 		return nullptr;
 	}
 
-	const ValuePlug *valuePlug = parameterPlug->getChild<ValuePlug>( 1 );
-	return PlugAlgo::extractDataFromPlug( valuePlug );
+	return PlugAlgo::extractDataFromPlug( parameterPlug->valuePlug() );
 }
 

--- a/src/Gaffer/CompoundDataPlug.cpp
+++ b/src/Gaffer/CompoundDataPlug.cpp
@@ -45,6 +45,25 @@ using namespace IECore;
 using namespace Gaffer;
 
 //////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+const ValuePlug *valuePlug( const NameValuePlug *p )
+{
+	if( auto v = p->valuePlug<Gaffer::ValuePlug>() )
+	{
+		return v;
+	}
+
+	throw IECore::Exception( "Not a ValuePlug" );
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
 // CompoundDataPlug implementation
 //////////////////////////////////////////////////////////////////////////
 
@@ -120,7 +139,7 @@ IECore::MurmurHash CompoundDataPlug::hash() const
 		if( active )
 		{
 			plug->namePlug()->hash( h );
-			plug->valuePlug()->hash( h );
+			valuePlug( plug )->hash( h );
 		}
 	}
 	return h;
@@ -169,6 +188,6 @@ IECore::DataPtr CompoundDataPlug::memberDataAndName( const NameValuePlug *parame
 		return nullptr;
 	}
 
-	return PlugAlgo::extractDataFromPlug( parameterPlug->valuePlug() );
+	return PlugAlgo::extractDataFromPlug( valuePlug( parameterPlug ) );
 }
 

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -603,9 +603,16 @@ void ValuePlug::setFrom( const ValuePlug *other )
 	ChildContainer::const_iterator it, otherIt;
 	for( it = children().begin(), otherIt = typedOther->children().begin(); it!=children().end() && otherIt!=typedOther->children().end(); it++, otherIt++ )
 	{
-		ValuePlug *child = static_cast<ValuePlug *>( it->get() );
-		const ValuePlug *otherChild = static_cast<ValuePlug *>( otherIt->get() );
-		child->setFrom( otherChild );
+		// We use `runTimeCast()` here as a concession to NameValuePlug,
+		// which egregiously ignores the wishes of our `acceptsChild()`
+		// implementation. See `NameValuePlug::acceptsChild()` for more
+		// details.
+		ValuePlug *child = IECore::runTimeCast<ValuePlug>( it->get() );
+		const ValuePlug *otherChild = IECore::runTimeCast<ValuePlug>( otherIt->get() );
+		if( child && otherChild )
+		{
+			child->setFrom( otherChild );
+		}
 	}
 }
 

--- a/src/GafferModule/NameValuePlugBinding.cpp
+++ b/src/GafferModule/NameValuePlugBinding.cpp
@@ -67,7 +67,7 @@ class NameValuePlugSerialiser : public ValuePlugSerialiser
 		{
 			return repr( static_cast<const NameValuePlug *>( graphComponent ), &serialisation );
 		}
-	
+
 
 		static std::string repr( const Gaffer::NameValuePlug *plug, const Serialisation *serialisation )
 		{
@@ -105,7 +105,7 @@ NameValuePlugPtr nameValuePlugConstructor1( const std::string &nameDefault, cons
 	return new NameValuePlug( nameDefault, valueDefault.get(), name, direction, flags );
 }
 
-NameValuePlugPtr nameValuePlugConstructor2( const std::string &nameDefault, const Gaffer::ValuePlugPtr valuePlug, const std::string &name )
+NameValuePlugPtr nameValuePlugConstructor2( const std::string &nameDefault, const Gaffer::PlugPtr valuePlug, const std::string &name )
 {
 	return new NameValuePlug( nameDefault, valuePlug, name );
 }
@@ -115,7 +115,7 @@ NameValuePlugPtr nameValuePlugConstructor3( const std::string &nameDefault, cons
 	return new NameValuePlug( nameDefault, valueDefault.get(), defaultEnabled, name, direction, flags );
 }
 
-NameValuePlugPtr nameValuePlugConstructor4( const std::string &nameDefault, const Gaffer::ValuePlugPtr valuePlug, bool defaultEnabled, const std::string &name )
+NameValuePlugPtr nameValuePlugConstructor4( const std::string &nameDefault, const Gaffer::PlugPtr valuePlug, bool defaultEnabled, const std::string &name )
 {
 	return new NameValuePlug( nameDefault, valuePlug, defaultEnabled, name );
 }


### PR DESCRIPTION
This will allow us to use ClosurePlugs in an upcoming OSLObject refactoring, and will also allow NameValuePlug to be used to create the NameSwitch requested in issue #2853. I've taken the approach that @danieldresser-ie had inadvertently taken in his original version : bypassing `ValuePlug::acceptsChild()`. I've just also made ValuePlug and CompoundDataPlug more robust to the deviance, and added unit tests to prove it.