### PR TITLE
LRUCache : Ensure cancellations don't set the fail state for value computation

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,7 +5,8 @@ Fixes
 -----
 
 - Viewer : Fixed X-Ray shading mode on MacOS (#3473).
-- Caching : Fixed bug in caches used across gaffer that could cause compute failures (#3469).
+- Caching : Changed the cache used in various sub-systems to avoid potential compute failures (#3476).
+- LRUCache : Fixed handling of cases where value computation for a cache-miss was cancelled in-flight, which then prevented the value ever being successfully retrieved (#3469).
 
 0.54.2.2 (relative to 0.54.2.1)
 ========

--- a/include/Gaffer/Private/IECorePreview/LRUCache.inl
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.inl
@@ -38,6 +38,7 @@
 
 #include "Gaffer/Private/IECorePreview/TaskMutex.h"
 
+#include "IECore/Canceller.h"
 #include "IECore/Exception.h"
 
 #include "boost/multi_index/hashed_index.hpp"
@@ -1091,6 +1092,10 @@ Value LRUCache<Key, Value, Policy, GetterKey>::get( const GetterKey &key )
 		try
 		{
 			handle.execute( [this, &value, &key, &cost] { value = m_getter( key, cost ); } );
+		}
+		catch( IECore::Cancelled const &c )
+		{
+			throw;
 		}
 		catch( ... )
 		{

--- a/python/GafferTest/IECorePreviewTest/LRUCacheTest.py
+++ b/python/GafferTest/IECorePreviewTest/LRUCacheTest.py
@@ -171,5 +171,17 @@ class LRUCacheTest( GafferTest.TestCase ) :
 
 		GafferTest.testLRUCacheExceptions( "taskParallel" )
 
+	def testCancellationSerial( self ) :
+
+		GafferTest.testLRUCacheCancellation( "serial" )
+
+	def testCancellationParallel( self ) :
+
+		GafferTest.testLRUCacheCancellation( "parallel" )
+
+	def testCancellationTaskParallel( self ) :
+
+		GafferTest.testLRUCacheCancellation( "taskParallel" )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
We were catching `IECore::Cancelled` and treating it the same as a failure during value computation. This meant it was never possible to retrieve the value later, as the cache would just re-throw the cancellation.

We now treat cancelled computations as uncached.

Works towards fixing #3469