### PR TITLE
Hash Cache Validation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -67,7 +67,7 @@ API
 ---
 
 - ValuePlug
-  - Improved interactive performance by not clearing the entire hash cache every time a plug is dirtied. Beware : this can reveal subtle bugs in `DependencyNode::affects()` implementations, causing hashes to be reused if a plug has not been dirtied appropriately. These bugs may previously have gone unnoticed but will now need fixing as a matter of urgency. The GAFFER_CLEAR_HASHCACHE_ON_DIRTY environment variable may be used to enable legacy behaviour in the interim.
+  - Improved interactive performance by not clearing the entire hash cache every time a plug is dirtied. Beware : this can reveal subtle bugs in `DependencyNode::affects()` implementations, causing hashes to be reused if a plug has not been dirtied appropriately. These bugs may previously have gone unnoticed but will now need fixing as a matter of urgency. The GAFFER_HASHCACHE_MODE environment variable may be set to "Legacy" to enable legacy behaviour in the interim, or to "Checked" to enable a slow mode which throws exceptions at the source of hash cache cache errors caused by bad `affects()` implementations.
   - Added `clearHashCache()` static method.
   - Added `resetDefault()` method.
 - ScenePlug :

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -180,6 +180,22 @@ class GAFFER_API ValuePlug : public Plug
 		/// > Note : Clearing occurs on a per-thread basis as and when
 		/// > each thread next accesses the cache.
 		static void clearHashCache();
+
+		/// The standard hash cache mode relies on correctly implemented
+		/// affects() methods to selectively clear the cache for dirtied
+		/// plugs.  If you have incorrect affects() methods, you can use
+		/// "Legacy", which pessimisticly dirties all hash cache entries
+		/// when something changes, or "Checked" which helps identify
+		/// bad affects() methods by throwing exceptions.
+		enum class HashCacheMode
+		{
+			Standard,
+			Checked,
+			Legacy
+		};
+		static void setHashCacheMode( HashCacheMode hashCacheMode );
+		static HashCacheMode getHashCacheMode();
+
 		//@}
 
 	protected :

--- a/include/GafferTest/MultiplyNode.h
+++ b/include/GafferTest/MultiplyNode.h
@@ -51,7 +51,7 @@ class GAFFERTEST_API MultiplyNode : public Gaffer::ComputeNode
 
 	public :
 
-		MultiplyNode( const std::string &name=defaultName<MultiplyNode>() );
+		MultiplyNode( const std::string &name=defaultName<MultiplyNode>(), bool brokenAffects = false );
 		~MultiplyNode() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferTest::MultiplyNode, MultiplyNodeTypeId, Gaffer::ComputeNode );
@@ -74,6 +74,7 @@ class GAFFERTEST_API MultiplyNode : public Gaffer::ComputeNode
 
 	private :
 
+		bool m_brokenAffects;
 		static size_t g_firstPlugIndex;
 
 };

--- a/src/GafferModule/ValuePlugBinding.cpp
+++ b/src/GafferModule/ValuePlugBinding.cpp
@@ -140,7 +140,17 @@ void GafferModule::bindValuePlug()
 		.staticmethod( "setHashCacheSizeLimit" )
 		.def( "clearHashCache", &ValuePlug::clearHashCache )
 		.staticmethod( "clearHashCache" )
+		.def( "getHashCacheMode", &ValuePlug::getHashCacheMode )
+		.staticmethod( "getHashCacheMode" )
+		.def( "setHashCacheMode", &ValuePlug::setHashCacheMode )
+		.staticmethod( "setHashCacheMode" )
 		.def( "__repr__", &repr )
+	;
+
+	enum_<ValuePlug::HashCacheMode>( "HashCacheMode" )
+		.value( "Standard", ValuePlug::HashCacheMode::Standard )
+		.value( "Checked", ValuePlug::HashCacheMode::Checked )
+		.value( "Legacy", ValuePlug::HashCacheMode::Legacy )
 	;
 
 	enum_<ValuePlug::CachePolicy>( "CachePolicy" )

--- a/src/GafferTest/MultiplyNode.cpp
+++ b/src/GafferTest/MultiplyNode.cpp
@@ -45,8 +45,8 @@ GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( MultiplyNode )
 
 size_t MultiplyNode::g_firstPlugIndex = 0;
 
-MultiplyNode::MultiplyNode( const std::string &name )
-	:	ComputeNode( name )
+MultiplyNode::MultiplyNode( const std::string &name, bool brokenAffects )
+	:	ComputeNode( name ), m_brokenAffects( brokenAffects )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new IntPlug( "op1" ) );
@@ -91,6 +91,11 @@ const Gaffer::IntPlug *MultiplyNode::productPlug() const
 void MultiplyNode::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	ComputeNode::affects( input, outputs );
