### PR TITLE
Viewer : Camera frustum visualisation

### DIFF
--- a/include/GafferScene/Camera.h
+++ b/include/GafferScene/Camera.h
@@ -99,12 +99,18 @@ class GAFFERSCENE_API Camera : public ObjectSource
 		Gaffer::CompoundDataPlug *renderSettingOverridesPlug();
 		const Gaffer::CompoundDataPlug *renderSettingOverridesPlug() const;
 
+		Gaffer::CompoundDataPlug *visualiserAttributesPlug();
+		const Gaffer::CompoundDataPlug *visualiserAttributesPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
+
+		void hashAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 		IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const override;
 

--- a/include/GafferScene/Private/IECoreGLPreview/ObjectVisualiser.h
+++ b/include/GafferScene/Private/IECoreGLPreview/ObjectVisualiser.h
@@ -39,6 +39,8 @@
 
 #include "GafferScene/Export.h"
 
+#include "GafferScene/Private/IECoreGLPreview/Visualiser.h"
+
 #include "IECoreGL/Renderable.h"
 
 #include "IECore/Object.h"
@@ -66,7 +68,7 @@ class GAFFERSCENE_API ObjectVisualiser : public IECore::RefCounted
 
 		/// Must be implemented by derived classes to return a suitable
 		/// visualisation of the object.
-		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const = 0;
+		virtual Visualisations visualise( const IECore::Object *object ) const = 0;
 
 		/// @name Factory
 		///////////////////////////////////////////////////////////////////

--- a/include/GafferScene/Private/IECoreGLPreview/Visualiser.h
+++ b/include/GafferScene/Private/IECoreGLPreview/Visualiser.h
@@ -47,13 +47,15 @@ namespace IECoreGLPreview
 enum VisualisationType
 {
 	Geometry, // Visualisations that inherit a location's transform.
-	Ornament  // Visualisations that don't inherit a location's scale and aren't
+	Ornament, // Visualisations that don't inherit a location's scale and aren't
 	          // considered for bounds computation if geometry or a Geometric
 	          // visualisation is present.
+	Frustum   // Visualisations that inherit a location's transform and
+	          // represent some in-world projection of frustum of the object.
 };
 
 // A container for renderables grouped by VisualisationType
-using Visualisations = std::array<IECoreGL::ConstRenderablePtr, 2>;
+using Visualisations = std::array<IECoreGL::ConstRenderablePtr, 3>;
 
 namespace Private
 {

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -72,7 +72,7 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 		static IECoreGL::ConstRenderablePtr ray();
 		static IECoreGL::ConstRenderablePtr pointRays( float radius = 0 );
 		static IECoreGL::ConstRenderablePtr distantRays();
-		static IECoreGL::ConstRenderablePtr spotlightCone( float innerAngle, float outerAngle, float lensRadius );
+		static IECoreGL::ConstRenderablePtr spotlightCone( float innerAngle, float outerAngle, float lensRadius, float length = 1.0f, float lineWidthScale = 1.0f );
 
 		static IECoreGL::ConstRenderablePtr quadPortal( const Imath::V2f &size );
 

--- a/python/GafferSceneTest/CameraTest.py
+++ b/python/GafferSceneTest/CameraTest.py
@@ -77,11 +77,32 @@ class CameraTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertSceneValid( p["out"] )
 
+	def testAttributes( self ) :
+
+		c = GafferScene.Camera()
+		path = "/%s" % c["name"].getValue()
+
+		a = c["out"].attributes( path )
+		self.assertFalse( "gl:visualiser:frustum" in a )
+
+		c["visualiserAttributes"]["frustum"]["enabled"].setValue( True )
+
+		a = c["out"].attributes( path )
+		self.assertEqual( a["gl:visualiser:frustum"], IECore.BoolData( True ) )
+
+		c["visualiserAttributes"]["frustum"]["value"].setValue( False )
+
+		a = c["out"].attributes( path )
+		self.assertEqual( a["gl:visualiser:frustum"], IECore.BoolData( False ) )
+
 	def testHashes( self ) :
 
 		p = GafferScene.Camera()
 		p["projection"].setValue( "perspective" )
 		p["fieldOfView"].setValue( 45 )
+
+		# Disabled by default, enabled for hash testing
+		p['visualiserAttributes']['frustum']['enabled'].setValue( True )
 
 		for i in p['renderSettingOverrides']:
 			i["enabled"].setValue( True )
@@ -92,8 +113,8 @@ class CameraTest( GafferSceneTest.SceneTestCase ) :
 			# We ignore the enabled and sets plugs because they aren't hashed (instead
 			# their values are used to decide how the hash should be computed). We ignore
 			# the transform plug because it isn't affected by any inputs when the path is "/".
-			# We ignore the set plug because that needs a different context - we test that below.
-			self.assertHashesValid( p, inputsToIgnore = [ p["enabled"], p["sets"] ], outputsToIgnore = [ p["out"]["transform"], p["out"]["set"] ] )
+			# We ignore the set plug + attr because they needs a different context - we test that below.
+			self.assertHashesValid( p, inputsToIgnore = [ p["enabled"], p["sets"] ], outputsToIgnore = [ p["out"]["transform"], p["out"]["set"], p["out"]["attributes"] ])
 
 			c["scene:path"] = IECore.InternedStringVectorData( [ "camera" ] )
 			# We ignore the childNames because it doesn't use any inputs to compute when

--- a/python/GafferSceneUI/CameraUI.py
+++ b/python/GafferSceneUI/CameraUI.py
@@ -339,6 +339,26 @@ plugsMetadata = {
 
 	],
 
+	"visualiserAttributes" : [
+
+			"description",
+			"""
+			Attributes that affect the visualisation of this Light in the Viewer.
+			""",
+
+			"layout:section", "Visualisation",
+
+	],
+
+	"visualiserAttributes.frustum" : [
+
+			"description",
+			"""
+			Controls whether the camera draws a visualisation of its frustum.
+			"""
+
+	],
+
 }
 
 __sourceMetadata = GafferSceneUI.StandardOptionsUI.plugsMetadata

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -123,6 +123,25 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"visualiserAttributes.frustum" : [
+
+			"description",
+			"""
+			Controls whether applicable lights draw a representation of their
+			light projection in the viewer.
+			"""
+
+		],
+
+		"visualiserAttributes.lightFrustumScale" : [
+
+			"description",
+			"""
+			Allows light projections to be scaled to better suit the scene.
+			"""
+
+		],
+
 		"visualiserAttributes.ornamentScale" : [
 
 			"description",

--- a/python/GafferSceneUI/OpenGLAttributesUI.py
+++ b/python/GafferSceneUI/OpenGLAttributesUI.py
@@ -423,6 +423,15 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"attributes.lightFrustumScale" : [
+
+			"description",
+			"""
+			Allows light projections to be scaled to better suit the scene.
+			""",
+
+			"layout:section", "Visualisers",
+		],
 
 
 	}

