### PR TITLE
Support Reading Variables In PythonCommand in Sequence Mode

### DIFF
--- a/apps/execute/execute-1.py
+++ b/apps/execute/execute-1.py
@@ -163,6 +163,10 @@ class execute( Gaffer.Application ) :
 		if not frames :
 			frames = [ scriptNode.context().getFrame() ]
 
+		# We want to use the frame set by executeSequence.   Remove any possibility of
+		# accidentally using the default frame set in the script
+		del context["frame"]
+
 		with context :
 			for node in nodes :
 				errorConnection = node.errorSignal().connect( Gaffer.WeakMethod( self.__error ) )

--- a/python/GafferDispatch/PythonCommand.py
+++ b/python/GafferDispatch/PythonCommand.py
@@ -152,12 +152,13 @@ class _VariablesDict( dict ) :
 		return dict.__getitem__( self, key )
 
 	def __update( self ) :
+		frame = self.__context.get( "frame", "NO FRAME" )
 
-		if self.__frame == self.__context.getFrame() :
+		if self.__frame == frame :
 			return
 
-		if self.__context.getFrame() not in self.__validFrames :
-			raise ValueError( "Invalid frame" )
+		if frame != "NO FRAME" and frame not in self.__validFrames :
+			raise ValueError( "Cannot access variables at frame outside range specified for PythonCommand" )
 
 		self.clear()
 		for plug in self.__variables.children() :
@@ -169,7 +170,7 @@ class _VariablesDict( dict ) :
 
 			self[name] = value
 
-		self.__frame = self.__context.getFrame()
+		self.__frame = frame
 
 class _Parser( ast.NodeVisitor ) :
 


### PR DESCRIPTION
In order to read variables in a PythonCommand, we require a valid frame, but when running in sequence mode, we don't set the frame.

I've put in a basic test that adding a basic variable read to the existing sequence mode test works - in the test, this currently fails because the frame is completely unset.  In a more practical example using "gaffer execute", the frame gets set to the current frame saved in the script - this is actually worse, because it works sometime, but can unexpectedly fail if the current frame is not one of the frames you are dispatching ( due to the check for `self.__context.getFrame() not in self.__validFrames` in _VariablesDict.__update.

If variable access is going to depend on the frame, setting the frame to the first frame in the sequence seems reasonable?  ( Do I need to add a special case for dispatching zero length sequences?  That seems pretty invalid anyway ).

The only alternative I can think of is changing _VariablesDict so it doesn't depend on the current frame when in sequence mode, but that seems like more work.

( If you're happy with this fix, this will probably need a backport, since this bug is a blocker for the support for Arnold's append flag in IERendering )