### PR TITLE
Add CI using Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,117 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - '*_maintenance'
+  pull_request:
+    branches:
+      - master
+      - '*_maintenance'
+
+jobs:
+
+  build:
+
+    strategy:
+
+      # Don't cancel other jobs in the build matrix if one job fails.
+      fail-fast: false
+
+      matrix:
+
+        # Rather than generate all permutations of various settings,
+        # we want to explicitly list each of the variants we want to
+        # test. We can use `name` to declare the names of our variants,
+        # and then use `include` to define their settings.
+
+        name: [
+          linux,
+          linux-debug,
+          macos,
+        ]
+
+        include:
+
+          - name: linux
+            os: ubuntu-16.04
+            buildType: RELEASE
+            containerImage: gafferhq/build:1.1.0
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.3.0/gafferDependencies-1.3.0-linux.tar.gz
+            # GitHub container builds run as root. This causes failures for tests that
+            # assert that filesystem permissions are respected, because root doesn't
+            # respect permissions. So we run the final test suite as a dedicated
+            # test user rather than as root.
+            testRunner: su testUser -c
+
+          - name: linux-debug
+            os: ubuntu-16.04
+            buildType: DEBUG
+            containerImage: gafferhq/build:1.1.0
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.3.0/gafferDependencies-1.3.0-linux.tar.gz
+            testRunner: su testUser -c
+
+          - name: macos
+            os: macos-10.15
+            buildType: RELEASE
+            containerImage:
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.3.0/gafferDependencies-1.3.0-osx.tar.gz
+            testRunner: bash -c
+
+    runs-on: ${{ matrix.os }}
+
+    container: ${{ matrix.containerImage }}
+
+    env:
+      DISPLAY: ":99.0"
+      ARNOLD_LICENSE_ORDER: none # Don't waste time looking for a license that doesn't exist
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Install toolchain (MacOS)
+      # Prefer `pip install` where possible because it is faster
+      # than `brew install`.
+      run: |
+        sudo pip install scons
+        sudo pip install sphinx==1.8.0 sphinx_rtd_theme==0.4.3 recommonmark==0.5.0 docutils==0.12
+        brew cask install xquartz https://raw.githubusercontent.com/Homebrew/homebrew-cask/5eafe6e9877c5524100b9ac1c5375fe8a2d039be/Casks/inkscape.rb
+      if: runner.os == 'macOS'
+
+    - name: Install toolchain (Linux)
+      run: |
+        echo "::add-path::/opt/rh/devtoolset-6/root/bin"
+        Xvfb :99 -screen 0 1280x1024x24 &
+        metacity&
+        useradd -m testUser
+      if: runner.os == 'Linux'
+
+    - name: Install dependencies
+      # The `::set-env` shenanigans creates an environment variable
+      # containing the hash of the archive, for use in the cache key
+      # below.
+      run: |
+        python .github/workflows/main/installDependencies.py --archiveURL ${{ matrix.dependenciesURL }} --dependenciesDir ./build --outputFormat "::set-env name=GAFFER_DEPENDENCIES_HASH::{archiveDigest}"
+        ./config/installDelight.sh
+        echo ::set-env name=DELIGHT::$GITHUB_WORKSPACE/3delight
+
+    - name: Cache
+      uses: actions/cache@v1
+      with:
+        path: sconsCache
+        key: ${{ runner.os }}-${{ matrix.containerImage }}-${{env.GAFFER_DEPENDENCIES_HASH}}-${{ matrix.buildType }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.containerImage }}-${{env.GAFFER_DEPENDENCIES_HASH}}-${{ matrix.buildType }}-
+
+    - name: Build
+      run: |
+       scons -j 2 build ENV_VARS_TO_IMPORT=PATH BUILD_TYPE=${{ matrix.buildType }} DELIGHT_ROOT=$DELIGHT ARNOLD_ROOT= BUILD_DIR=./build BUILD_CACHEDIR=sconsCache
+
+    - name: Test
+      run: |
+        ${{ matrix.testRunner }} "./build/bin/gaffer test"
+
+    - name: Limit cache size
+      run: python ./.github/workflows/main/limitCacheSize.py

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import sys
+import argparse
+import urllib
+import hashlib
+
+# Determine default archive URL.
+
+platform = "osx" if sys.platform == "darwin" else "linux"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/1.3.0/gafferDependencies-1.3.0-" + platform + ".tar.gz"
+
+# Parse command line arguments.
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument(
+	"--archiveURL",
+	help = "The URL to download the dependencies archive from.",
+	default = defaultURL,
+)
+
+parser.add_argument(
+	"--dependenciesDir",
+	help = "The directory to unpack the dependencies into.",
+	default = "dependencies",
+)
+
+parser.add_argument(
+	"--outputFormat",
+	help = "A format string that specifies the output printed "
+		"by this script. May contain {archiveURL} and {archiveDigest} "
+		"tokens that will be substituted appropriately.",
+	default = "",
+)
+
+args = parser.parse_args()
+
+# Download and unpack the archive.
+
+sys.stderr.write( "Downloading dependencies \"%s\"\n" % args.archiveURL )
+archiveFileName, headers = urllib.urlretrieve( args.archiveURL )
+
+os.makedirs( args.dependenciesDir )
+os.system( "tar xf %s -C %s --strip-components=1" % ( archiveFileName, args.dependenciesDir ) )
+
+# Tell the world
+
+if args.outputFormat :
+
+	md5 = hashlib.md5()
+	with open( archiveFileName ) as f :
+		md5.update( f.read() )
+
+	print(
+		args.outputFormat.format(
+			archiveURL = args.archiveURL,
+			archiveDigest = md5.hexdigest()
+		)
+	)

