### PR TITLE
ShadingEngine : Fix string lookups

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.56.2.x (relative to 0.56.2.1)
+========
+
+Fixes
+-----
+
+- OSLObject : Fixed bug that could cause string comparisons to fail for strings fetched using the InString shader or `inString()` function.
+
 0.56.2.1 (relative to 0.56.2.0)
 ========
 

--- a/python/GafferOSLTest/ShadingEngineTest.py
+++ b/python/GafferOSLTest/ShadingEngineTest.py
@@ -630,16 +630,18 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		) )
 
 		p = self.rectanglePoints()
-		p["strattr"] = IECore.StringVectorData( [ "testo" if x % 2 == 0 else "no-testo"  for x in range(len(p["P"])) ] )
+		p["strattr"] = IECore.StringVectorData( [ "testo" if i % 2 == 0 else "no-testo" for i in range(len(p["P"])) ] )
 
 		r = e.shade( p )
 
 		for i, c in enumerate( r["Ci"] ) :
-			f = 1.0 if x % 2 == 0 else 0.0
+
+			f = 1.0 if i % 2 == 0 else 0.0
 
 			self.assertEqual(
 				c,
-				imath.Color3f( f, f, f ) )
+				imath.Color3f( f, f, f )
+			)
 
 	def testUVProvidedAsV2f( self ) :
 

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -286,7 +286,7 @@ class RenderState
 				 eIt = shadingPoints->readable().end(); it != eIt; ++it )
 			{
 				UserData userData;
-				userData.dataView = IECoreImage::OpenImageIOAlgo::DataView( it->second.get() );
+				userData.dataView = IECoreImage::OpenImageIOAlgo::DataView( it->second.get(), /* createUStrings = */ true );
 				if( userData.dataView.data )
 				{
 					if( userData.dataView.type.arraylen )


### PR DESCRIPTION
Although `RendererServices::get_userdata()` passes strings to OSL as `const char *`, there's an implicit assumption that they have already been uniquefied using `OIIO::ustring`, because string comparisons in OSL compare by identity rather than contents. We've been bitten by this already in OSLExpressionEngine - see 963bf1966f267ff8f0ee9a6edf05544f8c0eed65.

We thought we had test coverage for this already, but in fact the test was broken. In a rare moment of helpfulness, Python 3 pointed this out by limiting the scope of `x` to the first string comprehension rather than leaking it out as Python 2 would. We had been using this leaked variable in the second loop all this time, not noticing that it meant we were only testing a single index in the array.
