### PR TITLE
CatalogueUI : Fix connection management bug

### DIFF
--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -173,8 +173,8 @@ class _ImagesPath( Gaffer.Path ) :
 		# Connect to all the signals we need to in order
 		# to emit pathChangedSignal at the appropriate times.
 
-		self.__images.childAddedSignal().connect( Gaffer.WeakMethod( self.__childAdded ), scoped = False )
-		self.__images.childRemovedSignal().connect( Gaffer.WeakMethod( self.__childRemoved ), scoped = False )
+		self.__childAddedConnection = self.__images.childAddedSignal().connect( Gaffer.WeakMethod( self.__childAdded ) )
+		self.__childRemovedConnection = self.__images.childRemovedSignal().connect( Gaffer.WeakMethod( self.__childRemoved ) )
 		self.__nameChangedConnections = {
 			image : image.nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ) )
 			for image in self.__images


### PR DESCRIPTION
I broke this in #3179, by failing to realise that `_ImagesPath` doesn't derive from `trackable`, and therefore isn't subject to automatic connection management.