### PR TITLE
Nuke Using compatibility version ( 0.53 maintenance

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -123,7 +123,10 @@ if targetApp :
 	compiler = targetAppReg["compiler"]
 	compilerVersion = targetAppReg["compilerVersion"]
 	pythonVersion = targetAppReg["pythonVersion"]
-	targetAppMajorVersion = targetAppReg.get( "majorVersion", targetAppVersion )
+	if targetApp in ( "nuke", ):
+		targetAppMajorVersion = targetAppReg.get( "compatibilityVersion", targetAppReg.get( "majorVersion", targetAppVersion ) )
+	else:
+		targetAppMajorVersion = targetAppReg.get( "majorVersion", targetAppVersion )
 
 	if "compilerFlags" in targetAppReg :
 		CXXFLAGS = CXXFLAGS + targetAppReg["compilerFlags"]


### PR DESCRIPTION
Install Gaffer for Nuke using the compatibility version defined at IE (#3284).

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
