### PR TITLE
InteractiveRender : Add message log

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
 - OSLObject/ClosestPointSampler/CurveSampler : Improved performance for cases where multiple downstream computes require the same upstream object.
 - Stats app : Added `-location` argument, to allow profiling of a single location in a scene.
 - AnimationEditor : Improved performance.
+- MessageWidget : Added alternate presentation options allowing log-style message display, search, etc.
 
 Fixes
 -----
@@ -61,6 +62,7 @@ Breaking Changes
 - ObjectProcessor : Added a virtual method.
 - PlugValueWidget : Removed connections to `plugFlagsChangedSignal()`. In the unlikely event that a derived class depends on plug flags, it must now manage the updates itself.
 - InteractiveRender : Changed base class from Node to ComputeNode, added members.
+- MessageWidget : Removed deprecated `appendMessage` method, use `messageHandler().handle()` instead.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -74,6 +74,7 @@ Fixes
 
 - NodeEditor : Fixed hangs when switching to "Follow Scene Selection" mode.
 - SourceSet : Fixed GIL management bug in constructor binding.
+- StyleSheet : Fixed monospace font stack.
 
 0.57.4.0 (relative to 0.57.3.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ API
 - InteractiveRender :
   - Changed base to `Gaffer::ComputeNode` (#3419).
   - Added messages plug containing the output of the node's renderer output (#3419).
+- Graphics : Renamed `errorNotificationSmall` icon to `errorSmall`.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -62,6 +62,11 @@ Breaking Changes
 - PlugValueWidget : Removed connections to `plugFlagsChangedSignal()`. In the unlikely event that a derived class depends on plug flags, it must now manage the updates itself.
 - InteractiveRender : Changed base class from Node to ComputeNode, added members.
 
+Fixes
+-----
+
+- GafferUI : Fixed lingering highlight state if a Button was disabled whilst the cursor was over it.
+
 Build
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -29,6 +29,7 @@ API
   - Changed base to `Gaffer::ComputeNode` (#3419).
   - Added messages plug containing the output of the node's renderer output (#3419).
 - Graphics : Renamed `errorNotificationSmall` icon to `errorSmall`.
+- NotificationMessageHandler : Constructor now accepts `GafferUI.MessageWidget` constructor kwargs to configure the widget.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.58.x.x
 ========
 
+Features
+--------
+
+- InteractiveRender : Added message log to the node's UI, displaying output from the last render (#3419).
+
 Improvements
 ------------
 

--- a/Changes.md
+++ b/Changes.md
@@ -24,6 +24,9 @@ API
   - Deprecated `hashOfTransformedChildBounds()`. Use `ScenePlug::childBoundsHash()` instead.
   - Deprecated `unionOfTransformedChildBounds()`. Use `ScenePlug::childBounds()` instead.
 - IECorePreview::Renderer : Added optional message handler to renderer construction to allow output message streams to be re-directed if required (#3419).
+- InteractiveRender :
+  - Changed base to `Gaffer::ComputeNode` (#3419).
+  - Added messages plug containing the output of the node's renderer output (#3419).
 
 Breaking Changes
 ----------------
@@ -56,6 +59,7 @@ Breaking Changes
 - IECorePreview::Renderer : Changed signature for `create` and `registerType` to include optional message handler.
 - ObjectProcessor : Added a virtual method.
 - PlugValueWidget : Removed connections to `plugFlagsChangedSignal()`. In the unlikely event that a derived class depends on plug flags, it must now manage the updates itself.
+- InteractiveRender : Changed base class from Node to ComputeNode, added members.
 
 Build
 -----

--- a/include/Gaffer/Private/IECorePreview/Messages.h
+++ b/include/Gaffer/Private/IECorePreview/Messages.h
@@ -1,0 +1,139 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Cinesite VFX Ltd. nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREPREVIEW_MESSAGES_H
+#define IECOREPREVIEW_MESSAGES_H
+
+#include "Gaffer/Export.h"
+
+#include "IECore/MessageHandler.h"
+#include "IECore/MurmurHash.h"
+
+#include <boost/optional.hpp>
+
+#include <array>
+#include <vector>
+
+namespace IECorePreview
+{
+
+struct GAFFER_API Message
+{
+	Message( IECore::MessageHandler::Level l, const std::string &c, const std::string &m )
+		:	level( l ), context( c ), message( m )
+	{}
+
+	IECore::MessageHandler::Level level;
+	std::string context;
+	std::string message;
+
+	void hash( IECore::MurmurHash &h ) const;
+
+	bool operator == ( const Message &other ) const;
+	bool operator != ( const Message &other ) const;
+};
+
+/// Messages provides a cheap-to-copy container for messages as passed by the
+/// IECore::MessageHandler. Once added, messages are immutable. Messages are stored
+/// in such a way that copying an instance of the Messages container with a large
+/// number of messages is orders of magnitude cheaper than copying the same
+/// number of messages directly.
+///
+class GAFFER_API Messages
+{
+	public :
+
+		Messages();
+		Messages( const Messages &other ) = default;
+		Messages &operator = ( const Messages &other ) = default;
+
+		/// Equality implies all messages in the container are the same.
+		bool operator == ( const Messages &other ) const;
+		bool operator != ( const Messages &other ) const;
+
+		void add( const Message &message );
+		void clear();
+
+		size_t size() const;
+
+		const Message& operator[]( size_t index ) const;
+
+		/// The number of messages of a specific severity
+		/// Messages are counted when they are added, so this is cheap.
+		size_t count( const IECore::MessageHandler::Level &level ) const;
+
+		/// The index of the first message that differs to the messages in
+		/// the other container. boost::none is returned if:
+		///  - This container is empty.
+		///  - This containers messages match those in others, and others
+		///    is of equal or greater size.
+		boost::optional<size_t> firstDifference( const Messages &others ) const;
+
+		/// The hash of all messages in the container.  Messages are hashed
+		/// when they are added, so this is cheap.
+		IECore::MurmurHash hash() const;
+
+	private :
+
+		// \todo The current implementation is naive and is sensitive to
+		// bucketSize .vs. ingest/copy rate and total number of messages.
+		//
+		// Messages are stored in const buckets whose size is determined by the
+		// m_bucketSize. Each bucket of messages is shared between all copies
+		// of the container, so the copy cost is that of the pointers to the
+		// full buckets themselves, rather than any of the messages. Only `size
+		// % m_bucketSize` messages from the 'next' bucket are ever directly
+		// copied.
+		//
+		// As such there is a trade-off between the expected number of
+		// messages, and the rate of ingest .vs. copies. If the bucketSize is
+		// much smaller than the total number of messages, then the cost of
+		// copying the bucket list can become significant. If the bucket size
+		// is too large, then the cost of copying messages for the next bucket
+		// may be significant. There is much scope for improvement here.
+		//
+		size_t m_bucketSize;
+		using Bucket = std::vector<Message>;
+
+		Bucket m_nextBucket;
+		std::vector<std::shared_ptr<const Bucket>> m_buckets;
+
+		std::array<size_t, int(IECore::MessageHandler::Level::Invalid)> m_counts;
+
+		IECore::MurmurHash m_hash;
+};
+
+} // IECorePreview
+
+#endif // IECOREPREVIEW_MESSAGES_H

--- a/include/Gaffer/Private/IECorePreview/MessagesData.h
+++ b/include/Gaffer/Private/IECorePreview/MessagesData.h
@@ -1,0 +1,58 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Cinesite VFX Ltd. nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREPREVIEW_MESSAGESDATA_H
+#define IECOREPREVIEW_MESSAGESDATA_H
+
+#include "Gaffer/Private/IECorePreview/Messages.h"
+
+#include "IECore/TypedData.h"
+
+namespace IECore
+{
+
+IECORE_DECLARE_TYPEDDATA( MessagesData, IECorePreview::Messages, void, IECore::SharedDataHolder );
+
+} // namespace IECore
+
+namespace IECorePreview
+{
+
+typedef IECore::MessagesData MessagesData;
+IE_CORE_DECLAREPTR( MessagesData );
+
+} // namespace IECorePreview
+
+
+#endif // IECOREPREVIEW_MESSAGESDATA_H

--- a/include/Gaffer/TypeIds.h
+++ b/include/Gaffer/TypeIds.h
@@ -138,6 +138,7 @@ enum TypeId
 	ShufflePlugTypeId = 110091,
 	ShufflesPlugTypeId = 110092,
 	EditScopeTypeId = 110093,
+	MessagesDataTypeId = 110094,
 
 	LastTypeId = 110159,
 

--- a/python/GafferAppleseedTest/InteractiveAppleseedRenderTest.py
+++ b/python/GafferAppleseedTest/InteractiveAppleseedRenderTest.py
@@ -89,6 +89,22 @@ class InteractiveAppleseedRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		self.assertTrue( False )
 
+	def testMessages( self ) :
+
+		p = GafferScene.Plane()
+		i = GafferAppleseed.InteractiveAppleseedRender()
+
+		i["in"].setInput( p["out"] )
+
+		self.assertEqual( i["messages"].getValue().value.size(), 0 )
+
+		with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as handler :
+			i["state"].setValue( GafferScene.InteractiveRender.State.Running )
+			handler.waitFor( 1 )
+			i["state"].setValue( GafferScene.InteractiveRender.State.Stopped )
+
+		self.assertGreater( i["messages"].getValue().value.size(), 0 )
+
 	def _createInteractiveRender( self ) :
 
 		return GafferAppleseed.InteractiveAppleseedRender()

--- a/python/GafferDispatchUI/LocalDispatcherUI.py
+++ b/python/GafferDispatchUI/LocalDispatcherUI.py
@@ -315,7 +315,7 @@ class _LocalJobsWindow( GafferUI.Window ) :
 			return
 
 		for m in jobs[0].messageHandler().messages :
-			self.__messageWidget.appendMessage( m.level, m.context, m.message )
+			self.__messageWidget.messageHandler().handle( m.level, m.context, m.message )
 
 	def __killClicked( self, button ) :
 

--- a/python/GafferDispatchUI/LocalDispatcherUI.py
+++ b/python/GafferDispatchUI/LocalDispatcherUI.py
@@ -240,7 +240,8 @@ class _LocalJobsWindow( GafferUI.Window ) :
 								self.__detailsDirectory.setTextSelectable( True )
 
 					with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing=10, borderWidth=10, parenting = { "label"  : "Messages" } ) as self.__messagesTab :
-						self.__messageWidget = GafferUI.MessageWidget()
+						self.__messageWidget = GafferUI.MessageWidget( toolbars = True, follow = True )
+						self.__messageWidget._qtWidget().setMinimumHeight( 150 )
 
 				self.__tabs.currentChangedSignal().connect( Gaffer.WeakMethod( self.__tabChanged ), scoped = False )
 

--- a/python/GafferSceneUI/CropWindowToolUI.py
+++ b/python/GafferSceneUI/CropWindowToolUI.py
@@ -88,7 +88,7 @@ class _StatusWidget( GafferUI.Frame ) :
 		with self :
 			with GafferUI.ListContainer( orientation = GafferUI.ListContainer.Orientation.Horizontal ) as self.__row :
 				self.__infoIcon = GafferUI.Image( "infoSmall.png" )
-				self.__errorIcon = GafferUI.Image( "errorNotificationSmall.png" )
+				self.__errorIcon = GafferUI.Image( "errorSmall.png" )
 				self.__warningIcon = GafferUI.Image( "warningSmall.png" )
 				GafferUI.Spacer( size = imath.V2i( 4 ), maximumSize = imath.V2i( 4 ) )
 				self.__label = GafferUI.Label( "" )

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -283,6 +283,17 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"messages" : [
+
+			"description",
+			"""
+			Messages from the render process.
+			""",
+
+			"plugValueWidget:type", "",
+
+		],
+
 		"out" : [
 
 			"description",

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -230,6 +230,41 @@ class _StatePlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.getPlug().setValue( GafferScene.InteractiveRender.State.Stopped )
 
 ##########################################################################
+# UI for the messages plug that presents the render log
+##########################################################################
+
+class _MessagesPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug, **kwargs ) :
+
+		self.__messages = GafferUI.MessageWidget(
+			toolbars = True,
+			follow = True,
+			role = GafferUI.MessageWidget.Role.Log
+		)
+
+		GafferUI.PlugValueWidget.__init__( self, self.__messages, plug, **kwargs )
+
+		self._updateFromPlug()
+
+	def hasLabel( self ) :
+
+		return True
+
+	def getToolTip( self ) :
+
+		# Suppress the default messages tool-tip that otherwise appears all over the log window.
+		return None
+
+	@GafferUI.LazyMethod( deferUntilPlaybackStops = True )
+	def _updateFromPlug( self, *unused ) :
+
+		with self.getContext() :
+			messages = self.getPlug().getValue().value
+
+		self.__messages.setMessages( messages )
+
+##########################################################################
 # Metadata for InteractiveRender node.
 ##########################################################################
 
@@ -242,6 +277,8 @@ Gaffer.Metadata.registerNode(
 	Performs interactive renders, updating the render on the fly
 	whenever the input scene changes.
 	""",
+
+	"layout:section:Settings.Log:collapsed", False,
 
 	plugs = {
 
@@ -290,7 +327,9 @@ Gaffer.Metadata.registerNode(
 			Messages from the render process.
 			""",
 
-			"plugValueWidget:type", "",
+			"label", "Messages",
+			"plugValueWidget:type", "GafferSceneUI.InteractiveRenderUI._MessagesPlugValueWidget",
+			"layout:section", "Settings.Log"
 
 		],
 

--- a/python/GafferTest/GraphComponentTest.py
+++ b/python/GafferTest/GraphComponentTest.py
@@ -730,6 +730,7 @@ class GraphComponentTest( GafferTest.TestCase ) :
 				"GafferDispatch::TaskSwitch",
 				"GafferDispatch::Wedge",
 				"GafferDispatch::FrameMask",
+				"IECorePreview::MessagesData"
 			] )
 		)
 		self.assertTypeNamesArePrefixed( GafferTest )

--- a/python/GafferTest/IECorePreviewTest/MessagesTest.py
+++ b/python/GafferTest/IECorePreviewTest/MessagesTest.py
@@ -1,0 +1,412 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferTest
+
+import IECore
+
+from Gaffer.Private.IECorePreview import Message
+from Gaffer.Private.IECorePreview import Messages
+from Gaffer.Private.IECorePreview import MessagesData
+
+class MessagesTest( GafferTest.TestCase ) :
+
+	def testMessage( self ) :
+
+		m = Message( IECore.MessageHandler.Level.Debug, "context", "message" )
+
+		self.assertEqual( m.level, IECore.MessageHandler.Level.Debug )
+		self.assertEqual( m.context, "context" )
+		self.assertEqual( m.message, "message" )
+
+		with self.assertRaises( AttributeError ) :
+			m.level = IECore.MessageHandler.Level.Info
+		with self.assertRaises( AttributeError ) :
+			m.context = ""
+		with self.assertRaises( AttributeError ) :
+			m.message = ""
+
+	def testData( self ) :
+
+		m1 = Messages()
+		m1d = MessagesData( m1 )
+		self.assertEqual( repr(m1d), "Gaffer.Private.IECorePreview.MessagesData()" )
+
+		m2d = m1d.copy()
+		m2 = m2d.value
+		m2.add( Message( IECore.MessageHandler.Level.Info, "testData", "message" ) )
+
+		self.assertEqual( m1.size(), 0 )
+		self.assertEqual( m2.size(), 1 )
+
+		with self.assertRaises( IECore.Exception ) :
+			repr(m2d)
+
+	def testMessageEquality( self ) :
+
+		m1  = Message( IECore.MessageHandler.Level.Debug, "context", "message" )
+		m2  = Message( IECore.MessageHandler.Level.Debug, "context", "message" )
+		m3  = Message( IECore.MessageHandler.Level.Info, "context", "message" )
+		m4  = Message( IECore.MessageHandler.Level.Debug, "context2", "message" )
+		m5  = Message( IECore.MessageHandler.Level.Debug, "context", "message2" )
+
+		self.assertEqual( m1, m2 )
+		self.assertNotEqual( m1, m3 )
+		self.assertTrue( m1 == m2 )
+		self.assertTrue( m1 != m3 )
+
+	def testMessageHash( self ) :
+
+		h = IECore.MurmurHash()
+
+		h1 = IECore.MurmurHash()
+		m1 = Message( IECore.MessageHandler.Level.Debug, "context", "message" )
+		m1.hash( h1 )
+
+		h2 = IECore.MurmurHash()
+		m2 = Message( IECore.MessageHandler.Level.Info, "context", "message" )
+		m2.hash( h2 )
+
+		h3 = IECore.MurmurHash()
+		m3 = Message( IECore.MessageHandler.Level.Debug, "", "message" )
+		m3.hash( h3 )
+
+		h4 = IECore.MurmurHash()
+		m4 = Message( IECore.MessageHandler.Level.Debug, "context", "" )
+		m4.hash( h4 )
+
+		# Check hashes are unique
+		hashes = [ h, h1, h2, h3, h4 ]
+		self.assertEqual( len(set(hashes)), len(hashes) )
+
+		# Check are stable
+		h4b = IECore.MurmurHash()
+		m4.hash( h4b )
+		self.assertEqual( h4b, h4 )
+
+		h5 = IECore.MurmurHash()
+		m5 = Message( IECore.MessageHandler.Level.Debug, "context", "" )
+		m5.hash( h5 )
+
+		self.assertEqual( h4, h5 )
+
+		# Test python hashing
+
+		allMessages = [ m1, m2, m3, m4, m5 ]
+		differentMsgs = [ m1, m2, m3, m4 ]
+
+		self.assertEqual( len(set(allMessages)), len(differentMsgs) )
+
+	def testMessages( self ) :
+
+		m = Messages()
+		self.assertEqual( m.size(), 0 )
+		self.assertEqual( len(m), 0 )
+
+		Level = IECore.MessageHandler.Level
+
+		for l in ( Level.Error, Level.Warning, Level.Info, Level.Debug ) :
+			self.assertEqual( m.count( l ), 0 )
+
+		for i in range( 20 ) :
+			m.add( Message( IECore.MessageHandler.Level( i % 4 ), "testMessages", str(i) ) )
+			self.assertEqual( m.size(), i + 1 )
+
+		self.assertEqual( len(m), m.size() )
+
+		for i in range( 20 ) :
+			self.assertEqual( m[i].level, IECore.MessageHandler.Level( i % 4 ) )
+			self.assertEqual( m[i].context, "testMessages" )
+			self.assertEqual( m[i].message, str(i) )
+
+		m.clear()
+
+		self.assertEqual( m.size(), 0 )
+
+	def testIndexing( self ) :
+
+		messages = (
+			Message( IECore.MessageHandler.Level.Debug, "testIndexing", "message1" ),
+			Message( IECore.MessageHandler.Level.Info, "testIndexing", "message2" ),
+			Message( IECore.MessageHandler.Level.Warning, "testIndexing", "message3" ),
+			Message( IECore.MessageHandler.Level.Error, "testIndexing", "message4" )
+		)
+
+		m = Messages()
+
+		for msg in messages :
+			m.add( msg )
+
+		for i in range( len(messages) ) :
+			self.assertEqual( m[i], messages[i] )
+			if i > 0 :
+				self.assertEqual( m[-i], messages[-i] )
+
+		with self.assertRaises( IndexError ) :
+			m[ len(m) ]
+
+		with self.assertRaises( IndexError ) :
+			m[ - ( len(m) + 1 ) ]
+
+	def testMessagesCopy( self ) :
+
+		m1 = Messages()
+		for i in range( 11 ) :
+			m1.add( Message( IECore.MessageHandler.Level( i % 4 ), "testMessagesCopy", str(i)  ) )
+
+		m2 = m1
+		m3 = Messages( m1 )
+
+		self.assertEqual( m1, m2 )
+		self.assertEqual( m1, m3 )
+		self.assertEqual( m2, m3 )
+
+		# Check copies are de-coupled
+
+		m2.add( Message( IECore.MessageHandler.Level.Info, "testMessagesCopy", "message"  ) )
+
+		self.assertEqual( m1, m2 )
+		self.assertNotEqual( m2, m3 )
+
+		m3.add( Message( IECore.MessageHandler.Level.Error, "testMessagesCopy", "message"  ) )
+
+		self.assertEqual( m1, m2 )
+		self.assertNotEqual( m2, m3 )
+
+	def testMessagesEquality( self ) :
+
+		messages = [
+			Message( IECore.MessageHandler.Level( i % 4 ), "testMessagesEquality", str(i) )
+			for i in range( 10 )
+		]
+
+		m1 = Messages()
+		m2 = Messages()
+
+		for msg in messages :
+			m1.add( msg )
+			m2.add( msg )
+
+		self.assertEqual( m1, m2 )
+		self.assertFalse( m1 != m2 )
+
+		m1.clear()
+
+		self.assertNotEqual( m1, m2 )
+		self.assertTrue( m1 != m2 )
+
+	def testMessagesHash( self ) :
+
+		m1 = Messages()
+		h = m1.hash()
+
+		lastHash = h
+		for i in range( 10 ) :
+			m1.add( Message( IECore.MessageHandler.Level.Debug, "testMessagesHash", "" ) )
+			newHash = m1.hash()
+			self.assertNotEqual( newHash, lastHash )
+			lastHash = newHash
+
+		# check stable
+		self.assertEqual( m1.hash(), lastHash )
+
+		m2 = Messages( m1 )
+		self.assertEqual( m2.hash(), m1.hash() )
+
+		m3 = Messages()
+		for i in range( 10 ) :
+			m3.add( Message( IECore.MessageHandler.Level.Debug, "testMessagesHash", "" ) )
+
+		self.assertEqual( len(set( ( m1, m2, m3 ) ) ), 1 )
+
+		m1.clear()
+		self.assertEqual( m1.hash(), h )
+		self.assertNotEqual( m1.hash(), m2.hash() )
+
+	def testMessagesCount( self ) :
+
+		Level = IECore.MessageHandler.Level
+		messageCounts = ( ( Level.Error, 1 ), ( Level.Warning, 2 ), ( Level.Info, 3 ), ( Level.Debug, 4 ) )
+
+		m = Messages()
+
+		self.assertEqual( { m.count(l) for l, c in messageCounts }, { 0 } )
+		self.assertEqual( m.count( Level.Invalid ), 0 )
+
+		for level, count in messageCounts :
+			for i in range( count ) :
+				m.add( Message( level, "testMessagesCount", "Message %d" % i ) )
+
+		self.assertEqual( [ m.count(l) for l, c in messageCounts ], [ c for l, c in messageCounts ] )
+
+		m.clear()
+
+		self.assertEqual( { m.count(l) for l, c in messageCounts }, { 0 } )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testFirstDifference( self ) :
+
+		def generateMessages( count, context ) :
+			m = Messages()
+			appendMessages( m, count, context )
+			return m
+
+		def appendMessages( messages, count, context ) :
+			for i in range( count ) :
+				messages.add( Message( IECore.MessageHandler.Level( i % 4 ), context, "message %d" % i ) )
+
+		# NB, bucketSize is 100 in the current implementation, we need to
+		# definitely verify the results of this method in multi-bucket
+		# scenarios, along with incomplete buckets.
+
+		# Test one empty
+
+		m1 = Messages()
+		m2 = generateMessages( 10, "m" )
+
+		self.assertIsNone( m1.firstDifference( m2 ) )
+		self.assertEqual( m2.firstDifference( m1 ), 0 )
+
+		# Test equal
+
+		m1 = generateMessages( 1234, "m" )
+		m2 = Messages( m1 )
+
+		self.assertIsNone( m1.firstDifference( m2 ) )
+		self.assertIsNone( m2.firstDifference( m1 ) )
+
+		# Test all different
+
+		m1 = generateMessages( 1234, "a" )
+		m2 = generateMessages( 1234, "b" )
+
+		self.assertEqual( m1.firstDifference( m2 ), 0 )
+		self.assertEqual( m2.firstDifference( m1 ), 0 )
+
+		# Test varying length
+
+		m1 = generateMessages( 1102, "a" )
+		m2 = Messages( m1 )
+		appendMessages( m2, 100, "a" )
+
+		self.assertIsNone( m1.firstDifference( m2 ) )
+		self.assertEqual( m2.firstDifference( m1 ), 1102 )
+
+		# Test some different
+
+		m1 = generateMessages( 47, "a" )
+		m2 = Messages( m1 )
+		appendMessages( m1, 2, "a" )
+		appendMessages( m2, 2, "b" )
+
+		self.assertEqual( m1.firstDifference( m2 ), 47 )
+		self.assertEqual( m2.firstDifference( m1 ), 47 )
+
+		m1 = generateMessages( 1030, "a" )
+		m2 = Messages( m1 )
+		appendMessages( m1, 300, "b" )
+		appendMessages( m2, 302, "a" )
+
+		self.assertEqual( m1.firstDifference( m2 ), 1030 )
+		self.assertEqual( m2.firstDifference( m1 ), 1030 )
+
+		# Test comparison optimisation
+
+		m1 = generateMessages( 30005, "a" )
+		m2 = Messages( m1 )
+		appendMessages( m1, 1, "a" )
+		appendMessages( m2, 1, "b" )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			self.assertEqual( m1.firstDifference( m2 ), 30005 )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testMessagesCopyPerformanceS( self ) :
+
+		numMessages = 5000
+		numCopies = 100000
+
+		m = Messages()
+		for i in range( numMessages ) :
+			m.add( Message( IECore.MessageHandler.Level( i % 4 ), "testMessagesCopyPerformanceS", str(i) ) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferTest.testMessagesCopyPerformance( m, numCopies )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testMessagesCopyPerformanceM( self ) :
+
+		numMessages = 50000
+		numCopies = 100000
+
+		m = Messages()
+		for i in range( numMessages ) :
+			m.add( Message( IECore.MessageHandler.Level( i % 4 ), "testMessagesCopyPerformanceM", str(i) ) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferTest.testMessagesCopyPerformance( m, numCopies )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testMessagesCopyPerformanceL( self ) :
+
+		numMessages = 500000
+		numCopies = 1000
+
+		m = Messages()
+		for i in range( numMessages ) :
+			m.add( Message( IECore.MessageHandler.Level( i % 4 ), "testMessagesCopyPerformanceL", str(i) ) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferTest.testMessagesCopyPerformance( m, numCopies )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testMessagesAddPerformance( self ) :
+
+		GafferTest.testMessagesAddPerformance( 1000000 )
+
+	def testMessagesValueReuse( self ):
+
+		GafferTest.testMessagesValueReuse()
+
+	def testMessagesConstness( self ) :
+
+		GafferTest.testMessagesConstness()
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/IECorePreviewTest/__init__.py
+++ b/python/GafferTest/IECorePreviewTest/__init__.py
@@ -36,6 +36,7 @@
 
 from .LRUCacheTest import LRUCacheTest
 from .TaskMutexTest import TaskMutexTest
+from .MessagesTest import MessagesTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferUI/Button.py
+++ b/python/GafferUI/Button.py
@@ -146,17 +146,10 @@ class Button( GafferUI.Widget ) :
 			self._qtWidget().setIcon( QtGui.QIcon() )
 			return
 
-		if not self.getHighlighted() :
-			pixmap = self.__image._qtPixmap()
-		else :
-			pixmap = self.__image._qtPixmapHighlighted()
-
 		# Qt's built-in disabled state generation doesn't work well with dark schemes
-		icon = QtGui.QIcon( pixmap )
-		icon.addPixmap( self.__image._qtPixmapDisabled(), QtGui.QIcon.Disabled )
-
+		icon = self.__image._qtIcon( highlighted = self.getHighlighted() )
 		self._qtWidget().setIcon( icon )
-		self._qtWidget().setIconSize( pixmap.size() )
+		self._qtWidget().setIconSize( self.__image._qtPixmap().size() )
 
 	def __enter( self, widget ) :
 

--- a/python/GafferUI/Button.py
+++ b/python/GafferUI/Button.py
@@ -52,6 +52,8 @@ class Button( GafferUI.Widget ) :
 
 		GafferUI.Widget.__init__( self, QtWidgets.QPushButton(), **kw )
 
+		self.__highlightForHover = False
+
 		self._qtWidget().setAttribute( QtCore.Qt.WA_LayoutUsesWidgetRect )
 		# allow return and enter keys to click button
 		self._qtWidget().setAutoDefault( True )
@@ -123,6 +125,16 @@ class Button( GafferUI.Widget ) :
 
 		return self._qtWidget().property( "gafferWithFrame" )
 
+	def setEnabled( self, enabled ) :
+
+		# Once we're disabled, mouse leave events will be skipped, and we'll
+		# remain in a highlighted state once re-enabled.
+		if not enabled and self.__highlightForHover :
+			self.__highlightForHover = False
+			self.__updateIcon()
+
+		GafferUI.Widget.setEnabled( self, enabled )
+
 	def clickedSignal( self ) :
 
 		return self.__clickedSignal
@@ -147,14 +159,18 @@ class Button( GafferUI.Widget ) :
 			return
 
 		# Qt's built-in disabled state generation doesn't work well with dark schemes
-		icon = self.__image._qtIcon( highlighted = self.getHighlighted() )
+		# There is no built-in support for QtGui.QIcon.Active in the default
+		# painter, which is why we have to juggle it here.
+		icon = self.__image._qtIcon( highlighted = self.getHighlighted() or self.__highlightForHover )
 		self._qtWidget().setIcon( icon )
 		self._qtWidget().setIconSize( self.__image._qtPixmap().size() )
 
 	def __enter( self, widget ) :
 
-		self.setHighlighted( True )
+		self.__highlightForHover = True
+		self.__updateIcon()
 
 	def __leave( self, widget ) :
 
-		self.setHighlighted( False )
+		self.__highlightForHover = False
+		self.__updateIcon()

--- a/python/GafferUI/Image.py
+++ b/python/GafferUI/Image.py
@@ -154,6 +154,14 @@ class Image( GafferUI.Widget ) :
 
 		return self.__pixmapDisabled
 
+	# Qt's built-in disabled state generation doesn't work well with dark schemes.
+	# This convenience method provides a QIcon, preconfigured with our own disabled pixmap rendering.
+	def _qtIcon( self, highlighted = False ) :
+
+		icon = QtGui.QIcon( self._qtPixmapHighlighted() if highlighted else self._qtPixmap() )
+		icon.addPixmap( self._qtPixmapDisabled(), QtGui.QIcon.Disabled )
+		return icon
+
 	@staticmethod
 	def _qtPixmapFromImagePrimitive( image ) :
 

--- a/python/GafferUI/MessageWidget.py
+++ b/python/GafferUI/MessageWidget.py
@@ -34,9 +34,10 @@
 #
 ##########################################################################
 
-import weakref
+import bisect
 import functools
 import imath
+import weakref
 
 import IECore
 
@@ -47,45 +48,94 @@ from Qt import QtCore
 from Qt import QtGui
 from Qt import QtWidgets
 
-## The MessageWidget class displays a log of messages in the format specified by
-# IECore MessageHandlers.
+from ._TableView import _TableView
+
+## The MessageWidget class displays a list of messages using the IECore MessageHandler
+# format. Two display roles are available depending on the nature/quantity of
+# the messages to be shown. Optional toolbars allow message navigation, search
+# and severity selection.
 class MessageWidget( GafferUI.Widget ) :
 
-	def __init__( self, **kw ) :
+	# Messages : For presenting longer messages in detail. They are shown as line-wrapped paragraphs.
+	# Log : For presenting a large number of messages in tabular form with un-wrapped lines.
+	Role = IECore.Enum.create( "Messages", "Log" )
 
-		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing=4 )
-		GafferUI.Widget.__init__( self, row, **kw )
+	# messageLevel : The minimum importance of message that will be displayed.
+	# role : The style of message presentation.
+	# toolbars : When true, search/navigation toolbars will be displayed with the widget.
+	# follow : When enabled, the widget will auto-scroll to the latest message unless the
+	#     user has set a custom scroll position (scrolling to the end will re-enable).
+	def __init__( self, messageLevel = IECore.MessageHandler.Level.Info, role = Role.Messages, toolbars = False, follow = False, **kw ) :
 
-		with row :
+		rows = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing=4 )
+		GafferUI.Widget.__init__( self, rows, **kw )
 
-			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing=6 ) :
+		upperToolbar = None
 
-				buttonSpecs = [
-					( IECore.Msg.Level.Error, "Errors. These may chill you to your very core. Click to scroll to the next one (if you can stomach it)." ),
-					( IECore.Msg.Level.Warning, "Warnings. These may give you pause for thought. Click to scroll to the next thinking point." ),
-					( IECore.Msg.Level.Info, "Information. You may find this edifying. Click to scroll to the next enlightening nugget." ),
-					( IECore.Msg.Level.Debug, "Debug information. You may find this very dull. Click to scroll to the next item." ),
-				]
-				self.__levelButtons = {}
-				for buttonSpec in buttonSpecs :
-					button = GafferUI.Button(
-						image = IECore.Msg.levelAsString( buttonSpec[0] ).lower() + "Notification.png",
-						hasFrame = False,
-					)
-					button.__level = buttonSpec[0]
-					self.__levelButtons[buttonSpec[0]] = button
-					button.clickedSignal().connect( Gaffer.WeakMethod( self.__buttonClicked ), scoped = False )
-					button.setVisible( False )
-					button.setToolTip( buttonSpec[1] )
+		with rows :
 
-				GafferUI.Spacer( imath.V2i( 10 ) )
+			if toolbars :
 
-			self.__text = GafferUI.MultiLineTextWidget( editable=False )
+				upperToolbar = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
+				with upperToolbar :
 
-		self.__messageLevel = IECore.Msg.Level.Info
+					GafferUI.Label( "Show" )
+					self.__levelWidget = _MessageLevelWidget()
+					self.__levelWidget.messageLevelChangedSignal().connect( Gaffer.WeakMethod( self.__messageLevelChanged ), scoped = False )
+
+					GafferUI.Spacer( imath.V2i( 6 ), preferredSize = imath.V2i( 100, 0 ) )
+
+			self.__table = _MessageTableView( follow = follow, expandRows = role is MessageWidget.Role.Messages )
+
+			if toolbars :
+
+				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal ) :
+
+					self.__summaryWidget = _MessageSummaryWidget()
+					self.__summaryWidget.levelButtonClickedSignal().connect( Gaffer.WeakMethod( self.__levelButtonClicked ), scoped = False )
+
+					GafferUI.Spacer( imath.V2i( 0 ) )
+
+					self.__toEndButton = GafferUI.Button( image = "scrollToBottom.png", hasFrame = False )
+					self.__toEndButton.setToolTip( "Scroll to bottom and follow new messages [B]" )
+					self.__toEndButton.buttonPressSignal().connect( Gaffer.WeakMethod( self.__table.scrollToLatest ), scoped = False )
+
+					GafferUI.Spacer( imath.V2i( 3 ), imath.V2i( 3 ) )
+
+		if toolbars :
+
+			upperToolbar.addChild( self.__table.searchWidget() )
+
+			self.__table.messageLevelChangedSignal().connect( Gaffer.WeakMethod( self.__messageLevelChanged ), scoped = False )
+			self.__table.messagesChangedSignal().connect( Gaffer.WeakMethod( self.__messagesChanged ), scoped = False )
+
+			if follow :
+
+				# When following, we manage the enabled state of the toEndButton based on the auto-scroll
+				# state of the table view. If we're not, then it should remain active the whole time.
+				self.__isFollowingMessagesChanged( self.__table )
+				self.__table.isFollowingMessagesChangedSignal().connect( Gaffer.WeakMethod( self.__isFollowingMessagesChanged ), scoped = False )
+
 		self.__messageHandler = _MessageHandler( self )
