### PR TITLE
StyleSheet : Restyle Tabs to work around Qt limitations

### DIFF
--- a/python/GafferSceneUI/HierarchyView.py
+++ b/python/GafferSceneUI/HierarchyView.py
@@ -54,7 +54,7 @@ class HierarchyView( GafferUI.NodeSetEditor ) :
 
 	def __init__( self, scriptNode, **kw ) :
 
-		column = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, borderWidth = 8, spacing = 4 )
+		column = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, borderWidth = 4, spacing = 4 )
 
 		GafferUI.NodeSetEditor.__init__( self, column, scriptNode, **kw )
 

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -187,6 +187,7 @@ class _ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 		with row :
 
 			self.__label = GafferUI.Label( "" )
+			self.__label._qtWidget().setProperty( "gafferItemName", True )
 
 			GafferUI.Spacer( imath.V2i( 1 ), parenting = { "expand" : True } )
 
@@ -203,7 +204,7 @@ class _ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		with self.getContext() :
 			shaderName = self.getPlug().getValue()
-			self.__label.setText( "<h3>Shader : " + shaderName + "</h3>" )
+			self.__label.setText( "Shader: " + shaderName )
 			self.__button.setEnabled( not Gaffer.MetadataAlgo.readOnly( self.getPlug() ) )
 
 	def __buttonClicked( self, button ) :

--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -55,7 +55,7 @@ class CompoundEditor( GafferUI.Editor ) :
 
 	def __init__( self, scriptNode, children=None, detachedPanels=None, windowState=None, **kw ) :
 
-		self.__splitContainer = _SplitContainer()
+		self.__splitContainer = _SplitContainer( borderWidth = 2 )
 
 		GafferUI.Editor.__init__( self, self.__splitContainer, scriptNode, **kw )
 
@@ -376,7 +376,7 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 
 		GafferUI.TabbedContainer.__init__( self, cornerWidget, **kw )
 
-		with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 2, borderWidth=1 ) as cornerWidget :
+		with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4, borderWidth=4 ) as cornerWidget :
 
 			self.__pinningButton = GafferUI.Button( image="targetNodesUnlocked.png", hasFrame=False )
 
@@ -384,6 +384,7 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 			layoutButton.setMenu( GafferUI.Menu( Gaffer.WeakMethod( self.__layoutMenuDefinition ) ) )
 			layoutButton.setToolTip( "Click to modify the layout" )
 
+		cornerWidget._qtWidget().setObjectName( "gafferCompoundEditorTools" )
 		self.setCornerWidget( cornerWidget )
 
 		self.__pinningButtonClickedConnection = self.__pinningButton.clickedSignal().connect( Gaffer.WeakMethod( self.__pinningButtonClicked ) )
@@ -399,6 +400,8 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 
 		self.__tabDragBehaviour = _TabDragBehaviour( self )
 
+		self.__updateStyles()
+
 	def addEditor( self, nameOrEditor ) :
 
 		if isinstance( nameOrEditor, basestring ) :
@@ -412,6 +415,8 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 		self.setLabel( editor, editor.getTitle() )
 		editor.__titleChangedConnection = editor.titleChangedSignal().connect( Gaffer.WeakMethod( self.__titleChanged ) )
 
+		self.__updateStyles()
+
 		return editor
 
 	def removeEditor( self, editor ) :
@@ -419,6 +424,7 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 		editor.__titleChangedConnection = None
 		self.removeChild( editor )
 		self.__updatePinningButton( None )
+		self.__updateStyles()
 
 	def setTabsVisible( self, tabsVisible ) :
 
@@ -438,6 +444,12 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 				QWIDGETSIZE_MAX = 16777215 # Macro not exposed by Qt.py, but needed to remove fixed height
 				self._qtWidget().setFixedHeight( QWIDGETSIZE_MAX )
 				self.parent()._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Ignored, QtWidgets.QSizePolicy.Ignored )
+
+	def __updateStyles( self ) :
+
+		# Had issues using ints
+		self._qtWidget().setProperty( "gafferNumChildren", GafferUI._Variant.toVariant( "%d" % len(self) ) )
+		self._repolish()
 
 	def __layoutMenuDefinition( self ) :
 
@@ -681,7 +693,7 @@ class _DetachedPanel( GafferUI.Window ) :
 
 		GafferUI.Window.__init__( self )
 
-		self.__splitContainer = _SplitContainer()
+		self.__splitContainer = _SplitContainer( borderWidth = 2 )
 		self.__splitContainer.append( _TabbedContainer() )
 		self.setChild( self.__splitContainer )
 

--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -376,13 +376,15 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 
 		GafferUI.TabbedContainer.__init__( self, cornerWidget, **kw )
 
-		with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4, borderWidth=4 ) as cornerWidget :
+		with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4, borderWidth=2 ) as cornerWidget :
 
 			self.__pinningButton = GafferUI.Button( image="targetNodesUnlocked.png", hasFrame=False )
+			self.__pinningButton._qtWidget().setFixedHeight( 15 )
 
 			layoutButton = GafferUI.MenuButton( image="layoutButton.png", hasFrame=False )
 			layoutButton.setMenu( GafferUI.Menu( Gaffer.WeakMethod( self.__layoutMenuDefinition ) ) )
 			layoutButton.setToolTip( "Click to modify the layout" )
+			layoutButton._qtWidget().setFixedHeight( 15 )
 
 		cornerWidget._qtWidget().setObjectName( "gafferCompoundEditorTools" )
 		self.setCornerWidget( cornerWidget )

--- a/python/GafferUI/MenuButton.py
+++ b/python/GafferUI/MenuButton.py
@@ -46,6 +46,7 @@ class MenuButton( GafferUI.Button ) :
 	def __init__( self, text="", image=None, hasFrame=True, menu=None, **kw ) :
 
 		GafferUI.Button.__init__( self, text, image, hasFrame, **kw )
+		self._qtWidget().setProperty( "gafferMenuButton", True )
 
 		self.__menu = None
 		self.setMenu( menu )

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -56,6 +56,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 	def __init__( self, topLevelWidget, plug, **kw ) :
 
 		GafferUI.Widget.__init__( self, topLevelWidget, **kw )
+		self._qtWidget().setProperty( "gafferPlugValueWidget", True )
 
 		# we don't want to call _updateFromPlug yet because the derived
 		# classes haven't constructed yet. they can call it themselves

--- a/python/GafferUI/PythonEditor.py
+++ b/python/GafferUI/PythonEditor.py
@@ -56,7 +56,8 @@ class PythonEditor( GafferUI.Editor ) :
 
 	def __init__( self, scriptNode, **kw ) :
 
-		self.__splittable = GafferUI.SplitContainer()
+		self.__splittable = GafferUI.SplitContainer( borderWidth = 2 )
+		self.__splittable._qtWidget().setObjectName( "gafferPythonEditor" )
 
 		GafferUI.Editor.__init__( self, self.__splittable, scriptNode, **kw )
 
@@ -69,6 +70,9 @@ class PythonEditor( GafferUI.Editor ) :
 			wrapMode = GafferUI.MultiLineTextWidget.WrapMode.None,
 			role = GafferUI.MultiLineTextWidget.Role.Code,
 		)
+
+		self.__outputWidget._qtWidget().setObjectName( "gafferPythonEditorOutput" )
+		self.__inputWidget._qtWidget().setObjectName( "gafferPythonEditorInput" )
 
 		self.__splittable.append( self.__outputWidget )
 		self.__splittable.append( self.__inputWidget )

--- a/python/GafferUI/ScriptWindow.py
+++ b/python/GafferUI/ScriptWindow.py
@@ -54,7 +54,7 @@ class ScriptWindow( GafferUI.Window ) :
 
 		self.__titleBehaviour = _WindowTitleBehaviour( self, script )
 
-		self.__listContainer = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing = 2 )
+		self.__listContainer = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing = 0 )
 
 		menuDefinition = self.menuDefinition( script.applicationRoot() ) if script.applicationRoot() else IECore.MenuDefinition()
 		self.__listContainer.append( GafferUI.MenuBar( menuDefinition ) )

--- a/python/GafferUI/SplitContainer.py
+++ b/python/GafferUI/SplitContainer.py
@@ -195,6 +195,7 @@ class SplitContainer( GafferUI.ContainerWidget ) :
 	
 	def __updateStyles( self ) :
 
+		# Had issues using ints
 		self._qtWidget().setProperty( "gafferNumChildren", GafferUI._Variant.toVariant( "%d" % len(self) ) )
 		self._repolish()
 

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -96,6 +96,7 @@ class VectorDataWidget( GafferUI.Widget ) :
 
 		self.__tableView.horizontalHeader().setVisible( bool( header ) )
 		self.__tableView.horizontalHeader().setMinimumSectionSize( 70 )
