### PR TITLE
PlugValueWidget : Don't allow creation of inputs to output plugs

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+0.54.x.x (relative to 0.54.2.1)
+========
+
+Fixes
+-----
+
+- NodeEditor : Fixed bug that allowed drag and drop to create unwanted input connections to output plugs.
+
 0.54.2.1 (relative to 0.54.2.0)
 ========
 

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -603,7 +603,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 			return False
 
 		if isinstance( event.data, Gaffer.Plug ) :
-			if self.getPlug().acceptsInput( event.data ) :
+			if self.getPlug().direction() == Gaffer.Plug.Direction.In and self.getPlug().acceptsInput( event.data ) :
 				self.setHighlighted( True )
 				return True
 		elif hasattr( self.getPlug(), "setValue" ) and self._convertValue( event.data ) is not None :


### PR DESCRIPTION
An input connection would mean that the plug value is no longer computed as expected, so we now disallow its creation. There might be an argument that we should allow connections to be made in the case of an output plug on a Box, but since the only way to create an output plug is via promotion, and promotion sets the input anyway, I don't think this is necessary.

@danieldresser-ie, in your original bug report you mentioned that perhaps we should allow connections to be made to outputs of non-ComputeNodes. I can't think of a use case for this, so didn't enable it, but perhaps you have something in mind?