### PR TITLE
ShaderTweaks : Add missing preset for Arnold Blockers

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@ Fixes
 - Viewer : Fixed X-Ray shading mode on MacOS (#3473).
 - Caching : Changed the cache used in various sub-systems to avoid potential compute failures (#3476).
 - LRUCache : Fixed handling of cases where value computation for a cache-miss was cancelled in-flight, which then prevented the value ever being successfully retrieved (#3469).
+- ShaderTweaks : Fixed missing preset for Arnold Blockers.
 
 0.54.2.2 (relative to 0.54.2.1)
 ========

--- a/startup/gui/shaderTweaks.py
+++ b/startup/gui/shaderTweaks.py
@@ -55,6 +55,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 		( "Arnold Gobo", "ai:lightFilter:gobo" ),
 		( "Arnold Decay", "ai:lightFilter:light_decay" ),
 		( "Arnold Barndoor", "ai:lightFilter:barndoor" ),
+		( "Arnold Blocker", "ai:lightFilter:filter" )
 
 	] )
 


### PR DESCRIPTION
Add Arnold light blockers to the ShaderTweaks node preset list.