### PR TITLE
GafferScene : Support attribute substitution tokens in shaders

### DIFF
--- a/include/GafferScene/RendererAlgo.h
+++ b/include/GafferScene/RendererAlgo.h
@@ -42,6 +42,7 @@
 #include "GafferScene/Private/IECoreScenePreview/Renderer.h"
 
 #include "IECoreScene/Camera.h"
+#include "IECoreScene/ShaderNetwork.h"
 #include "IECoreScene/VisibleRenderable.h"
 
 #include "IECore/CompoundObject.h"
@@ -265,6 +266,8 @@ GAFFERSCENE_API void outputObjects( const ScenePlug *scene, const IECore::Compou
 
 /// Applies the resolution, aspect ratio etc from the globals to the camera.
 GAFFERSCENE_API void applyCameraGlobals( IECoreScene::Camera *camera, const IECore::CompoundObject *globals, const ScenePlug *scene );
+
+GAFFERSCENE_API IECoreScene::ConstShaderNetworkPtr substitutedShader( IECoreScene::ConstShaderNetworkPtr shaderNetwork, const IECore::CompoundObject *attributes );
 
 } // namespace RendererAlgo
 


### PR DESCRIPTION
First pass at supporting shader substitutions.  At the very least, probably still needs some documentation, and a test for the RendererAlgo::updateAttributes part ( looking for existing tests, I guess maybe this stuff is only exercised by the renderer specific tests? ).

I've added a cache of substituted shaders, using the hashSubstitutions call you suggested in Cortex, but I haven't added the overall cache for identical renderer states, which you've suggested might be a good idea, and we did talk about.

Would be good to know if this is looking like about what you pictured.