### PR TITLE
NameSwitch

### DIFF
--- a/include/Gaffer/ArrayPlug.h
+++ b/include/Gaffer/ArrayPlug.h
@@ -65,7 +65,8 @@ class GAFFER_API ArrayPlug : public Plug
 			PlugPtr element = nullptr,
 			size_t minSize = 1,
 			size_t maxSize = Imath::limits<size_t>::max(),
-			unsigned flags = Default
+			unsigned flags = Default,
+			bool resizeWhenInputsChange = true
 		);
 
 		~ArrayPlug() override;
@@ -79,6 +80,12 @@ class GAFFER_API ArrayPlug : public Plug
 
 		size_t minSize() const;
 		size_t maxSize() const;
+		void resize( size_t size );
+		bool resizeWhenInputsChange() const;
+		/// Returns an unconnected element at the end of the array, adding one
+		/// if necessary. Returns null if `maxSize()` prevents the creation of
+		/// a new element.
+		Gaffer::Plug *next();
 
 	protected :
 
@@ -90,6 +97,7 @@ class GAFFER_API ArrayPlug : public Plug
 
 		size_t m_minSize;
 		size_t m_maxSize;
+		bool m_resizeWhenInputsChange;
 
 		boost::signals::scoped_connection m_inputChangedConnection;
 

--- a/include/Gaffer/NameSwitch.h
+++ b/include/Gaffer/NameSwitch.h
@@ -1,0 +1,82 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_NAMESWITCH_H
+#define GAFFER_NAMESWITCH_H
+
+#include "Gaffer/Switch.h"
+
+namespace Gaffer
+{
+
+class StringPlug;
+
+class IECORE_EXPORT NameSwitch : public Switch
+{
+
+	public :
+
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( Gaffer::NameSwitch, NameSwitchTypeId, Switch );
+
+		NameSwitch( const std::string &name=GraphComponent::defaultName<NameSwitch>() );
+		~NameSwitch() override;
+
+		void setup( const Plug *plug );
+
+		StringPlug *selectorPlug();
+		const StringPlug *selectorPlug() const;
+
+		void affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
+		void compute( ValuePlug *output, const Context *context ) const override;
+
+	private :
+
+		IntPlug *outIndexPlug();
+		const IntPlug *outIndexPlug() const;
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( NameSwitch );
+
+} // namespace Gaffer
+
+#endif // GAFFER_NAMESWITCH_H

--- a/include/Gaffer/Switch.h
+++ b/include/Gaffer/Switch.h
@@ -100,8 +100,6 @@ class IECORE_EXPORT Switch : public ComputeNode
 
 	private :
 
-		void init( bool expectBaseClassPlugs );
-
 		void childAdded( GraphComponent *child );
 		void plugSet( Plug *plug );
 		void plugInputChanged( Plug *plug );

--- a/include/Gaffer/Switch.h
+++ b/include/Gaffer/Switch.h
@@ -107,7 +107,7 @@ class IECORE_EXPORT Switch : public ComputeNode
 
 		// Returns the input corresponding to the output and vice versa. Returns null
 		// if plug is not meaningful to the switching process.
-		const Plug *oppositePlug( const Plug *plug, size_t inputIndex = 0 ) const;
+		const Plug *oppositePlug( const Plug *plug, const Context *context = nullptr ) const;
 
 		bool variesWithContext( const Plug *plug ) const;
 

--- a/include/Gaffer/Switch.h
+++ b/include/Gaffer/Switch.h
@@ -72,8 +72,15 @@ class IECORE_EXPORT Switch : public ComputeNode
 
 		/// Returns the input plug which will be passed through
 		/// by the switch in the current context.
+		/// \todo Remove, and add `nullptr` default to the version
+		/// below.
 		Plug *activeInPlug();
 		const Plug *activeInPlug() const;
+		/// Returns the input plug which will be passed through
+		/// by the switch when evaluating `outPlug` in the
+		/// current context.
+		Plug *activeInPlug( const Plug *outPlug );
+		const Plug *activeInPlug( const Plug *outPlug ) const;
 
 		IntPlug *indexPlug();
 		const IntPlug *indexPlug() const;

--- a/include/Gaffer/TypeIds.h
+++ b/include/Gaffer/TypeIds.h
@@ -101,7 +101,7 @@ enum TypeId
 	InternedStringVectorDataPlugTypeId = 110054,
 	SplinefColor4fPlugTypeId = 110055,
 	NumericBookmarkSetTypeId = 110056,
-	DispatcherTypeId = 110057, // obsolete - available for reuse
+	NameSwitchTypeId = 110057,
 	Transform2DPlugTypeId = 110058,
 	ReferenceTypeId = 110059,
 	ComputeNodeTypeId = 110060,

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -1688,6 +1688,38 @@ class DispatcherTest( GafferTest.TestCase ) :
 			self.assertEqual( len( s["n2"].log ), 2 )
 			self.assertEqual( len( s["n3"].log ), 5 )
 
+	def testNameSwitch( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n1"] = GafferDispatchTest.LoggingTaskNode()
+		s["n2"] = GafferDispatchTest.LoggingTaskNode()
+
+		s["switch"] = Gaffer.NameSwitch()
+		s["switch"].setup( s["n1"]["task"] )
+		s["switch"]["in"][0]["value"].setInput( s["n1"]["task"] )
+		s["switch"]["in"][1]["value"].setInput( s["n2"]["task"] )
+		s["switch"]["in"][1]["name"].setValue( "n2" )
+
+		s["n3"] = GafferDispatchTest.LoggingTaskNode()
+		s["n3"]["preTasks"][0].setInput( s["switch"]["out"]["value"] )
+
+		dispatcher = GafferDispatch.Dispatcher.create( "testDispatcher" )
+
+		s["switch"]["selector"].setValue( "n2" )
+		dispatcher.dispatch( [ s["n3"] ] )
+
+		self.assertEqual( len( s["n1"].log ), 0 )
+		self.assertEqual( len( s["n2"].log ), 1 )
+		self.assertEqual( len( s["n3"].log ), 1 )
+
+		s["switch"]["selector"].setValue( "n1" )
+		dispatcher.dispatch( [ s["n3"] ] )
+
+		self.assertEqual( len( s["n1"].log ), 1 )
+		self.assertEqual( len( s["n2"].log ), 1 )
+		self.assertEqual( len( s["n3"].log ), 2 )
+
 	def testContextProcessor( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferSceneUI/HierarchyView.py
+++ b/python/GafferSceneUI/HierarchyView.py
@@ -122,9 +122,8 @@ class HierarchyView( GafferUI.NodeSetEditor ) :
 		self.__plugParentChangedConnection = None
 		node = self._lastAddedNode()
 		if node is not None :
-			outputScenePlugs = [ p for p in node.children( GafferScene.ScenePlug ) if p.direction() == Gaffer.Plug.Direction.Out ]
-			if len( outputScenePlugs ) :
-				self.__plug = outputScenePlugs[0]
+			self.__plug = next( GafferScene.ScenePlug.RecursiveOutputRange( node ), None )
+			if self.__plug is not None :
 				self.__plugParentChangedConnection = self.__plug.parentChangedSignal().connect( Gaffer.WeakMethod( self.__plugParentChanged ) )
 
 		# call base class update - this will trigger a call to _titleFormat(),

--- a/python/GafferSceneUI/PrimitiveInspector.py
+++ b/python/GafferSceneUI/PrimitiveInspector.py
@@ -234,13 +234,10 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 		node = self._lastAddedNode()
 
 		if node :
-
-			outputScenePlugs = [p for p in node.children( GafferScene.ScenePlug ) if p.direction() == Gaffer.Plug.Direction.Out]
-
-			if len( outputScenePlugs ) :
-				self.__scenePlug = outputScenePlugs[0]
+			self.__scenePlug = next( GafferScene.ScenePlug.RecursiveOutputRange( node ), None )
+			if self.__scenePlug :
 				self.__plugDirtiedConnections.append( node.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ) ) )
-				self.__parentChangedConnections.append( outputScenePlugs[0].parentChangedSignal().connect( Gaffer.WeakMethod( self.__plugParentChanged ) ) )
+				self.__parentChangedConnections.append( self.__scenePlug.parentChangedSignal().connect( Gaffer.WeakMethod( self.__plugParentChanged ) ) )
 
 		self.__updateLazily()
 

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -226,11 +226,11 @@ class SceneInspector( GafferUI.NodeSetEditor ) :
 		self.__plugDirtiedConnections = []
 		self.__parentChangedConnections = []
 		for node in self.getNodeSet()[-2:] :
-			outputScenePlugs = [ p for p in node.children( GafferScene.ScenePlug ) if p.direction() == Gaffer.Plug.Direction.Out ]
-			if len( outputScenePlugs ) :
-				self.__scenePlugs.append( outputScenePlugs[0] )
+			outputScenePlug = next( GafferScene.ScenePlug.RecursiveOutputRange( node ), None )
+			if outputScenePlug :
+				self.__scenePlugs.append( outputScenePlug )
 				self.__plugDirtiedConnections.append( node.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ) ) )
