### PR TITLE
BoolWidget : Fix unwanted horizontal expansion

### DIFF
--- a/python/GafferUI/BoolWidget.py
+++ b/python/GafferUI/BoolWidget.py
@@ -148,6 +148,10 @@ class _CheckBox( QtWidgets.QCheckBox ) :
 
 		self.__hitMode = self.HitMode.CheckBox
 
+		self.setSizePolicy( QtWidgets.QSizePolicy(
+			QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
+		) )
+
 	def setHitMode( self, hitMode ) :
 
 		self.__hitMode = hitMode


### PR DESCRIPTION
This could cause fixed-width value widgets to be right-aligned in NameValuePlugValueWidget. This was made apparent by 7e732353b7c525faa8007c1095dcc24750e44b9a, which made the OpenGLAttributes `maxTextureResolution` widget fixed-width.

![image](https://user-images.githubusercontent.com/1133871/73388911-018c7d00-42cb-11ea-87ca-26d8851e2e2e.png)
