### PR TITLE
OSLExpressionEngine : Support boolean context variables

### DIFF
--- a/python/GafferOSLTest/OSLExpressionEngineTest.py
+++ b/python/GafferOSLTest/OSLExpressionEngineTest.py
@@ -182,6 +182,7 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 		s["n"]["user"]["c"] = Gaffer.Color3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["n"]["user"]["v"] = Gaffer.V3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["n"]["user"]["s"] = Gaffer.StringPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["user"]["b"] = Gaffer.BoolPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
 		s["e"] = Gaffer.Expression()
 		s["e"].setExpression(
@@ -192,6 +193,7 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 				parent.n.user.c = context( "c", color( 1, 2, 3 ) );
 				parent.n.user.v = context( "v", vector( 0, 1, 2 ) );
 				parent.n.user.s = context( "s", "default" );
+				parent.n.user.b = context( "b", 0 );
 				"""
 			),
 			"OSL"
@@ -204,18 +206,21 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 			self.assertEqual( s["n"]["user"]["c"].getValue(), imath.Color3f( 1, 2, 3 ) )
 			self.assertEqual( s["n"]["user"]["v"].getValue(), imath.V3f( 0, 1, 2 ) )
 			self.assertEqual( s["n"]["user"]["s"].getValue(), "default" )
+			self.assertEqual( s["n"]["user"]["b"].getValue(), False )
 
 			c["f"] = 10
 			c["i"] = 11
 			c["c"] = imath.Color3f( 4, 5, 6 )
 			c["v"] = imath.V3f( 1, 2, 3 )
 			c["s"] = "non-default"
+			c["b"] = IECore.BoolData( True )
 
 			self.assertEqual( s["n"]["user"]["f"].getValue(), 10 )
 			self.assertEqual( s["n"]["user"]["i"].getValue(), 11 )
 			self.assertEqual( s["n"]["user"]["c"].getValue(), imath.Color3f( 4, 5, 6 ) )
 			self.assertEqual( s["n"]["user"]["v"].getValue(), imath.V3f( 1, 2, 3 ) )
 			self.assertEqual( s["n"]["user"]["s"].getValue(), "non-default" )
+			self.assertEqual( s["n"]["user"]["b"].getValue(), True )
 
 	def testDefaultExpression( self ) :
 

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -135,6 +135,17 @@ class RendererServices : public OSL::RendererServices
 			IECoreImage::OpenImageIOAlgo::DataView dataView( data, /* createUStrings = */ true );
 			if( !dataView.data )
 			{
+				if( auto b = runTimeCast<const BoolData>( data ) )
+				{
+					// BoolData isn't supported by `DataView` because `OIIO::TypeDesc` doesn't
+					// have a boolean type. We could work around this in `DataView` by casting to
+					// `TypeDesc::UCHAR` (along with a `static_assert( sizeof( bool ) == 1`). But that
+					// wouldn't be round-trippable via `OpenImageIOAlgo::data()`, so it's not clear
+					// that it would be a good thing in general. Here we don't care about round
+					// tripping, so we simply perform a conversion ourselves.
+					const unsigned char c = b->readable();
+					return ShadingSystem::convert_value( value, type, &c, TypeDesc::UCHAR );
+				}
 				return false;
 			}
 			return ShadingSystem::convert_value( value, type, dataView.data, dataView.type );


### PR DESCRIPTION
Fixes
-----

- Expression : Fixed access to boolean context variables via the OSL `context()` function.
