### PR TITLE
IECoreScenePreview : Add message handlers to renderers

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,12 @@ Breaking Changes
     - `GafferCortex` attributes can no longer be accessed via the `Gaffer` namespace.
     - `GafferCortexUI` attributes can no longer be accessed via the `GafferUI` namespace.
 - RecursiveChildIterator : Changed private member data. Source compatibility is maintained.
+- IECorePreview::Renderer : Changed signature for `create` and `registerType` to include optional message handler.
+
+API
+---
+
+- IECorePreview::Renderer : Added optional message handler to renderer construction to allow output message streams to be re-directed if required (#3419).
 
 Build
 -----

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -61,7 +61,11 @@ class IECORESCENE_API CapturingRenderer : public Renderer
 
 		IE_CORE_DECLAREMEMBERPTR( CapturingRenderer )
 
-		CapturingRenderer( RenderType type = RenderType::Interactive, const std::string &fileName = "" );
+		CapturingRenderer(
+			RenderType type = RenderType::Interactive,
+			const std::string &fileName = "",
+			const IECore::MessageHandlerPtr &messageHandler = IECore::MessageHandlerPtr()
+		);
 
 		/// Introspection
 		/// =============

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -159,6 +159,8 @@ class IECORESCENE_API CapturingRenderer : public Renderer
 
 		void checkPaused() const;
 
+		IECore::MessageHandlerPtr m_messageHandler;
+
 		std::atomic_bool m_rendering;
 		using ObjectMap = tbb::concurrent_hash_map<std::string, const CapturedObject *>;
 		ObjectMap m_capturedObjects;

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -41,6 +41,7 @@
 #include "IECoreScene/Output.h"
 
 #include "IECore/CompoundObject.h"
+#include "IECore/MessageHandler.h"
 
 #include "boost/unordered_set.hpp"
 
@@ -89,8 +90,12 @@ class IECORESCENE_API Renderer : public IECore::RefCounted
 		IE_CORE_DECLAREMEMBERPTR( Renderer )
 
 		static const std::vector<IECore::InternedString> &types();
-		/// Filename is only used if the renderType is SceneDescription.
-		static Ptr create( const IECore::InternedString &type, RenderType renderType = Batch, const std::string &fileName = "" );
+		/// fileName is only used if the renderType is SceneDescription.
+		/// messageHandler may be provided by the owner of the renderer. If so, all in-render messages should be
+		/// passed to this handler. Message contexts can be left blank if no applicable information is available.
+		/// The renderer must scope the supplied handler before calling out to other code that makes use of static
+		/// IECore::msg logging.
+		static Ptr create( const IECore::InternedString &type, RenderType renderType = Batch, const std::string &fileName = "", const IECore::MessageHandlerPtr &messageHandler = IECore::MessageHandlerPtr() );
 
 		/// Returns the name of this renderer, for instance "OpenGL" or "Arnold".
 		virtual IECore::InternedString name() const = 0;
@@ -310,16 +315,16 @@ class IECORESCENE_API Renderer : public IECore::RefCounted
 
 			private :
 
-				static Ptr creator( RenderType renderType, const std::string &fileName )
+				static Ptr creator( RenderType renderType, const std::string &fileName, const IECore::MessageHandlerPtr &messageHandler )
 				{
-					return new T( renderType, fileName );
+					return new T( renderType, fileName, messageHandler );
 				}
 
 		};
 
 	private :
 
-		static void registerType( const IECore::InternedString &typeName, Ptr (*creator)( RenderType, const std::string & ) );
+		static void registerType( const IECore::InternedString &typeName, Ptr (*creator)( RenderType, const std::string &, const IECore::MessageHandlerPtr & ) );
 
 
 };

--- a/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
+++ b/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
@@ -2414,7 +2414,7 @@ class AppleseedRenderer final : public AppleseedRendererBase
 
 	public :
 
