### PR TITLE
Appleseed : Allow nodes to be hidden from the node menu

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - Stats app : Added `-postLoadScript` command line argument. This can be used to perform post-processing of the loaded script before stats are gathered.
+- Appleseed : Added the ability to hide Appleseed nodes and other presets from the UI by setting the `GAFFERAPPLESEED_HIDE_UI` environment variable to `1`. Appleseed will still be available for OSL shader previews and example scenes.
 
 Fixes
 -----

--- a/doc/source/GettingStarted/ConfiguringGafferForThirdPartyTools/index.md
+++ b/doc/source/GettingStarted/ConfiguringGafferForThirdPartyTools/index.md
@@ -9,8 +9,11 @@ Gaffer is compatible with the following commercial and open-source third-party t
 
 Gaffer comes with Appleseed, so it will require no additional configuration. For the rest of the tools in this list, you will need to set some additional environment variables.
 
+> Tip :
+> If you do not use Appleseed in production, you can hide its nodes and presets from the UI by setting the `GAFFERAPPLESEED_HIDE_UI` environment variable to `1`. Even when set, Appleseed will still be available for OSL shader previews and example scenes.
+
 > Note :
-> For the the following Linux instructions, we will assume you are using the _bash_ shell and are familiar with terminal commands. Other shells will have comparable methods for setting environment variables.
+> For the following Linux instructions, we will assume you are using the _bash_ shell and are familiar with terminal commands. Other shells will have comparable methods for setting environment variables.
 
 
 ## Configuring Gaffer for Arnold ##

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -235,22 +235,24 @@ if "APPLESEED" in os.environ :
 		import GafferOSL
 		import GafferOSLUI
 
-		GafferAppleseedUI.ShaderMenu.appendShaders( nodeMenu.definition() )
+		if os.environ.get( "GAFFERAPPLESEED_HIDE_UI", "" ) != "1" :
 
-		GafferAppleseedUI.LightMenu.appendLights( nodeMenu.definition() )
+			GafferAppleseedUI.ShaderMenu.appendShaders( nodeMenu.definition() )
 
-		nodeMenu.append( "/Appleseed/Attributes", GafferAppleseed.AppleseedAttributes, searchText = "AppleseedAttributes" )
-		nodeMenu.append( "/Appleseed/Options", GafferAppleseed.AppleseedOptions, searchText = "AppleseedOptions" )
-		nodeMenu.append( "/Appleseed/Render", GafferAppleseed.AppleseedRender, searchText = "AppleseedRender" )
-		nodeMenu.append( "/Appleseed/Interactive Render", GafferAppleseed.InteractiveAppleseedRender, searchText = "InteractiveAppleseedRender" )
-		nodeMenu.append( "/Appleseed/Shader Ball", GafferAppleseed.AppleseedShaderBall, searchText = "AppleseedShaderBall" )
+			GafferAppleseedUI.LightMenu.appendLights( nodeMenu.definition() )
 
-		scriptWindowMenu.append(
-			"/Help/Appleseed/User Docs",
-			{
-				"command" : functools.partial( GafferUI.showURL, "https://github.com/appleseedhq/appleseed/wiki" ),
-			}
-		)
+			nodeMenu.append( "/Appleseed/Attributes", GafferAppleseed.AppleseedAttributes, searchText = "AppleseedAttributes" )
+			nodeMenu.append( "/Appleseed/Options", GafferAppleseed.AppleseedOptions, searchText = "AppleseedOptions" )
+			nodeMenu.append( "/Appleseed/Render", GafferAppleseed.AppleseedRender, searchText = "AppleseedRender" )
+			nodeMenu.append( "/Appleseed/Interactive Render", GafferAppleseed.InteractiveAppleseedRender, searchText = "InteractiveAppleseedRender" )
+			nodeMenu.append( "/Appleseed/Shader Ball", GafferAppleseed.AppleseedShaderBall, searchText = "AppleseedShaderBall" )
+
+			scriptWindowMenu.append(
+				"/Help/Appleseed/User Docs",
+				{
+					"command" : functools.partial( GafferUI.showURL, "https://github.com/appleseedhq/appleseed/wiki" ),
+				}
+			)
 
 	except Exception, m :
 

--- a/startup/gui/outputs.py
+++ b/startup/gui/outputs.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import os
+
 import IECore
 import IECoreScene
 
@@ -189,62 +191,64 @@ with IECore.IgnoredExceptions( ImportError ) :
 
 # Add standard appleseed AOVs
 
-with IECore.IgnoredExceptions( ImportError ) :
+if os.environ.get( "GAFFERAPPLESEED_HIDE_UI", "" ) != "1" :
 
-	# If appleseed isn't available for any reason, this will fail
-	# and we won't add any unnecessary output definitions.
-	import GafferAppleseed
+	with IECore.IgnoredExceptions( ImportError ) :
 
-	for aov in [
-		"diffuse",
-		"glossy",
-		"emission",
-		"direct_diffuse",
-		"indirect_diffuse",
-		"direct_glossy",
-		"indirect_glossy",
-		"albedo",
+		# If appleseed isn't available for any reason, this will fail
+		# and we won't add any unnecessary output definitions.
+		import GafferAppleseed
 
-		"npr_contour",
-		"npr_shading",
+		for aov in [
+			"diffuse",
+			"glossy",
+			"emission",
+			"direct_diffuse",
+			"indirect_diffuse",
+			"direct_glossy",
+			"indirect_glossy",
+			"albedo",
 
-		"depth",
-		"normal",
-		"position",
-		"uv",
+			"npr_contour",
+			"npr_shading",
 
-		"pixel_variation",
-		"pixel_sample_count",
-		"pixel_time",
-		"invalid_samples"
-	] :
+			"depth",
+			"normal",
+			"position",
+			"uv",
 
-		label = aov.replace( "_", " " ).title().replace( " ", "_" )
-		aovModel = aov + "_aov"
+			"pixel_variation",
+			"pixel_sample_count",
+			"pixel_time",
+			"invalid_samples"
+		] :
 
