### PR TITLE
GraphComponent : Fix Range iterators for Python types

### DIFF
--- a/include/GafferBindings/GraphComponentBinding.inl
+++ b/include/GafferBindings/GraphComponentBinding.inl
@@ -55,23 +55,6 @@ static bool acceptsParent( const T &p, const Gaffer::GraphComponent *potentialPa
 	return p.T::acceptsParent( potentialParent );
 }
 
-template<typename RangeType>
-static boost::python::object range( Gaffer::GraphComponent &graphComponent )
-{
-	boost::python::list l;
-	for( auto &c : RangeType( graphComponent ) )
-	{
-		l.append( c );
-	}
-	// We could just return a list object, but instead we're returning an
-	// iterator to a list. This gives us a bit more latitude to
-	// replace with a true iterator in future, to avoid fully generating the
-	// range before returning. The reason we don't do that now is that
-	// if a python script modified the graph while iterating, it would
-	// invalidate the iterator it was using, leading to crashes.
-	return l.attr( "__iter__" )();
-}
-
 } // namespace Detail
 
 template<typename T, typename TWrapper>
@@ -80,10 +63,6 @@ GraphComponentClass<T, TWrapper>::GraphComponentClass( const char *docString )
 {
 	this->def( "acceptsChild", &Detail::acceptsChild<T> );
 	this->def( "acceptsParent", &Detail::acceptsParent<T> );
-	this->def( "Range", &Detail::range<typename T::Range> );
-	this->staticmethod( "Range" );
-	this->def( "RecursiveRange", &Detail::range<typename T::RecursiveRange> );
-	this->staticmethod( "RecursiveRange" );
 }
 
 } // namespace GafferBindings

--- a/include/GafferBindings/PlugBinding.inl
+++ b/include/GafferBindings/PlugBinding.inl
@@ -73,14 +73,6 @@ PlugClass<T, TWrapper>::PlugClass( const char *docString )
 	this->def( "acceptsInput", &Detail::acceptsInput<T> );
 	this->def( "setInput", &Detail::setInput<T> );
 	this->def( "createCounterpart", &Detail::createCounterpart<T> );
-	this->def( "InputRange", &Detail::range<typename T::InputRange> );
-	this->staticmethod( "InputRange" );
-	this->def( "OutputRange", &Detail::range<typename T::OutputRange> );
-	this->staticmethod( "OutputRange" );
-	this->def( "RecursiveInputRange", &Detail::range<typename T::RecursiveInputRange> );
-	this->staticmethod( "RecursiveInputRange" );
-	this->def( "RecursiveOutputRange", &Detail::range<typename T::RecursiveOutputRange> );
-	this->staticmethod( "RecursiveOutputRange" );
 }
 
 } // namespace GafferBindings

--- a/python/Gaffer/_Range.py
+++ b/python/Gaffer/_Range.py
@@ -1,0 +1,87 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import Gaffer
+
+# Rather than bind the C++ GraphComponent Range classes to
+# Python, we just reimplement them in pure Python. This allows
+# us to properly support filtering for subclasses defined in
+# Python.
+
+def __range( cls, parent ) :
+
+	for i in range( 0, len( parent ) ) :
+		child = parent[i]
+		if isinstance( child, cls ) :
+			yield child
+
+def __recursiveRange( cls, parent ) :
+
+	for i in range( 0, len( parent ) ) :
+		child = parent[i]
+		if isinstance( child, cls ) :
+			yield child
+		for r in __recursiveRange( cls, child ) :
+			yield r
+
+Gaffer.GraphComponent.Range = classmethod( __range )
+Gaffer.GraphComponent.RecursiveRange = classmethod( __recursiveRange )
+
+def __plugRange( cls, parent, direction ) :
+
+	for i in range( 0, len( parent ) ) :
+		child = parent[i]
+		if isinstance( child, cls ) and child.direction() == direction :
+			yield child
+
+def __recursivePlugRange( cls, parent, direction = None ) :
+
+	for i in range( 0, len( parent ) ) :
+		child = parent[i]
+		if isinstance( child, cls ) and ( direction is None or child.direction() == direction ):
+			yield child
+		if isinstance( child, Gaffer.Plug ) :
+			for r in __recursivePlugRange( cls, child, direction ) :
+				yield r
+
+Gaffer.Plug.InputRange = classmethod( functools.partial( __plugRange, direction = Gaffer.Plug.Direction.In ) )
+Gaffer.Plug.OutputRange = classmethod( functools.partial( __plugRange, direction = Gaffer.Plug.Direction.Out ) )
+Gaffer.Plug.RecursiveRange = classmethod( __recursivePlugRange )
+Gaffer.Plug.RecursiveInputRange = classmethod( functools.partial( __recursivePlugRange, direction = Gaffer.Plug.Direction.In ) )
+Gaffer.Plug.RecursiveOutputRange = classmethod( functools.partial( __recursivePlugRange, direction = Gaffer.Plug.Direction.Out ) )
+

--- a/python/Gaffer/__init__.py
+++ b/python/Gaffer/__init__.py
@@ -38,6 +38,7 @@
 __import__( "IECore" )
 
 from _Gaffer import *
