### PR TITLE
MergeScenes : Fixed bug in set computations

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - Dispatcher : Fixed dispatch of two or more Switches or ContextProcessors connected together directly.
 - ArnoldTextureBake : Fixed recursion depth exception caused by more than ~300 meshes in a UDIM.
+- MergeScenes : Fixed bug in set computations which could trigger crashes with an overloaded cache.
 
 0.56.2.3 (relative to 0.56.2.2)
 ========

--- a/src/GafferScene/MergeScenes.cpp
+++ b/src/GafferScene/MergeScenes.cpp
@@ -845,7 +845,8 @@ IECore::ConstInternedStringVectorDataPtr MergeScenes::computeSetNames( const Gaf
 					// This naive approach to merging set names preserves the order of the incoming names,
 					// but at the expense of using linear search. We assume that the number of sets is small
 					// enough and the InternedString comparison fast enough that this is OK.
-					for( const auto &setName : scene->setNamesPlug()->getValue()->readable() )
+					ConstInternedStringVectorDataPtr setNames = scene->setNamesPlug()->getValue();
+					for( const auto &setName : setNames->readable() )
 					{
 						if( std::find( merged->readable().begin(), merged->readable().end(), setName ) == merged->readable().end() )
 						{
@@ -902,9 +903,8 @@ IECore::ConstPathMatcherDataPtr MergeScenes::computeSet( const IECore::InternedS
 					merged = new PathMatcherData();
 					result = merged;
 				case InputType::Other :
-					merged->writable().addPaths(
-						scene->setPlug()->getValue()->readable()
-					);
+					ConstPathMatcherDataPtr paths = scene->setPlug()->getValue();
+					merged->writable().addPaths( paths->readable() );
 			}
 			return true;
 		}


### PR DESCRIPTION
In a heavy production setup we were seeing non-deterministic crashes during set expression evaluation and hashing. Working off 0.57_maintenance I was getting the crashes on 30-80% of frames on the farm, and roughly 1/3 of fresh computes in the GUI. With this PR all frames completed on the farm 3 times in a row, and I haven't had any GUI crashes since making the change. So I'm fairly hopeful this fixes both production issues.

### Farm Crash log ###

<details>
<summary>Click to Expand</summary><p>

<!-- Optional: Insert debug log output below -->

```
[Jun 16, 2020 16:15:47] task    [stdout]: * CRASHED in IECore::Detail::matchInternal at 00:00:00
[Jun 16, 2020 16:15:47] task    [stdout]: * signal caught: SIGSEGV -- Invalid memory reference (address not mapped to object)
[Jun 16, 2020 16:15:47] task    [stdout]: *
[Jun 16, 2020 16:15:47] task    [stdout]: * backtrace:
[Jun 16, 2020 16:15:47] task    [stdout]: *  0 0x00007fa6f9937b84 [libai.so             ] AiADPDialogStrings
[Jun 16, 2020 16:15:47] task    [stdout]: *  1 0x00007fa7b2ea35cf [libpthread.so.0      ] _L_unlock_13                                                                                                                                                                      [funlockfile.c:?]
[Jun 16, 2020 16:15:47] task    [stdout]: >> 2 0x00007fa78fce6ccf [libGafferScene.so    ] IECore::Detail::matchInternal(char const*, char const*, bool)                                                                                                                     [SetAlgo.cpp  :?]
[Jun 16, 2020 16:15:47] task    [stdout]: *  3 0x00007fa78fce6ccf [libGafferScene.so    ]                                                                                                                                                                                   [SetAlgo.cpp  :?]
[Jun 16, 2020 16:15:47] task    [stdout]: *  4 0x00007fa78fce821e [libGafferScene.so    ] IECore::Detail::matchInternal(char const*, char const*, bool)                                                                                                                     [SetAlgo.cpp  :?]
[Jun 16, 2020 16:15:47] task    [stdout]: *  5 0x00007fa78fce9ce7 [libGafferScene.so    ] GafferScene::SetAlgo::evaluateSetExpression(std::string const&, GafferScene::ScenePlug const*)
[Jun 16, 2020 16:15:47] task    [stdout]: *  6 0x00007fa78fceb767 [libGafferScene.so    ] GafferScene::SetFilter::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: *  7 0x00007fa79b84226f [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::ComputeProcess((anonymous namespace)                                                                                                           [ValuePlug.cpp:?]
[Jun 16, 2020 16:15:47] task    [stdout]: *  8 0x00007fa79b84a077 [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: *  9 0x00007fa79b846048 [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 10 0x00007fa79b83dbbf [libGaffer.so         ] Gaffer::TypedObjectPlug<IECore::TypedData<IECore::PathMatcher> >::getValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 11 0x00007fa78fceb491 [libGafferScene.so    ] GafferScene::SetFilter::computeMatch(GafferScene::ScenePlug const*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 12 0x00007fa78fc1b525 [libGafferScene.so    ] GafferScene::Filter::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 13 0x00007fa78fceb717 [libGafferScene.so    ] GafferScene::SetFilter::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 14 0x00007fa79b84226f [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)                                                                                                                      [ValuePlug.cpp:?]
[Jun 16, 2020 16:15:47] task    [stdout]: * 15 0x00007fa79b84a02a [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 16 0x00007fa79b846048 [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 17 0x00007fa79b7f428a [libGaffer.so         ] Gaffer::NumericPlug<int>::getValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 18 0x00007fa78fc58ea9 [libGafferScene.so    ] GafferScene::Isolate::computeSet(IECore::InternedString const&, Gaffer::Context const*, GafferScene::ScenePlug const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 19 0x00007fa78fccfbb8 [libGafferScene.so    ] GafferScene::SceneNode::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 20 0x00007fa79b84226f [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::ComputeProcess((anonymous namespace)                                                                                                           [ValuePlug.cpp:?]
[Jun 16, 2020 16:15:47] task    [stdout]: * 21 0x00007fa79b84a077 [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 22 0x00007fa79b846048 [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 23 0x00007fa79b83dbbf [libGaffer.so         ] Gaffer::TypedObjectPlug<IECore::TypedData<IECore::PathMatcher> >::getValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 24 0x00007fa78fc66296 [libGafferScene.so    ] GafferScene::MergeScenes::computeSet(IECore::InternedString const&, Gaffer::Context const*, GafferScene::ScenePlug const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 25 0x00007fa78fccfbb8 [libGafferScene.so    ] GafferScene::SceneNode::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 26 0x00007fa78fc68b9a [libGafferScene.so    ] GafferScene::MergeScenes::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 27 0x00007fa79b84226f [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)                                                                                                                      [ValuePlug.cpp:?]
[Jun 16, 2020 16:15:47] task    [stdout]: * 28 0x00007fa79b84a077 [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 29 0x00007fa79b846048 [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 30 0x00007fa79b83dbbf [libGaffer.so         ] Gaffer::TypedObjectPlug<IECore::TypedData<IECore::PathMatcher> >::getValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 31 0x00007fa78fc8c7b4 [libGafferScene.so    ] GafferScene::Parent::computeBranchSet(std::vector<IECore::InternedString, std::allocator<IECore::InternedString> > const&, IECore::InternedString const&, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 32 0x00007fa78fbdbadc [libGafferScene.so    ] GafferScene::BranchCreator::computeSet(IECore::InternedString const&, Gaffer::Context const*, GafferScene::ScenePlug const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 33 0x00007fa78fccfbb8 [libGafferScene.so    ] GafferScene::SceneNode::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 34 0x00007fa78fbddd22 [libGafferScene.so    ] GafferScene::BranchCreator::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 35 0x00007fa78fc8d6b1 [libGafferScene.so    ] GafferScene::Parent::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 36 0x00007fa79b84226f [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::ComputeProcess((anonymous namespace)                                                                                                           [ValuePlug.cpp:?]
[Jun 16, 2020 16:15:47] task    [stdout]: * 37 0x00007fa79b84a077 [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 38 0x00007fa79b846048 [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 39 0x00007fa79b83dbbf [libGaffer.so         ] Gaffer::TypedObjectPlug<IECore::TypedData<IECore::PathMatcher> >::getValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 40 0x00007fa78fc9e60d [libGafferScene.so    ] GafferScene::Prune::computeSet(IECore::InternedString const&, Gaffer::Context const*, GafferScene::ScenePlug const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 41 0x00007fa78fccfbb8 [libGafferScene.so    ] GafferScene::SceneNode::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 42 0x00007fa79b84226f [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)                                                                                                                      [ValuePlug.cpp:?]
[Jun 16, 2020 16:15:47] task    [stdout]: * 43 0x00007fa79b84a077 [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 44 0x00007fa79b846048 [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 45 0x00007fa79b83dbbf [libGaffer.so         ] Gaffer::TypedObjectPlug<IECore::TypedData<IECore::PathMatcher> >::getValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 46 0x00007fa78fcd721d [libGafferScene.so    ] GafferScene::ScenePlug::set(IECore::InternedString const&)
[Jun 16, 2020 16:15:47] task    [stdout]: * 47 0x00007fa78fbdb95c [libGafferScene.so    ] GafferScene::BranchCreator::computeSet(IECore::InternedString const&, Gaffer::Context const*, GafferScene::ScenePlug const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 48 0x00007fa78fccfbb8 [libGafferScene.so    ] GafferScene::SceneNode::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 49 0x00007fa78fbddd22 [libGafferScene.so    ] GafferScene::BranchCreator::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 50 0x00007fa78fc8d6b1 [libGafferScene.so    ] GafferScene::Parent::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 51 0x00007fa79b84226f [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::ComputeProcess((anonymous namespace)                                                                                                           [ValuePlug.cpp:?]
[Jun 16, 2020 16:15:47] task    [stdout]: * 52 0x00007fa79b84a077 [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 53 0x00007fa79b846048 [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 54 0x00007fa79b83dbbf [libGaffer.so         ] Gaffer::TypedObjectPlug<IECore::TypedData<IECore::PathMatcher> >::getValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 55 0x00007fa78fc9e60d [libGafferScene.so    ] GafferScene::Prune::computeSet(IECore::InternedString const&, Gaffer::Context const*, GafferScene::ScenePlug const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 56 0x00007fa78fccfbb8 [libGafferScene.so    ] GafferScene::SceneNode::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 57 0x00007fa79b84226f [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)                                                                                                                      [ValuePlug.cpp:?]
[Jun 16, 2020 16:15:47] task    [stdout]: * 58 0x00007fa79b84a077 [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 59 0x00007fa79b846048 [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 60 0x00007fa79b83dbbf [libGaffer.so         ] Gaffer::TypedObjectPlug<IECore::TypedData<IECore::PathMatcher> >::getValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 61 0x00007fa78fcd721d [libGafferScene.so    ] GafferScene::ScenePlug::set(IECore::InternedString const&)
[Jun 16, 2020 16:15:47] task    [stdout]: * 62 0x00007fa78fbdb95c [libGafferScene.so    ] GafferScene::BranchCreator::computeSet(IECore::InternedString const&, Gaffer::Context const*, GafferScene::ScenePlug const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 63 0x00007fa78fccfbb8 [libGafferScene.so    ] GafferScene::SceneNode::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 64 0x00007fa78fbddd22 [libGafferScene.so    ] GafferScene::BranchCreator::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 65 0x00007fa78fc8d6b1 [libGafferScene.so    ] GafferScene::Parent::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 66 0x00007fa79b84226f [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::ComputeProcess((anonymous namespace)                                                                                                           [ValuePlug.cpp:?]
[Jun 16, 2020 16:15:47] task    [stdout]: * 67 0x00007fa79b84a077 [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 68 0x00007fa79b846048 [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 69 0x00007fa79b83dbbf [libGaffer.so         ] Gaffer::TypedObjectPlug<IECore::TypedData<IECore::PathMatcher> >::getValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 70 0x00007fa78fc8c7b4 [libGafferScene.so    ] GafferScene::Parent::computeBranchSet(std::vector<IECore::InternedString, std::allocator<IECore::InternedString> > const&, IECore::InternedString const&, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 71 0x00007fa78fbdbadc [libGafferScene.so    ] GafferScene::BranchCreator::computeSet(IECore::InternedString const&, Gaffer::Context const*, GafferScene::ScenePlug const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 72 0x00007fa78fccfbb8 [libGafferScene.so    ] GafferScene::SceneNode::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 73 0x00007fa78fbddd22 [libGafferScene.so    ] GafferScene::BranchCreator::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 74 0x00007fa78fc8d6b1 [libGafferScene.so    ] GafferScene::Parent::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 75 0x00007fa79b84226f [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)                                                                                                                      [ValuePlug.cpp:?]
[Jun 16, 2020 16:15:47] task    [stdout]: * 76 0x00007fa79b84a077 [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 77 0x00007fa79b846048 [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 78 0x00007fa79b83dbbf [libGaffer.so         ] Gaffer::TypedObjectPlug<IECore::TypedData<IECore::PathMatcher> >::getValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 79 0x00007fa6ffa847d7 [_IEGafferRendering.so] IEGafferRendering::AssetOutput::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 80 0x00007fa79b84226f [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::ComputeProcess((anonymous namespace)                                                                                                           [ValuePlug.cpp:?]
[Jun 16, 2020 16:15:47] task    [stdout]: * 81 0x00007fa79b84a077 [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 82 0x00007fa79b846048 [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 83 0x00007fa79b83dbbf [libGaffer.so         ] Gaffer::TypedObjectPlug<IECore::TypedData<IECore::PathMatcher> >::getValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 84 0x00007fa78fcd721d [libGafferScene.so    ] GafferScene::ScenePlug::set(IECore::InternedString const&)
[Jun 16, 2020 16:15:47] task    [stdout]: * 85 0x00007fa78fce7fbf [libGafferScene.so    ] GafferScene::SceneNode::compute(Gaffer::ValuePlug*, Gaffer::Context const*)                                                                                                       [SetAlgo.cpp  :?]
[Jun 16, 2020 16:15:47] task    [stdout]: * 86 0x00007fa78fce821e [libGafferScene.so    ]                                                                                                                                                                                   [SetAlgo.cpp  :?]
[Jun 16, 2020 16:15:47] task    [stdout]: * 87 0x00007fa78fce9ce7 [libGafferScene.so    ] GafferScene::SetAlgo::evaluateSetExpression(std::string const&, GafferScene::ScenePlug const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 88 0x00007fa78fceb767 [libGafferScene.so    ] GafferScene::SetFilter::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 89 0x00007fa79b84226f [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)                                                                                                                      [ValuePlug.cpp:?]
[Jun 16, 2020 16:15:47] task    [stdout]: * 90 0x00007fa79b84a077 [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 91 0x00007fa79b846048 [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 92 0x00007fa79b83dbbf [libGaffer.so         ] Gaffer::TypedObjectPlug<IECore::TypedData<IECore::PathMatcher> >::getValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 93 0x00007fa78fceb491 [libGafferScene.so    ] GafferScene::SetFilter::computeMatch(GafferScene::ScenePlug const*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 94 0x00007fa78fc1b525 [libGafferScene.so    ] GafferScene::Filter::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 95 0x00007fa78fceb717 [libGafferScene.so    ] GafferScene::SetFilter::compute(Gaffer::ValuePlug*, Gaffer::Context const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 96 0x00007fa79b84226f [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::ComputeProcess((anonymous namespace)                                                                                                           [ValuePlug.cpp:?]
[Jun 16, 2020 16:15:47] task    [stdout]: * 97 0x00007fa79b84a02a [libGaffer.so         ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 98 0x00007fa79b846048 [libGaffer.so         ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: * 99 0x00007fa79b7f428a [libGaffer.so         ] Gaffer::NumericPlug<int>::getValue(IECore::MurmurHash const*)
[Jun 16, 2020 16:15:47] task    [stdout]: *
```
</p>
</details>

### GUI Crash log ###

<details>
<summary>Click to Expand</summary><p>

<!-- Optional: Insert debug log output below -->

```
ERROR   | signal caught: SIGSEGV -- Invalid memory reference

****
* Arnold 6.0.3.1 [93beeb25] linux clang-9.0.1 oiio-2.2.1 osl-1.11.0 vdb-4.0.0 clm-1.1.1.118 rlm-12.4.2 optix-6.7.0 2020/06/01 16:49:14
* CRASHED in IECore::Detail::matchInternal at 00:00:00
* signal caught: SIGSEGV -- Invalid memory reference (address not mapped to object)
*
* backtrace:
*  0 0x00007f013e8b6b84 [libai.so         ] AiADPDialogStrings                                                                                                                                                                                                                                               
*  1 0x00007f022835f5cf [libpthread.so.0  ] _L_unlock_13                                                                                                                                                                                                                                                     [funlockfile.c:?]
>> 2 0x00007f01e1d5cccf [libGafferScene.so] IECore::Detail::matchInternal(char const*, char const*, bool)                                                                                                                                                                                                    [SetAlgo.cpp  :?]
*  3 0x00007f01e1d5cccf [libGafferScene.so]                                                                                                                                                                                                                                                                  [SetAlgo.cpp  :?]
*  4 0x00007f01e1d5fd66 [libGafferScene.so] GafferScene::SetAlgo::setExpressionHash(std::string const&, GafferScene::ScenePlug const*, IECore::MurmurHash&)                                                                                                                                                  
*  5 0x00007f01e1d6169a [libGafferScene.so] GafferScene::SetFilter::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                              
*  6 0x00007f0210cbd31b [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::HashProcess((anonymous namespace)                                                                                                                                                                                                [ValuePlug.cpp:?]
*  7 0x00007f0210cc2944 [libGaffer.so     ]                                                                                                                                                                                                                                                                  [ValuePlug.cpp:?]
*  8 0x00007f0210cbc9fe [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::localCacheGetter((anonymous namespace)                                                                                                                                                                                           [ValuePlug.cpp:?]
*  9 0x00007f0210cc6cd0 [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::hash(Gaffer::ValuePlug const*)                                                                                                                                                                                                   
* 10 0x00007f0210cc3389 [libGaffer.so     ] Gaffer::ValuePlug::hash()                                                                                                                                                                                                                                        
* 11 0x00007f0210cbc90b [libGaffer.so     ]                                                                                                                                                                                                                                                                  [ValuePlug.cpp:?]
* 12 0x00007f0210cc1599 [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::hash(Gaffer::ValuePlug const*)                                                                                                                                                                                                   [ValuePlug.cpp:?]
* 13 0x00007f0210cc5f7e [libGaffer.so     ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)                                                                                                                                                                    
* 14 0x00007f0210cc2048 [libGaffer.so     ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)                                                                                                                                                                                                     
* 15 0x00007f0210cb9bbf [libGaffer.so     ] Gaffer::TypedObjectPlug<IECore::TypedData<IECore::PathMatcher> >::getValue(IECore::MurmurHash const*)                                                                                                                                                            
* 16 0x00007f01e1d61491 [libGafferScene.so] GafferScene::SetFilter::computeMatch(GafferScene::ScenePlug const*, Gaffer::Context const*)                                                                                                                                                                      
* 17 0x00007f01e1c91525 [libGafferScene.so] GafferScene::Filter::compute(Gaffer::ValuePlug*, Gaffer::Context const*)                                                                                                                                                                                         
* 18 0x00007f01e1d61717 [libGafferScene.so] GafferScene::SetFilter::compute(Gaffer::ValuePlug*, Gaffer::Context const*)                                                                                                                                                                                      
* 19 0x00007f0210cbe26f [libGaffer.so     ] (anonymous namespace)                                                                                                                                                                                                                                            [ValuePlug.cpp:?]
* 20 0x00007f0210cc602a [libGaffer.so     ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)                                                                                                                                                                    
* 21 0x00007f0210cc2048 [libGaffer.so     ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)                                                                                                                                                                                                     
* 22 0x00007f0210c7028a [libGaffer.so     ] Gaffer::NumericPlug<int>::getValue(IECore::MurmurHash const*)                                                                                                                                                                                                    
* 23 0x00007f01e1c93937 [libGafferScene.so] GafferScene::FilteredSceneProcessor::filterValue(Gaffer::Context const*)                                                                                                                                                                                         
* 24 0x00007f01e1ccdad3 [libGafferScene.so] GafferScene::Isolate::mayPruneChildren(std::vector<IECore::InternedString, std::allocator<IECore::InternedString> > const&, Gaffer::Context const*, GafferScene::Isolate::SetsToKeep const&)                                                                     
* 25 0x00007f01e1ccfc85 [libGafferScene.so] GafferScene::Isolate::hashChildNames(std::vector<IECore::InternedString, std::allocator<IECore::InternedString> > const&, Gaffer::Context const*, GafferScene::ScenePlug const*, IECore::MurmurHash&)                                                            
* 26 0x00007f01e1d46498 [libGafferScene.so] GafferScene::SceneNode::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                              
* 27 0x00007f01e1d4dabe [libGafferScene.so] GafferScene::SceneProcessor::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                         
* 28 0x00007f0210cbd31b [libGaffer.so     ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)                                                                                                                                                                    [ValuePlug.cpp:?]
* 29 0x00007f0210cc2944 [libGaffer.so     ]                                                                                                                                                                                                                                                                  [ValuePlug.cpp:?]
* 30 0x00007f0210cbc9fe [libGaffer.so     ] Gaffer::ValuePlug::getObjectValue(IECore::MurmurHash const*)                                                                                                                                                                                                     [ValuePlug.cpp:?]
* 31 0x00007f0210cc6cd0 [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::hash(Gaffer::ValuePlug const*)                                                                                                                                                                                                   
* 32 0x00007f0210cc3389 [libGaffer.so     ] Gaffer::ValuePlug::hash()                                                                                                                                                                                                                                        
* 33 0x00007f0210cbf329 [libGaffer.so     ] Gaffer::ValuePlug::hash(IECore::MurmurHash&)                                                                                                                                                                                                                     
* 34 0x00007f01e1cdf4fd [libGafferScene.so] GafferScene::MergeScenes::hashChildNames(std::vector<IECore::InternedString, std::allocator<IECore::InternedString> > const&, Gaffer::Context const*, GafferScene::ScenePlug const*, IECore::MurmurHash&)                                                        
* 35 0x00007f01e1d46498 [libGafferScene.so] GafferScene::SceneNode::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                              
* 36 0x00007f01e1d4dabe [libGafferScene.so] GafferScene::SceneProcessor::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                         
* 37 0x00007f01e1cdeafa [libGafferScene.so] GafferScene::MergeScenes::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                            
* 38 0x00007f0210cbd31b [libGaffer.so     ] Gaffer::ValuePlug::ComputeProcess::ComputeProcess((anonymous namespace)                                                                                                                                                                                          [ValuePlug.cpp:?]
* 39 0x00007f0210cc2944 [libGaffer.so     ]                                                                                                                                                                                                                                                                  [ValuePlug.cpp:?]
* 40 0x00007f0210cbc9fe [libGaffer.so     ] Gaffer::ValuePlug::ComputeProcess::value(Gaffer::ValuePlug const*, IECore::MurmurHash const*)                                                                                                                                                                    [ValuePlug.cpp:?]
* 41 0x00007f0210cc6cd0 [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::hash(Gaffer::ValuePlug const*)                                                                                                                                                                                                   
* 42 0x00007f0210cc3389 [libGaffer.so     ] Gaffer::ValuePlug::hash()                                                                                                                                                                                                                                        
* 43 0x00007f0210cbf329 [libGaffer.so     ] Gaffer::ValuePlug::hash(IECore::MurmurHash&)                                                                                                                                                                                                                     
* 44 0x00007f01e1d035f2 [libGafferScene.so] GafferScene::Parent::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                                 
* 45 0x00007f0210cbd31b [libGaffer.so     ] Gaffer::NumericPlug<int>::getValue(IECore::MurmurHash const*)                                                                                                                                                                                                    [ValuePlug.cpp:?]
* 46 0x00007f0210cc2944 [libGaffer.so     ]                                                                                                                                                                                                                                                                  [ValuePlug.cpp:?]
* 47 0x00007f0210cbc9fe [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::HashProcess((anonymous namespace)                                                                                                                                                                                                [ValuePlug.cpp:?]
* 48 0x00007f0210cc6cd0 [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::hash(Gaffer::ValuePlug const*)                                                                                                                                                                                                   
* 49 0x00007f0210cc3389 [libGaffer.so     ] Gaffer::ValuePlug::hash()                                                                                                                                                                                                                                        
* 50 0x00007f0210cbf329 [libGaffer.so     ] Gaffer::ValuePlug::hash(IECore::MurmurHash&)                                                                                                                                                                                                                     
* 51 0x00007f01e1d03c4a [libGafferScene.so] GafferScene::Parent::hashBranchChildNames(std::vector<IECore::InternedString, std::allocator<IECore::InternedString> > const&, std::vector<IECore::InternedString, std::allocator<IECore::InternedString> > const&, Gaffer::Context const*, IECore::MurmurHash&) 
* 52 0x00007f01e1c530a1 [libGafferScene.so] GafferScene::BranchCreator::hashMapping(Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                                             
* 53 0x00007f01e1c538ed [libGafferScene.so] GafferScene::BranchCreator::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                          
* 54 0x00007f01e1d034ee [libGafferScene.so] GafferScene::Parent::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                                 
* 55 0x00007f0210cbd31b [libGaffer.so     ] boost::detail::function::function_invoker2<IECore::MurmurHash (*)                                                                                                                                                                                                [ValuePlug.cpp:?]
* 56 0x00007f0210cc2944 [libGaffer.so     ]                                                                                                                                                                                                                                                                  [ValuePlug.cpp:?]
* 57 0x00007f0210cbc9fe [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::hash(Gaffer::ValuePlug const*)                                                                                                                                                                                                   [ValuePlug.cpp:?]
* 58 0x00007f0210cc6cd0 [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::hash(Gaffer::ValuePlug const*)                                                                                                                                                                                                   
* 59 0x00007f0210cc3389 [libGaffer.so     ] Gaffer::ValuePlug::hash()                                                                                                                                                                                                                                        
* 60 0x00007f0210cbf329 [libGaffer.so     ] Gaffer::ValuePlug::hash(IECore::MurmurHash&)                                                                                                                                                                                                                     
* 61 0x00007f01e1c548c5 [libGafferScene.so] GafferScene::BranchCreator::hashSet(IECore::InternedString const&, Gaffer::Context const*, GafferScene::ScenePlug const*, IECore::MurmurHash&)                                                                                                                   
* 62 0x00007f01e1d46408 [libGafferScene.so] GafferScene::SceneNode::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                              
* 63 0x00007f01e1d4dabe [libGafferScene.so] GafferScene::SceneProcessor::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                         
* 64 0x00007f01e1c5382e [libGafferScene.so] GafferScene::BranchCreator::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                          
* 65 0x00007f01e1d034ee [libGafferScene.so] GafferScene::Parent::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                                 
* 66 0x00007f0210cbd31b [libGaffer.so     ] Gaffer::ValuePlug::hash(IECore::MurmurHash&)                                                                                                                                                                                                                     [ValuePlug.cpp:?]
* 67 0x00007f0210cc2944 [libGaffer.so     ]                                                                                                                                                                                                                                                                  [ValuePlug.cpp:?]
* 68 0x00007f0210cbc9fe [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::HashProcess((anonymous namespace)                                                                                                                                                                                                [ValuePlug.cpp:?]
* 69 0x00007f0210cc6cd0 [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::hash(Gaffer::ValuePlug const*)                                                                                                                                                                                                   
* 70 0x00007f0210cc3389 [libGaffer.so     ] Gaffer::ValuePlug::hash()                                                                                                                                                                                                                                        
* 71 0x00007f0210cbf329 [libGaffer.so     ] Gaffer::ValuePlug::hash(IECore::MurmurHash&)                                                                                                                                                                                                                     
* 72 0x00007f01e1d153d5 [libGafferScene.so] GafferScene::Prune::hashSet(IECore::InternedString const&, Gaffer::Context const*, GafferScene::ScenePlug const*, IECore::MurmurHash&)                                                                                                                           
* 73 0x00007f01e1d46408 [libGafferScene.so] GafferScene::SceneNode::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                              
* 74 0x00007f01e1d4dabe [libGafferScene.so] GafferScene::SceneProcessor::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                         
* 75 0x00007f0210cbd31b [libGaffer.so     ] boost::detail::function::function_invoker2<IECore::MurmurHash (*)                                                                                                                                                                                                [ValuePlug.cpp:?]
* 76 0x00007f0210cc2944 [libGaffer.so     ]                                                                                                                                                                                                                                                                  [ValuePlug.cpp:?]
* 77 0x00007f0210cbc9fe [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::hash(Gaffer::ValuePlug const*)                                                                                                                                                                                                   [ValuePlug.cpp:?]
* 78 0x00007f0210cc6cd0 [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::hash(Gaffer::ValuePlug const*)                                                                                                                                                                                                   
* 79 0x00007f0210cc3389 [libGaffer.so     ] Gaffer::ValuePlug::hash()                                                                                                                                                                                                                                        
* 80 0x00007f01e1d4d28f [libGafferScene.so] GafferScene::ScenePlug::setHash(IECore::InternedString const&)                                                                                                                                                                                                   
* 81 0x00007f01e1c547c1 [libGafferScene.so] GafferScene::BranchCreator::hashSet(IECore::InternedString const&, Gaffer::Context const*, GafferScene::ScenePlug const*, IECore::MurmurHash&)                                                                                                                   
* 82 0x00007f01e1d46408 [libGafferScene.so] GafferScene::SceneNode::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                              
* 83 0x00007f01e1d4dabe [libGafferScene.so] GafferScene::SceneProcessor::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                         
* 84 0x00007f01e1c5382e [libGafferScene.so] GafferScene::BranchCreator::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                          
* 85 0x00007f01e1d034ee [libGafferScene.so] GafferScene::Parent::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                                 
* 86 0x00007f0210cbd31b [libGaffer.so     ]                                                                                                                                                                                                                                                                  [ValuePlug.cpp:?]
* 87 0x00007f0210cc2944 [libGaffer.so     ] Gaffer::ValuePlug::hash(IECore::MurmurHash&)                                                                                                                                                                                                                     [ValuePlug.cpp:?]
* 88 0x00007f0210cbc9fe [libGaffer.so     ]                                                                                                                                                                                                                                                                  [ValuePlug.cpp:?]
* 89 0x00007f0210cc6cd0 [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::hash(Gaffer::ValuePlug const*)                                                                                                                                                                                                   
* 90 0x00007f0210cc3389 [libGaffer.so     ] Gaffer::ValuePlug::hash()                                                                                                                                                                                                                                        
* 91 0x00007f0210cbf329 [libGaffer.so     ] Gaffer::ValuePlug::hash(IECore::MurmurHash&)                                                                                                                                                                                                                     
* 92 0x00007f01e1d153d5 [libGafferScene.so] GafferScene::Prune::hashSet(IECore::InternedString const&, Gaffer::Context const*, GafferScene::ScenePlug const*, IECore::MurmurHash&)                                                                                                                           
* 93 0x00007f01e1d46408 [libGafferScene.so] GafferScene::SceneNode::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                              
* 94 0x00007f01e1d4dabe [libGafferScene.so] GafferScene::SceneProcessor::hash(Gaffer::ValuePlug const*, Gaffer::Context const*, IECore::MurmurHash&)                                                                                                                                                         
* 95 0x00007f0210cbd31b [libGaffer.so     ]                                                                                                                                                                                                                                                                  [ValuePlug.cpp:?]
* 96 0x00007f0210cc2944 [libGaffer.so     ] boost::detail::function::function_invoker2<IECore::MurmurHash (*)                                                                                                                                                                                                [ValuePlug.cpp:?]
* 97 0x00007f0210cbc9fe [libGaffer.so     ]                                                                                                                                                                                                                                                                  [ValuePlug.cpp:?]
* 98 0x00007f0210cc6cd0 [libGaffer.so     ] Gaffer::ValuePlug::HashProcess::hash(Gaffer::ValuePlug const*)                                                                                                                                                                                                   
* 99 0x00007f0210cc3389 [libGaffer.so     ] Gaffer::ValuePlug::hash()
```

</p>
</details>