### PR TITLE
PathPlugValueWidget : Only start in home dir for filesystem paths

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,6 +10,7 @@ Fixes
 - TransformTools : Fixed rare crash triggered by selecting multiple objects.
 - Floating Editors : Fixed keyboard shortcuts (#3632).
 - ArnoldTextureBake :  Fixed imbalanced distribution of work among tasks when some UDIMs contain many more objects than others.
+- StandardOptions : Fixed bug which meant that the camera chooser dialogue started browsing in the user's home directory, not the root of the scene (#3695).
 - Spreadsheet :
   - Fixed scrollbar flickering in Spreadsheets with two rows (#3628).
   - Fixed bug which changed the width of the row name column when new rows were added.

--- a/python/GafferUI/PathPlugValueWidget.py
+++ b/python/GafferUI/PathPlugValueWidget.py
@@ -136,7 +136,7 @@ class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 			bookmarks = pathChooserDialogueKeywords.get( "bookmarks", None )
 			if bookmarks is not None :
 				pathCopy.setFromString( bookmarks.getDefault() )
-			else :
+			elif isinstance( pathCopy, Gaffer.FileSystemPath ) :
 				pathCopy.setFromString( os.path.expanduser( "~" ) )
 
 		return GafferUI.PathChooserDialogue( pathCopy, **pathChooserDialogueKeywords )


### PR DESCRIPTION
The previous behaviour was causing the camera chooser for the StandardOptions node to start out in daft places like `/Users/john`.

Fixes #3695.
