### PR TITLE
Update gaffer dependencies to run tests with Qt 5.12.5

### DIFF
--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -41,9 +41,16 @@ import urllib
 import hashlib
 
 # Determine default archive URL.
-
-platform = "osx" if sys.platform == "darwin" else "linux"
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/1.6.0/gafferDependencies-1.6.0-" + platform + ".tar.gz"
+dependencies = {
+	"version" : "2.0.0",
+	"versionSuffix" : "a5",
+	"pythonVersion" : "Python2",
+	"platform" : "osx" if sys.platform == "darwin" else "linux"
+}
+defaultURL = (
+	"https://github.com/GafferHQ/dependencies/releases/download/"
+	"{deps[version]}{deps[versionSuffix]}/gafferDependencies-{deps[version]}-{deps[pythonVersion]}-{deps[platform]}.tar.gz"
+).format(deps=dependencies)
 
 # Parse command line arguments.
 

--- a/python/GafferUITest/QtTest.py
+++ b/python/GafferUITest/QtTest.py
@@ -1,7 +1,6 @@
-#! /bin/bash
 ##########################################################################
 #
-#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2020, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -35,34 +34,16 @@
 #
 ##########################################################################
 
-set -e
+import unittest
 
-# Figure out where we'll be making the build
+import Gaffer
+import GafferUI
+import GafferUITest
 
-gafferMilestoneVersion=`grep "gafferMilestoneVersion = " SConstruct | cut -d" " -f 3`
-gafferMajorVersion=`grep "gafferMajorVersion = " SConstruct | cut -d" " -f 3`
-gafferMinorVersion=`grep "gafferMinorVersion = " SConstruct | cut -d" " -f 3`
-gafferPatchVersion=`grep "gafferPatchVersion = " SConstruct | cut -d" " -f 3`
+class QtTest( GafferUITest.TestCase ) :
+    def testQApplication( self ):
+        import Qt
+        self.assertIsInstance( Qt.QtWidgets.QApplication.instance(), Qt.QtWidgets.QApplication )
 
-if [[ `uname` = "Linux" ]] ; then
-	platform=linux
-else
-	platform=osx
-fi
-
-# The first argument can be used to specify a directory to install to
-buildDir=${1:-"build/gaffer-$gafferMilestoneVersion.$gafferMajorVersion.$gafferMinorVersion.$gafferPatchVersion-$platform"}
-
-# Get the prebuilt dependencies package and unpack it into the build directory
-
-dependenciesVersion="2.0.0"
-dependenciesVersionSuffix="a5"
-dependenciesPythonVersion="Python2"
-dependenciesFileName="gafferDependencies-$dependenciesVersion-$dependenciesPythonVersion-$platform.tar.gz"
-downloadURL="https://github.com/GafferHQ/dependencies/releases/download/$dependenciesVersion$dependenciesVersionSuffix/$dependenciesFileName"
-
-echo "Downloading dependencies \"$downloadURL\""
-curl -L $downloadURL > $dependenciesFileName
-
-mkdir -p $buildDir
-tar xf $dependenciesFileName -C $buildDir --strip-components=1
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 from .TestCase import TestCase
+from .QtTest import QtTest
 from .WidgetTest import WidgetTest
 from .MenuTest import MenuTest
 from .SplitContainerTest import SplitContainerTest


### PR DESCRIPTION
*DO NOT MERGE*

I recently discovered that PySide v5.12 is returning the incorrect type when calling `Qt.QtWidgets.QApplication.instance()`. This PR is simply to kick off the gaffer tests with the latest dependencies to see if gaffer will run into the same issues.
