### PR TITLE
Set : Deprecate `paths` plug

### DIFF
--- a/include/GafferScene/Set.h
+++ b/include/GafferScene/Set.h
@@ -76,6 +76,7 @@ class GAFFERSCENE_API Set : public FilteredSceneProcessor
 		Gaffer::StringPlug *namePlug();
 		const Gaffer::StringPlug *namePlug() const;
 
+		/// \deprecated
 		Gaffer::StringVectorDataPlug *pathsPlug();
 		const Gaffer::StringVectorDataPlug *pathsPlug() const;
 

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -54,6 +54,8 @@ Gaffer.Metadata.registerNode(
 	a particular set.
 	""",
 
+	"layout:activator:pathsInUse", lambda node : node["paths"].getInput() is not None or len( node["paths"].getValue() ),
+
 	plugs = {
 
 		"mode" : [
@@ -98,10 +100,15 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The paths to be added to or removed from the set.
+
+			> Caution : This plug is deprecated and will be removed
+			in a future release. No validity checks are performed on
+			these paths, so it is possible to accidentally generate
+			invalid sets.
 			""",
 
-			"ui:scene:acceptsPaths", True,
 			"vectorDataPlugValueWidget:dragPointer", "objects",
+			"layout:visibilityActivator", "pathsInUse",
 
 		],
 
@@ -109,15 +116,7 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			A filter to define additional paths to be added to
-			or removed from the set.
-
-			> Caution : Using a filter can be very expensive.
-			It is advisable to limit use to filters with a
-			limited number of matches and/or sets which are
-			not used heavily downstream. Wherever possible,
-			prefer to use the `paths` plug directly instead
-			of using a filter.
+			Defines the locations to be added to or removed from the set.
 			""",
 
 		],


### PR DESCRIPTION
The original version of the Set node didn't have a `filter` plug, so the only way of specifying locations was to enter them as paths. This had very good performance, but allowed users to accidentally enter invalid locations, which could have unintended consequences downstream.

Later on, we added the `filter` plug to provide a more flexible way of specifying locations. This method guarantees that only valid locations are used, but came with an overhead in performance. We documented that users should prefer the `paths` plug where possible.

In practice, users are just confused about which option to use and when. We've also substantially improved the performance of the `filter` option since its introduction, to the point where there is negligible overhead in replacing `paths` plug usage with `PathFilter` usage. So, we wish to rip out the `paths` plug to remove confusion and guarantee that sets can never contain invalid paths.

Here we're merely deprecating the `paths` plug and hiding it from the UI unless it is already in use (has a non-default value or current input). In a later version we'll remove it fully, at which point we'll deal with
the problem of auto-converting old `paths` usage into PathFilters.

Improvements
------------

- Set : Hid unused `paths` plugs from the UI, in preparation for eventual
  removal of the plug itself. The `filter` plug should now always be used
  in preference to the `paths` plug.
