### PR TITLE
SceneView : Fix Inspector plug metadata observation

### DIFF
--- a/python/GafferSceneUI/_SceneViewInspector.py
+++ b/python/GafferSceneUI/_SceneViewInspector.py
@@ -224,7 +224,7 @@ class _SceneViewInspector( GafferUI.Widget ) :
 		# As we don't fully understand which nodes/plugs affect our ability to edit (as the network
 		# inside the edit scope is effectively opaque to us), we only need to know if the plugs
 		# node was affected.
-		self.__nodeMetadataChanged( typeId, key, plug.node() )
+		self.__nodeMetadataChanged( typeId, key, plug.node() if plug is not None else None )
 
 	def __nodeMetadataChanged( self, typeId, key, node ) :
 


### PR DESCRIPTION
Calls such as `Gaffer.Metadata.registerValue( <cls>, "<plug>", ... )` result in `None` being passed for `plug` in the plug changed callback.