### PR TITLE
Revert "FilteredSceneProcessor : Use "userDefault" to default filters to off"

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,7 +18,6 @@ Improvements
 - CopyPrimitiveVariables : Improved performance. In one benchmark, scene generation time has been reduced by 50%.
 - MergeScenes : Improved performance when merging overlapping hierarchies.
 - Serialisation : Reduced file size and load time by omitting redundant `setInput()` calls from serialisations.
-- Scene node filters : All newly created nodes now require a filter to be connected before they will affect the scene. Previously some nodes affected everything by default and others affected nothing by default, resulting in confusion.
 
 Fixes
 -----

--- a/python/GafferSceneUI/FilteredSceneProcessorUI.py
+++ b/python/GafferSceneUI/FilteredSceneProcessorUI.py
@@ -74,14 +74,6 @@ Gaffer.Metadata.registerNode(
 			"nodule:type", "GafferUI::StandardNodule",
 			"plugValueWidget:type", "GafferSceneUI.FilterPlugValueWidget",
 
-			# Several of our older nodes default to affecting all
-			# locations if no filter is connected. This was a mistake,
-			# and one day we need to change the defaults and figure out
-			# how to convert old scripts during loading. Until then
-			# we use a `userDefault` so that nodes newly created via the
-			# UI will have the default behaviour we want.
-			"userDefault", IECore.PathMatcher.Result.NoMatch,
-
 		],
 
 	},


### PR DESCRIPTION
This reverts commit 6db597e2370e831e0bcc49ad03ce3c2f0558022f.

Although we still want to get to a point where the true default for all filters is off, this turned out not to be a useful intermediate step. The following sequence of operations lead to behaviour even more confusing than what we had before :

1. Make a ShaderAssignment and connect a shader. Nothing happens yet (good).
2. Add a filter, the shader is assigned (good).
3. Disconnect the filter, the shader is not assigned (good).
4. Reconnect. Copy paste. The shader is assigned by the copy too (good).
5. Disconnect the filter from the copy. The shader is still assigned (bad).

