### PR TITLE
IECoreArnoldPreview::Renderer : Use Arnold's new progressive renderining API

### DIFF
--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -59,6 +59,8 @@ def __samplingSummary( plug ) :
 	info = []
 	if plug["aaSamples"]["enabled"].getValue() :
 		info.append( "AA %d" % plug["aaSamples"]["value"].getValue() )
+	if plug["progressiveMinAASamples"]["enabled"].getValue() :
+		info.append( "Min AA %d" % plug["progressiveMinAASamples"]["value"].getValue() )
 	if plug["giDiffuseSamples"]["enabled"].getValue() :
 		info.append( "Diffuse %d" % plug["giDiffuseSamples"]["value"].getValue() )
 	if plug["giSpecularSamples"]["enabled"].getValue() :
@@ -320,6 +322,22 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Sampling",
 			"label", "AA Samples",
+
+		],
+
+		"options.progressiveMinAASamples" : [
+
+			"description",
+			"""
+			Controls the number of rays per pixel
+			for the first low quality pass of
+			progressive rendering.  -4 will start
+			with large squares, 1 will start one
+			sample for every pixel.
+			""",
+
+			"layout:section", "Sampling",
+			"label", "Progressive Min AA Samples",
 
 		],
 

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -57,6 +57,7 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	// Sampling parameters
 
 	options->addChild( new Gaffer::NameValuePlug( "ai:AA_samples", new IECore::IntData( 3 ), false, "aaSamples" ) );
+	options->addChild( new Gaffer::NameValuePlug( "ai:progressive_min_AA_samples", new IECore::IntData( -4 ), "progressiveMinAASamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:GI_diffuse_samples", new IECore::IntData( 2 ), false, "giDiffuseSamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:GI_specular_samples", new IECore::IntData( 2 ), false, "giSpecularSamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:GI_transmission_samples", new IECore::IntData( 2 ), false, "giTransmissionSamples" ) );

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -259,6 +259,7 @@ const AtString g_dispHeightArnoldString( "disp_height" );
 const AtString g_dispPaddingArnoldString( "disp_padding" );
 const AtString g_dispZeroValueArnoldString( "disp_zero_value" );
 const AtString g_dispAutoBumpArnoldString( "disp_autobump" );
+const AtString g_enableProgressiveRenderString( "enable_progressive_render" );
 const AtString g_fileNameArnoldString( "filename" );
 const AtString g_filtersArnoldString( "filters" );
 const AtString g_funcPtrArnoldString( "funcptr" );
