### PR TITLE
SpreadsheetUI : Avoid circular references

### DIFF
--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -2009,19 +2009,17 @@ GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu, scoped = Fa
 # NodeEditor tool menu
 # ====================
 
-def __createSpreadsheetForNode( node, activeRowNamesConnection, selectorContextVariablePlug, selectorValue ) :
+def __createSpreadsheetForNode( node, activeRowNamesConnection, selectorContextVariablePlug, selectorValue, menu ) :
 
 	with Gaffer.UndoScope( node.scriptNode() ) :
 
 		spreadsheet = Gaffer.Spreadsheet( node.getName() + "Spreadsheet" )
-		# We don't need to worry about uiParent here as it's a new sheet so there will be no conflicts.
-		__connectPlugToRowNames( activeRowNamesConnection, selectorContextVariablePlug, selectorValue, None, spreadsheet )
+		__connectPlugToRowNames( activeRowNamesConnection, selectorContextVariablePlug, selectorValue, spreadsheet, menu )
 		node.parent().addChild( spreadsheet )
 
 	GafferUI.NodeEditor.acquire( spreadsheet )
 
-# uiParent is used to find the parent window for the 'are you sure' confirmation dialogue - if required.
-def __connectPlugToRowNames( activeRowNamesConnection, selectorContextVariablePlug, selectorValue, uiParent, spreadsheet ) :
+def __connectPlugToRowNames( activeRowNamesConnection, selectorContextVariablePlug, selectorValue, spreadsheet, menu ) :
 
 	node = activeRowNamesConnection.node()
 
@@ -2049,12 +2047,7 @@ def __connectPlugToRowNames( activeRowNamesConnection, selectorContextVariablePl
 			confirmLabel = "Continue"
 		)
 
-		if uiParent is None :
-			window = GafferUI.ScriptWindow.acquire( node.scriptNode() )
-		else :
-			window = uiParent.ancestor( GafferUI.Window )
-
-		if not confirm.waitForConfirmation( parentWindow = window ) :
+		if not confirm.waitForConfirmation( parentWindow = menu.ancestor( GafferUI.Window ) ) :
 			return
 
 	with Gaffer.UndoScope( node.scriptNode() ) :
@@ -2117,7 +2110,7 @@ def __nodeEditorToolMenu( nodeEditor, node, menuDefinition ) :
 		}
 	)
 
-	connectCommand = functools.partial( __connectPlugToRowNames, activeRowNamesConnection, selectorContextVariablePlug, selectorValue, nodeEditor )
+	connectCommand = functools.partial( __connectPlugToRowNames, activeRowNamesConnection, selectorContextVariablePlug, selectorValue )
 	menuDefinition.append(
 		"/Connect to Spreadsheet",
 		{


### PR DESCRIPTION
This is a slightly speculative fix for a series of errors I discovered in my shell after testing #3560 :

```
Traceback (most recent call last):
  File "/disk1/john/dev/build/gaffer/python/Gaffer/WeakMethod.py", line 67, in __call__
    return m( *args, **kwArgs )
  File "/disk1/john/dev/build/gaffer/python/GafferUI/PlugLayout.py", line 516, in __plugDirtied
    if not self.visible() or plug.direction() != plug.Direction.In :
  File "/disk1/john/dev/build/gaffer/python/GafferUI/Widget.py", line 259, in visible
    return self.__qtWidget.isVisibleTo( relativeTo )
RuntimeError: Internal C++ object (PySide2.QtWidgets.QWidget) already deleted.
```

I was unable to get this to reproduce, but the error is a classic symptom of a circular reference keeping a `GafferUI.Widget` alive past the point the Qt half has expired. It seems more than coincidence that it occurred while testing new code that did indeed contain a circular reference due to baking the NodeEditor into a menu command.

The fix is pretty straightforward : just rely on the automatically provided `menu` argument to commands instead of stashing references inside a `partial()`.

