### PR TITLE
CompoundEditor : Fix broken key commands in DetachedPanels

### DIFF
--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -62,7 +62,7 @@ class CompoundEditor( GafferUI.Editor ) :
 
 		self.__splitContainer.append( _TabbedContainer() )
 
-		self.__splitContainer.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ), scoped = False )
+		self.__splitContainer.keyPressSignal().connect( CompoundEditor.__keyPress, scoped = False )
 		self.visibilityChangedSignal().connect( Gaffer.WeakMethod( self.__visibilityChanged ), scoped = False )
 
 		self.__windowState = windowState or {}
@@ -135,12 +135,15 @@ class CompoundEditor( GafferUI.Editor ) :
 
 		panel = _DetachedPanel( self,  *args, **kwargs )
 		panel.__removeOnCloseConnection = panel.closedSignal().connect( lambda w : w.parent()._removeDetachedPanel( w ) )
+		panel.keyPressSignal().connect( CompoundEditor.__keyPress, scoped = False )
 
 		scriptWindow = self.ancestor( GafferUI.ScriptWindow )
 		if scriptWindow :
 			panel.setTitle( scriptWindow.getTitle() )
 			weakSetTitle = Gaffer.WeakMethod( panel.setTitle )
 			panel.__titleChangedConnection = scriptWindow.titleChangedSignal().connect( lambda w, t : weakSetTitle( t ) )
+			# It's not directly in the qt hierarchy so shortcut events don't make it to the MenuBar
+			scriptWindow.menuBar().addShortcutTarget( panel )
 
 		self.__detachedPanels.append( panel )
 		return panel
@@ -187,7 +190,8 @@ class CompoundEditor( GafferUI.Editor ) :
 			[ p.reprArgs() for p in self.__detachedPanels ]
 		)
 
-	def __keyPress( self, unused, event ) :
+	@staticmethod
+	def __keyPress( unused, event ) :
 
 		if event.key == "Space" :
 
@@ -205,7 +209,7 @@ class CompoundEditor( GafferUI.Editor ) :
 					childIndex = parent.index( widget )
 					ancestors.append(
 						Ancestor(
-							parent, childIndex, self.__handlePosition( parent )
+							parent, childIndex, CompoundEditor.__handlePosition( parent )
 						)
 					)
 				widget = parent

--- a/python/GafferUI/ScriptWindow.py
+++ b/python/GafferUI/ScriptWindow.py
@@ -72,6 +72,10 @@ class ScriptWindow( GafferUI.Window ) :
 
 		ScriptWindow.__instances.append( weakref.ref( self ) )
 
+	def menuBar( self ) :
+
+		return self.__listContainer[0]
+
 	def scriptNode( self ) :
 
 		return self.__script


### PR DESCRIPTION
Fixes #3357.

Detached Panels don't exist under a `ScriptWindow` in the Qt hierarchy so they can exist as independent windows. This meant that several key handling mechanisms were missing.

This reinstates `<ctrl>-t` and `<space>` layout shortcuts, as well as any menu item shortcuts.

### API Changes :

 - Adds `ScriptWindow.menuBar()` to allow access to the windows MenuBar
 - Adds `MenuBar.addShortcutTarget` to allow key events received by other
    widgets to trigger menu actions held by the menu bar.
