### PR TITLE
Metadata/ImageView/SceneView : Avoid potential shutdown crashes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - OSLObject : Fixed bug that could cause string comparisons to fail for strings fetched using the InString shader or `inString()` function.
+- Fixed potential shutdown crashes when custom Metadata or View registrations have been made via Python.
 
 0.56.2.1 (relative to 0.56.2.0)
 ========

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -78,8 +78,8 @@ typedef std::map<IECore::InternedString, Values> MetadataMap;
 
 MetadataMap &metadataMap()
 {
-	static MetadataMap m;
-	return m;
+	static auto g_m = new MetadataMap;
+	return *g_m;
 }
 
 struct GraphComponentMetadata
@@ -119,8 +119,8 @@ typedef std::map<IECore::TypeId, GraphComponentMetadata> GraphComponentMetadataM
 
 GraphComponentMetadataMap &graphComponentMetadataMap()
 {
-	static GraphComponentMetadataMap m;
-	return m;
+	static auto g_m = new GraphComponentMetadataMap;
+	return *g_m;
 }
 
 struct NamedInstanceValue

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -673,6 +673,6 @@ GafferImage::ImageProcessorPtr ImageView::createDisplayTransform( const std::str
 
 ImageView::DisplayTransformCreatorMap &ImageView::displayTransformCreators()
 {
-	static DisplayTransformCreatorMap g_creators;
-	return g_creators;
+	static auto g_creators = new DisplayTransformCreatorMap;
+	return *g_creators;
 }

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -399,8 +399,8 @@ class SceneView::ShadingMode : public boost::signals::trackable
 
 		static ShadingModeCreatorMap &shadingModeCreators()
 		{
-			static ShadingModeCreatorMap g_creators;
-			return g_creators;
+			static auto g_creators = new ShadingModeCreatorMap;
+			return *g_creators;
 		}
 
 		SceneView *m_view;


### PR DESCRIPTION
We now deliberately "leak" the static maps so that their destructors don't run during shutdown. This avoid crashes when a Python callable has been registered, leading to the callable being destroyed _after_ Python has already shutdown. We've seen similar crashes with similar static registrations before, and fixed them the same way. See for instance 8cc57834dcd04dfebb931d6c65da0e6c94c48fd0.

Although we haven't seen these crashes in Python 2, they reproduce consistently in Python 3, and it seems worth applying the fixes as far back as possible.
