### PR TITLE
Fix broken CopyAttributes compatibility config.

### DIFF
--- a/startup/GafferScene/copyAttributesCompatibility.py
+++ b/startup/GafferScene/copyAttributesCompatibility.py
@@ -63,9 +63,11 @@ def __copyAttributesInGetItem( originalGetItem ) :
 		if key in ( "in0", 0 ) :
 			# First element of old ArrayPlug - redirect to self.
 			return self
-		else :
+		elif key in ( "in1", 1 ) :
 			# Second element of old ArrayPlug - redirect to source.
 			return self.parent()["source"]
+		else:
+			return originalGetItem( self, key )
 
 	return getItem
 


### PR DESCRIPTION
Was loading some existing scripts to test deep stuff, and got some really weird errors in an old expression because of this.

Without this fix, CopyAttributes["in"]["globals"] would return CopyAttributes["source"]
