### PR TITLE
Catalogue : Add UI to manage columns

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,8 +11,10 @@ Improvements
 ------------
 
 - Viewer : Added visualisation support for Arnold shader networks connected to light gobos (#3667).
-- Catalogue : Added column to help identify the nature of each image (#3646)
 - Render nodes : Added context variables to image metadata (#3646). Currently only a subset of variable types is supported, depending on the renderer used.
+- Catalogue :
+  - Added column to help identify the nature of each image (#3646).
+  - Added frame column preset (#3646).
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -12,9 +12,7 @@ Improvements
 
 - Viewer : Added visualisation support for Arnold shader networks connected to light gobos (#3667).
 - Render nodes : Added context variables to image metadata (#3646). Currently only a subset of variable types is supported, depending on the renderer used.
-- Catalogue :
-  - Added column to help identify the nature of each image (#3646).
-  - Added frame column preset (#3646).
+- Catalogue : Added customisable columns to display image information (#3646).
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
 
 - Viewer : Added visualisation support for Arnold shader networks connected to light gobos (#3667).
 - Catalogue : Added column to help identify the nature of each image (#3646)
+- Render nodes : Added context variables to image metadata (#3646). Currently only a subset of variable types is supported, depending on the renderer used.
 
 Fixes
 -----

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -544,7 +544,7 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 				sortable = False
 			)
 			self.__pathListing.setDragPointer( "" )
-			self.__pathListing.setHeaderVisible( len(columns) >  1 )
+			self.__pathListing.setHeaderVisible( True )
 			self.__pathListing.selectionChangedSignal().connect(
 				Gaffer.WeakMethod( self.__pathListingSelectionChanged ), scoped = False
 			)

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -222,6 +222,7 @@ class __StatusIconColumn( IconColumn ) :
 registerColumn( "Status", __StatusIconColumn() )
 registerColumn( "Name", SimpleColumn( "Name", lambda image, _ : image.getName() ) )
 registerColumn( "Frame", ContextVariableColumn( "Frame", "frame" ) )
+registerColumn( "Description", ImageMetadataColumn( "Description", "ImageDescription" ) )
 
 Gaffer.Metadata.registerValue(
 	GafferImage.Catalogue, "imageIndex", _columnsMetadataKey,

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -220,6 +220,7 @@ class __TypeIconColumn( IconColumn ) :
 
 registerColumn( "typeIcon", __TypeIconColumn() )
 registerColumn( "name", SimpleColumn( "Name", lambda image, _ : image.getName() ) )
+registerColumn( "Frame", ContextVariableColumn( "Frame", "frame" ) )
 
 Gaffer.Metadata.registerValue(
 	GafferImage.Catalogue, "imageIndex", "catalogue:columns",

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -177,7 +177,7 @@ registerColumn( "typeIcon", __TypeIconColumn() )
 registerColumn( "name", SimpleColumn( "Name", lambda image, _ : image.getName() ) )
 
 Gaffer.Metadata.registerValue(
-	GafferImage.Catalogue, "catalogue:columns",
+	GafferImage.Catalogue, "imageIndex", "catalogue:columns",
 	IECore.StringVectorData( [ "typeIcon", "name" ] )
 )
 
@@ -583,7 +583,7 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 
 		columns = []
 
-		for name in Gaffer.Metadata.value( self.__catalogue(), "catalogue:columns" ) :
+		for name in Gaffer.Metadata.value( self.getPlug(), "catalogue:columns" ) :
 
 			definition = column( name )
 

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -224,6 +224,44 @@ registerColumn( "Name", SimpleColumn( "Name", lambda image, _ : image.getName() 
 registerColumn( "Frame", ContextVariableColumn( "Frame", "frame" ) )
 registerColumn( "Description", ImageMetadataColumn( "Description", "ImageDescription" ) )
 
+# Image properties
+
+def __resolutionColumnValueProvider( image, catalogue ) :
+
+	format_ = catalogue["out"].format()
+	return "%d x %d" % ( format_.width(), format_.height() )
+
+def __formatBox( box ) :
+
+	return "(%d %d) - (%d, %d)" % ( box.min().x, box.min().y, box.max().x, box.max().y )
+
+registerColumn(
+	"Image/Resolution",
+	SimpleColumn( "Resolution", __resolutionColumnValueProvider )
+)
+registerColumn(
+	"Image/Channels",
+	SimpleColumn( "Channels", lambda _, c : ", ".join( c["out"].channelNames() ) )
+)
+registerColumn(
+	"Image/Type",
+	SimpleColumn( "Image Type", lambda _, c : "Deep" if c["out"].deep() else "Flat" )
+)
+registerColumn(
+	"Image/Pixel Aspect Ratio",
+	SimpleColumn( "P. Aspect", lambda _, c : c["out"].format().getPixelAspect() )
+)
+registerColumn(
+	"Image/Data Window",
+	SimpleColumn( "Data Window", lambda _, c : __formatBox( c["out"].dataWindow() ) )
+)
+registerColumn(
+	"Image/Display Window",
+	SimpleColumn( "Display Window", lambda _, c : __formatBox( c["out"].format().getDisplayWindow() ) )
+)
+
+# Default visible column set
+
 Gaffer.Metadata.registerValue(
 	GafferImage.Catalogue, "imageIndex", _columnsMetadataKey,
 	IECore.StringVectorData( [ "Status", "Name" ] )

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -209,7 +209,7 @@ class ContextVariableColumn( ImageMetadataColumn ) :
 # Standard Columns
 #
 
-class __TypeIconColumn( IconColumn ) :
+class __StatusIconColumn( IconColumn ) :
 
 	def __init__( self ) :
 
@@ -219,13 +219,13 @@ class __TypeIconColumn( IconColumn ) :
 
 		return "catalogueTypeDisk" if image["fileName"].getValue() else "catalogueTypeDisplay"
 
-registerColumn( "typeIcon", __TypeIconColumn() )
+registerColumn( "Status", __StatusIconColumn() )
 registerColumn( "Name", SimpleColumn( "Name", lambda image, _ : image.getName() ) )
 registerColumn( "Frame", ContextVariableColumn( "Frame", "frame" ) )
 
 Gaffer.Metadata.registerValue(
 	GafferImage.Catalogue, "imageIndex", _columnsMetadataKey,
-	IECore.StringVectorData( [ "typeIcon", "Name" ] )
+	IECore.StringVectorData( [ "Status", "Name" ] )
 )
 
 ##########################################################################

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -160,6 +160,51 @@ def registeredColumns() :
 	return __registeredColumns.keys()
 
 #
+# Convenience Column classes
+#
+
+# A Columns class that retrieves its value from the catalogue item's image
+# metadata. If multiple names are provided, the first one present will be used,
+# allowing a single column to support several source names depending on the
+# image's origin.
+class ImageMetadataColumn( Column ) :
+
+	def __init__( self, title, nameOrNames, defaultValue = None ) :
+
+		Column.__init__( self, title )
+
+		if isinstance( nameOrNames, basestring ) :
+			nameOrNames = [ nameOrNames, ]
+
+		self.__names = nameOrNames
+		self.__defaultValue = defaultValue
+
+	def value( self, image, catalogue ) :
+
+		metadata = catalogue["out"].metadata()
+		for name in self.__names :
+			value = metadata.get( name, None )
+			if value is not None :
+				return value
+
+		return self.__defaultValue
+
+# A Column class that retrieves its value from render-time context variable
+# values passed through the catalogue item's image metadata.  If multiple names
+# are provided, the first present context entry will be used. Note: Not all
+# context variables are available via image metadata, the exact list is renderer
+# dependent, but it is generally limited to basic value types
+class ContextVariableColumn( ImageMetadataColumn ) :
+
+	def __init__( self, title, nameOrNames, defaultValue = None ) :
+
+		if isinstance( nameOrNames, basestring ) :
+			nameOrNames = [ nameOrNames, ]
+
+		names = [ "gaffer:context:%s" % name for name in nameOrNames ]
+		ImageMetadataColumn.__init__( self, title, names, defaultValue )
+
+#
 # Standard Columns
 #
 

--- a/python/GafferImageUITest/CatalogueUITest.py
+++ b/python/GafferImageUITest/CatalogueUITest.py
@@ -69,6 +69,74 @@ class CatalogueUITest( GafferUITest.TestCase ) :
 		sw = GafferUI.ScriptWindow.acquire( s )
 		ne = GafferUI.NodeEditor.acquire( s["b"] )
 
+	def testImageHeaderColumns( self ) :
+
+		class MockImagePlug() :
+
+			def __init__( self, metadata = {} ) :
+				self.__metadata = metadata
+
+			def metadata( self ) :
+				return self.__metadata
+
+			def mockNode( self ) :
+				return { "out" : self }
+
+		mockPlug = MockImagePlug( {
+			"gaffer:context:shot" : "G100",
+			"gaffer:context:sequence" : "G",
+			"customHeaderA" : "A",
+			"customHeaderB": "B"
+		} )
+
+		catalogue = mockPlug.mockNode()
+
+		# Header value provider
+
+		c = CatalogueUI.ImageMetadataColumn( "Custom A", "customHeaderA" )
+		self.assertEqual( c.value( None, catalogue ), "A" )
+
+		c = CatalogueUI.ImageMetadataColumn( "Custom C", "customHeaderC" )
+		self.assertEqual( c.value( None, catalogue ), None )
+
+		c = CatalogueUI.ImageMetadataColumn( "Custom A", [ "customHeaderA" ] )
+		self.assertEqual( c.value( None, catalogue ), "A" )
+
+		c = CatalogueUI.ImageMetadataColumn( "Custom A", "customHeaderA", "X" )
+		self.assertEqual( c.value( None, catalogue ), "A" )
+
+		c = CatalogueUI.ImageMetadataColumn( "Custom C", "customHeaderC", "C" )
+		self.assertEqual( c.value( None, catalogue ), "C" )
+
+		c = CatalogueUI.ImageMetadataColumn( "Custom", [ "customHeaderC", "customHeaderB", "customHeaderA" ] )
+		self.assertEqual( c.value( None, catalogue ), "B" )
+
+		c = CatalogueUI.ImageMetadataColumn( "Custom", [ "customHeaderC", "customHeaderD" ], "X"  )
+		self.assertEqual( c.value( None, catalogue ), "X" )
+
+		# Context value provider
+
+		c = CatalogueUI.ContextVariableColumn( "Shot", "shot" )
+		self.assertEqual( c.value( None, catalogue ), "G100" )
+
+		c = CatalogueUI.ContextVariableColumn( "Layer", "layer" )
+		self.assertEqual( c.value( None, catalogue ), None )
+
+		c = CatalogueUI.ContextVariableColumn( "Shot", [ "shot" ] )
+		self.assertEqual( c.value( None, catalogue ), "G100" )
+
+		c = CatalogueUI.ContextVariableColumn( "Shot", "shot", "X" )
+		self.assertEqual( c.value( None, catalogue ), "G100" )
+
+		c = CatalogueUI.ContextVariableColumn( "Layer", "layer", "L" )
+		self.assertEqual( c.value( None, catalogue ), "L" )
+
+		c = CatalogueUI.ContextVariableColumn( "Layer", [ "layer", "shot", "sequence" ] )
+		self.assertEqual( c.value( None, catalogue ), "G100" )
+
+		c = CatalogueUI.ContextVariableColumn( "Layer", [ "subLayer", "layer" ], "X"  )
+		self.assertEqual( c.value( None, catalogue ), "X" )
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/python/GafferImageUITest/CatalogueUITest.py
+++ b/python/GafferImageUITest/CatalogueUITest.py
@@ -51,7 +51,7 @@ class CatalogueUITest( GafferUITest.TestCase ) :
 
 		c = GafferImage.Catalogue()
 		self.assertEqual(
-			Gaffer.Metadata.value( c, "catalogue:columns" ),
+			Gaffer.Metadata.value( c["imageIndex"], "catalogue:columns" ),
 			IECore.StringVectorData( [ "typeIcon", "name" ] )
 		)
 

--- a/python/GafferImageUITest/CatalogueUITest.py
+++ b/python/GafferImageUITest/CatalogueUITest.py
@@ -47,13 +47,13 @@ class CatalogueUITest( GafferUITest.TestCase ) :
 
 	def testStandardColumns( self ) :
 
-		self.assertTrue( "typeIcon" in CatalogueUI.registeredColumns() )
+		self.assertTrue( "Status" in CatalogueUI.registeredColumns() )
 		self.assertTrue( "Name" in CatalogueUI.registeredColumns() )
 
 		c = GafferImage.Catalogue()
 		self.assertEqual(
 			Gaffer.Metadata.value( c["imageIndex"], "catalogue:columns" ),
-			IECore.StringVectorData( [ "typeIcon", "Name" ] )
+			IECore.StringVectorData( [ "Status", "Name" ] )
 		)
 
 	def testBoxedCatalogue( self ) :

--- a/python/GafferImageUITest/CatalogueUITest.py
+++ b/python/GafferImageUITest/CatalogueUITest.py
@@ -47,7 +47,8 @@ class CatalogueUITest( GafferUITest.TestCase ) :
 
 	def testStandardColumns( self ) :
 
-		self.assertEqual( CatalogueUI.registeredColumns(), [ "typeIcon", "name" ] )
+		self.assertTrue( "typeIcon" in CatalogueUI.registeredColumns() )
+		self.assertTrue( "name" in CatalogueUI.registeredColumns() )
 
 		c = GafferImage.Catalogue()
 		self.assertEqual(

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -98,6 +98,8 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 	def testMetadata( self ) :
 
 		s = Gaffer.ScriptNode()
+		s["variables"].addChild( Gaffer.NameValuePlug( "a", "A", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+
 		s["s"] = GafferScene.Sphere()
 
 		s["o"] = GafferScene.Outputs()
@@ -123,7 +125,9 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		time.sleep( 1.0 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.assertEqual( image.blindData(), IECore.CompoundData({"gaffer:sourceScene": IECore.StringData( "r.__adaptedIn" )}) )
+		headers = image.blindData()
+		self.assertEqual( headers["gaffer:sourceScene"], IECore.StringData( "r.__adaptedIn" ) )
+		self.assertEqual( headers["gaffer:context:a"], IECore.StringData( "A" ) )
 
 	def testAddAndRemoveOutput( self ):
 

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -5130,7 +5130,7 @@
        id="ellipse1573"
        style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <g
-       id="forExport:catalogueTypeDisk"
+       id="forExport:catalogueStatusDisk"
        inkscape:label="#catalogTypeDisk">
       <path
          style="fill:url(#linearGradient1627);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
@@ -5146,9 +5146,9 @@
          style="fill:none;stroke:#3c3c3c;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
     <g
-       id="forExport:catalogueTypeDisplay"
+       id="forExport:catalogueStatusDisplay"
        transform="translate(-0.87501,-0.124997)"
-       inkscape:label="#catalogueTypeDisplay">
+       inkscape:label="#catalogueStatusDisplay">
       <path
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccccc"
@@ -5165,7 +5165,7 @@
     <path
        sodipodi:nodetypes="ccccccccccc"
        inkscape:connector-curvature="0"
-       id="forExport:catalogueTypeBatchRenderComplete"
+       id="forExport:catalogueStatusBatchRenderComplete"
        d="m 425,98.362183 v 2.999997 h -3.4 -6.1 v 1 h 6.1 c 1.10962,-10e-5 3.4,0 3.4,0 v 3 h 1.18359 v -6.999997 z"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1645);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke markers fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        inkscape:label="#path24667" />
@@ -5173,17 +5173,17 @@
        inkscape:label="#path24667"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke markers fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 407,98.362183 v 2.999997 h -0.15 l -3.25,-1.999997 v 1.999997 h -6.1 v 1 h 6.1 v 2 l 3.25,-2 H 407 v 3 h 1.18359 v -6.999997 z"
-       id="forExport:catalogueTypeBatchRenderRunning"
+       id="forExport:catalogueStatusBatchRenderRunning"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccccccccccccc" />
     <path
        inkscape:connector-curvature="0"
-       id="forExport:catalogueTypeInteractiveRenderComplete"
+       id="forExport:catalogueStatusInteractiveRenderComplete"
        d="m 423.73483,114.37685 c -2.1616,-1.22715 -4.96606,-0.92558 -6.8059,0.91426 -1.83984,1.83984 -2.1411,4.64399 -0.91426,6.80591 l 0.99436,-0.99437 c -0.7383,-1.6005 -0.46097,-3.54689 0.86179,-4.86964 1.32276,-1.32276 3.26952,-1.60047 4.86965,-0.86179 z m 2.12132,2.12132 -0.99436,0.99437 c 0.73867,1.60012 0.46097,3.54688 -0.86179,4.86964 -1.32276,1.32276 -3.26915,1.60009 -4.86965,0.86179 l -0.99436,0.99437 c 2.16192,1.22683 4.96606,0.92558 6.8059,-0.91427 1.83984,-1.83984 2.14141,-4.6443 0.91426,-6.8059 z"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1639);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        inkscape:label="#path1610" />
     <path
-       id="forExport:catalogueTypeInteractiveRenderRunning"
+       id="forExport:catalogueStatusInteractiveRenderRunning"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 400.13599,124.21833 c 2.1616,1.22715 4.96606,0.92558 6.8059,-0.91426 1.83984,-1.83984 2.1411,-4.64399 0.91426,-6.80591 l -0.99436,0.99437 c 0.7383,1.6005 0.46097,3.54689 -0.86179,4.86964 -0.62513,0.62513 -1.38963,1.01685 -2.19105,1.17819 -0.14351,0.0289 -0.87354,-1.74277 -0.87354,-1.74277 0,0 -1.61537,1.23668 -2.79942,2.42074 z m 5.59884,-9.84148 c -2.1616,-1.22715 -4.96606,-0.92558 -6.8059,0.91426 -1.83984,1.83984 -2.1411,4.64399 -0.91426,6.80591 l 0.99436,-0.99437 c -0.7383,-1.6005 -0.46097,-3.54689 0.86179,-4.86964 0.62513,-0.62513 1.38963,-1.01685 2.19105,-1.17819 0.14351,-0.0289 0.87354,1.74277 0.87354,1.74277 0,0 1.61537,-1.23668 2.79942,-2.42074 z"
        inkscape:connector-curvature="0"

--- a/startup/GafferSceneUI/catalogue.py
+++ b/startup/GafferSceneUI/catalogue.py
@@ -48,27 +48,28 @@ imageNameMap = {
 	GafferScene.Render : "catalogueTypeBatchRender",
 }
 
-typeIconColumnDefinition = CatalogueUI.columnDefinition( "typeIcon" )
-if typeIconColumnDefinition :
+typeIconColumn = CatalogueUI.columnDefinition( "typeIcon" )
+if typeIconColumn :
 
-	def typeIconColumnValueProvider( image, catalogue ):
+	class __ExtededTypeIconColumn( CatalogueUI.IconColumn ) :
 
-		iconName = typeIconColumnDefinition.valueProvider( image, catalogue )
+		def __init__( self ) :
 
-		scenePlug = GafferScene.SceneAlgo.sourceScene( catalogue["out"] )
-		if not scenePlug :
+			CatalogueUI.IconColumn.__init__( self, "" )
+
+		def value( self, image, catalogue ) :
+
+			iconName = typeIconColumn.value( image, catalogue )
+
+			scenePlug = GafferScene.SceneAlgo.sourceScene( catalogue["out"] )
+			if not scenePlug :
+				return iconName
+
+			for type_ in imageNameMap.keys() :
+				if isinstance( scenePlug.node(), type_ ) :
+					suffix = "Complete" if image["fileName"].getValue() else "Running"
+					return imageNameMap[type_] + suffix
+
 			return iconName
 
-		for type_ in imageNameMap.keys() :
-			if isinstance( scenePlug.node(), type_ ) :
-				suffix = "Complete" if image["fileName"].getValue() else "Running"
-				return imageNameMap[type_] + suffix
-
-		return iconName
-
-	CatalogueUI.registerColumn(
-		"typeIcon",
-		typeIconColumnDefinition.title,
-		typeIconColumnValueProvider,
-		CatalogueUI.ColumnType.Icon
-	)
+	CatalogueUI.registerColumn( "typeIcon", __ExtededTypeIconColumn() )

--- a/startup/GafferSceneUI/catalogue.py
+++ b/startup/GafferSceneUI/catalogue.py
@@ -48,7 +48,7 @@ imageNameMap = {
 	GafferScene.Render : "catalogueTypeBatchRender",
 }
 
-typeIconColumn = CatalogueUI.columnDefinition( "typeIcon" )
+typeIconColumn = CatalogueUI.column( "typeIcon" )
 if typeIconColumn :
 
 	class __ExtededTypeIconColumn( CatalogueUI.IconColumn ) :

--- a/startup/GafferSceneUI/catalogue.py
+++ b/startup/GafferSceneUI/catalogue.py
@@ -40,18 +40,18 @@ import GafferScene
 
 from GafferImageUI import CatalogueUI
 
-# We provide extended info in the Catalogue's type column
+# We provide extended info in the Catalogue's status column
 # to reflect interactive/batch renders triggered from the UI.
 
 imageNameMap = {
-	GafferScene.InteractiveRender : "catalogueTypeInteractiveRender",
-	GafferScene.Render : "catalogueTypeBatchRender",
+	GafferScene.InteractiveRender : "catalogueStatusInteractiveRender",
+	GafferScene.Render : "catalogueStatusBatchRender",
 }
 
-typeIconColumn = CatalogueUI.column( "typeIcon" )
-if typeIconColumn :
+statusIconColumn = CatalogueUI.column( "Status" )
+if statusIconColumn :
 
-	class __ExtededTypeIconColumn( CatalogueUI.IconColumn ) :
+	class __ExtededStatusIconColumn( CatalogueUI.IconColumn ) :
 
 		def __init__( self ) :
 
@@ -59,7 +59,7 @@ if typeIconColumn :
 
 		def value( self, image, catalogue ) :
 
-			iconName = typeIconColumn.value( image, catalogue )
+			iconName = statusIconColumn.value( image, catalogue )
 
 			scenePlug = GafferScene.SceneAlgo.sourceScene( catalogue["out"] )
 			if not scenePlug :
@@ -72,4 +72,4 @@ if typeIconColumn :
 
 			return iconName
 
-	CatalogueUI.registerColumn( "typeIcon", __ExtededTypeIconColumn() )
+	CatalogueUI.registerColumn( "Status", __ExtededStatusIconColumn() )


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/896779/77537790-95776100-6e96-11ea-9dfd-58e1e1fca13d.png)

- Adds UI to control column visibility via right-click on the header.
- Adds context variables to image header under the `gaffer:context:` prefix.
- Adds additional column presets.

NB: This is a 'minimal' UI, that allows order customisation via the order you add columns. Full drag-drop etc. is a bit of a faf right now with `PathListingWidget` so it'd be good to save this until it becomes completely essential...