### PR TITLE
Spreadsheet : Improve NameValuePlug support and support TweakPlugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,7 +11,9 @@ Fixes
 Improvements
 ------------
 
-- Spreadsheet : When promoting plugs - such as those from Attributes node - which have their own "enabled" switch, this switch is now adopted by the spreadsheet, instead of having an additional "enabled" switch on the cell.
+- Spreadsheet :
+  - The enabled/disabled state of a cell may now be edited directly via a new switch in the popup editing window.
+  - When promoting plugs - such as those from Attributes node - which have their own "enabled" switch, this switch is now adopted by the spreadsheet, instead of having an additional "enabled" switch on the cell.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Improvements
 - Spreadsheet :
   - The enabled/disabled state of a cell may now be edited directly via a new switch in the popup editing window.
   - When promoting plugs - such as those from Attributes node - which have their own "enabled" switch, this switch is now adopted by the spreadsheet, instead of having an additional "enabled" switch on the cell.
+  - Added support for creating columns from tweaks in ShaderTweaks nodes. This allows the mode and value to be grouped in a single column.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,11 @@ Improvements
   - The enabled/disabled state of a cell may now be edited directly via a new switch in the popup editing window.
   - When promoting plugs - such as those from Attributes node - which have their own "enabled" switch, this switch is now adopted by the spreadsheet, instead of having an additional "enabled" switch on the cell.
 
+Fixes
+-----
+
+- TweakPlug : Fixed bugs which prevented the creation of output TweakPlugs.
+
 API
 ---
 

--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ API
 ---
 
 - Spreadsheet : Added an `addColumn()` overload with an `adoptEnabledPlug` boolean argument. This allows cells to reuse the `enabled` plug from their `value` plug if it has one.
