### PR TITLE
UI Editor improvements

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ Improvements
 
 - Stats app : Added node compute counts to performanceMonitor script annotations.
 - UIEditor : Made the Plugs tab resize the editor window so the Presets section is fully visible when expanded.
+- UIEditor : Added options to the Node tab to turn on and off Box node plug creator decorations.
 
 Fixes
 -----

--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - Stats app : Added node compute counts to performanceMonitor script annotations.
+- UIEditor : Made the Plugs tab resize the editor window so the Presets section is fully visible when expanded.
 
 Fixes
 -----

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -538,6 +538,10 @@ class _PlugListing( GafferUI.Widget ) :
 		column = GafferUI.ListContainer( spacing = 4 )
 		GafferUI.Widget.__init__( self, column, **kw )
 
+		# We don't have a way to do this with Widget directly at present, this
+		# stops the preset name/value fields being off-screen.
+		column._qtWidget().setMinimumWidth( 650 )
+
 		with column :
 
 			self.__pathListing = GafferUI.PathListingWidget(

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -110,6 +110,17 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 						MetadataWidget.FileSystemPathMetadataWidget( key = "icon" )
 					)
 
+				with _Row() as self.__plugAddButtons :
+
+					_Label( "Plug Creators" )
+
+					for side in ( "Top", "Bottom", "Left", "Right" ) :
+						_Label( side )._qtWidget().setFixedWidth( 40 )
+						self.__nodeMetadataWidgets.append( MetadataWidget.BoolMetadataWidget(
+							key = "noduleLayout:customGadget:addButton%s:visible" % side,
+							defaultValue = True
+						) )
+
 			# Plugs tab
 			with GafferUI.SplitContainer( orientation=GafferUI.SplitContainer.Orientation.Horizontal, borderWidth = 8, parenting = { "label" : "Plugs" } ) as self.__plugTab :
 
@@ -251,6 +262,7 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 		self.__node = node
 		self.__nodeNameWidget.setGraphComponent( self.__node )
 		self.__nodeTab.setEnabled( self.__node is not None )
+		self.__plugAddButtons.setVisible( False )
 
 		if self.__node is None :
 			self.__plugListing.setPlugParent( None )
@@ -264,6 +276,7 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 				# is available for use by the user on Reference nodes once a Box has
 				# been exported and referenced.
 				plugParent = self.__node
+				self.__plugAddButtons.setVisible( True )
 			self.__plugListing.setPlugParent( plugParent )
 			self.__sectionEditor.setPlugParent( plugParent )
 


### PR DESCRIPTION
The Plugs > Preset section has a minimum width set, such that it should no longer be off-screen when it's section is opened:

![image](https://user-images.githubusercontent.com/896779/67692857-b182df00-f998-11e9-9751-f46d797343b7.png)

The UI Editor can now be used to hide the Box node 'add plug' node gadget decorators:

![image](https://user-images.githubusercontent.com/896779/67692822-a4fe8680-f998-11e9-90d3-c9fbcb02529b.png)
