### PR TITLE
TabbedContainer : Ensure currentChanged called with correct widget on removal

### DIFF
--- a/python/GafferUI/TabbedContainer.py
+++ b/python/GafferUI/TabbedContainer.py
@@ -173,8 +173,11 @@ class TabbedContainer( GafferUI.ContainerWidget ) :
 			self._qtWidget().setCornerWidget( None )
 			self.__cornerWidget = None
 		else :
-			self._qtWidget().removeTab( self.__widgets.index( child ) )
+			# We must remove the child from __widgets before the tab, otherwise
+			# currentChangedSignal will be emit with the old widget.
+			removalIndex = self.__widgets.index( child )
 			self.__widgets.remove( child )
+			self._qtWidget().removeTab( removalIndex )
 
 		child._qtWidget().setParent( None )
 		child._applyVisibility()

--- a/python/GafferUITest/TabbedContainerTest.py
+++ b/python/GafferUITest/TabbedContainerTest.py
@@ -149,6 +149,10 @@ class TabbedContainerTest( GafferUITest.TestCase ) :
 		self.failUnless( self.__current is b2 )
 		self.failUnless( tc.getCurrent() is b2 )
 
+		tc.remove( b1 )
+		self.failUnless( self.__current is b2 )
+		self.failUnless( tc.getCurrent() is b2 )
+
 	def testDel( self ) :
 
 		with GafferUI.TabbedContainer() as t :


### PR DESCRIPTION
Noticed as the editor focus menu would show incorrect pinning widget when the current tab was closed. This was as the currentChanged event was being emit with the old widget. So all the tracking signals were attached to the about-to-be-deleted widget...