### PR TITLE
Add ProcessException class

### DIFF
--- a/include/GafferBindings/ComputeNodeBinding.h
+++ b/include/GafferBindings/ComputeNodeBinding.h
@@ -116,6 +116,50 @@ class ComputeNodeWrapper : public DependencyNodeWrapper<WrappedType>
 			WrappedType::compute( output, context );
 		}
 
+		Gaffer::ValuePlug::CachePolicy hashCachePolicy( const Gaffer::ValuePlug *output ) const override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				try
+				{
+					boost::python::object f = this->methodOverride( "hashCachePolicy" );
+					if( f )
+					{
+						boost::python::object policy = f( Gaffer::ValuePlugPtr( const_cast<Gaffer::ValuePlug *>( output ) ) );
+						return boost::python::extract<Gaffer::ValuePlug::CachePolicy>( policy );
+					}
+				}
+				catch( const boost::python::error_already_set &e )
+				{
+					IECorePython::ExceptionAlgo::translatePythonException();
+				}
+			}
+			return WrappedType::hashCachePolicy( output );
+		}
+
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				try
+				{
+					boost::python::object f = this->methodOverride( "computeCachePolicy" );
+					if( f )
+					{
+						boost::python::object policy = f( Gaffer::ValuePlugPtr( const_cast<Gaffer::ValuePlug *>( output ) ) );
+						return boost::python::extract<Gaffer::ValuePlug::CachePolicy>( policy );
+					}
+				}
+				catch( const boost::python::error_already_set &e )
+				{
+					IECorePython::ExceptionAlgo::translatePythonException();
+				}
+			}
+			return WrappedType::computeCachePolicy( output );
+		}
+
 };
 
 } // namespace GafferBindings

--- a/python/GafferImageTest/CatalogueSelectTest.py
+++ b/python/GafferImageTest/CatalogueSelectTest.py
@@ -81,4 +81,4 @@ class CatalogueSelectTest( GafferImageTest.ImageTestCase ) :
 		with self.assertRaises( Exception ) as cm:
 			catalogueSelect["out"].image()
 
-		self.assertEqual( str( cm.exception ), "Unknown image name." )
+		self.assertEqual( str( cm.exception ), "CatalogueSelect.__context.out.format : Unknown image name." )

--- a/python/GafferImageTest/CatalogueSelectTest.py
+++ b/python/GafferImageTest/CatalogueSelectTest.py
@@ -81,4 +81,4 @@ class CatalogueSelectTest( GafferImageTest.ImageTestCase ) :
 		with self.assertRaises( Exception ) as cm:
 			catalogueSelect["out"].image()
 
-		self.assertEqual( str( cm.exception ), "Exception : Unknown image name." )
+		self.assertEqual( str( cm.exception ), "Unknown image name." )

--- a/python/GafferSceneTest/SetAlgoTest.py
+++ b/python/GafferSceneTest/SetAlgoTest.py
@@ -137,7 +137,7 @@ class SetAlgoTest( GafferSceneTest.SceneTestCase ) :
 			# note the missing )
 			GafferScene.SetAlgo.evaluateSetExpression( 'setA - (/group/group/sphere2', group2["out"] )
 
-		self.assertEqual( str( e.exception ), 'Exception : Syntax error in indicated part of SetExpression.\nsetA - (/group/group/sphere2\n     |---------------------|\n.' )
+		self.assertEqual( str( e.exception ), 'Syntax error in indicated part of SetExpression.\nsetA - (/group/group/sphere2\n     |---------------------|\n.' )
 
 		# Sets that don't exist should be replaced with an empty PathMatcher
 		expressionCheck( 'A', [] )

--- a/python/GafferTest/ComputeNodeTest.py
+++ b/python/GafferTest/ComputeNodeTest.py
@@ -589,6 +589,14 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 			else :
 				Gaffer.ComputeNode.compute( plug, context )
 
+		def hashCachePolicy( self, plug ) :
+
+			return Gaffer.ValuePlug.CachePolicy.Standard
+
+		def computeCachePolicy( self, plug ) :
+
+			return Gaffer.ValuePlug.CachePolicy.Standard
+
 	IECore.registerRunTimeTyped( ThrowingNode )
 
 	def testProcessException( self ) :
