### PR TITLE
Timeline : Draw the frame number next to the playhead

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Improvements
 - Expression : Improved error message when Python expression assigns an invalid value.
 - Numeric Bookmarks : Changed the Editor <kbd>1</kbd>-<kbd>9</kbd> hotkeys to follow the bookmark rather than pinning it (#4074).
 - Editors : Simplified the Editor Focus Menu, removing some seldom used (but potentially ambiguous) modes (#4074).
+- Timeline : Added support for sub-frame dragging with a <kbd>Ctrl</kbd> modifier, and fixed snapping of the frame indicator for regular drag operations.
 
 Fixes
 -----
@@ -18,6 +19,7 @@ API
 ---
 
 - Serialisation : Added `addModule()` method, for adding imports to the serialisation.
+- Slider : Added optional value snapping for drag and button press operations. This is controlled via the `setSnapIncrement()` and `getSnapIncrement()` methods.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -8,7 +8,9 @@ Improvements
 - Expression : Improved error message when Python expression assigns an invalid value.
 - Numeric Bookmarks : Changed the Editor <kbd>1</kbd>-<kbd>9</kbd> hotkeys to follow the bookmark rather than pinning it (#4074).
 - Editors : Simplified the Editor Focus Menu, removing some seldom used (but potentially ambiguous) modes (#4074).
-- Timeline : Added support for sub-frame dragging with a <kbd>Ctrl</kbd> modifier, and fixed snapping of the frame indicator for regular drag operations.
+- Timeline :
+  - Added support for sub-frame dragging with a <kbd>Ctrl</kbd> modifier, and fixed snapping of the frame indicator for regular drag operations.
+  - The current frame is now drawn next to the playhead.
 
 Fixes
 -----
@@ -33,6 +35,7 @@ Breaking Changes
   - Removed `positionChangedSignal()` from `Slider`. Use `valueChangedSignal()` instead.
   - Removed `PositionChangedReason` from `Slider`. Use `ValueChangedReason` instead.
   - Removed `setPositionIncrement()/getPositionIncrement()` from `Slider`. Use `setIncrement()/getIncrement()` instead.
+  - Replaced `_drawPosition()` method with `_drawValue()`.
 - StandardOptions : Removed `cameraBlur` plug. This never functioned as advertised, as the regular `transformBlur` and `deformationBlur` blur settings were applied to cameras instead. As before, a StandardAttributes node may be used to customise blur for individual cameras.
 - SceneAlgo : Changed signature of the following methods to use `GafferScene::FilterPlug` : `matchingPaths`, `filteredParallelTraverse`, `Detail::ThreadableFilteredFunctor`.
 - DeleteFaces / DeletePoints / DeleteCurves : The PrimitiveVariable name is now taken verbatim, rather than stripping whitespace.

--- a/Changes.md
+++ b/Changes.md
@@ -19,7 +19,9 @@ API
 ---
 
 - Serialisation : Added `addModule()` method, for adding imports to the serialisation.
-- Slider : Added optional value snapping for drag and button press operations. This is controlled via the `setSnapIncrement()` and `getSnapIncrement()` methods.
+- Slider :
+  - Added optional value snapping for drag and button press operations. This is controlled via the `setSnapIncrement()` and `getSnapIncrement()` methods.
+  - Added `setHoverPositionVisible()` and `getHoverPositionVisible()` accessors to control an optional position indicator drawn under the pointer.
 
 Breaking Changes
 ----------------

--- a/python/GafferUI/Slider.py
+++ b/python/GafferUI/Slider.py
@@ -387,10 +387,10 @@ class Slider( GafferUI.Widget ) :
 		if index is not None :
 			self.setSelectedIndex( index )
 			if len( self.getValues() ) == 1 :
-				self.__setValueInternal( index, self.__positionToValue( event.line.p0.x, clamp = True ), self.ValueChangedReason.Click )
+				self.__setValueInternal( index, self.__eventValue( event ), self.ValueChangedReason.Click )
 		elif self.getSizeEditable() :
 			values = self.getValues()[:]
-			values.append( self.__positionToValue( event.line.p0.x, clamp = True ) )
+			values.append( self.__eventValue( event ) )
 			self.__setValuesInternal( values, self.ValueChangedReason.IndexAdded )
 			self.setSelectedIndex( len( self.getValues() ) - 1 )
 
@@ -414,10 +414,7 @@ class Slider( GafferUI.Widget ) :
 
 		self.__setValueInternal(
 			self.getSelectedIndex(),
-			self.__positionToValue(
-				event.line.p0.x,
-				clamp = not (event.modifiers & event.modifiers.Shift )
-			),
+			self.__eventValue( event ),
 			self.ValueChangedReason.DragMove
 		)
 
@@ -501,11 +498,12 @@ class Slider( GafferUI.Widget ) :
 
 		signal( self, reason )
 
-	def __positionToValue( self, position, clamp = False ) :
+	def __eventValue( self, event ) :
 
-		f = position / float( self.size().x )
+		f = event.line.p0.x / float( self.size().x )
 		value = self.__min + ( self.__max - self.__min ) * f
-		if clamp :
+		if not (event.modifiers & event.modifiers.Shift) :
+			# Clamp
 			value = max( self.__min, min( self.__max, value ) )
 
 		return value

--- a/python/GafferUI/Slider.py
+++ b/python/GafferUI/Slider.py
@@ -335,7 +335,7 @@ class Slider( GafferUI.Widget ) :
 		else :
 			painter.drawEllipse( QtCore.QPoint( position, size.y / 2 ), size.y / 4, size.y / 4 )
 
-	def _indexUnderMouse( self ) :
+	def __indexUnderMouse( self ) :
 
 		size = self.size()
 		mousePosition = GafferUI.Widget.mousePosition( relativeTo = self ).x
@@ -383,7 +383,7 @@ class Slider( GafferUI.Widget ) :
 		if event.buttons != GafferUI.ButtonEvent.Buttons.Left :
 			return
 
-		index = self._indexUnderMouse()
+		index = self.__indexUnderMouse()
 		if index is not None :
 			self.setSelectedIndex( index )
 			if len( self.getValues() ) == 1 :
@@ -513,6 +513,26 @@ class Slider( GafferUI.Widget ) :
 		f = ( value - self.__min ) / ( self.__max - self.__min )
 		return f * self.size().x
 
+	def __draw( self, painter ) :
+
+		self._drawBackground( painter )
+
+		indexUnderMouse = self.__indexUnderMouse()
+		for index, value in enumerate( self.getValues() ) :
+			self._drawPosition(
+				painter,
+				self.__valueToPosition( value ),
+				highlighted = index == indexUnderMouse or index == self.getSelectedIndex()
+			)
+
+		if indexUnderMouse is None and self.getSizeEditable() and self._entered :
+			self._drawPosition(
+				painter,
+				GafferUI.Widget.mousePosition( relativeTo = self ).x,
+				highlighted = True,
+				opacity = 0.5
+			)
+
 class _Widget( QtWidgets.QWidget ) :
 
 	def __init__( self, parent=None ) :
@@ -533,23 +553,7 @@ class _Widget( QtWidgets.QWidget ) :
 		painter = QtGui.QPainter( self )
 		painter.setRenderHint( QtGui.QPainter.Antialiasing )
 
-		owner._drawBackground( painter )
-
-		indexUnderMouse = owner._indexUnderMouse()
-		for index, value in enumerate( owner.getValues() ) :
-			owner._drawPosition(
-				painter,
-				owner._Slider__valueToPosition( value ),
-				highlighted = index == indexUnderMouse or index == owner.getSelectedIndex()
-			)
-
-		if indexUnderMouse is None and owner.getSizeEditable() and owner._entered :
-			owner._drawPosition(
-				painter,
-				GafferUI.Widget.mousePosition( relativeTo = owner ).x,
-				highlighted = True,
-				opacity = 0.5
-			)
+		owner._Slider__draw( painter )
 
 	def event( self, event ) :
 

--- a/python/GafferUI/Slider.py
+++ b/python/GafferUI/Slider.py
@@ -240,25 +240,6 @@ class Slider( GafferUI.Widget ) :
 
 		return self.__increment
 
-	def __setValuesInternal( self, values, reason ) :
-
-		# We _always_ clamp to the hard min and max, as those are not optional.
-		# Optional clamping to soft min and max is performed before calling this
-		# function.
-		values = [ max( self.__hardMin, min( self.__hardMax, x ) ) for x in values ]
-
-		dragBeginOrEnd = reason in ( self.ValueChangedReason.DragBegin, self.ValueChangedReason.DragEnd )
-		if values == self.__values and not dragBeginOrEnd :
-			# early out if the values haven't changed, but not if the
-			# reason is either end of a drag - we always signal those so
-			# that they will always come in matching pairs.
-			return
-
-		self.__values = values
-		self._qtWidget().update()
-
-		self.__emitValueChanged( reason )
-
 	## \todo Colours should come from some unified style somewhere
 	def _drawBackground( self, painter ) :
 
@@ -491,6 +472,25 @@ class Slider( GafferUI.Widget ) :
 		values = self.getValues()[:]
 		values[index] = value
 		self.__setValuesInternal( values, reason )
+
+	def __setValuesInternal( self, values, reason ) :
+
+		# We _always_ clamp to the hard min and max, as those are not optional.
+		# Optional clamping to soft min and max is performed before calling this
+		# function, typically in `__eventValue()`.
+		values = [ max( self.__hardMin, min( self.__hardMax, x ) ) for x in values ]
+
+		dragBeginOrEnd = reason in ( self.ValueChangedReason.DragBegin, self.ValueChangedReason.DragEnd )
+		if values == self.__values and not dragBeginOrEnd :
+			# early out if the values haven't changed, but not if the
+			# reason is either end of a drag - we always signal those so
+			# that they will always come in matching pairs.
+			return
+
+		self.__values = values
+		self._qtWidget().update()
+
+		self.__emitValueChanged( reason )
 
 	def __emitValueChanged( self, reason ) :
 

--- a/python/GafferUI/Slider.py
+++ b/python/GafferUI/Slider.py
@@ -78,6 +78,7 @@ class Slider( GafferUI.Widget ) :
 		self.__sizeEditable = False
 		self.__minimumSize = 1
 		self.__increment = None
+		self.__snapIncrement = None
 		self.__hoverEvent = None # The mouseMove event that gives us hover status
 
 		self.leaveSignal().connect( Gaffer.WeakMethod( self.__leave ), scoped = False )
@@ -238,6 +239,17 @@ class Slider( GafferUI.Widget ) :
 	def getIncrement( self ) :
 
 		return self.__increment
+
+	## Sets the increment used for snapping values generated
+	# by interactions such as drags and button presses. Snapping
+	# can be ignored by by holding the `Ctrl` modifier.
+	def setSnapIncrement( self, increment ) :
+
+		self.__snapIncrement = increment
+
+	def getSnapIncrement( self ) :
+
+		return self.__snapIncrement
 
 	## \todo Colours should come from some unified style somewhere
 	def _drawBackground( self, painter ) :
@@ -505,6 +517,9 @@ class Slider( GafferUI.Widget ) :
 		if not (event.modifiers & event.modifiers.Shift) :
 			# Clamp
 			value = max( self.__min, min( self.__max, value ) )
+		if self.__snapIncrement and not (event.modifiers & GafferUI.ModifiableEvent.Modifiers.Control) :
+			# Snap
+			value = self.__snapIncrement * round( value / self.__snapIncrement )
 
 		return value
 

--- a/python/GafferUI/Slider.py
+++ b/python/GafferUI/Slider.py
@@ -79,6 +79,7 @@ class Slider( GafferUI.Widget ) :
 		self.__minimumSize = 1
 		self.__increment = None
 		self.__snapIncrement = None
+		self.__hoverPositionVisible = False
 		self.__hoverEvent = None # The mouseMove event that gives us hover status
 
 		self.leaveSignal().connect( Gaffer.WeakMethod( self.__leave ), scoped = False )
@@ -250,6 +251,14 @@ class Slider( GafferUI.Widget ) :
 	def getSnapIncrement( self ) :
 
 		return self.__snapIncrement
+
+	def setHoverPositionVisible( self, visible ) :
+
+		self.__hoverPositionVisible = visible
+
+	def getHoverPositionVisible( self ) :
+
+		return self.__hoverPositionVisible
 
 	## \todo Colours should come from some unified style somewhere
 	def _drawBackground( self, painter ) :
@@ -540,13 +549,21 @@ class Slider( GafferUI.Widget ) :
 				highlighted = index == indexUnderMouse or index == self.getSelectedIndex()
 			)
 
-		if indexUnderMouse is None and self.getSizeEditable() and self.__hoverEvent is not None :
-			self._drawPosition(
-				painter,
-				self.__valueToPosition( self.__eventValue( self.__hoverEvent ) ),
-				highlighted = True,
+		if self.__hoverEvent is not None :
+
+			opacity = None
+			if self.getSizeEditable() and indexUnderMouse is None :
 				opacity = 0.5
-			)
+			elif self.getHoverPositionVisible() :
+				opacity = 0.25
+
+			if opacity :
+				self._drawPosition(
+					painter,
+					self.__valueToPosition( self.__eventValue( self.__hoverEvent ) ),
+					highlighted = True,
+					opacity = opacity
+				)
 
 class _Widget( QtWidgets.QWidget ) :
 

--- a/python/GafferUI/Timeline.py
+++ b/python/GafferUI/Timeline.py
@@ -151,13 +151,7 @@ class Timeline( GafferUI.Editor ) :
 
 		assert( widget is self.__slider or widget is self.__frame )
 
-		if widget is self.__slider :
-			## \todo Have the rounding come from Slider, and allow the shift
-			# modifier to choose fractional frame values.
-			frame = int( self.__slider.getValue() )
-		else :
-			frame = self.__frame.getValue()
-
+		frame = widget.getValue()
 		frame = float( max( frame, self.scriptNode()["frameRange"]["start"].getValue() ) )
 		frame = float( min( frame, self.scriptNode()["frameRange"]["end"].getValue() ) )
 

--- a/python/GafferUI/Timeline.py
+++ b/python/GafferUI/Timeline.py
@@ -75,6 +75,8 @@ class Timeline( GafferUI.Editor ) :
 				parenting = { "expand" : True },
 			)
 			self.__slider.setIncrement( 0 ) # disable so the slider doesn't mask our global frame increment shortcut
+			self.__slider.setSnapIncrement( 1 )
+			self.__slider.setHoverPositionVisible( True )
 			self.__sliderValueChangedConnection = self.__slider.valueChangedSignal().connect( Gaffer.WeakMethod( self.__valueChanged ), scoped = False )
 
 			self.__startButton = GafferUI.Button( image = "timelineStart.png", hasFrame=False )
@@ -250,8 +252,34 @@ class _TimelineSlider( GafferUI.Slider ) :
 
 		GafferUI.Slider.__init__( self, value, min, max, **kw )
 
-	def _drawPosition( self, painter, position, highlighted, opacity=1 ) :
+	def _drawValue( self, painter, value, position, state ) :
 
 		size = self.size()
-		# \todo: make sure the TimelineSlider and the AnimationGadget always use the same color
-		painter.fillRect( position, 0, 2, size.y, QtGui.QColor( 240, 220, 40, 255 * opacity ) )
+
+		color = QtGui.QColor( 120, 120, 120 ) if state == state.DisabledState else QtGui.QColor( 240, 220, 40 )
+		painter.setPen( color )
+
+		# Draw vertical line at position ensuring we don't clip it
+		# at the edges of the widget.
+
+		lineWidth = 2
+		position = max( min( int( position ) - ( lineWidth / 2 ), size.x - lineWidth ), 0 )
+		painter.fillRect( position, 0, lineWidth, size.y, color )
+
+		# Draw frame number to the left of the playhead (unless we'd go off the
+		# edge). Most cursors are pointing to the left so this makes it easier
+		# to read the number when hovering.
+
+		font = painter.font()
+		font.setPixelSize( 10 )
+		painter.setFont( font )
+
+		frameText = GafferUI.NumericWidget.valueToString( value )
+		frameTextSize = QtGui.QFontMetrics( painter.font() ).size( QtCore.Qt.TextSingleLine, frameText )
+
+		textMargin = 6
+		textX = position - frameTextSize.width() - textMargin
+		if textX < textMargin :
+			textX = position + textMargin
+
+		painter.drawText( textX, frameTextSize.height(), frameText )


### PR DESCRIPTION
Straw person implementation for consideration.

![image](https://user-images.githubusercontent.com/896779/59437742-0529cd00-8dea-11e9-8623-49251908319a.png)

User facing changes :

 - The Timeline will now display the current frame number next to the
   playhead.

 - The Timeline will preview the frame number under the cursor when
   hovering over the timeline area to make frame selection easier.

Due to the way `paintEvent` is implemented in `Slider` I couldn't find a sensible way to scope this to a `Timeline` specific implementation. As such, this the introduces the concept of mouse interaction snapping to `Slider` and consequently `NumericSlider`.  It its implemented such that its effect is scoped to mouse actions, rather than all position/value sets.

TODO: What level of test coverage do we want for something like this?