### PR TITLE
GitHub Actions : Switch to dependencies 2.0.0a5 and build docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
             os: ubuntu-16.04
             buildType: RELEASE
             containerImage: gafferhq/build:1.1.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.6.0/gafferDependencies-1.6.0-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.0.0a5/gafferDependencies-2.0.0-Python2-linux.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -51,7 +51,7 @@ jobs:
             os: ubuntu-16.04
             buildType: DEBUG
             containerImage: gafferhq/build:1.1.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.6.0/gafferDependencies-1.6.0-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.0.0a5/gafferDependencies-2.0.0-Python2-linux.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -69,7 +69,7 @@ jobs:
             os: macos-10.15
             buildType: RELEASE
             containerImage:
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.6.0/gafferDependencies-1.6.0-osx.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.0.0a5/gafferDependencies-2.0.0-Python2-osx.tar.gz
             testRunner: bash -c
             sconsCacheMegabytes: 400
 
@@ -122,6 +122,10 @@ jobs:
     - name: Build
       run: |
        scons -j 2 build ENV_VARS_TO_IMPORT=PATH BUILD_TYPE=${{ matrix.buildType }} DELIGHT_ROOT=$DELIGHT ARNOLD_ROOT= BUILD_DIR=./build BUILD_CACHEDIR=sconsCache
+
+    - name: Docs
+      run: |
+       scons -j 2 docs ENV_VARS_TO_IMPORT=PATH BUILD_TYPE=${{ matrix.buildType }} DELIGHT_ROOT=$DELIGHT ARNOLD_ROOT= BUILD_DIR=./build BUILD_CACHEDIR=sconsCache
 
     - name: Test
       run: |

--- a/doc/source/WorkingWithTheNodeGraph/SpreadsheetNode/screengrab.py
+++ b/doc/source/WorkingWithTheNodeGraph/SpreadsheetNode/screengrab.py
@@ -2,10 +2,12 @@
 
 import sys
 import os
+import six
 import subprocess32 as subprocess
 import tempfile
 import time
 
+import Qt
 from Qt import QtCore, QtWidgets
 
 import imath
@@ -77,7 +79,11 @@ def __grabPlugContextSubmenu( plugWidget, contextMenuWidget, submenuWidget, menu
 	if windowHandle :
 		screen = windowHandle.screen()
 
-	pixmapMain = screen.grabWindow( long( mainWindow._qtWidget().winId() ) )
+	qtVersion = [ int( x ) for x in Qt.__qt_version__.split( "." ) ]
+	if qtVersion >= [ 5, 12 ] or six.PY3 :
+		pixmapMain = screen.grabWindow( mainWindow._qtWidget().winId() )
+	else :
+		pixmapMain = screen.grabWindow( long( mainWindow._qtWidget().winId() ) )
 
 	## Screengrab the context menu. The frame dimensions are too big by
 	# one pixel on each axis.


### PR DESCRIPTION
Test PR to check if deps updates resolve mac docs build hangs.