### PR TITLE
Viewer : Add message summary to Render Control UI

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -75,6 +75,9 @@ API
 - SetAlgo : Added Python binding for `affectsSetExpression()`.
 - Shader : Added `affectsAttributes()` protected method.
 - MessageWidget : Added MessageSummaryWidget class to simplify the display of message counts in other UIs.
+- MessageWidget :
+  - Added MessageSummaryWidget class to simplify the display of message counts in other UIs.
+  - Added `scrollToNextMessage()` and `scrollToPreviousMessage()` methods.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -74,6 +74,7 @@ API
     - PresetsPlugValueWidget
 - SetAlgo : Added Python binding for `affectsSetExpression()`.
 - Shader : Added `affectsAttributes()` protected method.
+- MessageWidget : Added MessageSummaryWidget class to simplify the display of message counts in other UIs.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Improvements
 - Stats app : Added `-location` argument, to allow profiling of a single location in a scene.
 - AnimationEditor : Improved performance.
 - MessageWidget : Added alternate presentation options allowing log-style message display, search, etc.
+- Viewer : Added warning/error message count to Render Control overlay.
 
 Fixes
 -----

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -44,6 +44,8 @@ import GafferScene
 import GafferUI
 import GafferImageUI
 
+import IECore
+
 ##########################################################################
 # ImageView UI for the viewed image's render node (if available)
 ##########################################################################
@@ -88,6 +90,7 @@ class _ViewRenderControlUI( GafferUI.Widget ) :
 				GafferUI.Spacer( imath.V2i( 1, 1 ), imath.V2i( 1, 1 ) )
 				self.__label = GafferUI.Label( "Render" )
 				self.__stateWidget = _StatePlugValueWidget( None )
+				self.__messagesWidget = _MessageSummaryPlugValueWidget( None )
 
 		self.__view = view
 
@@ -105,6 +108,7 @@ class _ViewRenderControlUI( GafferUI.Widget ) :
 
 			if not statePlug.isSame( self.__stateWidget.getPlug() ) :
 				self.__stateWidget.setPlug( statePlug )
+				self.__messagesWidget.setPlug( renderNode["messages"] )
 				self.__renderNodePlugDirtiedConnection = renderNode.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__renderNodePlugDirtied ) )
 
 			# We disable the controls if a render is in progress, but not being viewed
@@ -117,9 +121,11 @@ class _ViewRenderControlUI( GafferUI.Widget ) :
 				"" if controlsEnabled else "Controls disabled because image is not the one currently rendering."
 			)
 			self.__stateWidget.setEnabled( controlsEnabled )
+			self.__messagesWidget.setEnabled( controlsEnabled )
 
 		else :
 			self.__stateWidget.setPlug( None )
+			self.__messagesWidget.setPlug( None )
 			self.__renderNodePlugDirtiedConnection = None
 
 	@staticmethod
@@ -229,6 +235,105 @@ class _StatePlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __stopClicked( self, button ) :
 		self.getPlug().setValue( GafferScene.InteractiveRender.State.Stopped )
 
