### PR TITLE
SceneNode : Use TaskCollaboration policy for `childBounds` computation 

### DIFF
--- a/python/GafferSceneTest/PruneTest.py
+++ b/python/GafferSceneTest/PruneTest.py
@@ -107,6 +107,29 @@ class PruneTest( GafferSceneTest.SceneTestCase ) :
 		self.assertSceneHashesEqual( input["out"], prune["out"] )
 		self.assertTrue( input["out"].object( "/groupA/sphereAA", _copy = False ).isSame( prune["out"].object( "/groupA/sphereAA", _copy = False ) ) )
 
+		# The pass through should also apply to the `childBounds` plug, which is automatically
+		# computed by SceneNode/SceneProcessor.
+
+		for path in [
+			"/",
+			"/groupA",
+			"/groupB",
+			"/groupA/sphereAA",
+			"/groupA/sphereAB",
+			"/groupB/sphereBA",
+			"/groupB/sphereBB",
+		] :
+
+			self.assertEqual(
+				prune["out"].childBoundsHash( path ),
+				prune["in"].childBoundsHash( path ),
+			)
+
+			self.assertEqual(
+				prune["out"].childBounds( path ),
+				prune["in"].childBounds( path ),
+			)
+
 	def testPruning( self ) :
 
 		sphere = IECoreScene.SpherePrimitive()

--- a/src/GafferScene/SceneNode.cpp
+++ b/src/GafferScene/SceneNode.cpp
@@ -576,7 +576,7 @@ void SceneNode::hashChildBounds( const Gaffer::Context *context, const ScenePlug
 	using Range = blocked_range<size_t>;
 	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
 
-	h = parallel_deterministic_reduce(
+	const IECore::MurmurHash reduction = parallel_deterministic_reduce(
 		Range( 0, childNames.size() ),
 		h,
 		[&] ( const Range &range, const MurmurHash &hash ) {
@@ -605,6 +605,8 @@ void SceneNode::hashChildBounds( const Gaffer::Context *context, const ScenePlug
 		simple_partitioner(),
 		taskGroupContext
 	);
+
+	h.append( reduction );
 }
 
 Imath::Box3f SceneNode::computeChildBounds( const Gaffer::Context *context, const ScenePlug *parent ) const

--- a/src/GafferScene/SceneNode.cpp
+++ b/src/GafferScene/SceneNode.cpp
@@ -57,25 +57,6 @@ GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( SceneNode );
 
 size_t SceneNode::g_firstPlugIndex = 0;
 
-ValuePlug::CachePolicy childBoundsCachePolicy()
-{
-	ValuePlug::CachePolicy result = ValuePlug::CachePolicy::TaskIsolation;
-	if( const char *policy = getenv( "GAFFERSCENE_CHILDBOUNDS_CACHEPOLICY"  ))
-	{
-		if( !strcmp( policy, "TaskCollaboration" ) )
-		{
-			result = ValuePlug::CachePolicy::TaskCollaboration;
-		}
-		else if( strcmp( policy, "TaskIsolation" ) )
-		{
-			IECore::msg( IECore::Msg::Warning, "SceneNode", "Invalid value for GAFFERSCENE_CHILDBOUNDS_CACHEPOLICY. Must be TaskIsolation or TaskCollaboration." );
-		}
-	}
-	return result;
-}
-
-const ValuePlug::CachePolicy g_childBoundsCachePolicy = childBoundsCachePolicy();
-
 SceneNode::SceneNode( const std::string &name )
 	:	ComputeNode( name )
 {
@@ -433,7 +414,7 @@ Gaffer::ValuePlug::CachePolicy SceneNode::hashCachePolicy( const Gaffer::ValuePl
 	{
 		if( output == parent->childBoundsPlug() )
 		{
-			return g_childBoundsCachePolicy;
+			return ValuePlug::CachePolicy::TaskCollaboration;
 		}
 	}
 
@@ -446,7 +427,7 @@ Gaffer::ValuePlug::CachePolicy SceneNode::computeCachePolicy( const Gaffer::Valu
 	{
 		if( output == parent->childBoundsPlug() )
 		{
-			return g_childBoundsCachePolicy;
+			return ValuePlug::CachePolicy::TaskCollaboration;
 		}
 	}
 


### PR DESCRIPTION
This fixes a hang that would otherwise be triggered by the additions to `PruneTest.testPassThrough()`, which exercise the pass-through code in `SceneProcessor::hash()` and `SceneProcessor::compute()`.

The underlying issue is that when a node implements a pass-through, the output and source plugs share the same hash, and therefore the same cache entry. The cache holds a lock while running the compute (to prevent other threads repeating the work redundantly), but the compute pulls on the upstream source, which leads back to an access to the _same_ cache entry (because it has the same hash). Deadlock ensues.

This is fixed by using the TaskCollaboration policy because the TaskMutex has additional machinery to support reentrancy for that case. TaskCollaboration does have some additional overhead compared to TaskIsolation, but our initial production tests with GAFFERSCENE_CHILDBOUNDS_CACHEPOLICY seemed to suggest little difference either way (@murrays-ie, please can you confirm that I'm not mistaken here?). The overhead would be more worrying in the case of very cheap pass-through computations such as those in `testPassThrough()`, but in practice those should not occur in any frequency for `childBoundsPlug()`. The plug is primarily - so far exclusively - used to aid in bounds propagation and that only occurs for enabled nodes.

Ditching the TaskIsolation in favour of TaskCollaboration is consistent with our hopes for the future of the cache policies, which can be summarised as follows :

- `TaskIsolation` should be removed. If a compute is slow enough that it requires a parallel implementation, then we really want any waiting threads to collaborate on the work rather than do nothing. Any time we are using TaskIsolation we are hoping that the nature of the graph won't lead to waiting threads, but since users construct the graphs, this is not something we can guarantee. TBB's new `isolated_task_group` feature may hold the key to implementing TaskMutex without the overhead of the TBB arena, making `TaskCollaboration` a no-brainer in preference to `TaskIsolation`.
- `Legacy` is not as undesirable as we thought, and should in fact remain as the default. Where a compute is lightweight, we should prefer to allow threads to do redundant work without taking a lock, as it allows those threads to reach upstream computes involving TaskCollaboration.
- `Standard` has very limited use. If a compute is slow enough to warrant locking, then it should be given a parallel implementation using the TaskCollaboration policy. Only if no parallel implementation is possible should `Standard` be used. We would expect this typically to only make sense for computes doing I/O, where no further upstream computes exist.

An alternative fix would be to perform a manual check on the parent ComputeProcess before calling `cache.get()`, and if the parent process is for the same hash, avoid re-entering the cache. I did have this implemented a long while ago in an earlier CachePolicy prototype, but it is has its own overhead and is not as elegant as just using the re-entrancy already provided by TaskCollaboration.