### PR TITLE
JH Options : Build GafferCortex

### DIFF
--- a/config/jh/options
+++ b/config/jh/options
@@ -47,3 +47,4 @@ DOXYGEN = "/usr/local/bin/doxygen"
 PYTHON_LINK_FLAGS = [ "-lpython$PYTHON_VERSION" ]
 ENV_VARS_TO_IMPORT = "PATH"
 VTUNE_ROOT = "/disk1/apps/intel/system_studio_2018/vtune_amplifier_2018.1.0.535340"
+GAFFERCORTEX=1


### PR DESCRIPTION
This is a deprecated component that doesn't build by default, but I really should be building it during my day-to-day work so that I don't inadvertently break it, as I just did in #3657.
