### PR TITLE
Gadget optimisations

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.59.x.x
 ========
 
+Improvements
+------------
+
+- GraphEditor : Improved performance slightly for large graphs.
+
 API
 ---
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,18 @@
-0.59.0.0
+0.59.x.x
 ========
+
+API
+---
+
+- Gadget :
+  - Added `updateLayout()` virtual method to simplify implementation of container types.
+  - Added `dirty()` method for finer grained tracking of changes than `requestRender()` provided.
+  - Deprecated `requestRender()` method. Use `dirty()` instead.
+
+Breaking Changes
+----------------
+
+- Gadget : Added new virtual method and private member variables.
 
 0.58.0.1 (relative to 0.58.0.0)
 ========

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -322,6 +322,7 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 
 		ConstStylePtr m_style;
 
+		GLuint m_glName;
 		bool m_visible;
 		bool m_enabled;
 		bool m_highlighted;
@@ -331,31 +332,11 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		mutable Imath::Box3f m_bound;
 		mutable bool m_layoutDirty;
 
-		VisibilityChangedSignal m_visibilityChangedSignal;
-		RenderRequestSignal m_renderRequestSignal;
-
 		IECore::InternedString m_toolTip;
 
-		ButtonSignal m_buttonPressSignal;
-		ButtonSignal m_buttonReleaseSignal;
-		ButtonSignal m_buttonDoubleClickSignal;
-		ButtonSignal m_wheelSignal;
-
-		EnterLeaveSignal m_enterSignal;
-		EnterLeaveSignal m_leaveSignal;
-		ButtonSignal m_mouseMoveSignal;
-
-		DragBeginSignal m_dragBeginSignal;
-		DragDropSignal m_dragEnterSignal;
-		DragDropSignal m_dragMoveSignal;
-		DragDropSignal m_dragLeaveSignal;
-		DragDropSignal m_dragEndSignal;
-		DragDropSignal m_dropSignal;
-
-		KeySignal m_keyPressSignal;
-		KeySignal m_keyReleaseSignal;
-
-		GLuint m_glName;
+		struct Signals;
+		Signals *signals();
+		std::unique_ptr<Signals> m_signals;
 
 		// used by the bindings to know when the idleSignal()
 		// has been accessed, and only use an idle timer

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -277,11 +277,25 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 
 	protected :
 
-		/// Emits renderRequestSignal() as necessary for this and all ancestors.
-		/// Use this rather than emit the signal manually.
-		void requestRender();
-		/// Implemented to request a render for both the old and the new parent.
-		void parentChanged( GraphComponent *oldParent ) override;
+		enum class DirtyType
+		{
+			/// A re-render is needed, but the bounding box
+			/// and layout remain the same.
+			Render,
+			/// The bounding box has changed. Implies Render.
+			Bound,
+			/// Parameters used by `updateLayout()` have changed.
+			/// Implies Bound and Render.
+			Layout,
+		};
+
+		/// Must be called by derived classes to reflect changes
+		/// affecting `doRenderLayer()`, `bound()` or `updateLayout().
+		void dirty( DirtyType dirtyType );
+
+		/// May be implemented by derived classes to position child widgets.
+		/// This is called automatically prior to rendering or bound computation.
+		virtual void updateLayout() const;
 
 		/// Should be implemented by subclasses to draw themselves as appropriate
 		/// for the specified layer. Child gadgets will be drawn automatically
@@ -291,6 +305,11 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		/// of its children will render anything for the specified layer.
 		/// The default implementation returns true.
 		virtual bool hasLayer( Layer layer ) const;
+
+		/// \deprecated
+		void requestRender();
+		/// Implemented to dirty the layout for both the old and the new parent.
+		void parentChanged( GraphComponent *oldParent ) override;
 
 	private :
 
@@ -308,6 +327,9 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		bool m_highlighted;
 
 		Imath::M44f m_transform;
+
+		mutable Imath::Box3f m_bound;
+		mutable bool m_layoutDirty;
 
 		VisibilityChangedSignal m_visibilityChangedSignal;
 		RenderRequestSignal m_renderRequestSignal;

--- a/include/GafferUI/LinearContainer.h
+++ b/include/GafferUI/LinearContainer.h
@@ -90,23 +90,14 @@ class GAFFERUI_API LinearContainer : public ContainerGadget
 		void setDirection( Direction direction );
 		Direction getDirection() const;
 
-		Imath::Box3f bound() const override;
-
 	protected :
 
-		void doRenderLayer( Layer layer, const Style *style ) const override;
-
-	private :
-
-		void renderRequested( GadgetPtr gadget );
+		void updateLayout() const override;
 
 		Orientation m_orientation;
 		Alignment m_alignment;
 		float m_spacing;
 		Direction m_direction;
-
-		mutable bool m_clean;
-		void calculateChildTransforms() const;
 
 };
 

