### PR TITLE
`ScenePlug::exists()` dependency tracking fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -45,9 +45,10 @@ Fixes
   - CollectScenes
   - Instancer
   - Duplicate
+  - ClosestPointSampler
+  - CurveSampler
 - SetAlgo : Fixed `affectsSetExpression()` to return `True` for `ScenePlug::setNamesPlug()`.
 - GafferTractor: Fixed evaluation of 'tag' and 'service' plugs on Task nodes. Previously, these plugs were evaluated in the default context, which prevented one from using custom context variables (e.g. from Wedge node) to compute tags or service keys dynamically.
-
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -44,6 +44,7 @@ Fixes
   - MergeScenes
   - CollectScenes
   - Instancer
+  - Duplicate
 - SetAlgo : Fixed `affectsSetExpression()` to return `True` for `ScenePlug::setNamesPlug()`.
 - GafferTractor: Fixed evaluation of 'tag' and 'service' plugs on Task nodes. Previously, these plugs were evaluated in the default context, which prevented one from using custom context variables (e.g. from Wedge node) to compute tags or service keys dynamically.
 

--- a/Changes.md
+++ b/Changes.md
@@ -48,7 +48,9 @@ API
 - ValuePlug
   - Improved interactive performance by not clearing the entire hash cache every time a plug is dirtied. Beware : this can reveal subtle bugs in `DependencyNode::affects()` implementations, causing hashes to be reused if a plug has not been dirtied appropriately. These bugs may previously have gone unnoticed but will now need fixing as a matter of urgency. The GAFFER_CLEAR_HASHCACHE_ON_DIRTY environment variable may be used to enable legacy behaviour in the interim.
   - Added `clearHashCache()` static method.
-- ScenePlug : Added `childBounds()` and `childBoundsHash()` methods.
+- ScenePlug :
+  - Added `existsPlug()` accessor, and deprecated the argumentless overload of the `exists()` method.
+  - Added `childBoundsPlug()`, `childBounds()` and `childBoundsHash()` methods.
 - ObjectProcessor : Added `processedObjectComputeCachePolicy()` virtual method. This should be overridden to choose an appropriate cache policy when `computeProcessedObject()` spawns TBB tasks.
 - SceneNode :
   - Deprecated `hashOfTransformedChildBounds()`. Use `ScenePlug::childBoundsHash()` instead.

--- a/Changes.md
+++ b/Changes.md
@@ -38,6 +38,7 @@ Fixes
   - OpenImageIOReader
   - LevelSetOffset
   - MeshToLevelSet
+  - CopyPrimitiveVariables
 - SetAlgo : Fixed `affectsSetExpression()` to return `True` for `ScenePlug::setNamesPlug()`.
 - GafferTractor: Fixed evaluation of 'tag' and 'service' plugs on Task nodes. Previously, these plugs were evaluated in the default context, which prevented one from using custom context variables (e.g. from Wedge node) to compute tags or service keys dynamically.
 

--- a/Changes.md
+++ b/Changes.md
@@ -41,6 +41,9 @@ Fixes
   - CopyPrimitiveVariables
   - CopyAttributes
   - SubTree
+  - MergeScenes
+  - CollectScenes
+  - Instancer
 - SetAlgo : Fixed `affectsSetExpression()` to return `True` for `ScenePlug::setNamesPlug()`.
 - GafferTractor: Fixed evaluation of 'tag' and 'service' plugs on Task nodes. Previously, these plugs were evaluated in the default context, which prevented one from using custom context variables (e.g. from Wedge node) to compute tags or service keys dynamically.
 

--- a/Changes.md
+++ b/Changes.md
@@ -39,6 +39,7 @@ Fixes
   - LevelSetOffset
   - MeshToLevelSet
   - CopyPrimitiveVariables
+  - CopyAttributes
 - SetAlgo : Fixed `affectsSetExpression()` to return `True` for `ScenePlug::setNamesPlug()`.
 - GafferTractor: Fixed evaluation of 'tag' and 'service' plugs on Task nodes. Previously, these plugs were evaluated in the default context, which prevented one from using custom context variables (e.g. from Wedge node) to compute tags or service keys dynamically.
 

--- a/Changes.md
+++ b/Changes.md
@@ -40,6 +40,7 @@ Fixes
   - MeshToLevelSet
   - CopyPrimitiveVariables
   - CopyAttributes
+  - SubTree
 - SetAlgo : Fixed `affectsSetExpression()` to return `True` for `ScenePlug::setNamesPlug()`.
 - GafferTractor: Fixed evaluation of 'tag' and 'service' plugs on Task nodes. Previously, these plugs were evaluated in the default context, which prevented one from using custom context variables (e.g. from Wedge node) to compute tags or service keys dynamically.
 

--- a/include/GafferScene/ScenePlug.h
+++ b/include/GafferScene/ScenePlug.h
@@ -249,10 +249,6 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 		static void stringToPath( const std::string &s, ScenePlug::ScenePath &path );
 		static void pathToString( const ScenePlug::ScenePath &path, std::string &s );
 
-		/// \deprecated Use `childBoundsPlug()->getValue()` instead.
-		Imath::Box3f childBounds() const;
-		/// \deprecated Use `childBoundsPlug()->hash()` instead.
-		IECore::MurmurHash childBoundsHash() const;
 		/// \deprecated Use `existsPlug()->getValue()` instead.
 		bool exists() const;
 

--- a/include/GafferScene/ScenePlug.h
+++ b/include/GafferScene/ScenePlug.h
@@ -66,13 +66,20 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 		/// Only accepts ScenePlug inputs.
 		bool acceptsInput( const Gaffer::Plug *input ) const override;
 
