### PR TITLE
Viewer : Improve camera representation

### DIFF
--- a/python/GafferSceneUITest/VisualiserTest.py
+++ b/python/GafferSceneUITest/VisualiserTest.py
@@ -64,7 +64,7 @@ class VisualiserTest( GafferUITest.TestCase ) :
 		# The expected bound is the size of the green camera body visualisation.
 		# We want to make sure the renderer bound it doesn't contain the frustum
 		# visualisation which extends to the far clipping plane.
-		expectedBodyBound = imath.Box3f( imath.V3f( -5, -5, -5 ), imath.V3f( 5, 5, 2 ) )
+		expectedBodyBound = imath.Box3f( imath.V3f( -0.85, -0.85, -0.75 ), imath.V3f( 0.85, 0.85, 1.8 ) )
 
 		# Make sure the far plane is bigger than the camera body visualisation
 		clippingPlanes = camera.getClippingPlanes()

--- a/src/GafferSceneUI/CameraVisualiser.cpp
+++ b/src/GafferSceneUI/CameraVisualiser.cpp
@@ -66,7 +66,7 @@ class CameraVisualiser : public ObjectVisualiser
 		{
 		}
 
-		IECoreGL::CurvesPrimitivePtr createFrustum( const std::string& projection, const Box2f &screenWindow, const V2f &clippingPlanes ) const
+		IECoreGL::CurvesPrimitivePtr createFrustum( const std::string& projection, const Box2f &screenWindow, const V2f &clippingPlanes, float offset = 0.0f ) const
 		{
 
 			IECore::V3fVectorDataPtr pData = new IECore::V3fVectorData;
@@ -84,6 +84,12 @@ class CameraVisualiser : public ObjectVisualiser
 				far.min *= clippingPlanes[1];
 				far.max *= clippingPlanes[1];
 			}
+
+			const V2f o( offset );
+			near.min -= o;
+			near.max += o;
+			far.min -= o;
+			far.max += o;
 
 			vertsPerCurve.push_back( 5 );
 			p.push_back( V3f( near.min.x, near.min.y, -clippingPlanes[0] ) );
@@ -128,39 +134,121 @@ class CameraVisualiser : public ObjectVisualiser
 			vector<V3f> &p = pData->writable();
 			vector<int> &vertsPerCurve = vertsPerCurveData->writable();
 
-			// box for the camera body
+			// A box for the camera body, with a handle to show which way is up.
+			// Based on the more recent Arri cameras.
+			//       ______
+			//      |      |      Handle
+			//     ------------
+			// <=  |     ___  |
+			//     |____/   \-|   Rest
+			//
 
-			const Box3f b( V3f( -0.5, -0.5, 0 ), V3f( 0.5, 0.5, 2.0 ) );
+			static const Box3f b( V3f( -0.4f, -0.4f, 0 ), V3f( 0.4f, 0.4f, 1.8f ) );
+			static const V3f size = b.size();
+			static const float restHeight = size.y * 0.2f;
+			static const float backMinY = b.min.y + ( restHeight * 0.5f );
+
+			//
+			// Front
+			//
 
 			vertsPerCurve.push_back( 5 );
 			p.push_back( b.min );
 			p.push_back( V3f( b.max.x, b.min.y, b.min.z ) );
-			p.push_back( V3f( b.max.x, b.min.y, b.max.z ) );
-			p.push_back( V3f( b.min.x, b.min.y, b.max.z ) );
+			p.push_back( V3f( b.max.x, b.max.y, b.min.z ) );
+			p.push_back( V3f( b.min.x, b.max.y, b.min.z ) );
 			p.push_back( b.min );
+
+			//
+			// Back
+			//
 
 			vertsPerCurve.push_back( 5 );
+			p.push_back( b.max );
+			p.push_back( V3f( b.max.x, backMinY, b.max.z ) );
+			p.push_back( V3f( b.min.x, backMinY, b.max.z ) );
+			p.push_back( V3f( b.min.x, b.max.y, b.max.z ) );
+			p.push_back( b.max );
+
+			//
+			// Bottom edges (with shoulder rest curve)
+			//
+
+			static const float restXs[2] = { b.min.x, b.max.x };
+			static const float restZs[6] = { b.min.z, size.z * 0.3f, size.z * 0.4f, size.z * 0.8f, size.z * 0.9f, b.max.z };
+			static const float restYs[6] = { b.min.y, b.min.y, b.min.y + restHeight, b.min.y + restHeight, backMinY, backMinY };
+
+			// front to back
+			for( const float x : restXs )
+			{
+				vertsPerCurve.push_back( 6 );
+				p.push_back( V3f( x, restYs[0], restZs[0] ) );
+				p.push_back( V3f( x, restYs[1], restZs[1] ) );
+				p.push_back( V3f( x, restYs[2], restZs[2] ) );
+				p.push_back( V3f( x, restYs[3], restZs[3] ) );
+				p.push_back( V3f( x, restYs[4], restZs[4] ) );
+				p.push_back( V3f( x, restYs[5], restZs[5] ) );
+			}
+			// left to right edges
+			for( size_t i = 0; i < 6; ++i )
+			{
+				vertsPerCurve.push_back( 2 );
+				p.push_back( V3f( restXs[0], restYs[i], restZs[i] ) );
+				p.push_back( V3f( restXs[1], restYs[i], restZs[i] ) );
+			}
+
+			//
+			// Top edges
+			//
+
+			vertsPerCurve.push_back( 2 );
 			p.push_back( V3f( b.min.x, b.max.y, b.min.z ) );
+			p.push_back( V3f( b.min.x, b.max.y, b.max.z ) );
+
+			vertsPerCurve.push_back( 2 );
 			p.push_back( V3f( b.max.x, b.max.y, b.min.z ) );
 			p.push_back( V3f( b.max.x, b.max.y, b.max.z ) );
