### PR TITLE
ArnoldTextureBake : Simpler task allocation

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,7 @@ Fixes
 - Box : Fixed bug that allowed locked plugs to be promoted.
 - TransformTools : Fixed rare crash triggered by selecting multiple objects.
 - Floating Editors : Fixed keyboard shortcuts (#3632).
+- ArnoldTextureBake :  Fixed imbalanced distribution of work among tasks when some UDIMs contain many more objects than others.
 
 0.55.5.1 (relative to 0.55.5.0)
 ========


### PR DESCRIPTION
Instead of considering the number of objects that need baking, it just allocates tasks to UDIMs.  This could be a worse metric in certain corner cases where there are vast numbers of objects in one UDIM, but in general, UDIMs with more objects have objects that cover fewer pixels, so it works out OK.  This simpler metric gets rid of some weird results where tasks would be allocated badly in practical examples.