-		/// @name Child plugs
-		/// Different aspects of the scene are passed through different
-		/// child plugs.
-		////////////////////////////////////////////////////////////////////
-		//@{
+		/// Child plugs
+		/// ===========
+		///
+		/// Different properties of the scene are represented by different child
+		/// plugs of the ScenePlug.
+
+		/// Location properties
+		/// -------------------
+		///
+		/// These plugs require the `scenePathContextName` variable to
+		/// be provided by the current context.
+		///
 		/// The plug used to pass the bounding box of the current location in
-		/// the scene graph. The bounding box is supplied /without/ the
+		/// the scene graph. The bounding box is supplied _without_ the
 		/// transform applied.
 		Gaffer::AtomicBox3fPlug *boundPlug();
 		const Gaffer::AtomicBox3fPlug *boundPlug() const;
@@ -100,6 +107,10 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 		/// transforms.
 		Gaffer::AtomicBox3fPlug *childBoundsPlug();
 		const Gaffer::AtomicBox3fPlug *childBoundsPlug() const;
+
+		/// Global properties
+		/// -----------------
+		///
 		/// The plug used to pass renderer options including output etc,
 		/// represented as a CompoundObject. Note that this is not sensitive
 		/// to the "scene:path" context entry.
@@ -117,16 +128,16 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 		/// which set to compute.
 		Gaffer::PathMatcherDataPlug *setPlug();
 		const Gaffer::PathMatcherDataPlug *setPlug() const;
-		//@}
 
-		/// @name Context management
+		/// Context management
+		/// ==================
+		///
 		/// The child Plugs are expected to be evaluated in the context
 		/// of a particular location in the scenegraph, so that the
 		/// scenegraph can be evaluated piecemeal, rather than all needing
 		/// to exist at once. These members provide utilities for
 		/// constructing relevant contexts.
-		////////////////////////////////////////////////////////////////////
-		//@{
+
 		/// The type used to specify the current scene path in
 		/// a Context object.
 		typedef std::vector<IECore::InternedString> ScenePath;
@@ -185,9 +196,10 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 			/// ThreadState documentation for more details.
 			GlobalScope( const Gaffer::ThreadState &threadState );
 		};
-		//@}
 
-		/// @name Convenience accessors
+		/// Convenience accessors
+		/// =====================
+		///
 		/// These functions create temporary Contexts specifying the necessary
 		/// variables and then return the result of calling getValue() or hash()
 		/// on the appropriate child plug. Note that if you wish to evaluate
@@ -241,13 +253,18 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 		/// See comments for `setNames()` method.
 		IECore::MurmurHash setNamesHash() const;
 		IECore::MurmurHash setHash( const IECore::InternedString &setName ) const;
-		//@}
+
+		/// Utility methods
+		/// ===============
 
 		/// Utility function to convert a string into a path by splitting on '/'.
 		/// \todo Many of the places we use this, it would be preferable if the source data was already
 		/// a path. Perhaps a ScenePathPlug could take care of this for us?
 		static void stringToPath( const std::string &s, ScenePlug::ScenePath &path );
 		static void pathToString( const ScenePlug::ScenePath &path, std::string &s );
+
+		/// Deprecated methods
+		/// ==================
 
 		/// \deprecated Use `existsPlug()->getValue()` instead.
 		bool exists() const;

--- a/python/GafferOSLTest/OSLObjectTest.py
+++ b/python/GafferOSLTest/OSLObjectTest.py
@@ -1015,26 +1015,26 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 				expected
 			)
 			del cs[:]
-		checkAffected( ["transform", "bound" ] )
+		checkAffected( [ "transform", "bound", "childBounds" ] )
 
 		o["useTransform"].setValue( True )
 
-		checkAffected( ["object", "bound" ] )
+		checkAffected( [ "object", "bound", "childBounds" ] )
 
 		s["transform"]["translate"]["x"].setValue( 2 )
 
-		checkAffected( ["transform", "object", "bound" ] )
+		checkAffected( [ "transform", "object", "bound", "childBounds" ] )
 
 		a["attributes"][0]["value"].setValue( 1 )
 		checkAffected( ["attributes" ] )
 
 		o["useAttributes"].setValue( True )
 
-		checkAffected( ["object", "bound" ] )
+		checkAffected( [ "object", "bound", "childBounds" ] )
 
 		a["attributes"][0]["value"].setValue( 2 )
 
-		checkAffected( ["attributes", "object", "bound" ] )
+		checkAffected( ["attributes", "object", "bound", "childBounds" ] )
 
 	def testBoundsUpdate( self ) :
 

--- a/python/GafferSceneTest/ClosestPointSamplerTest.py
+++ b/python/GafferSceneTest/ClosestPointSamplerTest.py
@@ -263,5 +263,31 @@ class ClosestPointSamplerTest( GafferSceneTest.SceneTestCase ) :
 		with GafferTest.TestRunner.PerformanceScope() :
 			sampler["out"].object( "/plane" )
 
