### PR TITLE
Visualisers :  Performance tests

### DIFF
--- a/python/GafferArnoldUITest/LightVisualiserTest.py
+++ b/python/GafferArnoldUITest/LightVisualiserTest.py
@@ -1,0 +1,107 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferArnold
+import GafferScene
+import GafferSceneUITest
+import GafferTest
+
+@unittest.skipIf( GafferTest.inCI(), "OpenGL not set up" )
+class LightVisualiserTest( GafferSceneUITest.SceneUITestCase ) :
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testDrawPerformanceQuad( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["quad"] = GafferArnold.ArnoldLight()
+		script["quad"].loadShader( "quad_light" )
+
+		instancerOut = self.setupInstancer( script["quad"]["out"] )
+
+		self.benchmarkRender( instancerOut )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testDrawPerformanceSpot( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["spot"] = GafferArnold.ArnoldLight()
+		script["spot"].loadShader( "spot_light" )
+
+		script["light_decay"] = GafferArnold.ArnoldShader( "light_decay" )
+		script["light_decay"].loadShader( "light_decay" )
+		script["gobo"] = GafferArnold.ArnoldShader( "gobo" )
+		script["gobo"].loadShader( "gobo" )
+		script["barndoor"] = GafferArnold.ArnoldShader( "barndoor" )
+		script["barndoor"].loadShader( "barndoor" )
+		script["ShaderAssignment1"] = GafferScene.ShaderAssignment( "ShaderAssignment1" )
+		script["ShaderAssignment2"] = GafferScene.ShaderAssignment( "ShaderAssignment2" )
+		script["ShaderAssignment3"] = GafferScene.ShaderAssignment( "ShaderAssignment3" )
+		script["PathFilter4"] = GafferScene.PathFilter( "PathFilter4" )
+		script["light_decay"]["parameters"]["use_near_atten"].setValue( True )
+		script["light_decay"]["parameters"]["use_far_atten"].setValue( True )
+		script["light_decay"]["parameters"]["near_start"].setValue( 1.0 )
+		script["light_decay"]["parameters"]["near_end"].setValue( 2.0 )
+		script["light_decay"]["parameters"]["far_start"].setValue( 4.0 )
+		script["light_decay"]["parameters"]["far_end"].setValue( 5.0 )
+		script["gobo"]["parameters"]["density"].setValue( 0.30000001192092896 )
+		script["gobo"]["parameters"]["swrap"].setValue( 'periodic' )
+		script["gobo"]["parameters"]["twrap"].setValue( 'periodic' )
+		script["barndoor"]["parameters"]["barndoor_left_top"].setValue( 0.20000000298023224 )
+		script["barndoor"]["parameters"]["barndoor_left_bottom"].setValue( 0.30000001192092896 )
+		script["ShaderAssignment1"]["filter"].setInput( script["PathFilter4"]["out"] )
+		script["ShaderAssignment1"]["shader"].setInput( script["light_decay"]["out"] )
+		script["ShaderAssignment2"]["in"].setInput( script["ShaderAssignment1"]["out"] )
+		script["ShaderAssignment2"]["filter"].setInput( script["PathFilter4"]["out"] )
+		script["ShaderAssignment2"]["shader"].setInput( script["gobo"]["out"] )
+		script["ShaderAssignment3"]["in"].setInput( script["ShaderAssignment2"]["out"] )
+		script["ShaderAssignment3"]["filter"].setInput( script["PathFilter4"]["out"] )
+		script["ShaderAssignment3"]["shader"].setInput( script["barndoor"]["out"] )
+		script["PathFilter4"]["paths"].setValue( IECore.StringVectorData( [ '/*' ] ) )
+
+		instancerOut = self.setupInstancer( script["spot"]["out"] )
+
+		self.benchmarkRender( instancerOut )
+
+if __name__ == "__main__":
+	unittest.main()
+

--- a/python/GafferArnoldUITest/__init__.py
+++ b/python/GafferArnoldUITest/__init__.py
@@ -36,6 +36,7 @@
 
 from DocumentationTest import DocumentationTest
 from ArnoldShaderUITest import ArnoldShaderUITest
+from LightVisualiserTest import LightVisualiserTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/RendererTest.py
+++ b/python/GafferSceneUITest/RendererTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -15,7 +15,7 @@
 #        disclaimer in the documentation and/or other materials provided with
 #        the distribution.
 #
-#      * Neither the name of John Haddon nor the names of
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
 #        any other contributors to this software may be used to endorse or
 #        promote products derived from this software without specific prior
 #        written permission.
@@ -34,23 +34,33 @@
 #
 ##########################################################################
 
-from SceneViewTest import SceneViewTest
-from ShaderAssignmentUITest import ShaderAssignmentUITest
-from StandardGraphLayoutTest import StandardGraphLayoutTest
-from SceneGadgetTest import SceneGadgetTest
-from SceneInspectorTest import SceneInspectorTest
-from HierarchyViewTest import HierarchyViewTest
-from DocumentationTest import DocumentationTest
+import unittest
+
+import Gaffer
+import GafferScene
+import GafferTest
+
 from SceneUITestCase import SceneUITestCase
-from ShaderViewTest import ShaderViewTest
-from ShaderUITest import ShaderUITest
-from TranslateToolTest import TranslateToolTest
-from ScaleToolTest import ScaleToolTest
-from RotateToolTest import RotateToolTest
-from ContextAlgoTest import ContextAlgoTest
-from CameraToolTest import CameraToolTest
-from VisualiserTest import VisualiserTest
-from RendererTest import RendererTest
+
+@unittest.skipIf( GafferTest.inCI(), "OpenGL not set up" )
+class RendererTest( SceneUITestCase ) :
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testViewportDrawPerformanceEmpty( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["group"] = GafferScene.Group()
+
+		self.benchmarkRender( script["group"]["out"], frames = 10000 )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testViewportDrawPerformanceCubes( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["cube"] = GafferScene.Cube()
+		instancerOut = self.setupInstancer( script["cube"]["out"] )
+
+		self.benchmarkRender( instancerOut, frames = 1000 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/SceneUITestCase.py
+++ b/python/GafferSceneUITest/SceneUITestCase.py
@@ -1,0 +1,120 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import math
+import unittest
+
+import imath
+
+import IECore
+import IECoreGL
+
+import Gaffer
+import GafferUI
+import GafferScene
+import GafferTest
+
+import GafferUITest
+
+class SceneUITestCase( GafferUITest.TestCase ) :
+
+	# Sets up a grid of instances on the XY plane of the supplied source
+	# prototype scene. Each instance will have a random rotation applied. The
+	# supplied ScenePlug's node needs to be parented to a Gaffer.ScriptNode.
+	@staticmethod
+	def setupInstancer( prototypeScenePlug, copies = 2500, spacing = 5 ) :
+
+		divisions = math.ceil( math.sqrt( copies ) )
+		dimension = divisions * spacing
+		assert( divisions > 0 )
+
+		script = prototypeScenePlug.node().ancestor( Gaffer.ScriptNode )
+		script["_Plane"] = GafferScene.Plane()
+		script["_Instancer"] = GafferScene.Instancer()
+		script["_PathFilter"] = GafferScene.PathFilter()
+		script["_Instancer"]["in"].setInput( script["_Plane"]["out"] )
+		script["_Instancer"]["prototypes"].setInput( prototypeScenePlug )
+		script["_Instancer"]["filter"].setInput( script["_PathFilter"]["out"] )
+		script["_Plane"]["dimensions"].setValue( imath.V2f( dimension ) )
+		script["_Plane"]["divisions"].setValue( imath.V2i( divisions ) )
+		script["_PathFilter"]["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+		script["_Transform"] = GafferScene.Transform( "Transform" )
+		script["_Transform"]["in"].setInput( script["_Instancer"]["out"] )
+		script["_Random"] = Gaffer.Random( "Random" )
+		script["_Expression"] = Gaffer.Expression( "Expression" )
+		script["_PathFilter1"] = GafferScene.PathFilter( "PathFilter1" )
+		script["_Transform"]["filter"].setInput( script["_PathFilter1"]["out"] )
+		script["_Random"]["contextEntry"].setValue( 'scene:path' )
+		script["_Random"]["baseColor"].setValue( imath.Color3f( 0.5, 0, 0 ) )
+		script["_Random"]["hue"].setValue( 1.0 )
+		script["_Random"]["saturation"].setValue( 1.0 )
+		script["_Random"]["value"].setValue( 1.0 )
+		script["_PathFilter1"]["paths"].setValue( IECore.StringVectorData( [ '/*/instances/*/*' ] ) )
+		script["_Expression"].setExpression( 'import imath\n\nr = parent["_Random"]["outColor"]\nr *= 360\n\nparent["_Transform"]["transform"]["rotate"] = r', "python" )
+
+		return script["_Transform" ]["out"]
+
+	# Renders the supplied scene a fixed number of times using the
+	# GafferTest.TestRunner.PerformanceScipe to record timings.
+	def benchmarkRender( self, scenePlug, frames = 500, rendererName = "OpenGL" ) :
+
+		window = GafferUI.Window()
+		gl = GafferUI.GLWidget()
+		window.setChild( gl )
+
+		gl._qtWidget().setMinimumSize( 512, 512 )
+		gl._qtWidget().setMaximumSize( 512, 512 )
+
+		window.setVisible( True )
+		gl._makeCurrent()
+
+		self.waitForIdle( 1000 )
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			rendererName,
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
+		)
+
+		controller = GafferScene.RenderController( scenePlug,  Gaffer.Context(), renderer )
+		controller.setMinimumExpansionDepth( 999 )
+		controller.update()
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			for i in range( frames )  :
+				renderer.render()
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Supersedes #3603.

As part of extending and refining View port visualisations, we've degraded performance somewhat. Some of this is unavoidable as we're deliberately doing more work (frustums, and discreet transform spaces). This PR introduces some renderer/visualisation timing tests that report via the `GafferTest.TestRunner.PerformanceTestMethod` mechanism. They're currently limited in scope to just testing (ultimately) the performance of `render()`. So it includes:

 - The specific implementation of `IECoreGLPreview::Renderer::render`.
 - The overhead of any registered visualisers.

At this point, we're deliberately excluding Qt, scene processing, etc... 

We could arguably not bother with https://github.com/GafferHQ/gaffer/pull/3615/commits/ecd77c626df8627bed4e57229bdd7cec0663c5e3 if not having the wireframe state on the returned renderable is a concern, though it does seemingly improve quad performance.

I think most of the overhead in the spots test is because it is a spot + 3 light filters, using numerous visualisation transform spaces, so there may be further improvements we could make there in other areas.  

## Performance comparisons
```
              Empty   Cubes   Quads   Spots
0.55.4.1       0.1     13.5    34.5    34.9
0.56.0.0b2     0.1     14.2    41.8    51.3
earlyOut       0.1     13.3    40.7    50.5
combine        0.1     13.8    29.8    49.9
(removeGrp     0.1     14.0    28.6    51.1)

Times in seconds to render n frames, average of 3 runs.
NOTE: The spotlight case does more work in 0.56 due to visualisation improvements.
```
There seems to be a fairly significant variance ( +-0.5s) in most test run results (other than empty).  None of the changes other than `earlyOut` affect the `Cubes` code path.