### PR TITLE
Object relocation tools

### DIFF
--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -289,6 +289,7 @@ Decrease manipulator size                            :kbd:`-`
 Add animation key to transform of selected object(s) :kbd:`S`
 Adjust, high precision                               :kbd:`Shift` + click and drag
 Adjust, snapping to rounded increments               :kbd:`Ctrl` + click and drag
+Target mode (Translate and Rotate only)              Hold :kbd:`v`
 ==================================================== =============================================
 ```
 

--- a/include/GafferSceneUI/RotateTool.h
+++ b/include/GafferSceneUI/RotateTool.h
@@ -97,11 +97,25 @@ class GAFFERSCENEUI_API RotateTool : public TransformTool
 
 		};
 
-		// Drag handling.
+		// Handle Drag handling.
 
-		IECore::RunTimeTypedPtr dragBegin();
-		bool dragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
-		bool dragEnd();
+		IECore::RunTimeTypedPtr handleDragBegin();
+		bool handleDragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
+		bool handleDragEnd();
+
+		// Target mode handling
+
+		bool keyPress( const GafferUI::KeyEvent &event );
+		bool keyRelease( const GafferUI::KeyEvent &event );
+		void sceneGadgetLeave( const GafferUI::ButtonEvent &event );
+		void visibilityChanged( GafferUI::Gadget *gadget );
+		void plugSet( Gaffer::Plug *plug );
+
+		bool buttonPress( const GafferUI::ButtonEvent &event );
+
+		void setTargetedMode( bool targeted );
+		inline bool getTargetedMode() const { return m_targetedMode; }
+		bool m_targetedMode;
 
 		std::vector<Rotation> m_drag;
 

--- a/include/GafferSceneUI/SceneGadget.h
+++ b/include/GafferSceneUI/SceneGadget.h
@@ -151,6 +151,8 @@ class GAFFERSCENEUI_API SceneGadget : public GafferUI::Gadget
 		/// through gadget space. Returns true on success and false if there is no
 		/// such object.
 		bool objectAt( const IECore::LineSegment3f &lineInGadgetSpace, GafferScene::ScenePlug::ScenePath &path ) const;
+		/// As above. Additionally hitPoint is filled with the approximate intersection point in gadget space.
+		bool objectAt( const IECore::LineSegment3f &lineInGadgetSpace, GafferScene::ScenePlug::ScenePath &path, Imath::V3f &hitPoint ) const;
 		/// Fills paths with all objects intersected by a rectangle in screen space,
 		/// defined by two corners in gadget space (as required for drag selection).
 		size_t objectsAt(

--- a/include/GafferSceneUI/SelectionTool.h
+++ b/include/GafferSceneUI/SelectionTool.h
@@ -70,11 +70,14 @@ class GAFFERSCENEUI_API SelectionTool : public GafferUI::Tool
 		DragOverlay *dragOverlay();
 
 		bool buttonPress( const GafferUI::ButtonEvent &event );
+		bool buttonRelease( const GafferUI::ButtonEvent &event );
 		IECore::RunTimeTypedPtr dragBegin( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
 		bool dragEnter( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
 		bool dragMove( const GafferUI::DragDropEvent &event );
 		bool dragEnd( const GafferUI::DragDropEvent &event );
 
+		bool m_acceptedButtonPress = false;
+		bool m_initiatedDrag = false;
 };
 
 } // namespace GafferSceneUI

--- a/include/GafferSceneUI/TranslateTool.h
+++ b/include/GafferSceneUI/TranslateTool.h
@@ -95,11 +95,25 @@ class GAFFERSCENEUI_API TranslateTool : public TransformTool
 
 		};
 
-		// Drag handling.
+		// Handle drag handling.
 
-		IECore::RunTimeTypedPtr dragBegin();
-		bool dragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
-		bool dragEnd();
+		IECore::RunTimeTypedPtr handleDragBegin();
+		bool handleDragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
+		bool handleDragEnd();
+
+		// Targeted mode handling
+
+		bool keyPress( const GafferUI::KeyEvent &event );
+		bool keyRelease( const GafferUI::KeyEvent &event );
+		void sceneGadgetLeave( const GafferUI::ButtonEvent &event );
+		void visibilityChanged( GafferUI::Gadget *gadget );
+		void plugSet( Gaffer::Plug *plug );
+
+		bool buttonPress( const GafferUI::ButtonEvent &event );
+
+		void setTargetedMode( bool targeted );
+		inline bool getTargetedMode() const { return m_targetedMode; }
+		bool m_targetedMode;
 
 		std::vector<Translation> m_drag;
 

--- a/python/GafferUI/BoolWidget.py
+++ b/python/GafferUI/BoolWidget.py
@@ -53,6 +53,8 @@ class BoolWidget( GafferUI.Widget ) :
 
 		GafferUI.Widget.__init__( self, _CheckBox( text ), **kw )
 
+		self.__defaultFocusPolicy = self._qtWidget().focusPolicy()
+
 		self.setState( checked )
 		self.setDisplayMode( displayMode )
 		self.setImage( image )
@@ -101,6 +103,11 @@ class BoolWidget( GafferUI.Widget ) :
 		self._qtWidget().setHitMode(
 			_CheckBox.HitMode.Button if displayMode == self.DisplayMode.Tool else _CheckBox.HitMode.CheckBox
 		)
+
+		if displayMode == self.DisplayMode.Tool :
+			self._qtWidget().setFocusPolicy( QtCore.Qt.NoFocus )
+		else :
+			self._qtWidget().setFocusPolicy( self.__defaultFocusPolicy )
 
 	def getDisplayMode( self ) :
 

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -1023,6 +1023,13 @@ class _EventFilter( QtCore.QObject ) :
 
 	def __keyRelease( self, qObject, qEvent ) :
 
+		# When a key is held, the following events are observed:
+		#   MacOS: p p p p r
+		#   Linux: p r p r p r p r
+		# We conform linux to match Mac as it feels more intuitive.
+		if qEvent.isAutoRepeat() :
+			return True
+
 		if self.__updateDragModifiers( qObject, qEvent ) :
 			return True
 

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -4888,5 +4888,16 @@
          y="165.36217"
          inkscape:label="#rect3932" />
     </g>
+    <g
+       transform="translate(266.36574,54.292896)"
+       inkscape:label="target"
+       id="forExport:pointerTarget">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fdfdfd;fill-opacity:1;fill-rule:nonzero;stroke:#060606;stroke-width:1.55200005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 640.28711,131.5 v 2.37109 c -4.06417,0.42136 -7.30842,3.66441 -7.73047,7.72852 h -2.36914 v 1.80078 h 2.36914 c 0.42122,4.06483 3.66565,7.30925 7.73047,7.73047 V 153.5 h 1.79883 v -2.36914 c 4.06502,-0.42122 7.30904,-3.66565 7.73047,-7.73047 h 2.37109 v -1.80078 h -2.37109 c -0.42226,-4.06411 -3.66609,-7.30716 -7.73047,-7.72852 V 131.5 Z m 0,4.24219 v 2.29492 h 1.80078 v -2.29492 c 3.05392,0.40129 5.45672,2.80331 5.85742,5.85742 h -2.16601 v 1.80078 h 2.16601 c -0.39993,3.05472 -2.80295,5.45621 -5.85742,5.85742 v -2.02929 h -1.80078 v 2.02929 c -3.05571,-0.39991 -5.45751,-2.80171 -5.85742,-5.85742 h 2.16601 v -1.80078 h -2.16601 c 0.40068,-3.05511 2.80225,-5.45743 5.85742,-5.85742 z"
+         transform="translate(-266.36574,-1.930713)"
+         id="path1559"
+         inkscape:connector-curvature="0" />
+    </g>
   </g>
 </svg>

--- a/src/GafferSceneUI/RotateTool.cpp
+++ b/src/GafferSceneUI/RotateTool.cpp
@@ -38,6 +38,7 @@
 
 #include "GafferSceneUI/SceneView.h"
 
+#include "GafferUI/Pointer.h"
 #include "GafferUI/RotateHandle.h"
 
 #include "Gaffer/MetadataAlgo.h"
@@ -49,6 +50,7 @@
 
 IECORE_PUSH_DEFAULT_VISIBILITY
 #include "OpenEXR/ImathEuler.h"
+#include "OpenEXR/ImathMatrixAlgo.h"
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/bind.hpp"
@@ -79,10 +81,23 @@ RotateTool::RotateTool( SceneView *view, const std::string &name )
 		handle->setRasterScale( 75 );
 		handles()->setChild( handleNames[i], handle );
 		// connect with group 0, so we get called before the Handle's slot does.
-		handle->dragBeginSignal().connect( 0, boost::bind( &RotateTool::dragBegin, this ) );
-		handle->dragMoveSignal().connect( boost::bind( &RotateTool::dragMove, this, ::_1, ::_2 ) );
-		handle->dragEndSignal().connect( boost::bind( &RotateTool::dragEnd, this ) );
+		handle->dragBeginSignal().connect( 0, boost::bind( &RotateTool::handleDragBegin, this ) );
+		handle->dragMoveSignal().connect( boost::bind( &RotateTool::handleDragMove, this, ::_1, ::_2 ) );
+		handle->dragEndSignal().connect( boost::bind( &RotateTool::handleDragEnd, this ) );
 	}
+
+	SceneGadget *sg = runTimeCast<SceneGadget>( this->view()->viewportGadget()->getPrimaryChild() );
+	sg->keyPressSignal().connect( boost::bind( &RotateTool::keyPress, this, ::_2 ) );
+	sg->keyReleaseSignal().connect( boost::bind( &RotateTool::keyRelease, this, ::_2 ) );
+	sg->leaveSignal().connect( boost::bind( &RotateTool::sceneGadgetLeave, this, ::_2 ) );
+	// We have to insert this before the underlying SelectionTool connections or it starts an object drag.
+	sg->buttonPressSignal().connect( 0, boost::bind( &RotateTool::buttonPress, this, ::_2 ) );
+
+	// We need to track the tool state/view visibility so we don't leave a lingering target cursor
+	sg->visibilityChangedSignal().connect( boost::bind( &RotateTool::visibilityChanged, this, ::_1 ) );
+	// We use set not dirtied to make sure we're called synchronously. We're
+	// happy to assume that this plug won't ever be connected to anything.
+	plugSetSignal().connect( boost::bind( &RotateTool::plugSet, this, ::_1 ) );
 
 	storeIndexOfNextChild( g_firstPlugIndex );
 
@@ -148,7 +163,75 @@ void RotateTool::updateHandles( float rasterScale )
 	}
 }
 
-IECore::RunTimeTypedPtr RotateTool::dragBegin()
+bool RotateTool::keyPress( const GafferUI::KeyEvent &event )
+{
+	// We track this regardless of whether we're active or not in case the tool
+	// is changed whilst the key is held down.
+	if( activePlug()->getValue() && event.key == "V" )
+	{
+		setTargetedMode( true );
+		return true;
+	}
+
+	return false;
+}
+
+bool RotateTool::keyRelease( const GafferUI::KeyEvent &event )
+{
+	if( activePlug()->getValue() && event.key == "V" )
+	{
+		setTargetedMode( false );
+		return true;
+	}
+
+	return false;
+}
+
+void RotateTool::sceneGadgetLeave( const GafferUI::ButtonEvent & event )
+{
+	if( getTargetedMode() )
+	{
+		// We loose keyRelease events in a variety of scenarios so turn targeted
+		// off whenever the mouse leaves the scene view. Key-repeat events will
+		// cause it to be re-enabled when the mouse re-enters if the key is still
+		// held down at that time.
+		setTargetedMode( false );
+	}
+}
+
+void RotateTool::plugSet( Gaffer::Plug *plug )
+{
+	if( plug == activePlug() )
+	{
+		if( !activePlug()->getValue() && getTargetedMode() )
+		{
+			setTargetedMode( false );
+		}
+	}
+}
+
+void RotateTool::visibilityChanged( GafferUI::Gadget *gadget )
+{
+	if( !gadget->visible() && getTargetedMode() )
+	{
+		setTargetedMode( false );
+	}
+}
+
+void RotateTool::setTargetedMode( bool targeted )
+{
+	if( targeted == m_targetedMode )
+	{
+		return;
+	}
+
+	m_targetedMode = targeted;
+
+	GafferUI::Pointer::setCurrent( targeted ? "target" : "" );
+}
+
+
+IECore::RunTimeTypedPtr RotateTool::handleDragBegin()
 {
 	m_drag.clear();
 	const Orientation orientation = static_cast<Orientation>( orientationPlug()->getValue() );
@@ -161,7 +244,7 @@ IECore::RunTimeTypedPtr RotateTool::dragBegin()
 	return nullptr; // Let the handle start the drag.
 }
 
-bool RotateTool::dragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event )
+bool RotateTool::handleDragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event )
 {
 	UndoScope undoScope( selection().back().transformPlug->ancestor<ScriptNode>(), UndoScope::Enabled, undoMergeGroup() );
 	const V3f rotation = static_cast<const RotateHandle *>( gadget )->rotation( event );
@@ -172,10 +255,60 @@ bool RotateTool::dragMove( const GafferUI::Gadget *gadget, const GafferUI::DragD
 	return true;
 }
 
-bool RotateTool::dragEnd()
+bool RotateTool::handleDragEnd()
 {
 	TransformTool::dragEnd();
 	return false;
+}
+
+bool RotateTool::buttonPress( const GafferUI::ButtonEvent &event )
+{
+	if( event.buttons != ButtonEvent::Left
+		|| !activePlug()->getValue()
+		|| !getTargetedMode()
+	) {
+		return false;
+	}
+
+	// In targeted mode, we orient the selection so -z aims towards the clicked point.
+	//
+	// We always return true to prevent the SelectTool defaults.
+
+	GafferScene::ScenePlug::ScenePath _;
+	Imath::V3f targetPos;
+
+	const SceneView *sv = static_cast<const SceneView *>( view() );
+	const Gadget *g = sv->viewportGadget()->getPrimaryChild();
+	const SceneGadget* sg = static_cast<const SceneGadget *>( g );
+	if( !sg->objectAt( event.line, _, targetPos ) )
+	{
+		return true;
+	}
+
+	UndoScope undoScope( selection()[0].transformPlug->ancestor<ScriptNode>(), UndoScope::Enabled );
+
+	for( const auto &s : selection() )
+	{
+		Context::Scope scopedContext( s.context.get() );
+
+		V3f currentYAxis, currentZAxis;
+		const M44f worldTransform = s.scene->fullTransform( s.path );
+		worldTransform.multDirMatrix( V3f( 0.0f, 1.0f, 0.0f ), currentYAxis );
+		worldTransform.multDirMatrix( V3f( 0.0f, 0.0f, -1.0f ), currentZAxis );
+
+		const V3f targetZAzis = targetPos - ( V3f( 0.0f ) * worldTransform );
+
+		M44f reorientationMatrix = rotationMatrixWithUpDir(
+			currentZAxis, targetZAzis, currentYAxis
+		);
+
+		V3f offset;
+		extractEulerXYZ( reorientationMatrix, offset );
+
+		Rotation( s, World ).apply( offset );
+	}
+
+	return true;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -921,7 +921,7 @@ class SceneView::Camera : public boost::signals::trackable
 			plug->addChild(
 				new Gaffer::V2fPlug(
 					"clippingPlanes", Plug::In,
-					V2f( 0.01, 100000 ),
+					V2f( 0.1, 100000 ),
 					V2f( 0.0001 ),
 					V2f( Imath::limits<float>::max() ),
 					Plug::Default & ~Plug::AcceptsInputs

--- a/src/GafferSceneUIModule/SceneGadgetBinding.cpp
+++ b/src/GafferSceneUIModule/SceneGadgetBinding.cpp
@@ -35,6 +35,8 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "boost/python.hpp"
+#include "boost/python/tuple.hpp"
+
 
 #include "SceneGadgetBinding.h"
 
@@ -132,6 +134,17 @@ IECore::InternedStringVectorDataPtr objectAt( SceneGadget &g, IECore::LineSegmen
 	return nullptr;
 }
 
+tuple objectAndIntersectionAt( SceneGadget &g, IECore::LineSegment3f &l )
+{
+	IECore::InternedStringVectorDataPtr result = new IECore::InternedStringVectorData;
+	Imath::V3f hitPos( 0.0f );
+	if( g.objectAt( l, result->writable(), hitPos ) )
+	{
+		return boost::python::make_tuple( result, hitPos );
+	}
+	return boost::python::make_tuple( object(), hitPos );
+}
+
 } // namespace
 
 void GafferSceneUIModule::bindSceneGadget()
@@ -157,6 +170,7 @@ void GafferSceneUIModule::bindSceneGadget()
 		.def( "setSelectionMask", &SceneGadget::setSelectionMask )
 		.def( "getSelectionMask", &getSelectionMask )
 		.def( "objectAt", &objectAt )
+		.def( "objectAndIntersectionAt", &objectAndIntersectionAt )
 		.def( "objectsAt", &SceneGadget::objectsAt )
 		.def( "setSelection", &SceneGadget::setSelection )
 		.def( "getSelection", &SceneGadget::getSelection, return_value_policy<copy_const_reference>() )

--- a/src/GafferUI/Pointer.cpp
+++ b/src/GafferUI/Pointer.cpp
@@ -62,6 +62,7 @@ static Registry &registry()
 		r["contextMenu"] = new Pointer( "pointerContextMenu.png", Imath::V2i( 1 ) );
 		r["tab"] = new Pointer( "pointerTab.png", Imath::V2i( 12, 15 ) );
 		r["detachedPanel"] = new Pointer( "pointerDetachedPanel.png", Imath::V2i( 12, 15 ) );
+		r["target"] = new Pointer( "pointerTarget.png", Imath::V2i( 12, 12 ) );
 	}
 	return r;
 }


### PR DESCRIPTION
Implements / closes #3311 

## User facing changes

- To increase precision, the default near clipping plane for the Viewers built-in cameras has been changed from `0.01` to `0.1`.

 - In a 3D Viewer, with the Translate tool active, holding the `v` key and clicking on an object will teleport the selection to that point. If more than one object is selected, the bounding-box center of the selection will be aligned with the clicked point.

- In a 3D Viewer, with the Rotate tool active, holding the `v` key and clicking on an object will aim the selected objects at that point (down -z).

## API Changes

 - Adds `SceneGadget objectAt( line, &path, &hitPoint )` that also populates `hitPoint` with the (approximate) gadget-space intersection point of line and the hit object.