### PR TITLE
EditScopeUI : Order upstream scopes by furthest first

### DIFF
--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -189,7 +189,7 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		result.append( "/__UpstreamDivider__", { "divider" : True, "label" : "Upstream" } )
 		if upstream :
-			for editScope in upstream :
+			for editScope in reversed( upstream ) :
 				addItem( editScope )
 		else :
 			result.append( "/None Available", { "active" : False } )


### PR DESCRIPTION
We were inadvertently listing them furthest last which is visually opposite to the graph order.