-				self.__parentChangedConnections.append( outputScenePlugs[0].parentChangedSignal().connect( Gaffer.WeakMethod( self.__plugParentChanged ) ) )
+				self.__parentChangedConnections.append( outputScenePlug.parentChangedSignal().connect( Gaffer.WeakMethod( self.__plugParentChanged ) ) )
 
 		self.__updateLazily()
 

--- a/python/GafferSceneUI/UVInspector.py
+++ b/python/GafferSceneUI/UVInspector.py
@@ -87,10 +87,7 @@ class UVInspector( GafferUI.NodeSetEditor ) :
 
 		scene = None
 		if len( self.getNodeSet() ) :
-			for p in self.getNodeSet()[-1].children( GafferScene.ScenePlug ) :
-				if p.direction() == Gaffer.Plug.Direction.Out :
-					scene = p
-					break
+			scene = next( GafferScene.ScenePlug.RecursiveOutputRange( self.getNodeSet()[-1] ), None )
 
 		self.__uvView["in"].setInput( scene )
 

--- a/python/GafferTest/ArrayPlugTest.py
+++ b/python/GafferTest/ArrayPlugTest.py
@@ -441,6 +441,9 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 		s["n"]["user"]["p"][0].setInput( None )
 		self.assertEqual( len( s["n"]["user"]["p"] ), 1 )
 
+		p = s["n"]["user"]["p"].createCounterpart( "p", Gaffer.Plug.Direction.In )
+		self.assertEqual( p.resizeWhenInputsChange(), False )
+
 	def testNext( self ) :
 
 		a = GafferTest.AddNode()

--- a/python/GafferTest/ArrayPlugTest.py
+++ b/python/GafferTest/ArrayPlugTest.py
@@ -401,6 +401,31 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 		p = Gaffer.V2iPlug()
 		self.assertFalse( a.acceptsInput( p ) )
 
+	def testPartialConnections( self ) :
+
+		n = Gaffer.Node()
+		n["p"] = Gaffer.ArrayPlug( element = Gaffer.V3fPlug( "e" ) )
+		self.assertEqual( len( n["p"] ), 1 )
+
+		p = Gaffer.FloatPlug()
+		n["p"][0]["x"].setInput( p )
+		self.assertEqual( len( n["p"] ), 2 )
+
+		n["p"][0]["y"].setInput( p )
+		self.assertEqual( len( n["p"] ), 2 )
+
+		n["p"][1]["y"].setInput( p )
+		self.assertEqual( len( n["p"] ), 3 )
+
+		n["p"][2]["z"].setInput( p )
+		self.assertEqual( len( n["p"] ), 4 )
+
+		n["p"][1]["y"].setInput( None )
+		self.assertEqual( len( n["p"] ), 4 )
+
+		n["p"][2]["z"].setInput( None )
+		self.assertEqual( len( n["p"] ), 2 )
+
 	def tearDown( self ) :
 
 		# some bugs in the InputGenerator only showed themselves when

--- a/python/GafferTest/ArrayPlugTest.py
+++ b/python/GafferTest/ArrayPlugTest.py
@@ -426,6 +426,71 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 		n["p"][2]["z"].setInput( None )
 		self.assertEqual( len( n["p"] ), 2 )
 
+	def testResizeWhenInputsChange( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["a"] = GafferTest.AddNode()
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["p"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, resizeWhenInputsChange = False )
+		self.assertEqual( s["n"]["user"]["p"].resizeWhenInputsChange(), False )
+
+		self.assertEqual( len( s["n"]["user"]["p"] ), 1 )
+		s["n"]["user"]["p"][0].setInput( s["a"]["sum"] )
+		self.assertEqual( len( s["n"]["user"]["p"] ), 1 )
+		s["n"]["user"]["p"][0].setInput( None )
+		self.assertEqual( len( s["n"]["user"]["p"] ), 1 )
+
+	def testNext( self ) :
+
+		a = GafferTest.AddNode()
+
+		n = Gaffer.Node()
+		n["a1"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug() )
+		n["a2"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug(), maxSize = 3, resizeWhenInputsChange = False )
+
+		self.assertEqual( len( n["a1"] ), 1 )
+		self.assertEqual( len( n["a2"] ), 1 )
+		self.assertEqual( n["a1"].next(), n["a1"][0] )
+		self.assertEqual( n["a2"].next(), n["a2"][0] )
+
+		n["a1"][0].setInput( a["sum"] )
+		n["a2"][0].setInput( a["sum"] )
+
+		self.assertEqual( len( n["a1"] ), 2 )
+		self.assertEqual( len( n["a2"] ), 1 )
+		self.assertEqual( n["a1"].next(), n["a1"][1] )
+		self.assertEqual( n["a2"].next(), n["a2"][1] )
+		self.assertEqual( len( n["a2"] ), 2 )
+
+		self.assertEqual( n["a1"].next(), n["a1"][1] )
+		self.assertEqual( n["a2"].next(), n["a2"][1] )
+
+		n["a2"].next().setInput( a["sum"] )
+		n["a2"].next().setInput( a["sum"] )
+		self.assertEqual( len( n["a2"] ), 3 )
+
+		self.assertEqual( n["a2"].next(), None )
+
+	def testResize( self ) :
+
+		p = Gaffer.ArrayPlug( element = Gaffer.IntPlug(), minSize = 1, maxSize = 3, resizeWhenInputsChange = False )
+		self.assertEqual( len( p ), p.minSize() )
+
+		p.resize( 2 )
+		self.assertEqual( len( p ), 2 )
+		self.assertIsInstance( p[1], Gaffer.IntPlug )
+
+		p.resize( 3 )
+		self.assertEqual( len( p ), 3 )
+		self.assertIsInstance( p[2], Gaffer.IntPlug )
+
+		with self.assertRaises( RuntimeError ) :
+			p.resize( p.minSize() - 1 )
+
+		with self.assertRaises( RuntimeError ) :
+			p.resize( p.maxSize() + 1 )
+
 	def tearDown( self ) :
 
 		# some bugs in the InputGenerator only showed themselves when

--- a/python/GafferTest/NameSwitchTest.py
+++ b/python/GafferTest/NameSwitchTest.py
@@ -118,5 +118,23 @@ class NameSwitchTest( GafferTest.TestCase ) :
 		self.assertEqual( s2["s"]["in"][0]["value"].getInput(), s2["n"]["sum"] )
 		self.assertEqual( s2["s"]["in"][0]["enabled"].getValue(), s["s"]["in"][0]["enabled"].getValue() )
 
+	def testDirtyPropagation( self ) :
+
+		s = Gaffer.NameSwitch()
+		s.setup( Gaffer.IntPlug() )
+		s["in"].resize( 2 )
+
+		cs = GafferTest.CapturingSlot( s.plugDirtiedSignal() )
+		s["in"][1]["name"].setValue( "x" )
+		self.assertIn( s["out"], { x[0] for x in cs } )
+
+		del cs[:]
+		s["in"][1]["enabled"].setValue( False )
+		self.assertIn( s["out"], { x[0] for x in cs } )
+
+		del cs[:]
+		s["in"][1]["value"].setValue( 10 )
+		self.assertIn( s["out"], { x[0] for x in cs } )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/NameSwitchTest.py
+++ b/python/GafferTest/NameSwitchTest.py
@@ -1,0 +1,122 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+import Gaffer
+import GafferTest
+
+class NameSwitchTest( GafferTest.TestCase ) :
+
+	def testSetup( self ) :
+
+		s = Gaffer.NameSwitch()
+		s.setup( Gaffer.IntPlug() )
+
+		self.assertIsInstance( s["in"][0], Gaffer.ValuePlug )
+		self.assertEqual( s["in"][0]["name"].getValue(), "*" )
+		self.assertIsInstance( s["in"][0]["value"], Gaffer.IntPlug )
+		self.assertTrue( "enabled" in s["in"][0] )
+		self.assertEqual( s["in"][0]["enabled"].getValue(), True )
+		self.assertEqual( s["in"][0].getName(), "in0" )
+
+		self.assertIsInstance( s["out"], Gaffer.ValuePlug )
+		self.assertIsInstance( s["out"]["value"], Gaffer.IntPlug )
+
+	def testMatch( self ) :
+
+		s = Gaffer.NameSwitch()
+		s.setup( Gaffer.IntPlug() )
+
+		zero = Gaffer.IntPlug( defaultValue = 0 )
+		one = Gaffer.IntPlug( defaultValue = 1 )
+		two = Gaffer.IntPlug( defaultValue = 2 )
+
+		s["in"].resize( 3 )
+		s["in"][0]["value"].setInput( zero )
+		s["in"][1]["name"].setValue( "on*" )
+		s["in"][1]["value"].setInput( one )
+		s["in"][2]["name"].setValue( "t[wx]o TOO" )
+		s["in"][2]["value"].setInput( two )
+
+		s["selector"].setValue( "one" )
+		self.assertEqual( s["out"]["value"].getValue(), 1 )
+		self.assertEqual( s["out"]["name"].getValue(), "on*" )
+		self.assertEqual( s.activeInPlug(), s["in"][1] )
+
+		s["selector"].setValue( "ona" )
+		self.assertEqual( s["out"]["value"].getValue(), 1 )
+		self.assertEqual( s["out"]["name"].getValue(), "on*" )
+		self.assertEqual( s.activeInPlug(), s["in"][1] )
+
+		s["selector"].setValue( "TOO" )
+		self.assertEqual( s["out"]["value"].getValue(), 2 )
+		self.assertEqual( s["out"]["name"].getValue(), "t[wx]o TOO" )
+		self.assertEqual( s.activeInPlug(), s["in"][2] )
+
+		s["selector"].setValue( "somethingElse" )
+		self.assertEqual( s["out"]["value"].getValue(), 0 )
+		self.assertEqual( s["out"]["name"].getValue(), "*" )
+		self.assertEqual( s.activeInPlug(), s["in"][0] )
+
+		s["selector"].setValue( "one" )
+		self.assertEqual( s["out"]["value"].getValue(), 1 )
+		s["in"][1]["enabled"].setValue( False )
+		self.assertEqual( s["out"]["value"].getValue(), 0 )
+
+	def testSerialisation( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = GafferTest.AddNode()
+		s["s"] = Gaffer.NameSwitch()
+		s["s"].setup( s["n"]["sum"] )
+		s["s"]["in"][0]["name"].setValue( "x" )
+		s["s"]["in"][0]["value"].setInput( s["n"]["sum"] )
+		s["s"]["in"][0]["enabled"].setValue( False )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertIsInstance( s2["s"]["in"][0], Gaffer.NameValuePlug )
+		self.assertIsInstance( s2["s"]["in"][0]["value"], Gaffer.IntPlug )
+		self.assertEqual( s2["s"]["in"][0]["name"].getValue(), s["s"]["in"][0]["name"].getValue() )
+		self.assertEqual( s2["s"]["in"][0]["value"].getInput(), s2["n"]["sum"] )
+		self.assertEqual( s2["s"]["in"][0]["enabled"].getValue(), s["s"]["in"][0]["enabled"].getValue() )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/SwitchTest.py
+++ b/python/GafferTest/SwitchTest.py
@@ -521,6 +521,12 @@ class SwitchTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( s2["switch"]["in"], "test" ), 1 )
 		self.assertEqual( Gaffer.Metadata.value( s2["switch"]["out"], "test" ), 2 )
 
+	def testNestedPlugs( self ) :
+
+		s = Gaffer.Switch()
+		s.setup( Gaffer.NameValuePlug( "name", Gaffer.V3fPlug() ) )
+		self.assertEqual( s.correspondingInput( s["out"]["value"]["x"] ), s["in"][0]["value"]["x"] )
+
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )

