### PR TITLE
TranslateTool/AimConstraint interaction fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,4 @@
-0.57.x.x
+0.57.x.x (relative to 0.57.0.0)
 ========
 
 Features
@@ -6,6 +6,11 @@ Features
 
 - ClosestPointSampler : Added a new node for sampling primitive variables from the closest point on a source primitive.
 - CurveSampler : Added a new node for sampling primitive variables from parametric positions on some source curves.
+
+Fixes
+-----
+
+- TranslateTool : Fixed problems translating an object with a downstream AimConstraint applied.
 
 API
 ---

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -1095,5 +1095,29 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 			imath.V3f( 0, 10, 10 )
 		)
 
+		# Reset back to ( 0, 10, 0 ) and check the same thing works with
+		# an EditScope.
+
+		script["cube"]["transform"]["translate"].setValue( imath.V3f( 0, 10, 0 ) )
+
+		script["editScope"] = Gaffer.EditScope()
+		script["editScope"].setup( script["parent"]["out"] )
+		script["editScope"]["in"].setInput( script["parent"]["out"] )
+		script["aim"]["in"].setInput( script["editScope"]["out"] )
+
+		view["editScope"].setInput( script["editScope"]["out"] )
+
+		self.assertEqual( len( tool.selection() ), 1 )
+		self.assertTrue( tool.selectionEditable() )
+		self.assertEqual( tool.selection()[0].path(), "/cube" )
+		self.assertEqual( tool.selection()[0].upstreamPath(), "/cube" )
+		self.assertEqual( tool.selection()[0].editTarget(), script["editScope"] )
+
+		tool.translate( imath.V3f( 0, 0, 10 ) )
+		self.assertEqual(
+			script["aim"]["out"].transform( "/cube" ).translation(),
+			imath.V3f( 0, 10, 10 )
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -1045,5 +1045,55 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 			{ "Location does not exist" }
 		)
 
+	def testInteractionWithAimConstraints( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		# Cube at ( 0, 10, 0 ), aimed at a sphere at the origin.
+
+		script["sphere"] = GafferScene.Sphere()
+
+		script["cube"] = GafferScene.Cube()
+		script["cube"]["transform"]["translate"]["y"].setValue( 10 )
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["parent"].setValue( "/" )
+		script["parent"]["in"].setInput( script["sphere"]["out"] )
+		script["parent"]["children"][0].setInput( script["cube"]["out"] )
+
+		script["cubeFilter"] = GafferScene.PathFilter()
+		script["cubeFilter"]["paths"].setValue( IECore.StringVectorData( [ "/cube" ] ) )
+
+		script["aim"] = GafferScene.AimConstraint()
+		script["aim"]["in"].setInput( script["parent"]["out"] )
+		script["aim"]["filter"].setInput( script["cubeFilter"]["out"] )
+		script["aim"]["target"].setValue( "/sphere" )
+
+		# Translate in Z (parent space) and check that we moved to
+		# where we expected.
+
+		self.assertEqual(
+			script["aim"]["out"].transform( "/cube" ).translation(),
+			imath.V3f( 0, 10, 0 )
+		)
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["aim"]["out"] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/cube" ] ) )
+
+		tool = GafferSceneUI.TranslateTool( view )
+		tool["active"].setValue( True )
+
+		self.assertEqual( len( tool.selection() ), 1 )
+		self.assertEqual( tool.selection()[0].path(), "/cube" )
+		self.assertEqual( tool.selection()[0].upstreamPath(), "/cube" )
+		self.assertEqual( tool.selection()[0].editTarget(), script["cube"]["transform"] )
+
+		tool.translate( imath.V3f( 0, 0, 10 ) )
+		self.assertEqual(
+			script["aim"]["out"].transform( "/cube" ).translation(),
+			imath.V3f( 0, 10, 10 )
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -362,7 +362,7 @@ void TransformTool::Selection::initWalk( const GafferScene::SceneAlgo::History *
 	// the EditScope not being in the history at all, or it being
 	// overridden downstream.
 	Node *node = history->scene->node();
-	if( node == m_editScope && history->scene == m_editScope->outPlug() )
+	if( !editScopeFound && node == m_editScope && history->scene == m_editScope->outPlug() )
 	{
 		editScopeFound = true;
 		if( !m_upstreamScene )


### PR DESCRIPTION
This fixes a couple of problems with the use of the TranslateTool with an AimConstraint downstream of the node being edited.
