### PR TITLE
Viewer tool improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,7 +9,8 @@ Improvements
   - Organised UI into sections.
   - Added better defaults for the `orientation` and `scale` plugs.
 - OSLObject : Added non-uniform scale to standard primitive variable menu.
- - View navigation : Holding down <kbd>Shift</kbd> whilst using the scroll wheel in the Viewer and other Editors to adjust the camera or view magnification results in more precise adjustments (#3324).
+- View navigation : Added support for precise movement adjustments by holding down <kbd>Shift</kbd> whilst using the scroll wheel or moving the camera in the Viewer and other Editors (#3324).
+- AnimationEditor : Changed the modifier key used to enable single-axis zoom has changed to <kbd>Ctrl</kbd> to allow use in conjunction with precise movement mode (<kbd>Shift</kbd>) (#3324).
 - Error handling : The Cortex exception type is now included in error messages where relevant.
 
 Fixes
@@ -28,6 +29,7 @@ Breaking Changes
 - OSLObject : Removed support for the `GAFFEROSL_OSLOBJECT_CONTEXTCOMPATIBILITY` environment variable.
 - ShaderAssignment : Removed support for the `GAFFERSCENE_SHADERASSIGNMENT_CONTEXTCOMPATIBILITY` environment variable.
 - bin : Renamed the `gaffer.py` launch script (to `__gaffer.py`) to avoid a collision with the main `Gaffer` module (see #3477). This will cause the process string to change on systems that don't support process renaming.
+- ViewportGadget : Added private members, ABI break only - source compatibility is maintained (#3324).
 
 0.55.2.0 (relative to 0.55.1.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -12,12 +12,21 @@ Improvements
 - View navigation : Added support for precise movement adjustments by holding down <kbd>Shift</kbd> whilst using the scroll wheel or moving the camera in the Viewer and other Editors (#3324).
 - AnimationEditor : Changed the modifier key used to enable single-axis zoom has changed to <kbd>Ctrl</kbd> to allow use in conjunction with precise movement mode (<kbd>Shift</kbd>) (#3324).
 - Error handling : The Cortex exception type is now included in error messages where relevant.
+- Tools :
+  - Added generic support for precise tool adjustments by holding down <kbd>Shift</kbd> whilst adjusting tool handles (#3324).
+  - Changed the behaviour of existing precise tool handle adjustments such that the current handle position is maintained when the <kbd>Shift</kbd> key is depressed (#3324).
 
 Fixes
 -----
 
 - Resize : Fixed bug which caused unwanted image distortion when changing pixel aspect ratio.
 - Launch : Fixed bug which prevented gaffer launching when stored on case destroying file systems (#3477).
+
+API
+---
+
+- Handle :
+  - Added an optional `processModifiers` argument to drag constructors that allows the built-in precision mode handling to be disabled (#3324).
 
 Breaking Changes
 ----------------
@@ -30,6 +39,7 @@ Breaking Changes
 - ShaderAssignment : Removed support for the `GAFFERSCENE_SHADERASSIGNMENT_CONTEXTCOMPATIBILITY` environment variable.
 - bin : Renamed the `gaffer.py` launch script (to `__gaffer.py`) to avoid a collision with the main `Gaffer` module (see #3477). This will cause the process string to change on systems that don't support process renaming.
 - ViewportGadget : Added private members, ABI break only - source compatibility is maintained (#3324).
+- Handle : `LinearDrag::position` and `PlanarDrag::position` are no longer `const` methods. `RotateHandle`, `ScaleHandle` and `TranslateHandle` value provider methods loose `const`-ness accordingly.
 
 0.55.2.0 (relative to 0.55.1.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ API
 
 - Handle :
   - Added an optional `processModifiers` argument to drag constructors that allows the built-in precision mode handling to be disabled (#3324).
+  - Added a convenience constructor for `LinearDrag` that creates a drag in an arbitrary direction on the camera plane (#3324).
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ API
 - Handle :
   - Added an optional `processModifiers` argument to drag constructors that allows the built-in precision mode handling to be disabled (#3324).
   - Added a convenience constructor for `LinearDrag` that creates a drag in an arbitrary direction on the camera plane (#3324).
+  - Added `AngularDrag` helper to manage drags that represent rotations around a single axis (#3324).
 
 Breaking Changes
 ----------------

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -63,6 +63,7 @@ Zoom                                  :kbd:`Alt` + right-click and drag
                                       or
                                       
                                       Mouse wheel up/down
+Pan/Zoom, fine precision              Hold :kbd:`Shift` during action
 Frame selected nodes                  :kbd:`F`
 Enter `Box` node (subgraph)           :kbd:`↓`
 Leave `Box` node (subgraph)           :kbd:`↑`
@@ -246,6 +247,7 @@ Zoom/dolly                            :kbd:`Alt` + right-click and drag
                                       or
                                       
                                       Mouse wheel up/down
+Pan/Zoom, fine precision              Hold :kbd:`Shift` during action
 Frame view to contents                :kbd:`F`
 Pause processing                      :kbd:`Escape`
 Selection Tool                        :kbd:`Q`
@@ -265,6 +267,7 @@ Pin to numeric bookmark               :kbd:`1` … :kbd:`9`
 Action                                                 Control or shortcut
 ====================================================== =====================================
 Tumble                                                 :kbd:`Alt` + click and drag
+Tumble, fine precision                                 Hold :kbd:`Shift` during action
 Select objects                                         Click and drag marquee, then release
 Add/remove object from selection                       :kbd:`Ctrl` + click
 Add objects to selection                               :kbd:`Shift` + click and drag marquee, then
@@ -302,8 +305,8 @@ Action                                               Control or shortcut
 Increase manipulator size                            :kbd:`+`
 Decrease manipulator size                            :kbd:`-`
 Add animation key to transform of selected object(s) :kbd:`S`
-Adjust, high precision                               :kbd:`Shift` + click and drag
-Adjust, snapping to rounded increments               :kbd:`Ctrl` + click and drag
+Adjust, fine precision                               Hold :kbd:`Shift` during action
+Adjust, snapping to rounded increments               Hold :kbd:`Ctrl` + during action
 Target mode (Translate and Rotate only)              Hold :kbd:`v`
 ==================================================== =============================================
 ```
@@ -383,6 +386,8 @@ Zoom                                            :kbd:`Alt` + right-click and dra
                                                 or
                                                 
                                                 Mouse wheel up/down
+Zoom x/y axes independently                     Hold :kbd:`Ctrl` during action
+Pan/Zoom, fine precision                        Hold :kbd:`Shift` during action
 Adjust frame range                              :kbd:`Alt` + :kbd:`Shift` + right-click and
                                                 drag left/right
 Adjust key value range                          :kbd:`Alt` + :kbd:`Shift` + right-click and

--- a/include/GafferSceneUI/RotateTool.h
+++ b/include/GafferSceneUI/RotateTool.h
@@ -100,7 +100,7 @@ class GAFFERSCENEUI_API RotateTool : public TransformTool
 		// Handle Drag handling.
 
 		IECore::RunTimeTypedPtr handleDragBegin();
-		bool handleDragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
+		bool handleDragMove( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
 		bool handleDragEnd();
 
 		// Target mode handling

--- a/include/GafferSceneUI/ScaleTool.h
+++ b/include/GafferSceneUI/ScaleTool.h
@@ -90,7 +90,7 @@ class GAFFERSCENEUI_API ScaleTool : public TransformTool
 		// Drag handling.
 
 		IECore::RunTimeTypedPtr dragBegin( GafferUI::Style::Axes axes );
-		bool dragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
+		bool dragMove( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
 		bool dragEnd();
 
 		std::vector<Scale> m_drag;

--- a/include/GafferSceneUI/TranslateTool.h
+++ b/include/GafferSceneUI/TranslateTool.h
@@ -98,7 +98,7 @@ class GAFFERSCENEUI_API TranslateTool : public TransformTool
 		// Handle drag handling.
 
 		IECore::RunTimeTypedPtr handleDragBegin();
-		bool handleDragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
+		bool handleDragMove( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
 		bool handleDragEnd();
 
 		// Targeted mode handling

--- a/include/GafferUI/Handle.h
+++ b/include/GafferUI/Handle.h
@@ -163,6 +163,44 @@ class GAFFERUI_API Handle : public Gadget
 		// at the requested size in raster space.
 		Imath::V3f rasterScaleFactor() const;
 
+		// Helper for performing drags around a rotation axis.
+		struct AngularDrag
+		{
+
+			AngularDrag( bool processModifiers = true );
+			// Origin and axes are in gadget space. Rotations will be around
+			// axis0, with 0 rotation along axis1. Axes are assumed to be
+			// orthogonal, but may have any length.
+			AngularDrag( const Gadget *gadget, const Imath::V3f &origin, const Imath::V3f &axis0, const Imath::V3f axis1, const DragDropEvent &dragBeginEvent, bool processModifiers = true );
+
+			// The axis of rotation in Gadget space.
+			const Imath::V3f &axis0() const;
+			// The direction on which zero rotation lies.
+			const Imath::V3f &axis1() const;
+
+			// Rotation is in radians
+			float startRotation() const;
+			float updatedRotation( const DragDropEvent &event );
+
+			private :
+
+				float closestRotation( const Imath::V2f &p, float targetRotation );
+
+				PlanarDrag m_drag;
+				float m_rotation;
+
+				Imath::V3f m_axis0;
+				Imath::V3f m_axis1;
+				float m_dragBeginRotation;
+
+				bool m_processModifiers;
+
+				// AngularDrag re-implements precision so that it can be applied in
+				// angle space, to allow continuous 'winding'.
+				bool m_preciseMotionEnabled;
+				float m_preciseMotionOrigin;
+		};
+
 	private :
 
 		void enter();

--- a/include/GafferUI/Handle.h
+++ b/include/GafferUI/Handle.h
@@ -87,13 +87,13 @@ class GAFFERUI_API Handle : public Gadget
 		struct LinearDrag
 		{
 
-			LinearDrag();
+			LinearDrag( bool processModifiers = true );
 			// Line is specified in Gadget space.
-			LinearDrag( const Gadget *gadget, const IECore::LineSegment3f &line, const DragDropEvent &dragBeginEvent );
+			LinearDrag( const Gadget *gadget, const IECore::LineSegment3f &line, const DragDropEvent &dragBeginEvent, bool processModifiers = true );
 
 			// Positions are measured from 0 at line.p0 to 1 at line.p1.
 			float startPosition() const;
-			float position( const DragDropEvent &event ) const;
+			float updatedPosition( const DragDropEvent &event );
 
 			private :
 
@@ -104,19 +104,25 @@ class GAFFERUI_API Handle : public Gadget
 				IECore::LineSegment3f m_worldLine;
 				float m_dragBeginPosition;
 
+				bool m_processModifiers;
+
+				// We track the point where precision mode is enabled (hold shift)
+				// and scale movement after that point accordingly (x0.1)
+				bool m_preciseMotionEnabled;
+				float m_preciseMotionOrigin;
 		};
 
 		// Helper for performing drags in a plane.
 		struct PlanarDrag
 		{
 
-			PlanarDrag();
+			PlanarDrag( bool processModifiers = true );
 			// Plane is parallel to the camera plane, centered on gadget, and with unit
 			// length axes in gadget space.
-			PlanarDrag( const Gadget *gadget, const DragDropEvent &dragBeginEvent );
+			PlanarDrag( const Gadget *gadget, const DragDropEvent &dragBeginEvent, bool processModifiers = true );
 			// Origin and axes are in gadget space. Axes are assumed to be orthogonal
 			// but may have any length.
-			PlanarDrag( const Gadget *gadget, const Imath::V3f &origin, const Imath::V3f &axis0, const Imath::V3f &axis1, const DragDropEvent &dragBeginEvent );
+			PlanarDrag( const Gadget *gadget, const Imath::V3f &origin, const Imath::V3f &axis0, const Imath::V3f &axis1, const DragDropEvent &dragBeginEvent, bool processModifiers = true );
 
 			// The axes of the plane in Gadget space.
 			const Imath::V3f &axis0() const;
@@ -125,7 +131,7 @@ class GAFFERUI_API Handle : public Gadget
 			// X coordinate are measured from 0 at origin to 1 at `origin + axis0`
 			// Y coordinates are measured from 0 at origin to 1 at `origin + axis1`
 			Imath::V2f startPosition() const;
-			Imath::V2f position( const DragDropEvent &event ) const;
+			Imath::V2f updatedPosition( const DragDropEvent &event );
 
 			private :
 
@@ -140,6 +146,13 @@ class GAFFERUI_API Handle : public Gadget
 				Imath::V3f m_worldAxis0;
 				Imath::V3f m_worldAxis1;
 				Imath::V2f m_dragBeginPosition;
+
+				bool m_processModifiers;
+
+				// We track the point where precision mode is enabled (hold shift)
+				// and scale movement after that point accordingly (x0.1)
+				bool m_preciseMotionEnabled;
+				Imath::V2f m_preciseMotionOrigin;
 
 		};
 

--- a/include/GafferUI/Handle.h
+++ b/include/GafferUI/Handle.h
@@ -88,6 +88,9 @@ class GAFFERUI_API Handle : public Gadget
 		{
 
 			LinearDrag( bool processModifiers = true );
+			// Line is parallel to the camera plane, centered on gadget, and
+			// with unit length axes in gadget space.
+			LinearDrag( const Gadget *gadget, const Imath::V2f &line, const DragDropEvent &dragBeginEvent, bool processModifiers = true );
 			// Line is specified in Gadget space.
 			LinearDrag( const Gadget *gadget, const IECore::LineSegment3f &line, const DragDropEvent &dragBeginEvent, bool processModifiers = true );
 

--- a/include/GafferUI/RotateHandle.h
+++ b/include/GafferUI/RotateHandle.h
@@ -83,9 +83,9 @@ class GAFFERUI_API RotateHandle : public Handle
 
 		Style::Axes m_axes;
 		// For X, Y and Z handles.
-		PlanarDrag m_drag;
+		AngularDrag m_drag;
 		float m_rotation;
-		// For XYZ handle.
+		// For free rotation handle.
 		Imath::M44f m_dragBeginWorldTransform;
 		Imath::V3f m_dragBeginPointOnSphere;
 		Imath::V3f m_highlightVector;

--- a/include/GafferUI/RotateHandle.h
+++ b/include/GafferUI/RotateHandle.h
@@ -65,7 +65,7 @@ class GAFFERUI_API RotateHandle : public Handle
 		Imath::V3i axisMask() const;
 
 		// Measured in radians
-		Imath::Eulerf rotation( const DragDropEvent &event ) const;
+		Imath::Eulerf rotation( const DragDropEvent &event );
 
 	protected :
 

--- a/include/GafferUI/RotateHandle.h
+++ b/include/GafferUI/RotateHandle.h
@@ -78,6 +78,9 @@ class GAFFERUI_API RotateHandle : public Handle
 		bool mouseMove( const ButtonEvent &event );
 		Imath::V3f pointOnSphere( const IECore::LineSegment3f &line ) const;
 
+		void updatePreciseMotionState( const DragDropEvent &event );
+		IECore::LineSegment3f updatedLineFromEvent( const DragDropEvent &event ) const;
+
 		Style::Axes m_axes;
 		// For X, Y and Z handles.
 		PlanarDrag m_drag;
@@ -86,6 +89,9 @@ class GAFFERUI_API RotateHandle : public Handle
 		Imath::M44f m_dragBeginWorldTransform;
 		Imath::V3f m_dragBeginPointOnSphere;
 		Imath::V3f m_highlightVector;
+
+		bool m_preciseMotionEnabled;
+		IECore::LineSegment3f m_preciseMotionOriginLine;
 
 };
 

--- a/include/GafferUI/ScaleHandle.h
+++ b/include/GafferUI/ScaleHandle.h
@@ -61,7 +61,7 @@ class GAFFERUI_API ScaleHandle : public Handle
 		// scaling in that axis.
 		Imath::V3i axisMask() const;
 
-		Imath::V3f scaling( const DragDropEvent &event ) const;
+		Imath::V3f scaling( const DragDropEvent &event );
 
 	protected :
 

--- a/include/GafferUI/ScaleHandle.h
+++ b/include/GafferUI/ScaleHandle.h
@@ -72,7 +72,6 @@ class GAFFERUI_API ScaleHandle : public Handle
 
 		Style::Axes m_axes;
 		LinearDrag m_drag;
-		Imath::V2f m_uniformDragStartPosition;
 
 };
 

--- a/include/GafferUI/TranslateHandle.h
+++ b/include/GafferUI/TranslateHandle.h
@@ -67,7 +67,7 @@ class GAFFERUI_API TranslateHandle : public Handle
 		// > The use of a non-zero raster scale may make it appear
 		// > that a handle has no scaling applied, but that scaling
 		// > will still affect the results of `translation()`.
-		Imath::V3f translation( const DragDropEvent &event ) const;
+		Imath::V3f translation( const DragDropEvent &event );
 
 	protected :
 

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -244,6 +244,9 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		void updateGadgetUnderMouse( const ButtonEvent &event );
 		void emitEnterLeaveEvents( GadgetPtr newGadgetUnderMouse, GadgetPtr oldGadgetUnderMouse, const ButtonEvent &event );
 
+		void updateMotionState( const DragDropEvent &event, bool initialEvent = false );
+		Imath::V2f motionPositionFromEvent( const DragDropEvent &event ) const;
+
 		GadgetPtr updatedDragDestination( std::vector<GadgetPtr> &gadgets, const DragDropEvent &event );
 
 		void trackDrag( const DragDropEvent &event );
@@ -259,6 +262,10 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		std::unique_ptr<CameraController> m_cameraController;
 		bool m_cameraInMotion;
 		bool m_cameraEditable;
+
+		bool m_preciseMotionEnabled;
+		Imath::V2f m_motionSegmentOrigin;
+		Imath::V2f m_motionSegmentEventOrigin;
 
 		GadgetPtr m_lastButtonPressGadget;
 		GadgetPtr m_gadgetUnderMouse;

--- a/src/GafferSceneUI/RotateTool.cpp
+++ b/src/GafferSceneUI/RotateTool.cpp
@@ -244,10 +244,10 @@ IECore::RunTimeTypedPtr RotateTool::handleDragBegin()
 	return nullptr; // Let the handle start the drag.
 }
 
-bool RotateTool::handleDragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event )
+bool RotateTool::handleDragMove( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event )
 {
 	UndoScope undoScope( selection().back().transformPlug->ancestor<ScriptNode>(), UndoScope::Enabled, undoMergeGroup() );
-	const V3f rotation = static_cast<const RotateHandle *>( gadget )->rotation( event );
+	const V3f rotation = static_cast<RotateHandle *>( gadget )->rotation( event );
 	for( const auto &r : m_drag )
 	{
 		r.apply( rotation );

--- a/src/GafferSceneUI/ScaleTool.cpp
+++ b/src/GafferSceneUI/ScaleTool.cpp
@@ -181,10 +181,10 @@ IECore::RunTimeTypedPtr ScaleTool::dragBegin( GafferUI::Style::Axes axes )
 	return nullptr; // Let the handle start the drag.
 }
 
-bool ScaleTool::dragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event )
+bool ScaleTool::dragMove( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event )
 {
 	UndoScope undoScope( selection().back().transformPlug->ancestor<ScriptNode>(), UndoScope::Enabled, undoMergeGroup() );
-	const V3f &scaling = static_cast<const ScaleHandle *>( gadget )->scaling( event );
+	const V3f &scaling = static_cast<ScaleHandle *>( gadget )->scaling( event );
 	for( const auto &s : m_drag )
 	{
 		s.apply( scaling );

--- a/src/GafferSceneUI/TranslateTool.cpp
+++ b/src/GafferSceneUI/TranslateTool.cpp
@@ -243,10 +243,10 @@ IECore::RunTimeTypedPtr TranslateTool::handleDragBegin()
 	return nullptr; // let the handle start the drag with the event system
 }
 
-bool TranslateTool::handleDragMove( const GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event )
+bool TranslateTool::handleDragMove( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event )
 {
 	UndoScope undoScope( selection()[0].transformPlug->ancestor<ScriptNode>(), UndoScope::Enabled, undoMergeGroup() );
-	const V3f translation = static_cast<const TranslateHandle *>( gadget )->translation( event );
+	const V3f translation = static_cast<TranslateHandle *>( gadget )->translation( event );
 	for( const auto &t : m_drag )
 	{
 		t.apply( translation );

--- a/src/GafferUI/RotateHandle.cpp
+++ b/src/GafferUI/RotateHandle.cpp
@@ -76,7 +76,9 @@ float closestRotation( const V2f &p, float targetRotation )
 GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( RotateHandle );
 
 RotateHandle::RotateHandle( Style::Axes axes )
-	:	Handle( defaultName<RotateHandle>() ), m_axes( Style::X )
+	:	Handle( defaultName<RotateHandle>() ),
+		m_axes( Style::X ),
+		m_preciseMotionEnabled( false )
 {
 	setAxes( axes );
 	dragMoveSignal().connect( boost::bind( &RotateHandle::dragMove, this, ::_2 ) );
@@ -136,17 +138,10 @@ Imath::Eulerf RotateHandle::rotation( const DragDropEvent &event )
 {
 	if( m_axes == Style::XYZ )
 	{
-		const LineSegment3f line = event.line * fullTransform() * m_dragBeginWorldTransform.inverse();
+		const LineSegment3f line = updatedLineFromEvent( event ) * fullTransform() * m_dragBeginWorldTransform.inverse();
 		const M44f m = rotationMatrix( m_dragBeginPointOnSphere, pointOnSphere( line ) );
 		Eulerf e; e.extract( m );
 
-		// precision mode
-		if( event.modifiers & ButtonEvent::Shift )
-		{
-			Quatf q = e.toQuat();
-			Quatf interpolated = slerpShortestArc( Quatf(), q, 0.1f );
-			e.extract( interpolated );
-		}
 		return e;
 	}
 
@@ -180,6 +175,38 @@ void RotateHandle::renderHandle( const Style *style, Style::State state ) const
 	style->renderRotateHandle( m_axes, state, m_highlightVector );
 }
 
+void RotateHandle::updatePreciseMotionState( const DragDropEvent &event )
+{
+	const bool shiftHeld = event.modifiers & ModifiableEvent::Shift;
+	if( !m_preciseMotionEnabled && shiftHeld )
+	{
+		m_preciseMotionOriginLine = event.line;
+	}
+	m_preciseMotionEnabled = shiftHeld;
+}
+
+IECore::LineSegment3f RotateHandle::updatedLineFromEvent( const DragDropEvent &event ) const
+{
+	LineSegment3f line = event.line;
+
+	if( m_preciseMotionEnabled )
+	{
+		// We interpolate the mouse position, not the resulting rotation to
+		// ensure we don't get clamped by pointOnSphere once the actual mouse
+		// has moved way away from the handle. The compromise is a non-linear
+		// rotation response, but we have that anyway as the mouse is on a
+		// plane to start with.
+		const V3f dP0 = ( event.line.p0 - m_preciseMotionOriginLine.p0 ) * 0.1f;
+		const V3f dP1 = ( event.line.p1 - m_preciseMotionOriginLine.p1 ) * 0.1f;
+		line = LineSegment3f(
+			V3f( m_preciseMotionOriginLine.p0 + dP0 ),
+			V3f( m_preciseMotionOriginLine.p1 + dP1 )
+		);
+	}
+
+	return line;
+}
+
 void RotateHandle::dragBegin( const DragDropEvent &event )
 {
 	switch( m_axes )
@@ -199,6 +226,9 @@ void RotateHandle::dragBegin( const DragDropEvent &event )
 		case Style::XYZ :
 			m_dragBeginWorldTransform = fullTransform();
 			m_dragBeginPointOnSphere = pointOnSphere( event.line );
+			m_preciseMotionEnabled = false;
+			m_preciseMotionOriginLine = event.line;
+			updatePreciseMotionState( event );
 			break;
 		default :
 			// Checks in `setAxes()` prevent us getting here
@@ -210,7 +240,8 @@ bool RotateHandle::dragMove( const DragDropEvent &event )
 {
 	if( m_axes == Style::XYZ )
 	{
-		m_highlightVector = pointOnSphere( event.line );
+		updatePreciseMotionState( event );
+		m_highlightVector = pointOnSphere( updatedLineFromEvent( event ) );
 		requestRender();
 	}
 	else

--- a/src/GafferUI/RotateHandle.cpp
+++ b/src/GafferUI/RotateHandle.cpp
@@ -55,21 +55,6 @@ using namespace IECore;
 using namespace GafferUI;
 
 //////////////////////////////////////////////////////////////////////////
-//
-//////////////////////////////////////////////////////////////////////////
-
-namespace
-{
-
-float closestRotation( const V2f &p, float targetRotation )
-{
-	const float r = atan2( p.y, p.x );
-	return Eulerf::angleMod( r - targetRotation ) + targetRotation;
-}
-
-} // namespace
-
-//////////////////////////////////////////////////////////////////////////
 // RotateHandle
 //////////////////////////////////////////////////////////////////////////
 
@@ -145,7 +130,7 @@ Imath::Eulerf RotateHandle::rotation( const DragDropEvent &event )
 		return e;
 	}
 
-	float rotate = ( closestRotation( m_drag.updatedPosition( event ), m_rotation ) - closestRotation( m_drag.startPosition(), 0.0f ) );
+	float rotate = m_drag.updatedRotation( event ) - m_drag.startRotation();
 
 	// snap
 	if( event.modifiers & ButtonEvent::Control )
@@ -212,16 +197,16 @@ void RotateHandle::dragBegin( const DragDropEvent &event )
 	switch( m_axes )
 	{
 		case Style::X :
-			m_drag = PlanarDrag( this, V3f( 0 ), V3f( 0, 1, 0 ), V3f( 0, 0, 1 ), event );
-			m_rotation = closestRotation( m_drag.startPosition(), 0.0f );
+			m_drag = AngularDrag( this, V3f( 0 ), V3f( 1, 0, 0 ), V3f( 0, 0, 1 ), event );
+			m_rotation = m_drag.startRotation();
 			break;
 		case Style::Y :
-			m_drag = PlanarDrag( this, V3f( 0 ), V3f( 0, 0, 1 ), V3f( 1, 0, 0 ), event );
-			m_rotation = closestRotation( m_drag.startPosition(), 0.0f );
+			m_drag = AngularDrag( this, V3f( 0 ), V3f( 0, 1, 0 ), V3f( 1, 0, 0 ), event );
+			m_rotation = m_drag.startRotation();
 			break;
 		case Style::Z :
-			m_drag = PlanarDrag( this, V3f( 0 ), V3f( 1, 0, 0 ), V3f( 0, 1, 0 ), event );
-			m_rotation = closestRotation( m_drag.startPosition(), 0.0f );
+			m_drag = AngularDrag( this, V3f( 0 ), V3f( 0, 0, 1 ), V3f( 0, 1, 0 ), event );
+			m_rotation = m_drag.startRotation();
 			break;
 		case Style::XYZ :
 			m_dragBeginWorldTransform = fullTransform();
@@ -246,11 +231,7 @@ bool RotateHandle::dragMove( const DragDropEvent &event )
 	}
 	else
 	{
-		// We can only recover an angle in the range -PI, PI from the 2d position
-		// that our drag gives us, but we want to be able to support continuous
-		// values and multiple revolutions. Here we keep track of the current rotation
-		// position so that we can adjust correctly in `RotateHandle::rotation()`.
-		m_rotation = closestRotation( m_drag.updatedPosition( event ), m_rotation );
+		m_rotation = m_drag.updatedRotation( event );
 	}
 	return false;
 }

--- a/src/GafferUI/ScaleHandle.cpp
+++ b/src/GafferUI/ScaleHandle.cpp
@@ -96,13 +96,13 @@ Imath::V3i ScaleHandle::axisMask() const
 	}
 }
 
-Imath::V3f ScaleHandle::scaling( const DragDropEvent &event ) const
+Imath::V3f ScaleHandle::scaling( const DragDropEvent &event )
 {
 	float scale = 1;
 
 	if( m_axes != Style::XYZ )
 	{
-		scale = ( m_drag.position( event ) / m_drag.startPosition() - 1 );
+		scale = ( m_drag.updatedPosition( event ) / m_drag.startPosition() - 1 );
 	}
 	else
 	{
@@ -112,16 +112,13 @@ Imath::V3f ScaleHandle::scaling( const DragDropEvent &event ) const
 		scale *= 3;
 	}
 
-	// snap to integers
+	// snap
 	if( event.modifiers & ButtonEvent::Control )
 	{
-		scale = std::round( scale );
-	}
-
-	// precision mode
-	if( event.modifiers & ButtonEvent::Shift )
-	{
-		scale *= 0.1;
+		// Offset such that it behaves like round not floor.
+		const float snapIncrement = event.modifiers & ButtonEvent::Shift ? 0.1f : 1.0f;
+		const float snapOffset = snapIncrement * 0.5f;
+		scale = scale - fmodf( scale - snapOffset, snapIncrement ) + snapOffset;
 	}
 
 	scale = 1 + scale;

--- a/src/GafferUI/TranslateHandle.cpp
+++ b/src/GafferUI/TranslateHandle.cpp
@@ -94,22 +94,20 @@ Imath::V3i TranslateHandle::axisMask() const
 	}
 }
 
-Imath::V3f TranslateHandle::translation( const DragDropEvent &event ) const
+Imath::V3f TranslateHandle::translation( const DragDropEvent &event )
 {
+	const float snapIncrement = event.modifiers & ButtonEvent::Shift ? 0.1f : 1.0f;
+	const float snapOffset = snapIncrement * 0.5f;
+
 	if( m_axes == Style::X || m_axes == Style::Y || m_axes == Style::Z )
 	{
-		float offset = m_linearDrag.position( event ) - m_linearDrag.startPosition();
+		float offset = m_linearDrag.updatedPosition( event ) - m_linearDrag.startPosition();
 
-		// snap to integers
+		// snap
 		if( event.modifiers & ButtonEvent::Control )
 		{
-			offset = std::round( offset );
-		}
-
-		// precision mode
-		if( event.modifiers & ButtonEvent::Shift )
-		{
-			offset *= 0.1;
+			// Offset such that it behaves like round not floor.
+			offset = offset - fmodf( offset - snapOffset, snapIncrement ) + snapOffset;
 		}
 
 		switch( m_axes )
@@ -126,19 +124,13 @@ Imath::V3f TranslateHandle::translation( const DragDropEvent &event ) const
 	}
 	else
 	{
-		V2f offset = m_planarDrag.position( event ) - m_planarDrag.startPosition();
+		V2f offset = m_planarDrag.updatedPosition( event ) - m_planarDrag.startPosition();
 
-		// snap to integers
+		// snap
 		if( event.modifiers & ButtonEvent::Control )
 		{
-			offset[0] = std::round( offset[0] );
-			offset[1] = std::round( offset[1] );
-		}
-
-		// precision mode
-		if( event.modifiers & ButtonEvent::Shift )
-		{
-			offset *= 0.1;
+			offset[0] = offset[0] - fmodf( offset[0] - snapOffset, snapIncrement ) + snapOffset;
+			offset[1] = offset[1] - fmodf( offset[1] - snapOffset, snapIncrement ) + snapOffset;
 		}
 
 		return m_planarDrag.axis0() * offset[0] + m_planarDrag.axis1() * offset[1];


### PR DESCRIPTION
Implements #3324.

- Precise motion for camera movements (incl. CameraTool, and graph/animation editor).
- Precise motion for tools no longer resets positions to the starting point.

I'm not 100% on some of these variable names.   Will mull some more, but wanted a PR to get some user feedback too.
