### PR TITLE
SceneAlgoBinding : Release GIL in `sourceScene*()` wrappers

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ Fixes
 - NodeEditor : Fixed bug that allowed the node name to be edited on a locked node.
 - InteractiveArnoldRender : Fixed problem that could potentially stop the main RGBA AOV from receiving priority for progressive updates.
 - TransformTools : Fixed rare crash triggered by selecting multiple objects.
+- SceneAlgo : Fixed bug which could cause hangs when retrieving the source scene from an image via Python.
 
 API
 ---

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -170,11 +170,13 @@ ShaderTweaksPtr shaderTweaksWrapper( const ScenePlug &scene, const ScenePlug::Sc
 
 std::string sourceSceneNameWrapper( const GafferImage::ImagePlug &image )
 {
+	IECorePython::ScopedGILRelease r;
 	return SceneAlgo::sourceSceneName( &image );
 }
 
 ScenePlugPtr sourceSceneWrapper( GafferImage::ImagePlug &image )
 {
+	IECorePython::ScopedGILRelease r;
 	return SceneAlgo::sourceScene( &image );
 }
 


### PR DESCRIPTION
Both `sourceScene()` and `sourceSceneName()` trigger a computation for the image metadata. We must always release the GIL before triggering a computation, as the computation could spawn threads which then try to reenter Python.

