### PR TITLE
Azure : Fix intermittently failing validation + formatting backport

### DIFF
--- a/config/validateRelease.py
+++ b/config/validateRelease.py
@@ -80,9 +80,18 @@ for module in (
 with tarfile.open( args.archive, "r:gz" ) as a:
 
 	# getmember still reads the whole archive, so might as well grab them all
-	# as we go. We need to strip the first directory from all paths too as that
-	# contains the release name
-	archivePaths = { os.path.join( *m.name.split( os.sep )[1:] ) for m in a.getmembers() if os.sep in m.name }
+	# as we go. We need to strip the first directory from all paths as that
+	# contains the release name.
+
+	archivePaths = set()
+
+	for m in a.getmembers() :
+		# ignore anything not under the release directory
+		if os.sep not in m.name :
+			continue
+		# Strip the release dir and any empty components at the end
+		relPath = os.path.join( *m.name.split( os.sep )[1:] )
+		archivePaths.add( os.path.normpath( relPath ) )
 
 	missing = [ p for p in requiredPaths if p not in archivePaths ]
 	if missing :

--- a/config/validateRelease.py
+++ b/config/validateRelease.py
@@ -37,6 +37,7 @@
 
 import argparse
 import os
+import sys
 import tarfile
 
 # A script to validate a Gaffer release archive
@@ -56,7 +57,10 @@ if not os.path.exists( args.archive ) :
 	parser.exit( 1, "The specified archive '%s' does not exist." % args.archive )
 
 
-print( "Validating %s" % args.archive )
+print( "Validating %s..." % args.archive )
+# We often see the exit printout before the above on Azure, which overlaps
+# lines and confuses one. Make sure this gets printed early on.
+sys.stdout.flush()
 
 # Validate the release contains our mandatory components
 
@@ -82,9 +86,10 @@ with tarfile.open( args.archive, "r:gz" ) as a:
 
 	missing = [ p for p in requiredPaths if p not in archivePaths ]
 	if missing :
-		parser.exit( 1,
-			"ERROR: The following are missing from the archive:\n%s"
-				% "\n".join( missing )
+		sys.stderr.write(
+			"ERROR: The following are missing from the archive:\n%s\n"
+				% "\n".join( [ " - %s" % m for m in missing ] ),
 		)
+		sys.exit( 1 )
 
 print( "Archive appears OK" )


### PR DESCRIPTION
For some reason, in some situations, directories were listed with a trailing slash when reading the archive. This handles dir listing both with and without slashes.

It seemed to make sure to fix the validation errors (which fail CI) in our earliest supported branch.
We'd previously cleaned up the formatting for validation on master, so this also back-ports that fix to make the merge-forwards easier when it comes to it.