### PR TITLE
Catalogue : Ordering fixes and improved duplicate behaviour.

### DIFF
--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -486,7 +486,7 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 				self.__images().removeChild( self.__images()[index] )
 
 			# Figure out new selection
-			if not metadataIndex :
+			if metadataIndex is None :
 				selectionIndex = index - 1
 			else:
 				selectionIndex = self.__metadataIndexToGraphComponentIndex( metadataIndex - 1 )

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -590,7 +590,7 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 			return
 		self.__moveToPath = targetPath
 
-		images = sorted( self.__images(), key = lambda x : Gaffer.Metadata.value( x, _ImagesPath.indexMetadataName ) or -1 )
+		images = _ImagesPath( self.__images(), [] )._orderedImages()
 		imagesToMove = [image for image in images if '/'+image.getName() in event.data]
 
 		# Because of multi-selection it's possible to move the mouse over a selected image.


### PR DESCRIPTION
Fixes #3554 and improves duplicate behaviour.

Now, the copy is made above the source in the image list and the view remains on the source image. This better fits most common workflows where duplication is used to snapshot an in-progress IPR session.

Improvements
--------------

- Catalogue : Changed image duplication behaviour so the copy is now placed above the source in the image list. If <kbd>alt</kbd> is held whilst duplicating, then Catalog will switch to the last duplicate.

Fixes
-----

 - Catalogue : 
    - Fixed bug when deleting an image that had been dragged to the top, that resulted in incorrect image selection after deletion (#3554).
    - Fixed bug when drag-reordering images that could result other image jumping positions (#3554).