### PR TITLE
Multithreaded bounds propagation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - SceneNode : Improved performance for all nodes that must propagate bounds from children to parents.
 - PointsType : Removed unnecessary bounds computation overhead.
+- Stats app : Added `-location` argument, to allow profiling of a single location in a scene.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - SceneNode : Improved performance for all nodes that must propagate bounds from children to parents.
 - PointsType : Removed unnecessary bounds computation overhead.
+- OSLObject/ClosestPointSampler/CurveSampler : Improved performance for cases where multiple downstream computes require the same upstream object.
 - Stats app : Added `-location` argument, to allow profiling of a single location in a scene.
 
 API

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,11 @@ Improvements
 - SceneNode : Improved performance for all nodes that must propagate bounds from children to parents.
 - PointsType : Removed unnecessary bounds computation overhead.
 
+API
+---
+
+- ScenePlug : Added `childBounds()` and `childBoundsHash()` methods.
+
 Breaking Changes
 ----------------
 

--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,9 @@ API
 ---
 
 - ScenePlug : Added `childBounds()` and `childBoundsHash()` methods.
+- SceneNode :
+  - Deprecated `hashOfTransformedChildBounds()`. Use `ScenePlug::childBoundsHash()` instead.
+  - Deprecated `unionOfTransformedChildBounds()`. Use `ScenePlug::childBounds()` instead.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -12,9 +12,11 @@ API
 ---
 
 - ScenePlug : Added `childBounds()` and `childBoundsHash()` methods.
+- ObjectProcessor : Added `processedObjectComputeCachePolicy()` virtual method. This should be overridden to choose an appropriate cache policy when `computeProcessedObject()` spawns TBB tasks.
 - SceneNode :
   - Deprecated `hashOfTransformedChildBounds()`. Use `ScenePlug::childBoundsHash()` instead.
   - Deprecated `unionOfTransformedChildBounds()`. Use `ScenePlug::childBounds()` instead.
