### PR TITLE
ThreadState

### DIFF
--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -234,8 +234,6 @@ class stats( Gaffer.Application ) :
 			}
 		)
 
-		self.__vtuneMonitor = None
-
 	def _run( self, args ) :
 
 		if args["cacheMemoryLimit"].value :
@@ -278,8 +276,8 @@ class stats( Gaffer.Application ) :
 		if args["vtune"].value :
 			try:
 				self.__vtuneMonitor = Gaffer.VTuneMonitor()
-				self.__vtuneMonitor.setActive(True)
 			except AttributeError:
+				self.__vtuneMonitor = None
 				IECore.msg( IECore.Msg.Level.Error, "gui", "unable to create requested VTune monitor" )
 
 		self.__output = file( args["outputFile"].value, "w" ) if args["outputFile"].value else sys.stdout
@@ -488,7 +486,7 @@ class stats( Gaffer.Application ) :
 
 		memory = _Memory.maxRSS()
 		with _Timer() as sceneTimer :
-			with self.__performanceMonitor or _NullContextManager(), self.__contextMonitor or _NullContextManager() :
+			with self.__performanceMonitor or _NullContextManager(), self.__contextMonitor or _NullContextManager(), self.__vtuneMonitor or _NullContextManager() :
 				with contextSanitiser :
 					computeScene()
 
@@ -528,7 +526,7 @@ class stats( Gaffer.Application ) :
 
 		memory = _Memory.maxRSS()
 		with _Timer() as imageTimer :
-			with self.__performanceMonitor or _NullContextManager(), self.__contextMonitor or _NullContextManager() :
+			with self.__performanceMonitor or _NullContextManager(), self.__contextMonitor or _NullContextManager(), self.__vtuneMonitor or _NullContextManager() :
 				with contextSanitiser :
 					computeImage()
 
@@ -562,7 +560,7 @@ class stats( Gaffer.Application ) :
 
 		memory = _Memory.maxRSS()
 		with _Timer() as taskTimer :
-			with self.__performanceMonitor or _NullContextManager(), self.__contextMonitor or _NullContextManager() :
+			with self.__performanceMonitor or _NullContextManager(), self.__contextMonitor or _NullContextManager(), self.__vtuneMonitor or _NullContextManager() :
 				with Gaffer.Context( script.context() ) as context :
 					for frame in self.__frames( script, args ) :
 						context.setFrame( frame )

--- a/include/Gaffer/BackgroundTask.h
+++ b/include/Gaffer/BackgroundTask.h
@@ -125,10 +125,8 @@ class GAFFER_API BackgroundTask : public boost::noncopyable
 		// Called by `Action` to ensure that any related tasks are cancelled
 		// before an edit is made to `actionSubject`.
 		static void cancelAffectedTasks( const GraphComponent *actionSubject );
-		static void cancelAllTasks();
 		friend class Action;
 		friend class ScriptNode;
-		friend class Process;
 
 		// Function to be executed.
 		Function m_function;

--- a/include/Gaffer/ContextMonitor.h
+++ b/include/Gaffer/ContextMonitor.h
@@ -69,6 +69,8 @@ class GAFFER_API ContextMonitor : public Monitor
 		ContextMonitor( const GraphComponent *root = nullptr );
 		~ContextMonitor() override;
 
+		IE_CORE_DECLAREMEMBERPTR( ContextMonitor )
+
 		struct Statistics
 		{
 
@@ -124,6 +126,8 @@ class GAFFER_API ContextMonitor : public Monitor
 		mutable Statistics m_combinedStatistics;
 
 };
+
+IE_CORE_DECLAREPTR( ContextMonitor )
 
 } // namespace Gaffer
 

--- a/include/Gaffer/Monitor.h
+++ b/include/Gaffer/Monitor.h
@@ -39,7 +39,7 @@
 
 #include "Gaffer/Export.h"
 
-#include "boost/noncopyable.hpp"
+#include "IECore/RefCounted.h"
 
 namespace Gaffer
 {
@@ -47,13 +47,14 @@ namespace Gaffer
 class Process;
 
 /// Base class for monitoring node graph processes.
-class GAFFER_API Monitor : boost::noncopyable
+class GAFFER_API Monitor : public IECore::RefCounted
 {
 
 	public :
 
-		Monitor();
 		virtual ~Monitor();
+
+		IE_CORE_DECLAREMEMBERPTR( Monitor )
 
 		void setActive( bool active );
 		bool getActive() const;
@@ -77,6 +78,8 @@ class GAFFER_API Monitor : boost::noncopyable
 
 	protected :
 
+		Monitor();
+
 		friend class Process;
 
 		/// Implementations must be safe to call concurrently.
@@ -85,6 +88,8 @@ class GAFFER_API Monitor : boost::noncopyable
 		virtual void processFinished( const Process *process ) = 0;
 
 };
+
+IE_CORE_DECLAREPTR( Monitor )
 
 } // namespace Gaffer
 

--- a/include/Gaffer/Monitor.h
+++ b/include/Gaffer/Monitor.h
@@ -38,6 +38,7 @@
 #define GAFFER_MONITOR_H
 
 #include "Gaffer/Export.h"
+#include "Gaffer/ThreadState.h"
 
 #include "IECore/RefCounted.h"
 
@@ -56,25 +57,31 @@ class GAFFER_API Monitor : public IECore::RefCounted
 
 		IE_CORE_DECLAREMEMBERPTR( Monitor )
 
-		void setActive( bool active );
-		bool getActive() const;
+		using MonitorSet = boost::container::flat_set<MonitorPtr>;
 
-		class Scope : boost::noncopyable
+		class Scope : private ThreadState::Scope
 		{
 
 			public :
 
-				/// Constructing the Scope makes the monitor active.
-				/// If monitor is null, the Scope is a no-op.
-				Scope( Monitor *monitor );
-				/// Destruction of the Scope makes the monitor inactive.
+				/// Constructs a Scope where the monitor has the specified
+				/// active state. If monitor is null, the scope is a no-op.
+				Scope( const MonitorPtr &monitor, bool active = true );
+				/// Constructs a Scope where each of `monitors` has the
+				/// specified `active` state.
+				Scope( const MonitorSet &monitors, bool active = true );
+				/// Returns to the previously active set of monitors.
 				~Scope();
 
 			private :
 
-				Monitor *m_monitor;
+				MonitorSet m_monitors;
 
 		};
+
+		/// Returns the set of monitors that are currently active
+		/// on this thread.
+		static const MonitorSet &current();
 
 	protected :
 

--- a/include/Gaffer/PerformanceMonitor.h
+++ b/include/Gaffer/PerformanceMonitor.h
@@ -63,6 +63,8 @@ class GAFFER_API PerformanceMonitor : public Monitor
 		PerformanceMonitor();
 		~PerformanceMonitor() override;
 