--- a/include/GafferUIBindings/GadgetBinding.h
+++ b/include/GafferUIBindings/GadgetBinding.h
@@ -132,6 +132,28 @@ class GadgetWrapper : public GafferBindings::GraphComponentWrapper<WrappedType>
 			return WrappedType::getToolTip( line );
 		}
 
+		void updateLayout() const override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				try
+				{
+					boost::python::object f = this->methodOverride( "updateLayout" );
+					if( f )
+					{
+						f();
+						return;
+					}
+				}
+				catch( const boost::python::error_already_set &e )
+				{
+					IECorePython::ExceptionAlgo::translatePythonException();
+				}
+			}
+			WrappedType::updateLayout();
+		}
+
 		void doRenderLayer( GafferUI::Gadget::Layer layer, const GafferUI::Style *style ) const override
 		{
 			if( this->isSubclassed() )

--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -258,7 +258,7 @@ void ImageGadget::setSoloChannel( int index )
 		// channels.
 		dirty( TilesDirty );
 	}
-	requestRender();
+	Gadget::dirty( DirtyType::Render );
 }
 
 int ImageGadget::getSoloChannel() const
@@ -276,7 +276,7 @@ void ImageGadget::setClipping( bool clipping )
 	}
 	else
 	{
-		requestRender();
+		Gadget::dirty( DirtyType::Render );
 	}
 }
 
@@ -294,7 +294,7 @@ void ImageGadget::setExposure( float exposure )
 	}
 	else
 	{
-		requestRender();
+		Gadget::dirty( DirtyType::Render );
 	}
 }
 
@@ -313,7 +313,7 @@ void ImageGadget::setGamma( float gamma )
 	}
 	else
 	{
-		requestRender();
+		Gadget::dirty( DirtyType::Render );
 	}
 }
 
@@ -343,7 +343,7 @@ void ImageGadget::setDisplayTransform( ImageProcessorPtr displayTransform )
 
 	dirty( TilesDirty );
 	m_shaderDirty = true;
-	requestRender();
+	Gadget::dirty( DirtyType::Render );
 }
 
 ConstImageProcessorPtr ImageGadget::getDisplayTransform() const
@@ -369,7 +369,7 @@ void ImageGadget::setLabelsVisible( bool visible )
 		return;
 	}
 	m_labelsVisible = visible;
-	requestRender();
+	Gadget::dirty( DirtyType::Render );
 }
 
 bool ImageGadget::getLabelsVisible() const
@@ -391,7 +391,7 @@ void ImageGadget::setPaused( bool paused )
 	}
 	else if( m_dirtyFlags )
 	{
-		requestRender();
+		Gadget::dirty( DirtyType::Render );
 	}
 }
 
@@ -490,7 +490,9 @@ void ImageGadget::dirty( unsigned flags )
 	}
 
 	m_dirtyFlags |= flags;
-	requestRender();
+	Gadget::dirty(
+		( FormatDirty | DataWindowDirty ) ? DirtyType::Bound : DirtyType::Render
+	);
 }
 
 const GafferImage::Format &ImageGadget::format() const
@@ -763,7 +765,7 @@ void ImageGadget::updateTiles()
 			ParallelAlgo::callOnUIThread(
 				[thisRef] {
 					thisRef->m_renderRequestPending = false;
-					thisRef->requestRender();
+					thisRef->Gadget::dirty( DirtyType::Render );
 				}
 			);
 		}

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -189,7 +189,7 @@ class CropWindowTool::Rectangle : public GafferUI::Gadget
 				return;
 			}
 			m_masked = masked;
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 
 		bool getMasked() const
@@ -284,8 +284,8 @@ class CropWindowTool::Rectangle : public GafferUI::Gadget
 				return;
 			}
 			m_rectangle = rectangle;
+			dirty( DirtyType::Bound );
 			rectangleChangedSignal()( this, reason );
-			requestRender();
 		}
 
 		bool mouseMove( const ButtonEvent &event )

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -159,7 +159,7 @@ void SceneGadget::setPaused( bool paused )
 	}
 	else if( m_controller.updateRequired() )
 	{
-		requestRender();
+		dirty( DirtyType::Bound );
 	}
 }
 
@@ -176,7 +176,7 @@ void SceneGadget::setBlockingPaths( const IECore::PathMatcher &blockingPaths )
 		m_updateTask.reset();
 	}
 	m_blockingPaths = blockingPaths;
-	requestRender();
+	dirty( DirtyType::Bound );
 }
 
 const IECore::PathMatcher &SceneGadget::getBlockingPaths() const
@@ -192,7 +192,7 @@ void SceneGadget::setPriorityPaths( const IECore::PathMatcher &priorityPaths )
 		m_updateTask.reset();
 	}
 	m_priorityPaths = priorityPaths;
-	requestRender();
+	dirty( DirtyType::Bound );
 }
 
 const IECore::PathMatcher &SceneGadget::getPriorityPaths() const
@@ -263,7 +263,7 @@ void SceneGadget::setOpenGLOptions( const IECore::CompoundObject *options )
 	}
 
 	m_openGLOptions = options->copy();
