### PR TITLE
GafferScene : Conform visualiser attributes

### DIFF
--- a/include/GafferScene/Light.h
+++ b/include/GafferScene/Light.h
@@ -39,6 +39,8 @@
 
 #include "GafferScene/ObjectSource.h"
 
+#include "Gaffer/CompoundDataPlug.h"
+
 #include "IECoreScene/ShaderNetwork.h"
 
 namespace GafferScene
@@ -81,10 +83,8 @@ class GAFFERSCENE_API Light : public ObjectSource
 		virtual void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
 		virtual IECoreScene::ConstShaderNetworkPtr computeLight( const Gaffer::Context *context ) const = 0;
 
-		Gaffer::FloatPlug *visualiserScalePlug();
-		const Gaffer::FloatPlug *visualiserScalePlug() const;
-		Gaffer::BoolPlug *visualiserShadedPlug();
-		const Gaffer::BoolPlug *visualiserShadedPlug() const;
+		Gaffer::CompoundDataPlug *visualiserAttributesPlug();
+		const Gaffer::CompoundDataPlug *visualiserAttributesPlug() const;
 
 	private :
 

--- a/python/GafferSceneTest/LightTest.py
+++ b/python/GafferSceneTest/LightTest.py
@@ -217,5 +217,32 @@ class LightTest( GafferSceneTest.SceneTestCase ) :
 			imath.Box3f( imath.V3f( -0.5 ), imath.V3f( 0.5 ) ),
 		)
 
