### PR TITLE
PointsType : Change base class from Deformer to ObjectProcessor

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,9 +1,15 @@
 0.58.x.x
 ========
 
+Improvements
+------------
+
+- PointsType : Removed unnecessary bounds computation overhead.
+
 Breaking Changes
 ----------------
 
+- PointsType : Changed base class from Deformer to ObjectProcessor.
 - Startup :
   - Removed several compatibility shims for loading files from Gaffer versions prior to 0.20.0.0. Either resave the file from version 0.57.0.0 or adopt the appropriate shim into your own configuration. The following are affected :
      - RemoveChannels nodes.

--- a/include/GafferScene/Deformer.h
+++ b/include/GafferScene/Deformer.h
@@ -82,12 +82,6 @@ class GAFFERSCENE_API Deformer : public ObjectProcessor
 
 	private :
 
-		/// Private constructor and friendship for old nodes which are filtered to everything
-		/// by default. This was a mistake, and we want to ensure that we don't repeat the mistake
-		/// for new nodes.
-		Deformer( const std::string &name, IECore::PathMatcher::Result filterDefault );
-		friend class PointsType;
-
 		void init();
 
 		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const final;

--- a/include/GafferScene/ObjectProcessor.h
+++ b/include/GafferScene/ObjectProcessor.h
@@ -92,11 +92,11 @@ class GAFFERSCENE_API ObjectProcessor : public FilteredSceneProcessor
 		/// by default. This was a mistake, and we want to ensure that we don't repeat the mistake
 		/// for new nodes.
 		ObjectProcessor( const std::string &name, IECore::PathMatcher::Result filterDefault );
-		friend class Deformer;
 		friend class MeshType;
 		friend class MapOffset;
 		friend class MapProjection;
 		friend class MeshTangents;
+		friend class PointsType;
 		friend class PrimitiveVariables;
 
 };

--- a/include/GafferScene/PointsType.h
+++ b/include/GafferScene/PointsType.h
@@ -37,7 +37,7 @@
 #ifndef GAFFERSCENE_POINTSTYPE_H
 #define GAFFERSCENE_POINTSTYPE_H
 
-#include "GafferScene/Deformer.h"
+#include "GafferScene/ObjectProcessor.h"
 
 namespace Gaffer
 {
@@ -49,7 +49,7 @@ IE_CORE_FORWARDDECLARE( StringPlug )
 namespace GafferScene
 {
 
-class GAFFERSCENE_API PointsType : public Deformer
+class GAFFERSCENE_API PointsType : public ObjectProcessor
 {
 
 	public :
@@ -57,7 +57,7 @@ class GAFFERSCENE_API PointsType : public Deformer
 		PointsType( const std::string &name=defaultName<PointsType>() );
 		~PointsType() override;
 
-		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::PointsType, PointsTypeTypeId, Deformer );
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::PointsType, PointsTypeTypeId, ObjectProcessor );
 
 		Gaffer::StringPlug *typePlug();
 		const Gaffer::StringPlug *typePlug() const;

--- a/python/GafferSceneTest/PointsTypeTest.py
+++ b/python/GafferSceneTest/PointsTypeTest.py
@@ -107,10 +107,10 @@ class PointsTypeTest( GafferSceneTest.SceneTestCase ) :
 		pointsType["type"].setValue( "sphere" )
 		assertExpectedOutput( type = "sphere", unchanged = False )
 
-		# Test converting particles to patches. The bound should change at this point.
+		# Test converting particles to patches
 
 		pointsType["type"].setValue( "patch" )
-		assertExpectedOutput( type = "patch", unchanged = False )
+		self.assertEqual( pointsType["out"].object( "/group/object" )["type"].data.value, "patch" )
 
 	def testNonPrimitiveObject( self ) :
 

--- a/src/GafferScene/Deformer.cpp
+++ b/src/GafferScene/Deformer.cpp
@@ -59,12 +59,6 @@ Deformer::Deformer( const std::string &name, size_t minInputs, size_t maxInputs 
 	init();
 }
 
-Deformer::Deformer( const std::string &name, IECore::PathMatcher::Result filterDefault )
-	:	ObjectProcessor( name, filterDefault )
-{
-	init();
-}
-
 void Deformer::init()
 {
 	storeIndexOfNextChild( g_firstPlugIndex );

--- a/src/GafferScene/PointsType.cpp
+++ b/src/GafferScene/PointsType.cpp
@@ -50,7 +50,7 @@ GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( PointsType );
 size_t PointsType::g_firstPlugIndex = 0;
 
 PointsType::PointsType( const std::string &name )
-	:	Deformer( name, PathMatcher::EveryMatch )
+	:	ObjectProcessor( name, PathMatcher::EveryMatch )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new StringPlug( "type", Plug::In, "" ) );
@@ -73,14 +73,14 @@ const Gaffer::StringPlug *PointsType::typePlug() const
 bool PointsType::affectsProcessedObject( const Gaffer::Plug *input ) const
 {
 	return
-		Deformer::affectsProcessedObject( input ) ||
+		ObjectProcessor::affectsProcessedObject( input ) ||
 		input == typePlug()
 	;
 }
 
 void PointsType::hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	Deformer::hashProcessedObject( path, context, h );
+	ObjectProcessor::hashProcessedObject( path, context, h );
 	typePlug()->hash( h );
 }
 


### PR DESCRIPTION
The cost of the bounds propagation done by Deformer isn't justified by the small improvement in accuracy it provides. The only time PointsType affects a bound is when changing to and from `type == "patch"`. In this case there are two sources of bounds changes :

- `PointsPrimitive::bound()` uses the diagonal of a patch of the specified width, rather than using width directly. This error was worth worrying about when we rendered everything as a procedural (where incorrect bounds would clip the procedural in the rendered image), but is no longer a genuine concern.
- `PointsPrimitive::bound()` considers a "patchaspectratio" primitive variable that isn't supported in any of our current renderer backends (it was a 3Delight thing, back before NSI).

Ignoring both the above is consistent with our existing decision to ignore changes to the "width" primvar in our various `Deformer::adjustBounds()` overloads.
