### PR TITLE
TransformTool Fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -30,7 +30,9 @@ Fixes
   - Fixed bug which caused promoted Spreadsheet cells to be duplicated by copy/paste.
   - Prevented addition and removal of rows and columns for promoted Spreadsheets, as changes will be lost when reloading the reference.
 - DeleteSets : Fixed bug which allowed the deletion of Gaffer's internal `__lights`, `__cameras` and `__lightFilters` sets. These are now always preserved, because they are needed to output the scene for rendering.
-- TransformTool : Fixed handle orientation for transforms with negative scaling.
+- TransformTool :
+  - Fixed handle orientation for transforms with negative scaling.
+  - Fixed handle positions for locations with PointConstraints or ParentConstraints applied.
 - ImageReader/ImageWriter : Fixed handling of errors in Python functions registered using `setDefaultColorSpaceFunction()`.
 - StyleSheet : Fixed monospace font stack.
 - GafferUI : Fixed lingering highlight state if a Button was disabled whilst the cursor was over it.

--- a/Changes.md
+++ b/Changes.md
@@ -30,6 +30,7 @@ Fixes
   - Fixed bug which caused promoted Spreadsheet cells to be duplicated by copy/paste.
   - Prevented addition and removal of rows and columns for promoted Spreadsheets, as changes will be lost when reloading the reference.
 - DeleteSets : Fixed bug which allowed the deletion of Gaffer's internal `__lights`, `__cameras` and `__lightFilters` sets. These are now always preserved, because they are needed to output the scene for rendering.
+- TransformTool : Fixed handle orientation for transforms with negative scaling.
 - ImageReader/ImageWriter : Fixed handling of errors in Python functions registered using `setDefaultColorSpaceFunction()`.
 - StyleSheet : Fixed monospace font stack.
 - GafferUI : Fixed lingering highlight state if a Button was disabled whilst the cursor was over it.

--- a/Changes.md
+++ b/Changes.md
@@ -33,6 +33,7 @@ Fixes
 - TransformTool :
   - Fixed handle orientation for transforms with negative scaling.
   - Fixed handle positions for locations with PointConstraints or ParentConstraints applied.
+  - Fixed translation and rotation of locations with a ParentConstraint applied.
 - ImageReader/ImageWriter : Fixed handling of errors in Python functions registered using `setDefaultColorSpaceFunction()`.
 - StyleSheet : Fixed monospace font stack.
 - GafferUI : Fixed lingering highlight state if a Button was disabled whilst the cursor was over it.

--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,7 @@ Fixes
   - Fixed handle orientation for transforms with negative scaling.
   - Fixed handle positions for locations with PointConstraints or ParentConstraints applied.
   - Fixed translation and rotation of locations with a ParentConstraint applied.
+  - Fixed rotation of locations with negative scaling.
 - ImageReader/ImageWriter : Fixed handling of errors in Python functions registered using `setDefaultColorSpaceFunction()`.
 - StyleSheet : Fixed monospace font stack.
 - GafferUI : Fixed lingering highlight state if a Button was disabled whilst the cursor was over it.

--- a/include/GafferSceneUI/TransformTool.h
+++ b/include/GafferSceneUI/TransformTool.h
@@ -172,6 +172,7 @@ class GAFFERSCENEUI_API TransformTool : public GafferSceneUI::SelectionTool
 				void initFromSceneNode( const GafferScene::SceneAlgo::History *history );
 				void initWalk( const GafferScene::SceneAlgo::History *history, bool &editScopeFound );
 				void throwIfNotEditable() const;
+				Imath::M44f transformToLocalSpace() const;
 
 				GafferScene::ConstScenePlugPtr m_scene;
 				GafferScene::ScenePlug::ScenePath m_path;

--- a/include/GafferSceneUI/TransformTool.h
+++ b/include/GafferSceneUI/TransformTool.h
@@ -187,6 +187,7 @@ class GAFFERSCENEUI_API TransformTool : public GafferSceneUI::SelectionTool
 				Gaffer::EditScopePtr m_editScope;
 				mutable boost::optional<TransformEdit> m_transformEdit;
 				Imath::M44f m_transformSpace;
+				bool m_aimConstraint;
 
 		};
 

