### PR TITLE
TransformToolUI : Fix blank status message

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.57.x.x (relative to 0.57.4.1)
+========
+
+Fixes
+-----
+
+- TransformTool : Fixed blank status message for certain non-editable selections.
+
 0.57.4.1 (relative to 0.57.4.0)
 ========
 

--- a/python/GafferSceneUI/TransformToolUI.py
+++ b/python/GafferSceneUI/TransformToolUI.py
@@ -168,6 +168,8 @@ class _SelectionWidget( GafferUI.Frame ) :
 
 			editTargets = { s.editTarget() for s in toolSelection if s.editable() }
 			warnings = { s.warning() for s in toolSelection if s.warning() }
+			if not warnings and not self.__tool.selectionEditable() :
+				warnings = { "Selection not editable" }
 
 			# Update info row to show what we're editing
 


### PR DESCRIPTION
This would occur for non-editable transforms such as the one below :

```
import Gaffer
import GafferScene
import IECore
import imath

Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 58, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )

__children = {}

__children["Plane"] = GafferScene.Plane( "Plane" )
parent.addChild( __children["Plane"] )
__children["Plane"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["FreezeTransform"] = GafferScene.FreezeTransform( "FreezeTransform" )
parent.addChild( __children["FreezeTransform"] )
__children["FreezeTransform"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Plane"]["transform"]["translate"].setValue( imath.V3f( -4.37974834, 0, 0 ) )
__children["Plane"]["__uiPosition"].setValue( imath.V2f( -7.25, 6.3499999 ) )
__children["FreezeTransform"]["in"].setInput( __children["Plane"]["out"] )
__children["FreezeTransform"]["__uiPosition"].setValue( imath.V2f( -7.25, -1.8140626 ) )

del __children
```
