### PR TITLE
 NameValuePlug : Fix plug flag handling 

### DIFF
--- a/include/Gaffer/NameValuePlug.h
+++ b/include/Gaffer/NameValuePlug.h
@@ -70,6 +70,13 @@ class GAFFER_API NameValuePlug : public Gaffer::ValuePlug
 			const std::string &name=defaultName<NameValuePlug>()
 		);
 
+		NameValuePlug(
+			const std::string &nameDefault,
+			Gaffer::PlugPtr valuePlug,
+			const std::string &name,
+			unsigned flags
+		);
+
 		// Similar to above, construct a NameValuePlug with the "name" and "value" children,
 		// and also an "enabled" child.
 		NameValuePlug(
@@ -86,6 +93,14 @@ class GAFFER_API NameValuePlug : public Gaffer::ValuePlug
 			Gaffer::PlugPtr valuePlug,
 			bool defaultEnabled,
 			const std::string &name=defaultName<NameValuePlug>()
+		);
+
+		NameValuePlug(
+			const std::string &nameDefault,
+			Gaffer::PlugPtr valuePlug,
+			bool defaultEnabled,
+			const std::string &name,
+			unsigned flags
 		);
 
 		// Bare constructor required for compatibility with old CompoundDataPlug::MemberPlug constructor.

--- a/include/Gaffer/NameValuePlug.h
+++ b/include/Gaffer/NameValuePlug.h
@@ -64,6 +64,9 @@ class GAFFER_API NameValuePlug : public Gaffer::ValuePlug
 			unsigned flags=Default
 		);
 
+		/// \deprecated Use the version below.
+		/// \todo Remove, and add default arguments for `name` and `flags`
+		/// in the version below.
 		NameValuePlug(
 			const std::string &nameDefault,
 			Gaffer::PlugPtr valuePlug,
@@ -88,6 +91,9 @@ class GAFFER_API NameValuePlug : public Gaffer::ValuePlug
 			unsigned flags=Default
 		);
 
