### PR TITLE
ScriptWindow : Add Gaffer version to the window title

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Improvements
 - Tools :
   - Added generic support for precise tool adjustments by holding down <kbd>Shift</kbd> whilst adjusting tool handles (#3324).
   - Changed the behaviour of existing precise tool handle adjustments such that the current handle position is maintained when the <kbd>Shift</kbd> key is depressed (#3324).
+- UI : Added the Gaffer version to the window title.
 
 Fixes
 -----

--- a/python/GafferUI/ScriptWindow.py
+++ b/python/GafferUI/ScriptWindow.py
@@ -222,7 +222,7 @@ class _WindowTitleBehaviour :
 		u = " *" if self.__script()["unsavedChanges"].getValue() else ""
 		ro = " (read only) " if Gaffer.MetadataAlgo.readOnly( self.__script() ) else ""
 
-		w._setTitle( "Gaffer : %s%s%s%s" % ( f, ro, u, d ) )
+		w._setTitle( "Gaffer %s : %s%s%s%s" % ( Gaffer.About.versionString(), f, ro, u, d ) )
 
 	def __scriptPlugChanged( self, plug ) :
 


### PR DESCRIPTION
In production, quick access to the Gaffer version can aid support queries.