### PR TITLE
TransformTool : Add message for zero scale cases

### DIFF
--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -216,6 +216,7 @@ TransformTool::Selection::Selection(
 	V3f unusedScale;
 	if( !extractScaling( fullTransform, unusedScale, false ) )
 	{
+		m_warning = "Location has zero scale";
 		return;
 	}
 


### PR DESCRIPTION
The original fix was in `0.56_maintenance`, but had no means of messaging the user.