+	def testPruneSourceLocation( self ) :
+
+		plane = GafferScene.Plane()
+		sphere = GafferScene.Sphere()
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		prune = GafferScene.Prune()
+		prune["in"].setInput( sphere["out"] )
+
+		sampler = GafferScene.ClosestPointSampler()
+		sampler["in"].setInput( plane["out"] )
+		sampler["source"].setInput( prune["out"] )
+		sampler["filter"].setInput( planeFilter["out"] )
+		sampler["sourceLocation"].setValue( "/sphere" )
+		sampler["primitiveVariables"].setValue( "P" )
+		sampler["prefix"].setValue( "sampled:" )
+
+		self.assertIn( "sampled:P", sampler["out"].object( "/plane" ) )
+		prune["filter"].setInput( sphereFilter["out"] )
+		self.assertNotIn( "sampled:P", sampler["out"].object( "/plane" ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/CopyAttributesTest.py
+++ b/python/GafferSceneTest/CopyAttributesTest.py
@@ -211,5 +211,30 @@ class CopyAttributesTest( GafferSceneTest.SceneTestCase ) :
 		copyAttributes["sourceLocation"].setValue( "/sphere" )
 		self.assertEqual( copyAttributes["out"].attributes( "/plane" ), sphereAttributes["out"].attributes( "/sphere" ) )
 
+	def testDeleteSourceLocation( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		sphereAttributes = GafferScene.CustomAttributes()
+		sphereAttributes["in"].setInput( sphere["out"] )
+		sphereAttributes["filter"].setInput( sphereFilter["out"] )
+		sphereAttributes["attributes"].addChild( Gaffer.NameValuePlug( "test", 1 ) )
+
+		prune = GafferScene.Prune()
+		prune["in"].setInput( sphereAttributes["out"] )
+
+		copy = GafferScene.CopyAttributes()
+		copy["in"].setInput( sphere["out"] )
+		copy["source"].setInput( prune["out"] )
+		copy["filter"].setInput( sphereFilter["out"] )
+		copy["attributes"].setValue( "*" )
+
+		self.assertScenesEqual( copy["out"], sphereAttributes["out"] )
+		prune["filter"].setInput( sphereFilter["out"] )
+		self.assertScenesEqual( copy["out"], sphere["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/CopyPrimitiveVariablesTest.py
+++ b/python/GafferSceneTest/CopyPrimitiveVariablesTest.py
@@ -230,5 +230,27 @@ class CopyPrimitiveVariablesTest( GafferSceneTest.SceneTestCase ) :
 		self.assertScenesEqual( copy["out"], group["out"], checks = { "bound" } )
 		self.assertSceneHashesEqual( copy["out"], group["out"], checks = { "bound" } )
 
+	def testDeleteSourceLocation( self ) :
+
+		sphere1 = GafferScene.Sphere()
+		sphere2 = GafferScene.Sphere()
+		sphere2["radius"].setValue( 2 )
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		prune = GafferScene.Prune()
+		prune["in"].setInput( sphere2["out"] )
+
+		copy = GafferScene.CopyPrimitiveVariables()
+		copy["in"].setInput( sphere1["out"] )
+		copy["source"].setInput( prune["out"] )
+		copy["filter"].setInput( sphereFilter["out"] )
+		copy["primitiveVariables"].setValue( "*" )
+
+		self.assertScenesEqual( copy["out"], sphere2["out"] )
+		prune["filter"].setInput( sphereFilter["out"] )
+		self.assertScenesEqual( copy["out"], sphere1["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/CubeTest.py
+++ b/python/GafferSceneTest/CubeTest.py
@@ -87,7 +87,7 @@ class CubeTest( GafferSceneTest.SceneTestCase ) :
 		c["name"].setValue( "box" )
 		self.assertEqual(
 			{ x[0] for x in s if not x[0].getName().startswith( "__" ) },
-			{ c["name"], c["out"]["childNames"], c["out"]["set"], c["out"] }
+			{ c["name"], c["out"]["childNames"], c["out"]["childBounds"], c["out"]["exists"], c["out"]["set"], c["out"] }
 		)
 
 		del s[:]

--- a/python/GafferSceneTest/CustomOptionsTest.py
+++ b/python/GafferSceneTest/CustomOptionsTest.py
@@ -137,9 +137,11 @@ class CustomOptionsTest( GafferSceneTest.SceneTestCase ) :
 			dirtiedPlugs,
 			{
 				o["in"]["bound"],
+				o["in"]["childBounds"],
 				o["in"]["object"],
 				o["in"],
 				o["out"]["bound"],
+				o["out"]["childBounds"],
 				o["out"]["object"],
 				o["out"],
 			}

--- a/python/GafferSceneTest/DuplicateTest.py
+++ b/python/GafferSceneTest/DuplicateTest.py
@@ -218,5 +218,23 @@ class DuplicateTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( m.plugStatistics( d["out"]["setNames"] ).hashCount, 0 )
 		self.assertEqual( m.plugStatistics( d["out"]["setNames"] ).computeCount, 0 )
 
+	def testPruneTarget( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		prune = GafferScene.Prune()
+		prune["in"].setInput( sphere["out"] )
+
+		duplicate = GafferScene.Duplicate()
+		duplicate["in"].setInput( prune["out"] )
+		duplicate["target"].setValue( "/sphere" )
+		self.assertEqual( duplicate["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "sphere", "sphere1" ] ) )
+
+		prune["filter"].setInput( sphereFilter["out"] )
+		self.assertEqual( duplicate["out"].childNames( "/" ), IECore.InternedStringVectorData( [] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/ParentConstraintTest.py
+++ b/python/GafferSceneTest/ParentConstraintTest.py
@@ -133,6 +133,7 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 				constraint["relativeTransform"]["translate"],
 				constraint["relativeTransform"],
 				constraint["out"]["bound"],
+				constraint["out"]["childBounds"],
 				constraint["out"]["transform"],
 				constraint["out"]
 			}

--- a/python/GafferSceneTest/PlaneTest.py
+++ b/python/GafferSceneTest/PlaneTest.py
@@ -94,7 +94,7 @@ class PlaneTest( GafferSceneTest.SceneTestCase ) :
 		p["name"].setValue( "ground" )
 		self.assertEqual(
 			{ x[0] for x in s if not x[0].getName().startswith( "__" ) },
-			{ p["name"], p["out"]["childNames"], p["out"]["set"], p["out"] }
+			{ p["name"], p["out"]["childNames"], p["out"]["exists"], p["out"]["childBounds"], p["out"]["set"], p["out"] }
 		)
 
 		del s[:]

--- a/python/GafferSceneTest/SceneNodeTest.py
+++ b/python/GafferSceneTest/SceneNodeTest.py
@@ -346,8 +346,8 @@ class SceneNodeTest( GafferSceneTest.SceneTestCase ) :
 
 		with Gaffer.Context() as c :
 			c["scene:path"] = IECore.InternedStringVectorData( [ "group" ] )
-			h = group["out"].childBoundsHash()
-			b = group["out"].childBounds()
+			h = group["out"]["childBounds"].hash()
+			b = group["out"]["childBounds"].getValue()
 
 		self.assertEqual( h, group["out"].childBoundsHash( "/group" ) )
 		self.assertEqual( b, group["out"].childBounds( "/group" ) )

--- a/python/GafferSceneTest/SceneNodeTest.py
+++ b/python/GafferSceneTest/SceneNodeTest.py
@@ -333,7 +333,7 @@ class SceneNodeTest( GafferSceneTest.SceneTestCase ) :
 		cube["name"].setValue( "box" )
 		self.assertGreaterEqual(
 			{ x[0] for x in cs },
-			{ cube["out"]["childNames"], cube["out"]["__sortedChildNames"], cube["out"]["__exists"] }
+			{ cube["out"]["childNames"], cube["out"]["__sortedChildNames"], cube["out"]["exists"] }
 		)
 
 	def testChildBounds( self ) :

--- a/python/GafferSceneTest/SphereTest.py
+++ b/python/GafferSceneTest/SphereTest.py
@@ -152,7 +152,7 @@ class SphereTest( GafferSceneTest.SceneTestCase ) :
 		s["name"].setValue( "ball" )
 		self.assertEqual(
 			{ x[0] for x in ss if not x[0].getName().startswith( "__" ) },
-			{ s["name"], s["out"]["childNames"], s["out"]["set"], s["out"] }
+			{ s["name"], s["out"]["childNames"], s["out"]["exists"], s["out"]["childBounds"], s["out"]["set"], s["out"] }
 		)
 
 		del ss[:]

--- a/python/GafferSceneTest/TextTest.py
+++ b/python/GafferSceneTest/TextTest.py
@@ -80,7 +80,7 @@ class TextTest( GafferSceneTest.SceneTestCase ) :
 		t["name"].setValue( "ground" )
 		self.assertEqual(
 			{ x[0] for x in s if not x[0].getName().startswith( "__" ) },
-			{ t["name"], t["out"]["childNames"], t["out"]["set"], t["out"] }
+			{ t["name"], t["out"]["childNames"], t["out"]["exists"], t["out"]["childBounds"], t["out"]["set"], t["out"] }
 		)
 
 		del s[:]

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -160,7 +160,7 @@ void BranchCreator::affects( const Plug *input, AffectedPlugsContainer &outputs 
 {
 	FilteredSceneProcessor::affects( input, outputs );
 
-	if( input == parentPlug() || input == filteredPathsPlug() )
+	if( input == parentPlug() || input == filteredPathsPlug() || input == inPlug()->existsPlug() )
 	{
 		outputs.push_back( parentPathsPlug() );
 	}

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -324,7 +324,7 @@ void BranchCreator::hashBound( const ScenePath &path, const Gaffer::Context *con
 	{
 		FilteredSceneProcessor::hashBound( path, context, parent, h );
 		inPlug()->boundPlug()->hash( h );
-		h.append( outPlug()->childBoundsHash() );
+		outPlug()->childBoundsPlug()->hash( h );
 	}
 	else
 	{
@@ -344,7 +344,7 @@ Imath::Box3f BranchCreator::computeBound( const ScenePath &path, const Gaffer::C
 	else if( parentMatch == IECore::PathMatcher::ExactMatch || parentMatch == IECore::PathMatcher::DescendantMatch )
 	{
 		Box3f result = inPlug()->boundPlug()->getValue();
-		result.extendBy( outPlug()->childBounds() );
+		result.extendBy( outPlug()->childBoundsPlug()->getValue() );
 		return result;
 	}
 	else

--- a/src/GafferScene/CollectScenes.cpp
+++ b/src/GafferScene/CollectScenes.cpp
@@ -151,7 +151,7 @@ void CollectScenes::affects( const Gaffer::Plug *input, AffectedPlugsContainer &
 {
 	SceneProcessor::affects( input, outputs );
 
-	if( input == rootNamesPlug() )
+	if( input == rootNamesPlug() || input == inPlug()->existsPlug() )
 	{
 		outputs.push_back( outPlug()->childNamesPlug() );
 	}

--- a/src/GafferScene/CollectScenes.cpp
+++ b/src/GafferScene/CollectScenes.cpp
@@ -181,7 +181,7 @@ void CollectScenes::hashBound( const ScenePath &path, const Gaffer::Context *con
 {
 	if( path.size() == 0 )
 	{
-		h = outPlug()->childBoundsHash();
+		h = outPlug()->childBoundsPlug()->hash();
 	}
 	else
 	{
@@ -194,7 +194,7 @@ Imath::Box3f CollectScenes::computeBound( const ScenePath &path, const Gaffer::C
 {
 	if( path.size() == 0 )
 	{
-		return outPlug()->childBounds();
+		return outPlug()->childBoundsPlug()->getValue();
 	}
 	else
 	{

--- a/src/GafferScene/CopyAttributes.cpp
+++ b/src/GafferScene/CopyAttributes.cpp
@@ -119,7 +119,8 @@ void CopyAttributes::affects( const Gaffer::Plug *input, AffectedPlugsContainer 
 		input == filterPlug() ||
 		input == attributesPlug() ||
 		input == sourceLocationPlug() ||
-		input == deleteExistingPlug()
+		input == deleteExistingPlug() ||
+		input == sourcePlug()->existsPlug()
 	)
 	{
 		outputs.push_back( outPlug()->attributesPlug() );

--- a/src/GafferScene/CopyPrimitiveVariables.cpp
+++ b/src/GafferScene/CopyPrimitiveVariables.cpp
@@ -100,7 +100,8 @@ bool CopyPrimitiveVariables::affectsProcessedObject( const Gaffer::Plug *input )
 	return Deformer::affectsProcessedObject( input ) ||
 		input == sourcePlug()->objectPlug() ||
 		input == primitiveVariablesPlug() ||
-		input == sourceLocationPlug()
+		input == sourceLocationPlug() ||
+		input == sourcePlug()->existsPlug()
 	;
 }
 

--- a/src/GafferScene/Deformer.cpp
+++ b/src/GafferScene/Deformer.cpp
@@ -121,11 +121,11 @@ void Deformer::hashBound( const ScenePath &path, const Gaffer::Context *context,
 
 			if( m & PathMatcher::DescendantMatch )
 			{
-				h.append( outPlug()->childBoundsHash() );
+				outPlug()->childBoundsPlug()->hash( h );
 			}
 			else
 			{
-				h.append( inPlug()->childBoundsHash() );
+				inPlug()->childBoundsPlug()->hash( h );
 			}
 			return;
 		}
@@ -171,11 +171,11 @@ Imath::Box3f Deformer::computeBound( const ScenePath &path, const Gaffer::Contex
 
 			if( m & PathMatcher::DescendantMatch )
 			{
-				result.extendBy( outPlug()->childBounds() );
+				result.extendBy( outPlug()->childBoundsPlug()->getValue() );
 			}
 			else
 			{
-				result.extendBy( inPlug()->childBounds() );
+				result.extendBy( inPlug()->childBoundsPlug()->getValue() );
 			}
 			return result;
 		}

--- a/src/GafferScene/DeleteObject.cpp
+++ b/src/GafferScene/DeleteObject.cpp
@@ -133,7 +133,7 @@ void DeleteObject::hashBound( const ScenePath &path, const Gaffer::Context *cont
 		if( m & ( IECore::PathMatcher::ExactMatch | IECore::PathMatcher::DescendantMatch ) )
 		{
 			FilteredSceneProcessor::hashBound( path, context, parent, h );
-			h.append( outPlug()->childBoundsHash() );
+			outPlug()->childBoundsPlug()->hash( h );
 			if( !(m & IECore::PathMatcher::ExactMatch) )
 			{
 				inPlug()->objectPlug()->hash( h );
@@ -151,7 +151,7 @@ Imath::Box3f DeleteObject::computeBound( const ScenePath &path, const Gaffer::Co
 		const IECore::PathMatcher::Result m = filterValue( context );
 		if( m & ( IECore::PathMatcher::ExactMatch | IECore::PathMatcher::DescendantMatch ) )
 		{
-			Box3f result = outPlug()->childBounds();
+			Box3f result = outPlug()->childBoundsPlug()->getValue();
 			if( !(m & IECore::PathMatcher::ExactMatch) )
 			{
 				ConstObjectPtr o = inPlug()->objectPlug()->getValue();

--- a/src/GafferScene/Duplicate.cpp
+++ b/src/GafferScene/Duplicate.cpp
@@ -154,6 +154,7 @@ void Duplicate::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 	}
 
 	if(
+		input == inPlug()->existsPlug() ||
 		input == targetPlug() ||
 		input == copiesPlug() ||
 		input == namePlug()

--- a/src/GafferScene/FreezeTransform.cpp
+++ b/src/GafferScene/FreezeTransform.cpp
@@ -161,7 +161,7 @@ void FreezeTransform::hashBound( const ScenePath &path, const Gaffer::Context *c
 		// thus changing the bounds - so we must compute them properly from
 		// children.
 		SceneProcessor::hashBound( path, context, parent, h );
-		h.append( outPlug()->childBoundsHash() );
+		outPlug()->childBoundsPlug()->hash( h );
 		// we may also be changing the bounds at this specific location.
 		inPlug()->boundPlug()->hash( h );
 		transformPlug()->hash( h );
@@ -182,7 +182,7 @@ Imath::Box3f FreezeTransform::computeBound( const ScenePath &path, const Gaffer:
 	const unsigned m = filterValue( context );
 	if( m & ( IECore::PathMatcher::AncestorMatch | IECore::PathMatcher::ExactMatch ) )
 	{
-		Box3f result = outPlug()->childBounds();
+		Box3f result = outPlug()->childBoundsPlug()->getValue();
 		Box3f b = inPlug()->boundPlug()->getValue();
 		b = transform( b, transformPlug()->getValue() );
 		result.extendBy( b );

--- a/src/GafferScene/GlobalsProcessor.cpp
+++ b/src/GafferScene/GlobalsProcessor.cpp
@@ -53,6 +53,7 @@ GlobalsProcessor::GlobalsProcessor( const std::string &name )
 	outPlug()->childNamesPlug()->setInput( inPlug()->childNamesPlug() );
 	outPlug()->setNamesPlug()->setInput( inPlug()->setNamesPlug() );
 	outPlug()->setPlug()->setInput( inPlug()->setPlug() );
+	outPlug()->childBoundsPlug()->setInput( inPlug()->childBoundsPlug() );
 }
 
 GlobalsProcessor::~GlobalsProcessor()

--- a/src/GafferScene/Grid.cpp
+++ b/src/GafferScene/Grid.cpp
@@ -220,7 +220,7 @@ void Grid::hashBound( const SceneNode::ScenePath &path, const Gaffer::Context *c
 {
 	if( path.size() == 0 )
 	{
-		h = parent->childBoundsHash();
+		h = parent->childBoundsPlug()->hash();
 	}
 	else
 	{
@@ -233,7 +233,7 @@ Imath::Box3f Grid::computeBound( const SceneNode::ScenePath &path, const Gaffer:
 {
 	if( path.size() == 0 )
 	{
-		return parent->childBounds();
+		return parent->childBoundsPlug()->getValue();
 	}
 	else
 	{

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -672,6 +672,7 @@ void Instancer::affects( const Plug *input, AffectedPlugsContainer &outputs ) co
 		input == prototypeRootsPlug() ||
 		input == prototypeRootsListPlug() ||
 		input == prototypesPlug()->childNamesPlug() ||
+		input == prototypesPlug()->existsPlug() ||
 		input == idPlug() ||
 		input == positionPlug() ||
 		input == orientationPlug() ||

--- a/src/GafferScene/Isolate.cpp
+++ b/src/GafferScene/Isolate.cpp
@@ -195,7 +195,7 @@ void Isolate::hashBound( const ScenePath &path, const Gaffer::Context *context, 
 	const SetsToKeep setsToKeep( this );
 	if( adjustBoundsPlug()->getValue() && mayPruneChildren( path, context, setsToKeep ) )
 	{
-		h = outPlug()->childBoundsHash();
+		h = outPlug()->childBoundsPlug()->hash();
 		return;
 	}
 
@@ -208,7 +208,7 @@ Imath::Box3f Isolate::computeBound( const ScenePath &path, const Gaffer::Context
 	const SetsToKeep setsToKeep( this );
 	if( adjustBoundsPlug()->getValue() && mayPruneChildren( path, context, setsToKeep ) )
 	{
-		return outPlug()->childBounds();
+		return outPlug()->childBoundsPlug()->getValue();
 	}
 
 	return inPlug()->boundPlug()->getValue();

--- a/src/GafferScene/MergeScenes.cpp
+++ b/src/GafferScene/MergeScenes.cpp
@@ -512,7 +512,7 @@ void MergeScenes::hashBound( const ScenePath &path, const Gaffer::Context *conte
 
 	SceneProcessor::hashBound( path, context, parent, h );
 	outPlug()->objectPlug()->hash( h );
-	h.append( outPlug()->childBoundsHash() );
+	outPlug()->childBoundsPlug()->hash( h );
 }
 
 Imath::Box3f MergeScenes::computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
@@ -542,7 +542,7 @@ Imath::Box3f MergeScenes::computeBound( const ScenePath &path, const Gaffer::Con
 	// compute everything by brute force.
 
 	Box3f result = SceneAlgo::bound( outPlug()->objectPlug()->getValue().get() );
-	result.extendBy( outPlug()->childBounds() );
+	result.extendBy( outPlug()->childBoundsPlug()->getValue() );
 	return result;
 }
 

--- a/src/GafferScene/MergeScenes.cpp
+++ b/src/GafferScene/MergeScenes.cpp
@@ -323,7 +323,7 @@ void MergeScenes::hashActiveInputs( const Gaffer::Context *context, IECore::Murm
 			visit(
 				parentActiveInputs,
 				[&scenePath, &activeInputs] ( InputType type, size_t index, const ScenePlug *scene ) {
-					if( SceneAlgo::exists( scene, scenePath ) )
+					if( scene->exists( scenePath ) )
 					{
 						activeInputs[index] = true;
 					}
@@ -373,7 +373,7 @@ int MergeScenes::computeActiveInputs( const Gaffer::Context *context ) const
 			visit(
 				parentActiveInputs,
 				[&result, &scenePath] ( InputType type, size_t index, const ScenePlug *scene ) {
-					if( SceneAlgo::exists( scene, scenePath ) )
+					if( scene->exists( scenePath ) )
 					{
 						result[index] = true;
 					}

--- a/src/GafferScene/MergeScenes.cpp
+++ b/src/GafferScene/MergeScenes.cpp
@@ -183,7 +183,7 @@ void MergeScenes::affects( const Gaffer::Plug *input, AffectedPlugsContainer &ou
 
 	const ScenePlug *scene = inPlugs()->isAncestorOf( input ) ? input->parent<ScenePlug>() : nullptr;
 
-	if( scene && input == scene->childNamesPlug() )
+	if( scene && input == scene->existsPlug() )
 	{
 		outputs.push_back( activeInputsPlug() );
 	}

--- a/src/GafferScene/PrimitiveSampler.cpp
+++ b/src/GafferScene/PrimitiveSampler.cpp
@@ -257,7 +257,7 @@ void PrimitiveSampler::hashProcessedObject( const ScenePath &path, const Gaffer:
 
 	ScenePlug::ScenePath sourcePath;
 	ScenePlug::stringToPath( sourceLocation, sourcePath );
-	if( !SceneAlgo::exists( sourcePlug(), sourcePath ) )
+	if( !sourcePlug()->exists( sourcePath ) )
 	{
 		return;
 	}
@@ -296,7 +296,7 @@ IECore::ConstObjectPtr PrimitiveSampler::computeProcessedObject( const ScenePath
 
 	ScenePlug::ScenePath sourcePath;
 	ScenePlug::stringToPath( sourceLocation, sourcePath );
-	if( !SceneAlgo::exists( sourcePlug(), sourcePath ) )
+	if( !sourcePlug()->exists( sourcePath ) )
 	{
 		return inputObject;
 	}

--- a/src/GafferScene/PrimitiveSampler.cpp
+++ b/src/GafferScene/PrimitiveSampler.cpp
@@ -231,11 +231,11 @@ bool PrimitiveSampler::affectsProcessedObject( const Gaffer::Plug *input ) const
 {
 	return
 		Deformer::affectsProcessedObject( input ) ||
-		input == sourcePlug() ||
 		input == sourceLocationPlug() ||
 		input == primitiveVariablesPlug() ||
 		input == prefixPlug() ||
 		input == statusPlug() ||
+		input == sourcePlug()->existsPlug() ||
 		input == sourcePlug()->objectPlug() ||
 		input == inPlug()->transformPlug() ||
 		input == sourcePlug()->transformPlug() ||

--- a/src/GafferScene/Prune.cpp
+++ b/src/GafferScene/Prune.cpp
@@ -101,7 +101,7 @@ void Prune::hashBound( const ScenePath &path, const Gaffer::Context *context, co
 	{
 		if( filterValue( context ) & IECore::PathMatcher::DescendantMatch )
 		{
-			h = outPlug()->childBoundsHash();
+			h = outPlug()->childBoundsPlug()->hash();
 			return;
 		}
 	}
@@ -116,7 +116,7 @@ Imath::Box3f Prune::computeBound( const ScenePath &path, const Gaffer::Context *
 	{
 		if( filterValue( context ) & IECore::PathMatcher::DescendantMatch )
 		{
-			return outPlug()->childBounds();
+			return outPlug()->childBoundsPlug()->getValue();
 		}
 	}
 

--- a/src/GafferScene/SceneElementProcessor.cpp
+++ b/src/GafferScene/SceneElementProcessor.cpp
@@ -113,7 +113,7 @@ void SceneElementProcessor::hashBound( const ScenePath &path, const Gaffer::Cont
 			if( childNames->readable().size() )
 			{
 				FilteredSceneProcessor::hashBound( path, context, parent, h );
-				h.append( outPlug()->childBoundsHash() );
+				outPlug()->childBoundsPlug()->hash( h );
 				inPlug()->objectPlug()->hash( h );
 			}
 			else
@@ -144,7 +144,7 @@ Imath::Box3f SceneElementProcessor::computeBound( const ScenePath &path, const G
 			ConstInternedStringVectorDataPtr childNames = inPlug()->childNamesPlug()->getValue();
 			if( childNames->readable().size() )
 			{
-				result = outPlug()->childBounds();
+				result = outPlug()->childBoundsPlug()->getValue();
 				// We do have to resort to computing the object here, but its exceedingly
 				// rare to have an object at a location which also has children, so typically
 				// we should be receiving a NullObject cheaply.

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -575,19 +575,9 @@ Imath::Box3f ScenePlug::childBounds( const ScenePath &scenePath ) const
 	return childBoundsPlug()->getValue();
 }
 
-Imath::Box3f ScenePlug::childBounds() const
-{
-	return childBoundsPlug()->getValue();
-}
-
 IECore::MurmurHash ScenePlug::childBoundsHash( const ScenePath &scenePath ) const
 {
 	PathScope scope( Context::current(), scenePath );
-	return childBoundsPlug()->hash();
-}
-
-IECore::MurmurHash ScenePlug::childBoundsHash() const
-{
 	return childBoundsPlug()->hash();
 }
 

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -141,9 +141,18 @@ ScenePlug::ScenePlug( const std::string &name, Direction direction, unsigned fla
 
 	addChild(
 		new BoolPlug(
-			"__exists",
+			"exists",
 			direction,
 			true,
+			childFlags
+		)
+	);
+
+	addChild(
+		new AtomicBox3fPlug(
+			"childBounds",
+			direction,
+			Imath::Box3f(),
 			childFlags
 		)
 	);
@@ -153,15 +162,6 @@ ScenePlug::ScenePlug( const std::string &name, Direction direction, unsigned fla
 			"__sortedChildNames",
 			direction,
 			new IECore::InternedStringVectorData(),
-			childFlags
-		)
-	);
-
-	addChild(
-		new AtomicBox3fPlug(
-			"__childBounds",
-			direction,
-			Imath::Box3f(),
 			childFlags
 		)
 	);
@@ -289,24 +289,25 @@ const Gaffer::BoolPlug *ScenePlug::existsPlug() const
 	return getChild<BoolPlug>( 8 );
 }
 
-Gaffer::InternedStringVectorDataPlug *ScenePlug::sortedChildNamesPlug()
-{
-	return getChild<InternedStringVectorDataPlug>( 9 );
-}
-
-const Gaffer::InternedStringVectorDataPlug *ScenePlug::sortedChildNamesPlug() const
-{
-	return getChild<InternedStringVectorDataPlug>( 9 );
-}
-
 Gaffer::AtomicBox3fPlug *ScenePlug::childBoundsPlug()
 {
-	return getChild<AtomicBox3fPlug>( 10 );
+	return getChild<AtomicBox3fPlug>( 9 );
 }
 
 const Gaffer::AtomicBox3fPlug *ScenePlug::childBoundsPlug() const
 {
-	return getChild<AtomicBox3fPlug>( 10 );
+	return getChild<AtomicBox3fPlug>( 9 );
+}
+
+
+Gaffer::InternedStringVectorDataPlug *ScenePlug::sortedChildNamesPlug()
+{
+	return getChild<InternedStringVectorDataPlug>( 10 );
+}
+
+const Gaffer::InternedStringVectorDataPlug *ScenePlug::sortedChildNamesPlug() const
+{
+	return getChild<InternedStringVectorDataPlug>( 10 );
 }
 
 ScenePlug::PathScope::PathScope( const Gaffer::Context *context )

--- a/src/GafferScene/SceneReader.cpp
+++ b/src/GafferScene/SceneReader.cpp
@@ -203,7 +203,7 @@ Imath::Box3f SceneReader::computeBound( const ScenePath &path, const Gaffer::Con
 	}
 	else
 	{
-		result = parent->childBounds();
+		result = parent->childBoundsPlug()->getValue();
 	}
 
 	if( path.size() == 0 && !result.isEmpty() )

--- a/src/GafferScene/SubTree.cpp
+++ b/src/GafferScene/SubTree.cpp
@@ -118,7 +118,7 @@ void SubTree::hashBound( const ScenePath &path, const Gaffer::Context *context, 
 			h = inPlug()->boundHash( source );
 			break;
 		case CreateRoot :
-			h = parent->childBoundsHash();
+			h = parent->childBoundsPlug()->hash();
 			break;
 		case EmptyRoot :
 			SceneProcessor::hashBound( path, context, parent, h );
@@ -135,7 +135,7 @@ Imath::Box3f SubTree::computeBound( const ScenePath &path, const Gaffer::Context
 		case Default :
 			return inPlug()->bound( source );
 		case CreateRoot :
-			return parent->childBounds();
+			return parent->childBoundsPlug()->getValue();
 		default : // EmptyRoot
 			return Imath::Box3f();
 	}

--- a/src/GafferScene/SubTree.cpp
+++ b/src/GafferScene/SubTree.cpp
@@ -96,7 +96,7 @@ void SubTree::affects( const Plug *input, AffectedPlugsContainer &outputs ) cons
 	{
 		outputs.push_back( outPlug()->getChild<ValuePlug>( input->getName() ) );
 	}
-	else if( input == rootPlug() || input == includeRootPlug() )
+	else if( input == rootPlug() || input == includeRootPlug() || input == inPlug()->existsPlug() )
 	{
 		outputs.push_back( outPlug()->boundPlug() );
 		outputs.push_back( outPlug()->transformPlug() );

--- a/src/GafferSceneModule/CoreBinding.cpp
+++ b/src/GafferSceneModule/CoreBinding.cpp
@@ -268,28 +268,16 @@ bool existsWrapper2( const ScenePlug &plug )
 	return plug.exists();
 }
 
-Imath::Box3f childBoundsWrapper1( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+Imath::Box3f childBoundsWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
 {
 	IECorePython::ScopedGILRelease gilRelease;
 	return plug.childBounds( scenePath );
 }
 
-Imath::Box3f childBoundsWrapper2( const ScenePlug &plug )
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	return plug.childBounds();
-}
-
-IECore::MurmurHash childBoundsHashWrapper1( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+IECore::MurmurHash childBoundsHashWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
 {
 	IECorePython::ScopedGILRelease gilRelease;
 	return plug.childBoundsHash( scenePath );
-}
-
-IECore::MurmurHash childBoundsHashWrapper2( const ScenePlug &plug )
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	return plug.childBoundsHash();
 }
 
 IECore::InternedStringVectorDataPtr stringToPathWrapper( const char *s )
@@ -390,10 +378,8 @@ void GafferSceneModule::bindCore()
 		.def( "exists", &existsWrapper1 )
 		.def( "exists", &existsWrapper2 )
 		// child bounds queries
-		.def( "childBounds", &childBoundsWrapper1 )
-		.def( "childBounds", &childBoundsWrapper2 )
-		.def( "childBoundsHash", &childBoundsHashWrapper1 )
-		.def( "childBoundsHash", &childBoundsHashWrapper2 )
+		.def( "childBounds", &childBoundsWrapper )
+		.def( "childBoundsHash", &childBoundsHashWrapper )
 		// string utilities
 		.def( "stringToPath", &stringToPathWrapper )
 		.staticmethod( "stringToPath" )

--- a/src/GafferSceneTest/ContextSanitiser.cpp
+++ b/src/GafferSceneTest/ContextSanitiser.cpp
@@ -65,9 +65,7 @@ namespace
 {
 
 const InternedString g_internalOut( "__internalOut" );
-const InternedString g_exists( "__exists" );
 const InternedString g_sortedChildNames( "__sortedChildNames" );
-const InternedString g_childBounds( "__childBounds" );
 
 } // namespace
 
@@ -98,11 +96,11 @@ void ContextSanitiser::processStarted( const Gaffer::Process *process )
 			process->plug() != scene->attributesPlug() &&
 			process->plug() != scene->objectPlug() &&
 			process->plug() != scene->childNamesPlug() &&
-			// Private plugs, so we have no choice but to test
-			// for them by name.
-			process->plug()->getName() != g_exists &&
-			process->plug()->getName() != g_sortedChildNames &&
-			process->plug()->getName() != g_childBounds
+			process->plug() != scene->existsPlug() &&
+			process->plug() != scene->childBoundsPlug() &&
+			// Private plug, so we have no choice but to test
+			// for it by name.
+			process->plug()->getName() != g_sortedChildNames
 		)
 		{
 			if( process->context()->get<IECore::Data>( ScenePlug::scenePathContextName, nullptr ) )


### PR DESCRIPTION
When we first introduced the `ScenePlug::exists()` query, we implemented it using a private plug behind the scenes. It turns out this privacy was a mistake, as nodes need to declare their dependency on the plug via `DependencyNode::affects()`. This led to several subtle bugs. This PR makes the `exists` and `childBounds` plugs public on `ScenePlug`, and fixes all the clients of `exists` to properly declare their dependencies.