### PR TITLE
Release prep for 0.53.6.4

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+0.53.6.4 (relative to 0.53.6.3)
+========
+
+Build
+-----
+
+- ie/options: Using compatibility version before falling back to major version and then full version.
+
 0.53.6.3 (relative to 0.53.6.2)
 ========
 

--- a/SConstruct
+++ b/SConstruct
@@ -53,7 +53,7 @@ import subprocess
 gafferMilestoneVersion = 0 # for announcing major milestones - may contain all of the below
 gafferMajorVersion = 53 # backwards-incompatible changes
 gafferMinorVersion = 6 # new backwards-compatible features
-gafferPatchVersion = 3 # bug fixes
+gafferPatchVersion = 4 # bug fixes
 
 # All of the following must be considered when determining
 # whether or not a change is backwards-compatible


### PR DESCRIPTION
This is in preparation of a release we'll need at IE for @lucienfostier.

@johnhaddon @andrewkaufman Looks ok? John, usually I'd put up a PR against master that adds the most recent changes to Changes - I'm guessing I'll skip that this time as you're handling the 54 release at the moment? Just a PR that adds the 0.53.6.4 changes to master?

Cheerio,

Matti.
