### PR TITLE
ArnoldLight : Rejig `loadShader()` to fix "nodule:type" metadata

### DIFF
--- a/src/GafferArnold/ArnoldLight.cpp
+++ b/src/GafferArnold/ArnoldLight.cpp
@@ -82,9 +82,8 @@ void ArnoldLight::loadShader( const std::string &shaderName )
 		throw IECore::Exception( boost::str( boost::format( "Shader \"%s\" not found" ) % shaderName ) );
 	}
 
-	ParameterHandler::setupPlugs( shader, parametersPlug() );
-
 	shaderNamePlug()->setValue( shaderName );
+	ParameterHandler::setupPlugs( shader, parametersPlug() );
 }
 
 void ArnoldLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const


### PR DESCRIPTION
ArnoldLightUI registers the following for the "nodule:type" metadata for `parameters.color` :

```
lambda plug : "GafferUI::StandardNodule" if plug.node()["__shaderName"].getValue() in ( "quad_light", "skydome_light" ) else ""
```

When copy/pasting a light, the `color` plug was getting made before the `__shaderName` plug was set, and we were returning the wrong value. Setting the name before creating the parameters fixes this problem, and matches the loading order used by `ArnoldShader.loadShader()`.
