### PR TITLE
ShaderTweaks : Allow tweaks to inherited shaders

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -49,6 +49,7 @@ API
   - Added `Selection::editable()` method.
   - Added `Selection::warning()` method.
   - Added `selectionEditable()` method.
+- TweakPlug : Changed `applyTweak(s)` return type to `bool` - indicating if any tweaks were actually performed (#3699).
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Improvements
 - CopyPrimitiveVariables : Improved performance. In one benchmark, scene generation time has been reduced by 50%.
 - MergeScenes : Improved performance when merging overlapping hierarchies.
 - Serialisation : Reduced file size and load time by omitting redundant `setInput()` calls from serialisations.
+- ShaderTweaks : Added `localise` option to allow location-specific tweaks to be made to inherited shaders.
 
 Fixes
 -----

--- a/include/GafferScene/ShaderTweaks.h
+++ b/include/GafferScene/ShaderTweaks.h
@@ -64,6 +64,9 @@ class GAFFERSCENE_API ShaderTweaks : public AttributeProcessor
 		GafferScene::TweaksPlug *tweaksPlug();
 		const GafferScene::TweaksPlug *tweaksPlug() const;
 
+		Gaffer::BoolPlug *localisePlug();
+		const Gaffer::BoolPlug *localisePlug() const;
+
 	protected :
 
 		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;

--- a/include/GafferScene/TweakPlug.h
+++ b/include/GafferScene/TweakPlug.h
@@ -106,8 +106,9 @@ class GAFFERSCENE_API TweakPlug : public Gaffer::ValuePlug
 		};
 
 		/// \deprecated. Use `TweaksPlug::applyTweaks()` instead.
-		void applyTweak( IECore::CompoundData *parameters, MissingMode missingMode = MissingMode::Error ) const;
-		static void applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork *shaderNetwork, MissingMode missingMode = MissingMode::Error );
+		bool applyTweak( IECore::CompoundData *parameters, MissingMode missingMode = MissingMode::Error ) const;
+		/// \returns true if any tweaks were applied
+		static bool applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork *shaderNetwork, MissingMode missingMode = MissingMode::Error );
 
 	private :
 
@@ -141,9 +142,10 @@ class GAFFERSCENE_API TweaksPlug : public Gaffer::ValuePlug
 
 		/// Tweak application
 		/// =================
+		/// Functions return true if any tweaks were applied.
 
-		void applyTweaks( IECore::CompoundData *parameters, TweakPlug::MissingMode missingMode = TweakPlug::MissingMode::Error ) const;
-		void applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork, TweakPlug::MissingMode missingMode = TweakPlug::MissingMode::Error ) const;
+		bool applyTweaks( IECore::CompoundData *parameters, TweakPlug::MissingMode missingMode = TweakPlug::MissingMode::Error ) const;
+		bool applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork, TweakPlug::MissingMode missingMode = TweakPlug::MissingMode::Error ) const;
 
 };
 

--- a/python/GafferSceneTest/ShaderTweaksTest.py
+++ b/python/GafferSceneTest/ShaderTweaksTest.py
@@ -370,5 +370,59 @@ class ShaderTweaksTest( GafferSceneTest.SceneTestCase ) :
 		with self.assertRaisesRegexp( Gaffer.ProcessException, "Cannot apply tweak \"badShader.p\" because shader \"badShader\" does not exist" ) :
 			t["out"].attributes( "/light" )
 
