### PR TITLE
 ScriptNode : Fix bug that baked string substitutions into serialisations 

### DIFF
--- a/python/GafferDispatchTest/ExecuteApplicationTest.py
+++ b/python/GafferDispatchTest/ExecuteApplicationTest.py
@@ -45,6 +45,8 @@ import imath
 import IECore
 
 import Gaffer
+import GafferDispatch
+
 import GafferTest
 import GafferDispatchTest
 
@@ -329,6 +331,47 @@ class ExecuteApplicationTest( GafferTest.TestCase ) :
 			open( s["t"]["fileName"].getValue() ).read(),
 			"0.0 1.0 2.0"
 		)
+
+	def testCanSerialiseFrameDependentPlugs( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["PythonCommand"] = GafferDispatch.PythonCommand()
+		s["PythonCommand"]["command"].setValue(
+			inspect.cleandoc( """
+				import os
+				import GafferDispatchTest
+
+				tmpDir = os.path.dirname( self.scriptNode()["fileName"].getValue() )
+				s = Gaffer.ScriptNode()
+				s["t"] = GafferDispatchTest.TextWriter()
+				s["t"]["fileName"].setValue( tmpDir + "/test.####.txt" )
+				s["t"]["text"].setValue( "test" )
+				s["fileName"].setValue( tmpDir + "/canSerialiseFrameDependentPlug.gfr" )
+				s.save()
+			""" )
+		)
+
+		def validate( sequence ) :
+
+			s["PythonCommand"]["sequence"].setValue( sequence )
+
+			s["fileName"].setValue( self.__scriptFileName )
+			s.context().setFrame( 10 )
+			s.save()
+
+			subprocess.check_call( [ "gaffer", "execute", self.__scriptFileName, "-frames", "5", "-nodes", "PythonCommand" ] )
+
+			self.assertTrue( os.path.exists( self.temporaryDirectory() + "/canSerialiseFrameDependentPlug.gfr" ) )
+
+			ss = Gaffer.ScriptNode()
+			ss["fileName"].setValue( self.temporaryDirectory() + "/canSerialiseFrameDependentPlug.gfr" )
+			ss.load()
+
+			# we must retain the non-substituted value
+			self.assertEqual( ss["t"]["fileName"].getValue(), "{}/test.####.txt".format( self.temporaryDirectory() ) )
+
+		validate( sequence = True )
+		validate( sequence = False )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -204,6 +204,8 @@ std::string serialise( const Node *parent, const Set *filter )
 		Py_Initialize();
 	}
 
+	IECorePython::ScopedGILLock gilLock;
+
 	std::string result;
 	try
 	{

--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -45,6 +45,7 @@
 #include "Gaffer/ApplicationRoot.h"
 #include "Gaffer/CompoundDataPlug.h"
 #include "Gaffer/Context.h"
+#include "Gaffer/Monitor.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StandardSet.h"
 #include "Gaffer/StringPlug.h"
@@ -205,6 +206,19 @@ std::string serialise( const Node *parent, const Set *filter )
 	}
 
 	IECorePython::ScopedGILLock gilLock;
+
+	// Remove current Process from ThreadState, because it would
+	// cause `StringPlug::getValue()` to perform unwanted substitutions
+	// that would accidentally be baked into the serialisation.
+	/// \todo Consider having a serialisation process instead (and
+	/// perhaps a more general concept of a non-computing process)
+	/// and making StringPlug skip substitutions when it sees one.
+	const Context *context = Context::current();
+	const Monitor::MonitorSet &monitors = Monitor::current();
+	const ThreadState defaultThreadState;
+	ThreadState::Scope defaultThreadStateScope( defaultThreadState );
+	Context::Scope contextScope( context );
+	Monitor::Scope monitorScope( monitors );
 
 	std::string result;
 	try


### PR DESCRIPTION
This is a variation of #3338 that occurred to me overnight. I prefer it because it is guaranteed to have no additional overhead in the often-called `StringPlug::getValue()`, with the trade-off being a tiny bit of extra overhead in the not-often-called `serialise()`. I also realised that FormatPlug has a similar substitution mechanism to StringPlug which wasn't being addressed by #3338, but is addressed by this.