### PR TITLE
FreezeTransform : Fix filter evaluation bug

### DIFF
--- a/python/GafferSceneTest/FreezeTransformTest.py
+++ b/python/GafferSceneTest/FreezeTransformTest.py
@@ -107,5 +107,21 @@ class FreezeTransformTest( GafferSceneTest.SceneTestCase ) :
 		t = GafferScene.FreezeTransform()
 		self.assertEqual( set( t.affects( t["in"]["object"] ) ), set( [ t["out"]["object"] ] ) )
 
+	def testSetFilter( self ) :
+
+		plane = GafferScene.Plane()
+		plane["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
+		plane["sets"].setValue( "A" )
+
+		planeFilter = GafferScene.SetFilter()
+		planeFilter["setExpression"].setValue( "A" )
+
+		freezeTransform = GafferScene.FreezeTransform()
+		freezeTransform["in"].setInput( plane["out"] )
+		freezeTransform["filter"].setInput( planeFilter["out"] )
+
+		self.assertSceneValid( freezeTransform["out"] )
+		self.assertEqual( freezeTransform["out"].transform( "/plane" ), imath.M44f() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/FreezeTransform.cpp
+++ b/src/GafferScene/FreezeTransform.cpp
@@ -137,7 +137,7 @@ void FreezeTransform::compute( Gaffer::ValuePlug *output, const Gaffer::Context 
 
 void FreezeTransform::hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
-	const unsigned m = filterPlug()->getValue();
+	const unsigned m = filterValue( context );
 	if( m & ( IECore::PathMatcher::AncestorMatch | IECore::PathMatcher::ExactMatch ) )
 	{
 		// if there's an ancestor match or an exact match here then we know
@@ -163,7 +163,7 @@ void FreezeTransform::hashBound( const ScenePath &path, const Gaffer::Context *c
 
 Imath::Box3f FreezeTransform::computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	const unsigned m = filterPlug()->getValue();
+	const unsigned m = filterValue( context );
 	if( m & ( IECore::PathMatcher::AncestorMatch | IECore::PathMatcher::ExactMatch ) )
 	{
 		Box3f result = unionOfTransformedChildBounds( path, outPlug() );
@@ -180,7 +180,7 @@ Imath::Box3f FreezeTransform::computeBound( const ScenePath &path, const Gaffer:
 
 void FreezeTransform::hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
-	const unsigned m = filterPlug()->getValue();
+	const unsigned m = filterValue( context );
 	if( m & IECore::PathMatcher::ExactMatch )
 	{
 		SceneProcessor::hashTransform( path, context, parent, h );
@@ -193,7 +193,7 @@ void FreezeTransform::hashTransform( const ScenePath &path, const Gaffer::Contex
 
 Imath::M44f FreezeTransform::computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	const unsigned m = filterPlug()->getValue();
+	const unsigned m = filterValue( context );
 	if( m & IECore::PathMatcher::ExactMatch )
 	{
 		return M44f();
@@ -206,7 +206,7 @@ Imath::M44f FreezeTransform::computeTransform( const ScenePath &path, const Gaff
 
 void FreezeTransform::hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
-	const unsigned m = filterPlug()->getValue();
+	const unsigned m = filterValue( context );
 	if( m & ( IECore::PathMatcher::AncestorMatch | IECore::PathMatcher::ExactMatch ) )
 	{
 		FilteredSceneProcessor::hashObject( path, context, parent, h );
@@ -221,7 +221,7 @@ void FreezeTransform::hashObject( const ScenePath &path, const Gaffer::Context *
 
 IECore::ConstObjectPtr FreezeTransform::computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	const unsigned m = filterPlug()->getValue();
+	const unsigned m = filterValue( context );
 	if( m & ( IECore::PathMatcher::AncestorMatch | IECore::PathMatcher::ExactMatch ) )
 	{
 		ConstObjectPtr inputObject = inPlug()->objectPlug()->getValue();


### PR DESCRIPTION
This meant that it was incompatible with any filters that needed access to the input scene. Bug spotted by @themissingcow during review for #3393.
