### PR TITLE
Support Attribute Substitutions In Shaders, Round 2

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -171,9 +171,9 @@ dlVersion = getOption( "DL_VERSION", os.environ.get( "DL_VERSION", "" ) )
 
 try :
 	dlReg = IEEnv.registry["apps"]["3delight"][dlVersion][IEEnv.platform()]
-	RMAN_ROOT = dlReg["location"]
+	DELIGHT_ROOT = dlReg["location"]
 except :
-	RMAN_ROOT = ""
+	DELIGHT_ROOT = ""
 
 appleseedVersion = getOption( "APPLESEED_VERSION", os.environ.get( "APPLESEED_VERSION", "" ) )
 try :

--- a/config/installDependencies.sh
+++ b/config/installDependencies.sh
@@ -55,7 +55,7 @@ buildDir=${1:-"build/gaffer-$gafferMilestoneVersion.$gafferMajorVersion.$gafferM
 
 # Get the prebuilt dependencies package and unpack it into the build directory
 
-dependenciesVersion="0.54.0.0"
+dependenciesVersion="0.54.1.0"
 dependenciesVersionSuffix=""
 dependenciesFileName="gafferDependencies-$dependenciesVersion-$platform.tar.gz"
 downloadURL="https://github.com/GafferHQ/dependencies/releases/download/$dependenciesVersion$dependenciesVersionSuffix/$dependenciesFileName"

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -1219,12 +1219,10 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["cubeAttrs"]["in"].setInput( s["cube"]["out"] )
 		s["cubeAttrs"]["attributes"].addChild( Gaffer.NameValuePlug( "B", Gaffer.StringPlug( "value", defaultValue = 'override' ) ) )
 
-		
 		s["parent"] = GafferScene.Parent()
 		s["parent"]["in"].setInput( s["planeAttrs"]["out"] )
 		s["parent"]["child"].setInput( s["cubeAttrs"]["out"] )
 		s["parent"]["parent"].setValue( "/plane" )
-
 
 		s["shader"] = GafferArnold.ArnoldShader()
 		s["shader"].loadShader( "image" )
@@ -1238,9 +1236,49 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["shaderAssignment"]["filter"].setInput( s["filter"]["out"] )
 		s["shaderAssignment"]["shader"].setInput( s["shader"]["out"] )
 
+		s["light"] = GafferArnold.ArnoldLight()
+		s["light"].loadShader( "photometric_light" )
+		s["light"]["parameters"]["filename"].setValue( "/path/<attr:A>.ies" )
+
+		s["goboTexture"] = GafferArnold.ArnoldShader()
+		s["goboTexture"].loadShader( "image" )
+		s["goboTexture"]["parameters"]["filename"].setValue( "<attr:B>/gobo.tx" )
+
+		s["gobo"] = GafferArnold.ArnoldShader()
+		s["gobo"].loadShader( "gobo" )
+		s["gobo"]["parameters"]["slidemap"].setInput( s["goboTexture"]["out"] )
+
+		s["goboAssign"] = GafferScene.ShaderAssignment()
+		s["goboAssign"]["in"].setInput( s["light"]["out"] )
+		s["goboAssign"]["shader"].setInput( s["gobo"]["out"] )
+
+		
+		s["lightBlocker"] = GafferArnold.ArnoldLightFilter()
+		s["lightBlocker"].loadShader( "light_blocker" )
+		s["lightBlocker"]["parameters"]["geometry_type"].setValue( "<attr:geometryType>" )
+		#s["lightBlocker"]["parameters"]["geometry_type"].setValue( "plane" )
+
+
+		s["lightGroup"] = GafferScene.Group()
+		s["lightGroup"]["name"].setValue( "lightGroup" )
+		s["lightGroup"]["in"][0].setInput( s["goboAssign"]["out"] )
+		s["lightGroup"]["in"][1].setInput( s["lightBlocker"]["out"] )
+
+		s["parent2"] = GafferScene.Parent()
+		s["parent2"]["in"].setInput( s["shaderAssignment"]["out"] )
+		s["parent2"]["child"].setInput( s["lightGroup"]["out"] )
+		s["parent2"]["parent"].setValue( "/" )
+
+		s["globalAttrs"] = GafferScene.CustomAttributes()
+		s["globalAttrs"]["in"].setInput( s["parent2"]["out"] )
+		s["globalAttrs"]["global"].setValue( True )
+		s["globalAttrs"]["attributes"].addChild( Gaffer.NameValuePlug( "A", Gaffer.StringPlug( "value", defaultValue = 'default1' ) ) )
+		s["globalAttrs"]["attributes"].addChild( Gaffer.NameValuePlug( "B", Gaffer.StringPlug( "value", defaultValue = 'default2' ) ) )
+		s["globalAttrs"]["attributes"].addChild( Gaffer.NameValuePlug( "geometryType", Gaffer.StringPlug( "value", defaultValue = 'cylinder' ) ) )
+
 
 		s["render"] = GafferArnold.ArnoldRender()
-		s["render"]["in"].setInput( s["shaderAssignment"]["out"] )
+		s["render"]["in"].setInput( s["globalAttrs"]["out"] )
 		s["render"]["mode"].setValue( s["render"].Mode.SceneDescriptionMode )
 		s["render"]["fileName"].setValue( self.temporaryDirectory() + "/test.ass" )
 
@@ -1257,6 +1295,15 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 			shader2 = arnold.AiNodeGetPtr( cube, "shader" )
 			self.assertEqual( arnold.AiNodeGetStr( shader2, "filename" ), "bar/path/override.tx" )
 
+			light = arnold.AiNodeLookUpByName( "light:/lightGroup/light" )
+			self.assertEqual( arnold.AiNodeGetStr( light, "filename" ), "/path/default1.ies" )
+
+			gobo = arnold.AiNodeGetPtr( light, "filters" )
+			goboTex = arnold.AiNodeGetLink( gobo, "slidemap" )
+			self.assertEqual( arnold.AiNodeGetStr( goboTex, "filename" ), "default2/gobo.tx" )
+
+			lightFilter = arnold.AiNodeLookUpByName( "lightFilter:/lightGroup/lightFilter" )
+			self.assertEqual( arnold.AiNodeGetStr( lightFilter, "geometry_type" ), "cylinder" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -225,6 +225,24 @@ bool aiVersionLessThan( int arch, int major, int minor, int patch )
 	);
 }
 