+	def testVisualisationAttributes( self ) :
+
+		l = GafferSceneTest.TestLight()
+
+		# Test not set by default
+
+		a = l["out"].attributes( "/light" )
+
+		self.assertFalse( "gl:light:drawingMode" in a.keys() )
+		self.assertFalse( "gl:visualiser:ornamentScale" in a.keys() )
+		self.assertFalse( "gl:visualiser:maxTextureResolution" in a.keys() )
+
+		# Test attribute mapping
+
+		l["visualiserAttributes"]["lightDrawingMode"]["enabled"].setValue( True )
+		l["visualiserAttributes"]["lightDrawingMode"]["value"].setValue( "color" )
+		l["visualiserAttributes"]["ornamentScale"]["enabled"].setValue( True )
+		l["visualiserAttributes"]["ornamentScale"]["value"].setValue( 12.3 )
+		l["visualiserAttributes"]["maxTextureResolution"]["enabled"].setValue( True )
+		l["visualiserAttributes"]["maxTextureResolution"]["value"].setValue( 123 )
+
+		a = l["out"].attributes( "/light" )
+
+		self.assertEqual( a["gl:light:drawingMode"], IECore.StringData( "color" ) )
+		self.assertEqual( a["gl:visualiser:ornamentScale"], IECore.FloatData( 12.3 ) )
+		self.assertEqual( a["gl:visualiser:maxTextureResolution"], IECore.IntData( 123 ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -91,27 +91,55 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"visualiserScale" : [
+		"visualiserAttributes" : [
 
 			"description",
 			"""
-			The scale of the visualisation in the viewport.
+			Attributes that affect the visualisation of this Light in the Viewer.
 			""",
 
 			"layout:section", "Visualisation",
 
 		],
 
-		"visualiserShaded" : [
+		"visualiserAttributes.lightDrawingMode" : [
 
 			"description",
 			"""
-			Disable to restrict visualisations of this light to wireframe outlines.
+			Controls how lights are presented in the Viewer.
 			""",
 
-			"label", "Shaded",
-			"layout:section", "Visualisation",
+			"label", "Light Drawing Mode",
 
+		],
+
+		"visualiserAttributes.maxTextureResolution" : [
+
+			"description",
+			"""
+			Visualisers that load textures will respect this setting to
+			limit their resolution.
+			""",
+
+		],
+
+		"visualiserAttributes.ornamentScale" : [
+
+			"description",
+			"""
+			Scales non-geometric visualisations in the viewport to make them
+			easier to work with.
+			""",
+
+		],
+
+		"visualiserAttributes.lightDrawingMode.value" : [
+
+			"preset:Wireframe", "wireframe",
+			"preset:Color", "color",
+			"preset:Texture", "texture",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget"
 		]
 
 	}

--- a/python/GafferSceneUI/OpenGLAttributesUI.py
+++ b/python/GafferSceneUI/OpenGLAttributesUI.py
@@ -362,18 +362,55 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"attributes.maxTextureResolution" : [
+		"attributes.visualiserOrnamentScale" : [
 
 			"description",
 			"""
-			Light visualisers that load textures will respect this setting to
+			Scales non-geometric visualisations in the viewport to make them
+			easier to work with.
+			""",
+
+			"layout:section", "Visualisers",
+			"label", "Ornament Scale",
+
+		],
+
+		"attributes.visualiserMaxTextureResolution" : [
+
+			"description",
+			"""
+			Visualisers that load textures will respect this setting to
 			limit their resolution.
 			""",
 
-			"layout:section", "Light Visualisers",
+			"layout:section", "Visualisers",
 			"label", "Max Texture Resolution",
 
 		],
+
+		"attributes.lightDrawingMode" : [
+
+			"description",
+			"""
+			Controls how lights are presented in the Viewer.
+			""",
+
+			"layout:section", "Visualisers",
+			"label", "Light Drawing Mode",
+
+		],
+
+		"attributes.lightDrawingMode.value" : [
+
+			"preset:Wireframe", "wireframe",
+			"preset:Color", "color",
+			"preset:Texture", "texture",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget"
+
+		],
+
+
 
 	}
 

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -244,7 +244,62 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 			}
 		)
 
+		m.append( "/__visualiserDivider__", { "divider" : True } )
+
+		visScaleIsOther = True
+		visScalePlug = self.getPlug()["visualiserOrnamentScale"]
+		for scale in ( 1, 10, 100 ) :
+			isSelected = visScalePlug.getValue() == scale
+			if isSelected :
+				visScaleIsOther = False
+			m.append(
+				"/Visualiser Scale/%d" % scale,
+				{
+					"command" : functools.partial( lambda s, _ : visScalePlug.setValue( s ), scale ),
+					"checkBox" : isSelected
+				}
+			)
+
+		m.append( "/Visualiser Scale/__divider__", { "divider" : True } )
+		m.append(
+			"/Visualiser Scale/Other...",
+			{
+				"command" : functools.partial(  Gaffer.WeakMethod( self.__popupPlugWidget ), visScalePlug, "Other Scale" ),
+				"checkBox" : visScaleIsOther
+			}
+		)
+
 		return m
+
+	def __popupPlugWidget( self, plug, title, *unused ) :
+
+		_PlugWidgetDialog( plug, title ).waitForClose( parentWindow = self.ancestor( GafferUI.Window ) )
+
+class _PlugWidgetDialog( GafferUI.Dialogue ) :
+
+	def __init__( self, plug, title="", **kw ) :
+
+		self.__initialValue = plug.getValue()
+
+		if not title :
+			title = IECore.CamelCase.toSpaced( plug.getName() )
+
+		GafferUI.Dialogue.__init__( self, title, sizeMode=GafferUI.Window.SizeMode.Fixed, **kw )
+
+		self.__plugWidget = GafferUI.PlugValueWidget.create( plug )
+		self._setWidget( self.__plugWidget )
+
+		self.__cancelButton = self._addButton( "Cancel" )
+		self.__confirmButton = self._addButton( "OK" )
+
+	def waitForClose( self, **kw ) :
+
+		button = self.waitForButton( **kw )
+		if button is self.__cancelButton :
+			self.__plugWidget.getPlug().setValue( self.__initialValue )
+			return False
+		else :
+			return True
 
 ##########################################################################
 # _ShadingModePlugValueWidget

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -215,6 +215,16 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		m.append( "/ComponentsDivider", { "divider" : True } )
 
+		lightDrawingModePlug = self.getPlug()["light"]["drawingMode"]
+		for mode in ( "wireframe", "color", "texture" ) :
+			m.append(
+				"/Lights/" + IECore.CamelCase.toSpaced( mode ),
+				{
+					"command" : functools.partial( lambda m, _ : lightDrawingModePlug.setValue( m ), mode ),
+					"checkBox" : lightDrawingModePlug.getValue() == mode
+				}
+			)
+
 		for n in ( "useGLLines", "interpolate" ) :
 			plug = self.getPlug()["curvesPrimitive"][n]
 			m.append(

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -153,7 +153,7 @@ class OpenGLAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 		OpenGLAttributes( const IECore::CompoundObject *attributes )
 		{
-			const FloatData *ornamentScaleData = attributes->member<FloatData>( "visualiser:scale" );
+			const FloatData *ornamentScaleData = attributes->member<FloatData>( "gl:visualiser:ornamentScale" );
 			m_ornamentScale = ornamentScaleData ? ornamentScaleData->readable() : 1.0;
 
 			m_state = static_pointer_cast<const State>(

--- a/src/GafferScene/Light.cpp
+++ b/src/GafferScene/Light.cpp
@@ -38,6 +38,7 @@
 
 #include "GafferScene/SceneNode.h"
 
+#include "Gaffer/NumericPlug.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/TransformPlug.h"
 
@@ -64,8 +65,13 @@ Light::Light( const std::string &name )
 	addChild( new BoolPlug( "defaultLight", Gaffer::Plug::Direction::In, true ) );
 
 	Gaffer::CompoundDataPlug *visualiserAttr = new CompoundDataPlug( "visualiserAttributes" );
-	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", new IECore::FloatData( 1.0f ), false, "ornamentScale" ) );
-	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", new IECore::IntData( 512 ), false, "maxTextureResolution" ) );
+
+	FloatPlugPtr ornamentScaleValuePlug = new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f );
+	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", ornamentScaleValuePlug, false, "ornamentScale" ) );
+
+	IntPlugPtr maxResValuePlug = new IntPlug( "value", Gaffer::Plug::Direction::In, 512, 2, 2048 );
+	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", maxResValuePlug, false, "maxTextureResolution" ) );
+
 	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), false, "lightDrawingMode" ) );
 	addChild( visualiserAttr  );
 }

