### PR TITLE
Update to GafferHQ/dependencies 1.6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
             os: ubuntu-16.04
             buildType: RELEASE
             containerImage: gafferhq/build:1.1.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.4.0/gafferDependencies-1.4.0-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.6.0/gafferDependencies-1.6.0-linux.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -51,7 +51,7 @@ jobs:
             os: ubuntu-16.04
             buildType: DEBUG
             containerImage: gafferhq/build:1.1.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.4.0/gafferDependencies-1.4.0-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.6.0/gafferDependencies-1.6.0-linux.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -61,7 +61,7 @@ jobs:
             os: ubuntu-16.04
             buildType: RELEASE
             containerImage: gafferhq/build:1.1.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.0.0a3/gafferDependencies-2.0.0-Python3-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.0.0a5/gafferDependencies-2.0.0-Python3-linux.tar.gz
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 
@@ -69,7 +69,7 @@ jobs:
             os: macos-10.15
             buildType: RELEASE
             containerImage:
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.4.0/gafferDependencies-1.4.0-osx.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.6.0/gafferDependencies-1.6.0-osx.tar.gz
             testRunner: bash -c
             sconsCacheMegabytes: 400
 

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -43,7 +43,7 @@ import hashlib
 # Determine default archive URL.
 
 platform = "osx" if sys.platform == "darwin" else "linux"
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/1.4.0/gafferDependencies-1.4.0-" + platform + ".tar.gz"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/1.6.0/gafferDependencies-1.6.0-" + platform + ".tar.gz"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -126,7 +126,7 @@ Breaking Changes
 Build
 -----
 
-- Updated to GafferHQ/dependencies 1.4.0.
+- Updated to GafferHQ/dependencies 1.6.0.
 
 ========
 0.57.x.x (relative to 0.57.5.0)

--- a/config/installDependencies.sh
+++ b/config/installDependencies.sh
@@ -55,7 +55,7 @@ buildDir=${1:-"build/gaffer-$gafferMilestoneVersion.$gafferMajorVersion.$gafferM
 
 # Get the prebuilt dependencies package and unpack it into the build directory
 
-dependenciesVersion="1.4.0"
+dependenciesVersion="1.6.0"
 dependenciesVersionSuffix=""
 dependenciesFileName="gafferDependencies-$dependenciesVersion-$platform.tar.gz"
 downloadURL="https://github.com/GafferHQ/dependencies/releases/download/$dependenciesVersion$dependenciesVersionSuffix/$dependenciesFileName"


### PR DESCRIPTION
And 2.0.0a5 for Python 3 testing.
