### PR TITLE
Use SideFX VDB when build Gaffer for Houdini

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -220,8 +220,6 @@ vdbVersion = targetAppReg.get( "vdbVersion", cortexReg["vdbVersion"] )
 
 LOCATE_DEPENDENCY_SYSTEMPATH = [
 
-	os.path.join( IEEnv.Environment.rootPath(), "apps", "OpenVDB", vdbVersion, IEEnv.platform(), compiler, compilerVersion, "include" ),
-	os.path.join( IEEnv.Environment.rootPath(), "apps", "OpenVDB", vdbVersion, IEEnv.platform(), compiler, compilerVersion, "python", "include", "python{0}".format( pythonVersion ) ),
 	os.path.join( IEEnv.Environment.rootPath(), "apps", "OpenColorIO", ocioVersion, IEEnv.platform(), compiler, compilerVersion, "include" ),
 	os.path.join( IEEnv.Environment.rootPath(), "apps", "OpenImageIO", oiioVersion, IEEnv.platform(), compiler, compilerVersion, "include" ),
 	os.path.join( OSLHOME, "include" ),
@@ -234,6 +232,12 @@ LOCATE_DEPENDENCY_SYSTEMPATH = [
 	os.path.join( pythonReg["location"], compiler, compilerVersion, pythonReg["include"], "python" + pythonVersion ),
 	"/usr/include/freetype2",
 ]
+
+# append openVDB header when we are not building for Houdini.
+# In Houdini, we are using Sidefx's openVDB header.
+if not targetApp or targetApp != "houdini":
+		LOCATE_DEPENDENCY_SYSTEMPATH += [ os.path.join( IEEnv.Environment.rootPath(), "apps", "OpenVDB", vdbVersion, IEEnv.platform(), compiler, compilerVersion, "include" ) ]
+		LOCATE_DEPENDENCY_SYSTEMPATH += [ os.path.join( IEEnv.Environment.rootPath(), "apps", "OpenVDB", vdbVersion, IEEnv.platform(), compiler, compilerVersion, "python", "include", "python{0}".format( pythonVersion ) ) ]
 
 if targetAppVersion :
 	# for Houdini, we are favouring our dependency rather than sideFx's


### PR DESCRIPTION
Another change for H17.5, we don't want to use SideFx OpenEXR has they don't
ship their python binding and all their headers are together.

For openVDB on the other end, we want to use their header so we need to only
add the openVDB "generic" header when not building for Houdini because we
append SideFx header path.

backport for 0.53 (#3304)

Fixes
---

- ie/config: Use SideFx's vdb when building Gaffer for Houdini(#3305)

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
