### PR TITLE
BackdropNodeGadget : Avoid creating unnecessary plugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,12 @@ Fixes
 - NodeEditor : Fixed "Connect to Spreadsheet" tool menu item to work with Spreadsheets that have sections. Previously, the submenu showed the sections unnecessarily, and selecting a section triggered an error.
 - OSLObject : Fixed bug that could cause string comparisons to fail for strings fetched using the InString shader or `inString()` function.
 - Fixed potential shutdown crashes when custom Metadata or View registrations have been made via Python.
+- Backdrop : Fixed bug which caused unnecessary plugs to be added during copy/paste.
+
+API
+---
+
+- BackdropNodeGadget : Added `setBound()` and `getBound()` methods.
 
 0.57.3.0 (relative to 0.57.2.0)
 ========

--- a/include/GafferUI/BackdropNodeGadget.h
+++ b/include/GafferUI/BackdropNodeGadget.h
@@ -57,6 +57,9 @@ class GAFFERUI_API BackdropNodeGadget : public NodeGadget
 
 		std::string getToolTip( const IECore::LineSegment3f &line ) const override;
 
+		void setBound( const Imath::Box2f &bound );
+		Imath::Box2f getBound() const;
+
 		/// Resizes the backdrop to frame the specified nodes.
 		/// \undoable
 		void frame( const std::vector<Gaffer::Node *> &nodes );
@@ -92,8 +95,7 @@ class GAFFERUI_API BackdropNodeGadget : public NodeGadget
 
 		bool updateUserColor();
 
-		Gaffer::Box2fPlug *boundPlug();
-		const Gaffer::Box2fPlug *boundPlug() const;
+		Gaffer::Box2fPlug *acquireBoundPlug( bool createIfMissing = true );
 
 		bool m_hovered;
 		int m_horizontalDragEdge;

--- a/python/GafferUITest/BackdropNodeGadgetTest.py
+++ b/python/GafferUITest/BackdropNodeGadgetTest.py
@@ -1,0 +1,74 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+
+import Gaffer
+import GafferUI
+import GafferUITest
+
+class BackdropNodeGadgetTest( GafferUITest.TestCase ) :
+
+	def testNoExtraPlugsAfterCopyPaste( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["b"] = Gaffer.Backdrop()
+		script["n"] = Gaffer.Node()
+
+		graphGadget = GafferUI.GraphGadget( script )
+		backdropGadget = graphGadget.nodeGadget( script["b"] )
+		self.assertIsInstance( backdropGadget, GafferUI.BackdropNodeGadget )
+		backdropGadget.frame( [ script["n"] ] )
+
+		script.execute( script.serialise( filter = Gaffer.StandardSet( [ script["b"] ] ) ) )
+		self.assertEqual( script["b1"].keys(), script["b"].keys() )
+
+	def testBoundAccessors( self ) :
+
+		b = Gaffer.Backdrop()
+		g = GafferUI.BackdropNodeGadget( b )
+		self.assertEqual( g.getBound(), imath.Box2f( imath.V2f( -10 ), imath.V2f( 10 ) ) )
+
+		g.setBound( imath.Box2f( imath.V2f( -1, -2 ), imath.V2f( 3, 4 ) ) )
+		self.assertEqual(
+			g.getBound(),
+			imath.Box2f( imath.V2f( -1, -2 ), imath.V2f( 3, 4 ) )
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -117,6 +117,7 @@ from .CompoundNumericNoduleTest import CompoundNumericNoduleTest
 from .DocumentationAlgoTest import DocumentationAlgoTest
 from .ExamplesTest import ExamplesTest
 from .NodeSetEditorTest import NodeSetEditorTest
+from .BackdropNodeGadgetTest import BackdropNodeGadgetTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferUIModule/NodeGadgetBinding.cpp
+++ b/src/GafferUIModule/NodeGadgetBinding.cpp
@@ -132,6 +132,18 @@ GadgetPtr getEdgeGadget( StandardNodeGadget &g, StandardNodeGadget::Edge edge )
 	return g.getEdgeGadget( edge );
 }
 
+void setBound( BackdropNodeGadget &g, const Imath::Box2f &b )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	g.setBound( b );
+}
+
+Imath::Box2f getBound( BackdropNodeGadget &g )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return g.getBound();
+}
+
 void frame( BackdropNodeGadget &b, object nodes )
 {
 	std::vector<Node *> n;
@@ -198,6 +210,8 @@ void GafferUIModule::bindNodeGadget()
 
 	NodeGadgetClass<BackdropNodeGadget>()
 		.def( init<Gaffer::NodePtr>() )
+		.def( "setBound", &setBound )
+		.def( "getBound", &getBound )
 		.def( "frame", &frame )
 		.def( "framed", &framed )
 	;


### PR DESCRIPTION
We were adding a `__uiBound` plug in the gadget constructor, but during copy/paste, the Gadget is constructed when the node is first added to the script, and then any dynamic plugs are added afterwards. This meant a duplicate `__uiBound1` plug being added as the paste operation completes.

Although the `__uiBound` plug is private, it doesn't seem totally unlikely that people may be relying on setting it directly, so we provide the new `setBound()` and `getBound()` methods as a legitimate means of achieving the same thing. There's a reasonable argument for adding a public `Backdrop::boundsPlug()` instead, but dealing with bounds without reference to Gadgets is problematic, because without them you don't know how big a node is. So for now I've gone with fixing the bug in the existing scheme.

