### PR TITLE
EditScopeAlgo : Read-only discovery methods

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -93,6 +93,7 @@ API
   - Added MessageSummaryWidget class to simplify the display of message counts in other UIs.
   - Added `scrollToNextMessage()` and `scrollToPreviousMessage()` methods.
 - MetadataAlgo : Added `readOnlyReason`, returning the outer-most `GraphComponent` that causes the specified component to be read-only.
+- EditScopeAlgo : Added `prunedReadOnlyReason`, `transformEditReadOnlyReason` and `parameterEditReadOnlyReason` to determine the outer-most `GraphComponent` causing and edit (or potential edit) to be read-only.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -140,6 +140,7 @@ Breaking Changes
 - InteractiveRender : Changed base class from Node to ComputeNode, added members.
 - MessageWidget : Removed deprecated `appendMessage` method, use `messageHandler().handle()` instead.
 - Shader : Added virtual method.
+- MetadataAlgo : `readOnly( None )` will now raise an Exception instead of returning `False`.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -92,6 +92,7 @@ API
 - MessageWidget :
   - Added MessageSummaryWidget class to simplify the display of message counts in other UIs.
   - Added `scrollToNextMessage()` and `scrollToPreviousMessage()` methods.
+- MetadataAlgo : Added `readOnlyReason`, returning the outer-most `GraphComponent` that causes the specified component to be read-only.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -89,7 +89,6 @@ API
     - PresetsPlugValueWidget
 - SetAlgo : Added Python binding for `affectsSetExpression()`.
 - Shader : Added `affectsAttributes()` protected method.
-- MessageWidget : Added MessageSummaryWidget class to simplify the display of message counts in other UIs.
 - MessageWidget :
   - Added MessageSummaryWidget class to simplify the display of message counts in other UIs.
   - Added `scrollToNextMessage()` and `scrollToPreviousMessage()` methods.

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -96,6 +96,9 @@ GAFFER_API bool getChildNodesAreReadOnly( const Node *node );
 /// This is the method that should be used to determine if a graphComponent should be editable
 /// by the user or not.
 GAFFER_API bool readOnly( const GraphComponent *graphComponent );
+/// Returns the outer-most `GraphComponent` responsible for making `graphComponent` read-only. This may be
+/// `graphComponent` itself. Returns `nullptr` if `graphComponent` is not considered read-only.
+GAFFER_API const GraphComponent *readOnlyReason( const GraphComponent *graphComponent );
 
 /// Determines if a metadata value change affects the result of `readOnly( graphComponent )`.
 GAFFER_API bool readOnlyAffectedByChange( const GraphComponent *graphComponent, IECore::TypeId changedNodeTypeId, const IECore::StringAlgo::MatchPattern &changedPlugPath, const IECore::InternedString &changedKey, const Gaffer::Plug *changedPlug );

--- a/include/GafferScene/EditScopeAlgo.h
+++ b/include/GafferScene/EditScopeAlgo.h
@@ -51,12 +51,22 @@ namespace GafferScene
 namespace EditScopeAlgo
 {
 
+// 'readOnlyReason' methods
+// ========================
+// If is often necessary to determine the cause of the read-only state of an
+// edit, or whether an edit can be added to any given scope. These methods
+// return the outward-most GraphComponent that is causing any given edit (or
+// potential edit creation) to be read-only. Tools that create edits within a
+// scope should first check this returns null before calling any 'acquire'
+// method to avoid incorrectly modifying locked nodes/plugs.
+
 // Pruning
 // =======
 
 GAFFERSCENE_API void setPruned( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, bool pruned );
 GAFFERSCENE_API void setPruned( Gaffer::EditScope *scope, const IECore::PathMatcher &paths, bool pruned );
 GAFFERSCENE_API bool getPruned( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path );
+GAFFERSCENE_API const Gaffer::GraphComponent *prunedReadOnlyReason( const Gaffer::EditScope *scope );
 
 // Transforms
 // ==========
@@ -89,6 +99,7 @@ struct GAFFERSCENE_API TransformEdit
 GAFFERSCENE_API bool hasTransformEdit( const Gaffer::EditScope *scope, const ScenePlug::ScenePath &path );
 GAFFERSCENE_API boost::optional<TransformEdit> acquireTransformEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, bool createIfNecessary = true );
 GAFFERSCENE_API void removeTransformEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path );
