### PR TITLE
NodeSetEditor : Fix keyboard shortcuts

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,7 @@ Fixes
 - Backdrop : Fixed bug that prevented context variables from being used by the `title` and `description` plugs. All variables from the global script context are now available.
 - Box : Fixed bug that allowed locked plugs to be promoted.
 - TransformTools : Fixed rare crash triggered by selecting multiple objects.
+- Floating Editors : Fixed keyboard shortcuts (#3632).
 
 0.55.5.1 (relative to 0.55.5.0)
 ========

--- a/python/GafferUI/NodeSetEditor.py
+++ b/python/GafferUI/NodeSetEditor.py
@@ -325,6 +325,8 @@ class NodeSetEditor( GafferUI.Editor ) :
 			scriptWindow.getLayout().addEditor( editor )
 		else :
 			window = _EditorWindow( scriptWindow, editor )
+			# Ensure keyboard shortcuts are relayed to the main menu bar
+			scriptWindow.menuBar().addShortcutTarget( window )
 			## \todo Can we do better using `window.resizeToFitChild()`?
 			# Our problem is that some NodeEditors (for GafferImage.Text for instance)
 			# are very large, whereas some (GafferScene.Shader) don't have


### PR DESCRIPTION
Fixes #3632 - the floating window was missing the menu bar shortcut listener.