### PR TITLE
ImageSampler : Add GafferScene ImageSampler node

### DIFF
--- a/include/GafferScene/ImageSampler.h
+++ b/include/GafferScene/ImageSampler.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
-//  Copyright (c) 2013, John Haddon. All rights reserved.
+//  Copyright (c) 2020, Hypothetical Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,60 +34,65 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERSCENE_IMAGESAMPLER_H
+#define GAFFERSCENE_IMAGESAMPLER_H
 
-#include "AttributesBinding.h"
-#include "CoreBinding.h"
-#include "EditScopeAlgoBinding.h"
-#include "FilterBinding.h"
-#include "GlobalsBinding.h"
-#include "HierarchyBinding.h"
-#include "IECoreGLPreviewBinding.h"
-#include "ImageSamplerBinding.h"
-#include "IOBinding.h"
-#include "TweaksBinding.h"
-#include "ObjectProcessorBinding.h"
-#include "OptionsBinding.h"
-#include "PrimitiveSamplerBinding.h"
-#include "PrimitiveVariablesBinding.h"
-#include "PrimitivesBinding.h"
-#include "RenderBinding.h"
-#include "RenderControllerBinding.h"
-#include "RendererAlgoBinding.h"
-#include "SceneAlgoBinding.h"
-#include "ScenePathBinding.h"
-#include "SetAlgoBinding.h"
-#include "ShaderBinding.h"
-#include "TransformBinding.h"
+#include "GafferImage/ImagePlug.h"
 
-using namespace boost::python;
-using namespace GafferSceneModule;
+#include "GafferScene/Deformer.h"
 
-BOOST_PYTHON_MODULE( _GafferScene )
+#include "Gaffer/StringPlug.h"
+
+#include "IECoreScene/PrimitiveEvaluator.h"
+
+namespace GafferScene
 {
 
-	bindCore();
-	bindFilter();
-	bindTransform();
-	bindGlobals();
-	bindOptions();
-	bindAttributes();
-	bindSceneAlgo();
-	bindRendererAlgo();
-	bindSetAlgo();
-	bindPrimitives();
-	bindScenePath();
-	bindShader();
-	bindRender();
-	bindRenderController();
-	bindHierarchy();
-	bindObjectProcessor();
-	bindPrimitiveVariables();
-	bindTweaks();
-	bindIO();
-	bindPrimitiveSampler();
-	bindIECoreGLPreview();
-	bindEditScopeAlgo();
-	bindImageSampler();
+class GAFFERSCENE_API ImageSampler : public Deformer
+{
 
-}
+	public :
+
+		ImageSampler( const std::string &name = defaultName<ImageSampler>() );
+		~ImageSampler() override;
+
+		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::ImageSampler, ImageSamplerTypeId, Deformer );
+
+        enum UVBoundsMode
+		{
+			Clamp = 0,
+            Tile = 1
+		};
+
+        GafferImage::ImagePlug *imagePlug();
+		const GafferImage::ImagePlug *imagePlug() const;
+
+        Gaffer::StringPlug *primVarNamePlug();
+		const Gaffer::StringPlug *primVarNamePlug() const;
+
+        Gaffer::StringPlug *uvVarNamePlug();
+		const Gaffer::StringPlug *uvVarNamePlug() const;
+
+        Gaffer::IntPlug *uvBoundsModePlug();
+        const Gaffer::IntPlug *uvBoundsModePlug() const;
+
+		Gaffer::StringPlug *channelsPlug();
+		const Gaffer::StringPlug *channelsPlug() const;
+
+	private :
+
+		bool affectsProcessedObject( const Gaffer::Plug *input ) const final;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const final;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const final;
+
+		bool adjustBounds() const final;
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( ImageSampler )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_IMAGESAMPLER_H

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -156,6 +156,7 @@ enum TypeId
 	PrimitiveSamplerTypeId = 110611,
 	ClosestPointSamplerTypeId = 110612,
 	CurveSamplerTypeId = 110613,
+	ImageSamplerTypeId = 110614,
 
 	PreviewGeometryTypeId = 110648,
 	PreviewProceduralTypeId = 110649,