-	requestRender();
+	dirty( DirtyType::Bound );
 }
 
 const IECore::CompoundObject *SceneGadget::getOpenGLOptions() const
@@ -424,7 +424,7 @@ void SceneGadget::setSelection( const IECore::PathMatcher &selection )
 	m_selection = selection;
 	ConstDataPtr d = new IECore::PathMatcherData( selection );
 	m_renderer->option( "gl:selection", d.get() );
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 Imath::Box3f SceneGadget::selectionBound() const
@@ -526,7 +526,7 @@ void SceneGadget::updateRenderer()
 					if( shouldRequestRender )
 					{
 						thisRef->m_renderRequestPending = false;
-						thisRef->requestRender();
+						thisRef->dirty( DirtyType::Bound );
 					}
 				}
 			);

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -624,13 +624,13 @@ class GnomonPlane : public GnomonGadget
 		void enter()
 		{
 			m_hovering = true;
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 
 		void leave()
 		{
 			m_hovering = false;
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 
 		bool m_hovering;
@@ -779,7 +779,7 @@ class CameraOverlay : public GafferUI::Gadget
 				return;
 			}
 			m_resolutionGate = resolutionGate;
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 
 		const Box2f &getResolutionGate() const
@@ -795,7 +795,7 @@ class CameraOverlay : public GafferUI::Gadget
 				return;
 			}
 			m_apertureGate = apertureGate;
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 
 		const Box2f &getApertureGate() const
@@ -811,7 +811,7 @@ class CameraOverlay : public GafferUI::Gadget
 				return;
 			}
 			m_cropWindow = cropWindow;
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 
 		const Box2f &getCropWindow() const
@@ -827,7 +827,7 @@ class CameraOverlay : public GafferUI::Gadget
 				return;
 			}
 			m_overscan = overscan;
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 
 		const V4f &getOverscan() const
@@ -842,7 +842,7 @@ class CameraOverlay : public GafferUI::Gadget
 				return;
 			}
 			m_caption = caption;
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 
 		const std::string &getCaption() const
@@ -857,7 +857,7 @@ class CameraOverlay : public GafferUI::Gadget
 				return;
 			}
 			m_icon = icon;
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 
 		const std::string &getIcon() const

--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -80,7 +80,7 @@ class SelectionTool::DragOverlay : public GafferUI::Gadget
 				return;
 			}
 			m_startPosition = p;
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 
 		const V3f &getStartPosition() const
@@ -95,7 +95,7 @@ class SelectionTool::DragOverlay : public GafferUI::Gadget
 				return;
 			}
 			m_endPosition = p;
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 
 		const V3f &getEndPosition() const

--- a/src/GafferUI/AnimationGadget.cpp
+++ b/src/GafferUI/AnimationGadget.cpp
@@ -461,7 +461,7 @@ const Gaffer::StandardSet *AnimationGadget::editablePlugs() const
 
 void AnimationGadget::plugDirtied( Gaffer::Plug *plug )
 {
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 std::string AnimationGadget::getToolTip( const IECore::LineSegment3f &line ) const
@@ -767,7 +767,7 @@ bool AnimationGadget::buttonRelease( GadgetPtr gadget, const ButtonEvent &event 
 		m_selectedKeys.clear();
 	}
 
-	requestRender();
+	dirty( DirtyType::Render );
 
 	return true;
 }
@@ -876,7 +876,7 @@ IECore::RunTimeTypedPtr AnimationGadget::dragBegin( GadgetPtr gadget, const Drag
 
 	m_dragStartPosition = m_lastDragPosition = V2f( i.x, i.y );
 
-	requestRender();
+	dirty( DirtyType::Render );
 	return IECore::NullObject::defaultNullObject();
 }
 
@@ -933,7 +933,7 @@ bool AnimationGadget::mouseMove( GadgetPtr gadget, const ButtonEvent &event )
 	}
 
 	updateKeyPreviewLocation( m_highlightedCurve.get(), i.x );
-	requestRender();
+	dirty( DirtyType::Render );
 
 	return true;
 }
@@ -952,7 +952,7 @@ bool AnimationGadget::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
 	}
 
 	m_lastDragPosition = V2f( i.x, i.y );
-	requestRender();
+	dirty( DirtyType::Render );
 	return true;
 }
 
@@ -1016,7 +1016,7 @@ bool AnimationGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 
 	m_lastDragPosition = V2f( i.x, i.y );
 
-	requestRender();
+	dirty( DirtyType::Render );
 	return true;
 }
 
@@ -1073,7 +1073,7 @@ bool AnimationGadget::dragEnd( GadgetPtr gadget, const DragDropEvent &event )
 	m_moveAxis = MoveAxis::Both;
 	Pointer::setCurrent( "" );
 
-	requestRender();
+	dirty( DirtyType::Render );
 
 	return true;
 }
