### PR TITLE
StandardLightVisualiser : Improve viewport performance + tests

### DIFF
--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -105,10 +105,6 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 		static IECoreGL::ConstRenderablePtr environmentSphereWireframe( float radius, const Imath::Vec3<bool> &axisRings );
 		static IECoreGL::ConstRenderablePtr environmentSphereSurface( IECore::ConstDataPtr textureData, int textureMaxResolution, const Imath::Color3f &fallbackColor  );
 
-		// Spread is generally rendered as an angle, rather than in light space,
-		// as such, this should generally only be used as a uniformly scaled visualisation.
-		static IECoreGL::ConstRenderablePtr areaSpread( float spread );
-
 		static IECoreGL::ConstRenderablePtr quadWireframe( const Imath::V2f &size );
 		static IECoreGL::ConstRenderablePtr quadSurface( const Imath::V2f &size, IECore::ConstDataPtr textureData, int textureMaxResolution, const Imath::Color3f &fallbackColor );
 

--- a/python/GafferArnoldUITest/LightVisualiserTest.py
+++ b/python/GafferArnoldUITest/LightVisualiserTest.py
@@ -1,0 +1,107 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferArnold
+import GafferScene
+import GafferSceneUITest
+import GafferTest
+
+@unittest.skipIf( GafferTest.inCI(), "OpenGL not set up" )
+class LightVisualiserTest( GafferSceneUITest.SceneUITestCase ) :
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testDrawPerformanceQuad( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["quad"] = GafferArnold.ArnoldLight()
+		script["quad"].loadShader( "quad_light" )
+
+		instancerOut = self.setupInstancer( script["quad"]["out"] )
+
+		self.benchmarkRender( instancerOut )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testDrawPerformanceSpot( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["spot"] = GafferArnold.ArnoldLight()
+		script["spot"].loadShader( "spot_light" )
+
+		script["light_decay"] = GafferArnold.ArnoldShader( "light_decay" )
+		script["light_decay"].loadShader( "light_decay" )
+		script["gobo"] = GafferArnold.ArnoldShader( "gobo" )
+		script["gobo"].loadShader( "gobo" )
+		script["barndoor"] = GafferArnold.ArnoldShader( "barndoor" )
+		script["barndoor"].loadShader( "barndoor" )
+		script["ShaderAssignment1"] = GafferScene.ShaderAssignment( "ShaderAssignment1" )
+		script["ShaderAssignment2"] = GafferScene.ShaderAssignment( "ShaderAssignment2" )
+		script["ShaderAssignment3"] = GafferScene.ShaderAssignment( "ShaderAssignment3" )
+		script["PathFilter4"] = GafferScene.PathFilter( "PathFilter4" )
+		script["light_decay"]["parameters"]["use_near_atten"].setValue( True )
+		script["light_decay"]["parameters"]["use_far_atten"].setValue( True )
+		script["light_decay"]["parameters"]["near_start"].setValue( 1.0 )
+		script["light_decay"]["parameters"]["near_end"].setValue( 2.0 )
+		script["light_decay"]["parameters"]["far_start"].setValue( 4.0 )
+		script["light_decay"]["parameters"]["far_end"].setValue( 5.0 )
+		script["gobo"]["parameters"]["density"].setValue( 0.30000001192092896 )
+		script["gobo"]["parameters"]["swrap"].setValue( 'periodic' )
+		script["gobo"]["parameters"]["twrap"].setValue( 'periodic' )
+		script["barndoor"]["parameters"]["barndoor_left_top"].setValue( 0.20000000298023224 )
+		script["barndoor"]["parameters"]["barndoor_left_bottom"].setValue( 0.30000001192092896 )
+		script["ShaderAssignment1"]["filter"].setInput( script["PathFilter4"]["out"] )
+		script["ShaderAssignment1"]["shader"].setInput( script["light_decay"]["out"] )
+		script["ShaderAssignment2"]["in"].setInput( script["ShaderAssignment1"]["out"] )
+		script["ShaderAssignment2"]["filter"].setInput( script["PathFilter4"]["out"] )
+		script["ShaderAssignment2"]["shader"].setInput( script["gobo"]["out"] )
+		script["ShaderAssignment3"]["in"].setInput( script["ShaderAssignment2"]["out"] )
+		script["ShaderAssignment3"]["filter"].setInput( script["PathFilter4"]["out"] )
+		script["ShaderAssignment3"]["shader"].setInput( script["barndoor"]["out"] )
+		script["PathFilter4"]["paths"].setValue( IECore.StringVectorData( [ '/*' ] ) )
+
+		instancerOut = self.setupInstancer( script["spot"]["out"] )
+
+		self.benchmarkRender( instancerOut )
+
+if __name__ == "__main__":
+	unittest.main()
+

--- a/python/GafferArnoldUITest/__init__.py
+++ b/python/GafferArnoldUITest/__init__.py
@@ -36,6 +36,7 @@
 
 from DocumentationTest import DocumentationTest
 from ArnoldShaderUITest import ArnoldShaderUITest
+from LightVisualiserTest import LightVisualiserTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/RendererTest.py
+++ b/python/GafferSceneUITest/RendererTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -15,7 +15,7 @@
 #        disclaimer in the documentation and/or other materials provided with
 #        the distribution.
 #
-#      * Neither the name of John Haddon nor the names of
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
 #        any other contributors to this software may be used to endorse or
 #        promote products derived from this software without specific prior
 #        written permission.
@@ -34,23 +34,33 @@
 #
 ##########################################################################
 
-from SceneViewTest import SceneViewTest
-from ShaderAssignmentUITest import ShaderAssignmentUITest
-from StandardGraphLayoutTest import StandardGraphLayoutTest
-from SceneGadgetTest import SceneGadgetTest
-from SceneInspectorTest import SceneInspectorTest
-from HierarchyViewTest import HierarchyViewTest
-from DocumentationTest import DocumentationTest
+import unittest
+
+import Gaffer
+import GafferScene
+import GafferTest
+
 from SceneUITestCase import SceneUITestCase
-from ShaderViewTest import ShaderViewTest
-from ShaderUITest import ShaderUITest
-from TranslateToolTest import TranslateToolTest
-from ScaleToolTest import ScaleToolTest
-from RotateToolTest import RotateToolTest
-from ContextAlgoTest import ContextAlgoTest
-from CameraToolTest import CameraToolTest
-from VisualiserTest import VisualiserTest
-from RendererTest import RendererTest
+
+@unittest.skipIf( GafferTest.inCI(), "OpenGL not set up" )
+class RendererTest( SceneUITestCase ) :
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testViewportDrawPerformanceEmpty( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["group"] = GafferScene.Group()
+
+		self.benchmarkRender( script["group"]["out"], frames = 10000 )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testViewportDrawPerformanceCubes( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["cube"] = GafferScene.Cube()
+		instancerOut = self.setupInstancer( script["cube"]["out"] )
+
+		self.benchmarkRender( instancerOut, frames = 500 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/SceneUITestCase.py
+++ b/python/GafferSceneUITest/SceneUITestCase.py
@@ -1,0 +1,118 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import math
+import unittest
+
+import imath
+
+import IECore
+import IECoreGL
+
+import Gaffer
+import GafferUI
+import GafferScene
+import GafferTest
+
+import GafferUITest
+
+class SceneUITestCase( GafferUITest.TestCase ) :
+
+	# Sets up a grid of instances on the XY plane of the supplied source
+	# prototype scene. Each instance will have a random rotation applied. The
+	# supplied ScenePlug's node needs to be parented to a Gaffer.ScriptNode.
+	@staticmethod
+	def setupInstancer( prototypeScenePlug, copies = 2500, spacing = 5 ) :
+
+		divisions = math.ceil( math.sqrt( copies ) )
+		dimension = divisions * spacing
+		assert( divisions > 0 )
+
+		script = prototypeScenePlug.node().ancestor( Gaffer.ScriptNode )
+		script["_Plane"] = GafferScene.Plane()
+		script["_Instancer"] = GafferScene.Instancer()
+		script["_PathFilter"] = GafferScene.PathFilter()
+		script["_Instancer"]["in"].setInput( script["_Plane"]["out"] )
+		script["_Instancer"]["prototypes"].setInput( prototypeScenePlug )
+		script["_Instancer"]["filter"].setInput( script["_PathFilter"]["out"] )
+		script["_Plane"]["dimensions"].setValue( imath.V2f( dimension ) )
+		script["_Plane"]["divisions"].setValue( imath.V2i( divisions ) )
+		script["_PathFilter"]["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+		script["_Transform"] = GafferScene.Transform( "Transform" )
+		script["_Transform"]["in"].setInput( script["_Instancer"]["out"] )
+		script["_Random"] = Gaffer.Random( "Random" )
+		script["_Expression"] = Gaffer.Expression( "Expression" )
+		script["_PathFilter1"] = GafferScene.PathFilter( "PathFilter1" )
+		script["_Transform"]["filter"].setInput( script["_PathFilter1"]["out"] )
+		script["_Random"]["contextEntry"].setValue( 'scene:path' )
+		script["_Random"]["baseColor"].setValue( imath.Color3f( 0.5, 0, 0 ) )
+		script["_Random"]["hue"].setValue( 1.0 )
+		script["_Random"]["saturation"].setValue( 1.0 )
+		script["_Random"]["value"].setValue( 1.0 )
+		script["_PathFilter1"]["paths"].setValue( IECore.StringVectorData( [ '/*/instances/*/*' ] ) )
+		script["_Expression"].setExpression( 'import imath\n\nr = parent["_Random"]["outColor"]\nr *= 360\n\nparent["_Transform"]["transform"]["rotate"] = r', "python" )
+
+		return script["_Transform" ]["out"]
+
+	# Renders the supplied scene a fixed number of times using the
+	# GafferTest.TestRunner.PerformanceScipe to record timings.
+	def benchmarkRender( self, scenePlug, frames = 100, renderer = "OpenGL" ) :
+
+		w = GafferUI.Window()
+		g = GafferUI.GLWidget()
+		w.setChild( g )
+
+		w.setVisible( True )
+
+		self.waitForIdle( 1000 )
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			renderer,
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
+		)
+
+		controller = GafferScene.RenderController( scenePlug,  Gaffer.Context(), r )
+		controller.setMinimumExpansionDepth( 999 )
+		controller.update()
+
+		self.waitForIdle( 10000 )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			for i in range( frames )  :
+				r.render()
+
+if __name__ == "__main__":
+	unittest.main()

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -595,18 +595,26 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 	Visualisations result;
 	if( !geometry->children().empty() )
 	{
+		addWireframeCurveState( geometry.get() );
+		addConstantShader( geometry.get() );
 		result.push_back( Visualisation::createGeometry( geometry ) );
 	}
 	if( !ornaments->children().empty() )
 	{
+		addWireframeCurveState( ornaments.get() );
+		addConstantShader( ornaments.get() );
 		result.push_back( Visualisation::createOrnament( ornaments, false ) );
 	}
 	if( !boundOrnaments->children().empty() )
 	{
+		addWireframeCurveState( boundOrnaments.get() );
+		addConstantShader( boundOrnaments.get() );
 		result.push_back( Visualisation::createOrnament( boundOrnaments, true ) );
 	}
 	if( !frustum->children().empty() )
 	{
+		addWireframeCurveState( frustum.get() );
+		addConstantShader( frustum.get() );
 		result.push_back( Visualisation::createFrustum( frustum, Visualisation::Scale::Visualiser ) );
 	}
 	return result;
@@ -739,9 +747,6 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::distantRays()
 IECoreGL::ConstRenderablePtr StandardLightVisualiser::spotlightCone( float innerAngle, float outerAngle, float lensRadius, float length, float lineWidthScale )
 {
 	IECoreGL::GroupPtr group = new IECoreGL::Group();
-	addWireframeCurveState( group.get() );
-	addConstantShader( group.get(), false );
-
 	group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 1.0f * lineWidthScale ) );
 
 	IntVectorDataPtr vertsPerCurve = new IntVectorData;
@@ -929,10 +934,6 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::quadSurface( const Imath::
 	{
 		addTexturedConstantShader( group.get(), textureData, maxTextureResolution );
 	}
-	else
-	{
-		addConstantShader( group.get(), true );
-	}
 
 	IECoreGL::QuadPrimitivePtr textureQuad = new IECoreGL::QuadPrimitive( size.x, size.y );
 	textureQuad->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( fallbackColor ) ) );
@@ -1109,10 +1110,6 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::environmentSphereSurface( 
 	{
 		addTexturedConstantShader( sphereGroup.get(), texture, maxTextureResolution );
 	}
-	else
-	{
-		addConstantShader( sphereGroup.get(), true );
-	}
 
 	IECoreGL::SpherePrimitivePtr sphere = new IECoreGL::SpherePrimitive();
 	sphere->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( fallbackColor ) ) );
@@ -1134,10 +1131,6 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::diskSurface( float radius,
 	if( textureData )
 	{
 		addTexturedConstantShader( group.get(), textureData, maxTextureResolution );
-	}
-	else
-	{
-		addConstantShader( group.get(), true );
 	}
 
 	IntVectorDataPtr vertsPerPoly = new IntVectorData;

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -753,6 +753,11 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::spotlightCone( float inner
 	V3fVectorDataPtr p = new V3fVectorData;
 	addCone( innerAngle, lensRadius, vertsPerCurve->writable(), p->writable(), length );
 
+	if( fabs( innerAngle - outerAngle ) > 0.1 )
+	{
+		addCone( outerAngle, lensRadius, vertsPerCurve->writable(), p->writable(), length );
+	}
+
 	IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurve );
 	curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, p ) );
 
@@ -760,25 +765,6 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::spotlightCone( float inner
 	curves->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, color ) );
 
 	group->addChild( curves );
