### PR TITLE
Light Visualisation Improvements

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -742,7 +742,7 @@ libraries = {
 
 	"GafferSceneUI" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "GafferUI", "GafferImage", "GafferImageUI", "GafferScene", "Iex$OPENEXR_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX" ],
+			"LIBS" : [ "Gaffer", "GafferUI", "GafferImage", "GafferImageUI", "GafferScene", "GafferOSL", "Iex$OPENEXR_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "IECoreGL$CORTEX_LIB_SUFFIX", "GafferBindings", "GafferScene", "GafferUI", "GafferImageUI", "GafferSceneUI" ],

--- a/include/GafferArnold/ArnoldLight.h
+++ b/include/GafferArnold/ArnoldLight.h
@@ -37,10 +37,14 @@
 #ifndef GAFFERARNOLD_ARNOLDLIGHT_H
 #define GAFFERARNOLD_ARNOLDLIGHT_H
 
+#include "GafferArnold/ArnoldShader.h"
 #include "GafferArnold/Export.h"
 #include "GafferArnold/TypeIds.h"
 
 #include "GafferScene/Light.h"
+#include "GafferScene/ShaderPlug.h"
+
+#include "Gaffer/CompoundDataPlug.h"
 
 namespace GafferArnold
 {
@@ -55,14 +59,28 @@ class GAFFERARNOLD_API ArnoldLight : public GafferScene::Light
 		ArnoldLight( const std::string &name=defaultName<ArnoldLight>() );
 		~ArnoldLight() override;
 
+		Gaffer::CompoundDataPlug *attributesPlug();
+		const Gaffer::CompoundDataPlug *attributesPlug() const;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
 		void loadShader( const std::string &shaderName );
 
 	protected :
+
+		void hashAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const override;
 
 		void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECoreScene::ShaderNetworkPtr computeLight( const Gaffer::Context *context ) const override;
 
 	private :
+
+		ArnoldShader *shaderNode();
+		const ArnoldShader *shaderNode() const;
+
+		GafferScene::ShaderPlug *shaderInPlug();
+		const GafferScene::ShaderPlug *shaderInPlug() const;
 
 		Gaffer::StringPlug *shaderNamePlug();
 		const Gaffer::StringPlug *shaderNamePlug() const;

--- a/include/GafferSceneUI/LightFilterVisualiser.h
+++ b/include/GafferSceneUI/LightFilterVisualiser.h
@@ -43,6 +43,8 @@
 
 #include "IECoreScene/ShaderNetwork.h"
 
+#include "IECore/CompoundObject.h"
+
 namespace GafferSceneUI
 {
 
@@ -65,7 +67,7 @@ class GAFFERSCENEUI_API LightFilterVisualiser : public IECore::RefCounted
 
 		/// Must be implemented by derived classes to visualise
 		/// the light filter contained within `filterShaderNetwork`.
-		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *filterShaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, IECoreGL::ConstStatePtr &state ) const = 0;
+		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *filterShaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const = 0;
 
 		/// Registers a visualiser to visualise a particular type of light filter.
 		/// For instance, `registerLightFilterVisualiser( "ai:lightFilter", "gobo", visualiser )`

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -66,6 +66,8 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public LightVisualiser
 
 		static void spotlightParameters( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, float &innerAngle, float &outerAngle, float &lensRadius );
 
+		static IECore::CompoundDataPtr computeTextureFromOSLNetwork( const IECoreScene::ShaderNetwork *shaderNetwork, int resolution );
+
 	protected :
 
 		static const char *faceCameraVertexSource();

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -42,6 +42,7 @@
 #include "IECoreGL/Group.h"
 
 #include "IECore/SimpleTypedData.h"
+#include "IECore/CompoundData.h"
 
 
 namespace GafferSceneUI
@@ -83,7 +84,7 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public LightVisualiser
 
 		/// \todo Expose publicly once we have enough uses to dictate
 		/// the most general set of parameters.
-		static IECoreGL::ConstRenderablePtr quadShape();
+		static IECoreGL::ConstRenderablePtr quadShape( IECore::CompoundData *imageData );
 		static IECoreGL::ConstRenderablePtr diskShape( float radius );
 		static IECoreGL::ConstRenderablePtr cylinderShape( float radius );
 		static IECoreGL::ConstRenderablePtr cylinderRays( float radius );

--- a/src/GafferArnoldUI/BarndoorVisualiser.cpp
+++ b/src/GafferArnoldUI/BarndoorVisualiser.cpp
@@ -155,7 +155,7 @@ class BarndoorVisualiser final : public LightFilterVisualiser
 		BarndoorVisualiser();
 		~BarndoorVisualiser() override;
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, IECoreGL::ConstStatePtr &state ) const override;
+		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
 
 	protected :
 
@@ -176,7 +176,7 @@ BarndoorVisualiser::~BarndoorVisualiser()
 {
 }
 
-IECoreGL::ConstRenderablePtr BarndoorVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, IECoreGL::ConstStatePtr &state ) const
+IECoreGL::ConstRenderablePtr BarndoorVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
 {
 	IECoreGL::GroupPtr result = new IECoreGL::Group();
 

--- a/src/GafferArnoldUI/DecayVisualiser.cpp
+++ b/src/GafferArnoldUI/DecayVisualiser.cpp
@@ -200,7 +200,7 @@ class DecayVisualiser final : public LightFilterVisualiser
 		DecayVisualiser();
 		~DecayVisualiser() override;
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, IECoreGL::ConstStatePtr &state ) const override;
+		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
 
 	protected :
 
