### PR TITLE
Python : Fix inconsistent indentation

### DIFF
--- a/python/GafferCortexUI/ClassVectorParameterValueWidget.py
+++ b/python/GafferCortexUI/ClassVectorParameterValueWidget.py
@@ -150,13 +150,13 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 
 		return result
 
- 	def __classMenuDefinition( self ) :
+	def __classMenuDefinition( self ) :
 
- 		result = IECore.MenuDefinition()
+		result = IECore.MenuDefinition()
 
- 		classNameFilter = "*"
- 		with IECore.IgnoredExceptions( KeyError ) :
- 			classNameFilter = self._parameter().userData()["UI"]["classNameFilter"].value
+		classNameFilter = "*"
+		with IECore.IgnoredExceptions( KeyError ) :
+			classNameFilter = self._parameter().userData()["UI"]["classNameFilter"].value
 		menuPathStart = max( 0, classNameFilter.find( "*" ) )
 
 		loader = IECore.ClassLoader.defaultLoader( self._parameter().searchPathEnvVar() )

--- a/python/GafferCortexUI/OpDialogue.py
+++ b/python/GafferCortexUI/OpDialogue.py
@@ -347,7 +347,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 
 			self.__initiateResultDisplay( result )
 
- 			self.opExecutedSignal()( result )
+			self.opExecutedSignal()( result )
 			self.postExecuteSignal()( self, result )
 
 		else :

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -1455,7 +1455,7 @@ class DispatcherTest( GafferTest.TestCase ) :
 		if Gaffer.isDebug():
 			timeLimit *= 2
 
- 		self.assertLess( time.clock() - t, timeLimit )
+		self.assertLess( time.clock() - t, timeLimit )
 
 	def testTaskListWaitForSequence( self ) :
 

--- a/python/GafferSceneTest/GroupTest.py
+++ b/python/GafferSceneTest/GroupTest.py
@@ -152,10 +152,10 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 		g["in"][0].setInput( p["out"] )
 		self.assertEqual( len( g["in"] ), 2 )
 
- 		g["in"][1].setInput( p["out"] )
+		g["in"][1].setInput( p["out"] )
 		self.assertEqual( len( g["in"] ), 3 )
 
- 		g["in"][1].setInput( None )
+		g["in"][1].setInput( None )
 		self.assertEqual( len( g["in"] ), 2 )
 
 		g["in"][0].setInput( None )
@@ -164,7 +164,7 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 		g["in"][0].setInput( p["out"] )
 		self.assertEqual( len( g["in"] ), 2 )
 
- 		g["in"][1].setInput( p["out"] )
+		g["in"][1].setInput( p["out"] )
 		self.assertEqual( len( g["in"] ), 3 )
 
 		g["in"].setInput( None )
@@ -451,13 +451,13 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 		g1["in"][0].setInput( p["out"] )
 
 		g2 = GafferScene.Group()
- 		g2["in"][0].setInput( p["out"] )
+		g2["in"][0].setInput( p["out"] )
 
- 		self.assertSceneHashesEqual( g1["out"], g2["out"] )
+		self.assertSceneHashesEqual( g1["out"], g2["out"] )
 
