### PR TITLE
CompoundEditor : Pinning UX improvements

### DIFF
--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -724,6 +724,10 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 
 	def __titleChanged( self, editor ) :
 
+		# see __updatePinningButton
+		if not GafferUI._qtObjectIsValid( self._qtWidget() ) :
+			return
+
 		self.setLabel( editor, editor.getTitle() )
 
 	def __currentTabChanged( self, tabbedContainer, currentEditor ) :


### PR DESCRIPTION
**[update: Just implements #3139 - linked stated pushed for future work]**

Implements #3139, with the addition of a decoration to indicate whether an editor is linked or pinned in its title.  Due to Qt limitations we can't use icons/graphics and are limited to something we can encode in the tab title, using the same font/color/size.

![image](https://user-images.githubusercontent.com/896779/66198424-4fce9e00-e694-11e9-967b-8d12787a4e48.png)

This now allows at-a-glance observation of pinning state for inactive tabs. It also makes it easier to tell if a tab is pinned/linked when windows are large - as you no longer need to look to the other side of the tab bar.

So the rules, which can be combined, are:
 - Can I see square brackets in the tab title - if so, its pinned (regardless of link state)
 - Can I see the link icon - if so its linked to another editor

I experimented with a combined pinned/link decoration for linked editors who's driver is pinned, but it was hard to find a compact representation of this that worked well on both platforms.

As most editors also contain a display of which node/location they are showing, it feels loosing this from the tab title for un-pinned nodes doesn't compromising knowing what any specific editor is showing, for visible editors at least.

User facing changes :
 
  - Tab titles now only show node names when the editor is pinned (or its driving editor is pinned).
  - Tab titles include a bullet symbol if the editor is pinned, unless the editor is linked.
  - Tab titles include a triple bar symbol if the editor is linked to another editor.
