### PR TITLE
Viewer : Frustum visualisations [+refactor]

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -25,7 +25,7 @@ Improvements
     - Added support for mesh lights such that they draw a yellow outline around the source mesh.
     - Improved display of Arnold quad lights set to portal mode.
     - Added an approximation of Arnold area light spread.
-    - Added menu items to control visualiser ornament scale.
+    - Added menu items to control visualiser scale.
     - Added menu items to control the default drawing mode for lights.
 - Set expressions :
   - Added `in` operator. The expression `A in B` selects all locations from set A which are descendants of a location from set B.
@@ -114,8 +114,8 @@ Breaking Changes
 - LightFilterVisualiser : Moved `LightFilterVisualiser` into `IECoreGLPreview`, filter visualiser registrations will need updating (#3502).
 - ObjectToImage/ImagePrimitiveSource : Removed.
 - ParallelAlgoTest : Removed `ExpectedUIThreadCall`. Use `UIThreadCallHandler` instead.
-- OpenGLRenderer : `visualiser:scale` is now handled directly in the renderer, Visualisers should no longer apply this attribute to ornament visualisations unless they need to invert this scale for any geometry-related components of the ornament.
-- GafferScene : Renamed attribute `visualiser:scale` > `gl:visualiser:ornamentScale`. Note : Existing scenes with OpenGLAttribute nodes setting this will need values re-entering.
+- OpenGLRenderer : `visualiser:scale` is now handled directly in the renderer, Visualisers should no longer apply this attribute to visualisations unless they need to invert this scale for any geometry-related components of the visualisation.
+- GafferScene : Renamed attribute `visualiser:scale` > `gl:visualiser:scale`. Note : Existing scenes with OpenGLAttribute nodes setting this will need values re-entering.
 - IECoreGLPreview : Refactored the visualisation methods of `LightVisualiser`, `LightFilterVisualiser` and to support categorisation of renderables via `VisualisationMap`.
 - Arnold : Raised minimum required version to 5.4.
 

--- a/SConstruct
+++ b/SConstruct
@@ -731,7 +731,7 @@ libraries = {
 			"LIBS" : [ "Gaffer", "Iex$OPENEXR_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX",  "IECoreScene$CORTEX_LIB_SUFFIX", "GafferImage", "GafferDispatch", "Half" ],
 		},
 		"pythonEnvAppends" : {
-			"LIBS" : [ "GafferBindings", "GafferScene", "GafferDispatch", "GafferImage", "IECoreScene$CORTEX_LIB_SUFFIX" ],
+			"LIBS" : [ "GafferBindings", "GafferScene", "GafferDispatch", "GafferImage", "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX" ],
 		},
 		"additionalFiles" : glob.glob( "glsl/*.frag" ) + glob.glob( "glsl/*.vert" ) + glob.glob( "include/GafferScene/Private/IECore*Preview/*.h" )
 	},

--- a/include/GafferScene/Camera.h
+++ b/include/GafferScene/Camera.h
@@ -99,12 +99,18 @@ class GAFFERSCENE_API Camera : public ObjectSource
 		Gaffer::CompoundDataPlug *renderSettingOverridesPlug();
 		const Gaffer::CompoundDataPlug *renderSettingOverridesPlug() const;
 
+		Gaffer::CompoundDataPlug *visualiserAttributesPlug();
+		const Gaffer::CompoundDataPlug *visualiserAttributesPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
+
+		void hashAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 		IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const override;
 

--- a/include/GafferScene/Private/IECoreGLPreview/ObjectVisualiser.h
+++ b/include/GafferScene/Private/IECoreGLPreview/ObjectVisualiser.h
@@ -39,6 +39,8 @@
 
 #include "GafferScene/Export.h"
 
+#include "GafferScene/Private/IECoreGLPreview/Visualiser.h"
+
 #include "IECoreGL/Renderable.h"
 
 #include "IECore/Object.h"
@@ -66,7 +68,7 @@ class GAFFERSCENE_API ObjectVisualiser : public IECore::RefCounted
 
 		/// Must be implemented by derived classes to return a suitable
 		/// visualisation of the object.
-		virtual IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const = 0;
+		virtual Visualisations visualise( const IECore::Object *object ) const = 0;
 
 		/// @name Factory
 		///////////////////////////////////////////////////////////////////

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -72,7 +72,7 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 		static IECoreGL::ConstRenderablePtr ray();
 		static IECoreGL::ConstRenderablePtr pointRays( float radius = 0 );
 		static IECoreGL::ConstRenderablePtr distantRays();
-		static IECoreGL::ConstRenderablePtr spotlightCone( float innerAngle, float outerAngle, float lensRadius );
+		static IECoreGL::ConstRenderablePtr spotlightCone( float innerAngle, float outerAngle, float lensRadius, float length = 1.0f, float lineWidthScale = 1.0f );
 
 		static IECoreGL::ConstRenderablePtr quadPortal( const Imath::V2f &size );
 

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -106,7 +106,7 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 		static IECoreGL::ConstRenderablePtr environmentSphereSurface( IECore::ConstDataPtr textureData, int textureMaxResolution, const Imath::Color3f &fallbackColor  );
 
 		// Spread is generally rendered as an angle, rather than in light space,
-		// as such, this should generally only be used as an ornament type visualisation.
+		// as such, this should generally only be used as a uniformly scaled visualisation.
 		static IECoreGL::ConstRenderablePtr areaSpread( float spread );
 
 		static IECoreGL::ConstRenderablePtr quadWireframe( const Imath::V2f &size );

--- a/python/GafferSceneTest/CameraTest.py
+++ b/python/GafferSceneTest/CameraTest.py
@@ -90,20 +90,20 @@ class CameraTest( GafferSceneTest.SceneTestCase ) :
 
 		a = c["out"].attributes( path )
 		self.assertEqual( a["gl:visualiser:frustum"], IECore.BoolData( True ) )
-		self.assertFalse( "gl:visualiser:ornamentScale" in a )
+		self.assertFalse( "gl:visualiser:scale" in a )
 
-		c["visualiserAttributes"]["ornamentScale"]["enabled"].setValue( True )
+		c["visualiserAttributes"]["scale"]["enabled"].setValue( True )
 		a = c["out"].attributes( path )
 
 		self.assertEqual( a["gl:visualiser:frustum"], IECore.BoolData( True ) )
-		self.assertEqual( a["gl:visualiser:ornamentScale"], IECore.FloatData( 1.0 ) )
+		self.assertEqual( a["gl:visualiser:scale"], IECore.FloatData( 1.0 ) )
 
 		c["visualiserAttributes"]["frustum"]["value"].setValue( False )
-		c["visualiserAttributes"]["ornamentScale"]["value"].setValue( 12.1 )
+		c["visualiserAttributes"]["scale"]["value"].setValue( 12.1 )
 
 		a = c["out"].attributes( path )
 		self.assertEqual( a["gl:visualiser:frustum"], IECore.BoolData( False ) )
-		self.assertEqual( a["gl:visualiser:ornamentScale"], IECore.FloatData( 12.1 ) )
+		self.assertEqual( a["gl:visualiser:scale"], IECore.FloatData( 12.1 ) )
 
 	def testHashes( self ) :
 
@@ -113,7 +113,7 @@ class CameraTest( GafferSceneTest.SceneTestCase ) :
 
 		# Disabled by default, enabled for hash testing
 		p['visualiserAttributes']['frustum']['enabled'].setValue( True )
-		p['visualiserAttributes']['ornamentScale']['enabled'].setValue( True )
+		p['visualiserAttributes']['scale']['enabled'].setValue( True )
 
 		for i in p['renderSettingOverrides']:
 			i["enabled"].setValue( True )

--- a/python/GafferSceneTest/IECoreGLPreviewTest/VisualiserTest.py
+++ b/python/GafferSceneTest/IECoreGLPreviewTest/VisualiserTest.py
@@ -1,0 +1,85 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECoreGL
+
+import GafferTest
+import GafferScene
+
+class VisualiserTest( GafferTest.TestCase ) :
+
+	def testConstructor( self ) :
+
+		g = IECoreGL.Group()
+
+		v = GafferScene.IECoreScenePreview.Visualisation( g )
+		self.assertEqual( v.scale, GafferScene.IECoreScenePreview.Visualisation.Scale.Local )
+		self.assertEqual( v.category, GafferScene.IECoreScenePreview.Visualisation.Category.Generic )
+		self.assertEqual( v.affectsFramingBound, True )
+
+		v = GafferScene.IECoreScenePreview.Visualisation( g,
+			GafferScene.IECoreScenePreview.Visualisation.Scale.None,
+			GafferScene.IECoreScenePreview.Visualisation.Category.Frustum,
+			False
+		)
+		self.assertEqual( v.scale, GafferScene.IECoreScenePreview.Visualisation.Scale.None )
+		self.assertEqual( v.category, GafferScene.IECoreScenePreview.Visualisation.Category.Frustum )
+		self.assertEqual( v.affectsFramingBound, False )
+
+	def testVisualisationConvenienceConstructors( self ) :
+
+		g = IECoreGL.Group()
+
+		geom = GafferScene.IECoreScenePreview.Visualisation.createGeometry( g )
+		self.assertEqual( geom.scale, GafferScene.IECoreScenePreview.Visualisation.Scale.Local )
+		self.assertEqual( geom.category, GafferScene.IECoreScenePreview.Visualisation.Category.Generic )
+		self.assertEqual( geom.affectsFramingBound, True )
+
+		for bounded in ( True, False ) :
+			o = GafferScene.IECoreScenePreview.Visualisation.createOrnament( g, bounded )
+			self.assertEqual( o.scale, GafferScene.IECoreScenePreview.Visualisation.Scale.Visualiser )
+			self.assertEqual( o.category, GafferScene.IECoreScenePreview.Visualisation.Category.Generic )
+			self.assertEqual( o.affectsFramingBound, bounded )
+
+		Scale = GafferScene.IECoreScenePreview.Visualisation.Scale
+		for scale in ( Scale.Local, Scale.Visualiser ) :
+			f = GafferScene.IECoreScenePreview.Visualisation.createFrustum( g, scale )
+			self.assertEqual( f.scale, scale )
+			self.assertEqual( f.category, GafferScene.IECoreScenePreview.Visualisation.Category.Frustum )
+			self.assertEqual( f.affectsFramingBound, False )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/IECoreGLPreviewTest/__init__.py
+++ b/python/GafferSceneTest/IECoreGLPreviewTest/__init__.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 from RendererTest import RendererTest
+from VisualiserTest import VisualiserTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferSceneTest/LightTest.py
+++ b/python/GafferSceneTest/LightTest.py
@@ -228,6 +228,8 @@ class LightTest( GafferSceneTest.SceneTestCase ) :
 		self.assertFalse( "gl:light:drawingMode" in a.keys() )
 		self.assertFalse( "gl:visualiser:ornamentScale" in a.keys() )
 		self.assertFalse( "gl:visualiser:maxTextureResolution" in a.keys() )
