### PR TITLE
TaskMutex/ValuePlug : Address issues in TBB < 2018 Update 3

### DIFF
--- a/include/Gaffer/Private/IECorePreview/TaskMutex.h
+++ b/include/Gaffer/Private/IECorePreview/TaskMutex.h
@@ -193,15 +193,21 @@ class TaskMutex : boost::noncopyable
 							// The `run_and_wait()` method is buggy until
 							// TBB 2018 Update 3, causing calls to `wait()` on other threads to
 							// return immediately rather than do the work we want.
-							// So we call `run()` and `wait()` separately. This has a
-							// downside though : it appears to trigger a TBB bug whereby
-							// it is sometimes unable to destroy the internals of the
-							// `task_arena`. It then spends increasing amounts of time
-							// in `market::try_destroy_arena()`, doing a linear search
-							// through all the zombie arenas until it finds the one it
-							// wants to destroy, decides for some reason it can't destroy it,
-							// and gives up. With large numbers of arenas this can add
-							// huge overhead.
+							// So we call `run()` and `wait()` separately. This has two
+							// downsides though :
+							//
+							// 1. It appears to trigger a TBB bug whereby it is sometimes
+							//    unable to destroy the internals of the `task_arena`. It
+							//    then spends increasing amounts of time in
+							//    `market::try_destroy_arena()`, doing a linear search through
+							//    all the zombie arenas until it finds the one it
+							//    wants to destroy, decides for some reason it can't destroy it,
+							//    and gives up. With large numbers of arenas this can add
+							//    huge overhead.
+							// 2. It does not guarantee that `fWrapper` runs on the same thread
+							//    that `run()` is called on (`run_and_wait()` does provide
+							//    that guarantee). This forces us into nasty ThreadStateFixer
+							//    workarounds in Gaffer/ValuePlug.cpp.
 							m_mutex->m_executionState->taskGroup.run( fWrapper );
 							m_mutex->m_executionState->taskGroup.wait();
 #endif

--- a/include/Gaffer/Private/IECorePreview/TaskMutex.h
+++ b/include/Gaffer/Private/IECorePreview/TaskMutex.h
@@ -187,30 +187,7 @@ class TaskMutex : boost::noncopyable
 
 					m_mutex->m_executionState->arena.execute(
 						[this, &fWrapper] {
-#if TBB_INTERFACE_VERSION >= 10003
 							m_mutex->m_executionState->taskGroup.run_and_wait( fWrapper );
-#else
-							// The `run_and_wait()` method is buggy until
-							// TBB 2018 Update 3, causing calls to `wait()` on other threads to
-							// return immediately rather than do the work we want.
-							// So we call `run()` and `wait()` separately. This has two
-							// downsides though :
-							//
-							// 1. It appears to trigger a TBB bug whereby it is sometimes
-							//    unable to destroy the internals of the `task_arena`. It
-							//    then spends increasing amounts of time in
-							//    `market::try_destroy_arena()`, doing a linear search through
-							//    all the zombie arenas until it finds the one it
-							//    wants to destroy, decides for some reason it can't destroy it,
-							//    and gives up. With large numbers of arenas this can add
-							//    huge overhead.
-							// 2. It does not guarantee that `fWrapper` runs on the same thread
-							//    that `run()` is called on (`run_and_wait()` does provide
-							//    that guarantee). This forces us into nasty ThreadStateFixer
-							//    workarounds in Gaffer/ValuePlug.cpp.
-							m_mutex->m_executionState->taskGroup.run( fWrapper );
-							m_mutex->m_executionState->taskGroup.wait();
-#endif
 						}
 					);
 


### PR DESCRIPTION
First of all, if you are using the standard Gaffer builds, or are using GafferHQ/dependencies to make your own builds, or are otherwise using TBB 2018 Update 3 or later, there is nothing to see here. This PR applies only to those using older versions of TBB, perhaps due to dependence on a non-VFXPlatform-compliant DCC.

This PR fixes a context management problem when building with versions of TBB prior to 2018 Update 3. The symptom was a compute or hash process being given a default context rather than the expected one. The cause was that an existing workaround for old TBB versions meant that `TaskMutex::execute( f )` might skip threads, calling `f` on a different thread to the one that called `execute()`. The current context is stored on a per-thread stack within ThreadState, and the skipped-to thread typically has an empty stack, and therefore a default context. It _may_ even have been possible to skip to a thread with a non-empty stack, but I have not observed that in practice.

I've provided two possible fixes here. The first commit doubles down on the existing workaround, adding extra machinery in ValuePlug to make sure we transfer ThreadState over manually where necessary. The second commit rips that back out, and rips out the original workaround as well. This gives us cleaner code and a different set of compromises when using older TBBs : sometimes potential workers will fail to help out via a TaskMutex, but we will be free of worry about a huge [TBB slowdown we once saw in `task_arena` destruction](https://github.com/GafferHQ/gaffer/pull/3154#discussion_r283492809
). You'll need to read each commit individually rather than look at the whole diff, because the whole diff just shows the ripping-out.

With my GafferHQ hat on, the obvious preference is for the second approach : to have simpler code and to encourage everyone onto modern TBB. I'll leave it up to IE folks to decide what we actually merge though. The clincher is perhaps how much we lose out in terms of task collaboration by ripping out the original workaround, and how much more we might use task collaboration in future (where the chance of suffering from the slow destruction bug is greatly increased). This is anecdotal, but my recollection is that I added the workaround to make sure the TaskMutex tests passed at IE (they assert that all threads help out), but that this didn't correspond to much practical improvement in terms of the production benchmarking we were doing at the time. One option would be to run some more benchmarks with the workaround removed so we can make a more informed decision.


