### PR TITLE
NumericWidget : Fix up/down key handling when the widget is empty

### DIFF
--- a/python/GafferUI/NumericWidget.py
+++ b/python/GafferUI/NumericWidget.py
@@ -136,6 +136,9 @@ class NumericWidget( GafferUI.TextWidget ) :
 	def __incrementIndex( self, index, increment ) :
 
 		text = self.getText()
+		if text == "" :
+			return
+
 		if '.' in text :
 			decimalIndex = text.find( "." )
 			if decimalIndex >= index :


### PR DESCRIPTION
Fixed bug that caused an exception to be raised if the up/down keys were pressed in a NumericWidget when the widget's value was empty.