+GAFFERSCENE_API const Gaffer::GraphComponent *transformEditReadOnlyReason( const Gaffer::EditScope *scope, const ScenePlug::ScenePath &path );
 
 // Shaders
 // =======
@@ -98,6 +109,7 @@ GAFFERSCENE_API void removeTransformEdit( Gaffer::EditScope *scope, const SceneP
 GAFFERSCENE_API bool hasParameterEdit( const Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter );
 GAFFERSCENE_API TweakPlug *acquireParameterEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter, bool createIfNecessary = true );
 GAFFERSCENE_API void removeParameterEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter );
+GAFFERSCENE_API const Gaffer::GraphComponent *parameterEditReadOnlyReason( const Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter );
 
 } // namespace EditScopeAlgo
 

--- a/python/GafferSceneUI/EditScopeUI.py
+++ b/python/GafferSceneUI/EditScopeUI.py
@@ -79,20 +79,18 @@ def __pruningKeyPress( viewer, event ) :
 		# should emit a warning here.
 		return True
 
-	## \todo Accessing the processor directly like this rather defeats the object of
-	# the EditScopeAlgo API. Consider additional API to say whether or not a user
-	# should be able to edit something, based on all the `readOnly` and `enabled` checks
-	# we're performing manually here.
-	pruningProcessor = editScope.acquireProcessor( "PruningEdits", createIfNecessary = False )
-	if pruningProcessor is not None and Gaffer.MetadataAlgo.readOnly( pruningProcessor["paths"] ) :
+	if GafferScene.EditScopeAlgo.prunedReadOnlyReason( editScope ) is not None :
 		return True
 
+	# \todo This needs encapsulating in EditScopeAlgo some how so we don't need
+	# to interact with processors directly.
 	with viewer.getContext() :
 		if not editScope["enabled"].getValue() :
 			# Spare folks from deleting something when it won't be
 			# apparent what they've done until they reenable the
 			# EditScope.
 			return True
+		pruningProcessor = editScope.acquireProcessor( "PruningEdits", createIfNecessary = False )
 		if pruningProcessor is not None and not pruningProcessor["enabled"].getValue() :
 			return True
 

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -80,6 +80,45 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 		with six.assertRaisesRegex( self, Exception, r"did not match C\+\+ signature" ) :
 			Gaffer.MetadataAlgo.readOnly( None )
 
+	def testReadOnlyReason( self ) :
+
+		b = Gaffer.Box()
+		b["b"] = Gaffer.Box()
+
+		n = GafferTest.AddNode()
+		b["b"]["n"] = n
+
+		self.assertIsNone( Gaffer.MetadataAlgo.readOnlyReason( n ) )
+		self.assertIsNone( Gaffer.MetadataAlgo.readOnlyReason( n["op1"] ) )
+
+		Gaffer.MetadataAlgo.setReadOnly( b, True )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnlyReason( n ), b )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnlyReason( n["op1"] ), b )
+
+		Gaffer.MetadataAlgo.setReadOnly( b["b"], True )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnlyReason( n["op1"] ), b )
+
+		Gaffer.MetadataAlgo.setReadOnly( b["b"]["n"], True )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnlyReason( n["op1"] ), b )
+
+		Gaffer.MetadataAlgo.setReadOnly( b["b"]["n"]["op1"], True )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnlyReason( n["op1"] ), b )
+
+		Gaffer.MetadataAlgo.setReadOnly( b, False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnlyReason( n["op1"] ), b["b"] )
+
+		Gaffer.MetadataAlgo.setReadOnly( b["b"], False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnlyReason( n["op1"] ), n )
+
+		Gaffer.MetadataAlgo.setReadOnly( b["b"]["n"], False )
+		self.assertEqual( Gaffer.MetadataAlgo.readOnlyReason( n["op1"] ), n["op1"] )
+
+		Gaffer.MetadataAlgo.setReadOnly( b["b"]["n"]["op1"], False )
+		self.assertIsNone( Gaffer.MetadataAlgo.readOnlyReason( n["op1"] ) )
+
+		with six.assertRaisesRegex( self, Exception, r"did not match C\+\+ signature" ) :
+			Gaffer.MetadataAlgo.readOnlyReason( None )
+
 	def testChildNodesAreReadOnly( self ) :
 
 		b = Gaffer.Box()

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -38,6 +38,7 @@ import unittest
 import os
 
 import imath
