### PR TITLE
Instancer prototypes

### DIFF
--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -56,11 +56,11 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::StringPlug *namePlug();
 		const Gaffer::StringPlug *namePlug() const;
 
-		ScenePlug *instancesPlug();
-		const ScenePlug *instancesPlug() const;
+		ScenePlug *prototypesPlug();
+		const ScenePlug *prototypesPlug() const;
 
-		Gaffer::StringPlug *indexPlug();
-		const Gaffer::StringPlug *indexPlug() const;
+		Gaffer::StringPlug *prototypeIndexPlug();
+		const Gaffer::StringPlug *prototypeIndexPlug() const;
 
 		Gaffer::StringPlug *idPlug();
 		const Gaffer::StringPlug *idPlug() const;
@@ -133,9 +133,9 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		IECore::ConstCompoundDataPtr instanceChildNames( const ScenePath &parentPath, const Gaffer::Context *context ) const;
 		void instanceChildNamesHash( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 
-		struct InstanceScope : public Gaffer::Context::EditableScope
+		struct PrototypeScope : public Gaffer::Context::EditableScope
 		{
-			InstanceScope( const Gaffer::Context *context, const ScenePath &branchPath );
+			PrototypeScope( const Gaffer::Context *context, const ScenePath &branchPath );
 		};
 
 		static size_t g_firstPlugIndex;

--- a/python/GafferOSLUI/OSLObjectUI.py
+++ b/python/GafferOSLUI/OSLObjectUI.py
@@ -51,6 +51,7 @@ _primitiveVariableNamesOptions = {
 	"N" : IECore.V3fData( imath.V3f(0), IECore.GeometricData.Interpretation.Normal ),
 	"velocity" : IECore.V3fData( imath.V3f(0), IECore.GeometricData.Interpretation.Vector ),
 	"uv" : IECore.V3fData( imath.V3f(0), IECore.GeometricData.Interpretation.UV ),
+	"scale" : IECore.V3fData( imath.V3f(1) ),
 	"width" : IECore.FloatData(),
 	"Cs" : IECore.Color3fData(),
 	"customInt" : IECore.IntData(),

--- a/python/GafferSceneTest/FilterResultsTest.py
+++ b/python/GafferSceneTest/FilterResultsTest.py
@@ -133,7 +133,7 @@ class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
 
 		script["instancer"] = GafferScene.Instancer()
 		script["instancer"]["in"].setInput( script["plane"]["out"] )
-		script["instancer"]["instances"].setInput( script["sphere"]["out"] )
+		script["instancer"]["prototypes"].setInput( script["sphere"]["out"] )
 		script["instancer"]["parent"].setValue( "/plane" )
 
 		script["filter"] = GafferScene.PathFilter()

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -88,7 +88,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( seedsInput["out"] )
-		instancer["instances"].setInput( instanceInput["out"] )
+		instancer["prototypes"].setInput( instanceInput["out"] )
 		instancer["parent"].setValue( "/seeds" )
 		instancer["name"].setValue( "instances" )
 
@@ -162,7 +162,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( seedsInput["out"] )
-		instancer["instances"].setInput( instanceInput["out"] )
+		instancer["prototypes"].setInput( instanceInput["out"] )
 		instancer["parent"].setValue( "/seeds" )
 		instancer["name"].setValue( "instances" )
 
@@ -188,7 +188,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( sphere["out"] )
 		instancer["parent"].setValue( "/sphere" )
-		instancer["instances"].setInput( sphere["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
 
 		self.assertSceneValid( instancer["out"] )
 		self.assertEqual( instancer["out"].bound( "/sphere" ), sphere["out"].bound( "/sphere" ) )
@@ -211,7 +211,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( plane["out"] )
-		instancer["instances"].setInput( sphere["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
 
 		instancer["parent"].setValue( "" )
 
@@ -225,7 +225,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( plane["out"] )
-		instancer["instances"].setInput( sphere["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
 
 		instancer["parent"].setValue( "/plane" )
 
@@ -247,7 +247,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( plane["out"] )
-		instancer["instances"].setInput( sphere["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
 
 		instancer["parent"].setValue( "/plane" )
 
@@ -262,7 +262,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( plane["out"] )
-		instancer["instances"].setInput( sphere["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
 		instancer["parent"].setValue( "/plane" )
 
 		cs = GafferTest.CapturingSlot( instancer.plugDirtiedSignal() )
@@ -288,7 +288,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		script["instancer"] = GafferScene.Instancer()
 		script["instancer"]["in"].setInput( script["plane"]["out"] )
-		script["instancer"]["instances"].setInput( script["sphere"]["out"] )
+		script["instancer"]["prototypes"].setInput( script["sphere"]["out"] )
 		script["instancer"]["parent"].setValue( "/plane" )
 
 		# The Instancer spawns its own threads, so if we don't release the GIL
@@ -378,7 +378,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		script["instancer"] = GafferScene.Instancer()
 		script["instancer"]["in"].setInput( script["plane"]["out"] )
-		script["instancer"]["instances"].setInput( script["sphere"]["out"] )
+		script["instancer"]["prototypes"].setInput( script["sphere"]["out"] )
 		script["instancer"]["parent"].setValue( "/plane" )
 
 		script["attributes"] = GafferScene.CustomAttributes()
@@ -446,7 +446,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		script["instancer"] = GafferScene.Instancer()
 		script["instancer"]["in"].setInput( script["plane"]["out"] )
-		script["instancer"]["instances"].setInput( script["sphere"]["out"] )
+		script["instancer"]["prototypes"].setInput( script["sphere"]["out"] )
 		script["instancer"]["parent"].setValue( "/plane" )
 
 		script["box"] = Gaffer.Box()
@@ -481,7 +481,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		script["instancer"] = GafferScene.Instancer()
 		script["instancer"]["in"].setInput( script["plane"]["out"] )
-		script["instancer"]["instances"].setInput( script["sphere"]["out"] )
+		script["instancer"]["prototypes"].setInput( script["sphere"]["out"] )
 		script["instancer"]["parent"].setValue( "/plane" )
 
 		context = Gaffer.Context()
@@ -539,7 +539,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		script["instancer"] = GafferScene.Instancer()
 		script["instancer"]["in"].setInput( script["plane"]["out"] )
-		script["instancer"]["instances"].setInput( script["sphere"]["out"] )
+		script["instancer"]["prototypes"].setInput( script["sphere"]["out"] )
 		script["instancer"]["parent"].setValue( "/plane" )
 
 		script["pythonCommand"] = GafferDispatch.PythonCommand()
@@ -578,7 +578,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( objectToScene["out"] )
-		instancer["instances"].setInput( sphere["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
 		instancer["parent"].setValue( "/object" )
 
 		self.assertEqual( instancer["out"].transform( "/object/instances/sphere/0" ), imath.M44f().translate( imath.V3f( 4, 0, 0 ) ) )
@@ -627,9 +627,9 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( objectToScene["out"] )
-		instancer["instances"].setInput( instances["out"] )
+		instancer["prototypes"].setInput( instances["out"] )
 		instancer["parent"].setValue( "/object" )
-		instancer["index"].setValue( "index" )
+		instancer["prototypeIndex"].setValue( "index" )
 
 		self.assertEqual( instancer["out"].childNames( "/object/instances" ), IECore.InternedStringVectorData( [ "sphere", "cube" ] ) )
 		self.assertEqual( instancer["out"].childNames( "/object/instances/sphere" ), IECore.InternedStringVectorData( [ "0", "3" ] ) )
@@ -676,9 +676,9 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( objectToScene["out"] )
-		instancer["instances"].setInput( instances["out"] )
+		instancer["prototypes"].setInput( instances["out"] )
 		instancer["parent"].setValue( "/object" )
-		instancer["index"].setValue( "index" )
+		instancer["prototypeIndex"].setValue( "index" )
 
 		self.assertEqual(
 			instancer["out"]["setNames"].getValue(),
@@ -725,9 +725,9 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( objectToScene["out"] )
-		instancer["instances"].setInput( instances["out"] )
+		instancer["prototypes"].setInput( instances["out"] )
 		instancer["parent"].setValue( "/object" )
-		instancer["index"].setValue( "index" )
+		instancer["prototypeIndex"].setValue( "index" )
 		instancer["id"].setValue( "id" )
 
 		self.assertEqual( instancer["out"].childNames( "/object/instances" ), IECore.InternedStringVectorData( [ "sphere", "cube" ] ) )
@@ -780,9 +780,9 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( objectToScene["out"] )
-		instancer["instances"].setInput( instances["out"] )
+		instancer["prototypes"].setInput( instances["out"] )
 		instancer["parent"].setValue( "/object" )
-		instancer["index"].setValue( "index" )
+		instancer["prototypeIndex"].setValue( "index" )
 		instancer["id"].setValue( "id" )
 
 		self.assertEqual( instancer["out"].childNames( "/object/instances" ), IECore.InternedStringVectorData( [ "sphere", "cube" ] ) )
@@ -814,7 +814,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( objectToScene["out"] )
-		instancer["instances"].setInput( sphere["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
 		instancer["parent"].setValue( "/object" )
 		instancer["id"].setValue( "id" )
 
@@ -853,7 +853,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( objectToScene["out"] )
-		instancer["instances"].setInput( sphere["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
 		instancer["parent"].setValue( "/object" )
 
 		self.assertEqual(
@@ -959,7 +959,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( objectToScene["out"] )
-		instancer["instances"].setInput( sphere["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
 		instancer["parent"].setValue( "/object" )
 
 		self.assertEqual(
@@ -987,7 +987,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( objectToScene["out"] )
-		instancer["instances"].setInput( sphere["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
 		instancer["parent"].setValue( "/object" )
 
 		instancer["attributes"].setValue( "test*" )
@@ -1043,7 +1043,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		plane = GafferScene.Plane()
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( plane["out"] )
-		instancer["instances"].setInput( plane["out"] )
+		instancer["prototypes"].setInput( plane["out"] )
 
 		cs = GafferTest.CapturingSlot( instancer.plugDirtiedSignal() )
 		instancer["parent"].setValue( "plane" )

--- a/python/GafferSceneTest/RenderControllerTest.py
+++ b/python/GafferSceneTest/RenderControllerTest.py
@@ -287,7 +287,7 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 
 		sphereInstancer = GafferScene.Instancer()
 		sphereInstancer["in"].setInput( spherePlane["out"] )
-		sphereInstancer["instances"].setInput( sphere["out"] )
+		sphereInstancer["prototypes"].setInput( sphere["out"] )
 		sphereInstancer["parent"].setValue( "/spheres" )
 
 		# Make a bunch of lights
@@ -300,7 +300,7 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 
 		lightInstancer = GafferScene.Instancer()
 		lightInstancer["in"].setInput( lightPlane["out"] )
-		lightInstancer["instances"].setInput( light["out"] )
+		lightInstancer["prototypes"].setInput( light["out"] )
 		lightInstancer["parent"].setValue( "/lights" )
 
 		# Make a single non-default light. This

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -59,7 +59,7 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( plane2["out"] )
 		instancer["parent"].setValue( "/plane" )
-		instancer["instances"].setInput( group["out"] )
+		instancer["prototypes"].setInput( group["out"] )
 
 		filter = GafferScene.PathFilter()
 		filter["paths"].setValue( IECore.StringVectorData( [ "/plane/instances/group/*1/plane" ] ) )
@@ -478,7 +478,7 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( plane["out"] )
-		instancer["instances"].setInput( sphere["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
 		instancer["parent"].setValue( "/plane" )
 
 		filter = GafferScene.PathFilter()

--- a/python/GafferSceneTest/SceneFilterPathFilterTest.py
+++ b/python/GafferSceneTest/SceneFilterPathFilterTest.py
@@ -81,7 +81,7 @@ class SceneFilterPathFilterTest( GafferSceneTest.SceneTestCase ) :
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( plane["out"] )
 		instancer["parent"].setValue( "/plane" )
-		instancer["instances"].setInput( sphere["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
 
 		scenePathFilter = GafferScene.PathFilter()
 		scenePathFilter["paths"].setValue( IECore.StringVectorData( [ "/plane/instances/sphere/*" ] ) )

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -150,6 +150,8 @@ Gaffer.Metadata.registerNode(
 			before instancing.
 			""",
 
+			"userDefault", "orientation",
+
 		],
 
 		"scale" : [
@@ -161,6 +163,8 @@ Gaffer.Metadata.registerNode(
 			provided as a float for uniform scaling, or as a vector
 			to define different scaling in each axis.
 			""",
+
+			"userDefault", "scale",
 
 		],
 

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -90,19 +90,19 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"instances" : [
+		"prototypes" : [
 
 			"description",
 			"""
-			The scene containing the instances to be applied to
-			each vertex. Specify multiple instances by parenting
+			The scene containing the prototypes to be applied to
+			each vertex. Specify multiple prototypes by parenting
 			them at the root of the scene :
 
-			- /instance0
-			- /instance1
-			- /instance2
+			- /prototype0
+			- /prototype1
+			- /prototype2
 
-			Note that the instances are not limited to being a
+			Note that the prototypes are not limited to being a
 			single object : they can each have arbitrary child
 			hierarchies.
 			""",
@@ -111,17 +111,18 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"index" : [
+		"prototypeIndex" : [
 
 			"description",
 			"""
 			The name of a per-vertex integer primitive variable
-			used to determine which instance is applied to the
+			used to determine which prototype is applied to the
 			vertex. An index of 0 applies the first location from
-			the instances scene, an index of 1 applies the second
+			the prototypes scene, an index of 1 applies the second
 			and so on.
 			""",
 
+			"userDefault", "prototypeIndex",
 			"layout:section", "Settings.General",
 
 		],

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -55,6 +55,10 @@ Gaffer.Metadata.registerNode(
 	scale. Note the target object will be removed from the scene.
 	""",
 
+	"layout:section:Settings.General:collapsed", False,
+	"layout:section:Settings.Transforms:collapsed", False,
+	"layout:section:Settings.Attributes:collapsed", False,
+
 	plugs = {
 
 		"parent" : [
@@ -67,7 +71,9 @@ Gaffer.Metadata.registerNode(
 			this object. This is ignored when a filter is
 			connected, in which case the filter specifies
 			multiple objects to make the instances from.
-			"""
+			""",
+
+			"layout:section", "Settings.General",
 
 		],
 
@@ -78,7 +84,9 @@ Gaffer.Metadata.registerNode(
 			The name of the location the instances will be
 			generated below. This will be parented directly
 			under the parent location.
-			"""
+			""",
+
+			"layout:section", "Settings.General",
 
 		],
 
@@ -112,7 +120,9 @@ Gaffer.Metadata.registerNode(
 			vertex. An index of 0 applies the first location from
 			the instances scene, an index of 1 applies the second
 			and so on.
-			"""
+			""",
+
+			"layout:section", "Settings.General",
 
 		],
 
@@ -125,7 +135,9 @@ Gaffer.Metadata.registerNode(
 			is useful when points are added and removed over time,
 			as is often the case in a particle simulation. The
 			id is used to name the instance in the output scene.
-			"""
+			""",
+
+			"layout:section", "Settings.General",
 
 		],
 
@@ -136,6 +148,8 @@ Gaffer.Metadata.registerNode(
 			The name of the per-vertex primitive variable used
 			to specify the position of each instance.
 			""",
+
+			"layout:section", "Settings.Transforms",
 
 		],
 
@@ -151,6 +165,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"userDefault", "orientation",
+			"layout:section", "Settings.Transforms",
 
 		],
 
@@ -165,6 +180,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"userDefault", "scale",
+			"layout:section", "Settings.Transforms",
 
 		],
 
@@ -178,6 +194,8 @@ Gaffer.Metadata.registerNode(
 			standard wildcards.
 			""",
 
+			"layout:section", "Settings.Attributes",
+
 		],
 
 		"attributePrefix" : [
@@ -189,6 +207,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"userDefault", "user:",
+			"layout:section", "Settings.Attributes",
 
 		],
 

--- a/python/GafferSceneUITest/SceneGadgetTest.py
+++ b/python/GafferSceneUITest/SceneGadgetTest.py
@@ -317,7 +317,7 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 
 		instancer = GafferScene.Instancer()
 		instancer["in"].setInput( plane["out"] )
-		instancer["instances"].setInput( sphere["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
 		instancer["parent"].setValue( "/plane" )
 
 		subTree = GafferScene.SubTree()

--- a/startup/GafferScene/instancerCompatibility.py
+++ b/startup/GafferScene/instancerCompatibility.py
@@ -1,0 +1,52 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferScene
+
+def __instancerGetItem( originalGetItem ) :
+
+	def getItem( self, key ) :
+
+		if key == "instances" :
+			key = "prototypes"
+		elif key == "index" :
+			key = "prototypeIndex"
+
+		return originalGetItem( self, key )
+
+	return getItem
+
+GafferScene.Instancer.__getitem__ = __instancerGetItem( GafferScene.Instancer.__getitem__ )


### PR DESCRIPTION
This makes Gaffer's `Instancer` a bit easier to work with, by organizing the _NodeEditor_, setting some userDefaults, and renaming the `instances` plug to `prototypes` (matching USD naming).

I've also added a scale V3f to the `OSLObject` "Standard" menu to make it easier to setup primvars matching the new `Instancer` defaults.

There could be an argument to use `orient` rather than `orientation` (matching Houdini defaults), in which case we'd also want to update our `Orientation` node. Similarly, `id` is a common standard (as opposed to `instanceId`). If you feel either of those are worthwhile, just let me know and I'll push a change.