### PR TITLE
OpenImageIOReader : Fix FormatHash to include defaultFormat

### DIFF
--- a/python/GafferImageTest/OpenImageIOReaderTest.py
+++ b/python/GafferImageTest/OpenImageIOReaderTest.py
@@ -595,6 +595,26 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( len( mh.messages ), 1 )
 		self.assertTrue( mh.messages[0].message.startswith( "Ignoring subimage 1 of " ) )
 
+	def testDefaultFormatHash( self ) :
+
+		r = GafferImage.OpenImageIOReader()
+
+		with Gaffer.Context() as c :
+
+			GafferImage.FormatPlug.setDefaultFormat( c, GafferImage.Format( 100, 200 ) )
+			h1 = r["out"].formatHash()
+			GafferImage.FormatPlug.setDefaultFormat( c, GafferImage.Format( 200, 300 ) )
+			h2 = r["out"].formatHash()
+			GafferImage.FormatPlug.setDefaultFormat( c, GafferImage.Format( 100, 300, 2.0 ) )
+			h3 = r["out"].formatHash()
+			GafferImage.FormatPlug.setDefaultFormat( c, GafferImage.Format( 100, 200 ) )
+			h4 = r["out"].formatHash()
+
+		self.assertNotEqual( h1, h2 )
+		self.assertNotEqual( h1, h3 )
+		self.assertNotEqual( h2, h3 )
+		self.assertEqual( h1, h4 )
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -790,6 +790,9 @@ void OpenImageIOReader::hashFormat( const GafferImage::ImagePlug *output, const 
 	hashFileName( context, h );
 	refreshCountPlug()->hash( h );
 	missingFrameModePlug()->hash( h );
+	GafferImage::Format format = FormatPlug::getDefaultFormat( context );
+	h.append( format.getDisplayWindow() );
+	h.append( format.getPixelAspect() );
 }
 
 GafferImage::Format OpenImageIOReader::computeFormat( const Gaffer::Context *context, const ImagePlug *parent ) const


### PR DESCRIPTION
Fixes
---

- OpenImageIOReader : Fix FormatHash to include defaultFormat


----

Otherwise changing the `defaultFormat` value on the script would not force a recompute.
