### PR TITLE
Plug : Propagate dirtiness for all parent changes 

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -944,7 +944,7 @@ libraries = {
 			"LIBS" : [ "Gaffer", "GafferScene", "Half", "openvdb$VDB_LIB_SUFFIX", "IECoreVDB$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
-			"LIBS" : [ "GafferScene", "GafferVDB", "openvdb$VDB_LIB_SUFFIX", "IECoreVDB$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX"],
+			"LIBS" : [ "GafferBindings", "GafferScene", "GafferVDB", "openvdb$VDB_LIB_SUFFIX", "IECoreVDB$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX"],
 		}
 	},
 

--- a/include/Gaffer/DownstreamIterator.h
+++ b/include/Gaffer/DownstreamIterator.h
@@ -141,8 +141,10 @@ class DownstreamIterator : public boost::iterator_facade<DownstreamIterator, con
 					}
 
 					const DependencyNode *node = IECore::runTimeCast<const DependencyNode>( plug->node() );
-					if( !node )
+					if( !node || !node->refCount() )
 					{
+						// No node, or node constructing or destructing.
+						// We can't call `DependencyNode::affects()`.
 						return;
 					}
 

--- a/include/GafferBindings/DependencyNodeBinding.h
+++ b/include/GafferBindings/DependencyNodeBinding.h
@@ -64,8 +64,26 @@ class DependencyNodeClass : public NodeClass<T, TWrapper>
 
 };
 
+class GAFFER_API DependencyNodeWrapperBase
+{
+
+	protected :
+
+		DependencyNodeWrapperBase() : m_initialised( false ) {};
+		// Returns `true` once the Python `__init__()` method has
+		// completed.
+		bool initialised() const { return m_initialised; };
+
+	private :
+
+		// Friendship with the metaclass so it can set `m_initialised` for us.
+		friend PyObject *dependencyNodeMetaclassCall( PyObject *self, PyObject *args, PyObject *kw );
+		bool m_initialised;
+
+};
+
 template<typename WrappedType>
-class DependencyNodeWrapper : public NodeWrapper<WrappedType>
+class DependencyNodeWrapper : public NodeWrapper<WrappedType>, public DependencyNodeWrapperBase
 {
 	public :
 

--- a/include/GafferBindings/DependencyNodeBinding.h
+++ b/include/GafferBindings/DependencyNodeBinding.h
@@ -106,7 +106,7 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>, public Dependency
 
 		void affects( const Gaffer::Plug *input, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const override
 		{
-			if( this->isSubclassed() )
+			if( this->isSubclassed() && this->initialised() )
 			{
 				IECorePython::ScopedGILLock gilLock;
 				try

--- a/include/GafferBindings/DependencyNodeBinding.inl
+++ b/include/GafferBindings/DependencyNodeBinding.inl
@@ -70,6 +70,8 @@ static Gaffer::PlugPtr correspondingInput( T &n, const Gaffer::Plug *output )
 	return n.T::correspondingInput( output );
 }
 
+GAFFERBINDINGS_API PyTypeObject *dependencyNodeMetaclass();
+
 } // namespace Detail
 
 template<typename T, typename Ptr>
@@ -79,6 +81,8 @@ DependencyNodeClass<T, Ptr>::DependencyNodeClass( const char *docString )
 	this->def( "affects", &Detail::affects<T> );
 	this->def( "enabledPlug", &Detail::enabledPlug<T> );
 	this->def( "correspondingInput", &Detail::correspondingInput<T> );
+	// Install our custom metaclass.
+	Py_TYPE( this->ptr() ) = Detail::dependencyNodeMetaclass();
 }
 
 template<typename T, typename Ptr>
@@ -88,6 +92,8 @@ DependencyNodeClass<T, Ptr>::DependencyNodeClass( const char *docString, boost::
 	this->def( "affects", &Detail::affects<T> );
 	this->def( "enabledPlug", &Detail::enabledPlug<T> );
 	this->def( "correspondingInput", &Detail::correspondingInput<T> );
+	// Install our custom metaclass.
+	Py_TYPE( this->ptr() ) = Detail::dependencyNodeMetaclass();
 }
 
 } // namespace GafferBindings

