### PR TITLE
Light texture visualisation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -51,6 +51,7 @@ API
 - FlatImageSource : Added a new base class to help in implementing image sources which generate flat data.
 - FlatImageProcessor : Added a new base class to help in implementing image processors which don't support deep data.
 - GafferOSL : Added ShadingEngineAlgo to simplify the generation of shading point data for images, and rendering networks to textures.
+- StandardLightVisualiser : Added `surfaceTexture` virtual method to allow derived classes to provide alternate surface representations (#3407).
 
 Breaking Changes
 ----------------
@@ -66,6 +67,8 @@ Breaking Changes
 - Handle : `LinearDrag::position` and `PlanarDrag::position` are no longer `const` methods. `RotateHandle`, `ScaleHandle` and `TranslateHandle` value provider methods loose `const`-ness accordingly.
 - ImagePlug : Removed `image()` and `imageHash()` methods. These are now available in the ImageAlgo namespace.
 - ImageNode : Added virtual methods.
+- StandardLightVisualiser : Removed protected members `faceCameraVertexSource` and `environmentSphere` (#3407).
+- Light : Added plugs and accessors for `visualiserShaded` (#3407).
 
 0.55.x.x (relative to 0.55.1.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -68,8 +68,10 @@ Breaking Changes
 - Handle : `LinearDrag::position` and `PlanarDrag::position` are no longer `const` methods. `RotateHandle`, `ScaleHandle` and `TranslateHandle` value provider methods loose `const`-ness accordingly.
 - ImagePlug : Removed `image()` and `imageHash()` methods. These are now available in the ImageAlgo namespace.
 - ImageNode : Added virtual methods.
+- Light :
+  - Changed `Light::computeLight` return type to const (#3407).
+  - Added plug and accessors for `visualiserShaded` (#3407).
 - StandardLightVisualiser : Removed protected members `faceCameraVertexSource` and `environmentSphere` (#3407).
-- Light : Added plugs and accessors for `visualiserShaded` (#3407).
 
 0.55.x.x (relative to 0.55.1.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -24,6 +24,7 @@ Improvements
   - Added generic support for precise tool adjustments by holding down <kbd>Shift</kbd> whilst adjusting tool handles (#3324).
   - Changed the behaviour of existing precise tool handle adjustments such that the current handle position is maintained when the <kbd>Shift</kbd> key is depressed (#3324).
 - UI : Added the Gaffer version to the window title.
+- Viewer : Extended viewer color-correction to light textures, such that they now match rendered results (#3407).
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,7 @@ Fixes
 - CopyAttributes : Fixed bug loading scripts saved prior to version 0.55.0.0.
 - Mix : Fix wrong behaviour outside of mask data window.
 - ImageStats : Fixed bug that would return 1.0 if the 4th channel was missing. Missing channels now always return 0.0.
+- Viewer : Fixed bug that caused the StandardLightVisualiser to be used instead of render-specific ones (#3407).
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -49,6 +49,7 @@ API
   - Added `throwIfSampleOffsetsMismatch()` method.
 - FlatImageSource : Added a new base class to help in implementing image sources which generate flat data.
 - FlatImageProcessor : Added a new base class to help in implementing image processors which don't support deep data.
+- GafferOSL : Added ShadingEngineAlgo to simplify the generation of shading point data for images, and rendering networks to textures.
 
 Breaking Changes
 ----------------

--- a/SConstruct
+++ b/SConstruct
@@ -810,7 +810,7 @@ libraries = {
 
 	"GafferArnoldUI" : {
 		"envAppends" : {
-			"LIBS" : [ "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "Gaffer", "GafferOSL", "GafferScene", "GafferSceneUI" ],
+			"LIBS" : [ "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "Gaffer", "GafferScene", "GafferOSL", "GafferSceneUI" ],
 			},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferArnoldUI", "GafferSceneUI" ],

--- a/include/GafferAppleseed/AppleseedLight.h
+++ b/include/GafferAppleseed/AppleseedLight.h
@@ -62,7 +62,7 @@ class GAFFERAPPLESEED_API AppleseedLight : public GafferScene::Light
 	protected :
 
 		void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECoreScene::ShaderNetworkPtr computeLight( const Gaffer::Context *context ) const override;
+		IECoreScene::ConstShaderNetworkPtr computeLight( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferArnold/ArnoldLight.h
+++ b/include/GafferArnold/ArnoldLight.h
@@ -41,9 +41,12 @@
 #include "GafferArnold/TypeIds.h"
 
 #include "GafferScene/Light.h"
+#include "GafferScene/ShaderPlug.h"
 
 namespace GafferArnold
 {
+
+class ArnoldShader;
 
 class GAFFERARNOLD_API ArnoldLight : public GafferScene::Light
 {
@@ -55,6 +58,8 @@ class GAFFERARNOLD_API ArnoldLight : public GafferScene::Light
 		ArnoldLight( const std::string &name=defaultName<ArnoldLight>() );
 		~ArnoldLight() override;
 
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
 		void loadShader( const std::string &shaderName );
 
 	protected :
@@ -64,8 +69,11 @@ class GAFFERARNOLD_API ArnoldLight : public GafferScene::Light
 
 	private :
 
-		Gaffer::StringPlug *shaderNamePlug();
-		const Gaffer::StringPlug *shaderNamePlug() const;
+		ArnoldShader *shaderNode();
+		const ArnoldShader *shaderNode() const;
+
+		GafferScene::ShaderPlug *shaderInPlug();
+		const GafferScene::ShaderPlug *shaderInPlug() const;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferArnold/ArnoldLight.h
+++ b/include/GafferArnold/ArnoldLight.h
@@ -60,7 +60,7 @@ class GAFFERARNOLD_API ArnoldLight : public GafferScene::Light
 	protected :
 
 		void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECoreScene::ShaderNetworkPtr computeLight( const Gaffer::Context *context ) const override;
+		IECoreScene::ConstShaderNetworkPtr computeLight( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferOSL/OSLLight.h
+++ b/include/GafferOSL/OSLLight.h
@@ -101,7 +101,7 @@ class GAFFEROSL_API OSLLight : public GafferScene::Light
 		IECore::ConstCompoundObjectPtr computeAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const override;
 
 		void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECoreScene::ShaderNetworkPtr computeLight( const Gaffer::Context *context ) const override;
+		IECoreScene::ConstShaderNetworkPtr computeLight( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferOSL/ShadingEngineAlgo.h
+++ b/include/GafferOSL/ShadingEngineAlgo.h
@@ -1,0 +1,69 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Cinesite VFX Ltd. nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+#ifndef GAFFEROSL_SHADINGENGINEALGO_H
+#define GAFFEROSL_SHADINGENGINEALGO_H
+
+#include "GafferOSL/ShadingEngine.h"
+
+namespace GafferOSL
+{
+
+/// ShadingEngineAlgo provides convenience functions to aid the use of
+/// GafferOSL::ShadingEngine.
+namespace ShadingEngineAlgo
+{
+
+/// Returns an RGB CompoundData image representation of the specified shading
+/// network output. The output doesn't have to be the networks output and can
+/// reference the output of any shader within the network that can be connected
+/// to a color input. A copy of the network is taken for shading. Return is as
+/// per shadedPointsToImageData, may throw as per ShadingEngine::shade.
+///
+/// Note: P is set to ( 0, 0, 0 ) for all shading points.
+///
+/// Note: Shading carried out by this method is not cancellable, and uses a
+/// default context. As such, any shaders in the network that query time
+/// will use the default frame of 1. This is to allow use in cancel-unaware
+/// code paths.
+GAFFEROSL_API IECore::CompoundDataPtr shadeUVTexture(
+	const IECoreScene::ShaderNetwork *shaderNetwork,
+	const Imath::V2i &resolution,
+	IECoreScene::ShaderNetwork::Parameter output = IECoreScene::ShaderNetwork::Parameter()
+);
+
+}
+
+}
+
+#endif // GAFFEROSL_SHADINGENGINEALGO_H

--- a/include/GafferScene/Light.h
+++ b/include/GafferScene/Light.h
@@ -79,7 +79,7 @@ class GAFFERSCENE_API Light : public ObjectSource
 		/// Must be implemented by derived classes to hash and generate the light to be placed
 		/// in the scene graph.
 		virtual void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
-		virtual IECoreScene::ShaderNetworkPtr computeLight( const Gaffer::Context *context ) const = 0;
+		virtual IECoreScene::ConstShaderNetworkPtr computeLight( const Gaffer::Context *context ) const = 0;
 
 		Gaffer::FloatPlug *visualiserScalePlug();
 		const Gaffer::FloatPlug *visualiserScalePlug() const;

--- a/include/GafferScene/Light.h
+++ b/include/GafferScene/Light.h
@@ -83,6 +83,8 @@ class GAFFERSCENE_API Light : public ObjectSource
 
 		Gaffer::FloatPlug *visualiserScalePlug();
 		const Gaffer::FloatPlug *visualiserScalePlug() const;
+		Gaffer::BoolPlug *visualiserShadedPlug();
+		const Gaffer::BoolPlug *visualiserShadedPlug() const;
 
 	private :
 

--- a/include/GafferSceneTest/TestLight.h
+++ b/include/GafferSceneTest/TestLight.h
@@ -58,7 +58,7 @@ class GAFFERSCENETEST_API TestLight : public GafferScene::Light
 	protected :
 
 		void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECoreScene::ShaderNetworkPtr computeLight( const Gaffer::Context *context ) const override;
+		IECoreScene::ConstShaderNetworkPtr computeLight( const Gaffer::Context *context ) const override;
 
 };
 

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -69,24 +69,45 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 
 	protected :
 
-		static const char *faceCameraVertexSource();
-
 		static IECoreGL::ConstRenderablePtr ray();
 		static IECoreGL::ConstRenderablePtr pointRays( float radius = 0 );
 		static IECoreGL::ConstRenderablePtr distantRays();
 		static IECoreGL::ConstRenderablePtr spotlightCone( float innerAngle, float outerAngle, float lensRadius );
-		static IECoreGL::ConstRenderablePtr environmentSphere( const Imath::Color3f &color, const std::string &textureFileName, int maxTextureResolution );
+
 		static IECoreGL::ConstRenderablePtr colorIndicator( const Imath::Color3f &color, bool cameraFacing = true );
+
+		// This method should be overridden by any sub-classes that wish to
+		// provide an alternate surface texture for area-based lights.
+		//
+		// It should return one of :
+		//  - nullptr : No texture applicable
+		//  - StringData : The file path of a texture.
+		//  - CompoundData : An image representation of the texture data, as
+		//      supported by IECoreGL::ToGLTextureConverter.
+		//
+		// The default implementation looks for a string parameter registered
+		// as the "textureNameParameter" for the supplied shader network's
+		// output shader.
+		virtual IECore::DataPtr surfaceTexture( const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, int maxTextureResolution ) const;
 
 	private :
 
 		/// \todo Expose publicly once we have enough uses to dictate
 		/// the most general set of parameters.
-		static IECoreGL::ConstRenderablePtr quadShape();
-		static IECoreGL::ConstRenderablePtr diskShape( float radius );
-		static IECoreGL::ConstRenderablePtr cylinderShape( float radius );
+		static IECoreGL::ConstRenderablePtr cylinderShape( float radius, bool filled = false, const Imath::Color3f &color = Imath::Color3f( 1.0f ) );
 		static IECoreGL::ConstRenderablePtr pointShape( float radius );
 		static IECoreGL::ConstRenderablePtr cylinderRays( float radius );
+
+		// textureData should be as per return type of surfaceTexture
+
+		static IECoreGL::ConstRenderablePtr environmentSphereWireframe( float radius, const Imath::Vec3<bool> &axisRings );
+		static IECoreGL::ConstRenderablePtr environmentSphereSurface( IECore::ConstDataPtr textureData, int textureMaxResolution, const Imath::Color3f &fallbackColor  );
+
+		static IECoreGL::ConstRenderablePtr quadWireframe();
+		static IECoreGL::ConstRenderablePtr quadSurface( IECore::ConstDataPtr textureData, int textureMaxResolution, const Imath::Color3f &fallbackColor );
+
+		static IECoreGL::ConstRenderablePtr diskWireframe( float radius );
+		static IECoreGL::ConstRenderablePtr diskSurface( float radius, IECore::ConstDataPtr textureData, int textureMaxResolution, const Imath::Color3f &fallbackColor );
 
 		static LightVisualiser::LightVisualiserDescription<StandardLightVisualiser> g_description;
 

--- a/python/GafferArnoldUI/ArnoldLightUI.py
+++ b/python/GafferArnoldUI/ArnoldLightUI.py
@@ -34,8 +34,14 @@
 #
 ##########################################################################
 
+import functools
+
 import Gaffer
 import GafferArnold
+
+# Defer parameter metadata lookups to the internal shader node
+# aside from nodule:type, which we handle manually to prevent
+# some connectable plugs appearing.
 
 ## \todo Refactor the GafferScene::Light base class so this can be
 # registered there, and work for all subclasses. The main issue is that
@@ -45,7 +51,7 @@ def __parameterUserDefault( plug ) :
 
 	light = plug.node()
 	return Gaffer.Metadata.value(
-		"ai:light:" + light["__shaderName"].getValue() + ":" + plug.relativeName( light["parameters"] ),
+		"ai:light:" + light["__shader"]["name"].getValue() + ":" + plug.relativeName( light["parameters"] ),
 		"userDefault"
 	)
 
@@ -55,6 +61,12 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+		"parameters..." : [
+
+			"userDefault", __parameterUserDefault,
+
+		],
+
 		"parameters.*" : [
 
 			# Most light parameters are not connectable.
@@ -62,16 +74,10 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"parameters..." : [
-
-			"userDefault", __parameterUserDefault,
-
-		],
-
 		"parameters.color" : [
 
 			# The color parameter on quad and skydome lights is connectable.
-			"nodule:type", lambda plug : "GafferUI::StandardNodule" if plug.node()["__shaderName"].getValue() in ( "quad_light", "skydome_light" ) else ""
+			"nodule:type", lambda plug : "GafferUI::StandardNodule" if plug.node()["__shader"]["name"].getValue() in ( "quad_light", "skydome_light" ) else ""
 
 		],
 

--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -307,7 +307,7 @@ def __nodeDescription( node ) :
 			"""Loads shaders for use in Arnold renders. Use the ShaderAssignment node to assign shaders to objects in the scene.""",
 		)
 	else :
-		return __metadata[node["__shaderName"].getValue()].get(
+		return __metadata[node["__shader"]["name"].getValue()].get(
 			"description",
 			"""Loads an Arnold light shader and uses it to output a scene with a single light."""
 		)
@@ -318,7 +318,7 @@ def __nodeMetadata( node, name ) :
 		key = node["name"].getValue()
 	else :
 		# Node type is ArnoldLight.
-		key = node["__shaderName"].getValue()
+		key = node["__shader"]["name"].getValue()
 
 	return __metadata[key].get( name )
 
@@ -339,7 +339,7 @@ def __plugMetadata( plug, name ) :
 		key = plug.node()["name"].getValue() + "." + plug.relativeName( node )
 	else :
 		# Node type is ArnoldLight.
-		key = plug.node()["__shaderName"].getValue() + "." + plug.relativeName( node )
+		key = plug.node()["__shader"]["name"].getValue() + "." + plug.relativeName( node )
 
 	return __metadata[key].get( name )
 

--- a/python/GafferOSLTest/ShadingEngineAlgoTest.py
+++ b/python/GafferOSLTest/ShadingEngineAlgoTest.py
@@ -1,0 +1,139 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+import os
+import sys
+
+import IECore
+import IECoreScene
+
+import Gaffer
+import GafferOSL
+import GafferOSLTest
+
+class ShadingEngineAlgoTest( GafferOSLTest.OSLTestCase ) :
+
+	def testShadeTexture( self ) :
+
+		uvShader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/uv.osl" )
+		constant = self.compileShader( os.path.dirname( __file__ ) + "/shaders/constant.osl" )
+		addShader = self.compileShader( os.path.dirname( __file__ ) + "/shaders/add.osl" )
+
+		n = IECoreScene.ShaderNetwork(
+			shaders = {
+				"uvs" : IECoreScene.Shader( uvShader, "osl:shader" ),
+				"add" : IECoreScene.Shader( addShader, "osl:shader", { "b" : 1.0 } ),
+				"constant" : IECoreScene.Shader( constant, "osl:surface" ),
+			},
+			connections = [
+				( ( "uvs", "out" ), ( "add", "a" ) ),
+				( ( "add", "out" ), ( "constant", "Cs" ) )
+			],
+			output = "constant"
+		)
+
+		resolution = imath.V2i( 2, 4 )
+		window = imath.Box2i( imath.V2i( 0 ), imath.V2i( 1, 3 ) )
+		u =  ( 0.25, 0.75, 0.25, 0.75, 0.25, 0.75, 0.25, 0.75 )
+		v =  ( 0.125, 0.125, 0.375, 0.375, 0.625, 0.625, 0.875, 0.875 )
+		b = [ 0.0 ] * 8
+		uu = [ x + 1.0 for x in u ]
+		vv = [ x + 1.0 for x in v ]
+		bb = [ 1.0 ] * 8
+
+		# Test None passed as ptr
+
+		with self.assertRaisesRegexp( Exception, "Python argument types .*" ) :
+			GafferOSL.ShadingEngineAlgo.shadeUVTexture( None, resolution )
+
+		# Test network output
+
+		imageData = GafferOSL.ShadingEngineAlgo.shadeUVTexture( n, resolution )
+		self.assertEqual( sorted( imageData.keys() ), sorted( ( "dataWindow", "displayWindow", "channels" ) ))
+
+		self.assertEqual( imageData["dataWindow"], IECore.Box2iData( window ) )
+		self.assertEqual( imageData["displayWindow"], IECore.Box2iData( window ) )
+
+		c = imageData["channels"]
+		self.assertEqual( sorted( c.keys() ), sorted( ( "R", "G", "B" ) ) )
+		self.assertEqual( c["R"], IECore.FloatVectorData( uu ) )
+		self.assertEqual( c["G"], IECore.FloatVectorData( vv ) )
+		self.assertEqual( c["B"], IECore.FloatVectorData( bb ) )
+
+		# Test invalid resolutions
+
+		with self.assertRaises( Exception ) :
+			GafferOSL.ShadingEngineAlgo.imageShadingPoints( imath.V2i( 0, 0 ) )
+
+		with self.assertRaises( Exception ) :
+			GafferOSL.ShadingEngineAlgo.imageShadingPoints( imath.V2i( -1, 0 ) )
+
+		with self.assertRaises( Exception ) :
+			GafferOSL.ShadingEngineAlgo.imageShadingPoints( imath.V2i( 0, -1 ) )
+
+		# Test alternate output
+
+		imageData = GafferOSL.ShadingEngineAlgo.shadeUVTexture( n, resolution, ( "uvs", "out" ) )
+
+		c = imageData["channels"]
+		self.assertEqual( sorted( c.keys() ), sorted( ( "R", "G", "B" ) ) )
+		self.assertEqual( c["R"], IECore.FloatVectorData( u ) )
+		self.assertEqual( c["G"], IECore.FloatVectorData( v ) )
+		self.assertEqual( c["B"], IECore.FloatVectorData( b ) )
+
+		# Test network without surface as output
+
+		n = IECoreScene.ShaderNetwork(
+			shaders = {
+				"uvs" : IECoreScene.Shader( uvShader, "osl:shader" ),
+			},
+			output = ( "uvs", "out" )
+		)
+
+		imageData = GafferOSL.ShadingEngineAlgo.shadeUVTexture( n, resolution )
+
+		self.assertEqual( imageData["dataWindow"], IECore.Box2iData( window ) )
+		self.assertEqual( imageData["displayWindow"], IECore.Box2iData( window ) )
+
+		c = imageData["channels"]
+		self.assertEqual( sorted( c.keys() ), sorted( ( "R", "G", "B" ) ) )
+		self.assertEqual( c["R"], IECore.FloatVectorData( u ) )
+		self.assertEqual( c["G"], IECore.FloatVectorData( v ) )
+		self.assertEqual( c["B"], IECore.FloatVectorData( b ) )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferOSLTest/__init__.py
+++ b/python/GafferOSLTest/__init__.py
@@ -37,6 +37,7 @@
 from OSLTestCase import OSLTestCase
 from OSLShaderTest import OSLShaderTest
 from ShadingEngineTest import ShadingEngineTest
+from ShadingEngineAlgoTest import ShadingEngineAlgoTest
 from OSLImageTest import OSLImageTest
 from OSLObjectTest import OSLObjectTest
 from OSLExpressionEngineTest import OSLExpressionEngineTest

--- a/python/GafferOSLTest/shaders/uv.osl
+++ b/python/GafferOSLTest/shaders/uv.osl
@@ -1,0 +1,7 @@
+shader uv
+(
+output color out = 0
+)
+{
+	out = color( u, v, 0 );
+}

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -100,6 +100,18 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Visualisation",
 
+		],
+
+		"visualiserShaded" : [
+
+			"description",
+			"""
+			Disable to restrict visualisations of this light to wireframe outlines.
+			""",
+
+			"label", "Shaded",
+			"layout:section", "Visualisation",
+
 		]
 
 	}

--- a/shaders/__viewer/__arnold_add.osl
+++ b/shaders/__viewer/__arnold_add.osl
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+//
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Cinesite VFX Ltd nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+shader __arnold_add
+(
+	color input1 = 0,
+	color input2 = 0,
+
+	output color out = 0
+)
+{
+	out = input1 + input2;
+}

--- a/shaders/__viewer/__arnold_blackbody.osl
+++ b/shaders/__viewer/__arnold_blackbody.osl
@@ -1,0 +1,53 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+//
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Cinesite VFX Ltd nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+shader __arnold_blackbody
+(
+	float temperature = 6500,
+	int normalize_ = 0,
+	float intensity = 1,
+
+	output color out = 0
+)
+{
+	color c = blackbody( temperature ) / M_PI;
+	if ( normalize_ )
+		c = normalize( c );
+
+	out = c * intensity;
+}
+

--- a/shaders/__viewer/__arnold_color_correct.osl
+++ b/shaders/__viewer/__arnold_color_correct.osl
@@ -1,0 +1,63 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+//
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Cinesite VFX Ltd nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+shader __arnold_color_correct
+(
+	color input = 0,
+
+	float saturation = 1,
+
+	float exposure = 0,
+
+	color multiply = 1,
+	color add = 0,
+
+	output color out = 0 [[ string correspondingInput = "input" ]]
+)
+{
+	color c = input;
+	if( saturation != 1.0 )
+	{
+		c = transformc( "rgb", "hsl", c );
+		c[1] *= saturation;
+		c = transformc( "hsl", "rgb", c );
+	}
+
+	c *= pow( 2, exposure );
+
+	out = ( c * multiply ) + add;
+}

--- a/shaders/__viewer/__arnold_image.osl
+++ b/shaders/__viewer/__arnold_image.osl
@@ -1,0 +1,94 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+//
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Cinesite VFX Ltd nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "color4.h"
+
+shader __arnold_image
+(
+	string filename = "",
+	int single_channel = 0,
+	int start_channel = 0,
+
+	float sscale = 1.0,
+	float tscale = 1.0,
+	int sflip = 0,
+	int tflip = 0,
+	float soffset = 0,
+	float toffset = 0,
+	int swapst = 0,
+
+	color multiply = 1,
+	color add = 0,
+
+	string swrap = "default",
+	string twrap = "default",
+
+	color4 missing_texture_color = {color(0), 1},
+
+	output color out = 0
+)
+{
+	float uu = u * sscale;
+	float vv = v * tscale;
+
+	if( sflip > 0 )
+		uu = 1.0 - uu;
+	// Arnold / OSL have inverted v
+	if( tflip == 0 )
+		vv = 1.0 - vv;
+
+	uu += soffset;
+	vv += toffset;
+
+	if( swapst > 0 )
+	{
+		float tmp = uu;
+		uu == vv;
+		vv = tmp;
+	}
+
+	color t = texture(
+		filename, uu, vv,
+		"missingcolor", missing_texture_color.rgb, "missingalpha", missing_texture_color.a,
+		"swrap", swrap, "twrap", twrap
+	);
+
+	if( single_channel > 0 )
+		t = color( t[ start_channel ] );
+
+	out = ( t * multiply ) + add;
+}

--- a/shaders/__viewer/__arnold_multiply.osl
+++ b/shaders/__viewer/__arnold_multiply.osl
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+//
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Cinesite VFX Ltd nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+shader __arnold_multiply
+(
+	color input1 = 0,
+	color input2 = 0,
+
+	output color out = 0
+)
+{
+	out = input1 * input2;
+}

--- a/src/GafferAppleseed/AppleseedLight.cpp
+++ b/src/GafferAppleseed/AppleseedLight.cpp
@@ -114,7 +114,7 @@ void AppleseedLight::hashLight( const Gaffer::Context *context, IECore::MurmurHa
 	modelPlug()->hash( h );
 }
 
-IECoreScene::ShaderNetworkPtr AppleseedLight::computeLight( const Gaffer::Context *context ) const
+IECoreScene::ConstShaderNetworkPtr AppleseedLight::computeLight( const Gaffer::Context *context ) const
 {
 	IECoreScene::ShaderPtr shader = new IECoreScene::Shader( modelPlug()->getValue(), "as:light" );
 	for( InputValuePlugIterator it( parametersPlug() ); !it.done(); ++it )

--- a/src/GafferArnold/ArnoldLight.cpp
+++ b/src/GafferArnold/ArnoldLight.cpp
@@ -53,6 +53,7 @@
 #include "boost/format.hpp"
 
 using namespace std;
+using namespace IECore;
 using namespace Gaffer;
 using namespace GafferScene;
 using namespace GafferArnold;
@@ -65,94 +66,66 @@ ArnoldLight::ArnoldLight( const std::string &name )
 	:	GafferScene::Light( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	addChild( new StringPlug( "__shaderName", Plug::In, "", Plug::Default & ~Plug::Serialisable ) );
+
+	addChild( new ArnoldShader( "__shader" ) );
+	addChild( new ShaderPlug( "__shaderIn", Plug::In, Plug::Default & ~Plug::Serialisable ) );
+
+	shaderNode()->addChild( new Plug( "out", Plug::Out ) );
+	shaderNode()->typePlug()->setValue( "ai:light" );
+	shaderNode()->parametersPlug()->setFlags( Plug::AcceptsInputs, true );
+	shaderNode()->parametersPlug()->setInput( parametersPlug() );
+
+	shaderInPlug()->setInput( shaderNode()->outPlug() );
 }
 
 ArnoldLight::~ArnoldLight()
 {
 }
 
+ArnoldShader *ArnoldLight::shaderNode()
+{
+	return getChild<ArnoldShader>( g_firstPlugIndex );
+}
+
+const ArnoldShader *ArnoldLight::shaderNode() const
+{
+	return getChild<ArnoldShader>( g_firstPlugIndex );
+}
+
+GafferScene::ShaderPlug *ArnoldLight::shaderInPlug()
+{
+	return getChild<ShaderPlug>( g_firstPlugIndex + 1 );
+}
+
+const GafferScene::ShaderPlug *ArnoldLight::shaderInPlug() const
+{
+	return getChild<ShaderPlug>( g_firstPlugIndex + 1 );
+}
+
 void ArnoldLight::loadShader( const std::string &shaderName )
 {
-	IECoreArnold::UniverseBlock arnoldUniverse( /* writable = */ false );
+	shaderNode()->loadShader( shaderName );
+	shaderNode()->typePlug()->setValue( "ai:light" );
+	shaderInPlug()->setInput( shaderNode()->outPlug() );
+}
 
-	const AtNodeEntry *shader = AiNodeEntryLookUp( AtString( shaderName.c_str() ) );
-	if( !shader )
+void ArnoldLight::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	Light::affects( input, outputs );
+
+	if( input == shaderInPlug() )
 	{
-		throw IECore::Exception( boost::str( boost::format( "Shader \"%s\" not found" ) % shaderName ) );
+		outputs.push_back( outPlug()->attributesPlug() );
 	}
-
-	shaderNamePlug()->setValue( shaderName );
-	ParameterHandler::setupPlugs( shader, parametersPlug() );
 }
 
 void ArnoldLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	for( ValuePlugIterator it( parametersPlug() ); !it.done(); ++it )
-	{
-		if( const Shader *shader = IECore::runTimeCast<const Shader>( (*it)->source()->node() ) )
-		{
-			shader->attributesHash( h );
-		}
-		else
-		{
-			(*it)->hash( h );
-		}
-	}
-	shaderNamePlug()->hash( h );
+	h.append( shaderInPlug()->attributesHash() );
 }
 
-IECoreScene::ShaderNetworkPtr ArnoldLight::computeLight( const Gaffer::Context *context ) const
+IECoreScene::ConstShaderNetworkPtr ArnoldLight::computeLight( const Gaffer::Context *context ) const
 {
-	IECoreScene::ShaderNetworkPtr result = new IECoreScene::ShaderNetwork;
-	IECoreScene::ShaderPtr lightShader = new IECoreScene::Shader( shaderNamePlug()->getValue(), "ai:light" );
-	vector<IECoreScene::ShaderNetwork::Connection> connections;
-	for( InputPlugIterator it( parametersPlug() ); !it.done(); ++it )
-	{
-		if( const Shader *shader = IECore::runTimeCast<const Shader>( (*it)->source()->node() ) )
-		{
-			/// \todo Take the approach that OSLLight takes, and use an internal
-			/// ArnoldShader to do all the shader loading and network generation.
-			/// This would avoid manually splicing in networks here, and would
-			/// generalise nicely to the other Light subclasses too.
-			IECore::ConstCompoundObjectPtr inputAttributes = shader->attributes();
-			IECoreScene::ShaderNetwork const *inputNetwork = inputAttributes->member<const IECoreScene::ShaderNetwork>( "ai:surface" );
-			if( !inputNetwork ) {
-				inputNetwork = inputAttributes->member<const IECoreScene::ShaderNetwork>( "osl:shader" );
-			}
-			if( !inputNetwork || !inputNetwork->size() )
-			{
-				continue;
-			}
-
-			// Add input network into our result.
-			IECoreScene::ShaderNetwork::Parameter sourceParameter = IECoreScene::ShaderNetworkAlgo::addShaders( result.get(), inputNetwork );
-			connections.push_back(
-				{ sourceParameter, { IECore::InternedString(), (*it)->getName() } }
-			);
-		}
-		else if( ValuePlug *valuePlug = IECore::runTimeCast<ValuePlug>( it->get() ) )
-		{
-			lightShader->parameters()[valuePlug->getName()] = PlugAlgo::extractDataFromPlug( valuePlug );
-		}
-	}
-
-	const IECore::InternedString handle = result->addShader( "light", std::move( lightShader ) );
-	for( const auto &c : connections )
-	{
-		result->addConnection( { c.source, { handle, c.destination.name } } );
-	}
-	result->setOutput( handle );
-
-	return result;
-}
-
-Gaffer::StringPlug *ArnoldLight::shaderNamePlug()
-{
-	return getChild<StringPlug>( g_firstPlugIndex );
-}
-
-const Gaffer::StringPlug *ArnoldLight::shaderNamePlug() const
-{
-	return getChild<StringPlug>( g_firstPlugIndex );
+	IECore::ConstCompoundObjectPtr shaderAttributes = shaderInPlug()->attributes();
+	return shaderAttributes->member<const IECoreScene::ShaderNetwork>( "ai:light" );
 }

--- a/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
+++ b/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
@@ -1,0 +1,415 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Cinesite VFX Ltd. nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferSceneUI/StandardLightVisualiser.h"
+
+#include "Gaffer/Metadata.h"
+#include "Gaffer/Private/IECorePreview/LRUCache.h"
+
+#include "GafferOSL/ShadingEngineAlgo.h"
+
+#include "IECoreScene/Shader.h"
+#include "IECoreScene/ShaderNetworkAlgo.h"
+
+#include "IECore/MessageHandler.h"
+#include "IECore/Exception.h"
+#include "IECore/TypedData.h"
+
+#include "OSL/oslquery.h"
+
+#include "boost/algorithm/string/predicate.hpp"
+
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace OSL;
+
+// The ArnoldLightVisualiser provides an implementation of surfaceTexture,
+// rendering a lights color input network via OSL.
+//
+// Native OSL networks are fully supported, with basic conversion of
+// Arnold shaders networks to OSL for common scenarios. If unsupported
+// Arnold shaders are present in the network, a fallback of the last image
+// node found will be used instead:.
+
+namespace
+{
+
+//////////////////////////////////////////////////////////////////////////
+// OSL query LRU cache
+//////////////////////////////////////////////////////////////////////////
+
+const char *g_oslSearchPaths = getenv( "OSL_SHADER_PATHS" );
+
+typedef std::shared_ptr<OSLQuery> OSLQueryPtr;
+
+OSLQueryPtr oslQueryGetter( const std::string &shaderName, size_t &cost )
+{
+	cost = 1;
+
+	OSLQueryPtr result( new OSLQuery() );
+	if( result->open( shaderName, g_oslSearchPaths ? g_oslSearchPaths : "" ) )
+	{
+		return result;
+	}
+
+	return nullptr;
+}
+
+typedef IECorePreview::LRUCache<std::string, OSLQueryPtr, IECorePreview::LRUCachePolicy::Parallel> OSLQueryCache;
+OSLQueryCache g_oslQueryCache( oslQueryGetter, 128 );
+
+//////////////////////////////////////////////////////////////////////////
+// Network conversion helpers
+//////////////////////////////////////////////////////////////////////////
+
+// Re-connects any connections from oldName on oldShader to newName on newShader
+void remapOutputConnections( const InternedString &shader, const InternedString &oldName, const InternedString &newName, ShaderNetwork *network )
+{
+	ShaderNetwork::Parameter newSource( shader, newName );
+
+	ShaderNetwork::ConnectionRange inputConnections = network->outputConnections( shader );
+	for( ShaderNetwork::ConnectionIterator it = inputConnections.begin(); it != inputConnections.end(); )
+	{
+		// Copy and increment now so we still have a valid iterator
+		// if we remove the connection.
+		const ShaderNetwork::Connection connection = *it++;
+
+		if( connection.source.name == oldName )
+		{
+			ShaderNetwork::Parameter dest( connection.destination.shader, connection.destination.name );
+			network->removeConnection( connection );
+			network->addConnection( ShaderNetwork::Connection( newSource, dest ) );
+		}
+	}
+
+	ShaderNetwork::Parameter out = network->getOutput();
+	if( out.shader == shader && out.name == oldName )
+	{
+		network->setOutput( newSource );
+	}
+}
+
+void remapInputConnections( const InternedString &shader, const InternedString &oldName, const InternedString &newName, ShaderNetwork *network )
+{
+	ShaderNetwork::Parameter newDestination( shader, newName );
+
+	ShaderNetwork::ConnectionRange outputConnections = network->inputConnections( shader );
+	for( ShaderNetwork::ConnectionIterator it = outputConnections.begin(); it != outputConnections.end(); )
+	{
+		// Copy and increment now so we still have a valid iterator
+		// if we remove the connection.
+		const ShaderNetwork::Connection connection = *it++;
+
+		if( connection.destination.name == oldName )
+		{
+			ShaderNetwork::Parameter source( connection.source.shader, connection.source.name );
+			network->removeConnection( connection );
+			network->addConnection( ShaderNetwork::Connection( source, newDestination ) );
+		}
+	}
+}
+
+
+
+// Sets outName in outParams if inName is set in inParams.
+// Arnold data types not representable in OSL will be converted accordingly
+void copyAndConvertIfSet( const InternedString &inName,  const CompoundDataMap &inParams, const InternedString &outName, CompoundDataMap &outParams )
+{
+	const auto &it = inParams.find( inName );
+	if( it != inParams.end() )
+	{
+		if( const BoolData *boolData = dynamic_cast<const BoolData *>( it->second.get() ) )
+		{
+			outParams[ outName ] = new IntData( 1 ? boolData->readable() : 0 );
+		}
+		else
+		{
+			outParams[ outName ] = it->second;
+		}
+	};
+}
+
+// Attempts to substitute the Arnold shader with the supplied handle with an
+// OSL stand-in shader. Returns true upon success.
+//
+// If a stand-in is found, any parameters that exist on the stand-in shader
+// will be populated by the value of the equivalent parameter on the source shader.
+// Input/output connections will be remapped if required.
+//
+// The network is left un-touched if no stand-in is available.
+//
+// Stand-in shaders:
+//  - Should be placed be named: __viewer/__arnold_<shaderName>.
+//  - Should have identical parameter names/types.
+//  - Should have a single output called 'out'.
+//  - Arnold bool params should be OSL ints.
+//  - Any param name collisions with OSL reserved words should be suffixed
+//    with an '_'.
+bool substituteWithOSL( const IECore::InternedString &handle, ShaderNetwork *network )
+{
+	const Shader *arnoldShader = network->getShader( handle );
+
+	const std::string oslShaderName = "__viewer/__arnold_" + arnoldShader->getName();
+	const OSLQueryPtr query = g_oslQueryCache.get( oslShaderName );
+	if( !query )
+	{
+		return false;
+	}
+
+	ShaderPtr oslShader = new IECoreScene::Shader();
+	oslShader->setType( "osl:shader" );
+	oslShader->setName( oslShaderName );
+
+	const IECore::CompoundDataMap &aiParams = arnoldShader->parameters();
+	IECore::CompoundDataMap &oslParams = oslShader->parameters();
+	for( size_t i = 0; i < query->nparams(); ++i )
+	{
+		const OSLQuery::Parameter *parameter = query->getparam( i );
+
+		if( parameter->isoutput )
+		{
+			continue;
+		}
+
+		const std::string oslParamName = parameter->name.string();
+
+		// Skip struct members
+		if( oslParamName.find( "." ) != std::string::npos )
+		{
+			continue;
+		}
+
+		// We have to avoid collisions with function names and other language
+		// keywords, so some stand-in shaders prefix param names with '_'.
+		//   eg: normalize -> normalize_
+		std::string aiParamName = oslParamName;
+		if( aiParamName.back() == '_' )
+		{
+			aiParamName.pop_back();
+			remapInputConnections( handle, aiParamName, oslParamName, network );
+		}
+
+		copyAndConvertIfSet( aiParamName, aiParams, oslParamName, oslParams );
+	}
+
+	network->setShader( handle, std::move( oslShader ) );
+	remapOutputConnections( handle, "", "out", network );
+
+	return true;
+}
+
+// Attempts to conform the supplied shaderNetwork such that it only contains
+// OSL shaders. Arnold shaders are re-mapped in-place to their OSL equivalents
+// (if they exist). If any un-converted Arnold shaders remain, it attempts to
+// build a simple network using the first image found. If no image was found
+// then the resulting mixed network is returned.
+IECoreScene::ShaderNetworkPtr conformToOSLNetwork( const IECoreScene::ShaderNetwork::Parameter &output, const IECoreScene::ShaderNetwork *shaderNetwork )
+{
+	ShaderNetworkPtr oslNetwork = shaderNetwork->copy();
+
+	oslNetwork->setOutput( output );
+	ShaderNetworkAlgo::removeUnusedShaders( oslNetwork.get() );
+
+	bool hasUnconvertedArnoldShaders = false;
+	InternedString fallbackImageHandle;
+
+	for( const auto &s : oslNetwork->shaders() )
+	{
+		const Shader *shader = s.second.get();
+		if( boost::starts_with( shader->getType(), "ai:" ) )
+		{
+			if( !substituteWithOSL( s.first, oslNetwork.get() ) )
+			{
+				hasUnconvertedArnoldShaders = true;
+				continue;
+			}
+
+			if( shader->getName() == "image" )
+			{
+				fallbackImageHandle = s.first;
+			}
+		}
+	}
+
+	if( hasUnconvertedArnoldShaders && fallbackImageHandle != "" )
+	{
+		/// TODO: Tell the user which location this is
+		msg( Msg::Warning, "ArnoldLightVisualiser", "Unsupported shaders in network, falling back on " + fallbackImageHandle.string() );
+
+		ShaderNetworkPtr minimalNetwork = new ShaderNetwork();
+		minimalNetwork->addShader( "image", oslNetwork->getShader( fallbackImageHandle ) );
+		minimalNetwork->setOutput( ShaderNetwork::Parameter( "image", "out" ) );
+
+		oslNetwork = minimalNetwork;
+	}
+
+	return oslNetwork;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Surface texture LRU cache
+//////////////////////////////////////////////////////////////////////////
+
+struct SurfaceTextureCacheGetterKey
+{
+	SurfaceTextureCacheGetterKey()
+		: shaderNetwork( nullptr ), resolution( Imath::V2i( 512 ) )
+	{
+	}
+
+	SurfaceTextureCacheGetterKey( const IECoreScene::ShaderNetwork::Parameter &out, const IECoreScene::ShaderNetwork *shaderNetwork, const Imath::V2i &resolution )
+		:	output( out ), shaderNetwork( shaderNetwork ), resolution( resolution )
+	{
+		shaderNetwork->hash( hash );
+		hash.append( resolution.x );
+		hash.append( resolution.y );
+		hash.append( output.shader );
+		hash.append( output.name );
+	}
+
+	operator const IECore::MurmurHash & () const
+	{
+		return hash;
+	}
+
+	IECoreScene::ShaderNetwork::Parameter output;
+	const IECoreScene::ShaderNetwork *shaderNetwork;
+	Imath::V2i resolution;
+	MurmurHash hash;
+};
+
+CompoundDataPtr surfaceTextureGetter( const SurfaceTextureCacheGetterKey &key, size_t &cost )
+{
+	cost = key.resolution.x * key.resolution.y * 3 * 4; // 3 x 32bit float channels;
+
+	ShaderNetworkPtr textureNetwork = conformToOSLNetwork( key.output, key.shaderNetwork );
+	return GafferOSL::ShadingEngineAlgo::shadeUVTexture( textureNetwork.get(), key.resolution );
+}
+
+typedef IECorePreview::LRUCache<IECore::MurmurHash, CompoundDataPtr, IECorePreview::LRUCachePolicy::Parallel, SurfaceTextureCacheGetterKey> SurfaceTextureCache;
+// Cache cost is in bytes
+SurfaceTextureCache g_surfaceTextureCache( surfaceTextureGetter, 1024 * 1024 * 64 );
+
+//////////////////////////////////////////////////////////////////////////
+// ArnoldLightVisualiser implementation
+//////////////////////////////////////////////////////////////////////////
+
+class GAFFERSCENEUI_API ArnoldLightVisualiser : public GafferSceneUI::StandardLightVisualiser
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( ArnoldLightVisualiser )
+
+		ArnoldLightVisualiser();
+		~ArnoldLightVisualiser() override;
+
+	protected :
+
+		IECore::DataPtr surfaceTexture( const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, int maxTextureResolution ) const override;
+
+	private :
+
+		static LightVisualiser::LightVisualiserDescription<ArnoldLightVisualiser> g_description;
+
+};
+
+IE_CORE_DECLAREPTR( ArnoldLightVisualiser )
+
+
+IECoreGLPreview::LightVisualiser::LightVisualiserDescription<ArnoldLightVisualiser> ArnoldLightVisualiser::g_description( "ai:light", "*" );
+
+
+ArnoldLightVisualiser::ArnoldLightVisualiser()
+{
+}
+
+ArnoldLightVisualiser::~ArnoldLightVisualiser()
+{
+}
+
+IECore::DataPtr ArnoldLightVisualiser::surfaceTexture( const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, int maxTextureResolution ) const
+{
+	const ShaderNetwork::Parameter &output = shaderNetwork->getOutput();
+	if( !output )
+	{
+		return nullptr;
+	}
+
+	const IECoreScene::Shader *outputShader = shaderNetwork->outputShader();
+	const IECore::InternedString metadataTarget = outputShader->getType() + ":" + outputShader->getName();
+
+	ConstStringDataPtr colorParamData = Gaffer::Metadata::value<StringData>( metadataTarget, "colorParameter" );
+	if( !colorParamData )
+	{
+		return nullptr;
+	}
+
+	ShaderNetwork::Parameter colorParam( output.shader, colorParamData->readable() );
+	const ShaderNetwork::Parameter &colorInput = shaderNetwork->input( colorParam );
+	if( !colorInput )
+	{
+		return nullptr;
+	}
+
+	// skydome and quad_light may specify a resolution, so use that.
+	const IntData *textureResolutionData = shaderNetwork->outputShader()->parametersData()->member<IntData>( "resolution" );
+	int textureResolution = textureResolutionData ? textureResolutionData->readable() : 512;
+	Imath::V2i resolution( std::min( textureResolution, maxTextureResolution ) );
+
+	ConstStringDataPtr typeData = Gaffer::Metadata::value<StringData>( metadataTarget, "type" );
+	if( typeData && typeData->readable() == "environment" )
+	{
+		resolution.y /= 2;
+	}
+
+	CompoundDataPtr surfaceTexture = nullptr;
+	try
+	{
+		surfaceTexture = g_surfaceTextureCache.get( SurfaceTextureCacheGetterKey( colorInput, shaderNetwork, resolution ) );
+	}
+	catch( const Exception &e )
+	{
+		msg( Msg::Warning, "ArnoldLightVisualiser", e.what() );
+		return nullptr;
+	}
+
+	return surfaceTexture;
+}
+
+}
+

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -115,12 +115,13 @@ struct OSLTextureCacheGetterKey
 
 CompoundDataPtr getter( const OSLTextureCacheGetterKey &key, size_t &cost )
 {
-	cost = 1;
+	// make the cost be image data in bytes
+	cost = key.resolution * key.resolution * 3 * 4;
 	return GafferOSL::ShadingEngineAlgo::shadeUVTexture( key.shaderNetwork, V2i( key.resolution ), key.output );
 }
 
 typedef IECorePreview::LRUCache<IECore::MurmurHash, CompoundDataPtr, IECorePreview::LRUCachePolicy::Parallel, OSLTextureCacheGetterKey> OSLTextureCache;
-OSLTextureCache g_oslTextureCache( getter, 100 );
+OSLTextureCache g_oslTextureCache( getter, 1024 * 1024 * 64 );
 
 const char *goboFragSource()
 {

--- a/src/GafferOSL/OSLLight.cpp
+++ b/src/GafferOSL/OSLLight.cpp
@@ -269,7 +269,7 @@ void OSLLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash &h 
 	throw IECore::NotImplementedException( "OSLLight::hashLight" );
 }
 
-IECoreScene::ShaderNetworkPtr OSLLight::computeLight( const Gaffer::Context *context ) const
+IECoreScene::ConstShaderNetworkPtr OSLLight::computeLight( const Gaffer::Context *context ) const
 {
 	// Should never be called because we reimplemented computeAttributes() instead.
 	throw IECore::NotImplementedException( "OSLLight::computeLight" );

--- a/src/GafferOSL/ShadingEngineAlgo.cpp
+++ b/src/GafferOSL/ShadingEngineAlgo.cpp
@@ -1,0 +1,196 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Cinesite VFX Ltd. nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferOSL/ShadingEngineAlgo.h"
+
+#include "Gaffer/Context.h"
+
+#include "IECore/SimpleTypedData.h"
+#include "IECore/VectorTypedData.h"
+
+#include "OpenEXR/ImathBox.h"
+
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreScene;
+
+
+namespace
+{
+
+/// Returns points suitable for shading a flat image of the specified resolution.
+///   - u and v will be initialised as pixel centers.
+///   - P will be initialised to ( 0, 0, 0 )
+///
+/// Throws if either resolution component is < 1
+CompoundDataPtr imageShadingPoints( const V2i &resolution )
+{
+	if( resolution.x < 1 || resolution.y < 1 )
+	{
+		throw IECore::Exception( "Invalid resolution x: " + std::to_string( resolution.x ) + " y: " + std::to_string( resolution.y ) );
+	}
+
+	CompoundDataPtr shadingPoints = new CompoundData();
+
+	V3fVectorDataPtr pData = new V3fVectorData;
+	FloatVectorDataPtr uData = new FloatVectorData;
+	FloatVectorDataPtr vData = new FloatVectorData;
+
+	std::vector<V3f> &pWritable = pData->writable();
+	std::vector<float> &uWritable = uData->writable();
+	std::vector<float> &vWritable = vData->writable();
+
+	const int numPoints = resolution.x * resolution.y;
+
+	pWritable.reserve( numPoints );
+	uWritable.reserve( numPoints );
+	vWritable.reserve( numPoints );
+
+	for( int y = 0; y < resolution.y; ++y )
+	{
+		for( int x = 0; x < resolution.x; ++x )
+		{
+			// Generally speaking, real renderers leave P as 0 for the
+			// majority of 'texture' evaluations.
+			pWritable.push_back( V3f( 0.0f ) );
+			uWritable.push_back( ( x + 0.5f ) / resolution.x );
+			vWritable.push_back( ( y + 0.5f ) / resolution.y );
+		}
+	}
+
+	shadingPoints->writable()["P"] = pData;
+	shadingPoints->writable()["u"] = uData;
+	shadingPoints->writable()["v"] = vData;
+
+	return shadingPoints;
+}
+
+/// Converts shaded points returned by ShadingEngine::shade to an RGB
+/// CompoundData image representation of the supplied resolution. The result is
+/// suitable for use with IECoreGL::ToGLTextureConverter.  Null is returned if
+/// 'Ci' is missing from the shaded points.
+///
+/// Note: No checks are made to verify the correct number of pixels exist for
+/// the supplied resolution.
+CompoundDataPtr shadedPointsToImageData( const CompoundData* shadedPoints, const V2i &resolution )
+{
+	const ConstColor3fVectorDataPtr colors = shadedPoints->member<Color3fVectorData>( "Ci" );
+	if( !colors )
+	{
+		return nullptr;
+	}
+
+	CompoundDataPtr result = new CompoundData();
+
+	Box2i dataWindow( V2i( 0 ), V2i( resolution -  V2i( 1 ) ) );
+	Box2i displayWindow( V2i( 0 ), V2i( resolution - V2i( 1 ) ) );
+
+	result->writable()["dataWindow"] = new Box2iData( dataWindow );
+	result->writable()["displayWindow"] = new Box2iData( displayWindow );
+
+	FloatVectorDataPtr redChannelData = new FloatVectorData();
+	FloatVectorDataPtr greenChannelData = new FloatVectorData();
+	FloatVectorDataPtr blueChannelData = new FloatVectorData();
+	std::vector<float> &r = redChannelData->writable();
+	std::vector<float> &g = greenChannelData->writable();
+	std::vector<float> &b = blueChannelData->writable();
+
+	std::vector<Color3f>::size_type numColors = colors->readable().size();
+	r.reserve( numColors );
+	g.reserve( numColors );
+	b.reserve( numColors );
+
+	for( std::vector<Color3f>::size_type u = 0; u < numColors; ++u )
+	{
+		Color3f c = colors->readable()[u];
+
+		r.push_back( c[0] );
+		g.push_back( c[1] );
+		b.push_back( c[2] );
+	}
+
+	CompoundDataPtr channelData = new CompoundData;
+	channelData->writable()["R"] = redChannelData;
+	channelData->writable()["G"] = greenChannelData;
+	channelData->writable()["B"] = blueChannelData;
+
+	result->writable()["channels"] = channelData;
+
+	return result;
+}
+
+} // Anon namespace
+
+namespace GafferOSL
+{
+
+CompoundDataPtr ShadingEngineAlgo::shadeUVTexture( const IECoreScene::ShaderNetwork *shaderNetwork, const Imath::V2i &resolution, IECoreScene::ShaderNetwork::Parameter output )
+{
+	IECoreScene::ShaderNetworkPtr surfaceNetwork = shaderNetwork->copy();
+
+	if( !output )
+	{
+		output = shaderNetwork->getOutput();
+	}
+
+	const IECoreScene::Shader *outputShader = shaderNetwork->getShader( output.shader );
+	if( !outputShader )
+	{
+		throw IECore::Exception( "Requested output shader does not exist: " + output.shader.string() );
+	}
+
+	if( output != surfaceNetwork->getOutput() || outputShader->getType() != "osl:surface" )
+	{
+		IECore::InternedString surface = surfaceNetwork->addShader( "surface", new IECoreScene::Shader( "Surface/Constant", "osl:shader" ) );
+		surfaceNetwork->addConnection( { output, { surface, "Cs" } } );
+		surfaceNetwork->setOutput( { surface, "" } );
+	}
+
+	GafferOSL::ShadingEnginePtr shadingEngine = new GafferOSL::ShadingEngine( surfaceNetwork.get() );
+	const ConstCompoundDataPtr shadingPoints = imageShadingPoints( resolution );
+
+	// ShadingEngine currently respects cancellation via the context. If we do this
+	// shading for visualisation isn't designed for cancellation, so we scope a new context to
+	// temporarily ensure this doesn't happen. Long term, we plan to refactor such
+	// that cancellation is explicitly expressed in the API.
+	Gaffer::ContextPtr context = new Gaffer::Context();
+	Gaffer::Context::Scope contextScope( context.get() );
+	const ConstCompoundDataPtr shadingResult = shadingEngine->shade( shadingPoints.get() );
+
+	return shadedPointsToImageData( shadingResult.get(), resolution );
+}
+
+} // namespace GafferOSL

--- a/src/GafferOSLModule/GafferOSLModule.cpp
+++ b/src/GafferOSLModule/GafferOSLModule.cpp
@@ -43,6 +43,7 @@
 #include "GafferOSL/OSLObject.h"
 #include "GafferOSL/OSLShader.h"
 #include "GafferOSL/ShadingEngine.h"
+#include "GafferOSL/ShadingEngineAlgo.h"
 
 #include "GafferBindings/DataBinding.h"
 #include "GafferBindings/DependencyNodeBinding.h"
@@ -140,6 +141,12 @@ IECore::CompoundDataPtr shadeWrapper( ShadingEngine &shadingEngine, const IECore
 	return shadingEngine.shade( points, transforms );
 }
 
+IECore::CompoundDataPtr shadeUVTextureWrapper( const IECoreScene::ShaderNetwork &shaderNetwork, const Imath::V2i &resolution, const IECoreScene::ShaderNetwork::Parameter &output )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return ShadingEngineAlgo::shadeUVTexture( &shaderNetwork, resolution, output );
+}
+
 void loadShader( OSLLight &l, const std::string &shaderName )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -198,6 +205,20 @@ BOOST_PYTHON_MODULE( _GafferOSL )
 			.def_readwrite( "toObjectSpace", &ShadingEngine::Transform::toObjectSpace )
 			.def( "__repr__", &repr )
 		;
+	}
+
+	{
+		object module( borrowed( PyImport_AddModule( "GafferOSL.ShadingEngineAlgo" ) ) );
+		scope().attr( "ShadingEngineAlgo" ) = module;
+		scope moduleScope( module );
+
+		def( "shadeUVTexture", &shadeUVTextureWrapper,
+			(
+				boost::python::arg( "shaderNetwork" ),
+				boost::python::arg( "resolution" ),
+				boost::python::arg( "output" ) = IECoreScene::ShaderNetwork::Parameter()
+			)
+		);
 	}
 
 	{

--- a/src/GafferScene/IECoreGLPreview/LightVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/LightVisualiser.cpp
@@ -136,12 +136,28 @@ IECoreGL::ConstRenderablePtr LightVisualiser::allVisualisations( const IECore::C
 			// Direct lookup failed. See if we have any wildcard matches.
 			// We assume that the number of registered visualisers is small
 			// enough that linear search is OK here.
+
+			// First look for wildcards in shader names only, this ensures
+			// "ai:light *" beats "*:light *" even if iterated after it.
 			for( auto &r : l )
 			{
-				if( StringAlgo::matchMultiple( it->first, r.first.first ) && StringAlgo::matchMultiple( shaderName, r.first.second ) )
+				if( it->first == r.first.first && StringAlgo::matchMultiple( shaderName, r.first.second ) )
 				{
 					visualiser = r.second.get();
 					break;
+				}
+			}
+
+			// Then check look for wildcards in attribute names too if that failed
+			if( !visualiser )
+			{
+				for( auto &r : l )
+				{
+					if( StringAlgo::matchMultiple( it->first, r.first.first ) && StringAlgo::matchMultiple( shaderName, r.first.second ) )
+					{
+						visualiser = r.second.get();
+						break;
+					}
 				}
 			}
 		}

--- a/src/GafferScene/Light.cpp
+++ b/src/GafferScene/Light.cpp
@@ -162,13 +162,14 @@ IECore::ConstCompoundObjectPtr Light::computeAttributes( const SceneNode::SceneP
 
 	std::string lightAttribute = "light";
 
-	IECoreScene::ShaderNetworkPtr lightShaders = computeLight( context );
+	IECoreScene::ConstShaderNetworkPtr lightShaders = computeLight( context );
 	if( const IECoreScene::Shader *shader = lightShaders->outputShader() )
 	{
 		lightAttribute = shader->getType();
 	}
 
-	result->members()[lightAttribute] = lightShaders;
+	// As we output as const, then this just lets us get through the next few lines...
+	result->members()[lightAttribute] = const_cast<IECoreScene::ShaderNetwork*>( lightShaders.get() );
 	result->members()[g_visualiserScaleAttribute] = new IECore::FloatData( visualiserScalePlug()->getValue() );
 	result->members()[g_visualiserShadedAttribute] = new IECore::BoolData( visualiserShadedPlug()->getValue() );
 

--- a/src/GafferSceneModule/PrimitivesBinding.cpp
+++ b/src/GafferSceneModule/PrimitivesBinding.cpp
@@ -49,6 +49,7 @@
 #include "GafferScene/Light.h"
 #include "GafferScene/ObjectToScene.h"
 #include "GafferScene/Plane.h"
+#include "GafferScene/ShaderPlug.h"
 #include "GafferScene/Sphere.h"
 #include "GafferScene/Text.h"
 #include "GafferScene/LightFilter.h"
@@ -91,6 +92,13 @@ class LightSerialiser : public GafferBindings::NodeSerialiser
 		if( !shaderNamePlug )
 		{
 			shaderNamePlug = light->getChild<Gaffer::StringPlug>( "__model" );
+		}
+		if( !shaderNamePlug )
+		{
+			if( const GafferScene::Shader *shader = light->getChild<GafferScene::Shader>( "__shader" ) )
+			{
+				shaderNamePlug = shader->namePlug();
+			}
 		}
 
 		const std::string shaderName = shaderNamePlug ? shaderNamePlug->getValue() : "";

--- a/src/GafferSceneTest/TestLight.cpp
+++ b/src/GafferSceneTest/TestLight.cpp
@@ -64,7 +64,7 @@ void TestLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash &h
 	}
 }
 
-IECoreScene::ShaderNetworkPtr TestLight::computeLight( const Gaffer::Context *context ) const
+IECoreScene::ConstShaderNetworkPtr TestLight::computeLight( const Gaffer::Context *context ) const
 {
 	IECoreScene::ShaderPtr shader = new IECoreScene::Shader( "testLight", "light" );
 	shader->parameters()["intensity"] = new IECore::Color3fData( parametersPlug()->getChild<Color3fPlug>( "intensity" )->getValue() );

--- a/startup/GafferScene/arnoldLights.py
+++ b/startup/GafferScene/arnoldLights.py
@@ -63,6 +63,7 @@ Gaffer.Metadata.registerValue( "ai:light:quad_light", "type", "quad" )
 Gaffer.Metadata.registerValue( "ai:light:quad_light", "intensityParameter", "intensity" )
 Gaffer.Metadata.registerValue( "ai:light:quad_light", "exposureParameter", "exposure" )
 Gaffer.Metadata.registerValue( "ai:light:quad_light", "colorParameter", "color" )
+Gaffer.Metadata.registerValue( "ai:light:quad_light", "visualiserOrientation", imath.M44f().rotate( imath.V3f( 0, 0, 0.5 * math.pi ) ) )
 
 Gaffer.Metadata.registerValue( "ai:light:disk_light", "type", "disk" )
 Gaffer.Metadata.registerValue( "ai:light:disk_light", "intensityParameter", "intensity" )
@@ -80,3 +81,4 @@ Gaffer.Metadata.registerValue( "ai:light:cylinder_light", "visualiserOrientation
 Gaffer.Metadata.registerValue( "ai:light:skydome_light", "intensityParameter", "intensity" )
 Gaffer.Metadata.registerValue( "ai:light:skydome_light", "exposureParameter", "exposure" )
 Gaffer.Metadata.registerValue( "ai:light:skydome_light", "colorParameter", "color" )
+Gaffer.Metadata.registerValue( "ai:light:skydome_light", "type", "environment" )

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -426,6 +426,7 @@ if moduleSearchPath.find( "GafferOSL" ) :
 		# This match expression filters these categories of shader out
 		# as follows :
 		#
+		# - (?!__) asserts that the shader does not begin with double underscore.
 		# - (^|.*/) matches any number (including zero) of directory
 		#   names preceding the shader name.
 		# - (?<!maya/osl/) is a negative lookbehind, asserting that the
@@ -439,7 +440,7 @@ if moduleSearchPath.find( "GafferOSL" ) :
 		#   shaders.
 		# - [^/]*$ matches the rest of the shader name, ensuring it
 		#   doesn't include any directory separators.
-		matchExpression = re.compile( "(^|.*/)(?<!maya/osl/)(?<!3DelightForKatana/osl/)(?!as_|oslCode)[^/]*$"),
+		matchExpression = re.compile( "(?!__)(^|.*/)(?<!maya/osl/)(?<!3DelightForKatana/osl/)(?!as_|oslCode)[^/]*$"),
 		searchTextPrefix = "osl",
 	)
 


### PR DESCRIPTION
Implements #3407 aside from the global "visualiser shaded" option.

Note: This implementation doesn't presently support https://docs.arnoldrenderer.com/display/NodeRef/skydome_light#skydome_light-format.

I've broken the commits down to aid review, those prefixed with `[CR]` need squashing to some degree or another before merge.