### PR TITLE
SetFilter : Sanitise context used for set expression evaluation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.56.2.x (relative to 0.56.2.4)
+========
+
+Fixes
+-----
+
+- SetFilter : Sanitised context used to evaluate set expressions, by removing `scene:filter:inputScene` variable.
+
 0.56.2.4 (relative to 0.56.2.3)
 ========
 

--- a/src/GafferScene/SetFilter.cpp
+++ b/src/GafferScene/SetFilter.cpp
@@ -116,6 +116,7 @@ void SetFilter::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 
 	if( output == expressionResultPlug() )
 	{
+		ScenePlug::GlobalScope globalScope( context ); // Removes `scene:filter:inputScene`
 		SetAlgo::setExpressionHash( setExpressionPlug()->getValue(), getInputScene( context ), h );
 	}
 
@@ -127,6 +128,7 @@ void SetFilter::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 
 	if( output == expressionResultPlug() )
 	{
+		ScenePlug::GlobalScope globalScope( context ); // Removes `scene:filter:inputScene`
 		PathMatcherDataPtr data = new PathMatcherData( SetAlgo::evaluateSetExpression( setExpressionPlug()->getValue(), getInputScene( context ) ) );
 		static_cast<PathMatcherDataPlug *>( output )->setValue( data );
 	}


### PR DESCRIPTION
Without this we get the following test failure in `testWildcardsAndContextSanitisation()` :

```
RuntimeError: Unexpected message : WARNING : ContextSanitiser : scene:filter:inputScene in context for Group.out.setNames computeNode:hash (called from SetFilter.__expressionResult computeNode:hash)
```

The assertion about `hashCount` protects against context management bugs at the point we pull on `expressionResultPlug()` - this wasn't broken fortunately as it would have had far more severe performance consequences. But it seems worth protecting against in any case.