@@ -1083,7 +1083,7 @@ bool AnimationGadget::leave()
 	if( m_frameIndicatorPreviewFrame )
 	{
 		m_frameIndicatorPreviewFrame = boost::none;
-		requestRender();
+		dirty( DirtyType::Render );
 	}
 	return true;
 }
@@ -1094,7 +1094,7 @@ bool AnimationGadget::keyPress( GadgetPtr gadget, const KeyEvent &event )
 	{
 		insertKeyframes();
 		m_mergeGroupId++;
-		requestRender();
+		dirty( DirtyType::Render );
 		return true;
 	}
 
@@ -1109,7 +1109,7 @@ bool AnimationGadget::keyPress( GadgetPtr gadget, const KeyEvent &event )
 		if( m_highlightedCurve )
 		{
 			m_keyPreview = true;
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 		return true;
 	}
@@ -1118,7 +1118,7 @@ bool AnimationGadget::keyPress( GadgetPtr gadget, const KeyEvent &event )
 	{
 		removeKeyframes();
 		m_mergeGroupId++;
-		requestRender();
+		dirty( DirtyType::Render );
 		return true;
 	}
 
@@ -1130,7 +1130,7 @@ bool AnimationGadget::keyRelease( GadgetPtr gadget, const KeyEvent &event )
 	if( event.key == "Control" )
 	{
 		m_keyPreview = false;
-		requestRender();
+		dirty( DirtyType::Render );
 	}
 
 	return false;
@@ -1254,7 +1254,7 @@ bool AnimationGadget::frameIndicatorUnderMouse( const IECore::LineSegment3f &pos
 void AnimationGadget::setContext( Context *context )
 {
 	m_context = context;
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 Context *AnimationGadget::getContext() const
@@ -1272,22 +1272,22 @@ void AnimationGadget::visiblePlugAdded( Gaffer::Set *set, IECore::RunTimeTyped *
 		node->plugDirtiedSignal().connect( boost::bind( &AnimationGadget::plugDirtied, this, ::_1 ) );
 	}
 
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void AnimationGadget::visiblePlugRemoved( Gaffer::Set *set, IECore::RunTimeTyped *member )
 {
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void AnimationGadget::editablePlugAdded( Gaffer::Set *set, IECore::RunTimeTyped *member )
 {
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void AnimationGadget::editablePlugRemoved( Gaffer::Set *set, IECore::RunTimeTyped *member )
 {
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void AnimationGadget::renderCurve( const Animation::CurvePlug *curvePlug, const Style *style ) const

--- a/src/GafferUI/AnnotationsGadget.cpp
+++ b/src/GafferUI/AnnotationsGadget.cpp
@@ -316,6 +316,6 @@ void AnnotationsGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::
 		auto it = m_annotations.find( gadget );
 		assert( it != m_annotations.end() );
 		it->second.dirty = true;
-		requestRender();
+		dirty( DirtyType::Render );
 	}
 }

--- a/src/GafferUI/AuxiliaryConnectionsGadget.cpp
+++ b/src/GafferUI/AuxiliaryConnectionsGadget.cpp
@@ -438,7 +438,7 @@ void AuxiliaryConnectionsGadget::dirtyInputConnections( const NodeGadget *nodeGa
 		return;
 	}
 	m_dirty = true;
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void AuxiliaryConnectionsGadget::dirtyOutputConnections( const NodeGadget *nodeGadget )
@@ -459,7 +459,7 @@ void AuxiliaryConnectionsGadget::dirtyOutputConnections( const NodeGadget *nodeG
 		return;
 	}
 	m_dirty = true;
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void AuxiliaryConnectionsGadget::updateConnections() const

--- a/src/GafferUI/AuxiliaryNodeGadget.cpp
+++ b/src/GafferUI/AuxiliaryNodeGadget.cpp
@@ -97,7 +97,7 @@ void AuxiliaryNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore
 	{
 		if( updateLabel() )
 		{
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 	}
 
@@ -105,7 +105,7 @@ void AuxiliaryNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore
 	{
 		if( updateUserColor() )
 		{
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 	}
 }

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -339,7 +339,7 @@ void BackdropNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 void BackdropNodeGadget::contextChanged()
 {
 	// Title and description may depend on the context
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void BackdropNodeGadget::plugDirtied( const Gaffer::Plug *plug )
@@ -348,11 +348,16 @@ void BackdropNodeGadget::plugDirtied( const Gaffer::Plug *plug )
 	if(
 		plug == backdrop->titlePlug() ||
 		plug == backdrop->scalePlug() ||
-		plug == backdrop->descriptionPlug() ||
+		plug == backdrop->descriptionPlug()
+	)
+	{
+		dirty( DirtyType::Render );
+	}
+	else if(
 		plug == acquireBoundPlug( /* createIfMissing = */ false )
 	)
 	{
-		requestRender();
+		dirty( DirtyType::Bound );
 	}
 }
 
@@ -386,7 +391,7 @@ bool BackdropNodeGadget::mouseMove( Gadget *gadget, const ButtonEvent &event )
 	if( newHovered != m_hovered )
 	{
 		m_hovered = newHovered;
-		requestRender();
+		dirty( DirtyType::Render );
 	}
 
 	return true;
@@ -464,7 +469,7 @@ void BackdropNodeGadget::leave( Gadget *gadget, const ButtonEvent &event )
 {
 	Pointer::setCurrent( "" );
 	m_hovered = false;
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 float BackdropNodeGadget::hoverWidth() const
@@ -537,7 +542,7 @@ void BackdropNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore:
 	{
 		if( updateUserColor() )
 		{
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 	}
 }

--- a/src/GafferUI/ConnectionGadget.cpp
+++ b/src/GafferUI/ConnectionGadget.cpp
@@ -123,7 +123,7 @@ void ConnectionGadget::setMinimised( bool minimised )
 		return;
 	}
 	m_minimised = minimised;
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 bool ConnectionGadget::getMinimised() const

--- a/src/GafferUI/ContainerGadget.cpp
+++ b/src/GafferUI/ContainerGadget.cpp
@@ -66,7 +66,7 @@ void ContainerGadget::setPadding( const Imath::Box3f &padding )
 		return;
 	}
 	m_padding = padding;
-	requestRender();
+	dirty( DirtyType::Bound );
 }
 
 const Imath::Box3f &ContainerGadget::getPadding() const

--- a/src/GafferUI/DotNodeGadget.cpp
+++ b/src/GafferUI/DotNodeGadget.cpp
@@ -210,7 +210,7 @@ void DotNodeGadget::updateLabel()
 		);
 	}
 
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 bool DotNodeGadget::dragEnter( const DragDropEvent &event )

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -1645,6 +1645,21 @@ NodeGadget *GraphGadget::addNodeGadget( Gaffer::Node *node )
 		return nullptr;
 	}
 
