### PR TITLE
IECoreArnoldPreview::Renderer : Use Arnold's new progressive rendering API

### DIFF
--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -59,6 +59,8 @@ def __samplingSummary( plug ) :
 	info = []
 	if plug["aaSamples"]["enabled"].getValue() :
 		info.append( "AA %d" % plug["aaSamples"]["value"].getValue() )
+	if plug["progressiveMinAASamples"]["enabled"].getValue() :
+		info.append( "Min AA %d" % plug["progressiveMinAASamples"]["value"].getValue() )
 	if plug["giDiffuseSamples"]["enabled"].getValue() :
 		info.append( "Diffuse %d" % plug["giDiffuseSamples"]["value"].getValue() )
 	if plug["giSpecularSamples"]["enabled"].getValue() :
@@ -322,6 +324,22 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Sampling",
 			"label", "AA Samples",
+
+		],
+
+		"options.progressiveMinAASamples" : [
+
+			"description",
+			"""
+			Controls the number of rays per pixel
+			for the first low quality pass of
+			progressive rendering.  -4 will start
+			with large squares, 1 will start one
+			sample for every pixel.
+			""",
+
+			"layout:section", "Sampling",
+			"label", "Progressive Min AA Samples",
 
 		],
 

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -57,6 +57,7 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	// Sampling parameters
 
 	options->addChild( new Gaffer::NameValuePlug( "ai:AA_samples", new IECore::IntData( 3 ), false, "aaSamples" ) );
+	options->addChild( new Gaffer::NameValuePlug( "ai:progressive_min_AA_samples", new IECore::IntData( -4 ), false, "progressiveMinAASamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:GI_diffuse_samples", new IECore::IntData( 2 ), false, "giDiffuseSamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:GI_specular_samples", new IECore::IntData( 2 ), false, "giSpecularSamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:GI_transmission_samples", new IECore::IntData( 2 ), false, "giTransmissionSamples" ) );


### PR DESCRIPTION
It sounds like we're pretty close to focussing on Arnold 5.4 or Arnold 6, so maybe it's now actually time to consider this.

This should be a bit more performant, and we also now expose the progressive_min_aa_samples hint as an option

Appears to actually be reliable as of Arnold-5.4
In earlier Arnold versions, the AiRenderAbort( AI_BLOCKING ) call would not reliably halt the render, so some edits would be ignored.