### PR TITLE
JH config : Get default `PYTHON_VARIANT` from environment

### DIFF
--- a/config/jh/options
+++ b/config/jh/options
@@ -37,7 +37,7 @@
 import os
 import sys
 
-pythonVariant = None
+pythonVariant = os.environ.get( "PYTHON_VARIANT", None )
 for a in sys.argv :
 	if a.startswith( "PYTHON_VARIANT=" ) :
 		pythonVariant = a[15:]


### PR DESCRIPTION
This is just my personal build config. Nothing to see here.
