### PR TITLE
Range compatibility fixes

### DIFF
--- a/python/Gaffer/_Range.py
+++ b/python/Gaffer/_Range.py
@@ -45,15 +45,13 @@ import Gaffer
 
 def __range( cls, parent ) :
 
-	for i in range( 0, len( parent ) ) :
-		child = parent[i]
+	for child in parent.children() :
 		if isinstance( child, cls ) :
 			yield child
 
 def __recursiveRange( cls, parent ) :
 
-	for i in range( 0, len( parent ) ) :
-		child = parent[i]
+	for child in parent.children() :
 		if isinstance( child, cls ) :
 			yield child
 		for r in __recursiveRange( cls, child ) :

--- a/python/GafferSceneTest/CollectScenesTest.py
+++ b/python/GafferSceneTest/CollectScenesTest.py
@@ -310,5 +310,21 @@ class CollectScenesTest( GafferSceneTest.SceneTestCase ) :
 		collect2["rootNames"].setValue( IECore.StringVectorData( [ "c", "d" ] ) )
 		self.assertEqual( collect2["out"].set( "__lights" ).value, IECore.PathMatcher( [ "/c/light", "/d/light" ] ) )
 
+	def testRanges( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["collect"] = GafferScene.CollectScenes()
+		script["box"] = Gaffer.Box()
+		script["box"]["collect"] = GafferScene.CollectScenes()
+
+		self.assertEqual(
+			list( GafferScene.CollectScenes.Range( script ) ),
+			[ script["collect"] ],
+		)
+		self.assertEqual(
+			list( GafferScene.CollectScenes.RecursiveRange( script ) ),
+			[ script["collect"], script["box"]["collect"] ],
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/CopyAttributesTest.py
+++ b/python/GafferSceneTest/CopyAttributesTest.py
@@ -162,5 +162,21 @@ class CopyAttributesTest( GafferSceneTest.SceneTestCase ) :
 			parent["out"].attributes( "/sphere" )
 		)
 
+	def testRanges( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["copy"] = GafferScene.CopyAttributes()
+		script["box"] = Gaffer.Box()
+		script["box"]["copy"] = GafferScene.CopyAttributes()
+
+		self.assertEqual(
+			list( GafferScene.CopyAttributes.Range( script ) ),
+			[ script["copy"] ],
+		)
+		self.assertEqual(
+			list( GafferScene.CopyAttributes.RecursiveRange( script ) ),
+			[ script["copy"], script["box"]["copy"] ],
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/startup/GafferScene/collectScenesCompatibility.py
+++ b/startup/GafferScene/collectScenesCompatibility.py
@@ -73,10 +73,12 @@ def __collectScenesInGetItem( originalGetItem ) :
 		if key == "in0" :
 			# First element of old ArrayPlug - redirect to self.
 			return self
-		else :
+		elif isinstance( key, str ) and key.startswith( "in" ) :
 			# Any other element of old ArrayPlug - this should not
 			# have been used.
 			return None
+		else :
+			return originalGetItem( self, key )
 
 	return getItem
 


### PR DESCRIPTION
This fixes several problems caused by interactions between our startup compatibility shims and the Range/RecursiveRange functions. Longer term I think we need to pursue a policy of retiring compatibility shims after a few major versions have gone by, as they do affect loading times and as demonstrated here, they're often far from bulletproof.
