### PR TITLE
StandardLightVisualiser : scale/radius/portal fixes and de-clutter

### DIFF
--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -74,7 +74,7 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 		static IECoreGL::ConstRenderablePtr distantRays();
 		static IECoreGL::ConstRenderablePtr spotlightCone( float innerAngle, float outerAngle, float lensRadius, float length = 1.0f, float lineWidthScale = 1.0f );
 
-		static IECoreGL::ConstRenderablePtr quadPortal( const Imath::V2f &size );
+		static IECoreGL::ConstRenderablePtr quadPortal( const Imath::V2f &size, float hatchingScale = 1.0f );
 
 		static IECoreGL::ConstRenderablePtr colorIndicator( const Imath::Color3f &color );
 

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -65,7 +65,7 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 
 		IECoreGLPreview::Visualisations visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
 
-		static void spotlightParameters( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, float &innerAngle, float &outerAngle, float &lensRadius );
+		static void spotlightParameters( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, float &innerAngle, float &outerAngle, float &radius, float &lensRadius );
 
 	protected :
 

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -102,7 +102,6 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 
 		// textureData should be as per return type of surfaceTexture
 
-		static IECoreGL::ConstRenderablePtr environmentSphereWireframe( float radius, const Imath::Vec3<bool> &axisRings );
 		static IECoreGL::ConstRenderablePtr environmentSphereSurface( IECore::ConstDataPtr textureData, const Imath::Color3f &tint, int textureMaxResolution, const Imath::Color3f &fallbackColor );
 
 		// Spread is generally rendered as an angle, rather than in light space,
@@ -114,6 +113,8 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 
 		static IECoreGL::ConstRenderablePtr diskWireframe( float radius );
 		static IECoreGL::ConstRenderablePtr diskSurface( float radius, IECore::ConstDataPtr textureData, const Imath::Color3f &tint, int textureMaxResolution, const Imath::Color3f &fallbackColor );
+
+		static IECoreGL::ConstRenderablePtr sphereWireframe( float radius, const Imath::Vec3<bool> &axisRings, float lineWidthScale = 1.0f, const Imath::V3f &center = Imath::V3f( 0.0f ) );
 
 		static LightVisualiser::LightVisualiserDescription<StandardLightVisualiser> g_description;
 

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -73,6 +73,7 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 		static IECoreGL::ConstRenderablePtr pointRays( float radius = 0 );
 		static IECoreGL::ConstRenderablePtr distantRays();
 		static IECoreGL::ConstRenderablePtr spotlightCone( float innerAngle, float outerAngle, float lensRadius, float length = 1.0f, float lineWidthScale = 1.0f );
+		static IECoreGL::ConstRenderablePtr sphereWireframe( float radius, const Imath::Vec3<bool> &axisRings, float lineWidthScale = 1.0f, const Imath::V3f &center = Imath::V3f( 0.0f ) );
 
 		static IECoreGL::ConstRenderablePtr quadPortal( const Imath::V2f &size, float hatchingScale = 1.0f );
 
@@ -113,8 +114,6 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 
 		static IECoreGL::ConstRenderablePtr diskWireframe( float radius );
 		static IECoreGL::ConstRenderablePtr diskSurface( float radius, IECore::ConstDataPtr textureData, const Imath::Color3f &tint, int textureMaxResolution, const Imath::Color3f &fallbackColor );
-
-		static IECoreGL::ConstRenderablePtr sphereWireframe( float radius, const Imath::Vec3<bool> &axisRings, float lineWidthScale = 1.0f, const Imath::V3f &center = Imath::V3f( 0.0f ) );
 
 		static LightVisualiser::LightVisualiserDescription<StandardLightVisualiser> g_description;
 