+- SpreadsheetUI : Added `formatValue()` and `registerValueFormatter()` methods to support custom formatting for extension plug types.
 
 0.57.3.0 (relative to 0.57.2.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,11 @@ Fixes
 - OSLObject : Fixed bug that could cause string comparisons to fail for strings fetched using the InString shader or `inString()` function.
 - Fixed potential shutdown crashes when custom Metadata or View registrations have been made via Python.
 
+API
+---
+
+- Spreadsheet : Added an `addColumn()` overload with an `adoptEnabledPlug` boolean argument. This allows cells to reuse the `enabled` plug from their `value` plug if it has one.
+
 0.57.3.0 (relative to 0.57.2.0)
 ========
 

--- a/Changes.md
+++ b/Changes.md
@@ -19,7 +19,9 @@ API
 ---
 
 - Spreadsheet : Added an `addColumn()` overload with an `adoptEnabledPlug` boolean argument. This allows cells to reuse the `enabled` plug from their `value` plug if it has one.
-- SpreadsheetUI : Added `formatValue()` and `registerValueFormatter()` methods to support custom formatting for extension plug types.
+- SpreadsheetUI :
+  - Added `formatValue()` and `registerValueFormatter()` methods to support custom formatting for extension plug types.
+  - Added `registerValueWidget()` method to support customisation of widgets used for editing.
 
 0.57.3.0 (relative to 0.57.2.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,11 @@ Fixes
 - OSLObject : Fixed bug that could cause string comparisons to fail for strings fetched using the InString shader or `inString()` function.
 - Fixed potential shutdown crashes when custom Metadata or View registrations have been made via Python.
 
+Improvements
+------------
+
+- Spreadsheet : When promoting plugs - such as those from Attributes node - which have their own "enabled" switch, this switch is now adopted by the spreadsheet, instead of having an additional "enabled" switch on the cell.
+
 API
 ---
 

--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,7 @@ API
 - SpreadsheetUI :
   - Added `formatValue()` and `registerValueFormatter()` methods to support custom formatting for extension plug types.
   - Added `registerValueWidget()` method to support customisation of widgets used for editing.
+  - Added `spreadsheet:plugMenu:includeAsAncestor` and `spreadsheet:plugMenu:ancestorLabel` metadata, to allow ancestor plugs to be promoted from the popup menu for their descendants.
 
 0.57.3.0 (relative to 0.57.2.0)
 ========

--- a/include/Gaffer/Spreadsheet.h
+++ b/include/Gaffer/Spreadsheet.h
@@ -104,6 +104,15 @@ class GAFFER_API Spreadsheet : public ComputeNode
 				/// Spreadsheet so that they can be used for the editing and
 				/// serialisation of promoted plugs.
 
+				/// Adds a column to the spreadsheet, using `value` as a prototype for
+				/// the `CellPlug::valuePlug()` for each cell. If `adoptEnabledPlug`
+				/// is true, then `value` must have a BoolPlug child called "enabled",
+				/// and this will be used instead of adding another "enabled" plug to
+				/// the cell itself. This is useful when adding columns for NameValuePlugs
+				/// and TweakPlugs.
+				size_t addColumn( const ValuePlug *value, IECore::InternedString name, bool adoptEnabledPlug );
+				/// \todo Remove this overload, and add default values for `name` and `adoptEnabledPlug`
+				/// in the version above.
 				size_t addColumn( const ValuePlug *value, IECore::InternedString name = IECore::InternedString() );
 				void removeColumn( size_t columnIndex );
 
@@ -169,6 +178,10 @@ class GAFFER_API Spreadsheet : public ComputeNode
 
 				GAFFER_PLUG_DECLARE_TYPE( Gaffer::Spreadsheet::CellPlug, Gaffer::SpreadsheetCellPlugTypeId, Gaffer::ValuePlug );
 
+				/// Returns the plug used to enable or disable this cell.
+				/// Note : If `addColumn( adoptEnabledPlug = true )` was
+				/// used, this will return a child of `valuePlug()`, not
+				/// a direct child of the CellPlug itself.
 				BoolPlug *enabledPlug();
 				const BoolPlug *enabledPlug() const;
 
@@ -182,7 +195,7 @@ class GAFFER_API Spreadsheet : public ComputeNode
 
 			private :
 
-				CellPlug( const std::string &name, const Gaffer::Plug *value, Plug::Direction direction = Plug::In );
+				CellPlug( const std::string &name, const Gaffer::Plug *value, bool adoptEnabledPlug = false, Plug::Direction direction = Plug::In );
 				friend class Spreadsheet;
 
 		};

--- a/include/Gaffer/Spreadsheet.inl
+++ b/include/Gaffer/Spreadsheet.inl
@@ -43,13 +43,13 @@ namespace Gaffer
 template<typename T>
 T *Spreadsheet::CellPlug::valuePlug()
 {
-	return getChild<T>( 1 );
+	return getChild<T>( children().size() - 1 );
 }
 
 template<typename T>
 const T *Spreadsheet::CellPlug::valuePlug() const
 {
-	return getChild<T>( 1 );
+	return getChild<T>( children().size() - 1 );
 }
 
 } // namespace Gaffer

--- a/python/GafferSceneTest/TweakPlugTest.py
+++ b/python/GafferSceneTest/TweakPlugTest.py
@@ -287,5 +287,18 @@ class TweakPlugTest( GafferSceneTest.SceneTestCase ) :
 		self.assertTrue( tweaks.applyTweaks( tweakedNetwork ) )
 		self.assertEqual( tweakedNetwork.inputConnections( "surface" ), [ ( ( "texture", "" ), ( "surface", "c" ) ) ] )
 
