### PR TITLE
UI dependency fix

### DIFF
--- a/python/GafferAppleseedTest/ModuleTest.py
+++ b/python/GafferAppleseedTest/ModuleTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,30 +34,14 @@
 #
 ##########################################################################
 
-# Utility classes
+import GafferTest
 
-from TextWriter import TextWriter
-from LoggingTaskNode import LoggingTaskNode
-from DebugDispatcher import DebugDispatcher
-from ErroringTaskNode import ErroringTaskNode
+class ModuleTest( GafferTest.TestCase ) :
 
-# Test cases
+	def testDoesNotImportUI( self ) :
 
-from DispatcherTest import DispatcherTest
-from LocalDispatcherTest import LocalDispatcherTest
-from TaskNodeTest import TaskNodeTest
-from TaskSwitchTest import TaskSwitchTest
-from PythonCommandTest import PythonCommandTest
-from SystemCommandTest import SystemCommandTest
-from TaskListTest import TaskListTest
-from WedgeTest import WedgeTest
-from TaskContextVariablesTest import TaskContextVariablesTest
-from ExecuteApplicationTest import ExecuteApplicationTest
-from TaskPlugTest import TaskPlugTest
-from FrameMaskTest import FrameMaskTest
-from DispatchApplicationTest import DispatchApplicationTest
-from ModuleTest import ModuleTest
+		self.assertModuleDoesNotImportUI( "GafferAppleseed" )
+		self.assertModuleDoesNotImportUI( "GafferAppleseedTest" )
 
 if __name__ == "__main__":
-	import unittest
 	unittest.main()

--- a/python/GafferAppleseedTest/__init__.py
+++ b/python/GafferAppleseedTest/__init__.py
@@ -43,6 +43,7 @@ from AppleseedAutoInstancingTest import AppleseedAutoInstancingTest
 from AppleseedCameraTest import AppleseedCameraTest
 from AppleseedCapsuleTest import AppleseedCapsuleTest
 from InteractiveAppleseedRenderTest import InteractiveAppleseedRenderTest
+from ModuleTest import ModuleTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferArnoldTest/ModuleTest.py
+++ b/python/GafferArnoldTest/ModuleTest.py
@@ -48,5 +48,10 @@ class ModuleTest( GafferTest.TestCase ) :
 		self.assertRaises( AttributeError, getattr, GafferArnold, "sys" )
 		self.assertRaises( AttributeError, getattr, GafferArnold, "ctypes" )
 
