### PR TITLE
Spreadsheet Round 2 (this time I really mean it)

### DIFF
--- a/include/Gaffer/Spreadsheet.h
+++ b/include/Gaffer/Spreadsheet.h
@@ -76,6 +76,9 @@ class GAFFER_API Spreadsheet : public ComputeNode
 
 				GAFFER_PLUG_DECLARE_TYPE( Gaffer::Spreadsheet::RowsPlug, Gaffer::SpreadsheetRowsPlugTypeId, Gaffer::ValuePlug );
 
+				RowPlug *defaultRow();
+				const RowPlug *defaultRow() const;
+
 				/// Methods for adjusting spreadsheet size
 				/// ======================================
 				///
@@ -170,8 +173,8 @@ class GAFFER_API Spreadsheet : public ComputeNode
 		StringPlug *selectorPlug();
 		const StringPlug *selectorPlug() const;
 
-		ValuePlug *rowsPlug();
-		const ValuePlug *rowsPlug() const;
+		RowsPlug *rowsPlug();
+		const RowsPlug *rowsPlug() const;
 
 		ValuePlug *outPlug();
 		const ValuePlug *outPlug() const;

--- a/include/Gaffer/Spreadsheet.h
+++ b/include/Gaffer/Spreadsheet.h
@@ -1,0 +1,218 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_SPREADSHEET_H
+#define GAFFER_SPREADSHEET_H
+
+#include "Gaffer/ComputeNode.h"
+#include "Gaffer/NumericPlug.h"
+#include "Gaffer/TypedObjectPlug.h"
+
+namespace Gaffer
+{
+
+IE_CORE_FORWARDDECLARE( StringPlug )
+
+class GAFFER_API Spreadsheet : public ComputeNode
+{
+
+	public :
+
+		Spreadsheet( const std::string &name=defaultName<Spreadsheet>() );
+		~Spreadsheet() override;
+
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( Gaffer::Spreadsheet, SpreadsheetTypeId, ComputeNode );
+
+		/// Plug types
+		/// ==========
+		///
+		/// The spreadsheet is defined using a hierarchy of specialised plug
+		/// types, organised first by row and then by column.
+
+		IE_CORE_FORWARDDECLARE( RowPlug );
+
+		/// Top level plug that has a child for each row in the spreadsheet.
+		/// This also provides methods for adding and removing rows and columns.
+		/// Accessed via `Spreadsheet::rowsPlug()`.
+		class RowsPlug : public ValuePlug
+		{
+
+			public :
+
+				RowsPlug( const std::string &name = defaultName<RowsPlug>(), Direction direction = In, unsigned flags = Default );
+
+				GAFFER_PLUG_DECLARE_TYPE( Gaffer::Spreadsheet::RowsPlug, Gaffer::SpreadsheetRowsPlugTypeId, Gaffer::ValuePlug );
+
+				/// Methods for adjusting spreadsheet size
+				/// ======================================
+				///
+				/// Several constraints must be maintained when adjusting the
+				/// size of the spreadsheet, so these dedicated methods should
+				/// be used instead of manual addition of children.
+				///
+				/// These methods are defined on the RowPlug rather than on the
+				/// Spreadsheet so that they can be used for the editing and
+				/// serialisation of promoted plugs.
+
+				size_t addColumn( const ValuePlug *value, IECore::InternedString name = IECore::InternedString() );
+				void removeColumn( size_t columnIndex );
+
+				RowPlug *addRow();
+				/// \todo Return `RowPlug::Range`, which we can't do right
+				/// now because it doesn't have constructors which specify
+				/// the begin/end iterators.
+				void addRows( size_t numRows );
+				void removeRow( RowPlugPtr row );
+
+				Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
+
+			private :
+
+				ValuePlug *outPlug();
+
+		};
+
+		IE_CORE_DECLAREPTR( RowsPlug );
+
+		/// Defines a single row of the spreadsheet. Access using
+		/// `RowPlug::Range( *rowsPlug() )` or via `rowsPlug()->getChild<RowPlug>()`.
+		class RowPlug : public ValuePlug
+		{
+
+			public :
+
+				GAFFER_PLUG_DECLARE_TYPE( Gaffer::Spreadsheet::RowPlug, Gaffer::SpreadsheetRowPlugTypeId, Gaffer::ValuePlug );
+
+				StringPlug *namePlug();
+				const StringPlug *namePlug() const;
+
+				BoolPlug *enabledPlug();
+				const BoolPlug *enabledPlug() const;
+
+				ValuePlug *cellsPlug();
+				const ValuePlug *cellsPlug() const;
+
+				Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
+
+			private :
+
+				RowPlug( const std::string &name, Plug::Direction direction = Plug::In, unsigned flags = Default );
+				friend class Spreadsheet;
+
+		};
+
+		/// Defines a single cell in the spreadsheet. Access using
+		/// `CellPlug::Range( *rowPlug->cellsPlug() )` or via
+		/// `rowPlug->cellsPlug()->getChild<CellPlug>()`.
+		class CellPlug : public ValuePlug
+		{
+
+			public :
+
+				GAFFER_PLUG_DECLARE_TYPE( Gaffer::Spreadsheet::CellPlug, Gaffer::SpreadsheetCellPlugTypeId, Gaffer::ValuePlug );
+
+				BoolPlug *enabledPlug();
+				const BoolPlug *enabledPlug() const;
+
+				template<typename T = Gaffer::ValuePlug>
+				T *valuePlug();
+
+				template<typename T = Gaffer::ValuePlug>
+				const T *valuePlug() const;
+
+				Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
+
+			private :
+
+				CellPlug( const std::string &name, const Gaffer::Plug *value, Plug::Direction direction = Plug::In );
+				friend class Spreadsheet;
+
+		};
+
+		IE_CORE_DECLAREPTR( CellPlug );
+
+		/// Plug accessors
+		/// ==============
+
+		StringPlug *selectorPlug();
+		const StringPlug *selectorPlug() const;
+
+		ValuePlug *rowsPlug();
+		const ValuePlug *rowsPlug() const;
+
+		ValuePlug *outPlug();
+		const ValuePlug *outPlug() const;
+
+		StringVectorDataPlug *activeRowNamesPlug();
+		const StringVectorDataPlug *activeRowNamesPlug() const;
+
+		/// Returns the input plug which provides the value
+		/// for `output` in the current context.
+		ValuePlug *activeInPlug( const ValuePlug *output );
+		const ValuePlug *activeInPlug( const ValuePlug *output ) const;
+
+		/// DependencyNode methods
+		/// ======================
+
+		void affects( const Plug *input, AffectedPlugsContainer &outputs ) const override;
+		BoolPlug *enabledPlug() override;
+		const BoolPlug *enabledPlug() const override;
+		Plug *correspondingInput( const Plug *output ) override;
+		const Plug *correspondingInput( const Plug *output ) const override;
+
+	protected :
+
+		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
+		void compute( ValuePlug *output, const Context *context ) const override;
+
+	private :
+
+		IntPlug *rowIndexPlug();
+		const IntPlug *rowIndexPlug() const;
+
+		const ValuePlug *correspondingInput( const Plug *output, size_t rowIndex ) const;
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( Spreadsheet )
+
+} // namespace Gaffer
+
+#include "Gaffer/Spreadsheet.inl"
+
+#endif // GAFFER_SPREADSHEET_H

--- a/include/Gaffer/Spreadsheet.inl
+++ b/include/Gaffer/Spreadsheet.inl
@@ -1,0 +1,57 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_SPREADSHEET_INL
+#define GAFFER_SPREADSHEET_INL
+
+namespace Gaffer
+{
+
+template<typename T>
+T *Spreadsheet::CellPlug::valuePlug()
+{
+	return getChild<T>( 1 );
+}
+
+template<typename T>
+const T *Spreadsheet::CellPlug::valuePlug() const
+{
+	return getChild<T>( 1 );
+}
+
+} // namespace Gaffer
+
+#endif // GAFFER_SPREADSHEET_INL

--- a/include/Gaffer/TypeIds.h
+++ b/include/Gaffer/TypeIds.h
@@ -105,7 +105,7 @@ enum TypeId
 	Transform2DPlugTypeId = 110058,
 	ReferenceTypeId = 110059,
 	ComputeNodeTypeId = 110060,
-	ParameterisedHolderComputeNodeTypeId = 110061, // obsolete - available for reuse
+	SpreadsheetTypeId = 110061,
 	Color3fVectorDataPlugTypeId = 110062,
 	ActionTypeId = 110063,
 	SimpleActionTypeId = 110064,
@@ -115,7 +115,7 @@ enum TypeId
 	ArrayPlugTypeId = 110068,
 	BackdropTypeId = 110069,
 	SwitchTypeId = 110070,
-	SwitchDependencyNodeTypeId = 110071, // obsolete - available for reuse
+	SpreadsheetCellPlugTypeId = 110071,
 	PathMatcherDataPlugTypeId = 110072,
 	SubGraphTypeId = 110073,
 	DotTypeId = 110074,
@@ -133,6 +133,8 @@ enum TypeId
 	BoxInTypeId = 110086,
 	BoxOutTypeId = 110087,
 	DeleteContextVariablesTypeId = 110088,
+	SpreadsheetRowsPlugTypeId = 110089,
+	SpreadsheetRowPlugTypeId = 110090,
 
 	LastTypeId = 110159,
 

--- a/python/GafferDispatchUI/WedgeUI.py
+++ b/python/GafferDispatchUI/WedgeUI.py
@@ -72,6 +72,9 @@ Gaffer.Metadata.registerNode(
 	"layout:customWidget:colorValues:visibilityActivator", "modeIsColorRange",
 	"layout:customWidget:colorValues:section", "Settings",
 
+	"ui:spreadsheet:activeRowNamesConnection", "strings",
+	"ui:spreadsheet:selectorContextVariablePlug", "variable",
+
 	plugs = {
 
 		"variable" : [

--- a/python/GafferImageUI/CollectImagesUI.py
+++ b/python/GafferImageUI/CollectImagesUI.py
@@ -48,6 +48,9 @@ Gaffer.Metadata.registerNode(
 	Useful for networks that need to dynamically build an unknown number of image layers.
 	""",
 
+	"ui:spreadsheet:activeRowNamesConnection", "rootLayers",
+	"ui:spreadsheet:selectorContextVariablePlug", "layerVariable",
+
 	plugs = {
 
 		"in" : [

--- a/python/GafferSceneTest/SpreadsheetTest.py
+++ b/python/GafferSceneTest/SpreadsheetTest.py
@@ -1,0 +1,77 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+class SpreadsheetTest( GafferSceneTest.SceneTestCase ) :
+
+	def testScenePathAsSelector( self ) :
+
+		sphere = GafferScene.Sphere()
+		cube = GafferScene.Cube()
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( sphere["out"] )
+		group["in"][1].setInput( cube["out"] )
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/group/sphere", "/group/cube" ] ) )
+
+		attributes = GafferScene.StandardAttributes()
+		attributes["in"].setInput( group["out"] )
+		attributes["filter"].setInput( pathFilter["out"] )
+		attributes["attributes"]["deformationBlur"]["enabled"].setValue( True )
+
+		spreadsheet = Gaffer.Spreadsheet()
+		spreadsheet["selector"].setValue( "${scene:path}" )
+		spreadsheet["rows"].addColumn( attributes["attributes"]["deformationBlur"]["value"] )
+		attributes["attributes"]["deformationBlur"]["value"].setInput( spreadsheet["out"][0] )
+
+		row = spreadsheet["rows"].addRow()
+		row["name"].setValue( "/group/cube" )
+		row["cells"][0]["value"].setValue( False )
+
+		self.assertEqual( attributes["out"].attributes( "/group/sphere" )["gaffer:deformationBlur"].value, True )
+		self.assertEqual( attributes["out"].attributes( "/group/cube" )["gaffer:deformationBlur"].value, False )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -141,6 +141,7 @@ from SetVisualiserTest import SetVisualiserTest
 from OrientationTest import OrientationTest
 from MeshTypeTest import MeshTypeTest
 from CopyPrimitiveVariablesTest import CopyPrimitiveVariablesTest
+from SpreadsheetTest import SpreadsheetTest
 
 from IECoreScenePreviewTest import *
 from IECoreGLPreviewTest import *

--- a/python/GafferSceneUI/CollectPrimitiveVariablesUI.py
+++ b/python/GafferSceneUI/CollectPrimitiveVariablesUI.py
@@ -51,6 +51,9 @@ Gaffer.Metadata.registerNode(
 	effects.
 	""",
 
+	"ui:spreadsheet:activeRowNamesConnection", "suffixes",
+	"ui:spreadsheet:selectorContextVariablePlug", "suffixContextVariable",
+
 	plugs = {
 		"primitiveVariables" : [
 

--- a/python/GafferSceneUI/CollectScenesUI.py
+++ b/python/GafferSceneUI/CollectScenesUI.py
@@ -56,6 +56,9 @@ Gaffer.Metadata.registerNode(
 	`rootNames[0]`.
 	""",
 
+	"ui:spreadsheet:activeRowNamesConnection", "rootNames",
+	"ui:spreadsheet:selectorContextVariablePlug", "rootNameVariable",
+
 	plugs = {
 
 		"rootNames" : [

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -58,6 +58,9 @@ Gaffer.Metadata.registerNode(
 	paths.
 	""",
 
+	"ui:spreadsheet:activeRowNamesConnection", "paths",
+	"ui:spreadsheet:selectorValue", "${scene:path}",
+
 	plugs = {
 
 		"paths" : [

--- a/python/GafferSceneUI/ScenePathPlugValueWidget.py
+++ b/python/GafferSceneUI/ScenePathPlugValueWidget.py
@@ -98,3 +98,15 @@ class ScenePathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 			p = self.__scenePlug( output )
 			if p is not None :
 				return p
+
+		# Or perhaps `plug` is in a cell in a spreadsheet, in which case
+		# we may be able to get somewhere by looking where the corresponding
+		# output is connected.
+		## \todo Can this sort of traversal be wrapped up in PlugAlgo somehow?
+
+		cellPlug = plug.ancestor( Gaffer.Spreadsheet.CellPlug )
+		if cellPlug is not None :
+			spreadsheet = cellPlug.ancestor( Gaffer.Spreadsheet )
+			if spreadsheet is not None :
+				return self.__scenePlug( spreadsheet["out"][cellPlug.getName()] )
+

--- a/python/GafferSceneUI/TweakPlugValueWidget.py
+++ b/python/GafferSceneUI/TweakPlugValueWidget.py
@@ -189,8 +189,28 @@ def __noduleLabel( plug ) :
 
 	return name or plug.getName()
 
+def __spreadsheetColumnName( plug ) :
+
+	tweakPlug = plug.parent()
+	if plug == tweakPlug["name"] :
+		return plug.getName()
+
+	# Use some heuristics to come up with a more helpful
+	# column name.
+
+	name = tweakPlug.getName()
+	if name.startswith( "tweak" ) and tweakPlug["name"].source().direction() != Gaffer.Plug.Direction.Out :
+		name = tweakPlug["name"].getValue()
+
+	if name :
+		return name + plug.getName().title()
+	else :
+		return plug.getName()
+
 Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "nodule:type", "GafferUI::CompoundNodule" )
 Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "*", "nodule:type", "" )
 Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "value", "nodule:type", "GafferUI::StandardNodule" )
 Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "noduleLayout:label", __noduleLabel )
 Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "value", "noduleLayout:label", __noduleLabel )
+Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "*", "spreadsheet:columnName", __spreadsheetColumnName )
+

--- a/python/GafferTest/ContextTest.py
+++ b/python/GafferTest/ContextTest.py
@@ -337,6 +337,14 @@ class ContextTest( GafferTest.TestCase ) :
 		self.assertTrue( c.hasSubstitutions( "${a}" ) )
 		self.assertTrue( c.hasSubstitutions( "###" ) )
 
+	def testInternedStringVectorDataSubstitutions( self ) :
+
+		c = Gaffer.Context()
+		c["test1"] = IECore.InternedStringVectorData( [ "a", "b" ] )
+		c["test2"] = IECore.InternedStringVectorData()
+		self.assertEqual( c.substitute( "${test1}" ), "/a/b" )
+		self.assertEqual( c.substitute( "${test2}" ), "/" )
+
 	def testNames( self ) :
 
 		c = Gaffer.Context()

--- a/python/GafferTest/SpreadsheetTest.py
+++ b/python/GafferTest/SpreadsheetTest.py
@@ -1,0 +1,434 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+
+import IECore
+
+import Gaffer
+import GafferTest
+
+class SpreadsheetTest( GafferTest.TestCase ) :
+
+	def testConstructor( self ) :
+
+		self.assertEqual( Gaffer.Spreadsheet().getName(), "Spreadsheet" )
+
+		s = Gaffer.Spreadsheet( "s" )
+		self.assertEqual( s.getName(), "s" )
+
+		# Check default row
+
+		self.assertEqual( len( s["rows"] ), 1 )
+		self.assertEqual( s["rows"][0].getName(), "default" )
+		self.assertEqual( s["rows"][0]["name"].getValue(), "" )
+		self.assertEqual( s["rows"][0]["enabled"].getValue(), True )
+		self.assertIsInstance( s["rows"][0], Gaffer.Spreadsheet.RowPlug )
+
+		# Check we have no columns
+
+		self.assertEqual( len( s["rows"][0]["cells"] ), 0 )
+		self.assertEqual( len( s["out"] ), 0 )
+
+	def testEditColumnsAndRows( self ) :
+
+		s = Gaffer.Spreadsheet()
+
+		columnIndex = s["rows"].addColumn( Gaffer.IntPlug( "myInt" ) )
+		self.assertEqual( columnIndex, 0 )
+		self.assertEqual( len( s["rows"][0]["cells"] ), 1 )
+		self.assertIsInstance( s["rows"][0]["cells"][0], Gaffer.Spreadsheet.CellPlug )
+		self.assertEqual( s["rows"][0]["cells"][0].getName(), "myInt" )
+		self.assertIsInstance( s["rows"][0]["cells"][0]["value"], Gaffer.IntPlug )
+		self.assertEqual( s["rows"][0]["cells"][0]["enabled"].getValue(), True )
+		self.assertEqual( s["rows"][0]["cells"][0]["value"].getValue(), 0 )
+		self.assertEqual( len( s["out"] ), 1 )
+		self.assertEqual( s["out"][0].getName(), "myInt" )
+		self.assertIsInstance( s["out"][0], Gaffer.IntPlug )
+		self.assertEqual( s["out"][0].direction(), Gaffer.Plug.Direction.Out )
+
+		columnIndex = s["rows"].addColumn( Gaffer.FloatPlug( "myFloat", defaultValue = 1 ) )
+		self.assertEqual( columnIndex, 1 )
+		self.assertEqual( len( s["rows"][0]["cells"] ), 2 )
+		self.assertIsInstance( s["rows"][0]["cells"][1], Gaffer.Spreadsheet.CellPlug )
+		self.assertEqual( s["rows"][0]["cells"][1].getName(), "myFloat" )
+		self.assertIsInstance( s["rows"][0]["cells"][1]["value"], Gaffer.FloatPlug )
+		self.assertEqual( s["rows"][0]["cells"][1]["enabled"].getValue(), True )
+		self.assertEqual( s["rows"][0]["cells"][1]["value"].getValue(), 1 )
+		self.assertEqual( len( s["out"] ), 2 )
+		self.assertEqual( s["out"][1].getName(), "myFloat" )
+		self.assertIsInstance( s["out"][1], Gaffer.FloatPlug )
+		self.assertEqual( s["out"][1].direction(), Gaffer.Plug.Direction.Out )
+
+		row = s["rows"].addRow()
+		self.assertIsInstance( row, Gaffer.Spreadsheet.RowPlug )
+		self.assertEqual( row.parent(), s["rows"] )
+		self.assertEqual( row.getName(), "row1" )
+		self.assertEqual( len( row["cells"] ), 2 )
+		self.assertEqual( row["cells"][0].getName(), "myInt" )
+		self.assertEqual( row["cells"][1].getName(), "myFloat" )
+		self.assertIsInstance( row["cells"][0], Gaffer.Spreadsheet.CellPlug )
+		self.assertIsInstance( row["cells"][1], Gaffer.Spreadsheet.CellPlug )
+		self.assertEqual( row["cells"][0]["enabled"].getValue(), True )
+		self.assertEqual( row["cells"][0]["value"].getValue(), 0 )
+		self.assertEqual( row["cells"][1]["enabled"].getValue(), True )
+		self.assertEqual( row["cells"][1]["value"].getValue(), 1 )
+
+		s["rows"].removeColumn( columnIndex )
+		self.assertEqual( len( s["rows"][0]["cells"] ), 1 )
+		self.assertEqual( s["rows"][0]["cells"][0].getName(), "myInt" )
+		self.assertEqual( len( s["out"] ), 1 )
+		self.assertEqual( s["out"][0].getName(), "myInt" )
+
+	def testOutput( self ) :
+
+		s = Gaffer.Spreadsheet()
+
+		s["rows"].addColumn( Gaffer.IntPlug( "column1" ) )
+		s["rows"].addColumn( Gaffer.IntPlug( "column2" ) )
+
+		defaultRow = s["rows"]["default"]
+		row1 = s["rows"].addRow()
+		row1["name"].setValue( "row1" )
+		row2 = s["rows"].addRow()
+		row2["name"].setValue( "row2" )
+
+		defaultRow["cells"]["column1"]["value"].setValue( 1 )
+		defaultRow["cells"]["column2"]["value"].setValue( 2 )
+		row1["cells"]["column1"]["value"].setValue( 3 )
+		row1["cells"]["column2"]["value"].setValue( 4 )
+		row2["cells"]["column1"]["value"].setValue( 5 )
+		row2["cells"]["column2"]["value"].setValue( 6 )
+
+		for selector in ( "", "woteva", "row1", "row2" ) :
+
+			s["selector"].setValue( selector )
+			expectedRow = s["rows"].getChild( selector ) or s["rows"]["default"]
+
+			for out in s["out"] :
+
+				s["enabled"].setValue( True )
+				self.assertEqual( out.getValue(), expectedRow["cells"][out.getName()]["value"].getValue() )
+
+				s["enabled"].setValue( False )
+				self.assertEqual( out.getValue(), s["rows"]["default"]["cells"][out.getName()]["value"].getValue() )
+
+	def testSerialisation( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["s"] = Gaffer.Spreadsheet()
+		s["s"]["rows"].addColumn( Gaffer.IntPlug( "column1" ) )
+		s["s"]["rows"].addColumn( Gaffer.IntPlug( "column2" ) )
+		s["s"]["rows"].addRow()
+		s["s"]["rows"].addRow()
+
+		s["s"]["rows"][0]["cells"]["column1"]["value"].setValue( 10 )
+		s["s"]["rows"][1]["cells"]["column1"]["value"].setValue( 20 )
+		s["s"]["rows"][1]["cells"]["column1"]["enabled"].setValue( False )
+		s["s"]["rows"][1]["name"].setValue( "rrr" )
+		s["s"]["rows"][2]["name"].setValue( "zzz" )
+		s["s"]["rows"][2]["cells"]["column1"]["value"].setValue( 30 )
+		s["s"]["rows"][2]["cells"]["column2"]["value"].setValue( 40 )
+
+		ss = s.serialise()
+		self.assertEqual( ss.count( "addChild" ), 1 )
+		self.assertEqual( ss.count( "addColumn" ), 2 )
+		self.assertEqual( ss.count( "addRows" ), 1 )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( ss )
+
+		self.assertEqual( s2["s"]["rows"].keys(), s["s"]["rows"].keys() )
+		for r in s2["s"]["rows"].keys() :
+			self.assertEqual( s2["s"]["rows"][r]["name"].getValue(), s["s"]["rows"][r]["name"].getValue() )
+			self.assertEqual( s2["s"]["rows"][r]["enabled"].getValue(), s["s"]["rows"][r]["enabled"].getValue() )
+			self.assertEqual( s2["s"]["rows"][r]["cells"].keys(), s["s"]["rows"][r]["cells"].keys() )
+			for c in s2["s"]["rows"][r]["cells"].keys() :
+				self.assertEqual( s2["s"]["rows"][r]["cells"][c]["enabled"].getValue(), s["s"]["rows"][r]["cells"][c]["enabled"].getValue() )
+				self.assertEqual( s2["s"]["rows"][r]["cells"][c]["value"].getValue(), s["s"]["rows"][r]["cells"][c]["value"].getValue() )
+
+	def testNestedPlugs( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.TransformPlug( "transform" ) )
+		r = s["rows"].addRow()
+
+		self.assertEqual(
+			s.correspondingInput( s["out"]["transform"]["translate"]["x"] ),
+			s["rows"][0]["cells"]["transform"]["value"]["translate"]["x"]
+		)
+
+		r["name"].setValue( "n" )
+		r["cells"]["transform"]["value"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
+
+		self.assertEqual( s["out"]["transform"]["translate"].getValue(), imath.V3f( 0 ) )
+		s["selector"].setValue( "n" )
+		self.assertEqual( s["out"]["transform"]["translate"].getValue(), imath.V3f( 1, 2, 3 ) )
+
+	def testDirtyPropagation( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.V3fPlug( "v" ) )
+		s["rows"].addColumn( Gaffer.FloatPlug( "f" ) )
+		r = s["rows"].addRow()
+
+		cs = GafferTest.CapturingSlot( s.plugDirtiedSignal() )
+
+		s["enabled"].setValue( False )
+		self.assertTrue( set( s["out"].children() ).issubset( { x[0] for x in cs } ) )
+		del cs[:]
+
+		r["cells"]["v"]["value"]["x"].setValue( 2 )
+		self.assertIn( s["out"]["v"]["x"], { x[0] for x in cs } )
+		self.assertNotIn( s["out"]["v"]["z"], { x[0] for x in cs } )
+		self.assertNotIn( s["out"]["f"], { x[0] for x in cs } )
+		del cs[:]
+
+		r["cells"]["v"]["enabled"].setValue( False )
+		self.assertTrue( set( s["out"]["v"].children() ).issubset( { x[0] for x in cs } ) )
+		self.assertNotIn( s["out"]["f"], { x[0] for x in cs } )
+		del cs[:]
+
+		s["rows"].addRow()
+		self.assertTrue( set( s["out"].children() ).issubset( { x[0] for x in cs } ) )
+		del cs[:]
+
+		s["rows"].removeChild( s["rows"][-1] )
+		self.assertTrue( set( s["out"].children() ).issubset( { x[0] for x in cs } ) )
+		del cs[:]
+
+	def testDisablingRows( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["selector"].setValue( "a" )
+		s["rows"].addColumn( Gaffer.IntPlug( "i" ) )
+
+		r = s["rows"].addRow()
+		r["name"].setValue( "a" )
+		r["cells"]["i"]["value"].setValue( 2 )
+		self.assertEqual( s["out"]["i"].getValue(), 2 )
+
+		r["enabled"].setValue( False )
+		self.assertEqual( s["out"]["i"].getValue(), 0 )
+
+	def testCorrespondingInput( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.IntPlug( "column1" ) )
+		s["rows"].addRows( 2 )
+
+		self.assertEqual( s.correspondingInput( s["out"]["column1"] ), s["rows"]["default"]["cells"]["column1"]["value"] )
+		self.assertEqual( s.correspondingInput( s["out"] ), None )
+
+	def testPromotion( self ) :
+
+		def assertCellEqual( cellPlug1, cellPlug2 ) :
+
+			self.assertEqual( cellPlug1.getName(), cellPlug2.getName() )
+			self.assertIsInstance( cellPlug1, Gaffer.Spreadsheet.CellPlug )
+			self.assertIsInstance( cellPlug2, Gaffer.Spreadsheet.CellPlug )
+
+			self.assertEqual( cellPlug1["enabled"].getValue(), cellPlug2["enabled"].getValue() )
+			self.assertEqual( cellPlug1["value"].getValue(), cellPlug2["value"].getValue() )
+
+		def assertRowEqual( rowPlug1, rowPlug2 ) :
+
+			self.assertEqual( rowPlug1.getName(), rowPlug2.getName() )
+			self.assertIsInstance( rowPlug1, Gaffer.Spreadsheet.RowPlug )
+			self.assertIsInstance( rowPlug2, Gaffer.Spreadsheet.RowPlug )
+			self.assertEqual( rowPlug1["name"].getValue(), rowPlug2["name"].getValue() )
+			self.assertEqual( rowPlug1["enabled"].getValue(), rowPlug2["enabled"].getValue() )
+			self.assertEqual( rowPlug1["cells"].keys(), rowPlug2["cells"].keys() )
+
+			for k in rowPlug1["cells"].keys() :
+				assertCellEqual( rowPlug1["cells"][k], rowPlug2["cells"][k] )
+
+		def assertRowsEqual( rowsPlug1, rowsPlug2 ) :
+
+			self.assertIsInstance( rowsPlug1, Gaffer.Spreadsheet.RowsPlug )
+			self.assertIsInstance( rowsPlug2, Gaffer.Spreadsheet.RowsPlug )
+			self.assertEqual( rowsPlug1.keys(), rowsPlug2.keys() )
+
+			for k in rowsPlug1.keys() :
+				assertRowEqual( rowsPlug1[k], rowsPlug2[k] )
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+
+		# Make a Spreadsheet with some existing cells
+		# and promote the "rows" plug.
+
+		s["b"]["s1"] = Gaffer.Spreadsheet()
+		s["b"]["s1"]["rows"].addColumn( Gaffer.IntPlug( "i" ) )
+		s["b"]["s1"]["rows"].addRow()["cells"][0]["value"].setValue( 10 )
+		s["b"]["s1"]["rows"].addRow()["cells"][0]["value"].setValue( 20 )
+
+		p1 = Gaffer.PlugAlgo.promote( s["b"]["s1"]["rows"] )
+		assertRowsEqual( p1, s["b"]["s1"]["rows"] )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["s1"]["rows"] ) )
+
+		# Promote the "rows" plug on an empty spreadsheet,
+		# and add some cells.
+
+		s["b"]["s2"] = Gaffer.Spreadsheet()
+		p2 = Gaffer.PlugAlgo.promote( s["b"]["s2"]["rows"] )
+		assertRowsEqual( p2, s["b"]["s2"]["rows"] )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["s2"]["rows"] ) )
+
+		p2.addColumn( Gaffer.IntPlug( "i" ) )
+		p2.addRow()["cells"][0]["value"].setValue( 10 )
+		p2.addRow()["cells"][0]["value"].setValue( 20 )
+		assertRowsEqual( p2, s["b"]["s2"]["rows"] )
+		self.assertTrue( Gaffer.PlugAlgo.isPromoted( s["b"]["s2"]["rows"] ) )
+
+		# Serialise and reload, and check all is well
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		assertRowsEqual( s2["b"]["s1"]["rows"], s["b"]["s1"]["rows"] )
+		assertRowsEqual( s2["b"]["s2"]["rows"], s["b"]["s2"]["rows"] )
+
+	def testActiveRowNames( self ) :
+
+		s = Gaffer.Spreadsheet()
+		for i in range( 1, 4 ) :
+			s["rows"].addRow()["name"].setValue( str( i ) )
+
+		self.assertEqual( s["activeRowNames"].getValue(), IECore.StringVectorData( [ "1", "2", "3" ] ) )
+
+		s["rows"][1]["enabled"].setValue( False )
+		self.assertEqual( s["activeRowNames"].getValue(), IECore.StringVectorData( [ "2", "3" ] ) )
+
+		s["rows"][2]["name"].setValue( "two" )
+		self.assertEqual( s["activeRowNames"].getValue(), IECore.StringVectorData( [ "two", "3" ] ) )
+
+	def testAddColumnUsingDynamicPlug( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["s"] = Gaffer.Spreadsheet()
+		s["s"]["rows"].addColumn( Gaffer.Color3fPlug( "c", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		s["s"]["rows"].addColumn( Gaffer.IntPlug( "i", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( s2["s"]["rows"][0]["cells"].keys(), s["s"]["rows"][0]["cells"].keys() )
+		self.assertEqual( s2["s"]["out"].keys(), s["s"]["out"].keys() )
+
+		self.assertEqual( s2.serialise(), s.serialise() )
+
+	def testActiveInput( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.V3fPlug( "v" ) )
+		s["rows"].addColumn( Gaffer.IntPlug( "i" ) )
+		s["rows"].addRow()["name"].setValue( "a" )
+		s["rows"].addRow()["name"].setValue( "b" )
+		s["selector"].setValue( "${testSelector}" )
+
+		with Gaffer.Context() as c :
+
+			self.assertEqual( s.activeInPlug( s["out"]["v"] ), s["rows"]["default"]["cells"]["v"]["value"] )
+			self.assertEqual( s.activeInPlug( s["out"]["v"]["x"] ), s["rows"]["default"]["cells"]["v"]["value"]["x"] )
+			self.assertEqual( s.activeInPlug( s["out"]["i"] ), s["rows"]["default"]["cells"]["i"]["value"] )
+
+			c["testSelector"] = "a"
+			self.assertEqual( s.activeInPlug( s["out"]["v"] ), s["rows"][1]["cells"]["v"]["value"] )
+			self.assertEqual( s.activeInPlug( s["out"]["v"]["x"] ), s["rows"][1]["cells"]["v"]["value"]["x"] )
+			self.assertEqual( s.activeInPlug( s["out"]["i"] ), s["rows"][1]["cells"]["i"]["value"] )
+
+			c["testSelector"] = "b"
+			self.assertEqual( s.activeInPlug( s["out"]["v"] ), s["rows"][2]["cells"]["v"]["value"] )
+			self.assertEqual( s.activeInPlug( s["out"]["v"]["x"] ), s["rows"][2]["cells"]["v"]["value"]["x"] )
+			self.assertEqual( s.activeInPlug( s["out"]["i"] ), s["rows"][2]["cells"]["i"]["value"] )
+
+			c["testSelector"] = "x"
+			self.assertEqual( s.activeInPlug( s["out"]["v"] ), s["rows"]["default"]["cells"]["v"]["value"] )
+			self.assertEqual( s.activeInPlug( s["out"]["v"]["x"] ), s["rows"]["default"]["cells"]["v"]["value"]["x"] )
+			self.assertEqual( s.activeInPlug( s["out"]["i"] ), s["rows"]["default"]["cells"]["i"]["value"] )
+
+	def testAddColumnWithName( self ) :
+
+		s = Gaffer.Spreadsheet()
+		i = s["rows"].addColumn( Gaffer.IntPlug( "x" ), name = "y" )
+		self.assertEqual( s["rows"]["default"]["cells"][0].getName(), "y" )
+		self.assertEqual( s["out"][0].getName(), "y" )
+
+	def testAddColumnCopiesCurrentValue( self ) :
+
+		p = Gaffer.IntPlug( defaultValue = 1, minValue = -10, maxValue = 10 )
+		p.setValue( 3 )
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addRow()
+		s["rows"].addColumn( p )
+
+		for row in s["rows"] :
+			self.assertEqual( row["cells"][0]["value"].defaultValue(), p.defaultValue() )
+			self.assertEqual( row["cells"][0]["value"].minValue(), p.minValue() )
+			self.assertEqual( row["cells"][0]["value"].maxValue(), p.maxValue() )
+			self.assertEqual( row["cells"][0]["value"].getValue(), p.getValue() )
+
+	def testRemoveRow( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s2 = Gaffer.Spreadsheet( "other" )
+
+		defaultRow = s["rows"]["default"]
+		row1 = s["rows"].addRow()
+		row2 = s["rows"].addRow()
+		otherRow = s2["rows"].addRow()
+		self.assertEqual( len( s["rows"] ), 3 )
+
+		with self.assertRaisesRegexp( RuntimeError, 'Cannot remove default row from "Spreadsheet.rows"' ) :
+			s["rows"].removeRow( defaultRow )
+
+		self.assertEqual( len( s["rows"] ), 3 )
+
+		with self.assertRaisesRegexp( RuntimeError, 'Row "other.rows.row1" is not a child of "Spreadsheet.rows"' ) :
+			s["rows"].removeRow( otherRow )
+
+		self.assertEqual( len( s["rows"] ), 3 )
+
+		s["rows"].removeRow( row1 )
+		self.assertEqual( s["rows"].children(), ( defaultRow, row2 ) )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/SpreadsheetTest.py
+++ b/python/GafferTest/SpreadsheetTest.py
@@ -115,6 +115,61 @@ class SpreadsheetTest( GafferTest.TestCase ) :
 		self.assertEqual( len( s["out"] ), 1 )
 		self.assertEqual( s["out"][0].getName(), "myInt" )
 
+	def testRemoveMiddleColumn( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["s"] = Gaffer.Spreadsheet()
+		s["s"]["rows"].addRow()
+
+		c1 = s["s"]["rows"].addColumn( Gaffer.IntPlug( "c1" ) )
+		c2 = s["s"]["rows"].addColumn( Gaffer.FloatPlug( "c2" ) )
+		c3 = s["s"]["rows"].addColumn( Gaffer.StringPlug( "c3" ) )
+
+		def assertPreconditions() :
+
+			for row in s["s"]["rows"] :
+				self.assertEqual( row["cells"].keys(), [ "c1", "c2", "c3" ] )
+				self.assertIsInstance( row["cells"]["c1"]["value"], Gaffer.IntPlug )
+				self.assertIsInstance( row["cells"]["c2"]["value"], Gaffer.FloatPlug )
+				self.assertIsInstance( row["cells"]["c3"]["value"], Gaffer.StringPlug )
+
+			self.assertEqual( s["s"]["out"].keys(), [ "c1", "c2", "c3" ] )
+			self.assertIsInstance( s["s"]["out"]["c1"], Gaffer.IntPlug )
+			self.assertIsInstance( s["s"]["out"]["c2"], Gaffer.FloatPlug )
+			self.assertIsInstance( s["s"]["out"]["c3"], Gaffer.StringPlug )
+
+		assertPreconditions()
+
+		with Gaffer.UndoContext( s ) :
+			s["s"]["rows"].removeColumn( c2 )
+
+		def assertPostConditions() :
+
+			for row in s["s"]["rows"] :
+				self.assertEqual( row["cells"].keys(), [ "c1", "c3" ] )
+				self.assertIsInstance( row["cells"]["c1"]["value"], Gaffer.IntPlug )
+				self.assertIsInstance( row["cells"]["c3"]["value"], Gaffer.StringPlug )
+
+			self.assertEqual( s["s"]["out"].keys(), [ "c1", "c3" ] )
+			self.assertIsInstance( s["s"]["out"]["c1"], Gaffer.IntPlug )
+			self.assertIsInstance( s["s"]["out"]["c3"], Gaffer.StringPlug )
+
+		assertPostConditions()
+
+		s.undo()
+		assertPreconditions()
+
+		s.redo()
+		assertPostConditions()
+
+		s.undo()
+		assertPreconditions()
+
+		s.redo()
+		assertPostConditions()
+
+
 	def testOutput( self ) :
 
 		s = Gaffer.Spreadsheet()

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -161,6 +161,7 @@ from ExtensionAlgoTest import ExtensionAlgoTest
 from ModuleTest import ModuleTest
 from NumericBookmarkSetTest import NumericBookmarkSetTest
 from NameSwitchTest import NameSwitchTest
+from SpreadsheetTest import SpreadsheetTest
 
 from IECorePreviewTest import *
 

--- a/python/GafferUI/NameValuePlugValueWidget.py
+++ b/python/GafferUI/NameValuePlugValueWidget.py
@@ -143,3 +143,23 @@ class NameValuePlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__row[-1].setEnabled( enabled )
 
 GafferUI.PlugValueWidget.registerType( Gaffer.NameValuePlug, NameValuePlugValueWidget )
+
+def __spreadsheetColumnName( plug ) :
+
+	nameValuePlug = plug.parent()
+	if plug == nameValuePlug["name"] :
+		return plug.getName()
+
+	# Use some heuristics to come up with a more helpful
+	# column name.
+
+	name = nameValuePlug.getName()
+	if name.startswith( "member" ) and nameValuePlug["name"].source().direction() != Gaffer.Plug.Direction.Out :
+		name = nameValuePlug["name"].getValue()
+
+	if name :
+		return name + plug.getName().title()
+	else :
+		return plug.getName()
+
+Gaffer.Metadata.registerValue( Gaffer.NameValuePlug, "*", "spreadsheet:columnName", __spreadsheetColumnName )

--- a/python/GafferUI/NameValuePlugValueWidget.py
+++ b/python/GafferUI/NameValuePlugValueWidget.py
@@ -123,6 +123,14 @@ class NameValuePlugValueWidget( GafferUI.PlugValueWidget ) :
 		for w in self.__row :
 			w.setReadOnly( readOnly )
 
+	def setNameVisible( self, visible ) :
+
+		self.__row[0].setVisible( visible )
+
+	def getNameVisible( self ) :
+
+		return self.__row[0].getVisible()
+
 	def _updateFromPlug( self ) :
 
 		if "enabled" in self.getPlug() :

--- a/python/GafferUI/PresetsPlugValueWidget.py
+++ b/python/GafferUI/PresetsPlugValueWidget.py
@@ -60,6 +60,10 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self._addPopupMenu( self.__menuButton )
 		self._updateFromPlug()
 
+	def menu( self ) :
+
+		return self.__menuButton.getMenu()
+
 	def _updateFromPlug( self ) :
 
 		self.__menuButton.setEnabled( self._editable() )

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -523,6 +523,7 @@ class _PlugTableView( GafferUI.Widget ) :
 
 		tableView.setVerticalScrollBarPolicy( QtCore.Qt.ScrollBarAlwaysOff )
 		tableView.setHorizontalScrollBarPolicy( QtCore.Qt.ScrollBarAlwaysOff )
+		tableView.setHorizontalScrollMode( tableView.ScrollPerPixel )
 
 		tableView.setSizePolicy(
 			QtWidgets.QSizePolicy.Fixed if mode == self.Mode.RowNames else QtWidgets.QSizePolicy.Maximum,

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -595,7 +595,9 @@ class _PlugTableView( GafferUI.Widget ) :
 		header = self._qtWidget().horizontalHeader()
 		for index, plug in enumerate( rowsPlug["default"]["cells"] ) :
 			visualIndex = Gaffer.Metadata.value( plug, "spreadsheet:columnIndex" )
+			self.__callingMoveSection = True
 			header.moveSection( header.visualIndex( index ), visualIndex if visualIndex is not None else index )
+			self.__callingMoveSection = False
 
 	@GafferUI.LazyMethod()
 	def __applySectionOrderLazily( self ) :

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -1385,6 +1385,9 @@ def __addToSpreadsheetSubMenu( plug ) :
 	other = []
 	for spreadsheet in Gaffer.Spreadsheet.Range( plug.node().parent() ) :
 
+		if spreadsheet == plug.ancestor( Gaffer.Spreadsheet ) :
+			continue
+
 		connected = False
 		for output in spreadsheet["out"] :
 			for destination in output.outputs() :

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -1046,13 +1046,13 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 		elif value is None :
 			return ""
 
-		if not forToolTip :
+		try :
+			# Unknown type. If iteration is supported then use that.
+			separator = "\n" if forToolTip else ", "
+			return separator.join( str( x ) for x in value )
+		except :
+			# Otherwise just cast to string
 			return str( value )
-		else :
-			try :
-				return "\n".join( str( x ) for x in value )
-			except :
-				return str( value )
 
 class _PlugTableDelegate( QtWidgets.QStyledItemDelegate ) :
 

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -1,0 +1,1560 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import imath
+
+import IECore
+
+import Gaffer
+import GafferUI
+
+from Qt import QtCore
+from Qt import QtGui
+from Qt import QtWidgets
+from Qt import QtCompat
+
+from _TableView import _TableView
+
+Gaffer.Metadata.registerNode(
+
+	Gaffer.Spreadsheet,
+
+	"description",
+	"""
+	Provides a spreadsheet designed for easy management of sets of
+	associated plug values. Each column of the spreadsheet corresponds
+	to an output value that can be connected to drive a plug on another
+	node. Each row of the spreadsheet provides candidate values for each
+	output, along with a row name and enabled status. Row names are matched
+	against a selector to determine which row is passed through to the output.
+	Row matching is performed as follows :
+
+	- Matching starts with the second row and considers all subsequent
+	  rows one by one until a match is found. The first matching row
+	  is the one that is chosen.
+	- Matching is performed using Gaffer's standard wildcard matching.
+	  Each "name" may contain several individual patterns each separated
+	  by spaces.
+	- The first row is used as a default, and is chosen only if no other
+	  row matches.
+
+	> Note : The matching rules are identical to the ones used by the
+	> NameSwitch node.
+	""",
+
+	"nodeGadget:type", "GafferUI::AuxiliaryNodeGadget",
+	"nodeGadget:shape", "oval",
+	"uiEditor:nodeGadgetTypes", IECore.StringVectorData( [ "GafferUI::AuxiliaryNodeGadget", "GafferUI::StandardNodeGadget" ] ),
+	"auxiliaryNodeGadget:label", "#",
+
+	plugs = {
+
+		"*" : [
+
+			"noduleLayout:visible", False,
+
+		],
+
+		"selector" : [
+
+			"description",
+			"""
+			The value that the row names will be matched against.
+			Typically this will refer to a context variable using
+			the `${variableName}` syntax.
+			""",
+
+			"divider", True,
+
+		],
+
+		"rows" : [
+
+			"description",
+			"""
+			Holds a child RowPlug for each row in the spreadsheet.
+			""",
+
+		],
+
+		"rows.default" : [
+
+			"description",
+			"""
+			The default row. This provides output values when no other
+			row matches the `selector`.
+			""",
+
+			"spreadsheet:rowNameWidth", GafferUI.PlugWidget.labelWidth(),
+
+		],
+
+		"rows.*.name" : [
+
+			"description",
+			"""
+			The name of the row. This is matched against the `selector`
+			to determine which row is chosen to be passed to the output.
+			May contain multiple space separated names and any of Gaffer's
+			standard wildcards.
+			""",
+
+		],
+
+		"rows.*.enabled" : [
+
+			"description",
+			"""
+			Enables or disables this row. Disabled rows are ignored.
+			""",
+
+		],
+
+		"rows.*.cells" : [
+
+			"description",
+			"""
+			Contains a child CellPlug for each column in the spreadsheet.
+			""",
+
+		],
+
+		"out" : [
+
+			"description",
+			"""
+			The outputs from the spreadsheet. Contains a child plug for each
+			column in the spreadsheet.
+			""",
+
+			"plugValueWidget:type", "",
+
+		],
+
+		"activeRowNames" : [
+
+			"description",
+			"""
+			An output plug containing the names of all currently active rows.
+			""",
+
+			"plugValueWidget:type", "",
+
+		],
+
+	}
+
+)
+
+# Metadata methods
+# ================
+#
+# We don't want to copy identical metadata onto every cell of the spreadsheet, as
+# that's a lot of pointless duplication. Instead we register metadata onto the
+# default row only, and then mirror it dynamically onto the other rows. This isn't
+# flawless because we can only mirror metadata we know the names for in advance, but
+# since we only support a limited subset of widgets in the spreadsheet it seems
+# workable.
+
+def __correspondingDefaultPlug( plug ) :
+
+	rowPlug = plug.ancestor( Gaffer.Spreadsheet.RowPlug )
+	rowsPlug = rowPlug.parent()
+	return rowsPlug["default"].descendant( plug.relativeName( rowPlug ) )
+
+def __defaultCellMetadata( plug, key ) :
+
+	return Gaffer.Metadata.value( __correspondingDefaultPlug( plug ), key )
+
+for key in [
+	"spreadsheet:columnLabel",
+	"plugValueWidget:type",
+	"presetsPlugValueWidget:allowCustom"
+] :
+
+	Gaffer.Metadata.registerValue(
+		Gaffer.Spreadsheet.RowsPlug, "row*.cells...", key,
+		functools.partial( __defaultCellMetadata, key = key ),
+	)
+
+# Presets are tricky because we can't know their names in advance. We register
+# "presetNames" and "presetValues" arrays that we can use to gather all "preset:*"
+# metadata into on the fly.
+
+__plugPresetTypes = {
+
+	Gaffer.IntPlug : IECore.IntVectorData,
+	Gaffer.FloatPlug : IECore.FloatVectorData,
+	Gaffer.StringPlug : IECore.StringVectorData,
+	Gaffer.V3fPlug : IECore.V3fVectorData,
+	Gaffer.V2fPlug : IECore.V2fVectorData,
+	Gaffer.V3iPlug : IECore.V3iVectorData,
+	Gaffer.V2iPlug : IECore.V2iVectorData,
+	Gaffer.Color3fPlug : IECore.Color3fVectorData,
+	Gaffer.Color4fPlug : IECore.Color4fVectorData,
+
+}
+
+def __presetNamesMetadata( plug ) :
+
+	if plug.__class__ not in __plugPresetTypes :
+		return None
+
+	source = __correspondingDefaultPlug( plug )
+
+	result = IECore.StringVectorData()
+	for n in Gaffer.Metadata.registeredValues( source ) :
+		if n.startswith( "preset:" ) :
+			result.append( n[7:] )
+
+	result.extend( Gaffer.Metadata.value( source, "presetNames" ) or [] )
+	return result
+
+def __presetValuesMetadata( plug ) :
+
+	dataType = __plugPresetTypes.get( plug.__class__ )
+	if dataType is None :
+		return None
+
+	source = __correspondingDefaultPlug( plug )
+
+	result = dataType()
+	for n in Gaffer.Metadata.registeredValues( source ) :
+		if n.startswith( "preset:" ) :
+			result.append( Gaffer.Metadata.value( source, n ) )
+
+	result.extend( Gaffer.Metadata.value( source, "presetValues" ) or [] )
+	return result
+
+Gaffer.Metadata.registerValue( Gaffer.Spreadsheet.RowsPlug, "row*.cells...", "presetNames", __presetNamesMetadata )
+Gaffer.Metadata.registerValue( Gaffer.Spreadsheet.RowsPlug, "row*.cells...", "presetValues", __presetValuesMetadata )
+
+# _RowsPlugValueWidget
+# ====================
+#
+# This is the main top-level widget that forms the spreadsheet UI.
+
+class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug ) :
+
+		self.__grid = GafferUI.GridContainer( spacing = 4 )
+
+		GafferUI.PlugValueWidget.__init__( self, self.__grid, plug )
+
+		with self.__grid :
+
+			GafferUI.Label(
+				" Default", # Preceding space to cheat alignment
+				parenting = {
+					"index" : ( 0, 0 ),
+					"alignment" : ( GafferUI.HorizontalAlignment.Left, GafferUI.VerticalAlignment.Bottom ),
+				}
+			)
+
+			defaultTable = _PlugTableView(
+				plug, self.getContext(), _PlugTableView.Mode.Defaults,
+				parenting = {
+					"index" : ( 1, 0 ),
+				}
+			)
+
+			self.__rowNamesTable = _PlugTableView(
+				plug, self.getContext(), _PlugTableView.Mode.RowNames,
+				parenting = {
+					"index" : ( 0, 1 ),
+				}
+			)
+			self.__updateRowNamesWidth()
+
+			cellsTable = _PlugTableView(
+				plug, self.getContext(), _PlugTableView.Mode.Cells,
+				parenting = {
+					"index" : ( 1, 1 ),
+				}
+			)
+
+			_LinkedScrollBar(
+				GafferUI.ListContainer.Orientation.Vertical, [ cellsTable, self.__rowNamesTable ],
+				parenting = {
+					"index" : ( 2, 1 ),
+				}
+			)
+
+			_LinkedScrollBar(
+				GafferUI.ListContainer.Orientation.Horizontal, [ cellsTable, defaultTable ],
+				parenting = {
+					"index" : ( 1, 2 ),
+				}
+			)
+
+			addRowButton = GafferUI.Button(
+				image="plus.png", hasFrame=False, toolTip = "Click to add row, or drop new row names",
+				parenting = {
+					"index" : ( 0, 3 )
+				}
+			)
+			addRowButton.clickedSignal().connect( Gaffer.WeakMethod( self.__addRowButtonClicked ), scoped = False )
+			addRowButton.dragEnterSignal().connect( Gaffer.WeakMethod( self.__addRowButtonDragEnter ), scoped = False )
+			addRowButton.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__addRowButtonDragLeave ), scoped = False )
+			addRowButton.dropSignal().connect( Gaffer.WeakMethod( self.__addRowButtonDrop ), scoped = False )
+
+			self.__statusLabel = GafferUI.Label(
+				"",
+				parenting = {
+					"index" : ( slice( 1, 3 ), 3 ),
+					"alignment" : ( GafferUI.HorizontalAlignment.Left, GafferUI.VerticalAlignment.Top )
+				}
+			)
+			# The status label occupies the same column as `cellsTable`, and has a dynamic width based on the length
+			# of the status text. Ignore the width in X so that the column width is dictated solely by `cellsTable`,
+			# otherwise large status labels can force cells off the screen.
+			self.__statusLabel._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Ignored, QtWidgets.QSizePolicy.Fixed )
+
+		for widget in [ addRowButton ] :
+			widget.enterSignal().connect( Gaffer.WeakMethod( self.__enterToolTippedWidget ), scoped = False )
+			widget.leaveSignal().connect( Gaffer.WeakMethod( self.__leaveToolTippedWidget ), scoped = False )
+
+		for widget in [ defaultTable, cellsTable ] :
+			widget.mouseMoveSignal().connect( Gaffer.WeakMethod( self.__cellsMouseMove ), scoped = False )
+			widget.leaveSignal().connect( Gaffer.WeakMethod( self.__cellsLeave ), scoped = False )
+
+		Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = False )
+
+	def hasLabel( self ) :
+
+		return True
+
+	def _updateFromPlug( self ) :
+
+		self.__grid.setEnabled(
+			self.getPlug().getInput() is None and not Gaffer.MetadataAlgo.readOnly( self.getPlug() )
+		)
+
+	def __addRowButtonClicked( self, *unused ) :
+
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			row = self.getPlug().addRow()
+
+		# Select new row for editing. Have to do this on idle as otherwise it doesn't scroll
+		# right to the bottom.
+		GafferUI.EventLoop.addIdleCallback( functools.partial( self.__rowNamesTable.editPlug, row["name"] ) )
+
+	def __addRowButtonDragEnter( self, addButton, event ) :
+
+		if isinstance( event.data, ( IECore.StringData, IECore.StringVectorData ) ) :
+			addButton.setHighlighted( True )
+			return True
+
+		return False
+
+	def __addRowButtonDragLeave( self, addButton, event ) :
+
+		addButton.setHighlighted( False )
+		return True
+
+	def __addRowButtonDrop( self, addButton, event ) :
+
+		addButton.setHighlighted( False )
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			strings = event.data if isinstance( event.data, IECore.StringVectorData ) else [ event.data.value ]
+			for s in strings :
+				self.getPlug().addRow()["name"].setValue( s )
+
+		return True
+
+	def __enterToolTippedWidget( self, widget ) :
+
+		self.__statusLabel.setText( widget.getToolTip() )
+
+	def __leaveToolTippedWidget( self, widget ) :
+
+		self.__statusLabel.setText( "" )
+
+	def __cellsMouseMove( self, widget, event ) :
+
+		status = ""
+
+		plug = widget.plugAt( event.line.p0 )
+		if plug is not None :
+
+			rowPlug = plug.ancestor( Gaffer.Spreadsheet.RowPlug )
+			if rowPlug.getName() == "default" :
+				rowName = "Default"
+			else :
+				with self.getContext() :
+					rowName = rowPlug["name"].getValue() or "unnamed"
+
+			status = "Row : {}, Column : {}".format(
+				rowName,
+				IECore.CamelCase.toSpaced( plug.getName() ),
+			)
+
+		self.__statusLabel.setText( status )
+
+	def __cellsLeave( self, widget ) :
+
+		self.__statusLabel.setText( "" )
+
+	def __updateRowNamesWidth( self ) :
+
+		width = Gaffer.Metadata.value( self.getPlug()["default"], "spreadsheet:rowNameWidth" )
+		self.__rowNamesTable._qtWidget().setFixedWidth( width )
+
+	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
+
+		if plug is not None and key == "spreadsheet:rowNameWidth" :
+			if self.getPlug().isAncestorOf( plug ) :
+				self.__updateRowNamesWidth()
+
+GafferUI.PlugValueWidget.registerType( Gaffer.Spreadsheet.RowsPlug, _RowsPlugValueWidget )
+
+# _PlugTableView
+# ==============
+
+class _PlugTableView( GafferUI.Widget ) :
+
+	Mode = IECore.Enum.create( "RowNames", "Defaults", "Cells" )
+
+	def __init__( self, plug, context, mode, **kw ) :
+
+		tableView = _TableView()
+		GafferUI.Widget.__init__( self, tableView, **kw )
+
+		tableView.setModel(
+			_PlugTableModel( plug, context, mode )
+		)
+
+		# Headers and column sizing
+
+		QtCompat.setSectionResizeMode( tableView.verticalHeader(), QtWidgets.QHeaderView.Fixed )
+		tableView.verticalHeader().setDefaultSectionSize( 25 )
+		tableView.verticalHeader().setVisible( False )
+
+		self.__horizontalHeader = GafferUI.Widget( QtWidgets.QHeaderView( QtCore.Qt.Horizontal, tableView ) )
+		self.__horizontalHeader._qtWidget().setDefaultAlignment( QtCore.Qt.AlignLeft )
+		tableView.setHorizontalHeader( self.__horizontalHeader._qtWidget() )
+		self.__horizontalHeader.buttonPressSignal().connect( Gaffer.WeakMethod( self.__headerButtonPress ), scoped = False )
+
+		if mode in ( self.Mode.Cells, self.Mode.Defaults ) :
+
+			for index, plug in enumerate( plug["default"]["cells"] ) :
+				width = Gaffer.Metadata.value( plug, "spreadsheet:columnWidth" )
+				if width is not None :
+					tableView.horizontalHeader().resizeSection( index, width )
+				visualIndex = Gaffer.Metadata.value( plug, "spreadsheet:columnIndex" )
+
+			self.__applySectionOrderMetadata()
+
+			tableView.horizontalHeader().setSectionsMovable( True )
+			tableView.horizontalHeader().sectionResized.connect( Gaffer.WeakMethod( self.__sectionResized ) )
+			tableView.horizontalHeader().sectionMoved.connect( Gaffer.WeakMethod( self.__sectionMoved ) )
+
+			self.__callingResizeSection = False
+			self.__callingMoveSection = False
+
+			self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect(
+				Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = False
+			)
+
+		else : # RowNames mode
+
+			tableView.horizontalHeader().resizeSection( 1, 22 )
+			tableView.horizontalHeader().setSectionResizeMode( 0, QtWidgets.QHeaderView.Stretch )
+			# Style the row enablers as toggles rather than checkboxes.
+			## \todo Do the same for cells containing NameValuePlugs with enablers. This is tricky
+			# because we need to do it on a per-cell basis, so will need to use `_CellPlugItemDelegate.paint()`
+			# instead.
+			tableView.setProperty( "gafferToggleIndicator", True )
+
+		if mode != self.Mode.Defaults :
+			tableView.horizontalHeader().setVisible( False )
+
+		# Selection and editing. We disable all edit triggers so that
+		# the QTableView itself won't edit anything, and we then implement
+		# our own editing via PlugValueWidgets in _EditWindow.
+
+		tableView.setEditTriggers( tableView.NoEditTriggers )
+		tableView.setSelectionMode( QtWidgets.QAbstractItemView.NoSelection )
+		self.buttonPressSignal().connect( Gaffer.WeakMethod( self.__buttonPress ), scoped = False )
+
+		# Drawing
+
+		tableView.setItemDelegate( _PlugTableDelegate( tableView ) )
+
+		# Size and scrolling
+
+		tableView.setVerticalScrollBarPolicy( QtCore.Qt.ScrollBarAlwaysOff )
+		tableView.setHorizontalScrollBarPolicy( QtCore.Qt.ScrollBarAlwaysOff )
+
+		tableView.setSizePolicy(
+			QtWidgets.QSizePolicy.Fixed if mode == self.Mode.RowNames else QtWidgets.QSizePolicy.Maximum,
+			QtWidgets.QSizePolicy.Fixed if mode == self.Mode.Defaults else QtWidgets.QSizePolicy.Maximum,
+		)
+
+	def plugAt( self, position ) :
+
+		index = self._qtWidget().indexAt( QtCore.QPoint( position.x, position.y ) )
+		return self._qtWidget().model().plugForIndex( index )
+
+	def editPlug( self, plug, scrollTo = True ) :
+
+		index = self._qtWidget().model().indexForPlug( plug )
+		assert( index.isValid() )
+
+		if not index.flags() & QtCore.Qt.ItemIsEnabled or not index.flags() & QtCore.Qt.ItemIsEditable :
+			return
+
+		if not index.data( _PlugTableModel.CellPlugEnabledRole ) :
+			return
+
+		if scrollTo :
+			self._qtWidget().scrollTo( index )
+
+		rect = self._qtWidget().visualRect( index )
+		rect.setTopLeft( self._qtWidget().viewport().mapToGlobal( rect.topLeft() ) )
+		rect.setBottomRight( self._qtWidget().viewport().mapToGlobal( rect.bottomRight() ) )
+
+		if isinstance( plug, Gaffer.Spreadsheet.CellPlug ) :
+			plug = plug["value"]
+
+		_EditWindow.popupEditor(
+			plug,
+			imath.Box2i(
+				imath.V2i( rect.left(), rect.bottom() ),
+				imath.V2i( rect.right(), rect.top() )
+			)
+		)
+
+	def __sectionMoved( self, logicalIndex, oldVisualIndex, newVisualIndex ) :
+
+		if self.__callingMoveSection :
+			return
+
+		model = self._qtWidget().model()
+		header = self._qtWidget().horizontalHeader()
+
+		with Gaffer.UndoScope( model.rowsPlug().ancestor( Gaffer.ScriptNode ) ) :
+			with Gaffer.BlockedConnection( self.__plugMetadataChangedConnection ) :
+				for logicalIndex in range( 0, header.count() ) :
+					plug = model.plugForIndex( model.index( 0, logicalIndex ) )
+					Gaffer.Metadata.registerValue( plug, "spreadsheet:columnIndex", header.visualIndex( logicalIndex ) )
+
+	def __sectionResized( self, logicalIndex, oldSize, newSize ) :
+
+		if self.__callingResizeSection :
+			return
+
+		model = self._qtWidget().model()
+		plug = model.plugForIndex( model.index( 0, logicalIndex ) )
+
+		with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ), mergeGroup = "_PlugTableView{}{}".format( id( self ), logicalIndex ) ) :
+			with Gaffer.BlockedConnection( self.__plugMetadataChangedConnection ) :
+				Gaffer.Metadata.registerValue( plug, "spreadsheet:columnWidth", newSize )
+
+	def __applySectionOrderMetadata( self ) :
+
+		rowsPlug = self._qtWidget().model().rowsPlug()
+		header = self._qtWidget().horizontalHeader()
+		for index, plug in enumerate( rowsPlug["default"]["cells"] ) :
+			visualIndex = Gaffer.Metadata.value( plug, "spreadsheet:columnIndex" )
+			header.moveSection( header.visualIndex( index ), visualIndex if visualIndex is not None else index )
+
+	@GafferUI.LazyMethod()
+	def __applySectionOrderLazily( self ) :
+
+		self.__applySectionOrderMetadata()
+
+	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
+
+		if plug is None :
+			return
+
+		rowsPlug = self._qtWidget().model().rowsPlug()
+		if not rowsPlug.isAncestorOf( plug ) :
+			return
+
+		if key == "spreadsheet:columnWidth" :
+
+			column = rowsPlug["default"]["cells"].children().index( plug )
+			self.__callingResizeSection = True
+			self._qtWidget().horizontalHeader().resizeSection( column, Gaffer.Metadata.value( plug, "spreadsheet:columnWidth" ) )
+			self.__callingResizeSection = False
+
+		elif key == "spreadsheet:columnIndex" :
+
+			# Typically we get a flurry of edits to columnIndex at once,
+			# so we use a lazy method to update the order once everything
+			# has been done.
+			self.__applySectionOrderLazily()
+
+	def __buttonPress( self, widget, event ) :
+
+		index = self._qtWidget().indexAt( QtCore.QPoint( event.line.p0.x, event.line.p0.y ) )
+		plug = self._qtWidget().model().plugForIndex( index )
+		if plug is None :
+			return False
+
+		if event.buttons == event.Buttons.Right :
+
+			if index.flags() & QtCore.Qt.ItemIsEnabled :
+
+				if isinstance( plug, Gaffer.Spreadsheet.CellPlug ) :
+					plug = plug["value"]
+				## \todo We need to make this temporary PlugValueWidget just so we
+				# can show a plug menu. We should probably refactor so we can do it
+				# without the widget, but this would touch `PlugValueWidget.popupMenuSignal()`
+				# and all connected client code.
+				self.__menuPlugValueWidget = GafferUI.PlugValueWidget.create( plug )
+				self.__plugMenu = GafferUI.Menu(
+					self.__menuPlugValueWidget._popupMenuDefinition()
+				)
+				self.__plugMenu.popup()
+
+			return True
+
+		elif event.buttons == event.Buttons.Left :
+
+			valuePlug = plug["value"] if isinstance( plug, Gaffer.Spreadsheet.CellPlug ) else plug
+			if not isinstance( valuePlug, Gaffer.BoolPlug ) :
+				self.editPlug( plug, scrollTo = False )
+
+			return True
+
+		return False
+
+	def __headerButtonPress( self, header, event ) :
+
+		if event.buttons != event.Buttons.Right :
+			return False
+
+		cellPlug = self.plugAt( event.line.p0 )
+		assert( cellPlug.ancestor( Gaffer.Spreadsheet.RowPlug ).getName() == "default" )
+
+		menuDefinition = IECore.MenuDefinition()
+		menuDefinition.append(
+			"/Set Label...",
+			{
+				"command" : functools.partial( Gaffer.WeakMethod( self.__setColumnLabel ), cellPlug ),
+				"active" : not Gaffer.MetadataAlgo.readOnly( cellPlug ),
+			}
+		)
+
+		menuDefinition.append( "/DeleteDivider", { "divider" : True } )
+
+		menuDefinition.append(
+			"/Delete Column",
+			{
+				"command" : functools.partial( Gaffer.WeakMethod( self.__deleteColumn), cellPlug ),
+				"active" : not Gaffer.MetadataAlgo.readOnly( cellPlug ),
+			}
+		)
+
+		self.__headerMenu = GafferUI.Menu( menuDefinition )
+		self.__headerMenu.popup()
+
+		return True
+
+	def __setColumnLabel( self, cellPlug ) :
+
+		label = GafferUI.TextInputDialogue(
+			title = "Set Label",
+			confirmLabel = "Set",
+			initialText = Gaffer.Metadata.value( cellPlug, "spreadsheet:columnLabel" ) or cellPlug.getName()
+		).waitForText()
+
+		if label is not None :
+			with Gaffer.UndoScope( cellPlug.ancestor( Gaffer.ScriptNode ) ) :
+				Gaffer.Metadata.registerValue( cellPlug, "spreadsheet:columnLabel", label )
+
+	def __deleteColumn( self, cellPlug ) :
+
+		rowsPlug = cellPlug.ancestor( Gaffer.Spreadsheet.RowsPlug )
+		with Gaffer.UndoScope( rowsPlug.ancestor( Gaffer.ScriptNode ) ) :
+			rowsPlug.removeColumn( cellPlug.parent().children().index( cellPlug ) )
+
+class _PlugTableModel( QtCore.QAbstractTableModel ) :
+
+	CellPlugEnabledRole = QtCore.Qt.UserRole
+
+	def __init__( self, rowsPlug, context, mode, parent = None ) :
+
+		QtCore.QAbstractTableModel.__init__( self, parent )
+
+		self.__rowsPlug = rowsPlug
+		self.__context = context
+		self.__mode = mode
+
+		self.__plugDirtiedConnection = rowsPlug.node().plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ) )
+		self.__rowAddedConnection = rowsPlug.childAddedSignal().connect( Gaffer.WeakMethod( self.__rowAdded ) )
+		self.__rowRemovedConnection = rowsPlug.childRemovedSignal().connect( Gaffer.WeakMethod( self.__rowRemoved ) )
+		self.__columnAddedConnection = rowsPlug["default"]["cells"].childAddedSignal().connect( Gaffer.WeakMethod( self.__columnAdded ) )
+		self.__columnRemovedConnection = rowsPlug["default"]["cells"].childRemovedSignal().connect( Gaffer.WeakMethod( self.__columnRemoved ) )
+		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
+		self.__contextChangedConnection = self.__context.changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ) )
+
+	# Methods of our own
+	# ------------------
+
+	def rowsPlug( self ) :
+
+		return self.__rowsPlug
+
+	def plugForIndex( self, index ) :
+
+		if not index.isValid() :
+			return None
+
+		if self.__mode in ( _PlugTableView.Mode.Cells, _PlugTableView.Mode.RowNames ) :
+			row = self.__rowsPlug[index.row()+1]
+		else :
+			row = self.__rowsPlug[0]
+
+		if self.__mode == _PlugTableView.Mode.RowNames :
+			return row[index.column()]
+		else :
+			return row["cells"][index.column()]
+
+	def valuePlugForIndex( self, index ) :
+
+		plug = self.plugForIndex( index )
+		if isinstance( plug, Gaffer.Spreadsheet.CellPlug ) :
+			plug = plug["value"]
+
+		return plug
+
+	def indexForPlug( self, plug ) :
+
+		rowPlug = plug.ancestor( Gaffer.Spreadsheet.RowPlug )
+		if rowPlug is None :
+			return QtCore.QModelIndex()
+
+		if self.__mode in ( _PlugTableView.Mode.Cells, _PlugTableView.Mode.RowNames ) :
+			rowIndex = rowPlug.parent().children().index( rowPlug )
+			if rowIndex == 0 :
+				return QtCore.QModelIndex()
+			else :
+				rowIndex -= 1
+		else :
+			rowIndex = 0
+
+		if self.__mode == _PlugTableView.Mode.RowNames :
+			if plug == rowPlug["name"] :
+				columnIndex = 0
+			elif plug == rowPlug["enabled"] :
+				columnIndex = 1
+			else :
+				return QtCore.QModelIndex()
+		else :
+			cellPlug = plug if isinstance( plug, Gaffer.Spreadsheet.CellPlug ) else plug.ancestor( Gaffer.Spreadsheet.CellPlug )
+			if cellPlug is not None :
+				columnIndex = rowPlug["cells"].children().index( cellPlug )
+			else :
+				return QtCore.QModelIndex()
+
+		return self.index( rowIndex, columnIndex )
+
+	# Overrides for methods inherited from QAbstractTableModel
+	# --------------------------------------------------------
+
+	def rowCount( self, parent = QtCore.QModelIndex() ) :
+
+		if parent.isValid() :
+			return 0
+
+		if self.__mode == _PlugTableView.Mode.Defaults :
+			return 1
+		else :
+			return len( self.__rowsPlug ) - 1
+
+	def columnCount( self, parent = QtCore.QModelIndex() ) :
+
+		if parent.isValid() :
+			return 0
+
+		if self.__mode == _PlugTableView.Mode.RowNames :
+			return 2
+		else :
+			return len( self.__rowsPlug[0]["cells"] )
+
+	def headerData( self, section, orientation, role ) :
+
+		if role == QtCore.Qt.DisplayRole :
+			if orientation == QtCore.Qt.Horizontal and self.__mode != _PlugTableView.Mode.RowNames :
+				cellPlug = self.__rowsPlug["default"]["cells"][section]
+				label = Gaffer.Metadata.value( cellPlug, "spreadsheet:columnLabel" )
+				if not label :
+					label = IECore.CamelCase.toSpaced( cellPlug.getName() )
+				return label
+			return section
+
+	def flags( self, index ) :
+
+		result = QtCore.Qt.ItemIsSelectable
+
+		# We use the ItemIsEnabled flag to reflect the state of
+		# `RowPlug::enabledPlug()` for the row `index` is in.
+		enabled = True
+		plug = self.valuePlugForIndex( index )
+		rowPlug = plug.ancestor( Gaffer.Spreadsheet.RowPlug )
+		if plug != rowPlug["enabled"] :
+			with self.__context :
+				try :
+					enabled = rowPlug["enabled"].getValue()
+				except :
+					pass
+
+		if enabled :
+			result |= QtCore.Qt.ItemIsEnabled
+
+		# We use the ItemIsEditable flag to reflect the state of
+		# readOnly metadata.
+
+		if not Gaffer.MetadataAlgo.readOnly( plug ) :
+			result |= QtCore.Qt.ItemIsEditable
+			if isinstance( plug, Gaffer.BoolPlug ) :
+				result |= QtCore.Qt.ItemIsUserCheckable
+
+		return result
+
+	def data( self, index, role ) :
+
+		if role == QtCore.Qt.DisplayRole or role == QtCore.Qt.EditRole :
+
+			return self.__formatValue( self.__displayRoleValue( index ) )
+
+		elif role == QtCore.Qt.BackgroundColorRole :
+
+			if index.row() % 2 == 0 :
+				return GafferUI._Variant.toVariant( GafferUI._StyleSheet.styleColor( "background" ) )
+			else:
+				return GafferUI._Variant.toVariant( GafferUI._StyleSheet.styleColor( "backgroundAlt" ) )
+
+		elif role == QtCore.Qt.DecorationRole :
+
+			plug = self.valuePlugForIndex( index )
+			if isinstance( plug, Gaffer.Color3fPlug ) :
+				with self.__context :
+					try :
+						value = plug.getValue()
+					except :
+						return None
+				displayTransform = GafferUI.DisplayTransform.get()
+				return GafferUI.Widget._qtColor( displayTransform( value ) )
+
+		elif role == QtCore.Qt.CheckStateRole :
+
+			plug = self.__checkStatePlug( index )
+			if plug is not None :
+				with self.__context :
+					try :
+						value = plug.getValue()
+					except :
+						return None
+				return QtCore.Qt.Checked if value else QtCore.Qt.Unchecked
+
+		elif role == QtCore.Qt.ToolTipRole :
+
+			return self.__formatValue( self.__displayRoleValue( index ), forToolTip = True )
+
+		elif role == self.CellPlugEnabledRole :
+
+			plug = self.plugForIndex( index )
+			enabled = True
+			if isinstance( plug, Gaffer.Spreadsheet.CellPlug ) :
+				with self.__context :
+					try :
+						enabled = plug["enabled"].getValue()
+					except :
+						return None
+			return enabled
+
+		return None
+
+	def setData( self, index, value, role ) :
+
+		# We use Qt's built-in direct editing of check states
+		# as it is convenient, but all other editing is done
+		# separately via `_EditWindow`.
+
+		assert( role == QtCore.Qt.CheckStateRole )
+		plug = self.__checkStatePlug( index )
+		assert( isinstance( plug, Gaffer.BoolPlug ) )
+
+		with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
+			plug.setValue( value )
+
+		return True
+
+	# Methods of our own
+	# ------------------
+
+	def __checkStatePlug( self, index ) :
+
+		valuePlug = self.valuePlugForIndex( index )
+		if isinstance( valuePlug, Gaffer.BoolPlug ) :
+			return valuePlug
+
+		return None
+
+	def __rowAdded( self, rowsPlug, row ) :
+
+		## \todo Is there any benefit in finer-grained signalling?
+		self.__emitModelReset()
+		self.headerDataChanged.emit( QtCore.Qt.Vertical, 0, self.rowCount() )
+
+	def __rowRemoved( self, rowsPlug, row ) :
+
+		## \todo Is there any benefit in finer-grained signalling?
+		self.__emitModelReset()
+
+	def __columnAdded( self, cellsPlug, cellPlug ) :
+
+		## \todo Is there any benefit in finer-grained signalling?
+		self.__emitModelReset()
+		self.headerDataChanged.emit( QtCore.Qt.Horizontal, 0, self.columnCount() )
+
+	def __columnRemoved( self, cellsPlug, cellPlug ) :
+
+		## \todo Is there any benefit in finer-grained signalling?
+		self.__emitModelReset()
+
+	def __plugDirtied( self, plug ) :
+
+		if not self.__rowsPlug.isAncestorOf( plug ) :
+			return
+
+		parentPlug = plug.parent()
+		if isinstance( parentPlug, Gaffer.Spreadsheet.RowPlug ) and plug.getName() == "enabled" :
+			# Special case. The enabled plug affects the flags for the entire row.
+			# Qt doesn't have a mechanism for signalling flag changes, so we emit `dataChanged`
+			# instead, giving our delegate the kick it needs to redraw.
+			rowIndex = parentPlug.parent().children().index( parentPlug )
+			self.dataChanged.emit( self.index( rowIndex, 0 ), self.index( rowIndex, self.columnCount() - 1 ) )
+			return
+
+		# Regular case. Emit `dataChanged` for just this one plug.
+		index = self.indexForPlug( plug )
+		if index.isValid() :
+			self.dataChanged.emit( index, index )
+
+	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
+
+		if plug is None :
+			return
+
+		index = self.indexForPlug( plug )
+		if not index.isValid() :
+			return
+
+		if key == "spreadsheet:columnLabel" :
+			self.headerDataChanged.emit( QtCore.Qt.Horizontal, index.column(), index.column() )
+		elif Gaffer.MetadataAlgo.readOnlyAffectedByChange( key ) :
+			# Read-only metadata is actually reflected in `flags()`, but there's no signal to emit
+			# when they change. Emitting `dataChanged` is enough to kick a redraw off.
+			self.dataChanged.emit( index, index )
+
+	def __contextChanged( self, context, key ) :
+
+		if key.startswith( "ui:" ) :
+			return
+
+		self.__emitModelReset()
+
+	def __emitModelReset( self ) :
+
+		self.beginResetModel()
+		self.endResetModel()
+
+	def __displayRoleValue( self, index ) :
+
+		plug = self.valuePlugForIndex( index )
+		if isinstance( plug, Gaffer.BoolPlug ) :
+			# Dealt with via CheckStateRole
+			return None
+
+		try :
+			with self.__context :
+				currentPreset = Gaffer.NodeAlgo.currentPreset( plug )
+				if currentPreset is not None :
+					return currentPreset
+				if isinstance( plug, Gaffer.NameValuePlug ) :
+					return plug["enabled"].getValue(), plug["value"].getValue()
+				else :
+					return plug.getValue()
+		except :
+			return None
+
+	def __formatValue( self, value, forToolTip = False ) :
+
+		if isinstance( value, str ) :
+			return value
+		elif isinstance( value, ( int, float ) ) :
+			return GafferUI.NumericWidget.valueToString( value )
+		elif isinstance( value, ( imath.V2i, imath.V2f, imath.V3i, imath.V3f ) ) :
+			return ", ".join( GafferUI.NumericWidget.valueToString( v ) for v in value )
+		elif isinstance( value, bool ) :
+			return value
+		elif isinstance( value, tuple ) :
+			# NameValuePlug ( enabled, value )
+			s = self.__formatValue( value[1], forToolTip )
+			return "{}{}{}".format(
+				"On" if value[0] else "Off",
+				", \n" if forToolTip and "\n" in s else ", ",
+				s
+			)
+		elif value is None :
+			return ""
+
+		if not forToolTip :
+			return str( value )
+		else :
+			try :
+				return "\n".join( str( x ) for x in value )
+			except :
+				return str( value )
+
+class _PlugTableDelegate( QtWidgets.QStyledItemDelegate ) :
+
+	def __init__( self, parent = None ) :
+
+		QtWidgets.QStyledItemDelegate.__init__( self, parent )
+
+	def paint( self, painter, option, index ) :
+
+		QtWidgets.QStyledItemDelegate.paint( self, painter, option, index )
+
+		flags = index.flags()
+		enabled = flags & QtCore.Qt.ItemIsEnabled and flags & QtCore.Qt.ItemIsEditable
+		cellPlugEnabled = index.data( _PlugTableModel.CellPlugEnabledRole )
+
+		if enabled and cellPlugEnabled :
+			return
+
+		painter.save()
+
+		painter.setRenderHint( QtGui.QPainter.Antialiasing )
+
+		if not cellPlugEnabled :
+
+			painter.fillRect( option.rect, QtGui.QBrush( QtGui.QColor( 40, 40, 40, 200 ) ) )
+
+			pen = QtGui.QPen( QtGui.QColor( 20, 20, 20, 150 ) )
+			pen.setWidth( 2 )
+			painter.setPen( pen )
+			painter.drawLine( option.rect.bottomLeft(), option.rect.topRight() )
+
+		if not enabled :
+
+			color = QtGui.QColor( index.data( QtCore.Qt.BackgroundColorRole ) )
+			color.setAlpha( 200 )
+			painter.fillRect( option.rect, QtGui.QBrush( color ) )
+
+		painter.restore()
+
+class _EditWindow( GafferUI.Window ) :
+
+	__numericFieldWidth = 60
+
+	# Considered private - use `_EditWindow.popupEditor()` instead.
+	def __init__( self, plugValueWidget, **kw ) :
+
+		GafferUI.Window.__init__( self, "", child = plugValueWidget, borderWidth = 8, sizeMode=GafferUI.Window.SizeMode.Automatic, **kw )
+
+		self._qtWidget().setWindowFlags( QtCore.Qt.Popup )
+
+		self._qtWidget().setAttribute( QtCore.Qt.WA_TranslucentBackground )
+		self._qtWidget().paintEvent = Gaffer.WeakMethod( self.__paintEvent )
+
+		if isinstance( plugValueWidget, GafferUI.NameValuePlugValueWidget ) :
+			plugValueWidget.setNameVisible( False )
+
+		# Apply some fixed widths for some widgets, otherwise they're
+		# a bit too eager to grow. \todo Should we change the underlying
+		# behaviour of the widgets themselves?
+
+		fixedWidth = None
+		if isinstance( plugValueWidget, GafferUI.NumericPlugValueWidget ) :
+			fixedWidth = self.__numericFieldWidth
+		elif isinstance( plugValueWidget, GafferUI.ColorPlugValueWidget ) :
+			fixedWidth = self.__numericFieldWidth * len( plugValueWidget.getPlug() ) + 20
+		elif isinstance( plugValueWidget, GafferUI.CompoundNumericPlugValueWidget ) :
+			fixedWidth = self.__numericFieldWidth * len( plugValueWidget.getPlug() )
+		elif isinstance( plugValueWidget, GafferUI.VectorDataPlugValueWidget ) :
+			fixedWidth = 250
+
+		if fixedWidth is not None :
+			plugValueWidget._qtWidget().setFixedWidth( fixedWidth )
+			plugValueWidget._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetNoConstraint )
+
+		self.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ), scoped = False )
+
+	@classmethod
+	def popupEditor( cls, plug, plugBound ) :
+
+		plugValueWidget = GafferUI.PlugValueWidget.create( plug )
+		cls.__currentWindow = _EditWindow( plugValueWidget )
+
+		if isinstance( plugValueWidget, GafferUI.PresetsPlugValueWidget ) :
+			if not Gaffer.Metadata.value( plugValueWidget.getPlug(), "presetsPlugValueWidget:isCustom" ) :
+				plugValueWidget.menu().popup()
+				return
+
+		windowSize = cls.__currentWindow._qtWidget().sizeHint()
+		cls.__currentWindow.setPosition( plugBound.center() - imath.V2i( windowSize.width() / 2, windowSize.height() / 2 ) )
+		cls.__currentWindow.setVisible( True )
+
+		textWidget = cls.__textWidget( plugValueWidget )
+		if textWidget is not None :
+			if isinstance( textWidget, GafferUI.TextWidget ) :
+				textWidget.grabFocus()
+				textWidget.setSelection( 0, len( textWidget.getText() ) )
+			else :
+				textWidget.setFocussed( True )
+			textWidget._qtWidget().activateWindow()
+
+	def __paintEvent( self, event ) :
+
+		painter = QtGui.QPainter( self._qtWidget() )
+		painter.setRenderHint( QtGui.QPainter.Antialiasing )
+
+		painter.setBrush( QtGui.QColor( 35, 35, 35 ) )
+		painter.setPen( QtGui.QColor( 0, 0, 0, 0 ) )
+
+		radius = self._qtWidget().layout().contentsMargins().left()
+		size = self.size()
+		painter.drawRoundedRect( QtCore.QRectF( 0, 0, size.x, size.y ), radius, radius )
+
+	def __keyPress( self, widget, event ) :
+
+		if event.key == "Return" :
+			self.close()
+
+	@classmethod
+	def __textWidget( cls, plugValueWidget ) :
+
+		if isinstance( plugValueWidget, GafferUI.StringPlugValueWidget ) :
+			return plugValueWidget.textWidget()
+		elif isinstance( plugValueWidget, GafferUI.NumericPlugValueWidget ) :
+			return plugValueWidget.numericWidget()
+		elif isinstance( plugValueWidget, GafferUI.CompoundNumericPlugValueWidget ) :
+			return cls.__textWidget( plugValueWidget.childPlugValueWidget( plugValueWidget.getPlug()[0] ) )
+		elif isinstance( plugValueWidget, GafferUI.PathPlugValueWidget ) :
+			return plugValueWidget.pathWidget()
+		elif isinstance( plugValueWidget, GafferUI.MultiLineStringPlugValueWidget ) :
+			return plugValueWidget.textWidget()
+
+# ScrolledContainer linking
+# =========================
+#
+# To keep the row and column names and default cells visible at all times, we
+# need to house them in separate table views from the main one. But we
+# want to link the scrolling of them all, so they still act as a unit. We achieve
+# this using the _LinkedScrollBar widget, which provides two-way coupling between
+# the scrollbars of each container.
+
+class _LinkedScrollBar( GafferUI.Widget ) :
+
+	def __init__( self, orientation, scrolledContainers, **kw ) :
+
+		GafferUI.Widget.__init__(
+			self,
+			_StepsChangedScrollBar(
+				QtCore.Qt.Orientation.Horizontal if orientation == GafferUI.ListContainer.Orientation.Horizontal else QtCore.Qt.Orientation.Vertical
+			),
+			**kw
+		)
+
+		self.__scrollBars = [ self._qtWidget() ]
+		for container in scrolledContainers :
+			if orientation == GafferUI.ListContainer.Orientation.Horizontal :
+				if not isinstance( container._qtWidget().horizontalScrollBar(), _StepsChangedScrollBar ) :
+					container._qtWidget().setHorizontalScrollBar( _StepsChangedScrollBar( QtCore.Qt.Orientation.Horizontal ) )
+				self.__scrollBars.append( container._qtWidget().horizontalScrollBar() )
+			else :
+				if not isinstance( container._qtWidget().verticalScrollBar(), _StepsChangedScrollBar ) :
+					container._qtWidget().setVerticalScrollBar( _StepsChangedScrollBar( QtCore.Qt.Orientation.Vertical ) )
+				self.__scrollBars.append( container._qtWidget().verticalScrollBar() )
+
+		self._qtWidget().setValue( self.__scrollBars[1].value() )
+		self._qtWidget().setRange( self.__scrollBars[1].minimum(), self.__scrollBars[1].maximum() )
+		self._qtWidget().setPageStep( self.__scrollBars[1].pageStep() )
+		self._qtWidget().setSingleStep( self.__scrollBars[1].singleStep() )
+		self.setVisible( self._qtWidget().minimum() != self._qtWidget().maximum() )
+
+		for scrollBar in self.__scrollBars :
+			scrollBar.valueChanged.connect( Gaffer.WeakMethod( self.__valueChanged ) )
+			scrollBar.rangeChanged.connect( Gaffer.WeakMethod( self.__rangeChanged ) )
+			scrollBar.stepsChanged.connect( Gaffer.WeakMethod( self.__stepsChanged ) )
+
+	def __valueChanged( self, value ) :
+
+		for scrollBar in self.__scrollBars :
+			scrollBar.setValue( value )
+
+	def __rangeChanged( self, min, max ) :
+
+		for scrollBar in self.__scrollBars :
+			scrollBar.setRange( min, max )
+
+		self.setVisible( min != max )
+
+	def __stepsChanged( self, page, single ) :
+
+		for scrollBar in self.__scrollBars :
+			scrollBar.setPageStep( page )
+			scrollBar.setSingleStep( single )
+
+# QScrollBar provides signals for when the value and range are changed,
+# but not for when the page step is changed. This subclass adds the missing
+# signal.
+class _StepsChangedScrollBar( QtWidgets.QScrollBar ) :
+
+	stepsChanged = QtCore.Signal( int, int )
+
+	def __init__( self, orientation, parent = None ) :
+
+		QtWidgets.QScrollBar.__init__( self, orientation, parent )
+
+	def sliderChange( self, change ) :
+
+		QtWidgets.QScrollBar.sliderChange( self, change )
+
+		if change == self.SliderStepsChange :
+			self.stepsChanged.emit( self.pageStep(), self.singleStep() )
+
+# Plug context menu
+# =================
+
+def __setPlugValue( plug, value ) :
+
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
+		plug.setValue( value )
+
+def __deleteRow( rowPlug ) :
+
+	with Gaffer.UndoScope( rowPlug.ancestor( Gaffer.ScriptNode ) ) :
+		rowPlug.parent().removeChild( rowPlug )
+
+def __setRowNameWidth( rowPlug, width, *unused ) :
+
+	defaultRowPlug = rowPlug.parent()["default"]
+	with Gaffer.UndoScope( defaultRowPlug.ancestor( Gaffer.ScriptNode ) ) :
+		Gaffer.Metadata.registerValue( defaultRowPlug, "spreadsheet:rowNameWidth", width )
+
+def __prependRowAndCellMenuItems( menuDefinition, plugValueWidget ) :
+
+	plug = plugValueWidget.getPlug()
+	rowPlug = plug.ancestor( Gaffer.Spreadsheet.RowPlug )
+	if rowPlug is None :
+		return
+
+	# Row menu items
+
+	if plug.parent() == rowPlug and rowPlug.getName() != "default" :
+
+		menuDefinition.prepend(
+			"/Delete Row",
+			{
+				"command" : functools.partial( __deleteRow, rowPlug ),
+				"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( rowPlug )
+
+			}
+		)
+
+		widths = [
+			( "Half", GafferUI.PlugWidget.labelWidth() * 0.5 ),
+			( "Single", GafferUI.PlugWidget.labelWidth() ),
+			( "Double", GafferUI.PlugWidget.labelWidth() * 2 ),
+		]
+
+		currentWidth = Gaffer.Metadata.value( rowPlug, "spreadsheet:rowNameWidth" )
+		for label, width in reversed( widths ) :
+			menuDefinition.prepend(
+				"/Width/{}".format( label ),
+				{
+					"command" : functools.partial( __setRowNameWidth, rowPlug, width ),
+					"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( rowPlug ),
+					"checkBox" : width == currentWidth,
+				}
+			)
+
+	# Cell menu items
+
+	cellPlug = plug if isinstance( plug, Gaffer.Spreadsheet.CellPlug ) else plug.ancestor( Gaffer.Spreadsheet.CellPlug )
+	if cellPlug is not None :
+
+		if rowPlug.getName() != "default" :
+
+			enabled = None
+			enabledPlug = cellPlug["enabled"]
+			with plugValueWidget.getContext() :
+				with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
+					enabled = enabledPlug.getValue()
+
+			menuDefinition.prepend(
+				"/Disable Cell" if enabled else "/Enable Cell",
+				{
+					"command" : functools.partial( __setPlugValue, enabledPlug, not enabled ),
+					"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( enabledPlug ) and enabledPlug.settable()
+				}
+			)
+
+def __addColumn( spreadsheet, plug ) :
+
+	# We allow the name of a column to be overridden by metadata, so that NameValuePlug and
+	# TweakPlug can provide more meaningful names than "name" or "enabled" when their child
+	# plugs are added to spreadsheets.
+	columnName = Gaffer.Metadata.value( plug, "spreadsheet:columnName" ) or plug.getName()
+
+	columnIndex = spreadsheet["rows"].addColumn( plug, columnName )
+	valuePlug = spreadsheet["rows"]["default"]["cells"][columnIndex]["value"]
+	Gaffer.MetadataAlgo.copy( plug, valuePlug, exclude = "spreadsheet:columnName layout:* deletable" )
+
+	return columnIndex
+
+def __createSpreadsheet( plug ) :
+
+	spreadsheet = Gaffer.Spreadsheet()
+	__addColumn( spreadsheet, plug )
+	spreadsheet["rows"].addRow()
+
+	with Gaffer.UndoContext( plug.ancestor( Gaffer.ScriptNode ) ) :
+		plug.node().parent().addChild( spreadsheet )
+		plug.setInput( spreadsheet["out"][0] )
+
+	GafferUI.NodeEditor.acquire( spreadsheet )
+
+def __addToSpreadsheet( plug, spreadsheet ) :
+
+	with Gaffer.UndoContext( spreadsheet.ancestor( Gaffer.ScriptNode ) ) :
+		columnIndex = __addColumn( spreadsheet, plug )
+		plug.setInput( spreadsheet["out"][columnIndex] )
+
+def __addToSpreadsheetSubMenu( plug ) :
+
+	menuDefinition = IECore.MenuDefinition()
+
+	alreadyConnected = []
+	other = []
+	for spreadsheet in Gaffer.Spreadsheet.Range( plug.node().parent() ) :
+
+		connected = False
+		for output in spreadsheet["out"] :
+			for destination in output.outputs() :
+				if destination.node() == plug.node() :
+					connected = True
+					break
+			if connected :
+				break
+
+		if connected :
+			alreadyConnected.append( spreadsheet )
+		else :
+			other.append( spreadsheet )
+
+	if not alreadyConnected and not other :
+		menuDefinition.append(
+			"/No Spreadsheets Available",
+			{
+				"active" : False,
+			}
+		)
+		return menuDefinition
+
+	alreadyConnected.sort( key = Gaffer.GraphComponent.getName )
+	other.sort( key = Gaffer.GraphComponent.getName )
+
+	def addItem( spreadsheet ) :
+
+		menuDefinition.append(
+			"/" + spreadsheet.getName(),
+			{
+				"command" : functools.partial( __addToSpreadsheet, plug, spreadsheet )
+			}
+		)
+
+	if alreadyConnected and other :
+		menuDefinition.append( "/__ConnectedDivider__", { "divider" : True, "label" : "Connected" } )
+
+	for spreadsheet in alreadyConnected :
+		addItem( spreadsheet )
+
+	if alreadyConnected and other :
+		menuDefinition.append( "/__OtherDivider__", { "divider" : True, "label" : "Other" } )
+
+	for spreadsheet in other :
+		addItem( spreadsheet )
+
+	return menuDefinition
+
+def __prependSpreadsheetCreationMenuItems( menuDefinition, plugValueWidget ) :
+
+	plug = plugValueWidget.getPlug()
+	if not isinstance( plug, Gaffer.ValuePlug ) :
+		return
+
+	node = plug.node()
+	if node is None or node.parent() is None :
+		return
+
+	if plug.getInput() is not None or not plugValueWidget._editable() or Gaffer.MetadataAlgo.readOnly( plug ) :
+		return
+
+	ancestorPlug, ancestorLabel = None, ""
+	for ancestorType, ancestorLabel in [
+		( Gaffer.TransformPlug, "Transform" ),
+		( Gaffer.Transform2DPlug, "Transform" ),
+		( Gaffer.NameValuePlug, "Value and Switch" ),
+	] :
+		ancestorPlug = plug.ancestor( ancestorType )
+		if ancestorPlug :
+			if all( p.getInput() is None for p in Gaffer.Plug.RecursiveRange( ancestorPlug ) ) :
+				break
+			else :
+				ancestorPlug = None
+
+	if ancestorPlug :
+		menuDefinition.prepend(
+			"/Add to Spreadsheet ({})".format( ancestorLabel ),
+			{
+				"subMenu" :  functools.partial( __addToSpreadsheetSubMenu, ancestorPlug )
+			}
+		)
+		menuDefinition.prepend(
+			"/Create Spreadsheet ({})...".format( ancestorLabel ),
+			{
+				"command" : functools.partial( __createSpreadsheet, ancestorPlug )
+			}
+		)
+
+		menuDefinition.prepend(
+			"/__AncestorDivider__", { "divider" : True }
+		)
+
+	menuDefinition.prepend(
+		"/Add to Spreadsheet",
+		{
+			"subMenu" :  functools.partial( __addToSpreadsheetSubMenu, plug )
+		}
+	)
+
+	menuDefinition.prepend(
+		"/Create Spreadsheet...",
+		{
+			"command" : functools.partial( __createSpreadsheet, plug )
+		}
+	)
+
+def __plugPopupMenu( menuDefinition, plugValueWidget ) :
+
+	menuDefinition.prepend( "/SpreadsheetDivider", { "divider" : True } )
+
+	## \todo We're prepending rather than appending so that we get the ordering we
+	# want with respect to the Expression menu items. Really we need external control
+	# over this ordering.
+	__prependRowAndCellMenuItems( menuDefinition, plugValueWidget )
+	__prependSpreadsheetCreationMenuItems( menuDefinition, plugValueWidget )
+
+GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu, scoped = False )
+
+# NodeEditor tool menu
+# ====================
+
+def __createSpreadsheetForNode( node, activeRowNamesConnection, selectorContextVariablePlug, selectorValue ) :
+
+	with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
+
+		spreadsheet = Gaffer.Spreadsheet( node.getName() + "Spreadsheet" )
+
+		with node.scriptNode().context() :
+			rowNames = activeRowNamesConnection.getValue()
+		activeRowNamesConnection.setInput( spreadsheet["activeRowNames"] )
+
+		if rowNames :
+			for rowName in rowNames :
+				spreadsheet["rows"].addRow()["name"].setValue( rowName )
+		else :
+			spreadsheet["rows"].addRow()
+
+		if selectorValue is None :
+			selectorValue = "${" + selectorContextVariablePlug.getValue() + "}"
+			Gaffer.MetadataAlgo.setReadOnly( selectorContextVariablePlug, True )
+
+		if selectorValue :
+			spreadsheet["selector"].setValue( selectorValue )
+			Gaffer.MetadataAlgo.setReadOnly( spreadsheet["selector"], True )
+
+		node.parent().addChild( spreadsheet )
+
+	GafferUI.NodeEditor.acquire( spreadsheet )
+
+def __nodeEditorToolMenu( nodeEditor, node, menuDefinition ) :
+
+	if node.parent() is None :
+		return
+
+	activeRowNamesConnection = Gaffer.Metadata.value( node, "ui:spreadsheet:activeRowNamesConnection" )
+	if not activeRowNamesConnection :
+		return
+	else :
+		activeRowNamesConnection = node.descendant( activeRowNamesConnection )
+		assert( activeRowNamesConnection is not None )
+
+	selectorContextVariablePlug = Gaffer.Metadata.value( node, "ui:spreadsheet:selectorContextVariablePlug" )
+	if selectorContextVariablePlug :
+		selectorContextVariablePlug = node.descendant( selectorContextVariablePlug )
+		assert( selectorContextVariablePlug is not None )
+
+	selectorValue = Gaffer.Metadata.value( node, "ui:spreadsheet:selectorValue" )
+	assert( not ( selectorValue and selectorContextVariablePlug ) )
+
+	menuDefinition.append( "/SpreadsheetDivider", { "divider" : True } )
+	menuDefinition.append(
+		"/Create Spreadsheet...",
+		{
+			"command" : functools.partial( __createSpreadsheetForNode, node, activeRowNamesConnection, selectorContextVariablePlug, selectorValue ),
+			"active" : (
+				not nodeEditor.getReadOnly()
+				and not Gaffer.MetadataAlgo.readOnly( node )
+				and not Gaffer.MetadataAlgo.readOnly( activeRowNamesConnection )
+			)
+		}
+	)
+
+GafferUI.NodeEditor.toolMenuSignal().connect( __nodeEditorToolMenu, scoped = False )

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -1074,10 +1074,11 @@ class _PlugTableDelegate( QtWidgets.QStyledItemDelegate ) :
 		painter.save()
 
 		painter.setRenderHint( QtGui.QPainter.Antialiasing )
