### PR TITLE
Azure : Python 3 robustness and job structure improvements

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -400,7 +400,7 @@ elif env["PLATFORM"] == "posix" :
 
 	if "g++" in os.path.basename( env["CXX"] ) :
 
-		gccVersion = subprocess.Popen( [ env["CXX"], "-dumpversion" ], env=env["ENV"], stdout=subprocess.PIPE ).stdout.read().strip()
+		gccVersion = subprocess.check_output( [ env["CXX"], "-dumpversion" ], env=env["ENV"] ).decode().strip()
 		gccVersion = [ int( v ) for v in gccVersion.split( "." ) ]
 
 		# GCC 4.1.2 in conjunction with boost::flat_map produces crashes when
@@ -447,7 +447,7 @@ def findOnPath( file, path ) :
 	if os.path.isabs( file ) :
 		return file if os.path.exists( file ) else None
 	else :
-		if isinstance( path, basestring ) :
+		if isinstance( path, str ) :
 			path = path.split( os.pathsep )
 		for p in path :
 			f = os.path.join( p, file )
@@ -561,7 +561,7 @@ def runCommand( command ) :
 # Determine python version
 ###############################################################################################
 
-pythonVersion = subprocess.Popen( [ "python", "--version" ], env=commandEnv["ENV"], stderr=subprocess.PIPE ).stderr.read().strip()
+pythonVersion = subprocess.Popen( [ "python", "--version" ], env=commandEnv["ENV"], stderr=subprocess.PIPE ).stderr.read().decode().strip()
 pythonVersion = pythonVersion.split()[1].rpartition( "." )[0]
 
 env["PYTHON_VERSION"] = pythonVersion
@@ -1179,10 +1179,7 @@ def buildGraphics( target, source, env ) :
 		os.makedirs( dir )
 
 	queryCommand = env["INKSCAPE"] + " --query-all \"" + svgFileName + "\""
-	inkscape = subprocess.Popen( queryCommand, stdout=subprocess.PIPE, shell=True )
-	objects, stderr = inkscape.communicate()
-	if inkscape.returncode :
-		raise subprocess.CalledProcessError( inkscape.returncode, queryCommand )
+	objects = subprocess.check_output( queryCommand, shell=True ).decode()
 
 	for object in objects.split( "\n" ) :
 		tokens = object.split( "," )
@@ -1269,7 +1266,7 @@ def locateDocs( docRoot, env ) :
 			sources.append( sourceFile )
 			ext = os.path.splitext( f )[1]
 			if ext in ( ".py", ".sh" ) :
-				with file( sourceFile ) as s :
+				with open( sourceFile ) as s :
 					line = s.readline()
 					# the first line in a shell script is the language
 					# specifier so we need the second line

--- a/SConstruct
+++ b/SConstruct
@@ -46,6 +46,9 @@ import platform
 import py_compile
 import subprocess
 
+# Debug which python version we're using
+print( "Python %s" % sys.version )
+
 ###############################################################################################
 # Version
 ###############################################################################################

--- a/config/azure/build.yaml
+++ b/config/azure/build.yaml
@@ -47,7 +47,8 @@ jobs:
    - script: |
        pip install sphinx==1.8.0 sphinx_rtd_theme==0.4.3 recommonmark==0.5.0 docutils==0.12 &&
        brew update &&
-       brew install scons doxygen &&
+       brew install doxygen &&
+       brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/bb50e09187595c6a0ef68761e1c6457d8f7b2461/Formula/scons.rb &&
        brew cask install xquartz inkscape
      displayName: 'Install Toolchain (Darwin)'
      condition: eq( variables['Agent.OS'], 'Darwin' )

--- a/config/azure/build.yaml
+++ b/config/azure/build.yaml
@@ -74,8 +74,22 @@ jobs:
    - script: |
        echo BUILD_TYPE=${{ parameters.buildType }}
        g++ --version
-       scons -j ${{ parameters.threads }} package ENV_VARS_TO_IMPORT=PATH BUILD_TYPE=${{ parameters.buildType }} DELIGHT_ROOT=$DELIGHT ARNOLD_ROOT=$ARNOLD_ROOT BUILD_DIR=./build INSTALL_DIR=./install/$(Gaffer.Build.Name) BUILD_CACHEDIR=sconsCache
+       scons -j ${{ parameters.threads }} build ENV_VARS_TO_IMPORT=PATH BUILD_TYPE=${{ parameters.buildType }} DELIGHT_ROOT=$DELIGHT ARNOLD_ROOT=$ARNOLD_ROOT BUILD_DIR=./build INSTALL_DIR=./install/$(Gaffer.Build.Name) BUILD_CACHEDIR=sconsCache
      displayName: 'Build'
