### PR TITLE
Avoid USD traceback at startup

### DIFF
--- a/startup/GafferScene/usd.py
+++ b/startup/GafferScene/usd.py
@@ -41,7 +41,7 @@ import ctypes
 import IECore
 
 moduleSearchPath = IECore.SearchPath( os.environ["PYTHONPATH"] )
-if moduleSearchPath.find( "IECoreUSD" ) :
+if moduleSearchPath.find( "IECoreUSD" ) and moduleSearchPath.find( "pxr/Usd" ) :
 
 	# Import the USD Python module _without_ RTLD_GLOBAL, otherwise
 	# we get errors like the following spewed to the shell when we first


### PR DESCRIPTION
This avoids a traceback shown to users if a facility installed IECoreUSD but not the pxr python module.

I'm not sure if this is going to be controversial... its a bit of an odd scenario really, but we have a situation where in a certain DCC we have IECoreUSD on the python path, but we're not expecting it to be usable, as USD is not installed for that DCC... Currently users are seeing a confusing traceback, which this commit suppresses. Alternatively, I could catch that and print a one-line warning a la "Warning: USD not found, Gaffer will not be able to read/write USD files".