--- a/python/GafferSceneUI/OpenGLAttributesUI.py
+++ b/python/GafferSceneUI/OpenGLAttributesUI.py
@@ -388,6 +388,19 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"attributes.visualiserFrustum" : [
+
+			"description",
+			"""
+			Controls whether applicable locations draw a representation of
+			their projection or frustum.
+			""",
+
+			"layout:section", "Visualisers",
+			"label", "Frustum",
+
+		],
+
 		"attributes.lightDrawingMode" : [
 
 			"description",

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -253,7 +253,7 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		m.append( "/VisualisersDivider", { "divider" : True } )
 
-		frustumPlug = self.getPlug()["frustum"]
+		frustumPlug = self.getPlug()["visualiser"]["frustum"]
 		m.append(
 			"/Visualisers/Frustum",
 			{
@@ -263,7 +263,7 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 		)
 
 		self.__appendValuePresetMenu(
-			m, self.getPlug()["visualiserOrnamentScale"],
+			m, self.getPlug()["visualiser"]["ornamentScale"],
 			"/Visualisers/Ornament Scale", ( 1, 10, 100 ), "Other Scale"
 		)
 

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -225,6 +225,13 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 				}
 			)
 
+		m.append( "/Lights/OptionsDivider", { "divider" : True } )
+
+		self.__appendValuePresetMenu(
+			m, self.getPlug()["light"]["frustumScale"],
+			"/Lights/Frustum Scale", ( 1, 10, 100 ), "Other Scale"
+		)
+
 		for n in ( "useGLLines", "interpolate" ) :
 			plug = self.getPlug()["curvesPrimitive"][n]
 			m.append(
@@ -255,30 +262,40 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 			}
 		)
 
-		visScaleIsOther = True
-		visScalePlug = self.getPlug()["visualiserOrnamentScale"]
-		for scale in ( 1, 10, 100 ) :
-			isSelected = visScalePlug.getValue() == scale
+		self.__appendValuePresetMenu(
+			m, self.getPlug()["visualiserOrnamentScale"],
+			"/Visualisers/Ornament Scale", ( 1, 10, 100 ), "Other Scale"
+		)
+
+		return m
+
+	def __appendValuePresetMenu( self, menu, plug, title, presets, otherDialogTitle = None  ) :
+
+		if not otherDialogTitle :
+			otherDialogTitle = title
+
+		valueIsOther = True
+		for preset in presets :
+			isSelected = plug.getValue() == preset
 			if isSelected :
