### PR TITLE
ArnoldTextureBake : Avoid recursion depth fail with Python in loop

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Dispatcher : Fixed dispatch of two or more Switches or ContextProcessors connected together directly.
+- ArnoldTextureBake : Avoid "recursion depth" exception when more than 300 meshes in UDIM
 
 0.56.2.3 (relative to 0.56.2.2)
 ========


### PR DESCRIPTION
We were getting a "RuntimeError: maximum recursion depth exceeded" error on ArnoldTextureBake.__ImageLoop.out.format that came from the __SizeLoop which used a Python expression in critical path of a Loop node.  Making sure that only an OSL expression node is in this path changed the number of meshes supported from ~300 to >7000.