### PR TITLE
startup/gui/project : Don't import GafferUI modules in headless mode

### DIFF
--- a/startup/gui/project.py
+++ b/startup/gui/project.py
@@ -34,14 +34,14 @@
 #
 ##########################################################################
 
-import os
 import functools
+import os
+import sys
 
 import IECore
 
 import Gaffer
 import GafferImage
-import GafferUI
 import GafferDispatch
 
 ##########################################################################
@@ -93,9 +93,15 @@ def __projectBookmark( widget, location ) :
 	else :
 		return os.getcwd()
 
-GafferUI.Bookmarks.acquire( application ).add( "Project", functools.partial( __projectBookmark, location="${project:rootDirectory}" ) )
-GafferUI.Bookmarks.acquire( application, category="script" ).setDefault( functools.partial( __projectBookmark, location="${project:rootDirectory}/scripts" ) )
-GafferUI.Bookmarks.acquire( application, category="reference" ).setDefault( functools.partial( __projectBookmark, location="${project:rootDirectory}/references" ) )
+
+# We don't want to load UI modules unless we know we are in a UI context,
+# otherwise we force a connection to X. This situation arises as this startup
+# file is shared with the dispatch app, which has a headless mode.
+if 'GafferUI' in sys.modules :
+	import GafferUI
+	GafferUI.Bookmarks.acquire( application ).add( "Project", functools.partial( __projectBookmark, location="${project:rootDirectory}" ) )
+	GafferUI.Bookmarks.acquire( application, category="script" ).setDefault( functools.partial( __projectBookmark, location="${project:rootDirectory}/scripts" ) )
+	GafferUI.Bookmarks.acquire( application, category="reference" ).setDefault( functools.partial( __projectBookmark, location="${project:rootDirectory}/references" ) )
 
 ##########################################################################
 # Dispatchers


### PR DESCRIPTION
This startup script is shared with the `dispatch` app. The dispatch app runs without a gui by default (unless --gui is specified). If dispatch is run on a machine with no X display, the imports of `GafferUI` cause a `QXcbConnection Could not connect to display` error and a subsequent abort.

We now only initialize bookmarks if the application sourcing the startup file has already loaded the UI modules.