-		AppleseedRenderer( RenderType renderType, const string &fileName )
+		AppleseedRenderer( RenderType renderType, const string &fileName, const IECore::MessageHandlerPtr &messageHandler )
 			:	AppleseedRendererBase( renderType , fileName, 0.0f, 0.0f )
 			,	m_environmentEDFVisible( false )
 			,	m_maxInteractiveRenderSamples( 0 )

--- a/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
+++ b/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
@@ -160,6 +160,33 @@ class ScopedLogTarget
 		asf::auto_release_ptr<asf::ILogTarget> m_logTarget;
 };
 
+const std::vector<IECore::MessageHandler::Level> g_ieMsgLevels = {
+	IECore::MessageHandler::Level::Debug,
+	IECore::MessageHandler::Level::Info,
+	IECore::MessageHandler::Level::Warning,
+	IECore::MessageHandler::Level::Error,
+	IECore::MessageHandler::Level::Error
+};
+
+class CortexLogTarget : public asf::ILogTarget
+{
+
+	public :
+
+		CortexLogTarget( IECore::MessageHandler *messageHandler ) : m_messageHandler( messageHandler ) {};
+
+		void write( const asf::LogMessage::Category category, const char* file, const size_t line, const char* header, const char* message ) override
+		{
+			m_messageHandler->handle( g_ieMsgLevels[ min( int(category), 4 ) ], "Appleseed", message );
+		}
+
+		void release() override {};
+
+	private :
+
+		IECore::MessageHandlerPtr m_messageHandler;
+};
+
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -2418,6 +2445,7 @@ class AppleseedRenderer final : public AppleseedRendererBase
 			:	AppleseedRendererBase( renderType , fileName, 0.0f, 0.0f )
 			,	m_environmentEDFVisible( false )
 			,	m_maxInteractiveRenderSamples( 0 )
