### PR TITLE
SpreadsheetUI : Fix row name sizing bug

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,7 +10,9 @@ Fixes
 - TransformTools : Fixed rare crash triggered by selecting multiple objects.
 - Floating Editors : Fixed keyboard shortcuts (#3632).
 - ArnoldTextureBake :  Fixed imbalanced distribution of work among tasks when some UDIMs contain many more objects than others.
-- Spreadsheet : Fixed scrollbar flickering in Spreadsheets with two rows (#3628).
+- Spreadsheet :
+  - Fixed scrollbar flickering in Spreadsheets with two rows (#3628).
+  - Fixed bug which changed the width of the row name column when new rows were added.
 
 0.55.5.1 (relative to 0.55.5.0)
 ========

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -639,6 +639,9 @@ class _PlugTableView( GafferUI.Widget ) :
 
 	def __applyColumnWidthMetadata( self, cellPlug = None ) :
 
+		if self._qtWidget().model().mode() == self.Mode.RowNames :
+			return
+
 		defaultCells = self._qtWidget().model().rowsPlug().defaultRow()["cells"]
 
 		if cellPlug is not None :
@@ -664,6 +667,9 @@ class _PlugTableView( GafferUI.Widget ) :
 
 	def __applySectionOrderMetadata( self ) :
 
+		if self._qtWidget().model().mode() == self.Mode.RowNames :
+			return
+
 		rowsPlug = self._qtWidget().model().rowsPlug()
 		header = self._qtWidget().horizontalHeader()
 		for index, plug in enumerate( rowsPlug.defaultRow()["cells"] ) :
@@ -673,6 +679,9 @@ class _PlugTableView( GafferUI.Widget ) :
 			self.__callingMoveSection = False
 
 	def __applyColumnVisibility( self ) :
+
+		if self._qtWidget().model().mode() == self.Mode.RowNames :
+			return
 
 		# Changing column visibility seems to cause the
 		# `sectionResized()` signal to be emitted unnecessarily,
@@ -871,6 +880,10 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 
 	# Methods of our own
 	# ------------------
+
+	def mode( self ) :
+
+		return self.__mode
 
 	def rowsPlug( self ) :
 


### PR DESCRIPTION
This was introduced by 3a8ba8b83c3a1d1ad24405ba8a5448785cb789e7, with the root cause being an attempt to apply the column widths for the main columns to the two columns in the row name section. Added similar safeguards to the application of section order and column visibility.
