### PR TITLE
VectorTypedParameterHandler : Added support for Color3fVectorParameter

### DIFF
--- a/python/GafferCortexUI/CompoundVectorParameterValueWidget.py
+++ b/python/GafferCortexUI/CompoundVectorParameterValueWidget.py
@@ -163,9 +163,10 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 
 		data = vectorDataWidget.getData()
 
-		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
-			for d, p in zip( data, self._parameterHandler().plug().children() ) :
-				p.setValue( d )
+		with Gaffer.BlockedConnection( self._plugConnections() ) :
+			with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+				for d, p in zip( data, self._parameterHandler().plug().children() ) :
+					p.setValue( d )
 
 GafferCortexUI.ParameterValueWidget.registerType( IECore.CompoundVectorParameter, CompoundVectorParameterValueWidget )
 

--- a/src/GafferCortex/VectorTypedParameterHandler.cpp
+++ b/src/GafferCortex/VectorTypedParameterHandler.cpp
@@ -126,3 +126,4 @@ template class GafferCortex::VectorTypedParameterHandler<IECore::IntVectorParame
 template class GafferCortex::VectorTypedParameterHandler<IECore::FloatVectorParameter>;
 template class GafferCortex::VectorTypedParameterHandler<IECore::StringVectorParameter>;
 template class GafferCortex::VectorTypedParameterHandler<IECore::V3fVectorParameter>;
+template class GafferCortex::VectorTypedParameterHandler<IECore::Color3fVectorParameter>;


### PR DESCRIPTION
- VectorTypedParameterHandler : Added support for Color3fVectorParameter
- CompoundVectorParameterValueWidget : Fixed bug when editing data

  Without the blocked connections the widget resets when a plugDirtied
signal is sent, which redraws the widget and we lose the current
selection.

---------

@johnhaddon , in the second commit, you may notice that the `BlockedConnection()` is the outer block, which is different from the other similar uses in Gaffer, particularly when using it with `self._plugConnections()`.
The reason for that is that I was having issues with the `plugDirtied` signal being emitted if I use the `UndoScope()` as the outer block.
After some debugging, it turned out that as we leave the `UndoScope()`, a `plugDirtied` signal is immediately emitted (the one that was blocked previously).

I assume that is a bug?

So I added a test to demonstrate the issue, which fails in the last `assert` call.

Any ideas of what might cause that and how it could be fixed?

Also, let me know if you want that to be a separate PR.

Cheers!

Ivan
