### PR TITLE
SConstruct : Fix for addition of include/GafferScene/Private/IECoreGLPreview/Private/ 

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -733,7 +733,7 @@ libraries = {
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferBindings", "GafferScene", "GafferDispatch", "IECoreScene$CORTEX_LIB_SUFFIX" ],
 		},
-		"additionalFiles" : glob.glob( "glsl/*.frag" ) + glob.glob( "glsl/*.vert" ) + glob.glob( "include/GafferScene/Private/IECore*Preview/*.h" )
+		"additionalFiles" : glob.glob( "glsl/*.frag" ) + glob.glob( "glsl/*.vert" ) + glob.glob( "include/GafferScene/Private/IECore*Preview/*.h" ) + glob.glob( "include/GafferScene/Private/IECore*Preview/Private/*.h" )
 	},
 
 	"GafferSceneTest" : {


### PR DESCRIPTION
Currently with master, trying to include `include/GafferScene/Private/IECoreGLPreview/LightVisualiser.h` from another project is an error because it tries to include `include/GafferScene/Private/IECoreGLPreview/Private/Visualiser.h`, which is not installed.

Now, this is all inside a `Private` header, so I know it's discouraged to use this from outside, but given that `include/GafferScene/Private/IECore*Preview/*.h` is installed, I'm assuming the missing dependency is just an oversight.