### PR TITLE
Context : Adopt `IECore::StringAlgo` substitutions

### DIFF
--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -189,42 +189,12 @@ class GAFFER_API Context : public IECore::RefCounted
 		bool operator == ( const Context &other ) const;
 		bool operator != ( const Context &other ) const;
 
-		/// Enum to specify what sort of substitutions may
-		/// be performed on a string.
-		enum Substitutions
-		{
-			NoSubstitutions = 0,
-			/// Substituting one or more '#' characters with the frame
-			/// number, with the number of '#' characters determining
-			/// the padding. Note that this substitution is entirely
-			/// separate from ${frame} and $frame substitutions, which
-			/// are covered by the VariableSubstitutions flag.
-			FrameSubstitutions = 1,
-			/// Substituting $name or ${name} with the
-			/// value of a variable of that name.
-			VariableSubstitutions = 2,
-			/// Escaping of special characters using a preceding '\'.
-			EscapeSubstitutions = 4,
-			/// Substituting ~ with the path to the user's home directory.
-			TildeSubstitutions = 8,
-			AllSubstitutions = FrameSubstitutions | VariableSubstitutions | EscapeSubstitutions | TildeSubstitutions
-		};
-
-		/// Performs variable substitution of $name, ${name} and ###
-		/// keys in input, using values from the context.
-		/// \todo I'm not entirely sure this belongs here. If we had
-		/// an abstract base class for dictionary-style access to things
-		/// then we could have a separate substitute() function capable
-		/// of accepting Contexts, CompoundData, CompoundObjects etc.
-		std::string substitute( const std::string &input, unsigned substitutions = AllSubstitutions ) const;
-		/// Returns a bitmask of Substitutions values containing the
-		/// sorts of substitutions contained in the string. If this returns
-		/// NoSubstitutions, it is guaranteed that substitute( input ) == input.
-		static unsigned substitutions( const std::string &input );
-		/// Returns true if the specified string contains substitutions
-		/// which can be performed by the substitute() method. If it returns
-		/// false, it is guaranteed that substitute( input ) == input.
-		static bool hasSubstitutions( const std::string &input );
+		/// Uses `IECore::StringAlgo::substitute()` to perform variable
+		/// substitutions using values from the context.
+		std::string substitute( const std::string &input, unsigned substitutions = IECore::StringAlgo::AllSubstitutions ) const;
+		/// An `IECore::StringAlgo::VariableProvider` that can be used to
+		/// pass context variables to `IECore::StringAlgo::substitute()`.
+		class SubstitutionProvider;
 
 		/// Used to request cancellation of long running background operations.
 		/// May be null. Nodes that perform expensive work should check for
@@ -293,8 +263,6 @@ class GAFFER_API Context : public IECore::RefCounted
 	private :
 
 		Context( const Context &other, Ownership ownership, const IECore::Canceller *canceller );
-
-		void substituteInternal( const char *s, std::string &result, const int recursionDepth, unsigned substitutions ) const;
 
 		// Storage for each entry.
 		struct Storage

--- a/include/Gaffer/Context.inl
+++ b/include/Gaffer/Context.inl
@@ -211,16 +211,33 @@ typename Context::Accessor<T>::ResultType Context::get( const IECore::InternedSt
 	return Accessor<T>().get( it->second.data );
 }
 
-const IECore::Canceller *Context::canceller() const
-{
-	return m_canceller;
-}
-
 template<typename T>
 void Context::EditableScope::set( const IECore::InternedString &name, const T &value )
 {
 	m_context->set( name, value );
 }
+
+const IECore::Canceller *Context::canceller() const
+{
+	return m_canceller;
+}
+
+class Context::SubstitutionProvider : public IECore::StringAlgo::VariableProvider
+{
+
+	public :
+
+		SubstitutionProvider( const Context *context );
+
+		int frame() const override;
+		const std::string &variable( const boost::string_view &name, bool &recurse ) const override;
+
+	private :
+
+		const Context *m_context;
+		mutable std::string m_formattedString;
+
+};
 
 } // namespace Gaffer
 

--- a/include/Gaffer/StringPlug.h
+++ b/include/Gaffer/StringPlug.h
@@ -38,6 +38,8 @@
 #ifndef GAFFER_STRINGPLUG_H
 #define GAFFER_STRINGPLUG_H
 
+#include "IECore/StringAlgo.h"
+
 #include "Gaffer/Context.h"
 #include "Gaffer/ValuePlug.h"
 