--- a/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
+++ b/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
@@ -441,6 +441,13 @@ Visualisations ArnoldLightVisualiser::visualise( const IECore::InternedString &a
 			IECoreGL::RenderablePtr iesVis = iesVisualisation( iesFilenameData->readable() );
 			if( iesVis )
 			{
+				if( ConstM44fDataPtr visOrientationData = Gaffer::Metadata::value<M44fData>( "ai:light:photometric_light", "visualiserOrientation" ) )
+				{
+					IECoreGL::GroupPtr group = new IECoreGL::Group();
+					group->addChild( iesVis );
+					group->setTransform( visOrientationData->readable() );
+					iesVis = group;
+				}
 				v.push_back( Visualisation::createOrnament( iesVis, true ) );
 			}
 		}

--- a/src/GafferArnoldUI/BarndoorVisualiser.cpp
+++ b/src/GafferArnoldUI/BarndoorVisualiser.cpp
@@ -218,9 +218,10 @@ Visualisations BarndoorVisualiser::visualise( const IECore::InternedString &attr
 
 		float innerAngle;
 		float coneAngle;
+		float radius;
 		float lensRadius;
 
-		StandardLightVisualiser::spotlightParameters( "ai:light", lightShaderNetwork, innerAngle, coneAngle, lensRadius );
+		StandardLightVisualiser::spotlightParameters( "ai:light", lightShaderNetwork, innerAngle, coneAngle, radius, lensRadius );
 
 		const float halfAngle = 0.5 * M_PI * coneAngle / 180.0;
 		const float baseRadius = sin( halfAngle ) + lensRadius;

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -234,9 +234,10 @@ Visualisations GoboVisualiser::visualise( const IECore::InternedString &attribut
 
 	float innerAngle;
 	float coneAngle;
+	float radius;
 	float lensRadius;
 
-	StandardLightVisualiser::spotlightParameters( "ai:light", lightShaderNetwork, innerAngle, coneAngle, lensRadius );
+	StandardLightVisualiser::spotlightParameters( "ai:light", lightShaderNetwork, innerAngle, coneAngle, radius, lensRadius );
 
 	float halfPi = 0.5 * M_PI;
 

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -330,12 +330,12 @@ const char *faceCameraVertexSource()
 
 // Shader state helpers
 
-void addWireframeCurveState( IECoreGL::Group *group )
+void addWireframeCurveState( IECoreGL::Group *group, float lineWidthScale = 1.0f )
 {
 	group->getState()->add( new IECoreGL::Primitive::DrawWireframe( false ) );
 	group->getState()->add( new IECoreGL::Primitive::DrawSolid( true ) );
 	group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
-	group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 2.0f ) );
+	group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 2.0f * lineWidthScale ) );
 	group->getState()->add( new IECoreGL::LineSmoothingStateComponent( true ) );
 }
 
@@ -461,13 +461,14 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 			ConstDataPtr textureData = drawTextured ? surfaceTexture( shaderNetwork, attributes, maxTextureResolution ) : nullptr;
 			boundOrnaments->addChild( const_pointer_cast<IECoreGL::Renderable>( environmentSphereSurface( textureData, tint, maxTextureResolution, color ) ) );
 		}
-		boundOrnaments->addChild( const_pointer_cast<IECoreGL::Renderable>( environmentSphereWireframe( 1.05f, Vec3<bool>( true ) ) ) );
+		boundOrnaments->addChild( const_pointer_cast<IECoreGL::Renderable>( sphereWireframe( 1.05f, Vec3<bool>( true ) ) ) );
 	}
 	else if( type && type->readable() == "spot" )
 	{
 		float innerAngle, outerAngle, radius, lensRadius;
 		spotlightParameters( attributeName, shaderNetwork, innerAngle, outerAngle, radius, lensRadius );
 		boundOrnaments->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / visualiserScale, 1.0f, 1.0f ) ) );
+		fixedScaleOrnaments->addChild( const_pointer_cast<IECoreGL::Renderable>( sphereWireframe( radius, Vec3<bool>( false, false, true ), 0.5f, V3f( 0.0f, 0.0f, 0.1f * visualiserScale ) ) ) );
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( color ) ) );
 		frustum->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / visualiserScale, 10.0f * frustumScale, 0.2f ) ) );
