### PR TITLE
OpenGLRenderer : Classify visualisation renderables

### DIFF
--- a/include/GafferScene/Private/IECoreGLPreview/AttributeVisualiser.h
+++ b/include/GafferScene/Private/IECoreGLPreview/AttributeVisualiser.h
@@ -39,6 +39,8 @@
 
 #include "GafferScene/Export.h"
 
+#include "GafferScene/Private/IECoreGLPreview/Private/Visualiser.h"
+
 #include "IECoreGL/Renderable.h"
 
 #include "IECore/CompoundObject.h"
@@ -56,7 +58,7 @@ class GAFFERSCENE_API AttributeVisualiser : public IECore::RefCounted
 		IE_CORE_DECLAREMEMBERPTR( AttributeVisualiser )
 		~AttributeVisualiser() override;
 
-		virtual IECoreGL::ConstRenderablePtr visualise(
+		virtual Visualisations visualise(
 			const IECore::CompoundObject *attributes,
 			IECoreGL::ConstStatePtr &state
 		) const = 0;
@@ -64,10 +66,11 @@ class GAFFERSCENE_API AttributeVisualiser : public IECore::RefCounted
 		/// Registers an attribute visualiser
 		static void registerVisualiser( ConstAttributeVisualiserPtr visualiser );
 
-		/// Get all registered visualisations for the given attributes, by returning a renderable
-		/// group and some extra state. The return value value and/or the state may left null if
-		/// no registered visualisers do anything with these attributes
-		static IECoreGL::ConstRenderablePtr allVisualisations(
+		/// Get all registered visualisations for the given attributes, by
+		/// returning a map of renderable groups and some extra state. The
+		/// return value may be left empty and/or the state may left null if no
+		/// registered visualisers do anything with these attributes.
+		static Visualisations allVisualisations(
 			const IECore::CompoundObject *attributes,
 			IECoreGL::ConstStatePtr &state
 		);

--- a/include/GafferScene/Private/IECoreGLPreview/LightFilterVisualiser.h
+++ b/include/GafferScene/Private/IECoreGLPreview/LightFilterVisualiser.h
@@ -39,6 +39,8 @@
 
 #include "GafferScene/Export.h"
 
+#include "GafferScene/Private/IECoreGLPreview/Private/Visualiser.h"
+
 #include "IECoreGL/Renderable.h"
 
 #include "IECoreScene/ShaderNetwork.h"
@@ -67,7 +69,7 @@ class GAFFERSCENE_API LightFilterVisualiser : public IECore::RefCounted
 
 		/// Must be implemented by derived classes to visualise
 		/// the light filter contained within `filterShaderNetwork`.
-		virtual IECoreGL::ConstRenderablePtr visualise(
+		virtual Visualisations visualise(
 			const IECore::InternedString &attributeName,
 			const IECoreScene::ShaderNetwork *filterShaderNetwork,
 			const IECoreScene::ShaderNetwork *lightShaderNetwork,
@@ -84,10 +86,11 @@ class GAFFERSCENE_API LightFilterVisualiser : public IECore::RefCounted
 			ConstLightFilterVisualiserPtr visualiser
 		);
 
-		/// Get all registered visualisations for the given attributes, by returning a renderable
-		/// group and some extra state. The return value and/or the state may be left null if
+		/// Get all registered visualisations for the given attributes, by
+		/// returning a map of renderable groups and some extra state. The
+		/// return value may be left empty and/or the state may be left null if
 		/// no registered visualisers do anything with these attributes.
-		static IECoreGL::ConstRenderablePtr allVisualisations(
+		static Visualisations allVisualisations(
 			const IECore::CompoundObject *attributes,
 			IECoreGL::ConstStatePtr &state
 		);

--- a/include/GafferScene/Private/IECoreGLPreview/LightVisualiser.h
+++ b/include/GafferScene/Private/IECoreGLPreview/LightVisualiser.h
@@ -39,6 +39,8 @@
 
 #include "GafferScene/Export.h"
 
+#include "GafferScene/Private/IECoreGLPreview/Private/Visualiser.h"
+
 #include "IECoreGL/Renderable.h"
 
 #include "IECoreScene/ShaderNetwork.h"
@@ -67,7 +69,7 @@ class GAFFERSCENE_API LightVisualiser : public IECore::RefCounted
 
 		/// Must be implemented by derived classes to visualise
 		/// the light contained within `shaderNetwork`.
-		virtual IECoreGL::ConstRenderablePtr visualise(
+		virtual Visualisations visualise(
 			const IECore::InternedString &attributeName,
 			const IECoreScene::ShaderNetwork *shaderNetwork,
 			const IECore::CompoundObject *attributes,
@@ -83,10 +85,11 @@ class GAFFERSCENE_API LightVisualiser : public IECore::RefCounted
 			ConstLightVisualiserPtr visualiser
 		);
 
-		/// Get all registered visualisations for the given attributes, by returning a renderable
-		/// group and some extra state. The return value and/or the state may be left null if
+		/// Get all registered visualisations for the given attributes, by
+		/// returning a map of renderable groups and some extra state. The
+		/// return value may be left empty and/or the state may be left null if
 		/// no registered visualisers do anything with these attributes.
-		static IECoreGL::ConstRenderablePtr allVisualisations(
+		static Visualisations allVisualisations(
 			const IECore::CompoundObject *attributes,
 			IECoreGL::ConstStatePtr &state
 		);

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -63,7 +63,7 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 		StandardLightVisualiser();
 		~StandardLightVisualiser() override;
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
+		IECoreGLPreview::Visualisations visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
 
 		static void spotlightParameters( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, float &innerAngle, float &outerAngle, float &lensRadius );
 

--- a/src/GafferArnoldUI/BarndoorVisualiser.cpp
+++ b/src/GafferArnoldUI/BarndoorVisualiser.cpp
@@ -157,7 +157,7 @@ class BarndoorVisualiser final : public LightFilterVisualiser
 		BarndoorVisualiser();
 		~BarndoorVisualiser() override;
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
+		Visualisations visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
 
 	protected :
 
@@ -178,7 +178,7 @@ BarndoorVisualiser::~BarndoorVisualiser()
 {
 }
 
-IECoreGL::ConstRenderablePtr BarndoorVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
+Visualisations BarndoorVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
 {
 	IECoreGL::GroupPtr result = new IECoreGL::Group();
 
@@ -232,7 +232,10 @@ IECoreGL::ConstRenderablePtr BarndoorVisualiser::visualise( const IECore::Intern
 		result->setTransform( barndoorTrans );
 	}
 
-	return result;
+	Visualisations v;
+	v[ VisualisationType::Ornament ] = result;
+	return v;
+
 }
 
 } // namespace

--- a/src/GafferArnoldUI/DecayVisualiser.cpp
+++ b/src/GafferArnoldUI/DecayVisualiser.cpp
@@ -200,7 +200,7 @@ class DecayVisualiser final : public LightFilterVisualiser
 		DecayVisualiser();
 		~DecayVisualiser() override;
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
+		Visualisations visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
 
 	protected :
 
@@ -221,25 +221,28 @@ DecayVisualiser::~DecayVisualiser()
 {
 }
 
-IECoreGL::ConstRenderablePtr DecayVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
+Visualisations DecayVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
 {
-	IECoreGL::GroupPtr result = new IECoreGL::Group();
 
 	KnotVector knots;
 	getKnotsToVisualize( shaderNetwork, knots );
 
+	Visualisations v;
+
 	if( knots.empty() )
 	{
-		return result;
+		return v;
 	}
 
+	IECoreGL::GroupPtr result = new IECoreGL::Group();
 
 	for( KnotVector::size_type i = 0; i < knots.size(); ++i )
 	{
 		addKnot( result, knots[i] );
 	}
 
-	return result;
+	v[  VisualisationType::Geometry ] = result;
+	return v;
 }
 
 } // namespace

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -154,7 +154,7 @@ class GoboVisualiser final : public LightFilterVisualiser
 		GoboVisualiser();
 		~GoboVisualiser() override;
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
+		Visualisations visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
 
 	protected :
 
@@ -175,7 +175,7 @@ GoboVisualiser::~GoboVisualiser()
 {
 }
 
-IECoreGL::ConstRenderablePtr GoboVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
+Visualisations GoboVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
 {
 	IECoreGL::GroupPtr result = new IECoreGL::Group();
 
@@ -260,7 +260,9 @@ IECoreGL::ConstRenderablePtr GoboVisualiser::visualise( const IECore::InternedSt
 
 	result->addChild( new IECoreGL::QuadPrimitive( 1.0f, 1.0f ) );
 
-	return result;
+	Visualisations v;
+	v[ VisualisationType::Ornament ] = result;
+	return v;
 }
 
 } // namespace

--- a/src/GafferArnoldUI/LightBlockerVisualiser.cpp
+++ b/src/GafferArnoldUI/LightBlockerVisualiser.cpp
@@ -183,7 +183,7 @@ class LightBlockerVisualiser : public LightFilterVisualiser
 		LightBlockerVisualiser();
 		~LightBlockerVisualiser() override;
 
-		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *filterShaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
+		virtual Visualisations visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *filterShaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
 
 	protected :
 
@@ -211,7 +211,7 @@ LightBlockerVisualiser::~LightBlockerVisualiser()
 {
 }
 
-IECoreGL::ConstRenderablePtr LightBlockerVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *filterShaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
+Visualisations LightBlockerVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *filterShaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
 {
 	InternedString metadataTarget;
 	const IECore::CompoundData *shaderParameters = parametersAndMetadataTarget( attributeName, filterShaderNetwork, metadataTarget );
@@ -252,7 +252,9 @@ IECoreGL::ConstRenderablePtr LightBlockerVisualiser::visualise( const IECore::In
 		result->addChild( const_pointer_cast<IECoreGL::Renderable>( planeShape( shaderParameters ) ) );
 	}
 
-	return result;
+	Visualisations v;
+	v[ VisualisationType::Geometry ] = result;
+	return v;
 }
 
 IECoreGL::ConstRenderablePtr LightBlockerVisualiser::boxShape( const IECore::CompoundData *shaderParameters )

--- a/src/GafferScene/IECoreGLPreview/LightFilterVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/LightFilterVisualiser.cpp
@@ -87,14 +87,15 @@ void LightFilterVisualiser::registerLightFilterVisualiser( const IECore::Interne
 	lightFilterVisualisers()[AttributeAndShaderNames( attributeName, shaderName )] = visualiser;
 }
 
-IECoreGL::ConstRenderablePtr LightFilterVisualiser::allVisualisations( const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state )
+Visualisations LightFilterVisualiser::allVisualisations( const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state )
 {
+	Visualisations resultVis;
+
 	if( !attributes )
 	{
-		return nullptr;
+		return resultVis;
 	}
 
-	IECoreGL::GroupPtr resultGroup = nullptr;
 	IECoreGL::StatePtr resultState = nullptr;
 
 	/// This seems pretty expensive to do everywhere.
@@ -159,16 +160,11 @@ IECoreGL::ConstRenderablePtr LightFilterVisualiser::allVisualisations( const IEC
 		}
 
 		IECoreGL::ConstStatePtr curState = nullptr;
-		IECoreGL::ConstRenderablePtr curVis = visualiser->visualise( attributeName, filterShaderNetwork, lightShaderNetwork, attributes, curState );
+		const Visualisations curVis = visualiser->visualise( attributeName, filterShaderNetwork, lightShaderNetwork, attributes, curState );
 
-		if( curVis )
+		if( !curVis.empty() )
 		{
-			if( !resultGroup )
-			{
-				resultGroup = new IECoreGL::Group();
-			}
-			// resultGroup will be returned as const, so const-casting the children in order to add them is safe
-			resultGroup->addChild( const_cast<IECoreGL::Renderable*>( curVis.get() ) );
+			Private::collectVisualisations( curVis, resultVis );
 		}
 
 		if( curState )
@@ -182,5 +178,5 @@ IECoreGL::ConstRenderablePtr LightFilterVisualiser::allVisualisations( const IEC
 	}
 
 	state = resultState;
-	return resultGroup;
+	return resultVis;
 }

--- a/src/GafferScene/IECoreGLPreview/LightVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/LightVisualiser.cpp
@@ -85,14 +85,15 @@ void LightVisualiser::registerLightVisualiser( const IECore::InternedString &att
 	lightVisualisers()[AttributeAndShaderNames( attributeName, shaderName )] = visualiser;
 }
 
-IECoreGL::ConstRenderablePtr LightVisualiser::allVisualisations( const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state )
+Visualisations LightVisualiser::allVisualisations( const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state )
 {
+	Visualisations resultVis;
+
 	if( !attributes )
 	{
-		return nullptr;
+		return resultVis;
 	}
 
-	IECoreGL::GroupPtr resultGroup = nullptr;
 	IECoreGL::StatePtr resultState = nullptr;
 
 	/// This seems pretty expensive to do everywhere.
@@ -168,17 +169,11 @@ IECoreGL::ConstRenderablePtr LightVisualiser::allVisualisations( const IECore::C
 		}
 
 		IECoreGL::ConstStatePtr curState = nullptr;
-		IECoreGL::ConstRenderablePtr curVis = visualiser->visualise( it->first, shaderNetwork, attributes, curState );
+		const Visualisations curVis = visualiser->visualise( it->first, shaderNetwork, attributes, curState );
 
-		if( curVis )
+		if( !curVis.empty() )
 		{
-			if( !resultGroup )
-			{
-				resultGroup = new IECoreGL::Group();
-			}
-			// resultGroup will be returned as const, so const-casting the children in order to add them
-			// is safe
-			resultGroup->addChild( const_cast<IECoreGL::Renderable*>( curVis.get() ) );
+			Private::collectVisualisations( curVis, resultVis );
 		}
 
 		if( curState )
@@ -192,5 +187,5 @@ IECoreGL::ConstRenderablePtr LightVisualiser::allVisualisations( const IECore::C
 	}
 
 	state = resultState;
-	return resultGroup;
+	return resultVis;
 }

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -419,23 +419,13 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 	const IntData *textureMaxResolutionData = attributes->member<IntData>( "gl:visualiser:maxTextureResolution" );
 	const int textureMaxResolution = textureMaxResolutionData ? textureMaxResolutionData->readable() : std::numeric_limits<int>::max();
 
-	/// \todo: We should find a better way to opt out of expensive visualisations
-	///        (in particular for large environment light textures)
-	if( visualiserScale == 0 )
-	{
-		return {};
-	}
-
 	Imath::M44f topTransform;
 	if( orientation )
 	{
 		topTransform = orientation->readable();
 	}
 	geometry->setTransform( topTransform );
-
-	Imath::M44f ornamentsTransform = topTransform;
-	ornamentsTransform.scale( V3f( visualiserScale ) );
-	ornaments->setTransform( ornamentsTransform );
+	ornaments->setTransform( topTransform );
 
 	if( type && type->readable() == "environment" )
 	{

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -390,7 +390,7 @@ StandardLightVisualiser::~StandardLightVisualiser()
 {
 }
 
-IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
+Visualisations StandardLightVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
 {
 	const InternedString metadataTarget = metadataTargetForNetwork( shaderNetwork );
 	const IECore::CompoundData *shaderParameters = shaderNetwork->outputShader()->parametersData();
@@ -404,11 +404,12 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::I
 
 	const Color3f finalColor = color * intensity * pow( 2.0f, exposure );
 
-	GroupPtr result = new Group;
 	GroupPtr ornaments = new Group;  // Ornaments are affected by visualiser:scale while
 	GroupPtr geometry = new Group;   // geometry isn't as its size matters for rendering.
-	result->addChild( geometry );
-	result->addChild( ornaments );
+
+	Visualisations result;
+	result[ VisualisationType::Geometry ] = geometry;
+	result[ VisualisationType::Ornament ] = ornaments;
 
 	const FloatData *visualiserScaleData = attributes->member<FloatData>( "visualiser:scale" );
 	const float visualiserScale = visualiserScaleData ? visualiserScaleData->readable() : 1.0;
@@ -422,7 +423,7 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::I
 	///        (in particular for large environment light textures)
 	if( visualiserScale == 0 )
 	{
-		return result;
+		return {};
 	}
 
 	Imath::M44f topTransform;
@@ -430,9 +431,9 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::visualise( const IECore::I
 	{
 		topTransform = orientation->readable();
 	}
-	result->setTransform( topTransform );
+	geometry->setTransform( topTransform );
 
-	Imath::M44f ornamentsTransform;
+	Imath::M44f ornamentsTransform = topTransform;
 	ornamentsTransform.scale( V3f( visualiserScale ) );
 	ornaments->setTransform( ornamentsTransform );
 


### PR DESCRIPTION
In order to support improved visualisations as part of #3491, as well as the other more sophisticated presentations we have planned, we need to be able to de-couple ornaments from geometric visualisations.

This introduces two specific classes of visualiser renderables:

 - Geometry : Renderables will inherit the locations full transform.
 - Ornament : Renderables will only inherit the locations translation.
