### PR TITLE
0.53 release prep

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,15 @@
+0.53.6.5 (relative to 0.53.6.4)
+========
+
+Fixes
+-----
+
+- PythonCommand : Sequence mode now allows access to static variables without specifying the frame (#3262).
+- Execute app : Stopped current frame of saved script leaking into the context for TaskNode::executeSequence() (#3262).
+- GraphComponent : Fixed crashes caused by passing None as a child argument from Python (#3276, #3279).
+- Expression : Fixed bug whereby expressions could break if nodes were renamed during copy/paste (#3283).
+- CustomAttributes : Fixed performance regression caused by addition of the extraAttributes plug (#3280).
+
 0.53.6.4 (relative to 0.53.6.3)
 ========
 

--- a/SConstruct
+++ b/SConstruct
@@ -53,7 +53,7 @@ import subprocess
 gafferMilestoneVersion = 0 # for announcing major milestones - may contain all of the below
 gafferMajorVersion = 53 # backwards-incompatible changes
 gafferMinorVersion = 6 # new backwards-compatible features
-gafferPatchVersion = 4 # bug fixes
+gafferPatchVersion = 5 # bug fixes
 
 # All of the following must be considered when determining
 # whether or not a change is backwards-compatible

--- a/apps/execute/execute-1.py
+++ b/apps/execute/execute-1.py
@@ -163,6 +163,10 @@ class execute( Gaffer.Application ) :
 		if not frames :
 			frames = [ scriptNode.context().getFrame() ]
 
+		# We want to use the frame set by executeSequence.   Remove any possibility of
+		# accidentally using the default frame set in the script
+		del context["frame"]
+
 		with context :
 			for node in nodes :
 				errorConnection = node.errorSignal().connect( Gaffer.WeakMethod( self.__error ) )

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -92,6 +92,9 @@ class GAFFER_API ValuePlug : public Plug
 		/// as the default value. The default implementation is sufficient
 		/// for all subclasses except those where the number of child plugs
 		/// varies based on the value.
+		/// > Note : If a plug's value is being driven by a ComputeNode,
+		/// > we always consider it to be non-default, because it may vary
+		/// > by context. `isSetToDefault()` does not trigger computes.
 		virtual bool isSetToDefault() const;
 
 		/// Returns a hash to represent the value of this plug

--- a/python/GafferDispatch/PythonCommand.py
+++ b/python/GafferDispatch/PythonCommand.py
@@ -149,12 +149,13 @@ class _VariablesDict( dict ) :
 		return dict.__getitem__( self, key )
 
 	def __update( self ) :
+		frame = self.__context.get( "frame", "NO FRAME" )
 
-		if self.__frame == self.__context.getFrame() :
+		if self.__frame == frame :
 			return
 
-		if self.__context.getFrame() not in self.__validFrames :
-			raise ValueError( "Invalid frame" )
+		if frame != "NO FRAME" and frame not in self.__validFrames :
+			raise ValueError( "Cannot access variables at frame outside range specified for PythonCommand" )
 
 		self.clear()
 		for plug in self.__variables.children() :
@@ -166,7 +167,7 @@ class _VariablesDict( dict ) :
 
 			self[name] = value
 
-		self.__frame = self.__context.getFrame()
+		self.__frame = frame
 
 class _Parser( ast.NodeVisitor ) :
 

--- a/python/GafferDispatchTest/PythonCommandTest.py
+++ b/python/GafferDispatchTest/PythonCommandTest.py
@@ -259,10 +259,10 @@ class PythonCommandTest( GafferTest.TestCase ) :
 
 		s["n"] = GafferDispatch.PythonCommand()
 		s["n"]["sequence"].setValue( True )
-		s["n"]["variables"].addChild( Gaffer.NameValuePlug( "testInt", 42 ) )
+		s["n"]["variables"].addMember( "testInt", 42, "testInt" )
 
 		s["e"] = Gaffer.Expression()
-		s["e"].setExpression( "parent['n']['variables']['NameValuePlug']['value'] = context.getFrame() ** 2;", "python" )
+		s["e"].setExpression( "parent['n']['variables']['testInt']['value'] = context.getFrame() ** 2;", "python" )
 
 		commandLines = inspect.cleandoc(
 			"""
@@ -302,7 +302,7 @@ class PythonCommandTest( GafferTest.TestCase ) :
 
 		s["n"] = GafferDispatch.PythonCommand()
 		s["n"]["sequence"].setValue( True )
-		s["n"]["variables"].addChild( Gaffer.NameValuePlug( "testInt", 42 ) )
+		s["n"]["variables"].addMember( "testInt", 42, "testInt" )
 
 		commandLines = inspect.cleandoc(
 			"""

--- a/python/GafferSceneTest/CustomAttributesTest.py
+++ b/python/GafferSceneTest/CustomAttributesTest.py
@@ -317,6 +317,25 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 			} )
 		)
 
+	def testExtraAttributesOnlyEvaluatedForFilteredLocations( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["grid"] = GafferScene.Grid()
+
+		script["filter"] = GafferScene.PathFilter()
+		script["filter"]["paths"].setValue( IECore.StringVectorData( [ "/grid" ] ) )
+
+		script["customAttributes"] = GafferScene.CustomAttributes()
+		script["customAttributes"]["in"].setInput( script["grid"]["out"] )
+		script["customAttributes"]["filter"].setInput( script["filter"]["out"] )
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression( """parent["customAttributes"]["extraAttributes"] = IECore.CompoundData( { "a" : IECore.StringData( str( context.get( "scene:path" ) ) ) } )""" )
+
+		with Gaffer.ContextMonitor( script["expression"] ) as monitor :
+			GafferSceneTest.traverseScene( script["customAttributes"]["out"] )
+
+		self.assertEqual( monitor.combinedStatistics().numUniqueValues( "scene:path" ), 1 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -39,6 +39,7 @@ import os
 import inspect
 import unittest
 import imath
+import re
 
 import IECore
 
@@ -1412,6 +1413,102 @@ class ExpressionTest( GafferTest.TestCase ) :
 			del c["a"]
 			self.assertEqual( s["n"]["op1"].getValue(), 0 )
 			self.assertEqual( s["n"]["op2"].getValue(), 1 )
+
+	def testDuplicateDeserialise( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["source"] = GafferTest.CompoundNumericNode()
+		s["source"]["p"].setValue( imath.V3f( 0.1, 0.2, 0.3 ) )
+
+		s["dest"] = GafferTest.CompoundNumericNode()
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression(
+			"parent[\"dest\"][\"p\"]['x'] = parent[\"source\"][\"p\"]['x'] + 1;\n" +
+			"parent[\"dest\"][\"p\"]['y'] = parent[\"source\"][\"p\"]['y'] + 2;\n" +
+			"parent[\"dest\"][\"p\"]['z'] = parent[\"source\"][\"p\"]['z'] + 3;\n",
+			"python",
+		)
+
+		ss = s.serialise()
+
+		s.execute( ss )
+		s.execute( ss )
+
+		self.assertEqual( s["dest"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest1"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest2"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+
+		# Working well so far, but we've had a bug that could be hidden by the caching.  Lets
+		# try evaluating the plugs again, but flushing the cache each time
+
+		Gaffer.ValuePlug.clearCache()
+		self.assertEqual( s["dest"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest1"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest2"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		Gaffer.ValuePlug.clearCache()
+
+		# Now test that the expressions still serialise OK, because our process for loading
+		# expressions with misordered plugs could have messed something up
+		ss2 = s.serialise()
+		del s
+
+		s = Gaffer.ScriptNode()
+		s.execute( ss2 )
+		self.assertEqual( s["dest"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest1"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+		self.assertEqual( s["dest2"]["p"].getValue(), imath.V3f( 1.1, 2.2, 3.3 ) )
+
+	def testIndependentOfOrderOfPlugNames( self ) :
+
+		# We shouldn't depend on p0 being the first plug mentioned in the expression - as long as p0 is assigned
+		# correctly, the expression should still work
+
+		# Set up an expression with lots of plugs
+		s = Gaffer.ScriptNode()
+
+		exprLines = []
+		for i in range( 10 ):
+			s["source%i"%i] = GafferTest.CompoundNumericNode()
+			s["source%i"%i]["p"].setValue( imath.V3f( 0.1, 0.2, 0.3 ) + 0.3 * i )
+			s["dest%i"%i] = GafferTest.CompoundNumericNode()
+			for a in "xyz":
+				exprLines.append(
+					"parent[\"dest%i\"][\"p\"]['%s'] = parent[\"source%i\"][\"p\"]['%s'] + 10 * %i;" % (
+						i, a, i, a, i
+					)
+				)
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( "\n".join( exprLines ), "python" )
+
+		for i in range( 10 ):
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().x, 0.1 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().y, 0.2 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().z, 0.3 + 0.3 * i + 10 * i, places = 5 )
+
+		# Now serialize it, and reverse the order of all the lines in the expression before deserializing it
+		ss = s.serialise()
+
+		ssLines = ss.split( "\n" )
+		ssLinesEdited = []
+		for l in ssLines:
+			m = re.match( "^__children\[\"e\"\]\[\"__expression\"\].setValue\( '(.*)' \)$", l )
+			if not m:
+				ssLinesEdited.append( l )
+			else:
+				lines = m.groups()[0].split( "\\n" );
+				ssLinesEdited.append( "__children[\"e\"][\"__expression\"].setValue( '%s' )" % "\\n".join( lines[::-1] ) )
+
+		del s
+		s = Gaffer.ScriptNode()
+		s.execute( "\n".join( ssLinesEdited) )
+
+		for i in range( 10 ):
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().x, 0.1 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().y, 0.2 + 0.3 * i + 10 * i, places = 5 )
+			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().z, 0.3 + 0.3 * i + 10 * i, places = 5 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/GraphComponentTest.py
+++ b/python/GafferTest/GraphComponentTest.py
@@ -916,5 +916,18 @@ class GraphComponentTest( GafferTest.TestCase ) :
 		s.undo()
 		assertPreconditions()
 
+	def testNoneIsNotAGraphComponent( self ) :
+
+		g = Gaffer.GraphComponent()
+
+		with self.assertRaisesRegexp( Exception, r"did not match C\+\+ signature" ) :
+			g.addChild( None )
+
+		with self.assertRaisesRegexp( Exception, r"did not match C\+\+ signature" ) :
+			g.setChild( "x", None )
+
+		with self.assertRaisesRegexp( Exception, r"did not match C\+\+ signature" ) :
+			g.removeChild( None )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -280,7 +280,7 @@ class TestCase( unittest.TestCase ) :
 
 			for plug in node.children( Gaffer.Plug ) :
 
-				if plug.direction() != plug.Direction.In or not isinstance( plug, Gaffer.ValuePlug ) :
+				if plug.source().direction() != plug.Direction.In or not isinstance( plug, Gaffer.ValuePlug ) :
 					continue
 
 				if not plug.getFlags( plug.Flags.Serialisable ) :

--- a/python/GafferTest/ValuePlugTest.py
+++ b/python/GafferTest/ValuePlugTest.py
@@ -616,6 +616,44 @@ class ValuePlugTest( GafferTest.TestCase ) :
 		n["user"]["c"].setInput( None )
 		self.assertTrue( n["user"]["c"]["i"].getInput() is None )
 
+	def testIsSetToDefault( self ) :
+
+		n1 = GafferTest.AddNode()
+		self.assertTrue( n1["op1"].isSetToDefault() )
+		self.assertTrue( n1["op2"].isSetToDefault() )
+		self.assertFalse( n1["sum"].isSetToDefault() )
+
+		n1["op1"].setValue( 10 )
+		self.assertFalse( n1["op1"].isSetToDefault() )
+		self.assertTrue( n1["op2"].isSetToDefault() )
+
+		n1["op1"].setToDefault()
+		self.assertTrue( n1["op1"].isSetToDefault() )
+		self.assertTrue( n1["op2"].isSetToDefault() )
+
+		n2 = GafferTest.AddNode()
+		self.assertTrue( n2["op1"].isSetToDefault() )
+		self.assertTrue( n2["op2"].isSetToDefault() )
+		self.assertFalse( n2["sum"].isSetToDefault() )
+
+		n2["op1"].setInput( n1["op1"] )
+		# Receiving a static value via an input. We know
+		# it can have only one value for all contexts,
+		# and can be confident that it is set to the default.
+		self.assertTrue( n2["op1"].isSetToDefault() )
+		self.assertEqual( n2["op1"].getValue(), n2["op1"].defaultValue() )
+		n1["op1"].setValue( 1 )
+		# Until it provides a non-default value, that is.
+		self.assertFalse( n2["op1"].isSetToDefault() )
+
+		n1["op1"].setValue( 0 )
+		n2["op2"].setInput( n1["sum"] )
+		# Driven by a compute, so not considered to be
+		# at the default, even if it the result happens
+		# to be equal in this context.
+		self.assertFalse( n2["op2"].isSetToDefault() )
+		self.assertEqual( n2["op2"].getValue(), n2["op2"].defaultValue() )
+
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -515,6 +515,17 @@ void Expression::plugSet( const Plug *plug )
 	expression = transcribe( expression, /* toInternalForm = */ false );
 	std::vector<ValuePlug *> inPlugs, outPlugs;
 	m_engine->parse( this, expression, inPlugs, outPlugs, m_contextNames );
+
+	// Alas, it's not quite that simple. Nodes might have been renamed
+	// during deserialisation (to avoid name clashes between duplicates).
+	// And PythonExpressionEngine returns plugs in an order that depends
+	// on name, so our internal plugs may not correspond to what it is
+	// expecting. Call `updatePlugs()` to fix any mismatches. Transcribe
+	// to internal form to match the state that `setExpression()` leaves
+	// us in.
+	updatePlugs( inPlugs, outPlugs );
+	expressionPlug()->setValue( transcribe( expression, /* toInternalForm = */ true ) );
+
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -626,7 +626,18 @@ bool ValuePlug::isSetToDefault() const
 {
 	if( m_defaultValue != nullptr )
 	{
-		return getObjectValue()->isEqualTo( m_defaultValue.get() );
+		const ValuePlug *s = source<ValuePlug>();
+		if( s->direction() == Plug::Out && IECore::runTimeCast<const ComputeNode>( s->node() ) )
+		{
+			// Value is computed, and therefore can vary by context. There is no
+			// single "current value", so no true concept of whether or not it's at
+			// the default.
+			return false;
+		}
+		return
+			s->m_staticValue == m_defaultValue ||
+			s->m_staticValue->isEqualTo( m_defaultValue.get() );
+		;
 	}
 	else
 	{

--- a/src/GafferModule/GraphComponentBinding.cpp
+++ b/src/GafferModule/GraphComponentBinding.cpp
@@ -114,22 +114,22 @@ boost::python::tuple children( GraphComponent &c, IECore::TypeId typeId )
 	return boost::python::tuple( l );
 }
 
-void addChild( GraphComponent &g, GraphComponentPtr c )
+void addChild( GraphComponent &g, GraphComponent &c )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	g.addChild( c );
+	g.addChild( &c );
 }
 
-void setChild( GraphComponent &g, const IECore::InternedString &n, GraphComponentPtr c )
+void setChild( GraphComponent &g, const IECore::InternedString &n, GraphComponent &c )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	g.setChild( n, c );
+	g.setChild( n, &c );
 }
 
-void removeChild( GraphComponent &g, GraphComponentPtr c )
+void removeChild( GraphComponent &g, GraphComponent &c )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	g.removeChild( c );
+	g.removeChild( &c );
 }
 
 void clearChildren( GraphComponent &g )

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -702,7 +702,11 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 
 			for( int i = 0, e = inPlugPaths.size(); i < e; ++i )
 			{
-				string parameter = "_" + inPlugPaths[i];
+				string parameter = inPlugPaths[i];
+				if( parameter[0] != '_' )
+				{
+					parameter = "_" + parameter;
+				}
 				replace_all( parameter, ".", "_" );
 				replace_all( result, "parent." + inPlugPaths[i], parameter );
 				inParameters.push_back( ustring( parameter ) );
@@ -710,7 +714,11 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 
 			for( int i = 0, e = outPlugPaths.size(); i < e; ++i )
 			{
-				string parameter = "_" + outPlugPaths[i];
+				string parameter = outPlugPaths[i];
+				if( parameter[0] != '_' )
+				{
+					parameter = "_" + parameter;
+				}
 				replace_all( parameter, ".", "_" );
 				replace_all( result, "parent." + outPlugPaths[i], parameter );
 				outParameters.push_back( ustring( parameter ) );

--- a/src/GafferScene/Attributes.cpp
+++ b/src/GafferScene/Attributes.cpp
@@ -179,9 +179,7 @@ bool Attributes::processesAttributes() const
 {
 	// Although the base class says that we should return a constant, it should
 	// be OK to return this because it's constant across the hierarchy.
-	IECore::ConstCompoundDataPtr extraAttributesData = extraAttributesPlug()->getValue();
-	const IECore::CompoundDataMap &extraAttributes = extraAttributesData->readable();
-	return ( attributesPlug()->children().size() || !extraAttributes.empty() ) && !globalPlug()->getValue();
+	return ( attributesPlug()->children().size() || !extraAttributesPlug()->isSetToDefault() ) && !globalPlug()->getValue();
 }
 
 void Attributes::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const


### PR DESCRIPTION
Backports from 0.54 to 0.53

Fixes
-----

- PythonCommand : Sequence mode now allows access to static variables without specifying the frame (#3262).
- Execute app : Stopped current frame of saved script leaking into the context for TaskNode::executeSequence() (#3262).
- GraphComponent : Fixed crashes caused by passing None as a child argument from Python (#3276, #3279).
- Expression : Fixed bug whereby expressions could break if nodes were renamed during copy/paste (#3283).
- CustomAttributes : Fixed performance regression caused by addition of the extraAttributes plug (#3280).
