### PR TITLE
Revert "CatalogueUI : Prefer NodeAlgo to homegrown graph traversals"

### DIFF
--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -158,17 +158,29 @@ def __viewerKeyPress( viewer, event ) :
 	if not isinstance( viewer.view(), GafferImageUI.ImageView ) :
 		return False
 
-	catalogue = Gaffer.NodeAlgo.findUpstream(
-		viewer.view(),
-		lambda node : isinstance( node, GafferImage.Catalogue ),
-		order = Gaffer.NodeAlgo.VisitOrder.DepthFirst
-	)
+	catalogue = __findCatalogue( viewer.view() )
 	if catalogue is None :
 		return False
 
 	__incrementImageIndex( catalogue, event.key )
 
 	return True
+
+def __findCatalogue( node ) :
+
+	catalogue = node.ancestor( GafferImage.Catalogue )
+	if catalogue is not None :
+		return catalogue
+	else :
+		for inPlug in GafferImage.ImagePlug.RecursiveInputRange( node ) :
+			upstreamPlug = inPlug.source()
+			if upstreamPlug == inPlug or upstreamPlug.node() == node :
+				continue
+			catalogue = __findCatalogue( upstreamPlug.node() )
+			if catalogue is not None :
+				return catalogue
+
+	return None
 
 def __incrementImageIndex( catalogue, direction ) :
 


### PR DESCRIPTION
This reverts commit 1de95ebe54ac2f5ef4675d3e8b4a23a342a79cd3.

Fixes #3605. The problem is that `upstreamNodes()` doesn't traverse inside Boxes, whereas our homegrown traversal did. We either need to introduce an `upstreamPlugs()` family of methods mirroring `upstreamNodes()` but at the plug level, or we need to introduce some control over  traversal of internal nodes to `upstreamNodes()`. While we mull that over, we're simply reverting the problematic commit.

