### PR TITLE
Instancer Prototype Roots

### DIFF
--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -151,7 +151,7 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 
 		struct PrototypeScope : public Gaffer::Context::EditableScope
 		{
-			PrototypeScope( ConstEngineDataPtr engine, const Gaffer::Context *context, const ScenePath &branchPath );
+			PrototypeScope( const Gaffer::ObjectPlug *enginePlug, const Gaffer::Context *context, const ScenePath &parentPath, const ScenePath &branchPath );
 		};
 
 		static size_t g_firstPlugIndex;

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -53,14 +53,30 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::Instancer, InstancerTypeId, BranchCreator );
 
+		enum class PrototypeMode
+		{
+			IndexedRootsList = 0,
+			IndexedRootsVariable,
+			RootPerVertex,
+		};
+
 		Gaffer::StringPlug *namePlug();
 		const Gaffer::StringPlug *namePlug() const;
 
 		ScenePlug *prototypesPlug();
 		const ScenePlug *prototypesPlug() const;
 
+		Gaffer::IntPlug *prototypeModePlug();
+		const Gaffer::IntPlug *prototypeModePlug() const;
+
 		Gaffer::StringPlug *prototypeIndexPlug();
 		const Gaffer::StringPlug *prototypeIndexPlug() const;
+
+		Gaffer::StringPlug *prototypeRootsPlug();
+		const Gaffer::StringPlug *prototypeRootsPlug() const;
+
+		Gaffer::StringVectorDataPlug *prototypeRootPathsPlug();
+		const Gaffer::StringVectorDataPlug *prototypeRootPathsPlug() const;
 
 		Gaffer::StringPlug *idPlug();
 		const Gaffer::StringPlug *idPlug() const;
@@ -135,7 +151,7 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 
 		struct PrototypeScope : public Gaffer::Context::EditableScope
 		{
-			PrototypeScope( const Gaffer::Context *context, const ScenePath &branchPath );
+			PrototypeScope( ConstEngineDataPtr engine, const Gaffer::Context *context, const ScenePath &branchPath );
 		};
 
 		static size_t g_firstPlugIndex;

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -75,8 +75,8 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::StringPlug *prototypeRootsPlug();
 		const Gaffer::StringPlug *prototypeRootsPlug() const;
 
-		Gaffer::StringVectorDataPlug *prototypeRootPathsPlug();
-		const Gaffer::StringVectorDataPlug *prototypeRootPathsPlug() const;
+		Gaffer::StringVectorDataPlug *prototypeRootsListPlug();
+		const Gaffer::StringVectorDataPlug *prototypeRootsListPlug() const;
 
 		Gaffer::StringPlug *idPlug();
 		const Gaffer::StringPlug *idPlug() const;

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -870,6 +870,30 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertSceneValid( script["instancer"]["out"] )
 
+	def assertRootsToRoot( self, script ) :
+
+		self.assertEqual( script["instancer"]["out"].childNames( "/object/instances" ), IECore.InternedStringVectorData( [ "root" ] ) )
+		self.assertEqual( script["instancer"]["out"].childNames( "/object/instances/root" ), IECore.InternedStringVectorData( [ "0", "1", "2", "3" ] ) )
+
+		self.assertEqual( script["instancer"]["out"].object( "/object/instances" ), IECore.NullObject.defaultNullObject() )
+		self.assertEqual( script["instancer"]["out"].object( "/object/instances/root" ), IECore.NullObject.defaultNullObject() )
+
+		for i in [ "0", "1", "2", "3" ] :
+
+			self.assertEqual( script["instancer"]["out"].childNames( "/object/instances/root/{i}".format( i=i ) ), IECore.InternedStringVectorData( [ "foo", "bar" ] ) )
+			self.assertEqual( script["instancer"]["out"].childNames( "/object/instances/root/{i}/foo".format( i=i ) ), IECore.InternedStringVectorData( [ "bar" ] ) )
+			self.assertEqual( script["instancer"]["out"].childNames( "/object/instances/root/{i}/foo/bar".format( i=i ) ), IECore.InternedStringVectorData( [ "sphere" ] ) )
+			self.assertEqual( script["instancer"]["out"].childNames( "/object/instances/root/{i}/bar".format( i=i ) ), IECore.InternedStringVectorData( [ "baz" ] ) )
+			self.assertEqual( script["instancer"]["out"].childNames( "/object/instances/root/{i}/bar/baz".format( i=i ) ), IECore.InternedStringVectorData( [ "cube" ] ) )
+
+			self.assertEqual( script["instancer"]["out"].object( "/object/instances/root/{i}".format( i=i ) ), IECore.NullObject.defaultNullObject() )
+			self.assertEqual( script["instancer"]["out"].object( "/object/instances/root/{i}/foo".format( i=i ) ), IECore.NullObject.defaultNullObject() )
+			self.assertEqual( script["instancer"]["out"].object( "/object/instances/root/{i}/foo/bar".format( i=i ) ), IECore.NullObject.defaultNullObject() )
+			self.assertEqual( script["instancer"]["out"].object( "/object/instances/root/{i}/foo/bar/sphere".format( i=i ) ), script["sphere"]["out"].object( "/sphere" ) )
+			self.assertEqual( script["instancer"]["out"].object( "/object/instances/root/{i}/bar".format( i=i ) ), IECore.NullObject.defaultNullObject() )
+			self.assertEqual( script["instancer"]["out"].object( "/object/instances/root/{i}/bar/baz".format( i=i ) ), IECore.NullObject.defaultNullObject() )
+			self.assertEqual( script["instancer"]["out"].object( "/object/instances/root/{i}/bar/baz/cube".format( i=i ) ), script["cube"]["out"].object( "/cube" ) )
+
 	def testIndexedRootsList( self ) :
 
 		script = self.buildPrototypeRootsScript()
@@ -902,6 +926,10 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		# roots all the way to the leaf level of the prototype scene
 		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/foo/bar/sphere", "/bar/baz/cube" ] ) )
 		self.assertRootsToLeaves( script )
+
+		# we can specify the root of the prototype scene
+		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/" ] ) )
+		self.assertRootsToRoot( script )
 
 		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/foo", "/does/not/exist" ] ) )
 		self.assertRaisesRegexp(
@@ -944,6 +972,10 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		# roots all the way to the leaf level of the prototype scene
 		script["variables"]["primitiveVariables"]["prototypeRoots"]["value"].setValue( IECore.StringVectorData( [ "/foo/bar/sphere", "/bar/baz/cube" ] ) )
 		self.assertRootsToLeaves( script )
+
+		# we can specify the root of the prototype scene
+		script["variables"]["primitiveVariables"]["prototypeRoots"]["value"].setValue( IECore.StringVectorData( [ "/" ] ) )
+		self.assertRootsToRoot( script )
 
 		script["variables"]["primitiveVariables"]["prototypeRoots"]["value"].setValue( IECore.StringVectorData( [ "/foo", "/does/not/exist" ] ) )
 		self.assertRaisesRegexp(
@@ -1006,6 +1038,10 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		# roots all the way to the leaf level of the prototype scene
 		updateRoots( IECore.StringVectorData( [ "/foo/bar/sphere", "/bar/baz/cube" ] ), IECore.IntVectorData( [ 0, 1, 1, 0 ] ) )
 		self.assertRootsToLeaves( script )
+
+		# we can specify the root of the prototype scene
+		updateRoots( IECore.StringVectorData( [ "/", ] ), IECore.IntVectorData( [ 0, 0, 0, 0 ] ) )
+		self.assertRootsToRoot( script )
 
 		updateRoots( IECore.StringVectorData( [ "/foo", "/does/not/exist" ] ), IECore.IntVectorData( [ 0, 1, 1, 0 ] ) )
 		self.assertRaisesRegexp(

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -874,32 +874,32 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script = self.buildPrototypeRootsScript()
 		script["instancer"]["prototypeMode"].setValue( GafferScene.Instancer.PrototypeMode.IndexedRootsList )
 
-		script["instancer"]["prototypeRootPaths"].setValue( IECore.StringVectorData( [] ) )
+		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [] ) )
 		self.assertRootsMatchPrototypeSceneChildren( script )
 
-		script["instancer"]["prototypeRootPaths"].setValue( IECore.StringVectorData( [ "", ] ) )
+		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "", ] ) )
 		self.assertUnderspecifiedRoots( script )
 
