### PR TITLE
PrimitiveSampler nodes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.57.x.x
+========
+
+API
+---
+
+- PrimitiveSampler : Added a new base class for nodes which sample primitive variables using an `IECoreScene::PrimitiveEvaluator`.
+
 0.57.0.0
 ========
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.57.x.x
 ========
 
+Features
+--------
+
+- ClosestPointSampler : Added a new node for sampling primitive variables from the closest point on a source primitive.
+
 API
 ---
 

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - ClosestPointSampler : Added a new node for sampling primitive variables from the closest point on a source primitive.
+- CurveSampler : Added a new node for sampling primitive variables from parametric positions on some source curves.
 
 API
 ---

--- a/include/GafferScene/ClosestPointSampler.h
+++ b/include/GafferScene/ClosestPointSampler.h
@@ -59,7 +59,7 @@ class GAFFERSCENE_API ClosestPointSampler : public PrimitiveSampler
 
 		bool affectsSamplingFunction( const Gaffer::Plug *input ) const override;
 		void hashSamplingFunction( IECore::MurmurHash &h ) const override;
-		SamplingFunction computeSamplingFunction( const IECoreScene::Primitive *primitive, IECoreScene::PrimitiveVariable::Interpolation &interpolation ) const override;
+		SamplingFunction computeSamplingFunction( const IECoreScene::Primitive *destinationPrimitive, IECoreScene::PrimitiveVariable::Interpolation &interpolation ) const override;
 
 	private :
 

--- a/include/GafferScene/ClosestPointSampler.h
+++ b/include/GafferScene/ClosestPointSampler.h
@@ -34,24 +34,41 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERSCENE_CLOSESTPOINTSAMPLER_H
+#define GAFFERSCENE_CLOSESTPOINTSAMPLER_H
 
-#include "PrimitiveSamplerBinding.h"
-
-#include "GafferScene/ClosestPointSampler.h"
 #include "GafferScene/PrimitiveSampler.h"
 
