### PR TITLE
Instancer : Remove the target object.

### DIFF
--- a/include/GafferScene/BranchCreator.h
+++ b/include/GafferScene/BranchCreator.h
@@ -124,6 +124,10 @@ class GAFFERSCENE_API BranchCreator : public FilteredSceneProcessor
 		virtual IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const = 0;
 
 		virtual bool affectsBranchObject( const Gaffer::Plug *input ) const;
+		/// Called to determine if the parent object is affected. If true, hashBranchObject and computeBranchObject
+		/// will be called with an empty branchPath when the parentPath is an exact match. The default implementation
+		/// returns false as most BranchCreators should leave the parent object intact.
+		virtual bool processesRootObject() const;
 		virtual void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
 		virtual IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const = 0;
 

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -100,6 +100,8 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchObject( const Gaffer::Plug *input ) const override;
+		// Implemented to remove the parent object, because we "convert" the points into a hierarchy
+		bool processesRootObject() const override;
 		void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -97,7 +97,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( instancer["out"].bound( "/" ), imath.Box3f( imath.V3f( -1, -2, -2 ), imath.V3f( 4, 3, 2 ) ) )
 		self.assertEqual( instancer["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "seeds" ] ) )
 
-		self.assertEqual( instancer["out"].object( "/seeds" ), seeds )
+		self.assertEqual( instancer["out"].object( "/seeds" ), IECore.NullObject() )
 		self.assertEqual( instancer["out"].transform( "/seeds" ), imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) )
 		self.assertEqual( instancer["out"].bound( "/seeds" ), imath.Box3f( imath.V3f( -2, -2, -2 ), imath.V3f( 3, 3, 2 ) ) )
 		self.assertEqual( instancer["out"].childNames( "/seeds" ), IECore.InternedStringVectorData( [ "instances" ] ) )
@@ -202,7 +202,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		instancer["parent"].setValue( "/plane" )
 		instancer["name"].setValue( "" )
 
-		self.assertScenesEqual( instancer["out"], plane["out"] )
+		self.assertScenesEqual( instancer["out"], plane["out"], pathsToIgnore = ( "/plane", ) )
 
 	def testEmptyParent( self ) :
 

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -52,7 +52,7 @@ Gaffer.Metadata.registerNode(
 	object, making one copy per vertex. Additional primitive
 	variables on the target object can be used to choose between
 	multiple instances, and to specify their orientation and
-	scale.
+	scale. Note the target object will be removed from the scene.
 	""",
 
 	plugs = {

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -414,6 +414,11 @@ IECore::ConstCompoundObjectPtr BranchCreator::computeAttributes( const ScenePath
 	}
 }
 
+bool BranchCreator::processesRootObject() const
+{
+	return false;
+}
+
 void BranchCreator::hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	ScenePath parentPath, branchPath;
@@ -421,6 +426,11 @@ void BranchCreator::hashObject( const ScenePath &path, const Gaffer::Context *co
 
 	if( parentMatch == IECore::PathMatcher::AncestorMatch )
 	{
+		hashBranchObject( parentPath, branchPath, context, h );
+	}
+	else if( parentMatch == IECore::PathMatcher::ExactMatch && processesRootObject() )
+	{
+		// note branchPath is empty here
 		hashBranchObject( parentPath, branchPath, context, h );
 	}
 	else
@@ -436,6 +446,11 @@ IECore::ConstObjectPtr BranchCreator::computeObject( const ScenePath &path, cons
 
 	if( parentMatch == IECore::PathMatcher::AncestorMatch )
 	{
+		return computeBranchObject( parentPath, branchPath, context );
+	}
+	else if( parentMatch == IECore::PathMatcher::ExactMatch && processesRootObject() )
+	{
+		// note branchPath is empty here
 		return computeBranchObject( parentPath, branchPath, context );
 	}
 	else

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -855,6 +855,11 @@ IECore::ConstCompoundObjectPtr Instancer::computeBranchAttributes( const ScenePa
 	}
 }
 
+bool Instancer::processesRootObject() const
+{
+	return true;
+}
+
 bool Instancer::affectsBranchObject( const Gaffer::Plug *input ) const
 {
 	return input == instancesPlug()->objectPlug();


### PR DESCRIPTION
This is desirable since instancing is usually thought of as a "conversion" from a point cloud to a hierarchy of instances/prototypes.

Breaking Change:

- Added protected virtual methed to BranchCreator