### PR TITLE
SystemCommand : Allow control over the 'shell = True' argument

### DIFF
--- a/python/GafferDispatch/SystemCommand.py
+++ b/python/GafferDispatch/SystemCommand.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import shlex
 import subprocess32 as subprocess
 
 import IECore
@@ -49,6 +50,7 @@ class SystemCommand( GafferDispatch.TaskNode ) :
 		GafferDispatch.TaskNode.__init__( self, name )
 
 		self["command"] = Gaffer.StringPlug()
+		self["shell"] = Gaffer.BoolPlug( defaultValue = True )
 		self["substitutions"] = Gaffer.CompoundDataPlug()
 		self["environmentVariables"] = Gaffer.CompoundDataPlug()
 
@@ -62,6 +64,7 @@ class SystemCommand( GafferDispatch.TaskNode ) :
 
 		h.append( command )
 		self["substitutions"].hash( h )
+		self["shell"].hash( h )
 		self["environmentVariables"].hash( h )
 
 		return h
@@ -81,6 +84,10 @@ class SystemCommand( GafferDispatch.TaskNode ) :
 		for name, value in environmentVariables.items() :
 			env[name] = str( value )
 
-		subprocess.check_call( command, shell = True, env = env )
+		useShell = self["shell"].getValue()
+		if useShell == False :
+			command = shlex.split( command )
+
+		subprocess.check_call( command, shell = useShell, env = env )
 
 IECore.registerRunTimeTyped( SystemCommand, typeName = "GafferDispatch::SystemCommand" )

--- a/python/GafferDispatchTest/SystemCommandTest.py
+++ b/python/GafferDispatchTest/SystemCommandTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import subprocess32 as subprocess
 import unittest
 
 import IECore
@@ -114,6 +115,24 @@ class SystemCommandTest( GafferTest.TestCase ) :
 		sequences = IECore.ls( self.temporaryDirectory() )
 		self.assertEqual( len( sequences ), 1 )
 		self.assertEqual( str( sequences[0] ), "systemCommandTest.####.txt 1-10" )
+
+	def testShell( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = GafferDispatch.SystemCommand()
+
+		self.assertEqual( s["n"]["shell"].getValue(), True )
+
+		# The following command is only valid when interpreted as a shell command
+		s["n"]["command"].setValue( "date | wc -l" )
+
+		s["n"].execute()
+
+		s["n"]["shell"].setValue( False )
+
+		with self.assertRaises( subprocess.CalledProcessError ) :
+			s["n"].execute()
 
 	def testEmptyCommand( self ) :
 

--- a/python/GafferDispatchUI/SystemCommandUI.py
+++ b/python/GafferDispatchUI/SystemCommandUI.py
@@ -80,6 +80,26 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Settings.Environment Variables",
 
+		),
+
+		"shell" : (
+
+			"description",
+			"""
+			When enabled, the specified command is interpreted as a shell
+			command and run in a child shell. This allows semantics such
+			as pipes to be used.  Otherwise the supplied command is invoked
+			directly as an executable and its args.
+
+			> Note: On MacOS with System Integrity Protection enabled, child
+			> shells will not inherit `DYLD_LIBRARY_PATH` from the Gaffer
+			> process. If the executable you are running relies on this,
+			> disabling _shell_ should allow it to inherit the full Gaffer
+			> environment.
+			""",
+
+			"layout:section", "Advanced",
+
 		)
 
 	}


### PR DESCRIPTION
By default, we interpret the supplied command as a shell command. In some
situations using `shell = True` can cause commands to fail.
An example of this is on the Mac where System Integrity Protection blocks
processes in child shells from loading any new dylibs.

API Changes :

 - Adds a 'shell' plug (default True) to `GafferDispatch.SystemCommand` that
   determines whether or not the supplied command is interpreted as a shell
   command or executed directly.
