### PR TITLE
TransformTool : Fix comparison used with `std::sort()`

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Box : Fixed bug that allowed locked plugs to be promoted.
+- TransformTools : Fixed rare crash triggered by selecting multiple objects.
 
 0.55.5.1 (relative to 0.55.5.0)
 ========

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -620,7 +620,7 @@ void TransformTool::updateSelection() const
 			{
 				return true;
 			}
-			else if( b.transformPlug.get() > a.transformPlug.get() )
+			else if( b.transformPlug.get() < a.transformPlug.get() )
 			{
 				return false;
 			}


### PR DESCRIPTION
We were meant to be establishing a "strict weak ordering" as required by the standard, but I botched the lexicographical comparison that would ensure that. This could lead to invalid memory accesses in some circumstances. Embarrassingly I've already fixed one such bug in this function (see #3136).