### PR TITLE
Viewer : Add option to only draw frustums for selected objects

### DIFF
--- a/python/GafferSceneTest/CameraTest.py
+++ b/python/GafferSceneTest/CameraTest.py
@@ -89,20 +89,20 @@ class CameraTest( GafferSceneTest.SceneTestCase ) :
 		c["visualiserAttributes"]["frustum"]["enabled"].setValue( True )
 
 		a = c["out"].attributes( path )
-		self.assertEqual( a["gl:visualiser:frustum"], IECore.BoolData( True ) )
+		self.assertEqual( a["gl:visualiser:frustum"], IECore.StringData( "whenSelected" ) )
 		self.assertFalse( "gl:visualiser:scale" in a )
 
 		c["visualiserAttributes"]["scale"]["enabled"].setValue( True )
 		a = c["out"].attributes( path )
 
-		self.assertEqual( a["gl:visualiser:frustum"], IECore.BoolData( True ) )
+		self.assertEqual( a["gl:visualiser:frustum"], IECore.StringData( "whenSelected" ) )
 		self.assertEqual( a["gl:visualiser:scale"], IECore.FloatData( 1.0 ) )
 
-		c["visualiserAttributes"]["frustum"]["value"].setValue( False )
+		c["visualiserAttributes"]["frustum"]["value"].setValue( "off" )
 		c["visualiserAttributes"]["scale"]["value"].setValue( 12.1 )
 
 		a = c["out"].attributes( path )
-		self.assertEqual( a["gl:visualiser:frustum"], IECore.BoolData( False ) )
+		self.assertEqual( a["gl:visualiser:frustum"], IECore.StringData( "off" ) )
 		self.assertEqual( a["gl:visualiser:scale"], IECore.FloatData( 12.1 ) )
 
 	def testHashes( self ) :

--- a/python/GafferSceneTest/LightTest.py
+++ b/python/GafferSceneTest/LightTest.py
@@ -240,7 +240,7 @@ class LightTest( GafferSceneTest.SceneTestCase ) :
 		l["visualiserAttributes"]["maxTextureResolution"]["enabled"].setValue( True )
 		l["visualiserAttributes"]["maxTextureResolution"]["value"].setValue( 123 )
 		l["visualiserAttributes"]["frustum"]["enabled"].setValue( True )
-		l["visualiserAttributes"]["frustum"]["value"].setValue( False )
+		l["visualiserAttributes"]["frustum"]["value"].setValue( "off" )
 		l["visualiserAttributes"]["lightFrustumScale"]["enabled"].setValue( True )
 		l["visualiserAttributes"]["lightFrustumScale"]["value"].setValue( 1.23 )
 
@@ -249,7 +249,7 @@ class LightTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( a["gl:light:drawingMode"], IECore.StringData( "color" ) )
 		self.assertEqual( a["gl:visualiser:scale"], IECore.FloatData( 12.3 ) )
 		self.assertEqual( a["gl:visualiser:maxTextureResolution"], IECore.IntData( 123 ) )
-		self.assertEqual( a["gl:visualiser:frustum"], IECore.BoolData( False ) )
+		self.assertEqual( a["gl:visualiser:frustum"], IECore.StringData( "off" ) )
 		self.assertEqual( a["gl:light:frustumScale"], IECore.FloatData( 1.23 ) )
 
 if __name__ == "__main__":

--- a/python/GafferSceneUI/CameraUI.py
+++ b/python/GafferSceneUI/CameraUI.py
@@ -369,6 +369,15 @@ plugsMetadata = {
 
 	],
 