+	def testLocalise( self ) :
+
+		plane = GafferScene.Plane()
+		group = GafferScene.Group()
+		group["in"][0].setInput( plane["out"] )
+
+		shader = GafferSceneTest.TestShader( "surface" )
+		shader["type"].setValue( "surface" )
+		shader["parameters"]["c"].setValue( imath.Color3f( 1, 2, 3 ) )
+
+		groupFilter = GafferScene.PathFilter()
+		groupFilter["paths"].setValue( IECore.StringVectorData( [ "/group" ] ) )
+
+		assignment = GafferScene.ShaderAssignment()
+		assignment["in"].setInput( group["out"] )
+		assignment["filter"].setInput( groupFilter["out"] )
+		assignment["shader"].setInput( shader["out"] )
+
+		self.assertTrue( "surface" in assignment["out"].attributes( "/group" ) )
+		self.assertTrue( "surface" not in assignment["out"].attributes( "/group/plane" ) )
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/group/plane" ] ) )
+
+		tweaks = GafferScene.ShaderTweaks()
+		tweaks["in"].setInput( assignment["out"] )
+		tweaks["shader"].setValue( "light" )
+		tweaks["filter"].setInput( planeFilter["out"] )
+		tweaks["tweaks"].addChild( GafferScene.TweakPlug( "c", imath.Color3f( 3, 2, 1 ) ) )
+
+		self.assertEqual( tweaks["localise"].getValue(), False )
+
+		self.assertScenesEqual( tweaks["out"], tweaks["in"] )
+
+		tweaks["localise"].setValue( True )
+
+		# We have no matching shader yet
+		self.assertScenesEqual( tweaks["out"], tweaks["in"] )
+
+		tweaks["shader"].setValue( "surf*" )
+
+		groupAttr = tweaks["out"].attributes( "/group" )
+		self.assertEqual(
+			groupAttr["surface"].getShader( "surface" ).parameters["c"].value,
+			imath.Color3f( 1, 2, 3 )
+		)
+
+		planeAttr = tweaks["out"].attributes( "/group/plane" )
+		self.assertTrue( "surface" in planeAttr )
+		self.assertEqual(
+			planeAttr["surface"].getShader( "surface" ).parameters["c"].value,
+			imath.Color3f( 3, 2, 1 )
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/ShaderTweaksTest.py
+++ b/python/GafferSceneTest/ShaderTweaksTest.py
@@ -398,7 +398,9 @@ class ShaderTweaksTest( GafferSceneTest.SceneTestCase ) :
 		tweaks["in"].setInput( assignment["out"] )
 		tweaks["shader"].setValue( "light" )
 		tweaks["filter"].setInput( planeFilter["out"] )
-		tweaks["tweaks"].addChild( GafferScene.TweakPlug( "c", imath.Color3f( 3, 2, 1 ) ) )
+
+		colorTweak = GafferScene.TweakPlug( "c", imath.Color3f( 3, 2, 1 ) )
+		tweaks["tweaks"].addChild( colorTweak )
 
 		self.assertEqual( tweaks["localise"].getValue(), False )
 
@@ -423,6 +425,11 @@ class ShaderTweaksTest( GafferSceneTest.SceneTestCase ) :
 			planeAttr["surface"].getShader( "surface" ).parameters["c"].value,
 			imath.Color3f( 3, 2, 1 )
 		)
