### PR TITLE
PathFilter : Add `roots` filter plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Features
 Improvements
 ------------
 
+- PathFilter : Added `roots`, an optional filter input to provide multiple root locations which the `paths` are relative to. This can be useful when working on a single asset in isolation, and then placing it into multiple locations within a layout.
 - Spreadsheet : Improved performance of Spreadsheets with many rows.
 - CopyPrimitiveVariables : Improved performance. In one benchmark, scene generation time has been reduced by 50%.
 - MergeScenes : Improved performance when merging overlapping hierarchies.

--- a/include/GafferScene/PathFilter.h
+++ b/include/GafferScene/PathFilter.h
@@ -58,6 +58,9 @@ class GAFFERSCENE_API PathFilter : public Filter
 		Gaffer::StringVectorDataPlug *pathsPlug();
 		const Gaffer::StringVectorDataPlug *pathsPlug() const;
 
+		FilterPlug *rootsPlug();
+		const FilterPlug *rootsPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
@@ -68,21 +71,28 @@ class GAFFERSCENE_API PathFilter : public Filter
 		void hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		unsigned computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const override;
 
+		bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const override;
+
 	private :
 
-		// Filter matches are computed using a PathMatcher data structure in one of two ways:
-		// if pathsPlug() is receiving data from an output plug, we compute the PathMatcher
-		// using an intermediate plug called __pathMatcher, as it's possible the paths we're
-		// testing against could vary depending on the context:
-
+		// Used to compute a PathMatcher from `pathsPlug()`.
 		Gaffer::PathMatcherDataPlug *pathMatcherPlug();
 		const Gaffer::PathMatcherDataPlug *pathMatcherPlug() const;
 
-		// If that's not the case, we can improve performance by precomputing the PathMatcher
-		// whenever the plug is dirtied, which saves on graph evaluations:
+		// Used to compute a list containing the lengths of
+		// all the relevant roots matched by `rootsPlug()`.
+		// This is computed on a per-location basis, and roots
+		// are ordered by length with the shortest appearing first.
+		Gaffer::IntVectorDataPlug *rootSizesPlug();
+		const Gaffer::IntVectorDataPlug *rootSizesPlug() const;
 
+		void hashRootSizes( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		IECore::ConstIntVectorDataPtr computeRootSizes( const Gaffer::Context *context ) const;
+
+		// Optimisation for when `pathsPlug()` contains a constant
+		// value. We can store a constant `m_pathMatcher` instead
+		// of needing to compute `pathMatcherPlug()`.
 		void plugDirtied( const Gaffer::Plug *plug );
-
 		IECore::PathMatcherDataPtr m_pathMatcher;
 
 		static size_t g_firstPlugIndex;

--- a/python/GafferSceneTest/PathFilterTest.py
+++ b/python/GafferSceneTest/PathFilterTest.py
@@ -75,7 +75,7 @@ class PathFilterTest( GafferSceneTest.SceneTestCase ) :
 		] :
 
 			with Gaffer.Context() as c :
-				c["scene:path"] = IECore.InternedStringVectorData( path[1:].split( "/" ) )
+				c["scene:path"] = GafferScene.ScenePlug.stringToPath( path )
 				self.assertEqual( f["out"].getValue(), int( result ) )
 
 	def testNullPaths( self ) :
@@ -144,7 +144,7 @@ class PathFilterTest( GafferSceneTest.SceneTestCase ) :
 		] :
 
 			with Gaffer.Context() as c :
-				c["scene:path"] = IECore.InternedStringVectorData( path[1:].split( "/" ) )
+				c["scene:path"] = GafferScene.ScenePlug.stringToPath( path )
 				self.assertEqual( b["f"]["out"].getValue(), int( result ) )
 
 	def testPathPlugExpression( self ) :

--- a/python/GafferSceneTest/SceneTestCase.py
+++ b/python/GafferSceneTest/SceneTestCase.py
@@ -115,15 +115,15 @@ class SceneTestCase( GafferTest.TestCase ) :
 	def assertPathExists( self, scenePlug, path ) :
 
 		if isinstance( path, str ) :
-			path = path.strip( "/" ).split( "/" )
+			path = GafferScene.ScenePlug.stringToPath( path )
 
 		for i in range( 0, len( path ) ) :
 			self.assertTrue(
-				path[i] in scenePlug.childNames( "/" + "/".join( path[:i] ) ),
+				path[i] in scenePlug.childNames( path[:i] ),
 				"\"{childName}\" in {scene}.childNames( \"{location}\" )".format(
 					childName = path[i],
 					scene = scenePlug.relativeName( scenePlug.ancestor( Gaffer.ScriptNode ) ),
-					location =  "/" + "/".join( path[:i] )
+					location =  GafferScene.ScenePlug.pathToString( path[:i] )
 				)
 			)
 
