### PR TITLE
TransformToolUI : Fix bug in status tooltip generation

### DIFF
--- a/python/GafferSceneUI/TransformToolUI.py
+++ b/python/GafferSceneUI/TransformToolUI.py
@@ -139,7 +139,7 @@ class _SelectionWidget( GafferUI.Frame ) :
 			return toolTip
 
 		toolSelection = self.__tool.selection()
-		if not toolSelection :
+		if not toolSelection or not self.__tool.selectionEditable() :
 			return ""
 
 		result = ""


### PR DESCRIPTION
A non-editable selection would lead to the following stacktrace :

```
Traceback (most recent call last):
  File "/disk1/john/dev/build/gaffer/python/GafferUI/Widget.py", line 933, in eventFilter
    return self.__toolTip( qObject, qEvent )
  File "/disk1/john/dev/build/gaffer/python/GafferUI/Widget.py", line 992, in __toolTip
    toolTip = widget.getToolTip()
  File "/disk1/john/dev/build/gaffer/python/GafferSceneUI/TransformToolUI.py", line 146, in getToolTip
    script = toolSelection[0].editTarget().ancestor( Gaffer.ScriptNode )
IECore.Exception: Selection is not editable
```

We don't need to deal with non-editable selections in `getToolTip()` because we've already put a more specific tooltip on the warning indicator in this case (in `__update()`).