### PR TITLE
FileIndexedIOPathPreview: Fixed wrong enum being used in UI code

### DIFF
--- a/python/GafferCortexUI/FileIndexedIOPathPreview.py
+++ b/python/GafferCortexUI/FileIndexedIOPathPreview.py
@@ -50,7 +50,7 @@ class FileIndexedIOPathPreview( GafferUI.DeferredPathPreview ) :
 
 			self.__pathWidget = GafferUI.PathWidget( tmpPath )
 
-			with GafferUI.SplitContainer( GafferUI.ListContainer.Orientation.Horizontal ) :
+			with GafferUI.SplitContainer( GafferUI.SplitContainer.Orientation.Horizontal ) :
 
 				self.__pathListing = GafferUI.PathListingWidget(
 					tmpPath,


### PR DESCRIPTION
Fixes assert issue with Enums in https://github.com/ImageEngine/cortex/pull/1012 

Fixes
---
- FileIndexedIOPathPreview: Fixed wrong enum being used in UI code (#3558)