### PR TITLE
AttributesProcessor : Refactor to actually be useful

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -40,6 +40,15 @@ Breaking Changes
   - Removed `names` and `invertNames` plugs.
   - Rederived from FilteredSceneProcessor rather than SceneElementProcessor.
   - Added new pure virtual methods that must be implemented by derived classes.
+  - Changed base class of several nodes from SceneElementProcessor to AttributeProcessor :
+    - Attributes
+    - ShuffleAttributes
+    - DeleteAttributes
+    - ShaderTweaks
+    - ShaderAssignment
+    - SetVisualiser
+    - AttributeVisualiser
+    - CollectTransforms
 - Context : Removed `Substitutions`, `substitutions()` and `hasSubstitutions()`. Use the `IECore.StringAlgo` equivalents instead.
 - TransformTool : The `Selection` class now uses accessor methods rather than exposing data members directly.
 - Stats app : The `-scene` and `-image` arguments now ignore input plugs.

--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ API
 - ScenePlug : Added `exists()` method. This provides fast existence queries for locations.
 - SceneAlgo : Deprecated `exists()` function. Use `ScenePlug::exists()` instead
 - Spreadsheet : Added `RowsPlug::row( rowName )` method.
+- AttributeProcessor : Refactored to be more widely useful.
 - TransformTool :
   - Added `Selection::editable()` method.
   - Added `Selection::warning()` method.
@@ -35,6 +36,10 @@ API
 Breaking Changes
 ----------------
 
+- AttributeProcessor :
+  - Removed `names` and `invertNames` plugs.
+  - Rederived from FilteredSceneProcessor rather than SceneElementProcessor.
+  - Added new pure virtual methods that must be implemented by derived classes.
 - Context : Removed `Substitutions`, `substitutions()` and `hasSubstitutions()`. Use the `IECore.StringAlgo` equivalents instead.
 - TransformTool : The `Selection` class now uses accessor methods rather than exposing data members directly.
 - Stats app : The `-scene` and `-image` arguments now ignore input plugs.

--- a/include/GafferScene/AttributeProcessor.h
+++ b/include/GafferScene/AttributeProcessor.h
@@ -70,8 +70,10 @@ class GAFFERSCENE_API AttributeProcessor : public FilteredSceneProcessor
 		virtual bool affectsProcessedAttributes( const Gaffer::Plug *input ) const = 0;
 		/// Must be implemented by derived classes to do one of the following :
 		///
-		/// - Call `AttributeProcessor::hashProcessedAttributes()` and then append to the hash with all plugs used in `computeProcessedAttributes()`.
-		/// - Assign `h = inPlug()->attributesPlug()->hash()` to signify that `computeProcessedAttributes()` will pass through `inputAttributes`
+		/// - Call `AttributeProcessor::hashProcessedAttributes()` and then append to the hash
+		///   with all plugs used in `computeProcessedAttributes()`.
+		/// - Assign `h = inPlug()->attributesPlug()->hash()` to signify that
+		///   `computeProcessedAttributes()` will pass through `inputAttributes`
 		///   unchanged.
 		virtual void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
 		/// Must be implemented by derived classes to return the processed attributes.

--- a/include/GafferScene/AttributeProcessor.h
+++ b/include/GafferScene/AttributeProcessor.h
@@ -37,51 +37,58 @@
 #ifndef GAFFERSCENE_ATTRIBUTEPROCESSOR_H
 #define GAFFERSCENE_ATTRIBUTEPROCESSOR_H
 
-#include "GafferScene/SceneElementProcessor.h"
-
-namespace Gaffer
-{
-
-IE_CORE_FORWARDDECLARE( StringPlug )
-
-} // namespace Gaffer
+#include "GafferScene/FilteredSceneProcessor.h"
 
 namespace GafferScene
 {
 
-/// The AttributeProcessor base class simplifies the process of manipulating
-/// attributes.
-class GAFFERSCENE_API AttributeProcessor : public SceneElementProcessor
+/// Base class for nodes which manipulate attributes in some way.
+class GAFFERSCENE_API AttributeProcessor : public FilteredSceneProcessor
 {
 
 	public :
 
-		AttributeProcessor( const std::string &name=defaultName<AttributeProcessor>() );
 		~AttributeProcessor() override;
 
-		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::AttributeProcessor, AttributeProcessorTypeId, SceneElementProcessor );
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::AttributeProcessor, AttributeProcessorTypeId, FilteredSceneProcessor );
 