+		self.__tableView.horizontalHeader().setObjectName( "vectorDataWidgetHorizontalHeader" )
 
 		self.__tableView.verticalHeader().setVisible( showIndices )
 		QtCompat.setSectionResizeMode( self.__tableView.verticalHeader(), QtWidgets.QHeaderView.Fixed )

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -112,7 +112,6 @@ _styleSheet = string.Template(
 
 	"""
 	QWidget#gafferWindow {
-
 		color: $foreground;
 		font: 10px;
 		etch-disabled-text: 0;
@@ -121,60 +120,47 @@ _styleSheet = string.Template(
 	}
 
 	QWidget {
-
 		background-color: transparent;
-
 	}
 
-	QLabel, QCheckBox, QPushButton, QComboBox, QMenu, QMenuBar, QTabBar, QLineEdit, QAbstractItemView, QPlainTextEdit, QDateTimeEdit {
-
+	QLabel, QCheckBox, QPushButton, QComboBox, QMenu, QMenuBar,
+	QTabBar, QLineEdit, QAbstractItemView, QPlainTextEdit, QDateTimeEdit {
 		color: $foreground;
 		font: 10px;
 		etch-disabled-text: 0;
 		selection-background-color: $brightColor;
 		outline: none;
-
 	}
 
 	QLabel[gafferHighlighted=\"true\"] {
-
 		color: #b0d8fb;
-
 	}
 
 	QLabel#gafferPlugLabel[gafferValueChanged=\"true\"] {
-
 		background-image: url($GAFFER_ROOT/graphics/valueChanged.png);
 		background-repeat: no-repeat;
 		background-position: left;
 		padding-left: 20px;
-
 	}
 
 
 	QLabel[gafferItemName="true"] {
-
 		font-weight: bold;
 	}
 
 	QMenuBar {
-
 		background-color: $backgroundDarkest;
 		font-weight: bold;
 		padding: 0px;
 		margin: 0px;
-
 	}
 
 	QMenuBar::item {
-
 		background-color: $backgroundDarkest;
 		padding: 5px 8px 5px 8px;
-
 	}
 
 	QMenu {
-
 		border: 1px solid $backgroundDark;
 		padding-bottom: 5px;
 		padding-top: 5px;
@@ -182,7 +168,6 @@ _styleSheet = string.Template(
 	}
 
 	QMenu[gafferHasTitle=\"true\"] {
-
 		/* make sure the title widget sits at the very top.
 		   infuriatingly, qt uses padding-top for the bottom
 		   as well, and is ignoring padding-bottom. that makes
@@ -190,37 +175,28 @@ _styleSheet = string.Template(
 		   at the bottom. we hack around that by adding a little
 		   spacing widget in GafferUI.Menu. */
 		padding-top: 0px;
-
 	}
 
 	QLabel#gafferMenuTitle {
-
 		background-color: $backgroundDarkest;
 		font-weight: bold;
 		padding: 5px 25px 5px 20px;
 		margin-bottom: 6px;
-
 	}
 
 	QLabel#gafferMenuTitle:disabled {
-
 		color: $foreground;
-
 	}
 
 	QMenu::item {
-
 		color: $foreground;
 		background-color: transparent;
 		border: 0px;
 		padding: 2px 25px 2px 20px;
-
 	}
 
 	QMenu::item:disabled {
-
 		color: $tintLighterStronger;
-
 	}
 
 	QMenu::right-arrow {
@@ -229,14 +205,12 @@ _styleSheet = string.Template(
 	}
 
 	QMenu::separator {
-
 		height: 1px;
 		background: $backgroundLowlight;
 		margin-left: 10px;
 		margin-right: 10px;
 		margin-top: 5px;
 		margin-bottom: 5px;
-
 	}
 
 	QMenu::indicator {
@@ -258,7 +232,6 @@ _styleSheet = string.Template(
 		border-bottom-color: $backgroundLightLowlight;
 		border-right-color: $backgroundLightLowlight;
 		background-color: $backgroundLight;
-
 		border-radius: ${controlCornerRadius};
 	}
 
@@ -267,40 +240,29 @@ _styleSheet = string.Template(
 		padding: 0px;
 		background-color: transparent;
 		border-color: transparent;
-
 	}
 
 	QLineEdit[gafferError="true"], QPlainTextEdit[gafferError="true"] {
-
 		background-color: $errorColor;
-
 	}
 
 	QLineEdit[gafferAnimated="true"] {
-
 		padding: 0px;
 		border: 1px solid transparent;
 		background-color: $animatedColor;
-
 	}
 
 	QPlainTextEdit[gafferRole="Code"] {
-
 		font-family: monospace;
-
 	}
 
 	QLineEdit:focus, QPlainTextEdit[readOnly="false"]:focus, QLineEdit[gafferHighlighted=\"true\"] {
-
 		border: 1px solid $brightColor;
 		padding: 0px;
-
 	}
 
 	QLineEdit:disabled {
-
 		color: $foregroundFaded;
-
 	}
 
 	QLineEdit#search{
@@ -314,19 +276,15 @@ _styleSheet = string.Template(
 		margin-right: 4px;
 	}
 
-	QWidget#gafferSplineWidget
-	{
+	QWidget#gafferSplineWidget {
 		border: 1px solid $backgroundDark;
 	}
 
 	QWidget#gafferSplineWidget[gafferHighlighted=\"true\"] {
-
 		border: 1px solid $brightColor;
-
 	}
 
 	QDateTimeEdit {
-
 		background-color: $backgroundLighter;
 		padding: 1px;
 		margin: 0px;
@@ -339,17 +297,13 @@ _styleSheet = string.Template(
 	}
 
 	#qt_calendar_navigationbar {
-
 		background-color : $brightColor;
-
 	}
 
 	#qt_calendar_monthbutton, #qt_calendar_yearbutton {
-
 		color : $foreground;
 		font-weight : bold;
 		font-size : 16pt;
-
 	}
 
 	#qt_calendar_monthbutton::menu-indicator {
@@ -357,21 +311,18 @@ _styleSheet = string.Template(
 	}
 
 	#qt_calendar_calendarview {
-
 		color : $foreground;
 		font-weight : normal;
 		font-size : 14pt;
 		selection-background-color: $brightColor;
 		background-color : $backgroundLighter;
 		gridline-color: $backgroundDark;
-
 	}
 
 	/* buttons */
 
 	QPushButton#gafferWithFrame,
-	QComboBox
-	{
+	QComboBox {
 		border: 1px solid $backgroundDarkHighlight;
 		border-top-color: $backgroundLightHighlight;
 		border-left-color: $backgroundLightHighlight;
@@ -379,36 +330,28 @@ _styleSheet = string.Template(
 		border-radius: 4px;
 		padding: 4px;
 		margin: 1px;
-
 		font-weight: bold;
 	}
 
-	QPushButton#gafferWithFrame[gafferMenuButton="true"]
-	{
+	QPushButton#gafferWithFrame[gafferMenuButton="true"] {
 		padding: 2px;
 	}
 
-	*[gafferPlugValueWidget="true"] QPushButton#gafferWithFrame[gafferMenuButton="true"]
-	{
+	*[gafferPlugValueWidget="true"] QPushButton#gafferWithFrame[gafferMenuButton="true"] {
 		font-weight: normal;
 		text-align: left;
 	}
 
-	QPushButton#gafferWithFrame:focus
-	{
+	QPushButton#gafferWithFrame:focus {
 		border: 1px solid $brightColor;
 	}
 
-	QPushButton#gafferWithFrame:pressed
-	{
-
+	QPushButton#gafferWithFrame:pressed {
 		color: white;
 		background-color:	$brightColor;
-
 	}
 
 	QPushButton#gafferWithoutFrame {
-
 		border: 0px solid transparent;
 		border-radius: 0px;
 		padding: 0px;
@@ -418,16 +361,13 @@ _styleSheet = string.Template(
 		margin-left: -2px;
 		margin-right: -2px;
 		background-color: none;
-
 	}
 
 	QPushButton:disabled, QComboBox:disabled, QLabel::disabled {
-
 		color: $foregroundFaded;
 	}
 
-	QPushButton#gafferWithFrame:disabled
-	{
+	QPushButton#gafferWithFrame:disabled {
 		color: $tintLighterStrong;
 		background-color: $tintDarker;
 		border-color: transparent;
@@ -440,18 +380,14 @@ _styleSheet = string.Template(
 		left: -4px;
 	}
 
-	QPushButton#gafferWithFrame[gafferMenuIndicator="true"]
-	{
-
+	QPushButton#gafferWithFrame[gafferMenuIndicator="true"] {
 		background-image: url($GAFFER_ROOT/graphics/menuIndicator.png);
 		background-repeat: none;
 		background-position: center right;
 		padding-right: 20px
-
 	}
 
 	QComboBox {
-
 		padding: 0;
 		padding-left:3px;
 	}
@@ -462,7 +398,6 @@ _styleSheet = string.Template(
 	}
 
 	QComboBox QAbstractItemView {
-
 		border: 1px solid $backgroundDark;
 		selection-background-color: $backgroundLighter;
 		background-color: $background;
@@ -472,7 +407,6 @@ _styleSheet = string.Template(
 	}
 
 	QComboBox QAbstractItemView::item {
-
 		border: none;
 		padding: 2px;
 	}
@@ -480,19 +414,16 @@ _styleSheet = string.Template(
 	/* tabs */
 
 	QTabWidget::tab-bar {
-
 		left: 0px;
 	}
 
 	QTabWidget #gafferCompoundEditorTools  {
-
 		margin: 0;
 		padding: 0;
 		border: none;
 	}
 
 	QTabBar {
-
 		color: $foreground;
 		font-weight: bold;
 		outline:none;
@@ -500,7 +431,6 @@ _styleSheet = string.Template(
 	}
 
 	QTabBar::tab {
-
 		padding: 4px;
 		padding-left: 8px;
 		padding-right: 8px;
@@ -508,53 +438,40 @@ _styleSheet = string.Template(
 		border-top-right-radius: 4px;
 		margin: 0px;
 		margin-right: 1px;
-
 		border: 1px solid $backgroundHighlight;
 		border-right-color: $backgroundLowlight;
 		border-bottom-color: $background /* blend into frame below */
 	}
 
 	QTabBar::tab:disabled {
-
 		color: $tintLighter;
-
 	}
 
 	QTabBar::tab:selected {
-
 		background-color: $background;
-
 	}
 
 	QTabWidget QTabWidget > QTabBar::tab:selected {
-
 		background-color: $backgroundRaised;
-
 		border-color: $backgroundRaisedHighlight;
 		border-right-color: $backgroundRaisedLowlight;
 		border-bottom-color: $backgroundRaised; /* blend into frame below */
 	}
 
 	QTabBar::tab:!selected {
-
 		color: $tintLighterStronger;
 		background-color: $backgroundDark;
-
 		border-color: transparent;
 		border-bottom-color: $background;
 	}
 
 	QTabBar::tab:!selected:hover {
-
 		background-color: $backgroundDarkHighlight;
-
 	}
 
 	QTabWidget QTabWidget > QTabBar::tab:!selected {
-
 		color: $tintLighterStronger;
 		background-color: $backgroundDarkHighlight;
-
 		border-color: transparent;
 		border-bottom-color: $backgroundRaisedHighlight;
 	}
@@ -569,22 +486,16 @@ _styleSheet = string.Template(
 	}
 
 	QTabWidget::pane {
-
 		background-color: $background;
-
 		/* tab widget frame has a line at the top, tweaked up 1 pixel */
 		/* so that it sits underneath the bottom of the tabs.         */
 		/* this means the active tab can blend into the frame.        */
-
 		top: -1px;
-
 		border-radius: 2px;
 		border-top-left-radius: 0;
-
 		border: 1px solid $backgroundHighlight;
 		border-right-color: $backgroundLowlight;
 		border-bottom-color: $backgroundLowlight;
-
 	}
 
 	QTabWidget[gafferNumChildren="0"]::pane {
@@ -593,31 +504,24 @@ _styleSheet = string.Template(
 	}
 
 	QTabWidget QTabWidget::pane {
-
 		background-color: $backgroundRaised;
-
 		border-radius: $widgetCornerRadius;
 		border-top-left-radius: 0;
-
 		border-color: $backgroundRaisedHighlight;
 		border-right-color: $backgroundRaisedLowlight;
 		border-bottom-color: $backgroundRaisedLowlight;
 	}
 
 	QSplitter {
-
 		background-color: $backgroundDarker;
 	}
 
 	/* Ensures the QSplitter border is visible if we need to highlight */
 	QSplitter#gafferCompoundEditor[gafferNumChildren="1"] {
-
 		padding: 1px;
-
 	}
 
 	QSplitter::handle:vertical {
-
 		height: 2px;
 		border: 1px $backgroundDarker solid;
 		margin: 1px;
@@ -636,10 +540,8 @@ _styleSheet = string.Template(
 	QSplitterHandle:hover {}
 
 	QMenu::item:selected, QMenuBar::item:selected, QSplitter::handle:hover {
-
 		color: white;
-		background-color:	$brightColor;
-
+		background-color: $brightColor;
 	}
 	QTabWidget[gafferHighlighted=\"true\"]::pane {
 		border: 1px solid $brightColor;
@@ -660,68 +562,52 @@ _styleSheet = string.Template(
 	}
 
 	QCheckBox#gafferCollapsibleToggle {
-
 		font-weight: bold;
 	}
 
 	QWidget#gafferCollapsible QWidget#gafferCollapsible > QCheckBox#gafferCollapsibleToggle {
-
 		margin-left: 10px;
-
 	}
 
 	QCheckBox#gafferCollapsibleToggle:disabled {
-
 		color: $foregroundFaded;
-
 	}
 
 	QCheckBox#gafferCollapsibleToggle::indicator {
-
 		width: 12px;
 		height: 12px;
 		background-color: none;
-
 	}
 
 	QCheckBox#gafferCollapsibleToggle::indicator:unchecked {
-
 		image: url($GAFFER_ROOT/graphics/collapsibleArrowDown.png);
-
 	}
 
 	QCheckBox#gafferCollapsibleToggle::indicator:checked {
-
 		image: url($GAFFER_ROOT/graphics/collapsibleArrowRight.png);
-
 	}
 
-	QCheckBox#gafferCollapsibleToggle::indicator:unchecked:hover, QCheckBox#gafferCollapsibleToggle::indicator:unchecked:focus {
-
+	QCheckBox#gafferCollapsibleToggle::indicator:unchecked:hover,
+	QCheckBox#gafferCollapsibleToggle::indicator:unchecked:focus {
 		image: url($GAFFER_ROOT/graphics/collapsibleArrowDownHover.png);
-
 	}
 
-	QCheckBox#gafferCollapsibleToggle::indicator:checked:hover, QCheckBox#gafferCollapsibleToggle::indicator:checked:focus {
-
+	QCheckBox#gafferCollapsibleToggle::indicator:checked:hover,
+	QCheckBox#gafferCollapsibleToggle::indicator:checked:focus {
 		image: url($GAFFER_ROOT/graphics/collapsibleArrowRightHover.png);
-
 	}
 
 	QHeaderView {
-
 		border: 0px;
 		margin: 0px;
 	}
 
 	QHeaderView::section {
-
 		border: 1px solid $backgroundLowlight;
 		border-radius: 0;
 		padding: 3px;
 		font-weight: bold;
 		margin: 0px;
-
 		background-color: $tintLighter;
 	}
 	
@@ -756,45 +642,34 @@ _styleSheet = string.Template(
 
 	QHeaderView::section:horizontal:!first:!only-one {
 		margin-left: -1px;
-
 	}
 
 	QHeaderView::section:vertical:!first:!only-one {
 		margin-top: -1px;
-
 	}
 
 	QHeaderView::down-arrow {
-
 		image: url($GAFFER_ROOT/graphics/headerSortDown.png);
-
 	}
 
 	QHeaderView::up-arrow {
-
 		image: url($GAFFER_ROOT/graphics/headerSortUp.png);
-
 	}
 
 	QScrollBar {
-
 		border: none;
 		border-radius: 4px;
 		background-color: $tintDarker;
 	}
 
 	QScrollBar:vertical {
-
 		width: 16px;
 		margin: 4px;
-
 	}
 
 	QScrollBar:horizontal {
-
 		height: 16px;
 		margin: 4px;
-
 	}
 
 	QScrollBar::add-page, QScrollBar::sub-page {
@@ -849,7 +724,8 @@ _styleSheet = string.Template(
 		min-width: 14px;
 	}
 
-	QScrollBar::handle:hover, QScrollBar::add-line:hover, QScrollBar::sub-line:hover {
+	QScrollBar::handle:hover, QScrollBar::add-line:hover,
+	QScrollBar::sub-line:hover {
 		background-color: $brightColor;
 	}
 
@@ -1015,24 +891,18 @@ _styleSheet = string.Template(
 		color: $backgroundDarkest;
 		background-color: $foreground;
 		padding: 2px;
-
 	}
 
 
 	/* Tree/Table views */
 
 	QTreeView {
-
 		background-color: $backgroundRaised;
-
 		border: 1px solid $backgroundRaisedHighlight;
 		border-bottom-color: $backgroundRaisedLowlight;
 		border-right-color: $backgroundRaisedLowlight;
-
 		padding: 0;
-
 		alternate-background-color: $backgroundLowlight;
-
 	}
 
 	QTreeView::item {
@@ -1113,81 +983,59 @@ _styleSheet = string.Template(
 
 	QTableView[gafferHighlighted=\"true\"]#vectorDataWidget,
 	QTableView[gafferHighlighted=\"true\"]#vectorDataWidgetEditable {
-
 		gridline-color: $brightColor;
-
 	}
 
 	QTreeView[gafferHighlighted=\"true\"],
 	QTableView[gafferHighlighted=\"true\"] QHeaderView::section#vectorDataWidgetVerticalHeader {
-
 		border-color: $brightColor;
-
 	}
 
 	/* progress bars */
 
 	QProgressBar {
-
 		border: 1px solid $backgroundDark;
 		background: $backgroundLighter;
 		padding: 1px;
 		text-align: center;
-
 	}
 
 	QProgressBar::chunk:horizontal {
-
 		background-color: $brightColor;
-
 	}
 
 	/* gl widget */
 
 	QGraphicsView#gafferGLWidget {
-
 		border: 0px;
-
 	}
 
 	/* frame variants */
 
 	QFrame#gafferDiffA {
-
 		background: solid rgba( 181, 30, 0, 80 );
-
 	}
 
 	QFrame#gafferDiffB {
-
 		background: solid rgba( 34, 159, 0, 80 );
-
 	}
 
 	QFrame#gafferDiffAB {
-
 		background: solid rgba( 170, 170, 170, 60 );
-
 	}
 
 	QFrame#gafferDiffOther {
-
 		background: solid rgba( 70, 184, 255, 25 );
-
 	}
 
 	QFrame#gafferLighter {
-
 		background: solid rgba( 255, 255, 255, 10 );
-
 	}
 
 	QFrame#gafferDarker {
-
 		background: solid rgba( 0, 0, 0, 80 );
 		border-radius: 2px;
 		padding: 2px;
-
 	}
 
 	QFrame[gafferHighlighted=\"true\"]#gafferDiffA, QFrame[gafferHighlighted=\"true\"]#gafferDiffB, QFrame[gafferHighlighted=\"true\"]#gafferDiffAB {
@@ -1197,37 +1045,27 @@ _styleSheet = string.Template(
 	/* turn off rounded corners based on adjacency of other widgets */
 
 	*[gafferRounded="true"] {
-
 		border-radius: 6px;
-
 	}
 
 	*[gafferFlatTop="true"] {
-
 		border-top-left-radius: 0px;
 		border-top-right-radius: 0px;
-
 	}
 
 	*[gafferFlatBottom="true"] {
-
 		border-bottom-left-radius: 0px;
 		border-bottom-right-radius: 0px;
-
 	}
 
 	*[gafferFlatLeft="true"] {
-
 		border-top-left-radius: 0px;
 		border-bottom-left-radius: 0px;
-
 	}
 
 	*[gafferFlatRight="true"] {
-
 		border-top-right-radius: 0px;
 		border-bottom-right-radius: 0px;
-
 	}
 
 	/* PythonEditor */

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -41,19 +41,48 @@ import string
 from Qt import QtGui
 
 _styleColors = {
+
 	"backgroundDarkest" : (0, 0, 0),
-	"backgroundDark" : (60, 60, 60),
-	"backgroundDarkTransparent" : (60, 60, 60, 100),
-	"backgroundMid" : (76, 76, 76),
-	"backgroundLighter" : (108, 108, 108),
-	"backgroundLight" : (125, 125, 125),
+
+	"backgroundDarker" : (45, 45, 45),
+
+	"backgroundDark" : (56, 56, 56),
+	"backgroundDarkTransparent" : (56, 56, 56, 100),
+	"backgroundDarkHighlight" : (62, 62, 62),
+
+	"backgroundLowlight" : (68, 68, 68),
+	"background" : (76, 76, 76),
+	"backgroundHighlight" : (88, 88, 88),
+
+	"backgroundRaisedLowlight" : (70, 70, 70),
+	"backgroundRaised" : (82, 82, 82),
+	"backgroundRaisedHighlight" : (96, 96, 96),
+
+	"backgroundLightLowlight" : (82, 82, 82),
+	"backgroundLight" : (96, 96, 96),
+	"backgroundLightHighlight" : (106, 106, 106),
+
+	"backgroundLighter" : (125, 125, 125),
+
 	"brightColor" : (119, 156, 189),
 	"brightColorTransparent" : (119, 156, 189, 100),
+
 	"foreground" : (224, 224, 224),
 	"foregroundFaded" : (153, 153, 153),
-	"alternateColor" : (69, 69, 69),
+
 	"errorColor" : (255, 85, 85),
 	"animatedColor" : (128, 152, 94),
+
+	"tintLighter" :         ( 255, 255, 255, 20 ),
+	"tintLighterStrong" :   ( 255, 255, 255, 40 ),
+	"tintLighterStronger" : ( 255, 255, 255, 100 ),
+	"tintDarker" :          ( 0, 0, 0, 20 ),
+	"tintDarkerStrong" :    ( 0, 0, 0, 40 ),
+}
+
+_themeVariables = {
+	"widgetCornerRadius" : "4px",
+	"controlCornerRadius" : "2px"
 }
 
 substitutions = {
@@ -65,6 +94,8 @@ for k, v in _styleColors.items() :
 		substitutions[k] = "rgb({0}, {1}, {2})".format( *v )
 	elif len( v ) == 4 :
 		substitutions[k] = "rgba({0}, {1}, {2}, {3})".format( *v )
+
+substitutions.update( _themeVariables )
 
 def styleColor( key ) :
 	color = _styleColors.get( key, (0, 0, 0,) )
@@ -85,7 +116,7 @@ _styleSheet = string.Template(
 		color: $foreground;
 		font: 10px;
 		etch-disabled-text: 0;
-		background-color: $backgroundMid;
+		background-color: $backgroundLowlight;
 		border: 1px solid #555555;
 	}
 
@@ -100,7 +131,6 @@ _styleSheet = string.Template(
 		color: $foreground;
 		font: 10px;
 		etch-disabled-text: 0;
-		alternate-background-color: $alternateColor;
 		selection-background-color: $brightColor;
 		outline: none;
 
@@ -119,6 +149,12 @@ _styleSheet = string.Template(
 		background-position: left;
 		padding-left: 20px;
 
+	}
+
+
+	QLabel[gafferItemName="true"] {
+
+		font-weight: bold;
 	}
 
 	QMenuBar {
@@ -142,7 +178,7 @@ _styleSheet = string.Template(
 		border: 1px solid $backgroundDark;
 		padding-bottom: 5px;
 		padding-top: 5px;
-
+		background-color: $backgroundLight;
 	}
 
 	QMenu[gafferHasTitle=\"true\"] {
@@ -174,6 +210,7 @@ _styleSheet = string.Template(
 
 	QMenu::item {
 
+		color: $foreground;
 		background-color: transparent;
 		border: 0px;
 		padding: 2px 25px 2px 20px;
@@ -182,7 +219,7 @@ _styleSheet = string.Template(
 
 	QMenu::item:disabled {
 
-		color: $foregroundFaded;
+		color: $tintLighterStronger;
 
 	}
 
@@ -194,7 +231,7 @@ _styleSheet = string.Template(
 	QMenu::separator {
 
 		height: 1px;
-		background: $backgroundDark;
+		background: $backgroundLowlight;
 		margin-left: 10px;
 		margin-right: 10px;
 		margin-top: 5px;
@@ -215,29 +252,21 @@ _styleSheet = string.Template(
 		image: url($GAFFER_ROOT/graphics/arrowRight10.png);
 	}
 
-	QMenu, QTabBar::tab:selected, QHeaderView::section {
+	QLineEdit, QPlainTextEdit {
+		padding: 0px;
+		border: 1px solid transparent;
+		border-bottom-color: $backgroundLightLowlight;
+		border-right-color: $backgroundLightLowlight;
+		background-color: $backgroundLight;
 
-		background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 $backgroundLight, stop: 1 $backgroundMid);
-
+		border-radius: ${controlCornerRadius};
 	}
 
-	QPlainTextEdit {
 
-		border: 1px solid $backgroundDark;
-
-	}
-
-	QLineEdit, QPlainTextEdit[readOnly="false"] {
-
-		border: 1px solid $backgroundDark;
-		padding: 1px;
-		margin: 0px;
-
-	}
-
-	QLineEdit[readOnly="false"], QPlainTextEdit[readOnly="false"] {
-
-		background-color: $backgroundLighter;
+	QLineEdit[readOnly="true"], QPlainTextEdit[readOnly="true"] {
+		padding: 0px;
+		background-color: transparent;
+		border-color: transparent;
 
 	}
 
@@ -249,6 +278,8 @@ _styleSheet = string.Template(
 
 	QLineEdit[gafferAnimated="true"] {
 
+		padding: 0px;
+		border: 1px solid transparent;
 		background-color: $animatedColor;
 
 	}
@@ -261,7 +292,7 @@ _styleSheet = string.Template(
 
 	QLineEdit:focus, QPlainTextEdit[readOnly="false"]:focus, QLineEdit[gafferHighlighted=\"true\"] {
 
-		border: 2px solid $brightColor;
+		border: 1px solid $brightColor;
 		padding: 0px;
 
 	}
@@ -338,29 +369,38 @@ _styleSheet = string.Template(
 
 	/* buttons */
 
-	QPushButton, QComboBox {
-
-		font-weight: bold;
-
-	}
-
-	QPushButton#gafferWithFrame, QComboBox {
-
-		border: 1px solid $backgroundDark;
-		border-radius: 3px;
+	QPushButton#gafferWithFrame,
+	QComboBox
+	{
+		border: 1px solid $backgroundDarkHighlight;
+		border-top-color: $backgroundLightHighlight;
+		border-left-color: $backgroundLightHighlight;
+		background-color : qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 $backgroundLightHighlight, stop: 0.1 $backgroundLight, stop: 0.90 $backgroundLightLowlight);
+		border-radius: 4px;
 		padding: 4px;
 		margin: 1px;
-		background-color : qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 $backgroundLight, stop: 0.5 $backgroundLighter);
 
+		font-weight: bold;
 	}
 
-	QPushButton#gafferWithFrame:hover, QPushButton#gafferWithFrame:focus, QComboBox:hover {
-
-		border: 2px solid $brightColor;
-		margin: 0px;
+	QPushButton#gafferWithFrame[gafferMenuButton="true"]
+	{
+		padding: 2px;
 	}
 
-	QPushButton#gafferWithFrame:pressed {
+	*[gafferPlugValueWidget="true"] QPushButton#gafferWithFrame[gafferMenuButton="true"]
+	{
+		font-weight: normal;
+		text-align: left;
+	}
+
+	QPushButton#gafferWithFrame:focus
+	{
+		border: 1px solid $brightColor;
+	}
+
+	QPushButton#gafferWithFrame:pressed
+	{
 
 		color: white;
 		background-color:	$brightColor;
@@ -384,13 +424,13 @@ _styleSheet = string.Template(
 	QPushButton:disabled, QComboBox:disabled, QLabel::disabled {
 
 		color: $foregroundFaded;
-
 	}
 
-	QPushButton#gafferWithFrame:disabled {
-
-		background-color: $backgroundLighter;
-
+	QPushButton#gafferWithFrame:disabled
+	{
+		color: $tintLighterStrong;
+		background-color: $tintDarker;
+		border-color: transparent;
 	}
 
 	QPushButton::menu-indicator {
@@ -400,7 +440,8 @@ _styleSheet = string.Template(
 		left: -4px;
 	}
 
-	QPushButton#gafferWithFrame[gafferMenuIndicator="true"] {
+	QPushButton#gafferWithFrame[gafferMenuIndicator="true"]
+	{
 
 		background-image: url($GAFFER_ROOT/graphics/menuIndicator.png);
 		background-repeat: none;
@@ -413,7 +454,6 @@ _styleSheet = string.Template(
 
 		padding: 0;
 		padding-left:3px;
-
 	}
 
 	QComboBox::drop-down {
@@ -425,18 +465,16 @@ _styleSheet = string.Template(
 
 		border: 1px solid $backgroundDark;
 		selection-background-color: $backgroundLighter;
-		background-color: $backgroundMid;
+		background-color: $background;
 		height:40px;
 		margin:0;
-
+		text-align: left;
 	}
 
 	QComboBox QAbstractItemView::item {
 
 		border: none;
 		padding: 2px;
-		font-weight: bold;
-
 	}
 
 	/* tabs */
@@ -444,7 +482,13 @@ _styleSheet = string.Template(
 	QTabWidget::tab-bar {
 
 		left: 0px;
+	}
 
+	QTabWidget #gafferCompoundEditorTools  {
+
+		margin: 0;
+		padding: 0;
+		border: none;
 	}
 
 	QTabBar {
@@ -453,50 +497,116 @@ _styleSheet = string.Template(
 		font-weight: bold;
 		outline:none;
 		background-color: transparent;
-
 	}
 
 	QTabBar::tab {
 
-		border: 1px solid $backgroundDark;
 		padding: 4px;
 		padding-left: 8px;
 		padding-right: 8px;
-		border-top-left-radius: 3px;
-		border-top-right-radius: 3px;
+		border-top-left-radius: 4px;
+		border-top-right-radius: 4px;
 		margin: 0px;
+		margin-right: 1px;
 
+		border: 1px solid $backgroundHighlight;
+		border-right-color: $backgroundLowlight;
+		border-bottom-color: $background /* blend into frame below */
 	}
 
-	/* indent the first tab. can't do this using QTabWidget::tab-bar:left */
-	/* as that messes up the alignment of the corner widget (makes it overlap) */
-	QTabBar::tab:first, QTabBar::tab:only-one {
+	QTabBar::tab:disabled {
 
-		margin-left: 10px;
+		color: $tintLighter;
 
 	}
 
 	QTabBar::tab:selected {
 
-		border-bottom-color: $backgroundMid; /* blend into frame below */
+		background-color: $background;
 
+	}
+
+	QTabWidget QTabWidget > QTabBar::tab:selected {
+
+		background-color: $backgroundRaised;
+
+		border-color: $backgroundRaisedHighlight;
+		border-right-color: $backgroundRaisedLowlight;
+		border-bottom-color: $backgroundRaised; /* blend into frame below */
 	}
 
 	QTabBar::tab:!selected {
 
-		color: $foregroundFaded;
+		color: $tintLighterStronger;
 		background-color: $backgroundDark;
+
 		border-color: transparent;
-		border-radius: 0px;
-		padding-bottom: 2px;
-		padding-top: 2px;
-		margin-top: 4px;
+		border-bottom-color: $background;
 	}
 
-	QTabBar::tab:disabled {
+	QTabBar::tab:!selected:hover {
 
-		color: $foregroundFaded;
+		background-color: $backgroundDarkHighlight;
 
+	}
+
+	QTabWidget QTabWidget > QTabBar::tab:!selected {
+
+		color: $tintLighterStronger;
+		background-color: $backgroundDarkHighlight;
+
+		border-color: transparent;
+		border-bottom-color: $backgroundRaisedHighlight;
+	}
+
+	QTabWidget QTabWidget > QTabBar::tab:!selected:hover {
+		background-color: $backgroundDarkHighlight;
+	}
+
+	QSplitter[gafferHighlighted="true"] {
+
+		border: 1px solid $brightColor;
+	}
+
+	QTabWidget::pane {
+
+		background-color: $background;
+
+		/* tab widget frame has a line at the top, tweaked up 1 pixel */
+		/* so that it sits underneath the bottom of the tabs.         */
+		/* this means the active tab can blend into the frame.        */
+
+		top: -1px;
+
+		border-radius: 2px;
+		border-top-left-radius: 0;
+
+		border: 1px solid $backgroundHighlight;
+		border-right-color: $backgroundLowlight;
+		border-bottom-color: $backgroundLowlight;
+
+	}
+
+	QTabWidget[gafferNumChildren="0"]::pane {
+		background-color: $backgroundDarker;
+		border-color: $backgroundDarker;
+	}
+
+	QTabWidget QTabWidget::pane {
+
+		background-color: $backgroundRaised;
+
+		border-radius: $widgetCornerRadius;
+		border-top-left-radius: 0;
+
+		border-color: $backgroundRaisedHighlight;
+		border-right-color: $backgroundRaisedLowlight;
+		border-bottom-color: $backgroundRaisedLowlight;
+	}
+
+	QSplitter {
+
+		background-color: $backgroundDarker;
 	}
 
 	/* Ensures the QSplitter border is visible if we need to highlight */
@@ -508,51 +618,29 @@ _styleSheet = string.Template(
 
 	QSplitter::handle:vertical {
 
-		background-color: $backgroundDark;
 		height: 2px;
-		margin-top: 2px;
-		margin-bottom: 2px;
-		/* i don't know why the padding has to be here */
-		padding-top: -2px;
-		padding-bottom: -2px;
+		border: 1px $backgroundDarker solid;
+		margin: 1px;
+		padding: -2px;
 	}
 
 	QSplitter::handle:horizontal {
-
-		background-color: $backgroundDark;
+		background-color: $backgroundDarker;
 		width: 2px;
-		margin-left: 2px;
-		margin-right: 2px;
-
+		margin: 1px;
+		padding: -2px;
 	}
 
 	/* I'm not sure why this is necessary, but it works around a problem where the */
 	/* style for QSplitter::handle:hover isn't always accepted.                    */
 	QSplitterHandle:hover {}
 
-	QTabBar::tab:hover, QMenu::item:selected, QMenuBar::item:selected, QSplitter::handle:hover,
-	QComboBox QAbstractItemView::item:hover {
+	QMenu::item:selected, QMenuBar::item:selected, QSplitter::handle:hover {
 
 		color: white;
 		background-color:	$brightColor;
 
 	}
-
-	QSplitter[gafferHighlighted="true"] {
-
-		border: 1px solid $brightColor;
-
-	}
-
-	/* tab widget frame has a line at the top, tweaked up 1 pixel */
-	/* so that it sits underneath the bottom of the tabs.         */
-	/* this means the active tab can blend into the frame.        */
-	QTabWidget::pane {
-		border: 1px solid $backgroundDark;
-		border-top: 1px solid $backgroundDark;
-		top: -1px;
-	}
-
 	QTabWidget[gafferHighlighted=\"true\"]::pane {
 		border: 1px solid $brightColor;
 		border-top: 1px solid $brightColor;
@@ -560,8 +648,11 @@ _styleSheet = string.Template(
 	}
 
 	QTabWidget[gafferHighlighted=\"true\"] > QTabBar::tab:selected {
-		border: 1px solid $brightColor;
-		border-bottom-color: $backgroundMid; /* blend into frame below */
+		border-bottom-color: $background; /* blend into frame below */
+	}
+
+	QTabwidget QTabWidget[gafferHighlighted=\"true\"] > QTabBar::tab:selected {
+		border-bottom-color: $backgroundRaised; /* blend into frame below */
 	}
 
 	QTabWidget[gafferHighlighted=\"true\"] > QTabBar::tab:!selected {
@@ -575,8 +666,7 @@ _styleSheet = string.Template(
 
 	QWidget#gafferCollapsible QWidget#gafferCollapsible > QCheckBox#gafferCollapsibleToggle {
 
-		margin-left: 12px;
-		font-weight: normal;
+		margin-left: 10px;
 
 	}
 
@@ -622,41 +712,55 @@ _styleSheet = string.Template(
 
 		border: 0px;
 		margin: 0px;
-
 	}
 
 	QHeaderView::section {
 
-		border: 1px solid $backgroundDark;
-		padding: 6px;
+		border: 1px solid $backgroundLowlight;
+		border-radius: 0;
+		padding: 3px;
 		font-weight: bold;
 		margin: 0px;
 
+		background-color: $tintLighter;
+	}
+	
+	QHeaderView::section:first#vectorDataWidgetVerticalHeader {
+		border-top-left-radius: $widgetCornerRadius;
+	}
+
+	QHeaderView::section:last#vectorDataWidgetVerticalHeader {
+		border-bottom-left-radius: $widgetCornerRadius;
+	}
+
+	QHeaderView::section:only-one#vectorDataWidgetVerticalHeader {
+		border-top-left-radius: $widgetCornerRadius;
+		border-bottom-left-radius: $widgetCornerRadius;
+	}
+
+	QHeaderView::section:first#vectorDataWidgetHorizontalHeader {
+		border-top-left-radius: $widgetCornerRadius;
+	}
+
+	QHeaderView::section:last#vectorDataWidgetHorizontalHeader {
+		border-top-right-radius: $widgetCornerRadius;
+	}
+
+	QHeaderView::section:only-one#vectorDataWidgetHorizontalHeader {
+		border-top-left-radius: $widgetCornerRadius;
+		border-top-right-radius: $widgetCornerRadius;
 	}
 
 	/* tuck adjacent header sections beneath one another so we only get */
 	/* a single width line between them                                 */
-	QHeaderView::section:horizontal:!first {
 
+	QHeaderView::section:horizontal:!first:!only-one {
 		margin-left: -1px;
 
 	}
 
-	QHeaderView::section:horizontal:only-one {
-
-		margin-left: 0px;
-
-	}
-
-	QHeaderView::section:vertical:!first {
-
+	QHeaderView::section:vertical:!first:!only-one {
 		margin-top: -1px;
-
-	}
-
-	QHeaderView::section:vertical:only-one {
-
-		margin-top: 0px;
 
 	}
 
@@ -674,22 +778,22 @@ _styleSheet = string.Template(
 
 	QScrollBar {
 
-		border: 1px solid $backgroundDark;
-		background-color: $backgroundDark;
-
+		border: none;
+		border-radius: 4px;
+		background-color: $tintDarker;
 	}
 
 	QScrollBar:vertical {
 
-		width: 14px;
-		margin: 0px 0px 28px 0px;
+		width: 16px;
+		margin: 4px;
 
 	}
 
 	QScrollBar:horizontal {
 
-		height: 14px;
-		margin: 0px 28px 0px 0px;
+		height: 16px;
+		margin: 4px;
 
 	}
 
@@ -699,18 +803,18 @@ _styleSheet = string.Template(
 	}
 
 	QScrollBar::add-line, QScrollBar::sub-line {
-		background-color: $backgroundLight;
-		border: 1px solid $backgroundDark;
+		background-color: none;
+		border: none;
 	}
 
 	QScrollBar::add-line:vertical {
-		height: 14px;
+		height: 8px;
 		subcontrol-position: bottom;
 		subcontrol-origin: margin;
 	}
 
 	QScrollBar::add-line:horizontal {
-		width: 14px;
+		width: 8px;
 		subcontrol-position: right;
 		subcontrol-origin: margin;
 	}
@@ -731,39 +835,18 @@ _styleSheet = string.Template(
 		right: 15px;
 	}
 
-	QScrollBar::down-arrow {
-		image: url($GAFFER_ROOT/graphics/arrowDown10.png);
-	}
-
-	QScrollBar::up-arrow {
-		image: url($GAFFER_ROOT/graphics/arrowUp10.png);
-	}
-
-	QScrollBar::left-arrow {
-		image: url($GAFFER_ROOT/graphics/arrowLeft10.png);
-	}
-
-	QScrollBar::right-arrow {
-		image: url($GAFFER_ROOT/graphics/arrowRight10.png);
-	}
-
 	QScrollBar::handle {
-		background-color: $backgroundLight;
-		border: 1px solid $backgroundDark;
+		background-color: $tintLighterStrong;
+		border-radius: 4px;
+		border: none;
 	}
 
 	QScrollBar::handle:vertical {
 		min-height: 14px;
-		border-left: none;
-		border-right: none;
-		margin-top: -1px;
 	}
 
 	QScrollBar::handle:horizontal {
 		min-width: 14px;
-		border-top: none;
-		border-bottom: none;
-		margin-left: -1px;
 	}
 
 	QScrollBar::handle:hover, QScrollBar::add-line:hover, QScrollBar::sub-line:hover {
@@ -907,13 +990,13 @@ _styleSheet = string.Template(
 
 	.QFrame#borderStyleNone {
 		border: 1px solid transparent;
-		border-radius: 4px;
+		border-radius: $widgetCornerRadius;
 		padding: 2px;
 	}
 
 	.QFrame#borderStyleFlat {
 		border: 1px solid $backgroundDark;
-		border-radius: 4px;
+		border-radius: $widgetCornerRadius;
 		padding: 2px;
 	}
 
@@ -922,7 +1005,9 @@ _styleSheet = string.Template(
 	}
 
 	.QFrame#gafferDivider {
-		color: $backgroundDark;
+		color: $tintDarkerStrong;
+		margin-left: 10px;
+		margin-right: 10px;
 	}
 
 	QToolTip {
@@ -933,9 +1018,25 @@ _styleSheet = string.Template(
 
 	}
 
+
+	/* Tree/Table views */
+
 	QTreeView {
-		border: 1px solid $backgroundDark;
-		padding: 0px;
+
+		background-color: $backgroundRaised;
+
+		border: 1px solid $backgroundRaisedHighlight;
+		border-bottom-color: $backgroundRaisedLowlight;
+		border-right-color: $backgroundRaisedLowlight;
+
+		padding: 0;
+
+		alternate-background-color: $backgroundLowlight;
+
+	}
+
+	QTreeView::item {
+		padding: 2px;
 	}
 
 	QTreeView::item:selected {
@@ -943,9 +1044,11 @@ _styleSheet = string.Template(
 	}
 
 	QTableView {
+		border: 1px solid transparent;
+	}
 
-		border: 0px solid transparent;
-
+	QTableView::item {
+		background-color: $background;
 	}
 
 	QTableView::item:selected {
@@ -953,23 +1056,23 @@ _styleSheet = string.Template(
 	}
 
 	QTableView QTableCornerButton::section {
-		background-color: $backgroundMid;
-		border: 1px solid $backgroundMid;
+		background-color: transparent;
+		border: none;
 	}
 
 	QTableView#vectorDataWidget {
-		gridline-color: $backgroundDark;
+		gridline-color: $backgroundLowlight;
 		padding: 0px;
-		background-color: transparent;
+		background-color: $backgroundRaised;
 	}
 
 	QTableView#vectorDataWidgetEditable {
 		padding: 0px;
-		gridline-color: $backgroundDark;
+		gridline-color: $backgroundLowlight;
 	}
 
 	QTableView::item#vectorDataWidgetEditable {
-		background-color: $backgroundLighter;
+		background-color: $backgroundLight;
 	}
 
 	QTableView::item:selected#vectorDataWidgetEditable {
@@ -977,7 +1080,6 @@ _styleSheet = string.Template(
 	}
 
 	QHeaderView::section#vectorDataWidgetVerticalHeader {
-		background-color: transparent;
 		padding: 2px;
 	}
 
@@ -1128,6 +1230,26 @@ _styleSheet = string.Template(
 
 	}
 
+	/* PythonEditor */
+
+	QSplitter#gafferPythonEditor {
+		background-color: $background;
+	}
+
+	QPlainTextEdit#gafferPythonEditorOutput {
+		border-radius: 0;
+		border-top-left-radius: $widgetCornerRadius;
+		border-top-right-radius: $widgetCornerRadius;
+		background-color: rbg( 30, 30, 30 );
+	}
+
+	QPlainTextEdit#gafferPythonEditorInput {
+		border-radius: 0;
+		border-bottom-left-radius: $widgetCornerRadius;
+		border-bottom-right-radius: $widgetCornerRadius;
+	}
+
 	"""
 
 ).substitute( substitutions )
+

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -1053,30 +1053,6 @@
        id="path3885"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccccc" />
-    <path
-       style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 160,84.662183 c -3.97645,0 -7.2,3.22355 -7.2,7.2 0,3.97645 3.22355,7.2 7.2,7.2 3.97645,0 7.2,-3.22355 7.2,-7.2 0,-3.97645 -3.22355,-7.2 -7.2,-7.2 z m 0,2.4 c 2.65097,0 4.8,2.149034 4.8,4.8 0,2.650966 -2.14903,4.8 -4.8,4.8 -2.65097,0 -4.8,-2.149034 -4.8,-4.8 0,-2.650966 2.14903,-4.8 4.8,-4.8 z"
-       id="forExport:targetNodesLocked"
-       inkscape:label="#path3102"
-       inkscape:connector-curvature="0" />
-    <circle
-       style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3874"
-       cx="160"
-       cy="91.862183"
-       r="2.4000001" />
-    <path
-       id="forExport:targetNodesUnlocked"
-       d="m 180,84.662183 c -3.97645,0 -7.2,3.223549 -7.2,7.2 0,3.97645 3.22355,7.199997 7.2,7.199997 3.97645,0 7.2,-3.223547 7.2,-7.199997 0,-3.976451 -3.22355,-7.2 -7.2,-7.2 z m 0,2.4 c 2.65097,0 4.8,2.149033 4.8,4.8 0,2.650966 -2.14903,4.8 -4.8,4.8 -2.65097,0 -4.8,-2.149034 -4.8,-4.8 0,-2.650967 2.14903,-4.8 4.8,-4.8 z"
-       style="fill:url(#linearGradient6221);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0"
-       inkscape:label="#path3878" />
-    <circle
-       id="path3880"
-       style="fill:url(#linearGradient6227);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       cx="180"
-       cy="91.862183"
-       r="2.4000001" />
     <g
        transform="translate(21.93052,25.5)"
        id="g3874"
@@ -4462,5 +4438,75 @@
        id="path2986"
        d="m 170.19669,76.454588 c -0.43135,-0.109805 -0.69022,-0.361106 -1.31027,-1.271901 -0.65643,-0.964226 -1.33519,-1.836887 -2.02487,-2.603299 -0.52476,-0.583153 -0.91507,-1.161596 -1.00225,-1.48538 -0.191,-0.709291 0.39865,-1.562619 1.4473,-2.094536 0.47073,-0.238773 0.54816,-0.258015 1.03834,-0.258015 0.49709,0 0.56366,0.01721 1.082,0.280052 0.59482,0.301599 1.37342,0.965914 1.82292,1.555347 0.13651,0.178999 0.26603,0.325452 0.28783,0.325452 0.0218,0 0.16421,-0.274705 0.31648,-0.610464 0.33632,-0.741556 1.7286,-3.347638 2.31007,-4.32402 2.1563,-3.620682 4.53884,-6.626438 5.68071,-7.166624 0.42723,-0.202115 1.33862,-0.382904 2.38809,-0.473716 0.73272,-0.06338 0.81795,-0.05907 1.07584,0.05501 0.18422,0.0815 0.31819,0.197574 0.3914,0.339141 0.12782,0.247174 0.13951,0.679936 0.0244,0.901898 -0.0434,0.08357 -0.51977,0.601885 -1.0587,1.151771 -1.47567,1.505676 -2.29807,2.518125 -3.60446,4.437411 -1.74342,2.561359 -3.18888,5.206826 -4.45279,8.149473 -0.96967,2.257583 -0.98235,2.283931 -1.23312,2.561495 -0.12543,0.138843 -0.3802,0.319294 -0.56616,0.401018 -0.29933,0.131547 -0.45644,0.15059 -1.37014,0.16603 -0.56763,0.0097 -1.12681,-0.0066 -1.24262,-0.0362 z"
        style="fill:#666666;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-opacity:1" />
