### PR TITLE
StyleSheet : Revert to original Gaffer styling

### DIFF
--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -41,48 +41,19 @@ import string
 from Qt import QtGui
 
 _styleColors = {
-
 	"backgroundDarkest" : (0, 0, 0),
-
-	"backgroundDarker" : (45, 45, 45),
-
-	"backgroundDark" : (56, 56, 56),
-	"backgroundDarkTransparent" : (56, 56, 56, 100),
-	"backgroundDarkHighlight" : (62, 62, 62),
-
-	"backgroundLowlight" : (68, 68, 68),
-	"background" : (76, 76, 76),
-	"backgroundHighlight" : (88, 88, 88),
-
-	"backgroundRaisedLowlight" : (70, 70, 70),
-	"backgroundRaised" : (82, 82, 82),
-	"backgroundRaisedHighlight" : (96, 96, 96),
-
-	"backgroundLightLowlight" : (82, 82, 82),
-	"backgroundLight" : (96, 96, 96),
-	"backgroundLightHighlight" : (106, 106, 106),
-
-	"backgroundLighter" : (125, 125, 125),
-
+	"backgroundDark" : (60, 60, 60),
+	"backgroundDarkTransparent" : (60, 60, 60, 100),
+	"backgroundMid" : (76, 76, 76),
+	"backgroundLighter" : (108, 108, 108),
+	"backgroundLight" : (125, 125, 125),
 	"brightColor" : (119, 156, 189),
 	"brightColorTransparent" : (119, 156, 189, 100),
-
 	"foreground" : (224, 224, 224),
 	"foregroundFaded" : (153, 153, 153),
-
+	"alternateColor" : (69, 69, 69),
 	"errorColor" : (255, 85, 85),
 	"animatedColor" : (128, 152, 94),
-
-	"tintLighter" :         ( 255, 255, 255, 20 ),
-	"tintLighterStrong" :   ( 255, 255, 255, 40 ),
-	"tintLighterStronger" : ( 255, 255, 255, 100 ),
-	"tintDarker" :          ( 0, 0, 0, 20 ),
-	"tintDarkerStrong" :    ( 0, 0, 0, 40 ),
-}
-
-_themeVariables = {
-	"widgetCornerRadius" : "4px",
-	"controlCornerRadius" : "2px"
 }
 
 substitutions = {
@@ -94,8 +65,6 @@ for k, v in _styleColors.items() :
 		substitutions[k] = "rgb({0}, {1}, {2})".format( *v )
 	elif len( v ) == 4 :
 		substitutions[k] = "rgba({0}, {1}, {2}, {3})".format( *v )
-
-substitutions.update( _themeVariables )
 
 def styleColor( key ) :
 	color = _styleColors.get( key, (0, 0, 0,) )
@@ -112,62 +81,72 @@ _styleSheet = string.Template(
 
 	"""
 	QWidget#gafferWindow {
+
 		color: $foreground;
 		font: 10px;
 		etch-disabled-text: 0;
-		background-color: $backgroundLowlight;
+		background-color: $backgroundMid;
 		border: 1px solid #555555;
 	}
 
 	QWidget {
+
 		background-color: transparent;
+
 	}
 
-	QLabel, QCheckBox, QPushButton, QComboBox, QMenu, QMenuBar,
-	QTabBar, QLineEdit, QAbstractItemView, QPlainTextEdit, QDateTimeEdit {
+	QLabel, QCheckBox, QPushButton, QComboBox, QMenu, QMenuBar, QTabBar, QLineEdit, QAbstractItemView, QPlainTextEdit, QDateTimeEdit {
+
 		color: $foreground;
 		font: 10px;
 		etch-disabled-text: 0;
+		alternate-background-color: $alternateColor;
 		selection-background-color: $brightColor;
 		outline: none;
+
 	}
 
 	QLabel[gafferHighlighted=\"true\"] {
+
 		color: #b0d8fb;
+
 	}
 
 	QLabel#gafferPlugLabel[gafferValueChanged=\"true\"] {
+
 		background-image: url($GAFFER_ROOT/graphics/valueChanged.png);
 		background-repeat: no-repeat;
 		background-position: left;
 		padding-left: 20px;
-	}
 
-
-	QLabel[gafferItemName="true"] {
-		font-weight: bold;
 	}
 
 	QMenuBar {
+
 		background-color: $backgroundDarkest;
 		font-weight: bold;
 		padding: 0px;
 		margin: 0px;
+
 	}
 
 	QMenuBar::item {
+
 		background-color: $backgroundDarkest;
 		padding: 5px 8px 5px 8px;
+
 	}
 
 	QMenu {
+
 		border: 1px solid $backgroundDark;
 		padding-bottom: 5px;
 		padding-top: 5px;
-		background-color: $backgroundLight;
+
 	}
 
 	QMenu[gafferHasTitle=\"true\"] {
+
 		/* make sure the title widget sits at the very top.
 		   infuriatingly, qt uses padding-top for the bottom
 		   as well, and is ignoring padding-bottom. that makes
@@ -175,28 +154,36 @@ _styleSheet = string.Template(
 		   at the bottom. we hack around that by adding a little
 		   spacing widget in GafferUI.Menu. */
 		padding-top: 0px;
+
 	}
 
 	QLabel#gafferMenuTitle {
+
 		background-color: $backgroundDarkest;
 		font-weight: bold;
 		padding: 5px 25px 5px 20px;
 		margin-bottom: 6px;
+
 	}
 
 	QLabel#gafferMenuTitle:disabled {
+
 		color: $foreground;
+
 	}
 
 	QMenu::item {
-		color: $foreground;
+
 		background-color: transparent;
 		border: 0px;
 		padding: 2px 25px 2px 20px;
+
 	}
 
 	QMenu::item:disabled {
-		color: $tintLighterStronger;
+
+		color: $foregroundFaded;
+
 	}
 
 	QMenu::right-arrow {
@@ -205,12 +192,14 @@ _styleSheet = string.Template(
 	}
 
 	QMenu::separator {
+
 		height: 1px;
-		background: $backgroundLowlight;
+		background: $backgroundDark;
 		margin-left: 10px;
 		margin-right: 10px;
 		margin-top: 5px;
 		margin-bottom: 5px;
+
 	}
 
 	QMenu::indicator {
@@ -226,43 +215,61 @@ _styleSheet = string.Template(
 		image: url($GAFFER_ROOT/graphics/arrowRight10.png);
 	}
 
-	QLineEdit, QPlainTextEdit {
-		padding: 0px;
-		border: 1px solid transparent;
-		border-bottom-color: $backgroundLightLowlight;
-		border-right-color: $backgroundLightLowlight;
-		background-color: $backgroundLight;
-		border-radius: ${controlCornerRadius};
+	QMenu, QTabBar::tab:selected, QHeaderView::section {
+
+		background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 $backgroundLight, stop: 1 $backgroundMid);
+
 	}
 
+	QPlainTextEdit {
 
-	QLineEdit[readOnly="true"], QPlainTextEdit[readOnly="true"] {
-		padding: 0px;
-		background-color: transparent;
-		border-color: transparent;
+		border: 1px solid $backgroundDark;
+
+	}
+
+	QLineEdit, QPlainTextEdit[readOnly="false"] {
+
+		border: 1px solid $backgroundDark;
+		padding: 1px;
+		margin: 0px;
+
+	}
+
+	QLineEdit[readOnly="false"], QPlainTextEdit[readOnly="false"] {
+
+		background-color: $backgroundLighter;
+
 	}
 
 	QLineEdit[gafferError="true"], QPlainTextEdit[gafferError="true"] {
+
 		background-color: $errorColor;
+
 	}
 
 	QLineEdit[gafferAnimated="true"] {
-		padding: 0px;
-		border: 1px solid transparent;
+
 		background-color: $animatedColor;
+
 	}
 
 	QPlainTextEdit[gafferRole="Code"] {
+
 		font-family: monospace;
+
 	}
 
 	QLineEdit:focus, QPlainTextEdit[readOnly="false"]:focus, QLineEdit[gafferHighlighted=\"true\"] {
-		border: 1px solid $brightColor;
+
+		border: 2px solid $brightColor;
 		padding: 0px;
+
 	}
 
 	QLineEdit:disabled {
+
 		color: $foregroundFaded;
+
 	}
 
 	QLineEdit#search{
@@ -276,15 +283,19 @@ _styleSheet = string.Template(
 		margin-right: 4px;
 	}
 
-	QWidget#gafferSplineWidget {
+	QWidget#gafferSplineWidget
+	{
 		border: 1px solid $backgroundDark;
 	}
 
 	QWidget#gafferSplineWidget[gafferHighlighted=\"true\"] {
+
 		border: 1px solid $brightColor;
+
 	}
 
 	QDateTimeEdit {
+
 		background-color: $backgroundLighter;
 		padding: 1px;
 		margin: 0px;
@@ -297,13 +308,17 @@ _styleSheet = string.Template(
 	}
 
 	#qt_calendar_navigationbar {
+
 		background-color : $brightColor;
+
 	}
 
 	#qt_calendar_monthbutton, #qt_calendar_yearbutton {
+
 		color : $foreground;
 		font-weight : bold;
 		font-size : 16pt;
+
 	}
 
 	#qt_calendar_monthbutton::menu-indicator {
@@ -311,47 +326,49 @@ _styleSheet = string.Template(
 	}
 
 	#qt_calendar_calendarview {
+
 		color : $foreground;
 		font-weight : normal;
 		font-size : 14pt;
 		selection-background-color: $brightColor;
 		background-color : $backgroundLighter;
 		gridline-color: $backgroundDark;
+
 	}
 
 	/* buttons */
 
-	QPushButton#gafferWithFrame,
-	QComboBox {
-		border: 1px solid $backgroundDarkHighlight;
-		border-top-color: $backgroundLightHighlight;
-		border-left-color: $backgroundLightHighlight;
-		background-color : qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 $backgroundLightHighlight, stop: 0.1 $backgroundLight, stop: 0.90 $backgroundLightLowlight);
-		border-radius: 4px;
+	QPushButton, QComboBox {
+
+		font-weight: bold;
+
+	}
+
+	QPushButton#gafferWithFrame, QComboBox {
+
+		border: 1px solid $backgroundDark;
+		border-radius: 3px;
 		padding: 4px;
 		margin: 1px;
-		font-weight: bold;
+		background-color : qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 $backgroundLight, stop: 0.5 $backgroundLighter);
+
 	}
 
-	QPushButton#gafferWithFrame[gafferMenuButton="true"] {
-		padding: 2px;
-	}
+	QPushButton#gafferWithFrame:hover, QPushButton#gafferWithFrame:focus, QComboBox:hover {
 
-	*[gafferPlugValueWidget="true"] QPushButton#gafferWithFrame[gafferMenuButton="true"] {
-		font-weight: normal;
-		text-align: left;
-	}
-
-	QPushButton#gafferWithFrame:focus {
-		border: 1px solid $brightColor;
+		border: 2px solid $brightColor;
+		margin: 0px;
 	}
 
 	QPushButton#gafferWithFrame:pressed {
+
 		color: white;
 		background-color:	$brightColor;
+
 	}
 
 	QPushButton#gafferWithoutFrame {
+
 		border: 0px solid transparent;
 		border-radius: 0px;
 		padding: 0px;
@@ -361,16 +378,19 @@ _styleSheet = string.Template(
 		margin-left: -2px;
 		margin-right: -2px;
 		background-color: none;
+
 	}
 
 	QPushButton:disabled, QComboBox:disabled, QLabel::disabled {
+
 		color: $foregroundFaded;
+
 	}
 
 	QPushButton#gafferWithFrame:disabled {
-		color: $tintLighterStrong;
-		background-color: $tintDarker;
-		border-color: transparent;
+
+		background-color: $backgroundLighter;
+
 	}
 
 	QPushButton::menu-indicator {
@@ -381,15 +401,19 @@ _styleSheet = string.Template(
 	}
 
 	QPushButton#gafferWithFrame[gafferMenuIndicator="true"] {
+
 		background-image: url($GAFFER_ROOT/graphics/menuIndicator.png);
 		background-repeat: none;
 		background-position: center right;
 		padding-right: 20px
+
 	}
 
 	QComboBox {
+
 		padding: 0;
 		padding-left:3px;
+
 	}
 
 	QComboBox::drop-down {
@@ -398,147 +422,125 @@ _styleSheet = string.Template(
 	}
 
 	QComboBox QAbstractItemView {
+
 		border: 1px solid $backgroundDark;
 		selection-background-color: $backgroundLighter;
-		background-color: $background;
+		background-color: $backgroundMid;
 		height:40px;
 		margin:0;
-		text-align: left;
+
 	}
 
 	QComboBox QAbstractItemView::item {
+
 		border: none;
 		padding: 2px;
+		font-weight: bold;
+
 	}
 
 	/* tabs */
 
 	QTabWidget::tab-bar {
-		left: 0px;
-	}
 
-	QTabWidget #gafferCompoundEditorTools  {
-		margin: 0;
-		padding: 0;
-		border: none;
+		left: 0px;
+
 	}
 
 	QTabBar {
+
 		color: $foreground;
 		font-weight: bold;
 		outline:none;
 		background-color: transparent;
+
 	}
 
 	QTabBar::tab {
+
+		border: 1px solid $backgroundDark;
 		padding: 4px;
 		padding-left: 8px;
 		padding-right: 8px;
-		border-top-left-radius: 4px;
-		border-top-right-radius: 4px;
+		border-top-left-radius: 3px;
+		border-top-right-radius: 3px;
 		margin: 0px;
-		margin-right: 1px;
-		border: 1px solid $backgroundHighlight;
-		border-right-color: $backgroundLowlight;
-		border-bottom-color: $background /* blend into frame below */
-	}
 
-	QTabBar::tab:disabled {
-		color: $tintLighter;
 	}
 
 	QTabBar::tab:selected {
-		background-color: $background;
-	}
 
-	QTabWidget QTabWidget > QTabBar::tab:selected {
-		background-color: $backgroundRaised;
-		border-color: $backgroundRaisedHighlight;
-		border-right-color: $backgroundRaisedLowlight;
-		border-bottom-color: $backgroundRaised; /* blend into frame below */
+		border-bottom-color: $backgroundMid; /* blend into frame below */
+
 	}
 
 	QTabBar::tab:!selected {
-		color: $tintLighterStronger;
+
+		color: $foregroundFaded;
 		background-color: $backgroundDark;
 		border-color: transparent;
-		border-bottom-color: $background;
 	}
 
-	QTabBar::tab:!selected:hover {
-		background-color: $backgroundDarkHighlight;
-	}
+	QTabBar::tab:disabled {
 
-	QTabWidget QTabWidget > QTabBar::tab:!selected {
-		color: $tintLighterStronger;
-		background-color: $backgroundDarkHighlight;
-		border-color: transparent;
-		border-bottom-color: $backgroundRaisedHighlight;
-	}
+		color: $foregroundFaded;
 
-	QTabWidget QTabWidget > QTabBar::tab:!selected:hover {
-		background-color: $backgroundDarkHighlight;
-	}
-
-	QSplitter[gafferHighlighted="true"] {
-
-		border: 1px solid $brightColor;
-	}
-
-	QTabWidget::pane {
-		background-color: $background;
-		/* tab widget frame has a line at the top, tweaked up 1 pixel */
-		/* so that it sits underneath the bottom of the tabs.         */
-		/* this means the active tab can blend into the frame.        */
-		top: -1px;
-		border-radius: 2px;
-		border-top-left-radius: 0;
-		border: 1px solid $backgroundHighlight;
-		border-right-color: $backgroundLowlight;
-		border-bottom-color: $backgroundLowlight;
-	}
-
-	QTabWidget[gafferNumChildren="0"]::pane {
-		background-color: $backgroundDarker;
-		border-color: $backgroundDarker;
-	}
-
-	QTabWidget QTabWidget::pane {
-		background-color: $backgroundRaised;
-		border-radius: $widgetCornerRadius;
-		border-top-left-radius: 0;
-		border-color: $backgroundRaisedHighlight;
-		border-right-color: $backgroundRaisedLowlight;
-		border-bottom-color: $backgroundRaisedLowlight;
 	}
 
 	/* Ensures the QSplitter border is visible if we need to highlight */
 	QSplitter#gafferCompoundEditor[gafferNumChildren="1"] {
+
 		padding: 1px;
+
 	}
 
 	QSplitter::handle:vertical {
+
+		background-color: $backgroundDark;
 		height: 2px;
-		border: 1px;
-		margin: 1px;
-		padding: -2px;
+		margin-top: 2px;
+		margin-bottom: 2px;
+		/* i don't know why the padding has to be here */
+		padding-top: -2px;
+		padding-bottom: -2px;
 	}
 
 	QSplitter::handle:horizontal {
+
+		background-color: $backgroundDark;
 		width: 2px;
-		border: 1px;
-		margin: 1px;
-		padding: -2px;
+		margin-left: 2px;
+		margin-right: 2px;
+
 	}
 
 	/* I'm not sure why this is necessary, but it works around a problem where the */
 	/* style for QSplitter::handle:hover isn't always accepted.                    */
 	QSplitterHandle:hover {}
 
-	QMenu::item:selected, QMenuBar::item:selected, QSplitter::handle:hover {
+	QTabBar::tab:hover, QMenu::item:selected, QMenuBar::item:selected, QSplitter::handle:hover,
+	QComboBox QAbstractItemView::item:hover {
+
 		color: white;
-		background-color: $brightColor;
+		background-color:	$brightColor;
+
 	}
+
+	QSplitter[gafferHighlighted="true"] {
+
+		border: 1px solid $brightColor;
+
+	}
+
+	/* tab widget frame has a line at the top, tweaked up 1 pixel */
+	/* so that it sits underneath the bottom of the tabs.         */
+	/* this means the active tab can blend into the frame.        */
+	QTabWidget::pane {
+		border: 1px solid $backgroundDark;
+		border-top: 1px solid $backgroundDark;
+		top: -1px;
+	}
+
 	QTabWidget[gafferHighlighted=\"true\"]::pane {
 		border: 1px solid $brightColor;
 		border-top: 1px solid $brightColor;
@@ -546,11 +548,8 @@ _styleSheet = string.Template(
 	}
 
 	QTabWidget[gafferHighlighted=\"true\"] > QTabBar::tab:selected {
-		border-bottom-color: $background; /* blend into frame below */
-	}
-
-	QTabwidget QTabWidget[gafferHighlighted=\"true\"] > QTabBar::tab:selected {
-		border-bottom-color: $backgroundRaised; /* blend into frame below */
+		border: 1px solid $brightColor;
+		border-bottom-color: $backgroundMid; /* blend into frame below */
 	}
 
 	QTabWidget[gafferHighlighted=\"true\"] > QTabBar::tab:!selected {
@@ -558,114 +557,128 @@ _styleSheet = string.Template(
 	}
 
 	QCheckBox#gafferCollapsibleToggle {
+
 		font-weight: bold;
 	}
 
 	QWidget#gafferCollapsible QWidget#gafferCollapsible > QCheckBox#gafferCollapsibleToggle {
-		margin-left: 10px;
+
+		margin-left: 12px;
+		font-weight: normal;
+
 	}
 
 	QCheckBox#gafferCollapsibleToggle:disabled {
+
 		color: $foregroundFaded;
+
 	}
 
 	QCheckBox#gafferCollapsibleToggle::indicator {
+
 		width: 12px;
 		height: 12px;
 		background-color: none;
+
 	}
 
 	QCheckBox#gafferCollapsibleToggle::indicator:unchecked {
+
 		image: url($GAFFER_ROOT/graphics/collapsibleArrowDown.png);
+
 	}
 
 	QCheckBox#gafferCollapsibleToggle::indicator:checked {
+
 		image: url($GAFFER_ROOT/graphics/collapsibleArrowRight.png);
+
 	}
 
-	QCheckBox#gafferCollapsibleToggle::indicator:unchecked:hover,
-	QCheckBox#gafferCollapsibleToggle::indicator:unchecked:focus {
+	QCheckBox#gafferCollapsibleToggle::indicator:unchecked:hover, QCheckBox#gafferCollapsibleToggle::indicator:unchecked:focus {
+
 		image: url($GAFFER_ROOT/graphics/collapsibleArrowDownHover.png);
+
 	}
 
-	QCheckBox#gafferCollapsibleToggle::indicator:checked:hover,
-	QCheckBox#gafferCollapsibleToggle::indicator:checked:focus {
+	QCheckBox#gafferCollapsibleToggle::indicator:checked:hover, QCheckBox#gafferCollapsibleToggle::indicator:checked:focus {
+
 		image: url($GAFFER_ROOT/graphics/collapsibleArrowRightHover.png);
+
 	}
 
 	QHeaderView {
+
 		border: 0px;
 		margin: 0px;
+
 	}
 
 	QHeaderView::section {
-		border: 1px solid $backgroundLowlight;
-		border-radius: 0;
-		padding: 3px;
+
+		border: 1px solid $backgroundDark;
+		padding: 6px;
 		font-weight: bold;
 		margin: 0px;
-		background-color: $tintLighter;
-	}
 
-	QHeaderView::section:first#vectorDataWidgetVerticalHeader {
-		border-top-left-radius: $widgetCornerRadius;
-	}
-
-	QHeaderView::section:last#vectorDataWidgetVerticalHeader {
-		border-bottom-left-radius: $widgetCornerRadius;
-	}
-
-	QHeaderView::section:only-one#vectorDataWidgetVerticalHeader {
-		border-top-left-radius: $widgetCornerRadius;
-		border-bottom-left-radius: $widgetCornerRadius;
-	}
-
-	QHeaderView::section:first#vectorDataWidgetHorizontalHeader {
-		border-top-left-radius: $widgetCornerRadius;
-	}
-
-	QHeaderView::section:last#vectorDataWidgetHorizontalHeader {
-		border-top-right-radius: $widgetCornerRadius;
-	}
-
-	QHeaderView::section:only-one#vectorDataWidgetHorizontalHeader {
-		border-top-left-radius: $widgetCornerRadius;
-		border-top-right-radius: $widgetCornerRadius;
 	}
 
 	/* tuck adjacent header sections beneath one another so we only get */
 	/* a single width line between them                                 */
+	QHeaderView::section:horizontal:!first {
 
-	QHeaderView::section:horizontal:!first:!only-one {
 		margin-left: -1px;
+
 	}
 
-	QHeaderView::section:vertical:!first:!only-one {
+	QHeaderView::section:horizontal:only-one {
+
+		margin-left: 0px;
+
+	}
+
+	QHeaderView::section:vertical:!first {
+
 		margin-top: -1px;
+
+	}
+
+	QHeaderView::section:vertical:only-one {
+
+		margin-top: 0px;
+
 	}
 
 	QHeaderView::down-arrow {
+
 		image: url($GAFFER_ROOT/graphics/headerSortDown.png);
+
 	}
 
 	QHeaderView::up-arrow {
+
 		image: url($GAFFER_ROOT/graphics/headerSortUp.png);
+
 	}
 
 	QScrollBar {
-		border: none;
-		border-radius: 4px;
-		background-color: $tintDarker;
+
+		border: 1px solid $backgroundDark;
+		background-color: $backgroundDark;
+
 	}
 
 	QScrollBar:vertical {
-		width: 16px;
-		margin: 4px;
+
+		width: 14px;
+		margin: 0px 0px 28px 0px;
+
 	}
 
 	QScrollBar:horizontal {
-		height: 16px;
-		margin: 4px;
+
+		height: 14px;
+		margin: 0px 28px 0px 0px;
+
 	}
 
 	QScrollBar::add-page, QScrollBar::sub-page {
@@ -674,18 +687,18 @@ _styleSheet = string.Template(
 	}
 
 	QScrollBar::add-line, QScrollBar::sub-line {
-		background-color: none;
-		border: none;
+		background-color: $backgroundLight;
+		border: 1px solid $backgroundDark;
 	}
 
 	QScrollBar::add-line:vertical {
-		height: 8px;
+		height: 14px;
 		subcontrol-position: bottom;
 		subcontrol-origin: margin;
 	}
 
 	QScrollBar::add-line:horizontal {
-		width: 8px;
+		width: 14px;
 		subcontrol-position: right;
 		subcontrol-origin: margin;
 	}
@@ -706,22 +719,42 @@ _styleSheet = string.Template(
 		right: 15px;
 	}
 
+	QScrollBar::down-arrow {
+		image: url($GAFFER_ROOT/graphics/arrowDown10.png);
+	}
+
+	QScrollBar::up-arrow {
+		image: url($GAFFER_ROOT/graphics/arrowUp10.png);
+	}
+
+	QScrollBar::left-arrow {
+		image: url($GAFFER_ROOT/graphics/arrowLeft10.png);
+	}
+
+	QScrollBar::right-arrow {
+		image: url($GAFFER_ROOT/graphics/arrowRight10.png);
+	}
+
 	QScrollBar::handle {
-		background-color: $tintLighterStrong;
-		border-radius: 4px;
-		border: none;
+		background-color: $backgroundLight;
+		border: 1px solid $backgroundDark;
 	}
 
 	QScrollBar::handle:vertical {
 		min-height: 14px;
+		border-left: none;
+		border-right: none;
+		margin-top: -1px;
 	}
 
 	QScrollBar::handle:horizontal {
 		min-width: 14px;
+		border-top: none;
+		border-bottom: none;
+		margin-left: -1px;
 	}
 
-	QScrollBar::handle:hover, QScrollBar::add-line:hover,
-	QScrollBar::sub-line:hover {
+	QScrollBar::handle:hover, QScrollBar::add-line:hover, QScrollBar::sub-line:hover {
 		background-color: $brightColor;
 	}
 
@@ -862,13 +895,13 @@ _styleSheet = string.Template(
 
 	.QFrame#borderStyleNone {
 		border: 1px solid transparent;
-		border-radius: $widgetCornerRadius;
+		border-radius: 4px;
 		padding: 2px;
 	}
 
 	.QFrame#borderStyleFlat {
 		border: 1px solid $backgroundDark;
-		border-radius: $widgetCornerRadius;
+		border-radius: 4px;
 		padding: 2px;
 	}
 
@@ -877,9 +910,7 @@ _styleSheet = string.Template(
 	}
 
 	.QFrame#gafferDivider {
-		color: $tintDarkerStrong;
-		margin-left: 10px;
-		margin-right: 10px;
+		color: $backgroundDark;
 	}
 
 	QToolTip {
@@ -887,23 +918,12 @@ _styleSheet = string.Template(
 		color: $backgroundDarkest;
 		background-color: $foreground;
 		padding: 2px;
+
 	}
-
-
-	/* Tree/Table views */
 
 	QTreeView {
-		background-color: $backgroundRaised;
-		border: 1px solid $backgroundRaisedHighlight;
-		border-bottom-color: $backgroundRaisedLowlight;
-		border-right-color: $backgroundRaisedLowlight;
-		padding: 0;
-		alternate-background-color: $backgroundLowlight;
-	}
-
-	QTreeView::item {
-		padding-top: 2px;
-		padding-bottom: 2px;
+		border: 1px solid $backgroundDark;
+		padding: 0px;
 	}
 
 	QTreeView::item:selected {
@@ -911,11 +931,9 @@ _styleSheet = string.Template(
 	}
 
 	QTableView {
-		border: 1px solid transparent;
-	}
 
-	QTableView::item {
-		background-color: $background;
+		border: 0px solid transparent;
+
 	}
 
 	QTableView::item:selected {
@@ -923,23 +941,23 @@ _styleSheet = string.Template(
 	}
 
 	QTableView QTableCornerButton::section {
-		background-color: transparent;
-		border: none;
+		background-color: $backgroundMid;
+		border: 1px solid $backgroundMid;
 	}
 
 	QTableView#vectorDataWidget {
-		gridline-color: $backgroundLowlight;
+		gridline-color: $backgroundDark;
 		padding: 0px;
-		background-color: $backgroundRaised;
+		background-color: transparent;
 	}
 
 	QTableView#vectorDataWidgetEditable {
 		padding: 0px;
-		gridline-color: $backgroundLowlight;
+		gridline-color: $backgroundDark;
 	}
 
 	QTableView::item#vectorDataWidgetEditable {
-		background-color: $backgroundLight;
+		background-color: $backgroundLighter;
 	}
 
 	QTableView::item:selected#vectorDataWidgetEditable {
@@ -947,6 +965,7 @@ _styleSheet = string.Template(
 	}
 
 	QHeaderView::section#vectorDataWidgetVerticalHeader {
+		background-color: transparent;
 		padding: 2px;
 	}
 
@@ -980,59 +999,81 @@ _styleSheet = string.Template(
 
 	QTableView[gafferHighlighted=\"true\"]#vectorDataWidget,
 	QTableView[gafferHighlighted=\"true\"]#vectorDataWidgetEditable {
+
 		gridline-color: $brightColor;
+
 	}
 
 	QTreeView[gafferHighlighted=\"true\"],
 	QTableView[gafferHighlighted=\"true\"] QHeaderView::section#vectorDataWidgetVerticalHeader {
+
 		border-color: $brightColor;
+
 	}
 
 	/* progress bars */
 
 	QProgressBar {
+
 		border: 1px solid $backgroundDark;
 		background: $backgroundLighter;
 		padding: 1px;
 		text-align: center;
+
 	}
 
 	QProgressBar::chunk:horizontal {
+
 		background-color: $brightColor;
+
 	}
 
 	/* gl widget */
 
 	QGraphicsView#gafferGLWidget {
+
 		border: 0px;
+
 	}
 
 	/* frame variants */
 
 	QFrame#gafferDiffA {
+
 		background: solid rgba( 181, 30, 0, 80 );
+
 	}
 
 	QFrame#gafferDiffB {
+
 		background: solid rgba( 34, 159, 0, 80 );
+
 	}
 
 	QFrame#gafferDiffAB {
+
 		background: solid rgba( 170, 170, 170, 60 );
+
 	}
 
 	QFrame#gafferDiffOther {
+
 		background: solid rgba( 70, 184, 255, 25 );
+
 	}
 
 	QFrame#gafferLighter {
+
 		background: solid rgba( 255, 255, 255, 10 );
+
 	}
 
 	QFrame#gafferDarker {
+
 		background: solid rgba( 0, 0, 0, 80 );
 		border-radius: 2px;
 		padding: 2px;
+
 	}
 
 	QFrame[gafferHighlighted=\"true\"]#gafferDiffA, QFrame[gafferHighlighted=\"true\"]#gafferDiffB, QFrame[gafferHighlighted=\"true\"]#gafferDiffAB {
@@ -1042,49 +1083,39 @@ _styleSheet = string.Template(
 	/* turn off rounded corners based on adjacency of other widgets */
 
 	*[gafferRounded="true"] {
+
 		border-radius: 6px;
+
 	}
 
 	*[gafferFlatTop="true"] {
+
 		border-top-left-radius: 0px;
 		border-top-right-radius: 0px;
+
 	}
 
 	*[gafferFlatBottom="true"] {
+
 		border-bottom-left-radius: 0px;
 		border-bottom-right-radius: 0px;
+
 	}
 
 	*[gafferFlatLeft="true"] {
+
 		border-top-left-radius: 0px;
 		border-bottom-left-radius: 0px;
+
 	}
 
 	*[gafferFlatRight="true"] {
+
 		border-top-right-radius: 0px;
 		border-bottom-right-radius: 0px;
-	}
 
-	/* PythonEditor */
-
-	QSplitter#gafferPythonEditor {
-		background-color: $background;
-	}
-
-	QPlainTextEdit#gafferPythonEditorOutput {
-		border-radius: 0;
-		border-top-left-radius: $widgetCornerRadius;
-		border-top-right-radius: $widgetCornerRadius;
-		background-color: rbg( 30, 30, 30 );
-	}
-
-	QPlainTextEdit#gafferPythonEditorInput {
-		border-radius: 0;
-		border-bottom-left-radius: $widgetCornerRadius;
-		border-bottom-right-radius: $widgetCornerRadius;
 	}
 
 	"""
 
 ).substitute( substitutions )
-


### PR DESCRIPTION
The original concept of the #3193 re-style was a semi-skeuomorphic  'cards' presentation, whereby instead of using solid line borders to define the separation between elements, a subtle relief effect coupled with z-order shading separated different UI elements as if they were thin cards resting on each other. 

As we haven't been too keen on tonal variations in UI elements based on nesting levels, the result is perhaps a little low contrast and half in one camp, half in another. It has also surface numerous styling bugs caused by the wider-reaching scope of the change.

This PR conveys a simpler, rabbit-hole free alternative that should allow the implementation of draggable tabs and close buttons, without the accompanying bugs/inconsistencies were seeing with the new stylesheet.

![image](https://user-images.githubusercontent.com/896779/60025790-42b41300-9692-11e9-9ae6-f536cec77c15.png)

A quick mash-up with the `tabCloseButtons` PR:

![image](https://user-images.githubusercontent.com/896779/60027609-b277cd00-9695-11e9-9560-a96e07013144.png)
