### PR TITLE
Filter : Declare dependency cycles

### DIFF
--- a/python/GafferSceneTest/SetFilterTest.py
+++ b/python/GafferSceneTest/SetFilterTest.py
@@ -290,5 +290,25 @@ class SetFilterTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual( monitor.plugStatistics( setFilter["__expressionResult"] ).hashCount, 1 )
 
+	def testTwoAffectedScenes( self ) :
+
+		setNode = GafferScene.Set()
+		setFilter = GafferScene.SetFilter()
+
+		prune = GafferScene.Prune()
+		prune["in"].setInput( setNode["out"] )
+		prune["filter"].setInput( setFilter["out"] )
+
+		isolate = GafferScene.Isolate()
+		isolate["in"].setInput( prune["out"] )
+		isolate["filter"].setInput( setFilter["out"] )
+
+		cs = GafferTest.CapturingSlot( prune.plugDirtiedSignal(), isolate.plugDirtiedSignal() )
+		setNode["name"].setValue( "test" )
+
+		self.assertTrue(
+			{ x[0] for x in cs }.issuperset( { prune["filter"], isolate["filter"] } )
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/Set.cpp
+++ b/src/GafferScene/Set.cpp
@@ -138,31 +138,31 @@ void Set::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) 
 {
 	FilteredSceneProcessor::affects( input, outputs );
 
-	if( inPlug()->setNamesPlug() == input )
+	if(
+		input == inPlug()->setNamesPlug() ||
+		input == modePlug() ||
+		input == namePlug()
+	)
 	{
 		outputs.push_back( outPlug()->setNamesPlug() );
 	}
-	else if( inPlug()->setPlug() == input )
+
+	if(
+		input == namePlug() ||
+		input == inPlug()->setPlug() ||
+		input == modePlug() ||
+		input == pathMatcherPlug()
+	)
 	{
 		outputs.push_back( outPlug()->setPlug() );
 	}
-	else if( modePlug() == input )
-	{
-		outputs.push_back( outPlug()->setNamesPlug() );
-		outputs.push_back( outPlug()->setPlug() );
-	}
-	else if( namePlug() == input )
-	{
-		outputs.push_back( outPlug()->setNamesPlug() );
-		outputs.push_back( outPlug()->setPlug() );
-	}
-	else if( pathsPlug() == input || filterResultsPlug() == input )
+
+	if(
+		input == pathsPlug() ||
+		input == filterResultsPlug()
+	)
 	{
 		outputs.push_back( pathMatcherPlug() );
-	}
-	else if( pathMatcherPlug() == input )
-	{
-		outputs.push_back( outPlug()->setPlug() );
 	}
 }
 


### PR DESCRIPTION
As noted in the comment, we end up creating cycles because `DependencyNode::affects()` is context-free. But in practice, the cycle never arises during compute because all edges of the cycle do not share the same context. Before the fix, the test case would error after capturing an error message reporting the cycle.