@@ -221,7 +221,7 @@ DecayVisualiser::~DecayVisualiser()
 {
 }
 
-IECoreGL::ConstRenderablePtr DecayVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, IECoreGL::ConstStatePtr &state ) const
+IECoreGL::ConstRenderablePtr DecayVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
 {
 	IECoreGL::GroupPtr result = new IECoreGL::Group();
 

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -228,7 +228,7 @@ class GoboVisualiser final : public LightFilterVisualiser
 		GoboVisualiser();
 		~GoboVisualiser() override;
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, IECoreGL::ConstStatePtr &state ) const override;
+		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
 
 	protected :
 
@@ -249,7 +249,7 @@ GoboVisualiser::~GoboVisualiser()
 {
 }
 
-IECoreGL::ConstRenderablePtr GoboVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, IECoreGL::ConstStatePtr &state ) const
+IECoreGL::ConstRenderablePtr GoboVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
 {
 	IECoreGL::GroupPtr result = new IECoreGL::Group();
 

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -309,7 +309,9 @@ IECoreGL::ConstRenderablePtr GoboVisualiser::visualise( const IECore::InternedSt
 			"",
 			"",
 			goboFragSource(),
-			shaderParameters ) );
+			shaderParameters
+		)
+	);
 
 	float innerAngle;
 	float coneAngle;

--- a/src/GafferArnoldUI/LightBlockerVisualiser.cpp
+++ b/src/GafferArnoldUI/LightBlockerVisualiser.cpp
@@ -183,7 +183,7 @@ class GAFFERSCENEUI_API LightBlockerVisualiser : public LightFilterVisualiser
 		LightBlockerVisualiser();
 		~LightBlockerVisualiser() override;
 
-		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *filterShaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, IECoreGL::ConstStatePtr &state ) const override;
+		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *filterShaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
 
 	protected :
 
@@ -211,7 +211,7 @@ LightBlockerVisualiser::~LightBlockerVisualiser()
 {
 }
 
