### PR TITLE
ScenePath fixes

### DIFF
--- a/include/GafferScene/ScenePath.h
+++ b/include/GafferScene/ScenePath.h
@@ -100,6 +100,8 @@ class GAFFERSCENE_API ScenePath : public Gaffer::Path
 
 };
 
+IE_CORE_DECLAREPTR( ScenePath )
+
 } // namespace GafferScene
 
 #endif // GAFFERSCENE_SCENEPATH_H

--- a/python/GafferSceneTest/ScenePathTest.py
+++ b/python/GafferSceneTest/ScenePathTest.py
@@ -209,5 +209,15 @@ class ScenePathTest( GafferSceneTest.SceneTestCase ) :
 		path.setFilter( GafferScene.ScenePath.createStandardFilter( [ "__cameras" ] ) )
 		self.assertEqual( { str( c ) for c in path.children() }, { "/camera" } )
 
+	def testNone( self ) :
+
+		plane = GafferScene.Plane()
+
+		with self.assertRaisesRegexp( Exception, "Python argument types" ) :
+			GafferScene.ScenePath( None, Gaffer.Context() )
+
+		with self.assertRaisesRegexp( Exception, "Python argument types" ) :
+			GafferScene.ScenePath( plane["out"], None )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/ScenePathPlugValueWidget.py
+++ b/python/GafferSceneUI/ScenePathPlugValueWidget.py
@@ -52,10 +52,8 @@ class ScenePathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 					Gaffer.Metadata.value( plug, "scenePathPlugValueWidget:setsLabel" )
 				)
 
-			scenePlugName = Gaffer.Metadata.value( plug, "scenePathPlugValueWidget:scene" ) or "in"
-
 			path = GafferScene.ScenePath(
-				plug.node().descendant( scenePlugName ),
+				self.__scenePlug( plug ),
 				plug.node().scriptNode().context(),
 				"/",
 				filter = filter
@@ -84,3 +82,19 @@ class ScenePathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 			path[:] = pathNames
 
 		return dialogue
+
+	def __scenePlug( self, plug ) :
+
+		scenePlugName = Gaffer.Metadata.value( plug, "scenePathPlugValueWidget:scene" ) or "in"
+		scenePlug = plug.node().descendant( scenePlugName )
+		if scenePlug and isinstance( scenePlug, GafferScene.ScenePlug ) :
+			return scenePlug
+
+		# Couldn't find scene plug. Perhaps `plug` has been promoted but the
+		# corresponding scene hasn't been yet. Check outputs to see if that
+		# is the case.
+
+		for output in plug.outputs() :
+			p = self.__scenePlug( output )
+			if p is not None :
+				return p

--- a/src/GafferSceneModule/ScenePathBinding.cpp
+++ b/src/GafferSceneModule/ScenePathBinding.cpp
@@ -59,6 +59,16 @@ using namespace GafferScene;
 namespace
 {
 
+ScenePathPtr constructor1( ScenePlug &scene, Context &context, PathFilterPtr filter )
+{
+	return new ScenePath( &scene, &context, filter );
+}
+
+ScenePathPtr constructor2( ScenePlug &scene, Context &context, const std::string &path, PathFilterPtr filter )
+{
+	return new ScenePath( &scene, &context, path, filter );
+}
+
 PathFilterPtr createStandardFilter( object pythonSetNames, const std::string &setsLabel )
 {
 	std::vector<std::string> setNames;
@@ -73,19 +83,29 @@ void GafferSceneModule::bindScenePath()
 
 	PathClass<ScenePath>()
 		.def(
-			init<ScenePlugPtr, ContextPtr, PathFilterPtr>( (
-				arg( "scene" ),
-				arg( "context" ),
-				arg( "filter" ) = object()
-			) )
+			"__init__",
+			make_constructor(
+				constructor1,
+				default_call_policies(),
+				(
+					arg( "scene" ),
+					arg( "context" ),
+					arg( "filter" ) = object()
+				)
+			)
 		)
 		.def(
-			init<ScenePlugPtr, ContextPtr, const std::string &, PathFilterPtr>( (
-				arg( "scene" ),
-				arg( "context" ),
-				arg( "path" ),
-				arg( "filter" ) = object()
-			) )
+			"__init__",
+			make_constructor(
+				constructor2,
+				default_call_policies(),
+				(
+					arg( "scene" ),
+					arg( "context" ),
+					arg( "path" ),
+					arg( "filter" ) = object()
+				)
+			)
 		)
 		.def( "setScene", &ScenePath::setScene )
 		.def( "getScene", (ScenePlug *(ScenePath::*)())&ScenePath::getScene, return_value_policy<CastToIntrusivePtr>() )


### PR DESCRIPTION
This fixes hard crashes caused by the following sequence of actions :

1. Make Box
2. Make Parent node inside box
3. Promote `parent` plug from Parent node
4. View NodeEditor for Box