### PR TITLE
ParallelAlgoBinding : Release GIL in `popUIThreadCallHandler()`

### DIFF
--- a/src/GafferModule/ParallelAlgoBinding.cpp
+++ b/src/GafferModule/ParallelAlgoBinding.cpp
@@ -183,6 +183,12 @@ void pushUIThreadCallHandler( boost::python::object handler )
 	);
 }
 
+void popUIThreadCallHandler()
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	ParallelAlgo::popUIThreadCallHandler();
+}
+
 std::shared_ptr<BackgroundTask> callOnBackgroundThread( const Plug *subject, boost::python::object f )
 {
 	// The BackgroundTask we return will own the python function we
@@ -256,7 +262,7 @@ void GafferModule::bindParallelAlgo()
 
 	def( "callOnUIThread", &callOnUIThread );
 	def( "pushUIThreadCallHandler", &pushUIThreadCallHandler );
-	def( "popUIThreadCallHandler", &ParallelAlgo::popUIThreadCallHandler );
+	def( "popUIThreadCallHandler", &popUIThreadCallHandler );
 	def( "callOnBackgroundThread", &callOnBackgroundThread );
 
 }


### PR DESCRIPTION
Without this we could get a very rare hang in CI, with deadlock between the GIL and the mutex that ParallelAlgo uses to protect the handler stack.
