### PR TITLE
CatalogueUI : Ensure consistent re-selection behaviour after deletion

### DIFF
--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -496,9 +496,12 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 
 			orderedImages = self.__orderedImages()
+			reselectionIndex = len( orderedImages )
+
 			for index in reversed( sorted( indices ) ) :
 				image = self.__images()[ index ]
 				uiIndex = orderedImages.index( image )
+				reselectionIndex = min( max( 0, uiIndex - 1 ), reselectionIndex )
 				self.__images().removeChild( image )
 				orderedImages.remove( image )
 
@@ -506,7 +509,7 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 
 			# Figure out new selection
 			if orderedImages :
-				selectionIndex = self.__uiIndexToIndex( max( 0, uiIndex - 1 ) )
+				selectionIndex = self.__uiIndexToIndex( reselectionIndex )
 				self.getPlug().setValue( selectionIndex )
 
 	def __extractClicked( self, *unused ) :


### PR DESCRIPTION
If images had been re-ordered such that for any selection A,B - the plug index of A was greater than B - after deletion, the image above B would be re-selected, rather than the image above A.

Fixes
-----

 - Catalogue : Fixed a rare inconsistency with re-selection after deleting re-ordered images in certain edge cases.