### PR TITLE
Appleseed 2.1 compatibility

### DIFF
--- a/src/GafferAppleseed/AppleseedLight.cpp
+++ b/src/GafferAppleseed/AppleseedLight.cpp
@@ -43,10 +43,10 @@
 
 #include "IECore/Exception.h"
 
+#include "foundation/core/version.h"
 #include "renderer/api/edf.h"
 #include "renderer/api/environmentedf.h"
 #include "renderer/api/light.h"
-#include "renderer/api/version.h"
 
 #include "boost/format.hpp"
 


### PR DESCRIPTION
More prep for Python 3 compatibility. Appleseed's python module doesn't build with Python 3 until version 2.1.0-beta.