### PR TITLE
Viewer : Left-align ColorInspector in ImageViews

### DIFF
--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -67,6 +67,10 @@ Gaffer.Metadata.registerNode(
 	"toolbarLayout:customWidget:RightSpacer:section", "Top",
 	"toolbarLayout:customWidget:RightSpacer:index", -2,
 
+	"toolbarLayout:customWidget:BottomRightSpacer:widgetType", "GafferImageUI.ImageViewUI._Spacer",
+	"toolbarLayout:customWidget:BottomRightSpacer:section", "Bottom",
+	"toolbarLayout:customWidget:BottomRightSpacer:index", 2,
+
 	plugs = {
 
 		"clipping" : [
@@ -130,6 +134,7 @@ Gaffer.Metadata.registerNode(
 			"plugValueWidget:type", "GafferImageUI.ImageViewUI._ColorInspectorPlugValueWidget",
 			"label", "",
 			"toolbarLayout:section", "Bottom",
+			"toolbarLayout:index", 1,
 
 		],
 
@@ -248,7 +253,7 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
 
-				GafferUI.Spacer( imath.V2i( 0, 10 ) )
+				GafferUI.Spacer( imath.V2i( 10 ), imath.V2i( 10 ) )
 
 				self.__positionLabel = GafferUI.Label()
 				self.__positionLabel._qtWidget().setFixedWidth( 90 )
@@ -265,7 +270,7 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 				self.__hsvLabel = GafferUI.Label()
 
-				GafferUI.Spacer( imath.V2i( 0, 10 ) )
+				GafferUI.Spacer( imath.V2i( 10 ), imath.V2i( 10 ) )
 
 		self.__pixel = imath.V2f( 0 )
 


### PR DESCRIPTION
As part of #3582 we stretched out the `ColorInspector` so the info could still remain centred, whist the `CropWindowTool` was suck on the left due to no view-dependent placement.

The more I used it, I wasn't entirely sure about the huge margins. This left-aligns it with the other tool overlay.

You do have a little jiggle on the right edge as the non-fixed-width font changes length, but we had that when centred too.

Long term, we want to implement safe-margins in the viewer so we can manage all this a little more intelligently.

## Before
![image](https://user-images.githubusercontent.com/896779/74856476-13959480-533a-11ea-8474-b384c761fafd.png)

## After
![Screenshot 2020-02-19 at 16 29 51](https://user-images.githubusercontent.com/896779/74855853-222f7c00-5339-11ea-9fb7-48e2963679d0.png)
![Screenshot 2020-02-19 at 16 57 12](https://user-images.githubusercontent.com/896779/74855856-23f93f80-5339-11ea-8fac-fbc6395109f0.png)


Improvements
------------

- Viewer : Left-aligned the image ColorInspector to remove huge margins.  [since 0.56.0.0b2]