### PR TITLE
 Viewer : Allow up/down arrow keys to navigate the catalogue

### DIFF
--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -304,6 +304,8 @@ Isolate green channel                 :kbd:`G`
 Isolate blue channel                  :kbd:`B`
 Isolate alpha channel                 :kbd:`A`
 Center image at 1:1 scale             :kbd:`Home`
+Next Catalogue image                  :kbd:`↓`
+Previous Catalogue image              :kbd:`↑`
 ===================================== =============================================
 ```
 

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -1,6 +1,7 @@
 ##########################################################################
 #
 #  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2019, Cinesite VFX Limited. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -45,7 +46,10 @@ import GafferImage
 import GafferImageUI
 
 ## \todo
-## - Could up/down in the Viewer cycle through the image list?
+## Ideally Catalogue reordering wouldn't just be managed the UI layer, but
+## the scope of changing this is somewhat large. When we need to do folders,
+## then this will probably force us to sort this out. For now, is at least
+## contained within just this file...
 
 Gaffer.Metadata.registerNode(
 
@@ -130,6 +134,86 @@ Gaffer.Metadata.registerNode(
 	},
 
 )
+
+
+##########################################################################
+# Viewer hot-keys
+##########################################################################
+
+def addCatalogueHotkeys( editor ) :
+
+	if not isinstance( editor, GafferUI.Viewer ) :
+		return
+
+	editor.keyPressSignal().connect( __viewerKeyPress, scoped = False )
+
+def __viewerKeyPress( viewer, event ) :
+
+	# Up/Down arrows need to walk upstream of the viewer input and look for
+	# a Catalogue node and increment/decrement its active index
+
+	if event.key not in ( "Down", "Up" ) :
+		return False
+
+	if not isinstance( viewer.view(), GafferImageUI.ImageView ) :
+		return False
+
+	catalogue = __findCatalogue( viewer.view() )
+	if catalogue is None :
+		return False
+
+	__incrementImageIndex( catalogue, event.key )
+
+	return True
+
+def __findCatalogue( node ) :
+
+	catalogue = node.ancestor( GafferImage.Catalogue )
+	if catalogue is not None :
+		return catalogue
+	else :
+		for inPlug in GafferImage.ImagePlug.RecursiveInputRange( node ) :
+			upstreamPlug = inPlug.source()
+			if upstreamPlug == inPlug or upstreamPlug.node() == node :
+				continue
+			catalogue = __findCatalogue( upstreamPlug.node() )
+			if catalogue is not None :
+				return catalogue
+
+	return None
+
+def __incrementImageIndex( catalogue, direction ) :
+
+	indexPlug = catalogue["imageIndex"].source()
+
+	if Gaffer.MetadataAlgo.readOnly( indexPlug ) or not indexPlug.settable() :
+		return
+
+	# Match the UI's top-to-bottom order instead of 'up is a larger number'
+	increment = -1 if direction == "Up" else 1
+
+	# The Catalog UI re-orders images internally using metadata, rather than by
+	# shuffling plugs. As such, we can't just set imageIndex. We don't want to
+	# be poking into the specifics of how this works, so for now we re-use
+	# _ImagesPath as it knows all that logic.
+
+	images = catalogue["images"].source().children()
+	if len( images ) == 0 :
+		return
+
+	maxIndex = len( images ) - 1
+	orderedImages = _ImagesPath( catalogue["images"].source(), [] )._orderedImages()
+
+	# There are times when this can be out of sync with the number of images.
+	# Generally when the UI hasn't been opened.
+	currentPlugIndex = min( indexPlug.getValue(), maxIndex )
+
+	catalogueIndex = orderedImages.index( images[currentPlugIndex] )
+	nextIndex = max( min( catalogueIndex + increment, maxIndex ), 0 )
+	nextPlugIndex = images.index( orderedImages[nextIndex] )
+
+	if nextPlugIndex != currentPlugIndex :
+		indexPlug.setValue( nextPlugIndex )
 
 ##########################################################################
 # _CataloguePath

--- a/startup/gui/viewer.py
+++ b/startup/gui/viewer.py
@@ -45,6 +45,7 @@ import Gaffer
 import GafferUI
 import GafferScene
 import GafferSceneUI
+import GafferImageUI
 
 # add plugs to the preferences node
 
@@ -182,3 +183,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 		( "Diagnostic/Appleseed/Photon Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "as:visibility:light" } ),
 
 	] )
+
+
+# Add catalogue hotkeys to viewers, eg: up/down navigation
+GafferUI.Editor.instanceCreatedSignal().connect( GafferImageUI.CatalogueUI.addCatalogueHotkeys, scoped = False )


### PR DESCRIPTION
Also fixes a bug whereby items added to the catalog whilst the UI was closed would end up near the top of the catalog, rather than at the end.

This commit takes a pragmatic approach around the fact that currently the CatalogueUI manifests a custom display ordering, that isn't available at the Catalog plug API level. It is out of scope to refactor this, at least for now, we're keeping all the UI logic in one place.

### User facing changes

 - When the mouse is over the Viewer, and the Viewer is showing a Catalogue (or any other node downstream of one), the up and down arrow keys can be used to navigate images in the catalogue, as they do when in the catalogue's Node Editor.