### PR TITLE
GafferScene : Fix use of GAFFER_GRAPHCOMPONENT_DEFINE_TYPE

### DIFF
--- a/src/GafferScene/Orientation.cpp
+++ b/src/GafferScene/Orientation.cpp
@@ -504,7 +504,7 @@ void randomise( vector<Quatf> &orientations, const V3f &axis, float spreadMax, f
 // Orientation
 //////////////////////////////////////////////////////////////////////////
 
-IE_CORE_DEFINERUNTIMETYPED( Orientation );
+GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( Orientation );
 
 size_t Orientation::g_firstPlugIndex = 0;
 

--- a/src/GafferScene/SceneElementProcessor.cpp
+++ b/src/GafferScene/SceneElementProcessor.cpp
@@ -46,7 +46,7 @@ using namespace IECore;
 using namespace Gaffer;
 using namespace GafferScene;
 
-IE_CORE_DEFINERUNTIMETYPED( SceneElementProcessor );
+GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( SceneElementProcessor );
 
 size_t SceneElementProcessor::g_firstPlugIndex = 0;
 


### PR DESCRIPTION
Somehow these escaped the original conversion. Orientation may have been written in parallel, but I don't know how SceneElementProcessor slipped through the cracks.
