### PR TITLE
Menu : Fix padding when leading submenu item is a labelled divider.

### DIFF
--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -313,7 +313,7 @@ class Menu( GafferUI.Widget ) :
 							if len( qtMenu.actions() ) :
 								qtMenu.addAction( _SpacerAction( qtMenu ) )
 							elif action.hasText :
-								self._qtWidget().setProperty( "gafferHasLeadingLabelledDivider", GafferUI._Variant.toVariant( True ) )
+								qtMenu.setProperty( "gafferHasLeadingLabelledDivider", GafferUI._Variant.toVariant( True ) )
 								needsBottomSpacer = True
 
 						qtMenu.addAction( action )


### PR DESCRIPTION
In #3488 we were inadvertently applying the style to the base menu, not the specific sub-menu that actually had the items...