### PR TITLE
SceneView : Restore openGLOptions

### DIFF
--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -242,6 +242,8 @@ class SceneView::DrawingMode : public boost::signals::trackable
 				"forAll" :
 				"forGLPoints"
 			);
+
+			sceneGadget()->setOpenGLOptions( options.get() );
 		}
 
 		CustomAttributesPtr m_preprocessor;


### PR DESCRIPTION
Fixes inadvertent removal in df65f14aeaa9449aa4d2909fc9492cc9871c367a.