+			,	m_messageHandler( messageHandler )
 		{
 			// Create the renderer controller.
 			m_rendererController = new RendererController();
@@ -2431,6 +2459,8 @@ class AppleseedRenderer final : public AppleseedRendererBase
 
 		void option( const InternedString &name, const Object *value ) override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			if( name == g_cameraOptionName )
 			{
 				if( value == nullptr )
@@ -2806,6 +2836,8 @@ class AppleseedRenderer final : public AppleseedRendererBase
 
 		void output( const InternedString &name, const Output *output ) override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			if( output == nullptr )
 			{
 				// Reset display / image output related params and recreate the frame.
@@ -2899,6 +2931,8 @@ class AppleseedRenderer final : public AppleseedRendererBase
 
 		ObjectInterfacePtr camera( const string &name, const Camera *camera, const AttributesInterface *attributes ) override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			// Check if this is the active camera.
 			if( name == m_cameraName )
 			{
@@ -2915,6 +2949,8 @@ class AppleseedRenderer final : public AppleseedRendererBase
 
 		ObjectInterfacePtr light( const string &name, const Object *object, const AttributesInterface *attributes ) override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			// For now we only do area lights using OSL emission().
 			if( object == nullptr )
 			{
@@ -2948,6 +2984,8 @@ class AppleseedRenderer final : public AppleseedRendererBase
 
 		void render() override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			// Clear unused shaders.
 			m_shaderCache->clearUnused();
 
@@ -3016,6 +3054,8 @@ class AppleseedRenderer final : public AppleseedRendererBase
 
 		void pause() override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			m_rendererController->set_status( asr::IRendererController::AbortRendering );
 
 			if( m_renderThread.joinable() )
@@ -3032,7 +3072,13 @@ class AppleseedRenderer final : public AppleseedRendererBase
 			m_rendererController->set_status( asr::IRendererController::ContinueRendering );
 
 			// Logging.
-			ScopedLogTarget logTarget;
+			ScopedLogTarget cortexLogTarget;
+			if( m_messageHandler )
+			{
+				asf::auto_release_ptr<asf::ILogTarget> l( new CortexLogTarget( m_messageHandler.get() ) );
+				cortexLogTarget.setLogTarget( asf::auto_release_ptr<asf::ILogTarget>( l.release() ) );
+			}
+			ScopedLogTarget fileLogTarget;
 			if( !m_logFileName.empty() )
 			{
 				// Create the file log target and make sure it's open.
@@ -3045,7 +3091,7 @@ class AppleseedRenderer final : public AppleseedRendererBase
 					return;
 				}
 
-				logTarget.setLogTarget( asf::auto_release_ptr<asf::ILogTarget>( l.release() ) );
+				fileLogTarget.setLogTarget( asf::auto_release_ptr<asf::ILogTarget>( l.release() ) );
 			}
 
 			// Render progress logging.
@@ -3107,7 +3153,9 @@ class AppleseedRenderer final : public AppleseedRendererBase
 			// Enable console logging.
 			ScopedLogTarget logTarget;
 			{
-				asf::auto_release_ptr<asf::ILogTarget> l( asf::create_console_log_target( stderr ) );
+				asf::auto_release_ptr<asf::ILogTarget> l(
+					m_messageHandler ? new CortexLogTarget( m_messageHandler.get() ) : asf::create_console_log_target( stderr )
+				);
 				logTarget.setLogTarget( l );
 			}
 
@@ -3229,6 +3277,7 @@ class AppleseedRenderer final : public AppleseedRendererBase
 
 		int m_maxInteractiveRenderSamples;
 		boost::thread m_renderThread;
+		IECore::MessageHandlerPtr m_messageHandler;
 
 		// Registration with factory
 

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -3463,7 +3463,7 @@ class ArnoldRenderer final : public ArnoldRendererBase
 
 	public :
 
-		ArnoldRenderer( RenderType renderType, const std::string &fileName )
+		ArnoldRenderer( RenderType renderType, const std::string &fileName, const IECore::MessageHandlerPtr &messageHandler )
 			:	ArnoldRendererBase( nodeDeleter( renderType ) ),
 				m_globals( new ArnoldGlobals( renderType, fileName, m_shaderCache.get() ) )
 		{

--- a/src/GafferDelight/IECoreDelightPreview/Renderer.cpp
+++ b/src/GafferDelight/IECoreDelightPreview/Renderer.cpp
@@ -985,7 +985,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 
 	public :
 
-		DelightRenderer( RenderType renderType, const std::string &fileName )
+		DelightRenderer( RenderType renderType, const std::string &fileName, const IECore::MessageHandlerPtr &messageHandler )
 			:	m_renderType( renderType ), m_frame( 1 ), m_oversampling( 9 )
 		{
 			vector<NSIParam_t> params;

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -700,7 +700,7 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 	public :
 
 		OpenGLRenderer( RenderType renderType, const std::string &fileName, const IECore::MessageHandlerPtr &messageHandler )
-			:	m_renderType( renderType ), m_baseStateOptions( new CompoundObject )
+			:	m_renderType( renderType ), m_baseStateOptions( new CompoundObject ), m_messageHandler( messageHandler )
 		{
 			if( renderType == SceneDescription )
 			{
@@ -719,6 +719,8 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 		void option( const IECore::InternedString &name, const IECore::Object *value ) override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			if( name == "camera" )
 			{
 				if( value == nullptr )
@@ -790,6 +792,8 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 		Renderer::AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			OpenGLAttributesPtr result = new OpenGLAttributes( attributes );
 			m_editQueue.push( [ this, result ]() { m_attributes.push_back( result ); } );
 			return result;
@@ -797,6 +801,8 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			OpenGLCameraPtr result = new OpenGLCamera( name, camera, static_cast<const OpenGLAttributes *>( attributes ), m_editQueue );
 			m_editQueue.push( [this, result, name]() {
 				m_objects.push_back( result );
@@ -807,6 +813,8 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			OpenGLLightPtr result = new OpenGLLight( name, object, static_cast<const OpenGLAttributes *>( attributes ), m_editQueue );
 			m_editQueue.push( [this, result]() { m_objects.push_back( result ); } );
 			return result;
@@ -814,6 +822,8 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			OpenGLLightFilterPtr result = new OpenGLLightFilter( name, object, static_cast<const OpenGLAttributes *>( attributes ), m_editQueue );
 			m_editQueue.push( [this, result]() { m_objects.push_back( result ); } );
 			return result;
@@ -821,6 +831,8 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 		Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			OpenGLObjectPtr result = new OpenGLObject( name, object, static_cast<const OpenGLAttributes *>( attributes ), m_editQueue );
 			m_editQueue.push( [this, result]() { m_objects.push_back( result ); } );
 			return result;
@@ -833,6 +845,8 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 		void render() override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			if( m_renderType == Interactive )
 			{
 				renderInteractive();
@@ -845,6 +859,8 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 		void pause() override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			if( m_renderType != Interactive )
 			{
 				IECore::msg( IECore::Msg::Warning, "IECoreGL::Renderer::pause", "Cannot pause non-interactive renders" );
@@ -853,6 +869,8 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 		IECore::DataPtr command( const IECore::InternedString name, const IECore::CompoundDataMap &parameters ) override
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			if( name == "gl:queryBound" )
 			{
 				return queryBound( parameters );
@@ -1039,6 +1057,8 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 		void writeOutputs( const FrameBuffer *frameBuffer )
 		{
+			IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 			for( const auto &namedOutput : m_outputs )
 			{
 				IECoreImage::ImagePrimitivePtr image = nullptr;
@@ -1164,6 +1184,8 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 		IECore::PathMatcher m_selection;
 		IECore::CompoundObjectPtr m_baseStateOptions;
 		IECoreGL::StatePtr m_baseState;
+
+		IECore::MessageHandlerPtr m_messageHandler;
 
 		// Queue used to pass edits from background threads to the render thread.
 		EditQueue m_editQueue;

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -699,7 +699,7 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 	public :
 
-		OpenGLRenderer( RenderType renderType, const std::string &fileName )
+		OpenGLRenderer( RenderType renderType, const std::string &fileName, const IECore::MessageHandlerPtr &messageHandler )
 			:	m_renderType( renderType ), m_baseStateOptions( new CompoundObject )
 		{
 			if( renderType == SceneDescription )

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -50,7 +50,7 @@ using namespace IECoreScenePreview;
 IECoreScenePreview::Renderer::TypeDescription<CapturingRenderer> CapturingRenderer::g_typeDescription( "Capturing" );
 
 CapturingRenderer::CapturingRenderer( RenderType type, const std::string &fileName, const IECore::MessageHandlerPtr &messageHandler )
-	:	m_rendering( false )
+	:	m_messageHandler( messageHandler ), m_rendering( false )
 {
 }
 
@@ -107,6 +107,8 @@ Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name,
 
 Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes )
 {
+	IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 	checkPaused();
 
 	// To facilitate the testing of code that handles the return from the various object methods of
@@ -138,6 +140,8 @@ Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name,
 
 void CapturingRenderer::render()
 {
+	IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 	if( m_rendering )
 	{
 		IECore::msg( IECore::Msg::Warning, "CapturingRenderer::render", "Already rendering" );
@@ -147,6 +151,8 @@ void CapturingRenderer::render()
 
 void CapturingRenderer::pause()
 {
+	IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
 	if( m_rendering )
 	{
 		IECore::msg( IECore::Msg::Warning, "CapturingRenderer::pause", "Not rendering" );

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -49,7 +49,7 @@ using namespace IECoreScenePreview;
 
 IECoreScenePreview::Renderer::TypeDescription<CapturingRenderer> CapturingRenderer::g_typeDescription( "Capturing" );
 
-CapturingRenderer::CapturingRenderer( RenderType type, const std::string &fileName )
+CapturingRenderer::CapturingRenderer( RenderType type, const std::string &fileName, const IECore::MessageHandlerPtr &messageHandler )
 	:	m_rendering( false )
 {
 }

--- a/src/GafferScene/IECoreScenePreview/Renderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/Renderer.cpp
@@ -48,7 +48,7 @@ using namespace IECoreScenePreview;
 namespace
 {
 
-typedef Renderer::Ptr (*Creator)( Renderer::RenderType, const std::string & );
+typedef Renderer::Ptr (*Creator)( Renderer::RenderType, const std::string &, const IECore::MessageHandlerPtr & );
 
 vector<IECore::InternedString> &types()
 {
@@ -99,7 +99,7 @@ const std::vector<IECore::InternedString> &Renderer::types()
 	return ::types();
 }
 
-Renderer::Ptr Renderer::create( const IECore::InternedString &type, RenderType renderType, const std::string &fileName )
+Renderer::Ptr Renderer::create( const IECore::InternedString &type, RenderType renderType, const std::string &fileName, const IECore::MessageHandlerPtr &messageHandler )
 {
 	const CreatorMap &c = creators();
 	CreatorMap::const_iterator it = c.find( type );
@@ -107,11 +107,11 @@ Renderer::Ptr Renderer::create( const IECore::InternedString &type, RenderType r
 	{
 		return nullptr;
 	}
-	return it->second( renderType, fileName );
+	return it->second( renderType, fileName, messageHandler );
 }
 
 
-void Renderer::registerType( const IECore::InternedString &typeName, Ptr (*creator)( RenderType, const std::string & ) )
+void Renderer::registerType( const IECore::InternedString &typeName, Ptr (*creator)( RenderType, const std::string &, const IECore::MessageHandlerPtr & ) )
 {
 	CreatorMap &c = creators();
 	CreatorMap::iterator it = c.find( typeName );

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -178,6 +178,12 @@ void objectInterfaceLink( Renderer::ObjectInterface &objectInterface, const IECo
 	objectInterface.link( type, objectSet );
 }
 
+void render( Renderer &renderer )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	renderer.render();
+}
+
 class ProceduralWrapper : public IECorePython::RunTimeTypedWrapper<IECoreScenePreview::Procedural>
 {
 
@@ -351,7 +357,7 @@ void GafferSceneModule::bindRender()
 			.def( "object", &rendererObject1 )
 			.def( "object", &rendererObject2 )
 
-			.def( "render", &Renderer::render )
+			.def( "render", render )
 			.def( "pause", &Renderer::pause )
 			.def( "command", &rendererCommand )
 

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -340,7 +340,7 @@ void GafferSceneModule::bindRender()
 
 			.def( "types", &rendererTypes )
 			.staticmethod( "types" )
-			.def( "create", &Renderer::create, ( arg( "type" ), arg( "renderType" ) = Renderer::Batch, arg( "fileName" ) = "" ) )
+			.def( "create", &Renderer::create, ( arg( "type" ), arg( "renderType" ) = Renderer::Batch, arg( "fileName" ) = "", arg( "messageHandler" ) = IECore::MessageHandlerPtr() ) )
 			.staticmethod( "create" )
 
 			.def( "name", &rendererName )
@@ -389,7 +389,7 @@ void GafferSceneModule::bindRender()
 		;
 
 		scope capturingRendererScope = IECorePython::RefCountedClass<CapturingRenderer, Renderer>( "CapturingRenderer" )
-			.def( init<Renderer::RenderType, const std::string &>( ( arg( "renderType" ) = Renderer::RenderType::Interactive, arg( "fileName" ) = "" ) ) )
+			.def( init<Renderer::RenderType, const std::string &, const IECore::MessageHandlerPtr &>( ( arg( "renderType" ) = Renderer::RenderType::Interactive, arg( "fileName" ) = "", arg( "messageHandler") = IECore::MessageHandlerPtr() ) ) )
 			.def( "capturedObject", &capturingRendererCapturedObject )
 		;
 


### PR DESCRIPTION
In order to support in-application render logs, we required access to the messages generated during render and scene translation.

This PR adds an optional `IECore::MessageHandler` to the `Renderer` constructor. If provided, it is the responisibility of a renderer to route logging to this handler.

The PR also adds support for this to the standard renderers where possible.
