### PR TITLE
Spreadsheet : Use PathMatcher-style matching for `scene:path`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Improvements
 Fixes
 -----
 
+- Spreadsheet : Fixed pattern matching bugs when using `${scene:path}` as the selector. In this case, `*` no longer matches `/`, and `...` is now supported.
 - TranslateTool : Fixed problems translating an object with a downstream AimConstraint applied.
 - Instancer : Fixed crashes caused by attempts to instance onto a location without a primitive (#3715).
 - Script Settings :

--- a/python/GafferSceneTest/SpreadsheetTest.py
+++ b/python/GafferSceneTest/SpreadsheetTest.py
@@ -73,5 +73,25 @@ class SpreadsheetTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( attributes["out"].attributes( "/group/sphere" )["gaffer:deformationBlur"].value, True )
 		self.assertEqual( attributes["out"].attributes( "/group/cube" )["gaffer:deformationBlur"].value, False )
 
+	def testPathMatcherSyntax( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.BoolPlug( "v" ) )
+		row = s["rows"].addRow()
+		row["cells"]["v"]["value"].setValue( True )
+		s["selector"].setValue( "${scene:path}" )
+
+		for path, rowName, match in [
+			( "/foo", "/foo", True ),
+			( "/food", "/foo*", True ),
+			( "/foo/bar", "/foo*", False ),
+			( "/foo/bar/baz", "/foo/.../b*", True ),
+			( "/foo/bar/baz", "/foo/.../bar", False ),
+		] :
+			with Gaffer.Context() as c :
+				c["scene:path"] = GafferScene.ScenePlug.stringToPath( path )
+				row["name"].setValue( rowName )
+				self.assertEqual( s["out"]["v"].getValue(), match )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/Spreadsheet.cpp
+++ b/src/Gaffer/Spreadsheet.cpp
@@ -83,10 +83,82 @@ class RowsMap : public IECore::Data
 
 	public :
 
+		RowsMap( const Spreadsheet::RowsPlug *rows )
+			:	m_activeRowNames( new StringVectorData )
+		{
+			vector<string> &activeRowNames = m_activeRowNames->writable();
+
+			for( size_t i = 1, e = rows->children().size(); i < e; ++i )
+			{
+				const auto *row = rows->getChild<Spreadsheet::RowPlug>( i );
+				if( !row->enabledPlug()->getValue() )
+				{
+					continue;
+				}
+
+				const std::string name = row->namePlug()->getValue();
+				activeRowNames.push_back( name );
+
+				if(
+					StringAlgo::hasWildcards( name ) ||
+					name.find( ' ' ) != string::npos
+				)
+				{
+					m_wildcardRows.push_back( { name, i } );
+				}
+				else
+				{
+					m_plainRows.insert( { name, i } );
+				}
+			}
+		}
+
+		// Hashes everything accessed by the constructor.
+		static void hash( const Spreadsheet::RowsPlug *rows, IECore::MurmurHash &h )
+		{
+			for( int i = 1, e = rows->children().size(); i < e; ++i )
+			{
+				const auto *row = rows->getChild<Spreadsheet::RowPlug>( i );
+				row->namePlug()->hash( h );
+				row->enabledPlug()->hash( h );
+			}
+		}
+
+		size_t rowIndex( const std::string &selector ) const
+		{
+			size_t result = 0;
+			Map::const_iterator it = m_plainRows.find( selector );
+			if( it != m_plainRows.end() )
+			{
+				result = it->second;
+			}
+			for( auto &row : m_wildcardRows )
+			{
+				if( result && row.index > result )
+				{
+					break;
+				}
+
+				if( StringAlgo::matchMultiple( selector, row.name ) )
+				{
+					result = row.index;
+					break;
+				}
+			}
+			return result;
+		}
+
+		const StringVectorData *activeRowNames() const
+		{
+			return m_activeRowNames.get();
+		}
+
+	private :
+
 		// Rows without wildcards. We can look these up
 		// directly.
 		using Map = std::unordered_map<std::string, size_t>;
-		Map plainRows;
+		Map m_plainRows;
 
 		// Rows with wildcards. These require a linear search.
 		struct Row
@@ -95,10 +167,10 @@ class RowsMap : public IECore::Data
 			size_t index;
 		};
 		using Vector = std::vector<Row>;
-		Vector wildcardRows;
+		Vector m_wildcardRows;
 
 		// List of active row names for `activeRowNamesPlug()`.
