### PR TITLE
CropWindowTool : Consider read-only state when finding target plug

### DIFF
--- a/include/GafferSceneUI/CropWindowTool.h
+++ b/include/GafferSceneUI/CropWindowTool.h
@@ -76,6 +76,8 @@ class GAFFERSCENEUI_API CropWindowTool : public GafferUI::Tool
 
 		void viewportChanged();
 		void plugDirtied( const Gaffer::Plug *plug );
+		void nodeMetadataChanged( IECore::InternedString key, const Gaffer::Node *node );
+		void plugMetadataChanged( IECore::InternedString key, const Gaffer::Plug *plug );
 		void overlayRectangleChanged( unsigned reason );
 
 		void preRender();

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -585,6 +585,8 @@ void CropWindowTool::findCropWindowPlug()
 		m_overlay->setCaption( "No crop window found. Insert a StandardOptions node." );
 		m_cropWindowPlugDirtiedConnection.disconnect();
 	}
+
+	m_needCropWindowPlugSearch = false;
 }
 
 bool CropWindowTool::findCropWindowPlug( const SceneAlgo::History *history, bool enabledOnly )

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -45,6 +45,8 @@
 #include "GafferUI/Style.h"
 
 #include "Gaffer/BlockedConnection.h"
+#include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/UndoScope.h"
@@ -421,6 +423,9 @@ CropWindowTool::CropWindowTool( SceneView *view, const std::string &name )
 	view->viewportGadget()->viewportChangedSignal().connect( boost::bind( &CropWindowTool::viewportChanged, this ) );
 	view->viewportGadget()->preRenderSignal().connect( boost::bind( &CropWindowTool::preRender, this ) );
 	plugDirtiedSignal().connect( boost::bind( &CropWindowTool::plugDirtied, this, ::_1 ) );
+
+	Metadata::plugValueChangedSignal().connect( boost::bind( &CropWindowTool::plugMetadataChanged, this, ::_3, ::_4 ) );
+	Metadata::nodeValueChangedSignal().connect( boost::bind( &CropWindowTool::nodeMetadataChanged, this, ::_2, ::_3 ) );
 }
 
 CropWindowTool::~CropWindowTool()
@@ -456,6 +461,49 @@ void CropWindowTool::plugDirtied( const Gaffer::Plug *plug )
 	else if( plug == m_cropWindowPlug || plug == m_cropWindowEnabledPlug )
 	{
 		m_overlayDirty = true;
+	}
+}
+
+void CropWindowTool::nodeMetadataChanged( IECore::InternedString key, const Gaffer::Node* node )
+{
+	if( !m_cropWindowPlug || m_overlayDirty )
+	{
+		return;
+	}
+
+	if( node != m_cropWindowPlug->node() )
+	{
+		return;
+	}
+
+	if( MetadataAlgo::readOnlyAffectedByChange( key ) )
+	{
+		m_needCropWindowPlugSearch = m_overlayDirty = true;
+		view()->viewportGadget()->renderRequestSignal()(
+			view()->viewportGadget()
+		);
+	}
+}
+
+void CropWindowTool::plugMetadataChanged( IECore::InternedString key, const Gaffer::Plug* plug )
+{
+	if( !m_cropWindowPlug || m_overlayDirty )
+	{
+		return;
+	}
+
+	if(
+	    plug == m_cropWindowPlug
+	    || plug->isAncestorOf( m_cropWindowPlug.get() )
+	    || ( m_cropWindowEnabledPlug && plug == m_cropWindowEnabledPlug )
+	) {
+		if( MetadataAlgo::readOnlyAffectedByChange( key ) )
+		{
+			m_needCropWindowPlugSearch = m_overlayDirty = true;
+			view()->viewportGadget()->renderRequestSignal()(
+				view()->viewportGadget()
+			);
+		}
 	}
 }
 