+	// The call to `addChild( nodeGadget )` will uniquefy the name
+	// with respect to all our other NodeGadgets. This can have
+	// significant overhead when graphs get large, which we can
+	// avoid by making sure the name is unique already. The node
+	// name fits the bill, and is already conveniently available
+	// in `InternedString` form. Note that we are deliberately not
+	// synchronising the names in the case of them changing in the
+	// future, and provide no guarantees about NodeGadget names in
+	// general.
+	// \todo It may be better to modify GraphComponent to allow nameless
+	// children and then use them here. This would let us avoid _all_
+	// uniquefication overhead and would also be useful for ArrayPlug
+	// and Spreadsheet::RowsPlug children.
+	nodeGadget->setName( node->getName() );
+
 	addChild( nodeGadget );
 
 	NodeGadgetEntry &nodeGadgetEntry = m_nodeGadgets[node];

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -1257,7 +1257,7 @@ bool GraphGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 		offsetNodes( m_scriptNode->selection(), pos - m_lastDragPosition );
 		m_lastDragPosition = pos;
 		updateDragReconnectCandidate( event );
- 		requestRender();
+		dirty( DirtyType::Render );
 		return true;
 	}
 	else
@@ -1265,7 +1265,7 @@ bool GraphGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 		// we're drag selecting
 		m_lastDragPosition = V2f( i.x, i.y );
 		updateDragSelection( false, event.modifiers );
- 		requestRender();
+		dirty( DirtyType::Render );
 		return true;
 	}
 
@@ -1399,12 +1399,12 @@ bool GraphGadget::dragEnd( GadgetPtr gadget, const DragDropEvent &event )
 		}
 		m_dragReconnectCandidate = nullptr;
 		m_dragMergeGroupId++;
- 		requestRender();
+		dirty( DirtyType::Render );
 	}
 	else if( dragMode == Selecting )
 	{
 		updateDragSelection( true, event.modifiers );
- 		requestRender();
+		dirty( DirtyType::Render );
 	}
 
 	return true;

--- a/src/GafferUI/Handle.cpp
+++ b/src/GafferUI/Handle.cpp
@@ -90,7 +90,7 @@ void Handle::setRasterScale( float rasterScale )
 	}
 
 	m_rasterScale = rasterScale;
-	renderRequestSignal()( this );
+	dirty( DirtyType::Render );
 }
 
 float Handle::getRasterScale() const
@@ -106,7 +106,7 @@ void Handle::setVisibleOnHover( bool visibleOnHover )
 	}
 
 	m_visibleOnHover = visibleOnHover;
-	renderRequestSignal()( this );
+	dirty( DirtyType::Render );
 }
 
 bool Handle::getVisibleOnHover() const