+import six
 
 import IECore
 
@@ -75,6 +76,9 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.MetadataAlgo.getReadOnly( n["op1"] ), False )
 		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n ), True )
 		self.assertEqual( Gaffer.MetadataAlgo.readOnly( n["op1"] ), True )
+
+		with six.assertRaisesRegex( self, Exception, r"did not match C\+\+ signature" ) :
+			Gaffer.MetadataAlgo.readOnly( None )
 
 	def testChildNodesAreReadOnly( self ) :
 

--- a/src/GafferModule/MetadataAlgoBinding.cpp
+++ b/src/GafferModule/MetadataAlgoBinding.cpp
@@ -70,6 +70,11 @@ bool readOnlyWrapper( GraphComponent &g )
 	return readOnly( &g );
 }
 
+GraphComponentPtr readOnlyReasonWrapper( GraphComponent &g )
+{
+	return const_cast<GraphComponent *>( readOnlyReason( &g ) );
+}
+
 void setBookmarkedWrapper( Node &node, bool bookmarked, bool persistent )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -126,6 +131,7 @@ void GafferModule::bindMetadataAlgo()
 	def( "setChildNodesAreReadOnly", &setChildNodesAreReadOnlyWrapper, ( arg( "node" ), arg( "readOnly"), arg( "persistent" ) = true ) );
 	def( "getChildNodesAreReadOnly", &getChildNodesAreReadOnly );
 	def( "readOnly", &readOnlyWrapper );
