### PR TITLE
BackdropNodeGadget : Support context usage in title/description

### DIFF
--- a/include/GafferUI/BackdropNodeGadget.h
+++ b/include/GafferUI/BackdropNodeGadget.h
@@ -71,6 +71,7 @@ class GAFFERUI_API BackdropNodeGadget : public NodeGadget
 
 	private :
 
+		void contextChanged();
 		void plugDirtied( const Gaffer::Plug *plug );
 
 		bool mouseMove( Gadget *gadget, const ButtonEvent &event );


### PR DESCRIPTION
This was requested by @gregmassie-ie and @danieldresser-ie. It seems mostly harmless, but I do have a niggling worry that it might be misleading to use the global context when any branch of the graph can have a different context. If anyone wants to make a case for deliberately not supporting contexts at all, I'll listen...