### PR TITLE
GraphEditorTest : Extend idle wait in `testAutomaticLayout()`

### DIFF
--- a/python/GafferUITest/GraphEditorTest.py
+++ b/python/GafferUITest/GraphEditorTest.py
@@ -113,7 +113,7 @@ class GraphEditorTest( GafferUITest.TestCase ) :
 			graphEditor = GafferUI.GraphEditor( s )
 
 		w.setVisible( True )
-		self.waitForIdle( 1000 )
+		self.waitForIdle( 10000 )
 
 		def assertLower( graphGadget, n1, n2 ) :
 
@@ -123,14 +123,14 @@ class GraphEditorTest( GafferUITest.TestCase ) :
 		assertLower( graphEditor.graphGadget(), s["n2"], s["n1"] )
 
 		graphEditor.graphGadget().setRoot( s["b"] )
-		self.waitForIdle( 1000 )
+		self.waitForIdle( 10000 )
 
 		self.assertEqual( graphEditor.graphGadget().unpositionedNodeGadgets(), [] )
 		assertLower( graphEditor.graphGadget(), s["b"]["n2"], s["b"]["n1"] )
 
 		s["b"]["n3"] = GafferTest.AddNode()
 		s["b"]["n3"]["op1"].setInput( s["b"]["n2"]["sum"] )
-		self.waitForIdle( 1000 )
+		self.waitForIdle( 10000 )
 
 		self.assertEqual( graphEditor.graphGadget().unpositionedNodeGadgets(), [] )
 		assertLower( graphEditor.graphGadget(), s["b"]["n3"], s["b"]["n2"] )


### PR DESCRIPTION
Automatic layout is performed in `preRender()`, so the assertions require that we have waited long enough for the window to have been redrawn. Although the old wait is more than sufficient for local testing, we have been getting periodic failures on Travis that we assume to be due to a machine under heavy load, and look like this :

```
======================================================================
FAIL: testAutomaticLayout (GafferUITest.GraphEditorTest.GraphEditorTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/travis/build/GafferHQ/gaffer/install/python/GafferUITest/GraphEditorTest.py", line 128, in testAutomaticLayout
    self.assertEqual( graphEditor.graphGadget().unpositionedNodeGadgets(), [] )
AssertionError: Lists differ: [GafferUI.StandardNodeGadget( ... != []
First list contains 2 additional elements.
First extra element 0:
GafferUI.StandardNodeGadget( "Gadget1" )
+ []
- [GafferUI.StandardNodeGadget( "Gadget1" ),
-  GafferUI.StandardNodeGadget( "Gadget" )]
```
