### PR TITLE
FilteredSceneProcessor : Use "userDefault" to default filters to off

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 - CopyPrimitiveVariables : Improved performance. In one benchmark, scene generation time has been reduced by 50%.
 - MergeScenes : Improved performance when merging overlapping hierarchies.
 - Serialisation : Reduced file size and load time by omitting redundant `setInput()` calls from serialisations.
+- Scene node filters : All newly created nodes now require a filter to be connected before they will affect the scene. Previously some nodes affected everything by default and others affected nothing by default, resulting in confusion.
 
 Fixes
 -----

--- a/python/GafferSceneUI/FilteredSceneProcessorUI.py
+++ b/python/GafferSceneUI/FilteredSceneProcessorUI.py
@@ -74,6 +74,14 @@ Gaffer.Metadata.registerNode(
 			"nodule:type", "GafferUI::StandardNodule",
 			"plugValueWidget:type", "GafferSceneUI.FilterPlugValueWidget",
 
+			# Several of our older nodes default to affecting all
+			# locations if no filter is connected. This was a mistake,
+			# and one day we need to change the defaults and figure out
+			# how to convert old scripts during loading. Until then
+			# we use a `userDefault` so that nodes newly created via the
+			# UI will have the default behaviour we want.
+			"userDefault", IECore.PathMatcher.Result.NoMatch,
+
 		],
 
 	},


### PR DESCRIPTION
Due to historical errors, we have a mixture of behaviours for default-constructed FilteredSceneProcessors. Some affect the entire scene when no filter is connected, and others affect nothing. We wish to make this behaviour more predictable and less prone to unwanted processing by standardising everything to be off by default. Changing the default itself will be tricky because we'd need to do something to convert old files during loading. But we can at least make sure all newly created nodes behave predictably by using a `userDefault`.

The one downside I can see to this is that in a single file containing some previously-created nodes and some newly-created nodes, nodes that appear identical in the GraphEditor will behave differently. But taking the long view - and the lots-of-new-users-are-arriving-presently view - I think it's a definite win that all newly created nodes of any type will have consistent behaviour. Discuss.