+###############################################################################
+# A widget presenting a summary of the messages in a render nodes messages plug
+###############################################################################
+
+class _MessageSummaryPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug ) :
+
+		self.__summaryWidget = GafferUI.MessageSummaryWidget(
+			displayLevel = IECore.MessageHandler.Level.Warning,
+			hideUnusedLevels = True,
+			buttonToolTip = "Click to open the render log"
+		)
+
+		GafferUI.PlugValueWidget.__init__( self, self.__summaryWidget, plug )
+
+		self.__summaryWidget.levelButtonClickedSignal().connect( Gaffer.WeakMethod( self.__levelButtonClicked ), scoped = False )
+
+		self._updateFromPlug()
+
+	def getToolTip( self ) :
+
+		# Suppress the default messages tool-tip.
+		return ""
+
+	@GafferUI.LazyMethod( deferUntilPlaybackStops = True )
+	def _updateFromPlug( self ) :
+
+		if self.getPlug() is not None :
+			with self.getContext() :
+				messages = self.getPlug().getValue().value
+		else :
+			messages = Gaffer.Private.IECorePreview.Messages()
+
+		self.__summaryWidget.setMessages( messages )
+		self.__summaryWidget.setEnabled( self.getPlug() is not None )
+
+	def __levelButtonClicked( self, level ) :
+
+		window = _MessagesWindow.acquire( self.getPlug() )
+		window.setVisible( True )
+		window.messageWidget().scrollToNextMessage( level )
+
+###############################################################################
+# A utility window containing a render nodes message log
+###############################################################################
+
+## TODO: This is awefully similar to numerous color picker windows, etc...
+# we ideally could do with a GafferUI.PlugWindow or similar.
+class _MessagesWindow( GafferUI.Window ) :
+
+	# Use acquire instead to retrieve an existing window or create a new one
+	def __init__( self, parentWindow, plug ) :
+
+		GafferUI.Window.__init__( self, borderWidth = 8 )
+
+		self.setChild( _MessagesPlugValueWidget( plug ) )
+		self._qtWidget().resize( 600, 500 )
+
+		parentWindow.addChildWindow( self, removeOnClose = True )
+
+		node = plug.node()
+		scriptNode = node.scriptNode()
+		while node and not node.isSame( scriptNode ) :
+			node.nameChangedSignal().connect( Gaffer.WeakMethod( self.__updateTitle ), scoped = False )
+			node.parentChangedSignal().connect( Gaffer.WeakMethod( self.__destroy ), scoped = False )
+			node = node.parent()
+
+		self.__updateTitle()
+
+	def messageWidget( self ) :
+
+		return self.getChild().messageWidget()
+
+	def __updateTitle( self, *unused ) :
+
+		plug = self.getChild().getPlug()
+		self.setTitle( "{} Messages".format( plug.node().relativeName( plug.ancestor( Gaffer.ScriptNode ) ) ) )
+
+	def __destroy( self, *unused ) :
+
+		self.parent().removeChild( self )
+
+	@classmethod
+	def acquire( cls, plug ) :
+
+		script = plug.node().scriptNode()
+		scriptWindow = GafferUI.ScriptWindow.acquire( script )
+		childWindows = scriptWindow.childWindows()
+
+		for window in childWindows :
+			if isinstance( window, cls ) and window.getChild().getPlug().isSame( plug ) :
+				return window
+
+		window = cls( scriptWindow, plug )
+		window.setVisible( True )
+
+		return window
+
 ##########################################################################
 # UI for the messages plug that presents the render log
 ##########################################################################
@@ -254,13 +359,20 @@ class _MessagesPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def getToolTip( self ) :
 
 		# Suppress the default messages tool-tip that otherwise appears all over the log window.
-		return None
+		return ""
+
+	def messageWidget( self ) :
+
+		return self.__messages
 
 	@GafferUI.LazyMethod( deferUntilPlaybackStops = True )
 	def _updateFromPlug( self, *unused ) :
 
-		with self.getContext() :
-			messages = self.getPlug().getValue().value
+		if self.getPlug() is not None :
+			with self.getContext() :
+				messages = self.getPlug().getValue().value
+		else :
+			messages = Gaffer.Private.IECorePreview.Messages()
 
 		self.__messages.setMessages( messages )
 

--- a/python/GafferUI/MessageWidget.py
+++ b/python/GafferUI/MessageWidget.py
@@ -185,6 +185,18 @@ class MessageWidget( GafferUI.Widget ) :
 		else :
 			return messages.count( level )
 
+	## Navigates the view to the next message of the specified level,
+	# considering the current selection.
+	def scrollToNextMessage( self, messageLevel, select = True, wrap = True ) :
+
+		self.__table.scrollToNextMessage( messageLevel, select, wrap )
+
+	## Navigates the view to the previous message of the specified level,
+	# considering the current selection.
+	def scrollToPreviousMessage( self, messageLevel, select = True, wrap = True ) :
+
+		self.__table.scrollToPreviousMessage( messageLevel, select, wrap )
+
 	# Friendship for our internal message handler
 	def _addMessage( self, level, context, message ) :
 

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1209,7 +1209,7 @@ _styleSheet = string.Template(
 		padding: 0;
 	}
 
-	*[gafferClass="GafferUI.MessageWidget._MessageSummaryWidget"] QPushButton {
+	*[gafferClass="GafferUI.MessageWidget.MessageSummaryWidget"] QPushButton {
 		padding-left: 4px;
 		padding-right: 4px;
 	}

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -173,7 +173,7 @@ from .BusyWidget import BusyWidget
 from .NumericSlider import NumericSlider
 from .ColorChooser import ColorChooser
 from .ColorChooserDialogue import ColorChooserDialogue
-from .MessageWidget import MessageWidget
+from .MessageWidget import MessageWidget, MessageSummaryWidget
 from .NotificationMessageHandler import NotificationMessageHandler
 from .MenuButton import MenuButton
 from .MultiSelectionMenu import MultiSelectionMenu


### PR DESCRIPTION
As part of #3419 and as an extension of #3790, adds a summary of render log warning/errors along side the control buttons in the Viewer's Render Control UI.

My brain is somewhat tired. I feel like I've forgotten something.

![image](https://user-images.githubusercontent.com/896779/85143623-e30b2c00-b241-11ea-97b8-f5b4bb69f512.png)

It could probably do with a little more polish in terms of spacing etc... but wanted to get the basics over the line.