### PR TITLE
ValuePlug : Improve hash cache invalidation strategy

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -35,6 +35,7 @@ Fixes
   - FlatToDeep
   - OpenImageIOReader
   - LevelSetOffset
+  - MeshToLevelSet
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Features
 Improvements
 ------------
 
+- Caching : Improved interactive performance using an improved hash cache invalidation strategy.
 - SceneNode : Improved performance for all nodes that must propagate bounds from children to parents.
 - PointsType : Removed unnecessary bounds computation overhead.
 - OSLObject/ClosestPointSampler/CurveSampler : Improved performance for cases where multiple downstream computes require the same upstream object.
@@ -41,6 +42,9 @@ Fixes
 API
 ---
 
+- ValuePlug
+  - Improved interactive performance by not clearing the entire hash cache every time a plug is dirtied. Beware : this can reveal subtle bugs in `DependencyNode::affects()` implementations, causing hashes to be reused if a plug has not been dirtied appropriately. These bugs may previously have gone unnoticed but will now need fixing as a matter of urgency. The GAFFER_CLEAR_HASHCACHE_ON_DIRTY environment variable may be used to enable legacy behaviour in the interim.
+  - Added `clearHashCache()` static method.
 - ScenePlug : Added `childBounds()` and `childBoundsHash()` methods.
 - ObjectProcessor : Added `processedObjectComputeCachePolicy()` virtual method. This should be overridden to choose an appropriate cache policy when `computeProcessedObject()` spawns TBB tasks.
 - SceneNode :
@@ -68,7 +72,6 @@ API
     - PresetsPlugValueWidget
 - SetAlgo : Added Python binding for `affectsSetExpression()`.
 - Shader : Added `affectsAttributes()` protected method.
-- ValuePlug : Added `clearHashCache()` static method.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -25,7 +25,9 @@ Fixes
 - Signal : Fixed hang which could occur if a result combiner implemented in Python tried to handle exceptions.
 - NumericWidget : Fixed errors when trying to use a virtual slider with an empty value.
 - GraphComponent : Fixed return value for `items()` method. The returned keys are now regular `str()` objects rather than `InternedString`.
-- UDIMQuery : Fixed dependency tracking bug.
+- Fixed dependency tracking bugs in the following nodes :
+  - UDIMQuery
+  - Shader
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -36,6 +36,7 @@ Fixes
   - OpenImageIOReader
   - LevelSetOffset
   - MeshToLevelSet
+- SetAlgo : Fixed `affectsSetExpression()` to return `True` for `ScenePlug::setNamesPlug()`.
 
 API
 ---
@@ -65,6 +66,7 @@ API
     - TweakPlugValueWidget
     - BoolPlugValueWidget
     - PresetsPlugValueWidget
+- SetAlgo : Added Python binding for `affectsSetExpression()`.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -71,6 +71,8 @@ API
 Breaking Changes
 ----------------
 
+- Filter : Removed virtual `sceneAffectsMatch()` method. Derived classes should implement `affects()` instead.
+- FilterPlug : Replaced `sceneAffectsMatch()` method with a more general `sceneAffects()` method. This should be used to replace any calls to the old method.
 - PointsType : Changed base class from Deformer to ObjectProcessor.
 - Gaffer : Removed `lazyImport()` method.
 - GafferUI : Removed deprecated `_qtImport()` method. Use `from Qt import` instead.

--- a/Changes.md
+++ b/Changes.md
@@ -32,6 +32,7 @@ Fixes
   - FreezeTransform
   - ImageMetadata
   - FlatImageProcessor
+  - FlatToDeep
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -31,6 +31,7 @@ Fixes
   - FilterResults
   - FreezeTransform
   - ImageMetadata
+  - FlatImageProcessor
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ Fixes
 - Fixed dependency tracking bugs in the following nodes :
   - UDIMQuery
   - Shader
+  - FilterResults
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -67,6 +67,7 @@ API
     - BoolPlugValueWidget
     - PresetsPlugValueWidget
 - SetAlgo : Added Python binding for `affectsSetExpression()`.
+- Shader : Added `affectsAttributes()` protected method.
 
 Breaking Changes
 ----------------
@@ -114,6 +115,7 @@ Breaking Changes
   - Removed connections to `plugFlagsChangedSignal()`. In the unlikely event that a derived class depends on plug flags, it must now manage the updates itself.
 - InteractiveRender : Changed base class from Node to ComputeNode, added members.
 - MessageWidget : Removed deprecated `appendMessage` method, use `messageHandler().handle()` instead.
+- Shader : Added virtual method.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -29,6 +29,7 @@ Fixes
   - UDIMQuery
   - Shader
   - FilterResults
+  - FreezeTransform
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,7 @@ Fixes
   - FlatImageProcessor
   - FlatToDeep
   - OpenImageIOReader
+  - LevelSetOffset
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,7 @@ Fixes
 - Signal : Fixed hang which could occur if a result combiner implemented in Python tried to handle exceptions.
 - NumericWidget : Fixed errors when trying to use a virtual slider with an empty value.
 - GraphComponent : Fixed return value for `items()` method. The returned keys are now regular `str()` objects rather than `InternedString`.
+- UDIMQuery : Fixed dependency tracking bug.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -30,6 +30,7 @@ Fixes
   - Shader
   - FilterResults
   - FreezeTransform
+  - ImageMetadata
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -33,6 +33,7 @@ Fixes
   - ImageMetadata
   - FlatImageProcessor
   - FlatToDeep
+  - OpenImageIOReader
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -68,6 +68,7 @@ API
     - PresetsPlugValueWidget
 - SetAlgo : Added Python binding for `affectsSetExpression()`.
 - Shader : Added `affectsAttributes()` protected method.
+- ValuePlug : Added `clearHashCache()` static method.
 
 Breaking Changes
 ----------------

--- a/include/Gaffer/TypedObjectPlug.inl
+++ b/include/Gaffer/TypedObjectPlug.inl
@@ -98,7 +98,7 @@ void TypedObjectPlug<T>::setValue( ConstValuePtr value )
 template<class T>
 typename TypedObjectPlug<T>::ConstValuePtr TypedObjectPlug<T>::getValue( const IECore::MurmurHash *precomputedHash ) const
 {
-	return boost::static_pointer_cast<const ValueType>( getObjectValue( precomputedHash ) );
+	return getObjectValue<ValueType>( precomputedHash );
 }
 
 template<class T>

--- a/include/Gaffer/TypedPlug.inl
+++ b/include/Gaffer/TypedPlug.inl
@@ -98,8 +98,7 @@ void TypedPlug<T>::setValue( const T &value )
 template<class T>
 T TypedPlug<T>::getValue( const IECore::MurmurHash *precomputedHash ) const
 {
-	IECore::ConstObjectPtr o = getObjectValue( precomputedHash );
-	return static_cast<const DataType *>( o.get() )->readable();
+	return getObjectValue<DataType>( precomputedHash )->readable();
 }
 
 template<class T>

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -206,7 +206,8 @@ class GAFFER_API ValuePlug : public Plug
 		/// If a precomputed hash is available it may be passed to avoid computing
 		/// it again unnecessarily. Passing an incorrect hash has dire consequences, so
 		/// use with care.
