### PR TITLE
EditMenu : Consider detached panels when determining an action's scope

### DIFF
--- a/python/GafferUI/EditMenu.py
+++ b/python/GafferUI/EditMenu.py
@@ -97,15 +97,9 @@ def scope( menu ) :
 	scriptWindow = menu.ancestor( GafferUI.ScriptWindow )
 
 	graphEditor = None
-	## \todo Add public methods for querying focus.
-	focusWidget = GafferUI.Widget._owner( scriptWindow._qtWidget().focusWidget() )
-	if focusWidget is not None :
-		graphEditor = focusWidget.ancestor( GafferUI.GraphEditor )
 
-	if graphEditor is None :
-		graphEditors = scriptWindow.getLayout().editors( GafferUI.GraphEditor )
-		if graphEditors :
-			graphEditor = graphEditors[0]
+	if isinstance( scriptWindow.getLayout(), GafferUI.CompoundEditor ) :
+		graphEditor = scriptWindow.getLayout().editor( GafferUI.GraphEditor, focussedOnly = False )
 
 	if graphEditor is not None :
 		parent = graphEditor.graphGadget().getRoot()


### PR DESCRIPTION
`EditMenu.scope` wasn't taking into account any `GraphEditors` in detached panels. In order to keep `DetachedPanel` a private implementation detail of `CompoundEditor`, this moves the editor search into `CompoundEditor`, providing a public method to retrieve the focused editor of any required type.

## User facing changes

Any actions that determine a root of operation by searching for the nodes viewed in the foreground `GraphEditor` (eg: Copy/Paste), now return the root found from the first of the following candidates:
   
  1. The Graph Editor under the mouse of the active window.
  2. The first Graph Editor in the active window.
  3. The first Graph Editor in the layout.

If no suitable editors are found, then actions will be applied at the top level of the script.

## API changes:

 - Adds `CompoundEditor.focusedEditor` to retrieve the first editor of any requested type based on the logic described above