### PR TITLE
Spreadsheet Node (Preview)

### DIFF
--- a/include/Gaffer/Spreadsheet.h
+++ b/include/Gaffer/Spreadsheet.h
@@ -1,0 +1,219 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_SPREADSHEET_H
+#define GAFFER_SPREADSHEET_H
+
+#include "Gaffer/ComputeNode.h"
+#include "Gaffer/NumericPlug.h"
+#include "Gaffer/TypedObjectPlug.h"
+
+namespace Gaffer
+{
+
+IE_CORE_FORWARDDECLARE( StringPlug )
+
+class GAFFER_API Spreadsheet : public ComputeNode
+{
+
+	public :
+
+		Spreadsheet( const std::string &name=defaultName<Spreadsheet>() );
+		~Spreadsheet() override;
+
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( Gaffer::Spreadsheet, SpreadsheetTypeId, ComputeNode );
+
+		/// Plug types
+		/// ==========
+		///
+		/// The spreadsheet is defined using a hierarchy of specialised plug
+		/// types, organised first by row and then by column.
+
+		class RowPlug;
+
+		/// Top level plug that has a child for each row in the spreadsheet.
+		/// This also provides methods for adding and removing rows and columns.
+		/// Accessed via `Spreadsheet::rowsPlug()`.
+		class RowsPlug : public ValuePlug
+		{
+
+			public :
+
+				RowsPlug( const std::string &name = defaultName<RowsPlug>(), Direction direction = In, unsigned flags = Default );
+
+				GAFFER_PLUG_DECLARE_TYPE( Gaffer::Spreadsheet::RowsPlug, Gaffer::SpreadsheetRowsPlugTypeId, Gaffer::ValuePlug );
+
+				/// Methods for adjusting spreadsheet size
+				/// ======================================
+				///
+				/// Several constraints must be maintained when adjusting the
+				/// size of the spreadsheet, so these dedicated methods should
+				/// be used instead of manual addition of children.
+				///
+				/// These methods are defined on the RowPlug rather than on the
+				/// Spreadsheet so that they can be used for the editing and
+				/// serialisation of promoted plugs.
+
+				size_t addColumn( const ValuePlug *value, IECore::InternedString name = IECore::InternedString() );
+				void removeColumn( size_t columnIndex );
+
+				RowPlug *addRow();
+				/// \todo Return `RowPlug::Range`, which we can't do right
+				/// now because it doesn't have constructors which specify
+				/// the begin/end iterators.
+				void addRows( size_t numRows );
+
+				Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
+
+			private :
+
+				ValuePlug *outPlug();
+
+		};
+
+		IE_CORE_DECLAREPTR( RowsPlug );
+
+		/// Defines a single row of the spreadsheet. Access using
+		/// `RowPlug::Range( *rowsPlug() )` or via `rowsPlug()->getChild<RowPlug>()`.
+		class RowPlug : public ValuePlug
+		{
+
+			public :
+
+				GAFFER_PLUG_DECLARE_TYPE( Gaffer::Spreadsheet::RowPlug, Gaffer::SpreadsheetRowPlugTypeId, Gaffer::ValuePlug );
+
+				StringPlug *namePlug();
+				const StringPlug *namePlug() const;
+
+				BoolPlug *enabledPlug();
+				const BoolPlug *enabledPlug() const;
+
+				ValuePlug *cellsPlug();
+				const ValuePlug *cellsPlug() const;
+
+				Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
+
+			private :
+
+				RowPlug( const std::string &name, Plug::Direction direction = Plug::In );
+				friend class Spreadsheet;
+
+		};
+
+		IE_CORE_DECLAREPTR( RowPlug );
+
+		/// Defines a single cell in the spreadsheet. Access using
+		/// `CellPlug::Range( *rowPlug->cellsPlug() )` or via
+		/// `rowPlug->cellsPlug()->getChild<CellPlug>()`.
+		class CellPlug : public ValuePlug
+		{
+
+			public :
+
+				GAFFER_PLUG_DECLARE_TYPE( Gaffer::Spreadsheet::CellPlug, Gaffer::SpreadsheetCellPlugTypeId, Gaffer::ValuePlug );
+
+				BoolPlug *enabledPlug();
+				const BoolPlug *enabledPlug() const;
+
+				template<typename T = Gaffer::ValuePlug>
+				T *valuePlug();
+
+				template<typename T = Gaffer::ValuePlug>
+				const T *valuePlug() const;
+
+				Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
+
+			private :
+
+				CellPlug( const std::string &name, const Gaffer::Plug *value, Plug::Direction direction = Plug::In );
+				friend class Spreadsheet;
+
+		};
+
+		IE_CORE_DECLAREPTR( CellPlug );
+
+		/// Plug accessors
+		/// ==============
+
+		StringPlug *selectorPlug();
+		const StringPlug *selectorPlug() const;
+
+		ValuePlug *rowsPlug();
+		const ValuePlug *rowsPlug() const;
+
+		ValuePlug *outPlug();
+		const ValuePlug *outPlug() const;
+
+		StringVectorDataPlug *activeRowNamesPlug();
+		const StringVectorDataPlug *activeRowNamesPlug() const;
+
+		/// Returns the input plug which provides the value
+		/// for `output` in the current context.
+		ValuePlug *activeInPlug( const ValuePlug *output );
+		const ValuePlug *activeInPlug( const ValuePlug *output ) const;
+
+		/// DependencyNode methods
+		/// ======================
+
+		void affects( const Plug *input, AffectedPlugsContainer &outputs ) const override;
+		BoolPlug *enabledPlug() override;
+		const BoolPlug *enabledPlug() const override;
+		Plug *correspondingInput( const Plug *output ) override;
+		const Plug *correspondingInput( const Plug *output ) const override;
+
+	protected :
+
+		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
+		void compute( ValuePlug *output, const Context *context ) const override;
+
+	private :
+
+		IntPlug *rowIndexPlug();
+		const IntPlug *rowIndexPlug() const;
+
+		const ValuePlug *correspondingInput( const Plug *output, size_t rowIndex ) const;
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( Spreadsheet )
+
+} // namespace Gaffer
+
+#include "Gaffer/Spreadsheet.inl"
+
+#endif // GAFFER_SPREADSHEET_H

--- a/include/Gaffer/Spreadsheet.inl
+++ b/include/Gaffer/Spreadsheet.inl
@@ -1,0 +1,57 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_SPREADSHEET_INL
+#define GAFFER_SPREADSHEET_INL
+
+namespace Gaffer
+{
+
+template<typename T>
+T *Spreadsheet::CellPlug::valuePlug()
+{
+	return getChild<T>( 1 );
+}
+
+template<typename T>
+const T *Spreadsheet::CellPlug::valuePlug() const
+{
+	return getChild<T>( 1 );
+}
+
+} // namespace Gaffer
+
+#endif // GAFFER_SPREADSHEET_INL

--- a/include/Gaffer/TypeIds.h
+++ b/include/Gaffer/TypeIds.h
@@ -105,7 +105,7 @@ enum TypeId
 	Transform2DPlugTypeId = 110058,
 	ReferenceTypeId = 110059,
 	ComputeNodeTypeId = 110060,
-	ParameterisedHolderComputeNodeTypeId = 110061, // obsolete - available for reuse
+	SpreadsheetTypeId = 110061,
 	Color3fVectorDataPlugTypeId = 110062,
 	ActionTypeId = 110063,
 	SimpleActionTypeId = 110064,
@@ -115,7 +115,7 @@ enum TypeId
 	ArrayPlugTypeId = 110068,
 	BackdropTypeId = 110069,
 	SwitchTypeId = 110070,
-	SwitchDependencyNodeTypeId = 110071, // obsolete - available for reuse
+	SpreadsheetCellPlugTypeId = 110071,
 	PathMatcherDataPlugTypeId = 110072,
 	SubGraphTypeId = 110073,
 	DotTypeId = 110074,
@@ -133,6 +133,8 @@ enum TypeId
 	BoxInTypeId = 110086,
 	BoxOutTypeId = 110087,
 	DeleteContextVariablesTypeId = 110088,
+	SpreadsheetRowsPlugTypeId = 110089,
+	SpreadsheetRowPlugTypeId = 110090,
 
 	LastTypeId = 110159,
 

--- a/python/GafferDispatchUI/WedgeUI.py
+++ b/python/GafferDispatchUI/WedgeUI.py
@@ -72,6 +72,9 @@ Gaffer.Metadata.registerNode(
 	"layout:customWidget:colorValues:visibilityActivator", "modeIsColorRange",
 	"layout:customWidget:colorValues:section", "Settings",
 
+	"ui:spreadsheet:activeRowNamesConnection", "strings",
+	"ui:spreadsheet:selectorContextVariablePlug", "variable",
+
 	plugs = {
 
 		"variable" : [

--- a/python/GafferImageUI/CollectImagesUI.py
+++ b/python/GafferImageUI/CollectImagesUI.py
@@ -48,6 +48,9 @@ Gaffer.Metadata.registerNode(
 	Useful for networks that need to dynamically build an unknown number of image layers.
 	""",
 
+	"ui:spreadsheet:activeRowNamesConnection", "rootLayers",
+	"ui:spreadsheet:selectorContextVariablePlug", "layerVariable",
+
 	plugs = {
 
 		"in" : [

--- a/python/GafferSceneTest/SpreadsheetTest.py
+++ b/python/GafferSceneTest/SpreadsheetTest.py
@@ -1,0 +1,77 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+class SpreadsheetTest( GafferSceneTest.SceneTestCase ) :
+
+	def testScenePathAsSelector( self ) :
+
+		sphere = GafferScene.Sphere()
+		cube = GafferScene.Cube()
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( sphere["out"] )
+		group["in"][1].setInput( cube["out"] )
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/group/sphere", "/group/cube" ] ) )
+
+		attributes = GafferScene.StandardAttributes()
+		attributes["in"].setInput( group["out"] )
+		attributes["filter"].setInput( pathFilter["out"] )
+		attributes["attributes"]["deformationBlur"]["enabled"].setValue( True )
+
+		spreadsheet = Gaffer.Spreadsheet()
+		spreadsheet["selector"].setValue( "${scene:path}" )
+		spreadsheet["rows"].addColumn( attributes["attributes"]["deformationBlur"]["value"] )
+		attributes["attributes"]["deformationBlur"]["value"].setInput( spreadsheet["out"][0] )
+
+		row = spreadsheet["rows"].addRow()
+		row["name"].setValue( "/group/cube" )
+		row["cells"][0]["value"].setValue( False )
+
+		self.assertEqual( attributes["out"].attributes( "/group/sphere" )["gaffer:deformationBlur"].value, True )
+		self.assertEqual( attributes["out"].attributes( "/group/cube" )["gaffer:deformationBlur"].value, False )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -141,6 +141,7 @@ from SetVisualiserTest import SetVisualiserTest
 from OrientationTest import OrientationTest
 from MeshTypeTest import MeshTypeTest
 from CopyPrimitiveVariablesTest import CopyPrimitiveVariablesTest
+from SpreadsheetTest import SpreadsheetTest
 
 from IECoreScenePreviewTest import *
 from IECoreGLPreviewTest import *

--- a/python/GafferSceneUI/CollectPrimitiveVariablesUI.py
+++ b/python/GafferSceneUI/CollectPrimitiveVariablesUI.py
@@ -51,6 +51,9 @@ Gaffer.Metadata.registerNode(
 	effects.
 	""",
 
+	"ui:spreadsheet:activeRowNamesConnection", "suffixes",
+	"ui:spreadsheet:selectorContextVariablePlug", "suffixContextVariable",
+
 	plugs = {
 		"primitiveVariables" : [
 

--- a/python/GafferSceneUI/CollectScenesUI.py
+++ b/python/GafferSceneUI/CollectScenesUI.py
@@ -56,6 +56,9 @@ Gaffer.Metadata.registerNode(
 	`rootNames[0]`.
 	""",
 
+	"ui:spreadsheet:activeRowNamesConnection", "rootNames",
+	"ui:spreadsheet:selectorContextVariablePlug", "rootNameVariable",
+
 	plugs = {
 
 		"rootNames" : [

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -58,6 +58,9 @@ Gaffer.Metadata.registerNode(
 	paths.
 	""",
 
+	"ui:spreadsheet:activeRowNamesConnection", "paths",
+	"ui:spreadsheet:selectorValue", "${scene:path}",
+
 	plugs = {
 
 		"paths" : [

--- a/python/GafferSceneUI/ScenePathPlugValueWidget.py
+++ b/python/GafferSceneUI/ScenePathPlugValueWidget.py
@@ -98,3 +98,15 @@ class ScenePathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 			p = self.__scenePlug( output )
 			if p is not None :
 				return p
+
+		# Or perhaps `plug` is in a cell in a spreadsheet, in which case
+		# we may be able to get somewhere by looking where the corresponding
+		# output is connected.
+		## \todo Can this sort of traversal be wrapped up in PlugAlgo somehow?
+
+		cellPlug = plug.ancestor( Gaffer.Spreadsheet.CellPlug )
+		if cellPlug is not None :
+			spreadsheet = cellPlug.ancestor( Gaffer.Spreadsheet )
+			if spreadsheet is not None :
+				return self.__scenePlug( spreadsheet["out"][cellPlug.getName()] )
+

--- a/python/GafferSceneUI/TweakPlugValueWidget.py
+++ b/python/GafferSceneUI/TweakPlugValueWidget.py
@@ -189,8 +189,28 @@ def __noduleLabel( plug ) :
 
 	return name or plug.getName()
 
+def __spreadsheetColumnName( plug ) :
+
+	tweakPlug = plug.parent()
+	if plug == tweakPlug["name"] :
+		return plug.getName()
+
+	# Use some heuristics to come up with a more helpful
+	# column name.
+
+	name = tweakPlug.getName()
+	if name.startswith( "tweak" ) and tweakPlug["name"].source().direction() != Gaffer.Plug.Direction.Out :
+		name = tweakPlug["name"].getValue()
+
+	if name :
+		return name + plug.getName().title()
+	else :
+		return plug.getName()
+
 Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "nodule:type", "GafferUI::CompoundNodule" )
 Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "*", "nodule:type", "" )
 Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "value", "nodule:type", "GafferUI::StandardNodule" )
 Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "noduleLayout:label", __noduleLabel )
 Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "value", "noduleLayout:label", __noduleLabel )
+Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "*", "spreadsheet:columnName", __spreadsheetColumnName )
+

--- a/python/GafferTest/ContextTest.py
+++ b/python/GafferTest/ContextTest.py
@@ -337,6 +337,14 @@ class ContextTest( GafferTest.TestCase ) :
 		self.assertTrue( c.hasSubstitutions( "${a}" ) )
 		self.assertTrue( c.hasSubstitutions( "###" ) )
 
+	def testInternedStringVectorDataSubstitutions( self ) :
+
+		c = Gaffer.Context()
+		c["test1"] = IECore.InternedStringVectorData( [ "a", "b" ] )
+		c["test2"] = IECore.InternedStringVectorData()
+		self.assertEqual( c.substitute( "${test1}" ), "/a/b" )
+		self.assertEqual( c.substitute( "${test2}" ), "/" )
+
 	def testNames( self ) :
 
 		c = Gaffer.Context()

--- a/python/GafferTest/SpreadsheetTest.py
+++ b/python/GafferTest/SpreadsheetTest.py
@@ -1,0 +1,401 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+
+import IECore
+
+import Gaffer
+import GafferTest
+
+class SpreadsheetTest( GafferTest.TestCase ) :
+
+	def testConstructor( self ) :
+
+		self.assertEqual( Gaffer.Spreadsheet().getName(), "Spreadsheet" )
+
+		s = Gaffer.Spreadsheet( "s" )
+		self.assertEqual( s.getName(), "s" )
+
+		# Check default row
+
+		self.assertEqual( len( s["rows"] ), 1 )
+		self.assertEqual( s["rows"][0].getName(), "default" )
+		self.assertEqual( s["rows"][0]["name"].getValue(), "" )
+		self.assertEqual( s["rows"][0]["enabled"].getValue(), True )
+		self.assertIsInstance( s["rows"][0], Gaffer.Spreadsheet.RowPlug )
+
+		# Check we have no columns
+
+		self.assertEqual( len( s["rows"][0]["cells"] ), 0 )
+		self.assertEqual( len( s["out"] ), 0 )
+
+	def testEditColumnsAndRows( self ) :
+
+		s = Gaffer.Spreadsheet()
+
+		columnIndex = s["rows"].addColumn( Gaffer.IntPlug( "myInt" ) )
+		self.assertEqual( columnIndex, 0 )
+		self.assertEqual( len( s["rows"][0]["cells"] ), 1 )
+		self.assertIsInstance( s["rows"][0]["cells"][0], Gaffer.Spreadsheet.CellPlug )
+		self.assertEqual( s["rows"][0]["cells"][0].getName(), "myInt" )
+		self.assertIsInstance( s["rows"][0]["cells"][0]["value"], Gaffer.IntPlug )
+		self.assertEqual( s["rows"][0]["cells"][0]["enabled"].getValue(), True )
+		self.assertEqual( s["rows"][0]["cells"][0]["value"].getValue(), 0 )
+		self.assertEqual( len( s["out"] ), 1 )
+		self.assertEqual( s["out"][0].getName(), "myInt" )
+		self.assertIsInstance( s["out"][0], Gaffer.IntPlug )
+		self.assertEqual( s["out"][0].direction(), Gaffer.Plug.Direction.Out )
+
+		columnIndex = s["rows"].addColumn( Gaffer.FloatPlug( "myFloat", defaultValue = 1 ) )
+		self.assertEqual( columnIndex, 1 )
+		self.assertEqual( len( s["rows"][0]["cells"] ), 2 )
+		self.assertIsInstance( s["rows"][0]["cells"][1], Gaffer.Spreadsheet.CellPlug )
+		self.assertEqual( s["rows"][0]["cells"][1].getName(), "myFloat" )
+		self.assertIsInstance( s["rows"][0]["cells"][1]["value"], Gaffer.FloatPlug )
+		self.assertEqual( s["rows"][0]["cells"][1]["enabled"].getValue(), True )
+		self.assertEqual( s["rows"][0]["cells"][1]["value"].getValue(), 1 )
+		self.assertEqual( len( s["out"] ), 2 )
+		self.assertEqual( s["out"][1].getName(), "myFloat" )
+		self.assertIsInstance( s["out"][1], Gaffer.FloatPlug )
+		self.assertEqual( s["out"][1].direction(), Gaffer.Plug.Direction.Out )
+
+		row = s["rows"].addRow()
+		self.assertIsInstance( row, Gaffer.Spreadsheet.RowPlug )
+		self.assertEqual( row.parent(), s["rows"] )
+		self.assertEqual( row.getName(), "row1" )
+		self.assertEqual( len( row["cells"] ), 2 )
+		self.assertEqual( row["cells"][0].getName(), "myInt" )
+		self.assertEqual( row["cells"][1].getName(), "myFloat" )
+		self.assertIsInstance( row["cells"][0], Gaffer.Spreadsheet.CellPlug )
+		self.assertIsInstance( row["cells"][1], Gaffer.Spreadsheet.CellPlug )
+		self.assertEqual( row["cells"][0]["enabled"].getValue(), True )
+		self.assertEqual( row["cells"][0]["value"].getValue(), 0 )
+		self.assertEqual( row["cells"][1]["enabled"].getValue(), True )
+		self.assertEqual( row["cells"][1]["value"].getValue(), 1 )
+
+		s["rows"].removeColumn( columnIndex )
+		self.assertEqual( len( s["rows"][0]["cells"] ), 1 )
+		self.assertEqual( s["rows"][0]["cells"][0].getName(), "myInt" )
+		self.assertEqual( len( s["out"] ), 1 )
+		self.assertEqual( s["out"][0].getName(), "myInt" )
+
+	def testOutput( self ) :
+
+		s = Gaffer.Spreadsheet()
+
+		s["rows"].addColumn( Gaffer.IntPlug( "column1" ) )
+		s["rows"].addColumn( Gaffer.IntPlug( "column2" ) )
+
+		defaultRow = s["rows"]["default"]
+		row1 = s["rows"].addRow()
+		row1["name"].setValue( "row1" )
+		row2 = s["rows"].addRow()
+		row2["name"].setValue( "row2" )
+
+		defaultRow["cells"]["column1"]["value"].setValue( 1 )
+		defaultRow["cells"]["column2"]["value"].setValue( 2 )
+		row1["cells"]["column1"]["value"].setValue( 3 )
+		row1["cells"]["column2"]["value"].setValue( 4 )
+		row2["cells"]["column1"]["value"].setValue( 5 )
+		row2["cells"]["column2"]["value"].setValue( 6 )
+
+		for selector in ( "", "woteva", "row1", "row2" ) :
+
+			s["selector"].setValue( selector )
+			expectedRow = s["rows"].getChild( selector ) or s["rows"]["default"]
+
+			for out in s["out"] :
+
+				s["enabled"].setValue( True )
+				self.assertEqual( out.getValue(), expectedRow["cells"][out.getName()]["value"].getValue() )
+
+				s["enabled"].setValue( False )
+				self.assertEqual( out.getValue(), s["rows"]["default"]["cells"][out.getName()]["value"].getValue() )
+
+	def testSerialisation( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["s"] = Gaffer.Spreadsheet()
+		s["s"]["rows"].addColumn( Gaffer.IntPlug( "column1" ) )
+		s["s"]["rows"].addColumn( Gaffer.IntPlug( "column2" ) )
+		s["s"]["rows"].addRow()
+		s["s"]["rows"].addRow()
+
+		s["s"]["rows"][0]["cells"]["column1"]["value"].setValue( 10 )
+		s["s"]["rows"][1]["cells"]["column1"]["value"].setValue( 20 )
+		s["s"]["rows"][1]["cells"]["column1"]["enabled"].setValue( False )
+		s["s"]["rows"][1]["name"].setValue( "rrr" )
+		s["s"]["rows"][2]["name"].setValue( "zzz" )
+		s["s"]["rows"][2]["cells"]["column1"]["value"].setValue( 30 )
+		s["s"]["rows"][2]["cells"]["column2"]["value"].setValue( 40 )
+
+		ss = s.serialise()
+		self.assertEqual( ss.count( "addChild" ), 1 )
+		self.assertEqual( ss.count( "addColumn" ), 2 )
+		self.assertEqual( ss.count( "addRows" ), 1 )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( ss )
+
+		self.assertEqual( s2["s"]["rows"].keys(), s["s"]["rows"].keys() )
+		for r in s2["s"]["rows"].keys() :
+			self.assertEqual( s2["s"]["rows"][r]["name"].getValue(), s["s"]["rows"][r]["name"].getValue() )
+			self.assertEqual( s2["s"]["rows"][r]["enabled"].getValue(), s["s"]["rows"][r]["enabled"].getValue() )
+			self.assertEqual( s2["s"]["rows"][r]["cells"].keys(), s["s"]["rows"][r]["cells"].keys() )
+			for c in s2["s"]["rows"][r]["cells"].keys() :
+				self.assertEqual( s2["s"]["rows"][r]["cells"][c]["enabled"].getValue(), s["s"]["rows"][r]["cells"][c]["enabled"].getValue() )
+				self.assertEqual( s2["s"]["rows"][r]["cells"][c]["value"].getValue(), s["s"]["rows"][r]["cells"][c]["value"].getValue() )
+
+	def testNestedPlugs( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.TransformPlug( "transform" ) )
+		r = s["rows"].addRow()
+
+		self.assertEqual(
+			s.correspondingInput( s["out"]["transform"]["translate"]["x"] ),
+			s["rows"][0]["cells"]["transform"]["value"]["translate"]["x"]
+		)
+
+		r["name"].setValue( "n" )
+		r["cells"]["transform"]["value"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
+
+		self.assertEqual( s["out"]["transform"]["translate"].getValue(), imath.V3f( 0 ) )
+		s["selector"].setValue( "n" )
+		self.assertEqual( s["out"]["transform"]["translate"].getValue(), imath.V3f( 1, 2, 3 ) )
+
+	def testDirtyPropagation( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.V3fPlug( "v" ) )
+		s["rows"].addColumn( Gaffer.FloatPlug( "f" ) )
+		r = s["rows"].addRow()
+
+		cs = GafferTest.CapturingSlot( s.plugDirtiedSignal() )
+
+		s["enabled"].setValue( False )
+		self.assertTrue( set( s["out"].children() ).issubset( { x[0] for x in cs } ) )
+		del cs[:]
+
+		r["cells"]["v"]["value"]["x"].setValue( 2 )
+		self.assertIn( s["out"]["v"]["x"], { x[0] for x in cs } )
+		self.assertNotIn( s["out"]["v"]["z"], { x[0] for x in cs } )
+		self.assertNotIn( s["out"]["f"], { x[0] for x in cs } )
+		del cs[:]
+
+		r["cells"]["v"]["enabled"].setValue( False )
+		self.assertTrue( set( s["out"]["v"].children() ).issubset( { x[0] for x in cs } ) )
+		self.assertNotIn( s["out"]["f"], { x[0] for x in cs } )
+
+	def testDisablingRows( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["selector"].setValue( "a" )
+		s["rows"].addColumn( Gaffer.IntPlug( "i" ) )
+
+		r = s["rows"].addRow()
+		r["name"].setValue( "a" )
+		r["cells"]["i"]["value"].setValue( 2 )
+		self.assertEqual( s["out"]["i"].getValue(), 2 )
+
+		r["enabled"].setValue( False )
+		self.assertEqual( s["out"]["i"].getValue(), 0 )
+
+	def testCorrespondingInput( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.IntPlug( "column1" ) )
+		s["rows"].addRows( 2 )
+
+		self.assertEqual( s.correspondingInput( s["out"]["column1"] ), s["rows"]["default"]["cells"]["column1"]["value"] )
+		self.assertEqual( s.correspondingInput( s["out"] ), None )
+
+	def testPromotion( self ) :
+
+		def assertCellEqual( cellPlug1, cellPlug2 ) :
+
+			self.assertEqual( cellPlug1.getName(), cellPlug2.getName() )
+			self.assertIsInstance( cellPlug1, Gaffer.Spreadsheet.CellPlug )
+			self.assertIsInstance( cellPlug2, Gaffer.Spreadsheet.CellPlug )
+
+			self.assertEqual( cellPlug1["enabled"].getValue(), cellPlug2["enabled"].getValue() )
+			self.assertEqual( cellPlug1["value"].getValue(), cellPlug2["value"].getValue() )
+
+		def assertRowEqual( rowPlug1, rowPlug2 ) :
+
+			self.assertEqual( rowPlug1.getName(), rowPlug2.getName() )
+			self.assertIsInstance( rowPlug1, Gaffer.Spreadsheet.RowPlug )
+			self.assertIsInstance( rowPlug2, Gaffer.Spreadsheet.RowPlug )
+			self.assertEqual( rowPlug1["name"].getValue(), rowPlug2["name"].getValue() )
+			self.assertEqual( rowPlug1["enabled"].getValue(), rowPlug2["enabled"].getValue() )
+			self.assertEqual( rowPlug1["cells"].keys(), rowPlug2["cells"].keys() )
+
+			for k in rowPlug1["cells"].keys() :
+				assertCellEqual( rowPlug1["cells"][k], rowPlug2["cells"][k] )
+
+		def assertRowsEqual( rowsPlug1, rowsPlug2 ) :
+
+			self.assertIsInstance( rowsPlug1, Gaffer.Spreadsheet.RowsPlug )
+			self.assertIsInstance( rowsPlug2, Gaffer.Spreadsheet.RowsPlug )
+			self.assertEqual( rowsPlug1.keys(), rowsPlug2.keys() )
+
+			for k in rowsPlug1.keys() :
+				assertRowEqual( rowsPlug1[k], rowsPlug2[k] )
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+
+		# Make a Spreadsheet with some existing cells
+		# and promote the "rows" plug.
+
+		s["b"]["s1"] = Gaffer.Spreadsheet()
+		s["b"]["s1"]["rows"].addColumn( Gaffer.IntPlug( "i" ) )
+		s["b"]["s1"]["rows"].addRow()["cells"][0]["value"].setValue( 10 )
+		s["b"]["s1"]["rows"].addRow()["cells"][0]["value"].setValue( 20 )
+
+		p1 = Gaffer.PlugAlgo.promote( s["b"]["s1"]["rows"] )
+		assertRowsEqual( p1, s["b"]["s1"]["rows"] )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["s1"]["rows"] ) )
+
+		# Promote the "rows" plug on an empty spreadsheet,
+		# and add some cells.
+
+		s["b"]["s2"] = Gaffer.Spreadsheet()
+		p2 = Gaffer.PlugAlgo.promote( s["b"]["s2"]["rows"] )
+		assertRowsEqual( p2, s["b"]["s2"]["rows"] )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["s2"]["rows"] ) )
+
+		p2.addColumn( Gaffer.IntPlug( "i" ) )
+		p2.addRow()["cells"][0]["value"].setValue( 10 )
+		p2.addRow()["cells"][0]["value"].setValue( 20 )
+		assertRowsEqual( p2, s["b"]["s2"]["rows"] )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["s2"]["rows"] ) )
+
+		# Serialise and reload, and check all is well
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		assertRowsEqual( s2["b"]["s1"]["rows"], s["b"]["s1"]["rows"] )
+		assertRowsEqual( s2["b"]["s2"]["rows"], s["b"]["s2"]["rows"] )
+
+	def testActiveRowNames( self ) :
+
+		s = Gaffer.Spreadsheet()
+		for i in range( 1, 4 ) :
+			s["rows"].addRow()["name"].setValue( str( i ) )
+
+		self.assertEqual( s["activeRowNames"].getValue(), IECore.StringVectorData( [ "1", "2", "3" ] ) )
+
+		s["rows"][1]["enabled"].setValue( False )
+		self.assertEqual( s["activeRowNames"].getValue(), IECore.StringVectorData( [ "2", "3" ] ) )
+
+		s["rows"][2]["name"].setValue( "two" )
+		self.assertEqual( s["activeRowNames"].getValue(), IECore.StringVectorData( [ "two", "3" ] ) )
+
+	def testAddColumnUsingDynamicPlug( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["s"] = Gaffer.Spreadsheet()
+		s["s"]["rows"].addColumn( Gaffer.Color3fPlug( "c", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		s["s"]["rows"].addColumn( Gaffer.IntPlug( "i", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( s2["s"]["rows"][0]["cells"].keys(), s["s"]["rows"][0]["cells"].keys() )
+		self.assertEqual( s2["s"]["out"].keys(), s["s"]["out"].keys() )
+
+		self.assertEqual( s2.serialise(), s.serialise() )
+
+	def testActiveInput( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.V3fPlug( "v" ) )
+		s["rows"].addColumn( Gaffer.IntPlug( "i" ) )
+		s["rows"].addRow()["name"].setValue( "a" )
+		s["rows"].addRow()["name"].setValue( "b" )
+		s["selector"].setValue( "${testSelector}" )
+
+		with Gaffer.Context() as c :
+
+			self.assertEqual( s.activeInPlug( s["out"]["v"] ), s["rows"]["default"]["cells"]["v"]["value"] )
+			self.assertEqual( s.activeInPlug( s["out"]["v"]["x"] ), s["rows"]["default"]["cells"]["v"]["value"]["x"] )
+			self.assertEqual( s.activeInPlug( s["out"]["i"] ), s["rows"]["default"]["cells"]["i"]["value"] )
+
+			c["testSelector"] = "a"
+			self.assertEqual( s.activeInPlug( s["out"]["v"] ), s["rows"][1]["cells"]["v"]["value"] )
+			self.assertEqual( s.activeInPlug( s["out"]["v"]["x"] ), s["rows"][1]["cells"]["v"]["value"]["x"] )
+			self.assertEqual( s.activeInPlug( s["out"]["i"] ), s["rows"][1]["cells"]["i"]["value"] )
+
+			c["testSelector"] = "b"
+			self.assertEqual( s.activeInPlug( s["out"]["v"] ), s["rows"][2]["cells"]["v"]["value"] )
+			self.assertEqual( s.activeInPlug( s["out"]["v"]["x"] ), s["rows"][2]["cells"]["v"]["value"]["x"] )
+			self.assertEqual( s.activeInPlug( s["out"]["i"] ), s["rows"][2]["cells"]["i"]["value"] )
+
+			c["testSelector"] = "x"
+			self.assertEqual( s.activeInPlug( s["out"]["v"] ), s["rows"]["default"]["cells"]["v"]["value"] )
+			self.assertEqual( s.activeInPlug( s["out"]["v"]["x"] ), s["rows"]["default"]["cells"]["v"]["value"]["x"] )
+			self.assertEqual( s.activeInPlug( s["out"]["i"] ), s["rows"]["default"]["cells"]["i"]["value"] )
+
+	def testAddColumnWithName( self ) :
+
+		s = Gaffer.Spreadsheet()
+		i = s["rows"].addColumn( Gaffer.IntPlug( "x" ), name = "y" )
+		self.assertEqual( s["rows"]["default"]["cells"][0].getName(), "y" )
+		self.assertEqual( s["out"][0].getName(), "y" )
+
+	def testAddColumnCopiesCurrentValue( self ) :
+
+		p = Gaffer.IntPlug( defaultValue = 1, minValue = -10, maxValue = 10 )
+		p.setValue( 3 )
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addRow()
+		s["rows"].addColumn( p )
+
+		for row in s["rows"] :
+			self.assertEqual( row["cells"][0]["value"].defaultValue(), p.defaultValue() )
+			self.assertEqual( row["cells"][0]["value"].minValue(), p.minValue() )
+			self.assertEqual( row["cells"][0]["value"].maxValue(), p.maxValue() )
+			self.assertEqual( row["cells"][0]["value"].getValue(), p.getValue() )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -161,6 +161,7 @@ from ExtensionAlgoTest import ExtensionAlgoTest
 from ModuleTest import ModuleTest
 from NumericBookmarkSetTest import NumericBookmarkSetTest
 from NameSwitchTest import NameSwitchTest
+from SpreadsheetTest import SpreadsheetTest
 
 from IECorePreviewTest import *
 

--- a/python/GafferUI/NameValuePlugValueWidget.py
+++ b/python/GafferUI/NameValuePlugValueWidget.py
@@ -143,3 +143,23 @@ class NameValuePlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__row[-1].setEnabled( enabled )
 
 GafferUI.PlugValueWidget.registerType( Gaffer.NameValuePlug, NameValuePlugValueWidget )
+
+def __spreadsheetColumnName( plug ) :
+
+	nameValuePlug = plug.parent()
+	if plug == nameValuePlug["name"] :
+		return plug.getName()
+
+	# Use some heuristics to come up with a more helpful
+	# column name.
+
+	name = nameValuePlug.getName()
+	if name.startswith( "member" ) and nameValuePlug["name"].source().direction() != Gaffer.Plug.Direction.Out :
+		name = nameValuePlug["name"].getValue()
+
+	if name :
+		return name + plug.getName().title()
+	else :
+		return plug.getName()
+
+Gaffer.Metadata.registerValue( Gaffer.NameValuePlug, "*", "spreadsheet:columnName", __spreadsheetColumnName )

--- a/python/GafferUI/NameValuePlugValueWidget.py
+++ b/python/GafferUI/NameValuePlugValueWidget.py
@@ -123,6 +123,14 @@ class NameValuePlugValueWidget( GafferUI.PlugValueWidget ) :
 		for w in self.__row :
 			w.setReadOnly( readOnly )
 
+	def setNameVisible( self, visible ) :
+
+		self.__row[0].setVisible( visible )
+
+	def getNameVisible( self ) :
+
+		return self.__row[0].getVisible()
+
 	def _updateFromPlug( self ) :
 
 		if "enabled" in self.getPlug() :

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -293,6 +293,11 @@ def _cellWidthAndProxy( cellPlug ) :
 		"GafferUI.PresetsPlugValueWidget" : 100,
 		"GafferUI.StringPlugValueWidget" : 120,
 		"GafferUI.FileSystemPathPlugValueWidget" : 120,
+		# It's a bit naughty to refer to GafferSceneUI here.
+		# If we have other use cases, perhaps we should have
+		# a public method to allow the registration of supported
+		# widgets and their default widths.
+		"GafferSceneUI.ScenePathPlugValueWidget" : 120,
 		Gaffer.StringPlug : 120,
 
 		Gaffer.V2iPlug : 120,

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -1,0 +1,1297 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import imath
+
+import IECore
+
+import Gaffer
+import GafferUI
+
+from Qt import QtCore
+from Qt import QtWidgets
+
+Gaffer.Metadata.registerNode(
+
+	Gaffer.Spreadsheet,
+
+	"description",
+	"""
+	Provides a spreadsheet designed for easy management of sets of
+	associated plug values. Each column of the spreadsheet corresponds
+	to an output value that can be connected to drive a plug on another
+	node. Each row of the spreadsheet provides candidate values for each
+	output, along with a row name and enabled status. Row names are matched
+	against a selector to determine which row is passed through to the output.
+	Row matching is performed as follows :
+
+	- Matching starts with the second row and considers all subsequent
+	  rows one by one until a match is found. The first matching row
+	  is the one that is chosen.
+	- Matching is performed using Gaffer's standard wildcard matching.
+	  Each "name" may contain several individual patterns each separated
+	  by spaces.
+	- The first row is used as a default, and is chosen only if no other
+	  row matches.
+
+	> Note : The matching rules are identical to the ones used by the
+	> NameSwitch node.
+	""",
+
+	"nodeGadget:type", "GafferUI::AuxiliaryNodeGadget",
+	"nodeGadget:shape", "oval",
+	"uiEditor:nodeGadgetTypes", IECore.StringVectorData( [ "GafferUI::AuxiliaryNodeGadget", "GafferUI::StandardNodeGadget" ] ),
+	"auxiliaryNodeGadget:label", "#",
+
+	plugs = {
+
+		"*" : [
+
+			"noduleLayout:visible", False,
+
+		],
+
+		"selector" : [
+
+			"description",
+			"""
+			The value that the row names will be matched against.
+			Typically this will refer to a context variable using
+			the `${variableName}` syntax.
+			""",
+
+			"divider", True,
+
+		],
+
+		"rows" : [
+
+			"description",
+			"""
+			Holds a child RowPlug for each row in the spreadsheet.
+			""",
+
+		],
+
+		"rows.default" : [
+
+			"description",
+			"""
+			The default row. This provides output values when no other
+			row matches the `selector`.
+			""",
+
+		],
+
+		"rows.*.name" : [
+
+			"description",
+			"""
+			The name of the row. This is matched against the `selector`
+			to determine which row is chosen to be passed to the output.
+			May contain multiple space separated names and any of Gaffer's
+			standard wildcards.
+			""",
+
+		],
+
+		"rows.*.enabled" : [
+
+			"description",
+			"""
+			Enables or disables this row. Disabled rows are ignored.
+			""",
+
+		],
+
+		"rows.*.cells" : [
+
+			"description",
+			"""
+			Contains a child CellPlug for each column in the spreadsheet.
+			""",
+
+		],
+
+		"out" : [
+
+			"description",
+			"""
+			The outputs from the spreadsheet. Contains a child plug for each
+			column in the spreadsheet.
+			""",
+
+			"plugValueWidget:type", "",
+
+		],
+
+		"activeRowNames" : [
+
+			"description",
+			"""
+			An output plug containing the names of all currently active rows.
+			""",
+
+			"plugValueWidget:type", "",
+
+		],
+
+	}
+
+)
+
+# Metadata methods
+# ================
+#
+# We don't want to copy identical metadata onto every cell of the spreadsheet, as
+# that's a lot of pointless duplication. Instead we register metadata onto the
+# default row only, and then mirror it dynamically onto the other rows. This isn't
+# flawless because we can only mirror metadata we know the names for in advance, but
+# since we only support a limited subset of widgets in the spreadsheet it seems
+# workable.
+
+def __defaultRowMetadata( rowPlug, key ) :
+
+	rowsPlug = rowPlug.parent()
+	return Gaffer.Metadata.value( rowsPlug["default"], key )
+
+for key in [ "spreadsheet:rowNameWidthScale" ] :
+
+	Gaffer.Metadata.registerValue(
+		Gaffer.Spreadsheet.RowsPlug, "row*", key,
+		functools.partial( __defaultRowMetadata, key = key )
+	)
+
+def __correspondingDefaultPlug( plug ) :
+
+	rowPlug = plug.ancestor( Gaffer.Spreadsheet.RowPlug )
+	rowsPlug = rowPlug.parent()
+	return rowsPlug["default"].descendant( plug.relativeName( rowPlug ) )
+
+def __defaultCellMetadata( plug, key ) :
+
+	return Gaffer.Metadata.value( __correspondingDefaultPlug( plug ), key )
+
+for key in [ "spreadsheet:columnLabel", "spreadsheet:columnWidthScale", "plugValueWidget:type" ] :
+
+	Gaffer.Metadata.registerValue(
+		Gaffer.Spreadsheet.RowsPlug, "row*.cells...", key,
+		functools.partial( __defaultCellMetadata, key = key ),
+	)
+
+# Presets are tricky because we can't know their names in advance. We register
+# "presetNames" and "presetValues" arrays that we can use to gather all "preset:*"
+# metadata into on the fly.
+
+__plugPresetTypes = {
+
+	Gaffer.IntPlug : IECore.IntVectorData,
+	Gaffer.FloatPlug : IECore.FloatVectorData,
+	Gaffer.StringPlug : IECore.StringVectorData,
+
+}
+
+def __presetNamesMetadata( plug ) :
+
+	if plug.__class__ not in __plugPresetTypes :
+		return None
+
+	source = __correspondingDefaultPlug( plug )
+
+	result = IECore.StringVectorData()
+	for n in Gaffer.Metadata.registeredValues( source ) :
+		if n.startswith( "preset:" ) :
+			result.append( n[7:] )
+
+	result.extend( Gaffer.Metadata.value( source, "presetNames" ) or [] )
+	return result
+
+def __presetValuesMetadata( plug ) :
+
+	dataType = __plugPresetTypes.get( plug.__class__ )
+	if dataType is None :
+		return None
+
+	source = __correspondingDefaultPlug( plug )
+
+	result = dataType()
+	for n in Gaffer.Metadata.registeredValues( source ) :
+		if n.startswith( "preset:" ) :
+			result.append( Gaffer.Metadata.value( source, n ) )
+
+	result.extend( Gaffer.Metadata.value( source, "presetValues" ) or [] )
+	return result
+
+Gaffer.Metadata.registerValue( Gaffer.Spreadsheet.RowsPlug, "row*.cells...", "presetNames", __presetNamesMetadata )
+Gaffer.Metadata.registerValue( Gaffer.Spreadsheet.RowsPlug, "row*.cells...", "presetValues", __presetValuesMetadata )
+
+# Size constraints and spacing
+# ============================
+#
+# Because the headings, row names, default cells and regular cells of our spreadsheet
+# are all housed in different containers, we need to be careful that their sizes line
+# up so that rows and columns align correctly between the containers. We achieve this
+# by forcing fixed sizes onto the various UI elements. Some widget types just aren't
+# suited for viewing in a spreadsheet, so we fall back to displaying a proxy widget
+# for anything we haven't whitelisted.
+
+_rowHeight = 25
+_rowNameWidth = 150
+
+def _cellWidthAndProxy( cellPlug ) :
+
+	additionalWidth = 0
+	valuePlug = cellPlug["value"]
+	if isinstance( cellPlug["value"], Gaffer.NameValuePlug ) :
+		valuePlug = cellPlug["value"]["value"] # determine width from value plug
+		additionalWidth = 25 # add space for the switch
+
+	plugValueWidgetType = Gaffer.Metadata.value( valuePlug, "plugValueWidget:type" )
+	widthScale = Gaffer.Metadata.value( cellPlug, "spreadsheet:columnWidthScale" ) or 1
+
+	width = {
+
+		Gaffer.BoolPlug : 60,
+		Gaffer.IntPlug : 60,
+		Gaffer.FloatPlug : 60,
+
+		"GafferUI.PresetsPlugValueWidget" : 100,
+		"GafferUI.StringPlugValueWidget" : 120,
+		"GafferUI.FileSystemPathPlugValueWidget" : 120,
+		Gaffer.StringPlug : 120,
+
+		Gaffer.V2iPlug : 120,
+		Gaffer.V2fPlug : 120,
+
+		Gaffer.V3iPlug : 180,
+		Gaffer.V3fPlug : 180,
+
+		"GafferUI.ColorSwatchPlugValueWidget" : 60,
+		Gaffer.Color3fPlug : 200,
+		Gaffer.Color4fPlug : 260,
+
+	}.get( plugValueWidgetType or valuePlug.__class__  )
+
+	return ( width * widthScale + additionalWidth, False ) if width is not None else ( 60 * widthScale, True )
+
+def _applyFixedSize( widget, width, height ) :
+
+	layout = widget._qtWidget().layout()
+	if layout is not None :
+		layout.setSizeConstraint( QtWidgets.QLayout.SetNoConstraint )
+	widget._qtWidget().setFixedSize( width, height )
+
+_widthScales = [
+	( "Half", 0.5 ),
+	( "Single", 1 ),
+	( "Double", 2 ),
+]
+
+# Widgets
+# =======
+
+class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug ) :
+
+		grid = GafferUI.GridContainer()
+
+		GafferUI.PlugValueWidget.__init__( self, grid, plug )
+
+		with grid :
+
+			with GafferUI.ScrolledContainer(
+				horizontalMode = GafferUI.ScrollMode.Never,
+				verticalMode = GafferUI.ScrollMode.Never,
+				parenting = {
+					"index" : ( 1, 0 ),
+				}
+			) as columnHeadingsScrolledContainer :
+
+				_LinearLayoutPlugValueWidget( plug["default"]["cells"], childWidgetType = _HeaderPlugValueWidget, orientation = GafferUI.ListContainer.Orientation.Horizontal )
+
+			columnHeadingsScrolledContainer._qtWidget().setFixedHeight( _rowHeight )
+
+			GafferUI.Label(
+				"Default  ",
+				parenting = {
+					"index" : ( 0, 1 ),
+					"alignment" : ( GafferUI.HorizontalAlignment.Left, GafferUI.VerticalAlignment.None ),
+				}
+			)
+
+			with GafferUI.ScrolledContainer(
+				horizontalMode = GafferUI.ScrollMode.Never,
+				verticalMode = GafferUI.ScrollMode.Never,
+				parenting = {
+					"index" : ( 1, 1 ),
+				}
+			) as defaultRowScrolledContainer :
+
+				_LinearLayoutPlugValueWidget( plug["default"]["cells"], childWidgetType = _CellPlugValueWidget, orientation = GafferUI.ListContainer.Orientation.Horizontal )
+
+			defaultRowScrolledContainer._qtWidget().setFixedHeight( _rowHeight )
+
+			GafferUI.Divider( GafferUI.Divider.Orientation.Horizontal, parenting = { "index" : ( slice( 0, 3 ), 2 ) } )
+
+			with GafferUI.ScrolledContainer(
+				horizontalMode = GafferUI.ScrollMode.Never,
+				verticalMode = GafferUI.ScrollMode.Never,
+				parenting = {
+					"index" : ( 0, 3 ),
+				}
+			) as self.__rowNamesScrolledContainer :
+
+				self.__rowNamesPlugValueWidget = _LinearLayoutPlugValueWidget( plug, childWidgetType = _RowNamePlugValueWidget )
+
+			self.__updateRowNamesWidth()
+
+			with GafferUI.ScrolledContainer(
+				horizontalMode = GafferUI.ScrollMode.Never,
+				verticalMode = GafferUI.ScrollMode.Never,
+				parenting = {
+					"index" : ( 1, 3 ),
+				}
+			) as cellsScrolledContainer :
+
+				_LinearLayoutPlugValueWidget( plug, childWidgetType = _RowCellsPlugValueWidget )
+
+			_LinkedScrollBar(
+				GafferUI.ListContainer.Orientation.Vertical, [ cellsScrolledContainer, self.__rowNamesScrolledContainer ],
+				parenting = {
+					"index" : ( 2, 3 ),
+				}
+			)
+
+			_LinkedScrollBar(
+				GafferUI.ListContainer.Orientation.Horizontal, [ cellsScrolledContainer, columnHeadingsScrolledContainer, defaultRowScrolledContainer ],
+				parenting = {
+					"index" : ( 1, 4 ),
+				}
+			)
+
+			with GafferUI.ListContainer(
+				orientation = GafferUI.ListContainer.Orientation.Horizontal,
+				parenting = {
+					"index" : ( 0, 4 ),
+					"alignment" : ( GafferUI.HorizontalAlignment.Left, GafferUI.VerticalAlignment.Top ),
+				},
+			) :
+
+				addRowButton = GafferUI.Button( image="plus.png", hasFrame=False, toolTip = "Click to add row, or drop new row names" )
+				addRowButton.clickedSignal().connect( Gaffer.WeakMethod( self.__addRowButtonClicked ), scoped = False )
+				addRowButton.dragEnterSignal().connect( Gaffer.WeakMethod( self.__addRowButtonDragEnter ), scoped = False )
+				addRowButton.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__addRowButtonDragLeave ), scoped = False )
+				addRowButton.dropSignal().connect( Gaffer.WeakMethod( self.__addRowButtonDrop ), scoped = False )
+
+			self.__statusLabel = GafferUI.Label( "", parenting = { "index" : ( slice( 1, 5 ), 5 ) } )
+
+			# Allow a final invisible column and row to stretch. There must be better ways, but this is the only
+			# way I could find to stop the actual content columns from stretching.
+			GafferUI.Spacer( imath.V2i( 0 ), parenting = { "index" : ( 3, 6 ) } )
+			grid._qtWidget().layout().setColumnStretch( 4, 1 )
+			grid._qtWidget().layout().setRowStretch( 6, 1 )
+
+		_CellPlugValueWidget.currentCellChangedSignal().connect( Gaffer.WeakMethod( self.__currentCellChanged ), scoped = False )
+		for widget in [ addRowButton ] :
+			widget.enterSignal().connect( Gaffer.WeakMethod( self.__enterToolTippedWidget ), scoped = False )
+			widget.leaveSignal().connect( Gaffer.WeakMethod( self.__leaveToolTippedWidget ), scoped = False )
+
+		Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = False )
+
+	def hasLabel( self ) :
+
+		return True
+
+	def _updateFromPlug( self ) :
+
+		pass
+
+	def __addRowButtonClicked( self, *unused ) :
+
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			row = self.getPlug().addRow()
+
+		# Select new row for editing. Have to do this on idle as otherwise the scrollbars
+		# flicker on and off.
+		GafferUI.EventLoop.addIdleCallback( functools.partial( self.__editNewRow, row ) )
+
+	def __editNewRow( self, row ) :
+
+		rowWidget = self.__rowNamesPlugValueWidget.childPlugValueWidget( row, lazy = False )
+		rowNameWidget = rowWidget.childPlugValueWidget( row["name"] )
+		rowNameWidget.textWidget().grabFocus()
+
+		# Scroll to show row. Have to do this on idle so it comes after lazy creation of
+		# the new cells row, otherwise the offset is wrong.
+		GafferUI.EventLoop.addIdleCallback( rowNameWidget.reveal )
+
+	def __addRowButtonDragEnter( self, addButton, event ) :
+
+		if isinstance( event.data, ( IECore.StringData, IECore.StringVectorData ) ) :
+			addButton.setHighlighted( True )
+			return True
+
+		return False
+
+	def __addRowButtonDragLeave( self, addButton, event ) :
+
+		addButton.setHighlighted( False )
+		return True
+
+	def __addRowButtonDrop( self, addButton, event ) :
+
+		addButton.setHighlighted( False )
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			strings = event.data if isinstance( event.data, IECore.StringVectorData ) else [ event.data.value ]
+			for s in strings :
+				self.getPlug().addRow()["name"].setValue( s )
+
+		return True
+
+	def __currentCellChanged( self, cell ) :
+
+		status = ""
+		if cell is not None and self.isAncestorOf( cell ) :
+			rowPlug = cell.getPlug().ancestor( Gaffer.Spreadsheet.RowPlug )
+			if rowPlug.getName() == "default" :
+				rowName = "Default"
+			else :
+				with self.getContext() :
+					rowName = rowPlug["name"].getValue() or "unnamed"
+
+			status = "Row : {}, Column : {}".format(
+				rowName,
+				IECore.CamelCase.toSpaced( cell.getPlug().getName() ),
+			)
+
+		self.__statusLabel.setText( status )
+
+	def __enterToolTippedWidget( self, widget ) :
+
+		self.__statusLabel.setText( widget.getToolTip() )
+
+	def __leaveToolTippedWidget( self, widget ) :
+
+		self.__statusLabel.setText( "" )
+
+	def __updateRowNamesWidth( self ) :
+
+		scale = Gaffer.Metadata.value( self.getPlug()["default"], "spreadsheet:rowNameWidthScale" ) or 1
+		self.__rowNamesScrolledContainer._qtWidget().setFixedWidth( _rowNameWidth * scale )
+
+	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
+
+		if plug is not None and key == "spreadsheet:rowNameWidthScale" :
+			if self.getPlug().isAncestorOf( plug ) :
+				self.__updateRowNamesWidth()
+
+GafferUI.PlugValueWidget.registerType( Gaffer.Spreadsheet.RowsPlug, _RowsPlugValueWidget )
+
+class _LinearLayoutPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug, childWidgetType, orientation = GafferUI.ListContainer.Orientation.Vertical, spacing = 0, **kw ) :
+
+		self.__container = GafferUI.ListContainer( orientation = orientation, spacing = spacing )
+		GafferUI.PlugValueWidget.__init__( self, self.__container, plug, **kw )
+
+		self.__childWidgetType = childWidgetType
+		self.__widgets = {}
+
+		plug.childAddedSignal().connect( Gaffer.WeakMethod( self.__childAddedOrRemoved ), scoped = False )
+		plug.childRemovedSignal().connect( Gaffer.WeakMethod( self.__childAddedOrRemoved ), scoped = False )
+
+		self.__updateLayout()
+
+	def hasLabel( self ) :
+
+		return True
+
+	## \todo The `lazy = True` default comes from the PlugValueWidget base class, but
+	# I don't think the argument is useful at all. Confirm, and remove argument from
+	# all implementations.
+	def childPlugValueWidget( self, childPlug, lazy=True ) :
+
+		if not lazy :
+			self.__updateLayout.flush( self )
+
+		return self.__widgets.get( childPlug )
+
+	def _updateFromPlug( self ) :
+
+		pass
+
+	@GafferUI.LazyMethod()
+	def __updateLayout( self ) :
+
+		# Build layout
+
+		layout = []
+		for index, child in enumerate( Gaffer.Plug.Range( self.getPlug() ) ) :
+
+			if isinstance( child, Gaffer.Spreadsheet.RowPlug ) and index == 0 :
+				# Ignore the default row, since this is shown separately.
+				continue
+
+			widget = self.__widgets.get( child )
+			if widget is None :
+				widget = self.__childWidgetType( child )
+				self.__widgets[child] = widget
+
+			if hasattr( widget, "setAlternate" ) :
+				widget.setAlternate( len( layout ) % 2 )
+
+			layout.append( widget )
+
+		# Ditch old widgets we don't need and update our container
+
+		layoutSet = set( layout )
+		self.__widgets = { k : v for k, v in self.__widgets.items() if v in layoutSet }
+		self.__container[:] = layout
+
+	def __childAddedOrRemoved( self, *unused ) :
+
+		self.__updateLayout()
+
+class _RowNamePlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug ) :
+
+		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
+		row._qtWidget().setFixedHeight( _rowHeight )
+		row._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetNoConstraint )
+
+		GafferUI.PlugValueWidget.__init__( self, row, plug )
+		with row :
+
+				self.__namePlugValueWidget = GafferUI.StringPlugValueWidget( plug["name"] )
+				self.__enabledPlugValueWidget = GafferUI.BoolPlugValueWidget( plug["enabled"], displayMode = GafferUI.BoolWidget.DisplayMode.Switch )
+
+		self._updateFromPlug()
+
+	def hasLabel( self ) :
+
+		return True
+
+	def childPlugValueWidget( self, childPlug, lazy=True ) :
+
+		if childPlug == self.getPlug()["name"] :
+			return self.__namePlugValueWidget
+		elif childPlug == self.getPlug()["enabled"] :
+			return self.__enabledPlugValueWidget
+
+		return None
+
+	def setReadOnly( self, readOnly ) :
+
+		if readOnly == self.getReadOnly() :
+			return
+
+		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
+
+		self.__namePlugValueWidget.setReadOnly( self, readOnly )
+		self.__enabledPlugValueWidget.setReadOnly( self, readOnly )
+
+	def _updateFromPlug( self ) :
+
+		enabled = False
+		with self.getContext() :
+			with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
+				enabled = self.getPlug()["enabled"].getValue()
+
+		self.__namePlugValueWidget.setEnabled( enabled )
+
+class _RowCellsPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug ) :
+
+		self.__row = _LinearLayoutPlugValueWidget( plug["cells"], childWidgetType = _CellPlugValueWidget, orientation = GafferUI.ListContainer.Orientation.Horizontal )
+		GafferUI.PlugValueWidget.__init__( self, self.__row, plug )
+
+	def _updateFromPlug( self ) :
+
+		enabled = False
+		with self.getContext() :
+			with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
+				enabled = self.getPlug()["enabled"].getValue()
+
+		self.__row.setEnabled( enabled )
+
+class _HeaderPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug, **kw ) :
+
+		self.__label = GafferUI.Label()
+		GafferUI.PlugValueWidget.__init__( self, self.__label, plug, **kw )
+
+		self.contextMenuSignal().connect( Gaffer.WeakMethod( self.__contextMenu ), scoped = False )
+
+		self._updateFromPlug()
+
+	def _updateFromPlug( self ) :
+
+		self.__label.setText( "<b>" + self.__plugLabel() + "</b>" )
+		_applyFixedSize( self.__label, _cellWidthAndProxy( self.getPlug() )[0], _rowHeight )
+
+	def __plugLabel( self ) :
+
+		label = Gaffer.Metadata.value( self.getPlug(), "spreadsheet:columnLabel" )
+		if not label :
+			label = IECore.CamelCase.toSpaced( self.getPlug().getName() )
+
+		return label
+
+	def __contextMenu( self, widget ) :
+
+		readOnly = self.getReadOnly() or Gaffer.MetadataAlgo.readOnly( self.getPlug() )
+
+		menuDefinition = IECore.MenuDefinition()
+		menuDefinition.append(
+			"/Set Label...",
+			{
+				"command" : Gaffer.WeakMethod( self.__setLabel ),
+				"active" : not readOnly,
+			}
+		)
+
+		currentWidthScale = Gaffer.Metadata.value( self.getPlug(), "spreadsheet:columnWidthScale" ) or 1
+		for label, widthScale in _widthScales :
+			menuDefinition.append(
+				"/Width/{}".format( label ),
+				{
+					"command" : functools.partial( Gaffer.WeakMethod( self.__setWidth ), widthScale ),
+					"active" : not readOnly,
+					"checkBox" : widthScale == currentWidthScale,
+				}
+			)
+
+		menuDefinition.append( "/DeleteDivider", { "divider" : True } )
+
+		menuDefinition.append(
+			"/Delete Column",
+			{
+				"command" : Gaffer.WeakMethod( self.__deleteColumn ),
+				"active" : not readOnly,
+			}
+		)
+
+		self.__menu = GafferUI.Menu( menuDefinition )
+		self.__menu.popup()
+
+	def __setLabel( self ) :
+
+		label = GafferUI.TextInputDialogue(
+			title = "Set Label",
+			confirmLabel = "Set",
+			initialText = self.__plugLabel()
+		).waitForText()
+
+		if label is not None :
+			with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+				Gaffer.Metadata.registerValue( self.getPlug(), "spreadsheet:columnLabel", label )
+
+	def __setWidth( self, width, *unused ) :
+
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+				Gaffer.Metadata.registerValue( self.getPlug(), "spreadsheet:columnWidthScale", width )
+
+	def __deleteColumn( self ) :
+
+		rowsPlug = self.getPlug().ancestor( Gaffer.Spreadsheet.RowsPlug )
+		with Gaffer.UndoScope( rowsPlug.ancestor( Gaffer.ScriptNode ) ) :
+			rowsPlug.removeColumn( self.getPlug().parent().children().index( self.getPlug() ) )
+
+class _CellPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug, **kw ) :
+
+		self.__frame = GafferUI.Frame( borderStyle = GafferUI.Frame.BorderStyle.None, borderWidth = 0 )
+		GafferUI.PlugValueWidget.__init__( self, self.__frame, plug, **kw )
+
+		width, proxy = _cellWidthAndProxy( plug )
+
+		if proxy :
+			plugValueWidget = _ProxyPlugValueWidget( self.getPlug()["value"] )
+		else :
+			plugValueWidget = GafferUI.PlugValueWidget.create( self.getPlug()["value"] )
+			if isinstance( plugValueWidget, GafferUI.NameValuePlugValueWidget ) :
+				plugValueWidget.setNameVisible( False )
+
+		self.__frame.setChild( plugValueWidget )
+
+		_applyFixedSize( self.__frame, width, _rowHeight )
+		self.__frame._qtWidget().setProperty( "gafferAdjoinedTop", True )
+		self.__frame._qtWidget().setProperty( "gafferAdjoinedBottom", True )
+		self.__frame._qtWidget().setProperty( "gafferAdjoinedLeft", True )
+		self.__frame._qtWidget().setProperty( "gafferAdjoinedRight", True )
+
+		self.__alternate = None
+		self.setAlternate( False )
+
+		self._addPopupMenu( self.__frame )
+
+		self.__frame.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__doubleClick ), scoped = False )
+
+		self.enterSignal().connect( Gaffer.WeakMethod( self.__enter ), scoped = False )
+		self.leaveSignal().connect( Gaffer.WeakMethod( self.__leave ), scoped = False )
+
+		Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = False )
+
+		self._updateFromPlug()
+
+	def setAlternate( self, alternate ) :
+
+		alternate = bool( alternate )
+		if self.__alternate == alternate :
+			return
+
+		self.__alternate = alternate
+		self.__frame._qtWidget().setProperty( "gafferAlternate", alternate )
+		self.__frame._repolish()
+
+	def getAlternate( self ) :
+
+		return self.__alternate
+
+	@classmethod
+	def currentCellChangedSignal( cls ) :
+
+		return cls.__currentCellChangedSignal
+
+	__currentCellChangedSignal = GafferUI.WidgetSignal()
+
+	def _updateFromPlug( self ) :
+
+		with self.getContext() :
+			enabled = self.getPlug()["enabled"].getValue()
+
+		if enabled :
+			self.__frame.getChild().setVisible( True )
+		else :
+			self.__frame.getChild().setVisible( False )
+
+	def __enter( self, widget ) :
+
+		self.currentCellChangedSignal()( self )
+
+	def __leave( self, widget ) :
+
+		self.currentCellChangedSignal()( None )
+
+	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
+
+		if plug is not None and key == "spreadsheet:columnWidthScale" :
+			if plug.commonAncestor( self.getPlug(), Gaffer.Spreadsheet.RowsPlug ) :
+				# We inherit "spreadsheet:columnWidthScale" from the cells of the default
+				# row, so need to update when that changes.
+				_applyFixedSize( self.__frame, _cellWidthAndProxy( self.getPlug() )[0], _rowHeight )
+
+	def __doubleClick( self, widget, event ) :
+
+		if event.buttons != event.Buttons.Left :
+			return False
+
+		if self.__frame.getChild().getVisible() :
+			return False
+
+		if self.getReadOnly() or Gaffer.MetadataAlgo.readOnly( self.getPlug()["enabled"] ) :
+			return False
+
+		if not self.getPlug()["enabled"].settable() :
+			return False
+
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			self.getPlug()["enabled"].setValue( True )
+
+		return True
+
+class _ProxyPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug, **kw ) :
+
+		button = GafferUI.Button( "Edit..." )
+		GafferUI.PlugValueWidget.__init__( self, button, plug, **kw )
+
+		button.clickedSignal().connect( self.__clicked, scoped = False )
+
+	def getToolTip( self ) :
+
+		result = GafferUI.PlugValueWidget.getToolTip( self )
+		if not hasattr( self.getPlug(), "getValue" ) :
+			return result
+
+		with self.getContext() :
+			value = self.getPlug().getValue()
+			result += "\n\n### Current value\n\n" + str( value )
+
+		return result
+
+	def _updateFromPlug( self ) :
+
+		pass
+
+	def __clicked( self, button ) :
+
+		_PlugValueDialogue.acquire( self.getPlug() )
+
+## \todo See comments for `ColorSwatchPlugValueWidget._ColorPlugValueDialogue`.
+# and `SplinePlugValueWidget._SplinePlugValueDialogue`.
+class _PlugValueDialogue( GafferUI.Dialogue ) :
+
+	def __init__( self, plug ) :
+
+		GafferUI.Dialogue.__init__(
+			self,
+			plug.relativeName( plug.ancestor( Gaffer.ScriptNode ) )
+		)
+
+		self.__plug = plug
+		self.setChild( GafferUI.PlugValueWidget.create( plug ) )
+
+		plug.parentChangedSignal().connect( Gaffer.WeakMethod( self.__destroy ), scoped = False )
+		plug.node().parentChangedSignal().connect( Gaffer.WeakMethod( self.__destroy ), scoped = False )
+
+	@classmethod
+	def acquire( cls, plug ) :
+
+		script = plug.node().scriptNode()
+		scriptWindow = GafferUI.ScriptWindow.acquire( script )
+
+		for window in scriptWindow.childWindows() :
+			if isinstance( window, cls ) and window.__plug == plug :
+				window.setVisible( True )
+				return window
+
+		window = cls( plug )
+		scriptWindow.addChildWindow( window, removeOnClose = True )
+		window.setVisible( True )
+
+		return window
+
+	def __destroy( self, *unused ) :
+
+		self.parent().removeChild( self )
+
+# ScrolledContainer linking
+# =========================
+#
+# To keep the row and column names and default cells visible at all times, we
+# need to house them in separate ScrolledContainers from the main one. But we
+# want to link the scrolling of them all, so they still act as a unit. We achieve
+# this using the _LinkedScrollBar widget, which provides two-way coupling between
+# the scrollbars of each container.
+## \todo : Consider making this public as part of ScrolledContainer. If you do that,
+# you will want to move the Orientation enum from ListContainer into `GafferUI.Enums`.
+
+class _LinkedScrollBar( GafferUI.Widget ) :
+
+	def __init__( self, orientation, scrolledContainers, **kw ) :
+
+		GafferUI.Widget.__init__(
+			self,
+			_StepsChangedScrollBar(
+				QtCore.Qt.Orientation.Horizontal if orientation == GafferUI.ListContainer.Orientation.Horizontal else QtCore.Qt.Orientation.Vertical
+			),
+			**kw
+		)
+
+		self.__scrollBars = [ self._qtWidget() ]
+		for container in scrolledContainers :
+			if orientation == GafferUI.ListContainer.Orientation.Horizontal :
+				if not isinstance( container._qtWidget().horizontalScrollBar(), _StepsChangedScrollBar ) :
+					container._qtWidget().setHorizontalScrollBar( _StepsChangedScrollBar( QtCore.Qt.Orientation.Horizontal ) )
+				self.__scrollBars.append( container._qtWidget().horizontalScrollBar() )
+			else :
+				if not isinstance( container._qtWidget().verticalScrollBar(), _StepsChangedScrollBar ) :
+					container._qtWidget().setVerticalScrollBar( _StepsChangedScrollBar( QtCore.Qt.Orientation.Vertical ) )
+				self.__scrollBars.append( container._qtWidget().verticalScrollBar() )
+
+		self._qtWidget().setValue( self.__scrollBars[1].value() )
+		self._qtWidget().setRange( self.__scrollBars[1].minimum(), self.__scrollBars[1].maximum() )
+		self._qtWidget().setPageStep( self.__scrollBars[1].pageStep() )
+		self._qtWidget().setSingleStep( self.__scrollBars[1].singleStep() )
+		self.setVisible( self._qtWidget().minimum() != self._qtWidget().maximum() )
+
+		for scrollBar in self.__scrollBars :
+			scrollBar.valueChanged.connect( Gaffer.WeakMethod( self.__valueChanged ) )
+			scrollBar.rangeChanged.connect( Gaffer.WeakMethod( self.__rangeChanged ) )
+			scrollBar.stepsChanged.connect( Gaffer.WeakMethod( self.__stepsChanged ) )
+
+	def __valueChanged( self, value ) :
+
+		for scrollBar in self.__scrollBars :
+			scrollBar.setValue( value )
+
+	def __rangeChanged( self, min, max ) :
+
+		for scrollBar in self.__scrollBars :
+			scrollBar.setRange( min, max )
+
+		self.setVisible( min != max )
+
+	def __stepsChanged( self, page, single ) :
+
+		for scrollBar in self.__scrollBars :
+			scrollBar.setPageStep( page )
+			scrollBar.setSingleStep( single )
+
+# QScrollBar provides signals for when the value and range are changed,
+# but not for when the page step is changed. This subclass adds the missing
+# signal.
+class _StepsChangedScrollBar( QtWidgets.QScrollBar ) :
+
+	stepsChanged = QtCore.Signal( int, int )
+
+	def __init__( self, orientation, parent = None ) :
+
+		QtWidgets.QScrollBar.__init__( self, orientation, parent )
+
+	def sliderChange( self, change ) :
+
+		QtWidgets.QScrollBar.sliderChange( self, change )
+
+		if change == self.SliderStepsChange :
+			self.stepsChanged.emit( self.pageStep(), self.singleStep() )
+
+# Plug context menu
+# =================
+
+def __setPlugValue( plug, value ) :
+
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
+		plug.setValue( value )
+
+def __deleteRow( rowPlug ) :
+
+	with Gaffer.UndoScope( rowPlug.ancestor( Gaffer.ScriptNode ) ) :
+		rowPlug.parent().removeChild( rowPlug )
+
+def __setRowNameWidth( rowPlug, widthScale, *unused ) :
+
+	defaultRowPlug = rowPlug.parent()["default"]
+	with Gaffer.UndoScope( defaultRowPlug.ancestor( Gaffer.ScriptNode ) ) :
+		Gaffer.Metadata.registerValue( defaultRowPlug, "spreadsheet:rowNameWidthScale", widthScale )
+
+def __prependRowAndCellMenuItems( menuDefinition, plugValueWidget ) :
+
+	rowPlug = plugValueWidget.getPlug().ancestor( Gaffer.Spreadsheet.RowPlug )
+	if rowPlug is None :
+		return
+
+	# Row menu items
+
+	if isinstance( plugValueWidget, _RowNamePlugValueWidget ) :
+		rowNamePlugValueWidget = plugValueWidget
+	else :
+		rowNamePlugValueWidget = plugValueWidget.ancestor( _RowNamePlugValueWidget )
+
+	if rowNamePlugValueWidget and rowPlug.getName() != "default" :
+
+		menuDefinition.prepend(
+			"/Delete Row",
+			{
+				"command" : functools.partial( __deleteRow, rowPlug ),
+				"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( rowPlug )
+
+			}
+		)
+
+		currentWidthScale = Gaffer.Metadata.value( rowPlug, "spreadsheet:rowNameWidthScale" ) or 1
+		for label, widthScale in reversed( _widthScales ) :
+			menuDefinition.prepend(
+				"/Width/{}".format( label ),
+				{
+					"command" : functools.partial( __setRowNameWidth, rowPlug, widthScale ),
+					"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( rowPlug ),
+					"checkBox" : widthScale == currentWidthScale,
+				}
+			)
+
+	# Cell menu items
+
+	cellPlugValueWidget = None
+	if isinstance( plugValueWidget, _CellPlugValueWidget ) :
+		cellPlugValueWidget = plugValueWidget
+	else :
+		cellPlugValueWidget = plugValueWidget.ancestor( _CellPlugValueWidget )
+
+	if cellPlugValueWidget is not None :
+
+		if rowPlug.getName() != "default" :
+
+			enabled = None
+			enabledPlug = cellPlugValueWidget.getPlug()["enabled"]
+			with plugValueWidget.getContext() :
+				with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
+					enabled = enabledPlug.getValue()
+
+			menuDefinition.prepend(
+				"/Disable Cell" if enabled else "/Enable Cell",
+				{
+					"command" : functools.partial( __setPlugValue, enabledPlug, not enabled ),
+					"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( enabledPlug ) and enabledPlug.settable()
+				}
+			)
+
+def __addColumn( spreadsheet, plug ) :
+
+	# We allow the name of a column to be overridden by metadata, so that NameValuePlug and
+	# TweakPlug can provide more meaningful names than "name" or "enabled" when their child
+	# plugs are added to spreadsheets.
+	columnName = Gaffer.Metadata.value( plug, "spreadsheet:columnName" ) or plug.getName()
+
+	columnIndex = spreadsheet["rows"].addColumn( plug, columnName )
+	valuePlug = spreadsheet["rows"]["default"]["cells"][columnIndex]["value"]
+	Gaffer.MetadataAlgo.copy( plug, valuePlug )
+	if isinstance( plug, ( Gaffer.Color3fPlug, Gaffer.Color4fPlug ) ) :
+		# Space is at a premium in spreadsheets, so prefer a single colour
+		# swatch over numeric fields.
+		Gaffer.Metadata.registerValue( valuePlug, "plugValueWidget:type", "GafferUI.ColorSwatchPlugValueWidget" )
+
+	return columnIndex
+
+def __createSpreadsheet( plug ) :
+
+	spreadsheet = Gaffer.Spreadsheet()
+	__addColumn( spreadsheet, plug )
+	spreadsheet["rows"].addRow()
+
+	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+		plug.node().parent().addChild( spreadsheet )
+		plug.setInput( spreadsheet["out"][0] )
+
+	GafferUI.NodeEditor.acquire( spreadsheet )
+
+def __addToSpreadsheet( plug, spreadsheet ) :
+
+	with Gaffer.UndoContext( spreadsheet.ancestor( Gaffer.ScriptNode ) ) :
+		columnIndex = __addColumn( spreadsheet, plug )
+		plug.setInput( spreadsheet["out"][columnIndex] )
+
+def __addToSpreadsheetSubMenu( plug ) :
+
+	menuDefinition = IECore.MenuDefinition()
+
+	alreadyConnected = []
+	other = []
+	for spreadsheet in Gaffer.Spreadsheet.Range( plug.node().parent() ) :
+
+		connected = False
+		for output in spreadsheet["out"] :
+			for destination in output.outputs() :
+				if destination.node() == plug.node() :
+					connected = True
+					break
+			if connected :
+				break
+
+		if connected :
+			alreadyConnected.append( spreadsheet )
+		else :
+			other.append( spreadsheet )
+
+	if not alreadyConnected and not other :
+		menuDefinition.append(
+			"/No Spreadsheets Available",
+			{
+				"active" : False,
+			}
+		)
+		return menuDefinition
+
+	alreadyConnected.sort( key = Gaffer.GraphComponent.getName )
+	other.sort( key = Gaffer.GraphComponent.getName )
+
+	def addItem( spreadsheet ) :
+
+		menuDefinition.append(
+			"/" + spreadsheet.getName(),
+			{
+				"command" : functools.partial( __addToSpreadsheet, plug, spreadsheet )
+			}
+		)
+
+	if alreadyConnected and other :
+		menuDefinition.append( "/__ConnectedDivider__", { "divider" : True, "label" : "Connected" } )
+
+	for spreadsheet in alreadyConnected :
+		addItem( spreadsheet )
+
+	if alreadyConnected and other :
+		menuDefinition.append( "/__OtherDivider__", { "divider" : True, "label" : "Other" } )
+
+	for spreadsheet in other :
+		addItem( spreadsheet )
+
+	return menuDefinition
+
+def __prependSpreadsheetCreationMenuItems( menuDefinition, plugValueWidget ) :
+
+	plug = plugValueWidget.getPlug()
+	if not isinstance( plug, Gaffer.ValuePlug ) :
+		return
+
+	node = plug.node()
+	if node is None or node.parent() is None :
+		return
+
+	if plug.getInput() is not None or not plugValueWidget._editable() or Gaffer.MetadataAlgo.readOnly( plug ) :
+		return
+
+	ancestorPlug, ancestorLabel = None, ""
+	for ancestorType, ancestorLabel in [
+		( Gaffer.TransformPlug, "Transform" ),
+		( Gaffer.Transform2DPlug, "Transform" ),
+		( Gaffer.NameValuePlug, "Value and Switch" ),
+	] :
+		ancestorPlug = plug.ancestor( ancestorType )
+		if ancestorPlug :
+			if all( p.getInput() is None for p in Gaffer.Plug.RecursiveRange( ancestorPlug ) ) :
+				break
+			else :
+				ancestorPlug = None
+
+	if ancestorPlug :
+		menuDefinition.prepend(
+			"/Add to Spreadsheet ({})".format( ancestorLabel ),
+			{
+				"subMenu" :  functools.partial( __addToSpreadsheetSubMenu, ancestorPlug )
+			}
+		)
+		menuDefinition.prepend(
+			"/Create Spreadsheet ({})...".format( ancestorLabel ),
+			{
+				"command" : functools.partial( __createSpreadsheet, ancestorPlug )
+			}
+		)
+
+		menuDefinition.prepend(
+			"/__AncestorDivider__", { "divider" : True }
+		)
+
+	menuDefinition.prepend(
+		"/Add to Spreadsheet",
+		{
+			"subMenu" :  functools.partial( __addToSpreadsheetSubMenu, plug )
+		}
+	)
+
+	menuDefinition.prepend(
+		"/Create Spreadsheet...",
+		{
+			"command" : functools.partial( __createSpreadsheet, plug )
+		}
+	)
+
+def __plugPopupMenu( menuDefinition, plugValueWidget ) :
+
+	menuDefinition.prepend( "/SpreadsheetDivider", { "divider" : True } )
+
+	## \todo We're prepending rather than appending so that we get the ordering we
+	# want with respect to the Expression menu items. Really we need external control
+	# over this ordering.
+	__prependRowAndCellMenuItems( menuDefinition, plugValueWidget )
+	__prependSpreadsheetCreationMenuItems( menuDefinition, plugValueWidget )
+
+GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu, scoped = False )
+
+# NodeEditor tool menu
+# ====================
+
+def __createSpreadsheetForNode( node, activeRowNamesConnection, selectorContextVariablePlug, selectorValue ) :
+
+	with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
+
+		spreadsheet = Gaffer.Spreadsheet( node.getName() + "Spreadsheet" )
+
+		with node.scriptNode().context() :
+			rowNames = activeRowNamesConnection.getValue()
+		activeRowNamesConnection.setInput( spreadsheet["activeRowNames"] )
+
+		if rowNames :
+			for rowName in rowNames :
+				spreadsheet["rows"].addRow()["name"].setValue( rowName )
+		else :
+			spreadsheet["rows"].addRow()
+
+		if selectorValue is None :
+			selectorValue = "${" + selectorContextVariablePlug.getValue() + "}"
+			Gaffer.MetadataAlgo.setReadOnly( selectorContextVariablePlug, True )
+
+		if selectorValue :
+			spreadsheet["selector"].setValue( selectorValue )
+			Gaffer.MetadataAlgo.setReadOnly( spreadsheet["selector"], True )
+
+		node.parent().addChild( spreadsheet )
+
+	GafferUI.NodeEditor.acquire( spreadsheet )
+
+def __nodeEditorToolMenu( nodeEditor, node, menuDefinition ) :
+
+	if node.parent() is None :
+		return
+
+	activeRowNamesConnection = Gaffer.Metadata.value( node, "ui:spreadsheet:activeRowNamesConnection" )
+	if not activeRowNamesConnection :
+		return
+	else :
+		activeRowNamesConnection = node.descendant( activeRowNamesConnection )
+		assert( activeRowNamesConnection is not None )
+
+	selectorContextVariablePlug = Gaffer.Metadata.value( node, "ui:spreadsheet:selectorContextVariablePlug" )
+	if selectorContextVariablePlug :
+		selectorContextVariablePlug = node.descendant( selectorContextVariablePlug )
+		assert( selectorContextVariablePlug is not None )
+
+	selectorValue = Gaffer.Metadata.value( node, "ui:spreadsheet:selectorValue" )
+	assert( not ( selectorValue and selectorContextVariablePlug ) )
+
+	menuDefinition.append( "/SpreadsheetDivider", { "divider" : True } )
+	menuDefinition.append(
+		"/Create Spreadsheet...",
+		{
+			"command" : functools.partial( __createSpreadsheetForNode, node, activeRowNamesConnection, selectorContextVariablePlug, selectorValue ),
+			"active" : (
+				not nodeEditor.getReadOnly()
+				and not Gaffer.MetadataAlgo.readOnly( node )
+				and not Gaffer.MetadataAlgo.readOnly( activeRowNamesConnection )
+			)
+		}
+	)
+
+GafferUI.NodeEditor.toolMenuSignal().connect( __nodeEditorToolMenu, scoped = False )

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -179,6 +179,24 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 			}
 		)
 
