### PR TITLE
EventLoop : Fix application style

### DIFF
--- a/python/GafferUI/EventLoop.py
+++ b/python/GafferUI/EventLoop.py
@@ -154,10 +154,11 @@ class EventLoop( object ) :
 	if QtWidgets.QApplication.instance() :
 		__qtApplication = QtWidgets.QApplication.instance()
 	else :
-		# set the style explicitly so we don't inherit one from the desktop
-		# environment, which could mess with our own style (on gnome for instance,
+		# Set the style explicitly so we don't inherit one from the desktop
+		# environment, which could mess with our own style (on GNOME for instance,
 		# our icons can come out the wrong size).
-		QtWidgets.QApplication.setStyle( "plastique" )
+		style = QtWidgets.QApplication.setStyle( "Fusion" )
+		assert( style is not None )
 		__qtApplication = QtWidgets.QApplication( [ "gaffer" ] )
 
 	__mainEventLoop = None


### PR DESCRIPTION
The attempt to choose the "plastique" style was failing, and presumably has been ever since Qt 5. We now use the "Fusion" style to give us a consistent baseline regardless of platform, and that fixes problems such as the centre aligned tab bar on Mac reported in https://github.com/GafferHQ/gaffer/pull/3566. We now also assert that setting the style has succeeded, so we won't be caught out again in the same way.