--- a/include/GafferDispatchBindings/TaskNodeBinding.h
+++ b/include/GafferDispatchBindings/TaskNodeBinding.h
@@ -73,7 +73,7 @@ class TaskNodeWrapper : public GafferBindings::DependencyNodeWrapper<WrappedType
 
 		bool affectsTask( const Gaffer::Plug *input ) const override
 		{
-			if( this->isSubclassed() )
+			if( this->isSubclassed() && this->initialised() )
 			{
 				IECorePython::ScopedGILLock gilLock;
 				try

--- a/python/GafferTest/DependencyNodeTest.py
+++ b/python/GafferTest/DependencyNodeTest.py
@@ -554,6 +554,22 @@ class DependencyNodeTest( GafferTest.TestCase ) :
 		del n["in"]
 		self.assertEqual( valuesWhenDirtied, [ 0 ] )
 
+		# Check that dirty propagation still operates even if
+		# the plugs don't have the Dynamic flag set. Although
+		# DynamicAddNode would require the flag for serialisation
+		# to work, other nodes may not, and we don't want to mix
+		# up dirty propagation with serialisation.
+
+		del valuesWhenDirtied[:]
+		n["in"] = Gaffer.IntPlug( defaultValue = 1 )
+		n["in1"] = Gaffer.IntPlug( defaultValue = 2 )
+		self.assertEqual( valuesWhenDirtied, [ 1, 3 ] )
+
+		del valuesWhenDirtied[:]
+		del n["in"]
+		del n["in1"]
+		self.assertEqual( valuesWhenDirtied, [ 2, 0 ] )
+
 	def testThrowInAffects( self ) :
 		# Dirty propagation is a secondary process that
 		# is triggered by primary operations like adding

--- a/src/GafferBindings/DependencyNodeBinding.cpp
+++ b/src/GafferBindings/DependencyNodeBinding.cpp
@@ -1,0 +1,87 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferBindings/DependencyNodeBinding.h"
+
+using namespace Gaffer;
+
+namespace GafferBindings
+{
+
+// This is the `__call__` operator for the metaclass we use for DependencyNodes.
+// It is responsible for creating and initialising DependencyNode instances in
+// Python, which gives us a chance to inform the DependencyNodeWrapper when
+// `__init__` has completed.
+PyObject *dependencyNodeMetaclassCall( PyObject *self, PyObject *args, PyObject *kw )
+{
+	// Delegate the actual work to the default `type.__call__` method.
+	// This will call `__new__` and `__init__` and return a new DependencyNode
+	// instance.
+	PyObject *result = PyType_Type.tp_call( self, args, kw );
+	if( result )
+	{
+		// Inform the DependencyNodeWrapper that __init__ has completed.
+		auto n = boost::python::extract<DependencyNode *>( result )();
+		if( auto w = dynamic_cast<GafferBindings::DependencyNodeWrapperBase *>( n ) )
+		{
+			w->m_initialised = true;
+		}
+	}
+	return result;
+}
+
+} // namespace GafferBindings
+
+PyTypeObject *GafferBindings::Detail::dependencyNodeMetaclass()
+{
+	static PyTypeObject g_dependencyNodeMetaclass;
+	if( !g_dependencyNodeMetaclass.tp_name )
+	{
+		// Initialise. We derive from the standard Boost Python metaclass
+		// because it has functionality critical to making the Boost bindings
+		// work. The only thing we're doing is adding `dependencyNodeMetaclassCall`
+		// as the implementation of the `__call__` method.
+		Py_TYPE( &g_dependencyNodeMetaclass ) = &PyType_Type;
+		g_dependencyNodeMetaclass.tp_name = "Gaffer.DependencyNodeMetaclass";
+		g_dependencyNodeMetaclass.tp_basicsize = PyType_Type.tp_basicsize,
+		g_dependencyNodeMetaclass.tp_base = boost::python::objects::class_metatype().get();
+		g_dependencyNodeMetaclass.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
+		g_dependencyNodeMetaclass.tp_call = dependencyNodeMetaclassCall;
+		PyType_Ready( &g_dependencyNodeMetaclass );
+	}
+
+	return &g_dependencyNodeMetaclass;
+}

--- a/src/GafferModule/NodeBinding.cpp
+++ b/src/GafferModule/NodeBinding.cpp
@@ -136,7 +136,7 @@ void GafferModule::bindNode()
 	typedef DependencyNodeWrapper<DependencyNode> DependencyNodeWrapper;
 	DependencyNodeClass<DependencyNode, DependencyNodeWrapper>();
 
-	typedef ComputeNodeWrapper<ComputeNode> ComputNodeWrapper;
-	DependencyNodeClass<ComputeNode, ComputNodeWrapper>();
+	typedef ComputeNodeWrapper<ComputeNode> ComputeNodeWrapper;
+	DependencyNodeClass<ComputeNode, ComputeNodeWrapper>();
 
 }

--- a/src/GafferScene/AttributeProcessor.cpp
+++ b/src/GafferScene/AttributeProcessor.cpp
@@ -79,12 +79,6 @@ void AttributeProcessor::affects( const Gaffer::Plug *input, AffectedPlugsContai
 {
 	FilteredSceneProcessor::affects( input, outputs );
 
-	if( !refCount() )
-	{
-		// Avoid calling pure virtual methods while we're still constructing.
-		return;
-	}
-
 	if( affectsProcessedAttributes( input ) )
 	{
 		outputs.push_back( outPlug()->attributesPlug() );

--- a/src/GafferScene/ObjectProcessor.cpp
+++ b/src/GafferScene/ObjectProcessor.cpp
@@ -96,12 +96,6 @@ void ObjectProcessor::affects( const Gaffer::Plug *input, AffectedPlugsContainer
 {
 	FilteredSceneProcessor::affects( input, outputs );
 
-	if( !refCount() )
-	{
-		// Avoid calling pure virtual methods while we're still constructing.
-		return;
-	}
-
 	if( affectsProcessedObject( input ) )
 	{
 		outputs.push_back( processedObjectPlug() );


### PR DESCRIPTION
When plugs are added and/or removed from a node, we need to call `DependencyNode::affects()` so that we can propagate dirtiness to any affected outputs. To date, we have only done this for plugs with the `Dynamic` flag set, where `Dynamic` means roughly "I have been added outside of the node constructor, so I will need to be serialised separately". The primary reason for this restriction was that without it we would end up calling `DependencyNode::affects()` on nodes which hadn't yet finished construction, and inevitably crash as a result.

In #3807 we introduced an optimisation that is much more sensitive to accurate dirty propagation, and @danieldresser-ie raised the possibility that the `Dynamic` flag might not adequately identify all plugs added outside of a constructor.

>The only real concern I have is with the convention that, if I am understanding correctly, it is now undefined behaviour to add a child plug which isn't Dynamic outside of a constructor. 
>
>I can't think off-hand where we're currently doing this at ImageEngine, but if you've got a Python node that stores it's state in a non-network way, and then updates an internal network to reflect changes made to it with buttons or something, and doesn't serialize this internal network, then I would have said it was reasonable ( or even more correct ) to use non-dynamic plugs in the internal network. 

Essentially, `Dynamic` is underspecified for our use in controlling dirty propagation. We wanted it to mean "added outside a constructor", but in reality it means "please serialise a constructor for me", and those two things are subtly different. The `Dynamic` flag has been a constant source of subtle bugs anyway, and I'm actively trying to find ways of killing it.

This PR attempts to address Daniel's concern, by propagating dirtiness any time a plug is added or removed outside of a constructor, regardless of the setting of the `Dynamic` flag. This necessitated tracking the completion of construction, and the only way I could find of doing that in Python was to delve into Boost Python internals beyond my level of competence. Please review carefully! 