-		script["instancer"]["prototypeRootPaths"].setValue( IECore.StringVectorData( [ "/foo", ] ) )
+		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/foo", ] ) )
 		self.assertSingleRoot( script )
 
 		# roots list matching the prototype root children
 		# we expect the same results as without a roots list
-		script["instancer"]["prototypeRootPaths"].setValue( IECore.StringVectorData( [ "/foo", "/bar" ] ) )
+		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/foo", "/bar" ] ) )
 		self.assertRootsMatchPrototypeSceneChildren( script )
 
-		script["instancer"]["prototypeRootPaths"].setValue( IECore.StringVectorData( [ "/foo/bar", "/bar" ] ) )
+		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/foo/bar", "/bar" ] ) )
 		self.assertConflictingRootNames( script )
 
 		# opposite order to the prototype root children
-		script["instancer"]["prototypeRootPaths"].setValue( IECore.StringVectorData( [ "/bar", "/foo" ] ) )
+		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/bar", "/foo" ] ) )
 		self.assertSwappedRoots( script )
 
 		# roots all the way to the leaf level of the prototype scene
-		script["instancer"]["prototypeRootPaths"].setValue( IECore.StringVectorData( [ "/foo/bar/sphere", "/bar/baz/cube" ] ) )
+		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/foo/bar/sphere", "/bar/baz/cube" ] ) )
 		self.assertRootsToLeaves( script )