-			p.push_back( V3f( b.min.x, b.max.y, b.max.z ) );
-			p.push_back( V3f( b.min.x, b.max.y, b.min.z ) );
 
-			vertsPerCurve.push_back( 2 );
-			p.push_back( b.min );
-			p.push_back( V3f( b.min.x, b.max.y, b.min.z ) );
+			//
+			// Handle
+			//
 
-			vertsPerCurve.push_back( 2 );
-			p.push_back( V3f( b.max.x, b.min.y, b.min.z ) );
-			p.push_back( V3f( b.max.x, b.max.y, b.min.z ) );
+			static const float handleThickness = size.y * 0.3f;
+			static const float handleXs[2] = { b.min.x * 0.1f, b.max.x * 0.1f };
+			static const float handleYs[3] = { b.max.y, b.max.y + handleThickness, b.max.y + handleThickness + ( handleXs[1] - handleXs[0] ) };
+			static const float handleZs[4] = { b.min.z + 0.1f, b.min.z + 0.15f, b.max.z - 0.45f, b.max.z - 0.4f };
 
+			// Outer handle
+			for( const float x : handleXs )
+			{
+				vertsPerCurve.push_back( 4 );
+				p.push_back( V3f( x, handleYs[0], handleZs[0] ) );
+				p.push_back( V3f( x, handleYs[2], handleZs[0] ) );
+				p.push_back( V3f( x, handleYs[2], handleZs[3] ) );
+				p.push_back( V3f( x, handleYs[0], handleZs[3] ) );
+			}
+			// Inner handle
+			for( const float x : handleXs )
+			{
+				vertsPerCurve.push_back( 4 );
+				p.push_back( V3f( x, handleYs[0], handleZs[1] ) );
+				p.push_back( V3f( x, handleYs[1], handleZs[1] ) );
+				p.push_back( V3f( x, handleYs[1], handleZs[2] ) );
+				p.push_back( V3f( x, handleYs[0], handleZs[2] ) );
+			}
+			// left - to - right lines
 			vertsPerCurve.push_back( 2 );
-			p.push_back( V3f( b.max.x, b.min.y, b.max.z ) );
-			p.push_back( V3f( b.max.x, b.max.y, b.max.z ) );
-
+			p.push_back( V3f( handleXs[0], handleYs[2], handleZs[0] ) );
+			p.push_back( V3f( handleXs[1], handleYs[2], handleZs[0] ) );
 			vertsPerCurve.push_back( 2 );
-			p.push_back( V3f( b.min.x, b.min.y, b.max.z ) );
-			p.push_back( V3f( b.min.x, b.max.y, b.max.z ) );
+			p.push_back( V3f( handleXs[0], handleYs[1], handleZs[1] ) );
+			p.push_back( V3f( handleXs[1], handleYs[1], handleZs[1] ) );
+			vertsPerCurve.push_back( 2 );
+			p.push_back( V3f( handleXs[0], handleYs[1], handleZs[2] ) );
+			p.push_back( V3f( handleXs[1], handleYs[1], handleZs[2] ) );
+			vertsPerCurve.push_back( 2 );
+			p.push_back( V3f( handleXs[0], handleYs[2], handleZs[3] ) );
+			p.push_back( V3f( handleXs[1], handleYs[2], handleZs[3] ) );
 
 			IECoreGL::CurvesPrimitivePtr curves = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), false, vertsPerCurveData );
 			curves->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, pData ) );
@@ -189,7 +277,7 @@ class CameraVisualiser : public ObjectVisualiser
 			ornamentGroup->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0, 0.25, 0, 1 ) ) );
 
 			// The ornament uses fixed near/far planes so it's manageable
-			ornamentGroup->addChild( createFrustum( projection, screenWindow, V2f( 0, 5 ) ) );
+			ornamentGroup->addChild( createFrustum( projection, screenWindow, V2f( 0.0f, 0.75f ), 0.1f ) );
 			ornamentGroup->addChild( bodyVisualisation() );
 
 			// Real-world frustum

--- a/src/GafferSceneUI/CameraVisualiser.cpp
+++ b/src/GafferSceneUI/CameraVisualiser.cpp
@@ -275,6 +275,7 @@ class CameraVisualiser : public ObjectVisualiser
 			ornamentGroup->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
 			ornamentGroup->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
 			ornamentGroup->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0, 0.25, 0, 1 ) ) );
+			ornamentGroup->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 1.0f ) );
 
 			// The ornament uses fixed near/far planes so it's manageable
 			ornamentGroup->addChild( createFrustum( projection, screenWindow, V2f( 0.0f, 0.75f ), 0.1f ) );
@@ -286,7 +287,8 @@ class CameraVisualiser : public ObjectVisualiser
 			frustumGroup->getState()->add( new IECoreGL::Primitive::DrawWireframe( true ) );
 			frustumGroup->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
 			frustumGroup->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
-			frustumGroup->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0.4, 0.4, 0.4, 1 ) ) );
+			frustumGroup->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0, 0.25, 0, 1 ) ) );
+			frustumGroup->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 1.0f ) );
 
 			frustumGroup->addChild( createFrustum( projection, screenWindow, camera->getClippingPlanes() ) );
 


### PR DESCRIPTION
Closes #58.

![image](https://user-images.githubusercontent.com/896779/74651871-b7394600-517c-11ea-80b4-f09b510fd13d.png)

As we now have accurate frustum visualisation options, this one becomes more of a 'lens hood'. The outer rectangle still reflects the aperture aspect ratio correctly.

Based on a cut-down Arri Alexa.