### PR TITLE
PythonEditor : Fix exception in exception handling with small stack

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,8 @@ Fixes
 -----
 
 - Dispatcher : Fixed dispatch of two or more Switches or ContextProcessors connected together directly.
+- PythonEditor : Fixed bug displaying information about exceptions in certain rare circumstances.
+
 
 0.56.2.3 (relative to 0.56.2.2)
 ========


### PR DESCRIPTION
Q: Do we want the outer, or inner stack frame in the line number?

ie: for this code:
```
def p() :
	raise RuntimeError( "cat" )
def h() :
	g()
def g() :
	p()
h()
```
Should the line number be, `7`, or `2`? With this PR, it's `2`.
```
RuntimeError : line 2 : cat 
  File "<string>", line 4, in h
  File "<string>", line 6, in g
  File "<string>", line 2, in p
```
And, also, would we want to include line 7 in the traceback we print (historically, we havent)?