@@ -554,7 +555,7 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 		const float radius = parameter<float>( metadataTarget, shaderParameters, "radiusParameter", 0 );
 		if( radius > 0 )
 		{
-			fixedScaleOrnaments->addChild( const_pointer_cast<IECoreGL::Renderable>( environmentSphereWireframe( radius, Vec3<bool>( true, false, true ) ) ) );
+			fixedScaleOrnaments->addChild( const_pointer_cast<IECoreGL::Renderable>( sphereWireframe( radius, Vec3<bool>( true, false, true ), 0.5f ) ) );
 		}
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( color ) ) );
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
@@ -727,10 +728,8 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::distantRays()
 IECoreGL::ConstRenderablePtr StandardLightVisualiser::spotlightCone( float innerAngle, float outerAngle, float lensRadius, float length, float lineWidthScale )
 {
 	IECoreGL::GroupPtr group = new IECoreGL::Group();
-	addWireframeCurveState( group.get() );
+	addWireframeCurveState( group.get(), lineWidthScale );
 	addConstantShader( group.get(), false );
-
-	group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 1.0f * lineWidthScale ) );
 
 	IntVectorDataPtr vertsPerCurve = new IntVectorData;
 	V3fVectorDataPtr p = new V3fVectorData;
@@ -747,7 +746,7 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::spotlightCone( float inner
 	if( fabs( innerAngle - outerAngle ) > 0.1 )
 	{
 		IECoreGL::GroupPtr outerGroup = new Group;
-		outerGroup->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 0.5f * lineWidthScale ) );
+		outerGroup->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 1.0f * lineWidthScale ) );
 
 		IntVectorDataPtr vertsPerCurve = new IntVectorData;
 		V3fVectorDataPtr p = new V3fVectorData;
@@ -856,7 +855,7 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::cylinderShape( float radiu
 IECoreGL::ConstRenderablePtr StandardLightVisualiser::pointShape( float radius )
 {
 	IECoreGL::GroupPtr group = new IECoreGL::Group();
-	addWireframeCurveState( group.get() );
+	addWireframeCurveState( group.get(), 0.5f );
 	addConstantShader( group.get(), false, 1 );
 
 	IntVectorDataPtr vertsPerCurveData = new IntVectorData;
@@ -912,9 +911,8 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::areaSpread( float spread )
 	// Simple spaced parallel arrows that diverge by 45 degrees as spread approaches 1.
 
 	IECoreGL::GroupPtr group = new IECoreGL::Group();
-	addWireframeCurveState( group.get() );
+	addWireframeCurveState( group.get(), 0.5f );
 	addConstantShader( group.get() );
-	group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 0.5f ) );
 
 	IntVectorDataPtr vertsPerCurveData = new IntVectorData;
 	V3fVectorDataPtr pData = new V3fVectorData;