+		nodeGadgetTypes = Gaffer.Metadata.value( node, "uiEditor:nodeGadgetTypes" )
+		if nodeGadgetTypes :
+			nodeGadgetTypes = set( nodeGadgetTypes )
+			if nodeGadgetTypes == { "GafferUI::AuxiliaryNodeGadget", "GafferUI::StandardNodeGadget" } :
+				nodeGadgetType = Gaffer.Metadata.value( node, "nodeGadget:type" ) or "GafferUI::StandardNodeGadget"
+				menuDefinition.append(
+					"/Show Name",
+					{
+						"command" : functools.partial( cls.__setNameVisible, node ),
+						"checkBox" : nodeGadgetType == "GafferUI::StandardNodeGadget",
+						"active" : not Gaffer.MetadataAlgo.readOnly( node ),
+					}
+				)
+			else :
+				# We want to present the options above as a simple "Show Name" checkbox, and haven't yet
+				# decided how to present other combinations of allowable gadgets.
+				IECore.msg( IECore.msg.Warning, "UIEditor", 'Unknown combination of "uiEditor:nodeGadgetTypes"' )
+
 	@classmethod
 	def appendNodeEditorToolMenuDefinitions( cls, nodeEditor, node, menuDefinition ) :
 
@@ -316,6 +334,14 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 			with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
 				Gaffer.Metadata.registerValue( node, "nodeGadget:color", color )
 
