### PR TITLE
StandardLightVisualiser : Support mesh lights

### DIFF
--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -69,7 +69,8 @@ using namespace IECoreGLPreview;
 namespace
 {
 
-Color3f g_lightWireframeColor = Color3f( 1.0f, 0.835f, 0.07f );
+const Color3f g_lightWireframeColor = Color3f( 1.0f, 0.835f, 0.07f );
+const Color4f g_lightWireframeColor4 = Color4f( g_lightWireframeColor.x, g_lightWireframeColor.y, g_lightWireframeColor.z, 1.0f );
 
 enum Axis { X, Y, Z };
 
@@ -491,6 +492,16 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 		{
 			ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
 		}
+	}
+	else if( type && type->readable() == "mesh" )
+	{
+		// There isn't any meaningful place to draw anything for the mesh
+		// light, so instead we make the mesh outline visible and light coloured.
+		IECoreGL::StatePtr meshState = new IECoreGL::State( false );
+		meshState->add( new IECoreGL::Primitive::DrawOutline( true ) );
+		meshState->add( new IECoreGL::Primitive::OutlineWidth( 2.0f ) );
+		meshState->add( new IECoreGL::OutlineColorStateComponent( g_lightWireframeColor4 ) );
+		state = meshState;
 	}
 	else
 	{

--- a/startup/GafferScene/arnoldLights.py
+++ b/startup/GafferScene/arnoldLights.py
@@ -82,3 +82,8 @@ Gaffer.Metadata.registerValue( "ai:light:skydome_light", "intensityParameter", "
 Gaffer.Metadata.registerValue( "ai:light:skydome_light", "exposureParameter", "exposure" )
 Gaffer.Metadata.registerValue( "ai:light:skydome_light", "colorParameter", "color" )
 Gaffer.Metadata.registerValue( "ai:light:skydome_light", "type", "environment" )
+
+Gaffer.Metadata.registerValue( "ai:light:mesh_light", "intensityParameter", "intensity" )
+Gaffer.Metadata.registerValue( "ai:light:mesh_light", "exposureParameter", "exposure" )
+Gaffer.Metadata.registerValue( "ai:light:mesh_light", "colorParameter", "color" )
+Gaffer.Metadata.registerValue( "ai:light:mesh_light", "type", "mesh" )


### PR DESCRIPTION
As there is no sensible place to draw mesh lights (as we don't know what the mesh looks like) outline the mesh with the light color instead.

![image](https://user-images.githubusercontent.com/896779/71823465-353f0300-308f-11ea-8e33-60e0cfa49cf6.png)

Part of #3481

Improvements
------------

- Viewer : Added support for mesh lights such that they draw a yellow
  outline around the source mesh.
