### PR TITLE
ShaderAssignment/OSLObject : Remove per-location-shader compatibility

### DIFF
--- a/include/GafferOSL/OSLObject.h
+++ b/include/GafferOSL/OSLObject.h
@@ -41,7 +41,6 @@
 #include "GafferOSL/OSLCode.h"
 #include "GafferOSL/TypeIds.h"
 
-
 #include "GafferScene/Deformer.h"
 #include "GafferScene/ShaderPlug.h"
 
@@ -97,9 +96,6 @@ class GAFFEROSL_API OSLObject : public GafferScene::Deformer
 
 		Gaffer::StringPlug *resampledNamesPlug();
 		const Gaffer::StringPlug *resampledNamesPlug() const;
-
-		Gaffer::BoolPlug *contextCompatibilityPlug();
-		const Gaffer::BoolPlug *contextCompatibilityPlug() const;
 
 		ConstShadingEnginePtr shadingEngine( const Gaffer::Context *context ) const;
 

--- a/include/GafferScene/ShaderAssignment.h
+++ b/include/GafferScene/ShaderAssignment.h
@@ -67,9 +67,6 @@ class GAFFERSCENE_API ShaderAssignment : public SceneElementProcessor
 
 	private :
 
-		Gaffer::BoolPlug *contextCompatibilityPlug();
-		const Gaffer::BoolPlug *contextCompatibilityPlug() const;
-
 		static size_t g_firstPlugIndex;
 
 };

--- a/python/GafferOSLTest/OSLObjectTest.py
+++ b/python/GafferOSLTest/OSLObjectTest.py
@@ -744,7 +744,7 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 
 		script = Gaffer.ScriptNode()
 
-		# Network to assign the length of "scene:path" as a primvar called "id"
+		# Network to assign the existence of "scene:path" as a primvar called "id"
 
 		script["outInt"] = GafferOSL.OSLShader()
 		script["outInt"].loadShader( "ObjectProcessing/OutInt" )
@@ -754,7 +754,7 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		script["outObject"]["parameters"]["in0"].setInput( script["outInt"]["out"]["primitiveVariable"] )
 
 		script["expression"] = Gaffer.Expression()
-		script["expression"].setExpression( 'parent["outInt"]["parameters"]["value"] = len( context.get( "scene:path", [] ) )' )
+		script["expression"].setExpression( 'parent["outInt"]["parameters"]["value"] = 1 if context.get( "scene:path", None ) else 0' )
 
 		# OSLObject node to apply network
 
@@ -768,45 +768,9 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		script["oslObject"]["filter"].setInput( script["filter"]["out"] )
 		script["oslObject"]["shader"].setInput( script["outObject"]["out"]["out"] )
 
-		# SceneWriter to save the result for later perusal
+		# Check that "scene:path" isn't exposed to the shader
 
-		script["writer"] = GafferScene.SceneWriter()
-		script["writer"]["in"].setInput( script["oslObject"]["out"] )
-		script["writer"]["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.scc" ) )
-
-		script["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.gfr" ) )
-		script.save()
-
-		# Assertions
-
-		def assertContextCompatibility( expected, envVar ) :
-
-			env = os.environ.copy()
-			if envVar is not None :
-				env["GAFFEROSL_OSLOBJECT_CONTEXTCOMPATIBILITY"] = envVar
-
-			subprocess.check_call(
-				[ "gaffer", "execute", script["fileName"].getValue(), "-nodes", "writer" ],
-				env = env
-			)
-
-			scene = IECoreScene.SceneCache( script["writer"]["fileName"].getValue(), IECore.IndexedIO.OpenMode.Read )
-			plane = scene.child( "plane" )
-
-			self.assertEqual( plane.readObject( 0 )["id"].data[0], 1 if expected else 0 )
-
-		assertContextCompatibility( False, envVar = None )
-		assertContextCompatibility( False, envVar = "0" )
-		assertContextCompatibility( False, envVar = "?" )
-		assertContextCompatibility( True, envVar = "1" )
-
-		Gaffer.NodeAlgo.applyUserDefaults( script["oslObject"] )
-		script.save()
-
-		assertContextCompatibility( False, envVar = None )
-		assertContextCompatibility( False, envVar = "0" )
-		assertContextCompatibility( False, envVar = "?" )
-		assertContextCompatibility( False, envVar = "1" )
+		self.assertEqual( script["oslObject"]["out"].object( "/plane")["id"].data[0], 0 )
 
 	def testAllTypes( self ) :
 
@@ -1129,6 +1093,14 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 
 		self.assertScenesEqual( oslObject["out"], oslObject["in"], checks = { "bound" } )
 		self.assertSceneHashesEqual( oslObject["out"], oslObject["in"], checks = { "bound" } )
