### PR TITLE
OSLCode : Disable substitutions on code plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.57.x.x (relative to 0.57.2.0)
+========
+
+Fixes
+-----
+
+- OSLCode : Don't apply substitutions to code, so that symbols such as `#` can be used correctly 
+
 0.57.2.0 (relative to 0.57.1.0)
 ========
 

--- a/src/GafferOSL/OSLCode.cpp
+++ b/src/GafferOSL/OSLCode.cpp
@@ -362,7 +362,7 @@ OSLCode::OSLCode( const std::string &name )
 	/// \todo Rejig the NetworkGenerator so there is a hook for us to do our
 	/// code generation on demand at network generation time, and allow inputs
 	/// again.
-	addChild( new StringPlug( "code", Plug::In, "", Plug::Default & ~Plug::AcceptsInputs ) );
+	addChild( new StringPlug( "code", Plug::In, "", Plug::Default & ~Plug::AcceptsInputs, IECore::StringAlgo::NoSubstitutions ) );
 
 	// Must disable serialisation on the name because the GAFFEROSL_CODE_DIRECTORY
 	// might not be the same when we come to be loaded again.


### PR DESCRIPTION
One of artists asked why macros don't work in OSLCode.  I'm not sure we want to encourage artists to use macros ( providing a section where functions could be defined would probably be a lot better in a lot of ways ).

But the current reason why macros don't work doesn't seem intentional at all:  if you type `#ifdef`, the OSLCode substitutes that to `1ifdef`, apparently substituting some sort of default frame number.  I can't think of any reason not to just disable substitutions on this plug.