### PR TITLE
ArnoldLight : Support OSL shader network connections

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,7 @@ Fixes
 - NodeEditor : Fixed bug that allowed drag and drop to create unwanted input connections to output plugs.
 - GraphComponent : Fixed bug that allowed construction with an invalid name (#3436).
 - Layouts : Keyboard shortcuts will now work in detached panels restored with a layout.
+- ArnoldLight : Fixed a bug that prevented OSL shaders being used with Arnold lights.
 
 0.54.2.1 (relative to 0.54.2.0)
 ========

--- a/python/GafferArnoldTest/ArnoldLightTest.py
+++ b/python/GafferArnoldTest/ArnoldLightTest.py
@@ -112,5 +112,23 @@ class ArnoldLightTest( GafferSceneTest.SceneTestCase ) :
 		network = l["out"].attributes( "/light" )["ai:light"]
 		self.assertEqual( network.getShader( "sky" ).parameters["intensity"].value, 4 )
 
+	def testOSLShaderInputs( self ) :
+
+		l = GafferArnold.ArnoldLight()
+		l.loadShader( "skydome_light" )
+
+		c = GafferSceneTest.TestShader( "mockOSL" )
+		c["type"].setValue( "osl:shader" )
+
+		l["parameters"]["color"].setInput( c["out"] )
+
+		network = l["out"].attributes( "/light" )["ai:light"]
+		self.assertEqual(
+			network.inputConnections( network.getOutput().shader ),
+			[
+				network.Connection( ( "mockOSL", "" ), ( network.getOutput().shader, "color" ) )
+			]
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferArnold/ArnoldLight.cpp
+++ b/src/GafferArnold/ArnoldLight.cpp
@@ -116,7 +116,10 @@ IECoreScene::ShaderNetworkPtr ArnoldLight::computeLight( const Gaffer::Context *
 			/// This would avoid manually splicing in networks here, and would
 			/// generalise nicely to the other Light subclasses too.
 			IECore::ConstCompoundObjectPtr inputAttributes = shader->attributes();
-			const IECoreScene::ShaderNetwork *inputNetwork = inputAttributes->member<const IECoreScene::ShaderNetwork>( "ai:surface" );
+			IECoreScene::ShaderNetwork const *inputNetwork = inputAttributes->member<const IECoreScene::ShaderNetwork>( "ai:surface" );
+			if( !inputNetwork ) {
+				inputNetwork = inputAttributes->member<const IECoreScene::ShaderNetwork>( "osl:shader" );
+			}
 			if( !inputNetwork || !inputNetwork->size() )
 			{
 				continue;


### PR DESCRIPTION
We were previously only looking for `ai:surface`.

This allows Arnold Lights to make use of OSL networks as inputs.