### PR TITLE
TabbedContainer: Don't raise when the last tab is closed

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,7 @@ Fixes
 - GraphComponent : Fixed bug that allowed construction with an invalid name (#3436).
 - Layouts : Keyboard shortcuts will now work in detached panels restored with a layout.
 - Rotate/TranslateTool : Fixed a potential crash if targeted mode was used with an empty selection.
+- TabbedContainer : Fixed a bug that caused an exception when the last tab in a container was closed.
 
 0.55.0.0
 ========

--- a/python/GafferUI/TabbedContainer.py
+++ b/python/GafferUI/TabbedContainer.py
@@ -234,7 +234,8 @@ class TabbedContainer( GafferUI.ContainerWidget ) :
 
 	def __currentChanged( self, index ) :
 
-		self.__currentChangedSignal( self, self[index] )
+		current = self[index] if len(self) else None
+		self.__currentChangedSignal( self, current )
 
 	def __tabBarDragEnter( self, widget, event ) :
 

--- a/python/GafferUITest/TabbedContainerTest.py
+++ b/python/GafferUITest/TabbedContainerTest.py
@@ -135,6 +135,8 @@ class TabbedContainerTest( GafferUITest.TestCase ) :
 		c = tc.currentChangedSignal().connect( s )
 		self.__current = None
 
+		self.failUnless( tc.getCurrent() is None )
+
 		b1 = GafferUI.Button()
 		tc.append( b1 )
 		self.failUnless( self.__current is b1 )
@@ -152,6 +154,10 @@ class TabbedContainerTest( GafferUITest.TestCase ) :
 		tc.remove( b1 )
 		self.failUnless( self.__current is b2 )
 		self.failUnless( tc.getCurrent() is b2 )
+
+		tc.remove( b2 )
+		self.failUnless( self.__current is None )
+		self.failUnless( tc.getCurrent() is None )
 
 	def testDel( self ) :
 


### PR DESCRIPTION
In a previous commit, we fixed the order of change signals and widget removal (such that the change signal would be given the correct widget). 

Now we have this the right way around, we need to make sure that when the last widget has been removed (and the change signal is emitted) we handle the container being empty. Listeners to `currentChangedSignal` need to be able to handle the supplied widget being `None`.