### PR TITLE
Viewer : Handle locations with zero scale transforms

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,7 @@ Fixes
 -----
 
 - Instancer : Fixed crashes caused by attempts to instance onto a location without a primitive (#3715).
-- Viewer : Fixed crash displaying objects with zero scale transforms.
+- Viewer : Fixed crash displaying and/or manipulating objects with zero scale transform components.
 
 0.56.2.0 (relative to 0.56.1.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Instancer : Fixed crashes caused by attempts to instance onto a location without a primitive (#3715).
+- Viewer : Fixed crash displaying objects with zero scale transforms.
 
 0.56.2.0 (relative to 0.56.1.0)
 ========

--- a/python/GafferSceneTest/IECoreGLPreviewTest/RendererTest.py
+++ b/python/GafferSceneTest/IECoreGLPreviewTest/RendererTest.py
@@ -226,5 +226,25 @@ class RendererTest( GafferTest.TestCase ) :
 
 		del o
 
+	def testTransforms( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"OpenGL",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
+		)
+
+		cube = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -1 ), imath.V3f( 9 ) ) )
+
+		o = renderer.object(
+			"/cube",
+			cube,
+			renderer.attributes( IECore.CompoundObject() )
+		)
+		o.transform(
+			imath.M44f().scale( imath.V3f( 0 ) )
+		)
+
+		renderer.render()
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -407,7 +407,7 @@ class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 		{
 			m_editQueue.push( [this, transform]() {
 				m_transform = transform;
-				m_transformSansScale = sansScalingAndShear( transform );
+				m_transformSansScale = sansScalingAndShear( transform, false );
 			} );
 		}
 

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -283,6 +283,17 @@ TransformTool::Selection::Selection(
 		return;
 	}
 
+	// We disallow editing of any locations that have zero scale at any point in the
+	// hierarchy. This causes untold trouble in all sorts of places.
+	// We use this somewhat long winded detection approach to ensure we'll hit the same
+	// failure cases as we would do later on using imath with the same matrices.
+	const M44f fullTransform = scene->fullTransform( path );
+	V3f unusedScale;
+	if( !extractScaling( fullTransform, unusedScale, false ) )
+	{
+		return;
+	}
+
 	SceneAlgo::History::Ptr history = SceneAlgo::history( scene->transformPlug(), path );
 	updateSelectionWalk( history.get(), *this );
 }


### PR DESCRIPTION
This was inadvertently broken when we refactored the visualisation mechanism.