@@ -188,13 +188,13 @@ Imath::V3f Handle::rasterScaleFactor() const
 void Handle::enter()
 {
 	m_hovering = true;
- 	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void Handle::leave()
 {
 	m_hovering = false;
- 	requestRender();
+	dirty( DirtyType::Render );
 }
 
 bool Handle::buttonPress( const ButtonEvent &event )

--- a/src/GafferUI/NoduleLayout.cpp
+++ b/src/GafferUI/NoduleLayout.cpp
@@ -581,11 +581,11 @@ std::vector<NoduleLayout::GadgetKey> NoduleLayout::layoutOrder()
 
 	vector<InternedString> metadata;
 	Metadata::registeredValues( m_parent.get(), metadata );
-	boost::regex customGadgetRegex( "noduleLayout:customGadget:(.+):gadgetType" );
+	static boost::regex g_customGadgetRegex( "noduleLayout:customGadget:(.+):gadgetType" );
 	for( vector<InternedString>::const_iterator it = metadata.begin(), eIt = metadata.end(); it != eIt; ++it )
 	{
 		boost::cmatch match;
-		if( !boost::regex_match( it->c_str(), match, customGadgetRegex ) )
+		if( !boost::regex_match( it->c_str(), match, g_customGadgetRegex ) )
 		{
 			continue;
 		}

--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -203,7 +203,7 @@ void PlugAdder::updateDragEndPoint( const Imath::V3f position, const Imath::V3f 
 	m_dragPosition = position;
 	m_dragTangent = tangent;
 	m_dragging = true;
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 PlugAdder::PlugMenuSignal &PlugAdder::plugMenuSignal()
@@ -311,7 +311,7 @@ bool PlugAdder::dragEnter( const DragDropEvent &event )
 bool PlugAdder::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 {
 	m_dragPosition = V3f( event.line.p0.x, event.line.p0.y, 0 );
-	requestRender();
+	dirty( DirtyType::Render );
 	return true;
 }
 
@@ -338,6 +338,6 @@ bool PlugAdder::drop( const DragDropEvent &event )
 bool PlugAdder::dragEnd( const DragDropEvent &event )
 {
 	m_dragging = false;
-	requestRender();
+	dirty( DirtyType::Render );
 	return false;
 }

--- a/src/GafferUI/RotateHandle.cpp
+++ b/src/GafferUI/RotateHandle.cpp
@@ -93,7 +93,7 @@ void RotateHandle::setAxes( Style::Axes axes )
 	}
 
 	m_axes = axes;
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 Style::Axes RotateHandle::getAxes() const
@@ -227,7 +227,7 @@ bool RotateHandle::dragMove( const DragDropEvent &event )
 	{
 		updatePreciseMotionState( event );
 		m_highlightVector = pointOnSphere( updatedLineFromEvent( event ) );
-		requestRender();
+		dirty( DirtyType::Render );
 	}
 	else
 	{
@@ -239,7 +239,7 @@ bool RotateHandle::dragMove( const DragDropEvent &event )
 bool RotateHandle::mouseMove( const ButtonEvent &event )
 {
 	m_highlightVector = pointOnSphere( event.line );
-	requestRender();
+	dirty( DirtyType::Render );
 	return true;
 }
 

--- a/src/GafferUI/ScaleHandle.cpp
+++ b/src/GafferUI/ScaleHandle.cpp
@@ -65,7 +65,7 @@ void ScaleHandle::setAxes( Style::Axes axes )
 	}
 
 	m_axes = axes;
- 	requestRender();
+	dirty( DirtyType::Render );
 }
 
 Style::Axes ScaleHandle::getAxes() const

--- a/src/GafferUI/SpacerGadget.cpp
+++ b/src/GafferUI/SpacerGadget.cpp
@@ -70,7 +70,7 @@ void SpacerGadget::setSize( const Imath::Box3f &size )
 		return;
 	}
 	m_bound = size;
- 	requestRender();
+	dirty( DirtyType::Bound );
 }
 
 bool SpacerGadget::acceptsChild( const GraphComponent *potentialChild ) const

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -263,7 +263,7 @@ void StandardConnectionGadget::updateDragEndPoint( const Imath::V3f position, co
 	{
 		throw IECore::Exception( "Not dragging" );
 	}
- 	requestRender();
+	dirty( DirtyType::Bound );
 }
 
 void StandardConnectionGadget::createConnection( Gaffer::Plug *endpoint )
@@ -522,7 +522,7 @@ bool StandardConnectionGadget::dragEnd( const DragDropEvent &event )
 
 	m_dragEnd = Gaffer::Plug::Invalid;
 	m_addingConnection = false;
-	requestRender();
+	dirty( DirtyType::Render );
 	return true;
 }
 
@@ -604,7 +604,7 @@ bool StandardConnectionGadget::keyPressed( const KeyEvent &event )
 	if( event.modifiers & ButtonEvent::Control && srcNodule() )
 	{
 		m_dotPreview = true;
-		requestRender();
+		dirty( DirtyType::Render );
 		return true;
 	}
 	return false;
@@ -615,7 +615,7 @@ bool StandardConnectionGadget::keyReleased( const KeyEvent &event )
 	if( !(event.modifiers & ButtonEvent::Control) )
 	{
 		m_dotPreview = false;
-		requestRender();
+		dirty( DirtyType::Render );
 		return true;
 	}
 	return false;
