### PR TITLE
SceneAlgo : Include intermediate connections in `history()`

### DIFF
--- a/include/Gaffer/Process.h
+++ b/include/Gaffer/Process.h
@@ -63,9 +63,12 @@ class GAFFER_API Process : private ThreadState::Scope
 
 		/// The type of process being performed.
 		const IECore::InternedString type() const { return m_type; }
-		/// The plug for which the process is being
-		/// performed.
+		/// The plug which is the subject of the process being performed.
 		const Plug *plug() const { return m_plug; }
+		/// The plug which triggered the process. This may be the same as
+		/// `plug()` or may be a downstream plug. In either case,
+		/// `destinationPlug()->source() == plug()`.
+		const Plug *destinationPlug() const { return m_destinationPlug; }
 		/// The context in which the process is being
 		/// performed.
 		const Context *context() const { return m_threadState->m_context; }
@@ -81,7 +84,7 @@ class GAFFER_API Process : private ThreadState::Scope
 	protected :
 
 		/// Protected constructor for use by derived classes only.
-		Process( const IECore::InternedString &type, const Plug *plug, const Plug *downstream = nullptr );
+		Process( const IECore::InternedString &type, const Plug *plug, const Plug *destinationPlug = nullptr );
 		~Process();
 
 		/// Derived classes should catch exceptions thrown
@@ -99,7 +102,7 @@ class GAFFER_API Process : private ThreadState::Scope
 
 		IECore::InternedString m_type;
 		const Plug *m_plug;
-		const Plug *m_downstream;
+		const Plug *m_destinationPlug;
 		const Process *m_parent;
 
 };

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -177,8 +177,6 @@ struct History : public IECore::RefCounted
 	Predecessors predecessors;
 };
 
-/// Returns a nullptr if no history is available (eg: no computes would be
-/// performed to produce the plug's value).
 GAFFERSCENE_API History::Ptr history( const Gaffer::ValuePlug *scenePlugChild, const ScenePlug::ScenePath &path );
 
 /// Returns the upstream scene originally responsible for generating the specified location.

--- a/src/Gaffer/Process.cpp
+++ b/src/Gaffer/Process.cpp
@@ -73,8 +73,8 @@ std::string prefixedWhat( const IECore::Exception &e )
 // Process
 //////////////////////////////////////////////////////////////////////////
 