-				visScaleIsOther = False
-			m.append(
-				"/Visualisers/Ornament Scale/%d" % scale,
+				valueIsOther = False
+			menu.append(
+				"%s/%s" % ( title, preset ),
 				{
-					"command" : functools.partial( lambda s, _ : visScalePlug.setValue( s ), scale ),
+					"command" : functools.partial( lambda s, _ : plug.setValue( s ), preset ),
 					"checkBox" : isSelected
 				}
 			)
 
-		m.append( "/Visualisers/Ornament Scale/__divider__", { "divider" : True } )
-		m.append(
-			"/Visualisers/Ornament Scale/Other...",
+		menu.append( "%s/__divider__" % title, { "divider" : True } )
+
+		menu.append(
+			"%s/Other..." % title,
 			{
-				"command" : functools.partial(  Gaffer.WeakMethod( self.__popupPlugWidget ), visScalePlug, "Other Scale" ),
-				"checkBox" : visScaleIsOther
+				"command" : functools.partial(  Gaffer.WeakMethod( self.__popupPlugWidget ), plug, otherDialogTitle ),
+				"checkBox" : valueIsOther
 			}
 		)
-
-		return m
 
 	def __popupPlugWidget( self, plug, title, *unused ) :
 

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -244,7 +244,16 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 			}
 		)
 
-		m.append( "/__visualiserDivider__", { "divider" : True } )
+		m.append( "/VisualisersDivider", { "divider" : True } )
+
+		frustumPlug = self.getPlug()["frustum"]
+		m.append(
+			"/Visualisers/Frustum",
+			{
+				"command" : frustumPlug.setValue,
+				"checkBox" : frustumPlug.getValue()
+			}
+		)
 
 		visScaleIsOther = True
 		visScalePlug = self.getPlug()["visualiserOrnamentScale"]
@@ -253,16 +262,16 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 			if isSelected :
 				visScaleIsOther = False
 			m.append(
-				"/Visualiser Scale/%d" % scale,
+				"/Visualisers/Ornament Scale/%d" % scale,
 				{
 					"command" : functools.partial( lambda s, _ : visScalePlug.setValue( s ), scale ),
 					"checkBox" : isSelected
 				}
 			)
 
-		m.append( "/Visualiser Scale/__divider__", { "divider" : True } )
+		m.append( "/Visualisers/Ornament Scale/__divider__", { "divider" : True } )
 		m.append(
-			"/Visualiser Scale/Other...",
+			"/Visualisers/Ornament Scale/Other...",
 			{
 				"command" : functools.partial(  Gaffer.WeakMethod( self.__popupPlugWidget ), visScalePlug, "Other Scale" ),
 				"checkBox" : visScaleIsOther

--- a/src/GafferScene/Light.cpp
+++ b/src/GafferScene/Light.cpp
@@ -72,7 +72,13 @@ Light::Light( const std::string &name )
 	IntPlugPtr maxResValuePlug = new IntPlug( "value", Gaffer::Plug::Direction::In, 512, 2, 2048 );
 	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", maxResValuePlug, false, "maxTextureResolution" ) );
 
+	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), false, "frustum" ) );
+
+	FloatPlugPtr frustumScaleValuePlug = new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f );
+	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:light:frustumScale", frustumScaleValuePlug, false, "lightFrustumScale" ) );
+
 	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), false, "lightDrawingMode" ) );
+
 	addChild( visualiserAttr  );
 }
 

--- a/src/GafferScene/OpenGLAttributes.cpp
+++ b/src/GafferScene/OpenGLAttributes.cpp
@@ -84,6 +84,7 @@ OpenGLAttributes::OpenGLAttributes( const std::string &name )
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", new IntPlug( "value", Gaffer::Plug::Direction::In, 512, 2, 2048 ), false, "visualiserMaxTextureResolution" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), false, "visualiserFrustum" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), false, "lightDrawingMode" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "gl:light:frustumScale", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f ), false, "lightFrustumScale" ) );
 }
 
 OpenGLAttributes::~OpenGLAttributes()

--- a/src/GafferScene/OpenGLAttributes.cpp
+++ b/src/GafferScene/OpenGLAttributes.cpp
@@ -82,6 +82,7 @@ OpenGLAttributes::OpenGLAttributes( const std::string &name )
 
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f ), false, "visualiserOrnamentScale" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", new IntPlug( "value", Gaffer::Plug::Direction::In, 512, 2, 2048 ), false, "visualiserMaxTextureResolution" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), false, "visualiserFrustum" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), false, "lightDrawingMode" ) );
 }
 

