### PR TITLE
ArnoldColorManager node

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Features
 
 - ClosestPointSampler : Added a new node for sampling primitive variables from the closest point on a source primitive.
 - CurveSampler : Added a new node for sampling primitive variables from parametric positions on some source curves.
+- ArnoldColorManager : Added a new node for specifying the colour manager for use in Arnold renders (#3523).
 - Viewer : Added overlay to Image views to control interactive renders where available (#3419).
 
 Improvements

--- a/Changes.md
+++ b/Changes.md
@@ -31,6 +31,7 @@ API
 ---
 
 - PrimitiveSampler : Added a new base class for nodes which sample primitive variables using an `IECoreScene::PrimitiveEvaluator`.
+- Arnold Renderer : Added support for an `ai:color_manager` option.
 
 0.57.0.0
 ========

--- a/arnold/plugins/gaffer.mtd
+++ b/arnold/plugins/gaffer.mtd
@@ -962,7 +962,7 @@
 
 
 [node car_paint]
-	
+
 	gaffer.nodeMenu.category STRING "Surface"
 
 	gaffer.graphEditorLayout.defaultVisibility BOOL false
@@ -1067,7 +1067,6 @@
 
 	primaryInput STRING "input"
 	gaffer.nodeMenu.category STRING "Utility"
-
 
 [node color_correct]
 
@@ -2088,3 +2087,14 @@
 	gaffer.nodeMenu.category STRING "Surface"
 
 
+# Standard Arnold Colour Managers
+##########################################################################
+
+[node color_manager_ocio]
+
+	[attr config]
+		widget STRING "filename"
+
+	[attr linear_chromaticities]
+		# Disable because we don't support array plugs yet
+		gaffer.plugType STRING ""

--- a/include/GafferArnold/ArnoldColorManager.h
+++ b/include/GafferArnold/ArnoldColorManager.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,33 +34,58 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERARNOLD_TYPEIDS_H
-#define GAFFERARNOLD_TYPEIDS_H
+#ifndef GAFFERARNOLD_ARNOLDCOLORMANAGER_H
+#define GAFFERARNOLD_ARNOLDCOLORMANAGER_H
+
+#include "GafferArnold/Export.h"
+#include "GafferArnold/TypeIds.h"
+
+#include "GafferScene/GlobalsProcessor.h"
+#include "GafferScene/ShaderPlug.h"
+
+#include "Gaffer/StringPlug.h"
 
 namespace GafferArnold
 {
 
-enum TypeId
-{
-	ArnoldShaderTypeId = 110900,
-	ArnoldOptionsTypeId = 110901,
-	ArnoldAttributesTypeId = 110902,
-	ArnoldLightTypeId = 110903,
-	ArnoldVDBTypeId = 110904,
-	InteractiveArnoldRenderTypeId = 110905,
-	ArnoldRenderTypeId = 110906,
-	ArnoldDisplacementTypeId = 110907,
-	ArnoldMeshLightTypeId = 110908,
-	ArnoldAOVShaderTypeId = 110909,
-	ArnoldAtmosphereTypeId = 110910,
-	ArnoldBackgroundTypeId = 110911,
-	ArnoldCameraShadersTypeId = 110912,
-	ArnoldLightFilterTypeId = 110913,
-	ArnoldColorManagerTypeId = 110914,
+class ArnoldShader;
 
-	LastTypeId = 110924
+class GAFFERSCENE_API ArnoldColorManager : public GafferScene::GlobalsProcessor
+{
+
+	public :
+
+		ArnoldColorManager( const std::string &name=defaultName<ArnoldColorManager>() );
+		~ArnoldColorManager() override;
+
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferArnold::ArnoldColorManager, ArnoldColorManagerTypeId, GafferScene::GlobalsProcessor );
+
+		Gaffer::Plug *parametersPlug();
+		const Gaffer::Plug *parametersPlug() const;
+
+		void loadColorManager( const std::string &name, bool keepExistingValues=false );
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		void hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const override;
+
+	private :
+
+		GafferScene::ShaderPlug *shaderInPlug();
+		const GafferScene::ShaderPlug *shaderInPlug() const;
+
+		ArnoldShader *shaderNode();
+		const ArnoldShader *shaderNode() const;
+
+		static size_t g_firstPlugIndex;
+
 };
+
+IE_CORE_DECLAREPTR( ArnoldColorManager )
 
 } // namespace GafferArnold
 
-#endif // GAFFERARNOLD_TYPEIDS_H
+#endif // GAFFERARNOLD_ARNOLDCOLORMANAGER_H

--- a/python/GafferArnoldTest/ArnoldColorManagerTest.py
+++ b/python/GafferArnoldTest/ArnoldColorManagerTest.py
@@ -1,0 +1,127 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+import IECoreScene
+
+import Gaffer
+import GafferTest
+import GafferScene
+import GafferSceneTest
+import GafferArnold
+
+class ArnoldColorManagerTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		# Loading
+
+		colorManager = GafferArnold.ArnoldColorManager()
+
+		colorManager.loadColorManager( "color_manager_ocio" )
+
+		for name, plugType, defaultValue in [
+			( "config", Gaffer.StringPlug, "" ),
+			( "color_space_narrow", Gaffer.StringPlug, "" ),
+			( "color_space_linear", Gaffer.StringPlug, "" ),
+		] :
+			self.assertIn( "config", colorManager["parameters"] )
+			self.assertIsInstance( colorManager["parameters"][name], plugType )
+			self.assertEqual( colorManager["parameters"][name].getValue(), defaultValue )
+			self.assertEqual( colorManager["parameters"][name].defaultValue(), defaultValue )
+
+		# Affects
+
+		options = GafferScene.StandardOptions()
+		colorManager["in"].setInput( options["out"] )
+
+		cs = GafferTest.CapturingSlot( colorManager.plugDirtiedSignal() )
+		options["enabled"].setValue( False )
+		self.assertEqual(
+			{ x[0] for x in cs if not x[0].getName().startswith( "__" ) },
+			{ colorManager["in"]["globals"], colorManager["in"], colorManager["out"]["globals"], colorManager["out"] }
+		)
+
+		del cs[:]
+		colorManager["parameters"]["color_space_linear"].setValue( "linear" )
+		self.assertEqual(
+			{ x[0] for x in cs if not x[0].getName().startswith( "__" ) },
+			{ colorManager["parameters"]["color_space_linear"], colorManager["parameters"], colorManager["out"]["globals"], colorManager["out"] }
+		)
+
+		# Compute
+
+		g = colorManager["out"].globals()
+		self.assertIn( "option:ai:color_manager", g )
+		cm = g["option:ai:color_manager"]
+		self.assertIsInstance( cm, IECoreScene.ShaderNetwork )
+		self.assertEqual( cm.outputShader().name, "color_manager_ocio" )
+		self.assertEqual( cm.outputShader().type, "ai:color_manager" )
+		self.assertEqual(
+			cm.outputShader().parameters,
+			IECore.CompoundData( {
+				"color_space_linear" : "linear",
+				"color_space_narrow" : "",
+				"config" : "",
+			} )
+		)
+
+		colorManager["enabled"].setValue( False )
+		self.assertNotIn( "ai:color_manager", colorManager["out"].globals() )
+
+	def testSerialisation( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["m"] = GafferArnold.ArnoldColorManager()
+		s["m"].loadColorManager( "color_manager_ocio" )
+		s["m"]["parameters"]["color_space_narrow"].setValue( "narrow" )
+		s["m"]["parameters"]["color_space_linear"].setValue( "linear" )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertIn( "m", s2 )
+		self.assertIsInstance( s2["m"], GafferArnold.ArnoldColorManager )
+		self.assertEqual( s2["m"]["parameters"].keys(), s["m"]["parameters"].keys() )
+		self.assertEqual( s2["m"]["parameters"]["color_space_narrow"].getValue(), "narrow" )
+		self.assertEqual( s2["m"]["parameters"]["color_space_linear"].getValue(), "linear" )
+
+		self.assertEqual( s2["m"]["out"].globals(), s["m"]["out"].globals() )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -2466,6 +2466,46 @@ class RendererTest( GafferTest.TestCase ) :
 		r.option( "ai:background", None )
 		self.assertEqual( arnold.AiNodeGetPtr( options, "background" ), None )
 
+	def testColorManager( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
+		)
+
+		options = arnold.AiUniverseGetOptions()
+		self.assertEqual( arnold.AiNodeGetPtr( options, "color_manager" ), None )
+
+		r.option(
+			"ai:color_manager",
+			IECoreScene.ShaderNetwork(
+				{
+					"output" : IECoreScene.Shader(
+						"color_manager_ocio", "ai:color_manager",
+						{
+							"config" : "something.ocio",
+							"color_space_narrow" : "narrow",
+							"color_space_linear" : "linear",
+						}
+					)
+				},
+				output = "output"
+			)
+		)
+
+		colorManager = arnold.AiNodeGetPtr( options, "color_manager" )
+		self.assertEqual(
+			arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( colorManager ) ),
+			"color_manager_ocio",
+		)
+
+		self.assertEqual( arnold.AiNodeGetStr( colorManager, "config" ), "something.ocio" )
+		self.assertEqual( arnold.AiNodeGetStr( colorManager, "color_space_narrow" ), "narrow" )
+		self.assertEqual( arnold.AiNodeGetStr( colorManager, "color_space_linear" ), "linear" )
+
+		r.option( "ai:color_manager", None )
+		self.assertEqual( arnold.AiNodeGetPtr( options, "color_manager" ), None )
+
 	def testBlockerMotionBlur( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(

--- a/python/GafferArnoldTest/__init__.py
+++ b/python/GafferArnoldTest/__init__.py
@@ -53,6 +53,7 @@ from .ModuleTest import ModuleTest
 from .ArnoldShaderBallTest import ArnoldShaderBallTest
 from .ArnoldCameraShadersTest import ArnoldCameraShadersTest
 from .ArnoldLightFilterTest import ArnoldLightFilterTest
+from .ArnoldColorManagerTest import ArnoldColorManagerTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferArnoldUI/ArnoldColorManagerUI.py
+++ b/python/GafferArnoldUI/ArnoldColorManagerUI.py
@@ -1,0 +1,153 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import PyOpenColorIO
+
+import IECore
+
+import Gaffer
+import GafferArnold
+
+def __parameterUserDefault( plug ) :
+
+	node = plug.node()
+	return Gaffer.Metadata.value(
+		"ai:color_manager:" + node["__shader"]["name"].getValue() + ":" + plug.relativeName( node["parameters"] ),
+		"userDefault"
+	)
+
+def __ocioConfig( plug ) :
+
+	try :
+		context = plug.ancestor( Gaffer.ScriptNode ).context()
+		with context :
+			if plug.node()["__shader"]["name"].getValue() != "color_manager_ocio" :
+				return None
+			config = plug.node()["parameters"]["config"].getValue()
+		if not config :
+			return PyOpenColorIO.GetCurrentConfig()
+		else :
+			return PyOpenColorIO.Config.CreateFromFile( context.substitute( config ) )
+	except :
+		return None
+
+def __roles( config ) :
+
+	result = []
+	for i in range( 0, config.getNumRoles() ) :
+		result.append( config.getRoleName( i ) )
+	return result
+
+def __colorSpaces( config ) :
+
+	return [ cs.getName() for cs in config.getColorSpaces() ]
+
+def __colorSpacePresetNames( plug ) :
+
+	config = __ocioConfig( plug )
+	if config is None :
+		return None
+
+	return IECore.StringVectorData(
+		[ "Roles/{}".format( x.replace( "_", " ").title() ) for x in __roles( config ) ] +
+		__colorSpaces( config ) + [ "None" ]
+	)
+
+def __colorSpacePresetValues( plug ) :
+
+	config = __ocioConfig( plug )
+	if config is None :
+		return None
+
+	return IECore.StringVectorData( __roles( config ) + __colorSpaces( config ) + [ "" ] )
+
+def __colorSpacePlugValueWidget( plug ) :
+
+	if __ocioConfig( plug ) is None :
+		return None
+	else :
+		return "GafferUI.PresetsPlugValueWidget"
+
+Gaffer.Metadata.registerNode(
+
+	GafferArnold.ArnoldColorManager,
+
+	"description",
+	"""
+	Specifies the colour manager to be used in Arnold renders. This is represented
+	in the scene as an option called `ai:color_manager`.
+	""",
+
+	plugs = {
+
+		"parameters" : [
+
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
+
+			"description",
+			"""
+			The parameters for the colour manager.
+			""",
+
+		],
+
+		"parameters..." : [
+
+			"userDefault", __parameterUserDefault,
+
+		],
+
+		"parameters.color_space_narrow" : [
+
+			"presetNames", __colorSpacePresetNames,
+			"presetValues", __colorSpacePresetValues,
+			"plugValueWidget:type", __colorSpacePlugValueWidget,
+
+		],
+
+		"parameters.color_space_linear" : [
+
+			"presetNames", __colorSpacePresetNames,
+			"presetValues", __colorSpacePresetValues,
+			"plugValueWidget:type", __colorSpacePlugValueWidget,
+
+		]
+
+	}
+
+)

--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -352,7 +352,7 @@ def __translateNodeMetadata( nodeEntry ) :
 
 with IECoreArnold.UniverseBlock( writable = False ) :
 
-	nodeIt = arnold.AiUniverseGetNodeEntryIterator( arnold.AI_NODE_SHADER | arnold.AI_NODE_LIGHT )
+	nodeIt = arnold.AiUniverseGetNodeEntryIterator( arnold.AI_NODE_SHADER | arnold.AI_NODE_LIGHT | arnold.AI_NODE_COLOR_MANAGER )
 	while not arnold.AiNodeEntryIteratorFinished( nodeIt ) :
 
 		__translateNodeMetadata( arnold.AiNodeEntryIteratorGetNext( nodeIt ) )
@@ -406,7 +406,7 @@ def __plugMetadata( plug, name ) :
 
 	return __metadata[key].get( name )
 
-for nodeType in ( GafferArnold.ArnoldShader, GafferArnold.ArnoldLight, GafferArnold.ArnoldMeshLight ) :
+for nodeType in ( GafferArnold.ArnoldShader, GafferArnold.ArnoldLight, GafferArnold.ArnoldMeshLight, GafferArnold.ArnoldColorManager ) :
 
 	nodeKeys = set()
 	parametersPlugKeys = set()

--- a/python/GafferArnoldUI/ShaderMenu.py
+++ b/python/GafferArnoldUI/ShaderMenu.py
@@ -46,6 +46,8 @@ import IECoreArnold
 import GafferUI
 import GafferArnold
 
+## \todo Rename. This isn't about loading shaders, it's about loading all sorts
+# of Arnold node definitions.
 def appendShaders( menuDefinition, prefix="/Arnold" ) :
 
 	MenuItem = collections.namedtuple( "MenuItem", [ "menuPath", "nodeCreator" ] )
@@ -56,7 +58,7 @@ def appendShaders( menuDefinition, prefix="/Arnold" ) :
 	uncategorisedMenuItems = []
 	with IECoreArnold.UniverseBlock( writable = False ) :
 
-		it = arnold.AiUniverseGetNodeEntryIterator( arnold.AI_NODE_SHADER | arnold.AI_NODE_LIGHT )
+		it = arnold.AiUniverseGetNodeEntryIterator( arnold.AI_NODE_SHADER | arnold.AI_NODE_LIGHT | arnold.AI_NODE_COLOR_MANAGER )
 
 		while not arnold.AiNodeEntryIteratorFinished( it ) :
 
@@ -75,12 +77,15 @@ def appendShaders( menuDefinition, prefix="/Arnold" ) :
 					nodeCreator = functools.partial( __shaderCreator, shaderName, GafferArnold.ArnoldLightFilter, nodeName )
 				else :
 					nodeCreator = functools.partial( __shaderCreator, shaderName, GafferArnold.ArnoldShader, nodeName )
-			else :
+			elif arnold.AiNodeEntryGetType( nodeEntry ) == arnold.AI_NODE_LIGHT :
 				menuPath = "Light"
 				if shaderName != "mesh_light" :
 					nodeCreator = functools.partial( __shaderCreator, shaderName, GafferArnold.ArnoldLight, nodeName )
 				else :
 					nodeCreator = GafferArnold.ArnoldMeshLight
+			else :
+				menuPath = "Globals/Color Manager"
+				nodeCreator = functools.partial( __colorManagerCreator, shaderName, nodeName )
 
 			if category :
 				menuPath += "/" + category.strip( "/" )
@@ -121,6 +126,12 @@ def __shaderCreator( shaderName, nodeType, nodeName ) :
 	if isinstance( node, GafferArnold.ArnoldLight ) :
 		node["name"].setValue( nodeName[:1].lower() + nodeName[1:] )
 
+	return node
+
+def __colorManagerCreator( colorManagerName, nodeName ) :
+
+	node = GafferArnold.ArnoldColorManager( nodeName )
+	node.loadColorManager( colorManagerName )
 	return node
 
 def __aiMetadataGetStr( nodeEntry, paramName, name ) :

--- a/python/GafferArnoldUI/__init__.py
+++ b/python/GafferArnoldUI/__init__.py
@@ -55,6 +55,7 @@ from . import ArnoldBackgroundUI
 from . import ArnoldTextureBakeUI
 from . import ArnoldCameraShadersUI
 from . import ArnoldLightFilterUI
+from . import ArnoldColorManagerUI
 from . import CacheMenu
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferArnoldUI" )

--- a/src/GafferArnold/ArnoldColorManager.cpp
+++ b/src/GafferArnold/ArnoldColorManager.cpp
@@ -1,0 +1,135 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferArnold/ArnoldColorManager.h"
+
+#include "GafferArnold/ArnoldShader.h"
+
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferArnold;
+
+GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( ArnoldColorManager );
+
+size_t ArnoldColorManager::g_firstPlugIndex = 0;
+
+ArnoldColorManager::ArnoldColorManager( const std::string &name )
+	:	GlobalsProcessor( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new Plug( "parameters" ) );
+	addChild( new ShaderPlug( "__shaderIn", Plug::In, Plug::Default & ~Plug::Serialisable ) );
+	addChild( new ArnoldShader( "__shader" ) );
+
+	shaderNode()->parametersPlug()->setFlags( Plug::AcceptsInputs, true );
+	shaderNode()->parametersPlug()->setInput( parametersPlug() );
+}
+
+ArnoldColorManager::~ArnoldColorManager()
+{
+}
+
+Gaffer::Plug *ArnoldColorManager::parametersPlug()
+{
+	return getChild<Plug>( g_firstPlugIndex );
+}
+
+const Gaffer::Plug *ArnoldColorManager::parametersPlug() const
+{
+	return getChild<Plug>( g_firstPlugIndex );
+}
+
+GafferScene::ShaderPlug *ArnoldColorManager::shaderInPlug()
+{
+	return getChild<ShaderPlug>( g_firstPlugIndex + 1 );
+}
+
+const GafferScene::ShaderPlug *ArnoldColorManager::shaderInPlug() const
+{
+	return getChild<ShaderPlug>( g_firstPlugIndex + 1 );
+}
+
+ArnoldShader *ArnoldColorManager::shaderNode()
+{
+	return getChild<ArnoldShader>( g_firstPlugIndex + 2 );
+}
+
+const ArnoldShader *ArnoldColorManager::shaderNode() const
+{
+	return getChild<ArnoldShader>( g_firstPlugIndex + 2 );
+}
+
+void ArnoldColorManager::loadColorManager( const std::string &name, bool keepExistingValues )
+{
+	shaderNode()->loadShader( name, keepExistingValues );
+	shaderInPlug()->setInput( shaderNode()->outPlug() );
+}
+
+void ArnoldColorManager::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	GlobalsProcessor::affects( input, outputs );
+
+	if( input == shaderInPlug() )
+	{
+		outputs.push_back( outPlug()->globalsPlug() );
+	}
+}
+
+void ArnoldColorManager::hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	h.append( shaderInPlug()->attributesHash() );
+}
+
+IECore::ConstCompoundObjectPtr ArnoldColorManager::computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const
+{
+	ConstCompoundObjectPtr attributes = shaderInPlug()->attributes();
+	if( attributes->members().empty() )
+	{
+		return inputGlobals;
+	}
+
+	if( attributes->members().size() > 1 )
+	{
+		throw IECore::Exception( "Unexpected number of attributes" );
+	}
+
+	CompoundObjectPtr result = new CompoundObject;
+	result->members() = inputGlobals->members();
+	result->members()["option:ai:color_manager"] = attributes->members().begin()->second;
+
+	return result;
+}

--- a/src/GafferArnold/ArnoldShader.cpp
+++ b/src/GafferArnold/ArnoldShader.cpp
@@ -129,40 +129,38 @@ void ArnoldShader::loadShader( const std::string &shaderName, bool keepExistingV
 		}
 	}
 
