### PR TITLE
 ShaderTweaks : Add `ignoreMissing` plug 

### DIFF
--- a/include/GafferScene/ShaderTweaks.h
+++ b/include/GafferScene/ShaderTweaks.h
@@ -58,6 +58,9 @@ class GAFFERSCENE_API ShaderTweaks : public SceneElementProcessor
 		Gaffer::StringPlug *shaderPlug();
 		const Gaffer::StringPlug *shaderPlug() const;
 
+		Gaffer::BoolPlug *ignoreMissingPlug();
+		const Gaffer::BoolPlug *ignoreMissingPlug() const;
+
 		GafferScene::TweaksPlug *tweaksPlug();
 		const GafferScene::TweaksPlug *tweaksPlug() const;
 

--- a/include/GafferScene/TweakPlug.h
+++ b/include/GafferScene/TweakPlug.h
@@ -106,10 +106,8 @@ class GAFFERSCENE_API TweakPlug : public Gaffer::ValuePlug
 		};
 
 		/// \deprecated. Use `TweaksPlug::applyTweaks()` instead.
-		void applyTweak( IECore::CompoundData *parameters, bool requireExists = false ) const;
-		void applyTweak( IECore::CompoundData *parameters, MissingMode missingMode ) const;
-		static void applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork *shaderNetwork );
-		static void applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork *shaderNetwork, MissingMode missingMode );
+		void applyTweak( IECore::CompoundData *parameters, MissingMode missingMode = MissingMode::Error ) const;
+		static void applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork *shaderNetwork, MissingMode missingMode = MissingMode::Error );
 
 	private :
 
@@ -144,11 +142,8 @@ class GAFFERSCENE_API TweaksPlug : public Gaffer::ValuePlug
 		/// Tweak application
 		/// =================
 
-		void applyTweaks( IECore::CompoundData *parameters, bool requireExists = false ) const;
-		void applyTweaks( IECore::CompoundData *parameters, TweakPlug::MissingMode missingMode ) const;
-		void applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork ) const;
-		/// \todo Add default value for `missingMode` and remove version above.
-		void applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork, TweakPlug::MissingMode missingMode ) const;
+		void applyTweaks( IECore::CompoundData *parameters, TweakPlug::MissingMode missingMode = TweakPlug::MissingMode::Error ) const;
+		void applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork, TweakPlug::MissingMode missingMode = TweakPlug::MissingMode::Error ) const;
 
 };
 

--- a/include/GafferScene/TweakPlug.h
+++ b/include/GafferScene/TweakPlug.h
@@ -91,9 +91,25 @@ class GAFFERSCENE_API TweakPlug : public Gaffer::ValuePlug
 		/// ValuePlug::hash( h )
 		using ValuePlug::hash;
 
+		/// Controls behaviour when the parameter to be
+		/// tweaked cannot be found.
+		enum class MissingMode
+		{
+			Ignore,
+			Error,
+			/// Legacy mode used by CameraTweaks. Same as
+			/// Ignore mode except when `Mode == Replace`, in
+			/// which case a new parameter is created.
+			/// \deprecated Do not use in new code. If you find
+			/// yourself wanting to, add Mode::Create instead.
+			IgnoreOrReplace,
+		};
+
 		/// \deprecated. Use `TweaksPlug::applyTweaks()` instead.
 		void applyTweak( IECore::CompoundData *parameters, bool requireExists = false ) const;
+		void applyTweak( IECore::CompoundData *parameters, MissingMode missingMode ) const;
 		static void applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork *shaderNetwork );
+		static void applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork *shaderNetwork, MissingMode missingMode );
 
 	private :
 
@@ -129,7 +145,10 @@ class GAFFERSCENE_API TweaksPlug : public Gaffer::ValuePlug
 		/// =================
 
 		void applyTweaks( IECore::CompoundData *parameters, bool requireExists = false ) const;
+		void applyTweaks( IECore::CompoundData *parameters, TweakPlug::MissingMode missingMode ) const;
 		void applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork ) const;
+		/// \todo Add default value for `missingMode` and remove version above.
+		void applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork, TweakPlug::MissingMode missingMode ) const;
 
 };
 