+		self.assertFalse( "gl:visualiser:frustum" in a.keys() )
+		self.assertFalse( "gl:light:frustumScale" in a.keys() )
 
 		# Test attribute mapping
 
@@ -237,12 +239,18 @@ class LightTest( GafferSceneTest.SceneTestCase ) :
 		l["visualiserAttributes"]["ornamentScale"]["value"].setValue( 12.3 )
 		l["visualiserAttributes"]["maxTextureResolution"]["enabled"].setValue( True )
 		l["visualiserAttributes"]["maxTextureResolution"]["value"].setValue( 123 )
+		l["visualiserAttributes"]["frustum"]["enabled"].setValue( True )
+		l["visualiserAttributes"]["frustum"]["value"].setValue( False )
+		l["visualiserAttributes"]["lightFrustumScale"]["enabled"].setValue( True )
+		l["visualiserAttributes"]["lightFrustumScale"]["value"].setValue( 1.23 )
 
 		a = l["out"].attributes( "/light" )
 
 		self.assertEqual( a["gl:light:drawingMode"], IECore.StringData( "color" ) )
 		self.assertEqual( a["gl:visualiser:ornamentScale"], IECore.FloatData( 12.3 ) )
 		self.assertEqual( a["gl:visualiser:maxTextureResolution"], IECore.IntData( 123 ) )
