### PR TITLE
PerformanceMonitor : Include compute counts in the annotated script

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 0.55.0.1 (relative to 0.55.0.0)
 ========
 
+Improvements
+------------
+
+- Stats app : Added node compute counts to performanceMonitor script annotations.
+
 Fixes
 -----
 

--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -337,6 +337,7 @@ class stats( Gaffer.Application ) :
 			if self.__performanceMonitor is not None :
 				Gaffer.MonitorAlgo.annotate( script, self.__performanceMonitor, Gaffer.MonitorAlgo.PerformanceMetric.TotalDuration )
 				Gaffer.MonitorAlgo.annotate( script, self.__performanceMonitor, Gaffer.MonitorAlgo.PerformanceMetric.HashCount )
+				Gaffer.MonitorAlgo.annotate( script, self.__performanceMonitor, Gaffer.MonitorAlgo.PerformanceMetric.ComputeCount )
 			if self.__contextMonitor is not None :
 				Gaffer.MonitorAlgo.annotate( script, self.__contextMonitor )
 


### PR DESCRIPTION
Includes compute count in annotated scripts. This can be useful to see where you may be adding extra computes due on context variation.