-	 	g2["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
+		g2["transform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
 
- 		self.assertSceneHashesEqual( g1["out"], g2["out"], pathsToIgnore = ( "/", "/group", ) )
+		self.assertSceneHashesEqual( g1["out"], g2["out"], pathsToIgnore = ( "/", "/group", ) )
 		self.assertSceneHashesEqual( g1["out"], g2["out"], checks = self.allSceneChecks - { "transform", "bound" } )
 		self.assertNotEqual( g1["out"].transformHash( "/group" ), g2["out"].transformHash( "/group" ) )
 		self.assertEqual( g1["out"].boundHash( "/group" ), g2["out"].boundHash( "/group" ) )
@@ -471,9 +471,9 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 		g1["in"][0].setInput( p["out"] )
 
 		g2 = GafferScene.Group()
- 		g2["in"][0].setInput( p["out"] )
+		g2["in"][0].setInput( p["out"] )
 
- 		self.assertSceneHashesEqual( g1["out"], g2["out"] )
+		self.assertSceneHashesEqual( g1["out"], g2["out"] )
 
 		g2["name"].setValue( "stuff" )
 

--- a/python/GafferSceneTest/SceneTestCase.py
+++ b/python/GafferSceneTest/SceneTestCase.py
@@ -68,7 +68,7 @@ class SceneTestCase( GafferTest.TestCase ) :
 
 			o = scenePlug.object( scenePath, _copy = False )
 			if isinstance( o, IECoreScene.VisibleRenderable ) :
-				 if not IECore.BoxAlgo.contains( thisBound, o.bound() ) :
+				if not IECore.BoxAlgo.contains( thisBound, o.bound() ) :
 					self.fail( "Bound %s does not contain object %s at %s" % ( thisBound, o.bound(), scenePath ) )
 			if isinstance( o, IECoreScene.Primitive ) :
 				if "P" in o :

--- a/python/GafferSceneTest/TextTest.py
+++ b/python/GafferSceneTest/TextTest.py
@@ -54,9 +54,9 @@ class TextTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( t.getName(), "Text" )
 		self.assertEqual( t["name"].getValue(), "text" )
 
- 	def testCompute( self ) :
+	def testCompute( self ) :
 
- 		t = GafferScene.Text()
+		t = GafferScene.Text()
 
 		self.assertEqual( t["out"].object( "/" ), IECore.NullObject() )
 		self.assertEqual( t["out"].transform( "/" ), imath.M44f() )

--- a/python/GafferTest/TypedObjectPlugTest.py
+++ b/python/GafferTest/TypedObjectPlugTest.py
@@ -120,13 +120,13 @@ class TypedObjectPlugTest( GafferTest.TestCase ) :
 		s["n"]["t"] = Gaffer.ObjectPlug( "hello", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, defaultValue = IECore.IntData( 10 ) )
 		s["n"]["t"].setValue( IECore.CompoundObject( { "a" : IECore.IntData( 20 ) } ) )
 
- 		se = s.serialise()
+		se = s.serialise()
 
- 		s2 = Gaffer.ScriptNode()
- 		s2.execute( se )
+		s2 = Gaffer.ScriptNode()
+		s2.execute( se )
 
- 		self.failUnless( s2["n"]["t"].isInstanceOf( Gaffer.ObjectPlug.staticTypeId() ) )
- 		self.failUnless( s2["n"]["t"].defaultValue() == IECore.IntData( 10 ) )
+		self.failUnless( s2["n"]["t"].isInstanceOf( Gaffer.ObjectPlug.staticTypeId() ) )
+		self.failUnless( s2["n"]["t"].defaultValue() == IECore.IntData( 10 ) )
 		self.failUnless( s2["n"]["t"].getValue() == IECore.CompoundObject( { "a" : IECore.IntData( 20 ) } ) )
 
 	def testConstructCantSpecifyBothInputAndValue( self ) :
@@ -153,12 +153,12 @@ class TypedObjectPlugTest( GafferTest.TestCase ) :
 		s["n"] = self.TypedObjectPlugNode()
 		s["n"]["p"].setValue( IECore.IntData( 10 ) )
 
- 		se = s.serialise()
+		se = s.serialise()
 
 		s2 = Gaffer.ScriptNode()
- 		s2.execute( se )
+		s2.execute( se )
 
- 		self.assertEqual( s2["n"]["p"].getValue(), IECore.IntData( 10 ) )
+		self.assertEqual( s2["n"]["p"].getValue(), IECore.IntData( 10 ) )
 
 	def testSetToDefault( self ) :
 

--- a/python/GafferUI/NumericSlider.py
+++ b/python/GafferUI/NumericSlider.py
@@ -166,14 +166,14 @@ class NumericSlider( GafferUI.Slider ) :
 		if valueChangedSignal is not None :
 			valueChangedSignal( self, reason )
 
-  	def _drawBackground( self, painter ) :
+	def _drawBackground( self, painter ) :
 
-  		size = self.size()
-   		valueRange = self.__max - self.__min
-   		if valueRange == 0 :
-   			return
+		size = self.size()
+		valueRange = self.__max - self.__min
+		if valueRange == 0 :
+			return
 
-   		idealSpacing = 10
+		idealSpacing = 10
 		idealNumTicks = float( size.x ) / idealSpacing
 		tickStep = valueRange / idealNumTicks
 

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -145,10 +145,10 @@ class PlugLayout( GafferUI.Widget ) :
 
 	def setReadOnly( self, readOnly ) :
 
- 		if readOnly == self.getReadOnly() :
- 			return
+		if readOnly == self.getReadOnly() :
+			return
 
- 		self.__readOnly = readOnly
+		self.__readOnly = readOnly
 		for widget in self.__widgets.values() :
 			self.__applyReadOnly( widget, self.__readOnly )
 
@@ -362,7 +362,7 @@ class PlugLayout( GafferUI.Widget ) :
 
 		return result
 
- 	def __createPlugWidget( self, plug ) :
+	def __createPlugWidget( self, plug ) :
 
 		result = GafferUI.PlugValueWidget.create( plug )
 		if result is None :
@@ -375,7 +375,7 @@ class PlugLayout( GafferUI.Widget ) :
 				result._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetDefaultConstraint )
 
 		if isinstance( result, GafferUI.PlugValueWidget ) and not result.hasLabel() and self.__itemMetadataValue( plug, "label" ) != "" :
- 			result = GafferUI.PlugWidget( result )
+			result = GafferUI.PlugWidget( result )
 			if self.__layout.orientation() == GafferUI.ListContainer.Orientation.Horizontal :
 				# undo the annoying fixed size the PlugWidget has applied
 				# to the label.
@@ -391,7 +391,7 @@ class PlugLayout( GafferUI.Widget ) :
 		# in the future to determine if we can reuse the widget.
 		result.__plugValueWidgetType = Gaffer.Metadata.value( plug, "plugValueWidget:type" )
 
- 		return result
+		return result
 
 	def __createCustomWidget( self, name ) :
 

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -1185,26 +1185,26 @@ class _Delegate( QtWidgets.QStyledItemDelegate ) :
 		else :
 			QtWidgets.QStyledItemDelegate.setEditorData( self, editor, index )
 
- 	def setModelData( self, editor, model, index ) :
+	def setModelData( self, editor, model, index ) :
 
- 		if self.__editor is not None :
- 			model.setData( index, GafferUI._Variant.toVariant( self.__editor.getValue() ), QtCore.Qt.EditRole )
+		if self.__editor is not None :
+			model.setData( index, GafferUI._Variant.toVariant( self.__editor.getValue() ), QtCore.Qt.EditRole )
 		else :
 			QtWidgets.QStyledItemDelegate.setModelData( self, editor, model, index )
 
- 	def eventFilter( self, object, event ) :
+	def eventFilter( self, object, event ) :
 
- 		if QtWidgets.QStyledItemDelegate.eventFilter( self, object, event ) :
- 			return True
+		if QtWidgets.QStyledItemDelegate.eventFilter( self, object, event ) :
+			return True
 
- 		if event.type() == event.Hide and self.__editor is not None :
- 			# custom editors may hide themselves to indicate that editing
- 			# is complete. when this happens we are responsible for carrying
- 			# out this completion.
- 			self.commitData.emit( self.__editor._qtWidget() )
- 			self.closeEditor.emit( self.__editor._qtWidget(), self.NoHint )
+		if event.type() == event.Hide and self.__editor is not None :
+			# custom editors may hide themselves to indicate that editing
+			# is complete. when this happens we are responsible for carrying
+			# out this completion.
+			self.commitData.emit( self.__editor._qtWidget() )
+			self.closeEditor.emit( self.__editor._qtWidget(), self.NoHint )
 
- 		return False
+		return False
 
 	# Methods we define for our own purposes
 	########################################

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -154,24 +154,24 @@ class Widget( Gaffer.Trackable ) :
 
 		self._keyPressSignal = None
 		self._keyReleaseSignal = None
- 		self._buttonPressSignal = None
- 		self._buttonReleaseSignal = None
-  		self._buttonDoubleClickSignal = None
+		self._buttonPressSignal = None
+		self._buttonReleaseSignal = None
+		self._buttonDoubleClickSignal = None
 		self._mouseMoveSignal = None
- 		self._enterSignal = None
- 		self._leaveSignal = None
- 		self._dragBeginSignal = None
- 		self._dragEnterSignal = None
- 		self._dragMoveSignal = None
- 		self._dragLeaveSignal = None
- 		self._dropSignal = None
- 		self._dragEndSignal = None
- 		self._wheelSignal = None
- 		self._visibilityChangedSignal = None
- 		self._contextMenuSignal = None
- 		self._parentChangedSignal = None
+		self._enterSignal = None
+		self._leaveSignal = None
+		self._dragBeginSignal = None
+		self._dragEnterSignal = None
+		self._dragMoveSignal = None
+		self._dragLeaveSignal = None
+		self._dropSignal = None
+		self._dragEndSignal = None
+		self._wheelSignal = None
+		self._visibilityChangedSignal = None
+		self._contextMenuSignal = None
+		self._parentChangedSignal = None
 
- 		self.__visible = not isinstance( self, GafferUI.Window )
+		self.__visible = not isinstance( self, GafferUI.Window )
 
 		# perform automatic parenting if necessary. we don't want to do this
 		# for menus, because they don't have the same parenting semantics. if other

--- a/python/GafferUITest/MessageWidgetTest.py
+++ b/python/GafferUITest/MessageWidgetTest.py
@@ -59,10 +59,10 @@ class MessageWidgetTest( GafferUITest.TestCase ) :
 		w = GafferUI.MessageWidget()
 		assertCounts( 0, 0, 0, 0 )
 
- 		with w.messageHandler() :
+		with w.messageHandler() :
 
- 			msg( IECore.Msg.Level.Error )
- 			assertCounts( 0, 0, 0, 1 )
+			msg( IECore.Msg.Level.Error )
+			assertCounts( 0, 0, 0, 1 )
 
 			msg( IECore.Msg.Level.Warning )
 			assertCounts( 0, 0, 1, 1 )

--- a/python/GafferUITest/WidgetTest.py
+++ b/python/GafferUITest/WidgetTest.py
@@ -193,7 +193,7 @@ class WidgetTest( GafferUITest.TestCase ) :
 
 		w.setEnabled( True )
 		QtWidgets.QApplication.instance().sendEvent( w._qtWidget(), event )
- 		self.assertEqual( WidgetTest.signalsEmitted, 2 )
+		self.assertEqual( WidgetTest.signalsEmitted, 2 )
 
 	def testCanDieAfterUsingSignals( self ) :
 


### PR DESCRIPTION
This is the first of several PRs I'll be making that should eventually lead to Python 3 compatibility (while maintaining compatibility with 2). Things are complicated slightly by the fact that we support multiple concurrent versions of Gaffer - currently this is 0.56 for patches, 0.57 for features, with master eventually becoming 0.58. Full Python 3 support will only materialise on master, because it requires updates to our dependencies that we couldn't contemplate for 0.57. But certain of the Python 3 fixes affect a _lot_ of files, so working only on master is likely going to lead to conflict hell. The strategy will therefore be to merge the low-risk/high-volume changes (like this one) to 0.57 before merging the few higher-risk/low-volume changes to master.