### PR TITLE
ScriptWindow : Ensure ScriptWindow scriptAdded callback always runs first

### DIFF
--- a/python/GafferUI/ScriptWindow.py
+++ b/python/GafferUI/ScriptWindow.py
@@ -166,7 +166,7 @@ class ScriptWindow( GafferUI.Window ) :
 	@classmethod
 	def connect( cls, applicationRoot ) :
 
-		applicationRoot["scripts"].childAddedSignal().connect( ScriptWindow.__scriptAdded, scoped = False )
+		applicationRoot["scripts"].childAddedSignal().connect( 0, ScriptWindow.__scriptAdded, scoped = False )
 		applicationRoot["scripts"].childRemovedSignal().connect( ScriptWindow.__staticScriptRemoved, scoped = False )
 
 	__automaticallyCreatedInstances = [] # strong references to instances made by __scriptAdded()


### PR DESCRIPTION
`GafferUI.ScriptWindow.__scriptAdded` needs to run first. Otherwise, anyone wishing to modify the ScriptWindow (via 'acquire') may run first, create their own window, which then gets destroyed. This ensures that we always create, configure (and properly retain) script windows.