+		overlayColor = QtGui.QColor( 40, 40, 40, 200 )
 
 		if not cellPlugEnabled :
 
-			painter.fillRect( option.rect, QtGui.QBrush( QtGui.QColor( 40, 40, 40, 200 ) ) )
+			painter.fillRect( option.rect, overlayColor )
 
 			pen = QtGui.QPen( QtGui.QColor( 20, 20, 20, 150 ) )
 			pen.setWidth( 2 )
@@ -1086,9 +1087,7 @@ class _PlugTableDelegate( QtWidgets.QStyledItemDelegate ) :
 
 		if not enabled :
 
-			color = QtGui.QColor( index.data( QtCore.Qt.BackgroundColorRole ) )
-			color.setAlpha( 200 )
-			painter.fillRect( option.rect, QtGui.QBrush( color ) )
+			painter.fillRect( option.rect, overlayColor )
 
 		painter.restore()
 

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -1107,17 +1107,7 @@ class _EditWindow( GafferUI.Window ) :
 		# Apply some fixed widths for some widgets, otherwise they're
 		# a bit too eager to grow. \todo Should we change the underlying
 		# behaviour of the widgets themselves?
-
-		fixedWidth = None
-		if isinstance( plugValueWidget, GafferUI.NumericPlugValueWidget ) :
-			fixedWidth = self.__numericFieldWidth
-		elif isinstance( plugValueWidget, GafferUI.ColorPlugValueWidget ) :
-			fixedWidth = self.__numericFieldWidth * len( plugValueWidget.getPlug() ) + 20
-		elif isinstance( plugValueWidget, GafferUI.CompoundNumericPlugValueWidget ) :
-			fixedWidth = self.__numericFieldWidth * len( plugValueWidget.getPlug() )
-		elif isinstance( plugValueWidget, GafferUI.VectorDataPlugValueWidget ) :
-			fixedWidth = 250
-
+		fixedWidth = self.__fixedWidth( plugValueWidget )
 		if fixedWidth is not None :
 			plugValueWidget._qtWidget().setFixedWidth( fixedWidth )
 			plugValueWidget._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetNoConstraint )
