### PR TITLE
LightVisualiser refactoring round 2

### DIFF
--- a/include/GafferScene/Private/IECoreGLPreview/LightVisualiser.h
+++ b/include/GafferScene/Private/IECoreGLPreview/LightVisualiser.h
@@ -67,12 +67,21 @@ class GAFFERSCENE_API LightVisualiser : public IECore::RefCounted
 
 		/// Must be implemented by derived classes to visualise
 		/// the light contained within `shaderNetwork`.
-		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const = 0;
+		virtual IECoreGL::ConstRenderablePtr visualise(
+			const IECore::InternedString &attributeName,
+			const IECoreScene::ShaderNetwork *shaderNetwork,
+			const IECore::CompoundObject *attributes,
+			IECoreGL::ConstStatePtr &state
+		) const = 0;
 
 		/// Registers a visualiser to visualise a particular type of light.
 		/// For instance, `registerLightVisualiser( "ai:light", "point_light", visualiser )`
 		/// would register a visualiser for an Arnold point light.
-		static void registerLightVisualiser( const IECore::InternedString &attributeName, const IECore::InternedString &shaderName, ConstLightVisualiserPtr visualiser );
+		static void registerLightVisualiser(
+			const IECore::InternedString &attributeName,
+			const IECore::InternedString &shaderName,
+			ConstLightVisualiserPtr visualiser
+		);
 };
 
 } // namespace IECoreGLPreview

--- a/include/GafferScene/Private/IECoreGLPreview/LightVisualiser.h
+++ b/include/GafferScene/Private/IECoreGLPreview/LightVisualiser.h
@@ -82,6 +82,26 @@ class GAFFERSCENE_API LightVisualiser : public IECore::RefCounted
 			const IECore::InternedString &shaderName,
 			ConstLightVisualiserPtr visualiser
 		);
+
+		/// Get all registered visualisations for the given attributes, by returning a renderable
+		/// group and some extra state. The return value and/or the state may be left null if
+		/// no registered visualisers do anything with these attributes.
+		static IECoreGL::ConstRenderablePtr allVisualisations(
+			const IECore::CompoundObject *attributes,
+			IECoreGL::ConstStatePtr &state
+		);
+
+	protected :
+
+		template<typename VisualiserType>
+		struct LightVisualiserDescription
+		{
+			LightVisualiserDescription( const IECore::InternedString &attributeName, const IECore::InternedString &shaderName )
+			{
+				registerLightVisualiser( attributeName, shaderName, new VisualiserType() );
+			};
+		};
+
 };
 
 } // namespace IECoreGLPreview

--- a/include/GafferScene/Private/IECoreGLPreview/LightVisualiser.h
+++ b/include/GafferScene/Private/IECoreGLPreview/LightVisualiser.h
@@ -34,10 +34,10 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERSCENEUI_LIGHTVISUALISER_H
-#define GAFFERSCENEUI_LIGHTVISUALISER_H
+#ifndef IECOREGLPREVIEW_LIGHTVISUALISER_H
+#define IECOREGLPREVIEW_LIGHTVISUALISER_H
 
-#include "GafferSceneUI/Export.h"
+#include "GafferScene/Export.h"
 
 #include "IECoreGL/Renderable.h"
 
@@ -45,7 +45,7 @@
 
 #include "IECore/CompoundObject.h"
 
-namespace GafferSceneUI
+namespace IECoreGLPreview
 {
 
 IE_CORE_FORWARDDECLARE( LightVisualiser )
@@ -55,7 +55,7 @@ IE_CORE_FORWARDDECLARE( LightVisualiser )
 /// depending on their shader name (accessed using `IECore::Shader::getName()`). A
 /// factory mechanism is provided to map from this name to a specialised
 /// LightVisualiser.
-class GAFFERSCENEUI_API LightVisualiser : public IECore::RefCounted
+class GAFFERSCENE_API LightVisualiser : public IECore::RefCounted
 {
 
 	public :
@@ -75,6 +75,6 @@ class GAFFERSCENEUI_API LightVisualiser : public IECore::RefCounted
 		static void registerLightVisualiser( const IECore::InternedString &attributeName, const IECore::InternedString &shaderName, ConstLightVisualiserPtr visualiser );
 };
 
-} // namespace GafferSceneUI
+} // namespace IECoreGLPreview
 
-#endif // GAFFERSCENEUI_LIGHTVISUALISER_H
+#endif // IECOREGLPREVIEW_LIGHTVISUALISER_H

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -88,6 +88,8 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 		static IECoreGL::ConstRenderablePtr pointShape( float radius );
 		static IECoreGL::ConstRenderablePtr cylinderRays( float radius );
 