-	const bool isLightShader = AiNodeEntryGetType( shader ) == AI_NODE_LIGHT;
-	namePlug()->setValue( AiNodeEntryGetName( shader ) );
+	namePlug()->source<StringPlug>()->setValue( AiNodeEntryGetName( shader ) );
 
-	int aiOutputType = AI_TYPE_POINTER;
-	string type = "ai:light";
-	if( !isLightShader )
+	string type;
+	switch( AiNodeEntryGetType( shader ) )
 	{
-		const CompoundData *metadata = ArnoldShader::metadata();
-		const StringData *shaderTypeData = static_cast<const StringData*>( metadata->member<IECore::CompoundData>( "shader" )->member<IECore::Data>( "shaderType" ) );
-		if( shaderTypeData )
-		{
-			type = "ai:" + shaderTypeData->readable();
-		}
-		else
-		{
+		case AI_NODE_LIGHT :
+			type = "ai:light";
+			break;
+		case AI_NODE_COLOR_MANAGER :
+			type = "ai:color_manager";
+			break;
+		default :
 			type = "ai:surface";
-		}
-
-		if( type == "ai:surface" )
-		{
-			aiOutputType = AiNodeEntryGetOutputType( shader );
-		}
+			break;
 	}
 
-	if( !keepExistingValues && type == "ai:lightFilter" )
+	if( auto d = metadata()->member<CompoundData>( "shader" )->member<StringData>( "shaderType" ) )
 	{
-		attributeSuffixPlug()->setValue( shaderName );
+		type = "ai:" + d->readable();
 	}