@@ -93,7 +95,7 @@ class GAFFER_API StringPlug : public ValuePlug
 			Direction direction=In,
 			const std::string &defaultValue = "",
 			unsigned flags = Default,
-			unsigned substitutions = Context::AllSubstitutions
+			unsigned substitutions = IECore::StringAlgo::AllSubstitutions
 		);
 		~StringPlug() override;
 

--- a/include/GafferCortex/TypedParameterHandler.h
+++ b/include/GafferCortex/TypedParameterHandler.h
@@ -74,7 +74,7 @@ class GAFFERCORTEX_API TypedParameterHandler : public ParameterHandler
 
 		typename PlugType::Ptr createPlug( Gaffer::Plug::Direction direction ) const;
 		// variant for StringPlugs
-		typename PlugType::Ptr createPlug( Gaffer::Plug::Direction direction, Gaffer::Context::Substitutions substitutions ) const;
+		typename PlugType::Ptr createPlug( Gaffer::Plug::Direction direction, IECore::StringAlgo::Substitutions substitutions ) const;
 
 		typename ParameterType::Ptr m_parameter;
 		typename PlugType::Ptr m_plug;

--- a/python/GafferCortexTest/ParameterHandlerTest.py
+++ b/python/GafferCortexTest/ParameterHandlerTest.py
@@ -245,14 +245,14 @@ class ParameterHandlerTest( GafferTest.TestCase ) :
 		n = Gaffer.Node()
 		h = GafferCortex.ParameterHandler.create( p )
 		h.setupPlug( n )
-		self.assertEqual( n["s"].substitutions(), Gaffer.Context.Substitutions.AllSubstitutions )
+		self.assertEqual( n["s"].substitutions(), IECore.StringAlgo.Substitutions.AllSubstitutions )
 
 		# adding substitutions should affect the plug
 		p.userData()["gaffer"] = IECore.CompoundObject( {
-			"substitutions" : IECore.IntData( Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.FrameSubstitutions ),
+			"substitutions" : IECore.IntData( IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.FrameSubstitutions ),
 		} )
 		h.setupPlug( n )
-		self.assertEqual( n["s"].substitutions(), Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.FrameSubstitutions )
+		self.assertEqual( n["s"].substitutions(), IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.FrameSubstitutions )
 
 		# make sure connections are maintained as well
 		nn = Gaffer.Node()
@@ -260,10 +260,10 @@ class ParameterHandlerTest( GafferTest.TestCase ) :
 		n["s"].setInput( nn["driver"] )
 		# we're forcing a re-creation of the plug because substitutions have changed
 		p.userData()["gaffer"] = IECore.CompoundObject( {
-			"substitutions" : IECore.IntData( Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.VariableSubstitutions ),
+			"substitutions" : IECore.IntData( IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.VariableSubstitutions ),
 		} )
 		h.setupPlug( n )
-		self.assertEqual( n["s"].substitutions(), Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.VariableSubstitutions )
+		self.assertEqual( n["s"].substitutions(), IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.VariableSubstitutions )
 		self.assertEqual( n["s"].getInput(), nn["driver"] )
 
 if __name__ == "__main__":

--- a/python/GafferDispatch/PythonCommand.py
+++ b/python/GafferDispatch/PythonCommand.py
@@ -51,7 +51,7 @@ class PythonCommand( GafferDispatch.TaskNode ) :
 		# Turn off automatic substitutions for the command, since it's a pain
 		# to have to manually escape things, and the context is available
 		# directly anyway.
-		self["command"] = Gaffer.StringPlug( substitutions = Gaffer.Context.Substitutions.NoSubstitutions )
+		self["command"] = Gaffer.StringPlug( substitutions = IECore.StringAlgo.Substitutions.NoSubstitutions )
 		self["variables"] = Gaffer.CompoundDataPlug()
 		self["sequence"] = Gaffer.BoolPlug()
 

--- a/python/GafferSceneUI/SceneReaderPathPreview.py
+++ b/python/GafferSceneUI/SceneReaderPathPreview.py
@@ -303,7 +303,7 @@ class _ObjectPreview( Gaffer.Node ) :
 
 		import GafferCortex
 