+
+	if( m_brokenAffects && input == op2Plug() )
+	{
+		return;
+	}
 
 	if( input == op1Plug() || input == op2Plug() )
 	{

--- a/src/GafferTestModule/GafferTestModule.cpp
+++ b/src/GafferTestModule/GafferTestModule.cpp
@@ -65,7 +65,15 @@ static void testMetadataThreadingWrapper()
 BOOST_PYTHON_MODULE( _GafferTest )
 {
 
-	GafferBindings::DependencyNodeClass<MultiplyNode>();
+	GafferBindings::DependencyNodeClass<MultiplyNode>()
+		.def( init<const char *, bool>(
+				(
+					boost::python::arg_( "name" ),
+					boost::python::arg_( "brokenAffects" )=false
+				)
+			)
+		);
+
 
 	def( "testRecursiveChildIterator", &testRecursiveChildIterator );
 	def( "testFilteredRecursiveChildIterator", &testFilteredRecursiveChildIterator );


### PR DESCRIPTION
Some experiments in the direction John was suggesting.  Is this anything like what you were thinking?

The way I've split the dirty range in half doesn't feel the most intuitive, but I'm not sure what would be clearer.

This does appear to work ( it catches all the same bugs in old IERendering as the old code ), except that it reports the failures in the wrong place ( the newly added test demonstrates this by failing ).

The failures being reported in the wrong place is due to a general problem with error reporting in the hash cache.

This can be demonstrated in current Gaffer with a scene like this:

```
import Gaffer
import GafferScene
import IECore
import imath

Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 57, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 5, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )

__children = {}

__children["Sphere"] = GafferScene.Sphere( "Sphere" )
parent.addChild( __children["Sphere"] )
__children["Sphere"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group"] = GafferScene.Group( "Group" )
parent.addChild( __children["Group"] )
__children["Group"]["in"].addChild( GafferScene.ScenePlug( "in1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["ContextVariables"] = Gaffer.ContextVariables( "ContextVariables" )
parent.addChild( __children["ContextVariables"] )
__children["ContextVariables"].setup( GafferScene.ScenePlug( "in", ) )
__children["ContextVariables"]["variables"].addChild( Gaffer.NameValuePlug( "", Gaffer.StringPlug( "value", defaultValue = '', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), True, "member1", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
__children["ContextVariables"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Expression1"] = Gaffer.Expression( "Expression1" )
parent.addChild( __children["Expression1"] )
__children["Expression1"]["__out"].addChild( Gaffer.StringPlug( "p0", direction = Gaffer.Plug.Direction.Out, defaultValue = '', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Expression1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group1"] = GafferScene.Group( "Group1" )
parent.addChild( __children["Group1"] )
__children["Group1"]["in"].addChild( GafferScene.ScenePlug( "in1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group2"] = GafferScene.Group( "Group2" )
parent.addChild( __children["Group2"] )
__children["Group2"]["in"].addChild( GafferScene.ScenePlug( "in1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group2"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Transform"] = GafferScene.Transform( "Transform" )
parent.addChild( __children["Transform"] )
__children["Transform"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Expression"] = Gaffer.Expression( "Expression" )
parent.addChild( __children["Expression"] )
__children["Expression"]["__out"].addChild( Gaffer.FloatPlug( "p0", direction = Gaffer.Plug.Direction.Out, defaultValue = 0.0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Expression"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["PathFilter1"] = GafferScene.PathFilter( "PathFilter1" )
parent.addChild( __children["PathFilter1"] )
__children["PathFilter1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Sphere"]["__uiPosition"].setValue( imath.V2f( 64.5644836, 49.8795815 ) )
__children["Group"]["in"][0].setInput( __children["ContextVariables"]["out"] )
__children["Group"]["__uiPosition"].setValue( imath.V2f( 64.5644836, 23.1075974 ) )
__children["ContextVariables"]["variables"]["member1"]["name"].setValue( 'blah' )
__children["ContextVariables"]["variables"]["member1"]["value"].setInput( __children["Expression1"]["__out"]["p0"] )
__children["ContextVariables"]["__uiPosition"].setValue( imath.V2f( 64.5644836, 31.2716599 ) )
__children["ContextVariables"]["in"].setInput( __children["Transform"]["out"] )
Gaffer.Metadata.registerValue( __children["ContextVariables"]["in"], 'noduleLayout:section', 'top' )
Gaffer.Metadata.registerValue( __children["ContextVariables"]["out"], 'noduleLayout:section', 'bottom' )
__children["Expression1"]["__uiPosition"].setValue( imath.V2f( 52.1233368, 30.7001762 ) )
__children["Group1"]["in"][0].setInput( __children["Group"]["out"] )
__children["Group1"]["__uiPosition"].setValue( imath.V2f( 64.5635834, 17.3728962 ) )
__children["Group2"]["in"][0].setInput( __children["Group1"]["out"] )
__children["Group2"]["__uiPosition"].setValue( imath.V2f( 64.5635834, 11.1523256 ) )
__children["Transform"]["enabled"].setValue( False )
__children["Transform"]["in"].setInput( __children["Sphere"]["out"] )
__children["Transform"]["filter"].setInput( __children["PathFilter1"]["out"] )
__children["Transform"]["transform"]["translate"]["x"].setInput( __children["Expression"]["__out"]["p0"] )
__children["Transform"]["__uiPosition"].setValue( imath.V2f( 64.7820435, 41.2328873 ) )
__children["Expression"]["__uiPosition"].setValue( imath.V2f( 54.2821312, 41.2320518 ) )
__children["PathFilter1"]["paths"].setValue( IECore.StringVectorData( [ '/sphere' ] ) )
__children["PathFilter1"]["__uiPosition"].setValue( imath.V2f( 77.7820435, 47.3149185 ) )
__children["Expression1"]["__engine"].setValue( 'python' )
__children["Expression1"]["__expression"].setValue( 'parent["__out"]["p0"] = \'\'\n\nfoo' )
__children["Expression"]["__engine"].setValue( 'python' )
__children["Expression"]["__expression"].setValue( 'parent["__out"]["p0"] = 0.0\nx' )

del __children
```

If you then run `root['Group2']['out'].transform( "/group/group/group/sphere" )`, it correctly reports an error with `Group2.out.transform`, because hash errors are reported on the most downstream plug evaluated, not the actual plug with the problem.  If you switch which of the two nodes with bogus expressions is enabled however, then the other one triggers an exception during compute, and that is reported with the correct plug.  I have not yet figured out the difference - I think I can see why the hash fails due to the exception being rethrowUnwrapped at each level, and recaught and reconverted into a new ProcessException - but I haven't figured out why the same thing doesn't go wrong during computes.