### PR TITLE
IECoreArnoldPreviewTest : Compatible with Arnold 6

### DIFF
--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -53,23 +53,10 @@ import GafferScene
 class RendererTest( GafferTest.TestCase ) :
 
 	def assertReferSameNode( self, a, b ):
-		if not arnold.AiCheckAPIVersion( "5", "2", "0" ):
-			self.assertEqual( a, b )
-		else:
-			self.assertEqual( arnold.addressof( a.contents ), arnold.addressof( b.contents ) )
+		self.assertEqual( arnold.addressof( a.contents ), arnold.addressof( b.contents ) )
 
 	def assertReferDifferentNode( self, a, b ):
-		if not arnold.AiCheckAPIVersion( "5", "2", "0" ):
-			self.assertNotEqual( a, b )
-		else:
-			self.assertNotEqual( arnold.addressof( a.contents ), arnold.addressof( b.contents ) )
-
-	# \todo - delete all calls to this once we no longer need to support Arnold < 5.2
-	def arnoldCompat( self, a ):
-		if not arnold.AiCheckAPIVersion( "5", "2", "0" ):
-			return arnold.AtNode.from_address( a )
-		else:
-			return a
+		self.assertNotEqual( arnold.addressof( a.contents ), arnold.addressof( b.contents ) )
 
 	def testFactory( self ) :
 
@@ -320,11 +307,11 @@ class RendererTest( GafferTest.TestCase ) :
 		with IECoreArnold.UniverseBlock( writable = True ) :
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
-			target = self.arnoldCompat( arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "testPlane_scalarColor" ), "shader" ) )
+			target = arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "testPlane_scalarColor" ), "shader" )
 			source = arnold.AiNodeGetLink( target, "Kd_color" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( source ) ), "image" )
 
-			target = self.arnoldCompat( arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "testPlane_arrayColor" ), "shader" ) )
+			target = arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "testPlane_arrayColor" ), "shader" )
 			source = arnold.AiNodeGetLink( target, "color[0]" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( source ) ), "image" )
 
@@ -366,7 +353,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
-			outputNode = self.arnoldCompat( arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "test" ), "shader" ) )
+			outputNode = arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "test" ), "shader" )
 
 			componentIndex = ctypes.c_int()
 			sourceR = arnold.AiNodeGetLink( outputNode, "color.r", componentIndex )
@@ -422,7 +409,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
 
-			outputNode = self.arnoldCompat( arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "test" ), "shader" ) )
+			outputNode = arnold.AiNodeGetPtr( arnold.AiNodeLookUpByName( "test" ), "shader" )
 
 			pack = arnold.AiNodeGetLink( outputNode, "param_a" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( pack ) ), "osl" )
@@ -1328,8 +1315,8 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertReferSameNode( arnold.AiNodeGetPtr( plane1, "node" ), arnold.AiNodeGetPtr( plane2, "node" ) )
 			self.assertReferDifferentNode( arnold.AiNodeGetPtr( plane2, "node" ), arnold.AiNodeGetPtr( plane3, "node" ) )
 
-			polymesh1 = self.arnoldCompat( arnold.AiNodeGetPtr( plane1, "node" ) )
-			polymesh2 = self.arnoldCompat( arnold.AiNodeGetPtr( plane3, "node" ) )
+			polymesh1 = arnold.AiNodeGetPtr( plane1, "node" )
+			polymesh2 = arnold.AiNodeGetPtr( plane3, "node" )
 
 			self.assertTrue( arnold.AiNodeIs( polymesh1, "polymesh" ) )
 			self.assertTrue( arnold.AiNodeIs( polymesh2, "polymesh" ) )
@@ -1383,7 +1370,7 @@ class RendererTest( GafferTest.TestCase ) :
 					instance = arnold.AiNodeLookUpByName( interpolation + "-" + str( subdividePolygons ) )
 					self.assertTrue( arnold.AiNodeIs( instance, "ginstance" ) )
 
-					mesh = self.arnoldCompat( arnold.AiNodeGetPtr( instance, "node" ) )
+					mesh = arnold.AiNodeGetPtr( instance, "node" )
 					self.assertTrue( arnold.AiNodeIs( mesh, "polymesh" ) )
 
 					if subdividePolygons and interpolation == "linear" :
@@ -1425,7 +1412,7 @@ class RendererTest( GafferTest.TestCase ) :
 				instance = arnold.AiNodeLookUpByName( "mesh-" + ( uvSmoothing or "default" ) )
 				self.assertTrue( arnold.AiNodeIs( instance, "ginstance" ) )
 