-		self["fileName"] = Gaffer.StringPlug( defaultValue = "", substitutions = Gaffer.Context.Substitutions.NoSubstitutions )
+		self["fileName"] = Gaffer.StringPlug( defaultValue = "", substitutions = IECore.StringAlgo.Substitutions.NoSubstitutions )
 		self["frameRate"] = Gaffer.FloatPlug( defaultValue = 24.0 )
 		self["samplesPerFrame"] = Gaffer.IntPlug( defaultValue = 1, minValue = 1 )
 

--- a/python/GafferTest/ContextTest.py
+++ b/python/GafferTest/ContextTest.py
@@ -296,13 +296,13 @@ class ContextTest( GafferTest.TestCase ) :
 		c["a"] = "apple"
 		c["b"] = "bear"
 
-		self.assertEqual( c.substitute( "~", c.Substitutions.AllSubstitutions & ~c.Substitutions.TildeSubstitutions ), "~" )
-		self.assertEqual( c.substitute( "#", c.Substitutions.AllSubstitutions & ~c.Substitutions.FrameSubstitutions ), "#" )
-		self.assertEqual( c.substitute( "$a/${b}", c.Substitutions.AllSubstitutions & ~c.Substitutions.VariableSubstitutions ), "$a/${b}" )
-		self.assertEqual( c.substitute( "\\", c.Substitutions.AllSubstitutions & ~c.Substitutions.EscapeSubstitutions ), "\\" )
-		self.assertEqual( c.substitute( "\\$a", c.Substitutions.AllSubstitutions & ~c.Substitutions.EscapeSubstitutions ), "\\apple" )
-		self.assertEqual( c.substitute( "#${a}", c.Substitutions.AllSubstitutions & ~c.Substitutions.FrameSubstitutions ), "#apple" )
-		self.assertEqual( c.substitute( "#${a}", c.Substitutions.NoSubstitutions ), "#${a}" )
+		self.assertEqual( c.substitute( "~", IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.TildeSubstitutions ), "~" )
+		self.assertEqual( c.substitute( "#", IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.FrameSubstitutions ), "#" )
+		self.assertEqual( c.substitute( "$a/${b}", IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.VariableSubstitutions ), "$a/${b}" )
+		self.assertEqual( c.substitute( "\\", IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.EscapeSubstitutions ), "\\" )
+		self.assertEqual( c.substitute( "\\$a", IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.EscapeSubstitutions ), "\\apple" )
+		self.assertEqual( c.substitute( "#${a}", IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.FrameSubstitutions ), "#apple" )
+		self.assertEqual( c.substitute( "#${a}", IECore.StringAlgo.Substitutions.NoSubstitutions ), "#${a}" )
 
 	def testFrameAndVariableSubstitutionsAreDifferent( self ) :
 
@@ -311,31 +311,11 @@ class ContextTest( GafferTest.TestCase ) :
 
 		# Turning off variable substitutions should have no effect on '#' substitutions.
 		self.assertEqual( c.substitute( "###.$frame" ), "003.3" )
-		self.assertEqual( c.substitute( "###.$frame", c.Substitutions.AllSubstitutions & ~c.Substitutions.VariableSubstitutions ), "003.$frame" )
+		self.assertEqual( c.substitute( "###.$frame", IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.VariableSubstitutions ), "003.$frame" )
 
 		# Turning off '#' substitutions should have no effect on variable substitutions.
 		self.assertEqual( c.substitute( "###.$frame" ), "003.3" )
-		self.assertEqual( c.substitute( "###.$frame", c.Substitutions.AllSubstitutions & ~c.Substitutions.FrameSubstitutions ), "###.3" )
-
-	def testSubstitutions( self ) :
-
-		c = Gaffer.Context
-		self.assertEqual( c.substitutions( "a"), c.Substitutions.NoSubstitutions )
-		self.assertEqual( c.substitutions( "~/something"), c.Substitutions.TildeSubstitutions )
-		self.assertEqual( c.substitutions( "$a"), c.Substitutions.VariableSubstitutions )
-		self.assertEqual( c.substitutions( "${a}"), c.Substitutions.VariableSubstitutions )
-		self.assertEqual( c.substitutions( "###"), c.Substitutions.FrameSubstitutions )
-		self.assertEqual( c.substitutions( "\#"), c.Substitutions.EscapeSubstitutions )
-		self.assertEqual( c.substitutions( "${a}.###"), c.Substitutions.VariableSubstitutions | c.Substitutions.FrameSubstitutions )
-
-	def testHasSubstitutions( self ) :
-
-		c = Gaffer.Context()
-		self.assertFalse( c.hasSubstitutions( "a" ) )
-		self.assertTrue( c.hasSubstitutions( "~something" ) )
-		self.assertTrue( c.hasSubstitutions( "$a" ) )
-		self.assertTrue( c.hasSubstitutions( "${a}" ) )
-		self.assertTrue( c.hasSubstitutions( "###" ) )
+		self.assertEqual( c.substitute( "###.$frame", IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.FrameSubstitutions ), "###.3" )
 
 	def testInternedStringVectorDataSubstitutions( self ) :
 