+import _Range
 from About import About
 from Application import Application
 from WeakMethod import WeakMethod

--- a/python/GafferTest/NodeTest.py
+++ b/python/GafferTest/NodeTest.py
@@ -379,5 +379,34 @@ class NodeTest( GafferTest.TestCase ) :
 			[ n["c2"], n["c3"]["gc2"], n["c3"]["gc3"] ],
 		)
 
+	def testRangesForPythonTypes( self ) :
+
+		n = Gaffer.Node()
+		n["a"] = GafferTest.AddNode()
+		n["b"] = Gaffer.Node()
+		n["c"] = GafferTest.AddNode()
+		n["d"] = Gaffer.Node()
+		n["d"]["e"] = GafferTest.AddNode()
+
+		self.assertEqual(
+			list( Gaffer.Node.Range( n ) ),
+			[ n["a"], n["b"], n["c"], n["d"] ],
+		)
+
+		self.assertEqual(
+			list( GafferTest.AddNode.Range( n ) ),
+			[ n["a"], n["c"] ],
+		)
+
+		self.assertEqual(
+			list( Gaffer.Node.RecursiveRange( n ) ),
+			[ n["a"], n["b"], n["c"], n["d"], n["d"]["e"] ],
+		)
+
+		self.assertEqual(
+			list( GafferTest.AddNode.RecursiveRange( n ) ),
+			[ n["a"], n["c"], n["d"]["e"] ],
+		)
+
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/GafferTest/PlugTest.py
+++ b/python/GafferTest/PlugTest.py
@@ -911,5 +911,85 @@ class PlugTest( GafferTest.TestCase ) :
 			[ n["c2"], n["c3"]["gc2"] ]
 		)
 
+	def testRangesForPythonTypes( self ) :
+
+		class DerivedPlug( Gaffer.Plug ) :
+
+			def __init__( self, name = "DerivedPlug", direction = Gaffer.Plug.Direction.In, flags = Gaffer.Plug.Flags.Default ) :
+
+				Gaffer.Plug.__init__( self, name, direction, flags )
+
+		IECore.registerRunTimeTyped( DerivedPlug )
+
+		n = Gaffer.Node()
+
+		n["c1"] = Gaffer.Plug()
+		n["c1"]["gc1"] = DerivedPlug()
+		n["c2"] = DerivedPlug( direction = Gaffer.Plug.Direction.Out )
+		n["c3"] = DerivedPlug( flags = Gaffer.Plug.Flags.Default & ~Gaffer.Plug.Flags.AcceptsInputs )
+		n["c3"]["gc2"] = DerivedPlug()
+		n["c3"]["gc3"] = DerivedPlug( direction = Gaffer.Plug.Direction.Out )
+		n["c3"]["gc4"] = Gaffer.IntPlug()
+
+		self.assertEqual(
+			list( Gaffer.Plug.Range( n ) ),
+			[ n["user"], n["c1"], n["c2"], n["c3"] ],
+		)
+
+		self.assertEqual(
+			list( Gaffer.Plug.InputRange( n ) ),
+			[ n["user"], n["c1"], n["c3"] ],
+		)
+
+		self.assertEqual(
+			list( Gaffer.Plug.OutputRange( n ) ),
+			[ n["c2"] ],
+		)
+
+		self.assertEqual(
+			list( DerivedPlug.Range( n ) ),
+			[ n["c2"], n["c3"] ],
+		)
+
+		self.assertEqual(
+			list( DerivedPlug.InputRange( n ) ),
+			[ n["c3"] ],
+		)
+
+		self.assertEqual(
+			list( DerivedPlug.OutputRange( n ) ),
+			[ n["c2"] ],
+		)
+
+		self.assertEqual(
+			list( Gaffer.Plug.RecursiveRange( n ) ),
+			[ n["user"], n["c1"], n["c1"]["gc1"], n["c2"], n["c3"], n["c3"]["gc2"], n["c3"]["gc3"], n["c3"]["gc4"] ],
+		)
+
+		self.assertEqual(
+			list( Gaffer.Plug.RecursiveInputRange( n ) ),
+			[ n["user"], n["c1"], n["c1"]["gc1"], n["c3"], n["c3"]["gc2"], n["c3"]["gc4"] ],
+		)
+
+		self.assertEqual(
+			list( Gaffer.Plug.RecursiveOutputRange( n ) ),
+			[ n["c2"], n["c3"]["gc3"] ],
+		)
+
+		self.assertEqual(
+			list( DerivedPlug.RecursiveRange( n ) ),
+			[ n["c1"]["gc1"], n["c2"], n["c3"], n["c3"]["gc2"], n["c3"]["gc3"] ],
+		)
+
+		self.assertEqual(
+			list( DerivedPlug.RecursiveInputRange( n ) ),
+			[ n["c1"]["gc1"], n["c3"], n["c3"]["gc2"] ],
+		)
+
+		self.assertEqual(
+			list( DerivedPlug.RecursiveOutputRange( n ) ),
+			[ n["c2"], n["c3"]["gc3"] ],
+		)
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Fixes #3441

Fixes
-----

- GraphComponent : Fixed Range and RecursiveRange iterators so that they correctly filter classes defined in Python (#3441).

