### PR TITLE
Test app : Treat deprecation warnings as errors

### DIFF
--- a/apps/test/test-1.py
+++ b/apps/test/test-1.py
@@ -38,6 +38,7 @@
 import glob
 import os
 import sys
+import warnings
 
 import IECore
 import Gaffer
@@ -148,7 +149,9 @@ class test( Gaffer.Application ) :
 			if args["stopOnFailure"].value :
 				testRunner.failfast = True
 
-			testResult = testRunner.run( testSuite )
+			with warnings.catch_warnings() :
+				warnings.simplefilter( "error", DeprecationWarning )
+				testResult = testRunner.run( testSuite )
 
 			if args["outputFile"].value :
 				testResult.save( args["outputFile"].value )

--- a/python/GafferUITest/SelectionMenuTest.py
+++ b/python/GafferUITest/SelectionMenuTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import warnings
 
 import GafferUI
 import GafferUITest
@@ -43,59 +44,79 @@ class SelectionMenuTest( GafferUITest.TestCase ) :
 
 	def testAccessors( self ) :
 
-		s = GafferUI.SelectionMenu()
+		# The SelectionMenu class is deprecated, but we still want to
+		# run the tests for it for as long as it is still in Gaffer.
+		# So we temporarily suppress the warnings that it will emit
+		# when used.
+		with warnings.catch_warnings() :
 
-		# adding new items
-		s.addItem( "Test1" )
-		s.addItem( "Test2" )
-		s.addItem( "Test3" )
-		self.assertEqual( s.getTotal(), 3 )
+			warnings.simplefilter( "ignore", DeprecationWarning )
 
-		# changing and checking the current item
-		s.setCurrentIndex( 1 )
-		self.assertEqual( s.getCurrentItem(), "Test2" )
-		self.assertEqual( s.getItem(s.getCurrentIndex()), "Test2" )
+			s = GafferUI.SelectionMenu()
 
-		# removing item
-		s.removeIndex( 0 )
-		self.assertEqual ( s.getTotal(), 2 )
+			# adding new items
+			s.addItem( "Test1" )
+			s.addItem( "Test2" )
+			s.addItem( "Test3" )
+			self.assertEqual( s.getTotal(), 3 )
+
+			# changing and checking the current item
+			s.setCurrentIndex( 1 )
+			self.assertEqual( s.getCurrentItem(), "Test2" )
+			self.assertEqual( s.getItem(s.getCurrentIndex()), "Test2" )
+
+			# removing item
+			s.removeIndex( 0 )
+			self.assertEqual ( s.getTotal(), 2 )
 
 	def testInsert( self ) :
 
-		s = GafferUI.SelectionMenu()
+		with warnings.catch_warnings() :
 
-		# adding new items
-		s.addItem( "Test1" )
-		s.addItem( "Test2" )
-		s.addItem( "Test3" )
-		self.assertEqual( s.getTotal(), 3 )
+			warnings.simplefilter( "ignore", DeprecationWarning )
 
-		# insert an item and check it
-		s.insertItem( 1, "Test4")
-		self.assertEqual( s.getItem(1), "Test4" )
+			s = GafferUI.SelectionMenu()
+
+			# adding new items
+			s.addItem( "Test1" )
+			s.addItem( "Test2" )
+			s.addItem( "Test3" )
+			self.assertEqual( s.getTotal(), 3 )
+
+			# insert an item and check it
+			s.insertItem( 1, "Test4")
+			self.assertEqual( s.getItem(1), "Test4" )
 
 	def testCurrentIndexChangedSignal( self ):
 
-		s = GafferUI.SelectionMenu()
+		with warnings.catch_warnings() :
 
-		self.emissions = 0
-		def f( w ) :
-			self.emissions += 1
+			warnings.simplefilter( "ignore", DeprecationWarning )
 
-		c = s.currentIndexChangedSignal().connect(f)
+			s = GafferUI.SelectionMenu()
 
-		s.addItem("Test1")
-		s.addItem("Test2")
+			self.emissions = 0
+			def f( w ) :
+				self.emissions += 1
 
-		self.assertEqual(self.emissions, 1)
+			c = s.currentIndexChangedSignal().connect(f)
+
+			s.addItem("Test1")
+			s.addItem("Test2")
+
+			self.assertEqual(self.emissions, 1)
 
 	def testNoQString( self ) :
 
-		s = GafferUI.SelectionMenu()
-		s.addItem( "Test" )
+		with warnings.catch_warnings() :
 
-		self.assertIsInstance( s.getCurrentItem(), str )
-		self.assertIsInstance( s.getItem( 0 ), str )
+			warnings.simplefilter( "ignore", DeprecationWarning )
+
+			s = GafferUI.SelectionMenu()
+			s.addItem( "Test" )
+
+			self.assertIsInstance( s.getCurrentItem(), str )
+			self.assertIsInstance( s.getItem( 0 ), str )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/WindowTest.py
+++ b/python/GafferUITest/WindowTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import unittest
+import warnings
 import weakref
 import imath
 
@@ -264,14 +265,21 @@ class WindowTest( GafferUITest.TestCase ) :
 
 	def testResizeable( self ) :
 
-		w = GafferUI.Window()
-		self.assertTrue( w.getResizeable() )
+		# The methods we are testing are deprecated, so we must
+		# ignore the deprecation warnings they emit, as otherwise
+		# they would become exceptions.
+		with warnings.catch_warnings() :
 
-		w.setResizeable( False )
-		self.assertFalse( w.getResizeable() )
+			warnings.simplefilter( "ignore", DeprecationWarning )
 
-		w.setResizeable( True )
-		self.assertTrue( w.getResizeable() )
+			w = GafferUI.Window()
+			self.assertTrue( w.getResizeable() )
+
+			w.setResizeable( False )
+			self.assertFalse( w.getResizeable() )
+
+			w.setResizeable( True )
+			self.assertTrue( w.getResizeable() )
 
 	def testPosition( self ) :
 


### PR DESCRIPTION
This was useful in catching problems during the Python 3 compatibility work.