-		IECore::ConstObjectPtr getObjectValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
+		template<typename T = IECore::Object>
+		boost::intrusive_ptr<const T> getObjectValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 		/// Should be called by derived classes when they wish to set the plug
 		/// value - the value is referenced directly (not copied) and so must
 		/// not be changed following the call.
@@ -223,6 +224,7 @@ class GAFFER_API ValuePlug : public Plug
 		class ComputeProcess;
 		class SetValueAction;
 
+		IECore::ConstObjectPtr getValueInternal( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 		void setValueInternal( IECore::ConstObjectPtr value, bool propagateDirtiness );
 		void childAddedOrRemoved();
 		// Emits the appropriate Node::plugSetSignal() for this plug and all its
@@ -246,5 +248,7 @@ typedef FilteredRecursiveChildIterator<PlugPredicate<Plug::In, ValuePlug>, PlugP
 typedef FilteredRecursiveChildIterator<PlugPredicate<Plug::Out, ValuePlug>, PlugPredicate<> > RecursiveOutputValuePlugIterator;
 
 } // namespace Gaffer
+
+#include "Gaffer/ValuePlug.inl"
 
 #endif // GAFFER_VALUEPLUG_H

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -170,6 +170,10 @@ class GAFFER_API ValuePlug : public Plug
 		/// > Note : Limits are applied on a per-thread basis as and
 		/// > when each thread is used to compute a hash.
 		static void setHashCacheSizeLimit( size_t maxEntriesPerThread );
+		/// Clears the hash cache.
+		/// > Note : Clearing occurs on a per-thread basis as and when
+		/// > each thread next accesses the cache.
+		static void clearHashCache();
 		//@}
 
 	protected :

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -238,6 +238,10 @@ class GAFFER_API ValuePlug : public Plug
 		IECore::ConstObjectPtr m_defaultValue;
 		// For holding the value of input plugs with no input connections.
 		IECore::ConstObjectPtr m_staticValue;
+		// Number of calls made to `dirty()`. We use this as part of the key
+		// into the hash cache, so that previous entries are invalidated when
+		// the plug is dirtied.
+		uint64_t m_dirtyCount;
 
 };
 

--- a/include/GafferArnold/ArnoldCameraShaders.h
+++ b/include/GafferArnold/ArnoldCameraShaders.h
@@ -68,10 +68,9 @@ class GAFFERARNOLD_API ArnoldCameraShaders : public GafferScene::Shader
 		Gaffer::Plug *outPlug();
 		const Gaffer::Plug *outPlug() const;
 
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
-
 	protected :
 
+		bool affectsAttributes( const Gaffer::Plug *input ) const override;
 		void attributesHash( const Gaffer::Plug *output, IECore::MurmurHash &h ) const override;
 		IECore::ConstCompoundObjectPtr attributes( const Gaffer::Plug *output ) const override;
 

--- a/include/GafferArnold/ArnoldDisplacement.h
+++ b/include/GafferArnold/ArnoldDisplacement.h
@@ -80,10 +80,9 @@ class GAFFERARNOLD_API ArnoldDisplacement : public GafferScene::Shader
 		Gaffer::Plug *outPlug();
 		const Gaffer::Plug *outPlug() const;
 
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
-
 	protected :
 
+		bool affectsAttributes( const Gaffer::Plug *input ) const override;
 		void attributesHash( const Gaffer::Plug *output, IECore::MurmurHash &h ) const override;
 		IECore::ConstCompoundObjectPtr attributes( const Gaffer::Plug *output ) const override;
 

--- a/include/GafferImage/FlatImageProcessor.h
+++ b/include/GafferImage/FlatImageProcessor.h
@@ -63,6 +63,8 @@ class GAFFERIMAGE_API FlatImageProcessor : public ImageProcessor
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferImage::FlatImageProcessor, FlatImageProcessorTypeId, ImageProcessor );
 
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
 	protected :
 
 		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;

--- a/include/GafferScene/Encapsulate.h
+++ b/include/GafferScene/Encapsulate.h
@@ -56,8 +56,6 @@ class GAFFERSCENE_API Encapsulate : public FilteredSceneProcessor
 
 	protected :
 
-		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
-
 		void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 

--- a/include/GafferScene/Filter.h
+++ b/include/GafferScene/Filter.h
@@ -69,6 +69,9 @@ class GAFFERSCENE_API Filter : public Gaffer::ComputeNode
 		FilterPlug *outPlug();
 		const FilterPlug *outPlug() const;
 
+		/// > Note : `affects()` receives special treatment for Filter nodes. In addition to the
+		/// > regular calls where `input` is a plug belonging to the filter, calls are also made
+		/// > where `input` is a child of a ScenePlug that will later be provided to `computeMatch()`.
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		/// \deprecated Use FilterPlug::SceneScope instead.
@@ -86,8 +89,6 @@ class GAFFERSCENE_API Filter : public Gaffer::ComputeNode
 		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 		/// Implemented to disable compute caching for the filter result.
 		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
-
-		virtual bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const;
 
 		/// Hash method for outPlug(). A derived class must either :
 		///

--- a/include/GafferScene/FilterPlug.h
+++ b/include/GafferScene/FilterPlug.h
@@ -41,6 +41,7 @@
 #include "GafferScene/TypeIds.h"
 
 #include "Gaffer/Context.h"
+#include "Gaffer/DependencyNode.h"
 #include "Gaffer/NumericPlug.h"
 
 namespace GafferScene
@@ -81,7 +82,11 @@ class GAFFERSCENE_API FilterPlug : public Gaffer::IntPlug
 		bool acceptsInput( const Gaffer::Plug *input ) const override;
 		Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
-		bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const;
+		/// Must be called when a child of a ScenePlug is dirtied, and that ScenePlug will later
+		/// be passed to the filter via SceneScope. This allows the filter to participate fully in
+		/// dirty propagation, despite not having ScenePlug inputs of its own. For an example of
+		/// usage, see `FilteredSceneProcessor::affects()`.
+		void sceneAffects( const Gaffer::Plug *scenePlugChild, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const;
 
 		/// Name of a context variable used to provide the input
 		/// scene to the filter

--- a/include/GafferScene/FilterProcessor.h
+++ b/include/GafferScene/FilterProcessor.h
@@ -81,11 +81,11 @@ class GAFFERSCENE_API FilterProcessor : public Filter
 		Gaffer::ArrayPlug *inPlugs();
 		const Gaffer::ArrayPlug *inPlugs() const;
 
-		bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const override;
-
 		/// Returns inPlug() as the correspondingInput of outPlug();
 		Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) override;
 		const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const override;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 

--- a/include/GafferScene/Isolate.h
+++ b/include/GafferScene/Isolate.h
@@ -75,8 +75,6 @@ class GAFFERSCENE_API Isolate : public FilteredSceneProcessor
 
 	protected :
 
-		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
-
 		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;

--- a/include/GafferScene/LightToCamera.h
+++ b/include/GafferScene/LightToCamera.h
@@ -56,7 +56,6 @@ class GAFFERSCENE_API LightToCamera : public SceneElementProcessor
 		const Gaffer::IntPlug *filmFitPlug() const;
 
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
-		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
 
 	protected :
 

