### PR TITLE
TaskMutex/ValuePlug : Address issues in TBB < 2018 Update 3 (again)

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -147,8 +147,8 @@ if targetApp :
 else :
 
 	targetApp = "gaffer"
-	targetAppReg = cortexReg
-	pythonVersion = targetAppReg["preferredPythonVersion"]
+	targetAppReg = gafferReg
+	pythonVersion = cortexReg["preferredPythonVersion"]
 	platformReg = IEEnv.registry["platformDefaults"][IEEnv.platform()]
 	if not compiler :
 		compiler = platformReg.get( "toolsCompiler", platformReg["compiler"] )

--- a/include/Gaffer/Private/IECorePreview/TaskMutex.h
+++ b/include/Gaffer/Private/IECorePreview/TaskMutex.h
@@ -193,15 +193,21 @@ class TaskMutex : boost::noncopyable
 							// The `run_and_wait()` method is buggy until
 							// TBB 2018 Update 3, causing calls to `wait()` on other threads to
 							// return immediately rather than do the work we want.
-							// So we call `run()` and `wait()` separately. This has a
-							// downside though : it appears to trigger a TBB bug whereby
-							// it is sometimes unable to destroy the internals of the
-							// `task_arena`. It then spends increasing amounts of time
-							// in `market::try_destroy_arena()`, doing a linear search
-							// through all the zombie arenas until it finds the one it
-							// wants to destroy, decides for some reason it can't destroy it,
-							// and gives up. With large numbers of arenas this can add
-							// huge overhead.
+							// So we call `run()` and `wait()` separately. This has two
+							// downsides though :
+							//
+							// 1. It appears to trigger a TBB bug whereby it is sometimes
+							//    unable to destroy the internals of the `task_arena`. It
+							//    then spends increasing amounts of time in
+							//    `market::try_destroy_arena()`, doing a linear search through
+							//    all the zombie arenas until it finds the one it
+							//    wants to destroy, decides for some reason it can't destroy it,
+							//    and gives up. With large numbers of arenas this can add
+							//    huge overhead.
+							// 2. It does not guarantee that `fWrapper` runs on the same thread
+							//    that `run()` is called on (`run_and_wait()` does provide
+							//    that guarantee). This forces us into nasty ThreadStateFixer
+							//    workarounds in Gaffer/ValuePlug.cpp.
 							m_mutex->m_executionState->taskGroup.run( fWrapper );
 							m_mutex->m_executionState->taskGroup.wait();
 #endif


### PR DESCRIPTION
This is a followup on #3400. I split the test out into its own commit (its easier to verify the different behaviours this way), kept the workaround-of-a-workaround commit (to support old tbb in Maya), and added an IE config change so we can use modern tbb at IE when we're not in Maya.

All in all, nothing to see here for the general public.