+	@staticmethod
+	def __setNameVisible( node, nameVisible ) :
+
+		with Gaffer.UndoContext( node.ancestor( Gaffer.ScriptNode ) ) :
+			Gaffer.Metadata.registerValue(
+				node, "nodeGadget:type",
+				"GafferUI::StandardNodeGadget" if nameVisible else "GafferUI::AuxiliaryNodeGadget"
+			)
 
 GafferUI.Editor.registerType( "UIEditor", UIEditor )
 

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -312,6 +312,7 @@ from NameValuePlugValueWidget import NameValuePlugValueWidget
 import DependencyNodeUI
 import ComputeNodeUI
 import RandomUI
+import SpreadsheetUI
 import ExpressionUI
 import BoxUI
 import ReferenceUI

--- a/src/Gaffer/Context.cpp
+++ b/src/Gaffer/Context.cpp
@@ -38,6 +38,7 @@
 #include "Gaffer/Context.h"
 
 #include "IECore/SimpleTypedData.h"
+#include "IECore/VectorTypedData.h"
 
 #include "boost/lexical_cast.hpp"
 
@@ -480,6 +481,24 @@ void Context::substituteInternal( const char *s, std::string &result, const int 
 									static_cast<const IECore::IntData *>( d )->readable()
 								);
 								break;
