### PR TITLE
Gaffer : Add InternedStringDataPlug

### DIFF
--- a/include/Gaffer/TypeIds.h
+++ b/include/Gaffer/TypeIds.h
@@ -138,6 +138,7 @@ enum TypeId
 	ShufflePlugTypeId = 110091,
 	ShufflesPlugTypeId = 110092,
 	EditScopeTypeId = 110093,
+	InternedStringDataPlugTypeId = 110094,
 
 	LastTypeId = 110159,
 

--- a/include/Gaffer/TypedObjectPlug.h
+++ b/include/Gaffer/TypedObjectPlug.h
@@ -51,6 +51,7 @@
 #include "IECore/Object.h"
 #include "IECore/ObjectVector.h"
 #include "IECore/PathMatcherData.h"
+#include "IECore/SimpleTypedData.h"
 
 namespace Gaffer
 {
@@ -123,6 +124,7 @@ class IECORE_EXPORT TypedObjectPlug : public ValuePlug
 #ifndef Gaffer_EXPORTS
 
 extern template class TypedObjectPlug<IECore::Object>;
+extern template class TypedObjectPlug<IECore::InternedStringData>;
 extern template class TypedObjectPlug<IECore::BoolVectorData>;
 extern template class TypedObjectPlug<IECore::IntVectorData>;
 extern template class TypedObjectPlug<IECore::FloatVectorData>;
@@ -140,6 +142,7 @@ extern template class TypedObjectPlug<IECore::PathMatcherData>;
 #endif
 
 typedef TypedObjectPlug<IECore::Object> ObjectPlug;
+typedef TypedObjectPlug<IECore::InternedStringData> InternedStringDataPlug;
 typedef TypedObjectPlug<IECore::BoolVectorData> BoolVectorDataPlug;
 typedef TypedObjectPlug<IECore::IntVectorData> IntVectorDataPlug;
 typedef TypedObjectPlug<IECore::FloatVectorData> FloatVectorDataPlug;
@@ -155,6 +158,7 @@ typedef TypedObjectPlug<IECore::CompoundData> AtomicCompoundDataPlug;
 typedef TypedObjectPlug<IECore::PathMatcherData> PathMatcherDataPlug;
 
 IE_CORE_DECLAREPTR( ObjectPlug );
+IE_CORE_DECLAREPTR( InternedStringDataPlug );
 IE_CORE_DECLAREPTR( BoolVectorDataPlug );
 IE_CORE_DECLAREPTR( IntVectorDataPlug );
 IE_CORE_DECLAREPTR( FloatVectorDataPlug );
@@ -172,6 +176,10 @@ IE_CORE_DECLAREPTR( PathMatcherDataPlug );
 typedef FilteredChildIterator<PlugPredicate<Plug::Invalid, ObjectPlug> > ObjectPlugIterator;
 typedef FilteredChildIterator<PlugPredicate<Plug::In, ObjectPlug> > InputObjectPlugIterator;
 typedef FilteredChildIterator<PlugPredicate<Plug::Out, ObjectPlug> > OutputObjectPlugIterator;
+
+typedef FilteredChildIterator<PlugPredicate<Plug::Invalid, InternedStringDataPlug> > InternedStringDataPlugIterator;
+typedef FilteredChildIterator<PlugPredicate<Plug::In, InternedStringDataPlug> > InputInternedStringDataPlugIterator;
+typedef FilteredChildIterator<PlugPredicate<Plug::Out, InternedStringDataPlug> > OutputInternedStringDataPlugIterator;
 
 typedef FilteredChildIterator<PlugPredicate<Plug::Invalid, BoolVectorDataPlug> > BoolVectorDataPlugIterator;
 typedef FilteredChildIterator<PlugPredicate<Plug::In, BoolVectorDataPlug> > InputBoolVectorDataPlugIterator;
@@ -224,6 +232,10 @@ typedef FilteredChildIterator<PlugPredicate<Plug::Out, AtomicCompoundDataPlug> >
 typedef FilteredRecursiveChildIterator<PlugPredicate<Plug::Invalid, ObjectPlug>, PlugPredicate<> > RecursiveObjectPlugIterator;
 typedef FilteredRecursiveChildIterator<PlugPredicate<Plug::In, ObjectPlug>, PlugPredicate<> > RecursiveInputObjectPlugIterator;
 typedef FilteredRecursiveChildIterator<PlugPredicate<Plug::Out, ObjectPlug>, PlugPredicate<> > RecursiveOutputObjectPlugIterator;
+
+typedef FilteredRecursiveChildIterator<PlugPredicate<Plug::Invalid, InternedStringDataPlug>, PlugPredicate<> > RecursiveInternedStringDataPlugIterator;
+typedef FilteredRecursiveChildIterator<PlugPredicate<Plug::In, InternedStringDataPlug>, PlugPredicate<> > RecursiveInputInternedStringDataPlugIterator;
+typedef FilteredRecursiveChildIterator<PlugPredicate<Plug::Out, InternedStringDataPlug>, PlugPredicate<> > RecursiveOutputInternedStringDataPlugIterator;
 
 typedef FilteredRecursiveChildIterator<PlugPredicate<Plug::Invalid, BoolVectorDataPlug>, PlugPredicate<> > RecursiveBoolVectorDataPlugIterator;
 typedef FilteredRecursiveChildIterator<PlugPredicate<Plug::In, BoolVectorDataPlug>, PlugPredicate<> > RecursiveInputBoolVectorDataPlugIterator;

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -459,6 +459,8 @@ IECore::DataPtr extractDataFromPlug( const ValuePlug *plug )
 			return new M44fData( static_cast<const TransformPlug *>( plug )->matrix() );
 		case M44fPlugTypeId :
 			return new M44fData( static_cast<const M44fPlug *>( plug )->getValue() );
+		case InternedStringDataPlugTypeId :
+			return static_cast<const InternedStringDataPlug *>( plug )->getValue()->copy();
 		default :
 			throw IECore::Exception(
 				boost::str( boost::format( "Plug \"%s\" has unsupported type \"%s\"" ) % plug->getName().string() % plug->typeName() )

--- a/src/Gaffer/TypedObjectPlug.cpp
+++ b/src/Gaffer/TypedObjectPlug.cpp
@@ -43,6 +43,7 @@ namespace Gaffer
 {
 
 GAFFER_PLUG_DEFINE_TEMPLATE_TYPE( Gaffer::ObjectPlug, ObjectPlugTypeId )
+GAFFER_PLUG_DEFINE_TEMPLATE_TYPE( Gaffer::InternedStringDataPlug, InternedStringDataPlugTypeId )
 GAFFER_PLUG_DEFINE_TEMPLATE_TYPE( Gaffer::BoolVectorDataPlug, BoolVectorDataPlugTypeId )
 GAFFER_PLUG_DEFINE_TEMPLATE_TYPE( Gaffer::IntVectorDataPlug, IntVectorDataPlugTypeId )
 GAFFER_PLUG_DEFINE_TEMPLATE_TYPE( Gaffer::FloatVectorDataPlug, FloatVectorDataPlugTypeId )
@@ -59,6 +60,7 @@ GAFFER_PLUG_DEFINE_TEMPLATE_TYPE( Gaffer::PathMatcherDataPlug, PathMatcherDataPl
 
 // explicit instantiation
 template class TypedObjectPlug<IECore::Object>;
+template class TypedObjectPlug<IECore::InternedStringData>;
 template class TypedObjectPlug<IECore::BoolVectorData>;
 template class TypedObjectPlug<IECore::IntVectorData>;
 template class TypedObjectPlug<IECore::FloatVectorData>;

--- a/src/GafferModule/TypedObjectPlugBinding.cpp
+++ b/src/GafferModule/TypedObjectPlugBinding.cpp
@@ -47,6 +47,7 @@
 void GafferModule::bindTypedObjectPlug()
 {
 	GafferBindings::TypedObjectPlugClass<Gaffer::ObjectPlug>();
+	GafferBindings::TypedObjectPlugClass<Gaffer::InternedStringDataPlug>();
 	GafferBindings::TypedObjectPlugClass<Gaffer::BoolVectorDataPlug>();
 	GafferBindings::TypedObjectPlugClass<Gaffer::IntVectorDataPlug>();
 	GafferBindings::TypedObjectPlugClass<Gaffer::FloatVectorDataPlug>();


### PR DESCRIPTION
Not sure if this is a good idea, but I figured putting up a PR might be a good place to discuss it.

We have InternedStringVectorDataPlug, but not InternedStringDataPlug - it seems like it kind of makes sense in terms of symmetry.

I don't have a particularly strong use case, but this does make it possible to query sets from expressions using a ContextVariables node ( the scene:setName context variable needs to be set with an InternedStringData ).  This was useful in prototyping a feature for an ImageEngine ( that feature might be a terrible idea, but it's nice to be able to prototype it ).

If this is actually a good idea, I should probably add some tests in, but I figured I would do a minimal amount of work until we decide if we want to do this.