### PR TITLE
Experiment : Use internal expression format for evaluation

### DIFF
--- a/include/Gaffer/Expression.h
+++ b/include/Gaffer/Expression.h
@@ -113,7 +113,13 @@ class GAFFER_API Expression : public ComputeNode
 				/// that are read from and written to by the expression, and the
 				/// contextVariables array with the names of context variables the
 				/// expression will access.
-				virtual void parse( Expression *node, const std::string &expression, std::vector<ValuePlug *> &inputs, std::vector<ValuePlug *> &outputs, std::vector<IECore::InternedString> &contextVariables ) = 0;
+				///
+				/// If the "external" flag is set True, plug paths are relative to
+				/// the parent of the node, rather than the node itself.
+				/// Expressions in external format are not executed, but they do
+				/// need to be parsed in order to get the list of plugs to create
+				/// internal counterparts for while setting up an expression.
+				virtual void parse( Expression *node, const std::string &expression, std::vector<ValuePlug *> &inputs, std::vector<ValuePlug *> &outputs, std::vector<IECore::InternedString> &contextVariables, bool external = false ) = 0;
 				/// Executes the last parsed expression in the specified context, using the values
 				/// provided by proxyInputs and returning an array containing a value for
 				/// each output plug. The results returned will later be passed to apply()

--- a/python/GafferOSLTest/OSLExpressionEngineTest.py
+++ b/python/GafferOSLTest/OSLExpressionEngineTest.py
@@ -39,6 +39,7 @@ import inspect
 import math
 import os
 import imath
+import re
 
 import IECore
 
@@ -606,6 +607,93 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 
 			c["str"] = "abc"
 			self.assertEqual( s["n"]["user"]["i"].getValue(), 1 )