+     env:
+       DISPLAY: :99.0
+       AZURE: 1
+
+   - script: |
+       scons -j ${{ parameters.threads }} docs ENV_VARS_TO_IMPORT=PATH BUILD_TYPE=${{ parameters.buildType }} DELIGHT_ROOT=$DELIGHT ARNOLD_ROOT=$ARNOLD_ROOT BUILD_DIR=./build INSTALL_DIR=./install/$(Gaffer.Build.Name) BUILD_CACHEDIR=sconsCache
+     displayName: 'Build Docs'
+     env:
+       DISPLAY: :99.0
+       AZURE: 1
+
+   - script: |
+       scons -j ${{ parameters.threads }} package ENV_VARS_TO_IMPORT=PATH BUILD_TYPE=${{ parameters.buildType }} DELIGHT_ROOT=$DELIGHT ARNOLD_ROOT=$ARNOLD_ROOT BUILD_DIR=./build INSTALL_DIR=./install/$(Gaffer.Build.Name) BUILD_CACHEDIR=sconsCache
+     displayName: 'Package'
      env:
        DISPLAY: :99.0
        AZURE: 1

--- a/config/azure/build.yaml
+++ b/config/azure/build.yaml
@@ -29,6 +29,20 @@ jobs:
    steps:
 
    - script: |
+       brew update &&
+       brew install doxygen &&
+       brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/bb50e09187595c6a0ef68761e1c6457d8f7b2461/Formula/scons.rb &&
+       brew cask install xquartz inkscape &&
+       pip install sphinx==1.8.0 sphinx_rtd_theme==0.4.3 recommonmark==0.5.0 docutils==0.12
+     displayName: 'Install Toolchain (Darwin)'
+     condition: eq( variables['Agent.OS'], 'Darwin' )
+
+   - script: |
+        python --version
+        pip install --user azure-common==1.1.23 azure-nspkg==3.0.2 azure-storage-blob==2.1.0 azure-storage-common==2.1.0 azure-storage-nspkg==3.1.0 PyGithub==1.45
+     displayName: 'Install Python Modules'
+
+   - script: |
        sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off &&
        defaults -currentHost write ~/Library/Preferences/ByHost/com.apple.notificationcenterui doNotDisturb -boolean true &&
        sudo killall NotificationCenter &&
@@ -38,20 +52,10 @@ jobs:
 
    # Provides $(Gaffer.*) variables
    - script: |
-       pip install --user PyGithub==1.45 &&
        ./config/azure/setBuildVars.py
      displayName: 'Set Custom Variables'
      env:
        GITHUB_ACCESS_TOKEN: $(githubAccessToken)
-
-   - script: |
-       pip install sphinx==1.8.0 sphinx_rtd_theme==0.4.3 recommonmark==0.5.0 docutils==0.12 &&
-       brew update &&
-       brew install doxygen &&
-       brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/bb50e09187595c6a0ef68761e1c6457d8f7b2461/Formula/scons.rb &&
-       brew cask install xquartz inkscape
-     displayName: 'Install Toolchain (Darwin)'
-     condition: eq( variables['Agent.OS'], 'Darwin' )
 
    - script: |
        ./config/installDelight.sh &&
@@ -109,7 +113,6 @@ jobs:
    - ${{ if eq(parameters.publish, true) }}:
 
      - script: |
-         pip install --user azure-common==1.1.23 azure-nspkg==3.0.2 azure-storage-blob==2.1.0 azure-storage-common==2.1.0 azure-storage-nspkg==3.1.0 PyGithub==1.45 &&
          ./config/azure/publishBuild.py --archive ./install/$(Gaffer.Build.Name).tar.gz --repo $(Build.Repository.Name) --commit $(Gaffer.Source.Commit)
        displayName: "Publish Build"
        condition: and( succeeded(), or( eq( variables['Build.Reason'], 'PullRequest' ), eq( variables['Build.Reason'], 'Schedule' ) ) )
@@ -118,7 +121,6 @@ jobs:
          AZURE_ACCESS_TOKEN: $(azureBlobAccessToken)
 
      - script: |
-         pip install --user PyGithub==1.45 &&
          ./config/azure/publishRelease.py --archive ./install/$(Gaffer.Build.Name).tar.gz --repo $(Build.Repository.Name) --releaseId $(Gaffer.GitHub.ReleaseID)
        displayName: "Publish Release"
        condition: and( succeeded(), ne( variables['Gaffer.GitHub.ReleaseID'], '' ) )


### PR DESCRIPTION
Note: Includes #3621.

Brew's `scons@3.1.2_1` switches to hard-coded `python 3.8` regardless of the system python version.  This PR fixes SConstruct such that it no longer errors in python 3, but we need to re-visit our pip setup as part of #3620.

For now, we just lock the `brew install scons` to a specific version that uses python 2 (using brew's seemingly complex mechanism of making a local tap isn't great for CI, so we just pick up the old version from github).

Given we have to merge all this forward, this also includes some Azure build job structure improvements.

**Note:** When merging forwards, don't forget to add `-stopOnFailure` to `gaffer test` in `master`.