### PR TITLE
Release 0.53.6.3 : update Changes and SConstruct

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,17 @@
+0.53.6.3 (relative to 0.53.6.2)
+========
+
+Improvements
+------------
+
+- VectorTypedParameterHandler : Added support for Color3fVectorParameter (#3228)
+- CompoundVectorParameterValueWidget : Now preserves selection when editing data (#3228)
+
+Build
+-----
+
+- ie/options: Added support for Houdini 17.5 (#3215)
+
 0.53.6.2 (relative to 0.53.6.1)
 ========
 

--- a/SConstruct
+++ b/SConstruct
@@ -53,7 +53,7 @@ import subprocess
 gafferMilestoneVersion = 0 # for announcing major milestones - may contain all of the below
 gafferMajorVersion = 53 # backwards-incompatible changes
 gafferMinorVersion = 6 # new backwards-compatible features
-gafferPatchVersion = 2 # bug fixes
+gafferPatchVersion = 3 # bug fixes
 
 # All of the following must be considered when determining
 # whether or not a change is backwards-compatible


### PR DESCRIPTION
This is in preparation for a 0.53.6.3 backport release.