-
 	typePlug()->setValue( type );
 
-	ParameterHandler::setupPlugs( shader, parametersPlug );
-	ParameterHandler::setupPlug( "out", aiOutputType, this, Plug::Out );
+	if( !keepExistingValues )
+	{
+		attributeSuffixPlug()->setValue( type == "ai:lightFilter" ? shaderName : "" );
+	}
 
+	ParameterHandler::setupPlugs( shader, parametersPlug );
+
+	int aiOutputType = AiNodeEntryGetOutputType( shader );
+	aiOutputType = aiOutputType == AI_TYPE_NONE ? AI_TYPE_POINTER : aiOutputType;
+	ParameterHandler::setupPlug( "out", aiOutputType, this, Plug::Out );
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -252,6 +252,7 @@ const AtString g_backgroundArnoldString( "background" );
 const AtString g_boxArnoldString("box");
 const AtString g_cameraArnoldString( "camera" );
 const AtString g_catclarkArnoldString("catclark");
+const AtString g_colorManagerArnoldString( "color_manager" );
 const AtString g_customAttributesArnoldString( "custom_attributes" );
 const AtString g_curvesArnoldString("curves");
 const AtString g_dispMapArnoldString( "disp_map" );
@@ -2550,6 +2551,7 @@ IECore::InternedString g_progressiveMinAASamplesOptionName( "ai:progressive_min_
 IECore::InternedString g_sampleMotionOptionName( "sampleMotion" );
 IECore::InternedString g_atmosphereOptionName( "ai:atmosphere" );
 IECore::InternedString g_backgroundOptionName( "ai:background" );
+IECore::InternedString g_colorManagerOptionName( "ai:color_manager" );
 IECore::InternedString g_subdivDicingCameraOptionName( "ai:subdiv_dicing_camera" );
 
 std::string g_logFlagsOptionPrefix( "ai:log:" );
@@ -2784,6 +2786,19 @@ class ArnoldGlobals
 					}
 				}
 				AiNodeSetStr( options, g_pluginSearchPathArnoldString, AtString( s.c_str() ) );