@@ -613,6 +621,35 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 		self.assertEqual( raised.exception.plug(), thrower["out"] )
 		self.assertEqual( raised.exception.context(), context )
 		self.assertEqual( raised.exception.processType(), "computeNode:compute" )
+
+	def testProcessExceptionNotShared( self ) :
+
+		thrower1 = self.ThrowingNode( "thrower1" )
+		thrower2 = self.ThrowingNode( "thrower2" )
+
+		with self.assertRaisesRegexp( Gaffer.ProcessException, r'thrower1.out : [\s\S]*Eeek!' ) as raised :
+			thrower1["out"].getValue()
+
+		self.assertEqual( raised.exception.plug(), thrower1["out"] )
+
+		with self.assertRaisesRegexp( Gaffer.ProcessException, r'thrower2.out : [\s\S]*Eeek!' ) as raised :
+			thrower2["out"].getValue()
+
+		self.assertEqual( raised.exception.plug(), thrower2["out"] )
+
+	def testProcessExceptionRespectsNameChanges( self ) :
+
+		thrower = self.ThrowingNode( "thrower1" )
+		with self.assertRaisesRegexp( Gaffer.ProcessException, r'thrower1.out : [\s\S]*Eeek!' ) as raised :
+			thrower["out"].getValue()
+
+		self.assertEqual( raised.exception.plug(), thrower["out"] )
+
+		thrower.setName( "thrower2" )
+		with self.assertRaisesRegexp( Gaffer.ProcessException, r'thrower2.out : [\s\S]*Eeek!' ) as raised :
+			thrower["out"].getValue()
+
+		self.assertEqual( raised.exception.plug(), thrower["out"] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ComputeNodeTest.py
+++ b/python/GafferTest/ComputeNodeTest.py
@@ -560,5 +560,59 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 		# is not an error.
 		self.assertEqual( len( cs ), 0 )
 
+	class ThrowingNode( Gaffer.ComputeNode ) :
+
+		def __init__( self, name="ThrowingNode" ) :
+
+			Gaffer.ComputeNode.__init__( self, name )
+
+			self["in"] = Gaffer.IntPlug()
+			self["out"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
+
+		def affects( self, input ) :
+
+			outputs = Gaffer.ComputeNode.affects( self, input )
+			if input == self["in"] :
+				outputs.append( self["out"] )
+
+			return outputs
+
+		def hash( self, plug, context, h ) :
+
+			if plug == self["out"] :
+				self["in"].hash( h )
+
+		def compute( self, plug, context ) :
+
+			if plug == self["out"] :
+				raise RuntimeError( "Eeek!" )
+			else :
+				Gaffer.ComputeNode.compute( plug, context )
+
+	IECore.registerRunTimeTyped( ThrowingNode )
+
+	def testProcessException( self ) :
+
+		thrower = self.ThrowingNode( "thrower" )
+		add = GafferTest.AddNode()
+
+		add["op1"].setInput( thrower["out"] )
+		add["op2"].setValue( 1 )
+
+		# We expect `thrower` to throw, and we want the name of the plug to be added
+		# as a prefix to the error message.
+
+		with Gaffer.Context() as context :
+			context["test"] = 1
+			with self.assertRaisesRegexp( Gaffer.ProcessException, r'thrower.out : [\s\S]*Eeek!' ) as raised :
+				add["sum"].getValue()
+
+		# And we want to be able to retrieve details of the problem
+		# from the exception.
+
+		self.assertEqual( raised.exception.plug(), thrower["out"] )
+		self.assertEqual( raised.exception.context(), context )
+		self.assertEqual( raised.exception.processType(), "computeNode:compute" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -1240,8 +1240,8 @@ class ScriptNodeTest( GafferTest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 		self.assertRaisesRegexp(
-			Exception,
-			"^Exception : Line 2",
+			IECore.Exception,
+			"^Line 2",
 			s.execute,
 			inspect.cleandoc(
 				"""

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -60,6 +60,7 @@
 #include "PathFilterBinding.h"
 #include "PlugAlgoBinding.h"
 #include "PlugBinding.h"
+#include "ProcessBinding.h"
 #include "RandomBinding.h"
 #include "ScriptNodeBinding.h"
 #include "SerialisationBinding.h"
@@ -216,6 +217,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindContextProcessor();
 	bindProcessMessageHandler();
 	bindNameValuePlug();
+	bindProcess();
 
 	NodeClass<Backdrop>();
 

--- a/src/GafferModule/ProcessBinding.cpp
+++ b/src/GafferModule/ProcessBinding.cpp
@@ -1,0 +1,80 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "ProcessBinding.h"
+
+#include "Gaffer/Context.h"
+#include "Gaffer/Plug.h"
+#include "Gaffer/Process.h"
+
+#include "IECorePython/ExceptionBinding.h"
+#include "IECorePython/RefCountedBinding.h"
+
+using namespace Gaffer;
+using namespace IECorePython;
+
+namespace
+{
+
+PlugPtr processExceptionPlug( const ProcessException &e )
+{
+	return const_cast<Plug *>( e.plug() );
+}
+
+ContextPtr processExceptionContext( const ProcessException &e )
+{
+	return const_cast<Context *>( e.context() );
+}
+
+const char *processExceptionProcessType( const ProcessException &e )
+{
+	return e.processType().c_str();
+}
+
+} // namespace
+
+void GafferModule::bindProcess()
+{
+
+	IECorePython::ExceptionClass<ProcessException>( "ProcessException", PyExc_RuntimeError )
+		.def( "plug", &processExceptionPlug )
+		.def( "context", &processExceptionContext )
+		.def( "processType", &processExceptionProcessType )
+	;
+
+}

--- a/src/GafferModule/ProcessBinding.h
+++ b/src/GafferModule/ProcessBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERMODULE_PROCESSBINDING_H
+#define GAFFERMODULE_PROCESSBINDING_H
+
+namespace GafferModule
+{
+
+void bindProcess();
+
+} // namespace GafferModule
+
+#endif // GAFFERMODULE_PROCESSBINDING_H

--- a/src/GafferModule/ValuePlugBinding.cpp
+++ b/src/GafferModule/ValuePlugBinding.cpp
@@ -104,7 +104,7 @@ void hash2( ValuePlug *plug, IECore::MurmurHash &h )
 
 void GafferModule::bindValuePlug()
 {
-	PlugClass<ValuePlug, PlugWrapper<ValuePlug> >()
+	scope s = PlugClass<ValuePlug, PlugWrapper<ValuePlug> >()
 		.def( boost::python::init<const std::string &, Plug::Direction, unsigned>(
 				(
 					boost::python::arg_( "name" ) = GraphComponent::defaultName<ValuePlug>(),
@@ -132,6 +132,14 @@ void GafferModule::bindValuePlug()
 		.def( "setHashCacheSizeLimit", &ValuePlug::setHashCacheSizeLimit )
 		.staticmethod( "setHashCacheSizeLimit" )
 		.def( "__repr__", &repr )
+	;
+
+	enum_<ValuePlug::CachePolicy>( "CachePolicy" )
+		.value( "Uncached", ValuePlug::CachePolicy::Uncached )
+		.value( "Standard", ValuePlug::CachePolicy::Standard )
+		.value( "TaskCollaboration", ValuePlug::CachePolicy::TaskCollaboration )
+		.value( "TaskIsolation", ValuePlug::CachePolicy::TaskIsolation )
+		.value( "Legacy", ValuePlug::CachePolicy::Legacy )
 	;
 
 	Serialisation::registerSerialiser( Gaffer::ValuePlug::staticTypeId(), new ValuePlugSerialiser );


### PR DESCRIPTION
This has two purposes :

- To properly propagate the source plug up the call chain so that `Process::emitError()` reports the correct source even when the error occurs in a TBB task.
- To inform the recipient of the full details of the process in which the exception occurred.

Requires https://github.com/ImageEngine/cortex/pull/962