--- a/src/GafferSceneUI/CameraVisualiser.cpp
+++ b/src/GafferSceneUI/CameraVisualiser.cpp
@@ -66,12 +66,14 @@ class CameraVisualiser : public ObjectVisualiser
 		{
 		}
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const override
+		Visualisations visualise( const IECore::Object *object ) const override
 		{
+			Visualisations v;
+
 			const IECoreScene::Camera *camera = IECore::runTimeCast<const IECoreScene::Camera>( object );
 			if( !camera )
 			{
-				return nullptr;
+				return v;
 			}
 
 			IECoreGL::GroupPtr group = new IECoreGL::Group();
@@ -176,7 +178,8 @@ class CameraVisualiser : public ObjectVisualiser
 			curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, pData ) );
 			group->addChild( curves );
 
-			return group;
+			v[ VisualisationType::Ornament ] = group;
+			return v;
 		}
 
 	protected :

--- a/src/GafferSceneUI/ClippingPlaneVisualiser.cpp
+++ b/src/GafferSceneUI/ClippingPlaneVisualiser.cpp
@@ -56,13 +56,15 @@ class ClippingPlaneVisualiser : public ObjectVisualiser
 		typedef IECoreScene::ClippingPlane ObjectType;
 
 		ClippingPlaneVisualiser()
-			:	m_group( new IECoreGL::Group() )
 		{
-			m_group->getState()->add( new IECoreGL::Primitive::DrawWireframe( true ) );
-			m_group->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
-			m_group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
-			m_group->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0.06, 0.2, 0.56, 1 ) ) );
-			m_group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 1.0f ) );
+			IECoreGL::GroupPtr group = new IECoreGL::Group();
+			m_visualisations[ VisualisationType::Geometry ] = group;
+
+			group->getState()->add( new IECoreGL::Primitive::DrawWireframe( true ) );
+			group->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
+			group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
+			group->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0.06, 0.2, 0.56, 1 ) ) );
+			group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 1.0f ) );
 
 			IECore::V3fVectorDataPtr pData = new IECore::V3fVectorData;
 			IECore::IntVectorDataPtr vertsPerCurveData = new IECore::IntVectorData;
@@ -91,23 +93,23 @@ class ClippingPlaneVisualiser : public ObjectVisualiser
 
 			IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurveData );
 			curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, pData ) );
-			m_group->addChild( curves );
+			group->addChild( curves );
 		}
 
 		~ClippingPlaneVisualiser() override
 		{
 		}
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const override
+		Visualisations visualise( const IECore::Object *object ) const override
 		{
-			return m_group;
+			return m_visualisations;
 		}
 
 	protected :
 
 		static ObjectVisualiserDescription<ClippingPlaneVisualiser> g_visualiserDescription;
 
-		IECoreGL::GroupPtr m_group;
+		Visualisations m_visualisations;
 
 };
 

--- a/src/GafferSceneUI/CoordinateSystemVisualiser.cpp
+++ b/src/GafferSceneUI/CoordinateSystemVisualiser.cpp
@@ -56,14 +56,15 @@ class CoordinateSystemVisualiser : public ObjectVisualiser
 		typedef IECoreScene::CoordinateSystem ObjectType;
 
 		CoordinateSystemVisualiser()
-			:	m_group( new IECoreGL::Group() )
 		{
+			IECoreGL::GroupPtr group = new IECoreGL::Group();
+			m_visualisations[ VisualisationType::Geometry ] = group;
 
-			m_group->getState()->add( new IECoreGL::Primitive::DrawWireframe( true ) );
-			m_group->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
-			m_group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
-			m_group->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0.06, 0.2, 0.56, 1 ) ) );
-			m_group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 2.0f ) );
+			group->getState()->add( new IECoreGL::Primitive::DrawWireframe( true ) );
+			group->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
+			group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
+			group->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0.06, 0.2, 0.56, 1 ) ) );
+			group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 2.0f ) );
 
 			IECore::V3fVectorDataPtr pData = new IECore::V3fVectorData;
 			vector<V3f> &p = pData->writable();
@@ -80,23 +81,23 @@ class CoordinateSystemVisualiser : public ObjectVisualiser
 
 			IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurve );
 			curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, pData ) );
-			m_group->addChild( curves );
+			group->addChild( curves );
 		}
 
 		~CoordinateSystemVisualiser() override
 		{
 		}
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const override
+		Visualisations visualise( const IECore::Object *object ) const override
 		{
-			return m_group;
+			return m_visualisations;
 		}
 
 	protected :
 
 		static ObjectVisualiserDescription<CoordinateSystemVisualiser> g_visualiserDescription;
 
-		IECoreGL::GroupPtr m_group;
+		Visualisations m_visualisations;
 
 };
 