@@ -2501,90 +2502,6 @@ AtNode *convertProcedural( IECoreScenePreview::ConstProceduralPtr procedural, co
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
-// InteractiveRenderController
-//////////////////////////////////////////////////////////////////////////
-
-namespace
-{
-
-class InteractiveRenderController
-{
-
-	public :
-
-		InteractiveRenderController()
-		{
-			m_rendering = false;
-		}
-
-		void setRendering( bool rendering )
-		{
-			if( rendering == m_rendering )
-			{
-				return;
-			}
-
-			m_rendering = rendering;
-
-			if( rendering )
-			{
-				std::thread thread( boost::bind( &InteractiveRenderController::performInteractiveRender, this ) );
-				m_thread.swap( thread );
-			}
-			else
-			{
-				if( AiRendering() )
-				{
-					AiRenderInterrupt();
-				}
-				m_thread.join();
-			}
-		}
-
-		bool getRendering() const
-		{
-			return m_rendering;
-		}
-
-	private :
-
-		// Called in a background thread to control a
-		// progressive interactive render.
-		void performInteractiveRender()
-		{
-			AtNode *options = AiUniverseGetOptions();
-			const int finalAASamples = AiNodeGetInt( options, g_aaSamplesArnoldString );
-			const int startAASamples = min( -5, finalAASamples );
-
-			for( int aaSamples = startAASamples; aaSamples <= finalAASamples; ++aaSamples )
-			{
-				if( aaSamples == 0 || ( aaSamples > 1 && aaSamples != finalAASamples ) )
-				{
-					// 0 AA_samples is meaningless, and we want to jump straight
-					// from 1 AA_sample to the final sampling quality.
-					continue;
-				}
-
-				AiNodeSetInt( options, g_aaSamplesArnoldString, aaSamples );
-				if( !m_rendering || AiRender( AI_RENDER_MODE_CAMERA ) != AI_SUCCESS )
-				{
-					// Render cancelled on main thread.
-					break;
-				}
-			}
-
-			// Restore the setting we've been monkeying with.
-			AiNodeSetInt( options, g_aaSamplesArnoldString, finalAASamples );
-		}
-
-		std::thread m_thread;
-		tbb::atomic<bool> m_rendering;
-
-};
-
-} // namespace
-
-//////////////////////////////////////////////////////////////////////////
 // Globals
 //////////////////////////////////////////////////////////////////////////
 
@@ -2601,6 +2518,7 @@ IECore::InternedString g_logMaxWarningsOptionName( "ai:log:max_warnings" );
 IECore::InternedString g_statisticsFileNameOptionName( "ai:statisticsFileName" );
 IECore::InternedString g_pluginSearchPathOptionName( "ai:plugin_searchpath" );
 IECore::InternedString g_aaSeedOptionName( "ai:AA_seed" );
+IECore::InternedString g_progressiveMinAASamplesOptionName( "ai:progressive_min_AA_samples" );
 IECore::InternedString g_sampleMotionOptionName( "sampleMotion" );
 IECore::InternedString g_atmosphereOptionName( "ai:atmosphere" );
 IECore::InternedString g_backgroundOptionName( "ai:background" );
@@ -2622,12 +2540,22 @@ class ArnoldGlobals
 				m_logFileFlags( g_logFlagsDefault ),
 				m_consoleFlags( g_consoleFlagsDefault ),
 				m_shaderCache( shaderCache ),
+				m_renderBegun( false ),
 				m_assFileName( fileName )
 		{
 			AiMsgSetLogFileFlags( m_logFileFlags );
 			AiMsgSetConsoleFlags( m_consoleFlags );
 			// Get OSL shaders onto the shader searchpath.
 			option( g_pluginSearchPathOptionName, new IECore::StringData( "" ) );
+		}
+
+		~ArnoldGlobals()
+		{
+			if( m_renderBegun )
+			{
+				AiRenderInterrupt( AI_BLOCKING );
+				AiRenderEnd();
+			}
 		}
 
 		void option( const IECore::InternedString &name, const IECore::Object *value )
@@ -2737,6 +2665,18 @@ class ArnoldGlobals
 				{
 					return;
 				}
+			}
+			else if( name == g_progressiveMinAASamplesOptionName )
+			{
+				if( value == nullptr )
+				{
+					m_progressiveMinAASamples = boost::none;
+				}
+				else if( const IECore::IntData *d = reportedCast<const IECore::IntData>( value, "option", name ) )
+				{
+					m_progressiveMinAASamples = d->readable();
+				}
+				return;
 			}
 			else if( name == g_aaSeedOptionName )
 			{
@@ -2958,15 +2898,33 @@ class ArnoldGlobals
 					// If we want to use Arnold's progressive refinement, we can't be constantly switching
 					// the camera around, so just use the default camera
 					updateCamera( m_cameraName );
-					m_interactiveRenderController.setRendering( true );
 
+					AiNodeSetBool( AiUniverseGetOptions(), g_enableProgressiveRenderString, true );
+					AiRenderSetHintBool( AtString( "progressive" ), true );
+					AiRenderSetHintInt( AtString( "progressive_min_AA_samples" ), m_progressiveMinAASamples.get_value_or( -4 ) );
+
+					if( !m_renderBegun )
+					{
+						AiRenderBegin( AI_RENDER_MODE_CAMERA );
+
+						// Arnold's AiRenderGetStatus is not particularly reliable - renders start up on a separate thread,
+						// and the currently reported status may not include recent changes.  So instead, we track a basic
+						// status flag for whether we are already rendering ourselves
+						m_renderBegun = true;
+					}
+					else
+					{
+						AiRenderRestart();
+					}
 					break;
 			}
 		}
 
 		void pause()
 		{
-			m_interactiveRenderController.setRendering( false );
+			// We need to block here because pause() is used to make sure that the render isn't running
+			// before performing IPR edits.
+			AiRenderInterrupt( AI_BLOCKING );
 		}
 
 	private :
@@ -3242,12 +3200,11 @@ class ArnoldGlobals
 		int m_consoleFlags;
 		boost::optional<int> m_frame;
 		boost::optional<int> m_aaSeed;
+		boost::optional<int> m_progressiveMinAASamples;
 		boost::optional<bool> m_sampleMotion;
 		ShaderCache *m_shaderCache;
 
-		// Members used by interactive renders
-
-		InteractiveRenderController m_interactiveRenderController;
+		bool m_renderBegun;
 
 		// Members used by ass generation "renders"
 


### PR DESCRIPTION
Probably a good time to start talking about this PR again.  I'd hacked it up quite a while ago, but had never been able to get it working reliably.  As of Arnold 5.4, AiRenderAbort( AI_BLOCKING ) appears to actually reliably abort the render, and I'm no longer seeing sporadic failures in the interactive testes.

It's nice to get rid of some of our code, and bring ourselves more in line with how SolidAngle expects us to do interactive renders - plus this PR also exposes the progressive_min_aa_samples parameter - we've been needing this badly for a long time.

Hopefully we can now merge this once we can update the dependency package to Arnold 5.4.