### PR TITLE
RendererController : Defer updateObject hash update

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+0.54.2.3 (relative to 0.54.2.2)
+========
+
+Fixes
+-----
+
+- Viewer : Fixed a bug that prevented cancelled updates from retrying, potentially resulting in missing objects (#3469).
+
 0.54.2.2 (relative to 0.54.2.1)
 ========
 

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -564,12 +564,12 @@ class RenderController::SceneGraph
 			}
 
 			IECore::ConstObjectPtr object = objectPlug->getValue( &objectHash );
-			m_objectHash = objectHash;
 
 			const IECore::NullObject *nullObject = runTimeCast<const IECore::NullObject>( object.get() );
 			if( (type != LightType && type != LightFilterType) && nullObject )
 			{
 				m_objectInterface = nullptr;
+				m_objectHash = objectHash;
 				return hadObjectInterface;
 			}
 
@@ -650,6 +650,11 @@ class RenderController::SceneGraph
 			{
 				m_objectInterface = renderer->object( name, object.get(), attributesInterface( renderer ) );
 			}
+
+			// Object computation may take a while so we're sensitive to
+			// cancellation. Only update the hash if we successfully ran to the
+			// end, otherwise we may fail to retry as the hash hasn't changed.
+			m_objectHash = objectHash;
 
 			return true;
 		}


### PR DESCRIPTION
We were inadvertently updating the hash before successfully updating the object. If this took some time, and was cancelled, then the hash would match the next time the update ran and we'd be stuck with an empty object representation.

This started to manifest itself whilst implementing #3407, as the shading time to generate light textures overlapped with cancellations due to calls to `GafferSceneUI::ContextAlgo::setExpandedPaths`.