-Process::Process( const IECore::InternedString &type, const Plug *plug, const Plug *downstream )
-	:	m_type( type ), m_plug( plug ), m_downstream( downstream ? downstream : plug )
+Process::Process( const IECore::InternedString &type, const Plug *plug, const Plug *destinationPlug )
+	:	m_type( type ), m_plug( plug ), m_destinationPlug( destinationPlug ? destinationPlug : plug )
 {
 	IECore::Canceller::check( context()->canceller() );
 	m_parent = m_threadState->m_process;
@@ -145,7 +145,7 @@ void Process::handleException()
 
 void Process::emitError( const std::string &error, const Plug *source ) const
 {
-	const Plug *plug = m_downstream;
+	const Plug *plug = m_destinationPlug;
 	while( plug )
 	{
 		if( plug->direction() == Plug::Out )

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -191,20 +191,20 @@ size_t hash_value( const HashCacheKey &key )
 //   is included in the HashCacheKey. We store them explicitly only
 //   for convenience and performance.
 // - `context` is represented in HashCacheKey via `contextHash`.
-// - `downstreamPlug` does not influence the results of the computation
+// - `destinationPlug` does not influence the results of the computation
 //   in any way. It is merely used for error reporting.
 struct HashProcessKey : public HashCacheKey
 {
-	HashProcessKey( const ValuePlug *plug, const ValuePlug *downstreamPlug, const Context *context, const ComputeNode *computeNode, ValuePlug::CachePolicy cachePolicy )
+	HashProcessKey( const ValuePlug *plug, const ValuePlug *destinationPlug, const Context *context, const ComputeNode *computeNode, ValuePlug::CachePolicy cachePolicy )
 		:	HashCacheKey( plug, context ),
-			downstreamPlug( downstreamPlug ),
+			destinationPlug( destinationPlug ),
 			computeNode( computeNode ),
 			cachePolicy( cachePolicy ),
 			threadStateFixer( cachePolicy )
 	{
 	}
 
-	const ValuePlug *downstreamPlug;
+	const ValuePlug *destinationPlug;
 	const ComputeNode *computeNode;
 	const ValuePlug::CachePolicy cachePolicy;
 	const ThreadStateFixer threadStateFixer;
@@ -327,7 +327,7 @@ class ValuePlug::HashProcess : public Process
 	private :
 
 		HashProcess( const HashProcessKey &key )
-			:	Process( staticType, key.plug, key.downstreamPlug )
+			:	Process( staticType, key.plug, key.destinationPlug )
 		{
 			try
 			{
@@ -458,9 +458,9 @@ namespace
 // function.
 struct ComputeProcessKey
 {
-	ComputeProcessKey( const ValuePlug *plug, const ValuePlug *downstreamPlug, const ComputeNode *computeNode, ValuePlug::CachePolicy cachePolicy, const IECore::MurmurHash *precomputedHash )
+	ComputeProcessKey( const ValuePlug *plug, const ValuePlug *destinationPlug, const ComputeNode *computeNode, ValuePlug::CachePolicy cachePolicy, const IECore::MurmurHash *precomputedHash )
 		:	plug( plug ),
-			downstreamPlug( downstreamPlug ),
+			destinationPlug( destinationPlug ),
 			computeNode( computeNode ),
 			cachePolicy( cachePolicy ),
 			threadStateFixer( cachePolicy ),
@@ -469,7 +469,7 @@ struct ComputeProcessKey
 	}
 
 	const ValuePlug *plug;
-	const ValuePlug *downstreamPlug;
+	const ValuePlug *destinationPlug;
 	const ComputeNode *computeNode;
 	const ValuePlug::CachePolicy cachePolicy;
 	const ThreadStateFixer threadStateFixer;
@@ -616,7 +616,7 @@ class ValuePlug::ComputeProcess : public Process
 	private :
 
 		ComputeProcess( const ComputeProcessKey &key )
-			:	Process( staticType, key.plug, key.downstreamPlug )
+			:	Process( staticType, key.plug, key.destinationPlug )
 		{
 			try
 			{

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -583,16 +583,13 @@ void CropWindowTool::findCropWindowPlug()
 
 	const GafferScene::ScenePlug::ScenePath rootPath;
 	SceneAlgo::History::Ptr history = SceneAlgo::history( scenePlug()->globalsPlug(), rootPath );
-	if( history )
+	const bool foundAnEnabledPlug = findCropWindowPlug( history.get(), /* enabledOnly = */ true );
+	// If we didn't find an enabled cropWindow plug upstream, or we did and it's
+	// read-only, look again for any other plugs that could be edited, but aren't
+	// enabled yet. We'll enable it if the user makes an edit.
+	if( !foundAnEnabledPlug || MetadataAlgo::readOnly( m_cropWindowPlug.get() ) )
 	{
-		const bool foundAnEnabledPlug = findCropWindowPlug( history.get(), /* enabledOnly = */ true );
-		// If we didn't find an enabled cropWindow plug upstream, or we did and it's
-		// read-only, look again for any other plugs that could be edited, but aren't
-		// enabled yet. We'll enable it if the user makes an edit.
-		if( !foundAnEnabledPlug || MetadataAlgo::readOnly( m_cropWindowPlug.get() ) )
-		{
-			findCropWindowPlug( history.get(), /* enabledOnly = */ false );
-		}
+		findCropWindowPlug( history.get(), /* enabledOnly = */ false );
 	}
 
 	if( m_cropWindowPlug )
@@ -654,7 +651,7 @@ bool CropWindowTool::findCropWindowPlug( const SceneAlgo::History *history, bool
 bool CropWindowTool::findCropWindowPlugFromNode( GafferScene::ScenePlug *scene, bool enabledOnly )
 {
 	const Options *options = runTimeCast<const Options>( scene->node() );
-	if( !options )
+	if( !options || scene != options->outPlug() )
 	{
 		return false;
 	}


### PR DESCRIPTION
This is one of the building blocks for [EditScopes](#3467). It provides more complete information in `SceneAlgo::history()`, so that TransformTool will be able to track transitions through EditScopes when examining history. It's also designed such that `history()` will be useable for improving history tracebacks in the SceneInspector (which currently can't see through hierarchy transitions like Group/Subtree). 