@@ -1178,6 +1168,24 @@ class _EditWindow( GafferUI.Window ) :
 			return plugValueWidget.pathWidget()
 		elif isinstance( plugValueWidget, GafferUI.MultiLineStringPlugValueWidget ) :
 			return plugValueWidget.textWidget()
+
+	@classmethod
+	def __fixedWidth( cls, plugValueWidget ) :
+
+		if isinstance( plugValueWidget, GafferUI.NumericPlugValueWidget ) :
+			return cls.__numericFieldWidth
+		elif isinstance( plugValueWidget, GafferUI.ColorPlugValueWidget ) :
+			return cls.__numericFieldWidth * len( plugValueWidget.getPlug() ) + 20
+		elif isinstance( plugValueWidget, GafferUI.CompoundNumericPlugValueWidget ) :
+			return cls.__numericFieldWidth * len( plugValueWidget.getPlug() )
+		elif isinstance( plugValueWidget, GafferUI.VectorDataPlugValueWidget ) :
+			return 250
+		elif isinstance( plugValueWidget, GafferUI.NameValuePlugValueWidget ) :
+			w = cls.__fixedWidth( plugValueWidget.childPlugValueWidget( plugValueWidget.getPlug()["value"] ) )
+			if w is not None :
+				return w + 30
+
+		return None
 
 # ScrolledContainer linking
 # =========================

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -1292,9 +1292,14 @@ def __prependRowAndCellMenuItems( menuDefinition, plugValueWidget ) :
 	if rowPlug is None :
 		return
 