-		self.__messages = []
-		self.__processingEvents = False
+
+		self.setMessageLevel( messageLevel )
+		self.setMessages( Gaffer.Private.IECorePreview.Messages() )
+
+	## Displays the specified messages. To add individual messages, submit them
+	# via the widget's message handler \see messageHandler().
+	def setMessages( self, messages ) :
+
+		self.__table.setMessages( messages )
+
+	## Returns (a copy of) the messages displayed by the widget.
+	def getMessages( self ) :
+
+		return Gaffer.Private.IECorePreview.Messages( self.__table.getMessages() )
+
+	## Clears all the displayed messages.
+	def clear( self ) :
+
+		self.__table.clear()
 
 	## Returns a MessageHandler which will output to this Widget.
 	## \threading It is safe to use the handler on threads other than the main thread.
@@ -113,120 +163,57 @@ class MessageWidget( GafferUI.Widget ) :
 
 		assert( isinstance( messageLevel, IECore.MessageHandler.Level ) )
 
-		if messageLevel == self.__messageLevel :
-			return
+		self.__table.setMessageLevel( messageLevel )
 
-		self.__messageLevel = messageLevel
-		self.__text.setText( "" )
-		for message in self.__messages :
-			self.__appendMessageToText( *message )
-
+	## Returns the current IECore.MessageHandler.Level at and below which
+	# messages will be shown in the widget.
 	def getMessageLevel( self ) :
 