-		GafferScene.Outputs.registerOutput(
-			"Interactive/Appleseed/" + label,
-			IECoreScene.Output(
-				aov,
-				"ieDisplay",
-				aovModel,
-				{
-					"driverType" : "ClientDisplayDriver",
-					"displayHost" : "localhost",
-					"displayPort" : "${image:catalogue:port}",
-					"remoteDisplayType" : "GafferImage::GafferDisplayDriver",
-				}
+			label = aov.replace( "_", " " ).title().replace( " ", "_" )
+			aovModel = aov + "_aov"
+
+			GafferScene.Outputs.registerOutput(
+				"Interactive/Appleseed/" + label,
+				IECoreScene.Output(
+					aov,
+					"ieDisplay",
+					aovModel,
+					{
+						"driverType" : "ClientDisplayDriver",
+						"displayHost" : "localhost",
+						"displayPort" : "${image:catalogue:port}",
+						"remoteDisplayType" : "GafferImage::GafferDisplayDriver",
+					}
+				)
 			)
-		)
 
-		GafferScene.Outputs.registerOutput(
-			"Batch/Appleseed/" + label,
-			IECoreScene.Output(
-				"${project:rootDirectory}/renders/${script:name}/%s/%s.####.exr" % ( aov, aov ),
-				"exr",
-				aovModel
+			GafferScene.Outputs.registerOutput(
+				"Batch/Appleseed/" + label,
+				IECoreScene.Output(
+					"${project:rootDirectory}/renders/${script:name}/%s/%s.####.exr" % ( aov, aov ),
+					"exr",
+					aovModel
+				)
 			)
-		)
 
 # Publish the Catalogue port number as a context variable, so we can refer
 # to it easily in output definitions.

--- a/startup/gui/shaderTweaks.py
+++ b/startup/gui/shaderTweaks.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import os
+
 import IECore
 import Gaffer
 import GafferScene
@@ -58,15 +60,17 @@ with IECore.IgnoredExceptions( ImportError ) :
 
 	] )
 
-with IECore.IgnoredExceptions( ImportError ) :
+if os.environ.get( "GAFFERAPPLESEED_HIDE_UI", "" ) != "1" :
 
-	import GafferAppleseed
+	with IECore.IgnoredExceptions( ImportError ) :
 
-	__registerShaderPresets( [
+		import GafferAppleseed
 
-		( "Appleseed Light", "as:light" ),
+		__registerShaderPresets( [
 
-	] )
+			( "Appleseed Light", "as:light" ),
+
+		] )
 
 with IECore.IgnoredExceptions( ImportError ) :
 

--- a/startup/gui/viewer.py
+++ b/startup/gui/viewer.py
@@ -37,6 +37,7 @@
 import functools
 import imath
 import inspect
+import os
 
 import IECore
 import IECoreScene
@@ -172,21 +173,23 @@ with IECore.IgnoredExceptions( ImportError ) :
 
 	] )
 
-with IECore.IgnoredExceptions( ImportError ) :
+if os.environ.get( "GAFFERAPPLESEED_HIDE_UI", "" ) != "1" :
 
-	import GafferAppleseed
+	with IECore.IgnoredExceptions( ImportError ) :
 
-	__registerShadingModes( [
+		import GafferAppleseed
 
-		( "Diagnostic/Appleseed/Shader Assignment", GafferScene.AttributeVisualiser, { "attributeName" : "osl:surface", "mode" : GafferScene.AttributeVisualiser.Mode.ShaderNodeColor } ),
-		( "Diagnostic/Appleseed/Camera Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "as:visibility:camera" } ),
-		( "Diagnostic/Appleseed/Shadow Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "as:visibility:shadow" } ),
-		( "Diagnostic/Appleseed/Diffuse Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "as:visibility:diffuse" } ),
-		( "Diagnostic/Appleseed/Specular Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "as:visibility:specular" } ),
-		( "Diagnostic/Appleseed/Glossy Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "as:visibility:glossy" } ),
-		( "Diagnostic/Appleseed/Photon Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "as:visibility:light" } ),
+		__registerShadingModes( [
 
-	] )
+			( "Diagnostic/Appleseed/Shader Assignment", GafferScene.AttributeVisualiser, { "attributeName" : "osl:surface", "mode" : GafferScene.AttributeVisualiser.Mode.ShaderNodeColor } ),
+			( "Diagnostic/Appleseed/Camera Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "as:visibility:camera" } ),
+			( "Diagnostic/Appleseed/Shadow Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "as:visibility:shadow" } ),
+			( "Diagnostic/Appleseed/Diffuse Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "as:visibility:diffuse" } ),
+			( "Diagnostic/Appleseed/Specular Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "as:visibility:specular" } ),
+			( "Diagnostic/Appleseed/Glossy Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "as:visibility:glossy" } ),
+			( "Diagnostic/Appleseed/Photon Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "as:visibility:light" } ),
+
+		] )
 
 
 # Add catalogue hotkeys to viewers, eg: up/down navigation


### PR DESCRIPTION
For facilities not using Appleseed in production. There are a lot of name collisions with Arnold nodes that makes finding the right one harder.

We still load Appleseed so it can be used for OSL shader previews, etc.