+	if rowPlug.getName() == "default" :
+		return
+
+	menuDefinition.prepend( "/__SpreadsheetRowAndCellDivider__", { "divider" : True } )
+
 	# Row menu items
 
-	if plug.parent() == rowPlug and rowPlug.getName() != "default" :
+	if plug.parent() == rowPlug :
 
 		menuDefinition.prepend(
 			"/Delete Row",
@@ -1327,21 +1332,19 @@ def __prependRowAndCellMenuItems( menuDefinition, plugValueWidget ) :
 	cellPlug = plug if isinstance( plug, Gaffer.Spreadsheet.CellPlug ) else plug.ancestor( Gaffer.Spreadsheet.CellPlug )
 	if cellPlug is not None :
 
-		if rowPlug.getName() != "default" :
+		enabled = None
+		enabledPlug = cellPlug["enabled"]
+		with plugValueWidget.getContext() :
+			with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
+				enabled = enabledPlug.getValue()
 
-			enabled = None
-			enabledPlug = cellPlug["enabled"]
-			with plugValueWidget.getContext() :
-				with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
-					enabled = enabledPlug.getValue()
-
-			menuDefinition.prepend(
-				"/Disable Cell" if enabled else "/Enable Cell",
-				{
-					"command" : functools.partial( __setPlugValue, enabledPlug, not enabled ),
-					"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( enabledPlug ) and enabledPlug.settable()
-				}
-			)
+		menuDefinition.prepend(
+			"/Disable Cell" if enabled else "/Enable Cell",
+			{
+				"command" : functools.partial( __setPlugValue, enabledPlug, not enabled ),
+				"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( enabledPlug ) and enabledPlug.settable()
+			}
+		)
 
 def __addColumn( spreadsheet, plug ) :
 
@@ -1457,6 +1460,8 @@ def __prependSpreadsheetCreationMenuItems( menuDefinition, plugValueWidget ) :
 			else :
 				ancestorPlug = None
 
+	menuDefinition.prepend( "/__SpreadsheetCreationDivider__", { "divider" : True } )
+
 	if ancestorPlug :
 		menuDefinition.prepend(
 			"/Add to Spreadsheet ({})".format( ancestorLabel ),
@@ -1490,8 +1495,6 @@ def __prependSpreadsheetCreationMenuItems( menuDefinition, plugValueWidget ) :
 	)
 
 def __plugPopupMenu( menuDefinition, plugValueWidget ) :
-
-	menuDefinition.prepend( "/SpreadsheetDivider", { "divider" : True } )
 
 	## \todo We're prepending rather than appending so that we get the ordering we
 	# want with respect to the Expression menu items. Really we need external control

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -279,13 +279,15 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		with self.__grid :
 
-			GafferUI.Label(
-				" Default", # Preceding space to cheat alignment
+			with GafferUI.ListContainer(
 				parenting = {
 					"index" : ( 0, 0 ),
 					"alignment" : ( GafferUI.HorizontalAlignment.Left, GafferUI.VerticalAlignment.Bottom ),
 				}
-			)
+			) :
+
+				GafferUI.Label( "Default" )._qtWidget().setIndent( 6 )
+				GafferUI.Spacer( imath.V2i( 1, 8 ) )
 
 			defaultTable = _PlugTableView(
 				plug, self.getContext(), _PlugTableView.Mode.Defaults,

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -1035,7 +1035,7 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 			s = self.__formatValue( value[1], forToolTip )
 			return "{}{}{}".format(
 				"On" if value[0] else "Off",
-				", \n" if forToolTip and "\n" in s else ", ",
+				" : \n" if forToolTip and "\n" in s else " : ",
 				s
 			)
 		elif value is None :

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -179,6 +179,24 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 			}
 		)
 
