### PR TITLE
StandardLightVisualiser : Simplify color indicator

### DIFF
--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -76,7 +76,7 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 
 		static IECoreGL::ConstRenderablePtr quadPortal( const Imath::V2f &size );
 
-		static IECoreGL::ConstRenderablePtr colorIndicator( const Imath::Color3f &color, bool cameraFacing = true );
+		static IECoreGL::ConstRenderablePtr colorIndicator( const Imath::Color3f &color );
 
 		// This method should be overridden by any sub-classes that wish to
 		// provide an alternate surface texture for area-based lights.

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -397,10 +397,6 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 	ConstM44fDataPtr orientation = Metadata::value<M44fData>( metadataTarget, "visualiserOrientation" );
 
 	const Color3f color = parameter<Color3f>( metadataTarget, shaderParameters, "colorParameter", Color3f( 1.0f ) );
-	const float intensity = parameter<float>( metadataTarget, shaderParameters, "intensityParameter", 1 );
-	const float exposure = parameter<float>( metadataTarget, shaderParameters, "exposureParameter", 0 );
-
-	const Color3f finalColor = color * intensity * pow( 2.0f, exposure );
 
 	GroupPtr ornaments = new Group;  // Ornaments are affected by visualiser:scale while
 	GroupPtr geometry = new Group;   // geometry isn't as its size matters for rendering.
@@ -443,12 +439,12 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 		spotlightParameters( attributeName, shaderNetwork, innerAngle, outerAngle, lensRadius );
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / visualiserScale ) ) );
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
-		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( color ) ) );
 	}
 	else if( type && type->readable() == "distant" )
 	{
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( distantRays() ) );
-		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( color ) ) );
 	}
 	else if( type && type->readable() == "quad" )
 	{
@@ -467,7 +463,7 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 			}
 			else
 			{
-				ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
+				ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( color ) ) );
 			}
 			geometry->addChild( const_pointer_cast<IECoreGL::Renderable>( quadWireframe( size ) ) );
 		}
@@ -490,7 +486,7 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 		}
 		else
 		{
-			ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
+			ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( color ) ) );
 		}
 		geometry->addChild( const_pointer_cast<IECoreGL::Renderable>( diskWireframe( radius ) ) );
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
@@ -508,7 +504,7 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( cylinderRays( radius ) ) );
 		if( !drawShaded )
 		{
-			ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
+			ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( color ) ) );
 		}
 	}
 	else if( type && type->readable() == "mesh" )
@@ -528,7 +524,7 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 		{
 			geometry->addChild( const_pointer_cast<IECoreGL::Renderable>( environmentSphereWireframe( radius, Vec3<bool>( true, false, true ) ) ) );
 		}
-		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ false ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( color ) ) );
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
 	}
 	else
@@ -541,7 +537,7 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 		}
 
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( pointRays( radius ) ) );
-		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( finalColor, /* cameraFacing = */ true ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( color ) ) );
 
 	}
 
@@ -711,82 +707,28 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::spotlightCone( float inner
 	return group;
 }
 