+    <g
+       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;fill:url(#backgroundLighter)"
+       transform="matrix(0.8,0,0,0.8,-626.30839,-193.05238)"
+       id="forExport:targetNodesUnlocked">
+      <g
+         id="g1166"
+         transform="rotate(-45,1063.0797,502.31281)"
+         style="fill:url(#backgroundLighter)">
+        <path
+           id="path1164"
+           style="fill:url(#backgroundLighter);stroke:#3c3c3c;stroke-width:1px"
+           d="m 1099.5,342.135 1,-1.613 h 5 V 336 c 0.97,-1.378 1.01,-1.482 2,0 v 2 l 8,1 v -2 h 2 v 9 l -2,0.27 v -2.31 l -8,1.04 v 2 c -0.91,1.591 -1.3,1.384 -2,0 v -4.478 h -5 z"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="g1170"
+         transform="rotate(-45,1063.0911,503.72257)"
+         style="fill:url(#backgroundLighter)">
+        <path
+           id="path1168"
+           style="fill:url(#backgroundLighter);stroke:#3c3c3c;stroke-width:1px"
+           d="m 1108.5,339 v 7"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="g1174"
+         transform="rotate(-45,1058.8981,494.14549)"
+         style="fill:url(#backgroundLighter)">
+        <path
+           id="path1172"
+           style="fill:url(#backgroundLighter);stroke:#3c3c3c;stroke-width:1px"
+           d="m 1108.5,339 v 7"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;fill:url(#foreground)"
+       transform="matrix(0.8,0,0,0.8,-607.41407,-193.05238)"
+       id="forExport:targetNodesLocked">
+      <g
+         id="g1179"
+         transform="rotate(-45,1063.0797,502.31281)"
+         style="fill:url(#foreground)">
+        <path
+           id="path1177"
+           style="fill:url(#foreground);stroke:#3c3c3c;stroke-width:1px"
+           d="m 1099.5,342.135 1,-1.613 h 5 V 336 c 0.97,-1.378 1.01,-1.482 2,0 v 2 l 8,1 v -2 h 2 v 9 l -2,0.27 v -2.31 l -8,1.04 v 2 c -0.91,1.591 -1.3,1.384 -2,0 v -4.478 h -5 z"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="g1183"
+         transform="rotate(-45,1063.0911,503.72257)"
+         style="fill:url(#foreground)">
+        <path
+           id="path1181"
+           style="fill:url(#foreground);stroke:#3c3c3c;stroke-width:1px"
+           d="m 1108.5,339 v 7"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="g1187"
+         transform="rotate(-45,1058.8981,494.14549)"
+         style="fill:url(#foreground)">
+        <path
+           id="path1185"
+           style="fill:url(#foreground);stroke:#3c3c3c;stroke-width:1px"
+           d="m 1108.5,339 v 7"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
   </g>
 </svg>

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -81,6 +81,138 @@
          id="stop2121" />
     </linearGradient>
     <linearGradient
+       id="linearGradient6253"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#787878;stop-opacity:1;"
+         offset="0"
+         id="stop6251" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6247"
+       xlink:href="#linearGradient6241">
+      <stop
+         style="stop-color:#787878;stop-opacity:1;"
+         offset="0"
+         id="stop6245" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6241"
+       osb:paint="solid"
+       gradientTransform="translate(-71.339679,50.536488)">
+      <stop
+         style="stop-color:#969696;stop-opacity:1;"
+         offset="0"
+         id="stop6239" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6231">
+      <stop
+         style="stop-color:#f9f9f9;stop-opacity:1;"
+         offset="0"
+         id="stop6229" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6225">
+      <stop
+         style="stop-color:#787878;stop-opacity:1;"
+         offset="0"
+         id="stop6223" />
+    </linearGradient>
+    <linearGradient
+       id="background"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#4c4c4c;stop-opacity:1;"
+         offset="0"
+         id="stop6215" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6172">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6170" />
+    </linearGradient>
+    <linearGradient
+       id="tintDarker"
+       xlink:href="#tintDarkerStrong">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6156" />
+    </linearGradient>
+    <linearGradient
+       id="tintDarkerStrong">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6150" />
+    </linearGradient>
+    <linearGradient
+       id="backgroundDark"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#383838;stop-opacity:1;"
+         offset="0"
+         id="stop6029" />
+    </linearGradient>
+    <linearGradient
+       id="backgroundLighter"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#7d7d7d;stop-opacity:1;"
+         offset="0"
+         id="stop6023" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6017">
+      <stop
+         style="stop-color:#f9f9f9;stop-opacity:1;"
+         offset="0"
+         id="stop6015" />
+    </linearGradient>
+    <linearGradient
+       id="backgroundLightLowlight-5"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#525252;stop-opacity:1;"
+         offset="0"
+         id="stop5804" />
+    </linearGradient>
+    <linearGradient
+       id="backgroundLightLowlight">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5798" />
+    </linearGradient>
+    <linearGradient
+       id="brightColor"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#779cbd;stop-opacity:1;"
+         offset="0"
+         id="stop5786" />
+    </linearGradient>
+    <linearGradient
+       id="foreground"
+       osb:paint="solid"
+       gradientTransform="matrix(0.24,0,0,0.24,122.08,124.63193)">
+      <stop
+         style="stop-color:#e0e0e0;stop-opacity:1;"
+         offset="0"
+         id="stop5780" />
+    </linearGradient>
+    <linearGradient
+       id="backgroundLight"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#606060;stop-opacity:1;"
+         offset="0"
+         id="stop5738" />
+    </linearGradient>
+    <linearGradient
        id="linearGradient6311"
        osb:paint="solid">
       <stop
@@ -263,25 +395,179 @@
        y1="90.327164"
        x2="470.95706"
        y2="98.08519" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLight"
+       id="linearGradient5742"
+       x1="87"
+       y1="67.362183"
+       x2="103"
+       y2="67.362183"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient5784"
+       x1="85.323975"
+       y1="67.432732"
+       x2="104.30441"
+       y2="67.432732"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLightLowlight-5"
+       id="linearGradient5808"
+       x1="87"
+       y1="67.612183"
+       x2="103.5"
+       y2="67.612183"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLightLowlight-5"
+       id="linearGradient5851"
+       gradientUnits="userSpaceOnUse"
+       x1="87"
+       y1="67.612183"
+       x2="103.5"
+       y2="67.612183"
+       gradientTransform="translate(-0.5625,-0.50000038)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLight"
+       id="linearGradient5908"
+       gradientUnits="userSpaceOnUse"
+       x1="87"
+       y1="67.362183"
+       x2="103"
+       y2="67.362183" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLightLowlight-5"
+       id="linearGradient5910"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.5625,-0.50000038)"
+       x1="87"
+       y1="67.612183"
+       x2="103.5"
+       y2="67.612183" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#brightColor"
+       id="linearGradient5945"
+       gradientUnits="userSpaceOnUse"
+       x1="87"
+       y1="67.362183"
+       x2="103"
+       y2="67.362183" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#brightColor"
+       id="linearGradient6013"
+       gradientUnits="userSpaceOnUse"
+       x1="87"
+       y1="67.362183"
+       x2="103"
+       y2="67.362183" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient6021"
+       gradientUnits="userSpaceOnUse"
+       x1="145.32397"
+       y1="67.442017"
+       x2="164.30441"
+       y2="67.442017" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundDark"
+       id="linearGradient6033"
+       x1="48.75"
+       y1="91.862181"
+       x2="60.749997"
+       y2="91.862181"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundDark"
+       id="linearGradient6035"
+       x1="35.75"
+       y1="91.862181"
+       x2="47.749997"
+       y2="91.862181"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundDark"
+       id="linearGradient6037"
+       x1="26.75"
+       y1="91.362181"
+       x2="33.75"
+       y2="91.362181"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#background"
+       id="linearGradient6219"
+       x1="130"
+       y1="91.86219"
+       x2="149"
+       y2="91.86219"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8,0,0,0.8,27.9,18.372438)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLight"
+       id="linearGradient6221"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8,0,0,0.8,36,18.372436)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLight"
+       id="linearGradient6227"
+       x1="148.66667"
+       y1="38"
+       x2="167.33333"
+       y2="38"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3,0,0,0.3,132.6,80.462183)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient6233"
+       x1="108.46148"
+       y1="578.07648"
+       x2="121.48355"
+       y2="578.07648"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6241"
+       id="linearGradient6249"
+       x1="108.46148"
+       y1="578.07648"
+       x2="121.48355"
+       y2="578.07648"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
      id="base"
-     pagecolor="#666666"
+     pagecolor="#4c4c4c"
      bordercolor="#4c4c4c"
      borderopacity="1"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="2"
-     inkscape:cx="567.80162"
-     inkscape:cy="207.82982"
+     inkscape:zoom="1"
+     inkscape:cx="286.77472"
+     inkscape:cy="715.04552"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1016"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
+     inkscape:window-width="1231"
+     inkscape:window-height="1092"
+     inkscape:window-x="689"
+     inkscape:window-y="44"
+     inkscape:window-maximized="0"
      inkscape:snap-global="true"
      inkscape:snap-nodes="true"
      inkscape:snap-bbox="true"
@@ -291,10 +577,11 @@
      inkscape:snap-smooth-nodes="true"
      showguides="true"
      inkscape:guide-bbox="true"
-     inkscape:snap-grids="true"
+     inkscape:snap-grids="false"
      inkscape:object-paths="false"
      inkscape:bbox-paths="false"
-     inkscape:bbox-nodes="true">
+     inkscape:bbox-nodes="true"
+     inkscape:snap-to-guides="false">
     <inkscape:grid
        type="xygrid"
        id="grid3598"
@@ -315,7 +602,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -324,6 +611,19 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-52.362183)">
+    <g
+       transform="translate(101)"
+       id="g5812-7-8-9">
+      <rect
+         style="fill:#000000;fill-opacity:0.07843137"
+         ry="2"
+         rx="2"
+         y="59.362183"
+         x="87"
+         height="16"
+         width="16"
+         id="rect5736-0-2-4" />
+    </g>
     <rect
        style="fill:none;fill-opacity:1;stroke:none"
        id="forExport:plugAdder"
@@ -352,8 +652,8 @@
        sodipodi:nodetypes="ccccc"
        inkscape:connector-curvature="0"
        id="path4098"
-       d="m 448,252.33973 0,-17.21328 4,-1.769 0,18.98228 z"
-       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:4;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+       d="m 448,252.33973 v -17.21328 l 4,-1.769 v 18.98228 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:4;marker:none;enable-background:accumulate" />
     <rect
        y="202.36218"
        x="440"
@@ -371,8 +671,8 @@
        y="182.36218"
        inkscape:label="#rect4071" />
     <path
-       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:4;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-       d="m 448,197.36218 0,34.14035 4,-1.59099 0,-32.54936 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:4;marker:none;enable-background:accumulate"
+       d="m 448,197.36218 v 34.14035 l 4,-1.59099 v -32.54936 z"
        id="path4058"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccc" />
@@ -381,9 +681,9 @@
        inkscape:connector-curvature="0"
        id="path4067"
        d="m 450,257.36218 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 2.67905,0 4.88204,2.11157 4.99775,4.89411 0.002,2.86731 -2.23633,5.10589 -4.99775,5.10589 z"
-       style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <g
-       style="fill:#575757;fill-opacity:1;stroke:#424242;stroke-width:0.84210503000000003;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#575757;fill-opacity:1;stroke:#424242;stroke-width:0.84210503;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        transform="matrix(-1.1875,0,0,-1.1875007,427.15625,420.19865)"
        id="g4075" />
     <rect
@@ -403,16 +703,11 @@
        y="61.362183"
        inkscape:label="#rect3932" />
     <path
-       id="path3886"
-       style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:1"
-       d="m 87.5,59.862183 15,0 0,15 -15,0 z"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="opacity:0.98999999000000005;fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.5;stroke-miterlimit:4;stroke-opacity:1;stroke-linejoin:round;stroke-dasharray:none"
-       d="M 201 30.5 C 196.02944 30.5 192 34.529437 192 39.5 C 192 44.470563 196.02944 48.5 201 48.5 C 205.97056 48.5 210 44.470563 210 39.5 C 210 34.529437 205.97056 30.5 201 30.5 z M 200.9375 32.4375 C 201.69562 32.4375 202.3125 33.085626 202.3125 33.84375 C 202.3125 34.601873 201.69562 35.21875 200.9375 35.21875 C 200.16088 35.21875 199.53125 34.589114 199.53125 33.8125 C 199.53125 33.035885 200.14239 32.4375 200.9375 32.4375 z M 201.9375 36.78125 L 202.125 36.90625 L 202.125 43.65625 C 202.125 44.654754 202.20803 44.80677 202.78125 44.84375 L 203.4375 44.875 L 203.4375 45.5625 C 202.19861 45.52552 201.30731 45.5 200.9375 45.5 L 198.5625 45.5625 L 198.5625 44.875 L 199.21875 44.84375 C 199.79192 44.806768 199.875 44.654754 199.875 43.65625 L 199.875 39.59375 C 199.875 38.502792 199.83153 38.34948 199.40625 38.3125 L 198.5625 38.25 L 198.5625 37.59375 C 198.69193 37.57526 198.78825 37.5625 198.84375 37.5625 C 199.62037 37.470046 200.06455 37.372408 200.65625 37.1875 L 201.9375 36.78125 z "
+       style="opacity:0.98999999;fill:url(#backgroundLighter);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 201,30.5 c -4.97056,0 -9,4.029437 -9,9 0,4.970563 4.02944,9 9,9 4.97056,0 9,-4.029437 9,-9 0,-4.970563 -4.02944,-9 -9,-9 z m -0.0625,1.9375 c 0.75812,0 1.375,0.648126 1.375,1.40625 0,0.758123 -0.61688,1.375 -1.375,1.375 -0.77662,0 -1.40625,-0.629636 -1.40625,-1.40625 0,-0.776615 0.61114,-1.375 1.40625,-1.375 z m 1,4.34375 0.1875,0.125 v 6.75 c 0,0.998504 0.083,1.15052 0.65625,1.1875 l 0.65625,0.03125 v 0.6875 c -1.23889,-0.03698 -2.13019,-0.0625 -2.5,-0.0625 l -2.375,0.0625 V 44.875 l 0.65625,-0.03125 c 0.57317,-0.03698 0.65625,-0.188996 0.65625,-1.1875 v -4.0625 c 0,-1.090958 -0.0435,-1.24427 -0.46875,-1.28125 L 198.5625,38.25 v -0.65625 c 0.12943,-0.01849 0.22575,-0.03125 0.28125,-0.03125 0.77662,-0.09245 1.2208,-0.190092 1.8125,-0.375 z"
        transform="translate(0,52.362183)"
-       id="forExport:info" />
+       id="forExport:info"
+       inkscape:connector-curvature="0" />
     <g
        id="forExport:arrowDown10"
        inkscape:label="#downArrow10"
