### PR TITLE
CompoundEditor : Allow NodeSetEditors to follow Numeric Bookmarks

### DIFF
--- a/include/Gaffer/NumericBookmarkSet.h
+++ b/include/Gaffer/NumericBookmarkSet.h
@@ -1,0 +1,86 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_NUMERICBOOKMARKSET_H
+#define GAFFER_NUMERICBOOKMARKSET_H
+
+#include "Gaffer/ScriptNode.h"
+#include "Gaffer/Set.h"
+#include "Gaffer/TypeIds.h"
+
+namespace Gaffer
+{
+
+/// The NumericBookmarkSet provides a Set implementation that adjusts its membership such that
+/// it always contains the node associated with a specified numeric bookmark (@see MetadataAlgo.h).
+class GAFFER_API NumericBookmarkSet : public Gaffer::Set
+{
+
+	public :
+
+		NumericBookmarkSet( Gaffer::ScriptNodePtr script, int bookmark );
+		~NumericBookmarkSet() override;
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::NumericBookmarkSet, NumericBookmarkSetTypeId, Gaffer::Set );
+
+		void setBookmark( int bookmark );
+		int getBookmark() const;
+
+		/// @name Set interface
+		////////////////////////////////////////////////////////////////////
+		//@{
+		bool contains( const Member *object ) const override;
+		Member *member( size_t index ) override;
+		const Member *member( size_t index ) const override;
+		size_t size() const override;
+		//@}
+
+	private :
+
+		Gaffer::ScriptNodePtr m_script;
+		int m_bookmark;
+
+		Gaffer::NodePtr m_node;
+		void updateNode();
+
+		void metadataChanged( IECore::InternedString key, Gaffer::Node *node );
+};
+
+IE_CORE_DECLAREPTR( NumericBookmarkSet );
+
+} // namespace Gaffer
+
+#endif // GAFFER_NUMERICBOOKMARKSET_H

--- a/include/Gaffer/TypeIds.h
+++ b/include/Gaffer/TypeIds.h
@@ -100,7 +100,7 @@ enum TypeId
 	BoxTypeId = 110053,
 	InternedStringVectorDataPlugTypeId = 110054,
 	SplinefColor4fPlugTypeId = 110055,
-	ExecutableOpHolderTypeId = 110056, // obsolete - available for reuse
+	NumericBookmarkSetTypeId = 110056,
 	DispatcherTypeId = 110057, // obsolete - available for reuse
 	Transform2DPlugTypeId = 110058,
 	ReferenceTypeId = 110059,

