### PR TITLE
Viewer : Support Arnold shader networks attached to gobos

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.56.x.x (relative to 0.56.1.0)
 ========
 
+Improvements
+------------
+
+- Viewer : Added visualisation support for Arnold shader networks connected to light gobos (#3667).
+
 Fixes
 -----
 

--- a/SConstruct
+++ b/SConstruct
@@ -817,7 +817,7 @@ libraries = {
 			"LIBS" : [ "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "Gaffer", "GafferScene", "GafferOSL", "GafferSceneUI", "ai" ],
 			},
 		"pythonEnvAppends" : {
-			"LIBS" : [ "GafferArnoldUI", "GafferSceneUI" ],
+			"LIBS" : [ "GafferArnoldUI", "GafferSceneUI", "IECoreScene$CORTEX_LIB_SUFFIX" ],
 		},
 		"requiredOptions" : [ "ARNOLD_ROOT" ],
 	},

--- a/include/GafferArnoldUI/Export.h
+++ b/include/GafferArnoldUI/Export.h
@@ -1,0 +1,46 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Cinesite VFX Ltd. nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERARNOLDUI_EXPORT_H
+#define GAFFERARNOLDUI_EXPORT_H
+
+#include "IECore/Export.h"
+
+#ifdef GafferArnoldUI_EXPORTS
+	#define GAFFERARNOLDUI_API IECORE_EXPORT
+#else
+	#define GAFFERARNOLDUI_API IECORE_IMPORT
+#endif
+
+#endif // #ifndef GAFFERARNOLDUI_EXPORT_H

--- a/include/GafferArnoldUI/Private/VisualiserAlgo.h
+++ b/include/GafferArnoldUI/Private/VisualiserAlgo.h
@@ -57,7 +57,7 @@ namespace VisualiserAlgo
 // OSL shaders. Any Arnold shaders are re-mapped in-place to an OSL equivalent
 // (where available). If any un-converted Arnold shaders remain, attempts are
 // made to build a simple network using the first image shader found. If no
-// image was found then the resulting mixed network is returned.
+// image was found then a nullptr is returned.
 //
 // Stand-in shaders are:
 //

--- a/include/GafferArnoldUI/Private/VisualiserAlgo.h
+++ b/include/GafferArnoldUI/Private/VisualiserAlgo.h
@@ -1,0 +1,82 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Cinesite VFX Ltd. nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERARNOLDUI_VISUALISERALGO_H
+#define GAFFERARNOLDUI_VISUALISERALGO_H
+
+#include "GafferArnoldUI/Export.h"
+
+#include "IECoreScene/ShaderNetwork.h"
+
+namespace GafferArnoldUI
+{
+
+namespace Private
+{
+
+namespace VisualiserAlgo
+{
+
+// Shader network conversion
+// =========================
+//
+// Attempts to conform the supplied shaderNetwork such that it only contains
+// OSL shaders. Any Arnold shaders are re-mapped in-place to an OSL equivalent
+// (where available). If any un-converted Arnold shaders remain, attempts are
+// made to build a simple network using the first image shader found. If no
+// image was found then the resulting mixed network is returned.
+//
+// Stand-in shaders are:
+//
+//  - Found in shaders/__viewer/ and prefixed with __arnold.
+//  - Should have identical parameter names/types.
+//  - Should have a single output called 'out'.
+//  - Arnold bool params should be OSL ints.
+//  - Any param name collisions with OSL reserved words should be suffixed
+//    with an '_'.
+//
+GAFFERARNOLDUI_API IECoreScene::ShaderNetworkPtr conformToOSLNetwork(
+	const IECoreScene::ShaderNetwork::Parameter &output,
+	const IECoreScene::ShaderNetwork *shaderNetwork
+);
+
+} // namespace VisualiserAlgo
+
+} // namespace Private
+
+} // namespace GafferArnoldUI
+
+#endif // GAFFERARNOLDUI_VISUALISERALGO_H

--- a/python/GafferArnoldUITest/VisualiserAlgoTest.py
+++ b/python/GafferArnoldUITest/VisualiserAlgoTest.py
@@ -1,0 +1,133 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+import IECoreScene
+
+import GafferTest
+import GafferArnoldUI.Private.VisualiserAlgo as VisualiserAlgo
+
+class VisualiserAlgoTest( GafferTest.TestCase ) :
+
+	def testConformToOSLNetworkFull( self ) :
+
+		# Tests reserved word suffxing, bool to int conversions and output renaming
+
+		network = IECoreScene.ShaderNetwork(
+			shaders = {
+				"blackbodyHandle" : IECoreScene.Shader( "blackbody", "ai:shader", { "normalize" : True } ),
+				"imageHandle" :     IECoreScene.Shader( "image",     "ai:shader", { "filename" :"/a/map", "sflip" : True } ),
+				"multiplyHandle" :  IECoreScene.Shader( "multiply",  "ai:shader" ),
+			},
+			connections = [
+				( ( "blackbodyHandle", "" ), ( "multiplyHandle", "input1" ) ),
+				( ( "imageHandle",     "" ), ( "multiplyHandle", "input2" ) ),
+			],
+			output = "multiplyHandle"
+		)
+
+		convertedNetwork = VisualiserAlgo.conformToOSLNetwork( network.getOutput(), network )
+
+		self.assertEqual( convertedNetwork.shaders(), {
+			"blackbodyHandle" : IECoreScene.Shader( "__viewer/__arnold_blackbody", "osl:shader", { "normalize_" : 1 } ),
+			"imageHandle" :     IECoreScene.Shader( "__viewer/__arnold_image",     "osl:shader", { "filename" : "/a/map", "sflip" : 1 } ),
+			"multiplyHandle" :  IECoreScene.Shader( "__viewer/__arnold_multiply",  "osl:shader" )
+		} )
+
+		self.assertEqual( convertedNetwork.inputConnections( "multiplyHandle" ), [
+			( ( "blackbodyHandle", "out" ), ( "multiplyHandle", "input1" ) ),
+			( ( "imageHandle",     "out" ), ( "multiplyHandle", "input2" ) )
+		] )
+
+		self.assertEqual( convertedNetwork.getOutput(), ( "multiplyHandle", "out" ) )
+
+	def testConformToOSLNetworkImageFallback( self ) :
+
+		# Tests fallback on image
+
+		network = IECoreScene.ShaderNetwork(
+			shaders = {
+				"image1Handle" :      IECoreScene.Shader( "image", "ai:shader", { "filename" : "1" } ),
+				"image2Handle" :      IECoreScene.Shader( "image", "ai:shader", { "filename" : "2" } ),
+				"unsupportedHandle" : IECoreScene.Shader( "__never_supported__", "ai:shader" )
+			},
+			connections = [
+				( ( "image1Handle", "" ), ( "unsupportedHandle", "input1" ) ),
+				( ( "image2Handle", "" ), ( "unsupportedHandle", "input2" ) ),
+			],
+			output = "unsupportedHandle"
+		)
+
+		with IECore.CapturingMessageHandler() as mh :
+			convertedNetwork = VisualiserAlgo.conformToOSLNetwork( network.getOutput(), network )
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Warning )
+		self.assertTrue( "__never_supported__" in mh.messages[0].message )
+		self.assertTrue( "image2Handle" in mh.messages[0].message )
+
+		self.assertEqual( convertedNetwork.shaders(), {
+			"image" : IECoreScene.Shader( "__viewer/__arnold_image", "osl:shader", { "filename" : "2" } )
+		} )
+		self.assertEqual( convertedNetwork.getOutput(), ( "image", "out" ) )
+
+	def testConformToOSLNetworkFailure( self ) :
+
+		# Test null network
+
+		network = IECoreScene.ShaderNetwork(
+			shaders = {
+				"unsupportedHandle" :  IECoreScene.Shader( "__never_supported__", "ai:shader" ),
+				"unsupported2Handle" : IECoreScene.Shader( "__never_supported__", "ai:shader" )
+			},
+			connections = [
+				( ( "unsupported2Handle", "" ), ( "unsupportedHandle", "input" ) )
+			],
+			output = "unsupportedHandle"
+		)
+
+		with IECore.CapturingMessageHandler() as mh :
+			convertedNetwork = VisualiserAlgo.conformToOSLNetwork( network.getOutput(), network )
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Error )
+		self.assertTrue( "__never_supported__" in mh.messages[0].message )
+		self.assertIsNone( convertedNetwork )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferArnoldUITest/__init__.py
+++ b/python/GafferArnoldUITest/__init__.py
@@ -36,6 +36,7 @@
 
 from DocumentationTest import DocumentationTest
 from ArnoldShaderUITest import ArnoldShaderUITest