+							case IECore::InternedStringVectorDataTypeId : {
+								// This is unashamedly tailored to the needs of GafferScene's `${scene:path}`
+								// variable. We could make this cleaner by adding a mechanism for registering custom
+								// formatters, but that would be overkill for this one use case.
+								const auto &v = static_cast<const IECore::InternedStringVectorData *>( d )->readable();
+								if( v.empty() )
+								{
+									result += "/";
+								}
+								else
+								{
+									for( const auto &x : v )
+									{
+										result += "/" + x.string();
+									}
+								}
+								break;
+							}
 							default :
 								break;
 						}

--- a/src/Gaffer/Spreadsheet.cpp
+++ b/src/Gaffer/Spreadsheet.cpp
@@ -1,0 +1,532 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/Spreadsheet.h"
+
+#include "Gaffer/StringPlug.h"
+
+#include "boost/container/small_vector.hpp"
+
+using namespace std;
+using namespace IECore;
+using namespace Gaffer;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+void appendLeafPlugs( const Gaffer::Plug *p, DependencyNode::AffectedPlugsContainer &container )
+{
+	if( !p->children().size() )
+	{
+		container.push_back( p );
+	}
+	else
+	{
+		for( const auto &c : Plug::Range( *p ) )
+		{
+			appendLeafPlugs( c.get(), container );
+		}
+	}
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// RowsPlug
+//////////////////////////////////////////////////////////////////////////
+
+GAFFER_PLUG_DEFINE_TYPE( Spreadsheet::RowsPlug );
+
+Spreadsheet::RowsPlug::RowsPlug( const std::string &name, Direction direction, unsigned flags )
+	:	ValuePlug( name, direction, flags )
+{
+	RowPlugPtr defaultRow = new RowPlug( "default" );
+	addChild( defaultRow );
+}
+
+size_t Spreadsheet::RowsPlug::addColumn( const ValuePlug *value, IECore::InternedString name )
+{
+	if( name.string().empty() )
+	{
+		name = value->getName();
+	}
+
+	for( auto &row : RowPlug::Range( *this ) )
+	{
+		CellPlugPtr cellPlug = new CellPlug( name, value );
+		cellPlug->valuePlug()->setFrom( value );
+		row->cellsPlug()->addChild( cellPlug );
+	}
+	if( auto *o = outPlug() )
+	{
+		PlugPtr outColumn = value->createCounterpart( name, Plug::Out );
+		outColumn->setFlags( Plug::Dynamic, false );
+		o->addChild( outColumn );
+	}
+	return getChild<RowPlug>( 0 )->cellsPlug()->children().size() - 1;
+
+}
+
+void Spreadsheet::RowsPlug::removeColumn( size_t columnIndex )
+{
+	if( columnIndex >= getChild<RowPlug>( 0 )->cellsPlug()->children().size() )
+	{
+		throw IECore::Exception( "Column index out of range" );
+	}
+
+	for( auto &row : RowPlug::Range( *this ) )
+	{
+		row->cellsPlug()->removeChild( row->cellsPlug()->getChild( columnIndex ) );
+	}
+	if( auto *o = outPlug() )
+	{
+		o->removeChild( o->getChild( columnIndex ) );
+	}
+}
+
+Spreadsheet::RowPlug *Spreadsheet::RowsPlug::addRow()
+{
+	RowPlugPtr newRow = new RowPlug( "row1" );
+	for( auto &defaultCell : CellPlug::Range( *getChild<RowPlug>( 0 )->cellsPlug() ) )
+	{
+		CellPlugPtr newCell = boost::static_pointer_cast<CellPlug>(
+			defaultCell->createCounterpart( defaultCell->getName(), Plug::In )
+		);
+		newCell->setFrom( defaultCell.get() );
+		newRow->cellsPlug()->addChild( newCell );
+	}
+	addChild( newRow );
+	return newRow.get();
+}
+
+void Spreadsheet::RowsPlug::addRows( size_t numRows )
+{
+	for( ; numRows; --numRows )
+	{
+		addRow();
+	}
+}
+
+Gaffer::ValuePlug *Spreadsheet::RowsPlug::outPlug()
+{
+	// Find the `outPlug()` on our parent Spreadsheet node.
+	// We use this from `add/removeColumn()` so that we can
+	// add the appropriate columns to the output plug. It's
+	// not ideal that this responsibility falls to us. What
+	// might be nice would be to rename RowsPlug to SheetPlug
+	// and let it manage both "rows" and "out" children, so
+	// that it's more natural to modify "out". We can't do that
+	// at present because we don't allow connections to plugs
+	// which have a mix of input and output children.
+	if( auto *s = parent<Spreadsheet>() )
+	{
+		return s->outPlug();
+	}
+	return nullptr;
+}
+
+
+Gaffer::PlugPtr Spreadsheet::RowsPlug::createCounterpart( const std::string &name, Direction direction ) const
+{
+	RowsPlugPtr result = new RowsPlug( name, direction, getFlags() );
+	for( const auto &row : RowPlug::Range( *this ) )
+	{
+		result->setChild( row->getName(), row->createCounterpart( row->getName(), direction ) );
+	}
+	return result;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// RowPlug
+//////////////////////////////////////////////////////////////////////////
+
+GAFFER_PLUG_DEFINE_TYPE( Spreadsheet::RowPlug );
+
+Spreadsheet::RowPlug::RowPlug( const std::string &name, Plug::Direction direction )
+	:	ValuePlug( name )
+{
+	addChild( new StringPlug( "name", direction ) );
+	addChild( new BoolPlug( "enabled",direction, true ) );
+	addChild( new ValuePlug( "cells", direction ) );
+}
+
+StringPlug *Spreadsheet::RowPlug::namePlug()
+{
+	return getChild<StringPlug>( 0 );
+}
+
+const StringPlug *Spreadsheet::RowPlug::namePlug() const
+{
+	return getChild<StringPlug>( 0 );
+}
+
+BoolPlug *Spreadsheet::RowPlug::enabledPlug()
+{
+	return getChild<BoolPlug>( 1 );
+}
+
+const BoolPlug *Spreadsheet::RowPlug::enabledPlug() const
+{
+	return getChild<BoolPlug>( 1 );
+}
+
+ValuePlug *Spreadsheet::RowPlug::cellsPlug()
+{
+	return getChild<ValuePlug>( 2 );
+}
+
+const ValuePlug *Spreadsheet::RowPlug::cellsPlug() const
+{
+	return getChild<ValuePlug>( 2 );
+}
+
+Gaffer::PlugPtr Spreadsheet::RowPlug::createCounterpart( const std::string &name, Direction direction ) const
+{
+	RowPlugPtr result = new RowPlug( name, direction );
+	for( const auto &cell : CellPlug::Range( *cellsPlug() ) )
+	{
+		result->cellsPlug()->addChild( cell->createCounterpart( cell->getName(), direction ) );
+	}
+	return result;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// CellPlug
+//////////////////////////////////////////////////////////////////////////
+
+GAFFER_PLUG_DEFINE_TYPE( Spreadsheet::CellPlug );
+
+Spreadsheet::CellPlug::CellPlug( const std::string &name, const Gaffer::Plug *value, Plug::Direction direction )
+	:	ValuePlug( name, direction )
+{
+	addChild( new BoolPlug( "enabled", direction, true ) );
+	addChild( value->createCounterpart( "value", direction ) );
+	valuePlug()->setFlags( Plug::Dynamic, false );
+}
+
+BoolPlug *Spreadsheet::CellPlug::enabledPlug()
+{
+	return getChild<BoolPlug>( 0 );
+}
+
+const BoolPlug *Spreadsheet::CellPlug::enabledPlug() const
+{
+	return getChild<BoolPlug>( 0 );
+}
+
+Gaffer::PlugPtr Spreadsheet::CellPlug::createCounterpart( const std::string &name, Direction direction ) const
+{
+	return new CellPlug( name, valuePlug(), direction );
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Spreadsheet
+//////////////////////////////////////////////////////////////////////////
+
+size_t Spreadsheet::g_firstPlugIndex = 0;
+GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( Spreadsheet );
+
+Spreadsheet::Spreadsheet( const std::string &name )
+	:	ComputeNode( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new BoolPlug( "enabled", Plug::In, true ) );
+	addChild( new StringPlug( "selector" ) );
+	addChild( new RowsPlug( "rows" ) );
+	addChild( new ValuePlug( "out", Plug::Out ) );
+	addChild( new StringVectorDataPlug( "activeRowNames", Plug::Out, new IECore::StringVectorData ) );
+	addChild( new IntPlug( "__rowIndex", Plug::Out ) );
+}
+
+Spreadsheet::~Spreadsheet()
+{
+}
+
+BoolPlug *Spreadsheet::enabledPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex );
+}
+
+const BoolPlug *Spreadsheet::enabledPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex );
+}
+
+StringPlug *Spreadsheet::selectorPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+const StringPlug *Spreadsheet::selectorPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+ValuePlug *Spreadsheet::rowsPlug()
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 2 );
+}
+
+const ValuePlug *Spreadsheet::rowsPlug() const
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 2 );
+}
+
+ValuePlug *Spreadsheet::outPlug()
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 3 );
+}
+
+const ValuePlug *Spreadsheet::outPlug() const
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 3 );
+}
+
+StringVectorDataPlug *Spreadsheet::activeRowNamesPlug()
+{
+	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 4 );
+}
+
+const StringVectorDataPlug *Spreadsheet::activeRowNamesPlug() const
+{
+	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 4 );
+}
+
+IntPlug *Spreadsheet::rowIndexPlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 5 );
+}
+
+const IntPlug *Spreadsheet::rowIndexPlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 5 );
+}
+
+void Spreadsheet::affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const
+{
+	ComputeNode::affects( input, outputs );
+
+	const auto *row = input->parent<RowPlug>();
+	if(
+		input == enabledPlug() ||
+		input == selectorPlug() ||
+		( row && input == row->namePlug() ) ||
+		( row && input == row->enabledPlug() )
+	)
+	{
+		outputs.push_back( rowIndexPlug() );
+	}
+
+	if( input == rowIndexPlug() )
+	{
+		appendLeafPlugs( outPlug(), outputs );
+	}
+
+	if( const auto *cell = input->ancestor<CellPlug>() )
+	{
+		if( const Plug *out = outPlug()->getChild<ValuePlug>( cell->getName() ) )
+		{
+			if( input == cell->enabledPlug() )
+			{
+				appendLeafPlugs( out, outputs );
+			}
+			else if( input == cell->valuePlug() )
+			{
+				outputs.push_back( out );
+			}
+			else
+			{
+				outputs.push_back(
+					out->descendant<Plug>( input->relativeName( cell->valuePlug() ) )
+				);
+			}
+		}
+	}
+
+	if(
+		( row && input == row->namePlug() ) ||
+		( row && input == row->enabledPlug() )
+	)
+	{
+		outputs.push_back( activeRowNamesPlug() );
+	}
+}
+
+Plug *Spreadsheet::correspondingInput( const Plug *output )
+{
+	return const_cast<Plug *>( const_cast<const Spreadsheet *>( this)->correspondingInput( output ) );
+}
+
+const Plug *Spreadsheet::correspondingInput( const Plug *output ) const
+{
+	if( const Plug *p = correspondingInput( output, /* rowIndex = */ 0 ) )
+	{
+		return p;
+	}
+
+	return DependencyNode::correspondingInput( output );
+}
+
+void Spreadsheet::hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const
+{
+	if( output == rowIndexPlug() )
+	{
+		ComputeNode::hash( output, context, h );
+		enabledPlug()->hash( h );
+		selectorPlug()->hash( h );
+		for( int i = 1, e = rowsPlug()->children().size(); i < e; ++i )
+		{
+			const auto *row = rowsPlug()->getChild<RowPlug>( i );
+			row->namePlug()->hash( h );
+			row->enabledPlug()->hash( h );
+		}
+		return;
+	}
+	else if( outPlug()->isAncestorOf( output ) )
+	{
+		h = correspondingInput( output, rowIndexPlug()->getValue() )->hash();
+		return;
+	}
+	else if( output == activeRowNamesPlug() )
+	{
+		ComputeNode::hash( output, context, h );
+		for( int i = 1, e = rowsPlug()->children().size(); i < e; ++i )
+		{
+			const auto *row = rowsPlug()->getChild<RowPlug>( i );
+			row->namePlug()->hash( h );
+			row->enabledPlug()->hash( h );
+		}
+		return;
+	}
+
+	ComputeNode::hash( output, context, h );
+}
+
+void Spreadsheet::compute( ValuePlug *output, const Context *context ) const
+{
+	if( output == rowIndexPlug() )
+	{
+		int result = 0;
+		if( enabledPlug()->getValue() )
+		{
+			const std::string selector = selectorPlug()->getValue();
+			for( int i = 1, e = rowsPlug()->children().size(); i < e; ++i )
+			{
+				const auto *row = rowsPlug()->getChild<RowPlug>( i );
+				if( !row->enabledPlug()->getValue() )
+				{
+					continue;
+				}
+				if( StringAlgo::matchMultiple( selector, row->namePlug()->getValue() ) )
+				{
+					result = i;
+					break;
+				}
+			}
+		}
+		static_cast<IntPlug *>( output )->setValue( result );
+		return;
+	}
+	else if( outPlug()->isAncestorOf( output ) )
+	{
+		output->setFrom( correspondingInput( output, rowIndexPlug()->getValue() ) );
+		return;
+	}
+	else if( output == activeRowNamesPlug() )
+	{
+		StringVectorDataPtr resultData = new StringVectorData;
+		auto &result = resultData->writable();
+		result.reserve( rowsPlug()->children().size() - 1 );
+
+		for( int i = 1, e = rowsPlug()->children().size(); i < e; ++i )
+		{
+			const auto *row = rowsPlug()->getChild<RowPlug>( i );
+			if( row->enabledPlug()->getValue() )
+			{
+				result.push_back( row->namePlug()->getValue() );
+			}
+		}
+		static_cast<StringVectorDataPlug *>( output )->setValue( resultData );
+	}
+
+	ComputeNode::compute( output, context );
+}
+
+const ValuePlug *Spreadsheet::correspondingInput( const Plug *plug, size_t rowIndex ) const
+{
+	const ValuePlug *out = outPlug();
+	boost::container::small_vector<IECore::InternedString, 4> names;
+	while( plug && plug != out )
+	{
+		names.push_back( plug->getName() );
+		plug = plug->parent<Plug>();
+	}
+
+	if( !plug || names.empty() )
+	{
+		return nullptr;
+	}
+
+	const CellPlug *cell = rowsPlug()->getChild<RowPlug>( rowIndex )->cellsPlug()->getChild<CellPlug>( names.back() );
+	if( rowIndex && !cell->enabledPlug()->getValue() )
+	{
+		cell = rowsPlug()->getChild<RowPlug>( 0 )->cellsPlug()->getChild<CellPlug>( names.back() );
+	}
+
+	names.pop_back();
+	const ValuePlug *result = cell->valuePlug();
+	for( auto it = names.rbegin(), eIt = names.rend(); it != eIt; ++it )
+	{
+		result = result->getChild<ValuePlug>( *it );
+	}
+
+	return result;
+}
+
+ValuePlug *Spreadsheet::activeInPlug( const ValuePlug *output )
+{
+	return const_cast<ValuePlug *>( correspondingInput( output, rowIndexPlug()->getValue() ) );
+}
+
+const ValuePlug *Spreadsheet::activeInPlug( const ValuePlug *output ) const
+{
+	return correspondingInput( output, rowIndexPlug()->getValue() );
+}

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -67,6 +67,7 @@
 #include "SetBinding.h"
 #include "SignalBinding.h"
 #include "SplinePlugBinding.h"