--- a/.github/workflows/main/limitCacheSize.py
+++ b/.github/workflows/main/limitCacheSize.py
@@ -1,0 +1,38 @@
+import os
+import collections
+
+# GitHub has a limit of 5G for all caches in a repository. Because we both read
+# from and write to `.sconsCache`, it would quickly grow to exceed this limit if
+# left unchecked. This script limits the cache size to avoid unbounded growth.
+
+# 2.5G. This is roughly the right size to hold a single debug build, which is
+# extremely bloated compared to a regular release build. In practice, the actual
+# GitHub quota used is much lower, because GitHub compresses all files into a
+# single archive before uploading them.
+sizeLimit = 2.5 * 1024 * 1024 * 1024
+
+CacheEntry = collections.namedtuple( "CacheEntry", [ "file", "size", "mtime" ] )
+
+totalSize = 0
+cacheEntries = []
+
+for root, dirs, files in os.walk( "./sconsCache" ) :
+	for file in files :
+		fileName = os.path.join( root, file )
+		size = os.path.getsize( fileName )
+		totalSize += size
+		cacheEntries.append(
+			CacheEntry(
+				fileName,
+				size,
+				os.path.getmtime( fileName ),
+			)
+		)
+
+cacheEntries = sorted( cacheEntries, key = lambda x : x.mtime )
+for c in cacheEntries :
+	if totalSize < sizeLimit :
+		break
+	os.remove( c.file )
+	print( "REMOVING", c.file )
+	totalSize -= c.size

--- a/python/GafferSceneUITest/SceneGadgetTest.py
+++ b/python/GafferSceneUITest/SceneGadgetTest.py
@@ -132,7 +132,7 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 		sg.waitForCompletion()
 		self.assertObjectAt( sg, imath.V2f( 0.5 ), IECore.InternedStringVectorData( [ "group", "sphere" ] ) )
 
-	@unittest.skipIf( "TF_BUILD" in os.environ, "Unknown problem running on Azure Pipelines" )
+	@unittest.skipIf( GafferTest.inCI(), "Unknown problem running in cloud" )
 	def testExpansion( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -61,7 +61,8 @@ def inCI( platforms = set() ) :
 		# There isn't a specific 'We're on Azure' var (other than some azure specific
 		# vars that are set that would be 'magic words'), so we set our own in our
 		# azure-pipelines.yaml
-		'azure' : 'AZURE'
+		"azure" : "AZURE",
+		"github" : "CI",
 	}
 
 	targets = platforms or platformVars.keys()


### PR DESCRIPTION
This currently omits GafferArnold, until we figure out what to do about the login secret (the GitHub rules are different to the Azure ones). But it has the major benefit of caching builds. My intention is to use this to set up Python 3 testing, as we did for Cortex, then to make the setup more comprehensive and use it to replace Azure.