-		return self.__messageLevel
-
-	## May be called to append a message manually.
-	# \note Because these are not real messages, they are not
-	# passed to the forwardingMessageHandler().
-	# \deprecated.
-	def appendMessage( self, level, context, message ) :
-
-		self.__levelButtons[level].setVisible( True )
-		self.__messages.append( ( level, context, message ) )
-		if self.__appendMessageToText( level, context, message ) :
-
-			# Update the gui so messages are output as they occur, rather than all getting queued
-			# up till the end. We have to be careful to avoid recursion when doing this - another
-			# thread may be queuing up loads of messages using self.messageHandler(), and those
-			# will get processed by processEvents(), resulting in a recursive call to appendMessage().
-			# If the other thread supplies messages fast enough and we don't guard against recursion
-			# then we can end up exceeding Python's stack limit very quickly.
-			if not self.__processingEvents :
-				try :
-					self.__processingEvents = True
-					# Calling processEvents can cause almost anything to be executed,
-					# including idle callbacks that might build UIs. We must push an
-					# empty parent so that any widgets created will not be inadvertently
-					# parented to the wrong thing.
-					## \todo Calling `processEvents()` has also caused problems in the
-					# past where a simple error message has then led to idle callbacks
-					# being triggered which in turn triggered a graph evaluation. Having
-					# a message handler lead to arbitarary code execution is not good! Is
-					# there some way we can update the UI without triggering arbitrary
-					# code evaluation?
-					self._pushParent( None )
-					QtWidgets.QApplication.instance().processEvents( QtCore.QEventLoop.ExcludeUserInputEvents )
-					self._popParent()
-				finally :
-					self.__processingEvents = False
+		return self.__table.getMessageLevel()
 
 	## Returns the number of messages being displayed, optionally
 	# restricted to the specified level.
 	def messageCount( self, level = None ) :
 
-		if level is not None :
-			return sum( y[0] == level for y in self.__messages )
+		messages = self.__table.getMessages()
+		if level is None :
+			return len( messages )
 		else :
-			return sum(
-				[
-					self.messageCount( IECore.Msg.Level.Debug ),
-					self.messageCount( IECore.Msg.Level.Info ),
-					self.messageCount( IECore.Msg.Level.Warning ),
-					self.messageCount( IECore.Msg.Level.Error ),
-				]
-			)
+			return messages.count( level )
 
-	## Clears all the displayed messages.
-	def clear( self ) :
+	# Friendship for our internal message handler
+	def _addMessage( self, level, context, message ) :
 
-		self.__text.setText( "" )
-		self.__messages = []
-		for button in self.__levelButtons.values() :
-			button.setVisible( False )
+		self.__table.addMessage( Gaffer.Private.IECorePreview.Message( level, context, message ) )
 
-	def __buttonClicked( self, button ) :
+	# Signal callbacks - only called when toolbars are present
 
-		# make sure messages of this level are being displayed
-		if button.__level > self.__messageLevel :
-			self.setMessageLevel( button.__level )
+	def __messageLevelChanged( self, widget ) :
 
-		# scroll to the next one
-		toFind = IECore.Msg.levelAsString( button.__level ) + " : "
+		messageLevel = widget.getMessageLevel()
+		self.__table.setMessageLevel( messageLevel )
+		self.__levelWidget.setMessageLevel( messageLevel )
 
-		def find( widget, text ) :
+	def __levelButtonClicked( self, level ) :
 
-			# Really we just want to call `widget.find( text )`
-			# but that is utterly broken in PySide - it is marked
-			# as a static method so receives a null self and promptly
-			# crashes. So instead we reproduce the work that
-			# `widget.find()` does internally.
+		if GafferUI.Widget.currentModifiers() == GafferUI.ModifiableEvent.Modifiers.Shift :
+			self.__table.previousMessage( level )
+		else :
+			self.__table.nextMessage( level )
 
-			search = widget.document().find( text, widget.textCursor() )
-			if search :
-				widget.setTextCursor( search )
+	def __messagesChanged( self, widget ) :
 
-			return search
+		self.__summaryWidget.updateFromMessages( widget.getMessages() )
 
-		if not find( self.__text._qtWidget(), toFind ) :
-			self.__text._qtWidget().moveCursor( QtGui.QTextCursor.Start )
-			find( self.__text._qtWidget(), toFind )
+	def __isFollowingMessagesChanged( self, widget ) :
 
-	def __appendMessageToText( self, level, context, message ) :
+		self.__toEndButton.setEnabled( not widget.isFollowingMessages() )
 
-		if level > self.__messageLevel :
-			return False
+# ================
+# Internal Classes
+# ================
 
-		formatted = "<h1 class='%s'>%s : %s </h1><pre class='message'>%s</pre><br>" % (
-			IECore.Msg.levelAsString( level ),
-			IECore.Msg.levelAsString( level ),
-			context,
-			message
-		)
-
-		self.__text.appendHTML( formatted )
-
-		return True
-
+# A message handler that adds messages directly to the widgets messages container.
 class _MessageHandler( IECore.MessageHandler ) :
 
 	def __init__( self, messageWidget ) :
@@ -234,6 +221,7 @@ class _MessageHandler( IECore.MessageHandler ) :
 		IECore.MessageHandler.__init__( self )
 
 		self._forwarder = IECore.CompoundMessageHandler()
+		self.__processingEvents = False
 
 		# using a weak reference because we're owned by the MessageWidget,
 		# so we mustn't have a reference back.
@@ -246,8 +234,1225 @@ class _MessageHandler( IECore.MessageHandler ) :
 		w = self.__messageWidget()
 
 		if w :
-			GafferUI.EventLoop.executeOnUIThread( functools.partial( w.appendMessage, level, context, msg ) )
+
+			application = QtWidgets.QApplication.instance()
+
+			if QtCore.QThread.currentThread() == application.thread() :
+
+				w._addMessage( level, context, msg )
+
+				# Code like GafferCortexUI.OpDialogue has the option to run the op on the
+				# main thread. We want to update the ui as they occur, so we force the
+				# event loop to clear here. As processEvents may result in re-entry to this
+				# function (the called code may desire to log another message through this
+				# handler), we must guard against recursion so we don't run out of stack).
+				if not self.__processingEvents :
+					try :
+						self.__processingEvents = True
+						# Calling processEvents can cause almost anything to be executed,
+						# including idle callbacks that might build UIs. We must push an
+						# empty parent so that any widgets created will not be inadvertently
+						# parented to the wrong thing.
+						## \todo Calling `processEvents()` has also caused problems in the
+						# past where a simple error message has then led to idle callbacks
+						# being triggered which in turn triggered a graph evaluation. Having
+						# a message handler lead to arbitarary code execution is not good! Is
+						# there some way we can update the UI without triggering arbitrary
+						# code evaluation?
+						w._pushParent( None )
+						application.processEvents( QtCore.QEventLoop.ExcludeUserInputEvents )
+						w._popParent()
+					finally :
+						self.__processingEvents = False
+
+			else :
+
+				GafferUI.EventLoop.executeOnUIThread( functools.partial( w._addMessage, level, context, msg ) )
+
 		else :
 			# the widget has died. bad things are probably afoot so its best
 			# that we output the messages somewhere to aid in debugging.
 			IECore.MessageHandler.getDefaultHandler().handle( level, context, msg )
