### PR TITLE
OSLExpression : Fix compute when time is not needed.

### DIFF
--- a/python/GafferOSLTest/OSLExpressionEngineTest.py
+++ b/python/GafferOSLTest/OSLExpressionEngineTest.py
@@ -393,7 +393,7 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 			c.setTime( 2 )
 			self.assertEqual( s["n"]["user"]["f"].getValue(), 2 )
 
-	def testHashIgnoresTimeWhenTimeNotReferenced( self ) :
+	def testIgnoresTimeWhenTimeNotReferenced( self ) :
 
 		s = Gaffer.ScriptNode()
 
@@ -410,6 +410,10 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 			h2 = s["n"]["user"]["f"].hash()
 
 		self.assertEqual( h1, h2 )
+
+		with Gaffer.Context() as c :
+			del c["frame"]
+			self.assertEqual( s["n"]["user"]["f"].getValue(), 1 )
 
 	def testDeleteOutputPlug( self ) :
 

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -230,6 +230,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 			m_inParameters.clear();
 			m_outSymbols.clear();
 			m_shaderGroup.reset();
+			m_needsTime = false;
 
 			// Find all references to plugs within the expression.
 			vector<string> inPlugPaths;
@@ -301,6 +302,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 					{
 						contextVariables.push_back( "frame" );
 						contextVariables.push_back( "framesPerSecond" );
+						m_needsTime = true;
 						break;
 					}
 				}
@@ -323,7 +325,10 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 		    OSL::ShaderGlobals shaderGlobals;
 			memset( &shaderGlobals, 0, sizeof( ShaderGlobals ) );
 
-			shaderGlobals.time = context->getTime();
+			if( m_needsTime )
+			{
+				shaderGlobals.time = context->getTime();
+			}
 
 			RenderState renderState;
 			renderState.inParameters = &m_inParameters;
@@ -811,6 +816,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 		}
 
 		// Initialised by parse().
+		bool m_needsTime;
 		vector<ustring> m_inParameters;
 		vector<const OSL::ShaderSymbol *> m_outSymbols;
 		OSL::ShaderGroupRef m_shaderGroup;


### PR DESCRIPTION
Previosuly we were only hashing time (frame) when needed, but our compute didn't respect this, which could result in errors like the following when computing an OSLExpression during a `gaffer execute` process:

```
ProcessException: e.__execute : Context has no entry named "frame"
```

I'll need to backport this one to 0.54_maintenance as well.