### PR TITLE
 GafferScene : Fix `childBoundsPlug()` dependency bugs 

### DIFF
--- a/python/GafferOSLTest/OSLObjectTest.py
+++ b/python/GafferOSLTest/OSLObjectTest.py
@@ -1008,33 +1008,31 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 
 		cs = GafferTest.CapturingSlot( o.plugDirtiedSignal() )
 
-		s["transform"]["translate"]["x"].setValue( 1 )
-		def checkAffected( expected ):
+		def checkAffected( expected ) :
+
 			self.assertEqual(
-				[ i[0].getName() for i in cs if i[0].parent() == o["out"] and not i[0].getName().startswith( "__" ) ],
-				expected
+				{ i[0].getName() for i in cs if i[0].parent() == o["out"] },
+				set( expected )
 			)
 			del cs[:]
+
+		s["transform"]["translate"]["x"].setValue( 1 )
 		checkAffected( [ "transform", "bound", "childBounds" ] )
 
 		o["useTransform"].setValue( True )
-
 		checkAffected( [ "object", "bound", "childBounds" ] )
 
 		s["transform"]["translate"]["x"].setValue( 2 )
-
 		checkAffected( [ "transform", "object", "bound", "childBounds" ] )
 
 		a["attributes"][0]["value"].setValue( 1 )
-		checkAffected( ["attributes" ] )
+		checkAffected( [ "attributes" ] )
 
 		o["useAttributes"].setValue( True )
-
 		checkAffected( [ "object", "bound", "childBounds" ] )
 
 		a["attributes"][0]["value"].setValue( 2 )
-
-		checkAffected( ["attributes", "object", "bound", "childBounds" ] )
+		checkAffected( [ "attributes", "object", "bound", "childBounds" ] )
 
 	def testBoundsUpdate( self ) :
 

--- a/python/GafferSceneTest/PruneTest.py
+++ b/python/GafferSceneTest/PruneTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import imath
 
 import IECore
 import IECoreScene
@@ -336,6 +337,25 @@ class PruneTest( GafferSceneTest.SceneTestCase ) :
 						self.assertTrue( inputSetPath not in outputSet )
 					else :
 						self.assertTrue( inputSetPath in outputSet )
+
+	def testNameChangeUpdatesBounds( self ) :
+
+		plane = GafferScene.Plane()
+		group = GafferScene.Group()
+		group["in"][0].setInput( plane["out"] )
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		prune = GafferScene.Prune()
+		prune["in"].setInput( plane["out"] )
+		prune["filter"].setInput( planeFilter["out"] )
+		prune["adjustBounds"].setValue( True )
+
+		self.assertEqual( prune["out"].bound( "/" ), imath.Box3f() )
+
+		plane["name"].setValue( "youCantPruneMe" )
+		self.assertEqual( prune["out"].bound( "/" ), plane["out"].bound( "/" ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/SubTreeTest.py
+++ b/python/GafferSceneTest/SubTreeTest.py
@@ -214,7 +214,7 @@ class SubTreeTest( GafferSceneTest.SceneTestCase ) :
 
 		s = GafferScene.SubTree()
 
-		for n in s["in"].keys() :
+		for n in [ "bound", "transform", "attributes", "object", "childNames", "set" ] :
 			a = s.affects( s["in"][n] )
 			self.assertEqual( len( a ), 1 )
 			self.assertTrue( a[0].isSame( s["out"][n] ) )

--- a/python/GafferTest/DependencyNodeTest.py
+++ b/python/GafferTest/DependencyNodeTest.py
@@ -38,6 +38,7 @@
 import unittest
 import threading
 import collections
+import six
 
 import IECore
 
@@ -691,6 +692,39 @@ class DependencyNodeTest( GafferTest.TestCase ) :
 		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Error )
 		self.assertEqual( mh.messages[0].context, "BadAffects::affects()" )
 		self.assertEqual( mh.messages[0].message, "TypeError: No registered converter was able to extract a C++ reference to type Gaffer::Plug from this Python object of type NoneType\n" )
+
+	def testDependencyCyclesDontStopPlugsDirtying( self ) :
+
+		nodes = [ GafferTest.MultiplyNode( "node{}".format( i ) ) for i in range( 0, 10 ) ]
+		cs = GafferTest.CapturingSlot( *[ n.plugDirtiedSignal() for n in nodes ] )
+
+		with IECore.CapturingMessageHandler() as mh :
+			for i, node in enumerate( nodes ) :
+				node["op1"].setInput( nodes[i-1]["product"] )
+
+		self.assertEqual(
+			{ x[0] for x in cs },
+			{ n["op1"] for n in nodes } | { n["product"] for n in nodes }
+		)
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Error )
+		self.assertEqual( mh.messages[0].context, "Plug dirty propagation" )
+		six.assertRegex( self, mh.messages[0].message, r"Cycle detected between node.* and node.*" )
+
+		del cs[:]
+		with IECore.CapturingMessageHandler() as mh :
+			nodes[0]["op2"].setValue( 10 )
+
+		self.assertEqual(
+			{ x[0] for x in cs },
+			{ n["op1"] for n in nodes } | { n["product"] for n in nodes } | { nodes[0]["op2"] }
+		)
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Error )
+		self.assertEqual( mh.messages[0].context, "Plug dirty propagation" )
+		six.assertRegex( self, mh.messages[0].message, r"Cycle detected between node.* and node.*" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -868,11 +868,14 @@ class Plug::DirtyPlugs
 
 			void back_edge( const EdgeDescriptor &e, const Graph &graph )
 			{
-				throw IECore::Exception( boost::str(
-					boost::format( "Cycle detected between %1% and %2%" ) %
-					graph[boost::target( e, graph )]->fullName() %
-					graph[boost::source( e, graph )]->fullName()
-				) );
+				IECore::msg(
+					IECore::Msg::Error, "Plug dirty propagation",
+					boost::str(
+						boost::format( "Cycle detected between %1% and %2%" ) %
+							graph[boost::target( e, graph )]->fullName() %
+							graph[boost::source( e, graph )]->fullName()
+					)
+				);
 			}
 
 			void finish_vertex( const VertexDescriptor &u, const Graph &graph )

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -110,6 +110,7 @@ BranchCreator::BranchCreator( const std::string &name )
 	filteredPathsPlug()->setInput( filterResults->outPlug() );
 
 	outPlug()->globalsPlug()->setInput( inPlug()->globalsPlug() );
+	outPlug()->childBoundsPlug()->setFlags( Plug::AcceptsDependencyCycles, true );
 }
 
 BranchCreator::~BranchCreator()
