### PR TITLE
CompoundEditor : Add tab close buttons

### DIFF
--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -397,6 +397,7 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 		self.__dropConnection = self.dropSignal().connect( Gaffer.WeakMethod( self.__drop ) )
 
 		tabBar = self._qtWidget().tabBar()
+		tabBar.setProperty( "gafferHasTabCloseButtons", GafferUI._Variant.toVariant( True ) )
 		tabBar.setContextMenuPolicy( QtCore.Qt.CustomContextMenu )
 		tabBar.customContextMenuRequested.connect( Gaffer.WeakMethod( self.__tabContextMenu ) )
 
@@ -418,6 +419,8 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 		editor.__titleChangedConnection = editor.titleChangedSignal().connect( Gaffer.WeakMethod( self.__titleChanged ) )
 
 		self.__updateStyles()
+
+		self.__configureTab( editor )
 
 		return editor
 
@@ -452,6 +455,20 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 		# Had issues using ints
 		self._qtWidget().setProperty( "gafferNumChildren", GafferUI._Variant.toVariant( "%d" % len(self) ) )
 		self._repolish()
+
+	def __configureTab( self, editor ) :
+
+		button = GafferUI.Button( image="deleteSmall.png", hasFrame=False )
+		button._qtWidget().setFixedSize( 11, 11 )
+
+		editor.__removeButton = button
+		editor.__removeButtonConnection = button.clickedSignal().connect( functools.partial(
+			lambda editor, container, _ : container().removeEditor( editor() ),
+			weakref.ref( editor ), weakref.ref( self )
+		) )
+
+		tabIndex = self.index( editor )
+		self._qtWidget().tabBar().setTabButton( tabIndex, QtWidgets.QTabBar.RightSide, button._qtWidget() )
 
 	def __layoutMenuDefinition( self ) :
 

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -443,6 +443,10 @@ _styleSheet = string.Template(
 		border-bottom-color: $background /* blend into frame below */
 	}
 
+	QTabBar[gafferHasTabCloseButtons="true"]::tab {
+		padding-right: 3px;
+	}
+
 	QTabBar::tab:disabled {
 		color: $tintLighter;
 	}

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -4423,6 +4423,16 @@
          width="16"
          id="rect5736-0-2" />
     </g>
+    <g
+       id="forExport:deleteSmall"
+       transform="matrix(0.49818887,-0.49818887,0.49818887,0.49818887,-44.252357,207.19317)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3271-4"
+         d="m 410.75,205.36218 v 5 h -5 v 4 h 5 v 5 h 4 v -5 h 5 v -4 h -5 v -5 z"
+         style="fill:#ffffff;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none"
+         sodipodi:nodetypes="ccccccccccccc" />
+    </g>
     <path
        inkscape:connector-curvature="0"
        id="path2986"


### PR DESCRIPTION
Adds close buttons to Tabs, as per offline thread, these are present for all tabs.

![tabCloseButtons](https://user-images.githubusercontent.com/896779/59500297-124dc700-8e91-11e9-8f7f-2553e3671e84.png)

This PR is branched based off #3193, so you can test both out with this one. If we merge that one first, then the apparent inclusion of those commits here should go.