### PR TITLE
CompoundEditor : Don't save pinning using basic state

### DIFF
--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -523,14 +523,6 @@ class _SplitContainer( GafferUI.SplitContainer ) :
 			if tabbedContainer.getCurrent() is not None :
 				tabDict["currentTab"] = tabbedContainer.index( tabbedContainer.getCurrent() )
 			tabDict["tabsVisible"] = tabbedContainer.getTabsVisible()
-
-			tabDict["pinned"] = []
-			for editor in tabbedContainer :
-				if isinstance( editor, GafferUI.NodeSetEditor ) :
-					tabDict["pinned"].append( not editor.getNodeSet().isSame( scriptNode.selection() ) )
-				else :
-					tabDict["pinned"].append( None )
-
 			return repr( tabDict )
 
 	def restoreChildren( self, children ) :
@@ -554,8 +546,6 @@ class _SplitContainer( GafferUI.SplitContainer ) :
 				# new format - various fields provided by a dictionary
 				for i, c in enumerate( children["tabs"] ) :
 					editor = self[0].addEditor( c )
-					if "pinned" in children and isinstance( editor, GafferUI.NodeSetEditor ) and children["pinned"][i] :
-						editor.setNodeSet( Gaffer.StandardSet() )
 
 				if "currentTab" in children :
 					self[0].setCurrent( self[0][children["currentTab"]] )


### PR DESCRIPTION
If an editor is pinned to specific node(s) when a layout is saved, we used to store this as a simple boolean flag. When the layout was loaded, we would then pin editors with this flag to nothing.

This seems to have been to allow layouts to restore with a viewer 'pinned off' to help with large scenes. As we now have async updates, as well as a pause button, this behaviour is generally unhelpful.

There is a bigger question as to the potential benefit of saving layouts with scripts (where storing a specific node reference could make sense). Coupled with the numerous recent changes to the Editor Focus mechanism (that allow saved layouts to express some specific pinning
states when loaded). It feels this simple pinning restoration is no longer needed.

This commit removes support for the old `pinned` flag. Existing layouts containing this flag will still load and the flag be ignored.

Improvements
------------

- Layouts : Prevented editors pinned to a specific node from restoring with the editor pinned to an empty node set. Specific pinning is no longer saved or recalled.