### PR TITLE
IECoreArnoldPreview::Renderer : Temporarily hack around Arnold update bug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- Arnold : Added workaround for Arnold bug which prevented interactive edits to quad light colour textures.
 - CopyAttributes : Fixed bugs triggered by non-existent source locations. CopyAttributes now matches the behavior of CopyPrimitiveVariables : if the source location does not exist, nothing is copied and no error is caused.
 - Viewer : Fixed bugs in the "Edit Tweaks..." menu item. The wrong ShaderTweaks node could be displayed for certain upstream configurations of nodes like CopyAttributes, ShuffleAttributes and MergeScenes.
 - OSLCode : Removed string substitutions on code, so that symbols such as `#` can be used directly. Substitutions were of no use anyway, because they were not being applied in a suitable context.


### PR DESCRIPTION
Currently in Arnold, shaders on quad lights don't update properly during interactive rendering.

We can hack around this by throwing out quad lights whenever a parameter changes.