-#include "GafferBindings/DependencyNodeBinding.h"
-
-using namespace boost::python;
-using namespace Gaffer;
-using namespace GafferBindings;
-using namespace GafferScene;
-
-void GafferSceneModule::bindPrimitiveSampler()
+namespace GafferScene
 {
 
-	GafferBindings::DependencyNodeClass<GafferScene::PrimitiveSampler>();
-	GafferBindings::DependencyNodeClass<GafferScene::ClosestPointSampler>();
+class GAFFERSCENE_API ClosestPointSampler : public PrimitiveSampler
+{
 
-}
+	public :
+
+		ClosestPointSampler( const std::string &name = defaultName<ClosestPointSampler>() );
+		~ClosestPointSampler() override;
+
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::ClosestPointSampler, ClosestPointSamplerTypeId, PrimitiveSampler );
+
+		Gaffer::StringPlug *positionPlug();
+		const Gaffer::StringPlug *positionPlug() const;
+
+	protected :
+
+		bool affectsSamplingFunction( const Gaffer::Plug *input ) const override;
+		void hashSamplingFunction( IECore::MurmurHash &h ) const override;
+		SamplingFunction computeSamplingFunction( const IECoreScene::Primitive *primitive, IECoreScene::PrimitiveVariable::Interpolation &interpolation ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( ClosestPointSampler )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_CLOSESTPOINTSAMPLER_H

--- a/include/GafferScene/CurveSampler.h
+++ b/include/GafferScene/CurveSampler.h
@@ -34,26 +34,44 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERSCENE_CURVESAMPLER_H
+#define GAFFERSCENE_CURVESAMPLER_H
 
-#include "PrimitiveSamplerBinding.h"
-
-#include "GafferScene/ClosestPointSampler.h"
-#include "GafferScene/CurveSampler.h"
 #include "GafferScene/PrimitiveSampler.h"
 
-#include "GafferBindings/DependencyNodeBinding.h"
-
-using namespace boost::python;
-using namespace Gaffer;
-using namespace GafferBindings;
-using namespace GafferScene;
-
-void GafferSceneModule::bindPrimitiveSampler()
+namespace GafferScene
 {
 
-	GafferBindings::DependencyNodeClass<GafferScene::PrimitiveSampler>();
-	GafferBindings::DependencyNodeClass<GafferScene::ClosestPointSampler>();
-	GafferBindings::DependencyNodeClass<GafferScene::CurveSampler>();
+class GAFFERSCENE_API CurveSampler : public PrimitiveSampler
+{
 
-}
+	public :
+
+		CurveSampler( const std::string &name = defaultName<CurveSampler>() );
+		~CurveSampler() override;
+
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::CurveSampler, CurveSamplerTypeId, PrimitiveSampler );
+
+		Gaffer::StringPlug *curveIndexPlug();
+		const Gaffer::StringPlug *curveIndexPlug() const;
+
+		Gaffer::StringPlug *vPlug();
+		const Gaffer::StringPlug *vPlug() const;
+
+	protected :
+
+		bool affectsSamplingFunction( const Gaffer::Plug *input ) const override;
+		void hashSamplingFunction( IECore::MurmurHash &h ) const override;
+		SamplingFunction computeSamplingFunction( const IECoreScene::Primitive *primitive, IECoreScene::PrimitiveVariable::Interpolation &interpolation ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( CurveSampler )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_CURVESAMPLER_H

--- a/include/GafferScene/CurveSampler.h
+++ b/include/GafferScene/CurveSampler.h
@@ -62,7 +62,7 @@ class GAFFERSCENE_API CurveSampler : public PrimitiveSampler
 
 		bool affectsSamplingFunction( const Gaffer::Plug *input ) const override;
 		void hashSamplingFunction( IECore::MurmurHash &h ) const override;
-		SamplingFunction computeSamplingFunction( const IECoreScene::Primitive *primitive, IECoreScene::PrimitiveVariable::Interpolation &interpolation ) const override;
+		SamplingFunction computeSamplingFunction( const IECoreScene::Primitive *destinationPrimitive, IECoreScene::PrimitiveVariable::Interpolation &interpolation ) const override;
 
 	private :
 

--- a/include/GafferScene/PrimitiveSampler.h
+++ b/include/GafferScene/PrimitiveSampler.h
@@ -81,17 +81,19 @@ class GAFFERSCENE_API PrimitiveSampler : public Deformer
 		///
 		/// Derived classes are responsible for generating a `SamplingFunction`, which
 		/// performs an `IECoreScene::PrimitiveEvaluator` query for a single index within the
-		/// input primitive. The base class takes care of everything else.
+		/// destination primitive. The base class takes care of everything else.
 
 		using SamplingFunction = std::function<bool (
-			/// The PrimitiveEvaluator to use for sampling.
+			/// The PrimitiveEvaluator to use for sampling
+			/// the source primitive.
 			const IECoreScene::PrimitiveEvaluator &evaluator,
-			/// The index within the input to date to sample for.
+			/// The index within the destination primitive to
+			/// sample for.
 			size_t index,
 			/// A transform that must be applied to any geometric
 			/// data before querying the `evaluator`. This converts
-			/// from the object space of the sampling object into
-			/// the object space of the source object.
+			/// from the object space of the destination primitive into
+			/// the object space of the source primitive.
 			const Imath::M44f &transform,
 			/// The destination for the result of the `evaluator`
 			/// query.
@@ -105,12 +107,12 @@ class GAFFERSCENE_API PrimitiveSampler : public Deformer
 		/// Must be implemented to hash all plugs that are used in `computeSamplingFunction()`.
 		/// All implementation should call the base class implementation first.
 		virtual void hashSamplingFunction( IECore::MurmurHash &h ) const = 0;
-		/// Must be implemented to return an appropriate `SamplingFunction` for the
-		/// specified primitive, and fill `interpolation` with the interpolation of
-		/// the primitive variables being used for the query. The sampling function
-		/// will then be queried with `index` values in the interval
-		/// `[ 0, primitive->variableSize( interpolation ) )`.
-		virtual SamplingFunction computeSamplingFunction( const IECoreScene::Primitive *primitive, IECoreScene::PrimitiveVariable::Interpolation &interpolation ) const = 0;
+		/// Must be implemented to return a `SamplingFunction` that will perform queries
+		/// on behalf of the destination primitive. The `interpolation` output parameter
+		/// must be filled with the interpolation of the primitive variables to be added
+		/// to the destination primitive. The sampling function will then be queried with
+		/// `index` values in the interval `[ 0, destinationPrimitive->variableSize( interpolation ) )`.
+		virtual SamplingFunction computeSamplingFunction( const IECoreScene::Primitive *destinationPrimitive, IECoreScene::PrimitiveVariable::Interpolation &interpolation ) const = 0;
 
 	private :
 

--- a/include/GafferScene/PrimitiveSampler.h
+++ b/include/GafferScene/PrimitiveSampler.h
@@ -1,0 +1,131 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENE_PRIMITIVESAMPLER_H
+#define GAFFERSCENE_PRIMITIVESAMPLER_H
+
+#include "GafferScene/Deformer.h"
+
+#include "Gaffer/StringPlug.h"
+
+#include "IECoreScene/PrimitiveEvaluator.h"
+
+namespace GafferScene
+{
+
+/// Base class for nodes which use an `IECoreScene::PrimitiveEvaluator`
+/// to sample primitive variables from another object.
+class GAFFERSCENE_API PrimitiveSampler : public Deformer
+{
+
+	public :
+
+		~PrimitiveSampler() override;
+
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::PrimitiveSampler, PrimitiveSamplerTypeId, Deformer );
+
+		ScenePlug *sourcePlug();
+		const ScenePlug *sourcePlug() const;
+
+		Gaffer::StringPlug *sourceLocationPlug();
+		const Gaffer::StringPlug *sourceLocationPlug() const;
+
+		Gaffer::StringPlug *primitiveVariablesPlug();
+		const Gaffer::StringPlug *primitiveVariablesPlug() const;
+
+		Gaffer::StringPlug *prefixPlug();
+		const Gaffer::StringPlug *prefixPlug() const;
+
+		Gaffer::StringPlug *statusPlug();
+		const Gaffer::StringPlug *statusPlug() const;
+
+	protected :
+
+		PrimitiveSampler( const std::string &name = defaultName<PrimitiveSampler>() );
+
+		/// SamplingFunction
+		/// ================
+		///
+		/// Derived classes are responsible for generating a `SamplingFunction`, which
+		/// performs an `IECoreScene::PrimitiveEvaluator` query for a single index within the
+		/// input primitive. The base class takes care of everything else.
+
+		using SamplingFunction = std::function<bool (
+			/// The PrimitiveEvaluator to use for sampling.
+			const IECoreScene::PrimitiveEvaluator &evaluator,
+			/// The index within the input to date to sample for.
+			size_t index,
+			/// A transform that must be applied to any geometric
+			/// data before querying the `evaluator`. This converts
+			/// from the object space of the sampling object into
+			/// the object space of the source object.
+			const Imath::M44f &transform,
+			/// The destination for the result of the `evaluator`
+			/// query.
+			IECoreScene::PrimitiveEvaluator::Result &result
+		)>;
+
+		/// Must be implemented to return true if the specified plug affects the
+		/// generation of the `SamplingFunction`. All implementations should call
+		/// the base implementation first, and return `true` if it does.
+		virtual bool affectsSamplingFunction( const Gaffer::Plug *input ) const = 0;
+		/// Must be implemented to hash all plugs that are used in `computeSamplingFunction()`.
+		/// All implementation should call the base class implementation first.
+		virtual void hashSamplingFunction( IECore::MurmurHash &h ) const = 0;
+		/// Must be implemented to return an appropriate `SamplingFunction` for the
+		/// specified primitive, and fill `interpolation` with the interpolation of
+		/// the primitive variables being used for the query. The sampling function
+		/// will then be queried with `index` values in the interval
+		/// `[ 0, primitive->variableSize( interpolation ) )`.
+		virtual SamplingFunction computeSamplingFunction( const IECoreScene::Primitive *primitive, IECoreScene::PrimitiveVariable::Interpolation &interpolation ) const = 0;
+
+	private :
+
+		bool affectsProcessedObject( const Gaffer::Plug *input ) const final;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const final;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const final;
+
+		bool adjustBounds() const final;
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( PrimitiveSampler )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_PRIMITIVESAMPLER_H

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -154,6 +154,7 @@ enum TypeId
 	ShufflePrimitiveVariablesTypeId = 110609,
 	LocaliseAttributesTypeId = 110610,
 	PrimitiveSamplerTypeId = 110611,
+	ClosestPointSamplerTypeId = 110612,
 
 	PreviewGeometryTypeId = 110648,
 	PreviewProceduralTypeId = 110649,

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -153,6 +153,7 @@ enum TypeId
 	ShuffleAttributesTypeId = 110608,
 	ShufflePrimitiveVariablesTypeId = 110609,
 	LocaliseAttributesTypeId = 110610,
+	PrimitiveSamplerTypeId = 110611,
 
 	PreviewGeometryTypeId = 110648,
 	PreviewProceduralTypeId = 110649,

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -155,6 +155,7 @@ enum TypeId
 	LocaliseAttributesTypeId = 110610,
 	PrimitiveSamplerTypeId = 110611,
 	ClosestPointSamplerTypeId = 110612,
+	CurveSamplerTypeId = 110613,
 
 	PreviewGeometryTypeId = 110648,
 	PreviewProceduralTypeId = 110649,

--- a/python/GafferSceneTest/ClosestPointSamplerTest.py
+++ b/python/GafferSceneTest/ClosestPointSamplerTest.py
@@ -39,6 +39,7 @@ import imath
 import IECore
 import IECoreScene
 
+import GafferTest
 import GafferScene
 import GafferSceneTest
 
@@ -236,6 +237,31 @@ class ClosestPointSamplerTest( GafferSceneTest.SceneTestCase ) :
 		self.assertNotEqual( sampler["out"].boundHash( "/plane" ), sampler["in"].boundHash( "/plane" ) )
 		sampler["adjustBounds"].setValue( False )
 		self.assertEqual( sampler["out"].boundHash( "/plane" ), sampler["in"].boundHash( "/plane" ) )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testPerformance( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		plane = GafferScene.Plane()
+		plane["divisions"].setValue( imath.V2i( 1000, 200 ) )
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		sampler = GafferScene.ClosestPointSampler()
+		sampler["in"].setInput( plane["out"] )
+		sampler["source"].setInput( sphere["out"] )
+		sampler["filter"].setInput( planeFilter["out"] )
+		sampler["sourceLocation"].setValue( "/sphere" )
+		sampler["primitiveVariables"].setValue( "uv" )
+
+		# Precache the input object so we don't include
+		# it in the performance measurement.
+		sampler["in"].object( "/plane" )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			sampler["out"].object( "/plane" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/ClosestPointSamplerTest.py
+++ b/python/GafferSceneTest/ClosestPointSamplerTest.py
@@ -1,0 +1,241 @@
+##########################################################################
+#
+#  Copyright (c) 2020, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+
+import IECore
+import IECoreScene
+
+import GafferScene
+import GafferSceneTest
+
+class ClosestPointSamplerTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		# Build network to perform closest point queries
+		# from a plane, against a copy of the same plane
+		# converted to a points primitive. Closest points
+		# should be exact vertices.
+
+		plane = GafferScene.Plane()
+		plane["dimensions"].setValue( imath.V2f( 2 ) )
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		planeTransform = GafferScene.Transform()
+		planeTransform["in"].setInput( plane["out"] )
+		planeTransform["filter"].setInput( planeFilter["out"] )
+
+		points = GafferScene.MeshToPoints()
+		points["in"].setInput( plane["out"] )
+		points["filter"].setInput( planeFilter["out"] )
+
+		pointsTransform = GafferScene.Transform()
+		pointsTransform["in"].setInput( points["out"] )
+		pointsTransform["filter"].setInput( planeFilter["out"] )
+
+		sampler = GafferScene.ClosestPointSampler()
+		sampler["in"].setInput( planeTransform["out"] )
+		sampler["source"].setInput( pointsTransform["out"] )
+		sampler["filter"].setInput( planeFilter["out"] )
+		sampler["sourceLocation"].setValue( "/plane" )
+		sampler["prefix"].setValue( "sampled:" )
+		self.assertScenesEqual( sampler["out"], plane["out"] )
+
+		# Identical transforms. Closest point should
+		# be the same as the query point.
+
+		sampler["primitiveVariables"].setValue( "P" )
+		self.assertSceneValid( sampler["out"] )
+
+		inMesh = sampler["in"].object( "/plane" )
+		outMesh = sampler["out"].object( "/plane" )
+		self.assertEqual( set( outMesh.keys() ), set( inMesh.keys() + [ "sampled:P" ] ) )
+		self.assertEqual( outMesh["sampled:P"], inMesh["P"] )
+
+		# Translate source off to one side. A single
+		# point is the closest for all query points.
+
+		pointsTransform["transform"]["translate"].setValue( imath.V3f( 5, 5, 0 ) )
+		outMesh = sampler["out"].object( "/plane" )
+		self.assertEqual(
+			outMesh["sampled:P"].data,
+			IECore.V3fVectorData(
+				[ imath.V3f( 4, 4, 0 ) ] * 4,
+				IECore.GeometricData.Interpretation.Point
+			)
+		)
+
+		# Translate the plane too. Sampled results should
+		# be adjusted so that they are relative to the local
+		# space of the plane.
+
+		planeTransform["transform"]["translate"].setValue( imath.V3f( -1, 0, 0 ) )
+		outMesh = sampler["out"].object( "/plane" )
+		self.assertEqual(
+			outMesh["sampled:P"].data,
+			IECore.V3fVectorData(
+				[ imath.V3f( 5, 4, 0 ) ] * 4,
+				IECore.GeometricData.Interpretation.Point
+			)
+		)
+
+	def testPrimitiveVariableTypes( self ) :
+
+		pointsPrimitive = IECoreScene.PointsPrimitive(
+			IECore.V3fVectorData( [ imath.V3f( 0 ) ] )
+		)
+		pointsPrimitive["vector"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.V3fVectorData(
+				[ imath.V3f( 1, 2, 3 ) ],
+				IECore.GeometricData.Interpretation.Vector
+			),
+		)
+		pointsPrimitive["normal"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.V3fVectorData(
+				[ imath.V3f( 4, 5, 6 ) ],
+				IECore.GeometricData.Interpretation.Normal
+			),
+		)
+		pointsPrimitive["point"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.V3fVectorData(
+				[ imath.V3f( 4, 5, 6 ) ],
+				IECore.GeometricData.Interpretation.Point
+			),
+		)
+		pointsPrimitive["uv"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.V2fVectorData(
+				[ imath.V2f( 0, 1 ) ],
+				IECore.GeometricData.Interpretation.UV
+			),
+		)
+		pointsPrimitive["Cs"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.Color3fVectorData( [ imath.Color3f( 0, 0, 1 ) ] ),
+		)
+		pointsPrimitive["float"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.FloatVectorData( [ 0.5 ] ),
+		)
+		pointsPrimitive["int"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.IntVectorData( [ 10 ] ),
+		)
+
+		points = GafferScene.ObjectToScene()
+		points["object"].setValue( pointsPrimitive )
+
+		plane = GafferScene.Plane()
+		plane["transform"]["translate"]["x"].setValue( 1 )
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		sampler = GafferScene.ClosestPointSampler()
+		sampler["in"].setInput( plane["out"] )
+		sampler["source"].setInput( points["out"] )
+		sampler["filter"].setInput( planeFilter["out"] )
+		sampler["sourceLocation"].setValue( "/object" )
+		sampler["primitiveVariables"].setValue( "*" )
+		sampler["prefix"].setValue( "sampled:" )
+
+		p = sampler["out"].object( "/plane" )
+		for name in pointsPrimitive.keys() :
+			primVar = pointsPrimitive[name]
+			sampledName = "sampled:" + name
+			self.assertIn( sampledName, p )
+			sampledPrimVar = p[sampledName]
+			self.assertIsInstance( sampledPrimVar.data, primVar.data.__class__ )
+			if hasattr( primVar.data, "getInterpretation" ) :
+				self.assertEqual( sampledPrimVar.data.getInterpretation(), primVar.data.getInterpretation() )
+
+		self.assertEqual( p["sampled:vector"].data[0], imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( p["sampled:normal"].data[0], imath.V3f( 4, 5, 6 ) )
+		self.assertEqual( p["sampled:point"].data[0], imath.V3f( 3, 5, 6 ) )
+		self.assertEqual( p["sampled:uv"].data[0], imath.V2f( 0, 1 ) )
+		self.assertEqual( p["sampled:Cs"].data[0], imath.Color3f( 0, 0, 1 ) )
+		self.assertEqual( p["sampled:float"].data[0], 0.5 )
+		self.assertEqual( p["sampled:int"].data[0], 10 )
+
+	def testAdjustBounds( self ) :
+
+		plane = GafferScene.Plane()
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		sphere = GafferScene.Sphere()
+
+		sampler = GafferScene.ClosestPointSampler()
+		sampler["in"].setInput( plane["out"] )
+		sampler["source"].setInput( sphere["out"] )
+		sampler["sourceLocation"].setValue( "/sphere" )
+
+		# Not filtered to anything, so we expect bounds to be passed through.
+		self.assertEqual( sampler["out"].boundHash( "/plane" ), sampler["in"].boundHash( "/plane" ) )
+
+		# Filtered to something, but no primitive variables specified.
+		# We expect bounds to be passed through.
+		sampler["filter"].setInput( planeFilter["out"] )
+		self.assertEqual( sampler["out"].boundHash( "/plane" ), sampler["in"].boundHash( "/plane" ) )
+
+		# P being sampled. We expect the bounds to change.
+		sampler["primitiveVariables"].setValue( "P" )
+		self.assertNotEqual( sampler["out"].boundHash( "/plane" ), sampler["in"].boundHash( "/plane" ) )
+		sampler["primitiveVariables"].setValue( "*" )
+		self.assertNotEqual( sampler["out"].boundHash( "/plane" ), sampler["in"].boundHash( "/plane" ) )
+		sampler["primitiveVariables"].setValue( "P uv" )
+		self.assertNotEqual( sampler["out"].boundHash( "/plane" ), sampler["in"].boundHash( "/plane" ) )
+
+		# Unless there is a prefix being applied, in which case we
+		# expect a pass through again.
+		sampler["prefix"].setValue( "sampled:" )
+		self.assertEqual( sampler["out"].boundHash( "/plane" ), sampler["in"].boundHash( "/plane" ) )
+
+		# And we should be able to explicitly disable bounds updates.
+		sampler["prefix"].setValue( "" )
+		self.assertNotEqual( sampler["out"].boundHash( "/plane" ), sampler["in"].boundHash( "/plane" ) )
+		sampler["adjustBounds"].setValue( False )
+		self.assertEqual( sampler["out"].boundHash( "/plane" ), sampler["in"].boundHash( "/plane" ) )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/CurveSamplerTest.py
+++ b/python/GafferSceneTest/CurveSamplerTest.py
@@ -1,0 +1,129 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+
+import IECore
+import IECoreScene
+
+import GafferScene
+import GafferSceneTest
+
+class CurveSamplerTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		curvesPrimitive = IECoreScene.CurvesPrimitive(
+			IECore.IntVectorData( [ 2, 2 ] ),
+			IECore.CubicBasisf.linear(),
+			False,
+			IECore.V3fVectorData( [
+				imath.V3f( 0 ), imath.V3f( 1, 0, 0 ),
+				imath.V3f( 0 ), imath.V3f( 0, 1, 0 )
+			] )
+		)
+
+		curves = GafferScene.ObjectToScene()
+		curves["object"].setValue( curvesPrimitive )
+		curves["name"].setValue( "curves" )
+
+		points = GafferScene.ObjectToScene()
+		points["name"].setValue( "points" )
+
+		pointsFilter = GafferScene.PathFilter()
+		pointsFilter["paths"].setValue( IECore.StringVectorData( [ "/points" ] ) )
+
+		sampler = GafferScene.CurveSampler()
+		sampler["in"].setInput( points["out"] )
+		sampler["source"].setInput( curves["out"] )
+		sampler["filter"].setInput( pointsFilter["out"] )
+		sampler["sourceLocation"].setValue( "/curves" )
+		sampler["primitiveVariables"].setValue( "P" )
+		sampler["status"].setValue( "status" )
+		sampler["curveIndex"].setValue( "curveIndex" )
+		sampler["v"].setValue( "v" )
+
+		def __sampleCurves( curveIndex, v ) :
+
+			pointsPrimitive = IECoreScene.PointsPrimitive(
+				IECore.V3fVectorData( [ imath.V3f( 0 ) ] )
+			)
+			pointsPrimitive["curveIndex"] = IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+				IECore.IntVectorData( [ curveIndex ] ),
+			)
+			pointsPrimitive["v"] = IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+				IECore.FloatVectorData( [ v ] ),
+			)
+
+			points["object"].setValue( pointsPrimitive )
+
+			sampledPoints = sampler["out"].object( "/points" )
+			return sampledPoints["P"].data[0], sampledPoints["status"].data[0]
+
+		self.assertEqual(
+			__sampleCurves( 0, 0.5 ),
+			( imath.V3f( 0.5, 0, 0 ), True )
+		)
+
+		self.assertEqual(
+			__sampleCurves( 1, 0.5 ),
+			( imath.V3f( 0, 0.5, 0 ), True )
+		)
+
+		self.assertEqual(
+			__sampleCurves( -1, 0.5 ), # Curve index out of range
+			( imath.V3f( 0, 0, 0 ), False )
+		)
+
+		self.assertEqual(
+			__sampleCurves( 2, 0.5 ), # Curve index out of range
+			( imath.V3f( 0, 0, 0 ), False )
+		)
+
+		self.assertEqual(
+			__sampleCurves( 0, -0.01 ), # v out of range
+			( imath.V3f( 0, 0, 0 ), False )
+		)
+
+		self.assertEqual(
+			__sampleCurves( 0, 1.01 ), # v out of range
+			( imath.V3f( 0, 0, 0 ), False )
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -148,6 +148,7 @@ from ShufflePrimitiveVariablesTest import ShufflePrimitiveVariablesTest
 from EditScopeAlgoTest import EditScopeAlgoTest
 from LocaliseAttributesTest import LocaliseAttributesTest
 from ClosestPointSamplerTest import ClosestPointSamplerTest
+from CurveSamplerTest import CurveSamplerTest
 
 from IECoreScenePreviewTest import *
 from IECoreGLPreviewTest import *

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -147,6 +147,7 @@ from ShuffleAttributesTest import ShuffleAttributesTest
 from ShufflePrimitiveVariablesTest import ShufflePrimitiveVariablesTest
 from EditScopeAlgoTest import EditScopeAlgoTest
 from LocaliseAttributesTest import LocaliseAttributesTest
+from ClosestPointSamplerTest import ClosestPointSamplerTest
 
 from IECoreScenePreviewTest import *
 from IECoreGLPreviewTest import *

--- a/python/GafferSceneUI/ClosestPointSamplerUI.py
+++ b/python/GafferSceneUI/ClosestPointSamplerUI.py
@@ -1,0 +1,70 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.ClosestPointSampler,
+
+	"description",
+	"""
+	Samples primitive variables from the closest point on
+	the surface of a source primitive, and transfers the
+	values onto new primitive variable on the sampling objects.
+	""",
+
+	plugs = {
+
+		"position" : [
+
+			"description",
+			"""
+			The primitive variable that provides the positions
+			to find the closest point to. This defaults to "P",
+			the vertex position of the sampling object.
+			""",
+
+			"layout:section", "Settings.Input",
+			# Put the Input section before the Output section
+			"layout:index", 2,
+
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/CurveSamplerUI.py
+++ b/python/GafferSceneUI/CurveSamplerUI.py
@@ -1,0 +1,87 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.CurveSampler,
+
+	"description",
+	"""
+	Samples primitive variables from parametric positions on some
+	source curves. The positions are specified using the index of
+	the curve and its `v` parameter.
+	""",
+
+	plugs = {
+
+		"curveIndex" : [
+
+			"description",
+			"""
+			The name of an integer primitive variable that specifies the index of
+			the curve to be sampled. If left unspecified, the first curve will be sampled.
+			""",
+
+			"layout:section", "Settings.Input",
+			# Put the Input section before the Output section
+			"layout:index", 2,
+
+		],
+
+		"v" : [
+
+			"description",
+			"""
+			The name of a float primitive variable that specifies the parametric
+			position on the curve to be sampled. A value of 0 corresponds to
+			the start of the curve, and a value of 1 corresponds to the end.
+			If left unspecified, a value of 0 is used.
+
+			> Note : Values outside the `0-1` range are invalid and cannot
+			> be sampled. In this case, the `status` output primitive variable
+			> will contain `False` to indicate failure.
+			""",
+
+			"layout:section", "Settings.Input",
+
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/PrimitiveSamplerUI.py
+++ b/python/GafferSceneUI/PrimitiveSamplerUI.py
@@ -1,0 +1,126 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.PrimitiveSampler,
+
+	"description",
+	"""
+	Base class for nodes which sample primitive variables from
+	another primitive.
+	""",
+
+	plugs = {
+
+		"filter" : [
+
+			"description",
+			"""
+			The filter used to determine which objects in the
+			`in` scene will receive primitive variables sampled
+			from the `sourceLocation` in the `source` scene.
+			""",
+
+		],
+
+		"source" : [
+
+			"description",
+			"""
+			The scene that contains the source primitive that
+			primitive variables will be sampled from.
+			""",
+
+		],
+
+		"sourceLocation" : [
+
+			"description",
+			"""
+			The location of the primitive in the `source` scene that
+			will be sampled from.
+			""",
+
+			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
+			"scenePathPlugValueWidget:scene", "source",
+
+		],
+
+		"primitiveVariables" : [
+
+			"description",
+			"""
+			The names of the primitive variables to be sampled from the source
+			primitive. These should be separated by spaces and can use Gaffer's
+			standard wildcards to match multiple variables. The sampled variables
+			are prefixed with `prefix` before being added to the sampling object.
+			""",
+
+		],
+
+		"prefix" : [
+
+			"description",
+			"""
+			A prefix applied to the names of the sampled primitive variables before
+			they are added to the sampling object. This is particularly useful when
+			sampling something like "P", and not not wanting to modify the true
+			vertex positions of the sampling primitive.
+			""",
+
+			"layout:section", "Settings.Output",
+
+		],
+
+		"status" : [
+
+			"description",
+			"""
+			The name of a boolean primitive variable created to record the success or
+			failure of the sampling operation.
+			""",
+
+			"layout:section", "Settings.Output",
+
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -160,6 +160,7 @@ import ShuffleAttributesUI
 import ShufflePrimitiveVariablesUI
 import LocaliseAttributesUI
 import PrimitiveSamplerUI
+import ClosestPointSamplerUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -159,6 +159,7 @@ import MergeScenesUI
 import ShuffleAttributesUI
 import ShufflePrimitiveVariablesUI
 import LocaliseAttributesUI
+import PrimitiveSamplerUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -161,6 +161,7 @@ import ShufflePrimitiveVariablesUI
 import LocaliseAttributesUI
 import PrimitiveSamplerUI
 import ClosestPointSamplerUI
+import CurveSamplerUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/ClosestPointSampler.cpp
+++ b/src/GafferScene/ClosestPointSampler.cpp
@@ -79,7 +79,7 @@ void ClosestPointSampler::hashSamplingFunction( IECore::MurmurHash &h ) const
 	positionPlug()->hash( h );
 }
 
-PrimitiveSampler::SamplingFunction ClosestPointSampler::computeSamplingFunction( const IECoreScene::Primitive *primitive, IECoreScene::PrimitiveVariable::Interpolation &interpolation ) const
+PrimitiveSampler::SamplingFunction ClosestPointSampler::computeSamplingFunction( const IECoreScene::Primitive *destinationPrimitive, IECoreScene::PrimitiveVariable::Interpolation &interpolation ) const
 {
 	const std::string position = positionPlug()->getValue();
 	if( position.empty() )
@@ -87,8 +87,8 @@ PrimitiveSampler::SamplingFunction ClosestPointSampler::computeSamplingFunction(
 		return SamplingFunction();
 	}
 
-	auto it = primitive->variables.find( position );
-	if( it == primitive->variables.end() )
+	auto it = destinationPrimitive->variables.find( position );
+	if( it == destinationPrimitive->variables.end() )
 	{
 		throw IECore::Exception( "No primitive variable named \"" + position + "\"" );
 	}

--- a/src/GafferScene/CurveSampler.cpp
+++ b/src/GafferScene/CurveSampler.cpp
@@ -98,7 +98,7 @@ void CurveSampler::hashSamplingFunction( IECore::MurmurHash &h ) const
 	vPlug()->hash( h );
 }
 
-PrimitiveSampler::SamplingFunction CurveSampler::computeSamplingFunction( const IECoreScene::Primitive *primitive, IECoreScene::PrimitiveVariable::Interpolation &interpolation ) const
+PrimitiveSampler::SamplingFunction CurveSampler::computeSamplingFunction( const IECoreScene::Primitive *destinationPrimitive, IECoreScene::PrimitiveVariable::Interpolation &interpolation ) const
 {
 	const std::string curveIndex = curveIndexPlug()->getValue();
 	const std::string v = vPlug()->getValue();
@@ -108,8 +108,8 @@ PrimitiveSampler::SamplingFunction CurveSampler::computeSamplingFunction( const 
 
 	if( !curveIndex.empty() )
 	{
-		auto it = primitive->variables.find( curveIndex );
-		if( it == primitive->variables.end() )
+		auto it = destinationPrimitive->variables.find( curveIndex );
+		if( it == destinationPrimitive->variables.end() )
 		{
 			throw IECore::Exception( "No primitive variable named \"" + curveIndex + "\"" );
 		}
@@ -119,8 +119,8 @@ PrimitiveSampler::SamplingFunction CurveSampler::computeSamplingFunction( const 
 
 	if( !v.empty() )
 	{
-		auto it = primitive->variables.find( v );
-		if( it == primitive->variables.end() )
+		auto it = destinationPrimitive->variables.find( v );
+		if( it == destinationPrimitive->variables.end() )
 		{
 			throw IECore::Exception( "No primitive variable named \"" + v + "\"" );
 		}

--- a/src/GafferScene/CurveSampler.cpp
+++ b/src/GafferScene/CurveSampler.cpp
@@ -1,0 +1,155 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/CurveSampler.h"
+
+#include "IECoreScene/CurvesPrimitive.h"
+#include "IECoreScene/CurvesPrimitiveEvaluator.h"
+
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+
+GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( CurveSampler );
+
+size_t CurveSampler::g_firstPlugIndex = 0;
+
+CurveSampler::CurveSampler( const std::string &name )
+	:	PrimitiveSampler( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new StringPlug( "curveIndex", Plug::In, "" ) );
+	addChild( new StringPlug( "v", Plug::In, "" ) );
+}
+
+CurveSampler::~CurveSampler()
+{
+}
+
+Gaffer::StringPlug *CurveSampler::curveIndexPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::StringPlug *CurveSampler::curveIndexPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+Gaffer::StringPlug *CurveSampler::vPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::StringPlug *CurveSampler::vPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+bool CurveSampler::affectsSamplingFunction( const Gaffer::Plug *input ) const
+{
+	return
+		PrimitiveSampler::affectsSamplingFunction( input ) ||
+		input == curveIndexPlug() ||
+		input == vPlug()
+	;
+}
+
+void CurveSampler::hashSamplingFunction( IECore::MurmurHash &h ) const
+{
+	PrimitiveSampler::hashSamplingFunction( h );
+	curveIndexPlug()->hash( h );
+	vPlug()->hash( h );
+}
+
+PrimitiveSampler::SamplingFunction CurveSampler::computeSamplingFunction( const IECoreScene::Primitive *primitive, IECoreScene::PrimitiveVariable::Interpolation &interpolation ) const
+{
+	const std::string curveIndex = curveIndexPlug()->getValue();
+	const std::string v = vPlug()->getValue();
+
+	boost::optional<PrimitiveVariable::IndexedView<int>> curveIndexView;
+	boost::optional<PrimitiveVariable::IndexedView<float>> vView;
+
+	if( !curveIndex.empty() )
+	{
+		auto it = primitive->variables.find( curveIndex );
+		if( it == primitive->variables.end() )
+		{
+			throw IECore::Exception( "No primitive variable named \"" + curveIndex + "\"" );
+		}
+		curveIndexView.emplace( it->second );
+		interpolation = it->second.interpolation;
+	}
+
+	if( !v.empty() )
+	{
+		auto it = primitive->variables.find( v );
+		if( it == primitive->variables.end() )
+		{
+			throw IECore::Exception( "No primitive variable named \"" + v + "\"" );
+		}
+		vView.emplace( it->second );
+		if( !curveIndex.empty() )
+		{
+			if( interpolation != it->second.interpolation )
+			{
+				throw IECore::Exception( "Primitive variables \"" + curveIndex + "\" and \"" + v + "\" have different interpolation" );
+			}
+		}
+		else
+		{
+			interpolation = it->second.interpolation;
+		}
+	}
+
+	return [curveIndexView, vView] ( const PrimitiveEvaluator &evaluator, size_t index, const M44f &transform, PrimitiveEvaluator::Result &result ) {
+		auto curvesEvaluator = runTimeCast<const CurvesPrimitiveEvaluator>( &evaluator );
+		if( !curvesEvaluator )
+		{
+			return false;
+		}
+
+		return curvesEvaluator->pointAtV(
+			curveIndexView ? (*curveIndexView)[index] : 0,
+			vView ? (*vView)[index] : 0.0f,
+			&result
+		);
+	};
+}
+

--- a/src/GafferScene/PrimitiveSampler.cpp
+++ b/src/GafferScene/PrimitiveSampler.cpp
@@ -1,0 +1,385 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/PrimitiveSampler.h"
+
+#include "GafferScene/SceneAlgo.h"
+
+#include "IECoreScene/MeshAlgo.h"
+#include "IECoreScene/MeshPrimitive.h"
+#include "IECoreScene/PrimitiveEvaluator.h"
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+using OutputVariableFunction = std::function<void ( size_t, const PrimitiveEvaluator::Result & )>;
+
+M44f matrix( const M44f &transform, GeometricData::Interpretation interpretation )
+{
+	switch( interpretation )
+	{
+		case GeometricData::Point :
+			return transform;
+		case GeometricData::Vector : {
+			// Don't apply translation to vectors.
+			M44f x = transform;
+			x[3][0] = x[3][1] = x[3][2] = 0.0f;
+			return x;
+		}
+		case GeometricData::Normal : {
+			// Use the transpose of the inverse
+			// for transforming normals. Also,
+			// don't apply translation.
+			M44f x = transform;
+			x[3][0] = x[3][1] = x[3][2] = 0.0f;
+			x = x.inverse();
+			x.transpose();
+			return x;
+		}
+		default :
+			return M44f();
+	}
+}
+
+OutputVariableFunction addPrimitiveVariable( Primitive *outputPrimitive, const std::string &name, const PrimitiveVariable &sourceVariable, PrimitiveVariable::Interpolation outputInterpolation, const M44f &transform )
+{
+	const size_t size = outputPrimitive->variableSize( outputInterpolation );
+	switch( sourceVariable.data->typeId() )
+	{
+		case V3fVectorDataTypeId : {
+			V3fVectorDataPtr data = new V3fVectorData;
+			data->writable().resize( size, V3f( 0 ) );
+			const GeometricData::Interpretation interpretation = static_cast<const V3fVectorData *>( sourceVariable.data.get() )->getInterpretation();
+			data->setInterpretation( interpretation );
+			outputPrimitive->variables[name] = PrimitiveVariable( outputInterpolation, data );
+			V3f *d = data->writable().data();
+			const M44f m = matrix( transform, interpretation );
+			return [d, &sourceVariable, m ] ( size_t index, const PrimitiveEvaluator::Result &result ) {
+				d[index] = result.vectorPrimVar( sourceVariable ) * m;
+			};
+		}
+		case V2fVectorDataTypeId : {
+			V2fVectorDataPtr data = new V2fVectorData;
+			data->writable().resize( size, V2f( 0 ) );
+			data->setInterpretation( static_cast<const V2fVectorData *>( sourceVariable.data.get() )->getInterpretation() );
+			outputPrimitive->variables[name] = PrimitiveVariable( outputInterpolation, data );
+			V2f *d = data->writable().data();
+			return [d, &sourceVariable] ( size_t index, const PrimitiveEvaluator::Result &result ) {
+				d[index] = result.vec2PrimVar( sourceVariable );
+			};
+		}
+		case Color3fVectorDataTypeId : {
+			Color3fVectorDataPtr data = new Color3fVectorData;
+			data->writable().resize( size, Color3f( 0 ) );
+			outputPrimitive->variables[name] = PrimitiveVariable( outputInterpolation, data );
+			Color3f *d = data->writable().data();
+			return [d, &sourceVariable] ( size_t index, const PrimitiveEvaluator::Result &result ) {
+				d[index] = result.colorPrimVar( sourceVariable );
+			};
+		}
+		case FloatVectorDataTypeId : {
+			FloatVectorDataPtr data = new FloatVectorData;
+			data->writable().resize( size, 0 );
+			outputPrimitive->variables[name] = PrimitiveVariable( outputInterpolation, data );
+			float *d = data->writable().data();
+			return [d, &sourceVariable] ( size_t index, const PrimitiveEvaluator::Result &result ) {
+				d[index] = result.floatPrimVar( sourceVariable );
+			};
+		}
+		case IntVectorDataTypeId : {
+			IntVectorDataPtr data = new IntVectorData;
+			data->writable().resize( size, 0 );
+			outputPrimitive->variables[name] = PrimitiveVariable( outputInterpolation, data );
+			int *d = data->writable().data();
+			return [d, &sourceVariable] ( size_t index, const PrimitiveEvaluator::Result &result ) {
+				d[index] = result.intPrimVar( sourceVariable );
+			};
+		}
+		default :
+			// Unsupported type
+			return OutputVariableFunction();
+	};
+
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Sampler
+//////////////////////////////////////////////////////////////////////////
+
+GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( PrimitiveSampler );
+
+size_t PrimitiveSampler::g_firstPlugIndex = 0;
+
+PrimitiveSampler::PrimitiveSampler( const std::string &name )
+	:	Deformer( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new ScenePlug( "source" ) );
+	addChild( new StringPlug( "sourceLocation" ) );
+	addChild( new StringPlug( "primitiveVariables" ) );
+	addChild( new StringPlug( "prefix" ) );
+	addChild( new StringPlug( "status" ) );
+}
+
+PrimitiveSampler::~PrimitiveSampler()
+{
+}
+
+ScenePlug *PrimitiveSampler::sourcePlug()
+{
+	return getChild<ScenePlug>( g_firstPlugIndex );
+}
+
+const ScenePlug *PrimitiveSampler::sourcePlug() const
+{
+	return getChild<ScenePlug>( g_firstPlugIndex );
+}
+
+Gaffer::StringPlug *PrimitiveSampler::sourceLocationPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::StringPlug *PrimitiveSampler::sourceLocationPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::StringPlug *PrimitiveSampler::primitiveVariablesPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::StringPlug *PrimitiveSampler::primitiveVariablesPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::StringPlug *PrimitiveSampler::prefixPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::StringPlug *PrimitiveSampler::prefixPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+}
+
+Gaffer::StringPlug *PrimitiveSampler::statusPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+}
+
+const Gaffer::StringPlug *PrimitiveSampler::statusPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+}
+
+bool PrimitiveSampler::affectsProcessedObject( const Gaffer::Plug *input ) const
+{
+	return
+		Deformer::affectsProcessedObject( input ) ||
+		input == sourcePlug() ||
+		input == sourceLocationPlug() ||
+		input == primitiveVariablesPlug() ||
+		input == prefixPlug() ||
+		input == statusPlug() ||
+		input == sourcePlug()->objectPlug() ||
+		input == inPlug()->transformPlug() ||
+		input == sourcePlug()->transformPlug() ||
+		affectsSamplingFunction( input )
+	;
+}
+
+void PrimitiveSampler::hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	PrimitiveSampler::Deformer::hashProcessedObject( path, context, h );
+
+	const string sourceLocation = sourceLocationPlug()->getValue();
+	const string primitiveVariables = primitiveVariablesPlug()->getValue();
+	const string status = statusPlug()->getValue();
+	if( sourceLocation.empty() || ( primitiveVariables.empty() && status.empty() ) )
+	{
+		return;
+	}
+
+	ScenePlug::ScenePath sourcePath;
+	ScenePlug::stringToPath( sourceLocation, sourcePath );
+	if( !SceneAlgo::exists( sourcePlug(), sourcePath ) )
+	{
+		return;
+	}
+
+	h.append( sourcePlug()->objectHash( sourcePath ) );
+	h.append( primitiveVariables );
+	prefixPlug()->hash( h );
+	h.append( status );
+	h.append( inPlug()->fullTransformHash( path ) );
+	h.append( sourcePlug()->fullTransformHash( sourcePath ) );
+	hashSamplingFunction( h );
+}
+
+IECore::ConstObjectPtr PrimitiveSampler::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const
+{
+	const Primitive *inputPrimitive = runTimeCast<const Primitive>( inputObject );
+	if( !inputPrimitive )
+	{
+		return inputObject;
+	}
+
+	const string sourceLocation = sourceLocationPlug()->getValue();
+	const string primitiveVariables = primitiveVariablesPlug()->getValue();
+	const string status = statusPlug()->getValue();
+	if( sourceLocation.empty() || ( primitiveVariables.empty() && status.empty() ) )
+	{
+		return inputObject;
+	}
+
+	PrimitiveVariable::Interpolation outputInterpolation = PrimitiveVariable::Invalid;
+	SamplingFunction samplingFunction = computeSamplingFunction( inputPrimitive, outputInterpolation );
+	if( !samplingFunction || outputInterpolation == PrimitiveVariable::Invalid )
+	{
+		return inputObject;
+	}
+
+	ScenePlug::ScenePath sourcePath;
+	ScenePlug::stringToPath( sourceLocation, sourcePath );
+	if( !SceneAlgo::exists( sourcePlug(), sourcePath ) )
+	{
+		return inputObject;
+	}
+
+	ConstObjectPtr sourceObject = sourcePlug()->object( sourcePath );
+	const Primitive *sourcePrimitive = runTimeCast<const Primitive>( sourceObject.get() );
+	if( !sourcePrimitive )
+	{
+		return inputObject;
+	}
+
+	ConstPrimitivePtr preprocessedSourcePrimitive = sourcePrimitive;
+	if( auto mesh = runTimeCast<const MeshPrimitive>( preprocessedSourcePrimitive.get() ) )
+	{
+		preprocessedSourcePrimitive = MeshAlgo::triangulate( mesh );
+	}
+	PrimitiveEvaluatorPtr evaluator = PrimitiveEvaluator::create( preprocessedSourcePrimitive );
+	if( !evaluator )
+	{
+		return inputObject;
+	}
+
+	PrimitivePtr outputPrimitive = inputPrimitive->copy();
+	const size_t size = outputPrimitive->variableSize( outputInterpolation );
+
+	const string prefix = prefixPlug()->getValue();
+	const M44f transform = inPlug()->fullTransform( path );
+	const M44f sourceTransform = sourcePlug()->fullTransform( sourcePath );
+	const M44f primitiveVariableTransform = sourceTransform * transform.inverse();
+
+	vector<OutputVariableFunction> outputVariables;
+	for( auto &p : preprocessedSourcePrimitive->variables )
+	{
+		if( !StringAlgo::matchMultiple( p.first, primitiveVariables ) )
+		{
+			continue;
+		}
+
+		if( auto o = addPrimitiveVariable( outputPrimitive.get(), prefix + p.first, p.second, outputInterpolation, primitiveVariableTransform ) )
+		{
+			outputVariables.push_back( o );
+		}
+	}
+
+	BoolVectorDataPtr statusData;
+	if( !status.empty() )
+	{
+		statusData = new BoolVectorData();
+		statusData->writable().resize( size, false );
+		outputPrimitive->variables[status] = PrimitiveVariable( outputInterpolation, statusData );
+	}
+
+	PrimitiveEvaluator::ResultPtr evaluatorResult = evaluator->createResult();
+	const M44f samplingTransform = transform * sourceTransform.inverse();
+	for( size_t i = 0; i < size; ++i )
+	{
+		if( samplingFunction( *evaluator, i, samplingTransform, *evaluatorResult ) )
+		{
+			for( const auto &o : outputVariables )
+			{
+				o( i, *evaluatorResult );
+			}
+			if( statusData )
+			{
+				statusData->writable()[i] = true;
+			}
+		}
+	}
+
+	return outputPrimitive;
+}
+
+
+bool PrimitiveSampler::adjustBounds() const
+{
+	return
+		Deformer::adjustBounds() &&
+		prefixPlug()->getValue().empty() &&
+		StringAlgo::matchMultiple( "P", primitiveVariablesPlug()->getValue() )
+	;
+}
+
+bool PrimitiveSampler::affectsSamplingFunction( const Gaffer::Plug *input ) const
+{
+	return false;
+}
+
+void PrimitiveSampler::hashSamplingFunction( IECore::MurmurHash &h ) const
+{
+}
+

--- a/src/GafferScene/PrimitiveSampler.cpp
+++ b/src/GafferScene/PrimitiveSampler.cpp
@@ -369,7 +369,7 @@ IECore::ConstObjectPtr PrimitiveSampler::computeProcessedObject( const ScenePath
 		}
 	};
 
-	/// \todo We should probably be implementing `ComputeNode::computeCachePolicy()` instead
+	/// \todo We should be implementing `ComputeNode::computeCachePolicy()` instead
 	/// of doing our own isolation here, and we might even prefer the `TaskCollaboration`
 	/// that would provide. But we might also be filtered to only affect a single
 	/// object in an entire scene, and it seems that changing cache policy for
@@ -379,7 +379,8 @@ IECore::ConstObjectPtr PrimitiveSampler::computeProcessedObject( const ScenePath
 	/// on an internal plug with a custom policy. But we leave that for another time.
 	IECorePreview::ParallelAlgo::isolate(
 		[&] () {
-			parallel_for( blocked_range<size_t>( 0, size ), rangeSampler );
+			tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
+			parallel_for( blocked_range<size_t>( 0, size ), rangeSampler, taskGroupContext );
 		}
 	);
 

--- a/src/GafferScene/PrimitiveSampler.cpp
+++ b/src/GafferScene/PrimitiveSampler.cpp
@@ -245,7 +245,7 @@ bool PrimitiveSampler::affectsProcessedObject( const Gaffer::Plug *input ) const
 
 void PrimitiveSampler::hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	PrimitiveSampler::Deformer::hashProcessedObject( path, context, h );
+	Deformer::hashProcessedObject( path, context, h );
 
 	const string sourceLocation = sourceLocationPlug()->getValue();
 	const string primitiveVariables = primitiveVariablesPlug()->getValue();

--- a/src/GafferScene/PrimitiveSampler.cpp
+++ b/src/GafferScene/PrimitiveSampler.cpp
@@ -355,6 +355,7 @@ IECore::ConstObjectPtr PrimitiveSampler::computeProcessedObject( const ScenePath
 		PrimitiveEvaluator::ResultPtr evaluatorResult = evaluator->createResult();
 		for( size_t i = r.begin(); i != r.end(); ++i )
 		{
+			Canceller::check( context->canceller() );
 			if( samplingFunction( *evaluator, i, samplingTransform, *evaluatorResult ) )
 			{
 				for( const auto &o : outputVariables )

--- a/src/GafferSceneModule/PrimitiveSamplerBinding.cpp
+++ b/src/GafferSceneModule/PrimitiveSamplerBinding.cpp
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
-//  Copyright (c) 2013, John Haddon. All rights reserved.
+//  Copyright (c) 2020, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -37,56 +36,20 @@
 
 #include "boost/python.hpp"
 
-#include "AttributesBinding.h"
-#include "CoreBinding.h"
-#include "EditScopeAlgoBinding.h"
-#include "FilterBinding.h"
-#include "GlobalsBinding.h"
-#include "HierarchyBinding.h"
-#include "IECoreGLPreviewBinding.h"
-#include "IOBinding.h"
-#include "TweaksBinding.h"
-#include "ObjectProcessorBinding.h"
-#include "OptionsBinding.h"
 #include "PrimitiveSamplerBinding.h"
-#include "PrimitiveVariablesBinding.h"
-#include "PrimitivesBinding.h"
-#include "RenderBinding.h"
-#include "RenderControllerBinding.h"
-#include "RendererAlgoBinding.h"
-#include "SceneAlgoBinding.h"
-#include "ScenePathBinding.h"
-#include "SetAlgoBinding.h"
-#include "ShaderBinding.h"
-#include "TransformBinding.h"
+
+#include "GafferScene/PrimitiveSampler.h"
+
+#include "GafferBindings/DependencyNodeBinding.h"
 
 using namespace boost::python;
-using namespace GafferSceneModule;
+using namespace Gaffer;
+using namespace GafferBindings;
+using namespace GafferScene;
 
-BOOST_PYTHON_MODULE( _GafferScene )
+void GafferSceneModule::bindPrimitiveSampler()
 {
 
-	bindCore();
-	bindFilter();
-	bindTransform();
-	bindGlobals();
-	bindOptions();
-	bindAttributes();
-	bindSceneAlgo();
-	bindRendererAlgo();
-	bindSetAlgo();
-	bindPrimitives();
-	bindScenePath();
-	bindShader();
-	bindRender();
-	bindRenderController();
-	bindHierarchy();
-	bindObjectProcessor();
-	bindPrimitiveVariables();
-	bindTweaks();
-	bindIO();
-	bindPrimitiveSampler();
-	bindIECoreGLPreview();
-	bindEditScopeAlgo();
+	GafferBindings::DependencyNodeClass<GafferScene::PrimitiveSampler>();
 
 }

--- a/src/GafferSceneModule/PrimitiveSamplerBinding.h
+++ b/src/GafferSceneModule/PrimitiveSamplerBinding.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
-//  Copyright (c) 2013, John Haddon. All rights reserved.
+//  Copyright (c) 2020, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,58 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERSCENEMODULE_PRIMITIVESAMPLERBINDING_H
+#define GAFFERSCENEMODULE_PRIMITIVESAMPLERBINDING_H
 
-#include "AttributesBinding.h"
-#include "CoreBinding.h"
-#include "EditScopeAlgoBinding.h"
-#include "FilterBinding.h"
-#include "GlobalsBinding.h"
-#include "HierarchyBinding.h"
-#include "IECoreGLPreviewBinding.h"
-#include "IOBinding.h"
-#include "TweaksBinding.h"
-#include "ObjectProcessorBinding.h"
-#include "OptionsBinding.h"
-#include "PrimitiveSamplerBinding.h"
-#include "PrimitiveVariablesBinding.h"
-#include "PrimitivesBinding.h"
-#include "RenderBinding.h"
-#include "RenderControllerBinding.h"
-#include "RendererAlgoBinding.h"
-#include "SceneAlgoBinding.h"
-#include "ScenePathBinding.h"
-#include "SetAlgoBinding.h"
-#include "ShaderBinding.h"
-#include "TransformBinding.h"
-
-using namespace boost::python;
-using namespace GafferSceneModule;
-
-BOOST_PYTHON_MODULE( _GafferScene )
+namespace GafferSceneModule
 {
 
-	bindCore();
-	bindFilter();
-	bindTransform();
-	bindGlobals();
-	bindOptions();
-	bindAttributes();
-	bindSceneAlgo();
-	bindRendererAlgo();
-	bindSetAlgo();
-	bindPrimitives();
-	bindScenePath();
-	bindShader();
-	bindRender();
-	bindRenderController();
-	bindHierarchy();
-	bindObjectProcessor();
-	bindPrimitiveVariables();
-	bindTweaks();
-	bindIO();
-	bindPrimitiveSampler();
-	bindIECoreGLPreview();
-	bindEditScopeAlgo();
+void bindPrimitiveSampler();
 
-}
+} // namespace GafferSceneModule
+
+#endif // GAFFERSCENEMODULE_PRIMITIVESAMPLERBINDING_H

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -298,6 +298,7 @@ nodeMenu.append( "/Scene/Object/Delete Object", GafferScene.DeleteObject, search
 nodeMenu.append( "/Scene/Object/Reverse Winding", GafferScene.ReverseWinding, searchText = "ReverseWinding" )
 nodeMenu.append( "/Scene/Object/Mesh Distortion", GafferScene.MeshDistortion, searchText = "MeshDistortion" )
 nodeMenu.append( "/Scene/Object/Camera Tweaks", GafferScene.CameraTweaks, searchText = "CameraTweaks" )
+nodeMenu.append( "/Scene/Object/Closest Point Sampler", GafferScene.ClosestPointSampler, searchText = "ClosestPointSampler" )
 nodeMenu.append( "/Scene/Attributes/Shader Assignment", GafferScene.ShaderAssignment, searchText = "ShaderAssignment" )
 nodeMenu.append( "/Scene/Attributes/Shader Tweaks", GafferScene.ShaderTweaks, searchText = "ShaderTweaks" )
 nodeMenu.append( "/Scene/Attributes/Standard Attributes", GafferScene.StandardAttributes, searchText = "StandardAttributes" )

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -298,6 +298,7 @@ nodeMenu.append( "/Scene/Object/Delete Object", GafferScene.DeleteObject, search
 nodeMenu.append( "/Scene/Object/Reverse Winding", GafferScene.ReverseWinding, searchText = "ReverseWinding" )
 nodeMenu.append( "/Scene/Object/Mesh Distortion", GafferScene.MeshDistortion, searchText = "MeshDistortion" )
 nodeMenu.append( "/Scene/Object/Camera Tweaks", GafferScene.CameraTweaks, searchText = "CameraTweaks" )
+nodeMenu.append( "/Scene/Object/Curve Sampler", GafferScene.CurveSampler, searchText = "CurveSampler" )
 nodeMenu.append( "/Scene/Object/Closest Point Sampler", GafferScene.ClosestPointSampler, searchText = "ClosestPointSampler" )
 nodeMenu.append( "/Scene/Attributes/Shader Assignment", GafferScene.ShaderAssignment, searchText = "ShaderAssignment" )
 nodeMenu.append( "/Scene/Attributes/Shader Tweaks", GafferScene.ShaderTweaks, searchText = "ShaderTweaks" )


### PR DESCRIPTION
This adds ClosestPointSampler and CurveSampler nodes, based on a new PrimitiveSampler base class. I'd started working on these in spare moments after being inspired by @dboogert VDB sampling prototype in #3576, and since @danieldresser-ie may have a production use for them, I've got them to a finished (enough, i hope) state today. I also have a UVSampler up my sleeve, and since most of the work is in the base class and in the PrimitiveEvaluators already, an IntersectionSampler should be pretty trivial. I've refrained from presenting the UVSampler here though, as I seemed to be getting some sampled "falling through the cracks". I think there may be some robustness issues to deal with in Cortex before we could present UV and Intersection sampling to a user.