### PR TITLE
TransformTools : Don't edit read-only EditScopes

### DIFF
--- a/src/GafferSceneUI/RotateTool.cpp
+++ b/src/GafferSceneUI/RotateTool.cpp
@@ -357,9 +357,8 @@ bool RotateTool::Rotation::canApply( const Imath::V3i &axisMask ) const
 	auto edit = m_selection.acquireTransformEdit( /* createIfNecessary = */ false );
 	if( !edit )
 	{
-		// Edit will be created on demand in apply(), at which point we know
-		// it will be editable.
-		return true;
+		// Edit will be created on demand in `apply()`.
+		return !MetadataAlgo::readOnly( m_selection.editTarget() );
 	}
 
 	Imath::V3f current;

--- a/src/GafferSceneUI/ScaleTool.cpp
+++ b/src/GafferSceneUI/ScaleTool.cpp
@@ -208,9 +208,8 @@ bool ScaleTool::Scale::canApply( const Imath::V3i &axisMask ) const
 	auto edit = m_selection.acquireTransformEdit( /* createIfNecessary = */ false );
 	if( !edit )
 	{
-		// Edit will be created on demand in apply(), at which point we know
-		// it will be editable.
-		return true;
+		// Edit will be created on demand in `apply()`.
+		return !MetadataAlgo::readOnly( m_selection.editTarget() );
 	}
 
 	for( int i = 0; i < 3; ++i )

--- a/src/GafferSceneUI/TranslateTool.cpp
+++ b/src/GafferSceneUI/TranslateTool.cpp
@@ -327,9 +327,8 @@ bool TranslateTool::Translation::canApply( const Imath::V3f &offset ) const
 	auto edit = m_selection.acquireTransformEdit( /* createIfNecessary = */ false );
 	if( !edit )
 	{
-		// Plugs will be created on demand in apply(), at which point we know
-		// it will be editable.
-		return true;
+		// Edit will be created on demand in `apply()`.
+		return !MetadataAlgo::readOnly( m_selection.editTarget() );
 	}
 
 	V3f offsetInTransformSpace;


### PR DESCRIPTION
This bug caused a strange behaviour with locked EditScope nodes. The transform handles were initially moveable, allowing the user to start a drag. But as soon as the drag started, we created the edit and immediately realised that it was read-only, and so made the handles non-moveable. The result : the object didn't move, but an unwanted edit was still created in the EditScope.