+#include "SpreadsheetBinding.h"
 #include "StringPlugBinding.h"
 #include "SubGraphBinding.h"
 #include "SwitchBinding.h"
@@ -218,6 +219,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindProcessMessageHandler();
 	bindNameValuePlug();
 	bindProcess();
+	bindSpreadsheet();
 
 	NodeClass<Backdrop>();
 

--- a/src/GafferModule/SpreadsheetBinding.cpp
+++ b/src/GafferModule/SpreadsheetBinding.cpp
@@ -1,0 +1,146 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "SpreadsheetBinding.h"
+
+#include "GafferBindings/DependencyNodeBinding.h"
+#include "GafferBindings/ValuePlugBinding.h"
+
+#include "Gaffer/Spreadsheet.h"
+
+using namespace boost::python;
+using namespace IECorePython;
+using namespace Gaffer;
+using namespace GafferBindings;
+
+namespace
+{
+
+size_t addColumn( Spreadsheet::RowsPlug &rowsPlug, ValuePlug &value, IECore::InternedString name )
+{
+	ScopedGILRelease gilRelease;
+	return rowsPlug.addColumn( &value, name );
+}
+
+void removeColumn( Spreadsheet::RowsPlug &rowsPlug, size_t columnIndex )
+{
+	ScopedGILRelease gilRelease;
+	return rowsPlug.removeColumn( columnIndex );
+}
+
+Spreadsheet::RowPlugPtr addRow( Spreadsheet::RowsPlug &rowsPlug )
+{
+	ScopedGILRelease gilRelease;
+	return rowsPlug.addRow();
+}
+
+void addRows( Spreadsheet::RowsPlug &rowsPlug, size_t numRows )
+{
+	ScopedGILRelease gilRelease;
+	rowsPlug.addRows( numRows );
+}
+
+ValuePlugPtr activeInPlug( Spreadsheet &s, const ValuePlug &outPlug )
+{
+	ScopedGILRelease gilRelease;
+	return s.activeInPlug( &outPlug );
+}
+
+class RowsPlugSerialiser : public ValuePlugSerialiser
+{
+
+	public :
+
+		std::string postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override
+		{
+			std::string result = ValuePlugSerialiser::postConstructor( graphComponent, identifier, serialisation );
+
+			const auto *plug = static_cast<const Spreadsheet::RowsPlug *>( graphComponent );
+			for( const auto &cell : Spreadsheet::CellPlug::Range( *plug->getChild<Spreadsheet::RowPlug>( 0 )->cellsPlug() ) )
+			{
+				PlugPtr p = cell->valuePlug()->createCounterpart( cell->getName(), Plug::In );
+				const Serialiser *plugSerialiser = Serialisation::acquireSerialiser( p.get() );
+				result += identifier + ".addColumn( " + plugSerialiser->constructor( p.get(), serialisation ) + " )\n";
+			}
+
+			const size_t numRows = plug->children().size();
+			if( numRows > 1 )
+			{
+				result += identifier + ".addRows( " + std::to_string( numRows - 1 ) + " )\n";
+			}
+			return result;
+		}
+
+};
+
+} // namespace
+
+void GafferModule::bindSpreadsheet()
+{
+
+	scope s = DependencyNodeClass<Spreadsheet>()
+		.def( "activeInPlug", &activeInPlug )
+	;
+
+	PlugClass<Spreadsheet::RowsPlug>()
+		.def( init<std::string, Plug::Direction, unsigned>(
+				(
+					arg( "name" )=GraphComponent::defaultName<Spreadsheet::RowsPlug>(),
+					arg( "direction" )=Plug::In,
+					arg( "flags" )=Plug::Default
+				)
+			)
+		)
+		.def( "addColumn", &addColumn, ( arg( "value" ), arg( "name" ) = "" ) )
+		.def( "removeColumn", &removeColumn )
+		.def( "addRow", &addRow )
+		.def( "addRows", &addRows )
+		.attr( "__qualname__" ) = "Spreadsheet.RowsPlug"
+	;
+
+	PlugClass<Spreadsheet::RowPlug>()
+		.attr( "__qualname__" ) = "Spreadsheet.RowPlug"
+	;
+
+	PlugClass<Spreadsheet::CellPlug>()
+		.attr( "__qualname__" ) = "Spreadsheet.CellPlug"
+	;
+
+	Serialisation::registerSerialiser( Gaffer::Spreadsheet::RowsPlug::staticTypeId(), new RowsPlugSerialiser );
+
+}

