### PR TITLE
IECoreArnoldPreview : Set interactive display to the first beauty

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -3163,7 +3163,18 @@ class ArnoldGlobals
 			std::sort( outputs->writable().begin(), outputs->writable().end() );
 			IECoreArnold::ParameterAlgo::setParameter( options, "outputs", outputs.get() );
 			IECoreArnold::ParameterAlgo::setParameter( options, "light_path_expressions", lpes.get() );
-
+		
+			// Set the beauty as the output to get frequent interactive updates	
+			unsigned int primaryOutput = 0;
+			for( unsigned int i = 0; i < outputs->readable().size(); i++ )
+			{
+				if( boost::starts_with( outputs->readable()[i], "RGBA " ) )
+				{
+					primaryOutput = i;
+					break;
+				}
+			}
+			AiRenderSetInteractiveOutput( primaryOutput );
 
 			const IECoreScene::Camera *cortexCamera;
 			AtNode *arnoldCamera = AiNodeLookUpByName( AtString( cameraName.c_str() ) );


### PR DESCRIPTION
This fixes a hypothetical problem.

When rendering interactively, Arnold prioritizes getting buckets to outputs that are flagged as "interactive".  By default, this is the first output.  We just sort outputs alphabetically, so there's no guarantee that this is a sensible output to make interactive.  But in practice, the first part of the output is the data, and the beauty data is capital "RGBA" which sorts before any of the other builtin AOVS, like "emission".  But just in case someone names a custom mask "AAAAA" and reads it in an extra output of an interactive render, this PR finds an AOV that looks like a beauty, and sets that as the interactive AOV.

While testing this, I found a more concerning issue:  as of Arnold 6, sometimes AOVs that aren't tagged interactive stop receiving output at all after a few edits.  It's not clear whether we're doing anything wrong to cause this - I've isolated a test case outside of Gaffer for this and reported it to SolidAngle.