--- a/src/GafferSceneUI/ProceduralVisualiser.cpp
+++ b/src/GafferSceneUI/ProceduralVisualiser.cpp
@@ -62,7 +62,7 @@ class BoundVisualiser : public ObjectVisualiser
 		{
 		}
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const override
+		Visualisations visualise( const IECore::Object *object ) const override
 		{
 			const IECoreScene::VisibleRenderable *renderable = IECore::runTimeCast<const IECoreScene::VisibleRenderable>( object );
 
@@ -114,7 +114,9 @@ class BoundVisualiser : public ObjectVisualiser
 			curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, pData ) );
 			group->addChild( curves );
 
-			return group;
+			Visualisations v;
+			v[ VisualisationType::Geometry ] = group;
+			return v;
 		}
 
 };

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -168,6 +168,10 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			NameValuePlugPtr frustumPlug = new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), true, "visualiserFrustum" );
 			attr->addChild( frustumPlug );
 
+			FloatPlugPtr lightFrustumScaleValuePlug = new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f );
+			NameValuePlugPtr lightFrustumScalePlug = new Gaffer::NameValuePlug( "gl:light:frustumScale", lightFrustumScaleValuePlug, true, "lightFrustumScale" );
+			attr->addChild( lightFrustumScalePlug );
+
 			// View plugs
 
 			ValuePlugPtr drawingMode = new ValuePlug( "drawingMode" );
@@ -189,6 +193,7 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			ValuePlugPtr lights = new ValuePlug( "light" );
 			drawingMode->addChild( lights );
 			lights->addChild( new StringPlug( "drawingMode", Plug::In, "texture" ) );
+			lights->addChild( new FloatPlug( "frustumScale", Plug::In, 1.0f ) );
 
 			drawingMode->addChild( new BoolPlug( "frustum", Plug::In, true ) );
 			drawingMode->addChild( ornamentScaleValuePlug->createCounterpart( "visualiserOrnamentScale", Plug::Direction::In ) );
@@ -196,6 +201,7 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			lightModePlug->getChild<StringPlug>( "value" )->setInput( lights->getChild<StringPlug>( "drawingMode" ) );
 			frustumPlug->getChild<BoolPlug>( "value" )->setInput( drawingMode->getChild<BoolPlug>( "frustum" ) );
 			ornamentScaleValuePlug->setInput( drawingMode->getChild<FloatPlug>( "visualiserOrnamentScale" ) );
+			lightFrustumScaleValuePlug->setInput( lights->getChild<FloatPlug>( "frustumScale" ) );
 
 			updateOpenGLOptions();
 

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -165,6 +165,9 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			NameValuePlugPtr ornamentScalePlug = new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", ornamentScaleValuePlug, true, "visualiserOrnamentScale" );
 			attr->addChild( ornamentScalePlug );
 
+			NameValuePlugPtr frustumPlug = new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), true, "visualiserFrustum" );
+			attr->addChild( frustumPlug );
+
 			// View plugs
 
 			ValuePlugPtr drawingMode = new ValuePlug( "drawingMode" );
@@ -187,9 +190,11 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			drawingMode->addChild( lights );
 			lights->addChild( new StringPlug( "drawingMode", Plug::In, "texture" ) );
 
+			drawingMode->addChild( new BoolPlug( "frustum", Plug::In, true ) );
 			drawingMode->addChild( ornamentScaleValuePlug->createCounterpart( "visualiserOrnamentScale", Plug::Direction::In ) );
 
 			lightModePlug->getChild<StringPlug>( "value" )->setInput( lights->getChild<StringPlug>( "drawingMode" ) );
+			frustumPlug->getChild<BoolPlug>( "value" )->setInput( drawingMode->getChild<BoolPlug>( "frustum" ) );
 			ornamentScaleValuePlug->setInput( drawingMode->getChild<FloatPlug>( "visualiserOrnamentScale" ) );
 
 			updateOpenGLOptions();

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -148,31 +148,23 @@ class SceneView::DrawingMode : public boost::signals::trackable
 		DrawingMode( SceneView *view )
 			:	m_view( view )
 		{
-			// Attributes drive many of the GL drawing toggles. Some we can set
-			// through renderer options as they simply modify the state used to
-			// render existing renderables. Visualiser however, may generate
-			// different renderables all together and so we need to modify the
-			// in-scene attribute values rather than any renderer option.
+			// We can implement many drawing mode controls via render options.
+			// They simply modify the state used to render existing
+			// renderables. Visualisers however, may generate different
+			// renderables all together and so we need to modify the in-scene
+			// attribute values rather than any renderer option, which will
+			// cause the visualisers to be re-evaluated. We use a general
+			// purpose CustomAttributes preprocessor to set globals attributes
+			// with the desired values.  This allows them to be overridden at
+			// specific locations in the user's graph if desired.
+
+			// Global attributes preprocessor
+
 			m_preprocessor = new CustomAttributes();
 			m_preprocessor->globalPlug()->setValue( true );
-
 			CompoundDataPlug *attr = m_preprocessor->attributesPlug();
 
-			NameValuePlugPtr lightModePlug = new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), true, "lightDrawingMode" );
-			attr->addChild( lightModePlug );
-
-			FloatPlugPtr ornamentScaleValuePlug = new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f );
-			NameValuePlugPtr ornamentScalePlug = new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", ornamentScaleValuePlug, true, "visualiserOrnamentScale" );
-			attr->addChild( ornamentScalePlug );
-
-			NameValuePlugPtr frustumPlug = new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), true, "visualiserFrustum" );
-			attr->addChild( frustumPlug );
-
-			FloatPlugPtr lightFrustumScaleValuePlug = new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f );
-			NameValuePlugPtr lightFrustumScalePlug = new Gaffer::NameValuePlug( "gl:light:frustumScale", lightFrustumScaleValuePlug, true, "lightFrustumScale" );
-			attr->addChild( lightFrustumScalePlug );
-
-			// View plugs
+			// View plugs controlling renderer options
 
 			ValuePlugPtr drawingMode = new ValuePlug( "drawingMode" );
 			m_view->addChild( drawingMode );