--- a/python/GafferSceneTest/TweakPlugTest.py
+++ b/python/GafferSceneTest/TweakPlugTest.py
@@ -83,7 +83,7 @@ class TweakPlugTest( GafferSceneTest.SceneTestCase ) :
 		tweaks.addChild( GafferScene.TweakPlug( "a", 1.0, GafferScene.TweakPlug.Mode.Replace ) )
 		tweaks.addChild( GafferScene.TweakPlug( "b", 10.0, GafferScene.TweakPlug.Mode.Multiply ) )
 
-		parameters = IECore.CompoundData( { "b" : 2.0 } )
+		parameters = IECore.CompoundData( { "a" : 0.0, "b" : 2.0 } )
 		tweaks.applyTweaks( parameters )
 		self.assertEqual( parameters, IECore.CompoundData( { "a" : 1.0, "b" : 20.0 } ) )
 

--- a/python/GafferSceneTest/TweakPlugTest.py
+++ b/python/GafferSceneTest/TweakPlugTest.py
@@ -131,6 +131,37 @@ class TweakPlugTest( GafferSceneTest.SceneTestCase ) :
 		with self.assertRaisesRegexp( RuntimeError, "Cannot apply tweak to \"test\" : Value of type \"IntData\" does not match parameter of type \"Color3fData\"" ) :
 			p.applyTweak( d )
 
+	def testMissingMode( self ) :
+
+		p = GafferScene.TweaksPlug()
+		p["t"] = GafferScene.TweakPlug( "test", 0.5, GafferScene.TweakPlug.Mode.Replace )
+
+		d = IECore.CompoundData()
+		with self.assertRaisesRegexp( RuntimeError, "Cannot apply tweak with mode Replace to \"test\" : This parameter does not exist" ) :
+			p.applyTweaks( d, missingMode = GafferScene.TweakPlug.MissingMode.Error )
+		self.assertEqual( d, IECore.CompoundData() )
+
+		d = IECore.CompoundData()
+		p.applyTweaks( d, missingMode = GafferScene.TweakPlug.MissingMode.Ignore )
+		self.assertEqual( d, IECore.CompoundData() )
+
+		d = IECore.CompoundData()
+		p.applyTweaks( d, missingMode = GafferScene.TweakPlug.MissingMode.IgnoreOrReplace )
+		self.assertEqual( d, IECore.CompoundData( { "test" : 0.5 } ) )
+
+		d = IECore.CompoundData()
+		p["t"]["mode"].setValue( GafferScene.TweakPlug.Mode.Add )
+		with self.assertRaisesRegexp( RuntimeError, "Cannot apply tweak with mode Add to \"test\" : This parameter does not exist" ) :
+			p.applyTweaks( d, missingMode = GafferScene.TweakPlug.MissingMode.Error )
+		self.assertEqual( d, IECore.CompoundData() )
+
+		with self.assertRaisesRegexp( RuntimeError, "Cannot apply tweak with mode Add to \"test\" : This parameter does not exist" ) :
+			p.applyTweaks( d, missingMode = GafferScene.TweakPlug.MissingMode.IgnoreOrReplace )
+		self.assertEqual( d, IECore.CompoundData() )
+
+		p.applyTweaks( d, missingMode = GafferScene.TweakPlug.MissingMode.Ignore )
+		self.assertEqual( d, IECore.CompoundData() )
+
 	def testTweaksPlug( self ) :
 
 		p = GafferScene.TweaksPlug()