+
+		# Test disabling tweak results in no localisation
+
+		colorTweak["enabled"].setValue( False )
+		self.assertTrue( "surface" not in tweaks["out"].attributes( "/group/plane" ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/TweakPlugTest.py
+++ b/python/GafferSceneTest/TweakPlugTest.py
@@ -84,7 +84,7 @@ class TweakPlugTest( GafferSceneTest.SceneTestCase ) :
 		tweaks.addChild( GafferScene.TweakPlug( "b", 10.0, GafferScene.TweakPlug.Mode.Multiply ) )
 
 		parameters = IECore.CompoundData( { "a" : 0.0, "b" : 2.0 } )
-		tweaks.applyTweaks( parameters )
+		self.assertTrue( tweaks.applyTweaks( parameters ) )
 		self.assertEqual( parameters, IECore.CompoundData( { "a" : 1.0, "b" : 20.0 } ) )
 
 	def testTweakNetwork( self ) :
@@ -103,7 +103,7 @@ class TweakPlugTest( GafferSceneTest.SceneTestCase ) :
 		tweaks.addChild( GafferScene.TweakPlug( "surface.Kd", 0.5, GafferScene.TweakPlug.Mode.Multiply ) )
 		tweaks.addChild( GafferScene.TweakPlug( "Kd", 0.25, GafferScene.TweakPlug.Mode.Add ) )
 
-		tweaks.applyTweaks( network )
+		self.assertTrue( tweaks.applyTweaks( network ) )
 
 		self.assertEqual( network.getShader( "texture" ).parameters["sscale"].value, 11.0 )
 		self.assertEqual( network.getShader( "surface" ).parameters["Kd"].value, 0.75 )
@@ -142,11 +142,11 @@ class TweakPlugTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( d, IECore.CompoundData() )
 
 		d = IECore.CompoundData()
-		p.applyTweaks( d, missingMode = GafferScene.TweakPlug.MissingMode.Ignore )
+		self.assertFalse( p.applyTweaks( d, missingMode = GafferScene.TweakPlug.MissingMode.Ignore ) )
 		self.assertEqual( d, IECore.CompoundData() )
 
 		d = IECore.CompoundData()
-		p.applyTweaks( d, missingMode = GafferScene.TweakPlug.MissingMode.IgnoreOrReplace )
+		self.assertTrue( p.applyTweaks( d, missingMode = GafferScene.TweakPlug.MissingMode.IgnoreOrReplace ) )
 		self.assertEqual( d, IECore.CompoundData( { "test" : 0.5 } ) )
 
 		d = IECore.CompoundData()
@@ -159,7 +159,7 @@ class TweakPlugTest( GafferSceneTest.SceneTestCase ) :
 			p.applyTweaks( d, missingMode = GafferScene.TweakPlug.MissingMode.IgnoreOrReplace )
 		self.assertEqual( d, IECore.CompoundData() )
 
-		p.applyTweaks( d, missingMode = GafferScene.TweakPlug.MissingMode.Ignore )
+		self.assertFalse( p.applyTweaks( d, missingMode = GafferScene.TweakPlug.MissingMode.Ignore ) )
 		self.assertEqual( d, IECore.CompoundData() )
 
 	def testTweaksPlug( self ) :
@@ -199,7 +199,7 @@ class TweakPlugTest( GafferSceneTest.SceneTestCase ) :
 			p.applyTweaks( networkCopy, missingMode = GafferScene.TweakPlug.MissingMode.Error )
 
 		self.assertEqual( networkCopy, network )
-		p.applyTweaks( networkCopy, missingMode = GafferScene.TweakPlug.MissingMode.Ignore )
+		self.assertFalse( p.applyTweaks( networkCopy, missingMode = GafferScene.TweakPlug.MissingMode.Ignore ) )
 		self.assertEqual( networkCopy, network )
 
 		p["t"]["name"].setValue( "missingShader.parameterName" )
@@ -211,8 +211,80 @@ class TweakPlugTest( GafferSceneTest.SceneTestCase ) :
 			p.applyTweaks( networkCopy, missingMode = GafferScene.TweakPlug.MissingMode.Error )
 
 		self.assertEqual( networkCopy, network )
-		p.applyTweaks( networkCopy, missingMode = GafferScene.TweakPlug.MissingMode.Ignore )
+		self.assertFalse( p.applyTweaks( networkCopy, missingMode = GafferScene.TweakPlug.MissingMode.Ignore ) )
 		self.assertEqual( networkCopy, network )
+
+	def testApplyReturnValues( self ) :
+
+		parameters = IECore.CompoundData( { "a" : 0.0, "b" : 2.0 } )
+
+		tweaks = GafferScene.TweaksPlug()
+
+		# Test none to apply
+
+		self.assertFalse( tweaks.applyTweaks( parameters ) )
+
+		# Test none enabled
+
+		tweaks.addChild( GafferScene.TweakPlug( "a", 1.0, GafferScene.TweakPlug.Mode.Replace, False ) )
+		tweaks.addChild( GafferScene.TweakPlug( "b", 10.0, GafferScene.TweakPlug.Mode.Multiply, False ) )
+
+		tweakedParameters = parameters.copy()
+		self.assertFalse( tweaks.applyTweaks( parameters ) )
+		self.assertEqual( tweakedParameters, parameters )
+
+		# Test enabled
+
+		tweaks[0]["enabled"].setValue( True )
+		tweaks[1]["enabled"].setValue( True )
+
+		self.assertTrue( tweaks.applyTweaks( parameters ) )
+
+		# Test non-matching
+
+		altParameters = IECore.CompoundData( { "c" : 0.0, "d" : 2.0 } )
+		tweakedAltParameters = altParameters.copy()
+		self.assertFalse( tweaks.applyTweaks( tweakedAltParameters, missingMode = GafferScene.TweakPlug.MissingMode.Ignore ) )
+		self.assertEqual( tweakedAltParameters, altParameters )
+
+		# Test empty names
+
+		tweaks[0]["name"].setValue( "" )
+		tweaks[1]["name"].setValue( "" )
+
+		tweakedParameters = parameters.copy()
+		self.assertFalse( tweaks.applyTweaks( parameters ) )
+		self.assertEqual( tweakedParameters, parameters )
+
+	def testApplyReturnValuesNetworkEdits( self ) :
+
+		network = IECoreScene.ShaderNetwork(
+			shaders = {
+				"surface" : IECoreScene.Shader( "lambert", "surface", { "c" : imath.Color3f( 1.0 ) } )
+			},
+			output = "surface"
+		)
+
+		textureShader = GafferSceneTest.TestShader( "texture" )
+
+		tweaks = GafferScene.TweaksPlug()
+
+		tweaks.addChild( GafferScene.TweakPlug( "c", Gaffer.Color3fPlug(), GafferScene.TweakPlug.Mode.Replace, False ) )
+		tweaks[0]["value"].setInput( textureShader["out"] )
+
+		# Test none to apply
+
+		tweakedNetwork = network.copy()
+		self.assertFalse( tweaks.applyTweaks( tweakedNetwork ) )
+		self.assertEqual( tweakedNetwork, network )
+
+		# Test enabled
+
+		tweaks[0]["enabled"].setValue( True )
+
+		tweakedNetwork = network.copy()
+		self.assertTrue( tweaks.applyTweaks( tweakedNetwork ) )
+		self.assertEqual( tweakedNetwork.inputConnections( "surface" ), [ ( ( "texture", "" ), ( "surface", "c" ) ) ] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/ShaderTweaksUI.py
+++ b/python/GafferSceneUI/ShaderTweaksUI.py
@@ -69,6 +69,21 @@ Gaffer.Metadata.registerNode(
 
 			"preset:None", "",
 
+			"layout:index", 0
+
+		],
+
+		"localise" : [
+
+			"description",
+			"""
+			Turn on to allow location-specific tweaks to be made to inherited
+			shaders. Shaders will be localised to locations matching the
+			node's filter prior to tweaking. The original inherited shader will
+			remain untouched.
+			""",
+
+			"layout:index", 1
 		],
 
 		"ignoreMissing" : [
@@ -77,10 +92,11 @@ Gaffer.Metadata.registerNode(
 			"""
 			Ignores tweaks targeting missing parameters. When off, missing parameters
 			cause the node to error.
-			"""
+			""",
+
+			"layout:index", 2
 
 		],
-
 
 		"tweaks" : [
 
@@ -172,9 +188,10 @@ def _shaderAttributes( plugValueWidget, paths, affectedOnly ) :
 		return result
 
 	with plugValueWidget.getContext() :
+		useFullAttr = node["localise"].getValue()
 		attributeNamePatterns = node["shader"].getValue() if affectedOnly else "*"
 		for path in paths :
-			attributes = node["in"].attributes( path )
+			attributes = node["in"].fullAttributes( path ) if useFullAttr else node["in"].attributes( path )
 			for name, attribute in attributes.items() :
 				if not IECore.StringAlgo.matchMultiple( name, attributeNamePatterns ) :
 					continue

--- a/src/GafferScene/ShaderTweaks.cpp
+++ b/src/GafferScene/ShaderTweaks.cpp
@@ -189,8 +189,10 @@ IECore::ConstCompoundObjectPtr ShaderTweaks::computeProcessedAttributes( const S
 		}
 
 		ShaderNetworkPtr tweakedNetwork = network->copy();
-		tweaksPlug->applyTweaks( tweakedNetwork.get(), ignoreMissing ? TweakPlug::MissingMode::Ignore : TweakPlug::MissingMode::Error );
-		out[attribute.first] = tweakedNetwork;
+		if( tweaksPlug->applyTweaks( tweakedNetwork.get(), ignoreMissing ? TweakPlug::MissingMode::Ignore : TweakPlug::MissingMode::Error ) )
+		{
+			out[attribute.first] = tweakedNetwork;
+		}
 	}
 
 	return result;

--- a/src/GafferSceneModule/TweaksBinding.cpp
+++ b/src/GafferSceneModule/TweaksBinding.cpp
@@ -61,22 +61,22 @@ TweakPlugPtr constructUsingData( const std::string &tweakName, IECore::ConstData
 	return new TweakPlug( tweakName, tweakValue.get(), mode, enabled );
 }
 
-void applyTweak( const TweakPlug &plug, IECore::CompoundData &parameters, TweakPlug::MissingMode missingMode )
+bool applyTweak( const TweakPlug &plug, IECore::CompoundData &parameters, TweakPlug::MissingMode missingMode )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	plug.applyTweak( &parameters, missingMode );
+	return plug.applyTweak( &parameters, missingMode );
 }
 
-void applyTweaks( const Plug &tweaksPlug, IECoreScene::ShaderNetwork &shaderNetwork, TweakPlug::MissingMode missingMode )
+bool applyTweaks( const Plug &tweaksPlug, IECoreScene::ShaderNetwork &shaderNetwork, TweakPlug::MissingMode missingMode )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	TweakPlug::applyTweaks( &tweaksPlug, &shaderNetwork, missingMode );
+	return TweakPlug::applyTweaks( &tweaksPlug, &shaderNetwork, missingMode );
 }
 
-void applyTweaksToParameters( const TweaksPlug &tweaksPlug, IECore::CompoundData &parameters, TweakPlug::MissingMode missingMode )
+bool applyTweaksToParameters( const TweaksPlug &tweaksPlug, IECore::CompoundData &parameters, TweakPlug::MissingMode missingMode )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	tweaksPlug.applyTweaks( &parameters, missingMode );
+	return tweaksPlug.applyTweaks( &parameters, missingMode );
 }
 
 class TweakPlugSerialiser : public ValuePlugSerialiser


### PR DESCRIPTION
Allows shaders to be tweaked at child locations without the need for manually adding a `LocaliseAttributes` node. This should also help with EditScope/HUD based workflows.