### PR TITLE
GafferScene : Exclude peripheral hash processes from history

### DIFF
--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -421,7 +421,13 @@ SceneAlgo::History::Ptr historyWalk( const CapturedProcess *process, InternedStr
 
 	for( const auto &p : process->children )
 	{
-		historyWalk( p.get(), scenePlugChildName, parent );
+		// Parents may spawn other processes in support of the requested plug.
+		// We don't want these to show up in history output, so we only include
+		// ones that are directly in service of the requested plug.
+		if( p->plug->parent<ScenePlug>() && p->plug->getName() == scenePlugChildName )
+		{
+			historyWalk( p.get(), scenePlugChildName, parent );
+		}
 	}
 
 	return result;


### PR DESCRIPTION
Fixes #3647. It surfaced a case where an hash process for a transform plug unrelated to one passed to a `SceneAlgo::history` query was surfaced in the results, leading to incorrect tool behaviour.

Fixes
-----

- SceneAlgo : Fixed bug that caused unrelated processes to appear in plug histories (#3647).
