### PR TITLE
CurveSampler : Hack around bug in old GCC

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -415,6 +415,11 @@ elif env["PLATFORM"] == "posix" :
 		if gccVersion >= [ 4, 2 ] :
 			env.Append( CXXFLAGS = [ "-Wno-error=strict-overflow" ] )
 
+		# Old GCC emits spurious "maybe uninitialized" warnings when using
+		# boost::optional
+		if gccVersion < [ 5, 1 ] :
+			env.Append( CXXFLAGS = [ "-Wno-error=maybe-uninitialized" ] )
+
 		if gccVersion >= [ 5, 1 ] :
 			env.Append( CXXFLAGS = [ "-D_GLIBCXX_USE_CXX11_ABI=0" ] )
 


### PR DESCRIPTION
As per : https://www.boost.org/doc/libs/1_65_1/libs/optional/doc/html/boost_optional/tutorial/gotchas/false_positive_with__wmaybe_uninitialized.html

This is necessary to get Gaffer >= 0.57 building at ImageEngine
