### PR TITLE
TractorDispatcher: evaluate service/tags plugs in correct context

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -38,6 +38,7 @@ Fixes
   - LevelSetOffset
   - MeshToLevelSet
 - SetAlgo : Fixed `affectsSetExpression()` to return `True` for `ScenePlug::setNamesPlug()`.
+- GafferTractor: Fixed evaluation of 'tag' and 'service' plugs on Task nodes. Previously, these plugs were evaluated in the default context, which prevented one from using custom context variables (e.g. from Wedge node) to compute tags or service keys dynamically.
 
 API
 ---

--- a/python/GafferTractor/TractorDispatcher.py
+++ b/python/GafferTractor/TractorDispatcher.py
@@ -179,11 +179,15 @@ class TractorDispatcher( GafferDispatch.Dispatcher ) :
 
 			tractorPlug = batch.node()["dispatcher"].getChild( "tractor" )
 			if tractorPlug is not None :
-				## \todo Remove these manual substitutions once #887 is resolved.
-				# Note though that we will need to use `with batch.context()` to
-				# ensure the substitutions occur in the right context.
-				command.service = batch.context().substitute( tractorPlug["service"].getValue() )
-				command.tags = batch.context().substitute( tractorPlug["tags"].getValue() ).split()
+				with Gaffer.Context( batch.context() ) as batchContextWithFrame:
+					# tags and services can not be varied per-frame within a batch, but we provide the context variable
+					# as a concession to existing production setups that would error without it
+					batchContextWithFrame["frame"] = min( batch.frames() )
+					## \todo Remove these manual substitutions once #887 is resolved.
+					# Note though that we will need to use `with batch.context()` to
+					# ensure the substitutions occur in the right context.
+					command.service = batchContextWithFrame.substitute( tractorPlug["service"].getValue() )
+					command.tags = batchContextWithFrame.substitute( tractorPlug["tags"].getValue() ).split()
 
 		# Remember the task for next time, and return it.
 


### PR DESCRIPTION
This PR fixes a bug in Tractor dispatcher, where tags and service plugs were not evaluated in the correct context. These bug would only affect scripts that compute tags/service using expressions. For example:

<code>
parent["ArnoldRender"]["dispatcher"]["tags"] = context.get("render_layer_name", "")
</code>
