### PR TITLE
ViewportGadget : Make `SelectionScope` and `RasterScope` non-copyable

### DIFF
--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -167,7 +167,7 @@ class GAFFERUI_API ViewportGadget : public Gadget
 
 		/// The SelectionScope class can be used by child Gadgets to perform
 		/// OpenGL selection from event signal callbacks.
-		class SelectionScope
+		class SelectionScope : boost::noncopyable
 		{
 
 			public :
@@ -209,7 +209,7 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		};
 
 		/// The RasterScope class can be used to perform drawing in raster space.
-		class RasterScope
+		class RasterScope : boost::noncopyable
 		{
 
 			public :


### PR DESCRIPTION
Since they push state in their constructors, and pop it in their destructors, inadvertent copying would cause havoc.

Breaking Changes
----------------

- ViewportGadget : Made the SelectionScope and RasterScope classes non-copyable.
