### PR TITLE
Azure : macOS python2 band-aid

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -46,6 +46,9 @@ import platform
 import py_compile
 import subprocess
 
+# Debug which python version we're using
+print( sys.version )
+
 ###############################################################################################
 # Version
 ###############################################################################################

--- a/config/azure/build.yaml
+++ b/config/azure/build.yaml
@@ -46,7 +46,6 @@ jobs:
 
    - script: |
        pip install sphinx==1.8.0 sphinx_rtd_theme==0.4.3 recommonmark==0.5.0 docutils==0.12 &&
-       brew update &&
        brew install scons doxygen &&
        brew cask install xquartz inkscape
      displayName: 'Install Toolchain (Darwin)'


### PR DESCRIPTION
Something relating to `brew update` results in `scons` getting `python 3.8.1`.

This is just to get CI running again till we get to the bottom of it.