### PR TITLE
ShaderPlug : Relax `acceptsInput()` restrictions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Fixes
 - SetFilter : Added missing set expression operators to node reference/tooltip.
 - UIEditor : Fixed bug which allowed the creation of non-selectable presets.
 - EditScopes : Fixed crash in `EditScope::processors()` if intermediate nodes had no corresponding input.
+- ShaderAssignment : Fixed bug in `shader` plug connection acceptance that could cause crashes at shutdown.
 
 0.57.7.0 (relative to 0.57.6.0)
 ========

--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -211,12 +211,10 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 		s["b"]["out"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, direction = Gaffer.Plug.Direction.Out )
 
 		# Shader assignments should accept connections speculatively
-		# from unconnected box inputs and outputs. We use `execute()` for
-		# this because the backwards compatibility is provided only when
-		# a script is loading.
+		# from unconnected box inputs and outputs.
 
-		s.execute( """script["b"]["a"]["shader"].setInput( script["b"]["in"] )""" )
-		s.execute( """script["a"]["shader"].setInput( script["b"]["out"] )""" )
+		s["b"]["a"]["shader"].setInput( s["b"]["in"] )
+		s["a"]["shader"].setInput( s["b"]["out"] )
 
 		# but should reject connections to connected box inputs and outputs
 		# if they're unsuitable.
@@ -262,7 +260,7 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 		script["s"] = Gaffer.Switch()
 		script["s"].setup( Gaffer.Plug() )
 
-		script.execute( """script["a"]["shader"].setInput( script["s"]["out"] )""" )
+		script["a"]["shader"].setInput( script["s"]["out"] )
 		self.assertTrue( script["a"]["shader"].getInput().isSame( script["s"]["out"] ) )
 
 	def testAcceptsNoneInputs( self ) :
@@ -280,10 +278,29 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 		script["d"] = Gaffer.Dot()
 		script["d"].setup( script["s"]["out"] )
 
-		# Input only accepted during execution, for backwards compatibility
-		# when loading old scripts.
-		script.execute( """script["a"]["shader"].setInput( script["d"]["out"] )""" )
+		# The Dot doesn't know about Shaders, and just has a Color3fPlug
+		# input, so it should accept input from any old Color3fPlug, not
+		# merely shader outputs.
+
+		script["r"] = Gaffer.Random()
+		self.assertTrue( script["d"]["in"].acceptsInput( script["r"]["outColor"] ) )
+
+		# And we should be able to connect the Dot into the
+		# ShaderAssignment even if the Dot doesn't have an input
+		# yet. The user should be able to wire the graph up in any
+		# order, provided we end up with a valid network.
+
+		script["a"]["shader"].setInput( script["d"]["out"] )
 		self.assertTrue( script["a"]["shader"].getInput().isSame( script["d"]["out"] ) )
+
+		# But once that is done, the Dot should reject
+		# inputs that the ShaderAssignment can't handle.
+
+		self.assertFalse( script["d"]["in"].acceptsInput( script["r"]["outColor"] ) )
+
+		# And only accept inputs from a Shader.
+
+		self.assertTrue( script["d"]["in"].acceptsInput( script["s"]["out"] ) )
 
 	def testFilterInputAcceptanceFromReferences( self ) :
 
@@ -601,6 +618,16 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 		script.load()
 
 		self.assertNotIn( "__contextCompatibility", script["ShaderAssignment"] )
