### PR TITLE
Gadget : Fix rare shutdown crashes

### DIFF
--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -452,9 +452,14 @@ Gadget::KeySignal &Gadget::keyReleaseSignal()
 
 Gadget::IdleSignal &Gadget::idleSignal()
 {
-	static IdleSignal g_idleSignal;
+	// Deliberately leaking here, as the alternative is for `g_idleSignal`
+	// to be destroyed during shutdown when static destructors are run.
+	// Static destructors are run _after_ Python has shut down, so we are
+	// not in a position to destroy any slots that might still be holding
+	// on to Python objects.
+	static IdleSignal *g_idleSignal = new IdleSignal;
 	idleSignalAccessedSignal()();
-	return g_idleSignal;
+	return *g_idleSignal;
 }
 
 Gadget::IdleSignal &Gadget::idleSignalAccessedSignal()


### PR DESCRIPTION
These manifested as crashes after running `gaffer test GafferSceneUITest.ShaderViewTest`. The trigger was the idle connection made by `ShaderView::plugDirtied()`, which caused Python objects to outlive the interpreter, and then crash when they were accessed later during shutdown. See stack trace below :

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   org.python.python             	0x0000000104ffc052 PyObject_Call + 50
1   org.python.python             	0x00000001050b4752 PyEval_CallObjectWithKeywords + 162
2   org.python.python             	0x00000001050d31ce PyEval_CallFunction + 222
3   libboost_python.dylib         	0x0000000107e92738 boost::python::detail::dependent<boost::python::api::object, boost::python::api::object>::type boost::python::api::object_operators<boost::python::api::proxy<boost::python::api::const_attribute_policies> >::operator()<boost::python::api::object, boost::python::api::object>(boost::python::api::object const&, boost::python::api::object const&) const + 56
4   libboost_python.dylib         	0x0000000107e926aa boost::python::detail::dict_base::get(boost::python::api::object const&, boost::python::api::object const&) const + 42
5   libboost_python.dylib         	0x0000000107e9a635 boost::python::api::object boost::python::dict::get<long, boost::python::api::object>(long const&, boost::python::api::object const&) const + 117
6   libboost_python.dylib         	0x0000000107e9a341 boost::python::objects::enum_base::to_python(_typeobject*, long) + 337
7   libboost_python.dylib         	0x0000000107ea9f61 boost::python::converter::detail::arg_to_python_base::arg_to_python_base(void const volatile*, boost::python::converter::registration const&) + 17
8   _GafferScene.so               	0x00000001196e3327 boost::python::detail::returnable<boost::python::api::object>::type boost::python::call<boost::python::api::object, IECore::TypeId>(_object*, IECore::TypeId const&, boost::type<boost::python::api::object>*) + 39
9   _GafferScene.so               	0x00000001196e310f IECorePython::RunTimeTypedWrapper<GafferScene::SceneNode>::isInstanceOf(IECore::TypeId) const + 207
10  libGafferScene.dylib          	0x0000000119fbc0f7 GafferScene::SceneNode::affects(Gaffer::Plug const*, std::__1::vector<Gaffer::Plug const*, std::__1::allocator<Gaffer::Plug const*> >&) const + 359
11  _GafferScene.so               	0x00000001196e1faf GafferBindings::DependencyNodeWrapper<GafferScene::SceneNode>::affects(Gaffer::Plug const*, std::__1::vector<Gaffer::Plug const*, std::__1::allocator<Gaffer::Plug const*> >&) const + 671
12  libGaffer.dylib               	0x000000010bcef444 Gaffer::DownstreamIterator::Level::addDependentPlugs(Gaffer::Plug const*) + 116
13  libGaffer.dylib               	0x000000010bcef2b9 Gaffer::DownstreamIterator::Level::Level(Gaffer::Plug const*) + 185
14  libGaffer.dylib               	0x000000010bcefce2 Gaffer::DownstreamIterator::increment() + 210
15  libGaffer.dylib               	0x000000010bced45a Gaffer::Plug::DirtyPlugs::insert(Gaffer::Plug*) + 426
16  libGaffer.dylib               	0x000000010bceaa32 Gaffer::Plug::setInputInternal(boost::intrusive_ptr<Gaffer::Plug>, bool) + 146
17  libGaffer.dylib               	0x000000010bcf2215 void boost::_bi::list3<boost::_bi::value<boost::intrusive_ptr<Gaffer::Plug> >, boost::_bi::value<boost::intrusive_ptr<Gaffer::Plug> >, boost::_bi::value<bool> >::operator()<boost::_mfi::mf2<void, Gaffer::Plug, boost::intrusive_ptr<Gaffer::Plug>, bool>, boost::_bi::list0>(boost::_bi::type<void>, boost::_mfi::mf2<void, Gaffer::Plug, boost::intrusive_ptr<Gaffer::Plug>, bool>&, boost::_bi::list0&, int) + 85
18  libGaffer.dylib               	0x000000010bcf217e std::__1::__function::__func<boost::_bi::bind_t<void, boost::_mfi::mf2<void, Gaffer::Plug, boost::intrusive_ptr<Gaffer::Plug>, bool>, boost::_bi::list3<boost::_bi::value<boost::intrusive_ptr<Gaffer::Plug> >, boost::_bi::value<boost::intrusive_ptr<Gaffer::Plug> >, boost::_bi::value<bool> > >, std::__1::allocator<boost::_bi::bind_t<void, boost::_mfi::mf2<void, Gaffer::Plug, boost::intrusive_ptr<Gaffer::Plug>, bool>, boost::_bi::list3<boost::_bi::value<boost::intrusive_ptr<Gaffer::Plug> >, boost::_bi::value<boost::intrusive_ptr<Gaffer::Plug> >, boost::_bi::value<bool> > > >, void ()>::operator()() + 30
19  libGaffer.dylib               	0x000000010bc4648f Gaffer::Action::enact(boost::intrusive_ptr<Gaffer::GraphComponent>, std::__1::function<void ()> const&, std::__1::function<void ()> const&, bool) + 111
20  libGaffer.dylib               	0x000000010bceb93f Gaffer::Plug::setInput(boost::intrusive_ptr<Gaffer::Plug>, bool, bool) + 1871
21  libGaffer.dylib               	0x000000010bceb185 Gaffer::Plug::setInput(boost::intrusive_ptr<Gaffer::Plug>) + 53
22  libGaffer.dylib               	0x000000010bcdff87 Gaffer::Node::parentChanging(Gaffer::GraphComponent*) + 791
23  libGaffer.dylib               	0x000000010bca090d Gaffer::GraphComponent::~GraphComponent() + 93
24  libGafferSceneUI.dylib        	0x000000013931088e GafferSceneUI::ShaderView::~ShaderView() + 14
25  libGafferSceneUI.dylib        	0x00000001393162a0 boost::any::holder<boost::function<void ()> >::~holder() + 64
26  libboost_signals.dylib        	0x000000010bc2d6c7 std::__1::__tree<std::__1::__value_type<boost::signals::detail::stored_group, std::__1::list<boost::signals::detail::connection_slot_pair, std::__1::allocator<boost::signals::detail::connection_slot_pair> > >, std::__1::__map_value_compare<boost::signals::detail::stored_group, std::__1::__value_type<boost::signals::detail::stored_group, std::__1::list<boost::signals::detail::connection_slot_pair, std::__1::allocator<boost::signals::detail::connection_slot_pair> > >, boost::function2<bool, boost::signals::detail::stored_group, boost::signals::detail::stored_group>, false>, std::__1::allocator<std::__1::__value_type<boost::signals::detail::stored_group, std::__1::list<boost::signals::detail::connection_slot_pair, std::__1::allocator<boost::signals::detail::connection_slot_pair> > > > >::destroy(std::__1::__tree_node<std::__1::__value_type<boost::signals::detail::stored_group, std::__1::list<boost::signals::detail::connection_slot_pair, std::__1::allocator<boost::signals::detail::connection_slot_pair> > >, void*>*) + 135
27  libboost_signals.dylib        	0x000000010bc2d674 std::__1::__tree<std::__1::__value_type<boost::signals::detail::stored_group, std::__1::list<boost::signals::detail::connection_slot_pair, std::__1::allocator<boost::signals::detail::connection_slot_pair> > >, std::__1::__map_value_compare<boost::signals::detail::stored_group, std::__1::__value_type<boost::signals::detail::stored_group, std::__1::list<boost::signals::detail::connection_slot_pair, std::__1::allocator<boost::signals::detail::connection_slot_pair> > >, boost::function2<bool, boost::signals::detail::stored_group, boost::signals::detail::stored_group>, false>, std::__1::allocator<std::__1::__value_type<boost::signals::detail::stored_group, std::__1::list<boost::signals::detail::connection_slot_pair, std::__1::allocator<boost::signals::detail::connection_slot_pair> > > > >::destroy(std::__1::__tree_node<std::__1::__value_type<boost::signals::detail::stored_group, std::__1::list<boost::signals::detail::connection_slot_pair, std::__1::allocator<boost::signals::detail::connection_slot_pair> > >, void*>*) + 52
28  libboost_signals.dylib        	0x000000010bc2ffbf boost::detail::sp_counted_impl_p<boost::signals::detail::signal_base_impl>::dispose() + 47
29  libboost_signals.dylib        	0x000000010bc2fe4e boost::signals::detail::signal_base::~signal_base() + 30
30  libsystem_c.dylib             	0x00007fff5fb92ef2 __cxa_finalize_ranges + 351
31  libsystem_c.dylib             	0x00007fff5fb931de exit + 55
32  org.python.python             	0x00000001050d8de5 handle_system_exit + 341
33  org.python.python             	0x00000001050d89d9 PyErr_PrintEx + 41
34  org.python.python             	0x00000001050d823f PyRun_SimpleFileExFlags + 687
35  org.python.python             	0x00000001050f065f Py_Main + 3279
36  libdyld.dylib                 	0x00007fff5fae9ed9 start + 1
```