+		IE_CORE_DECLAREMEMBERPTR( PerformanceMonitor )
+
 		struct Statistics
 		{
 
@@ -122,6 +124,8 @@ class GAFFER_API PerformanceMonitor : public Monitor
 		mutable Statistics m_combinedStatistics;
 
 };
+
+IE_CORE_DECLAREPTR( PerformanceMonitor )
 
 } // namespace Gaffer
 

--- a/include/Gaffer/Process.h
+++ b/include/Gaffer/Process.h
@@ -47,7 +47,6 @@ namespace Gaffer
 
 class Context;
 class Plug;
-class Monitor;
 
 /// Base class representing a node graph process being
 /// performed on behalf of a plug. Processes are never
@@ -95,13 +94,6 @@ class GAFFER_API Process : private ThreadState::Scope
 		void handleException();
 
 	private :
-
-		// Friendship allows monitors to register and deregister
-		// themselves.
-		friend class Monitor;
-		static void registerMonitor( Monitor *monitor );
-		static void deregisterMonitor( Monitor *monitor );
-		static bool monitorRegistered( const Monitor *monitor );
 
 		void emitError( const std::string &error ) const;
 

--- a/include/Gaffer/Process.h
+++ b/include/Gaffer/Process.h
@@ -38,12 +38,9 @@
 #define GAFFER_PROCESS_H
 
 #include "Gaffer/Export.h"
+#include "Gaffer/ThreadState.h"
 
 #include "IECore/InternedString.h"
-
-#include "boost/noncopyable.hpp"
-
-#include "tbb/enumerable_thread_specific.h"
 
 namespace Gaffer
 {
@@ -60,7 +57,7 @@ class Monitor;
 /// considered to be entirely an internal implementation
 /// detail - they are exposed publicly only so they can
 /// be used by the Monitor classes.
-class GAFFER_API Process : public boost::noncopyable
+class GAFFER_API Process : private ThreadState::Scope
 {
 
 	public :
@@ -72,13 +69,10 @@ class GAFFER_API Process : public boost::noncopyable
 		const Plug *plug() const { return m_plug; }
 		/// The context in which the process is being
 		/// performed.
-		const Context *context() const { return m_context; }
+		const Context *context() const { return m_threadState->m_context; }
 
 		/// Returns the parent process for this process - that
 		/// is, the process that invoked this one.
-		/// \todo Currently this does not track parent/child
-		/// relationships correctly when a parent process spawns
-		/// child processes on separate threads.
 		const Process *parent() const { return m_parent; }
 
 		/// Returns the Process currently being performed on
@@ -88,9 +82,7 @@ class GAFFER_API Process : public boost::noncopyable
 	protected :
 
 		/// Protected constructor for use by derived classes only.
-		/// If `Context::current()` has already been retrieved it can be passed
-		/// via `currentContext` to avoid a second lookup.
-		Process( const IECore::InternedString &type, const Plug *plug, const Plug *downstream = nullptr, const Context *currentContext = nullptr );
+		Process( const IECore::InternedString &type, const Plug *plug, const Plug *downstream = nullptr );
 		~Process();
 
 		/// Derived classes should catch exceptions thrown
@@ -113,16 +105,10 @@ class GAFFER_API Process : public boost::noncopyable
 
 		void emitError( const std::string &error ) const;
 
-		struct ThreadData;
-
 		IECore::InternedString m_type;
 		const Plug *m_plug;
 		const Plug *m_downstream;
-		const Context *m_context;
 		const Process *m_parent;
-		ThreadData *m_threadData;
-
-		static tbb::enumerable_thread_specific<ThreadData, tbb::cache_aligned_allocator<Process::ThreadData>, tbb::ets_key_per_instance> g_threadData;
 
 };
 

--- a/include/Gaffer/ThreadState.h
+++ b/include/Gaffer/ThreadState.h
@@ -1,0 +1,129 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_THREADSTATE_H
+#define GAFFER_THREADSTATE_H
+
+#include "Gaffer/Export.h"
+
+#include "boost/noncopyable.hpp"
+
+#include <stack>
+
+namespace Gaffer
+{
+
+class Context;
+class Process;
+
+/// ThreadState provides the foundations for multi-threaded compute
+/// in Gaffer. Typically you will not interact with ThreadStates directly,
+/// but will instead use the specialised APIs provided by the Process,
+/// Context and Monitor classes. The exception to this is when using
+/// task-based TBB algorithms, in which case it is necessary to manually
+/// transfer the current ThreadState from the calling code to the tasks
+/// running on it's behalf. For example :
+///
+/// ```
+/// const ThreadState &threadState = ThreadState::current();
+/// tbb::parallel_for(
+/// 	tbb::blocked_range<size_t>( ... ),
+/// 	[&threadState] ( const tbb::blocked_range<size_t> &r )
+/// 	{
+/// 		ThreadState::Scope threadStateScope( threadState );
+/// 		...
+/// 	}
+/// );
+/// ```
+class GAFFER_API ThreadState
+{
+
+	public :
+
+		/// Constructs a default thread state, with no current Process,
+		/// and a default constructed Context.
+		ThreadState();
+
+		class Scope : public boost::noncopyable
+		{
+
+			public :
+
+				/// Scopes a copy of `state` on the current
+				/// thread. When a process spawns TBB tasks, each
+				/// task _must_ use this to transfer `ThreadState::current()`
+				/// from the calling thread to the thread executing
+				/// the task.
+				Scope( const ThreadState &state );
+				/// Pops the ThreadState that was pushed by the
+				/// constructor.
+				~Scope();
+
+			protected :
+
+				/// Pushes a copy of the current ThreadState onto
+				/// the stack for this thread. Passing `push = false`
+				/// yields a no-op.
+				Scope( bool push = true );
+
+				/// The ThreadState being managed by this scope.
+				/// Will be null if the constructor is called with
+				/// `push = false`.
+				ThreadState *m_threadState;
+
+			private :
+
+				std::stack<ThreadState> *m_stack;
+
+		};
+
+		static const ThreadState &current();
+
+	private :
+
+		friend class Process;
+		friend class Context;
+
+		const Context *m_context;
+		const Process *m_process;
+
+		static const ThreadState g_defaultState;
+
+};
+
+} // namespace Gaffer
+
+#endif // GAFFER_THREADSTATE_H

--- a/include/Gaffer/ThreadState.h
+++ b/include/Gaffer/ThreadState.h
@@ -39,6 +39,9 @@
 
 #include "Gaffer/Export.h"
 
+#include "IECore/RefCounted.h"
+
+#include "boost/container/flat_set.hpp"
 #include "boost/noncopyable.hpp"
 
 #include <stack>
@@ -48,6 +51,7 @@ namespace Gaffer
 
 class Context;
 class Process;
+IE_CORE_FORWARDDECLARE( Monitor );
 
 /// ThreadState provides the foundations for multi-threaded compute
 /// in Gaffer. Typically you will not interact with ThreadStates directly,
@@ -74,7 +78,7 @@ class GAFFER_API ThreadState
 	public :
 
 		/// Constructs a default thread state, with no current Process,
-		/// and a default constructed Context.
+		/// no active monitors, and a default constructed Context.
 		ThreadState();
 
 		class Scope : public boost::noncopyable
@@ -116,10 +120,15 @@ class GAFFER_API ThreadState
 
 		friend class Process;
 		friend class Context;
+		friend class Monitor;
+
+		using MonitorSet = boost::container::flat_set<MonitorPtr>;
 
 		const Context *m_context;
 		const Process *m_process;
+		const MonitorSet *m_monitors;
 
+		static const MonitorSet g_defaultMonitors;
 		static const ThreadState g_defaultState;
 
 };

