### PR TITLE
StandardLightVisualiser : Photometric light support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -810,7 +810,9 @@ libraries = {
 
 	"GafferArnoldUI" : {
 		"envAppends" : {
-			"LIBS" : [ "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "Gaffer", "GafferScene", "GafferOSL", "GafferSceneUI" ],
+			"CPPPATH" : [ "$ARNOLD_ROOT/include" ],
+			"LIBPATH" : [ "$ARNOLD_ROOT/bin" ],
+			"LIBS" : [ "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "Gaffer", "GafferScene", "GafferOSL", "GafferSceneUI", "ai" ],
 			},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferArnoldUI", "GafferSceneUI" ],

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -521,6 +521,16 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 		meshState->add( new IECoreGL::OutlineColorStateComponent( g_lightWireframeColor4 ) );
 		state = meshState;
 	}
+	else if( type && type->readable() == "photometric" )
+	{
+		const float radius = parameter<float>( metadataTarget, shaderParameters, "radiusParameter", 0 );
+		if( radius > 0 )
+		{
+			geometry->addChild( const_pointer_cast<IECoreGL::Renderable>( environmentSphereWireframe( radius, Vec3<bool>( true, false, true ) ) ) );
+		}
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
+	}
 	else
 	{
 		// Treat everything else as a point light.

--- a/startup/GafferScene/arnoldLights.py
+++ b/startup/GafferScene/arnoldLights.py
@@ -90,3 +90,11 @@ Gaffer.Metadata.registerValue( "ai:light:mesh_light", "intensityParameter", "int
 Gaffer.Metadata.registerValue( "ai:light:mesh_light", "exposureParameter", "exposure" )
 Gaffer.Metadata.registerValue( "ai:light:mesh_light", "colorParameter", "color" )
 Gaffer.Metadata.registerValue( "ai:light:mesh_light", "type", "mesh" )
+
+Gaffer.Metadata.registerValue( "ai:light:photometric_light", "intensityParameter", "intensity" )
+Gaffer.Metadata.registerValue( "ai:light:photometric_light", "exposureParameter", "exposure" )
+Gaffer.Metadata.registerValue( "ai:light:photometric_light", "colorParameter", "color" )
+Gaffer.Metadata.registerValue( "ai:light:photometric_light", "radiusParameter", "radius" )
+# Most profiles generally shine down -y
+Gaffer.Metadata.registerValue( "ai:light:photometric_light", "visualiserOrientation", imath.M44f().rotate( imath.V3f( -0.5 * math.pi, 0 , 0 ) ) )
+Gaffer.Metadata.registerValue( "ai:light:photometric_light", "type", "photometric" )


### PR DESCRIPTION
The Viewer now draws photometric lights differently from point lights and takes advantage of the new `AiIESLightLoad` API in Arnold 6+ to preview profile distribution in the viewer.

![image](https://user-images.githubusercontent.com/896779/71822026-b1374c00-308b-11ea-910e-e4b34329c344.png)

Part of #3481

Improvements
------------

Viewer : Added intensity distribution preview for Arnold photometric lights.
