### PR TITLE
Stats app : Add `-postScript` command line argument

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+0.55.2.0 (relative to 0.55.1.0)
+========
+
+Improvements
+------------
+
+- Stats app : Added `-postLoadScript` command line argument. This can be used to perform post-processing of the loaded script before stats are gathered.
+
 0.55.1.0 (relative to 0.55.0.0)
 ========
 

--- a/contrib/statsPostLoadScripts/setPathsToPathFilters.py
+++ b/contrib/statsPostLoadScripts/setPathsToPathFilters.py
@@ -1,0 +1,31 @@
+# Replaces all usage of the `Set.paths` plug with a PathFilter
+# connected to `Set.filter`. This can be used to assess the performance
+# impact of deprecating the `paths` plug and always requiring a filter
+# to be used.
+
+import GafferScene
+
+for s in GafferScene.Set.RecursiveRange( root ) :
+
+	if not s["paths"].isSetToDefault() :
+
+		pathFilter = GafferScene.PathFilter()
+		if s["paths"].getInput() :
+			pathFilter["paths"].setInput( s["paths"].getInput() )
+			s["paths"].setInput( None )
+		else :
+			pathFilter["paths"].setValue( s["paths"].getValue() )
+			s["paths"].setToDefault()
+
+		s.parent().addChild( pathFilter )
+
+		if s["filter"].getInput() :
+			unionFilter = GafferScene.UnionFilter()
+			unionFilter["in"][0].setInput( s["filter"].getInput() )
+			unionFilter["in"][1].setInput( pathFilter["out"] )
+			s["filter"].setInput( unionFilter["out"] )
+			s.parent().addChild( unionFilter )
+		else :
+			s["filter"].setInput( pathFilter["out"] )
+
+		print "Replaced {}.paths with PathFilter".format( s.relativeName( root ) )


### PR DESCRIPTION
We've discovered that users are mighty confused by the two options for providing locations to the Set node, and understandably. They can either add paths manually via `Set.paths`, in which case they get optimum performance, aren't allowed to use wildcards, and are responsible for only adding valid paths. Or they can plug a filter into `Set.filter`, in which case they get worse performance but can use any filter combination they want, including wildcards, and invalid locations will never be generated.

Ideally we would deprecate and hide the `Set.paths` plug so that everyone uses the safer and more powerful `Set.filter`, but we can't do that without first assessing the performance impact. This adds an argument to the `stats` app so that scripts can be post processed after loading, and then adds a small script in `/contrib` that can be used to convert `Set.paths` usage to `Set.filter` usage on loading. This should give us the performance answers we need.