@@ -432,7 +727,7 @@
          sodipodi:cx="117.14286"
          sodipodi:sides="3"
          id="path2818"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:url(#linearGradient6241);fill-opacity:1;stroke:url(#backgroundDark);stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:type="star" />
       <rect
          y="57.36219"
@@ -447,7 +742,7 @@
        inkscape:export-xdpi="10"
        inkscape:label="#downArrow10"
        id="g3604"
-       transform="translate(10.000004,0)">
+       transform="translate(10.000004)">
       <rect
          style="fill:none;stroke:none"
          id="rect3608"
@@ -464,7 +759,7 @@
        transform="matrix(1,0,0,-1,10.000008,124.72438)">
       <path
          sodipodi:type="star"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:url(#linearGradient6249);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path3612"
          sodipodi:sides="3"
          sodipodi:cx="117.14286"
@@ -491,10 +786,10 @@
        inkscape:export-xdpi="10"
        inkscape:label="#downArrow10"
        id="forExport:arrowLeft10"
-       transform="matrix(0,1,-1,0,92.362192,52.362187)">
+       transform="rotate(90,20.000002,72.362189)">
       <path
          sodipodi:type="star"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:url(#linearGradient6241);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path3618"
          sodipodi:sides="3"
          sodipodi:cx="117.14286"
@@ -560,7 +855,7 @@
        sodipodi:cx="117.14286"
        sodipodi:sides="3"
        id="path2835"
-       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        sodipodi:type="star" />
     <rect
        y="55.000004"
@@ -579,7 +874,7 @@
        transform="matrix(0,1,1,0,-22.362182,52.362187)">
       <path
          sodipodi:type="star"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-opacity:0.99215686;stroke-dasharray:none"
+         style="fill:url(#linearGradient6241);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
          id="path2851"
          sodipodi:sides="3"
          sodipodi:cx="117.14286"
@@ -603,7 +898,7 @@
     </g>
     <path
        sodipodi:type="star"
-       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852143000000008;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="down"
        sodipodi:sides="3"
        sodipodi:cx="117.14286"
@@ -628,15 +923,10 @@
        y="45"
        inkscape:label="#rect2865" />
     <path
-       style="fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-opacity:1"
-       d="m 90.196685,76.454588 c -0.431342,-0.109805 -0.690215,-0.361106 -1.31027,-1.271901 -0.65643,-0.964226 -1.33519,-1.836887 -2.024863,-2.603299 -0.524766,-0.583153 -0.91507,-1.161596 -1.002255,-1.48538 -0.190993,-0.709291 0.398649,-1.562619 1.447306,-2.094536 0.470729,-0.238773 0.54816,-0.258015 1.038337,-0.258015 0.497095,0 0.563657,0.01721 1.082001,0.280052 0.594818,0.301599 1.373418,0.965914 1.822921,1.555347 0.136504,0.178999 0.26603,0.325452 0.287827,0.325452 0.02177,0 0.164208,-0.274705 0.316485,-0.610464 0.336313,-0.741556 1.728594,-3.347638 2.310071,-4.32402 2.156294,-3.620682 4.538839,-6.626438 5.680704,-7.166624 0.427231,-0.202115 1.338621,-0.382904 2.388091,-0.473716 0.73272,-0.06338 0.81795,-0.05907 1.07584,0.05501 0.18422,0.0815 0.31819,0.197574 0.3914,0.339141 0.12782,0.247174 0.13951,0.679936 0.0244,0.901898 -0.0434,0.08357 -0.51977,0.601885 -1.0587,1.151771 -1.47567,1.505676 -2.29807,2.518125 -3.604458,4.437411 -1.743419,2.561359 -3.18888,5.206826 -4.452792,8.149473 -0.96967,2.257583 -0.982354,2.283931 -1.233117,2.561495 -0.125435,0.138843 -0.380198,0.319294 -0.56616,0.401018 -0.299329,0.131547 -0.456439,0.15059 -1.370145,0.16603 -0.567628,0.0097 -1.126805,-0.0066 -1.242616,-0.0362 z"
-       id="path3923"
-       inkscape:connector-curvature="0" />
-    <path
        inkscape:connector-curvature="0"
        id="path3925"
        d="M 10.00302,97.80467 C 9.67541,97.72127 9.47879,97.53041 9.00785,96.83864 8.50927,96.10629 7.99375,95.44349 7.46993,94.861385 7.07136,94.41847 6.77491,93.979131 6.7087,93.733211 6.56363,93.194492 7.01148,92.546373 7.80796,92.142372 8.16548,91.961019 8.2243,91.946405 8.5966,91.946405 c 0.37755,0 0.4281,0.01307 0.82179,0.212704 0.45178,0.22907 1.04314,0.733631 1.38454,1.181315 0.10373,0.135954 0.20206,0.247188 0.21862,0.247188 0.0166,0 0.12472,-0.208644 0.24037,-0.463659 0.25544,-0.563226 1.31289,-2.542595 1.75455,-3.284175 1.63774,-2.749977 3.44733,-5.032904 4.31459,-5.443186 0.3245,-0.15351 1.01672,-0.290822 1.81381,-0.359796 0.55651,-0.04814 0.62125,-0.04487 0.81712,0.04177 0.13992,0.0619 0.24167,0.150061 0.29727,0.257584 0.0971,0.187734 0.10594,0.516424 0.0185,0.685008 -0.0328,0.06347 -0.39478,0.457143 -0.80411,0.874793 -1.1208,1.143589 -1.74543,1.912562 -2.73766,3.370297 -1.32415,1.9454 -2.422,3.954681 -3.38197,6.189678 -0.73648,1.714674 -0.74612,1.734684 -0.93659,1.945504 -0.0953,0.10545 -0.28876,0.24251 -0.42999,0.30458 -0.22736,0.0999 -0.34668,0.11437 -1.04066,0.1261 -0.43112,0.007 -0.85582,-0.005 -0.94379,-0.0275 z"
-       style="fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-opacity:1" />
+       style="fill:url(#foreground);fill-opacity:1;stroke:url(#backgroundDark);stroke-opacity:1" />
     <rect
        style="fill:none;stroke:none"
        id="forExport:checkBoxChecked"
@@ -673,17 +963,6 @@
        y="125.02723"
        transform="matrix(0,1,1,0,0,0)"
        inkscape:label="#rect3931" />
-    <path
-       sodipodi:nodetypes="ccccc"
-       inkscape:connector-curvature="0"
-       d="m 147.5,59.862183 15,0 0,15 -15,0 z"
-       style="fill:#779cbd;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:1"
-       id="path3960" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path3962"
-       d="m 150.19669,76.454588 c -0.43135,-0.109805 -0.69022,-0.361106 -1.31027,-1.271901 -0.65643,-0.964226 -1.33519,-1.836887 -2.02487,-2.603299 -0.52476,-0.583153 -0.91507,-1.161596 -1.00225,-1.48538 -0.191,-0.709291 0.39865,-1.562619 1.4473,-2.094536 0.47073,-0.238773 0.54816,-0.258015 1.03834,-0.258015 0.49709,0 0.56366,0.01721 1.082,0.280052 0.59482,0.301599 1.37342,0.965914 1.82292,1.555347 0.13651,0.178999 0.26603,0.325452 0.28783,0.325452 0.0218,0 0.16421,-0.274705 0.31648,-0.610464 0.33632,-0.741556 1.7286,-3.347638 2.31007,-4.32402 2.1563,-3.620682 4.53884,-6.626438 5.68071,-7.166624 0.42723,-0.202115 1.33862,-0.382904 2.38809,-0.473716 0.73272,-0.06338 0.81795,-0.05907 1.07584,0.05501 0.18422,0.0815 0.31819,0.197574 0.3914,0.339141 0.12782,0.247174 0.13951,0.679936 0.0244,0.901898 -0.0434,0.08357 -0.51977,0.601885 -1.0587,1.151771 -1.47567,1.505676 -2.29807,2.518125 -3.60446,4.437411 -1.74342,2.561359 -3.18888,5.206826 -4.45279,8.149473 -0.96967,2.257583 -0.98235,2.283931 -1.23312,2.561495 -0.12543,0.138843 -0.3802,0.319294 -0.56616,0.401018 -0.29933,0.131547 -0.45644,0.15059 -1.37014,0.16603 -0.56763,0.0097 -1.12681,-0.0066 -1.24262,-0.0362 z"
-       style="fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-opacity:1" />
     <rect
        inkscape:label="#rect3931"
        transform="matrix(0,1,1,0,0,0)"
@@ -695,7 +974,7 @@
        style="fill:none;stroke:none" />
     <path
        sodipodi:type="star"
-       style="fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-opacity:1;stroke-width:1.53852143000000008;stroke-miterlimit:4;stroke-dasharray:none"
+       style="fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="fds"
        sodipodi:sides="3"
        sodipodi:cx="117.14286"
@@ -733,7 +1012,7 @@
        sodipodi:cx="117.14286"
        sodipodi:sides="3"
        id="path2918"
-       style="fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-opacity:1;stroke-width:1.53852143000000008;stroke-miterlimit:4;stroke-dasharray:none"
+       style="fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        sodipodi:type="star" />
     <rect
        y="65"
@@ -745,76 +1024,69 @@
        transform="matrix(0,1,1,0,0,0)"
        inkscape:label="#rect2920" />
     <path
-       style="fill:#787878;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686"
-       d="m 214,63.362183 4,0 c 1,0 1,2 1,2 l 6,0 0,9 -12,0 0,-9 c 0,0 -0.1875,-2.125 1,-2 z"
+       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686"
+       d="m 214,63.362183 h 4 c 1,0 1,2 1,2 h 6 v 9 h -12 v -9 c 0,0 -0.1875,-2.125 1,-2 z"
        id="forExport:pathChooser"
        sodipodi:nodetypes="cccccccc"
-       inkscape:label="#rect2859" />
+       inkscape:label="#rect2859"
+       inkscape:connector-curvature="0" />
     <path
        inkscape:label="#rect2859"
        sodipodi:nodetypes="ccccccc"
        id="pathUpArrow"
-       d="m 232,74.862183 0,-4.5 -3,0 6,-7 6,7 -3,0 0,4.5"
-       style="fill:#787878;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686"
+       d="m 232,74.862183 v -4.5 h -3 l 6,-7 6,7 h -3 v 4.5"
+       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686"
        inkscape:connector-curvature="0" />
     <rect
-       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+       style="fill:url(#linearGradient6219);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.80000001;stroke-opacity:1"
        id="forExport:layoutButton"
-       width="18"
-       height="18"
-       x="130.5"
-       y="82.86219"
-       rx="2"
-       ry="2"
+       width="14.4"
+       height="14.4"
+       x="132.3"
+       y="84.662193"
+       rx="1.6"
+       ry="1.6"
        inkscape:label="#rect3097" />
     <path
-       style="fill:none;stroke:#3c3c3c;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 130.5,91.862183 18.02773,0 0,0 -9.02773,0 0,-9 0,17.999997"
+       style="fill:none;stroke:#3c3c3c;stroke-width:0.80000001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 132.3,91.862184 h 14.42218 v 0 H 139.5 v -7.2 14.399998"
        id="path3885"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccccc" />
     <path
-       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="M 160 30.5 C 155.02944 30.5 151 34.529437 151 39.5 C 151 44.470563 155.02944 48.5 160 48.5 C 164.97056 48.5 169 44.470563 169 39.5 C 169 34.529437 164.97056 30.5 160 30.5 z M 160 33.5 C 163.31371 33.5 166 36.186292 166 39.5 C 166 42.813708 163.31371 45.5 160 45.5 C 156.68629 45.5 154 42.813708 154 39.5 C 154 36.186292 156.68629 33.5 160 33.5 z "
-       transform="translate(0,52.362183)"
+       style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 160,84.662183 c -3.97645,0 -7.2,3.22355 -7.2,7.2 0,3.97645 3.22355,7.2 7.2,7.2 3.97645,0 7.2,-3.22355 7.2,-7.2 0,-3.97645 -3.22355,-7.2 -7.2,-7.2 z m 0,2.4 c 2.65097,0 4.8,2.149034 4.8,4.8 0,2.650966 -2.14903,4.8 -4.8,4.8 -2.65097,0 -4.8,-2.149034 -4.8,-4.8 0,-2.650966 2.14903,-4.8 4.8,-4.8 z"
        id="forExport:targetNodesLocked"
-       inkscape:label="#path3102" />
-    <path
-       sodipodi:type="arc"
-       style="fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.66666675000000009;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:label="#path3102"
+       inkscape:connector-curvature="0" />
+    <circle
+       style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path3874"
-       sodipodi:cx="158"
-       sodipodi:cy="38"
-       sodipodi:rx="8"
-       sodipodi:ry="8"
-       d="m 166,38 a 8,8 0 0 1 -8,8 8,8 0 0 1 -8,-8 8,8 0 0 1 8,-8 8,8 0 0 1 8,8 z"
-       transform="matrix(0.375,0,0,0.375,100.75,77.612183)" />
+       cx="160"
+       cy="91.862183"
+       r="2.4000001" />
     <path
        id="forExport:targetNodesUnlocked"
-       d="m 180,82.862183 c -4.97056,0 -9,4.029437 -9,9 0,4.970563 4.02944,8.999997 9,8.999997 4.97056,0 9,-4.029434 9,-8.999997 0,-4.970563 -4.02944,-9 -9,-9 z m 0,3 c 3.31371,0 6,2.686292 6,6 0,3.313708 -2.68629,6 -6,6 -3.31371,0 -6,-2.686292 -6,-6 0,-3.313708 2.68629,-6 6,-6 z"
-       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 180,84.662183 c -3.97645,0 -7.2,3.223549 -7.2,7.2 0,3.97645 3.22355,7.199997 7.2,7.199997 3.97645,0 7.2,-3.223547 7.2,-7.199997 0,-3.976451 -3.22355,-7.2 -7.2,-7.2 z m 0,2.4 c 2.65097,0 4.8,2.149033 4.8,4.8 0,2.650966 -2.14903,4.8 -4.8,4.8 -2.65097,0 -4.8,-2.149034 -4.8,-4.8 0,-2.650967 2.14903,-4.8 4.8,-4.8 z"
+       style="fill:url(#linearGradient6221);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:connector-curvature="0"
        inkscape:label="#path3878" />
-    <path
-       transform="matrix(0.375,0,0,0.375,120.75,77.612183)"
-       d="m 166,38 a 8,8 0 0 1 -8,8 8,8 0 0 1 -8,-8 8,8 0 0 1 8,-8 8,8 0 0 1 8,8 z"
-       sodipodi:ry="8"
-       sodipodi:rx="8"
-       sodipodi:cy="38"
-       sodipodi:cx="158"
+    <circle
        id="path3880"
-       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.66666675000000009;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       sodipodi:type="arc" />
+       style="fill:url(#linearGradient6227);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       cx="180"
+       cy="91.862183"
+       r="2.4000001" />
     <g
        transform="translate(21.93052,25.5)"
        id="g3874"
-       style="font-size:18.49083518999999853px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:0.50000000000000000;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:URW Palladio L;-inkscape-font-specification:URW Palladio L Bold">
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.49083519px;line-height:125%;font-family:'URW Palladio L';-inkscape-font-specification:'URW Palladio L Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
       <path
          sodipodi:nodetypes="cccccsscccccccsccccsssc"
          inkscape:connector-curvature="0"
-         style="fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:0.50000000000000000;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path3876"
-         d="m 178.71815,64.059798 c -0.5917,0.184908 -1.03548,0.258871 -1.8121,0.351325 -0.0555,0 -0.14793,0.01849 -0.27736,0.03698 l 0,0.66567 0.83209,0.05547 c 0.42528,0.03698 0.48076,0.2034 0.48076,1.294358 l 0,4.049493 c 0,0.998504 -0.0925,1.146432 -0.66567,1.183414 l -0.64718,0.03698 0,0.684161 2.38532,-0.05547 c 0.36981,0 1.25737,0.01849 2.49626,0.05547 l 0,-0.684161 -0.64718,-0.03698 c -0.57322,-0.03698 -0.66567,-0.18491 -0.66567,-1.183414 l 0,-6.749155 -0.18491,-0.110943 z m 0.29586,-4.75215 c -0.79511,0 -1.40531,0.591707 -1.40531,1.368322 0,0.776614 0.6102,1.405303 1.38682,1.405303 0.75812,0 1.38681,-0.628689 1.38681,-1.386812 0,-0.758124 -0.6102,-1.386813 -1.36832,-1.386813" />
+         d="m 178.71815,64.059798 c -0.5917,0.184908 -1.03548,0.258871 -1.8121,0.351325 -0.0555,0 -0.14793,0.01849 -0.27736,0.03698 v 0.66567 l 0.83209,0.05547 c 0.42528,0.03698 0.48076,0.2034 0.48076,1.294358 v 4.049493 c 0,0.998504 -0.0925,1.146432 -0.66567,1.183414 l -0.64718,0.03698 v 0.684161 l 2.38532,-0.05547 c 0.36981,0 1.25737,0.01849 2.49626,0.05547 v -0.684161 l -0.64718,-0.03698 c -0.57322,-0.03698 -0.66567,-0.18491 -0.66567,-1.183414 v -6.749155 l -0.18491,-0.110943 z m 0.29586,-4.75215 c -0.79511,0 -1.40531,0.591707 -1.40531,1.368322 0,0.776614 0.6102,1.405303 1.38682,1.405303 0.75812,0 1.38681,-0.628689 1.38681,-1.386812 0,-0.758124 -0.6102,-1.386813 -1.36832,-1.386813" />
     </g>
     <path
        id="path3882"
@@ -823,8 +1095,8 @@
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="sssss" />
     <path
-       style="fill:#000000;fill-opacity:1;stroke:none"
-       d="m 26.75,85.362182 0,3 3.625,3 -3.625,2.999998 0,3 7,-5.999998 z"
+       style="fill:url(#linearGradient6037);fill-opacity:1;stroke:none"
+       d="m 26.75,85.362182 v 3 l 3.625,3 -3.625,2.999998 v 3 l 7,-5.999998 z"
        id="path3970"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccccc" />
@@ -842,40 +1114,40 @@
        sodipodi:nodetypes="ccccccc"
        inkscape:connector-curvature="0"
        id="forExport:headerSortDown"
-       d="m 47.749997,88.362182 -3,0 -3,3.625 -3,-3.625 -2.999997,0 5.999997,6.999998 z"
-       style="fill:#000000;fill-opacity:1;stroke:none"
+       d="m 47.749997,88.362182 h -3 l -3,3.625 -3,-3.625 H 35.75 l 5.999997,6.999998 z"
+       style="fill:url(#linearGradient6035);fill-opacity:1;stroke:none"
        inkscape:label="#path2860" />
     <path
        inkscape:label="#path2860"
-       style="fill:#000000;fill-opacity:1;stroke:none"
-       d="m 60.749997,95.36218 -3,0 -3,-3.624998 -3,3.624998 -2.999997,0 5.999997,-6.999998 z"
+       style="fill:url(#linearGradient6033);fill-opacity:1;stroke:none"
+       d="m 60.749997,95.36218 h -3 l -3,-3.624998 -3,3.624998 H 48.75 l 5.999997,-6.999998 z"
        id="forExport:headerSortUp"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccccc" />
     <path
        inkscape:connector-curvature="0"
        style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
-       d="m 69.75,84.362182 0,5 -5,0 0,5.999998 5,0 0,5 6,0 0,-5 5,0 0,-5.999998 -5,0 0,-5 -6,0 z"
+       d="m 69.75,84.362182 v 5 h -5 v 5.999998 h 5 v 5 h 6 v -5 h 5 v -5.999998 h -5 v -5 z"
        id="forExport:plus"
        sodipodi:nodetypes="ccccccccccccc"
        inkscape:label="#rect3638" />
     <path
        inkscape:connector-curvature="0"
        id="path3651"
-       d="m 70.75,85.362182 0,5 -5,0 0,3.999998 5,0 0,5 4,0 0,-5 5,0 0,-3.999998 -5,0 0,-5 -4,0 z"
-       style="fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 70.75,85.362182 v 5 h -5 v 3.999998 h 5 v 5 h 4 v -5 h 5 v -3.999998 h -5 v -5 z"
+       style="fill:url(#backgroundLighter);fill-opacity:1;fill-rule:nonzero;stroke:none"
        sodipodi:nodetypes="ccccccccccccc" />
     <path
        inkscape:connector-curvature="0"
        inkscape:label="#rect3638"
        sodipodi:nodetypes="ccccc"
        id="fsdsf"
-       d="m 84.75,89.362182 0,5.999998 16,0 0,-5.999998 -16,0 z"
+       d="m 84.75,89.362182 v 5.999998 h 16 v -5.999998 z"
        style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none" />
     <path
        sodipodi:nodetypes="ccccc"
-       style="fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none"
-       d="m 85.75,90.362182 0,3.999998 14,0 0,-3.999998 -14,0 z"
+       style="fill:url(#backgroundLighter);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 85.75,90.362182 v 3.999998 h 14 v -3.999998 z"
        id="path2865"
        inkscape:connector-curvature="0" />
     <rect
@@ -887,8 +1159,8 @@
        y="83.362183"
        inkscape:label="#rect3043" />
     <path
-       style="opacity:0.98999999;fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-       d="m 251,62.862183 c -3.4,0 -6.15625,2.756247 -6.15625,6.15625 0,3.400006 2.75625,6.15625 6.15625,6.15625 0.053,0 0.10358,0.0013 0.15625,0 l 0,-2.9375 c -0.0626,0.0036 -0.12389,0.03125 -0.1875,0.03125 -1.76904,0 -3.21875,-1.418465 -3.21875,-3.1875 0,-1.769034 1.44971,-3.21875 3.21875,-3.21875 1.76903,0 3.1875,1.449716 3.1875,3.21875 0,0.09476 -0.025,0.186855 -0.0312,0.28125 l -2.75,0 4.125,5.9375 4.1562,-5.9375 -2.53125,0 c 0.006,-0.116523 0.0312,-0.226636 0.0312,-0.34375 0,-3.400003 -2.75624,-6.15625 -6.15625,-6.15625 z"
+       style="opacity:0.98999999;fill:url(#backgroundLighter);fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+       d="m 251,62.862183 c -3.4,0 -6.15625,2.756247 -6.15625,6.15625 0,3.400006 2.75625,6.15625 6.15625,6.15625 0.053,0 0.10358,0.0013 0.15625,0 v -2.9375 c -0.0626,0.0036 -0.12389,0.03125 -0.1875,0.03125 -1.76904,0 -3.21875,-1.418465 -3.21875,-3.1875 0,-1.769034 1.44971,-3.21875 3.21875,-3.21875 1.76903,0 3.1875,1.449716 3.1875,3.21875 0,0.09476 -0.025,0.186855 -0.0312,0.28125 h -2.75 l 4.125,5.9375 4.1562,-5.9375 H 257.125 c 0.006,-0.116523 0.0312,-0.226636 0.0312,-0.34375 0,-3.400003 -2.75624,-6.15625 -6.15625,-6.15625 z"
        id="refresh"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="sssccsssscccccss"
@@ -911,28 +1183,10 @@
        width="14.500001"
        id="forExport:pathUpArrow"
        style="fill:none;stroke:none" />
-    <path
-       id="path3878"
-       style="fill:#779cbd;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:1"
-       d="m 127.5,59.862183 15,0 0,15 -15,0 z"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       sodipodi:nodetypes="ccccc"
-       inkscape:connector-curvature="0"
-       d="m 127.5,59.862183 15,0 0,15 -15,0 z"
-       style="fill:#779cbd;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:1"
-       id="path3884" />
-    <path
-       sodipodi:nodetypes="ccccc"
-       inkscape:connector-curvature="0"
-       d="m 108.5,59.862183 15,0 0,15 -15,0 z"
-       style="fill:#787878;stroke:#3c3c3c;stroke-opacity:1;fill-opacity:1"
-       id="path3888" />
     <g
        id="forExport:pathListingList"
        inkscape:label="#g3271"
-       transform="translate(20,0)">
+       transform="translate(20)">
       <rect
          inkscape:label="#rect3931"
          transform="matrix(0,1,1,0,0,0)"
@@ -948,9 +1202,9 @@
          height="2"
          width="11"
          id="rect3246"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <rect
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect3248"
          width="11"
          height="2"
@@ -962,18 +1216,18 @@
          height="2"
          width="11"
          id="rect3250"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
        id="forExport:pathListingTree"
        inkscape:label="#g3279"
-       transform="translate(20,0)">
+       transform="translate(20)">
       <path
          sodipodi:nodetypes="ccccccccccccc"
          inkscape:connector-curvature="0"
          id="rect3268"
-         d="m 262,64.862183 5,0 0,4 3,0 0,4 3,0.03125 0,1.968753 -5,-3e-6 0,-4 -3,0 0,-4 -3,3e-6 z"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
+         d="m 262,64.862183 h 5 v 4 h 3 v 4 l 3,0.03125 v 1.968753 l -5,-3e-6 v -4 h -3 v -4 l -3,3e-6 z"
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
       <rect
          style="fill:none;stroke:none"
          id="rect3277"
@@ -987,39 +1241,30 @@
     <g
        id="forExport:timeline3"
        inkscape:label="#g3968"
-       transform="translate(40,0)">
+       transform="translate(40)">
       <g
          id="g3181">
-        <path
-           sodipodi:type="arc"
+        <circle
            style="fill:#3c3c3c;fill-opacity:1;stroke:none"
            id="path3407"
-           sodipodi:cx="260.25"
-           sodipodi:cy="13.25"
-           sodipodi:rx="1.25"
-           sodipodi:ry="1.25"
-           d="M 261.5,13.25 A 1.25,1.25 0 0 1 260.25,14.5 1.25,1.25 0 0 1 259,13.25 1.25,1.25 0 0 1 260.25,12 1.25,1.25 0 0 1 261.5,13.25 Z"
-           transform="matrix(1.6,0,0,1.6,-135.4,43.162183)" />
-        <path
+           transform="matrix(1.6,0,0,1.6,-135.4,43.162183)"
+           cx="260.25"
+           cy="13.25"
+           r="1.25" />
+        <circle
            transform="matrix(1.6,0,0,1.6,-135.4,49.162183)"
-           d="M 261.5,13.25 A 1.25,1.25 0 0 1 260.25,14.5 1.25,1.25 0 0 1 259,13.25 1.25,1.25 0 0 1 260.25,12 1.25,1.25 0 0 1 261.5,13.25 Z"
-           sodipodi:ry="1.25"
-           sodipodi:rx="1.25"
-           sodipodi:cy="13.25"
-           sodipodi:cx="260.25"
            id="path3169"
            style="fill:#3c3c3c;fill-opacity:1;stroke:none"
-           sodipodi:type="arc" />
-        <path
-           sodipodi:type="arc"
+           cx="260.25"
+           cy="13.25"
+           r="1.25" />
+        <circle
            style="fill:#3c3c3c;fill-opacity:1;stroke:none"
            id="path3171"
-           sodipodi:cx="260.25"
-           sodipodi:cy="13.25"
-           sodipodi:rx="1.25"
-           sodipodi:ry="1.25"
-           d="M 261.5,13.25 A 1.25,1.25 0 0 1 260.25,14.5 1.25,1.25 0 0 1 259,13.25 1.25,1.25 0 0 1 260.25,12 1.25,1.25 0 0 1 261.5,13.25 Z"
-           transform="matrix(1.6,0,0,1.6,-135.4,55.162183)" />
+           transform="matrix(1.6,0,0,1.6,-135.4,55.162183)"
+           cx="260.25"
+           cy="13.25"
+           r="1.25" />
       </g>
       <rect
          y="61.362183"
@@ -1032,30 +1277,24 @@
     <g
        id="forExport:timeline2"
        inkscape:label="#g3975"
-       transform="translate(40,0)">
+       transform="translate(40)">
       <g
          transform="translate(0,3)"
          id="g3177">
-        <path
+        <circle
            transform="matrix(1.6,0,0,1.6,-129.4,43.162183)"
-           d="M 261.5,13.25 A 1.25,1.25 0 0 1 260.25,14.5 1.25,1.25 0 0 1 259,13.25 1.25,1.25 0 0 1 260.25,12 1.25,1.25 0 0 1 261.5,13.25 Z"
-           sodipodi:ry="1.25"
-           sodipodi:rx="1.25"
-           sodipodi:cy="13.25"
-           sodipodi:cx="260.25"
            id="path3173"
            style="fill:#3c3c3c;fill-opacity:1;stroke:none"
-           sodipodi:type="arc" />
-        <path
-           sodipodi:type="arc"
+           cx="260.25"
+           cy="13.25"
+           r="1.25" />
+        <circle
            style="fill:#3c3c3c;fill-opacity:1;stroke:none"
            id="path3175"
-           sodipodi:cx="260.25"
-           sodipodi:cy="13.25"
-           sodipodi:rx="1.25"
-           sodipodi:ry="1.25"
-           d="M 261.5,13.25 A 1.25,1.25 0 0 1 260.25,14.5 1.25,1.25 0 0 1 259,13.25 1.25,1.25 0 0 1 260.25,12 1.25,1.25 0 0 1 261.5,13.25 Z"
-           transform="matrix(1.6,0,0,1.6,-129.4,49.162183)" />
+           transform="matrix(1.6,0,0,1.6,-129.4,49.162183)"
+           cx="260.25"
+           cy="13.25"
+           r="1.25" />
       </g>
       <rect
          style="fill:none;stroke:none"
@@ -1067,17 +1306,14 @@
     </g>
     <g
        id="forExport:timeline1"
-       transform="translate(40,0)">
-      <path
+       transform="translate(40)">
+      <circle
          transform="matrix(1.6,0,0,1.6,-123.4,49.162183)"
-         d="M 261.5,13.25 A 1.25,1.25 0 0 1 260.25,14.5 1.25,1.25 0 0 1 259,13.25 1.25,1.25 0 0 1 260.25,12 1.25,1.25 0 0 1 261.5,13.25 Z"
-         sodipodi:ry="1.25"
-         sodipodi:rx="1.25"
-         sodipodi:cy="13.25"
-         sodipodi:cx="260.25"
          id="path3188"
          style="fill:#3c3c3c;fill-opacity:1;stroke:none"
-         sodipodi:type="arc" />
+         cx="260.25"
+         cy="13.25"
+         r="1.25" />
       <rect
          y="61.362183"
          x="290.5"
@@ -1097,14 +1333,14 @@
          id="rect3127"
          style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-opacity:1" />
       <rect
-         style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-opacity:1"
+         style="fill:url(#backgroundLighter);fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-opacity:1"
          id="rect3897"
          width="4"
          height="14"
          x="336.5"
          y="62.862183" />
       <rect
-         style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-opacity:1"
+         style="fill:url(#backgroundLighter);fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-opacity:1"
          id="rect3211"
          width="4"
          height="14"
@@ -1112,20 +1348,20 @@
          y="62.862183" />
     </g>
     <path
-       style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-opacity:1"
-       d="m 355.5,62.987183 0,4.875 2.5,2.125 -2.5,2.125 0,4.875 10.5,-7 z"
+       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-opacity:1"
+       d="m 355.5,62.987183 v 4.875 l 2.5,2.125 -2.5,2.125 v 4.875 l 10.5,-7 z"
        id="rect3899"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccccc" />
     <path
-       style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-       d="m 374,62.924683 0,4.5625 -3.5,-2.8125 0,10.5 3.5,-2.8125 0,4.5625 3,0 0,-7 0,-7 -3,0 z"
+       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+       d="m 374,62.924683 v 4.5625 l -3.5,-2.8125 v 10.5 l 3.5,-2.8125 v 4.5625 h 3 v -7 -7 z"
        id="rect3920"
        inkscape:connector-curvature="0" />
     <path
        id="path3926"
-       d="m 348.5,62.799683 0,4.5625 3.5,-2.8125 0,10.5 -3.5,-2.8125 0,4.5625 -3,0 0,-7 0,-7 3,0 z"
-       style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+       d="m 348.5,62.799683 v 4.5625 l 3.5,-2.8125 v 10.5 l -3.5,-2.8125 v 4.5625 h -3 v -7 -7 z"
+       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
        inkscape:connector-curvature="0" />
     <rect
        inkscape:label="#rect3932"
@@ -1134,7 +1370,7 @@
        height="17"
        width="13"
        id="forExport:timelinePause"
-       style="fill:none;stroke:none;fill-opacity:1;stroke-opacity:1" />
+       style="fill:none;fill-opacity:1;stroke:none;stroke-opacity:1" />
     <rect
        style="fill:none;stroke:none"
        id="forExport:timelineStart"
@@ -1146,15 +1382,15 @@
     <path
        id="path3115"
        d="m 88.46875,110.54346 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
-       style="opacity:0.98999999;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="opacity:0.98999999;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="sssss" />
     <g
-       style="font-size:18.49083519px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;font-family:URW Palladio L;-inkscape-font-specification:URW Palladio L Bold"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.49083519px;line-height:125%;font-family:'URW Palladio L';-inkscape-font-specification:'URW Palladio L Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none"
        id="g3117"
        transform="matrix(1.1174828,0,0,1.1174828,-111.63832,49.197893)">
       <path
-         d="m 178.71815,64.059798 c -0.5917,0.184908 -1.03548,0.258871 -1.8121,0.351325 -0.0555,0 -0.14793,0.01849 -0.27736,0.03698 l 0,0.66567 0.83209,0.05547 c 0.42528,0.03698 0.48076,0.2034 0.48076,1.294358 l 0,4.049493 c 0,0.998504 -0.0925,1.146432 -0.66567,1.183414 l -0.64718,0.03698 0,0.684161 2.38532,-0.05547 c 0.36981,0 1.25737,0.01849 2.49626,0.05547 l 0,-0.684161 -0.64718,-0.03698 c -0.57322,-0.03698 -0.66567,-0.18491 -0.66567,-1.183414 l 0,-6.749155 -0.18491,-0.110943 z m 0.29586,-4.75215 c -0.79511,0 -1.40531,0.591707 -1.40531,1.368322 0,0.776614 0.6102,1.405303 1.38682,1.405303 0.75812,0 1.38681,-0.628689 1.38681,-1.386812 0,-0.758124 -0.6102,-1.386813 -1.36832,-1.386813"
+         d="m 178.71815,64.059798 c -0.5917,0.184908 -1.03548,0.258871 -1.8121,0.351325 -0.0555,0 -0.14793,0.01849 -0.27736,0.03698 v 0.66567 l 0.83209,0.05547 c 0.42528,0.03698 0.48076,0.2034 0.48076,1.294358 v 4.049493 c 0,0.998504 -0.0925,1.146432 -0.66567,1.183414 l -0.64718,0.03698 v 0.684161 l 2.38532,-0.05547 c 0.36981,0 1.25737,0.01849 2.49626,0.05547 v -0.684161 l -0.64718,-0.03698 c -0.57322,-0.03698 -0.66567,-0.18491 -0.66567,-1.183414 v -6.749155 l -0.18491,-0.110943 z m 0.29586,-4.75215 c -0.79511,0 -1.40531,0.591707 -1.40531,1.368322 0,0.776614 0.6102,1.405303 1.38682,1.405303 0.75812,0 1.38681,-0.628689 1.38681,-1.386812 0,-0.758124 -0.6102,-1.386813 -1.36832,-1.386813"
          id="path3119"
          style="fill:#3c3c3c;fill-opacity:1;stroke:none"
          inkscape:connector-curvature="0"
@@ -1167,18 +1403,18 @@
        d="m 88.46875,110.54346 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
        id="path3121" />
     <path
-       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-       d="m 20.84375,110.86218 c -0.63482,0.0493 -1.23606,0.42206 -1.5625,0.96875 l -13,21.5 c -0.7268,1.20821 0.30879,3.03461 1.71875,3.03125 l 26,0 c 1.40997,0.003 2.44556,-1.82304 1.71875,-3.03125 l -13,-21.5 c -0.37983,-0.6363 -1.13625,-1.02711 -1.875,-0.96875 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 20.84375,110.86218 c -0.63482,0.0493 -1.23606,0.42206 -1.5625,0.96875 l -13,21.5 c -0.7268,1.20821 0.30879,3.03461 1.71875,3.03125 h 26 c 1.40997,0.003 2.44556,-1.82304 1.71875,-3.03125 l -13,-21.5 c -0.37983,-0.6363 -1.13625,-1.02711 -1.875,-0.96875 z"
        id="forExport:errorNotification"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccccccc"
        inkscape:label="#path3123" />
     <g
-       style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none"
        id="text3918"
        transform="translate(-26.8125,-0.624997)">
       <path
-         d="m 49.740965,129.21831 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,10e-6 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 -0.260292,0 z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105"
+         d="m 49.740965,129.21831 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,10e-6 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 H 49.74097 Z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105"
          style="fill:#3c3c3c;fill-opacity:1;stroke:none"
          id="path3896"
          inkscape:connector-curvature="0"
@@ -1186,32 +1422,32 @@
     </g>
     <g
        id="g3898"
-       style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none"
        transform="translate(-30.8125,-0.624997)">
       <path
          sodipodi:nodetypes="cccsccccccccscsc"
          inkscape:connector-curvature="0"
          id="path3900"
          style="fill:#3c3c3c;fill-opacity:1;stroke:none"
-         d="m 49.740965,129.21831 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,10e-6 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 -0.260292,0 z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105" />
+         d="m 49.740965,129.21831 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,10e-6 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 H 49.74097 Z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105" />
     </g>
     <path
        sodipodi:nodetypes="cccccccc"
        inkscape:connector-curvature="0"
        id="forExport:warningNotification"
-       d="m 55.84375,110.86218 c -0.63483,0.0493 -1.23606,0.42206 -1.5625,0.96875 l -13,21.5 c -0.72681,1.20821 0.30878,3.03461 1.71875,3.03125 l 26,0 c 1.40997,0.003 2.44556,-1.82304 1.71875,-3.03125 l -13,-21.5 c -0.37984,-0.6363 -1.13625,-1.02711 -1.875,-0.96875 z"
-       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#efc618;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 55.84375,110.86218 c -0.63483,0.0493 -1.23606,0.42206 -1.5625,0.96875 l -13,21.5 c -0.72681,1.20821 0.30878,3.03461 1.71875,3.03125 h 26 c 1.40997,0.003 2.44556,-1.82304 1.71875,-3.03125 l -13,-21.5 c -0.37984,-0.6363 -1.13625,-1.02711 -1.875,-0.96875 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#efc618;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
        inkscape:label="#path3902" />
     <g
        transform="translate(6,-0.999997)"
        id="g3904"
-       style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light">
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none">
       <path
          sodipodi:nodetypes="cccsccccccccscsc"
          inkscape:connector-curvature="0"
          id="path3906"
          style="fill:#3c3c3c;fill-opacity:1;stroke:none"
-         d="m 49.740965,129.21831 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,10e-6 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 -0.260292,0 z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105" />
+         d="m 49.740965,129.21831 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,10e-6 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 H 49.74097 Z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105" />
     </g>
     <path
        id="forExport:infoNotification"
@@ -1223,7 +1459,7 @@
     <path
        sodipodi:nodetypes="sssss"
        inkscape:connector-curvature="0"
-       style="opacity:0.98999999000000005;fill:#69ffa5;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.99215686000000003;stroke-dasharray:none"
+       style="opacity:0.98999999;fill:#69ffa5;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
        d="m 120.46875,110.54346 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
        id="forExport:debugNotification"
        inkscape:label="#path3910" />
@@ -1263,7 +1499,7 @@
     <path
        sodipodi:nodetypes="sssss"
        inkscape:connector-curvature="0"
-       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+       style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        d="m 225,82.862187 c -4.97056,0 -9,4.029437 -9,9 0,4.970563 4.02944,8.999993 9,8.999993 4.97056,0 9,-4.02943 9,-8.999993 0,-4.970563 -4.02944,-9 -9,-9 z"
        id="forExport:classVectorParameterHandle"
        inkscape:label="#path3135" />
@@ -1289,8 +1525,8 @@
        x="220.00002"
        y="94.36219" />
     <path
-       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-       d="m 116.78197,83.264694 c -0.14255,0.01371 -0.31629,0.02644 -0.49895,0.07128 -2.92242,0.717452 1.03171,2.639709 -1.28302,4.526209 -2.31472,1.886499 -3.52713,-2.254231 -4.77568,0.427673 -1.24856,2.681903 2.71498,0.867296 2.77987,3.81342 0.0649,2.946123 -3.96717,1.257871 -2.60167,3.884698 1.36549,2.62683 2.38004,-1.537779 4.77568,0.249476 2.39564,1.787256 -1.45445,3.86123 1.49686,4.45493 2.95131,0.59369 0.24948,-2.775213 3.17191,-3.492665 2.92242,-0.717452 2.17584,3.490265 4.49057,1.603779 2.31472,-1.886504 -2.06827,-1.915588 -0.81971,-4.597492 1.24855,-2.681903 4.16343,0.522642 4.09853,-2.423481 -0.0649,-2.946124 -2.83995,0.381542 -4.20545,-2.245285 -1.3655,-2.626827 3.00151,-2.845871 0.60587,-4.633127 -2.39564,-1.787255 -1.43234,2.411308 -4.38365,1.817612 -2.76685,-0.55659 -0.71276,-3.662656 -2.85116,-3.457026 z m 1.7107,7.341724 c 0.7931,0 1.42557,0.649927 1.42557,1.425578 0,0.775666 -0.63247,1.389938 -1.42557,1.389938 -0.7931,0 -1.46122,-0.614272 -1.46122,-1.389938 0,-0.775651 0.66812,-1.425578 1.46122,-1.425578 z"
+       style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+       d="m 116.78197,83.264694 c -0.14255,0.01371 -0.31629,0.02644 -0.49895,0.07128 -2.92242,0.717452 1.03171,2.639709 -1.28302,4.526209 -2.31472,1.886499 -3.52713,-2.254231 -4.77568,0.427673 -1.24856,2.681903 2.71498,0.867296 2.77987,3.81342 0.0649,2.946123 -3.96717,1.257871 -2.60167,3.884698 1.36549,2.62683 2.38004,-1.537779 4.77568,0.249476 2.39564,1.787256 -1.45445,3.86123 1.49686,4.45493 2.95131,0.59369 0.24948,-2.775213 3.17191,-3.492665 2.92242,-0.717452 2.17584,3.490265 4.49057,1.603779 2.31472,-1.886504 -2.06827,-1.915588 -0.81971,-4.597492 1.24855,-2.681903 4.16343,0.522642 4.09853,-2.423481 -0.0649,-2.946124 -2.83995,0.381542 -4.20545,-2.245285 -1.3655,-2.626827 3.00151,-2.845871 0.60587,-4.633127 -2.39564,-1.787255 -1.43234,2.411308 -4.38365,1.817612 -2.76685,-0.55659 -0.71276,-3.662656 -2.85116,-3.457027 z m 1.7107,7.341724 c 0.7931,0 1.42557,0.649927 1.42557,1.425578 0,0.775666 -0.63247,1.389938 -1.42557,1.389938 -0.7931,0 -1.46122,-0.614272 -1.46122,-1.389938 0,-0.775651 0.66812,-1.425578 1.46122,-1.425578 z"
        id="path3333"
        inkscape:connector-curvature="0" />
     <rect
@@ -1301,17 +1537,6 @@
        x="108.6044"
        y="82.233063"
        inkscape:label="#rect4103" />
-    <path
-       sodipodi:nodetypes="ccccc"
-       inkscape:connector-curvature="0"
-       d="m 167.5,59.862183 15,0 0,15 -15,0 z"
-       style="fill:#787878;fill-opacity:0;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:1"
-       id="path2984" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path2986"
-       d="m 170.19669,76.454588 c -0.43135,-0.109805 -0.69022,-0.361106 -1.31027,-1.271901 -0.65643,-0.964226 -1.33519,-1.836887 -2.02487,-2.603299 -0.52476,-0.583153 -0.91507,-1.161596 -1.00225,-1.48538 -0.191,-0.709291 0.39865,-1.562619 1.4473,-2.094536 0.47073,-0.238773 0.54816,-0.258015 1.03834,-0.258015 0.49709,0 0.56366,0.01721 1.082,0.280052 0.59482,0.301599 1.37342,0.965914 1.82292,1.555347 0.13651,0.178999 0.26603,0.325452 0.28783,0.325452 0.0218,0 0.16421,-0.274705 0.31648,-0.610464 0.33632,-0.741556 1.7286,-3.347638 2.31007,-4.32402 2.1563,-3.620682 4.53884,-6.626438 5.68071,-7.166624 0.42723,-0.202115 1.33862,-0.382904 2.38809,-0.473716 0.73272,-0.06338 0.81795,-0.05907 1.07584,0.05501 0.18422,0.0815 0.31819,0.197574 0.3914,0.339141 0.12782,0.247174 0.13951,0.679936 0.0244,0.901898 -0.0434,0.08357 -0.51977,0.601885 -1.0587,1.151771 -1.47567,1.505676 -2.29807,2.518125 -3.60446,4.437411 -1.74342,2.561359 -3.18888,5.206826 -4.45279,8.149473 -0.96967,2.257583 -0.98235,2.283931 -1.23312,2.561495 -0.12543,0.138843 -0.3802,0.319294 -0.56616,0.401018 -0.29933,0.131547 -0.45644,0.15059 -1.37014,0.16603 -0.56763,0.0097 -1.12681,-0.0066 -1.24262,-0.0362 z"
-       style="fill:#666666;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-opacity:1" />
     <rect
        inkscape:label="#rect3931"
        transform="matrix(0,1,1,0,0,0)"
@@ -1330,18 +1555,13 @@
        y="186"
        transform="matrix(0,1,1,0,0,0)"
        inkscape:label="#rect3931" />
-    <path
-       id="path2992"
-       style="fill:#787878;fill-opacity:0;stroke:#3c3c3c;stroke-opacity:1"
-       d="m 188.5,59.862183 15,0 0,15 -15,0 z"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
     <g
        transform="translate(4.9651315e-6,-0.04534109)"
        id="forExport:search"
-       inkscape:label="#g3188">
+       inkscape:label="#g3188"
+       style="fill:url(#backgroundLighter)">
       <path
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="M 257.09375,44.90625 253.4375,41.25 c 0.67769,-1.087575 1.0625,-2.372568 1.0625,-3.75 -0.004,-3.89216 -3.13671,-7.03125 -7,-7.03125 -3.86599,0 -7,3.136366 -7,7.03125 0,3.894884 3.13401,7.0625 7,7.0625 1.43426,0 2.76489,-0.440152 3.875,-1.1875 L 255,47 m -7.5,-14 c 2.46825,0 4.46631,2.012609 4.46875,4.5 0,2.489132 -1.99877,4.5 -4.46875,4.5 -2.46998,0 -4.46875,-2.010868 -4.46875,-4.5 0,-2.489132 1.99877,-4.5 4.46875,-4.5 z"
          transform="translate(-4.9651315e-6,52.407524)"
          id="path4173"
@@ -1357,7 +1577,7 @@
          inkscape:label="#g3187"
          id="fsdfsd">
         <rect
-           style="fill:#9c1d17;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#9c1d17;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect4443"
            width="4"
            height="4.0000005"
@@ -1369,9 +1589,9 @@
            height="4.0000005"
            width="4"
            id="rect4445"
-           style="fill:#42ae45;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+           style="fill:#42ae45;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:#5066c5;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#5066c5;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect4447"
            width="4"
            height="4.0000005"
@@ -1379,31 +1599,31 @@
            y="86.862183" />
         <g
            id="text4957"
-           style="font-size:9.18084049px;font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;font-family:Futura;-inkscape-font-specification:Futura Medium">
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:9.18084049px;line-height:125%;font-family:Futura;-inkscape-font-specification:'Futura Medium';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none">
           <path
              inkscape:connector-curvature="0"
              id="path3205"
-             d="m 279.63832,87.243638 1.01312,0 0,4.366279 -1.01312,0 0,-0.457249 c -0.41542,0.388512 -0.8622,0.582768 -1.34037,0.582768 -0.60369,0 -1.10278,-0.218164 -1.49727,-0.654494 -0.3915,-0.445293 -0.58725,-1.001164 -0.58725,-1.667613 0,-0.654491 0.19575,-1.199902 0.58725,-1.636234 0.3915,-0.436325 0.88163,-0.654489 1.47037,-0.654493 0.50805,4e-6 0.96381,0.209203 1.36727,0.627596 l 0,-0.50656 m -2.39384,2.169691 c 0,0.418399 0.11207,0.759094 0.33622,1.022086 0.23011,0.265982 0.52,0.398972 0.86967,0.398972 0.37356,0 0.67541,-0.128507 0.90553,-0.385524 0.23011,-0.26598 0.34517,-0.603686 0.34518,-1.01312 -10e-6,-0.409429 -0.11507,-0.747136 -0.34518,-1.01312 -0.23012,-0.260001 -0.52898,-0.390003 -0.89657,-0.390006 -0.34667,3e-6 -0.63656,0.131499 -0.86967,0.394489 -0.23012,0.265984 -0.34518,0.594725 -0.34518,0.986223" />
+             d="m 279.63832,87.243638 h 1.01312 v 4.366279 h -1.01312 v -0.457249 c -0.41542,0.388512 -0.8622,0.582768 -1.34037,0.582768 -0.60369,0 -1.10278,-0.218164 -1.49727,-0.654494 -0.3915,-0.445293 -0.58725,-1.001164 -0.58725,-1.667613 0,-0.654491 0.19575,-1.199902 0.58725,-1.636234 0.3915,-0.436325 0.88163,-0.654489 1.47037,-0.654493 0.50805,4e-6 0.96381,0.209203 1.36727,0.627596 v -0.50656 m -2.39384,2.169691 c 0,0.418399 0.11207,0.759094 0.33622,1.022086 0.23011,0.265982 0.52,0.398972 0.86967,0.398972 0.37356,0 0.67541,-0.128507 0.90553,-0.385524 0.23011,-0.26598 0.34517,-0.603686 0.34518,-1.01312 -10e-6,-0.409429 -0.11507,-0.747136 -0.34518,-1.01312 -0.23012,-0.260001 -0.52898,-0.390003 -0.89657,-0.390006 -0.34667,3e-6 -0.63656,0.131499 -0.86967,0.394489 -0.23012,0.265984 -0.34518,0.594725 -0.34518,0.986223" />
           <path
              inkscape:connector-curvature="0"
              id="path3207"
-             d="m 282.9332,84.038413 0,3.711785 c 0.40345,-0.418393 0.8607,-0.627592 1.37175,-0.627596 0.58874,4e-6 1.07886,0.219663 1.47036,0.658976 0.3915,0.436332 0.58725,0.980249 0.58726,1.631751 -1e-5,0.672426 -0.19725,1.228297 -0.59174,1.667613 -0.3915,0.43633 -0.88611,0.654494 -1.48382,0.654494 -0.50506,0 -0.95634,-0.194256 -1.35381,-0.582768 l 0,0.457249 -1.00864,0 0,-7.571504 1.00864,0 m 2.39831,5.419744 c 0,-0.418395 -0.11357,-0.75909 -0.34069,-1.022086 -0.23012,-0.268966 -0.51852,-0.403451 -0.86519,-0.403454 -0.37058,3e-6 -0.67243,0.130005 -0.90553,0.390006 -0.23012,0.257019 -0.34518,0.591736 -0.34518,1.004154 0,0.424377 0.11357,0.763578 0.3407,1.017603 0.22713,0.260005 0.52598,0.390007 0.89656,0.390007 0.34966,0 0.63955,-0.130002 0.86967,-0.390007 0.23311,-0.262991 0.34966,-0.591732 0.34966,-0.986223" />
+             d="m 282.9332,84.038413 v 3.711785 c 0.40345,-0.418393 0.8607,-0.627592 1.37175,-0.627596 0.58874,4e-6 1.07886,0.219663 1.47036,0.658976 0.3915,0.436332 0.58725,0.980249 0.58726,1.631751 -1e-5,0.672426 -0.19725,1.228297 -0.59174,1.667613 -0.3915,0.43633 -0.88611,0.654494 -1.48382,0.654494 -0.50506,0 -0.95634,-0.194256 -1.35381,-0.582768 v 0.457249 h -1.00864 v -7.571504 h 1.00864 m 2.39831,5.419744 c 0,-0.418395 -0.11357,-0.75909 -0.34069,-1.022086 -0.23012,-0.268966 -0.51852,-0.403451 -0.86519,-0.403454 -0.37058,3e-6 -0.67243,0.130005 -0.90553,0.390006 -0.23012,0.257019 -0.34518,0.591736 -0.34518,1.004154 0,0.424377 0.11357,0.763578 0.3407,1.017603 0.22713,0.260005 0.52598,0.390007 0.89656,0.390007 0.34966,0 0.63955,-0.130002 0.86967,-0.390007 0.23311,-0.262991 0.34966,-0.591732 0.34966,-0.986223" />
           <path
              inkscape:connector-curvature="0"
              id="path3209"
-             d="m 290.82747,87.431917 0,1.340367 c -0.23013,-0.280921 -0.43634,-0.473683 -0.61863,-0.578286 -0.17932,-0.107584 -0.39001,-0.161378 -0.63208,-0.161381 -0.37955,3e-6 -0.69484,0.132994 -0.94588,0.398972 -0.25104,0.265984 -0.37656,0.599207 -0.37656,0.999671 0,0.409434 0.12104,0.745646 0.36311,1.008637 0.24506,0.262994 0.55736,0.39449 0.93691,0.39449 0.24207,0 0.45575,-0.0523 0.64105,-0.156899 0.17931,-0.10161 0.39,-0.298855 0.63208,-0.591734 l 0,1.331401 c -0.40944,0.212187 -0.81887,0.318281 -1.2283,0.318281 -0.67542,0 -1.24025,-0.218164 -1.69451,-0.654494 -0.45426,-0.439316 -0.68139,-0.984727 -0.68139,-1.636233 0,-0.651502 0.23012,-1.201396 0.69036,-1.649683 0.46023,-0.448279 1.02507,-0.67242 1.69451,-0.672424 0.43034,4e-6 0.83679,0.103109 1.21933,0.309315" />
+             d="m 290.82747,87.431917 v 1.340367 c -0.23013,-0.280921 -0.43634,-0.473683 -0.61863,-0.578286 -0.17932,-0.107584 -0.39001,-0.161378 -0.63208,-0.161381 -0.37955,3e-6 -0.69484,0.132994 -0.94588,0.398972 -0.25104,0.265984 -0.37656,0.599207 -0.37656,0.999671 0,0.409434 0.12104,0.745646 0.36311,1.008637 0.24506,0.262994 0.55736,0.39449 0.93691,0.39449 0.24207,0 0.45575,-0.0523 0.64105,-0.156899 0.17931,-0.10161 0.39,-0.298855 0.63208,-0.591734 v 1.331401 c -0.40944,0.212187 -0.81887,0.318281 -1.2283,0.318281 -0.67542,0 -1.24025,-0.218164 -1.69451,-0.654494 -0.45426,-0.439316 -0.68139,-0.984727 -0.68139,-1.636233 0,-0.651502 0.23012,-1.201396 0.69036,-1.649683 0.46023,-0.448279 1.02507,-0.67242 1.69451,-0.672424 0.43034,4e-6 0.83679,0.103109 1.21933,0.309315" />
         </g>
         <g
            id="text4957-2"
-           style="font-size:8.49427414px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;font-family:Arial Black;-inkscape-font-specification:'Arial Black, Heavy'">
+           style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:8.49427414px;line-height:125%;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, Heavy';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none">
           <path
              inkscape:connector-curvature="0"
              id="path3198"
-             d="m 271.48656,94.435275 0,6.184065 -1.7088,0 0,-4.052201 c -0.27651,0.210149 -0.54472,0.3802 -0.80464,0.510154 -0.25715,0.129961 -0.58066,0.254389 -0.97054,0.373284 l 0,-1.385297 c 0.57514,-0.185255 1.02169,-0.407842 1.33968,-0.667763 0.31798,-0.25991 0.56683,-0.580657 0.74657,-0.962242 l 1.39773,0" />
+             d="m 271.48656,94.435275 v 6.184065 h -1.7088 v -4.052201 c -0.27651,0.210149 -0.54472,0.3802 -0.80464,0.510154 -0.25715,0.129961 -0.58066,0.254389 -0.97054,0.373284 V 96.06528 c 0.57514,-0.185255 1.02169,-0.407842 1.33968,-0.667763 0.31798,-0.25991 0.56683,-0.580657 0.74657,-0.962242 h 1.39773" />
           <path
              inkscape:connector-curvature="0"
              id="path3200"
-             d="m 273.49815,98.92712 1.8042,0 0,1.69222 -1.8042,0 0,-1.69222" />
+             d="m 273.49815,98.92712 h 1.8042 v 1.69222 h -1.8042 v -1.69222" />
           <path
              inkscape:connector-curvature="0"
              id="path3202"
@@ -1415,13 +1635,13 @@
            height="3.9999995"
            width="4"
            id="rect5011"
-           style="fill:#b3b3b3;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+           style="fill:#b3b3b3;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <path
          sodipodi:nodetypes="ccccccccc"
          inkscape:connector-curvature="0"
          id="path4086"
-         d="m 287.5,153.36218 0,-14.5 10,11 -4,0 2,3.5 0,2.5 -2.5,0 -2.5,-5 z"
+         d="m 287.5,153.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 293 l -2.5,-5 z"
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
     </g>
     <g
@@ -1438,9 +1658,9 @@
            height="9.000001"
            width="5"
            id="rect4443-7"
-           style="fill:#9c1d17;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+           style="fill:#9c1d17;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:#42ae45;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#42ae45;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect4445-9"
            width="5"
            height="9"
@@ -1452,9 +1672,9 @@
            height="9"
            width="5"
            id="rect4447-3"
-           style="fill:#5066c5;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+           style="fill:#5066c5;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:#b3b3b3;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#b3b3b3;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect5011-8"
            width="5"
            height="9.000001"
@@ -1463,7 +1683,7 @@
       </g>
       <path
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         d="m 336.5,148.36218 0,-14.5 10,11 -4,0 2,3.5 0,2.5 -2.5,0 -2.5,-5 z"
+         d="m 336.5,148.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 342 l -2.5,-5 z"
          id="path4163"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccc" />
@@ -1479,13 +1699,13 @@
          id="objects">
         <path
            style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
-           d="m 392.52471,75.862183 5.99436,12.546318 -11.98873,0 z"
+           d="m 392.52471,75.862183 5.99436,12.546318 h -11.98873 z"
            id="rect4062"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="cccc" />
         <path
            sodipodi:type="arc"
-           style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path3260"
            sodipodi:cx="385"
            sodipodi:cy="40"
@@ -1498,13 +1718,13 @@
            sodipodi:open="true" />
         <path
            style="fill:#787878;fill-opacity:0.99215896;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           d="m 387,87.862183 6,2.5 0,9.999997 -6,-3.499997 z"
+           d="m 387,87.862183 6,2.5 v 9.999997 l -6,-3.499997 z"
            id="rect4065"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccc" />
         <path
            style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           d="M 392.93011,90.61057 401,88.862183 l 0,9 -8,2.499997 z"
+           d="M 392.93011,90.61057 401,88.862183 v 9 l -8,2.499997 z"
            id="rect4067"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccc" />
@@ -1519,11 +1739,11 @@
          sodipodi:nodetypes="ccccccccc"
          inkscape:connector-curvature="0"
          id="path4167"
-         d="m 374.5,154.36218 0,-14.5 10,11 -4,0 2,3.5 0,2.5 -2.5,0 -2.5,-5 z"
+         d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
       <path
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         d="m 374.5,154.36218 0,-14.5 10,11 -4,0 2,3.5 0,2.5 -2.5,0 -2.5,-5 z"
+         d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
          id="path3193"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccc" />
@@ -1559,7 +1779,7 @@
       </g>
       <path
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         d="m 400.5,152.36218 0,-14.5 10,11 -4,0 2,3.5 0,2.5 -2.5,0 -2.5,-5 z"
+         d="m 400.5,152.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 406 l -2.5,-5 z"
          id="path4171"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccc" />
@@ -1605,7 +1825,7 @@
          sodipodi:nodetypes="ccccccccc"
          inkscape:connector-curvature="0"
          id="path4175"
-         d="m 435.5,153.36218 0,-14.5 10,11 -4,0 2,3.5 0,2.5 -2.5,0 -2.5,-5 z"
+         d="m 435.5,153.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 441 l -2.5,-5 z"
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
     </g>
     <path
@@ -1621,41 +1841,45 @@
       <path
          id="path4263"
          d="m 247,128.36219 c -3.31371,0 -6,2.68629 -6,5.99999 0,3.31372 2.68629,6 6,6 3.31371,0 5.99999,-2.68628 5.99999,-6 0,-3.3137 -2.68628,-5.99999 -5.99999,-5.99999 z"
-         style="opacity:0.5;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="opacity:0.5;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="sssss" />
       <path
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         d="m 248.5,149.36218 0,-14.5 10,11 -4,0 2,3.5 0,2.5 -2.5,0 -2.5,-5 z"
+         d="m 248.5,149.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 254 l -2.5,-5 z"
          id="path4086-7"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccc" />
     </g>
     <path
-       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 514.5,93.5 0,-3.5 -5.5,5 5.5,5 0,-3.5 7,0 0,3.5 5.5,-5 -5.5,-5 0,3.5 -7,0 z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 514.5,93.5 V 90 l -5.5,5 5.5,5 v -3.5 h 7 v 3.5 l 5.5,-5 -5.5,-5 v 3.5 z"
        id="forExport:moveHorizontally"
        sodipodi:nodetypes="ccccccccccc"
        transform="translate(0,52.362183)"
-       inkscape:label="#path3088" />
+       inkscape:label="#path3088"
+       inkscape:connector-curvature="0" />
     <path
        sodipodi:nodetypes="ccccccccccc"
        id="forExport:moveVertically"
-       d="m 534,150.86218 -3.5,0 5,5.5 5,-5.5 -3.5,0 0,-7 3.5,0 -5,-5.5 -5,5.5 3.5,0 0,7 z"
-       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       inkscape:label="#path3093" />
+       d="m 534,150.86218 h -3.5 l 5,5.5 5,-5.5 H 537 v -7 h 3.5 l -5,-5.5 -5,5.5 h 3.5 z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:label="#path3093"
+       inkscape:connector-curvature="0" />
     <path
-       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 552.44974,150.81192 -2.47487,2.47488 7.42462,0.35355 -0.35355,-7.42462 -2.47488,2.47487 -4.94974,-4.94974 2.47487,-2.47488 -7.42462,-0.35355 0.35355,7.42462 2.47488,-2.47487 4.94974,4.94974 z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 552.44974,150.81192 -2.47487,2.47488 7.42462,0.35355 -0.35355,-7.42462 -2.47488,2.47487 -4.94974,-4.94974 2.47487,-2.47488 -7.42462,-0.35355 0.35355,7.42462 2.47488,-2.47487 z"
        id="forExport:moveDiagonallyDown"
        sodipodi:nodetypes="ccccccccccc"
-       inkscape:label="#path3095" />
+       inkscape:label="#path3095"
+       inkscape:connector-curvature="0" />
     <path
        sodipodi:nodetypes="ccccccccccc"
        id="forExport:moveDiagonallyUp"
-       d="m 566.22183,150.76167 2.47487,2.47488 -7.42462,0.35355 0.35355,-7.42462 2.47488,2.47487 4.94974,-4.94974 -2.47487,-2.47488 7.42462,-0.35355 -0.35355,7.42462 -2.47488,-2.47487 -4.94974,4.94974 z"
-       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       inkscape:label="#path3097" />
+       d="m 566.22183,150.76167 2.47487,2.47488 -7.42462,0.35355 0.35355,-7.42462 2.47488,2.47487 4.94974,-4.94974 -2.47487,-2.47488 7.42462,-0.35355 -0.35355,7.42462 -2.47488,-2.47487 z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:label="#path3097"
+       inkscape:connector-curvature="0" />
     <g
        transform="translate(-7,-1.9999996)"
        id="forExport:toggleOff"
@@ -1668,7 +1892,7 @@
          height="15"
          width="15"
          id="rect3875"
-         style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <rect
          ry="2.5"
          rx="2.0913782"
@@ -1677,7 +1901,7 @@
          height="15"
          width="8.5"
          id="rect3875-3"
-         style="opacity:0.98999999000000005;fill:#c7c7c7;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225007999999993;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="opacity:0.98999999;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
        id="forExport:toggleOn"
@@ -1686,7 +1910,7 @@
       <g
          id="g3938">
         <rect
-           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225007999999993;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3875-8"
            width="15"
            height="15"
@@ -1695,7 +1919,7 @@
            rx="2.5"
            ry="2.5" />
         <rect
-           style="opacity:0.98999999000000005;fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225007999999993;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="opacity:0.98999999;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3875-3-9"
            width="8.5"
            height="15"
@@ -1712,7 +1936,7 @@
       <g
          id="g3970">
         <rect
-           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225007999999993;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3875-8-9"
            width="15"
            height="15"
@@ -1721,7 +1945,7 @@
            rx="2.5"
            ry="2.5" />
         <rect
-           style="opacity:0.98999999;fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="opacity:0.98999999;fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3875-3-9-1"
            width="8.5"
            height="15"
@@ -1743,7 +1967,7 @@
          height="15"
          width="15"
          id="rect3875-1"
-         style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <rect
          ry="2.5"
          rx="2.0913782"
@@ -1752,7 +1976,7 @@
          height="15"
          width="8.5"
          id="rect3875-3-2"
-         style="opacity:0.98999999;fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="opacity:0.98999999;fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
        transform="translate(-7,18)"
@@ -1767,7 +1991,7 @@
          height="15"
          width="15"
          id="rect3875-86"
-         style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <rect
          ry="2.5"
          rx="2.0913782"
@@ -1776,7 +2000,7 @@
          height="15"
          width="8.5"
          id="rect3875-3-7"
-         style="opacity:0.98999999;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="opacity:0.98999999;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
        id="forExport:toggleOnDisabled"
@@ -1786,7 +2010,7 @@
       <g
          id="g3938-8">
         <rect
-           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225007999999993;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3875-8-3"
            width="15"
            height="15"
@@ -1795,7 +2019,7 @@
            rx="2.5"
            ry="2.5" />
         <rect
-           style="opacity:0.98999999;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="opacity:0.98999999;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3875-3-9-15"
            width="8.5"
            height="15"
@@ -1810,18 +2034,21 @@
        inkscape:label="#g3078">
       <path
          id="path4093"
-         d="m 70.21875,163.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 -8.5,-2.5625 z"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         d="m 70.21875,163.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 z"
+         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
       <path
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 62.36661,176.49782 -0.710223,-10.45042 8.522673,3.39892 -0.177555,11.69331 -7.634895,-4.64181 z"
+         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 62.36661,176.49782 -0.710223,-10.45042 8.522673,3.39892 -0.177555,11.69331 z"
          id="path4100"
-         sodipodi:nodetypes="ccccc" />
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
       <path
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 61.656387,166.0474 8.522673,3.39892 8.548039,-3.37356 -8.522674,-2.56187 -8.548038,2.53651 z"
+         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 61.656387,166.0474 8.522673,3.39892 8.548039,-3.37356 -8.522674,-2.56187 z"
          id="path4120"
-         sodipodi:nodetypes="ccccc" />
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
       <path
          sodipodi:type="arc"
          style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
@@ -1916,7 +2143,7 @@
     </g>
     <path
        sodipodi:type="star"
-       style="fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.79977703;stroke-linejoin:round;stroke-opacity:1"
+       style="fill:url(#backgroundLighter);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.79977703;stroke-linejoin:round;stroke-opacity:1"
        id="fsdf"
        sodipodi:sides="5"
        sodipodi:cx="298.875"
@@ -1944,11 +2171,11 @@
        inkscape:label="#path3910"
        id="forExport:success"
        d="m 30.013395,193.54296 c -13.176684,0 -23.8585234,10.68182 -23.8585234,23.8585 0,13.17673 10.6818394,23.85853 23.8585234,23.85853 13.176684,0 23.858505,-10.6818 23.858505,-23.85853 0,-13.17668 -10.681821,-23.8585 -23.858505,-23.8585 z"
-       style="opacity:0.98999999;fill:#69ffa5;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1.99999988;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.99215686;stroke-dasharray:none"
+       style="opacity:0.98999999;fill:#69ffa5;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1.99999988;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="sssss" />
     <path
-       style="fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 22.94827,230.49836 c -0.602413,-0.15335 -0.96396,-0.50431 -1.829931,-1.77635 -0.916793,-1.34665 -1.864739,-2.56542 -2.827945,-3.63579 -0.732895,-0.81445 -1.27801,-1.62231 -1.399758,-2.07451 -0.266756,-0.99059 0.556756,-2.18236 2.021333,-2.92524 0.657411,-0.33349 0.76557,-0.36035 1.45016,-0.36035 0.694243,0 0.787195,0.0241 1.511116,0.39112 0.830738,0.42122 1.918138,1.34901 2.545909,2.17222 0.190739,0.24999 0.371549,0.45454 0.402,0.45454 0.03052,0 0.229337,-0.38367 0.441995,-0.85259 0.469707,-1.03566 2.414157,-4.67535 3.226286,-6.03899 3.011496,-5.05669 6.33899,-9.25455 7.933719,-10.00898 0.596694,-0.28227 1.869556,-0.53478 3.335253,-0.66159 1.023317,-0.0884 1.142362,-0.0826 1.50253,0.0769 0.257287,0.1138 0.444386,0.27593 0.546624,0.47365 0.178548,0.34521 0.194803,0.94961 0.03402,1.2596 -0.06031,0.11676 -0.725926,0.84059 -1.478606,1.60857 -2.060941,2.10284 -3.209518,3.51685 -5.034042,6.19735 -2.434862,3.57722 -4.453601,7.27191 -6.218805,11.38165 -1.354248,3.15296 -1.371974,3.18975 -1.722212,3.5774 -0.175239,0.19391 -0.530975,0.44594 -0.79067,0.56008 -0.418073,0.18369 -0.63748,0.2103 -1.913577,0.23186 -0.792749,0.0129 -1.573693,-0.009 -1.735453,-0.0505 z"
        id="path3236"
        inkscape:connector-curvature="0" />
@@ -1957,29 +2184,29 @@
        transform="matrix(1.8253088,0,0,1.8253088,-39.283415,-210.61758)"
        inkscape:label="#g4022">
       <path
-         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.09570503;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-         d="m 68.96875,221.73718 c -0.63482,0.0493 -1.23606,0.42206 -1.5625,0.96875 l -13,21.5 c -0.7268,1.20821 0.30879,3.03461 1.71875,3.03125 l 26,0 c 1.40997,0.003 2.44556,-1.82304 1.71875,-3.03125 l -13,-21.5 c -0.37983,-0.6363 -1.13625,-1.02711 -1.875,-0.96875 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.09570503;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 68.96875,221.73718 c -0.63482,0.0493 -1.23606,0.42206 -1.5625,0.96875 l -13,21.5 c -0.7268,1.20821 0.30879,3.03461 1.71875,3.03125 h 26 c 1.40997,0.003 2.44556,-1.82304 1.71875,-3.03125 l -13,-21.5 c -0.37983,-0.6363 -1.13625,-1.02711 -1.875,-0.96875 z"
          id="path4012"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccccccc"
          inkscape:label="#path3123" />
       <g
-         style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none"
          id="g4014"
          transform="translate(21.3125,110.25)" />
       <g
          id="g4018"
-         style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.19141006;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.19141006;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          transform="translate(17.3125,110.72937)" />
       <g
          transform="translate(17.3125,110.72937)"
-         style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="g4029">
         <g
            id="g4034">
           <path
-             d="m 51.72693,127.91715 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,1e-5 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 -0.260292,0 z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105"
-             style="font-size:20.02241134999999872px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.19141005999999994;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+             d="m 51.72693,127.91715 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,1e-5 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 h -0.260292 z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105"
+             style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.19141006;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              id="path4020"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="cccsccccccccscsc" />
@@ -1987,8 +2214,8 @@
              sodipodi:nodetypes="cccsccccccccscsc"
              inkscape:connector-curvature="0"
              id="path4031"
-             style="fill:#f9f9f9;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-             d="m 51.72693,127.91715 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,1e-5 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 -0.260292,0 z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105" />
+             style="fill:#f9f9f9;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 51.72693,127.91715 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,1e-5 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 h -0.260292 z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105" />
         </g>
       </g>
     </g>
@@ -1998,7 +2225,7 @@
        inkscape:label="#g4113">
       <path
          sodipodi:type="arc"
-         style="fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:9.02981281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:9.02981281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path4111"
          sodipodi:cx="187.11813"
          sodipodi:cy="174.54121"
@@ -2016,42 +2243,42 @@
         <path
            style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
            inkscape:transform-center-x="1.2504885"
-           d="m 99.597353,169.77492 0,8.58228 -7.502966,-4.29114 z"
+           d="m 99.597353,169.77492 v 8.58228 l -7.502966,-4.29114 z"
            id="path4064"
            inkscape:connector-curvature="0" />
         <path
            transform="matrix(0.13558531,-0.23263436,0.23484065,0.13431151,26.907388,209.48587)"
            style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2.9274621;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
            inkscape:transform-center-x="-1.25049"
-           d="m 268.97293,130.27541 0,31.94918 -27.6688,-15.97459 6.9172,-3.99365 6.9172,-3.99365 6.9172,-3.99364 z"
+           d="m 268.97293,130.27541 v 31.94918 l -27.6688,-15.97459 6.9172,-3.99365 6.9172,-3.99365 6.9172,-3.99364 z"
            id="path4066"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccccc" />
         <path
            style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
            inkscape:transform-center-x="1.2504999"
-           d="m 86.467162,166.55658 7.502966,-4.29115 0,8.58229 -1.875741,-1.07279 -1.875742,-1.07278 -1.875741,-1.07279 z"
+           d="m 86.467162,166.55658 7.502966,-4.29115 v 8.58229 l -1.875741,-1.07279 -1.875742,-1.07278 -1.875741,-1.07279 z"
            id="path4068"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccccc" />
         <path
            style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
            inkscape:transform-center-x="-1.2505016"
-           d="m 84.591421,174.06607 0,-8.58228 7.502966,4.29114 -1.875741,1.07278 -1.875742,1.07279 -1.875742,1.07279 z"
+           d="m 84.591421,174.06607 v -8.58228 l 7.502966,4.29114 -1.875741,1.07278 -1.875742,1.07279 -1.875742,1.07279 z"
            id="path4070"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccccc" />
         <path
            style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
            inkscape:transform-center-x="1.2504858"
-           d="m 90.218646,179.42999 -7.502966,-4.29114 7.502966,-4.29114 0,2.14557 0,2.14557 0,2.14557 z"
+           d="m 90.218646,179.42999 -7.502966,-4.29114 7.502966,-4.29114 v 2.14557 2.14557 2.14557 z"
            id="path4072"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccccc" />
         <path
            style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
            inkscape:transform-center-x="-1.2504877"
-           d="m 97.721612,177.28442 -7.502966,4.29114 0,-8.58228 1.875741,1.07278 1.875742,1.07279 1.875741,1.07278 z"
+           d="m 97.721612,177.28442 -7.502966,4.29114 v -8.58228 l 1.875741,1.07278 1.875742,1.07279 1.875741,1.07278 z"
            id="path4074"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccccc" />
@@ -2067,7 +2294,7 @@
          sodipodi:cy="174.54121"
          sodipodi:cx="187.11813"
          id="path4105"
-         style="fill:none;stroke:#3c3c3c;stroke-width:3.68261814;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:none;stroke:#3c3c3c;stroke-width:3.68261814;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:type="arc" />
     </g>
     <g
@@ -2075,7 +2302,7 @@
        inkscape:label="#g4093">
       <path
          style="fill:#565656;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
-         d="m 204.5,182.86218 0,19 -19,0 z"
+         d="m 204.5,182.86218 v 19 h -19 z"
          id="path4073"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccc" />
@@ -2084,10 +2311,10 @@
         <g
            id="g4052"
            transform="matrix(1.1875,0,0,1.1875007,-37.15625,-35.474284)"
-           style="fill:#787878;fill-opacity:1;stroke:#424242;stroke-width:0.84210503;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none">
+           style="fill:#787878;fill-opacity:1;stroke:#424242;stroke-width:0.84210503;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
           <path
-             style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.84210503;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-             d="m 203.5,183.86218 0,15.99999 -16,0 c 9.30458,-2.50716 13.64016,-5.83089 16,-15.99999 z"
+             style="fill:url(#backgroundLighter);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.84210503;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 203.5,183.86218 v 15.99999 h -16 c 9.30458,-2.50716 13.64016,-5.83089 16,-15.99999 z"
              id="path4041"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="cccc" />
@@ -2099,7 +2326,7 @@
        inkscape:label="#g4172"
        transform="matrix(1.1456995,0,0,1.1456995,-19.856318,-25.721737)">
       <path
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 100.24995,172.89343 7.75005,3.71875 0.71875,-10.53125 -8.5,-2.5625 z"
          id="path3304"
          inkscape:connector-curvature="0"
@@ -2108,34 +2335,34 @@
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
          d="m 92.375,176.48718 7.87495,-3.59375 -0.0312,-9.375 -8.5625,2.53125 z"
-         style="fill:#595959;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#595959;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path3309" />
       <path
          transform="translate(0,52.362183)"
          inkscape:connector-curvature="0"
          id="path4168"
          d="m 92.375,124.125 7.625,4.65625 8,-4.53125 -7.75005,-3.71875 z"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          inkscape:connector-curvature="0"
          id="path3284"
-         d="m 100.20696,167.44141 -4.835088,1.42936 0.405865,5.89387 4.305703,2.6293 4.51746,-2.55872 0.40586,-5.94681 -4.7998,-1.447 z"
-         style="fill:#595959;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         d="m 100.20696,167.44141 -4.835088,1.42936 0.405865,5.89387 4.305703,2.6293 4.51746,-2.55872 0.40586,-5.94681 z"
+         style="fill:#595959;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          inkscape:connector-curvature="0"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 95.773,174.77064 -0.401051,-5.90116 4.812601,1.91931 -0.10026,6.603 -4.31129,-2.62115 z"
+         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 95.773,174.77064 -0.401051,-5.90116 4.812601,1.91931 -0.10026,6.603 z"
          id="path3286"
          sodipodi:nodetypes="ccccc" />
       <path
          inkscape:connector-curvature="0"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 95.371949,168.86948 4.812601,1.91931 4.82693,-1.90499 -4.8126,-1.44664 -4.826931,1.43232 z"
+         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 95.371949,168.86948 4.812601,1.91931 4.82693,-1.90499 -4.8126,-1.44664 z"
          id="path3288"
          sodipodi:nodetypes="ccccc" />
       <path
-         style="fill:none;stroke:#3c3c3c;stroke-width:0.87282926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 100.21875,163.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 -8.5,-2.5625 z"
+         style="fill:none;stroke:#3c3c3c;stroke-width:0.87282926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 100.21875,163.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 z"
          id="path3246"
          inkscape:connector-curvature="0" />
     </g>
@@ -2154,7 +2381,7 @@
          sodipodi:cy="174.54121"
          sodipodi:cx="187.11813"
          id="path3268"
-         style="fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:9.02981281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:9.02981281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:type="arc" />
       <g
          id="g3270"
@@ -2163,49 +2390,49 @@
         <path
            inkscape:connector-curvature="0"
            id="path3272"
-           d="m 99.597353,169.77492 0,8.58228 -7.502966,-4.29114 z"
+           d="m 99.597353,169.77492 v 8.58228 l -7.502966,-4.29114 z"
            inkscape:transform-center-x="1.2504885"
-           style="fill:#c6c6c6;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391000000002;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+           style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
         <path
            sodipodi:nodetypes="ccccccc"
            inkscape:connector-curvature="0"
            id="path3274"
-           d="m 268.97293,130.27541 0,31.94918 -27.6688,-15.97459 6.9172,-3.99365 6.9172,-3.99365 6.9172,-3.99364 z"
+           d="m 268.97293,130.27541 v 31.94918 l -27.6688,-15.97459 6.9172,-3.99365 6.9172,-3.99365 6.9172,-3.99364 z"
            inkscape:transform-center-x="-1.25049"
-           style="fill:#c6c6c6;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2.92746210000000007;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+           style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2.9274621;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
            transform="matrix(0.13558531,-0.23263436,0.23484065,0.13431151,26.907388,209.48587)" />
         <path
            sodipodi:nodetypes="ccccccc"
            inkscape:connector-curvature="0"
            id="path3276"
-           d="m 86.467162,166.55658 7.502966,-4.29115 0,8.58229 -1.875741,-1.07279 -1.875742,-1.07278 -1.875741,-1.07279 z"
+           d="m 86.467162,166.55658 7.502966,-4.29115 v 8.58229 l -1.875741,-1.07279 -1.875742,-1.07278 -1.875741,-1.07279 z"
            inkscape:transform-center-x="1.2504999"
-           style="fill:#c6c6c6;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391000000002;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+           style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
         <path
            sodipodi:nodetypes="ccccccc"
            inkscape:connector-curvature="0"
            id="path3278"
-           d="m 84.591421,174.06607 0,-8.58228 7.502966,4.29114 -1.875741,1.07278 -1.875742,1.07279 -1.875742,1.07279 z"
+           d="m 84.591421,174.06607 v -8.58228 l 7.502966,4.29114 -1.875741,1.07278 -1.875742,1.07279 -1.875742,1.07279 z"
            inkscape:transform-center-x="-1.2505016"
-           style="fill:#c6c6c6;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391000000002;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+           style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
         <path
            sodipodi:nodetypes="ccccccc"
            inkscape:connector-curvature="0"
            id="path3280"
-           d="m 90.218646,179.42999 -7.502966,-4.29114 7.502966,-4.29114 0,2.14557 0,2.14557 0,2.14557 z"
+           d="m 90.218646,179.42999 -7.502966,-4.29114 7.502966,-4.29114 v 2.14557 2.14557 2.14557 z"
            inkscape:transform-center-x="1.2504858"
-           style="fill:#c6c6c6;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391000000002;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+           style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
         <path
            sodipodi:nodetypes="ccccccc"
            inkscape:connector-curvature="0"
            id="path3282"
-           d="m 97.721612,177.28442 -7.502966,4.29114 0,-8.58228 1.875741,1.07278 1.875742,1.07279 1.875741,1.07278 z"
+           d="m 97.721612,177.28442 -7.502966,4.29114 v -8.58228 l 1.875741,1.07278 1.875742,1.07279 1.875741,1.07278 z"
            inkscape:transform-center-x="-1.2504877"
-           style="fill:#c6c6c6;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391000000002;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+           style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
       </g>
       <path
          sodipodi:type="arc"
-         style="fill:none;stroke:#3c3c3c;stroke-width:3.68261814;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:none;stroke:#3c3c3c;stroke-width:3.68261814;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path3285"
          sodipodi:cx="187.11813"
          sodipodi:cy="174.54121"
@@ -2225,11 +2452,11 @@
          sodipodi:nodetypes="cccc"
          inkscape:connector-curvature="0"
          id="path3251"
-         d="m 229.5,182.86218 0,19 -19,0 z"
-         style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+         d="m 229.5,182.86218 v 19 h -19 z"
+         style="fill:url(#backgroundLighter);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
       <path
          style="fill:#565656;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
-         d="m 229.5,182.86218 0,7 -7,0 z"
+         d="m 229.5,182.86218 v 7 h -7 z"
          id="path4071"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccc" />
@@ -2239,8 +2466,8 @@
        id="forExport:clippingOn"
        inkscape:label="#g4109">
       <path
-         style="fill:#c6c6c6;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
-         d="m 229.5,182.86218 0,19 -19,0 z"
+         style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         d="m 229.5,182.86218 v 19 h -19 z"
          id="path4112"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccc" />
@@ -2248,7 +2475,7 @@
          sodipodi:nodetypes="cccc"
          inkscape:connector-curvature="0"
          id="path4114"
-         d="m 229.5,182.86218 0,7 -7,0 z"
+         d="m 229.5,182.86218 v 7 h -7 z"
          style="fill:#565656;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
     </g>
     <g
@@ -2259,27 +2486,27 @@
          sodipodi:nodetypes="cccc"
          inkscape:connector-curvature="0"
          id="path4128"
-         d="m 204.5,182.86218 0,19 -19,0 z"
+         d="m 204.5,182.86218 v 19 h -19 z"
          style="fill:#565656;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
       <g
          id="g4130">
         <g
-           style="fill:#787878;fill-opacity:1;stroke:#424242;stroke-width:0.84210503;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:url(#foreground);fill-opacity:1;stroke:#424242;stroke-width:0.84210503;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            transform="matrix(1.1875,0,0,1.1875007,-37.15625,-35.474284)"
            id="g4132">
           <path
              sodipodi:nodetypes="cccc"
              inkscape:connector-curvature="0"
              id="path4134"
-             d="m 203.5,183.86218 0,15.99999 -16,0 c 9.30458,-2.50716 13.64016,-5.83089 16,-15.99999 z"
-             style="fill:#c6c6c6;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.84210503;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+             d="m 203.5,183.86218 v 15.99999 h -16 c 9.30458,-2.50716 13.64016,-5.83089 16,-15.99999 z"
+             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.84210503;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         </g>
       </g>
     </g>
     <path
        sodipodi:nodetypes="sssss"
        inkscape:connector-curvature="0"
-       style="opacity:0.98999999000000005;fill:#efc618;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1.99999988000000006;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.99215686000000003;stroke-dasharray:none"
+       style="opacity:0.98999999;fill:#efc618;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1.99999988;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
        d="m 30.013395,253.54296 c -13.176684,0 -23.8585234,10.68182 -23.8585234,23.8585 0,13.17673 10.6818394,23.85853 23.8585234,23.85853 13.176684,0 23.858505,-10.6818 23.858505,-23.85853 0,-13.17668 -10.681821,-23.8585 -23.858505,-23.8585 z"
        id="forExport:successWarning"
        inkscape:label="#path3910" />
@@ -2287,22 +2514,22 @@
        inkscape:connector-curvature="0"
        id="path3265"
        d="m 22.94827,290.49836 c -0.602413,-0.15335 -0.96396,-0.50431 -1.829931,-1.77635 -0.916793,-1.34665 -1.864739,-2.56542 -2.827945,-3.63579 -0.732895,-0.81445 -1.27801,-1.62231 -1.399758,-2.07451 -0.266756,-0.99059 0.556756,-2.18236 2.021333,-2.92524 0.657411,-0.33349 0.76557,-0.36035 1.45016,-0.36035 0.694243,0 0.787195,0.0241 1.511116,0.39112 0.830738,0.42122 1.918138,1.34901 2.545909,2.17222 0.190739,0.24999 0.371549,0.45454 0.402,0.45454 0.03052,0 0.229337,-0.38367 0.441995,-0.85259 0.469707,-1.03566 2.414157,-4.67535 3.226286,-6.03899 3.011496,-5.05669 6.33899,-9.25455 7.933719,-10.00898 0.596694,-0.28227 1.869556,-0.53478 3.335253,-0.66159 1.023317,-0.0884 1.142362,-0.0826 1.50253,0.0769 0.257287,0.1138 0.444386,0.27593 0.546624,0.47365 0.178548,0.34521 0.194803,0.94961 0.03402,1.2596 -0.06031,0.11676 -0.725926,0.84059 -1.478606,1.60857 -2.060941,2.10284 -3.209518,3.51685 -5.034042,6.19735 -2.434862,3.57722 -4.453601,7.27191 -6.218805,11.38165 -1.354248,3.15296 -1.371974,3.18975 -1.722212,3.5774 -0.175239,0.19391 -0.530975,0.44594 -0.79067,0.56008 -0.418073,0.18369 -0.63748,0.2103 -1.913577,0.23186 -0.792749,0.0129 -1.573693,-0.009 -1.735453,-0.0505 z"
-       style="fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       style="fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <g
        id="forExport:delete"
-       transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,-174.02106,231.8862)"
+       transform="rotate(-45,192.90087,326.0051)"
        inkscape:label="#g3273">
       <path
          inkscape:connector-curvature="0"
          style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
-         d="m 409.75,204.36218 0,5 -5,0 0,6 5,0 0,5 6,0 0,-5 5,0 0,-6 -5,0 0,-5 -6,0 z"
+         d="m 409.75,204.36218 v 5 h -5 v 6 h 5 v 5 h 6 v -5 h 5 v -6 h -5 v -5 z"
          id="path3269"
          sodipodi:nodetypes="ccccccccccccc"
          inkscape:label="#rect3638" />
       <path
          inkscape:connector-curvature="0"
          id="path3271"
-         d="m 410.75,205.36218 0,5 -5,0 0,4 5,0 0,5 4,0 0,-5 5,0 0,-4 -5,0 0,-5 -4,0 z"
+         d="m 410.75,205.36218 v 5 h -5 v 4 h 5 v 5 h 4 v -5 h 5 v -4 h -5 v -5 z"
          style="fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none"
          sodipodi:nodetypes="ccccccccccccc" />
     </g>
@@ -2313,7 +2540,7 @@
       <path
          sodipodi:nodetypes="ccccc"
          style="fill:#787878;fill-opacity:1;stroke:none"
-         d="m 35.42406,171.23218 9.272,5.662 9.728,-5.51 L 45,167.36218 z"
+         d="m 35.42406,171.23218 9.272,5.662 9.728,-5.51 L 45,167.36218 Z"
          id="path3275"
          inkscape:connector-curvature="0" />
       <path
@@ -2322,76 +2549,76 @@
          inkscape:connector-curvature="0"
          id="path3292"
          d="m 41,116.88378 8.895356,4.80676"
-         style="fill:#000000;fill-opacity:0;stroke:#4d4d4d;stroke-width:0.69;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#000000;fill-opacity:0;stroke:#4d4d4d;stroke-width:0.69;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cc"
          transform="translate(0,52.362183)"
          inkscape:connector-curvature="0"
          id="path3296"
          d="m 39.955806,121.28466 9.066291,-4.38952"
-         style="fill:#000000;fill-opacity:0;stroke:#4d4d4d;stroke-width:0.69;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#000000;fill-opacity:0;stroke:#4d4d4d;stroke-width:0.69;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          inkscape:connector-curvature="0"
          id="path4102"
-         d="m 35.42406,171.23218 9.272,5.662 9.728,-5.51 L 45,167.36218 z"
-         style="fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 35.42406,171.23218 9.272,5.662 9.728,-5.51 L 45,167.36218 Z"
+         style="fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:nodetypes="ccccc" />
     </g>
     <g
        id="forExport:sceneInspectorHistory"
        inkscape:label="#g4191"
-       transform="translate(160,0)">
+       transform="translate(160)">
       <path
          id="path5134"
          transform="translate(0,52.362183)"
-         d="m 342.96875,130.0625 -0.84375,1.40625 -2.96875,5 L 338.25,138 l 1.75,0 0.9375,0 c -0.0378,0.787 -0.0302,1.56573 0.28125,2.5 0.25149,0.75447 0.90647,1.59386 1.71875,2 0.81228,0.40614 1.64583,0.5 2.5625,0.5 l 11,0 c 0.19444,0 0.0886,-0.0143 0.125,0.0312 0.0364,0.0455 0.125,0.24375 0.125,0.46875 0,0.225 -0.0886,0.42324 -0.125,0.46875 -0.0364,0.0455 0.0694,0.0312 -0.125,0.0312 l -6,0 c -0.75833,0 -1.45648,0.0513 -2.1875,0.34375 -0.73102,0.29241 -1.43419,0.93088 -1.78125,1.625 C 345.83713,147.35709 346,148.5 346,150 l 4,0 c 0,-1.31282 0.10755,-1.8749 0.0937,-1.96875 0.11122,-0.018 0.11614,-0.0312 0.4063,-0.0312 l 6,0 c 1.30556,0 2.53641,-0.63926 3.25,-1.53125 0.71359,-0.89199 1,-1.94375 1,-2.96875 0,-1.025 -0.28641,-2.07676 -1,-2.96875 C 359.03641,139.63926 357.80556,139 356.5,139 l -11,0 c -0.36496,0 -0.36229,-0.0404 -0.46875,-0.0625 -8e-4,-0.0789 0.006,-0.69826 0,-0.96875 l 0.96875,0 1.78125,0 -0.9375,-1.53125 -3,-4.96875 -0.875,-1.40625 z"
-         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 342.96875,130.0625 -0.84375,1.40625 -2.96875,5 L 338.25,138 h 1.75 0.9375 c -0.0378,0.787 -0.0302,1.56573 0.28125,2.5 0.25149,0.75447 0.90647,1.59386 1.71875,2 0.81228,0.40614 1.64583,0.5 2.5625,0.5 h 11 c 0.19444,0 0.0886,-0.0143 0.125,0.0312 0.0364,0.0455 0.125,0.24375 0.125,0.46875 0,0.225 -0.0886,0.42324 -0.125,0.46875 -0.0364,0.0455 0.0694,0.0312 -0.125,0.0312 h -6 c -0.75833,0 -1.45648,0.0513 -2.1875,0.34375 -0.73102,0.29241 -1.43419,0.93088 -1.78125,1.625 C 345.83713,147.35709 346,148.5 346,150 h 4 c 0,-1.31282 0.10755,-1.8749 0.0937,-1.96875 0.11122,-0.018 0.11614,-0.0312 0.4063,-0.0312 h 6 c 1.30556,0 2.53641,-0.63926 3.25,-1.53125 0.71359,-0.89199 1,-1.94375 1,-2.96875 0,-1.025 -0.28641,-2.07676 -1,-2.96875 C 359.03641,139.63926 357.80556,139 356.5,139 h -11 c -0.36496,0 -0.36229,-0.0404 -0.46875,-0.0625 -8e-4,-0.0789 0.006,-0.69826 0,-0.96875 H 346 h 1.78125 l -0.9375,-1.53125 -3,-4.96875 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;marker:none;enable-background:accumulate"
          inkscape:connector-curvature="0" />
       <path
          id="path5120"
          transform="translate(0,52.362183)"
-         d="M 342.96875,132 340,137 l 2,0 c -0.0313,1.19278 -0.14123,2.20131 0.1875,3.1875 0.18825,0.56474 0.62511,1.10943 1.21875,1.40625 C 343.99989,141.89057 344.66667,142 345.5,142 l 11,0 c 0.47222,0 0.70054,0.14912 0.90625,0.40625 0.20571,0.25713 0.34375,0.66875 0.34375,1.09375 0,0.425 -0.13804,0.83662 -0.34375,1.09375 C 357.20054,144.85088 356.97222,145 356.5,145 l -6,0 c -0.69167,0 -1.27121,0.0335 -1.8125,0.25 -0.54129,0.21652 -1.02959,0.65294 -1.28125,1.15625 C 346.90294,147.41287 347,148.5 347,150 l 2,0 c 0,-1.5 0.0971,-2.44412 0.21875,-2.6875 0.0608,-0.12169 0.0569,-0.12277 0.21875,-0.1875 0.16184,-0.0647 0.50417,-0.125 1.0625,-0.125 l 6,0 c 1.02778,0 1.92446,-0.47588 2.46875,-1.15625 0.54429,-0.68037 0.78125,-1.51875 0.78125,-2.34375 0,-0.825 -0.23696,-1.66338 -0.78125,-2.34375 C 358.42446,140.47588 357.52778,140 356.5,140 l -11,0 c -0.66667,0 -1.06239,-0.10932 -1.21875,-0.1875 -0.15636,-0.0782 -0.157,-0.096 -0.21875,-0.28125 -0.10881,-0.32642 -0.0722,-1.29015 -0.0625,-2.5625 l 2,0 L 342.96875,132 z"
-         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#787878;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="M 342.96875,132 340,137 h 2 c -0.0313,1.19278 -0.14123,2.20131 0.1875,3.1875 0.18825,0.56474 0.62511,1.10943 1.21875,1.40625 C 343.99989,141.89057 344.66667,142 345.5,142 h 11 c 0.47222,0 0.70054,0.14912 0.90625,0.40625 0.20571,0.25713 0.34375,0.66875 0.34375,1.09375 0,0.425 -0.13804,0.83662 -0.34375,1.09375 C 357.20054,144.85088 356.97222,145 356.5,145 h -6 c -0.69167,0 -1.27121,0.0335 -1.8125,0.25 -0.54129,0.21652 -1.02959,0.65294 -1.28125,1.15625 C 346.90294,147.41287 347,148.5 347,150 h 2 c 0,-1.5 0.0971,-2.44412 0.21875,-2.6875 0.0608,-0.12169 0.0569,-0.12277 0.21875,-0.1875 0.16184,-0.0647 0.50417,-0.125 1.0625,-0.125 h 6 c 1.02778,0 1.92446,-0.47588 2.46875,-1.15625 0.54429,-0.68037 0.78125,-1.51875 0.78125,-2.34375 0,-0.825 -0.23696,-1.66338 -0.78125,-2.34375 C 358.42446,140.47588 357.52778,140 356.5,140 h -11 c -0.66667,0 -1.06239,-0.10932 -1.21875,-0.1875 -0.15636,-0.0782 -0.157,-0.096 -0.21875,-0.28125 -0.10881,-0.32642 -0.0722,-1.29015 -0.0625,-2.5625 h 2 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#787878;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          inkscape:connector-curvature="0" />
     </g>
     <g
        id="forExport:sceneInspectorInheritance"
        inkscape:label="#g4195"
-       transform="translate(160,0)">
+       transform="translate(160)">
       <path
          id="path4151"
          transform="translate(0,52.362183)"
-         d="m 373,130.21875 -1.53125,0.90625 -4.96875,3.03125 -1.40625,0.875 1.40625,0.84375 5,2.96875 1.53125,0.90625 0,-1.78125 0,-0.96875 0.96875,0 0.5,0 c 0.31236,0 0.29919,0.0492 0.375,0.125 0.0758,0.0758 0.125,0.0626 0.125,0.375 l 0,1 c 0,1.19766 0.39322,2.39322 1.25,3.25 0.85678,0.85678 2.05234,1.25 3.25,1.25 l 0.5,0 0.5,0 c 0.31274,0 0.29858,0.0487 0.375,0.125 0.0772,0.0771 0.125,0.0585 0.125,0.375 l 0,0.5 0,0.5 c 0,1.19766 0.39322,2.39322 1.25,3.25 0.85678,0.85678 2.05234,1.25 3.25,1.25 l 0.5,0 3,0 0,-4 -3,0 -0.5,0 c -0.31236,0 -0.29919,-0.0492 -0.375,-0.125 C 385.0492,144.7992 385,144.8124 385,144.5 l 0,-0.5 0,-0.5 c 0,-1.19869 -0.3924,-2.39376 -1.25,-3.25 -0.8573,-0.85594 -2.05307,-1.25 -3.25,-1.25 l -0.5,0 -0.5,0 c -0.31236,0 -0.29919,-0.0492 -0.375,-0.125 C 379.0492,138.7992 379,138.8124 379,138.5 l 0,-1 c 0,-1.19766 -0.39322,-2.39322 -1.25,-3.25 -0.85678,-0.85678 -2.05234,-1.25 -3.25,-1.25 l -0.5,0 -1,0 0,-1.03125 0,-1.75 z"
-         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 373,130.21875 -1.53125,0.90625 -4.96875,3.03125 -1.40625,0.875 1.40625,0.84375 5,2.96875 1.53125,0.90625 V 137.96875 137 H 374 h 0.5 c 0.31236,0 0.29919,0.0492 0.375,0.125 0.0758,0.0758 0.125,0.0626 0.125,0.375 v 1 c 0,1.19766 0.39322,2.39322 1.25,3.25 0.85678,0.85678 2.05234,1.25 3.25,1.25 h 0.5 0.5 c 0.31274,0 0.29858,0.0487 0.375,0.125 0.0772,0.0771 0.125,0.0585 0.125,0.375 v 0.5 0.5 c 0,1.19766 0.39322,2.39322 1.25,3.25 0.85678,0.85678 2.05234,1.25 3.25,1.25 h 0.5 3 v -4 h -3 -0.5 c -0.31236,0 -0.29919,-0.0492 -0.375,-0.125 C 385.0492,144.7992 385,144.8124 385,144.5 v -0.5 -0.5 c 0,-1.19869 -0.3924,-2.39376 -1.25,-3.25 -0.8573,-0.85594 -2.05307,-1.25 -3.25,-1.25 h -0.5 -0.5 c -0.31236,0 -0.29919,-0.0492 -0.375,-0.125 C 379.0492,138.7992 379,138.8124 379,138.5 v -1 c 0,-1.19766 -0.39322,-2.39322 -1.25,-3.25 -0.85678,-0.85678 -2.05234,-1.25 -3.25,-1.25 h -0.5 -1 v -1.03125 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          inkscape:connector-curvature="0" />
       <path
          transform="translate(0,52.362183)"
          id="path5122-9"
-         d="m 372,132 -4.96875,3.03125 5,2.96875 0,-2 0.46875,0 1.5,0 0.5,0 c 0.52778,0 0.85828,0.17078 1.09375,0.40625 C 375.82922,136.64172 376,136.97222 376,137.5 l 0,1 c 0,0.97222 0.32922,1.89172 0.96875,2.53125 C 377.60828,141.67078 378.52778,142 379.5,142 l 0.5,0 0.5,0 c 0.52901,0 0.85897,0.17185 1.09375,0.40625 C 381.82853,142.64065 382,142.96863 382,143.5 l 0,0.5 0,0.5 c 0,0.97222 0.32922,1.89172 0.96875,2.53125 C 383.60828,147.67078 384.52778,148 385.5,148 l 0.5,0 1.5,0 1.5,0 0,-2 -1.5,0 -1.5,0 -0.5,0 c -0.52778,0 -0.85828,-0.17078 -1.09375,-0.40625 C 384.17078,145.35828 384,145.02778 384,144.5 l 0,-0.5 0,-0.5 c 0,-0.97417 -0.32853,-1.89204 -0.96875,-2.53125 C 382.39103,140.32954 381.47099,140 380.5,140 l -0.5,0 -0.5,0 c -0.52778,0 -0.85828,-0.17078 -1.09375,-0.40625 C 378.17078,139.35828 378,139.02778 378,138.5 l 0,-1 c 0,-0.97222 -0.32922,-1.89172 -0.96875,-2.53125 C 376.39172,134.32922 375.47222,134 374.5,134 l -0.5,0 -1.5,0 -0.5,0 0,-2 z"
+         d="m 372,132 -4.96875,3.03125 5,2.96875 v -2 h 0.46875 1.5 0.5 c 0.52778,0 0.85828,0.17078 1.09375,0.40625 C 375.82922,136.64172 376,136.97222 376,137.5 v 1 c 0,0.97222 0.32922,1.89172 0.96875,2.53125 C 377.60828,141.67078 378.52778,142 379.5,142 h 0.5 0.5 c 0.52901,0 0.85897,0.17185 1.09375,0.40625 C 381.82853,142.64065 382,142.96863 382,143.5 v 0.5 0.5 c 0,0.97222 0.32922,1.89172 0.96875,2.53125 C 383.60828,147.67078 384.52778,148 385.5,148 h 0.5 1.5 1.5 v -2 h -1.5 -1.5 -0.5 c -0.52778,0 -0.85828,-0.17078 -1.09375,-0.40625 C 384.17078,145.35828 384,145.02778 384,144.5 v -0.5 -0.5 c 0,-0.97417 -0.32853,-1.89204 -0.96875,-2.53125 C 382.39103,140.32954 381.47099,140 380.5,140 h -0.5 -0.5 c -0.52778,0 -0.85828,-0.17078 -1.09375,-0.40625 C 378.17078,139.35828 378,139.02778 378,138.5 v -1 c 0,-0.97222 -0.32922,-1.89172 -0.96875,-2.53125 C 376.39172,134.32922 375.47222,134 374.5,134 H 374 372.5 372 Z"
          style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:none"
          inkscape:connector-curvature="0" />
     </g>
     <path
-       style="fill:#787878;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#787878;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 450,197.36218 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 2.67905,0 4.88204,2.11157 4.99775,4.89411 0.002,2.86731 -2.23633,5.10589 -4.99775,5.10589 z"
        id="path4053"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ssscs" />
     <path
-       style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 450.00225,217.46807 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 2.67905,0 4.88204,2.11157 4.99775,4.89411 0.002,2.86731 -2.23633,5.10589 -4.99775,5.10589 z"
        id="path4069"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ssscs" />
     <path
-       style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0"
-       d="M 444.56876,231.00921 455.5,225.86218 455.43124,228.3622 444.5,233.36218 z"
+       style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 444.56876,231.00921 455.5,225.86218 455.43124,228.3622 444.5,233.36218 Z"
        id="rect4086"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccc" />
     <path
-       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#787878;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-       d="m 449,192.36218 0,37.9913 2,-1.14905 0,-36.84225 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#787878;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+       d="m 449,192.36218 v 37.9913 l 2,-1.14905 v -36.84225 z"
        id="path4056"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccc" />
@@ -2399,14 +2626,14 @@
        sodipodi:nodetypes="ccccc"
        inkscape:connector-curvature="0"
        id="path4104"
-       d="M 444.56876,236.36218 455.5,231.21515 455.43124,233.71517 444.5,238.71516 z"
-       style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0" />
+       d="M 444.56876,236.36218 455.5,231.21515 455.43124,233.71517 444.5,238.71516 Z"
+       style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        sodipodi:nodetypes="ccccc"
        inkscape:connector-curvature="0"
        id="path4101"
-       d="m 449,252.28948 0,-16.89786 2,-0.75076 0,17.64862 z"
-       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#787878;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+       d="m 449,252.28948 v -16.89786 l 2,-0.75076 v 17.64862 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#787878;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
     <rect
        inkscape:label="#rect4071"
        y="201.36218"
@@ -2422,7 +2649,7 @@
          style="opacity:0.5"
          id="g4151">
         <rect
-           style="opacity:1;fill:#787878;fill-opacity:0.49803922000000000;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           style="opacity:1;fill:#787878;fill-opacity:0.49803922;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="rect3349"
            width="14"
            height="15"
@@ -2434,26 +2661,26 @@
            height="3.0000007"
            width="14"
            id="rect4124"
-           style="fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
         <path
            style="fill:none;stroke:#3c3c3c;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 462,156.86218 11,0"
+           d="m 462,156.86218 h 11"
            id="path4143"
            inkscape:connector-curvature="0" />
         <path
            inkscape:connector-curvature="0"
            id="path4145"
-           d="m 462,159.86218 11,0"
+           d="m 462,159.86218 h 11"
            style="fill:none;stroke:#3c3c3c;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
         <path
            style="fill:none;stroke:#3c3c3c;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 462,162.86218 11,0"
+           d="m 462,162.86218 h 11"
            id="path4147"
            inkscape:connector-curvature="0" />
       </g>
       <path
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         d="m 457.5,153.36218 0,-14.5 10,11 -4,0 2,3.5 0,2.5 -2.5,0 -2.5,-5 z"
+         d="m 457.5,153.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 463 l -2.5,-5 z"
          id="path3341"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccc" />
@@ -2467,22 +2694,19 @@
        x="440"
        y="262.36218" />
     <path
-       style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 450,277.36218 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 2.67905,0 4.88204,2.11157 4.99775,4.89411 0.002,2.86731 -2.23633,5.10589 -4.99775,5.10589 z"
        id="path3303"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ssscs" />
-    <path
+    <circle
        transform="matrix(0.375,0,0,0.375,409.25,176.61218)"
-       d="m 166,38 a 8,8 0 0 1 -8,8 8,8 0 0 1 -8,-8 8,8 0 0 1 8,-8 8,8 0 0 1 8,8 z"
-       sodipodi:ry="8"
-       sodipodi:rx="8"
-       sodipodi:cy="38"
-       sodipodi:cx="158"
        id="forExport:setMembershipDot"
-       style="fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.66666675;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       sodipodi:type="arc"
-       inkscape:label="#path3699" />
+       style="fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.66666675;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:label="#path3699"
+       cx="158"
+       cy="38"
+       r="8" />
     <g
        id="g4104">
       <rect
@@ -2495,7 +2719,7 @@
          style="opacity:0.5;fill:none;stroke:none" />
       <path
          sodipodi:type="star"
-         style="fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852140999999998;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:url(#linearGradient6233);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path2818-2"
          sodipodi:sides="3"
          sodipodi:cx="117.14286"
@@ -2516,19 +2740,19 @@
        style="fill:#779bbc;fill-opacity:1">
       <path
          style="fill:#557490;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.72103286;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 128.38062,163.8549 -5.53956,1.63762 0.465,6.7526 4.93304,3.01239 5.17566,-2.93152 0.46499,-6.81326 -5.49913,-1.65783 z"
+         d="m 128.38062,163.8549 -5.53956,1.63762 0.465,6.7526 4.93304,3.01239 5.17566,-2.93152 0.46499,-6.81326 z"
          id="path3284-0"
          inkscape:connector-curvature="0" />
       <path
          sodipodi:nodetypes="ccccc"
          id="path3286-5"
-         d="m 123.30064,172.252 -0.45949,-6.76096 5.5138,2.19895 -0.11487,7.56506 -4.93944,-3.00305 z"
+         d="m 123.30064,172.252 -0.45949,-6.76096 5.5138,2.19895 -0.11487,7.56506 z"
          style="fill:#779bbc;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.72103286;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          inkscape:connector-curvature="0" />
       <path
          sodipodi:nodetypes="ccccc"
          id="path3288-6"
-         d="m 122.84115,165.49104 5.5138,2.19895 5.53021,-2.18254 -5.5138,-1.65742 -5.53021,1.64101 z"
+         d="m 122.84115,165.49104 5.5138,2.19895 5.53021,-2.18254 -5.5138,-1.65742 z"
          style="fill:#89accd;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.72103286;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          inkscape:connector-curvature="0" />
     </g>
@@ -2542,36 +2766,36 @@
          height="25"
          width="25"
          id="rect4090"
-         style="opacity:0.35344830999999999;fill:none;fill-opacity:0.99607842999999996;fill-rule:evenodd;stroke:none" />
+         style="opacity:0.35344831;fill:none;fill-opacity:0.99607843;fill-rule:evenodd;stroke:none" />
       <g
          inkscape:label="#g4601"
          id="f">
         <path
            inkscape:connector-curvature="0"
            id="path4542"
-           d="m 150.21875,223.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 -8.5,-2.5625 z"
-           style="fill:#595959;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+           d="m 150.21875,223.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 z"
+           style="fill:#595959;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <path
            inkscape:connector-curvature="0"
-           style="fill:#787878;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           d="m 142.36661,236.49782 -0.71022,-10.45042 8.52267,3.39892 -0.17756,11.69331 -7.63489,-4.64181 z"
+           style="fill:#787878;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 142.36661,236.49782 -0.71022,-10.45042 8.52267,3.39892 -0.17756,11.69331 z"
            id="path4544"
            sodipodi:nodetypes="ccccc" />
         <path
            inkscape:connector-curvature="0"
-           style="fill:#787878;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           d="m 141.65639,226.0474 8.52267,3.39892 8.54804,-3.37356 -8.52267,-2.56187 -8.54804,2.53651 z"
+           style="fill:#787878;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 141.65639,226.0474 8.52267,3.39892 8.54804,-3.37356 -8.52267,-2.56187 z"
            id="path4546"
            sodipodi:nodetypes="ccccc" />
         <path
            sodipodi:nodetypes="ccccccccc"
            inkscape:connector-curvature="0"
            id="path3692"
-           d="m 154.55204,244.8176 0,-11.87736 8.12095,9.01041 -3.24836,0 1.62418,2.86695 0,2.04782 -2.03024,0 -2.03022,-4.09564 z"
-           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+           d="m 154.55204,244.8176 v -11.87736 l 8.12095,9.01041 h -3.24836 l 1.62418,2.86695 v 2.04782 h -2.03024 l -2.03022,-4.09564 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <path
-           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           d="m 154.55204,244.8176 0,-11.87736 8.12095,9.01041 -3.24836,0 1.62418,2.86695 0,2.04782 -2.03024,0 -2.03022,-4.09564 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 154.55204,244.8176 v -11.87736 l 8.12095,9.01041 h -3.24836 l 1.62418,2.86695 v 2.04782 h -2.03024 l -2.03022,-4.09564 z"
            id="path4761"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccccccc" />
@@ -2595,15 +2819,15 @@
            sodipodi:cy="40"
            sodipodi:cx="385"
            id="path4107"
-           style="opacity:0.35344831;fill:none;stroke:#3c3c3c;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="opacity:0.35344831;fill:none;stroke:#3c3c3c;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            sodipodi:type="arc" />
         <path
-           style="fill:#a7a7a7;fill-opacity:0.99607843;stroke:#3c3c3c;stroke-width:0.99999994000000003;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-           d="m 177.5,224.86218 c -5.52285,0 -10,4.47715 -10,10 0,0.69036 0.0855,1.34902 0.21875,2 l 11.78125,0 0,-11.8125 c -0.65057,-0.13304 -1.31013,-0.1875 -2,-0.1875 z"
+           style="fill:#a7a7a7;fill-opacity:0.99607843;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 177.5,224.86218 c -5.52285,0 -10,4.47715 -10,10 0,0.69036 0.0855,1.34902 0.21875,2 H 179.5 v -11.8125 c -0.65057,-0.13304 -1.31013,-0.1875 -2,-0.1875 z"
            id="rect4109"
            inkscape:connector-curvature="0" />
         <rect
-           style="fill:none;stroke:#bb2b2b;stroke-width:0.99999994000000003;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           style="fill:none;stroke:#bb2b2b;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="rect3319"
            width="14"
            height="14"
@@ -2620,17 +2844,17 @@
          style="opacity:0.35344831;fill:none;stroke:none" />
     </g>
     <g
-       style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none"
        id="g3328"
        transform="matrix(4.0808246,0,0,4.0808246,-116.25082,-136.58974)" />
     <g
        id="g3330"
-       style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.22524261;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.22524261;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        transform="matrix(4.0808246,0,0,4.0808246,-132.57411,-134.63351)" />
     <g
        id="forExport:gadgetError"
        inkscape:label="#g4105"
-       transform="translate(20,0)">
+       transform="translate(20)">
       <rect
          y="316.36218"
          x="9"
@@ -2642,15 +2866,15 @@
          transform="matrix(1.0229949,0,0,1.0572693,-4.4222807,-17.752239)"
          id="g3329">
         <path
-           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#313131;stroke-width:4.80773449;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-           d="m 76.999384,319.35707 c -2.590589,0.20118 -5.044144,1.72235 -6.376289,3.9533 l -53.05072,87.73773 c -2.965943,4.93049 1.260118,12.38371 7.013918,12.37 l 106.101437,0 c 5.75384,0.0122 9.9799,-7.43951 7.01392,-12.37 L 84.65093,323.31037 c -1.55002,-2.59663 -4.636837,-4.19146 -7.651546,-3.9533 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#313131;stroke-width:4.80773449;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="m 76.999384,319.35707 c -2.590589,0.20118 -5.044144,1.72235 -6.376289,3.9533 l -53.05072,87.73773 c -2.965943,4.93049 1.260118,12.38371 7.013918,12.37 H 130.68773 c 5.75384,0.0122 9.9799,-7.43951 7.01392,-12.37 L 84.65093,323.31037 c -1.55002,-2.59663 -4.636837,-4.19146 -7.651546,-3.9533 z"
            id="fsdffsd"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="cccccccc"
            inkscape:label="#path3123" />
         <path
-           d="M 77.28782,388.36112 76.634158,380.0269 C 76.416242,377.79358 75.871538,373.57201 75,367.36218 c -0.817091,-6.26427 -1.225631,-9.91388 -1.225623,-10.94889 -8e-6,-4.30323 1.361792,-6.45489 4.0854,-6.45493 2.723583,4e-5 4.085378,2.09722 4.085399,6.29153 -2.1e-5,0.43579 -0.02734,0.92606 -0.0817,1.47073 -0.05448,0.49031 -0.08174,0.89884 -0.0817,1.22563 l -3.431733,29.41487 -1.062206,0 z m -3.513422,10.29519 c -8e-6,-2.77806 1.389027,-4.16709 4.167105,-4.16709 2.778054,0 4.167089,1.33455 4.167106,4.00365 -1.7e-5,2.66915 -1.389052,4.0037 -4.167106,4.0037 -2.778078,0 -4.167113,-1.28007 -4.167105,-3.84026"
-           style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:#313131;stroke-width:5.76928091;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
+           d="M 77.28782,388.36112 76.634158,380.0269 C 76.416242,377.79358 75.871538,373.57201 75,367.36218 c -0.817091,-6.26427 -1.225631,-9.91388 -1.225623,-10.94889 -8e-6,-4.30323 1.361792,-6.45489 4.0854,-6.45493 2.723583,4e-5 4.085378,2.09722 4.085399,6.29153 -2.1e-5,0.43579 -0.02734,0.92606 -0.0817,1.47073 -0.05448,0.49031 -0.08174,0.89884 -0.0817,1.22563 l -3.431733,29.41487 h -1.062206 z m -3.513422,10.29519 c -8e-6,-2.77806 1.389027,-4.16709 4.167105,-4.16709 2.778054,0 4.167089,1.33455 4.167106,4.00365 -1.7e-5,2.66915 -1.389052,4.0037 -4.167106,4.0037 -2.778078,0 -4.167113,-1.28007 -4.167105,-3.84026"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:#313131;stroke-width:5.76928091;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path3336"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="cccsccccccccscsc" />
@@ -2658,8 +2882,8 @@
            sodipodi:nodetypes="cccsccccccccscsc"
            inkscape:connector-curvature="0"
            id="path3338"
-           style="font-size:20.02241135px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:none;font-family:Apple LiSung;-inkscape-font-specification:Apple LiSung Light"
-           d="M 77.28782,388.36112 76.634158,380.0269 C 76.416242,377.79358 75.871538,373.57201 75,367.36218 c -0.817091,-6.26427 -1.225631,-9.91388 -1.225623,-10.94889 -8e-6,-4.30323 1.361792,-6.45489 4.0854,-6.45493 2.723583,4e-5 4.085378,2.09722 4.085399,6.29153 -2.1e-5,0.43579 -0.02734,0.92606 -0.0817,1.47073 -0.05448,0.49031 -0.08174,0.89884 -0.0817,1.22563 l -3.431733,29.41487 -1.062206,0 z m -3.513422,10.29519 c -8e-6,-2.77806 1.389027,-4.16709 4.167105,-4.16709 2.778054,0 4.167089,1.33455 4.167106,4.00365 -1.7e-5,2.66915 -1.389052,4.0037 -4.167106,4.0037 -2.778078,0 -4.167113,-1.28007 -4.167105,-3.84026" />
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:none"
+           d="M 77.28782,388.36112 76.634158,380.0269 C 76.416242,377.79358 75.871538,373.57201 75,367.36218 c -0.817091,-6.26427 -1.225631,-9.91388 -1.225623,-10.94889 -8e-6,-4.30323 1.361792,-6.45489 4.0854,-6.45493 2.723583,4e-5 4.085378,2.09722 4.085399,6.29153 -2.1e-5,0.43579 -0.02734,0.92606 -0.0817,1.47073 -0.05448,0.49031 -0.08174,0.89884 -0.0817,1.22563 l -3.431733,29.41487 h -1.062206 z m -3.513422,10.29519 c -8e-6,-2.77806 1.389027,-4.16709 4.167105,-4.16709 2.778054,0 4.167089,1.33455 4.167106,4.00365 -1.7e-5,2.66915 -1.389052,4.0037 -4.167106,4.0037 -2.778078,0 -4.167113,-1.28007 -4.167105,-3.84026" />
       </g>
     </g>
     <path
@@ -2673,13 +2897,13 @@
        sodipodi:cy="174.54121"
        sodipodi:cx="187.11813"
        id="forExport:localDispatcherStatusRunning"
-       style="fill:#69ffa5;stroke:#3c3c3c;stroke-width:3.68261814000000021;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;fill-opacity:0.99215686"
+       style="fill:#69ffa5;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:3.68261814;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        sodipodi:type="arc"
        inkscape:label="#path3352" />
     <path
        inkscape:label="#path3352"
        sodipodi:type="arc"
-       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:3.68261814000000021;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:3.68261814;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="forExport:localDispatcherStatusKilled"
        sodipodi:cx="187.11813"
        sodipodi:cy="174.54121"
@@ -2701,12 +2925,12 @@
        sodipodi:cy="174.54121"
        sodipodi:cx="187.11813"
        id="forExport:localDispatcherStatusFailed"
-       style="fill:#bb2b2b;fill-opacity:1;stroke:#3c3c3c;stroke-width:3.68261814000000021;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#bb2b2b;fill-opacity:1;stroke:#3c3c3c;stroke-width:3.68261814;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        sodipodi:type="arc"
        inkscape:label="#path3352" />
     <path
        sodipodi:type="star"
-       style="fill:#69ffa5;fill-opacity:0.99215686;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.5598439;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#69ffa5;fill-opacity:0.99215686;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.5598439;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="forExport:valueChanged"
        sodipodi:sides="6"
        sodipodi:cx="298.875"
@@ -2732,18 +2956,19 @@
        sodipodi:cy="174.54121"
        sodipodi:cx="187.11813"
        id="forExport:shading"
-       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:3.92672118;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:3.9267211;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        sodipodi:type="arc"
        inkscape:label="#path3352" />
     <path
        style="fill:#aaaaaa;fill-opacity:1;stroke:none"
        d="m 17.444981,168.57203 c -2.092886,1.37871 -2.641656,4.33859 -3.535981,3.1401 -0.894324,-1.19849 0.405111,-3.97228 1.59811,-4.87074 1.192994,-0.89844 4.11797,-1.89376 5.012295,-0.69526 0.894325,1.19848 -1.122142,0.79291 -3.074424,2.4259 z"
        id="path3163"
-       sodipodi:nodetypes="csssc" />
+       sodipodi:nodetypes="csssc"
+       inkscape:connector-curvature="0" />
     <g
        id="forExport:addObjects"
        inkscape:label="#g4133"
-       transform="translate(140,0)">
+       transform="translate(140)">
       <g
          transform="translate(0,46.999993)"
          id="g3952">
@@ -2751,13 +2976,13 @@
            inkscape:label="#rect3638"
            sodipodi:nodetypes="ccccccccccccc"
            id="path3948"
-           d="m 430,177.36219 0,5 -5,0 0,5.99999 5,0 0,5 6,0 0,-5 5,0 0,-5.99999 -5,0 0,-5 -6,0 z"
+           d="m 430,177.36219 v 5 h -5 v 5.99999 h 5 v 5 h 6 v -5 h 5 v -5.99999 h -5 v -5 z"
            style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
            inkscape:connector-curvature="0" />
         <path
            sodipodi:nodetypes="ccccccccccccc"
            style="fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 431,178.36219 0,5 -5,0 0,3.99999 5,0 0,5 4,0 0,-5 5,0 0,-3.99999 -5,0 0,-5 -4,0 z"
+           d="m 431,178.36219 v 5 h -5 v 3.99999 h 5 v 5 h 4 v -5 h 5 v -3.99999 h -5 v -5 z"
            id="path3950"
            inkscape:connector-curvature="0" />
       </g>
@@ -2769,7 +2994,7 @@
            sodipodi:nodetypes="cccc"
            inkscape:connector-curvature="0"
            id="path3252"
-           d="m 392.52471,75.862183 5.99436,12.546318 -11.98873,0 z"
+           d="m 392.52471,75.862183 5.99436,12.546318 h -11.98873 z"
            style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
         <path
            sodipodi:open="true"
@@ -2782,19 +3007,19 @@
            sodipodi:cy="40"
            sodipodi:cx="385"
            id="path3254"
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            sodipodi:type="arc" />
         <path
            sodipodi:nodetypes="ccccc"
            inkscape:connector-curvature="0"
            id="path3256"
-           d="m 387,87.862183 6,2.5 0,9.999997 -6,-3.499997 z"
+           d="m 387,87.862183 6,2.5 v 9.999997 l -6,-3.499997 z"
            style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
         <path
            sodipodi:nodetypes="ccccc"
            inkscape:connector-curvature="0"
            id="path3258"
-           d="M 392.93011,90.61057 401,88.862183 l 0,9 -8,2.499997 z"
+           d="M 392.93011,90.61057 401,88.862183 v 9 l -8,2.499997 z"
            style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
         <path
            style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
@@ -2805,7 +3030,7 @@
       </g>
       <path
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         d="m 459.5,249.36218 0,-14.5 10,11 -4,0 2,3.5 0,2.5 -2.5,0 -2.5,-5 z"
+         d="m 459.5,249.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 465 l -2.5,-5 z"
          id="path3263"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccc" />
@@ -2813,13 +3038,13 @@
     <g
        id="forExport:removeObjects"
        inkscape:label="#g4146"
-       transform="translate(140,0)">
+       transform="translate(140)">
       <g
          transform="translate(340.25,180)"
          id="g3989">
         <path
            style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 84.75,89.362182 0,5.999998 16,0 0,-5.999998 -16,0 z"
+           d="m 84.75,89.362182 v 5.999998 h 16 v -5.999998 z"
            id="path3985"
            sodipodi:nodetypes="ccccc"
            inkscape:label="#rect3638"
@@ -2827,7 +3052,7 @@
         <path
            inkscape:connector-curvature="0"
            id="path3987"
-           d="m 85.75,90.362182 0,3.999998 14,0 0,-3.999998 -14,0 z"
+           d="m 85.75,90.362182 v 3.999998 h 14 v -3.999998 z"
            style="fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:none"
            sodipodi:nodetypes="ccccc" />
       </g>
@@ -2837,13 +3062,13 @@
          id="g4092">
         <path
            style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
-           d="m 392.52471,75.862183 5.99436,12.546318 -11.98873,0 z"
+           d="m 392.52471,75.862183 5.99436,12.546318 h -11.98873 z"
            id="path4094"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="cccc" />
         <path
            sodipodi:type="arc"
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path4096"
            sodipodi:cx="385"
            sodipodi:cy="40"
@@ -2856,13 +3081,13 @@
            sodipodi:open="true" />
         <path
            style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           d="m 387,87.862183 6,2.5 0,9.999997 -6,-3.499997 z"
+           d="m 387,87.862183 6,2.5 v 9.999997 l -6,-3.499997 z"
            id="path4099"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccc" />
         <path
            style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           d="M 392.93011,90.61057 401,88.862183 l 0,9 -8,2.499997 z"
+           d="M 392.93011,90.61057 401,88.862183 v 9 l -8,2.499997 z"
            id="path4103"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccc" />
@@ -2875,7 +3100,7 @@
       </g>
       <path
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         d="m 459.5,289.36218 0,-14.5 10,11 -4,0 2,3.5 0,2.5 -2.5,0 -2.5,-5 z"
+         d="m 459.5,289.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 465 l -2.5,-5 z"
          id="path4108"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccc" />
@@ -2883,7 +3108,7 @@
     <g
        id="forExport:replaceObjects"
        inkscape:label="#g4158"
-       transform="translate(140,0)">
+       transform="translate(140)">
       <g
          transform="translate(0,21.000001)"
          id="g4125">
@@ -2895,12 +3120,12 @@
              inkscape:label="#rect3638"
              sodipodi:nodetypes="ccccc"
              id="path4013"
-             d="m 84.75,89.362182 0,5.000001 16,0 0,-5.000001 -16,0 z"
+             d="m 84.75,89.362182 v 5.000001 h 16 v -5.000001 z"
              style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none" />
           <path
              sodipodi:nodetypes="ccccc"
              style="fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:none"
-             d="m 85.75,90.362182 0,3.000001 14,0 0,-3.000001 -14,0 z"
+             d="m 85.75,90.362182 v 3.000001 h 14 v -3.000001 z"
              id="path4015"
              inkscape:connector-curvature="0" />
         </g>
@@ -2909,7 +3134,7 @@
            id="g4017">
           <path
              style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
-             d="m 84.75,89.362182 0,5.000001 16,0 0,-5.000001 -16,0 z"
+             d="m 84.75,89.362182 v 5.000001 h 16 v -5.000001 z"
              id="path4019"
              sodipodi:nodetypes="ccccc"
              inkscape:label="#rect3638"
@@ -2917,7 +3142,7 @@
           <path
              inkscape:connector-curvature="0"
              id="path4021"
-             d="m 85.75,90.362182 0,3.000001 14,0 0,-3.000001 -14,0 z"
+             d="m 85.75,90.362182 v 3.000001 h 14 v -3.000001 z"
              style="fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:none"
              sodipodi:nodetypes="ccccc" />
         </g>
@@ -2930,7 +3155,7 @@
            sodipodi:nodetypes="cccc"
            inkscape:connector-curvature="0"
            id="path4113"
-           d="m 392.52471,75.862183 5.99436,12.546318 -11.98873,0 z"
+           d="m 392.52471,75.862183 5.99436,12.546318 h -11.98873 z"
            style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
         <path
            sodipodi:open="true"
@@ -2943,19 +3168,19 @@
            sodipodi:cy="40"
            sodipodi:cx="385"
            id="path4115"
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            sodipodi:type="arc" />
         <path
            sodipodi:nodetypes="ccccc"
            inkscape:connector-curvature="0"
            id="path4117"
-           d="m 387,87.862183 6,2.5 0,9.999997 -6,-3.499997 z"
+           d="m 387,87.862183 6,2.5 v 9.999997 l -6,-3.499997 z"
            style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
         <path
            sodipodi:nodetypes="ccccc"
            inkscape:connector-curvature="0"
            id="path4119"
-           d="M 392.93011,90.61057 401,88.862183 l 0,9 -8,2.499997 z"
+           d="M 392.93011,90.61057 401,88.862183 v 9 l -8,2.499997 z"
            style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
         <path
            style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
@@ -2968,18 +3193,18 @@
          sodipodi:nodetypes="ccccccccc"
          inkscape:connector-curvature="0"
          id="path4123"
-         d="m 459.5,329.36218 0,-14.5 10,11 -4,0 2,3.5 0,2.5 -2.5,0 -2.5,-5 z"
+         d="m 459.5,329.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 465 l -2.5,-5 z"
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
     </g>
     <path
        inkscape:connector-curvature="0"
-       style="fill:#787878;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686"
-       d="m 448,72.862183 -8.5,0 0,3 -7,-6 7,-6 0,3 8.5,0"
+       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686"
+       d="m 448,72.862183 h -8.5 v 3 l -7,-6 7,-6 v 3 h 8.5"
        id="gfsdf"
        sodipodi:nodetypes="ccccccs"
        inkscape:label="#rect2859" />
     <rect
-       style="opacity:0.50000000000000000;fill:none;fill-opacity:0.99215686000000003;stroke:none"
+       style="opacity:0.5;fill:none;fill-opacity:0.99215686;stroke:none"
        id="forExport:shuffleArrow"
        width="20"
        height="15"
@@ -2988,7 +3213,7 @@
        transform="translate(0,52.362183)"
        inkscape:label="#rect3197" />
     <rect
-       style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.00011265;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.00011265;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect3127-7"
        width="13.910246"
        height="13.999775"
@@ -3011,13 +3236,14 @@
          sodipodi:nodetypes="cccc"
          inkscape:connector-curvature="0"
          id="path3210"
-         d="m 217.52471,338.86218 5.99436,12.54632 -11.98873,0 z"
+         d="m 217.52471,338.86218 5.99436,12.54632 h -11.98873 z"
          style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="csssc"
          id="path5613"
          d="m 216.36359,344.37414 c -1.39098,2.80968 -1.3485,5.32706 -2.15932,4.74335 -0.82798,-0.59606 1.10884,-3.84476 2.01952,-5.77699 0.58434,-1.23982 0.70044,-1.64715 0.92344,-2.12839 0.86772,-1.87255 0.3054,0.52038 -0.78364,3.16203 z"
-         style="fill:#aaaaaa;fill-opacity:1;stroke:none" />
+         style="fill:#aaaaaa;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
       <path
          sodipodi:open="true"
          sodipodi:end="6.2821966"
@@ -3029,20 +3255,20 @@
          sodipodi:cy="40"
          sodipodi:cx="385"
          id="path3212"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:type="arc" />
       <path
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
          id="path3214"
-         d="m 212,350.86218 6,2.5 0,10 -6,-3.5 z"
+         d="m 212,350.86218 6,2.5 v 10 l -6,-3.5 z"
          style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
          id="path3216"
-         d="M 217.93011,353.61057 226,351.86218 l 0,9 -8,2.5 z"
-         style="fill:#6a6a6a;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994000000003;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+         d="M 217.93011,353.61057 226,351.86218 v 9 l -8,2.5 z"
+         style="fill:#6a6a6a;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
       <path
          style="fill:#8e8e8e;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
          d="m 212,350.86218 5.93008,2.74839 8.06992,-1.74839 -6.0625,-2.4375 z"
@@ -3060,19 +3286,20 @@
          sodipodi:cy="289.875"
          sodipodi:cx="211.625"
          id="path5609"
-         style="fill:#efc618;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.84720147;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#efc618;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.84720147;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:type="arc" />
       <path
          style="fill:#aaaaaa;fill-opacity:1;stroke:none"
          d="m 207.58234,349.71789 c -1.70348,1.12218 -2.15015,3.53134 -2.87807,2.55585 -0.72792,-0.9755 0.32974,-3.23319 1.30077,-3.96449 0.97102,-0.73127 3.35177,-1.5414 4.07969,-0.56589 0.72793,0.97548 -0.91335,0.64538 -2.50239,1.97453 z"
          id="path5611"
-         sodipodi:nodetypes="csssc" />
+         sodipodi:nodetypes="csssc"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        id="forExport:soloChannel-1"
        inkscape:label="#g4322">
       <rect
-         style="fill:#823631;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994000000003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#823631;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4860"
          width="6"
          height="18.969242"
@@ -3084,9 +3311,9 @@
          height="18.969244"
          width="6"
          id="rect4862"
-         style="fill:#449645;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#449645;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <rect
-         style="fill:#4a5ebd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036000000003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#4a5ebd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4864"
          width="6"
          height="18.969244"
@@ -3098,13 +3325,13 @@
          height="18.969242"
          width="6"
          id="rect4866"
-         style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
        id="forExport:soloChannel0"
        inkscape:label="#g4328">
       <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4254"
          width="6"
          height="18.995764"
@@ -3116,9 +3343,9 @@
          height="18.995764"
          width="6"
          id="rect4256"
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000036000000003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4258"
          width="6"
          height="18.995762"
@@ -3130,20 +3357,20 @@
          height="18.969242"
          width="6"
          id="rect4314"
-         style="fill:#823631;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994000000003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#823631;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
        id="forExport:soloChannel1"
        inkscape:label="#g4334">
       <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:0.99999987999999995;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4290"
          width="6"
          height="18.995762"
          x="290.5"
          y="232.86218" />
       <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000036000000003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4294"
          width="6"
          height="18.995764"
@@ -3155,14 +3382,14 @@
          height="18.995762"
          width="6"
          id="rect4296"
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <rect
          y="232.86218"
          x="296.5"
          height="18.969244"
          width="6"
          id="rect4316"
-         style="fill:#449645;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#449645;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
        id="forExport:soloChannel2"
@@ -3173,23 +3400,23 @@
          height="18.995762"
          width="6"
          id="rect4298"
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:0.99999987999999995;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4300"
          width="6"
          height="18.995764"
          x="296.5"
          y="257.86218" />
       <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4304"
          width="6"
          height="18.995762"
          x="308.5"
          y="257.86218" />
       <rect
-         style="fill:#4a5ebd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036000000003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#4a5ebd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4318"
          width="6"
          height="18.969244"
@@ -3200,7 +3427,7 @@
        id="forExport:soloChannel3"
        inkscape:label="#g4346">
       <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:0.99999987999999995;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4306"
          width="6"
          height="18.995762"
@@ -3212,9 +3439,9 @@
          height="18.995764"
          width="6"
          id="rect4308"
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000036000000003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4310"
          width="6"
          height="18.995764"
@@ -3226,7 +3453,7 @@
          height="18.969242"
          width="6"
          id="rect4320"
-         style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
        inkscape:label="#g4195"
@@ -3238,7 +3465,7 @@
          style="opacity:0.5"
          transform="translate(0,46)">
         <rect
-           style="fill:#9c1d17;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#9c1d17;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect4233"
            width="5"
            height="9.000001"
@@ -3250,9 +3477,9 @@
            height="9"
            width="5"
            id="rect4235"
-           style="fill:#42ae45;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+           style="fill:#42ae45;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:#5066c5;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#5066c5;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect4237"
            width="5"
            height="9"
@@ -3264,13 +3491,13 @@
            height="9.000001"
            width="5"
            id="rect4239"
-           style="fill:#b3b3b3;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+           style="fill:#b3b3b3;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <path
          sodipodi:nodetypes="ccccccccc"
          inkscape:connector-curvature="0"
          id="path4241"
-         d="m 336.5,148.36218 0,-14.5 10,11 -4,0 2,3.5 0,2.5 -2.5,0 -2.5,-5 z"
+         d="m 336.5,148.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 342 l -2.5,-5 z"
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
     </g>
     <g
@@ -3279,14 +3506,14 @@
       <path
          inkscape:connector-curvature="0"
          style="fill:#262626;fill-opacity:1;fill-rule:nonzero;stroke:none"
-         d="m 13.571445,466.36217 0,4.57145 -4.5714451,0 0,6.85716 4.5714451,0 0,4.57145 6.857168,0 0,-4.57145 4.571445,0 0,-6.85716 -4.571445,0 0,-4.57145 -6.857168,0 z"
+         d="m 13.571445,466.36217 v 4.57145 H 8.9999999 v 6.85716 h 4.5714451 v 4.57145 h 6.857168 v -4.57145 h 4.571445 v -6.85716 h -4.571445 v -4.57145 z"
          id="fsd"
          sodipodi:nodetypes="ccccccccccccc"
          inkscape:label="#rect3638" />
       <path
          inkscape:connector-curvature="0"
          id="path3257"
-         d="m 14.714307,467.50503 0,4.57145 -4.571446,0 0,4.57144 4.571446,0 0,4.57145 4.571445,0 0,-4.57145 4.571445,0 0,-4.57144 -4.571445,0 0,-4.57145 -4.571445,0 z"
+         d="m 14.714307,467.50503 v 4.57145 h -4.571446 v 4.57144 h 4.571446 v 4.57145 h 4.571445 v -4.57145 h 4.571445 v -4.57144 h -4.571445 v -4.57145 z"
          style="fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none"
          sodipodi:nodetypes="ccccccccccccc" />
     </g>
@@ -3305,13 +3532,13 @@
          inkscape:label="#rect3638"
          sodipodi:nodetypes="ccccccccccccc"
          id="path3262"
-         d="m 13.571445,466.36217 0,4.57145 -4.5714451,0 0,6.85716 4.5714451,0 0,4.57145 6.857168,0 0,-4.57145 4.571445,0 0,-6.85716 -4.571445,0 0,-4.57145 -6.857168,0 z"
+         d="m 13.571445,466.36217 v 4.57145 H 8.9999999 v 6.85716 h 4.5714451 v 4.57145 h 6.857168 v -4.57145 h 4.571445 v -6.85716 h -4.571445 v -4.57145 z"
          style="fill:#262626;fill-opacity:1;fill-rule:nonzero;stroke:none"
          inkscape:connector-curvature="0" />
       <path
          sodipodi:nodetypes="ccccccccccccc"
          style="fill:#779cbd;fill-opacity:1;fill-rule:nonzero;stroke:none"
-         d="m 14.714307,467.50503 0,4.57145 -4.571446,0 0,4.57144 4.571446,0 0,4.57145 4.571445,0 0,-4.57145 4.571445,0 0,-4.57144 -4.571445,0 0,-4.57145 -4.571445,0 z"
+         d="m 14.714307,467.50503 v 4.57145 h -4.571446 v 4.57144 h 4.571446 v 4.57145 h 4.571445 v -4.57145 h 4.571445 v -4.57144 h -4.571445 v -4.57145 z"
          id="path3264"
          inkscape:connector-curvature="0" />
     </g>
@@ -3331,14 +3558,14 @@
              inkscape:transform-center-x="7.5"
              sodipodi:nodetypes="ccccc"
              inkscape:connector-curvature="0"
-             d="m 149.5,152.86218 -15,0 0,15 15,0 z"
+             d="m 149.5,152.86218 h -15 v 15 h 15 z"
              style="opacity:0.60344825;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.27950537;stroke-opacity:1"
              id="path5125" />
         </g>
         <path
            id="path5137"
            style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-           d="M 39.268288,336.15243 28.55854,331.38414 23.790252,342.09389 34.5,346.86218 z"
+           d="M 39.268288,336.15243 28.55854,331.38414 23.790252,342.09389 34.5,346.86218 Z"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccc"
            inkscape:transform-center-x="3.801065"
@@ -3360,7 +3587,7 @@
            inkscape:connector-curvature="0"
            id="path5184"
            d="m 18.919829,338.41825 c 1.609786,-3.50691 4.785185,-6.213 8.827138,-7.1893 1.068186,-0.25801 2.137435,-0.37646 3.18856,-0.36706"
-           style="fill:none;stroke:#3c3c3c;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+           style="fill:none;stroke:#3c3c3c;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
         <path
            inkscape:label="#forExport:collapsibleArrowRightHover"
            transform="matrix(-0.55936791,-0.00554531,-0.00567669,0.55589671,99.812034,10.284701)"
@@ -3376,10 +3603,10 @@
            sodipodi:cx="117.14286"
            sodipodi:sides="3"
            id="path5182"
-           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.7932142;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.7932142;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            sodipodi:type="star" />
         <path
-           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            d="m 18.919829,338.41825 c 1.609786,-3.50691 4.785185,-6.213 8.827138,-7.1893 1.068186,-0.25801 2.137435,-0.37646 3.18856,-0.36706"
            id="path5169"
            inkscape:connector-curvature="0"
@@ -3399,13 +3626,13 @@
            inkscape:transform-center-x="5.201905"
            sodipodi:nodetypes="ccccc"
            inkscape:connector-curvature="0"
-           d="m 183.35283,163.45837 -10.40381,0 0,10.40381 10.40381,0 z"
+           d="m 183.35283,163.45837 h -10.40381 v 10.40381 h 10.40381 z"
            style="opacity:0.625;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
            id="path5151" />
         <path
            id="path5149"
            style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-           d="m 187.35283,159.45837 -10.40381,0 0,10.40381 10.40381,0 z"
+           d="m 187.35283,159.45837 h -10.40381 v 10.40381 h 10.40381 z"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccc"
            inkscape:transform-center-x="5.201905"
@@ -3414,7 +3641,7 @@
       <path
          id="path5147"
          style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-         d="m 195.90381,253.45837 -10.40381,0 0,10.40381 10.40381,0 z"
+         d="M 195.90381,253.45837 H 185.5 v 10.40381 h 10.40381 z"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccc"
          inkscape:transform-center-x="5.201905"
@@ -3423,14 +3650,14 @@
          transform="translate(-0.91160869,98.530327)"
          id="g5246">
         <path
-           style="fill:none;stroke:#3c3c3c;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:none;stroke:#3c3c3c;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 185,120 10,-10"
            id="path5238"
            inkscape:connector-curvature="0"
            transform="translate(0,52.362183)" />
         <path
            sodipodi:type="star"
-           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.40149021;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.40149021;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path5232"
            sodipodi:sides="3"
            sodipodi:cx="117.14286"
@@ -3450,7 +3677,7 @@
            inkscape:connector-curvature="0"
            id="path5240"
            d="m 185,120 10,-10"
-           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
     </g>
     <g
@@ -3463,7 +3690,7 @@
         <path
            id="path5153"
            style="opacity:0.56896548;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-           d="m 216.27881,171.48718 -5.27881,0 0,5.27881 5.27881,0 z"
+           d="M 216.27881,171.48718 H 211 v 5.27881 h 5.27881 z"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccc"
            inkscape:transform-center-x="2.639405"
@@ -3473,7 +3700,7 @@
            inkscape:transform-center-x="5"
            sodipodi:nodetypes="ccccc"
            inkscape:connector-curvature="0"
-           d="m 223,164.766 -10,0 0,10 10,0 z"
+           d="m 223,164.766 h -10 v 10 h 10 z"
            style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
            id="path5155" />
       </g>
@@ -3482,18 +3709,18 @@
          inkscape:transform-center-x="7.0000102"
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
-         d="m 230.09619,252.26599 -14,0 0,14.00001 14,0 z"
-         style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 230.09619,252.26599 h -14 V 266.266 h 14 z"
+         style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path5157" />
       <path
-         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:4;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:4;marker:none;enable-background:accumulate"
          d="m 225.12177,260.4067 -8.59375,11.40625 11.40625,-8.59375 z"
          id="path5253"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccc" />
       <path
          sodipodi:type="star"
-         style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.40149021;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.40149021;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path5255"
          sodipodi:sides="3"
          sodipodi:cx="117.14286"
@@ -3509,7 +3736,7 @@
          transform="matrix(-0.50398184,0.50823176,0.50493003,0.50100644,-4.83073,-88.605708)"
          inkscape:label="#forExport:collapsibleArrowRightHover" />
       <path
-         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          d="m 225.80927,261.0942 -9.28125,10.71875 10.71875,-9.28125 z"
          id="path5257"
          inkscape:connector-curvature="0"
@@ -3534,35 +3761,39 @@
       <path
          sodipodi:nodetypes="cccccc"
          id="path4138"
-         d="m 150,572.36218 25,-4e-4 0,150.00002 -150.000001,0 0,-150.00002 25.000001,4e-4"
-         style="fill:none;stroke:#e5e5e5;stroke-width:19.99999428;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:142.99989574" />
+         d="m 150,572.36218 25,-4e-4 V 722.3618 H 24.999999 V 572.36178 L 50,572.36218"
+         style="fill:none;stroke:#e5e5e5;stroke-width:19.99999428;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
       <path
          id="path4156"
-         d="m 60,632.36218 80,0 -40,60 -40,-60 z"
-         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         d="m 60,632.36218 h 80 l -40,60 z"
+         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
       <rect
          y="552.36218"
          x="85"
          height="75"
          width="30"
          id="rect4175"
-         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:142.99989574" />
+         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1" />
     </g>
     <g
        id="forExport:boxOutNode"
        inkscape:label="#g4200"
        transform="translate(-5.0000019,3.8586102e-4)">
       <path
-         style="fill:none;stroke:#e5e5e5;stroke-width:19.99999428;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:142.99989574"
-         d="m 360,722.3618 15,0 0,-150.00002 -150,0 0,150.00002 15,0"
+         style="fill:none;stroke:#e5e5e5;stroke-width:19.99999428;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
+         d="m 360,722.3618 h 15 V 572.36178 H 225 V 722.3618 h 15"
          id="path4166"
-         sodipodi:nodetypes="cccccc" />
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0" />
       <path
-         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 260,687.36218 80,0 -40,60 -40,-60 z"
-         id="path4177" />
+         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 260,687.36218 h 80 l -40,60 z"
+         id="path4177"
+         inkscape:connector-curvature="0" />
       <rect
-         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:142.99989574"
+         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
          id="rect4179"
          width="30"
          height="75"
@@ -3576,26 +3807,28 @@
       <path
          sodipodi:nodetypes="cccccc"
          id="path4632"
-         d="m 360,722.3618 15,0 0,-150.00002 -150,0 0,150.00002 15,0"
-         style="fill:none;stroke:#e5e5e5;stroke-width:19.99999428;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:142.99989574" />
+         d="m 360,722.3618 h 15 V 572.36178 H 225 V 722.3618 h 15"
+         style="fill:none;stroke:#e5e5e5;stroke-width:19.99999428;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
       <path
          id="path4634"
-         d="m 260,687.36218 80,0 -40,60 -40,-60 z"
-         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         d="m 260,687.36218 h 80 l -40,60 z"
+         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
       <rect
          y="607.36218"
          x="285"
          height="75"
          width="30"
          id="rect4636"
-         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:142.99989574" />
+         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1" />
     </g>
     <g
        id="forExport:export"
        inkscape:label="#g4666">
       <path
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
-         d="m 292.5,83.862183 0,-1 -12,0 0,14 12,0 0,-1"
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
+         d="m 292.5,83.862183 v -1 h -12 v 14 h 12 v -1"
          id="path4640"
          sodipodi:nodetypes="cccccc"
          inkscape:connector-curvature="0" />
@@ -3603,8 +3836,8 @@
          sodipodi:nodetypes="ccccccc"
          inkscape:connector-curvature="0"
          id="path4642"
-         d="m 284,91.862183 8.5,0 0,2 6,-4 -6,-4 0,2 -8.5,0"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="m 284,91.862183 h 8.5 v 2 l 6,-4 -6,-4 v 2 H 284"
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
        id="forExport:duplicate"
@@ -3613,11 +3846,11 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccc"
          id="path4647"
-         d="m 315.50001,82.862183 -10,0 0,11 10,0 z"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1" />
+         d="m 315.50001,82.862183 h -10 v 11 h 10 z"
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1" />
       <path
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
-         d="m 318.50001,85.862183 -10,0 0,11 10,0 z"
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
+         d="m 318.50001,85.862183 h -10 v 11 h 10 z"
          id="path4645"
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0" />
@@ -3637,12 +3870,12 @@
          y="92.862183" />
     </g>
     <g
-       transform="matrix(0,1,-1,0,377.36218,-181.63782)"
+       transform="rotate(90,279.5,97.86218)"
        id="forExport:extract"
        inkscape:label="#g4666">
       <path
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:142.99989319"
-         d="m 292.5,83.862183 0,-1 -12,0 0,14 12,0 0,-1"
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
+         d="m 292.5,83.862183 v -1 h -12 v 14 h 12 v -1"
          id="path4640-5"
          sodipodi:nodetypes="cccccc"
          inkscape:connector-curvature="0" />
@@ -3650,8 +3883,8 @@
          sodipodi:nodetypes="ccccccc"
          inkscape:connector-curvature="0"
          id="path4642-9"
-         d="m 284,91.862183 8.5,0 0,2 6,-4 -6,-4 0,2 -8.5,0"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         d="m 284,91.862183 h 8.5 v 2 l 6,-4 -6,-4 v 2 H 284"
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
        id="forExport:gafferSceneUICameraTool"
@@ -3662,7 +3895,7 @@
         <path
            inkscape:connector-curvature="0"
            style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.84701049;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.5,0.5 -1.5,0 c -1.662,0 -3,1.338 -3,3 l 0,7 c 0,1.662 1.338,3 3,3 l 13,0 c 1.662,0 3,-1.338 3,-3 l 0,-7 c 0,-1.662 -1.338,-3 -3,-3 l -1.5,0 -0.5,-0.5 c -0.78347,-0.78348 -0.892,-2 -2,-2 l -5,0 z"
+           d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.5,0.5 h -1.5 c -1.662,0 -3,1.338 -3,3 v 7 c 0,1.662 1.338,3 3,3 h 13 c 1.662,0 3,-1.338 3,-3 v -7 c 0,-1.662 -1.338,-3 -3,-3 H 255 l -0.5,-0.5 c -0.78347,-0.78348 -0.892,-2 -2,-2 z"
            transform="translate(0,52.362183)"
            id="rect5222" />
         <ellipse
@@ -3725,7 +3958,7 @@
        inkscape:label="#g5275">
       <path
          style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486483;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.5,0.5 -1.5,0 c -1.662,0 -3,1.338 -3,3 l 0,7 c 0,1.662 1.338,3 3,3 l 13,0 c 1.662,0 3,-1.338 3,-3 l 0,-7 c 0,-1.662 -1.338,-3 -3,-3 l -1.5,0 -0.5,-0.5 c -0.78347,-0.78348 -0.892,-2 -2,-2 l -5,0 z"
+         d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.5,0.5 h -1.5 c -1.662,0 -3,1.338 -3,3 v 7 c 0,1.662 1.338,3 3,3 h 13 c 1.662,0 3,-1.338 3,-3 v -7 c 0,-1.662 -1.338,-3 -3,-3 H 255 l -0.5,-0.5 c -0.78347,-0.78348 -0.892,-2 -2,-2 z"
          transform="translate(0,52.362183)"
          id="path5277"
          inkscape:connector-curvature="0" />
@@ -3757,8 +3990,9 @@
          inkscape:connector-curvature="0"
          id="path4695"
          transform="translate(0,52.362183)"
-         d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.5,0.5 -1.5,0 c -1.662,0 -3,1.338 -3,3 l 0,7 c 0,1.662 1.338,3 3,3 l 13,0 c 1.662,0 3,-1.338 3,-3 l 0,-7 c 0,-1.662 -1.338,-3 -3,-3 l -1.5,0 -0.5,-0.5 c -0.78347,-0.78348 -0.892,-2 -2,-2 l -5,0 z"
-         style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486483;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.5,0.5 h -1.5 c -1.662,0 -3,1.338 -3,3 v 7 c 0,1.662 1.338,3 3,3 h 13 c 1.662,0 3,-1.338 3,-3 v -7 c 0,-1.662 -1.338,-3 -3,-3 H 255 l -0.5,-0.5 c -0.78347,-0.78348 -0.892,-2 -2,-2 z"
+         style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486483;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="sccssssssssccss" />
       <ellipse
          ry="4"
          rx="4.0000005"
@@ -3783,23 +4017,23 @@
        id="forExport:selectionMaskOff"
        inkscape:label="#g4793">
       <g
-         transform="translate(188,0)"
+         transform="translate(188)"
          id="g4784">
         <path
            inkscape:connector-curvature="0"
            id="path4741"
-           d="m -9.78125,163.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 -8.5,-2.5625 z"
+           d="m -9.78125,163.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 z"
            style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <path
            inkscape:connector-curvature="0"
            style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m -17.63339,176.49782 -0.710223,-10.45042 8.522673,3.39892 -0.177555,11.69331 -7.634895,-4.64181 z"
+           d="m -17.63339,176.49782 -0.710223,-10.45042 8.522673,3.39892 -0.177555,11.69331 z"
            id="path4743"
            sodipodi:nodetypes="ccccc" />
         <path
            inkscape:connector-curvature="0"
            style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m -18.343613,166.0474 8.522673,3.39892 8.548039,-3.37356 -8.522674,-2.56187 -8.548038,2.53651 z"
+           d="m -18.343613,166.0474 8.522673,3.39892 8.548039,-3.37356 -8.522674,-2.56187 z"
            id="path4745"
            sodipodi:nodetypes="ccccc" />
       </g>
@@ -3807,7 +4041,7 @@
          sodipodi:nodetypes="ccccccccc"
          inkscape:connector-curvature="0"
          id="path4718"
-         d="m 182.25033,179.48925 0,-8.31457 5.78532,6.3076 -2.31413,0 1.15706,2.00697 0,1.43354 -1.44633,0 -1.44633,-2.8671 z"
+         d="m 182.25033,179.48925 v -8.31457 l 5.78532,6.3076 h -2.31413 l 1.15706,2.00697 v 1.43354 h -1.44633 l -1.44633,-2.8671 z"
          style="fill:#000000;fill-opacity:1;stroke:#f4f4f4;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
       <g
          transform="matrix(0.57849085,0,0,0.57849085,192.70448,76.652237)"
@@ -3836,31 +4070,31 @@
     <g
        inkscape:label="#g4793"
        id="forExport:selectionMaskOn"
-       transform="translate(28,0)">
+       transform="translate(28)">
       <g
          id="g4805"
-         transform="translate(188,0)">
+         transform="translate(188)">
         <path
            style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m -9.78125,163.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 -8.5,-2.5625 z"
+           d="m -9.78125,163.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 z"
            id="path4807"
            inkscape:connector-curvature="0" />
         <path
            sodipodi:nodetypes="ccccc"
            id="path4809"
-           d="m -17.63339,176.49782 -0.710223,-10.45042 8.522673,3.39892 -0.177555,11.69331 -7.634895,-4.64181 z"
+           d="m -17.63339,176.49782 -0.710223,-10.45042 8.522673,3.39892 -0.177555,11.69331 z"
            style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            inkscape:connector-curvature="0" />
         <path
            sodipodi:nodetypes="ccccc"
            id="path4811"
-           d="m -18.343613,166.0474 8.522673,3.39892 8.548039,-3.37356 -8.522674,-2.56187 -8.548038,2.53651 z"
+           d="m -18.343613,166.0474 8.522673,3.39892 8.548039,-3.37356 -8.522674,-2.56187 z"
            style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            inkscape:connector-curvature="0" />
       </g>
       <path
          style="fill:#000000;fill-opacity:1;stroke:#f4f4f4;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         d="m 182.25033,179.48925 0,-8.31457 5.78532,6.3076 -2.31413,0 1.15706,2.00697 0,1.43354 -1.44633,0 -1.44633,-2.8671 z"
+         d="m 182.25033,179.48925 v -8.31457 l 5.78532,6.3076 h -2.31413 l 1.15706,2.00697 v 1.43354 h -1.44633 l -1.44633,-2.8671 z"
          id="path4813"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccc" />
@@ -3891,22 +4125,22 @@
     <g
        id="forExport:referenceNode"
        inkscape:label="#g6041"
-       style="stroke:#e5e5e5;stroke-opacity:1;fill:#000000;fill-opacity:0">
+       style="fill:#000000;fill-opacity:0;stroke:#e5e5e5;stroke-opacity:1">
       <path
          inkscape:connector-curvature="0"
          id="path5997"
-         d="m 296.97606,798.64087 -72.61352,21.46604 6.09529,88.5143 64.66314,39.48691 67.84329,-38.42686 6.0953,-89.30933 -72.0835,-21.73106 z"
+         d="m 296.97606,798.64087 -72.61352,21.46604 6.09529,88.5143 64.66314,39.48691 67.84329,-38.42686 6.0953,-89.30933 z"
          style="fill:#000000;fill-opacity:0;stroke:#e5e5e5;stroke-width:8.48041153;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          inkscape:connector-curvature="0"
          style="fill:#000000;fill-opacity:0;stroke:#e5e5e5;stroke-width:8.47999954;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 224.3637,820.08758 72.27577,28.82424 72.49089,-28.60918 -72.27578,-21.72571 -72.49088,21.51065 z"
+         d="m 224.3637,820.08758 72.27577,28.82424 72.49089,-28.60918 -72.27578,-21.72571 z"
          id="path5999"
          sodipodi:nodetypes="ccccc" />
       <path
          inkscape:connector-curvature="0"
          style="fill:#000000;fill-opacity:0;stroke:#e5e5e5;stroke-width:8.48041153;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 230.38668,908.71144 -6.02298,-88.62386 72.27577,28.82424 -1.50574,99.16408 -64.74705,-39.36446 z"
+         d="m 230.38668,908.71144 -6.02298,-88.62386 72.27577,28.82424 -1.50574,99.16408 z"
          id="path6001"
          sodipodi:nodetypes="ccccc" />
       <path
@@ -3923,7 +4157,7 @@
     <g
        id="forExport:boxNode"
        inkscape:label="#g6027"
-       transform="translate(220,0)">
+       transform="translate(220)">
       <path
          sodipodi:nodetypes="cccccccc"
          inkscape:connector-curvature="0"
@@ -3991,7 +4225,7 @@
        y="147.36218" />
     <path
        sodipodi:type="star"
-       style="fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:#262626;stroke-width:0.49690737;stroke-linejoin:round;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       style="fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:#262626;stroke-width:0.49690738;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="forExport:bookmarkStar"
        sodipodi:sides="5"
        sodipodi:cx="298.875"
@@ -4008,7 +4242,7 @@
        inkscape:label="#path3064" />
     <path
        sodipodi:type="star"
-       style="fill:#efc618;fill-opacity:0.99215686;fill-rule:nonzero;stroke:#262626;stroke-width:0.49683791;stroke-linejoin:round;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       style="fill:#efc618;fill-opacity:0.99215686;fill-rule:nonzero;stroke:#262626;stroke-width:0.49683791;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="forExport:bookmarkStar2"
        sodipodi:sides="5"
        sodipodi:cx="298.875"
@@ -4123,5 +4357,110 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccc" />
     </g>
+    <g
+       id="g5812">
+      <rect
+         style="fill:url(#linearGradient5742);fill-opacity:1"
+         ry="2"
+         rx="2"
+         y="59.362183"
+         x="87"
+         height="16"
+         width="16"
+         id="rect5736" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path5796"
+         d="m 89.409772,74.862183 h 11.570078 c 0.88096,0 1.52015,-0.590755 1.52015,-1.513216 l 0.0259,-12.486784"
+         style="fill:none;stroke:url(#linearGradient5851);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <path
+       style="fill:url(#linearGradient5784);fill-opacity:1;stroke:#3c3c3c;stroke-opacity:1"
+       d="m 90.196685,76.454588 c -0.431342,-0.109805 -0.690215,-0.361106 -1.31027,-1.271901 -0.65643,-0.964226 -1.33519,-1.836887 -2.024863,-2.603299 -0.524766,-0.583153 -0.91507,-1.161596 -1.002255,-1.48538 -0.190993,-0.709291 0.398649,-1.562619 1.447306,-2.094536 0.470729,-0.238773 0.54816,-0.258015 1.038337,-0.258015 0.497095,0 0.563657,0.01721 1.082001,0.280052 0.594818,0.301599 1.373418,0.965914 1.822921,1.555347 0.136504,0.178999 0.26603,0.325452 0.287827,0.325452 0.02177,0 0.164208,-0.274705 0.316485,-0.610464 0.336313,-0.741556 1.728594,-3.347638 2.310071,-4.32402 2.156294,-3.620682 4.538839,-6.626438 5.680704,-7.166624 0.427231,-0.202115 1.338621,-0.382904 2.388091,-0.473716 0.73272,-0.06338 0.81795,-0.05907 1.07584,0.05501 0.18422,0.0815 0.31819,0.197574 0.3914,0.339141 0.12782,0.247174 0.13951,0.679936 0.0244,0.901898 -0.0434,0.08357 -0.51977,0.601885 -1.0587,1.151771 -1.47567,1.505676 -2.29807,2.518125 -3.604458,4.437411 -1.743419,2.561359 -3.18888,5.206826 -4.452792,8.149473 -0.96967,2.257583 -0.982354,2.283931 -1.233117,2.561495 -0.125435,0.138843 -0.380198,0.319294 -0.56616,0.401018 -0.299329,0.131547 -0.456439,0.15059 -1.370145,0.16603 -0.567628,0.0097 -1.126805,-0.0066 -1.242616,-0.0362 z"
+       id="path3923"
+       inkscape:connector-curvature="0" />
+    <g
+       transform="translate(21,0.013216)"
+       id="g5812-7">
+      <rect
+         style="fill:url(#linearGradient5908);fill-opacity:1"
+         ry="2"
+         rx="2"
+         y="59.362183"
+         x="87"
+         height="16"
+         width="16"
+         id="rect5736-0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path5796-4"
+         d="m 89.409772,74.862183 h 11.570078 c 0.88096,0 1.52015,-0.590755 1.52015,-1.513216 l 0.0259,-12.486784"
+         style="fill:none;stroke:url(#linearGradient5910);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <g
+       transform="translate(39.9741)"
+       id="g5812-7-9"
+       style="display:inline">
+      <rect
+         style="fill:url(#linearGradient5945);fill-opacity:1"
+         ry="2"
+         rx="2"
+         y="59.362183"
+         x="87"
+         height="16"
+         width="16"
+         id="rect5736-0-3" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path5796-4-4"
+         d="m 89.409772,74.862183 h 11.570078 c 0.88096,0 1.52015,-0.590755 1.52015,-1.513216 l 0.0259,-12.486784"
+         style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:0.11764706" />
+    </g>
+    <g
+       transform="translate(60,0.013216)"
+       id="g5812-7-9-5"
+       style="display:inline">
+      <rect
+         style="fill:url(#linearGradient6013);fill-opacity:1"
+         ry="2"
+         rx="2"
+         y="59.362183"
+         x="87"
+         height="16"
+         width="16"
+         id="rect5736-0-3-5" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path5796-4-4-0"
+         d="m 89.409772,74.862183 h 11.570078 c 0.88096,0 1.52015,-0.590755 1.52015,-1.513216 l 0.0259,-12.486784"
+         style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:0.11764706" />
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3962"
+       d="m 150.19669,76.454588 c -0.43135,-0.109805 -0.69022,-0.361106 -1.31027,-1.271901 -0.65643,-0.964226 -1.33519,-1.836887 -2.02487,-2.603299 -0.52476,-0.583153 -0.91507,-1.161596 -1.00225,-1.48538 -0.191,-0.709291 0.39865,-1.562619 1.4473,-2.094536 0.47073,-0.238773 0.54816,-0.258015 1.03834,-0.258015 0.49709,0 0.56366,0.01721 1.082,0.280052 0.59482,0.301599 1.37342,0.965914 1.82292,1.555347 0.13651,0.178999 0.26603,0.325452 0.28783,0.325452 0.0218,0 0.16421,-0.274705 0.31648,-0.610464 0.33632,-0.741556 1.7286,-3.347638 2.31007,-4.32402 2.1563,-3.620682 4.53884,-6.626438 5.68071,-7.166624 0.42723,-0.202115 1.33862,-0.382904 2.38809,-0.473716 0.73272,-0.06338 0.81795,-0.05907 1.07584,0.05501 0.18422,0.0815 0.31819,0.197574 0.3914,0.339141 0.12782,0.247174 0.13951,0.679936 0.0244,0.901898 -0.0434,0.08357 -0.51977,0.601885 -1.0587,1.151771 -1.47567,1.505676 -2.29807,2.518125 -3.60446,4.437411 -1.74342,2.561359 -3.18888,5.206826 -4.45279,8.149473 -0.96967,2.257583 -0.98235,2.283931 -1.23312,2.561495 -0.12543,0.138843 -0.3802,0.319294 -0.56616,0.401018 -0.29933,0.131547 -0.45644,0.15059 -1.37014,0.16603 -0.56763,0.0097 -1.12681,-0.0066 -1.24262,-0.0362 z"
+       style="fill:url(#linearGradient6021);fill-opacity:1;stroke:#3c3c3c;stroke-opacity:1" />
+    <g
+       transform="translate(79.974035,-5e-5)"
+       id="g5812-7-8">
+      <rect
+         style="fill:#000000;fill-opacity:0.07843137"
+         ry="2"
+         rx="2"
+         y="59.362183"
+         x="87"
+         height="16"
+         width="16"
+         id="rect5736-0-2" />
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="path2986"
+       d="m 170.19669,76.454588 c -0.43135,-0.109805 -0.69022,-0.361106 -1.31027,-1.271901 -0.65643,-0.964226 -1.33519,-1.836887 -2.02487,-2.603299 -0.52476,-0.583153 -0.91507,-1.161596 -1.00225,-1.48538 -0.191,-0.709291 0.39865,-1.562619 1.4473,-2.094536 0.47073,-0.238773 0.54816,-0.258015 1.03834,-0.258015 0.49709,0 0.56366,0.01721 1.082,0.280052 0.59482,0.301599 1.37342,0.965914 1.82292,1.555347 0.13651,0.178999 0.26603,0.325452 0.28783,0.325452 0.0218,0 0.16421,-0.274705 0.31648,-0.610464 0.33632,-0.741556 1.7286,-3.347638 2.31007,-4.32402 2.1563,-3.620682 4.53884,-6.626438 5.68071,-7.166624 0.42723,-0.202115 1.33862,-0.382904 2.38809,-0.473716 0.73272,-0.06338 0.81795,-0.05907 1.07584,0.05501 0.18422,0.0815 0.31819,0.197574 0.3914,0.339141 0.12782,0.247174 0.13951,0.679936 0.0244,0.901898 -0.0434,0.08357 -0.51977,0.601885 -1.0587,1.151771 -1.47567,1.505676 -2.29807,2.518125 -3.60446,4.437411 -1.74342,2.561359 -3.18888,5.206826 -4.45279,8.149473 -0.96967,2.257583 -0.98235,2.283931 -1.23312,2.561495 -0.12543,0.138843 -0.3802,0.319294 -0.56616,0.401018 -0.29933,0.131547 -0.45644,0.15059 -1.37014,0.16603 -0.56763,0.0097 -1.12681,-0.0066 -1.24262,-0.0362 z"
+       style="fill:#666666;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-opacity:1" />
   </g>
 </svg>


### PR DESCRIPTION
Numerous aspects of tab-related development have run into issues caused by Qt failing to either compensate for stylesheet based margins/positioning rules, or apply the required selectors correctly.

In particular, the tab title baseline shift between current/non-current tabs precluded acceptable placement of close buttons in the tab title.

Instead of fudging more and more workarounds, it seemed like an opportunity to refresh the styling and remove the need to work around the issues.

As such, this is a first-pass at:

 - Adjusting the stylesheet to minimise layout-related bugs.
 - Reducing visual complexity/contrast in the UI.
 - Not going down a rabbit hole and fixing/changing everything. Keep the scope to being coherent, without getting carried away. Some bugs exist from before, such as the disabled 'remove' button for vector data editors.

![gafferStyleSheetv2](https://user-images.githubusercontent.com/896779/59095242-e1f5ae00-890f-11e9-8274-213cc1d885e7.png)

It needs some field testing with custom UIs, and general assessment as to whether its now a little subtle...

Note: Once this is accepted, we should tidy up the formatting inconsistencies in `_StyleSheet.py`.

User Facing Changes:

  - Gaffer now looks somewhat different. Functionality should remain unchanged.