### PR TITLE
Fix Crash When Rendering With Performance Monitor

### DIFF
--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -1201,5 +1201,19 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		return result
 
+	def testPerformanceMonitorDoesntCrash( self ) :
+
+		options = GafferScene.StandardOptions()
+
+		options["options"]["performanceMonitor"]["value"].setValue( True )
+		options["options"]["performanceMonitor"]["enabled"].setValue( True )
+
+		render = GafferArnold.ArnoldRender()
+		render["in"].setInput( options["out"] )
+		render["mode"].setValue( render.Mode.SceneDescriptionMode )
+		render["fileName"].setValue( self.temporaryDirectory() + "/test.ass" )
+
+		render["task"].execute()
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -281,15 +281,15 @@ void Render::execute() const
 		GafferScene::RendererAlgo::createOutputDirectories( globals.get() );
 	}
 
-	std::unique_ptr<PerformanceMonitor> performanceMonitor;
+	PerformanceMonitorPtr performanceMonitor;
 	if( const BoolData *d = globals->member<const BoolData>( g_performanceMonitorOptionName ) )
 	{
 		if( d->readable() )
 		{
-			performanceMonitor.reset( new PerformanceMonitor );
+			performanceMonitor = new PerformanceMonitor;
 		}
 	}
-	Monitor::Scope performanceMonitorScope( performanceMonitor.get() );
+	Monitor::Scope performanceMonitorScope( performanceMonitor );
 
 	RendererAlgo::outputOptions( globals.get(), renderer.get() );
 	RendererAlgo::outputOutputs( globals.get(), renderer.get() );


### PR DESCRIPTION
I was rendering some production scenes in Gaffer 0.54 just to see how we're doing for production readiness, and came across this crash.

Monitor::Scope stores the monitor as a shared_ptr, but Render::execute was storing it as a unique_ptr, and passing it in as a raw pointer.  This lead to both having ownership, and a crash during destruction.

This seems like a simple fix that just wasn't caught during the recent switch to using RefCounted.