### PR TITLE
ImageTransform : Fix bug in `hashChannelData()`

### DIFF
--- a/src/GafferImage/ImageTransform.cpp
+++ b/src/GafferImage/ImageTransform.cpp
@@ -296,10 +296,7 @@ void ImageTransform::hashChannelData( const GafferImage::ImagePlug *parent, cons
 	else
 	{
 		// Rotation of either the input or the resampled input.
-		{
-			ImagePlug::GlobalScope c( context );
-			ImageTransform::hashDataWindow( parent, context, h );
-		}
+		ImageProcessor::hashChannelData( parent, context, h );
 
 		const ImagePlug *samplerImage; M33f samplerMatrix;
 		const Box2i samplerRegion = sampler( op, matrix, resampleMatrix, context->get<V2i>( ImagePlug::tileOriginContextName ), samplerImage, samplerMatrix );


### PR DESCRIPTION
Two historical problems were compounded to end up with the bizarre construct replaced here. First, I had originally got the base class call completely wrong, calling `hashDataWindow()` when it should have been `hashChannelData()`. Second, 93c9c148bb9ac4c8ce11f84b85cca97ec8de9b46 mistook this for a legitimate call to `dataWindowPlug()->hash()` and wrapped it in a GlobalScope. We're now back to where we should be - a straight call to our base class implementation.
