### PR TITLE
EditScope/NodeAlgo fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,7 +27,9 @@ Fixes
 - FilterResults : Fixed the UI to show the connected filter instead of a meaningless numeric value. This also avoids triggering spurious errors on PathFilter nodes.
 - Viewer :
   - Fixed crash displaying and/or manipulating objects with zero scale transform components.
+  - Fixed EditScope menu to include scopes nested inside Boxes.
   - Fixed EditScope menu button so it updates when the EditScope is renamed.
+- NodeAlgo : Fixed bugs that prevented visitation of nodes nested inside Boxes.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -25,7 +25,9 @@ Fixes
   - Fixed Spreadsheet menu items.
 - UI : Fixed appearance of button icons when disabled.
 - FilterResults : Fixed the UI to show the connected filter instead of a meaningless numeric value. This also avoids triggering spurious errors on PathFilter nodes.
-- Viewer : Fixed crash displaying and/or manipulating objects with zero scale transform components.
+- Viewer :
+  - Fixed crash displaying and/or manipulating objects with zero scale transform components.
+  - Fixed EditScope menu button so it updates when the EditScope is renamed.
 
 API
 ---

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -379,29 +379,18 @@ def __viewerKeyPress( viewer, event ) :
 	if not isinstance( viewer.view(), GafferImageUI.ImageView ) :
 		return False
 
-	catalogue = __findUpstreamCatalogue( viewer.view() )
+	catalogue = Gaffer.NodeAlgo.findUpstream(
+		viewer.view(),
+		lambda node : isinstance( node, GafferImage.Catalogue ),
+		order = Gaffer.NodeAlgo.VisitOrder.DepthFirst
+	)
+
 	if catalogue is None :
 		return False
 
 	__incrementImageIndex( catalogue, event.key )
 
 	return True
-
-def __findUpstreamCatalogue( node ) :
-
-	catalogue = node.ancestor( GafferImage.Catalogue )
-	if catalogue is not None :
-		return catalogue
-	else :
-		for inPlug in GafferImage.ImagePlug.RecursiveInputRange( node ) :
-			upstreamPlug = inPlug.source()
-			if upstreamPlug == inPlug or upstreamPlug.node() == node :
-				continue
-			catalogue = __findUpstreamCatalogue( upstreamPlug.node() )
-			if catalogue is not None :
-				return catalogue
-
-	return None
 
 def __incrementImageIndex( catalogue, direction ) :
 

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -135,8 +135,22 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 	def _updateFromPlug( self ) :
 
 		editScope = self.__editScope()
-		self.__menuButton.setText( editScope.getName() if editScope is not None else "None" )
+		self.__updateMenuButton( editScope )
 		self.__navigationMenuButton.setEnabled( editScope is not None )
+		if editScope is not None :
+			self.__editScopeNameChangedConnection = editScope.nameChangedSignal().connect(
+				Gaffer.WeakMethod( self.__editScopeNameChanged ), scoped = True
+			)
+		else :
+			self.__editScopeNameChangedConnection = None
+
+	def __updateMenuButton( self, editScope ) :
+
+		self.__menuButton.setText( editScope.getName() if editScope is not None else "None" )
+
+	def __editScopeNameChanged( self, editScope ) :
+
+		self.__updateMenuButton( editScope )
 
 	def __editScope( self ) :
 


### PR DESCRIPTION
The meat of this PR is a fix to the `NodeAlgo::visit()` functions that causes them to traverse connections into and out of Boxes (and other nested networks). This allows us to expose nested EditScopes in the Viewer, and means we can once again use `findUpstream()` in the CatalogueUI, having [backed out of that](https://github.com/GafferHQ/gaffer/pull/3608/commits/7444ff2fb82c40d72aac00099a8fd7002cbca3ea) due to a lack of nested traversal in the past.

I was a little hesitant to call this a bugfix at first, since it does change behaviour. But I have been convinced by a few things :

- We currently only have two use cases for the functions in Gaffer, and neither are viable without the fix. Without the fix we'd have to revert to manual traversals in both EditScopeUI and CatalogueUI, which defeats the point of providing centralised Algo.
- The nodes we now hit are consistent with the definition of "upstream" and "downstream" in the [original documentation](https://github.com/GafferHQ/gaffer/blob/master/include/Gaffer/NodeAlgo.h#L58-L61).
- It's fairly trivial to filter out the nested nodes using a predicate if you really don't want them.

If anyone has used NodeAlgo in anger and has counterexamples, please speak up.