### PR TITLE
Instancer : Fix lifetime management bug

### DIFF
--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -1266,7 +1266,8 @@ Instancer::PrototypeScope::PrototypeScope( const Gaffer::ObjectPlug *enginePlug,
 	assert( branchPath.size() >= 2 );
 
 	set( ScenePlug::scenePathContextName, parentPath );
-	const ScenePlug::ScenePath &prototypeRoot = boost::static_pointer_cast<const EngineData>( enginePlug->getValue() )->prototypeRoot( branchPath[1] );
+	ConstEngineDataPtr engine = boost::static_pointer_cast<const EngineData>( enginePlug->getValue() );
+	const ScenePlug::ScenePath &prototypeRoot = engine->prototypeRoot( branchPath[1] );
 
 	if( branchPath.size() > 3 )
 	{


### PR DESCRIPTION
The `prototypeRoot` references memory owned by EngineData, so we must keep a reference to EngineData alive for as long as we use it.

I came across this via a slightly interesting path. Typically it's very hard to track down this sort of bug, because usually the cache keeps the object alive anyway, until your luck runs out and it gets unloaded by another thread just as you're about to use it. But today I was being lazy and had hacked the cache to be completely inactive so I could write and test a `compute()` method without needing to worry about `hash()` just yet. And voila, a completely unrelated crash. It seems like this little exercise might be worth performing periodically...