@@ -1103,10 +1101,10 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::quadPortal( const V2f &siz
 
 // Spheres
 
-IECoreGL::ConstRenderablePtr StandardLightVisualiser::environmentSphereWireframe( float radius, const Vec3<bool> &axisRings )
+IECoreGL::ConstRenderablePtr StandardLightVisualiser::sphereWireframe( float radius, const Vec3<bool> &axisRings, float lineWidthScale, const V3f &center )
 {
 	IECoreGL::GroupPtr group = new IECoreGL::Group();
-	addWireframeCurveState( group.get() );
+	addWireframeCurveState( group.get(), lineWidthScale );
 	addConstantShader( group.get() );
 
 	IntVectorDataPtr vertsPerCurve = new IntVectorData;
@@ -1114,15 +1112,15 @@ IECoreGL::ConstRenderablePtr StandardLightVisualiser::environmentSphereWireframe
 
 	if( axisRings.x )
 	{
-		addCircle( Axis::X,  V3f( 0 ), radius, vertsPerCurve->writable(), p->writable() );
+		addCircle( Axis::X,  center, radius, vertsPerCurve->writable(), p->writable() );
 	}
 	if( axisRings.y )
 	{
-		addCircle( Axis::Y,  V3f( 0 ), radius, vertsPerCurve->writable(), p->writable() );
+		addCircle( Axis::Y,  center, radius, vertsPerCurve->writable(), p->writable() );
 	}
 	if( axisRings.z )
 	{
-		addCircle( Axis::Z,  V3f( 0 ), radius, vertsPerCurve->writable(), p->writable() );
+		addCircle( Axis::Z,  center, radius, vertsPerCurve->writable(), p->writable() );
 	}
 
 	IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurve );

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -465,8 +465,8 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 	}
 	else if( type && type->readable() == "spot" )
 	{
-		float innerAngle, outerAngle, lensRadius;
-		spotlightParameters( attributeName, shaderNetwork, innerAngle, outerAngle, lensRadius );
+		float innerAngle, outerAngle, radius, lensRadius;
+		spotlightParameters( attributeName, shaderNetwork, innerAngle, outerAngle, radius, lensRadius );
 		boundOrnaments->addChild( const_pointer_cast<IECoreGL::Renderable>( spotlightCone( innerAngle, outerAngle, lensRadius / visualiserScale, 1.0f, 1.0f ) ) );
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( ray() ) );
 		ornaments->addChild( const_pointer_cast<IECoreGL::Renderable>( colorIndicator( color ) ) );
@@ -610,7 +610,7 @@ IECore::DataPtr StandardLightVisualiser::surfaceTexture( const IECoreScene::Shad
 	return nullptr;
 }
 
-void StandardLightVisualiser::spotlightParameters( const InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, float &innerAngle, float &outerAngle, float &lensRadius )
+void StandardLightVisualiser::spotlightParameters( const InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, float &innerAngle, float &outerAngle, float &radius, float &lensRadius )
 {
 
 	InternedString metadataTarget = metadataTargetForNetwork( shaderNetwork );
@@ -654,6 +654,9 @@ void StandardLightVisualiser::spotlightParameters( const InternedString &attribu
 	{
 		lensRadius = parameter<float>( metadataTarget, shaderParameters, "lensRadiusParameter", 0.0f );
 	}
+
+	radius = parameter<float>( metadataTarget, shaderParameters, "radiusParameter", 0.0f );
+
 }
 
 

--- a/startup/GafferScene/arnoldLights.py
+++ b/startup/GafferScene/arnoldLights.py
@@ -46,6 +46,7 @@ Gaffer.Metadata.registerValue( "ai:light:spot_light", "penumbraType", "inset" )
 Gaffer.Metadata.registerValue( "ai:light:spot_light", "intensityParameter", "intensity" )
 Gaffer.Metadata.registerValue( "ai:light:spot_light", "exposureParameter", "exposure" )
 Gaffer.Metadata.registerValue( "ai:light:spot_light", "colorParameter", "color" )
+Gaffer.Metadata.registerValue( "ai:light:spot_light", "radiusParameter", "radius" )
 Gaffer.Metadata.registerValue( "ai:light:spot_light", "lensRadiusParameter", "lens_radius" )
 
 Gaffer.Metadata.registerValue( "ai:light:point_light", "type", "point" )


### PR DESCRIPTION
### Fixes (relative to 0.56.0.0b2) 
 - Missing Arnold `spot_light` radius representation.
 - Incorrect interaction with `radius` and visualiser scale for Point/Photometric lights.
 - Fixes incorrect IES profile visualisation orientation.
 - Removes `quad_light` portal rendering artefacts with non unit square portals.

### Improvements (relative to 0.56.0.0b2)
 - Declutters `spot_light` cones (removes inner spokes from cone visualisation)
 - Adds radius representation for `spot_light`.
 - `quad_light` portal hatching now scales with visualisers.

![Screenshot 2020-02-14 at 13 24 04](https://user-images.githubusercontent.com/896779/74539457-f6c22100-4f35-11ea-877d-0d1d25e1f0dc.png)

![image](https://user-images.githubusercontent.com/896779/74367942-9f537200-4dca-11ea-8342-65f19999f9b6.png)