@@ -190,18 +182,59 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			drawingMode->addChild( points );
 			points->addChild( new BoolPlug( "useGLPoints", Plug::In, true ) );
 
-			ValuePlugPtr lights = new ValuePlug( "light" );
-			drawingMode->addChild( lights );
-			lights->addChild( new StringPlug( "drawingMode", Plug::In, "texture" ) );
-			lights->addChild( new FloatPlug( "frustumScale", Plug::In, 1.0f ) );
+			// View plugs controlling attribute values
 
-			drawingMode->addChild( new BoolPlug( "frustum", Plug::In, true ) );
-			drawingMode->addChild( ornamentScaleValuePlug->createCounterpart( "visualiserOrnamentScale", Plug::Direction::In ) );
+			// General :
 
-			lightModePlug->getChild<StringPlug>( "value" )->setInput( lights->getChild<StringPlug>( "drawingMode" ) );
-			frustumPlug->getChild<BoolPlug>( "value" )->setInput( drawingMode->getChild<BoolPlug>( "frustum" ) );
-			ornamentScaleValuePlug->setInput( drawingMode->getChild<FloatPlug>( "visualiserOrnamentScale" ) );
-			lightFrustumScaleValuePlug->setInput( lights->getChild<FloatPlug>( "frustumScale" ) );
+			ValuePlugPtr visualiser = new ValuePlug( "visualiser" );
+			drawingMode->addChild( visualiser );
+
+			//    gl:visualiser:frustum
+
+			BoolPlugPtr frustrumAttrValuePlug = new BoolPlug( "value", Plug::In, true );
+
+			NameValuePlugPtr frustumAttrPlug = new Gaffer::NameValuePlug( "gl:visualiser:frustum", frustrumAttrValuePlug, true, "frustum" );
+			attr->addChild( frustumAttrPlug );
+			PlugPtr frustumViewPlug = frustrumAttrValuePlug->createCounterpart( "frustum", Plug::In );
+			visualiser->addChild( frustumViewPlug );
+			frustrumAttrValuePlug->setInput( frustumViewPlug );
+
+			//    gl:visualiser:ornamentScale
+
+			FloatPlugPtr ornamentScaleAttrValuePlug = new FloatPlug( "value", Plug::In, 1.0f, 0.01f );
+
+			NameValuePlugPtr ornamentScaleAttrPlug = new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", ornamentScaleAttrValuePlug, true, "ornamentScale" );
+			attr->addChild( ornamentScaleAttrPlug );
+			PlugPtr ornamentScaleViewPlug = ornamentScaleAttrValuePlug->createCounterpart( "ornamentScale", Plug::In );
+			visualiser->addChild( ornamentScaleViewPlug );
+			ornamentScaleAttrValuePlug->setInput( ornamentScaleViewPlug );
+
+			// Light specific :
+
+			ValuePlugPtr light = new ValuePlug( "light" );
+			drawingMode->addChild( light );
+
+			//    gl:light:drawingMode
+
+			StringPlugPtr lightModeAttrValuePlug = new StringPlug( "value", Plug::In, "texture" );
+
+			NameValuePlugPtr lightModeAttrPlug = new Gaffer::NameValuePlug( "gl:light:drawingMode", lightModeAttrValuePlug, true, "lightDrawingMode" );
+			attr->addChild( lightModeAttrPlug );
+			PlugPtr lightModeViewPlug = lightModeAttrValuePlug->createCounterpart( "drawingMode", Plug::In );
+			light->addChild( lightModeViewPlug );
+			lightModeAttrValuePlug->setInput( lightModeViewPlug );
+
+			//    gl:light:frustumScale
+
+			FloatPlugPtr lightFrustumScaleAttrValuePlug = new FloatPlug( "value", Plug::In , 1.0f, 0.01f );
+
+			NameValuePlugPtr lightFrustumScaleAttrPlug = new Gaffer::NameValuePlug( "gl:light:frustumScale", lightFrustumScaleAttrValuePlug, true, "lightFrustumScale" );
+			attr->addChild( lightFrustumScaleAttrPlug );
+			PlugPtr lightFrustumScaleViewPlug = lightFrustumScaleAttrValuePlug->createCounterpart( "frustumScale", Plug::In );
+			light->addChild( lightFrustumScaleViewPlug );
+			lightFrustumScaleAttrValuePlug->setInput( lightFrustumScaleViewPlug );
+
+			// Initialise renderer and event tracking
 
 			updateOpenGLOptions();
 

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -166,11 +166,11 @@ void addSolidArc( Axis axis, const V3f &center, float majorRadius, float minorRa
 	}
 }
 
