### PR TITLE
Installing Gaffer for Nuke using NUKE_COMPATIBILITY_VERSION

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -123,7 +123,10 @@ if targetApp :
 	compiler = targetAppReg["compiler"]
 	compilerVersion = targetAppReg["compilerVersion"]
 	pythonVersion = targetAppReg["pythonVersion"]
-	targetAppMajorVersion = targetAppReg.get( "majorVersion", targetAppVersion )
+	if targetApp in ( "nuke", ):
+		targetAppMajorVersion = targetAppReg.get( "compatibilityVersion", targetAppReg.get( "majorVersion", targetAppVersion ) )
+	else:
+		targetAppMajorVersion = targetAppReg.get( "majorVersion", targetAppVersion )
 
 	if "compilerFlags" in targetAppReg :
 		CXXFLAGS = CXXFLAGS + targetAppReg["compilerFlags"]


### PR DESCRIPTION
For IE installation, we want to start using compatibility version to ease the maintenance of
custom code installed for each nuke patch version ( which is the case at the moment ).

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
