### PR TITLE
Expression : Compensate for Misordered Plugs

### DIFF
--- a/python/GafferOSLTest/OSLExpressionEngineTest.py
+++ b/python/GafferOSLTest/OSLExpressionEngineTest.py
@@ -39,6 +39,7 @@ import inspect
 import math
 import os
 import imath
+import re
 
 import IECore
 
@@ -606,6 +607,93 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 
 			c["str"] = "abc"
 			self.assertEqual( s["n"]["user"]["i"].getValue(), 1 )
+
+	def testDuplicateDeserialise( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["source"] = Gaffer.Node()
+		s["source"]["p"] = Gaffer.V3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["source"]["p"].setValue( imath.V3f( 0.1, 0.2, 0.3 ) )
+
+		s["dest"] = Gaffer.Node()
+		s["dest"]["p"] = Gaffer.V3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression(
+			"parent.dest.p.x = parent.source.p.x + 1;\n" +
+			"parent.dest.p.y = parent.source.p.y + 2;\n" +
+			"parent.dest.p.z = parent.source.p.z + 3;\n",
+			"OSL",
+		)
+
+		ss = s.serialise()
+
+		s.execute( ss )
+		s.execute( ss )
+
+		self.assertEqual( s["dest"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest1"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest2"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+
+		# Working well so far, but we've had a bug that could be hidden by the caching.  Lets
+		# try evaluating the plugs again, but flushing the cache each time
+		prevMemory = Gaffer.ValuePlug.getCacheMemoryLimit()
+		Gaffer.ValuePlug.setCacheMemoryLimit( 0 )
+		try:
+			self.assertEqual( s["dest"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+			self.assertEqual( s["dest1"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+			self.assertEqual( s["dest2"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		finally:
+			Gaffer.ValuePlug.setCacheMemoryLimit( prevMemory )
+
+	def testIndependentOfOrderOfPlugNames( self ) :
+		# We shouldn't depend on p0 being the first plug mentioned in the expression - as long as p0 is assigned
+		# correctly, the expression should still work
+
+		# Set up an expression with lots of plugs
+		s = Gaffer.ScriptNode()
+
+		exprLines = []
+		for i in range( 10 ):
+			s["source%i"%i] = Gaffer.Node()
+			s["source%i"%i]["p"] = Gaffer.V3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+			s["source%i"%i]["p"].setValue( imath.V3f( 0.1, 0.2, 0.3 ) + 0.3 * i )
+			s["dest%i"%i] = Gaffer.Node()
+			s["dest%i"%i]["p"] = Gaffer.V3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+			for a in "xyz":
+				exprLines.append(  "parent.dest%i.p.%s = parent.source%i.p.%s + 10 * %i;" % ( i, a, i, a, i ) )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( "\n".join( exprLines ), "OSL" )
+
+		for i in range( 10 ):
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().x, 0.1 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().y, 0.2 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().z, 0.3 + 0.3 * i + 10 * i, places = 5 )
+
+		# Now serialize it, and reverse the order of all the lines in the expression before deserializing it
+		ss = s.serialise()
+
+		ssLines = ss.split( "\n" )
+		ssLinesEdited = []
+		for l in ssLines:
+			m = re.match( "^__children\[\"e\"\]\[\"__expression\"\].setValue\( '(.*)' \)$", l )
+			if not m:
+				ssLinesEdited.append( l )
+			else:
+				lines = m.groups()[0].split( "\\n" );
+				ssLinesEdited.append( "__children[\"e\"][\"__expression\"].setValue( '%s' )" % "\\n".join( lines[::-1] ) )
+
+		del s
+		s = Gaffer.ScriptNode()
+		s.execute( "\n".join( ssLinesEdited) )
+
+		for i in range( 10 ):
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().x, 0.1 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().y, 0.2 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().z, 0.3 + 0.3 * i + 10 * i, places = 5 )
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -39,6 +39,7 @@ import os
 import inspect
 import unittest
 import imath
+import re
 
 import IECore
 
@@ -1415,6 +1416,92 @@ class ExpressionTest( GafferTest.TestCase ) :
 			del c["a"]
 			self.assertEqual( s["n"]["op1"].getValue(), 0 )
 			self.assertEqual( s["n"]["op2"].getValue(), 1 )
+
+	def testDuplicateDeserialise( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["source"] = GafferTest.CompoundNumericNode()
+		s["source"]["p"].setValue( imath.V3f( 0.1, 0.2, 0.3 ) )
+
+		s["dest"] = GafferTest.CompoundNumericNode()
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression(
+			"parent[\"dest\"][\"p\"]['x'] = parent[\"source\"][\"p\"]['x'] + 1;\n" +
+			"parent[\"dest\"][\"p\"]['y'] = parent[\"source\"][\"p\"]['y'] + 2;\n" +
+			"parent[\"dest\"][\"p\"]['z'] = parent[\"source\"][\"p\"]['z'] + 3;\n",
+			"python",
+		)
+
+		ss = s.serialise()
+
+		s.execute( ss )
+		s.execute( ss )
+
+		self.assertEqual( s["dest"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest1"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest2"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+
+		# Working well so far, but we've had a bug that could be hidden by the caching.  Lets
+		# try evaluating the plugs again, but flushing the cache each time
+		prevMemory = Gaffer.ValuePlug.getCacheMemoryLimit()
+		Gaffer.ValuePlug.setCacheMemoryLimit( 0 )
+		try:
+			self.assertEqual( s["dest"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+			self.assertEqual( s["dest1"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+			self.assertEqual( s["dest2"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		finally:
+			Gaffer.ValuePlug.setCacheMemoryLimit( prevMemory )
+
+	def testIndependentOfOrderOfPlugNames( self ) :
+		# We shouldn't depend on p0 being the first plug mentioned in the expression - as long as p0 is assigned
+		# correctly, the expression should still work
+
+		# Set up an expression with lots of plugs
+		s = Gaffer.ScriptNode()
+
+		exprLines = []
+		for i in range( 10 ):
+			s["source%i"%i] = GafferTest.CompoundNumericNode()
+			s["source%i"%i]["p"].setValue( imath.V3f( 0.1, 0.2, 0.3 ) + 0.3 * i )
+			s["dest%i"%i] = GafferTest.CompoundNumericNode()
+			for a in "xyz":
+				exprLines.append(
+					"parent[\"dest%i\"][\"p\"]['%s'] = parent[\"source%i\"][\"p\"]['%s'] + 10 * %i;" % (
+						i, a, i, a, i
+					)
+				)
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( "\n".join( exprLines ), "python" )
+
+		for i in range( 10 ):
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().x, 0.1 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().y, 0.2 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().z, 0.3 + 0.3 * i + 10 * i, places = 5 )
+
+		# Now serialize it, and reverse the order of all the lines in the expression before deserializing it
+		ss = s.serialise()
+
+		ssLines = ss.split( "\n" )
+		ssLinesEdited = []
+		for l in ssLines:
+			m = re.match( "^__children\[\"e\"\]\[\"__expression\"\].setValue\( '(.*)' \)$", l )
+			if not m:
+				ssLinesEdited.append( l )
+			else:
+				lines = m.groups()[0].split( "\\n" );
+				ssLinesEdited.append( "__children[\"e\"][\"__expression\"].setValue( '%s' )" % "\\n".join( lines[::-1] ) )
+
+		del s
+		s = Gaffer.ScriptNode()
+		s.execute( "\n".join( ssLinesEdited) )
+
+		for i in range( 10 ):
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().x, 0.1 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().y, 0.2 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().z, 0.3 + 0.3 * i + 10 * i, places = 5 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1454,6 +1454,18 @@ class ExpressionTest( GafferTest.TestCase ) :
 		finally:
 			Gaffer.ValuePlug.setCacheMemoryLimit( prevMemory )
 
+		# Now test that the expressions still serialise OK, because our process for loading
+		# expressions with misordered plugs could have messed something up
+		ss2 = s.serialise()
+		del s
+
+		s = Gaffer.ScriptNode()
+		s.execute( ss2 )
+		self.assertEqual( s["dest"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest1"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest2"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+
+
 	def testIndependentOfOrderOfPlugNames( self ) :
 		# We shouldn't depend on p0 being the first plug mentioned in the expression - as long as p0 is assigned
 		# correctly, the expression should still work

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -702,7 +702,11 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 
 			for( int i = 0, e = inPlugPaths.size(); i < e; ++i )
 			{
-				string parameter = "_" + inPlugPaths[i];
+				string parameter = inPlugPaths[i];
+				if( parameter[0] != '_' )
+				{
+					parameter = "_" + parameter;
+				}
 				replace_all( parameter, ".", "_" );
 				replace_all( result, "parent." + inPlugPaths[i], parameter );
 				inParameters.push_back( ustring( parameter ) );
@@ -710,7 +714,11 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 
 			for( int i = 0, e = outPlugPaths.size(); i < e; ++i )
 			{
-				string parameter = "_" + outPlugPaths[i];
+				string parameter = outPlugPaths[i];
+				if( parameter[0] != '_' )
+				{
+					parameter = "_" + parameter;
+				}
 				replace_all( parameter, ".", "_" );
 				replace_all( result, "parent." + outPlugPaths[i], parameter );
 				outParameters.push_back( ustring( parameter ) );


### PR DESCRIPTION
Since removing the dependency on the order that the expression engine happens to output plugs in would require an API change ( see discussion on #3250 ), instead we need check the order coming out of the expression engine, and rejigger everything accordingly.

Is this robust?  Not really sure, but it gets all the tests passing.  Definitely needs review that it's safe to do all this stuff in a plugSet ( including a setValue on the original plug ).

I've also left in the commit which allows using double underscore prefixed plugs in OSLExpressionEngine - that's unrelated, and I can put it up separately if desired, but it seems like something worth fixing.