### PR TITLE
Hash Cache Validation Experiments

### DIFF
--- a/python/GafferImageTest/ConstantTest.py
+++ b/python/GafferImageTest/ConstantTest.py
@@ -161,9 +161,12 @@ class ConstantTest( GafferImageTest.ImageTestCase ) :
 			c.affects( c["format"]["displayWindow"]["min"]["x"] ),
 			[ c["out"]["format"], c["out"]["dataWindow"] ],
 		)
+
+		# For the sake of simplicity when dealing with falling back to a default format from the context,
+		# we make all child plugs of the format affect everything that depends at all on the format
 		self.assertEqual(
 			c.affects( c["format"]["pixelAspect"] ),
-			[ c["out"]["format"] ],
+			[ c["out"]["format"], c["out"]["dataWindow"] ],
 		)
 
 	def testLayer( self ) :

--- a/python/GafferSceneTest/SeedsTest.py
+++ b/python/GafferSceneTest/SeedsTest.py
@@ -221,7 +221,7 @@ class SeedsTest( GafferSceneTest.SceneTestCase ) :
 		# Add the primitive variable, it should take effect.
 
 		primitiveVariables["primitiveVariables"].addChild( Gaffer.NameValuePlug( "d", IECore.FloatData( 0.5 ) ) )
-		self.assertLessEqual( seeds["out"].object( "/plane/seeds" ).numPoints, p.numPoints )
+		self.assertLess( seeds["out"].object( "/plane/seeds" ).numPoints, p.numPoints )
 
 	def testInternalConnectionsNotSerialised( self ) :
 

--- a/python/GafferSceneTest/SeedsTest.py
+++ b/python/GafferSceneTest/SeedsTest.py
@@ -220,7 +220,7 @@ class SeedsTest( GafferSceneTest.SceneTestCase ) :
 
 		# Add the primitive variable, it should take effect.
 
-		primitiveVariables["primitiveVariables"].addChild( Gaffer.NameValuePlug( "d", IECore.FloatData( 0.5 ) ) )
+		primitiveVariables["primitiveVariables"].addChild( Gaffer.NameValuePlug( "d", IECore.FloatData( 0.5 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 		self.assertLess( seeds["out"].object( "/plane/seeds" ).numPoints, p.numPoints )
 
 	def testInternalConnectionsNotSerialised( self ) :

--- a/src/GafferImage/Constant.cpp
+++ b/src/GafferImage/Constant.cpp
@@ -107,15 +107,10 @@ void Constant::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outpu
 		outputs.push_back( outPlug()->channelDataPlug() );
 	}
 
-	if( formatPlug()->displayWindowPlug()->isAncestorOf( input ) )
+	if( formatPlug()->isAncestorOf( input ) )
 	{
 		outputs.push_back( outPlug()->formatPlug() );
 		outputs.push_back( outPlug()->dataWindowPlug() );
-	}
-
-	if( input == formatPlug()->pixelAspectPlug() )
-	{
-		outputs.push_back( outPlug()->formatPlug() );
 	}
 
 	if( input == layerPlug() )

--- a/src/GafferImage/Resize.cpp
+++ b/src/GafferImage/Resize.cpp
@@ -154,7 +154,9 @@ void Resize::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs
 
 	if(
 		input == inPlug()->dataWindowPlug() ||
-		input == resampledInPlug()->dataWindowPlug()
+		input == resampledInPlug()->dataWindowPlug() ||
+		input == inPlug()->formatPlug() ||
+		formatPlug()->isAncestorOf( input )
 	)
 	{
 		outputs.push_back( outPlug()->dataWindowPlug() );
@@ -162,7 +164,9 @@ void Resize::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs
 
 	if(
 		input == inPlug()->channelDataPlug() ||
-		input == resampledInPlug()->channelDataPlug()
+		input == resampledInPlug()->channelDataPlug() ||
+		input == inPlug()->formatPlug() ||
+		formatPlug()->isAncestorOf( input )
 	)
 	{
 		outputs.push_back( outPlug()->channelDataPlug() );

--- a/src/GafferImage/Shape.cpp
+++ b/src/GafferImage/Shape.cpp
@@ -199,6 +199,11 @@ void Shape::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs 
 		return;
 	}
 
+	if( input == inPlug()->deepPlug() )
+	{
+		outputs.push_back( shapePlug()->deepPlug() );
+	}
+
 	if( affectsShapeDataWindow( input ) )
 	{
 		outputs.push_back( shapePlug()->dataWindowPlug() );


### PR DESCRIPTION
While looking into auditing affects() in IERendering, it became apparent that there is a lot of custom Gaffer nodes floating around at IE, and that making sure that their affects methods are all up to the new standard of complete accuracy being required as a result of the new hash cache behaviour is quite a large undertaking.

While I do still think a full audit is called for, I also think anything we can do to catch anything that slips through the cracks, and makes it easier to debug potential production issues that could be caused by a missing affects() is probably worthwhile.

This is an experiment which adds a mode where the hash cache is updated, but all hash entries are computed on the fly as well, so that it is possible to confirm that the cache entry matches the current result.

I'm not sure if it makes sense to actually merge in this form, but something like this would definitely be useful.  It turns up some interesting results of potentially debatable value in Gaffer, but definitely highlights a bunch of actual failures in IERendering.  The biggest downside is that the performance loss from disabling the hash cache is so enormous that there a bunch of tests that must be disabled before enabling this flag.

In terms of results of testing in Gaffer:

* GafferImage::Constant is an interesting case - the hash is unnecessarily pessimistic, including the whole format plug, instead of just the displayWindow.  affects() and compute use just formatPlug()->displayWindowPlug().  I'm not sure whether this should be generally considered invalid or not, but this seems to be the main case of it that's shown up, and in this case, it's easy enough to switch the hash to only hash what's needed.

* GafferImage::Shape - I think this is a legitimate bug it turned up which I've fixed ... the generic FlatImageProcessor::hashDeep is causing the intermediate image deep plug to depend on the input deep, and the affects() did not reflect this.

* GafferImage::Resize - I don't think the tests actually turned this up, but while searching for the explanation for something else, I happened to notice that the plugs used by source() didn't seem accounted for

* SeedsTest - This is the really interesting one.  The new flag highlighted this, and on investigation, it actually looks like it's failing badly.  The test was actually written incorrectly so it didn't test what it said it was testing ( it was testing that a change in density produced a point count `<=` to what it was before, when in order to ensure a change it should test  `<` ).  After correcting this test, the actual test is now failing.  This appears to be because adding child plugs is not triggering affects() - I searched a bit, but I couldn't figure out how adding a child should interact with the affects() mechanism.  ( Should all newly added child plugs automatically be dirtied? ) Hopefully this is a simple oversight rather than anything fundamental, but I'm probably going to need John to comment.  There appears to be a similar problem in python/GafferOSLTest/OSLObjectTest.py at line 971, due to a new child being added to the "attributes" plug and not invalidating - this one doesn't cause an actual test failure though, possibly because the code is modified at the same time, triggering an invalidate.

So, some stuff for John to mull over whenever he gets a chance.  I've got lots of IE code to cleanup now anyway, this check gives me some indication that I'm actually fixing some bugs.

