### PR TITLE
MenuBar : Allow subMenus to opt out of short cut discovery

### DIFF
--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -297,7 +297,7 @@ class Menu( GafferUI.Widget ) :
 					subMenu.__definition = definition.reRooted( "/" + name + "/" )
 					subMenu.aboutToShow.connect( IECore.curry( Gaffer.WeakMethod( self.__build ), weakref.ref( subMenu ) ) )
 					if recurse :
-						self.__build( subMenu, recurse )
+						self.__build( subMenu, recurse, forShortCuts=forShortCuts )
 
 				else :
 
@@ -315,7 +315,7 @@ class Menu( GafferUI.Widget ) :
 						subMenu.__definition = item.subMenu
 						subMenu.aboutToShow.connect( IECore.curry( Gaffer.WeakMethod( self.__build ), weakref.ref( subMenu ) ) )
 						if recurse :
-							self.__build( subMenu, recurse )
+							self.__build( subMenu, recurse, forShortCuts=forShortCuts )
 
 					else :
 

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -63,7 +63,7 @@ class Menu( GafferUI.Widget ) :
 	# - 'label' in conjunction with 'divider' = True, displays a textual
 	#   divider as opposed to a simple line.
 	#
-	# - 'hasShortCut' = False in conjunction with `subMenu`, instructs the Menu
+	# - 'hasShortCuts' = False in conjunction with `subMenu`, instructs the Menu
 	#   to ignore the subMenu when building for keyboard shortcut discovery.
 	#   This can avoid long blocking waits when the user first presses a key whilst
 	#   the action map is built if your subMenu is particularly slow to build.
@@ -254,15 +254,15 @@ class Menu( GafferUI.Widget ) :
 		self.__lastHoverAction = None
 
 	# May be called to fully build the menu /now/, rather than only do it lazily
-	# when it's shown. This is used by the MenuBar. forShortCut should be set
+	# when it's shown. This is used by the MenuBar. forShortCuts should be set
 	# if the build is for short cut discovery as it will skip dynamic subMenus
 	# that declare they have no shortcuts.
 	#   See https://github.com/GafferHQ/gaffer/issues/3651)
-	def _buildFully( self, forShortCut=False ) :
+	def _buildFully( self, forShortCuts=False ) :
 
-		self.__build( self._qtWidget(), recurse=True, forShortCut=forShortCut )
+		self.__build( self._qtWidget(), recurse=True, forShortCuts=forShortCuts )
 
-	def __build( self, qtMenu, recurse=False, forShortCut=False ) :
+	def __build( self, qtMenu, recurse=False, forShortCuts=False ) :
 
 		if isinstance( qtMenu, weakref.ref ) :
 			qtMenu = qtMenu()
@@ -306,7 +306,7 @@ class Menu( GafferUI.Widget ) :
 						# Skip any subMenus that declare they have no short cuts.
 						# _buildFully can be called blocking on the UI thread so
 						# this facilities to skip potentially expensive custom menus.
-						if forShortCut and not getattr( item, 'hasShortCut', True ) :
+						if forShortCuts and not getattr( item, 'hasShortCuts', True ) :
 							continue
 
 						subMenu = _Menu( qtMenu, name )

--- a/python/GafferUI/MenuBar.py
+++ b/python/GafferUI/MenuBar.py
@@ -169,7 +169,7 @@ class _ShortcutEventFilter( QtCore.QObject ) :
 			menuBar = self.__menuBar()
 			for menu in menuBar._MenuBar__subMenus :
 				if menu._qtWidget().isEmpty() :
-					menu._buildFully( forShortCut = True )
+					menu._buildFully( forShortCuts = True )
 				action = self.__matchingAction( keySequence, menu._qtWidget() )
 				if action is not None :
 					# Store for use in KeyPress

--- a/python/GafferUI/MenuBar.py
+++ b/python/GafferUI/MenuBar.py
@@ -169,7 +169,7 @@ class _ShortcutEventFilter( QtCore.QObject ) :
 			menuBar = self.__menuBar()
 			for menu in menuBar._MenuBar__subMenus :
 				if menu._qtWidget().isEmpty() :
-					menu._buildFully()
+					menu._buildFully( forShortCut = True )
 				action = self.__matchingAction( keySequence, menu._qtWidget() )
 				if action is not None :
 					# Store for use in KeyPress

--- a/python/GafferUITest/MenuTest.py
+++ b/python/GafferUITest/MenuTest.py
@@ -126,8 +126,8 @@ class MenuTest( GafferUITest.TestCase ) :
 		md = IECore.MenuDefinition()
 		md.append( "/staticItem1", {} )
 		md.append( "/subMenuA", { "subMenu" : functools.partial( buildSubMenu, "subMenuA" ) } )
-		md.append( "/subMenuB", { "subMenu" : functools.partial( buildSubMenu, "subMenuB" ), "hasShortCut" : False } )
-		md.append( "/subMenuC", { "subMenu" : functools.partial( buildSubMenu, "subMenuC" ), "hasShortCut" : True } )
+		md.append( "/subMenuB", { "subMenu" : functools.partial( buildSubMenu, "subMenuB" ), "hasShortCuts" : False } )
+		md.append( "/subMenuC", { "subMenu" : functools.partial( buildSubMenu, "subMenuC" ), "hasShortCuts" : True } )
 		md.append( "/subMenuD/staticItemA", {} )
 
 		# Full build
@@ -146,7 +146,7 @@ class MenuTest( GafferUITest.TestCase ) :
 		# For short cuts
 
 		m = GafferUI.Menu( md )
-		m._buildFully( forShortCut = True )
+		m._buildFully( forShortCuts = True )
 
 		ma = m._qtWidget().actions()
 		self.assertEqual( [ a.text() for a in ma ], [ "staticItem1", "subMenuA", "subMenuC", "subMenuD" ] )


### PR DESCRIPTION
Facilities often register custom menu bar menus that talk to asset management systems, etc. that can cause (relatively) slow build times.

Qt's ShortcutOverride event bubbles up the widget hierarchy before KeyPress events are sent to the target widget. We use this in `GafferUI.MenuBar` to implement global short cuts. To achieve this we fully build the main menu bar and search for any actions with short cut keys.

This effectively means we build the main menu bar whenever the user presses a key over an editor without a text input focus. A common case for this is `tab` to open the Node Menu, which can result in long delays before the menu appears.

We can't avoid this behaviour (as we want main menu items with short cuts), so we instead allow expensive menus to opt-out of short cut discovery if they don't have any.

Closes #3651.

API
---

 - MenuBar : Added support for `hasShortCut` on a `IECore.MenuDefinition` which when `False` prevents a dynamic sub menu from being build to discover keyboard short cuts (#3651).