### PR TITLE
Docs : Swap image title text for alt text in Markdown files

### DIFF
--- a/doc/source/GettingStarted/ConfiguringGafferForThirdPartyTools/index.md
+++ b/doc/source/GettingStarted/ConfiguringGafferForThirdPartyTools/index.md
@@ -62,7 +62,7 @@ To create the `ARNOLD_ROOT` environment variable in OSX:
 
 The next time you start Gaffer, the Arnold nodes will be available from the node creation menu (right-click inside the _Graph Editor_).
 
-<!-- TODO: ![Arnold node menu](images/arnoldNodes.png) -->
+<!-- TODO: ![](images/arnoldNodes.png "Arnold node menu") -->
 
 
 ## Configuring Gaffer for 3Delight ##
@@ -114,7 +114,7 @@ To create the `DELIGHT` environment variable in OSX:
 
 The next time you start Gaffer, the 3Delight nodes will be available from the node creation menu (right-click inside the _Graph Editor_).
 
-<!-- TODO: ![Delight node menu](images/delightNodes.png) -->
+<!-- TODO: ![](images/delightNodes.png "Delight node menu") -->
 
 
 ## Configuring Gaffer for Tractor ##
@@ -180,7 +180,7 @@ Once the tractor folder has been added to your `PYTHONPATH`, you can then verify
 
 4. _Tractor_ will be available in the _Dispatcher_ drop-down menu.
 
-<!-- TODO: ![Tractor dispatch](images/tractorDispatch.png) -->
+<!-- TODO: ![](images/tractorDispatch.png "Tractor dispatch") -->
 
 
 ## See also ##

--- a/doc/source/GettingStarted/TutorialAssemblingTheGafferBot/index.md
+++ b/doc/source/GettingStarted/TutorialAssemblingTheGafferBot/index.md
@@ -22,7 +22,7 @@ By the end of this tutorial you will have built a basic scene with Gaffer's robo
 
 After [installing Gaffer](../../GettingStarted/InstallingGaffer/index.md), launch Gaffer [from its directory](../../GettingStarted/LaunchingGafferFirstTime/index.md) or by using the ["gaffer" command](../../GettingStarted/SettingUpGafferCommand/index.md). Gaffer will start, and you will be presented with an empty node graph in the default UI layout.
 
-![An empty node graph in the default layout](images/mainDefaultLayout.png "An empty node graph in the default layout")
+![](images/mainDefaultLayout.png "An empty node graph in the default layout")
 
 
 ## Importing a geometry scene cache ##
@@ -35,13 +35,13 @@ First, load Gaffy's geometry cache with a SceneReader node:
 
 2. Select _Scene_ > _File_ > _Reader_. The SceneReader node will appear in the _Graph Editor_ and be selected automatically.
 
-    ![A new SceneReader node](images/mainSceneReaderNode.png "A new SceneReader node") <!-- TODO: add annotation? -->
+    ![](images/mainSceneReaderNode.png "A new SceneReader node") <!-- TODO: add annotation? -->
 
 3. The _Node Editor_ in the top-right panel has now updated to display the SceneReader node's values. In the _File Name_ field, type `${GAFFER_ROOT}/resources/gafferBot/caches/gafferBot.scc`.
 
 4. Hover the cursor over the background of the _Viewer_ (in the top-left panel), and hit <kbd>F</kbd>. The view will reframe to cover the whole scene.
     
-    ![The bounding box of the selected SceneReader node](images/viewerSceneReaderBounding.png "The bounding box of the selected SceneReader node") <!-- TODO: add annotation -->
+    ![](images/viewerSceneReaderBounding.png "The bounding box of the selected SceneReader node") <!-- TODO: add annotation -->
 
 The SceneReader node has loaded, and the _Viewer_ is showing a bounding box, but the geometry remains invisible. You can confirm that the scene has loaded by examining the _Hierarchy View_ in the bottom-right panel. It too has updated, and shows that you have _GAFFERBOT_ at the root of the scene. In order to view the geometry, you will need to expand the scene's locations down to their leaves.
 
@@ -70,22 +70,22 @@ You can use the _Hierarchy View_ to expand the scene's locations:
 
 1. If the SceneReader node is deselected, select it by clicking it in the _Graph Editor_.
 
-2. In the _Hierarchy View_, click ![the triangle](images/collapsibleArrowRight.png "Triangle") next to _GAFFERBOT_. The _GAFFERBOT_ location will expand to show a child location named *C_torso_GRP*.
+2. In the _Hierarchy View_, click ![](images/collapsibleArrowRight.png "the triangle") next to _GAFFERBOT_. The _GAFFERBOT_ location will expand to show a child location named *C_torso_GRP*.
 
-3. Click ![the triangle](images/collapsibleArrowRight.png "Triangle") next to *C_torso_GRP* to show its child locations.
+3. Click ![](images/collapsibleArrowRight.png "the triangle") next to *C_torso_GRP* to show its child locations.
 
-    ![The scene hierarchy, expanded down two levels](images/hierarchyViewExpandedTwoLevels.png "The scene hierarchy, expanded down two levels") <!-- TODO: add annotation -->
+    ![](images/hierarchyViewExpandedTwoLevels.png "The scene hierarchy, expanded down two levels") <!-- TODO: add annotation -->
 
 > Note :
 > Gaffy's geometry cache contains location names with affixes like _C_, _R_, _L_, _GRP_, _CPT_ and _REN_. Gaffer places no significance whatsoever on these names, and you are free to use whichever naming conventions you see fit.
 
 In the _Viewer_, you can now see the bounding boxes of the objects at several locations, revealing more of the scene's structure. However, it would be tedious to expand the whole scene, location-by-location, in this manner. Instead, you can expand a location, its children, and all its sub-children at once with a shortcut:
 
-1. In the _Hierarchy View_, <kbd>Shift</kbd> + click the ![triangle](images/collapsibleArrowRight.png "Triangle") next to *C_head_GRP*. All of the children of *C_head_GRP* will expand. Now the _Viewer_ shows all of the geometry that comprises Gaffy's head.
+1. In the _Hierarchy View_, <kbd>Shift</kbd> + click the ![](images/collapsibleArrowRight.png "triangle") next to *C_head_GRP*. All of the children of *C_head_GRP* will expand. Now the _Viewer_ shows all of the geometry that comprises Gaffy's head.
 
-2. <kbd>Shift</kbd> + click the ![triangle](images/collapsibleArrowRight.png "Triangle") next to *R_legUpper_GRP*. All the locations under *R_legUpper_GRP* will expand. Now the _Viewer_ also shows all of the geometry that comprises Gaffy's right leg.
+2. <kbd>Shift</kbd> + click the ![](images/collapsibleArrowRight.png "triangle") next to *R_legUpper_GRP*. All the locations under *R_legUpper_GRP* will expand. Now the _Viewer_ also shows all of the geometry that comprises Gaffy's right leg.
 
-![The geometry of the head and right leg, expanded](images/mainHeadAndLeftLegExpanded.png "The geometry of the head and right leg, expanded")
+![](images/mainHeadAndLeftLegExpanded.png "The geometry of the head and right leg, expanded")
 
 
 ### Navigating the scene using the _Viewer_ ###
@@ -100,7 +100,7 @@ You can expand the scene hierarchy using the arrow keys and the _Viewer:_
 
 3. Hit <kbd>Shift</kbd> + <kbd>↓</kbd> to fully expand all the left leg's child locations.
 
-    ![The head and leg geometry, expanded](images/viewerHeadAndLegsExpanded.png "The head and leg geometry, expanded")
+    ![](images/viewerHeadAndLegsExpanded.png "The head and leg geometry, expanded")
 
 You can also collapse locations in a similar manner through the _Viewer:_
 
@@ -143,7 +143,7 @@ Earlier, you learned how to create a node by navigating the node creation menu i
 
 3. Hit <kbd>Enter</kbd>. A Camera node will appear in the _Graph Editor_.
 
-    ![A new Camera node](images/mainCameraNode.png "A new Camera node")
+    ![](images/mainCameraNode.png "A new Camera node")
 
 As before, the newly created node will be selected automatically, and the _Viewer_, _Hierarchy View_, and _Node Editor_ will update to reflect this new selection.
 
@@ -178,7 +178,7 @@ When a scene node computes a scene, scene data passes through it like so:
 
 The inputs and outputs of a node are called **plugs**, and are represented in the _Graph Editor_ as colored circles around the node's edges.
 
