### PR TITLE
ImageView : Make 'f' sticky untill the camera is manually changed

### DIFF
--- a/include/GafferImageUI/ImageView.h
+++ b/include/GafferImageUI/ImageView.h
@@ -130,8 +130,12 @@ class GAFFERIMAGEUI_API ImageView : public GafferUI::View
 		const GafferImage::ImageProcessor *displayTransformNode() const;
 
 		void plugSet( Gaffer::Plug *plug );
+		void plugDirtied( Gaffer::Plug *plug );
 		bool keyPress( const GafferUI::KeyEvent &event );
 		void preRender();
+
+		boost::signals::scoped_connection m_viewportCameraChangedConnection;
+		void viewportCameraChanged();
 
 		void insertDisplayTransform();
 
@@ -140,6 +144,9 @@ class GAFFERIMAGEUI_API ImageView : public GafferUI::View
 
 		ImageGadgetPtr m_imageGadget;
 		bool m_framed;
+		bool m_reframeOnChange;
+
+		bool reframeToFit();
 
 		class ChannelChooser;
 		std::unique_ptr<ChannelChooser> m_channelChooser;

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -50,6 +50,7 @@
 #include "GafferUI/StandardStyle.h"
 #include "GafferUI/Style.h"
 
+#include "Gaffer/BlockedConnection.h"
 #include "Gaffer/Context.h"
 #include "Gaffer/DeleteContextVariables.h"
 #include "Gaffer/StringPlug.h"
@@ -357,7 +358,8 @@ ImageView::ViewDescription<ImageView> ImageView::g_viewDescription( GafferImage:
 ImageView::ImageView( const std::string &name )
 	:	View( name, new GafferImage::ImagePlug() ),
 		m_imageGadget( new ImageGadget() ),
-		m_framed( false )
+		m_framed( false ),
+		m_reframeOnChange( false )
 {
 
 	// build the preprocessor we use for applying colour
@@ -407,8 +409,10 @@ ImageView::ImageView( const std::string &name )
 	// connect up to some signals
 
 	plugSetSignal().connect( boost::bind( &ImageView::plugSet, this, ::_1 ) );
+	plugDirtiedSignal().connect( boost::bind( &ImageView::plugDirtied, this, ::_1 ) );
 	viewportGadget()->keyPressSignal().connect( boost::bind( &ImageView::keyPress, this, ::_2 ) );
 	viewportGadget()->preRenderSignal().connect( boost::bind( &ImageView::preRender, this ) );
+	m_viewportCameraChangedConnection = viewportGadget()->cameraChangedSignal().connect( boost::bind( &ImageView::viewportCameraChanged, this ) );
 
 	// get our display transform right
 
@@ -549,14 +553,39 @@ void ImageView::plugSet( Gaffer::Plug *plug )
 	}
 }
 
+void ImageView::plugDirtied( Gaffer::Plug *plug )
+{
+	if( plug == inPlug() )
+	{
+		if( m_reframeOnChange )
+		{
+			m_framed = false;
+		}
+	}
+}
+
+
+bool ImageView::reframeToFit()
+{
+	const Box3f b = m_imageGadget->bound();
+	if( !b.isEmpty() && viewportGadget()->getCameraEditable() )
+	{
+		BlockedConnection blockedConnection( m_viewportCameraChangedConnection );
+		viewportGadget()->frame( b );
+		m_framed = true;
+		return true;
+	}
+
+	return false;
+}
+
 bool ImageView::keyPress( const GafferUI::KeyEvent &event )
 {
 	if( event.key == "F" && !event.modifiers )
 	{
-		const Box3f b = m_imageGadget->bound();
-		if( !b.isEmpty() && viewportGadget()->getCameraEditable() )
+		m_reframeOnChange = true;
+		if( reframeToFit() )
 		{
-			viewportGadget()->frame( b );
 			return true;
 		}
 	}
@@ -588,14 +617,12 @@ void ImageView::preRender()
 		return;
 	}
 
-	const Box3f b = m_imageGadget->bound();
-	if( b.isEmpty() )
-	{
-		return;
-	}
+	reframeToFit();
+}
 
-	viewportGadget()->frame( b );
-	m_framed = true;
+void ImageView::viewportCameraChanged()
+{
+	m_reframeOnChange = false;
 }
 
 void ImageView::insertDisplayTransform()


### PR DESCRIPTION
Draft to get user feedback on this one, to see if it just 'works as youd want it to' or it needs to be indicated in the viewer/different.

User facing changes:

 - Pressing the `f` in the viewer is now 'sticky', in that, the viewer will now adjust the framing whilst viewing different images so they always fit until the camera is manually changed (via the mouse or other zoom key). Previously it would only fit the specific image being viewed when the key was pressed.