@@ -580,9 +560,6 @@ class ContextTest( GafferTest.TestCase ) :
 		# the extra slashes are escaping for the python interpreter.
 		self.assertEqual( c.substitute( "\\\\" ), "\\" )
 		self.assertEqual( c.substitute( "\\" ), "" )
-
-		self.assertTrue( c.hasSubstitutions( "\\" ) ) # must return true, because escaping affects substitution
-		self.assertTrue( c.hasSubstitutions( "\\\\" ) ) # must return true, because escaping affects substitution
 
 	def testRemove( self ) :
 

--- a/python/GafferTest/StringInOutNode.py
+++ b/python/GafferTest/StringInOutNode.py
@@ -39,7 +39,7 @@ import Gaffer
 
 class StringInOutNode( Gaffer.ComputeNode ) :
 
-	def __init__( self, name="StringInOutNode", defaultValue="", substitutions = Gaffer.Context.Substitutions.AllSubstitutions ) :
+	def __init__( self, name="StringInOutNode", defaultValue="", substitutions = IECore.StringAlgo.Substitutions.AllSubstitutions ) :
 
 		Gaffer.ComputeNode.__init__( self, name )
 

--- a/python/GafferTest/StringPlugTest.py
+++ b/python/GafferTest/StringPlugTest.py
@@ -217,6 +217,14 @@ class StringPlugTest( GafferTest.TestCase ) :
 
 		self.assertEqual( s["n"]["user"]["p"].substitutions(), Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.FrameSubstitutions )
 