--- a/src/GafferModule/SpreadsheetBinding.h
+++ b/src/GafferModule/SpreadsheetBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERMODULE_SPREADSHEETBINDING_H
+#define GAFFERMODULE_SPREADSHEETBINDING_H
+
+namespace GafferModule
+{
+
+void bindSpreadsheet();
+
+} // namespace GafferModule
+
+#endif // GAFFERMODULE_SPREADSHEETBINDING_H

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -49,6 +49,7 @@
 #include "Gaffer/Metadata.h"
 #include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/ScriptNode.h"
+#include "Gaffer/Spreadsheet.h"
 
 #include "OpenEXR/ImathMatrixAlgo.h"
 
@@ -157,6 +158,17 @@ bool updateSelection( const SceneAlgo::History *history, TransformTool::Selectio
 	if( selection.transformPlug )
 	{
 		selection.transformPlug = selection.transformPlug->source<TransformPlug>();
+
+		if( auto *spreadsheet = runTimeCast<Spreadsheet>( selection.transformPlug->node() ) )
+		{
+			if( spreadsheet->outPlug()->isAncestorOf( selection.transformPlug.get() ) )
+			{
+				selection.transformPlug = static_cast<TransformPlug *>(
+					spreadsheet->activeInPlug( selection.transformPlug.get() )
+				);
+			}
+		}
+
 		if( ancestorMakesChildNodesReadOnly( selection.transformPlug->node() ) )
 		{
 			// Inside a Reference node or similar. Unlike a regular read-only

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -61,6 +61,7 @@ Gaffer.Metadata.registerValue( Gaffer.BoxIO, "nodeGadget:color", imath.Color3f( 
 Gaffer.Metadata.registerValue( Gaffer.Random, "nodeGadget:color", imath.Color3f( 0.45, 0.3, 0.3 ) )
 Gaffer.Metadata.registerValue( Gaffer.Expression, "nodeGadget:color", imath.Color3f( 0.3, 0.45, 0.3 ) )
 Gaffer.Metadata.registerValue( Gaffer.Animation, "nodeGadget:color", imath.Color3f( 0.3, 0.3, 0.45 ) )
+Gaffer.Metadata.registerValue( Gaffer.Spreadsheet, "nodeGadget:color", imath.Color3f( 0.69, 0.5445, 0.2208 ) )
 
 Gaffer.Metadata.registerValue( GafferScene.ScenePlug, "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -484,6 +484,7 @@ nodeMenu.append( "/Utility/Context Variables", Gaffer.ContextVariables, searchTe
 nodeMenu.append( "/Utility/Delete Context Variables", Gaffer.DeleteContextVariables, searchText = "DeleteContextVariables" )
 nodeMenu.append( "/Utility/Time Warp", Gaffer.TimeWarp, searchText = "TimeWarp" )
 nodeMenu.append( "/Utility/Loop", Gaffer.Loop )
+nodeMenu.append( "/Utility/Spreadsheet", Gaffer.Spreadsheet )
 
 ## Miscellaneous UI
 ###########################################################################


### PR DESCRIPTION
This implements the Spreadsheet node described in https://github.com/GafferHQ/gaffer/issues/3222. I'm putting the PR up for a few reasons :

- To get a review on the implementation of the node itself, which I believe to be done.
- To give people a preview of the functionality the spreadsheet provides, because it factors into various conversations about graph templates, light editors etc.
- To get feedback on the UI, which I'm not remotely happy with.

The UI is sortof useable, but lacks the following functionality that I'm aware of (and I'm sure, some that I'm not aware of) :

- No drag reordering of rows.
- No reordering of columns.
- No multi-select editing of multiple cells.
- No grouping of columns into subsets, to help with wrangling high column counts.

My woes in implementing the first three, along with performance problems for any non-trivial number of rows, are making me think I've gone down the wrong path with the UI. I've been using a GridContainer of PlugValueWidgets, but I think for any kind of scalability, I should be using a QTableView. So I'm putting this PR up to gather feedback on other things I may be missing, while tomorrow I attempt to sprint in a QTableView direction to see how it works out.