-		ConstStringVectorDataPtr activeRowNames;
+		StringVectorDataPtr m_activeRowNames;
 
 };
 
@@ -791,12 +863,7 @@ void Spreadsheet::hash( const ValuePlug *output, const Context *context, IECore:
 	if( output == rowsMapPlug() )
 	{
 		ComputeNode::hash( output, context, h );
-		for( int i = 1, e = rowsPlug()->children().size(); i < e; ++i )
-		{
-			const auto *row = rowsPlug()->getChild<RowPlug>( i );
-			row->namePlug()->hash( h );
-			row->enabledPlug()->hash( h );
-		}
+		RowsMap::hash( rowsPlug(), h );
 		return;
 	}
 	else if( output == rowIndexPlug() )
@@ -828,36 +895,9 @@ void Spreadsheet::compute( ValuePlug *output, const Context *context ) const
 {
 	if( output == rowsMapPlug() )
 	{
-		StringVectorDataPtr activeRowNamesData = new StringVectorData;
-		vector<string> &activeRowNames = activeRowNamesData->writable();
-		RowsMapPtr result = new RowsMap;
-		result->activeRowNames = activeRowNamesData;
-
-		for( size_t i = 1, e = rowsPlug()->children().size(); i < e; ++i )
-		{
-			const auto *row = rowsPlug()->getChild<RowPlug>( i );
-			if( !row->enabledPlug()->getValue() )
-			{
-				continue;
-			}
-
-			const std::string name = row->namePlug()->getValue();
-			activeRowNames.push_back( name );
-
-			if(
-				StringAlgo::hasWildcards( name ) ||
-				name.find( ' ' ) != string::npos
-			)
-			{
-				result->wildcardRows.push_back( { name, i } );
-			}
-			else
-			{
-				result->plainRows.insert( { name, i } );
-			}
-		}
-
-		static_cast<ObjectPlug *>( output )->setValue( result );
+		static_cast<ObjectPlug *>( output )->setValue(
+			new RowsMap( rowsPlug() )
+		);
 		return;
 	}
 	else if( output == rowIndexPlug() )
@@ -867,25 +907,7 @@ void Spreadsheet::compute( ValuePlug *output, const Context *context ) const
 		{
 			RowsMapScope rowsMapScope( context, selectorPlug()->getValue() );
 			ConstRowsMapPtr rowsMap = boost::static_pointer_cast<const RowsMap>( rowsMapPlug()->getValue() );
-
-			RowsMap::Map::const_iterator it = rowsMap->plainRows.find( rowsMapScope.selector() );
-			if( it != rowsMap->plainRows.end() )
-			{
-				result = it->second;
-			}
-			for( auto &row : rowsMap->wildcardRows )
-			{
-				if( result && row.index > result )
-				{
-					break;
-				}
-
-				if( StringAlgo::matchMultiple( rowsMapScope.selector(), row.name ) )
-				{
-					result = row.index;
-					break;
-				}
-			}
+			result = rowsMap->rowIndex( rowsMapScope.selector() );
 		}
 		static_cast<IntPlug *>( output )->setValue( result );
 		return;
@@ -899,7 +921,7 @@ void Spreadsheet::compute( ValuePlug *output, const Context *context ) const
 	{
 		RowsMapScope rowsMapScope( context, selectorPlug()->getValue() );
 		ConstRowsMapPtr rowsMap = boost::static_pointer_cast<const RowsMap>( rowsMapPlug()->getValue() );
-		static_cast<StringVectorDataPlug *>( output )->setValue( rowsMap->activeRowNames );
+		static_cast<StringVectorDataPlug *>( output )->setValue( rowsMap->activeRowNames() );
 		return;
 	}
 


### PR DESCRIPTION
The `IECore::StringAlgo::match()` algorithm we were using for matching row names against the selector deviates from the `IECore::PathMatcher` style matching we use in PathFilter. In `StringAlgo::match()`, `*` is allowed to match `/`, and `...` has no meaning at all. This produced totally unintuitive results when using a Spreadsheet/PathFilter combo.

I'm not overly enamoured with the doubled-up member data in RowsMap, or of the hardcoded check for `${scene:path}`, but I think this is the best we can do at present. I've included some comments in the code about how we might improve the data structure. And we _could_ avoid the hardcoded check for `${scene:path}` and instead check for any single variable reference that results in InternedStringVectorData. That would be more complex though (with and without {}, avoiding multiple variables, avoiding the allocation involved in regex::match_results), and I don't think would serve any practical purpose.