### PR TITLE
Dependencies : Update to 1.4.1

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -124,7 +124,7 @@ Breaking Changes
 Build
 -----
 
-- Updated to GafferHQ/dependencies 1.4.0.
+- Updated to GafferHQ/dependencies 1.4.1.
 
 0.57.5.0 (relative to 0.57.4.1)
 ========

--- a/config/installDependencies.sh
+++ b/config/installDependencies.sh
@@ -55,7 +55,7 @@ buildDir=${1:-"build/gaffer-$gafferMilestoneVersion.$gafferMajorVersion.$gafferM
 
 # Get the prebuilt dependencies package and unpack it into the build directory
 
-dependenciesVersion="1.4.0"
+dependenciesVersion="1.4.1"
 dependenciesVersionSuffix=""
 dependenciesFileName="gafferDependencies-$dependenciesVersion-$platform.tar.gz"
 downloadURL="https://github.com/GafferHQ/dependencies/releases/download/$dependenciesVersion$dependenciesVersionSuffix/$dependenciesFileName"


### PR DESCRIPTION
Adds a patch to Cortex to back-port 3D sampler support to IECoreGL::Shader

Note: Waiting on Mac package build before merging