### PR TITLE
Maximum Texture Resolution For Light Visualisers

### DIFF
--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -74,7 +74,7 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public LightVisualiser
 		static IECoreGL::ConstRenderablePtr pointRays();
 		static IECoreGL::ConstRenderablePtr distantRays();
 		static IECoreGL::ConstRenderablePtr spotlightCone( float innerAngle, float outerAngle, float lensRadius );
-		static IECoreGL::ConstRenderablePtr environmentSphere( const Imath::Color3f &color, const std::string &textureFileName );
+		static IECoreGL::ConstRenderablePtr environmentSphere( const Imath::Color3f &color, const std::string &textureFileName, int maxTextureResolution );
 		static IECoreGL::ConstRenderablePtr colorIndicator( const Imath::Color3f &color, bool cameraFacing = true );
 
 	private :

--- a/python/GafferSceneUI/OpenGLAttributesUI.py
+++ b/python/GafferSceneUI/OpenGLAttributesUI.py
@@ -362,6 +362,19 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"attributes.maxTextureResolution" : [
+
+			"description",
+			"""
+			Light visualisers that load textures will respect this setting to
+			limit their resolution.
+			""",
+
+			"layout:section", "Light Visualisers",
+			"label", "Max Texture Resolution",
+
+		],
+
 	}
 
 )

--- a/src/GafferScene/OpenGLAttributes.cpp
+++ b/src/GafferScene/OpenGLAttributes.cpp
@@ -78,6 +78,10 @@ OpenGLAttributes::OpenGLAttributes( const std::string &name )
 	attributes->addChild( new NameValuePlug( "gl:curvesPrimitive:glLineWidth", new IECore::FloatData( 1.0 ), false, "curvesPrimitiveGLLineWidth" ) );
 	attributes->addChild( new NameValuePlug( "gl:curvesPrimitive:ignoreBasis", new IECore::BoolData( false ), false, "curvesPrimitiveIgnoreBasis" ) );
 
+	// light visualisers
+
+	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", new IECore::IntData( 512 ), false, "maxTextureResolution" ) );
+
 }
 
 OpenGLAttributes::~OpenGLAttributes()

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -266,7 +266,9 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::I
 	if( type && type->readable() == "environment" )
 	{
 		const std::string textureName = parameter<std::string>( metadataTarget, shaderParameters, "textureNameParameter", "" );
-		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( environmentSphere( finalColor, textureName ) ) );
+		const IntData *textureMaxResolutionData = attributes->member<IntData>( "gl:visualiser:maxTextureResolution" );
+		const int textureMaxResolution = textureMaxResolutionData ? textureMaxResolutionData->readable() : std::numeric_limits<int>::max();
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( environmentSphere( finalColor, textureName, textureMaxResolution ) ) );
 	}
 	else if( type && type->readable() == "spot" )
 	{
@@ -556,7 +558,7 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::spotlightCone( float inner
 	return group;
 }
 
-IECoreGL::ConstRenderablePtr StandardLightVisualiser::environmentSphere( const Imath::Color3f &color, const std::string &textureFileName )
+IECoreGL::ConstRenderablePtr StandardLightVisualiser::environmentSphere( const Imath::Color3f &color, const std::string &textureFileName, int textureMaxResolution )
 {
 	IECoreGL::GroupPtr group = new IECoreGL::Group();
 
@@ -571,8 +573,11 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::environmentSphere( const I
 	IECore::CompoundObjectPtr parameters = new CompoundObject;
 	parameters->members()["lightMultiplier"] = new Color3fData( color );
 	parameters->members()["previewOpacity"] = new FloatData( 1 );
-	parameters->members()["mapSampler"] = new StringData( textureFileName );
 	parameters->members()["defaultColor"] = new Color3fData( Color3f( textureFileName == "" ? 1.0f : 0.0f ) );
+	parameters->members()["mapSampler"] = new StringData( textureFileName );
+
+	parameters->members()["mapSampler:maxResolution"] = new IntData( textureMaxResolution );
+
 	group->getState()->add(
 		new IECoreGL::ShaderStateComponent( ShaderLoader::defaultShaderLoader(), TextureLoader::defaultTextureLoader(), IECoreGL::Shader::defaultVertexSource(), "", environmentSphereFragSource(), parameters )
 	);


### PR DESCRIPTION
Hey John,

this is the code for the Gaffer side of things and depends on https://github.com/ImageEngine/cortex/pull/961. 

It's not ideal that we explicitly need to know about the "_maxResolution" naming convention here, hey? Also, I've jabbed that new attribute into StandardAttributes as I'm assuming that people here will want to apply it to lights that have already been published and come in via cache. 

I think the only lights that will currently use this new feature are lights in IERendering, though. If that's the case, would you rather we only make changes to the visualiser here and handle the attributes setup in IERendering? That would have the downside that published lights can't be easily modified, but then we don't have to deal with it here.
If we opt to add the attribute to StandardAttributes, is it worth looking at "visualiser:scale" again and add it to the same section? Maybe with a tooltip saying that it's only for lights currently? It feels to me like that section could be useful to have. I was thinking about making our gobo visualiser respect the texture resolution attribute to figure out the grid size on which the osl network gets evaluated, for example...

Cheerio,

Matti.