### PR TITLE
GafferScene : Harden RenderController against null objects

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - OSLObject : Fixed bug that could cause string comparisons to fail for strings fetched using the InString shader or `inString()` function.
 - Fixed potential shutdown crashes when custom Metadata or View registrations have been made via Python.
+- Fixed crash when rendering unknown lights in 3Delight.
 
 0.56.2.1 (relative to 0.56.2.0)
 ========

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -50,6 +50,10 @@ namespace IECoreScenePreview
 /// A "Renderer" which just captures the scene passed to it, and
 /// keeps a history of any interactive edits made. Useful for testing
 /// renderer output code.
+///
+/// If the Bool `cr:unrenderable` attribute is set to true at a location, then
+/// calls to object, light, lightFilter, camera, etc... for that location will
+/// return nullptr rather than a valid ObjectInterface.
 class IECORESCENE_API CapturingRenderer : public Renderer
 {
 

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -248,22 +248,27 @@ class IECORESCENE_API Renderer : public IECore::RefCounted
 		/// "shutter", V2fData
 		/// The time interval for which the shutter is open - this is used in conjunction with the
 		/// times passed to motionBegin() to specify motion blur. Defaults to 0,0 if unspecified.
+		///
+		/// May return a nullptr if the camera definition is not supported by the renderer.
 		virtual ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) = 0;
 
 		/// Adds a named light with the initially supplied set of attributes, which are expected
 		/// to provide at least a light shader. Object may be non-null to specify arbitrary geometry
 		/// for a geometric area light, or null to indicate that the light shader specifies its own
 		/// geometry internally (or is non-geometric in nature).
+		/// May return a nullptr if the light definition is not supported by the renderer.
 		/// \todo Should object be typed as Primitive?
 		virtual ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) = 0;
 
 		/// Adds a named light filter with the initially supplied set of attributes, which are expected
 		/// to provide at least a light filter shader.
+		/// May return a nullptr if the light filter definition is not supported by the renderer.
 		virtual ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) = 0;
 
 		/// Adds a named object to the render with the initally supplied set of attributes.
 		/// The attributes may subsequently be edited in interactive mode using
 		/// ObjectInterface::attributes().
+		/// May return a nullptr if the object definition is not supported by the renderer.
 		/// \todo Rejig class hierarchy so we can have something less generic than
 		/// Object here, but still pass CoordinateSystems. Or should
 		/// coordinate systems have their own dedicated calls?

--- a/python/GafferDelightTest/InteractiveDelightRenderTest.py
+++ b/python/GafferDelightTest/InteractiveDelightRenderTest.py
@@ -63,10 +63,24 @@ class InteractiveDelightRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		pass
 
+	# Disable this test for now as we don't have light linking support in
+	# 3Delight, yet.
+	@unittest.skip( "No light linking support just yet" )
+	def testHideLinkedLight( self ) :
+
+		pass
+
 	# Disable this test for now as we don't have light filter support in
 	# 3Delight, yet.
 	@unittest.skip( "No light filter support just yet" )
 	def testLightFilters( self ) :
+
+		pass
+
+	# Disable this test for now as we don't have light filter support in
+	# 3Delight, yet.
+	@unittest.skip( "No light filter support just yet" )
+	def testLightFiltersAndSetEdits( self ) :
 
 		pass
 

--- a/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
@@ -118,5 +118,34 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 		self.assertEqual( mh.messages[0].message, "Object named \"o\" already exists" )
 		del o
 