@@ -149,6 +180,39 @@ class TweakPlugTest( GafferSceneTest.SceneTestCase ) :
 
 		# Old scripts call a constructor with an outdated signature as below.
 		plug = GafferScene.TweakPlug( "exposure", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+	def testMissingModeForShaderNetwork( self ) :
+
+		network = IECoreScene.ShaderNetwork(
+			shaders = { "surface" : IECoreScene.Shader( "lambert", "ai:surface", { "Kd" : 0.25 } ) },
+			output = "surface"
+		)
+
+		p = GafferScene.TweaksPlug()
+		p["t"] = GafferScene.TweakPlug( "Ks", 0.5, GafferScene.TweakPlug.Mode.Replace )
+
+		networkCopy = network.copy()
+		with self.assertRaisesRegexp( RuntimeError, "Cannot apply tweak with mode Replace to \"Ks\" : This parameter does not exist" ) :
+			p.applyTweaks( networkCopy )
+
+		with self.assertRaisesRegexp( RuntimeError, "Cannot apply tweak with mode Replace to \"Ks\" : This parameter does not exist" ) :
+			p.applyTweaks( networkCopy, missingMode = GafferScene.TweakPlug.MissingMode.Error )
+
+		self.assertEqual( networkCopy, network )
+		p.applyTweaks( networkCopy, missingMode = GafferScene.TweakPlug.MissingMode.Ignore )
+		self.assertEqual( networkCopy, network )
+
+		p["t"]["name"].setValue( "missingShader.parameterName" )
+
+		with self.assertRaisesRegexp( RuntimeError, "Cannot apply tweak \"missingShader.parameterName\" because shader \"missingShader\" does not exist" ) :
+			p.applyTweaks( networkCopy )
+
+		with self.assertRaisesRegexp( RuntimeError, "Cannot apply tweak \"missingShader.parameterName\" because shader \"missingShader\" does not exist" ) :
+			p.applyTweaks( networkCopy, missingMode = GafferScene.TweakPlug.MissingMode.Error )
+
+		self.assertEqual( networkCopy, network )
+		p.applyTweaks( networkCopy, missingMode = GafferScene.TweakPlug.MissingMode.Ignore )
+		self.assertEqual( networkCopy, network )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/CameraTweaksUI.py
+++ b/python/GafferSceneUI/CameraTweaksUI.py
@@ -223,8 +223,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 		else :
 			plug = GafferScene.TweakPlug( name, plugTypeOrValue() )
 
-		if name:
-			plug.setName( "tweak_" + name )
+		plug.setName( name or "tweak1" )
 
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().addChild( plug )

--- a/python/GafferSceneUI/ShaderTweaksUI.py
+++ b/python/GafferSceneUI/ShaderTweaksUI.py
@@ -71,6 +71,17 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"ignoreMissing" : [
+
+			"description",
+			"""
+			Ignores tweaks targeting missing parameters. When off, missing parameters
+			cause the node to error.
+			"""
+
+		],
+
+
 		"tweaks" : [
 
 			"description",

--- a/src/GafferScene/CameraTweaks.cpp
+++ b/src/GafferScene/CameraTweaks.cpp
@@ -131,7 +131,7 @@ IECore::ConstObjectPtr CameraTweaks::computeProcessedObject( const ScenePath &pa
 			InternedString internedName(name);
 			CompoundDataPtr dummyParameters = new CompoundData();
 			dummyParameters->writable()[internedName] = new FloatData( result->calculateFieldOfView()[0] );
-			(*tIt)->applyTweak( dummyParameters.get() );
+			(*tIt)->applyTweak( dummyParameters.get(), TweakPlug::MissingMode::IgnoreOrReplace );
 			FloatData *tweakedData = dummyParameters->member<FloatData>( internedName );
 			if( tweakedData )
 			{
@@ -145,7 +145,7 @@ IECore::ConstObjectPtr CameraTweaks::computeProcessedObject( const ScenePath &pa
 			Imath::V2f aperture = result->getAperture();
 			CompoundDataPtr dummyParameters = new CompoundData();
 			dummyParameters->writable()[internedName] = new FloatData( aperture[0] / aperture[1] );
-			(*tIt)->applyTweak( dummyParameters.get() );
+			(*tIt)->applyTweak( dummyParameters.get(), TweakPlug::MissingMode::IgnoreOrReplace );
 			FloatData *tweakedData = dummyParameters->member<FloatData>( internedName );
 			if( tweakedData )
 			{
@@ -155,7 +155,7 @@ IECore::ConstObjectPtr CameraTweaks::computeProcessedObject( const ScenePath &pa
 		}
 		else
 		{
-			(*tIt)->applyTweak( result->parametersData() );
+			(*tIt)->applyTweak( result->parametersData(), TweakPlug::MissingMode::IgnoreOrReplace );
 		}
 	}
 

--- a/src/GafferScene/TweakPlug.cpp
+++ b/src/GafferScene/TweakPlug.cpp
@@ -325,11 +325,6 @@ void applyTweakInternal( TweakPlug::Mode mode, const ValuePlug *valuePlug, const
 
 } // namespace
 
-void TweakPlug::applyTweak( IECore::CompoundData *parameters, bool requireExists ) const
-{
-	applyTweak( parameters, requireExists ? MissingMode::Error : MissingMode::IgnoreOrReplace );
-}
-
 void TweakPlug::applyTweak( IECore::CompoundData *parameters, MissingMode missingMode ) const
 {
 	if( !enabledPlug()->getValue() )
@@ -345,11 +340,6 @@ void TweakPlug::applyTweak( IECore::CompoundData *parameters, MissingMode missin
 
 	const Mode mode = static_cast<Mode>( modePlug()->getValue() );
 	applyTweakInternal( mode, this->valuePlug(), name, name, parameters, missingMode );
-}
-
-void TweakPlug::applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork *shaderNetwork )
-{
-	applyTweaks( tweaksPlug, shaderNetwork, TweakPlug::MissingMode::Error );
 }
 
 void TweakPlug::applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork *shaderNetwork, TweakPlug::MissingMode missingMode )
@@ -535,25 +525,12 @@ Gaffer::PlugPtr TweaksPlug::createCounterpart( const std::string &name, Directio
 	return result;
 }
 
-void TweaksPlug::applyTweaks( IECore::CompoundData *parameters, bool requireExists ) const
-{
-	for( TweakPlugIterator it( this ); !it.done(); ++it )
-	{
-		(*it)->applyTweak( parameters, requireExists );
-	}
-}
-
 void TweaksPlug::applyTweaks( IECore::CompoundData *parameters, TweakPlug::MissingMode missingMode ) const
 {
 	for( TweakPlugIterator it( this ); !it.done(); ++it )
 	{
 		(*it)->applyTweak( parameters, missingMode );
 	}
-}
-
-void TweaksPlug::applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork ) const
-{
-	TweakPlug::applyTweaks( this, shaderNetwork );
 }
 
 void TweaksPlug::applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork, TweakPlug::MissingMode missingMode ) const

--- a/src/GafferScene/TweakPlug.cpp
+++ b/src/GafferScene/TweakPlug.cpp
@@ -354,6 +354,11 @@ void TweakPlug::applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork 
 			continue;
 		}
 
+		if( !tweakPlug->enabledPlug()->getValue() )
+		{
+			continue;
+		}
+
 		ShaderNetwork::Parameter parameter;
 		size_t dotPos = name.find_last_of( '.' );
 		if( dotPos == string::npos )
@@ -365,11 +370,6 @@ void TweakPlug::applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork 
 		{
 			parameter.shader = InternedString( name.c_str(), dotPos );
 			parameter.name = InternedString( name.c_str() + dotPos + 1 );
-		}
-
-		if( !tweakPlug->enabledPlug()->getValue() )
-		{
-			continue;
 		}
 
 		const Mode mode = static_cast<Mode>( tweakPlug->modePlug()->getValue() );

--- a/src/GafferScene/TweakPlug.cpp
+++ b/src/GafferScene/TweakPlug.cpp
@@ -280,7 +280,7 @@ private:
 	const std::string &m_tweakName;
 };
 