-				mesh = self.arnoldCompat( arnold.AiNodeGetPtr( instance, "node" ) )
+				mesh = arnold.AiNodeGetPtr( instance, "node" )
 				self.assertTrue( arnold.AiNodeIs( mesh, "polymesh" ) )
 
 				self.assertEqual( arnold.AiNodeGetStr( mesh, "subdiv_uv_smoothing" ), uvSmoothing or "pin_corners" )
@@ -1461,19 +1448,14 @@ class RendererTest( GafferTest.TestCase ) :
 
 			instance = arnold.AiNodeLookUpByName( "myLight" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( instance ) ), "ginstance" )
-			mesh = self.arnoldCompat( arnold.AiNodeGetPtr( instance, "node" ) )
+			mesh = arnold.AiNodeGetPtr( instance, "node" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( mesh ) ), "polymesh" )
 
 			lights = self.__allNodes( type = arnold.AI_NODE_LIGHT )
 			self.assertEqual( len( lights ), 1 )
 			light = lights[0]
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( light ) ), "mesh_light" )
-			if not arnold.AiCheckAPIVersion( "5", "2", "0" ):
-				# \todo : We're comparing a raw pointer to a node reference, so we need to convert.
-				# After Arnold 5.2, AiNodeGetPtr returns a reference the same as everything else
-				self.assertEqual( arnold.AiNodeGetPtr( light, "mesh" ), ctypes.addressof( instance.contents ) )
-			else:
-				self.assertReferSameNode( arnold.AiNodeGetPtr( light, "mesh" ), instance )
+			self.assertReferSameNode( arnold.AiNodeGetPtr( light, "mesh" ), instance )
 
 	def testMeshLightsWithSharedShaders( self ) :
 
@@ -1529,7 +1511,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			self.assertReferSameNode( arnold.AiNodeGetPtr( instance1, "node" ), arnold.AiNodeGetPtr( instance2, "node" ) )
 
-			mesh = self.arnoldCompat( arnold.AiNodeGetPtr( instance1, "node" ) )
+			mesh = arnold.AiNodeGetPtr( instance1, "node" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( mesh ) ), "polymesh" )
 
 			lights = self.__allNodes( type = arnold.AI_NODE_LIGHT )
@@ -1602,7 +1584,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			n = arnold.AiNodeLookUpByName( "testPlane" )
 
-			add = self.arnoldCompat( arnold.AiNodeGetPtr( n, "shader" ) )
+			add = arnold.AiNodeGetPtr( n, "shader" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( add ) ), "add" )
 
 			spline = arnold.AiNodeGetLink( add, "input1" )
@@ -1655,7 +1637,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			n = arnold.AiNodeLookUpByName( "testPlane" )
 
-			noise = self.arnoldCompat( arnold.AiNodeGetPtr( n, "shader" ) )
+			noise = arnold.AiNodeGetPtr( n, "shader" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( noise ) ), "osl" )
 			self.assertEqual( arnold.AiNodeGetStr( noise, "shadername" ), "Pattern/Noise" )
 
@@ -1700,7 +1682,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			n = arnold.AiNodeLookUpByName( "testPlane" )
 
-			floatToColor = self.arnoldCompat( arnold.AiNodeGetPtr( n, "shader" ) )
+			floatToColor = arnold.AiNodeGetPtr( n, "shader" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( floatToColor ) ), "osl" )
 			self.assertEqual( arnold.AiNodeGetStr( floatToColor, "shadername" ), "Conversion/FloatToColor" )
 
@@ -1864,7 +1846,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 				node = arnold.AiNodeLookUpByName( name )
 				if arnold.AiNodeIs( node, "ginstance" ) :
-					shape = self.arnoldCompat( arnold.AiNodeGetPtr( node, "node" ) )
+					shape = arnold.AiNodeGetPtr( node, "node" )
 				else :
 					shape = node
 
@@ -2027,7 +2009,7 @@ class RendererTest( GafferTest.TestCase ) :
 				for an, a in attributes.items() :
 
 					instance = arnold.AiNodeLookUpByName( pn + "_" + an )
-					shape = self.arnoldCompat( arnold.AiNodeGetPtr( instance, "node" ) )
+					shape = arnold.AiNodeGetPtr( instance, "node" )
 
 					stepSize = a.get( "ai:shape:step_size" )
 					stepSize = stepSize.value if stepSize is not None else 0
@@ -2127,7 +2109,7 @@ class RendererTest( GafferTest.TestCase ) :
 				for an, a in attributes.items() :
 
 					instance = arnold.AiNodeLookUpByName( pn + "_" + an )
-					shape = self.arnoldCompat( arnold.AiNodeGetPtr( instance, "node" ) )
+					shape = arnold.AiNodeGetPtr( instance, "node" )
 
 					volumePadding = a.get( "ai:shape:volume_padding" )
 					volumePadding = volumePadding.value if volumePadding is not None else 0
