### PR TITLE
 Attributes : Don't evaluate `extraAttributes` unnecessarily

### DIFF
--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -92,6 +92,9 @@ class GAFFER_API ValuePlug : public Plug
 		/// as the default value. The default implementation is sufficient
 		/// for all subclasses except those where the number of child plugs
 		/// varies based on the value.
+		/// > Note : If a plug's value is being driven by a ComputeNode,
+		/// > we always consider it to be non-default, because it may vary
+		/// > by context. `isSetToDefault()` does not trigger computes.
 		virtual bool isSetToDefault() const;
 
 		/// Returns a hash to represent the value of this plug

--- a/python/GafferSceneTest/CustomAttributesTest.py
+++ b/python/GafferSceneTest/CustomAttributesTest.py
@@ -322,6 +322,25 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 			} )
 		)
 
+	def testExtraAttributesOnlyEvaluatedForFilteredLocations( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["grid"] = GafferScene.Grid()
+
+		script["filter"] = GafferScene.PathFilter()
+		script["filter"]["paths"].setValue( IECore.StringVectorData( [ "/grid" ] ) )
+
+		script["customAttributes"] = GafferScene.CustomAttributes()
+		script["customAttributes"]["in"].setInput( script["grid"]["out"] )
+		script["customAttributes"]["filter"].setInput( script["filter"]["out"] )
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression( """parent["customAttributes"]["extraAttributes"] = IECore.CompoundData( { "a" : IECore.StringData( str( context.get( "scene:path" ) ) ) } )""" )
+
+		with Gaffer.ContextMonitor( script["expression"] ) as monitor :
+			GafferSceneTest.traverseScene( script["customAttributes"]["out"] )
+
+		self.assertEqual( monitor.combinedStatistics().numUniqueValues( "scene:path" ), 1 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -285,7 +285,7 @@ class TestCase( unittest.TestCase ) :
 
 			for plug in node.children( Gaffer.Plug ) :
 
-				if plug.direction() != plug.Direction.In or not isinstance( plug, Gaffer.ValuePlug ) :
+				if plug.source().direction() != plug.Direction.In or not isinstance( plug, Gaffer.ValuePlug ) :
 					continue
 
 				if not plug.getFlags( plug.Flags.Serialisable ) :

--- a/python/GafferTest/ValuePlugTest.py
+++ b/python/GafferTest/ValuePlugTest.py
@@ -621,6 +621,44 @@ class ValuePlugTest( GafferTest.TestCase ) :
 
 		GafferTest.testValuePlugContentionForOneItem()
 
+	def testIsSetToDefault( self ) :
+
+		n1 = GafferTest.AddNode()
+		self.assertTrue( n1["op1"].isSetToDefault() )
+		self.assertTrue( n1["op2"].isSetToDefault() )
+		self.assertFalse( n1["sum"].isSetToDefault() )
+
+		n1["op1"].setValue( 10 )
+		self.assertFalse( n1["op1"].isSetToDefault() )
+		self.assertTrue( n1["op2"].isSetToDefault() )
+
+		n1["op1"].setToDefault()
+		self.assertTrue( n1["op1"].isSetToDefault() )
+		self.assertTrue( n1["op2"].isSetToDefault() )
+
+		n2 = GafferTest.AddNode()
+		self.assertTrue( n2["op1"].isSetToDefault() )
+		self.assertTrue( n2["op2"].isSetToDefault() )
+		self.assertFalse( n2["sum"].isSetToDefault() )
+
+		n2["op1"].setInput( n1["op1"] )
+		# Receiving a static value via an input. We know
+		# it can have only one value for all contexts,
+		# and can be confident that it is set to the default.
+		self.assertTrue( n2["op1"].isSetToDefault() )
+		self.assertEqual( n2["op1"].getValue(), n2["op1"].defaultValue() )
+		n1["op1"].setValue( 1 )
+		# Until it provides a non-default value, that is.
+		self.assertFalse( n2["op1"].isSetToDefault() )
+
+		n1["op1"].setValue( 0 )
+		n2["op2"].setInput( n1["sum"] )
+		# Driven by a compute, so not considered to be
+		# at the default, even if it the result happens
+		# to be equal in this context.
+		self.assertFalse( n2["op2"].isSetToDefault() )
+		self.assertEqual( n2["op2"].getValue(), n2["op2"].defaultValue() )
+
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -876,7 +876,18 @@ bool ValuePlug::isSetToDefault() const
 {
 	if( m_defaultValue != nullptr )
 	{
-		return getObjectValue()->isEqualTo( m_defaultValue.get() );
+		const ValuePlug *s = source<ValuePlug>();
+		if( s->direction() == Plug::Out && IECore::runTimeCast<const ComputeNode>( s->node() ) )
+		{
+			// Value is computed, and therefore can vary by context. There is no
+			// single "current value", so no true concept of whether or not it's at
+			// the default.
+			return false;
+		}
+		return
+			s->m_staticValue == m_defaultValue ||
+			s->m_staticValue->isEqualTo( m_defaultValue.get() );
+		;
 	}
 	else
 	{

--- a/src/GafferScene/Attributes.cpp
+++ b/src/GafferScene/Attributes.cpp
@@ -179,9 +179,7 @@ bool Attributes::processesAttributes() const
 {
 	// Although the base class says that we should return a constant, it should
 	// be OK to return this because it's constant across the hierarchy.
-	IECore::ConstCompoundDataPtr extraAttributesData = extraAttributesPlug()->getValue();
-	const IECore::CompoundDataMap &extraAttributes = extraAttributesData->readable();
-	return ( attributesPlug()->children().size() || !extraAttributes.empty() ) && !globalPlug()->getValue();
+	return ( attributesPlug()->children().size() || !extraAttributesPlug()->isSetToDefault() ) && !globalPlug()->getValue();
 }
 
 void Attributes::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const


### PR DESCRIPTION
This fixes a severe performance problem when driving `CustomAttributes.extraAttributes` with a python expression.

@danieldresser-ie, I believe we've discussed the `ValuePlug::isSetToDefault()` change in the past, agreeing that it probably made sense, but that we'd leave it till we needed it. If this seems unwanted after all, I can revert and isolate my fix to just the Attributes code.