-void applyTweakInternal( TweakPlug::Mode mode, const ValuePlug *valuePlug, const std::string &tweakName, const InternedString &parameterName, IECore::CompoundData *parameters, bool requireExists )
+void applyTweakInternal( TweakPlug::Mode mode, const ValuePlug *valuePlug, const std::string &tweakName, const InternedString &parameterName, IECore::CompoundData *parameters, TweakPlug::MissingMode missingMode )
 {
 	if( mode == TweakPlug::Remove )
 	{
@@ -301,20 +301,22 @@ void applyTweakInternal( TweakPlug::Mode mode, const ValuePlug *valuePlug, const
 		throw IECore::Exception( boost::str( boost::format( "Cannot apply tweak to \"%s\" : Value of type \"%s\" does not match parameter of type \"%s\"" ) % tweakName % parameterValue->typeName() % newData->typeName() ) );
 	}
 
-	if( mode == TweakPlug::Replace )
-	{
-		if( !parameterValue && requireExists )
-		{
-			throw IECore::Exception( boost::str( boost::format( "Cannot replace parameter \"%s\" which does not exist" ) % tweakName ) );
-		}
-
-		parameters->writable()[parameterName] = newData;
-		return;
-	}
-
 	if( !parameterValue )
 	{
-		throw IECore::Exception( boost::str( boost::format( "Cannot apply tweak with mode %s to \"%s\" : This parameter does not exist" ) % modeToString( mode ) % tweakName ) );
+		if( missingMode == TweakPlug::MissingMode::Ignore )
+		{
+			return;
+		}
+		else if( !( mode == TweakPlug::Replace && missingMode == TweakPlug::MissingMode::IgnoreOrReplace ) )
+		{
+			throw IECore::Exception( boost::str( boost::format( "Cannot apply tweak with mode %s to \"%s\" : This parameter does not exist" ) % modeToString( mode ) % tweakName ) );
+		}
+	}
+
+	if( mode == TweakPlug::Replace )
+	{
+		parameters->writable()[parameterName] = newData;
+		return;
 	}
 
 	NumericTweak t( newData.get(), mode, tweakName );
@@ -324,6 +326,11 @@ void applyTweakInternal( TweakPlug::Mode mode, const ValuePlug *valuePlug, const
 } // namespace
 
 void TweakPlug::applyTweak( IECore::CompoundData *parameters, bool requireExists ) const
+{
+	applyTweak( parameters, requireExists ? MissingMode::Error : MissingMode::IgnoreOrReplace );
+}
+
+void TweakPlug::applyTweak( IECore::CompoundData *parameters, MissingMode missingMode ) const
 {
 	if( !enabledPlug()->getValue() )
 	{
@@ -337,10 +344,15 @@ void TweakPlug::applyTweak( IECore::CompoundData *parameters, bool requireExists
 	}
 
 	const Mode mode = static_cast<Mode>( modePlug()->getValue() );
-	applyTweakInternal( mode, this->valuePlug(), name, name, parameters, requireExists );
+	applyTweakInternal( mode, this->valuePlug(), name, name, parameters, missingMode );
 }
 
 void TweakPlug::applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork *shaderNetwork )
+{
+	applyTweaks( tweaksPlug, shaderNetwork, TweakPlug::MissingMode::Error );
+}
+
+void TweakPlug::applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork *shaderNetwork, TweakPlug::MissingMode missingMode )
 {
 	unordered_map<InternedString, IECoreScene::ShaderPtr> modifiedShaders;
 
@@ -370,6 +382,21 @@ void TweakPlug::applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork 
 		{
 			parameter.shader = InternedString( name.c_str(), dotPos );
 			parameter.name = InternedString( name.c_str() + dotPos + 1 );
+		}
+
+		const IECoreScene::Shader *shader = shaderNetwork->getShader( parameter.shader );
+		if( !shader )
+		{
+			if( missingMode != TweakPlug::MissingMode::Ignore )
+			{
+				throw IECore::Exception( boost::str(
+					boost::format( "Cannot apply tweak \"%1%\" because shader \"%2%\" does not exist" ) % name % parameter.shader
+				) );
+			}
+			else
+			{
+				continue;
+			}
 		}
 
 		const Mode mode = static_cast<Mode>( tweakPlug->modePlug()->getValue() );
@@ -414,19 +441,10 @@ void TweakPlug::applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork 
 			auto modifiedShader = modifiedShaders.insert( { parameter.shader, nullptr } );
 			if( modifiedShader.second )
 			{
-				if( const IECoreScene::Shader *shader = shaderNetwork->getShader( parameter.shader ) )
-				{
-					modifiedShader.first->second = shader->copy();
-				}
-				else
-				{
-					throw IECore::Exception( boost::str(
-						boost::format( "Cannot apply tweak \"%1%\" because shader \"%2%\" does not exist" ) % name % parameter.shader
-					) );
-				}
+				modifiedShader.first->second = shader->copy();
 			}
 
-			applyTweakInternal( mode, tweakPlug->valuePlug(), name, parameter.name, modifiedShader.first->second->parametersData(), /* requireExists = */ true );
+			applyTweakInternal( mode, tweakPlug->valuePlug(), name, parameter.name, modifiedShader.first->second->parametersData(), missingMode );
 		}
 	}
 
