### PR TITLE
CropTool/PresetsPlugValueWidget : Set context

### DIFF
--- a/python/GafferUI/PresetsPlugValueWidget.py
+++ b/python/GafferUI/PresetsPlugValueWidget.py
@@ -92,30 +92,33 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if self.getPlug() is None :
 			return result
 
-		currentPreset = Gaffer.NodeAlgo.currentPreset( self.getPlug() )
-		allowCustom = Gaffer.Metadata.value( self.getPlug(), "presetsPlugValueWidget:allowCustom" )
-		isCustom = Gaffer.Metadata.value( self.getPlug(), "presetsPlugValueWidget:isCustom" )
-		for n in Gaffer.NodeAlgo.presets( self.getPlug() ) :
-			menuPath = n if n.startswith( "/" ) else "/" + n
-			result.append(
-				menuPath,
-				{
-					"command" : functools.partial( Gaffer.WeakMethod( self.__applyPreset ), preset = n ),
-					"checkBox" : n == currentPreset and not isCustom,
-				}
-			)
+		# Required for context-sensitive dynamic presets
+		with self.getContext():
 
-		if allowCustom:
-			result.append( "/CustomDivider", { "divider" : True } )
-			result.append(
-				"/Custom",
-				{
-					"command" : Gaffer.WeakMethod( self.__applyCustomPreset ),
-					"checkBox" : isCustom or not currentPreset,
-				}
-			)
+			currentPreset = Gaffer.NodeAlgo.currentPreset( self.getPlug() )
+			allowCustom = Gaffer.Metadata.value( self.getPlug(), "presetsPlugValueWidget:allowCustom" )
+			isCustom = Gaffer.Metadata.value( self.getPlug(), "presetsPlugValueWidget:isCustom" )
+			for n in Gaffer.NodeAlgo.presets( self.getPlug() ) :
+				menuPath = n if n.startswith( "/" ) else "/" + n
+				result.append(
+					menuPath,
+					{
+						"command" : functools.partial( Gaffer.WeakMethod( self.__applyPreset ), preset = n ),
+						"checkBox" : n == currentPreset and not isCustom,
+					}
+				)
 
-		return result
+			if allowCustom:
+				result.append( "/CustomDivider", { "divider" : True } )
+				result.append(
+					"/Custom",
+					{
+						"command" : Gaffer.WeakMethod( self.__applyCustomPreset ),
+						"checkBox" : isCustom or not currentPreset,
+					}
+				)
+
+			return result
 
 	def __applyPreset( self, unused, preset ) :
 

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -579,6 +579,8 @@ void CropWindowTool::findCropWindowPlug()
 
 	m_cropWindowPlug = nullptr;
 
+	Context::Scope scopedContext( view()->getContext() );
+
 	const GafferScene::ScenePlug::ScenePath rootPath;
 	SceneAlgo::History::Ptr history = SceneAlgo::history( scenePlug()->globalsPlug(), rootPath );
 	if( history )


### PR DESCRIPTION
Ensures context variables are set for:

 - CropWindowTool StandardOptions node search.
 - PresetsPlugValueWidget menu generation.

Fixes #3496 