### PR TITLE
GafferUI : Fix lingering MenuButton highlight after menu is used

### DIFF
--- a/python/GafferUI/MenuButton.py
+++ b/python/GafferUI/MenuButton.py
@@ -102,3 +102,7 @@ class MenuButton( GafferUI.Button ) :
 
 		if not menu.visible() :
 			self._qtWidget().setDown( False )
+			# There is a bug whereby Button never receives the event for __leave,
+			# if the menu is shown. This results in the image highlight state sticking.
+			if self.widgetAt( self.mousePosition() ) is not self :
+				self.setHighlighted( False )


### PR DESCRIPTION
Supersedes #3297.

For "reasons" `GafferUI.Button` never receives the event to trigger `__leave` when the mouse leaves the button via a menu presented from it. This was causing the highlight state of the button to stick after the menu was dismissed.

Fixes
-----

- MenuButton : Fixed bug that caused buttons to remain highlighted after their menu was closed.