@@ -645,7 +645,7 @@ void StandardConnectionGadget::enter( const ButtonEvent &event )
 	updateDotPreviewLocation( event );
 
 	m_hovering = endAt( event.line ) != Plug::Invalid;
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 bool StandardConnectionGadget::mouseMove( const ButtonEvent &event )
@@ -653,7 +653,7 @@ bool StandardConnectionGadget::mouseMove( const ButtonEvent &event )
 	updateDotPreviewLocation( event );
 
 	m_hovering = endAt( event.line ) != Plug::Invalid;
- 	requestRender();
+	dirty( DirtyType::Render );
 	return false;
 }
 
@@ -664,7 +664,7 @@ void StandardConnectionGadget::leave( const ButtonEvent &event )
 	m_dotPreview = false;
 
 	m_hovering = false;
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void StandardConnectionGadget::plugMetadataChanged( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
@@ -676,7 +676,7 @@ void StandardConnectionGadget::plugMetadataChanged( IECore::TypeId nodeTypeId, c
 
 	if( updateUserColor() )
 	{
-		requestRender();
+		dirty( DirtyType::Render );
 	}
 }
 

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -775,7 +775,7 @@ void StandardNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore:
 	{
 		if( updateUserColor() )
 		{
- 			requestRender();
+			dirty( DirtyType::Render );
 		}
 	}
 	else if( key == g_paddingKey )
@@ -790,7 +790,7 @@ void StandardNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore:
 	{
 		if( updateShape() )
 		{
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 	}
 }
@@ -860,7 +860,7 @@ void StandardNodeGadget::updateNodeEnabled( const Gaffer::Plug *dirtiedPlug )
 	}
 
 	m_nodeEnabled = enabled;
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void StandardNodeGadget::updateIcon()

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -99,7 +99,7 @@ void StandardNodule::setLabelVisible( bool labelVisible )
 		return;
 	}
 	m_labelVisible = labelVisible;
- 	requestRender();
+	dirty( DirtyType::Render );
 }
 
 bool StandardNodule::getLabelVisible() const
@@ -136,7 +136,7 @@ void StandardNodule::updateDragEndPoint( const Imath::V3f position, const Imath:
 	m_dragPosition = position;
 	m_dragTangent = tangent;
 	m_draggingConnection = true;
- 	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void StandardNodule::createConnection( Gaffer::Plug *endpoint )
@@ -311,7 +311,7 @@ bool StandardNodule::buttonPress( GadgetPtr gadget, const ButtonEvent &event )
 
 IECore::RunTimeTypedPtr StandardNodule::dragBegin( GadgetPtr gadget, const ButtonEvent &event )
 {
- 	requestRender();
+	dirty( DirtyType::Render );
 	if( event.buttons == ButtonEvent::Middle )
 	{
 		GafferUI::Pointer::setCurrent( "plug" );
@@ -374,7 +374,7 @@ bool StandardNodule::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
 			setCompatibleLabelsVisible( event, true );
 		}
 
- 		requestRender();
+		dirty( DirtyType::Render );
 		return true;
 	}
 
@@ -384,7 +384,7 @@ bool StandardNodule::dragEnter( GadgetPtr gadget, const DragDropEvent &event )
 bool StandardNodule::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 {
 	m_dragPosition = V3f( event.line.p0.x, event.line.p0.y, 0 );
- 	requestRender();
+	dirty( DirtyType::Render );
 	return true;
 }
 
@@ -419,7 +419,7 @@ bool StandardNodule::dragLeave( GadgetPtr gadget, const DragDropEvent &event )
 		m_draggingConnection = false;
 	}
 
- 	requestRender();
+	dirty( DirtyType::Render );
 	return true;
 }
 
@@ -485,14 +485,14 @@ void StandardNodule::plugMetadataChanged( IECore::TypeId nodeTypeId, const IECor
 	{
 		if( updateUserColor() )
 		{
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 	}
 	else if( key == g_labelKey )
 	{
 		if( m_labelVisible )
 		{
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 	}
 }

--- a/src/GafferUI/TextGadget.cpp
+++ b/src/GafferUI/TextGadget.cpp
@@ -74,7 +74,7 @@ void TextGadget::setText( const std::string &text )
 		Imath::Box3f cb = style()->characterBound( Style::LabelText );
 		m_bound.min.y = std::min( m_bound.min.y, cb.min.y );
 		m_bound.max.y = std::max( m_bound.max.y, cb.max.y );
- 		requestRender();
+		dirty( DirtyType::Bound );
 	}
 }
 

--- a/src/GafferUI/TranslateHandle.cpp
+++ b/src/GafferUI/TranslateHandle.cpp
@@ -63,7 +63,7 @@ void TranslateHandle::setAxes( Style::Axes axes )
 	}
 
 	m_axes = axes;
