### PR TITLE
Docs : Build improvement pass

### DIFF
--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -116,7 +116,7 @@ Redo last dispatch                    :kbd:`Ctrl` + :kbd:`R`
 ### Node copying and deletion ###
 
 > Tip :
-> For a Box node to be disableable, it must first be <a href="../../WorkingWithTheNodeGraph/BoxNode/index.html#setting-up-a-box-for-pass-through">set up for pass-through</a>.
+> For a Box node to be disableable, it must first be [set up for pass-through](../../WorkingWithTheNodeGraph/BoxNode/index.html#setting-up-a-box-for-pass-through).
 
 ```eval_rst
 ===================================== =============================================
@@ -169,6 +169,7 @@ Jump to bookmarked node               Hover cursor over editor, :kbd:`Ctrl` +
 Assign numeric bookmark               :kbd:`Ctrl` + :kbd:`1` … :kbd:`9`
 Remove numeric bookmark               :kbd:`Ctrl` + :kbd:`0`
 ===================================== =============================================
+
 .. |pin| image:: images/targetNodesLocked.png
     :alt: Pin
 ```

--- a/doc/source/WorkingWithScenes/AnatomyOfACamera/index.md
+++ b/doc/source/WorkingWithScenes/AnatomyOfACamera/index.md
@@ -98,11 +98,11 @@ For example, assume a lens with a focalLength of 50mm, an fStop of 4, and a worl
 
 ### Camera data ###
 
-Within the <a href="../AnatomyOfAScene/index.html#scene-hierarchy">scene paradigm</a>, a camera, just like any other scene component, starts with a location in the scene hierarchy. To define a camera, the location must have the following data:
+Within the [scene paradigm](../../../AnatomyOfAScene/index.html#scene-hierarchy), a camera, just like any other scene component, starts with a location in the scene hierarchy. To define a camera, the location must have the following data:
 
 - **Transform:** The vectors that define the position and orientation of the camera.
 - **Object:** A special camera object at the location. Instead of geometry, the object stores camera data, called parameters.
-    - **Parameters:** The crucial values that define a camera, such as the perspective type, field of view/aperture, and depth of field settings. If defined, a special kind of optional parameter, called a **render override**, will supercede one of the scene's **<a href="../AnatomyOfAScene/index.html#options">render options</a>** during computation and rendering.<br>
+    - **Parameters:** The crucial values that define a camera, such as the perspective type, field of view/aperture, and depth of field settings. If defined, a special kind of optional parameter, called a **render override**, will supercede one of the scene's **[render options](../../../AnatomyOfAScene/index.html#options)** during computation and rendering.<br>
     ![Camera parameters in the Scene Inspector](images/interfaceCameraParameters.png)
 - **Sets:** A list of sets the location belongs to. By default, every camera is assigned to an automatic "Cameras" set, accessible in the API by the `__cameras` variable.<br>
     ![Camera sets in the Scene Inspector](images/interfaceCameraSets.png)
@@ -134,5 +134,5 @@ Finally, all camera parameters and render options are passed to the renderer. Al
 ## See also ##
 
 - [Camera](../Camera/index.md)
-- [Camera node reference]()
+- [Camera node reference](../../Reference/NodeReference/GafferScene/Camera.md)
 - [Anatomy of a Scene](../AnatomyOfAScene/index.md)

--- a/doc/source/WorkingWithScenes/Camera/index.md
+++ b/doc/source/WorkingWithScenes/Camera/index.md
@@ -52,7 +52,7 @@ To select a look-through camera for a _Viewer:_
 
 #### Translating and rotating the look-through camera ####
 
-With the Camera Tool ![Camera Tool](images/gafferSceneUICameraTool.png "Camera Tool") toggled on, you can translate and rotate the look-through camera with the <a href="../../Interface/ControlsAndShortcuts/index.html#d-scenes">camera controls</a>.
+With the Camera Tool ![Camera Tool](images/gafferSceneUICameraTool.png "Camera Tool") toggled on, you can translate and rotate the look-through camera with the [camera controls](../../../../Interface/ControlsAndShortcuts/index.html#d-scenes).
 
 ![Manipulating the camera with the Camera Tool and camera controls](images/taskCameraToolLookThroughCamera.gif "Manipulating the camera with the Camera Tool and camera controls")
 
@@ -71,7 +71,7 @@ To orbit with the look-through camera:
 1. Make sure the Camera Tool ![Camera Tool](images/gafferSceneUICameraTool.png "Camera Tool") (<kbd>T</kbd>) is activated.
 2. Select an object in the scene.
 3. Hit <kbd>F</kbd>. The camera will aim at the object and adjust position.
-4. Use the <a href="../../Interface/ControlsAndShortcuts/index.html#d-scenes">camera controls</a> to orbit around the object.
+4. Use the [camera controls](../../../../Interface/ControlsAndShortcuts/index.html#d-scenes) to orbit around the object.
 
 
 ### Constructing a perspective camera ###
@@ -152,7 +152,7 @@ To add depth of field blur:
 
 Depending on your workflow and pipeline process, and how upstream data is inherited by your graph (such as from Reference nodes), you may find yourself in situations where you need to:
 
-- Introduce a camera that, to work correctly, must override one or more of the scene's <a href="../AnatomyOfAScene/index.html#options">render options</a> (such as the film fit), preempting the downstream StandardOptions node.
+- Introduce a camera that, to work correctly, must override one or more of the scene's [render options](../../../AnatomyOfAScene/index.html#options) (such as the film fit), preempting the downstream StandardOptions node.
 - Override an upstream camera's parameters, or preempt the downstream render options, without modifying the associated nodes.
 - Completely override a camera to create a custom camera type.
 

--- a/doc/source/WorkingWithScenes/Camera/screengrab.py
+++ b/doc/source/WorkingWithScenes/Camera/screengrab.py
@@ -153,6 +153,17 @@ __dispatchScript(
 ## TODO: Automate `images/taskApertureOffset.gif` when these tools become available:
 # - KB/M recording and simulated playback
 
+# Render: depth of field blur
+#
+__imageName = "renderDepthOfFieldBlur"
+__dispatchScript(
+	script = "scripts/{}.gfr".format( __imageName ),
+	tasks = [ "AppleseedRender" ],
+	settings = [
+		"-Outputs.outputs.output2.fileName '\"{}\"'".format( os.path.abspath( "images/{}.png".format( __imageName ) ) )
+		]
+  )
+
 # Task: the Depth of Field tab, with settings, in the Node Editor
 script["Camera"]["focusDistance"].setValue( 22.0 )
 script["Camera"]["fStop"].setValue( 2.8 )

--- a/doc/source/WorkingWithScenes/Camera/scripts/renderDepthOfFieldBlur.gfr
+++ b/doc/source/WorkingWithScenes/Camera/scripts/renderDepthOfFieldBlur.gfr
@@ -9,7 +9,7 @@ import imath
 
 Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
 Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 53, persistent=False )
-Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 1, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 5, persistent=False )
 Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )
 
 __children = {}
@@ -125,10 +125,7 @@ __children["point_light1"] = GafferAppleseed.AppleseedLight( "point_light1" )
 parent.addChild( __children["point_light1"] )
 __children["point_light1"].loadShader( "point_light" )
 __children["point_light1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
-__children["Text"] = GafferImage.Text( "Text" )
-parent.addChild( __children["Text"] )
-__children["Text"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
-parent["variables"]["imageCataloguePort"]["value"].setValue( 46033 )
+parent["variables"]["imageCataloguePort"]["value"].setValue( 34046 )
 Gaffer.Metadata.registerValue( parent["variables"]["imageCataloguePort"], 'readOnly', True )
 Gaffer.Metadata.registerValue( parent["variables"]["projectName"]["name"], 'readOnly', True )
 Gaffer.Metadata.registerValue( parent["variables"]["projectRootDirectory"]["name"], 'readOnly', True )
@@ -249,17 +246,13 @@ __children["Plane"]["PathFilter"]["paths"].setValue( IECore.StringVectorData( [ 
 __children["Plane"]["PathFilter"]["__uiPosition"].setValue( imath.V2f( 8.47416401, 18.7893734 ) )
 __children["AppleseedRender"]["in"].setInput( __children["Outputs"]["out"] )
 __children["AppleseedRender"]["fileName"].setValue( '${project:rootDirectory}/appleseeds/${script:name}/${script:name}.####.appleseed' )
-__children["AppleseedRender"]["__uiPosition"].setValue( imath.V2f( -4.62300301, -24.5285225 ) )
+__children["AppleseedRender"]["__uiPosition"].setValue( imath.V2f( -4.62300348, -24.5285225 ) )
 __children["point_light"]["transform"]["translate"].setValue( imath.V3f( -40, 40, 40 ) )
 __children["point_light"]["parameters"]["exposure"].setValue( 15.0 )
 __children["point_light"]["__uiPosition"].setValue( imath.V2f( 9.92286491, 6.29177904 ) )
 __children["point_light1"]["transform"]["translate"].setValue( imath.V3f( 40, -40, 15 ) )
 __children["point_light1"]["parameters"]["exposure"].setValue( 12.0 )
 __children["point_light1"]["__uiPosition"].setValue( imath.V2f( 22.9937744, 6.29177856 ) )
-__children["Text"]["out"].setInput( __children["Text"]["__merge"]["out"] )
-__children["Text"]["text"].setValue( '${USER}\n' )
-__children["Text"]["area"].setValue( imath.Box2i( imath.V2i( 0, 0 ), imath.V2i( 1920, 1080 ) ) )
-__children["Text"]["__uiPosition"].setValue( imath.V2f( -78.2757568, 1.0391531 ) )
 
 
 del __children

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -37,12 +37,7 @@ import Gaffer
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    'sphinx.ext.autosectionlabel'
-]
-
-# Whether to use unique IDs for automatic section labels (articleName:section).
-autosectionlabel_prefix_document = True
+extensions = []
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = []


### PR DESCRIPTION
The idea for this one is to cut down on the errors during docs build. Currently, builds spit out approximately 1800 unsuppressable `Duplicate label` warnings. I've noticed that occasionally these errors seem to mask other, more important warnings and errors. This is actually a bug that will be resolved when we update Sphinx, but I don't know how long off that will be, and I don't actually use these labels anyway.

The main change is to disable the `autosectionlabel` Sphinx extension. I thought I would use the `:ref:` directive to point to other articles' headings, but that hasn't happened. Links like these (links to headings in internal docs) are possible in regular Markdown, they just are a bit unintuitive (they require an extra `../../` before the link). The alternative is also unintuitive (`` ```eval_rst  :ref:<name_of_ref>``` ``), but worse because it requires the whole paragraph that contains the link to be written in reST.

Additional changes are more mundane, just fixing some problem links and a missing image. There's an error about a `Hardbreak` character that I hadn't seen until today. Maybe @themissingcow can comment whether he sees that?

There are a few broken links in the Scripting section that I left unfixed, since they are fixed in #3210.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
