### PR TITLE
Rotate/TranslateTool : Handle the selection being empty in targeted mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+0.55.0.1 (relative to 0.55.0.0)
+========
+
+Fixes
+-----
+
+- Rotate/TranslateTool : Fixed a potential crash if targeted mode was used with an empty selection.
+
 0.55.0.0
 ========
 

--- a/src/GafferSceneUI/RotateTool.cpp
+++ b/src/GafferSceneUI/RotateTool.cpp
@@ -266,6 +266,7 @@ bool RotateTool::buttonPress( const GafferUI::ButtonEvent &event )
 	if( event.buttons != ButtonEvent::Left
 		|| !activePlug()->getValue()
 		|| !getTargetedMode()
+		|| selection().size() == 0
 	) {
 		return false;
 	}

--- a/src/GafferSceneUI/TranslateTool.cpp
+++ b/src/GafferSceneUI/TranslateTool.cpp
@@ -265,6 +265,7 @@ bool TranslateTool::buttonPress( const GafferUI::ButtonEvent &event )
 	if( event.buttons != ButtonEvent::Left
 		|| !activePlug()->getValue()
 		|| !getTargetedMode()
+		|| selection().size() == 0
 	) {
 		return false;
 	}


### PR DESCRIPTION
Fixes a crash when the selection is empty.