### PR TITLE
EditScopeAlgo : Add methods for editing shader parameters

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -32,6 +32,7 @@ Fixes
 API
 ---
 
+- EditScopeAlgo : Added functions for creating edits on shader parameters.
 - Spreadsheet : Added an `addColumn()` overload with an `adoptEnabledPlug` boolean argument. This allows cells to reuse the `enabled` plug from their `value` plug if it has one.
 - SpreadsheetUI :
   - Added `formatValue()` and `registerValueFormatter()` methods to support custom formatting for extension plug types.

--- a/include/GafferScene/EditScopeAlgo.h
+++ b/include/GafferScene/EditScopeAlgo.h
@@ -37,10 +37,13 @@
 #ifndef GAFFERSCENE_EDITSCOPEALGO_H
 #define GAFFERSCENE_EDITSCOPEALGO_H
 
+#include "GafferScene/ScenePlug.h"
+#include "GafferScene/TweakPlug.h"
+
 #include "Gaffer/EditScope.h"
 #include "Gaffer/TransformPlug.h"
 
-#include "GafferScene/ScenePlug.h"
+#include "IECoreScene/ShaderNetwork.h"
 
 namespace GafferScene
 {
@@ -86,6 +89,15 @@ struct GAFFERSCENE_API TransformEdit
 GAFFERSCENE_API bool hasTransformEdit( const Gaffer::EditScope *scope, const ScenePlug::ScenePath &path );
 GAFFERSCENE_API boost::optional<TransformEdit> acquireTransformEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, bool createIfNecessary = true );
 GAFFERSCENE_API void removeTransformEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path );
+
+// Shaders
+// =======
+//
+// These methods edit shader parameters for a particular location.
+
+GAFFERSCENE_API bool hasParameterEdit( const Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter );
+GAFFERSCENE_API TweakPlug *acquireParameterEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter, bool createIfNecessary = true );
+GAFFERSCENE_API void removeParameterEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter );
 
 } // namespace EditScopeAlgo
 

--- a/src/GafferSceneModule/EditScopeAlgoBinding.cpp
+++ b/src/GafferSceneModule/EditScopeAlgoBinding.cpp
@@ -114,6 +114,23 @@ Imath::M44f matrixWrapper( EditScopeAlgo::TransformEdit &e )
 	return e.matrix();
 }
 
+bool hasParameterEditWrapper( const Gaffer::EditScope &scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter )
+{
+	return EditScopeAlgo::hasParameterEdit( &scope, path, attribute, parameter );
+}
+
+TweakPlugPtr acquireParameterEditWrapper( Gaffer::EditScope &scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter, bool createIfNecessary )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return EditScopeAlgo::acquireParameterEdit( &scope, path, attribute, parameter, createIfNecessary );
+}
+
+void removeParameterEditWrapper( Gaffer::EditScope &scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return EditScopeAlgo::removeParameterEdit( &scope, path, attribute, parameter );
+}
+
 } // namespace
 
 namespace GafferSceneModule
@@ -143,6 +160,11 @@ void bindEditScopeAlgo()
 	def( "acquireTransformEdit", &acquireTransformEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "createIfNecessary" ) = true ) );
 	def( "hasTransformEdit", &hasTransformEditWrapper );
 	def( "removeTransformEdit", &removeTransformEditWrapper );
+
+	def( "acquireParameterEdit", &acquireParameterEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ), arg( "parameter" ), arg( "createIfNecessary" ) = true ) );
+	def( "hasParameterEdit", &hasParameterEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ), arg( "parameter" ) ) );
+	def( "removeParameterEdit", &removeParameterEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ), arg( "parameter" ) ) );
+
 }
 
 } // namespace GafferSceneModule


### PR DESCRIPTION
This adds the underlying API that #3661 will use to make edits to shader parameters.