### PR TITLE
EditScope : Harden processors() against misconfigured child nodes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Fixes
 - Box : Fixed GIL management bug that could cause hangs when promoting a plug.
 - SetFilter : Added missing set expression operators to node reference/tooltip.
 - UIEditor : Fixed bug which allowed the creation of non-selectable presets.
+- EditScopes : Fixed crash in `EditScope::processors()` if intermediate nodes had no corresponding input.
 
 0.57.7.0 (relative to 0.57.6.0)
 ========

--- a/python/GafferTest/EditScopeTest.py
+++ b/python/GafferTest/EditScopeTest.py
@@ -150,6 +150,29 @@ class EditScopeTest( GafferTest.TestCase ) :
 		with six.assertRaisesRegex( self, RuntimeError, "Output not linked to input" ) :
 			e.acquireProcessor( "Test" )
 
+		# Check internal connections of children
+
+		box = Gaffer.Box()
+		box["BoxIn"] = Gaffer.BoxIn()
+		box["BoxOut"] = Gaffer.BoxOut()
+		box["BoxIn"].setup( e["in"] )
+		box["BoxOut"].setup( e["out"] )
+
+		e["b"] = box
+		e["b"]["in"].setInput( e["BoxIn"]["out"] )
+		e["BoxOut"]["in"].setInput( e["b"]["out"] )
+
+		with six.assertRaisesRegex( self, RuntimeError, "Node 'b' has no corresponding input" ) :
+			e.processors()
+
+		box["BoxOut"]["in"].setInput( box["BoxIn"]["out"] )
+
+		with six.assertRaisesRegex( self, RuntimeError, "Node 'b' has no corresponding input" ) :
+			e.processors()
+
+		e["b"]["BoxOut"]["passThrough"].setInput( e["b"]["BoxIn"]["out"] )
+		self.assertEqual( e.processors(), [] )
+
 	def testSerialisation( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/src/Gaffer/EditScope.cpp
+++ b/src/Gaffer/EditScope.cpp
@@ -136,9 +136,16 @@ std::vector<DependencyNode *> EditScope::processors()
 			}
 		}
 
-		if( plug->direction() == Plug::Out )
+		if( plug->direction() == Plug::Out && node )
 		{
-			plug = node ? node->correspondingInput( plug )->getInput() : plug->getInput();
+			if( auto input = node->correspondingInput( plug ) )
+			{
+				plug = input->getInput();
+			}
+			else
+			{
+				throw IECore::Exception( "Node '" + node->getName().string() + "' has no corresponding input" );
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Could cause a segfault clicking the Edit Scope UI jump menu, or for any other invocations of `EditScope::processors()`.
