### PR TITLE
CatalogueUI : Configurable columns

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,9 @@ API
 - NodeUI : Deprecated `setReadOnly()` and `getReadOnly()` methods.
 - PlugValueWidget : Deprecated `setReadOnly()` and `getReadOnly()` methods.
 - CatalogueUI : Added column configuration API (#3646).
+- PathListingWidget :
+	- Added `sortable` kwarg to avoid premature sorting of the path passed to the constructor (#3684).
+	- Deprecated `setSortable` and `getSortable` in favour of the constructor argument.
 
 0.56.1.0 (relative to 0.56.0.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,7 @@ API
 - NodeEditor : Deprecated `setReadOnly()` and `getReadOnly()` methods.
 - NodeUI : Deprecated `setReadOnly()` and `getReadOnly()` methods.
 - PlugValueWidget : Deprecated `setReadOnly()` and `getReadOnly()` methods.
+- CatalogueUI : Added column configuration API (#3646).
 
 0.56.1.0 (relative to 0.56.0.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - Viewer : Added visualisation support for Arnold shader networks connected to light gobos (#3667).
+- Catalogue : Added column to help identify the nature of each image (#3646)
 
 Fixes
 -----

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -430,10 +430,10 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 			self.__pathListing = GafferUI.PathListingWidget(
 				_ImagesPath( self.__images(), [] ),
 				columns = columns,
-				allowMultipleSelection = True
+				allowMultipleSelection = True,
+				sortable = False
 			)
 			self.__pathListing.setDragPointer( "" )
-			self.__pathListing.setSortable( False )
 			self.__pathListing.setHeaderVisible( len(columns) >  1 )
 			self.__pathListing.selectionChangedSignal().connect(
 				Gaffer.WeakMethod( self.__pathListingSelectionChanged ), scoped = False

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -372,6 +372,7 @@ class _ImagesPath( Gaffer.Path ) :
 
 		self.__childAddedConnection = self.__images.childAddedSignal().connect( Gaffer.WeakMethod( self.__childAdded ) )
 		self.__childRemovedConnection = self.__images.childRemovedSignal().connect( Gaffer.WeakMethod( self.__childRemoved ) )
+		self.__cataloguePlugDirtiedConnection = self.__catalogue.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__cataloguePlugDirtied ) )
 		self.__nameChangedConnections = {
 			image : image.nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ) )
 			for image in self.__images
@@ -398,6 +399,11 @@ class _ImagesPath( Gaffer.Path ) :
 	def __nameChanged( self, child ) :
 
 		self._emitPathChanged()
+
+	def __cataloguePlugDirtied( self, plug ):
+
+		if plug.ancestor( GafferImage.Catalogue.Image ) :
+			self._emitPathChanged()
 
 ##########################################################################
 # _ImageListing

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -490,6 +490,13 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 
 		self._updateFromPlug()
 
+	def getToolTip( self ) :
+
+		# Suppress the default imageIndex tool-tip until we can do something
+		# more intelligent. We can't use setToolTip as PlugValueWidget defaults
+		# to the plug description for 'falsy' values.
+		return None
+
 	def _updateFromPlug( self ) :
 
 		with self.getContext() :

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -103,13 +103,19 @@ def registeredColumns() :
 
 	return __registeredColumns.keys()
 
+#
 # Standard Columns
+#
 
+def __typeIconColumnValueProvider( image, catalogue ) :
+	return "catalogueTypeDisk" if image["fileName"].getValue() else "catalogueTypeDisplay"
+
+registerColumn( "typeIcon", "", __typeIconColumnValueProvider, ColumnType.Icon )
 registerColumn( "name", "Name", lambda image, _ : image.getName() )
 
 Gaffer.Metadata.registerValue(
 	GafferImage.Catalogue, "catalogue:columns",
-	IECore.StringVectorData( [ "name" ] )
+	IECore.StringVectorData( [ "typeIcon", "name" ] )
 )
 
 ##########################################################################

--- a/python/GafferImageUITest/CatalogueUITest.py
+++ b/python/GafferImageUITest/CatalogueUITest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -15,7 +15,7 @@
 #        disclaimer in the documentation and/or other materials provided with
 #        the distribution.
 #
-#      * Neither the name of John Haddon nor the names of
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
 #        any other contributors to this software may be used to endorse or
 #        promote products derived from this software without specific prior
 #        written permission.
@@ -34,11 +34,38 @@
 #
 ##########################################################################
 
-from FormatPlugValueWidgetTest import FormatPlugValueWidgetTest
-from ImageViewTest import ImageViewTest
-from DocumentationTest import DocumentationTest
-from ImageGadgetTest import ImageGadgetTest
-from CatalogueUITest import CatalogueUITest
+import Gaffer
+import GafferImage
+import GafferUI
+import GafferUITest
+
+from GafferImageUI import CatalogueUI
+
+import IECore
+
+class CatalogueUITest( GafferUITest.TestCase ) :
+
+	def testStandardColumns( self ) :
+
+		self.assertEqual( CatalogueUI.registeredColumns(), [ "name" ] )
+
+		c = GafferImage.Catalogue()
+		self.assertEqual( Gaffer.Metadata.value( c, "catalogue:columns" ), IECore.StringVectorData( [ "name" ] ) )
+
+	def testBoxedCatalogue( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+		s["b"]["c"] = GafferImage.Catalogue()
+
+		# 'images' is required to for serialisation if the
+		# catalogue is inside a reference/extension.
+		Gaffer.PlugAlgo.promote( s["b"]["c"]["images"] )
+		Gaffer.PlugAlgo.promote( s["b"]["c"]["imageIndex"] )
+
+		sw = GafferUI.ScriptWindow.acquire( s )
+		ne = GafferUI.NodeEditor.acquire( s["b"] )
 
 if __name__ == "__main__":
 	unittest.main()
+

--- a/python/GafferImageUITest/CatalogueUITest.py
+++ b/python/GafferImageUITest/CatalogueUITest.py
@@ -47,10 +47,13 @@ class CatalogueUITest( GafferUITest.TestCase ) :
 
 	def testStandardColumns( self ) :
 
-		self.assertEqual( CatalogueUI.registeredColumns(), [ "name" ] )
+		self.assertEqual( CatalogueUI.registeredColumns(), [ "typeIcon", "name" ] )
 
 		c = GafferImage.Catalogue()
-		self.assertEqual( Gaffer.Metadata.value( c, "catalogue:columns" ), IECore.StringVectorData( [ "name" ] ) )
+		self.assertEqual(
+			Gaffer.Metadata.value( c, "catalogue:columns" ),
+			IECore.StringVectorData( [ "typeIcon", "name" ] )
+		)
 
 	def testBoxedCatalogue( self ) :
 

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -91,6 +91,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		columns = defaultFileSystemColumns,
 		allowMultipleSelection = False,
 		displayMode = DisplayMode.List,
+		sortable = True,
 		**kw
 	) :
 
@@ -107,7 +108,7 @@ class PathListingWidget( GafferUI.Widget ) :
 			self._qtWidget().header().setMovable( False )
 
 		self._qtWidget().header().setSortIndicator( 0, QtCore.Qt.AscendingOrder )
-		self._qtWidget().setSortingEnabled( True )
+		self._qtWidget().setSortingEnabled( sortable )
 
 		self._qtWidget().expansionChanged.connect( Gaffer.WeakMethod( self.__expansionChanged ) )
 
@@ -280,6 +281,7 @@ class PathListingWidget( GafferUI.Widget ) :
 
 		return not self._qtWidget().header().isHidden()
 
+	## \deprecated Use constructor argument instead.
 	def setSortable( self, sortable ) :
 
 		if sortable == self.getSortable() :
@@ -289,6 +291,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		if not sortable :
 			self._qtWidget().model().sort( -1 )
 
+	## \deprecated
 	def getSortable( self ) :
 
 		return self._qtWidget().isSortingEnabled()

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -5072,5 +5072,38 @@
        cx="-4.9705095"
        id="ellipse1573"
        style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <g
+       id="forExport:catalogueTypeDisk"
+       inkscape:label="#catalogTypeDisk">
+      <path
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
+         d="m 353.5,105.86218 h -3.99999 l -5,5.5 v 5.5 H 353.5 Z"
+         id="path2400"
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path2402"
+         d="m 349.37502,105.98718 v 5.375 h -4.87501"
+         style="fill:none;stroke:#3c3c3c;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <g
+       id="forExport:catalogueTypeDisplay"
+       transform="translate(-0.87501,-0.124997)"
+       inkscape:label="#catalogueTypeDisplay">
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc"
+         id="path2408"
+         d="m 367.375,105.98718 h -3.99999 l -5,5.5 v 5.5 h 8.99999 z"
+         style="fill:#9e9e9e;fill-opacity:0.39215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0.1;stroke-opacity:1"
+         d="m 363.37501,105.98718 v 5.375 H 358.5"
+         id="path2410"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+    </g>
   </g>
 </svg>

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -21,6 +21,30 @@
   <defs
      id="defs4">
     <linearGradient
+       id="linearGradient1643"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#9e9e9e;stop-opacity:1;"
+         offset="0"
+         id="stop1641" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1637"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#9e9e9e;stop-opacity:1;"
+         offset="0"
+         id="stop1635" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1631"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#9e9e9e;stop-opacity:1;"
+         offset="0"
+         id="stop1629" />
+    </linearGradient>
+    <linearGradient
        id="linearGradient1650"
        osb:paint="solid">
       <stop
@@ -749,6 +773,39 @@
        y1="226.47861"
        x2="159.22701"
        y2="226.47861" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLight"
+       id="linearGradient1627"
+       gradientTransform="matrix(0.65385227,0,0,0.89517676,86.4607,15.307204)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLight"
+       id="linearGradient1633"
+       x1="357.87421"
+       y1="111.48718"
+       x2="367.87579"
+       y2="111.48718"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLight"
+       id="linearGradient1639"
+       x1="414.27768"
+       y1="119.29751"
+       x2="427.59329"
+       y2="119.29751"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLight"
+       id="linearGradient1645"
+       x1="414"
+       y1="101.86218"
+       x2="427.18359"
+       y2="101.86218"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -757,18 +814,18 @@
      borderopacity="1"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="5.12"
-     inkscape:cx="296.22304"
-     inkscape:cy="700.95812"
+     inkscape:zoom="11.313708"
+     inkscape:cx="386.74433"
+     inkscape:cy="929.60055"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:window-width="1501"
-     inkscape:window-height="1091"
-     inkscape:window-x="212"
-     inkscape:window-y="34"
+     inkscape:window-height="1036"
+     inkscape:window-x="444"
+     inkscape:window-y="62"
      inkscape:window-maximized="0"
-     inkscape:snap-global="false"
+     inkscape:snap-global="true"
      inkscape:snap-nodes="true"
      inkscape:snap-bbox="true"
      inkscape:object-nodes="true"
@@ -5076,7 +5133,7 @@
        id="forExport:catalogueTypeDisk"
        inkscape:label="#catalogTypeDisk">
       <path
-         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
+         style="fill:url(#linearGradient1627);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
          d="m 353.5,105.86218 h -3.99999 l -5,5.5 v 5.5 H 353.5 Z"
          id="path2400"
          sodipodi:nodetypes="cccccc"
@@ -5097,13 +5154,39 @@
          sodipodi:nodetypes="cccccc"
          id="path2408"
          d="m 367.375,105.98718 h -3.99999 l -5,5.5 v 5.5 h 8.99999 z"
-         style="fill:#9e9e9e;fill-opacity:0.39215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1" />
+         style="fill:url(#linearGradient1633);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1.00157475, 2.00314951;stroke-dashoffset:0;stroke-opacity:1" />
       <path
-         style="fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0.1;stroke-opacity:1"
+         style="fill:none;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.00314951, 1.00157475;stroke-dashoffset:1.10173225;stroke-opacity:1"
          d="m 363.37501,105.98718 v 5.375 H 358.5"
          id="path2410"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccc" />
     </g>
+    <path
+       sodipodi:nodetypes="ccccccccccc"
+       inkscape:connector-curvature="0"
+       id="forExport:catalogueTypeBatchRenderComplete"
+       d="m 425,98.362183 v 2.999997 h -3.4 -6.1 v 1 h 6.1 c 1.10962,-10e-5 3.4,0 3.4,0 v 3 h 1.18359 v -6.999997 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1645);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke markers fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       inkscape:label="#path24667" />
+    <path
+       inkscape:label="#path24667"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke markers fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 407,98.362183 v 2.999997 h -0.15 l -3.25,-1.999997 v 1.999997 h -6.1 v 1 h 6.1 v 2 l 3.25,-2 H 407 v 3 h 1.18359 v -6.999997 z"
+       id="forExport:catalogueTypeBatchRenderRunning"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       id="forExport:catalogueTypeInteractiveRenderComplete"
+       d="m 423.73483,114.37685 c -2.1616,-1.22715 -4.96606,-0.92558 -6.8059,0.91426 -1.83984,1.83984 -2.1411,4.64399 -0.91426,6.80591 l 0.99436,-0.99437 c -0.7383,-1.6005 -0.46097,-3.54689 0.86179,-4.86964 1.32276,-1.32276 3.26952,-1.60047 4.86965,-0.86179 z m 2.12132,2.12132 -0.99436,0.99437 c 0.73867,1.60012 0.46097,3.54688 -0.86179,4.86964 -1.32276,1.32276 -3.26915,1.60009 -4.86965,0.86179 l -0.99436,0.99437 c 2.16192,1.22683 4.96606,0.92558 6.8059,-0.91427 1.83984,-1.83984 2.14141,-4.6443 0.91426,-6.8059 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1639);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       inkscape:label="#path1610" />
+    <path
+       id="forExport:catalogueTypeInteractiveRenderRunning"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 400.13599,124.21833 c 2.1616,1.22715 4.96606,0.92558 6.8059,-0.91426 1.83984,-1.83984 2.1411,-4.64399 0.91426,-6.80591 l -0.99436,0.99437 c 0.7383,1.6005 0.46097,3.54689 -0.86179,4.86964 -0.62513,0.62513 -1.38963,1.01685 -2.19105,1.17819 -0.14351,0.0289 -0.87354,-1.74277 -0.87354,-1.74277 0,0 -1.61537,1.23668 -2.79942,2.42074 z m 5.59884,-9.84148 c -2.1616,-1.22715 -4.96606,-0.92558 -6.8059,0.91426 -1.83984,1.83984 -2.1411,4.64399 -0.91426,6.80591 l 0.99436,-0.99437 c -0.7383,-1.6005 -0.46097,-3.54689 0.86179,-4.86964 0.62513,-0.62513 1.38963,-1.01685 2.19105,-1.17819 0.14351,-0.0289 0.87354,1.74277 0.87354,1.74277 0,0 1.61537,-1.23668 2.79942,-2.42074 z"
+       inkscape:connector-curvature="0"
+       inkscape:label="#path1624" />
   </g>
 </svg>

--- a/startup/GafferSceneUI/catalogue.py
+++ b/startup/GafferSceneUI/catalogue.py
@@ -1,0 +1,74 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import GafferImageUI
+import GafferScene
+
+from GafferImageUI import CatalogueUI
+
+# We provide extended info in the Catalogue's type column
+# to reflect interactive/batch renders triggered from the UI.
+
+imageNameMap = {
+	GafferScene.InteractiveRender : "catalogueTypeInteractiveRender",
+	GafferScene.Render : "catalogueTypeBatchRender",
+}
+
+typeIconColumnDefinition = CatalogueUI.columnDefinition( "typeIcon" )
+if typeIconColumnDefinition :
+
+	def typeIconColumnValueProvider( image, catalogue ):
+
+		iconName = typeIconColumnDefinition.valueProvider( image, catalogue )
+
+		scenePlug = GafferScene.SceneAlgo.sourceScene( catalogue["out"] )
+		if not scenePlug :
+			return iconName
+
+		for type_ in imageNameMap.keys() :
+			if isinstance( scenePlug.node(), type_ ) :
+				suffix = "Complete" if image["fileName"].getValue() else "Running"
+				return imageNameMap[type_] + suffix
+
+		return iconName
+
+	CatalogueUI.registerColumn(
+		"typeIcon",
+		typeIconColumnDefinition.title,
+		typeIconColumnValueProvider,
+		CatalogueUI.ColumnType.Icon
+	)


### PR DESCRIPTION
As part of #3646, this PR moves the Catalogue UI to support fully configurable columns. At present, this is limited to startup configuration with no UI. This will follow in a future commit. https://github.com/GafferHQ/gaffer/commit/d3c83105a7c3e9478602119f9d30ee531875a1f5 illustrates how an existing column can be extended/overridden. Using this mechanism, it should be possible for a facility to completely customise any of the columns as required, whilst providing meaningful base functionality in stock Gaffer.

I'm sure this will ultimately turn into a long discussion about icons, it'd be great if we could initially focus on the implementation/API, so we can that stabilise.