### PR TITLE
CompoundEditor : Keyboard shortcuts should break editor links

### DIFF
--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -818,8 +818,7 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 			self.insert( 0, newEditor )
 			self.setCurrent( newEditor )
 		else :
-			target = self.getCurrent().drivingEditor() or self.getCurrent()
-			target.setNodeSet( nodeSet )
+			self.getCurrent().setNodeSet( nodeSet )
 
 		self.setHighlighted( False )
 
@@ -1519,13 +1518,11 @@ class _PinningWidget( _Frame ) :
 		if not isinstance( editor, GafferUI.NodeSetEditor ) :
 			return False
 
-		targetEditor = editor.drivingEditor() or editor
-
 		if event.key == "N" :
-			_PinningWidget.__followNodeSelection( targetEditor )
+			_PinningWidget.__followNodeSelection( editor )
 			return True
 		elif event.key == "P" :
-			_PinningWidget.__pinToNodeSelection( targetEditor )
+			_PinningWidget.__pinToNodeSelection( editor )
 			return True
 
 		return False
@@ -1683,14 +1680,16 @@ class _PinningWidget( _Frame ) :
 
 		m.append( "/Node Selection", {
 			"command" : functools.partial( self.__followNodeSelection, weakref.ref( editor ) ),
-			"checkBox" : drivingEditor is None and editor.getNodeSet().isSame( editor.scriptNode().selection() )
+			"checkBox" : drivingEditor is None and editor.getNodeSet().isSame( editor.scriptNode().selection() ),
+			"shortCut" : "n"
 		} )
 
 		m.append( "/Pin Divider", { "divider" : True, "label" : "Pin" } )
 
 		m.append( "/Pin Node Selection", {
 			"command" : functools.partial( self.__pinToNodeSelection, weakref.ref( editor ) ),
-			"label" : "Node Selection"
+			"label" : "Node Selection",
+			"shortCut" : "p"
 		} )
 
 	def __getNodeSetEditor( self ) :

--- a/python/GafferUI/GraphBookmarksUI.py
+++ b/python/GafferUI/GraphBookmarksUI.py
@@ -288,7 +288,7 @@ def __assignNumericBookmark( node, numericBookmark ) :
 		else :
 			Gaffer.MetadataAlgo.setNumericBookmark( node.scriptNode(), numericBookmark, node )
 
-def __findNumericBookmark( editor, numericBookmark, removeDriver = True ) :
+def __findNumericBookmark( editor, numericBookmark ) :
 
 	if not isinstance( editor, ( GafferUI.NodeSetEditor, GafferUI.GraphEditor ) ) :
 		return False
@@ -307,11 +307,7 @@ def __findNumericBookmark( editor, numericBookmark, removeDriver = True ) :
 		editor.frame( [ node ] )
 	else :
 		s = Gaffer.StandardSet( [ node ] )
-		if removeDriver :
-			editor.setNodeSet( s )
-		else :
-			target = editor.drivingEditor() or editor
-			target.setNodeSet( s )
+		editor.setNodeSet( s )
 
 	return True
 
@@ -353,10 +349,9 @@ def __editorKeyPress( editor, event ) :
 			# the driving editor, rather than breaking the link.
 
 			if numericBookmark != 0 :
-				__findNumericBookmark( editor, numericBookmark, False )
+				__findNumericBookmark( editor, numericBookmark )
 			elif isinstance( editor, GafferUI.NodeSetEditor ) :
-				target = editor.drivingEditor() or editor
-				target.setNodeSet( editor.scriptNode().selection() )
+				editor.setNodeSet( editor.scriptNode().selection() )
 
 		return True
 


### PR DESCRIPTION
### User facing changes:

 - When using node drag and drop or the `1`-`9`, `n` and `p` shortcuts to
adjust a slave editor's focus, Gaffer will now break the link to the master
and update the target editor of the event.