### PR TITLE
ChildNamesMap : Don't throw on invalid sets, fix them instead

### DIFF
--- a/Changes
+++ b/Changes
@@ -17,6 +17,7 @@ Fixes
 - TabbedContainer : Fixed a bug that caused an exception when the last tab in a container was closed.
 - ArnoldLight : Fixed a bug that prevented OSL shaders being used with Arnold lights.
 - GraphEditor : Fixed several bugs and a crash that could occur when a parent of the editor's root node was changed or deleted.
+- Group/Parent : Fixed processing of invalid input sets. This now omits the invalid set members rather than throwing an error.
 
 0.55.0.0
 ========

--- a/include/GafferScene/Private/ChildNamesMap.h
+++ b/include/GafferScene/Private/ChildNamesMap.h
@@ -78,8 +78,6 @@ class ChildNamesMap : public IECore::Data
 
 	private :
 
-		IECore::InternedString output( const Input &input ) const;
-
 		const IECore::InternedStringVectorDataPtr m_childNames;
 
 		struct Child

--- a/python/GafferSceneTest/GroupTest.py
+++ b/python/GafferSceneTest/GroupTest.py
@@ -759,6 +759,24 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( noduleColor, None )
 		self.assertEqual( noduleColor, connectionColor )
 
+	def testProcessInvalidSet( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		bogusSet = GafferScene.Set()
+		bogusSet["in"].setInput( sphere["out"] )
+		bogusSet["paths"].setValue( IECore.StringVectorData( [ "/sphere", "/notASphere" ] ) )
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( bogusSet["out"] )
+
+		self.assertEqual(
+			group["out"].set( "set" ).value,
+			IECore.PathMatcher( [ "/group/sphere" ] )
+		)
+
+		self.assertSceneValid( group["out"] )
+
 	def setUp( self ) :
 
 		GafferSceneTest.SceneTestCase.setUp( self )


### PR DESCRIPTION
Longer term we should definitely consider making it impossible for the user to generate invalid sets. The original Set node implementation didn't check `pathsPlug()` for validity for performance reasons, but we have since introduced `Set::filterPlug()` which only generates valid paths but at greater expense (via FilterResults). Users are already confused as to which method they should prefer, and we hope to now have FilterResults performance under control using the new cache policies, so there may be a case for just removing `Set::pathsPlug()` in future.
