### PR TITLE
EditScope status improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -39,6 +39,7 @@ API
 - TransformTool :
   - Added `Selection::editable()` method.
   - Added `Selection::warning()` method.
+  - Added `selectionEditable()` method.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,8 @@ Improvements
 Fixes
 -----
 
+- RotateTool : Fixed bug which caused aiming clicks to change the selection in some circumstances.
+- TranslateTool : Fixed bug which caused snapping clicks to change the selection in some circumstances.
 - Stats app :
   - Fixed bug which caused the `-scene` and `-image` arguments to evaluate a node's input rather than its output. In particular this affected nodes like ContextVariables.
   - Fixed bug which meant that the `-scene` and `image` arguments didn't support nested output plugs.

--- a/include/GafferSceneUI/TransformTool.h
+++ b/include/GafferSceneUI/TransformTool.h
@@ -189,7 +189,11 @@ class GAFFERSCENEUI_API TransformTool : public GafferSceneUI::SelectionTool
 
 		};
 
+		/// Returns the current selection.
 		const std::vector<Selection> &selection() const;
+		/// Returns true only if the selection is non-empty
+		/// and every item is editable.
+		bool selectionEditable() const;
 
 		using SelectionChangedSignal = boost::signal<void (TransformTool &)>;
 		SelectionChangedSignal &selectionChangedSignal();

--- a/src/GafferSceneUI/RotateTool.cpp
+++ b/src/GafferSceneUI/RotateTool.cpp
@@ -272,7 +272,7 @@ bool RotateTool::buttonPress( const GafferUI::ButtonEvent &event )
 	//
 	// We always return true to prevent the SelectTool defaults.
 
-	if( selection().size() == 0 )
+	if( !selectionEditable() )
 	{
 		return true;
 	}

--- a/src/GafferSceneUI/RotateTool.cpp
+++ b/src/GafferSceneUI/RotateTool.cpp
@@ -263,17 +263,19 @@ bool RotateTool::handleDragEnd()
 
 bool RotateTool::buttonPress( const GafferUI::ButtonEvent &event )
 {
-	if( event.buttons != ButtonEvent::Left
-		|| !activePlug()->getValue()
-		|| !getTargetedMode()
-		|| selection().size() == 0
-	) {
+	if( event.buttons != ButtonEvent::Left || !activePlug()->getValue() || !getTargetedMode() )
+	{
 		return false;
 	}
 
 	// In targeted mode, we orient the selection so -z aims towards the clicked point.
 	//
 	// We always return true to prevent the SelectTool defaults.
+
+	if( selection().size() == 0 )
+	{
+		return true;
+	}
 
 	GafferScene::ScenePlug::ScenePath _;
 	Imath::V3f targetPos;

--- a/src/GafferSceneUI/TranslateTool.cpp
+++ b/src/GafferSceneUI/TranslateTool.cpp
@@ -262,11 +262,8 @@ bool TranslateTool::handleDragEnd()
 
 bool TranslateTool::buttonPress( const GafferUI::ButtonEvent &event )
 {
-	if( event.buttons != ButtonEvent::Left
-		|| !activePlug()->getValue()
-		|| !getTargetedMode()
-		|| selection().size() == 0
-	) {
+	if( event.buttons != ButtonEvent::Left || !activePlug()->getValue() || !getTargetedMode() )
+	{
 		return false;
 	}
 
@@ -277,6 +274,11 @@ bool TranslateTool::buttonPress( const GafferUI::ButtonEvent &event )
 	// bounds should be used, so they retain their existing relative spacing.
 	//
 	// We always return true to prevent the SelectTool defaults.
+
+	if( selection().size() == 0 )
+	{
+		return true;
+	}
 
 	GafferScene::ScenePlug::ScenePath _;
 	Imath::V3f targetPos;

--- a/src/GafferSceneUI/TranslateTool.cpp
+++ b/src/GafferSceneUI/TranslateTool.cpp
@@ -275,7 +275,7 @@ bool TranslateTool::buttonPress( const GafferUI::ButtonEvent &event )
 	//
 	// We always return true to prevent the SelectTool defaults.
 
-	if( selection().size() == 0 )
+	if( !selectionEditable() )
 	{
 		return true;
 	}

--- a/src/GafferSceneUIModule/ToolBinding.cpp
+++ b/src/GafferSceneUIModule/ToolBinding.cpp
@@ -96,6 +96,12 @@ boost::python::list selection( const TransformTool &tool )
 	return result;
 }
 
+bool selectionEditable( const TransformTool &tool )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return tool.selectionEditable();
+}
+
 struct SelectionChangedSlotCaller
 {
 	boost::signals::detail::unusable operator()( boost::python::object slot, TransformTool &t )
@@ -177,6 +183,7 @@ void GafferSceneUIModule::bindTools()
 	{
 		scope s = GafferBindings::NodeClass<TransformTool>( nullptr, no_init )
 			.def( "selection", &selection )
+			.def( "selectionEditable", &selectionEditable )
 			.def( "selectionChangedSignal", &TransformTool::selectionChangedSignal, return_internal_reference<1>() )
 			.def( "handlesTransform", &TransformTool::handlesTransform )
 		;


### PR DESCRIPTION
This improves the TransformTools to show appropriate warnings when the selection isn't editable for any reason. This includes times when the EditScope isn't in the history, or is overridden by another node downstream.