### PR TITLE
NodeSetEditor : Ensure pinned state is always reflected in the title

### DIFF
--- a/python/GafferUI/NodeSetEditor.py
+++ b/python/GafferUI/NodeSetEditor.py
@@ -357,10 +357,10 @@ class NodeSetEditor( GafferUI.Editor ) :
 		# Only add node names if we're pinned in some way shape or form
 		if not self.__nodeSetIsScriptSelection() :
 
+			result.append( " [" )
+
 			numNames = min( _maxNodes, len( self.__nodeSet ) )
 			if numNames :
-
-				result.append( " [" )
 
 				if _reverseNodes :
 					nodes = self.__nodeSet[len(self.__nodeSet)-numNames:]
@@ -376,7 +376,7 @@ class NodeSetEditor( GafferUI.Editor ) :
 				if _ellipsis and len( self.__nodeSet ) > _maxNodes :
 					result.append( "..." )
 
-				result.append( "]" )
+			result.append( "]" )
 
 		return result
 


### PR DESCRIPTION
Previously, if an editor's node set had no applicable nodes, the square-bracket ` [<nodes>]` suffix would be omitted.

This made it look like the editor wasn't pinned. Which was a lie, and was particularly noticeable when in the default layout, the Viewer was pinned to a 2D node, so the 3D editors had no applicable nodes in their set.

Now the title will always contain the bracket suffix, even if there are no nodes. In the case of no nodes, it will simply be ` []`.