### PR TITLE
Support for Houdini17.5

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -236,10 +236,10 @@ LOCATE_DEPENDENCY_SYSTEMPATH = [
 ]
 
 if targetAppVersion :
-	# avoid the proper dependency order for Houdini 16.5 and earlier.
-	# this is not ideal, but we're too far along in the H16.5 lifecycle
-	##\ todo: Remove this clause once we're onto H17.0 across the studio.
-	if targetApp == "houdini" and distutils.version.LooseVersion(targetAppVersion) < distutils.version.LooseVersion("17.0") :
+	# for Houdini, we are favouring our dependency rather than sideFx's
+	# given that 17.5 is shipping with openExr mangled lib without python binding.
+	# We should reassess for next version of Houdini to see if that still holds true.
+	if targetApp == "houdini" :
 		LOCATE_DEPENDENCY_SYSTEMPATH += [ os.path.join( targetAppReg['location'], x ) for x in targetAppReg.get( 'includes', [] ) ]
 	else :
 		LOCATE_DEPENDENCY_SYSTEMPATH[:0] = [ os.path.join( targetAppReg['location'], x ) for x in targetAppReg.get( 'includes', [] ) ]

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -99,7 +99,7 @@ struct HashCacheKey
 	{
 	}
 
-	const bool operator == ( const HashCacheKey &other ) const
+	bool operator == ( const HashCacheKey &other ) const
 	{
 		return other.plug == plug && other.contextHash == contextHash;
 	}


### PR DESCRIPTION
Added support for Houdini 17.5 (#3214)
Note we are using our 3rd party lib ( openEXR ) instead of Houdini's one

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