- 	requestRender();
+	dirty( DirtyType::Render );
 }
 
 Style::Axes TranslateHandle::getAxes() const

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -774,7 +774,7 @@ void ViewportGadget::setCamera( IECoreScene::CameraPtr camera )
 	}
 	m_cameraController->setCamera( camera->copy() );
 	m_cameraChangedSignal( this );
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 const Imath::M44f &ViewportGadget::getCameraTransform() const
@@ -790,7 +790,7 @@ void ViewportGadget::setCameraTransform( const Imath::M44f &transform )
 	}
 	m_cameraController->setTransform( transform );
 	m_cameraChangedSignal( this );
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 ViewportGadget::UnarySignal &ViewportGadget::cameraChangedSignal()
@@ -822,7 +822,7 @@ void ViewportGadget::frame( const Imath::Box3f &box )
 {
 	m_cameraController->frame( box, m_variableAspectZoom );
 	m_cameraChangedSignal( this );
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void ViewportGadget::frame( const Imath::Box3f &box, const Imath::V3f &viewDirection,
@@ -830,7 +830,7 @@ void ViewportGadget::frame( const Imath::Box3f &box, const Imath::V3f &viewDirec
 {
 	m_cameraController->frame( box, viewDirection, upVector );
 	m_cameraChangedSignal( this );
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void ViewportGadget::fitClippingPlanes( const Imath::Box3f &box )
@@ -866,7 +866,7 @@ void ViewportGadget::fitClippingPlanes( const Imath::Box3f &box )
 
 	m_cameraController->setClippingPlanes( V2f( near, far ) );
 	m_cameraChangedSignal( this );
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void ViewportGadget::setDragTracking( unsigned dragTracking )
@@ -1233,7 +1233,7 @@ bool ViewportGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 			updateMotionState( event );
 			m_cameraController->motionUpdate( motionPositionFromEvent( event ), m_variableAspectZoom && ( event.modifiers & ModifiableEvent::Control ) != 0 );
 			m_cameraChangedSignal( this );
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 		return true;
 	}
@@ -1369,7 +1369,7 @@ void ViewportGadget::trackDragIdle()
 	dragMove( this, m_dragTrackingEvent );
 
 	m_cameraChangedSignal( this );
-	requestRender();
+	dirty( DirtyType::Render );
 }
 
 void ViewportGadget::updateMotionState( const DragDropEvent &event, bool initialEvent )
@@ -1510,7 +1510,7 @@ bool ViewportGadget::dragEnd( GadgetPtr gadget, const DragDropEvent &event )
 			m_cameraController->motionEnd( motionPositionFromEvent( event ), m_variableAspectZoom && ( event.modifiers & ModifiableEvent::Control ) != 0 );
 			m_cameraChangedSignal( this );
 			m_preciseMotionEnabled = false;
-			requestRender();
+			dirty( DirtyType::Render );
 		}
 		return true;
 	}
@@ -1549,7 +1549,7 @@ bool ViewportGadget::wheel( GadgetPtr gadget, const ButtonEvent &event )
 	m_cameraController->motionEnd( position );
 
 	m_cameraChangedSignal( this );
-	requestRender();
+	dirty( DirtyType::Render );
 
 	return true;
 }

--- a/src/GafferUIModule/GadgetBinding.cpp
+++ b/src/GafferUIModule/GadgetBinding.cpp
@@ -223,6 +223,7 @@ void GafferUIModule::bindGadget()
 		.staticmethod( "idleSignal" )
 		.def( "_idleSignalAccessedSignal", &Gadget::idleSignalAccessedSignal, return_value_policy<reference_existing_object>() )
 		.staticmethod( "_idleSignalAccessedSignal" )
+		.def( "_dirty", &Gadget::dirty )
 		.def( "_requestRender", &Gadget::requestRender )
 		.def( "select", &Gadget::select ).staticmethod( "select" )
 	;
@@ -233,6 +234,12 @@ void GafferUIModule::bindGadget()
 		.value( "Main", Gadget::Layer::Main )
 		.value( "MidFront", Gadget::Layer::MidFront )
 		.value( "Front", Gadget::Layer::Front )
+	;
+
+	enum_<Gadget::DirtyType>( "DirtyType" )
+		.value( "Render", Gadget::DirtyType::Render )
+		.value( "Bound", Gadget::DirtyType::Bound )
+		.value( "Layout", Gadget::DirtyType::Layout )
 	;
 
 	SignalClass<Gadget::RenderRequestSignal, DefaultSignalCaller<Gadget::RenderRequestSignal>, RenderRequestSlotCaller>( "RenderRequestSignal" );


### PR DESCRIPTION
I didn't quite manage to sneak this in to the 0.58 timeframe, so it'll have to wait for 0.59 now. This makes a bunch of small improvements to the Gadget classes, resulting in around a ~45% reduction in GraphGadget initialisation time for a large graph, and a corresponding ~38% reduction in draw times.