@@ -565,7 +613,11 @@ void CropWindowTool::findCropWindowPlug()
 	SceneAlgo::History::Ptr history = SceneAlgo::history( scenePlug()->globalsPlug(), rootPath );
 	if( history )
 	{
-		if( !findCropWindowPlug( history.get(), /* enabledOnly = */ true ) )
+		const bool foundAnEnabledPlug = findCropWindowPlug( history.get(), /* enabledOnly = */ true );
+		// If we didn't find an enabled cropWindow plug upstream, or we did and it's
+		// read-only, look again for any other plugs that could be edited, but aren't
+		// enabled yet. We'll enable it if the user makes an edit.
+		if( !foundAnEnabledPlug || MetadataAlgo::readOnly( m_cropWindowPlug.get() ) )
 		{
 			findCropWindowPlug( history.get(), /* enabledOnly = */ false );
 		}
@@ -573,10 +625,29 @@ void CropWindowTool::findCropWindowPlug()
 
 	if( m_cropWindowPlug )
 	{
-		bool editable = m_cropWindowPlug->settable();
-		editable = m_cropWindowEnabledPlug ? editable || m_cropWindowEnabledPlug->settable() : editable;
-		m_overlay->setEditable( editable );
-		m_overlay->setCaption( m_cropWindowPlug->relativeName( m_cropWindowPlug->ancestor<ScriptNode>() ) );
+		const std::string plugName =  m_cropWindowPlug->relativeName( m_cropWindowPlug->ancestor<ScriptNode>() );
+
+		// If even after the second search, we could still be read-only
+		if( MetadataAlgo::readOnly( m_cropWindowPlug.get() ) )
+		{
+			m_overlay->setEditable( false );
+			m_overlay->setCaption( plugName + " is locked" );
+		}
+		else
+		{
+			bool plugEditable = m_cropWindowPlug->settable();
+
+			// If our cropWindow plug hasn't been enabled, we need to check if it's corresponding 'enabled'
+			// plug is editable, it could be expressioned or locked even if our value plug isn't.
+			if( m_cropWindowEnabledPlug && m_cropWindowEnabledPlug->getValue() == false )
+			{
+				plugEditable &= ( m_cropWindowEnabledPlug->settable() && !MetadataAlgo::readOnly( m_cropWindowEnabledPlug.get() ) );
+			}
+
+			m_overlay->setEditable( plugEditable );
+			m_overlay->setCaption( plugEditable ? plugName : ( plugName + " isn't editable" ) );
+		}
+
 		m_cropWindowPlugDirtiedConnection = m_cropWindowPlug->node()->plugDirtiedSignal().connect( boost::bind( &CropWindowTool::plugDirtied, this, ::_1 ) );
 	}
 	else

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -627,7 +627,7 @@ void CropWindowTool::findCropWindowPlug()
 	{
 		const std::string plugName =  m_cropWindowPlug->relativeName( m_cropWindowPlug->ancestor<ScriptNode>() );
 
-		// If even after the second search, we could still be read-only
+		// Even after the second search, we could still be read-only
 		if( MetadataAlgo::readOnly( m_cropWindowPlug.get() ) )
 		{
 			m_overlay->setEditable( false );

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -466,12 +466,12 @@ void CropWindowTool::plugDirtied( const Gaffer::Plug *plug )
 
 void CropWindowTool::nodeMetadataChanged( IECore::InternedString key, const Gaffer::Node* node )
 {
-	if( !m_cropWindowPlug || m_overlayDirty )
+	if( !m_cropWindowPlug || m_needCropWindowPlugSearch )
 	{
 		return;
 	}
 
-	if( node != m_cropWindowPlug->node() )
+	if( node != m_cropWindowPlug->node() && !node->isAncestorOf( m_cropWindowPlug->node() ) )
 	{
 		return;
 	}
@@ -487,7 +487,7 @@ void CropWindowTool::nodeMetadataChanged( IECore::InternedString key, const Gaff
 
 void CropWindowTool::plugMetadataChanged( IECore::InternedString key, const Gaffer::Plug* plug )
 {
-	if( !m_cropWindowPlug || m_overlayDirty )
+	if( !m_cropWindowPlug || m_needCropWindowPlugSearch )
 	{
 		return;
 	}


### PR DESCRIPTION
Fixes #3236

User Facing Changes :

 - The `CropWindowTool` now properly considers a plug's read-only state when
   looking for a crop window to edit. This covers nodes within references
   as well as individually locked plugs.
