### PR TITLE
Auzure : Only append build type if it is DEBUG

### DIFF
--- a/config/azure/publishBuild.py
+++ b/config/azure/publishBuild.py
@@ -118,12 +118,12 @@ if not args.githubAccessToken :
 
 
 formatVars = {
-	"type" : os.environ.get( "BUILD_TYPE", "UNKNOWN" ).title(),
+	"buildTypeSuffix" : " Debug" if os.environ.get( "BUILD_TYPE", "" ) == "DEBUG" else "",
 	"platform" : "MacOS" if sys.platform == "darwin" else "Linux",
 }
 
 if not args.context :
-	args.context = "CI Build ({platform} {type})".format( **formatVars )
+	args.context = "CI Build ({platform}{buildTypeSuffix})".format( **formatVars )
 
 if not os.path.exists( args.archive ) :
 	parser.exit( 1, "The specified archive '%s' does not exist." % args.archive )

--- a/config/azure/setBuildVars.py
+++ b/config/azure/setBuildVars.py
@@ -61,7 +61,7 @@ def getCommitHash() :
 	return commit
 
 formatVars = {
-	"buildType" : os.environ.get( "BUILD_TYPE", "UNKNOWN" ).title(),
+	"buildTypeSuffix" : "-debug" if os.environ.get( "BUILD_TYPE", "" ) == "DEBUG" else "",
 	"platform" : "MacOS" if sys.platform == "darwin" else "Linux",
 	"timestamp" : datetime.datetime.now().strftime( "%Y%m%d%H%M" ),
 	"pullRequest" : os.environ.get( "SYSTEM_PULLREQUEST_PULLREQUESTNUMBER", "UNKNOWN" ),
@@ -69,8 +69,8 @@ formatVars = {
 }
 
 nameFormats = {
-	"default" : "gaffer-{timestamp}-{commit}-{platform}-{buildType}",
-	"PullRequest" : "gaffer-PR{pullRequest}-{commit}-{platform}-{buildType}"
+	"default" : "gaffer-{timestamp}-{commit}-{platform}{buildTypeSuffix}",
+	"PullRequest" : "gaffer-PR{pullRequest}-{commit}-{platform}{buildTypeSuffix}"
 }
 
 trigger = os.environ.get( 'BUILD_REASON', 'Manual' )

--- a/config/azure/setBuildVars.py
+++ b/config/azure/setBuildVars.py
@@ -62,7 +62,7 @@ def getCommitHash() :
 
 formatVars = {
 	"buildTypeSuffix" : "-debug" if os.environ.get( "BUILD_TYPE", "" ) == "DEBUG" else "",
-	"platform" : "MacOS" if sys.platform == "darwin" else "Linux",
+	"platform" : "macos" if sys.platform == "darwin" else "linux",
 	"timestamp" : datetime.datetime.now().strftime( "%Y%m%d%H%M" ),
 	"pullRequest" : os.environ.get( "SYSTEM_PULLREQUEST_PULLREQUESTNUMBER", "UNKNOWN" ),
 	"commit" : getCommitHash()


### PR DESCRIPTION
In order to avoid ambiguity between pre-release CI builds and an actual software release, we now only include the build type (`RELEASE|DEBUG`) in the archive name if its a debug build.