### PR TITLE
SpreadSheet : Fix crashes when removing a column

### DIFF
--- a/src/Gaffer/Spreadsheet.cpp
+++ b/src/Gaffer/Spreadsheet.cpp
@@ -121,13 +121,13 @@ void Spreadsheet::RowsPlug::removeColumn( size_t columnIndex )
 		throw IECore::Exception( "Column index out of range" );
 	}
 
-	for( auto &row : RowPlug::Range( *this ) )
-	{
-		row->cellsPlug()->removeChild( row->cellsPlug()->getChild( columnIndex ) );
-	}
 	for( auto o : outPlugs() )
 	{
 		o->removeChild( o->getChild( columnIndex ) );
+	}
+	for( auto &row : RowPlug::Range( *this ) )
+	{
+		row->cellsPlug()->removeChild( row->cellsPlug()->getChild( columnIndex ) );
 	}
 }
 


### PR DESCRIPTION
Because we were removing the output plugs last, an overzealous observer could trigger a compute at a point when `correspondingInput( out )` would return null, causing crashes. By removing the output plugs first, we guarantee that no observer can trigger a compute while we are in such a state.
