### PR TITLE
Azure : Remove cruft from MacOS documentation screenshots

### DIFF
--- a/config/azure/build.yaml
+++ b/config/azure/build.yaml
@@ -28,6 +28,14 @@ jobs:
 
    steps:
 
+   - script: |
+       sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off &&
+       defaults -currentHost write ~/Library/Preferences/ByHost/com.apple.notificationcenterui doNotDisturb -boolean true &&
+       sudo killall NotificationCenter &&
+       defaults write com.apple.Dock autohide -bool true && sleep 1 && killall Dock
+     displayName: 'Configure Environment (Darwin)'
+     condition: eq( variables['Agent.OS'], 'Darwin' )
+
    # Provides $(Gaffer.*) variables
    - script: |
        pip install --user PyGithub &&


### PR DESCRIPTION
This prevents the 'Do you want to allow Python.app to accept incoming
network connections?' dialog. Which usually ends up over the top of our
screenshots, such as:

![PastedGraphic-13](https://user-images.githubusercontent.com/896779/62459436-3e8e1180-b777-11e9-8900-3da2ad4f679b.png)

Other intrusions come from the dock, and the 'Welcome to MacOS' persistent notification centre banners.