### PR TITLE
StandardLightVisualiser : Make point lights smaller

### DIFF
--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -631,7 +631,7 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::pointRays( float radius )
 	{
 		const float angle = M_PI * 2.0f * float(i)/(float)numRays;
 		const V3f dir( 0.0, sin( angle ), -cos( angle ) );
-		addRay( dir * (.5 + radius), dir * (1 + radius), vertsPerCurve->writable(), p->writable() );
+		addRay( dir * ( 0.2f + radius ), dir * ( 0.5f + radius ), vertsPerCurve->writable(), p->writable() );
 	}
 
 	IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurve );


### PR DESCRIPTION
They were quite a lot bigger than other lights

Note: Should only be merged after #3542.

Improvements
------------

 - Viewer : Reduced size of point lights to better match other light sources.

**Before**
![image](https://user-images.githubusercontent.com/896779/71995738-ee8a0e00-3232-11ea-9a0c-e392c3e1408d.png)

**After**
![image](https://user-images.githubusercontent.com/896779/71995595-c0a4c980-3232-11ea-991f-86564b310b3b.png)
