### PR TITLE
InteractiveRender : Fix illegal plug set during dirty proagation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -158,7 +158,9 @@ Breaking Changes
     - BoolPlugValueWidget
     - PresetsPlugValueWidget
   - Removed connections to `plugFlagsChangedSignal()`. In the unlikely event that a derived class depends on plug flags, it must now manage the updates itself.
-- InteractiveRender : Changed base class from Node to ComputeNode, added members.
+- InteractiveRender :
+  - Changed base class from Node to ComputeNode, added members.
+  - `state` and `renderer` plugs can no longer be connected to compute node outputs due to dirty propagation constraints.
 - MessageWidget : Removed deprecated `appendMessage` method, use `messageHandler().handle()` instead.
 - Shader : Added virtual method.
 - MetadataAlgo : `readOnly( None )` will now raise an Exception instead of returning `False`.

--- a/include/GafferScene/InteractiveRender.h
+++ b/include/GafferScene/InteractiveRender.h
@@ -109,6 +109,8 @@ class GAFFERSCENE_API InteractiveRender : public Gaffer::ComputeNode
 
 		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
 
+		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
+
 	private :
 
 		ScenePlug *adaptedInPlug();
@@ -120,7 +122,7 @@ class GAFFERSCENE_API InteractiveRender : public Gaffer::ComputeNode
 		void messagesChanged();
 		static void messagesChangedUI();
 
-		void plugDirtied( const Gaffer::Plug *plug );
+		void plugSet( const Gaffer::Plug *plug );
 
 		void update();
 		Gaffer::ConstContextPtr effectiveContext();

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -39,6 +39,8 @@ import inspect
 import unittest
 import imath
 
+import six
+
 import IECore
 import IECoreScene
 import IECoreImage
@@ -2067,6 +2069,28 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( c, imath.Color3f( 0, 0, 0 ) )
 
 			s["renderer"]["state"].setValue( s["renderer"].State.Stopped )
+
+	def testAcceptsInput( self ) :
+
+		r = GafferScene.InteractiveRender()
+
+		p = Gaffer.StringPlug()
+		r["renderer"].setInput( p )
+		r["renderer"].setInput( None )
+
+		s = GafferTest.StringInOutNode()
+		with six.assertRaisesRegex( self, Exception, 'Plug "%s.renderer" rejects input "StringInOutNode.out".' % r.getName() ) :
+			r["renderer"].setInput( s["out"] )
+
+		r = self._createInteractiveRender()
+
+		p = Gaffer.IntPlug()
+		r["state"].setInput( p )
+		r["state"].setInput( None )
+
+		a = GafferTest.AddNode()
+		with six.assertRaisesRegex( self, Exception, 'Plug "%s.state" rejects input "AddNode.sum".' % r.getName() ) :
+			r["state"].setInput( a["sum"] )
 
 	def tearDown( self ) :
 


### PR DESCRIPTION
We'd accidentally been setting plugs during dirty propagation. This caused the message log clear at the start of a render to be ignored, leaving any output from a previous render visible.

This moves updates to plugSet instead of plugDirtied. Hopefuly this won't cause any practical problems.
