### PR TITLE
ShuffleAttributes : Fix filter default

### DIFF
--- a/python/GafferSceneTest/ShuffleAttributesTest.py
+++ b/python/GafferSceneTest/ShuffleAttributesTest.py
@@ -240,5 +240,10 @@ class ShuffleAttributesTest( GafferSceneTest.SceneTestCase ) :
 		s3.execute( s2.serialise() )
 		self.assertPromotedAttribute( s3 )
 
+	def testFilterDefault( self ) :
+
+		s = GafferScene.ShuffleAttributes()
+		self.assertEqual( s["filter"].defaultValue(), IECore.PathMatcher.Result.NoMatch )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/ShuffleAttributes.cpp
+++ b/src/GafferScene/ShuffleAttributes.cpp
@@ -44,7 +44,8 @@ GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( ShuffleAttributes );
 
 size_t ShuffleAttributes::g_firstPlugIndex = 0;
 
-ShuffleAttributes::ShuffleAttributes( const std::string &name ) : SceneElementProcessor( name )
+ShuffleAttributes::ShuffleAttributes( const std::string &name )
+	:	SceneElementProcessor( name, PathMatcher::NoMatch )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new ShufflesPlug( "shuffles" ) );


### PR DESCRIPTION
The SceneElementProcessor defaults to matching everything, but that is a historical error which needs to be corrected in all new derived classes.