-void addCone( float angle, float startRadius, vector<int> &vertsPerCurve, vector<V3f> &p )
+void addCone( float angle, float startRadius, vector<int> &vertsPerCurve, vector<V3f> &p, float length )
 {
 	const float halfAngle = 0.5 * M_PI * angle / 180.0;
-	const float baseRadius = sin( halfAngle );
-	const float baseDistance = cos( halfAngle );
+	const float baseRadius = length * sin( halfAngle );
+	const float baseDistance = length * cos( halfAngle );
 
 	if( startRadius > 0 )
 	{
@@ -182,8 +182,16 @@ void addCone( float angle, float startRadius, vector<int> &vertsPerCurve, vector
 	p.push_back( V3f( 0, baseRadius + startRadius, -baseDistance ) );
 	vertsPerCurve.push_back( 2 );
 
+	p.push_back( V3f( startRadius, 0, 0 ) );
+	p.push_back( V3f( baseRadius + startRadius, 0, -baseDistance ) );
+	vertsPerCurve.push_back( 2 );
+
 	p.push_back( V3f( 0, -startRadius, 0 ) );
 	p.push_back( V3f( 0, -baseRadius - startRadius, -baseDistance ) );
+	vertsPerCurve.push_back( 2 );
+
+	p.push_back( V3f( -startRadius, 0, 0 ) );
+	p.push_back( V3f( -baseRadius - startRadius, 0, -baseDistance ) );
 	vertsPerCurve.push_back( 2 );
 }
 
@@ -400,13 +408,17 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 
 	GroupPtr ornaments = new Group;  // Ornaments are affected by visualiser:scale while
 	GroupPtr geometry = new Group;   // geometry isn't as its size matters for rendering.
+	GroupPtr frustum = new Group;    // inherits scaling as per geometry
 
 	Visualisations result;
 	result[ VisualisationType::Geometry ] = geometry;
 	result[ VisualisationType::Ornament ] = ornaments;
+	result[ VisualisationType::Frustum ] = frustum;
 
 	const FloatData *visualiserScaleData = attributes->member<FloatData>( "gl:visualiser:ornamentScale" );
 	const float visualiserScale = visualiserScaleData ? visualiserScaleData->readable() : 1.0;
+	const FloatData *frustumScaleData = attributes->member<FloatData>( "gl:light:frustumScale" );
+	const float frustumScale = frustumScaleData ? frustumScaleData->readable() : 1.0;
 	const StringData *visualiserDrawingModeData = attributes->member<StringData>( "gl:light:drawingMode" );
 	const std::string visualiserDrawingMode = visualiserDrawingModeData ? visualiserDrawingModeData->readable() : "texture";
 
@@ -437,9 +449,10 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 	{
 		float innerAngle, outerAngle, lensRadius;
 		spotlightParameters( attributeName, shaderNetwork, innerAngle, outerAngle, lensRadius );
-		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / visualiserScale ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / visualiserScale, 1.0f, 1.0f ) ) );
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( color ) ) );
+		frustum->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / visualiserScale, 10.0f * frustumScale, 0.2f ) ) );
 	}
 	else if( type && type->readable() == "distant" )
 	{
@@ -668,36 +681,39 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::distantRays()
 	return result;
 }
 
-IECoreGL::ConstRenderablePtr StandardLightVisualiser::spotlightCone( float innerAngle, float outerAngle, float lensRadius )
+IECoreGL::ConstRenderablePtr StandardLightVisualiser::spotlightCone( float innerAngle, float outerAngle, float lensRadius, float length, float lineWidthScale )
 {
 	IECoreGL::GroupPtr group = new IECoreGL::Group();
 	addWireframeCurveState( group.get() );
-	addConstantShader( group.get(), false, 0 );
+	addConstantShader( group.get(), false );
 
-	group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 1.0f ) );
+	group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 1.0f * lineWidthScale ) );
 
 	IntVectorDataPtr vertsPerCurve = new IntVectorData;
 	V3fVectorDataPtr p = new V3fVectorData;