@@ -525,7 +543,20 @@ void TweaksPlug::applyTweaks( IECore::CompoundData *parameters, bool requireExis
 	}
 }
 
+void TweaksPlug::applyTweaks( IECore::CompoundData *parameters, TweakPlug::MissingMode missingMode ) const
+{
+	for( TweakPlugIterator it( this ); !it.done(); ++it )
+	{
+		(*it)->applyTweak( parameters, missingMode );
+	}
+}
+
 void TweaksPlug::applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork ) const
 {
 	TweakPlug::applyTweaks( this, shaderNetwork );
+}
+
+void TweaksPlug::applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork, TweakPlug::MissingMode missingMode ) const
+{
+	TweakPlug::applyTweaks( this, shaderNetwork, missingMode );
 }

--- a/src/GafferSceneModule/TweaksBinding.cpp
+++ b/src/GafferSceneModule/TweaksBinding.cpp
@@ -61,10 +61,10 @@ TweakPlugPtr constructUsingData( const std::string &tweakName, IECore::ConstData
 	return new TweakPlug( tweakName, tweakValue.get(), mode, enabled );
 }
 
-void applyTweak( const TweakPlug &plug, IECore::CompoundData &parameters, bool requireExists )
+void applyTweak( const TweakPlug &plug, IECore::CompoundData &parameters, TweakPlug::MissingMode missingMode )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	plug.applyTweak( &parameters, requireExists );
+	plug.applyTweak( &parameters, missingMode );
 }
 
 void applyTweaks( const Plug &tweaksPlug, IECoreScene::ShaderNetwork &shaderNetwork, TweakPlug::MissingMode missingMode )
