### PR TITLE
Updated plug colors

### DIFF
--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -64,6 +64,7 @@ Gaffer.Metadata.registerValue( Gaffer.Expression, "nodeGadget:color", imath.Colo
 Gaffer.Metadata.registerValue( Gaffer.Animation, "nodeGadget:color", imath.Color3f( 0.3, 0.3, 0.45 ) )
 
 Gaffer.Metadata.registerValue( GafferScene.ScenePlug, "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
+Gaffer.Metadata.registerValue( GafferScene.ScenePlug, "connectionGadget:color", imath.Color3f( 0.11, 0.14, 0.265 ) )
 
 Gaffer.Metadata.registerValue( GafferScene.SceneProcessor, "nodeGadget:color", imath.Color3f( 0.495, 0.2376, 0.4229 ) )
 Gaffer.Metadata.registerValue( GafferScene.SceneElementProcessor, "nodeGadget:color", imath.Color3f( 0.1886, 0.2772, 0.41 ) )

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -42,6 +42,7 @@ import IECore
 
 import Gaffer
 import GafferUI
+import GafferImage
 import GafferScene
 import GafferSceneUI
 import GafferDispatch
@@ -73,6 +74,9 @@ Gaffer.Metadata.registerValue( GafferScene.Transform, "nodeGadget:color", imath.
 Gaffer.Metadata.registerValue( GafferScene.Constraint, "nodeGadget:color", imath.Color3f( 0.485, 0.3112, 0.2255 ) )
 
 Gaffer.Metadata.registerValue( GafferScene.GlobalsProcessor, "nodeGadget:color", imath.Color3f( 0.255, 0.505, 0.28 ) )
+
+Gaffer.Metadata.registerValue( GafferImage.ImagePlug, "nodule:color", imath.Color3f( 0.458, 0.29, 0.482 ) )
+Gaffer.Metadata.registerValue( GafferImage.ImagePlug, "connectionGadget:color", imath.Color3f( 0.22, 0.035, 0.31 ) )
 
 Gaffer.Metadata.registerValue( Gaffer.FloatPlug, "nodule:color", imath.Color3f( 0.2467, 0.3762, 0.47 ) )
 Gaffer.Metadata.registerValue( Gaffer.Color3fPlug, "nodule:color", imath.Color3f( 0.69, 0.5378, 0.2283 ) )

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -52,6 +52,8 @@ import GafferDispatchUI
 # Colour
 ##########################################################################
 
+Gaffer.Metadata.registerValue( Gaffer.Plug, "connectionGadget:color", imath.Color3f( 0.17 ) )
+
 Gaffer.Metadata.registerValue( GafferDispatch.TaskNode, "nodeGadget:color", imath.Color3f( 0.61, 0.1525, 0.1525 ) )
 Gaffer.Metadata.registerValue( GafferDispatch.TaskNode.TaskPlug, "nodule:color", imath.Color3f( 0.645, 0.2483, 0.2483 ) )
 Gaffer.Metadata.registerValue( GafferDispatch.TaskNode.TaskPlug, "connectionGadget:color", imath.Color3f( 0.315, 0.0787, 0.0787 ) )


### PR DESCRIPTION
gui app : Color ImagePlugs and connections purple. Color ScenePlug connections blue.

This aids with the visual semantics of mixed graphs (eg scene and image processing), and matches several online videos of Gaffer.

Note I've just copied the colors used at IE. At one time there was an issue with the purple tone on Mac retina displays. Can someone double-check if it looks acceptable now, and if not propose a tweak (ideally remaining some tone of purple)?