-	addCone( innerAngle, lensRadius, vertsPerCurve->writable(), p->writable() );
+	addCone( innerAngle, lensRadius, vertsPerCurve->writable(), p->writable(), length );
 
 	IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurve );
 	curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, p ) );
-	curves->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( g_lightWireframeColor ) ) );
+
+	const Color3fDataPtr color = new Color3fData( lineWidthScale < 1.0f ? Color3f( 0.627f, 0.580f, 0.352f ) : g_lightWireframeColor );
+	curves->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, color ) );
 
 	group->addChild( curves );
 
 	if( fabs( innerAngle - outerAngle ) > 0.1 )
 	{
 		IECoreGL::GroupPtr outerGroup = new Group;
-		outerGroup->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 0.5f ) );
+		outerGroup->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 0.5f * lineWidthScale ) );
 
 		IntVectorDataPtr vertsPerCurve = new IntVectorData;
 		V3fVectorDataPtr p = new V3fVectorData;
-		addCone( outerAngle, lensRadius, vertsPerCurve->writable(), p->writable() );
+		addCone( outerAngle, lensRadius, vertsPerCurve->writable(), p->writable(), length );
 
 		IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurve );
 		curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, p ) );
-		curves->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( g_lightWireframeColor ) ) );
+
+		curves->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, color ) );
 
 		outerGroup->addChild( curves );
 

--- a/src/GafferVDBUI/VDBVisualiser.cpp
+++ b/src/GafferVDBUI/VDBVisualiser.cpp
@@ -278,14 +278,16 @@ class VDBVisualiser : public ObjectVisualiser
 		typedef VDBObject ObjectType;
 
 		VDBVisualiser()
-			:	m_group( new IECoreGL::Group() )
 		{
 
-			m_group->getState()->add( new IECoreGL::Primitive::DrawWireframe( true ) );
-			m_group->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
-			m_group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
-			m_group->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0.06, 0.2, 0.56, 1 ) ) );
-			m_group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 2.0f ) );
+			IECoreGL::GroupPtr group = new IECoreGL::Group();
+			m_defaultVisualisations[ VisualisationType::Geometry ] = group;
+
+			group->getState()->add( new IECoreGL::Primitive::DrawWireframe( true ) );
+			group->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
+			group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
+			group->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0.06, 0.2, 0.56, 1 ) ) );
+			group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 2.0f ) );
 
 			IECore::V3fVectorDataPtr pData = new IECore::V3fVectorData;
 			vector<V3f> &p = pData->writable();
@@ -302,26 +304,26 @@ class VDBVisualiser : public ObjectVisualiser
 
 			IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurve );
 			curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, pData ) );
-			m_group->addChild( curves );
+			group->addChild( curves );
 		}
 
 		~VDBVisualiser() override
 		{
 		}
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const override
+		Visualisations visualise( const IECore::Object *object ) const override
 		{
 			const VDBObject* vdbObject = IECore::runTimeCast<const VDBObject>(object);
 			if ( !vdbObject )
 			{
-				return m_group;
+				return m_defaultVisualisations;
 			}
 
 			// todo which grid should be visualised?
 			std::vector<std::string> names = vdbObject->gridNames();
 			if (names.empty())
 			{
-				return m_group;
+				return m_defaultVisualisations;
 			}
 
 			openvdb::GridBase::ConstPtr grid = vdbObject->findGrid( names[0] );
@@ -370,14 +372,16 @@ class VDBVisualiser : public ObjectVisualiser
 
 			}
 
-			return rootGroup;
+			Visualisations v;
+			v[ VisualisationType::Geometry ] = rootGroup;
+			return v;
 		}
 
 	protected :
 
 		static ObjectVisualiserDescription<VDBVisualiser> g_visualiserDescription;
 
-		IECoreGL::GroupPtr m_group;
+		Visualisations m_defaultVisualisations;
 
 };
 


### PR DESCRIPTION
Whilst were on with Viewer improvements and we can now render frustums, a requested feature was to be able to visualise the camera frustum with clipping planes.

The grey color is used as the green was quite oppressive when drawing practically set clipping planes.

Also adds a Visualisation tab to `Camera` to match the facilities provided on `Light`.

Requires #3551 to be merged before this.

![image](https://user-images.githubusercontent.com/896779/72168089-5e7bce00-33c4-11ea-87b4-e377bf863411.png)
![image](https://user-images.githubusercontent.com/896779/72168116-6e93ad80-33c4-11ea-8cde-f9d301c52b5d.png)