+	def testLoadSubstitutionsVersion0_55( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( os.path.join( os.path.dirname( __file__ ), "scripts", "stringPlugSubstitutions-0.55.4.0.gfr" ) )
+		s.load()
+
+		self.assertEqual( s["n"]["user"]["p"].substitutions(), IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.FrameSubstitutions )
+
 	def testSubstitutionsRepr( self ) :
 
 		p = Gaffer.StringPlug(

--- a/python/GafferTest/StringPlugTest.py
+++ b/python/GafferTest/StringPlugTest.py
@@ -179,8 +179,8 @@ class StringPlugTest( GafferTest.TestCase ) :
 
 	def testExpansionMask( self ) :
 
-		n1 = GafferTest.StringInOutNode( substitutions = Gaffer.Context.Substitutions.AllSubstitutions )
-		n2 = GafferTest.StringInOutNode( substitutions = Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.FrameSubstitutions )
+		n1 = GafferTest.StringInOutNode( substitutions = IECore.StringAlgo.Substitutions.AllSubstitutions )
+		n2 = GafferTest.StringInOutNode( substitutions = IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.FrameSubstitutions )
 
 		n1["in"].setValue( "hello.####.${ext}" )
 		n2["in"].setValue( "hello.####.${ext}" )
@@ -201,9 +201,9 @@ class StringPlugTest( GafferTest.TestCase ) :
 		s["n"]["p"] = Gaffer.StringPlug(
 			"p",
 			flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
-			substitutions = Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.FrameSubstitutions
+			substitutions = IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.FrameSubstitutions
 		)
-		self.assertEqual( s["n"]["p"].substitutions(), Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.FrameSubstitutions )
+		self.assertEqual( s["n"]["p"].substitutions(), IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.FrameSubstitutions )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
@@ -215,7 +215,7 @@ class StringPlugTest( GafferTest.TestCase ) :
 		s["fileName"].setValue( os.path.join( os.path.dirname( __file__ ), "scripts", "stringPlugSubstitutions-0.56.0.0.gfr" ) )
 		s.load()
 
-		self.assertEqual( s["n"]["user"]["p"].substitutions(), Gaffer.Context.Substitutions.AllSubstitutions & ~Gaffer.Context.Substitutions.FrameSubstitutions )
+		self.assertEqual( s["n"]["user"]["p"].substitutions(), IECore.StringAlgo.Substitutions.AllSubstitutions & ~IECore.StringAlgo.Substitutions.FrameSubstitutions )
 
 	def testLoadSubstitutionsVersion0_55( self ) :
 
@@ -228,7 +228,7 @@ class StringPlugTest( GafferTest.TestCase ) :
 	def testSubstitutionsRepr( self ) :
 
 		p = Gaffer.StringPlug(
-			substitutions = Gaffer.Context.Substitutions.TildeSubstitutions | Gaffer.Context.Substitutions.FrameSubstitutions
+			substitutions = IECore.StringAlgo.Substitutions.TildeSubstitutions | IECore.StringAlgo.Substitutions.FrameSubstitutions
 		)
 
 		p2 = eval( repr( p ) )
@@ -237,7 +237,7 @@ class StringPlugTest( GafferTest.TestCase ) :
 	def testSubstitutionsCounterpart( self ) :
 
 		p = Gaffer.StringPlug(
-			substitutions = Gaffer.Context.Substitutions.TildeSubstitutions | Gaffer.Context.Substitutions.FrameSubstitutions
+			substitutions = IECore.StringAlgo.Substitutions.TildeSubstitutions | IECore.StringAlgo.Substitutions.FrameSubstitutions
 		)
 
 		p2 = p.createCounterpart( "p2", p.Direction.In )
@@ -251,7 +251,7 @@ class StringPlugTest( GafferTest.TestCase ) :
 		s["substitionsOn"] = GafferTest.StringInOutNode()
 
 		# Should pass through the input directly, without substitutions.
-		s["substitionsOff"] = GafferTest.StringInOutNode( substitutions = Gaffer.Context.Substitutions.NoSubstitutions )
+		s["substitionsOff"] = GafferTest.StringInOutNode( substitutions = IECore.StringAlgo.Substitutions.NoSubstitutions )
 
 		# The third case is trickier. The "in" plug on the node
 		# itself requests no substitutions, but it receives its
@@ -269,7 +269,7 @@ class StringPlugTest( GafferTest.TestCase ) :
 		# nodes that know when a substitution is relevant, and the
 		# user shouldn't be burdened with the job of thinking about
 		# them when making intermediate connections to that node.
-		s["substitionsOnIndirectly"] = GafferTest.StringInOutNode( substitutions = Gaffer.Context.Substitutions.NoSubstitutions )
+		s["substitionsOnIndirectly"] = GafferTest.StringInOutNode( substitutions = IECore.StringAlgo.Substitutions.NoSubstitutions )
 		s["substitionsOnIndirectly"]["user"]["in"] = Gaffer.StringPlug()
 		s["substitionsOnIndirectly"]["in"].setInput( s["substitionsOnIndirectly"]["user"]["in"] )
 

--- a/python/GafferTest/scripts/stringPlugSubstitutions-0.55.4.0.gfr
+++ b/python/GafferTest/scripts/stringPlugSubstitutions-0.55.4.0.gfr
@@ -1,0 +1,18 @@
+import Gaffer
+import IECore
+import imath
+
+Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 55, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 4, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+__children["n"] = Gaffer.Node( "n" )
+parent.addChild( __children["n"] )
+__children["n"]["user"].addChild( Gaffer.StringPlug( "p", defaultValue = '', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, substitutions = Gaffer.Context.Substitutions.VariableSubstitutions | Gaffer.Context.Substitutions.EscapeSubstitutions | Gaffer.Context.Substitutions.TildeSubstitutions ) )
+
+
+del __children
+

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -71,7 +71,7 @@ Expression::Expression( const std::string &name )
 			Plug::In,
 			"",
 			Plug::Default & ~( Plug::AcceptsInputs | Plug::Serialisable ),
-			Context::NoSubstitutions
+			IECore::StringAlgo::NoSubstitutions
 		)
 	);
 	addChild(
@@ -80,7 +80,7 @@ Expression::Expression( const std::string &name )
 			Plug::In,
 			"",
 			Plug::Default & ~( Plug::AcceptsInputs | Plug::Serialisable ),
-			Context::NoSubstitutions
+			IECore::StringAlgo::NoSubstitutions
 		)
 	);
 

--- a/src/Gaffer/StringPlug.cpp
+++ b/src/Gaffer/StringPlug.cpp
@@ -106,7 +106,7 @@ std::string StringPlug::getValue( const IECore::MurmurHash *precomputedHash ) co
 		m_substitutions &&
 		direction() == In &&
 		Process::current() &&