@@ -2181,7 +2163,7 @@ class RendererTest( GafferTest.TestCase ) :
 			instance = arnold.AiNodeLookUpByName( "test" )
 			self.assertTrue( arnold.AiNodeIs( instance, "ginstance" ) )
 
-			shape = self.arnoldCompat( arnold.AiNodeGetPtr( instance, "node" ) )
+			shape = arnold.AiNodeGetPtr( instance, "node" )
 			self.assertTrue( arnold.AiNodeIs( shape, "volume" ) )
 			self.assertEqual( arnold.AiNodeGetFlt( shape, "step_size" ), 0.25 )
 
@@ -2317,14 +2299,9 @@ class RendererTest( GafferTest.TestCase ) :
 
 		with open( self.temporaryDirectory() + "/test/test_stats.json", "r" ) as statsHandle:
 			stats = json.load( statsHandle )["render 0000"]
-			if arnold.AiCheckAPIVersion( "5", "2", "2" ) :
-				self.assertTrue( "microseconds" in stats["scene creation time"] )
-				self.assertTrue( "microseconds" in stats["frame time"] )
-				self.assertTrue( "peak CPU memory used" in stats )
-			else:
-				self.assertTrue( "scene creation time microseconds" in stats )
-				self.assertTrue( "frame time microseconds" in stats )
-				self.assertTrue( "memory consumed MB" in stats )
+			self.assertTrue( "microseconds" in stats["scene creation time"] )
+			self.assertTrue( "microseconds" in stats["frame time"] )
+			self.assertTrue( "peak CPU memory used" in stats )
 
 			self.assertTrue( "ray counts" in stats )
 
@@ -2456,7 +2433,7 @@ class RendererTest( GafferTest.TestCase ) :
 			IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "atmosphere_volume", "ai:shader" ) }, output = "output" )
 		)
 
-		shader = self.arnoldCompat( arnold.AiNodeGetPtr( options, "atmosphere" ) )
+		shader = arnold.AiNodeGetPtr( options, "atmosphere" )
 		self.assertEqual(
 			arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( shader ) ),
 			"atmosphere_volume",
@@ -2480,7 +2457,7 @@ class RendererTest( GafferTest.TestCase ) :
 			IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "flat", "ai:shader" ) }, output = "output" )
 		)
 
-		shader = self.arnoldCompat( arnold.AiNodeGetPtr( options, "background" ) )
+		shader = arnold.AiNodeGetPtr( options, "background" )
 		self.assertEqual(
 			arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( shader ) ),
 			"flat",
@@ -2591,7 +2568,7 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertEqual( numVDBs, 1 )
 
 			vdbInstance = arnold.AiNodeLookUpByName( "test_vdb" )
-			vdbShape = self.arnoldCompat( arnold.AiNodeGetPtr( vdbInstance, "node" ) )
+			vdbShape = arnold.AiNodeGetPtr( vdbInstance, "node" )
 
 			self.assertEqual( arnold.AiNodeGetFlt( vdbShape, "velocity_scale" ), 10 )
 			self.assertEqual( arnold.AiNodeGetFlt( vdbShape, "velocity_fps" ), 25 )
@@ -2682,7 +2659,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 			nodePtr = arnold.AiNodeGetPtr( instanceNode, "node" )
 			self.assertReferSameNode( nodePtr, arnold.AiNodeGetPtr( firstInstanceNode, "node" ) )
-			self.assertEqual( arnold.AiNodeGetByte( self.arnoldCompat( nodePtr ), "visibility" ), 0 )
+			self.assertEqual( arnold.AiNodeGetByte( nodePtr, "visibility" ), 0 )
 
 	def __assertNotInstanced( self, *names ) :
 


### PR DESCRIPTION
We had been using `arnold.AiCheckAPIVersion( "5", "2", "0" )` to check if the Arnold version was compatible with 5.2, because we needed at least 5.2, where a big change to the Python API happened.  What I haven't realized is that this function always returns false when comparing major versions ... which makes it truly obnoxious that SolidAngle just bumped their major version number to 6 as a PR stunt, despite no significant API changes.

The quickest fix was just removing the compatibility for Arnold version 5.1 and older - I don't think anyone who is running the Gaffer tests should have any issue using version 5.2 or later?

While looking at the tests, I did notice some disturbing warnings in the Arnold console output - in particular, the value of ai:profileFileName set by testStatsAndLog seems to leak into the other tests in that file, which seems to indicate an actual problem ... but that's unrelated to this PR, and can be dealt with later.