+	def( "readOnlyReason", &readOnlyReasonWrapper );
 	def(
 		"readOnlyAffectedByChange",
 		(bool (*)( const GraphComponent *, IECore::TypeId, const IECore::StringAlgo::MatchPattern &, const IECore::InternedString &, const Gaffer::Plug * ))&readOnlyAffectedByChange,

--- a/src/GafferModule/MetadataAlgoBinding.cpp
+++ b/src/GafferModule/MetadataAlgoBinding.cpp
@@ -65,6 +65,11 @@ void setChildNodesAreReadOnlyWrapper( Node &node, bool readOnly, bool persistent
 	setChildNodesAreReadOnly( &node, readOnly, persistent );
 }
 
+bool readOnlyWrapper( GraphComponent &g )
+{
+	return readOnly( &g );
+}
+
 void setBookmarkedWrapper( Node &node, bool bookmarked, bool persistent )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -120,7 +125,7 @@ void GafferModule::bindMetadataAlgo()
 	def( "getReadOnly", &getReadOnly );
 	def( "setChildNodesAreReadOnly", &setChildNodesAreReadOnlyWrapper, ( arg( "node" ), arg( "readOnly"), arg( "persistent" ) = true ) );
 	def( "getChildNodesAreReadOnly", &getChildNodesAreReadOnly );
-	def( "readOnly", &readOnly );
+	def( "readOnly", &readOnlyWrapper );
 	def(
 		"readOnlyAffectedByChange",
 		(bool (*)( const GraphComponent *, IECore::TypeId, const IECore::StringAlgo::MatchPattern &, const IECore::InternedString &, const Gaffer::Plug * ))&readOnlyAffectedByChange,

--- a/src/GafferSceneModule/EditScopeAlgoBinding.cpp
+++ b/src/GafferSceneModule/EditScopeAlgoBinding.cpp
@@ -69,6 +69,11 @@ bool getPrunedWrapper( Gaffer::EditScope &scope, const ScenePlug::ScenePath &pat
 	return EditScopeAlgo::getPruned( &scope, path );
 }
 
+GraphComponentPtr prunedReadOnlyReasonWrapper( Gaffer::EditScope &scope )
+{
+	return const_cast<GraphComponent *>( EditScopeAlgo::prunedReadOnlyReason( &scope ) );
+}
+
 bool hasTransformEditWrapper( const Gaffer::EditScope &scope, const ScenePlug::ScenePath &path )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -86,6 +91,11 @@ void removeTransformEditWrapper( Gaffer::EditScope &scope, const ScenePlug::Scen
 {
 	IECorePython::ScopedGILRelease gilRelease;
 	EditScopeAlgo::removeTransformEdit( &scope, path );
+}
+
+GraphComponentPtr transformEditReadOnlyReasonWrapper( Gaffer::EditScope &scope, const ScenePlug::ScenePath &path )
+{
+	return const_cast<GraphComponent *>( EditScopeAlgo::transformEditReadOnlyReason( &scope, path ) );
 }
 
 V3fPlugPtr translateAccessor( EditScopeAlgo::TransformEdit &e )
@@ -131,6 +141,11 @@ void removeParameterEditWrapper( Gaffer::EditScope &scope, const ScenePlug::Scen
 	return EditScopeAlgo::removeParameterEdit( &scope, path, attribute, parameter );
 }
 
+GraphComponentPtr parameterEditReadOnlyReasonWrapper( Gaffer::EditScope &scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter )
+{
+	return const_cast<GraphComponent *>( EditScopeAlgo::parameterEditReadOnlyReason( &scope, path, attribute, parameter ) );
+}
+
 } // namespace
 
 namespace GafferSceneModule
@@ -145,6 +160,7 @@ void bindEditScopeAlgo()
 	def( "setPruned", &setPrunedWrapper1 );
 	def( "setPruned", &setPrunedWrapper2 );
 	def( "getPruned", &getPrunedWrapper );
+	def( "prunedReadOnlyReason", &prunedReadOnlyReasonWrapper );
 
 	class_<EditScopeAlgo::TransformEdit>( "TransformEdit", no_init )
 		.def( init<const V3fPlugPtr &, const V3fPlugPtr &, const V3fPlugPtr &, const V3fPlugPtr &>() )
@@ -160,10 +176,12 @@ void bindEditScopeAlgo()
 	def( "acquireTransformEdit", &acquireTransformEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "createIfNecessary" ) = true ) );
 	def( "hasTransformEdit", &hasTransformEditWrapper );
 	def( "removeTransformEdit", &removeTransformEditWrapper );
+	def( "transformEditReadOnlyReason", &transformEditReadOnlyReasonWrapper );
 
 	def( "acquireParameterEdit", &acquireParameterEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ), arg( "parameter" ), arg( "createIfNecessary" ) = true ) );
 	def( "hasParameterEdit", &hasParameterEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ), arg( "parameter" ) ) );
 	def( "removeParameterEdit", &removeParameterEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ), arg( "parameter" ) ) );
+	def( "parameterEditReadOnlyReason", &parameterEditReadOnlyReasonWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ), arg( "parameter" ) ) );
 
 }
 


### PR DESCRIPTION
In order to prevent tools like the Transform tools or Scene View Inpsector from inadvertently editing locked plugs or SceneProcessors, we need to be able to easily determine whether any of the nodes managed via `EditScopeAlgo` are locked.

This PR adds `MetadataAlgo::readOnlyReason` to determine the outward-most `GraphComponent` that is making any particular plug or node read-only, and variants of this method in `EditScopeAlgo` to aid intorspection of edits and potential edits.

