### PR TITLE
Menu : Fix spacing above leading labelled dividers

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-0.55.2.0 (relative to 0.55.1.0)
+0.55.x.x (relative to 0.55.1.0)
 ========
 
 Improvements
@@ -12,6 +12,7 @@ Fixes
 - Viewer : Fixed X-Ray shading mode on MacOS (#3473).
 - Caching : Changed the cache used in various sub-systems to avoid potential compute failures (#3476).
 - LRUCache : Fixed handling of cases where value computation for a cache-miss was cancelled in-flight, which then prevented the value ever being successfully retrieved (#3469).
+- Menu : Fixed spacing issue in menus when the first item was a labelled divider.
 
 0.55.1.0 (relative to 0.55.0.0)
 ========

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -308,13 +308,12 @@ class Menu( GafferUI.Widget ) :
 						# it's not a submenu
 						action = self.__buildAction( item, name, qtMenu )
 
-						# Wrangle some divider spacing issues
+						# Wrangle some divider/menu spacing issues
 						if isinstance( action, _DividerAction ) :
 							if len( qtMenu.actions() ) :
 								qtMenu.addAction( _SpacerAction( qtMenu ) )
-							elif not self.__title and action.hasText :
-								# If a divider is the first item, we want the menu padding as per a title
-								self._qtWidget().setProperty( "gafferHasTitle", GafferUI._Variant.toVariant( True ) )
+							elif action.hasText :
+								self._qtWidget().setProperty( "gafferHasLeadingLabelledDivider", GafferUI._Variant.toVariant( True ) )
 								needsBottomSpacer = True
 
 						qtMenu.addAction( action )

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -237,7 +237,8 @@ _styleSheet = string.Template(
 		background-color: $backgroundLight;
 	}
 
-	QMenu[gafferHasTitle="true"] {
+	QMenu[gafferHasTitle="true"],
+	QMenu[gafferHasLeadingLabelledDivider="true"] {
 		/* make sure the title widget sits at the very top.
 		   infuriatingly, qt uses padding-top for the bottom
 		   as well, and is ignoring padding-bottom. that makes
@@ -253,6 +254,13 @@ _styleSheet = string.Template(
 		padding: 5px 25px 5px 20px;
 		margin-bottom: 6px;
 	}
+
+	QMenu[gafferHasLeadingLabelledDivider="true"] QLabel#gafferMenuTitle {
+		/* If the first item is a labeled section, we don't want any
+		   space under the title. */
+		margin-bottom: 0;
+	}
+
 
 	QLabel#gafferMenuLabeledDivider {
 		background-color: $backgroundLightLowlight;


### PR DESCRIPTION
The extra padding above a leading label looked bad, especially when between the title and the divider.

It now looks like this:

![image](https://user-images.githubusercontent.com/896779/69705962-8b16a780-10ee-11ea-9f2a-f43f841ccd1c.png) ![image](https://user-images.githubusercontent.com/896779/69705973-91a51f00-10ee-11ea-93d4-50ed870fbc2e.png) ![image](https://user-images.githubusercontent.com/896779/69705988-98cc2d00-10ee-11ea-9070-a29849cd705c.png)

