### PR TITLE
GraphEditor : Track changes to parents of the current root

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,7 @@ Fixes
 - NodeEditor : Fixed bug that allowed drag and drop to create unwanted input connections to output plugs.
 - GraphComponent : Fixed bug that allowed construction with an invalid name (#3436).
 - Layouts : Keyboard shortcuts will now work in detached panels restored with a layout.
+- GraphEditor : Fixed several bugs and a crash that could occur when a parent of the editor's root node was changed or deleted.
 
 0.54.2.1 (relative to 0.54.2.0)
 ========


### PR DESCRIPTION
Fixes #3455 .

The validity of the current root, and the title of the editor depend upon not only the root itself, but its hierarchy back up to the script node.

We need to make sure we track all ancestors for changes, otherwise we can easily end up in a root that has been removed from a script without realising.

@johnhaddon Do you want to put any additional validation in `GraphEditor` sanity-checking the root before we adopt it?