### PR TITLE
About : Load dependency information from manifest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
             os: ubuntu-16.04
             buildType: RELEASE
             containerImage: gafferhq/build:1.1.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.3.0/gafferDependencies-1.3.0-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.4.0/gafferDependencies-1.4.0-linux.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -50,7 +50,7 @@ jobs:
             os: ubuntu-16.04
             buildType: DEBUG
             containerImage: gafferhq/build:1.1.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.3.0/gafferDependencies-1.3.0-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.4.0/gafferDependencies-1.4.0-linux.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -60,7 +60,7 @@ jobs:
             os: macos-10.15
             buildType: RELEASE
             containerImage:
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.3.0/gafferDependencies-1.3.0-osx.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.4.0/gafferDependencies-1.4.0-osx.tar.gz
             testRunner: bash -c
             sconsCacheMegabytes: 400
 

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -43,7 +43,7 @@ import hashlib
 # Determine default archive URL.
 
 platform = "osx" if sys.platform == "darwin" else "linux"
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/1.3.0/gafferDependencies-1.3.0-" + platform + ".tar.gz"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/1.4.0/gafferDependencies-1.4.0-" + platform + ".tar.gz"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -35,6 +35,11 @@ Breaking Changes
     - `GafferCortexUI` attributes can no longer be accessed via the `GafferUI` namespace.
 - RecursiveChildIterator : Changed private member data. Source compatibility is maintained.
 
+Build
+-----
+
+- Updated to GafferHQ/dependencies 1.4.0.
+
 0.57.x.x (relative to 0.57.3.0)
 ========
 