+	def testCreateOutputCounterpart( self ) :
+
+		p = GafferScene.TweakPlug( "test", 10.0, GafferScene.TweakPlug.Mode.Multiply )
+		p2 = p.createCounterpart( "p2", Gaffer.Plug.Direction.Out )
+
+		self.assertIsInstance( p2, GafferScene.TweakPlug )
+		self.assertEqual( p2.getName(), "p2" )
+		self.assertEqual( p2.direction(), Gaffer.Plug.Direction.Out )
+		self.assertEqual( p2.keys(), p.keys() )
+		for n in p2.keys() :
+			self.assertEqual( p2.direction(), Gaffer.Plug.Direction.Out )
+			self.assertIsInstance( p2[n], p[n].__class__ )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/TweakPlugValueWidget.py
+++ b/python/GafferSceneUI/TweakPlugValueWidget.py
@@ -112,6 +112,14 @@ class TweakPlugValueWidget( GafferUI.PlugValueWidget ) :
 		for w in self.__row :
 			w.setReadOnly( readOnly )
 
+	def setNameVisible( self, visible ) :
+
+		self.__row[0].setVisible( visible )
+
+	def getNameVisible( self ) :
+
+		return self.__row[0].getVisible()
+
 	def _updateFromPlug( self ) :
 
 		with self.getContext() :
@@ -195,6 +203,18 @@ def __noduleLabel( plug ) :
 
 	return name or plug.getName()
 
+Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "nodule:type", "GafferUI::CompoundNodule" )
+Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "*", "nodule:type", "" )
+Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "value", "nodule:type", "GafferUI::StandardNodule" )
+Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "noduleLayout:label", __noduleLabel )
+Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "value", "noduleLayout:label", __noduleLabel )
+
+# Spreadsheet Interoperability
+# ============================
+
+Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "spreadsheet:plugMenu:includeAsAncestor", True )
+Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "spreadsheet:plugMenu:ancestorLabel", "Tweak" )
+
 def __spreadsheetColumnName( plug ) :
 
 	tweakPlug = plug.parent()
@@ -213,10 +233,28 @@ def __spreadsheetColumnName( plug ) :
 	else :
 		return plug.getName()
 
-Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "nodule:type", "GafferUI::CompoundNodule" )
-Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "*", "nodule:type", "" )
-Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "value", "nodule:type", "GafferUI::StandardNodule" )
-Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "noduleLayout:label", __noduleLabel )
-Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "value", "noduleLayout:label", __noduleLabel )
 Gaffer.Metadata.registerValue( GafferScene.TweakPlug, "*", "spreadsheet:columnName", __spreadsheetColumnName )
 
+def __spreadsheetFormatter( plug, forToolTip ) :
+
+	result = ""
+	if "enabled" in plug.parent() :
+		result = "On, " if plug["enabled"].getValue() else "Off, "
+
+	result += str( GafferScene.TweakPlug.Mode.values[plug["mode"].getValue()] )
+
+	value = GafferUI.SpreadsheetUI.formatValue( plug["value"], forToolTip )
+	separator = " : \n" if forToolTip and "\n" in value else " : "
+	result += separator + value
+
+	return result
+
+GafferUI.SpreadsheetUI.registerValueFormatter( GafferScene.TweakPlug, __spreadsheetFormatter )
+
+def __spreadsheetValueWidget( plug ) :
+
+	w = TweakPlugValueWidget( plug )
+	w.setNameVisible( False )
+	return w
+
+GafferUI.SpreadsheetUI.registerValueWidget( GafferScene.TweakPlug, __spreadsheetValueWidget )

--- a/python/GafferSceneUI/TweakPlugValueWidget.py
+++ b/python/GafferSceneUI/TweakPlugValueWidget.py
@@ -42,6 +42,8 @@ import Gaffer
 import GafferUI
 import GafferScene
 
+from Qt import QtWidgets
+
 # Widget for TweakPlug, which is used to build tweak nodes such as ShaderTweaks
 # and CameraTweaks.  Shows a value plug that you can use to specify a tweak value, along with
 # a target parameter name, an enabled plug, and a mode.  The mode can be "Replace",
@@ -70,7 +72,11 @@ class TweakPlugValueWidget( GafferUI.PlugValueWidget ) :
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top,
 		)
 
