### PR TITLE
Metadata Lookup Issue

### DIFF
--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -283,8 +283,9 @@ def __translateNodeMetadata( nodeEntry ) :
 			userDefault = __aiMetadataGetStr( nodeEntry, paramName, "gaffer.userDefault" )
 
 		if userDefault:
-			__metadata[paramPath]["userDefault"] = userDefault
-			
+			nodeName, _, plugName = paramPath.split( "." )
+			Gaffer.Metadata.registerValue( "ai:surface:%s:%s" % ( nodeName, plugName ), "userDefault", userDefault )
+
 
 with IECoreArnold.UniverseBlock( writable = False ) :
 

--- a/python/GafferArnoldUITest/ArnoldShaderUITest.py
+++ b/python/GafferArnoldUITest/ArnoldShaderUITest.py
@@ -189,7 +189,16 @@ root["SceneWriter"].execute()
 		self.assertEqual( parms["uvcoords"].value, imath.V2f( 12, 13 ) )
 		self.assertEqual( parms["filename"].value, "overrideUserDefault" )
 		self.assertEqual( parms["filter"].value, "bilinear" )
-		
+
+	def testBaseClassMetadataLookup( self ) :
+
+		surface = GafferArnold.ArnoldShader()
+		surface.loadShader( "standard_surface" )
+
+		# Make sure that metadata registration based on mechanism in GafferScene.ShaderUI works
+		Gaffer.Metadata.registerValue( "ai:surface:standard_surface:aov_id1", "userDefault", "id_1" )
+
+		self.assertEqual( Gaffer.Metadata.value( surface["parameters"]["aov_id1"], "userDefault" ), "id_1" )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Hey John,

this took me a while to track down and it might not be the best fix - could you take a look? 

**Background:**
Arnold changed some default values for shader parameters in a recent update and we've counteracted that on some shows by putting the old values in an mtd file. That broke metadata lookups of data that was registered through the 

`Gaffer.Metadata.registerValue( "ai:surface:standard_surface:<parameterName>", "userDefault", "defaultValue" )`

mechanism (that's a feature of the shader base class). My intuition is that registering those old defaults via mtd on _other_ plugs shouldn't break the lookup for existing entries that are somewhat unrelated and only share the 'userDefault' key with the new entry. Does that make sense?

I've added a test that illustrates the problem. Maybe the fix should be that the method registered to lookup the plug values passes on that lookup to the base class to figure out if there were any values registered through the syntax mentioned above? Is that function now solely responsible for the lookup or should the logic live in Metadata.cpp (that's what I've done in this PR)?

Thanks :)

Matti.