### PR TITLE
PathBinding : Fix GIL management bugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- Fixed hangs caused by bad GIL management in Path bindings.
 - OSLObject : Fixed bug that could cause string comparisons to fail for strings fetched using the InString shader or `inString()` function.
 - Fixed potential shutdown crashes when custom Metadata or View registrations have been made via Python.
 - Fixed crash when rendering unknown lights in 3Delight.

--- a/include/GafferBindings/PathBinding.inl
+++ b/include/GafferBindings/PathBinding.inl
@@ -50,12 +50,14 @@ namespace Detail
 template<typename T>
 bool isValid( const T &p )
 {
+	IECorePython::ScopedGILRelease gilRelease;
 	return p.T::isValid();
 }
 
 template<typename T>
 bool isLeaf( const T &p )
 {
+	IECorePython::ScopedGILRelease gilRelease;
 	return p.T::isLeaf();
 }
 
@@ -63,7 +65,11 @@ template<typename T>
 boost::python::list propertyNames( const T &p )
 {
 	std::vector<IECore::InternedString> n;
-	p.T::propertyNames( n );
+	{
+		IECorePython::ScopedGILRelease gilRelease;
+		p.T::propertyNames( n );
+	}
+
 	boost::python::list result;
 	for( std::vector<IECore::InternedString>::const_iterator it = n.begin(), eIt = n.end(); it != eIt; ++it )
 	{
@@ -77,7 +83,12 @@ GAFFERBINDINGS_API boost::python::object propertyToPython( IECore::ConstRunTimeT
 template<typename T>
 boost::python::object property( const T &p, const IECore::InternedString &name )
 {
-	return propertyToPython( p.T::property( name ) );
+	IECore::ConstRunTimeTypedPtr property;
+	{
+		IECorePython::ScopedGILRelease gilRelease;
+		property = p.T::property( name );
+	}
+	return propertyToPython( property );
 }
 
 template<typename T>

--- a/python/GafferSceneTest/ScenePathTest.py
+++ b/python/GafferSceneTest/ScenePathTest.py
@@ -36,6 +36,9 @@
 
 import os
 import unittest
+import imath
+
+import IECore
 
 import Gaffer
 import GafferTest
@@ -218,6 +221,50 @@ class ScenePathTest( GafferSceneTest.SceneTestCase ) :
 
 		with self.assertRaisesRegexp( Exception, "Python argument types" ) :
 			GafferScene.ScenePath( plane["out"], None )
+
+	def testGILManagement( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		# Build a contrived scene that will cause `childNames` queries to spawn
+		# a threaded compute that will execute a Python expression.
+
+		script["plane"] = GafferScene.Plane()
+		script["plane"]["divisions"].setValue( imath.V2i( 50 ) )
+
+		script["planeFilter"] = GafferScene.PathFilter()
+		script["planeFilter"]["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		script["sphere"] = GafferScene.Sphere()
+
+		script["instancer"] = GafferScene.Instancer()
+		script["instancer"]["in"].setInput( script["plane"]["out"] )
+		script["instancer"]["prototypes"].setInput( script["sphere"]["out"] )
+		script["instancer"]["filter"].setInput( script["planeFilter"]["out"] )
+
+		script["instanceFilter"] = GafferScene.PathFilter()
+		script["instanceFilter"]["paths"].setValue( IECore.StringVectorData( [ "/plane/instances/*/*" ] ) )
+
+		script["cube"] = GafferScene.Cube()
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["instancer"]["out"] )
+		script["parent"]["children"][0].setInput( script["cube"]["out"] )
+		script["parent"]["filter"].setInput( script["instanceFilter"]["out"] )
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression( 'parent["sphere"]["name"] = context["sphereName"]' )
+
+		# Test that `ScenePath` bindings release the GIL so that the compute
+		# doesn't hang. If we're lucky, the expression executes on the main
+		# thread anyway, so loop to give it plenty of chances to fail.
+
+		for i in range( 0, 100 ) :
+
+			context = Gaffer.Context()
+			context["sphereName"] = "sphere{}".format( i )
+			path = GafferScene.ScenePath( script["parent"]["out"], context, "/plane/instances/{}/2410/cube".format( context["sphereName"] ) )
+			self.assertTrue( path.isValid() )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
The motivation here is to fix hangs caused by `ScenePath.isValid()`, but I've applied the fix to all Path classes and for the `isLeaf()`, `propertyNames()` and `property()` methods as well.
