### PR TITLE
Set expression enhancements

### DIFF
--- a/doc/source/Reference/ScriptingReference/SetExpressions/index.md
+++ b/doc/source/Reference/ScriptingReference/SetExpressions/index.md
@@ -1,13 +1,13 @@
 Set Expressions
 ===============
 
-Set expressions are a convenient way to build sets from other sets or locations. For the following examples we will assume that these objects are available in the scene:
+Set expressions are a convenient way to build sets from other sets or locations. For the following examples we will assume that the scene has the following hierarchy :
 
-* A
-* B
-* C
-* D
-* E
+- A
+- B
+- C
+- D
+  - E
 
 Set memberships in this imaginary scene are as follows.
 
@@ -28,6 +28,12 @@ Operator            Behaviour
 \|                  Union, unites two sets
 &                   Intersection, intersects two sets
 \-                  Difference, removes elements from sets
+in                  Descendant query, selects locations from
+                    one set which are parented under locations
+                    in another
+containing          Ancestor query, selections locations from
+                    one set which are parents of locations
+                    in another
 =================== ======================================
 ```
 
@@ -35,22 +41,24 @@ Simple Examples
 ---------------
 
 ```eval_rst
-=================== ==============================
-SetExpression       Objects in resulting set                        
-=================== ==============================
-set1                A B C
-set1 \| set2        A B C D
-set1 & set2         B C
-set1 \- set2        A
-set1 \- C           A B
-=================== ==============================
+===================== ==============================
+SetExpression         Objects in resulting set
+===================== ==============================
+set1                  A B C
+set1 \| set2          A B C D
+set1 & set2           B C
+set1 \- set2          A
+set1 \- C             A B
+set4 in set2          E
+set2 containing set4  D
+===================== ==============================
 ```
 
 The last example illustrates the use of objects in set expressions. Gaffer will interpret them as a set with the specified object as its sole member. Gaffer will also conveniently interpret space separated lists of sets and objects as a set that contains all the elements in the list (think of it as Gaffer inserting the \| for you).
 
 ```eval_rst
 =================== ==============================
-SetExpression       Objects in resulting set                        
+SetExpression       Objects in resulting set
 =================== ==============================
 set1 set2           A B C D
 set1 D              A B C D
@@ -61,7 +69,7 @@ Note that you can build sets on-the-fly to be used in the expression by using th
 
 ```eval_rst
 ==================== ==============================
-SetExpression        Objects in resulting set                        
+SetExpression        Objects in resulting set
 ==================== ==============================
 set1 \| (D E)        A B C D E
 set1 & (A B D)       A B
@@ -72,11 +80,11 @@ set1 \- (B C)        A
 Operator Precedence
 -------------------
 
-Operations in the expression are executed in the following order: difference before intersection before union. The following examples demonstrate this in action.
+Operations in the expression are executed in the following order : `-`, `&`, `containing` and then `in`. The following examples demonstrate this in action.
 
 ```eval_rst
 ==================== ==============================
-SetExpression        Objects in resulting set                        
+SetExpression        Objects in resulting set
 ==================== ==============================
 set1 \| set3 & set4  A B C E
 set1 \- set2 \| set4 A E
