### PR TITLE
OrientationUI: Allow user to specify prim var name for Houdini's quaternion

### DIFF
--- a/python/GafferSceneUI/OrientationUI.py
+++ b/python/GafferSceneUI/OrientationUI.py
@@ -72,7 +72,7 @@ Gaffer.Metadata.registerNode(
 	""",
 
 	"layout:activator:inModeIsEuler", lambda node : node["inMode"].getValue() == GafferScene.Orientation.Mode.Euler,
-	"layout:activator:inModeIsQuaternion", lambda node : node["inMode"].getValue() == GafferScene.Orientation.Mode.Quaternion,
+	"layout:activator:inModeIsQuaternion", lambda node : node["inMode"].getValue() in ( GafferScene.Orientation.Mode.Quaternion, GafferScene.Orientation.Mode.QuaternionXYZW ),
 	"layout:activator:inModeIsAxisAngle", lambda node : node["inMode"].getValue() == GafferScene.Orientation.Mode.AxisAngle,
 	"layout:activator:inModeIsAim", lambda node : node["inMode"].getValue() == GafferScene.Orientation.Mode.Aim,
 	"layout:activator:inModeIsMatrix", lambda node : node["inMode"].getValue() == GafferScene.Orientation.Mode.Matrix,


### PR DESCRIPTION
Allow user to specify in quaternion prim var name when using Houdini's quternion mode (#3352).

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
