### PR TITLE
GraphComponentBinding : Fix crashes caused by passing `None` as child

### DIFF
--- a/python/GafferTest/GraphComponentTest.py
+++ b/python/GafferTest/GraphComponentTest.py
@@ -987,5 +987,18 @@ class GraphComponentTest( GafferTest.TestCase ) :
 			c = s[n]
 			self.assertEqual( c.getName(), n )
 
+	def testNoneIsNotAGraphComponent( self ) :
+
+		g = Gaffer.GraphComponent()
+
+		with self.assertRaisesRegexp( Exception, r"did not match C\+\+ signature" ) :
+			g.addChild( None )
+
+		with self.assertRaisesRegexp( Exception, r"did not match C\+\+ signature" ) :
+			g.setChild( "x", None )
+
+		with self.assertRaisesRegexp( Exception, r"did not match C\+\+ signature" ) :
+			g.removeChild( None )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferModule/GraphComponentBinding.cpp
+++ b/src/GafferModule/GraphComponentBinding.cpp
@@ -114,22 +114,22 @@ boost::python::tuple children( GraphComponent &c, IECore::TypeId typeId )
 	return boost::python::tuple( l );
 }
 
-void addChild( GraphComponent &g, GraphComponentPtr c )
+void addChild( GraphComponent &g, GraphComponent &c )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	g.addChild( c );
+	g.addChild( &c );
 }
 
-void setChild( GraphComponent &g, const IECore::InternedString &n, GraphComponentPtr c )
+void setChild( GraphComponent &g, const IECore::InternedString &n, GraphComponent &c )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	g.setChild( n, c );
+	g.setChild( n, &c );
 }
 
-void removeChild( GraphComponent &g, GraphComponentPtr c )
+void removeChild( GraphComponent &g, GraphComponent &c )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	g.removeChild( c );
+	g.removeChild( &c );
 }
 
 void clearChildren( GraphComponent &g )


### PR DESCRIPTION
Fixes #3276
