### PR TITLE
SetUI : Fix context menu bugs

### DIFF
--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -169,10 +169,13 @@ def __setsPopupMenu( menuDefinition, plugValueWidget ) :
 	if plug is None :
 		return
 
+	# Some operations require a text widget so we can manipulate insertion position, etc...
+	hasTextWidget = hasattr( plugValueWidget, 'textWidget' )
+
 	# get required data
 	acceptsSetName = Gaffer.Metadata.value( plug, "ui:scene:acceptsSetName" )
 	acceptsSetNames = Gaffer.Metadata.value( plug, "ui:scene:acceptsSetNames" )
-	acceptsSetExpression = Gaffer.Metadata.value( plug, "ui:scene:acceptsSetExpression" )
+	acceptsSetExpression = hasTextWidget and Gaffer.Metadata.value( plug, "ui:scene:acceptsSetExpression" )
 	if not acceptsSetName and not acceptsSetNames and not acceptsSetExpression :
 		return
 

--- a/startup/GafferScene/copyAttributesCompatibility.py
+++ b/startup/GafferScene/copyAttributesCompatibility.py
@@ -63,9 +63,11 @@ def __copyAttributesInGetItem( originalGetItem ) :
 		if key in ( "in0", 0 ) :
 			# First element of old ArrayPlug - redirect to self.
 			return self
-		else :
+		elif key in ( "in1", 1 ) :
 			# Second element of old ArrayPlug - redirect to source.
 			return self.parent()["source"]
+
+		return originalGetItem( self, key )
 
 	return getItem
 


### PR DESCRIPTION
Fixes two bugs that could cause the context menu to fail to appear:
 - In the `SetFilter` for Set Expression when connected to `CopyAttribtues` node.
 - Any plug that accepts set expressions when the label was clicked, not the field.

Fixes
-----

- SetFilter : Fixed bug that prevented the Set Expression context menu
  from appearing when attached to a CopyAttributes node.
- GafferScene : Fixed bug that prevented the plug label context menu
  opening when the plug accepted set expressions.