--- a/python/GafferTest/SwitchTest.py
+++ b/python/GafferTest/SwitchTest.py
@@ -526,6 +526,7 @@ class SwitchTest( GafferTest.TestCase ) :
 		s = Gaffer.Switch()
 		s.setup( Gaffer.NameValuePlug( "name", Gaffer.V3fPlug() ) )
 		self.assertEqual( s.correspondingInput( s["out"]["value"]["x"] ), s["in"][0]["value"]["x"] )
+		self.assertEqual( s.activeInPlug( s["out"]["value"]["y"] ), s["in"][0]["value"]["y"] )
 
 	def setUp( self ) :
 

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -160,6 +160,7 @@ from NameValuePlugTest import NameValuePlugTest
 from ExtensionAlgoTest import ExtensionAlgoTest
 from ModuleTest import ModuleTest
 from NumericBookmarkSetTest import NumericBookmarkSetTest
+from NameSwitchTest import NameSwitchTest
 
 from IECorePreviewTest import *
 

--- a/python/GafferUI/BoxUI.py
+++ b/python/GafferUI/BoxUI.py
@@ -81,6 +81,7 @@ Gaffer.Metadata.registerNode(
 
 		"*" : [
 
+			"deletable", True,
 			"labelPlugValueWidget:renameable", True,
 
 		],
@@ -198,22 +199,6 @@ def __upgradeToUseBoxIO( node ) :
 # Shared menu code
 ##########################################################################
 
-def __deletePlug( plug ) :
-
-	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
-		plug.parent().removeChild( plug )
-
-def __appendPlugDeletionMenuItems( menuDefinition, plug, readOnly = False ) :
-
-	if not isinstance( plug.parent(), Gaffer.Box ) :
-		return
-
-	menuDefinition.append( "/DeleteDivider", { "divider" : True } )
-	menuDefinition.append( "/Delete", {
-		"command" : functools.partial( __deletePlug, plug ),
-		"active" : not readOnly,
-	} )
-
 def __promote( plug ) :
 
 	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
@@ -282,7 +267,6 @@ def __appendPlugPromotionMenuItems( menuDefinition, plug, readOnly = False ) :
 
 def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 
-	__appendPlugDeletionMenuItems( menuDefinition, plugValueWidget.getPlug(), readOnly = plugValueWidget.getReadOnly() )
 	__appendPlugPromotionMenuItems( menuDefinition, plugValueWidget.getPlug(), readOnly = plugValueWidget.getReadOnly() )
 
 __plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )
@@ -375,7 +359,6 @@ def __graphEditorPlugContextMenu( graphEditor, plug, menuDefinition ) :
 			}
 		)
 
-	__appendPlugDeletionMenuItems( menuDefinition, parentPlug, readOnly )
 	__appendPlugPromotionMenuItems( menuDefinition, plug, readOnly )
 
 GafferUI.GraphEditor.plugContextMenuSignal().connect( __graphEditorPlugContextMenu, scoped = False )

--- a/python/GafferUI/CompoundDataPlugValueWidget.py
+++ b/python/GafferUI/CompoundDataPlugValueWidget.py
@@ -170,32 +170,7 @@ class CompoundDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 GafferUI.PlugValueWidget.registerType( Gaffer.CompoundDataPlug, CompoundDataPlugValueWidget )
 
 ##########################################################################
-# Plug menu
+# Plug metadata
 ##########################################################################
 
-def __deletePlug( plug ) :
-
-	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
-		plug.parent().removeChild( plug )
-
-def __plugPopupMenu( menuDefinition, plugValueWidget ) :
-
-	plug = plugValueWidget.getPlug()
-	memberPlug = plug if isinstance( plug, Gaffer.CompoundDataPlug.MemberPlug ) else None
-	memberPlug = memberPlug if memberPlug is not None else plug.ancestor( Gaffer.CompoundDataPlug.MemberPlug )
-	if memberPlug is None :
-		return
-
-	if not memberPlug.getFlags( Gaffer.Plug.Flags.Dynamic ) :
-		return
-
-	menuDefinition.append( "/DeleteDivider", { "divider" : True } )
-	menuDefinition.append(
-		"/Delete",
-		{
-			"command" : functools.partial( __deletePlug, memberPlug ),
-			"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( memberPlug ),
-		}
-	)
-
-__plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )
+Gaffer.Metadata.registerValue( Gaffer.CompoundDataPlug, "*", "deletable", lambda plug : plug.getFlags( Gaffer.Plug.Flags.Dynamic ) )

--- a/python/GafferUI/NameSwitchUI.py
+++ b/python/GafferUI/NameSwitchUI.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -232,8 +234,13 @@ class _RowPlugValueWidget( GafferUI.PlugValueWidget ) :
 			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
 
 				self.__dragHandle = _DragHandle()