+- IECorePreview::Renderer : Added optional message handler to renderer construction to allow output message streams to be re-directed if required (#3419).
 
 Breaking Changes
 ----------------
@@ -45,11 +47,7 @@ Breaking Changes
     - `GafferCortexUI` attributes can no longer be accessed via the `GafferUI` namespace.
 - RecursiveChildIterator : Changed private member data. Source compatibility is maintained.
 - IECorePreview::Renderer : Changed signature for `create` and `registerType` to include optional message handler.
-
-API
----
-
-- IECorePreview::Renderer : Added optional message handler to renderer construction to allow output message streams to be re-directed if required (#3419).
+- ObjectProcessor : Added a virtual method.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Improvements
 ------------
 
+- SceneNode : Improved performance for all nodes that must propagate bounds from children to parents.
 - PointsType : Removed unnecessary bounds computation overhead.
 
 Breaking Changes

--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -134,6 +134,14 @@ class stats( Gaffer.Application ) :
 					defaultValue = "",
 				),
 
+				IECore.StringParameter(
+					name = "location",
+					description = "The path to a location in the scene. If this is specified "
+						"then that single location will be generated profiled, otherwise "
+						"the entire scene will generated.",
+					defaultValue = "",
+				),
+
 				IECore.StringVectorParameter(
 					name = "sets",
 					description = "The names of scene sets to be examined.",
@@ -489,13 +497,21 @@ class stats( Gaffer.Application ) :
 					context.setFrame( frame )
 
 					if isinstance( scene, GafferDispatch.TaskNode.TaskPlug ) :
+						if args["location"].value :
+							IECore.msg( IECore.Msg.Level.Warning, "stats", "`-location` argument is not compatible with TaskPlugs" )
 						context["scene:render:sceneTranslationOnly"] = IECore.BoolData( True )
 						scene.execute()
 					else :
 						if args["sets"] :
 							GafferScene.SceneAlgo.sets( scene, args["sets"] )
 						else :
-							GafferSceneTest.traverseScene( scene )
+							if args["location"].value :
+								scene.transform( args["location"].value )
+								scene.bound( args["location"].value )
+								scene.attributes( args["location"].value )
+								scene.object( args["location"].value )
+							else :
+								GafferSceneTest.traverseScene( scene )
 
 		if args["preCache"].value :
 			computeScene()

--- a/include/Gaffer/Private/IECorePreview/LRUCache.inl
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.inl
@@ -816,12 +816,7 @@ class TaskParallel
 						const bool acquired = m_itemLock.acquireOr(
 							it->mutex, lockType,
 							// Work accepter
-							[&binLock, &spawnsTasks] ( bool workAvailable ) {
-								if( workAvailable )
-								{
-									assert( spawnsTasks );
-									(void)spawnsTasks;
-								}
+							[&binLock] ( bool workAvailable ) {
 								// Release the bin lock prior to accepting work, because
 								// the work might involve recursion back into the cache,
 								// thus requiring the bin lock.

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -116,6 +116,19 @@ class GAFFER_API ValuePlug : public Plug
 			/// Suitable for regular processes that don't spawn
 			/// TBB tasks. It is essential that any task-spawning
 			/// processes use one of the dedicated policies below.
+			/// \todo It isn't actually clear that the locking of the
+			/// Standard policy is an improvement over the non-locked
+			/// Legacy policy. Locking on a downstream Standard
+			/// compute might prevent multiple threads from participating
+			/// in an upstream TaskCollaboration. And for small computes
+			/// that are unlikely to be needed by multiple threads,
+			/// we may well prefer to avoid the contention. Note that
+			/// many scene computes may fit this category, as every
+			/// non-filtered location is implemented as a very cheap
+			/// pass-through compute. There's also a decent argument
+			/// that any non-trivial amount of work should be using TBB,
+			/// so it would be a mistake to do anything expensive with
+			/// a Standard policy anyway.
 			Standard,
 			/// Suitable for processes that spawn TBB tasks.
 			/// Threads waiting for the same result will collaborate

--- a/include/GafferOSL/OSLObject.h
+++ b/include/GafferOSL/OSLObject.h
@@ -81,6 +81,7 @@ class GAFFEROSL_API OSLObject : public GafferScene::Deformer
 		bool affectsProcessedObject( const Gaffer::Plug *input ) const override;
 		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const override;
+		Gaffer::ValuePlug::CachePolicy processedObjectComputeCachePolicy() const override;
 		bool adjustBounds() const override;
 
 		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;

--- a/include/GafferScene/PrimitiveSampler.h
+++ b/include/GafferScene/PrimitiveSampler.h
@@ -119,6 +119,7 @@ class GAFFERSCENE_API PrimitiveSampler : public Deformer
 		bool affectsProcessedObject( const Gaffer::Plug *input ) const final;
 		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const final;
 		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const final;
+		Gaffer::ValuePlug::CachePolicy processedObjectComputeCachePolicy() const final;
 
 		bool adjustBounds() const final;
 

--- a/include/GafferScene/SceneNode.h
+++ b/include/GafferScene/SceneNode.h
@@ -119,13 +119,9 @@ class GAFFERSCENE_API SceneNode : public Gaffer::ComputeNode
 		/// it, and that makes computation quicker, as we don't need to access setNamesPlug() at all in many common cases.
 		virtual IECore::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const;
 
-		/// Convenience function to compute the correct bounding box for a path from the bounding box and transforms of its
-		/// children. Using this from computeBound() should be a last resort, as it implies peeking inside children to determine
-		/// information about the parent - the last thing we want to be doing when defining large scenes procedurally. If
-		/// `out->childNames()` has been computed already for some reason, then it may be passed to avoid recomputing it
-		/// internally.
+		/// \deprecated Use `ScenePlug::childBounds()` instead.
 		Imath::Box3f unionOfTransformedChildBounds( const ScenePath &path, const ScenePlug *out, const IECore::InternedStringVectorData *childNames = nullptr ) const;
-		/// A hash for the result of the computation in unionOfTransformedChildBounds().
+		/// \deprecated Use `ScenePlug::childBoundsHash()` instead.
 		IECore::MurmurHash hashOfTransformedChildBounds( const ScenePath &path, const ScenePlug *out, const IECore::InternedStringVectorData *childNames = nullptr ) const;
 
 		Gaffer::ValuePlug::CachePolicy hashCachePolicy( const Gaffer::ValuePlug *output ) const override;

--- a/include/GafferScene/SceneNode.h
+++ b/include/GafferScene/SceneNode.h
@@ -128,6 +128,9 @@ class GAFFERSCENE_API SceneNode : public Gaffer::ComputeNode
 		/// A hash for the result of the computation in unionOfTransformedChildBounds().
 		IECore::MurmurHash hashOfTransformedChildBounds( const ScenePath &path, const ScenePlug *out, const IECore::InternedStringVectorData *childNames = nullptr ) const;
 
+		Gaffer::ValuePlug::CachePolicy hashCachePolicy( const Gaffer::ValuePlug *output ) const override;
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
+
 	private :
 
 		void plugInputChanged( Gaffer::Plug *plug );
@@ -137,6 +140,9 @@ class GAFFERSCENE_API SceneNode : public Gaffer::ComputeNode
 
 		void hashSortedChildNames( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
 		IECore::ConstInternedStringVectorDataPtr computeSortedChildNames( const Gaffer::Context *context, const ScenePlug *parent ) const;
+
+		void hashChildBounds( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		Imath::Box3f computeChildBounds( const Gaffer::Context *context, const ScenePlug *parent ) const;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferScene/ScenePlug.h
+++ b/include/GafferScene/ScenePlug.h
@@ -255,6 +255,9 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 		Gaffer::InternedStringVectorDataPlug *sortedChildNamesPlug();
 		const Gaffer::InternedStringVectorDataPlug *sortedChildNamesPlug() const;
 
+		Gaffer::AtomicBox3fPlug *childBoundsPlug();
+		const Gaffer::AtomicBox3fPlug *childBoundsPlug() const;
+
 };
 
 IE_CORE_DECLAREPTR( ScenePlug );

--- a/include/GafferScene/ScenePlug.h
+++ b/include/GafferScene/ScenePlug.h
@@ -235,6 +235,15 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 		/// As above, but for the location specified by the current context.
 		bool exists() const;
 
+		/// Returns the union of the bounding boxes of all the children
+		/// of `scenePath`, transformed using their respective transforms.
+		Imath::Box3f childBounds( const ScenePath &scenePath ) const;
+		/// As above, but for the location specified by the current context.
+		Imath::Box3f childBounds() const;
+		/// Returns a hash representing the results of `childBounds()`.
+		IECore::MurmurHash childBoundsHash( const ScenePath &scenePath ) const;
+		IECore::MurmurHash childBoundsHash() const;
+
 		/// Utility function to convert a string into a path by splitting on '/'.
 		/// \todo Many of the places we use this, it would be preferable if the source data was already
 		/// a path. Perhaps a ScenePathPlug could take care of this for us?

--- a/python/GafferOSLTest/OSLObjectTest.py
+++ b/python/GafferOSLTest/OSLObjectTest.py
@@ -1010,7 +1010,10 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 
 		s["transform"]["translate"]["x"].setValue( 1 )
 		def checkAffected( expected ):
-			self.assertEqual( [ i[0].getName() for i in cs if i[0].parent() == o["out"] ], expected )
+			self.assertEqual(
+				[ i[0].getName() for i in cs if i[0].parent() == o["out"] and not i[0].getName().startswith( "__" ) ],
+				expected
+			)
 			del cs[:]
 		checkAffected( ["transform", "bound" ] )
 

--- a/python/GafferSceneTest/CustomOptionsTest.py
+++ b/python/GafferSceneTest/CustomOptionsTest.py
@@ -132,15 +132,18 @@ class CustomOptionsTest( GafferSceneTest.SceneTestCase ) :
 
 		p["dimensions"]["x"].setValue( 100.1 )
 
-		dirtiedPlugs = set( [ x[0].relativeName( x[0].node() ) for x in cs ] )
-
-		self.assertEqual( len( dirtiedPlugs ), 6 )
-		self.assertTrue( "in.bound" in dirtiedPlugs )
-		self.assertTrue( "in.object" in dirtiedPlugs )
-		self.assertTrue( "in" in dirtiedPlugs )
-		self.assertTrue( "out.bound" in dirtiedPlugs )
-		self.assertTrue( "out.object" in dirtiedPlugs )
-		self.assertTrue( "out" in dirtiedPlugs )
+		dirtiedPlugs = { x[0] for x in cs if not x[0].getName().startswith( "__" ) }
+		self.assertEqual(
+			dirtiedPlugs,
+			{
+				o["in"]["bound"],
+				o["in"]["object"],
+				o["in"],
+				o["out"]["bound"],
+				o["out"]["object"],
+				o["out"],
+			}
+		)
 
 	def testSubstitution( self ) :
 

--- a/python/GafferSceneTest/ParametersTest.py
+++ b/python/GafferSceneTest/ParametersTest.py
@@ -93,9 +93,9 @@ class ParametersTest( GafferSceneTest.SceneTestCase ) :
 		p = Gaffer.NameValuePlug( "test", 10, True )
 		parameters["parameters"].addChild( p )
 
-		self.assertEqual( parameters.affects( p["name"] ), [ parameters["out"]["object"] ] )
-		self.assertEqual( parameters.affects( p["enabled"] ), [ parameters["out"]["object"] ] )
-		self.assertEqual( parameters.affects( p["value"] ), [ parameters["out"]["object"] ] )
+		self.assertEqual( parameters.affects( p["name"] ), [ parameters["__processedObject"] ] )
+		self.assertEqual( parameters.affects( p["enabled"] ), [ parameters["__processedObject"] ] )
+		self.assertEqual( parameters.affects( p["value"] ), [ parameters["__processedObject"] ] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/ParentConstraintTest.py
+++ b/python/GafferSceneTest/ParentConstraintTest.py
@@ -125,11 +125,17 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		constraint["relativeTransform"]["translate"]["x"].setValue( 10 )
 
-		self.assertEqual( len( cs ), 6 )
-		plugs = [ x[0].relativeName( x[0].node() ) for x in cs ]
+		plugs = { x[0] for x in cs if not x[0].getName().startswith( "__" ) }
 		self.assertEqual(
-			set( [ "relativeTransform.translate.x", "relativeTransform.translate", "relativeTransform", "out.bound", "out.transform", "out" ] ),
-			set( plugs )
+			plugs,
+			{
+				constraint["relativeTransform"]["translate"]["x"],
+				constraint["relativeTransform"]["translate"],
+				constraint["relativeTransform"],
+				constraint["out"]["bound"],
+				constraint["out"]["transform"],
+				constraint["out"]
+			}
 		)
 
 	def testParentNodeEquivalence( self ) :

--- a/python/GafferSceneTest/SceneNodeTest.py
+++ b/python/GafferSceneTest/SceneNodeTest.py
@@ -336,6 +336,43 @@ class SceneNodeTest( GafferSceneTest.SceneTestCase ) :
 			{ cube["out"]["childNames"], cube["out"]["__sortedChildNames"], cube["out"]["__exists"] }
 		)
 
+	def testChildBounds( self ) :
+
+		cube = GafferScene.Cube()
+		sphere = GafferScene.Sphere()
+		group = GafferScene.Group()
+		group["in"][0].setInput( cube["out"] )
+		group["in"][1].setInput( sphere["out"] )
+
+		with Gaffer.Context() as c :
+			c["scene:path"] = IECore.InternedStringVectorData( [ "group" ] )
+			h = group["out"].childBoundsHash()
+			b = group["out"].childBounds()
+
+		self.assertEqual( h, group["out"].childBoundsHash( "/group" ) )
+		self.assertEqual( b, group["out"].childBounds( "/group" ) )
+
+		b2 = cube["out"].bound( "/" )
+		b2.extendBy( sphere["out"].bound( "/" ) )
+		self.assertEqual( b, b2 )
+
+		cube["transform"]["translate"]["x"].setValue( 10 )
+
+		self.assertNotEqual( group["out"].childBoundsHash( "/group"), h )
+		b = group["out"].childBounds( "/group" )
+
+		b2 = cube["out"].bound( "/" )
+		b2.extendBy( sphere["out"].bound( "/" ) )
+		self.assertEqual( b, b2 )
+
+	def testChildBoundsWhenNoChildren( self ) :
+
+		plane = GafferScene.Plane()
+		sphere = GafferScene.Sphere()
+
+		self.assertEqual( plane["out"].childBounds( "/plane" ), imath.Box3f() )
+		self.assertEqual( sphere["out"].childBounds( "/sphere" ), imath.Box3f() )
+
 	def setUp( self ) :
 
 		GafferSceneTest.SceneTestCase.setUp( self )

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -689,7 +689,11 @@ class ValuePlug::ComputeProcess : public Process
 						// the compute will lead to deadlock. We'll do the work outside.
 						break;
 				}
-				cost = result ? result->memoryUsage() : 0;
+				// Using max size for legacy policy so that our null result will never be
+				// cached. This avoids `assert( processKey.cachePolicy == CachePolicy::Legacy )`
+				// being triggered in `ComputeProcess::value()` when a plug with a legacy
+				// policy implements a pass-through from a plug with non-legacy policy.
+				cost = result ? result->memoryUsage() : std::numeric_limits<size_t>::max();
 				return result;
 			}
 			catch( const ProcessException &processException )

--- a/src/GafferOSL/OSLObject.cpp
+++ b/src/GafferOSL/OSLObject.cpp
@@ -369,6 +369,11 @@ IECore::ConstObjectPtr OSLObject::computeProcessedObject( const ScenePath &path,
 	return outputPrimitive;
 }
 
+Gaffer::ValuePlug::CachePolicy OSLObject::processedObjectComputeCachePolicy() const
+{
+	return ValuePlug::CachePolicy::TaskCollaboration;
+}
+
 bool OSLObject::adjustBounds() const
 {
 	if( !Deformer::adjustBounds() )

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -324,7 +324,7 @@ void BranchCreator::hashBound( const ScenePath &path, const Gaffer::Context *con
 	{
 		FilteredSceneProcessor::hashBound( path, context, parent, h );
 		inPlug()->boundPlug()->hash( h );
-		h.append( hashOfTransformedChildBounds( path, outPlug() ) );
+		h.append( outPlug()->childBoundsHash() );
 	}
 	else
 	{
@@ -344,7 +344,7 @@ Imath::Box3f BranchCreator::computeBound( const ScenePath &path, const Gaffer::C
 	else if( parentMatch == IECore::PathMatcher::ExactMatch || parentMatch == IECore::PathMatcher::DescendantMatch )
 	{
 		Box3f result = inPlug()->boundPlug()->getValue();
-		result.extendBy( unionOfTransformedChildBounds( path, outPlug() ) );
+		result.extendBy( outPlug()->childBounds() );
 		return result;
 	}
 	else

--- a/src/GafferScene/CollectScenes.cpp
+++ b/src/GafferScene/CollectScenes.cpp
@@ -181,7 +181,7 @@ void CollectScenes::hashBound( const ScenePath &path, const Gaffer::Context *con
 {
 	if( path.size() == 0 )
 	{
-		h = hashOfTransformedChildBounds( path, outPlug() );
+		h = outPlug()->childBoundsHash();
 	}
 	else
 	{
@@ -194,7 +194,7 @@ Imath::Box3f CollectScenes::computeBound( const ScenePath &path, const Gaffer::C
 {
 	if( path.size() == 0 )
 	{
-		return unionOfTransformedChildBounds( path, outPlug() );
+		return outPlug()->childBounds();
 	}
 	else
 	{

--- a/src/GafferScene/Deformer.cpp
+++ b/src/GafferScene/Deformer.cpp
@@ -121,11 +121,11 @@ void Deformer::hashBound( const ScenePath &path, const Gaffer::Context *context,
 
 			if( m & PathMatcher::DescendantMatch )
 			{
-				h.append( hashOfTransformedChildBounds( path, outPlug() ) );
+				h.append( outPlug()->childBoundsHash() );
 			}
 			else
 			{
-				h.append( hashOfTransformedChildBounds( path, inPlug() ) );
+				h.append( inPlug()->childBoundsHash() );
 			}
 			return;
 		}
@@ -171,11 +171,11 @@ Imath::Box3f Deformer::computeBound( const ScenePath &path, const Gaffer::Contex
 
 			if( m & PathMatcher::DescendantMatch )
 			{
-				result.extendBy( unionOfTransformedChildBounds( path, outPlug() ) );
+				result.extendBy( outPlug()->childBounds() );
 			}
 			else
 			{
-				result.extendBy( unionOfTransformedChildBounds( path, inPlug() ) );
+				result.extendBy( inPlug()->childBounds() );
 			}
 			return result;
 		}

--- a/src/GafferScene/DeleteObject.cpp
+++ b/src/GafferScene/DeleteObject.cpp
@@ -133,7 +133,7 @@ void DeleteObject::hashBound( const ScenePath &path, const Gaffer::Context *cont
 		if( m & ( IECore::PathMatcher::ExactMatch | IECore::PathMatcher::DescendantMatch ) )
 		{
 			FilteredSceneProcessor::hashBound( path, context, parent, h );
-			h.append( hashOfTransformedChildBounds( path, outPlug() ) );
+			h.append( outPlug()->childBoundsHash() );
 			if( !(m & IECore::PathMatcher::ExactMatch) )
 			{
 				inPlug()->objectPlug()->hash( h );
@@ -151,7 +151,7 @@ Imath::Box3f DeleteObject::computeBound( const ScenePath &path, const Gaffer::Co
 		const IECore::PathMatcher::Result m = filterValue( context );
 		if( m & ( IECore::PathMatcher::ExactMatch | IECore::PathMatcher::DescendantMatch ) )
 		{
-			Box3f result = unionOfTransformedChildBounds( path, outPlug() );
+			Box3f result = outPlug()->childBounds();
 			if( !(m & IECore::PathMatcher::ExactMatch) )
 			{
 				ConstObjectPtr o = inPlug()->objectPlug()->getValue();

--- a/src/GafferScene/FreezeTransform.cpp
+++ b/src/GafferScene/FreezeTransform.cpp
@@ -145,7 +145,7 @@ void FreezeTransform::hashBound( const ScenePath &path, const Gaffer::Context *c
 		// thus changing the bounds - so we must compute them properly from
 		// children.
 		SceneProcessor::hashBound( path, context, parent, h );
-		h.append( hashOfTransformedChildBounds( path, outPlug() ) );
+		h.append( outPlug()->childBoundsHash() );
 		// we may also be changing the bounds at this specific location.
 		inPlug()->boundPlug()->hash( h );
 		transformPlug()->hash( h );
@@ -166,7 +166,7 @@ Imath::Box3f FreezeTransform::computeBound( const ScenePath &path, const Gaffer:
 	const unsigned m = filterValue( context );
 	if( m & ( IECore::PathMatcher::AncestorMatch | IECore::PathMatcher::ExactMatch ) )
 	{
-		Box3f result = unionOfTransformedChildBounds( path, outPlug() );
+		Box3f result = outPlug()->childBounds();
 		Box3f b = inPlug()->boundPlug()->getValue();
 		b = transform( b, transformPlug()->getValue() );
 		result.extendBy( b );

--- a/src/GafferScene/Grid.cpp
+++ b/src/GafferScene/Grid.cpp
@@ -220,7 +220,7 @@ void Grid::hashBound( const SceneNode::ScenePath &path, const Gaffer::Context *c
 {
 	if( path.size() == 0 )
 	{
-		h = hashOfTransformedChildBounds( path, parent );
+		h = parent->childBoundsHash();
 	}
 	else
 	{
@@ -233,7 +233,7 @@ Imath::Box3f Grid::computeBound( const SceneNode::ScenePath &path, const Gaffer:
 {
 	if( path.size() == 0 )
 	{
-		return unionOfTransformedChildBounds( path, parent );
+		return parent->childBounds();
 	}
 	else
 	{

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -826,7 +826,7 @@ void Instancer::hashBranchBound( const ScenePath &parentPath, const ScenePath &b
 		{
 			path.push_back( namePlug()->getValue() );
 		}
-		h = hashOfTransformedChildBounds( path, outPlug() );
+		h = outPlug()->childBoundsHash( path );
 	}
 	else if( branchPath.size() == 2 )
 	{
@@ -862,7 +862,7 @@ Imath::Box3f Instancer::computeBranchBound( const ScenePath &parentPath, const S
 		{
 			path.push_back( namePlug()->getValue() );
 		}
-		return unionOfTransformedChildBounds( path, outPlug() );
+		return outPlug()->childBounds( path );
 	}
 	else if( branchPath.size() == 2 )
 	{
@@ -870,7 +870,7 @@ Imath::Box3f Instancer::computeBranchBound( const ScenePath &parentPath, const S
 		//
 		// We need to return the union of all the transformed children, but
 		// because we have direct access to the engine, we can implement this
-		// more efficiently than `unionOfTransformedChildBounds()`.
+		// more efficiently than `ScenePlug::childBounds()`.
 
 		ConstEngineDataPtr e = engine( parentPath, context );
 		ConstCompoundDataPtr ic = prototypeChildNames( parentPath, context );

--- a/src/GafferScene/Isolate.cpp
+++ b/src/GafferScene/Isolate.cpp
@@ -226,7 +226,7 @@ void Isolate::hashBound( const ScenePath &path, const Gaffer::Context *context, 
 	const SetsToKeep setsToKeep( this );
 	if( adjustBoundsPlug()->getValue() && mayPruneChildren( path, context, setsToKeep ) )
 	{
-		h = hashOfTransformedChildBounds( path, outPlug() );
+		h = outPlug()->childBoundsHash();
 		return;
 	}
 
@@ -239,7 +239,7 @@ Imath::Box3f Isolate::computeBound( const ScenePath &path, const Gaffer::Context
 	const SetsToKeep setsToKeep( this );
 	if( adjustBoundsPlug()->getValue() && mayPruneChildren( path, context, setsToKeep ) )
 	{
-		return unionOfTransformedChildBounds( path, outPlug() );
+		return outPlug()->childBounds();
 	}
 
 	return inPlug()->boundPlug()->getValue();

--- a/src/GafferScene/MergeScenes.cpp
+++ b/src/GafferScene/MergeScenes.cpp
@@ -512,7 +512,7 @@ void MergeScenes::hashBound( const ScenePath &path, const Gaffer::Context *conte
 
 	SceneProcessor::hashBound( path, context, parent, h );
 	outPlug()->objectPlug()->hash( h );
-	h.append( hashOfTransformedChildBounds( path, outPlug() ) );
+	h.append( outPlug()->childBoundsHash() );
 }
 
 Imath::Box3f MergeScenes::computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
@@ -542,7 +542,7 @@ Imath::Box3f MergeScenes::computeBound( const ScenePath &path, const Gaffer::Con
 	// compute everything by brute force.
 
 	Box3f result = SceneAlgo::bound( outPlug()->objectPlug()->getValue().get() );
-	result.extendBy( unionOfTransformedChildBounds( path, outPlug() ) );
+	result.extendBy( outPlug()->childBounds() );
 	return result;
 }
 

--- a/src/GafferScene/Prune.cpp
+++ b/src/GafferScene/Prune.cpp
@@ -132,7 +132,7 @@ void Prune::hashBound( const ScenePath &path, const Gaffer::Context *context, co
 	{
 		if( filterValue( context ) & IECore::PathMatcher::DescendantMatch )
 		{
-			h = hashOfTransformedChildBounds( path, outPlug() );
+			h = outPlug()->childBoundsHash();
 			return;
 		}
 	}
@@ -147,7 +147,7 @@ Imath::Box3f Prune::computeBound( const ScenePath &path, const Gaffer::Context *
 	{
 		if( filterValue( context ) & IECore::PathMatcher::DescendantMatch )
 		{
-			return unionOfTransformedChildBounds( path, outPlug() );
+			return outPlug()->childBounds();
 		}
 	}
 

--- a/src/GafferScene/SceneElementProcessor.cpp
+++ b/src/GafferScene/SceneElementProcessor.cpp
@@ -113,7 +113,7 @@ void SceneElementProcessor::hashBound( const ScenePath &path, const Gaffer::Cont
 			if( childNames->readable().size() )
 			{
 				FilteredSceneProcessor::hashBound( path, context, parent, h );
-				h.append( hashOfTransformedChildBounds( path, outPlug(), childNames.get() ) );
+				h.append( outPlug()->childBoundsHash() );
 				inPlug()->objectPlug()->hash( h );
 			}
 			else
@@ -144,7 +144,7 @@ Imath::Box3f SceneElementProcessor::computeBound( const ScenePath &path, const G
 			ConstInternedStringVectorDataPtr childNames = inPlug()->childNamesPlug()->getValue();
 			if( childNames->readable().size() )
 			{
-				result = unionOfTransformedChildBounds( path, outPlug(), childNames.get() );
+				result = outPlug()->childBounds();
 				// We do have to resort to computing the object here, but its exceedingly
 				// rare to have an object at a location which also has children, so typically
 				// we should be receiving a NullObject cheaply.

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -568,6 +568,28 @@ IECore::MurmurHash ScenePlug::setHash( const IECore::InternedString &setName ) c
 	return setPlug()->hash();
 }
 
+Imath::Box3f ScenePlug::childBounds( const ScenePath &scenePath ) const
+{
+	PathScope scope( Context::current(), scenePath );
+	return childBoundsPlug()->getValue();
+}
+
+Imath::Box3f ScenePlug::childBounds() const
+{
+	return childBoundsPlug()->getValue();
+}
+
+IECore::MurmurHash ScenePlug::childBoundsHash( const ScenePath &scenePath ) const
+{
+	PathScope scope( Context::current(), scenePath );
+	return childBoundsPlug()->hash();
+}
+
+IECore::MurmurHash ScenePlug::childBoundsHash() const
+{
+	return childBoundsPlug()->hash();
+}
+
 void ScenePlug::stringToPath( const std::string &s, ScenePlug::ScenePath &path )
 {
 	path.clear();

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -157,6 +157,15 @@ ScenePlug::ScenePlug( const std::string &name, Direction direction, unsigned fla
 		)
 	);
 
+	addChild(
+		new AtomicBox3fPlug(
+			"__childBounds",
+			direction,
+			Imath::Box3f(),
+			childFlags
+		)
+	);
+
 }
 
 ScenePlug::~ScenePlug()
@@ -169,7 +178,7 @@ bool ScenePlug::acceptsChild( const GraphComponent *potentialChild ) const
 	{
 		return false;
 	}
-	return children().size() != 10;
+	return children().size() != 11;
 }
 
 Gaffer::PlugPtr ScenePlug::createCounterpart( const std::string &name, Direction direction ) const
@@ -288,6 +297,16 @@ Gaffer::InternedStringVectorDataPlug *ScenePlug::sortedChildNamesPlug()
 const Gaffer::InternedStringVectorDataPlug *ScenePlug::sortedChildNamesPlug() const
 {
 	return getChild<InternedStringVectorDataPlug>( 9 );
+}
+
+Gaffer::AtomicBox3fPlug *ScenePlug::childBoundsPlug()
+{
+	return getChild<AtomicBox3fPlug>( 10 );
+}
+
+const Gaffer::AtomicBox3fPlug *ScenePlug::childBoundsPlug() const
+{
+	return getChild<AtomicBox3fPlug>( 10 );
 }
 
 ScenePlug::PathScope::PathScope( const Gaffer::Context *context )

--- a/src/GafferScene/SceneReader.cpp
+++ b/src/GafferScene/SceneReader.cpp
@@ -203,7 +203,7 @@ Imath::Box3f SceneReader::computeBound( const ScenePath &path, const Gaffer::Con
 	}
 	else
 	{
-		result = unionOfTransformedChildBounds( path, parent );
+		result = parent->childBounds();
 	}
 
 	if( path.size() == 0 && !result.isEmpty() )

--- a/src/GafferScene/SubTree.cpp
+++ b/src/GafferScene/SubTree.cpp
@@ -118,7 +118,7 @@ void SubTree::hashBound( const ScenePath &path, const Gaffer::Context *context, 
 			h = inPlug()->boundHash( source );
 			break;
 		case CreateRoot :
-			h = hashOfTransformedChildBounds( path, parent );
+			h = parent->childBoundsHash();
 			break;
 		case EmptyRoot :
 			SceneProcessor::hashBound( path, context, parent, h );
@@ -135,7 +135,7 @@ Imath::Box3f SubTree::computeBound( const ScenePath &path, const Gaffer::Context
 		case Default :
 			return inPlug()->bound( source );
 		case CreateRoot :
-			return unionOfTransformedChildBounds( path, parent );
+			return parent->childBounds();
 		default : // EmptyRoot
 			return Imath::Box3f();
 	}

--- a/src/GafferSceneModule/CoreBinding.cpp
+++ b/src/GafferSceneModule/CoreBinding.cpp
@@ -268,6 +268,30 @@ bool existsWrapper2( const ScenePlug &plug )
 	return plug.exists();
 }
 
+Imath::Box3f childBoundsWrapper1( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.childBounds( scenePath );
+}
+
+Imath::Box3f childBoundsWrapper2( const ScenePlug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.childBounds();
+}
+
+IECore::MurmurHash childBoundsHashWrapper1( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.childBoundsHash( scenePath );
+}
+
+IECore::MurmurHash childBoundsHashWrapper2( const ScenePlug &plug )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return plug.childBoundsHash();
+}
+
 IECore::InternedStringVectorDataPtr stringToPathWrapper( const char *s )
 {
 	IECore::InternedStringVectorDataPtr p = new IECore::InternedStringVectorData;
@@ -365,6 +389,11 @@ void GafferSceneModule::bindCore()
 		// existence queries
 		.def( "exists", &existsWrapper1 )
 		.def( "exists", &existsWrapper2 )
+		// child bounds queries
+		.def( "childBounds", &childBoundsWrapper1 )
+		.def( "childBounds", &childBoundsWrapper2 )
+		.def( "childBoundsHash", &childBoundsHashWrapper1 )
+		.def( "childBoundsHash", &childBoundsHashWrapper2 )
 		// string utilities
 		.def( "stringToPath", &stringToPathWrapper )
 		.staticmethod( "stringToPath" )

--- a/src/GafferSceneTest/ContextSanitiser.cpp
+++ b/src/GafferSceneTest/ContextSanitiser.cpp
@@ -67,6 +67,7 @@ namespace
 const InternedString g_internalOut( "__internalOut" );
 const InternedString g_exists( "__exists" );
 const InternedString g_sortedChildNames( "__sortedChildNames" );
+const InternedString g_childBounds( "__childBounds" );
 
 } // namespace
 
@@ -100,7 +101,8 @@ void ContextSanitiser::processStarted( const Gaffer::Process *process )
 			// Private plugs, so we have no choice but to test
 			// for them by name.
 			process->plug()->getName() != g_exists &&
-			process->plug()->getName() != g_sortedChildNames
+			process->plug()->getName() != g_sortedChildNames &&
+			process->plug()->getName() != g_childBounds
 		)
 		{
 			if( process->context()->get<IECore::Data>( ScenePlug::scenePathContextName, nullptr ) )


### PR DESCRIPTION
This improves the performance of the various bounds-modifying nodes when the `adjustBounds` plug is on, by using `parallel_reduce` to compute the union of child bounds in parallel, and then caching the results for later use. It uses the same idea we used for `ScenePlug::exists()` : ScenePlug adds a new private plug and SceneNode performs the computations for it. I think this approach to computing derived/secondary properties of a location is looking fruitful, and wouldn't be surprised if we find ourselves using if for `fullTransform()` and/or `fullAttributes()` in the future.

I'm seeing positive results in all my toy benchmarks :

- 6-7x speedup in `gaffer stats -scene` for a scene with heavy deformation of many locations, on a 6 core machine (with hyperthreading).
- More modest 2x speedup for a SceneReader test where we need to compute bounds for a `.abc` file that doesn't have them, and similar for a MergeScenes node where `objectMode == Replace`.

We did try this basic approach many years ago, and found that it actually slowed certain production scenes down. What's different this time is that we understand the importance of task isolation and have cache policies to account for that. This will still need some testing on proper production scenes before merging, which @murrays-ie has generously volunteered for :)