-		
-		script["instancer"]["prototypeRootPaths"].setValue( IECore.StringVectorData( [ "/foo", "/does/not/exist" ] ) )
+
+		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/foo", "/does/not/exist" ] ) )
 		self.assertRaisesRegexp(
 			Gaffer.ProcessException, '.*Prototype root "/does/not/exist" does not exist.*',
 			script["instancer"]["out"].childNames, "/object/instances",
@@ -1086,7 +1086,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script["instancer"]["prototypes"].setInput( script["set"]["out"] )
 
 		script["instancer"]["prototypeMode"].setValue( GafferScene.Instancer.PrototypeMode.IndexedRootsList )
-		script["instancer"]["prototypeRootPaths"].setValue( IECore.StringVectorData( [ "/foo/bar", "/bar" ] ) )
+		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/foo/bar", "/bar" ] ) )
 
 		self.assertEqual(
 			script["instancer"]["out"]["setNames"].getValue(),

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -1513,19 +1513,21 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/foo", "/bar" ] ) )
 
 		self.assertEqual( script["instancer"]["out"].attributes( "/object/instances" ), IECore.CompoundObject() )
-		self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/foo" ), IECore.CompoundObject() )
-		self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/bar" ), IECore.CompoundObject() )
+		self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/foo" )["gaffer:deformationBlur"].value, False )
+		self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/bar" )["gaffer:deformationBlur"].value, True )
 
 		for i in [ "0", "3" ] :
 
-			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/foo/{i}".format( i=i ) )["gaffer:deformationBlur"].value, False )
+			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/foo/{i}".format( i=i ) ), IECore.CompoundObject() )
+			self.assertEqual( script["instancer"]["out"].fullAttributes( "/object/instances/foo/{i}".format( i=i ) )["gaffer:deformationBlur"].value, False )
 			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/foo/{i}/bar".format( i=i ) )["gaffer:deformationBlur"].value, True )
 			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/foo/{i}/bar/sphere" ), IECore.CompoundObject() )
 			self.assertEqual( script["instancer"]["out"].fullAttributes( "/object/instances/foo/{i}/bar/sphere".format( i=i ) )["gaffer:deformationBlur"].value, True )
 
 		for i in [ "1", "2" ] :
 
-			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/bar/{i}".format( i=i ) )["gaffer:deformationBlur"].value, True )
+			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/bar/{i}".format( i=i ) ), IECore.CompoundObject() )
+			self.assertEqual( script["instancer"]["out"].fullAttributes( "/object/instances/bar/{i}".format( i=i ) )["gaffer:deformationBlur"].value, True )
 			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/bar/{i}/baz".format( i=i ) ), IECore.CompoundObject() )
 			self.assertEqual( script["instancer"]["out"].fullAttributes( "/object/instances/bar/{i}/baz".format( i=i ) )["gaffer:deformationBlur"].value, True )
 			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/bar/{i}/baz/cube".format( i=i ) )["gaffer:deformationBlur"].value, False )

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -121,7 +121,7 @@ Gaffer.Metadata.registerNode(
 			- In "Indexed (Roots List)" mode, the `prototypeIndex`
 			  primitive variable must be an integer per-vertex.
 			  Optionally, a path in the prototypes scene corresponding
-			  to each index can be specified via the `prototypeRootPaths`
+			  to each index can be specified via the `prototypeRootsList`
 			  plug. If no roots are specified, an index of 0 applies the
 			  first location from the prototypes scene, an index of 1
 			  applies the second, and so on.
@@ -186,7 +186,7 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"prototypeRootPaths" : [
+		"prototypeRootsList" : [
 
 			"description",
 			"""

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -59,6 +59,10 @@ Gaffer.Metadata.registerNode(
 	"layout:section:Settings.Transforms:collapsed", False,
 	"layout:section:Settings.Attributes:collapsed", False,
 
+	"layout:activator:modeIsIndexedRootsList", lambda node : node["prototypeMode"].getValue() == GafferScene.Instancer.PrototypeMode.IndexedRootsList,
+	"layout:activator:modeIsNotIndexedRootsList", lambda node : node["prototypeMode"].getValue() != GafferScene.Instancer.PrototypeMode.IndexedRootsList,
+	"layout:activator:modeIsNotRootPerVertex", lambda node : node["prototypeMode"].getValue() != GafferScene.Instancer.PrototypeMode.RootPerVertex,
+
 	plugs = {
 
 		"parent" : [
@@ -95,19 +99,52 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The scene containing the prototypes to be applied to
-			each vertex. Specify multiple prototypes by parenting
-			them at the root of the scene :
+			each vertex. Use the `prototypeMode` and associated
+			plugs to control the mapping between prototypes and
+			instances.
 
-			- /prototype0
-			- /prototype1
-			- /prototype2
-
-			Note that the prototypes are not limited to being a
-			single object : they can each have arbitrary child
-			hierarchies.
+			Note that the prototypes are not limited to being a single
+			object - they can have arbitrary child hierarchies.
 			""",
 
 			"plugValueWidget:type", "",
+
+		],
+
+		"prototypeMode" : [
+
+			"description",
+			"""
+			The method used to define how the prototypes map
+			onto each instance.
+
+			- In "Indexed (Roots List)" mode, the `prototypeIndex`
+			  primitive variable must be an integer per-vertex.
+			  Optionally, a path in the prototypes scene corresponding
+			  to each index can be specified via the `prototypeRootPaths`
+			  plug. If no roots are specified, an index of 0 applies the
+			  first location from the prototypes scene, an index of 1
+			  applies the second, and so on.
+
+			- In "Indexed (Roots Variable)" mode, the `prototypeIndex`
+			  primitive variable must be an integer per-vertex, and
+			  the `prototypeRoots` primitive variable must be a separate
+			  constant string array specifying a path in the prototypes
+			  scene corresponding to each index.
+
+			- In "Root per Vertex" mode, the `prototypeRoots` primitive
+			  variable must be a string per-vertex which will be used to
+			  specify a path in the prototypes scene for each instance.
+
+			  > Note : it is advisable to provide an indexed string
+			  array in order to limit the number of unique prototypes.
+			""",
+
+			"preset:Indexed (Roots List)", GafferScene.Instancer.PrototypeMode.IndexedRootsList,
+			"preset:Indexed (Roots Variable)", GafferScene.Instancer.PrototypeMode.IndexedRootsVariable,
+			"preset:Root per Vertex", GafferScene.Instancer.PrototypeMode.RootPerVertex,
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+			"layout:section", "Prototypes",
 
 		],
 
@@ -115,15 +152,51 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			The name of a per-vertex integer primitive variable
-			used to determine which prototype is applied to the
-			vertex. An index of 0 applies the first location from
-			the prototypes scene, an index of 1 applies the second
-			and so on.
+			The name of a per-vertex integer primitive variable used
+			to determine which prototype is applied to the vertex.
+			This plug is used in "Indexed (Roots List)" mode as well
+			as "Indexed (Roots Variable)" mode.
 			""",
 
 			"userDefault", "prototypeIndex",
-			"layout:section", "Settings.General",
+			"layout:section", "Prototypes",
+			"layout:visibilityActivator", "modeIsNotRootPerVertex",
+
+		],
+
+		"prototypeRoots" : [
+
+			"description",
+			"""
+			If `prototypeMode` is set to "Indexed (Roots Variable)",
+			then this should specify the name of a constant string
+			array primitive variable used to map between `prototypeIndex`
+			and paths in the prototypes scene.
+
+			If `prototypeMode` is set to "Root per Vertex", then this
+			should specify the name of a per-vertex string primitive
+			variable used to specify a path in the prototypes scene
+			for each instance.
+
+			This plug is not used in "Indexed (Roots List)" mode.
+			""",
+
+			"layout:section", "Prototypes",
+			"layout:visibilityActivator", "modeIsNotIndexedRootsList",
+
+		],
+
+		"prototypeRootPaths" : [
+
+			"description",
+			"""
+			An explicit list of paths used to map between `prototypeIndex`
+			and paths in the prototypes scene. This plug is only used in
+			"Indexed (Roots List)" mode.
+			""",
+
+			"layout:section", "Prototypes",
+			"layout:visibilityActivator", "modeIsIndexedRootsList",
 
 		],
 

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -421,8 +421,6 @@ class Instancer::EngineData : public Data
 
 			size_t i = 0;
 			ScenePlug::ScenePath path;
-			ScenePlug::PathScope pathScope( Context::current() );
-			pathScope.setPath( ScenePath() );
 			for( const auto &root : *rootStrings )
 			{
 				ScenePlug::stringToPath( root, path );

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -69,6 +69,13 @@ using namespace IECoreScene;
 using namespace Gaffer;
 using namespace GafferScene;
 
+namespace
+{
+
+InternedString g_prototypeRootName( "root" );
+
+}
+
 //////////////////////////////////////////////////////////////////////////
 // EngineData
 //////////////////////////////////////////////////////////////////////////
@@ -432,7 +439,16 @@ class Instancer::EngineData : public Data
 
 				if( path.empty() )
 				{
-					m_prototypeIndexRemap.emplace_back( -1 );
+					if( root == "/" )
+					{
+						inputNames.emplace_back( new InternedStringVectorData( { g_prototypeRootName } ) );
+						m_roots.emplace_back( new InternedStringVectorData( path ) );
+						m_prototypeIndexRemap.emplace_back( i++ );
+					}
+					else
+					{
+						m_prototypeIndexRemap.emplace_back( -1 );
+					}
 				}
 				else
 				{

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -485,7 +485,7 @@ Instancer::Instancer( const std::string &name )
 	addChild( new IntPlug( "prototypeMode", Plug::In, (int)PrototypeMode::IndexedRootsList, /* min */ (int)PrototypeMode::IndexedRootsList, /* max */ (int)PrototypeMode::RootPerVertex ) );
 	addChild( new StringPlug( "prototypeIndex", Plug::In, "instanceIndex" ) );
 	addChild( new StringPlug( "prototypeRoots", Plug::In, "prototypeRoots" ) );
-	addChild( new StringVectorDataPlug( "prototypeRootPaths", Plug::In, new StringVectorData ) );
+	addChild( new StringVectorDataPlug( "prototypeRootsList", Plug::In, new StringVectorData ) );
 	addChild( new StringPlug( "id", Plug::In, "instanceId" ) );
 	addChild( new StringPlug( "position", Plug::In, "P" ) );
 	addChild( new StringPlug( "orientation", Plug::In ) );
@@ -550,12 +550,12 @@ const Gaffer::StringPlug *Instancer::prototypeRootsPlug() const
 	return getChild<StringPlug>( g_firstPlugIndex + 4 );
 }
 
-Gaffer::StringVectorDataPlug *Instancer::prototypeRootPathsPlug()
+Gaffer::StringVectorDataPlug *Instancer::prototypeRootsListPlug()
 {
 	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 5 );
 }
 
-const Gaffer::StringVectorDataPlug *Instancer::prototypeRootPathsPlug() const
+const Gaffer::StringVectorDataPlug *Instancer::prototypeRootsListPlug() const
 {
 	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 5 );
 }
@@ -649,7 +649,7 @@ void Instancer::affects( const Plug *input, AffectedPlugsContainer &outputs ) co
 		input == prototypeModePlug() ||
 		input == prototypeIndexPlug() ||
 		input == prototypeRootsPlug() ||
-		input == prototypeRootPathsPlug() ||
+		input == prototypeRootsListPlug() ||
 		input == prototypesPlug()->childNamesPlug() ||
 		input == idPlug() ||
 		input == positionPlug() ||
@@ -679,7 +679,7 @@ void Instancer::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 		prototypeModePlug()->hash( h );
 		prototypeIndexPlug()->hash( h );
 		prototypeRootsPlug()->hash( h );
-		prototypeRootPathsPlug()->hash( h );
+		prototypeRootsListPlug()->hash( h );
 		h.append( prototypesPlug()->childNamesHash( ScenePath() ) );
 
 		idPlug()->hash( h );
@@ -703,11 +703,11 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 	if( output == enginePlug() )
 	{
 		PrototypeMode mode = (PrototypeMode)prototypeModePlug()->getValue();
-		ConstStringVectorDataPtr prototypeRootPaths = prototypeRootPathsPlug()->getValue();
-		if( mode == PrototypeMode::IndexedRootsList && prototypeRootPaths->readable().empty() )
+		ConstStringVectorDataPtr prototypeRootsList = prototypeRootsListPlug()->getValue();
+		if( mode == PrototypeMode::IndexedRootsList && prototypeRootsList->readable().empty() )
 		{
 			const auto childNames = prototypesPlug()->childNames( ScenePath() );
-			prototypeRootPaths = new StringVectorData(
+			prototypeRootsList = new StringVectorData(
 				std::vector<string>(
 					childNames->readable().begin(),
 					childNames->readable().end()
@@ -721,7 +721,7 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 				mode,
 				prototypeIndexPlug()->getValue(),
 				prototypeRootsPlug()->getValue(),
-				prototypeRootPaths.get(),
+				prototypeRootsList.get(),
 				prototypesPlug(),
 				idPlug()->getValue(),
 				positionPlug()->getValue(),

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -835,7 +835,7 @@ void Instancer::hashBranchBound( const ScenePath &parentPath, const ScenePath &b
 		h.append( branchPath.back() );
 
 		{
-			PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+			PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 			prototypesPlug()->transformPlug()->hash( h );
 			prototypesPlug()->boundPlug()->hash( h );
 		}
@@ -843,7 +843,7 @@ void Instancer::hashBranchBound( const ScenePath &parentPath, const ScenePath &b
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 		h = prototypesPlug()->boundPlug()->hash();
 	}
 }
@@ -876,7 +876,7 @@ Imath::Box3f Instancer::computeBranchBound( const ScenePath &parentPath, const S
 		M44f childTransform;
 		Box3f childBound;
 		{
-			PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+			PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 			childTransform = prototypesPlug()->transformPlug()->getValue();
 			childBound = prototypesPlug()->boundPlug()->getValue();
 		}
@@ -912,7 +912,7 @@ Imath::Box3f Instancer::computeBranchBound( const ScenePath &parentPath, const S
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 		return prototypesPlug()->boundPlug()->getValue();
 	}
 }
@@ -937,7 +937,7 @@ void Instancer::hashBranchTransform( const ScenePath &parentPath, const ScenePat
 		// "/instances/<prototypeName>/<id>"
 		BranchCreator::hashBranchTransform( parentPath, branchPath, context, h );
 		{
-			PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+			PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 			prototypesPlug()->transformPlug()->hash( h );
 		}
 		engineHash( parentPath, context, h );
@@ -946,7 +946,7 @@ void Instancer::hashBranchTransform( const ScenePath &parentPath, const ScenePat
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 		h = prototypesPlug()->transformPlug()->hash();
 	}
 }
@@ -963,7 +963,7 @@ Imath::M44f Instancer::computeBranchTransform( const ScenePath &parentPath, cons
 		// "/instances/<prototypeName>/<id>"
 		M44f result;
 		{
-			PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+			PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 			result = prototypesPlug()->transformPlug()->getValue();
 		}
 		ConstEngineDataPtr e = engine( parentPath, context );
@@ -974,7 +974,7 @@ Imath::M44f Instancer::computeBranchTransform( const ScenePath &parentPath, cons
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 		return prototypesPlug()->transformPlug()->getValue();
 	}
 }
@@ -997,7 +997,7 @@ void Instancer::hashBranchAttributes( const ScenePath &parentPath, const ScenePa
 	else if( branchPath.size() == 2 )
 	{
 		// "/instances/<prototypeName>"
-		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 		h = prototypesPlug()->attributesPlug()->hash();
 	}
 	else if( branchPath.size() == 3 )
@@ -1015,7 +1015,7 @@ void Instancer::hashBranchAttributes( const ScenePath &parentPath, const ScenePa
 	else
 	{
 		// "/instances/<prototypeName>/<id>/...
-		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 		h = prototypesPlug()->attributesPlug()->hash();
 	}
 }
@@ -1030,7 +1030,7 @@ IECore::ConstCompoundObjectPtr Instancer::computeBranchAttributes( const ScenePa
 	else if( branchPath.size() == 2 )
 	{
 		// "/instances/<prototypeName>"
-		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 		return prototypesPlug()->attributesPlug()->getValue();
 	}
 	else if( branchPath.size() == 3 )
@@ -1049,7 +1049,7 @@ IECore::ConstCompoundObjectPtr Instancer::computeBranchAttributes( const ScenePa
 	else
 	{
 		// "/instances/<prototypeName>/<id>/...
-		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 		return prototypesPlug()->attributesPlug()->getValue();
 	}
 }
@@ -1077,7 +1077,7 @@ void Instancer::hashBranchObject( const ScenePath &parentPath, const ScenePath &
 	else
 	{
 		// "/instances/<prototypeName>/<id>/...
-		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 		h = prototypesPlug()->objectPlug()->hash();
 	}
 }
@@ -1092,7 +1092,7 @@ IECore::ConstObjectPtr Instancer::computeBranchObject( const ScenePath &parentPa
 	else
 	{
 		// "/instances/<prototypeName>/<id>/...
-		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 		return prototypesPlug()->objectPlug()->getValue();
 	}
 }
@@ -1130,7 +1130,7 @@ void Instancer::hashBranchChildNames( const ScenePath &parentPath, const ScenePa
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 		h = prototypesPlug()->childNamesPlug()->hash();
 	}
 }
@@ -1163,7 +1163,7 @@ IECore::ConstInternedStringVectorDataPtr Instancer::computeBranchChildNames( con
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
+		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
 		return prototypesPlug()->childNamesPlug()->getValue();
 	}
 }
@@ -1260,12 +1260,13 @@ void Instancer::prototypeChildNamesHash( const ScenePath &parentPath, const Gaff
 	prototypeChildNamesPlug()->hash( h );
 }
 
-Instancer::PrototypeScope::PrototypeScope( ConstEngineDataPtr engine, const Gaffer::Context *context, const ScenePath &branchPath )
+Instancer::PrototypeScope::PrototypeScope( const Gaffer::ObjectPlug *enginePlug, const Gaffer::Context *context, const ScenePath &parentPath, const ScenePath &branchPath )
 	:	Gaffer::Context::EditableScope( context )
 {
 	assert( branchPath.size() >= 2 );
 
-	const ScenePlug::ScenePath &prototypeRoot = engine->prototypeRoot( branchPath[1] );
+	set( ScenePlug::scenePathContextName, parentPath );
+	const ScenePlug::ScenePath &prototypeRoot = boost::static_pointer_cast<const EngineData>( enginePlug->getValue() )->prototypeRoot( branchPath[1] );
 
 	if( branchPath.size() > 3 )
 	{

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -37,6 +37,10 @@
 
 #include "GafferScene/Instancer.h"
 
+#include "GafferScene/SceneAlgo.h"
+
+#include "GafferScene/Private/ChildNamesMap.h"
+
 #include "Gaffer/Context.h"
 #include "Gaffer/StringPlug.h"
 
@@ -44,6 +48,7 @@
 
 #include "IECore/DataAlgo.h"
 #include "IECore/MessageHandler.h"
+#include "IECore/ObjectVector.h"
 #include "IECore/NullObject.h"
 #include "IECore/VectorTypedData.h"
 
@@ -78,7 +83,11 @@ class Instancer::EngineData : public Data
 
 		EngineData(
 			ConstObjectPtr object,
+			PrototypeMode mode,
 			const std::string &index,
+			const std::string &rootsVariable,
+			const StringVectorData *rootsList,
+			const ScenePlug *prototypes,
 			const std::string &id,
 			const std::string &position,
 			const std::string &orientation,
@@ -99,21 +108,14 @@ class Instancer::EngineData : public Data
 				return;
 			}
 
-			if( const IntVectorData *indices = m_primitive->variableData<IntVectorData>( index ) )
-			{
-				m_indices = &indices->readable();
-				if( m_indices->size() != numPoints() )
-				{
-					throw IECore::Exception( "Index primitive variable has incorrect size" );
-				}
-			}
+			initPrototypes( mode, index, rootsVariable, rootsList, prototypes );
 
 			if( const IntVectorData *ids = m_primitive->variableData<IntVectorData>( id ) )
 			{
 				m_ids = &ids->readable();
 				if( m_ids->size() != numPoints() )
 				{
-					throw IECore::Exception( "Id primitive variable has incorrect size" );
+					throw IECore::Exception( boost::str( boost::format( "Id primitive variable \"%1%\" has incorrect size" ) % id ) );
 				}
 			}
 
@@ -122,7 +124,7 @@ class Instancer::EngineData : public Data
 				m_positions = &p->readable();
 				if( m_positions->size() != numPoints() )
 				{
-					throw IECore::Exception( "Position primitive variable has incorrect size" );
+					throw IECore::Exception( boost::str( boost::format( "Position primitive variable \"%1%\" has incorrect size" ) % position ) );
 				}
 			}
 
@@ -131,7 +133,7 @@ class Instancer::EngineData : public Data
 				m_orientations = &o->readable();
 				if( m_orientations->size() != numPoints() )
 				{
-					throw IECore::Exception( "Orientation primitive variable has incorrect size" );
+					throw IECore::Exception( boost::str( boost::format( "Orientation primitive variable \"%1%\" has incorrect size" ) % orientation ) );
 				}
 			}
 
@@ -140,7 +142,7 @@ class Instancer::EngineData : public Data
 				m_scales = &s->readable();
 				if( m_scales->size() != numPoints() )
 				{
-					throw IECore::Exception( "Scale primitive variable has incorrect size" );
+					throw IECore::Exception( boost::str( boost::format( "Scale primitive variable \"%1%\" has incorrect size" ) % scale ) );
 				}
 			}
 			else if( const FloatVectorData *s = m_primitive->variableData<FloatVectorData>( scale ) )
@@ -148,7 +150,7 @@ class Instancer::EngineData : public Data
 				m_uniformScales = &s->readable();
 				if( m_uniformScales->size() != numPoints() )
 				{
-					throw IECore::Exception( "Scale primitive variable has incorrect size" );
+					throw IECore::Exception( boost::str( boost::format( "Uniform scale primitive variable \"%1%\" has incorrect size" ) % scale ) );
 				}
 			}
 
@@ -186,15 +188,30 @@ class Instancer::EngineData : public Data
 			IdsToPointIndices::const_iterator it = m_idsToPointIndices.find( i );
 			if( it == m_idsToPointIndices.end() )
 			{
-				throw IECore::Exception( "Invalid id" );
+				throw IECore::Exception( boost::str( boost::format( "Instance id \"%1%\" is invalid" ) % name ) );
 			}
 
 			return it->second;
 		}
 
+		size_t numPrototypes() const
+		{
+			return m_numPrototypes;
+		}
+
 		size_t prototypeIndex( size_t pointIndex ) const
 		{
-			return m_indices ? (*m_indices)[pointIndex] : 0;
+			return ( m_indices ? (*m_indices)[pointIndex] : 0 ) % m_numPrototypes;
+		}
+
+		const ScenePlug::ScenePath &prototypeRoot( const InternedString &name ) const
+		{
+			return runTimeCast<const InternedStringVectorData>( m_roots[m_names->input( name ).index] )->readable();
+		}
+
+		const InternedStringVectorData *prototypeNames() const
+		{
+			return m_names->outputChildNames();
 		}
 
 		M44f instanceTransform( size_t pointIndex ) const
@@ -323,7 +340,119 @@ class Instancer::EngineData : public Data
 			}
 		}
 
+		void initPrototypes( PrototypeMode mode, const std::string &index, const std::string &rootsVariable, const StringVectorData *rootsList, const ScenePlug *prototypes )
+		{
+			const std::vector<std::string> *rootStrings = nullptr;
+
+			switch( mode )
+			{
+				case PrototypeMode::IndexedRootsList :
+				{
+					if( const auto *indices = m_primitive->variableData<IntVectorData>( index ) )
+					{
+						m_indices = &indices->readable();
+						if( m_indices->size() != numPoints() )
+						{
+							throw IECore::Exception( boost::str( boost::format( "prototypeIndex primitive variable \"%1%\" has incorrect size" ) % index ) );
+						}
+					}
+
+					rootStrings = &rootsList->readable();
+
+					break;
+				}
+				case PrototypeMode::IndexedRootsVariable :
+				{
+					if( const auto *indices = m_primitive->variableData<IntVectorData>( index ) )
+					{
+						m_indices = &indices->readable();
+						if( m_indices->size() != numPoints() )
+						{
+							throw IECore::Exception( boost::str( boost::format( "prototypeIndex primitive variable \"%1%\" has incorrect size" ) % index ) );
+						}
+					}
+
+					const auto *roots = m_primitive->variableData<StringVectorData>( rootsVariable, PrimitiveVariable::Constant );
+					if( !roots )
+					{
+						std::string message = boost::str( boost::format( "prototypeRoots primitive variable \"%1%\" must be Constant StringVectorData when using IndexedRootsVariable mode" ) % rootsVariable );
+						if( m_primitive->variables.find( rootsVariable ) == m_primitive->variables.end() )
+						{
+							message += ", but it does not exist";
+						}
+						throw IECore::Exception( message );
+					}
+
+					rootStrings = &roots->readable();
+					if( rootStrings->empty() )
+					{
+						throw IECore::Exception( boost::str( boost::format( "prototypeRoots primitive variable \"%1%\" must specify at least one root location" ) % rootsVariable ) );
+					}
+
+					break;
+				}
+				case PrototypeMode::RootPerVertex :
+				{
+					const auto view = m_primitive->variableIndexedView<StringVectorData>( rootsVariable, PrimitiveVariable::Vertex );
+					if( !view )
+					{
+						std::string message = boost::str( boost::format( "prototypeRoots primitive variable \"%1%\" must be Vertex StringVectorData when using RootPerVertex mode" ) % rootsVariable );
+						if( m_primitive->variables.find( rootsVariable ) == m_primitive->variables.end() )
+						{
+							message += ", but it does not exist";
+						}
+						throw IECore::Exception( message );
+					}
+
+					m_indices = view->indices();
+					rootStrings = &view->data();
+					if( rootStrings->empty() )
+					{
+						throw IECore::Exception( boost::str( boost::format( "prototypeRoots primitive variable \"%1%\" must specify at least one root location" ) % rootsVariable ) );
+					}
+
+					break;
+				}
+			}
+
+			std::vector<ConstInternedStringVectorDataPtr> inputNames;
+			inputNames.reserve( rootStrings->size() );
+			m_roots.reserve( rootStrings->size() );
+
+			size_t i = 0;
+			ScenePlug::ScenePath path;
+			ScenePlug::PathScope pathScope( Context::current() );
+			pathScope.setPath( ScenePath() );
+			for( const auto &root : *rootStrings )
+			{
+				ScenePlug::stringToPath( root, path );
+				if( !SceneAlgo::exists( prototypes, path ) )
+				{
+					throw IECore::Exception( boost::str( boost::format( "Prototype root \"%1%\" does not exist in the `prototypes` scene" ) % root ) );
+				}
+
+				m_roots.emplace_back( new InternedStringVectorData( path ) );
+
+				InternedStringVectorDataPtr name = new InternedStringVectorData;
+				if( path.empty() )
+				{
+					name->writable().emplace_back( i++ );
+				}
+				else
+				{
+					name->writable().emplace_back( path.back() );
+				}
+				inputNames.emplace_back( name );
+			}
+
+			m_names = new Private::ChildNamesMap( inputNames );
+			m_numPrototypes = m_names->outputChildNames()->readable().size();
+		}
+
 		IECoreScene::ConstPrimitivePtr m_primitive;
+		size_t m_numPrototypes;
+		Private::ChildNamesMapPtr m_names;
+		std::vector<InternedStringVectorDataPtr> m_roots;
 		const std::vector<int> *m_indices;
 		const std::vector<int> *m_ids;
 		const std::vector<Imath::V3f> *m_positions;
@@ -355,7 +484,10 @@ Instancer::Instancer( const std::string &name )
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new StringPlug( "name", Plug::In, "instances" ) );
 	addChild( new ScenePlug( "prototypes" ) );
+	addChild( new IntPlug( "prototypeMode", Plug::In, (int)PrototypeMode::IndexedRootsList, /* min */ (int)PrototypeMode::IndexedRootsList, /* max */ (int)PrototypeMode::RootPerVertex ) );
 	addChild( new StringPlug( "prototypeIndex", Plug::In, "instanceIndex" ) );
+	addChild( new StringPlug( "prototypeRoots", Plug::In, "prototypeRoots" ) );
+	addChild( new StringVectorDataPlug( "prototypeRootPaths", Plug::In, new StringVectorData ) );
 	addChild( new StringPlug( "id", Plug::In, "instanceId" ) );
 	addChild( new StringPlug( "position", Plug::In, "P" ) );
 	addChild( new StringPlug( "orientation", Plug::In ) );
@@ -390,94 +522,124 @@ const ScenePlug *Instancer::prototypesPlug() const
 	return getChild<ScenePlug>( g_firstPlugIndex + 1 );
 }
 
+Gaffer::IntPlug *Instancer::prototypeModePlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::IntPlug *Instancer::prototypeModePlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 2 );
+}
+
 Gaffer::StringPlug *Instancer::prototypeIndexPlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+	return getChild<StringPlug>( g_firstPlugIndex + 3 );
 }
 
 const Gaffer::StringPlug *Instancer::prototypeIndexPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+}
+
+Gaffer::StringPlug *Instancer::prototypeRootsPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+}
+
+const Gaffer::StringPlug *Instancer::prototypeRootsPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+}
+
+Gaffer::StringVectorDataPlug *Instancer::prototypeRootPathsPlug()
+{
+	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 5 );
+}
+
+const Gaffer::StringVectorDataPlug *Instancer::prototypeRootPathsPlug() const
+{
+	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 5 );
 }
 
 Gaffer::StringPlug *Instancer::idPlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+	return getChild<StringPlug>( g_firstPlugIndex + 6 );
 }
 
 const Gaffer::StringPlug *Instancer::idPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+	return getChild<StringPlug>( g_firstPlugIndex + 6 );
 }
 
 Gaffer::StringPlug *Instancer::positionPlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+	return getChild<StringPlug>( g_firstPlugIndex + 7 );
 }
 
 const Gaffer::StringPlug *Instancer::positionPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+	return getChild<StringPlug>( g_firstPlugIndex + 7 );
 }
 
 Gaffer::StringPlug *Instancer::orientationPlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 5 );
+	return getChild<StringPlug>( g_firstPlugIndex + 8 );
 }
 
 const Gaffer::StringPlug *Instancer::orientationPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 5 );
+	return getChild<StringPlug>( g_firstPlugIndex + 8 );
 }
 
 Gaffer::StringPlug *Instancer::scalePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 6 );
+	return getChild<StringPlug>( g_firstPlugIndex + 9 );
 }
 
 const Gaffer::StringPlug *Instancer::scalePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 6 );
+	return getChild<StringPlug>( g_firstPlugIndex + 9 );
 }
 
 Gaffer::StringPlug *Instancer::attributesPlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 7 );
+	return getChild<StringPlug>( g_firstPlugIndex + 10 );
 }
 
 const Gaffer::StringPlug *Instancer::attributesPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 7 );
+	return getChild<StringPlug>( g_firstPlugIndex + 10 );
 }
 
 Gaffer::StringPlug *Instancer::attributePrefixPlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 8 );
+	return getChild<StringPlug>( g_firstPlugIndex + 11 );
 }
 
 const Gaffer::StringPlug *Instancer::attributePrefixPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 8 );
+	return getChild<StringPlug>( g_firstPlugIndex + 11 );
 }
 
 Gaffer::ObjectPlug *Instancer::enginePlug()
 {
-	return getChild<ObjectPlug>( g_firstPlugIndex + 9 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 12 );
 }
 
 const Gaffer::ObjectPlug *Instancer::enginePlug() const
 {
-	return getChild<ObjectPlug>( g_firstPlugIndex + 9 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 12 );
 }
 
 Gaffer::AtomicCompoundDataPlug *Instancer::prototypeChildNamesPlug()
 {
-	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 10 );
+	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 13 );
 }
 
 const Gaffer::AtomicCompoundDataPlug *Instancer::prototypeChildNamesPlug() const
 {
-	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 10 );
+	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 13 );
 }
 
 void Instancer::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
@@ -486,7 +648,11 @@ void Instancer::affects( const Plug *input, AffectedPlugsContainer &outputs ) co
 
 	if(
 		input == inPlug()->objectPlug() ||
+		input == prototypeModePlug() ||
 		input == prototypeIndexPlug() ||
+		input == prototypeRootsPlug() ||
+		input == prototypeRootPathsPlug() ||
+		input == prototypesPlug()->childNamesPlug() ||
 		input == idPlug() ||
 		input == positionPlug() ||
 		input == orientationPlug() ||
@@ -498,14 +664,10 @@ void Instancer::affects( const Plug *input, AffectedPlugsContainer &outputs ) co
 		outputs.push_back( enginePlug() );
 	}
 
-	if(
-		input == enginePlug() ||
-		input == prototypesPlug()->childNamesPlug()
-	)
+	if( input == enginePlug() )
 	{
 		outputs.push_back( prototypeChildNamesPlug() );
 	}
-
 }
 
 void Instancer::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
@@ -515,7 +677,13 @@ void Instancer::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 	if( output == enginePlug() )
 	{
 		inPlug()->objectPlug()->hash( h );
+
+		prototypeModePlug()->hash( h );
 		prototypeIndexPlug()->hash( h );
+		prototypeRootsPlug()->hash( h );
+		prototypeRootPathsPlug()->hash( h );
+		h.append( prototypesPlug()->childNamesHash( ScenePath() ) );
+
 		idPlug()->hash( h );
 		positionPlug()->hash( h );
 		orientationPlug()->hash( h );
@@ -526,7 +694,6 @@ void Instancer::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 	else if( output == prototypeChildNamesPlug() )
 	{
 		enginePlug()->hash( h );
-		h.append( prototypesPlug()->childNamesHash( ScenePath() ) );
 	}
 }
 
@@ -537,10 +704,27 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 	// branch.
 	if( output == enginePlug() )
 	{
+		PrototypeMode mode = (PrototypeMode)prototypeModePlug()->getValue();
+		ConstStringVectorDataPtr prototypeRootPaths = prototypeRootPathsPlug()->getValue();
+		if( mode == PrototypeMode::IndexedRootsList && prototypeRootPaths->readable().empty() )
+		{
+			const auto childNames = prototypesPlug()->childNames( ScenePath() );
+			prototypeRootPaths = new StringVectorData(
+				std::vector<string>(
+					childNames->readable().begin(),
+					childNames->readable().end()
+				)
+			);
+		}
+
 		static_cast<ObjectPlug *>( output )->setValue(
 			new EngineData(
 				inPlug()->objectPlug()->getValue(),
+				mode,
 				prototypeIndexPlug()->getValue(),
+				prototypeRootsPlug()->getValue(),
+				prototypeRootPaths.get(),
+				prototypesPlug(),
 				idPlug()->getValue(),
 				positionPlug()->getValue(),
 				orientationPlug()->getValue(),
@@ -560,23 +744,22 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 		// passes over the input points, where N is the number
 		// of prototypes.
 		ConstEngineDataPtr engine = boost::static_pointer_cast<const EngineData>( enginePlug()->getValue() );
-		ConstInternedStringVectorDataPtr prototypeNames = prototypesPlug()->childNames( ScenePath() );
+		const auto &prototypeNames = engine->prototypeNames()->readable();
 
 		vector<vector<size_t>> indexedPrototypeChildIds;
 
-		int numPrototypes = prototypeNames->readable().size();
+		size_t numPrototypes = engine->numPrototypes();
 		if( numPrototypes )
 		{
 			indexedPrototypeChildIds.resize( numPrototypes );
 			for( size_t i = 0, e = engine->numPoints(); i < e; ++i )
 			{
-				size_t prototypeIndex = engine->prototypeIndex( i ) % numPrototypes;
-				indexedPrototypeChildIds[prototypeIndex].push_back( engine->instanceId( i ) );
+				indexedPrototypeChildIds[ engine->prototypeIndex( i ) ].push_back( engine->instanceId( i ) );
 			}
 		}
 
 		CompoundDataPtr result = new CompoundData;
-		for( int i = 0; i < numPrototypes; i++ )
+		for( size_t i = 0; i < numPrototypes; ++i )
 		{
 			// Sort and uniquify ids before converting to string
 			std::sort( indexedPrototypeChildIds[i].begin(), indexedPrototypeChildIds[i].end() );
@@ -586,9 +769,9 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 			InternedStringVectorDataPtr prototypeChildNames = new InternedStringVectorData;
 			for( size_t id : indexedPrototypeChildIds[i] )
 			{
-				prototypeChildNames->writable().push_back( InternedString( id ) );
+				prototypeChildNames->writable().emplace_back( id );
 			}
-			result->writable()[prototypeNames->readable()[i]] = prototypeChildNames;
+			result->writable()[prototypeNames[i]] = prototypeChildNames;
 		}
 
 		static_cast<AtomicCompoundDataPlug *>( output )->setValue( result );
@@ -632,7 +815,7 @@ void Instancer::hashBranchBound( const ScenePath &parentPath, const ScenePath &b
 		h.append( branchPath.back() );
 
 		{
-			PrototypeScope scope( context, branchPath );
+			PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 			prototypesPlug()->transformPlug()->hash( h );
 			prototypesPlug()->boundPlug()->hash( h );
 		}
@@ -640,7 +823,7 @@ void Instancer::hashBranchBound( const ScenePath &parentPath, const ScenePath &b
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( context, branchPath );
+		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 		h = prototypesPlug()->boundPlug()->hash();
 	}
 }
@@ -673,7 +856,7 @@ Imath::Box3f Instancer::computeBranchBound( const ScenePath &parentPath, const S
 		M44f childTransform;
 		Box3f childBound;
 		{
-			PrototypeScope scope( context, branchPath );
+			PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 			childTransform = prototypesPlug()->transformPlug()->getValue();
 			childBound = prototypesPlug()->boundPlug()->getValue();
 		}
@@ -709,7 +892,7 @@ Imath::Box3f Instancer::computeBranchBound( const ScenePath &parentPath, const S
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( context, branchPath );
+		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 		return prototypesPlug()->boundPlug()->getValue();
 	}
 }
@@ -734,7 +917,7 @@ void Instancer::hashBranchTransform( const ScenePath &parentPath, const ScenePat
 		// "/instances/<prototypeName>/<id>"
 		BranchCreator::hashBranchTransform( parentPath, branchPath, context, h );
 		{
-			PrototypeScope scope( context, branchPath );
+			PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 			prototypesPlug()->transformPlug()->hash( h );
 		}
 		engineHash( parentPath, context, h );
@@ -743,7 +926,7 @@ void Instancer::hashBranchTransform( const ScenePath &parentPath, const ScenePat
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( context, branchPath );
+		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 		h = prototypesPlug()->transformPlug()->hash();
 	}
 }
@@ -760,7 +943,7 @@ Imath::M44f Instancer::computeBranchTransform( const ScenePath &parentPath, cons
 		// "/instances/<prototypeName>/<id>"
 		M44f result;
 		{
-			PrototypeScope scope( context, branchPath );
+			PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 			result = prototypesPlug()->transformPlug()->getValue();
 		}
 		ConstEngineDataPtr e = engine( parentPath, context );
@@ -771,7 +954,7 @@ Imath::M44f Instancer::computeBranchTransform( const ScenePath &parentPath, cons
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( context, branchPath );
+		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 		return prototypesPlug()->transformPlug()->getValue();
 	}
 }
@@ -797,7 +980,7 @@ void Instancer::hashBranchAttributes( const ScenePath &parentPath, const ScenePa
 		BranchCreator::hashBranchAttributes( parentPath, branchPath, context, h );
 		{
 			{
-				PrototypeScope scope( context, branchPath );
+				PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 				prototypesPlug()->attributesPlug()->hash( h );
 			}
 			ConstEngineDataPtr e = engine( parentPath, context );
@@ -810,7 +993,7 @@ void Instancer::hashBranchAttributes( const ScenePath &parentPath, const ScenePa
 	else
 	{
 		// "/instances/<prototypeName>/<id>/...
-		PrototypeScope scope( context, branchPath );
+		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 		h = prototypesPlug()->attributesPlug()->hash();
 	}
 }
@@ -827,7 +1010,7 @@ IECore::ConstCompoundObjectPtr Instancer::computeBranchAttributes( const ScenePa
 		// "/instances/<prototypeName>/<id>"
 		ConstCompoundObjectPtr baseAttributes;
 		{
-			PrototypeScope scope( context, branchPath );
+			PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 			baseAttributes = prototypesPlug()->attributesPlug()->getValue();
 		}
 
@@ -850,7 +1033,7 @@ IECore::ConstCompoundObjectPtr Instancer::computeBranchAttributes( const ScenePa
 	else
 	{
 		// "/instances/<prototypeName>/<id>/...
-		PrototypeScope scope( context, branchPath );
+		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 		return prototypesPlug()->attributesPlug()->getValue();
 	}
 }
@@ -862,7 +1045,10 @@ bool Instancer::processesRootObject() const
 
 bool Instancer::affectsBranchObject( const Gaffer::Plug *input ) const
 {
-	return input == prototypesPlug()->objectPlug();
+	return
+		input == prototypesPlug()->objectPlug() ||
+		input == enginePlug()
+	;
 }
 
 void Instancer::hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
@@ -875,7 +1061,7 @@ void Instancer::hashBranchObject( const ScenePath &parentPath, const ScenePath &
 	else
 	{
 		// "/instances/<prototypeName>/<id>/...
-		PrototypeScope scope( context, branchPath );
+		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 		h = prototypesPlug()->objectPlug()->hash();
 	}
 }
@@ -890,7 +1076,7 @@ IECore::ConstObjectPtr Instancer::computeBranchObject( const ScenePath &parentPa
 	else
 	{
 		// "/instances/<prototypeName>/<id>/...
-		PrototypeScope scope( context, branchPath );
+		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 		return prototypesPlug()->objectPlug()->getValue();
 	}
 }
@@ -900,7 +1086,7 @@ bool Instancer::affectsBranchChildNames( const Gaffer::Plug *input ) const
 	return
 		input == namePlug() ||
 		input == prototypeChildNamesPlug() ||
-		input == prototypesPlug()->childNamesPlug()
+		input == enginePlug()
 	;
 }
 
@@ -915,7 +1101,8 @@ void Instancer::hashBranchChildNames( const ScenePath &parentPath, const ScenePa
 	else if( branchPath.size() == 1 )
 	{
 		// "/instances"
-		h = prototypesPlug()->childNamesHash( ScenePath() );
+		BranchCreator::hashBranchChildNames( parentPath, branchPath, context, h );
+		engineHash( parentPath, context, h );
 	}
 	else if( branchPath.size() == 2 )
 	{
@@ -927,7 +1114,7 @@ void Instancer::hashBranchChildNames( const ScenePath &parentPath, const ScenePa
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( context, branchPath );
+		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 		h = prototypesPlug()->childNamesPlug()->hash();
 	}
 }
@@ -949,7 +1136,7 @@ IECore::ConstInternedStringVectorDataPtr Instancer::computeBranchChildNames( con
 	else if( branchPath.size() == 1 )
 	{
 		// "/instances"
-		return prototypesPlug()->childNames( ScenePath() );
+		return engine( parentPath, context )->prototypeNames();
 	}
 	else if( branchPath.size() == 2 )
 	{
@@ -960,7 +1147,7 @@ IECore::ConstInternedStringVectorDataPtr Instancer::computeBranchChildNames( con
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( context, branchPath );
+		PrototypeScope scope( engine( parentPath, context ), context, branchPath );
 		return prototypesPlug()->childNamesPlug()->getValue();
 	}
 }
@@ -985,7 +1172,7 @@ IECore::ConstInternedStringVectorDataPtr Instancer::computeBranchSetNames( const
 bool Instancer::affectsBranchSet( const Gaffer::Plug *input ) const
 {
 	return
-		input == prototypesPlug()->childNamesPlug() ||
+		input == enginePlug() ||
 		input == prototypesPlug()->setPlug() ||
 		input == prototypeChildNamesPlug() ||
 		input == namePlug()
@@ -996,7 +1183,7 @@ void Instancer::hashBranchSet( const ScenePath &parentPath, const IECore::Intern
 {
 	BranchCreator::hashBranchSet( parentPath, setName, context, h );
 
-	h.append( prototypesPlug()->childNamesHash( ScenePath() ) );
+	engineHash( parentPath, context, h );
 	prototypeChildNamesHash( parentPath, context, h );
 	prototypesPlug()->setPlug()->hash( h );
 	namePlug()->hash( h );
@@ -1004,7 +1191,6 @@ void Instancer::hashBranchSet( const ScenePath &parentPath, const IECore::Intern
 
 IECore::ConstPathMatcherDataPtr Instancer::computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const
 {
-	ConstInternedStringVectorDataPtr prototypeNames = prototypesPlug()->childNames( ScenePath() );
 	IECore::ConstCompoundDataPtr prototypeChildNames = this->prototypeChildNames( parentPath, context );
 	ConstPathMatcherDataPtr inputSet = prototypesPlug()->setPlug()->getValue();
 
@@ -1012,19 +1198,18 @@ IECore::ConstPathMatcherDataPtr Instancer::computeBranchSet( const ScenePath &pa
 	PathMatcher &outputSet = outputSetData->writable();
 
 	vector<InternedString> branchPath( { namePlug()->getValue() } );
-	vector<InternedString> instancePath( 1 );
 
-	for( const auto &prototypeName : prototypeNames->readable() )
+	ConstEngineDataPtr engine = this->engine( parentPath, context );
+	for( const auto &prototypeName : engine->prototypeNames()->readable() )
 	{
 		branchPath.resize( 2 );
 		branchPath.back() = prototypeName;
-		instancePath.back() = prototypeName;
 
-		PathMatcher instanceSet = inputSet->readable().subTree( instancePath );
+		PathMatcher instanceSet = inputSet->readable().subTree( engine->prototypeRoot( prototypeName ) );
 
 		const vector<InternedString> &childNames = prototypeChildNames->member<InternedStringVectorData>( prototypeName )->readable();
 
-		branchPath.push_back( InternedString() );
+		branchPath.emplace_back( InternedString() );
 		for( const auto &childName : childNames )
 		{
 			branchPath.back() = childName;
@@ -1059,16 +1244,22 @@ void Instancer::prototypeChildNamesHash( const ScenePath &parentPath, const Gaff
 	prototypeChildNamesPlug()->hash( h );
 }
 
-Instancer::PrototypeScope::PrototypeScope( const Gaffer::Context *context, const ScenePath &branchPath )
-	:	EditableScope( context )
+Instancer::PrototypeScope::PrototypeScope( ConstEngineDataPtr engine, const Gaffer::Context *context, const ScenePath &branchPath )
+	:	Gaffer::Context::EditableScope( context )
 {
 	assert( branchPath.size() >= 2 );
-	ScenePath prototypePath;
-	prototypePath.reserve( 1 + ( branchPath.size() > 3 ? branchPath.size() - 3 : 0 ) );
-	prototypePath.push_back( branchPath[1] );
+
+	const ScenePlug::ScenePath &prototypeRoot = engine->prototypeRoot( branchPath[1] );
+
 	if( branchPath.size() > 3 )
 	{
+		ScenePlug::ScenePath prototypePath( prototypeRoot );
+		prototypePath.reserve( prototypeRoot.size() + branchPath.size() - 3 );
 		prototypePath.insert( prototypePath.end(), branchPath.begin() + 3, branchPath.end() );
+		set( ScenePlug::scenePathContextName, prototypePath );
 	}
-	set( ScenePlug::scenePathContextName, prototypePath );
+	else
+	{
+		set( ScenePlug::scenePathContextName, prototypeRoot );
+	}
 }

--- a/src/GafferSceneModule/HierarchyBinding.cpp
+++ b/src/GafferSceneModule/HierarchyBinding.cpp
@@ -110,7 +110,15 @@ void GafferSceneModule::bindHierarchy()
 	GafferBindings::DependencyNodeClass<Isolate>();
 	GafferBindings::DependencyNodeClass<CollectScenes>();
 	GafferBindings::DependencyNodeClass<Seeds>();
-	GafferBindings::DependencyNodeClass<Instancer>();
 	GafferBindings::DependencyNodeClass<Encapsulate>();
+
+	{
+		scope s = GafferBindings::DependencyNodeClass<Instancer>();
+		enum_<Instancer::PrototypeMode>( "PrototypeMode" )
+			.value( "IndexedRootsList", Instancer::PrototypeMode::IndexedRootsList )
+			.value( "IndexedRootsVariable", Instancer::PrototypeMode::IndexedRootsVariable )
+			.value( "RootPerVertex", Instancer::PrototypeMode::RootPerVertex )
+			;
+	}
 
 }


### PR DESCRIPTION
This adds control over prototype root locations via a string array, which can be optionally specified using a plug, Constant primvar, or Vertex primvar. Note the default behaviour is backwards compatible, as it uses the prototype scene root children in the absence of a specified root array.

The new `prototypeMode` plug defines how the prototypes map onto each instance. In all cases, a primitive variable will be used to determine which path in the prototypes scene is applied to each instance.

- In "Indexed (Roots List)" mode, the primitive variable must be an integer per-vertex. Optionally, a path in the prototypes scene corresponding to each index can be specified via the `prototypeRootPaths` plug. If no roots are specified, an index of 0 applies the first location			  from the prototypes scene, an index of 1 applies the second, and so on.

- In "Indexed (Roots Variable)" mode, the main primitive variable must be an integer per-vertex, and there must be a separate constant string array primitive variable specifying a path in the prototypes scene corresponding to each index.

- In "Root per Vertex" mode, the primitive variable must be a string per-vertex which will be used to specify a path in the prototypes scene for each instance.

One thing to note, its non-trivial (impossible?) to use `RootPerVertex` mode efficiently, purely in Gaffer... while this will likely be the most commonly used mode at studios using Houdini to generate the input points, I've not a found any way to author an indexed StringVectorData primvar in Gaffer. You can author a non-indexed string primvar using OSLObject, but that generates a unique prototype per instance, which is obviously a bad idea. We could perhaps add a new "index-my-primvar" node to Gaffer, or update `OSLObject` to automatically index string primvars, but both of those felt out-of-scope for this PR.