@@ -88,7 +96,7 @@ Parenthesis can be used to explicitly change the order of evaluation. The follow
 
 ```eval_rst
 ====================== ==============================
-SetExpression          Objects in resulting set                        
+SetExpression          Objects in resulting set
 ====================== ==============================
 (set1 \| set3) & set4  E
 set1 \- (set2 \| set4) A

--- a/python/GafferSceneTest/SetAlgoTest.py
+++ b/python/GafferSceneTest/SetAlgoTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import re
 import functools
 
 import IECore
@@ -286,6 +287,18 @@ class SetAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.assertCorrectEvaluation( setB["out"], "containingThings", setB["out"].set( "containingThings" ).value.paths() )
 		self.assertCorrectEvaluation( setB["out"], "B in containing*", setB["paths"].getValue() )
 
+	def testWildcardsInObjectNames( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		for expression in [
+			"/*",
+			"/spher[ef]",
+			"/spher?",
+		] :
+			with self.assertRaisesRegexp( RuntimeError, 'Object name "{0}" contains wildcards'.format( re.escape( expression ) ) ) :
+				GafferScene.SetAlgo.evaluateSetExpression( expression, sphere["out"] )
+
 	def assertCorrectEvaluation( self, scenePlug, expression, expectedContents ) :
 
 		result = set( GafferScene.SetAlgo.evaluateSetExpression( expression, scenePlug ).paths() )
@@ -293,4 +306,3 @@ class SetAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 if __name__ == "__main__":
 	unittest.main()
-

--- a/src/GafferScene/SetAlgo.cpp
+++ b/src/GafferScene/SetAlgo.cpp
@@ -64,18 +64,6 @@ namespace
 struct BinaryOp;
 struct Nil {};
 
-// Wrap a string into a SetName struct that gives it semantic meaning
-struct SetName
-{
-	std::string name;
-};
-
-// Wrap a string into an ObjectName struct that gives it semantic meaning
-struct ObjectName
-{
-	std::string name;
-};
-
 // Determine which Ops are supported in SetExpressions
 // and provide a way to print them for debugging.
 enum Op { And, Or, AndNot, In, Containing };
@@ -103,8 +91,7 @@ struct ExpressionAst
 	typedef
 	boost::variant<
 		Nil,
-		SetName,
-		ObjectName,
+		std::string, // identifier
 		boost::recursive_wrapper<ExpressionAst>,
 		boost::recursive_wrapper<BinaryOp>
 		>
@@ -171,16 +158,6 @@ struct AstPrinter
 		stream << n;
 	}
 
-	void operator()( const ObjectName &n ) const
-	{
-		stream << n.name;
-	}
-
-	void operator()( const SetName &n ) const
-	{
-		stream << n.name;
-	}
-
 	void operator()( const ExpressionAst &ast ) const
 	{
 		boost::apply_visitor( *this, ast.expr );
@@ -223,43 +200,51 @@ struct AstEvaluator
 	{
 	}
 
-	result_type operator()( const SetName &set ) const
+	result_type operator()( const std::string &identifier ) const
 	{
-		if( !StringAlgo::hasWildcards( set.name ) )
+		if( identifier[0] == '/' )
 		{
-			return m_scene->set( set.name )->readable();
-		}
-
-		result_type result;
-
-		IECore::ConstInternedStringVectorDataPtr setNamesData = m_scene->setNamesPlug()->getValue();
-		const std::vector<IECore::InternedString> &setNames = setNamesData->readable();
-		if( setNames.empty() )
-		{
+			// Object name
+			PathMatcher result;
+			if( StringAlgo::hasWildcards( identifier ) )
+			{
+				throw IECore::Exception( boost::str( boost::format( "Object name \"%1%\" contains wildcards" ) % identifier ) );
+			}
+			result.addPath( identifier );
 			return result;
 		}
-
-		ScenePlug::SetScope setScope( Context::current() );
-		for( const IECore::InternedString &setName : setNames )
+		else
 		{
-			if( !StringAlgo::match( setName.string(), set.name ) )
+			// Set name
+
+			if( !StringAlgo::hasWildcards( identifier ) )
 			{
-				continue;
+				return m_scene->set( identifier )->readable();
 			}
 
-			setScope.setSetName( setName );
-			ConstPathMatcherDataPtr setData = m_scene->setPlug()->getValue();
-			result.addPaths( setData->readable() );
+			result_type result;
+
+			IECore::ConstInternedStringVectorDataPtr setNamesData = m_scene->setNamesPlug()->getValue();
+			const std::vector<IECore::InternedString> &setNames = setNamesData->readable();
+			if( setNames.empty() )
+			{
+				return result;
+			}
+
+			ScenePlug::SetScope setScope( Context::current() );
+			for( const IECore::InternedString &setName : setNames )
+			{
+				if( !StringAlgo::match( setName.string(), identifier ) )
+				{
+					continue;
+				}
+
+				setScope.setSetName( setName );
+				ConstPathMatcherDataPtr setData = m_scene->setPlug()->getValue();
+				result.addPaths( setData->readable() );
+			}
+			return result;
 		}
-
-		return result;
-	}
-
-	result_type operator()( const ObjectName &object ) const
-	{
-		PathMatcher result;
-		result.addPath( object.name );
-		return result;
 	}
 
 	result_type operator()( const ExpressionAst &ast ) const
@@ -337,41 +322,45 @@ struct AstHasher
 	{
 	}
 
-	void operator()( const ObjectName &n )
+	void operator()( const std::string &identifier )
 	{
-		m_hash.append( n.name );
-	}
-
-	void operator()( const SetName &n )
-	{
-		if( !m_scene )
+		if( identifier[0] == '/' )
 		{
-			throw IECore::Exception( "SetAlgo: Invalid scene given. Can not hash set expression." );
+			// Object name
+			m_hash.append( identifier );
 		}
-
-		if( !StringAlgo::hasWildcards( n.name ) )
+		else
 		{
-			m_hash.append( m_scene->setHash( n.name ) );
-			return;
-		}
-
-		IECore::ConstInternedStringVectorDataPtr setNamesData = m_scene->setNamesPlug()->getValue();
-		const std::vector<IECore::InternedString> &setNames = setNamesData->readable();
-		if( setNames.empty() )
-		{
-			return;
-		}
-
-		ScenePlug::SetScope setScope( Context::current() );
-		for( const IECore::InternedString &setName : setNames )
-		{
-			if( !StringAlgo::match( setName.string(), n.name ) )
+			// Set name
+			if( !m_scene )
 			{
-				continue;
+				throw IECore::Exception( "SetAlgo: Invalid scene given. Can not hash set expression." );
 			}
 
-			setScope.setSetName( setName );
-			m_hash.append( m_scene->setPlug()->hash() );
+			if( !StringAlgo::hasWildcards( identifier ) )
+			{
+				m_hash.append( m_scene->setHash( identifier ) );
+				return;
+			}
+
+			IECore::ConstInternedStringVectorDataPtr setNamesData = m_scene->setNamesPlug()->getValue();
+			const std::vector<IECore::InternedString> &setNames = setNamesData->readable();
+			if( setNames.empty() )
+			{
+				return;
+			}
+
+			ScenePlug::SetScope setScope( Context::current() );
+			for( const IECore::InternedString &setName : setNames )
+			{
+				if( !StringAlgo::match( setName.string(), identifier ) )
+				{
+					continue;
+				}
+
+				setScope.setSetName( setName );
+				m_hash.append( m_scene->setPlug()->hash() );
+			}
 		}
 	}
 
@@ -412,7 +401,7 @@ struct ExpressionGrammar : qi::grammar<Iterator, ExpressionAst(), ascii::space_t
 			 expression ->   andExpr  ( '|' andExpr | andExpr  )
 			 andExpr    ->   andNotExpr '&' andNotExpr
 			 andNotExpr ->   element    '-' element
-			 element    ->   set | object | '(' expression ')'
+			 element    ->   identifier | '(' expression ')'
 
 			 This gives us implicit operator precedence in this order: -, &, |
 			 It also supports space separated lists (implicit OR).
@@ -451,20 +440,14 @@ struct ExpressionGrammar : qi::grammar<Iterator, ExpressionAst(), ascii::space_t
 			    );
 
 		element =
-			  objectName                                               [_val  = _1]
-			| setName                                                  [_val  = _1]
+			  identifier                                               [_val  = _1]
 			| lit('(') >> expression                                   [_val  = _1] >> lit(')');
 
-		const char *setNameCharacters = "a-zA-Z_0-9:.*?[]!\\";
+		const char *identifierCharacters = "a-zA-Z_0-9/:.*?[]!\\";
+		identifier %= !reservedWords >> +char_( identifierCharacters );
 
-		setName %= setNameToken;
-		setNameToken %= !reservedWords >> +char_( setNameCharacters );
-
-		objectName %= objectNameToken;
-		objectNameToken %= char_( "/" ) >> *char_( "a-zA-Z_0-9/:." );
-
-		inKeyword = distinct( char_( setNameCharacters ) )["in"];
-		containingKeyword = distinct( char_( setNameCharacters ) )["containing"];
+		inKeyword = distinct( char_( identifierCharacters ) )["in"];
+		containingKeyword = distinct( char_( identifierCharacters ) )["containing"];
 		reservedWords = inKeyword | containingKeyword;
 
 		// these have no effect unless BOOST_SPIRIT_DEBUG is defined
@@ -474,14 +457,11 @@ struct ExpressionGrammar : qi::grammar<Iterator, ExpressionAst(), ascii::space_t
 		BOOST_SPIRIT_DEBUG_NODE(andNotExpression);
 		BOOST_SPIRIT_DEBUG_NODE(andExpression);
 		BOOST_SPIRIT_DEBUG_NODE(orExpression);
-		BOOST_SPIRIT_DEBUG_NODE(setName);
-		BOOST_SPIRIT_DEBUG_NODE(objectName);
+		BOOST_SPIRIT_DEBUG_NODE(identifier);
 	}
 
 	qi::rule<Iterator> inKeyword, containingKeyword, reservedWords;
-	qi::rule<Iterator, SetName()> setName;
-	qi::rule<Iterator, ObjectName()> objectName;
-	qi::rule<Iterator, std::string()> setNameToken, objectNameToken;
+	qi::rule<Iterator, std::string()> identifier;
 	qi::rule<Iterator, ExpressionAst(), ascii::space_type> expression, inExpression, containingExpression, andNotExpression, andExpression, orExpression, element;
 };
 
@@ -532,16 +512,6 @@ void expressionToAST( const std::string &setExpression, ExpressionAst &ast)
 }
 
 } // namespace
-
-BOOST_FUSION_ADAPT_STRUCT(
-	ObjectName,
-	(std::string, name)
-)
-
-BOOST_FUSION_ADAPT_STRUCT(
-	SetName,
-	(std::string, name)
-)
 
 namespace GafferScene
 {

--- a/src/GafferScene/SetAlgo.cpp
+++ b/src/GafferScene/SetAlgo.cpp
@@ -59,6 +59,7 @@ namespace ascii = boost::spirit::ascii;
 
 namespace
 {
+
 struct BinaryOp;
 struct Nil {};
 
@@ -67,7 +68,6 @@ struct SetName
 {
 	std::string name;
 };
-
 
 // Wrap a string into an ObjectName struct that gives it semantic meaning
 struct ObjectName
@@ -83,12 +83,12 @@ std::ostream & operator<<( std::ostream &out, const Op &op )
 {
 	switch( op )
 	{
-	case Or :
-		out << "|"; break;
-	case And :
-		out << "&"; break;
-	case AndNot :
-		out << "-"; break;
+		case Or :
+			out << "|"; break;
+		case And :
+			out << "&"; break;
+		case AndNot :
+			out << "-"; break;
 	}
 	return out;
 }
@@ -124,8 +124,9 @@ struct BinaryOp
 	BinaryOp(
 		const ExpressionAst &left,
 		Op op,
-		const ExpressionAst &right )
-		: left( left ), op(op), right( right ) {}
+		const ExpressionAst &right
+	)
+		: left( left ), op( op ), right( right ) {}
 
 	ExpressionAst left;
 	Op op;


### PR DESCRIPTION
- Added `in` operator. The expression `A in B` selects all locations from set A which are descendants of a location from set B.
- Added `containing` operator. The expression `A containing B` selects all locations from set A which are ancestors of a location from set B.
- Removed restrictions on the allowable characters at the start of a set name.

I was a bit out of my depth with the `boost::spirit` stuff so please take a close look! For that same reason, along with other pressing priorities, I haven't tried to tackle the related requests of `and/or` synonyms and escaping.