-
-	if( fabs( innerAngle - outerAngle ) > 0.1 )
-	{
-		IECoreGL::GroupPtr outerGroup = new Group;
-		outerGroup->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 0.5f * lineWidthScale ) );
-
-		IntVectorDataPtr vertsPerCurve = new IntVectorData;
-		V3fVectorDataPtr p = new V3fVectorData;
-		addCone( outerAngle, lensRadius, vertsPerCurve->writable(), p->writable(), length );
-
-		IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurve );
-		curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, p ) );
-
-		curves->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, color ) );
-
-		outerGroup->addChild( curves );
-
-		group->addChild( outerGroup );
-	}
 
 	return group;
 }
@@ -948,10 +934,6 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::quadSurface( const Imath::
 
 IECoreGL::ConstRenderablePtr StandardLightVisualiser::quadWireframe( const V2f &size )
 {
-	IECoreGL::GroupPtr group = new IECoreGL::Group();
-	addWireframeCurveState( group.get() );
-	addConstantShader( group.get() );
-
 	IntVectorDataPtr vertsPerCurveData = new IntVectorData;
 	V3fVectorDataPtr pData = new V3fVectorData;
 
@@ -968,9 +950,7 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::quadWireframe( const V2f &
 	curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, pData ) );
 	curves->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( g_lightWireframeColor ) ) );
 
