### PR TITLE
ShaderNetworkAlgo : Ensure Arnold nodes are properly reset before reuse

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,7 @@ Fixes
 - Caching : Changed the cache used in various sub-systems to avoid potential compute failures (#3476).
 - LRUCache : Fixed handling of cases where value computation for a cache-miss was cancelled in-flight, which then prevented the value ever being successfully retrieved (#3469).
 - ShaderTweaks : Fixed missing preset for Arnold Blockers.
+- Arnold : Fixed crash when disconnecting shader networks from lights (#3484).
 
 0.54.2.2 (relative to 0.54.2.1)
 ========

--- a/src/GafferArnold/IECoreArnoldPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/ShaderNetworkAlgo.cpp
@@ -318,6 +318,9 @@ void resetNode( AtNode *node )
 			continue;
 		}
 
+		// We've seen cases where AiNodeResetParameter doesn't unlink
+		// connections hence the call directly to AiNodeUnlink.
+		AiNodeUnlink( node, name );
 		AiNodeResetParameter( node, name );
 	}
 	AiParamIteratorDestroy( it );


### PR DESCRIPTION
Fixes #3484.

AiNodeResetParameter is supposed to clear connections, but it seemingly doesn't in some cases. Adding in AiNodeUnlink seems to remedy this.