### PR TITLE
GafferUITest : Extend Qt grace periods

### DIFF
--- a/python/GafferUITest/GLWidgetTest.py
+++ b/python/GafferUITest/GLWidgetTest.py
@@ -75,7 +75,7 @@ class GLWidgetTest( GafferUITest.TestCase ) :
 
 		w.setVisible( True )
 
-		self.waitForIdle( 1000 )
+		self.waitForIdle( 10000 )
 
 		self.assertTrue( GafferUI.Widget.widgetAt( w.bound().min() + imath.V2i( 4 ) ) is b )
 
@@ -91,14 +91,14 @@ class GLWidgetTest( GafferUITest.TestCase ) :
 		f.setChild( b )
 
 		w.setVisible( True )
-		self.waitForIdle( 1000 )
+		self.waitForIdle( 10000 )
 
 		w.setPosition( imath.V2i( 100 ) )
-		self.waitForIdle( 1000 )
+		self.waitForIdle( 10000 )
 		b1 = b.bound()
 
 		w.setPosition( imath.V2i( 200 ) )
-		self.waitForIdle( 1000 )
+		self.waitForIdle( 10000 )
 		b2 = b.bound()
 
 		self.assertEqual( b2.min(), b1.min() + imath.V2i( 100 ) )

--- a/python/GafferUITest/WidgetTest.py
+++ b/python/GafferUITest/WidgetTest.py
@@ -415,7 +415,7 @@ class WidgetTest( GafferUITest.TestCase ) :
 		w1.setPosition( imath.V2i( 100 ) )
 		w2.setPosition( imath.V2i( 300 ) )
 
-		self.waitForIdle( 1000 )
+		self.waitForIdle( 10000 )
 
 		self.assertTrue( GafferUI.Widget.widgetAt( w1.bound().center() ) is t1 )
 		self.assertTrue( GafferUI.Widget.widgetAt( w2.bound().center() ) is t2 )


### PR DESCRIPTION
Qt is event-based and doesn't get windows positioned on screen immediately we call `setVisible()` or `setPosition()`, so we need to give it a grace period before asserting anything. Extending the grace period as done here has no real effect on test duration, but significantly improves reliability.
