### PR TITLE
CollectScenes : Fix set hashing bug

### DIFF
--- a/python/GafferSceneTest/CollectScenesTest.py
+++ b/python/GafferSceneTest/CollectScenesTest.py
@@ -296,5 +296,19 @@ class CollectScenesTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( collect["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "A" ] ) )
 		self.assertEqual( collect["out"].childNames( "/A" ), IECore.InternedStringVectorData() )
 
+	def testSetRespectsRootName( self ) :
+
+		light = GafferSceneTest.TestLight()
+
+		collect1 = GafferScene.CollectScenes()
+		collect1["in"].setInput( light["out"] )
+		collect1["rootNames"].setValue( IECore.StringVectorData( [ "a", "b" ] ) )
+		self.assertEqual( collect1["out"].set( "__lights" ).value, IECore.PathMatcher( [ "/a/light", "/b/light" ] ) )
+
+		collect2 = GafferScene.CollectScenes()
+		collect2["in"].setInput( light["out"] )
+		collect2["rootNames"].setValue( IECore.StringVectorData( [ "c", "d" ] ) )
+		self.assertEqual( collect2["out"].set( "__lights" ).value, IECore.PathMatcher( [ "/c/light", "/d/light" ] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/CollectScenes.cpp
+++ b/src/GafferScene/CollectScenes.cpp
@@ -437,6 +437,7 @@ void CollectScenes::hashSet( const IECore::InternedString &setName, const Gaffer
 		sceneScope.setRootName( *it );
 		inSetPlug->hash( h );
 		sourceRootPlug->hash( h );
+		h.append( *it );
 	}
 }
 


### PR DESCRIPTION
Fixes #3497.

Fixes
-----

- CollectScenes : Fixed bug in set computations. This first appeared as a
  failure to display lights in the viewer in certain circumstances (#3497).