-		Gaffer::StringPlug *namesPlug();
-		const Gaffer::StringPlug *namesPlug() const;
-
-		Gaffer::BoolPlug *invertNamesPlug();
-		const Gaffer::BoolPlug *invertNamesPlug() const;
-
-		/// Implemented so that namesPlug() affects outPlug()->attributesPlug().
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
-		bool processesAttributes() const override;
-		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const override;
+		/// Constructs with a single input ScenePlug named "in". Use inPlug()
+		/// to access this plug.
+		AttributeProcessor( const std::string &name );
+		/// Constructs with an ArrayPlug called "in". Use inPlug() as a
+		/// convenience for accessing the first child in the array, and use
+		/// inPlugs() to access the array itself.
+		AttributeProcessor( const std::string &name, size_t minInputs, size_t maxInputs = Imath::limits<size_t>::max() );
 
-		/// Must be implemented by subclasses to process the attribute.
-		virtual IECore::ConstObjectPtr processAttribute( const ScenePath &path, const Gaffer::Context *context, const IECore::InternedString &attributeName, const IECore::Object *inputAttribute ) const = 0;
+		/// Must be implemented by derived classes to return true if `input` is used
+		/// by `computeProcessedAttributes()`. Overrides must start by calling the base
+		/// class first, and return true if it returns true.
+		virtual bool affectsProcessedAttributes( const Gaffer::Plug *input ) const = 0;
+		/// Must be implemented by derived classes to do one of the following :
+		///
+		/// - Call `AttributeProcessor::hashProcessedAttributes()` and then append to the hash with all plugs used in `computeProcessedAttributes()`.
+		/// - Assign `h = inPlug()->attributesPlug()->hash()` to signify that `computeProcessedAttributes()` will pass through `inputAttributes`
+		///   unchanged.
+		virtual void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
+		/// Must be implemented by derived classes to return the processed attributes.
+		virtual IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const = 0;
 
 	private :
 
-		static size_t g_firstPlugIndex;
+		void init();
+
+		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const final;
+		IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const final;
+
+		/// Private constructor and friendship for old nodes which are filtered to everything
+		/// by default. This was a mistake, and we want to ensure that we don't repeat the mistake
+		/// for new nodes.
+		AttributeProcessor( const std::string &name, IECore::PathMatcher::Result filterDefault );
+		friend class DeleteAttributes;
 
 };
 

--- a/include/GafferScene/AttributeProcessor.h
+++ b/include/GafferScene/AttributeProcessor.h
@@ -89,6 +89,9 @@ class GAFFERSCENE_API AttributeProcessor : public FilteredSceneProcessor
 		/// for new nodes.
 		AttributeProcessor( const std::string &name, IECore::PathMatcher::Result filterDefault );
 		friend class DeleteAttributes;
+		friend class ShaderAssignment;
+		friend class Attributes;
+		friend class AttributeVisualiser;
 
 };
 

--- a/include/GafferScene/AttributeVisualiser.h
+++ b/include/GafferScene/AttributeVisualiser.h
@@ -37,7 +37,7 @@
 #ifndef GAFFERSCENE_ATTRIBUTEVISUALISER_H
 #define GAFFERSCENE_ATTRIBUTEVISUALISER_H
 
-#include "GafferScene/SceneElementProcessor.h"
+#include "GafferScene/AttributeProcessor.h"
 
 #include "Gaffer/NumericPlug.h"
 #include "Gaffer/SplinePlug.h"