-				self.__defaultLabel = GafferUI.Label( "Default", horizontalAlignment = GafferUI.HorizontalAlignment.Right )
-				self.__defaultLabel._qtWidget().setFixedWidth( self.__labelWidth + 44 )
+				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) as self.__defaultLabel :
+					# Spacers on default row occupy the space taken by PlugValueWidgets on
+					# non-default rows. This keeps the ConnectionPlugValueWidgets in alignment.
+					GafferUI.Spacer( imath.V2i( 11, 1 ) )
+					label = GafferUI.Label( "Default", horizontalAlignment = GafferUI.HorizontalAlignment.Left )
+					label._qtWidget().setFixedWidth( self.__labelWidth )
+					GafferUI.Spacer( imath.V2i( 25, 1 ) )
 
 				self.__plugValueWidgets = []
 				self.__plugValueWidgets.append( GafferUI.StringPlugValueWidget( plug["name"] ) )

--- a/python/GafferUI/NameSwitchUI.py
+++ b/python/GafferUI/NameSwitchUI.py
@@ -1,0 +1,392 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+
+import Gaffer
+import GafferUI
+
+Gaffer.Metadata.registerNode(
+
+	Gaffer.NameSwitch,
+
+	"description",
+	"""
+	Switches between multiple input connections, passing through the
+	chosen input to the output. Each input has a "name" as well
+	as a value, and switching is performed by comparing the names against
+	the value of `selector` as follows :
+
+	- Matching starts with the second input and considers all subsequent
+	  inputs one by one until a match is found. The first matching input
+	  is the one that is chosen.
+	- Matching is performed using Gaffer's standard wildcard matching.
+	  Each "name" may contain several individual patterns each separated
+	  by spaces.
+	- The first input is used as a default, and is chosen only if no other
+	  input matches.
+	""",
+
+	plugs = {
+
+		"selector" : [
+
+			"description",
+			"""
+			The value that the input names will be matched against.
+			Typically this will refer to a context variable using
+			the `${variableName}` syntax.
+			""",
+
+			"nodule:type", "",
+			"divider", True,
+
+		],
+
+		"in" : [
+
+			"plugValueWidget:type", "GafferUI.NameSwitchUI._InPlugValueWidget",
+			"noduleLayout:customGadget:addButton:gadgetType", "GafferUI.NameSwitchUI.PlugAdder",
+
+		],
+
+		"in.in0" : [
+
+			"deletable", False,
+
+		],
+
+		"in.in0.value" : [
+
+			"noduleLayout:label", "default",
+
+		],
+
+		"in.*" : [
+
+			"nodule:type", "GafferUI::CompoundNodule",
+			"plugValueWidget:type", "GafferUI.NameSwitchUI._RowPlugValueWidget",
+			"deletable", True,
+
+		],
+
+		"in.*.name" : [
+
+			"nodule:type", "",
+
+		],
+
+		"in.*.enabled" : [
+
+			"nodule:type", "",
+
+		],
+
+		"in.*.value" : [
+
+			"plugValueWidget:type", "GafferUI.ConnectionPlugValueWidget",
+			"noduleLayout:label", lambda plug : plug.parent()["name"].getValue(),
+
+		],
+
+		"out" : [
+
+			"nodule:type", "GafferUI::CompoundNodule",
+
+		],
+
+		"out.name" : [
+
+			"nodule:type", "",
+
+		],
+
+		"out.enabled" : [
+
+			"nodule:type", "",
+
+		],
+
+		"out.value" : [
+
+			"noduleLayout:label", "out",
+
+		],
+
+	}
+
+)
+
+# Equivalent to LayoutPlugValueWidget, but with a little footer with a button
+# for adding new inputs.
+class _InPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug, **kw ) :
+
+		column = GafferUI.ListContainer( spacing = 4 )
+		GafferUI.PlugValueWidget.__init__( self, column, plug )
+
+		with column :
+			self.__plugLayout = GafferUI.PlugLayout( plug )
+			self.__addButton = GafferUI.Button( image = "plus.png", hasFrame = False )
+
+		self.__addButton.clickedSignal().connect( Gaffer.WeakMethod( self.__addButtonClicked ), scoped = False )
+
+	def hasLabel( self ) :
+
+		return True
+
+	def setReadOnly( self, readOnly ) :
+
+		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
+		self.__plugLayout.setReadOnly( readOnly )
+
+	def childPlugValueWidget( self, childPlug, lazy=True ) :
+
+		return self.__plugLayout.plugValueWidget( childPlug, lazy )
+
+	def _updateFromPlug( self ) :
+
+		self.__addButton.setEnabled( self._editable() )
+
+	def __addButtonClicked( self, button ) :
+
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			self.getPlug().resize( len( self.getPlug() ) + 1 )
+
+class _DragHandle( GafferUI.Image ) :
+
+	def __init__( self, **kw ) :
+
+		GafferUI.Image.__init__( self, "reorderVertically.png", **kw )
+
+		self.enterSignal().connect( Gaffer.WeakMethod( self.__enter ), scoped = False )
+		self.leaveSignal().connect( Gaffer.WeakMethod( self.__leave ), scoped = False )
+		self.buttonPressSignal().connect( Gaffer.WeakMethod( self.__buttonPress ), scoped = False )
+		self.dragBeginSignal().connect( Gaffer.WeakMethod( self.__dragBegin ), scoped = False )
+
+	def __enter( self, widget ) :
+
+		GafferUI.Pointer.setCurrent( "moveVertically" )
+
+	def __leave( self, widget ) :
+
+		GafferUI.Pointer.setCurrent( None )
+
+	def __buttonPress( self, widget, event ) :
+
+		return event.buttons == event.Buttons.Left
+
+	def __dragBegin( self, widget, event ) :
+
+		if event.buttons == event.Buttons.Left :
+			# NullObject is the convention for data for private drags.
+			return IECore.NullObject().defaultNullObject()
+
+# Widget for an individual input.
+class _RowPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	__labelWidth = 200
+
+	def __init__( self, plug ) :
+
+		column = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing = 4 )
+
+		GafferUI.PlugValueWidget.__init__( self, column, plug )
+
+		with column :
+
+			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+
+				self.__dragHandle = _DragHandle()
+				self.__defaultLabel = GafferUI.Label( "Default", horizontalAlignment = GafferUI.HorizontalAlignment.Right )
+				self.__defaultLabel._qtWidget().setFixedWidth( self.__labelWidth + 44 )
+
+				self.__plugValueWidgets = []
+				self.__plugValueWidgets.append( GafferUI.StringPlugValueWidget( plug["name"] ) )
+				self.__plugValueWidgets.append( GafferUI.BoolPlugValueWidget( plug["enabled"] ) )
+				self.__plugValueWidgets.append( GafferUI.PlugValueWidget.create( plug["value"] ) )
+
+				self.__plugValueWidgets[0].textWidget()._qtWidget().setFixedWidth( self.__labelWidth )
+
+			self.__dragDivider = GafferUI.Divider()
+
+		self.dragEnterSignal().connect( Gaffer.WeakMethod( self.__dragEnter ), scoped = False )
+		self.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__dragLeave ), scoped = False )
+		self.dropSignal().connect( 0, Gaffer.WeakMethod( self.__drop ), scoped = False )
+
+		self.__updateWidgetVisibility()
+		self._updateFromPlug()
+
+	def setPlug( self, plug ) :
+
+		GafferUI.PlugValueWidget.setPlug( self, plug )
+
+		self.__plugValueWidgets[0].setPlug( plug["name"] )
+		self.__plugValueWidgets[1].setPlug( plug["enabled"] )
+		self.__plugValueWidgets[2].setPlug( plug["value"] )
+
+		self.__updateWidgetVisibility()
+
+	def hasLabel( self ) :
+
+		return True
+
+	def childPlugValueWidget( self, childPlug, lazy=True ) :
+
+		for w in self.__plugValueWidgets :
+			if w.getPlug().isSame( childPlug ) :
+				return w
+
+		return None
+
+	def setReadOnly( self, readOnly ) :
+
+		if readOnly == self.getReadOnly() :
+			return
+
+		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
+
+		for w in self.__plugValueWidgets :
+			w.setReadOnly( readOnly )
+
+	def _updateFromPlug( self ) :
+
+		enabled = False
+		with self.getContext() :
+			with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
+				enabled = self.getPlug()["enabled"].getValue()
+
+		self.__plugValueWidgets[0].setEnabled( enabled )
+		self.__plugValueWidgets[2].setEnabled( enabled )
+
+		self.__dragHandle.setEnabled(
+			not self.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( self.getPlug() )
+		)
+
+	def __updateWidgetVisibility( self ) :
+
+		default = False
+		if self.getPlug() is not None :
+			default = self.getPlug().parent().children().index( self.getPlug() ) == 0
+
+		self.__defaultLabel.setVisible( default )
+		self.__dragHandle.setVisible( not default )
+		self.__plugValueWidgets[0].setVisible( not default )
+		self.__plugValueWidgets[1].setVisible( not default )
+
+	def __dragEnter( self, widget, event ) :
+
+		if self.__sourcePlug( event ) is not None :
+			self.__dragDivider.setHighlighted( True )
+			return True
+
+		return False
+
+	def __dragLeave( self, widget, event ) :
+
+		self.__dragDivider.setHighlighted( False )
+
+	def __drop( self, widget, event ) :
+
+		self.__dragDivider.setHighlighted( False )
+
+		srcPlug = self.__sourcePlug( event )
+		dstPlug = self.getPlug()
+		parent = dstPlug.parent()
+		assert( srcPlug.parent() == parent )
+
+		srcIndex = parent.children().index( srcPlug )
+		dstIndex = parent.children().index( dstPlug )
+
+		# Reordering the plugs themselves is problematic, so
+		# we reorder their values and connections instead.
+
+		assert( srcIndex != 0 )
+
+		if dstIndex > srcIndex :
+			with Gaffer.UndoScope( srcPlug.ancestor( Gaffer.ScriptNode ) ) :
+				srcState = self.__getValuesAndInputs( srcPlug )
+				for i in range( srcIndex, dstIndex ) :
+					self.__setValuesAndInputs( parent[i], self.__getValuesAndInputs( parent[i+1] ) )
+				self.__setValuesAndInputs( parent[dstIndex], srcState )
+		elif dstIndex < srcIndex - 1 :
+			with Gaffer.UndoScope( srcPlug.ancestor( Gaffer.ScriptNode ) ) :
+				srcState = self.__getValuesAndInputs( srcPlug )
+				for i in range( srcIndex, dstIndex + 1, -1 ) :
+					self.__setValuesAndInputs( parent[i], self.__getValuesAndInputs( parent[i-1] ) )
+				self.__setValuesAndInputs( parent[dstIndex + 1], srcState )
+
+		return True
+
+	def __sourcePlug( self, dragEvent ) :
+
+		if not isinstance( dragEvent.sourceWidget, _DragHandle ) :
+			return None
+
+		if dragEvent.data != IECore.NullObject.defaultNullObject() :
+			return None
+
+		sourcePlug = dragEvent.sourceWidget.ancestor( _RowPlugValueWidget ).getPlug()
+		if sourcePlug.parent() == self.getPlug().parent() :
+			return sourcePlug
+
+		return None
+
+	@staticmethod
+	def __getValuesAndInputs( plug ) :
+
+		result = []
+		for child in Gaffer.Plug.Range( plug ) :
+			if child.getInput() is not None :
+				result.append( child.getInput() )
+			elif hasattr( child, "getValue" ) :
+				result.append( child.getValue() )
+			else :
+				result.append( None )
+
+		return result
+
+	@staticmethod
+	def __setValuesAndInputs( plug, valuesAndInputs ) :
+
+		for i, valueOrInput in enumerate( valuesAndInputs ) :
+			if isinstance( valueOrInput, Gaffer.Plug ) :
+				plug[i].setInput( valueOrInput )
+			else :
+				plug[i].setInput( None )
+				if valueOrInput is not None :
+					plug[i].setValue( valueOrInput )

