### PR TITLE
IECoreArnoldPreview::Renderer : Sort AOVs

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -3163,6 +3163,7 @@ class ArnoldGlobals
 					it->second->append( outputs->writable(), lpes->writable() );
 				}
 			}
+			std::sort( outputs->writable().begin(), outputs->writable().end() );
 			IECoreArnold::ParameterAlgo::setParameter( options, "outputs", outputs.get() );
 			IECoreArnold::ParameterAlgo::setParameter( options, "light_path_expressions", lpes.get() );
 


### PR DESCRIPTION
This shouldn't have any effect, but might help track down a weird unreproducible bug at IE

We've occasionally had reports of deep passes failing to render when we're also rendering Z as a separate flat pass.  I thought I'd seen this once myself, but any attempt to reproduce does not show the problem.

We had some idea that the order AOVs are output in might be contributing to the issue, and currently, they are in the really horrible InternedString order, which may be mostly consistent, depending on the order strings are visited in.  Making this order consistent might help avoid this phantom problem, or better yet, make it happen consistently so we can actually track it down.