+	def testObjects( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+
+		renderableAttr = renderer.attributes( IECore.CompoundObject( {} ) )
+		unrenderableAttr = renderer.attributes( IECore.CompoundObject( { "cr:unrenderable" : IECore.BoolData( True ) } ) )
+
+		self.assertIsNone( renderer.object( "o", IECoreScene.SpherePrimitive(), unrenderableAttr ) )
+		self.assertIsNone( renderer.camera( "c", IECoreScene.Camera(), unrenderableAttr ) )
+		self.assertIsNone( renderer.light( "l", IECore.NullObject(), unrenderableAttr ) )
+		self.assertIsNone( renderer.lightFilter( "lf", IECore.NullObject(), unrenderableAttr ) )
+
+		self.assertIsInstance(
+			renderer.object( "ro", IECoreScene.SpherePrimitive(), renderableAttr ),
+			GafferScene.Private.IECoreScenePreview.Renderer.ObjectInterface
+		)
+		self.assertIsInstance(
+			renderer.camera( "rc", IECoreScene.Camera(), renderableAttr ),
+			GafferScene.Private.IECoreScenePreview.Renderer.ObjectInterface
+		)
+		self.assertIsInstance(
+			renderer.light( "rl", IECore.NullObject(), renderableAttr ),
+			GafferScene.Private.IECoreScenePreview.Renderer.ObjectInterface
+		)
+		self.assertIsInstance(
+			renderer.lightFilter( "rl", IECore.NullObject(), renderableAttr ),
+			GafferScene.Private.IECoreScenePreview.Renderer.ObjectInterface
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/RenderControllerTest.py
+++ b/python/GafferSceneTest/RenderControllerTest.py
@@ -497,5 +497,35 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 
 		del capturedSphere
 
+	def testNullObjects( self ) :
+
+		camera = GafferScene.Camera()
+		sphere = GafferScene.Sphere()
+		light = GafferSceneTest.TestLight()
+
+		lightAttr = GafferScene.StandardAttributes()
+		lightAttr["in"].setInput( sphere["out"] )
+		lightAttr["attributes"]["linkedLights"]["enabled"].setValue( True )
+		lightAttr["attributes"]["linkedLights"]["value"].setValue( "defaultLights" )
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( camera["out"] )
+		group["in"][1].setInput( sphere["out"] )
+		group["in"][2].setInput( light["out"] )
+
+		allFilter = GafferScene.PathFilter()
+		allFilter["paths"].setValue( IECore.StringVectorData( [ "..." ] ) )
+
+		attr = GafferScene.CustomAttributes()
+		unrenderableAttrPlug = Gaffer.NameValuePlug( "cr:unrenderable", IECore.BoolData( True ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		attr["attributes"].addChild( unrenderableAttrPlug )
+		attr["filter"].setInput( allFilter["out"] )
+		attr["in"].setInput( group["out"] )
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+		controller = GafferScene.RenderController( attr["out"], Gaffer.Context(), renderer )
+		controller.setMinimumExpansionDepth( 10 )
+		controller.update()
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferDelight/IECoreDelightPreview/Renderer.cpp
+++ b/src/GafferDelight/IECoreDelightPreview/Renderer.cpp
@@ -1186,6 +1186,11 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 
 		Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
 		{
+			if( !object )
+			{
+				return nullptr;
+			}
+
 			DelightHandleSharedPtr instance = m_instanceCache->get( object );
 			if( !instance )
 			{

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -37,6 +37,7 @@
 #include "GafferScene/Private/IECoreScenePreview/CapturingRenderer.h"
 
 #include "IECore/MessageHandler.h"
+#include "IECore/SimpleTypedData.h"
 
 using namespace std;
 using namespace IECore;
@@ -107,6 +108,17 @@ Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name,
 Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes )
 {
 	checkPaused();
+
+	// To facilitate the testing of code that handles the return from the various object methods of
+	// a renderer, we return null if the `cr:unrenderable` attribute is set to true.
+	if( const auto attr = dynamic_cast<const CapturingRenderer::CapturedAttributes *>( attributes ) )
+	{
+		const BoolData *attrData = attr->attributes()->member<BoolData>( "cr:unrenderable" );
+		if( attrData && attrData->readable() )
+		{
+			return nullptr;
+		}
+	}
 
 	ObjectMap::accessor a;
 	if( !m_capturedObjects.insert( a, name ) )

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -449,7 +449,10 @@ class RenderController::SceneGraph
 					}
 
 					m_boundInterface = controller->m_renderer->object( boundName, boundCurves.get(), controller->m_boundAttributes.get() );
-					m_boundInterface->transform( m_fullTransform );
+					if( m_boundInterface )
+					{
+						m_boundInterface->transform( m_fullTransform );
+					}
 				}
 				else
 				{
@@ -681,7 +684,7 @@ class RenderController::SceneGraph
 			else if( type == LightType )
 			{
 				auto light = renderer->light( name, nullObject ? nullptr : object.get(), attributesInterface( renderer ) );
-				if( lightLinks )
+				if( light && lightLinks )
 				{
 					lightLinks->addLight( name, light );
 					m_objectInterface.assign(
@@ -699,7 +702,7 @@ class RenderController::SceneGraph
 			else if( type == LightFilterType )
 			{
 				auto lightFilter = renderer->lightFilter( name, nullObject ? nullptr : object.get(), attributesInterface( renderer ) );
-				if( lightLinks )
+				if( lightFilter && lightLinks )
 				{
 					lightLinks->addLightFilter( lightFilter, m_fullAttributes.get() );
 					m_objectInterface.assign(

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -924,7 +924,7 @@ struct LocationOutput
 
 		void applyTransform( IECoreScenePreview::Renderer::ObjectInterface *objectInterface )
 		{
-			if( !m_transformSamples.size() || !objectInterface )
+			if( !m_transformSamples.size() )
 			{
 				return;
 			}
@@ -1096,7 +1096,10 @@ struct CameraOutput : public LocationOutput
 					attributesInterface().get()
 				);
 
-				applyTransform( objectInterface.get() );
+				if( objectInterface )
+				{
+					applyTransform( objectInterface.get() );
+				}
 			}
 		}
 
@@ -1137,11 +1140,15 @@ struct LightOutput : public LocationOutput
 				attributesInterface().get()
 			);
 
-			applyTransform( objectInterface.get() );
-			if( m_lightLinks )
+			if( objectInterface )
 			{
-				m_lightLinks->addLight( name, objectInterface );
+				applyTransform( objectInterface.get() );
+				if( m_lightLinks )
+				{
+					m_lightLinks->addLight( name, objectInterface );
+				}
 			}
+
 		}
 
 		return lightMatch & IECore::PathMatcher::DescendantMatch;
@@ -1178,10 +1185,13 @@ struct LightFiltersOutput : public LocationOutput
 				attributesInterface().get()
 			);
 
-			applyTransform( objectInterface.get() );
-			if( m_lightLinks )
+			if( objectInterface )
 			{
-				m_lightLinks->addLightFilter( objectInterface, attributes() );
+				applyTransform( objectInterface.get() );
+				if( m_lightLinks )
+				{
+					m_lightLinks->addLightFilter( objectInterface, attributes() );
+				}
 			}
 		}
 
@@ -1240,10 +1250,13 @@ struct ObjectOutput : public LocationOutput
 			objectInterface = renderer()->object( name( path ), objectsVector, timesVector, attributesInterface.get() );
 		}
 
-		applyTransform( objectInterface.get() );
-		if( m_lightLinks )
+		if( objectInterface )
 		{
-			m_lightLinks->outputLightLinks( scene, attributes(), objectInterface.get() );
+			applyTransform( objectInterface.get() );
+			if( m_lightLinks )
+			{
+				m_lightLinks->outputLightLinks( scene, attributes(), objectInterface.get() );
+			}
 		}
 
 		return true;


### PR DESCRIPTION
Noticed the 3Delight crash whilst testing a multi-renderer scene. 3Delight wasn't prepared for `light(` to be called with a null `IECore::Object` ptr. Fixing that revealed that `RenderController`/`RendererAlgo` weren't prepared for any of a `Renderer`'s `ObjectInterface` returning methods to return a null either.

We decided that it is acceptable for a `Renderer` to return a null interface if it doesn't understand/support the requested object/light/etc.

`RendererAlgo` aborts traversal under unsupported locations, as the transform hierarchy would be incomplete. @johnhaddon, do we want to warn about this do you think?