-IECoreGL::ConstRenderablePtr StandardLightVisualiser::colorIndicator( const Imath::Color3f &color, bool faceCamera )
+IECoreGL::ConstRenderablePtr StandardLightVisualiser::colorIndicator( const Imath::Color3f &color )
 {
 
-	float maxChannel = std::max( color[0], std::max( color[1], color[2] ) );
-	float exposure = 0;
-	Imath::Color3f indicatorColor = color;
-	if( maxChannel > 1 )
-	{
-		indicatorColor = color / maxChannel;
-		exposure = log( maxChannel ) / log( 2 );
-	}
 	IECoreGL::GroupPtr group = new IECoreGL::Group();
-	IECoreGL::GroupPtr wirelessGroup = new IECoreGL::Group();
 
-	addConstantShader( group.get(), true, faceCamera ? 1 : -1 );
+	addConstantShader( group.get(), true, 1 );
 
-	wirelessGroup->getState()->add( new IECoreGL::Primitive::DrawWireframe( false ) );
-
-	float indicatorRad = 0.3;
-	Axis indicatorAxis = faceCamera ? Axis::X : Axis::Z;
+	const float indicatorRad = 0.1f;
 
 	{
 		IntVectorDataPtr vertsPerPoly = new IntVectorData;
 		IntVectorDataPtr vertIds = new IntVectorData;
 		V3fVectorDataPtr p = new V3fVectorData;
 
-		addSolidArc( indicatorAxis, V3f( 0 ), indicatorRad, indicatorRad * 0.9, 0, 1, vertsPerPoly->writable(), vertIds->writable(), p->writable() );
+		addSolidArc( Axis::X, V3f( 0 ), 0, indicatorRad, 0, 1, vertsPerPoly->writable(), vertIds->writable(), p->writable() );
 
 		IECoreScene::MeshPrimitivePtr mesh = new IECoreScene::MeshPrimitive( vertsPerPoly, vertIds, "linear", p );
 		mesh->variables["N"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new V3fData( V3f( 0 ) ) );
-		mesh->variables["Cs"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( indicatorColor ) );
+		mesh->variables["Cs"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( color ) );
 		ToGLMeshConverterPtr meshConverter = new ToGLMeshConverter( mesh );
 		group->addChild( IECore::runTimeCast<IECoreGL::Renderable>( meshConverter->convert() ) );
 	}
-	{
-		IntVectorDataPtr vertsPerPoly = new IntVectorData;
-		IntVectorDataPtr vertIds = new IntVectorData;
-		V3fVectorDataPtr p = new V3fVectorData;
-
-		addSolidArc( indicatorAxis, V3f( 0 ), indicatorRad * 0.4, 0.0, 0, 1, vertsPerPoly->writable(), vertIds->writable(), p->writable() );
-
-		for( int i = 0; i < exposure && i < 20; i++ )
-		{
-			float startAngle = 1 - pow( 0.875, i );
-			float endAngle = 1 - pow( 0.875, std::min( i+1.0, (double)exposure ) );
-			float maxEndAngle = 1 - pow( 0.875, i+1.0);
-			float sectorScale = ( maxEndAngle - startAngle - 0.008 ) / ( maxEndAngle - startAngle );
-			addSolidArc( indicatorAxis, V3f( 0 ), indicatorRad * 0.85, indicatorRad * 0.45, startAngle, startAngle + ( endAngle - startAngle ) * sectorScale, vertsPerPoly->writable(), vertIds->writable(), p->writable() );
-		}
-
-		IECoreScene::MeshPrimitivePtr mesh = new IECoreScene::MeshPrimitive( vertsPerPoly, vertIds, "linear", p );
-		mesh->variables["N"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new V3fData( V3f( 0 ) ) );
-		mesh->variables["Cs"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( indicatorColor ) );
-		ToGLMeshConverterPtr meshConverter = new ToGLMeshConverter( mesh );
-		wirelessGroup->addChild( IECore::runTimeCast<IECoreGL::Renderable>( meshConverter->convert() ) );
-	}
-
-	// For exposures greater than 20, draw an additional solid bar of a darker color at the very end, without any segment dividers
-	if( exposure > 20 )
-	{
-		IntVectorDataPtr vertsPerPoly = new IntVectorData;
-		IntVectorDataPtr vertIds = new IntVectorData;
-		V3fVectorDataPtr p = new V3fVectorData;
-
-		float startAngle = 1 - pow( 0.875, 20 );
-		float endAngle = 1 - pow( 0.875, (double)exposure );
-		addSolidArc( indicatorAxis, V3f( 0 ), indicatorRad * 0.85, indicatorRad * 0.45, startAngle, endAngle, vertsPerPoly->writable(), vertIds->writable(), p->writable() );
-
-		IECoreScene::MeshPrimitivePtr mesh = new IECoreScene::MeshPrimitive( vertsPerPoly, vertIds, "linear", p );
-		mesh->variables["N"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new V3fData( V3f( 0 ) ) );
-		mesh->variables["Cs"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( 0.5f * indicatorColor ) );
-		ToGLMeshConverterPtr meshConverter = new ToGLMeshConverter( mesh );
-		wirelessGroup->addChild( IECore::runTimeCast<IECoreGL::Renderable>( meshConverter->convert() ) );
-	}
-
-	group->addChild( wirelessGroup );
 
 	return group;
 }


### PR DESCRIPTION
Simplifies the light color indication to be a smaller, camera-facing dot. User feedback suggested that the exposure indicator was often too small on screen to be useful. The majority of users were in favour of less clutter in the viewport.

In addition, we now only color the indicator with the light's tint, and don't factor in intensity or exposure. In most real-world cases, this resulted in either bleached out, or too dark a display. It also now matches texture rendering for area lights.

Improvements
------------

 - Viewer :
     - Simplified light the light color indicator and removed the
       exposure wedges.
     - Removed the contribution of intensity and exposure to the color
       indicator.


**Before**
![image](https://user-images.githubusercontent.com/896779/71994306-673b9b00-3230-11ea-8097-f847d2c38aa6.png)

**After**
![image](https://user-images.githubusercontent.com/896779/71994430-a1a53800-3230-11ea-872c-172b70a3401f.png)