### PR TITLE
Plug popup menus : Connect with `scoped = False`

### DIFF
--- a/python/GafferCortexUI/ParameterPresets.py
+++ b/python/GafferCortexUI/ParameterPresets.py
@@ -501,4 +501,4 @@ def __parameterPopupMenu( menuDefinition, parameterValueWidget ) :
 	menuDefinition.append( "/Load Preset...", { "command" : IECore.curry( __loadPreset, parameterHandler ), "active" : editable } )
 	menuDefinition.append( "/Delete Presets...", { "command" : IECore.curry( __deletePresets, parameterHandler ) } )
 
-__popupMenuConnection = GafferCortexUI.ParameterValueWidget.popupMenuSignal().connect( __parameterPopupMenu )
+GafferCortexUI.ParameterValueWidget.popupMenuSignal().connect( __parameterPopupMenu, scoped = False )

--- a/python/GafferCortexUI/ParameterValueWidget.py
+++ b/python/GafferCortexUI/ParameterValueWidget.py
@@ -142,7 +142,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 
 	ParameterValueWidget.popupMenuSignal()( menuDefinition, parameterValueWidget )
 
-__plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )
+GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu, scoped = False )
 
 # add menu items for presets
 

--- a/python/GafferSceneUI/CustomAttributesUI.py
+++ b/python/GafferSceneUI/CustomAttributesUI.py
@@ -148,4 +148,4 @@ def __attributePopupMenu( menuDefinition, plugValueWidget ) :
 			}
 		)
 
-__attributesPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __attributePopupMenu )
+GafferUI.PlugValueWidget.popupMenuSignal().connect( __attributePopupMenu, scoped = False )

--- a/python/GafferSceneUI/DeleteGlobalsUI.py
+++ b/python/GafferSceneUI/DeleteGlobalsUI.py
@@ -130,4 +130,4 @@ def __namesPopupMenu( menuDefinition, plugValueWidget ) :
 			}
 		)
 
-__namesPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __namesPopupMenu )
+GafferUI.PlugValueWidget.popupMenuSignal().connect( __namesPopupMenu, scoped = False )

--- a/python/GafferSceneUI/SceneReaderUI.py
+++ b/python/GafferSceneUI/SceneReaderUI.py
@@ -169,4 +169,4 @@ def __tagsPopupMenu( menuDefinition, plugValueWidget ) :
 			}
 		)
 
-__tagsPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __tagsPopupMenu )
+GafferUI.PlugValueWidget.popupMenuSignal().connect( __tagsPopupMenu, scoped = False )

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -236,7 +236,7 @@ def __setsPopupMenu( menuDefinition, plugValueWidget ) :
 
 		menuDefinition.prepend( "/Sets/%s" % setName, parameters )
 
-__setsPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __setsPopupMenu )
+GafferUI.PlugValueWidget.popupMenuSignal().connect( __setsPopupMenu, scoped = False )
 
 ##########################################################################
 # Gadgets

--- a/python/GafferSceneUI/TweakPlugValueWidget.py
+++ b/python/GafferSceneUI/TweakPlugValueWidget.py
@@ -137,7 +137,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ):
 		}
 	)
 
-__plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )
+GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu, scoped = False )
 
 GafferUI.PlugValueWidget.registerType( GafferScene.TweakPlug, TweakPlugValueWidget )
 

--- a/python/GafferUI/AnimationUI.py
+++ b/python/GafferUI/AnimationUI.py
@@ -148,4 +148,4 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 		}
 	)
 
-__popupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __popupMenu )
+GafferUI.PlugValueWidget.popupMenuSignal().connect( __popupMenu, scoped = False )

--- a/python/GafferUI/BoxUI.py
+++ b/python/GafferUI/BoxUI.py
@@ -269,7 +269,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 
 	__appendPlugPromotionMenuItems( menuDefinition, plugValueWidget.getPlug(), readOnly = plugValueWidget.getReadOnly() )
 
-__plugPopupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu )
+GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu, scoped = False )
 
 # GraphEditor plug context menu
 ##########################################################################

--- a/python/GafferUI/RandomUI.py
+++ b/python/GafferUI/RandomUI.py
@@ -237,4 +237,4 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 			}
 		)
 
-__popupMenuConnection = GafferUI.PlugValueWidget.popupMenuSignal().connect( __popupMenu )
+GafferUI.PlugValueWidget.popupMenuSignal().connect( __popupMenu, scoped = False )


### PR DESCRIPTION
This represents a _tiny_ bit of progress towards _maybe_ one day being able to reverse the default for `scoped` to match the C++ behaviour. That's a rather ambitious goal because we'd need all Gaffer client code to be updated to specify a `scoped` argument before we can do it. But the fewer examples we provide of how _not_ to do it, the better.