@@ -174,6 +175,7 @@ void BranchCreator::affects( const Plug *input, AffectedPlugsContainer &outputs 
 		input == parentPathsPlug() ||
 		input == mappingPlug() ||
 		input == inPlug()->boundPlug() ||
+		input == outPlug()->childBoundsPlug() ||
 		affectsBranchBound( input )
 	)
 	{

--- a/src/GafferScene/CollectScenes.cpp
+++ b/src/GafferScene/CollectScenes.cpp
@@ -111,6 +111,8 @@ CollectScenes::CollectScenes( const std::string &name )
 	addChild( new StringVectorDataPlug( "rootNames", Plug::In, new StringVectorData() ) );
 	addChild( new StringPlug( "rootNameVariable", Plug::In, "collect:rootName" ) );
 	addChild( new StringPlug( "sourceRoot", Plug::In, "/" ) );
+
+	outPlug()->childBoundsPlug()->setFlags( Plug::AcceptsDependencyCycles, true );
 }
 
 CollectScenes::~CollectScenes()
@@ -151,28 +153,70 @@ void CollectScenes::affects( const Gaffer::Plug *input, AffectedPlugsContainer &
 {
 	SceneProcessor::affects( input, outputs );
 
-	if( input == rootNamesPlug() || input == inPlug()->existsPlug() )
+	const bool affectsSceneScope =
+		input == rootNameVariablePlug() ||
+		input == sourceRootPlug()
+	;
+
+	if(
+		input == outPlug()->childBoundsPlug() ||
+		affectsSceneScope ||
+		input == inPlug()->boundPlug()
+	)
+	{
+		outputs.push_back( outPlug()->boundPlug() );
+	}
+
+	if( affectsSceneScope || input == inPlug()->transformPlug() )
+	{
+		outputs.push_back( outPlug()->transformPlug() );
+	}
+
+	if( affectsSceneScope || input == inPlug()->attributesPlug() )
+	{
+		outputs.push_back( outPlug()->attributesPlug() );
+	}
+
+	if( affectsSceneScope || input == inPlug()->objectPlug() )
+	{
+		outputs.push_back( outPlug()->objectPlug() );
+	}
+
+	if(
+		input == rootNamesPlug() ||
+		affectsSceneScope ||
+		input == inPlug()->existsPlug() ||
+		input == inPlug()->childNamesPlug()
+	)
 	{
 		outputs.push_back( outPlug()->childNamesPlug() );
 	}
-	else if(
+
+	if(
+		input == outPlug()->childNamesPlug() ||
 		input == rootNameVariablePlug() ||
-		input == sourceRootPlug()
+		input == inPlug()->globalsPlug()
 	)
 	{
-		for( PlugIterator it( outPlug() ); !it.done(); ++it )
-		{
-			outputs.push_back( it->get() );
-		}
-	}
-	else if( input->parent<ScenePlug>() == inPlug() )
-	{
-		outputs.push_back( outPlug()->getChild<Plug>( input->getName() ) );
-	}
-	else if( input == outPlug()->childNamesPlug() )
-	{
 		outputs.push_back( outPlug()->globalsPlug() );
+	}
+
+	if(
+		input == outPlug()->childNamesPlug() ||
+		input == inPlug()->setNamesPlug() ||
+		input == rootNameVariablePlug()
+	)
+	{
 		outputs.push_back( outPlug()->setNamesPlug() );
+	}
+
+	if(
+		input == outPlug()->childNamesPlug() ||
+		input == inPlug()->setPlug() ||
+		input == sourceRootPlug() ||
+		input == rootNameVariablePlug()
+	)
+	{
 		outputs.push_back( outPlug()->setPlug() );
 	}
 }

--- a/src/GafferScene/Deformer.cpp
+++ b/src/GafferScene/Deformer.cpp
@@ -65,6 +65,7 @@ void Deformer::init()
 	addChild( new BoolPlug( "adjustBounds", Plug::In, true ) );
 	// Remove pass-through created by base class
 	outPlug()->boundPlug()->setInput( nullptr );
+	outPlug()->childBoundsPlug()->setFlags( Plug::AcceptsDependencyCycles, true );
 }
 
 Deformer::~Deformer()
@@ -85,7 +86,15 @@ void Deformer::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outpu
 {
 	ObjectProcessor::affects( input, outputs );
 
-	if( input == outPlug()->objectPlug() || input == inPlug()->boundPlug() || input == adjustBoundsPlug() )
+	if(
+		input == adjustBoundsPlug() ||
+		input == filterPlug() ||
+		input == outPlug()->objectPlug() ||
+		input == inPlug()->objectPlug() ||
+		input == outPlug()->childBoundsPlug() ||
+		input == inPlug()->childBoundsPlug() ||
+		input == inPlug()->boundPlug()
+	)
 	{
 		outputs.push_back( outPlug()->boundPlug() );
 	}

--- a/src/GafferScene/DeleteObject.cpp
+++ b/src/GafferScene/DeleteObject.cpp
@@ -55,6 +55,8 @@ DeleteObject::DeleteObject( const std::string &name )
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new BoolPlug( "adjustBounds", Plug::In, false ) );
 
+	outPlug()->childBoundsPlug()->setFlags( Plug::AcceptsDependencyCycles, true );
+
 	// Fast pass-throughs for things we don't modify
 	outPlug()->childNamesPlug()->setInput( inPlug()->childNamesPlug() );
 	outPlug()->globalsPlug()->setInput( inPlug()->globalsPlug() );
@@ -94,7 +96,8 @@ void DeleteObject::affects( const Gaffer::Plug *input, AffectedPlugsContainer &o
 		input == filterPlug() ||
 		input == adjustBoundsPlug() ||
 		input == inPlug()->boundPlug() ||
-		input == inPlug()->objectPlug()
+		input == inPlug()->objectPlug() ||
+		input == outPlug()->childBoundsPlug()
 	)
 	{
 		outputs.push_back( outPlug()->boundPlug() );

--- a/src/GafferScene/FreezeTransform.cpp
+++ b/src/GafferScene/FreezeTransform.cpp
@@ -61,6 +61,8 @@ FreezeTransform::FreezeTransform( const std::string &name )
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new M44fPlug( "__transform", Plug::Out ) );
 
+	outPlug()->childBoundsPlug()->setFlags( Plug::AcceptsDependencyCycles, true );
+
 	// pass through the things we don't want to change
 	outPlug()->attributesPlug()->setInput( inPlug()->attributesPlug() );
 	outPlug()->childNamesPlug()->setInput( inPlug()->childNamesPlug() );
@@ -97,6 +99,7 @@ void FreezeTransform::affects( const Gaffer::Plug *input, AffectedPlugsContainer
 
 	if(
 		input == filterPlug() ||
+		input == outPlug()->childBoundsPlug() ||
 		input == inPlug()->boundPlug() ||
 		input == transformPlug()
 	)

--- a/src/GafferScene/Grid.cpp
+++ b/src/GafferScene/Grid.cpp
@@ -74,6 +74,7 @@ Grid::Grid( const std::string &name )
 	addChild( new FloatPlug( "centerPixelWidth", Plug::In, 1.0f, 0.01f ) );
 	addChild( new FloatPlug( "borderPixelWidth", Plug::In, 1.0f, 0.01f ) );
 
+	outPlug()->childBoundsPlug()->setFlags( Plug::AcceptsDependencyCycles, true );
 }
 
 Grid::~Grid()
@@ -184,20 +185,30 @@ void Grid::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	SceneNode::affects( input, outputs );
 
-	if( input == namePlug() )
+	if(
+		input == outPlug()->childBoundsPlug() ||
+		dimensionsPlug()->isAncestorOf( input )
+	)
 	{
-		outputs.push_back( outPlug()->childNamesPlug() );
+		outputs.push_back( outPlug()->boundPlug() );
 	}
-	else if( transformPlug()->isAncestorOf( input ) )
+
+	if( transformPlug()->isAncestorOf( input ) )
 	{
 		outputs.push_back( outPlug()->transformPlug() );
 	}
-	else if( dimensionsPlug()->isAncestorOf( input ) )
+
+	if(
+		input == gridPixelWidthPlug() ||
+		input == centerPixelWidthPlug() ||
+		input == borderPixelWidthPlug()
+	)
 	{
-		outputs.push_back( outPlug()->boundPlug() );
-		outputs.push_back( outPlug()->objectPlug() );
+		outputs.push_back( outPlug()->attributesPlug() );
 	}
-	else if(
+
+	if(
+		dimensionsPlug()->isAncestorOf( input ) ||
 		input == spacingPlug() ||
 		input->parent<Plug>() == gridColorPlug() ||
 		input->parent<Plug>() == centerColorPlug() ||
@@ -206,13 +217,10 @@ void Grid::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 	{
 		outputs.push_back( outPlug()->objectPlug() );
 	}
-	else if(
-		input == gridPixelWidthPlug() ||
-		input == centerPixelWidthPlug() ||
-		input == borderPixelWidthPlug()
-	)
+
+	if( input == namePlug() )
 	{
-		outputs.push_back( outPlug()->attributesPlug() );
+		outputs.push_back( outPlug()->childNamesPlug() );
 	}
 }
 

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -812,7 +812,8 @@ bool Instancer::affectsBranchBound( const Gaffer::Plug *input ) const
 		input == namePlug() ||
 		input == prototypesPlug()->boundPlug() ||
 		input == prototypesPlug()->transformPlug() ||
-		input == prototypeChildNamesPlug()
+		input == prototypeChildNamesPlug() ||
+		input == outPlug()->childBoundsPlug()
 	;
 }
 

--- a/src/GafferScene/MergeScenes.cpp
+++ b/src/GafferScene/MergeScenes.cpp
@@ -101,6 +101,8 @@ MergeScenes::MergeScenes( const std::string &name )
 	addChild( new BoolPlug( "adjustBounds", Plug::In, true ) );
 	addChild( new IntPlug( "__activeInputs", Plug::Out, 0 ) );
 	addChild( new AtomicBox3fPlug( "__mergedDescendantsBound", Plug::Out ) );
+
+	outPlug()->childBoundsPlug()->setFlags( Plug::AcceptsDependencyCycles, true );
 }
 
 MergeScenes::~MergeScenes()
