### PR TITLE
ArnoldLightVisualiser : Draw portals differently to standard quads

### DIFF
--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -74,6 +74,8 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 		static IECoreGL::ConstRenderablePtr distantRays();
 		static IECoreGL::ConstRenderablePtr spotlightCone( float innerAngle, float outerAngle, float lensRadius );
 
+		static IECoreGL::ConstRenderablePtr quadPortal( const Imath::V2f &size );
+
 		static IECoreGL::ConstRenderablePtr colorIndicator( const Imath::Color3f &color, bool cameraFacing = true );
 
 		// This method should be overridden by any sub-classes that wish to
@@ -107,8 +109,8 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 		// as such, this should generally only be used as an ornament type visualisation.
 		static IECoreGL::ConstRenderablePtr areaSpread( float spread );
 
-		static IECoreGL::ConstRenderablePtr quadWireframe();
-		static IECoreGL::ConstRenderablePtr quadSurface( IECore::ConstDataPtr textureData, int textureMaxResolution, const Imath::Color3f &fallbackColor );
+		static IECoreGL::ConstRenderablePtr quadWireframe( const Imath::V2f &size );
+		static IECoreGL::ConstRenderablePtr quadSurface( const Imath::V2f &size, IECore::ConstDataPtr textureData, int textureMaxResolution, const Imath::Color3f &fallbackColor );
 
 		static IECoreGL::ConstRenderablePtr diskWireframe( float radius );
 		static IECoreGL::ConstRenderablePtr diskSurface( float radius, IECore::ConstDataPtr textureData, int textureMaxResolution, const Imath::Color3f &fallbackColor );

--- a/startup/GafferScene/arnoldLights.py
+++ b/startup/GafferScene/arnoldLights.py
@@ -63,6 +63,7 @@ Gaffer.Metadata.registerValue( "ai:light:quad_light", "type", "quad" )
 Gaffer.Metadata.registerValue( "ai:light:quad_light", "intensityParameter", "intensity" )
 Gaffer.Metadata.registerValue( "ai:light:quad_light", "exposureParameter", "exposure" )
 Gaffer.Metadata.registerValue( "ai:light:quad_light", "colorParameter", "color" )
+Gaffer.Metadata.registerValue( "ai:light:quad_light", "portalParameter", "portal" )
 Gaffer.Metadata.registerValue( "ai:light:quad_light", "spreadParameter", "spread" )
 Gaffer.Metadata.registerValue( "ai:light:quad_light", "visualiserOrientation", imath.M44f().rotate( imath.V3f( 0, 0, 0.5 * math.pi ) ) )
 


### PR DESCRIPTION
![unnamed-1](https://user-images.githubusercontent.com/896779/71722731-cd37b500-2e21-11ea-9b55-84af9af0cc39.png)

Sadly, we have to draw in local space (as the visualisers don't have access to the location's matrix). This does mean that the hatched area distorts as the light is scaled, but at least they are now visually distinct from normal lights.

Part of #3481.

Improvements
------------

 - Viewer : Improved display of Arnold quad lights set to portal mode.