### PR TITLE
ImageViewUI : Avoid crashes caused by non-finite pixel values

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+0.56.2.x (relative to 0.56.2.5)
+========
+
+- Viewer : Fixed crashes that could be caused by invalid pixel values.
+
 0.56.2.5 (relative to 0.56.2.4)
 ========
 

--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -237,6 +237,19 @@ class _TogglePlugValueWidget( GafferUI.PlugValueWidget ) :
 # _ColorInspectorPlugValueWidget
 ##########################################################################
 
+def _hsvString( color ) :
+
+	if any( math.isinf( x ) or math.isnan( x ) for x in color ) :
+		# The conventional thing to do would be to call `color.rgb2hsv()`
+		# and catch the exception that PyImath throws. But PyImath's
+		# exception handling involves a signal handler for SIGFPE. And
+		# Arnold likes to install its own handler for that, somehow
+		# breaking everything so that the entire application terminates.
+		return "- - -"
+	else :
+		hsv = color.rgb2hsv()
+		return "%.3f %.3f %.3f" % ( hsv.r, hsv.g, hsv.b )
+
 class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, **kw ) :
@@ -353,8 +366,7 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 		else :
 			self.__rgbLabel.setText( "<b>RGB : %.3f %.3f %.3f</b>" % ( color.r, color.g, color.b ) )
 
-		hsv = color.rgb2hsv()
-		self.__hsvLabel.setText( "<b>HSV : %.3f %.3f %.3f</b>" % ( hsv.r, hsv.g, hsv.b ) )
+		self.__hsvLabel.setText( "<b>HSV : %s</b>" % _hsvString( color ) )
 
 	def __mouseMove( self, viewportGadget, event ) :
 


### PR DESCRIPTION
PyImath relies on being able to use a signal handler for SIGFPE to turn floating point exceptions into Python exceptions. Arnold also has a signal handler for SIGFPE, and together they conspire to cause crashes. This is illustrated by the following code :

```
import imath
import arnold

c = imath.Color4f( float( "NaN" ), float( "NaN" ), float( "NaN" ), float( "NaN" ) )
try :
	c.rgb2hsv()
except Exception as e :
	print "1. Caught in Python", e

arnold.AiBegin()

try :
	c.rgb2hsv()
except Exception as e :
	print "2. Caught in Python", e
```

Which causes crashes in the following form :

