### PR TITLE
CustomAttributes : extraAttributes affects the output

### DIFF
--- a/python/GafferSceneTest/CustomAttributesTest.py
+++ b/python/GafferSceneTest/CustomAttributesTest.py
@@ -283,9 +283,11 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 		p = Gaffer.NameValuePlug( "user:test", 10, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["a"]["attributes"].addChild( p )
 		self.assertEqual( set( s["a"].affects( p["value"] ) ), set( [ s["a"]["out"]["attributes"] ] ) )
+		self.assertEqual( set( s["a"].affects( s["a"]["extraAttributes"] ) ), set( [ s["a"]["out"]["attributes"] ] ) )
 
 		s["a"]["global"].setValue( True )
 		self.assertEqual( set( s["a"].affects( p["value"] ) ), set( [ s["a"]["out"]["globals"] ] ) )
+		self.assertEqual( set( s["a"].affects( s["a"]["extraAttributes"] ) ), set( [ s["a"]["out"]["globals"] ] ) )
 
 		s["e"] = Gaffer.Expression()
 		s["e"].setExpression( """parent["a"]["global"] = context.getFrame() > 10""" )

--- a/src/GafferScene/Attributes.cpp
+++ b/src/GafferScene/Attributes.cpp
@@ -105,7 +105,7 @@ void Attributes::affects( const Gaffer::Plug *input, AffectedPlugsContainer &out
 {
 	SceneElementProcessor::affects( input, outputs );
 
-	if( attributesPlug()->isAncestorOf( input ) || input == globalPlug() )
+	if( attributesPlug()->isAncestorOf( input ) || input == globalPlug() || input == extraAttributesPlug() )
 	{
 		// We can only affect a particular output if we haven't
 		// connected it as a pass-through in updateInternalConnections().


### PR DESCRIPTION
- CustomAttributes : extraAttributes affects the output

Missed updating the `affects()` method when adding the `extraAttributes` plug.
That was preventing the SceneInspector panel from automatically updating.