-		Context::hasSubstitutions( s->readable() )
+		IECore::StringAlgo::hasSubstitutions( s->readable() )
 	;
 
 	return performSubstitutions ? Context::current()->substitute( s->readable(), m_substitutions ) : s->readable();
@@ -141,7 +141,7 @@ IECore::MurmurHash StringPlug::hash() const
 			throw IECore::Exception( "StringPlug::getObjectValue() didn't return StringData - is the hash being computed correctly?" );
 		}
 
-		if( Context::hasSubstitutions( s->readable() ) )
+		if( IECore::StringAlgo::hasSubstitutions( s->readable() ) )
 		{
 			IECore::MurmurHash result;
 			result.append( Context::current()->substitute( s->readable(), m_substitutions ) );

--- a/src/GafferCortex/TypedParameterHandler.cpp
+++ b/src/GafferCortex/TypedParameterHandler.cpp
@@ -84,7 +84,7 @@ typename TypedParameterHandler<T>::PlugType::Ptr TypedParameterHandler<T>::creat
 }
 
 template<>
-TypedParameterHandler<std::string>::PlugType::Ptr TypedParameterHandler<std::string>::createPlug( Gaffer::Plug::Direction direction, Gaffer::Context::Substitutions substitutions ) const
+TypedParameterHandler<std::string>::PlugType::Ptr TypedParameterHandler<std::string>::createPlug( Gaffer::Plug::Direction direction, IECore::StringAlgo::Substitutions substitutions ) const
 {
 	return new Gaffer::StringPlug( m_parameter->name(), direction, m_parameter->typedDefaultValue(), Gaffer::Plug::Default, substitutions );
 }