@@ -52,7 +52,7 @@ IE_CORE_FORWARDDECLARE( StringPlug )
 namespace GafferScene
 {
 
-class GAFFERSCENE_API AttributeVisualiser : public SceneElementProcessor
+class GAFFERSCENE_API AttributeVisualiser : public AttributeProcessor
 {
 
 	public :
@@ -60,7 +60,7 @@ class GAFFERSCENE_API AttributeVisualiser : public SceneElementProcessor
 		AttributeVisualiser( const std::string &name=defaultName<AttributeVisualiser>() );
 		~AttributeVisualiser() override;
 
-		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::AttributeVisualiser, AttributeVisualiserTypeId, SceneElementProcessor );
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::AttributeVisualiser, AttributeVisualiserTypeId, AttributeProcessor );
 
 		enum Mode
 		{
@@ -94,13 +94,11 @@ class GAFFERSCENE_API AttributeVisualiser : public SceneElementProcessor
 		Gaffer::StringPlug *shaderParameterPlug();
 		const Gaffer::StringPlug *shaderParameterPlug() const;
 
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
-
 	protected :
 
-		bool processesAttributes() const override;
+		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
 		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 	private :
 

--- a/include/GafferScene/Attributes.h
+++ b/include/GafferScene/Attributes.h
@@ -38,7 +38,7 @@
 #ifndef GAFFERSCENE_ATTRIBUTES_H
 #define GAFFERSCENE_ATTRIBUTES_H
 
-#include "GafferScene/SceneElementProcessor.h"
+#include "GafferScene/AttributeProcessor.h"
 
 #include "Gaffer/CompoundDataPlug.h"
 #include "Gaffer/TypedObjectPlug.h"
@@ -46,7 +46,7 @@
 namespace GafferScene
 {
 
-class GAFFERSCENE_API Attributes : public SceneElementProcessor
+class GAFFERSCENE_API Attributes : public AttributeProcessor
 {
 
 	public :
@@ -54,7 +54,7 @@ class GAFFERSCENE_API Attributes : public SceneElementProcessor
 		Attributes( const std::string &name=defaultName<Attributes>() );
 		~Attributes() override;
 
-		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::Attributes, AttributesTypeId, SceneElementProcessor );
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::Attributes, AttributesTypeId, AttributeProcessor );
 
 		Gaffer::CompoundDataPlug *attributesPlug();
 		const Gaffer::CompoundDataPlug *attributesPlug() const;
@@ -72,9 +72,9 @@ class GAFFERSCENE_API Attributes : public SceneElementProcessor
 		void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
-		bool processesAttributes() const override;
+		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
 		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 	private :
 

--- a/include/GafferScene/CollectTransforms.h
+++ b/include/GafferScene/CollectTransforms.h
@@ -37,7 +37,7 @@
 #ifndef GAFFERSCENE_COLLECTTRANSFORMS_H
 #define GAFFERSCENE_COLLECTTRANSFORMS_H
 
-#include "GafferScene/SceneElementProcessor.h"
+#include "GafferScene/AttributeProcessor.h"
 
 namespace Gaffer
 {
@@ -49,7 +49,7 @@ IE_CORE_FORWARDDECLARE( StringPlug )
 namespace GafferScene
 {
 
-class GAFFERSCENE_API CollectTransforms : public SceneElementProcessor
+class GAFFERSCENE_API CollectTransforms : public AttributeProcessor
 {
 
 	public :
@@ -57,7 +57,7 @@ class GAFFERSCENE_API CollectTransforms : public SceneElementProcessor
 		CollectTransforms( const std::string &name=defaultName<CollectTransforms>() );
 		~CollectTransforms() override;
 
-		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::CollectTransforms, CollectTransformsTypeId, SceneElementProcessor );
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::CollectTransforms, CollectTransformsTypeId, AttributeProcessor );
 
 		Gaffer::StringVectorDataPlug *attributesPlug();
 		const Gaffer::StringVectorDataPlug *attributesPlug() const;
@@ -77,13 +77,13 @@ class GAFFERSCENE_API CollectTransforms : public SceneElementProcessor
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
+
 		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-
-		bool processesAttributes() const override;
+		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
 		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputObject ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 	private :
 

--- a/include/GafferScene/DeleteAttributes.h
+++ b/include/GafferScene/DeleteAttributes.h
@@ -39,6 +39,8 @@
 
 #include "GafferScene/AttributeProcessor.h"
 
+#include "Gaffer/StringPlug.h"
+
 namespace GafferScene
 {
 
@@ -52,9 +54,21 @@ class GAFFERSCENE_API DeleteAttributes : public AttributeProcessor
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::DeleteAttributes, DeleteAttributesTypeId, AttributeProcessor );
 
+		Gaffer::StringPlug *namesPlug();
+		const Gaffer::StringPlug *namesPlug() const;
+
+		Gaffer::BoolPlug *invertNamesPlug();
+		const Gaffer::BoolPlug *invertNamesPlug() const;
+
 	protected :
 
-		IECore::ConstObjectPtr processAttribute( const ScenePath &path, const Gaffer::Context *context, const IECore::InternedString &attributeName, const IECore::Object *inputAttribute ) const override;
+		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
+		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
 
 };
 

--- a/include/GafferScene/SetVisualiser.h
+++ b/include/GafferScene/SetVisualiser.h
@@ -37,7 +37,7 @@
 #ifndef GAFFERSCENE_SETVISUALISER_H
 #define GAFFERSCENE_SETVISUALISER_H
 
-#include "GafferScene/SceneElementProcessor.h"
+#include "GafferScene/AttributeProcessor.h"
 
 #include "Gaffer/NumericPlug.h"
 
@@ -60,7 +60,7 @@ namespace GafferScene
 /// display. This allows more efficient hashing/compute without the need for
 /// any internal state management, as well as permitting informative UIs that
 /// help the user understand the resultant color mappings.
-class GAFFERSCENE_API SetVisualiser : public SceneElementProcessor
+class GAFFERSCENE_API SetVisualiser : public AttributeProcessor
 {
 
 	public :
@@ -68,7 +68,7 @@ class GAFFERSCENE_API SetVisualiser : public SceneElementProcessor
 		SetVisualiser( const std::string &name=defaultName<SetVisualiser>() );
 		~SetVisualiser() override;
 
-		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::SetVisualiser, SetVisualiserTypeId, SceneElementProcessor );
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::SetVisualiser, SetVisualiserTypeId, AttributeProcessor );
 
 		Gaffer::StringPlug *setsPlug();
 		const Gaffer::StringPlug *setsPlug() const;
