### PR TITLE
Dispatcher : Fix bug handling multiple connected Switches/ContextProcessors

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.56.2.x (relative to 0.56.2.3)
+========
+
+Fixes
+-----
+
+- Dispatcher : Fixed dispatch of two or more Switches or ContextProcessors connected together directly.
+
 0.56.2.3 (relative to 0.56.2.2)
 ========
 

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -1720,6 +1720,40 @@ class DispatcherTest( GafferTest.TestCase ) :
 		self.assertEqual( len( s["n2"].log ), 1 )
 		self.assertEqual( len( s["n3"].log ), 2 )
 
+	def testTwoNameSwitches( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n1"] = GafferDispatchTest.LoggingTaskNode()
+		s["n2"] = GafferDispatchTest.LoggingTaskNode()
+		s["n3"] = GafferDispatchTest.LoggingTaskNode()
+
+		s["switch1"] = Gaffer.NameSwitch()
+		s["switch1"].setup( s["n1"]["task"] )
+		s["switch1"]["in"][0]["value"].setInput( s["n1"]["task"] )
+		s["switch1"]["in"][1]["value"].setInput( s["n2"]["task"] )
+		s["switch1"]["in"][1]["name"].setValue( "n2" )
+
+		s["switch2"] = Gaffer.NameSwitch()
+		s["switch2"].setup( s["n1"]["task"] )
+		s["switch2"]["in"][0]["value"].setInput( s["switch1"]["out"]["value"] )
+		s["switch2"]["in"][1]["value"].setInput( s["n3"]["task"] )
+		s["switch2"]["in"][1]["name"].setValue( "n3" )
+
+		s["n4"] = GafferDispatchTest.LoggingTaskNode()
+		s["n4"]["preTasks"][0].setInput( s["switch2"]["out"]["value"] )
+
+		dispatcher = GafferDispatch.Dispatcher.create( "testDispatcher" )
+
+		s["switch1"]["selector"].setValue( "n2" )
+
+		dispatcher.dispatch( [ s["n4"] ] )
+
+		self.assertEqual( len( s["n1"].log ), 0 )
+		self.assertEqual( len( s["n2"].log ), 1 )
+		self.assertEqual( len( s["n3"].log ), 0 )
+		self.assertEqual( len( s["n4"].log ), 1 )
+
 	def testContextProcessor( self ) :
 
 		s = Gaffer.ScriptNode()
@@ -1743,6 +1777,38 @@ class DispatcherTest( GafferTest.TestCase ) :
 		self.assertNotIn( "test", s["n2"].log[0].context )
 		self.assertIn( "test", s["n1"].log[0].context )
 		self.assertEqual( s["n1"].log[0].context["test"], 10 )
+
+	def testTwoContextProcessors( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n1"] = GafferDispatchTest.LoggingTaskNode()
+
+		s["cv1"] = Gaffer.ContextVariables()
+		s["cv1"].setup( s["n1"]["task"] )
+		s["cv1"]["in"].setInput( s["n1"]["task"] )
+		s["cv1"]["variables"].addChild( Gaffer.NameValuePlug( "test1", 10 ) )
+
+		s["cv2"] = Gaffer.ContextVariables()
+		s["cv2"].setup( s["n1"]["task"] )
+		s["cv2"]["in"].setInput( s["cv1"]["out"] )
+		s["cv2"]["variables"].addChild( Gaffer.NameValuePlug( "test2", 20 ) )
+
+		s["n2"] = GafferDispatchTest.LoggingTaskNode()
+		s["n2"]["preTasks"][0].setInput( s["cv2"]["out"] )
+
+		dispatcher = GafferDispatch.Dispatcher.create( "testDispatcher" )
+		dispatcher.dispatch( [ s["n2"] ] )
+
+		self.assertEqual( len( s["n1"].log ), 1 )
+		self.assertEqual( len( s["n2"].log ), 1 )
+
+		self.assertNotIn( "test1", s["n2"].log[0].context )
+		self.assertNotIn( "test2", s["n2"].log[0].context )
+		self.assertIn( "test1", s["n1"].log[0].context )
+		self.assertIn( "test2", s["n1"].log[0].context )
+		self.assertEqual( s["n1"].log[0].context["test1"], 10 )
+		self.assertEqual( s["n1"].log[0].context["test2"], 20 )
 
 	def testTaskPlugsWithoutTaskNodes( self ) :
 


### PR DESCRIPTION
Refactored the special handling for these nodes into a separate function, which uses recursion to deal with multiple connected instances in a row.

We don't really have a standard policy for how to return multiple values from one function, so I've experimented with `std::tuple()`. This is nice in that it'd map to Python naturally, where output parameters often don't make sense. The `tie()` stuff at the call site is a bit faffy, but becomes unnecessary when we finally make it to `C++17`, where you can do `auto [ source, context ] = computedSource()` instead. It's potentially confusing not giving names to the types, as a struct would, but in this case the types are distinct enough for it not to matter. Structs may still be the clearest in some ways, but they introduce a lot of namespace pollution with small types all over the place, and they're more faff for binding into Python. The jury is out...
