### PR TITLE
Catalogue fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Fixes
 - Catalogue :
   - Fixed incorrect column values when an image is renamed in a promoted Catalogue (#3815).
   - Fixed dependency tracking and hashing bugs.
+  - Improved handling of missing images (#3808).
 - SetFilter : Sanitised context used to evaluate set expressions, by removing `scene:filter:inputScene` variable.
 
 0.56.2.4 (relative to 0.56.2.3)

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,9 @@
 Fixes
 -----
 
+- Catalogue :
+  - Fixed incorrect column values when an image is renamed in a promoted Catalogue (#3815).
+  - Fixed dependency tracking and hashing bugs.
 - SetFilter : Sanitised context used to evaluate set expressions, by removing `scene:filter:inputScene` variable.
 
 0.56.2.4 (relative to 0.56.2.3)

--- a/include/GafferImage/Catalogue.h
+++ b/include/GafferImage/Catalogue.h
@@ -86,6 +86,18 @@ class GAFFERIMAGE_API Catalogue : public ImageNode
 
 				Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
+			private :
+
+				// The Catalogue needs to know the name of each image
+				// so it can support the `catalogue:imageName` context
+				// variable. But computes can only depend on plugs,
+				// so we transfer the name into this private plug
+				// each time it changes.
+				void nameChanged();
+				Gaffer::StringPlug *namePlug();
+				const Gaffer::StringPlug *namePlug() const;
+				friend class Catalogue;
+
 		};
 
 		typedef Gaffer::FilteredChildIterator<Gaffer::PlugPredicate<Gaffer::Plug::Invalid, Image> > ImageIterator;
@@ -121,9 +133,6 @@ class GAFFERIMAGE_API Catalogue : public ImageNode
 		Gaffer::IntPlug *internalImageIndexPlug();
 		const Gaffer::IntPlug *internalImageIndexPlug() const;
 
-		Gaffer::AtomicCompoundDataPlug *mappingPlug();
-		const Gaffer::AtomicCompoundDataPlug *mappingPlug() const;
-
 		Gaffer::Switch *imageSwitch();
 		const Gaffer::Switch *imageSwitch() const;
 
@@ -139,8 +148,6 @@ class GAFFERIMAGE_API Catalogue : public ImageNode
 
 		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
-
-		void computeNameToIndexMapping();
 
 		static size_t g_firstPlugIndex;
 

--- a/python/GafferImageTest/CatalogueSelectTest.py
+++ b/python/GafferImageTest/CatalogueSelectTest.py
@@ -81,4 +81,4 @@ class CatalogueSelectTest( GafferImageTest.ImageTestCase ) :
 		with self.assertRaises( Exception ) as cm:
 			GafferImage.ImageAlgo.image( catalogueSelect["out"] )
 
-		self.assertEqual( str( cm.exception ), "CatalogueSelect.__context.out.deep : Unknown image name." )
+		self.assertEqual( str( cm.exception ), 'CatalogueSelect.__context.out.deep : Unknown image name "nope".' )

--- a/python/GafferImageTest/CatalogueTest.py
+++ b/python/GafferImageTest/CatalogueTest.py
@@ -729,5 +729,63 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 			shutil.copyfile( sourceFile, fileName )
 			GafferImage.Catalogue.Image.load( fileName )
 
+	def testRenamePromotedImages( self ) :
+
+		# Create boxed Catalogue with promoted `images` plug.
+
+		box = Gaffer.Box()
+
+		box["catalogue"] = GafferImage.Catalogue()
+		box["catalogue"]["directory"].setValue( os.path.join( self.temporaryDirectory(), "catalogue" ) )
+
+		images = Gaffer.PlugAlgo.promote( box["catalogue"]["images"] )
+
+		# Send 2 images and name them using the promoted plugs.
+
+		red = GafferImage.Constant()
+		red["format"].setValue( GafferImage.Format( 64, 64 ) )
+		red["color"]["r"].setValue( 1 )
+		self.sendImage( red["out"], box["catalogue"] )
+		images[-1].setName( "Red" )
+
+		green = GafferImage.Constant()
+		green["format"].setValue( GafferImage.Format( 64, 64 ) )
+		green["color"]["g"].setValue( 1 )
+		self.sendImage( green["out"], box["catalogue"] )
+		images[-1].setName( "Green" )
+
+		# Assert that images are accessible under those names.
+
+		with Gaffer.Context() as c :
+			c["catalogue:imageName"] = "Red"
+			self.assertImagesEqual( box["catalogue"]["out"], red["out"], ignoreMetadata = True )
+			c["catalogue:imageName"] = "Green"
+			self.assertImagesEqual( box["catalogue"]["out"], green["out"], ignoreMetadata = True )
+
+		# And that invalid names generate errors.
+
+		with self.assertRaisesRegexp( RuntimeError, 'Unknown image name "Blue"' ) :
+			with Gaffer.Context() as c :
+				c["catalogue:imageName"] = "Blue"
+				box["catalogue"]["out"].metadata()
+
+		# Assert that we can rename the images and get them under the new name.
+
+		images[0].setName( "Crimson" )
+		images[1].setName( "Emerald" )
+
+		with Gaffer.Context() as c :
+			c["catalogue:imageName"] = "Crimson"
+			self.assertImagesEqual( box["catalogue"]["out"], red["out"], ignoreMetadata = True )
+			c["catalogue:imageName"] = "Emerald"
+			self.assertImagesEqual( box["catalogue"]["out"], green["out"], ignoreMetadata = True )
+
+		# And that the old names are now invalid.
+
+		with self.assertRaisesRegexp( RuntimeError, 'Unknown image name "Red"' ) :
+			with Gaffer.Context() as c :
+				c["catalogue:imageName"] = "Red"
+				box["catalogue"]["out"].metadata()
+
 if __name__ == "__main__":
 	unittest.main()

--- a/startup/GafferImage/catalogueCompatibility.py
+++ b/startup/GafferImage/catalogueCompatibility.py
@@ -1,0 +1,55 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+import Gaffer
+import GafferImage
+
+def __catalogueGetItem( originalGetItem ) :
+
+	def getItem( self, key ) :
+
+		if key == "__mapping" :
+			# `__mapping` was a private plug that should never have been serialisable.
+			# It no longer exists, so we must make a throwaway one to keep old serialisations
+			# happy.
+			return Gaffer.AtomicCompoundDataPlug( key, Gaffer.Plug.Direction.In, IECore.CompoundData() )
+
+		return originalGetItem( self, key )
+
+	return getItem
+
+GafferImage.Catalogue.__getitem__ = __catalogueGetItem( GafferImage.Catalogue.__getitem__ )

--- a/startup/GafferSceneUI/catalogue.py
+++ b/startup/GafferSceneUI/catalogue.py
@@ -35,8 +35,10 @@
 ##########################################################################
 
 import os
-import GafferImageUI
+
+import Gaffer
 import GafferScene
+import GafferImageUI
 
 from GafferImageUI import CatalogueUI
 
@@ -61,9 +63,12 @@ if statusIconColumn :
 
 			iconName = statusIconColumn.value( image, catalogue )
 
-			scenePlug = GafferScene.SceneAlgo.sourceScene( catalogue["out"] )
-			if not scenePlug :
-				return iconName
+			try :
+				scenePlug = GafferScene.SceneAlgo.sourceScene( catalogue["out"] )
+				if not scenePlug :
+					return iconName
+			except Gaffer.ProcessException :
+				return "errorNotificationSmall"
 
 			for type_ in imageNameMap.keys() :
 				if isinstance( scenePlug.node(), type_ ) :

--- a/startup/GafferSceneUI/catalogue.py
+++ b/startup/GafferSceneUI/catalogue.py
@@ -53,7 +53,7 @@ imageNameMap = {
 statusIconColumn = CatalogueUI.column( "Status" )
 if statusIconColumn :
 
-	class __ExtededStatusIconColumn( CatalogueUI.IconColumn ) :
+	class __ExtendedStatusIconColumn( CatalogueUI.IconColumn ) :
 
 		def __init__( self ) :
 
@@ -77,4 +77,4 @@ if statusIconColumn :
 
 			return iconName
 
-	CatalogueUI.registerColumn( "Status", __ExtededStatusIconColumn() )
+	CatalogueUI.registerColumn( "Status", __ExtendedStatusIconColumn() )


### PR DESCRIPTION
This supercedes #3816, taking an approach to the `catalogue:name` fix that also fixes dependency tracking and hashing bugs that will be needed for compatibility with the optimised hash cache.