-IECoreGL::ConstRenderablePtr LightBlockerVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *filterShaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, IECoreGL::ConstStatePtr &state ) const
+IECoreGL::ConstRenderablePtr LightBlockerVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *filterShaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
 {
 	InternedString metadataTarget;
 	const IECore::CompoundData *shaderParameters = parametersAndMetadataTarget( attributeName, filterShaderNetwork, metadataTarget );

--- a/src/GafferSceneUI/LightFilterVisualiser.cpp
+++ b/src/GafferSceneUI/LightFilterVisualiser.cpp
@@ -164,7 +164,7 @@ IECoreGL::ConstRenderablePtr AttributeVisualiserForLightFilters::visualise( cons
 		}
 
 		IECoreGL::ConstStatePtr curState = nullptr;
-		IECoreGL::ConstRenderablePtr curVis = visualiser->visualise( attributeName, filterShaderNetwork, lightShaderNetwork, curState );
+		IECoreGL::ConstRenderablePtr curVis = visualiser->visualise( attributeName, filterShaderNetwork, lightShaderNetwork, attributes, curState );
 
 		if( curVis )
 		{

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -265,9 +265,7 @@ CompoundDataPtr evalOSL( const IECoreScene::ShaderNetwork *shaderNetwork, int re
 		for( int x = 0; x < resolution; ++x )
 		{
 			uWritable.push_back( (float)(x + 0.5f) / resolution );
-			// V is flipped because we're generating a Cortex image,
-			// and Cortex has the pixel origin at the top left.
-			vWritable.push_back( 1.0f - ( (y + 0.5f) / resolution ) );
+			vWritable.push_back( (y + 0.5f) / resolution );
 			pWritable.push_back( V3f( x + 0.5f, y + 0.5f, 0.0f ) );
 		}
 	}


### PR DESCRIPTION
As promised in https://github.com/GafferHQ/gaffer/pull/3219, here are the commits that I split off for further discussion. I'm responding to the questions on that other PR below. Not sure if we want to put this on hold for now, though.

Re: Dependency to GafferOSL in GafferSceneUI
> Let's discuss alternative structures - it feels like maybe the "run this shader and give me an image" functionality might be more generally useful if it was in ShadingEngine or ShadingEngineAlgo?

Yeah, sounds good. Not sure if we have more use cases than just these two to inform our decision regarding where to put the code?

> How close does this put us to being able to change the base class to require the use of an internal shader? I guess AppleseedLight would still need work? If we're splitting this off, I'm just wondering if we can go all the way with it.

Yes, `AppleseedLight` would be the only actual one left, I think. There's also `GafferSceneTest::TestLight` that we might have to touch. I can look into it, if we want to do it as part of this PR.

> Also, I'm curious, why was this needed to support the visualisation of quad lights? I would naively have expected that to be possible without.

Yeah, me too. I forget the details, but I think what it was is that without the shading network being connected to a `ShaderPlug` like it is now, the output parameter of the network didn't have a name. Addressing that comment in the light seemed like the cleanest and most future-proof way to fix that and consequently being able to hook up the Constant shader used for evaluation on the grid. Does that make sense?

> I'm finding myself wishing that this didn't obscure the regular color/exposure visualiser. Perhaps that should be offset?

I tried to address that issue by multiplying the exposure into the texture. That would potentially allow us to get rid of that UI element altogether? I guess it does give us better visualisation for large exposures, though. The texture visualisation would just be a white square at some point... Offsetting sounds good, too. I'm assuming it would be offset in the direction of the arrow? Maybe just minimally to avoid the z-fighting?

> Cinesite folks [...] were more interested in some basic heuristics for recognising aiImage shaders in the network and loading the image it references. 

Sounds good. I guess in an ideal world, we'd have both? When talking to @themissingcow , I had optimistically said that texture visualisation on quad lights is hopefully somewhat close, but I guess it isn't, after all.

> Full of optimism I also enquired about using the Arnold API to evaluate Arnold shaders fully, but while this is possible, it falls foul of the "one universe" problem.

I saw that. Too bad...

Thanks, no need to push this PR forward if there's nobody asking for these features and you aren't super keen on the cleanup bits. Happy to jump back onto this whenever we deem is a good moment.

Matti.