+				return;
+			}
+			else if( name == g_colorManagerOptionName )
+			{
+				m_colorManager = nullptr;
+				if( value )
+				{
+					if( const IECoreScene::ShaderNetwork *d = reportedCast<const IECoreScene::ShaderNetwork>( value, "option", name ) )
+					{
+						m_colorManager = m_shaderCache->get( d, nullptr );
+					}
+				}
+				AiNodeSetPtr( options, g_colorManagerArnoldString, m_colorManager ? m_colorManager->root() : nullptr );
 				return;
 			}
 			else if( name == g_atmosphereOptionName )
@@ -3163,8 +3178,8 @@ class ArnoldGlobals
 			std::sort( outputs->writable().begin(), outputs->writable().end() );
 			IECoreArnold::ParameterAlgo::setParameter( options, "outputs", outputs.get() );
 			IECoreArnold::ParameterAlgo::setParameter( options, "light_path_expressions", lpes.get() );
-		
-			// Set the beauty as the output to get frequent interactive updates	
+
+			// Set the beauty as the output to get frequent interactive updates
 			unsigned int primaryOutput = 0;
 			for( unsigned int i = 0; i < outputs->readable().size(); i++ )
 			{
@@ -3292,6 +3307,7 @@ class ArnoldGlobals
 		typedef std::map<IECore::InternedString, ArnoldShaderPtr> AOVShaderMap;
 		AOVShaderMap m_aovShaders;
 
+		ArnoldShaderPtr m_colorManager;
 		ArnoldShaderPtr m_atmosphere;
 		ArnoldShaderPtr m_background;
 


### PR DESCRIPTION
This addresses #3523. We currently don't support the `linear_chromaticities` array on the `color_manager_ocio` node because we don't have support for array parameters in general. But Arnold will get the chromaticities right automatically as long as you're using one of the common choices for `color_space_linear`. From their technical support :

> Chromaticities only make a difference for spectral effects, not for color space conversion. If you don’t provide them, Arnold will take a stab at guessing the rendering color space chromaticities, which will work fine for well known rendering color spaces like ACEScg sRGB Rec2020 etc… In other words, you should be fine if you leave it at the default value and spectral effects will be accurate.

It seems the `linear_chromaticities` parameter is necessary because OCIO doesn't provide any information about chromaticities : https://groups.google.com/forum/#!topic/ocio-dev/1gAf2Xwlu1I. This seems like a pity, because separate `color_space_linear` and `linear_chromaticities` parameters make it easy for the user to get the two out of sync. Given how hard colour management is already, I think omitting `linear_chromaticities` might even avoid confusion for the majority of users (including me).
