### PR TITLE
Support Ramp Widget For Read-Only Plugs

### DIFF
--- a/python/GafferUI/Slider.py
+++ b/python/GafferUI/Slider.py
@@ -333,7 +333,7 @@ class Slider( GafferUI.Widget ) :
 			positions = self.getPositions()[:]
 			positions.append( float( event.line.p0.x ) / self.size().x )
 			self._setPositionsInternal( positions, self.PositionChangedReason.IndexAdded )
-			self.setSelectedIndex( len( positions ) - 1 )
+			self.setSelectedIndex( len( self.getPositions() ) - 1 )
 
 		return True
 

--- a/python/GafferUI/SplinePlugValueWidget.py
+++ b/python/GafferUI/SplinePlugValueWidget.py
@@ -86,9 +86,6 @@ class SplinePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		if event.buttons & event.Buttons.Left :
 
-			if not self._editable() :
-				return False
-
 			_SplinePlugValueDialogue.acquire( self.getPlug() )
 			return True
 


### PR DESCRIPTION
It's been a long term annoyance for artists at IE that they would gang the channels of a color plug on a ramp, and everything would work fine, but then once they closed the ramp editor, they would be unable to open it again.  We only recently figured out what was happening - it was just reported as "ramps break sometimes" - it is pretty tricky to figure out what's going on, because everything continues working fine until you close the window.

When thinking about how to fix this, one option would have been to allow showing ramps as long as everything but the Y components are editable, since the existing UI already handles readOnly y components properly.

I decided to take a quick look at fixing it properly though, so you can always open the editor, even for completely readOnly ramps.  Maybe you'll spot something I've missed, but this now seems to all be working correctly, and is definitely a nice feature.