### PR TITLE
Azure : Lock python package versions

### DIFF
--- a/config/azure/build.yaml
+++ b/config/azure/build.yaml
@@ -38,7 +38,7 @@ jobs:
 
    # Provides $(Gaffer.*) variables
    - script: |
-       pip install --user PyGithub &&
+       pip install --user PyGithub==1.45 &&
        ./config/azure/setBuildVars.py
      displayName: 'Set Custom Variables'
      env:
@@ -94,7 +94,7 @@ jobs:
    - ${{ if eq(parameters.publish, true) }}:
 
      - script: |
-         pip install --user azure-common==1.1.23 azure-nspkg==3.0.2 azure-storage-blob==2.1.0 azure-storage-common==2.1.0 azure-storage-nspkg==3.1.0 PyGithub &&
+         pip install --user azure-common==1.1.23 azure-nspkg==3.0.2 azure-storage-blob==2.1.0 azure-storage-common==2.1.0 azure-storage-nspkg==3.1.0 PyGithub==1.45 &&
          ./config/azure/publishBuild.py --archive ./install/$(Gaffer.Build.Name).tar.gz --repo $(Build.Repository.Name) --commit $(Gaffer.Source.Commit)
        displayName: "Publish Build"
        condition: and( succeeded(), or( eq( variables['Build.Reason'], 'PullRequest' ), eq( variables['Build.Reason'], 'Schedule' ) ) )
@@ -103,7 +103,7 @@ jobs:
          AZURE_ACCESS_TOKEN: $(azureBlobAccessToken)
 
      - script: |
-         pip install --user PyGithub &&
+         pip install --user PyGithub==1.45 &&
          ./config/azure/publishRelease.py --archive ./install/$(Gaffer.Build.Name).tar.gz --repo $(Build.Repository.Name) --releaseId $(Gaffer.GitHub.ReleaseID)
        displayName: "Publish Release"
        condition: and( succeeded(), ne( variables['Gaffer.GitHub.ReleaseID'], '' ) )

--- a/config/azure/build.yaml
+++ b/config/azure/build.yaml
@@ -45,7 +45,7 @@ jobs:
        GITHUB_ACCESS_TOKEN: $(githubAccessToken)
 
    - script: |
-       pip install sphinx sphinx_rtd_theme recommonmark &&
+       pip install sphinx==1.8.0 sphinx_rtd_theme==0.4.3 recommonmark==0.5.0 docutils==0.12 &&
        brew update &&
        brew install scons doxygen &&
        brew cask install xquartz inkscape


### PR DESCRIPTION
As noted in [last nights release](https://github.com/PyGithub/PyGithub/releases/tag/v1.46) of `PyGithub`:
> Python 2 support has been removed. If you still require Python 2, use 1.45.

This also locks macOS docs packages installed via `pip` to the same versions as in the `gaffer/build` CentOS container.