### PR TITLE
CompoundEditor : Allow editors to be linked to each other or the scene selection

### DIFF
--- a/doc/source/GettingStarted/TutorialAssemblingTheGafferBot/generate.sh
+++ b/doc/source/GettingStarted/TutorialAssemblingTheGafferBot/generate.sh
@@ -5,8 +5,8 @@ set -e
 
 cp $GAFFER_ROOT/graphics/expansion.png images
 cp $GAFFER_ROOT/graphics/plus.png images
-cp $GAFFER_ROOT/graphics/targetNodesUnlocked.png images
-cp $GAFFER_ROOT/graphics/targetNodesLocked.png images
+cp $GAFFER_ROOT/graphics/nodeSetDriverNodeSelection.png images
+cp $GAFFER_ROOT/graphics/nodeSetStandardSet.png images
 cp $GAFFER_ROOT/graphics/layoutButton.png images
 cp $GAFFER_ROOT/graphics/objects.png images
 cp $GAFFER_ROOT/graphics/addObjects.png images

--- a/doc/source/GettingStarted/TutorialAssemblingTheGafferBot/index.md
+++ b/doc/source/GettingStarted/TutorialAssemblingTheGafferBot/index.md
@@ -310,7 +310,7 @@ To make switching between viewing Gaffy's geometry and the render easier, you ca
 1. Select the InteractiveAppleseedRender node.
 
 2. Click ![](images/targetNodesUnlocked.png "the pin button") at the top-right
-  of the top panel. The pin button will highlight: ![](images/targetNodesLocked.png "highlighted pin").
+  of the top panel. The pin button will highlight: ![](images/nodeSetStandardSet.png "highlighted pin").
 
 <!-- TODO: Screenshot of pinned Viewer -->
 

--- a/doc/source/Interface/ControlsAndShortcuts/.gitignore
+++ b/doc/source/Interface/ControlsAndShortcuts/.gitignore
@@ -1,1 +1,1 @@
-images/targetNodesLocked.png
+images/nodeSetStandardSet.png

--- a/doc/source/Interface/ControlsAndShortcuts/generate.sh
+++ b/doc/source/Interface/ControlsAndShortcuts/generate.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
-# BuildTarget: images/targetNodesLocked.png
+# BuildTarget: images/nodeSetStandardSet.png
 
 set -e
 
-cp $GAFFER_ROOT/graphics/targetNodesLocked.png images
+cp $GAFFER_ROOT/graphics/nodeSetStandardSet.png images

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -170,7 +170,7 @@ Assign numeric bookmark               :kbd:`Ctrl` + :kbd:`1` … :kbd:`9`
 Remove numeric bookmark               :kbd:`Ctrl` + :kbd:`0`
 ===================================== =============================================
 