--- a/python/GafferTest/NumericBookmarkSetTest.py
+++ b/python/GafferTest/NumericBookmarkSetTest.py
@@ -1,0 +1,152 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+
+import Gaffer
+import GafferTest
+
+class NumericBookmarkSetTest( GafferTest.TestCase ) :
+
+	def testAccessors( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		b = Gaffer.NumericBookmarkSet( s, 1 )
+
+		self.assertEqual( b.getBookmark(), 1 )
+
+		for i in range( 1, 10 ) :
+			b.setBookmark( i )
+			self.assertEqual( b.getBookmark(), i )
+
+		for i in ( 0, 10 ) :
+			with self.assertRaises( RuntimeError ) :
+				b.setBookmark( i )
+
+	def testBookmarkUpdates( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["a"] = Gaffer.Node()
+		s["b"] = Gaffer.Node()
+		s["c"] = Gaffer.Node()
+
+		b = Gaffer.NumericBookmarkSet( s, 1 )
+		self.assertEqual( b.size(), 0 )
+
+		Gaffer.MetadataAlgo.setNumericBookmark( s, 1, s["a"] )
+		self.assertEqual( set(b), { s["a"] } )
+
+		Gaffer.MetadataAlgo.setNumericBookmark( s, 1, s["b"] )
+		self.assertEqual( set(b), { s["b"] } )
+
+		Gaffer.MetadataAlgo.setNumericBookmark( s, 1, None )
+		self.assertEqual( b.size(), 0 )
+
+		Gaffer.MetadataAlgo.setNumericBookmark( s, 2, s["c"] )
+
+		b2 = Gaffer.NumericBookmarkSet( s, 2 )
+		self.assertEqual( set(b2), { s["c"] } )
+
+		Gaffer.MetadataAlgo.setNumericBookmark( s, 2, s["a"] )
+		self.assertEqual( set(b2), { s["a"] } )
+
+	def testSignals( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["a"] = Gaffer.Node()
+		s["b"] = Gaffer.Node()
+
+		mirror = set()
+
+		def added( _, member ) :
+			mirror.add( member )
+
+		def removed( _, member ) :
+			mirror.remove( member )
+
+		b = Gaffer.NumericBookmarkSet( s, 1 )
+
+		ca = b.memberAddedSignal().connect( added )
+		cr = b.memberRemovedSignal().connect( removed )
+
+		self.assertEqual( set(b), mirror )
+
+		Gaffer.MetadataAlgo.setNumericBookmark( s, 1, s["a"] )
+		self.assertEqual( set(b), mirror )
+
+		Gaffer.MetadataAlgo.setNumericBookmark( s, 1, s["b"] )
+		self.assertEqual( set(b), mirror )
+
+	def testSignalOrder( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["a"] = Gaffer.Node()
+		s["b"] = Gaffer.Node()
+
+		b = Gaffer.NumericBookmarkSet( s, 1 )
+
+		callbackFailures = { "added" : 0, "removed" : 0 }
+
+		# Check we have no members when one is removed as we're
+		# defined as only ever containing one node. We can't assert
+		# here as the exception gets eaten and the test passes anyway
+		def removed( _, member ) :
+			if set(b) != set() :
+				callbackFailures["removed"] += 1
+
+		cr = b.memberRemovedSignal().connect( removed )
+
+		Gaffer.MetadataAlgo.setNumericBookmark( s, 1, s["a"] )
+		Gaffer.MetadataAlgo.setNumericBookmark( s, 1, s["b"] )
+
+		self.assertEqual( callbackFailures["removed"], 0 )
+
+		# Check member is added before signal, same deal re: asserts
+		def added( _, member ) :
+			if set(b) != { s["a"] } :
+				callbackFailures["added"] += 1
+
+		ca = b.memberAddedSignal().connect( added )
+
+		Gaffer.MetadataAlgo.setNumericBookmark( s, 1, s["a"] )
+		self.assertEqual( callbackFailures["added"], 0 )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -159,6 +159,7 @@ from MonitorAlgoTest import MonitorAlgoTest
 from NameValuePlugTest import NameValuePlugTest
 from ExtensionAlgoTest import ExtensionAlgoTest
 from ModuleTest import ModuleTest
+from NumericBookmarkSetTest import NumericBookmarkSetTest
 
 from IECorePreviewTest import *
 

--- a/python/GafferUI/GraphBookmarksUI.py
+++ b/python/GafferUI/GraphBookmarksUI.py
@@ -118,20 +118,38 @@ def appendPlugContextMenuDefinitions( graphEditor, plug, menuDefinition ) :
 
 def appendNodeSetMenuDefinitions( editor, menuDefinition ) :
 
+	weakEditor = weakref.ref( editor )
+
+	def followBookmark( number, weakEditor, _ ) :
+		editor = weakEditor()
+		if editor is not None :
+			b = Gaffer.NumericBookmarkSet( editor.scriptNode(), number )
+			editor.setNodeSet( b )
+
+	n = editor.getNodeSet()
+
+	for i in range( 1, 10 ) :
+		isCurrent = isinstance( n, Gaffer.NumericBookmarkSet ) and n.getBookmark() == i
+		menuDefinition.append( "/Follow/Bookmark/%d" % i, {
+			"command" : functools.partial( followBookmark, i, weakEditor ),
+			"active" : not isCurrent,
+			"checkBox" : isCurrent
+		} )
+
 	for i in range( 1, 10 ) :
 	  menuDefinition.append(
-		  "/Pin Bookmark/%s" % i,
+		  "/Pin/Bookmark/%s" % i,
 		  {
 			  "command" : functools.partial( __findNumericBookmark, editor, i ),
 			  "active" : Gaffer.MetadataAlgo.getNumericBookmark( editor.scriptNode(), i ) is not None,
 		  }
 	  )
 
-	menuDefinition.append( "/Pin Bookmark/Divider", { "divider" : True } )
+	menuDefinition.append( "/Pin/Bookmark/Divider", { "divider" : True } )
 
 	bookmarks = __findableBookmarks( editor )
 	menuDefinition.append(
-		"/Pin Bookmark/Other...",
+		"/Pin/Bookmark/Other...",
 		{
 			"command" : functools.partial( __findBookmark, editor, bookmarks ),
 			"active" : len( bookmarks ),

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -21,6 +21,14 @@
   <defs
      id="defs4">
     <linearGradient
+       id="linearGradient2267"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#787878;stop-opacity:1;"
+         offset="0"
+         id="stop2265" />
+    </linearGradient>
+    <linearGradient
        id="compoundEditorButtonDisabled">
       <stop
          style="stop-color:#696969;stop-opacity:1;"
@@ -4781,5 +4789,22 @@
          y="220.61823"
          inkscape:label="export" />
     </g>
+    <path
+       inkscape:label="#forExport:nodeSetNumericBookmarkSet"
+       transform="matrix(1.2161846,0,0,1.2434878,-17.319593,317.77547)"
+       d="m 302.30138,18.423424 -3.43097,-2.443491 -3.44073,2.429728 1.26367,-4.018128 -3.37406,-2.521504 4.21197,-0.03985 1.35545,-3.9881025 1.33946,3.9935005 4.21177,0.05672 -3.38412,2.507967 z"
+       inkscape:randomized="0"
+       inkscape:rounded="0"
+       inkscape:flatsided="false"
+       sodipodi:arg2="1.5727992"
+       sodipodi:arg1="0.94448073"
+       sodipodi:r2="2.2924397"
+       sodipodi:r1="5.8454323"
+       sodipodi:cy="13.687498"
+       sodipodi:cx="298.875"
+       sodipodi:sides="5"
+       id="forExport:nodeSetNumericBookmarkSet"
+       style="fill:#e0e0e0;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.49690738;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:type="star" />
   </g>
 </svg>

--- a/src/Gaffer/NumericBookmarkSet.cpp
+++ b/src/Gaffer/NumericBookmarkSet.cpp
@@ -1,0 +1,129 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/NumericBookmarkSet.h"
+
+#include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
+
+#include "IECore/Exception.h"
+
+#include "boost/bind.hpp"
+
+using namespace IECore;
+using namespace Gaffer;
+
+
+NumericBookmarkSet::NumericBookmarkSet( ScriptNodePtr script, int bookmark )
+	: m_bookmark( 0 )
+{
+	m_script = script;
+	Metadata::nodeValueChangedSignal().connect( boost::bind( &NumericBookmarkSet::metadataChanged, this, ::_2, ::_3 ) );
+	setBookmark( bookmark );
+}
+
+NumericBookmarkSet::~NumericBookmarkSet()
+{
+}
+
+void NumericBookmarkSet::setBookmark( int bookmark )
+{
+	if( bookmark < 1 || bookmark > 9 )
+	{
+		throw IECore::Exception( "Bookmark number must be between 1 and 9 (inclusive)." );
+	}
+
+	if( bookmark != m_bookmark )
+	{
+		m_bookmark = bookmark;
+		updateNode();
+	}
+}
+
+int NumericBookmarkSet::getBookmark() const
+{
+	return m_bookmark;
+}
+
+bool NumericBookmarkSet::contains( const Member *object ) const
+{
+	return m_node && m_node.get() == object;
+}
+
+Set::Member *NumericBookmarkSet::member( size_t index )
+{
+	return m_node.get();
+}
+
+const Set::Member *NumericBookmarkSet::member( size_t index ) const
+{
+	return m_node.get();
+}
+
+size_t NumericBookmarkSet::size() const
+{
+	return m_node ? 1 : 0;
+}
+
+void NumericBookmarkSet::metadataChanged( IECore::InternedString key, Gaffer::Node *node )
+{
+	if( MetadataAlgo::numericBookmarkAffectedByChange( key ) )
+	{
+		updateNode();
+	}
+}
+
+void NumericBookmarkSet::updateNode()
+{
+	Node *bookmarkedNode = MetadataAlgo::getNumericBookmark( m_script.get(), m_bookmark );
+
+	if( bookmarkedNode != m_node )
+	{
+		if( m_node )
+		{
+			NodePtr oldNode = m_node;
+			m_node.reset();
+			memberRemovedSignal()( this, oldNode.get() );
+		}
+
+		m_node = bookmarkedNode;
+
+		if( bookmarkedNode )
+		{
+			memberAddedSignal()( this, bookmarkedNode );
+		}
+	}
+}

--- a/src/GafferModule/SetBinding.cpp
+++ b/src/GafferModule/SetBinding.cpp
@@ -44,6 +44,7 @@
 #include "GafferBindings/SignalBinding.h"
 
 #include "Gaffer/ChildSet.h"
+#include "Gaffer/NumericBookmarkSet.h"
 #include "Gaffer/Set.h"
 #include "Gaffer/StandardSet.h"
 
@@ -206,6 +207,12 @@ void GafferModule::bindSet()
 
 	IECorePython::RunTimeTypedClass<ChildSet>()
 		.def( boost::python::init<GraphComponentPtr>() )
+	;
+
+	IECorePython::RunTimeTypedClass<NumericBookmarkSet>()
+		.def( boost::python::init<ScriptNodePtr, int>() )
+		.def( "setBookmark", &NumericBookmarkSet::setBookmark )
+		.def( "getBookmark", &NumericBookmarkSet::getBookmark )
 	;
 
 }

--- a/startup/gui/editor.py
+++ b/startup/gui/editor.py
@@ -81,11 +81,11 @@ def __addFollowMenuItem( menuDefinition, editor, targetEditor, subMenuTitle, mod
 		weakTarget = weakref.ref( targetEditor )
 
 		isCurrent = existingMode == mode if existingDriver is targetEditor else False
-		menuDefinition.insertBefore( "/%s/%s" % ( subMenuTitle, title ), {
-			"checkBox" : isCurrent,
-			"command" : None if isCurrent else lambda _ : weakEditor().setNodeSetDriver( weakTarget(), mode ),
-			"active" : not editor.drivesNodeSet( targetEditor )
-		}, "/ActionsDivider" )
+		menuDefinition.append( "/%s/%s" % ( subMenuTitle, title ), {
+			"command" : lambda _ : weakEditor().setNodeSetDriver( weakTarget(), mode ),
+			"active" : not editor.drivesNodeSet( targetEditor ) and not isCurrent,
+			"checkBox" : isCurrent
+		} )
 
 # Simple follows, eg: Hierarchy -> Viewer
 def __registerEditorNodeSetDriverItems( editor, menuDefinition ) :
@@ -110,7 +110,7 @@ def __registerEditorNodeSetDriverItems( editor, menuDefinition ) :
 		if target is not editor :
 			__addFollowMenuItem( menuDefinition,
 				editor, target,
-				"Linked to Editor",
+				"Follow/Editor",
 				GafferUI.NodeSetEditor.DriverModeNodeSet ,
 				itemNameCounts
 			)
@@ -132,18 +132,17 @@ def __registerNodeSetFollowsSceneSelectionItems( editor, menuDefinition ) :
 		if target is not editor :
 			__addFollowMenuItem( menuDefinition,
 				editor, target,
-				"Following Scene Selection",
+				"Follow/Scene Selection",
 				DriverModeSceneSelectionSource,
 				itemNameCounts
 			)
-
 
 ## Registration
 
 def __registerNodeSetMenuItems( editor, menuDefinition ) :
 
-	__registerEditorNodeSetDriverItems( editor, menuDefinition )
 	__registerNodeSetFollowsSceneSelectionItems( editor, menuDefinition )
+	__registerEditorNodeSetDriverItems( editor, menuDefinition )
 
 	GafferUI.GraphBookmarksUI.appendNodeSetMenuDefinitions( editor, menuDefinition )
 


### PR DESCRIPTION
## Summary

Allows `NodeSetEditor`s to persistently follow numeric bookmarks. This can be used to emulate global 'view' and 'edit' flags through conventions such as '1 = view, 2 = edit'.  It can also be used to avoid inadvertent view re-focusing, allowing editors to be easily re-focused, independently of the GraphEditor selection using the bookmark shortcuts.

This also re-arranges the pinning menu to make it hopefully a little more user friendly given the increase in options. 

## Bookmark Pinning

![image](https://user-images.githubusercontent.com/896779/64717203-aa4f5280-d478-11e9-9fc1-69cbcd5f4e76.png)

- Adds the `Gaffer.NumericBookmarkSet` - a `Gaffer.Set` implementation that maintains its membership to contain the Node associated with a specific numeric bookmark.

- Allows Editors to follow numeric bookmarks such that they always show the node associated with that bookmark.

This follows the implementation approach established by the `GafferSceneUI.SourceSet` mechanism for scene selection linking.

## User Facing Changes

 - The pinning menu now allows editors to follow numeric bookmarks. As the node associated with a numeric bookmark changes, then following editors will now show the new node. This can be used to emulate global 'view' and 'edit' flags if desired by forming conventions for the use of specific bookmark numbers.

 - The pinning menu has been re-arranged to better present the various options available.

Closes #3310 