### PR TITLE
Miscellaneous small optimisations

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,7 @@ Breaking Changes
     - `GafferCortex.ParameterisedHolderExecutableNode` is no longer an alias for `GafferCortex.ParameterisedHolderTaskNode`.
     - `GafferCortex` attributes can no longer be accessed via the `Gaffer` namespace.
     - `GafferCortexUI` attributes can no longer be accessed via the `GafferUI` namespace.
+- RecursiveChildIterator : Changed private member data. Source compatibility is maintained.
 
 0.57.3.0 (relative to 0.57.2.0)
 ========

--- a/include/Gaffer/RecursiveChildIterator.h
+++ b/include/Gaffer/RecursiveChildIterator.h
@@ -39,6 +39,7 @@
 
 #include "Gaffer/GraphComponent.h"
 
+#include "boost/container/small_vector.hpp"
 #include "boost/iterator/iterator_facade.hpp"
 
 namespace Gaffer
@@ -119,7 +120,7 @@ class RecursiveChildIterator : public boost::iterator_facade<RecursiveChildItera
 			GraphComponent::ChildIterator it;
 		};
 
-		typedef std::vector<Level> Levels;
+		using Levels = boost::container::small_vector<Level, 4>;
 		Levels m_stack;
 		bool m_pruned;
 

--- a/src/Gaffer/GraphComponent.cpp
+++ b/src/Gaffer/GraphComponent.cpp
@@ -130,6 +130,7 @@ GraphComponent::~GraphComponent()
 		(*it)->parentChanged( nullptr );
 		Signals::emitLazily( (*it)->m_signals.get(), &Signals::parentChangedSignal, (*it).get(), nullptr );
 	}
+	m_children.clear();
 }
 
 const IECore::InternedString &GraphComponent::setName( const IECore::InternedString &name )

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -820,7 +820,7 @@ class Plug::DirtyPlugs
 		typedef Graph::vertex_descriptor VertexDescriptor;
 		typedef Graph::edge_descriptor EdgeDescriptor;
 
-		typedef std::map<const Plug *, VertexDescriptor> PlugMap;
+		typedef std::unordered_map<const Plug *, VertexDescriptor> PlugMap;
 
 		// Equivalent to the return type for map::insert - the first
 		// field is the vertex descriptor, and the second field is

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -788,7 +788,14 @@ void TransformTool::plugDirtied( const Gaffer::Plug *plug )
 		plug == activePlug() ||
 		plug == scenePlug()->childNamesPlug() ||
 		plug == scenePlug()->transformPlug() ||
-		plug == view()->editScopePlug()
+		// The `ancestor()` check protects us from accessing an
+		// already-destructed View in the case that the View is
+		// destroyed before the Tool.
+		/// \todo It'd be good to have a more robust solution to
+		/// this, perhaps with Tools being owned by Views so that
+		/// the validity of `Tool::m_view` can be managed. Also
+		/// see comments in `__toolPlugSet()` in Viewer.py.
+		( plug->ancestor<View>() && plug == view()->editScopePlug() )
 	)
 	{
 		m_selectionDirty = true;


### PR DESCRIPTION
While playing with a reasonably large script with tens of thousands of nodes, I noticed that just shutting Gaffer down was taking a reasonable amount of time. After profiling it, this PR tackles some of the most obvious low hanging fruit, knocking about 20% off the shutdown time.