### PR TITLE
TransformTool : Fix ignorance of SetFiltered nodes

### DIFF
--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -493,5 +493,41 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 			len( instancer["out"].childNames( "/plane/instances/sphere" ) ) + 4,
 		)
 
+	def testObjectTweaksWithSetFilter( self ) :
+
+		camera = GafferScene.Camera()
+		camera["sets"].setValue( "A" )
+
+		setFilter = GafferScene.SetFilter()
+		setFilter["set"].setValue( "A" )
+
+		cameraTweaks = GafferScene.CameraTweaks()
+		cameraTweaks["in"].setInput( camera["out"] )
+		cameraTweaks["filter"].setInput( setFilter["out"] )
+
+		self.assertEqual( GafferScene.SceneAlgo.objectTweaks( cameraTweaks["out"], "/camera" ), cameraTweaks )
+
+	def testShaderTweaksWithSetFilter( self ) :
+
+		shader = GafferSceneTest.TestShader()
+		shader["type"].setValue( "test:surface" )
+
+		plane = GafferScene.Plane()
+		plane["sets"].setValue( "A" )
+
+		planeShaderAssignment = GafferScene.ShaderAssignment()
+		planeShaderAssignment["in"].setInput( plane["out"] )
+		planeShaderAssignment["shader"].setInput( shader["out"] )
+
+		setFilter = GafferScene.SetFilter()
+		setFilter["set"].setValue( "A" )
+
+		planeTweaks = GafferScene.ShaderTweaks()
+		planeTweaks["in"].setInput( planeShaderAssignment["out"] )
+		planeTweaks["filter"].setInput( setFilter["out"] )
+		planeTweaks["shader"].setValue( "test:surface" )
+
+		self.assertEqual( GafferScene.SceneAlgo.shaderTweaks( planeTweaks["out"], "/plane", "test:surface" ), planeTweaks )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -726,5 +726,28 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		self.assertEqual( len( tool.selection() ), 1 )
 		self.assertEqual( tool.selection()[0].transformPlug, script["reader"]["transform"] )
 
+	def testSetFilter( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["sphere"] = GafferScene.Sphere()
+		script["sphere"]["sets"].setValue( "A" )
+
+		script["setFilter"] = GafferScene.SetFilter()
+		script["setFilter"]["set"].setValue( "A" )
+
+		script["transform"] = GafferScene.Transform()
+		script["transform"]["in"].setInput( script["sphere"]["out"] )
+		script["transform"]["filter"].setInput( script["setFilter"]["out"] )
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["transform"]["out"] )
+
+		tool = GafferSceneUI.TranslateTool( view )
+		tool["active"].setValue( True )
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/sphere" ] ) )
+		self.assertEqual( tool.selection()[0].transformPlug, script["transform"]["transform"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -74,6 +74,12 @@ using namespace GafferSceneUI;
 namespace
 {
 
+int filterResult( const FilterPlug *filter, const ScenePlug *scene )
+{
+	FilterPlug::SceneScope scope( Context::current(), scene );
+	return filter->getValue();
+}
+
 bool ancestorMakesChildNodesReadOnly( const Node *node )
 {
 	node = node->parent<Node>();
@@ -118,7 +124,7 @@ bool updateSelection( const SceneAlgo::History *history, TransformTool::Selectio
 	}
 	else if( const GafferScene::Transform *transform = runTimeCast<const GafferScene::Transform>( node ) )
 	{
-		if( transform->filterPlug()->getValue() & PathMatcher::ExactMatch )
+		if( filterResult( transform->filterPlug(), transform->inPlug() ) & PathMatcher::ExactMatch )
 		{
 			selection.transformPlug = const_cast<TransformPlug *>( transform->transformPlug() );
 			ScenePlug::ScenePath spacePath = history->context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );


### PR DESCRIPTION
We'd only tested with PathFilters, which don't require a scene to work with. Providing the appropriate scene via FilterPlug::SceneScope allows SetFilter (and other) matches to be detected properly.