+		static LightVisualiser::LightVisualiserDescription<StandardLightVisualiser> g_description;
+
 };
 
 IE_CORE_DECLAREPTR( StandardLightVisualiser )

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -37,7 +37,8 @@
 #ifndef GAFFERSCENEUI_STANDARDLIGHTVISUALISER_H
 #define GAFFERSCENEUI_STANDARDLIGHTVISUALISER_H
 
-#include "GafferSceneUI/LightVisualiser.h"
+#include "GafferSceneUI/Export.h"
+#include "GafferScene/Private/IECoreGLPreview/LightVisualiser.h"
 
 #include "IECoreGL/Group.h"
 
@@ -52,7 +53,7 @@ namespace GafferSceneUI
 /// This also provides several protected utility methods for
 /// making standard visualisations, so is suitable for use as
 /// a base class for custom light visualisers.
-class GAFFERSCENEUI_API StandardLightVisualiser : public LightVisualiser
+class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightVisualiser
 {
 
 	public :

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 __import__( "GafferImageUI" )
+__import__( "GafferScene" )
 
 from _GafferSceneUI import *
 

--- a/src/GafferScene/IECoreGLPreview/LightVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/LightVisualiser.cpp
@@ -34,11 +34,11 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GafferSceneUI/LightVisualiser.h"
 
 #include "GafferSceneUI/StandardLightVisualiser.h"
 
 #include "GafferScene/Private/IECoreGLPreview/AttributeVisualiser.h"
+#include "GafferScene/Private/IECoreGLPreview/LightVisualiser.h"
 
 #include "IECoreGL/CurvesPrimitive.h"
 #include "IECoreGL/Group.h"

--- a/src/GafferSceneModule/IECoreGLPreviewBinding.cpp
+++ b/src/GafferSceneModule/IECoreGLPreviewBinding.cpp
@@ -38,6 +38,7 @@
 
 #include "GafferScene/Private/IECoreGLPreview/ObjectVisualiser.h"
 #include "GafferScene/Private/IECoreGLPreview/AttributeVisualiser.h"
+#include "GafferScene/Private/IECoreGLPreview/LightVisualiser.h"
 
 #include "IECorePython/RefCountedBinding.h"
 
@@ -60,5 +61,10 @@ void GafferSceneModule::bindIECoreGLPreview()
 		.staticmethod( "registerVisualiser" )
 		.def( "allVisualisations", &AttributeVisualiser::allVisualisations )
 		.staticmethod( "allVisualisations" )
+	;
+
+	IECorePython::RefCountedClass<LightVisualiser, IECore::RefCounted>( "LightVisualiser" )
+		.def( "registerLightVisualiser", &LightVisualiser::registerLightVisualiser )
+		.staticmethod( "registerLightVisualiser" )
 	;
 }

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -58,6 +58,7 @@ using namespace IECoreScene;
 using namespace IECoreGL;
 using namespace Gaffer;
 using namespace GafferSceneUI;
+using namespace IECoreGLPreview;
 
 //////////////////////////////////////////////////////////////////////////
 // Utility methods. We define these in an anonymouse namespace rather
@@ -213,6 +214,9 @@ const char *environmentSphereFragSource()
 //////////////////////////////////////////////////////////////////////////
 // StandardLightVisualiser implementation.
 //////////////////////////////////////////////////////////////////////////
+
+// Register as the standard fallback visualiser.
+LightVisualiser::LightVisualiserDescription<StandardLightVisualiser> StandardLightVisualiser::g_description( "light *:light", "*" );
 
 StandardLightVisualiser::StandardLightVisualiser()
 {

--- a/src/GafferSceneUIModule/VisualiserBinding.cpp
+++ b/src/GafferSceneUIModule/VisualiserBinding.cpp
@@ -36,20 +36,15 @@
 
 #include "VisualiserBinding.h"
 
-#include "GafferSceneUI/LightVisualiser.h"
 #include "GafferSceneUI/StandardLightVisualiser.h"
 
 #include "IECorePython/RefCountedBinding.h"
 
 using namespace GafferSceneUI;
+using namespace IECoreGLPreview;
 
 void GafferSceneUIModule::bindVisualisers()
 {
-
-	IECorePython::RefCountedClass<LightVisualiser, IECore::RefCounted>( "LightVisualiser" )
-		.def( "registerLightVisualiser", &LightVisualiser::registerLightVisualiser )
-		.staticmethod( "registerLightVisualiser" )
-	;
 
 	IECorePython::RefCountedClass<StandardLightVisualiser, LightVisualiser>( "StandardLightVisualiser" )
 	;


### PR DESCRIPTION
This is intended to replace our dearly departed @mattigruener's PR #3364. I've just made a few tweaks to get it over the line :

- Replaced the new StandardLightVisualiserDescription class with a more general-purpose LightVisualiserDescription class.
- Added support for arbitrary wildcard matching for light visualisers, rather than hardcoding `"*" "*"` as a special case.
- Tidied up a couple of stray includes.

