### PR TITLE
Add ai:profileFileName option

### DIFF
--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -2281,6 +2281,8 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.option( "ai:log:filename", IECore.StringData( self.temporaryDirectory() + "/test/test_log.txt" ) )
 		r.option( "ai:statisticsFileName", IECore.StringData( self.temporaryDirectory() + "/test/test_stats.json" ) )
+		r.option( "ai:profileFileName", IECore.StringData( self.temporaryDirectory() + "/test/test_profile.json" ) )
+
 		c = r.camera(
 			"testCamera",
 			IECoreScene.Camera(
@@ -2304,6 +2306,9 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.render()
 
+		# required to flush the profile json
+		del r
+
 		with open( self.temporaryDirectory() + "/test/test_log.txt", "r" ) as logHandle:
 			self.assertNotEqual( logHandle.read().find( "rendering image at 640 x 480" ), -1 )
 
@@ -2319,6 +2324,11 @@ class RendererTest( GafferTest.TestCase ) :
 				self.assertTrue( "memory consumed MB" in stats )
 
 			self.assertTrue( "ray counts" in stats )
+
+		with open( self.temporaryDirectory() + "/test/test_profile.json", "r" ) as profileHandle :
+			stats = json.load( profileHandle )["traceEvents"]
+			driverEvents = [ x for x in stats if x["name"] == "ieCoreArnold:display:testBeauty" ]
+			self.assertEqual( driverEvents[0]["cat"], "driver_exr" )
 
 	def testProcedural( self ) :
 

--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -176,7 +176,9 @@ def __statisticsSummary( plug ) :
 
 	info = []
 	if plug["statisticsFileName"]["enabled"].getValue() :
-		info.append( "File name: " + plug["statisticsFileName"]["value"].getValue() )
+		info.append( "Stats File: " + plug["statisticsFileName"]["value"].getValue() )
+	if plug["profileFileName"]["enabled"].getValue() :
+		info.append( "Profile File: " + plug["profileFileName"]["value"].getValue() )
 
 	return ", ".join( info )
 
@@ -915,7 +917,21 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"layout:section", "Statistics",
-			"label", "File Name",
+			"label", "Statistics File",
+
+		],
+
+		"options.profileFileName" : [
+
+			"description",
+			"""
+			The name of a profile json file where Arnold will store a
+			detailed node performance graph. Use chrome://tracing to
+			view the profile.
+			""",
+
+			"layout:section", "Statistics",
+			"label", "Profile File",
 
 		],
 

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -153,6 +153,7 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 
 	// Statistics
 	options->addChild( new Gaffer::NameValuePlug( "ai:statisticsFileName", new IECore::StringData( "" ), false, "statisticsFileName" ) );
+	options->addChild( new Gaffer::NameValuePlug( "ai:profileFileName", new IECore::StringData( "" ), false, "profileFileName" ) );
 
 	// Licensing
 

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -2599,6 +2599,7 @@ IECore::InternedString g_cameraOptionName( "camera" );
 IECore::InternedString g_logFileNameOptionName( "ai:log:filename" );
 IECore::InternedString g_logMaxWarningsOptionName( "ai:log:max_warnings" );
 IECore::InternedString g_statisticsFileNameOptionName( "ai:statisticsFileName" );
+IECore::InternedString g_profileFileNameOptionName( "ai:profileFileName" );
 IECore::InternedString g_pluginSearchPathOptionName( "ai:plugin_searchpath" );
 IECore::InternedString g_aaSeedOptionName( "ai:AA_seed" );
 IECore::InternedString g_sampleMotionOptionName( "sampleMotion" );
@@ -2709,6 +2710,32 @@ class ArnoldGlobals
 					}
 					AiStatsSetFileName( d->readable().c_str() );
 
+				}
+				return;
+			}
+			else if( name == g_profileFileNameOptionName )
+			{
+				if( value == nullptr )
+				{
+					AiProfileSetFileName( "" );
+				}
+				else if( const IECore::StringData *d = reportedCast<const IECore::StringData>( value, "option", name ) )
+				{
+					if( !d->readable().empty() )
+					{
+						try
+						{
+							boost::filesystem::path path( d->readable() );
+							path.remove_filename();
+							boost::filesystem::create_directories( path );
+						}
+						catch( const std::exception &e )
+						{
+							IECore::msg( IECore::Msg::Error, "ArnoldRenderer::option()", e.what() );
+						}
+					}
+
+					AiProfileSetFileName( d->readable().c_str() );
 				}
 				return;
 			}


### PR DESCRIPTION
This enables users to generate detailed profiles of Arnold renders, which can be inspected with chrome://tracing

https://docs.arnoldrenderer.com/pages/viewpage.action?pageId=86806604