### PR TITLE
RotateTool : Fix arbitrary z-axis rotations when using targeted mode

### DIFF
--- a/include/GafferSceneUI/RotateTool.h
+++ b/include/GafferSceneUI/RotateTool.h
@@ -84,11 +84,11 @@ class GAFFERSCENEUI_API RotateTool : public TransformTool
 			Rotation( const Selection &selection, Orientation orientation );
 
 			bool canApply( const Imath::V3i &axisMask ) const;
-			void apply( const Imath::Eulerf &rotation ) const;
+			void apply( const Imath::Eulerf &rotation, bool relative = true ) const;
 
 			private :
 
-				Imath::V3f updatedRotateValue( const Imath::Eulerf &rotation, Imath::V3f *currentValue = nullptr ) const;
+				Imath::V3f updatedRotateValue( const Imath::Eulerf &rotation, bool relative = true, Imath::V3f *currentValue = nullptr ) const;
 
 				Gaffer::V3fPlugPtr m_plug;
 				Imath::Eulerf m_originalRotation; // Radians

--- a/include/GafferSceneUI/RotateTool.h
+++ b/include/GafferSceneUI/RotateTool.h
@@ -84,11 +84,11 @@ class GAFFERSCENEUI_API RotateTool : public TransformTool
 			Rotation( const Selection &selection, Orientation orientation );
 
 			bool canApply( const Imath::V3i &axisMask ) const;
-			void apply( const Imath::Eulerf &rotation, bool relative = true ) const;
+			void apply( const Imath::Eulerf &rotation ) const;
 
 			private :
 
-				Imath::V3f updatedRotateValue( const Imath::Eulerf &rotation, bool relative = true, Imath::V3f *currentValue = nullptr ) const;
+				Imath::V3f updatedRotateValue( const Imath::Eulerf &rotation, Imath::V3f *currentValue = nullptr ) const;
 
 				Gaffer::V3fPlugPtr m_plug;
 				Imath::Eulerf m_originalRotation; // Radians


### PR DESCRIPTION
An alternate solution to:
https://github.com/GafferHQ/gaffer/pull/3442

The root cause of the problem with the current master is that when we click in targetted mode, we are creating a new orientation which doesn't have much to do with the existing orientation - it takes the same up vector, but otherwise, we are finding a brand new direction for the Z axis.

( Arguably, maybe we shouldn't even be keeping the up vector.  It introduces some annoying rotation on the roll axis if you tilt up and then pan sideways - but we can at least make sure that we only introduce roll when we are doing something to cause it ).

The previous code was complicated by the fact that we need this absolute new rotation, but we need to compute it as relative euler angle offsets on the previous rotation ... in order to pass it into code that uses those euler offsets to build a matrix, and concatenates to the previous rotation, ideally getting us back where we started.  Reversing the existing rotation wasn't taken into account while handling the up vector.  I could add some extra code to reverse this as well, but it seemed far clearer to simply split apply() into two methods, so that you have the option to pass in an absolute rotation value.  ( If it's important to keep the signature the same, I can do the more confusing version instead ).

I've also made the call here that it's better not to find the euler angles closest to the current rotation when performing targetting.  If the rotation is <0, 1080, 0>, and the user clicks 5 degrees right, we might as well reset the rotation to <0, 5, 0>, rather than <0, 1085, 0> - it keeps the numbers easier to read, and because it's a discrete action, I don't see much value in preserving the existing number of wraps ( I can also switch this back if desired ).

Testing it, Michael still very rightly points out that it's annoying that you constantly get a little bit of roll introduced whenever you tilt up, and then pan over.  The only things I can think of that would help with this are an alternate mode where we set the up vector to a fixed +Y in world space, or the option to work in other rotate orders ( Keeping your camera in ZXY would at least make it easy to set the Z rot to default whenever you notice it drifting ).