### PR TITLE
GafferSceneUI : Move LightFilterVisualiser to IECoreGLPreview

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -810,7 +810,7 @@ libraries = {
 
 	"GafferArnoldUI" : {
 		"envAppends" : {
-			"LIBS" : [ "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "Gaffer", "GafferOSL", "GafferSceneUI" ],
+			"LIBS" : [ "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "Gaffer", "GafferOSL", "GafferScene", "GafferSceneUI" ],
 			},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferArnoldUI", "GafferSceneUI" ],

--- a/include/GafferScene/Private/IECoreGLPreview/LightFilterVisualiser.h
+++ b/include/GafferScene/Private/IECoreGLPreview/LightFilterVisualiser.h
@@ -34,10 +34,10 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERSCENEUI_LIGHTFILTERVISUALISER_H
-#define GAFFERSCENEUI_LIGHTFILTERVISUALISER_H
+#ifndef IECOREGLPREVIEW_LIGHTFILTERVISUALISER_H
+#define IECOREGLPREVIEW_LIGHTFILTERVISUALISER_H
 
-#include "GafferSceneUI/Export.h"
+#include "GafferScene/Export.h"
 
 #include "IECoreGL/Renderable.h"
 
@@ -45,7 +45,7 @@
 
 #include "IECore/CompoundObject.h"
 
-namespace GafferSceneUI
+namespace IECoreGLPreview
 {
 
 IE_CORE_FORWARDDECLARE( LightFilterVisualiser )
@@ -55,7 +55,7 @@ IE_CORE_FORWARDDECLARE( LightFilterVisualiser )
 /// depending on their shader name (accessed using `IECore::Shader::getName()`). A
 /// factory mechanism is provided to map from this name to a specialised
 /// LightFilterVisualiser.
-class GAFFERSCENEUI_API LightFilterVisualiser : public IECore::RefCounted
+class GAFFERSCENE_API LightFilterVisualiser : public IECore::RefCounted
 {
 
 	public :
@@ -67,12 +67,30 @@ class GAFFERSCENEUI_API LightFilterVisualiser : public IECore::RefCounted
 
 		/// Must be implemented by derived classes to visualise
 		/// the light filter contained within `filterShaderNetwork`.
-		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *filterShaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const = 0;
+		virtual IECoreGL::ConstRenderablePtr visualise(
+			const IECore::InternedString &attributeName,
+			const IECoreScene::ShaderNetwork *filterShaderNetwork,
+			const IECoreScene::ShaderNetwork *lightShaderNetwork,
+			const IECore::CompoundObject *attributes,
+			IECoreGL::ConstStatePtr &state
+		) const = 0;
 
 		/// Registers a visualiser to visualise a particular type of light filter.
 		/// For instance, `registerLightFilterVisualiser( "ai:lightFilter", "gobo", visualiser )`
 		/// would register a visualiser for an Arnold gobo light filter.
-		static void registerLightFilterVisualiser( const IECore::InternedString &attributeName, const IECore::InternedString &shaderName, ConstLightFilterVisualiserPtr visualiser );
+		static void registerLightFilterVisualiser(
+			const IECore::InternedString &attributeName,
+			const IECore::InternedString &shaderName,
+			ConstLightFilterVisualiserPtr visualiser
+		);
+
+		/// Get all registered visualisations for the given attributes, by returning a renderable
+		/// group and some extra state. The return value and/or the state may be left null if
+		/// no registered visualisers do anything with these attributes.
+		static IECoreGL::ConstRenderablePtr allVisualisations(
+			const IECore::CompoundObject *attributes,
+			IECoreGL::ConstStatePtr &state
+		);
 
 	protected :
 
@@ -81,11 +99,11 @@ class GAFFERSCENEUI_API LightFilterVisualiser : public IECore::RefCounted
 		{
 			LightFilterVisualiserDescription( const IECore::InternedString &attributeName, const IECore::InternedString &shaderName )
 			{
-				registerLightFilterVisualiser( attributeName, shaderName, new FilterVisualiserType );
+				registerLightFilterVisualiser( attributeName, shaderName, new FilterVisualiserType() );
 			}
 		};
 };
 
-} // namespace GafferSceneUI
+} // namespace IECoreGLPreview
 
-#endif // GAFFERSCENEUI_LIGHTFILTERVISUALISER_H
+#endif // IECOREGLPREVIEW_LIGHTFILTERVISUALISER_H

--- a/src/GafferArnoldUI/BarndoorVisualiser.cpp
+++ b/src/GafferArnoldUI/BarndoorVisualiser.cpp
@@ -34,8 +34,9 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GafferSceneUI/LightFilterVisualiser.h"
 #include "GafferSceneUI/StandardLightVisualiser.h"
+
+#include "GafferScene/Private/IECoreGLPreview/LightFilterVisualiser.h"
 
 #include "Gaffer/Metadata.h"
 
@@ -54,6 +55,7 @@ using namespace Imath;
 using namespace IECore;
 using namespace IECoreScene;
 using namespace IECoreGL;
+using namespace IECoreGLPreview;
 using namespace GafferSceneUI;
 
 namespace

--- a/src/GafferArnoldUI/DecayVisualiser.cpp
+++ b/src/GafferArnoldUI/DecayVisualiser.cpp
@@ -34,7 +34,7 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GafferSceneUI/LightFilterVisualiser.h"
+#include "GafferScene/Private/IECoreGLPreview/LightFilterVisualiser.h"
 
 #include "IECoreGL/Group.h"
 #include "IECoreGL/Primitive.h"
@@ -52,7 +52,7 @@ using namespace Imath;
 using namespace IECore;
 using namespace IECoreScene;
 using namespace IECoreGL;
-using namespace GafferSceneUI;
+using namespace IECoreGLPreview;
 
 namespace
 {

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -36,8 +36,9 @@
 
 #include "GafferOSL/ShadingEngine.h"
 
-#include "GafferSceneUI/LightFilterVisualiser.h"
 #include "GafferSceneUI/StandardLightVisualiser.h"
+
+#include "GafferScene/Private/IECoreGLPreview/LightFilterVisualiser.h"
 
 #include "Gaffer/Metadata.h"
 #include "Gaffer/Private/IECorePreview/LRUCache.h"
@@ -61,6 +62,7 @@ using namespace Imath;
 using namespace IECore;
 using namespace IECoreScene;
 using namespace IECoreGL;
+using namespace IECoreGLPreview;
 using namespace GafferSceneUI;
 
 namespace

--- a/src/GafferArnoldUI/LightBlockerVisualiser.cpp
+++ b/src/GafferArnoldUI/LightBlockerVisualiser.cpp
@@ -34,7 +34,7 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GafferSceneUI/LightFilterVisualiser.h"
+#include "GafferScene/Private/IECoreGLPreview/LightFilterVisualiser.h"
 
 #include "Gaffer/Metadata.h"
 
@@ -52,8 +52,8 @@ using namespace Imath;
 using namespace IECore;
 using namespace IECoreScene;
 using namespace IECoreGL;
+using namespace IECoreGLPreview;
 using namespace Gaffer;
-using namespace GafferSceneUI;
 
 namespace
 {
@@ -173,7 +173,7 @@ void setFalloffGroupSettings( IECoreGL::Group *group, const IECore::CompoundData
 // LightBlockerVisualiser implementation.
 //////////////////////////////////////////////////////////////////////////
 
-class GAFFERSCENEUI_API LightBlockerVisualiser : public LightFilterVisualiser
+class LightBlockerVisualiser : public LightFilterVisualiser
 {
 
 	public :

--- a/src/GafferScene/IECoreGLPreview/LightFilterVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/LightFilterVisualiser.cpp
@@ -34,7 +34,7 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GafferSceneUI/LightFilterVisualiser.h"
+#include "GafferScene/Private/IECoreGLPreview/LightFilterVisualiser.h"
 
 #include "GafferScene/Private/IECoreGLPreview/AttributeVisualiser.h"
 
@@ -50,7 +50,6 @@
 using namespace std;
 using namespace Imath;
 using namespace IECoreGLPreview;
-using namespace GafferSceneUI;
 
 //////////////////////////////////////////////////////////////////////////
 // Internal implementation details
@@ -68,31 +67,27 @@ LightFilterVisualisers &lightFilterVisualisers()
 	return l;
 }
 
-/// Class for visualisation of light filters. All light filters in Gaffer are represented
-/// as IECore::Shader objects, but we need to visualise them differently
-/// depending on their shader name (accessed using `IECore::Shader::getName()`). A
-/// factory mechanism is provided to map from this type to a specialised
-/// LightFilterVisualiser.
-class AttributeVisualiserForLightFilters : public AttributeVisualiser
-{
-
-	public :
-
-		IE_CORE_DECLAREMEMBERPTR( AttributeVisualiserForLightFilters )
-
-		/// Uses a custom visualisation registered via `registerLightFilterVisualiser()` if one
-		/// is available, if not falls back to a basic visualisation.
-		IECoreGL::ConstRenderablePtr visualise( const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
-
-	protected :
-
-		static AttributeVisualiser::AttributeVisualiserDescription<AttributeVisualiserForLightFilters> g_visualiserDescription;
-
-};
-
 } // namespace
 
-IECoreGL::ConstRenderablePtr AttributeVisualiserForLightFilters::visualise( const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
+//////////////////////////////////////////////////////////////////////////
+// LightFilterVisualiser class
+//////////////////////////////////////////////////////////////////////////
+
+
+LightFilterVisualiser::LightFilterVisualiser()
+{
+}
+
+LightFilterVisualiser::~LightFilterVisualiser()
+{
+}
+
+void LightFilterVisualiser::registerLightFilterVisualiser( const IECore::InternedString &attributeName, const IECore::InternedString &shaderName, ConstLightFilterVisualiserPtr visualiser )
+{
+	lightFilterVisualisers()[AttributeAndShaderNames( attributeName, shaderName )] = visualiser;
+}
+
+IECoreGL::ConstRenderablePtr LightFilterVisualiser::allVisualisations( const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state )
 {
 	if( !attributes )
 	{
@@ -188,24 +183,4 @@ IECoreGL::ConstRenderablePtr AttributeVisualiserForLightFilters::visualise( cons
 
 	state = resultState;
 	return resultGroup;
-}
-
-AttributeVisualiser::AttributeVisualiserDescription<AttributeVisualiserForLightFilters> AttributeVisualiserForLightFilters::g_visualiserDescription;
-
-//////////////////////////////////////////////////////////////////////////
-// LightVisualiser class
-//////////////////////////////////////////////////////////////////////////
-
-
-LightFilterVisualiser::LightFilterVisualiser()
-{
-}
-
-LightFilterVisualiser::~LightFilterVisualiser()
-{
-}
-
-void LightFilterVisualiser::registerLightFilterVisualiser( const IECore::InternedString &attributeName, const IECore::InternedString &shaderName, ConstLightFilterVisualiserPtr visualiser )
-{
-	lightFilterVisualisers()[AttributeAndShaderNames( attributeName, shaderName )] = visualiser;
 }


### PR DESCRIPTION
Moves `GafferSceneUI::LightFilterVisualiser` into `IECoreGLPreview`. This allows us to more easily separate out light, filter and attribute visualisations, which in turn fixes #3502.

Existing filter visualiser registrations will need updating, but functionality remains the same.