-		self.__row.append( GafferUI.PlugValueWidget.create( plug["mode"] ) )
+		modeWidget = GafferUI.PlugValueWidget.create( plug["mode"] )
+		modeWidget._qtWidget().setFixedWidth( 80 )
+		modeWidget._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetDefaultConstraint )
+		self.__row.append( modeWidget )
+
 		self.__row.append( GafferUI.PlugValueWidget.create( plug["value"] ), expand = True )
 
 		self._updateFromPlug()

--- a/python/GafferUI/NameValuePlugValueWidget.py
+++ b/python/GafferUI/NameValuePlugValueWidget.py
@@ -148,6 +148,9 @@ GafferUI.PlugValueWidget.registerType( Gaffer.NameValuePlug, NameValuePlugValueW
 # Spreadsheet integration
 # =======================
 
+Gaffer.Metadata.registerValue( Gaffer.NameValuePlug, "spreadsheet:plugMenu:includeAsAncestor", True )
+Gaffer.Metadata.registerValue( Gaffer.NameValuePlug, "spreadsheet:plugMenu:ancestorLabel", "Value and Switch" )
+
 def __spreadsheetColumnName( plug ) :
 
 	nameValuePlug = plug.parent()
@@ -187,4 +190,3 @@ def __spreadsheetValueWidget( plug ) :
 	return w
 
 GafferUI.SpreadsheetUI.registerValueWidget( Gaffer.NameValuePlug, __spreadsheetValueWidget )
-

--- a/python/GafferUI/NameValuePlugValueWidget.py
+++ b/python/GafferUI/NameValuePlugValueWidget.py
@@ -180,3 +180,11 @@ def __spreadsheetFormatter( plug, forToolTip ) :
 
 GafferUI.SpreadsheetUI.registerValueFormatter( Gaffer.NameValuePlug, __spreadsheetFormatter )
 
+def __spreadsheetValueWidget( plug ) :
+
+	w = GafferUI.NameValuePlugValueWidget( plug )
+	w.setNameVisible( False )
+	return w
+
+GafferUI.SpreadsheetUI.registerValueWidget( Gaffer.NameValuePlug, __spreadsheetValueWidget )
+

--- a/python/GafferUI/NameValuePlugValueWidget.py
+++ b/python/GafferUI/NameValuePlugValueWidget.py
@@ -38,6 +38,7 @@ import IECore
 
 import Gaffer
 import GafferUI
+import GafferUI.SpreadsheetUI
 
 ## Supported plug metadata :
 #
@@ -144,6 +145,9 @@ class NameValuePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 GafferUI.PlugValueWidget.registerType( Gaffer.NameValuePlug, NameValuePlugValueWidget )
 
+# Spreadsheet integration
+# =======================
+
 def __spreadsheetColumnName( plug ) :
 
 	nameValuePlug = plug.parent()
@@ -163,3 +167,16 @@ def __spreadsheetColumnName( plug ) :
 		return plug.getName()
 
 Gaffer.Metadata.registerValue( Gaffer.NameValuePlug, "*", "spreadsheet:columnName", __spreadsheetColumnName )
+
+def __spreadsheetFormatter( plug, forToolTip ) :
+
+	value = GafferUI.SpreadsheetUI.formatValue( plug["value"], forToolTip )
+	if "enabled" not in plug.parent() :
+		return value
+
+	enabled = "On" if plug["enabled"].getValue() else "Off"
+	separator = " : \n" if forToolTip and "\n" in value else " : "
+	return enabled + separator + value
+
+GafferUI.SpreadsheetUI.registerValueFormatter( Gaffer.NameValuePlug, __spreadsheetFormatter )
+

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -1072,7 +1072,7 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 			if isinstance( plug, Gaffer.Spreadsheet.CellPlug ) :
 				with self.__context :
 					try :
-						enabled = plug["enabled"].getValue()
+						enabled = plug.enabledPlug().getValue()
 					except :
 						return None
 			return enabled
@@ -1187,7 +1187,10 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 				if currentPreset is not None :
 					return currentPreset
 				if isinstance( plug, Gaffer.NameValuePlug ) :
-					return plug["enabled"].getValue(), plug["value"].getValue()
+					if "enabled" in plug.parent() :
+						return plug["enabled"].getValue(), plug["value"].getValue()
+					else :
+						return plug["value"].getValue()
 				elif isinstance( plug, Gaffer.TransformPlug ) :
 					return collections.OrderedDict( [
 						( "T", plug["translate"].getValue() ),
@@ -1841,7 +1844,7 @@ def __prependRowAndCellMenuItems( menuDefinition, plugValueWidget ) :
 	if cellPlug is not None :
 
 		enabled = None
-		enabledPlug = cellPlug["enabled"]
+		enabledPlug = cellPlug.enabledPlug()
 		with plugValueWidget.getContext() :
 			with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
 				enabled = enabledPlug.getValue()

--- a/src/GafferScene/TweakPlug.cpp
+++ b/src/GafferScene/TweakPlug.cpp
@@ -81,9 +81,9 @@ TweakPlug::TweakPlug( const std::string &tweakName, const IECore::Data *value, M
 TweakPlug::TweakPlug( Gaffer::ValuePlugPtr valuePlug, const std::string &name, Direction direction, unsigned flags )
 	:	ValuePlug( name, direction, flags )
 {
-	addChild( new StringPlug( "name" ) );
-	addChild( new BoolPlug( "enabled", Plug::In, true ) );
-	addChild( new IntPlug( "mode", Plug::In, Replace, Replace, Remove ) );
+	addChild( new StringPlug( "name", direction ) );
+	addChild( new BoolPlug( "enabled", direction, true ) );
+	addChild( new IntPlug( "mode", direction, Replace, Replace, Remove ) );
 
 	if( valuePlug )
 	{


### PR DESCRIPTION
The [Viewer HUD](#3661) design will require us to be able to use TweakPlugs effectively within Spreadsheets. To date, customisations for specific plug types have been handled within the SpreadsheetUI code directly, but that approach doesn't work for TweakPlug because it is in a different module. So here we add a few minimal additions to the SpreadsheetUI API to allow custom formatters and widgets to be registered.

There's a potentially more contentious change too : the ability for a Spreadsheet cell to "adopt" an existing `enabledPlug()` from its child, rather than add one of its own. This has some benefits :

- Users have already found the doubling of `enabled` plugs for NameValuePlug columns to be pretty confusing.
- Having two `enabled` plugs would be completely redundant for the tweak spreadsheets we want to make in EditScopes.
- It's easier to read the status of disabled tweaks from the strike-through and fading of a cell than it is from the On/Off label text we previously used.
- It's easier and quicker to edit the tweak switch than it is to edit the cell enable/disable state.
- The addition of a cell enable/disable switch in the popup editor for all column types makes cell state editing easier across the board.

But there are also downsides :

- The "Add to Spreadsheet (Name and Switch)" and the "Add to Spreadsheet" menu items for NameValuePlugs produce columns that are similar in outward appearance (both have switches in the popup editor now), but different in behaviour.
- The "adoption" concept adds complexity to the mental model for the spreadsheet, and I can see it adding confusion of its own for API users.

I'm putting up this PR to gather feedback on the approach to de-duplicating enabled plugs. I was pretty sold on it before, but I'm really not sure now. Other options seem to be :

- Just accept the original confusion.
- Connect `cell.enabled` to `cell.value.enabled`. This is similar to adoption, but with higher serialisation overheads, and the ability for people to break a connection and end up with confusing behaviour again. The fragility of this approach is what made adoption seem superior.
- Keep the two plugs, but hide one. I do like the new `cell.enabled` switch that's available for everything in the popup editor now, which suggests we should maybe hide `cell.value.enabled`?

Thoughts welcome...
