### PR TITLE
ColorProcessor and ChannelDataProcessor: Branch for unpremult and zero

### DIFF
--- a/python/GafferImageTest/GradeTest.py
+++ b/python/GafferImageTest/GradeTest.py
@@ -248,3 +248,64 @@ class GradeTest( GafferImageTest.ImageTestCase ) :
 
 		sampler["channels"].setValue( IECore.StringVectorData( [ "B.R", "B.G", "B.B", "B.A" ] ) )
 		self.assertEqual( sampler["color"].getValue(), imath.Color4f( 1 ) )
+
+	def testUnpremultiplied( self ) :
+
+		i = GafferImage.ImageReader()
+		i["fileName"].setValue( self.checkerFile )
+
+		shuffleAlpha = GafferImage.Shuffle()
+		shuffleAlpha["channels"].addChild( GafferImage.Shuffle.ChannelPlug( "channel" ) )
+		shuffleAlpha["in"].setInput( i["out"] )
+		shuffleAlpha["channels"]["channel"]["out"].setValue( 'A' )
+		shuffleAlpha["channels"]["channel"]["in"].setValue( 'R' )
+
+		gradeAlpha = GafferImage.Grade()
+		gradeAlpha["in"].setInput( shuffleAlpha["out"] )
+		gradeAlpha["channels"].setValue( '[RGBA]' )
+		gradeAlpha["offset"].setValue( imath.Color4f( 0, 0, 0, 0.1 ) )
+
+		unpremultipliedGrade = GafferImage.Grade()
+		unpremultipliedGrade["in"].setInput( gradeAlpha["out"] )
+		unpremultipliedGrade["processUnpremultiplied"].setValue( True )
+		unpremultipliedGrade["gamma"].setValue( imath.Color4f( 2, 2, 2, 1.0 ) )
+
+		unpremultiply = GafferImage.Unpremultiply()
+		unpremultiply["in"].setInput( gradeAlpha["out"] )
+
+		bareGrade = GafferImage.Grade()
+		bareGrade["in"].setInput( unpremultiply["out"] )
+		bareGrade["gamma"].setValue( imath.Color4f( 2, 2, 2, 1.0 ) )
+
+		premultiply = GafferImage.Premultiply()
+		premultiply["in"].setInput( bareGrade["out"] )
+
+		# Assert that with a non-zero alpha, processUnpremultiplied is identical to:
+		# unpremult, grade, and premult
+		self.assertImagesEqual( unpremultipliedGrade["out"], premultiply["out"] )
+
+
+		# Assert that grading alpha to 0 inside the grade still premults at the end correctly
+		unpremultipliedGrade["channels"].setValue( '[RGBA]' )
+		unpremultipliedGrade["multiply"].setValue( imath.Color4f( 1, 1, 1, 0 ) )
+
+		zeroGrade = GafferImage.Grade()
+		zeroGrade["channels"].setValue( '[RGBA]' )
+		zeroGrade["in"].setInput( gradeAlpha["out"] )
+		zeroGrade["multiply"].setValue( imath.Color4f( 0, 0, 0, 0 ) )
+
+		self.assertImagesEqual( unpremultipliedGrade["out"], zeroGrade["out"] )
+
+		unpremultipliedGrade["multiply"].setValue( imath.Color4f( 1, 1, 1, 1 ) )
+
+		# Assert that when input alpha is zero, processUnpremultiplied doesn't affect the result
+
+		gradeAlpha["multiply"].setValue( imath.Color4f( 1, 1, 1, 0.0 ) )
+		gradeAlpha["offset"].setValue( imath.Color4f( 0, 0, 0, 0.0 ) )
+
+		defaultGrade = GafferImage.Grade()
+		defaultGrade["in"].setInput( gradeAlpha["out"] )
+		defaultGrade["gamma"].setValue( imath.Color4f( 2, 2, 2, 1.0 ) )
+
+		self.assertImagesEqual( unpremultipliedGrade["out"], defaultGrade["out"] )
+

--- a/src/GafferImage/ChannelDataProcessor.cpp
+++ b/src/GafferImage/ChannelDataProcessor.cpp
@@ -220,11 +220,32 @@ IECore::ConstFloatVectorDataPtr ChannelDataProcessor::computeChannelData( const 
 		int size = postAlphaData->readable().size();
 		const float *A = &postAlphaData->readable().front();
 		float *O = &outData->writable().front();
-		for( int j = 0; j < size; j++ )
+
+		if( repremultByProcessedAlpha )
 		{
-			*O *= *A;
-			A++;
-			O++;
+			const float *preA = &alphaData->readable().front();
+			for( int j = 0; j < size; j++ )
+			{
+				if( ! ( *A == 0 && *preA == 0 ) )
+				{
+					*O *= *A;
+				}
+				A++;
+				O++;
+				preA++;
+			}
+		}
+		else
+		{
+			for( int j = 0; j < size; j++ )
+			{
+				if( *A != 0 )
+				{
+					*O *= *A;
+				}
+				A++;
+				O++;
+			}
 		}
 
 	}

--- a/src/GafferImage/ColorProcessor.cpp
+++ b/src/GafferImage/ColorProcessor.cpp
@@ -234,7 +234,11 @@ void ColorProcessor::compute( Gaffer::ValuePlug *output, const Gaffer::Context *
 					float *C = &rgb[i]->writable().front();
 					for( int j = 0; j < samples; j++ )
 					{
-						*C *= *A;
+						// Pixels with no alpha aren't touched by either the unpremult or repremult
+						if( *A != 0 )
+						{
+							*C *= *A;
+						}
 						A++;
 						C++;
 					}


### PR DESCRIPTION
As per conversation here: https://github.com/OpenImageIO/oiio/pull/2447

Add a special case which skips unpremult / repremult  on pixels with zero alpha when doing an unpremultiplied operation.  This is because zero alpha pixels are interpreted as special additive contributions.  This allows operations to performed unpremultiplied on images containing some additive pixels.  It can't help on an image where pixels contain mixed additive and occluding contributions, unless it's a deep image where the additive and occluding contributions are split into separate samples, but it helps in some cases, and never particularly makes things worse.