### PR TITLE
NodeEditor : Cache recently used NodeUIs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ Improvements
 - AnimationEditor : Improved performance.
 - MessageWidget : Added alternate presentation options allowing log-style message display, search, etc.
 - Viewer : Added warning/error message count to Render Control overlay.
+- NodeEditor : Improved performance when switching back to a recently viewed node.
 
 Fixes
 -----

--- a/python/GafferUI/NodeEditor.py
+++ b/python/GafferUI/NodeEditor.py
@@ -84,6 +84,13 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 			)
 
 		self.__nodeUI = None
+		# Building NodeUIs is slower than we would like, so we keep
+		# a small cache of recently displayed UIs so we can switch
+		# between them quickly.
+		self.__nodeUICache = IECore.LRUCache(
+			lambda node : ( GafferUI.NodeUI.create( node ), 1 ),
+			5
+		)
 		self.__readOnly = False
 
 		self._updateFromSet()
@@ -160,7 +167,7 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 
 		self.__header.setVisible( True )
 
-		self.__nodeUI = GafferUI.NodeUI.create( node )
+		self.__nodeUI = self.__nodeUICache.get( node )
 		self.__nodeUI.setReadOnly( self.getReadOnly() )
 		self.__nodeUIFrame.setChild( self.__nodeUI )
 


### PR DESCRIPTION
This gives a faster response for the common operation of switching back to a recently viewed node.

This seems like a pretty decent win for very little effort. But it does mean keeping more NodeUIs around in the background, which means more connections to the static Metadata changed signals. I think perhaps we need to increase the granularity of Metadata signalling before we can confidently consider merging this. Thoughts?