@@ -109,14 +109,14 @@ Gaffer::Plug *TypedParameterHandler<std::string>::setupPlug( Gaffer::GraphCompon
 {
 	// We have to turn off substitutions for FileSequenceParameters because they'd remove the
 	// #### destined for the parameter.
-	Gaffer::Context::Substitutions substitutions = m_parameter->isInstanceOf( IECore::FileSequenceParameterTypeId ) ? Gaffer::Context::NoSubstitutions : Gaffer::Context::AllSubstitutions;
+	IECore::StringAlgo::Substitutions substitutions = m_parameter->isInstanceOf( IECore::FileSequenceParameterTypeId ) ? IECore::StringAlgo::NoSubstitutions : IECore::StringAlgo::AllSubstitutions;
 
 	// We also allow individual parameters to override the substitutions via userData
 	if( const auto *gafferUserData = m_parameter->userData()->member<IECore::CompoundObject>( "gaffer" ) )
 	{
 		if( const auto *substitutionsUserData = gafferUserData->member<IECore::IntData>( "substitutions" ) )
 		{
-			substitutions = (Gaffer::Context::Substitutions)substitutionsUserData->readable();
+			substitutions = (IECore::StringAlgo::Substitutions)substitutionsUserData->readable();
 		}
 	}
 

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -834,7 +834,7 @@ std::string Catalogue::generateFileName( const ImagePlug *image ) const
 	{
 		directory = script->context()->substitute( directory );
 	}
-	else if( Context::hasSubstitutions( directory ) )
+	else if( IECore::StringAlgo::hasSubstitutions( directory ) )
 	{
 		// Its possible for a Catalogue to have been removed from its script
 		// and still receive an image. If it will attempt to save that image

--- a/src/GafferImage/ImageReader.cpp
+++ b/src/GafferImage/ImageReader.cpp
@@ -121,7 +121,7 @@ ImageReader::ImageReader( const std::string &name )
 		new StringPlug(
 			"fileName", Plug::In, "",
 			/* flags */ Plug::Default,
-			/* substitutions */ Context::AllSubstitutions & ~Context::FrameSubstitutions
+			/* substitutions */ IECore::StringAlgo::AllSubstitutions & ~IECore::StringAlgo::FrameSubstitutions
 		)
 	);
 	addChild( new IntPlug( "refreshCount" ) );

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -764,7 +764,7 @@ OpenImageIOReader::OpenImageIOReader( const std::string &name )
 		new StringPlug(
 			"fileName", Plug::In, "",
 			/* flags */ Plug::Default,
-			/* substitutions */ Context::AllSubstitutions & ~Context::FrameSubstitutions
+			/* substitutions */ IECore::StringAlgo::AllSubstitutions & ~IECore::StringAlgo::FrameSubstitutions
 		)
 	);
 	addChild( new IntPlug( "refreshCount" ) );
@@ -960,7 +960,7 @@ void OpenImageIOReader::hashFileName( const Gaffer::Context *context, IECore::Mu
 	// when the value contains FrameSubstitutions.
 	const std::string fileName = fileNamePlug()->getValue();
 	h.append( fileName );
-	if( Context::substitutions( fileName ) & Context::FrameSubstitutions )
+	if( IECore::StringAlgo::substitutions( fileName ) & IECore::StringAlgo::FrameSubstitutions )
 	{
 		h.append( context->getFrame() );
 	}

--- a/src/GafferModule/ContextBinding.cpp
+++ b/src/GafferModule/ContextBinding.cpp
@@ -161,15 +161,6 @@ void GafferModule::bindContext()
 		.value( "Borrowed", Context::Borrowed )
 	;
 
-	enum_<Context::Substitutions>( "Substitutions" )
-		.value( "NoSubstitutions", Context::NoSubstitutions )
-		.value( "FrameSubstitutions", Context::FrameSubstitutions )
-		.value( "VariableSubstitutions", Context::VariableSubstitutions )
-		.value( "EscapeSubstitutions", Context::EscapeSubstitutions )
-		.value( "TildeSubstitutions", Context::TildeSubstitutions )
-		.value( "AllSubstitutions", Context::AllSubstitutions )
-	;
-
 	contextClass
 		.def( init<>() )
 		.def( init<const Context &, Context::Ownership>( ( arg( "other" ), arg( "ownership" ) = Context::Copied ) ) )
@@ -215,9 +206,7 @@ void GafferModule::bindContext()
 		.def( "hash", &Context::hash )
 		.def( self == self )
 		.def( self != self )
-		.def( "substitute", &Context::substitute, ( arg( "input" ), arg( "substitutions" ) = Context::AllSubstitutions ) )
-		.def( "substitutions", &Context::substitutions ).staticmethod( "substitutions" )
-		.def( "hasSubstitutions", &Context::hasSubstitutions ).staticmethod( "hasSubstitutions" )
+		.def( "substitute", &Context::substitute, ( arg( "input" ), arg( "substitutions" ) = IECore::StringAlgo::AllSubstitutions ) )
 		.def( "canceller", &Context::canceller, return_internal_reference<1>() )
 		.def( "current", &current ).staticmethod( "current" )
 		;

--- a/src/GafferModule/StringPlugBinding.cpp
+++ b/src/GafferModule/StringPlugBinding.cpp
@@ -67,16 +67,22 @@ std::string getValue( const StringPlug *plug, const IECore::MurmurHash *precompu
 
 std::string substitutionsRepr( unsigned substitutions )
 {
-	static const Context::Substitutions values[] = { Context::FrameSubstitutions, Context::VariableSubstitutions, Context::EscapeSubstitutions, Context::TildeSubstitutions, Context::NoSubstitutions };
+	static const IECore::StringAlgo::Substitutions values[] = {
+		IECore::StringAlgo::FrameSubstitutions,
+		IECore::StringAlgo::VariableSubstitutions,
+		IECore::StringAlgo::EscapeSubstitutions,
+		IECore::StringAlgo::TildeSubstitutions,
+		IECore::StringAlgo::NoSubstitutions
+	};
 	static const char *names[] = { "FrameSubstitutions", "VariableSubstitutions", "EscapeSubstitutions", "TildeSubstitutions", nullptr };
 
-	if( substitutions == Context::AllSubstitutions )
+	if( substitutions == IECore::StringAlgo::AllSubstitutions )
 	{
-		return "Gaffer.Context.Substitutions.AllSubstitutions";
+		return "IECore.StringAlgo.Substitutions.AllSubstitutions";
 	}
-	else if( substitutions == Context::NoSubstitutions )
+	else if( substitutions == IECore::StringAlgo::NoSubstitutions )
 	{
-		return "Gaffer.Context.Substitutions.NoSubstitutions";
+		return "IECore.StringAlgo.Substitutions.NoSubstitutions";
 	}
 
 	std::string result;
@@ -88,7 +94,7 @@ std::string substitutionsRepr( unsigned substitutions )
 			{
 				result += " | ";
 			}
-			result += "Gaffer.Context.Substitutions." + std::string( names[i] );
+			result += "IECore.StringAlgo.Substitutions." + std::string( names[i] );
 		}
 	}
 
@@ -98,7 +104,7 @@ std::string substitutionsRepr( unsigned substitutions )
 std::string serialisationRepr( const Gaffer::StringPlug *plug, const Serialisation *serialisation )
 {
 	std::string extraArguments;
-	if( plug->substitutions() != Context::AllSubstitutions )
+	if( plug->substitutions() != IECore::StringAlgo::AllSubstitutions )
 	{
 		extraArguments = "substitutions = " + substitutionsRepr( plug->substitutions() );
 	}
@@ -135,7 +141,7 @@ void GafferModule::bindStringPlug()
 					boost::python::arg_( "direction" )=Gaffer::Plug::In,
 					boost::python::arg_( "defaultValue" )="",
 					boost::python::arg_( "flags" )=Gaffer::Plug::Default,
-					boost::python::arg_( "substitutions" )=Gaffer::Context::AllSubstitutions
+					boost::python::arg_( "substitutions" )=IECore::StringAlgo::AllSubstitutions
 				)
 			)
 		)

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -549,7 +549,7 @@ Shader::Shader( const std::string &name )
 	addChild( new StringPlug( "attributeSuffix", Gaffer::Plug::In, "" ) );
 	addChild( new Plug( "parameters", Plug::In, Plug::Default & ~Plug::AcceptsInputs ) );
 	addChild( new BoolPlug( "enabled", Gaffer::Plug::In, true ) );