--- a/src/GafferScene/OpenGLAttributes.cpp
+++ b/src/GafferScene/OpenGLAttributes.cpp
@@ -78,10 +78,11 @@ OpenGLAttributes::OpenGLAttributes( const std::string &name )
 	attributes->addChild( new NameValuePlug( "gl:curvesPrimitive:glLineWidth", new IECore::FloatData( 1.0 ), false, "curvesPrimitiveGLLineWidth" ) );
 	attributes->addChild( new NameValuePlug( "gl:curvesPrimitive:ignoreBasis", new IECore::BoolData( false ), false, "curvesPrimitiveIgnoreBasis" ) );
 
-	// light visualisers
+	// visualisers
 
-	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", new IECore::IntData( 512 ), false, "maxTextureResolution" ) );
-
+	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", new IECore::FloatData( 1.0f ), false, "visualiserOrnamentScale" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", new IECore::IntData( 512 ), false, "visualiserMaxTextureResolution" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), false, "lightDrawingMode" ) );
 }
 
 OpenGLAttributes::~OpenGLAttributes()

--- a/src/GafferScene/OpenGLAttributes.cpp
+++ b/src/GafferScene/OpenGLAttributes.cpp
@@ -50,11 +50,11 @@ OpenGLAttributes::OpenGLAttributes( const std::string &name )
 
 	// drawing parameters
 
-	attributes->addChild( new NameValuePlug( "gl:primitive:solid", new IECore::BoolData( true ), false, "primitiveSolid" ) );
+	attributes->addChild( new NameValuePlug( "gl:primitive:solid", new IECore::BoolData( true ), false, "primitiveSolid" ) ); 
 
-	attributes->addChild( new NameValuePlug( "gl:primitive:wireframe", new IECore::BoolData( true ), false, "primitiveWireframe" ) );
-	attributes->addChild( new NameValuePlug( "gl:primitive:wireframeColor", new IECore::Color4fData( Color4f( 0.25, 0.6, 0.85, 1 ) ), false, "primitiveWireframeColor" ) );
-	attributes->addChild( new NameValuePlug( "gl:primitive:wireframeWidth", new IECore::FloatData( 1.0f ), false, "primitiveWireframeWidth" ) );
+	attributes->addChild( new NameValuePlug( "gl:primitive:wireframe", new IECore::BoolData( true ), false, "primitiveWireframe" ) ); 
+	attributes->addChild( new NameValuePlug( "gl:primitive:wireframeColor", new IECore::Color4fData( Color4f( 0.25, 0.6, 0.85, 1 ) ), false, "primitiveWireframeColor" ) ); 
+	attributes->addChild( new NameValuePlug( "gl:primitive:wireframeWidth", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.1f, 32.0f ), false, "primitiveWireframeWidth" ) );
 
 	attributes->addChild( new NameValuePlug( "gl:primitive:outline", new IECore::BoolData( true ), false, "primitiveOutline" ) );
 	attributes->addChild( new NameValuePlug( "gl:primitive:outlineColor", new IECore::Color4fData( Color4f( 0.85, 0.75, 0.45, 1 ) ), false, "primitiveOutlineColor" ) );
@@ -70,18 +70,18 @@ OpenGLAttributes::OpenGLAttributes( const std::string &name )
 	// points primitive parameters
 
 	attributes->addChild( new NameValuePlug( "gl:pointsPrimitive:useGLPoints", new IECore::StringData( "forGLPoints" ), false, "pointsPrimitiveUseGLPoints" ) );