@@ -214,7 +216,9 @@ void MergeScenes::affects( const Gaffer::Plug *input, AffectedPlugsContainer &ou
 		input == objectModePlug() ||
 		input == adjustBoundsPlug() ||
 		input == activeInputsPlug() ||
-		input == mergedDescendantsBoundPlug()
+		input == mergedDescendantsBoundPlug() ||
+		input == outPlug()->objectPlug() ||
+		input == outPlug()->childBoundsPlug()
 	)
 	{
 		outputs.push_back( outPlug()->boundPlug() );

--- a/src/GafferScene/SceneElementProcessor.cpp
+++ b/src/GafferScene/SceneElementProcessor.cpp
@@ -55,6 +55,8 @@ SceneElementProcessor::SceneElementProcessor( const std::string &name, IECore::P
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 
+	outPlug()->childBoundsPlug()->setFlags( Plug::AcceptsDependencyCycles, true );
+
 	// We don't ever want to change the scene hierarchy, globals, or sets,
 	// so we make pass-through connections for them. This is quicker than
 	// implementing a pass through of the input in the hash and compute
@@ -73,28 +75,39 @@ void SceneElementProcessor::affects( const Plug *input, AffectedPlugsContainer &
 {
 	FilteredSceneProcessor::affects( input, outputs );
 
-	const ScenePlug *in = inPlug();
-	if( input->parent<ScenePlug>() == in )
+	if(
+		input == filterPlug() ||
+		input == inPlug()->boundPlug() ||
+		input == inPlug()->childNamesPlug() ||
+		input == outPlug()->childBoundsPlug() ||
+		input == inPlug()->objectPlug()
+	)
 	{
-		const ValuePlug *output = outPlug()->getChild<ValuePlug>( input->getName() );
-		if( !output->getInput() )
-		{
-			outputs.push_back( output );
-		}
+		outputs.push_back( outPlug()->boundPlug() );
 	}
-	else if( input == filterPlug() )
+
+	if(
+		input == filterPlug() ||
+		input == inPlug()->transformPlug()
+	)
 	{
-		for( ValuePlugIterator it( outPlug() ); !it.done(); ++it )
-		{
-			if( (*it)->getInput() )
-			{
-				// If the output has been connected as a pass-through,
-				// then it clearly can't be affected by the filter plug,
-				// because there won't even be a compute() call for it.
-				continue;
-			}
-			outputs.push_back( it->get() );
-		}
+		outputs.push_back( outPlug()->transformPlug() );
+	}
+
+	if(
+		input == filterPlug() ||
+		input == inPlug()->attributesPlug()
+	)
+	{
+		outputs.push_back( outPlug()->attributesPlug() );
+	}
+
+	if(
+		input == filterPlug() ||
+		input == inPlug()->objectPlug()
+	)
+	{
+		outputs.push_back( outPlug()->objectPlug() );
 	}
 }
 

--- a/src/GafferScene/SubTree.cpp
+++ b/src/GafferScene/SubTree.cpp
@@ -59,6 +59,8 @@ SubTree::SubTree( const std::string &name )
 	addChild( new StringPlug( "root", Plug::In, "" ) );
 	addChild( new BoolPlug( "includeRoot", Plug::In, false ) );
 
+	outPlug()->childBoundsPlug()->setFlags( Plug::AcceptsDependencyCycles, true );
+
 	// Fast pass-throughs for things we don't modify.
 	outPlug()->globalsPlug()->setInput( inPlug()->globalsPlug() );
 	outPlug()->setNamesPlug()->setInput( inPlug()->setNamesPlug() );
@@ -92,20 +94,45 @@ void SubTree::affects( const Plug *input, AffectedPlugsContainer &outputs ) cons
 {
 	SceneProcessor::affects( input, outputs );
 
-	if( input->parent<ScenePlug>() == inPlug() )
-	{
-		outputs.push_back( outPlug()->getChild<ValuePlug>( input->getName() ) );
-	}
-	else if( input == rootPlug() || input == includeRootPlug() || input == inPlug()->existsPlug() )
+	const bool affectsSourcePath = input == rootPlug() || input == includeRootPlug() || input == inPlug()->existsPlug();
+
+	if(
+		affectsSourcePath ||
+		input == inPlug()->boundPlug() ||
+		input == outPlug()->childBoundsPlug()
+	)
 	{
 		outputs.push_back( outPlug()->boundPlug() );
-		outputs.push_back( outPlug()->transformPlug() );
-		outputs.push_back( outPlug()->attributesPlug() );
-		outputs.push_back( outPlug()->objectPlug() );
-		outputs.push_back( outPlug()->childNamesPlug() );
-		outputs.push_back( outPlug()->setPlug() );
 	}
 
+	if( affectsSourcePath || input == inPlug()->transformPlug() )
+	{
+		outputs.push_back( outPlug()->transformPlug() );
+	}
+
+	if( affectsSourcePath || input == inPlug()->attributesPlug() )
+	{
+		outputs.push_back( outPlug()->attributesPlug() );
+	}
+
+	if( affectsSourcePath || input == inPlug()->objectPlug() )
+	{
+		outputs.push_back( outPlug()->objectPlug() );
+	}
+
+	if( affectsSourcePath || input == inPlug()->childNamesPlug() )
+	{
+		outputs.push_back( outPlug()->childNamesPlug() );
+	}
+
+	if(
+		input == inPlug()->setPlug() ||
+		input == rootPlug() ||
+		input == includeRootPlug()
+	)
+	{
+		outputs.push_back( outPlug()->setPlug() );
+	}
 }
 
 void SubTree::hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const


### PR DESCRIPTION
When `childBoundsPlug()` was introduced as a faster cached alternative to `unionOfTransformedChildBounds()`, I neglected to update nodes to declare the dependency on the new plug. That was OKish until we introduced the improved hash cache invalidation, at which point it meant that we could lookup stale results from the cache. The fix is simple - just declare the dependencies accurately. For many of the nodes I've also taken the time to refactor `affects()` so that there is a single conditional per output plug, making it much easier to verify that it is in agreement with the contents of hash/compute.