+		/// \deprecated Use the version below.
+		/// \todo Remove, and add default arguments for `name` and `flags`
+		/// in the version below.
 		NameValuePlug(
 			const std::string &nameDefault,
 			Gaffer::PlugPtr valuePlug,

--- a/python/GafferOSLTest/OSLImageTest.py
+++ b/python/GafferOSLTest/OSLImageTest.py
@@ -94,7 +94,7 @@ class OSLImageTest( GafferOSLTest.OSLTestCase ) :
 		def checkDirtiness( expected):
 			self.assertEqual( [ i[0].fullName() for i in cs ], [ "OSLImage." + i for i in expected ] )
 			del cs[:]
-			
+
 		image["channels"]["testClosure"]["value"].setInput( imageShader["out"]["out"] )
 
 		checkDirtiness( [
@@ -153,7 +153,7 @@ class OSLImageTest( GafferOSLTest.OSLTestCase ) :
 				'__shading',
 				'out.channelNames', 'out.channelData', 'out.format', 'out.dataWindow', 'out.metadata', 'out'
 		] )
-		
+
 
 	def testAcceptsShaderSwitch( self ) :
 
@@ -238,7 +238,7 @@ class OSLImageTest( GafferOSLTest.OSLTestCase ) :
 
 		s["b"] = Gaffer.Box()
 		s["b"]["i"] = GafferOSL.OSLImage()
-		s["b"]["i"]["channels"].addChild( Gaffer.NameValuePlug( "", GafferOSL.ClosurePlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ), "testClosure" ) )
+		s["b"]["i"]["channels"].addChild( Gaffer.NameValuePlug( "", GafferOSL.ClosurePlug(), "testClosure", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 		p = Gaffer.PlugAlgo.promote( s["b"]["i"]["channels"]["testClosure"]["value"] )
 		p.setName( "p" )
 

--- a/python/GafferOSLTest/OSLObjectTest.py
+++ b/python/GafferOSLTest/OSLObjectTest.py
@@ -224,7 +224,7 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 
 		s["b"] = Gaffer.Box()
 		s["b"]["o"] = GafferOSL.OSLObject()
-		s["b"]["o"]["primitiveVariables"].addChild( Gaffer.NameValuePlug( "", GafferOSL.ClosurePlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ), "testClosure" ) )
+		s["b"]["o"]["primitiveVariables"].addChild( Gaffer.NameValuePlug( "", GafferOSL.ClosurePlug(), "testClosure", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 		p = Gaffer.PlugAlgo.promote( s["b"]["o"]["primitiveVariables"]["testClosure"]["value"] )
 		p.setName( "p" )
 
@@ -1043,7 +1043,7 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		o["in"].setInput( a["out"] )
 
 		cs = GafferTest.CapturingSlot( o.plugDirtiedSignal() )
-		
+
 		s["transform"]["translate"]["x"].setValue( 1 )
 		def checkAffected( expected ):
 			self.assertEqual( [ i[0].getName() for i in cs if i[0].parent() == o["out"] ], expected )

--- a/python/GafferOSLUI/OSLImageUI.py
+++ b/python/GafferOSLUI/OSLImageUI.py
@@ -144,26 +144,26 @@ class _ChannelsFooter( GafferUI.PlugValueWidget ) :
 		return result
 
 	def __addPlug( self, name, defaultData ) :
+
 		alphaValue = None
 
 		if isinstance( defaultData, IECore.Color4fData ):
-			alphaValue = Gaffer.FloatPlug( "value", Gaffer.Plug.Direction.In, defaultData.value.a, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+			alphaValue = Gaffer.FloatPlug( "value", Gaffer.Plug.Direction.In, defaultData.value.a )
 			defaultData = IECore.Color3fData( imath.Color3f( defaultData.value.r, defaultData.value.g, defaultData.value.b ) )
 
 		if defaultData == None:
 			plugName = "closure"
 			name = ""
-			valuePlug = GafferOSL.ClosurePlug( "value", Gaffer.Plug.Direction.In, Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+			valuePlug = GafferOSL.ClosurePlug( "value" )
 		else:
 			plugName = "channel"
-			valuePlug = Gaffer.PlugAlgo.createPlugFromData( "value", Gaffer.Plug.Direction.In, Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, defaultData )
-
+			valuePlug = Gaffer.PlugAlgo.createPlugFromData( "value", Gaffer.Plug.Direction.In, Gaffer.Plug.Flags.Default, defaultData )
 
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
-			self.getPlug().addChild( Gaffer.NameValuePlug( name, valuePlug, True, plugName ) )
+			self.getPlug().addChild( Gaffer.NameValuePlug( name, valuePlug, True, plugName, Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 			if alphaValue:
 				self.getPlug().addChild(
-					Gaffer.NameValuePlug( name + ".A" if name else "A", alphaValue, True, plugName )
+					Gaffer.NameValuePlug( name + ".A" if name else "A", alphaValue, True, plugName, Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 				)
 
 def __channelLabelFromPlug( plug ):
@@ -207,7 +207,7 @@ Gaffer.Metadata.registerNode(
 			Define image channels to output by adding child plugs and connecting
 			corresponding OSL shaders.  You can drive RGB layers with a color,
 			or connect individual channels to a float.
- 
+
 			If you want to add multiple channels at once, you can also add a closure plug,
 			which can accept a connection from an OSLCode with a combined output closure.
  			""",
@@ -217,7 +217,7 @@ Gaffer.Metadata.registerNode(
 			"noduleLayout:section", "left",
 			"noduleLayout:spacing", 0.2,
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
- 
+
 			# Add + button for showing and hiding parameters in the GraphEditor
 			"noduleLayout:customGadget:addButton:gadgetType", "GafferOSLUI.OSLImageUI.PlugAdder",
 		],
@@ -240,7 +240,7 @@ Gaffer.Metadata.registerNode(
 			"nodule:type", "",
 		],
 		"channels.*.value" : [
- 
+
 			# Although the parameters plug is positioned
 			# as we want above, we must also register
 			# appropriate values for each individual parameter,

--- a/python/GafferOSLUI/OSLObjectUI.py
+++ b/python/GafferOSLUI/OSLObjectUI.py
@@ -146,12 +146,12 @@ class _PrimitiveVariablesFooter( GafferUI.PlugValueWidget ) :
 		if defaultData == None:
 			plugName = "closure"
 			name = ""
-			valuePlug = GafferOSL.ClosurePlug( "value", Gaffer.Plug.Direction.In, Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+			valuePlug = GafferOSL.ClosurePlug( "value" )
 		else:
 			plugName = "primitiveVariable"
-			valuePlug = Gaffer.PlugAlgo.createPlugFromData( "value", Gaffer.Plug.Direction.In, Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, defaultData )
+			valuePlug = Gaffer.PlugAlgo.createPlugFromData( "value", Gaffer.Plug.Direction.In, Gaffer.Plug.Flags.Default, defaultData )
 
-		plug = Gaffer.NameValuePlug( name, valuePlug, True, plugName )
+		plug = Gaffer.NameValuePlug( name, valuePlug, True, plugName, Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().addChild( plug )
@@ -237,7 +237,7 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The interpolation type of the primitive variables created by this node.
-			For instance, Uniform interpolation means that the shader is run once per face on a mesh, allowing it to output primitive variables with a value per face. 
+			For instance, Uniform interpolation means that the shader is run once per face on a mesh, allowing it to output primitive variables with a value per face.
 			All non-constant input primitive variables are resampled to match the selected interpolation so that they can be accessed from the shader.
 			""",
 

--- a/python/GafferSceneTest/StandardAttributesTest.py
+++ b/python/GafferSceneTest/StandardAttributesTest.py
@@ -119,5 +119,58 @@ class StandardAttributesTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( a["out"].setHash( "flatThings" ), p["out"].setHash( "flatThings" ) )
 		self.assertTrue( a["out"].set( "flatThings", _copy=False ).isSame( p["out"].set( "flatThings", _copy=False ) ) )
 
+	def assertPromotedAttribute( self, script ) :
+
+		self.assertIn( "attributes_visibility", script["Box"] )
+		self.assertIsInstance( script["Box"]["attributes_visibility"], Gaffer.NameValuePlug )
+
+		self.assertIn( "name", script["Box"]["attributes_visibility"] )
+		self.assertIsInstance( script["Box"]["attributes_visibility"]["name"], Gaffer.StringPlug )
+
+		self.assertIn( "value", script["Box"]["attributes_visibility"] )
+		self.assertIsInstance( script["Box"]["attributes_visibility"]["value"], Gaffer.BoolPlug )
+
+		self.assertIn( "enabled", script["Box"]["attributes_visibility"] )
+		self.assertIsInstance( script["Box"]["attributes_visibility"]["enabled"], Gaffer.BoolPlug )
+
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( script["Box"]["StandardAttributes"]["attributes"]["visibility"] ) )
+		self.assertEqual(
+			script["Box"]["StandardAttributes"]["attributes"]["visibility"].getInput(),
+			script["Box"]["attributes_visibility"]
+		)
+
+		self.assertTrue( script["Box"]["attributes_visibility"].getFlags( Gaffer.Plug.Flags.Dynamic ) )
+
+	def testLoadPromotedAttributeFrom0_53( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/promotedCompoundDataMemberPlug-0.53.4.0.gfr" )
+		s.load()
+		self.assertPromotedAttribute( s )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+		self.assertPromotedAttribute( s2 )
+
+		s3 = Gaffer.ScriptNode()
+		s3.execute( s2.serialise() )
+		self.assertPromotedAttribute( s3 )
+
+	def testPromoteAndSerialiseAttribute( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["Box"] = Gaffer.Box()
+		s["Box"]["StandardAttributes"] = GafferScene.StandardAttributes()
+		Gaffer.PlugAlgo.promote( s["Box"]["StandardAttributes"]["attributes"]["visibility"] )
+		self.assertPromotedAttribute( s )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+		self.assertPromotedAttribute( s2 )
+
+		s3 = Gaffer.ScriptNode()
+		s3.execute( s2.serialise() )
+		self.assertPromotedAttribute( s3 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/scripts/promotedCompoundDataMemberPlug-0.53.4.0.gfr
+++ b/python/GafferSceneTest/scripts/promotedCompoundDataMemberPlug-0.53.4.0.gfr
@@ -1,0 +1,48 @@
+import Gaffer
+import GafferImage
+import GafferScene
+import IECore
+import imath
+
+Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 53, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 4, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "imageCataloguePort", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"].addChild( Gaffer.StringPlug( "name", defaultValue = 'image:catalogue:port', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"].addChild( Gaffer.IntPlug( "value", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectName", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:name', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectName"].addChild( Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "projectRootDirectory", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "name", defaultValue = 'project:rootDirectory', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["projectRootDirectory"].addChild( Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format( 1920, 1080, 1.000 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["defaultFormat"] )
+__children["Box"] = Gaffer.Box( "Box" )
+parent.addChild( __children["Box"] )
+__children["Box"].addChild( GafferScene.StandardAttributes( "StandardAttributes" ) )
+__children["Box"]["StandardAttributes"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Box"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Box"].addChild( Gaffer.CompoundDataPlug.MemberPlug( "attributes_visibility", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Box"]["attributes_visibility"].addChild( Gaffer.StringPlug( "name", defaultValue = 'scene:visible', ) )
+__children["Box"]["attributes_visibility"].addChild( Gaffer.BoolPlug( "value", defaultValue = True, ) )
+__children["Box"]["attributes_visibility"].addChild( Gaffer.BoolPlug( "enabled", defaultValue = False, ) )
+parent["variables"]["imageCataloguePort"]["value"].setValue( 33007 )
+Gaffer.Metadata.registerValue( parent["variables"]["imageCataloguePort"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectName"]["name"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectRootDirectory"]["name"], 'readOnly', True )
+__children["Box"]["StandardAttributes"]["attributes"]["visibility"].setInput( __children["Box"]["attributes_visibility"] )
+__children["Box"]["StandardAttributes"]["attributes"]["visibility"]["name"].setInput( __children["Box"]["attributes_visibility"]["name"] )
+__children["Box"]["StandardAttributes"]["attributes"]["visibility"]["value"].setInput( __children["Box"]["attributes_visibility"]["value"] )
+__children["Box"]["StandardAttributes"]["attributes"]["visibility"]["enabled"].setInput( __children["Box"]["attributes_visibility"]["enabled"] )
+__children["Box"]["StandardAttributes"]["__uiPosition"].setValue( imath.V2f( 5.25, -0.25 ) )
+__children["Box"]["__uiPosition"].setValue( imath.V2f( 5.25, -0.25 ) )
+Gaffer.Metadata.registerValue( __children["Box"]["attributes_visibility"], 'description', 'Whether or not the object can be seen - invisible objects are\nnot sent to the renderer at all. Typically more fine\ngrained (camera, reflection etc) visibility can be\nspecified using a renderer specific attributes node.\nNote that making a parent location invisible will\nalways make all the children invisible too, regardless\nof their visibility settings.' )
+
+
+del __children
+

--- a/python/GafferTest/CompoundDataPlugTest.py
+++ b/python/GafferTest/CompoundDataPlugTest.py
@@ -251,8 +251,8 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 
 		p = Gaffer.CompoundDataPlug()
 
-		v = Gaffer.IntPlug( minValue = -10, maxValue = 10, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		m1 = Gaffer.NameValuePlug( "a", v )
+		v = Gaffer.IntPlug( minValue = -10, maxValue = 10 )
+		m1 = Gaffer.NameValuePlug( "a", v, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		p.addChild( m1 )
 		self.assertTrue( v.parent().isSame( m1 ) )
 		self.assertEqual( m1["value"].getName(), "value" )

--- a/src/Gaffer/NameValuePlug.cpp
+++ b/src/Gaffer/NameValuePlug.cpp
@@ -56,10 +56,14 @@ NameValuePlug::NameValuePlug( const std::string &nameDefault, const IECore::Data
 }
 
 NameValuePlug::NameValuePlug( const std::string &nameDefault, Gaffer::PlugPtr valuePlug, const std::string &name )
-	:	NameValuePlug( name, valuePlug->direction(), valuePlug->getFlags() )
+	:	NameValuePlug( nameDefault, valuePlug, name, valuePlug->getFlags() )
 {
-	addChild( new StringPlug( "name", valuePlug->direction(), nameDefault, valuePlug->getFlags() ) );
+}
 
+NameValuePlug::NameValuePlug( const std::string &nameDefault, Gaffer::PlugPtr valuePlug, const std::string &name, unsigned flags )
+	:	NameValuePlug( name, valuePlug->direction(), flags )
+{
+	addChild( new StringPlug( "name", valuePlug->direction(), nameDefault ) );
 	valuePlug->setName( "value" );
 	addChild( valuePlug );
 }
@@ -71,9 +75,14 @@ NameValuePlug::NameValuePlug( const std::string &nameDefault, const IECore::Data
 }
 
 NameValuePlug::NameValuePlug( const std::string &nameDefault, Gaffer::PlugPtr valuePlug, bool enabled, const std::string &name )
-	:	NameValuePlug( nameDefault, valuePlug, name )
+	:	NameValuePlug( nameDefault, valuePlug, enabled, name, valuePlug->getFlags() )
 {
-	addChild( new BoolPlug( "enabled", valuePlug->direction(), enabled, valuePlug->getFlags() ) );
+}
+
+NameValuePlug::NameValuePlug( const std::string &nameDefault, Gaffer::PlugPtr valuePlug, bool defaultEnabled, const std::string &name, unsigned flags )
+	:	NameValuePlug( nameDefault, valuePlug, name, flags )
+{
+	addChild( new BoolPlug( "enabled", direction(), defaultEnabled ) );
 }
 
 // We need to check if the namePlug exists because we offer a bare constructor that leaves the child plugs
@@ -164,13 +173,13 @@ PlugPtr NameValuePlug::createCounterpart( const std::string &name, Direction dir
 	if( enabledPlug() )
 	{
 		return new NameValuePlug(
-			namePlug()->defaultValue(), valueCounterpart, enabledPlug()->defaultValue(), name
+			namePlug()->defaultValue(), valueCounterpart, enabledPlug()->defaultValue(), name, getFlags()
 		);
 	}
 	else
 	{
 		return new NameValuePlug(
-			namePlug()->defaultValue(), valueCounterpart, name
+			namePlug()->defaultValue(), valueCounterpart, name, getFlags()
 		);
 	}
 }

--- a/src/GafferModule/NameValuePlugBinding.cpp
+++ b/src/GafferModule/NameValuePlugBinding.cpp
@@ -86,7 +86,9 @@ class NameValuePlugSerialiser : public ValuePlugSerialiser
 				result += std::string( plug->enabledPlug()->defaultValue() ? "True" : "False" ) + ", ";
 			}
 
-			result += "\"" + plug->getName().string() + "\" )";
+			result += "\"" + plug->getName().string() + "\", ";
+
+			result += flagsRepr( plug->getFlags() ) + " )";
 
 			return result;
 		}
@@ -99,15 +101,21 @@ std::string repr( const NameValuePlug *plug )
 	return NameValuePlugSerialiser::repr( plug, &tempSerialisation );
 }
 
-
 NameValuePlugPtr nameValuePlugConstructor1( const std::string &nameDefault, const IECore::DataPtr valueDefault, const std::string &name, Plug::Direction direction, unsigned flags )
 {
 	return new NameValuePlug( nameDefault, valueDefault.get(), name, direction, flags );
 }
 
-NameValuePlugPtr nameValuePlugConstructor2( const std::string &nameDefault, const Gaffer::PlugPtr valuePlug, const std::string &name )
+NameValuePlugPtr nameValuePlugConstructor2( const std::string &nameDefault, const Gaffer::PlugPtr valuePlug, const std::string &name, object flags )
 {
-	return new NameValuePlug( nameDefault, valuePlug, name );
+	if( flags == object() )
+	{
+		return new NameValuePlug( nameDefault, valuePlug, name );
+	}
+	else
+	{
+		return new NameValuePlug( nameDefault, valuePlug, name, extract<unsigned>( flags ) );
+	}
 }
 
 NameValuePlugPtr nameValuePlugConstructor3( const std::string &nameDefault, const IECore::DataPtr valueDefault, bool defaultEnabled, const std::string &name, Plug::Direction direction, unsigned flags )
@@ -115,12 +123,17 @@ NameValuePlugPtr nameValuePlugConstructor3( const std::string &nameDefault, cons
 	return new NameValuePlug( nameDefault, valueDefault.get(), defaultEnabled, name, direction, flags );
 }
 
-NameValuePlugPtr nameValuePlugConstructor4( const std::string &nameDefault, const Gaffer::PlugPtr valuePlug, bool defaultEnabled, const std::string &name )
+NameValuePlugPtr nameValuePlugConstructor4( const std::string &nameDefault, const Gaffer::PlugPtr valuePlug, bool defaultEnabled, const std::string &name, object flags )
 {
-	return new NameValuePlug( nameDefault, valuePlug, defaultEnabled, name );
+	if( flags == object() )
+	{
+		return new NameValuePlug( nameDefault, valuePlug, defaultEnabled, name );
+	}
+	else
+	{
+		return new NameValuePlug( nameDefault, valuePlug, defaultEnabled, name, extract<unsigned>( flags ) );
+	}
 }
-
-
 
 } // namespace
 
@@ -150,7 +163,8 @@ void GafferModule::bindNameValuePlug()
 				(
 					arg( "nameDefault" ),
 					arg( "valuePlug" ),
-					arg( "name" ) = GraphComponent::defaultName<NameValuePlug>()
+					arg( "name" ) = GraphComponent::defaultName<NameValuePlug>(),
+					arg( "flags" ) = object()
 				)
 			)
 		)
@@ -170,7 +184,8 @@ void GafferModule::bindNameValuePlug()
 					arg( "nameDefault" ),
 					arg( "valuePlug" ),
 					arg( "defaultEnabled" ),
-					arg( "name" ) = GraphComponent::defaultName<NameValuePlug>()
+					arg( "name" ) = GraphComponent::defaultName<NameValuePlug>(),
+					arg( "flags" ) = object()
 				)
 			)
 		)


### PR DESCRIPTION
Recap :

- Every plug has its own set of flags.
- There are no constraints on a plug's flags in relation to the flags of its parent.
- The `Dynamic` flag is used to tag plugs that are added outside of their parent's constructor,
  meaning they will need to be recreated explicitly by the serialisation.
- Flags - especially `Dynamic` - are a constant source of bugs, and we need to get rid of
  them (but I digress).

The NameValuePlug has two main forms for its constructor. The first takes a `Data *` to define the "value" plug implicitly, and an explicit argument for the flags of the `NameValuePlug`. The second takes a `PlugPtr` to define the "value" plug explicitly, and then borrows the flags from that to define the flags of the `NameValuePlug` implicitly. This latter form was used in the serialisation, and led to the bugs exposed in the new `StandardAttributesTest` methods.

The key problem was that the serialisation was lossy : we didn't serialise the parent flags, so upon loading they were replaced with the child flags. This led to the following sequence of operations :

1. Promote a NameValuePlug from a StandardAttributes node. The promotion code sets the `Dynamic` flag to indicate that the serialisation will need to include a constructor for the promoted plug. The child plugs do not have the `Dynamic` flag set, which is fine, because they will be created by the parent constructor. All is well.
2. Serialise. Oops. The flags from the parent plug are omitted from the serialisation.
3. Load. Everything _seems_ OK, because the plug has been recreated, but behind the scenes the `Dynamic` flag has been lost.
4. Save. The NameValuePlug constructor is omitted from the serialisation.
5. Load. The NameValuePlug has gone, never to return.

The solution is to introduce an extended constructor which passes flags explicitly, and use it to make the serialisation lossless. It's a pity to extend the already-slightly-confusing set of constructors for NameValuePlug with two more, but we can remove the lossy versions in a future major version. Alternative solutions considered were :

- Use a `const_cast` and poke the Dynamic flag into the child during serialisation. This would have fixed the bug but with downsides :
	- The serialisation would still be lossy.
	- We would be modifying state on a supposedly `const` object, and emitting signals during serialisation. I didn't fancy the gamble.
- Hack the plug promotion code to apply the Dynamic flag to the children too. This would work for plugs promoted in the future, but was no good for promoted plugs serialised in Gaffer 0.53. It would also mean we were specifying the Dynamic plug on children that we knew didn't need it.
- Monkey patch `NameValuePlug.addChild()` to transfer the Dynamic flag to the child. This would have fixed old serialisations, so could have been used with the above. But again, it leaves the child with a confusing Dynamic flag, and doesn't address the general problem.