-	attributes->addChild( new NameValuePlug( "gl:pointsPrimitive:glPointWidth", new IECore::FloatData( 1.0 ), false, "pointsPrimitiveGLPointWidth" ) );
+	attributes->addChild( new NameValuePlug( "gl:pointsPrimitive:glPointWidth", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.1f, 128.0f ), false, "pointsPrimitiveGLPointWidth" ) ); 
 
 	// curves primitive parameters
 
 	attributes->addChild( new NameValuePlug( "gl:curvesPrimitive:useGLLines", new IECore::BoolData( false ), false, "curvesPrimitiveUseGLLines" ) );
-	attributes->addChild( new NameValuePlug( "gl:curvesPrimitive:glLineWidth", new IECore::FloatData( 1.0 ), false, "curvesPrimitiveGLLineWidth" ) );
+	attributes->addChild( new NameValuePlug( "gl:curvesPrimitive:glLineWidth", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.1f, 32.0f ), false, "curvesPrimitiveGLLineWidth" ) );
 	attributes->addChild( new NameValuePlug( "gl:curvesPrimitive:ignoreBasis", new IECore::BoolData( false ), false, "curvesPrimitiveIgnoreBasis" ) );
 
 	// visualisers
 
-	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", new IECore::FloatData( 1.0f ), false, "visualiserOrnamentScale" ) );
-	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", new IECore::IntData( 512 ), false, "visualiserMaxTextureResolution" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f ), false, "visualiserOrnamentScale" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", new IntPlug( "value", Gaffer::Plug::Direction::In, 512, 2, 2048 ), false, "visualiserMaxTextureResolution" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), false, "lightDrawingMode" ) );
 }
 

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -155,7 +155,17 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			// in-scene attribute values rather than any renderer option.
 			m_preprocessor = new CustomAttributes();
 			m_preprocessor->globalPlug()->setValue( true );
-			m_preprocessor->attributesPlug()->addChild( new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), true, "lightDrawingMode" ) );
+
+			CompoundDataPlug *attr = m_preprocessor->attributesPlug();
+
+			NameValuePlugPtr lightModePlug = new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), true, "lightDrawingMode" );
+			attr->addChild( lightModePlug );
+
+			FloatPlugPtr ornamentScaleValuePlug = new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f );
+			NameValuePlugPtr ornamentScalePlug = new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", ornamentScaleValuePlug, true, "visualiserOrnamentScale" );
+			attr->addChild( ornamentScalePlug );
+
+			// View plugs
 
 			ValuePlugPtr drawingMode = new ValuePlug( "drawingMode" );
 			m_view->addChild( drawingMode );
@@ -177,10 +187,10 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			drawingMode->addChild( lights );
 			lights->addChild( new StringPlug( "drawingMode", Plug::In, "texture" ) );
 
-			// Connect our attributes plugs up
-			m_preprocessor->attributesPlug()->getChild<NameValuePlug>( "lightDrawingMode" )->getChild<StringPlug>( "value" )->setInput(
-				lights->getChild<StringPlug>( "drawingMode" )
-			);
+			drawingMode->addChild( ornamentScaleValuePlug->createCounterpart( "visualiserOrnamentScale", Plug::Direction::In ) );
+
+			lightModePlug->getChild<StringPlug>( "value" )->setInput( lights->getChild<StringPlug>( "drawingMode" ) );
+			ornamentScaleValuePlug->setInput( drawingMode->getChild<FloatPlug>( "visualiserOrnamentScale" ) );
 
 			updateOpenGLOptions();
 

--- a/startup/GafferScene/lightCompatibility.py
+++ b/startup/GafferScene/lightCompatibility.py
@@ -1,0 +1,54 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+def __lightGetItemWrapper( originalGetItem ) :
+
+	def getItem( self, key ) :
+
+		if key == "visualiserScale" :
+			visualiserAttr = originalGetItem( self, "visualiserAttributes" )
+			visualiserAttr[ "ornamentScale" ][ "enabled" ].setValue( True )
+			return visualiserAttr[ "ornamentScale" ][ "value" ]
+		else :
+			return originalGetItem( self, key )
+
+	return getItem
+
+GafferScene.Light.__getitem__ = __lightGetItemWrapper( GafferScene.Light.__getitem__ )
+


### PR DESCRIPTION
We had a mixture of name spaces for visualisation attributes, and some were a little broad in their naming.

We also used specific plugs for each visualisation attribute. This meant that every light made by a `Light` node would always set a value for each attribute. This made it difficult to implement any easily changed global default.

This PR improves attribute naming and moves over to using a `CompoundDataPlug` in Light nodes for all visualisation attributes. It also adds Viewer menu items to easily control default values for `gl:visualiser:ornamentScale` and `gl:light:drawMode`. 

Closes #3407