### PR TITLE
Azure : Lock azure package versions

### DIFF
--- a/config/azure/build.yaml
+++ b/config/azure/build.yaml
@@ -94,7 +94,7 @@ jobs:
    - ${{ if eq(parameters.publish, true) }}:
 
      - script: |
-         pip install --user azure-storage-blob PyGithub &&
+         pip install --user azure-common==1.1.23 azure-nspkg==3.0.2 azure-storage-blob==2.1.0 azure-storage-common==2.1.0 azure-storage-nspkg==3.1.0 PyGithub &&
          ./config/azure/publishBuild.py --archive ./install/$(Gaffer.Build.Name).tar.gz --repo $(Build.Repository.Name) --commit $(Gaffer.Source.Commit)
        displayName: "Publish Build"
        condition: and( succeeded(), or( eq( variables['Build.Reason'], 'PullRequest' ), eq( variables['Build.Reason'], 'Schedule' ) ) )


### PR DESCRIPTION
Microsoft have completely re-written `azure-storage-blob`. For now, switch
back to the old version.

Need to move over to `BlobServiceClient` [it seems](https://github.com/Azure/azure-sdk-for-python/blob/fef8456b489f9c46eda8f40ef2566095cea63a97/sdk/storage/azure-storage-blob/tests/test_page_blob.py#L1230).  