### PR TITLE
FilterResults : Improve UI

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,7 @@ Fixes
   - Fixed errors showing the popup menu for the `frameRange` plug.
   - Fixed Spreadsheet menu items.
 - UI : Fixed appearance of button icons when disabled.
+- FilterResults : Fixed the UI to show the connected filter instead of a meaningless numeric value. This also avoids triggering spurious errors on PathFilter nodes.
 
 API
 ---

--- a/python/GafferSceneUI/FilterResultsUI.py
+++ b/python/GafferSceneUI/FilterResultsUI.py
@@ -73,6 +73,8 @@ Gaffer.Metadata.registerNode(
 			matching locations.
 			""",
 
+			"plugValueWidget:type", "GafferUI.ConnectionPlugValueWidget",
+
 		],
 
 		"out" : [
@@ -81,6 +83,8 @@ Gaffer.Metadata.registerNode(
 			"""
 			The results of the search.
 			""",
+
+			"plugValueWidget:type", "",
 
 		],
 


### PR DESCRIPTION
Replace default numeric widget for `filter` with a ConnectionPlugValueWidget. The numeric value never showed anything useful because NumericPlugValueWidget doesn't provide `scene:path` in its context. Since 8bc1a1c633fc4e05d3399ee4b5760feed60061fd it was also triggering an error by using this incomplete context.

Also remove widget for `out`, because it never showed the results anyway.

