### PR TITLE
Display node metadata

### DIFF
--- a/include/GafferImage/Display.h
+++ b/include/GafferImage/Display.h
@@ -89,7 +89,7 @@ class GAFFERIMAGE_API Display : public ImageNode
 		void hashDataWindow( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
-		// Don't need to re-implement hashMetadata() because we always return the same value.
+		void hashMetadata( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstCompoundDataPtr computeMetadata( const Gaffer::Context *context, const ImagePlug *parent ) const override;
 
 		void hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;

--- a/python/GafferImageTest/CatalogueTest.py
+++ b/python/GafferImageTest/CatalogueTest.py
@@ -76,13 +76,13 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
 		for image in images :
 			c["images"].addChild( image )
-			self.assertImagesEqual( readers[0]["out"], c["out"], ignoreMetadata = True )
+			self.assertImagesEqual( readers[0]["out"], c["out"] )
 
 		def assertExpectedImages() :
 
 			for i, reader in enumerate( readers ) :
 				c["imageIndex"].setValue( i )
-				self.assertImagesEqual( readers[i]["out"], c["out"], ignoreMetadata = True )
+				self.assertImagesEqual( readers[i]["out"], c["out"] )
 
 		assertExpectedImages()
 
@@ -95,7 +95,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
 		c = GafferImage.Catalogue()
 		c["images"].addChild( c.Image.load( "${GAFFER_ROOT}/python/GafferImageTest/images/blurRange.exr" ) )
-		self.assertEqual( c["out"]["metadata"].getValue()["ImageDescription"].value, "" )
+		self.assertNotIn( "ImageDescription", c["out"]["metadata"].getValue() )
 
 		c["images"][-1]["description"].setValue( "ddd" )
 		self.assertEqual( c["out"]["metadata"].getValue()["ImageDescription"].value, "ddd" )
@@ -116,8 +116,10 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		r = GafferImage.ImageReader()
 		r["fileName"].setValue( w["fileName"].getValue() )
 
-		i = GafferImage.Catalogue.Image.load( w["fileName"].getValue() )
-		self.assertEqual( i["description"].getValue(), "i am a description" )
+		c = GafferImage.Catalogue()
+		c["images"].addChild( GafferImage.Catalogue.Image.load( w["fileName"].getValue() ) )
+		self.assertEqual( c["images"][0]["description"].getValue(), "" )
+		self.assertEqual( c["out"]["metadata"].getValue()["ImageDescription"].value, "i am a description" )
 
 	def testSerialisation( self ) :
 
@@ -187,7 +189,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( c["images"][0]["fileName"].getValue(), "" )
 		self.assertEqual( c["imageIndex"].getValue(), 0 )
 
-		self.assertImagesEqual( r["out"], c["out"], ignoreMetadata = True )
+		self.assertImagesEqual( r["out"], c["out"] )
 
 		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/blurRange.exr" )
 		self.sendImage( r["out"], c )
@@ -195,7 +197,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( len( c["images"] ), 2 )
 		self.assertEqual( c["images"][1]["fileName"].getValue(), "" )
 		self.assertEqual( c["imageIndex"].getValue(), 1 )
-		self.assertImagesEqual( r["out"], c["out"], ignoreMetadata = True )
+		self.assertImagesEqual( r["out"], c["out"] )
 
 	def testDisplayDriverAOVGrouping( self ) :
 
@@ -273,8 +275,8 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( len( c1["images"] ), 1 )
 		self.assertEqual( len( c2["images"] ), 1 )
 
-		self.assertImagesEqual( c1["out"], constant1["out"], ignoreMetadata = True )
-		self.assertImagesEqual( c2["out"], constant2["out"], ignoreMetadata = True )
+		self.assertImagesEqual( c1["out"], constant1["out"] )
+		self.assertImagesEqual( c2["out"], constant2["out"] )
 
 	def testDontSerialiseUnsavedRenders( self ) :
 
@@ -313,25 +315,25 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
 		for image in images :
 			promotedImages.addChild( image )
-			self.assertImagesEqual( readers[0]["out"], promotedOut, ignoreMetadata = True )
+			self.assertImagesEqual( readers[0]["out"], promotedOut )
 
 		for i, reader in enumerate( readers ) :
 			promotedImageIndex.setValue( i )
-			self.assertImagesEqual( readers[i]["out"], promotedOut, ignoreMetadata = True )
+			self.assertImagesEqual( readers[i]["out"], promotedOut )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 
 		for i, reader in enumerate( readers ) :
 			s2["b"]["imageIndex"].setValue( i )
-			self.assertImagesEqual( readers[i]["out"], s2["b"]["out"], ignoreMetadata = True )
+			self.assertImagesEqual( readers[i]["out"], s2["b"]["out"] )
 
 		s3 = Gaffer.ScriptNode()
 		s3.execute( s.serialise() )
 
 		for i, reader in enumerate( readers ) :
 			s3["b"]["imageIndex"].setValue( i )
-			self.assertImagesEqual( readers[i]["out"], s3["b"]["out"], ignoreMetadata = True )
+			self.assertImagesEqual( readers[i]["out"], s3["b"]["out"] )
 
 	def testDisplayDriverAndPromotion( self ) :
 
@@ -416,7 +418,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
 			self.assertEqual( len( s["c"]["images"] ), 2 )
 			self.assertEqual( s["c"]["imageIndex"].getValue(), 1 )
-			self.assertImagesEqual( s["c"]["out"], r["out"], ignoreMetadata = True )
+			self.assertImagesEqual( s["c"]["out"], r["out"] )
 
 		assertPostConditions()
 

--- a/python/GafferImageTest/DisplayTest.py
+++ b/python/GafferImageTest/DisplayTest.py
@@ -110,11 +110,15 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 			dataWindow = image["dataWindow"].getValue()
 			channelNames = image["channelNames"].getValue()
 
+			parameters = IECore.CompoundData()
+			parameters.update( { "header:" + k : v for k, v in image["metadata"].getValue().items() } )
+			parameters.update( extraParameters )
+
 			driver = DisplayTest.Driver(
 				image["format"].getValue(),
 				dataWindow,
 				channelNames,
-				port, extraParameters
+				port, parameters
 			)
 
 			tileSize = GafferImage.ImagePlug.tileSize()
@@ -289,7 +293,7 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 
 		self.Driver.sendImage( imageReader["out"], port = server.portNumber() )
 
-		self.assertImagesEqual( imageReader["out"], node["out"], ignoreMetadata = True )
+		self.assertImagesEqual( imageReader["out"], node["out"] )
 
 		self.assertEqual( len( imagesReceived ), 1 )
 		self.assertEqual( imagesReceived[0][0], node["out"] )

--- a/python/GafferTest/TypedPlugTest.py
+++ b/python/GafferTest/TypedPlugTest.py
@@ -219,5 +219,30 @@ class TypedPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( n.numHashCalls, numHashCalls )
 		self.assertEqual( n.numComputeCalls, 1 )
 
+	def testBoolPlugStringConnections( self ) :
+
+		n = GafferTest.AddNode()
+		n["op1"].setValue( 0 )
+		n["op2"].setValue( 2 )
+		self.assertEqual( n["sum"].getValue(), 2 )
+
+		s = Gaffer.StringPlug()
+		n["enabled"].setInput( s )
+		self.assertEqual( n["sum"].getValue(), 0 )
+
+		s.setValue( "notEmpty" )
+		self.assertEqual( n["sum"].getValue(), 2 )
+
+		s.setValue( "${test}" )
+		self.assertEqual( n["sum"].getValue(), 0 )
+
+		with Gaffer.Context() as c :
+
+			c["test"] = "notEmpty"
+			self.assertEqual( n["sum"].getValue(), 2 )
+
+			c["test"] = ""
+			self.assertEqual( n["sum"].getValue(), 0 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/TypedPlug.cpp
+++ b/src/Gaffer/TypedPlug.cpp
@@ -38,6 +38,7 @@
 #include "Gaffer/TypedPlug.h"
 
 #include "Gaffer/NumericPlug.h"
+#include "Gaffer/StringPlug.h"
 #include "Gaffer/TypedPlug.inl"
 
 namespace Gaffer
@@ -50,7 +51,7 @@ GAFFER_PLUG_DEFINE_TEMPLATE_TYPE( Gaffer::AtomicBox2fPlug, AtomicBox2fPlugTypeId
 GAFFER_PLUG_DEFINE_TEMPLATE_TYPE( Gaffer::AtomicBox3fPlug, AtomicBox3fPlugTypeId )
 GAFFER_PLUG_DEFINE_TEMPLATE_TYPE( Gaffer::AtomicBox2iPlug, AtomicBox2iPlugTypeId )
 
-// specialise BoolPlug to accept connections from NumericPlugs
+// Specialise BoolPlug to accept connections from NumericPlugs and StringPlugs
 
 template<>
 bool BoolPlug::acceptsInput( const Plug *input ) const
@@ -63,7 +64,9 @@ bool BoolPlug::acceptsInput( const Plug *input ) const
 	{
 		return input->isInstanceOf( staticTypeId() ) ||
 		       input->isInstanceOf( IntPlug::staticTypeId() ) ||
-		       input->isInstanceOf( FloatPlug::staticTypeId() );
+		       input->isInstanceOf( FloatPlug::staticTypeId() ) ||
+		       input->isInstanceOf( StringPlug::staticTypeId() )
+		;
 	}
 	return true;
 }
@@ -81,6 +84,9 @@ void BoolPlug::setFrom( const ValuePlug *other )
 			break;
 		case IntPlugTypeId :
 			setValue( static_cast<const IntPlug *>( other )->getValue() );
+			break;
+		case StringPlugTypeId :
+			setValue( static_cast<const StringPlug *>( other )->getValue().size() );
 			break;
 		default :
 			throw IECore::Exception( "Unsupported plug type" );

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -136,9 +136,10 @@ class Catalogue::InternalImage : public ImageNode
 			// Adds on a description to the output
 			addChild( new ImageMetadata() );
 			imageMetadata()->inPlug()->setInput( imageSwitch()->outPlug() );
-			NameValuePlugPtr meta = new NameValuePlug( "ImageDescription", new StringData(), "member1" );
+			NameValuePlugPtr meta = new NameValuePlug( "ImageDescription", new StringData(), true, "member1" );
 			imageMetadata()->metadataPlug()->addChild( meta );
-			meta->valuePlug<StringPlug>()->setInput( descriptionPlug() );
+			meta->valuePlug()->setInput( descriptionPlug() );
+			meta->enabledPlug()->setInput( descriptionPlug() ); // Enable only for non-empty strings
 
 			outPlug()->setInput( imageMetadata()->outPlug() );
 		}
@@ -620,14 +621,6 @@ Catalogue::Image::Ptr Catalogue::Image::load( const std::string &fileName )
 
 	Ptr image = new Image( name, Plug::In, Plug::Default | Plug::Dynamic );
 	image->fileNamePlug()->setValue( fileName );
-
-	ImageReaderPtr reader = new ImageReader;
-	reader->fileNamePlug()->setValue( fileName );
-	ConstCompoundDataPtr meta = reader->outPlug()->metadataPlug()->getValue();
-	if( const StringData *description = meta->member<const StringData>( "ImageDescription" ) )
-	{
-		image->descriptionPlug()->setValue( description->readable() );
-	}
 
 	return image;
 }


### PR DESCRIPTION
This makes it possible for a render to send image metadata to the catalogue by using output parameters of the form "header:<name>". This is the same convention we use for passing image metadata to image files rendered by Arnold. I intend to use this as part of the implementation of #2835, by outputting metadata so we can track back from the image to the node that rendered it.