### PR TITLE
Visualiser Changes To Allow IE To Use As Much As Possible

### DIFF
--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -465,7 +465,10 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 	}
 	else if( type && type->readable() == "quad" )
 	{
-		const V2f size( 2 );
+		const V2f size(
+			parameter<float>( metadataTarget, shaderParameters, "widthParameter", 2.0f ),
+			parameter<float>( metadataTarget, shaderParameters, "heightParameter", 2.0f )
+		);
 		// Cycles/Arnold define portals via a parameter on a quad, rather than as it's own light type.
 		if( parameter<bool>( metadataTarget, shaderParameters, "portalParameter", false ) )
 		{


### PR DESCRIPTION
I'm looking into getting ImageEngine using as much of the new visualiser code as possible, and have hit a few snags.

One of them has a simple solution, so I figured I would start this conversation with this PR.

There are other possible solutions to this ( we could make StandardLightVisualiser::quadPortal public so I could call it from IERendering ), but this one feels like a reasonable way to keep us from having to deviate too far from core on the visualisation.

It would also be nice if I could explicitly specify that a type of light is always a portal in the metadata ( our area light supports being output as a quad or cylinder, so it doesn't make sense to combine that with a portal ), but I can hack around that by adding a hidden parameter to our portals that is always true.

The most potentially annoying thing to fix is that since these changes, there's now no way to get the color and texture of an env light multiplied together like they were before.  This is pretty important to see the actual color of our env lights.  Do we need to add a new visualiser parameter "tintParameter", which would be multiplied, with the existing "colorParameter" being interpreted to just be default color?  What should happen if someone sets both colorParameter and tintParameter?

The other thing I noticed that seems off is that the point light color indicator doesn't scale with the radius.  If you have a 10 unit wide point light, the color indicator is a tiny, unreadable dot in the middle.

There's also no indication at all of the radius of a spot light - maybe this is how it was in Gaffer before.  Previously we did indicate radius on IE spotlights - though this is one where the artists I've surveyed sounded fine with the Gaffer behaviour, but then I worry that they aren't paying enough attention to tuning spot light sizes, and may be getting some oversharp highlights.  I could go either way on this one.

Anyway, other than that, it seems like most things are hooking up OK.  Getting the IE spot visualiser with gobo/barndoor/decay vis support in line with the new Gaffer stuff is a bit annoying, but it seems to be working OK, and adding one of the new frustums looks nice.

I guess dealing with portals isn't strictly necessary - we could keep visualising them like area lights, but the new portal visualiser is pretty enough that I wanted to hook it up.