### PR TITLE
SConstruct : Disable GafferCortex by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
     - $COMPILER --version
 
 script:
-    - scons -j 2 install CXX=$COMPILER CXXSTD=$CXXSTD BUILD_TYPE=$BUILD_TYPE ENV_VARS_TO_IMPORT=PATH DELIGHT_ROOT=$DELIGHT BUILD_DIR=./build INSTALL_DIR=./install BUILD_CACHEDIR=sconsCache
+    - scons -j 2 install CXX=$COMPILER CXXSTD=$CXXSTD BUILD_TYPE=$BUILD_TYPE GAFFERCORTEX=1 ENV_VARS_TO_IMPORT=PATH DELIGHT_ROOT=$DELIGHT BUILD_DIR=./build INSTALL_DIR=./install BUILD_CACHEDIR=sconsCache
     # Preload libSegFault when running tests, so we get stack
     # traces from any crashes.
     - export LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so

--- a/SConstruct
+++ b/SConstruct
@@ -282,7 +282,7 @@ options.Add(
 		"GAFFERCORTEX",
 		"Builds and installs the GafferCortex modules. These are deprecated and will "
 		"be removed completely in a future version.",
-		True
+		False
 	)
 )
 

--- a/config/ie/options
+++ b/config/ie/options
@@ -208,6 +208,8 @@ if targetAppVersion :
 	BUILD_DIR = os.path.join( BUILD_DIR, targetAppMajorVersion )
 	INSTALL_DIR = os.path.join( INSTALL_DIR, targetAppMajorVersion )
 
+GAFFERCORTEX = True
+
 ##########################################################################
 # get include locations right
 ##########################################################################

--- a/python/GafferUITest/EditorTest.py
+++ b/python/GafferUITest/EditorTest.py
@@ -51,8 +51,8 @@ class EditorTest( GafferUITest.TestCase ) :
 		scriptNode = Gaffer.ScriptNode()
 		application.root()["scripts"].addChild( scriptNode )
 
-		scriptNode["write"] = Gaffer.ObjectWriter()
-		scriptNode.selection().add( scriptNode["write"] )
+		scriptNode["random"] = Gaffer.Random()
+		scriptNode.selection().add( scriptNode["random"] )
 
 		for type in GafferUI.Editor.types() :
 			editor = GafferUI.Editor.create( type, scriptNode )


### PR DESCRIPTION
We will no longer ship it in official public builds. The IE config keeps it enabled for Image Engine internal builds.
