### PR TITLE
Stylesheet : Fix header over-scroll

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ Fixes
 - ArnoldTextureBake :  Fixed imbalanced distribution of work among tasks when some UDIMs contain many more objects than others.
 - Spreadsheet : Fixed scrollbar flickering in Spreadsheets with two rows (#3628).
 - Viewer : Fixed bug when using the Crop Window Tool with anamorphic images (#3690).
+- UI : Fixed bug that could cause header views to show scroll bars unnecessarily.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -40,6 +40,7 @@ API
 - CatalogueUI : Added column configuration API (#3646).
 - PathListingWidget :
 	- Added `sortable` kwarg to avoid premature sorting of the path passed to the constructor (#3684).
+	- Added `horizontalScrollMode` kwarg to control scroll bar behaviour (#3684).
 	- Deprecated `setSortable` and `getSortable` in favour of the constructor argument.
 
 0.56.1.0 (relative to 0.56.0.0)

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -431,7 +431,8 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 				_ImagesPath( self.__images(), [] ),
 				columns = columns,
 				allowMultipleSelection = True,
-				sortable = False
+				sortable = False,
+				horizontalScrollMode = GafferUI.ScrollMode.Automatic
 			)
 			self.__pathListing.setDragPointer( "" )
 			self.__pathListing.setHeaderVisible( len(columns) >  1 )

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -92,6 +92,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		allowMultipleSelection = False,
 		displayMode = DisplayMode.List,
 		sortable = True,
+		horizontalScrollMode = GafferUI.ScrollMode.Never,
 		**kw
 	) :
 
@@ -101,6 +102,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		self._qtWidget().setUniformRowHeights( True )
 		self._qtWidget().setEditTriggers( QtWidgets.QTreeView.NoEditTriggers )
 		self._qtWidget().activated.connect( Gaffer.WeakMethod( self.__activated ) )
+		self._qtWidget().setHorizontalScrollBarPolicy( GafferUI.ScrollMode._toQt( horizontalScrollMode ) )
 
 		if Qt.__binding__ in ( "PySide2", "PyQt5" ) :
 			self._qtWidget().header().setSectionsMovable( False )
@@ -597,8 +599,6 @@ class _TreeView( QtWidgets.QTreeView ) :
 	def __init__( self ) :
 
 		QtWidgets.QTreeView.__init__( self )
-
-		self.setHorizontalScrollBarPolicy( QtCore.Qt.ScrollBarAlwaysOff )
 
 		self.header().geometriesChanged.connect( self.updateGeometry )
 		self.header().sectionResized.connect( self.__sectionResized )

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -781,15 +781,14 @@ _styleSheet = string.Template(
 		border-top-right-radius: $widgetCornerRadius;
 	}
 
-	/* tuck adjacent header sections beneath one another so we only get */
-	/* a single width line between them                                 */
+	/* Remove left/top borders so we don't get a double-width line between columns */
 
 	QHeaderView::section:horizontal:!first:!only-one {
-		margin-left: -1px;
+		border-left-color: transparent;
 	}
 
 	QHeaderView::section:vertical:!first:!only-one {
-		margin-top: -1px;
+		border-top-color: transparent;
 	}
 
 	QHeaderView::down-arrow {
@@ -894,11 +893,40 @@ _styleSheet = string.Template(
 		spacing: 5px;
 	}
 
-	QTreeView QHeaderView {
-		/* tuck header border inside the treeview border */
-		margin-top: -1px;
-		margin-left: -1px;
-		margin-right: -1px;
+	/* Avoid a double border with the tree view's border */
+
+	QTreeView QHeaderView::section:horizontal {
+		border-top-color: transparent;
+	}
+
+	QTreeView QHeaderView::section:horizontal:only-one {
+		border-left-color: transparent;
+		border-right-color: transparent;
+	}
+
+	QTreeView QHeaderView::section:horizontal:first {
+		border-left-color: transparent;
+	}
+
+	QTreeView QHeaderView::section:horizontal:last {
+		border-right-color: transparent;
+	}
+
+	QTreeView QHeaderView::section:vertical {
+		border-left-color: transparent;
+	}
+
+	QTreeView QHeaderView::section:vertical:only-one {
+		border-top-color: transparent;
+		border-bottom-color: transparent;
+	}
+
+	QTreeView QHeaderView::section:vertical:first {
+		border-top-color: transparent;
+	}
+
+	QTreeView QHeaderView::section:vertical:last {
+		border-bottom-color: transparent;
 	}
 
 	QTreeView::branch {


### PR DESCRIPTION
Fixes the stylesheet such that we can now safely allow scroll bars to be shown in the `PathListingWidget` (and/or other tree views with a header).