--- a/python/GafferUI/NameSwitchUI.py
+++ b/python/GafferUI/NameSwitchUI.py
@@ -114,7 +114,6 @@ Gaffer.Metadata.registerNode(
 		"in.*.enabled" : [
 
 			"nodule:type", "",
-			"boolPlugValueWidget:displayMode", "switch",
 
 		],
 
@@ -196,6 +195,10 @@ class _InPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().resize( len( self.getPlug() ) + 1 )
+			parent = self.getPlug().parent()
+			if not isinstance( parent, Gaffer.NameSwitch ) or self.getPlug() != parent["in"] :
+				## See comments in `NameSwitchPlugAdder::createConnection()`
+				Gaffer.MetadataAlgo.copy( self.getPlug()[-2], self.getPlug()[-1] )
 
 	def __dragEnter( self, widget, event ) :
 
@@ -357,7 +360,7 @@ class _RowPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 				self.__plugValueWidgets = []
 				self.__plugValueWidgets.append( GafferUI.StringPlugValueWidget( plug["name"] ) )
-				self.__plugValueWidgets.append( GafferUI.BoolPlugValueWidget( plug["enabled"] ) )
+				self.__plugValueWidgets.append( GafferUI.BoolPlugValueWidget( plug["enabled"], displayMode = GafferUI.BoolWidget.DisplayMode.Switch ) )
 				self.__plugValueWidgets.append( GafferUI.PlugValueWidget.create( plug["value"] ) )
 
 				self.__plugValueWidgets[0].textWidget()._qtWidget().setFixedWidth( self.__labelWidth )

--- a/python/GafferUI/NameSwitchUI.py
+++ b/python/GafferUI/NameSwitchUI.py
@@ -114,6 +114,7 @@ Gaffer.Metadata.registerNode(
 		"in.*.enabled" : [
 
 			"nodule:type", "",
+			"boolPlugValueWidget:displayMode", "switch",
 
 		],
 

--- a/python/GafferUI/SwitchUI.py
+++ b/python/GafferUI/SwitchUI.py
@@ -83,7 +83,7 @@ Gaffer.Metadata.registerNode(
 			"nodule:type", "GafferUI::CompoundNodule",
 			"plugValueWidget:type", "",
 
-			"noduleLayout:spacing", lambda plug : 2.0 if Gaffer.Metadata.value( plug, "noduleLayout:section" ) in ( "Top", "Bottom", None ) else 0.25,
+			"noduleLayout:spacing", lambda plug : 2.0 if Gaffer.Metadata.value( plug, "noduleLayout:section" ) in ( "top", "bottom", None ) else 0.25,
 
 		],
 

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -181,8 +181,8 @@ class Viewer( GafferUI.NodeSetEditor ) :
 
 		node = self._lastAddedNode()
 		if node :
-			for plug in node.children( Gaffer.Plug ) :
-				if plug.direction() == Gaffer.Plug.Direction.Out and not plug.getName().startswith( "__" ) :
+			for plug in Gaffer.Plug.RecursiveOutputRange( node ) :
+				if not plug.getName().startswith( "__" ) :
 					# try to reuse an existing view
 					for view in self.__views :
 						if view["in"].acceptsInput( plug ) :

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -979,6 +979,10 @@ _styleSheet = string.Template(
 		margin-right: 10px;
 	}
 
+	QFrame[gafferClass="GafferUI.Divider"][gafferHighlighted="true"] {
+		color: $brightColor;
+	}
+
 	QToolTip {
 		background-clip: border;
 		color: $backgroundDarkest;

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -312,6 +312,7 @@ import AnimationUI
 import BoxIOUI
 import BoxInUI
 import BoxOutUI
+import NameSwitchUI
 
 # backwards compatibility
 ## \todo Remove me

--- a/python/GafferUITest/StandardGraphLayoutTest.py
+++ b/python/GafferUITest/StandardGraphLayoutTest.py
@@ -899,5 +899,24 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		self.assertTrue( expressionPosition.y < i1Bounds.min().y )
 		self.assertTrue( expressionPosition.y > i2Bounds.max().y )
 
+	def testConnectNameSwitch( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = GafferTest.AddNode()
+		s["s"] = Gaffer.NameSwitch()
+
+		g = GafferUI.GraphGadget( s )
+		g.getLayout().connectNode( g, s["s"], Gaffer.StandardSet( [ s["n"] ] ) )
+
+		self.assertIsInstance( s["s"]["in"][0], Gaffer.NameValuePlug )
+		self.assertTrue( isinstance( s["s"]["in"][0]["value"], Gaffer.IntPlug ) )
+		self.assertEqual( s["s"]["in"][0]["value"].getInput(), s["n"]["sum"] )
+
+		s["c"] = Gaffer.ContextVariables()
+		g.getLayout().connectNode( g, s["c"], Gaffer.StandardSet( [ s["s"] ] ) )
+
+		self.assertIsInstance( s["c"]["in"], Gaffer.IntPlug )
+		self.assertEqual( s["c"]["in"].getInput(), s["s"]["out"]["value"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -4806,5 +4806,12 @@
        id="forExport:nodeSetNumericBookmarkSet"
        style="fill:#e0e0e0;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.49690738;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        sodipodi:type="star" />
+    <path
+       inkscape:connector-curvature="0"
+       inkscape:label="#path3093"
+       style="fill:#9e9e9e;fill-opacity:0.99215686;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+       d="m 494,150.86218 h -3.5 l 5,5.5 5,-5.5 H 497 v -7 h 3.5 l -5,-5.5 -5,5.5 h 3.5 z"
+       id="forExport:reorderVertically"
+       sodipodi:nodetypes="ccccccccccc" />
   </g>
 </svg>

--- a/src/Gaffer/ArrayPlug.cpp
+++ b/src/Gaffer/ArrayPlug.cpp
@@ -126,7 +126,7 @@ void ArrayPlug::setInput( PlugPtr input )
 
 PlugPtr ArrayPlug::createCounterpart( const std::string &name, Direction direction ) const
 {
-	ArrayPlugPtr result = new ArrayPlug( name, direction, nullptr, m_minSize, m_maxSize, getFlags() );
+	ArrayPlugPtr result = new ArrayPlug( name, direction, nullptr, m_minSize, m_maxSize, getFlags(), resizeWhenInputsChange() );
 	for( PlugIterator it( this ); !it.done(); ++it )
 	{
 		result->addChild( (*it)->createCounterpart( (*it)->getName(), direction ) );

--- a/src/Gaffer/NameSwitch.cpp
+++ b/src/Gaffer/NameSwitch.cpp
@@ -118,7 +118,10 @@ void NameSwitch::affects( const Plug *input, DependencyNode::AffectedPlugsContai
 	auto nameValuePlug = input->parent<NameValuePlug>();
 	if(
 		input == selectorPlug() ||
-		( nameValuePlug && input == nameValuePlug->namePlug() && nameValuePlug->parent() == inPlugs() )
+		(
+			nameValuePlug && nameValuePlug->parent() == inPlugs() &&
+			( input == nameValuePlug->namePlug() || input == nameValuePlug->enabledPlug() )
+		)
 	)
 	{
 		outputs.push_back( outIndexPlug() );

--- a/src/Gaffer/NameSwitch.cpp
+++ b/src/Gaffer/NameSwitch.cpp
@@ -1,0 +1,172 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/NameSwitch.h"
+
+#include "Gaffer/NameValuePlug.h"
+#include "Gaffer/StringPlug.h"
+
+using namespace std;
+using namespace IECore;
+using namespace Gaffer;
+
+size_t NameSwitch::g_firstPlugIndex = 0;
+
+GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( NameSwitch );
+
+NameSwitch::NameSwitch( const std::string &name )
+	:	Switch( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new StringPlug( "selector" ) );
+	addChild( new IntPlug( "__outIndex", Plug::Out ) );
+	indexPlug()->setName( "__index" );
+	indexPlug()->setInput( outIndexPlug() );
+}
+
+NameSwitch::~NameSwitch()
+{
+}
+
+void NameSwitch::setup( const Plug *plug )
+{
+	if( inPlugs() )
+	{
+		throw IECore::Exception( "Switch already has an \"in\" plug." );
+	}
+	if( outPlug() )
+	{
+		throw IECore::Exception( "Switch already has an \"out\" plug." );
+	}
+
+	NameValuePlugPtr element = new NameValuePlug( "", plug->createCounterpart( "value", Plug::In ), /* defaultEnabled = */ true, "in0" );
+	ArrayPlugPtr in = new ArrayPlug(
+		"in",
+		Plug::In,
+		element,
+		2,
+		Imath::limits<size_t>::max(),
+		Plug::Default,
+		/* resizeWhenInputsChange = */ false
+	);
+	addChild( in );
+
+	PlugPtr out = new NameValuePlug( "", plug->createCounterpart( "value", Plug::Out ), /* defaultEnabled = */ true, "out" );
+	addChild( out );
+
+	inPlugs()->getChild<NameValuePlug>( 0 )->namePlug()->setValue( "*" );
+}
+
+StringPlug *NameSwitch::selectorPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+const StringPlug *NameSwitch::selectorPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+IntPlug *NameSwitch::outIndexPlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 1 );
+}
+
+const IntPlug *NameSwitch::outIndexPlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 1 );
+}
+
+void NameSwitch::affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const
+{
+	Switch::affects( input, outputs );
+
+	auto nameValuePlug = input->parent<NameValuePlug>();
+	if(
+		input == selectorPlug() ||
+		( nameValuePlug && input == nameValuePlug->namePlug() && nameValuePlug->parent() == inPlugs() )
+	)
+	{
+		outputs.push_back( outIndexPlug() );
+	}
+}
+
+void NameSwitch::hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const
+{
+	Switch::hash( output, context, h );
+
+	if( output == outIndexPlug() )
+	{
+		selectorPlug()->hash( h );
+		const ArrayPlug *in = inPlugs();
+		for( int i = 1, e = in->children().size(); i < e; ++i )
+		{
+			auto p = in->getChild<NameValuePlug>( i );
+			p->enabledPlug()->hash( h );
+			p->namePlug()->hash( h );
+		}
+	}
+}
+
+void NameSwitch::compute( ValuePlug *output, const Context *context ) const
+{
+	if( output == outIndexPlug() )
+	{
+		int outIndex = 0;
+		const string selector = selectorPlug()->getValue();
+		const ArrayPlug *in = inPlugs();
+		for( int i = 1, e = in->children().size(); i < e; ++i )
+		{
+			auto p = in->getChild<NameValuePlug>( i );
+			if( !p->enabledPlug()->getValue() )
+			{
+				continue;
+			}
+			if( StringAlgo::matchMultiple( selector, p->namePlug()->getValue() ) )
+			{
+				outIndex = i;
+				break;
+			}
+		}
+
+		static_cast<IntPlug *>( output )->setValue( outIndex );
+		return;
+	}
+
+	Switch::compute( output, context );
+}
+

--- a/src/Gaffer/Switch.cpp
+++ b/src/Gaffer/Switch.cpp
@@ -363,7 +363,7 @@ const Plug *Switch::oppositePlug( const Plug *plug, const Context *context ) con
 
 	// And then find the opposite of plug by traversing down from the ancestor plug.
 	const Plug *result = oppositeAncestorPlug;
-	for( std::vector<IECore::InternedString>::const_iterator it = names.begin(), eIt = names.end(); it != eIt; ++it )
+	for( auto it = names.rbegin(), eIt = names.rend(); it != eIt; ++it )
 	{
 		result = result->getChild<Plug>( *it );
 	}

--- a/src/Gaffer/Switch.cpp
+++ b/src/Gaffer/Switch.cpp
@@ -121,17 +121,22 @@ const Plug *Switch::outPlug() const
 
 Plug *Switch::activeInPlug()
 {
-	ArrayPlug *inputs = inPlugs();
-	if( !inputs )
-	{
-		return nullptr;
-	}
-	return inputs->getChild<Plug>( inputIndex( Context::current() ) );
+	return activeInPlug( outPlug() );
 }
 
 const Plug *Switch::activeInPlug() const
 {
-	return const_cast<Switch *>( this )->activeInPlug();
+	return activeInPlug( outPlug() );
+}
+
+Plug *Switch::activeInPlug( const Plug *outPlug )
+{
+	return const_cast<Plug *>( oppositePlug( outPlug ? outPlug : this->outPlug(), Context::current() ) );
+}
+
+const Plug *Switch::activeInPlug( const Plug *outPlug ) const
+{
+	return oppositePlug( outPlug ? outPlug : this->outPlug(), Context::current() );
 }
 
 IntPlug *Switch::indexPlug()

--- a/src/Gaffer/Switch.cpp
+++ b/src/Gaffer/Switch.cpp
@@ -307,7 +307,16 @@ size_t Switch::inputIndex( const Context *context ) const
 		{
 			index = indexPlug->getValue();
 		}
-		return index % (inPlugs->children().size() - 1);
+
+		if( inPlugs->resizeWhenInputsChange() )
+		{
+			// Last input is always unconnected, so should be ignored.
+			return index % (inPlugs->children().size() - 1);
+		}
+		else
+		{
+			return index % inPlugs->children().size();
+		}
 	}
 	else
 	{

--- a/src/Gaffer/Switch.cpp
+++ b/src/Gaffer/Switch.cpp
@@ -219,12 +219,12 @@ void Switch::childAdded( GraphComponent *child )
 
 Plug *Switch::correspondingInput( const Plug *output )
 {
-	return const_cast<Plug *>( oppositePlug( output, 0 ) );
+	return const_cast<Plug *>( oppositePlug( output ) );
 }
 
 const Plug *Switch::correspondingInput( const Plug *output ) const
 {
-	return oppositePlug( output, 0 );
+	return oppositePlug( output );
 }
 
 bool Switch::acceptsInput( const Plug *plug, const Plug *inputPlug ) const
@@ -255,7 +255,7 @@ bool Switch::acceptsInput( const Plug *plug, const Plug *inputPlug ) const
 
 void Switch::hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const
 {
-	if( const ValuePlug *input = IECore::runTimeCast<const ValuePlug>( oppositePlug( output, inputIndex( context ) ) ) )
+	if( const ValuePlug *input = IECore::runTimeCast<const ValuePlug>( oppositePlug( output, context ) ) )
 	{
 		h = input->hash();
 		return;
@@ -266,7 +266,7 @@ void Switch::hash( const ValuePlug *output, const Context *context, IECore::Murm
 
 void Switch::compute( ValuePlug *output, const Context *context ) const
 {
-	if( const ValuePlug *input = IECore::runTimeCast<const ValuePlug>( oppositePlug( output, inputIndex( context ) ) ) )
+	if( const ValuePlug *input = IECore::runTimeCast<const ValuePlug>( oppositePlug( output, context ) ) )
 	{
 		output->setFrom( input );
 		return;
@@ -315,7 +315,7 @@ size_t Switch::inputIndex( const Context *context ) const
 	}
 }
 
-const Plug *Switch::oppositePlug( const Plug *plug, size_t inputIndex ) const
+const Plug *Switch::oppositePlug( const Plug *plug, const Context *context ) const
 {
 	const ArrayPlug *inPlugs = this->inPlugs();
 	const Plug *outPlug = this->outPlug();
@@ -353,7 +353,8 @@ const Plug *Switch::oppositePlug( const Plug *plug, size_t inputIndex ) const
 	const Plug *oppositeAncestorPlug = nullptr;
 	if( plug->direction() == Plug::Out )
 	{
-		oppositeAncestorPlug = inPlugs->getChild<Plug>( inputIndex );
+		const size_t i = context ? inputIndex( context ) : 0;
+		oppositeAncestorPlug = inPlugs->getChild<Plug>( i );
 	}
 	else
 	{
@@ -393,6 +394,6 @@ void Switch::updateInternalConnection()
 		return;
 	}
 
-	Plug *in = const_cast<Plug *>( oppositePlug( out, inputIndex() ) );
+	Plug *in = const_cast<Plug *>( oppositePlug( out, Context::current() ) );
 	out->setInput( in );
 }

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -404,10 +404,10 @@ class Dispatcher::Batcher
 			// because they only know how to deal with ValuePlugs, and we use TaskPlugs.
 			if( auto sw = runTimeCast<const Switch>( task.plug()->node() ) )
 			{
-				if( task.plug() == sw->outPlug() )
+				Context::Scope scopedTaskContext( task.context() );
+				if( auto activeInPlug = sw->activeInPlug( task.plug() ) )
 				{
-					Context::Scope scopedTaskContext( task.context() );
-					task = TaskNode::Task( sw->activeInPlug()->source<TaskNode::TaskPlug>(), task.context() );
+					task = TaskNode::Task( activeInPlug->source<TaskNode::TaskPlug>(), task.context() );
 				}
 			}
 			else if( auto contextProcessor = runTimeCast<const ContextProcessor>( task.plug()->node() ) )

--- a/src/GafferModule/ArrayPlugBinding.cpp
+++ b/src/GafferModule/ArrayPlugBinding.cpp
@@ -79,6 +79,11 @@ std::string repr( const ArrayPlug *plug )
 		result += "flags = " + PlugSerialiser::flagsRepr( flags ) + ", ";
 	}
 
+	if( !plug->resizeWhenInputsChange() )
+	{
+		result += "resizeWhenInputsChange = False,";
+	}
+
 	result += ")";
 
 	return result;
@@ -115,12 +120,24 @@ class ArrayPlugSerialiser : public PlugSerialiser
 
 };
 
+void resize( ArrayPlug &p, size_t size )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	p.resize( size );
+}
+
+PlugPtr next( ArrayPlug &p )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return p.next();
+}
+
 } // namespace
 
 void GafferModule::bindArrayPlug()
 {
 	PlugClass<ArrayPlug>()
-		.def(	init< const std::string &, Plug::Direction, PlugPtr, size_t, size_t, unsigned >
+		.def(	init< const std::string &, Plug::Direction, PlugPtr, size_t, size_t, unsigned, bool >
 				(
 					(
 						arg( "name" ) = GraphComponent::defaultName<ArrayPlug>(),
@@ -128,12 +145,16 @@ void GafferModule::bindArrayPlug()
 						arg( "element" ) = PlugPtr(),
 						arg( "minSize" ) = 1,
 						arg( "maxSize" ) = Imath::limits<size_t>::max(),
-						arg( "flags" ) = Plug::Default
+						arg( "flags" ) = Plug::Default,
+						arg( "resizeWhenInputsChange" ) = true
 					)
 				)
 		)
 		.def( "minSize", &ArrayPlug::minSize )
 		.def( "maxSize", &ArrayPlug::maxSize )
+		.def( "resize", &resize )
+		.def( "resizeWhenInputsChange", &ArrayPlug::resizeWhenInputsChange )
+		.def( "next", &next )
 		.def( "__repr__", &repr )
 	;
 

--- a/src/GafferModule/SwitchBinding.cpp
+++ b/src/GafferModule/SwitchBinding.cpp
@@ -59,6 +59,12 @@ void setup( T &s, const Plug &plug )
 	s.setup( &plug );
 }
 
+PlugPtr activeInPlug( Switch &s, const Plug *plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return s.activeInPlug( plug );
+}
+
 /// \todo This is almost identical to the serialisers for Dot, ContextProcessor and Loop.
 /// Can we somehow consolidate them all into one? Or should `setup()` calls be supported by
 /// the standard serialiser, driven by some metadata?
@@ -115,7 +121,7 @@ void GafferModule::bindSwitch()
 {
 	DependencyNodeClass<Switch>()
 		.def( "setup", &setup<Switch> )
-		.def( "activeInPlug", (Plug *(Switch::*)())&Switch::activeInPlug, return_value_policy<CastToIntrusivePtr>() )
+		.def( "activeInPlug", &activeInPlug, ( arg( "plug") = object() ) )
 	;
 
 	DependencyNodeClass<NameSwitch>()

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -250,12 +250,12 @@ class Shader::NetworkBuilder
 					assert( isInputParameter( parameterPlug ) );
 					const Gaffer::Plug *source = parameterPlug->source<Gaffer::Plug>();
 
-					if( const Switch *switchNode = source->parent<Switch>() )
+					if( auto switchNode = IECore::runTimeCast<const Switch>( source->node() ) )
 					{
 						// Special case for switches with context-varying index values.
 						// Query the active input for this context, and manually traverse
 						// out the other side.
-						if( const Plug *activeInPlug = switchNode->activeInPlug() )
+						if( const Plug *activeInPlug = switchNode->activeInPlug( source ) )
 						{
 							source = activeInPlug->source();
 						}

--- a/src/GafferUI/ArrayPlugUI.cpp
+++ b/src/GafferUI/ArrayPlugUI.cpp
@@ -1,0 +1,147 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferUI/PlugAdder.h"
+
+#include "GafferUI/NoduleLayout.h"
+
+#include "Gaffer/ArrayPlug.h"
+#include "Gaffer/Metadata.h"
+
+#include "boost/bind.hpp"
+
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferUI;
+
+namespace
+{
+
+class ArrayPlugAdder : public PlugAdder
+{
+
+	public :
+
+		ArrayPlugAdder( ArrayPlugPtr plug )
+			:	m_plug( plug )
+		{
+		}
+
+	protected :
+
+		bool canCreateConnection( const Plug *endpoint ) const override
+		{
+			if( !PlugAdder::canCreateConnection( endpoint ) )
+			{
+				return false;
+			}
+
+			// Assume that if the first plug wouldn't accept the input,
+			// then neither would the new one that we add.
+
+			if( !m_plug->children().size() )
+			{
+				return false;
+			}
+			else if( !m_plug->getChild<Plug>( 0 )->acceptsInput( endpoint ) )
+			{
+				return false;
+			}
+
+			return m_plug->children().size() < m_plug->maxSize();
+		}
+
+		void createConnection( Plug *endpoint ) override
+		{
+			const size_t s = m_plug->children().size();
+			m_plug->resize( s + 1 );
+			auto p = m_plug->getChild<Plug>( s );
+
+			if( endpoint->direction() == Plug::In )
+			{
+				endpoint->setInput( p );
+			}
+			else
+			{
+				p->setInput( endpoint );
+			}
+		}
+
+	private :
+
+		ArrayPlugPtr m_plug;
+
+};
+
+struct Registration
+{
+
+	Registration()
+	{
+		NoduleLayout::registerCustomGadget( "GafferUI.ArrayPlugUI.PlugAdder", boost::bind( &create, ::_1 ) );
+		Gaffer::Metadata::registerValue(
+			ArrayPlug::staticTypeId(), "noduleLayout:customGadget:addButton:gadgetType",
+			[]( const GraphComponent *plug ) -> ConstDataPtr {
+				auto arrayPlug = static_cast<const ArrayPlug *>( plug );
+				if( !arrayPlug->resizeWhenInputsChange() )
+				{
+					return new StringData( "GafferUI.ArrayPlugUI.PlugAdder" );
+				}
+				else
+				{
+					return nullptr;
+				}
+			}
+		);
+	}
+
+	private :
+
+		static GadgetPtr create( GraphComponentPtr parent )
+		{
+			if( ArrayPlugPtr plug = runTimeCast<ArrayPlug>( parent ) )
+			{
+				return new ArrayPlugAdder( plug );
+			}
+			throw IECore::Exception( "Expected an ArrayPlug" );
+		}
+
+};
+
+Registration g_registration;
+
+} // namespace
+

--- a/src/GafferUI/NameSwitchUI.cpp
+++ b/src/GafferUI/NameSwitchUI.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,16 +34,12 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GafferUI/Nodule.h"
-#include "GafferUI/NoduleLayout.h"
 #include "GafferUI/PlugAdder.h"
 
-#include "Gaffer/ArrayPlug.h"
+#include "GafferUI/NoduleLayout.h"
+
 #include "Gaffer/NameSwitch.h"
 #include "Gaffer/NameValuePlug.h"
-#include "Gaffer/ScriptNode.h"
-#include "Gaffer/Switch.h"
-#include "Gaffer/UndoScope.h"
 
 #include "boost/bind.hpp"
 
@@ -54,92 +50,59 @@ using namespace GafferUI;
 namespace
 {
 
-class SwitchPlugAdder : public PlugAdder
+class NameSwitchPlugAdder : public PlugAdder
 {
 
 	public :
 
-		SwitchPlugAdder( SwitchPtr node )
-			:	m_switch( node )
+		NameSwitchPlugAdder( ArrayPlugPtr plug )
+			:	m_plug( plug )
 		{
-			node->childAddedSignal().connect( boost::bind( &SwitchPlugAdder::childAdded, this ) );
-			node->childRemovedSignal().connect( boost::bind( &SwitchPlugAdder::childRemoved, this ) );
-
-			updateVisibility();
 		}
 
 	protected :
 
 		bool canCreateConnection( const Plug *endpoint ) const override
 		{
-			return PlugAdder::canCreateConnection( endpoint );
+			if( !PlugAdder::canCreateConnection( endpoint ) )
+			{
+				return false;
+			}
+
+			// Assume that if the first plug wouldn't accept the input,
+			// then neither would the new one that we add.
+
+			if( !m_plug->children().size() )
+			{
+				return false;
+			}
+			else if( !m_plug->getChild<NameValuePlug>( 0 )->valuePlug()->acceptsInput( endpoint ) )
+			{
+				return false;
+			}
+
+			return m_plug->children().size() < m_plug->maxSize();
 		}
 
 		void createConnection( Plug *endpoint ) override
 		{
-			auto nameSwitch = runTimeCast<NameSwitch>( m_switch.get() );
-			if( nameSwitch  )
+			const size_t s = m_plug->children().size();
+			m_plug->resize( s + 1 );
+			auto p = m_plug->getChild<NameValuePlug>( s );
+
+			if( endpoint->direction() == Plug::In )
 			{
-				/// \todo Should `Switch::setup()` be virtual so that we don't
-				/// need to downcast?
-				nameSwitch->setup( endpoint );
+				endpoint->setInput( p->valuePlug() );
 			}
 			else
 			{
-				m_switch->setup( endpoint );
+				p->valuePlug()->setInput( endpoint );
 			}
-
-			ArrayPlug *inPlug = m_switch->getChild<ArrayPlug>( "in" );
-			Plug *outPlug = m_switch->getChild<Plug>( "out" );
-
-			bool inOpposite = false;
-			if( endpoint->direction() == Plug::Out )
-			{
-				if( nameSwitch )
-				{
-					inPlug->getChild<NameValuePlug>( 0 )->valuePlug()->setInput( endpoint );
-				}
-				else
-				{
-					inPlug->getChild<Plug>( 0 )->setInput( endpoint );
-				}
-				inOpposite = false;
-			}
-			else
-			{
-				if( nameSwitch )
-				{
-					endpoint->setInput( static_cast<NameValuePlug *>( outPlug )->valuePlug() );
-				}
-				else
-				{
-					endpoint->setInput( outPlug );
-				}
-				inOpposite = true;
-			}
-
-			applyEdgeMetadata( inPlug, inOpposite );
-			applyEdgeMetadata( outPlug, !inOpposite );
 		}
 
 	private :
 
-		void childAdded()
-		{
-			updateVisibility();
-		}
-
-		void childRemoved()
-		{
-			updateVisibility();
-		}
-
-		void updateVisibility()
-		{
-			setVisible( m_switch->getChild<ArrayPlug>( "in" ) == nullptr );
-		}
-
-		SwitchPtr m_switch;
+		ArrayPlugPtr m_plug;
 
 };
 
@@ -148,20 +111,18 @@ struct Registration
 
 	Registration()
 	{
-		NoduleLayout::registerCustomGadget( "GafferUI.SwitchUI.PlugAdder", boost::bind( &create, ::_1 ) );
+		NoduleLayout::registerCustomGadget( "GafferUI.NameSwitchUI.PlugAdder", boost::bind( &create, ::_1 ) );
 	}
 
 	private :
 
 		static GadgetPtr create( GraphComponentPtr parent )
 		{
-			SwitchPtr switchNode = runTimeCast<Switch>( parent );
-			if( !switchNode )
+			if( auto s = parent->parent<NameSwitch>() )
 			{
-				throw Exception( "SwitchPlugAdder requires a Switch" );
+				return new NameSwitchPlugAdder( s->inPlugs() );
 			}
-
-			return new SwitchPlugAdder( switchNode );
+			throw IECore::Exception( "Expected an ArrayPlug belonging to a NameSwitch" );
 		}
 
 };
@@ -169,3 +130,4 @@ struct Registration
 Registration g_registration;
 
 } // namespace
+

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -103,9 +103,10 @@ def __nodeContextMenu( graphEditor, node, menuDefinition ) :
 
 GafferUI.GraphEditor.nodeContextMenuSignal().connect( __nodeContextMenu, scoped = False )
 
-def __plugContextMenu( graphEditor, node, menuDefinition ) :
+def __plugContextMenu( graphEditor, plug, menuDefinition ) :
 
-	GafferUI.GraphBookmarksUI.appendPlugContextMenuDefinitions( graphEditor, node, menuDefinition )
+	GafferUI.GraphBookmarksUI.appendPlugContextMenuDefinitions( graphEditor, plug, menuDefinition )
+	GafferUI.NodeUI.appendPlugDeletionMenuDefinitions( plug, menuDefinition )
 
 GafferUI.GraphEditor.plugContextMenuSignal().connect( __plugContextMenu, scoped = False )
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -478,6 +478,7 @@ nodeMenu.append( "/Utility/Reference", GafferUI.ReferenceUI.nodeMenuCreateComman
 nodeMenu.definition().append( "/Utility/Backdrop", { "command" : GafferUI.BackdropUI.nodeMenuCreateCommand } )
 nodeMenu.append( "/Utility/Dot", Gaffer.Dot )
 nodeMenu.append( "/Utility/Switch", Gaffer.Switch )
+nodeMenu.append( "/Utility/Name Switch", Gaffer.NameSwitch, searchText = "NameSwitch" )
 nodeMenu.append( "/Utility/Context Variables", Gaffer.ContextVariables, searchText = "ContextVariables" )
 nodeMenu.append( "/Utility/Delete Context Variables", Gaffer.DeleteContextVariables, searchText = "DeleteContextVariables" )
 nodeMenu.append( "/Utility/Time Warp", Gaffer.TimeWarp, searchText = "TimeWarp" )

--- a/startup/gui/nodeEditor.py
+++ b/startup/gui/nodeEditor.py
@@ -44,3 +44,9 @@ def __toolMenu( nodeEditor, node, menuDefinition ) :
 	GafferSceneUI.FilteredSceneProcessorUI.appendNodeEditorToolMenuDefinitions( nodeEditor, node, menuDefinition )
 
 GafferUI.NodeEditor.toolMenuSignal().connect( __toolMenu, scoped = False )
+
+def __plugPopupMenu( menuDefinition, plugValueWidget ) :
+
+	GafferUI.NodeUI.appendPlugDeletionMenuDefinitions( plugValueWidget, menuDefinition )
+
+GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu, scoped = False )


### PR DESCRIPTION
This adds the NameSwitch node as per #2853. The ArrayPlug changes contain a small ABI change, so can't be backported to 0.54 or 0.53 as-is. We can use a nasty `IECore::ClassData` approach if we do want to backport them, but I didn't want that in master.