### PR TITLE
SConstruct : Include renderer roots in child command environment

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -545,6 +545,12 @@ else :
 
 commandEnv["ENV"]["PYTHONPATH"] = commandEnv.subst( ":".join( split( commandEnv["LOCATE_DEPENDENCY_PYTHONPATH"] ) ) )
 
+# SIP on MacOS prevents DYLD_LIBRARY_PATH being passed down so we make sure
+# we also pass through to gaffer the other base vars it uses to populate paths
+# for third-party support.
+for v in ( 'ARNOLD_ROOT', 'DELIGHT_ROOT' ) :
+	commandEnv["ENV"][ v ] = commandEnv[ v ]
+
 def runCommand( command ) :
 
 	command = commandEnv.subst( command )


### PR DESCRIPTION
Passing DYLD_LIBRARY_PATH via the env argument is blocked when SIP is
enabled on OSX. As we only run `gaffer` via generateDocs, the wrapper
will take care of setting DYLD_ etc. assuming ARNOLD_ROOT, etc.. are
set correctly.