@@ -73,13 +73,7 @@ void applyTweaks( const Plug &tweaksPlug, IECoreScene::ShaderNetwork &shaderNetw
 	TweakPlug::applyTweaks( &tweaksPlug, &shaderNetwork, missingMode );
 }
 
-void applyTweaksToParameters( const TweaksPlug &tweaksPlug, IECore::CompoundData &parameters, bool requireExists )
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	tweaksPlug.applyTweaks( &parameters, requireExists );
-}
-
-void applyTweaksToParameters2( const TweaksPlug &tweaksPlug, IECore::CompoundData &parameters, TweakPlug::MissingMode missingMode )
+void applyTweaksToParameters( const TweaksPlug &tweaksPlug, IECore::CompoundData &parameters, TweakPlug::MissingMode missingMode )
 {
 	IECorePython::ScopedGILRelease gilRelease;
 	tweaksPlug.applyTweaks( &parameters, missingMode );
@@ -172,7 +166,7 @@ void GafferSceneModule::bindTweaks()
 				)
 			)
 		)
-		.def( "applyTweak", &applyTweak, ( arg( "parameters" ), arg( "requireExists" ) = false ) )
+		.def( "applyTweak", &applyTweak, ( arg( "parameters" ), arg( "missingMode" ) = TweakPlug::MissingMode::Error ) )
 		.def( "applyTweaks", &applyTweaks, ( arg( "shaderNetwork" ), arg( "missingMode" ) = TweakPlug::MissingMode::Error ) )
 		.staticmethod( "applyTweaks" )
 	;
@@ -190,8 +184,7 @@ void GafferSceneModule::bindTweaks()
 			)
 		)
 		.def( "applyTweaks", &applyTweaks, ( arg( "shaderNetwork" ), arg( "missingMode" ) = TweakPlug::MissingMode::Error ) )
-		.def( "applyTweaks", &applyTweaksToParameters, ( arg( "parameters" ), arg( "requireExists" ) = false ) )
-		.def( "applyTweaks", &applyTweaksToParameters2, ( arg( "parameters" ), arg( "missingMode" ) ) )
+		.def( "applyTweaks", &applyTweaksToParameters, ( arg( "parameters" ), arg( "missingMode" ) = TweakPlug::MissingMode::Error ) )
 	;
 
 }

