### PR TITLE
OSLImageTest : Fix periodic test failure

### DIFF
--- a/python/GafferOSLTest/OSLImageTest.py
+++ b/python/GafferOSLTest/OSLImageTest.py
@@ -443,6 +443,9 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 
 		constant = GafferImage.Constant()
 		constant["color"].setValue( imath.Color4f( 0.1101, 0.1224, 0.1353, 0.135 ) )
+		constant["format"].setValue(
+			GafferImage.Format( GafferImage.ImagePlug.tileSize(), GafferImage.ImagePlug.tileSize() )
+		)
 
 		outLayer = GafferOSL.OSLShader()
 		outLayer.loadShader( "ImageProcessing/OutLayer" )


### PR DESCRIPTION
Because `Constant.out.channelData` isn't using a blocking cache policy, we can occasionally get two threads computing the same upstream tile concurrently, resulting in the following test failure :

```
Traceback (most recent call last):
  File "/disk1/john/dev/build/gaffer/python/GafferOSLTest/OSLImageTest.py", line 469, in testPullsMinimalSetOfInputChannels
    self.assertEqual( s.computeCount, 1 )
AssertionError: 2 != 1
```

Limiting the image size to a single tile means we are now asserting what we actually want to - that only a single upstream _channel_ (not _tile_) is computed.