+	"visualiserAttributes.frustum.value" : [
+
+			"preset:Off", "off",
+			"preset:When Selected", "whenSelected",
+			"preset:On", "on",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget"
+	]
+
 }
 
 __sourceMetadata = GafferSceneUI.StandardOptionsUI.plugsMetadata

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -139,6 +139,15 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"visualiserAttributes.frustum.value" : [
+
+			"preset:Off", "off",
+			"preset:When Selected", "whenSelected",
+			"preset:On", "on",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget"
+		],
+
 		"visualiserAttributes.lightFrustumScale" : [
 
 			"description",

--- a/python/GafferSceneUI/OpenGLAttributesUI.py
+++ b/python/GafferSceneUI/OpenGLAttributesUI.py
@@ -401,6 +401,15 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"attributes.visualiserFrustum.value" : [
+
+				"preset:Off", "off",
+				"preset:When Selected", "whenSelected",
+				"preset:On", "on",
+
+				"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget"
+		],
+
 		"attributes.lightDrawingMode" : [
 
 			"description",

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -254,13 +254,14 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 		m.append( "/VisualisersDivider", { "divider" : True } )
 
 		frustumPlug = self.getPlug()["visualiser"]["frustum"]
-		m.append(
-			"/Visualisers/Frustum",
-			{
-				"command" : frustumPlug.setValue,
-				"checkBox" : frustumPlug.getValue()
-			}
-		)
+		for mode in ( "off", "whenSelected", "on" ) :
+			m.append(
+				"/Visualisers/Frustum/" + IECore.CamelCase.toSpaced( mode ),
+				{
+					"command" : functools.partial( lambda m, _ : frustumPlug.setValue( m ), mode ),
+					"checkBox" : frustumPlug.getValue() == mode
+				}
+			)
 
 		self.__appendValuePresetMenu(
 			m, self.getPlug()["visualiser"]["scale"],

--- a/src/GafferScene/Camera.cpp
+++ b/src/GafferScene/Camera.cpp
@@ -89,7 +89,7 @@ Camera::Camera( const std::string &name )
 
 	addChild( new CompoundDataPlug( "visualiserAttributes" ) );
 	visualiserAttributesPlug()->addChild( new Gaffer::NameValuePlug( "gl:visualiser:scale", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f ), false, "scale" ) );
-	visualiserAttributesPlug()->addChild( new NameValuePlug( "gl:visualiser:frustum", new BoolData( true ), false, "frustum" ) );
+	visualiserAttributesPlug()->addChild( new NameValuePlug( "gl:visualiser:frustum", new StringData( "whenSelected" ), false, "frustum" ) );
 }
 
 Camera::~Camera()

--- a/src/GafferScene/Light.cpp
+++ b/src/GafferScene/Light.cpp
@@ -72,7 +72,7 @@ Light::Light( const std::string &name )
 	IntPlugPtr maxResValuePlug = new IntPlug( "value", Gaffer::Plug::Direction::In, 512, 2, 2048 );
 	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", maxResValuePlug, false, "maxTextureResolution" ) );
 
-	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), false, "frustum" ) );
+	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::StringData( "whenSelected" ), false, "frustum" ) );
 
 	FloatPlugPtr frustumScaleValuePlug = new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f );
 	visualiserAttr->addChild( new Gaffer::NameValuePlug( "gl:light:frustumScale", frustumScaleValuePlug, false, "lightFrustumScale" ) );

--- a/src/GafferScene/OpenGLAttributes.cpp
+++ b/src/GafferScene/OpenGLAttributes.cpp
@@ -82,7 +82,7 @@ OpenGLAttributes::OpenGLAttributes( const std::string &name )
 
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:scale", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f ), false, "visualiserScale" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:maxTextureResolution", new IntPlug( "value", Gaffer::Plug::Direction::In, 512, 2, 2048 ), false, "visualiserMaxTextureResolution" ) );
-	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::BoolData( true ), false, "visualiserFrustum" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "gl:visualiser:frustum", new IECore::StringData( "whenSelected" ), false, "visualiserFrustum" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:light:drawingMode", new IECore::StringData( "texture" ), false, "lightDrawingMode" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "gl:light:frustumScale", new FloatPlug( "value", Gaffer::Plug::Direction::In, 1.0f, 0.01f ), false, "lightFrustumScale" ) );
 }

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -191,7 +191,7 @@ class SceneView::DrawingMode : public boost::signals::trackable
 
 			//    gl:visualiser:frustum
 
-			BoolPlugPtr frustrumAttrValuePlug = new BoolPlug( "value", Plug::In, true );
+			StringPlugPtr frustrumAttrValuePlug = new StringPlug( "value", Plug::In, "whenSelected" );
 
 			NameValuePlugPtr frustumAttrPlug = new Gaffer::NameValuePlug( "gl:visualiser:frustum", frustrumAttrValuePlug, true, "frustum" );
 			attr->addChild( frustumAttrPlug );


### PR DESCRIPTION
![Screenshot 2020-02-17 at 13 25 54](https://user-images.githubusercontent.com/896779/74657985-43516a80-5189-11ea-9a18-6b7ed261d08f.png)

Enabled by default.

A note on two options .vs. enum state:

This could also be encoded via a third value state for `gl:visualiser:frustum`. This would be more concise, but has a usability downside that I think is better avoided via the split-option approach.

Because we use attributes to define the behaviour at each location, in that, the Viewer Draw Options menu sets a global attribute, that can then be overridden at each location to customise behaviour. Using a single value prevents globally toggling frustums on/off if the user has ever changed the selected only behaviour at any specific locations (as their local opinion will prevent the global change from being reflected).  Given the visual weight of frustums, it feels that maintaining the ability to easily show/hide them all would be more beneficial than the simplification of the attribute mechanism used.



Improvements
------------

- Viewer : Added option to only draw frustums for selected locations. [relative to 0.56.0.0b2]