+
+	def testLoadFrom0_55( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["fileName"].setValue( os.path.join( os.path.dirname( __file__ ), "scripts", "oslObjectVersion-0.55.0.0.gfr" ) )
+		script.load()
+
+		self.assertNotIn( "__contextCompatibility", script["OSLObject"] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLTest/scripts/oslObjectVersion-0.55.0.0.gfr
+++ b/python/GafferOSLTest/scripts/oslObjectVersion-0.55.0.0.gfr
@@ -1,0 +1,32 @@
+import Gaffer
+import GafferImage
+import GafferOSL
+import GafferScene
+import IECore
+import imath
+
+Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 55, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 0, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.NameValuePlug( "image:catalogue:port", Gaffer.IntPlug( "value", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "imageCataloguePort", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+parent["variables"].addChild( Gaffer.NameValuePlug( "project:name", Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectName", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+parent["variables"].addChild( Gaffer.NameValuePlug( "project:rootDirectory", Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectRootDirectory", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format( 1920, 1080, 1.000 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["defaultFormat"] )
+__children["OSLObject"] = GafferOSL.OSLObject( "OSLObject" )
+parent.addChild( __children["OSLObject"] )
+__children["OSLObject"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"]["value"].setValue( 36138 )
+Gaffer.Metadata.registerValue( parent["variables"]["imageCataloguePort"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectName"]["name"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectRootDirectory"]["name"], 'readOnly', True )
+__children["OSLObject"]["__contextCompatibility"].setValue( False )
+__children["OSLObject"]["__uiPosition"].setValue( imath.V2f( -5.3499999, -2.1500001 ) )
+
+
+del __children
+

--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import inspect
 import os
 import subprocess
 import unittest
@@ -445,7 +444,7 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 				"shader2"
 			)
 
-	def testContextCompatibility( self ) :
+	def testGlobalContext( self ) :
 
 		script = Gaffer.ScriptNode()
 
@@ -453,62 +452,21 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 		script["shader"]["type"].setValue( "shader" )
 
 		script["expression"] = Gaffer.Expression()
-		script["expression"].setExpression( 'parent["shader"]["parameters"]["i"] = len( context.get( "scene:path", [] ) )' )
+		script["expression"].setExpression( 'parent["shader"]["parameters"]["i"] = 1 if context.get( "scene:path", None ) else 0' )
 
 		script["sphere"] = GafferScene.Sphere()
 
-		script["group"] = GafferScene.Group()
-		script["group"]["in"][0].setInput( script["sphere"]["out"] )
-
 		script["filter"] = GafferScene.PathFilter()
-		script["filter"]["paths"].setValue( IECore.StringVectorData( [ "/group", "/group/sphere" ] ) )
+		script["filter"]["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
 
 		script["assignment"] = GafferScene.ShaderAssignment()
-		script["assignment"]["in"].setInput( script["group"]["out"] )
+		script["assignment"]["in"].setInput( script["sphere"]["out"] )
 		script["assignment"]["filter"].setInput( script["filter"]["out"] )
 		script["assignment"]["shader"].setInput( script["shader"]["out"] )
 
-		script["writer"] = GafferScene.SceneWriter()
-		script["writer"]["in"].setInput( script["assignment"]["out"] )
-		script["writer"]["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.scc" ) )
-
-		script["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.gfr" ) )
-		script.save()
-
-		def assertContextCompatibility( expected, envVar ) :
-
-			env = os.environ.copy()
-			if envVar is not None :
-				env["GAFFERSCENE_SHADERASSIGNMENT_CONTEXTCOMPATIBILITY"] = envVar
-
-			subprocess.check_call(
-				[ "gaffer", "execute", script["fileName"].getValue(), "-nodes", "writer" ],
-				env = env
-			)
-
-			scene = IECoreScene.SceneCache( script["writer"]["fileName"].getValue(), IECore.IndexedIO.OpenMode.Read )
-			group = scene.child( "group" )
-			sphere = group.child( "sphere" )
-
-			if expected :
-				self.assertEqual( group.readAttribute( "shader", 0 ).outputShader().parameters["i"].value, 1 )
-				self.assertEqual( sphere.readAttribute( "shader", 0 ).outputShader().parameters["i"].value, 2 )
-			else :
-				self.assertEqual( group.readAttribute( "shader", 0 ).outputShader().parameters["i"].value, 0 )
-				self.assertEqual( sphere.readAttribute( "shader", 0 ).outputShader().parameters["i"].value, 0 )
-
-		assertContextCompatibility( False, envVar = None )
-		assertContextCompatibility( False, envVar = "0" )
-		assertContextCompatibility( False, envVar = "?" )
-		assertContextCompatibility( True, envVar = "1" )
-
-		Gaffer.NodeAlgo.applyUserDefaults( script["assignment"] )
-		script.save()
-
-		assertContextCompatibility( False, envVar = None )
-		assertContextCompatibility( False, envVar = "0" )
-		assertContextCompatibility( False, envVar = "?" )
-		assertContextCompatibility( False, envVar = "1" )
+		self.assertEqual(
+			script["assignment"]["out"].attributes( "/sphere" )["shader"].outputShader().parameters["i"].value, 0
+		)
 
 	def testInputRejectsNonShaderSwitch( self ) :
 
@@ -635,6 +593,14 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 				assignment["out"].attributes( "/plane" )["test:surface"].outputShader().name,
 				"shader2"
 			)
+
+	def testLoadFrom0_55( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["fileName"].setValue( os.path.join( os.path.dirname( __file__ ), "scripts", "shaderAssignment-0.55.0.0.gfr" ) )
+		script.load()
+
+		self.assertNotIn( "__contextCompatibility", script["ShaderAssignment"] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/scripts/shaderAssignment-0.55.0.0.gfr
+++ b/python/GafferSceneTest/scripts/shaderAssignment-0.55.0.0.gfr
@@ -1,0 +1,31 @@
+import Gaffer
+import GafferImage
+import GafferScene
+import IECore
+import imath
+
+Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 55, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 0, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.NameValuePlug( "image:catalogue:port", Gaffer.IntPlug( "value", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "imageCataloguePort", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+parent["variables"].addChild( Gaffer.NameValuePlug( "project:name", Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectName", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+parent["variables"].addChild( Gaffer.NameValuePlug( "project:rootDirectory", Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectRootDirectory", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format( 1920, 1080, 1.000 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["defaultFormat"] )
+__children["ShaderAssignment"] = GafferScene.ShaderAssignment( "ShaderAssignment" )
+parent.addChild( __children["ShaderAssignment"] )
+__children["ShaderAssignment"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"]["value"].setValue( 41130 )
+Gaffer.Metadata.registerValue( parent["variables"]["imageCataloguePort"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectName"]["name"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectRootDirectory"]["name"], 'readOnly', True )
+__children["ShaderAssignment"]["__contextCompatibility"].setValue( False )
+__children["ShaderAssignment"]["__uiPosition"].setValue( imath.V2f( -14.8000002, -7.6500001 ) )
+
+
+del __children
+

--- a/src/GafferScene/ShaderAssignment.cpp
+++ b/src/GafferScene/ShaderAssignment.cpp
@@ -54,40 +54,6 @@ const InternedString g_oslSurface( "osl:surface" );
 const char *g_oslPrefix( getenv( "GAFFERSCENE_SHADERASSIGNMENT_OSL_PREFIX" ) );
 const InternedString g_oslTarget( g_oslPrefix ? std::string( g_oslPrefix ) + ":surface" : "osl:surface" );
 
-/// Historically, we evaluated `ShaderAssignment::shaderPlug()` in a context
-/// containing "scene:path". This was undesirable for a couple of reasons :
-///
-/// - If the user used "scene:path" to vary the shader in some way, it
-///   could result in a unique ShaderNetwork for every location assigned, which
-///   could translate into huge numbers of unique networks in the renderer.
-///   This is a very inefficient way of generating shader variation. A better
-///   approach is to use a CustomAttributes node to assign random user attributes
-///   and to read from those in a single static shader network.
-/// - Even if the user didn't use "scene:path", we still needed to compute the
-///   hash for the input network in a potentially huge number of contexts. Since
-///   shader networks are often large, this could have significant overhead, particularly
-///   during interactive render updates. If we can remove "scene:path" from
-///   the context before hashing the shader, we make much more efficient use of the
-///   hash cache and get better performance.
-///
-/// Because of this, we want to evaluate the input shader in a GlobalScope.
-/// Unfortunately, we have no way of knowing if a shader network is relying on
-/// "scene:path", so we must provide some backwards compatibility while folks migrate
-/// to the preferred way of working. Setting the GAFFERSCENE_SHADERASSIGNMENT_CONTEXTCOMPATIBILITY
-/// environment variable to "1" provides that compatibility, allowing old ShaderAssignments
-/// to operate as they did before. To hasten migration, we don't want the environment variable
-/// to allow _new_ ShaderAssignments to operate in the old way, so we use the "__contextCompatibility"
-/// plug to provide additional control per node. It defaults to on, but we use a userDefault
-/// to turn it off for all newly created nodes.
-bool initContextCompatibility()
-{
-	Gaffer::Metadata::registerValue( ShaderAssignment::staticTypeId(), "__contextCompatibility", "userDefault", new BoolData( false ) );
-	const char *e = getenv( "GAFFERSCENE_SHADERASSIGNMENT_CONTEXTCOMPATIBILITY" );
-	return e && !strcmp( e, "1" );
-}
-
-const bool g_contextCompatibilityEnabled = initContextCompatibility();
-
 } // namespace
 
 size_t ShaderAssignment::g_firstPlugIndex = 0;
@@ -97,7 +63,6 @@ ShaderAssignment::ShaderAssignment( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new ShaderPlug( "shader" ) );
-	addChild( new BoolPlug( "__contextCompatibility", Plug::In, true, Plug::Default & ~Plug::AcceptsInputs ) );
 
 	// Fast pass-throughs for the things we don't alter.
 	outPlug()->objectPlug()->setInput( inPlug()->objectPlug() );
@@ -119,21 +84,11 @@ const GafferScene::ShaderPlug *ShaderAssignment::shaderPlug() const
 	return getChild<ShaderPlug>( g_firstPlugIndex );
 }
 
-Gaffer::BoolPlug *ShaderAssignment::contextCompatibilityPlug()
-{
-	return getChild<BoolPlug>( g_firstPlugIndex + 1 );
-}
-
-const Gaffer::BoolPlug *ShaderAssignment::contextCompatibilityPlug() const
-{
-	return getChild<BoolPlug>( g_firstPlugIndex + 1 );
-}
-
 void ShaderAssignment::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	SceneElementProcessor::affects( input, outputs );
 
-	if( input == shaderPlug() || input == contextCompatibilityPlug() )
+	if( input == shaderPlug() )
 	{
 		outputs.push_back( outPlug()->attributesPlug() );
 	}
@@ -146,29 +101,14 @@ bool ShaderAssignment::processesAttributes() const
 
 void ShaderAssignment::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	if( g_contextCompatibilityEnabled && contextCompatibilityPlug()->getValue() )
-	{
-		h.append( shaderPlug()->attributesHash() );
-	}
-	else
-	{
-		ScenePlug::GlobalScope globalScope( context );
-		h.append( shaderPlug()->attributesHash() );
-	}
+	ScenePlug::GlobalScope globalScope( context );
+	h.append( shaderPlug()->attributesHash() );
 }
 
 IECore::ConstCompoundObjectPtr ShaderAssignment::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const
 {
-	ConstCompoundObjectPtr attributes;
-	if( g_contextCompatibilityEnabled && contextCompatibilityPlug()->getValue() )
-	{
-		attributes = shaderPlug()->attributes();
-	}
-	else
-	{
-		ScenePlug::GlobalScope globalScope( context );
-		attributes = shaderPlug()->attributes();
-	}
+	ScenePlug::GlobalScope globalScope( context );
+	ConstCompoundObjectPtr attributes = shaderPlug()->attributes();
 
 	if( attributes->members().empty() )
 	{

--- a/startup/GafferOSL/oslObjectCompatibility.py
+++ b/startup/GafferOSL/oslObjectCompatibility.py
@@ -1,0 +1,53 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferOSL
+
+def __shaderAssignmentGetItem( originalGetItem ) :
+
+	def getItem( self, key ) :
+
+		if key == "__contextCompatibility" :
+			# Plug no longer exists - just return a throwaway one to
+			# keep old serialisations happy.
+			return Gaffer.BoolPlug( key )
+
+		return originalGetItem( self, key )
+
+	return getItem
+
+GafferOSL.OSLObject.__getitem__ = __shaderAssignmentGetItem( GafferOSL.OSLObject.__getitem__ )

--- a/startup/GafferScene/shaderAssignmentCompatibility.py
+++ b/startup/GafferScene/shaderAssignmentCompatibility.py
@@ -1,0 +1,53 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+def __shaderAssignmentGetItem( originalGetItem ) :
+
+	def getItem( self, key ) :
+
+		if key == "__contextCompatibility" :
+			# Plug no longer exists - just return a throwaway one to
+			# keep old serialisations happy.
+			return Gaffer.BoolPlug( key )
+
+		return originalGetItem( self, key )
+
+	return getItem
+
+GafferScene.ShaderAssignment.__getitem__ = __shaderAssignmentGetItem( GafferScene.ShaderAssignment.__getitem__ )


### PR DESCRIPTION
In Gaffer 0.54, we introduced a very worthwhile optimisation whereby ShaderAssignment and OSLObject used a global context to evaluate the input shader network. We didn't know if folks were generating different networks based on `scene:path` though, so we included backwards compatibility enabled by a pair of environment variables.

As far as I'm aware, this compatibility option has never been used in production, so here I'm simplifying everything by ripping it out for 0.56.