### PR TITLE
Fixed a few issues when saving a script while executing a task

### DIFF
--- a/python/GafferDispatchTest/ExecuteApplicationTest.py
+++ b/python/GafferDispatchTest/ExecuteApplicationTest.py
@@ -45,6 +45,8 @@ import imath
 import IECore
 
 import Gaffer
+import GafferDispatch
+
 import GafferTest
 import GafferDispatchTest
 
@@ -329,6 +331,47 @@ class ExecuteApplicationTest( GafferTest.TestCase ) :
 			open( s["t"]["fileName"].getValue() ).read(),
 			"0.0 1.0 2.0"
 		)
+
+	def testCanSerialiseFrameDependentPlugs( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["PythonCommand"] = GafferDispatch.PythonCommand()
+		s["PythonCommand"]["command"].setValue(
+			inspect.cleandoc( """
+				import os
+				import GafferDispatchTest
+
+				tmpDir = os.path.dirname( self.scriptNode()["fileName"].getValue() )
+				s = Gaffer.ScriptNode()
+				s["t"] = GafferDispatchTest.TextWriter()
+				s["t"]["fileName"].setValue( tmpDir + "/test.####.txt" )
+				s["t"]["text"].setValue( "test" )
+				s["fileName"].setValue( tmpDir + "/canSerialiseFrameDependentPlug.gfr" )
+				s.save()
+			""" )
+		)
+
+		def validate( sequence ) :
+
+			s["PythonCommand"]["sequence"].setValue( sequence )
+
+			s["fileName"].setValue( self.__scriptFileName )
+			s.context().setFrame( 10 )
+			s.save()
+
+			subprocess.check_call( [ "gaffer", "execute", self.__scriptFileName, "-frames", "5", "-nodes", "PythonCommand" ] )
+
+			self.assertTrue( os.path.exists( self.temporaryDirectory() + "/canSerialiseFrameDependentPlug.gfr" ) )
+
+			ss = Gaffer.ScriptNode()
+			ss["fileName"].setValue( self.temporaryDirectory() + "/canSerialiseFrameDependentPlug.gfr" )
+			ss.load()
+
+			# we must retain the non-substituted value
+			self.assertEqual( ss["t"]["fileName"].getValue(), "{}/test.####.txt".format( self.temporaryDirectory() ) )
+
+		validate( sequence = True )
+		validate( sequence = False )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -199,6 +199,7 @@ boost::python::object executionDict( ScriptNodePtr script, NodePtr parent )
 
 std::string serialise( const Node *parent, const Set *filter )
 {
+	IECorePython::ScopedGILLock gilLock;
 	if( !Py_IsInitialized() )
 	{
 		Py_Initialize();


### PR DESCRIPTION
This first issue is a SIGSEGV, caused by a mismanaged GIL. Once the crash is out of the way, we run into 2 more issues, demonstrated in e68de1304aaa4eccd849f84959d7e99150090d07. In sequence mode the PythonCommand errors, whereas in individual frame mode it unexpectedly substitutes the plug value.

The proposed fix in 5a1e0389dad8a32d7ee642244b60a8a7d2326e9e isn't necessarily ideal, in that it adds some overhead to `StringPlug::getValue()`, but hopefully that has been protected enough behind the other `performSubstitutions` checks that it doesn't come up too often in practice.

I added a comment recording some offline discussion there, regarding making serialisation a Process of its own and changing this "relevant process" check to test process type instead.