+
+	def testSwitchGraphDestruction( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["fileName"].setValue( os.path.join( os.path.dirname( __file__ ), "scripts", "shaderAssignmentSwitchProblem.gfr" ) )
+		script.load()
+
+		# This exposed a bug whereby `ShaderPlug.acceptsInput()` rejected an input as the inputs
+		# were being removed between nodes during script destruction.
+		del script
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/scripts/shaderAssignmentSwitchProblem.gfr
+++ b/python/GafferSceneTest/scripts/shaderAssignmentSwitchProblem.gfr
@@ -1,0 +1,50 @@
+import Gaffer
+import GafferScene
+import GafferSceneTest
+import IECore
+import imath
+
+Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 57, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 7, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+__children["shader"] = GafferSceneTest.TestShader( "shader" )
+parent.addChild( __children["shader"] )
+__children["shader"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["shaderAssignment"] = GafferScene.ShaderAssignment( "shaderAssignment" )
+parent.addChild( __children["shaderAssignment"] )
+__children["shaderAssignment"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["switch"] = Gaffer.Switch( "switch" )
+parent.addChild( __children["switch"] )
+__children["switch"].setup( GafferScene.ShaderPlug( "in", ) )
+__children["switch"]["in"].addChild( GafferScene.ShaderPlug( "in1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["switch"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["expr"] = Gaffer.Expression( "expr" )
+parent.addChild( __children["expr"] )
+__children["expr"]["__out"].addChild( Gaffer.IntPlug( "p0", direction = Gaffer.Plug.Direction.Out, defaultValue = 0, minValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["expr"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["dot"] = Gaffer.Dot( "dot" )
+parent.addChild( __children["dot"] )
+__children["dot"].setup( Gaffer.Color3fPlug( "in", defaultValue = imath.Color3f( 0, 0, 0 ), ) )
+__children["dot"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["shader"]["type"].setValue( 'test:surface' )
+__children["shader"]["__uiPosition"].setValue( imath.V2f( -15.1341801, 4.44920874 ) )
+__children["shaderAssignment"]["shader"].setInput( __children["switch"]["out"] )
+__children["shaderAssignment"]["__uiPosition"].setValue( imath.V2f( 14.4972792, -7.71484327 ) )
+__children["switch"]["index"].setInput( __children["expr"]["__out"]["p0"] )
+__children["switch"]["in"][0].setInput( __children["dot"]["out"] )
+__children["switch"]["__uiPosition"].setValue( imath.V2f( 0.277552426, -1.63281226 ) )
+__children["expr"]["__uiPosition"].setValue( imath.V2f( -10.2215948, -1.63226855 ) )
+__children["dot"]["in"].setInput( __children["shader"]["out"] )
+Gaffer.Metadata.registerValue( __children["dot"]["in"], 'noduleLayout:section', 'left' )
+Gaffer.Metadata.registerValue( __children["dot"]["out"], 'noduleLayout:section', 'right' )
+__children["dot"]["__uiPosition"].setValue( imath.V2f( -6.47503853, 4.44921875 ) )
+__children["expr"]["__engine"].setValue( 'python' )
+__children["expr"]["__expression"].setValue( 'parent["__out"]["p0"] = 0' )
+
+
+del __children
+

--- a/src/GafferScene/ShaderPlug.cpp
+++ b/src/GafferScene/ShaderPlug.cpp
@@ -158,7 +158,9 @@ bool ShaderPlug::acceptsInput( const Gaffer::Plug *input ) const
 
 	// And we support switches by traversing across them
 	// ourselves when necessary, in `shaderOutPlug()`.
-	if( auto switchNode = runTimeCast<const Switch>( sourcePlug->node() ) )
+
+	const Node *sourceNode = sourcePlug->node();
+	if( auto switchNode = runTimeCast<const Switch>( sourceNode ) )
 	{
 		if(
 			sourcePlug == switchNode->outPlug() ||
@@ -187,25 +189,24 @@ bool ShaderPlug::acceptsInput( const Gaffer::Plug *input ) const
 		}
 	}
 
-	// Really, we want to return false now, but during
-	// deserialisation we're not in control of the order
-	// of connection of plugs. We must accept intermediate
-	// connections from plugs on utility nodes on the
-	// assumption that they will later be connected to
-	// a shader.
+	// We must accept intermediate connections from plugs on utility nodes on the
+	// assumption that they will later be connected to a shader. Once we're connected
+	// to `sourcePlug`, we'll be consulted about any inputs it will receive, so we
+	// can reject non-shaders then.
 
-	const ScriptNode *script = ancestor<ScriptNode>();
-	if( !script || !script->isExecuting() )
-	{
-		return false;
-	}
-
-	const Node *sourceNode = sourcePlug->node();
-	return
+	if(
 		runTimeCast<const SubGraph>( sourceNode ) ||
 		runTimeCast<const Dot>( sourceNode ) ||
 		runTimeCast<const BoxIO>( sourceNode )
-	;
+	)
+	{
+		if( isParameterType( sourcePlug ) )
+		{
+			return true;
+		}
+	}
+
+	return false;
 }
 
 IECore::MurmurHash ShaderPlug::attributesHash() const

--- a/src/GafferScene/ShaderPlug.cpp
+++ b/src/GafferScene/ShaderPlug.cpp
@@ -95,7 +95,7 @@ bool isParameterType( const Plug *plug )
 		default :
 			// Use typeName query to avoid hard dependency on
 			// GafferOSL. It may be that we should move ClosurePlug
-			// to GafferScene anyway.s
+			// to GafferScene anyway.
 			return plug->isInstanceOf( "GafferOSL::ClosurePlug" );
 	}
 	return false;


### PR DESCRIPTION
These were tightened too much in #2321 via c6dfc6c. That PR was about tightening up `acceptsInput()` for specific plug types (ShaderPlug, TaskPlug, FilterPlug and ClosurePlug) which were introduced to replace the use of more generic plug types (Plug and IntPlug). TaskPlug, FilterPlug and ClosurePlug should never accept new inputs from their former generic types, except to support the loading of old scripts, hence we tightened the checks in cases where loading wasn't being performed. It was a mistake to do the same for ShaderPlug though. ShaderPlug is different in that it can accept inputs not only from plugs of its type, but also from any suitable parameter plug being output from a Shader. The acceptance of intermediate inputs from Dots etc therefore needs to be allowed at any time, not just when loading old scripts.

This improves some interactions in the UI, allowing a Dot output to be connected to a ShaderAssignment before a Shader is connected to the Dot input. It also fixes a crash when destroying a node network with a Dot feeding through a Switch into a ShaderAssignment, as demonstrated in `ShaderAssignmentTest.testSwitchGraphDestruction()`.