@@ -89,9 +89,9 @@ class GAFFERSCENE_API SetVisualiser : public SceneElementProcessor
 		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-		bool processesAttributes() const override;
+		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
 		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 	private :
 

--- a/include/GafferScene/ShaderAssignment.h
+++ b/include/GafferScene/ShaderAssignment.h
@@ -38,13 +38,13 @@
 #ifndef GAFFERSCENE_SHADERASSIGNMENT_H
 #define GAFFERSCENE_SHADERASSIGNMENT_H
 
-#include "GafferScene/SceneElementProcessor.h"
+#include "GafferScene/AttributeProcessor.h"
 #include "GafferScene/ShaderPlug.h"
 
 namespace GafferScene
 {
 
-class GAFFERSCENE_API ShaderAssignment : public SceneElementProcessor
+class GAFFERSCENE_API ShaderAssignment : public AttributeProcessor
 {
 
 	public :
@@ -52,18 +52,16 @@ class GAFFERSCENE_API ShaderAssignment : public SceneElementProcessor
 		ShaderAssignment( const std::string &name=defaultName<ShaderAssignment>() );
 		~ShaderAssignment() override;
 
-		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::ShaderAssignment, ShaderAssignmentTypeId, SceneElementProcessor );
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::ShaderAssignment, ShaderAssignmentTypeId, AttributeProcessor );
 
 		GafferScene::ShaderPlug *shaderPlug();
 		const GafferScene::ShaderPlug *shaderPlug() const;
 
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
-
 	protected :
 
-		bool processesAttributes() const override;
+		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
 		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 	private :
 

--- a/include/GafferScene/ShaderTweaks.h
+++ b/include/GafferScene/ShaderTweaks.h
@@ -37,7 +37,7 @@
 #ifndef GAFFERSCENE_SHADERTWEAKS_H
 #define GAFFERSCENE_SHADERTWEAKS_H
 
-#include "GafferScene/SceneElementProcessor.h"
+#include "GafferScene/AttributeProcessor.h"
 #include "GafferScene/TweakPlug.h"
 
 #include "Gaffer/StringPlug.h"
@@ -45,7 +45,7 @@
 namespace GafferScene
 {
 
-class GAFFERSCENE_API ShaderTweaks : public SceneElementProcessor
+class GAFFERSCENE_API ShaderTweaks : public AttributeProcessor
 {
 
 	public :
@@ -53,7 +53,7 @@ class GAFFERSCENE_API ShaderTweaks : public SceneElementProcessor
 		ShaderTweaks( const std::string &name=defaultName<ShaderTweaks>() );
 		~ShaderTweaks() override;
 
-		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::ShaderTweaks, ShaderTweaksTypeId, SceneElementProcessor );
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::ShaderTweaks, ShaderTweaksTypeId, AttributeProcessor );
 
 		Gaffer::StringPlug *shaderPlug();
 		const Gaffer::StringPlug *shaderPlug() const;
@@ -64,13 +64,11 @@ class GAFFERSCENE_API ShaderTweaks : public SceneElementProcessor
 		GafferScene::TweaksPlug *tweaksPlug();
 		const GafferScene::TweaksPlug *tweaksPlug() const;
 
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
-
 	protected :
 
-		bool processesAttributes() const override;
+		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
 		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferScene/ShuffleAttributes.h
+++ b/include/GafferScene/ShuffleAttributes.h
@@ -37,14 +37,14 @@
 #ifndef GAFFERSCENE_SHUFFLEATTRIBUTES_H
 #define GAFFERSCENE_SHUFFLEATTRIBUTES_H
 