+	def testDoesNotImportUI( self ) :
+
+		self.assertModuleDoesNotImportUI( "GafferArnold" )
+		self.assertModuleDoesNotImportUI( "GafferArnoldTest" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDelightTest/ModuleTest.py
+++ b/python/GafferDelightTest/ModuleTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,30 +34,14 @@
 #
 ##########################################################################
 
-# Utility classes
+import GafferTest
 
-from TextWriter import TextWriter
-from LoggingTaskNode import LoggingTaskNode
-from DebugDispatcher import DebugDispatcher
-from ErroringTaskNode import ErroringTaskNode
+class ModuleTest( GafferTest.TestCase ) :
 
-# Test cases
+	def testDoesNotImportUI( self ) :
 
-from DispatcherTest import DispatcherTest
-from LocalDispatcherTest import LocalDispatcherTest
-from TaskNodeTest import TaskNodeTest
-from TaskSwitchTest import TaskSwitchTest
-from PythonCommandTest import PythonCommandTest
-from SystemCommandTest import SystemCommandTest
-from TaskListTest import TaskListTest
-from WedgeTest import WedgeTest
-from TaskContextVariablesTest import TaskContextVariablesTest
-from ExecuteApplicationTest import ExecuteApplicationTest
-from TaskPlugTest import TaskPlugTest
-from FrameMaskTest import FrameMaskTest
-from DispatchApplicationTest import DispatchApplicationTest
-from ModuleTest import ModuleTest
+		self.assertModuleDoesNotImportUI( "GafferDelight" )
+		self.assertModuleDoesNotImportUI( "GafferDelightTest" )
 
 if __name__ == "__main__":
-	import unittest
 	unittest.main()

--- a/python/GafferDelightTest/__init__.py
+++ b/python/GafferDelightTest/__init__.py
@@ -38,6 +38,7 @@ from IECoreDelightPreviewTest import *
 
 from DelightRenderTest import DelightRenderTest
 from InteractiveDelightRenderTest import InteractiveDelightRenderTest
+from ModuleTest import ModuleTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferDispatchTest/ModuleTest.py
+++ b/python/GafferDispatchTest/ModuleTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,30 +34,14 @@
 #
 ##########################################################################
 
-# Utility classes
+import GafferTest
 
-from TextWriter import TextWriter
-from LoggingTaskNode import LoggingTaskNode
-from DebugDispatcher import DebugDispatcher
-from ErroringTaskNode import ErroringTaskNode
+class ModuleTest( GafferTest.TestCase ) :
 
-# Test cases
+	def testDoesNotImportUI( self ) :
 
-from DispatcherTest import DispatcherTest
-from LocalDispatcherTest import LocalDispatcherTest
-from TaskNodeTest import TaskNodeTest
-from TaskSwitchTest import TaskSwitchTest
-from PythonCommandTest import PythonCommandTest
-from SystemCommandTest import SystemCommandTest
-from TaskListTest import TaskListTest
-from WedgeTest import WedgeTest
-from TaskContextVariablesTest import TaskContextVariablesTest
-from ExecuteApplicationTest import ExecuteApplicationTest
-from TaskPlugTest import TaskPlugTest
-from FrameMaskTest import FrameMaskTest
-from DispatchApplicationTest import DispatchApplicationTest
-from ModuleTest import ModuleTest
+		self.assertModuleDoesNotImportUI( "GafferDispatch" )
+		self.assertModuleDoesNotImportUI( "GafferDispatchTest" )
 
 if __name__ == "__main__":
-	import unittest
 	unittest.main()

--- a/python/GafferImageTest/ModuleTest.py
+++ b/python/GafferImageTest/ModuleTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,30 +34,14 @@
 #
 ##########################################################################
 
-# Utility classes
+import GafferTest
 
-from TextWriter import TextWriter
-from LoggingTaskNode import LoggingTaskNode
-from DebugDispatcher import DebugDispatcher
-from ErroringTaskNode import ErroringTaskNode
+class ModuleTest( GafferTest.TestCase ) :
 
-# Test cases
+	def testDoesNotImportUI( self ) :
 
-from DispatcherTest import DispatcherTest
-from LocalDispatcherTest import LocalDispatcherTest
-from TaskNodeTest import TaskNodeTest
-from TaskSwitchTest import TaskSwitchTest
-from PythonCommandTest import PythonCommandTest
-from SystemCommandTest import SystemCommandTest
-from TaskListTest import TaskListTest
-from WedgeTest import WedgeTest
-from TaskContextVariablesTest import TaskContextVariablesTest
-from ExecuteApplicationTest import ExecuteApplicationTest
-from TaskPlugTest import TaskPlugTest
-from FrameMaskTest import FrameMaskTest
-from DispatchApplicationTest import DispatchApplicationTest
-from ModuleTest import ModuleTest
+		self.assertModuleDoesNotImportUI( "GafferImage" )
+		self.assertModuleDoesNotImportUI( "GafferImageTest" )
 
 if __name__ == "__main__":
-	import unittest
 	unittest.main()

--- a/python/GafferImageTest/__init__.py
+++ b/python/GafferImageTest/__init__.py
@@ -96,6 +96,7 @@ from CollectImagesTest import CollectImagesTest
 from CatalogueSelectTest import CatalogueSelectTest
 from BleedFillTest import BleedFillTest
 from RectangleTest import RectangleTest
+from ModuleTest import ModuleTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferOSLTest/ModuleTest.py
+++ b/python/GafferOSLTest/ModuleTest.py
@@ -47,5 +47,10 @@ class ModuleTest( GafferTest.TestCase ) :
 		self.assertRaises( AttributeError, getattr, GafferOSL, "GafferScene" )
 		self.assertRaises( AttributeError, getattr, GafferOSL, "GafferImage" )
 
+	def testDoesNotImportUI( self ) :
+
+		self.assertModuleDoesNotImportUI( "GafferOSL" )
+		self.assertModuleDoesNotImportUI( "GafferOSLTest" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/ModuleTest.py
+++ b/python/GafferSceneTest/ModuleTest.py
@@ -47,5 +47,10 @@ class ModuleTest( GafferTest.TestCase ) :
 		self.assertRaises( AttributeError, getattr, GafferScene, "GafferScene" )
 		self.assertRaises( AttributeError, getattr, GafferScene, "GafferImage" )
 
+	def testDoesNotImportUI( self ) :
+
+		self.assertModuleDoesNotImportUI( "GafferScene" )
+		self.assertModuleDoesNotImportUI( "GafferSceneTest" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ModuleTest.py
+++ b/python/GafferTest/ModuleTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,30 +34,14 @@
 #
 ##########################################################################
 
-# Utility classes
+import GafferTest
 
-from TextWriter import TextWriter
-from LoggingTaskNode import LoggingTaskNode
-from DebugDispatcher import DebugDispatcher
-from ErroringTaskNode import ErroringTaskNode
+class ModuleTest( GafferTest.TestCase ) :
 
-# Test cases
+	def testDoesNotImportUI( self ) :
 
-from DispatcherTest import DispatcherTest
-from LocalDispatcherTest import LocalDispatcherTest
-from TaskNodeTest import TaskNodeTest
-from TaskSwitchTest import TaskSwitchTest
-from PythonCommandTest import PythonCommandTest
-from SystemCommandTest import SystemCommandTest
-from TaskListTest import TaskListTest
-from WedgeTest import WedgeTest
-from TaskContextVariablesTest import TaskContextVariablesTest
-from ExecuteApplicationTest import ExecuteApplicationTest
-from TaskPlugTest import TaskPlugTest
-from FrameMaskTest import FrameMaskTest
-from DispatchApplicationTest import DispatchApplicationTest
-from ModuleTest import ModuleTest
+		self.assertModuleDoesNotImportUI( "Gaffer" )
+		self.assertModuleDoesNotImportUI( "GafferTest" )
 
 if __name__ == "__main__":
-	import unittest
 	unittest.main()

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -34,9 +34,11 @@
 #
 ##########################################################################
 
+import os
 import sys
 import unittest
 import inspect
+import subprocess
 import types
 import shutil
 import tempfile
@@ -292,3 +294,13 @@ class TestCase( unittest.TestCase ) :
 					continue
 
 				self.assertTrue( plug.isSetToDefault(), plug.fullName() + " not at default value following construction" )
+
+	def assertModuleDoesNotImportUI( self, moduleName ) :
+
+		script = os.path.join( self.temporaryDirectory(), "test.py" )
+		with open( script, "w" ) as f :
+			f.write( "import {}\n".format( moduleName ) )
+			f.write( "import sys\n" )
+			f.write( "assert( 'GafferUI' not in sys.modules )\n" )
+
+		subprocess.check_call( [ "gaffer", "python", script ] )

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -160,6 +160,7 @@ from ProcessMessageHandlerTest import ProcessMessageHandlerTest
 from MonitorAlgoTest import MonitorAlgoTest
 from NameValuePlugTest import NameValuePlugTest
 from ExtensionAlgoTest import ExtensionAlgoTest
+from ModuleTest import ModuleTest
 
 from IECorePreviewTest import *
 

--- a/python/GafferTractorTest/ModuleTest.py
+++ b/python/GafferTractorTest/ModuleTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,30 +34,20 @@
 #
 ##########################################################################
 
-# Utility classes
+import unittest
+import sys
 
-from TextWriter import TextWriter
-from LoggingTaskNode import LoggingTaskNode
-from DebugDispatcher import DebugDispatcher
-from ErroringTaskNode import ErroringTaskNode
+import IECore
 
-# Test cases
+import GafferTest
 
-from DispatcherTest import DispatcherTest
-from LocalDispatcherTest import LocalDispatcherTest
-from TaskNodeTest import TaskNodeTest
-from TaskSwitchTest import TaskSwitchTest
-from PythonCommandTest import PythonCommandTest
-from SystemCommandTest import SystemCommandTest
-from TaskListTest import TaskListTest
-from WedgeTest import WedgeTest
-from TaskContextVariablesTest import TaskContextVariablesTest
-from ExecuteApplicationTest import ExecuteApplicationTest
-from TaskPlugTest import TaskPlugTest
-from FrameMaskTest import FrameMaskTest
-from DispatchApplicationTest import DispatchApplicationTest
-from ModuleTest import ModuleTest
+@unittest.skipIf( not IECore.SearchPath( sys.path ).find( "tractor" ), "Tractor not available" )
+class ModuleTest( GafferTest.TestCase ) :
+
+	def testDoesNotImportUI( self ) :
+
+		self.assertModuleDoesNotImportUI( "GafferTractor" )
+		self.assertModuleDoesNotImportUI( "GafferTractorTest" )
 
 if __name__ == "__main__":
-	import unittest
 	unittest.main()

--- a/python/GafferTractorTest/__init__.py
+++ b/python/GafferTractorTest/__init__.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 from TractorDispatcherTest import TractorDispatcherTest
+from ModuleTest import ModuleTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferVDBTest/ModuleTest.py
+++ b/python/GafferVDBTest/ModuleTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,30 +34,14 @@
 #
 ##########################################################################
 
-# Utility classes
+import GafferTest
 
-from TextWriter import TextWriter
-from LoggingTaskNode import LoggingTaskNode
-from DebugDispatcher import DebugDispatcher
-from ErroringTaskNode import ErroringTaskNode
+class ModuleTest( GafferTest.TestCase ) :
 
-# Test cases
+	def testDoesNotImportUI( self ) :
 
-from DispatcherTest import DispatcherTest
-from LocalDispatcherTest import LocalDispatcherTest
-from TaskNodeTest import TaskNodeTest
-from TaskSwitchTest import TaskSwitchTest
-from PythonCommandTest import PythonCommandTest
-from SystemCommandTest import SystemCommandTest
-from TaskListTest import TaskListTest
-from WedgeTest import WedgeTest
-from TaskContextVariablesTest import TaskContextVariablesTest
-from ExecuteApplicationTest import ExecuteApplicationTest
-from TaskPlugTest import TaskPlugTest
-from FrameMaskTest import FrameMaskTest
-from DispatchApplicationTest import DispatchApplicationTest
-from ModuleTest import ModuleTest
+		self.assertModuleDoesNotImportUI( "GafferVDB" )
+		self.assertModuleDoesNotImportUI( "GafferVDBTest" )
 
 if __name__ == "__main__":
-	import unittest
 	unittest.main()

--- a/python/GafferVDBTest/__init__.py
+++ b/python/GafferVDBTest/__init__.py
@@ -39,6 +39,7 @@ from MeshToLevelSetTest import MeshToLevelSetTest
 from LevelSetToMeshTest import LevelSetToMeshTest
 from LevelSetOffsetTest import LevelSetOffsetTest
 from PointsGridToPointsTest import PointsGridToPointsTest
+from ModuleTest import ModuleTest
 
 if __name__ == "__main__":
 	import unittest

--- a/startup/GafferSceneUI/oslHideShaders.py
+++ b/startup/GafferSceneUI/oslHideShaders.py
@@ -37,7 +37,9 @@
 import GafferSceneUI
 import IECore
 
-toHide = IECore.PathMatcher()
-toHide.addPath( "ObjectProcessing/Out*.oso" )
-toHide.addPath( "ImageProcessing/Out*.oso" )
-GafferSceneUI.ShaderUI.hideShaders( toHide )
+GafferSceneUI.ShaderUI.hideShaders(
+	IECore.PathMatcher( [
+		"ObjectProcessing/Out*.oso",
+		"ImageProcessing/Out*.oso",
+	] )
+)


### PR DESCRIPTION
This fixes a problem whereby a startup file for GafferOSL was importing GafferUI, and could therefore cause errors on headless farm machines. It also adds unit tests to ensure that we can't repeat the mistake in the future.