### PR TITLE
CompoundEditor : Add titles to Editor Focus and Layout menus

### DIFF
--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -565,7 +565,7 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 			self.__pinningWidget = _PinningWidget()
 
 			layoutButton = GafferUI.MenuButton( image="layoutButton.png", hasFrame=False )
-			layoutButton.setMenu( GafferUI.Menu( Gaffer.WeakMethod( self.__layoutMenuDefinition ) ) )
+			layoutButton.setMenu( GafferUI.Menu( Gaffer.WeakMethod( self.__layoutMenuDefinition ), title = "Layout" ) )
 			layoutButton.setToolTip( "Click to modify the layout" )
 			layoutButton._qtWidget().setFixedHeight( 15 )
 
@@ -1662,7 +1662,7 @@ class _PinningWidget( _Frame ) :
 		self.__addStandardItems( e, m )
 		CompoundEditor.nodeSetMenuSignal()( e, m )
 
-		self.__pinningMenu = GafferUI.Menu( m )
+		self.__pinningMenu = GafferUI.Menu( m, title = "Editor Focus" )
 
 		buttonBound = self.__icon.bound()
 		self.__pinningMenu.popup(


### PR DESCRIPTION
In order to help users get to grips with the terminology, it seemed like it'd be worth adding titles to the Editor Focus and Layout menus.

![image](https://user-images.githubusercontent.com/896779/67279876-d3c1bc00-f4c3-11e9-8cd6-6fd78c844350.png)

![image](https://user-images.githubusercontent.com/896779/67279882-d7554300-f4c3-11e9-8887-d04027d57a47.png)
