### PR TITLE
CompoundEditor : Only show node names for pinned editors

### DIFF
--- a/python/Gaffer/NodeAlgo.py
+++ b/python/Gaffer/NodeAlgo.py
@@ -138,3 +138,15 @@ def __applyUserDefaults( graphComponent ) :
 
 	for plug in graphComponent.children( Gaffer.Plug ) :
 		__applyUserDefaults( plug )
+
+##########################################################################
+# Names
+##########################################################################
+
+def appendNodeNames( string, nodes ) :
+
+	if len(nodes) :
+		string += " [%s]" % ", ".join( [ n.getName() for n in nodes ] )
+
+	return string
+

--- a/python/GafferSceneUI/PrimitiveInspector.py
+++ b/python/GafferSceneUI/PrimitiveInspector.py
@@ -224,6 +224,10 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 
 		return "GafferSceneUI.PrimitiveInspector( scriptNode )"
 
+	def _affectedNodes( self, nodeSet ) :
+
+		return GafferUI.NodeSetEditor._nodeSetSubset( nodeSet, maxNodes = 1, reverseNodes = False )
+
 	def _updateFromSet( self ) :
 		GafferUI.NodeSetEditor._updateFromSet( self )
 
@@ -231,7 +235,7 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 		self.__plugDirtiedConnections = []
 		self.__parentChangedConnections = []
 
-		node = self._lastAddedNode()
+		node = self._lastAffectedNode()
 
 		if node :
 

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -225,7 +225,7 @@ class SceneInspector( GafferUI.NodeSetEditor ) :
 		self.__scenePlugs = []
 		self.__plugDirtiedConnections = []
 		self.__parentChangedConnections = []
-		for node in self.getNodeSet()[-2:] :
+		for node in self.affectedNodesSet() :
 			outputScenePlugs = [ p for p in node.children( GafferScene.ScenePlug ) if p.direction() == Gaffer.Plug.Direction.Out ]
 			if len( outputScenePlugs ) :
 				self.__scenePlugs.append( outputScenePlugs[0] )
@@ -241,9 +241,9 @@ class SceneInspector( GafferUI.NodeSetEditor ) :
 				self.__updateLazily()
 				break
 
-	def _titleFormat( self ) :
+	def _affectedNodes( self, nodeSet ) :
 
-		return GafferUI.NodeSetEditor._titleFormat( self, _maxNodes = 2, _reverseNodes = True, _ellipsis = False )
+		return GafferUI.NodeSetEditor._nodeSetSubset( nodeSet, maxNodes = 2, reverseNodes = True )
 
 	def __plugDirtied( self, plug ) :
 
@@ -1223,7 +1223,7 @@ class _SectionWindow( GafferUI.Window ) :
 		# tricky because sections resize lazily when they are first shown.
 		self._qtWidget().resize( 400, 250 )
 
-		editor.getNodeSet().memberRemovedSignal().connect( Gaffer.WeakMethod( self.__nodeSetMemberRemoved ), scoped = False )
+		editor.affectedNodesSet().memberRemovedSignal().connect( Gaffer.WeakMethod( self.__nodeSetMemberRemoved ), scoped = False )
 
 	def __nodeSetMemberRemoved( self, set, node ) :
 

--- a/python/GafferUI/NodeEditor.py
+++ b/python/GafferUI/NodeEditor.py
@@ -113,7 +113,7 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 		self.__nodeUI = None
 		self.__nameWidget = None
 
-		node = self._lastAddedNode()
+		node = self._lastAffectedNode()
 		if not node :
 			with self.__column :
 				GafferUI.Spacer( imath.V2i( 0 ) )
@@ -166,9 +166,9 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 		self.__nodeUI.setReadOnly( self.getReadOnly() )
 		frame.setChild( self.__nodeUI )
 
-	def _titleFormat( self ) :
+	def _affectedNodes( self, nodeSet ) :
 
-		return GafferUI.NodeSetEditor._titleFormat( self, _maxNodes = 1, _reverseNodes = True, _ellipsis = False )
+		return GafferUI.NodeSetEditor._nodeSetSubset( nodeSet, maxNodes = 1, reverseNodes = True )
 
 	def __menuDefinition( self ) :
 

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -189,9 +189,13 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 
 		self.__updateFromSetInternal()
 
+	def _affectedNodes( self, nodeSet ) :
+
+		return GafferUI.NodeSetEditor._nodeSetSubset( nodeSet, maxNodes = 1, reverseNodes = True )
+
 	def __updateFromSetInternal( self, lazy=True ) :
 
-		node = self._lastAddedNode()
+		node = self._lastAffectedNode()
 
 		if lazy and node == self.__node :
 			return

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -179,7 +179,7 @@ class Viewer( GafferUI.NodeSetEditor ) :
 
 		self.__currentView = None
 
-		node = self._lastAddedNode()
+		node = self._lastAffectedNode()
 		if node :
 			for plug in node.children( Gaffer.Plug ) :
 				if plug.direction() == Gaffer.Plug.Direction.Out and not plug.getName().startswith( "__" ) :
@@ -218,9 +218,9 @@ class Viewer( GafferUI.NodeSetEditor ) :
 
 		self.__primaryToolChanged()
 
-	def _titleFormat( self ) :
+	def _affectedNodes( self, nodeSet ) :
 
-		return GafferUI.NodeSetEditor._titleFormat( self, _maxNodes = 1, _reverseNodes = True, _ellipsis = False )
+		return GafferUI.NodeSetEditor._nodeSetSubset( nodeSet, maxNodes = 1, reverseNodes = True )
 
 	def __primaryToolChanged( self, *unused ) :
 


### PR DESCRIPTION
As part of our UI declutter, the `CompoundEditor` now only displays node names in a tab's title when the editor in question is pinned. This makes skim-reading tabs easier, and allows users to know at-a-glance if a tab is pinned without having to switch to it to see the icon. This required some changes to how tab titles are generated.

Previously, `NodeSetEditor `took care of generating a title string that reflected which nodes an editor was affecting. The display of the title itself however was never part of `Editor` but instead implemented by `CompoundEditor` or `_EditorWindow`. This made it difficult for the presenting code to have any control over the length/format of this title as it may required editors to know about concepts only understood by its parent container - eg: pinning.

This commit:

 - Introduces the concept of `affectedNodes` to the `NodeSetEditor`, that defines which of the nodes in the specified `nodeSet` are being affected by the editor.

 - It removes information about an editors affected node set from it's title string.

 - The `CompoundEditor` and `_EditorWindow` now make use of `NodeAlgo` to suffix the title string (if appropriate) before presentation.

 - The `CompoundEditor` now only appends the affected node set if an Editor is pinned, this cleans up the Tab Bar significantly.

### User Facing Changes:

 - Editor tab titles now only contain node names if the editor is pinned. This makes it easier to see at a glance which editors are pinned and makes the tab bar easier to read at a glance.

### API Changes :

 - Adds `GafferUI.NodeSetEditor.affectdNodesSet` to retrieve the set of affected nodes from an editor.

 - `NodeSetEditor` derived classes are now expected to implement `_affectedNodes` to reduce the incoming node set to those they are concerned with.

 - Adds `Gaffer.NodeAlgo.appendNodeNames` to share common string building code amongst classes that present NodeSetEditor titles to the user.

 - `NodeSetEditor._titleFormat` will no longer be called.

 - `NodeSetEditor._lastAddedNode` -> `NodeSetEditor._lastAffectedNode`
