### PR TITLE
Spreadsheet : Add `RowsPlug::row( rowName )` method

### DIFF
--- a/include/Gaffer/Spreadsheet.h
+++ b/include/Gaffer/Spreadsheet.h
@@ -76,11 +76,22 @@ class GAFFER_API Spreadsheet : public ComputeNode
 			public :
 
 				RowsPlug( const std::string &name = defaultName<RowsPlug>(), Direction direction = In, unsigned flags = Default );
+				virtual ~RowsPlug();
 
 				GAFFER_PLUG_DECLARE_TYPE( Gaffer::Spreadsheet::RowsPlug, Gaffer::SpreadsheetRowsPlugTypeId, Gaffer::ValuePlug );
 
+				/// Row accessors
+				/// =============
+
 				RowPlug *defaultRow();
 				const RowPlug *defaultRow() const;
+
+				/// Returns the first row which has a name - as specified by
+				/// `RowPlug::namePlug()->getValue()` - equal to `rowName`.
+				/// Ignores rows with names driven by a ComputeNode, and never
+				/// returns `defaultRow()`.
+				RowPlug *row( const std::string &rowName );
+				const RowPlug *row( const std::string &rowName ) const;
 
 				/// Methods for adjusting spreadsheet size
 				/// ======================================
@@ -103,11 +114,19 @@ class GAFFER_API Spreadsheet : public ComputeNode
 				void addRows( size_t numRows );
 				void removeRow( RowPlugPtr row );
 
+				/// Overrides
+				/// =========
+
+				bool acceptsChild( const GraphComponent *potentialChild ) const override;
 				Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
 			private :
 
 				std::vector<ValuePlug *> outPlugs();
+
+				// Used to implement the `row()` accessor.
+				class RowNameMap;
+				std::unique_ptr<RowNameMap> m_rowNameMap;
 
 		};
 

--- a/src/GafferModule/SpreadsheetBinding.cpp
+++ b/src/GafferModule/SpreadsheetBinding.cpp
@@ -56,6 +56,11 @@ Spreadsheet::RowPlugPtr defaultRow( Spreadsheet::RowsPlug &rowsPlug )
 	return rowsPlug.defaultRow();
 }
 
+Spreadsheet::RowPlugPtr row( Spreadsheet::RowsPlug &rowsPlug, const std::string &name )
+{
+	return rowsPlug.row( name );
+}
+
 size_t addColumn( Spreadsheet::RowsPlug &rowsPlug, ValuePlug &value, IECore::InternedString name )
 {
 	ScopedGILRelease gilRelease;
@@ -144,6 +149,7 @@ void GafferModule::bindSpreadsheet()
 			)
 		)
 		.def( "defaultRow", &defaultRow )
+		.def( "row", &row )
 		.def( "addColumn", &addColumn, ( arg( "value" ), arg( "name" ) = "" ) )
 		.def( "removeColumn", &removeColumn )
 		.def( "addRow", &addRow )


### PR DESCRIPTION
This provides improved performance over a naive search, knocking 85% of the runtime off `SpreadsheetTest.testRowAccessorPerformance()`, with most of the remaining time being outside of `row()`. The motivation for this is programatic management of large spreadsheets in a forthcoming EditScopes PR.