### PR TITLE
RotateTool : Fix arbitrary z-axis rotations when using targeted mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+0.55.0.1 (relative to 0.55.0.0)
+========
+
+Fixes
+-----
+
+- RotateTool : When using targeted mode, the tool no longer introduces arbitrary rotation around the z-axis.
+
 0.55.0.0
 ========
 

--- a/src/GafferSceneUI/RotateTool.cpp
+++ b/src/GafferSceneUI/RotateTool.cpp
@@ -291,16 +291,17 @@ bool RotateTool::buttonPress( const GafferUI::ButtonEvent &event )
 	{
 		Context::Scope scopedContext( s.context.get() );
 
-		V3f currentYAxis, currentZAxis;
+		V3f currentZAxis;
 		const M44f worldTransform = s.scene->fullTransform( s.path );
-		worldTransform.multDirMatrix( V3f( 0.0f, 1.0f, 0.0f ), currentYAxis );
 		worldTransform.multDirMatrix( V3f( 0.0f, 0.0f, -1.0f ), currentZAxis );
+		currentZAxis.normalize();
 
-		const V3f targetZAzis = targetPos - ( V3f( 0.0f ) * worldTransform );
+		const V3f targetZAxis = ( targetPos - ( V3f( 0.0f ) * worldTransform ) ).normalized();
 
-		M44f reorientationMatrix = rotationMatrixWithUpDir(
-			currentZAxis, targetZAzis, currentYAxis
-		);
+		// Note: despite rotationMatrixWithUpDir using the current Y axis
+		// sounding like a better option, it actually introduces arbitrary
+		// rotations in z, which we never got to the bottom of.
+		M44f reorientationMatrix = rotationMatrix( currentZAxis, targetZAxis );
 
 		V3f offset;
 		extractEulerXYZ( reorientationMatrix, offset );


### PR DESCRIPTION
Fixes #3439