+		nodeGadgetTypes = Gaffer.Metadata.value( node, "uiEditor:nodeGadgetTypes" )
+		if nodeGadgetTypes :
+			nodeGadgetTypes = set( nodeGadgetTypes )
+			if nodeGadgetTypes == { "GafferUI::AuxiliaryNodeGadget", "GafferUI::StandardNodeGadget" } :
+				nodeGadgetType = Gaffer.Metadata.value( node, "nodeGadget:type" ) or "GafferUI::StandardNodeGadget"
+				menuDefinition.append(
+					"/Show Name",
+					{
+						"command" : functools.partial( cls.__setNameVisible, node ),
+						"checkBox" : nodeGadgetType == "GafferUI::StandardNodeGadget",
+						"active" : not Gaffer.MetadataAlgo.readOnly( node ),
+					}
+				)
+			else :
+				# We want to present the options above as a simple "Show Name" checkbox, and haven't yet
+				# decided how to present other combinations of allowable gadgets.
+				IECore.msg( IECore.msg.Warning, "UIEditor", 'Unknown combination of "uiEditor:nodeGadgetTypes"' )
+
 	@classmethod
 	def appendNodeEditorToolMenuDefinitions( cls, nodeEditor, node, menuDefinition ) :
 
@@ -316,6 +334,14 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 			with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
 				Gaffer.Metadata.registerValue( node, "nodeGadget:color", color )
 