--- a/include/GafferScene/PathFilter.h
+++ b/include/GafferScene/PathFilter.h
@@ -71,8 +71,6 @@ class GAFFERSCENE_API PathFilter : public Filter
 		void hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		unsigned computeMatch( const ScenePlug *scene, const Gaffer::Context *context ) const override;
 
-		bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const override;
-
 	private :
 
 		// Used to compute a PathMatcher from `pathsPlug()`.

--- a/include/GafferScene/Prune.h
+++ b/include/GafferScene/Prune.h
@@ -59,8 +59,6 @@ class GAFFERSCENE_API Prune : public FilteredSceneProcessor
 
 	protected :
 
-		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
-
 		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -209,6 +209,12 @@ GAFFERSCENE_API SceneProcessor *objectTweaks( const ScenePlug *scene, const Scen
 /// Returns the last ShaderTweaks node to edit the specified attribute.
 GAFFERSCENE_API ShaderTweaks *shaderTweaks( const ScenePlug *scene, const ScenePlug::ScenePath &path, const IECore::InternedString &attributeName );
 
+/// Returns the name of a context variable in which the history methods store a unique value
+/// to disable the effects of the hash cache, so that the full upstream process can be examined.
+/// May be removed from a context to reenable the cache for expensive hash operations that are
+/// known to be irrelevant to the history.
+GAFFERSCENE_API IECore::InternedString historyIDContextName();
+
 /// Render Metadata
 /// ===============
 ///

--- a/include/GafferScene/SetFilter.h
+++ b/include/GafferScene/SetFilter.h
@@ -67,8 +67,6 @@ class GAFFERSCENE_API SetFilter : public Filter
 
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
-		bool sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const override;
-
 	protected :
 
 		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -135,15 +135,29 @@ class GAFFERSCENE_API Shader : public Gaffer::ComputeNode
 		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
-		/// Called when computing the hash for this node. May be reimplemented in derived classes
-		/// to deal with special cases, in which case parameterValue() should be reimplemented too.
-		virtual void parameterHash( const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h ) const;
-		/// Called for each parameter plug when constructing an IECore::Shader from this node.
-		/// May be reimplemented in derived classes to deal with special cases.
-		virtual IECore::DataPtr parameterValue( const Gaffer::Plug *parameterPlug ) const;
+		/// Attributes computation
+		/// ----------------------
+		///
+		/// These methods are used to perform the compute that turns the shader network
+		/// into one or more attributes that are made available by `ShaderPlug::attributes()`.
+		/// May be overridden by derived classes to customise the output. Customisation may
+		/// also be achieved at the level of individual shader parameters by implementing
+		/// the parameter conversion methods below.
 
-		virtual void attributesHash( const Gaffer::Plug *output, IECore::MurmurHash &h) const;
+		virtual bool affectsAttributes( const Gaffer::Plug *input ) const;
+		virtual void attributesHash( const Gaffer::Plug *output, IECore::MurmurHash &h ) const;
 		virtual IECore::ConstCompoundObjectPtr attributes( const Gaffer::Plug *output ) const;
+
+		/// Parameter conversion
+		/// --------------------
+
+		/// Called when computing `attributesHash()`. May be reimplemented in derived classes
+		/// to deal with special cases, in which case `parameterValue()` should be reimplemented too.
+		virtual void parameterHash( const Gaffer::Plug *parameterPlug, IECore::MurmurHash &h ) const;
+		/// Called for each parameter plug when constructing an IECore::Shader from this node
+		/// in the `attributes()` method. May be reimplemented in derived classes to deal with special
+		/// cases.
+		virtual IECore::DataPtr parameterValue( const Gaffer::Plug *parameterPlug ) const;
 
 	private :
 

--- a/python/GafferImageTest/ImageMetadataTest.py
+++ b/python/GafferImageTest/ImageMetadataTest.py
@@ -64,8 +64,8 @@ class ImageMetadataTest( GafferImageTest.ImageTestCase ) :
 
 		# check that we can make metadata
 
-		m["metadata"].addChild( Gaffer.NameValuePlug( "comment", IECore.StringData( "my favorite image!" ), "member1" ) )
-		m["metadata"].addChild( Gaffer.NameValuePlug( "range", IECore.V2iData( imath.V2i( 5, 10 ) ), True, "member1" ) )
+		m["metadata"].addChild( Gaffer.NameValuePlug( "comment", IECore.StringData( "my favorite image!" ), "member1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		m["metadata"].addChild( Gaffer.NameValuePlug( "range", IECore.V2iData( imath.V2i( 5, 10 ) ), True, "member1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 
 		metadata = m["out"]["metadata"].getValue()
 		self.assertEqual( len(metadata), len(inMetadata) + 2 )

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -378,6 +378,8 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 						imath.V2i( 106, 28 )
 					]:
 
+					o["offset"].setValue( offset )
+
 					with Gaffer.Context() :
 						w["task"].execute()
 

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -264,6 +264,7 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( history.scene, plug )
 			self.assertEqual( history.context.getFrame(), 10 )
 			self.assertEqual( GafferScene.ScenePlug.pathToString( history.context["scene:path"] ), scenePath )
+			self.assertFalse( any( n.startswith( "__" ) for n in history.context.names() ) )
 			history = history.predecessors[0] if history.predecessors else None
 
 		self.assertIsNone( history )
@@ -286,6 +287,7 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( history.scene, plug )
 			self.assertEqual( history.context.getFrame(), 20 )
 			self.assertEqual( GafferScene.ScenePlug.pathToString( history.context["scene:path"] ), scenePath )
+			self.assertFalse( any( n.startswith( "__" ) for n in history.context.names() ) )
 			history = history.predecessors[0] if history.predecessors else None
 
 		self.assertIsNone( history )

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -655,7 +655,12 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		o.execute()
 
 		pathWithMeta = os.path.join( self.temporaryDirectory(), "sceneAlgoSourceSceneWithMeta.exr" )
-		m["metadata"].addChild( Gaffer.NameValuePlug( "gaffer:sourceScene", IECore.StringData( expectedPath ), True, "sourceScene" ) )
+		m["metadata"].addChild(
+			Gaffer.NameValuePlug(
+				"gaffer:sourceScene", IECore.StringData( expectedPath ), True, "sourceScene",
+				flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+			)
+		)
 		o["fileName"].setValue( pathWithMeta )
 		o.execute()
 

--- a/python/GafferSceneTest/SetAlgoTest.py
+++ b/python/GafferSceneTest/SetAlgoTest.py
@@ -40,6 +40,7 @@ import six
 
 import IECore
 
+import Gaffer
 import GafferScene
 import GafferSceneTest
 
@@ -299,6 +300,17 @@ class SetAlgoTest( GafferSceneTest.SceneTestCase ) :
 		] :
 			with six.assertRaisesRegex( self, RuntimeError, 'Object name "{0}" contains wildcards'.format( re.escape( expression ) ) ) :
 				GafferScene.SetAlgo.evaluateSetExpression( expression, sphere["out"] )
+
+	def testAffectsSetExpression( self ) :
+
+		scenePlug = GafferScene.ScenePlug()
+		for childPlug in scenePlug :
+			self.assertEqual(
+				GafferScene.SetAlgo.affectsSetExpression( childPlug ),
+				childPlug in ( scenePlug["set"], scenePlug["setNames"] )
+			)
+
+		self.assertFalse( GafferScene.SetAlgo.affectsSetExpression( Gaffer.IntPlug() ) )
 
 	def assertCorrectEvaluation( self, scenePlug, expression, expectedContents ) :
 

--- a/python/GafferTest/ValuePlugTest.py
+++ b/python/GafferTest/ValuePlugTest.py
@@ -685,6 +685,20 @@ class ValuePlugTest( GafferTest.TestCase ) :
 		with Gaffer.Context( s.context(), canceller ) :
 			self.assertEqual( s["n"]["sum"].getValue(), 40 )
 
+	def testClearHashCache( self ) :
+
+		node = GafferTest.AddNode()
+		node["sum"].getValue()
+
+		with Gaffer.PerformanceMonitor() as m :
+			node["sum"].getValue()
+		self.assertEqual( m.plugStatistics( node["sum"] ).hashCount, 0 )
+
+		Gaffer.ValuePlug.clearHashCache()
+		with Gaffer.PerformanceMonitor() as m :
+			node["sum"].getValue()
+		self.assertEqual( m.plugStatistics( node["sum"] ).hashCount, 1 )
+
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -178,7 +178,16 @@ void Expression::setExpression( const std::string &expression, const std::string
 	// node/plug names in getExpression(), where we convert back
 	// to the external form.
 
-	expressionPlug()->setValue( transcribe( expression, /* toInternalForm = */ true ) );
+	const std::string internalExpression = transcribe( expression, /* toInternalForm = */ true );
+	if( internalExpression == expressionPlug()->getValue() )
+	{
+		// It is possible for two different expressions to map to the same
+		// internal form. If neither expression has any input plugs, then
+		// there would be no graph change to trigger dirty propagation for
+		// `executePlug()`, so we must force one.
+		expressionPlug()->setValue( "" );
+	}
+	expressionPlug()->setValue( internalExpression );
 
 	Action::enact(
 		this,

--- a/src/Gaffer/NumericPlug.cpp
+++ b/src/Gaffer/NumericPlug.cpp
@@ -138,13 +138,7 @@ void NumericPlug<T>::setValue( T value )
 template<class T>
 T NumericPlug<T>::getValue( const IECore::MurmurHash *precomputedHash ) const
 {
-	ConstObjectPtr o = getObjectValue( precomputedHash );
-	const DataType *d = IECore::runTimeCast<const DataType>( o.get() );
-	if( !d )
-	{
-		throw IECore::Exception( "NumericPlug::getObjectValue() didn't return expected type - is the hash being computed correctly?" );
-	}
-	return d->readable();
+	return getObjectValue<DataType>( precomputedHash )->readable();
 }
 
 template<class T>

--- a/src/Gaffer/StringPlug.cpp
+++ b/src/Gaffer/StringPlug.cpp
@@ -95,12 +95,7 @@ void StringPlug::setValue( const std::string &value )
 
 std::string StringPlug::getValue( const IECore::MurmurHash *precomputedHash ) const
 {
-	IECore::ConstObjectPtr o = getObjectValue( precomputedHash );
-	const IECore::StringData *s = IECore::runTimeCast<const IECore::StringData>( o.get() );
-	if( !s )
-	{
-		throw IECore::Exception( "StringPlug::getObjectValue() didn't return StringData - is the hash being computed correctly?" );
-	}
+	ConstStringDataPtr s = getObjectValue<StringData>( precomputedHash );
 
 	const bool performSubstitutions =
 		m_substitutions &&
@@ -134,13 +129,7 @@ IECore::MurmurHash StringPlug::hash() const
 
 	if( performSubstitutions )
 	{
-		IECore::ConstObjectPtr o = getObjectValue();
-		const IECore::StringData *s = IECore::runTimeCast<const IECore::StringData>( o.get() );
-		if( !s )
-		{
-			throw IECore::Exception( "StringPlug::getObjectValue() didn't return StringData - is the hash being computed correctly?" );
-		}
-
+		ConstStringDataPtr s = getObjectValue<StringData>();
 		if( IECore::StringAlgo::hasSubstitutions( s->readable() ) )
 		{
 			IECore::MurmurHash result;

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -1125,3 +1125,8 @@ void ValuePlug::setHashCacheSizeLimit( size_t maxEntriesPerThread )
 {
 	HashProcess::setCacheSizeLimit( maxEntriesPerThread );
 }
+
+void ValuePlug::clearHashCache()
+{
+	HashProcess::clearCache();
+}

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -1000,7 +1000,7 @@ const IECore::Object *ValuePlug::defaultObjectValue() const
 	return m_defaultValue.get();
 }
 
-IECore::ConstObjectPtr ValuePlug::getObjectValue( const IECore::MurmurHash *precomputedHash ) const
+IECore::ConstObjectPtr ValuePlug::getValueInternal( const IECore::MurmurHash *precomputedHash ) const
 {
 	return ComputeProcess::value( this, precomputedHash );
 }

--- a/src/GafferArnold/ArnoldCameraShaders.cpp
+++ b/src/GafferArnold/ArnoldCameraShaders.cpp
@@ -102,14 +102,13 @@ const Gaffer::Plug *ArnoldCameraShaders::outPlug() const
 	return getChild<Plug>( g_firstPlugIndex + 2 );
 }
 
-void ArnoldCameraShaders::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+bool ArnoldCameraShaders::affectsAttributes( const Gaffer::Plug *input ) const
 {
-	Shader::affects( input, outputs );
-
-	if( input == filterMapPlug() || input == uvRemapPlug() )
-	{
-		outputs.push_back( outPlug() );
-	}
+	return
+		Shader::affectsAttributes( input ) ||
+		input == filterMapPlug() ||
+		input == uvRemapPlug()
+	;
 }
 
 void ArnoldCameraShaders::attributesHash( const Gaffer::Plug *output, IECore::MurmurHash &h ) const

--- a/src/GafferArnold/ArnoldDisplacement.cpp
+++ b/src/GafferArnold/ArnoldDisplacement.cpp
@@ -129,20 +129,16 @@ const Gaffer::Plug *ArnoldDisplacement::outPlug() const
 	return getChild<Plug>( g_firstPlugIndex + 5 );
 }
 
-void ArnoldDisplacement::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+bool ArnoldDisplacement::affectsAttributes( const Gaffer::Plug *input ) const
 {
-	Shader::affects( input, outputs );
-
-	if(
+	return
+		Shader::affectsAttributes( input ) ||
 		input == mapPlug() ||
 		input == heightPlug() ||
 		input == paddingPlug() ||
 		input == zeroValuePlug() ||
 		input == autoBumpPlug()
-	)
-	{
-		outputs.push_back( outPlug() );
-	}
+	;
 }
 
 void ArnoldDisplacement::attributesHash( const Gaffer::Plug *output, IECore::MurmurHash &h ) const

--- a/src/GafferImage/FlatImageProcessor.cpp
+++ b/src/GafferImage/FlatImageProcessor.cpp
@@ -69,6 +69,21 @@ Gaffer::ValuePlug::CachePolicy FlatImageProcessor::computeCachePolicy( const Gaf
 	return ImageProcessor::computeCachePolicy( output );
 }
 
+void FlatImageProcessor::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	ImageProcessor::affects( input, outputs );
+
+	auto imagePlug = input->parent<ImagePlug>();
+	if(
+		imagePlug &&
+		( imagePlug == inPlug() || imagePlug->parent() == inPlugs() ) &&
+		input == imagePlug->deepPlug()
+	)
+	{
+		outputs.push_back( outPlug()->deepPlug() );
+	}
+}
+
 void FlatImageProcessor::hashDeep( const GafferImage::ImagePlug *parent, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	ImageProcessor::hashDeep( parent, context, h );

--- a/src/GafferImage/FlatToDeep.cpp
+++ b/src/GafferImage/FlatToDeep.cpp
@@ -116,7 +116,6 @@ const IntPlug *FlatToDeep::zBackModePlug() const
 	return getChild<IntPlug>( g_firstPlugIndex + 3 );
 }
 
-
 FloatPlug *FlatToDeep::thicknessPlug()
 {
 	return getChild<FloatPlug>( g_firstPlugIndex + 4 );
@@ -141,14 +140,20 @@ void FlatToDeep::affects( const Gaffer::Plug *input, AffectedPlugsContainer &out
 {
 	ImageProcessor::affects( input, outputs );
 
-	if( input == inPlug()->channelNamesPlug() || input == zBackModePlug() )
+	if(
+		input == inPlug()->channelNamesPlug() ||
+		input == zBackModePlug()
+	)
 	{
 		outputs.push_back( outPlug()->channelNamesPlug() );
 	}
-	else if( input == inPlug()->channelDataPlug() ||
+
+	if(
+		input == inPlug()->channelDataPlug() ||
 		input == zModePlug() ||
 		input == zChannelPlug() ||
 		input == depthPlug() ||
+		input == inPlug()->channelNamesPlug() ||
 		input == zBackModePlug() ||
 		input == zBackChannelPlug() ||
 		input == thicknessPlug()

--- a/src/GafferImage/ImageMetadata.cpp
+++ b/src/GafferImage/ImageMetadata.cpp
@@ -71,7 +71,7 @@ void ImageMetadata::affects( const Gaffer::Plug *input, AffectedPlugsContainer &
 {
 	MetadataProcessor::affects( input, outputs );
 
-	if ( input == inPlug()->metadataPlug() )
+	if( metadataPlug()->isAncestorOf( input ) )
 	{
 		outputs.push_back( outPlug()->metadataPlug() );
 	}

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -864,6 +864,11 @@ void OpenImageIOReader::affects( const Gaffer::Plug *input, AffectedPlugsContain
 
 	if( input == fileNamePlug() || input == refreshCountPlug() || input == missingFrameModePlug() )
 	{
+		outputs.push_back( tileBatchPlug() );
+	}
+
+	if( input == fileNamePlug() || input == refreshCountPlug() || input == missingFrameModePlug() )
+	{
 		for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
 		{
 			outputs.push_back( it->get() );

--- a/src/GafferModule/ValuePlugBinding.cpp
+++ b/src/GafferModule/ValuePlugBinding.cpp
@@ -131,6 +131,8 @@ void GafferModule::bindValuePlug()
 		.staticmethod( "getHashCacheSizeLimit" )
 		.def( "setHashCacheSizeLimit", &ValuePlug::setHashCacheSizeLimit )
 		.staticmethod( "setHashCacheSizeLimit" )
+		.def( "clearHashCache", &ValuePlug::clearHashCache )
+		.staticmethod( "clearHashCache" )
 		.def( "__repr__", &repr )
 	;
 

--- a/src/GafferScene/Encapsulate.cpp
+++ b/src/GafferScene/Encapsulate.cpp
@@ -95,37 +95,6 @@ void Encapsulate::affects( const Plug *input, AffectedPlugsContainer &outputs ) 
 	}
 }
 
-bool Encapsulate::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
-{
-	if( !FilteredSceneProcessor::acceptsInput( plug, inputPlug ) )
-	{
-		return false;
-	}
-
-	if( plug == filterPlug() )
-	{
-		if(
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->boundPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->transformPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->attributesPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->objectPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->childNamesPlug() )
-		)
-		{
-			// We make a single call to filterHash() in hashSet(), to account for
-			// the fact that the filter is used in remapping sets. This wouldn't
-			// work for filter types which actually vary based on data within the
-			// scene hierarchy, because then multiple calls would be necessary.
-			// We could make more calls here, but that would be expensive.
-			/// \todo In an ideal world we'd be able to compute a hash for the
-			/// filter across a whole hierarchy.
-			return false;
-		}
-	}
-
-	return true;
-}
-
 void Encapsulate::hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	if( filterValue( context ) & IECore::PathMatcher::ExactMatch )

--- a/src/GafferScene/Filter.cpp
+++ b/src/GafferScene/Filter.cpp
@@ -90,11 +90,6 @@ void Filter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs
 	}
 }
 
-bool Filter::sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const
-{
-	return false;
-}
-
 void Filter::setInputScene( Gaffer::Context *context, const ScenePlug *scenePlug )
 {
 	context->set( inputSceneContextName, (uint64_t)scenePlug );

--- a/src/GafferScene/FilterPlug.cpp
+++ b/src/GafferScene/FilterPlug.cpp
@@ -127,19 +127,19 @@ Gaffer::PlugPtr FilterPlug::createCounterpart( const std::string &name, Directio
 	return new FilterPlug( name, direction, defaultValue(), minValue(), maxValue(), getFlags() );
 }
 
-bool FilterPlug::sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const
+void FilterPlug::sceneAffects( const Gaffer::Plug *scenePlugChild, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const
 {
 	const Plug *source = this->source();
 	if( source == this )
 	{
 		// No input
-		return false;
+		return;
 	}
 
 	const Node *sourceNode = source->node();
 	if( const Filter *filter = runTimeCast<const Filter>( sourceNode ) )
 	{
-		return filter->sceneAffectsMatch( scene, child );
+		filter->affects( scenePlugChild, outputs );
 	}
 	else if( const Switch *switchNode = runTimeCast<const Switch>( sourceNode ) )
 	{
@@ -149,14 +149,10 @@ bool FilterPlug::sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValueP
 			// relevant.
 			for( InputFilterPlugIterator it( switchNode->inPlugs() ); !it.done(); ++it )
 			{
-				if( (*it)->sceneAffectsMatch( scene, child ) )
-				{
-					return true;
-				}
+				(*it)->sceneAffects( scenePlugChild, outputs );
 			}
 		}
 	}
-	return false;
 }
 
 FilterPlug::SceneScope::SceneScope( const Gaffer::Context *context, const ScenePlug *scenePlug )

--- a/src/GafferScene/FilterProcessor.cpp
+++ b/src/GafferScene/FilterProcessor.cpp
@@ -36,6 +36,8 @@
 
 #include "GafferScene/FilterProcessor.h"
 
+#include "GafferScene/ScenePlug.h"
+
 #include "Gaffer/ArrayPlug.h"
 
 using namespace IECore;
@@ -102,22 +104,23 @@ const Gaffer::ArrayPlug *FilterProcessor::inPlugs() const
 	return getChild<Gaffer::ArrayPlug>( g_firstPlugIndex );
 }
 
-bool FilterProcessor::sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const
+void FilterProcessor::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
-	if( const ArrayPlug *arrayIn = this->inPlugs() )
+	Filter::affects( input, outputs );
+
+	if( input->parent<ScenePlug>() )
 	{
-		for( InputFilterPlugIterator it( arrayIn ); !it.done(); ++it )
+		if( const ArrayPlug *arrayIn = this->inPlugs() )
 		{
-			if( (*it)->sceneAffectsMatch( scene, child ) )
+			for( InputFilterPlugIterator it( arrayIn ); !it.done(); ++it )
 			{
-				return true;
+				(*it)->sceneAffects( input, outputs );
 			}
 		}
-		return false;
-	}
-	else
-	{
-		return inPlug()->sceneAffectsMatch( scene, child );
+		else
+		{
+			inPlug()->sceneAffects( input, outputs );
+		}
 	}
 }
 

--- a/src/GafferScene/FilterResults.cpp
+++ b/src/GafferScene/FilterResults.cpp
@@ -109,10 +109,7 @@ void FilterResults::affects( const Gaffer::Plug *input, AffectedPlugsContainer &
 	const ScenePlug *scenePlug = input->parent() == this->scenePlug() ? this->scenePlug() : nullptr;
 	if( scenePlug )
 	{
-		if( filterPlug()->sceneAffectsMatch( scenePlug, static_cast<const ValuePlug *>( input ) ) )
-		{
-			outputs.push_back( filterPlug() );
-		}
+		filterPlug()->sceneAffects( input, outputs );
 	}
 
 	if(

--- a/src/GafferScene/FilterResults.cpp
+++ b/src/GafferScene/FilterResults.cpp
@@ -106,19 +106,24 @@ void FilterResults::affects( const Gaffer::Plug *input, AffectedPlugsContainer &
 {
 	ComputeNode::affects( input, outputs );
 
-	const ScenePlug *scenePlug = input->parent<ScenePlug>();
-	if( scenePlug && scenePlug == this->scenePlug() )
+	const ScenePlug *scenePlug = input->parent() == this->scenePlug() ? this->scenePlug() : nullptr;
+	if( scenePlug )
 	{
 		if( filterPlug()->sceneAffectsMatch( scenePlug, static_cast<const ValuePlug *>( input ) ) )
 		{
 			outputs.push_back( filterPlug() );
 		}
 	}
-	else if( input == filterPlug() )
+
+	if(
+		input == filterPlug() ||
+		( scenePlug && input == scenePlug->childNamesPlug() )
+	)
 	{
 		outputs.push_back( internalOutPlug() );
 	}
-	else if( input == internalOutPlug() )
+
+	if( input == internalOutPlug() )
 	{
 		outputs.push_back( outPlug() );
 	}

--- a/src/GafferScene/FilterResults.cpp
+++ b/src/GafferScene/FilterResults.cpp
@@ -106,15 +106,14 @@ void FilterResults::affects( const Gaffer::Plug *input, AffectedPlugsContainer &
 {
 	ComputeNode::affects( input, outputs );
 
-	const ScenePlug *scenePlug = input->parent() == this->scenePlug() ? this->scenePlug() : nullptr;
-	if( scenePlug )
+	if( input->parent() == scenePlug() )
 	{
 		filterPlug()->sceneAffects( input, outputs );
 	}
 
 	if(
 		input == filterPlug() ||
-		( scenePlug && input == scenePlug->childNamesPlug() )
+		input == scenePlug()->childNamesPlug()
 	)
 	{
 		outputs.push_back( internalOutPlug() );

--- a/src/GafferScene/FilterResults.cpp
+++ b/src/GafferScene/FilterResults.cpp
@@ -142,6 +142,7 @@ void FilterResults::hash( const Gaffer::ValuePlug *output, const Gaffer::Context
 	else if( output == outPlug() )
 	{
 		ScenePlug::GlobalScope globalScope( context );
+		globalScope.remove( SceneAlgo::historyIDContextName() );
 		internalOutPlug()->hash( h );
 	}
 }
@@ -158,6 +159,7 @@ void FilterResults::compute( Gaffer::ValuePlug *output, const Gaffer::Context *c
 	else if( output == outPlug() )
 	{
 		ScenePlug::GlobalScope globalScope( context );
+		globalScope.remove( SceneAlgo::historyIDContextName() );
 		output->setFrom( internalOutPlug() );
 		return;
 	}

--- a/src/GafferScene/FilteredSceneProcessor.cpp
+++ b/src/GafferScene/FilteredSceneProcessor.cpp
@@ -82,10 +82,11 @@ void FilteredSceneProcessor::affects( const Gaffer::Plug *input, AffectedPlugsCo
 	const ScenePlug *scenePlug = input->parent<ScenePlug>();
 	if( scenePlug && scenePlug == inPlug() )
 	{
-		if( filterPlug()->sceneAffectsMatch( scenePlug, static_cast<const ValuePlug *>( input ) ) )
-		{
-			outputs.push_back( filterPlug() );
-		}
+		// We'll be passing this scene to the filter when we
+		// call `filterValue()`, so we must give the filter
+		// a chance to dirty any of its plugs that depend on
+		// the scene.
+		filterPlug()->sceneAffects( input, outputs );
 	}
 }
 

--- a/src/GafferScene/FreezeTransform.cpp
+++ b/src/GafferScene/FreezeTransform.cpp
@@ -87,21 +87,37 @@ void FreezeTransform::affects( const Gaffer::Plug *input, AffectedPlugsContainer
 {
 	FilteredSceneProcessor::affects( input, outputs );
 
-	if( input == inPlug()->transformPlug() )
+	if(
+		input == inPlug()->transformPlug() ||
+		input == outPlug()->transformPlug()
+	)
 	{
 		outputs.push_back( transformPlug() );
 	}
-	else if( input == inPlug()->objectPlug() )
+
+	if(
+		input == filterPlug() ||
+		input == inPlug()->boundPlug() ||
+		input == transformPlug()
+	)
 	{
-		outputs.push_back( outPlug()->objectPlug() );
+		outputs.push_back( outPlug()->boundPlug() );
 	}
-	else if(
-		input == transformPlug() ||
-		input == filterPlug()
+
+	if(
+		input == filterPlug() ||
+		input == inPlug()->transformPlug()
 	)
 	{
 		outputs.push_back( outPlug()->transformPlug() );
-		outputs.push_back( outPlug()->boundPlug() );
+	}
+
+	if(
+		input == filterPlug() ||
+		input == inPlug()->objectPlug() ||
+		input == transformPlug()
+	)
+	{
 		outputs.push_back( outPlug()->objectPlug() );
 	}
 }

--- a/src/GafferScene/Isolate.cpp
+++ b/src/GafferScene/Isolate.cpp
@@ -190,37 +190,6 @@ void Isolate::affects( const Gaffer::Plug *input, AffectedPlugsContainer &output
 	}
 }
 
-bool Isolate::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
-{
-	if( !FilteredSceneProcessor::acceptsInput( plug, inputPlug ) )
-	{
-		return false;
-	}
-
-	if( plug == filterPlug() )
-	{
-		if(
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->boundPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->transformPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->attributesPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->objectPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->childNamesPlug() )
-		)
-		{
-			// We make a single call to filterHash() in hashSet(), to account for
-			// the fact that the filter is used in remapping sets. This wouldn't
-			// work for filter types which actually vary based on data within the
-			// scene hierarchy, because then multiple calls would be necessary.
-			// We could make more calls here, but that would be expensive.
-			/// \todo In an ideal world we'd be able to compute a hash for the
-			/// filter across a whole hierarchy.
-			return false;
-		}
-	}
-
-	return true;
-}
-
 void Isolate::hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	const SetsToKeep setsToKeep( this );

--- a/src/GafferScene/LightToCamera.cpp
+++ b/src/GafferScene/LightToCamera.cpp
@@ -294,38 +294,6 @@ void LightToCamera::affects( const Gaffer::Plug *input, AffectedPlugsContainer &
 	}
 }
 
-bool LightToCamera::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
-{
-	if( !SceneElementProcessor::acceptsInput( plug, inputPlug ) )
-	{
-		return false;
-	}
-
-	if( plug == filterPlug() )
-	{
-		if(
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->boundPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->transformPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->attributesPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->objectPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->childNamesPlug() )
-		)
-		{
-			// We make a single call to filterHash() in hashSet(), to account for
-			// the fact that the filter is used in remapping sets. This wouldn't
-			// work for filter types which actually vary based on data within the
-			// scene hierarchy, because then multiple calls would be necessary.
-			// We could make more calls here, but that would be expensive.
-			/// \todo In an ideal world we'd be able to compute a hash for the
-			/// filter across a whole hierarchy.
-			return false;
-		}
-	}
-
-	return true;
-}
-
-
 bool LightToCamera::processesObject() const
 {
 	return true;

--- a/src/GafferScene/PathFilter.cpp
+++ b/src/GafferScene/PathFilter.cpp
@@ -159,6 +159,11 @@ void PathFilter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &out
 	{
 		outputs.push_back( outPlug() );
 	}
+
+	if( input->parent<ScenePlug>() )
+	{
+		rootsPlug()->sceneAffects( input, outputs );
+	}
 }
 
 void PathFilter::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
@@ -273,16 +278,6 @@ unsigned PathFilter::computeMatch( const ScenePlug *scene, const Gaffer::Context
 	}
 
 	return result;
-}
-
-bool PathFilter::sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const
-{
-	if( Filter::sceneAffectsMatch( scene, child ) )
-	{
-		return true;
-	}
-
-	return rootsPlug()->sceneAffectsMatch( scene, child );
 }
 
 void PathFilter::hashRootSizes( const Gaffer::Context *context, IECore::MurmurHash &h ) const

--- a/src/GafferScene/Prune.cpp
+++ b/src/GafferScene/Prune.cpp
@@ -95,37 +95,6 @@ void Prune::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs 
 	}
 }
 
-bool Prune::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
-{
-	if( !FilteredSceneProcessor::acceptsInput( plug, inputPlug ) )
-	{
-		return false;
-	}
-
-	if( plug == filterPlug() )
-	{
-		if(
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->boundPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->transformPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->attributesPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->objectPlug() ) ||
-			filterPlug()->sceneAffectsMatch( inPlug(), inPlug()->childNamesPlug() )
-		)
-		{
-			// We make a single call to filterHash() in hashSet(), to account for
-			// the fact that the filter is used in remapping sets. This wouldn't
-			// work for filter types which actually vary based on data within the
-			// scene hierarchy, because then multiple calls would be necessary.
-			// We could make more calls here, but that would be expensive.
-			/// \todo In an ideal world we'd be able to compute a hash for the
-			/// filter across a whole hierarchy.
-			return false;
-		}
-	}
-
-	return true;
-}
-
 void Prune::hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	if( adjustBoundsPlug()->getValue() )

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -368,8 +368,7 @@ class CapturingMonitor : public Monitor
 
 IE_CORE_DECLAREPTR( CapturingMonitor )
 
-InternedString g_contextUniquefierName = "__sceneAlgoHistory:uniquefier";
-uint64_t g_contextUniquefierValue = 0;
+uint64_t g_historyID = 0;
 
 SceneAlgo::History::Ptr historyWalk( const CapturedProcess *process, InternedString scenePlugChildName, SceneAlgo::History *parent )
 {
@@ -601,6 +600,12 @@ ShaderTweaks *shaderTweaksWalk( const SceneAlgo::AttributeHistory *h )
 
 } // namespace
 
+InternedString SceneAlgo::historyIDContextName()
+{
+	static InternedString s( "__sceneAlgoHistory:id" );
+	return s;
+}
+
 SceneAlgo::History::Ptr SceneAlgo::history( const Gaffer::ValuePlug *scenePlugChild, const ScenePlug::ScenePath &path )
 {
 	if( !scenePlugChild->parent<ScenePlug>() )
@@ -614,7 +619,7 @@ SceneAlgo::History::Ptr SceneAlgo::history( const Gaffer::ValuePlug *scenePlugCh
 	{
 		ScenePlug::PathScope pathScope( Context::current(), path );
 		// Trick to bypass the hash cache and get a full upstream evaluation.
-		pathScope.set( g_contextUniquefierName, g_contextUniquefierValue++ );
+		pathScope.set( historyIDContextName(), g_historyID++ );
 		Monitor::Scope monitorScope( monitor );
 		scenePlugChild->hash();
 	}

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -383,7 +383,9 @@ SceneAlgo::History::Ptr historyWalk( const CapturedProcess *process, InternedStr
 		ScenePlug *scene = plug->parent<ScenePlug>();
 		if( scene && plug == scene->getChild( scenePlugChildName ) )
 		{
-			SceneAlgo::History::Ptr history = new SceneAlgo::History( scene, process->context );
+			ContextPtr cleanContext = new Context( *process->context, Context::Copied );
+			cleanContext->remove( SceneAlgo::historyIDContextName() );
+			SceneAlgo::History::Ptr history = new SceneAlgo::History( scene, cleanContext );
 			if( !result )
 			{
 				result = history;

--- a/src/GafferScene/SetAlgo.cpp
+++ b/src/GafferScene/SetAlgo.cpp
@@ -546,13 +546,13 @@ IECore::MurmurHash setExpressionHash( const std::string &setExpression, const Sc
 
 bool affectsSetExpression( const Plug *scenePlugChild )
 {
-	const ScenePlug *parent = scenePlugChild->parent<ScenePlug>();
-
-	if( parent->setPlug() == scenePlugChild )
+	if( auto parent = scenePlugChild->parent<ScenePlug>() )
 	{
-		return true;
+		return
+			scenePlugChild == parent->setPlug() ||
+			scenePlugChild == parent->setNamesPlug()
+		;
 	}
-
 	return false;
 }
 

--- a/src/GafferScene/SetFilter.cpp
+++ b/src/GafferScene/SetFilter.cpp
@@ -88,7 +88,10 @@ void SetFilter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 {
 	Filter::affects( input, outputs );
 
-	if( input == setExpressionPlug() )
+	if(
+		input == setExpressionPlug() ||
+		( input->parent<ScenePlug>() && SetAlgo::affectsSetExpression( input ) )
+	)
 	{
 		outputs.push_back( expressionResultPlug() );
 	}
@@ -98,16 +101,6 @@ void SetFilter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 		outputs.push_back( outPlug() );
 	}
 
-}
-
-bool SetFilter::sceneAffectsMatch( const ScenePlug *scene, const Gaffer::ValuePlug *child ) const
-{
-	if( Filter::sceneAffectsMatch( scene, child ) )
-	{
-		return true;
-	}
-
-	return child == scene->setPlug();
 }
 
 void SetFilter::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -704,7 +704,8 @@ void Shader::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs
 		input == nodeNamePlug() ||
 		input == namePlug() ||
 		input == typePlug() ||
-		input->parent<Plug>() == nodeColorPlug()
+		input->parent<Plug>() == nodeColorPlug() ||
+		input == attributeSuffixPlug()
 	)
 	{
 		if( const Plug *out = outPlug() )

--- a/src/GafferScene/UDIMQuery.cpp
+++ b/src/GafferScene/UDIMQuery.cpp
@@ -130,7 +130,8 @@ void UDIMQuery::affects( const Plug *input, AffectedPlugsContainer &outputs ) co
 		input == attributesPlug() ||
 		input == filterPlug() ||
 		input == inPlug()->objectPlug() ||
-		input == inPlug()->attributesPlug()
+		input == inPlug()->attributesPlug() ||
+		input == inPlug()->childNamesPlug()
 	)
 	{
 		outputs.push_back( outPlug() );
@@ -249,7 +250,7 @@ struct InfoDataAccumulator
 		// and without checking adjacency information, it would be impossible to tell which UDIM the edge
 		// belongs to.  Checking face centers is fairly simple, and is completely accurate except in extreme
 		// cases of polygons spanning multiple UDIMs, which is not done according to UDIM conventions.
-		int faceVertId = 0;	
+		int faceVertId = 0;
 		for( int numVerts : vertsPerFace )
 		{
 			Imath::V2f accum = Imath::V2f(0);
@@ -306,7 +307,7 @@ void UDIMQuery::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 		GafferScene::SceneAlgo::filteredParallelTraverse( inPlug(), filterPlug(), f );
 
 		IECore::CompoundObjectPtr result = new IECore::CompoundObject();
-	
+
 		for( const auto &i : f.m_data )
 		{
 			for( int udim : i.udims )

--- a/src/GafferScene/UnionFilter.cpp
+++ b/src/GafferScene/UnionFilter.cpp
@@ -55,7 +55,7 @@ UnionFilter::~UnionFilter()
 
 void UnionFilter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
-	Filter::affects( input, outputs );
+	FilterProcessor::affects( input, outputs );
 
 	if( input->parent<ArrayPlug>() == inPlugs() )
 	{

--- a/src/GafferSceneModule/SetAlgoBinding.cpp
+++ b/src/GafferSceneModule/SetAlgoBinding.cpp
@@ -93,6 +93,9 @@ void bindSetAlgo()
 		&setExpressionHashWrapper2,
 		( arg( "expression" ), arg( "scene" ), arg( "h" ) )
 	);
+
+	def( "affectsSetExpression", &SetAlgo::affectsSetExpression );
+
 }
 
 } // namespace GafferSceneModule

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -545,10 +545,9 @@ Imath::M44f TransformTool::Selection::transform( Imath::V3f &translate, Imath::V
 		V3f shear;
 		extractSHRT( m, scale, shear, rotate, translate );
 		M44f result;
-		result.translate( pivot + translate );
+		result.translate( translate );
 		result.rotate( rotate );
 		result.scale( scale );
-		result.translate( -pivot );
 		pivot = V3f( 0 );
 		rotate = IECore::radiansToDegrees( rotate );
 		return result;

--- a/src/GafferVDB/LevelSetToMesh.cpp
+++ b/src/GafferVDB/LevelSetToMesh.cpp
@@ -232,6 +232,11 @@ void LevelSetToMesh::affects( const Gaffer::Plug *input, AffectedPlugsContainer 
 	{
 		outputs.push_back( outPlug()->objectPlug() );
 	}
+
+	if( input == isoValuePlug() )
+	{
+		outputs.push_back( outPlug()->boundPlug() );
+	}
 }
 
 bool LevelSetToMesh::processesObject() const
@@ -274,18 +279,11 @@ bool LevelSetToMesh::processesBound() const
 void LevelSetToMesh::hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	SceneElementProcessor::hashProcessedBound( path, context, h );
-
-	gridPlug()->hash( h );
 	isoValuePlug()->hash( h );
 }
 
 Imath::Box3f LevelSetToMesh::computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const
 {
-	Imath::Box3f newBound = inputBound;
-	float offset = isoValuePlug()->getValue();
-
-	newBound.min -= Imath::V3f(offset, offset, offset);
-	newBound.max += Imath::V3f(offset, offset, offset);
-
-	return newBound;
+	const V3f offset( isoValuePlug()->getValue() );
+	return Box3f( inputBound.min - offset, inputBound.max + offset );
 }

--- a/src/GafferVDB/MeshToLevelSet.cpp
+++ b/src/GafferVDB/MeshToLevelSet.cpp
@@ -186,7 +186,12 @@ void MeshToLevelSet::affects( const Gaffer::Plug *input, AffectedPlugsContainer 
 {
 	SceneElementProcessor::affects( input, outputs );
 
-	if( input == voxelSizePlug() || input == gridPlug() )
+	if(
+		input == gridPlug() ||
+		input == voxelSizePlug() ||
+		input == exteriorBandwidthPlug() ||
+		input == interiorBandwidthPlug()
+	)
 	{
 		outputs.push_back( outPlug()->objectPlug() );
 	}


### PR DESCRIPTION
This significantly improves interactive performance by removing the previous brute-force clearing of the cache whenever the node graph is modified. The main reason we've been slow to implement this despite the obvious benefits is that it is much more sensitive to bugs in `DependencyNode::affects()` implementations. Previously such bugs typically just meant that a UI update wasn't triggered when expected, but now the failure mode is the fetching of stale results from the cache, which is potentially much worse. I've mitigated against this as best I can :

- Fixed all the bugs exposed by our unit tests. We should have decent coverage, but I wouldn't be surprised if there are still a few lurking.
- Improved some sanity checks that help detect stale hashes (49ad815).
- Added an API call to do a brute force clear of the cache to help in debugging (ec9aa54  ).
- Added an environment variable that can be used to revert to the old behaviour.

I expect it will take a little bit of effort to get all the legacy bugs fixed for this one, but with the results I'm seeing, that effort should be worth it.