### PR TITLE
GafferSceneTest : Fix MeshTypeTest

### DIFF
--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -139,6 +139,7 @@ from TweakPlugTest import TweakPlugTest
 from ContextSanitiserTest import ContextSanitiserTest
 from SetVisualiserTest import SetVisualiserTest
 from OrientationTest import OrientationTest
+from MeshTypeTest import MeshTypeTest
 
 from IECoreScenePreviewTest import *
 from IECoreGLPreviewTest import *


### PR DESCRIPTION
This was omitted from `__init__.py`, so we hadn't realised it had become broken over time.