### PR TITLE
gaffer.py : Don't overlap the main Gaffer module on case destroying filesystems

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 -----
 
 - Resize : Fixed bug which caused unwanted image distortion when changing pixel aspect ratio.
+- Launch : Fixed bug which prevented gaffer launching when stored on case destroying file systems (#3477).
 
 Breaking Changes
 ----------------
@@ -25,6 +26,7 @@ Breaking Changes
   config file.
 - OSLObject : Removed support for the `GAFFEROSL_OSLOBJECT_CONTEXTCOMPATIBILITY` environment variable.
 - ShaderAssignment : Removed support for the `GAFFERSCENE_SHADERASSIGNMENT_CONTEXTCOMPATIBILITY` environment variable.
+- bin : Renamed the `gaffer.py` launch script (to `__gaffer.py`) to avoid a collision with the main `Gaffer` module (see #3477). This will cause the process string to change on systems that don't support process renaming.
 
 0.55.1.0 (relative to 0.55.0.0)
 ========

--- a/SConstruct
+++ b/SConstruct
@@ -927,7 +927,7 @@ libraries = {
 	},
 
 	"scripts" : {
-		"additionalFiles" : [ "bin/gaffer", "bin/gaffer.py" ],
+		"additionalFiles" : [ "bin/gaffer", "bin/__gaffer.py" ],
 	},
 
 	"misc" : {

--- a/bin/__gaffer.py
+++ b/bin/__gaffer.py
@@ -36,6 +36,10 @@
 #
 ##########################################################################
 
+# Note: This file is generally considered private. Those wishing to launch
+# gaffer should use the gaffer wrapper script (also in this directory)
+# as it ensures the correct process environment is set up prior to launch.
+
 import os
 import sys
 import signal

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -304,7 +304,7 @@ if [[ -n $GAFFER_DEBUG ]] ; then
 		fi
 	fi
 	# Using `which` because lldb doesn't seem to respect $PATH
-	exec $GAFFER_DEBUGGER `which python` "$GAFFER_ROOT/bin/gaffer.py" "$@"
+	exec $GAFFER_DEBUGGER `which python` "$GAFFER_ROOT/bin/__gaffer.py" "$@"
 else
-	exec python "$GAFFER_ROOT/bin/gaffer.py" "$@"
+	exec python "$GAFFER_ROOT/bin/__gaffer.py" "$@"
 fi


### PR DESCRIPTION
On case destroying file systems, `gaffer.py` overlaps the main `Gaffer` module, which breaks, well, pretty much everything.

Addressed this as it facilitates building/running linux builds on MacOS, which aids cross-platform testing.