### PR TITLE
CompoundEditor : Ensure keyboards shortcuts work for panels in layouts

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+0.54.2.2 (relative to 0.54.2.1)
+========
+
+Fixes
+-----
+
+- Layouts : Keyboard shortcuts will now work in detached panels restored with a layout.
+
 0.54.2.1 (relative to 0.54.2.0)
 ========
 

--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -75,6 +75,8 @@ class CompoundEditor( GafferUI.Editor ) :
 			for panelArgs in detachedPanels  :
 				self._createDetachedPanel( **panelArgs )
 
+		self.parentChangedSignal().connect( Gaffer.WeakMethod( self.__parentChanged ), scoped=False )
+
 	# Returns the editor of the specified type that the user is currently
 	# interested in. This takes into account detached panels and window
 	# ordering such that when the keyboard focus is with an editor of the
@@ -195,6 +197,14 @@ class CompoundEditor( GafferUI.Editor ) :
 		v = self.visible()
 		for p in self.__detachedPanels :
 			p.setVisible( v )
+
+	def __parentChanged( self, widget ) :
+
+		# Make sure we have the correct keyboard shortcut listeners
+		scriptWindow = self.ancestor( GafferUI.ScriptWindow )
+		if scriptWindow is not None :
+			for panel in self._detachedPanels() :
+				scriptWindow.menuBar().addShortcutTarget( panel )
 
 	def __repr__( self ) :
 

--- a/python/GafferUI/MenuBar.py
+++ b/python/GafferUI/MenuBar.py
@@ -67,10 +67,16 @@ class MenuBar( GafferUI.Widget ) :
 	# in response to keyboard shortcut events received by that widget.
 	# This can be useful to ensure secondary windows not in the hierarchy of
 	# the MenuBar's parent still cause associated actions to fire.
+	# If the widget already has a shortcut target for another MenuBar, this
+	# will be removed.
 	def addShortcutTarget( self, widget ) :
 
-		widget.__shortcutEventFilter = _ShortcutEventFilter( widget._qtWidget(), self )
-		widget._qtWidget().installEventFilter( widget.__shortcutEventFilter )
+		if not hasattr( widget, '_MenuBar__shortcutEventFilter' ) :
+			widget.__shortcutEventFilter = _ShortcutEventFilter( widget._qtWidget(), self )
+			widget._qtWidget().installEventFilter( widget.__shortcutEventFilter )
+
+		if widget.__shortcutEventFilter.getMenuBar() != self :
+			widget.__shortcutEventFilter.setMenuBar( self )
 
 	def __setattr__( self, key, value ) :
 
@@ -183,6 +189,14 @@ class _ShortcutEventFilter( QtCore.QObject ) :
 				return True
 
 		return QtCore.QObject.eventFilter( self, qObject, qEvent )
+
+	def setMenuBar( self, menuBar ) :
+
+		self.__menuBar = weakref.ref( menuBar )
+
+	def getMenuBar( self ) :
+
+		return self.__menuBar()
 
 	def __keySequence( self, keyEvent ) :
 


### PR DESCRIPTION
During construction, the CompoundEditor isn't yet a child of a ScriptWindow. Consequently, any detached panels being restored don't have a menu bar to attach to. We now listen for a parentChanged and update accordingly.

Fixes #3357 properly this time...