+from VisualiserAlgoTest import VisualiserAlgoTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
+++ b/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
@@ -105,8 +105,11 @@ CompoundDataPtr surfaceTextureGetter( const SurfaceTextureCacheGetterKey &key, s
 {
 	cost = key.resolution.x * key.resolution.y * 3 * 4; // 3 x 32bit float channels;
 
-	ShaderNetworkPtr textureNetwork = VisualiserAlgo::conformToOSLNetwork( key.output, key.shaderNetwork );
-	return GafferOSL::ShadingEngineAlgo::shadeUVTexture( textureNetwork.get(), key.resolution );
+	if( ShaderNetworkPtr textureNetwork = VisualiserAlgo::conformToOSLNetwork( key.output, key.shaderNetwork ) )
+	{
+		return GafferOSL::ShadingEngineAlgo::shadeUVTexture( textureNetwork.get(), key.resolution );
+	}
+	return nullptr;
 }
 
 typedef IECorePreview::LRUCache<IECore::MurmurHash, CompoundDataPtr, IECorePreview::LRUCachePolicy::Parallel, SurfaceTextureCacheGetterKey> SurfaceTextureCache;

--- a/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
+++ b/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
@@ -34,15 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include "GafferArnoldUI/Private/VisualiserAlgo.h"
+
 #include "GafferSceneUI/StandardLightVisualiser.h"
 
 #include "Gaffer/Metadata.h"
 #include "Gaffer/Private/IECorePreview/LRUCache.h"
 
 #include "GafferOSL/ShadingEngineAlgo.h"
-
-#include "IECoreScene/Shader.h"
-#include "IECoreScene/ShaderNetworkAlgo.h"
 
 #include "IECoreGL/PointsPrimitive.h"
 
@@ -51,17 +50,13 @@
 #include "IECore/TypedData.h"
 #include "IECore/VectorTypedData.h"
 
-#include "OSL/oslquery.h"
-
 #include "ai.h"
-
-#include "boost/algorithm/string/predicate.hpp"
 
 using namespace Imath;
 using namespace IECore;
 using namespace IECoreGLPreview;
 using namespace IECoreScene;
-using namespace OSL;
+using namespace GafferArnoldUI::Private;
 
 // The ArnoldLightVisualiser provides an implementation of surfaceTexture,
 // rendering a lights color input network via OSL.
@@ -73,218 +68,6 @@ using namespace OSL;
 
 namespace
 {
-
-//////////////////////////////////////////////////////////////////////////
-// OSL query LRU cache
-//////////////////////////////////////////////////////////////////////////
-
-const char *g_oslSearchPaths = getenv( "OSL_SHADER_PATHS" );
-
-typedef std::shared_ptr<OSLQuery> OSLQueryPtr;
-
-OSLQueryPtr oslQueryGetter( const std::string &shaderName, size_t &cost )
-{
-	cost = 1;
-
-	OSLQueryPtr result( new OSLQuery() );
-	if( result->open( shaderName, g_oslSearchPaths ? g_oslSearchPaths : "" ) )
-	{
-		return result;
-	}
-
-	return nullptr;
-}
-
-typedef IECorePreview::LRUCache<std::string, OSLQueryPtr, IECorePreview::LRUCachePolicy::Parallel> OSLQueryCache;
-OSLQueryCache g_oslQueryCache( oslQueryGetter, 128 );
-
-//////////////////////////////////////////////////////////////////////////
-// Network conversion helpers
-//////////////////////////////////////////////////////////////////////////
-
-// Re-connects any connections from oldName on oldShader to newName on newShader
-void remapOutputConnections( const InternedString &shader, const InternedString &oldName, const InternedString &newName, ShaderNetwork *network )
-{
-	ShaderNetwork::Parameter newSource( shader, newName );
-
-	ShaderNetwork::ConnectionRange inputConnections = network->outputConnections( shader );
-	for( ShaderNetwork::ConnectionIterator it = inputConnections.begin(); it != inputConnections.end(); )
-	{
-		// Copy and increment now so we still have a valid iterator
-		// if we remove the connection.
-		const ShaderNetwork::Connection connection = *it++;
-
-		if( connection.source.name == oldName )
-		{
-			ShaderNetwork::Parameter dest( connection.destination.shader, connection.destination.name );
-			network->removeConnection( connection );
-			network->addConnection( ShaderNetwork::Connection( newSource, dest ) );
-		}
-	}
-
-	ShaderNetwork::Parameter out = network->getOutput();
-	if( out.shader == shader && out.name == oldName )
-	{
-		network->setOutput( newSource );
-	}
-}
-
-void remapInputConnections( const InternedString &shader, const InternedString &oldName, const InternedString &newName, ShaderNetwork *network )
-{
-	ShaderNetwork::Parameter newDestination( shader, newName );
-
-	ShaderNetwork::ConnectionRange outputConnections = network->inputConnections( shader );
-	for( ShaderNetwork::ConnectionIterator it = outputConnections.begin(); it != outputConnections.end(); )
-	{
-		// Copy and increment now so we still have a valid iterator
-		// if we remove the connection.
-		const ShaderNetwork::Connection connection = *it++;
-
-		if( connection.destination.name == oldName )
-		{
-			ShaderNetwork::Parameter source( connection.source.shader, connection.source.name );
-			network->removeConnection( connection );
-			network->addConnection( ShaderNetwork::Connection( source, newDestination ) );
-		}
-	}
-}
-
-
-
-// Sets outName in outParams if inName is set in inParams.
-// Arnold data types not representable in OSL will be converted accordingly
-void copyAndConvertIfSet( const InternedString &inName,  const CompoundDataMap &inParams, const InternedString &outName, CompoundDataMap &outParams )
-{
-	const auto &it = inParams.find( inName );
-	if( it != inParams.end() )
-	{
-		if( const BoolData *boolData = dynamic_cast<const BoolData *>( it->second.get() ) )
-		{
-			outParams[ outName ] = new IntData( 1 ? boolData->readable() : 0 );
-		}
-		else
-		{
-			outParams[ outName ] = it->second;
-		}
-	};
-}
-
-// Attempts to substitute the Arnold shader with the supplied handle with an
-// OSL stand-in shader. Returns true upon success.
-//
-// If a stand-in is found, any parameters that exist on the stand-in shader
-// will be populated by the value of the equivalent parameter on the source shader.
-// Input/output connections will be remapped if required.
-//
-// The network is left un-touched if no stand-in is available.
-//
-// Stand-in shaders:
-//  - Should be placed be named: __viewer/__arnold_<shaderName>.
-//  - Should have identical parameter names/types.
-//  - Should have a single output called 'out'.
-//  - Arnold bool params should be OSL ints.
-//  - Any param name collisions with OSL reserved words should be suffixed
-//    with an '_'.
-bool substituteWithOSL( const IECore::InternedString &handle, ShaderNetwork *network )
-{
-	const Shader *arnoldShader = network->getShader( handle );
-
-	const std::string oslShaderName = "__viewer/__arnold_" + arnoldShader->getName();
-	const OSLQueryPtr query = g_oslQueryCache.get( oslShaderName );
-	if( !query )
-	{
-		return false;
-	}
-
-	ShaderPtr oslShader = new IECoreScene::Shader();
-	oslShader->setType( "osl:shader" );
-	oslShader->setName( oslShaderName );
-
-	const IECore::CompoundDataMap &aiParams = arnoldShader->parameters();
-	IECore::CompoundDataMap &oslParams = oslShader->parameters();
-	for( size_t i = 0; i < query->nparams(); ++i )
-	{
-		const OSLQuery::Parameter *parameter = query->getparam( i );
-
-		if( parameter->isoutput )
-		{
-			continue;
-		}
-
-		const std::string oslParamName = parameter->name.string();
-
-		// Skip struct members
-		if( oslParamName.find( "." ) != std::string::npos )
-		{
-			continue;
-		}
-
-		// We have to avoid collisions with function names and other language
-		// keywords, so some stand-in shaders prefix param names with '_'.
-		//   eg: normalize -> normalize_
-		std::string aiParamName = oslParamName;
-		if( aiParamName.back() == '_' )
-		{
-			aiParamName.pop_back();
-			remapInputConnections( handle, aiParamName, oslParamName, network );
-		}
-
-		copyAndConvertIfSet( aiParamName, aiParams, oslParamName, oslParams );
-	}
-
-	network->setShader( handle, std::move( oslShader ) );
-	remapOutputConnections( handle, "", "out", network );
-
-	return true;
-}
-
-// Attempts to conform the supplied shaderNetwork such that it only contains
-// OSL shaders. Arnold shaders are re-mapped in-place to their OSL equivalents
-// (if they exist). If any un-converted Arnold shaders remain, it attempts to
-// build a simple network using the first image found. If no image was found
-// then the resulting mixed network is returned.
-IECoreScene::ShaderNetworkPtr conformToOSLNetwork( const IECoreScene::ShaderNetwork::Parameter &output, const IECoreScene::ShaderNetwork *shaderNetwork )
-{
-	ShaderNetworkPtr oslNetwork = shaderNetwork->copy();
-
-	oslNetwork->setOutput( output );
-	ShaderNetworkAlgo::removeUnusedShaders( oslNetwork.get() );
-
-	bool hasUnconvertedArnoldShaders = false;
-	InternedString fallbackImageHandle;
-
-	for( const auto &s : oslNetwork->shaders() )
-	{
-		const Shader *shader = s.second.get();
-		if( boost::starts_with( shader->getType(), "ai:" ) )
-		{
-			if( !substituteWithOSL( s.first, oslNetwork.get() ) )
-			{
-				hasUnconvertedArnoldShaders = true;
-				continue;
-			}
-
-			if( shader->getName() == "image" )
-			{
-				fallbackImageHandle = s.first;
-			}
-		}
-	}
-
-	if( hasUnconvertedArnoldShaders && fallbackImageHandle != "" )
-	{
-		/// TODO: Tell the user which location this is
-		msg( Msg::Warning, "ArnoldLightVisualiser", "Unsupported shaders in network, falling back on " + fallbackImageHandle.string() );
-
-		ShaderNetworkPtr minimalNetwork = new ShaderNetwork();
-		minimalNetwork->addShader( "image", oslNetwork->getShader( fallbackImageHandle ) );
-		minimalNetwork->setOutput( ShaderNetwork::Parameter( "image", "out" ) );
-
-		oslNetwork = minimalNetwork;
-	}
-
-	return oslNetwork;
-}
 
 //////////////////////////////////////////////////////////////////////////
 // Surface texture LRU cache
@@ -322,7 +105,7 @@ CompoundDataPtr surfaceTextureGetter( const SurfaceTextureCacheGetterKey &key, s
 {
 	cost = key.resolution.x * key.resolution.y * 3 * 4; // 3 x 32bit float channels;
 
-	ShaderNetworkPtr textureNetwork = conformToOSLNetwork( key.output, key.shaderNetwork );
+	ShaderNetworkPtr textureNetwork = VisualiserAlgo::conformToOSLNetwork( key.output, key.shaderNetwork );
 	return GafferOSL::ShadingEngineAlgo::shadeUVTexture( textureNetwork.get(), key.resolution );
 }
 

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -121,8 +121,11 @@ CompoundDataPtr getter( const OSLTextureCacheGetterKey &key, size_t &cost )
 	// make the cost be image data in bytes
 	cost = key.resolution * key.resolution * 3 * 4;
 
-	ShaderNetworkPtr textureNetwork = VisualiserAlgo::conformToOSLNetwork( key.output, key.shaderNetwork );
-	return GafferOSL::ShadingEngineAlgo::shadeUVTexture( textureNetwork.get(), V2i( key.resolution ) );
+	if( ShaderNetworkPtr textureNetwork = VisualiserAlgo::conformToOSLNetwork( key.output, key.shaderNetwork ) )
+	{
+		return GafferOSL::ShadingEngineAlgo::shadeUVTexture( textureNetwork.get(), V2i( key.resolution ) );
+	}
+	return nullptr;
 }
 
 typedef IECorePreview::LRUCache<IECore::MurmurHash, CompoundDataPtr, IECorePreview::LRUCachePolicy::Parallel, OSLTextureCacheGetterKey> OSLTextureCache;

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -34,6 +34,8 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include "GafferArnoldUI/Private/VisualiserAlgo.h"
+
 #include "GafferOSL/ShadingEngineAlgo.h"
 
 #include "GafferSceneUI/StandardLightVisualiser.h"
@@ -64,6 +66,7 @@ using namespace IECoreScene;
 using namespace IECoreGL;
 using namespace IECoreGLPreview;
 using namespace GafferSceneUI;
+using namespace GafferArnoldUI::Private;
 
 namespace
 {
@@ -117,7 +120,9 @@ CompoundDataPtr getter( const OSLTextureCacheGetterKey &key, size_t &cost )
 {
 	// make the cost be image data in bytes
 	cost = key.resolution * key.resolution * 3 * 4;
-	return GafferOSL::ShadingEngineAlgo::shadeUVTexture( key.shaderNetwork, V2i( key.resolution ), key.output );
+
+	ShaderNetworkPtr textureNetwork = VisualiserAlgo::conformToOSLNetwork( key.output, key.shaderNetwork );
+	return GafferOSL::ShadingEngineAlgo::shadeUVTexture( textureNetwork.get(), V2i( key.resolution ) );
 }
 
 typedef IECorePreview::LRUCache<IECore::MurmurHash, CompoundDataPtr, IECorePreview::LRUCachePolicy::Parallel, OSLTextureCacheGetterKey> OSLTextureCache;
@@ -189,7 +194,11 @@ Visualisations GoboVisualiser::visualise( const IECore::InternedString &attribut
 
 		try
 		{
-			imageData = g_oslTextureCache.get( OSLTextureCacheGetterKey( slideMapInput, shaderNetwork, resolution ) );
+			const OSLTextureCacheGetterKey key( slideMapInput, shaderNetwork, resolution );
+			if( CompoundDataPtr shadedImageData = g_oslTextureCache.get( key ) )
+			{
+				imageData = shadedImageData;
+			}
 		}
 		catch( const Exception &e )
 		{

--- a/src/GafferArnoldUI/VisualiserAlgo.cpp
+++ b/src/GafferArnoldUI/VisualiserAlgo.cpp
@@ -1,0 +1,255 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Cinesite VFX Ltd. nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferArnoldUI/Private/VisualiserAlgo.h"
+
+#include "Gaffer/Private/IECorePreview/LRUCache.h"
+
+#include "IECoreScene/Shader.h"
+#include "IECoreScene/ShaderNetworkAlgo.h"
+
+#include "IECore/MessageHandler.h"
+#include "IECore/SimpleTypedData.h"
+
+#include "boost/algorithm/string/predicate.hpp"
+
+#include "OSL/oslquery.h"
+
+using namespace OSL;
+using namespace IECore;
+using namespace IECoreScene;
+
+namespace
+{
+
+//////////////////////////////////////////////////////////////////////////
+// OSL query LRU cache
+//////////////////////////////////////////////////////////////////////////
+
+const char *g_oslSearchPaths = getenv( "OSL_SHADER_PATHS" );
+
+typedef std::shared_ptr<OSLQuery> OSLQueryPtr;
+
+OSLQueryPtr oslQueryGetter( const std::string &shaderName, size_t &cost )
+{
+	cost = 1;
+
+	OSLQueryPtr result( new OSLQuery() );
+	if( result->open( shaderName, g_oslSearchPaths ? g_oslSearchPaths : "" ) )
+	{
+		return result;
+	}
+
+	return nullptr;
+}
+
+typedef IECorePreview::LRUCache<std::string, OSLQueryPtr, IECorePreview::LRUCachePolicy::Parallel> OSLQueryCache;
+OSLQueryCache g_oslQueryCache( oslQueryGetter, 128 );
+
+//////////////////////////////////////////////////////////////////////////
+// Network conversion helpers
+//////////////////////////////////////////////////////////////////////////
+
+// Re-connects any connections from oldName on oldShader to newName on newShader
+void remapOutputConnections( const InternedString &shader, const InternedString &oldName, const InternedString &newName, ShaderNetwork *network )
+{
+	ShaderNetwork::Parameter newSource( shader, newName );
+
+	ShaderNetwork::ConnectionRange inputConnections = network->outputConnections( shader );
+	for( ShaderNetwork::ConnectionIterator it = inputConnections.begin(); it != inputConnections.end(); )
+	{
+		// Copy and increment now so we still have a valid iterator
+		// if we remove the connection.
+		const ShaderNetwork::Connection connection = *it++;
+
+		if( connection.source.name == oldName )
+		{
+			ShaderNetwork::Parameter dest( connection.destination.shader, connection.destination.name );
+			network->removeConnection( connection );
+			network->addConnection( ShaderNetwork::Connection( newSource, dest ) );
+		}
+	}
+
+	ShaderNetwork::Parameter out = network->getOutput();
+	if( out.shader == shader && out.name == oldName )
+	{
+		network->setOutput( newSource );
+	}
+}
+
+void remapInputConnections( const InternedString &shader, const InternedString &oldName, const InternedString &newName, ShaderNetwork *network )
+{
+	ShaderNetwork::Parameter newDestination( shader, newName );
+
+	ShaderNetwork::ConnectionRange outputConnections = network->inputConnections( shader );
+	for( ShaderNetwork::ConnectionIterator it = outputConnections.begin(); it != outputConnections.end(); )
+	{
+		// Copy and increment now so we still have a valid iterator
+		// if we remove the connection.
+		const ShaderNetwork::Connection connection = *it++;
+
+		if( connection.destination.name == oldName )
+		{
+			ShaderNetwork::Parameter source( connection.source.shader, connection.source.name );
+			network->removeConnection( connection );
+			network->addConnection( ShaderNetwork::Connection( source, newDestination ) );
+		}
+	}
+}
+
+// Sets outName in outParams if inName is set in inParams.
+// Arnold data types not representable in OSL will be converted accordingly
+void copyAndConvertIfSet( const InternedString &inName,  const CompoundDataMap &inParams, const InternedString &outName, CompoundDataMap &outParams )
+{
+	const auto &it = inParams.find( inName );
+	if( it != inParams.end() )
+	{
+		if( const BoolData *boolData = dynamic_cast<const BoolData *>( it->second.get() ) )
+		{
+			outParams[ outName ] = new IntData( 1 ? boolData->readable() : 0 );
+		}
+		else
+		{
+			outParams[ outName ] = it->second;
+		}
+	};
+}
+
+// Attempts to substitute the Arnold shader with the supplied handle with an
+// OSL stand-in shader. Returns true upon success.
+//
+// If a stand-in is found, any parameters that exist on the stand-in shader
+// will be populated by the value of the equivalent parameter on the source shader.
+// Input/output connections will be remapped if required.
+//
+// The network is left un-touched if no stand-in is available.
+bool substituteWithOSL( const IECore::InternedString &handle, ShaderNetwork *network )
+{
+	const Shader *arnoldShader = network->getShader( handle );
+
+	const std::string oslShaderName = "__viewer/__arnold_" + arnoldShader->getName();
+	const OSLQueryPtr query = g_oslQueryCache.get( oslShaderName );
+	if( !query )
+	{
+		return false;
+	}
+
+	ShaderPtr oslShader = new IECoreScene::Shader();
+	oslShader->setType( "osl:shader" );
+	oslShader->setName( oslShaderName );
+
+	const IECore::CompoundDataMap &aiParams = arnoldShader->parameters();
+	IECore::CompoundDataMap &oslParams = oslShader->parameters();
+	for( size_t i = 0; i < query->nparams(); ++i )
+	{
+		const OSLQuery::Parameter *parameter = query->getparam( i );
+
+		if( parameter->isoutput )
+		{
+			continue;
+		}
+
+		const std::string oslParamName = parameter->name.string();
+
+		// Skip struct members
+		if( oslParamName.find( "." ) != std::string::npos )
+		{
+			continue;
+		}
+
+		// We have to avoid collisions with function names and other language
+		// keywords, so some stand-in shaders prefix param names with '_'.
+		//   eg: normalize -> normalize_
+		std::string aiParamName = oslParamName;
+		if( aiParamName.back() == '_' )
+		{
+			aiParamName.pop_back();
+			remapInputConnections( handle, aiParamName, oslParamName, network );
+		}
+
+		copyAndConvertIfSet( aiParamName, aiParams, oslParamName, oslParams );
+	}
+
+	network->setShader( handle, std::move( oslShader ) );
+	remapOutputConnections( handle, "", "out", network );
+
+	return true;
+}
+
+} // anon namespace
+
+IECoreScene::ShaderNetworkPtr GafferArnoldUI::Private::VisualiserAlgo::conformToOSLNetwork( const IECoreScene::ShaderNetwork::Parameter &output, const IECoreScene::ShaderNetwork *shaderNetwork )
+{
+	ShaderNetworkPtr oslNetwork = shaderNetwork->copy();
+
+	oslNetwork->setOutput( output );
+	ShaderNetworkAlgo::removeUnusedShaders( oslNetwork.get() );
+
+	bool hasUnconvertedArnoldShaders = false;
+	InternedString fallbackImageHandle;
+
+	for( const auto &s : oslNetwork->shaders() )
+	{
+		const Shader *shader = s.second.get();
+		if( boost::starts_with( shader->getType(), "ai:" ) )
+		{
+			if( !substituteWithOSL( s.first, oslNetwork.get() ) )
+			{
+				hasUnconvertedArnoldShaders = true;
+				continue;
+			}
+
+			if( shader->getName() == "image" )
+			{
+				fallbackImageHandle = s.first;
+			}
+		}
+	}
+
+	if( hasUnconvertedArnoldShaders && fallbackImageHandle != "" )
+	{
+		/// \todo More detailed error reporting
+		msg( Msg::Warning, "GafferArnold::VisualiserAlgo", "Unsupported shaders in network, falling back on " + fallbackImageHandle.string() );
+
+		ShaderNetworkPtr minimalNetwork = new ShaderNetwork();
+		minimalNetwork->addShader( "image", oslNetwork->getShader( fallbackImageHandle ) );
+		minimalNetwork->setOutput( ShaderNetwork::Parameter( "image", "out" ) );
+
+		oslNetwork = minimalNetwork;
+	}
+
+	return oslNetwork;
+}

--- a/src/GafferArnoldUI/VisualiserAlgo.cpp
+++ b/src/GafferArnoldUI/VisualiserAlgo.cpp
@@ -242,18 +242,29 @@ IECoreScene::ShaderNetworkPtr GafferArnoldUI::Private::VisualiserAlgo::conformTo
 		}
 	}
 
-	if( unsupportedShaders.size() > 0 && fallbackImageHandle != "" )
+	if( unsupportedShaders.size() > 0 )
 	{
 		std::string message = "Unsupported Arnold shaders in network";
 		message += " (" + boost::join( unsupportedShaders, ", " ) + ")";
-		message += ", falling back on " + fallbackImageHandle.string() + ".";
-		msg( Msg::Warning, "GafferArnold::VisualiserAlgo", message );
 
-		ShaderNetworkPtr minimalNetwork = new ShaderNetwork();
-		minimalNetwork->addShader( "image", oslNetwork->getShader( fallbackImageHandle ) );
-		minimalNetwork->setOutput( ShaderNetwork::Parameter( "image", "out" ) );
+		if( fallbackImageHandle != "" )
+		{
+			message += ", falling back on " + fallbackImageHandle.string() + ".";
+			msg( Msg::Warning, "GafferArnold::VisualiserAlgo", message );
 
-		oslNetwork = minimalNetwork;
+			ShaderNetworkPtr minimalNetwork = new ShaderNetwork();
+			minimalNetwork->addShader( "image", oslNetwork->getShader( fallbackImageHandle ) );
+			minimalNetwork->setOutput( ShaderNetwork::Parameter( "image", "out" ) );
+
+			oslNetwork = minimalNetwork;
+		}
+		else
+		{
+			message += ", unable to convert network to OSL.";
+			msg( Msg::Error, "GafferArnold::VisualiserAlgo", message );
+
+			return nullptr;
+		}
 	}
 
 	return oslNetwork;

--- a/src/GafferArnoldUIModule/GafferArnoldUIModule.cpp
+++ b/src/GafferArnoldUIModule/GafferArnoldUIModule.cpp
@@ -36,9 +36,33 @@
 
 #include "boost/python.hpp"
 
-// Despite being empty, this module is still necessary because importing it
-// loads libGafferArnolUI, which registers visualisers.
+#include "GafferArnoldUI/Private/VisualiserAlgo.h"
+
+using namespace boost::python;
+using namespace IECoreScene;
+using namespace GafferArnoldUI::Private;
+
+namespace
+{
+
+ShaderNetworkPtr conformToOSLNetwork(
+	const ShaderNetwork::Parameter &output,
+	const ShaderNetwork &shaderNetwork
+) {
+	return VisualiserAlgo::conformToOSLNetwork( output, &shaderNetwork );
+}
+
+}
 
 BOOST_PYTHON_MODULE( _GafferArnoldUI )
 {
+	object privateModule( borrowed( PyImport_AddModule( "GafferArnoldUI.Private" ) ) );
+	scope().attr( "Private" ) = privateModule;
+	scope privateScope( privateModule );
+
+	object visualiserAlgoModule( borrowed( PyImport_AddModule( "GafferArnoldUI.Private.VisualiserAlgo" ) ) );
+	scope().attr( "VisualiserAlgo" ) = visualiserAlgoModule;
+	scope visualiserAlgoScope( visualiserAlgoModule );
+
+	def( "conformToOSLNetwork", &conformToOSLNetwork, ( arg( "output" ), arg( "shaderNetwork" ) ) );
 }


### PR DESCRIPTION
Adds support for Arnold shader networks attached to Gobo light filters.

In order to re-use the network conversion previously used in `ArnoldLightVisualiser`, it splits this out into `GafferArnoldUI/Private/VisualiserAlgo.h`.

Took the opportunity to clean up messaging and error case handling a little.