+void substituteShaderIfNecessary( IECoreScene::ConstShaderNetworkPtr &shaderNetwork, const IECore::CompoundObject *attributes )
+{
+	if( !shaderNetwork )
+	{
+		return;
+	}
+
+	IECore::MurmurHash h;
+	shaderNetwork->hashSubstitutions( attributes, h );
+	if( h != IECore::MurmurHash() )
+	{
+		IECoreScene::ShaderNetworkPtr substituted = shaderNetwork->copy();
+		substituted->applySubstitutions( attributes );
+		shaderNetwork = substituted;
+	}
+}
+
+
 const AtString g_aaSamplesArnoldString( "AA_samples" );
 const AtString g_aaSeedArnoldString( "AA_seed" );
 const AtString g_aovShadersArnoldString( "aov_shaders" );
@@ -812,8 +830,10 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 			m_lightShader = attribute<IECoreScene::ShaderNetwork>( g_arnoldLightShaderAttributeName, attributes );
 			m_lightShader = m_lightShader ? m_lightShader : attribute<IECoreScene::ShaderNetwork>( g_lightShaderAttributeName, attributes );
+			substituteShaderIfNecessary( m_lightShader, attributes );
 
 			m_lightFilterShader = attribute<IECoreScene::ShaderNetwork>( g_arnoldLightFilterShaderAttributeName, attributes );
+			substituteShaderIfNecessary( m_lightFilterShader, attributes );
 
 			m_traceSets = attribute<IECore::InternedStringVectorData>( g_setsAttributeName, attributes );
 			m_transformType = attribute<IECore::StringData>( g_transformTypeAttributeName, attributes );


### PR DESCRIPTION
OK, as suggested in #3295, I've now moved substitutions into the backend.  Definitely simpler, and gets rid of the concern about the possible size of the extra intermediate shader cache.

Sorry, still haven't gotten to the performance profiling part, got sidetracked by rejiggering this and dealing with some other stuff.

Other open questions:  should I support substitutions in light shaders or global shaders ( like AOV shaders )?  I realized that I currently support substitutions in m_lightFilterShaders but not m_lightFilterShader, because I added it on the cache, and one goes through the cache and one doesn't.  I guess the simplest solution would just be don't pass in attributes when retrieving m_lightFilterShaders from the cache, to consistently disable substitutions.  But I don't really understand why some things are in the cache and other things aren't, and maybe substitutions on light filters would be useful ( texture paths on gobos seem like a plausible target ).  Hmm.