### PR TITLE
IE Config : Limit Appleseed installs to 1.9

### DIFF
--- a/config/ie/installAll
+++ b/config/ie/installAll
@@ -26,7 +26,7 @@ if platform in ( "cent7.x86_64" ) :
 
 	# find a specific appleseed version per compiler
 	compilerVersions = IEEnv.activeVersions( IEEnv.registry["compilers"]["gcc"] )
-	appleseedVersions = IEEnv.activeVersions( IEEnv.registry["apps"]["appleseed"] )
+	appleseedVersions = [ x for x in IEEnv.activeVersions( IEEnv.registry["apps"]["appleseed"] ) if x.startswith( "1.9" ) ]
 	appleseedCompilerMap = { x : [] for x in compilerVersions }
 	for appleseedVersion in appleseedVersions :
 		compilerVersion = IEEnv.registry["apps"]["appleseed"][appleseedVersion][platform]["compilerVersion"]


### PR DESCRIPTION
This is a backport PR to make sure we don't build Gaffer 0.53 against Appleseed 2+

I'll just merge this one straight away since it only touches IE configs.