### PR TITLE
Instancer : Prefix promoted attributes with "user:"

### DIFF
--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -77,6 +77,9 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::StringPlug *attributesPlug();
 		const Gaffer::StringPlug *attributesPlug() const;
 
+		Gaffer::StringPlug *attributePrefixPlug();
+		const Gaffer::StringPlug *attributePrefixPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -897,6 +897,58 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 			} )
 		)
 
+		instancer["attributePrefix"].setValue( "user:" )
+
+		self.assertEqual(
+			instancer["out"].attributes( "/object/instances/sphere/0" ),
+			IECore.CompoundObject( {
+				"user:testFloat" : IECore.FloatData( 0.0 ),
+				"user:testColor" : IECore.Color3fData( imath.Color3f( 1, 0, 0 ) ),
+				"user:testPoint" : IECore.V3fData(
+					imath.V3f( 0 ),
+					IECore.GeometricData.Interpretation.Point
+				)
+			} )
+		)
+
+		self.assertEqual(
+			instancer["out"].attributes( "/object/instances/sphere/1" ),
+			IECore.CompoundObject( {
+				"user:testFloat" : IECore.FloatData( 1.0 ),
+				"user:testColor" : IECore.Color3fData( imath.Color3f( 0, 1, 0 ) ),
+				"user:testPoint" : IECore.V3fData(
+					imath.V3f( 1 ),
+					IECore.GeometricData.Interpretation.Point
+				)
+			} )
+		)
+
+		instancer["attributePrefix"].setValue( "foo:" )
+
+		self.assertEqual(
+			instancer["out"].attributes( "/object/instances/sphere/0" ),
+			IECore.CompoundObject( {
+				"foo:testFloat" : IECore.FloatData( 0.0 ),
+				"foo:testColor" : IECore.Color3fData( imath.Color3f( 1, 0, 0 ) ),
+				"foo:testPoint" : IECore.V3fData(
+					imath.V3f( 0 ),
+					IECore.GeometricData.Interpretation.Point
+				)
+			} )
+		)
+
+		self.assertEqual(
+			instancer["out"].attributes( "/object/instances/sphere/1" ),
+			IECore.CompoundObject( {
+				"foo:testFloat" : IECore.FloatData( 1.0 ),
+				"foo:testColor" : IECore.Color3fData( imath.Color3f( 0, 1, 0 ) ),
+				"foo:testPoint" : IECore.V3fData(
+					imath.V3f( 1 ),
+					IECore.GeometricData.Interpretation.Point
+				)
+			} )
+		)
+
 	def testEmptyAttributesHaveConstantHash( self ) :
 
 		points = IECoreScene.PointsPrimitive( IECore.V3fVectorData( [ imath.V3f( x, 0, 0 ) for x in range( 0, 2 ) ] ) )

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -184,6 +184,8 @@ Gaffer.Metadata.registerNode(
 			via the \"attributes\" plug. 
 			""",
 
+			"userDefault", "user:",
+
 		],
 
 	}

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -176,6 +176,16 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"attributePrefix" : [
+
+			"description",
+			"""
+			A prefix added to all per-instance attributes specified
+			via the \"attributes\" plug. 
+			""",
+
+		],
+
 	}
 
 )


### PR DESCRIPTION
This makes the attributes more useful to downstream operations like shaders or OSLObject.

Alternatively we could add an "attributePrefix" plug that defaults (or userDefaults at a studio) to "user:", but I didn't think that was worth the trouble. Happy to add it if its contentious though.