+
+# =================
+# Component Widgets
+# =================
+
+# Provides a canonical list of IECore MessageHandler message levels
+def _messageLevels() :
+
+	Level = IECore.MessageHandler.Level
+	return [ l for l in Level.values.values() if l is not Level.Invalid ]
+
+# Provides badge + count for each message level. The badges are clickable,
+# \see levelButtonClickedSignal.
+class _MessageSummaryWidget( GafferUI.Widget ) :
+
+	# \todo If this is promoted for use in the Viewer render control UI, make sure to update
+	# the stylesheet class names, and factor in how to configure the tooltips.
+
+	def __init__( self, **kw ) :
+
+		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
+		GafferUI.Widget.__init__( self, row, **kw )
+
+		# Keep in a local too to allow us to capture the signal in a lambda without dragging in self
+		buttonSignal = Gaffer.Signal1()
+		self.__levelButtonClickedSignal = buttonSignal
+
+		self.__buttons = {}
+
+		tooltipTempate = "Click to jump to next {} message [{}]"
+		buttonShortcuts = {
+			IECore.MessageHandler.Level.Error : "E", IECore.MessageHandler.Level.Warning : "W",
+			IECore.MessageHandler.Level.Info : "I", IECore.MessageHandler.Level.Debug : "D"
+		}
+
+		with row :
+
+			for level in _messageLevels() :
+
+				button = GafferUI.Button( image = str(level).lower() + "Small.png", hasFrame = False )
+				button.clickedSignal().connect( functools.partial( lambda l, _ : buttonSignal( l ), level ), scoped = False )
+				button.setToolTip( tooltipTempate.format( level, buttonShortcuts[ level ] ) )
+				self.__buttons[ level ] = button
+
+		self.updateFromMessages( Gaffer.Private.IECorePreview.Messages() )
+
+	# Emitted with the level of the button that was pressed
+	def levelButtonClickedSignal( self ) :
+
+		return self.__levelButtonClickedSignal
+
+	# Updates the button status and message count to that of the supplied messages
+	def updateFromMessages( self, messages ) :
+
+		for level, button in self.__buttons.items() :
+
+			count = messages.count( level )
+			button.setEnabled( count > 0 )
+			button.setText( "%d" % count )
+
+## Provides a drop down menu to select an IECore.MessageHandler.Level
+class _MessageLevelWidget( GafferUI.Widget ) :
+
+	def __init__( self, messageLevel = IECore.MessageHandler.Level.Info, **kw ) :
+
+		self.__menuButton = GafferUI.MenuButton( menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ) )
+		GafferUI.Widget.__init__( self, self.__menuButton, **kw )
+
+		self.__menuButton._qtWidget().setFixedWidth( 75 )
+
+		self.__level = None
+		self.__messageLevelChangedSignal = GafferUI.WidgetSignal()
+		self.setMessageLevel( messageLevel )
+
+	def setMessageLevel( self, level ) :
+
+		assert( isinstance( level, IECore.MessageHandler.Level ) )
+
+		if level == self.__level :
+			return
+
+		self.__menuButton.setText( str(level) )
+		self.__level = level
+
+		self.__messageLevelChangedSignal( self )
+
+	def getMessageLevel( self ) :
+
+		return self.__level
+
+	def messageLevelChangedSignal( self ) :
+
+		return self.__messageLevelChangedSignal
+
+	def __setMessageLevel( self, level, unused ) :
+
+		self.setMessageLevel( level )
+
+	def __menuDefinition( self ) :
+
+		menuDefinition = IECore.MenuDefinition()
+		for level in _messageLevels() :
+			menuDefinition.append(
+				"/%s" % level,
+				{
+					"command" : functools.partial( Gaffer.WeakMethod( self.__setMessageLevel ), level ),
+					"checkBox" : self.__level == level
+				}
+			)
+
+		return menuDefinition
+
+## Provides a search field along with result count display and navigation buttons for
+# a _MessageTableView
+class _MessageTableSearchWidget( GafferUI.Widget ) :
+
+	def __init__( self, tableView, **kw ) :
+
+		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
+		GafferUI.Widget.__init__( self, row, **kw )
+
+		with row :
+
+			self.__results = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
+			with self.__results :
+
+				self.__resultCount = GafferUI.Label()
+
+				self.__prevButton = GafferUI.Button( image = "arrowLeft10.png", hasFrame = False )
+				self.__prevButton.clickedSignal().connect( Gaffer.WeakMethod( self.__buttonClicked ), scoped = False )
+
+				self.__nextButton = GafferUI.Button( image = "arrowRight10.png", hasFrame = False )
+				self.__nextButton.clickedSignal().connect( Gaffer.WeakMethod( self.__buttonClicked ), scoped = False )
+
+				self.__focusButton = GafferUI.Button( image = "searchFocusOff.png", hasFrame = False )
+				self.__focusButton.clickedSignal().connect( Gaffer.WeakMethod( self.__buttonClicked ), scoped = False )
+
+			self.__searchField = GafferUI.TextWidget()
+			# Edited catches focus-out and makes sure we update the search text
+			self.__searchField.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__textEdited ), scoped = False )
+			# Activated allows <enter> to repeatedly jump to the next search result
+			self.__searchField.activatedSignal().connect( Gaffer.WeakMethod( self.__textActivated ), scoped = False )
+			self.__searchField._qtWidget().setObjectName( "gafferSearchField" )
+			self.__searchField._qtWidget().setPlaceholderText( "Search" )
+			self.__searchField._qtWidget().setMaximumWidth( 250 )
+
+		self.__prevButton.setToolTip( "Show previous match [P]" )
+		self.__nextButton.setToolTip( "Show next match [N]" )
+
+		# Though Qt provides clearButtonEnabled(), this seems to be missing its icon on macOS, resulting in a
+		# clickable-but-not-visible clear button. As such we need to make our own. Icons need to be 16x16 exactly.
+		clearImage = GafferUI.Image( "clearSearch.png" )
+		self.__clearAction = QtWidgets.QAction( clearImage._qtIcon(), "Clear Search", None )
+		self.__clearAction.triggered.connect( Gaffer.WeakMethod( self.__clear ) )
+		self.__searchField._qtWidget().addAction( self.__clearAction, QtWidgets.QLineEdit.TrailingPosition )
+
+		self.__table = weakref.ref( tableView )
+		tableView.searchTextChangedSignal().connect( Gaffer.WeakMethod( self.__searchTextChanged ), scoped = False )
+		tableView.focusSearchResultsChangedSignal().connect( Gaffer.WeakMethod( self.__focusSearchResultsChanged ), scoped = False )
+		tableView.searchResultsChangedSignal().connect( Gaffer.WeakMethod( self.__searchResultsChanged ), scoped = False )
+
+		self.__searchTextChanged( tableView )
+		self.__focusSearchResultsChanged( tableView )
+		self.__searchResultsChanged( tableView )
+
+	def grabFocus( self ) :
+
+		self.__searchField.grabFocus()
+		self.__searchField.setSelection( None, None )
+
+	def __buttonClicked( self, button ) :
+
+		if button is self.__prevButton :
+			self.__table().previousSearchResult( self )
+		elif button is self.__nextButton :
+			self.__table().nextSearchResult( self )
+		elif button is self.__focusButton :
+			self.__table().setFocusSearchResults( not self.__table().getFocusSearchResults() )
+
+	def __textEdited( self, *unused ) :
+
+		self.__table().setSearchText( self.__searchField.getText() )
+
+	def __textActivated( self, *unused ) :
+
+		self.__table().setSearchText( self.__searchField.getText() )
+
+		if not self.__table().getFocusSearchResults() and self.__table().searchResultCount() > 0 :
+			self.__table().nextSearchResult()
+
+	def __clear( self ) :
+
+		self.__table().clearSearch()
+		self.grabFocus()
+
+	def __searchTextChanged( self, table ) :
+
+		text = table.getSearchText()
+		self.__searchField.setText( text )
+		self.__clearAction.setVisible( len(text) > 0 )
+
+	def __focusSearchResultsChanged( self, table ) :
+
+		isFocused = table.getFocusSearchResults()
+		haveResults = table.searchResultCount()
+
+		self.__focusButton.setImage( "searchFocusOn.png" if isFocused else "searchFocusOff.png" )
+		self.__focusButton.setToolTip( "Show all [S]" if isFocused else "Only show matches [S]" )
+
+		self.__prevButton.setEnabled( haveResults and not isFocused )
+		self.__nextButton.setEnabled( haveResults and not isFocused )
+
+	def __searchResultsChanged( self, table ) :
+
+		haveSearchString = len( table.getSearchText() ) > 0
+		self.__results.setVisible( haveSearchString )
+
+		isFocused = table.getFocusSearchResults()
+		count = table.searchResultCount()
+
+		self.__resultCount.setText( "{} match{}".format( count, "" if count == 1 else "es" ) )
+		self.__prevButton.setEnabled( count > 0 and not isFocused )
+		self.__nextButton.setEnabled( count > 0 and not isFocused )
+
+## The main table view presenting messages to the user.
+#
+# The view manages three QAbstractItemModels :
+#
+#  - __model :       A model presenting the raw message data.
+#  - __filterModel : A proxy model filtering the message data for display based on the selected message level.
+#  - __searchModel : A side-car proxy model used to determine the result count for the free-text search
+#                    independent of the current display.
+#
+# The table's view is driven from the __displayModel - which is set to either the __filterModel or __searchModel
+# depending on getFocusSearchResults().
+#
+# The optional __displayTransform proxy facilitates 'expanded rows' display (\see MessageWidge.Role.Messages), to
+# avoid duplication of search/message navigation coding.
+#
+class _MessageTableView( GafferUI.Widget ) :
+
+	SearchWidget = _MessageTableSearchWidget
+
+	# - follow :     When set, the view will scroll to new messages as they are added (or to the end, when
+	#                setMessages is used). If the user sets a custom scroll position, then following will be
+	#                temporarily disabled. This state changed can be queried via isFollowingMessages.
+	# - expandRows : When set, a proxy model will be set in __displayTransform that unpacks message columns into
+	#                separate rows.
+	def __init__( self, follow = False, expandRows = True, **kw ) :
+
+		tableView = _TableView()
+		GafferUI.Widget.__init__( self, tableView, **kw )
+
+		self.__setupSignals()
+		self.__setupModels( expandRows )
+		self.__setupAppearance( expandRows )
+
+		self.__didInitiateScroll = False
+		self.__userSetScrollPosition( False )
+		self.__setFollowMessages( follow )
+
+		self.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ), scoped = False )
+
+		self.setMessageLevel( IECore.MessageHandler.Level.Info )
+
+		self.__searchWidget = None
+
+	# Provides a search widget controlling this view that can be embedded in the containing UI.
+	def searchWidget( self ) :
+
+		if self.__searchWidget is None :
+			self.__searchWidget = _MessageTableView.SearchWidget( self )
+
+		return self.__searchWidget
+
+	def setMessageLevel( self, level ) :
+
+		if self.__filterModel.getLevel() == level :
+			return
+
+		self.__filterModel.setLevel( level )
+		self.__scrollIfNeeded()
+
+		self.__messageLevelChangedSignal( self )
+
+	def getMessageLevel( self ) :
+
+		return self.__filterModel.getLevel()
+
+	def messageLevelChangedSignal( self ) :
+
+		return self.__messageLevelChangedSignal
+
+	# Message management
+
+	def setMessages( self, messages ) :
+
+		self.__model.setMessages( messages )
+		self.__scrollIfNeeded()
+
+		self.__messagesChangedSignal( self )
+
+	def getMessages( self ) :
+
+		return self.__model.getMessages()
+
+	def addMessage( self, message ) :
+
+		self.__model.addMessage( message )
+		self.__scrollIfNeeded()
+
+		self.__messagesChangedSignal( self )
+
+	def clear( self ) :
+
+		self.__userSetScrollPosition( False )
+		self.setMessages( Gaffer.Private.IECorePreview.Messages() )
+
+	def messagesChangedSignal( self ) :
+
+		return self.__messagesChangedSignal
+
+	# Search
+
+	def setSearchText( self, searchText ) :
+
+		if searchText == self.__searchText :
+			return
+
+		self.__searchText = searchText
+		self.__searchModel.setFilterWildcard( searchText )
+
+		if not searchText :
+			self.setFocusSearchResults( False )
+
+		self.__searchTextChangedSignal( self )
+
+	def getSearchText( self ) :
+
+		return self.__searchText
+
+	def clearSearch( self, *unused ) :
+
+		self.setSearchText( "" )
+
+	def searchResultCount( self ) :
+
+		if not self.getSearchText() :
+			return 0
+
+		return self.__searchModel.rowCount()
+
+	def nextSearchResult( self, *unused ) :
+
+		self.__navigateSearchResult( previous = False )
+
+	def previousSearchResult( self, *unused ) :
+
+		self.__navigateSearchResult( previous = True )
+
+	def setFocusSearchResults( self, focus ) :
+
+		if self.getFocusSearchResults() == focus :
+			return
+
+		self.__setDisplayModel( self.__searchModel if focus else self.__filterModel )
+
+		self.__focusSearchResultsChangedSignal( self )
+
+	def getFocusSearchResults( self ) :
+
+		return self.__displayModel == self.__searchModel
+
+	def focusSearchResultsChangedSignal( self ) :
+
+		return self.__focusSearchResultsChangedSignal
+
+	def searchTextChangedSignal( self ) :
+
+		return self.__searchTextChangedSignal
+
+	def searchResultsChangedSignal( self ) :
+
+		return self.__searchResultsChangedSignal
+
+	# Message navigation
+
+	def nextMessage( self, messageLevel, select = True, wrap = True ) :
+
+		assert( isinstance( messageLevel, IECore.MessageHandler.Level ) )
+
+		self.setFocusSearchResults( False )
+
+		if messageLevel > self.getMessageLevel() :
+			self.setMessageLevel( messageLevel )
+
+		nextMessageIndex = self.__findNextMessage( messageLevel, reverse = False, wrap = wrap )
+		self.__scrollToMessage( nextMessageIndex, select )
+
+	def previousMessage( self, messageLevel, select = True, wrap = True ) :
+
+		assert( isinstance( messageLevel, IECore.MessageHandler.Level ) )
+
+		self.setFocusSearchResults( False )
+
+		if messageLevel > self.getMessageLevel() :
+			self.setMessageLevel( messageLevel )
+
+		prevMessageIndex = self.__findNextMessage( messageLevel, reverse = True, wrap = wrap )
+		self.__scrollToMessage( prevMessageIndex, select )
+
+	# Scrolling
+
+	def isFollowingMessages( self ) :
+
+		return not self.__userScrollPosition
+
+	def isFollowingMessagesChangedSignal( self ) :
+
+		return self.__isFollowingMessagesChangedSignal
+
+	def scrollToLatest( self, *unused ) :
+
+		self.__userSetScrollPosition( False )
+		self.__scrollToBottom()
+
+	# Internal
+
+	def __setupSignals( self ) :
+
+		self.__messagesChangedSignal = GafferUI.WidgetSignal()
+		self.__searchResultsChangedSignal = GafferUI.WidgetSignal()
+		self.__searchTextChangedSignal = GafferUI.WidgetSignal()
+		self.__focusSearchResultsChangedSignal = GafferUI.WidgetSignal()
+		self.__messageLevelChangedSignal = GafferUI.WidgetSignal()
+		self.__isFollowingMessagesChangedSignal = GafferUI.WidgetSignal()
+
+	def __setupModels( self, expandRows ) :
+
+		self.__model = _MessageTableModel()
+
+		self.__filterModel = _MessageTableFilterModel()
+		self.__filterModel.setSourceModel( self.__model )
+
+		self.__searchModel = QtCore.QSortFilterProxyModel()
+		self.__searchModel.setFilterCaseSensitivity( QtCore.Qt.CaseInsensitive )
+		self.__searchModel.setFilterKeyColumn( -1 )
+		self.__searchModel.setSourceModel( self.__filterModel )
+		searchResultsChangedSlot = Gaffer.WeakMethod( self.__searchResultsChanged )
+		self.__searchModel.rowsInserted.connect( searchResultsChangedSlot )
+		self.__searchModel.rowsRemoved.connect( searchResultsChangedSlot )
+		self.__searchModel.dataChanged.connect( searchResultsChangedSlot )
+		self.__searchModel.modelReset.connect( searchResultsChangedSlot )
+		# QSortFilterProxyModel doesn't support a transparent get/set (as it goes via regex)
+		self.__searchText = ""
+
+		self.__displayTransform = _MessageTableExpandedViewProxy() if expandRows else _MessageTableCollapseColumnsProxy()
+
+		self.__setDisplayModel( self.__filterModel )
+
+		self._qtWidget().setModel( self.__displayTransform )
+
+	def __setupAppearance( self, expandRows ) :
+
+		tableView = self._qtWidget()
+
+		tableView.setEditTriggers( tableView.NoEditTriggers )
+		tableView.setSelectionBehavior( QtWidgets.QAbstractItemView.SelectRows )
+		tableView.setSelectionMode( QtWidgets.QAbstractItemView.ContiguousSelection )
+
+		tableView.verticalHeader().setVisible( False )
+		tableView.horizontalHeader().setVisible( False )
+
+		tableView.setHorizontalScrollMode( tableView.ScrollPerPixel )
+
+		tableView.setShowGrid( False )
+
+		if expandRows :
+
+			tableView.horizontalHeader().setSectionResizeMode( 0, QtWidgets.QHeaderView.Stretch )
+			tableView.verticalHeader().setSectionResizeMode( QtWidgets.QHeaderView.ResizeToContents )
+			tableView.setWordWrap( True )
+
+		else :
+
+			tableView.verticalHeader().setSectionResizeMode( QtWidgets.QHeaderView.Fixed )
+			tableView.verticalHeader().setDefaultSectionSize( 14 )
+
+			# Fortunately we have a fixed set of known message levels so its ok to hard code this here
+			tableView.setColumnWidth( 0, 75 )
+			tableView.horizontalHeader().setStretchLastSection( True )
+
+			tableView.setHorizontalScrollBarPolicy( QtCore.Qt.ScrollBarAsNeeded )
+
+			tableView.setWordWrap( False )
+
+	def __setDisplayModel( self, model ) :
+
+		self.__displayModel = model
+		self.__displayTransform.setSourceModel( model )
+
+	#
+	# A display index refers to indices into self.__displayModel, before any self.__displayTransform
+	#
+
+	def __displayIndexForMessage( self, messageIndex ) :
+
+		displayIndex = self.__filterModel.mapFromSource( self.__model.index( messageIndex, 0 ) )
+		if self.__displayModel != self.__filterModel :
+			displayIndex = self.__displayModel.mapFromSource( displayIndex )
+		return displayIndex
+
+	# Selection
+
+	def __selectedDisplayIndexes( self ) :
+
+		displayIndexes = self._qtWidget().selectedIndexes()
+		if self.__displayTransform is not None :
+			displayIndexes = [ self.__displayTransform.mapToSource(i) for i in displayIndexes ]
+
+		return displayIndexes
+
+	def __selectDisplayIndex( self, index ) :
+
+		if not index.isValid() :
+			return
+
+		selectionMode = QtCore.QItemSelectionModel.ClearAndSelect | QtCore.QItemSelectionModel.Rows
+		selection = self._qtWidget().selectionModel()
+
+		if self.__displayTransform is not None :
+			# Expand the selection to make sure we have the whole row as the transform may map columns to rows
+			row = index.row()
+			lastColumn = index.model().columnCount() - 1
+			rowSelection = QtCore.QItemSelection( index.sibling( row, 0 ), index.sibling( row, lastColumn ) )
+			selection.select( self.__displayTransform.mapSelectionFromSource( rowSelection ), selectionMode )
+		else :
+			selection.select( index, selectionMode )
+
+	def __selectedMessageIndices( self ) :
+
+		# Gets back to the base model index, whose indices equate to the actual message container indices.
+		def messageModelIndex( index ) :
+			model = self.__displayModel
+			while hasattr( model, "sourceModel" ) :
+				index = model.mapToSource( index )
+				model = model.sourceModel()
+			return index
+
+		# remove duplicates, either due to the expanded display model, or multi-column selection
+		return sorted( { messageModelIndex( i ).row() for i in self.__selectedDisplayIndexes() } )
+
+	# Scrolling
+
+	def __scrollToDisplayIndex( self, index ) :
+
+		if not index.isValid() :
+			return
+
+		if self.__displayTransform is not None :
+			index = self.__displayTransform.mapFromSource( index )
+
+		self._qtWidget().scrollTo( index )
+
+	def __scrollToBottom( self ) :
+
+		self.__didInitiateScroll = True
+		self._qtWidget().scrollToBottom()
+		self.__didInitiateScroll = False
+
+	def __scrollToMessage( self, messageIndex, select ) :
+
+		if messageIndex is None :
+			return
+
+		displayIndex = self.__displayIndexForMessage( messageIndex )
+		if displayIndex.isValid() :
+			self.__scrollToDisplayIndex( displayIndex )
+			self.__userSetScrollPosition( True )
+			if select :
+				self.__selectDisplayIndex( displayIndex )
+
+	# Search result management
+
+	def __searchResultsChanged( self, *unused ) :
+
+		self.__searchResultsChangedSignal( self )
+
+	def __navigateSearchResult( self, previous = False ) :
+
+		if self.searchResultCount() == 0 :
+				return
+
+		selected = self.__selectedDisplayIndexes()
+		selectedIndex = selected[0] if selected else None
+
+		if selectedIndex is None :
+			row = ( self.__searchModel.rowCount() - 1 ) if previous else 0
+			resultIndex = self.__searchModel.mapToSource( self.__searchModel.index( row, 0 ) )
+		else :
+			resultIndex = self.__adjacentSearchResultDisplayIndex( selectedIndex, previous )
+
+		if resultIndex is not None :
+			self.__scrollToDisplayIndex( resultIndex )
+			self.__selectDisplayIndex( resultIndex )
+
+	def __adjacentSearchResultDisplayIndex( self, currentDisplayIndex, previous ) :
+
+		displayIsSearchModel = currentDisplayIndex.model() == self.__searchModel
+
+		if displayIsSearchModel :
+			currentResult = currentDisplayIndex
+		else :
+			currentResult = self.__searchModel.mapFromSource( currentDisplayIndex )
+
+		result = None
+
+		if currentResult.isValid() :
+			# If the selected row is already a search result, we simply increment/decrement to the next
+			currentRow = currentResult.row()
+			if previous :
+				if currentRow > 0 :
+					result = currentResult.sibling( currentRow - 1, 0 )
+			else :
+				if currentRow < currentResult.model().rowCount() - 1 :
+					result = currentResult.sibling( currentRow + 1, 0 )
+
+		else :
+			# Find the nearest result
+			result = self.__findNearestSearchResult( currentDisplayIndex, previous )
+
+		if result is not None :
+			return result if displayIsSearchModel else self.__searchModel.mapToSource( result )
+
+	# Exposes a proxy models source rows via the sequence interface
+	class __ModelToSourceRowsWrapper() :
+
+		def __init__( self, searchModel ) :
+			self.__model = searchModel
+
+		def __len__( self ) :
+			return self.__model.rowCount()
+
+		def __getitem__( self, index ) :
+			return self.__model.mapToSource( self.__model.index( index, 0 ) ).row()
+
+	def __findNearestSearchResult( self, displayIndex, before = False ) :
+
+		model = self.__searchModel
+		selectedDisplayRow = displayIndex.row()
+
+		# As bisect needs a sequence type, but we don't want to pre-generate a list of all result
+		# source rows, we wrap the model in a class that will convert the lookups to our source rows.
+		bisectable = _MessageTableView.__ModelToSourceRowsWrapper( model )
+
+		if before :
+			nearest = bisect.bisect_left( bisectable, selectedDisplayRow ) - 1
+		else :
+			nearest = bisect.bisect_right( bisectable, selectedDisplayRow )
+
+		if nearest < 0 or nearest == model.rowCount() :
+			return None
+
+		return model.index( nearest, 0 )
+
+	# Message navigation
+
+	def __findNextMessage( self, messageLevel, reverse = False, wrap = True ) :
+
+		lastIndex = len( self.__model.getMessages() ) - 1
+
+		searchStart = lastIndex if reverse else 0
+
+		selected = self.__selectedMessageIndices()
+		if selected :
+			i = selected[0]
+			searchStart = ( i - 1 ) if reverse else ( i + 1 )
+
+		nextMessageIndex = self.__nextMessageIndex( messageLevel, searchStart, 0 if reverse else lastIndex  )
+		if nextMessageIndex is None and selected and wrap :
+			nextMessageIndex = self.__nextMessageIndex( messageLevel, lastIndex if reverse else 0, searchStart )
+
+		return nextMessageIndex
+
+	def __nextMessageIndex( self, messageLevel, startIndex, endIndex ) :
+
+		reverse = startIndex > endIndex
+		step = -1 if reverse else 1
+		rangeEnd = endIndex + step
+
+		messages = self.__model.getMessages()
+		if startIndex < 0 or startIndex >= len(messages) :
+			return None
+
+		for i in range( startIndex, rangeEnd, step ) :
+			if messages[i].level == messageLevel :
+				return i
+
+		return None
+
+	# Auto-follow
+
+	def __setFollowMessages( self, follow ) :
+
+		self.__followMessages = follow
+
+		if self.__followMessages :
+			slot = Gaffer.WeakMethod( self.__vScrollBarValueChanged )
+			self._qtWidget().verticalScrollBar().valueChanged.connect( slot )
+
+	def __scrollIfNeeded( self ) :
+
+		if not self.__followMessages :
+			return
+
+		if self.__userScrollPosition :
+			return
+
+		self.__scrollToBottom()
+
+	def __vScrollBarValueChanged( self, value ) :
+
+		if self.__didInitiateScroll :
+			return
+
+		if ( self._qtWidget().verticalScrollBar().maximum() - value ) == 0 :
+			self.__userSetScrollPosition( False )
+		else:
+			self.__userSetScrollPosition( True )
+
+	def __userSetScrollPosition( self, didSet ) :
+
+		self.__userScrollPosition = didSet
+		self.__isFollowingMessagesChangedSignal( self )
+
+	# Keyboard shortcuts
+
+	__eventLevelShortcuts = {
+		"E" : IECore.MessageHandler.Level.Error,
+		"W" : IECore.MessageHandler.Level.Warning,
+		"I" : IECore.MessageHandler.Level.Info,
+		"D" : IECore.MessageHandler.Level.Debug,
+	}
+
+	def __keyPress( self, unused, event ) :
+
+		if event.key == "C" and event.modifiers == event.Modifiers.Control :
+
+			self.__copySelectedRows()
+			return True
+
+		elif event.key == "A" and event.modifiers == event.Modifiers.Control :
+			self._qtWidget().selectAll()
+			return True
+
+		elif event.key == "F" and event.modifiers == event.Modifiers.Control and self.__searchWidget is not None :
+
+			self.__searchWidget.grabFocus()
+			return True
+
+		elif event.key in self.__eventLevelShortcuts :
+
+			if event.modifiers == event.Modifiers.None_ :
+				self.nextMessage( self.__eventLevelShortcuts[ event.key ] )
+				return True
+			elif event.modifiers == event.Modifiers.Shift :
+				self.previousMessage( self.__eventLevelShortcuts[ event.key ] )
+				return True
+
+		elif event.key == "S" and event.modifiers == event.Modifiers.None_ :
+
+			self.setFocusSearchResults( not self.getFocusSearchResults() )
+			return True
+
+		elif event.key == "P" and event.modifiers == event.Modifiers.None_ :
+
+			self.previousSearchResult()
+			return True
+
+		elif event.key == "N" and event.modifiers == event.Modifiers.None_ :
+
+			self.nextSearchResult()
+			return True
+
+		elif event.key in ( "End", "B" ) and event.modifiers == event.Modifiers.None_ :
+
+			self.__userSetScrollPosition( False )
+			self.__scrollToBottom()
+			return True
+
+		return False
+
+	# Copy/Paste
+
+	def __copySelectedRows( self ) :
+
+		# TODO only slected, can we get something for free from QT?
+
+		messageIndices = self.__selectedMessageIndices()
+		text = self.__plainTextForMessages( messageIndices )
+		QtWidgets.QApplication.clipboard().setText( text )
+
+	def __plainTextForMessages( self, messageIndices ) :
+
+		messages = self.getMessages()
+		indices = messageIndices or range( len(messages) )
+
+		text = ""
+		for i in indices :
+			m = messages[ i ]
+			text += "%s [%s] %s\n" % ( str(m.level).ljust(7).upper(), m.context, m.message )
+
+		return text
+
+# Combines context and message to work around column sizing issues. Asking the table view
+# to autoresize sections is prohibitively slow for the update rate that we receive messages.
+# Having context as a separate column consequently requires either a fixed width, specified
+# by the parent UI, or truncated contents. Neither or which are ideal. This proxy combines
+# context/message such that we don't have to worry about how long the context string is.
+# It would save some boilerplate if we derived from QIdentityProxyModel (though strictly, this
+# wouldn't be an identity proxy), but it is missing from the bindings.
+class _MessageTableCollapseColumnsProxy( QtCore.QAbstractProxyModel ) :
+
+	def columnCount( self, parent ) :
+
+		return 2
+
+	def rowCount( self, parent ) :
+
+		return self.sourceModel().rowCount()
+
+	def mapFromSource( self, sourceIndex ):
+
+		if not sourceIndex.isValid() or sourceIndex.row() < 0 :
+			return QtCore.QModelIndex()
+
+		# This does double up on indexes, but means you get the
+		# correct mapping for selection rectangles.
+		if sourceIndex.column() == 2 :
+			return self.index( sourceIndex.row(), 1 )
+		else :
+			return self.index( sourceIndex.row(), sourceIndex.column() )
+
+	def mapToSource( self, proxyIndex ) :
+
+		if not proxyIndex.isValid() or proxyIndex.row() < 0 :
+			return QtCore.QModelIndex()
+
+		if proxyIndex.column() == 1 :
+			return self.sourceModel().index( proxyIndex.row(), 2 )
+		else :
+			return self.sourceModel().index( proxyIndex.row(), proxyIndex.column() )
+
+	def data( self, index, role = QtCore.Qt.DisplayRole ) :
+
+		sourceModel = self.sourceModel()
+
+		if index.column() == 1 and role == QtCore.Qt.DisplayRole :
+			contextIndex = sourceModel.index( index.row(), 1 )
+			messageIndex = sourceModel.index( index.row(), 2 )
+			return "%s : %s" % (
+				sourceModel.data( contextIndex, role ),
+				sourceModel.data( messageIndex, role )
+			)
+
+		return sourceModel.data( self.mapToSource( index ), role )
+
+	def setSourceModel( self, model ) :
+
+		oldModel = self.sourceModel()
+
+		# We don't encounter column changes so we don't need to bother with those signals here.
+		# We don't have to worry about parent as it's always invalid as the model isn't a tree.
+		for signal in (
+			"modelReset", "rowsAboutToBeInserted", "rowsInserted", "rowsAboutToBeRemoved", "rowsRemoved"
+		) :
+			slot = getattr( self, signal )
+			if oldModel :
+				getattr( oldModel, signal ).disconnect( slot )
+			if model :
+				getattr( model, signal ).connect( slot )
+
+		if oldModel :
+			oldModel.dataChanged.disconnect( self.__dataChanged )
+		if model :
+			model.dataChanged.connect( self.__dataChanged )
+
+		self.beginResetModel()
+		QtCore.QAbstractProxyModel.setSourceModel( self, model )
+		self.endResetModel()
+
+	def index( self, row, column, parent = QtCore.QModelIndex() ) :
+
+		if parent.isValid() :
+			return QtCore.QModelIndex()
+
+		return self.createIndex( row, column )
+
+	def parent( self, index ) :
+
+		return QtCore.QModelIndex()
+
+	def __dataChanged( self, topLeft, bottomRight, roles ) :
+
+		self.dataChanged.emit( self.mapFromSource( topLeft ), self.mapFromSource( bottomRight ), roles )
+
+# Expands messages into a two-row presentation, with level + context on one
+# row, and the body of the message on the next.
+class _MessageTableExpandedViewProxy( QtCore.QAbstractProxyModel ) :
+
+	def columnCount( self, parent ) :
+
+		return 1
+
+	def rowCount( self, parent ) :
+
+		if parent.isValid() :
+			return 0
+
+		return 2 * self.sourceModel().rowCount() if self.sourceModel() else 0
+
+	def mapFromSource( self, sourceIndex )  :
+
+		if not sourceIndex.isValid() or sourceIndex.row() < 0 :
+			return QtCore.QModelIndex()
+
+		row = sourceIndex.row() * 2
+		if sourceIndex.column() == int( _MessageTableModel.Column.Message ) :
+			row += 1
+
+		return self.index( row, 0 )
+
+	def mapToSource( self, proxyIndex ) :
+
+		if not proxyIndex.isValid() or proxyIndex.row() < 0 :
+			return QtCore.QModelIndex()
+
+		if proxyIndex.row() % 2 == 0 :
+			column = _MessageTableModel.Column.Level
+		else :
+			column = _MessageTableModel.Column.Message
+
+		return self.sourceModel().index( proxyIndex.row() // 2, int(column) )
+
+	def data( self, index, role = QtCore.Qt.DisplayRole ) :
+
+		source = self.sourceModel()
+		sourceIndex = self.mapToSource( index )
+
+		# We combine the level/context columns into one row, and the message into another
+
+		if index.row() % 2 == 0 :
+
+			levelIndex = source.index( sourceIndex.row(), 0 )
+
+			if role == QtCore.Qt.DisplayRole :
+				# Combine level/context
+				contextIndex = source.index( sourceIndex.row(), 1 )
+				return "%s: %s" % ( source.data( levelIndex, role ), source.data( contextIndex, role ) )
+
+			elif role == QtCore.Qt.ForegroundRole :
+				# In expanded mode, only colourise the header
+				return self.__headerColor( source.data( levelIndex, _MessageTableModel.ValueRole ) )
+
+		else :
+
+			if role == QtCore.Qt.DisplayRole :
+				# Add a new line to separate messages out
+				return "%s\n" % source.data( sourceIndex, role )
+
+			elif role == QtCore.Qt.ForegroundRole :
+				return GafferUI._Variant.toVariant( GafferUI._StyleSheet.styleColor( "foreground" ) )
+
+		return source.data( sourceIndex, role )
+
+	def index( self, row, column, parent = QtCore.QModelIndex() ) :
+
+		if parent.isValid() :
+			return QtCore.QModelIndex()
+
+		return self.createIndex( row, column )
+
+	def parent( self, index ) :
+
+		return QtCore.QModelIndex()
+
+	def setSourceModel( self, model ) :
+
+		oldModel = self.sourceModel()
+
+		# We don't encounter column changes so we don't need to bother with those signals here.
+		for signal in (
+			"dataChanged", "modelReset",
+			"rowsAboutToBeInserted", "rowsInserted", "rowsAboutToBeRemoved", "rowsRemoved"
+		) :
+			slot = getattr( self, "_MessageTableExpandedViewProxy__" + signal )
+			if oldModel :
+				getattr( oldModel, signal ).disconnect( slot )
+			if model :
+				getattr( model, signal ).connect( slot )
+
+		self.beginResetModel()
+		QtCore.QAbstractProxyModel.setSourceModel( self, model )
+		self.endResetModel()
+
+	def __headerColor( self, levelData ) :
+
+		# Sadly as QAbstractProxyModel is, well - abstract, we can't add a constructor of our own
+		# as python will complain we haven't called the base constructor. Uses _ to avoid mangling fun.
+		if not hasattr( self, "_colorMap" ) :
+			self._colorMap = {}
+			for l in _messageLevels() :
+				self._colorMap[ int(l) ] = GafferUI._Variant.toVariant( GafferUI._StyleSheet.styleColor( "foreground%s" % l ) )
+
+		return self._colorMap[ levelData ]
+
+	# Signal forwarding.
+
+	def __dataChanged( self, topLeft, bottomRight, roles ) :
+
+		self.dataChanged.emit( self.index( topLeft.row() * 2, 0 ), self.index( ( bottomRight.row() * 2 ) + 1, 0 ), roles )
+
+	def __modelReset( self ) :
+
+		self.modelReset.emit()
+
+	def __rowsAboutToBeInserted( self, parent, start, end ) :
+
+		self.rowsAboutToBeInserted.emit( QtCore.QModelIndex(), start * 2, end * 2 + 1 )
+
+	def __rowsInserted( self, parent, start, end ) :
+
+		self.rowsInserted.emit( QtCore.QModelIndex(), start * 2, end * 2 + 1 )
+
+	def __rowsAboutToBeRemoved( self, parent, start, end ) :
+
+		self.rowsAboutToBeRemoved.emit( QtCore.QModelIndex(), start * 2, end * 2 + 1 )
+
+	def __rowsRemoved( self, parent, start, end ) :
+
+		self.rowsRemoved.emit( QtCore.QModelIndex(), start * 2, end * 2 + 1 )
+
+
+# Provides filtering based on message level. This isn't directly used for search
+# filtering as we often want search not to affect the number messages displayed.
+class _MessageTableFilterModel( QtCore.QSortFilterProxyModel ) :
+
+	def __init__( self, level = IECore.MessageHandler.Level.Info, *kw ) :
+
+		QtCore.QSortFilterProxyModel.__init__( self, *kw )
+		self.setLevel( level )
+
+	def setLevel( self, level ) :
+
+		self.__maxLevel = level
+		self.invalidateFilter()
+
+	def getLevel( self ) :
+
+		return self.__maxLevel
+
+	# Overrides for methods inherited from QSortFilterProxyModel
+	# --------------------------------------------------------
+
+	def filterAcceptsRow( self, sourceRow, sourceParent ) :
+
+		levelIndex = self.sourceModel().index( sourceRow, _MessageTableModel.Column.Level, sourceParent )
+		return self.sourceModel().data( levelIndex, _MessageTableModel.ValueRole ) <= self.__maxLevel
+
+# The base TabelModel representing the underlying message data.
+class _MessageTableModel( QtCore.QAbstractTableModel ) :
+
+	ColumnCount = 3
+	Column = IECore.Enum.create( "Level", "Context", "Message" )
+
+	# A role to allow access the underlying Message data, without any display coercion.
+	ValueRole = 100
+
+	def __init__( self, messages = None, parent = None ) :
+
+		QtCore.QAbstractTableModel.__init__( self, parent )
+
+		self.__messages = messages
+
+	def setMessages( self, messages ) :
+
+		# We make use of existing rows here rather than resetting
+		# the model as it avoids flickering where the view first
+		# scrolls to the top, and then is re-scrolled back to the
+		# bottom.
+
+		firstDifference = messages.firstDifference( self.__messages ) if self.__messages is not None else 0
+
+		numRows = len( self.__messages ) if self.__messages else 0
+		targetNumRows = len( messages )
+
+		if targetNumRows > numRows :
+
+			self.beginInsertRows( QtCore.QModelIndex(), numRows, targetNumRows - 1 )
+			self.__messages = messages
+			self.endInsertRows()
+
+		elif targetNumRows < numRows :
+
+			self.beginRemoveRows( QtCore.QModelIndex(), targetNumRows, numRows - 1 )
+			self.__messages = messages
+			self.endRemoveRows()
+
+		else :
+
+			self.__messages = messages
+
+		if targetNumRows > 0 :
+
+			lastRowIndex = targetNumRows - 1
+			if firstDifference is not None :
+				self.dataChanged.emit(
+					self.index( firstDifference, 0 ),
+					self.index( lastRowIndex, self.columnCount() - 1 )
+				)
+
+	def getMessages( self ) :
+
+		return self.__messages
+
+	def addMessage( self, message ) :
+
+		nextIndex = self.rowCount()
+		self.beginInsertRows( QtCore.QModelIndex(), nextIndex, nextIndex )
+		self.__messages.add( message )
+		self.endInsertRows()
+
+	# Overrides for methods inherited from QAbstractTableModel
+	# --------------------------------------------------------
+
+	def rowCount( self, parent = QtCore.QModelIndex() ) :
+
+		if parent.isValid() :
+			return 0
+
+		if self.__messages is None :
+			return 0
+
+		return len( self.__messages )
+
+	def columnCount( self, parent = QtCore.QModelIndex() ) :
+
+		if parent.isValid() :
+			return 0
+
+		return _MessageTableModel.ColumnCount
+
+	def headerData( self, section, orientation, role ) :
+
+		if role == QtCore.Qt.DisplayRole and orientation == QtCore.Qt.Horizontal :
+			return str( _MessageTableModel.Column( section ) )
+
+	def flags( self, index ) :
+
+		return QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled
+
+	def data( self, index, role ) :
+
+		if not index.isValid() :
+			return None
+
+		if role == QtCore.Qt.DisplayRole or role == _MessageTableModel.ValueRole :
+
+			message = self.__messages[ index.row() ]
+
+			if index.column() == int( _MessageTableModel.Column.Level ) :
+				return str(message.level).upper() if role == QtCore.Qt.DisplayRole else message.level
+			elif index.column() == int( _MessageTableModel.Column.Context ) :
+				return message.context
+			elif index.column() == int( _MessageTableModel.Column.Message ) :
+				return message.message
+
+		elif role == QtCore.Qt.ForegroundRole :
+
+			message = self.__messages[ index.row() ]
+			# Keep info level messages white
+			suffix = "" if message.level == IECore.MessageHandler.Level.Info else str( message.level )
+			return GafferUI._Variant.toVariant( GafferUI._StyleSheet.styleColor( "foreground%s" % suffix ) )

--- a/python/GafferUI/NotificationMessageHandler.py
+++ b/python/GafferUI/NotificationMessageHandler.py
@@ -89,4 +89,4 @@ class _Window( GafferUI.Window ) :
 
 	def appendMessage( self, level, context, message ) :
 
-		self.getChild().appendMessage( level, context, message )
+		self.getChild().messageHandler().handle( level, context, message )

--- a/python/GafferUI/NotificationMessageHandler.py
+++ b/python/GafferUI/NotificationMessageHandler.py
@@ -50,17 +50,19 @@ class NotificationMessageHandler( IECore.MessageHandler ) :
 	# window
 	__windows = set()
 
-	def __init__( self, windowTitle = "Notifications" ) :
+	# GafferUI.MessageWidget kwargs can be used here to control message presentation.
+	def __init__( self, windowTitle = "Notifications", **widgetKw ) :
 
 		IECore.MessageHandler.__init__( self )
 
 		self.__window = None
 		self.__windowTitle = windowTitle
+		self.__widgetKw = widgetKw
 
 	def handle( self, level, context, msg ) :
 
 		if self.__window is None :
-			self.__window = _Window( self.__windowTitle )
+			self.__window = _Window( self.__windowTitle, self.__widgetKw )
 			self.__window.closedSignal().connect( NotificationMessageHandler.__windowClosed, scoped = False )
 			NotificationMessageHandler.__windows.add( self.__window )
 
@@ -79,11 +81,11 @@ class NotificationMessageHandler( IECore.MessageHandler ) :
 
 class _Window( GafferUI.Window ) :
 
-	def __init__( self, title ) :
+	def __init__( self, title, widgetKw ) :
 
 		GafferUI.Window.__init__( self, title, borderWidth = 8 )
 
-		self.setChild( GafferUI.MessageWidget() )
+		self.setChild( GafferUI.MessageWidget( **widgetKw ) )
 
 		self.setResizeable( True )
 

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -100,6 +100,11 @@ _styleColors = {
 	"errorColor" : (255, 85, 85),
 	"animatedColor" : (128, 152, 94),
 
+	"foregroundError" : ( 196, 80, 80 ),
+	"foregroundWarning" : ( 239, 129, 24 ),
+	"foregroundInfo" : ( 128, 179, 254 ),
+	"foregroundDebug" : ( 163, 163, 163 ),
+
 	# Controls and other UI elements may have to sit on a variety of background
 	# colors and as such should make use of the $tint* colors for tonal
 	# variation. This should be in preference to using $background* colors
@@ -1139,6 +1144,20 @@ _styleSheet = string.Template(
 
 	_TableView QHeaderView::section:vertical {
 		padding: 2px;
+	}
+
+	*[gafferClass="GafferUI.MessageWidget._MessageTableView"] {
+		font-family: $monospaceFontFamily;
+		background-color: $background;
+		border: 1px solid $backgroundHighlight;
+		border-top-color: $backgroundLowlight;
+		border-left-color: $backgroundLowlight;
+		padding: 0;
+	}
+
+	*[gafferClass="GafferUI.MessageWidget._MessageSummaryWidget"] QPushButton {
+		padding-left: 4px;
+		padding-right: 4px;
 	}
 
 	/* checkboxes within table views */

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -120,7 +120,8 @@ _themeVariables = {
 	"roundedCornerRadius" : "6px",
 	"widgetCornerRadius" : "4px",
 	"controlCornerRadius" : "2px",
-	"toolOverlayInset" : "44px"
+	"toolOverlayInset" : "44px",
+	"monospaceFontFamily" : '"SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace'
 }
 
 substitutions = {
@@ -341,7 +342,7 @@ _styleSheet = string.Template(
 	}
 
 	QPlainTextEdit[gafferRole="Code"] {
-		font-family: monospace;
+		font-family: $monospaceFontFamily;
 	}
 
 	QLineEdit:focus, QPlainTextEdit[readOnly="false"]:focus, QLineEdit[gafferHighlighted="true"] {

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -40,7 +40,7 @@
 		'editScopeNode',
 		'editScopeProcessorNode',
 		'errorNotification',
-		'errorNotificationSmall',
+		'errorSmall',
 		'expansion',
 		'export',
 		'exposureOff',

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -33,6 +33,7 @@
 		'collapsibleArrowRight',
 		'collapsibleArrowRightHover',
 		'debugNotification',
+		'debugSmall',
 		'delete',
 		'deleteSmall',
 		'drawingStyles',
@@ -120,6 +121,7 @@
 		'sceneInspectorHistory',
 		'sceneInspectorInheritance',
 		'search',
+		'clearSearch',
 		'selectionMaskOff',
 		'selectionMaskOn',
 		'setMembershipDot',
@@ -153,5 +155,8 @@
 		'viewPaused',
 		'warningNotification',
 		'warningSmall',
+		'searchFocusOff',
+		'searchFocusOn',
+		'scrollToBottom'
 	]
 }

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -5068,7 +5068,7 @@
     <path
        sodipodi:nodetypes="cccccccc"
        inkscape:connector-curvature="0"
-       id="errorNotificationSmall"
+       id="errorSmall"
        d="m -5.0077704,145.53928 c -0.275586,0.0214 -0.536587,0.183 -0.678299,0.42003 l -5.6434386,9.32208 c -0.315516,0.52386 0.134045,1.31576 0.746128,1.31431 H 0.70349865 c 0.61208295,0.002 1.06164395,-0.79045 0.74612795,-1.31431 l -5.643439,-9.32208 c -0.164893,-0.27589 -0.493259,-0.44533 -0.813958,-0.42003 z"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
        inkscape:label="#path3902" />

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -21,6 +21,47 @@
   <defs
      id="defs4">
     <linearGradient
+       id="linearGradient1697"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#9e9e9e;stop-opacity:1;"
+         offset="0"
+         id="stop1695" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1691"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#9e9e9e;stop-opacity:1;"
+         offset="0"
+         id="stop1688" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3889"
+       osb:paint="solid"
+       gradientTransform="translate(105.56325,109.08497)">
+      <stop
+         style="stop-color:#9e9e9e;stop-opacity:1;"
+         offset="0"
+         id="stop3887" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1659"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#3c3c3c;stop-opacity:1;"
+         offset="0"
+         id="stop1657" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1653"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#686868;stop-opacity:1;"
+         offset="0"
+         id="stop1651" />
+    </linearGradient>
+    <linearGradient
        id="linearGradient1643"
        osb:paint="solid"
        gradientTransform="matrix(0,-0.58060489,0.58060489,0,667.41509,28.649796)">
@@ -800,6 +841,55 @@
        y1="13.132758"
        x2="304.68634"
        y2="13.132758" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundDark"
+       id="linearGradient1661"
+       x1="-53"
+       y1="62.965736"
+       x2="-44"
+       y2="62.965736"
+       gradientUnits="userSpaceOnUse" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask2603">
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         style="opacity:0.98999999;fill:#ffffff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+         d="m 120.00001,111.38722 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
+         id="path2605"
+         inkscape:label="#path3910" />
+    </mask>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask2800">
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         style="opacity:0.98999999;fill:#ffffff;fill-opacity:0.98431373;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 130.23571,107.15898 c -6.3945,0 -11.57828,5.18439 -11.57828,11.57965 0,6.39526 5.18378,11.57963 11.57828,11.57963 6.39449,0 11.57826,-5.18437 11.57826,-11.57963 0,-6.39526 -5.18377,-11.57965 -11.57826,-11.57965 z"
+         id="path2802"
+         inkscape:label="#path1410" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient1693"
+       x1="-74.5"
+       y1="62.362183"
+       x2="-65.5"
+       y2="62.362183"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient1699"
+       x1="-72.5"
+       y1="62.362183"
+       x2="-67.5"
+       y2="62.362183"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -808,16 +898,16 @@
      borderopacity="1"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="16"
-     inkscape:cx="372.07192"
-     inkscape:cy="724.3096"
+     inkscape:zoom="24.052944"
+     inkscape:cx="-67.594043"
+     inkscape:cy="993.24201"
      inkscape:document-units="px"
-     inkscape:current-layer="layer1"
+     inkscape:current-layer="searchFocusOn"
      showgrid="true"
-     inkscape:window-width="1572"
-     inkscape:window-height="981"
-     inkscape:window-x="348"
-     inkscape:window-y="28"
+     inkscape:window-width="2363"
+     inkscape:window-height="1399"
+     inkscape:window-x="538"
+     inkscape:window-y="100"
      inkscape:window-maximized="0"
      inkscape:snap-global="true"
      inkscape:snap-nodes="true"
@@ -826,7 +916,7 @@
      inkscape:snap-object-midpoints="false"
      inkscape:snap-bbox-midpoints="true"
      inkscape:snap-smooth-nodes="true"
-     showguides="true"
+     showguides="false"
      inkscape:guide-bbox="true"
      inkscape:snap-grids="true"
      inkscape:object-paths="false"
@@ -861,7 +951,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -1768,43 +1858,10 @@
     <path
        sodipodi:nodetypes="sssss"
        inkscape:connector-curvature="0"
-       style="opacity:0.98999999;fill:#69ffa5;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
-       d="m 120.46875,110.54346 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
+       style="opacity:0.98999999;fill:#b7b1b1;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+       d="m 119.97497,111.41225 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
        id="debugNotification"
        inkscape:label="#path3910" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Palatino;-inkscape-font-specification:'Palatino Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none"
-       x="116.33425"
-       y="127.65516"
-       id="text3930"><tspan
-         sodipodi:role="line"
-         id="tspan3932"
-         x="116.33425"
-         y="127.65516"
-         style="font-size:12.17015266px;line-height:1.25">z</tspan></text>
-    <text
-       id="text3934"
-       y="124.37085"
-       x="121.93954"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Palatino;-inkscape-font-specification:'Palatino Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none"
-       xml:space="preserve"><tspan
-         y="124.37085"
-         x="121.93954"
-         id="tspan3936"
-         sodipodi:role="line"
-         style="font-size:15.91973209px;line-height:1.25">z</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:Palatino;-inkscape-font-specification:'Palatino Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none"
-       x="112.00182"
-       y="130.95595"
-       id="text3938"><tspan
-         sodipodi:role="line"
-         id="tspan3940"
-         x="112.00182"
-         y="130.95595"
-         style="font-size:8.80884838px;line-height:1.25">z</tspan></text>
     <path
        sodipodi:nodetypes="sssss"
        inkscape:connector-curvature="0"
@@ -1866,7 +1923,7 @@
        inkscape:label="#rect3931" />
     <g
        transform="translate(4.9651315e-6,-0.04534109)"
-       id="search"
+       id="search-old"
        inkscape:label="#g3188"
        style="fill:url(#backgroundLighter)">
       <path
@@ -5415,5 +5472,307 @@
        d="m 302.30138,18.423424 -3.43097,-2.443491 -3.44073,2.429728 1.26367,-4.018128 -3.37406,-2.521504 4.21197,-0.03985 1.35545,-3.9881025 1.33946,3.9935005 4.21177,0.05672 -3.38412,2.507967 z"
        transform="matrix(1.119198,0,0,1.1443239,39.017934,313.89113)"
        inkscape:label="" />
+    <path
+       inkscape:label="#path1410"
+       id="debugSmall"
+       d="m 43.263458,145.36217 c -3.037564,0 -5.500002,2.46244 -5.500002,5.50001 0,3.03757 2.462438,5.5 5.500002,5.5 3.037564,0 5.499997,-2.46243 5.499997,-5.5 0,-3.03757 -2.462433,-5.50001 -5.499997,-5.50001 z"
+       style="opacity:0.98999999;fill:#b8b2b2;fill-opacity:0.98431373;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssss" />
+    <rect
+       inkscape:label="#rect3931"
+       transform="matrix(0,1,1,0,0,0)"
+       y="-54.258709"
+       x="55.467892"
+       height="14.999993"
+       width="15.000001"
+       id="rect2480"
+       style="fill:none;stroke:none" />
+    <g
+       inkscape:label="messagesFocus"
+       id="messagesFocus"
+       transform="translate(-10)"
+       style="stroke:url(#linearGradient1661);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers" />
+    <path
+       style="opacity:1;fill:#9e9e9e;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m -41,5.5 3.427734,6 H -42.5 v 2 h 11 v -2 h -4.927734 L -33,5.5 Z"
+       transform="translate(0,52.362183)"
+       id="scrollToBottom"
+       inkscape:connector-curvature="0" />
+    <rect
+       y="56.36219"
+       x="-42"
+       height="10"
+       width="10"
+       id="rect1650"
+       style="fill:none;stroke:none" />
+    <path
+       inkscape:transform-center-y="-0.93289306"
+       inkscape:transform-center-x="0.28410261"
+       d="m 132.8388,126.10749 c -1.85373,2.47164 1.88941,4.32251 -0.9518,5.53615 -2.8412,1.21364 -1.59048,-2.77039 -4.65785,-3.13995 -3.06738,-0.36956 -2.7987,3.79753 -5.27035,1.9438 -2.47164,-1.85374 1.60399,-2.7626 0.39035,-5.6038 -1.21364,-2.8412 -4.68811,-0.52498 -4.31855,-3.59236 0.36956,-3.06737 3.19447,0.008 5.0482,-2.46384 1.85374,-2.47165 -1.8894,-4.32252 0.9518,-5.53616 2.8412,-1.21364 1.59048,2.77039 4.65785,3.13995 3.06738,0.36956 2.79871,-3.79753 5.27035,-1.94379 2.47165,1.85373 -1.60399,2.76259 -0.39035,5.60379 1.21364,2.84121 4.68811,0.52499 4.31855,3.59236 -0.36955,3.06737 -3.19447,-0.008 -5.0482,2.46385 z"
+       inkscape:randomized="0"
+       inkscape:rounded="0.55"
+       inkscape:flatsided="false"
+       sodipodi:arg2="1.1670999"
+       sodipodi:arg1="0.64350111"
+       sodipodi:r2="10"
+       sodipodi:r1="6.0999999"
+       sodipodi:cy="122.44749"
+       sodipodi:cx="127.9588"
+       sodipodi:sides="6"
+       id="path2550"
+       style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.10526323;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       sodipodi:type="star"
+       transform="matrix(0.47502779,0,0,0.47497219,64.551272,61.341162)" />
+    <g
+       id="g2571"
+       mask="url(#mask2603)">
+      <path
+         transform="matrix(1.3226179,0,0,1.3409245,-40.20488,-41.331321)"
+         inkscape:transform-center-y="-2.63371"
+         inkscape:transform-center-x="0.7910214"
+         d="m 121.76711,134.48717 c -0.97623,1.30163 1.46568,1.89797 0.22429,2.94974 -1.24138,1.05177 -1.42852,-1.45493 -2.87282,-0.70577 -1.44431,0.74916 0.49703,2.34595 -1.07776,2.75494 -1.57479,0.40899 -0.65579,-1.93066 -2.28211,-1.88234 -1.62632,0.0483 -0.57005,2.32928 -2.16635,2.01449 -1.59629,-0.31479 0.24684,-2.024 -1.23938,-2.68611 -1.48623,-0.6621 -1.52424,1.85128 -2.82587,0.87505 -1.30163,-0.97622 1.10057,-1.71646 0.0488,-2.95784 -1.05176,-1.24139 -2.17652,1.0066 -2.92569,-0.43771 -0.74916,-1.4443 1.73633,-1.06895 1.32734,-2.64375 -0.40899,-1.57479 -2.39773,-0.0374 -2.44604,-1.66377 -0.0483,-1.62632 2.02818,-0.20973 2.34297,-1.80603 0.31479,-1.59629 -2.14404,-1.07407 -1.48193,-2.5603 0.66211,-1.48622 1.91832,0.69103 2.89455,-0.6106 0.97622,-1.30163 -1.46569,-1.89796 -0.2243,-2.94973 1.24139,-1.05177 1.42853,1.45493 2.87283,0.70577 1.4443,-0.74917 -0.49704,-2.34595 1.07775,-2.75494 1.5748,-0.40899 0.65579,1.93066 2.28211,1.88234 1.62632,-0.0483 0.57006,-2.32928 2.16635,-2.01449 1.5963,0.31479 -0.24684,2.024 1.23939,2.68611 1.48622,0.6621 1.52424,-1.85128 2.82587,-0.87506 1.30163,0.97623 -1.10057,1.71647 -0.0488,2.95785 1.05177,1.24139 2.17653,-1.0066 2.92569,0.43771 0.74916,1.4443 -1.73633,1.06895 -1.32733,2.64375 0.40899,1.57479 2.39773,0.0374 2.44604,1.66377 0.0483,1.62632 -2.02818,0.20973 -2.34297,1.80602 -0.31479,1.5963 2.14403,1.07408 1.48193,2.5603 -0.66211,1.48623 -1.91833,-0.69103 -2.89455,0.6106 z"
+         inkscape:randomized="0"
+         inkscape:rounded="0.55"
+         inkscape:flatsided="false"
+         sodipodi:arg2="0.86790059"
+         sodipodi:arg1="0.64350111"
+         sodipodi:r2="10"
+         sodipodi:r1="7.8000002"
+         sodipodi:cy="129.80717"
+         sodipodi:cx="115.52711"
+         sodipodi:sides="14"
+         id="path2548"
+         style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.75089747;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+         sodipodi:type="star" />
+      <path
+         d="m 120.59334,132.7303 a 7.9999995,7.9999995 0 0 1 -7.99801,8 7.9999995,7.9999995 0 0 1 -8.00199,-7.99602 7.9999995,7.9999995 0 0 1 7.99403,-8.00398 7.9999995,7.9999995 0 0 1 8.00596,7.99204"
+         sodipodi:open="true"
+         sodipodi:end="6.2821905"
+         sodipodi:start="0"
+         sodipodi:ry="7.9999995"
+         sodipodi:rx="7.9999995"
+         sodipodi:cy="132.7303"
+         sodipodi:cx="112.59334"
+         sodipodi:type="arc"
+         id="path2552"
+         style="opacity:1;fill:#b8b2b2;fill-opacity:0.98431373;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
+    </g>
+    <path
+       style="opacity:1;fill:#b8b2b2;fill-opacity:0.98431373;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       id="path2552-3"
+       sodipodi:type="arc"
+       sodipodi:cx="125.33526"
+       sodipodi:cy="119.50031"
+       sodipodi:rx="1.5975029"
+       sodipodi:ry="1.6198807"
+       sodipodi:start="0"
+       sodipodi:end="6.2821905"
+       sodipodi:open="true"
+       d="m 126.93276,119.50031 a 1.5975029,1.6198807 0 0 1 -1.5971,1.61988 1.5975029,1.6198807 0 0 1 -1.5979,-1.61907 1.5975029,1.6198807 0 0 1 1.59631,-1.62069 1.5975029,1.6198807 0 0 1 1.59869,1.61827" />
+    <path
+       inkscape:label="#path3910"
+       id="path2622"
+       d="m 119.97497,111.41225 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
+       style="opacity:0.98999999;fill:none;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssss" />
+    <g
+       id="g2632"
+       transform="matrix(0.74401127,0,0,0.79808084,9.1899804,31.101191)"
+       style="stroke-width:1.29773736" />
+    <g
+       id="search"
+       inkscape:label="search"
+       transform="translate(1,-0.00447807)">
+      <path
+         d="m 251.5,112.36666 a 4.5,4.5 0 0 1 -4.49888,4.5 4.5,4.5 0 0 1 -4.50112,-4.49776 4.5,4.5 0 0 1 4.49664,-4.50224 4.5,4.5 0 0 1 4.50336,4.49552"
+         sodipodi:open="true"
+         sodipodi:end="6.2821905"
+         sodipodi:start="0"
+         sodipodi:ry="4.5"
+         sodipodi:rx="4.5"
+         sodipodi:cy="112.36666"
+         sodipodi:cx="247"
+         sodipodi:type="arc"
+         id="path2706"
+         style="opacity:1;fill:none;fill-opacity:0.98431373;stroke:#3c3c3c;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
+      <path
+         sodipodi:nodetypes="ccc"
+         style="fill:none;stroke:#3c3c3c;stroke-width:3.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 250,115.36218 3,3 0.5,0.5"
+         id="path2640"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:1;fill:none;fill-opacity:0.98431373;stroke:#9e9e9e;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+         id="path2636"
+         sodipodi:type="arc"
+         sodipodi:cx="247"
+         sodipodi:cy="112.36666"
+         sodipodi:rx="4.5"
+         sodipodi:ry="4.5"
+         sodipodi:start="0"
+         sodipodi:end="6.2821905"
+         sodipodi:open="true"
+         d="m 251.5,112.36666 a 4.5,4.5 0 0 1 -4.49888,4.5 4.5,4.5 0 0 1 -4.50112,-4.49776 4.5,4.5 0 0 1 4.49664,-4.50224 4.5,4.5 0 0 1 4.50336,4.49552" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path2638"
+         d="m 250,115.36218 2.5,2.5 0.5,0.5"
+         style="fill:none;stroke:#9e9e9e;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+         id="rect2728"
+         width="18"
+         height="14"
+         x="237"
+         y="106.36666" />
+    </g>
+    <path
+       inkscape:label="#path3271-4-9"
+       sodipodi:nodetypes="ccccccccccccc"
+       style="fill:#9e9e9e;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 226.5163,111.87124 2.49095,2.49094 -2.49095,2.49095 1.99276,1.99275 2.49094,-2.49094 2.49095,2.49094 1.99275,-1.99275 -2.49094,-2.49095 2.49094,-2.49094 -1.99275,-1.99276 -2.49095,2.49095 -2.49094,-2.49095 z"
+       id="213223"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       id="clearSearch"
+       width="15.999999"
+       height="15.999999"
+       x="223"
+       y="106.36218"
+       inkscape:label="rect2708" />
+    <g
+       id="g2632-5"
+       transform="matrix(0.82222636,0,0,0.84233353,4.4504368,28.146872)"
+       style="stroke-width:1.20160651" />
+    <path
+       inkscape:transform-center-y="-0.93289306"
+       inkscape:transform-center-x="0.28410261"
+       d="m 132.8388,126.10749 c -1.85373,2.47164 1.88941,4.32251 -0.9518,5.53615 -2.8412,1.21364 -1.59048,-2.77039 -4.65785,-3.13995 -3.06738,-0.36956 -2.7987,3.79753 -5.27035,1.9438 -2.47164,-1.85374 1.60399,-2.7626 0.39035,-5.6038 -1.21364,-2.8412 -4.68811,-0.52498 -4.31855,-3.59236 0.36956,-3.06737 3.19447,0.008 5.0482,-2.46384 1.85374,-2.47165 -1.8894,-4.32252 0.9518,-5.53616 2.8412,-1.21364 1.59048,2.77039 4.65785,3.13995 3.06738,0.36956 2.79871,-3.79753 5.27035,-1.94379 2.47165,1.85373 -1.60399,2.76259 -0.39035,5.60379 1.21364,2.84121 4.68811,0.52499 4.31855,3.59236 -0.36955,3.06737 -3.19447,-0.008 -5.0482,2.46385 z"
+       inkscape:randomized="0"
+       inkscape:rounded="0.55"
+       inkscape:flatsided="false"
+       sodipodi:arg2="1.1670999"
+       sodipodi:arg1="0.64350111"
+       sodipodi:r2="10"
+       sodipodi:r1="6.0999999"
+       sodipodi:cy="122.44749"
+       sodipodi:cx="127.9588"
+       sodipodi:sides="6"
+       id="path2550-7"
+       style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.10526323;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       sodipodi:type="star"
+       transform="matrix(0.47502779,0,0,0.47497219,-18.602122,94.964634)"
+       mask="url(#mask2800)" />
+    <path
+       style="opacity:1;fill:#b8b2b2;fill-opacity:0.98431373;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       id="path2552-3-3"
+       sodipodi:type="arc"
+       sodipodi:cx="42.5"
+       sodipodi:cy="152.86218"
+       sodipodi:rx="1.5"
+       sodipodi:ry="1.5"
+       sodipodi:start="0"
+       sodipodi:end="6.2821905"
+       sodipodi:open="true"
+       d="m 44,152.86218 a 1.5,1.5 0 0 1 -1.499627,1.5 A 1.5,1.5 0 0 1 41,152.86293 a 1.5,1.5 0 0 1 1.498881,-1.50075 1.5,1.5 0 0 1 1.501118,1.49851" />
+    <g
+       id="searchFocusOn"
+       inkscape:label="#g1676">
+      <rect
+         y="56.362183"
+         x="-76"
+         height="12"
+         width="12"
+         id="rect1670"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill" />
+      <path
+         style="opacity:1;fill:none;fill-opacity:1;stroke:#383838;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+         id="path1663"
+         sodipodi:type="arc"
+         sodipodi:cx="-70"
+         sodipodi:cy="62.362183"
+         sodipodi:rx="4"
+         sodipodi:ry="4"
+         sodipodi:start="0"
+         sodipodi:end="6.2821905"
+         sodipodi:open="true"
+         d="M -66,62.362183 A 4,4 0 0 1 -69.999005,66.362182 4,4 0 0 1 -74,62.364172 a 4,4 0 0 1 3.997016,-4.001988 4,4 0 0 1 4.002982,3.996019" />
+      <path
+         d="m -66.25,62.362183 a 3.75,3.75 0 0 1 -3.749067,3.75 3.75,3.75 0 0 1 -3.750933,-3.748135 3.75,3.75 0 0 1 3.747202,-3.751864 3.75,3.75 0 0 1 3.752796,3.746268"
+         sodipodi:open="true"
+         sodipodi:end="6.2821905"
+         sodipodi:start="0"
+         sodipodi:ry="3.75"
+         sodipodi:rx="3.75"
+         sodipodi:cy="62.362183"
+         sodipodi:cx="-70"
+         sodipodi:type="arc"
+         id="path1659"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient1693);stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
+      <path
+         d="m -68.5,62.362183 a 1.5,1.5 0 0 1 -1.499627,1.5 1.5,1.5 0 0 1 -1.500373,-1.499254 1.5,1.5 0 0 1 1.498881,-1.500746 1.5,1.5 0 0 1 1.501118,1.498507"
+         sodipodi:open="true"
+         sodipodi:end="6.2821905"
+         sodipodi:start="0"
+         sodipodi:ry="1.5"
+         sodipodi:rx="1.5"
+         sodipodi:cy="62.362183"
+         sodipodi:cx="-70"
+         sodipodi:type="arc"
+         id="path1661"
+         style="opacity:1;fill:url(#linearGradient1699);fill-opacity:1.0;stroke:#383838;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill" />
+    </g>
+    <g
+       inkscape:label="#g1676"
+       id="searchFocusOff"
+       transform="translate(-13)">
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill"
+         id="rect1678"
+         width="12"
+         height="12"
+         x="-76"
+         y="56.362183" />
+      <path
+         d="M -66,62.362183 A 4,4 0 0 1 -69.999005,66.362182 4,4 0 0 1 -74,62.364172 a 4,4 0 0 1 3.997016,-4.001988 4,4 0 0 1 4.002982,3.996019"
+         sodipodi:open="true"
+         sodipodi:end="6.2821905"
+         sodipodi:start="0"
+         sodipodi:ry="4"
+         sodipodi:rx="4"
+         sodipodi:cy="62.362183"
+         sodipodi:cx="-70"
+         sodipodi:type="arc"
+         id="path1680"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:#383838;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
+      <path
+         style="opacity:1;fill:none;fill-opacity:1;stroke:#9e9e9e;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+         id="path1682"
+         sodipodi:type="arc"
+         sodipodi:cx="-70"
+         sodipodi:cy="62.362183"
+         sodipodi:rx="3.75"
+         sodipodi:ry="3.75"
+         sodipodi:start="0"
+         sodipodi:end="6.2821905"
+         sodipodi:open="true"
+         d="m -66.25,62.362183 a 3.75,3.75 0 0 1 -3.749067,3.75 3.75,3.75 0 0 1 -3.750933,-3.748135 3.75,3.75 0 0 1 3.747202,-3.751864 3.75,3.75 0 0 1 3.752796,3.746268" />
+      <path
+         style="opacity:1;fill:#9e9e9e;fill-opacity:1;stroke:#383838;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill"
+         id="path1684"
+         sodipodi:type="arc"
+         sodipodi:cx="-70"
+         sodipodi:cy="62.362183"
+         sodipodi:rx="1.5"
+         sodipodi:ry="1.5"
+         sodipodi:start="0"
+         sodipodi:end="6.2821905"
+         sodipodi:open="true"
+         d="m -68.5,62.362183 a 1.5,1.5 0 0 1 -1.499627,1.5 1.5,1.5 0 0 1 -1.500373,-1.499254 1.5,1.5 0 0 1 1.498881,-1.500746 1.5,1.5 0 0 1 1.501118,1.498507" />
+    </g>
   </g>
 </svg>

--- a/src/Gaffer/IECorePreview/Messages.cpp
+++ b/src/Gaffer/IECorePreview/Messages.cpp
@@ -1,0 +1,179 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Cinesite VFX Ltd. nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+/////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/Private/IECorePreview/Messages.h"
+
+#include <algorithm>
+
+using namespace IECorePreview;
+
+void Message::hash( IECore::MurmurHash &h ) const
+{
+	h.append( level );
+	h.append( context );
+	h.append( message );
+}
+
+bool Message::operator == ( const Message &other ) const
+{
+	return level == other.level && context == other.context && message == other.message;
+}
+
+bool Message::operator != ( const Message &other ) const
+{
+	return !( *this == other );
+}
+
+Messages::Messages()
+	: m_bucketSize( 100 )
+{
+	m_nextBucket.reserve( m_bucketSize );
+	clear();
+}
+
+bool Messages::operator == ( const Messages &other ) const
+{
+	return m_hash == other.m_hash;
+}
+
+bool Messages::operator != ( const Messages &other ) const
+{
+	return !( *this == other );
+}
+
+void Messages::add( const Message &message )
+{
+	m_nextBucket.push_back( message );
+	message.hash( m_hash );
+
+	++m_counts[ int(message.level) ];
+
+	if( m_nextBucket.size() == m_bucketSize )
+	{
+		const std::shared_ptr<const Bucket> b( new Bucket( std::move(m_nextBucket) ) );
+		m_buckets.push_back( b );
+		m_nextBucket.reserve( m_bucketSize );
+	}
+}
+
+void Messages::clear()
+{
+	m_nextBucket.clear();
+	m_buckets.clear();
+	std::fill( m_counts.begin(), m_counts.end(), 0 );
+	m_hash = IECore::MurmurHash();
+}
+
+size_t Messages::size() const
+{
+	return ( m_buckets.size() * m_bucketSize ) + m_nextBucket.size();
+}
+
+const Message& Messages::operator[]( size_t index ) const
+{
+	const size_t item = index % m_bucketSize;
+	const size_t bucket = index / m_bucketSize;
+	return bucket == m_buckets.size() ? m_nextBucket[ item ] : (*m_buckets[ bucket ])[ item ];
+}
+
+size_t Messages::count( const IECore::MessageHandler::Level &level ) const
+{
+	if( level == IECore::MessageHandler::Level::Invalid )
+	{
+		return 0;
+	}
+
+	return m_counts[ int(level) ];
+}
+
+boost::optional<size_t> Messages::firstDifference( const Messages &other ) const
+{
+	if( size() == 0 )
+	{
+		return boost::none;
+	}
+
+	if( other.size() == 0 )
+	{
+		return 0;
+	}
+
+	// If a container is copied, then it will share full buckets
+	// with the other container. As such, we can reverse iterate
+	// the list of completed buckets looking for a match. If a later
+	// bucket matches, then all the previous buckets must match,
+	// so we can skip checking any messages in shared buckets.
+
+	size_t comparisonStartIndex = 0;
+
+	const size_t numComparableBuckets = std::min( m_buckets.size(), other.m_buckets.size() );
+	if( numComparableBuckets > 0 )
+	{
+		for( size_t i = numComparableBuckets - 1; ; --i )
+		{
+			if( m_buckets[i] == other.m_buckets[i] )
+			{
+				comparisonStartIndex = ( i + 1 ) * m_bucketSize;
+				break;
+			}
+
+			if( i == 0 ) { break; }
+		}
+	}
+
+	// Now we've found the latest safe comparison start point, actually check messages
+	const size_t numComparableMessages = std::min( size(), other.size() );
+	for( size_t i = comparisonStartIndex; i < numComparableMessages; ++i )
+	{
+		if( (*this)[i] != other[i] )
+		{
+			return i;
+		}
+	}
+
+	// No differences - only return the index if other has fewer messages
+	if( numComparableMessages < size() )
+	{
+		return numComparableMessages;
+	}
+
+	return boost::none;
+}
+
+IECore::MurmurHash Messages::hash() const
+{
+	return m_hash;
+}

--- a/src/Gaffer/IECorePreview/MessagesData.cpp
+++ b/src/Gaffer/IECorePreview/MessagesData.cpp
@@ -1,0 +1,70 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Cinesite VFX Ltd. nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+/////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/Private/IECorePreview/MessagesData.h"
+
+#include "Gaffer/TypeIds.h"
+
+#include "IECore/TypedData.inl"
+
+using namespace IECorePreview;
+
+namespace IECore
+{
+
+IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( IECorePreview::MessagesData, Gaffer::MessagesDataTypeId )
+
+template<>
+void MessagesData::save( SaveContext *context ) const
+{
+	throw IECore::NotImplementedException( "MessagesData::save Not implemented" );
+}
+
+template<>
+void MessagesData::load( LoadContextPtr context )
+{
+	throw IECore::NotImplementedException( "MessagesData::load Not implemented" );
+}
+
+template<>
+MurmurHash SharedDataHolder<Messages>::hash() const
+{
+	return readable().hash();
+}
+
+template class TypedData<Messages>;
+
+};

--- a/src/GafferImage/Display.cpp
+++ b/src/GafferImage/Display.cpp
@@ -639,12 +639,11 @@ void Display::dataReceived()
 // Called on the UI thread after being scheduled by `dataReceived()`.
 void Display::dataReceivedUI()
 {
-	// Get the batch of plugs to trigger updates for. We want to hold
-	// g_plugsPendingUpdateMutex for the shortest duration possible,
-	// because it causes contention between the background rendering
-	// thread and the UI thread, and can significantly affect performance.
-	// We do this by "stealing" the current batch, so the background
-	// thread will create a new batch and we are safe to iterate our
+	// Get the batch of plugs to trigger updates for. We want to hold the mutex
+	// for the shortest duration possible, because it causes contention between
+	// the background rendering thread and the UI thread, and can significantly
+	// affect performance.  We do this by "stealing" the current batch, so the
+	// background thread will create a new batch and we are safe to iterate our
 	// batch without holding the lock.
 	PlugSetPtr batch;
 	{

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -80,6 +80,7 @@
 #include "ValuePlugBinding.h"
 #include "NameValuePlugBinding.h"
 #include "ShufflesBinding.h"
+#include "MessagesBinding.h"
 
 #include "GafferBindings/DependencyNodeBinding.h"
 
@@ -238,6 +239,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindSpreadsheet();
 	bindNodeAlgo();
 	bindShuffles();
+	bindMessages();
 
 	NodeClass<Backdrop>();
 

--- a/src/GafferModule/MessagesBinding.cpp
+++ b/src/GafferModule/MessagesBinding.cpp
@@ -1,0 +1,158 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+#include "boost/python/slice.hpp"
+#include "boost/python/suite/indexing/container_utils.hpp"
+
+#include "MessagesBinding.h"
+
+#include "Gaffer/Private/IECorePreview/MessagesData.h"
+
+#include "IECorePython/RunTimeTypedBinding.h"
+#include "IECorePython/RunTimeTypedBinding.inl"
+
+#include "IECorePython/SimpleTypedDataBinding.h"
+
+#include "boost/functional/hash.hpp"
+
+using namespace boost::python;
+using namespace IECorePreview;
+
+namespace
+{
+
+Message getItem( Messages &m, long index )
+{
+	const long size = m.size();
+
+	if( index < 0 )
+	{
+		index = size + index;
+	}
+
+	if( index < 0 || index >= size )
+	{
+		PyErr_SetString( PyExc_IndexError, "Index out of range" );
+		throw_error_already_set();
+	}
+
+	return m[ index ];
+
+}
+
+long hashMessage( const Message &m )
+{
+	IECore::MurmurHash h;
+	m.hash( h );
+	return boost::hash<IECore::MurmurHash>()( h );
+}
+
+object firstDifferenceWrapper( const Messages &m, const Messages &others )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	auto d = m.firstDifference( others );
+	return d ? object( *d ) : object();
+}
+
+long hashMessages( const Messages &m )
+{
+	return boost::hash<IECore::MurmurHash>()( m.hash() );
+}
+
+std::string reprMessagesData( const MessagesData *m )
+{
+	if( m->readable().size() > 0 )
+	{
+		throw IECore::NotImplementedException( "MessagesData::repr Not implemented for non-empty containers" );
+	}
+
+	return std::string( "Gaffer.Private.IECorePreview.MessagesData()" );
+}
+
+}
+
+void GafferModule::bindMessages()
+{
+	object privateModule( borrowed( PyImport_AddModule( "Gaffer.Private" ) ) );
+	scope().attr( "Private" ) = privateModule;
+
+	object ieCorePreviewModule( borrowed( PyImport_AddModule( "Gaffer.Private.IECorePreview" ) ) );
+	scope().attr( "Private" ).attr( "IECorePreview" ) = ieCorePreviewModule;
+
+	scope previewScope( ieCorePreviewModule );
+
+	class_<Message>( "Message", no_init )
+		.def(
+			init<IECore::MessageHandler::Level, const std::string &, const std::string &>(
+				( arg( "level" ), arg( "context" ), arg( "message" ) )
+			)
+		)
+		.add_property( "level", &Message::level )
+		.add_property( "context", &Message::context )
+		.add_property( "message", &Message::message )
+		.def( "hash", &Message::hash )
+		.def( self == self )
+		.def( self != self )
+		.def( "__hash__", &hashMessage )
+	;
+
+	class_<Messages>( "Messages" )
+		.def( init<>() )
+		.def( init<const Messages &>( ( arg("other") ) ) )
+		.def( "size", &Messages::size )
+		.def( "count", &Messages::count )
+		.def( "clear", &Messages::clear )
+		.def( "hash", &Messages::hash )
+		.def( "add", &Messages::add )
+		.def( "firstDifference", &firstDifferenceWrapper )
+		.def( self == self )
+		.def( self != self )
+		.def( "__len__", &Messages::size )
+		.def( "__getitem__", &getItem )
+		.def( "__hash__", &hashMessages )
+	;
+
+	IECorePython::RunTimeTypedClass<MessagesData>()
+		.def( init<>() )
+		.def( init<const IECorePreview::Messages &>() )
+		.add_property( "value", make_function( &MessagesData::writable, return_internal_reference<1>() ) )
+		.def( "hasBase", &MessagesData::hasBase ).staticmethod( "hasBase" )
+		.def( "__repr__", &reprMessagesData )
+	;
+
+	IECorePython::TypedDataFromType<MessagesData>();
+}

--- a/src/GafferModule/MessagesBinding.h
+++ b/src/GafferModule/MessagesBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020 Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Cinesite VFX Ltd. nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERMODULE_MESSAGESBINDING_H
+#define GAFFERMODULE_MESSAGESBINDING_H
+
+namespace GafferModule
+{
+
+void bindMessages();
+
+} // namespace GafferModule
+
+#endif // GAFFERMODULE_MESSAGESBINDING_H

--- a/src/GafferTestModule/GafferTestModule.cpp
+++ b/src/GafferTestModule/GafferTestModule.cpp
@@ -48,6 +48,7 @@
 #include "LRUCacheTest.h"
 #include "TaskMutexTest.h"
 #include "ValuePlugTest.h"
+#include "MessagesTest.h"
 
 #include "IECorePython/ScopedGILRelease.h"
 
@@ -80,5 +81,6 @@ BOOST_PYTHON_MODULE( _GafferTest )
 	bindTaskMutexTest();
 	bindLRUCacheTest();
 	bindValuePlugTest();
+	bindMessagesTest();
 
 }

--- a/src/GafferTestModule/MessagesTest.cpp
+++ b/src/GafferTestModule/MessagesTest.cpp
@@ -1,0 +1,134 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Cinesite VFX Ltd. nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "MessagesTest.h"
+
+#include "GafferTest/Assert.h"
+
+#include "Gaffer/Private/IECorePreview/Messages.h"
+
+using namespace IECorePreview;
+using namespace boost::python;
+
+namespace
+{
+
+void testCopyPerformance( const Messages &m, size_t count )
+{
+	for( size_t i = 0; i < count; ++i )
+	{
+		Messages c = m;
+		c.size();
+	}
+}
+
+void testAddPerformance( size_t count )
+{
+	const std::string context = "testMessagesAddPerformance";
+	const std::string message = "testMessagesAddPerformancetestMessagesAddPerformancetestMessagesAddPerformance";
+
+	Messages m;
+	for( size_t i = 0; i < count; ++i )
+	{
+		m.add( Message( IECore::MessageHandler::Level( i % 4 ), context, message ) );
+	}
+}
+
+void testValueReuse()
+{
+	// Note, this is a somewhat 'internal' test, to verify we're not
+	// over-copying. As such, it has an explicit understanding of
+	// the underlying implementation.
+
+	size_t numMessages = 102;
+	size_t bucketSize = 100;
+
+	Messages m;
+
+	for( size_t i = 0; i < numMessages; ++ i )
+	{
+		m.add( Message( IECore::MessageHandler::Level( i % 5 ), "testValueReuse", std::to_string( i ) ) );
+	}
+
+	Messages c = m;
+
+	// Messages should be shared once in the const buckets
+	for( size_t i = 0; i < bucketSize; ++ i )
+	{
+		GAFFERTEST_ASSERT( &c[i] == &m[i] );
+	}
+}
+
+void testConstness()
+{
+	Messages m;
+	std::vector<Messages> c;
+
+	const size_t numMessages = 25;
+
+	c.push_back( m );
+	for( size_t i = 1; i < numMessages; ++i )
+	{
+		m.add( Message( IECore::MessageHandler::Level( i % 5 ), "testMessagesConstness", std::to_string( i ) ) );
+		c.push_back( m );
+	}
+
+	for( size_t i = 1; i < numMessages; ++i )
+	{
+		GAFFERTEST_ASSERT( c[i].size() == i );
+		GAFFERTEST_ASSERT( c[i][i-1].message == std::to_string( i ) );
+		GAFFERTEST_ASSERT( c.back()[i-1].message == std::to_string( i ) );
+	}
+
+	m.clear();
+
+	for( size_t i = 1; i < numMessages; ++i )
+	{
+		GAFFERTEST_ASSERT( c[i].size() == i );
+		GAFFERTEST_ASSERT( c[i][i-1].message == std::to_string( i ) );
+		GAFFERTEST_ASSERT( c.back()[i-1].message == std::to_string( i ) );
+	}
+}
+
+} // namespace
+
+void GafferTestModule::bindMessagesTest()
+{
+	def( "testMessagesCopyPerformance", &testCopyPerformance );
+	def( "testMessagesAddPerformance", &testAddPerformance );
+	def( "testMessagesValueReuse", &testValueReuse );
+	def( "testMessagesConstness", &testConstness );
+}

--- a/src/GafferTestModule/MessagesTest.h
+++ b/src/GafferTestModule/MessagesTest.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Cinesite VFX Ltd. nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERTESTMODULE_MESSAGESTEST_H
+#define GAFFERTESTMODULE_MESSAGESTEST_H
+
+namespace GafferTestModule
+{
+
+void bindMessagesTest();
+
+} // namespace GafferTestModule
+
+
+
+#endif // GAFFERTESTMODULE_MESSAGESTEST_H


### PR DESCRIPTION
As part of #3419, we require a mechanism to collect renderer output, and feed this into a log viewer within the Gaffer UI.

This commit adds new cheap-to-copy data types to hold messages, along with improved widgets to display and search them in the Gaffer UI. 

![image](https://user-images.githubusercontent.com/896779/83901288-69a80f80-a752-11ea-8d98-d6e1d0820758.png)

It should be backwards compatible with existing code, aside from the removal of the deprecated `MessageWidget.appendMessage` method.

Note: The `MessageWidget` changes seem to have introduced an intermittent `Internal C++ object already deleted` error. I've not been able to reliably reproduce this to fix it yet. It maybe to do with the need to hold a strong reference to a `QAction` [here](https://github.com/GafferHQ/gaffer/commit/3a1868662633246b9bf606fca65a70ed3147a895#diff-025a5d68e8d612161cc57c7ca80cea1bR426).
```
Traceback (most recent call last):
  File "/Volumes/Data/dev/gaffer-build/python/GafferUI/Widget.py", line 928, in eventFilter
    raise e
RuntimeError: Internal C++ object (PySide2.QtWidgets.QWidget) already deleted.
```
I'll attempt to get this resolved during the course of this review.

@johnhaddon There are a few contentious parts in some of the ancillary commits so feel free to suggest alternatives, etc :)