### PR TITLE
Spreadsheet : Don't draw values for disabled cells

### DIFF
--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -1088,13 +1088,13 @@ class _PlugTableDelegate( QtWidgets.QStyledItemDelegate ) :
 		painter.save()
 
 		painter.setRenderHint( QtGui.QPainter.Antialiasing )
-		overlayColor = QtGui.QColor( 40, 40, 40, 200 )
+		overlayColor = QtGui.QColor( 45, 45, 45, 255 )
 
 		if not cellPlugEnabled :
 
 			painter.fillRect( option.rect, overlayColor )
 
-			pen = QtGui.QPen( QtGui.QColor( 20, 20, 20, 150 ) )
+			pen = QtGui.QPen( QtGui.QColor( 20, 20, 20, 60 ) )
 			pen.setWidth( 2 )
 			painter.setPen( pen )
 			painter.drawLine( option.rect.bottomLeft(), option.rect.topRight() )


### PR DESCRIPTION
The more I use the spreadsheet, it started to feel difficult to work out exactly what the state of a row would be, given the numberous check boxes and cell states. This commit omits values from disabled cells, which hopefully helps show that it won't contribute.

**Before**

![image](https://user-images.githubusercontent.com/896779/71976708-e1f3be80-320e-11ea-808e-efca41ceb13b.png)

Is the `giSamples` value for `0200` `2` or not? It is two, but you could be forgiven for thinking it wasn't.

**After**

![image](https://user-images.githubusercontent.com/896779/71976740-f8017f00-320e-11ea-915a-3cf43a50f967.png)

More apparent you need to look up at the defaults row?

Ultimately we plan to have a 'preview' row, that can show the final values for any selector. But, an alternative option could be to draw the 'resolved' value in the disabled cell instead (maybe in italics or brackets or something)?

Improvements
------------

 - Spreadsheet : Improved the presentation of disabled cells.