-#include "GafferScene/SceneElementProcessor.h"
+#include "GafferScene/AttributeProcessor.h"
 
 #include "Gaffer/ShufflePlug.h"
 
 namespace GafferScene
 {
 
-class GAFFERSCENE_API ShuffleAttributes : public SceneElementProcessor
+class GAFFERSCENE_API ShuffleAttributes : public AttributeProcessor
 {
 
 	public :
@@ -52,18 +52,16 @@ class GAFFERSCENE_API ShuffleAttributes : public SceneElementProcessor
 		ShuffleAttributes( const std::string &name=defaultName<ShuffleAttributes>() );
 		~ShuffleAttributes() override;
 
-		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::ShuffleAttributes, ShuffleAttributesTypeId, SceneElementProcessor );
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::ShuffleAttributes, ShuffleAttributesTypeId, AttributeProcessor );
 
 		Gaffer::ShufflesPlug *shufflesPlug();
 		const Gaffer::ShufflesPlug *shufflesPlug() const;
 
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
-
 	protected :
 
-		bool processesAttributes() const override;
+		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
 		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputAttributes ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 	private :
 

--- a/src/GafferSceneModule/AttributesBinding.cpp
+++ b/src/GafferSceneModule/AttributesBinding.cpp
@@ -41,10 +41,12 @@
 #include "GafferScene/AttributeProcessor.h"
 #include "GafferScene/AttributeVisualiser.h"
 #include "GafferScene/Attributes.h"
+#include "GafferScene/CollectTransforms.h"
 #include "GafferScene/CopyAttributes.h"
 #include "GafferScene/CustomAttributes.h"
 #include "GafferScene/DeleteAttributes.h"
 #include "GafferScene/OpenGLAttributes.h"
+#include "GafferScene/SetVisualiser.h"
 #include "GafferScene/ShaderAssignment.h"
 #include "GafferScene/ShuffleAttributes.h"
 #include "GafferScene/StandardAttributes.h"
@@ -57,15 +59,17 @@ using namespace GafferScene;
 void GafferSceneModule::bindAttributes()
 {
 
+	GafferBindings::DependencyNodeClass<AttributeProcessor>();
 	GafferBindings::DependencyNodeClass<ShaderAssignment>();
 	GafferBindings::DependencyNodeClass<Attributes>();
 	GafferBindings::DependencyNodeClass<OpenGLAttributes>();
 	GafferBindings::DependencyNodeClass<StandardAttributes>();
 	GafferBindings::DependencyNodeClass<CustomAttributes>();
-	GafferBindings::DependencyNodeClass<AttributeProcessor>();
 	GafferBindings::DependencyNodeClass<DeleteAttributes>();
 	GafferBindings::DependencyNodeClass<CopyAttributes>();
 	GafferBindings::DependencyNodeClass<ShuffleAttributes>();
+	GafferBindings::DependencyNodeClass<SetVisualiser>();
+	GafferBindings::DependencyNodeClass<CollectTransforms>();
 
 	scope s = GafferBindings::DependencyNodeClass<AttributeVisualiser>();
 

--- a/src/GafferSceneModule/GlobalsBinding.cpp
+++ b/src/GafferSceneModule/GlobalsBinding.cpp
@@ -43,7 +43,6 @@
 #include "GafferScene/GlobalShader.h"
 #include "GafferScene/Outputs.h"
 #include "GafferScene/Set.h"
-#include "GafferScene/SetVisualiser.h"
 
 #include "GafferBindings/DependencyNodeBinding.h"
 
@@ -112,7 +111,6 @@ void GafferSceneModule::bindGlobals()
 			;
 	}
 
-	DependencyNodeClass<SetVisualiser>();
 	DependencyNodeClass<GlobalShader>();
 
 }

--- a/src/GafferSceneModule/TransformBinding.cpp
+++ b/src/GafferSceneModule/TransformBinding.cpp
@@ -44,7 +44,6 @@
 #include "GafferScene/ParentConstraint.h"
 #include "GafferScene/PointConstraint.h"
 #include "GafferScene/Transform.h"
-#include "GafferScene/CollectTransforms.h"
 
 #include "GafferBindings/ComputeNodeBinding.h"
 
@@ -104,7 +103,5 @@ void GafferSceneModule::bindTransform()
 			.value( "ResetWorld", Transform::ResetWorld )
 		;
 	}
-
-	GafferBindings::DependencyNodeClass<GafferScene::CollectTransforms>();
 
 }


### PR DESCRIPTION
We have a large number of nodes which process attributes, and only one of them - DeleteAttributes - fitted the pattern required by the AttributesProcessor base class. The refactoring here follows the patterns established by the ObjectProcessor base class, and should be much more widely useful.