### PR TITLE
EditScopeAlgo : Improve TransformEdits UI

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -30,7 +30,9 @@ API
 - EditScopeAlgo : Added new namespace with utility functions for editing scenes using EditScope nodes.
 - ScenePlug : Added `exists()` method. This provides fast existence queries for locations.
 - SceneAlgo : Deprecated `exists()` function. Use `ScenePlug::exists()` instead
-- Spreadsheet : Added `RowsPlug::row( rowName )` method.
+- Spreadsheet :
+  - Added `RowsPlug::row( rowName )` method.
+  - Added support for `spreadsheet:defaultRowVisible` metadata, which can be used to hide the default row.
 - AttributeProcessor : Refactored to be more widely useful.
 - Spacer : Added optional `preferredSize` constructor argument.
 - View : Added `editScope` plug and `editScope()` accessor method.

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -42,6 +42,7 @@
 #include "GafferScene/Transform.h"
 
 #include "Gaffer/EditScope.h"
+#include "Gaffer/Metadata.h"
 #include "Gaffer/PlugAlgo.h"
 #include "Gaffer/Spreadsheet.h"
 #include "Gaffer/StringPlug.h"
@@ -165,7 +166,10 @@ SceneProcessorPtr transformProcessor()
 		plug->setInput( spreadsheet->outPlug()->getChild<Plug>( name ) );
 	}
 
-	PlugAlgo::promoteWithName( spreadsheet->rowsPlug(), "edits" );
+	auto rowsPlug = static_cast<Spreadsheet::RowsPlug *>( PlugAlgo::promoteWithName( spreadsheet->rowsPlug(), "edits" ) );
+	Metadata::registerValue( rowsPlug, "spreadsheet:defaultRowVisible", new BoolData( false ) );
+	Metadata::registerValue( rowsPlug->defaultRow(), "spreadsheet:rowNameWidth", new IntData( 300 ) );
+
 	result->outPlug()->setInput( transform->outPlug() );
 
 	return result;


### PR DESCRIPTION
- Make row names wider, to better accomodate long location names.
- Hide default row. It is never used because every location in the PathFilter has a dedicated row in the spreadsheet.