--- a/python/GafferSceneUITest/RotateToolTest.py
+++ b/python/GafferSceneUITest/RotateToolTest.py
@@ -403,5 +403,8 @@ class RotateToolTest( GafferUITest.TestCase ) :
 		tool["orientation"].setValue( tool.Orientation.Local )
 		self.assertEqual( tool.handlesTransform(), script["constraint"]["out"].transform( "/sphere" ) )
 
+		tool.rotate( imath.Eulerf( 0, 90, 0 ) )
+		self.assertEqual( script["sphere"]["transform"]["rotate"].getValue(), imath.V3f( 0, 90, 0 ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -1209,5 +1209,14 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 			)
 		)
 
+		# Check translation operation
+
+		tool["orientation"].setValue( tool.Orientation.Local )
+		tool.translate( imath.V3f( 1, 2, 3 ) )
+		self.assertEqual(
+			script["cube"]["transform"]["translate"].getValue(),
+			imath.V3f( 1, 2, 3 )
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -320,6 +320,43 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 			)
 		)
 
+	def testNegativeScale( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["plane"] = GafferScene.Plane()
+		script["plane"]["transform"]["scale"]["x"].setValue( -10 )
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["plane"]["out"] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/plane" ] ) )
+
+		tool = GafferSceneUI.TranslateTool( view )
+		tool["active"].setValue( True )
+		tool["orientation"].setValue( tool.Orientation.Local )
+
+		# We want the direction of the handles to reflect the
+		# flipped scale, but not its magnitude.
+
+		self.assertTrue(
+			tool.handlesTransform().equalWithAbsError(
+				imath.M44f().scale( imath.V3f( -1, 1, 1 ) ),
+				0.000001
+			)
+		)
+
+		# And the handles need to move the object in the right
+		# direction still.
+
+		tool.translate( imath.V3f( 1, 2, 3 ) )
+
+		self.assertTrue(
+			script["plane"]["transform"]["translate"].getValue().equalWithAbsError(
+				imath.V3f(-1, 2, 3),
+				0.000001
+			)
+		)
+
 	def testGroup( self ) :
 
 		script = Gaffer.ScriptNode()

--- a/src/GafferSceneUI/RotateTool.cpp
+++ b/src/GafferSceneUI/RotateTool.cpp
@@ -405,7 +405,8 @@ Imath::V3f RotateTool::Rotation::updatedRotateValue( const Gaffer::V3fPlug *rota
 	Quatf q = rotation.toQuat();
 	V3f transformSpaceAxis;
 	m_gadgetToTransform.multDirMatrix( q.axis(), transformSpaceAxis );
-	q.setAxisAngle( transformSpaceAxis, q.angle() );
+	float d = Imath::sign( m_gadgetToTransform.determinant() );
+	q.setAxisAngle( transformSpaceAxis, q.angle() * d );
 
 	// Compose it with the original.
 

--- a/src/GafferSceneUI/ScaleTool.cpp
+++ b/src/GafferSceneUI/ScaleTool.cpp
@@ -57,34 +57,6 @@ using namespace GafferScene;
 using namespace GafferSceneUI;
 
 //////////////////////////////////////////////////////////////////////////
-// Internal utilities
-//////////////////////////////////////////////////////////////////////////
-
-namespace
-{
-
-M44f signOnlyScaling( const M44f &m )
-{
-	V3f scale;
-	V3f shear;
-	V3f rotate;
-	V3f translate;
-
-	extractSHRT( m, scale, shear, rotate, translate );
-
-	M44f result;
-
-	result.translate( translate );
-	result.rotate( rotate );
-	result.shear( shear );
-	result.scale( V3f( sign( scale.x ), sign( scale.y ), sign( scale.z ) ) );
-
-	return result;
-}
-
-} // namespace
-
-//////////////////////////////////////////////////////////////////////////
 // ScaleTool
 //////////////////////////////////////////////////////////////////////////
 
@@ -126,20 +98,8 @@ bool ScaleTool::affectsHandles( const Gaffer::Plug *input ) const
 
 void ScaleTool::updateHandles( float rasterScale )
 {
-	const Selection &primarySelection = this->selection().back();
-
-	V3f translate, rotate, scale, pivot;
-	const M44f transform = primarySelection.transform( translate, rotate, scale, pivot );
-
-	M44f handlesMatrix = M44f().translate( pivot ) * transform * primarySelection.sceneToTransformSpace().inverse();
-	// We want to take the sign of the scaling into account so that
-	// our handles point in the right direction. But we don't want
-	// the magnitude because a non-uniform handle scale breaks the
-	// operation of the xy/xz/yz handles.
-	handlesMatrix = signOnlyScaling( handlesMatrix );
-
 	handles()->setTransform(
-		handlesMatrix
+		this->selection().back().orientedTransform( Local )
 	);
 
 	for( ScaleHandleIterator it( handles() ); !it.done(); ++it )

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -78,6 +78,25 @@ using namespace GafferSceneUI;
 namespace
 {
 
+M44f signOnlyScaling( const M44f &m )
+{
+	V3f scale;
+	V3f shear;
+	V3f rotate;
+	V3f translate;
+
+	extractSHRT( m, scale, shear, rotate, translate );
+
+	M44f result;
+
+	result.translate( translate );
+	result.rotate( rotate );
+	result.shear( shear );
+	result.scale( V3f( Imath::sign( scale.x ), Imath::sign( scale.y ), Imath::sign( scale.z ) ) );
+
+	return result;
+}
+
 int filterResult( const FilterPlug *filter, const ScenePlug *scene )
 {
 	FilterPlug::SceneScope scope( Context::current(), scene );
@@ -618,7 +637,7 @@ Imath::M44f TransformTool::Selection::orientedTransform( Orientation orientation
 		}
 	}
 
-	result = sansScaling( result );
+	result = signOnlyScaling( result );
 
 	// And reset the translation to put it where the pivot is
 

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -39,6 +39,7 @@
 #include "GafferSceneUI/SceneView.h"
 #include "GafferSceneUI/ContextAlgo.h"
 
+#include "GafferScene/AimConstraint.h"
 #include "GafferScene/EditScopeAlgo.h"
 #include "GafferScene/Group.h"
 #include "GafferScene/ObjectSource.h"
@@ -213,7 +214,7 @@ TransformTool::Selection::Selection(
 	const Gaffer::ConstContextPtr &context,
 	const Gaffer::EditScopePtr &editScope
 )
-	:	m_scene( scene ), m_path( path ), m_context( context ), m_editable( false ), m_editScope( editScope )
+	:	m_scene( scene ), m_path( path ), m_context( context ), m_editable( false ), m_editScope( editScope ), m_aimConstraint( false )
 {
 	Context::Scope scopedContext( context.get() );
 	if( path.empty() )
@@ -273,6 +274,8 @@ TransformTool::Selection::Selection(
 
 void TransformTool::Selection::initFromSceneNode( const GafferScene::SceneAlgo::History *history )
 {
+	// Check for SceneNode and return if there isn't one or it is disabled.
+
 	const SceneNode *node = runTimeCast<const SceneNode>( history->scene->node() );
 	if( !node )
 	{
@@ -284,6 +287,22 @@ void TransformTool::Selection::initFromSceneNode( const GafferScene::SceneAlgo::
 	{
 		return;
 	}
+
+	// Check for AimConstraints. These must be accounted for in `sceneToTransformSpace()`.
+
+	if( auto constraint = runTimeCast<const AimConstraint>( node ) )
+	{
+		if(
+			history->scene == constraint->outPlug() &&
+			( filterResult( constraint->filterPlug(), constraint->inPlug() ) & PathMatcher::ExactMatch )
+		)
+		{
+			m_aimConstraint = true;
+			return;
+		}
+	}
+
+	// Determine if node edits the transform at this location.
 
 	TransformPlug *transformPlug = nullptr;
 	if( const ObjectSource *objectSource = runTimeCast<const ObjectSource>( node ) )
@@ -587,23 +606,50 @@ Imath::M44f TransformTool::Selection::sceneToTransformSpace() const
 	//   to the parent location.
 	//
 	// To account for this we align the two scenes by finding the
-	// difference between the parent transforms of `path()` and
+	// difference between the full transforms of `path()` and
 	// `upstreamPath()`.
+	//
+	// This is made trickier by the presence of AimConstraints
+	// between `upstreamScene()` and `scene()`. These overwrite
+	// the local rotation from upstream, meaning we no longer have
+	// a direct correspondence between the upstream and downstream
+	// spaces. In this event we omit the local matrix entirely by
+	// aligning the parent transforms instead.
+	//
+	// \todo I suspect the truth of the situation is more nuanced
+	// than this and the correct approach depends on the type of
+	// constraint and its order of composition with the edits we make
+	// to the upstream transform. We are fortunate to be able to ignore
+	// PointConstraints for now because we only transform direction vectors
+	// with `sceneToTransformSpace()`. I'm sure there is a more principled
+	// approach than the blunt instrument used here.
 
 	M44f downstreamMatrix;
-	if( path().size() )
 	{
-		ScenePlug::ScenePath parentPath = path(); parentPath.pop_back();
 		Context::Scope scopedContext( context() );
-		downstreamMatrix = scene()->fullTransform( parentPath );
+		if( !m_aimConstraint )
+		{
+			downstreamMatrix = scene()->fullTransform( path() );
+		}
+		else if( path().size() )
+		{
+			ScenePlug::ScenePath parentPath = path(); parentPath.pop_back();
+			downstreamMatrix = scene()->fullTransform( parentPath );
+		}
 	}
 
 	M44f upstreamMatrix;
-	if( upstreamPath().size() )
 	{
-		ScenePlug::ScenePath upstreamParentPath = upstreamPath(); upstreamParentPath.pop_back();
 		Context::Scope scopedContext( upstreamContext() );
-		upstreamMatrix = upstreamScene()->fullTransform( upstreamParentPath );
+		if( !m_aimConstraint )
+		{
+			upstreamMatrix = upstreamScene()->fullTransform( upstreamPath() );
+		}
+		else if( upstreamPath().size() )
+		{
+			ScenePlug::ScenePath upstreamParentPath = upstreamPath(); upstreamParentPath.pop_back();
+			upstreamMatrix = upstreamScene()->fullTransform( upstreamParentPath );
+		}
 	}
 
 	return downstreamMatrix.inverse() * upstreamMatrix * transformSpace().inverse();

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -609,6 +609,25 @@ Imath::M44f TransformTool::Selection::sceneToTransformSpace() const
 	return downstreamMatrix.inverse() * upstreamMatrix * transformSpace().inverse();
 }
 
+Imath::M44f TransformTool::Selection::transformToLocalSpace() const
+{
+	throwIfNotEditable();
+
+	M44f downstreamMatrix;
+	{
+		Context::Scope scopedContext( context() );
+		downstreamMatrix = scene()->fullTransform( path() );
+	}
+
+	M44f upstreamMatrix;
+	{
+		Context::Scope scopedContext( upstreamContext() );
+		upstreamMatrix = upstreamScene()->fullTransform( upstreamPath() );
+	}
+
+	return transformSpace() * upstreamMatrix.inverse() * downstreamMatrix;
+}
+
 Imath::M44f TransformTool::Selection::orientedTransform( Orientation orientation ) const
 {
 	throwIfNotEditable();
@@ -645,7 +664,7 @@ Imath::M44f TransformTool::Selection::orientedTransform( Orientation orientation
 	transform( translate, rotate, scale, pivot );
 
 	const V3f transformSpacePivot = pivot + translate;
-	const V3f downstreamWorldPivot = transformSpacePivot * sceneToTransformSpace().inverse();
+	const V3f downstreamWorldPivot = transformSpacePivot * transformToLocalSpace();
 
 	result[3][0] = downstreamWorldPivot[0];
 	result[3][1] = downstreamWorldPivot[1];


### PR DESCRIPTION
This fixes several bugs in the TransformTools :

 - Handle orientation for transforms with negative scaling.
 - Handle positions for locations with PointConstraints or ParentConstraints applied.
 - Translation and rotation of locations with a ParentConstraint applied.
 - Rotation of locations with negative scaling.

It's a rather attritional affair, and bd9a023 in particular is rather unsatisfactory : it makes worthwhile fixes for the cases we're most likely to encounter but falls short of a general solution.