-	addChild( new StringPlug( "__nodeName", Gaffer::Plug::In, name, Plug::Default & ~(Plug::Serialisable | Plug::AcceptsInputs), Context::NoSubstitutions ) );
+	addChild( new StringPlug( "__nodeName", Gaffer::Plug::In, name, Plug::Default & ~(Plug::Serialisable | Plug::AcceptsInputs), IECore::StringAlgo::NoSubstitutions ) );
 	addChild( new Color3fPlug( "__nodeColor", Gaffer::Plug::In, Color3f( 0.0f ) ) );
 	nodeColorPlug()->setFlags( Plug::Serialisable | Plug::AcceptsInputs, false );
 	addChild( new CompoundObjectPlug( "__outAttributes", Plug::Out, new IECore::CompoundObject ) );

--- a/src/GafferTest/ContextTest.cpp
+++ b/src/GafferTest/ContextTest.cpp
@@ -91,7 +91,7 @@ void GafferTest::testManySubstitutions()
 	const std::string expectedResult( "smoke me a kipper" );
 
 	Timer t;
-	for( int i = 0; i < 100000; ++i )
+	for( int i = 0; i < 1000000; ++i )
 	{
 		const std::string s = context->substitute( phrase );
 		GAFFERTEST_ASSERT( s == expectedResult );

--- a/startup/Gaffer/contextCompatibility.py
+++ b/startup/Gaffer/contextCompatibility.py
@@ -37,10 +37,14 @@
 import IECore
 import Gaffer
 
-# In an upcoming Gaffer version, `Gaffer.Context.Substitutions` will be
-# replaced by `IECore.StringAlgo.Substitutions`, and will be referenced
-# by StringPlug constructors in `.gfr` files. Support loading of such
-# "files from the future" by monkey patching Cortex.
+# The original Gaffer.Context substitution code was generalised and moved
+# to Cortex. Here we provide some backwards compatibility.
 
-if not hasattr( IECore.StringAlgo, "Substitutions" ) :
-	IECore.StringAlgo.Substitutions = Gaffer.Context.Substitutions
+# This is absolutely necessary for the loading of old files containing
+# dynamic StringPlugs with non-default substitutions.
+Gaffer.Context.Substitutions = IECore.StringAlgo.Substitutions
+# These are just provided as a temporary nicety, since it's much harder
+# to audit Python code to discover dependencies. On the C++ side, we have
+# removed these completely.
+Gaffer.Context.hasSubstitutions = staticmethod( IECore.StringAlgo.hasSubstitutions )
+Gaffer.Context.substitutions = staticmethod( IECore.StringAlgo.substitutions )


### PR DESCRIPTION
Following up on https://github.com/ImageEngine/cortex/pull/1039, this updates Gaffer to use `IECore::StringAlgo::substitute()` rather than its own internal code.