### PR TITLE
Catalogue : Add shortcuts to duplicate current/selected images

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,12 @@
 0.58.x.x
 ========
 
+Improvements
+------------
+
+- Catalogue : Added <kbd>Ctrl-D</kbd> shortcut to duplicate selected images (#3545).
+- Viewer : Added <kbd>Ctrl-D</kbd> shortcut to duplicate currently viewed image when viewing the output of Catalogue node (#3545).
+
 Fixes
 -----
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -335,6 +335,7 @@ Isolate alpha channel                 :kbd:`A`
 Center image at 1:1 scale             :kbd:`Home`
 Next Catalogue image                  :kbd:`↓`
 Previous Catalogue image              :kbd:`↑`
+Duplicate current Catalogue image     :kbd:`Ctrl` + `:kbd:`D`
 ===================================== =============================================
 ```
 


### PR DESCRIPTION
Adds keyboard shortcuts to duplicate the currently selected/viewed Catalogue image to the viewer (Closes #3545).

@johnhaddon, we should have a think about how we want to avoid code duplication for actions triggered outside
the _ImageListing UI.

@andrewkaufman I went for `Ctrl-D` for now, as we generally try to avoid no-modifier shortcuts that make persistent changes, be good to understand more about what specifically prompted the 'no modifier' part of the original request.
