### PR TITLE
NameValuePlug : Allow createCounterpart for incomplete plug

### DIFF
--- a/src/Gaffer/NameValuePlug.cpp
+++ b/src/Gaffer/NameValuePlug.cpp
@@ -144,6 +144,16 @@ bool NameValuePlug::acceptsChild( const Gaffer::GraphComponent *potentialChild )
 
 PlugPtr NameValuePlug::createCounterpart( const std::string &name, Direction direction ) const
 {
+	if( !namePlug() && !valuePlug() )
+	{
+		// We'd like this to be an error, but when deserializing files, we might call
+		// createCounterpart on half-loaded NameValuePlugs, which don't have any plugs yet.
+		// To allow this to load, we have allow the counterpart to also be an invalid 
+		// NameValuePlug.  We are depending on subsequent serialization code to actually
+		// add the required children, or else we will be left with an invalid plug
+		return new NameValuePlug( name, direction, getFlags() );
+	}
+
 	if( !namePlug() || !valuePlug() )
 	{
 		throw IECore::Exception( "Cannot create counterpart for : " + fullName() + " - NameValuePlug must have name and value." );


### PR DESCRIPTION
While originally setting up NameValuePlug, I had missed that deserialising old scripts may require createCounterpart of incomplete NameValuePlugs.

We have stuff serialized like:

parent.addChild( MemberPlug() )
parent["memberPlug"].addChild( StringPlug( "name" ) )
parent["memberPlug"].addChild( FloatPlug( "value" ) )

We're now translating MemberPlug to NameValuePlug.
If the parent is the input to something else, the initial addChild will trigger a createCounterpart, before the children are added and the NameValuePlug becomes valid.