+
+	def testDuplicateDeserialise( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["source"] = Gaffer.Node()
+		s["source"]["p"] = Gaffer.V3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["source"]["p"].setValue( imath.V3f( 0.1, 0.2, 0.3 ) )
+
+		s["dest"] = Gaffer.Node()
+		s["dest"]["p"] = Gaffer.V3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression(
+			"parent.dest.p.x = parent.source.p.x + 1;\n" +
+			"parent.dest.p.y = parent.source.p.y + 2;\n" +
+			"parent.dest.p.z = parent.source.p.z + 3;\n",
+			"OSL",
+		)
+
+		ss = s.serialise()
+
+		s.execute( ss )
+		s.execute( ss )
+
+		self.assertEqual( s["dest"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest1"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest2"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+
+		# Working well so far, but we've had a bug that could be hidden by the caching.  Lets
+		# try evaluating the plugs again, but flushing the cache each time
+		prevMemory = Gaffer.ValuePlug.getCacheMemoryLimit()
+		Gaffer.ValuePlug.setCacheMemoryLimit( 0 )
+		try:
+			self.assertEqual( s["dest"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+			self.assertEqual( s["dest1"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+			self.assertEqual( s["dest2"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		finally:
+			Gaffer.ValuePlug.setCacheMemoryLimit( prevMemory )
+
+	def testIndependentOfOrderOfPlugNames( self ) :
+		# We shouldn't depend on p0 being the first plug mentioned in the expression - as long as p0 is assigned
+		# correctly, the expression should still work
+
+		# Set up an expression with lots of plugs
+		s = Gaffer.ScriptNode()
+
+		exprLines = []
+		for i in range( 10 ):
+			s["source%i"%i] = Gaffer.Node()
+			s["source%i"%i]["p"] = Gaffer.V3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+			s["source%i"%i]["p"].setValue( imath.V3f( 0.1, 0.2, 0.3 ) + 0.3 * i )
+			s["dest%i"%i] = Gaffer.Node()
+			s["dest%i"%i]["p"] = Gaffer.V3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+			for a in "xyz":
+				exprLines.append(  "parent.dest%i.p.%s = parent.source%i.p.%s + 10 * %i;" % ( i, a, i, a, i ) )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( "\n".join( exprLines ), "OSL" )
+
+		for i in range( 10 ):
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().x, 0.1 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().y, 0.2 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().z, 0.3 + 0.3 * i + 10 * i, places = 5 )
+
+		# Now serialize it, and reverse the order of all the lines in the expression before deserializing it
+		ss = s.serialise()
+
+		ssLines = ss.split( "\n" )
+		ssLinesEdited = []
+		for l in ssLines:
+			m = re.match( "^__children\[\"e\"\]\[\"__expression\"\].setValue\( '(.*)' \)$", l )
+			if not m:
+				ssLinesEdited.append( l )
+			else:
+				lines = m.groups()[0].split( "\\n" );
+				ssLinesEdited.append( "__children[\"e\"][\"__expression\"].setValue( '%s' )" % "\\n".join( lines[::-1] ) )
+
+		del s
+		s = Gaffer.ScriptNode()
+		s.execute( "\n".join( ssLinesEdited) )
+
+		for i in range( 10 ):
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().x, 0.1 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().y, 0.2 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().z, 0.3 + 0.3 * i + 10 * i, places = 5 )
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -39,6 +39,7 @@ import os
 import inspect
 import unittest
 import imath
+import re
 
 import IECore
 
@@ -1415,6 +1416,92 @@ class ExpressionTest( GafferTest.TestCase ) :
 			del c["a"]
 			self.assertEqual( s["n"]["op1"].getValue(), 0 )
 			self.assertEqual( s["n"]["op2"].getValue(), 1 )
+
+	def testDuplicateDeserialise( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["source"] = GafferTest.CompoundNumericNode()
+		s["source"]["p"].setValue( imath.V3f( 0.1, 0.2, 0.3 ) )
+
+		s["dest"] = GafferTest.CompoundNumericNode()
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression(
+			"parent[\"dest\"][\"p\"]['x'] = parent[\"source\"][\"p\"]['x'] + 1;\n" +
+			"parent[\"dest\"][\"p\"]['y'] = parent[\"source\"][\"p\"]['y'] + 2;\n" +
+			"parent[\"dest\"][\"p\"]['z'] = parent[\"source\"][\"p\"]['z'] + 3;\n",
+			"python",
+		)
+
+		ss = s.serialise()
+
+		s.execute( ss )
+		s.execute( ss )
+
+		self.assertEqual( s["dest"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest1"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest2"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+
+		# Working well so far, but we've had a bug that could be hidden by the caching.  Lets
+		# try evaluating the plugs again, but flushing the cache each time
+		prevMemory = Gaffer.ValuePlug.getCacheMemoryLimit()
+		Gaffer.ValuePlug.setCacheMemoryLimit( 0 )
+		try:
+			self.assertEqual( s["dest"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+			self.assertEqual( s["dest1"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+			self.assertEqual( s["dest2"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		finally:
+			Gaffer.ValuePlug.setCacheMemoryLimit( prevMemory )
+
+	def testIndependentOfOrderOfPlugNames( self ) :
+		# We shouldn't depend on p0 being the first plug mentioned in the expression - as long as p0 is assigned
+		# correctly, the expression should still work
+
+		# Set up an expression with lots of plugs
+		s = Gaffer.ScriptNode()
+
+		exprLines = []
+		for i in range( 10 ):
+			s["source%i"%i] = GafferTest.CompoundNumericNode()
+			s["source%i"%i]["p"].setValue( imath.V3f( 0.1, 0.2, 0.3 ) + 0.3 * i )
+			s["dest%i"%i] = GafferTest.CompoundNumericNode()
+			for a in "xyz":
+				exprLines.append(
+					"parent[\"dest%i\"][\"p\"]['%s'] = parent[\"source%i\"][\"p\"]['%s'] + 10 * %i;" % (
+						i, a, i, a, i
+					)
+				)
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( "\n".join( exprLines ), "python" )
+
+		for i in range( 10 ):
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().x, 0.1 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().y, 0.2 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().z, 0.3 + 0.3 * i + 10 * i, places = 5 )
+
+		# Now serialize it, and reverse the order of all the lines in the expression before deserializing it
+		ss = s.serialise()
+
+		ssLines = ss.split( "\n" )
+		ssLinesEdited = []
+		for l in ssLines:
+			m = re.match( "^__children\[\"e\"\]\[\"__expression\"\].setValue\( '(.*)' \)$", l )
+			if not m:
+				ssLinesEdited.append( l )
+			else:
+				lines = m.groups()[0].split( "\\n" );
+				ssLinesEdited.append( "__children[\"e\"][\"__expression\"].setValue( '%s' )" % "\\n".join( lines[::-1] ) )
+
+		del s
+		s = Gaffer.ScriptNode()
+		s.execute( "\n".join( ssLinesEdited) )
+
+		for i in range( 10 ):
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().x, 0.1 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().y, 0.2 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().z, 0.3 + 0.3 * i + 10 * i, places = 5 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferModule/ExpressionBinding.cpp
+++ b/src/GafferModule/ExpressionBinding.cpp
@@ -115,7 +115,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 		{
 		}
 
-		void parse( Expression *node, const std::string &expression, std::vector<ValuePlug *> &inputs, std::vector<ValuePlug *> &outputs, std::vector<IECore::InternedString> &contextVariables ) override
+		void parse( Expression *node, const std::string &expression, std::vector<ValuePlug *> &inputs, std::vector<ValuePlug *> &outputs, std::vector<IECore::InternedString> &contextVariables, bool external ) override
 		{
 			if( isSubclassed() )
 			{
@@ -126,7 +126,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 					if( f )
 					{
 						list pythonInputs, pythonOutputs, pythonContextVariables;
-						f( ExpressionPtr( node ), expression, pythonInputs, pythonOutputs, pythonContextVariables );
+						f( ExpressionPtr( node ), expression, pythonInputs, pythonOutputs, pythonContextVariables, external );
 
 						container_utils::extend_container( inputs, pythonInputs );
 						container_utils::extend_container( outputs, pythonOutputs );

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -702,7 +702,11 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 
 			for( int i = 0, e = inPlugPaths.size(); i < e; ++i )
 			{
-				string parameter = "_" + inPlugPaths[i];
+				string parameter = inPlugPaths[i];
+				if( parameter[0] != '_' )
+				{
+					parameter = "_" + parameter;
+				}
 				replace_all( parameter, ".", "_" );
 				replace_all( result, "parent." + inPlugPaths[i], parameter );
 				inParameters.push_back( ustring( parameter ) );
@@ -710,7 +714,11 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 
 			for( int i = 0, e = outPlugPaths.size(); i < e; ++i )
 			{
-				string parameter = "_" + outPlugPaths[i];
+				string parameter = outPlugPaths[i];
+				if( parameter[0] != '_' )
+				{
+					parameter = "_" + parameter;
+				}
 				replace_all( parameter, ".", "_" );
 				replace_all( result, "parent." + outPlugPaths[i], parameter );
 				outParameters.push_back( ustring( parameter ) );


### PR DESCRIPTION
On Friday, Ivan asked me to take a look at the expression copy-and-paste bug, since it's a nasty one, and it seems like the overall expression overhaul won't happen for a bit.

To summarize after a bit of investigation:
Bad news : I can't see any way to resolve this cleanly with how we currently treat expressions
Good news : It actually looks pretty easy to switch up how we handle expressions, in a way that is fully backwards compatible.  Maybe there's something about this switch that's a bit weird, but on the whole, it feels less weird than what we're currently doing - and it feels like it's a small step in the direction we want to head with expressions anyway.

The simplest description of the current issue:  you have expression that looks like:
"someNode.somePlug = ...; otherNode.otherPlug = ..."

In order to build the output vector, you need to know which of these outputs is p0 and which is p1.  This is currently rather tricky.  If it's an OSL expression, someNode.somePlug is p0, because it comes first.  This introduces a kind of unexpected interaction between the order plugs are mentioned, and the result, but it's at least consistent.  If it's a Python expression, however, which is p0 depends on whether "someNode.somePlug" < "otherNode.otherPlug", not according to string comparison, but according to the hash function used by Python's set.  This is arbitrary, but consistent, so while weird, it does work ... until you copy and paste the expression into a scene where someNode or otherNode already exists.  Then these nodes get renamed, and it's random whether the ordering stays the same, creating the possibility for the expression's outputs to get scrambled.

Simple solution: just always use the OSL approach based on the order plugs are mentioned.  Problem:  this breaks compatibility with all existing Python expressions.  We could try and patch this up with a ridiculous compatibility config, but what do we really want?

Ideally, copy and pasting would be robust, and the order plugs are mentioned in wouldn't matter.  How could we achieve this?  Well, the serialization format is clearly consistent:  if p0 is connected to otherNode.otherPlug, and p1 is connected to someNode.somePlug, and the expression is serialized as "__out.p1 = 5; _out.p0 = 3;", then the result is clear.

This lead to the question of "Why don't we just execute the same format we serialize".  Originally, this was just a hypothetical to understand the problem better - I'm sure it's based on the way expressions were originally before we changed the serialization format.  But once I started playing around with it, it was actually pretty easy to get it working with this switched.

The result is something that passes both my new tests, and it seems to make more sense to me at least.  There is probably some more rejiggering that could be done if this is the direction we want to move, but I wanted to start my making an absolutely minimal set of code changes.

One thing that could be done differently with this approach:  when external = false, the plug outputs of parse() are always something like "__out.p0, __out.p1, __out.p2, ... , __out.p[NUM_OUTPUTS-1]".  Currently, I've set up a special sort operator to make sure we order these correctly, but we could just count them and then have a for loop that writes out the names from scratch, since they're always the same - again, I'm currently err'ing on the side of changing the current approach as little as possible while fixing the bug.

What do you think?  I've named this Experimental, since it's a slightly more fundamental change than I was expecting to make, but as far as I can, it's pretty solid and deployable.  ( More testing definitely required, since the most recent version of this code has only been run on the expression specific tests, and it's late enough I'm not waiting to see if all the tests pass ).