--- a/src/GafferSceneModule/TweaksBinding.cpp
+++ b/src/GafferSceneModule/TweaksBinding.cpp
@@ -67,16 +67,22 @@ void applyTweak( const TweakPlug &plug, IECore::CompoundData &parameters, bool r
 	plug.applyTweak( &parameters, requireExists );
 }
 
-void applyTweaks( const Plug &tweaksPlug, IECoreScene::ShaderNetwork &shaderNetwork )
+void applyTweaks( const Plug &tweaksPlug, IECoreScene::ShaderNetwork &shaderNetwork, TweakPlug::MissingMode missingMode )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	TweakPlug::applyTweaks( &tweaksPlug, &shaderNetwork );
+	TweakPlug::applyTweaks( &tweaksPlug, &shaderNetwork, missingMode );
 }
 
 void applyTweaksToParameters( const TweaksPlug &tweaksPlug, IECore::CompoundData &parameters, bool requireExists )
 {
 	IECorePython::ScopedGILRelease gilRelease;
 	tweaksPlug.applyTweaks( &parameters, requireExists );
+}
+
+void applyTweaksToParameters2( const TweaksPlug &tweaksPlug, IECore::CompoundData &parameters, TweakPlug::MissingMode missingMode )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	tweaksPlug.applyTweaks( &parameters, missingMode );
 }
 
 class TweakPlugSerialiser : public ValuePlugSerialiser
@@ -116,12 +122,19 @@ void GafferSceneModule::bindTweaks()
 
 	{
 		scope tweakPlugScope = tweakPlugClass;
+
 		enum_<TweakPlug::Mode>( "Mode" )
 			.value( "Replace", TweakPlug::Replace )
 			.value( "Add", TweakPlug::Add )
 			.value( "Subtract", TweakPlug::Subtract )
 			.value( "Multiply", TweakPlug::Multiply )
 			.value( "Remove", TweakPlug::Remove )
+		;
+
+		enum_<TweakPlug::MissingMode>( "MissingMode" )
+			.value( "Ignore", TweakPlug::MissingMode::Ignore )
+			.value( "Error", TweakPlug::MissingMode::Error )
+			.value( "IgnoreOrReplace", TweakPlug::MissingMode::IgnoreOrReplace )
 		;
 	}
 
@@ -160,7 +173,7 @@ void GafferSceneModule::bindTweaks()
 			)
 		)
 		.def( "applyTweak", &applyTweak, ( arg( "parameters" ), arg( "requireExists" ) = false ) )
-		.def( "applyTweaks", &applyTweaks, ( arg( "shaderNetwork" ) ) )
+		.def( "applyTweaks", &applyTweaks, ( arg( "shaderNetwork" ), arg( "missingMode" ) = TweakPlug::MissingMode::Error ) )
 		.staticmethod( "applyTweaks" )
 	;
 
@@ -176,8 +189,9 @@ void GafferSceneModule::bindTweaks()
 				)
 			)
 		)
-		.def( "applyTweaks", &applyTweaks, ( arg( "shaderNetwork" ) ) )
+		.def( "applyTweaks", &applyTweaks, ( arg( "shaderNetwork" ), arg( "missingMode" ) = TweakPlug::MissingMode::Error ) )
 		.def( "applyTweaks", &applyTweaksToParameters, ( arg( "parameters" ), arg( "requireExists" ) = false ) )
+		.def( "applyTweaks", &applyTweaksToParameters2, ( arg( "parameters" ), arg( "missingMode" ) ) )
 	;
 
 }


### PR DESCRIPTION
This suppresses the errors that would usually be emitted by an attempt to tweak a non-existent parameter. Adding this turned out to be a lot more involved than anticipated, because of a latent bug in TweakPlug::Replace mode that happened to be quite convenient for CameraTweaks but doesn't make sense for ShaderTweaks. I've tried to fix it in such a way that those relying on the old behaviour aren't inconvenienced, but as documented in 834e7ba, it's not absolutely 100% watertight. There might be an argument for saying "bug fix, patch release, deal with it", but I think that's probably the wrong call. I have separately out the unnecessary-but-neater breaking changes of dfb9d94 into a separate commit though, in case anyone wants to make the case for backporting.