```
1. Caught in Python Invalid floating-point operation.
00:00:00    96MB         | log started Thu Jul 30 13:28:59 2020
00:00:00    96MB         | Arnold 6.0.1.0 [25372a4c] linux clang-5.0.0 oiio-2.1.4 osl-1.11.0 vdb-4.0.0 clm-1.1.1.118 rlm-12.4.2 optix-6.5.0 2019/12/04 07:45:07
00:00:00    96MB         | running on localhost.localdomain, pid=3085
00:00:00    96MB         |  1 x Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz (6 cores, 12 logical) with 15786MB
00:00:00    96MB         |  NVIDIA driver version 430.40 (Optix 0)
00:00:00    96MB         |  CentOS Linux 7 (Core), Linux kernel 3.10.0-1062.9.1.el7.x86_64
00:00:00    96MB         |  soft limit for open files raised from 1024 to 4094
00:00:00    96MB         |
00:00:00    96MB         | loading plugins from /disk1/john/dev/build/gaffer/arnold/plugins ...
00:00:00    96MB         | loaded 1 plugins from 1 lib(s) in 0:00.01
00:00:00    96MB         | loading plugins from /disk1/apps/arnold/6.0.1.0/bin/../plugins ...
00:00:00    96MB         | loaded 4 plugins from 2 lib(s) in 0:00.00
00:00:00    96MB ERROR   | signal caught: SIGFPE -- Floating point exception

****
* Arnold 6.0.1.0 [25372a4c] linux clang-5.0.0 oiio-2.1.4 osl-1.11.0 vdb-4.0.0 clm-1.1.1.118 rlm-12.4.2 optix-6.5.0 2019/12/04 07:45:07
* CRASHED in Imath_2_3::rgb2hsv_d at 00:00:00
* signal caught: SIGFPE -- Floating point exception (invalid floating point operation)
*
* backtrace:
*  0 0x00007f783d48bc02 [libai.so                 ] AiPromptADPDialog
*  1 0x00007f784cfcc5ef [libpthread.so.0          ] _L_unlock_13                                                                                                                                  [funlockfile.c          :                   ?]
>> 2 0x00007f7843ccdaa3 [libImath-2_3.so.24       ] Imath_2_3::rgb2hsv_d(Imath_2_3::Color4<double> const&)                                                                                        [ImathColorAlgo.cpp     :152 (discriminator 2]
*  3 0x00007f7843ccdaa3 [libImath-2_3.so.24       ] Imath_2_3::rgb2hsv_d(Imath_2_3::Color4<double> const&)                                                                                        [ImathColorAlgo.cpp     :152 (discriminator 2]
*  4 0x00007f7844e12f78 [libPyImath.so.24         ] Imath_2_3::Color4<float> PyImath::rgb2hsv<float>(Imath_2_3::Color4<float>&)                                                                   [PyImathColor4.cpp      :                 227]
*  5 0x00007f7844ded40d [libPyImath.so.24         ] boost::python::objects::caller_py_function_impl<boost::python::detail::caller<Imath_2_3::Color4<float> (*)                                    [invoke.hpp             :                  75]
*  6 0x00007f784322915c [libboost_python.so.1.61.0] boost::python::objects::function::call(_object*, _object*)
*  7 0x00007f7843229367 [libboost_python.so.1.61.0]                                                                                                                                               [function.cpp           :                   ?]
*  8 0x00007f784322fc4a [libboost_python.so.1.61.0] boost::python::detail::exception_handler::operator()
*  9 0x00007f78427b46f2 [iexmodule.so             ] boost::detail::function::function_obj_invoker2<boost::_bi::bind_t<bool, boost::python::detail::translate_exception<Iex_2_3::BaseExc, void (*) [translate_exception.hpp:                  48]
* 10 0x00007f784322fa1e [libboost_python.so.1.61.0] boost::python::handle_exception_impl(boost::function0<void>)
* 11 0x00007f7843226748 [libboost_python.so.1.61.0] boost::python::detail::exception_handler::operator()                                                                                          [function.cpp           :                   ?]
* 12 0x00007f784d22dba2 [libpython2.7.so.1.0      ] PyObject_Call                                                                                                                                 [abstract.c             :                2547]
* 13 0x00007f784d2e4c96 [libpython2.7.so.1.0      ] PyEval_EvalFrameEx                                                                                                                            [ceval.c                :                4589]
* 14 0x00007f784d2e954b [libpython2.7.so.1.0      ] PyEval_EvalCodeEx                                                                                                                             [ceval.c                :                3604]
* 15 0x00007f784d2e9648 [libpython2.7.so.1.0      ] PyEval_EvalCode                                                                                                                               [ceval.c                :                 669]
* 16 0x00007f784d30db79 [libpython2.7.so.1.0      ] PyRun_FileExFlags                                                                                                                             [pythonrun.c            :                1385]
* 17 0x00007f784d30ef54 [libpython2.7.so.1.0      ] PyRun_SimpleFileExFlags                                                                                                                       [pythonrun.c            :                 957]
* 18 0x00007f784d3256f0 [libpython2.7.so.1.0      ] Py_Main                                                                                                                                       [main.c                 :645 (discriminator 4]
* 19 0x00007f784c508504 [libc.so.6                ] __libc_start_main
* 20 0x000000000040066d [                         ]
*
* loaded modules:
*    0x00007f783ca8a000  libai.so
*    0x00007f784cfbd000  libpthread.so.0
*    0x00007f003220726f  libImath-2_3.so.24
*    0x00007f78442e9000  libPyImath.so.24
*    0x00007f78431f8000  libboost_python.so.1.61.0
*    0x00007f784271a000  iexmodule.so
*    0x00007f784d1d9000  libpython2.7.so.1.0
*    0x00007f003420726f  libpython2.7.so.1.0
*    0x00007f784c4e6000  libc.so.6
*    0x0000000000400000
*
* memory: VM 579 MB, RSS 97 MB, 2 page faults
****
2. Caught in Python Floating-point exception.
00:00:00    92MB         |
00:00:00    92MB         | releasing resources
00:00:00    92MB         | Arnold shutdown
terminate called after throwing an instance of 'Iex_2_3::MathExc'
  what():  Floating-point exception.
```

Longer term we would hope that PyImath and Arnold can resolve their differences, but for now this hack appears sufficient to avoid crashing Gaffer. We do still have unprotected calls to `rgb2hsv()` in the ColorChooser, but I am hoping that they don't need a hack because they deal in user-entered numbers, and to my knowledge there's no way to enter nan/inf. If we need a better patch in the medium term then it probably makes sense to add our own `rgb2hsv()` binding in Cortex somewhere.