+		self.assertEqual( a["gl:visualiser:frustum"], IECore.BoolData( False ) )
+		self.assertEqual( a["gl:light:frustumScale"], IECore.FloatData( 1.23 ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/LightTest.py
+++ b/python/GafferSceneTest/LightTest.py
@@ -226,7 +226,7 @@ class LightTest( GafferSceneTest.SceneTestCase ) :
 		a = l["out"].attributes( "/light" )
 
 		self.assertFalse( "gl:light:drawingMode" in a.keys() )
-		self.assertFalse( "gl:visualiser:ornamentScale" in a.keys() )
+		self.assertFalse( "gl:visualiser:scale" in a.keys() )
 		self.assertFalse( "gl:visualiser:maxTextureResolution" in a.keys() )
 		self.assertFalse( "gl:visualiser:frustum" in a.keys() )
 		self.assertFalse( "gl:light:frustumScale" in a.keys() )
@@ -235,8 +235,8 @@ class LightTest( GafferSceneTest.SceneTestCase ) :
 
 		l["visualiserAttributes"]["lightDrawingMode"]["enabled"].setValue( True )
 		l["visualiserAttributes"]["lightDrawingMode"]["value"].setValue( "color" )
-		l["visualiserAttributes"]["ornamentScale"]["enabled"].setValue( True )
-		l["visualiserAttributes"]["ornamentScale"]["value"].setValue( 12.3 )
+		l["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+		l["visualiserAttributes"]["scale"]["value"].setValue( 12.3 )
 		l["visualiserAttributes"]["maxTextureResolution"]["enabled"].setValue( True )
 		l["visualiserAttributes"]["maxTextureResolution"]["value"].setValue( 123 )
 		l["visualiserAttributes"]["frustum"]["enabled"].setValue( True )
@@ -247,7 +247,7 @@ class LightTest( GafferSceneTest.SceneTestCase ) :
 		a = l["out"].attributes( "/light" )
 
 		self.assertEqual( a["gl:light:drawingMode"], IECore.StringData( "color" ) )
-		self.assertEqual( a["gl:visualiser:ornamentScale"], IECore.FloatData( 12.3 ) )
+		self.assertEqual( a["gl:visualiser:scale"], IECore.FloatData( 12.3 ) )
 		self.assertEqual( a["gl:visualiser:maxTextureResolution"], IECore.IntData( 123 ) )
 		self.assertEqual( a["gl:visualiser:frustum"], IECore.BoolData( False ) )
 		self.assertEqual( a["gl:light:frustumScale"], IECore.FloatData( 1.23 ) )

--- a/python/GafferSceneUI/CameraUI.py
+++ b/python/GafferSceneUI/CameraUI.py
@@ -339,6 +339,36 @@ plugsMetadata = {
 
 	],
 
+	"visualiserAttributes" : [
+
+			"description",
+			"""
+			Attributes that affect the visualisation of this Light in the Viewer.
+			""",
+
+			"layout:section", "Visualisation",
+
+	],
+
+	"visualiserAttributes.ornamentScale" : [
+
+			"description",
+			"""
+			Scales non-geometric visualisations in the viewport to make them
+			easier to work with.
+			""",
+
+	],
+
+	"visualiserAttributes.frustum" : [
+
+			"description",
+			"""
+			Controls whether the camera draws a visualisation of its frustum.
+			"""
+
+	],
+
 }
 
 __sourceMetadata = GafferSceneUI.StandardOptionsUI.plugsMetadata

--- a/python/GafferSceneUI/CameraUI.py
+++ b/python/GafferSceneUI/CameraUI.py
@@ -350,7 +350,7 @@ plugsMetadata = {
 
 	],
 
-	"visualiserAttributes.ornamentScale" : [
+	"visualiserAttributes.scale" : [
 
 			"description",
 			"""

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -148,7 +148,7 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"visualiserAttributes.ornamentScale" : [
+		"visualiserAttributes.scale" : [
 
 			"description",
 			"""

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -129,6 +129,25 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"visualiserAttributes.frustum" : [
+
+			"description",
+			"""
+			Controls whether applicable lights draw a representation of their
+			light projection in the viewer.
+			"""
+
+		],
+
+		"visualiserAttributes.lightFrustumScale" : [
+
+			"description",
+			"""
+			Allows light projections to be scaled to better suit the scene.
+			"""
+
+		],
+
 		"visualiserAttributes.ornamentScale" : [
 
 			"description",

--- a/python/GafferSceneUI/OpenGLAttributesUI.py
+++ b/python/GafferSceneUI/OpenGLAttributesUI.py
@@ -362,7 +362,7 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"attributes.visualiserOrnamentScale" : [
+		"attributes.visualiserScale" : [
 
 			"description",
 			"""
@@ -371,7 +371,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"layout:section", "Visualisers",
-			"label", "Ornament Scale",
+			"label", "Scale",
 
 		],
 

--- a/python/GafferSceneUI/OpenGLAttributesUI.py
+++ b/python/GafferSceneUI/OpenGLAttributesUI.py
@@ -423,6 +423,15 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"attributes.lightFrustumScale" : [
+
+			"description",
+			"""
+			Allows light projections to be scaled to better suit the scene.
+			""",
+
+			"layout:section", "Visualisers",
+		],
 
 
 	}

--- a/python/GafferSceneUI/OpenGLAttributesUI.py
+++ b/python/GafferSceneUI/OpenGLAttributesUI.py
@@ -388,6 +388,19 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"attributes.visualiserFrustum" : [
+
+			"description",
+			"""
+			Controls whether applicable locations draw a representation of
+			their projection or frustum.
+			""",
+
+			"layout:section", "Visualisers",
+			"label", "Frustum",
+
+		],
+
 		"attributes.lightDrawingMode" : [
 
 			"description",

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -225,6 +225,13 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 				}
 			)
 
+		m.append( "/Lights/OptionsDivider", { "divider" : True } )
+
+		self.__appendValuePresetMenu(
+			m, self.getPlug()["light"]["frustumScale"],
+			"/Lights/Frustum Scale", ( 1, 10, 100 ), "Other Scale"
+		)
+
 		for n in ( "useGLLines", "interpolate" ) :
 			plug = self.getPlug()["curvesPrimitive"][n]
 			m.append(
@@ -255,30 +262,40 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 			}
 		)
 
-		visScaleIsOther = True
-		visScalePlug = self.getPlug()["visualiserOrnamentScale"]
-		for scale in ( 1, 10, 100 ) :
-			isSelected = visScalePlug.getValue() == scale
+		self.__appendValuePresetMenu(
+			m, self.getPlug()["visualiserOrnamentScale"],
+			"/Visualisers/Ornament Scale", ( 1, 10, 100 ), "Other Scale"
+		)
+
+		return m
+
+	def __appendValuePresetMenu( self, menu, plug, title, presets, otherDialogTitle = None  ) :
+
+		if not otherDialogTitle :
+			otherDialogTitle = title
+
+		valueIsOther = True
+		for preset in presets :
+			isSelected = plug.getValue() == preset
 			if isSelected :
-				visScaleIsOther = False
-			m.append(
-				"/Visualisers/Ornament Scale/%d" % scale,
+				valueIsOther = False
+			menu.append(
+				"%s/%s" % ( title, preset ),
 				{
-					"command" : functools.partial( lambda s, _ : visScalePlug.setValue( s ), scale ),
+					"command" : functools.partial( lambda s, _ : plug.setValue( s ), preset ),
 					"checkBox" : isSelected
 				}
 			)
 
-		m.append( "/Visualisers/Ornament Scale/__divider__", { "divider" : True } )
-		m.append(
-			"/Visualisers/Ornament Scale/Other...",
+		menu.append( "%s/__divider__" % title, { "divider" : True } )
+
+		menu.append(
+			"%s/Other..." % title,
 			{
-				"command" : functools.partial(  Gaffer.WeakMethod( self.__popupPlugWidget ), visScalePlug, "Other Scale" ),
-				"checkBox" : visScaleIsOther
+				"command" : functools.partial(  Gaffer.WeakMethod( self.__popupPlugWidget ), plug, otherDialogTitle ),
+				"checkBox" : valueIsOther
 			}
 		)
-
-		return m
 
 	def __popupPlugWidget( self, plug, title, *unused ) :
 

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -263,8 +263,8 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 		)
 
 		self.__appendValuePresetMenu(
-			m, self.getPlug()["visualiserOrnamentScale"],
-			"/Visualisers/Ornament Scale", ( 1, 10, 100 ), "Other Scale"
+			m, self.getPlug()["visualiserScale"],
+			"/Visualisers/Scale", ( 1, 10, 100 ), "Other Scale"
 		)
 
 		return m

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -253,7 +253,7 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		m.append( "/VisualisersDivider", { "divider" : True } )
 
-		frustumPlug = self.getPlug()["frustum"]
+		frustumPlug = self.getPlug()["visualiser"]["frustum"]
 		m.append(
 			"/Visualisers/Frustum",
 			{
@@ -263,7 +263,7 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 		)
 
 		self.__appendValuePresetMenu(
-			m, self.getPlug()["visualiserScale"],
+			m, self.getPlug()["visualiser"]["scale"],
 			"/Visualisers/Scale", ( 1, 10, 100 ), "Other Scale"
 		)
 

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -244,7 +244,16 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 			}
 		)
 
-		m.append( "/__visualiserDivider__", { "divider" : True } )
+		m.append( "/VisualisersDivider", { "divider" : True } )
+
+		frustumPlug = self.getPlug()["frustum"]
+		m.append(
+			"/Visualisers/Frustum",
+			{
+				"command" : frustumPlug.setValue,
+				"checkBox" : frustumPlug.getValue()
+			}
+		)
 
 		visScaleIsOther = True
 		visScalePlug = self.getPlug()["visualiserOrnamentScale"]
@@ -253,16 +262,16 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 			if isSelected :
 				visScaleIsOther = False
 			m.append(
-				"/Visualiser Scale/%d" % scale,
+				"/Visualisers/Ornament Scale/%d" % scale,
 				{
 					"command" : functools.partial( lambda s, _ : visScalePlug.setValue( s ), scale ),
 					"checkBox" : isSelected
 				}
 			)
 
-		m.append( "/Visualiser Scale/__divider__", { "divider" : True } )
+		m.append( "/Visualisers/Ornament Scale/__divider__", { "divider" : True } )
 		m.append(
-			"/Visualiser Scale/Other...",
+			"/Visualisers/Ornament Scale/Other...",
 			{
 				"command" : functools.partial(  Gaffer.WeakMethod( self.__popupPlugWidget ), visScalePlug, "Other Scale" ),
 				"checkBox" : visScaleIsOther

--- a/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
+++ b/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
@@ -441,9 +441,7 @@ Visualisations ArnoldLightVisualiser::visualise( const IECore::InternedString &a
 			IECoreGL::RenderablePtr iesVis = iesVisualisation( iesFilenameData->readable() );
 			if( iesVis )
 			{
-				IECoreGL::Renderable *ornamentVis = boost::const_pointer_cast<IECoreGL::Renderable>( v[VisualisationType::Ornament] ).get();
-				IECoreGL::Group *g = runTimeCast<IECoreGL::Group>( ornamentVis );
-				g->addChild( iesVis );
+				v.push_back( Visualisation::createOrnament( iesVis, true ) );
 			}
 		}
 	}

--- a/src/GafferArnoldUI/BarndoorVisualiser.cpp
+++ b/src/GafferArnoldUI/BarndoorVisualiser.cpp
@@ -232,9 +232,7 @@ Visualisations BarndoorVisualiser::visualise( const IECore::InternedString &attr
 		result->setTransform( barndoorTrans );
 	}
 
-	Visualisations v;
-	v[ VisualisationType::Ornament ] = result;
-	return v;
+	return { Visualisation::createOrnament( result, false ) };
 
 }
 

--- a/src/GafferArnoldUI/DecayVisualiser.cpp
+++ b/src/GafferArnoldUI/DecayVisualiser.cpp
@@ -227,11 +227,9 @@ Visualisations DecayVisualiser::visualise( const IECore::InternedString &attribu
 	KnotVector knots;
 	getKnotsToVisualize( shaderNetwork, knots );
 
-	Visualisations v;
-
 	if( knots.empty() )
 	{
-		return v;
+		return {};
 	}
 
 	IECoreGL::GroupPtr result = new IECoreGL::Group();
@@ -241,8 +239,10 @@ Visualisations DecayVisualiser::visualise( const IECore::InternedString &attribu
 		addKnot( result, knots[i] );
 	}
 
-	v[  VisualisationType::Geometry ] = result;
-	return v;
+	// On the whole in Gaffer we assume that light scale doesn't affect the
+	// render (this may need to be configurable later). Decay shouldn't scale
+	// with visualisation scale either though.
+	return { Visualisation( result, Visualisation::Scale::None ) };
 }
 
 } // namespace

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -260,9 +260,7 @@ Visualisations GoboVisualiser::visualise( const IECore::InternedString &attribut
 
 	result->addChild( new IECoreGL::QuadPrimitive( 1.0f, 1.0f ) );
 
-	Visualisations v;
-	v[ VisualisationType::Ornament ] = result;
-	return v;
+	return { Visualisation::createOrnament( result, true ) };
 }
 
 } // namespace

--- a/src/GafferArnoldUI/LightBlockerVisualiser.cpp
+++ b/src/GafferArnoldUI/LightBlockerVisualiser.cpp
@@ -252,9 +252,7 @@ Visualisations LightBlockerVisualiser::visualise( const IECore::InternedString &
 		result->addChild( const_pointer_cast<IECoreGL::Renderable>( planeShape( shaderParameters ) ) );
 	}
 
-	Visualisations v;
-	v[ VisualisationType::Geometry ] = result;
-	return v;
+	return { Visualisation::createGeometry( result ) };
 }
 
 IECoreGL::ConstRenderablePtr LightBlockerVisualiser::boxShape( const IECore::CompoundData *shaderParameters )

--- a/src/GafferScene/Camera.cpp
+++ b/src/GafferScene/Camera.cpp
@@ -88,7 +88,7 @@ Camera::Camera( const std::string &name )
 	renderSettingOverridesPlug()->addChild( new NameValuePlug( "depthOfField", new BoolData( false ), false, "depthOfField" ) );
 
 	addChild( new CompoundDataPlug( "visualiserAttributes" ) );
-	visualiserAttributesPlug()->addChild( new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f ), false, "ornamentScale" ) );
+	visualiserAttributesPlug()->addChild( new Gaffer::NameValuePlug( "gl:visualiser:scale", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f ), false, "scale" ) );
 	visualiserAttributesPlug()->addChild( new NameValuePlug( "gl:visualiser:frustum", new BoolData( true ), false, "frustum" ) );
 }
 

--- a/src/GafferScene/Camera.cpp
+++ b/src/GafferScene/Camera.cpp
@@ -86,6 +86,10 @@ Camera::Camera( const std::string &name )
 	renderSettingOverridesPlug()->addChild( new NameValuePlug( "overscanBottom", new FloatData( 0.0f ), false, "overscanBottom" ) );
 	renderSettingOverridesPlug()->addChild( new NameValuePlug( "cropWindow", new Box2fData( Box2f( V2f(0.0f), V2f(1.0f) ) ), false, "cropWindow" ) );
 	renderSettingOverridesPlug()->addChild( new NameValuePlug( "depthOfField", new BoolData( false ), false, "depthOfField" ) );
+
+	addChild( new CompoundDataPlug( "visualiserAttributes" ) );
+	visualiserAttributesPlug()->addChild( new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f ), false, "ornamentScale" ) );
+	visualiserAttributesPlug()->addChild( new NameValuePlug( "gl:visualiser:frustum", new BoolData( true ), false, "frustum" ) );
 }
 
 Camera::~Camera()
@@ -222,6 +226,16 @@ const Gaffer::CompoundDataPlug *Camera::renderSettingOverridesPlug() const
 	return getChild<CompoundDataPlug>( g_firstPlugIndex + 12 );
 }
 
+Gaffer::CompoundDataPlug *Camera::visualiserAttributesPlug()
+{
+	return getChild<CompoundDataPlug>( g_firstPlugIndex + 13 );
+}
+
+const Gaffer::CompoundDataPlug *Camera::visualiserAttributesPlug() const
+{
+	return getChild<CompoundDataPlug>( g_firstPlugIndex + 13 );
+}
+
 void Camera::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	ObjectSource::affects( input, outputs );
@@ -243,6 +257,11 @@ void Camera::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 	)
 	{
 		outputs.push_back( sourcePlug() );
+	}
+
+	if( visualiserAttributesPlug()->isAncestorOf( input ) )
+	{
+		outputs.push_back( outPlug()->attributesPlug() );
 	}
 }
 
@@ -302,5 +321,20 @@ IECore::ConstInternedStringVectorDataPtr Camera::computeStandardSetNames() const
 {
 	IECore::InternedStringVectorDataPtr result = new IECore::InternedStringVectorData();
 	result->writable().push_back( g_camerasSetName );
+	return result;
+}
+
+void Camera::hashAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	ObjectSource::hashAttributes( path, context, parent, h );
+	visualiserAttributesPlug()->hash( h );
+}
+
+IECore::ConstCompoundObjectPtr Camera::computeAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
+{
+	IECore::CompoundObjectPtr result = new IECore::CompoundObject;
+	IECore::ConstCompoundObjectPtr attr = ObjectSource::computeAttributes( path, context, parent );
+	result->members() = attr->members(); // Shallow copy for speed - do not modify in place!
+	visualiserAttributesPlug()->fillCompoundObject( result->members() );
 	return result;
 }

--- a/src/GafferScene/IECoreGLPreview/AttributeVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/AttributeVisualiser.cpp
@@ -75,7 +75,7 @@ Visualisations AttributeVisualiser::allVisualisations( const IECore::CompoundObj
 
 		if( !curVis.empty() )
 		{
-			Private::collectVisualisations( curVis, resultVis );
+			resultVis.insert( resultVis.end(), curVis.begin(), curVis.end() );
 		}
 
 		if( curState )

--- a/src/GafferScene/IECoreGLPreview/LightFilterVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/LightFilterVisualiser.cpp
@@ -164,7 +164,7 @@ Visualisations LightFilterVisualiser::allVisualisations( const IECore::CompoundO
 
 		if( !curVis.empty() )
 		{
-			Private::collectVisualisations( curVis, resultVis );
+			resultVis.insert( resultVis.end(), curVis.begin(), curVis.end() );
 		}
 
 		if( curState )

--- a/src/GafferScene/IECoreGLPreview/LightVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/LightVisualiser.cpp
@@ -173,7 +173,7 @@ Visualisations LightVisualiser::allVisualisations( const IECore::CompoundObject 
 
 		if( !curVis.empty() )
 		{
-			Private::collectVisualisations( curVis, resultVis );
+			resultVis.insert( resultVis.end(), curVis.begin(), curVis.end() );
 		}
 
 		if( curState )

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -91,6 +91,70 @@ using namespace IECoreGLPreview;
 
 namespace
 {
+class ScopedTransform
+{
+	public:
+		ScopedTransform( const M44f &transform )
+		{
+			m_nonIdentity = transform != M44f();
+			if( m_nonIdentity )
+			{
+				glPushMatrix();
+				glMultMatrixf( transform.getValue() );
+			}
+		}
+
+		~ScopedTransform()
+		{
+			if( m_nonIdentity )
+			{
+				glPopMatrix();
+			}
+		}
+
+	private :
+		bool m_nonIdentity;
+};
+
+bool haveMatchingVisualisations( const Visualisations& visualisations, Visualisation::Scale scale, Visualisation::Category category )
+{
+	for( auto v : visualisations )
+	{
+		if( v.scale == scale && v.category & category )
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+void renderMatchingVisualisations( const Visualisations& visualisations, Visualisation::Scale scale, Visualisation::Category category, IECoreGL::State *state )
+{
+	for( auto v : visualisations )
+	{
+		if( v.scale == scale && v.category & category )
+		{
+			v.renderable()->render( state );
+		}
+	}
+}
+
+void accumulateVisualisationBounds( const Visualisations& visualisations, Box3f &target, Visualisation::Scale scale, const M44f &transform )
+{
+	for( auto v : visualisations )
+	{
+		if( !v.affectsFramingBound || v.scale != scale )
+		{
+			continue;
+		}
+
+		const Box3f b = v.renderable()->bound();
+		if( !b.isEmpty() )
+		{
+			target.extendBy( Imath::transform( b, transform ) );
+		}
+	}
+}
 
 template<typename T>
 T *reportedCast( const IECore::RunTimeTyped *v, const char *type, const IECore::InternedString &name )
@@ -156,6 +220,9 @@ class OpenGLAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			const FloatData *ornamentScaleData = attributes->member<FloatData>( "gl:visualiser:ornamentScale" );
 			m_ornamentScale = ornamentScaleData ? ornamentScaleData->readable() : 1.0;
 
+			const BoolData *drawFrustumData = attributes->member<BoolData>( "gl:visualiser:frustum" );
+			m_drawFrustum = drawFrustumData ? drawFrustumData->readable() : true;
+
 			m_state = static_pointer_cast<const State>(
 				CachedConverter::defaultCachedConverter()->convert( attributes )
 			);
@@ -176,10 +243,9 @@ class OpenGLAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 					// Light filter visualisers are in `m_lightFilterVisualisations` and light visualisers are in
 					// `m_lightVisualisations`. Combine them both into `m_lightVisualisations` so that
 					// filters attached to light locations are drawn as expected.
-					Visualisations allVisualisation;
-					Private::collectVisualisations( m_lightVisualisations, allVisualisation );
-					Private::collectVisualisations( m_lightFilterVisualisations, allVisualisation );
-					m_lightVisualisations = allVisualisation;
+					m_lightVisualisations.insert( m_lightVisualisations.end(),
+						m_lightFilterVisualisations.begin(), m_lightFilterVisualisations.end()
+					);
 				}
 				else
 				{
@@ -216,19 +282,19 @@ class OpenGLAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			return m_state.get();
 		}
 
-		const IECoreGL::Renderable *visualisation( VisualisationType type ) const
+		const IECoreGLPreview::Visualisations &visualisations() const
 		{
-			return m_visualisations[ type ].get();
+			return m_visualisations;
 		}
 
-		const IECoreGL::Renderable *lightVisualisation( VisualisationType type ) const
+		const IECoreGLPreview::Visualisations &lightVisualisations() const
 		{
-			return m_lightVisualisations[ type ].get();
+			return m_lightVisualisations;
 		}
 
-		const IECoreGL::Renderable *lightFilterVisualisation( VisualisationType type ) const
+		const IECoreGLPreview::Visualisations &lightFilterVisualisations() const
 		{
-			return m_lightFilterVisualisations[ type  ].get();
+			return m_lightFilterVisualisations;
 		}
 
 		float ornamentScale() const
@@ -236,9 +302,15 @@ class OpenGLAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			return m_ornamentScale;
 		}
 
+		bool drawFrustum() const
+		{
+			return m_drawFrustum;
+		}
+
 	private :
 
 		ConstStatePtr m_state;
+		bool m_drawFrustum;
 		Visualisations m_visualisations;
 		Visualisations m_lightVisualisations;
 		Visualisations m_lightFilterVisualisations;
@@ -297,7 +369,7 @@ class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 		{
 			m_editQueue.push( [this, transform]() {
 				m_transform = transform;
-				updateOrnamentTransform();
+				m_transformSansScale = sansScalingAndShear( transform );
 			} );
 		}
 
@@ -311,7 +383,6 @@ class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 			ConstOpenGLAttributesPtr openGLAttributes = static_cast<const OpenGLAttributes *>( attributes );
 			m_editQueue.push( [this, openGLAttributes]() {
 				m_attributes = openGLAttributes;
-				updateOrnamentTransform();
 			} );
 			return true;
 		}
@@ -322,39 +393,22 @@ class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 
 		Box3f transformedBound() const
 		{
-			// Note: Imath::transform with a non-identify matrix on an empty
-			// box results in a box that returns false to isEmpty, hence the
-			// checks below.
 			Box3f b;
+
 			if( m_renderable )
 			{
-				b.extendBy( m_renderable->bound() );
-			}
-
-			if( auto v = visualisation( *m_attributes, VisualisationType::Geometry ) )
-			{
-				b.extendBy( v->bound() );
-			}
-
-			if( !b.isEmpty() )
-			{
-				b = Imath::transform( b, m_transform );
-			}
-			else
-			{
-				// We only consider ornaments if there is no geometric representation.
-				// As we don't use the bounds for culling, we can get away with this,
-				// and it means sizable visualisations don't mess up the framing when there
-				// is a geometric component.
-				if( auto v = visualisation( *m_attributes, VisualisationType::Ornament ) )
+				const Box3f renderableBound = m_renderable->bound();
+				if( !renderableBound.isEmpty() )
 				{
-					const Box3f ornamentB = v->bound();
-					if( !ornamentB.isEmpty() )
-					{
-						b.extendBy( Imath::transform( ornamentB, m_ornamentTransform ) );
-					}
+					b.extendBy( Imath::transform( renderableBound, m_transform ) );
 				}
 			}
+
+			const Visualisations &vis = visualisations( *m_attributes );
+			accumulateVisualisationBounds( vis, b, Visualisation::Scale::None, m_transformSansScale );
+			accumulateVisualisationBounds( vis, b, Visualisation::Scale::Local, m_transform );
+			accumulateVisualisationBounds( vis, b, Visualisation::Scale::Visualiser, visualiserTransform( false ) );
+			accumulateVisualisationBounds( vis, b, Visualisation::Scale::LocalAndVisualiser, visualiserTransform( true ) );
 
 			return b;
 		}
@@ -371,53 +425,48 @@ class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 
 		void render( IECoreGL::State *currentState, const IECore::PathMatcher &selection ) const
 		{
-			const bool haveTransform = m_transform != M44f();
-			if( haveTransform )
-			{
-				glPushMatrix();
-				glMultMatrixf( m_transform.getValue() );
-			}
-
 			IECoreGL::State::ScopedBinding scope( *m_attributes->state(), *currentState );
 			IECoreGL::State::ScopedBinding selectionScope( selectionState(), *currentState, selected( selection ) );
 
-			if( m_renderable )
+			// In order to minimize z-fighting, we draw non-geometric visualisations
+			// first and real geometry last, so that they sit on top. This is
+			// still prone to flicker, but seems to provide the best results.
+
+			const Visualisations &attrVis = visualisations( *m_attributes );
+
+			Visualisation::Category categories = Visualisation::Category::Generic;
+			if( m_attributes->drawFrustum() )
 			{
-				m_renderable->render( currentState );
+				categories = Visualisation::Category( categories | Visualisation::Category::Frustum );
 			}
 
-			// Local space visualisations
-
-			if( auto v = visualisation( *m_attributes, VisualisationType::Geometry ) )
+			if( m_attributes->ornamentScale() > 0.0f )
 			{
-				v->render( currentState );
-			}
-
-			if( haveTransform )
-			{
-				glPopMatrix();
-			}
-
-			// Local-scale-free visualisations, that use the attribute driven
-			// visualiserScale for size adjustments.
-			if( m_attributes->ornamentScale() > 0 )
-			{
-				if( auto v = visualisation( *m_attributes, VisualisationType::Ornament ) )
+				if( haveMatchingVisualisations( attrVis, Visualisation::Scale::Visualiser, categories ) )
 				{
-					const bool haveOrnamentTransform = m_ornamentTransform != M44f();
-					if( haveOrnamentTransform )
-					{
-						glPushMatrix();
-						glMultMatrixf( m_ornamentTransform.getValue() );
-					}
-
-					v->render( currentState );
-
-					if( haveOrnamentTransform )
-					{
-						glPopMatrix();
-					}
+					ScopedTransform v( visualiserTransform( false ) );
+					renderMatchingVisualisations( attrVis, Visualisation::Scale::Visualiser, categories, currentState );
 				}
+
+				if( haveMatchingVisualisations( attrVis, Visualisation::Scale::LocalAndVisualiser, categories ) )
+				{
+					ScopedTransform c( visualiserTransform( true ) );
+					renderMatchingVisualisations( attrVis, Visualisation::Scale::LocalAndVisualiser, categories, currentState );
+				}
+			}
+
+			if( haveMatchingVisualisations( attrVis, Visualisation::Scale::None, categories ) )
+			{
+				ScopedTransform l( m_transformSansScale );
+				renderMatchingVisualisations( attrVis, Visualisation::Scale::None, categories, currentState );
+			}
+
+			if( m_renderable || haveMatchingVisualisations( attrVis, Visualisation::Scale::Local, categories ) )
+			{
+				ScopedTransform l( m_transform );
+
+				renderMatchingVisualisations( attrVis, Visualisation::Scale::Local, categories, currentState );
+				if( m_renderable ) { m_renderable->render( currentState ); }
 			}
 		}
 
@@ -433,23 +482,27 @@ class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 			return m_editQueue;
 		}
 
-		virtual const IECoreGL::Renderable *visualisation( const OpenGLAttributes &attributes, VisualisationType type ) const
+		virtual const Visualisations &visualisations( const OpenGLAttributes &attributes ) const
 		{
-			return attributes.visualisation( type );
+			return attributes.visualisations();
 		}
 
 	private :
 
-		void updateOrnamentTransform()
+		// sansScalingAndShear is expensive, so we store that, the other
+		// visualiser scaled variants we compute in transformedBound/render
+		// to save memory.
+
+		M44f visualiserTransform( bool includeLocal ) const
 		{
-			M44f ornamentTransform = sansScalingAndShear( m_transform );
-			ornamentTransform.scale( V3f( m_attributes->ornamentScale() ) );
-			m_ornamentTransform = ornamentTransform;
+			M44f t = includeLocal ? m_transform : m_transformSansScale;
+			t.scale( V3f( m_attributes->ornamentScale() ) );
+			return t;
 		}
 
 		IECore::TypeId m_objectType;
 		M44f m_transform;
-		M44f m_ornamentTransform;
+		M44f m_transformSansScale;
 		ConstOpenGLAttributesPtr m_attributes;
 		IECoreGL::ConstRenderablePtr m_renderable;
 		vector<InternedString> m_name;
@@ -538,9 +591,9 @@ class OpenGLLight : public OpenGLObject
 
 	protected :
 
-		const IECoreGL::Renderable *visualisation( const OpenGLAttributes &attributes, VisualisationType type ) const override
+		const Visualisations &visualisations( const OpenGLAttributes &attributes ) const override
 		{
-			return attributes.lightVisualisation( type );
+			return attributes.lightVisualisations();
 		}
 
 };
@@ -559,9 +612,9 @@ class OpenGLLightFilter : public OpenGLObject
 
 	protected :
 
-		const IECoreGL::Renderable *visualisation( const OpenGLAttributes &attributes, VisualisationType type ) const override
+		const Visualisations &visualisations( const OpenGLAttributes &attributes ) const override
 		{
-			return attributes.lightFilterVisualisation( type );
+			return attributes.lightFilterVisualisations();
 		}
 
 };

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -229,8 +229,8 @@ class OpenGLAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 		OpenGLAttributes( const IECore::CompoundObject *attributes )
 		{
-			const FloatData *ornamentScaleData = attributes->member<FloatData>( "gl:visualiser:ornamentScale" );
-			m_ornamentScale = ornamentScaleData ? ornamentScaleData->readable() : 1.0;
+			const FloatData *visualiserScaleData = attributes->member<FloatData>( "gl:visualiser:scale" );
+			m_visualiserScale = visualiserScaleData ? visualiserScaleData->readable() : 1.0;
 
 			const BoolData *drawFrustumData = attributes->member<BoolData>( "gl:visualiser:frustum" );
 			m_drawFrustum = drawFrustumData ? drawFrustumData->readable() : true;
@@ -309,9 +309,9 @@ class OpenGLAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			return m_lightFilterVisualisations;
 		}
 
-		float ornamentScale() const
+		float visualiserScale() const
 		{
-			return m_ornamentScale;
+			return m_visualiserScale;
 		}
 
 		bool drawFrustum() const
@@ -327,7 +327,7 @@ class OpenGLAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 		Visualisations m_lightVisualisations;
 		Visualisations m_lightFilterVisualisations;
 
-		float m_ornamentScale = 1.0f;
+		float m_visualiserScale = 1.0f;
 };
 
 IE_CORE_DECLAREPTR( OpenGLAttributes )
@@ -429,7 +429,6 @@ class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 			accumulateVisualisationBounds( b, Visualisation::Scale::Local, categories, m_transform, attrVis, m_objectVisualisations );
 			accumulateVisualisationBounds( b, Visualisation::Scale::Visualiser, categories, visualiserTransform( false ), attrVis, m_objectVisualisations );
 			accumulateVisualisationBounds( b, Visualisation::Scale::LocalAndVisualiser, categories, visualiserTransform( true ), attrVis, m_objectVisualisations );
-
 			return b;
 		}
 
@@ -460,7 +459,7 @@ class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 				categories = Visualisation::Category( categories | Visualisation::Category::Frustum );
 			}
 
-			if( m_attributes->ornamentScale() > 0.0f )
+			if( m_attributes->visualiserScale() > 0.0f )
 			{
 				if( haveMatchingVisualisations( Visualisation::Scale::Visualiser, categories, attrVis, m_objectVisualisations ) )
 				{
@@ -516,7 +515,7 @@ class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 		M44f visualiserTransform( bool includeLocal ) const
 		{
 			M44f t = includeLocal ? m_transform : m_transformSansScale;
-			t.scale( V3f( m_attributes->ornamentScale() ) );
+			t.scale( V3f( m_attributes->visualiserScale() ) );
 			return t;
 		}
 

--- a/src/GafferScene/IECoreGLPreview/Visualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/Visualiser.cpp
@@ -36,37 +36,36 @@
 
 #include "GafferScene/Private/IECoreGLPreview/Visualiser.h"
 
-#include "IECoreGL/Group.h"
-#include "IECoreGL/State.h"
+using namespace IECoreGLPreview;
 
-void IECoreGLPreview::Private::collectVisualisations( const Visualisations &source, Visualisations &target )
+Visualisation::Visualisation( const IECoreGL::ConstRenderablePtr &renderable, Scale scale, Category category, bool affectsFramingBound )
+	: scale( scale ), category( category ), affectsFramingBound( affectsFramingBound ), m_renderable( renderable )
 {
-	int t = 0;
-	for( auto &visualisation : source )
-	{
-		if( !visualisation )
-		{
-			continue;
-		}
+}
 
-		IECoreGL::Group *group = nullptr;
+const IECoreGL::Renderable *Visualisation::renderable() const
+{
+	return m_renderable.get();
+}
 
-		if( target[t] )
-		{
-			IECoreGL::Renderable *existing = boost::const_pointer_cast<IECoreGL::Renderable>( target[t] ).get();
-			group = dynamic_cast<IECoreGL::Group *>( existing );
-		}
-		else
-		{
-			group = new IECoreGL::Group;
-			target[t] = group;
-		}
+Visualisation Visualisation::createGeometry( const IECoreGL::ConstRenderablePtr &renderable )
+{
+	return Visualisation( renderable );
+}
 
-		assert( group );
+Visualisation Visualisation::createOrnament( const IECoreGL::ConstRenderablePtr &renderable, bool affectsFramingBounds )
+{
+	Visualisation v( renderable );
+	v.scale = Visualisation::Scale::Visualiser;
+	v.affectsFramingBound = affectsFramingBounds;
+	return v;
+}
 
-		// `const_pointer_cast` ok because group/renderable becomes const on assignment
-		group->addChild( boost::const_pointer_cast<IECoreGL::Renderable>( visualisation ) );
-
-		++t;
-	}
+Visualisation Visualisation::createFrustum( const IECoreGL::ConstRenderablePtr &renderable, Scale scale )
+{
+	Visualisation v( renderable );
+	v.affectsFramingBound = false;
+	v.category = Visualisation::Category::Frustum;
+	v.scale = scale;
+	return v;
 }

--- a/src/GafferScene/Light.cpp
+++ b/src/GafferScene/Light.cpp
@@ -66,8 +66,8 @@ Light::Light( const std::string &name )
 
 	Gaffer::CompoundDataPlug *visualiserAttr = new CompoundDataPlug( "visualiserAttributes" );
 
-	FloatPlugPtr ornamentScaleValuePlug = new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f );
-	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", ornamentScaleValuePlug, false, "ornamentScale" ) );
+	FloatPlugPtr scaleValuePlug = new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f );
+	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:visualiser:scale", scaleValuePlug, false, "scale" ) );
 
 	IntPlugPtr maxResValuePlug = new IntPlug( "value", Gaffer::Plug::Direction::In, 512, 2, 2048 );
 	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", maxResValuePlug, false, "maxTextureResolution" ) );

--- a/src/GafferScene/Light.cpp
+++ b/src/GafferScene/Light.cpp
@@ -72,7 +72,13 @@ Light::Light( const std::string &name )
 	IntPlugPtr maxResValuePlug = new IntPlug( "value", Gaffer::Plug::Direction::In, 512, 2, 2048 );
 	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", maxResValuePlug, false, "maxTextureResolution" ) );
 
+	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), false, "frustum" ) );
+
+	FloatPlugPtr frustumScaleValuePlug = new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f );
+	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:light:frustumScale", frustumScaleValuePlug, false, "lightFrustumScale" ) );
+
 	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), false, "lightDrawingMode" ) );
+
 	addChild( visualiserAttr  );
 }
 

--- a/src/GafferScene/OpenGLAttributes.cpp
+++ b/src/GafferScene/OpenGLAttributes.cpp
@@ -84,6 +84,7 @@ OpenGLAttributes::OpenGLAttributes( const std::string &name )
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", new IntPlug( "value", Gaffer::Plug::Direction::In, 512, 2, 2048 ), false, "visualiserMaxTextureResolution" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), false, "visualiserFrustum" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), false, "lightDrawingMode" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "gl:light:frustumScale", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f ), false, "lightFrustumScale" ) );
 }
 
 OpenGLAttributes::~OpenGLAttributes()

--- a/src/GafferScene/OpenGLAttributes.cpp
+++ b/src/GafferScene/OpenGLAttributes.cpp
@@ -82,6 +82,7 @@ OpenGLAttributes::OpenGLAttributes( const std::string &name )
 
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f ), false, "visualiserOrnamentScale" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", new IntPlug( "value", Gaffer::Plug::Direction::In, 512, 2, 2048 ), false, "visualiserMaxTextureResolution" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), false, "visualiserFrustum" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), false, "lightDrawingMode" ) );
 }
 

--- a/src/GafferScene/OpenGLAttributes.cpp
+++ b/src/GafferScene/OpenGLAttributes.cpp
@@ -80,7 +80,7 @@ OpenGLAttributes::OpenGLAttributes( const std::string &name )
 
 	// visualisers
 
-	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f ), false, "visualiserOrnamentScale" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:scale", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f ), false, "visualiserScale" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", new IntPlug( "value", Gaffer::Plug::Direction::In, 512, 2, 2048 ), false, "visualiserMaxTextureResolution" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), false, "visualiserFrustum" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), false, "lightDrawingMode" ) );

--- a/src/GafferSceneModule/IECoreGLPreviewBinding.cpp
+++ b/src/GafferSceneModule/IECoreGLPreviewBinding.cpp
@@ -36,6 +36,7 @@
 
 #include "IECoreGLPreviewBinding.h"
 
+#include "GafferScene/Private/IECoreGLPreview/Visualiser.h"
 #include "GafferScene/Private/IECoreGLPreview/ObjectVisualiser.h"
 #include "GafferScene/Private/IECoreGLPreview/AttributeVisualiser.h"
 #include "GafferScene/Private/IECoreGLPreview/LightVisualiser.h"
@@ -66,5 +67,46 @@ void GafferSceneModule::bindIECoreGLPreview()
 	IECorePython::RefCountedClass<LightVisualiser, IECore::RefCounted>( "LightVisualiser" )
 		.def( "registerLightVisualiser", &LightVisualiser::registerLightVisualiser )
 		.staticmethod( "registerLightVisualiser" )
+	;
+
+	auto v = class_<Visualisation>( "Visualisation", no_init );
+	{
+		scope visualisationScope( v );
+
+		enum_<Visualisation::Scale>("Scale")
+			.value( "None", Visualisation::Scale::None )
+			.value( "Local", Visualisation::Scale::Local )
+			.value( "Visualiser", Visualisation::Scale::Visualiser )
+			.value( "LocalAndVisualiser", Visualisation::Scale::LocalAndVisualiser )
+		;
+		enum_<Visualisation::Category>("Category")
+			.value( "Generic", Visualisation::Category::Generic )
+			.value( "Frustum", Visualisation::Category::Frustum )
+		;
+	}
+	v.def( init<
+				IECoreGL::ConstRenderablePtr,
+				Visualisation::Scale,
+				Visualisation::Category,
+				bool
+			>(
+				(
+					arg( "renderable" ),
+					arg( "scale" ) = Visualisation::Scale::Local,
+					arg( "category" ) = Visualisation::Category::Generic,
+					arg( "affectsFramingBound" ) = true
+				)
+			)
+		)
+		.def_readwrite( "scale", &Visualisation::scale )
+		.def_readwrite( "category", &Visualisation::category )
+		.def_readwrite( "affectsFramingBound", &Visualisation::affectsFramingBound )
+		.def( "renderable", &Visualisation::renderable, return_value_policy<IECorePython::CastToIntrusivePtr>() )
+		.def( "createGeometry", &Visualisation::createGeometry )
+		.staticmethod( "createGeometry" )
+		.def( "createOrnament", &Visualisation::createOrnament )
+		.staticmethod( "createOrnament" )
+		.def( "createFrustum", &Visualisation::createFrustum )
+		.staticmethod( "createFrustum" )
 	;
 }

--- a/src/GafferSceneUI/CameraVisualiser.cpp
+++ b/src/GafferSceneUI/CameraVisualiser.cpp
@@ -66,12 +66,14 @@ class CameraVisualiser : public ObjectVisualiser
 		{
 		}
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const override
+		Visualisations visualise( const IECore::Object *object ) const override
 		{
+			Visualisations v;
+
 			const IECoreScene::Camera *camera = IECore::runTimeCast<const IECoreScene::Camera>( object );
 			if( !camera )
 			{
-				return nullptr;
+				return v;
 			}
 
 			IECoreGL::GroupPtr group = new IECoreGL::Group();
@@ -176,7 +178,11 @@ class CameraVisualiser : public ObjectVisualiser
 			curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, pData ) );
 			group->addChild( curves );
 
-			return group;
+			// We need to make sure the frustum preview of the ornament scales
+			// with any non-uniform scaling of the location.
+			Visualisation boxVis = Visualisation::ornamentVisualisation( group, true );
+			boxVis.scale = Visualisation::Scale::LocalAndVisualiser;
+			return { boxVis };
 		}
 
 	protected :

--- a/src/GafferSceneUI/ClippingPlaneVisualiser.cpp
+++ b/src/GafferSceneUI/ClippingPlaneVisualiser.cpp
@@ -56,13 +56,15 @@ class ClippingPlaneVisualiser : public ObjectVisualiser
 		typedef IECoreScene::ClippingPlane ObjectType;
 
 		ClippingPlaneVisualiser()
-			:	m_group( new IECoreGL::Group() )
 		{
-			m_group->getState()->add( new IECoreGL::Primitive::DrawWireframe( true ) );
-			m_group->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
-			m_group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
-			m_group->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0.06, 0.2, 0.56, 1 ) ) );
-			m_group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 1.0f ) );
+			IECoreGL::GroupPtr group = new IECoreGL::Group();
+			m_visualisations.push_back( Visualisation::createGeometry( group ) );
+
+			group->getState()->add( new IECoreGL::Primitive::DrawWireframe( true ) );
+			group->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
+			group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
+			group->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0.06, 0.2, 0.56, 1 ) ) );
+			group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 1.0f ) );
 
 			IECore::V3fVectorDataPtr pData = new IECore::V3fVectorData;
 			IECore::IntVectorDataPtr vertsPerCurveData = new IECore::IntVectorData;
@@ -91,23 +93,23 @@ class ClippingPlaneVisualiser : public ObjectVisualiser
 
 			IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurveData );
 			curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, pData ) );
-			m_group->addChild( curves );
+			group->addChild( curves );
 		}
 
 		~ClippingPlaneVisualiser() override
 		{
 		}
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const override
+		Visualisations visualise( const IECore::Object *object ) const override
 		{
-			return m_group;
+			return m_visualisations;
 		}
 
 	protected :
 
 		static ObjectVisualiserDescription<ClippingPlaneVisualiser> g_visualiserDescription;
 
-		IECoreGL::GroupPtr m_group;
+		Visualisations m_visualisations;
 
 };
 

--- a/src/GafferSceneUI/CoordinateSystemVisualiser.cpp
+++ b/src/GafferSceneUI/CoordinateSystemVisualiser.cpp
@@ -56,14 +56,15 @@ class CoordinateSystemVisualiser : public ObjectVisualiser
 		typedef IECoreScene::CoordinateSystem ObjectType;
 
 		CoordinateSystemVisualiser()
-			:	m_group( new IECoreGL::Group() )
 		{
+			IECoreGL::GroupPtr group = new IECoreGL::Group();
+			m_visualisations.push_back( Visualisation::createGeometry( group ) );
 
-			m_group->getState()->add( new IECoreGL::Primitive::DrawWireframe( true ) );
-			m_group->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
-			m_group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
-			m_group->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0.06, 0.2, 0.56, 1 ) ) );
-			m_group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 2.0f ) );
+			group->getState()->add( new IECoreGL::Primitive::DrawWireframe( true ) );
+			group->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
+			group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
+			group->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0.06, 0.2, 0.56, 1 ) ) );
+			group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 2.0f ) );
 
 			IECore::V3fVectorDataPtr pData = new IECore::V3fVectorData;
 			vector<V3f> &p = pData->writable();
@@ -80,23 +81,23 @@ class CoordinateSystemVisualiser : public ObjectVisualiser
 
 			IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurve );
 			curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, pData ) );
-			m_group->addChild( curves );
+			group->addChild( curves );
 		}
 
 		~CoordinateSystemVisualiser() override
 		{
 		}
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const override
+		Visualisations visualise( const IECore::Object *object ) const override
 		{
-			return m_group;
+			return m_visualisations;
 		}
 
 	protected :
 
 		static ObjectVisualiserDescription<CoordinateSystemVisualiser> g_visualiserDescription;
 
-		IECoreGL::GroupPtr m_group;
+		Visualisations m_visualisations;
 
 };
 

--- a/src/GafferSceneUI/ProceduralVisualiser.cpp
+++ b/src/GafferSceneUI/ProceduralVisualiser.cpp
@@ -62,7 +62,7 @@ class BoundVisualiser : public ObjectVisualiser
 		{
 		}
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const override
+		Visualisations visualise( const IECore::Object *object ) const override
 		{
 			const IECoreScene::VisibleRenderable *renderable = IECore::runTimeCast<const IECoreScene::VisibleRenderable>( object );
 
@@ -114,7 +114,7 @@ class BoundVisualiser : public ObjectVisualiser
 			curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, pData ) );
 			group->addChild( curves );
 
-			return group;
+			return { Visualisation::createGeometry( group ) };
 		}
 
 };

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -168,6 +168,10 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			NameValuePlugPtr frustumPlug = new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), true, "visualiserFrustum" );
 			attr->addChild( frustumPlug );
 
+			FloatPlugPtr lightFrustumScaleValuePlug = new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f );
+			NameValuePlugPtr lightFrustumScalePlug = new Gaffer::NameValuePlug( "gl:light:frustumScale", lightFrustumScaleValuePlug, true, "lightFrustumScale" );
+			attr->addChild( lightFrustumScalePlug );
+
 			// View plugs
 
 			ValuePlugPtr drawingMode = new ValuePlug( "drawingMode" );
@@ -189,6 +193,7 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			ValuePlugPtr lights = new ValuePlug( "light" );
 			drawingMode->addChild( lights );
 			lights->addChild( new StringPlug( "drawingMode", Plug::In, "texture" ) );
+			lights->addChild( new FloatPlug( "frustumScale", Plug::In, 1.0f ) );
 
 			drawingMode->addChild( new BoolPlug( "frustum", Plug::In, true ) );
 			drawingMode->addChild( ornamentScaleValuePlug->createCounterpart( "visualiserOrnamentScale", Plug::Direction::In ) );
@@ -196,6 +201,7 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			lightModePlug->getChild<StringPlug>( "value" )->setInput( lights->getChild<StringPlug>( "drawingMode" ) );
 			frustumPlug->getChild<BoolPlug>( "value" )->setInput( drawingMode->getChild<BoolPlug>( "frustum" ) );
 			ornamentScaleValuePlug->setInput( drawingMode->getChild<FloatPlug>( "visualiserOrnamentScale" ) );
+			lightFrustumScaleValuePlug->setInput( lights->getChild<FloatPlug>( "frustumScale" ) );
 
 			updateOpenGLOptions();
 

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -165,6 +165,9 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			NameValuePlugPtr ornamentScalePlug = new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", ornamentScaleValuePlug, true, "visualiserOrnamentScale" );
 			attr->addChild( ornamentScalePlug );
 
+			NameValuePlugPtr frustumPlug = new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), true, "visualiserFrustum" );
+			attr->addChild( frustumPlug );
+
 			// View plugs
 
 			ValuePlugPtr drawingMode = new ValuePlug( "drawingMode" );
@@ -187,9 +190,11 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			drawingMode->addChild( lights );
 			lights->addChild( new StringPlug( "drawingMode", Plug::In, "texture" ) );
 
+			drawingMode->addChild( new BoolPlug( "frustum", Plug::In, true ) );
 			drawingMode->addChild( ornamentScaleValuePlug->createCounterpart( "visualiserOrnamentScale", Plug::Direction::In ) );
 
 			lightModePlug->getChild<StringPlug>( "value" )->setInput( lights->getChild<StringPlug>( "drawingMode" ) );
+			frustumPlug->getChild<BoolPlug>( "value" )->setInput( drawingMode->getChild<BoolPlug>( "frustum" ) );
 			ornamentScaleValuePlug->setInput( drawingMode->getChild<FloatPlug>( "visualiserOrnamentScale" ) );
 
 			updateOpenGLOptions();

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -161,9 +161,9 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			NameValuePlugPtr lightModePlug = new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), true, "lightDrawingMode" );
 			attr->addChild( lightModePlug );
 
-			FloatPlugPtr ornamentScaleValuePlug = new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f );
-			NameValuePlugPtr ornamentScalePlug = new Gaffer::NameValuePlug( "gl:visualiser:ornamentScale", ornamentScaleValuePlug, true, "visualiserOrnamentScale" );
-			attr->addChild( ornamentScalePlug );
+			FloatPlugPtr visualiserScaleValuePlug = new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f );
+			NameValuePlugPtr visualiserScalePlug = new Gaffer::NameValuePlug( "gl:visualiser:scale", visualiserScaleValuePlug, true, "visualiserVisualiserScale" );
+			attr->addChild( visualiserScalePlug );
 
 			NameValuePlugPtr frustumPlug = new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), true, "visualiserFrustum" );
 			attr->addChild( frustumPlug );
@@ -196,11 +196,11 @@ class SceneView::DrawingMode : public boost::signals::trackable
 			lights->addChild( new FloatPlug( "frustumScale", Plug::In, 1.0f ) );
 
 			drawingMode->addChild( new BoolPlug( "frustum", Plug::In, true ) );
-			drawingMode->addChild( ornamentScaleValuePlug->createCounterpart( "visualiserOrnamentScale", Plug::Direction::In ) );
+			drawingMode->addChild( visualiserScaleValuePlug->createCounterpart( "visualiserScale", Plug::Direction::In ) );
 
 			lightModePlug->getChild<StringPlug>( "value" )->setInput( lights->getChild<StringPlug>( "drawingMode" ) );
 			frustumPlug->getChild<BoolPlug>( "value" )->setInput( drawingMode->getChild<BoolPlug>( "frustum" ) );
-			ornamentScaleValuePlug->setInput( drawingMode->getChild<FloatPlug>( "visualiserOrnamentScale" ) );
+			visualiserScaleValuePlug->setInput( drawingMode->getChild<FloatPlug>( "visualiserScale" ) );
 			lightFrustumScaleValuePlug->setInput( lights->getChild<FloatPlug>( "frustumScale" ) );
 
 			updateOpenGLOptions();

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -410,7 +410,7 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 	GroupPtr geometry = new Group;   // geometry isn't as its size matters for rendering.
 	GroupPtr frustum = new Group;    // inherits scaling as per geometry
 
-	const FloatData *visualiserScaleData = attributes->member<FloatData>( "gl:visualiser:ornamentScale" );
+	const FloatData *visualiserScaleData = attributes->member<FloatData>( "gl:visualiser:scale" );
 	const float visualiserScale = visualiserScaleData ? visualiserScaleData->readable() : 1.0;
 	const FloatData *frustumScaleData = attributes->member<FloatData>( "gl:light:frustumScale" );
 	const float frustumScale = frustumScaleData ? frustumScaleData->readable() : 1.0;

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -166,11 +166,11 @@ void addSolidArc( Axis axis, const V3f &center, float majorRadius, float minorRa
 	}
 }
 
-void addCone( float angle, float startRadius, vector<int> &vertsPerCurve, vector<V3f> &p )
+void addCone( float angle, float startRadius, vector<int> &vertsPerCurve, vector<V3f> &p, float length )
 {
 	const float halfAngle = 0.5 * M_PI * angle / 180.0;
-	const float baseRadius = sin( halfAngle );
-	const float baseDistance = cos( halfAngle );
+	const float baseRadius = length * sin( halfAngle );
+	const float baseDistance = length * cos( halfAngle );
 
 	if( startRadius > 0 )
 	{
@@ -182,8 +182,16 @@ void addCone( float angle, float startRadius, vector<int> &vertsPerCurve, vector
 	p.push_back( V3f( 0, baseRadius + startRadius, -baseDistance ) );
 	vertsPerCurve.push_back( 2 );
 
+	p.push_back( V3f( startRadius, 0, 0 ) );
+	p.push_back( V3f( baseRadius + startRadius, 0, -baseDistance ) );
+	vertsPerCurve.push_back( 2 );
+
 	p.push_back( V3f( 0, -startRadius, 0 ) );
 	p.push_back( V3f( 0, -baseRadius - startRadius, -baseDistance ) );
+	vertsPerCurve.push_back( 2 );
+
+	p.push_back( V3f( -startRadius, 0, 0 ) );
+	p.push_back( V3f( -baseRadius - startRadius, 0, -baseDistance ) );
 	vertsPerCurve.push_back( 2 );
 }
 
@@ -400,9 +408,12 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 
 	GroupPtr ornaments = new Group;  // Ornaments are affected by visualiser:scale while
 	GroupPtr geometry = new Group;   // geometry isn't as its size matters for rendering.
+	GroupPtr frustum = new Group;    // inherits scaling as per geometry
 
 	const FloatData *visualiserScaleData = attributes->member<FloatData>( "gl:visualiser:ornamentScale" );
 	const float visualiserScale = visualiserScaleData ? visualiserScaleData->readable() : 1.0;
+	const FloatData *frustumScaleData = attributes->member<FloatData>( "gl:light:frustumScale" );
+	const float frustumScale = frustumScaleData ? frustumScaleData->readable() : 1.0;
 	const StringData *visualiserDrawingModeData = attributes->member<StringData>( "gl:light:drawingMode" );
 	const std::string visualiserDrawingMode = visualiserDrawingModeData ? visualiserDrawingModeData->readable() : "texture";
 
@@ -419,6 +430,7 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 	}
 	geometry->setTransform( topTransform );
 	ornaments->setTransform( topTransform );
+	frustum->setTransform( topTransform );
 
 	if( type && type->readable() == "environment" )
 	{
@@ -433,9 +445,10 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 	{
 		float innerAngle, outerAngle, lensRadius;
 		spotlightParameters( attributeName, shaderNetwork, innerAngle, outerAngle, lensRadius );
-		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / visualiserScale ) ) );
+		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / visualiserScale, 1.0f, 1.0f ) ) );
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( color ) ) );
+		frustum->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / visualiserScale, 10.0f * frustumScale, 0.2f ) ) );
 	}
 	else if( type && type->readable() == "distant" )
 	{
@@ -545,6 +558,10 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 	if( !ornaments->children().empty() )
 	{
 		result.push_back( Visualisation::createOrnament( ornaments, false ) );
+	}
+	if( !frustum->children().empty() )
+	{
+		result.push_back( Visualisation::createFrustum( frustum, Visualisation::Scale::Visualiser ) );
 	}
 	return result;
 }
@@ -673,36 +690,39 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::distantRays()
 	return result;
 }
 
-IECoreGL::ConstRenderablePtr StandardLightVisualiser::spotlightCone( float innerAngle, float outerAngle, float lensRadius )
+IECoreGL::ConstRenderablePtr StandardLightVisualiser::spotlightCone( float innerAngle, float outerAngle, float lensRadius, float length, float lineWidthScale )
 {
 	IECoreGL::GroupPtr group = new IECoreGL::Group();
 	addWireframeCurveState( group.get() );
-	addConstantShader( group.get(), false, 0 );
+	addConstantShader( group.get(), false );
 
-	group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 1.0f ) );
+	group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 1.0f * lineWidthScale ) );
 
 	IntVectorDataPtr vertsPerCurve = new IntVectorData;
 	V3fVectorDataPtr p = new V3fVectorData;
-	addCone( innerAngle, lensRadius, vertsPerCurve->writable(), p->writable() );
+	addCone( innerAngle, lensRadius, vertsPerCurve->writable(), p->writable(), length );
 
 	IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurve );
 	curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, p ) );
-	curves->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( g_lightWireframeColor ) ) );
+
+	const Color3fDataPtr color = new Color3fData( lineWidthScale < 1.0f ? Color3f( 0.627f, 0.580f, 0.352f ) : g_lightWireframeColor );
+	curves->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, color ) );
 
 	group->addChild( curves );
 
 	if( fabs( innerAngle - outerAngle ) > 0.1 )
 	{
 		IECoreGL::GroupPtr outerGroup = new Group;
-		outerGroup->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 0.5f ) );
+		outerGroup->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 0.5f * lineWidthScale ) );
 
 		IntVectorDataPtr vertsPerCurve = new IntVectorData;
 		V3fVectorDataPtr p = new V3fVectorData;
-		addCone( outerAngle, lensRadius, vertsPerCurve->writable(), p->writable() );
+		addCone( outerAngle, lensRadius, vertsPerCurve->writable(), p->writable(), length );
 
 		IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurve );
 		curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, p ) );
-		curves->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( g_lightWireframeColor ) ) );
+
+		curves->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, color ) );
 
 		outerGroup->addChild( curves );
 

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -401,10 +401,6 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 	GroupPtr ornaments = new Group;  // Ornaments are affected by visualiser:scale while
 	GroupPtr geometry = new Group;   // geometry isn't as its size matters for rendering.
 
-	Visualisations result;
-	result[ VisualisationType::Geometry ] = geometry;
-	result[ VisualisationType::Ornament ] = ornaments;
-
 	const FloatData *visualiserScaleData = attributes->member<FloatData>( "gl:visualiser:ornamentScale" );
 	const float visualiserScale = visualiserScaleData ? visualiserScaleData->readable() : 1.0;
 	const StringData *visualiserDrawingModeData = attributes->member<StringData>( "gl:light:drawingMode" );
@@ -541,6 +537,15 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 
 	}
 
+	Visualisations result;
+	if( !geometry->children().empty() )
+	{
+		result.push_back( Visualisation::createGeometry( geometry ) );
+	}
+	if( !ornaments->children().empty() )
+	{
+		result.push_back( Visualisation::createOrnament( ornaments, false ) );
+	}
 	return result;
 }
 

--- a/src/GafferVDBUI/VDBVisualiser.cpp
+++ b/src/GafferVDBUI/VDBVisualiser.cpp
@@ -278,14 +278,16 @@ class VDBVisualiser : public ObjectVisualiser
 		typedef VDBObject ObjectType;
 
 		VDBVisualiser()
-			:	m_group( new IECoreGL::Group() )
 		{
 
-			m_group->getState()->add( new IECoreGL::Primitive::DrawWireframe( true ) );
-			m_group->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
-			m_group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
-			m_group->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0.06, 0.2, 0.56, 1 ) ) );
-			m_group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 2.0f ) );
+			IECoreGL::GroupPtr group = new IECoreGL::Group();
+			m_defaultVisualisations.push_back( Visualisation::createGeometry( group ) );
+
+			group->getState()->add( new IECoreGL::Primitive::DrawWireframe( true ) );
+			group->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
+			group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
+			group->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0.06, 0.2, 0.56, 1 ) ) );
+			group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 2.0f ) );
 
 			IECore::V3fVectorDataPtr pData = new IECore::V3fVectorData;
 			vector<V3f> &p = pData->writable();
@@ -302,26 +304,26 @@ class VDBVisualiser : public ObjectVisualiser
 
 			IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurve );
 			curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, pData ) );
-			m_group->addChild( curves );
+			group->addChild( curves );
 		}
 
 		~VDBVisualiser() override
 		{
 		}
 
-		IECoreGL::ConstRenderablePtr visualise( const IECore::Object *object ) const override
+		Visualisations visualise( const IECore::Object *object ) const override
 		{
 			const VDBObject* vdbObject = IECore::runTimeCast<const VDBObject>(object);
 			if ( !vdbObject )
 			{
-				return m_group;
+				return m_defaultVisualisations;
 			}
 
 			// todo which grid should be visualised?
 			std::vector<std::string> names = vdbObject->gridNames();
 			if (names.empty())
 			{
-				return m_group;
+				return m_defaultVisualisations;
 			}
 
 			openvdb::GridBase::ConstPtr grid = vdbObject->findGrid( names[0] );
@@ -370,14 +372,14 @@ class VDBVisualiser : public ObjectVisualiser
 
 			}
 
-			return rootGroup;
+			return { Visualisation::createGeometry( rootGroup ) };
 		}
 
 	protected :
 
 		static ObjectVisualiserDescription<VDBVisualiser> g_visualiserDescription;
 
-		IECoreGL::GroupPtr m_group;
+		Visualisations m_defaultVisualisations;
 
 };
 

--- a/startup/GafferScene/lightCompatibility.py
+++ b/startup/GafferScene/lightCompatibility.py
@@ -43,8 +43,8 @@ def __lightGetItemWrapper( originalGetItem ) :
 
 		if key == "visualiserScale" :
 			visualiserAttr = originalGetItem( self, "visualiserAttributes" )
-			visualiserAttr[ "ornamentScale" ][ "enabled" ].setValue( True )
-			return visualiserAttr[ "ornamentScale" ][ "value" ]
+			visualiserAttr[ "scale" ][ "enabled" ].setValue( True )
+			return visualiserAttr[ "scale" ][ "value" ]
 		else :
 			return originalGetItem( self, key )
 


### PR DESCRIPTION
Supersedes #3551 and #3056. Sorry there is a bunch in here now, but it was hard to do this refactor and still maintain two independent PRs for the spot/camera frustum work.

In practice, as we developed more visualisers and attempted to match behaviour across renderers, it became clear that the concrete-type approach we went for in #3514 wouldn't scale to all the permutations required. Particularly as specific rendering behaviours don't match to specific user-land categories such as 'frustums'. The requirement to expose drawing toggles in the UI made the typed approach untenable.

This PR switches to an alternate approach, refactoring Visualisers such that they return a vector of `Visualisation` structs instead of a type-keyed array.

We experimented with various combinations flags, and/or enums, and this ended up with (hopefully) the most logical naming conventions, visualiser and renderer logic.

Improvements
--------------

- Viewer : 
  - Added menu items to control frustum visualisations. These can also be controlled via the `OpenGLAttributes` node (#3569).
  - Added spotlight light cone visualisation (#3569).
  - Added visualisation of camera frustums (#3569).
  - Improved <kbd>f</kbd> framing behaviour for light visualisations (#3569).
- Camera : Added Visualisation controls to the Camera node to allow frustum visualisation to be easily overridden per-camera (#3569).

API
---

- IECoreGLPreview : Added support for more flexible visualisations via the `Visualisation` struct (#3569).

Breaking Changes
------------------

 - IECoreGLPreview : Changed the return type of `(Light|LightFilter|Attribute|Object)Visualiser` classes. Visualisations are now a vector of `Visualisation` structs (#3569).


## Cameras

![image](https://user-images.githubusercontent.com/896779/72168089-5e7bce00-33c4-11ea-87b4-e377bf863411.png)

## Spot Lights

![image](https://user-images.githubusercontent.com/896779/72148326-6887d780-3398-11ea-8261-42cbc3077ae8.png)
