### PR TITLE
Arnold metadata : Disable `camera_projection.camera` parameter

### DIFF
--- a/arnold/plugins/gaffer.mtd
+++ b/arnold/plugins/gaffer.mtd
@@ -346,6 +346,10 @@
 
 	gaffer.nodeMenu.category STRING "Utility"
 
+	[attr camera]
+
+		gaffer.plugType STRING ""
+
 
 [node checkerboard]
 


### PR DESCRIPTION
This is an Arnold parameter of type `NODE` that can't currently be represented in Gaffer. Despite this limitation, folks _are_ still using the `camera_projection` shader in practice, because by default Arnold uses the render camera, and that's often what you want. Until now though, they've been habitually ignoring the `Unsupported parameter "camera" of type "NODE"` warnings that occurred during loading. By explicitly disabling the parameter, we avoid those warnings, stop worrying people, and hopefully encourage them not to ignore any other warnings that might remain.
