### PR TITLE
GafferCortex: Support userData to enable StringParameter substitutions

### DIFF
--- a/include/GafferCortex/TypedParameterHandler.h
+++ b/include/GafferCortex/TypedParameterHandler.h
@@ -73,6 +73,8 @@ class GAFFERCORTEX_API TypedParameterHandler : public ParameterHandler
 	private :
 
 		typename PlugType::Ptr createPlug( Gaffer::Plug::Direction direction ) const;
+		// variant for StringPlugs
+		typename PlugType::Ptr createPlug( Gaffer::Plug::Direction direction, Gaffer::Context::Substitutions substitutions ) const;
 
 		typename ParameterType::Ptr m_parameter;
 		typename PlugType::Ptr m_plug;

--- a/python/GafferCortexTest/ParameterHandlerTest.py
+++ b/python/GafferCortexTest/ParameterHandlerTest.py
@@ -254,5 +254,17 @@ class ParameterHandlerTest( GafferTest.TestCase ) :
 		h.setupPlug( n )
 		self.assertEqual( n["s"].substitutions(), Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.FrameSubstitutions )
 
+		# make sure connections are maintained as well
+		nn = Gaffer.Node()
+		nn["driver"] = Gaffer.StringPlug()
+		n["s"].setInput( nn["driver"] )
+		# we're forcing a re-creation of the plug because substitutions have changed
+		p.userData()["gaffer"] = IECore.CompoundObject( {
+			"substitutions" : IECore.IntData( Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.VariableSubstitutions ),
+		} )
+		h.setupPlug( n )
+		self.assertEqual( n["s"].substitutions(), Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.VariableSubstitutions )
+		self.assertEqual( n["s"].getInput(), nn["driver"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferCortexTest/ParameterHandlerTest.py
+++ b/python/GafferCortexTest/ParameterHandlerTest.py
@@ -238,5 +238,21 @@ class ParameterHandlerTest( GafferTest.TestCase ) :
 		self.assertNotEqual( hash1, hash3 )
 		self.assertNotEqual( hash2, hash3 )
 
+	def testSubstitutions( self ) :
+
+		p = IECore.StringParameter( "s", "d", "" )
+
+		n = Gaffer.Node()
+		h = GafferCortex.ParameterHandler.create( p )
+		h.setupPlug( n )
+		self.assertEqual( n["s"].substitutions(), Gaffer.Context.Substitutions.AllSubstitutions )
+
+		# adding substitutions should affect the plug
+		p.userData()["gaffer"] = IECore.CompoundObject( {
+			"substitutions" : IECore.IntData( Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.FrameSubstitutions ),
+		} )
+		h.setupPlug( n )
+		self.assertEqual( n["s"].substitutions(), Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.FrameSubstitutions )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferCortex/TypedParameterHandler.cpp
+++ b/src/GafferCortex/TypedParameterHandler.cpp
@@ -96,7 +96,7 @@ Gaffer::Plug *TypedParameterHandler<T>::setupPlug( Gaffer::GraphComponent *plugP
 	if( !m_plug || m_plug->direction()!=direction )
 	{
 		m_plug = createPlug( direction );
-		plugParent->setChild( m_parameter->name(), m_plug );
+		Gaffer::PlugAlgo::replacePlug( plugParent, m_plug );
 	}
 
 	setupPlugFlags( m_plug.get(), flags );
@@ -124,7 +124,7 @@ Gaffer::Plug *TypedParameterHandler<std::string>::setupPlug( Gaffer::GraphCompon
 	if( !m_plug || m_plug->direction()!=direction || m_plug->substitutions()!=substitutions )
 	{
 		m_plug = createPlug( direction, substitutions );
-		plugParent->setChild( m_parameter->name(), m_plug );
+		Gaffer::PlugAlgo::replacePlug( plugParent, m_plug );
 	}
 
 	setupPlugFlags( m_plug.get(), flags );

--- a/src/GafferCortex/TypedParameterHandler.cpp
+++ b/src/GafferCortex/TypedParameterHandler.cpp
@@ -37,8 +37,10 @@
 
 #include "GafferCortex/TypedParameterHandler.h"
 
+#include "Gaffer/PlugAlgo.h"
 #include "Gaffer/TypedPlug.h"
 
+#include "IECore/CompoundObject.h"
 #include "IECore/TypedParameter.h"
 
 namespace GafferCortex
@@ -82,14 +84,9 @@ typename TypedParameterHandler<T>::PlugType::Ptr TypedParameterHandler<T>::creat
 }
 
 template<>
-TypedParameterHandler<std::string>::PlugType::Ptr TypedParameterHandler<std::string>::createPlug( Gaffer::Plug::Direction direction ) const
+TypedParameterHandler<std::string>::PlugType::Ptr TypedParameterHandler<std::string>::createPlug( Gaffer::Plug::Direction direction, Gaffer::Context::Substitutions substitutions ) const
 {
-	return new Gaffer::StringPlug(
-		m_parameter->name(), direction, m_parameter->typedDefaultValue(), Gaffer::Plug::Default,
-		// We have to turn off substitutions for FileSequenceParameters because they'd remove the
-		// #### destined for the parameter.
-		m_parameter->isInstanceOf( IECore::FileSequenceParameterTypeId ) ? Gaffer::Context::NoSubstitutions : Gaffer::Context::AllSubstitutions
-	);
+	return new Gaffer::StringPlug( m_parameter->name(), direction, m_parameter->typedDefaultValue(), Gaffer::Plug::Default, substitutions );
 }
 
 template<typename T>
@@ -99,6 +96,34 @@ Gaffer::Plug *TypedParameterHandler<T>::setupPlug( Gaffer::GraphComponent *plugP
 	if( !m_plug || m_plug->direction()!=direction )
 	{
 		m_plug = createPlug( direction );
+		plugParent->setChild( m_parameter->name(), m_plug );
+	}
+
+	setupPlugFlags( m_plug.get(), flags );
+
+	return m_plug.get();
+}
+
+template<>
+Gaffer::Plug *TypedParameterHandler<std::string>::setupPlug( Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction, unsigned flags )
+{
+	// We have to turn off substitutions for FileSequenceParameters because they'd remove the
+	// #### destined for the parameter.
+	Gaffer::Context::Substitutions substitutions = m_parameter->isInstanceOf( IECore::FileSequenceParameterTypeId ) ? Gaffer::Context::NoSubstitutions : Gaffer::Context::AllSubstitutions;
+
+	// We also allow individual parameters to override the substitutions via userData
+	if( const auto *gafferUserData = m_parameter->userData()->member<IECore::CompoundObject>( "gaffer" ) )
+	{
+		if( const auto *substitutionsUserData = gafferUserData->member<IECore::IntData>( "substitutions" ) )
+		{
+			substitutions = (Gaffer::Context::Substitutions)substitutionsUserData->readable();
+		}
+	}
+
+	m_plug = plugParent->getChild<PlugType>( m_parameter->name() );
+	if( !m_plug || m_plug->direction()!=direction || m_plug->substitutions()!=substitutions )
+	{
+		m_plug = createPlug( direction, substitutions );
 		plugParent->setChild( m_parameter->name(), m_plug );
 	}
 


### PR DESCRIPTION
We have a bizarre workflow at IE where we translate back and forth between Plugs and Parameters several times. Previously, the round tripping from `Plug -> Parameter -> Plug` was losing the substitutions on StringPlugs, but now we're able to maintain them but stashing them in userData on the parameter.

I'll need a backport for 0.54_maintenance once we confirm the code is appropriate.