### PR TITLE
SetUI : Improve organisation of sets submenu

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,14 @@
 0.56.2.x (relative to 0.56.2.5)
 ========
 
+Improvements
+------------
+
+- Sets : Improved organisation of the set expression menu, sub menus are created for each `_` or `:` in the set name.
+
+Fixes
+-----
+
 - Viewer : Fixed crashes that could be caused by invalid pixel values.
 
 0.56.2.5 (relative to 0.56.2.4)

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -237,7 +237,12 @@ def __setsPopupMenu( menuDefinition, plugValueWidget ) :
 				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
 			}
 
-		menuDefinition.prepend( "/Sets/%s" % setName, parameters )
+		# Group sets based on any underscores or colons in their names
+		# eg: RND:prop_table -> RND > prop > table
+		nameParts = setName.replace( ":", "_" ).split( "_" )
+		path = "/".join( nameParts )
+
+		menuDefinition.prepend( "/Sets/%s" % path, parameters )
 
 GafferUI.PlugValueWidget.popupMenuSignal().connect( __setsPopupMenu, scoped = False )
 


### PR DESCRIPTION
Production has regularly seen scene with more sets that fit on a 24" monitor, with the menu _filling the entire screen_. This is a short-term band-aid to try and make this many sets more manageable.

![unnamed](https://user-images.githubusercontent.com/896779/89655494-21c47680-d8c2-11ea-9c72-360b0874513e.png)

Sub menus are created for each `:` or `_` in the set name.
