### PR TITLE
Startup : Add compatibility for upcoming Context changes

### DIFF
--- a/python/GafferTest/StringPlugTest.py
+++ b/python/GafferTest/StringPlugTest.py
@@ -209,6 +209,14 @@ class StringPlugTest( GafferTest.TestCase ) :
 		s2.execute( s.serialise() )
 		self.assertEqual( s["n"]["p"].substitutions(), s2["n"]["p"].substitutions() )
 
+	def testLoadSubstitutionsVersion0_56( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( os.path.join( os.path.dirname( __file__ ), "scripts", "stringPlugSubstitutions-0.56.0.0.gfr" ) )
+		s.load()
+
+		self.assertEqual( s["n"]["user"]["p"].substitutions(), Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.FrameSubstitutions )
+
 	def testSubstitutionsRepr( self ) :
 
 		p = Gaffer.StringPlug(

--- a/python/GafferTest/scripts/stringPlugSubstitutions-0.56.0.0.gfr
+++ b/python/GafferTest/scripts/stringPlugSubstitutions-0.56.0.0.gfr
@@ -1,0 +1,18 @@
+import Gaffer
+import IECore
+import imath
+
+Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 56, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 0, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+__children["n"] = Gaffer.Node( "n" )
+parent.addChild( __children["n"] )
+__children["n"]["user"].addChild( Gaffer.StringPlug( "p", defaultValue = '', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, substitutions = IECore.StringAlgo.Substitutions.VariableSubstitutions | IECore.StringAlgo.Substitutions.EscapeSubstitutions | IECore.StringAlgo.Substitutions.TildeSubstitutions ) )
+
+
+del __children
+

--- a/startup/Gaffer/contextCompatibility.py
+++ b/startup/Gaffer/contextCompatibility.py
@@ -1,0 +1,46 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+import Gaffer
+
+# In an upcoming Gaffer version, `Gaffer.Context.Substitutions` will be
+# replaced by `IECore.StringAlgo.Substitutions`, and will be referenced
+# by StringPlug constructors in `.gfr` files. Support loading of such
+# "files from the future" by monkey patching Cortex.
+
+if not hasattr( IECore.StringAlgo, "Substitutions" ) :
+	IECore.StringAlgo.Substitutions = Gaffer.Context.Substitutions


### PR DESCRIPTION
In an upcoming Gaffer version, `Gaffer.Context.Substitutions` will be replaced by `IECore.StringAlgo.Substitutions` (see https://github.com/ImageEngine/cortex/pull/1039), and will be referenced by StringPlug constructors in `.gfr` files. We can support loading of such "files from the future" by monkey patching Cortex.