-<!-- TODO: add close-up of node plugs ![A node's plug.](images/nodePlug.png) -->
+<!-- TODO: add close-up of node plugs ![](images/nodePlug.png "A node's plug") -->
 
 For your two nodes to occupy the same scene (and later render together), you will need to combine them into a single scene. You can connect both of their output plugs to a Group node, and you can also rearrange the nodes to better visually represent the data flow in the graph.
 
@@ -197,7 +197,7 @@ It's time to connect the SceneReader and Camera nodes to combine their scenes:
 
 The Group node is now computing a new scene combining the input scenes from the two nodes above it, under a new parent scene location called _group_. You can see this new hierarchy by selecting the Group node and examining the _Hierarchy View_.
 
-![A new Group node](images/mainGroupNode.png "A new Group node")
+![](images/mainGroupNode.png "A new Group node")
 
 Only the combined scene computed by the Group node is modified. The upstream nodes' scenes are unaffected. You can verify this by reselecting one of them and checking the _Hierarchy View_.
 
@@ -219,30 +219,30 @@ First, set the camera's position using the _TranslateTool:_
 
 1. Select the Group node in the _Graph Editor_.
 
-2. Fully expand all scene locations by <kbd>Shift</kbd> + clicking ![the triangle](images/collapsibleArrowRight.png "Triangle") next to _group_ in the _Hierarchy View_.
+2. Fully expand all scene locations by <kbd>Shift</kbd> + clicking ![](images/collapsibleArrowRight.png "the triangle") next to _group_ in the _Hierarchy View_.
 
 3. Click the camera object in the _Viewer_, or select the _camera_ location in the _Hierarchy View_.
 
-4. In the _Viewer_, click ![the TranslateTool button](images/gafferSceneUITranslateTool.png "The TranslateTool button"). The translation manipulators will appear on the camera.
+4. In the _Viewer_, click ![](images/gafferSceneUITranslateTool.png "the TranslateTool button"). The translation manipulators will appear on the camera.
 
 5. Using the manipulators, adjust the camera back and up.
 
-    ![The camera, repositioned, in the Viewer](images/viewerCameraRepositioned.png "The camera, repositioned, in the Viewer")
+    ![](images/viewerCameraRepositioned.png "The camera, repositioned, in the Viewer")
 
 Next, rotate the camera using the _RotateTool:_
 
-1. In the _Viewer_, click ![the RotateTool button](images/gafferSceneUIRotateTool.png "The RotateTool button"). The rotation manipulators will appear around the camera.
+1. In the _Viewer_, click ![](images/gafferSceneUIRotateTool.png "the RotateTool button"). The rotation manipulators will appear around the camera.
 
 2. Using the manipulators, rotate the camera so it points at Gaffy.
 
-![The camera, rotated, in the Viewer](images/viewerCameraRotated.png "The camera, rotated, in the Viewer")
+![](images/viewerCameraRotated.png "The camera, rotated, in the Viewer")
 
 
 ### More precise camera adjustment ###
 
 For more precise positioning and rotation, you can set the Translate and Rotate values in the _Transform_ tab of the _Node Editor:_
 
-![The camera's transform values](images/nodeEditorWindowCameraTransform.png "The camera's transform values")
+![](images/nodeEditorWindowCameraTransform.png "The camera's transform values")
 
 > Important :
 > In the prior section _Connecting Plugs_, we referred to the main inputs and outputs of a node as plugs. In actuality, **all** the values you see in the _Node Editor_, including the camera's transform, are plugs. For ease of use, only a subset of a node's available plugs appear in the _Graph Editor_.
@@ -264,7 +264,7 @@ Create the render settings nodes:
 
 3. Finally, create a Catalogue node (_Image_ > _Utility_ > _Catalogue_). This is an image node for listing and displaying a directory of images in the _Viewer_. By default, it points to the default output directory of your graph's rendered images. Place it next to the InteractiveAppleseedRender node.
 
-    ![The render-related nodes](images/graphEditorRenderSettings.png "The render-related nodes")
+    ![](images/graphEditorRenderSettings.png "The render-related nodes")
 
     > Note :
     > The Catalogue node is not a scene node, but an image node. It cannot be connected to a scene node.
@@ -284,19 +284,19 @@ Next, you need to add an image type to render:
 
 1. Select the Outputs node.
 
-2. In the _Node Editor_, click ![the plus button](images/plus.png "Plus") and select _Interactive_ > _Beauty_ from the drop-down menu.
+2. In the _Node Editor_, click ![](images/plus.png "the plus button") and select _Interactive_ > _Beauty_ from the drop-down menu.
 
 With all the settings complete, start the interactive renderer:
 
 1. Select the InteractiveAppleseedRender node in the _Graph Editor_.
 
-2. In the _Node Editor_, click ![the play button](images/timelinePlay.png "Play") to start the renderer.
+2. In the _Node Editor_, click ![](images/timelinePlay.png "the play button") to start the renderer.
 
 3. Select the Catalogue node.
 
 4. Hover the cursor over the _Viewer_ and hit <kbd>F</kbd> to frame the Catalogue node's live image of the interactive render.
 
-    ![The first render](images/mainRenderGrey.png "The first render")
+    ![](images/mainRenderGrey.png "The first render")
 
 Congratulations! You have successfully rendered your first image. Gaffy is currently lacking shading, lighting, and texturing. We will move on to those soon. First, you should adjust the UI to provide yourself a more optimal workflow.
 
@@ -309,8 +309,8 @@ To make switching between viewing Gaffy's geometry and the render easier, you ca
 
 1. Select the InteractiveAppleseedRender node.
 
-2. Click ![the pin button](images/targetNodesUnlocked.png "Pin button") at the top-right
-  of the top panel. The pin button will highlight: ![highlighted pin](images/targetNodesLocked.png "Highlighted pin").
+2. Click ![](images/targetNodesUnlocked.png "the pin button") at the top-right
+  of the top panel. The pin button will highlight: ![](images/targetNodesLocked.png "highlighted pin").
 
 <!-- TODO: Screenshot of pinned Viewer -->
 
@@ -329,7 +329,7 @@ As with the _Viewer_, the _Hierarchy View_ will now remain locked to the output 
 
 For the final adjustment to the UI, create another _Viewer_ in the top-left panel, and pin the Catalogue node to it:
 
-1. At the top-right of the top panel, click ![the layout menu button](images/layoutButton.png "Layout menu button") to open the layout menu.
+1. At the top-right of the top panel, click ![](images/layoutButton.png "the layout menu button") to open the layout menu.
 
 2. Select _Viewer_. A new _Viewer_ will appear on the panel next to the first one.
 
@@ -355,7 +355,7 @@ It will be best if you keep the render option nodes at the end of the graph. Sin
 
 2. Click and drag the nodes to move thme to a lower position in the graph.
 
-    ![The graph with some added space](images/mainRenderSettingsWithGap.png "The graph with some added space")
+    ![](images/mainRenderSettingsWithGap.png "The graph with some added space")
 
 
 ### Adding a shader ###
@@ -372,7 +372,7 @@ Now that you have more space, it's time to add some shading nodes:
 
 4. Click and drag the ShaderAssignment node onto the connector between the Group and StandardOptions nodes. The ShaderAssignment node will be interjected between them.
 
-    ![The ShaderAssignment and Disney Material nodes](images/graphEditorFirstShaderNodes.png "The ShaderAssignment and Disney Material nodes")
+    ![](images/graphEditorFirstShaderNodes.png "The ShaderAssignment and Disney Material nodes")
 
 > Important :
 > In the _Graph Editor_, shader data flows from left to right.
@@ -394,7 +394,7 @@ For lights to take effect, they need to be combined with the main scene. For sim
 
 4. Connect the PhysicalSky node's _out_ plug to the Group node's _in3_ plug.
 
-![A new environment light node](images/graphEditorEnvironmentLightNode.png "A new environment light node")
+![](images/graphEditorEnvironmentLightNode.png "A new environment light node")
 
 For the light to take effect, you will need to assign it:
 
@@ -408,7 +408,7 @@ For the light to take effect, you will need to assign it:
 
 The interactive render will now begin updating, and you will be able to see Gaffy with some basic shaders and lighting.
 
-![The first render with a shader and lighting](images/viewerRenderOneShader.png "The first render with a shader and lighting")
+![](images/viewerRenderOneShader.png "The first render with a shader and lighting")
 
 
 ### Adding textures ###
@@ -423,7 +423,7 @@ As Gaffy is looking a bit bland, you should drive the shader with some robot tex
 
 3. In the _Graph Editor_, connect the Appleseed color texture node's ColorOut plug to the Disney Material node's BaseColor plug. Gaffy's textures will now drive the color of the surface shader, and the render will update to show the combined results.
 
-    ![Gaffy with textures](images/viewerRenderTextures.png "Gaffy with textures")
+    ![](images/viewerRenderTextures.png "Gaffy with textures")
 
 
 ### Adding another shader ###
@@ -442,11 +442,11 @@ Begin by creating another shader:
 
 4. Interject the new ShaderAssignment node after the first ShaderAssignment node.
 
-    ![A second shader in the Graph Editor](images/graphEditorSecondShaderNodes.png "A second shader in the Graph Editor")
+    ![](images/graphEditorSecondShaderNodes.png "A second shader in the Graph Editor")
 
 The _Viewer_ will update to show the new shader.
 
-![The second shader, rendered](images/mainRenderTwoShaders.png "The second shader, rendered")
+![](images/mainRenderTwoShaders.png "The second shader, rendered")
 
 You will immediately notice something that now _all_ the geometry is metallic. The new shader has overridden the previous one.
 
@@ -460,13 +460,13 @@ In order to selectively apply a shader to only certain locations in the scene, y
 
 1. Create a PathFilter node (_Scene_ > _Filters_ > _PathFilter_).
 
-2. In the _Node Editor_, click ![the plus button](images/plus.png "Plus") next to _Paths_. This will add a new text field.
+2. In the _Node Editor_, click ![](images/plus.png "the plus button") next to _Paths_. This will add a new text field.
 
 3. In the text field, type `/group/GAFFERBOT/C_torso_GRP/C_head_GRP/C_head_CPT/L_ear001_REN`. This is the full path to Gaffy's left ear.
 
 4. Connect the PathFilter node's _out_ plug to the filter input on the right hand side of the ShaderAssignment1 node's filter plug (yellow, on the right).
 
-    ![The connected PathFilter node](images/graphEditorPathFilterNode.png "The connected PathFilter node")
+    ![](images/graphEditorPathFilterNode.png "The connected PathFilter node")
 
 Now when you check the render, you will see that the chrome shader is only applied to Gaffy's left ear. There are many other parts of Gaffy that could use the chrome treatment, but it would be tedious for you to manually enter multiple locations. Instead, we will demonstrate two easier ways to add locations to the filter: using text wildcards, and interacting directly with the geometry through the _Viewer_.
 
@@ -492,20 +492,20 @@ As your final lesson in this tutorial, add the metallic shader to the rest of th
 
 4. <kbd>Shift</kbd> + click Gaffy's mouth to add it to the selection.
 
-    ![The face, with selection](images/viewerSelectionFace.png "The face, with selection")
+    ![](images/viewerSelectionFace.png "The face, with selection")
 
-5. Click and drag the selection (the cursor will change to ![the "replace objects" icon](images/replaceObjects.png "Replace objects")), and hold it over the PathFilter node without releasing.
+5. Click and drag the selection (the cursor will change to ![](images/replaceObjects.png "Replace objects")), and hold it over the PathFilter node without releasing.
 
-6. While still holding the mouse button, hold <kbd>Shift</kbd> (the cursor will change to ![the "add objects" icon](images/addObjects.png "Add objects")). You are now adding to the path, rather than replacing it.
+6. While still holding the mouse button, hold <kbd>Shift</kbd> (the cursor will change to ![](images/addObjects.png "Add objects")). You are now adding to the path, rather than replacing it.
 
 7. Release the selection over the PathFilter node. This will add the locations as new values fields on the plug.
 
 > Tip :
-> Just as locations can be added by holding <kbd>Shift</kbd>, they can be removed by holding <kbd>Ctrl</kbd> (the cursor will change to ![the "remove objects" icon](images/removeObjects.png "Remove objects")).
+> Just as locations can be added by holding <kbd>Shift</kbd>, they can be removed by holding <kbd>Ctrl</kbd> (the cursor will change to ![](images/removeObjects.png "Remove objects")).
 
 Add and remove locations to the filter as you see fit. Remember to switch between the two _Viewers_ to check the render output as it updates. After adding Gaffy's hands and bolts to the filter, you should achieve an image similar to this:
 
-![The final render](images/viewerRenderFinal.png "The final render")
+![](images/viewerRenderFinal.png "The final render")
 
 
 ## Recap ##

--- a/doc/source/WorkingWithScenes/AnatomyOfACamera/index.md
+++ b/doc/source/WorkingWithScenes/AnatomyOfACamera/index.md
@@ -5,7 +5,7 @@
 
 The camera in Gaffer is designed to accommodate two related but sometimes divergent conceptions of a camera: the idealized "CG" cameras that we use in software, and the real cameras used in photography and cinematography.
 
-![A real camera and CG camera](images/illustrationCamerasRealCG.png)
+![](images/illustrationCamerasRealCG.png "A real camera and CG camera")
 
 Fundamentally, current mainstream renderers use the CG camera model. However, many users are well-versed in the operating principles of real cameras, in particular the properties of aperture and focal length. Some DCC and scene format developers have made an effort to integrate these properties into their projects, to make camera construction easier for this audience. Gaffer does the same.
 
@@ -103,9 +103,9 @@ Within the [scene paradigm](../../../AnatomyOfAScene/index.html#scene-hierarchy)
 - **Transform:** The vectors that define the position and orientation of the camera.
 - **Object:** A special camera object at the location. Instead of geometry, the object stores camera data, called parameters.
     - **Parameters:** The crucial values that define a camera, such as the perspective type, field of view/aperture, and depth of field settings. If defined, a special kind of optional parameter, called a **render override**, will supercede one of the scene's **[render options](../../../AnatomyOfAScene/index.html#options)** during computation and rendering.<br>
-    ![Camera parameters in the Scene Inspector](images/interfaceCameraParameters.png)
+    ![](images/interfaceCameraParameters.png "Camera parameters in the Scene Inspector")
 - **Sets:** A list of sets the location belongs to. By default, every camera is assigned to an automatic "Cameras" set, accessible in the API by the `__cameras` variable.<br>
-    ![Camera sets in the Scene Inspector](images/interfaceCameraSets.png)
+    ![](images/interfaceCameraSets.png "Camera sets in the Scene Inspector")
 
 
 ### Data flow ###

--- a/doc/source/WorkingWithScenes/AnatomyOfAScene/index.md
+++ b/doc/source/WorkingWithScenes/AnatomyOfAScene/index.md
@@ -14,11 +14,11 @@ The structure of a scene can be broken down into two main areas:
 
 In common with most DCCs, Gaffer represents a 3D scene as a hierarchy or tree structure. We refer to positions within this tree as **locations**, specified by their path within the scene, e.g. `/world/city/building01`. Locations are arranged via parent-child relationships, such that `/world/city` is considered the parent of the child `/world/city/building01`. Do not confuse locations in the scene hierachy with nodes in the node graph; nodes _output_ scenes, but are not part of them.
 
-![The Hierarchy View with a location selected](images/hierarchyView.png)
+![](images/hierarchyView.png "The Hierarchy View with a location selected")
 
 Each location has a number of properties that describe the content of the scene at that point in the hierarchy. They can be inspected in the _Selection_ tab of the _Scene Inspector_. Each property of each location is computed independently, allowing Gaffer to generate the scene lazily on demand.
 
-![All of a location's property sections in the Selection tab Scene Inspector](images/sceneInspector.png)
+![](images/sceneInspector.png "All of a location's property sections in the Selection tab Scene Inspector")
 
 > Important :
 > In this article, "property" only refers generically to a piece of data that describes a scene. It does not carry the more specific meanings from other DCCs.
@@ -28,21 +28,21 @@ Each location has a number of properties that describe the content of the scene 
 
 The **transform** contains a 4x4 matrix storing the local transformation of the location. It is used to position the location in 3D space using a combination of translation, rotation and scaling.
 
-![A location's Transform section in the Scene Inspector](images/sceneInspectorTransformSection.png)
+![](images/sceneInspectorTransformSection.png "A location's Transform section in the Scene Inspector")
 
 
 ### Bound ###
 
 The **bound** contains the union of the bounding box of the location's contents and of the contents of all of its descendants. This is stored relative to the location’s local space. The bound may be computed independently of the contents themselves.
 
-![A location's Bound section in the Scene Inspector](images/sceneInspectorBoundSection.png)
+![](images/sceneInspectorBoundSection.png "A location's Bound section in the Scene Inspector")
 
 
 ### Object ###
 
 When a location contains a 3D object, such as a primitive or a camera, it is stored in the **object** property. Although any location can have an object, typically they are only stored at leaf locations.
 
-![A location's Object section in the Scene Inspector](images/sceneInspectorObjectSection.png)
+![](images/sceneInspectorObjectSection.png "A location's Object section in the Scene Inspector")
 
 
 #### Primitive variables ####
@@ -63,7 +63,7 @@ Locations inherit attributes from their parent, with attributes local to the loc
 >
 > Users familiar with RenderMan may be reassured to know that Gaffer derives its use of the term attribute from RenderMan. Gaffer and RenderMan attributes are very much alike.
 
-![A location's Attributes section in the Scene Inspector](images/sceneInspectorAttributesSection.png)
+![](images/sceneInspectorAttributesSection.png "A location's Attributes section in the Scene Inspector")
 
 
 ## Globals ##

--- a/doc/source/WorkingWithScenes/Camera/index.md
+++ b/doc/source/WorkingWithScenes/Camera/index.md
@@ -2,7 +2,7 @@
 
 Gaffer's cameras setups are quite flexible, allowing for a variety of camera types, measurement systems, and industry-standard formats. With this freedom, you can simulate many common camera and lens setups.
 
-![The Camera node](images/interfaceCameraNode.png "The Camera node")
+![](images/interfaceCameraNode.png "The Camera node")
 
 In this article, we will assume you are fairly familiar with camera terminology and the settings of real cameras and lenses.
 
@@ -13,13 +13,13 @@ Before you begin, we highly recommend you read [Anatomy of a Camera](../AnatomyO
 
 Each Camera node (_Scene_ > _Source_ > _Camera_) adds a scene containing a single location (`/camera` by default) with a camera object. When previewing the scene in the _Viewer_, the camera object is represented by a wireframe model. The width and size of the frustum on the model roughly corresponds to the angle of view and aspect ratio of the camera.
 
-![The camera visualizer in the Viewer](images/interfaceCameraVisualizer.png "The camera visualizer in the Viewer")
+![](images/interfaceCameraVisualizer.png "The camera visualizer in the Viewer")
 
 Scenes can support multiple cameras, but renderers typically work with one at a time. The StandardOptions node, placed downstream, sets which camera in the scene to use for a given render.
 
 When looking through a camera, the _Viewer_ matches its projection, so the scene will appear as foreshortened or as flat as dictated by the projection parameters. This lets you preview the precise framing and composition of the scene. Additionally, a frame overlay appears in the _Viewer_, showing the aperture gate, the resolution gate, and the crop window.
 
-![The elements of the frame overlay](images/interfaceFrameOverlay.png "The elements of the frame overlay")
+![](images/interfaceFrameOverlay.png "The elements of the frame overlay")
 
 > Tip :
 > If the aperture gate isn't visible, that means it is identical to the resolution gate.
@@ -33,28 +33,28 @@ When looking through a camera, the _Viewer_ matches its projection, so the scene
 
 #### Selecting, translating, and rotating a camera ####
 
-Like other objects in the scene, the camera can be manipulated in the _Viewer_. You can select it by clicking it or dragging a marquee around it, rotate it with the Rotate Tool ![Rotate Tool](images/gafferSceneUIRotateTool.png "Rotate Tool") (<kbd>W</kbd>), and translate it with the Translate Tool ![Translate Tool](images/gafferSceneUITranslateTool.png "Translate Tool") (<kbd>E</kbd>).
+Like other objects in the scene, the camera can be manipulated in the _Viewer_. You can select it by clicking it or dragging a marquee around it, rotate it with the Rotate Tool ![](images/gafferSceneUIRotateTool.png "RotateTool") (<kbd>W</kbd>), and translate it with the Translate Tool ![](images/gafferSceneUITranslateTool.png "Translate Tool") (<kbd>E</kbd>).
 
-![Selecting, translating, and rotating a camera object in the Viewer](images/taskSelectTranslateRotateCamera.gif "Selecting, translating, and rotating a camera object in the Viewer")
+![](images/taskSelectTranslateRotateCamera.gif "Selecting, translating, and rotating a camera object in the Viewer")
 
 
 #### Selecting a look-through camera for a _Viewer_ ####
 
 Each _Viewer_ can be set to look through a camera in the scene, rather than the default free camera. This can be quite useful if the scene has multiple cameras and you need to preview each in a separate _Viewer_ at once, such as in a scene with witness cameras, or if you simply want to compare the flat-shaded scene to its render preview.
 
-![Selecting a look-through camera in the Viewer](images/taskSelectLookThroughCamera.gif "Selecting a look-through camera in the Viewer")
+![](images/taskSelectLookThroughCamera.gif "Selecting a look-through camera in the Viewer")
 
 To select a look-through camera for a _Viewer:_
 
-1. In the _Viewer_, click ![camera](images/cameraOff.png "camera"). A drop-down menu of objects will appear.
+1. In the _Viewer_, click ![](images/cameraOff.png "Camera"). A drop-down menu of objects will appear.
 2. Select either _Render Camera_ for the current scene's render camera (if defined by a StandardOptions node), or a camera from the _Camera_ sub-menu (a list of all cameras in the current scene).
 
 
 #### Translating and rotating the look-through camera ####
 
-With the Camera Tool ![Camera Tool](images/gafferSceneUICameraTool.png "Camera Tool") toggled on, you can translate and rotate the look-through camera with the [camera controls](../../../../Interface/ControlsAndShortcuts/index.html#d-scenes).
+With the Camera Tool ![](images/gafferSceneUICameraTool.png "CameraTool") toggled on, you can translate and rotate the look-through camera with the [camera controls](../../../../Interface/ControlsAndShortcuts/index.html#d-scenes).
 
-![Manipulating the camera with the Camera Tool and camera controls](images/taskCameraToolLookThroughCamera.gif "Manipulating the camera with the Camera Tool and camera controls")
+![](images/taskCameraToolLookThroughCamera.gif "Manipulating the camera with the Camera Tool and camera controls")
 
 > Note :
 > The shortcuts for the clipping plane affect the clipping plane of the default free camera, **not** the look-through camera.
@@ -64,11 +64,11 @@ With the Camera Tool ![Camera Tool](images/gafferSceneUICameraTool.png "Camera T
 
 Like the default free camera, you can set the look-through camera to focus on an object in the scene, and orbit it around that object's position.
 
-![Orbiting the look-through camera around an object](images/taskOrbitLookThroughCamera.gif "Orbiting the look-through camera around an object")
+![](images/taskOrbitLookThroughCamera.gif "Orbiting the look-through camera around an object")
 
 To orbit with the look-through camera:
 
-1. Make sure the Camera Tool ![Camera Tool](images/gafferSceneUICameraTool.png "Camera Tool") (<kbd>T</kbd>) is activated.
+1. Make sure the Camera Tool ![](images/gafferSceneUICameraTool.png "CameraTool") (<kbd>T</kbd>) is activated.
 2. Select an object in the scene.
 3. Hit <kbd>F</kbd>. The camera will aim at the object and adjust position.
 4. Use the [camera controls](../../../../Interface/ControlsAndShortcuts/index.html#d-scenes) to orbit around the object.
@@ -88,7 +88,7 @@ Then, assign the projection parameters using one of the perspective modes:
 
 #### Using field of view ####
 
-![The Field of View projection mode, with plugs that define a horizontal FOV of 40 and an aspect ratio of 1.778](images/taskCameraFOVPlugs.png "The Field of View projection mode, with plugs that define a horizontal FOV of 40 and an aspect ratio of 1.778")
+![](images/taskCameraFOVPlugs.png "The Field of View projection mode, with plugs that define a horizontal FOV of 40 and an aspect ratio of 1.778")
 
 1. Set the _Perspective Mode_ plug to _Field Of View_.
 2. Input an angle for the _Field Of View_ plug, in degrees.
@@ -97,12 +97,12 @@ Then, assign the projection parameters using one of the perspective modes:
 
 #### Using aperture and focal length ####
 
-![The Aperture and Focal Length projection mode, with plugs that define a 50mm lens on a Full Frame 35mm body](images/taskCameraApertureFocalLengthPlugs.png "The Aperture and Focal Length projection mode, with plugs that define a 50mm lens on a Full Frame 35mm body")
+![](images/taskCameraApertureFocalLengthPlugs.png "The Aperture and Focal Length projection mode, with plugs that define a 50mm lens on a Full Frame 35mm body")
 
 1. Set the _Perspective Mode_ plug to _Aperture and Focal Length_.
 2. For the _Aperture_ plug, select the appropriate camera from the list of standard camera film backs/sensors. If the camera you need is not available:
     1. Select _Custom_. Two new plug fields will appear. Fill in:
-        ![The custom aperture plugs in the Node Editor](images/taskCameraCustomAperturePlugs.png "The custom aperture plugs in the Node Editor")
+        ![](images/taskCameraCustomAperturePlugs.png "The custom aperture plugs in the Node Editor")
         - _aperture.x:_ The horizontal film back/sensor length, typically in millimeters.
         - _aperture.y:_ The vertical film back/sensor length, typically in millimeters.
     2. Set the _Focal Length_ plug to an appropriate lens focal length. This is typically in millimeters.
@@ -115,7 +115,7 @@ Then, assign the projection parameters using one of the perspective modes:
 
 The offset is the amount by which the camera view is shifted parallel to the image plane. This parameter is used in special cases, such as simulating a tilt-shift lens, rendering tiles for a panorama, or matching a plate that has been asymmetrically cropped.
 
-![The camera frustum adjusting in response to Aperture Offset](images/taskAdjustApertureOffset.gif "The camera frustum adjusting in response to Aperture Offset")
+![](images/taskAdjustApertureOffset.gif "The camera frustum adjusting in response to Aperture Offset")
 
 A camera's _Aperture Offset_ plug controls the horizontal and vertical offset. The length of one unit of offset depends on the projection type of the camera:
 - Perspective projection:
@@ -126,7 +126,7 @@ A camera's _Aperture Offset_ plug controls the horizontal and vertical offset. T
 
 ### Adding depth of field blur ###
 
-![A render with depth of field blur](images/renderDepthOfFieldBlur.png "A render with depth of field blur")
+![](images/renderDepthOfFieldBlur.png "A render with depth of field blur")
 
 Depth of field is controlled as if the camera had a lens, with plugs analogous to real lens settings – _F Stop_ and _Focus Distance_. You can use these settings to replicate the depth of field of a real lens.
 
@@ -140,9 +140,9 @@ To add depth of field blur:
 3. Input an appropriate _F Stop_ for the lens aperture. The higher the number, the less depth of field blur.
 4. Select a _Focal Length World Scale_. This is the scale factor between the camera's focal length unit of measure and the world space unit of measure. For example, if the focal length is measured in millimeters but the world is measured in centimeters, select _Millimeters to Centimeters (0.1)_. For most scenes and scene formats, use this scale. If the scale you need isn't provided, select _Custom_ and input a custom scale.
 5. Input the _Focus Distance_ between the camera and the object(s) in focus, in world space units.
-    ![The Depth of Field tab and plugs of a Camera node in the Node Editor](images/taskCameraDepthOfFieldPlugs.png "The Depth of Field tab and plugs of a Camera node in the Node Editor")
-6. On a downstream StandardOptions node, enable the _Depth Of Field_ plug (click ![switch](images/toggleOff.png "switch")) and turn it on.
-    ![The Depth of Field plug of a StandardOptions node in the Node Editor](images/taskStandardOptionsDepthOfFieldPlug.png "The Depth of Field plug of a StandardOptions node in the Node Editor")
+    ![](images/taskCameraDepthOfFieldPlugs.png "The Depth of Field tab and plugs of a Camera node in the Node Editor")
+6. On a downstream StandardOptions node, enable the _Depth Of Field_ plug (click ![](images/toggleOff.png "Switch")) and turn it on.
+    ![](images/taskStandardOptionsDepthOfFieldPlug.png "The Depth of Field plug of a StandardOptions node in the Node Editor")
 
 > Important :
 > Depth of field information will only be passed to the renderer if the Camera node's _F Stop_ plug is greater than `0` and a downstream StandardOptions node has its _Depth of Field Blur_ plug enabled and turned on. Otherwise, your render will not have depth of field blur.
@@ -163,7 +163,7 @@ You can resolve these by enabling the Camera node's render overrides, employing 
 
 A **render override** is a special camera parameter that overrides a corresponding render option.
 
-![The Resolution override plug in the Render Overrides tab in the Node Editor](images/taskCameraRenderOverridePlugs.png "The Resolution override plug in the Render Overrides tab in the Node Editor")
+![](images/taskCameraRenderOverridePlugs.png "The Resolution override plug in the Render Overrides tab in the Node Editor")
 
 Since an override is a parameter, and thus data on the camera's object, it does not modify the actual render option. It instead takes precedence over the render option during computation or rendering. An override can be tweaked or removed at a later point in the graph. If removed, the corresponding render option will come into effect again.
 
@@ -171,16 +171,16 @@ To activate a render override:
 
 1. Select a Camera node in the _Graph Editor_.
 2. In the _Node Editor_, switch to the _Render Overrides_ tab.
-3. Enable the override (click ![switch](images/toggleOff.png "switch")) and adjust its plug values as needed.
+3. Enable the override (click ![](images/toggleOff.png "Switch")) and adjust its plug values as needed.
 
 
 ### Camera tweaks ###
 
-![The CameraTweaks node](images/interfaceCameraTweaksNode.png "The CameraTweaks node")
+![](images/interfaceCameraTweaksNode.png "The CameraTweaks node")
 
 The CameraTweaks node (_Scene_ > _Object_ > _Camera Tweaks_) is a special node that adds any number of adjustments, known as as **camera tweaks**, to render options and camera parameters. A camera tweak can also add custom camera parameters to the scene data.
 
-![Two camera tweaks in the Node Editor](images/taskCameraTweaksTweaks.png "Two camera tweaks in the Node Editor")
+![](images/taskCameraTweaksTweaks.png "Two camera tweaks in the Node Editor")
 
 Multiple tweaks can be applied to the same parameter or render option. If so, they apply their operations in sequence.
 
@@ -191,10 +191,10 @@ To add a camera tweak:
 1. Create a CameraTweaks node at a point in the graph that is downstream of the target camera(s).
 2. Create a PathFilter node, add the path location(s) of the camera(s) to it, and connect it to the filter plug of the CameraTweaks node.
 3. Select the CameraTweaks node.
-4. In the _Node Editor_, click ![add](images/plus.png "add") and select a parameter or render option to tweak. The tweak will appear in the editor as a compound plug.
-5. Enable the tweak (click ![switch](images/toggleOff.png "switch")).
+4. In the _Node Editor_, click ![](images/plus.png "Add") and select a parameter or render option to tweak. The tweak will appear in the editor as a compound plug.
+5. Enable the tweak (click ![](images/toggleOff.png "Switch")).
 6. Assign the tweak operation:<br>
-    ![The plugs of a camera tweak in the Node Editor](images/taskCameraTweaksPlugs.png "The plugs of a camera tweak in the Node Editor")
+    ![](images/taskCameraTweaksPlugs.png "The plugs of a camera tweak in the Node Editor")
     - Mode: The operation to apply between the new value and old value of the parameter or render option. You have a choice between _Replace_, _Add_, _Multiply_, and _Remove_. String values cannot be multiplied/added/subtracted. For example, with default parameter value `A`, operation _Multiply_, and new value `B`, the tweak would apply `A × B`.
     - Value: The new value to use in the operation.
 
@@ -204,7 +204,7 @@ To add a camera tweak:
 
 ### Anamorphic camera setup ###
 
-![Preview of anamorphic camera setup example](images/exampleAnamorphicCameraSetup.png "Preview of anamorphic camera setup example")
+![](images/exampleAnamorphicCameraSetup.png "Preview of anamorphic camera setup example")
 
 This can be loaded in Gaffer from _Help_ > _Examples_ > _Rendering_ > _Anamorphic Cameras_.
 
@@ -213,13 +213,13 @@ A setup that replicates an anamorphic camera and lens, by rendering with a non-s
 
 ### Spherical camera in Arnold ###
 
-![Preview of Arnold spherical camera example](images/exampleSphericalCameraSetupArnold.png "Preview of Arnold spherical camera example")
+![](images/exampleSphericalCameraSetupArnold.png "Preview of Arnold spherical camera example")
 
 This can be loaded in Gaffer from _Help_ > _Examples_ > _Rendering_ > _Spherical Cameras (Arnold)_.
 
 A camera with spherical projection that is compatible with the Arnold renderer. To achieve this, a CameraTweaks node overrides certain camera parameters to create a custom projection type. The tweaks are:
 
-![The parameter tweaks needed for a spherical camera in Arnold](images/exampleSphericalCameraSetupArnoldTweaks.png "The parameter tweaks needed for a spherical camera in Arnold")
+![](images/exampleSphericalCameraSetupArnoldTweaks.png "The parameter tweaks needed for a spherical camera in Arnold")
 
 > Tip :
 > Other renderers will likely use similar means to achieve spherical cameras.

--- a/doc/source/WorkingWithScenes/LightLinking/index.md
+++ b/doc/source/WorkingWithScenes/LightLinking/index.md
@@ -2,7 +2,7 @@
 
 When lighting a scene, you will sometimes need to selectively control whether a piece of geometry is illuminated by a particular light, both for artistic purposes and to cut down on rendering time. The relationships that determine whether a light applies to an object are collectively known as **light linking**, and are controlled by the object's `linkedLights` attribute.
 
-![A sphere, a cube, and two lights, but the second light only illuminates the cube](images/illustrationLightLinking.png "A sphere, a cube, and two lights, but the second light only illuminates the cube")
+![](images/illustrationLightLinking.png "A sphere, a cube, and two lights, but the second light only illuminates the cube")
 
 > Note :
 > The only supported renderer that currently implements light linking is Arnold.
@@ -15,7 +15,7 @@ When lighting a scene, you will sometimes need to selectively control whether a 
 
 From the light side of things, by default, each light is a member of a set named **"defaultLights"**, and will cast light on every object in the scene. Each light's node has a _Default Light_ plug, which is checked by default. If unchecked, the light is removed from "defaultLights", and, from then on, will only illuminate objects that are expressly linked to it.
 
-![The Default Light plug of a light](images/interfaceDefaultLightPlug.png "The Default Light plug of a light")
+![](images/interfaceDefaultLightPlug.png "The Default Light plug of a light")
 
 From the object side of things, by default, an object is lit by all lights belonging to the "defaultLights" set. To bring about any other behaviour, such as having the object only lit by one light, a `linkedLights` attribute must be added to the object's location in the hierarchy, and the attribute must specify one or more lights, or sets of lights. The `linkedLights` attribute follows standard [inheritance rules for attributes](../../../AnatomyOfAScene/index.html#attributes) in the hierarchy, so if the object doesn't have the `linkedLights` attribute, but one of its ancestors does, it will inherit the attribute.
 
@@ -32,9 +32,9 @@ From the object side of things, by default, an object is lit by all lights belon
 
 In a graph, in order to actually link a light to an object, you must connect a StandardAttributes node downstream of the object, filter for the object's location, and then add a set expression to the _Linked Lights_ plug.
 
-![A StandardAttributes node downstream of an object node](images/interfaceLightLinkSetupGraphEditor.png "A StandardAttributes node downstream of an object node")
+![](images/interfaceLightLinkSetupGraphEditor.png "A StandardAttributes node downstream of an object node")
 
-![The Linked Lights plug of an object](images/interfaceLinkedLightsPlug.png "The Linked Lights plug of an object")
+![](images/interfaceLinkedLightsPlug.png "The Linked Lights plug of an object")
 
 Once the _Linked Lights_ plug is toggled on, the `linkedLights` attribute is added to the object's location. The value of the _Linked Lights_ plug is a [set expression](../../Reference/ScriptingReference/SetExpressions/index.md), which can consist of individual light locations, set names, or both. We will cover how to filter for both types below.
 
@@ -47,7 +47,7 @@ Once the _Linked Lights_ plug is toggled on, the `linkedLights` attribute is add
 
 To link a light by location, simply add the light's full location to the set expression. No additional node is needed.
 
-![A light linking set expression with a location](images/taskLightLinkingSetExpressionLocation.png "A light linking set expression with a location")
+![](images/taskLightLinkingSetExpressionLocation.png "A light linking set expression with a location")
 
 > Important :
 > When linking a light by its location, the path you provide **must** be the final location of the light within the hierarchy **as delivered to the render node**. For example, if you link to a light at `/group/light`, but later in the graph you shuffle the hierarchy and the light exists at `/building/lights/light`, the renderer will look for the light at the original location, find nothing there, and then the link will fail. Therefore, you would unintuitively need to target a downstream location in an upstream part of the graph.
@@ -59,17 +59,17 @@ In setups with more than a few lights, managing a set expression with multiple l
 
 A light can be added to any number of custom sets using the _Sets_ plug on the light's node, or a separate Set node. Custom sets are separate and do not affect the "defaultLights" set.
 
-![A Set node downstream of a light node in the Graph Editor](images/interfaceLightSetGraphEditor.png "A Set node downstream of a light node in the Graph Editor")
+![](images/interfaceLightSetGraphEditor.png "A Set node downstream of a light node in the Graph Editor")
 
-![A Set node in the Node Editor](images/interfaceLightSetNodeEditor.png "A Set node in the Node Editor")
+![](images/interfaceLightSetNodeEditor.png "A Set node in the Node Editor")
 
 To link one or more lights by a set, simply add it to the set expression.
 
-![A light linking set expression with a set](images/taskLightLinkingSetExpressionSet.png "The light linking set expression with a set")
+![](images/taskLightLinkingSetExpressionSet.png "A light linking set expression with a set")
 
 Be aware that if an object belongs to multiple sets with light linking, the object will only inherit the `linkedLights` attribute from the last set that was linked in the graph, as shown in the illustration below.
 
-![A graph where an object belongs to multiple sets, each with different linked lights](images/illustrationLightLinkingMultipleSets.png "A graph where an object belongs to multiple sets, each with different linked lights")
+![](images/illustrationLightLinkingMultipleSets.png "A graph where an object belongs to multiple sets, each with different linked lights")
 
 
 ## Example scenario ##
@@ -81,7 +81,7 @@ Here we'll explore an example scenario where link lighting would be appropriate,
 
 Picture a scene where a giant robot attacks a highly detailed metropolitan city at night. For dramatic effect, let's say we want the robot's eyes to shine with some menacing red highlights. What's more, on the robot's chest is affixed the logo of its evil creator, and we want to make sure the audience can just make out the logo, regardless of the ambient illumination. With a photorealism mindset, both of these lights would be conceits, as they would have no plausible light source. Even so, with their inclusion, the scene becomes more evocative.
 
-![A preview of the example scenario in the Viewer](images/exampleGaffyAttacksScene.png "A preview of the example scenario in the Viewer")
+![](images/exampleGaffyAttacksScene.png "A preview of the example scenario in the Viewer")
 
 To achieve both of these highlights, we could add special lights in front of the robot's eyes and chest. But, by default, these lights would also illuminate the rest of the robot, and everything else in the scene. This may not achieve our artistic intent, and could also affect render time and memory usage.
 
@@ -123,7 +123,7 @@ Location                                                       `Linked Lights` e
 
 The above set expressions link the special lights and sets. The eyes are linked to all lights plus the eye light's set; the logo is linked to all lights plus the logo light's set. The result is that the special lights only illuminate the subjects we want them to: the eye light hits the eyes, and the logo light hits the logo.
 
-![The resulting render of the example scenario with the correct light links](images/exampleGaffyAttacksResults.png "The resulting render of the example scenario with the correct light links")
+![](images/exampleGaffyAttacksResults.png "The resulting render of the example scenario with the correct light links")
 
 ```eval_rst
 =============================== ==============================================================
@@ -153,7 +153,7 @@ Object                                                         Linked lights
 
 > _Help_ > _Examples_ > _Lighting_ > _Light Linking Basics (Arnold)_
 
-![Example: Light linking basics](images/exampleLightLinkingBasics.png)
+![](images/exampleLightLinkingBasics.png "Example: Light linking basics")
 
 This example contains the various permutations of light linking on objects:
 
@@ -169,7 +169,7 @@ This example contains the various permutations of light linking on objects:
 
 > _Help_ > _Examples_ > _Lighting_ > _Light Linking City Attack (Arnold)_
 
-![Example: Light linking city attack](images/exampleLightLinkingCityAttack.png)
+![](images/exampleLightLinkingCityAttack.png "Example: Light linking city attack")
 
 In this example, a supersized version of our mascot, Gaffy, is throwing a tantrum, and attacking a city. Two special and unrealistic light sources are added to the scene, in order to add highlights to  Gaffy's eyes and chest logo. This graph contains the light-link setup described in the above example scenario.
 

--- a/doc/source/WorkingWithTheNodeGraph/BoxNode/index.md
+++ b/doc/source/WorkingWithTheNodeGraph/BoxNode/index.md
@@ -1,7 +1,7 @@
 # Box Node #
 
 A Box node (_Utility_ > _Box_) is a container for holding a nested node network inside a node graph. The network contained by a Box is called a **sub-graph**. A sub-graph can only be viewed if you enter its containing Box. You can use Boxes to organize and add modularity to your node graphs.
-![A Box in the main graph, and its contents in a sub-graph](images/illustrationBoxBasics.png "A Box in the main graph, and its contents in a sub-graph")
+![](images/illustrationBoxBasics.png "A Box in the main graph, and its contents in a sub-graph")
 
 
 ## Usage ##
@@ -10,15 +10,15 @@ Boxes are powerful tools for structuring, organizing, and abstracting node graph
 
 In their most basic uses, you can simplify large graphs by wrapping up complicated portions in Boxes, or sub-divide a graph into a series of component sub-graphs.
 
-![Left: boxing up complex sections. Right: boxing up component sections.](images/illustrationBoxUses.png "Left: boxing up complex sections. Right: boxing up component sections.")
+![](images/illustrationBoxUses.png "Left: boxing up complex sections. Right: boxing up component sections")
 
 You can also nest Boxes, to maintain modularity and simplicity in your sub-graphs.
 
-![Boxes nested like Matryoshka dolls](images/illustrationBoxNesting.png "Boxes nested like Matryoshka dolls")
+![](images/illustrationBoxNesting.png "Boxes nested like Matryoshka dolls")
 
 In more advanced uses, Boxes serve to export (and occasionally import) saved sub-graphs, known as **reference scripts**. When you export a Box, it preserves any custom UI, descriptions, tooltips, and documentation links in the network and on the Box itself, giving you the ability to document the network's purpose and function for other users.
 
-![Importing reference scripts into your node graph](images/illustrationBoxReferences.png "Importing reference scripts into your node graph")
+![](images/illustrationBoxReferences.png "Importing reference scripts into your node graph")
 
 
 ## Box data flow ##
@@ -30,14 +30,14 @@ Like any other node, a Box can have _in_ and _out_ plugs. It can take plugs from
 
 While you can connect the nodes inside a Box to the main graph, you cannot view both the main graph and a sub-graph in the same _Graph Editor_. To compensate, a sub-graph's main input and output connections are represented by the special **BoxIn** (_Utility_ > _BoxIn_) and **BoxOut** (_Utility_ > _BoxOut_) nodes. When a Box has _in_ or _out_ plugs, these nodes behave as proxies for them in the sub-graph. The names of the BoxIn and BoxOut nodes will match the names of their corresponding plugs on the Box, and vice versa.
 
-![Left: the in and out plugs in the main graph. Right: the corresponding BoxIn and BoxOut nodes in the sub-graph.](images/illustrationBoxInBoxOutNodes.png "Left: the in and out plugs in the main graph. Right: the corresponding BoxIn and BoxOut nodes in the sub-graph.")
+![](images/illustrationBoxInBoxOutNodes.png "Left: the in and out plugs in the main graph. Right: the corresponding BoxIn and BoxOut nodes in the sub-graph")
 
 
 ### Promoted plugs ###
 
 When boxing up portions of your node graph, the _in_ plugs of the top-most node(s) and _out_ plugs of the bottom-most node(s) are promoted up to the Box. These **promoted plugs** pass data between the main graph and the sub-graph. This is not limited to main _in_ and _out_ plugs: any plug in the sub-graph can be promoted to the Box.
 
-![A promoted plug in the Node Editor, and how it appears on the Box in the Graph Editor](images/illustrationPromotedPlug.png "A promoted plug in the Node Editor, and how it appears on the Box in the Graph Editor")
+![](images/illustrationPromotedPlug.png "A promoted plug in the Node Editor, and how it appears on the Box in the Graph Editor")
 In the sub-graph, promoted plugs are read-only (they appear greyed out in the _Node Editor_). They can only be edited on the Box in the main graph. 
 
 
@@ -54,11 +54,11 @@ To box up a bunch of nodes:
 1. Select one or more nodes in the _Graph Editor_.
 2. Create a Box (_Utility_ > _Box_).
 
-![Boxing up some nodes](images/taskBoxUpNodes.gif "Boxing up some nodes")
+![](images/taskBoxUpNodes.gif "Boxing up some nodes")
 
 The selected nodes will be replaced by a Box. If they were connected to other nodes in the main graph, the Box and the sub-graph will automatically populate with corresponding _in_ and _out_ plugs to maintain the connections.
 
-![The resulting sub-graph after boxing up some nodes](images/taskBoxUpNodesResult.png "The resulting sub-graph after boxing up some nodes")
+![](images/taskBoxUpNodesResult.png "The resulting sub-graph after boxing up some nodes")
 
 
 ### Entering and exiting a Box ###
@@ -96,18 +96,18 @@ The simplest way to connect a Box to a main graph is to promote a node's main _i
     - If the plug is an _in_ array plug, such as the input of a Group node, you can instead select _Promote Array to Box_.
 3. Exit the Box, and connect the new plug to a node in the main graph.
 
-![Connecting a Box to the main graph, from sub-graph to main graph](images/taskConnectBox.gif "Connecting a Box to the main graph, from sub-graph to main graph")
+![](images/taskConnectBox.gif "Connecting a Box to the main graph, from sub-graph to main graph")
 
-Alternatively, dragging a connection to a ![plug adder](images/plugAdder.png "plug adder") on the Box creates a corresponding BoxIn or BoxOut node in the sub-graph:
+Alternatively, dragging a connection to a ![](images/plugAdder.png "Plug adder") on the Box creates a corresponding BoxIn or BoxOut node in the sub-graph:
 
-![Connecting a Box to the main graph, from main graph to sub-graph](images/taskConnectBoxAlt.gif "Connecting a Box to the main graph, from main graph to sub-graph")
+![](images/taskConnectBoxAlt.gif "Connecting a Box to the main graph, from main graph to sub-graph")
 
 
 ### Setting up a Box for pass-through ###
 
 By default, you cannot disable a Box. If it has _in_ and _out_ plugs set up, you also cannot automatically interject it by dropping it over a connection. The BoxOut node has a special _passThrough_ plug, which, when connected to a BoxIn node, provides data pass-through, which enables dropping onto connections and disabling.
 
-![The passThrough plug on a BoxOut node](images/interfacePassthroughPlug.png "The passThrough plug on a BoxOut node")
+![](images/interfacePassthroughPlug.png "The passThrough plug on a BoxOut node")
 
 > Important :
 > The BoxIn node and its connected BoxOut node with the _passThrough_ plug become the main plugs that connect when you drag and drop the Box over a connection.
@@ -117,7 +117,7 @@ To set up a Box for disabling and pass-through:
 1. Enter the Box.
 2. Connect the _passThrough_ plug to a BoxIn node.
 
-![Connecting a passThrough node, so that the Box can be dropped over connections and disabled](images/taskConnectPassthroughPlug.gif "Connecting a passThrough node, so that the Box can be dropped over connections and disabled")
+![](images/taskConnectPassthroughPlug.gif "Connecting a passThrough node, so that the Box can be dropped over connections and disabled")
 
 
 ### Promoting and demoting a plug ###
@@ -144,7 +144,7 @@ When promoted, the following plug types will also add a plug to the Box in the _
 
 Once promoted, you can set the name and value of the plug on the Box using the _Node Editor_. If the promotion added a plug to the Box in the _Graph Editor_, you can drive its value by connecting it to a node.
 
-![Promoting a plug to allow disabling a node using the Box](images/taskPromotePlug.gif "Promoting a plug to allow disabling a node using the Box")
+![](images/taskPromotePlug.gif "Promoting a plug to allow disabling a node using the Box")
 
 
 #### Demoting a plug ####
@@ -160,7 +160,7 @@ To demote a plug:
 2. Select the node with the promoted plug.
 3. In the _Node Editor_, right-click the plug label, then select _Unpromote from Box_ from the context menu.
 
-![Demoting a plug](images/taskDemotePlug.gif "Demoting a plug")
+![](images/taskDemotePlug.gif "Demoting a plug")
 
 > Tip :
 > For faster results, you can unpromote a plug on the Box itself by first right-clicking the plug label in the _Node Editor_, then selecting _Delete_ or _Unpromote from Box_ from the context menu.
@@ -173,7 +173,7 @@ To demote a plug:
 Like other utility nodes with addable plugs, you can reposition and rearrange the plugs on a Box. You can move a plug to any edge of the Box in the _Graph Editor_, or adjust the order of the plugs on an edge.
 
 > Note :
-> An addable plug (![addable plug](images/plugAdder.png "addable plug")) cannot be moved or re-ordered. You must connect or promote a plug to it first.
+> An addable plug (![](images/plugAdder.png "addable plug")) cannot be moved or re-ordered. You must connect or promote a plug to it first.
 
 To adjust the position of a plug on a node, first right-click the plug in the _Graph Editor_. The context menu will open. Then:
 
@@ -182,7 +182,7 @@ To adjust the position of a plug on a node, first right-click the plug in the _G
 - Re-order plugs on a node edge:
     - Select _Move Up_/_Move Down_, or _Move Left_/_Move Right_.
 
-![Adjusting plug position and order around the Box edge in the Graph Editor](images/taskAdjustPlugPosition.gif "Adjusting plug position and order around the Box edge in the Graph Editor")
+![](images/taskAdjustPlugPosition.gif "Adjusting plug position and order around the Box edge in the Graph Editor")
 
 
 #### Renaming and relabelling plugs ####
@@ -214,16 +214,16 @@ The metadata plugs of a Box, which comprise its name, description, documentation
 - Description: Text that appears in the tooltip and the _Node Editor_. Can be adjusted to explain the Box's purpose, contents, and connections.
     > Tip :
     > You can format the _Description_ plug using [Markdown](https://commonmark.org) syntax.
-- Documentation URL: The main help link for the Box (visited by clicking ![the info button](images/info.png "the info button") in the _Node Editor_). Can be edited to point to a location with custom documentation on your studio filesystem or the internet.
+- Documentation URL: The main help link for the Box (visited by clicking ![](images/info.png "Info") in the _Node Editor_). Can be edited to point to a location with custom documentation on your studio filesystem or the internet.
 - Color: Determines the color of the Box in the _Graph Editor_.
 
 To edit the metadata and appearance of a Box:
 
 1. Select the Box.
-2. In the _Node Editor_, click ![the gear](images/gear.png "the gear"), then select _Edit UI..._. The _UI Editor_ will open.
+2. In the _Node Editor_, click ![](images/gear.png "Gear"), then select _Edit UI..._. The _UI Editor_ will open.
 3. Edit the _Name_, _Description_, _Documentation URL_, and _Color_ values as needed.
 
-![The UIEditor with customized plugs](images/interfaceUIEditor.png "The UIEditor with customized plugs")
+![](images/interfaceUIEditor.png "The UIEditor with customized plugs")
 
 
 ### Exporting and importing a reference script ###
@@ -236,7 +236,7 @@ A Box, its sub-graph, its promoted plugs, and its metadata can all be exported a
 To export a Box as a reference script, or import a reference script into a Box:
 
 1. Select the Box.
-2. In the _Node Editor_, click ![the gear](images/gear.png "the gear").
+2. In the _Node Editor_, click ![](images/gear.png "Gear").
 3. Select _Export Reference_ or _Import Reference_. A file dialogue will open.
 4. Using the file dialogue, export or import a `.grf` file.
 
@@ -246,7 +246,7 @@ To export a Box as a reference script, or import a reference script into a Box:
 
 ### Box basics ###
 
-![Box basics](images/exampleBoxBasics.png "Box basics example")
+![](images/exampleBoxBasics.png "Box basics example")
 
 This can be loaded in Gaffer from _Help_ > _Examples_ > _Box Basics_.
 

--- a/doc/source/WorkingWithTheNodeGraph/PerformanceBestPractices/index.md
+++ b/doc/source/WorkingWithTheNodeGraph/PerformanceBestPractices/index.md
@@ -15,11 +15,11 @@ Consider a scene containing 4 assets, with the geometry cache for each imported 
 
 - _Graph1:_ Group all the assets together, and then apply the lookdev nodes in series.
 
-![Grouping, then applying lookdev](images/graphEditorGroupFirst.png "Grouping, then applying lookdev")
+![](images/graphEditorGroupFirst.png "Grouping, then applying lookdev")
 
 - _Graph2:_ First apply the lookdev nodes, and then group all the resulting scenes together.
 
-![Applying lookdev, then grouping](images/graphEditorGroupSecond.png "Applying lookdev, then grouping")
+![](images/graphEditorGroupSecond.png "Applying lookdev, then grouping")
 
 For the sake of simplicity, let's assume that each asset's scene contains 1000 locations, and each lookdev subgraph contains 100 nodes. Now we can estimate each graph's performance load.
 

--- a/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/index.md
+++ b/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/index.md
@@ -8,17 +8,17 @@ A one line shader
 
 Start by creating an OSLCode node in the GraphEditor. With this selected, the NodeEditor will display a blank shader to be edited.
 
-![Blank Shader](images/blank.png)
+![](images/blank.png "Blank Shader")
 
 We'll start by adding some parameters (inputs and outputs) for the shader.
 
-- Click on the upper ![Plus icon](images/plus.png) and choose "Float" from the menu. This creates an input parameter which takes a floating point number.
+- Click on the upper ![](images/plus.png "Plus") and choose "Float" from the menu. This creates an input parameter which takes a floating point number.
 - Double click the "Input1" label that appears, and rename the parameter to `width`.
 - Enter the value `0.025` into the width field.
-- Click on the lower ![Plus Icon](images/plus.png) and choose "Color" from the menu. This creates an output color parameter.
+- Click on the lower ![](images/plus.png "Plus") and choose "Color" from the menu. This creates an output color parameter.
 - Double click the "Output1" label, and rename the parameter to "stripes".
 
-![Parameters](images/parameters.png)
+![](images/parameters.png "Parameters")
 
 We can now enter any OSL code we want to generate the output from the input. Start by entering the following :
 
@@ -28,7 +28,7 @@ stripes = aastep( 0, sin( v * M_PI / width ) )
 
 Now hit _Control + Enter_ to update the shader. The Viewer will update to show a shader ball with the shader on it, and adjusting the width parameter will update the render interactively.
 
-![Shader ball](images/shaderBallStripes.png)
+![](images/shaderBallStripes.png "Shader ball")
 
 > Tip : Enter the names for input and outputs into the code easily by dragging
 > their labels into the code editor. This is especially useful for color
@@ -53,7 +53,7 @@ stripes = mix( color1, color2, m );
 
 And as before, hit _Control + Enter_ to update the shader.
 
-![Shader ball](images/shaderBallColoredStripes.png)
+![](images/shaderBallColoredStripes.png "Shader ball")
 
 No doubt you didn't come here to learn how to make blue and red wobbly stripes, but you are now armed with the ability to add inputs and outputs, edit code and view the results interactively, so are hopefully in a position to create the shader you _do_ want.
 

--- a/doc/source/WorkingWithTheNodeGraph/UsingThePerformanceMonitor/index.md
+++ b/doc/source/WorkingWithTheNodeGraph/UsingThePerformanceMonitor/index.md
@@ -17,7 +17,7 @@ To turn on the performance monitor:
 
 4. Toggle the Performance Monitor plug's switch, and then check its box.
 
-    ![The performance monitor, activated](images/nodeEditorWindowPerformanceMonitor.png "The performance monitor, activated")
+    ![](images/nodeEditorWindowPerformanceMonitor.png "The performance monitor, activated")
 
 When you dispatch your script to the renderer, performance data will output to the stdout in your terminal. If you are dispatching to a render farm, the farm will receive the stdout.
 

--- a/doc/source/WorkingWithThePythonScriptingAPI/ThePythonEditor/index.md
+++ b/doc/source/WorkingWithThePythonScriptingAPI/ThePythonEditor/index.md
@@ -11,11 +11,11 @@ Each _Python Editor_ is a separate instance. Python modules that you `import` wi
 
 The _Python Editor_ is split into two areas. The bottom-half is the input field. The top-half is the output. The input field of the _Python Editor_ functions like a basic plain text editor. You can type, select, cut, copy, paste, and execute code.
 
-![A Python Editor with its input and the output field](images/interfacePythonEditorOutput.png "A Python Editor with its input and the output field")
+![](images/interfacePythonEditorOutput.png "A Python Editor with its input and the output field")
 
 The output field behaves like a typical console output. It records the output stream, including return values and errors. Errors appear in red.
 
-![Errors in a Python Editor's output field](images/interfacePythonEditorError.png "Errors in a Python Editor's output field")
+![](images/interfacePythonEditorError.png "Errors in a Python Editor's output field")
 
 > Caution :
 > Code in Expression nodes is handled by a separate interpreter, and the syntax between them and the _Python Editor_ should not be considered safely compatible.
@@ -41,7 +41,7 @@ To execute code with the _Python Editor:_
 
 The _Python Editor_ can access the same graph elements (nodes and plugs) and scene and image data results (locations, objects, and so on) visible in the various other editors. However, this requires inputting precise dictionary syntax, data types, and code. Instead of typing out the exact code, you can use a shortcut: simply click and drag the element or data from the editor into the _Python Editor's_ input field.
 
-![Dragging elements of the graph from the Graph Editor to the Python Editor](images/taskAccessingElementsPythonEditor.gif "Dragging elements of the graph from the Graph Editor to the Python Editor")
+![](images/taskAccessingElementsPythonEditor.gif "Dragging elements of the graph from the Graph Editor to the Python Editor")
 
 The specific shortcut for dragging depends on the source editor:
 

--- a/doc/source/WorkingWithThePythonScriptingAPI/TutorialNodeGraphEditingInPython/index.md
+++ b/doc/source/WorkingWithThePythonScriptingAPI/TutorialNodeGraphEditingInPython/index.md
@@ -2,7 +2,7 @@
 
 In Gaffer, you can interactively manipulate node graphs in Python using the _Python Editor_. Gaffer's API is fairly frugal, so learning a few fundamental concepts and tasks will go a long way. In this tutorial, we will give you a quick tour of these fundamentals. Using only Python, you will create a simple graph that consists of a camera and a mauve sphere:
 
-![A preview of the final scene](images/viewerFinalScene.png "A preview of the final scene")
+![](images/viewerFinalScene.png "A preview of the final scene")
 
 By the end of this tutorial, you should have an understanding of the following topics in Python:
 
@@ -29,7 +29,7 @@ The bottom-half of the _Python Editor_ is the code input field. The top-half is 
 1. Type `print "Hello, World!"` into the input field.
 2. Hit <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to execute the code.
 
-![The Python Editor with “Hello, World!”](images/pythonEditorHelloWorld.png "The Python Editor with “Hello, World!”")
+![](images/pythonEditorHelloWorld.png "The Python Editor with “Hello, World!”")
 
 
 ## Creating nodes ##
@@ -47,7 +47,7 @@ mySphere = GafferScene.Sphere()
 root.addChild( mySphere )
 ```
 
-![A new Sphere node in the main window](images/mainWindowSphereNode.png "A new Sphere node in the main window")
+![](images/mainWindowSphereNode.png "A new Sphere node in the main window")
 
 Notice that the node was added with the `addChild()` method to the `root` variable. The `addChild()` method is the core method for adding nodes and plugs to the node graph. The `root` variable references the root of the node graph. All nodes in the graph are ultimately children of the root. If you declared the node variable without adding it to the `root` variable, it would exist in memory (all variables in Python are objects), but it would not yet be part of the graph.
 
@@ -66,14 +66,14 @@ root.addChild( myCamera )
 root.addChild( myGroup )
 ```
 
-![All nodes in the Graph Editor, unconnected](images/graphEditorAllNodes.png "All nodes in the Graph Editor, unconnected")
+![](images/graphEditorAllNodes.png "All nodes in the Graph Editor, unconnected")
 
 
 ## Referencing nodes without variables ##
 
 Nodes that do not have variables can be referenced by dragging and dropping them in the interface:
 
-1. Middle-click and drag a node from the _Graph Editor_ (the cursor will change to ![the nodes icon](images/nodes.png "The nodes icon")).
+1. Middle-click and drag a node from the _Graph Editor_ (the cursor will change to ![](images/nodes.png "the nodes icon")).
 2. Release the selection onto the input field of the _Python Editor_.
 
 
@@ -96,7 +96,7 @@ For example, you could reference the radius plug of the Sphere node like this:
 mySphere['radius']
 ```
 
-![A plug reference in the Python Editor](images/pythonEditorPlugReference.png "A plug reference in the Python Editor")
+![](images/pythonEditorPlugReference.png "A plug reference in the Python Editor")
 
 > Caution :
 > Because Python dictionaries do not have built-in overwrite protection, you can accidentally and irrecoverably replace nodes and plugs with assignments that use existing node names, like `root['Sphere'] = ...`. Use dictionary syntax with care.
@@ -104,7 +104,7 @@ mySphere['radius']
 Just like with nodes, you can insert a reference to a plug by dragging. Try inserting a reference to radius plug of the Sphere node:
  
 1. Select the Sphere node in the _Graph Editor_.
-2. Click and drag the **label** of the radius plug from the _Node Editor_ (the cursor will change to ![a plug](images/plug.png "A plug")).
+2. Click and drag the **label** of the radius plug from the _Node Editor_ (the cursor will change to ![](images/plug.png "a plug")).
 3. Release it onto the input field of the _Python Editor_.
 
 A reference to `root['Sphere']['radius']` will be inserted. This is identical to `mySphere['radius']` from earlier. Notice how when you drag and drop plugs, the reference is formatted in dictionary syntax.
@@ -121,9 +121,9 @@ The `getValue()` method retrieves a plug's value. Try it on the `Cs` (colour) pl
 myShader['parameters']['Cs'].getValue()
 ```
 
-There is also a shortcut for grabbing a plug value, which involves <kbd>Shift</kbd> + clicking and dragging the plug label from a _Node Editor_ (the cursor will change to ![the values icon](images/values.png "The values icon")) and releasing it onto the input field of the _Python Editor:_
+There is also a shortcut for grabbing a plug value, which involves <kbd>Shift</kbd> + clicking and dragging the plug label from a _Node Editor_ (the cursor will change to ![](images/values.png "the values icon")) and releasing it onto the input field of the _Python Editor:_
 
-![A plug value reference in the Python Editor](images/pythonEditorPlugValueReference.png "A plug value reference in the Python Editor")
+![](images/pythonEditorPlugValueReference.png "A plug value reference in the Python Editor")
 
 > Tip :
 > The above shortcut can also be very handy in regular use. For instance, if you need to know the type and format of a particular plug's value, dragging it into the _Python Editor_ will reveal it.
@@ -141,7 +141,7 @@ Editing plugs with one element is simple. All you need to provide is the value. 
 mySphere['radius'].setValue( 4 )
 ```
 
-![The sphere with increased radius in the Viewer](images/viewerSphereRadius.png "The sphere with increased radius in the Viewer")
+![](images/viewerSphereRadius.png "The sphere with increased radius in the Viewer")
 
 When editing a plug with multiple elements, such as a vector, color, matrix, etc., you can either edit all the values at once, or one at a time. Editing all the values at once requires formatting the value in the type's syntax. Most of the multi-element types belong to the `imath` utility module, so before you can edit them, you will first need to import it.
 
@@ -157,7 +157,7 @@ import imath
 myShader['parameters']['Cs'].setValue( imath.Color3f( 0.25, 0.75, 0.25 ) )
 ```
 
-![The OpenGL node with an adjusted constant plug](images/nodeEditorOpenGLPlug.png "The OpenGL node with an adjusted constant plug")
+![](images/nodeEditorOpenGLPlug.png "The OpenGL node with an adjusted constant plug")
 
 Next, adjust the camera position, but this time specify only the _z_-axis value of the transform, with dictionary syntax:
 
@@ -165,7 +165,7 @@ Next, adjust the camera position, but this time specify only the _z_-axis value 
 myCamera['transform']['translate']['z'].setValue( 8 )
 ```
 
-![The camera node with an adjusted translate plug](images/viewerCameraPosition.png "The camera node with an adjusted translate plug")
+![](images/viewerCameraPosition.png "The camera node with an adjusted translate plug")
 
 Finally, add a location to the `paths` plug of the PathFilter node:
 
@@ -200,7 +200,7 @@ myShaderAssignment['shader'].setInput( myShader['out'] ) # Shader input/output
 myShaderAssignment['filter'].setInput( myFilter['out'] ) # Filter input/output
 ```
 
-![The ShaderAssignment node with new connections](images/graphEditorShaderAssignmentConnections.png "The ShaderAssignment node with new connections")
+![](images/graphEditorShaderAssignmentConnections.png "The ShaderAssignment node with new connections")
 
 A node that takes multiple input scenes, like the Group node, is slightly different. Its `in` plug is an `ArrayPlug` that consists of multiple children, each a separate scene input accessed via integer index:
 
@@ -209,14 +209,14 @@ myGroup['in'][0].setInput( myShaderAssignment['out'] )
 myGroup['in'][1].setInput( myCamera['out'] )
 ```
 
-![The Group node with new connections](images/graphEditorGroupConnections.png "The Group node with new connections")
+![](images/graphEditorGroupConnections.png "The Group node with new connections")
 
 > Caution :
 > Scene nodes with an `ArrayPlug` input automatically maintain one free child, so that there is always at least one input available. Make sure to connect their child plugs in order: `['in'][0]`, `['in'][1]`, `['in'][2]`, etc. Connecting them out-of-order will return an error.
 
 As you probably noticed, the graph looks tangled up, but that's a consequence of scripting a graph piece-by-piece. Correct this by selecting all the nodes, and then hitting <kbd>Ctrl</kbd> + <kbd>L</kbd>.
 
-![The nodes, rearranged](images/graphEditorRearrangedNodes.png "The nodes, rearranged")
+![](images/graphEditorRearrangedNodes.png "The nodes, rearranged")
 
 Much better!
 
@@ -225,7 +225,7 @@ Much better!
 
 Here is the final graph:
 
-![The final scene](images/mainWindowFinalScene.png "The final scene")
+![](images/mainWindowFinalScene.png "The final scene")
 
 
 ## Deleting nodes ##

--- a/doc/source/WorkingWithThePythonScriptingAPI/TutorialStartupConfig1/index.md
+++ b/doc/source/WorkingWithThePythonScriptingAPI/TutorialStartupConfig1/index.md
@@ -10,14 +10,14 @@ In this three-part tutorial, we will walk through the following example startup 
 
 In this first config, we will add a global context variable called `${project:resources}` that points to the `/resources` directory in the Gaffer installation directory. This context variable will make it slightly easier to reach the directory from any string plug that load files. Since we'll add the context variable using a startup config, it will be automatically added to every node graph Gaffer opens or creates.
 
-![A global context variable in a string plug](images/tutorialVariableSubstitutionInStringPlug.png "A global context variable in a string plug")
+![](images/tutorialVariableSubstitutionInStringPlug.png "A global context variable in a string plug")
 
 
 ## Global context variables ##
 
 Before we begin, a quick aside. A **global** context variables is a context variable that exists at the node graph's root, and which is available to every node and plug at every point in the graph. You can view all of a graph's global context variable in the _Variables_ tab of the the settings menu (_File_ > _Settings_).
 
-![The default global context variable in the Settings window](images/tutorialSettingsWindowDefaultContextVariables.png "The default global context variable in the Settings window")
+![](images/tutorialSettingsWindowDefaultContextVariables.png "The default global context variable in the Settings window")
 
 All startup configs can modify not only their app, but graphs as well. For instance, all graphs automatically receive the above `project:name` and `project:rootDirectory` context variables from the GUI app's default startup config. These global context variables help determine where to save the graph, and where to export renders and caches. Thus, in their standard construction, Gaffer graphs already depend on file path substitutions.
 
@@ -135,7 +135,7 @@ Notice the use of the `application` variable. This is a special variable that re
 
 Now we can test the startup config in a live graph. If you haven't already, save `customVariables.py`, then launch a new instance of Gaffer. In the empty graph, take a look at the global context variables found in the _Variables_ tab of the graph's settings (_File_ > _Settings_). You should see the new `project:resources` variable pointing to the correct path.
 
-![The custom global context variable in the Settings window](images/tutorialSettingsWindowCustomContextVariable.png "The custom global context variable in the Settings window")
+![](images/tutorialSettingsWindowCustomContextVariable.png "The custom global context variable in the Settings window")
 
 Success! Now every node graph you open or create will have the `project:resources` global context variable added to it. Try using the variable to load Gaffy's scene cache:
 
@@ -144,7 +144,7 @@ Success! Now every node graph you open or create will have the `project:resource
 
 If all went well, Gaffy's geometry cache should have loaded in the graph.
 
-![Successfully reading Gaffy using variable substitution in a string](images/tutorialVariableSubstitutionTest.png "Successfully reading Gaffy using variable substitution in a string")
+![](images/tutorialVariableSubstitutionTest.png "Successfully reading Gaffy using variable substitution in a string")
 
 As mentioned earlier, if we wanted to, we could make the path more granular, perhaps by assigning a global context variable to each its child directories.
 

--- a/doc/source/WorkingWithThePythonScriptingAPI/TutorialStartupConfig2/index.md
+++ b/doc/source/WorkingWithThePythonScriptingAPI/TutorialStartupConfig2/index.md
@@ -2,7 +2,7 @@
 
 In this second startup config of the tutorial, we will add default path bookmarks to Gaffer's file browsers.
 
-![The bookmarks in a Gaffer file browser](images/tutorialBookmarks.png "The bookmarks in a Gaffer file browser")
+![](images/tutorialBookmarks.png "The bookmarks in a Gaffer file browser")
 
 In the file browsers inside the Gaffer application, users have the option of bookmarking file paths. In a studio pipeline, it could be beneficial to provide artists with some centrally-deployed  bookmarks to relevant locations on the file system. Giving every artist a common set – or a project-specific set – of bookmarks could help standardize their workflows. User path bookmarks are maintained separately from default bookmarks, so the artists' personal bookmarks would not be at risk.
 
@@ -66,12 +66,12 @@ That's all we need to add a default bookmark to Gaffer's file browsers. Try test
 
 1. If you haven't already, save `customBookmarks.py`, then launch a new instance of Gaffer.
 2. Create a SceneReader node (_Scene_ > _File_ > _Reader_).
-3. In the _Node Editor_, click ![file browser](images/pathChooser.png "File browser").
-4. In the file browser, click ![bookmarks](images/bookmarks.png "Bookmarks").
+3. In the _Node Editor_, click ![](images/pathChooser.png "file browser").
+4. In the file browser, click ![](images/bookmarks.png "bookmarks").
 
 If all goes well, _Resources_ should be in the list of bookmarks:
 
-![A custom default bookmark in a file browser](images/tutorialDefaultBookmark.png "A custom default bookmark in a file browser")
+![](images/tutorialDefaultBookmark.png "A custom default bookmark in a file browser")
 
 You may have noticed that we used a global context variable for a path in the first startup config of this tutorial, but not here. The reason is simply that global context variables are plugs stored per-node graph, whereas path bookmarks are stored in the application.
 
@@ -94,10 +94,10 @@ To add a bookmark to a category, we acquire all of the application's the bookmar
 This should bookmark your `~/Pictures` direcotry for all image node file browsers. Try testing it:
 
 1. Create a Catalogue node.
-2. In the _Node Editor_, In the _Images_ tab, click ![file browser](images/pathChooser.png "File browser").
-3. In the file browser, click ![bookmark](images/bookmarks.png). _Pictures_ should be in the list of bookmarks.
+2. In the _Node Editor_, In the _Images_ tab, click ![](images/pathChooser.png "file browser").
+3. In the file browser, click ![](images/bookmarks.png "bookmark"). _Pictures_ should be in the list of bookmarks.
 
-![A custom default bookmark in an image node's file browser](images/tutorialDefaultImageNodeBookmark.png "A custom default bookmark in an image node's file browser")
+![](images/tutorialDefaultImageNodeBookmark.png "A custom default bookmark in an image node's file browser")
 
 Since this points to a directory in the user's home folder, this isn't the most realistic example for a bookmark in a studio pipeline, but it should provide an example basis from which to incorporate your own asset and resource locations as bookmarks. Using Python string manipulation, you can compose multi-component strings from several context variables or environment variables that point to locations in your file system.
 
@@ -121,11 +121,11 @@ Now, try testing an image node's default file browser path:
 
 1. Save `customBookmarks.py`, then launch a new instance of Gaffer.
 2. Create a Catalogue node.
-3. In the _Node Editor_, in the _Images_ tab, click ![file browser](images/pathChooser.png "File browser").
+3. In the _Node Editor_, in the _Images_ tab, click ![](images/pathChooser.png "file browser").
 
 If all goes well, the file path should default to `~/Pictures`.
 
-![A custom default path in an image node's file browser](images/tutorialDefaultImageNodePath.png "A custom default path in an image node's file browser")
+![](images/tutorialDefaultImageNodePath.png "A custom default path in an image node's file browser")
 
 > Caution :
 > We recommend removing this last line from the config, as it will override the default file browser paths for image nodes with an unrealistic filesystem path that has little utility in a studio environment.

--- a/doc/source/WorkingWithThePythonScriptingAPI/TutorialStartupConfig3/index.md
+++ b/doc/source/WorkingWithThePythonScriptingAPI/TutorialStartupConfig3/index.md
@@ -2,7 +2,7 @@
 
 In this final part of the multi-part startup config tutorial, we will demonstrate a startup config that adds a custom entry to the node menu.
 
-![A custom entry in the node menu](images/tutorialNodeMenuCustomEntry.png "A custom entry in the node menu")
+![](images/tutorialNodeMenuCustomEntry.png "A custom entry in the node menu")
 
 For your convenience, we've shipped Gaffer with a "MacbethTexture" reference graph. Using OSL, this reference procedurally generates a texture of a Macbeth chart on-the-fly, which should come in handy in lookdev and lighting graphs. Our custom node menu entry will insert a Reference node, and then load this reference graph.
 
@@ -126,7 +126,7 @@ That's all! You can add more customized nodes to this config with similar ease, 
 
 Let's try testing the custom node. If you haven't already, save the startup config, then launch a new instance of Gaffer. In the _Graph Editor_, the new entry should appear in the node menu under _Custom_ > _MacbethTexture_, and will create a MacbethTexture node when selected.
 
-![The MacbethTexture node in the Graph Editor](images/tutorialMacbethTextureNode.png "The MacbethTexture node in the Graph Editor")
+![](images/tutorialMacbethTextureNode.png "The MacbethTexture node in the Graph Editor")
 
 
 ## Example graphs ##
@@ -134,7 +134,7 @@ Let's try testing the custom node. If you haven't already, save the startup conf
 
 ### Macbeth chart ###
 
-![Preview of the Macbeth chart example](images/exampleMacbethChart.png)
+![](images/exampleMacbethChart.png "Preview of the Macbeth chart example")
 
 This can be loaded in Gaffer from _Help_ > _Examples_ > _Rendering_ > _Macbeth Chart_.
 

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -1,4 +1,4 @@
-![Gaffer Logo](_static/GafferLogo.svg)
+![](_static/GafferLogo.svg "Gaffer Logo")
 
 # Introduction #
 


### PR DESCRIPTION
This is necessary for docs to work with Sphinx 1.8.0 and the Docker build.

This workaround prevents images from displaying title text on the page as captions, which is a bug with Recommonmark 0.5.0 (the latest). Once they have released a fix, we can revert the alt-text back to title-text.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