-	group->addChild( curves );
-
-	return group;
+	return curves;
 }
 
 IECoreGL::ConstRenderablePtr StandardLightVisualiser::quadPortal( const V2f &size )
@@ -1072,10 +1052,6 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::quadPortal( const V2f &siz
 
 IECoreGL::ConstRenderablePtr StandardLightVisualiser::environmentSphereWireframe( float radius, const Vec3<bool> &axisRings )
 {
-	IECoreGL::GroupPtr group = new IECoreGL::Group();
-	addWireframeCurveState( group.get() );
-	addConstantShader( group.get() );
-
 	IntVectorDataPtr vertsPerCurve = new IntVectorData;
 	V3fVectorDataPtr p = new V3fVectorData;
 
@@ -1096,9 +1072,7 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::environmentSphereWireframe
 	curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, p ) );
 	curves->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( Color3f( 1.0f, 0.835f, 0.07f ) ) ) );
 
-	group->addChild( curves );
-
-	return group;
+	return curves;
 }
 
 IECoreGL::ConstRenderablePtr StandardLightVisualiser::environmentSphereSurface( IECore::ConstDataPtr texture, int maxTextureResolution, const Imath::Color3f &fallbackColor )
@@ -1150,10 +1124,6 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::diskSurface( float radius,
 
 IECoreGL::ConstRenderablePtr StandardLightVisualiser::diskWireframe( float radius )
 {
-	IECoreGL::GroupPtr group = new IECoreGL::Group();
-	addWireframeCurveState( group.get() );
-	addConstantShader( group.get() );
-
 	IntVectorDataPtr vertsPerCurveData = new IntVectorData;
 	V3fVectorDataPtr pData = new V3fVectorData;
 
@@ -1163,9 +1133,7 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::diskWireframe( float radiu
 	curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, pData ) );
 	curves->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( g_lightWireframeColor ) ) );
 
-	group->addChild( curves );
-
-	return group;
+	return curves;
 }
 
 


### PR DESCRIPTION
Hopefully gets us back to `0.55` speeds (or better) aside from cases where we draw extra visualisations (such as spot cones).

Adds API level support for retrieving `GadgetWidget.draw()` performance and support for easy programatic camera movement in `ViewportGadget`.

Adds basic tests for `SceneView` and Arnold light visualisation performance based on conservative low water marks. We may want to disable these on CI.