### PR TITLE
Arnold renderer : Fix light_blocker motion blur bug

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+0.54.x.x (relative to 0.54.2.1)
+========
+
+Fixes
+-----
+
+- ArnoldLightFilter : Fixed bug which caused animated light blockers to lose their transform.
+
 0.54.2.1 (relative to 0.54.2.0)
 ========
 

--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -2476,6 +2476,51 @@ class RendererTest( GafferTest.TestCase ) :
 		r.option( "ai:background", None )
 		self.assertEqual( arnold.AiNodeGetPtr( options, "background" ), None )
 
+	def testBlockerMotionBlur( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			self.temporaryDirectory() + "/test.ass"
+		)
+
+		o = r.lightFilter(
+			"/lightFilter", IECore.NullObject(),
+			r.attributes( IECore.CompoundObject( {
+				"ai:lightFilter:filter" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"filter" : IECoreScene.Shader( "light_blocker", "ai:lightFilter" ),
+					},
+					output = "filter"
+				)
+			} ) )
+		)
+
+		# Ask for transform motion blur
+
+		o.transform(
+			[ imath.M44f().translate( imath.V3f( 1, 0, 0 ) ), imath.M44f().translate( imath.V3f( 2, 0, 0 ) ) ],
+			[ 0, 1 ]
+		)
+
+		r.render()
+
+		del o
+		del r
+
+		with IECoreArnold.UniverseBlock( writable = True ) :
+
+			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+
+			# Since Arnold's `light_blocker` node doesn't support transform blur,
+			# we just expect a single matrix with the first transform sample.
+
+			node = arnold.AiNodeLookUpByName( "lightFilter:/lightFilter" )
+			self.assertEqual(
+				self.__m44f( arnold.AiNodeGetMatrix( node, "geometry_matrix" ) ),
+				imath.M44f().translate( imath.V3f( 1, 0, 0 ) )
+			)
+
 	def __testVDB( self, stepSize = None, stepScale = 1.0, expectedSize = 0.0, expectedScale = 1.0 ) :
 
 		import IECoreVDB

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1886,6 +1886,14 @@ class ArnoldObjectBase : public IECoreScenePreview::Renderer::ObjectInterface
 
 		void applyTransform( AtNode *node, const std::vector<Imath::M44f> &samples, const std::vector<float> &times, const AtString matrixParameterName = g_matrixArnoldString )
 		{
+			const AtParamEntry *parameter = AiNodeEntryLookUpParameter( AiNodeGetNodeEntry( node ), matrixParameterName );
+			if( AiParamGetType( parameter ) != AI_TYPE_ARRAY )
+			{
+				// Parameter doesn't support motion blur
+				applyTransform( node, samples[0], matrixParameterName );
+				return;
+			}
+
 			const size_t numSamples = samples.size();
 			AtArray *matricesArray = AiArrayAllocate( 1, numSamples, AI_TYPE_MATRIX );
 			for( size_t i = 0; i < numSamples; ++i )

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -340,6 +340,7 @@ void GafferSceneModule::bindRender()
 
 			.def( "camera", &Renderer::camera )
 			.def( "light", &Renderer::light )
+			.def( "lightFilter", &Renderer::lightFilter )
 
 			.def( "object", &rendererObject1 )
 			.def( "object", &rendererObject2 )


### PR DESCRIPTION
Arnold doesn't currently support motion blur on light blockers, so our attempts to create it were resulting in the following errors :

```
00:00:00   209MB WARNING | lightFilter:/lightFilter.geometry_matrix: use type MATRIX, not ARRAY
00:00:00   209MB WARNING | lightFilter:/lightFilter: could not set ARRAY parameter "geometry_matrix"
00:00:00   209MB WARNING | lightFilter:/lightFilter: could not set FLOAT parameter "motion_start"
00:00:00   209MB WARNING | lightFilter:/lightFilter: could not set FLOAT parameter "motion_end"
```

We now just take the first transform sample and apply that instead. This is implemented such that it should automatically support motion blur as soon as Arnold's `light_blocker` supports it. The more pessimistic approach would have been to rip out `ArnoldLightFilter::m_transformMatrices/m_transformTimes`, replacing them with a single matrix and update `ArnoldLightFilter::applyLightFilterTransform()` to always call the static version of `applyTransform()`.
