### PR TITLE
StandardAttributesUI : Fix set expression metadata

### DIFF
--- a/python/GafferSceneUI/StandardAttributesUI.py
+++ b/python/GafferSceneUI/StandardAttributesUI.py
@@ -187,6 +187,11 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Light Linking",
 			"label", "Linked Lights",
+
+		],
+
+		"attributes.linkedLights.value" : [
+
 			"ui:scene:acceptsSetExpression", True,
 
 		],
@@ -203,6 +208,11 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Light Linking",
 			"label", "Filtered Lights",
+
+		],
+
+		"attributes.filteredLights.value" : [
+
 			"ui:scene:acceptsSetExpression", True,
 
 		],


### PR DESCRIPTION
It was being registered for the wrong plug, and breaking the popup menus with this error :

```
  File "/disk1/john/dev/build/gaffer/python/GafferSceneUI/SetUI.py", line 185, in __setsPopupMenu
    currentExpression = plug.getValue()
AttributeError: 'NameValuePlug' object has no attribute 'getValue'
```
