### PR TITLE
CompoundEditor : Consider modifiers with Editor Focus shortcuts

### DIFF
--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -1528,10 +1528,10 @@ class _PinningWidget( _Frame ) :
 		if not isinstance( editor, GafferUI.NodeSetEditor ) :
 			return False
 
-		if event.key == "N" :
+		if event.key == "N" and not event.modifiers :
 			_PinningWidget.__followNodeSelection( editor )
 			return True
-		elif event.key == "P" :
+		elif event.key == "P" and not event.modifiers :
 			_PinningWidget.__pinToNodeSelection( editor )
 			return True
 


### PR DESCRIPTION
Fixes #3546.

Fixes
-----

- CompoundEditor : Fixed bug that prevented `Ctrl-N` from working when the mouse was over a `NodeSetEditor` (#3546).
