### PR TITLE
MultiLineTextWidget : Fix `selectedText()` return type in Python 3

### DIFF
--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -185,7 +185,10 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 
 		cursor = self._qtWidget().textCursor()
 		text = cursor.selection().toPlainText()
-		return text.encode( "utf-8" )
+		if six.PY3 :
+			return text
+		else :
+			return text.encode( "utf-8" )
 
 	def linkAt( self, position ) :
 


### PR DESCRIPTION
We now return `str` (unicode), as we do in `getText()`. This fixes the execution of selected text in the PythonEditor (and no doubt other things too).