--- a/python/GafferSceneTest/ImageSamplerTest.py
+++ b/python/GafferSceneTest/ImageSamplerTest.py
@@ -1,0 +1,505 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Hypothetical Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+import os
+
+import IECore
+import IECoreScene
+
+import Gaffer
+import GafferTest
+import GafferScene
+import GafferSceneTest
+import GafferImage
+
+class ImageSamplerTest( GafferSceneTest.SceneTestCase ) :
+
+	def checkVector( self, outMesh, primVar ) :
+		self.assertTrue( 
+			imath.V3f( 1.0, 0.0, 0.0 ).equalWithAbsError( 
+				outMesh[primVar].data[0],
+				.000001
+			)
+		)
+		self.assertTrue( 
+			imath.V3f( 0.0, 1.0, 0.0 ).equalWithAbsError(
+				outMesh[primVar].data[1],
+				.000001
+			)
+		)
+		self.assertTrue( 
+			imath.V3f( 0.0, 0.0, 1.0 ).equalWithAbsError(
+				outMesh[primVar].data[5],
+				.000001
+			)
+		)
+
+	def getTestRamp( self ) :
+
+		# Setup the ramp for convenient color interpolation.
+		# The ramp goes from pure red to green (at halfway)
+		# to blue across the u axis, so samples on the v 
+		# axis are identical.
+
+		ramp = GafferImage.Ramp()
+		ramp["format"].setValue( GafferImage.Format( 9, 9, 1. ) )
+		ramp["startPosition"].setValue( imath.V2f( 0, 0 ) )
+		ramp["endPosition"].setValue( imath.V2f( 9, 0 ) )
+		ramp["ramp"]["interpolation"].setValue( 0 )	# Linear interpolation
+
+		ramp["ramp"]["p0"]["x"].setValue( ( 1.0 / 9.0 / 2.0 ) )
+		ramp["ramp"]["p0"]["y"].setValue( imath.Color4f( 1.0, 0.0, 0.0, 0.0 ) )
+		ramp["ramp"]["p1"]["x"].setValue( 1.0 - ( 1.0 / 9.0 / 2.0 ) )
+		ramp["ramp"]["p1"]["y"].setValue( imath.Color4f( 0.0, 0.0, 1.0, 0.0 ) )
+		ramp["ramp"].addChild( Gaffer.ValuePlug( "p2" ) )
+		ramp["ramp"]["p2"].addChild( Gaffer.FloatPlug( "x", defaultValue = 0.5 ) )
+		ramp["ramp"]["p2"].addChild( Gaffer.Color4fPlug( "y", defaultValue = imath.Color4f( 0.0, 1.0, 0.0, 0.0 ) ) )
+
+		return ramp
+
+	def test( self ) :
+
+		# Sample from an image ramp onto a plane
+		# checking that values are as expected.
+
+		plane = GafferScene.Plane()
+		plane["dimensions"].setValue( imath.V2f( 2 ) )
+		plane["divisions"].setValue( imath.V2i( 2 ) )
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( ["/plane" ] ) )
+
+		ramp = self.getTestRamp()
+
+		imageSampler = GafferScene.ImageSampler()
+		imageSampler["in"].setInput( plane["out"] )
+		imageSampler["filter"].setInput( planeFilter["out"] )
+		imageSampler["image"].setInput( ramp["out"] )
+		imageSampler["uvPrimitiveVariable"].setValue( "uv" )
+
+		# Test pass through
+		self.assertScenesEqual( imageSampler["out"], plane["out"] )
+
+		# Test Cs
+		imageSampler["primitiveVariable"].setValue( "Cs" )
+		imageSampler["channels"].setValue( "R G B" )
+
+		self.assertSceneValid( imageSampler["out"] )
+
+		inMesh = imageSampler["in"].object( "/plane" )
+		outMesh = imageSampler["out"].object( "/plane" )
+		self.assertTrue( set( outMesh.keys() ), set( inMesh.keys() + ["Cs" ] ) )
+		self.assertTrue( 
+			imath.Color3f( 1.0, 0.0, 0.0 ).equalWithAbsError( 
+				outMesh["Cs"].data[0],
+				.000001
+			)
+		)
+		self.assertTrue( 
+			imath.Color3f( 0.0, 1.0, 0.0).equalWithAbsError(
+				outMesh["Cs"].data[1],
+				.000001
+			)
+		)
+		self.assertTrue( 
+			imath.Color3f( 0.0, 0.0, 1.0).equalWithAbsError(
+				outMesh["Cs"].data[5],
+				.000001
+			)
+		)
+
+		# Test N
+		imageSampler["primitiveVariable"].setValue( "N" )
+		outMesh = imageSampler["out"].object( "/plane" )
+		self.checkVector( outMesh, "N" )
+
+		# Test P
+		imageSampler["primitiveVariable"].setValue( "P" )
+		outMesh = imageSampler["out"].object( "/plane" )
+		self.checkVector( outMesh, "P" )
+
+		# Test Pref
+		imageSampler["primitiveVariable"].setValue( "Pref" )
+		outMesh = imageSampler["out"].object( "/plane" )
+		self.checkVector( outMesh, "Pref" )
+
+		# Test scale
+		imageSampler["primitiveVariable"].setValue( "scale" )
+		outMesh = imageSampler["out"].object( "/plane" )
+		self.checkVector( outMesh, "scale" )
+
+		# Test velocity
+		imageSampler["primitiveVariable"].setValue( "velocity" )
+		outMesh = imageSampler["out"].object( "/plane" )
+		self.checkVector( outMesh, "velocity" )
+
+		# Test uv
+		imageSampler["primitiveVariable"].setValue( "uv" )
+		imageSampler["channels"].setValue( "R G" )
+		outMesh = imageSampler["out"].object( "/plane" )
+		self.assertTrue( 
+			imath.V2f( 1.0, 0.0 ).equalWithAbsError( 
+				outMesh["uv"].data[0],
+				.000001
+			)
+		)
+		self.assertTrue( 
+			imath.V2f( 0.0, 1.0 ).equalWithAbsError(
+				outMesh["uv"].data[1],
+				.000001
+			)
+		)
+		self.assertTrue( 
+			imath.V2f( 0.0, 0.0 ).equalWithAbsError(
+				outMesh["uv"].data[5],
+				.000001
+			)
+		)
+
+		# Test width
+		imageSampler["primitiveVariable"].setValue( "width" )
+		imageSampler["channels"].setValue( "R" )
+		outMesh = imageSampler["out"].object( "/plane" )
+		self.assertAlmostEqual( 1.0, outMesh["width"].data[0], places = 5 )
+		self.assertAlmostEqual( 0.0, outMesh["width"].data[1], places = 5 )
+		self.assertAlmostEqual( 0.0, outMesh["width"].data[5], places = 5 )
+
+		# Test single float
+		imageSampler["primitiveVariable"].setValue( "test" )
+		imageSampler["channels"].setValue( "R" )
+		outMesh = imageSampler["out"].object( "/plane" )
+		self.assertAlmostEqual( 1.0, outMesh["test.R"].data[0], places = 5 )
+		self.assertAlmostEqual( 0.0, outMesh["test.R"].data[1], places = 5 )
+		self.assertAlmostEqual( 0.0, outMesh["test.R"].data[5], places = 5 )
+
+		# Test multiple floats
+		imageSampler["primitiveVariable"].setValue( "test2" )
+		imageSampler["channels"].setValue( "R G B" )
+		outMesh = imageSampler["out"].object( "/plane" )
+		self.assertAlmostEqual( 1.0, outMesh["test2.R"].data[0], places = 5 )
+		self.assertAlmostEqual( 0.0, outMesh["test2.G"].data[0], places = 5 )
+		self.assertAlmostEqual( 0.0, outMesh["test2.B"].data[0], places = 5 )
+
+		self.assertAlmostEqual( 0.0, outMesh["test2.R"].data[1], places = 5 )
+		self.assertAlmostEqual( 1.0, outMesh["test2.G"].data[1], places = 5 )
+		self.assertAlmostEqual( 0.0, outMesh["test2.B"].data[1], places = 5 )
+
+		self.assertAlmostEqual( 0.0, outMesh["test2.R"].data[5], places = 5 )
+		self.assertAlmostEqual( 0.0, outMesh["test2.G"].data[5], places = 5 )
+		self.assertAlmostEqual( 1.0, outMesh["test2.B"].data[5], places = 5 )
+
+	def testUVClamp( self ) :
+		pointsPrimitive = IECoreScene.PointsPrimitive(
+			IECore.V3fVectorData( [imath.V3f( 0 ) ] * 3 )
+		)
+
+		pointsPrimitive["uv"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.V2fVectorData(
+				[
+					imath.V2f( -0.1, 0.0 ),
+					imath.V2f( 0.5, 0.0 ),
+					imath.V2f( 1.1, 0.0 ),
+				],
+				IECore.GeometricData.Interpretation.UV
+			),
+		)
+
+		points = GafferScene.ObjectToScene()
+		points["object"].setValue( pointsPrimitive )
+
+		pointsFilter = GafferScene.PathFilter()
+		pointsFilter["paths"].setValue( IECore.StringVectorData( ["/object"] ) )
+
+		ramp = self.getTestRamp()
+
+		imageSampler = GafferScene.ImageSampler()
+		imageSampler["in"].setInput( points["out"] )
+		imageSampler["filter"].setInput( pointsFilter["out"] )
+		imageSampler["image"].setInput( ramp["out"] )
+		imageSampler["uvPrimitiveVariable"].setValue( "uv" )
+		imageSampler["primitiveVariable"].setValue( "Cs" )
+		imageSampler["channels"].setValue( "R G B" )
+
+		self.assertSceneValid( imageSampler["out"] )
+
+		inMesh = imageSampler["in"].object( "/object" )
+		outMesh = imageSampler["out"].object( "/object" )
+		self.assertTrue( set( outMesh.keys() ), set( inMesh.keys() + ["Cs"] ) )
+		self.assertTrue( 
+			imath.Color3f( 1.0, 0.0, 0.0 ).equalWithAbsError( 
+				outMesh["Cs"].data[0],
+				.000001
+			)
+		)
+		self.assertTrue( 
+			imath.Color3f( 0.0, 1.0, 0.0).equalWithAbsError(
+				outMesh["Cs"].data[1],
+				.000001
+			)
+		)
+		self.assertTrue( 
+			imath.Color3f( 0.0, 0.0, 1.0).equalWithAbsError(
+				outMesh["Cs"].data[2],
+				.000001
+			)
+		)
+
+	def testUVTile( self ) :
+		pointsPrimitive = IECoreScene.PointsPrimitive(
+			IECore.V3fVectorData( [imath.V3f( 0 ) ] * 3 )
+		)
+
+		pointsPrimitive["uv"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.V2fVectorData(
+				[
+					imath.V2f( -1.0 / 8.0, 0.0 ),
+					imath.V2f( 0.5, 0.0 ),
+					imath.V2f( 9.0 / 8.0, 0.0 ),
+				],
+				IECore.GeometricData.Interpretation.UV
+			),
+		)
+
+		points = GafferScene.ObjectToScene()
+		points["object"].setValue( pointsPrimitive )
+
+		pointsFilter = GafferScene.PathFilter()
+		pointsFilter["paths" ].setValue( IECore.StringVectorData( ["/object"] ) )
+
+		ramp = self.getTestRamp()
+
+		imageSampler = GafferScene.ImageSampler()
+		imageSampler["in"].setInput( points["out"] )
+		imageSampler["filter"].setInput( pointsFilter["out"] )
+		imageSampler["image"].setInput( ramp["out"] )
+		imageSampler["uvPrimitiveVariable"].setValue( "uv" )
+		imageSampler["primitiveVariable"].setValue( "Cs" )
+		imageSampler["channels"].setValue( "R G B" )
+		imageSampler["uvBoundsMode"].setValue( 1 )	# Tiled
+
+		self.assertSceneValid( imageSampler["out"] )
+
+		inMesh = imageSampler["in"].object( "/object" )
+		outMesh = imageSampler["out"].object( "/object" )
+		self.assertTrue( set( outMesh.keys() ), set( inMesh.keys() + ["Cs" ] ) )
+		self.assertTrue( 
+			imath.Color3f( 0, 0.25, 0.75 ).equalWithAbsError( 
+				outMesh["Cs"].data[0],
+				.000001
+			)
+		)
+		self.assertTrue( 
+			imath.Color3f( 0.0, 1.0, 0.0).equalWithAbsError(
+				outMesh["Cs"].data[1],
+				.000001
+			)
+		)
+		self.assertTrue( 
+			imath.Color3f( 0.75, 0.25, 0.0).equalWithAbsError(
+				outMesh["Cs"].data[2],
+				.000001
+			)
+		)
+
+		# Test that we don't flip 0.0 and 1.0 values
+		pointsPrimitive["uv"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.V2fVectorData(
+				[
+					imath.V2f( 0.0, 0.0 ),
+					imath.V2f( 0.5, 0.0 ),
+					imath.V2f( 1.0, 1.0 ),
+				],
+				IECore.GeometricData.Interpretation.UV
+			),
+		)
+
+		points["object"].setValue( pointsPrimitive )
+
+		outMesh = imageSampler["out"].object( "/object" )
+		self.assertTrue( set( outMesh.keys() ), set( inMesh.keys() + ["Cs" ] ) )
+		self.assertTrue( 
+			imath.Color3f( 1.0, 0.0, 0.0 ).equalWithAbsError( 
+				outMesh["Cs"].data[0],
+				.000001
+			)
+		)
+		self.assertTrue( 
+			imath.Color3f( 0.0, 1.0, 0.0).equalWithAbsError(
+				outMesh["Cs"].data[1],
+				.000001
+			)
+		)
+		self.assertTrue( 
+			imath.Color3f( 0.0, 0.0, 1.0).equalWithAbsError(
+				outMesh["Cs"].data[2],
+				.000001
+			)
+		)
+		
+
+	def testWrongSampleCount( self ) :
+		pointsPrimitive = IECoreScene.PointsPrimitive(
+			IECore.V3fVectorData( [imath.V3f( 0 ) ] * 3 )
+		)
+
+		pointsPrimitive["uv"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.V2fVectorData(
+				[
+					imath.V2f( 0.0, 0.0 ),
+					imath.V2f( 0.5, 0.0 ),
+					imath.V2f( 1.0, 0.0 ),
+				],
+				IECore.GeometricData.Interpretation.UV
+			),
+		)
+
+		points = GafferScene.ObjectToScene()
+		points["object"].setValue( pointsPrimitive )
+
+		pointsFilter = GafferScene.PathFilter()
+		pointsFilter["paths"].setValue( IECore.StringVectorData( ["/object" ] ) )
+
+		ramp = self.getTestRamp()
+
+		imageSampler = GafferScene.ImageSampler()
+		imageSampler["in"].setInput( points["out"] )
+		imageSampler["filter"].setInput( pointsFilter["out"] )
+		imageSampler["image"].setInput( ramp["out"] )
+		imageSampler["uvPrimitiveVariable"].setValue( "uv" )
+		imageSampler["primitiveVariable"].setValue( "Cs" )
+		imageSampler["channels"].setValue( "R G" )
+
+		self.assertRaises( Gaffer.ProcessException, imageSampler["out"].object, "/object" )
+
+		imageSampler["primitiveVariable"].setValue( "Cs" )
+		self.assertRaises( Gaffer.ProcessException, imageSampler["out"].object, "/object" )
+		
+		imageSampler["primitiveVariable"].setValue( "P" )
+		self.assertRaises( Gaffer.ProcessException, imageSampler["out"].object, "/object" )
+
+		imageSampler["primitiveVariable"].setValue( "Pref" )
+		self.assertRaises( Gaffer.ProcessException, imageSampler["out"].object, "/object" )
+
+		imageSampler["primitiveVariable"].setValue( "scale" )
+		self.assertRaises( Gaffer.ProcessException, imageSampler["out"].object, "/object" )
+
+		imageSampler["primitiveVariable"].setValue( "velocity" )
+		self.assertRaises( Gaffer.ProcessException, imageSampler["out"].object, "/object" )
+
+		imageSampler["channels"].setValue( "R G B" )
+
+		imageSampler["primitiveVariable"].setValue( "uv" )
+		self.assertRaises( Gaffer.ProcessException, imageSampler["out"].object, "/object" )
+
+		imageSampler["primitiveVariable"].setValue( "width" )
+		self.assertRaises( Gaffer.ProcessException, imageSampler["out"].object, "/object" )
+
+	def testContext( self ) :
+		pointsPrimitive = IECoreScene.PointsPrimitive(
+			IECore.V3fVectorData( [imath.V3f( 0 ) ] * 3 )
+		)
+
+		pointsPrimitive["uv"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.V2fVectorData(
+				[
+					imath.V2f( 0.0, 0.0 ),
+					imath.V2f( 0.5, 0.0 ),
+					imath.V2f( 1.0, 0.0 ),
+				],
+				IECore.GeometricData.Interpretation.UV
+			),
+		)
+
+		points = GafferScene.ObjectToScene()
+		points["object"].setValue( pointsPrimitive )
+
+		pointsFilter = GafferScene.PathFilter()
+		pointsFilter["paths"].setValue( IECore.StringVectorData( ["/object" ] ) )
+
+		imgReader = GafferImage.ImageReader()
+		imgReader["fileName"].setValue( "$a" )
+
+		imageSampler = GafferScene.ImageSampler()
+		imageSampler["in"].setInput( points["out"] )
+		imageSampler["filter"].setInput( pointsFilter["out"] )
+		imageSampler["image"].setInput( imgReader["out"] )
+		imageSampler["uvPrimitiveVariable"].setValue( "uv" )
+		imageSampler["primitiveVariable"].setValue( "Cs" )
+		imageSampler["channels"].setValue( "R G B" )
+
+		c = Gaffer.ContextVariables()
+		c.setup( GafferScene.ScenePlug() )
+		c["in"].setInput( imageSampler["out"] )
+
+		if os.name == "nt":
+			gaffer_root = os.path.abspath( os.path.expandvars( "%GAFFER_ROOT%" ) ).replace( "\\", "/" )
+		else:
+			gaffer_root = os.path.expandvars( "$GAFFER_ROOT" )
+
+		c["variables"].addChild( Gaffer.NameValuePlug( "a", IECore.StringData( gaffer_root + "/python/GafferImageTest/images/checker.exr" ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+
+		self.assertSceneValid( c["out"] )
+
+		inMesh = c["in"].object( "/object" )
+		outMesh = c["out"].object( "/object" )
+		self.assertTrue( set( outMesh.keys() ), set( inMesh.keys() + ["Cs" ] ) )
+		self.assertTrue( 
+			imath.Color3f( 0.1, 0.1, 0.1 ).equalWithAbsError( 
+				outMesh["Cs"].data[0],
+				.000001
+			)
+		)
+		self.assertTrue( 
+			imath.Color3f( 1.0, 1.0, 0.0 ).equalWithAbsError(
+				outMesh["Cs"].data[1],
+				.000001
+			)
+		)
+		self.assertTrue( 
+			imath.Color3f( 0.5, 0.5, 0.5 ).equalWithAbsError(
+				outMesh["Cs"].data[2],
+				.000001
+			)
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -149,6 +149,7 @@ from .EditScopeAlgoTest import EditScopeAlgoTest
 from .LocaliseAttributesTest import LocaliseAttributesTest
 from .ClosestPointSamplerTest import ClosestPointSamplerTest
 from .CurveSamplerTest import CurveSamplerTest
+from .ImageSamplerTest import ImageSamplerTest
 
 from .IECoreScenePreviewTest import *
 from .IECoreGLPreviewTest import *

--- a/python/GafferSceneUI/ImageSamplerUI.py
+++ b/python/GafferSceneUI/ImageSamplerUI.py
@@ -1,0 +1,113 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Hypothetical Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.ImageSampler,
+
+	"description",
+	"""
+	Samples image data and transfers the values onto a primitive
+    variable on the sampling objects. Values of \"Cs\", \"N\", 
+	\"P\", \"Pref\", \"scale\", \"uv\", \"velocity\" and \"width\" 
+	will define their interpretation appropriately when the correct 
+	number of channels are sampled. Other variables will create a 
+	float primitive variable per channel sampled.
+	""",
+
+	plugs = {
+
+		"image" : [
+
+			"description",
+			"""
+			The image to sample primitive variable data from.
+			""",
+			"plugValueWidget:type", "",
+			"nodule:type", "GafferUI::StandardNodule",
+			"noduleLayout:spacing", 2.0,
+
+		],
+
+		"primitiveVariable" : [
+
+			"description",
+			"""
+			The primitive variable to sample image data onto.
+			""",
+
+		],
+
+        "uvPrimitiveVariable" : [
+
+			"description",
+			"""
+			The primitive variable holding uv data used to sample the image.
+			""",
+			
+		],
+
+		"channels" : [
+
+			"description",
+			"""
+			The image channels to sample. Multiple channels are separated by spaces. 
+            For vector primitive variables the order of the channels corresponds to 
+			the indices of the vector. Wildcard expressions are not supported.
+			""",
+
+		],
+
+		"uvBoundsMode" : [
+
+				"description",
+				"""
+				The method to use to handle uv data outside the range of 0.0 - 1.0.
+				- Clamp : Values below 0.0 will be reset to 0.0, values above 1.0 
+				will be reset to 1.0 and values in between are unchanged.
+				- Tile : Values wrap on integer boundaries.
+				""",
+				"preset:Clamp", 0,
+				"preset:Tile", 1,
+				"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -163,6 +163,7 @@ from . import LocaliseAttributesUI
 from . import PrimitiveSamplerUI
 from . import ClosestPointSamplerUI
 from . import CurveSamplerUI
+from . import ImageSamplerUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/ImageSampler.cpp
+++ b/src/GafferScene/ImageSampler.cpp
@@ -1,0 +1,447 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Hypothetical Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferImage/Sampler.h"
+
+#include "GafferScene/ImageSampler.h"
+#include "GafferScene/SceneAlgo.h"
+
+#include "Gaffer/Private/IECorePreview/ParallelAlgo.h"
+
+#include "tbb/parallel_for.h"
+
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferImage;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+using OutputVariableFunction = std::function<void ( size_t, size_t, Sampler &, float, float )>;
+
+template <typename T>
+typename T::Ptr getVariableData( Primitive *outputPrimitive, const std::string &name, const PrimitiveVariable::Interpolation outputInterpolation, const size_t &size )
+{
+    auto it = outputPrimitive->variables.find( name );
+    if( it == outputPrimitive->variables.end() || 
+        it->second.data->typeId() != T::staticTypeId() ||
+        it->second.interpolation != outputInterpolation
+    )
+    {
+        typename T::Ptr data = new T();
+        data->writable().resize( size );
+        outputPrimitive->variables[name] = PrimitiveVariable( outputInterpolation, data );
+        return data;
+    }
+
+    typename T::Ptr data = runTimeCast<T>( it->second.data );
+    if( data->writable().size() != size )
+    {
+        data->writable().resize( size );
+    }
+    return data;
+}
+
+OutputVariableFunction addPrimitiveVariable( Primitive *outputPrimitive, const std::string &name, const PrimitiveVariable::Interpolation outputInterpolation )
+{
+	const size_t size = outputPrimitive->variableSize( outputInterpolation );
+
+    if( name == "Cs" )
+    {
+        Color3fVectorDataPtr data = getVariableData<Color3fVectorData>( outputPrimitive, name, outputInterpolation, size );
+        Color3f *d = data->writable().data();
+        return [ d ] ( size_t index, size_t subIndex, Sampler &s, float x, float y ) {
+            d[index][subIndex] = s.sample( x, y );
+        };
+    }
+    else if( name == "N" )
+    {
+        V3fVectorDataPtr data = getVariableData<V3fVectorData>( outputPrimitive, name, outputInterpolation, size );
+        data->setInterpretation( GeometricData::Interpretation::Normal );
+        V3f *d = data->writable().data();
+        return [ d ] ( size_t index, size_t subIndex, Sampler &s, float x, float y ) {
+            d[index][subIndex] = s.sample( x, y );
+        };
+    }
+    else if( name == "P" )
+    {
+        V3fVectorDataPtr data = getVariableData<V3fVectorData>( outputPrimitive, name, outputInterpolation, size );
+        data->setInterpretation( GeometricData::Interpretation::Point );
+        V3f *d = data->writable().data();
+        return [ d ] ( size_t index, size_t subIndex, Sampler &s, float x, float y ) {
+            d[index][subIndex] = s.sample( x, y );
+        };
+    }
+    else if( name == "Pref" || name == "scale" || name == "velocity" )
+    {
+        V3fVectorDataPtr data = getVariableData<V3fVectorData>( outputPrimitive, name, outputInterpolation, size );
+        data->setInterpretation( GeometricData::Interpretation::Vector );
+        V3f *d = data->writable().data();
+        return [ d ] ( size_t index, size_t subIndex, Sampler &s, float x, float y ) {
+            d[index][subIndex] = s.sample( x, y );
+        };
+    }
+    
+    else if( name == "uv" )
+    {
+        V2fVectorDataPtr data = getVariableData<V2fVectorData>( outputPrimitive, name, outputInterpolation, size );
+        data->setInterpretation( GeometricData::Interpretation::UV );
+        V2f *d = data->writable().data();
+        return [ d ] ( size_t index, size_t subIndex, Sampler &s, float x, float y ) {
+            d[index][subIndex] = s.sample( x, y );
+        };
+    }
+    else {
+        FloatVectorDataPtr data = getVariableData<FloatVectorData>( outputPrimitive, name, outputInterpolation, size );
+        float *d = data->writable().data();
+        return [ d ] ( size_t index, size_t subIndex, Sampler &s, float x, float y ) {
+            d[index] = s.sample( x, y );
+        };
+    }   
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Sampler
+//////////////////////////////////////////////////////////////////////////
+
+GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( ImageSampler );
+
+size_t ImageSampler::g_firstPlugIndex = 0;
+
+ImageSampler::ImageSampler( const std::string &name )
+	:	Deformer( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+    addChild( new ImagePlug( "image" ) );
+	addChild( new StringPlug( "primitiveVariable" ) );
+	addChild( new StringPlug( "uvPrimitiveVariable", Gaffer::Plug::Direction::In, "uv" ) );
+    addChild( new IntPlug( "uvBoundsMode") );
+	addChild( new StringPlug( "channels" ) );
+	
+}
+
+ImageSampler::~ImageSampler()
+{
+}
+
+GafferImage::ImagePlug *ImageSampler::imagePlug()
+{
+	return getChild<ImagePlug>( g_firstPlugIndex );
+}
+
+const GafferImage::ImagePlug *ImageSampler::imagePlug() const
+{
+	return getChild<ImagePlug>( g_firstPlugIndex );
+}
+
+Gaffer::StringPlug *ImageSampler::primVarNamePlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::StringPlug *ImageSampler::primVarNamePlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::StringPlug *ImageSampler::uvVarNamePlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::StringPlug *ImageSampler::uvVarNamePlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::IntPlug *ImageSampler::uvBoundsModePlug()
+{
+    return getChild<IntPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::IntPlug *ImageSampler::uvBoundsModePlug() const
+{
+    return getChild<IntPlug>( g_firstPlugIndex + 3 );
+}
+
+Gaffer::StringPlug *ImageSampler::channelsPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+}
+
+const Gaffer::StringPlug *ImageSampler::channelsPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+}
+
+bool ImageSampler::affectsProcessedObject( const Gaffer::Plug *input ) const
+{
+    bool val =
+		Deformer::affectsProcessedObject( input ) ||
+        input == imagePlug()->channelNamesPlug() ||
+		input == imagePlug()->channelDataPlug() ||
+		input == imagePlug()->dataWindowPlug() ||
+		input == primVarNamePlug() ||
+		input == uvVarNamePlug() ||
+        input == uvBoundsModePlug() ||
+		input == channelsPlug() ||
+		input == inPlug()->objectPlug()
+	;
+	return val;
+}
+
+void ImageSampler::hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+    Deformer::hashProcessedObject( path, context, h );
+
+    const std::string channelNames = channelsPlug()->getValue();
+    const std::string primVarName = primVarNamePlug()->getValue();
+    const std::string uvVarName = uvVarNamePlug()->getValue();
+    const int boundsMode = uvBoundsModePlug()->getValue();
+
+    if( channelNames.empty() || primVarName.empty() || uvVarName.empty() )
+    {
+        return;
+    }
+
+    h.append( channelNames );
+    h.append( primVarName );
+    h.append( uvVarName );
+    h.append( boundsMode );
+
+    inPlug()->objectPlug()->hash( h );
+
+	imagePlug()->channelNamesPlug()->hash( h );
+    imagePlug()->dataWindowPlug()->hash( h );
+
+	ConstStringVectorDataPtr inChannelNamesData = imagePlug()->channelNamesPlug()->getValue();
+	const std::vector<std::string> inChannelNames = inChannelNamesData->readable();
+
+    std::vector<std::string> channels;
+	IECore::StringAlgo::tokenize(channelNames, ' ', channels);
+
+	for( std::vector<std::string>::const_iterator it = channels.begin(), eIt = channels.end(); it != eIt; ++it )
+	{
+		std::vector<std::string>::const_iterator match = find(inChannelNames.begin(), inChannelNames.end(), *it);
+		if( match != inChannelNames.end() )
+		{
+			Sampler s( imagePlug(), *it, imagePlug()->dataWindow() );
+			s.hash( h );
+		}
+	}
+}
+
+IECore::ConstObjectPtr ImageSampler::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const
+{
+    const Primitive *primitive = runTimeCast<const Primitive>( inputObject );
+	if( !primitive )
+	{
+		return inputObject;
+	}
+	
+	PrimitivePtr outputPrimitive = primitive->copy();
+
+	const std::string channelNames = channelsPlug()->getValue();
+    const std::string primVarName = primVarNamePlug()->getValue();
+    const std::string uvVarName = uvVarNamePlug()->getValue();
+
+    if( channelNames.empty() || primVarName.empty() || uvVarName.empty() )
+    {
+        return inputObject;
+    }
+
+	const auto uvVarNameIt = outputPrimitive->variables.find( uvVarName );
+	if( uvVarNameIt == outputPrimitive->variables.end() )
+	{
+		IECore::msg(IECore::Msg::Warning, "ImageSampler::computeProcessedObject", boost::format( "UV primitive variable \"%s\" does not exist." ) % uvVarName.c_str());
+		return inputObject;
+	}
+
+    PrimitiveVariable::IndexedView<V2f> uvView( uvVarNameIt->second );
+    const size_t size = uvView.size();
+	const PrimitiveVariable::Interpolation interpolation = uvVarNameIt->second.interpolation;
+
+	ConstStringVectorDataPtr inChannelNamesData = imagePlug()->channelNamesPlug()->getValue();
+	const std::vector<std::string> inChannelNames = inChannelNamesData->readable();
+
+	const Imath::V2i imageSize = imagePlug()->dataWindow().size();
+	const Imath::V2i imageMin = imagePlug()->dataWindow().min;
+
+    std::vector<std::string> channels;
+	IECore::StringAlgo::tokenize( channelNames, ' ', channels );
+
+	// TODO: Check for missing channels?
+
+    if( ( primVarName == "Cs" && channels.size() != 3 ) ||
+        ( primVarName == "N" && channels.size() != 3 ) ||
+        ( primVarName == "P" && channels.size() != 3 ) ||
+        ( primVarName == "Pref" && channels.size() != 3 ) ||
+        ( primVarName == "scale" && channels.size() != 3 ) ||
+        ( primVarName == "velocity" && channels.size() != 3 )
+        
+    )
+    {
+        throw IECore::Exception( "Primitive variable \"" + primVarName + "\" must sample three channels." );
+    }
+
+    if( primVarName == "uv" && channels.size() != 2 )
+    {
+        throw IECore::Exception( "Primitive variable \"uv\" must sample two channels." );
+    }
+
+    if( primVarName == "width" && channels.size() != 1)
+    {
+        throw IECore::Exception( "Primitive variable \"width\" must sample one channels." );
+    }
+
+    std::vector<OutputVariableFunction> outputs;
+
+    if( primVarName == "Cs" ||
+        primVarName == "N" ||
+        primVarName == "P" ||
+        primVarName == "Pref" ||
+        primVarName == "scale" ||
+        primVarName == "uv" ||
+        primVarName == "velocity" ||
+        primVarName == "width"
+    )
+    {
+        for( size_t i = 0; i < channels.size(); ++i )
+        {
+            if( auto o = addPrimitiveVariable( outputPrimitive.get(), primVarName, interpolation ) )
+            {
+                outputs.push_back( o );
+            }
+        }
+    }
+    else
+    {
+        for( size_t i = 0; i < channels.size(); ++i )
+        {
+            if( auto o = addPrimitiveVariable( outputPrimitive.get(), primVarName + "." + channels[i], interpolation ) )
+            {
+                outputs.push_back( o );
+            }
+        }
+    }
+
+    const int uvBoundsMode = uvBoundsModePlug()->getValue();
+
+    for( size_t channelIndex = 0; channelIndex < outputs.size(); ++channelIndex )
+    {
+        Sampler sampler( imagePlug(), channels[channelIndex], imagePlug()->dataWindow() );
+        const OutputVariableFunction &o = outputs[channelIndex];
+
+        auto rangeSampler = [ & ]( const tbb::blocked_range<size_t> &r )
+        {
+            Context::EditableScope editScope( context );
+            for( size_t i = r.begin(); i != r.end(); ++i )
+            {
+                V2f uv = uvView[i];
+
+                if( uv.x < 0 || uv.x > 1 )
+                {
+                    switch( uvBoundsMode )
+                    {
+                        case UVBoundsMode::Clamp : 
+                            uv.x = std::max( std::min( uv.x, 1.f ), 0.f );
+                            break;
+                        case UVBoundsMode::Tile : 
+                            uv.x = abs( uv.x - floor( uv.x ) );
+                            break;
+                    }
+                }
+
+                if( uv.y < 0 || uv.y > 1 )
+                {
+                    switch( uvBoundsMode )
+                    {
+                        case UVBoundsMode::Clamp : 
+                            uv.y = std::max( std::min( uv.y, 1.f ), 0.f );
+                            break;
+                        case UVBoundsMode::Tile : 
+                            uv.y = abs( uv.y - floor( uv.y ) );
+                            break;
+                    }
+                }
+            
+                o(  i, 
+                    channelIndex, 
+                    sampler,
+                    ( uv.x * ( ( float )imageSize.x - 1.0f ) + imageMin.x ) + 0.5f, 
+                    ( uv.y * ( ( float )imageSize.y - 1.0f ) + imageMin.y ) + 0.5f
+                );
+            }
+        };
+
+        /// \todo We should be implementing `ComputeNode::computeCachePolicy()` instead
+        /// of doing our own isolation here, and we might even prefer the `TaskCollaboration`
+        /// that would provide. But we might also be filtered to only affect a single
+        /// object in an entire scene, and it seems that changing cache policy for
+        /// `outPlug()->objectPlug()` might give unwanted overhead for the pass-through
+        /// computations (particulary if we used `TaskCollaboration`). We might be able to
+        /// deal with this in ObjectProcessor by performing the non-pass-through computations
+        /// on an internal plug with a custom policy. But we leave that for another time.
+        IECorePreview::ParallelAlgo::isolate(
+            [ & ] () {
+                tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
+                parallel_for( tbb::blocked_range<size_t>( 0, size ), rangeSampler, taskGroupContext );
+            }
+	    );
+    }
+
+	return outputPrimitive;
+}
+
+
+bool ImageSampler::adjustBounds() const
+{
+	return
+		Deformer::adjustBounds() &&
+
+		StringAlgo::matchMultiple( "P", primVarNamePlug()->getValue() )
+	;
+}

--- a/src/GafferSceneModule/ImageSamplerBinding.cpp
+++ b/src/GafferSceneModule/ImageSamplerBinding.cpp
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
-//  Copyright (c) 2013, John Haddon. All rights reserved.
+//  Copyright (c) 2020, Hypothetical Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -37,58 +36,20 @@
 
 #include "boost/python.hpp"
 
-#include "AttributesBinding.h"
-#include "CoreBinding.h"
-#include "EditScopeAlgoBinding.h"
-#include "FilterBinding.h"
-#include "GlobalsBinding.h"
-#include "HierarchyBinding.h"
-#include "IECoreGLPreviewBinding.h"
 #include "ImageSamplerBinding.h"
-#include "IOBinding.h"
-#include "TweaksBinding.h"
-#include "ObjectProcessorBinding.h"
-#include "OptionsBinding.h"
-#include "PrimitiveSamplerBinding.h"
-#include "PrimitiveVariablesBinding.h"
-#include "PrimitivesBinding.h"
-#include "RenderBinding.h"
-#include "RenderControllerBinding.h"
-#include "RendererAlgoBinding.h"
-#include "SceneAlgoBinding.h"
-#include "ScenePathBinding.h"
-#include "SetAlgoBinding.h"
-#include "ShaderBinding.h"
-#include "TransformBinding.h"
+
+#include "GafferScene/ImageSampler.h"
+
+#include "GafferBindings/DependencyNodeBinding.h"
 
 using namespace boost::python;
-using namespace GafferSceneModule;
+using namespace Gaffer;
+using namespace GafferBindings;
+using namespace GafferScene;
 
-BOOST_PYTHON_MODULE( _GafferScene )
+void GafferSceneModule::bindImageSampler()
 {
 
-	bindCore();
-	bindFilter();
-	bindTransform();
-	bindGlobals();
-	bindOptions();
-	bindAttributes();
-	bindSceneAlgo();
-	bindRendererAlgo();
-	bindSetAlgo();
-	bindPrimitives();
-	bindScenePath();
-	bindShader();
-	bindRender();
-	bindRenderController();
-	bindHierarchy();
-	bindObjectProcessor();
-	bindPrimitiveVariables();
-	bindTweaks();
-	bindIO();
-	bindPrimitiveSampler();
-	bindIECoreGLPreview();
-	bindEditScopeAlgo();
-	bindImageSampler();
+	GafferBindings::DependencyNodeClass<GafferScene::ImageSampler>();
 
 }

--- a/src/GafferSceneModule/ImageSamplerBinding.h
+++ b/src/GafferSceneModule/ImageSamplerBinding.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
-//  Copyright (c) 2013, John Haddon. All rights reserved.
+//  Copyright (c) 2020, Hypothetical Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,60 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERSCENEMODULE_IMAGESAMPLERBINDING_H
+#define GAFFERSCENEMODULE_IMAGESAMPLERBINDING_H
 
-#include "AttributesBinding.h"
-#include "CoreBinding.h"
-#include "EditScopeAlgoBinding.h"
-#include "FilterBinding.h"
-#include "GlobalsBinding.h"
-#include "HierarchyBinding.h"
-#include "IECoreGLPreviewBinding.h"
-#include "ImageSamplerBinding.h"
-#include "IOBinding.h"
-#include "TweaksBinding.h"
-#include "ObjectProcessorBinding.h"
-#include "OptionsBinding.h"
-#include "PrimitiveSamplerBinding.h"
-#include "PrimitiveVariablesBinding.h"
-#include "PrimitivesBinding.h"
-#include "RenderBinding.h"
-#include "RenderControllerBinding.h"
-#include "RendererAlgoBinding.h"
-#include "SceneAlgoBinding.h"
-#include "ScenePathBinding.h"
-#include "SetAlgoBinding.h"
-#include "ShaderBinding.h"
-#include "TransformBinding.h"
-
-using namespace boost::python;
-using namespace GafferSceneModule;
-
-BOOST_PYTHON_MODULE( _GafferScene )
+namespace GafferSceneModule
 {
 
-	bindCore();
-	bindFilter();
-	bindTransform();
-	bindGlobals();
-	bindOptions();
-	bindAttributes();
-	bindSceneAlgo();
-	bindRendererAlgo();
-	bindSetAlgo();
-	bindPrimitives();
-	bindScenePath();
-	bindShader();
-	bindRender();
-	bindRenderController();
-	bindHierarchy();
-	bindObjectProcessor();
-	bindPrimitiveVariables();
-	bindTweaks();
-	bindIO();
-	bindPrimitiveSampler();
-	bindIECoreGLPreview();
-	bindEditScopeAlgo();
-	bindImageSampler();
+void bindImageSampler();
 
-}
+} // namespace GafferSceneModule
+
+#endif // GAFFERSCENEMODULE_IMAGESAMPLERBINDING_H

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -301,6 +301,7 @@ nodeMenu.append( "/Scene/Object/Mesh Distortion", GafferScene.MeshDistortion, se
 nodeMenu.append( "/Scene/Object/Camera Tweaks", GafferScene.CameraTweaks, searchText = "CameraTweaks" )
 nodeMenu.append( "/Scene/Object/Curve Sampler", GafferScene.CurveSampler, searchText = "CurveSampler" )
 nodeMenu.append( "/Scene/Object/Closest Point Sampler", GafferScene.ClosestPointSampler, searchText = "ClosestPointSampler" )
+nodeMenu.append( "/Scene/Object/Image Sampler", GafferScene.ImageSampler, searchTest = "ImageSampler" )
 nodeMenu.append( "/Scene/Attributes/Shader Assignment", GafferScene.ShaderAssignment, searchText = "ShaderAssignment" )
 nodeMenu.append( "/Scene/Attributes/Shader Tweaks", GafferScene.ShaderTweaks, searchText = "ShaderTweaks" )
 nodeMenu.append( "/Scene/Attributes/Standard Attributes", GafferScene.StandardAttributes, searchText = "StandardAttributes" )


### PR DESCRIPTION
This pull request adds an ImageSampler node to sample image data onto geometry primitive variables.

- Samples one or more channels from a GafferImage onto a single primitive variable.
- Automatically creates appropriate type and interpretation for Cs, N, P, Pref, scale, uv, velocity and width primitive variables (this list based on the preset hints in the OSLObject output creator).
- Non-automatic variables are suffixed with a ".<channel name>" for each image channel sampled.

### Related issues ###

This is a feature addition based on [Gaffer forum thread](https://groups.google.com/forum/#!searchin/gaffer-dev/image$20sampler%7Csort:date/gaffer-dev/8k_3Yk3UtH4/tD8rrTDWCAAJ).

### Dependencies ###

None

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
