### PR TITLE
Raw file support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,11 @@ Improvements
 - Stats app : Added `-location` argument, to allow profiling of a single location in a scene.
 - AnimationEditor : Improved performance.
 
+Fixes
+-----
+
+- ImageReader/ImageWriter : Fixed handling of errors in Python functions registered using `setDefaultColorSpaceFunction()`.
+
 API
 ---
 

--- a/src/GafferImageModule/IOBinding.cpp
+++ b/src/GafferImageModule/IOBinding.cpp
@@ -69,9 +69,14 @@ struct DefaultColorSpaceFunction
 	{
 
 		IECorePython::ScopedGILLock gilock;
-		string result = extract<string>( m_fn( fileName, fileFormat, dataType, IECore::CompoundDataPtr( const_cast<IECore::CompoundData *>( metadata ) ) ) );
-		return result;
-
+		try
+		{
+			return extract<string>( m_fn( fileName, fileFormat, dataType, IECore::CompoundDataPtr( const_cast<IECore::CompoundData *>( metadata ) ) ) );
+		}
+		catch( const error_already_set &e )
+		{
+			IECorePython::ExceptionAlgo::translatePythonException();
+		}
 	}
 
 	private:

--- a/startup/GafferImage/defaultColorSpace.py
+++ b/startup/GafferImage/defaultColorSpace.py
@@ -39,6 +39,7 @@ def defaultColorSpace( fileName, fileFormat, dataType, metadata ) :
 		"png" : display,
 		"pnm" : display,
 		"psd" : display,
+		"raw" : linear,
 		"rla" : display,
 		"sgi" : display,
 		"softimage" : display,


### PR DESCRIPTION
This is the bare minimum required to make use of the LibRaw build from https://github.com/GafferHQ/dependencies/pull/150 in the ImageReader. OIIO provides numerous options for controlling LibRaw output, none of which are exposed here. We can deal with that as a followup when we've learnt more about them, and ideally once we've upgraded to the latest OIIO, which appears to behave slightly differently anyway.