--- a/config/installDependencies.sh
+++ b/config/installDependencies.sh
@@ -55,7 +55,7 @@ buildDir=${1:-"build/gaffer-$gafferMilestoneVersion.$gafferMajorVersion.$gafferM
 
 # Get the prebuilt dependencies package and unpack it into the build directory
 
-dependenciesVersion="1.3.0"
+dependenciesVersion="1.4.0"
 dependenciesVersionSuffix=""
 dependenciesFileName="gafferDependencies-$dependenciesVersion-$platform.tar.gz"
 downloadURL="https://github.com/GafferHQ/dependencies/releases/download/$dependenciesVersion$dependenciesVersionSuffix/$dependenciesFileName"

--- a/python/Gaffer/About.py
+++ b/python/Gaffer/About.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import json
 
 class About :
 
@@ -99,145 +100,16 @@ class About :
 	@staticmethod
 	def dependencies() :
 
-		result = [
+		licenseDir = os.path.expandvars( "$GAFFER_ROOT/doc/licenses" )
+		if not os.path.exists( licenseDir ) :
+			# Internal build, not based on GafferHQ/dependencies.
+			return []
 
-			{
-				"name" : "boost",
-				"url" : "http://www.boost.org/",
-				"license" : "$GAFFER_ROOT/doc/licenses/Boost",
-			},
+		with open( os.path.join( licenseDir, "manifest.json" ) ) as f :
+			result = json.load( f )
 
-			{
-				"name" : "cortex",
-				"url" : "https://github.com/ImageEngine/cortex/",
-				"license" : "$GAFFER_ROOT/doc/licenses/Cortex",
-			},
-
-			{
-				"name" : "freetype",
-				"url" : "http://www.freetype.org/",
-				"license" : "$GAFFER_ROOT/doc/licenses/FreeType",
-				"credit" : "Portions of this software are copyright (c) 2009 The FreeType Project (www.freetype.org). All rights reserved."
-			},
-
-			{
-				"name" : "glew",
-				"url" : "http://glew.sourceforge.net/",
-				"license" : "$GAFFER_ROOT/doc/licenses/GLEW",
-			},
-
-			{
-				"name" : "ilmbase",
-				"url" : "http://www.openexr.com/",
-				"license" : "$GAFFER_ROOT/doc/licenses/IlmBase",
-			},
-
-			{
-				"name" : "libjpeg-turbo",
-				"url" : "https://libjpeg-turbo.org/",
-				"license" : "$GAFFER_ROOT/doc/licenses/LibJPEG-Turbo",
-				"credit" : "This software is based in part on the work of the Independent JPEG Group.",
-			},
-
-			{
-				"name" : "libpng",
-				"url" : "http://www.libpng.org/",
-				"license" : "$GAFFER_ROOT/doc/licenses/LibPNG",
-			},
-
-			{
-				"name" : "openexr",
-				"url" : "http://www.openexr.com/",
-				"license" : "$GAFFER_ROOT/doc/licenses/OpenEXR",
-			},
-
-			{
-				"name" : "python",
-				"url" : "http://python.org/",
-				"license" : "$GAFFER_ROOT/doc/licenses/Python",
-			},
-
-			{
-				"name" : "pyopengl",
-				"url" : "http://pyopengl.sourceforge.net/",
-			},
-
-			{
-				"name" : "libtiff",
-				"url" : "http://www.libtiff.org/",
-				"license" : "$GAFFER_ROOT/doc/licenses/LibTIFF",
-			},
-
-			{
-				"name" : "tbb",
-				"url" : "http://threadingbuildingblocks.org/",
-				"license" : "$GAFFER_ROOT/doc/licenses/TBB",
-			},
-
-			{
-				"name" : "OpenColorIO",
-				"url" : "http://opencolorio.org/",
-				"license" : "$GAFFER_ROOT/doc/licenses/OpenColorIO",
-			},
-
-			{
-				"name" : "OpenImageIO",
-				"url" : "http://www.openimageio.org/",
-				"license" : "$GAFFER_ROOT/doc/licenses/OpenImageIO",
-			},
-
-			{
-				"name" : "HDF5",
-				"url" : "http://www.hdfgroup.org/",
-				"license" : "$GAFFER_ROOT/doc/licenses/HDF5",
-			},
-
-			{
-				"name" : "Alembic",
-				"url" : "http://www.alembic.io/",
-				"license" : "$GAFFER_ROOT/doc/licenses/Alembic",
-			},
-
-			{
-				"name" : "OpenShadingLanguage",
-				"url" : "https://github.com/imageworks/OpenShadingLanguage/",
-				"license" : "$GAFFER_ROOT/doc/licenses/OpenShadingLanguage",
-			},
-
-			{
-				"name" : "OpenVDB",
-				"url" : "http://www.openvdb.org//",
-				"license" : "$GAFFER_ROOT/doc/licenses/OpenVDB",
-			},
-
-			{
-				"name" : "USD",
-				"url" : "http://http://graphics.pixar.com/usd",
-				"license" : "$GAFFER_ROOT/doc/licenses/USD",
-			},
-
-			{
-				"name" : "Qt",
-				"url" : "http://qt.nokia.com/",
-				"license" : "$GAFFER_ROOT/doc/licenses/Qt",
-			},
-
-		]
-
-		if os.path.exists( os.environ["GAFFER_ROOT"] + "/python/PyQt4" ) :
-
-			result.append( {
-				"name" : "PyQt",
-				"url" : "http://www.riverbankcomputing.co.uk/",
-				"license" : "$GAFFER_ROOT/doc/licenses/pyQt",
-			} )
-
-		if os.path.exists( os.environ["GAFFER_ROOT"] + "/python/PySide" ) :
-
-			result.append( {
-				"name" : "PySide",
-				"url" : "http://www.pyside.org/",
-				"license" : "$GAFFER_ROOT/doc/licenses/pySide",
-			} )
+		for project in result :
+			if "license" in project :
+				project["license"] = os.path.normpath( os.path.join( licenseDir, project["license"] ) )
 
 		return result


### PR DESCRIPTION
The hardcoded list was always getting out of sync with GafferHQ/dependencies, so now we get the information straight from the horses mouth.