--- a/include/Gaffer/VTuneMonitor.h
+++ b/include/Gaffer/VTuneMonitor.h
@@ -53,6 +53,8 @@ class GAFFER_API VTuneMonitor : public Monitor
 		VTuneMonitor( bool monitorHashProcess = false );
 		~VTuneMonitor() override;
 
+		IE_CORE_DECLAREMEMBERPTR( VTuneMonitor )
+
 	protected :
 
 		void processStarted( const Process *process ) override;
@@ -63,6 +65,8 @@ class GAFFER_API VTuneMonitor : public Monitor
 		bool m_monitorHashProcess;
 
 };
+
+IE_CORE_DECLAREPTR( VTuneMonitor )
 
 } // namespace Gaffer
 

--- a/include/GafferImage/ImageAlgo.inl
+++ b/include/GafferImage/ImageAlgo.inl
@@ -321,7 +321,7 @@ void parallelProcessTiles( const ImagePlug *imagePlug, TileFunctor &&functor, co
 	}
 
 	Detail::TileInputIterator tileIterator( processWindow, tileOrder );
-	const Gaffer::Context *context = Gaffer::Context::current();
+	const Gaffer::ThreadState &threadState = Gaffer::ThreadState::current();
 
 	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
 	parallel_pipeline( tbb::task_scheduler_init::default_num_threads(),
@@ -335,9 +335,9 @@ void parallelProcessTiles( const ImagePlug *imagePlug, TileFunctor &&functor, co
 
 			tbb::filter::parallel,
 
-			[ imagePlug, &functor, context ] ( const Imath::V2i &tileOrigin ) {
+			[ imagePlug, &functor, &threadState ] ( const Imath::V2i &tileOrigin ) {
 
-				ImagePlug::ChannelDataScope channelDataScope( context );
+				ImagePlug::ChannelDataScope channelDataScope( threadState );
 				channelDataScope.setTileOrigin( tileOrigin );
 				functor( imagePlug, tileOrigin );
 
@@ -365,7 +365,7 @@ void parallelProcessTiles( const ImagePlug *imagePlug, const std::vector<std::st
 	}
 
 	Detail::TileChannelInputIterator tileIterator( processWindow, channelNames, tileOrder );
-	const Gaffer::Context *context = Gaffer::Context::current();
+	const Gaffer::ThreadState &threadState = Gaffer::ThreadState::current();
 
 	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
 	parallel_pipeline(
@@ -381,9 +381,9 @@ void parallelProcessTiles( const ImagePlug *imagePlug, const std::vector<std::st
 
 			tbb::filter::parallel,
 
-			[ imagePlug, &functor, context ] ( const Detail::OriginAndName &input ) {
+			[ imagePlug, &functor, &threadState ] ( const Detail::OriginAndName &input ) {
 
-				ImagePlug::ChannelDataScope channelDataScope( context );
+				ImagePlug::ChannelDataScope channelDataScope( threadState );
 				channelDataScope.setTileOrigin( input.origin );
 				channelDataScope.setChannelName( input.name );
 				functor( imagePlug, input.name, input.origin );
@@ -415,7 +415,7 @@ void parallelGatherTiles( const ImagePlug *imagePlug, const TileFunctor &tileFun
 	typedef std::pair<Imath::V2i, TileFunctorResult> TileFilterResult;
 
 	Detail::TileInputIterator tileIterator( processWindow, tileOrder );
-	const Gaffer::Context *context = Gaffer::Context::current();
+	const Gaffer::ThreadState &threadState = Gaffer::ThreadState::current();
 
 	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
 	parallel_pipeline( tbb::task_scheduler_init::default_num_threads(),
@@ -429,9 +429,9 @@ void parallelGatherTiles( const ImagePlug *imagePlug, const TileFunctor &tileFun
 
 			tbb::filter::parallel,
 
-			[ imagePlug, &tileFunctor, context ] ( const Imath::V2i &tileOrigin ) {
+			[ imagePlug, &tileFunctor, &threadState ] ( const Imath::V2i &tileOrigin ) {
 
-				ImagePlug::ChannelDataScope channelDataScope( context );
+				ImagePlug::ChannelDataScope channelDataScope( threadState );
 				channelDataScope.setTileOrigin( tileOrigin );
 
 				return TileFilterResult(
@@ -445,9 +445,9 @@ void parallelGatherTiles( const ImagePlug *imagePlug, const TileFunctor &tileFun
 
 			tileOrder == Unordered ? tbb::filter::serial_out_of_order : tbb::filter::serial_in_order,
 
-			[ imagePlug, &gatherFunctor, context ] ( const TileFilterResult &input ) {
+			[ imagePlug, &gatherFunctor, &threadState ] ( const TileFilterResult &input ) {
 
-				ImagePlug::ChannelDataScope channelDataScope( context );
+				ImagePlug::ChannelDataScope channelDataScope( threadState );
 				channelDataScope.setTileOrigin( input.first );
 
 				gatherFunctor( imagePlug, input.first, input.second );
@@ -479,7 +479,7 @@ void parallelGatherTiles( const ImagePlug *imagePlug, const std::vector<std::str
 	typedef std::pair<Detail::OriginAndName, TileFunctorResult> TileFilterResult;
 
 	Detail::TileChannelInputIterator tileIterator( processWindow, channelNames, tileOrder );
-	const Gaffer::Context *context = Gaffer::Context::current();
+	const Gaffer::ThreadState &threadState = Gaffer::ThreadState::current();
 
 	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
 	parallel_pipeline(
@@ -495,9 +495,9 @@ void parallelGatherTiles( const ImagePlug *imagePlug, const std::vector<std::str
 
 			tbb::filter::parallel,
 
-			[ imagePlug, &tileFunctor, context ] ( const Detail::OriginAndName &input ) {
+			[ imagePlug, &tileFunctor, &threadState ] ( const Detail::OriginAndName &input ) {
 
-				ImagePlug::ChannelDataScope channelDataScope( context );
+				ImagePlug::ChannelDataScope channelDataScope( threadState );
 				channelDataScope.setTileOrigin( input.origin );
 				channelDataScope.setChannelName( input.name );
 
@@ -513,9 +513,9 @@ void parallelGatherTiles( const ImagePlug *imagePlug, const std::vector<std::str
 
 			tileOrder == Unordered ? tbb::filter::serial_out_of_order : tbb::filter::serial_in_order,
 
-			[ imagePlug, &gatherFunctor, context ] ( const TileFilterResult &input ) {
+			[ imagePlug, &gatherFunctor, &threadState ] ( const TileFilterResult &input ) {
 
-				ImagePlug::ChannelDataScope channelDataScope( context );
+				ImagePlug::ChannelDataScope channelDataScope( threadState );
 				channelDataScope.setTileOrigin( input.first.origin );
 				channelDataScope.setChannelName( input.first.name );
 

--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -127,6 +127,7 @@ class GAFFERIMAGE_API ImagePlug : public Gaffer::ValuePlug
 		struct GlobalScope : public Gaffer::Context::EditableScope
 		{
 			GlobalScope( const Gaffer::Context *context );
+			GlobalScope( const Gaffer::ThreadState &threadState );
 		};
 
 		/// Utility class to scope a temporary copy of a context,
@@ -135,6 +136,7 @@ class GAFFERIMAGE_API ImagePlug : public Gaffer::ValuePlug
 		struct ChannelDataScope : public Gaffer::Context::EditableScope
 		{
 			ChannelDataScope( const Gaffer::Context *context );
+			ChannelDataScope( const Gaffer::ThreadState &threadState );
 			void setTileOrigin( const Imath::V2i &tileOrigin );
 			void setChannelName( const std::string &channelName );
 		};

--- a/include/GafferImageTest/ContextSanitiser.h
+++ b/include/GafferImageTest/ContextSanitiser.h
@@ -53,6 +53,8 @@ class GAFFER_API ContextSanitiser : public Gaffer::Monitor
 
 		ContextSanitiser();
 
+		IE_CORE_DECLAREMEMBERPTR( ContextSanitiser )
+
 	protected :
 
 		void processStarted( const Gaffer::Process *process ) override;
@@ -71,6 +73,8 @@ class GAFFER_API ContextSanitiser : public Gaffer::Monitor
 		WarningSet m_warningsEmitted;
 
 };
+
+IE_CORE_DECLAREPTR( ContextSanitiser )
 
 } // namespace GafferImageTest
 

--- a/include/GafferScene/ScenePlug.h
+++ b/include/GafferScene/ScenePlug.h
@@ -134,8 +134,14 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 		/// specifying the scene path.
 		struct PathScope : public Gaffer::Context::EditableScope
 		{
+			/// Standard constructors, for modifying context on the current thread.
 			PathScope( const Gaffer::Context *context );
 			PathScope( const Gaffer::Context *context, const ScenePath &scenePath );
+
+			/// Specialised constructors used to transfer state to TBB tasks. See
+			/// ThreadState documentation for more details.
+			PathScope( const Gaffer::ThreadState &threadState );
+			PathScope( const Gaffer::ThreadState &threadState, const ScenePath &scenePath );
 
 			void setPath( const ScenePath &scenePath );
 		};
@@ -144,8 +150,14 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 		/// specifying the set name.
 		struct SetScope : public Gaffer::Context::EditableScope
 		{
+			/// Standard constructors, for modifying context on the current thread.
 			SetScope( const Gaffer::Context *context );
 			SetScope( const Gaffer::Context *context, const IECore::InternedString &setName );
+
+			/// Specialised constructors used to transfer state to TBB tasks. See
+			/// ThreadState documentation for more details.
+			SetScope( const Gaffer::ThreadState &threadState );
+			SetScope( const Gaffer::ThreadState &threadState, const IECore::InternedString &setName );
 
 			void setSetName( const IECore::InternedString &setName );
 		};
@@ -157,7 +169,11 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 		/// reducing pressure on the hash cache.
 		struct GlobalScope : public Gaffer::Context::EditableScope
 		{
+			/// Standard constructor, for modifying context on the current thread.
 			GlobalScope( const Gaffer::Context *context );
+			/// Specialised constructor used to transfer state to TBB tasks. See
+			/// ThreadState documentation for more details.
+			GlobalScope( const Gaffer::ThreadState &threadState );
 		};
 		//@}
 

--- a/include/GafferSceneTest/ContextSanitiser.h
+++ b/include/GafferSceneTest/ContextSanitiser.h
@@ -53,6 +53,8 @@ class GAFFER_API ContextSanitiser : public Gaffer::Monitor
 
 		ContextSanitiser();
 
+		IE_CORE_DECLAREMEMBERPTR( ContextSanitiser )
+
 	protected :
 
 		void processStarted( const Gaffer::Process *process ) override;
@@ -71,6 +73,8 @@ class GAFFER_API ContextSanitiser : public Gaffer::Monitor
 		WarningSet m_warningsEmitted;
 
 };
+
+IE_CORE_DECLAREPTR( ContextSanitiser )
 
 } // namespace GafferSceneTest
 

--- a/python/Gaffer/Monitor.py
+++ b/python/Gaffer/Monitor.py
@@ -1,7 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2011-2012, John Haddon. All rights reserved.
-#  Copyright (c) 2011-2014, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -35,26 +34,25 @@
 #
 ##########################################################################
 
-__import__( "IECore" )
+import Gaffer
 
-from _Gaffer import *
-from About import About
-from Application import Application
-from WeakMethod import WeakMethod
-from BlockedConnection import BlockedConnection
-from FileNamePathFilter import FileNamePathFilter
-from UndoScope import UndoScope
-from Context import Context
-from InfoPathFilter import InfoPathFilter
-from LazyModule import lazyImport, LazyModule
-from DictPath import DictPath
-from PythonExpressionEngine import PythonExpressionEngine
-from SequencePath import SequencePath
-from GraphComponentPath import GraphComponentPath
-from OutputRedirection import OutputRedirection
-from Monitor import Monitor
+# Add on methods to allow monitors to be used in "with" blocks.
+# In python we use this mechanism in preference to the Monitor::Scope
+# class used in C++.
 
-import NodeAlgo
-import ExtensionAlgo
+def __enter( self ) :
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "Gaffer" )
+	if not hasattr( self, "_scopes" ) :
+		self._scopes = []
+
+	self._scopes.append( Gaffer.Monitor._Scope( self ) )
+	return self
+
+def __exit( self, type, value, traceBack ) :
+
+	del self._scopes[-1]
+
+Gaffer.Monitor.__enter__ = __enter
+Gaffer.Monitor.__exit__ = __exit
+
+Monitor = Gaffer.Monitor

--- a/python/GafferImageTest/ImageAlgoTest.py
+++ b/python/GafferImageTest/ImageAlgoTest.py
@@ -39,6 +39,7 @@ import imath
 
 import IECore
 
+import Gaffer
 import GafferTest
 import GafferImage
 import GafferImageTest
@@ -250,6 +251,27 @@ class ImageAlgoTest( GafferImageTest.ImageTestCase ) :
 			self.assertIsInstance( tile, IECore.FloatVectorData )
 
 		GafferImage.ImageAlgo.parallelGatherTiles( constant["out"], [ "R", "G", "B", "A" ], computeTile, gatherTile )
+
+	def testMonitorParallelProcessTiles( self ) :
+
+		numTilesX = 50
+		numTilesY = 50
+
+		c = GafferImage.Checkerboard()
+		c["format"].setValue(
+			GafferImage.Format(
+				numTilesX * GafferImage.ImagePlug.tileSize(),
+				numTilesY * GafferImage.ImagePlug.tileSize(),
+			)
+		)
+
+		with Gaffer.PerformanceMonitor() as m :
+			GafferImageTest.processTiles( c["out"] )
+
+		self.assertEqual(
+			m.plugStatistics( c["out"]["channelData"] ).computeCount,
+			numTilesX * numTilesY * 4
+		)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ContextTest.py
+++ b/python/GafferTest/ContextTest.py
@@ -354,6 +354,7 @@ class ContextTest( GafferTest.TestCase ) :
 
 		self.assertEqual( cc.names(), cc.keys() )
 
+	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testManyContexts( self ) :
 
 		GafferTest.testManyContexts()
@@ -547,10 +548,12 @@ class ContextTest( GafferTest.TestCase ) :
 		c["ui:test"] = 1
 		self.assertEqual( h, c.hash() )
 
+	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testManySubstitutions( self ) :
 
 		GafferTest.testManySubstitutions()
 
+	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testManyEnvironmentSubstitutions( self ) :
 
 		GafferTest.testManyEnvironmentSubstitutions()

--- a/python/GafferTest/PerformanceMonitorTest.py
+++ b/python/GafferTest/PerformanceMonitorTest.py
@@ -63,21 +63,6 @@ class PerformanceMonitorTest( GafferTest.TestCase ) :
 		while gc.collect() :
 			pass
 
-	def testActiveStatus( self ) :
-
-		m = Gaffer.PerformanceMonitor()
-
-		self.assertEqual( m.getActive(), False )
-		m.setActive( True )
-		self.assertEqual( m.getActive(), True )
-		m.setActive( False )
-		self.assertEqual( m.getActive(), False )
-
-		with m :
-			self.assertEqual( m.getActive(), True )
-
-		self.assertEqual( m.getActive(), False )
-
 	def testStatistics( self ) :
 
 		m = Gaffer.PerformanceMonitor()

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -61,6 +61,11 @@ class TestCase( unittest.TestCase ) :
 		self.addCleanup( functools.partial( self.__messageHandlerCleanup, IECore.MessageHandler.getDefaultHandler() ) )
 		IECore.MessageHandler.setDefaultHandler( IECore.CapturingMessageHandler() )
 
+		# Clear the cache so that each test starts afresh. This is
+		# important for tests which use monitors to assert that specific
+		# processes are being invoked as expected.
+		Gaffer.ValuePlug.clearCache()
+
 	def tearDown( self ) :
 
 		# Clear any previous exceptions, as they can be holding

--- a/src/Gaffer/BackgroundTask.cpp
+++ b/src/Gaffer/BackgroundTask.cpp
@@ -329,22 +329,3 @@ void BackgroundTask::cancelAffectedTasks( const GraphComponent *actionSubject )
 		it = nextIt;
 	}
 }
-
-void BackgroundTask::cancelAllTasks()
-{
-	const ActiveTasks &a = activeTasks();
-	// Call cancel for everything first.
-	for( const auto &t : a )
-	{
-		t.task->cancel();
-	}
-	// And then perform all the waits. This way the wait on one
-	// task doesn't delay the start of cancellation for the next.
-	for( auto it = a.begin(); it != a.end(); )
-	{
-		// Wait invalidates iterator, so must increment first.
-		auto nextIt = std::next( it );
-		it->task->wait();
-		it = nextIt;
-	}
-}

--- a/src/Gaffer/BackgroundTask.cpp
+++ b/src/Gaffer/BackgroundTask.cpp
@@ -36,6 +36,7 @@
 
 #include "Gaffer/BackgroundTask.h"
 #include "Gaffer/ScriptNode.h"
+#include "Gaffer/ThreadState.h"
 
 #include "IECore/MessageHandler.h"
 
@@ -177,6 +178,11 @@ BackgroundTask::BackgroundTask( const Plug *subject, const Function &function )
 
 			taskData->status = Running;
 			lock.unlock();
+
+			// Reset thread state rather then inherit the random
+			// one that TBB task-stealing might present us with.
+			const ThreadState defaultThreadState;
+			ThreadState::Scope threadStateScope( defaultThreadState );
 
 			Status status;
 			try

--- a/src/Gaffer/ParallelAlgo.cpp
+++ b/src/Gaffer/ParallelAlgo.cpp
@@ -38,6 +38,7 @@
 
 #include "Gaffer/BackgroundTask.h"
 #include "Gaffer/Context.h"
+#include "Gaffer/Monitor.h"
 
 #include "boost/make_unique.hpp"
 
@@ -99,15 +100,18 @@ void ParallelAlgo::popUIThreadCallHandler()
 GAFFER_API std::unique_ptr<BackgroundTask> ParallelAlgo::callOnBackgroundThread( const Plug *subject, BackgroundFunction function )
 {
 	ContextPtr backgroundContext = new Context( *Context::current() );
+	Monitor::MonitorSet backgroundMonitors = Monitor::current();
 
 	return boost::make_unique<BackgroundTask>(
 
 		subject,
 
-		[backgroundContext, function] ( const IECore::Canceller &canceller ) {
+		[backgroundContext, backgroundMonitors, function] ( const IECore::Canceller &canceller ) {
 
 			ContextPtr c = new Context( *backgroundContext, canceller );
 			Context::Scope contextScope( c.get() );
+			Monitor::Scope monitorScope( backgroundMonitors );
+
 			function();
 
 		}

--- a/src/Gaffer/Process.cpp
+++ b/src/Gaffer/Process.cpp
@@ -36,7 +36,6 @@
 
 #include "Gaffer/Process.h"
 
-#include "Gaffer/BackgroundTask.h"
 #include "Gaffer/Context.h"
 #include "Gaffer/Monitor.h"
 #include "Gaffer/Node.h"
@@ -44,17 +43,12 @@
 
 #include "IECore/Canceller.h"
 
-#include "boost/container/flat_set.hpp"
-
 #include "tbb/enumerable_thread_specific.h"
 
 using namespace Gaffer;
 
 namespace
 {
-
-typedef boost::container::flat_set<Monitor *> Monitors;
-Monitors g_activeMonitors;
 
 // Used by `handleException()/emitError()` to track the original (most upstream)
 // source of an error.
@@ -86,17 +80,17 @@ Process::Process( const IECore::InternedString &type, const Plug *plug, const Pl
 	m_parent = m_threadState->m_process;
 	m_threadState->m_process = this;
 
-	for( Monitors::const_iterator it = g_activeMonitors.begin(), eIt = g_activeMonitors.end(); it != eIt; ++it )
+	for( const auto &m : *m_threadState->m_monitors )
 	{
-		(*it)->processStarted( this );
+		m->processStarted( this );
 	}
 }
 
 Process::~Process()
 {
-	for( Monitors::const_iterator it = g_activeMonitors.begin(), eIt = g_activeMonitors.end(); it != eIt; ++it )
+	for( const auto &m : *m_threadState->m_monitors )
 	{
-		(*it)->processFinished( this );
+		m->processFinished( this );
 	}
 	if( !parent() )
 	{
@@ -158,37 +152,3 @@ void Process::emitError( const std::string &error ) const
 		plug = plug != m_plug ? plug->getInput() : nullptr;
 	}
 }
-
-void Process::registerMonitor( Monitor *monitor )
-{
-	// Because `g_activeMonitors` is global state, we can't modify it
-	// while other threads are creating processes. So we cancel all BackgroundTasks
-	// to make sure that is not the case. This is needed by the TransformTool,
-	// which attaches a monitor temporarily at a point when the viewer is likely
-	// to be updating asynchronously. Without this workaround, at best the TransformTool
-	// ends up monitoring processes it doesn't want to, and at worst we get
-	// crashes.
-	//
-	// This is a bit of a hack, but it represents progress towards an improved Monitor API.
-	// When making a monitor active, ideally it should only be active for processes launched from
-	// _the current thread_, and any processes that those processes launch (potentially on other
-	// threads). In other words, we only want to monitor process trees that originate from
-	// inside the monitor's active scope. To do this properly we need to be able to track
-	// `Process::parent()` accurately when a process uses TBB to launch child processes on
-	// other threads. So for now we use this poor man's version whereby we at least prevent
-	// background tasks from being monitored inadvertently.
-	BackgroundTask::cancelAllTasks();
-	g_activeMonitors.insert( monitor );
-}
-
-void Process::deregisterMonitor( Monitor *monitor )
-{
-	BackgroundTask::cancelAllTasks();
-	g_activeMonitors.erase( monitor );
-}
-
-bool Process::monitorRegistered( const Monitor *monitor )
-{
-	return g_activeMonitors.find( const_cast<Monitor *>( monitor ) ) != g_activeMonitors.end();
-}
-

--- a/src/Gaffer/ThreadState.cpp
+++ b/src/Gaffer/ThreadState.cpp
@@ -1,0 +1,92 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/ThreadState.h"
+
+#include "Gaffer/Context.h"
+
+#include "tbb/enumerable_thread_specific.h"
+
+using namespace Gaffer;
+
+namespace
+{
+
+using Stack = std::stack<ThreadState>;
+tbb::enumerable_thread_specific<Stack, tbb::cache_aligned_allocator<Stack>, tbb::ets_key_per_instance> g_stack;
+
+ContextPtr g_defaultContext = new Context;
+
+} // namespace
+
+const ThreadState ThreadState::g_defaultState;
+
+ThreadState::ThreadState()
+	:	m_context( g_defaultContext.get() ), m_process( nullptr )
+{
+}
+
+ThreadState::Scope::Scope( const ThreadState &state )
+	:	m_stack( &g_stack.local() )
+{
+	m_stack->push( state );
+	m_threadState = &m_stack->top();
+}
+
+ThreadState::Scope::Scope( bool push )
+	:	m_threadState( nullptr ), m_stack( nullptr )
+{
+	if( push )
+	{
+		m_stack = &g_stack.local();
+		m_stack->push( m_stack->size() ? m_stack->top() : g_defaultState );
+		m_threadState = &m_stack->top();
+	}
+}
+
+ThreadState::Scope::~Scope()
+{
+	if( m_stack )
+	{
+		m_stack->pop();
+	}
+}
+
+const ThreadState &ThreadState::current()
+{
+	const Stack &stack = g_stack.local();
+	return stack.size() ? stack.top() : g_defaultState;
+}

--- a/src/Gaffer/ThreadState.cpp
+++ b/src/Gaffer/ThreadState.cpp
@@ -37,6 +37,7 @@
 #include "Gaffer/ThreadState.h"
 
 #include "Gaffer/Context.h"
+#include "Gaffer/Monitor.h"
 
 #include "tbb/enumerable_thread_specific.h"
 
@@ -52,10 +53,11 @@ ContextPtr g_defaultContext = new Context;
 
 } // namespace
 
+const ThreadState::MonitorSet ThreadState::g_defaultMonitors;
 const ThreadState ThreadState::g_defaultState;
 
 ThreadState::ThreadState()
-	:	m_context( g_defaultContext.get() ), m_process( nullptr )
+	:	m_context( g_defaultContext.get() ), m_process( nullptr ), m_monitors( &g_defaultMonitors )
 {
 }
 

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -143,14 +143,12 @@ struct HashProcessKey : public HashCacheKey
 	HashProcessKey( const ValuePlug *plug, const ValuePlug *downstreamPlug, const Context *context, const ComputeNode *computeNode, ValuePlug::CachePolicy cachePolicy )
 		:	HashCacheKey( plug, context ),
 			downstreamPlug( downstreamPlug ),
-			context( context ),
 			computeNode( computeNode ),
 			cachePolicy( cachePolicy )
 	{
 	}
 
 	const ValuePlug *downstreamPlug;
-	const Context *context;
 	const ComputeNode *computeNode;
 	const ValuePlug::CachePolicy cachePolicy;
 };
@@ -265,7 +263,7 @@ class ValuePlug::HashProcess : public Process
 	private :
 
 		HashProcess( const HashProcessKey &key )
-			:	Process( staticType, key.plug, key.downstreamPlug, key.context )
+			:	Process( staticType, key.plug, key.downstreamPlug )
 		{
 			try
 			{
@@ -379,10 +377,9 @@ namespace
 // function.
 struct ComputeProcessKey
 {
-	ComputeProcessKey( const ValuePlug *plug, const ValuePlug *downstreamPlug, const Context *context, const ComputeNode *computeNode, ValuePlug::CachePolicy cachePolicy, const IECore::MurmurHash *precomputedHash )
+	ComputeProcessKey( const ValuePlug *plug, const ValuePlug *downstreamPlug, const ComputeNode *computeNode, ValuePlug::CachePolicy cachePolicy, const IECore::MurmurHash *precomputedHash )
 		:	plug( plug ),
 			downstreamPlug( downstreamPlug ),
-			context( context ),
 			computeNode( computeNode ),
 			cachePolicy( cachePolicy ),
 			m_hash( precomputedHash ? *precomputedHash : IECore::MurmurHash() )
@@ -391,7 +388,6 @@ struct ComputeProcessKey
 
 	const ValuePlug *plug;
 	const ValuePlug *downstreamPlug;
-	const Context *context;
 	const ComputeNode *computeNode;
 	const ValuePlug::CachePolicy cachePolicy;
 
@@ -463,7 +459,7 @@ class ValuePlug::ComputeProcess : public Process
 			// it with a ComputeProcess.
 
 			const ComputeNode *computeNode = IECore::runTimeCast<const ComputeNode>( p->node() );
-			const ComputeProcessKey processKey( p, plug, Context::current(), computeNode, computeNode ? computeNode->computeCachePolicy( p ) : CachePolicy::Uncached, precomputedHash );
+			const ComputeProcessKey processKey( p, plug, computeNode, computeNode ? computeNode->computeCachePolicy( p ) : CachePolicy::Uncached, precomputedHash );
 
 			if( processKey.cachePolicy == CachePolicy::Uncached )
 			{
@@ -527,7 +523,7 @@ class ValuePlug::ComputeProcess : public Process
 	private :
 
 		ComputeProcess( const ComputeProcessKey &key )
-			:	Process( staticType, key.plug, key.downstreamPlug, key.context )
+			:	Process( staticType, key.plug, key.downstreamPlug )
 		{
 			try
 			{

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -286,8 +286,20 @@ ImagePlug::GlobalScope::GlobalScope( const Gaffer::Context *context )
 	remove( tileOriginContextName );
 }
 
+ImagePlug::GlobalScope::GlobalScope( const Gaffer::ThreadState &threadState )
+	:	EditableScope( threadState )
+{
+	remove( channelNameContextName );
+	remove( tileOriginContextName );
+}
+
 ImagePlug::ChannelDataScope::ChannelDataScope( const Gaffer::Context *context )
 	:   EditableScope( context )
+{
+}
+
+ImagePlug::ChannelDataScope::ChannelDataScope( const Gaffer::ThreadState &threadState )
+	:	EditableScope( threadState )
 {
 }
 

--- a/src/GafferImageTestModule/GafferImageTestModule.cpp
+++ b/src/GafferImageTestModule/GafferImageTestModule.cpp
@@ -43,6 +43,7 @@
 
 #include "Gaffer/Node.h"
 
+#include "IECorePython/RefCountedBinding.h"
 #include "IECorePython/ScopedGILRelease.h"
 
 using namespace boost::python;
@@ -102,7 +103,9 @@ boost::signals::connection connectProcessTilesToPlugDirtiedSignal( GafferImage::
 
 BOOST_PYTHON_MODULE( _GafferImageTest )
 {
-	class_<ContextSanitiser, bases<Gaffer::Monitor>, boost::noncopyable>( "ContextSanitiser" );
+	IECorePython::RefCountedClass<ContextSanitiser, Gaffer::Monitor>( "ContextSanitiser" )
+		.def( init<>() )
+	;
 
 	def( "processTiles", &processTilesWrapper );
 	def( "connectProcessTilesToPlugDirtiedSignal", &connectProcessTilesToPlugDirtiedSignal );

--- a/src/GafferModule/MonitorBinding.cpp
+++ b/src/GafferModule/MonitorBinding.cpp
@@ -46,6 +46,7 @@
 #include "Gaffer/Plug.h"
 #include "Gaffer/VTuneMonitor.h"
 
+#include "IECorePython/RefCountedBinding.h"
 #include "IECorePython/ScopedGILRelease.h"
 
 #include "boost/format.hpp"
@@ -211,7 +212,7 @@ void GafferModule::bindMonitor()
 		);
 	}
 
-	class_<Monitor, boost::noncopyable>( "Monitor", no_init )
+	IECorePython::RefCountedClass<Monitor, IECore::RefCounted>( "Monitor" )
 		.def( "setActive", &Monitor::setActive )
 		.def( "getActive", &Monitor::getActive )
 		.def( "__enter__", &enterScope, return_self<>() )
@@ -219,7 +220,8 @@ void GafferModule::bindMonitor()
 	;
 
 	{
-		scope s = class_<PerformanceMonitor, bases<Monitor>, boost::noncopyable >( "PerformanceMonitor" )
+		scope s = IECorePython::RefCountedClass<PerformanceMonitor, Monitor>( "PerformanceMonitor" )
+			.def( init<>() )
 			.def( "allStatistics", &allStatistics<PerformanceMonitor> )
 			.def( "plugStatistics", &PerformanceMonitor::plugStatistics, return_value_policy<copy_const_reference>() )
 			.def( "combinedStatistics", &PerformanceMonitor::combinedStatistics, return_value_policy<copy_const_reference>() )
@@ -246,7 +248,7 @@ void GafferModule::bindMonitor()
 	}
 
 	{
-		scope s = class_<ContextMonitor, bases<Monitor>, boost::noncopyable>( "ContextMonitor", no_init )
+		scope s = IECorePython::RefCountedClass<ContextMonitor, Monitor>( "ContextMonitor" )
 			.def( init<const GraphComponent *>( arg( "root" ) = object() ) )
 			.def( "allStatistics", &allStatistics<ContextMonitor> )
 			.def( "plugStatistics", &ContextMonitor::plugStatistics, return_value_policy<copy_const_reference>() )
@@ -264,7 +266,7 @@ void GafferModule::bindMonitor()
 
 #ifdef GAFFER_VTUNE
 	{
-		scope s = class_<VTuneMonitor, bases<Monitor>, boost::noncopyable>( "VTuneMonitor" )
+		scope s = IECorePython::RefCountedClass<VTuneMonitor, Monitor>( "VTuneMonitor" )
 			.def( init<bool>(
 					(
 						arg( "monitorHashProcess" ) = false )

--- a/src/GafferModule/MonitorBinding.cpp
+++ b/src/GafferModule/MonitorBinding.cpp
@@ -58,18 +58,6 @@ using namespace Gaffer::MonitorAlgo;
 namespace
 {
 
-void enterScope( Monitor &m )
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	m.setActive( true );
-}
-
-void exitScope( Monitor &m, object type, object value, object traceBack )
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	m.setActive( false );
-}
-
 std::string repr( PerformanceMonitor::Statistics &s )
 {
 	return boost::str(
@@ -212,12 +200,12 @@ void GafferModule::bindMonitor()
 		);
 	}
 
-	IECorePython::RefCountedClass<Monitor, IECore::RefCounted>( "Monitor" )
-		.def( "setActive", &Monitor::setActive )
-		.def( "getActive", &Monitor::getActive )
-		.def( "__enter__", &enterScope, return_self<>() )
-		.def( "__exit__", &exitScope )
-	;
+	{
+		scope s = IECorePython::RefCountedClass<Monitor, IECore::RefCounted>( "Monitor" );
+
+		class_<Monitor::Scope, boost::noncopyable>( "_Scope", init<Monitor *>() )
+		;
+	}
 
 	{
 		scope s = IECorePython::RefCountedClass<PerformanceMonitor, Monitor>( "PerformanceMonitor" )

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -348,6 +348,8 @@ class CapturingMonitor : public Monitor
 		{
 		}
 
+		IE_CORE_DECLAREMEMBERPTR( CapturingMonitor )
+
 		const CapturedProcess::PtrVector &rootProcesses()
 		{
 			return m_rootProcesses;
@@ -410,6 +412,8 @@ class CapturingMonitor : public Monitor
 		CapturedProcess::PtrVector m_rootProcesses;
 
 };
+
+IE_CORE_DECLAREPTR( CapturingMonitor )
 
 InternedString g_contextUniquefierName = "__sceneAlgoHistory:uniquefier";
 uint64_t g_contextUniquefierValue = 0;
@@ -503,16 +507,16 @@ SceneAlgo::History::Ptr SceneAlgo::history( const Gaffer::ValuePlug *scenePlugCh
 		) );
 	}
 
-	CapturingMonitor monitor;
+	CapturingMonitorPtr monitor = new CapturingMonitor;
 	{
 		ScenePlug::PathScope pathScope( Context::current(), path );
 		// Trick to bypass the hash cache and get a full upstream evaluation.
 		pathScope.set( g_contextUniquefierName, g_contextUniquefierValue++ );
-		Monitor::Scope monitorScope( &monitor );
+		Monitor::Scope monitorScope( monitor );
 		scenePlugChild->hash();
 	}
-	assert( monitor.rootProcesses().size() == 1 );
-	return historyWalk( monitor.rootProcesses().front().get(), scenePlugChild->getName(), nullptr );
+	assert( monitor->rootProcesses().size() == 1 );
+	return historyWalk( monitor->rootProcesses().front().get(), scenePlugChild->getName(), nullptr );
 }
 
 ScenePlug *SceneAlgo::source( const ScenePlug *scene, const ScenePlug::ScenePath &path )

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -264,6 +264,17 @@ ScenePlug::PathScope::PathScope( const Gaffer::Context *context, const ScenePath
 	setPath( scenePath );
 }
 
+ScenePlug::PathScope::PathScope( const Gaffer::ThreadState &threadState )
+	:	EditableScope( threadState )
+{
+}
+
+ScenePlug::PathScope::PathScope( const Gaffer::ThreadState &threadState, const ScenePath &scenePath )
+	:	EditableScope( threadState )
+{
+	setPath( scenePath );
+}
+
 void ScenePlug::PathScope::setPath( const ScenePath &scenePath )
 {
 	set( scenePathContextName, scenePath );
@@ -284,6 +295,21 @@ ScenePlug::SetScope::SetScope( const Gaffer::Context *context, const IECore::Int
 	setSetName( setName );
 }
 
+ScenePlug::SetScope::SetScope( const Gaffer::ThreadState &threadState )
+	:	EditableScope( threadState )
+{
+	remove( Filter::inputSceneContextName );
+	remove( ScenePlug::scenePathContextName );
+}
+
+ScenePlug::SetScope::SetScope( const Gaffer::ThreadState &threadState, const IECore::InternedString &setName )
+	:	EditableScope( threadState )
+{
+	remove( Filter::inputSceneContextName );
+	remove( ScenePlug::scenePathContextName );
+	setSetName( setName );
+}
+
 void ScenePlug::SetScope::setSetName( const IECore::InternedString &setName )
 {
 	set( setNameContextName, setName );
@@ -291,6 +317,14 @@ void ScenePlug::SetScope::setSetName( const IECore::InternedString &setName )
 
 ScenePlug::GlobalScope::GlobalScope( const Gaffer::Context *context )
 	:	EditableScope( context )
+{
+	remove( Filter::inputSceneContextName );
+	remove( scenePathContextName );
+	remove( setNameContextName );
+}
+
+ScenePlug::GlobalScope::GlobalScope( const Gaffer::ThreadState &threadState )
+	:	EditableScope( threadState )
 {
 	remove( Filter::inputSceneContextName );
 	remove( scenePathContextName );

--- a/src/GafferSceneTestModule/GafferSceneTestModule.cpp
+++ b/src/GafferSceneTestModule/GafferSceneTestModule.cpp
@@ -60,7 +60,9 @@ static void traverseSceneWrapper( const GafferScene::ScenePlug *scenePlug )
 BOOST_PYTHON_MODULE( _GafferSceneTest )
 {
 
-	class_<ContextSanitiser, bases<Gaffer::Monitor>, boost::noncopyable>( "ContextSanitiser" );
+	IECorePython::RefCountedClass<ContextSanitiser, Gaffer::Monitor>( "ContextSanitiser" )
+		.def( init<>() )
+	;
 
 	GafferBindings::DependencyNodeClass<CompoundObjectSource>();
 	GafferBindings::NodeClass<TestShader>();

--- a/src/GafferTest/ContextTest.cpp
+++ b/src/GafferTest/ContextTest.cpp
@@ -71,16 +71,13 @@ void GafferTest::testManyContexts()
 	// change a value or two, and then continue.
 
 	Timer t;
-	for( int i = 0; i < 100000; ++i )
+	for( int i = 0; i < 1000000; ++i )
 	{
 		ContextPtr tmp = new Context( *base, Context::Borrowed );
 		tmp->set( keys[i%numKeys], i );
 		GAFFERTEST_ASSERT( tmp->get<int>( keys[i%numKeys] ) == i );
 		GAFFERTEST_ASSERT( tmp->hash() != baseHash );
 	}
-
-	// uncomment to get timing information
-	//std::cerr << t.stop() << std::endl;
 }
 
 // Useful for assessing the performance of substitutions.
@@ -99,9 +96,6 @@ void GafferTest::testManySubstitutions()
 		const std::string s = context->substitute( phrase );
 		GAFFERTEST_ASSERT( s == expectedResult );
 	}
-
-	// uncomment to get timing information
-	//std::cerr << t.stop() << std::endl;
 }
 
 // Useful for assessing the performance of environment variable substitutions.
@@ -118,9 +112,6 @@ void GafferTest::testManyEnvironmentSubstitutions()
 		const std::string s = context->substitute( phrase );
 		GAFFERTEST_ASSERT( s == expectedResult );
 	}
-
-	// uncomment to get timing information
-	//std::cerr << t.stop() << std::endl;
 }
 
 // Tests that scoping a null context is a no-op


### PR DESCRIPTION
This introduces a ThreadState class which consolidates the thread-local stacks for Contexts and Processes into a single spot. This allows us to transfer state appropriately between threads when using TBB tasks, meaning that `Process:parent()` is now accurate even when task-stealing takes place. It also allows to refactor Monitors so that they are scoped properly on a per-thread basis. This should fix a nasty crash bug involving interaction between the TransformTool and the Catalogue.

In the process of doing this work, I discovered a similar but less critical problem involving the Process `errorSource`. Time constraints have meant I wasn't able to fix it yet, but I've included some comments based on my investigations so far.