+	@staticmethod
+	def __setNameVisible( node, nameVisible ) :
+
+		with Gaffer.UndoContext( node.ancestor( Gaffer.ScriptNode ) ) :
+			Gaffer.Metadata.registerValue(
+				node, "nodeGadget:type",
+				"GafferUI::StandardNodeGadget" if nameVisible else "GafferUI::AuxiliaryNodeGadget"
+			)
 
 GafferUI.Editor.registerType( "UIEditor", UIEditor )
 

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1090,6 +1090,22 @@ _styleSheet = string.Template(
 		background-color: $brightColor;
 	}
 
+	QTableView[gafferToggleIndicator="true"]::indicator:unchecked {
+		image: url($GAFFER_ROOT/graphics/toggleOff.png);
+	}
+
+	QTableView[gafferToggleIndicator="true"]::indicator:unchecked:hover {
+		image: url($GAFFER_ROOT/graphics/toggleOffHover.png);
+	}
+
+	QTableView[gafferToggleIndicator="true"]::indicator:checked {
+		image: url($GAFFER_ROOT/graphics/toggleOn.png);
+	}
+
+	QTableView[gafferToggleIndicator="true"]::indicator:checked:hover {
+		image: url($GAFFER_ROOT/graphics/toggleOnHover.png);
+	}
+
 	/* highlighted state for VectorDataWidget and tree views */
 
 	_TableView[gafferHighlighted="true"] {

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -708,28 +708,28 @@ _styleSheet = string.Template(
 		background-color: $tintLighter;
 	}
 
-	*[gafferClass="GafferUI.VectorDataWidget"] QHeaderView::section:vertical:first {
+	_TableView QHeaderView::section:vertical:first {
 		border-top-left-radius: $widgetCornerRadius;
 	}
 
-	*[gafferClass="GafferUI.VectorDataWidget"] QHeaderView::section:vertical:last {
+	_TableView QHeaderView::section:vertical:last {
 		border-bottom-left-radius: $widgetCornerRadius;
 	}
 
-	*[gafferClass="GafferUI.VectorDataWidget"] QHeaderView::section:vertical:only-one {
+	_TableView QHeaderView::section:vertical:only-one {
 		border-top-left-radius: $widgetCornerRadius;
 		border-bottom-left-radius: $widgetCornerRadius;
 	}
 
-	*[gafferClass="GafferUI.VectorDataWidget"] QHeaderView::section:horizontal:first {
+	_TableView QHeaderView::section:horizontal:first {
 		border-top-left-radius: $widgetCornerRadius;
 	}
 
-	*[gafferClass="GafferUI.VectorDataWidget"] QHeaderView::section:horizontal:last {
+	_TableView QHeaderView::section:horizontal:last {
 		border-top-right-radius: $widgetCornerRadius;
 	}
 
-	*[gafferClass="GafferUI.VectorDataWidget"] QHeaderView::section:horizontal:only-one {
+	_TableView QHeaderView::section:horizontal:only-one {
 		border-top-left-radius: $widgetCornerRadius;
 		border-top-right-radius: $widgetCornerRadius;
 	}
@@ -1041,26 +1041,26 @@ _styleSheet = string.Template(
 		border: none;
 	}
 
-	*[gafferClass="GafferUI.VectorDataWidget"] QTableView {
+	_TableView {
 		gridline-color: $backgroundLowlight;
 		padding: 0px;
 		background-color: $backgroundRaised;
 	}
 
-	*[gafferClass="GafferUI.VectorDataWidget"] QTableView[gafferEditable="true"] {
+	_TableView[gafferEditable="true"] {
 		padding: 0px;
 		gridline-color: $backgroundLowlight;
 	}
 
-	*[gafferClass="GafferUI.VectorDataWidget"] QTableView[gafferEditable="true"]::item {
+	_TableView[gafferEditable="true"]::item {
 		background-color: $backgroundLight;
 	}
 
-	*[gafferClass="GafferUI.VectorDataWidget"] QTableView[gafferEditable="true"]::item:selected {
+	_TableView::item:selected {
 		background-color: $brightColor;
 	}
 
-	*[gafferClass="GafferUI.VectorDataWidget"] QHeaderView::section:vertical {
+	_TableView QHeaderView::section:vertical {
 		padding: 2px;
 	}
 
@@ -1092,12 +1092,12 @@ _styleSheet = string.Template(
 
 	/* highlighted state for VectorDataWidget and tree views */
 
-	*[gafferClass="GafferUI.VectorDataWidget"] QTableView[gafferHighlighted="true"] {
+	_TableView[gafferHighlighted="true"] {
 		gridline-color: $brightColor;
 	}
 
 	QTreeView[gafferHighlighted="true"],
-	*[gafferClass="GafferUI.VectorDataWidget"] QTableView[gafferHighlighted="true"] QHeaderView::section {
+	_TableView[gafferHighlighted="true"] QHeaderView::section {
 		border-color: $brightColor;
 	}
 

--- a/python/GafferUI/_TableView.py
+++ b/python/GafferUI/_TableView.py
@@ -50,6 +50,7 @@ class _TableView( QtWidgets.QTableView ) :
 		QtWidgets.QTableView.__init__( self )
 
 		self.__minimumVisibleRows = minimumVisibleRows
+		self.horizontalHeader().sectionResized.connect( self.__sizeShouldChange )
 
 	def setModel( self, model ) :
 
@@ -71,6 +72,15 @@ class _TableView( QtWidgets.QTableView ) :
 			model.columnsRemoved.connect( self.__sizeShouldChange )
 			model.dataChanged.connect( self.__sizeShouldChange )
 			model.modelReset.connect( self.__sizeShouldChange )
+
+	def setHorizontalHeader( self, header ) :
+
+		if header == self.horizontalHeader() :
+			return
+
+		self.horizontalHeader().sectionResized.disconnect( self.__sizeShouldChange )
+		QtWidgets.QTableView.setHorizontalHeader( self, header )
+		self.horizontalHeader().sectionResized.connect( self.__sizeShouldChange )
 
 	def minimumSizeHint( self ) :
 

--- a/python/GafferUI/_TableView.py
+++ b/python/GafferUI/_TableView.py
@@ -1,0 +1,112 @@
+##########################################################################
+#
+#  Copyright (c) 2011-2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2012, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+from Qt import QtCore
+from Qt import QtWidgets
+
+# A QTableView derived class with custom size behaviours we want for
+# GafferUI. This is not part of the public API.
+class _TableView( QtWidgets.QTableView ) :
+
+	def __init__( self, minimumVisibleRows ) :
+
+		QtWidgets.QTableView.__init__( self )
+
+		self.__minimumVisibleRows = minimumVisibleRows
+
+	def setModel( self, model ) :
+
+		prevModel = self.model()
+		if prevModel :
+			prevModel.rowsInserted.disconnect( self.__sizeShouldChange )
+			prevModel.rowsRemoved.disconnect( self.__sizeShouldChange )
+			prevModel.dataChanged.connect( self.__sizeShouldChange )
+
+		QtWidgets.QTableView.setModel( self, model )
+
+		if model :
+			model.rowsInserted.connect( self.__sizeShouldChange )
+			model.rowsRemoved.connect( self.__sizeShouldChange )
+			model.dataChanged.connect( self.__sizeShouldChange )
+
+	def minimumSizeHint( self ) :
+
+		# compute the minimum height to be the size of the header plus
+		# a minimum number of rows specified in self.__minimumVisibleRows
+
+		margins = self.contentsMargins()
+		minimumHeight = margins.top() + margins.bottom()
+
+		if not self.horizontalHeader().isHidden() :
+			minimumHeight += self.horizontalHeader().sizeHint().height()
+
+		numRows = self.verticalHeader().count()
+		if numRows :
+			minimumHeight += self.verticalHeader().sectionSize( 0 ) * min( numRows, self.__minimumVisibleRows )
+
+		# horizontal direction doesn't matter, as we don't allow shrinking
+		# in that direction anyway.
+
+		return QtCore.QSize( 1, minimumHeight )
+
+	def sizeHint( self ) :
+
+		# this seems to be necessary to nudge the header into calculating
+		# the correct size - otherwise the length() below comes out wrong
+		# sometimes. in other words it's a hack.
+		for i in range( 0, self.horizontalHeader().count() ) :
+			self.horizontalHeader().sectionSize( i )
+
+		margins = self.contentsMargins()
+
+		w = self.horizontalHeader().length() + margins.left() + margins.right()
+		if not self.verticalHeader().isHidden() :
+			w += self.verticalHeader().sizeHint().width()
+		# always allow room for a scrollbar even though we don't always need one. we
+		# make sure the background in the stylesheet is transparent so that when the
+		# scrollbar is hidden we don't draw an empty gap where it otherwise would be.
+		w += self.verticalScrollBar().sizeHint().width()
+
+		h = self.verticalHeader().length() + margins.top() + margins.bottom()
+		if not self.horizontalHeader().isHidden() :
+			h += self.horizontalHeader().sizeHint().height()
+
+		return QtCore.QSize( w, h )
+
+	def __sizeShouldChange( self, *unusedArgs ) :
+
+		self.updateGeometry()

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -312,6 +312,7 @@ from NameValuePlugValueWidget import NameValuePlugValueWidget
 import DependencyNodeUI
 import ComputeNodeUI
 import RandomUI
+import SpreadsheetUI
 import ExpressionUI
 import BoxUI
 import ReferenceUI

--- a/src/Gaffer/Context.cpp
+++ b/src/Gaffer/Context.cpp
@@ -38,6 +38,7 @@
 #include "Gaffer/Context.h"
 
 #include "IECore/SimpleTypedData.h"
+#include "IECore/VectorTypedData.h"
 
 #include "boost/lexical_cast.hpp"
 
@@ -480,6 +481,24 @@ void Context::substituteInternal( const char *s, std::string &result, const int 
 									static_cast<const IECore::IntData *>( d )->readable()
 								);
 								break;
+							case IECore::InternedStringVectorDataTypeId : {
+								// This is unashamedly tailored to the needs of GafferScene's `${scene:path}`
+								// variable. We could make this cleaner by adding a mechanism for registering custom
+								// formatters, but that would be overkill for this one use case.
+								const auto &v = static_cast<const IECore::InternedStringVectorData *>( d )->readable();
+								if( v.empty() )
+								{
+									result += "/";
+								}
+								else
+								{
+									for( const auto &x : v )
+									{
+										result += "/" + x.string();
+									}
+								}
+								break;
+							}
 							default :
 								break;
 						}

--- a/src/Gaffer/Spreadsheet.cpp
+++ b/src/Gaffer/Spreadsheet.cpp
@@ -81,6 +81,16 @@ Spreadsheet::RowsPlug::RowsPlug( const std::string &name, Direction direction, u
 	addChild( defaultRow );
 }
 
+Spreadsheet::RowPlug *Spreadsheet::RowsPlug::defaultRow()
+{
+	return getChild<RowPlug>( 0 );
+}
+
+const Spreadsheet::RowPlug *Spreadsheet::RowsPlug::defaultRow() const
+{
+	return getChild<RowPlug>( 0 );
+}
+
 size_t Spreadsheet::RowsPlug::addColumn( const ValuePlug *value, IECore::InternedString name )
 {
 	if( name.string().empty() )
@@ -100,13 +110,13 @@ size_t Spreadsheet::RowsPlug::addColumn( const ValuePlug *value, IECore::Interne
 		outColumn->setFlags( Plug::Dynamic, false );
 		o->addChild( outColumn );
 	}
-	return getChild<RowPlug>( 0 )->cellsPlug()->children().size() - 1;
+	return defaultRow()->cellsPlug()->children().size() - 1;
 
 }
 
 void Spreadsheet::RowsPlug::removeColumn( size_t columnIndex )
 {
-	if( columnIndex >= getChild<RowPlug>( 0 )->cellsPlug()->children().size() )
+	if( columnIndex >= defaultRow()->cellsPlug()->children().size() )
 	{
 		throw IECore::Exception( "Column index out of range" );
 	}
@@ -126,7 +136,7 @@ Spreadsheet::RowPlug *Spreadsheet::RowsPlug::addRow()
 	// We need to use the `Dynamic` flag so that we get dirty propagation via
 	// `Plug::propagateDirtinessForParentChange()`.
 	RowPlugPtr newRow = new RowPlug( "row1", direction(), Default | Dynamic );
-	for( auto &defaultCell : CellPlug::Range( *getChild<RowPlug>( 0 )->cellsPlug() ) )
+	for( auto &defaultCell : CellPlug::Range( *defaultRow()->cellsPlug() ) )
 	{
 		CellPlugPtr newCell = boost::static_pointer_cast<CellPlug>(
 			defaultCell->createCounterpart( defaultCell->getName(), Plug::In )
@@ -324,14 +334,14 @@ const StringPlug *Spreadsheet::selectorPlug() const
 	return getChild<StringPlug>( g_firstPlugIndex + 1 );
 }
 
-ValuePlug *Spreadsheet::rowsPlug()
+Spreadsheet::RowsPlug *Spreadsheet::rowsPlug()
 {
-	return getChild<ValuePlug>( g_firstPlugIndex + 2 );
+	return getChild<RowsPlug>( g_firstPlugIndex + 2 );
 }
 
-const ValuePlug *Spreadsheet::rowsPlug() const
+const Spreadsheet::RowsPlug *Spreadsheet::rowsPlug() const
 {
-	return getChild<ValuePlug>( g_firstPlugIndex + 2 );
+	return getChild<RowsPlug>( g_firstPlugIndex + 2 );
 }
 
 ValuePlug *Spreadsheet::outPlug()
@@ -533,7 +543,7 @@ const ValuePlug *Spreadsheet::correspondingInput( const Plug *plug, size_t rowIn
 	const CellPlug *cell = rowsPlug()->getChild<RowPlug>( rowIndex )->cellsPlug()->getChild<CellPlug>( names.back() );
 	if( rowIndex && !cell->enabledPlug()->getValue() )
 	{
-		cell = rowsPlug()->getChild<RowPlug>( 0 )->cellsPlug()->getChild<CellPlug>( names.back() );
+		cell = rowsPlug()->defaultRow()->cellsPlug()->getChild<CellPlug>( names.back() );
 	}
 
 	names.pop_back();

--- a/src/Gaffer/Spreadsheet.cpp
+++ b/src/Gaffer/Spreadsheet.cpp
@@ -1,0 +1,557 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/Spreadsheet.h"
+
+#include "Gaffer/StringPlug.h"
+
+#include "boost/container/small_vector.hpp"
+
+using namespace std;
+using namespace IECore;
+using namespace Gaffer;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+void appendLeafPlugs( const Gaffer::Plug *p, DependencyNode::AffectedPlugsContainer &container )
+{
+	if( !p->children().size() )
+	{
+		container.push_back( p );
+	}
+	else
+	{
+		for( const auto &c : Plug::Range( *p ) )
+		{
+			appendLeafPlugs( c.get(), container );
+		}
+	}
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// RowsPlug
+//////////////////////////////////////////////////////////////////////////
+
+GAFFER_PLUG_DEFINE_TYPE( Spreadsheet::RowsPlug );
+
+Spreadsheet::RowsPlug::RowsPlug( const std::string &name, Direction direction, unsigned flags )
+	:	ValuePlug( name, direction, flags )
+{
+	RowPlugPtr defaultRow = new RowPlug( "default" );
+	addChild( defaultRow );
+}
+
+size_t Spreadsheet::RowsPlug::addColumn( const ValuePlug *value, IECore::InternedString name )
+{
+	if( name.string().empty() )
+	{
+		name = value->getName();
+	}
+
+	for( auto &row : RowPlug::Range( *this ) )
+	{
+		CellPlugPtr cellPlug = new CellPlug( name, value );
+		cellPlug->valuePlug()->setFrom( value );
+		row->cellsPlug()->addChild( cellPlug );
+	}
+	if( auto *o = outPlug() )
+	{
+		PlugPtr outColumn = value->createCounterpart( name, Plug::Out );
+		outColumn->setFlags( Plug::Dynamic, false );
+		o->addChild( outColumn );
+	}
+	return getChild<RowPlug>( 0 )->cellsPlug()->children().size() - 1;
+
+}
+
+void Spreadsheet::RowsPlug::removeColumn( size_t columnIndex )
+{
+	if( columnIndex >= getChild<RowPlug>( 0 )->cellsPlug()->children().size() )
+	{
+		throw IECore::Exception( "Column index out of range" );
+	}
+
+	for( auto &row : RowPlug::Range( *this ) )
+	{
+		row->cellsPlug()->removeChild( row->cellsPlug()->getChild( columnIndex ) );
+	}
+	if( auto *o = outPlug() )
+	{
+		o->removeChild( o->getChild( columnIndex ) );
+	}
+}
+
+Spreadsheet::RowPlug *Spreadsheet::RowsPlug::addRow()
+{
+	// We need to use the `Dynamic` flag so that we get dirty propagation via
+	// `Plug::propagateDirtinessForParentChange()`.
+	RowPlugPtr newRow = new RowPlug( "row1", direction(), Default | Dynamic );
+	for( auto &defaultCell : CellPlug::Range( *getChild<RowPlug>( 0 )->cellsPlug() ) )
+	{
+		CellPlugPtr newCell = boost::static_pointer_cast<CellPlug>(
+			defaultCell->createCounterpart( defaultCell->getName(), Plug::In )
+		);
+		newCell->setFrom( defaultCell.get() );
+		newRow->cellsPlug()->addChild( newCell );
+	}
+	addChild( newRow );
+	return newRow.get();
+}
+
+void Spreadsheet::RowsPlug::addRows( size_t numRows )
+{
+	for( ; numRows; --numRows )
+	{
+		addRow();
+	}
+}
+
+void Spreadsheet::RowsPlug::removeRow( Spreadsheet::RowPlugPtr row )
+{
+	if( row->parent() != this )
+	{
+		throw Exception( boost::str(
+			boost::format( "Row \"%1%\" is not a child of \"%2%\"." ) % row->fullName() % fullName()
+		) );
+	}
+
+	if( row == getChild( 0 ) )
+	{
+		throw Exception( boost::str(
+			boost::format( "Cannot remove default row from \"%1%\"." ) % fullName()
+		) );
+	}
+
+	removeChild( row );
+}
+
+Gaffer::ValuePlug *Spreadsheet::RowsPlug::outPlug()
+{
+	// Find the `outPlug()` on our parent Spreadsheet node.
+	// We use this from `add/removeColumn()` so that we can
+	// add the appropriate columns to the output plug. It's
+	// not ideal that this responsibility falls to us. What
+	// might be nice would be to rename RowsPlug to SheetPlug
+	// and let it manage both "rows" and "out" children, so
+	// that it's more natural to modify "out". We can't do that
+	// at present because we don't allow connections to plugs
+	// which have a mix of input and output children.
+	if( auto *s = parent<Spreadsheet>() )
+	{
+		return s->outPlug();
+	}
+	return nullptr;
+}
+
+
+Gaffer::PlugPtr Spreadsheet::RowsPlug::createCounterpart( const std::string &name, Direction direction ) const
+{
+	RowsPlugPtr result = new RowsPlug( name, direction, getFlags() );
+	for( const auto &row : RowPlug::Range( *this ) )
+	{
+		// Using `setChild()` rather than `addChild()` because we want to replace
+		// the default-constructed default row with one with the right number of
+		// cells.
+		result->setChild( row->getName(), row->createCounterpart( row->getName(), direction ) );
+	}
+	return result;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// RowPlug
+//////////////////////////////////////////////////////////////////////////
+
+GAFFER_PLUG_DEFINE_TYPE( Spreadsheet::RowPlug );
+
+Spreadsheet::RowPlug::RowPlug( const std::string &name, Plug::Direction direction, unsigned flags )
+	:	ValuePlug( name, direction, flags )
+{
+	addChild( new StringPlug( "name", direction ) );
+	addChild( new BoolPlug( "enabled",direction, true ) );
+	addChild( new ValuePlug( "cells", direction ) );
+}
+
+StringPlug *Spreadsheet::RowPlug::namePlug()
+{
+	return getChild<StringPlug>( 0 );
+}
+
+const StringPlug *Spreadsheet::RowPlug::namePlug() const
+{
+	return getChild<StringPlug>( 0 );
+}
+
+BoolPlug *Spreadsheet::RowPlug::enabledPlug()
+{
+	return getChild<BoolPlug>( 1 );
+}
+
+const BoolPlug *Spreadsheet::RowPlug::enabledPlug() const
+{
+	return getChild<BoolPlug>( 1 );
+}
+
+ValuePlug *Spreadsheet::RowPlug::cellsPlug()
+{
+	return getChild<ValuePlug>( 2 );
+}
+
+const ValuePlug *Spreadsheet::RowPlug::cellsPlug() const
+{
+	return getChild<ValuePlug>( 2 );
+}
+
+Gaffer::PlugPtr Spreadsheet::RowPlug::createCounterpart( const std::string &name, Direction direction ) const
+{
+	RowPlugPtr result = new RowPlug( name, direction );
+	for( const auto &cell : CellPlug::Range( *cellsPlug() ) )
+	{
+		result->cellsPlug()->addChild( cell->createCounterpart( cell->getName(), direction ) );
+	}
+	return result;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// CellPlug
+//////////////////////////////////////////////////////////////////////////
+
+GAFFER_PLUG_DEFINE_TYPE( Spreadsheet::CellPlug );
+
+Spreadsheet::CellPlug::CellPlug( const std::string &name, const Gaffer::Plug *value, Plug::Direction direction )
+	:	ValuePlug( name, direction )
+{
+	addChild( new BoolPlug( "enabled", direction, true ) );
+	addChild( value->createCounterpart( "value", direction ) );
+	valuePlug()->setFlags( Plug::Dynamic, false );
+}
+
+BoolPlug *Spreadsheet::CellPlug::enabledPlug()
+{
+	return getChild<BoolPlug>( 0 );
+}
+
+const BoolPlug *Spreadsheet::CellPlug::enabledPlug() const
+{
+	return getChild<BoolPlug>( 0 );
+}
+
+Gaffer::PlugPtr Spreadsheet::CellPlug::createCounterpart( const std::string &name, Direction direction ) const
+{
+	return new CellPlug( name, valuePlug(), direction );
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Spreadsheet
+//////////////////////////////////////////////////////////////////////////
+
+size_t Spreadsheet::g_firstPlugIndex = 0;
+GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( Spreadsheet );
+
+Spreadsheet::Spreadsheet( const std::string &name )
+	:	ComputeNode( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new BoolPlug( "enabled", Plug::In, true ) );
+	addChild( new StringPlug( "selector" ) );
+	addChild( new RowsPlug( "rows" ) );
+	addChild( new ValuePlug( "out", Plug::Out ) );
+	addChild( new StringVectorDataPlug( "activeRowNames", Plug::Out, new IECore::StringVectorData ) );
+	addChild( new IntPlug( "__rowIndex", Plug::Out ) );
+}
+
+Spreadsheet::~Spreadsheet()
+{
+}
+
+BoolPlug *Spreadsheet::enabledPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex );
+}
+
+const BoolPlug *Spreadsheet::enabledPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex );
+}
+
+StringPlug *Spreadsheet::selectorPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+const StringPlug *Spreadsheet::selectorPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+ValuePlug *Spreadsheet::rowsPlug()
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 2 );
+}
+
+const ValuePlug *Spreadsheet::rowsPlug() const
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 2 );
+}
+
+ValuePlug *Spreadsheet::outPlug()
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 3 );
+}
+
+const ValuePlug *Spreadsheet::outPlug() const
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 3 );
+}
+
+StringVectorDataPlug *Spreadsheet::activeRowNamesPlug()
+{
+	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 4 );
+}
+
+const StringVectorDataPlug *Spreadsheet::activeRowNamesPlug() const
+{
+	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 4 );
+}
+
+IntPlug *Spreadsheet::rowIndexPlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 5 );
+}
+
+const IntPlug *Spreadsheet::rowIndexPlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 5 );
+}
+
+void Spreadsheet::affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const
+{
+	ComputeNode::affects( input, outputs );
+
+	const auto *row = input->parent<RowPlug>();
+	if(
+		input == enabledPlug() ||
+		input == selectorPlug() ||
+		( row && input == row->namePlug() ) ||
+		( row && input == row->enabledPlug() )
+	)
+	{
+		outputs.push_back( rowIndexPlug() );
+	}
+
+	if( input == rowIndexPlug() )
+	{
+		appendLeafPlugs( outPlug(), outputs );
+	}
+
+	if( const auto *cell = input->ancestor<CellPlug>() )
+	{
+		if( const Plug *out = outPlug()->getChild<ValuePlug>( cell->getName() ) )
+		{
+			if( input == cell->enabledPlug() )
+			{
+				appendLeafPlugs( out, outputs );
+			}
+			else if( input == cell->valuePlug() )
+			{
+				outputs.push_back( out );
+			}
+			else
+			{
+				outputs.push_back(
+					out->descendant<Plug>( input->relativeName( cell->valuePlug() ) )
+				);
+			}
+		}
+	}
+
+	if(
+		( row && input == row->namePlug() ) ||
+		( row && input == row->enabledPlug() )
+	)
+	{
+		outputs.push_back( activeRowNamesPlug() );
+	}
+}
+
+Plug *Spreadsheet::correspondingInput( const Plug *output )
+{
+	return const_cast<Plug *>( const_cast<const Spreadsheet *>( this)->correspondingInput( output ) );
+}
+
+const Plug *Spreadsheet::correspondingInput( const Plug *output ) const
+{
+	if( const Plug *p = correspondingInput( output, /* rowIndex = */ 0 ) )
+	{
+		return p;
+	}
+
+	return DependencyNode::correspondingInput( output );
+}
+
+void Spreadsheet::hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const
+{
+	if( output == rowIndexPlug() )
+	{
+		ComputeNode::hash( output, context, h );
+		enabledPlug()->hash( h );
+		selectorPlug()->hash( h );
+		for( int i = 1, e = rowsPlug()->children().size(); i < e; ++i )
+		{
+			const auto *row = rowsPlug()->getChild<RowPlug>( i );
+			row->namePlug()->hash( h );
+			row->enabledPlug()->hash( h );
+		}
+		return;
+	}
+	else if( outPlug()->isAncestorOf( output ) )
+	{
+		h = correspondingInput( output, rowIndexPlug()->getValue() )->hash();
+		return;
+	}
+	else if( output == activeRowNamesPlug() )
+	{
+		ComputeNode::hash( output, context, h );
+		for( int i = 1, e = rowsPlug()->children().size(); i < e; ++i )
+		{
+			const auto *row = rowsPlug()->getChild<RowPlug>( i );
+			row->namePlug()->hash( h );
+			row->enabledPlug()->hash( h );
+		}
+		return;
+	}
+
+	ComputeNode::hash( output, context, h );
+}
+
+void Spreadsheet::compute( ValuePlug *output, const Context *context ) const
+{
+	if( output == rowIndexPlug() )
+	{
+		int result = 0;
+		if( enabledPlug()->getValue() )
+		{
+			const std::string selector = selectorPlug()->getValue();
+			for( int i = 1, e = rowsPlug()->children().size(); i < e; ++i )
+			{
+				const auto *row = rowsPlug()->getChild<RowPlug>( i );
+				if( !row->enabledPlug()->getValue() )
+				{
+					continue;
+				}
+				if( StringAlgo::matchMultiple( selector, row->namePlug()->getValue() ) )
+				{
+					result = i;
+					break;
+				}
+			}
+		}
+		static_cast<IntPlug *>( output )->setValue( result );
+		return;
+	}
+	else if( outPlug()->isAncestorOf( output ) )
+	{
+		output->setFrom( correspondingInput( output, rowIndexPlug()->getValue() ) );
+		return;
+	}
+	else if( output == activeRowNamesPlug() )
+	{
+		StringVectorDataPtr resultData = new StringVectorData;
+		auto &result = resultData->writable();
+		result.reserve( rowsPlug()->children().size() - 1 );
+
+		for( int i = 1, e = rowsPlug()->children().size(); i < e; ++i )
+		{
+			const auto *row = rowsPlug()->getChild<RowPlug>( i );
+			if( row->enabledPlug()->getValue() )
+			{
+				result.push_back( row->namePlug()->getValue() );
+			}
+		}
+		static_cast<StringVectorDataPlug *>( output )->setValue( resultData );
+		return;
+	}
+
+	ComputeNode::compute( output, context );
+}
+
+const ValuePlug *Spreadsheet::correspondingInput( const Plug *plug, size_t rowIndex ) const
+{
+	const ValuePlug *out = outPlug();
+	boost::container::small_vector<IECore::InternedString, 4> names;
+	while( plug && plug != out )
+	{
+		names.push_back( plug->getName() );
+		plug = plug->parent<Plug>();
+	}
+
+	if( !plug || names.empty() )
+	{
+		return nullptr;
+	}
+
+	const CellPlug *cell = rowsPlug()->getChild<RowPlug>( rowIndex )->cellsPlug()->getChild<CellPlug>( names.back() );
+	if( rowIndex && !cell->enabledPlug()->getValue() )
+	{
+		cell = rowsPlug()->getChild<RowPlug>( 0 )->cellsPlug()->getChild<CellPlug>( names.back() );
+	}
+
+	names.pop_back();
+	const ValuePlug *result = cell->valuePlug();
+	for( auto it = names.rbegin(), eIt = names.rend(); it != eIt; ++it )
+	{
+		result = result->getChild<ValuePlug>( *it );
+	}
+
+	return result;
+}
+
+ValuePlug *Spreadsheet::activeInPlug( const ValuePlug *output )
+{
+	return const_cast<ValuePlug *>( correspondingInput( output, rowIndexPlug()->getValue() ) );
+}
+
+const ValuePlug *Spreadsheet::activeInPlug( const ValuePlug *output ) const
+{
+	return correspondingInput( output, rowIndexPlug()->getValue() );
+}

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -67,6 +67,7 @@
 #include "SetBinding.h"
 #include "SignalBinding.h"
 #include "SplinePlugBinding.h"
+#include "SpreadsheetBinding.h"
 #include "StringPlugBinding.h"
 #include "SubGraphBinding.h"
 #include "SwitchBinding.h"
@@ -218,6 +219,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindProcessMessageHandler();
 	bindNameValuePlug();
 	bindProcess();
+	bindSpreadsheet();
 
 	NodeClass<Backdrop>();
 

--- a/src/GafferModule/SpreadsheetBinding.cpp
+++ b/src/GafferModule/SpreadsheetBinding.cpp
@@ -1,0 +1,159 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "SpreadsheetBinding.h"
+
+#include "GafferBindings/DependencyNodeBinding.h"
+#include "GafferBindings/ValuePlugBinding.h"
+
+#include "Gaffer/Spreadsheet.h"
+
+using namespace boost::python;
+using namespace IECorePython;
+using namespace Gaffer;
+using namespace GafferBindings;
+
+namespace
+{
+
+size_t addColumn( Spreadsheet::RowsPlug &rowsPlug, ValuePlug &value, IECore::InternedString name )
+{
+	ScopedGILRelease gilRelease;
+	return rowsPlug.addColumn( &value, name );
+}
+
+void removeColumn( Spreadsheet::RowsPlug &rowsPlug, size_t columnIndex )
+{
+	ScopedGILRelease gilRelease;
+	return rowsPlug.removeColumn( columnIndex );
+}
+
+Spreadsheet::RowPlugPtr addRow( Spreadsheet::RowsPlug &rowsPlug )
+{
+	ScopedGILRelease gilRelease;
+	return rowsPlug.addRow();
+}
+
+void addRows( Spreadsheet::RowsPlug &rowsPlug, size_t numRows )
+{
+	ScopedGILRelease gilRelease;
+	rowsPlug.addRows( numRows );
+}
+
+void removeRow( Spreadsheet::RowsPlug &rowsPlug, Spreadsheet::RowPlug &row )
+{
+	ScopedGILRelease gilRelease;
+	rowsPlug.removeRow( &row );
+}
+
+ValuePlugPtr activeInPlug( Spreadsheet &s, const ValuePlug &outPlug )
+{
+	ScopedGILRelease gilRelease;
+	return s.activeInPlug( &outPlug );
+}
+
+class RowsPlugSerialiser : public ValuePlugSerialiser
+{
+
+	public :
+
+		std::string postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, const Serialisation &serialisation ) const override
+		{
+			std::string result = ValuePlugSerialiser::postConstructor( graphComponent, identifier, serialisation );
+
+			const auto *plug = static_cast<const Spreadsheet::RowsPlug *>( graphComponent );
+			for( const auto &cell : Spreadsheet::CellPlug::Range( *plug->getChild<Spreadsheet::RowPlug>( 0 )->cellsPlug() ) )
+			{
+				PlugPtr p = cell->valuePlug()->createCounterpart( cell->getName(), Plug::In );
+				const Serialiser *plugSerialiser = Serialisation::acquireSerialiser( p.get() );
+				result += identifier + ".addColumn( " + plugSerialiser->constructor( p.get(), serialisation ) + " )\n";
+			}
+
+			const size_t numRows = plug->children().size();
+			if( numRows > 1 )
+			{
+				result += identifier + ".addRows( " + std::to_string( numRows - 1 ) + " )\n";
+			}
+			return result;
+		}
+
+		bool childNeedsConstruction( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override
+		{
+			// We can serialise much more compactly via the `addRows()` call made by `postConstructor()`.
+			return false;
+		}
+
+};
+
+} // namespace
+
+void GafferModule::bindSpreadsheet()
+{
+
+	scope s = DependencyNodeClass<Spreadsheet>()
+		.def( "activeInPlug", &activeInPlug )
+	;
+
+	PlugClass<Spreadsheet::RowsPlug>()
+		.def( init<std::string, Plug::Direction, unsigned>(
+				(
+					arg( "name" )=GraphComponent::defaultName<Spreadsheet::RowsPlug>(),
+					arg( "direction" )=Plug::In,
+					arg( "flags" )=Plug::Default
+				)
+			)
+		)
+		.def( "addColumn", &addColumn, ( arg( "value" ), arg( "name" ) = "" ) )
+		.def( "removeColumn", &removeColumn )
+		.def( "addRow", &addRow )
+		.def( "addRows", &addRows )
+		.def( "removeRow", &removeRow )
+		.attr( "__qualname__" ) = "Spreadsheet.RowsPlug"
+	;
+
+	PlugClass<Spreadsheet::RowPlug>()
+		.attr( "__qualname__" ) = "Spreadsheet.RowPlug"
+	;
+
+	PlugClass<Spreadsheet::CellPlug>()
+		.attr( "__qualname__" ) = "Spreadsheet.CellPlug"
+	;
+
+	Serialisation::registerSerialiser( Gaffer::Spreadsheet::RowsPlug::staticTypeId(), new RowsPlugSerialiser );
+
+}

--- a/src/GafferModule/SpreadsheetBinding.h
+++ b/src/GafferModule/SpreadsheetBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERMODULE_SPREADSHEETBINDING_H
+#define GAFFERMODULE_SPREADSHEETBINDING_H
+
+namespace GafferModule
+{
+
+void bindSpreadsheet();
+
+} // namespace GafferModule
+
+#endif // GAFFERMODULE_SPREADSHEETBINDING_H

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -163,9 +163,20 @@ bool updateSelection( const SceneAlgo::History *history, TransformTool::Selectio
 		{
 			if( spreadsheet->outPlug()->isAncestorOf( selection.transformPlug.get() ) )
 			{
-				selection.transformPlug = static_cast<TransformPlug *>(
+				auto spreadsheetTransformPlug = static_cast<TransformPlug *>(
 					spreadsheet->activeInPlug( selection.transformPlug.get() )
 				);
+				if( spreadsheetTransformPlug->ancestor<Spreadsheet::RowPlug>() != spreadsheet->rowsPlug()->defaultRow() )
+				{
+					selection.transformPlug = spreadsheetTransformPlug;
+				}
+				else
+				{
+					// Default spreadsheet row. Editing this could affect any number
+					// of unrelated objects, so don't do that.
+					selection.transformPlug = nullptr;
+					return false;
+				}
 			}
 		}
 

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -49,6 +49,7 @@
 #include "Gaffer/Metadata.h"
 #include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/ScriptNode.h"
+#include "Gaffer/Spreadsheet.h"
 
 #include "OpenEXR/ImathMatrixAlgo.h"
 
@@ -157,6 +158,17 @@ bool updateSelection( const SceneAlgo::History *history, TransformTool::Selectio
 	if( selection.transformPlug )
 	{
 		selection.transformPlug = selection.transformPlug->source<TransformPlug>();
+
+		if( auto *spreadsheet = runTimeCast<Spreadsheet>( selection.transformPlug->node() ) )
+		{
+			if( spreadsheet->outPlug()->isAncestorOf( selection.transformPlug.get() ) )
+			{
+				selection.transformPlug = static_cast<TransformPlug *>(
+					spreadsheet->activeInPlug( selection.transformPlug.get() )
+				);
+			}
+		}
+
 		if( ancestorMakesChildNodesReadOnly( selection.transformPlug->node() ) )
 		{
 			// Inside a Reference node or similar. Unlike a regular read-only

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -61,6 +61,7 @@ Gaffer.Metadata.registerValue( Gaffer.BoxIO, "nodeGadget:color", imath.Color3f( 
 Gaffer.Metadata.registerValue( Gaffer.Random, "nodeGadget:color", imath.Color3f( 0.45, 0.3, 0.3 ) )
 Gaffer.Metadata.registerValue( Gaffer.Expression, "nodeGadget:color", imath.Color3f( 0.3, 0.45, 0.3 ) )
 Gaffer.Metadata.registerValue( Gaffer.Animation, "nodeGadget:color", imath.Color3f( 0.3, 0.3, 0.45 ) )
+Gaffer.Metadata.registerValue( Gaffer.Spreadsheet, "nodeGadget:color", imath.Color3f( 0.69, 0.5445, 0.2208 ) )
 
 Gaffer.Metadata.registerValue( GafferScene.ScenePlug, "nodule:color", imath.Color3f( 0.2401, 0.3394, 0.485 ) )
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -486,6 +486,7 @@ nodeMenu.append( "/Utility/Context Variables", Gaffer.ContextVariables, searchTe
 nodeMenu.append( "/Utility/Delete Context Variables", Gaffer.DeleteContextVariables, searchText = "DeleteContextVariables" )
 nodeMenu.append( "/Utility/Time Warp", Gaffer.TimeWarp, searchText = "TimeWarp" )
 nodeMenu.append( "/Utility/Loop", Gaffer.Loop )
+nodeMenu.append( "/Utility/Spreadsheet", Gaffer.Spreadsheet )
 
 ## Miscellaneous UI
 ###########################################################################


### PR DESCRIPTION
This is a revamp of #3494, with Tom's notes on the node itself addressed, and with a completely rewritten UI which is much more fit for purpose. Below you can see it in action, coupled with a toy CollectScenes network to generate a light creation spreadsheet :

![image](https://user-images.githubusercontent.com/1133871/70647885-daf28400-1c41-11ea-94ee-b9e8f5c3627b.png)

The nice thing about this setup is that creating lots of lights doesn't involve wrangling huge numbers of nodes. The node graph itself remains entirely static, with the only thing that changes being the number of rows in the spreadsheet. And because it's a general purpose node, you can use the same workflow to manage the creation of _anything_. Or you can control PathFilters and their associated nodes with a row per match. There's also a short [blog post](http://blog.gafferhq.org/?p=514) on some less advanced usages that we think are going to be useful too.

There are many possibilities for further improvements to the UI, and I haven't hit every point on the [design ticket](https://github.com/GafferHQ/gaffer/issues/3222). But I believe this is at a good point to release as a version 1, with the intention of making further refinements based on feedback, and after we have EditScopes in the bag.