-.. |pin| image:: images/targetNodesLocked.png
+.. |pin| image:: images/nodeSetStandardSet.png
     :alt: Pin
 ```
 

--- a/include/GafferSceneUI/SourceSet.h
+++ b/include/GafferSceneUI/SourceSet.h
@@ -1,0 +1,114 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEUI_SOURCESET_H
+#define GAFFERSCENEUI_SOURCESET_H
+
+#include "GafferSceneUI/TypeIds.h"
+
+#include "GafferScene/ScenePlug.h"
+#include "GafferScene/SceneNode.h"
+
+#include "Gaffer/Context.h"
+#include "Gaffer/Set.h"
+#include "Gaffer/StandardSet.h"
+
+#include "IECore/PathMatcher.h"
+
+namespace GafferSceneUI
+{
+
+/// The SourceSet provides a Set implementation that adjusts its membership such that
+/// it contains the source node for the current scene selection, given a context and
+/// a target node from which to observe the scene.
+///
+/// When there is no scene selection, or the supplied node set contains no SceneNodes,
+/// it falls back to the node in the node set.
+///
+/// When multiple locations are selected or there are multiple nodes in the node set,
+/// the last of each will be used to determine which source node is presented by the set.
+///
+/// The SourceSet requires a valid context and node set in order to determine source nodes
+/// other than the direct selection of non-SceneNodes.
+class GAFFER_API SourceSet : public Gaffer::Set
+{
+
+	public :
+
+		SourceSet( Gaffer::ContextPtr context, Gaffer::SetPtr nodeSet );
+		~SourceSet() override;
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::SourceSet, SourceSetTypeId, Gaffer::Set );
+
+		void setContext( Gaffer::ContextPtr context );
+		Gaffer::Context *getContext() const;
+
+		void setNodeSet( Gaffer::SetPtr nodeSet );
+		Gaffer::Set *getNodeSet() const;
+
+		/// @name Set interface
+		////////////////////////////////////////////////////////////////////
+		//@{
+		bool contains( const Member *object ) const override;
+		Member *member( size_t index ) override;
+		const Member *member( size_t index ) const override;
+		size_t size() const override;
+		//@}
+
+	private :
+
+		Gaffer::ContextPtr m_context;
+		Gaffer::SetPtr m_nodes;
+
+		GafferScene::ScenePlugPtr m_scenePlug;
+		void updateScenePlug();
+
+		Gaffer::NodePtr m_sourceNode;
+		void updateSourceNode();
+
+		void contextChanged( const IECore::InternedString &name );
+		void plugDirtied( const Gaffer::Plug *plug );
+		boost::signals::scoped_connection m_contextChangedConnection;
+		boost::signals::scoped_connection m_plugDirtiedConnection;
+		boost::signals::scoped_connection m_nodeAddedConnection;
+		boost::signals::scoped_connection m_nodeRemovedConnection;
+};
+
+IE_CORE_DECLAREPTR( SourceSet );
+
+} // namespace GafferSceneUI
+
+#endif // GAFFERSCENEUI_SOURCESET_H

--- a/include/GafferSceneUI/TypeIds.h
+++ b/include/GafferSceneUI/TypeIds.h
@@ -55,6 +55,7 @@ enum TypeId
 	CameraToolTypeId = 110661,
 	UVViewTypeId = 110662,
 	UVSceneTypeId = 110663,
+	SourceSetTypeId = 110664,
 
 	LastTypeId = 110700
 };

--- a/python/GafferSceneUITest/SourceSetTest.py
+++ b/python/GafferSceneUITest/SourceSetTest.py
@@ -1,0 +1,268 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+import GafferUITest
+import GafferSceneUI
+
+class SourceSetTest( GafferUITest.TestCase ) :
+
+	def testAccessors( self ) :
+
+		s = Gaffer.StandardSet()
+		c = Gaffer.Context()
+
+		h = GafferSceneUI.SourceSet( c, s )
+
+		self.assertEqual( h.getContext(), c )
+		self.assertEqual( h.getNodeSet(), s )
+
+		self.assertEqual( h.size(), 0 )
+
+		s2 = Gaffer.StandardSet()
+		c2 = Gaffer.Context()
+
+		h.setContext( c2 )
+		self.assertEqual( h.getContext(), c2 )
+		self.assertEqual( h.getNodeSet(), s )
+
+		h.setNodeSet( s2 )
+		self.assertEqual( h.getContext(), c2 )
+		self.assertEqual( h.getNodeSet(), s2 )
+
+	def testSource( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["pA"] = GafferScene.Plane()
+		s["pA"]["name"].setValue( "planeA" )
+		s["pB"] = GafferScene.Plane()
+		s["pB"]["name"].setValue( "planeB" )
+		s["g"] = GafferScene.Group()
+		s["g"]["in"][0].setInput( s["pA"]["out"] )
+		s["g"]["in"][1].setInput( s["pB"]["out"] )
+
+		s["s"] = GafferSceneTest.TestShader()
+		s["a"] = GafferScene.ShaderAssignment()
+		s["a"]["in"].setInput( s["g"]["out"] )
+		s["a"]["shader"].setInput( s["s"]["out"] )
+
+		s["s2"] = GafferSceneTest.TestShader()
+		s["a2"] = GafferScene.ShaderAssignment()
+		s["a2"]["in"].setInput( s["a"]["out"] )
+		s["a2"]["shader"].setInput( s["s2"]["out"] )
+
+		s["g2"] = GafferScene.Group()
+		s["g2"]["in"][0].setInput( s["a2"]["out"] )
+
+		s["o"] = GafferScene.SceneWriter()
+		s["o"]["in"].setInput( s["g2"]["out"] )
+
+		n = Gaffer.StandardSet()
+		c = Gaffer.Context()
+
+		self.assertEqual( len(GafferSceneUI.ContextAlgo.getSelectedPaths( c ).paths()), 0 )
+
+		h = GafferSceneUI.SourceSet( c, n )
+		self.assertEqual( h.size(), 0 )
+
+		a = "/group/group/planeA"
+		b = "/group/group/planeB"
+
+		n.add( s["o"] )
+
+		# Test scene selection changed
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( c, IECore.PathMatcher( [ a	 ] ) )
+		self.assertEqual( set(h), { s["pA"] } )
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( c, IECore.PathMatcher( [ a, b ] ) )
+
+		self.assertEqual( set(h), { s["pA"] } )
+
+		# Test defaulting to last input node if no valid plug or path
+		GafferSceneUI.ContextAlgo.setSelectedPaths( c, IECore.PathMatcher() )
+		self.assertEqual( set(h), { s["o"] } )
+
+		# Test nodes changed
+
+		n.clear()
+		self.assertEqual( h.size(), 0 )
+
+		n.add( s["g2" ] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( c, IECore.PathMatcher( [ a ] ) )
+		self.assertEqual( set(h), { s["pA"] } )
+
+		n.remove( s["g2"] )
+		n.add( s["g"] )
+		self.assertEqual( set(h), { s["g"] } )
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( c, IECore.PathMatcher( [ "/group/planeA" ] ) )
+		self.assertEqual( set(h), { s["pA"] } )
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( c, IECore.PathMatcher( [ "/group" ] ) )
+		n.clear()
+		n.add( s["g2"] )
+		self.assertEqual( set(h), { s["g2"] } )
+
+		# Test incoming scene dirtied
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( c, IECore.PathMatcher( [ b ] ) )
+		self.assertEqual( set(h), { s["pB"] } )
+
+		s["pB"]["name"].setValue( "notPlaneB" )
+		self.assertEqual( set(h), { s["g2"] } )
+
+		# Test multiple non-scene nodes
+		n.clear()
+		n.add( s["s"] )
+		self.assertEqual( set(h), { s["s"] } )
+		n.add( s["s2"] )
+		self.assertEqual( set(h), { s["s2"] } )
+		n.remove( s["s2"] )
+		self.assertEqual( set(h), { s["s"] } )
+
+	def testReadOnlyNodeHierarchies( self ) :
+
+		class TestShaderBall( GafferScene.ShaderBall ) :
+			def __init__( self, name = "TestShaderBall" ) :
+				GafferScene.ShaderBall.__init__( self, name )
+
+		# Test to make sure we don't surface internal nodes
+
+		s = Gaffer.StandardSet()
+		c = Gaffer.Context()
+		h = GafferSceneUI.SourceSet( c, s )
+
+		b = TestShaderBall()
+		s.add( b )
+		self.assertEqual( set(h), set( [ b, ] ) )
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( c, IECore.PathMatcher( [ "/sphere" ] ) )
+		self.assertEqual( set(h), set( [ b, ] ) )
+
+	def testSignals( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["pA"] = GafferScene.Plane()
+		s["pA"]["name"].setValue( "planeA" )
+		s["pB"] = GafferScene.Plane()
+		s["pB"]["name"].setValue( "planeB" )
+		s["g"] = GafferScene.Group()
+		s["g"]["in"][0].setInput( s["pA"]["out"] )
+		s["g"]["in"][1].setInput( s["pB"]["out"] )
+
+		s["g2"] = GafferScene.Group()
+		s["g2"]["in"][0].setInput( s["g"]["out"] )
+
+		mirror = set()
+
+		def added( _, member ) :
+			mirror.add( member )
+
+		def removed( _, member ) :
+			mirror.remove( member )
+
+		n = Gaffer.StandardSet()
+		c = Gaffer.Context()
+
+		h = GafferSceneUI.SourceSet( c, n )
+		ca = h.memberAddedSignal().connect( added )
+		cr = h.memberRemovedSignal().connect( removed )
+
+		self.assertEqual( h.size(), 0 )
+		self.assertEqual( len(mirror), 0 )
+
+		a = "/group/group/planeA"
+		b = "/group/group/planeB"
+
+		n.add( s["g2"] )
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( c, IECore.PathMatcher( [ a ] ) )
+		self.assertEqual( set(h), mirror )
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( c, IECore.PathMatcher( [ b ] ) )
+		self.assertEqual( set(h), mirror )
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( c, IECore.PathMatcher( [ a, b ] ) )
+		self.assertEqual( set(h), mirror )
+
+	def testSignalOrder( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["p1"] = GafferScene.Plane()
+		s["p2"] = GafferScene.Plane()
+
+		n = Gaffer.StandardSet()
+		c = Gaffer.Context()
+		h = GafferSceneUI.SourceSet( c, n )
+
+		callbackFailures = { "added" : 0, "removed" : 0 }
+
+		# Check we have no members when one is removed as we're
+		# defined as only ever containing one node. We can't assert
+		# here as the exception gets eaten and the test passes anyway
+		def removed( _, member ) :
+			if set(h) != set() :
+				callbackFailures["removed"] += 1
+
+		cr = h.memberRemovedSignal().connect( removed )
+
+		n.add( s["p1"] )
+		n.add( s["p2"] )
+		n.remove( s["p1"] )
+		n.remove( s["p2"] )
+
+		self.assertEqual( callbackFailures["removed"], 0 )
+
+		# Check member is added before signal, same deal re: asserts
+		def added( _, member ) :
+			if set(h) != { s["p1"] } :
+				callbackFailures["added"] += 1
+
+		ca = h.memberAddedSignal().connect( added )
+
+		n.add( s["p1"] )
+		self.assertEqual( callbackFailures["added"], 0 )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUI/GraphBookmarksUI.py
+++ b/python/GafferUI/GraphBookmarksUI.py
@@ -118,36 +118,42 @@ def appendPlugContextMenuDefinitions( graphEditor, plug, menuDefinition ) :
 
 def appendNodeSetMenuDefinitions( editor, menuDefinition ) :
 
-	if len( editor.getNodeSet() ) :
-		primaryNode = editor.getNodeSet()[-1]
-	else :
-		primaryNode = None
-
-	menuDefinition.append(
-		"/Bookmarked",
-		{
-			"checkBox" : primaryNode is not None and Gaffer.MetadataAlgo.getBookmarked( primaryNode ),
-			"command" : functools.partial( __setBookmarked, primaryNode ),
-			"active" : primaryNode is not None and not Gaffer.MetadataAlgo.readOnly( primaryNode ),
-		}
-	)
-
 	for i in range( 1, 10 ) :
 	  menuDefinition.append(
-		  "/Numeric Bookmark/%s" % i,
+		  "/Pin Bookmark/%s" % i,
 		  {
 			  "command" : functools.partial( __findNumericBookmark, editor, i ),
 			  "active" : Gaffer.MetadataAlgo.getNumericBookmark( editor.scriptNode(), i ) is not None,
 		  }
 	  )
 
+	menuDefinition.append( "/Pin Bookmark/Divider", { "divider" : True } )
+
 	bookmarks = __findableBookmarks( editor )
 	menuDefinition.append(
-		"/Find Bookmark...",
+		"/Pin Bookmark/Other...",
 		{
 			"command" : functools.partial( __findBookmark, editor, bookmarks ),
 			"active" : len( bookmarks ),
 			"shortCut" : "B",
+		}
+	)
+
+	menuDefinition.append( "/BookmarkNodeDivider", { "divider" : True } )
+
+	if len( editor.getNodeSet() ) :
+		primaryNode = editor.getNodeSet()[-1]
+		title = "Bookmark %s" % primaryNode.getName()
+		canBookmark = not Gaffer.MetadataAlgo.getBookmarked( primaryNode ) and not Gaffer.MetadataAlgo.readOnly( primaryNode )
+	else :
+		primaryNode = None
+		title = "Bookmark Current Node"
+		canBookmark = False
+
+	menuDefinition.append( title,
+		{
+			"command" : functools.partial( __setBookmarked, primaryNode, True ),
+			"active" : canBookmark
 		}
 	)
 

--- a/python/GafferUI/NodeSetEditor.py
+++ b/python/GafferUI/NodeSetEditor.py
@@ -42,15 +42,31 @@ import GafferUI
 
 from Qt import QtCore
 
+import weakref
+
 ## The NodeSetEditor is a base class for all Editors which focus their
 # editing on a subset of nodes beneath a ScriptNode. This set defaults
 # to the ScriptNode.selection() but can be modified to be any Set of nodes.
+#
+# The node set for any given editor can be optionally driven by that of some
+# other editor, such that they don't need to be independently maintained. The
+# default mode simply ensures they have the same node set. Custom modes can be
+# registered for extended functionality.
 class NodeSetEditor( GafferUI.Editor ) :
+
+	DriverModeNodeSet = "NodeSet"
+
+	__nodeSetDriverModes = {}
 
 	def __init__( self, topLevelWidget, scriptNode, **kw ) :
 
 		self.__nodeSet = Gaffer.StandardSet()
 		self.__nodeSetChangedSignal = GafferUI.WidgetSignal()
+
+		self.__nodeSetDriver = {}
+		self.__nodeSetDriverChangedSignal = GafferUI.WidgetSignal()
+		self.__drivenNodeSets = {}
+		self.__drivenNodeSetsChangedSignal = GafferUI.WidgetSignal()
 
 		GafferUI.Editor.__init__( self, topLevelWidget, scriptNode, **kw )
 
@@ -65,17 +81,170 @@ class NodeSetEditor( GafferUI.Editor ) :
 	# added to and removed from the set, the UI will be updated automatically
 	# to show them. This also calls `nodeSet.setRemoveOrphans( True )` so that
 	# deleted nodes are not visible in the UI.
+	#
+	# This will break any editor links, if set.
+	#
+	# The driver will be updated *after* the node set, such that calling
+	# `getNodeSetDriver` in the nodeSetChangedSignal will return the departing
+	# driver. TODO: We need to work out a sensible way to signal once state has
+	# stabilised
 	def setNodeSet( self, nodeSet ) :
 
 		self.__setNodeSetInternal( nodeSet, callUpdateFromSet=True )
+		# We do this after setting the node set, so that when the driver changed
+		# signal is emitted, we will have the new node set. Otherwise the editor
+		# looks like it has the old drivers node set still despite not having a
+		# driver...
+		self.setNodeSetDriver( None )
 
 	def getNodeSet( self ) :
 
 		return self.__nodeSet
 
+	## Called before nodeSetDriverChangedSignal in the event that setNodeSet breaks a driver link.
 	def nodeSetChangedSignal( self ) :
 
 		return self.__nodeSetChangedSignal
+
+	## Links the nodeSet for this editor to that of the supplied drivingEditor.
+	# The default mode results in a simple mirroring of the driver's node set
+	# to this editor. Other modes may be registered by other Gaffer modules.
+	# If drivingEditor is None, any existing links will be broken.
+	def setNodeSetDriver( self, drivingEditor, mode = DriverModeNodeSet ) :
+
+		if drivingEditor is not None :
+			assert( isinstance( drivingEditor, GafferUI.NodeSetEditor ) )
+			# We also need to stop people creating infinite loops
+			if self.drivesNodeSet( drivingEditor ) :
+				raise ValueError( "The supplied driver is already driven by this editor" )
+
+		if self.__nodeSetDriver :
+			previousDriver = self.__nodeSetDriver["weakDriver"]()
+			# It may have been deleted, we'll still have link data but the ref will be dead
+			if previousDriver is not None :
+				if drivingEditor is previousDriver and mode == self.__nodeSetDriver["mode"] :
+					return
+				else :
+					previousDriver.__unregisterDrivenEditor( self )
+
+		self.__nodeSetDriver = {}
+
+		if drivingEditor :
+
+			drivingEditor.__registerDrivenEditor( self, mode )
+
+			weakDriver = weakref.ref(
+				drivingEditor,
+				# We need to unlink ourselves if the driver goes away
+				lambda _ : self.setNodeSetDriver( None )
+			)
+			changeCallback = self.__nodeSetDriverModes[ mode ]
+
+			def updateFromDriver( _ ) :
+				if weakDriver() is not None :
+					nodeSet = weakDriver().getNodeSet()
+					if changeCallback :
+						nodeSet = changeCallback( self, weakDriver() )
+					self.__setNodeSetInternal( nodeSet, callUpdateFromSet=True )
+
+			self.__nodeSetDriver = {
+				"mode" : mode,
+				"weakDriver" : weakDriver,
+				"driverNodeSetChangedConnection" : drivingEditor.nodeSetChangedSignal().connect( updateFromDriver ),
+			}
+			updateFromDriver( drivingEditor )
+
+		self.__nodeSetDriverChangedSignal( self )
+
+	## Returns a tuple of the drivingEditor and the drive mode.
+	# When there is no driver ( None, "" ) will be returned.
+	def getNodeSetDriver( self ) :
+
+		if self.__nodeSetDriver :
+			return ( self.__nodeSetDriver["weakDriver"](), self.__nodeSetDriver["mode"] )
+
+		return ( None, "" )
+
+	## Called whenever the editor's driving node set changes.
+	# Note: This is called after nodeSetChangedSignal in the event that
+	# the setNodeSet call breaks an existing driver link.
+	def nodeSetDriverChangedSignal( self ) :
+
+		return self.__nodeSetDriverChangedSignal
+
+	## Returns a dict of { editor : mode } that are driven by this editor.
+	# If recurse is true, the link chain will be followed recursively to
+	# also include editors that indirectly driven by this one.
+	def drivenNodeSets( self, recurse = False ) :
+
+		# Unwrap the weak refs
+		driven = { w(): m for w,m in self.__drivenNodeSets.items() if w() is not None }
+
+		if recurse :
+			for editor in driven.keys() :
+				driven.update( editor.drivenNodeSets( recurse = True ) )
+
+		return driven
+
+	def drivenNodeSetsChangedSignal( self ) :
+
+		return self.__drivenNodeSetsChangedSignal
+
+	## Does this editor ultimately drive otherEditor
+	def drivesNodeSet( self, otherEditor ) :
+
+		assert( isinstance( otherEditor, GafferUI.NodeSetEditor ) )
+
+		driver = otherEditor
+		while True :
+			if driver is None :
+				break
+			if driver is self :
+				return True
+			driver, _ = driver.getNodeSetDriver()
+
+		return False
+
+	## Returns the editor that ultimately drives this editor. If this editor
+	# is not driven, None is returned.
+	def drivingEditor( self ) :
+
+		driver = None
+
+		upstreamEditor = self
+		while True :
+			upstreamEditor, _ = upstreamEditor.getNodeSetDriver()
+			if upstreamEditor :
+				driver = upstreamEditor
+			else :
+				break
+
+		return driver
+
+	def __registerDrivenEditor( self, drivenEditor, mode ) :
+
+		if drivenEditor in self.drivenNodeSets() :
+			return
+
+		self.__drivenNodeSets[ weakref.ref( drivenEditor ) ] = mode
+		self.__drivenNodeSetsChangedSignal( self )
+
+	def __unregisterDrivenEditor( self, drivenEditor ) :
+
+		for weakEditor in self.__drivenNodeSets :
+			if weakEditor() is drivenEditor :
+				del self.__drivenNodeSets[ weakEditor ]
+				self.__drivenNodeSetsChangedSignal( self )
+				break
+
+	## Call to register a new DriverMode that can be used with setNodeSetDriver.
+	# The supplied callback will be called with ( thisEditor, drivingEditor ) and
+	# must return a derivative of Gaffer.Set that represents the nodesSet to be
+	# set in the driven editor.
+	@classmethod
+	def registerNodeSetDriverMode( cls, mode, changeCallback ) :
+
+		cls.__nodeSetDriverModes[ mode ] = changeCallback
 
 	## Overridden to display the names of the nodes being edited.
 	# Derived classes should override _titleFormat() rather than
@@ -220,7 +389,8 @@ class NodeSetEditor( GafferUI.Editor ) :
 		self.__memberAddedConnection = self.__nodeSet.memberAddedSignal().connect( Gaffer.WeakMethod( self.__membersChanged ) )
 		self.__memberRemovedConnection = self.__nodeSet.memberRemovedSignal().connect( Gaffer.WeakMethod( self.__membersChanged ) )
 
-		nodeSet.setRemoveOrphans( True )
+		if isinstance( nodeSet, Gaffer.StandardSet ) :
+			nodeSet.setRemoveOrphans( True )
 
 		if callUpdateFromSet :
 			# only update if the nodes being held have actually changed,
@@ -277,3 +447,6 @@ class _EditorWindow( GafferUI.Window ) :
 
 		if not len( set ) :
 			self.parent().removeChild( self )
+
+
+NodeSetEditor.registerNodeSetDriverMode( NodeSetEditor.DriverModeNodeSet, None )

--- a/python/GafferUITest/NodeSetEditorTest.py
+++ b/python/GafferUITest/NodeSetEditorTest.py
@@ -1,0 +1,324 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+import weakref
+
+import Gaffer
+import GafferUI
+import GafferUITest
+
+class NodeSetEditorTest( GafferUITest.TestCase ) :
+
+	def testDefaultsToNodeSelection( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		ne = GafferUI.NodeEditor( s )
+		self.assertTrue( ne.getNodeSet().isSame( s.selection() ) )
+
+	def testSetNodeSet( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		n = Gaffer.StandardSet()
+		n2 = Gaffer.StandardSet()
+
+		ne = GafferUI.NodeEditor( s )
+		ne.setNodeSet( n )
+		self.assertTrue( ne.getNodeSet().isSame( n ) )
+		ne.setNodeSet( n2 )
+		self.assertTrue( ne.getNodeSet().isSame( n2 ) )
+
+	def testSetNodeSetDriver( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		n1 = Gaffer.StandardSet()
+		n2 = Gaffer.StandardSet()
+		n3 = Gaffer.StandardSet()
+
+		ne1 = GafferUI.NodeEditor( s )
+
+		# Test default state
+		self.assertEqual( ne1.drivenNodeSets(), {} )
+		self.assertEqual( ne1.getNodeSetDriver(), ( None, "" ) )
+
+		ne2 = GafferUI.NodeEditor( s )
+		ne3 = GafferUI.NodeEditor( s )
+
+		ne1.setNodeSet( n1 )
+		ne2.setNodeSet( n2 )
+		ne3.setNodeSet( n3 )
+
+		ne2.setNodeSetDriver( ne1 )
+		self.assertTrue( ne2.getNodeSet().isSame( ne1.getNodeSet() ) )
+		self.assertTrue( ne2.getNodeSet().isSame( n1 ) )
+		self.assertEqual( ne2.getNodeSetDriver(), ( ne1, GafferUI.NodeSetEditor.DriverModeNodeSet ) )
+		self.assertDictEqual( ne1.drivenNodeSets(), { ne2 : GafferUI.NodeSetEditor.DriverModeNodeSet } )
+		self.assertDictEqual( ne2.drivenNodeSets(), {} )
+
+		ne3.setNodeSetDriver( ne2 )
+		self.assertTrue( ne3.getNodeSet().isSame( ne2.getNodeSet() ) )
+		self.assertTrue( ne3.getNodeSet().isSame( ne1.getNodeSet() ) )
+		self.assertTrue( ne3.getNodeSet().isSame( n1 ) )
+		self.assertEqual( ne3.getNodeSetDriver(), ( ne2, GafferUI.NodeSetEditor.DriverModeNodeSet ) )
+		self.assertDictEqual( ne1.drivenNodeSets(), { ne2 : GafferUI.NodeSetEditor.DriverModeNodeSet } )
+		self.assertDictEqual( ne1.drivenNodeSets( recurse = True ) , { ne2 : GafferUI.NodeSetEditor.DriverModeNodeSet, ne3 : GafferUI.NodeSetEditor.DriverModeNodeSet } )
+		self.assertDictEqual( ne2.drivenNodeSets(), { ne3 : GafferUI.NodeSetEditor.DriverModeNodeSet } )
+		self.assertDictEqual( ne3.drivenNodeSets(), {} )
+
+		ne1.setNodeSet( n3 )
+		self.assertTrue( ne1.getNodeSet().isSame( n3 ) )
+		self.assertTrue( ne2.getNodeSet().isSame( n3 ) )
+		self.assertTrue( ne3.getNodeSet().isSame( n3 ) )
+
+		ne1.setNodeSet( n1 )
+
+		# setNodeSet should clear driver link
+		ne2.setNodeSet( n2 )
+		self.assertFalse( ne2.getNodeSet().isSame( ne1.getNodeSet() ) )
+		self.assertTrue( ne2.getNodeSet().isSame( n2 ) )
+		self.assertTrue( ne3.getNodeSet().isSame( n2 ) )
+		self.assertFalse( ne3.getNodeSet().isSame( ne1.getNodeSet() ) )
+		self.assertEqual( ne2.getNodeSetDriver(), ( None, "" ) )
+		self.assertDictEqual( ne1.drivenNodeSets(), {} )
+
+		ne3.setNodeSetDriver( None )
+		self.assertTrue( ne3.getNodeSet().isSame( n2 ) )
+		self.assertEqual( ne3.getNodeSetDriver(), ( None, "" ) )
+		self.assertDictEqual( ne2.drivenNodeSets(), {} )
+
+		ne2.setNodeSetDriver( ne1 )
+		ne3.setNodeSetDriver( ne1 )
+		self.assertDictEqual( ne1.drivenNodeSets(), {
+			ne2 : GafferUI.NodeSetEditor.DriverModeNodeSet,
+			ne3 : GafferUI.NodeSetEditor.DriverModeNodeSet
+		} )
+		self.assertEqual( ne2.getNodeSetDriver(), ( ne1, GafferUI.NodeSetEditor.DriverModeNodeSet ) )
+		self.assertEqual( ne3.getNodeSetDriver(), ( ne1, GafferUI.NodeSetEditor.DriverModeNodeSet ) )
+
+		# Check passing in garbage
+		with self.assertRaises( AssertionError ) :
+			ne2.setNodeSetDriver( n1 )
+
+	def testLinkLifetime( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		ne1 = GafferUI.NodeEditor( s )
+		ne2 = GafferUI.NodeEditor( s )
+
+		ne2.setNodeSetDriver( ne1 )
+		self.assertEqual( ne2.getNodeSetDriver(), ( ne1, GafferUI.NodeSetEditor.DriverModeNodeSet ) )
+
+		del ne1
+		self.assertEqual( ne2.getNodeSetDriver(), ( None, "" ) )
+
+	def testLoop( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		ne1 = GafferUI.NodeEditor( s )
+		ne2 = GafferUI.NodeEditor( s )
+		ne3 = GafferUI.NodeEditor( s )
+
+		ne2.setNodeSetDriver( ne1 )
+		with self.assertRaises( ValueError ) :
+			ne1.setNodeSetDriver( ne2 )
+		self.assertEqual( ne1.getNodeSetDriver(), ( None, "" ) )
+
+		ne2.setNodeSetDriver( ne1 )
+		ne3.setNodeSetDriver( ne2 )
+		with self.assertRaises( ValueError ) :
+			ne1.setNodeSetDriver( ne3 )
+		self.assertEqual( ne1.getNodeSetDriver(), ( None, "" ) )
+
+	def testSignals( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		n1 = Gaffer.StandardSet()
+		n2 = Gaffer.StandardSet()
+
+		ne1 = GafferUI.NodeEditor( s )
+		ne2 = GafferUI.NodeEditor( s )
+
+		weakne1 = weakref.ref( ne1 )
+
+		signalData = {
+			'ne1nodeSetMirror' : None,
+			'ne2nodeSetMirror' : None,
+			'ne1driverMirror' : ( None, "" ),
+			'ne2driverMirror' : ( None, "" ),
+			'ne1drivenMirror' : {},
+			'ne2drivenMirror' : {}
+		}
+
+		def nodeSetChangedCallback( editor ) :
+			d = editor.getNodeSet()
+			if editor is weakne1() :
+				signalData['ne1nodeSetMirror'] = d
+			else :
+				signalData['ne2nodeSetMirror'] = d
+
+		def nodeSetDriverChangedCallback( editor ) :
+			d = editor.getNodeSetDriver()
+			if editor is weakne1() :
+				signalData['ne1driverMirror']= d
+			else :
+				signalData['ne2driverMirror']= d
+
+		def drivenChangedCallback( editor ) :
+			d = editor.drivenNodeSets()
+			if editor is weakne1() :
+				signalData['ne1drivenMirror']= d
+			else :
+				signalData['ne2drivenMirror']= d
+
+		c1 = ne1.nodeSetChangedSignal().connect( nodeSetChangedCallback )
+		c2 = ne1.nodeSetDriverChangedSignal().connect( nodeSetDriverChangedCallback )
+		c3 = ne1.drivenNodeSetsChangedSignal().connect( drivenChangedCallback )
+
+		c4 = ne2.nodeSetChangedSignal().connect( nodeSetChangedCallback )
+		c5 = ne2.nodeSetDriverChangedSignal().connect( nodeSetDriverChangedCallback )
+		c6 = ne2.drivenNodeSetsChangedSignal().connect( drivenChangedCallback )
+
+		ne1.setNodeSet( n1 )
+		ne2.setNodeSet( n2 )
+
+		self.assertEqual( ne1.getNodeSet(), signalData['ne1nodeSetMirror'] )
+		self.assertEqual( ne2.getNodeSet(), signalData['ne2nodeSetMirror'] )
+
+		ne2.setNodeSetDriver( ne1 )
+		self.assertEqual( ne1.getNodeSet(), signalData['ne1nodeSetMirror'] )
+		self.assertEqual( ne2.getNodeSet(), signalData['ne2nodeSetMirror'] )
+		self.assertEqual( ne1.getNodeSetDriver(), signalData['ne1driverMirror'] )
+		self.assertEqual( ne2.getNodeSetDriver(), signalData['ne2driverMirror'] )
+		self.assertEqual( ne1.drivenNodeSets(), signalData['ne1drivenMirror'] )
+		self.assertEqual( ne2.drivenNodeSets(), signalData['ne2drivenMirror'] )
+
+		ne1.setNodeSet( n2 )
+		self.assertEqual( ne1.getNodeSet(), signalData['ne1nodeSetMirror'] )
+		self.assertEqual( ne2.getNodeSet(), signalData['ne2nodeSetMirror'] )
+		self.assertEqual( ne1.getNodeSetDriver(), signalData['ne1driverMirror'] )
+		self.assertEqual( ne2.getNodeSetDriver(), signalData['ne2driverMirror'] )
+		self.assertEqual( ne1.drivenNodeSets(), signalData['ne1drivenMirror'] )
+		self.assertEqual( ne2.drivenNodeSets(), signalData['ne2drivenMirror'] )
+
+		ne2.setNodeSet( n1 )
+		self.assertEqual( ne1.getNodeSet(), signalData['ne1nodeSetMirror'] )
+		self.assertEqual( ne2.getNodeSet(), signalData['ne2nodeSetMirror'] )
+		self.assertEqual( ne1.getNodeSetDriver(), signalData['ne1driverMirror'] )
+		self.assertEqual( ne2.getNodeSetDriver(), signalData['ne2driverMirror'] )
+		self.assertEqual( ne1.drivenNodeSets(), signalData['ne1drivenMirror'] )
+		self.assertEqual( ne2.drivenNodeSets(), signalData['ne2drivenMirror'] )
+
+		ne2.setNodeSetDriver( ne1 )
+		ne2.setNodeSetDriver( None )
+		self.assertEqual( ne1.getNodeSet(), signalData['ne1nodeSetMirror'] )
+		self.assertEqual( ne2.getNodeSet(), signalData['ne2nodeSetMirror'] )
+		self.assertEqual( ne1.getNodeSetDriver(), signalData['ne1driverMirror'] )
+		self.assertEqual( ne2.getNodeSetDriver(), signalData['ne2driverMirror'] )
+		self.assertEqual( ne1.drivenNodeSets(), signalData['ne1drivenMirror'] )
+		self.assertEqual( ne2.drivenNodeSets(), signalData['ne2drivenMirror'] )
+
+		ne2.setNodeSetDriver( ne1 )
+		del c1, c2, c3, ne1
+		self.assertEqual( ne2.getNodeSet(), signalData['ne2nodeSetMirror'] )
+		self.assertEqual( ne2.getNodeSetDriver(), signalData['ne2driverMirror'] )
+		self.assertEqual( ne2.drivenNodeSets(), signalData['ne2drivenMirror'] )
+
+	def testSignalOrder( self ) :
+
+		d = Gaffer.StandardSet()
+		def dummyDriverModeCallback( editor, targetEditor ) :
+			return d
+
+		DummyMode = "Dummy"
+		GafferUI.NodeSetEditor.registerNodeSetDriverMode( DummyMode, dummyDriverModeCallback )
+
+		s = Gaffer.ScriptNode()
+
+		ne1 = GafferUI.NodeEditor( s )
+		ne2 = GafferUI.NodeEditor( s )
+
+		ne2.setNodeSetDriver( ne1, DummyMode )
+		self.assertTrue( ne2.getNodeSet().isSame( d ) )
+
+		# People acting upon these signals need to know the order in which these signals
+		# fire. We have to pick one way around (there are gotchas with either way). This is
+		# to ensure we don't inadvertently change this ordering.
+
+		def nodeSetChangedCallback( _ ) :
+			self.assertTrue( ne2.getNodeSetDriver(), ( ne1, DummyMode ) )
+
+		s2 = Gaffer.StandardSet()
+		def driverChangedCallback( _ ) :
+			self.assertTrue( ne2.getNodeSet().isSame( s2 ) )
+
+		c1 = ne2.nodeSetChangedSignal().connect( nodeSetChangedCallback )
+		c2 = ne2.nodeSetDriverChangedSignal().connect( driverChangedCallback )
+
+		ne2.setNodeSet( s2 )
+
+	def testDriverModes( self ) :
+
+		d = Gaffer.StandardSet()
+		def dummyDriverModeCallback( editor, targetEditor ) :
+			return d
+
+		DummyMode = "Dummy"
+		GafferUI.NodeSetEditor.registerNodeSetDriverMode( DummyMode, dummyDriverModeCallback )
+
+		s = Gaffer.ScriptNode()
+
+		ne1 = GafferUI.NodeEditor( s )
+		ne2 = GafferUI.NodeEditor( s )
+
+		ne2.setNodeSetDriver( ne1 )
+		self.assertEqual( ne2.getNodeSetDriver(), ( ne1, GafferUI.NodeSetEditor.DriverModeNodeSet ) )
+		self.assertTrue( ne2.getNodeSet().isSame( s.selection() ) )
+
+		ne2.setNodeSetDriver( ne1, DummyMode )
+		self.assertEqual( ne2.getNodeSetDriver(), ( ne1, DummyMode ) )
+		self.assertTrue( ne2.getNodeSet().isSame( d ) )
+
+		ne1.setNodeSet( Gaffer.StandardSet() )
+		self.assertTrue( ne2.getNodeSet().isSame( d ) )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -116,6 +116,7 @@ from LayoutsTest import LayoutsTest
 from CompoundNumericNoduleTest import CompoundNumericNoduleTest
 from DocumentationAlgoTest import DocumentationAlgoTest
 from ExamplesTest import ExamplesTest
+from NodeSetEditorTest import NodeSetEditorTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -23,9 +23,65 @@
     <linearGradient
        id="compoundEditorButtonDisabled">
       <stop
-         style="stop-color:#7d7d7d;stop-opacity:1;"
+         style="stop-color:#696969;stop-opacity:1;"
          offset="0"
          id="stop1497" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1537"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#787878;stop-opacity:1;"
+         offset="0"
+         id="stop1535" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1531"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#787878;stop-opacity:1;"
+         offset="0"
+         id="stop1529" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1521"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#779bbc;stop-opacity:1;"
+         offset="0"
+         id="stop1519" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1550"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#3c3c3c;stop-opacity:1;"
+         offset="0"
+         id="stop1548" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1542"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#8f8f8f;stop-opacity:1;"
+         offset="0"
+         id="stop1540" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1534"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#8f8f8f;stop-opacity:1;"
+         offset="0"
+         id="stop1532" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1571"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#787878;stop-opacity:1;"
+         offset="0"
+         id="stop1569" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
@@ -97,7 +153,12 @@
     </linearGradient>
     <linearGradient
        id="linearGradient6247"
-       xlink:href="#linearGradient6241">
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="0"
+       gradientUnits="objectBoundingBox"
+       spreadMethod="pad">
       <stop
          style="stop-color:#787878;stop-opacity:1;"
          offset="0"
@@ -548,13 +609,48 @@
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#backgroundLight"
-       id="linearGradient2199"
+       xlink:href="#compoundEditorButtonDisabled"
+       id="linearGradient4863"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient1536"
+       x1="143.36874"
+       y1="233.49455"
+       x2="157.56445"
+       y2="233.49455"
        gradientUnits="userSpaceOnUse"
-       x1="108.46148"
-       y1="578.07648"
-       x2="121.48355"
-       y2="578.07648" />
+       gradientTransform="translate(1.5124446,-0.53929075)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient1544"
+       x1="127.03812"
+       y1="215.299"
+       x2="150.2056"
+       y2="215.299"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient1552"
+       x1="125.42407"
+       y1="215.29883"
+       x2="151.82007"
+       y2="215.29883"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.7137094,16.582842)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient1556"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(25.201613,16.58284)"
+       x1="125.42407"
+       y1="215.29883"
+       x2="151.82007"
+       y2="215.29883" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#foreground"
@@ -564,10 +660,62 @@
        y1="578.07648"
        x2="121.48355"
        y2="578.07648" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask5259">
+      <rect
+         y="220.59137"
+         x="139.07568"
+         height="22.580645"
+         width="22.580645"
+         id="rect5261"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.29247308;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5291">
+      <feBlend
+         inkscape:collect="always"
+         mode="hard-light"
+         in2="BackgroundImage"
+         id="feBlend5293" />
+    </filter>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#compoundEditorButtonDisabled"
-       id="linearGradient4863"
+       xlink:href="#backgroundDark"
+       id="linearGradient1523"
+       x1="141.15625"
+       y1="232.33093"
+       x2="159.21875"
+       y2="232.33093"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundDark"
+       id="linearGradient1525"
+       x1="141.1564"
+       y1="233.59351"
+       x2="150.67906"
+       y2="233.59351"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundDark"
+       id="linearGradient1527"
+       x1="141.15649"
+       y1="226.47861"
+       x2="159.22701"
+       y2="226.47861"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient1533"
+       x1="141.15649"
+       y1="226.47861"
+       x2="159.22701"
+       y2="226.47861"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
@@ -577,18 +725,18 @@
      borderopacity="1"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="8"
-     inkscape:cx="128.63552"
-     inkscape:cy="951.33865"
+     inkscape:zoom="8.0000004"
+     inkscape:cx="312.09716"
+     inkscape:cy="673.18996"
      inkscape:document-units="px"
-     inkscape:current-layer="forExport:targetNodesUnlocked"
+     inkscape:current-layer="forExport:nodeSetDriverSceneSelectionSource"
      showgrid="true"
      inkscape:window-width="1231"
      inkscape:window-height="1006"
-     inkscape:window-x="472"
-     inkscape:window-y="30"
+     inkscape:window-x="427"
+     inkscape:window-y="0"
      inkscape:window-maximized="0"
-     inkscape:snap-global="true"
+     inkscape:snap-global="false"
      inkscape:snap-nodes="true"
      inkscape:snap-bbox="true"
      inkscape:object-nodes="true"
@@ -4328,7 +4476,7 @@
          sodipodi:nodetypes="ccccccccc" />
     </g>
     <g
-       transform="translate(101.19765,-49.336359)"
+       transform="translate(101.19765,-49.336362)"
        id="forExport:pointerTab"
        inkscape:label="#g4212">
       <g
@@ -4505,7 +4653,7 @@
     <g
        style="clip-rule:evenodd;fill:url(#linearGradient4863);fill-opacity:1;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5"
        transform="matrix(0.8,0,0,0.8,-626.30839,-193.05238)"
-       id="forExport:targetNodesUnlocked">
+       id="forExport:nodeSetDriverNodeSelection">
       <g
          id="g1166"
          transform="rotate(-45,1063.0797,502.31281)"
@@ -4519,35 +4667,36 @@
       <g
          id="g1170"
          transform="rotate(-45,1063.0911,503.72257)"
-         style="fill:url(#linearGradient4863);fill-opacity:1">
+         style="fill:none;fill-opacity:1">
         <path
            id="path1168"
-           style="fill:url(#linearGradient4863);fill-opacity:1;stroke:#3c3c3c;stroke-width:1px"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1px"
            d="m 1108.5,339 v 7"
            inkscape:connector-curvature="0" />
       </g>
       <g
          id="g1174"
          transform="rotate(-45,1058.8981,494.14549)"
-         style="fill:url(#linearGradient4863);fill-opacity:1">
+         style="fill:none;fill-opacity:1">
         <path
            id="path1172"
-           style="fill:url(#linearGradient4863);fill-opacity:1;stroke:#3c3c3c;stroke-width:1px"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1px"
            d="m 1108.5,339 v 7"
            inkscape:connector-curvature="0" />
       </g>
     </g>
     <g
        style="clip-rule:evenodd;fill:url(#foreground);fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5"
-       transform="matrix(0.8,0,0,0.8,-607.41407,-193.05238)"
-       id="forExport:targetNodesLocked">
+       transform="matrix(0.8,0,0,0.8,-502.05516,50.192352)"
+       id="forExport:nodeSetStandardSet"
+       inkscape:label="forExport:nodeSetStandardSet">
       <g
          id="g1179"
          transform="rotate(-45,1063.0797,502.31281)"
          style="fill:url(#foreground)">
         <path
            id="path1177"
-           style="fill:url(#foreground);stroke:#3c3c3c;stroke-width:1px"
+           style="fill:url(#foreground);stroke:#3c3c3c;stroke-width:1.00157475;stroke-miterlimit:1.5;stroke-dasharray:none"
            d="m 1099.5,342.135 1,-1.613 h 5 V 336 c 0.97,-1.378 1.01,-1.482 2,0 v 2 l 8,1 v -2 h 2 v 9 l -2,0.27 v -2.31 l -8,1.04 v 2 c -0.91,1.591 -1.3,1.384 -2,0 v -4.478 h -5 z"
            inkscape:connector-curvature="0" />
       </g>
@@ -4571,6 +4720,66 @@
            d="m 1108.5,339 v 7"
            inkscape:connector-curvature="0" />
       </g>
+    </g>
+    <g
+       id="forExport:nodeSetDriverSceneSelectionSource"
+       inkscape:label="#forExport:nodeSetDriverSceneSelectionSource"
+       transform="matrix(0.72887391,0,0,0.77572483,196.02955,155.38621)">
+      <path
+         style="fill:#a0a0a0;fill-opacity:1;stroke:url(#linearGradient1523);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 150.21875,223.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 z"
+         id="path1495"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path1497"
+         d="m 142.36661,236.49782 -0.71022,-10.45042 8.52267,3.39892 -0.17756,11.69331 z"
+         style="fill:#c8c8c8;fill-opacity:1;stroke:url(#linearGradient1525);stroke-width:1.00025451;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path1499"
+         d="m 141.65639,226.0474 8.52267,3.39892 8.54804,-3.37356 -8.52267,-2.56187 z"
+         style="fill:url(#linearGradient1533);fill-opacity:1;stroke:url(#linearGradient1527);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="matrix(0.62,0,0,0.62,232.4607,190.59554)"
+       id="taargetNodeSetLinkNodeSet"
+       inkscape:label="nodeSetDriverNodeSet"
+       style="stroke:#3c3c3c;stroke-width:1.29247308;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1">
+      <g
+         id="g5252"
+         mask="url(#mask5259)"
+         transform="translate(0,-3.326111e-6)"
+         style="opacity:1;filter:url(#filter5291)">
+        <path
+           inkscape:connector-curvature="0"
+           id="rect1538"
+           d="m 131.31362,224.87387 c -3.8261,0 -6.95703,3.13092 -6.95703,6.95703 v 0.10156 c 0,3.8261 3.13093,6.95703 6.95703,6.95703 h 11.18946 c 3.8261,0 6.95703,-3.13093 6.95703,-6.95703 v -0.10156 c 0,-3.82611 -3.13093,-6.95703 -6.95703,-6.95703 z m 0,3.22851 h 11.18946 c 2.09365,0 3.72851,1.63487 3.72851,3.72852 v 0.10156 c 0,2.09365 -1.63486,3.72852 -3.72851,3.72851 h -11.18946 c -2.09365,0 -3.72851,-1.63486 -3.72851,-3.72851 v -0.10156 c 0,-2.09365 1.63486,-3.72852 3.72851,-3.72852 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1552);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.29235458;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1556);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.29247308;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 158.22895,224.87387 c -3.8261,0 -6.95703,3.13092 -6.95703,6.95703 v 0.10156 c 0,3.8261 3.13093,6.95703 6.95703,6.95703 h 11.18946 c 3.8261,0 6.95703,-3.13093 6.95703,-6.95703 v -0.10156 c 0,-3.82611 -3.13093,-6.95703 -6.95703,-6.95703 z m 0,3.22851 h 11.18946 c 2.09365,0 3.72851,1.63487 3.72851,3.72852 v 0.10156 c 0,2.09365 -1.63486,3.72852 -3.72851,3.72851 h -11.18946 c -2.09365,0 -3.72851,-1.63486 -3.72851,-3.72851 v -0.10156 c 0,-2.09365 1.63486,-3.72852 3.72851,-3.72852 z"
+           id="path1554"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         style="fill:url(#linearGradient1536);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.29247308;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1"
+         id="rect1524"
+         width="16.129236"
+         height="5.1310506"
+         x="142.30139"
+         y="229.31615"
+         ry="2.5655253" />
+      <rect
+         style="opacity:0;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.29247308;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1"
+         id="forExport:nodeSetDriverNodeSet"
+         width="22.580645"
+         height="22.580645"
+         x="139.10577"
+         y="220.61823"
+         inkscape:label="export" />
     </g>
   </g>
 </svg>

--- a/src/GafferSceneUI/SourceSet.cpp
+++ b/src/GafferSceneUI/SourceSet.cpp
@@ -1,0 +1,244 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferSceneUI/SourceSet.h"
+
+#include "GafferSceneUI/ContextAlgo.h"
+
+#include "GafferScene/SceneAlgo.h"
+#include "GafferScene/SceneNode.h"
+
+#include "Gaffer/MetadataAlgo.h"
+
+#include "IECore/Exception.h"
+
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferSceneUI;
+
+namespace {
+
+// This is a re-implementation of the python version
+// in SceneHistoryUI.py as we couldn't find a sensible
+// name for this in the public API
+// TODO: Re-home in MetadataAlgo we can make it make sense...
+Node *ancestorWithReadOnlyChildNodes( Node *node )
+{
+	Node *ancestor = nullptr;
+	while( node )
+	{
+		if( MetadataAlgo::getChildNodesAreReadOnly( node ) )
+		{
+			ancestor = node;
+		}
+		node = runTimeCast<Node>( node->parent() );
+	}
+	return ancestor;
+}
+
+}
+
+
+SourceSet::SourceSet(  ContextPtr context, SetPtr nodeSet )
+{
+	setContext( context );
+	setNodeSet( nodeSet );
+}
+
+SourceSet::~SourceSet()
+{
+}
+
+void SourceSet::setContext( ContextPtr context )
+{
+	if( context == m_context )
+	{
+		return;
+	}
+
+	m_context = context;
+	m_contextChangedConnection = context->changedSignal().connect( boost::bind( &SourceSet::contextChanged, this, ::_2 ) );
+	updateSourceNode();
+}
+
+Context *SourceSet::getContext() const
+{
+	return m_context.get();
+}
+
+void SourceSet::setNodeSet( SetPtr nodeSet )
+{
+	if( nodeSet == m_nodes )
+	{
+		return;
+	}
+
+	m_nodes = nodeSet;
+	m_nodeAddedConnection = nodeSet->memberAddedSignal().connect( boost::bind( &SourceSet::updateScenePlug, this ) );
+	m_nodeRemovedConnection = nodeSet->memberRemovedSignal().connect( boost::bind( &SourceSet::updateScenePlug, this ) );
+	updateScenePlug();
+}
+
+Set *SourceSet::getNodeSet() const
+{
+	return m_nodes.get();
+}
+
+
+bool SourceSet::contains( const Member *object ) const
+{
+	return m_sourceNode && m_sourceNode.get() == object;
+}
+
+Set::Member *SourceSet::member( size_t index )
+{
+	return m_sourceNode.get();
+}
+
+const Set::Member *SourceSet::member( size_t index ) const
+{
+	return m_sourceNode.get();
+}
+
+size_t SourceSet::size() const
+{
+	return m_sourceNode ? 1 : 0;
+}
+
+void SourceSet::contextChanged( const IECore::InternedString &name )
+{
+	if( ContextAlgo::affectsLastSelectedPath( name ) )
+	{
+		updateSourceNode();
+	}
+}
+
+void SourceSet::plugDirtied( const Gaffer::Plug *plug )
+{
+	if( m_scenePlug && m_scenePlug == plug )
+	{
+		updateSourceNode();
+	}
+}
+
+void SourceSet::updateScenePlug()
+{
+	ScenePlug *newScenePlug = nullptr;
+	if( m_nodes && m_nodes->size() > 0 )
+	{
+		// We want the last selected node rather than the first
+		Node const *node = runTimeCast<Node>( m_nodes->member( m_nodes->size() - 1 ) );
+		if( node )
+		{
+			OutputScenePlugIterator it( node );
+			if( !it.done() )
+			{
+				newScenePlug = it->get();
+			}
+		}
+	}
+
+	if( newScenePlug != m_scenePlug )
+	{
+		m_plugDirtiedConnection.disconnect();
+		if( newScenePlug )
+		{
+			m_plugDirtiedConnection = newScenePlug->node()->plugDirtiedSignal().connect( boost::bind( &SourceSet::plugDirtied, this, ::_1 ) );
+		}
+
+		m_scenePlug = newScenePlug;
+	}
+
+	// We always update this (even if we don't find a scene plug) to ensure we update
+	// the presented node through consecutive selection of nodes without scene plugs.
+	updateSourceNode();
+}
+
+void SourceSet::updateSourceNode()
+{
+	Node *newSourceNode = nullptr;
+
+	if( m_context && m_scenePlug )
+	{
+		const ScenePlug::ScenePath path = ContextAlgo::getLastSelectedPath( m_context.get() );
+
+		Context::Scope scope( m_context.get() );
+		try
+		{
+			if( !path.empty() && SceneAlgo::exists( m_scenePlug.get(), path ) )
+			{
+				if( ScenePlug *sourcePlug = SceneAlgo::source( m_scenePlug.get(), path ) )
+				{
+					Node* const firstEditableAncestor = ancestorWithReadOnlyChildNodes( sourcePlug->node() );
+					newSourceNode = firstEditableAncestor ? firstEditableAncestor : sourcePlug->node();
+				}
+			}
+			else
+			{
+				newSourceNode = m_scenePlug->node();
+			}
+		}
+		catch( std::exception &e )
+		{
+			/* this will reported by Node::errorSignal() */
+		}
+	}
+	else if( m_nodes && m_nodes->size() > 0 )
+	{
+		// If we don't have a valid context or scene plug, but do have a node,
+		// just assume that's the source. This generally makes sense for non-
+		// scene nodes.
+		newSourceNode = runTimeCast<Node>( m_nodes->member( m_nodes->size() - 1 ) );
+	}
+
+	if( newSourceNode != m_sourceNode )
+	{
+		if( m_sourceNode )
+		{
+			NodePtr oldSourceNode = m_sourceNode;
+			m_sourceNode.reset();
+			memberRemovedSignal()( this, oldSourceNode.get() );
+		}
+
+		m_sourceNode = newSourceNode;
+
+		if( newSourceNode )
+		{
+			memberAddedSignal()( this, newSourceNode );
+		}
+	}
+}

--- a/src/GafferSceneUIModule/SourceSetBinding.cpp
+++ b/src/GafferSceneUIModule/SourceSetBinding.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2013, John Haddon. All rights reserved.
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -36,25 +36,42 @@
 
 #include "boost/python.hpp"
 
-#include "ContextAlgoBinding.h"
-#include "HierarchyViewBinding.h"
-#include "SceneGadgetBinding.h"
+#include "IECorePython/RunTimeTypedBinding.h"
+
 #include "SourceSetBinding.h"
-#include "ToolBinding.h"
-#include "ViewBinding.h"
-#include "VisualiserBinding.h"
 
-using namespace GafferSceneUIModule;
+#include "GafferSceneUI/SourceSet.h"
 
-BOOST_PYTHON_MODULE( _GafferSceneUI )
+using namespace Gaffer;
+using namespace GafferSceneUI;
+
+using namespace IECorePython;
+using namespace boost::python;
+
+namespace {
+
+void setContext( SourceSet &s, Context &c )
 {
+	IECorePython::ScopedGILRelease gilRelease;
+	s.setContext( &c );
+}
 
-	bindViews();
-	bindTools();
-	bindVisualisers();
-	bindHierarchyView();
-	bindSceneGadget();
-	bindContextAlgo();
-	bindSourceSet();
+void setNodeSet( SourceSet &s, Set &t )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	s.setNodeSet( &t );
+}
 
 }
+
+void GafferSceneUIModule::bindSourceSet()
+{
+	RunTimeTypedClass<SourceSet>()
+		.def( init<ContextPtr, SetPtr>() )
+		.def( "setContext", &setContext )
+		.def( "getContext", &SourceSet::getContext, return_value_policy<CastToIntrusivePtr>() )
+		.def( "setNodeSet", &setNodeSet )
+		.def( "getNodeSet", &SourceSet::getNodeSet, return_value_policy<CastToIntrusivePtr>() )
+	;
+}
+

--- a/src/GafferSceneUIModule/SourceSetBinding.h
+++ b/src/GafferSceneUIModule/SourceSetBinding.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2013, John Haddon. All rights reserved.
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,27 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERSCENEUIMODULE_SOURCESETBINDING_H
+#define GAFFERSCENEUIMODULE_SOURCESETBINDING_H
 
-#include "ContextAlgoBinding.h"
-#include "HierarchyViewBinding.h"
-#include "SceneGadgetBinding.h"
-#include "SourceSetBinding.h"
-#include "ToolBinding.h"
-#include "ViewBinding.h"
-#include "VisualiserBinding.h"
-
-using namespace GafferSceneUIModule;
-
-BOOST_PYTHON_MODULE( _GafferSceneUI )
+namespace GafferSceneUIModule
 {
 
-	bindViews();
-	bindTools();
-	bindVisualisers();
-	bindHierarchyView();
-	bindSceneGadget();
-	bindContextAlgo();
-	bindSourceSet();
+void bindSourceSet();
 
-}
+} // namespace GafferSceneUIModule
+
+#endif // GAFFERSCENEUIMODULE_SOURCESETBINDING_H


### PR DESCRIPTION
The pinning menu has been significantly re-vamped to support linking editors to one another, or the scene selection. See individual commits for details.

![image](https://user-images.githubusercontent.com/896779/61528050-bf2ddd80-aa15-11e9-8a72-bf5184b3d56b.png)

NOTE: These changes highlight an existing bug whereby we don't clear the highlight state of button images when its menu is closed.

## User Facing Changes

 - New pinning menu items to allow editors to be linked and follow scene selection.
 - Re-structured pinning menu bookmarks section
 - New pinning button icons to reflect the editors link state
 - Color decorations next to the pinning button for linked editors
   to help understand link relationships

## API Changes

 - Adds `GafferSceneUI.SceneSet`
 - `NodeSetEditor` :
   - Adds `setNodeSetDriver`/`getNodeSetDriver` to link editors.
   - Adds `drivenNodeSets` to query linked editors.
   - Adds `nodeSetDriverChangedSignal`, `nodeSetDriverChangedSignal` signals to allow link status to be observed.
   - Adds registerNodeSetDriverMode to allow custom link modes to be registered by other code.
 - `NodeSetEditorAlgo` provides extended query functions.
