### PR TITLE
Use `py-setproctitle` for setting process name

### DIFF
--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -106,18 +106,22 @@ bool isDebug()
 #endif
 }
 
-// This is documented as being for the use of extension
-// modules, but then isn't declared in the Python headers,
-// so we declare it ourselves.
-extern "C" void Py_GetArgcArgv( int *argc, char ***argv );
+int g_argc = 0;
+char **g_argv = nullptr;
+
+int storeArgcArgv( int argc, char **argv, char **env )
+{
+	g_argc = argc;
+	g_argv = argv;
+	return 0;
+}
 
 void clobberArgv()
 {
-	// Get the original argc/argv that was passed to
-	// `main()`. We will modify this in place.
-	int argc;
-	char **argv;
-	Py_GetArgcArgv( &argc, &argv );
+	if( g_argc < 2 )
+	{
+		return;
+	}
 
 	// A typical command line looks like this :
 	//
@@ -132,15 +136,15 @@ void clobberArgv()
 	// shuffle all the arguments around so that
 	// the `gaffer.py` argument disappears and we
 	// get back to the original.
-	char *end = argv[argc-1] + strlen( argv[argc-1] );
-	strncpy( argv[0], "gaffer", strlen( argv[0] ) );
-	strncpy( argv[1], "", strlen( argv[1] ) );
-	char *emptyString = argv[1];
-	for( int i = 1; i < argc - 1; ++i )
+	char *end = g_argv[g_argc-1] + strlen( g_argv[g_argc-1] );
+	strncpy( g_argv[0], "gaffer", strlen( g_argv[0] ) );
+	strncpy( g_argv[1], "", strlen( g_argv[1] ) );
+	char *emptyString = g_argv[1];
+	for( int i = 1; i < g_argc - 1; ++i )
 	{
-		argv[i] = argv[i+1];
+		g_argv[i] = g_argv[i+1];
 	}
-	argv[argc-1] = emptyString;
+	g_argv[g_argc-1] = emptyString;
 
 	// We've just shuffled the pointers so far, but
 	// in practice the original strings were contiguous
@@ -150,15 +154,15 @@ void clobberArgv()
 	//
 	// Pack everything back down so `ps` sees what it
 	// expects.
-	char *c = argv[0];
-	for( int i = 0; i < argc - 1; ++i )
+	char *c = g_argv[0];
+	for( int i = 0; i < g_argc - 1; ++i )
 	{
-		const size_t l = strlen( argv[i] ) + 1;
-		memmove( c, argv[i], l );
-		argv[i] = c;
+		const size_t l = strlen( g_argv[i] ) + 1;
+		memmove( c, g_argv[i], l );
+		g_argv[i] = c;
 		c += l;
 	}
-	argv[argc-1] = c;
+	g_argv[g_argc-1] = c;
 	memset( c, 0, end - c );
 }
 
@@ -175,6 +179,16 @@ void nameProcess()
 }
 
 } // namespace
+
+// Arrange for `storeArgcArgv()` to be called when our module loads,
+// so we can stash the original values for `argc` and `argv`.
+// In Python 2 we could simply use `Py_GetArgcArgv()` instead, but
+// in Python 3 that gives us a mangled copy which is of no use.
+#if  defined( __APPLE__ )
+__attribute__( ( section( "__DATA,__mod_init_func" ) ) ) decltype( storeArgcArgv ) *g_initArgcArgv = storeArgcArgv;
+#elif defined( __linux__ )
+__attribute__( ( section( ".init_array" ) ) ) decltype( storeArgcArgv ) *g_initArgcArgv = storeArgcArgv;
+#endif
 
 BOOST_PYTHON_MODULE( _Gaffer )
 {


### PR DESCRIPTION
The hacks needed to make this work for all variations of Python and OS are sufficient to warrant the addition of another dependency. See https://github.com/dvarrazzo/py-setproctitle/commit/ee3ef006a0fb1e5611e1e08eb42d9329ca9084f6 for details of the horrors involved in supporting Python 3. The other benefit of this is that `setproctitle` claims to support Windows, which should help in @ericmehl's porting efforts.