@@ -212,7 +212,7 @@ class SceneTestCase( GafferTest.TestCase ) :
 		scenePath1 = IECore.InternedStringVectorData()
 		scenePath2 = IECore.InternedStringVectorData()
 		if scenePlug2PathPrefix :
-			scenePath2.extend( IECore.InternedStringVectorData( scenePlug2PathPrefix[1:].split( "/" ) ) )
+			scenePath2.extend( GafferScene.ScenePlug.stringToPath( scenePlug2PathPrefix ) )
 
 		walkScene( scenePath1, scenePath2 )
 
@@ -277,7 +277,7 @@ class SceneTestCase( GafferTest.TestCase ) :
 		scenePath1 = IECore.InternedStringVectorData()
 		scenePath2 = IECore.InternedStringVectorData()
 		if scenePlug2PathPrefix :
-			scenePath2.extend( IECore.InternedStringVectorData( scenePlug2PathPrefix[1:].split( "/" ) ) )
+			scenePath2.extend( GafferScene.ScenePlug.stringToPath( scenePlug2PathPrefix ) )
 
 		walkScene( scenePath1, scenePath2 )
 
@@ -316,7 +316,7 @@ class SceneTestCase( GafferTest.TestCase ) :
 		scenePath1 = IECore.InternedStringVectorData()
 		scenePath2 = IECore.InternedStringVectorData()
 		if scenePlug2PathPrefix :
-			scenePath2.extend( IECore.InternedStringVectorData( scenePlug2PathPrefix[1:].split( "/" ) ) )
+			scenePath2.extend( GafferScene.ScenePlug.stringToPath( scenePlug2PathPrefix ) )
 
 		walkScene( scenePath1, scenePath2 )
 

--- a/python/GafferSceneTest/UnionFilterTest.py
+++ b/python/GafferSceneTest/UnionFilterTest.py
@@ -75,7 +75,7 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 			"/a/b/c/d",
 		] :
 			with Gaffer.Context() as c :
-				c["scene:path"] = IECore.InternedStringVectorData( path[1:].split( "/" ) )
+				c["scene:path"] = GafferScene.ScenePlug.stringToPath( path )
 				self.assertEqual( u["out"].getValue(), f1["out"].getValue() )
 
 		u["in"][1].setInput( f2["out"] )
@@ -93,7 +93,7 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 			( "/a/b/c/e/f/g/h", IECore.PathMatcher.Result.AncestorMatch ),
 		] :
 			with Gaffer.Context() as c :
-				c["scene:path"] = IECore.InternedStringVectorData( path[1:].split( "/" ) )
+				c["scene:path"] = GafferScene.ScenePlug.stringToPath( path )
 				self.assertEqual( u["out"].getValue(), int( result ) )
 
 		f2["paths"].setValue( IECore.StringVectorData( [

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -95,6 +95,21 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"roots" : [
+
+			"description",
+			"""
+			An optional filter input used to provide multiple root locations
+			which the `paths` are relative to. This can be useful when working
+			on a single asset in isolation, and then placing it into multiple
+			locations within a layout. When no filter is connected, all `paths`
+			are treated as being relative to `/`, the true scene root.
+			""",
+
+			"plugValueWidget:type", "",
+
+		],
+
 	}
 
 )

--- a/src/GafferScene/PathFilter.cpp
+++ b/src/GafferScene/PathFilter.cpp
@@ -170,16 +170,7 @@ void PathFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *conte
 
 unsigned PathFilter::computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const
 {
-	typedef IECore::TypedData<ScenePlug::ScenePath> ScenePathData;
-	const ScenePathData *pathData = context->get<ScenePathData>( ScenePlug::scenePathContextName, nullptr );
-	if( pathData )
-	{
-		// If we have a precomputed PathMatcher, we use that to compute matches, otherwise
-		// we grab the PathMatcher from the intermediate plug (which is a bit more expensive
-		// as it involves graph evaluations):
-
-		ConstPathMatcherDataPtr pathMatcher = m_pathMatcher ? m_pathMatcher : pathMatcherPlug()->getValue();
-		return pathMatcher->readable().match( pathData->readable() );
-	}
-	return IECore::PathMatcher::NoMatch;
+	const ScenePlug::ScenePath &path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+	ConstPathMatcherDataPtr pathMatcher = m_pathMatcher ? m_pathMatcher : pathMatcherPlug()->getValue();
+	return pathMatcher->readable().match( path );
 }


### PR DESCRIPTION
This is an optional filter input to provide multiple root locations which the `paths` are relative to. This can be useful when working on a single asset in isolation, and then placing it into multiple locations within a layout. Below is an example where the primary filter was set up to lookdev a chair in isolation, and then a roots filter was added to account for its position at multiple locations in a layout.

![image](https://user-images.githubusercontent.com/1133871/77649109-26b30a00-6f61-11ea-8004-c26652be76c0.png)

I've made this PR for master rather than 0.56_maintenance, not because I believe that is essential, but out of caution given the change in 8436bd8 and the absolutely core nature of the PathFilter.