### PR TITLE
Window : Constrain `setPosition` to keep the whole frame on screen

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -53,6 +53,7 @@ Fixes
 - SetAlgo : Fixed `affectsSetExpression()` to return `True` for `ScenePlug::setNamesPlug()`.
 - GafferTractor: Fixed evaluation of 'tag' and 'service' plugs on Task nodes. Previously, these plugs were evaluated in the default context, which prevented one from using custom context variables (e.g. from Wedge node) to compute tags or service keys dynamically.
 - NodeEditor : Reduced layout flicker when switching between nodes.
+- Spreadsheet : Fixed bug that could result in editor windows being placed partially off screen.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -94,6 +94,7 @@ API
   - Added `scrollToNextMessage()` and `scrollToPreviousMessage()` methods.
 - MetadataAlgo : Added `readOnlyReason`, returning the outer-most `GraphComponent` that causes the specified component to be read-only.
 - EditScopeAlgo : Added `prunedReadOnlyReason`, `transformEditReadOnlyReason` and `parameterEditReadOnlyReason` to determine the outer-most `GraphComponent` causing and edit (or potential edit) to be read-only.
+- Window : Changed `setPosition` such that the whole window will remain on screen. Set `forcePosition` to `False` to disable this behaviour.
 
 Breaking Changes
 ----------------

--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -1438,8 +1438,9 @@ class _EditWindow( GafferUI.Window ) :
 					valuePlugValueWidget.menu().popup()
 					return
 
-		windowSize = cls.__currentWindow._qtWidget().sizeHint()
-		cls.__currentWindow.setPosition( plugBound.center() - imath.V2i( windowSize.width() / 2, windowSize.height() / 2 ) )
+		cls.__currentWindow.resizeToFitChild()
+		windowSize = cls.__currentWindow.bound().size()
+		cls.__currentWindow.setPosition( plugBound.center() - windowSize / 2 )
 		cls.__currentWindow.setVisible( True )
 
 		textWidget = cls.__textWidget( plugValueWidget )

--- a/python/GafferUI/Window.py
+++ b/python/GafferUI/Window.py
@@ -261,13 +261,61 @@ class Window( GafferUI.ContainerWidget ) :
 
 		self._qtWidget().resize( s )
 
-	def setPosition( self, position ) :
+	## Repositions the window, attempting to keep the whole frame on screen.
+	# If the window is larger than the available screen area, its position will
+	# be clamped to the top left. If forcePosition is True, the window will be
+	# moved to the specified position even if clipping will occur.
+	def setPosition( self, position, forcePosition = False ) :
 
-		self._qtWidget().move( position.x, position.y )
+		p = QtCore.QPoint( position.x, position.y )
+		if not forcePosition :
+			p = self.__constrainToScreen( p )
+
+		self._qtWidget().move( p )
 
 	def getPosition( self ) :
 
 		return imath.V2i( self._qtWidget().x(), self._qtWidget().y() )
+
+	def __constrainToScreen( self, position ) :
+
+		# Constrain position such that the whole window remains on screen where
+		# possible. Sadly Qt keeps their implementation of this private.
+		# Qt documents that for a window, move() is really pos and includes frame geometry
+
+		desktop = QtWidgets.QApplication.desktop()
+		screenNumber = desktop.screenNumber( position )
+		screenRect = desktop.availableGeometry( screenNumber )
+
+		# Find what our window's rect would be on that screen
+		windowRect = self._qtWidget().frameGeometry()
+		windowRect.moveTo( position )
+
+		# Determine the offset and which direction to move to stay on screen,
+		# based on this size difference and which co-ordinate changed in the
+		# intersected frame
+
+		intersection = windowRect.intersected( screenRect )
+		difference = windowRect.size() - intersection.size()
+
+		signX = -1 if intersection.left() == windowRect.left() else 1
+		signY = -1 if intersection.top() == windowRect.top() else 1
+
+		offset = QtCore.QPoint(
+			signX * difference.width(),
+			signY * difference.height()
+		)
+
+		newPosition = position + offset
+
+		# Bottom-right corrections may have moved us off to the top-left,
+		# constrain to the screen origin.
+		finalPos = QtCore.QPoint(
+			max( newPosition.x(), screenRect.topLeft().x() ),
+			max( newPosition.y(), screenRect.topLeft().y() )
+		)
+
+		return finalPos
 
 	def setFullScreen( self, fullScreen ) :
 

--- a/python/GafferUITest/WindowTest.py
+++ b/python/GafferUITest/WindowTest.py
@@ -284,8 +284,56 @@ class WindowTest( GafferUITest.TestCase ) :
 	def testPosition( self ) :
 
 		w = GafferUI.Window()
-		w.setPosition( imath.V2i( 10, 20 ) )
-		self.assertEqual( w.getPosition(), imath.V2i( 10, 20 ) )
+		w._qtWidget().resize( 200, 100 )
+		self.assertEqual( ( w._qtWidget().width(), w._qtWidget().height() ), ( 200, 100 ) )
+
+		w.setPosition( imath.V2i( 20, 30 ) )
+		self.assertEqual( w.getPosition(), imath.V2i( 20, 30 ) )
+
+		desktop = QtWidgets.QApplication.desktop()
+
+		screenRect = desktop.availableGeometry( w._qtWidget() )
+		windowRect = w._qtWidget().frameGeometry()
+
+		# Smaller, off-screen bottom right
+
+		w.setPosition( imath.V2i( screenRect.right() - 50, screenRect.bottom() - 75 ) )
+		self.assertEqual(
+			w.getPosition(),
+			imath.V2i(
+				screenRect.right() - windowRect.width() + 1,
+				screenRect.bottom() - windowRect.height() + 1
+			)
+		)
+
+		# Smaller, off-screen top left
+
+		w.setPosition( imath.V2i( screenRect.left() - 25 , screenRect.top() - 15 ) )
+		self.assertEqual( w.getPosition(), imath.V2i( screenRect.left(), screenRect.top() ) )
+
+		# Bigger width only
+
+		w._qtWidget().resize( screenRect.width() + 300, 200 )
+		windowRect = w._qtWidget().frameGeometry()
+
+		w.setPosition( imath.V2i( 100, 100 ) )
+		self.assertEqual( w.getPosition(), imath.V2i( screenRect.left(), 100 ) )
+		self.assertEqual( w._qtWidget().frameGeometry().size(), windowRect.size() )
+
+		# Bigger
+
+		w._qtWidget().resize( screenRect.width() + 300, screenRect.height() + 200 )
+		windowRect = w._qtWidget().frameGeometry()
+
+		w.setPosition( imath.V2i( 100, 100 ) )
+		self.assertEqual( w.getPosition(), imath.V2i( screenRect.left(), screenRect.top() ) )
+		self.assertEqual( w._qtWidget().frameGeometry().size(), windowRect.size() )
+
+		# Force position
+
+		w.setPosition( imath.V2i( 100, 100 ), forcePosition = True )
+		self.assertEqual( w.getPosition(), imath.V2i( 100, 100 ) )
+		self.assertEqual( w._qtWidget().frameGeometry().size(), windowRect.size() )
 
 	def testChildWindowsMethod( self ) :
 


### PR DESCRIPTION
Fixes assorted bugs in popup editor placement. This behaviour can be disabled by setting `forcePosition` to `True`.