### PR TITLE
graphics.svg : Align to pixel boundaries

### DIFF
--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -118,9 +118,9 @@ Gaffer.Metadata.registerNode(
 # NodeGadget drop handler
 ##########################################################################
 
-GafferUI.Pointer.registerPointer( "addObjects", GafferUI.Pointer( "addObjects.png", imath.V2i( 36, 18 ) ) )
-GafferUI.Pointer.registerPointer( "removeObjects", GafferUI.Pointer( "removeObjects.png", imath.V2i( 36, 18 ) ) )
-GafferUI.Pointer.registerPointer( "replaceObjects", GafferUI.Pointer( "replaceObjects.png", imath.V2i( 36, 18 ) ) )
+GafferUI.Pointer.registerPointer( "addObjects", GafferUI.Pointer( "addObjects.png", imath.V2i( 53, 14 ) ) )
+GafferUI.Pointer.registerPointer( "removeObjects", GafferUI.Pointer( "removeObjects.png", imath.V2i( 53, 14 ) ) )
+GafferUI.Pointer.registerPointer( "replaceObjects", GafferUI.Pointer( "replaceObjects.png", imath.V2i( 53, 14 ) ) )
 
 __DropMode = IECore.Enum.create( "None_", "Add", "Remove", "Replace" )
 

--- a/resources/GafferLogo.py
+++ b/resources/GafferLogo.py
@@ -1,3 +1,7 @@
 {
+	"options" : {
+		"validatePixelAlignment" : False
+	},
+
 	"ids" : [ "GafferLogo" ]
 }

--- a/resources/GafferLogoMini.py
+++ b/resources/GafferLogoMini.py
@@ -1,3 +1,7 @@
 {
+	"options" : {
+		"validatePixelAlignment" : False
+	},
+
 	"ids" : [ "GafferLogoMini" ]
 }

--- a/resources/docGraphics.py
+++ b/resources/docGraphics.py
@@ -1,4 +1,8 @@
 {
+	"options" : {
+		"validatePixelAlignment" : False
+	},
+
 	"ids" : [
 		"mousePointerLeftClick",
 		"mousePointerRightClick",

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -1,71 +1,259 @@
 {
+	# \todo Remove once all artwork has been aligned
 	"options" : {
 		"validatePixelAlignment" : False
 	},
 
+	"groups" : {
+
+		"pointers" : {
+
+			"options" : {
+				"requiredWidth" : 32,
+				"requiredHeight" : 32,
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				"plug", # \todo prefix with 'pointer'
+				"values", # \todo prefix with 'pointer'
+				"rgba", # \todo prefix with 'pointer'
+				"nodes", # \todo prefix with 'pointer'
+				"paths", # \todo prefix with 'pointer'
+				'pointerContextMenu',
+				'pointerTab',
+				'pointerDetachedPanel',
+				"move", # \todo prefix with 'pointer'
+				"moveHorizontally", # \todo prefix with 'pointer',
+				"moveVertically", # \todo prefix with 'pointer'
+				"moveDiagonallyDown", # \todo prefix with 'pointer'
+				"moveDiagonallyUp", # \todo prefix with 'pointer'
+				'pointerTarget',
+				'pointerCrossHair',
+			]
+		},
+
+		"pointers-pathFilterUI" : {
+
+			"options" : {
+				"requiredWidth" : 64,
+				"requiredHeight" : 32,
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				"objects", # \todo prefix with 'pointer'
+				"addObjects", # \todo prefix with 'pointer'
+				"removeObjects", # \todo prefix with 'pointer'
+				"replaceObjects" # \todo prefix with 'pointer'
+			]
+		},
+
+		"arrows-10x10" : {
+
+			"options" : {
+				"requiredWidth" : 10,
+				"requiredHeight" : 10,
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				'arrowDown10',
+				'arrowUp10',
+				'arrowLeft10',
+				'arrowRight10',
+				'collapsibleArrowDown',
+				'collapsibleArrowDownHover',
+				'collapsibleArrowRight',
+				'collapsibleArrowRightHover'
+			]
+
+		},
+
+		"catalogueStatus" : {
+
+			"options" : {
+				"requiredWidth" : 13,
+				"requiredHeight" : 13,
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				'catalogueStatusBatchRenderComplete',
+				'catalogueStatusBatchRenderRunning',
+				'catalogueStatusDisk',
+				'catalogueStatusDisplay',
+				'catalogueStatusInteractiveRenderComplete',
+				'catalogueStatusInteractiveRenderRunning'
+			]
+
+		},
+
+		"sceneView" : {
+
+			"options" : {
+				"requiredWidth" : 25,
+				"requiredHeight" : 25,
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				'cameraOff',
+				'cameraOn',
+				'drawingStyles',
+				'expansion',
+				'grid', # \todo rename to 'sceneViewGadgets'
+				'selectionMaskOff',
+				'selectionMaskOn',
+				'shading'
+			]
+
+		},
+
+		"imageView" : {
+
+			"options" : {
+				"requiredWidth" : 25,
+				"requiredHeight" : 25,
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				'clippingOff',
+				'clippingOn',
+				'exposureOff',
+				'exposureOn',
+				'gammaOff',
+				'gammaOn',
+				'soloChannel-1',
+				'soloChannel0',
+				'soloChannel1',
+				'soloChannel2',
+				'soloChannel3'
+			]
+
+		},
+
+		"tools" : {
+
+			"options" : {
+				"requiredWidth" : 25,
+				"requiredHeight" : 25,
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				'gafferSceneUISelectionTool',
+				'gafferSceneUICameraTool',
+				'gafferSceneUICropWindowTool',
+				'gafferSceneUIRotateTool',
+				'gafferSceneUIScaleTool',
+				'gafferSceneUITranslateTool',
+			]
+
+		},
+
+		"browserIcons" : {
+
+			"options" : {
+				"requiredWidth" : 14,
+				"requiredHeight" : 14,
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				'bookmarks',
+				'pathChooser',
+				'pathListingList',
+				'pathListingTree',
+				'pathUpArrow',
+				'refresh'
+			]
+
+		},
+
+		"controls-checkBox" : {
+
+			"options" : {
+				"requiredWidth" : 20,
+				"requiredHeight" : 20,
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				'checkBoxChecked',
+				'checkBoxCheckedDisabled',
+				'checkBoxCheckedHover',
+				'checkBoxIndeterminate',
+				'checkBoxIndeterminateDisabled',
+				'checkBoxIndeterminateHover',
+				'checkBoxUnchecked',
+				'checkBoxUncheckedDisabled',
+				'checkBoxUncheckedHover'
+			]
+
+		},
+
+		"controls-switch" : {
+
+			"options" : {
+				"requiredWidth" : 16,
+				"requiredHeight" : 16,
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				'toggleIndeterminate',
+				'toggleIndeterminateDisabled',
+				'toggleIndeterminateHover',
+				'toggleOff',
+				'toggleOffDisabled',
+				'toggleOffHover',
+				'toggleOn',
+				'toggleOnDisabled',
+				'toggleOnHover'
+			]
+
+		},
+
+		"viewer" : {
+
+			"options" : {
+				"requiredWidth" : 25,
+				"requiredHeight" : 25,
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				'viewPause',
+				'viewPaused'
+			]
+
+		}
+
+	},
+
 	"ids" : [
-		'addObjects',
-		'arrowDown10',
-		'arrowLeft10',
-		'arrowRight10',
-		'arrowUp10',
 		'bookmarkStar',
 		'bookmarkStar2',
-		'bookmarks',
 		'boxInNode',
 		'boxNode',
 		'boxOutNode',
-		'cameraOff',
-		'cameraOn',
-		'catalogueStatusBatchRenderComplete',
-		'catalogueStatusBatchRenderRunning',
-		'catalogueStatusDisk',
-		'catalogueStatusDisplay',
-		'catalogueStatusInteractiveRenderComplete',
-		'catalogueStatusInteractiveRenderRunning',
-		'checkBoxChecked',
-		'checkBoxCheckedDisabled',
-		'checkBoxCheckedHover',
-		'checkBoxIndeterminate',
-		'checkBoxIndeterminateDisabled',
-		'checkBoxIndeterminateHover',
-		'checkBoxUnchecked',
-		'checkBoxUncheckedDisabled',
-		'checkBoxUncheckedHover',
 		'classVectorParameterHandle',
-		'clippingOff',
-		'clippingOn',
-		'collapsibleArrowDown',
-		'collapsibleArrowDownHover',
-		'collapsibleArrowRight',
-		'collapsibleArrowRightHover',
 		'debugNotification',
 		'debugSmall',
 		'delete',
 		'deleteSmall',
-		'drawingStyles',
 		'duplicate',
 		'editScopeNode',
 		'editScopeProcessorNode',
 		'errorNotification',
 		'errorSmall',
-		'expansion',
 		'export',
-		'exposureOff',
-		'exposureOn',
 		'extract',
 		'failure',
 		'gadgetError',
-		'gafferSceneUICameraTool',
-		'gafferSceneUICropWindowTool',
-		'gafferSceneUIRotateTool',
-		'gafferSceneUIScaleTool',
-		'gafferSceneUISelectionTool',
-		'gafferSceneUITranslateTool',
-		'gammaOff',
-		'gammaOn',
 		'gear',
-		'grid',
 		'headerSortDown',
 		'headerSortUp',
 		'info',
@@ -79,11 +267,6 @@
 		'menuIndicator',
 		'menuIndicatorDisabled',
 		'minus',
-		'move',
-		'moveDiagonallyDown',
-		'moveDiagonallyUp',
-		'moveHorizontally',
-		'moveVertically',
 		'navigationArrow',
 		'nodeSetDriverNodeSelection',
 		'nodeSetDriverNodeSet',
@@ -92,22 +275,9 @@
 		'nodeSetNumericBookmarkSet',
 		'nodeSetSourceSet',
 		'nodeSetStandardSet',
-		'nodes',
-		'objects',
-		'pathChooser',
-		'pathListingList',
-		'pathListingTree',
-		'pathUpArrow',
-		'paths',
-		'plug',
 		'plugAdder',
 		'plugAdderHighlighted',
 		'plus',
-		'pointerContextMenu',
-		'pointerCrossHair',
-		'pointerDetachedPanel',
-		'pointerTab',
-		'pointerTarget',
 		'railBottom',
 		'railGap',
 		'railLine',
@@ -115,30 +285,17 @@
 		'railSingle',
 		'railTop',
 		'referenceNode',
-		'refresh',
-		'removeObjects',
 		'renderStop',
 		'renderStart',
 		'renderResume',
 		'renderPause',
 		'reorderVertically',
-		'replaceObjects',
-		'rgba',
 		'scene',
 		'sceneInspectorHistory',
 		'sceneInspectorInheritance',
 		'search',
-		'clearSearch',
-		'selectionMaskOff',
-		'selectionMaskOn',
 		'setMembershipDot',
-		'shading',
 		'shuffleArrow',
-		'soloChannel-1',
-		'soloChannel0',
-		'soloChannel1',
-		'soloChannel2',
-		'soloChannel3',
 		'subMenuArrow',
 		'success',
 		'successWarning',
@@ -150,28 +307,17 @@
 		'timelinePlay',
 		'timelineStart',
 		'timelineStop',
-		'toggleIndeterminate',
-		'toggleIndeterminateDisabled',
-		'toggleIndeterminateHover',
-		'toggleOff',
-		'toggleOffDisabled',
-		'toggleOffHover',
-		'toggleOn',
-		'toggleOnDisabled',
-		'toggleOnHover',
 		'valueChanged',
-		'values',
-		'viewPause',
-		'viewPaused',
 		'warningNotification',
 		'warningSmall',
-		'searchFocusOff',
-		'searchFocusOn',
 		'scrollToBottom',
-		"editOn",
-		"editOff",
-		"editDisabled",
-		"lutGPU",
-		"lutCPU",
+		'searchFocusOn',
+		'searchFocusOff',
+		'clearSearch',
+		'lutGPU',
+		'lutCPU',
+		'editDisabled',
+		'editOff',
+		'editOn'
 	]
 }

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -1,4 +1,8 @@
 {
+	"options" : {
+		"validatePixelAlignment" : False
+	},
+
 	"ids" : [
 		'addObjects',
 		'arrowDown10',

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -15,120 +15,135 @@
    height="1000"
    id="svg2"
    version="1.1"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
    sodipodi:docname="graphics.svg"
    enable-background="new">
   <defs
      id="defs4">
     <linearGradient
-       id="linearGradient1740"
+       id="linearGradient5870"
        osb:paint="solid">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         style="stop-color:#3c3c3c;stop-opacity:1;"
          offset="0"
-         id="stop1738" />
+         id="stop5868" />
     </linearGradient>
     <linearGradient
-       id="linearGradient1726"
+       id="linearGradient5864"
        osb:paint="solid">
       <stop
-         style="stop-color:#b81515;stop-opacity:1;"
+         style="stop-color:#829d8c;stop-opacity:1;"
          offset="0"
-         id="stop1722" />
+         id="stop5862" />
     </linearGradient>
     <linearGradient
-       id="linearGradient1731"
-       osb:paint="solid">
-      <stop
-         style="stop-color:#9e9e9e;stop-opacity:1;"
-         offset="0"
-         id="stop1728" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5421"
+       id="linearGradient1974"
        osb:paint="solid">
       <stop
          style="stop-color:#000000;stop-opacity:1;"
          offset="0"
-         id="stop5419" />
+         id="stop1972" />
     </linearGradient>
     <linearGradient
-       id="linearGradient1723"
+       id="linearGradient3014"
        osb:paint="solid">
       <stop
-         style="stop-color:#3c3c3c;stop-opacity:1;"
+         style="stop-color:#000000;stop-opacity:1;"
          offset="0"
-         id="stop1721" />
+         id="stop3012" />
     </linearGradient>
     <linearGradient
-       id="linearGradient1716"
+       id="linearGradient3002"
        osb:paint="solid">
       <stop
-         style="stop-color:#3c3c3c;stop-opacity:1;"
+         style="stop-color:#787878;stop-opacity:1;"
          offset="0"
-         id="stop1714" />
+         id="stop3000" />
     </linearGradient>
     <linearGradient
-       id="linearGradient1710"
+       id="linearGradient2785"
        osb:paint="solid">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         style="stop-color:#787878;stop-opacity:1;"
          offset="0"
-         id="stop1708" />
+         id="stop2783" />
     </linearGradient>
     <linearGradient
-       id="linearGradient1722"
+       id="linearGradient2779"
        osb:paint="solid">
       <stop
-         style="stop-color:#9e9e9e;stop-opacity:1;"
+         style="stop-color:#787878;stop-opacity:1;"
          offset="0"
-         id="stop1720" />
+         id="stop2777" />
     </linearGradient>
     <linearGradient
-       id="linearGradient1697"
+       id="linearGradient2773"
        osb:paint="solid">
       <stop
-         style="stop-color:#9e9e9e;stop-opacity:1;"
+         style="stop-color:#787878;stop-opacity:1;"
          offset="0"
-         id="stop1695" />
+         id="stop2771" />
     </linearGradient>
     <linearGradient
-       id="linearGradient1691"
+       id="linearGradient2767"
        osb:paint="solid">
       <stop
-         style="stop-color:#9e9e9e;stop-opacity:1;"
+         style="stop-color:#787878;stop-opacity:1;"
          offset="0"
-         id="stop1688" />
+         id="stop2765" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3889"
-       osb:paint="solid"
-       gradientTransform="translate(105.56325,109.08497)">
-      <stop
-         style="stop-color:#9e9e9e;stop-opacity:1;"
-         offset="0"
-         id="stop3887" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient1659"
+       id="linearGradient2705"
        osb:paint="solid">
       <stop
-         style="stop-color:#3c3c3c;stop-opacity:1;"
+         style="stop-color:#787878;stop-opacity:1;"
          offset="0"
-         id="stop1657" />
+         id="stop2703" />
     </linearGradient>
     <linearGradient
-       id="linearGradient1653"
+       id="boundsTemplate"
        osb:paint="solid">
       <stop
-         style="stop-color:#686868;stop-opacity:1;"
+         style="stop-color:#ff0101;stop-opacity:0.0787037;"
          offset="0"
-         id="stop1651" />
+         id="stop2644" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2640"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2638" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2559"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2557" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2553"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2551" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2547"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2545" />
     </linearGradient>
     <linearGradient
        id="linearGradient1643"
        osb:paint="solid"
-       gradientTransform="matrix(0,-0.58060489,0.58060489,0,667.41509,28.649796)">
+       gradientTransform="translate(0.13258252,471.41431)">
       <stop
          style="stop-color:#9e9e9e;stop-opacity:1;"
          offset="0"
@@ -303,18 +318,6 @@
          id="stop1569" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient6232">
-      <stop
-         style="stop-color:#949494;stop-opacity:1"
-         offset="0"
-         id="stop6228" />
-      <stop
-         style="stop-color:#8f8f8f;stop-opacity:0"
-         offset="1"
-         id="stop6230" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient6112"
        inkscape:collect="always">
       <stop
@@ -374,7 +377,7 @@
     <linearGradient
        id="backgroundLighter"
        osb:paint="solid"
-       gradientTransform="matrix(-3.5374372,0,0,4.8441373,1177.7743,490.98508)">
+       gradientTransform="matrix(-3.5374372,0,0,4.8441373,435.74315,7818.3291)">
       <stop
          style="stop-color:#9e9e9e;stop-opacity:1;"
          offset="0"
@@ -384,7 +387,7 @@
        id="backgroundLightLowlight-5"
        osb:paint="solid">
       <stop
-         style="stop-color:#434343;stop-opacity:1;"
+         style="stop-color:#525252;stop-opacity:1;"
          offset="0"
          id="stop5804" />
     </linearGradient>
@@ -399,7 +402,7 @@
     <linearGradient
        id="foreground"
        osb:paint="solid"
-       gradientTransform="matrix(0.24,0,0,0.24,34.022055,144.73006)">
+       gradientTransform="matrix(0.24,0,0,0.24,128.58,124.63193)">
       <stop
          style="stop-color:#e0e0e0;stop-opacity:1;"
          offset="0"
@@ -421,63 +424,6 @@
          offset="0"
          id="stop6313" />
     </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath4107">
-      <path
-         sodipodi:open="true"
-         sodipodi:end="6.2821966"
-         sodipodi:start="0"
-         transform="matrix(0.21504038,0,0,0.21405979,51.877933,134.54238)"
-         d="m 220.61732,174.54121 a 33.499184,33.499184 0 1 1 -2e-5,-0.0331"
-         sodipodi:ry="33.499184"
-         sodipodi:rx="33.499184"
-         sodipodi:cy="174.54121"
-         sodipodi:cx="187.11813"
-         id="path4109"
-         style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:4.66092873;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         sodipodi:type="arc" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6112"
-       id="linearGradient6005"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.87285128,0,0,1,64.086082,0.12290918)"
-       x1="470.90897"
-       y1="90.327164"
-       x2="470.95706"
-       y2="98.08519" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6106"
-       id="linearGradient5930"
-       x1="479.95123"
-       y1="81.894287"
-       x2="482.25763"
-       y2="96.752724"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0410235,0,0,1.0168263,-21.141649,-3.0997358)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6106"
-       id="linearGradient6224"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0410235,0,0,1.0168263,-21.141649,-3.0997358)"
-       x1="479.95123"
-       y1="81.894287"
-       x2="482.25763"
-       y2="96.752724" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6232"
-       id="linearGradient6226"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.87285128,0,0,1,64.086082,0.12290918)"
-       x1="470.90897"
-       y1="90.327164"
-       x2="470.95706"
-       y2="98.08519" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#backgroundLight"
@@ -495,63 +441,8 @@
        y1="67.432732"
        x2="104.30441"
        y2="67.432732"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#backgroundLightLowlight-5"
-       id="linearGradient5851"
        gradientUnits="userSpaceOnUse"
-       x1="87"
-       y1="67.612183"
-       x2="103.5"
-       y2="67.612183"
-       gradientTransform="translate(-0.5625,-0.50000038)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#backgroundLight"
-       id="linearGradient5908"
-       gradientUnits="userSpaceOnUse"
-       x1="87"
-       y1="67.362183"
-       x2="103"
-       y2="67.362183" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#backgroundLightLowlight-5"
-       id="linearGradient5910"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.5625,-0.50000038)"
-       x1="87"
-       y1="67.612183"
-       x2="103.5"
-       y2="67.612183" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#brightColor"
-       id="linearGradient5945"
-       gradientUnits="userSpaceOnUse"
-       x1="87"
-       y1="67.362183"
-       x2="103"
-       y2="67.362183" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#brightColor"
-       id="linearGradient6013"
-       gradientUnits="userSpaceOnUse"
-       x1="87"
-       y1="67.362183"
-       x2="103"
-       y2="67.362183" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#foreground"
-       id="linearGradient6021"
-       gradientUnits="userSpaceOnUse"
-       x1="145.32397"
-       y1="67.442017"
-       x2="164.30441"
-       y2="67.442017" />
+       gradientTransform="matrix(0.94551188,0,0,0.92891877,-69.63579,1921.786)" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#backgroundDark"
@@ -605,19 +496,9 @@
     <linearGradient
        inkscape:collect="always"
        xlink:href="#foreground"
-       id="linearGradient1552"
-       x1="125.42407"
-       y1="215.29883"
-       x2="151.82007"
-       y2="215.29883"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-1.7137094,16.582842)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#foreground"
        id="linearGradient1556"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(25.201613,16.58284)"
+       gradientTransform="translate(25.128445,16.571219)"
        x1="125.42407"
        y1="215.29883"
        x2="151.82007"
@@ -663,7 +544,7 @@
        inkscape:collect="always"
        xlink:href="#foreground"
        id="linearGradient1574"
-       gradientTransform="matrix(0.43578082,0,0,1.3405581,143.16965,-12.094075)"
+       gradientTransform="matrix(0.43578082,0,0,1.3405581,143.16964,-12.740484)"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
@@ -674,7 +555,7 @@
        x2="257.00393"
        y2="66.360213"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66648203,0,0,1.4975348,85.545129,-35.017143)" />
+       gradientTransform="matrix(0.66648203,0,0,1.4975348,85.545122,-35.663552)" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient1586"
@@ -734,25 +615,8 @@
        y1="231.88168"
        x2="177.02168"
        y2="231.88168"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1586"
-       id="linearGradient1626"
-       x1="123.71041"
-       y1="231.88168"
-       x2="150.10629"
-       y2="231.88168"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1586"
-       id="linearGradient1634"
-       x1="293.07089"
-       y1="13.132758"
-       x2="304.68634"
-       y2="13.132758"
-       gradientUnits="userSpaceOnUse" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.07316819,-0.01162128)" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient1644"
@@ -762,124 +626,6 @@
        x2="147.1"
        y2="91.862193"
        gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1586"
-       id="linearGradient1652"
-       x1="253"
-       y1="65.652184"
-       x2="254"
-       y2="65.652184"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.044913,0,0,0.61490486,-11.362971,22.417805)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#backgroundLighter"
-       id="linearGradient1682"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.30129759,0,0,1.4067094,174.21797,-10.364137)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1586"
-       id="linearGradient1684"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46080373,0,0,1.571432,134.37655,-34.418368)"
-       x1="247"
-       y1="66.360213"
-       x2="257.00393"
-       y2="66.360213" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#backgroundLighter"
-       id="linearGradient1688"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.30129759,0,0,1.406711,180.21796,-10.364244)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1586"
-       id="linearGradient1690"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46080373,0,0,1.5714339,140.37653,-34.418502)"
-       x1="247"
-       y1="66.360213"
-       x2="257.00393"
-       y2="66.360213" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1586"
-       id="linearGradient1739"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.044913,0,0,0.42266021,-14.362966,43.800586)"
-       x1="253"
-       y1="65.652184"
-       x2="254"
-       y2="65.652184" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#foreground"
-       id="linearGradient1748"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.83200537,0,0,0.87540517,-185.40186,69.355943)"
-       x1="143.36874"
-       y1="233.49455"
-       x2="157.56445"
-       y2="233.49455" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1586"
-       id="linearGradient1750"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97547648,0,0,1.0263601,-209.88689,35.145297)"
-       x1="144.63138"
-       y1="231.56898"
-       x2="159.49074"
-       y2="231.56898" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1586"
-       id="linearGradient1777"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.044913,0,0,0.42266021,-8.362966,43.800586)"
-       x1="253"
-       y1="65.652184"
-       x2="254"
-       y2="65.652184" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1586"
-       id="linearGradient1609"
-       gradientUnits="userSpaceOnUse"
-       x1="141.15625"
-       y1="232.33093"
-       x2="159.21875"
-       y2="232.33093" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1586"
-       id="linearGradient1611"
-       gradientUnits="userSpaceOnUse"
-       x1="141.1564"
-       y1="233.59351"
-       x2="150.67906"
-       y2="233.59351" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#foreground"
-       id="linearGradient1613"
-       gradientUnits="userSpaceOnUse"
-       x1="141.15649"
-       y1="226.47861"
-       x2="159.22701"
-       y2="226.47861" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1586"
-       id="linearGradient1615"
-       gradientUnits="userSpaceOnUse"
-       x1="141.15649"
-       y1="226.47861"
-       x2="159.22701"
-       y2="226.47861" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#backgroundLight"
@@ -898,8 +644,513 @@
        y2="111.48718" />
     <linearGradient
        inkscape:collect="always"
+       xlink:href="#boundsTemplate"
+       id="linearGradient2648"
+       x1="10"
+       y1="1358.3622"
+       x2="42"
+       y2="1358.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6106"
+       id="linearGradient2704"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0410235,0,0,1.0168263,-21.141651,-1.0996925)"
+       x1="479.95123"
+       y1="81.894287"
+       x2="482.25763"
+       y2="96.752724" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6112"
+       id="linearGradient2706"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87285128,0,0,1,-60.73369,1213.4116)"
+       x1="470.90897"
+       y1="90.327164"
+       x2="470.95706"
+       y2="98.08519" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6112"
+       id="linearGradient2723"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87285128,0,0,1,-96.71627,1213.4244)"
+       x1="470.90897"
+       y1="90.327164"
+       x2="470.95706"
+       y2="98.08519" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#boundsTemplate"
+       id="linearGradient2759"
+       gradientUnits="userSpaceOnUse"
+       x1="10"
+       y1="1358.3622"
+       x2="42"
+       y2="1358.3622"
+       gradientTransform="matrix(2,0,0,1,-10,47.63782)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#boundsTemplate"
+       id="linearGradient2759-7"
+       gradientUnits="userSpaceOnUse"
+       x1="10"
+       y1="1358.3622"
+       x2="42"
+       y2="1358.3622"
+       gradientTransform="matrix(0.3125,0,0,0.3125,6.875,1074.5118)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#boundsTemplate"
+       id="linearGradient2641"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40625,0,0,0.40625,5.9375,1010.6653)"
+       x1="10"
+       y1="1358.3622"
+       x2="42"
+       y2="1358.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#boundsTemplate"
+       id="linearGradient2660"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.78124999,0,0,0.78124999,2.1874999,573.27942)"
+       x1="10"
+       y1="1358.3622"
+       x2="42"
+       y2="1358.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient2707"
+       x1="240.04054"
+       y1="205.7635"
+       x2="259.93243"
+       y2="205.7635"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient2769"
+       x1="-49.38419"
+       y1="172.36218"
+       x2="-30.61581"
+       y2="172.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient2775"
+       x1="-18.781151"
+       y1="166.51463"
+       x2="-0.77300137"
+       y2="166.51463"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient2781"
+       x1="-18.781244"
+       y1="173.51839"
+       x2="-9.28125"
+       y2="173.51839"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient2787"
+       x1="-18.781248"
+       y1="172.2684"
+       x2="-0.78125262"
+       y2="172.2684"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#boundsTemplate"
+       id="linearGradient2860"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.78124999,0,0,0.78124999,2.187498,649.27943)"
+       x1="10"
+       y1="1358.3622"
+       x2="42"
+       y2="1358.3622" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath2950">
+      <path
+         sodipodi:type="arc"
+         style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path2952"
+         sodipodi:cx="92.023056"
+         sodipodi:cy="171.96445"
+         sodipodi:rx="7.1108398"
+         sodipodi:ry="7.1110315"
+         d="m 99.133896,171.96445 a 7.1108398,7.1110315 0 0 1 -7.109082,7.11103 7.1108398,7.1110315 0 0 1 -7.112597,-7.10752 7.1108398,7.1110315 0 0 1 7.105566,-7.11454 7.1108398,7.1110315 0 0 1 7.116109,7.104"
+         sodipodi:start="0"
+         sodipodi:end="6.2821966"
+         sodipodi:open="true" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2779"
+       id="linearGradient2974"
+       gradientTransform="matrix(0.24,0,0,0.24,122.08,124.63193)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2779"
+       id="linearGradient2976"
+       gradientTransform="matrix(0.24,0,0,0.24,122.08,124.63193)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2779"
+       id="linearGradient2978"
+       gradientTransform="matrix(0.24,0,0,0.24,122.08,124.63193)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2779"
+       id="linearGradient2980"
+       gradientTransform="matrix(0.24,0,0,0.24,122.08,124.63193)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2779"
+       id="linearGradient2982"
+       gradientTransform="matrix(0.24,0,0,0.24,122.08,124.63193)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2779"
+       id="linearGradient2984"
+       gradientTransform="matrix(0.24,0,0,0.24,122.08,124.63193)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3004"
+       x1="187.92133"
+       y1="192.28339"
+       x2="203.92105"
+       y2="192.28339"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3010"
+       gradientUnits="userSpaceOnUse"
+       x1="187.92133"
+       y1="192.28339"
+       x2="203.92105"
+       y2="192.28339" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3002"
+       id="linearGradient3016"
+       x1="186.00034"
+       y1="192.86237"
+       x2="205"
+       y2="192.86237"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3002"
+       id="linearGradient3034"
+       gradientTransform="matrix(-3.5374372,0,0,4.8441373,1193.2743,491.48508)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3036"
+       gradientTransform="matrix(-3.5374372,0,0,4.8441373,1193.2743,491.48508)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#boundsTemplate"
+       id="linearGradient3184"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.78124999,0,0,0.78124999,2.187498,725.27943)"
+       x1="10"
+       y1="1358.3622"
+       x2="42"
+       y2="1358.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#boundsTemplate"
+       id="linearGradient3322"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.43749999,0,0,0.43749999,5.6249989,1262.7165)"
+       x1="10"
+       y1="1358.3622"
+       x2="42"
+       y2="1358.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#boundsTemplate"
+       id="linearGradient1820"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62499997,0,0,0.62499997,3.7499983,1083.0235)"
+       x1="10"
+       y1="1358.3622"
+       x2="42"
+       y2="1358.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLightLowlight-5"
+       id="linearGradient1847"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99220307,0,0,0.99833048,0.13900758,-0.37418199)"
+       x1="87"
+       y1="67.612183"
+       x2="103.5"
+       y2="67.612183" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLight"
+       id="linearGradient5742-3"
+       x1="87"
+       y1="67.362183"
+       x2="103"
+       y2="67.362183"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLightLowlight-5"
+       id="linearGradient1904"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99220307,0,0,0.99833048,0.13900758,-0.37418199)"
+       x1="87"
+       y1="67.612183"
+       x2="103.5"
+       y2="67.612183" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLightLowlight-5"
+       id="linearGradient1928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99220307,0,0,0.99833048,-24.384521,0.05825831)"
+       x1="87"
+       y1="67.612183"
+       x2="103.5"
+       y2="67.612183" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient1930"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94551188,0,0,0.92891877,-93.635783,1921.786)"
+       x1="85.323975"
+       y1="67.432732"
+       x2="104.30441"
+       y2="67.432732" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#brightColor"
+       id="linearGradient1932"
+       gradientUnits="userSpaceOnUse"
+       x1="87"
+       y1="67.362183"
+       x2="103"
+       y2="67.362183"
+       gradientTransform="translate(-24.038905,-6.2687245e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#brightColor"
+       id="linearGradient1976"
+       x1="87"
+       y1="67.363434"
+       x2="103.02639"
+       y2="67.363434"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-24.523529,0.43244031)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#boundsTemplate"
+       id="linearGradient2022"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.49999998,0,0,0.49999973,4.9999986,1324.8195)"
+       x1="10"
+       y1="1358.3622"
+       x2="42"
+       y2="1358.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#brightColor"
+       id="linearGradient2112"
+       gradientTransform="matrix(0.24,0,0,0.24,132.08,150.13193)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#brightColor"
+       id="linearGradient2114"
+       gradientTransform="matrix(0.24,0,0,0.24,128.58,124.63193)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#brightColor"
+       id="linearGradient6477"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24,0,0,0.24,128.58,124.63193)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#brightColor"
+       id="linearGradient6485"
+       gradientUnits="userSpaceOnUse"
+       x1="87"
+       y1="67.363434"
+       x2="103.02639"
+       y2="67.363434"
+       gradientTransform="translate(-24.523529,0.43244031)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#brightColor"
+       id="linearGradient6487"
+       gradientUnits="userSpaceOnUse"
+       x1="87"
+       y1="67.363434"
+       x2="103.02639"
+       y2="67.363434"
+       gradientTransform="translate(-24.523529,0.43244031)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLight"
+       id="linearGradient6501"
+       gradientUnits="userSpaceOnUse"
+       x1="87"
+       y1="67.362183"
+       x2="103"
+       y2="67.362183"
+       gradientTransform="translate(-24.064853,-1.5376943e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLightLowlight-5"
+       id="linearGradient6503"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99220307,0,0,0.99833048,-23.925845,-0.37418352)"
+       x1="87"
+       y1="67.612183"
+       x2="103.5"
+       y2="67.612183" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#brightColor"
+       id="linearGradient6511"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-48.061636,-0.06758254)"
+       x1="87"
+       y1="67.362183"
+       x2="103"
+       y2="67.362183" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#boundsTemplate"
+       id="linearGradient2471"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40624998,0,0,0.4062494,5.9374989,1518.6663)"
+       x1="10"
+       y1="1358.3622"
+       x2="42"
+       y2="1358.3622" />
+    <linearGradient
+       inkscape:collect="always"
        xlink:href="#linearGradient1586"
-       id="linearGradient1625"
+       id="linearGradient2520"
+       gradientUnits="userSpaceOnUse"
+       x1="141.15625"
+       y1="232.33093"
+       x2="159.21875"
+       y2="232.33093" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1586"
+       id="linearGradient2522"
+       gradientUnits="userSpaceOnUse"
+       x1="141.1564"
+       y1="233.59351"
+       x2="150.67906"
+       y2="233.59351" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient2524"
+       gradientUnits="userSpaceOnUse"
+       x1="141.15649"
+       y1="226.47861"
+       x2="159.22701"
+       y2="226.47861" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1586"
+       id="linearGradient2526"
+       gradientUnits="userSpaceOnUse"
+       x1="141.15649"
+       y1="226.47861"
+       x2="159.22701"
+       y2="226.47861" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1586"
+       id="linearGradient2528"
+       gradientUnits="userSpaceOnUse"
+       x1="141.15625"
+       y1="232.33093"
+       x2="159.21875"
+       y2="232.33093" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1586"
+       id="linearGradient2614"
+       gradientUnits="userSpaceOnUse"
+       x1="141.15625"
+       y1="232.33093"
+       x2="159.21875"
+       y2="232.33093" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient2616"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.7137094,16.582842)"
+       x1="125.42407"
+       y1="215.29883"
+       x2="151.82007"
+       y2="215.29883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1586"
+       id="linearGradient2618"
+       gradientUnits="userSpaceOnUse"
+       x1="123.71041"
+       y1="231.88168"
+       x2="150.10629"
+       y2="231.88168" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient2620"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83200537,0,0,0.87540517,-185.40186,69.355943)"
+       x1="143.36874"
+       y1="233.49455"
+       x2="157.56445"
+       y2="233.49455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1586"
+       id="linearGradient2622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97547648,0,0,1.0263601,-209.88689,35.145297)"
+       x1="144.63138"
+       y1="231.56898"
+       x2="159.49074"
+       y2="231.56898" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1586"
+       id="linearGradient2624"
        gradientUnits="userSpaceOnUse"
        x1="293.07089"
        y1="13.132758"
@@ -907,36 +1158,48 @@
        y2="13.132758" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#backgroundDark"
-       id="linearGradient1661"
-       x1="-53"
-       y1="62.965736"
-       x2="-44"
-       y2="62.965736"
-       gradientUnits="userSpaceOnUse" />
-    <mask
-       maskUnits="userSpaceOnUse"
-       id="mask2603">
-      <path
-         sodipodi:nodetypes="sssss"
-         inkscape:connector-curvature="0"
-         style="opacity:0.98999999;fill:#ffffff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
-         d="m 120.00001,111.38722 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
-         id="path2605"
-         inkscape:label="#path3910" />
-    </mask>
-    <mask
-       maskUnits="userSpaceOnUse"
-       id="mask2800">
-      <path
-         sodipodi:nodetypes="sssss"
-         inkscape:connector-curvature="0"
-         style="opacity:0.98999999;fill:#ffffff;fill-opacity:0.98431373;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 130.23571,107.15898 c -6.3945,0 -11.57828,5.18439 -11.57828,11.57965 0,6.39526 5.18378,11.57963 11.57828,11.57963 6.39449,0 11.57826,-5.18437 11.57826,-11.57963 0,-6.39526 -5.18377,-11.57965 -11.57826,-11.57965 z"
-         id="path2802"
-         inkscape:label="#path1410" />
-    </mask>
+       xlink:href="#backgroundLighter"
+       id="linearGradient2626"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30129759,0,0,1.4067094,174.14345,-10.438603)" />
     <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1586"
+       id="linearGradient2628"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46080373,0,0,1.571432,134.30203,-34.492834)"
+       x1="247"
+       y1="66.360213"
+       x2="257.00393"
+       y2="66.360213" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLighter"
+       id="linearGradient2630"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30129759,0,0,1.406711,180.29248,-10.43871)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1586"
+       id="linearGradient2632"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46080373,0,0,1.5714339,140.45105,-34.492968)"
+       x1="247"
+       y1="66.360213"
+       x2="257.00393"
+       y2="66.360213" />
+    <linearGradient
+       gradientTransform="translate(106,5.6378)"
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient1699"
+       x1="-72.5"
+       y1="62.362183"
+       x2="-67.5"
+       y2="62.362183"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(106,5.6378)"
        inkscape:collect="always"
        xlink:href="#foreground"
        id="linearGradient1693"
@@ -947,51 +1210,105 @@
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#foreground"
-       id="linearGradient1699"
-       x1="-72.5"
-       y1="62.362183"
-       x2="-67.5"
-       y2="62.362183"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#boundsTemplate"
+       id="linearGradient5610"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.78124995,0,0,0.78124884,2.1874983,1085.2813)"
+       x1="10"
+       y1="1358.3622"
+       x2="42"
+       y2="1358.3622" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#backgroundLight"
-       id="linearGradient1730"
+       xlink:href="#boundsTemplate"
+       id="linearGradient5826"
        gradientUnits="userSpaceOnUse"
-       x1="87"
-       y1="67.362183"
-       x2="103"
-       y2="67.362183" />
+       gradientTransform="matrix(0.87499994,0,0,0.8749987,1.2499981,1029.4351)"
+       x1="10"
+       y1="1358.3622"
+       x2="42"
+       y2="1358.3622" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#backgroundLightLowlight-5"
-       id="linearGradient1732"
+       xlink:href="#boundsTemplate"
+       id="linearGradient5834"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.5625,-0.50000038)"
-       x1="87"
-       y1="67.612183"
-       x2="103.5"
-       y2="67.612183" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#brightColor"
-       id="linearGradient1734"
-       gradientUnits="userSpaceOnUse"
-       x1="87"
-       y1="67.362183"
-       x2="103"
-       y2="67.362183" />
+       gradientTransform="matrix(0.37499998,0,0,0.37499944,6.2499992,1732.6151)"
+       x1="10"
+       y1="1358.3622"
+       x2="42"
+       y2="1358.3622" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#foreground"
-       id="linearGradient1712"
-       x1="-5.7694654"
-       y1="150.56934"
-       x2="-4.1273022"
-       y2="150.56934"
-       gradientUnits="userSpaceOnUse" />
+       id="linearGradient1733"
+       x1="228.00011"
+       y1="219.36218"
+       x2="237.99989"
+       y2="219.36218"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-17,-122.36218)" />
     <linearGradient
+       id="backgroundLightLowlight-5-9"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#434343;stop-opacity:1;"
+         offset="0"
+         id="stop5804-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#backgroundLightLowlight-5-9"
+       id="linearGradient1742"
+       x1="48.5"
+       y1="172.36218"
+       x2="53.5"
+       y2="172.36218"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.79999998,251.49999,1548.4725)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter2913">
+      <feBlend
+         inkscape:collect="always"
+         mode="screen"
+         in2="BackgroundImage"
+         id="feBlend2915" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient1724"
+       x1="209.8215"
+       y1="56.362183"
+       x2="227.17856"
+       y2="56.362183"
+       gradientUnits="userSpaceOnUse" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask2800-2">
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         style="opacity:0.98999999;fill:#ffffff;fill-opacity:0.98431373;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 130.23571,107.15898 c -6.3945,0 -11.57828,5.18439 -11.57828,11.57965 0,6.39526 5.18378,11.57963 11.57828,11.57963 6.39449,0 11.57826,-5.18437 11.57826,-11.57963 0,-6.39526 -5.18377,-11.57965 -11.57826,-11.57965 z"
+         id="path2802-7"
+         inkscape:label="#path1410" />
+    </mask>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask2603-3">
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         style="opacity:0.98999999;fill:#ffffff;fill-opacity:0.99215686;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+         d="m 120.00001,111.38722 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
+         id="path2605-7"
+         inkscape:label="#path3910" />
+    </mask>
+    <linearGradient
+       gradientTransform="translate(285.9325,135.23546)"
        inkscape:collect="always"
        xlink:href="#foreground"
        id="linearGradient1718"
@@ -999,6 +1316,16 @@
        y1="154.56934"
        x2="-4.2205095"
        y2="154.56934"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(285.9325,135.23546)"
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient1712"
+       x1="-5.7694654"
+       y1="150.56934"
+       x2="-4.1273022"
+       y2="150.56934"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
@@ -1012,51 +1339,30 @@
     <linearGradient
        inkscape:collect="always"
        xlink:href="#foreground"
-       id="linearGradient1727"
+       id="linearGradient7560"
+       gradientUnits="userSpaceOnUse"
        x1="48.880001"
        y1="126.24497"
        x2="50.922291"
-       y2="126.24497"
-       gradientUnits="userSpaceOnUse" />
+       y2="126.24497" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#foreground"
-       id="linearGradient1724"
-       x1="209.8215"
-       y1="56.362183"
-       x2="227.17856"
-       y2="56.362183"
-       gradientUnits="userSpaceOnUse" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter2913">
-      <feBlend
-         inkscape:collect="always"
-         mode="screen"
-         in2="BackgroundImage"
-         id="feBlend2915" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#backgroundLightLowlight-5"
-       id="linearGradient1742"
-       x1="48.5"
-       y1="172.36218"
-       x2="53.5"
-       y2="172.36218"
+       id="linearGradient7562"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.79999998,-0.5,34.972438)" />
+       x1="48.880001"
+       y1="126.24497"
+       x2="50.922291"
+       y2="126.24497" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#foreground"
-       id="linearGradient1733"
-       x1="228.00011"
-       y1="219.36218"
-       x2="237.99989"
-       y2="219.36218"
+       id="linearGradient7564"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-2,8.0000004)" />
+       x1="48.880001"
+       y1="126.24497"
+       x2="50.922291"
+       y2="126.24497" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -1065,16 +1371,16 @@
      borderopacity="1"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="17.008"
-     inkscape:cx="210.84577"
-     inkscape:cy="828.32283"
+     inkscape:zoom="2"
+     inkscape:cx="285.15627"
+     inkscape:cy="-320.69002"
      inkscape:document-units="px"
-     inkscape:current-layer="layer1"
+     inkscape:current-layer="g2889"
+     inkscape:window-width="2181"
+     inkscape:window-height="1250"
+     inkscape:window-x="1183"
+     inkscape:window-y="208"
      showgrid="true"
-     inkscape:window-width="1680"
-     inkscape:window-height="981"
-     inkscape:window-x="74"
-     inkscape:window-y="28"
      inkscape:window-maximized="0"
      inkscape:snap-global="true"
      inkscape:snap-nodes="true"
@@ -1083,7 +1389,7 @@
      inkscape:snap-object-midpoints="false"
      inkscape:snap-bbox-midpoints="true"
      inkscape:snap-smooth-nodes="true"
-     showguides="false"
+     showguides="true"
      inkscape:guide-bbox="true"
      inkscape:snap-grids="true"
      inkscape:object-paths="false"
@@ -1109,6 +1415,209 @@
        empcolor="#e6e6e6"
        empopacity="0.2"
        dotted="false" />
+    <sodipodi:guide
+       position="10,-290"
+       orientation="0,1"
+       id="guide2654"
+       inkscape:locked="false"
+       inkscape:label="pointers - top bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="10,-656"
+       orientation="1,0"
+       id="guide2544"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="10,-322"
+       orientation="0,1"
+       id="guide2619"
+       inkscape:locked="false"
+       inkscape:label="pointer - bottomBound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="79,-390"
+       orientation="0,1"
+       id="guide2755"
+       inkscape:locked="false"
+       inkscape:label="pointers -  PathFilterUI - top bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="10,-422"
+       orientation="0,1"
+       id="guide2761"
+       inkscape:locked="false"
+       inkscape:label="pointers - PathFilterUI - bottom bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="10,-494"
+       orientation="0,1"
+       id="guide2653"
+       inkscape:locked="false"
+       inkscape:label="arrows 10 - upperBound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="10,-504"
+       orientation="0,1"
+       id="guide2655"
+       inkscape:locked="false"
+       inkscape:label="arrows 10 - lower bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-556"
+       orientation="0,1"
+       id="guide2636"
+       inkscape:locked="false"
+       inkscape:label="catalog status - upper bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-569"
+       orientation="0,1"
+       id="guide2643"
+       inkscape:locked="false"
+       inkscape:label="catalogue status - lower bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="127,-622"
+       orientation="0,1"
+       id="guide2662"
+       inkscape:locked="false"
+       inkscape:label="sceneView - menu icons -upper bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-647"
+       orientation="0,1"
+       id="guide2664"
+       inkscape:locked="false"
+       inkscape:label="sceneView - menu icons - lower bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-2,-698"
+       orientation="0,1"
+       id="guide2862"
+       inkscape:locked="false"
+       inkscape:label="imageView - menu icons - upper bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-1,-723"
+       orientation="0,1"
+       id="guide2864"
+       inkscape:locked="false"
+       inkscape:label="imageView - menu icons - lower bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-774"
+       orientation="0,1"
+       id="guide3186"
+       inkscape:locked="false"
+       inkscape:label="tools - upper bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-799"
+       orientation="0,1"
+       id="guide3188"
+       inkscape:locked="false"
+       inkscape:label="tools - lower bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-850"
+       orientation="0,1"
+       id="guide3328"
+       inkscape:locked="false"
+       inkscape:label="browserIcons - upper bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-864"
+       orientation="0,1"
+       id="guide3330"
+       inkscape:locked="false"
+       inkscape:label="browserIcons - lower bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-922"
+       orientation="0,1"
+       id="guide1822"
+       inkscape:locked="false"
+       inkscape:label="controls - checkBox - upper bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-942"
+       orientation="0,1"
+       id="guide1824"
+       inkscape:locked="false"
+       inkscape:label="controls - checkBox - lower bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-996"
+       orientation="0,1"
+       id="guide2024"
+       inkscape:locked="false"
+       inkscape:label="controls - switch - upper bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-1012"
+       orientation="0,1"
+       id="guide2026"
+       inkscape:locked="false"
+       inkscape:label="controls - switch - lower bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-1064"
+       orientation="0,1"
+       id="guide2473"
+       inkscape:locked="false"
+       inkscape:label="editorFocus - upper bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-1077"
+       orientation="0,1"
+       id="guide2502"
+       inkscape:locked="false"
+       inkscape:label="editorFocus - lower bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-1134"
+       orientation="0,1"
+       id="guide5612"
+       inkscape:locked="false"
+       inkscape:label="viewer - upper bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-1159"
+       orientation="0,1"
+       id="guide5614"
+       inkscape:locked="false"
+       inkscape:label="viewer - lower bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-1204"
+       orientation="0,1"
+       id="guide5828"
+       inkscape:locked="false"
+       inkscape:label="notifications - 28 - upper bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-1232"
+       orientation="0,1"
+       id="guide5830"
+       inkscape:locked="false"
+       inkscape:label="notifications - 28 - lower bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-1236"
+       orientation="0,1"
+       id="guide5836"
+       inkscape:locked="false"
+       inkscape:label="notifications - 12 - upper bound"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="0,-1248"
+       orientation="0,1"
+       id="guide5838"
+       inkscape:locked="false"
+       inkscape:label="notifications - 12 - lower bound"
+       inkscape:color="rgb(0,0,255)" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -1123,106 +1632,1703 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-52.362183)">
-    <rect
-       style="opacity:1;fill:#888888;fill-opacity:0.74509805;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:fill markers stroke"
-       id="grid"
+     id="layer3"
+     inkscape:label="Annotations"
+     style="display:inline;opacity:1"
+     sodipodi:insensitive="true">
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot2508"
+       style="font-style:normal;font-weight:normal;font-size:8px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f8f8f8;fill-opacity:1;stroke:none"
+       transform="translate(-4,20.818545)"
+       inkscape:label="overview"><flowRegion
+         id="flowRegion2510"
+         style="fill:#f8f8f8;fill-opacity:1"><rect
+           id="rect2512"
+           width="368"
+           height="155.18146"
+           x="4"
+           y="1008"
+           style="fill:#f8f8f8;fill-opacity:1" /></flowRegion><flowPara
+         id="flowPara2514"
+         style="fill:#f8f8f8;fill-opacity:1">This document contains in-application graphics for core gaffer apps. Exports are registered in the sidecar graphics.py file, which lists object IDs (as set in Object Properties -&gt; ID) along with any associated size validation options.</flowPara><flowPara
+         id="flowPara2538"
+         style="fill:#f8f8f8;fill-opacity:1" /><flowPara
+         id="flowPara2536"
+         style="fill:#f8f8f8;fill-opacity:1">All graphics must be aligned to pixel boundaries. It is reccomended to create an export boundary rect with the correct ID in the ExportAreas layer, then construct the artwork on the Artwork layer on top, within its bounds.</flowPara><flowPara
+         style="fill:#f8f8f8;fill-opacity:1"
+         id="flowPara2575" /><flowPara
+         style="fill:#f8f8f8;fill-opacity:1"
+         id="flowPara2579" /></flowRoot>    <path
+       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 0,1026 H 750"
+       id="path2472"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc"
+       inkscape:label="hr1" />
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot2464"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none"
+       transform="translate(292.91406,13.740791)"
+       inkscape:label="docTitle"><flowRegion
+         id="flowRegion2466"
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1"><rect
+           id="rect2468"
+           width="343.75"
+           height="54.25"
+           x="-295"
+           y="983"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1" /></flowRegion><flowPara
+         id="flowPara2470"
+         style="fill:#f4f4f4;fill-opacity:1">UI GRAPHICS</flowPara></flowRoot>    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:8px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="280"
+       y="1096"
+       id="text2565"><tspan
+         sodipodi:role="line"
+         id="tspan2563"
+         x="280"
+         y="1103.0781" /></text>
+    <flowRoot
+       inkscape:label="overview"
+       transform="translate(5.4023437,213.09198)"
+       style="font-style:normal;font-weight:normal;font-size:8px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f8f8f8;fill-opacity:1;stroke:none"
+       id="flowRoot2601"
+       xml:space="preserve"><flowRegion
+         style="fill:#f8f8f8;fill-opacity:1"
+         id="flowRegion2583"><rect
+           style="fill:#f8f8f8;fill-opacity:1"
+           y="1008"
+           x="4"
+           height="50.90802"
+           width="550.59766"
+           id="rect2581" /></flowRegion><flowPara
+         style="fill:#f8f8f8;fill-opacity:1"
+         id="flowPara2650">- Mouse cursors are registered in src/GafferUI/Pointer.cpp.</flowPara><flowPara
+         style="fill:#f8f8f8;fill-opacity:1"
+         id="flowPara2548">- Cursors should be 32x32 (see https://doc.qt.io/qt-5/qcursor.html#QCursor-3)</flowPara><flowPara
+         style="fill:#f8f8f8;fill-opacity:1"
+         id="flowPara2634">- The x,y coordinate of the pointer should be set to the coordinates of the pixel to be used when computing mouse/object intersection.</flowPara><flowPara
+         style="fill:#f8f8f8;fill-opacity:1"
+         id="flowPara2623">- All exports should use the 'pointer' prefix.</flowPara></flowRoot>    <path
+       inkscape:label="hr1"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path2603"
+       d="M 0,1216 H 750"
+       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <flowRoot
+       inkscape:label="docTitle"
+       transform="translate(293.4375,204.86188)"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none"
+       id="flowRoot2611"
+       xml:space="preserve"><flowRegion
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
+         id="flowRegion2607"><rect
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
+           y="983"
+           x="-295"
+           height="54.25"
+           width="343.75"
+           id="rect2605" /></flowRegion><flowPara
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1"
+         id="flowPara2609">POINTERS</flowPara></flowRoot>    <flowRoot
+       xml:space="preserve"
+       id="flowRoot2594"
+       style="font-style:normal;font-weight:normal;font-size:8px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f8f8f8;fill-opacity:1;stroke:none"
+       transform="translate(6,99.701357)"
+       inkscape:label="overview"><flowRegion
+         id="flowRegion2584"
+         style="fill:#f8f8f8;fill-opacity:1"><rect
+           id="rect2582"
+           width="572"
+           height="34.950989"
+           x="4"
+           y="1008"
+           style="fill:#f8f8f8;fill-opacity:1" /></flowRegion><flowPara
+         id="flowPara2592"
+         style="fill:#f8f8f8;fill-opacity:1">- Use integer pixel width lines where possible.</flowPara><flowPara
+         style="fill:#f8f8f8;fill-opacity:1"
+         id="flowPara2605">- Align 1px lines to 1/2 pixel gridlines to prevent anti-aliasing.</flowPara><flowPara
+         style="fill:#f8f8f8;fill-opacity:1"
+         id="flowPara2607">- Odd sized images are valid if its assists center alignment, especially at small scales.</flowPara><flowPara
+         style="fill:#f8f8f8;fill-opacity:1"
+         id="flowPara2610">    - Use standard swatch fills/strokes where possible.</flowPara></flowRoot>    <rect
+       transform="translate(0,-52.362183)"
+       style="display:inline;opacity:1;fill:url(#linearGradient2648);fill-opacity:1;stroke:none;stroke-width:1.91236579;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       id="rect2636"
+       width="32"
+       height="32"
+       x="10"
+       y="1342.3622"
+       inkscape:label="sizeGuide" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 0,1376.5 H 750"
+       id="path2727"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc"
+       inkscape:label="hr1" />
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot2735"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none"
+       transform="translate(293.4375,364.86188)"
+       inkscape:label="docTitle"><flowRegion
+         id="flowRegion2731"
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1"><rect
+           id="rect2729"
+           width="343.75"
+           height="54.25"
+           x="-295"
+           y="983"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1" /></flowRegion><flowPara
+         id="flowPara2733"
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1">POINTERS - PathFilterUI</flowPara></flowRoot>    <rect
+       y="1390"
+       x="10"
+       height="32"
+       width="64"
+       id="rect2757"
+       style="display:inline;opacity:1;fill:url(#linearGradient2759);fill-opacity:1;stroke:none;stroke-width:2.70449376;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       inkscape:label="sizeGuide" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 0,1486 H 750"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc"
+       inkscape:label="hr1"
+       id="path2636" />
+    <flowRoot
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none"
+       transform="translate(294.79687,474.86188)"
+       inkscape:label="docTitle"
+       id="flowRoot2644"><flowRegion
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
+         id="flowRegion2640"><rect
+           width="343.75"
+           height="54.25"
+           x="-295"
+           y="983"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
+           id="rect2638" /></flowRegion><flowPara
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1"
+         id="flowPara2642">ARROWS 10x10</flowPara></flowRoot>    <rect
+       y="1494"
+       x="10"
+       height="10"
+       width="10"
+       id="rect2757-3"
+       style="display:inline;opacity:1;fill:url(#linearGradient2759-7);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       inkscape:label="sizeGuide" />
+    <path
+       id="path2626"
+       inkscape:label="hr1"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       d="M 0,1548 H 750"
+       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <flowRoot
+       id="flowRoot2634"
+       inkscape:label="docTitle"
+       transform="translate(294.10156,536.86188)"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none"
+       xml:space="preserve"><flowRegion
+         id="flowRegion2630"
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1"><rect
+           id="rect2628"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
+           y="983"
+           x="-295"
+           height="54.25"
+           width="343.75" /></flowRegion><flowPara
+         id="flowPara2632"
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1">CATALOGUE STATUS</flowPara></flowRoot>    <rect
+       inkscape:label="sizeGuide"
+       style="display:inline;opacity:1;fill:url(#linearGradient2641);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       id="rect2639"
+       width="13"
+       height="13"
+       x="10"
+       y="1556" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 0,1614 H 750"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc"
+       inkscape:label="hr1"
+       id="path2646" />
+    <flowRoot
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none"
+       transform="translate(294.10156,602.86188)"
+       inkscape:label="docTitle"
+       id="flowRoot2654"><flowRegion
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
+         id="flowRegion2650"><rect
+           width="343.75"
+           height="54.25"
+           x="-295"
+           y="983"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
+           id="rect2648" /></flowRegion><flowPara
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1"
+         id="flowPara2652">SCENE VIEW</flowPara></flowRoot>    <rect
+       y="1622"
+       x="10"
+       height="25"
+       width="25"
+       id="rect2656"
+       style="display:inline;opacity:1;fill:url(#linearGradient2660);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       inkscape:label="sizeGuide" />
+    <path
+       id="path2844"
+       inkscape:label="hr1"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       d="M -2,1690 H 748"
+       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <flowRoot
+       id="flowRoot2852"
+       inkscape:label="docTitle"
+       transform="translate(292.10156,678.86186)"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none"
+       xml:space="preserve"><flowRegion
+         id="flowRegion2848"
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1"><rect
+           id="rect2846"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
+           y="983"
+           x="-295"
+           height="54.25"
+           width="343.75" /></flowRegion><flowPara
+         id="flowPara2850"
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1">IMAGE VIEW</flowPara></flowRoot>    <rect
+       inkscape:label="sizeGuide"
+       style="display:inline;opacity:1;fill:url(#linearGradient2860);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       id="rect2854"
+       width="25"
+       height="25"
+       x="10"
+       y="1698" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M -4,1766 H 746"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc"
+       inkscape:label="hr1"
+       id="path3172" />
+    <flowRoot
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none"
+       transform="translate(290.10156,754.86186)"
+       inkscape:label="docTitle"
+       id="flowRoot3180"><flowRegion
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
+         id="flowRegion3176"><rect
+           width="343.75"
+           height="54.25"
+           x="-295"
+           y="983"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
+           id="rect3174" /></flowRegion><flowPara
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1"
+         id="flowPara3178">TOOLS</flowPara></flowRoot>    <rect
+       y="1774"
+       x="10"
+       height="25"
+       width="25"
+       id="rect3182"
+       style="display:inline;opacity:1;fill:url(#linearGradient3184);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       inkscape:label="sizeGuide" />
+    <path
+       id="path3310"
+       inkscape:label="hr1"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       d="M -6,1843 H 743.99999"
+       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <flowRoot
+       id="flowRoot3318"
+       inkscape:label="docTitle"
+       transform="translate(288.10156,831.86182)"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none"
+       xml:space="preserve"><flowRegion
+         id="flowRegion3314"
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1"><rect
+           id="rect3312"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
+           y="983"
+           x="-295"
+           height="54.25"
+           width="343.75" /></flowRegion><flowPara
+         id="flowPara3316"
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1">BROWSER ICONS</flowPara></flowRoot>    <rect
+       inkscape:label="sizeGuide"
+       style="display:inline;opacity:1;fill:url(#linearGradient3322);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       id="rect3320"
+       width="14"
+       height="14"
+       x="10"
+       y="1850" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="-10"
+       y="1804"
+       id="text3326"><tspan
+         sodipodi:role="line"
+         id="tspan3324"
+         x="-10"
+         y="1839.3906" /></text>
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M -6,1915 H 743.99999"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc"
+       inkscape:label="hr1"
+       id="path1808" />
+    <flowRoot
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none"
+       transform="translate(288.10156,903.86182)"
+       inkscape:label="docTitle"
+       id="flowRoot1816"><flowRegion
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
+         id="flowRegion1812"><rect
+           width="343.75"
+           height="54.25"
+           x="-295"
+           y="983"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
+           id="rect1810" /></flowRegion><flowPara
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1"
+         id="flowPara1814">CONTROLS  - checkBox</flowPara></flowRoot>    <rect
+       y="1922"
+       x="10"
+       height="20"
        width="20"
-       height="15"
-       x="34.5"
-       y="164.86218"
-       rx="2.2222223"
-       ry="2"
-       inkscape:label="#rect1734" />
-    <circle
-       r="11"
-       cy="179.86218"
-       cx="392.5"
-       id="viewPaused"
-       style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
-       inkscape:label="#circle4126" />
-    <circle
-       style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
-       id="viewPause"
-       cx="360.5"
-       cy="179.86218"
-       r="11"
-       inkscape:label="#path4124" />
+       id="rect1818"
+       style="display:inline;opacity:1;fill:url(#linearGradient1820);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       inkscape:label="sizeGuide" />
     <path
-       style="opacity:1;fill:#787878;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
-       d="m 360.5,168.36218 a 11.5,11.5 0 0 0 -11.5,11.5 11.5,11.5 0 0 0 11.5,11.5 11.5,11.5 0 0 0 11.5,-11.5 11.5,11.5 0 0 0 -11.5,-11.5 z m 0.5957,4.26562 c 0.38371,-0.006 0.69592,0.30573 0.69141,0.68946 v 5.00195 c 0.48437,0.15106 0.39206,0.17203 0.81055,0.4668 l 0.37695,-4.68555 c -0.004,-0.3753 0.47239,-0.63865 0.84766,-0.64453 0.38361,-0.006 0.6959,0.30582 0.6914,0.68945 v 6.3125 c 0.0846,0.14116 -0.002,0.10095 0.0684,0.25196 l 1.08985,-1.4043 c 0.18216,-0.32672 0.52828,-0.52693 0.90234,-0.52344 0.7905,0.006 1.27459,0.86826 0.86914,1.54688 l -2.16016,4.30273 c -0.33612,0.8126 -0.5361,1.05085 -0.89453,1.55859 -0.64414,0.91255 -1.77649,1.43555 -3.28125,1.43555 -1.41958,0 -2.85042,-0.15685 -4.01758,-0.75195 -1.16716,-0.5951 -2.03515,-1.75261 -2.03515,-3.33594 0,0 -0.29326,-1.9064 -0.32031,-2.54883 -0.027,-0.64244 -0.196,-4.04264 -0.2754,-5.56445 -0.004,-0.3753 0.38254,-0.8828 0.75782,-0.88867 0.38361,-0.006 0.91857,0.48551 0.91406,0.86914 l 0.11914,3.75 c 0.19112,-0.11788 0.43504,0.18101 0.69531,0.0391 0.23634,-0.12892 0.20352,0.007 0.4668,-0.11719 l 0.0449,-5.09961 c -0.004,-0.37529 0.42747,-0.74997 0.80274,-0.75585 0.38362,-0.006 0.80723,0.39371 0.80273,0.77734 l 0.26562,4.28516 c 0.44701,-0.12512 0.15056,-0.13086 0.61133,-0.13086 l 0.17578,-4.57032 c -0.004,-0.3753 0.31808,-0.86131 0.69336,-0.86718 z"
-       id="path2699"
+       id="path2010"
+       inkscape:label="hr1"
+       sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
-       inkscape:label="#path2699" />
+       d="M -6,1988.0002 H 743.99999"
+       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <flowRoot
+       id="flowRoot2018"
+       inkscape:label="docTitle"
+       transform="matrix(1,0,0,0.99999439,288.10156,976.86735)"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none;stroke-width:1.00000536"
+       xml:space="preserve"><flowRegion
+         id="flowRegion2014"
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000536"><rect
+           id="rect2012"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000536"
+           y="983"
+           x="-295"
+           height="54.25"
+           width="343.75" /></flowRegion><flowPara
+         id="flowPara2016"
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000536">CONTROLS  - switch</flowPara></flowRoot>    <rect
+       inkscape:label="sizeGuide"
+       style="display:inline;opacity:1;fill:url(#linearGradient2022);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       id="rect2020"
+       width="16"
+       height="16"
+       x="10"
+       y="1996" />
     <path
-       style="opacity:1;fill:#d03232;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
-       d="m 392.5,168.36218 a 11.5,11.5 0 0 0 -11.5,11.5 11.5,11.5 0 0 0 11.5,11.5 11.5,11.5 0 0 0 11.5,-11.5 11.5,11.5 0 0 0 -11.5,-11.5 z m 0.5957,4.26562 c 0.38371,-0.006 0.69592,0.30573 0.69141,0.68946 v 5.00195 c 0.48437,0.15106 0.39206,0.17203 0.81055,0.4668 l 0.37695,-4.68555 c -0.004,-0.3753 0.47239,-0.63865 0.84766,-0.64453 0.38361,-0.006 0.6959,0.30582 0.6914,0.68945 v 6.3125 c 0.0846,0.14116 -0.002,0.10095 0.0684,0.25196 l 1.08985,-1.4043 c 0.18216,-0.32672 0.52828,-0.52693 0.90234,-0.52344 0.7905,0.006 1.27459,0.86826 0.86914,1.54688 l -2.16016,4.30273 c -0.33612,0.8126 -0.5361,1.05085 -0.89453,1.55859 -0.64414,0.91255 -1.77649,1.43555 -3.28125,1.43555 -1.41958,0 -2.85042,-0.15685 -4.01758,-0.75195 -1.16716,-0.5951 -2.03515,-1.75261 -2.03515,-3.33594 0,0 -0.29326,-1.9064 -0.32031,-2.54883 -0.027,-0.64244 -0.196,-4.04264 -0.2754,-5.56445 -0.004,-0.3753 0.38254,-0.8828 0.75782,-0.88867 0.38361,-0.006 0.91857,0.48551 0.91406,0.86914 l 0.11914,3.75 c 0.19112,-0.11788 0.43504,0.18101 0.69531,0.0391 0.23634,-0.12892 0.20352,0.007 0.4668,-0.11719 l 0.0449,-5.09961 c -0.004,-0.37529 0.42747,-0.74997 0.80274,-0.75585 0.38362,-0.006 0.80723,0.39371 0.80273,0.77734 l 0.26562,4.28516 c 0.44701,-0.12512 0.15056,-0.13086 0.61133,-0.13086 l 0.17578,-4.57032 c -0.004,-0.3753 0.31808,-0.86131 0.69336,-0.86718 z"
-       id="path2699-8"
+       style="fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M -6,2057.0003 H 743.99999"
        inkscape:connector-curvature="0"
-       inkscape:label="#path2699-8" />
-    <rect
-       style="opacity:1;fill:none;fill-opacity:0.10588235;stroke:none;stroke-width:1.53206468;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
-       id="renderStart"
-       width="13"
-       height="13"
-       x="343"
-       y="18.362183"
-       inkscape:label="#rect2589-2" />
-    <rect
-       style="opacity:1;fill:none;fill-opacity:0.10588235;stroke:none;stroke-width:1.53206468;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
-       id="renderResume"
-       width="13"
-       height="13"
-       x="357"
-       y="18.362183"
-       inkscape:label="#rect2589-4" />
-    <rect
-       style="opacity:1;fill:none;fill-opacity:0.10588235;stroke:none;stroke-width:1.53206468;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
-       id="renderPause"
-       width="13"
-       height="13"
-       x="371"
-       y="18.362183"
-       inkscape:label="#rect2589-4-8" />
-    <rect
-       style="opacity:1;fill:none;fill-opacity:0.10588235;stroke:none;stroke-width:1.53206468;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
-       id="renderStop"
-       width="13"
-       height="13"
-       x="329"
-       y="18.362183"
-       inkscape:label="#rect2589" />
-    <rect
-       inkscape:label="interactiveCompleteBounds"
-       y="112.36218"
-       x="416"
+       sodipodi:nodetypes="cc"
+       inkscape:label="hr1"
+       id="path2458" />
+    <flowRoot
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none;stroke-width:1.00000381"
+       transform="matrix(1,0,0,1.0000138,288.10156,1045.8477)"
+       inkscape:label="docTitle"
+       id="flowRoot2466"><flowRegion
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
+         id="flowRegion2462"><rect
+           width="343.75"
+           height="54.25"
+           x="-295"
+           y="983"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
+           id="rect2460" /></flowRegion><flowPara
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
+         id="flowPara2464">Editor Focus Menu</flowPara></flowRoot>    <rect
+       y="2064"
+       x="10"
        height="13"
        width="13"
-       id="catalogueStatusInteractiveRenderComplete"
-       style="opacity:1;fill:none;fill-opacity:0.07407406;stroke:none;stroke-width:2.17422915;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+       id="rect2469"
+       style="display:inline;opacity:1;fill:url(#linearGradient2471);fill-opacity:1;stroke:none;stroke-width:0.59761447;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       inkscape:label="sizeGuide" />
+    <path
+       id="path5598"
+       inkscape:label="hr1"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       d="M -6,2127 H 743.99999"
+       style="fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <flowRoot
+       id="flowRoot5606"
+       inkscape:label="docTitle"
+       transform="matrix(1,0,0,1.0000138,288.10156,1115.8474)"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none;stroke-width:1.00000381"
+       xml:space="preserve"><flowRegion
+         id="flowRegion5602"
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"><rect
+           id="rect5600"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
+           y="983"
+           x="-295"
+           height="54.25"
+           width="343.75" /></flowRegion><flowPara
+         id="flowPara5604"
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381">Viewer 25x25</flowPara></flowRoot>    <rect
+       inkscape:label="sizeGuide"
+       style="display:inline;opacity:1;fill:url(#linearGradient5610);fill-opacity:1;stroke:none;stroke-width:0.59761447;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       id="rect5608"
+       width="25"
+       height="25"
+       x="10"
+       y="2134" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M -6,2197 H 743.99999"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc"
+       inkscape:label="hr1"
+       id="path5814" />
+    <flowRoot
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none;stroke-width:1.00000381"
+       transform="matrix(1,0,0,1.0000138,288.10156,1185.8474)"
+       inkscape:label="docTitle"
+       id="flowRoot5822"><flowRegion
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
+         id="flowRegion5818"><rect
+           width="343.75"
+           height="54.25"
+           x="-295"
+           y="983"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
+           id="rect5816" /></flowRegion><flowPara
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
+         id="flowPara5820">Notifications</flowPara></flowRoot>    <rect
+       y="2204"
+       x="10"
+       height="28"
+       width="28"
+       id="rect5824"
+       style="display:inline;opacity:1;fill:url(#linearGradient5826);fill-opacity:1;stroke:none;stroke-width:0.59761447;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       inkscape:label="sizeGuide" />
     <rect
-       style="opacity:1;fill:none;fill-opacity:0.07407406;stroke:none;stroke-width:2.17422915;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
-       id="catalogueStatusInteractiveRenderRunning"
-       width="13"
-       height="13"
-       x="400"
-       y="112.36218"
-       inkscape:label="interactiveRunningBounds" />
+       inkscape:label="sizeGuide"
+       style="display:inline;opacity:1;fill:url(#linearGradient5834);fill-opacity:1;stroke:none;stroke-width:0.59761447;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       id="rect5832"
+       width="12"
+       height="12"
+       x="10"
+       y="2236" />
+    <path
+       id="path3115"
+       d="m 374.40125,245.77892 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
+       style="opacity:0.98999999;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssss" />
     <g
-       transform="translate(101)"
-       id="g5812-7-8-9">
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.49083519px;line-height:125%;font-family:'URW Palladio L';-inkscape-font-specification:'URW Palladio L Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none"
+       id="g3117"
+       transform="matrix(1.1174828,0,0,1.1174828,174.29418,184.43335)">
+      <path
+         d="m 178.71815,64.059798 c -0.5917,0.184908 -1.03548,0.258871 -1.8121,0.351325 -0.0555,0 -0.14793,0.01849 -0.27736,0.03698 v 0.66567 l 0.83209,0.05547 c 0.42528,0.03698 0.48076,0.2034 0.48076,1.294358 v 4.049493 c 0,0.998504 -0.0925,1.146432 -0.66567,1.183414 l -0.64718,0.03698 v 0.684161 l 2.38532,-0.05547 c 0.36981,0 1.25737,0.01849 2.49626,0.05547 v -0.684161 l -0.64718,-0.03698 c -0.57322,-0.03698 -0.66567,-0.18491 -0.66567,-1.183414 v -6.749155 l -0.18491,-0.110943 z m 0.29586,-4.75215 c -0.79511,0 -1.40531,0.591707 -1.40531,1.368322 0,0.776614 0.6102,1.405303 1.38682,1.405303 0.75812,0 1.38681,-0.628689 1.38681,-1.386812 0,-0.758124 -0.6102,-1.386813 -1.36832,-1.386813"
+         id="path3119"
+         style="fill:#3c3c3c;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccsscccccccsccccsssc" />
+    </g>
+    <path
+       sodipodi:nodetypes="sssss"
+       inkscape:connector-curvature="0"
+       style="opacity:0.98999999;fill:none;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+       d="m 374.40125,245.77892 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
+       id="path3121" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 306.77625,246.09764 c -0.63482,0.0493 -1.23606,0.42206 -1.5625,0.96875 l -13,21.5 c -0.7268,1.20821 0.30879,3.03461 1.71875,3.03125 h 26 c 1.40997,0.003 2.44556,-1.82304 1.71875,-3.03125 l -13,-21.5 c -0.37983,-0.6363 -1.13625,-1.02711 -1.875,-0.96875 z"
+       id="errorNotification"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:label="#path3123" />
+    <g
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient7562);fill-opacity:1;stroke:none"
+       id="text3918"
+       transform="translate(259.12,134.61046)">
+      <path
+         d="m 49.740965,129.21831 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,10e-6 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 H 49.74097 Z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105"
+         style="fill:url(#linearGradient7560);fill-opacity:1;stroke:none"
+         id="path3896"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccsccccccccscsc" />
+    </g>
+    <g
+       id="g3898"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient1725);fill-opacity:1;stroke:none"
+       transform="translate(255.12,134.61046)">
+      <path
+         sodipodi:nodetypes="cccsccccccccscsc"
+         inkscape:connector-curvature="0"
+         id="path3900"
+         style="fill:url(#linearGradient7564);fill-opacity:1;stroke:none"
+         d="m 49.740965,129.21831 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,10e-6 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 H 49.74097 Z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="warningNotification"
+       d="m 341.77625,246.09764 c -0.63483,0.0493 -1.23606,0.42206 -1.5625,0.96875 l -13,21.5 c -0.72681,1.20821 0.30878,3.03461 1.71875,3.03125 h 26 c 1.40997,0.003 2.44556,-1.82304 1.71875,-3.03125 l -13,-21.5 c -0.37984,-0.6363 -1.13625,-1.02711 -1.875,-0.96875 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#efc618;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       inkscape:label="#path3902" />
+    <g
+       transform="translate(291.9325,134.23546)"
+       id="g3904"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none">
+      <path
+         sodipodi:nodetypes="cccsccccccccscsc"
+         inkscape:connector-curvature="0"
+         id="path3906"
+         style="fill:#3c3c3c;fill-opacity:1;stroke:none"
+         d="m 49.740965,129.21831 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,10e-6 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 H 49.74097 Z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105" />
+    </g>
+    <path
+       id="infoNotification"
+       d="m 374.40125,245.77892 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
+       style="opacity:0.98999999;fill:none;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssss"
+       inkscape:label="#path3908" />
+    <path
+       sodipodi:nodetypes="sssss"
+       inkscape:connector-curvature="0"
+       style="opacity:0.98999999;fill:#b7b1b1;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+       d="m 405.90747,246.64771 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
+       id="debugNotification"
+       inkscape:label="#path3910" />
+    <path
+       inkscape:label="#path3908"
+       sodipodi:nodetypes="sssss"
+       inkscape:connector-curvature="0"
+       style="opacity:0.98999999;fill:none;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+       d="m 374.40125,245.77892 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
+       id="path4261" />
+    <path
+       inkscape:label="#path3902"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#efc618;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 298.39524,280.56758 c -0.27559,0.0214 -0.53659,0.183 -0.6783,0.42003 l -5.64344,9.32208 c -0.31552,0.52386 0.13405,1.31576 0.74613,1.31431 h 11.28688 c 0.61208,0.002 1.06164,-0.79045 0.74613,-1.31431 l -5.64344,-9.32208 c -0.1649,-0.27589 -0.49326,-0.44533 -0.81396,-0.42003 z"
+       id="warningSmall"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 298.42693,283.09764 v 0 c 0.28009,0 0.87197,0.21546 0.84807,0.49452 l -0.3425,3.99991 c -0.0239,0.27906 -0.22548,0.50557 -0.50557,0.50557 v 0 c -0.28009,0 -0.48545,-0.22621 -0.50557,-0.50557 l -0.28726,-3.98886 c -0.0201,-0.27936 0.51274,-0.50557 0.79283,-0.50557 z"
+       id="rect1440"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccssccssc" />
+    <ellipse
+       style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1444"
+       cx="298.4325"
+       cy="289.59763"
+       rx="0.75"
+       ry="0.7499994" />
+    <path
+       sodipodi:nodetypes="sssss"
+       inkscape:connector-curvature="0"
+       style="opacity:0.98999999;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 312.9325,280.59763 c -3.03756,0 -5.5,2.46244 -5.5,5.50001 0,3.03757 2.46244,5.5 5.5,5.5 3.03757,0 5.5,-2.46243 5.5,-5.5 0,-3.03757 -2.46243,-5.50001 -5.5,-5.50001 z"
+       id="infoSmall"
+       inkscape:label="#path1410" />
+    <path
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:125%;font-family:'URW Palladio L';-inkscape-font-specification:'URW Palladio L Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:1.11748278"
+       d="m 311.1838,285.61974 0.7487,-0.0221 v 3 h -0.5 v 1 h 2.5 v -1 h -0.5 v -4 c -0.8565,0.18711 -1.54664,0.53253 -2.2487,1.0221 z"
+       id="path1441"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5105"
+       width="1.5"
+       height="1.5"
+       x="311.9325"
+       y="282.59763" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="errorSmall"
+       d="m 280.92473,280.77474 c -0.27559,0.0214 -0.53659,0.183 -0.6783,0.42003 l -5.64344,9.32208 c -0.31551,0.52386 0.13405,1.31576 0.74613,1.31431 H 286.636 c 0.61208,0.002 1.06164,-0.79045 0.74613,-1.31431 l -5.64344,-9.32208 c -0.1649,-0.27589 -0.49326,-0.44533 -0.81396,-0.42003 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       inkscape:label="#path3902" />
+    <path
+       sodipodi:nodetypes="ccssccssc"
+       inkscape:connector-curvature="0"
+       id="path1571"
+       d="m 280.95642,283.3048 v 0 c 0.28009,0 0.87197,0.21546 0.84808,0.49452 l -0.34251,3.99991 c -0.0239,0.27906 -0.22548,0.50557 -0.50557,0.50557 v 0 c -0.28009,0 -0.48545,-0.22621 -0.50557,-0.50557 l -0.28726,-3.98886 c -0.0201,-0.27936 0.51274,-0.50557 0.79283,-0.50557 z"
+       style="opacity:1;fill:url(#linearGradient1712);fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <ellipse
+       ry="0.7499994"
+       rx="0.75"
+       cy="289.80478"
+       cx="280.96198"
+       id="ellipse1573"
+       style="opacity:1;fill:url(#linearGradient1718);fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       inkscape:label="#path1410"
+       id="debugSmall"
+       d="m 329.19596,280.59763 c -3.03757,0 -5.5,2.46244 -5.5,5.50001 0,3.03757 2.46243,5.5 5.5,5.5 3.03756,0 5.49999,-2.46243 5.49999,-5.5 0,-3.03757 -2.46243,-5.50001 -5.49999,-5.50001 z"
+       style="opacity:0.98999999;fill:#b8b2b2;fill-opacity:0.98431373;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssss" />
+    <path
+       inkscape:transform-center-y="-0.93289306"
+       inkscape:transform-center-x="0.28410261"
+       d="m 132.8388,126.10749 c -1.85373,2.47164 1.88941,4.32251 -0.9518,5.53615 -2.8412,1.21364 -1.59048,-2.77039 -4.65785,-3.13995 -3.06738,-0.36956 -2.7987,3.79753 -5.27035,1.9438 -2.47164,-1.85374 1.60399,-2.7626 0.39035,-5.6038 -1.21364,-2.8412 -4.68811,-0.52498 -4.31855,-3.59236 0.36956,-3.06737 3.19447,0.008 5.0482,-2.46384 1.85374,-2.47165 -1.8894,-4.32252 0.9518,-5.53616 2.8412,-1.21364 1.59048,2.77039 4.65785,3.13995 3.06738,0.36956 2.79871,-3.79753 5.27035,-1.94379 2.47165,1.85373 -1.60399,2.76259 -0.39035,5.60379 1.21364,2.84121 4.68811,0.52499 4.31855,3.59236 -0.36955,3.06737 -3.19447,-0.008 -5.0482,2.46385 z"
+       inkscape:randomized="0"
+       inkscape:rounded="0.55"
+       inkscape:flatsided="false"
+       sodipodi:arg2="1.1670999"
+       sodipodi:arg1="0.64350111"
+       sodipodi:r2="10"
+       sodipodi:r1="6.0999999"
+       sodipodi:cy="122.44749"
+       sodipodi:cx="127.9588"
+       sodipodi:sides="6"
+       id="path2550"
+       style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.10526323;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       sodipodi:type="star"
+       transform="matrix(0.47502779,0,0,0.47497219,350.48377,196.57662)" />
+    <g
+       transform="translate(285.9325,135.23546)"
+       id="g2571"
+       mask="url(#mask2603-3)">
+      <path
+         transform="matrix(1.3226179,0,0,1.3409245,-40.20488,-41.331321)"
+         inkscape:transform-center-y="-2.63371"
+         inkscape:transform-center-x="0.7910214"
+         d="m 121.76711,134.48717 c -0.97623,1.30163 1.46568,1.89797 0.22429,2.94974 -1.24138,1.05177 -1.42852,-1.45493 -2.87282,-0.70577 -1.44431,0.74916 0.49703,2.34595 -1.07776,2.75494 -1.57479,0.40899 -0.65579,-1.93066 -2.28211,-1.88234 -1.62632,0.0483 -0.57005,2.32928 -2.16635,2.01449 -1.59629,-0.31479 0.24684,-2.024 -1.23938,-2.68611 -1.48623,-0.6621 -1.52424,1.85128 -2.82587,0.87505 -1.30163,-0.97622 1.10057,-1.71646 0.0488,-2.95784 -1.05176,-1.24139 -2.17652,1.0066 -2.92569,-0.43771 -0.74916,-1.4443 1.73633,-1.06895 1.32734,-2.64375 -0.40899,-1.57479 -2.39773,-0.0374 -2.44604,-1.66377 -0.0483,-1.62632 2.02818,-0.20973 2.34297,-1.80603 0.31479,-1.59629 -2.14404,-1.07407 -1.48193,-2.5603 0.66211,-1.48622 1.91832,0.69103 2.89455,-0.6106 0.97622,-1.30163 -1.46569,-1.89796 -0.2243,-2.94973 1.24139,-1.05177 1.42853,1.45493 2.87283,0.70577 1.4443,-0.74917 -0.49704,-2.34595 1.07775,-2.75494 1.5748,-0.40899 0.65579,1.93066 2.28211,1.88234 1.62632,-0.0483 0.57006,-2.32928 2.16635,-2.01449 1.5963,0.31479 -0.24684,2.024 1.23939,2.68611 1.48622,0.6621 1.52424,-1.85128 2.82587,-0.87506 1.30163,0.97623 -1.10057,1.71647 -0.0488,2.95785 1.05177,1.24139 2.17653,-1.0066 2.92569,0.43771 0.74916,1.4443 -1.73633,1.06895 -1.32733,2.64375 0.40899,1.57479 2.39773,0.0374 2.44604,1.66377 0.0483,1.62632 -2.02818,0.20973 -2.34297,1.80602 -0.31479,1.5963 2.14403,1.07408 1.48193,2.5603 -0.66211,1.48623 -1.91833,-0.69103 -2.89455,0.6106 z"
+         inkscape:randomized="0"
+         inkscape:rounded="0.55"
+         inkscape:flatsided="false"
+         sodipodi:arg2="0.86790059"
+         sodipodi:arg1="0.64350111"
+         sodipodi:r2="10"
+         sodipodi:r1="7.8000002"
+         sodipodi:cy="129.80717"
+         sodipodi:cx="115.52711"
+         sodipodi:sides="14"
+         id="path2548"
+         style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.75089747;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+         sodipodi:type="star" />
+      <path
+         d="m 120.59334,132.7303 a 7.9999995,7.9999995 0 0 1 -7.99801,8 7.9999995,7.9999995 0 0 1 -8.00199,-7.99602 7.9999995,7.9999995 0 0 1 7.99403,-8.00398 7.9999995,7.9999995 0 0 1 8.00596,7.99204"
+         sodipodi:open="true"
+         sodipodi:end="6.2821905"
+         sodipodi:start="0"
+         sodipodi:ry="7.9999995"
+         sodipodi:rx="7.9999995"
+         sodipodi:cy="132.7303"
+         sodipodi:cx="112.59334"
+         sodipodi:type="arc"
+         id="path2552"
+         style="opacity:1;fill:#b8b2b2;fill-opacity:0.98431373;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
+    </g>
+    <path
+       style="opacity:1;fill:#b8b2b2;fill-opacity:0.98431373;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       id="path2552-3"
+       sodipodi:type="arc"
+       sodipodi:cx="411.26776"
+       sodipodi:cy="254.73576"
+       sodipodi:rx="1.5975029"
+       sodipodi:ry="1.6198807"
+       sodipodi:start="0"
+       sodipodi:end="6.2821905"
+       sodipodi:open="true"
+       d="m 412.86526,254.73576 a 1.5975029,1.6198807 0 0 1 -1.5971,1.61988 1.5975029,1.6198807 0 0 1 -1.5979,-1.61907 1.5975029,1.6198807 0 0 1 1.59631,-1.62069 1.5975029,1.6198807 0 0 1 1.59869,1.61827" />
+    <path
+       inkscape:label="#path3910"
+       id="path2622"
+       d="m 405.90747,246.64771 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
+       style="opacity:0.98999999;fill:none;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssss" />
+    <path
+       inkscape:transform-center-y="-0.93289306"
+       inkscape:transform-center-x="0.28410261"
+       d="m 132.8388,126.10749 c -1.85373,2.47164 1.88941,4.32251 -0.9518,5.53615 -2.8412,1.21364 -1.59048,-2.77039 -4.65785,-3.13995 -3.06738,-0.36956 -2.7987,3.79753 -5.27035,1.9438 -2.47164,-1.85374 1.60399,-2.7626 0.39035,-5.6038 -1.21364,-2.8412 -4.68811,-0.52498 -4.31855,-3.59236 0.36956,-3.06737 3.19447,0.008 5.0482,-2.46384 1.85374,-2.47165 -1.8894,-4.32252 0.9518,-5.53616 2.8412,-1.21364 1.59048,2.77039 4.65785,3.13995 3.06738,0.36956 2.79871,-3.79753 5.27035,-1.94379 2.47165,1.85373 -1.60399,2.76259 -0.39035,5.60379 1.21364,2.84121 4.68811,0.52499 4.31855,3.59236 -0.36955,3.06737 -3.19447,-0.008 -5.0482,2.46385 z"
+       inkscape:randomized="0"
+       inkscape:rounded="0.55"
+       inkscape:flatsided="false"
+       sodipodi:arg2="1.1670999"
+       sodipodi:arg1="0.64350111"
+       sodipodi:r2="10"
+       sodipodi:r1="6.0999999"
+       sodipodi:cy="122.44749"
+       sodipodi:cx="127.9588"
+       sodipodi:sides="6"
+       id="path2550-7"
+       style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.10526323;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       sodipodi:type="star"
+       transform="matrix(0.47502779,0,0,0.47497219,267.33038,230.20009)"
+       mask="url(#mask2800-2)" />
+    <path
+       style="opacity:1;fill:#b8b2b2;fill-opacity:0.98431373;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       id="path2552-3-3"
+       sodipodi:type="arc"
+       sodipodi:cx="328.4325"
+       sodipodi:cy="288.09763"
+       sodipodi:rx="1.5"
+       sodipodi:ry="1.5"
+       sodipodi:start="0"
+       sodipodi:end="6.2821905"
+       sodipodi:open="true"
+       d="m 329.9325,288.09763 a 1.5,1.5 0 0 1 -1.49963,1.5 1.5,1.5 0 0 1 -1.50037,-1.49926 1.5,1.5 0 0 1 1.49888,-1.50074 1.5,1.5 0 0 1 1.50111,1.4985" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="ExportAreas"
+     style="display:inline">
+    <g
+       id="g2711"
+       inkscape:label="pointers">
       <rect
-         style="fill:#000000;fill-opacity:0.07843137"
-         ry="2"
-         rx="2"
-         y="59.362183"
-         x="87"
+         inkscape:label="pointerPlug"
+         y="1290"
+         x="46"
+         height="32"
+         width="32"
+         id="plug"
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.93652129;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         inkscape:label="pointerValues"
+         y="1290"
+         x="82"
+         height="32"
+         width="32"
+         id="values"
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="rgba"
+         width="32"
+         height="32"
+         x="118"
+         y="1290"
+         inkscape:label="pointerRgba" />
+      <rect
+         inkscape:label="pointerNodes"
+         y="1290"
+         x="154"
+         height="32"
+         width="32"
+         id="nodes"
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="paths"
+         width="32"
+         height="32"
+         x="190"
+         y="1290"
+         inkscape:label="pointerPaths" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="pointerContextMenu"
+         width="32"
+         height="32"
+         x="230"
+         y="1290"
+         inkscape:label="pointerContextMenu" />
+      <rect
+         inkscape:label="pointerTab"
+         y="1290"
+         x="270"
+         height="32"
+         width="32"
+         id="pointerTab"
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="pointerDetachedPanel"
+         width="32"
+         height="32"
+         x="306"
+         y="1290"
+         inkscape:label="pointerDetachedPanel" />
+      <rect
+         inkscape:label="pointerMove"
+         y="1290"
+         x="346"
+         height="32"
+         width="32"
+         id="move"
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         inkscape:label="pointerMoveVertically"
+         y="1290"
+         x="418"
+         height="32"
+         width="32"
+         id="moveVertically"
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="moveHorizontally"
+         width="32"
+         height="32"
+         x="382"
+         y="1290"
+         inkscape:label="pointerMoveHorizontally" />
+      <rect
+         inkscape:label="pointerMoveDiagonallyDown"
+         y="1290"
+         x="454"
+         height="32"
+         width="32"
+         id="moveDiagonallyDown"
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="moveDiagonallyUp"
+         width="32"
+         height="32"
+         x="490"
+         y="1290"
+         inkscape:label="pointerMoveDiagonallyUp" />
+      <rect
+         inkscape:label="pointerTarget"
+         y="1290"
+         x="530"
+         height="32"
+         width="32"
+         id="pointerTarget"
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="pointerCrossHair"
+         width="32"
+         height="32"
+         x="566"
+         y="1290"
+         inkscape:label="pointerCrossHair" />
+    </g>
+    <g
+       id="g2889"
+       inkscape:label="pointers-PathFilterUI"
+       transform="translate(0,-54)">
+      <rect
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:3.12102342;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="removeObjects"
+         width="64"
+         height="32"
+         x="78"
+         y="1444"
+         inkscape:label="pointerRemoveObjects" />
+      <rect
+         inkscape:label="pointerAddObjects"
+         y="1444"
+         x="146"
+         height="32"
+         width="64"
+         id="addObjects"
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:3.12102342;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:3.12102342;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="replaceObjects"
+         width="64"
+         height="32"
+         x="214"
+         y="1444"
+         inkscape:label="pointerReplaceObjects" />
+      <rect
+         inkscape:label="pointerObjects"
+         y="1444"
+         x="282"
+         height="32"
+         width="64"
+         id="objects"
+         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:3.12102342;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+    <g
+       id="g2749"
+       inkscape:label="arrows 10">
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="arrowDown10"
+         width="10"
+         height="10"
+         x="24"
+         y="1494"
+         inkscape:label="arrowDown10" />
+      <rect
+         inkscape:label="arrowUp10"
+         y="1494"
+         x="38"
+         height="10"
+         width="10"
+         id="arrowUp10"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="arrowLeft10"
+         width="10"
+         height="10"
+         x="52"
+         y="1494"
+         inkscape:label="arrowLeft10" />
+      <rect
+         inkscape:label="arrowRight10"
+         y="1494"
+         x="66"
+         height="10"
+         width="10"
+         id="arrowRight10"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="collapsibleArrowDown"
+         width="10"
+         height="10"
+         x="84"
+         y="1494"
+         inkscape:label="collapsibleArrowDown" />
+      <rect
+         inkscape:label="collapsibleArrowRight"
+         y="1494"
+         x="98"
+         height="10"
+         width="10"
+         id="collapsibleArrowRight"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         inkscape:label="collapsibleArrowDownHover"
+         y="1494"
+         x="116"
+         height="10"
+         width="10"
+         id="collapsibleArrowDownHover"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="collapsibleArrowRightHover"
+         width="10"
+         height="10"
+         x="130"
+         y="1494"
+         inkscape:label="collapsibleArrowRightHover" />
+    </g>
+    <g
+       id="g2684"
+       inkscape:label="catalogueStatus">
+      <rect
+         inkscape:label="catalogueStatusDisk"
+         y="1556"
+         x="27"
+         height="13"
+         width="13"
+         id="catalogueStatusDisk"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="catalogueStatusDisplay"
+         width="13"
+         height="13"
+         x="44"
+         y="1556"
+         inkscape:label="catalogueStatusDisplay" />
+      <rect
+         inkscape:label="catalogueStatusBatchRenderRunning"
+         y="1556"
+         x="65"
+         height="13"
+         width="13"
+         id="catalogueStatusBatchRenderRunning"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="catalogueStatusBatchRenderComplete"
+         width="13"
+         height="13"
+         x="82"
+         y="1556"
+         inkscape:label="catalogueStatusBatchRenderComplete" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="catalogueStatusInteractiveRenderRunning"
+         width="13"
+         height="13"
+         x="103"
+         y="1556"
+         inkscape:label="catalogueStatusInteractiveRenderRunning" />
+      <rect
+         inkscape:label="catalogueStatusInteractiveRenderComplete"
+         y="1556"
+         x="120"
+         height="13"
+         width="13"
+         id="catalogueStatusInteractiveRenderComplete"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+    <g
+       id="g2691"
+       inkscape:label="scene view">
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="shading"
+         width="25"
+         height="25"
+         x="39"
+         y="1622"
+         inkscape:label="shading" />
+      <rect
+         inkscape:label="sceneViewGadgets"
+         y="1622"
+         x="68"
+         height="25"
+         width="25"
+         id="grid"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         inkscape:label="drawingStyles"
+         y="1622"
+         x="97"
+         height="25"
+         width="25"
+         id="drawingStyles"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="expansion"
+         width="25"
+         height="25"
+         x="126"
+         y="1622"
+         inkscape:label="expansion" />
+      <rect
+         inkscape:label="cameraOff"
+         y="1622"
+         x="159"
+         height="25"
+         width="25"
+         id="cameraOff"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="cameraOn"
+         width="25"
+         height="25"
+         x="188"
+         y="1622"
+         inkscape:label="cameraOn" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="selectionMaskOff"
+         width="25"
+         height="25"
+         x="221"
+         y="1622"
+         inkscape:label="selectionMaskOff" />
+      <rect
+         inkscape:label="selectionMaskOn"
+         y="1622"
+         x="250"
+         height="25"
+         width="25"
+         id="selectionMaskOn"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+    <g
+       id="g3212"
+       inkscape:label="image view">
+      <rect
+         inkscape:label="exposureOff"
+         y="1698"
+         x="39"
+         height="25"
+         width="25"
+         id="exposureOff"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="exposureOn"
+         width="25"
+         height="25"
+         x="68"
+         y="1698"
+         inkscape:label="exposureOn" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="gammaOff"
+         width="25"
+         height="25"
+         x="101"
+         y="1698"
+         inkscape:label="gammaOff" />
+      <rect
+         inkscape:label="gammaOn"
+         y="1698"
+         x="130"
+         height="25"
+         width="25"
+         id="gammaOn"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         inkscape:label="clippingOff"
+         y="1698"
+         x="163"
+         height="25"
+         width="25"
+         id="clippingOff"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="clippingOn"
+         width="25"
+         height="25"
+         x="192"
+         y="1698"
+         inkscape:label="clippingOn" />
+      <rect
+         inkscape:label="soloChannel-1"
+         y="1698"
+         x="225"
+         height="25"
+         width="25"
+         id="soloChannel-1"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="soloChannel0"
+         width="25"
+         height="25"
+         x="254"
+         y="1698"
+         inkscape:label="soloChannel0" />
+      <rect
+         inkscape:label="soloChannel1"
+         y="1698"
+         x="283"
+         height="25"
+         width="25"
+         id="soloChannel1"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="soloChannel2"
+         width="25"
+         height="25"
+         x="312"
+         y="1698"
+         inkscape:label="soloChannel2" />
+      <rect
+         inkscape:label="soloChannel3"
+         y="1698.0154"
+         x="341"
+         height="25"
+         width="25"
+         id="soloChannel3"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+    <g
+       id="g3230"
+       inkscape:label="tools">
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="gafferSceneUISelectionTool"
+         width="25"
+         height="25"
+         x="39"
+         y="1774"
+         inkscape:label="gafferSceneUISelectionTool" />
+      <rect
+         inkscape:label="gafferSceneUIRotateTool"
+         y="1774"
+         x="68"
+         height="25"
+         width="25"
+         id="gafferSceneUIRotateTool"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="gafferSceneUITranslateTool"
+         width="25"
+         height="25"
+         x="97"
+         y="1774"
+         inkscape:label="gafferSceneUITranslateTool" />
+      <rect
+         inkscape:label="gafferSceneUIScaleTool"
+         y="1774"
+         x="126"
+         height="25"
+         width="25"
+         id="gafferSceneUIScaleTool"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="gafferSceneUICameraTool"
+         width="25"
+         height="25"
+         x="155"
+         y="1774"
+         inkscape:label="gafferSceneUICameraTool" />
+      <rect
+         inkscape:label="gafferSceneUICropWindowTool"
+         y="1774"
+         x="184"
+         height="25"
+         width="25"
+         id="gafferSceneUICropWindowTool"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+    <g
+       id="g3414"
+       inkscape:label="browserIcons">
+      <rect
+         inkscape:label="pathChooser"
+         y="1850"
+         x="28"
+         height="14"
+         width="14"
+         id="pathChooser"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="pathUpArrow"
+         width="14"
+         height="14"
+         x="46"
+         y="1850"
+         inkscape:label="pathUpArrow" />
+      <rect
+         inkscape:label="refresh"
+         y="1850"
+         x="64"
+         height="14"
+         width="14"
+         id="refresh"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="pathListingList"
+         width="14"
+         height="14"
+         x="82"
+         y="1850"
+         inkscape:label="pathListingList" />
+      <rect
+         inkscape:label="pathListingTree"
+         y="1850"
+         x="100"
+         height="14"
+         width="14"
+         id="pathListingTree"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="bookmarks"
+         width="14"
+         height="14"
+         x="118"
+         y="1850"
+         inkscape:label="bookmarks" />
+    </g>
+    <g
+       id="g2008"
+       inkscape:label="controls-checkBox">
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="checkBoxChecked"
+         width="20"
+         height="20"
+         x="38"
+         y="1922"
+         inkscape:label="checkBoxChecked" />
+      <rect
+         inkscape:label="checkBoxUnchecked"
+         y="1922"
+         x="62"
+         height="20"
+         width="20"
+         id="checkBoxUnchecked"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         inkscape:label="checkBoxCheckedHover"
+         y="1922"
+         x="114"
+         height="20"
+         width="20"
+         id="checkBoxCheckedHover"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="checkBoxUncheckedHover"
+         width="20"
+         height="20"
+         x="138"
+         y="1922"
+         inkscape:label="checkBoxUncheckedHover" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="checkBoxCheckedDisabled"
+         width="20"
+         height="20"
+         x="190"
+         y="1922"
+         inkscape:label="checkBoxCheckedDisabled" />
+      <rect
+         inkscape:label="checkBoxUncheckedDisabled"
+         y="1922"
+         x="214"
+         height="20"
+         width="20"
+         id="checkBoxUncheckedDisabled"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="checkBoxIndeterminate"
+         width="20"
+         height="20"
+         x="86"
+         y="1922"
+         inkscape:label="checkBoxIndeterminate" />
+      <rect
+         inkscape:label="checkBoxUncheckedHover"
+         y="1922"
+         x="162"
+         height="20"
+         width="20"
+         id="checkBoxIndeterminateHover"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="checkBoxIndeterminateDisabled"
+         width="20"
+         height="20"
+         x="238"
+         y="1922"
+         inkscape:label="checkBoxUncheckedDisabled" />
+    </g>
+    <g
+       id="g2074"
+       inkscape:label="controls-switch">
+      <rect
+         inkscape:label="toggleOn"
+         y="1996"
+         x="34"
          height="16"
          width="16"
-         id="rect5736-0-2-4" />
+         id="toggleOn"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="toggleOff"
+         width="16"
+         height="16"
+         x="54"
+         y="1996"
+         inkscape:label="toggleOff" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="toggleOnHover"
+         width="16"
+         height="16"
+         x="98"
+         y="1996"
+         inkscape:label="toggleOnHover" />
+      <rect
+         inkscape:label="toggleOffHover"
+         y="1996"
+         x="118"
+         height="16"
+         width="16"
+         id="toggleOffHover"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         inkscape:label="toggleOnDisabled"
+         y="1996"
+         x="162"
+         height="16"
+         width="16"
+         id="toggleOnDisabled"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="toggleOffDisabled"
+         width="16"
+         height="16"
+         x="182"
+         y="1996"
+         inkscape:label="toggleOffDisabled" />
+      <rect
+         inkscape:label="toggleIndeterminate"
+         y="1996"
+         x="74"
+         height="16"
+         width="16"
+         id="toggleIndeterminate"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="toggleIndeterminateHover"
+         width="16"
+         height="16"
+         x="138"
+         y="1996"
+         inkscape:label="toggleIndeterminateHover" />
+      <rect
+         inkscape:label="toggleIndeterminateDisabled"
+         y="1996"
+         x="202"
+         height="16"
+         width="16"
+         id="toggleIndeterminateDisabled"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+    <g
+       id="g2707"
+       inkscape:label="editorFocusMenu">
+      <rect
+         inkscape:label="nodeSetDriverNodeSelection"
+         y="2064"
+         x="31"
+         height="13"
+         width="13"
+         id="nodeSetDriverNodeSelection"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766286;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766286;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="nodeSetStandardSet"
+         width="13"
+         height="13"
+         x="48"
+         y="2064"
+         inkscape:label="nodeSetStandardSet" />
+      <rect
+         inkscape:label="nodeSetDriverSceneSelectionSource"
+         y="2064"
+         x="65"
+         height="13"
+         width="13"
+         id="nodeSetDriverSceneSelectionSource"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766286;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766286;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="nodeSetSourceSet"
+         width="13"
+         height="13"
+         x="82"
+         y="2064"
+         inkscape:label="nodeSetSourceSet" />
+      <rect
+         inkscape:label="nodeSetDriverNodeSet"
+         y="2064"
+         x="112"
+         height="13"
+         width="13"
+         id="nodeSetDriverNodeSet"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766286;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766286;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="nodeSetNumericBookmarkSet"
+         width="13"
+         height="13"
+         x="138"
+         y="2064"
+         inkscape:label="nodeSetNumericBookmarkSet" />
+      <rect
+         inkscape:label="nodeSetDrivertestMode"
+         y="2064"
+         x="159"
+         height="13"
+         width="13"
+         id="nodeSetDrivertestMode"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766286;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill"
+       id="searchFocusOn"
+       width="12"
+       height="12"
+       x="30"
+       y="62"
+       inkscape:label="#rect1670" />
+    <path
+       d="M 40,68 A 4,4 0 0 1 36.000995,72 4,4 0 0 1 32,68.00199 a 4,4 0 0 1 3.997016,-4.001989 4,4 0 0 1 4.002982,3.99602"
+       sodipodi:open="true"
+       sodipodi:end="6.2821905"
+       sodipodi:start="0"
+       sodipodi:ry="4"
+       sodipodi:rx="4"
+       sodipodi:cy="68"
+       sodipodi:cx="36"
+       sodipodi:type="arc"
+       id="path1663"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#383838;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
+    <path
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient1693);stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       id="path1659"
+       sodipodi:type="arc"
+       sodipodi:cx="36"
+       sodipodi:cy="68"
+       sodipodi:rx="3.75"
+       sodipodi:ry="3.75"
+       sodipodi:start="0"
+       sodipodi:end="6.2821905"
+       sodipodi:open="true"
+       d="M 39.75,68 A 3.75,3.75 0 0 1 36.000933,71.75 3.75,3.75 0 0 1 32.25,68.001865 a 3.75,3.75 0 0 1 3.747202,-3.751864 3.75,3.75 0 0 1 3.752796,3.746268" />
+    <path
+       style="opacity:1;fill:url(#linearGradient1699);fill-opacity:1;stroke:#383838;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill"
+       id="path1661"
+       sodipodi:type="arc"
+       sodipodi:cx="36"
+       sodipodi:cy="68"
+       sodipodi:rx="1.5"
+       sodipodi:ry="1.5"
+       sodipodi:start="0"
+       sodipodi:end="6.2821905"
+       sodipodi:open="true"
+       d="M 37.5,68 A 1.5,1.5 0 0 1 36.000373,69.5 1.5,1.5 0 0 1 34.5,68.000746 1.5,1.5 0 0 1 35.998881,66.5 a 1.5,1.5 0 0 1 1.501118,1.498508" />
+    <g
+       inkscape:label="#g1676"
+       id="searchFocusOff"
+       transform="translate(93,5.6378)">
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill"
+         id="rect1678"
+         width="12"
+         height="12"
+         x="-76"
+         y="56.362183" />
+      <path
+         d="M -66,62.362183 A 4,4 0 0 1 -69.999005,66.362182 4,4 0 0 1 -74,62.364172 a 4,4 0 0 1 3.997016,-4.001988 4,4 0 0 1 4.002982,3.996019"
+         sodipodi:open="true"
+         sodipodi:end="6.2821905"
+         sodipodi:start="0"
+         sodipodi:ry="4"
+         sodipodi:rx="4"
+         sodipodi:cy="62.362183"
+         sodipodi:cx="-70"
+         sodipodi:type="arc"
+         id="path1680"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:#383838;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
+      <path
+         style="opacity:1;fill:none;fill-opacity:1;stroke:#9e9e9e;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+         id="path1682"
+         sodipodi:type="arc"
+         sodipodi:cx="-70"
+         sodipodi:cy="62.362183"
+         sodipodi:rx="3.75"
+         sodipodi:ry="3.75"
+         sodipodi:start="0"
+         sodipodi:end="6.2821905"
+         sodipodi:open="true"
+         d="m -66.25,62.362183 a 3.75,3.75 0 0 1 -3.749067,3.75 3.75,3.75 0 0 1 -3.750933,-3.748135 3.75,3.75 0 0 1 3.747202,-3.751864 3.75,3.75 0 0 1 3.752796,3.746268" />
+      <path
+         style="opacity:1;fill:#9e9e9e;fill-opacity:1;stroke:#383838;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill"
+         id="path1684"
+         sodipodi:type="arc"
+         sodipodi:cx="-70"
+         sodipodi:cy="62.362183"
+         sodipodi:rx="1.5"
+         sodipodi:ry="1.5"
+         sodipodi:start="0"
+         sodipodi:end="6.2821905"
+         sodipodi:open="true"
+         d="m -68.5,62.362183 a 1.5,1.5 0 0 1 -1.499627,1.5 1.5,1.5 0 0 1 -1.500373,-1.499254 1.5,1.5 0 0 1 1.498881,-1.500746 1.5,1.5 0 0 1 1.501118,1.498507" />
+    </g>
+    <rect
+       inkscape:label="viewPause"
+       y="2134"
+       x="39"
+       height="25"
+       width="25"
+       id="viewPause"
+       style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.9176628;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+    <rect
+       style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.9176628;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       id="viewPaused"
+       width="25"
+       height="25"
+       x="68"
+       y="2134"
+       inkscape:label="viewerPaused" />
+    <rect
+       inkscape:label="#rect1735"
+       y="89"
+       x="211"
+       height="16"
+       width="10"
+       id="lutGPU"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       id="lutCPU"
+       width="10"
+       height="16"
+       x="192"
+       y="89"
+       inkscape:label="#rect1735" />
+    <path
+       sodipodi:nodetypes="ccccccc"
+       inkscape:connector-curvature="0"
+       id="path2635"
+       d="m 198,90 -5,9 4,-1 -1,6 5,-9 -4,1 z"
+       style="fill:#9e9e9e;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers" />
+    <path
+       style="fill:url(#linearGradient1733);fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       d="m 217,90 -5,9 4,-1 -1,6 5,-9 -4,1 z"
+       id="path1726"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+  </g>
+  <g
+     inkscape:label="Artwork"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-52.362183)"
+     style="display:inline">
+    <g
+       id="path12345"
+       inkscape:label="move"
+       transform="translate(-236.58594,1205.4141)"
+       style="paint-order:markers stroke fill">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:12.02084923;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="rect2570"
+         width="12.020849"
+         height="12.020849"
+         x="516.92395"
+         y="-321.11588"
+         transform="rotate(44.999114)" />
+      <path
+         sodipodi:nodetypes="ccccccccccccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path1565"
+         d="m 592.58594,138.44808 -3.5,3.5 h 2.5 v 4 h -4 v -2.5 l -3.5,3.5 3.5,3.5 v -2.5 h 4 v 4 h -2.5 l 3.5,3.5 3.5,-3.5 h -2.5 v -4 h 4 v 2.5 l 3.5,-3.5 -3.5,-3.5 v 2.5 h -4 v -4 h 2.5 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
     </g>
     <rect
        style="fill:none;fill-opacity:1;stroke:none"
@@ -1308,13 +3414,25 @@
        transform="translate(0,52.362183)"
        id="info"
        inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3925"
+       d="M 10.00302,97.80467 C 9.67541,97.72127 9.47879,97.53041 9.00785,96.83864 8.50927,96.10629 7.99375,95.44349 7.46993,94.861385 7.07136,94.41847 6.77491,93.979131 6.7087,93.733211 6.56363,93.194492 7.01148,92.546373 7.80796,92.142372 8.16548,91.961019 8.2243,91.946405 8.5966,91.946405 c 0.37755,0 0.4281,0.01307 0.82179,0.212704 0.45178,0.22907 1.04314,0.733631 1.38454,1.181315 0.10373,0.135954 0.20206,0.247188 0.21862,0.247188 0.0166,0 0.12472,-0.208644 0.24037,-0.463659 0.25544,-0.563226 1.31289,-2.542595 1.75455,-3.284175 1.63774,-2.749977 3.44733,-5.032904 4.31459,-5.443186 0.3245,-0.15351 1.01672,-0.290822 1.81381,-0.359796 0.55651,-0.04814 0.62125,-0.04487 0.81712,0.04177 0.13992,0.0619 0.24167,0.150061 0.29727,0.257584 0.0971,0.187734 0.10594,0.516424 0.0185,0.685008 -0.0328,0.06347 -0.39478,0.457143 -0.80411,0.874793 -1.1208,1.143589 -1.74543,1.912562 -2.73766,3.370297 -1.32415,1.9454 -2.422,3.954681 -3.38197,6.189678 -0.73648,1.714674 -0.74612,1.734684 -0.93659,1.945504 -0.0953,0.10545 -0.28876,0.24251 -0.42999,0.30458 -0.22736,0.0999 -0.34668,0.11437 -1.04066,0.1261 -0.43112,0.007 -0.85582,-0.005 -0.94379,-0.0275 z"
+       style="fill:url(#foreground);fill-opacity:1;stroke:url(#backgroundDark);stroke-opacity:1" />
+    <rect
+       style="fill:none;stroke:none"
+       id="menuChecked"
+       width="15"
+       height="15"
+       x="83.362183"
+       y="6"
+       transform="matrix(0,1,1,0,0,0)"
+       inkscape:label="#rect3946" />
     <g
-       id="arrowDown10"
-       inkscape:label="#downArrow10"
-       inkscape:export-xdpi="10"
-       inkscape:export-ydpi="10">
+       id="g2739"
+       inkscape:label="arrows 10">
       <path
-         transform="matrix(0,-0.65333366,0.646633,0,-363.80332,137.72889)"
+         transform="matrix(0,-0.65333366,0.646633,0,-344.80332,1626.7289)"
          d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
          inkscape:randomized="0"
          inkscape:rounded="0"
@@ -1328,35 +3446,8 @@
          sodipodi:sides="3"
          id="path2818"
          style="fill:url(#linearGradient6241);fill-opacity:1;stroke:url(#backgroundDark);stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         sodipodi:type="star" />
-      <rect
-         y="57.36219"
-         x="5.0000029"
-         height="10"
-         width="10"
-         id="rect2820"
-         style="fill:none;stroke:none" />
-    </g>
-    <g
-       inkscape:export-ydpi="10"
-       inkscape:export-xdpi="10"
-       inkscape:label="#downArrow10"
-       id="g3604"
-       transform="translate(10.000004)">
-      <rect
-         style="fill:none;stroke:none"
-         id="rect3608"
-         width="10"
-         height="10"
-         x="5.0000029"
-         y="57.36219" />
-    </g>
-    <g
-       inkscape:export-ydpi="10"
-       inkscape:export-xdpi="10"
-       inkscape:label="#downArrow10"
-       id="arrowUp10"
-       transform="matrix(1,0,0,-1,10.000008,124.72438)">
+         sodipodi:type="star"
+         inkscape:label="down" />
       <path
          sodipodi:type="star"
          style="fill:url(#linearGradient6249);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1372,21 +3463,8 @@
          inkscape:rounded="0"
          inkscape:randomized="0"
          d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
-         transform="matrix(0,-0.65333366,0.646633,0,-363.80333,137.72891)" />
-      <rect
-         style="fill:none;stroke:none"
-         id="rect3614"
-         width="10"
-         height="10"
-         x="5.0000029"
-         y="57.36219" />
-    </g>
-    <g
-       inkscape:export-ydpi="10"
-       inkscape:export-xdpi="10"
-       inkscape:label="#downArrow10"
-       id="arrowLeft10"
-       transform="rotate(90,20.000002,72.362189)">
+         transform="matrix(0,0.65333366,0.646633,0,-330.80332,1475.9955)"
+         inkscape:label="up" />
       <path
          sodipodi:type="star"
          style="fill:url(#linearGradient6241);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1402,76 +3480,8 @@
          inkscape:rounded="0"
          inkscape:randomized="0"
          d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
-         transform="matrix(0,-0.65333366,0.646633,0,-363.80333,137.7289)" />
-      <rect
-         style="fill:none;stroke:none"
-         id="rect3620"
-         width="10"
-         height="10"
-         x="5.0000029"
-         y="57.36219" />
-    </g>
-    <g
-       transform="matrix(0,1,1,0,-22.362182,52.362187)"
-       id="arrowRight10"
-       inkscape:label="#downArrow10"
-       inkscape:export-xdpi="10"
-       inkscape:export-ydpi="10">
-      <path
-         transform="matrix(0,-0.65333366,0.646633,0,-363.80333,137.22889)"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
-         inkscape:randomized="0"
-         inkscape:rounded="0"
-         inkscape:flatsided="true"
-         sodipodi:arg2="2.0943952"
-         sodipodi:arg1="1.0471976"
-         sodipodi:r2="5.7786927"
-         sodipodi:r1="7.1428571"
-         sodipodi:cy="578.07648"
-         sodipodi:cx="117.14286"
-         sodipodi:sides="3"
-         id="path3624"
-         style="fill:#000000;fill-opacity:1;stroke:none"
-         sodipodi:type="star" />
-      <rect
-         y="57.36219"
-         x="5.0000029"
-         height="10"
-         width="10"
-         id="rect3626"
-         style="fill:none;stroke:none" />
-    </g>
-    <path
-       transform="matrix(-0.65333366,0,0,0.646633,135.86671,-311.44114)"
-       d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
-       inkscape:randomized="0"
-       inkscape:rounded="0"
-       inkscape:flatsided="true"
-       sodipodi:arg2="2.0943952"
-       sodipodi:arg1="1.0471976"
-       sodipodi:r2="5.7786927"
-       sodipodi:r1="7.1428571"
-       sodipodi:cy="578.07648"
-       sodipodi:cx="117.14286"
-       sodipodi:sides="3"
-       id="path2835"
-       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       sodipodi:type="star" />
-    <rect
-       y="55.000004"
-       x="57.36219"
-       height="10"
-       width="10"
-       id="collapsibleArrowRight"
-       style="fill:none;stroke:none"
-       transform="matrix(0,1,1,0,0,0)"
-       inkscape:label="#rect2837" />
-    <g
-       inkscape:export-ydpi="10"
-       inkscape:export-xdpi="10"
-       inkscape:label="#downArrow10"
-       id="g2849"
-       transform="matrix(0,1,1,0,-22.362182,52.362187)">
+         transform="matrix(0.65333366,0,0,0.646633,-18.366708,1177.5589)"
+         inkscape:label="left" />
       <path
          sodipodi:type="star"
          style="fill:url(#linearGradient6241);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
@@ -1487,156 +3497,77 @@
          inkscape:rounded="0"
          inkscape:randomized="0"
          d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
-         transform="matrix(0,-0.65333366,0.646633,0,-363.80333,137.72889)" />
-      <rect
-         style="fill:none;stroke:none"
-         id="rect2853"
-         width="10"
-         height="10"
-         x="5.0000029"
-         y="57.36219" />
+         transform="matrix(-0.65333366,0,0,0.646633,146.36671,1177.5589)"
+         inkscape:label="right" />
+      <path
+         sodipodi:type="star"
+         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path2835"
+         sodipodi:sides="3"
+         sodipodi:cx="117.14286"
+         sodipodi:cy="578.07648"
+         sodipodi:r1="7.1428571"
+         sodipodi:r2="5.7786927"
+         sodipodi:arg1="1.0471976"
+         sodipodi:arg2="2.0943952"
+         inkscape:flatsided="true"
+         inkscape:rounded="0"
+         inkscape:randomized="0"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+         transform="matrix(-0.65333366,0,0,0.646633,178.36671,1177.5589)"
+         inkscape:label="collapsibleRight" />
+      <path
+         inkscape:label="collapsibleDown"
+         transform="matrix(0,-0.65333366,-0.646633,0,462.80332,1626.7289)"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+         inkscape:randomized="0"
+         inkscape:rounded="0"
+         inkscape:flatsided="true"
+         sodipodi:arg2="2.0943952"
+         sodipodi:arg1="1.0471976"
+         sodipodi:r2="5.7786927"
+         sodipodi:r1="7.1428571"
+         sodipodi:cy="578.07648"
+         sodipodi:cx="117.14286"
+         sodipodi:sides="3"
+         id="down"
+         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:type="star" />
+      <path
+         inkscape:label="collapsibleRightHover"
+         transform="matrix(-0.65333366,0,0,0.646633,210.36671,1177.5589)"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+         inkscape:randomized="0"
+         inkscape:rounded="0"
+         inkscape:flatsided="true"
+         sodipodi:arg2="2.0943952"
+         sodipodi:arg1="1.0471976"
+         sodipodi:r2="5.7786927"
+         sodipodi:r1="7.1428571"
+         sodipodi:cy="578.07648"
+         sodipodi:cx="117.14286"
+         sodipodi:sides="3"
+         id="fds"
+         style="fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:type="star" />
+      <path
+         sodipodi:type="star"
+         style="fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path2918"
+         sodipodi:sides="3"
+         sodipodi:cx="117.14286"
+         sodipodi:cy="578.07648"
+         sodipodi:r1="7.1428571"
+         sodipodi:r2="5.7786927"
+         sodipodi:arg1="1.0471976"
+         sodipodi:arg2="2.0943952"
+         inkscape:flatsided="true"
+         inkscape:rounded="0"
+         inkscape:randomized="0"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+         transform="matrix(0,-0.65333366,-0.646633,0,494.80333,1626.7289)"
+         inkscape:label="collapsibleDownHover" />
     </g>
-    <path
-       sodipodi:type="star"
-       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="down"
-       sodipodi:sides="3"
-       sodipodi:cx="117.14286"
-       sodipodi:cy="578.07648"
-       sodipodi:r1="7.1428571"
-       sodipodi:r2="5.7786927"
-       sodipodi:arg1="1.0471976"
-       sodipodi:arg2="2.0943952"
-       inkscape:flatsided="true"
-       inkscape:rounded="0"
-       inkscape:randomized="0"
-       d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
-       transform="matrix(0,-0.65333366,-0.646633,0,423.30333,137.72889)"
-       inkscape:label="#path2847" />
-    <rect
-       transform="matrix(0,1,1,0,0,0)"
-       style="fill:none;stroke:none"
-       id="collapsibleArrowDown"
-       width="10"
-       height="10"
-       x="57.36219"
-       y="45"
-       inkscape:label="#rect2865" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path3925"
-       d="M 10.00302,97.80467 C 9.67541,97.72127 9.47879,97.53041 9.00785,96.83864 8.50927,96.10629 7.99375,95.44349 7.46993,94.861385 7.07136,94.41847 6.77491,93.979131 6.7087,93.733211 6.56363,93.194492 7.01148,92.546373 7.80796,92.142372 8.16548,91.961019 8.2243,91.946405 8.5966,91.946405 c 0.37755,0 0.4281,0.01307 0.82179,0.212704 0.45178,0.22907 1.04314,0.733631 1.38454,1.181315 0.10373,0.135954 0.20206,0.247188 0.21862,0.247188 0.0166,0 0.12472,-0.208644 0.24037,-0.463659 0.25544,-0.563226 1.31289,-2.542595 1.75455,-3.284175 1.63774,-2.749977 3.44733,-5.032904 4.31459,-5.443186 0.3245,-0.15351 1.01672,-0.290822 1.81381,-0.359796 0.55651,-0.04814 0.62125,-0.04487 0.81712,0.04177 0.13992,0.0619 0.24167,0.150061 0.29727,0.257584 0.0971,0.187734 0.10594,0.516424 0.0185,0.685008 -0.0328,0.06347 -0.39478,0.457143 -0.80411,0.874793 -1.1208,1.143589 -1.74543,1.912562 -2.73766,3.370297 -1.32415,1.9454 -2.422,3.954681 -3.38197,6.189678 -0.73648,1.714674 -0.74612,1.734684 -0.93659,1.945504 -0.0953,0.10545 -0.28876,0.24251 -0.42999,0.30458 -0.22736,0.0999 -0.34668,0.11437 -1.04066,0.1261 -0.43112,0.007 -0.85582,-0.005 -0.94379,-0.0275 z"
-       style="fill:url(#foreground);fill-opacity:1;stroke:url(#backgroundDark);stroke-opacity:1" />
-    <rect
-       style="fill:none;stroke:none"
-       id="checkBoxChecked"
-       width="19.97287"
-       height="19.972771"
-       x="57.389313"
-       y="85.027229"
-       transform="matrix(0,1,1,0,0,0)"
-       inkscape:label="#rect3931" />
-    <rect
-       style="fill:none;stroke:none"
-       id="menuChecked"
-       width="15"
-       height="15"
-       x="83.362183"
-       y="6"
-       transform="matrix(0,1,1,0,0,0)"
-       inkscape:label="#rect3946" />
-    <rect
-       inkscape:label="#rect3931"
-       transform="matrix(0,1,1,0,0,0)"
-       y="106"
-       x="57.362183"
-       height="19.972771"
-       width="19.97287"
-       id="checkBoxUnchecked"
-       style="fill:none;fill-opacity:1;stroke:none" />
-    <rect
-       style="fill:none;stroke:none"
-       id="checkBoxUncheckedHover"
-       width="19.97287"
-       height="19.972771"
-       x="57.389313"
-       y="125.02723"
-       transform="matrix(0,1,1,0,0,0)"
-       inkscape:label="#rect3931" />
-    <rect
-       inkscape:label="#rect3931"
-       transform="matrix(0,1,1,0,0,0)"
-       y="145.02722"
-       x="57.389313"
-       height="19.972771"
-       width="19.97287"
-       id="checkBoxCheckedHover"
-       style="fill:none;stroke:none" />
-    <path
-       sodipodi:type="star"
-       style="fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="fds"
-       sodipodi:sides="3"
-       sodipodi:cx="117.14286"
-       sodipodi:cy="578.07648"
-       sodipodi:r1="7.1428571"
-       sodipodi:r2="5.7786927"
-       sodipodi:arg1="1.0471976"
-       sodipodi:arg2="2.0943952"
-       inkscape:flatsided="true"
-       inkscape:rounded="0"
-       inkscape:randomized="0"
-       d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
-       transform="matrix(-0.65333366,0,0,0.646633,155.86671,-311.44114)"
-       inkscape:label="#collapsibleArrowRightHover" />
-    <rect
-       transform="matrix(0,1,1,0,0,0)"
-       style="fill:none;stroke:none"
-       id="collapsibleArrowRightHover"
-       width="10"
-       height="10"
-       x="57.36219"
-       y="75"
-       inkscape:label="#rect2914" />
-    <path
-       transform="matrix(0,-0.65333366,-0.646633,0,443.30333,137.72889)"
-       d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
-       inkscape:randomized="0"
-       inkscape:rounded="0"
-       inkscape:flatsided="true"
-       sodipodi:arg2="2.0943952"
-       sodipodi:arg1="1.0471976"
-       sodipodi:r2="5.7786927"
-       sodipodi:r1="7.1428571"
-       sodipodi:cy="578.07648"
-       sodipodi:cx="117.14286"
-       sodipodi:sides="3"
-       id="path2918"
-       style="fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       sodipodi:type="star" />
-    <rect
-       y="65"
-       x="57.36219"
-       height="10"
-       width="10"
-       id="collapsibleArrowDownHover"
-       style="fill:none;stroke:none"
-       transform="matrix(0,1,1,0,0,0)"
-       inkscape:label="#rect2920" />
-    <path
-       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686"
-       d="m 214,63.362183 h 4 c 1,0 1,2 1,2 h 6 v 9 h -12 v -9 c 0,0 -0.1875,-2.125 1,-2 z"
-       id="pathChooser"
-       sodipodi:nodetypes="cccccccc"
-       inkscape:label="#rect2859"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:label="#rect2859"
-       sodipodi:nodetypes="ccccccc"
-       id="rect2859"
-       d="m 232,74.862183 v -4.5 h -3 l 6,-7 6,7 h -3 v 4.5"
-       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686"
-       inkscape:connector-curvature="0" />
     <rect
        style="display:inline;fill:url(#linearGradient1646);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.80000001;stroke-opacity:1"
        id="layoutButton"
@@ -1734,86 +3665,6 @@
        x="84.75"
        y="83.362183"
        inkscape:label="#rect3043" />
-    <path
-       style="opacity:0.98999999;fill:url(#backgroundLighter);fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-       d="m 251,62.862183 c -3.4,0 -6.15625,2.756247 -6.15625,6.15625 0,3.400006 2.75625,6.15625 6.15625,6.15625 0.053,0 0.10358,0.0013 0.15625,0 v -2.9375 c -0.0626,0.0036 -0.12389,0.03125 -0.1875,0.03125 -1.76904,0 -3.21875,-1.418465 -3.21875,-3.1875 0,-1.769034 1.44971,-3.21875 3.21875,-3.21875 1.76903,0 3.1875,1.449716 3.1875,3.21875 0,0.09476 -0.025,0.186855 -0.0312,0.28125 h -2.75 l 4.125,5.9375 4.1562,-5.9375 H 257.125 c 0.006,-0.116523 0.0312,-0.226636 0.0312,-0.34375 0,-3.400003 -2.75624,-6.15625 -6.15625,-6.15625 z"
-       id="path3109"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="sssccsssscccccss"
-       inkscape:label="#path3109" />
-    <rect
-       style="fill:none;stroke:none"
-       id="refresh"
-       width="14.500001"
-       height="16.499992"
-       x="61.862183"
-       y="244"
-       transform="matrix(0,1,1,0,0,0)"
-       inkscape:label="#rect3931" />
-    <rect
-       inkscape:label="#rect3931"
-       transform="matrix(0,1,1,0,0,0)"
-       y="227.5"
-       x="61.862183"
-       height="14.999993"
-       width="14.500001"
-       id="pathUpArrow"
-       style="fill:none;stroke:none" />
-    <g
-       id="pathListingList"
-       inkscape:label="#g3271"
-       transform="translate(20)">
-      <rect
-         inkscape:label="#rect3931"
-         transform="matrix(0,1,1,0,0,0)"
-         y="245"
-         x="62.362183"
-         height="14.999993"
-         width="15.000001"
-         id="rect3244"
-         style="fill:none;stroke:none" />
-      <rect
-         y="64.862183"
-         x="247"
-         height="2"
-         width="11"
-         id="rect3246"
-         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect3248"
-         width="11"
-         height="2"
-         x="247"
-         y="68.862183" />
-      <rect
-         y="72.862183"
-         x="247"
-         height="2"
-         width="11"
-         id="rect3250"
-         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="pathListingTree"
-       inkscape:label="#g3279"
-       transform="translate(20)">
-      <path
-         sodipodi:nodetypes="ccccccccccccc"
-         inkscape:connector-curvature="0"
-         id="rect3268"
-         d="m 262,64.862183 h 5 v 4 h 3 v 4 l 3,0.03125 v 1.968753 l -5,-3e-6 v -4 h -3 v -4 l -3,3e-6 z"
-         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
-      <rect
-         style="fill:none;stroke:none"
-         id="rect3277"
-         width="15.000001"
-         height="14.999993"
-         x="62.362183"
-         y="260"
-         transform="matrix(0,1,1,0,0,0)"
-         inkscape:label="#rect3931" />
-    </g>
     <g
        id="timeline3"
        inkscape:label="#g3968"
@@ -1956,90 +3807,6 @@
        y="61.299683"
        inkscape:label="#rect3932" />
     <path
-       id="path3115"
-       d="m 88.46875,110.54346 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
-       style="opacity:0.98999999;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="sssss" />
-    <g
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.49083519px;line-height:125%;font-family:'URW Palladio L';-inkscape-font-specification:'URW Palladio L Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none"
-       id="g3117"
-       transform="matrix(1.1174828,0,0,1.1174828,-111.63832,49.197893)">
-      <path
-         d="m 178.71815,64.059798 c -0.5917,0.184908 -1.03548,0.258871 -1.8121,0.351325 -0.0555,0 -0.14793,0.01849 -0.27736,0.03698 v 0.66567 l 0.83209,0.05547 c 0.42528,0.03698 0.48076,0.2034 0.48076,1.294358 v 4.049493 c 0,0.998504 -0.0925,1.146432 -0.66567,1.183414 l -0.64718,0.03698 v 0.684161 l 2.38532,-0.05547 c 0.36981,0 1.25737,0.01849 2.49626,0.05547 v -0.684161 l -0.64718,-0.03698 c -0.57322,-0.03698 -0.66567,-0.18491 -0.66567,-1.183414 v -6.749155 l -0.18491,-0.110943 z m 0.29586,-4.75215 c -0.79511,0 -1.40531,0.591707 -1.40531,1.368322 0,0.776614 0.6102,1.405303 1.38682,1.405303 0.75812,0 1.38681,-0.628689 1.38681,-1.386812 0,-0.758124 -0.6102,-1.386813 -1.36832,-1.386813"
-         id="path3119"
-         style="fill:#3c3c3c;fill-opacity:1;stroke:none"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccsscccccccsccccsssc" />
-    </g>
-    <path
-       sodipodi:nodetypes="sssss"
-       inkscape:connector-curvature="0"
-       style="opacity:0.98999999;fill:none;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-       d="m 88.46875,110.54346 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
-       id="path3121" />
-    <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-       d="m 20.84375,110.86218 c -0.63482,0.0493 -1.23606,0.42206 -1.5625,0.96875 l -13,21.5 c -0.7268,1.20821 0.30879,3.03461 1.71875,3.03125 h 26 c 1.40997,0.003 2.44556,-1.82304 1.71875,-3.03125 l -13,-21.5 c -0.37983,-0.6363 -1.13625,-1.02711 -1.875,-0.96875 z"
-       id="errorNotification"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccc"
-       inkscape:label="#path3123" />
-    <g
-       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient1727);fill-opacity:1;stroke:none"
-       id="text3918"
-       transform="translate(-26.8125,-0.624997)">
-      <path
-         d="m 49.740965,129.21831 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,10e-6 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 H 49.74097 Z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105"
-         style="fill:url(#linearGradient1727);fill-opacity:1;stroke:none"
-         id="path3896"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccsccccccccscsc" />
-    </g>
-    <g
-       id="g3898"
-       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient1725);fill-opacity:1;stroke:none"
-       transform="translate(-30.8125,-0.624997)">
-      <path
-         sodipodi:nodetypes="cccsccccccccscsc"
-         inkscape:connector-curvature="0"
-         id="path3900"
-         style="fill:url(#linearGradient1725);fill-opacity:1;stroke:none"
-         d="m 49.740965,129.21831 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,10e-6 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 H 49.74097 Z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105" />
-    </g>
-    <path
-       sodipodi:nodetypes="cccccccc"
-       inkscape:connector-curvature="0"
-       id="warningNotification"
-       d="m 55.84375,110.86218 c -0.63483,0.0493 -1.23606,0.42206 -1.5625,0.96875 l -13,21.5 c -0.72681,1.20821 0.30878,3.03461 1.71875,3.03125 h 26 c 1.40997,0.003 2.44556,-1.82304 1.71875,-3.03125 l -13,-21.5 c -0.37984,-0.6363 -1.13625,-1.02711 -1.875,-0.96875 z"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#efc618;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-       inkscape:label="#path3902" />
-    <g
-       transform="translate(6,-0.999997)"
-       id="g3904"
-       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none">
-      <path
-         sodipodi:nodetypes="cccsccccccccscsc"
-         inkscape:connector-curvature="0"
-         id="path3906"
-         style="fill:#3c3c3c;fill-opacity:1;stroke:none"
-         d="m 49.740965,129.21831 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,10e-6 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 H 49.74097 Z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105" />
-    </g>
-    <path
-       id="infoNotification"
-       d="m 88.46875,110.54346 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
-       style="opacity:0.98999999;fill:none;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="sssss"
-       inkscape:label="#path3908" />
-    <path
-       sodipodi:nodetypes="sssss"
-       inkscape:connector-curvature="0"
-       style="opacity:0.98999999;fill:#b7b1b1;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
-       d="m 119.97497,111.41225 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
-       id="debugNotification"
-       inkscape:label="#path3910" />
-    <path
        sodipodi:nodetypes="sssss"
        inkscape:connector-curvature="0"
        style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
@@ -2080,27 +3847,9 @@
        x="108.6044"
        y="82.233063"
        inkscape:label="#rect4103" />
-    <rect
-       inkscape:label="#rect3931"
-       transform="matrix(0,1,1,0,0,0)"
-       y="165.02722"
-       x="57.389313"
-       height="19.972771"
-       width="19.97287"
-       id="checkBoxCheckedDisabled"
-       style="fill:none;stroke:none" />
-    <rect
-       style="fill:none;stroke:none"
-       id="checkBoxUncheckedDisabled"
-       width="19.97287"
-       height="19.972771"
-       x="57.362183"
-       y="186"
-       transform="matrix(0,1,1,0,0,0)"
-       inkscape:label="#rect3931" />
     <g
        transform="translate(4.9651315e-6,-0.04534109)"
-       id="search-old"
+       id="search"
        inkscape:label="#g3188"
        style="fill:url(#backgroundLighter)">
       <path
@@ -2112,8 +3861,9 @@
          sodipodi:nodetypes="cccsssccscsss" />
     </g>
     <g
-       id="values"
-       inkscape:label="#g4179">
+       id="g4179"
+       inkscape:label="values"
+       transform="translate(-187,1215)">
       <g
          transform="translate(4,45)"
          style="opacity:0.5"
@@ -2188,8 +3938,9 @@
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
     </g>
     <g
-       id="rgba"
-       inkscape:label="#g4195">
+       id="g4195"
+       inkscape:label="rgba"
+       transform="translate(-207,1214)">
       <g
          transform="translate(0,46)"
          style="opacity:0.5"
@@ -2232,68 +3983,9 @@
          sodipodi:nodetypes="ccccccccc" />
     </g>
     <g
-       id="objects"
-       inkscape:label="#g4299"
-       transform="translate(225,55.000003)">
-      <g
-         transform="translate(-20,48)"
-         style="opacity:0.5"
-         inkscape:label="#g4081"
-         id="g4081">
-        <path
-           style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
-           d="m 392.52471,75.862183 5.99436,12.546318 h -11.98873 z"
-           id="rect4062"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cccc" />
-        <path
-           sodipodi:type="arc"
-           style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3260"
-           sodipodi:cx="385"
-           sodipodi:cy="40"
-           sodipodi:rx="5"
-           sodipodi:ry="5"
-           d="M 390,40 A 5,5 0 0 1 385.00124,45 5,5 0 0 1 380,40.002472 5,5 0 0 1 384.99629,35.000001 5,5 0 0 1 390,39.995056"
-           transform="matrix(1.2149049,0,0,1.2149049,-83.343223,40.597872)"
-           sodipodi:start="0"
-           sodipodi:end="6.2821966"
-           sodipodi:open="true" />
-        <path
-           style="fill:#787878;fill-opacity:0.99215896;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           d="m 387,87.862183 6,2.5 v 9.999997 l -6,-3.499997 z"
-           id="rect4065"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           d="M 392.93011,90.61057 401,88.862183 v 9 l -8,2.499997 z"
-           id="rect4067"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           id="path4079"
-           d="m 387,87.862183 5.93008,2.748387 8.06992,-1.748387 -6.0625,-2.4375 z"
-           style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
-      </g>
-      <path
-         sodipodi:nodetypes="ccccccccc"
-         inkscape:connector-curvature="0"
-         id="path4167"
-         d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
-         style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
-      <path
-         style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
-         id="path3193"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccc" />
-    </g>
-    <g
-       id="nodes"
-       inkscape:label="#g4212">
+       id="g4212"
+       inkscape:label="nodes"
+       transform="translate(-236,1210)">
       <g
          transform="translate(-70,52)"
          style="opacity:0.5"
@@ -2328,8 +4020,9 @@
          sodipodi:nodetypes="ccccccccc" />
     </g>
     <g
-       id="paths"
-       inkscape:label="#g4219">
+       id="g4219"
+       inkscape:label="paths"
+       transform="translate(-238,1210)">
       <g
          transform="translate(-12,52)"
          style="opacity:0.5"
@@ -2371,16 +4064,10 @@
          d="m 435.5,153.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 441 l -2.5,-5 z"
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
     </g>
-    <path
-       inkscape:label="#path3908"
-       sodipodi:nodetypes="sssss"
-       inkscape:connector-curvature="0"
-       style="opacity:0.98999999;fill:none;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-       d="m 88.46875,110.54346 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
-       id="path4261" />
     <g
-       id="plug"
-       inkscape:label="#g4288">
+       id="g4288"
+       inkscape:label="plug"
+       transform="translate(-193.99999,1215)">
       <path
          id="path4263"
          d="m 247,128.36219 c -3.31371,0 -6,2.68629 -6,5.99999 0,3.31372 2.68629,6 6,6 3.31371,0 5.99999,-2.68628 5.99999,-6 0,-3.3137 -2.68628,-5.99999 -5.99999,-5.99999 z"
@@ -2395,321 +4082,12 @@
          sodipodi:nodetypes="ccccccccc" />
     </g>
     <path
-       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 514.5,93.5 V 90 l -5.5,5 5.5,5 v -3.5 h 7 v 3.5 l 5.5,-5 -5.5,-5 v 3.5 z"
-       id="moveHorizontally"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+       d="m 387,1351.3622 v -2.5 l -3.5,3.5 3.5,3.5 v -2.5 h 10 v 2.5 l 3.5,-3.5 -3.5,-3.5 v 2.5 z"
+       id="path1234"
        sodipodi:nodetypes="ccccccccccc"
-       transform="translate(0,52.362183)"
-       inkscape:label="#path3088"
+       inkscape:label="moveHorizontally"
        inkscape:connector-curvature="0" />
-    <path
-       sodipodi:nodetypes="ccccccccccc"
-       id="moveVertically"
-       d="m 534,150.86218 h -3.5 l 5,5.5 5,-5.5 H 537 v -7 h 3.5 l -5,-5.5 -5,5.5 h 3.5 z"
-       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:label="#path3093"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 552.44974,150.81192 -2.47487,2.47488 7.42462,0.35355 -0.35355,-7.42462 -2.47488,2.47487 -4.94974,-4.94974 2.47487,-2.47488 -7.42462,-0.35355 0.35355,7.42462 2.47488,-2.47487 z"
-       id="moveDiagonallyDown"
-       sodipodi:nodetypes="ccccccccccc"
-       inkscape:label="#path3095"
-       inkscape:connector-curvature="0" />
-    <path
-       sodipodi:nodetypes="ccccccccccc"
-       id="moveDiagonallyUp"
-       d="m 566.22183,150.76167 2.47487,2.47488 -7.42462,0.35355 0.35355,-7.42462 2.47488,2.47487 4.94974,-4.94974 -2.47487,-2.47488 7.42462,-0.35355 -0.35355,7.42462 -2.47488,-2.47487 z"
-       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:label="#path3097"
-       inkscape:connector-curvature="0" />
-    <g
-       transform="translate(-7,-1.9999996)"
-       id="toggleOff"
-       inkscape:label="#g3906">
-      <rect
-         ry="2.5"
-         rx="2.5"
-         y="109.86218"
-         x="172.5"
-         height="15"
-         width="15"
-         id="rect3875"
-         style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         ry="2.5"
-         rx="2.0913782"
-         y="109.86218"
-         x="172.5"
-         height="15"
-         width="8.5"
-         id="rect3875-3"
-         style="opacity:0.98999999;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="toggleOn"
-       transform="matrix(-1,0,0,1,373,-1.9999996)"
-       inkscape:label="#g3974">
-      <g
-         id="g3938">
-        <rect
-           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect3875-8"
-           width="15"
-           height="15"
-           x="172.5"
-           y="109.86218"
-           rx="2.5"
-           ry="2.5" />
-        <rect
-           style="opacity:0.98999999;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect3875-3-9"
-           width="8.5"
-           height="15"
-           x="172.5"
-           y="109.86218"
-           rx="2.0913782"
-           ry="2.5" />
-      </g>
-    </g>
-    <g
-       transform="matrix(-1,0,0,1,393,-1.9999996)"
-       id="toggleOnHover"
-       inkscape:label="#g3938-7">
-      <g
-         id="g3970">
-        <rect
-           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect3875-8-9"
-           width="15"
-           height="15"
-           x="172.5"
-           y="109.86218"
-           rx="2.5"
-           ry="2.5" />
-        <rect
-           style="opacity:0.98999999;fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect3875-3-9-1"
-           width="8.5"
-           height="15"
-           x="172.5"
-           y="109.86218"
-           rx="2.0913782"
-           ry="2.5" />
-      </g>
-    </g>
-    <g
-       transform="translate(-27,-1.9999996)"
-       id="toggleOffHover"
-       inkscape:label="#g3906-5">
-      <rect
-         ry="2.5"
-         rx="2.5"
-         y="109.86218"
-         x="172.5"
-         height="15"
-         width="15"
-         id="rect3875-1"
-         style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         ry="2.5"
-         rx="2.0913782"
-         y="109.86218"
-         x="172.5"
-         height="15"
-         width="8.5"
-         id="rect3875-3-2"
-         style="opacity:0.98999999;fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       transform="translate(-7,18)"
-       id="toggleOffDisabled"
-       inkscape:label="#g3906"
-       style="opacity:0.5">
-      <rect
-         ry="2.5"
-         rx="2.5"
-         y="109.86218"
-         x="172.5"
-         height="15"
-         width="15"
-         id="rect3875-86"
-         style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         ry="2.5"
-         rx="2.0913782"
-         y="109.86218"
-         x="172.5"
-         height="15"
-         width="8.5"
-         id="rect3875-3-7"
-         style="opacity:0.98999999;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="toggleOnDisabled"
-       transform="matrix(-1,0,0,1,373,18)"
-       inkscape:label="#g3974"
-       style="opacity:0.5">
-      <g
-         id="g3938-8">
-        <rect
-           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect3875-8-3"
-           width="15"
-           height="15"
-           x="172.5"
-           y="109.86218"
-           rx="2.5"
-           ry="2.5" />
-        <rect
-           style="opacity:0.98999999;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12225008;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect3875-3-9-15"
-           width="8.5"
-           height="15"
-           x="172.5"
-           y="109.86218"
-           rx="2.0913782"
-           ry="2.5" />
-      </g>
-    </g>
-    <g
-       id="drawingStyles"
-       inkscape:label="#g3078">
-      <path
-         id="path4093"
-         d="m 70.21875,163.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 z"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         inkscape:connector-curvature="0" />
-      <path
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 62.36661,176.49782 -0.710223,-10.45042 8.522673,3.39892 -0.177555,11.69331 z"
-         id="path4100"
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0" />
-      <path
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 61.656387,166.0474 8.522673,3.39892 8.548039,-3.37356 -8.522674,-2.56187 z"
-         id="path4120"
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:type="arc"
-         style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
-         id="path4283"
-         sodipodi:cx="74.102585"
-         sodipodi:cy="121.29829"
-         sodipodi:rx="0.4087961"
-         sodipodi:ry="0.4087961"
-         d="m 74.511381,121.29829 a 0.4087961,0.4087961 0 0 1 -0.408695,0.40879 0.4087961,0.4087961 0 0 1 -0.408897,-0.40859 0.4087961,0.4087961 0 0 1 0.408493,-0.409 0.4087961,0.4087961 0 0 1 0.409099,0.40839"
-         transform="matrix(3.6693109,0,0,3.6693109,-210.2748,-279.16373)"
-         sodipodi:start="0"
-         sodipodi:end="6.2821966"
-         sodipodi:open="true" />
-      <path
-         sodipodi:open="true"
-         sodipodi:end="6.2821966"
-         sodipodi:start="0"
-         transform="matrix(3.6693109,0,0,3.6693109,-193.37432,-278.83607)"
-         d="m 74.511381,121.29829 a 0.4087961,0.4087961 0 0 1 -0.408695,0.40879 0.4087961,0.4087961 0 0 1 -0.408897,-0.40859 0.4087961,0.4087961 0 0 1 0.408493,-0.409 0.4087961,0.4087961 0 0 1 0.409099,0.40839"
-         sodipodi:ry="0.4087961"
-         sodipodi:rx="0.4087961"
-         sodipodi:cy="121.29829"
-         sodipodi:cx="74.102585"
-         id="path4285"
-         style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
-         sodipodi:type="arc" />
-      <path
-         sodipodi:open="true"
-         sodipodi:end="6.2821966"
-         sodipodi:start="0"
-         transform="matrix(3.6693109,0,0,3.6693109,-193.66537,-268.50222)"
-         d="m 74.511381,121.29829 a 0.4087961,0.4087961 0 0 1 -0.408695,0.40879 0.4087961,0.4087961 0 0 1 -0.408897,-0.40859 0.4087961,0.4087961 0 0 1 0.408493,-0.409 0.4087961,0.4087961 0 0 1 0.409099,0.40839"
-         sodipodi:ry="0.4087961"
-         sodipodi:rx="0.4087961"
-         sodipodi:cy="121.29829"
-         sodipodi:cx="74.102585"
-         id="path4289"
-         style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
-         sodipodi:type="arc" />
-      <path
-         sodipodi:open="true"
-         sodipodi:end="6.2821966"
-         sodipodi:start="0"
-         transform="matrix(3.6693109,0,0,3.6693109,-201.33686,-281.46941)"
-         d="m 74.511381,121.29829 a 0.4087961,0.4087961 0 0 1 -0.408695,0.40879 0.4087961,0.4087961 0 0 1 -0.408897,-0.40859 0.4087961,0.4087961 0 0 1 0.408493,-0.409 0.4087961,0.4087961 0 0 1 0.409099,0.40839"
-         sodipodi:ry="0.4087961"
-         sodipodi:rx="0.4087961"
-         sodipodi:cy="121.29829"
-         sodipodi:cx="74.102585"
-         id="path4291"
-         style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
-         sodipodi:type="arc" />
-      <path
-         sodipodi:type="arc"
-         style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
-         id="path4297"
-         sodipodi:cx="74.102585"
-         sodipodi:cy="121.29829"
-         sodipodi:rx="0.4087961"
-         sodipodi:ry="0.4087961"
-         d="m 74.511381,121.29829 a 0.4087961,0.4087961 0 0 1 -0.408695,0.40879 0.4087961,0.4087961 0 0 1 -0.408897,-0.40859 0.4087961,0.4087961 0 0 1 0.408493,-0.409 0.4087961,0.4087961 0 0 1 0.409099,0.40839"
-         transform="matrix(3.6693109,0,0,3.6693109,-201.91537,-264.18972)"
-         sodipodi:start="0"
-         sodipodi:end="6.2821966"
-         sodipodi:open="true" />
-      <path
-         sodipodi:open="true"
-         sodipodi:end="6.2821966"
-         sodipodi:start="0"
-         transform="matrix(3.6693109,0,0,3.6693109,-209.66537,-268.68972)"
-         d="m 74.511381,121.29829 a 0.4087961,0.4087961 0 0 1 -0.408695,0.40879 0.4087961,0.4087961 0 0 1 -0.408897,-0.40859 0.4087961,0.4087961 0 0 1 0.408493,-0.409 0.4087961,0.4087961 0 0 1 0.409099,0.40839"
-         sodipodi:ry="0.4087961"
-         sodipodi:rx="0.4087961"
-         sodipodi:cy="121.29829"
-         sodipodi:cx="74.102585"
-         id="path4299"
-         style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
-         sodipodi:type="arc" />
-      <path
-         sodipodi:type="arc"
-         style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
-         id="path4301"
-         sodipodi:cx="74.102585"
-         sodipodi:cy="121.29829"
-         sodipodi:rx="0.4087961"
-         sodipodi:ry="0.4087961"
-         d="m 74.511381,121.29829 a 0.4087961,0.4087961 0 0 1 -0.408695,0.40879 0.4087961,0.4087961 0 0 1 -0.408897,-0.40859 0.4087961,0.4087961 0 0 1 0.408493,-0.409 0.4087961,0.4087961 0 0 1 0.409099,0.40839"
-         transform="matrix(3.6693109,0,0,3.6693109,-201.89622,-275.65482)"
-         sodipodi:start="0"
-         sodipodi:end="6.2821966"
-         sodipodi:open="true" />
-    </g>
-    <path
-       sodipodi:type="star"
-       style="fill:url(#backgroundLighter);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.79977703;stroke-linejoin:round;stroke-opacity:1"
-       id="fsdf"
-       sodipodi:sides="5"
-       sodipodi:cx="298.875"
-       sodipodi:cy="13.687498"
-       sodipodi:r1="5.8454323"
-       sodipodi:r2="2.2924397"
-       sodipodi:arg1="0.94448073"
-       sodipodi:arg2="1.5727992"
-       inkscape:flatsided="false"
-       inkscape:rounded="0"
-       inkscape:randomized="0"
-       d="m 302.30138,18.423424 -3.43097,-2.443491 -3.44073,2.429728 1.26367,-4.018128 -3.37406,-2.521504 4.21197,-0.03985 1.35545,-3.9881025 1.33946,3.9935005 4.21177,0.05672 -3.38412,2.507967 z"
-       transform="matrix(1.2498253,0,0,1.2508721,-71.090254,52.672228)"
-       inkscape:label="#path3064" />
-    <rect
-       inkscape:label="#rect3931"
-       transform="matrix(0,1,1,0,0,0)"
-       y="294.48615"
-       x="61.862183"
-       height="16.013857"
-       width="14.500001"
-       id="bookmarks"
-       style="fill:none;stroke:none" />
     <path
        inkscape:label="#path3910"
        id="success"
@@ -2762,290 +4140,6 @@
         </g>
       </g>
     </g>
-    <g
-       id="exposureOff"
-       transform="translate(53.149048,19.734835)"
-       inkscape:label="#g4113">
-      <path
-         sodipodi:type="arc"
-         style="fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:9.02981281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4111"
-         sodipodi:cx="187.11813"
-         sodipodi:cy="174.54121"
-         sodipodi:rx="33.499184"
-         sodipodi:ry="33.499184"
-         d="m 220.61732,174.54121 a 33.499184,33.499184 0 0 1 -33.49091,33.49919 33.499184,33.499184 0 0 1 -33.50746,-33.48263 33.499184,33.499184 0 0 1 33.47434,-33.51573 33.499184,33.499184 0 0 1 33.52401,33.46605"
-         transform="matrix(0.11101843,0,0,0.11047078,70.600104,153.24998)"
-         sodipodi:start="0"
-         sodipodi:end="6.2821966"
-         sodipodi:open="true" />
-      <g
-         clip-path="url(#clipPath4107)"
-         transform="matrix(1.2656733,0,0,1.2656392,-25.214957,-45.037563)"
-         id="g4082">
-        <path
-           style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           inkscape:transform-center-x="1.2504885"
-           d="m 99.597353,169.77492 v 8.58228 l -7.502966,-4.29114 z"
-           id="path4064"
-           inkscape:connector-curvature="0" />
-        <path
-           transform="matrix(0.13558531,-0.23263436,0.23484065,0.13431151,26.907388,209.48587)"
-           style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2.9274621;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           inkscape:transform-center-x="-1.25049"
-           d="m 268.97293,130.27541 v 31.94918 l -27.6688,-15.97459 6.9172,-3.99365 6.9172,-3.99365 6.9172,-3.99364 z"
-           id="path4066"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccccc" />
-        <path
-           style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           inkscape:transform-center-x="1.2504999"
-           d="m 86.467162,166.55658 7.502966,-4.29115 v 8.58229 l -1.875741,-1.07279 -1.875742,-1.07278 -1.875741,-1.07279 z"
-           id="path4068"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccccc" />
-        <path
-           style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           inkscape:transform-center-x="-1.2505016"
-           d="m 84.591421,174.06607 v -8.58228 l 7.502966,4.29114 -1.875741,1.07278 -1.875742,1.07279 -1.875742,1.07279 z"
-           id="path4070"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccccc" />
-        <path
-           style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           inkscape:transform-center-x="1.2504858"
-           d="m 90.218646,179.42999 -7.502966,-4.29114 7.502966,-4.29114 v 2.14557 2.14557 2.14557 z"
-           id="path4072"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccccc" />
-        <path
-           style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           inkscape:transform-center-x="-1.2504877"
-           d="m 97.721612,177.28442 -7.502966,4.29114 v -8.58228 l 1.875741,1.07278 1.875742,1.07279 1.875741,1.07278 z"
-           id="path4074"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccccc" />
-      </g>
-      <path
-         sodipodi:open="true"
-         sodipodi:end="6.2821966"
-         sodipodi:start="0"
-         transform="matrix(0.27217086,0,0,0.27092245,40.445563,125.24455)"
-         d="m 220.61732,174.54121 a 33.499184,33.499184 0 0 1 -33.49091,33.49919 33.499184,33.499184 0 0 1 -33.50746,-33.48263 33.499184,33.499184 0 0 1 33.47434,-33.51573 33.499184,33.499184 0 0 1 33.52401,33.46605"
-         sodipodi:ry="33.499184"
-         sodipodi:rx="33.499184"
-         sodipodi:cy="174.54121"
-         sodipodi:cx="187.11813"
-         id="path4105"
-         style="fill:none;stroke:#3c3c3c;stroke-width:3.68261814;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         sodipodi:type="arc" />
-    </g>
-    <g
-       id="gammaOff"
-       inkscape:label="#g4093">
-      <path
-         style="fill:#565656;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
-         d="m 204.5,182.86218 v 19 h -19 z"
-         id="path4073"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-      <g
-         id="g4083">
-        <g
-           id="g4052"
-           transform="matrix(1.1875,0,0,1.1875007,-37.15625,-35.474284)"
-           style="fill:#787878;fill-opacity:1;stroke:#424242;stroke-width:0.84210503;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-          <path
-             style="fill:url(#backgroundLighter);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.84210503;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m 203.5,183.86218 v 15.99999 h -16 c 9.30458,-2.50716 13.64016,-5.83089 16,-15.99999 z"
-             id="path4041"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccc" />
-        </g>
-      </g>
-    </g>
-    <g
-       id="expansion"
-       inkscape:label="#g4172"
-       transform="matrix(1.1456995,0,0,1.1456995,-19.856318,-25.721737)">
-      <path
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 100.24995,172.89343 7.75005,3.71875 0.71875,-10.53125 -8.5,-2.5625 z"
-         id="path3304"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         d="m 92.375,176.48718 7.87495,-3.59375 -0.0312,-9.375 -8.5625,2.53125 z"
-         style="fill:#595959;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path3309" />
-      <path
-         transform="translate(0,52.362183)"
-         inkscape:connector-curvature="0"
-         id="path4168"
-         d="m 92.375,124.125 7.625,4.65625 8,-4.53125 -7.75005,-3.71875 z"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3284"
-         d="m 100.20696,167.44141 -4.835088,1.42936 0.405865,5.89387 4.305703,2.6293 4.51746,-2.55872 0.40586,-5.94681 z"
-         style="fill:#595959;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 95.773,174.77064 -0.401051,-5.90116 4.812601,1.91931 -0.10026,6.603 z"
-         id="path3286"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 95.371949,168.86948 4.812601,1.91931 4.82693,-1.90499 -4.8126,-1.44664 z"
-         id="path3288"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:none;stroke:#3c3c3c;stroke-width:0.87282926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 100.21875,163.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 z"
-         id="path3246"
-         inkscape:connector-curvature="0" />
-    </g>
-    <g
-       inkscape:label="#g4113"
-       transform="translate(75.149048,19.734835)"
-       id="exposureOn">
-      <path
-         sodipodi:open="true"
-         sodipodi:end="6.2821966"
-         sodipodi:start="0"
-         transform="matrix(0.11101843,0,0,0.11047078,70.600104,153.24998)"
-         d="m 220.61732,174.54121 a 33.499184,33.499184 0 0 1 -33.49091,33.49919 33.499184,33.499184 0 0 1 -33.50746,-33.48263 33.499184,33.499184 0 0 1 33.47434,-33.51573 33.499184,33.499184 0 0 1 33.52401,33.46605"
-         sodipodi:ry="33.499184"
-         sodipodi:rx="33.499184"
-         sodipodi:cy="174.54121"
-         sodipodi:cx="187.11813"
-         id="path3268"
-         style="fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:9.02981281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         sodipodi:type="arc" />
-      <g
-         id="g3270"
-         transform="matrix(1.2656733,0,0,1.2656392,-25.214957,-45.037563)"
-         clip-path="url(#clipPath4107)">
-        <path
-           inkscape:connector-curvature="0"
-           id="path3272"
-           d="m 99.597353,169.77492 v 8.58228 l -7.502966,-4.29114 z"
-           inkscape:transform-center-x="1.2504885"
-           style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
-        <path
-           sodipodi:nodetypes="ccccccc"
-           inkscape:connector-curvature="0"
-           id="path3274"
-           d="m 268.97293,130.27541 v 31.94918 l -27.6688,-15.97459 6.9172,-3.99365 6.9172,-3.99365 6.9172,-3.99364 z"
-           inkscape:transform-center-x="-1.25049"
-           style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2.9274621;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           transform="matrix(0.13558531,-0.23263436,0.23484065,0.13431151,26.907388,209.48587)" />
-        <path
-           sodipodi:nodetypes="ccccccc"
-           inkscape:connector-curvature="0"
-           id="path3276"
-           d="m 86.467162,166.55658 7.502966,-4.29115 v 8.58229 l -1.875741,-1.07279 -1.875742,-1.07278 -1.875741,-1.07279 z"
-           inkscape:transform-center-x="1.2504999"
-           style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
-        <path
-           sodipodi:nodetypes="ccccccc"
-           inkscape:connector-curvature="0"
-           id="path3278"
-           d="m 84.591421,174.06607 v -8.58228 l 7.502966,4.29114 -1.875741,1.07278 -1.875742,1.07279 -1.875742,1.07279 z"
-           inkscape:transform-center-x="-1.2505016"
-           style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
-        <path
-           sodipodi:nodetypes="ccccccc"
-           inkscape:connector-curvature="0"
-           id="path3280"
-           d="m 90.218646,179.42999 -7.502966,-4.29114 7.502966,-4.29114 v 2.14557 2.14557 2.14557 z"
-           inkscape:transform-center-x="1.2504858"
-           style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
-        <path
-           sodipodi:nodetypes="ccccccc"
-           inkscape:connector-curvature="0"
-           id="path3282"
-           d="m 97.721612,177.28442 -7.502966,4.29114 v -8.58228 l 1.875741,1.07278 1.875742,1.07279 1.875741,1.07278 z"
-           inkscape:transform-center-x="-1.2504877"
-           style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
-      </g>
-      <path
-         sodipodi:type="arc"
-         style="fill:none;stroke:#3c3c3c;stroke-width:3.68261814;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path3285"
-         sodipodi:cx="187.11813"
-         sodipodi:cy="174.54121"
-         sodipodi:rx="33.499184"
-         sodipodi:ry="33.499184"
-         d="m 220.61732,174.54121 a 33.499184,33.499184 0 0 1 -33.49091,33.49919 33.499184,33.499184 0 0 1 -33.50746,-33.48263 33.499184,33.499184 0 0 1 33.47434,-33.51573 33.499184,33.499184 0 0 1 33.52401,33.46605"
-         transform="matrix(0.27217086,0,0,0.27092245,40.445563,125.24455)"
-         sodipodi:start="0"
-         sodipodi:end="6.2821966"
-         sodipodi:open="true" />
-    </g>
-    <g
-       id="clippingOff"
-       transform="translate(25,2.9999999e-6)"
-       inkscape:label="#g4079">
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path3251"
-         d="m 229.5,182.86218 v 19 h -19 z"
-         style="fill:url(#backgroundLighter);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
-      <path
-         style="fill:#565656;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
-         d="m 229.5,182.86218 v 7 h -7 z"
-         id="path4071"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-    </g>
-    <g
-       transform="translate(50,2.9999999e-6)"
-       id="clippingOn"
-       inkscape:label="#g4109">
-      <path
-         style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
-         d="m 229.5,182.86218 v 19 h -19 z"
-         id="path4112"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path4114"
-         d="m 229.5,182.86218 v 7 h -7 z"
-         style="fill:#565656;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
-    </g>
-    <g
-       inkscape:label="#g4093"
-       id="gammaOn"
-       transform="translate(25,2.9999999e-6)">
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path4128"
-         d="m 204.5,182.86218 v 19 h -19 z"
-         style="fill:#565656;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
-      <g
-         id="g4130">
-        <g
-           style="fill:url(#foreground);fill-opacity:1;stroke:#424242;stroke-width:0.84210503;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           transform="matrix(1.1875,0,0,1.1875007,-37.15625,-35.474284)"
-           id="g4132">
-          <path
-             sodipodi:nodetypes="cccc"
-             inkscape:connector-curvature="0"
-             id="path4134"
-             d="m 203.5,183.86218 v 15.99999 h -16 c 9.30458,-2.50716 13.64016,-5.83089 16,-15.99999 z"
-             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.84210503;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        </g>
-      </g>
-    </g>
     <path
        sodipodi:nodetypes="sssss"
        inkscape:connector-curvature="0"
@@ -3075,38 +4169,6 @@
          d="m 410.75,205.36218 v 5 h -5 v 4 h 5 v 5 h 4 v -5 h 5 v -4 h -5 v -5 z"
          style="fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none"
          sodipodi:nodetypes="ccccccccccccc" />
-    </g>
-    <g
-       id="g41043"
-       transform="matrix(0.78835689,0,0,0.73973705,8.5731982,47.195395)"
-       inkscape:label="#g4104"
-       style="stroke-width:1.40838981">
-      <path
-         sodipodi:nodetypes="ccccc"
-         style="fill:#919191;fill-opacity:1;stroke:none;stroke-width:1.40838981"
-         d="m 35.42406,171.23218 9.272,5.662 9.728,-5.51 L 45,167.36218 Z"
-         id="path3275"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="cc"
-         transform="translate(0,52.362183)"
-         inkscape:connector-curvature="0"
-         id="path3292"
-         d="m 41,116.88378 8.895356,4.80676"
-         style="fill:#000000;fill-opacity:0;stroke:#4d4d4d;stroke-width:0.97178906;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         sodipodi:nodetypes="cc"
-         transform="translate(0,52.362183)"
-         inkscape:connector-curvature="0"
-         id="path3296"
-         d="m 39.955806,121.28466 9.066291,-4.38952"
-         style="fill:#000000;fill-opacity:0;stroke:#4d4d4d;stroke-width:0.97178906;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path4102"
-         d="m 35.42406,171.23218 9.272,5.662 9.728,-5.51 L 45,167.36218 Z"
-         style="fill:none;stroke:#3c3c3c;stroke-width:1.40838981;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         sodipodi:nodetypes="ccccc" />
     </g>
     <g
        id="sceneInspectorHistory"
@@ -3187,8 +4249,9 @@
        id="railLine"
        style="fill:#985858;fill-opacity:0;fill-rule:evenodd;stroke:none" />
     <g
-       id="pointerContextMenu"
-       inkscape:label="#g4163">
+       id="g4163"
+       inkscape:label="contextMenu"
+       transform="translate(-227,1204)">
       <g
          style="opacity:0.5"
          id="g4151">
@@ -3325,101 +4388,6 @@
          inkscape:connector-curvature="0" />
     </g>
     <g
-       id="gafferSceneUISelectionTool"
-       inkscape:label="#g4092">
-      <rect
-         transform="translate(0,52.362183)"
-         y="170"
-         x="140"
-         height="25"
-         width="25"
-         id="rect4090"
-         style="opacity:0.35344831;fill:none;fill-opacity:0.99607843;fill-rule:evenodd;stroke:none" />
-      <g
-         inkscape:label="#g4601"
-         id="f">
-        <path
-           inkscape:connector-curvature="0"
-           id="path4542"
-           d="m 150.21875,223.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 z"
-           style="fill:#595959;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#787878;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 142.36661,236.49782 -0.71022,-10.45042 8.52267,3.39892 -0.17756,11.69331 z"
-           id="path4544"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#787878;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 141.65639,226.0474 8.52267,3.39892 8.54804,-3.37356 -8.52267,-2.56187 z"
-           id="path4546"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           sodipodi:nodetypes="ccccccccc"
-           inkscape:connector-curvature="0"
-           id="path3692"
-           d="m 154.55204,244.8176 v -11.87736 l 8.12095,9.01041 h -3.24836 l 1.62418,2.86695 v 2.04782 h -2.03024 l -2.03022,-4.09564 z"
-           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 154.55204,244.8176 v -11.87736 l 8.12095,9.01041 h -3.24836 l 1.62418,2.86695 v 2.04782 h -2.03024 l -2.03022,-4.09564 z"
-           id="path4761"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccccccc" />
-      </g>
-    </g>
-    <g
-       id="gafferSceneUICropWindowTool"
-       inkscape:label="#g4102">
-      <g
-         transform="translate(6,1.0000156)"
-         inkscape:label="#g4134"
-         id="fs">
-        <path
-           sodipodi:open="true"
-           sodipodi:end="6.2821966"
-           sodipodi:start="0"
-           transform="matrix(2.0000002,0,0,1.9999998,-592.50008,154.86219)"
-           d="M 390,40 A 5,5 0 0 1 385.00124,45 5,5 0 0 1 380,40.002472 5,5 0 0 1 384.99629,35.000001 5,5 0 0 1 390,39.995056"
-           sodipodi:ry="5"
-           sodipodi:rx="5"
-           sodipodi:cy="40"
-           sodipodi:cx="385"
-           id="path4107"
-           style="opacity:0.35344831;fill:none;stroke:#3c3c3c;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           sodipodi:type="arc" />
-        <path
-           style="fill:#a7a7a7;fill-opacity:0.99607843;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           d="m 177.5,224.86218 c -5.52285,0 -10,4.47715 -10,10 0,0.69036 0.0855,1.34902 0.21875,2 H 179.5 v -11.8125 c -0.65057,-0.13304 -1.31013,-0.1875 -2,-0.1875 z"
-           id="rect4109"
-           inkscape:connector-curvature="0" />
-        <rect
-           style="fill:none;stroke:#bb2b2b;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="rect3319"
-           width="14"
-           height="14"
-           x="165.5"
-           y="222.86217" />
-      </g>
-      <rect
-         transform="translate(0,52.362183)"
-         y="170"
-         x="170"
-         height="25"
-         width="25"
-         id="rect4100"
-         style="opacity:0.35344831;fill:none;stroke:none" />
-    </g>
-    <g
-       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none"
-       id="g3328"
-       transform="matrix(4.0808246,0,0,4.0808246,-116.25082,-136.58974)" />
-    <g
-       id="g3330"
-       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.22524261;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(4.0808246,0,0,4.0808246,-132.57411,-134.63351)" />
-    <g
        id="gadgetError"
        inkscape:label="#g4105"
        transform="translate(20)">
@@ -3513,257 +4481,6 @@
        d="m 302.30138,18.423424 -3.26391,-3.457531 -2.55071,4.0569 1.36235,-4.555392 -4.78873,-0.180534 4.62626,-1.097861 -2.23802,-4.2374343 3.26391,3.4575313 2.55071,-4.0569002 -1.36235,4.5553922 4.78873,0.180534 -4.62626,1.097861 z"
        transform="matrix(1.1039167,-0.49853331,0.49895085,1.1048412,55.474744,203.81434)"
        inkscape:label="#path3064" />
-    <path
-       sodipodi:open="true"
-       sodipodi:end="6.2821966"
-       sodipodi:start="0"
-       transform="matrix(0.25466537,0,0,0.25466542,-27.652509,127.91257)"
-       d="m 220.61732,174.54121 a 33.499184,33.499184 0 0 1 -33.49091,33.49919 33.499184,33.499184 0 0 1 -33.50746,-33.48263 33.499184,33.499184 0 0 1 33.47434,-33.51573 33.499184,33.499184 0 0 1 33.52401,33.46605"
-       sodipodi:ry="33.499184"
-       sodipodi:rx="33.499184"
-       sodipodi:cy="174.54121"
-       sodipodi:cx="187.11813"
-       id="shading"
-       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:3.9267211;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       sodipodi:type="arc"
-       inkscape:label="#path3352" />
-    <path
-       style="fill:#aaaaaa;fill-opacity:1;stroke:none"
-       d="m 17.444981,168.57203 c -2.092886,1.37871 -2.641656,4.33859 -3.535981,3.1401 -0.894324,-1.19849 0.405111,-3.97228 1.59811,-4.87074 1.192994,-0.89844 4.11797,-1.89376 5.012295,-0.69526 0.894325,1.19848 -1.122142,0.79291 -3.074424,2.4259 z"
-       id="path3163"
-       sodipodi:nodetypes="csssc"
-       inkscape:connector-curvature="0" />
-    <g
-       id="addObjects"
-       inkscape:label="#g4133"
-       transform="translate(140)">
-      <g
-         transform="translate(0,46.999993)"
-         id="g3952">
-        <path
-           inkscape:label="#rect3638"
-           sodipodi:nodetypes="ccccccccccccc"
-           id="path3948"
-           d="m 430,177.36219 v 5 h -5 v 5.99999 h 5 v 5 h 6 v -5 h 5 v -5.99999 h -5 v -5 z"
-           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccccccccccc"
-           style="fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 431,178.36219 v 5 h -5 v 3.99999 h 5 v 5 h 4 v -5 h 5 v -3.99999 h -5 v -5 z"
-           id="path3950"
-           inkscape:connector-curvature="0" />
-      </g>
-      <g
-         id="g3249"
-         inkscape:label="#g4081"
-         transform="translate(65,143)">
-        <path
-           sodipodi:nodetypes="cccc"
-           inkscape:connector-curvature="0"
-           id="path3252"
-           d="m 392.52471,75.862183 5.99436,12.546318 h -11.98873 z"
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
-        <path
-           sodipodi:open="true"
-           sodipodi:end="6.2821966"
-           sodipodi:start="0"
-           transform="matrix(1.2149049,0,0,1.2149049,-83.343223,40.597872)"
-           d="M 390,40 A 5,5 0 0 1 385.00124,45 5,5 0 0 1 380,40.002472 5,5 0 0 1 384.99629,35.000001 5,5 0 0 1 390,39.995056"
-           sodipodi:ry="5"
-           sodipodi:rx="5"
-           sodipodi:cy="40"
-           sodipodi:cx="385"
-           id="path3254"
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           sodipodi:type="arc" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           id="path3256"
-           d="m 387,87.862183 6,2.5 v 9.999997 l -6,-3.499997 z"
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           id="path3258"
-           d="M 392.93011,90.61057 401,88.862183 v 9 l -8,2.499997 z"
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
-        <path
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           d="m 387,87.862183 5.93008,2.748387 8.06992,-1.748387 -6.0625,-2.4375 z"
-           id="path3261"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-      </g>
-      <path
-         style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         d="m 459.5,249.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 465 l -2.5,-5 z"
-         id="path3263"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccc" />
-    </g>
-    <g
-       id="removeObjects"
-       inkscape:label="#g4146"
-       transform="translate(140)">
-      <g
-         transform="translate(340.25,180)"
-         id="g3989">
-        <path
-           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 84.75,89.362182 v 5.999998 h 16 v -5.999998 z"
-           id="path3985"
-           sodipodi:nodetypes="ccccc"
-           inkscape:label="#rect3638"
-           inkscape:connector-curvature="0" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path3987"
-           d="m 85.75,90.362182 v 3.999998 h 14 v -3.999998 z"
-           style="fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           sodipodi:nodetypes="ccccc" />
-      </g>
-      <g
-         transform="translate(65,183)"
-         inkscape:label="#g4081"
-         id="g4092">
-        <path
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
-           d="m 392.52471,75.862183 5.99436,12.546318 h -11.98873 z"
-           id="path4094"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cccc" />
-        <path
-           sodipodi:type="arc"
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path4096"
-           sodipodi:cx="385"
-           sodipodi:cy="40"
-           sodipodi:rx="5"
-           sodipodi:ry="5"
-           d="M 390,40 A 5,5 0 0 1 385.00124,45 5,5 0 0 1 380,40.002472 5,5 0 0 1 384.99629,35.000001 5,5 0 0 1 390,39.995056"
-           transform="matrix(1.2149049,0,0,1.2149049,-83.343223,40.597872)"
-           sodipodi:start="0"
-           sodipodi:end="6.2821966"
-           sodipodi:open="true" />
-        <path
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           d="m 387,87.862183 6,2.5 v 9.999997 l -6,-3.499997 z"
-           id="path4099"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           d="M 392.93011,90.61057 401,88.862183 v 9 l -8,2.499997 z"
-           id="path4103"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           id="path4106"
-           d="m 387,87.862183 5.93008,2.748387 8.06992,-1.748387 -6.0625,-2.4375 z"
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
-      </g>
-      <path
-         style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         d="m 459.5,289.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 465 l -2.5,-5 z"
-         id="path4108"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccc" />
-    </g>
-    <g
-       id="replaceObjects"
-       inkscape:label="#g4158"
-       transform="translate(140)">
-      <g
-         transform="translate(0,21.000001)"
-         id="g4125">
-        <g
-           id="g4011"
-           transform="translate(340.25,197)">
-          <path
-             inkscape:connector-curvature="0"
-             inkscape:label="#rect3638"
-             sodipodi:nodetypes="ccccc"
-             id="path4013"
-             d="m 84.75,89.362182 v 5.000001 h 16 v -5.000001 z"
-             style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-          <path
-             sodipodi:nodetypes="ccccc"
-             style="fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:none"
-             d="m 85.75,90.362182 v 3.000001 h 14 v -3.000001 z"
-             id="path4015"
-             inkscape:connector-curvature="0" />
-        </g>
-        <g
-           transform="translate(340.25,203)"
-           id="g4017">
-          <path
-             style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
-             d="m 84.75,89.362182 v 5.000001 h 16 v -5.000001 z"
-             id="path4019"
-             sodipodi:nodetypes="ccccc"
-             inkscape:label="#rect3638"
-             inkscape:connector-curvature="0" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4021"
-             d="m 85.75,90.362182 v 3.000001 h 14 v -3.000001 z"
-             style="fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:none"
-             sodipodi:nodetypes="ccccc" />
-        </g>
-      </g>
-      <g
-         id="g4110"
-         inkscape:label="#g4081"
-         transform="translate(65,223)">
-        <path
-           sodipodi:nodetypes="cccc"
-           inkscape:connector-curvature="0"
-           id="path4113"
-           d="m 392.52471,75.862183 5.99436,12.546318 h -11.98873 z"
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
-        <path
-           sodipodi:open="true"
-           sodipodi:end="6.2821966"
-           sodipodi:start="0"
-           transform="matrix(1.2149049,0,0,1.2149049,-83.343223,40.597872)"
-           d="M 390,40 A 5,5 0 0 1 385.00124,45 5,5 0 0 1 380,40.002472 5,5 0 0 1 384.99629,35.000001 5,5 0 0 1 390,39.995056"
-           sodipodi:ry="5"
-           sodipodi:rx="5"
-           sodipodi:cy="40"
-           sodipodi:cx="385"
-           id="path4115"
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           sodipodi:type="arc" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           id="path4117"
-           d="m 387,87.862183 6,2.5 v 9.999997 l -6,-3.499997 z"
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           id="path4119"
-           d="M 392.93011,90.61057 401,88.862183 v 9 l -8,2.499997 z"
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
-        <path
-           style="fill:#a4a4a4;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
-           d="m 387,87.862183 5.93008,2.748387 8.06992,-1.748387 -6.0625,-2.4375 z"
-           id="path4121"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-      </g>
-      <path
-         sodipodi:nodetypes="ccccccccc"
-         inkscape:connector-curvature="0"
-         id="path4123"
-         d="m 459.5,329.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 465 l -2.5,-5 z"
-         style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
-    </g>
     <path
        inkscape:connector-curvature="0"
        style="fill:url(#backgroundLighter);fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686"
@@ -3864,166 +4581,6 @@
          inkscape:connector-curvature="0" />
     </g>
     <g
-       id="soloChannel-1"
-       inkscape:label="#g4322">
-      <rect
-         style="fill:#823631;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4860"
-         width="6"
-         height="18.969242"
-         x="290.5"
-         y="182.89151" />
-      <rect
-         y="182.89154"
-         x="296.5"
-         height="18.969244"
-         width="6"
-         id="rect4862"
-         style="fill:#449645;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         style="fill:#4a5ebd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4864"
-         width="6"
-         height="18.969244"
-         x="302.5"
-         y="182.89154" />
-      <rect
-         y="182.89151"
-         x="308.5"
-         height="18.969242"
-         width="6"
-         id="rect4866"
-         style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="soloChannel0"
-       inkscape:label="#g4328">
-      <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4254"
-         width="6"
-         height="18.995764"
-         x="296.5"
-         y="207.86432" />
-      <rect
-         y="207.86432"
-         x="302.5"
-         height="18.995764"
-         width="6"
-         id="rect4256"
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4258"
-         width="6"
-         height="18.995762"
-         x="308.5"
-         y="207.8643" />
-      <rect
-         y="207.89294"
-         x="290.5"
-         height="18.969242"
-         width="6"
-         id="rect4314"
-         style="fill:#823631;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="soloChannel1"
-       inkscape:label="#g4334">
-      <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4290"
-         width="6"
-         height="18.995762"
-         x="290.5"
-         y="232.86218" />
-      <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4294"
-         width="6"
-         height="18.995764"
-         x="302.5"
-         y="232.8622" />
-      <rect
-         y="232.86218"
-         x="308.5"
-         height="18.995762"
-         width="6"
-         id="rect4296"
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         y="232.86218"
-         x="296.5"
-         height="18.969244"
-         width="6"
-         id="rect4316"
-         style="fill:#449645;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="soloChannel2"
-       inkscape:label="#g4340">
-      <rect
-         y="257.86218"
-         x="290.5"
-         height="18.995762"
-         width="6"
-         id="rect4298"
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4300"
-         width="6"
-         height="18.995764"
-         x="296.5"
-         y="257.86218" />
-      <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4304"
-         width="6"
-         height="18.995762"
-         x="308.5"
-         y="257.86218" />
-      <rect
-         style="fill:#4a5ebd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4318"
-         width="6"
-         height="18.969244"
-         x="302.5"
-         y="257.86218" />
-    </g>
-    <g
-       id="soloChannel3"
-       inkscape:label="#g4346">
-      <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4306"
-         width="6"
-         height="18.995762"
-         x="290.5"
-         y="282.86218" />
-      <rect
-         y="282.86218"
-         x="296.5"
-         height="18.995764"
-         width="6"
-         id="rect4308"
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         style="fill:#000000;fill-opacity:0;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4310"
-         width="6"
-         height="18.995764"
-         x="302.5"
-         y="282.86218" />
-      <rect
-         y="282.89294"
-         x="308.5"
-         height="18.969242"
-         width="6"
-         id="rect4320"
-         style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
        id="g4065"
        transform="matrix(1.7499936,0,0,1.7499936,-5.7499423,-348.76863)">
       <path
@@ -4064,206 +4621,6 @@
          d="m 14.714307,467.50503 v 4.57145 h -4.571446 v 4.57144 h 4.571446 v 4.57145 h 4.571445 v -4.57145 h 4.571445 v -4.57144 h -4.571445 v -4.57145 z"
          id="path3264"
          inkscape:connector-curvature="0" />
-    </g>
-    <g
-       id="gafferSceneUIRotateTool"
-       inkscape:label="#g3299">
-      <g
-         style="opacity:0.66379311"
-         id="g4136"
-         transform="translate(120.59619,-75.596198)">
-        <g
-           style="opacity:0.71551723"
-           id="g5216"
-           transform="matrix(0.78155202,0,0,0.78155202,-82.618747,215.66916)">
-          <path
-             inkscape:transform-center-y="-7.5"
-             inkscape:transform-center-x="7.5"
-             sodipodi:nodetypes="ccccc"
-             inkscape:connector-curvature="0"
-             d="m 149.5,152.86218 h -15 v 15 h 15 z"
-             style="opacity:0.60344825;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.27950537;stroke-opacity:1"
-             id="path5125" />
-        </g>
-        <path
-           id="path5137"
-           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-           d="M 39.268288,336.15243 28.55854,331.38414 23.790252,342.09389 34.5,346.86218 Z"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           inkscape:transform-center-x="3.801065"
-           inkscape:transform-center-y="-9.902115" />
-      </g>
-      <path
-         inkscape:transform-center-y="-10.592065"
-         inkscape:transform-center-x="-0.555105"
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         d="m 163.80828,263.42159 -7.8444,-8.71209 -8.71209,7.8444 7.8444,8.7121 z"
-         style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-         id="path5133" />
-      <g
-         transform="translate(122.66066,-76.595908)"
-         id="g4141">
-        <path
-           sodipodi:nodetypes="csc"
-           inkscape:connector-curvature="0"
-           id="path5184"
-           d="m 18.919829,338.41825 c 1.609786,-3.50691 4.785185,-6.213 8.827138,-7.1893 1.068186,-0.25801 2.137435,-0.37646 3.18856,-0.36706"
-           style="fill:none;stroke:#3c3c3c;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        <path
-           inkscape:label="#collapsibleArrowRightHover"
-           transform="matrix(-0.55936791,-0.00554531,-0.00567669,0.55589671,99.812034,10.284701)"
-           d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
-           inkscape:randomized="0"
-           inkscape:rounded="0"
-           inkscape:flatsided="true"
-           sodipodi:arg2="2.0943952"
-           sodipodi:arg1="1.0471976"
-           sodipodi:r2="5.7786927"
-           sodipodi:r1="7.1428571"
-           sodipodi:cy="578.07648"
-           sodipodi:cx="117.14286"
-           sodipodi:sides="3"
-           id="path5182"
-           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.7932142;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           sodipodi:type="star" />
-        <path
-           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           d="m 18.919829,338.41825 c 1.609786,-3.50691 4.785185,-6.213 8.827138,-7.1893 1.068186,-0.25801 2.137435,-0.37646 3.18856,-0.36706"
-           id="path5169"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csc" />
-      </g>
-    </g>
-    <g
-       transform="translate(-1.40381,-0.596187)"
-       id="gafferSceneUITranslateTool"
-       inkscape:label="#g3356">
-      <g
-         transform="translate(4.5509813,97.999997)"
-         style="opacity:0.70258622"
-         id="g5242">
-        <path
-           inkscape:transform-center-y="-5.201905"
-           inkscape:transform-center-x="5.201905"
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           d="m 183.35283,163.45837 h -10.40381 v 10.40381 h 10.40381 z"
-           style="opacity:0.625;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-           id="path5151" />
-        <path
-           id="path5149"
-           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-           d="m 187.35283,159.45837 h -10.40381 v 10.40381 h 10.40381 z"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           inkscape:transform-center-x="5.201905"
-           inkscape:transform-center-y="-5.201905" />
-      </g>
-      <path
-         id="path5147"
-         style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-         d="M 195.90381,253.45837 H 185.5 v 10.40381 h 10.40381 z"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         inkscape:transform-center-x="5.201905"
-         inkscape:transform-center-y="-5.201905" />
-      <g
-         transform="translate(-0.91160869,98.530327)"
-         id="g5246">
-        <path
-           style="fill:none;stroke:#3c3c3c;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 185,120 10,-10"
-           id="path5238"
-           inkscape:connector-curvature="0"
-           transform="translate(0,52.362183)" />
-        <path
-           sodipodi:type="star"
-           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.40149021;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path5232"
-           sodipodi:sides="3"
-           sodipodi:cx="117.14286"
-           sodipodi:cy="578.07648"
-           sodipodi:r1="7.1428571"
-           sodipodi:r2="5.7786927"
-           sodipodi:arg1="1.0471976"
-           sodipodi:arg2="2.0943952"
-           inkscape:flatsided="true"
-           inkscape:rounded="0"
-           inkscape:randomized="0"
-           d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
-           transform="matrix(-0.50398184,0.50823176,0.50493003,0.50100644,-36.358749,-188.05646)"
-           inkscape:label="#collapsibleArrowRightHover" />
-        <path
-           transform="translate(0,52.362183)"
-           inkscape:connector-curvature="0"
-           id="path5240"
-           d="m 185,120 10,-10"
-           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-    </g>
-    <g
-       id="gafferSceneUIScaleTool"
-       inkscape:label="#g3402">
-      <g
-         transform="translate(0.09619,94.500002)"
-         style="opacity:0.70689655"
-         id="g5259">
-        <path
-           id="path5153"
-           style="opacity:0.56896548;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-           d="M 216.27881,171.48718 H 211 v 5.27881 h 5.27881 z"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           inkscape:transform-center-x="2.639405"
-           inkscape:transform-center-y="-2.639405" />
-        <path
-           inkscape:transform-center-y="-4.99999"
-           inkscape:transform-center-x="5"
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           d="m 223,164.766 h -10 v 10 h 10 z"
-           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
-           id="path5155" />
-      </g>
-      <path
-         inkscape:transform-center-y="-7.0000182"
-         inkscape:transform-center-x="7.0000102"
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         d="m 230.09619,252.26599 h -14 V 266.266 h 14 z"
-         style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path5157" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:4;marker:none;enable-background:accumulate"
-         d="m 225.12177,260.4067 -8.59375,11.40625 11.40625,-8.59375 z"
-         id="path5253"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-      <path
-         sodipodi:type="star"
-         style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.40149021;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path5255"
-         sodipodi:sides="3"
-         sodipodi:cx="117.14286"
-         sodipodi:cy="578.07648"
-         sodipodi:r1="7.1428571"
-         sodipodi:r2="5.7786927"
-         sodipodi:arg1="1.0471976"
-         sodipodi:arg2="2.0943952"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
-         transform="matrix(-0.50398184,0.50823176,0.50493003,0.50100644,-4.83073,-88.605708)"
-         inkscape:label="#collapsibleArrowRightHover" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="m 225.80927,261.0942 -9.28125,10.71875 10.71875,-9.28125 z"
-         id="path5257"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
     </g>
     <text
        xml:space="preserve"
@@ -4410,239 +4767,330 @@
          style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
-       id="gafferSceneUICameraTool"
-       inkscape:label="#g5318">
+       id="g3307"
+       inkscape:label="tools">
       <g
-         transform="matrix(1.1796873,0,0,1.1815592,-43.1523,-43.361813)"
-         id="g5269">
+         transform="translate(-100.54881,1603.9968)"
+         inkscape:label="selection"
+         id="g435">
         <path
            inkscape:connector-curvature="0"
-           style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.84701049;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.5,0.5 h -1.5 c -1.662,0 -3,1.338 -3,3 v 7 c 0,1.662 1.338,3 3,3 h 13 c 1.662,0 3,-1.338 3,-3 v -7 c 0,-1.662 -1.338,-3 -3,-3 H 255 l -0.5,-0.5 c -0.78347,-0.78348 -0.892,-2 -2,-2 z"
-           transform="translate(0,52.362183)"
-           id="rect5222" />
-        <ellipse
-           style="fill:#2a2a2a;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.84701049;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path5224"
-           cx="250.00002"
-           cy="258.86218"
-           rx="4.0000005"
-           ry="4" />
-        <circle
-           style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path5230"
-           cx="249"
-           cy="257.36218"
-           r="1" />
-        <circle
-           r="1"
-           cy="255.86218"
-           cx="256.5"
-           id="circle5232"
-           style="fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-      <g
-         id="g5251"
-         transform="matrix(0.56897805,-0.82235271,-0.82235271,-0.56897805,516.80551,481.49079)">
-        <path
-           style="fill:none;stroke:#3c3c3c;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           d="m 18.919829,338.41825 c 1.609786,-3.50691 4.785185,-6.213 8.827138,-7.1893 1.068186,-0.25801 2.137435,-0.37646 3.18856,-0.36706"
-           id="path5254"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csc" />
-        <path
-           sodipodi:type="star"
-           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.7932142;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path5256"
-           sodipodi:sides="3"
-           sodipodi:cx="117.14286"
-           sodipodi:cy="578.07648"
-           sodipodi:r1="7.1428571"
-           sodipodi:r2="5.7786927"
-           sodipodi:arg1="1.0471976"
-           sodipodi:arg2="2.0943952"
-           inkscape:flatsided="true"
-           inkscape:rounded="0"
-           inkscape:randomized="0"
-           d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
-           transform="matrix(-0.55936791,-0.00554531,-0.00567669,0.55589671,99.812034,10.284701)"
-           inkscape:label="#collapsibleArrowRightHover" />
-        <path
-           sodipodi:nodetypes="csc"
-           inkscape:connector-curvature="0"
-           id="path5258"
-           d="m 18.919829,338.41825 c 1.609786,-3.50691 4.785185,-6.213 8.827138,-7.1893 1.068186,-0.25801 2.137435,-0.37646 3.18856,-0.36706"
-           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      </g>
-    </g>
-    <g
-       id="cameraOff"
-       transform="matrix(1.15625,0,0,1.15625,-167.57812,-126.61909)"
-       inkscape:label="#g5275">
-      <path
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486483;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.5,0.5 h -1.5 c -1.662,0 -3,1.338 -3,3 v 7 c 0,1.662 1.338,3 3,3 h 13 c 1.662,0 3,-1.338 3,-3 v -7 c 0,-1.662 -1.338,-3 -3,-3 H 255 l -0.5,-0.5 c -0.78347,-0.78348 -0.892,-2 -2,-2 z"
-         transform="translate(0,52.362183)"
-         id="path5277"
-         inkscape:connector-curvature="0" />
-      <ellipse
-         style="fill:#494949;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486489;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="ellipse5279"
-         cx="250.00002"
-         cy="258.86218"
-         rx="4.0000005"
-         ry="4" />
-      <circle
-         style="fill:#9b9b9b;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="circle5281"
-         cx="249"
-         cy="257.36218"
-         r="1" />
-      <circle
-         r="1"
-         cy="255.86218"
-         cx="256.5"
-         id="circle5283"
-         style="fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       inkscape:label="#g5275"
-       transform="matrix(1.15625,0,0,1.15625,-141.57812,-126.61909)"
-       id="cameraOn">
-      <path
-         inkscape:connector-curvature="0"
-         id="path4695"
-         transform="translate(0,52.362183)"
-         d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.5,0.5 h -1.5 c -1.662,0 -3,1.338 -3,3 v 7 c 0,1.662 1.338,3 3,3 h 13 c 1.662,0 3,-1.338 3,-3 v -7 c 0,-1.662 -1.338,-3 -3,-3 H 255 l -0.5,-0.5 c -0.78347,-0.78348 -0.892,-2 -2,-2 z"
-         style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486483;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         sodipodi:nodetypes="sccssssssssccss" />
-      <ellipse
-         ry="4"
-         rx="4.0000005"
-         cy="258.86218"
-         cx="250.00002"
-         id="ellipse4697"
-         style="fill:#494949;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486489;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <circle
-         r="1"
-         cy="257.36218"
-         cx="249"
-         id="circle4699"
-         style="fill:#9b9b9b;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <circle
-         style="fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="circle4701"
-         cx="256.5"
-         cy="255.86218"
-         r="1" />
-    </g>
-    <g
-       id="selectionMaskOff"
-       inkscape:label="#g4793">
-      <g
-         transform="translate(188)"
-         id="g4784">
+           id="path4542"
+           d="m 150.21875,223.51843 -8.5625,2.53125 0.71875,10.4375 7.67381,4.8782 7.95119,-4.7532 0.71875,-10.53125 z"
+           style="fill:#595959;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           sodipodi:nodetypes="ccccccc" />
         <path
            inkscape:connector-curvature="0"
-           id="path4741"
-           d="m -9.78125,163.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 z"
-           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m -17.63339,176.49782 -0.710223,-10.45042 8.522673,3.39892 -0.177555,11.69331 z"
-           id="path4743"
+           style="fill:#787878;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 142.36661,236.49782 -0.71022,-10.45042 8.39242,3.31798 v 12 z"
+           id="path4544"
            sodipodi:nodetypes="ccccc" />
         <path
            inkscape:connector-curvature="0"
-           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m -18.343613,166.0474 8.522673,3.39892 8.548039,-3.37356 -8.522674,-2.56187 z"
-           id="path4745"
+           style="fill:#787878;fill-opacity:1;stroke:#779bbc;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 141.65639,226.0474 8.39242,3.31798 8.67829,-3.29262 -8.52267,-2.56187 z"
+           id="path4546"
            sodipodi:nodetypes="ccccc" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path3692"
+           d="m 154.55204,244.8176 -0.003,-11.95222 8,9 h -3 l 1.5,2.95222 v 2.04782 h -2.03024 l -2.03022,-4.09564 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 154.54881,244.86538 v -11.87111 -0.12889 l 8,9 h -3 l 1.5,3 v 2.00004 l -2,-4e-5 -2.06046,-4.0956 z"
+           id="path4761"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccc" />
       </g>
-      <path
-         sodipodi:nodetypes="ccccccccc"
-         inkscape:connector-curvature="0"
-         id="path4718"
-         d="m 182.25033,179.48925 v -8.31457 l 5.78532,6.3076 h -2.31413 l 1.15706,2.00697 v 1.43354 h -1.44633 l -1.44633,-2.8671 z"
-         style="fill:#000000;fill-opacity:1;stroke:#f4f4f4;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
       <g
-         transform="matrix(0.57849085,0,0,0.57849085,192.70448,76.652237)"
-         id="g4789">
-        <path
-           inkscape:label="#path3352"
-           sodipodi:type="arc"
-           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.72863579;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path4780"
-           sodipodi:cx="-40"
-           sodipodi:cy="172.36218"
-           sodipodi:rx="8.5310822"
-           sodipodi:ry="8.5310841"
-           d="m -31.468918,172.36218 a 8.5310822,8.5310841 0 0 1 -8.528973,8.53109 8.5310822,8.5310841 0 0 1 -8.53319,-8.52687 8.5310822,8.5310841 0 0 1 8.524755,-8.5353 8.5310822,8.5310841 0 0 1 8.537404,8.52265"
-           sodipodi:start="0"
-           sodipodi:end="6.2821966"
-           sodipodi:open="true" />
-        <path
-           sodipodi:nodetypes="csssc"
-           id="path4782"
-           d="m -42.555019,168.57203 c -2.092886,1.37871 -2.641656,4.33859 -3.535981,3.1401 -0.894324,-1.19849 0.405111,-3.97228 1.59811,-4.87074 1.192994,-0.89844 4.11797,-1.89376 5.012295,-0.69526 0.894325,1.19848 -1.122142,0.79291 -3.074424,2.4259 z"
-           style="fill:#aaaaaa;fill-opacity:1;stroke:none"
-           inkscape:connector-curvature="0" />
-      </g>
-    </g>
-    <g
-       inkscape:label="#g4793"
-       id="selectionMaskOn"
-       transform="translate(28)">
-      <g
-         id="g4805"
-         transform="translate(188)">
-        <path
-           style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m -9.78125,163.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 z"
-           id="path4807"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path4809"
-           d="m -17.63339,176.49782 -0.710223,-10.45042 8.522673,3.39892 -0.177555,11.69331 z"
-           style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path4811"
-           d="m -18.343613,166.0474 8.522673,3.39892 8.548039,-3.37356 -8.522674,-2.56187 z"
-           style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           inkscape:connector-curvature="0" />
-      </g>
-      <path
-         style="fill:#000000;fill-opacity:1;stroke:#f4f4f4;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         d="m 182.25033,179.48925 v -8.31457 l 5.78532,6.3076 h -2.31413 l 1.15706,2.00697 v 1.43354 h -1.44633 l -1.44633,-2.8671 z"
-         id="path4813"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccc" />
-      <g
-         id="g4815"
-         transform="matrix(0.57849085,0,0,0.57849085,192.70448,76.652237)">
+         transform="translate(14.638962,1604.4133)"
+         inkscape:label="cropWindow"
+         id="cropWindow">
         <path
            sodipodi:open="true"
            sodipodi:end="6.2821966"
            sodipodi:start="0"
-           d="m -31.468918,172.36218 a 8.5310822,8.5310841 0 0 1 -8.528973,8.53109 8.5310822,8.5310841 0 0 1 -8.53319,-8.52687 8.5310822,8.5310841 0 0 1 8.524755,-8.5353 8.5310822,8.5310841 0 0 1 8.537404,8.52265"
-           sodipodi:ry="8.5310841"
-           sodipodi:rx="8.5310822"
-           sodipodi:cy="172.36218"
-           sodipodi:cx="-40"
-           id="path4817"
-           style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.72863579;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           sodipodi:type="arc"
-           inkscape:label="#path3352" />
+           d="m 192.86104,235.44888 a 10.000001,9.999999 0 0 1 -9.99753,10 10.000001,9.999999 0 0 1 -10.00247,-9.99505 10.000001,9.999999 0 0 1 9.99258,-10.00494 10.000001,9.999999 0 0 1 10.00741,9.99011"
+           sodipodi:ry="9.999999"
+           sodipodi:rx="10.000001"
+           sodipodi:cy="235.44888"
+           sodipodi:cx="182.86104"
+           id="path4107"
+           style="opacity:0.35344831;fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           sodipodi:type="arc" />
         <path
+           style="fill:#a7a7a7;fill-opacity:0.99607843;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 182.86104,225.44889 c -5.52285,0 -10,4.47715 -10,10 0,0.69036 0.0855,1.34902 0.21875,2 h 11.78125 v -11.8125 c -0.65057,-0.13304 -1.31013,-0.1875 -2,-0.1875 z"
+           id="rect4109"
+           inkscape:connector-curvature="0" />
+        <rect
+           style="fill:none;stroke:#bb2b2b;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect3319"
+           width="13.999997"
+           height="14"
+           x="170.86104"
+           y="223.44888" />
+      </g>
+      <g
+         transform="translate(-71.632318,1577.5533)"
+         inkscape:label="rotate"
+         id="g3299">
+        <g
+           transform="translate(120.59619,-75.596198)"
+           id="g4136"
+           style="opacity:0.66379311">
+          <g
+             transform="matrix(0.78155202,0,0,0.78155202,-82.582619,215.71206)"
+             id="g5216"
+             style="opacity:0.71551723">
+            <path
+               id="path5125"
+               style="opacity:0.60344825;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.27950537;stroke-opacity:1"
+               d="M 149.85406,152.50811 H 134.5 v 15.35407 l 15.35406,-1e-5 z"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="ccccc"
+               inkscape:transform-center-x="7.5"
+               inkscape:transform-center-y="-7.5" />
+          </g>
+          <path
+             inkscape:transform-center-y="-9.902115"
+             inkscape:transform-center-x="3.801065"
+             sodipodi:nodetypes="ccccc"
+             inkscape:connector-curvature="0"
+             d="m 39.304416,336.19533 -10.709748,-4.76829 -4.768288,10.70975 10.709748,4.76829 z"
+             style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+             id="path5137" />
+        </g>
+        <path
+           id="path5133"
+           style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+           d="m 163.84441,263.46447 -7.8444,-8.71209 -8.71209,7.8444 7.8444,8.7121 z"
            inkscape:connector-curvature="0"
-           style="fill:#efefef;fill-opacity:1;stroke:none"
-           d="m -42.555019,168.57203 c -2.092886,1.37871 -2.641656,4.33859 -3.535981,3.1401 -0.894324,-1.19849 0.405111,-3.97228 1.59811,-4.87074 1.192994,-0.89844 4.11797,-1.89376 5.012295,-0.69526 0.894325,1.19848 -1.122142,0.79291 -3.074424,2.4259 z"
-           id="path4819"
-           sodipodi:nodetypes="csssc" />
+           sodipodi:nodetypes="ccccc"
+           inkscape:transform-center-x="-0.555105"
+           inkscape:transform-center-y="-10.592065" />
+        <g
+           id="g4141"
+           transform="translate(122.66066,-76.595908)">
+          <path
+             style="fill:none;stroke:#3c3c3c;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m 19.61327,339.93784 c 2.74451,-5.28645 4.900807,-6.89433 8.827138,-7.6893 1.077049,-0.21807 2.137435,-0.37646 3.18856,-0.36706"
+             id="path5184"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="csc" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path5182"
+             d="m 29.50319,336.1243 6.524435,-4.49995 -6.5,-4 z"
+             style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="ccc"
+             inkscape:connector-curvature="0"
+             id="path5169"
+             d="m 19.975795,339.13781 c 1.171242,-2.55154 3.171268,-4.67916 5.730832,-6.02505 2.021493,-1.01124 3.796563,-1.48846 6.296563,-1.48846"
+             style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        </g>
+      </g>
+      <g
+         inkscape:label="move"
+         id="52345"
+         transform="translate(-78.90381,1575.9038)">
+        <g
+           id="g5242"
+           style="opacity:0.70258622"
+           transform="translate(4.5509813,97)">
+          <path
+             id="path5151"
+             style="opacity:0.625;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+             d="m 183.35283,163.95839 h -10.5 v 10 h 10.5 z"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccc"
+             inkscape:transform-center-x="5.201905"
+             inkscape:transform-center-y="-5.201905" />
+          <path
+             inkscape:transform-center-y="-5.201905"
+             inkscape:transform-center-x="5.201905"
+             sodipodi:nodetypes="ccccc"
+             inkscape:connector-curvature="0"
+             d="m 186.85283,159.95839 h -10 v 10 h 10 z"
+             style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+             id="path5149" />
+        </g>
+        <path
+           inkscape:transform-center-y="-5.201905"
+           inkscape:transform-center-x="5.201905"
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           d="m 195.40381,252.95838 h -10 v 10 h 10 z"
+           style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+           id="path5147" />
+        <g
+           id="g5246"
+           transform="translate(-0.91160869,98.530327)">
+          <path
+             inkscape:connector-curvature="0"
+             id="path5238"
+             d="m 185.224,172.32117 10,-10"
+             style="fill:none;stroke:#3c3c3c;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:label="#collapsibleArrowRightHover"
+             transform="matrix(-0.50398184,0.50823176,0.50493003,0.50100644,-36.13475,-188.09748)"
+             d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+             inkscape:randomized="0"
+             inkscape:rounded="0"
+             inkscape:flatsided="true"
+             sodipodi:arg2="2.0943952"
+             sodipodi:arg1="1.0471976"
+             sodipodi:r2="5.7786927"
+             sodipodi:r1="7.1428571"
+             sodipodi:cy="578.07648"
+             sodipodi:cx="117.14286"
+             sodipodi:sides="3"
+             id="path5232"
+             style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.40149021;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:type="star" />
+          <path
+             style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 185.224,172.32117 10,-10"
+             id="path5240"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         transform="translate(-82.119439,1576.4424)"
+         inkscape:label="scale"
+         id="g3402">
+        <g
+           id="g5259"
+           style="opacity:0.70689655"
+           transform="translate(-0.380561,94.653783)">
+          <path
+             inkscape:transform-center-y="-2.5"
+             inkscape:transform-center-x="2.5"
+             sodipodi:nodetypes="ccccc"
+             inkscape:connector-curvature="0"
+             d="m 216,171.766 h -5 v 5 h 5 z"
+             style="opacity:0.56896548;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+             id="path5153" />
+          <path
+             id="path5155"
+             style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+             d="m 223,164.766 h -10 v 10 h 10 z"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccc"
+             inkscape:transform-center-x="5"
+             inkscape:transform-center-y="-4.99999" />
+        </g>
+        <path
+           id="path5157"
+           style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 229.61944,252.41978 h -14 v 14.00001 h 14 z"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc"
+           inkscape:transform-center-x="7.0000102"
+           inkscape:transform-center-y="-7.0000182" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path5253"
+           d="m 225.12177,260.4067 -8.59375,11.40625 11.40625,-8.59375 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:4;marker:none;enable-background:accumulate" />
+        <path
+           inkscape:label="#collapsibleArrowRightHover"
+           transform="matrix(-0.50398184,0.50823176,0.50493003,0.50100644,-4.83073,-88.605708)"
+           d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+           inkscape:randomized="0"
+           inkscape:rounded="0"
+           inkscape:flatsided="true"
+           sodipodi:arg2="2.0943952"
+           sodipodi:arg1="1.0471976"
+           sodipodi:r2="5.7786927"
+           sodipodi:r1="7.1428571"
+           sodipodi:cy="578.07648"
+           sodipodi:cx="117.14286"
+           sodipodi:sides="3"
+           id="path5255"
+           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.40149021;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           sodipodi:type="star" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path5257"
+           d="m 225.80927,261.0942 -9.28125,10.71875 10.71875,-9.28125 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      </g>
+      <g
+         transform="translate(-85.371089,1575.9524)"
+         inkscape:label="camera"
+         id="g385960">
+        <g
+           id="g5269"
+           transform="matrix(1.1796873,0,0,1.1815592,-42.843707,-43.906533)">
+          <path
+             sodipodi:nodetypes="sccssssssssccss"
+             id="rect5222"
+             transform="translate(0,52.362183)"
+             d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.76159,0.53781 h -1.69536 c -1.662,0 -2.54305,1.30019 -2.54305,2.96219 v 7.19388 c 0,1.662 1.30489,2.53902 2.96689,2.53902 h 12.71523 c 1.662,0 2.96689,-0.87702 2.96689,-2.53902 V 203.5 c 0,-1.662 -0.88151,-2.92307 -2.54305,-2.96219 H 254.9106 L 254.5,200 c -0.78347,-0.78348 -0.892,-2 -2,-2 z"
+             style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.84701049;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <ellipse
+             ry="4.2313609"
+             rx="4.2387471"
+             cy="258.82404"
+             cx="249.82451"
+             id="path5224"
+             style="fill:#2a2a2a;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.84701049;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <ellipse
+             ry="0.84633929"
+             rx="0.84768224"
+             cy="257.55487"
+             cx="248.55298"
+             id="path5230"
+             style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <ellipse
+             ry="0.84633929"
+             rx="0.84768224"
+             style="fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="circle5232"
+             cx="256.18213"
+             cy="255.86218" />
+        </g>
+        <g
+           transform="matrix(0.56897805,-0.82235271,-0.82235271,-0.56897805,516.90529,480.52111)"
+           id="g5251">
+          <path
+             sodipodi:nodetypes="csc"
+             inkscape:connector-curvature="0"
+             id="path5254"
+             d="m 18.919829,338.41825 c 1.609786,-3.50691 4.785185,-6.213 8.827138,-7.1893 1.068186,-0.25801 2.137435,-0.37646 3.18856,-0.36706"
+             style="fill:none;stroke:#3c3c3c;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             inkscape:label="#collapsibleArrowRightHover"
+             transform="matrix(-0.55936791,-0.00554531,-0.00567669,0.55589671,99.812034,10.284701)"
+             d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+             inkscape:randomized="0"
+             inkscape:rounded="0"
+             inkscape:flatsided="true"
+             sodipodi:arg2="2.0943952"
+             sodipodi:arg1="1.0471976"
+             sodipodi:r2="5.7786927"
+             sodipodi:r1="7.1428571"
+             sodipodi:cy="578.07648"
+             sodipodi:cx="117.14286"
+             sodipodi:sides="3"
+             id="path5256"
+             style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.7932142;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:type="star" />
+          <path
+             style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m 18.919829,338.41825 c 1.609786,-3.50691 4.785185,-6.213 8.827138,-7.1893 1.068186,-0.25801 2.137435,-0.37646 3.18856,-0.36706"
+             id="path5258"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="csc" />
+        </g>
       </g>
     </g>
     <g
@@ -4707,46 +5155,6 @@
          style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#e5e5e5;stroke-width:8.47999954;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <path
-       inkscape:label="#path3902"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#efc618;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-       d="m 12.462739,145.33212 c -0.275586,0.0214 -0.536587,0.183 -0.678299,0.42003 l -5.6434388,9.32208 c -0.3155159,0.52386 0.134045,1.31576 0.7461277,1.31431 H 18.174008 c 0.612083,0.002 1.061644,-0.79045 0.746128,-1.31431 l -5.643439,-9.32208 c -0.164893,-0.27589 -0.493259,-0.44533 -0.813958,-0.42003 z"
-       id="warningSmall"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccc" />
-    <path
-       style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 12.49443,147.86218 v 0 c 0.280086,0 0.87197,0.21546 0.848075,0.49452 L 13,152.35661 c -0.02389,0.27906 -0.225484,0.50557 -0.50557,0.50557 v 0 c -0.280086,0 -0.485452,-0.22621 -0.50557,-0.50557 l -0.287262,-3.98886 c -0.02012,-0.27936 0.512746,-0.50557 0.792832,-0.50557 z"
-       id="rect1440"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccssccssc" />
-    <ellipse
-       style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path1444"
-       cx="12.5"
-       cy="154.36218"
-       rx="0.75"
-       ry="0.7499994" />
-    <path
-       sodipodi:nodetypes="sssss"
-       inkscape:connector-curvature="0"
-       style="opacity:0.98999999;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 27.000002,145.36217 c -3.037564,0 -5.500002,2.46244 -5.500002,5.50001 0,3.03757 2.462438,5.5 5.500002,5.5 3.037564,0 5.499997,-2.46243 5.499997,-5.5 0,-3.03757 -2.462433,-5.50001 -5.499997,-5.50001 z"
-       id="infoSmall"
-       inkscape:label="#path1410" />
-    <path
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:125%;font-family:'URW Palladio L';-inkscape-font-specification:'URW Palladio L Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:1.11748278"
-       d="M 25.251301,150.38428 26,150.36218 v 3 h -0.5 v 1 H 28 v -1 h -0.5 v -4 c -0.856496,0.18711 -1.546642,0.53253 -2.248699,1.0221 z"
-       id="path1441"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
-    <rect
-       style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect5105"
-       width="1.5"
-       height="1.5"
-       x="26"
-       y="147.36218" />
-    <path
        sodipodi:type="star"
        style="fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:#262626;stroke-width:0.49690738;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="bookmarkStar"
@@ -4781,204 +5189,22 @@
        transform="matrix(15.926225,0,0,16.279373,-4039.9249,656.02277)"
        inkscape:label="#path3064" />
     <g
-       transform="translate(131.19765,-49.336359)"
-       id="pointerDetachedPanel"
-       inkscape:label="#g4212">
-      <g
-         transform="translate(-72.066275,52.000002)"
-         style="opacity:0.8"
-         id="g4016-2-7">
-        <rect
-           style="fill:url(#linearGradient5930);fill-opacity:1;stroke:none;stroke-width:1.03047383;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect5922"
-           width="25.000004"
-           height="20.469828"
-           x="460.86862"
-           y="76.69854" />
-        <rect
-           style="fill:#fefefe;fill-opacity:1;stroke:none;stroke-width:0.96510452;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect5933"
-           width="25.000004"
-           height="4.5000005"
-           x="460.86862"
-           y="74.69854" />
-      </g>
-      <g
-         transform="translate(-74,50)"
-         style="opacity:0.5"
-         id="g4016-2-6">
-        <rect
-           style="fill:url(#linearGradient6005);fill-opacity:1;stroke:none;stroke-width:0.9357363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect2127-3"
-           width="23.646435"
-           height="11.092737"
-           x="464.15591"
-           y="86.319862" />
-        <rect
-           style="fill:#8f8f8f;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect2163-4"
-           width="16.034912"
-           height="6.0255737"
-           x="464.15591"
-           y="82.319862"
-           ry="2" />
-      </g>
+       id="g2745"
+       inkscape:label="tab"
+       transform="translate(-32,2.9999999e-6)">
+      <path
+         inkscape:connector-curvature="0"
+         id="rect2127-3"
+         transform="translate(0,52.362183)"
+         d="m 306,1296 c -1.108,0 -2,0.892 -2,2 v 1 1.0254 V 1311 h 23 v -12 h -7 v -1 c 0,-1.108 -0.85684,-2 -1.96484,-2 z"
+         style="fill:url(#linearGradient2723);fill-opacity:1;stroke:none;stroke-width:0.9357363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="ssccccccsss" />
       <path
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         d="m 400.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 406 l -2.5,-5 z"
+         d="m 314.5,1370.3622 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 320 l -2.5,-5 z"
          id="path4171-5-1"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccc" />
-    </g>
-    <g
-       transform="translate(101.19765,-49.336362)"
-       id="pointerTab"
-       inkscape:label="#g4212">
-      <g
-         transform="translate(-72.066275,52.000002)"
-         style="opacity:0.8"
-         id="g4016-2-7-6">
-        <rect
-           style="opacity:0;fill:url(#linearGradient6224);fill-opacity:1;stroke:none;stroke-width:1.03047383;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect5922-3"
-           width="25.000004"
-           height="20.469828"
-           x="460.86862"
-           y="76.69854" />
-        <rect
-           style="opacity:0;fill:#fefefe;fill-opacity:1;stroke:none;stroke-width:0.96510452;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect5933-9"
-           width="25.000004"
-           height="4.5000005"
-           x="460.86862"
-           y="74.69854" />
-      </g>
-      <g
-         transform="translate(-74,50)"
-         style="opacity:0.5"
-         id="g4016-2-6-3">
-        <rect
-           style="fill:url(#linearGradient6226);fill-opacity:1;stroke:none;stroke-width:0.9357363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect2127-3-2"
-           width="23.646435"
-           height="11.092737"
-           x="464.15591"
-           y="86.319862" />
-        <rect
-           style="fill:#8f8f8f;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect2163-4-0"
-           width="16.034912"
-           height="6.0255737"
-           x="464.15591"
-           y="82.319862"
-           ry="2" />
-      </g>
-      <path
-         style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         d="m 400.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 406 l -2.5,-5 z"
-         id="path4171-5-1-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccc" />
-    </g>
-    <g
-       id="g5812">
-      <rect
-         style="fill:url(#linearGradient5742);fill-opacity:1"
-         ry="2"
-         rx="2"
-         y="59.362183"
-         x="87"
-         height="16"
-         width="16"
-         id="rect5736" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path5796"
-         d="m 89.409772,74.862183 h 11.570078 c 0.88096,0 1.52015,-0.590755 1.52015,-1.513216 l 0.0259,-12.486784"
-         style="fill:none;stroke:url(#linearGradient5851);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    </g>
-    <path
-       style="fill:url(#linearGradient5784);fill-opacity:1;stroke:#3c3c3c;stroke-opacity:1"
-       d="m 90.196685,76.454588 c -0.431342,-0.109805 -0.690215,-0.361106 -1.31027,-1.271901 -0.65643,-0.964226 -1.33519,-1.836887 -2.024863,-2.603299 -0.524766,-0.583153 -0.91507,-1.161596 -1.002255,-1.48538 -0.190993,-0.709291 0.398649,-1.562619 1.447306,-2.094536 0.470729,-0.238773 0.54816,-0.258015 1.038337,-0.258015 0.497095,0 0.563657,0.01721 1.082001,0.280052 0.594818,0.301599 1.373418,0.965914 1.822921,1.555347 0.136504,0.178999 0.26603,0.325452 0.287827,0.325452 0.02177,0 0.164208,-0.274705 0.316485,-0.610464 0.336313,-0.741556 1.728594,-3.347638 2.310071,-4.32402 2.156294,-3.620682 4.538839,-6.626438 5.680704,-7.166624 0.427231,-0.202115 1.338621,-0.382904 2.388091,-0.473716 0.73272,-0.06338 0.81795,-0.05907 1.07584,0.05501 0.18422,0.0815 0.31819,0.197574 0.3914,0.339141 0.12782,0.247174 0.13951,0.679936 0.0244,0.901898 -0.0434,0.08357 -0.51977,0.601885 -1.0587,1.151771 -1.47567,1.505676 -2.29807,2.518125 -3.604458,4.437411 -1.743419,2.561359 -3.18888,5.206826 -4.452792,8.149473 -0.96967,2.257583 -0.982354,2.283931 -1.233117,2.561495 -0.125435,0.138843 -0.380198,0.319294 -0.56616,0.401018 -0.299329,0.131547 -0.456439,0.15059 -1.370145,0.16603 -0.567628,0.0097 -1.126805,-0.0066 -1.242616,-0.0362 z"
-       id="path3923"
-       inkscape:connector-curvature="0" />
-    <g
-       transform="translate(21,0.013216)"
-       id="g5812-7">
-      <rect
-         style="fill:url(#linearGradient5908);fill-opacity:1"
-         ry="2"
-         rx="2"
-         y="59.362183"
-         x="87"
-         height="16"
-         width="16"
-         id="rect5736-0" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path5796-4"
-         d="m 89.409772,74.862183 h 11.570078 c 0.88096,0 1.52015,-0.590755 1.52015,-1.513216 l 0.0259,-12.486784"
-         style="fill:none;stroke:url(#linearGradient5910);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
-    </g>
-    <g
-       transform="translate(39.9741)"
-       id="g5812-7-9"
-       style="display:inline">
-      <rect
-         style="fill:url(#linearGradient5945);fill-opacity:1"
-         ry="2"
-         rx="2"
-         y="59.362183"
-         x="87"
-         height="16"
-         width="16"
-         id="rect5736-0-3" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path5796-4-4"
-         d="m 89.409772,74.862183 h 11.570078 c 0.88096,0 1.52015,-0.590755 1.52015,-1.513216 l 0.0259,-12.486784"
-         style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:0.11764706" />
-    </g>
-    <g
-       transform="translate(60,0.013216)"
-       id="g5812-7-9-5"
-       style="display:inline">
-      <rect
-         style="fill:url(#linearGradient6013);fill-opacity:1"
-         ry="2"
-         rx="2"
-         y="59.362183"
-         x="87"
-         height="16"
-         width="16"
-         id="rect5736-0-3-5" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path5796-4-4-0"
-         d="m 89.409772,74.862183 h 11.570078 c 0.88096,0 1.52015,-0.590755 1.52015,-1.513216 l 0.0259,-12.486784"
-         style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:0.11764706" />
-    </g>
-    <path
-       inkscape:connector-curvature="0"
-       id="path3962"
-       d="m 150.19669,76.454588 c -0.43135,-0.109805 -0.69022,-0.361106 -1.31027,-1.271901 -0.65643,-0.964226 -1.33519,-1.836887 -2.02487,-2.603299 -0.52476,-0.583153 -0.91507,-1.161596 -1.00225,-1.48538 -0.191,-0.709291 0.39865,-1.562619 1.4473,-2.094536 0.47073,-0.238773 0.54816,-0.258015 1.03834,-0.258015 0.49709,0 0.56366,0.01721 1.082,0.280052 0.59482,0.301599 1.37342,0.965914 1.82292,1.555347 0.13651,0.178999 0.26603,0.325452 0.28783,0.325452 0.0218,0 0.16421,-0.274705 0.31648,-0.610464 0.33632,-0.741556 1.7286,-3.347638 2.31007,-4.32402 2.1563,-3.620682 4.53884,-6.626438 5.68071,-7.166624 0.42723,-0.202115 1.33862,-0.382904 2.38809,-0.473716 0.73272,-0.06338 0.81795,-0.05907 1.07584,0.05501 0.18422,0.0815 0.31819,0.197574 0.3914,0.339141 0.12782,0.247174 0.13951,0.679936 0.0244,0.901898 -0.0434,0.08357 -0.51977,0.601885 -1.0587,1.151771 -1.47567,1.505676 -2.29807,2.518125 -3.60446,4.437411 -1.74342,2.561359 -3.18888,5.206826 -4.45279,8.149473 -0.96967,2.257583 -0.98235,2.283931 -1.23312,2.561495 -0.12543,0.138843 -0.3802,0.319294 -0.56616,0.401018 -0.29933,0.131547 -0.45644,0.15059 -1.37014,0.16603 -0.56763,0.0097 -1.12681,-0.0066 -1.24262,-0.0362 z"
-       style="fill:url(#linearGradient6021);fill-opacity:1;stroke:#3c3c3c;stroke-opacity:1" />
-    <g
-       transform="translate(79.974035,-5e-5)"
-       id="g5812-7-8">
-      <rect
-         style="fill:#000000;fill-opacity:0.07843137"
-         ry="2"
-         rx="2"
-         y="59.362183"
-         x="87"
-         height="16"
-         width="16"
-         id="rect5736-0-2" />
     </g>
     <g
        id="g3196"
@@ -5000,11 +5226,6 @@
          transform="rotate(45)"
          inkscape:label="deleteSmall" />
     </g>
-    <path
-       inkscape:connector-curvature="0"
-       id="path2986"
-       d="m 170.19669,76.454588 c -0.43135,-0.109805 -0.69022,-0.361106 -1.31027,-1.271901 -0.65643,-0.964226 -1.33519,-1.836887 -2.02487,-2.603299 -0.52476,-0.583153 -0.91507,-1.161596 -1.00225,-1.48538 -0.191,-0.709291 0.39865,-1.562619 1.4473,-2.094536 0.47073,-0.238773 0.54816,-0.258015 1.03834,-0.258015 0.49709,0 0.56366,0.01721 1.082,0.280052 0.59482,0.301599 1.37342,0.965914 1.82292,1.555347 0.13651,0.178999 0.26603,0.325452 0.28783,0.325452 0.0218,0 0.16421,-0.274705 0.31648,-0.610464 0.33632,-0.741556 1.7286,-3.347638 2.31007,-4.32402 2.1563,-3.620682 4.53884,-6.626438 5.68071,-7.166624 0.42723,-0.202115 1.33862,-0.382904 2.38809,-0.473716 0.73272,-0.06338 0.81795,-0.05907 1.07584,0.05501 0.18422,0.0815 0.31819,0.197574 0.3914,0.339141 0.12782,0.247174 0.13951,0.679936 0.0244,0.901898 -0.0434,0.08357 -0.51977,0.601885 -1.0587,1.151771 -1.47567,1.505676 -2.29807,2.518125 -3.60446,4.437411 -1.74342,2.561359 -3.18888,5.206826 -4.45279,8.149473 -0.96967,2.257583 -0.98235,2.283931 -1.23312,2.561495 -0.12543,0.138843 -0.3802,0.319294 -0.56616,0.401018 -0.29933,0.131547 -0.45644,0.15059 -1.37014,0.16603 -0.56763,0.0097 -1.12681,-0.0066 -1.24262,-0.0362 z"
-       style="fill:#666666;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-opacity:1" />
     <g
        style="clip-rule:evenodd;fill:url(#linearGradient4863);fill-opacity:1;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5"
        transform="matrix(0.8,0,0,0.8,-626.30839,-193.05238)"
@@ -5041,125 +5262,6 @@
            inkscape:connector-curvature="0" />
       </g>
     </g>
-    <g
-       style="clip-rule:evenodd;fill:url(#foreground);fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5"
-       transform="matrix(0.74882855,0,0,0.74882855,-454.64703,65.171218)"
-       id="nodeSetStandardSet"
-       inkscape:label="nodeSetStandardSet">
-      <g
-         id="g1179"
-         transform="rotate(-45,1063.0797,502.31281)"
-         style="fill:url(#foreground)">
-        <path
-           id="path1177"
-           style="fill:url(#foreground);stroke:url(#linearGradient1596);stroke-width:1.00157475;stroke-miterlimit:1.5;stroke-dasharray:none"
-           d="m 1099.5,342.135 1,-1.613 h 5 V 336 c 0.97,-1.378 1.01,-1.482 2,0 v 2 l 8,1 v -2 h 2 v 9 l -2,0.27 v -2.31 l -8,1.04 v 2 c -0.91,1.591 -1.3,1.384 -2,0 v -4.478 h -5 z"
-           inkscape:connector-curvature="0" />
-      </g>
-      <g
-         id="g1183"
-         transform="rotate(-45,1063.0911,503.72257)"
-         style="fill:url(#foreground)">
-        <path
-           id="path1181"
-           style="fill:url(#foreground);stroke:url(#linearGradient1602);stroke-width:1px"
-           d="m 1108.5,339 v 7"
-           inkscape:connector-curvature="0" />
-      </g>
-      <g
-         id="g1187"
-         transform="rotate(-45,1058.8981,494.14549)"
-         style="fill:url(#foreground)">
-        <path
-           id="path1185"
-           style="fill:url(#linearGradient1604);fill-opacity:1;stroke:url(#linearGradient1610);stroke-width:0.99996185;stroke-miterlimit:1.5;stroke-dasharray:none"
-           d="m 1108.5,339 v 7"
-           inkscape:connector-curvature="0" />
-      </g>
-    </g>
-    <g
-       id="nodeSetDriverSceneSelectionSource"
-       inkscape:label="#nodeSetDriverSceneSelectionSource"
-       transform="matrix(0.7193948,0,0,0.69766458,188.59869,168.58733)">
-      <path
-         style="fill:#a0a0a0;fill-opacity:1;stroke:url(#linearGradient1616);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 150.21875,223.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 z"
-         id="path1495"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path1497"
-         d="m 142.36661,236.49782 -0.71022,-10.45042 8.52267,3.39892 -0.17756,11.69331 z"
-         style="fill:#c8c8c8;fill-opacity:1;stroke:url(#linearGradient1525);stroke-width:1.00025451;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path1499"
-         d="m 141.65639,226.0474 8.52267,4.1156 8.54804,-4.09024 -8.52267,-2.56187 z"
-         style="fill:url(#linearGradient1533);fill-opacity:1;stroke:url(#linearGradient1618);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         inkscape:connector-curvature="0" />
-    </g>
-    <g
-       transform="matrix(0.48166347,0,0,0.50576472,248.81397,214.57857)"
-       id="taargetNodeSetLinkNodeSet"
-       inkscape:label="nodeSetDriverNodeSet"
-       style="stroke:#3c3c3c;stroke-width:1.29247308;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1">
-      <g
-         id="g1746"
-         transform="matrix(0.84189541,0.83703021,-0.92289177,0.84189541,234.14585,-95.902408)">
-        <g
-           clip-path="none"
-           style="opacity:1;filter:url(#filter5291)"
-           transform="matrix(0.71674668,-0.71149348,0.78447764,0.71674668,-131.62162,168.30996)"
-           mask="none"
-           id="g5252">
-          <path
-             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1552);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1626);stroke-width:1.29235458;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-             d="m 131.31362,224.87387 c -3.8261,0 -6.95703,3.13092 -6.95703,6.95703 v 0.10156 c 0,3.8261 3.13093,6.95703 6.95703,6.95703 h 11.18946 c 3.8261,0 6.95703,-3.13093 6.95703,-6.95703 v -0.10156 c 0,-3.82611 -3.13093,-6.95703 -6.95703,-6.95703 z m 0,3.22851 h 11.18946 c 2.09365,0 3.72851,1.63487 3.72851,3.72852 v 0.10156 c 0,2.09365 -1.63486,3.72852 -3.72851,3.72851 h -11.18946 c -2.09365,0 -3.72851,-1.63486 -3.72851,-3.72851 v -0.10156 c 0,-2.09365 1.63486,-3.72852 3.72851,-3.72852 z"
-             id="rect1538"
-             inkscape:connector-curvature="0" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path1554"
-             d="m 158.22895,224.87387 c -3.8261,0 -6.95703,3.13092 -6.95703,6.95703 v 0.10156 c 0,3.8261 3.13093,6.95703 6.95703,6.95703 h 11.18946 c 3.8261,0 6.95703,-3.13093 6.95703,-6.95703 v -0.10156 c 0,-3.82611 -3.13093,-6.95703 -6.95703,-6.95703 z m 0,3.22851 h 11.18946 c 2.09365,0 3.72851,1.63487 3.72851,3.72852 v 0.10156 c 0,2.09365 -1.63486,3.72852 -3.72851,3.72851 h -11.18946 c -2.09365,0 -3.72851,-1.63486 -3.72851,-3.72851 v -0.10156 c 0,-2.09365 1.63486,-3.72852 3.72851,-3.72852 z"
-             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1556);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1624);stroke-width:1.29247308;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-        </g>
-        <rect
-           transform="matrix(0.70970278,-0.70450121,0.73825842,0.67451798,0,0)"
-           ry="2.2458742"
-           y="270.57257"
-           x="-68.264702"
-           height="4.4917483"
-           width="13.419611"
-           id="rect1524"
-           style="fill:url(#linearGradient1748);fill-opacity:1;stroke:url(#linearGradient1750);stroke-width:1.1030345;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-      <rect
-         style="opacity:0;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.50758708;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1"
-         id="nodeSetDriverNodeSet"
-         width="26.989798"
-         height="25.703651"
-         x="143.63977"
-         y="215.08739"
-         inkscape:label="export" />
-    </g>
-    <path
-       inkscape:label="#nodeSetNumericBookmarkSet"
-       transform="matrix(1.119198,0,0,1.1443239,19.017934,313.89113)"
-       d="m 302.30138,18.423424 -3.43097,-2.443491 -3.44073,2.429728 1.26367,-4.018128 -3.37406,-2.521504 4.21197,-0.03985 1.35545,-3.9881025 1.33946,3.9935005 4.21177,0.05672 -3.38412,2.507967 z"
-       inkscape:randomized="0"
-       inkscape:rounded="0"
-       inkscape:flatsided="false"
-       sodipodi:arg2="1.5727992"
-       sodipodi:arg1="0.94448073"
-       sodipodi:r2="2.2924397"
-       sodipodi:r1="5.8454323"
-       sodipodi:cy="13.687498"
-       sodipodi:cx="298.875"
-       sodipodi:sides="5"
-       id="nodeSetNumericBookmarkSet"
-       style="fill:#e0e0e0;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1634);stroke-width:0.49690738;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       sodipodi:type="star" />
     <path
        inkscape:connector-curvature="0"
        inkscape:label="#path3093"
@@ -5167,159 +5269,18 @@
        d="m 494,150.86218 h -3.5 l 5,5.5 5,-5.5 H 497 v -7 h 3.5 l -5,-5.5 -5,5.5 h 3.5 z"
        id="reorderVertically"
        sodipodi:nodetypes="ccccccccccc" />
-    <g
-       transform="translate(266.36574,54.292896)"
-       inkscape:label="target"
-       id="pointerTarget">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fdfdfd;fill-opacity:1;fill-rule:nonzero;stroke:#060606;stroke-width:1.55200005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 640.28711,131.5 v 2.37109 c -4.06417,0.42136 -7.30842,3.66441 -7.73047,7.72852 h -2.36914 v 1.80078 h 2.36914 c 0.42122,4.06483 3.66565,7.30925 7.73047,7.73047 V 153.5 h 1.79883 v -2.36914 c 4.06502,-0.42122 7.30904,-3.66565 7.73047,-7.73047 h 2.37109 v -1.80078 h -2.37109 c -0.42226,-4.06411 -3.66609,-7.30716 -7.73047,-7.72852 V 131.5 Z m 0,4.24219 v 2.29492 h 1.80078 v -2.29492 c 3.05392,0.40129 5.45672,2.80331 5.85742,5.85742 h -2.16601 v 1.80078 h 2.16601 c -0.39993,3.05472 -2.80295,5.45621 -5.85742,5.85742 v -2.02929 h -1.80078 v 2.02929 c -3.05571,-0.39991 -5.45751,-2.80171 -5.85742,-5.85742 h 2.16601 v -1.80078 h -2.16601 c 0.40068,-3.05511 2.80225,-5.45743 5.85742,-5.85742 z"
-         transform="translate(-266.36574,-1.930713)"
-         id="path1559"
-         inkscape:connector-curvature="0" />
-    </g>
-    <g
-       transform="translate(13,264.5)"
-       inkscape:label="#g3271"
-       id="g1559">
-      <rect
-         style="opacity:1;fill:url(#linearGradient1777);fill-opacity:1;stroke:none;stroke-width:0.46991649;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect1775"
-         width="1.0449129"
-         height="4.2266016"
-         x="256"
-         y="69.435852" />
-      <rect
-         y="69.435852"
-         x="250"
-         height="4.2266016"
-         width="1.0449129"
-         id="rect1737"
-         style="opacity:1;fill:url(#linearGradient1739);fill-opacity:1;stroke:none;stroke-width:0.46991649;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <image
-         y="-88.911987"
-         x="245.84317"
-         id="image1712"
-         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAFCAYAAACEhIafAAAABHNCSVQICAgIfAhkiAAAABhJREFU CJljUFdX/8/EwMDAgESoqal9BQAiNgLk0MFnOAAAAABJRU5ErkJggg== "
-         style="image-rendering:optimizeSpeed"
-         preserveAspectRatio="none"
-         height="5.0000033"
-         width="1.0000004"
-         transform="rotate(34.253676)" />
-      <image
-         transform="rotate(141.61904)"
-         width="1.0000004"
-         height="5.0000033"
-         preserveAspectRatio="none"
-         style="image-rendering:optimizeSpeed"
-         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAFCAYAAACEhIafAAAABHNCSVQICAgIfAhkiAAAABhJREFU CJljUFdX/8/EwMDAgESoqal9BQAiNgLk0MFnOAAAAABJRU5ErkJggg== "
-         id="image1735"
-         x="-158.64658"
-         y="-213.41306" />
-      <rect
-         style="opacity:1;fill:url(#linearGradient1652);fill-opacity:1;stroke:none;stroke-width:0.56679887;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect1572"
-         width="1.0449129"
-         height="6.1490483"
-         x="253"
-         y="59.713135" />
-      <rect
-         style="fill:none;stroke:none;stroke-width:0.86666685"
-         id="nodeSetDriverNodeSelection"
-         width="13"
-         height="13"
-         x="60.462185"
-         y="247"
-         transform="matrix(0,1,1,0,0,0)"
-         inkscape:label="#nodeSetDriverNodeSelection" />
-      <rect
-         style="fill:url(#linearGradient1574);fill-opacity:1;stroke:url(#linearGradient1590);stroke-width:0.99903917;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect1553"
-         width="6.0009608"
-         height="3.0009608"
-         x="250.49953"
-         y="62.859112" />
-      <rect
-         y="68.287651"
-         x="248.42548"
-         height="3.1490464"
-         width="4.1490464"
-         id="rect1680"
-         style="fill:url(#linearGradient1682);fill-opacity:1;stroke:url(#linearGradient1684);stroke-width:0.85095352;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:url(#linearGradient1688);fill-opacity:1;stroke:url(#linearGradient1690);stroke-width:0.85095352;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect1686"
-         width="4.1490464"
-         height="3.14905"
-         x="254.42548"
-         y="68.287651" />
-    </g>
-    <g
-       transform="matrix(0.7193948,0,0,0.69766458,188.59869,188.31389)"
-       inkscape:label="#nodeSetSourceSet"
-       id="nodeSetSourceSet">
-      <path
-         inkscape:connector-curvature="0"
-         id="path1600"
-         d="m 150.21875,223.51843 -8.5625,2.53125 0.71875,10.4375 7.625,4.65625 8,-4.53125 0.71875,-10.53125 z"
-         style="fill:#a0a0a0;fill-opacity:1;stroke:url(#linearGradient1609);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#c8c8c8;fill-opacity:1;stroke:url(#linearGradient1611);stroke-width:1.00025451;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 142.36661,236.49782 -0.71022,-10.45042 8.52267,3.39892 -0.17756,11.69331 z"
-         id="path1602"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient1613);fill-opacity:1;stroke:url(#linearGradient1615);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 141.65639,226.0474 8.52267,4.1156 8.54804,-4.09024 -8.52267,-2.56187 z"
-         id="path1604"
-         sodipodi:nodetypes="ccccc" />
-    </g>
-    <g
-       id="move"
-       inkscape:label="#move">
-      <rect
-         y="143.61218"
-         x="589"
-         height="8.75"
-         width="9.125"
-         id="rect1573"
-         style="opacity:1;fill:#fefefe;fill-opacity:1;stroke:none;stroke-width:2.41889763;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill" />
-      <path
-         sodipodi:nodetypes="ccccccccccccccccccccccccc"
-         inkscape:connector-curvature="0"
-         id="path1565"
-         d="m 593.58594,139.3432 -3.3463,3.82447 h 2.39025 v 3.82441 h -3.82441 v -2.39026 l -3.82447,3.3463 3.82447,3.34642 v -2.39026 h 3.82441 v 3.82441 h -2.39025 l 3.3463,3.82436 3.34642,-3.82436 h -2.39026 v -3.82441 h 3.82441 v 2.39026 l 3.82436,-3.34642 -3.82436,-3.3463 v 2.39026 h -3.82441 v -3.82441 h 2.39026 z"
-         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2.41889763;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill" />
-    </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="circle2648"
+       d="m 541,1343.3622 v 2.0605 a 9,9 0 0 0 -7.93359,7.9395 H 531 v 2 h 2.06055 A 9,9 0 0 0 541,1363.2958 v 2.0664 h 2 v -2.0605 a 9,9 0 0 0 7.93359,-7.9395 H 553 v -2 h -2.06055 A 9,9 0 0 0 543,1345.4286 v -2.0664 z m 0,4.0781 v 1.9219 h 2 v -1.9199 a 7,7 0 0 1 5.92188,5.9199 H 547 v 2 h 1.91992 A 7,7 0 0 1 543,1361.2841 v -1.9219 h -2 v 1.9199 a 7,7 0 0 1 -5.92188,-5.9199 H 537 v -2 h -1.91992 A 7,7 0 0 1 541,1347.4403 Z"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       inkscape:label="target" />
     <path
        style="opacity:1;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
-       d="m 637,87 v 7 h -7 v 2 h 7 v 7 h 2 v -7 h 7 v -2 h -7 v -7 z"
-       transform="translate(0,52.362183)"
-       id="pointerCrossHair"
+       d="m 577,1346.3622 v 7 h -7 v 2 h 7 v 7 h 2 v -7 h 7 v -2 h -7 v -7 z"
+       id="path2"
        inkscape:connector-curvature="0"
        inkscape:label="#pointerCrossHair" />
-    <path
-       sodipodi:nodetypes="cccccccc"
-       inkscape:connector-curvature="0"
-       id="errorSmall"
-       d="m -5.0077704,145.53928 c -0.275586,0.0214 -0.536587,0.183 -0.678299,0.42003 l -5.6434386,9.32208 c -0.315516,0.52386 0.134045,1.31576 0.746128,1.31431 H 0.70349865 c 0.61208295,0.002 1.06164395,-0.79045 0.74612795,-1.31431 l -5.643439,-9.32208 c -0.164893,-0.27589 -0.493259,-0.44533 -0.813958,-0.42003 z"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-       inkscape:label="#path3902" />
-    <path
-       sodipodi:nodetypes="ccssccssc"
-       inkscape:connector-curvature="0"
-       id="path1571"
-       d="m -4.9760794,148.06934 v 0 c 0.280086,0 0.87197,0.21546 0.848075,0.49452 l -0.342505,3.99991 c -0.02389,0.27906 -0.225484,0.50557 -0.50557,0.50557 v 0 c -0.280086,0 -0.485452,-0.22621 -0.50557,-0.50557 l -0.287262,-3.98886 c -0.02012,-0.27936 0.512746,-0.50557 0.792832,-0.50557 z"
-       style="opacity:1;fill:url(#linearGradient1712);fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <ellipse
-       ry="0.7499994"
-       rx="0.75"
-       cy="154.56934"
-       cx="-4.9705095"
-       id="ellipse1573"
-       style="opacity:1;fill:url(#linearGradient1718);fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:connector-curvature="0"
        style="fill:none;fill-opacity:1;stroke:#e5e5e5;stroke-width:8.48041153;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -5335,7 +5296,7 @@
        inkscape:label="#rect2859"
        sodipodi:nodetypes="ccccccc"
        id="navigationArrow"
-       d="m 440.5,111.86218 v 4 l 7,-6 -7,-6 v 4 c -5.5,0 -9.5,4.5 -9.5,4.5 0,0 6,-2 9.5,-0.5 z"
+       d="m 456,112.36218 v 4 l 7,-6 -7,-6 v 4 c -5.5,0 -9.5,4.5 -9.5,4.5 0,0 6,-2 9.5,-0.5 z"
        style="fill:url(#backgroundLighter);fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-linejoin:miter;stroke-opacity:0.99215686"
        inkscape:connector-curvature="0" />
     <path
@@ -5352,239 +5313,2171 @@
        style="fill:#e5e5e5;fill-opacity:1;stroke:none;stroke-width:8.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:label="#path1876" />
     <g
-       id="catalogueStatusDisk"
-       inkscape:label="#catalogTypeDisk"
-       transform="translate(23,8.000003)">
+       id="g2724"
+       inkscape:label="catalogueStatus">
+      <g
+         transform="translate(-316,1504)"
+         inkscape:label="disk"
+         id="g1234">
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccc"
+           id="path2400"
+           d="m 355.5,104.86218 h -6 l -6,6 v 6 h 12 z"
+           style="fill:url(#linearGradient1627);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1" />
+        <path
+           style="fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 349.5,105.36218 v 5.5 H 344"
+           id="path2402"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccc" />
+      </g>
+      <g
+         inkscape:label="display"
+         transform="translate(-313.87501,1503.875)"
+         id="g43253">
+        <path
+           style="fill:url(#linearGradient3526);fill-opacity:1;stroke:#818181;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 370.37501,104.98718 h -6 l -6,6 v 6 h 12 z"
+           id="path2408"
+           sodipodi:nodetypes="cccccc"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 364.37501,106.48718 v 1"
+           id="path3497"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path3495"
+           d="m 364.37501,108.48718 v 1"
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 364.37501,110.48718 v 1"
+           id="path3493"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path3491"
+           d="m 362.37501,110.48718 v 1"
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 360.37501,110.48718 v 1"
+           id="path3489"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 364.37501,104.48718 v 1"
+           id="path3487"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path3485"
+           d="m 370.37501,116.48718 v 1"
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 363.2521,106.11009 -0.75418,0.75418"
+           id="path3445-0"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 361.7521,107.61009 -0.75418,0.75418"
+           id="path3445-3"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 360.2521,109.11009 -0.75418,0.75418"
+           id="path3445"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path3441"
+           d="m 366.37501,104.48718 v 1"
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 368.37501,104.48718 v 1"
+           id="path3439"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path3437"
+           d="m 358.37501,110.48718 v 1"
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 358.37501,112.48718 v 1"
+           id="path3435"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path3433"
+           d="m 358.37501,114.48718 v 1"
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 358.37501,116.48718 v 1"
+           id="path3431"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path3429"
+           d="m 360.37501,116.48718 v 1"
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 362.37501,116.48718 v 1"
+           id="path3427"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path3425"
+           d="m 364.37501,116.48718 v 1"
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 366.37501,116.48718 v 1"
+           id="path3423"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path3421"
+           d="m 368.37501,116.48718 v 1"
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 370.37501,114.48718 v 1"
+           id="path3419"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path3417"
+           d="m 370.37501,112.48718 v 1"
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 370.37501,110.48718 v 1"
+           id="path3415"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path3413"
+           d="m 370.37501,108.48718 v 1"
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 370.37501,106.48718 v 1"
+           id="path3411"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path3409"
+           d="m 370.37501,104.48718 v 1"
+           style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+      </g>
+      <g
+         transform="translate(-333,1513)"
+         inkscape:label="batchComplete"
+         id="g3278">
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           style="opacity:1;fill:#818181;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+           d="m 426,45 v 4 h -10 v 1 h 10 v 4 h 1 v -9 z"
+           transform="translate(0,52.362183)"
+           id="rect3267"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="translate(-350,1513)"
+         id="g3285"
+         inkscape:label="batchRunning">
+        <path
+           sodipodi:nodetypes="ccccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path3281"
+           transform="translate(0,52.362183)"
+           d="m 426,45 v 4 l -4,-2 v 2 h -6 v 1 h 6 v 2 l 4,-2 v 4 h 1 v -9 z"
+           style="opacity:1;fill:#cccccc;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      </g>
       <path
-         style="fill:url(#linearGradient1627);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
-         d="m 355.5,104.86218 h -6 l -6,6 v 6 h 12 z"
-         id="path2400"
-         sodipodi:nodetypes="cccccc"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccc"
+         inkscape:label="interactiveComplete"
          inkscape:connector-curvature="0"
-         id="path2402"
-         d="m 349.5,105.36218 v 5.5 H 344"
-         style="fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         id="3287"
+         d="m 126.5,1609.3622 c -3.03164,0 -5.5,2.4683 -5.5,5.5 0,3.0316 2.46836,5.5 5.5,5.5 3.03164,0 5.5,-2.4684 5.5,-5.5 0,-3.0317 -2.46836,-5.5 -5.5,-5.5 z m 0,1 c 2.4912,0 4.5,2.0088 4.5,4.5 0,2.4912 -2.0088,4.5 -4.5,4.5 -2.4912,0 -4.5,-2.0088 -4.5,-4.5 0,-2.4912 2.0088,-4.5 4.5,-4.5 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#818181;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         inkscape:label="interactiveRunning"
+         sodipodi:nodetypes="ssccscccsscscccsss"
+         inkscape:connector-curvature="0"
+         id="3219"
+         d="m 109.5,1609.3622 c -3.03164,0 -5.5,2.4683 -5.5,5.5 0,0.9721 0.25638,1.8842 0.70117,2.6777 l 0.74805,-0.748 c -0.2791,-0.5864 -0.44922,-1.2353 -0.44922,-1.9297 0,-1.9618 1.24566,-3.6243 2.99162,-4.2424 l 1.00838,1.7424 3.17773,-2.2988 c -0.79347,-0.4448 -1.70561,-0.7012 -2.67773,-0.7012 z m 4.79883,2.8223 -0.74805,0.748 c 0.2791,0.5864 0.44922,1.2353 0.44922,1.9297 0,1.9685 -1.25432,3.6359 -3.00983,4.2488 L 110,1616.8622 l -3.17773,2.7988 c 0.79347,0.4448 1.70561,0.7012 2.67773,0.7012 3.03164,0 5.5,-2.4684 5.5,-5.5 0,-0.9721 -0.25638,-1.8843 -0.70117,-2.6777 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     </g>
     <g
-       id="catalogueStatusDisplay"
-       transform="translate(25.12499,7.875003)"
-       inkscape:label="#catalogueStatusDisplay">
+       id="g2741"
+       inkscape:label="detachedPanel"
+       transform="translate(-31.982592,0.01284627)">
+      <g
+         id="g2696"
+         style="opacity:0.8"
+         transform="translate(-122.88603,1267.6508)">
+        <rect
+           y="78.698586"
+           x="460.86862"
+           height="16.999998"
+           width="24.999998"
+           id="rect2692"
+           style="fill:url(#linearGradient2704);fill-opacity:1;stroke:none;stroke-width:1.03047383;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           y="74.69854"
+           x="460.86862"
+           height="4.0000863"
+           width="25.000004"
+           id="rect2694"
+           style="fill:#fefefe;fill-opacity:1;stroke:none;stroke-width:0.90991908;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
       <path
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccc"
-         id="path2408"
-         d="m 370.37501,104.98718 h -6 l -6,6 v 6 h 12 z"
-         style="fill:url(#linearGradient3526);fill-opacity:1;stroke:#818181;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3497"
-         d="m 364.37501,106.48718 v 1"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
-         d="m 364.37501,108.48718 v 1"
-         id="path3495"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3493"
-         d="m 364.37501,110.48718 v 1"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
-         d="m 362.37501,110.48718 v 1"
-         id="path3491"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3489"
-         d="m 360.37501,110.48718 v 1"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3487"
-         d="m 364.37501,104.48718 v 1"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
-         d="m 370.37501,116.48718 v 1"
-         id="path3485"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3445-0"
-         d="m 363.2521,106.11009 -0.75418,0.75418"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3445-3"
-         d="m 361.7521,107.61009 -0.75418,0.75418"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3445"
-         d="m 360.2521,109.11009 -0.75418,0.75418"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
-         d="m 366.37501,104.48718 v 1"
-         id="path3441"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3439"
-         d="m 368.37501,104.48718 v 1"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
-         d="m 358.37501,110.48718 v 1"
-         id="path3437"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3435"
-         d="m 358.37501,112.48718 v 1"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
-         d="m 358.37501,114.48718 v 1"
-         id="path3433"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3431"
-         d="m 358.37501,116.48718 v 1"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
-         d="m 360.37501,116.48718 v 1"
-         id="path3429"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3427"
-         d="m 362.37501,116.48718 v 1"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
-         d="m 364.37501,116.48718 v 1"
-         id="path3425"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3423"
-         d="m 366.37501,116.48718 v 1"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
-         d="m 368.37501,116.48718 v 1"
-         id="path3421"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3419"
-         d="m 370.37501,114.48718 v 1"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
-         d="m 370.37501,112.48718 v 1"
-         id="path3417"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3415"
-         d="m 370.37501,110.48718 v 1"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
-         d="m 370.37501,108.48718 v 1"
-         id="path3413"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3411"
-         d="m 370.37501,106.48718 v 1"
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
-      <path
-         style="opacity:1;fill:url(#linearGradient1632);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
-         d="m 370.37501,104.48718 v 1"
-         id="path3409"
-         inkscape:connector-curvature="0" />
-    </g>
-    <g
-       id="g3278"
-       inkscape:label="batchComplete"
-       transform="translate(1,2.0000004)">
-      <path
-         inkscape:connector-curvature="0"
-         id="rect3267"
+         id="rect2698"
          transform="translate(0,52.362183)"
-         d="m 426,45 v 4 h -10 v 1 h 10 v 4 h 1 v -9 z"
-         style="opacity:1;fill:#818181;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
-         sodipodi:nodetypes="ccccccccc" />
-      <rect
-         inkscape:label="batchCompleteBounds"
-         y="95.362183"
-         x="415"
-         height="13"
-         width="13"
-         id="catalogueStatusBatchRenderComplete"
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.17422915;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
-    </g>
-    <g
-       inkscape:label="batchRunning"
-       id="g3285"
-       transform="translate(-15,2.0000002)">
+         d="m 341.98242,1295.9863 c -1.108,0 -2,0.892 -2,2 v 1 1.0274 10.9746 h 23 v -12.002 l -6.99983,9e-4 v -1 c 0,-1.108 -0.85701,-2.0009 -1.96501,-2.0009 z"
+         style="fill:url(#linearGradient2706);fill-opacity:1;stroke:none;stroke-width:0.9357363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="ssccccccsss" />
       <path
-         style="opacity:1;fill:#cccccc;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
-         d="m 426,45 v 4 l -4,-2 v 2 h -6 v 1 h 6 v 2 l 4,-2 v 4 h 1 v -9 z"
-         transform="translate(0,52.362183)"
-         id="path3281"
+         sodipodi:nodetypes="ccccccccc"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccc" />
-      <rect
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.17422915;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
-         id="catalogueStatusBatchRenderRunning"
-         width="13"
-         height="13"
-         x="415"
-         y="95.362183"
-         inkscape:label="batchRunningBounds" />
+         id="path2702"
+         d="m 350.48259,1370.3494 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 h -2.5 l -2.5,-5 z"
+         style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
     </g>
     <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#818181;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       d="m 422.5,113.36218 c -3.03164,0 -5.5,2.4683 -5.5,5.5 0,3.0316 2.46836,5.5 5.5,5.5 3.03164,0 5.5,-2.4684 5.5,-5.5 0,-3.0317 -2.46836,-5.5 -5.5,-5.5 z m 0,1 c 2.4912,0 4.5,2.0088 4.5,4.5 0,2.4912 -2.0088,4.5 -4.5,4.5 -2.4912,0 -4.5,-2.0088 -4.5,-4.5 0,-2.4912 2.0088,-4.5 4.5,-4.5 z"
-       id="3287"
        inkscape:connector-curvature="0"
-       inkscape:label="#path3287" />
+       inkscape:label="moveDiagonallyDown"
+       sodipodi:nodetypes="ccccccccccc"
+       id="path2587"
+       d="M 461.17157,1348.1196 463,1346.3622 h -5 v 5 l 1.75736,-1.8284 7.07107,7.071 -1.82843,1.7574 h 5 v -5 l -1.75736,1.8284 z"
+       style="display:inline;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
     <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       d="m 406.5,113.36218 c -3.03164,0 -5.5,2.46835 -5.5,5.5 0,0.97212 0.25638,1.88426 0.70117,2.67774 l 0.74805,-0.74805 C 402.17012,120.20549 402,119.55659 402,118.86218 c 0,-1.96174 1.24566,-3.62433 2.99162,-4.24243 l 1.00838,1.74243 3.17773,-2.29883 c -0.79347,-0.44479 -1.70561,-0.70117 -2.67773,-0.70117 z m 4.79883,2.82227 -0.74805,0.74804 c 0.2791,0.58639 0.44922,1.23529 0.44922,1.92969 0,1.96855 -1.25432,3.63587 -3.00983,4.24884 L 407,120.86218 l -3.17773,2.79883 c 0.79347,0.44479 1.70561,0.70117 2.67773,0.70117 3.03164,0 5.5,-2.46836 5.5,-5.5 0,-0.97212 -0.25638,-1.88426 -0.70117,-2.67773 z"
-       id="3219"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ssccscccsscscccsss"
-       inkscape:label="#path3291" />
+       inkscape:label="moveVertically"
+       sodipodi:nodetypes="ccccccccccc"
+       id="path2604"
+       d="m 429,1347.3622 h 2.5 l -3.5,-3.5 -3.5,3.5 h 2.5 v 10 h -2.5 l 3.5,3.5 3.5,-3.5 H 429 Z"
+       style="display:inline;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+       d="M 495.75736,1355.1906 494,1353.3622 v 5 h 5 l -1.82843,-1.7574 7.07107,-7.071 1.75736,1.8284 v -5 h -5 l 1.82843,1.7574 z"
+       id="path2606"
+       sodipodi:nodetypes="ccccccccccc"
+       inkscape:label="moveDiagonallyUp"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g2984"
+       inkscape:label="pointers-PathFilterUI"
+       transform="translate(0,-54)"
+       style="paint-order:stroke fill markers">
+      <g
+         id="g2683"
+         inkscape:label="removeObjects"
+         style="paint-order:stroke fill markers">
+        <g
+           transform="translate(-243,1371)"
+           inkscape:label="objects"
+           id="g4299-3"
+           style="display:inline;paint-order:stroke fill markers">
+          <g
+             id="g4081-8"
+             inkscape:label="#g4081"
+             style="opacity:1;paint-order:stroke fill markers"
+             transform="translate(-21.93011,50.751613)">
+            <path
+               sodipodi:nodetypes="cccc"
+               inkscape:connector-curvature="0"
+               id="rect4062-0"
+               d="m 392.93011,76.11057 6,12 h -12 z"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke" />
+            <path
+               sodipodi:open="true"
+               sodipodi:end="6.2821966"
+               sodipodi:start="0"
+               d="m 390.93011,88.610573 a 5.9999995,5.9999995 0 0 1 -5.99851,5.999999 5.9999995,5.9999995 0 0 1 -6.00148,-5.997033 5.9999995,5.9999995 0 0 1 5.99555,-6.002964 5.9999995,5.9999995 0 0 1 6.00444,5.994066"
+               sodipodi:ry="5.9999995"
+               sodipodi:rx="5.9999995"
+               sodipodi:cy="88.610573"
+               sodipodi:cx="384.93011"
+               id="path3260-2"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+               sodipodi:type="arc" />
+            <path
+               sodipodi:nodetypes="ccccc"
+               inkscape:connector-curvature="0"
+               id="rect4065-4"
+               d="m 386.43011,87.610588 6,3 v 9.500002 l -6,-3.500002 z"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke" />
+            <path
+               sodipodi:nodetypes="ccccc"
+               inkscape:connector-curvature="0"
+               id="rect4067-8"
+               d="m 392.43011,90.110588 8,-1.5 v 9 l -8,2.500002 z"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke" />
+            <path
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
+               d="m 386.43011,87.610588 6,3 8,-2 -6,-2.5 z"
+               id="path4079-3"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="ccccc" />
+          </g>
+          <path
+             style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;paint-order:stroke fill markers"
+             d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
+             id="path4167-9"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccccccc" />
+          <path
+             sodipodi:nodetypes="ccccccccc"
+             inkscape:connector-curvature="0"
+             id="path3193-0"
+             d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
+             style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;paint-order:normal" />
+        </g>
+        <g
+           id="g3989"
+           transform="translate(10.25,1419)"
+           style="paint-order:stroke fill markers">
+          <path
+             inkscape:connector-curvature="0"
+             inkscape:label="#rect3638"
+             sodipodi:nodetypes="ccccc"
+             id="path3985"
+             d="m 84.75,89.362182 v 5.999998 h 16 v -5.999998 z"
+             style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;paint-order:stroke fill markers" />
+          <path
+             sodipodi:nodetypes="ccccc"
+             style="fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:none;paint-order:stroke fill markers"
+             d="m 85.75,90.362182 v 3.999998 h 14 v -3.999998 z"
+             id="path3987"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g2697"
+         inkscape:label="addObjects"
+         style="paint-order:stroke fill markers">
+        <g
+           id="g3952"
+           transform="translate(-262,1326)"
+           style="paint-order:stroke fill markers">
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;paint-order:stroke fill markers"
+             d="m 430,177.36219 v 5 h -5 v 5.99999 h 5 v 5 h 6 v -5 h 5 v -5.99999 h -5 v -5 z"
+             id="path3948"
+             sodipodi:nodetypes="ccccccccccccc"
+             inkscape:label="#rect3638" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path3950"
+             d="m 431,178.36219 v 5 h -5 v 3.99999 h 5 v 5 h 4 v -5 h 5 v -3.99999 h -5 v -5 z"
+             style="fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:none;paint-order:stroke fill markers"
+             sodipodi:nodetypes="ccccccccccccc" />
+        </g>
+        <g
+           style="display:inline;paint-order:stroke fill markers"
+           id="g3060"
+           inkscape:label="objects"
+           transform="translate(-175,1371)">
+          <g
+             transform="translate(-21.93011,50.751613)"
+             style="opacity:1;paint-order:stroke fill markers"
+             inkscape:label="#g4081"
+             id="g3054">
+            <path
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
+               d="m 392.93011,76.11057 6,12 h -12 z"
+               id="path3044"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cccc" />
+            <path
+               sodipodi:type="arc"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+               id="path3046"
+               sodipodi:cx="384.93011"
+               sodipodi:cy="88.610573"
+               sodipodi:rx="5.9999995"
+               sodipodi:ry="5.9999995"
+               d="m 390.93011,88.610573 a 5.9999995,5.9999995 0 0 1 -5.99851,5.999999 5.9999995,5.9999995 0 0 1 -6.00148,-5.997033 5.9999995,5.9999995 0 0 1 5.99555,-6.002964 5.9999995,5.9999995 0 0 1 6.00444,5.994066"
+               sodipodi:start="0"
+               sodipodi:end="6.2821966"
+               sodipodi:open="true" />
+            <path
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
+               d="m 386.43011,87.610588 6,3 v 9.500002 l -6,-3.500002 z"
+               id="path3048"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="ccccc" />
+            <path
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
+               d="m 392.43011,90.110588 8,-1.5 v 9 l -8,2.500002 z"
+               id="path3050"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="ccccc" />
+            <path
+               sodipodi:nodetypes="ccccc"
+               inkscape:connector-curvature="0"
+               id="path3052"
+               d="m 386.43011,87.610588 6,3 8,-2 -6,-2.5 z"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke" />
+          </g>
+          <path
+             sodipodi:nodetypes="ccccccccc"
+             inkscape:connector-curvature="0"
+             id="path3056"
+             d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
+             style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;paint-order:stroke fill markers" />
+          <path
+             style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;paint-order:normal"
+             d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
+             id="path3058"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccccccc" />
+        </g>
+      </g>
+      <g
+         id="g2715"
+         inkscape:label="replaceObjects"
+         style="paint-order:stroke fill markers">
+        <g
+           id="g4125"
+           transform="translate(-194,1220)"
+           style="paint-order:stroke fill markers">
+          <g
+             transform="translate(340.25,197)"
+             id="g4011"
+             style="paint-order:stroke fill markers">
+            <path
+               style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;paint-order:stroke fill markers"
+               d="m 84.75,89.362182 v 5.000001 h 16 v -5.000001 z"
+               id="path4013"
+               sodipodi:nodetypes="ccccc"
+               inkscape:label="#rect3638"
+               inkscape:connector-curvature="0" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path4015"
+               d="m 85.75,90.362182 v 3.000001 h 14 v -3.000001 z"
+               style="fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:none;paint-order:stroke fill markers"
+               sodipodi:nodetypes="ccccc" />
+          </g>
+          <g
+             id="g4017"
+             transform="translate(340.25,203)"
+             style="paint-order:stroke fill markers">
+            <path
+               inkscape:connector-curvature="0"
+               inkscape:label="#rect3638"
+               sodipodi:nodetypes="ccccc"
+               id="path4019"
+               d="m 84.75,89.362182 v 5.000001 h 16 v -5.000001 z"
+               style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;paint-order:stroke fill markers" />
+            <path
+               sodipodi:nodetypes="ccccc"
+               style="fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:none;paint-order:stroke fill markers"
+               d="m 85.75,90.362182 v 3.000001 h 14 v -3.000001 z"
+               id="path4021"
+               inkscape:connector-curvature="0" />
+          </g>
+        </g>
+        <g
+           transform="translate(-107,1371)"
+           inkscape:label="objects"
+           id="g3078"
+           style="display:inline;paint-order:stroke fill markers">
+          <g
+             id="g3072"
+             inkscape:label="#g4081"
+             style="opacity:1;paint-order:stroke fill markers"
+             transform="translate(-21.93011,50.751613)">
+            <path
+               sodipodi:nodetypes="cccc"
+               inkscape:connector-curvature="0"
+               id="path3062"
+               d="m 392.93011,76.11057 6,12 h -12 z"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke" />
+            <path
+               sodipodi:open="true"
+               sodipodi:end="6.2821966"
+               sodipodi:start="0"
+               d="m 390.93011,88.610573 a 5.9999995,5.9999995 0 0 1 -5.99851,5.999999 5.9999995,5.9999995 0 0 1 -6.00148,-5.997033 5.9999995,5.9999995 0 0 1 5.99555,-6.002964 5.9999995,5.9999995 0 0 1 6.00444,5.994066"
+               sodipodi:ry="5.9999995"
+               sodipodi:rx="5.9999995"
+               sodipodi:cy="88.610573"
+               sodipodi:cx="384.93011"
+               id="path3064"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+               sodipodi:type="arc" />
+            <path
+               sodipodi:nodetypes="ccccc"
+               inkscape:connector-curvature="0"
+               id="path3066"
+               d="m 386.43011,87.610588 6,3 v 9.500002 l -6,-3.500002 z"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke" />
+            <path
+               sodipodi:nodetypes="ccccc"
+               inkscape:connector-curvature="0"
+               id="path3068"
+               d="m 392.43011,90.110588 8,-1.5 v 9 l -8,2.500002 z"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke" />
+            <path
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
+               d="m 386.43011,87.610588 6,3 8,-2 -6,-2.5 z"
+               id="path3070"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="ccccc" />
+          </g>
+          <path
+             style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;paint-order:stroke fill markers"
+             d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
+             id="path3074"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccccccc" />
+          <path
+             sodipodi:nodetypes="ccccccccc"
+             inkscape:connector-curvature="0"
+             id="path3076"
+             d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
+             style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;paint-order:normal" />
+        </g>
+      </g>
+      <g
+         style="paint-order:stroke fill markers"
+         inkscape:label="replaceObjects"
+         id="g2044"
+         transform="translate(68)">
+        <g
+           style="display:inline;paint-order:stroke fill markers"
+           id="g2042"
+           inkscape:label="objects"
+           transform="translate(-107,1371)">
+          <g
+             transform="translate(-21.93011,50.751613)"
+             style="opacity:0.5;paint-order:stroke fill markers"
+             inkscape:label="#g4081"
+             id="g2036">
+            <path
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
+               d="m 392.93011,76.11057 6,12 h -12 z"
+               id="path2026"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cccc" />
+            <path
+               sodipodi:type="arc"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+               id="path2028"
+               sodipodi:cx="384.93011"
+               sodipodi:cy="88.610573"
+               sodipodi:rx="5.9999995"
+               sodipodi:ry="5.9999995"
+               d="m 390.93011,88.610573 a 5.9999995,5.9999995 0 0 1 -5.99851,5.999999 5.9999995,5.9999995 0 0 1 -6.00148,-5.997033 5.9999995,5.9999995 0 0 1 5.99555,-6.002964 5.9999995,5.9999995 0 0 1 6.00444,5.994066"
+               sodipodi:start="0"
+               sodipodi:end="6.2821966"
+               sodipodi:open="true" />
+            <path
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
+               d="m 386.43011,87.610588 6,3 v 9.500002 l -6,-3.500002 z"
+               id="path2030"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="ccccc" />
+            <path
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
+               d="m 392.43011,90.110588 8,-1.5 v 9 l -8,2.500002 z"
+               id="path2032"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="ccccc" />
+            <path
+               sodipodi:nodetypes="ccccc"
+               inkscape:connector-curvature="0"
+               id="path2034"
+               d="m 386.43011,87.610588 6,3 8,-2 -6,-2.5 z"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke" />
+          </g>
+          <path
+             sodipodi:nodetypes="ccccccccc"
+             inkscape:connector-curvature="0"
+             id="path2038"
+             d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
+             style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;paint-order:stroke fill markers" />
+          <path
+             style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;paint-order:normal"
+             d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
+             id="path2040"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccccccc" />
+        </g>
+      </g>
+    </g>
+    <g
+       id="g2842"
+       inkscape:label="scene view">
+      <g
+         transform="translate(39.32094,1514.9159)"
+         inkscape:label="drawingStyles"
+         id="g30782">
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 70.21875,163.51843 -8.53969,2.42785 0.5,10.5 8,5 8,-5 0.5,-10.5 z"
+           id="path4093" />
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc"
+           id="path4100"
+           d="m 62.17906,176.44628 -0.5,-10.5 8.5,3.50004 v 11.99996 z"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc"
+           id="path4120"
+           d="m 61.67906,165.94628 8.5,3.50004 8.5,-3.50004 -8.474635,-2.43539 z"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           sodipodi:open="true"
+           sodipodi:end="6.2821966"
+           sodipodi:start="0"
+           d="m 63.179062,165.94629 a 1.5,1.5 0 0 1 -1.499629,1.5 1.5,1.5 0 0 1 -1.500371,-1.49926 1.5,1.5 0 0 1 1.498888,-1.50074 1.5,1.5 0 0 1 1.501111,1.49852"
+           sodipodi:ry="1.5"
+           sodipodi:rx="1.5"
+           sodipodi:cy="165.94629"
+           sodipodi:cx="61.679062"
+           id="path4283"
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931081"
+           sodipodi:type="arc" />
+        <path
+           inkscape:transform-center-y="0.31250001"
+           inkscape:transform-center-x="0.12500001"
+           sodipodi:type="arc"
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931081"
+           id="path4285"
+           sodipodi:cx="78.679062"
+           sodipodi:cy="165.94629"
+           sodipodi:rx="1.5"
+           sodipodi:ry="1.5"
+           d="m 80.179062,165.94629 a 1.5,1.5 0 0 1 -1.499629,1.5 1.5,1.5 0 0 1 -1.500371,-1.49926 1.5,1.5 0 0 1 1.498888,-1.50074 1.5,1.5 0 0 1 1.501111,1.49852"
+           sodipodi:start="0"
+           sodipodi:end="6.2821966"
+           sodipodi:open="true" />
+        <path
+           sodipodi:type="arc"
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931081"
+           id="path4289"
+           sodipodi:cx="78.179062"
+           sodipodi:cy="176.44629"
+           sodipodi:rx="1.5"
+           sodipodi:ry="1.5"
+           d="m 79.679062,176.44629 a 1.5,1.5 0 0 1 -1.499629,1.5 1.5,1.5 0 0 1 -1.500371,-1.49926 1.5,1.5 0 0 1 1.498888,-1.50074 1.5,1.5 0 0 1 1.501111,1.49852"
+           sodipodi:start="0"
+           sodipodi:end="6.2821966"
+           sodipodi:open="true" />
+        <path
+           sodipodi:type="arc"
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931081"
+           id="path4291"
+           sodipodi:cx="70.179062"
+           sodipodi:cy="163.44629"
+           sodipodi:rx="1.5"
+           sodipodi:ry="1.5"
+           d="m 71.679062,163.44629 a 1.5,1.5 0 0 1 -1.499629,1.5 1.5,1.5 0 0 1 -1.500371,-1.49926 1.5,1.5 0 0 1 1.498888,-1.50074 1.5,1.5 0 0 1 1.501111,1.49852"
+           sodipodi:start="0"
+           sodipodi:end="6.2821966"
+           sodipodi:open="true" />
+        <path
+           sodipodi:open="true"
+           sodipodi:end="6.2821966"
+           sodipodi:start="0"
+           d="m 71.679062,180.94629 a 1.5,1.5 0 0 1 -1.499629,1.5 1.5,1.5 0 0 1 -1.500371,-1.49926 1.5,1.5 0 0 1 1.498888,-1.50074 1.5,1.5 0 0 1 1.501111,1.49852"
+           sodipodi:ry="1.5"
+           sodipodi:rx="1.5"
+           sodipodi:cy="180.94629"
+           sodipodi:cx="70.179062"
+           id="path4297"
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931081"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:type="arc"
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931081"
+           id="path4299"
+           sodipodi:cx="62.179062"
+           sodipodi:cy="176.44629"
+           sodipodi:rx="1.5"
+           sodipodi:ry="1.5"
+           d="m 63.679062,176.44629 a 1.5,1.5 0 0 1 -1.499629,1.5 1.5,1.5 0 0 1 -1.500371,-1.49926 1.5,1.5 0 0 1 1.498888,-1.50074 1.5,1.5 0 0 1 1.501111,1.49852"
+           sodipodi:start="0"
+           sodipodi:end="6.2821966"
+           sodipodi:open="true" />
+        <path
+           sodipodi:open="true"
+           sodipodi:end="6.2821966"
+           sodipodi:start="0"
+           d="m 71.679062,169.44629 a 1.5,1.5 0 0 1 -1.499629,1.5 1.5,1.5 0 0 1 -1.500371,-1.49926 1.5,1.5 0 0 1 1.498888,-1.50074 1.5,1.5 0 0 1 1.501111,1.49852"
+           sodipodi:ry="1.5"
+           sodipodi:rx="1.5"
+           sodipodi:cy="169.44629"
+           sodipodi:cx="70.179062"
+           id="path4301"
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931081"
+           sodipodi:type="arc" />
+      </g>
+      <g
+         transform="matrix(1.1456995,0,0,1.1456995,23.579778,1490.2263)"
+         inkscape:label="expansion"
+         id="g1472">
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path3304"
+           d="m 100.21875,172.68314 7.85546,3.92773 0.87283,-10.47395 -8.72829,-2.61849 z"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path3309"
+           style="fill:#595959;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 92.363287,176.61087 7.855463,-3.92773 v -9.16471 l -8.728292,2.61849 z"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 92.363287,124.24868 7.855463,4.17322 7.85546,-4.17322 -7.85546,-3.92773 z"
+           id="path4168"
+           inkscape:connector-curvature="0"
+           transform="translate(0,52.362183)" />
+        <path
+           sodipodi:nodetypes="ccccccc"
+           style="fill:#595959;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 100.20696,167.44141 -4.788771,1.31399 0.218208,6.23255 4.582353,2.49575 4.596,-2.56394 0.20456,-6.16436 z"
+           id="path3284"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           id="path3286"
+           d="m 95.636397,174.97431 -0.218208,-6.21891 4.800561,1.93135 v 6.79695 z"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           id="path3288"
+           d="m 95.418189,168.7554 4.800561,1.87349 4.80056,-1.87349 -4.82043,-1.31824 z"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="path3246"
+           d="m 100.21875,163.51843 -8.728292,2.61849 0.872829,10.47395 7.855463,4.15958 7.85546,-4.15958 0.87283,-10.47395 z"
+           style="fill:none;stroke:#3c3c3c;stroke-width:0.87282926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         inkscape:label="cameraOff"
+         transform="matrix(1.15625,0,0,1.15625,-117.54687,1388.4278)"
+         id="group12345">
+        <path
+           sodipodi:nodetypes="sccssssssssccss"
+           inkscape:connector-curvature="0"
+           id="path5277"
+           transform="translate(0,52.362183)"
+           d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.70271,0.55404 H 243.5 c -1.662,0 -3.02703,1.36503 -3.02703,3.02703 v 6.91892 c 0,1.662 1.36502,3.02702 3.02703,3.02702 l 12.97297,-1e-5 c 1.662,0 3.02703,-1.36501 3.02703,-3.02701 v -6.91892 c -10e-6,-1.662 -1.36503,-3.02704 -3.02703,-3.02704 h -1.2973 L 254.5,200 c -0.78347,-0.78348 -0.892,-2 -2,-2 z"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486483;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <circle
+           r="4.3243241"
+           cy="258.97028"
+           cx="249.98648"
+           id="ellipse5279"
+           style="fill:#494949;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486495;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <circle
+           r="0.86486489"
+           cy="257.24054"
+           cx="248.25676"
+           id="circle5281"
+           style="fill:#818181;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <circle
+           r="0.86486489"
+           style="fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="circle5283"
+           cx="256.47296"
+           cy="255.94325" />
+      </g>
+      <g
+         transform="translate(57.28125,1513.8438)"
+         inkscape:label="selectionMaskOff"
+         id="selectionMaskOffOd">
+        <g
+           id="g4784"
+           transform="translate(188)">
+          <path
+             sodipodi:nodetypes="ccccccc"
+             style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m -9.78125,163.51843 -8.5,2.49995 0.65625,10.4688 7.84375,4.5312 7.78125,-4.4062 0.71875,-10.53125 z"
+             id="path4741"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="ccccc"
+             id="path4743"
+             d="m -17.63339,176.49782 -0.64786,-10.47944 8.5,3.5 v 11.5 z"
+             style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="ccccc"
+             id="path4745"
+             d="m -18.28125,166.01838 8.5,3.5 8.508349,-3.44562 -8.522674,-2.56187 z"
+             style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           style="stroke-width:0.98703074"
+           id="g4789"
+           transform="matrix(0.58611117,0,0,0.58607293,193.6632,75.501411)">
+          <path
+             sodipodi:open="true"
+             sodipodi:end="6.2821966"
+             sodipodi:start="0"
+             d="m -31.468918,172.36218 a 8.5310822,8.5310841 0 0 1 -8.528973,8.53109 8.5310822,8.5310841 0 0 1 -8.53319,-8.52687 8.5310822,8.5310841 0 0 1 8.524755,-8.5353 8.5310822,8.5310841 0 0 1 8.537404,8.52265"
+             sodipodi:ry="8.5310841"
+             sodipodi:rx="8.5310822"
+             sodipodi:cy="172.36218"
+             sodipodi:cx="-40"
+             id="path4780"
+             style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.70621657;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:type="arc"
+             inkscape:label="#path3352" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:#aaaaaa;fill-opacity:1;stroke:none;stroke-width:0.98703074"
+             d="m -42.555019,168.57203 c -2.092886,1.37871 -2.641656,4.33859 -3.535981,3.1401 -0.894324,-1.19849 0.405111,-3.97228 1.59811,-4.87074 1.192994,-0.89844 4.11797,-1.89376 5.012295,-0.69526 0.894325,1.19848 -1.122142,0.79291 -3.074424,2.4259 z"
+             id="path4782"
+             sodipodi:nodetypes="csssc" />
+        </g>
+        <path
+           style="display:inline;fill:#1e1e1e;fill-opacity:1;stroke:#e1e1e1;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="m 181.71879,180.03969 v -7.5214 l 4.99999,5.5001 h -2 l 1.00004,2.0213 -4e-5,1.4787 h -1.17185 l -1.32813,-2.7733 z"
+           id="path3193-0-7"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc" />
+      </g>
+      <g
+         id="g2701"
+         transform="matrix(1.15625,0,0,1.15625,-88.546872,1388.4278)"
+         inkscape:label="cameraOn">
+        <path
+           style="fill:url(#linearGradient2707);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486483;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.70271,0.55404 H 243.5 c -1.662,0 -3.02703,1.36503 -3.02703,3.02703 v 6.91892 c 0,1.662 1.36502,3.02702 3.02703,3.02702 l 12.97297,-1e-5 c 1.662,0 3.02703,-1.36501 3.02703,-3.02701 v -6.91892 c -10e-6,-1.662 -1.36503,-3.02704 -3.02703,-3.02704 h -1.2973 L 254.5,200 c -0.78347,-0.78348 -0.892,-2 -2,-2 z"
+           transform="translate(0,52.362183)"
+           id="path2693"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccssssssssccss" />
+        <circle
+           style="fill:#494949;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486495;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="circle2695"
+           cx="249.98648"
+           cy="258.97028"
+           r="4.3243241" />
+        <circle
+           style="fill:#818181;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="circle2697"
+           cx="248.25676"
+           cy="257.24054"
+           r="0.86486489" />
+        <circle
+           cy="255.94325"
+           cx="256.47296"
+           id="circle2699"
+           style="fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           r="0.86486489" />
+      </g>
+      <g
+         id="g2763"
+         inkscape:label="selectionMaskOn"
+         transform="translate(86.281247,1513.8441)">
+        <g
+           transform="translate(188)"
+           id="g2753">
+          <path
+             inkscape:connector-curvature="0"
+             id="path2747"
+             d="m -9.78125,163.51843 -8.5,2.49995 0.65625,10.4688 7.84375,4.5312 7.78125,-4.4062 0.71875,-10.53125 z"
+             style="fill:url(#linearGradient2787);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="ccccccc" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:url(#linearGradient2781);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m -17.63339,176.49782 -0.64786,-10.47944 8.5,3.5 v 11.5 z"
+             id="path2749"
+             sodipodi:nodetypes="ccccc" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:url(#linearGradient2775);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m -18.28125,166.01838 8.5,3.5 8.508349,-3.44562 -8.522674,-2.56187 z"
+             id="path2751"
+             sodipodi:nodetypes="ccccc" />
+        </g>
+        <g
+           transform="matrix(0.58611117,0,0,0.58607293,193.6632,75.501411)"
+           id="g2759"
+           style="stroke-width:0.98703074">
+          <path
+             inkscape:label="#path3352"
+             sodipodi:type="arc"
+             style="fill:url(#linearGradient2769);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.70621657;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path2755"
+             sodipodi:cx="-40"
+             sodipodi:cy="172.36218"
+             sodipodi:rx="8.5310822"
+             sodipodi:ry="8.5310841"
+             d="m -31.468918,172.36218 a 8.5310822,8.5310841 0 0 1 -8.528973,8.53109 8.5310822,8.5310841 0 0 1 -8.53319,-8.52687 8.5310822,8.5310841 0 0 1 8.524755,-8.5353 8.5310822,8.5310841 0 0 1 8.537404,8.52265"
+             sodipodi:start="0"
+             sodipodi:end="6.2821966"
+             sodipodi:open="true" />
+          <path
+             sodipodi:nodetypes="csssc"
+             id="path2757"
+             d="m -42.555019,168.57203 c -2.092886,1.37871 -2.641656,4.33859 -3.535981,3.1401 -0.894324,-1.19849 0.405111,-3.97228 1.59811,-4.87074 1.192994,-0.89844 4.11797,-1.89376 5.012295,-0.69526 0.894325,1.19848 -1.122142,0.79291 -3.074424,2.4259 z"
+             style="fill:#f4f4f4;fill-opacity:1;stroke:none;stroke-width:0.98703074"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path2761"
+           d="m 181.71879,180.03969 v -7.5214 l 4.99999,5.5001 h -2 l 1.00004,2.0213 -4e-5,1.4787 h -1.17185 l -1.32813,-2.7733 z"
+           style="display:inline;fill:#1e1e1e;fill-opacity:1;stroke:#e1e1e1;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers" />
+      </g>
+      <g
+         id="g7588"
+         inkscape:label="shading">
+        <path
+           transform="scale(1,-1)"
+           sodipodi:open="true"
+           sodipodi:end="6.2821966"
+           sodipodi:start="0"
+           d="m 60.5,-1686.8622 a 9,9 0 0 1 -8.997775,9 9,9 0 0 1 -9.002224,-8.9955 9,9 0 0 1 8.993325,-9.0045 9,9 0 0 1 9.00667,8.9911"
+           sodipodi:ry="9"
+           sodipodi:rx="9"
+           sodipodi:cy="-1686.8622"
+           sodipodi:cx="51.5"
+           id="path3352"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           sodipodi:type="arc"
+           inkscape:label="shading"
+           inkscape:transform-center-x="0.03124999"
+           inkscape:transform-center-y="0.59375002" />
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="csssc"
+           id="path3163"
+           d="m 48.687871,1683.0928 c -2.092886,1.3787 -2.641656,4.3386 -3.535981,3.1401 -0.894324,-1.1985 0.405111,-3.9723 1.59811,-4.8707 1.192994,-0.8985 4.11797,-1.8938 5.012295,-0.6953 0.894325,1.1985 -1.122142,0.7929 -3.074424,2.4259 z"
+           style="fill:#aaaaaa;fill-opacity:1;stroke:none" />
+      </g>
+    </g>
+    <g
+       id="g3149"
+       inkscape:label="image view">
+      <g
+         transform="translate(-82,1570)"
+         inkscape:label="gammaOff"
+         id="g12343">
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path4073"
+           d="m 204.5,183.86218 v 18 h -18 z"
+           style="fill:#565656;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+        <g
+           style="fill:url(#linearGradient3016);fill-opacity:1"
+           id="g4083">
+          <g
+             style="fill:url(#linearGradient3016);fill-opacity:1;stroke:#424242;stroke-width:0.84210503;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="matrix(1.1875,0,0,1.1875007,-37.15625,-35.474284)"
+             id="g4052">
+            <path
+               sodipodi:nodetypes="cccc"
+               inkscape:connector-curvature="0"
+               id="path4041"
+               d="m 203.5,184.70428 v 15.15789 h -15.15789 c 9.30458,-2.50716 12.79805,-4.98879 15.15789,-15.15789 z"
+               style="fill:url(#linearGradient3016);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.84210503;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          </g>
+        </g>
+      </g>
+      <g
+         id="g2346"
+         transform="translate(-10.756168,1590.2548)"
+         inkscape:label="exposureOn">
+        <path
+           sodipodi:type="arc"
+           style="fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:9.02981281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path3268"
+           sodipodi:cx="187.11813"
+           sodipodi:cy="174.54121"
+           sodipodi:rx="33.499184"
+           sodipodi:ry="33.499184"
+           d="m 220.61732,174.54121 a 33.499184,33.499184 0 0 1 -33.49091,33.49919 33.499184,33.499184 0 0 1 -33.50746,-33.48263 33.499184,33.499184 0 0 1 33.47434,-33.51573 33.499184,33.499184 0 0 1 33.52401,33.46605"
+           transform="matrix(0.11101843,0,0,0.11047078,70.600104,153.24998)"
+           sodipodi:start="0"
+           sodipodi:end="6.2821966"
+           sodipodi:open="true" />
+        <g
+           clip-path="url(#clipPath2950)"
+           transform="matrix(1.2656733,0,0,1.2656392,-25.214957,-45.037563)"
+           id="g3270">
+          <path
+             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+             inkscape:transform-center-x="1.2504885"
+             d="m 99.597353,169.77492 v 8.58228 l -7.502966,-4.29114 z"
+             id="path3272"
+             inkscape:connector-curvature="0" />
+          <path
+             transform="matrix(0.13558531,-0.23263436,0.23484065,0.13431151,26.907388,209.48587)"
+             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2.9274621;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+             inkscape:transform-center-x="-1.25049"
+             d="m 268.97293,130.27541 v 31.94918 l -27.6688,-15.97459 6.9172,-3.99365 6.9172,-3.99365 6.9172,-3.99364 z"
+             id="path3274"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccccc" />
+          <path
+             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+             inkscape:transform-center-x="1.2504999"
+             d="m 86.467162,166.55658 7.502966,-4.29115 v 8.58229 l -1.875741,-1.07279 -1.875742,-1.07278 -1.875741,-1.07279 z"
+             id="path3276"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccccc" />
+          <path
+             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+             inkscape:transform-center-x="-1.2505016"
+             d="m 84.591421,174.06607 v -8.58228 l 7.502966,4.29114 -1.875741,1.07278 -1.875742,1.07279 -1.875742,1.07279 z"
+             id="path3278"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccccc" />
+          <path
+             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+             inkscape:transform-center-x="1.2504858"
+             d="m 90.218646,179.42999 -7.502966,-4.29114 7.502966,-4.29114 v 2.14557 2.14557 2.14557 z"
+             id="path3280"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccccc" />
+          <path
+             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+             inkscape:transform-center-x="-1.2504877"
+             d="m 97.721612,177.28442 -7.502966,4.29114 v -8.58228 l 1.875741,1.07278 1.875742,1.07279 1.875741,1.07278 z"
+             id="path3282"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccccc" />
+        </g>
+        <path
+           inkscape:label="outline"
+           sodipodi:open="true"
+           sodipodi:end="6.2821966"
+           sodipodi:start="0"
+           d="m 100.25616,172.60736 a 9,9 0 0 1 -8.997771,9 9,9 0 0 1 -9.002223,-8.99555 9,9 0 0 1 8.993325,-9.00445 9,9 0 0 1 9.006669,8.9911"
+           sodipodi:ry="9"
+           sodipodi:rx="9"
+           sodipodi:cy="172.60736"
+           sodipodi:cx="91.256165"
+           id="path3285"
+           style="fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           sodipodi:type="arc" />
+      </g>
+      <g
+         inkscape:label="exposureOn"
+         transform="translate(-39.756165,1590.2548)"
+         id="g2972">
+        <path
+           sodipodi:open="true"
+           sodipodi:end="6.2821966"
+           sodipodi:start="0"
+           transform="matrix(0.11101843,0,0,0.11047078,70.600104,153.24998)"
+           d="m 220.61732,174.54121 a 33.499184,33.499184 0 0 1 -33.49091,33.49919 33.499184,33.499184 0 0 1 -33.50746,-33.48263 33.499184,33.499184 0 0 1 33.47434,-33.51573 33.499184,33.499184 0 0 1 33.52401,33.46605"
+           sodipodi:ry="33.499184"
+           sodipodi:rx="33.499184"
+           sodipodi:cy="174.54121"
+           sodipodi:cx="187.11813"
+           id="path2954"
+           style="fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:9.02981281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           sodipodi:type="arc" />
+        <g
+           id="g2968"
+           transform="matrix(1.2656733,0,0,1.2656392,-25.214957,-45.037563)"
+           clip-path="url(#clipPath2950)">
+          <path
+             inkscape:connector-curvature="0"
+             id="path2956"
+             d="m 99.597353,169.77492 v 8.58228 l -7.502966,-4.29114 z"
+             inkscape:transform-center-x="1.2504885"
+             style="fill:url(#linearGradient2974);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="ccccccc"
+             inkscape:connector-curvature="0"
+             id="path2958"
+             d="m 268.97293,130.27541 v 31.94918 l -27.6688,-15.97459 6.9172,-3.99365 6.9172,-3.99365 6.9172,-3.99364 z"
+             inkscape:transform-center-x="-1.25049"
+             style="fill:url(#linearGradient2976);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2.9274621;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+             transform="matrix(0.13558531,-0.23263436,0.23484065,0.13431151,26.907388,209.48587)" />
+          <path
+             sodipodi:nodetypes="ccccccc"
+             inkscape:connector-curvature="0"
+             id="path2960"
+             d="m 86.467162,166.55658 7.502966,-4.29115 v 8.58229 l -1.875741,-1.07279 -1.875742,-1.07278 -1.875741,-1.07279 z"
+             inkscape:transform-center-x="1.2504999"
+             style="fill:url(#linearGradient2978);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="ccccccc"
+             inkscape:connector-curvature="0"
+             id="path2962"
+             d="m 84.591421,174.06607 v -8.58228 l 7.502966,4.29114 -1.875741,1.07278 -1.875742,1.07279 -1.875742,1.07279 z"
+             inkscape:transform-center-x="-1.2505016"
+             style="fill:url(#linearGradient2980);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="ccccccc"
+             inkscape:connector-curvature="0"
+             id="path2964"
+             d="m 90.218646,179.42999 -7.502966,-4.29114 7.502966,-4.29114 v 2.14557 2.14557 2.14557 z"
+             inkscape:transform-center-x="1.2504858"
+             style="fill:url(#linearGradient2982);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="ccccccc"
+             inkscape:connector-curvature="0"
+             id="path2966"
+             d="m 97.721612,177.28442 -7.502966,4.29114 v -8.58228 l 1.875741,1.07278 1.875742,1.07279 1.875741,1.07278 z"
+             inkscape:transform-center-x="-1.2504877"
+             style="fill:url(#linearGradient2984);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+        </g>
+        <path
+           sodipodi:type="arc"
+           style="fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path2970"
+           sodipodi:cx="91.256165"
+           sodipodi:cy="172.60736"
+           sodipodi:rx="9"
+           sodipodi:ry="9"
+           d="m 100.25616,172.60736 a 9,9 0 0 1 -8.997771,9 9,9 0 0 1 -9.002223,-8.99555 9,9 0 0 1 8.993325,-9.00445 9,9 0 0 1 9.006669,8.9911"
+           sodipodi:start="0"
+           sodipodi:end="6.2821966"
+           sodipodi:open="true"
+           inkscape:label="outline" />
+      </g>
+      <g
+         id="g2998"
+         inkscape:label="gammaOn"
+         transform="translate(-53,1570)">
+        <path
+           style="fill:#565656;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+           d="m 204.5,183.86218 v 18 h -18 z"
+           id="path2990"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccc" />
+        <g
+           id="g2996">
+          <g
+             id="g2994"
+             transform="matrix(1.1875,0,0,1.1875007,-37.15625,-35.474284)"
+             style="fill:url(#linearGradient3004);fill-opacity:1;stroke:#424242;stroke-width:0.84210503;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+            <path
+               style="fill:url(#linearGradient3010);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.84210503;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 203.5,184.70428 v 15.15789 h -15.15789 c 9.30458,-2.50716 12.79805,-4.98879 15.15789,-15.15789 z"
+               id="path2992"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cccc" />
+          </g>
+        </g>
+      </g>
+      <g
+         inkscape:label="clippingOff"
+         transform="translate(-45,1570)"
+         id="g4345">
+        <path
+           style="fill:url(#linearGradient3034);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+           d="m 229.5,183.86218 v 18 h -18 z"
+           id="path3251"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccc" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path4071"
+           d="m 229.5,183.86218 v 7 h -7 z"
+           style="fill:#565656;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      </g>
+      <g
+         transform="translate(-65,1569.9707)"
+         inkscape:label="soloChannel-1"
+         id="g4322">
+        <rect
+           y="183.89148"
+           x="290.5"
+           height="17.969265"
+           width="6"
+           id="rect4860"
+           style="fill:#823631;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           style="fill:#449645;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4862"
+           width="6"
+           height="17.969296"
+           x="296.5"
+           y="183.89148" />
+        <rect
+           y="183.89148"
+           x="302.5"
+           height="17.969296"
+           width="6"
+           id="rect4864"
+           style="fill:#4a5ebd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4866"
+           width="6"
+           height="17.969265"
+           x="308.5"
+           y="183.89148" />
+      </g>
+      <g
+         id="g3026"
+         transform="translate(-16,1570)"
+         inkscape:label="clippingOn">
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path3022"
+           d="m 229.5,183.86218 v 18 h -18 z"
+           style="fill:url(#linearGradient3036);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           style="fill:#565656;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+           d="m 229.5,183.86218 v 7 h -7 z"
+           id="path3024"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccc" />
+      </g>
+      <g
+         id="g3050"
+         inkscape:label="soloChannel0"
+         transform="translate(-36,1569.9707)">
+        <rect
+           style="fill:#823631;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3042"
+           width="6"
+           height="17.969265"
+           x="290.5"
+           y="183.89148" />
+        <rect
+           y="183.89148"
+           x="296.5"
+           height="17.969296"
+           width="6"
+           id="rect3044"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3046"
+           width="6"
+           height="17.969296"
+           x="302.5"
+           y="183.89148" />
+        <rect
+           y="183.89148"
+           x="308.5"
+           height="17.969265"
+           width="6"
+           id="rect3048"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         transform="translate(-7,1569.9707)"
+         inkscape:label="soloChannel1"
+         id="g3062">
+        <rect
+           y="183.89148"
+           x="290.5"
+           height="17.969265"
+           width="6"
+           id="rect3054"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           style="fill:#449645;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3056"
+           width="6"
+           height="17.969296"
+           x="296.5"
+           y="183.89148" />
+        <rect
+           y="183.89148"
+           x="302.5"
+           height="17.969296"
+           width="6"
+           id="rect3058"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3060"
+           width="6"
+           height="17.969265"
+           x="308.5"
+           y="183.89148" />
+      </g>
+      <g
+         id="g3074"
+         inkscape:label="soloChannel2"
+         transform="translate(22,1569.9707)">
+        <rect
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3066"
+           width="6"
+           height="17.969265"
+           x="290.5"
+           y="183.89148" />
+        <rect
+           y="183.89148"
+           x="296.5"
+           height="17.969296"
+           width="6"
+           id="rect3068"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           style="fill:#4a5ebd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3070"
+           width="6"
+           height="17.969296"
+           x="302.5"
+           y="183.89148" />
+        <rect
+           y="183.89148"
+           x="308.5"
+           height="17.969265"
+           width="6"
+           id="rect3072"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         transform="translate(51,1569.9861)"
+         inkscape:label="soloChannel3"
+         id="g3086">
+        <rect
+           y="183.89148"
+           x="290.5"
+           height="17.969265"
+           width="6"
+           id="rect3078"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3080"
+           width="6"
+           height="17.969296"
+           x="296.5"
+           y="183.89148" />
+        <rect
+           y="183.89148"
+           x="302.5"
+           height="17.969296"
+           width="6"
+           id="rect3082"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3084"
+           width="6"
+           height="17.969265"
+           x="308.5"
+           y="183.89148" />
+      </g>
+    </g>
+    <g
+       id="g3406"
+       inkscape:label="browserIcons">
+      <path
+         inkscape:connector-curvature="0"
+         inkscape:label="pathChooser"
+         sodipodi:nodetypes="cccccccc"
+         id="p3423"
+         d="m 31,1904.8622 h 3.5 c 1,0 1,2 1,2 h 5 v 8 h -11 v -8 c 0,0 0.3125,-2.125 1.5,-2 z"
+         style="fill:url(#backgroundLighter);fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#backgroundLighter);fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686"
+         d="m 50,1915.3622 v -4.5 h -3 l 6,-7 6,7 h -3 v 4.5"
+         id="rect2859"
+         sodipodi:nodetypes="ccccccc"
+         inkscape:label="pathUpArrow" />
+      <g
+         transform="translate(-143,1851)"
+         inkscape:label="list"
+         id="56789">
+        <rect
+           style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3246"
+           width="11"
+           height="2"
+           x="226.5"
+           y="53.862183" />
+        <rect
+           y="57.862183"
+           x="226.5"
+           height="2"
+           width="11"
+           id="rect3248"
+           style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3250"
+           width="11"
+           height="2"
+           x="226.5"
+           y="61.862183" />
+      </g>
+      <path
+         inkscape:label="tree"
+         sodipodi:nodetypes="ccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="rect3268"
+         d="m 101.5,1904.8624 h 5 v 4 l 3,2e-4 v 3.9686 l 3,0.031 v 1.9688 h -5 v -3.9686 l -3,-2e-4 v -4 h -3 z"
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
+      <path
+         inkscape:label="bookmarks"
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0"
+         id="3604"
+         d="m 302.30329,18.508217 -3.42247,-2.655261 -3.42248,2.655261 1.28343,-3.982892 -3.42248,-2.655261 h 4.2781 l 1.28343,-3.9828915 1.28342,3.9828915 h 4.2781 l -3.42248,2.655261 z"
+         style="fill:url(#backgroundLighter);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.87022853;stroke-linejoin:round;stroke-opacity:1"
+         transform="matrix(1.1687441,0,0,1.1298324,-224.31519,1894.451)" />
+      <path
+         inkscape:label="refresh"
+         inkscape:connector-curvature="0"
+         id="circle3363"
+         d="m 70,1904.3622 a 5,5 0 0 0 -5,5 5,5 0 0 0 5,5 v -2 a 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 3,3 0 0 1 3,3 h -2 l 3,4.5 3,-4.5 h -2 a 5,5 0 0 0 -5,-5 z"
+         style="opacity:1;fill:#9f9f9f;fill-opacity:0.97647059;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
+    </g>
+    <g
+       id="g2000"
+       inkscape:label="controls-checkBox">
+      <g
+         transform="translate(27.971946,-1.7e-5)"
+         id="g1845">
+        <g
+           id="g5812"
+           transform="matrix(0.99838132,0,0,0.99992227,-74.831121,1917.0046)"
+           style="stroke-width:1.00084925">
+          <rect
+             style="fill:url(#linearGradient5742);fill-opacity:1;stroke-width:1.00084925"
+             ry="2"
+             rx="2"
+             y="59.362183"
+             x="87"
+             height="16"
+             width="16"
+             id="rect5736" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path5796"
+             d="M 89.504053,74.863419 H 101.0227 c 0.87409,0 1.50243,-0.579195 1.50243,-1.500116 V 61.862409"
+             style="fill:none;stroke:url(#linearGradient1847);stroke-width:1.00242543;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <path
+           style="fill:url(#linearGradient5784);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 15.646247,1992.8061 c -0.407839,-0.102 -0.652607,-0.3355 -1.238876,-1.1815 -0.620662,-0.8957 -1.262438,-1.7064 -1.914532,-2.4183 -0.496172,-0.5416 -0.865209,-1.079 -0.947644,-1.3798 -0.180586,-0.6589 0.376927,-1.4515 1.368445,-1.9456 0.44508,-0.2218 0.518292,-0.2397 0.98176,-0.2397 0.470009,0 0.532945,0.016 1.023045,0.2601 0.562407,0.2801 1.298583,0.8974 1.723594,1.4449 0.129065,0.1662 0.251534,0.3023 0.272143,0.3023 0.02058,0 0.155261,-0.2552 0.299241,-0.5671 0.317988,-0.6889 1.634406,-3.1097 2.184199,-4.0165 2.038801,-3.3635 4.291526,-6.1556 5.371174,-6.6575 0.403951,-0.1877 1.265682,-0.3556 2.257968,-0.4399 0.692795,-0.058 0.773381,-0.054 1.017219,0.05 0.174182,0.076 0.300853,0.1835 0.370073,0.3151 0.120856,0.2295 0.131909,0.6315 0.02307,0.8378 -0.04104,0.077 -0.491449,0.559 -1.001014,1.0698 -1.395263,1.3987 -2.172852,2.3393 -3.408058,4.122 -1.648424,2.3793 -3.015124,4.8368 -4.210168,7.5702 -0.916834,2.0971 -0.928827,2.1216 -1.165927,2.3795 -0.118599,0.1289 -0.359481,0.2965 -0.53531,0.3724 -0.283019,0.1223 -0.431569,0.14 -1.295489,0.1544 -0.536699,0.01 -1.065407,-0.01 -1.174908,-0.034 z"
+           id="path3923"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         inkscape:label="checkBoxUnchecked"
+         id="g5812-5"
+         transform="matrix(0.99838132,0,0,0.99992227,-22.859175,1917.0046)"
+         style="display:inline;stroke-width:1.00084925">
+        <rect
+           style="fill:url(#linearGradient5742-3);fill-opacity:1;stroke-width:1.00084925"
+           ry="2"
+           rx="2"
+           y="59.362183"
+           x="87"
+           height="16"
+           width="16"
+           id="rect5736-2" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path5796-2"
+           d="M 89.504053,74.863419 H 101.0227 c 0.87409,0 1.50243,-0.579195 1.50243,-1.500116 V 61.862409"
+           style="fill:none;stroke:url(#linearGradient1904);stroke-width:1.00242543;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         id="g1918"
+         transform="translate(103.98811,-0.06748539)">
+        <g
+           style="fill:url(#linearGradient1976);fill-opacity:1;stroke-width:1.00084925"
+           transform="matrix(0.99838132,0,0,0.99992227,-74.347282,1916.5721)"
+           id="g1914">
+          <rect
+             id="rect1910"
+             width="16"
+             height="16"
+             x="87"
+             y="59.362183"
+             rx="2"
+             ry="2"
+             style="fill:url(#linearGradient6485);fill-opacity:1;stroke-width:1.00084925" />
+          <path
+             style="fill:url(#linearGradient6487);fill-opacity:1;stroke:url(#linearGradient1928);stroke-width:1.00242543;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="M 89.504053,74.863419 H 101.0227 c 0.87409,0 1.50243,-0.579195 1.50243,-1.500116 V 61.862409"
+             id="path1912"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cccc" />
+        </g>
+        <path
+           inkscape:connector-curvature="0"
+           id="path1916"
+           d="m 15.646247,1992.8061 c -0.407839,-0.102 -0.652607,-0.3355 -1.238876,-1.1815 -0.620662,-0.8957 -1.262438,-1.7064 -1.914532,-2.4183 -0.496172,-0.5416 -0.865209,-1.079 -0.947644,-1.3798 -0.180586,-0.6589 0.376927,-1.4515 1.368445,-1.9456 0.44508,-0.2218 0.518292,-0.2397 0.98176,-0.2397 0.470009,0 0.532945,0.016 1.023045,0.2601 0.562407,0.2801 1.298583,0.8974 1.723594,1.4449 0.129065,0.1662 0.251534,0.3023 0.272143,0.3023 0.02058,0 0.155261,-0.2552 0.299241,-0.5671 0.317988,-0.6889 1.634406,-3.1097 2.184199,-4.0165 2.038801,-3.3635 4.291526,-6.1556 5.371174,-6.6575 0.403951,-0.1877 1.265682,-0.3556 2.257968,-0.4399 0.692795,-0.058 0.773381,-0.054 1.017219,0.05 0.174182,0.076 0.300853,0.1835 0.370073,0.3151 0.120856,0.2295 0.131909,0.6315 0.02307,0.8378 -0.04104,0.077 -0.491449,0.559 -1.001014,1.0698 -1.395263,1.3987 -2.172852,2.3393 -3.408058,4.122 -1.648424,2.3793 -3.015124,4.8368 -4.210168,7.5702 -0.916834,2.0971 -0.928827,2.1216 -1.165927,2.3795 -0.118599,0.1289 -0.359481,0.2965 -0.53531,0.3724 -0.283019,0.1223 -0.431569,0.14 -1.295489,0.1544 -0.536699,0.01 -1.065407,-0.01 -1.174908,-0.034 z"
+           style="fill:url(#linearGradient1930);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline;stroke-width:1.00084925"
+         transform="matrix(0.99838132,0,0,0.99992227,53.156979,1916.9371)"
+         id="g1924"
+         inkscape:label="checkBoxUnchecked">
+        <rect
+           id="rect1920"
+           width="16"
+           height="16"
+           x="87"
+           y="59.362183"
+           rx="2"
+           ry="2"
+           style="fill:url(#linearGradient1932);fill-opacity:1;stroke-width:1.00084925" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:1.00242543;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.11764706"
+           d="M 89.504053,74.863419 H 101.0227 c 0.87409,0 1.50243,-0.579195 1.50243,-1.500116 V 61.862409"
+           id="path1922"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccc" />
+      </g>
+      <g
+         transform="translate(179.97195,1.4605267e-5)"
+         id="g1948">
+        <g
+           id="g1944"
+           transform="matrix(0.99838132,0,0,0.99992227,-74.831121,1917.0046)"
+           style="fill:#000000;fill-opacity:0.11764706;stroke-width:1.00084925">
+          <rect
+             style="fill:#000000;fill-opacity:0.11764706;stroke-width:1.00084925"
+             ry="2"
+             rx="2"
+             y="59.362183"
+             x="87"
+             height="16"
+             width="16"
+             id="rect1940" />
+        </g>
+        <path
+           style="fill:#666666;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 15.646247,1992.8061 c -0.407839,-0.102 -0.652607,-0.3355 -1.238876,-1.1815 -0.620662,-0.8957 -1.262438,-1.7064 -1.914532,-2.4183 -0.496172,-0.5416 -0.865209,-1.079 -0.947644,-1.3798 -0.180586,-0.6589 0.376927,-1.4515 1.368445,-1.9456 0.44508,-0.2218 0.518292,-0.2397 0.98176,-0.2397 0.470009,0 0.532945,0.016 1.023045,0.2601 0.562407,0.2801 1.298583,0.8974 1.723594,1.4449 0.129065,0.1662 0.251534,0.3023 0.272143,0.3023 0.02058,0 0.155261,-0.2552 0.299241,-0.5671 0.317988,-0.6889 1.634406,-3.1097 2.184199,-4.0165 2.038801,-3.3635 4.291526,-6.1556 5.371174,-6.6575 0.403951,-0.1877 1.265682,-0.3556 2.257968,-0.4399 0.692795,-0.058 0.773381,-0.054 1.017219,0.05 0.174182,0.076 0.300853,0.1835 0.370073,0.3151 0.120856,0.2295 0.131909,0.6315 0.02307,0.8378 -0.04104,0.077 -0.491449,0.559 -1.001014,1.0698 -1.395263,1.3987 -2.172852,2.3393 -3.408058,4.122 -1.648424,2.3793 -3.015124,4.8368 -4.210168,7.5702 -0.916834,2.0971 -0.928827,2.1216 -1.165927,2.3795 -0.118599,0.1289 -0.359481,0.2965 -0.53531,0.3724 -0.283019,0.1223 -0.431569,0.14 -1.295489,0.1544 -0.536699,0.01 -1.065407,-0.01 -1.174908,-0.034 z"
+           id="path1946"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         inkscape:label="checkBoxUnchecked"
+         id="g1954"
+         transform="matrix(0.99838132,0,0,0.99992227,129.14083,1917.0046)"
+         style="display:inline;stroke-width:1.00084925">
+        <rect
+           style="fill:#000000;fill-opacity:0.11764706;stroke-width:1.00084925"
+           ry="2"
+           rx="2"
+           y="59.362183"
+           x="87"
+           height="16"
+           width="16"
+           id="rect1950" />
+      </g>
+      <g
+         style="display:inline;stroke-width:1.00084925"
+         transform="matrix(0.99838132,0,0,0.99992227,1.166724,1917.0046)"
+         id="g6499"
+         inkscape:label="checkBoxUnchecked">
+        <rect
+           id="rect6495"
+           width="16"
+           height="16"
+           x="87"
+           y="59.362183"
+           rx="2"
+           ry="2"
+           style="fill:url(#linearGradient6501);fill-opacity:1;stroke-width:1.00084925" />
+        <path
+           style="fill:none;stroke:url(#linearGradient6503);stroke-width:1.00242543;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 89.504053,74.863419 H 101.0227 c 0.87409,0 1.50243,-0.579195 1.50243,-1.500116 V 61.862409"
+           id="path6497"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccc" />
+        <rect
+           style="display:inline;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00084913;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+           id="rect1642"
+           width="11.017835"
+           height="3.0002327"
+           x="89.478111"
+           y="65.862701"
+           rx="1.0016212"
+           ry="1.0000777" />
+      </g>
+      <g
+         inkscape:label="checkBoxUnchecked"
+         id="g6509"
+         transform="matrix(0.99838132,0,0,0.99992227,77.140825,1917.0046)"
+         style="display:inline;stroke-width:1.00084925">
+        <rect
+           style="fill:url(#linearGradient6511);fill-opacity:1;stroke-width:1.00084925"
+           ry="2"
+           rx="2"
+           y="59.362183"
+           x="87"
+           height="16"
+           width="16"
+           id="rect6505" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path6507"
+           d="M 89.504053,74.863419 H 101.0227 c 0.87409,0 1.50243,-0.579195 1.50243,-1.500116 V 61.862409"
+           style="fill:none;stroke:#000000;stroke-width:1.00242543;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.11764706" />
+        <rect
+           style="display:inline;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00084913;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+           id="rect1642-9"
+           width="11.017835"
+           height="3.0002327"
+           x="89.504051"
+           y="65.862701"
+           rx="1.0016212"
+           ry="1.0000777" />
+      </g>
+      <g
+         style="display:inline;stroke-width:1.00084925"
+         transform="matrix(0.99838132,0,0,0.99992227,153.14083,1917.0046)"
+         id="g6515"
+         inkscape:label="checkBoxUnchecked">
+        <rect
+           id="rect6513"
+           width="16"
+           height="16"
+           x="87"
+           y="59.362183"
+           rx="2"
+           ry="2"
+           style="fill:#000000;fill-opacity:0.11764706;stroke-width:1.00084925" />
+        <rect
+           style="display:inline;opacity:1;fill:#666666;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.00084913;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+           id="rect1642-99"
+           width="11.017835"
+           height="3.0002327"
+           x="89.504051"
+           y="65.862701"
+           rx="1.0016212"
+           ry="1.0000777" />
+      </g>
+    </g>
+    <g
+       id="g2612"
+       inkscape:label="controls-switch">
+      <g
+         transform="matrix(-1,0,0,1,222,1939)"
+         id="g3938"
+         inkscape:label="toggleOn">
+        <rect
+           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3875-8"
+           width="15"
+           height="15"
+           x="172.5"
+           y="109.86218"
+           rx="2.5"
+           ry="2.5" />
+        <rect
+           style="opacity:0.98999999;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3875-3-9"
+           width="8"
+           height="15"
+           x="172.5"
+           y="109.86218"
+           rx="2.5"
+           ry="2.5" />
+      </g>
+      <g
+         id="g2080"
+         transform="matrix(-1,0,0,1,242,1939)"
+         inkscape:label="toggleOff">
+        <rect
+           ry="2.5"
+           rx="2.5"
+           y="109.86218"
+           x="172.5"
+           height="15"
+           width="15"
+           id="rect2076"
+           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           ry="2.5"
+           rx="2.5"
+           y="109.86218"
+           x="179.5"
+           height="15"
+           width="8"
+           id="rect2078"
+           style="opacity:0.98999999;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         inkscape:label="toglleOnHover"
+         id="g2092"
+         transform="matrix(-1,0,0,1,289.5,1913.5)">
+        <rect
+           ry="2.5"
+           rx="2.5"
+           y="135.36218"
+           x="176"
+           height="15"
+           width="15"
+           id="rect2088"
+           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           ry="2.5"
+           rx="2.5"
+           y="135.36218"
+           x="176"
+           height="15"
+           width="8"
+           id="rect2090"
+           style="opacity:0.98999999;fill:url(#linearGradient2112);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         inkscape:label="toggleOffHover"
+         transform="matrix(-1,0,0,1,306,1939)"
+         id="g2098">
+        <rect
+           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect2094"
+           width="15"
+           height="15"
+           x="172.5"
+           y="109.86218"
+           rx="2.5"
+           ry="2.5" />
+        <rect
+           style="opacity:0.98999999;fill:url(#linearGradient2114);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect2096"
+           width="8"
+           height="15"
+           x="179.5"
+           y="109.86218"
+           rx="2.5"
+           ry="2.5" />
+      </g>
+      <g
+         inkscape:label="toggleOnDisabled"
+         transform="matrix(-1,0,0,1,350,1939)"
+         id="234234234">
+        <rect
+           style="fill:#000000;fill-opacity:0.11764706;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect2100"
+           width="15"
+           height="15"
+           x="172.5"
+           y="109.86218"
+           rx="2.5"
+           ry="2.5" />
+        <rect
+           style="opacity:0.98999999;fill:#787878;fill-opacity:0.50196078;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect2102"
+           width="8"
+           height="15"
+           x="172.5"
+           y="109.86218"
+           rx="2.5"
+           ry="2.5" />
+      </g>
+      <g
+         inkscape:label="toggleOffDisabled"
+         id="23423423"
+         transform="matrix(-1,0,0,1,370,1939)">
+        <rect
+           ry="2.5"
+           rx="2.5"
+           y="109.86218"
+           x="172.5"
+           height="15"
+           width="15"
+           id="rect2106"
+           style="fill:#000000;fill-opacity:0.11764706;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           ry="2.5"
+           rx="2.5"
+           y="109.86218"
+           x="179.5"
+           height="15"
+           width="8"
+           id="rect2108"
+           style="opacity:0.98999999;fill:#787878;fill-opacity:0.50196078;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         inkscape:label="toggleIndeterminate"
+         transform="matrix(-1,0,0,1,262,1939)"
+         id="g6469">
+        <rect
+           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect6465"
+           width="15"
+           height="15"
+           x="172.5"
+           y="109.86218"
+           rx="2.5"
+           ry="2.5" />
+        <rect
+           style="opacity:0.98999999;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect6467"
+           width="7"
+           height="11"
+           x="176.5"
+           y="111.86218"
+           rx="2.5"
+           ry="2.5" />
+      </g>
+      <g
+         inkscape:label="togleIndeterminateHover"
+         id="g6475"
+         transform="matrix(-1,0,0,1,326,1939)">
+        <rect
+           ry="2.5"
+           rx="2.5"
+           y="109.86218"
+           x="172.5"
+           height="15"
+           width="15"
+           id="rect6471"
+           style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           ry="2.5"
+           rx="2.5"
+           y="111.86218"
+           x="176.5"
+           height="11"
+           width="7"
+           id="rect6473"
+           style="opacity:0.98999999;fill:url(#linearGradient6477);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         transform="matrix(-1,0,0,1,390,1939)"
+         id="g6483"
+         inkscape:label="toggleIndeterminateDisabled">
+        <rect
+           style="fill:#000000;fill-opacity:0.11764706;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect6479"
+           width="15"
+           height="15"
+           x="172.5"
+           y="109.86218"
+           rx="2.5"
+           ry="2.5" />
+        <rect
+           style="opacity:0.98999999;fill:#787878;fill-opacity:0.50196078;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect6481"
+           width="7"
+           height="11"
+           x="176.5"
+           y="111.86218"
+           rx="2.5"
+           ry="2.5" />
+      </g>
+    </g>
+    <g
+       style="clip-rule:evenodd;fill:url(#foreground);fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5"
+       transform="matrix(0.74882855,0,0,0.74882855,-681.66109,1856.9401)"
+       id="sdfsf"
+       inkscape:label="nodeSetStandardSet">
+      <g
+         id="g1179"
+         transform="rotate(-45,1063.0797,502.31281)"
+         style="fill:url(#foreground)">
+        <path
+           id="path1177"
+           style="fill:url(#foreground);stroke:url(#linearGradient1596);stroke-width:1.33541918;stroke-miterlimit:1.5;stroke-dasharray:none"
+           d="m 1099.5,342.135 1,-1.613 h 5 V 336 c 0.97,-1.378 1.01,-1.482 2,0 v 2 l 8,1 v -2 h 2 v 9 l -2,0.27 v -2.31 l -8,1.04 v 2 c -0.91,1.591 -1.3,1.384 -2,0 v -4.478 h -5 z"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="g1183"
+         transform="rotate(-45,1063.0911,503.72257)"
+         style="fill:url(#foreground)">
+        <path
+           id="path1181"
+           style="fill:url(#foreground);stroke:url(#linearGradient1602);stroke-width:1.00156438;stroke-miterlimit:1.5;stroke-dasharray:none"
+           d="m 1108.5,339 v 7"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="g1187"
+         transform="rotate(-45,1058.8981,494.14549)"
+         style="fill:url(#foreground)">
+        <path
+           id="path1185"
+           style="fill:url(#linearGradient1604);fill-opacity:1;stroke:url(#linearGradient1610);stroke-width:1.00156438;stroke-miterlimit:1.5;stroke-dasharray:none"
+           d="m 1108.5,339 v 7"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       id="sdfsdfsdf"
+       inkscape:label="#nodeSetDriverSceneSelectionSource"
+       transform="matrix(0.7193948,0,0,0.69766458,-36.538035,1960.7856)">
+      <path
+         style="fill:#a0a0a0;fill-opacity:1;stroke:url(#linearGradient2614);stroke-width:1.41153944;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 150.17906,223.71292 -8.34034,2.15003 0.69503,10.75016 7.64531,4.30006 7.64532,-4.30006 0.69502,-10.75016 z"
+         id="path1495"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path1497"
+         d="m 142.53375,236.61311 -0.69503,-10.75016 8.34034,3.58339 v 11.46683 z"
+         style="fill:#c8c8c8;fill-opacity:1;stroke:url(#linearGradient1525);stroke-width:0.70576972;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path1499"
+         d="m 141.83872,225.86295 8.34034,3.58339 8.34034,-3.58339 -8.34034,-2.15003 z"
+         style="fill:url(#linearGradient1533);fill-opacity:1;stroke:url(#linearGradient1618);stroke-width:0.70576972;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path2506"
+         d="m 150.17906,223.71292 -8.34034,2.15003 0.69503,10.75016 7.64531,4.30006 7.64532,-4.30006 0.69502,-10.75016 z"
+         style="fill:none;fill-opacity:1;stroke:url(#linearGradient1616);stroke-width:1.41153944;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       transform="matrix(0.48166347,0,0,0.50576472,42.813973,2023.0786)"
+       id="taargetNodeSetLinkNodeSet"
+       inkscape:label="nodeSetDriverNodeSet"
+       style="stroke:#3c3c3c;stroke-width:2.02606726;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1">
+      <g
+         id="g1746"
+         transform="matrix(0.84189541,0.83703021,-0.92289177,0.84189541,234.15095,-126.49564)"
+         style="stroke-width:1.66469955;stroke-miterlimit:1.5;stroke-dasharray:none">
+        <path
+           inkscape:connector-curvature="0"
+           id="rect1538"
+           d="m 131.31362,224.87387 c -3.8261,0 -6.95703,3.13092 -6.95703,6.95703 v 0.10156 c 0,3.8261 3.13093,6.95703 6.95703,6.95703 h 11.18946 c 3.8261,0 6.95703,-3.13093 6.95703,-6.95703 v -0.10156 c 0,-3.82611 -3.13093,-6.95703 -6.95703,-6.95703 z m 0,3.22851 h 11.18946 c 2.09365,0 3.72851,1.63487 3.72851,3.72852 v 0.10156 c 0,2.09365 -1.63486,3.72852 -3.72851,3.72851 h -11.18946 c -2.09365,0 -3.72851,-1.63486 -3.72851,-3.72851 v -0.10156 c 0,-2.09365 1.63486,-3.72852 3.72851,-3.72852 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient2616);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2618);stroke-width:1.60791647;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5291);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           transform="matrix(0.71674668,-0.71149348,0.78447764,0.71674668,-131.70129,168.23717)" />
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1556);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1624);stroke-width:1.60791647;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5291);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 158.15578,224.86225 c -3.8261,0 -6.95703,3.13092 -6.95703,6.95703 v 0.10156 c 0,3.8261 3.13093,6.95703 6.95703,6.95703 h 11.18946 c 3.8261,0 6.95703,-3.13093 6.95703,-6.95703 v -0.10156 c 0,-3.82611 -3.13093,-6.95703 -6.95703,-6.95703 z m 0,3.22851 h 11.18946 c 2.09365,0 3.72851,1.63487 3.72851,3.72852 v 0.10156 c 0,2.09365 -1.63486,3.72852 -3.72851,3.72851 h -11.18946 c -2.09365,0 -3.72851,-1.63486 -3.72851,-3.72851 v -0.10156 c 0,-2.09365 1.63486,-3.72852 3.72851,-3.72852 z"
+           id="path1554"
+           inkscape:connector-curvature="0"
+           transform="matrix(0.71674668,-0.71149348,0.78447764,0.71674668,-131.75835,168.30936)" />
+        <rect
+           transform="matrix(0.70970278,-0.70450121,0.73825842,0.67451798,0,0)"
+           ry="1.9545777"
+           y="270.6026"
+           x="-68.173393"
+           height="4.158031"
+           width="13.315293"
+           id="rect1524"
+           style="fill:url(#linearGradient2620);fill-opacity:1;stroke:url(#linearGradient2622);stroke-width:1.66568995;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
+    <path
+       inkscape:label="#nodeSetNumericBookmarkSet"
+       transform="matrix(1.0802781,0,0,1.1043814,-178.36641,2108.2531)"
+       d="m 302.30138,18.423424 -3.43097,-2.443491 -3.44073,2.429728 1.26367,-4.018128 -3.37406,-2.521504 4.21197,-0.03985 1.35545,-3.9881025 1.33946,3.9935005 4.21177,0.05672 -3.38412,2.507967 z"
+       inkscape:randomized="0"
+       inkscape:rounded="0"
+       inkscape:flatsided="false"
+       sodipodi:arg2="1.5727992"
+       sodipodi:arg1="0.94448073"
+       sodipodi:r2="2.2924397"
+       sodipodi:r1="5.8454323"
+       sodipodi:cy="13.687498"
+       sodipodi:cx="298.875"
+       sodipodi:sides="5"
+       id="ekr"
+       style="fill:#e0e0e0;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2624);stroke-width:0.9155302;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:type="star" />
+    <g
+       transform="translate(-216,2056.649)"
+       inkscape:label="#g3271"
+       id="g1559">
+      <path
+         style="fill:none;stroke:#272727;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 253.5,59.7132 v 2.5"
+         id="path2494"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#272727;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 250.5,68.2132 3,-3 3,3"
+         id="path2496"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="fill:url(#linearGradient1574);fill-opacity:1;stroke:url(#linearGradient1590);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect1553"
+         width="6.0009608"
+         height="3.0009608"
+         x="250.49953"
+         y="62.212704" />
+      <rect
+         y="68.213181"
+         x="248.5"
+         height="3.0000024"
+         width="4"
+         id="rect1680"
+         style="fill:url(#linearGradient2626);fill-opacity:1;stroke:url(#linearGradient2628);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:url(#linearGradient2630);fill-opacity:1;stroke:url(#linearGradient2632);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect1686"
+         width="4"
+         height="3.0000024"
+         x="254.5"
+         y="68.213181" />
+      <path
+         style="fill:none;stroke:#272727;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 250.5,72.7132 v -1.5"
+         id="path2498"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#272727;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 256.5,72.7132 v -1.5"
+         id="path2500"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="matrix(0.7193948,0,0,0.69766458,-19.538038,1960.7856)"
+       inkscape:label="#nodeSetDriverSceneSelectionSource"
+       id="g2518">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path2510"
+         d="m 150.17906,223.71292 -8.34034,2.15003 0.69503,10.75016 7.64531,4.30006 7.64532,-4.30006 0.69502,-10.75016 z"
+         style="fill:#a0a0a0;fill-opacity:1;stroke:url(#linearGradient2520);stroke-width:1.41153944;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#c8c8c8;fill-opacity:1;stroke:url(#linearGradient2522);stroke-width:0.70576972;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 142.53375,236.61311 -0.69503,-10.75016 8.34034,3.58339 v 11.46683 z"
+         id="path2512"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2524);fill-opacity:1;stroke:url(#linearGradient2526);stroke-width:0.70576972;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 141.83872,225.86295 8.34034,3.58339 8.34034,-3.58339 -8.34034,-2.15003 z"
+         id="path2514"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:url(#linearGradient2528);stroke-width:1.41153944;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 150.17906,223.71292 -8.34034,2.15003 0.69503,10.75016 7.64531,4.30006 7.64532,-4.30006 0.69502,-10.75016 z"
+         id="path2516"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </g>
+    <g
+       style="display:inline"
+       id="g5618"
+       transform="translate(-39.5,47.862183)">
+      <circle
+         inkscape:label="#path4124"
+         r="11"
+         cy="2152"
+         cx="91.5"
+         id="sdfgs"
+         style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <path
+         inkscape:label="#path2699"
+         inkscape:connector-curvature="0"
+         id="path2699"
+         d="M 91.5,2140.5 A 11.5,11.5 0 0 0 80,2152 11.5,11.5 0 0 0 91.5,2163.5 11.5,11.5 0 0 0 103,2152 11.5,11.5 0 0 0 91.5,2140.5 Z m 0.5957,4.2656 c 0.38371,-0.01 0.69592,0.3057 0.69141,0.6895 v 5.0019 c 0.48437,0.1511 0.39206,0.1721 0.81055,0.4668 l 0.37695,-4.6855 c -0.004,-0.3753 0.47239,-0.6387 0.84766,-0.6446 0.38361,-0.01 0.6959,0.3059 0.6914,0.6895 v 6.3125 c 0.0846,0.1412 -0.002,0.1009 0.0684,0.252 l 1.08985,-1.4043 c 0.18216,-0.3268 0.52828,-0.527 0.90234,-0.5235 0.7905,0.01 1.27459,0.8683 0.86914,1.5469 l -2.16016,4.3027 c -0.33612,0.8126 -0.5361,1.0509 -0.89453,1.5586 -0.64414,0.9126 -1.77649,1.4356 -3.28125,1.4356 -1.41958,0 -2.85042,-0.1569 -4.01758,-0.752 -1.16716,-0.5951 -2.03515,-1.7526 -2.03515,-3.3359 0,0 -0.29326,-1.9064 -0.32031,-2.5489 -0.027,-0.6424 -0.196,-4.0426 -0.2754,-5.5644 -0.004,-0.3753 0.38254,-0.8828 0.75782,-0.8887 0.38361,-0.01 0.91857,0.4855 0.91406,0.8692 l 0.11914,3.75 c 0.19112,-0.1179 0.43504,0.181 0.69531,0.039 0.23634,-0.129 0.20352,0.01 0.4668,-0.1172 l 0.0449,-5.0996 c -0.004,-0.3753 0.42747,-0.75 0.80274,-0.7559 0.38362,-0.01 0.80723,0.3937 0.80273,0.7774 l 0.26562,4.2851 c 0.44701,-0.1251 0.15056,-0.1308 0.61133,-0.1308 l 0.17578,-4.5704 c -0.004,-0.3753 0.31808,-0.8613 0.69336,-0.8671 z"
+         style="opacity:1;fill:#787878;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+    <g
+       style="display:inline"
+       id="g5622"
+       transform="translate(-43.5,47.362183)">
+      <circle
+         inkscape:label="#circle4126"
+         style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="sdfsgdf"
+         cx="123.5"
+         cy="2152"
+         r="11" />
+      <path
+         inkscape:label="#path2699-8"
+         inkscape:connector-curvature="0"
+         id="path2699-8"
+         d="m 123.5,2140.5 a 11.5,11.5 0 0 0 -11.5,11.5 11.5,11.5 0 0 0 11.5,11.5 11.5,11.5 0 0 0 11.5,-11.5 11.5,11.5 0 0 0 -11.5,-11.5 z m 0.5957,4.2656 c 0.38371,-0.01 0.69592,0.3057 0.69141,0.6895 v 5.0019 c 0.48437,0.1511 0.39206,0.1721 0.81055,0.4668 l 0.37695,-4.6855 c -0.004,-0.3753 0.47239,-0.6387 0.84766,-0.6446 0.38361,-0.01 0.6959,0.3059 0.6914,0.6895 v 6.3125 c 0.0846,0.1412 -0.002,0.1009 0.0684,0.252 l 1.08985,-1.4043 c 0.18216,-0.3268 0.52828,-0.527 0.90234,-0.5235 0.7905,0.01 1.27459,0.8683 0.86914,1.5469 l -2.16016,4.3027 c -0.33612,0.8126 -0.5361,1.0509 -0.89453,1.5586 -0.64414,0.9126 -1.77649,1.4356 -3.28125,1.4356 -1.41958,0 -2.85042,-0.1569 -4.01758,-0.752 -1.16716,-0.5951 -2.03515,-1.7526 -2.03515,-3.3359 0,0 -0.29326,-1.9064 -0.32031,-2.5489 -0.027,-0.6424 -0.196,-4.0426 -0.2754,-5.5644 -0.004,-0.3753 0.38254,-0.8828 0.75782,-0.8887 0.38361,-0.01 0.91857,0.4855 0.91406,0.8692 l 0.11914,3.75 c 0.19112,-0.1179 0.43504,0.181 0.69531,0.039 0.23634,-0.129 0.20352,0.01 0.4668,-0.1172 l 0.0449,-5.0996 c -0.004,-0.3753 0.42747,-0.75 0.80274,-0.7559 0.38362,-0.01 0.80723,0.3937 0.80273,0.7774 l 0.26562,4.2851 c 0.44701,-0.1251 0.15056,-0.1308 0.61133,-0.1308 l 0.17578,-4.5704 c -0.004,-0.3753 0.31808,-0.8613 0.69336,-0.8671 z"
+         style="opacity:1;fill:#d03232;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+    <path
+       style="opacity:1;fill:#9e9e9e;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 23,137.86219 3.427734,6 H 21.5 v 2 h 11 v -2 h -4.927734 l 3.427734,-6 z"
+       id="scrollToBottom"
+       inkscape:connector-curvature="0" />
+    <rect
+       y="136.3622"
+       x="22"
+       height="10"
+       width="10"
+       id="rect1650"
+       style="fill:none;stroke:none" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:0.10588235;stroke:none;stroke-width:1.53206468;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
+       id="renderStart"
+       width="13"
+       height="13"
+       x="215"
+       y="50.362183"
+       inkscape:label="#rect2589-2" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:0.10588235;stroke:none;stroke-width:1.53206468;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
+       id="renderResume"
+       width="13"
+       height="13"
+       x="229"
+       y="50.362183"
+       inkscape:label="#rect2589-4" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:0.10588235;stroke:none;stroke-width:1.53206468;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
+       id="renderPause"
+       width="13"
+       height="13"
+       x="243"
+       y="50.362183"
+       inkscape:label="#rect2589-4-8" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:0.10588235;stroke:none;stroke-width:1.53206468;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
+       id="renderStop"
+       width="13"
+       height="13"
+       x="201"
+       y="50.362183"
+       inkscape:label="#rect2589" />
     <rect
        style="opacity:1;fill:#9e9e9e;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
        id="rect2735"
        width="8"
        height="8"
-       x="331.5"
-       y="20.862183"
+       x="203.5"
+       y="52.862183"
        ry="0"
        rx="0" />
     <path
        style="fill:#9e9e9e;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 345.5,19.862183 v 10 l 8,-5 z"
+       d="m 217.5,51.862183 v 10 l 8,-5 z"
        id="path2737"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
     <g
        id="g2771"
-       transform="translate(-20)">
+       transform="translate(-148,32)">
       <rect
          rx="0"
          ry="0"
@@ -5609,533 +7502,82 @@
        id="rect2735-7-93"
        width="2"
        height="8"
-       x="358.5"
-       y="20.862183"
+       x="230.5"
+       y="52.862183"
        ry="0"
        rx="0" />
     <path
        style="fill:#9e9e9e;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 361.5,20.362183 v 9 l 7.5,-4.5 z"
+       d="m 233.5,52.362183 v 9 l 7.5,-4.5 z"
        id="path2737-0"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
-    <rect
-       style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:1.9993701;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
-       id="rect2486"
-       width="17"
-       height="17"
-       x="260"
-       y="162.36218" />
-    <rect
-       y="162.36218"
-       x="278"
-       height="17"
-       width="17"
-       id="rect2488"
-       style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:1.9993701;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
-    <path
-       sodipodi:type="star"
-       style="fill:none;fill-opacity:0.2;fill-rule:nonzero;stroke:url(#linearGradient1625);stroke-width:0.49690738;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="nodeSetDrivertestMode"
-       sodipodi:sides="5"
-       sodipodi:cx="298.875"
-       sodipodi:cy="13.687498"
-       sodipodi:r1="5.8454323"
-       sodipodi:r2="2.2924397"
-       sodipodi:arg1="0.94448073"
-       sodipodi:arg2="1.5727992"
-       inkscape:flatsided="false"
-       inkscape:rounded="0"
-       inkscape:randomized="0"
-       d="m 302.30138,18.423424 -3.43097,-2.443491 -3.44073,2.429728 1.26367,-4.018128 -3.37406,-2.521504 4.21197,-0.03985 1.35545,-3.9881025 1.33946,3.9935005 4.21177,0.05672 -3.38412,2.507967 z"
-       transform="matrix(1.119198,0,0,1.1443239,39.017934,313.89113)"
-       inkscape:label="" />
-    <path
-       inkscape:label="#path1410"
-       id="debugSmall"
-       d="m 43.263458,145.36217 c -3.037564,0 -5.500002,2.46244 -5.500002,5.50001 0,3.03757 2.462438,5.5 5.500002,5.5 3.037564,0 5.499997,-2.46243 5.499997,-5.5 0,-3.03757 -2.462433,-5.50001 -5.499997,-5.50001 z"
-       style="opacity:0.98999999;fill:#b8b2b2;fill-opacity:0.98431373;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="sssss" />
-    <rect
-       inkscape:label="#rect3931"
-       transform="matrix(0,1,1,0,0,0)"
-       y="-54.258709"
-       x="55.467892"
-       height="14.999993"
-       width="15.000001"
-       id="rect2480"
-       style="fill:none;stroke:none" />
     <g
-       inkscape:label="messagesFocus"
-       id="messagesFocus"
-       transform="translate(-10)"
-       style="stroke:url(#linearGradient1661);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers" />
-    <path
-       style="opacity:1;fill:#9e9e9e;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m -41,5.5 3.427734,6 H -42.5 v 2 h 11 v -2 h -4.927734 L -33,5.5 Z"
-       transform="translate(0,52.362183)"
-       id="scrollToBottom"
-       inkscape:connector-curvature="0" />
-    <rect
-       y="56.36219"
-       x="-42"
-       height="10"
-       width="10"
-       id="rect1650"
-       style="fill:none;stroke:none" />
-    <path
-       inkscape:transform-center-y="-0.93289306"
-       inkscape:transform-center-x="0.28410261"
-       d="m 132.8388,126.10749 c -1.85373,2.47164 1.88941,4.32251 -0.9518,5.53615 -2.8412,1.21364 -1.59048,-2.77039 -4.65785,-3.13995 -3.06738,-0.36956 -2.7987,3.79753 -5.27035,1.9438 -2.47164,-1.85374 1.60399,-2.7626 0.39035,-5.6038 -1.21364,-2.8412 -4.68811,-0.52498 -4.31855,-3.59236 0.36956,-3.06737 3.19447,0.008 5.0482,-2.46384 1.85374,-2.47165 -1.8894,-4.32252 0.9518,-5.53616 2.8412,-1.21364 1.59048,2.77039 4.65785,3.13995 3.06738,0.36956 2.79871,-3.79753 5.27035,-1.94379 2.47165,1.85373 -1.60399,2.76259 -0.39035,5.60379 1.21364,2.84121 4.68811,0.52499 4.31855,3.59236 -0.36955,3.06737 -3.19447,-0.008 -5.0482,2.46385 z"
-       inkscape:randomized="0"
-       inkscape:rounded="0.55"
-       inkscape:flatsided="false"
-       sodipodi:arg2="1.1670999"
-       sodipodi:arg1="0.64350111"
-       sodipodi:r2="10"
-       sodipodi:r1="6.0999999"
-       sodipodi:cy="122.44749"
-       sodipodi:cx="127.9588"
-       sodipodi:sides="6"
-       id="path2550"
-       style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.10526323;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
-       sodipodi:type="star"
-       transform="matrix(0.47502779,0,0,0.47497219,64.551272,61.341162)" />
-    <g
-       id="g2571"
-       mask="url(#mask2603)">
-      <path
-         transform="matrix(1.3226179,0,0,1.3409245,-40.20488,-41.331321)"
-         inkscape:transform-center-y="-2.63371"
-         inkscape:transform-center-x="0.7910214"
-         d="m 121.76711,134.48717 c -0.97623,1.30163 1.46568,1.89797 0.22429,2.94974 -1.24138,1.05177 -1.42852,-1.45493 -2.87282,-0.70577 -1.44431,0.74916 0.49703,2.34595 -1.07776,2.75494 -1.57479,0.40899 -0.65579,-1.93066 -2.28211,-1.88234 -1.62632,0.0483 -0.57005,2.32928 -2.16635,2.01449 -1.59629,-0.31479 0.24684,-2.024 -1.23938,-2.68611 -1.48623,-0.6621 -1.52424,1.85128 -2.82587,0.87505 -1.30163,-0.97622 1.10057,-1.71646 0.0488,-2.95784 -1.05176,-1.24139 -2.17652,1.0066 -2.92569,-0.43771 -0.74916,-1.4443 1.73633,-1.06895 1.32734,-2.64375 -0.40899,-1.57479 -2.39773,-0.0374 -2.44604,-1.66377 -0.0483,-1.62632 2.02818,-0.20973 2.34297,-1.80603 0.31479,-1.59629 -2.14404,-1.07407 -1.48193,-2.5603 0.66211,-1.48622 1.91832,0.69103 2.89455,-0.6106 0.97622,-1.30163 -1.46569,-1.89796 -0.2243,-2.94973 1.24139,-1.05177 1.42853,1.45493 2.87283,0.70577 1.4443,-0.74917 -0.49704,-2.34595 1.07775,-2.75494 1.5748,-0.40899 0.65579,1.93066 2.28211,1.88234 1.62632,-0.0483 0.57006,-2.32928 2.16635,-2.01449 1.5963,0.31479 -0.24684,2.024 1.23939,2.68611 1.48622,0.6621 1.52424,-1.85128 2.82587,-0.87506 1.30163,0.97623 -1.10057,1.71647 -0.0488,2.95785 1.05177,1.24139 2.17653,-1.0066 2.92569,0.43771 0.74916,1.4443 -1.73633,1.06895 -1.32733,2.64375 0.40899,1.57479 2.39773,0.0374 2.44604,1.66377 0.0483,1.62632 -2.02818,0.20973 -2.34297,1.80602 -0.31479,1.5963 2.14403,1.07408 1.48193,2.5603 -0.66211,1.48623 -1.91833,-0.69103 -2.89455,0.6106 z"
-         inkscape:randomized="0"
-         inkscape:rounded="0.55"
-         inkscape:flatsided="false"
-         sodipodi:arg2="0.86790059"
-         sodipodi:arg1="0.64350111"
-         sodipodi:r2="10"
-         sodipodi:r1="7.8000002"
-         sodipodi:cy="129.80717"
-         sodipodi:cx="115.52711"
-         sodipodi:sides="14"
-         id="path2548"
-         style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.75089747;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
-         sodipodi:type="star" />
-      <path
-         d="m 120.59334,132.7303 a 7.9999995,7.9999995 0 0 1 -7.99801,8 7.9999995,7.9999995 0 0 1 -8.00199,-7.99602 7.9999995,7.9999995 0 0 1 7.99403,-8.00398 7.9999995,7.9999995 0 0 1 8.00596,7.99204"
-         sodipodi:open="true"
-         sodipodi:end="6.2821905"
-         sodipodi:start="0"
-         sodipodi:ry="7.9999995"
-         sodipodi:rx="7.9999995"
-         sodipodi:cy="132.7303"
-         sodipodi:cx="112.59334"
-         sodipodi:type="arc"
-         id="path2552"
-         style="opacity:1;fill:#b8b2b2;fill-opacity:0.98431373;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
-    </g>
-    <path
-       style="opacity:1;fill:#b8b2b2;fill-opacity:0.98431373;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
-       id="path2552-3"
-       sodipodi:type="arc"
-       sodipodi:cx="125.33526"
-       sodipodi:cy="119.50031"
-       sodipodi:rx="1.5975029"
-       sodipodi:ry="1.6198807"
-       sodipodi:start="0"
-       sodipodi:end="6.2821905"
-       sodipodi:open="true"
-       d="m 126.93276,119.50031 a 1.5975029,1.6198807 0 0 1 -1.5971,1.61988 1.5975029,1.6198807 0 0 1 -1.5979,-1.61907 1.5975029,1.6198807 0 0 1 1.59631,-1.62069 1.5975029,1.6198807 0 0 1 1.59869,1.61827" />
-    <path
-       inkscape:label="#path3910"
-       id="path2622"
-       d="m 119.97497,111.41225 c -7.16587,0 -12.97497,5.80909 -12.97497,12.97496 0,7.16589 5.8091,12.97497 12.97497,12.97497 7.16587,0 12.97496,-5.80908 12.97496,-12.97497 0,-7.16587 -5.80909,-12.97496 -12.97496,-12.97496 z"
-       style="opacity:0.98999999;fill:none;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="sssss" />
-    <g
-       id="g2632"
-       transform="matrix(0.74401127,0,0,0.79808084,9.1899804,31.101191)"
-       style="stroke-width:1.29773736" />
-    <g
-       id="search"
-       inkscape:label="search"
-       transform="translate(1,-0.00447807)">
-      <path
-         d="m 251.5,112.36666 a 4.5,4.5 0 0 1 -4.49888,4.5 4.5,4.5 0 0 1 -4.50112,-4.49776 4.5,4.5 0 0 1 4.49664,-4.50224 4.5,4.5 0 0 1 4.50336,4.49552"
-         sodipodi:open="true"
-         sodipodi:end="6.2821905"
-         sodipodi:start="0"
-         sodipodi:ry="4.5"
-         sodipodi:rx="4.5"
-         sodipodi:cy="112.36666"
-         sodipodi:cx="247"
-         sodipodi:type="arc"
-         id="path2706"
-         style="opacity:1;fill:none;fill-opacity:0.98431373;stroke:#3c3c3c;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
-      <path
-         sodipodi:nodetypes="ccc"
-         style="fill:none;stroke:#3c3c3c;stroke-width:3.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 250,115.36218 3,3 0.5,0.5"
-         id="path2640"
-         inkscape:connector-curvature="0" />
-      <path
-         style="opacity:1;fill:none;fill-opacity:0.98431373;stroke:#9e9e9e;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
-         id="path2636"
-         sodipodi:type="arc"
-         sodipodi:cx="247"
-         sodipodi:cy="112.36666"
-         sodipodi:rx="4.5"
-         sodipodi:ry="4.5"
-         sodipodi:start="0"
-         sodipodi:end="6.2821905"
-         sodipodi:open="true"
-         d="m 251.5,112.36666 a 4.5,4.5 0 0 1 -4.49888,4.5 4.5,4.5 0 0 1 -4.50112,-4.49776 4.5,4.5 0 0 1 4.49664,-4.50224 4.5,4.5 0 0 1 4.50336,4.49552" />
-      <path
-         sodipodi:nodetypes="ccc"
-         inkscape:connector-curvature="0"
-         id="path2638"
-         d="m 250,115.36218 2.5,2.5 0.5,0.5"
-         style="fill:none;stroke:#9e9e9e;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
-         id="rect2728"
-         width="18"
-         height="14"
-         x="237"
-         y="106.36666" />
-    </g>
-    <path
-       inkscape:label="#path3271-4-9"
-       sodipodi:nodetypes="ccccccccccccc"
-       style="fill:#9e9e9e;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 226.5163,111.87124 2.49095,2.49094 -2.49095,2.49095 1.99276,1.99275 2.49094,-2.49094 2.49095,2.49094 1.99275,-1.99275 -2.49094,-2.49095 2.49094,-2.49094 -1.99275,-1.99276 -2.49095,2.49095 -2.49094,-2.49095 z"
-       id="213223"
-       inkscape:connector-curvature="0" />
-    <rect
-       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
-       id="clearSearch"
-       width="15.999999"
-       height="15.999999"
-       x="223"
-       y="106.36218"
-       inkscape:label="rect2708" />
-    <g
-       id="g2632-5"
-       transform="matrix(0.82222636,0,0,0.84233353,4.4504368,28.146872)"
-       style="stroke-width:1.20160651" />
-    <path
-       inkscape:transform-center-y="-0.93289306"
-       inkscape:transform-center-x="0.28410261"
-       d="m 132.8388,126.10749 c -1.85373,2.47164 1.88941,4.32251 -0.9518,5.53615 -2.8412,1.21364 -1.59048,-2.77039 -4.65785,-3.13995 -3.06738,-0.36956 -2.7987,3.79753 -5.27035,1.9438 -2.47164,-1.85374 1.60399,-2.7626 0.39035,-5.6038 -1.21364,-2.8412 -4.68811,-0.52498 -4.31855,-3.59236 0.36956,-3.06737 3.19447,0.008 5.0482,-2.46384 1.85374,-2.47165 -1.8894,-4.32252 0.9518,-5.53616 2.8412,-1.21364 1.59048,2.77039 4.65785,3.13995 3.06738,0.36956 2.79871,-3.79753 5.27035,-1.94379 2.47165,1.85373 -1.60399,2.76259 -0.39035,5.60379 1.21364,2.84121 4.68811,0.52499 4.31855,3.59236 -0.36955,3.06737 -3.19447,-0.008 -5.0482,2.46385 z"
-       inkscape:randomized="0"
-       inkscape:rounded="0.55"
-       inkscape:flatsided="false"
-       sodipodi:arg2="1.1670999"
-       sodipodi:arg1="0.64350111"
-       sodipodi:r2="10"
-       sodipodi:r1="6.0999999"
-       sodipodi:cy="122.44749"
-       sodipodi:cx="127.9588"
-       sodipodi:sides="6"
-       id="path2550-7"
-       style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.10526323;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
-       sodipodi:type="star"
-       transform="matrix(0.47502779,0,0,0.47497219,-18.602122,94.964634)"
-       mask="url(#mask2800)" />
-    <path
-       style="opacity:1;fill:#b8b2b2;fill-opacity:0.98431373;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
-       id="path2552-3-3"
-       sodipodi:type="arc"
-       sodipodi:cx="42.5"
-       sodipodi:cy="152.86218"
-       sodipodi:rx="1.5"
-       sodipodi:ry="1.5"
-       sodipodi:start="0"
-       sodipodi:end="6.2821905"
-       sodipodi:open="true"
-       d="m 44,152.86218 a 1.5,1.5 0 0 1 -1.499627,1.5 A 1.5,1.5 0 0 1 41,152.86293 a 1.5,1.5 0 0 1 1.498881,-1.50075 1.5,1.5 0 0 1 1.501118,1.49851" />
-    <rect
-       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill"
-       id="searchFocusOn"
-       width="12"
-       height="12"
-       x="-76"
-       y="56.362183"
-       inkscape:label="#rect1670" />
-    <path
-       d="M -66,62.362183 A 4,4 0 0 1 -69.999005,66.362182 4,4 0 0 1 -74,62.364172 a 4,4 0 0 1 3.997016,-4.001988 4,4 0 0 1 4.002982,3.996019"
-       sodipodi:open="true"
-       sodipodi:end="6.2821905"
-       sodipodi:start="0"
-       sodipodi:ry="4"
-       sodipodi:rx="4"
-       sodipodi:cy="62.362183"
-       sodipodi:cx="-70"
-       sodipodi:type="arc"
-       id="path1663"
-       style="opacity:1;fill:none;fill-opacity:1;stroke:#383838;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
-    <path
-       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient1693);stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
-       id="path1659"
-       sodipodi:type="arc"
-       sodipodi:cx="-70"
-       sodipodi:cy="62.362183"
-       sodipodi:rx="3.75"
-       sodipodi:ry="3.75"
-       sodipodi:start="0"
-       sodipodi:end="6.2821905"
-       sodipodi:open="true"
-       d="m -66.25,62.362183 a 3.75,3.75 0 0 1 -3.749067,3.75 3.75,3.75 0 0 1 -3.750933,-3.748135 3.75,3.75 0 0 1 3.747202,-3.751864 3.75,3.75 0 0 1 3.752796,3.746268" />
-    <path
-       style="opacity:1;fill:url(#linearGradient1699);fill-opacity:1;stroke:#383838;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill"
-       id="path1661"
-       sodipodi:type="arc"
-       sodipodi:cx="-70"
-       sodipodi:cy="62.362183"
-       sodipodi:rx="1.5"
-       sodipodi:ry="1.5"
-       sodipodi:start="0"
-       sodipodi:end="6.2821905"
-       sodipodi:open="true"
-       d="m -68.5,62.362183 a 1.5,1.5 0 0 1 -1.499627,1.5 1.5,1.5 0 0 1 -1.500373,-1.499254 1.5,1.5 0 0 1 1.498881,-1.500746 1.5,1.5 0 0 1 1.501118,1.498507" />
-    <rect
-       inkscape:label="#rect1668"
-       transform="scale(-1,1)"
-       style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12199998;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="toggleIndeterminate"
-       width="15"
-       height="15"
-       x="-123.5"
-       y="20.862183"
-       rx="2.5"
-       ry="2.5" />
-    <rect
-       transform="scale(-1,1)"
-       style="opacity:0.98999999;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect1670-2"
-       width="8.5"
-       height="15"
-       x="-120.50001"
-       y="20.862183"
-       rx="2.0913782"
-       ry="2.5" />
-    <rect
-       ry="2.5"
-       rx="2.5"
-       y="20.862183"
-       x="-143.50002"
-       height="15"
-       width="15"
-       id="toggleIndeterminateHover"
-       style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12199998;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="scale(-1,1)"
-       inkscape:label="#rect1668" />
-    <rect
-       ry="2.5"
-       rx="2.0913782"
-       y="20.862183"
-       x="-140.5"
-       height="15"
-       width="8.5"
-       id="rect3123"
-       style="opacity:0.98999999;fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="scale(-1,1)" />
-    <g
-       inkscape:label="#g3141"
-       style="opacity:0.5"
-       id="toggleIndeterminateDisabled"
-       transform="translate(-118,-107)">
-      <rect
-         inkscape:label="#rect1668"
-         transform="scale(-1,1)"
-         style="fill:#444444;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.12199998;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect3125"
-         width="15"
-         height="15"
-         x="-220.5"
-         y="127.86218"
-         rx="2.5"
-         ry="2.5" />
-      <rect
-         transform="scale(-1,1)"
-         style="opacity:1;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect3128"
-         width="8.5"
-         height="15"
-         x="-217.5"
-         y="127.86218"
-         rx="2.0913782"
-         ry="2.5" />
-    </g>
-    <rect
-       style="fill:none;stroke:none;stroke-width:0.99999994"
-       id="checkBoxIndeterminate"
-       width="19.97287"
-       height="19.972773"
-       x="36.88932"
-       y="85.027237"
-       transform="matrix(0,1,1,0,0,0)"
-       inkscape:label="#rect3931" />
-    <g
-       transform="translate(0,-20.5)"
-       id="g1630">
-      <rect
-         style="fill:url(#linearGradient1730);fill-opacity:1"
-         ry="2"
-         rx="2"
-         y="59.362183"
-         x="87"
-         height="16"
-         width="16"
-         id="rect1626" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path1628"
-         d="m 89.409772,74.862183 h 11.570078 c 0.88096,0 1.52015,-0.590755 1.52015,-1.513216 l 0.0259,-12.486784"
-         style="fill:none;stroke:url(#linearGradient1732);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    </g>
-    <rect
-       ry="0.99999994"
-       rx="0.99999994"
-       y="45.362167"
-       x="89.000008"
-       height="2.9999995"
-       width="11"
-       id="rect1642"
-       style="opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal" />
-    <rect
-       inkscape:label="#rect3931"
-       transform="matrix(0,1,1,0,0,0)"
-       y="106.00001"
-       x="36.86219"
-       height="20"
-       width="19.999998"
-       id="checkBoxIndeterminateHover"
-       style="fill:none;stroke:none;stroke-width:0.99999994" />
-    <g
-       transform="translate(21.00001,-20.48678)"
-       id="g1650"
-       style="display:inline">
-      <rect
-         style="fill:url(#linearGradient1734);fill-opacity:1"
-         ry="2"
-         rx="2"
-         y="59.362183"
-         x="87"
-         height="16"
-         width="16"
-         id="rect1646" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path1648"
-         d="m 89.409772,74.862183 h 11.570078 c 0.88096,0 1.52015,-0.590755 1.52015,-1.513216 l 0.0259,-12.486784"
-         style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:0.11764706" />
-    </g>
-    <rect
-       style="opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-       id="rect1658"
-       width="11"
-       height="2.9999995"
-       x="110.49999"
-       y="45.362167"
-       rx="0.99999994"
-       ry="0.99999994" />
-    <g
-       transform="translate(41,-20.5)"
-       id="g1662">
-      <rect
-         style="fill:#000000;fill-opacity:0.07843137"
-         ry="2"
-         rx="2"
-         y="59.362183"
-         x="87"
-         height="16"
-         width="16"
-         id="rect1660" />
-      <rect
-         style="opacity:1;fill:#666666;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-         id="rect1666"
-         width="11"
-         height="2.9999995"
-         x="130.49998"
-         y="45.362167"
-         rx="0.99999994"
-         ry="0.99999994" />
-    </g>
-    <rect
-       style="fill:none;stroke:none;stroke-width:0.99999994"
-       id="checkBoxIndeterminateDisabled"
-       width="19.97287"
-       height="19.972773"
-       x="36.86219"
-       y="126.00001"
-       transform="matrix(0,1,1,0,0,0)"
-       inkscape:label="#rect3931" />
-    <rect
-       ry="0.99999994"
-       rx="0.99999994"
-       y="45.362167"
-       x="130.49998"
-       height="2.9999995"
-       width="11"
-       id="rect2624"
-       style="opacity:1;fill:#666666;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal" />
-    <g
-       inkscape:label="#g1676"
-       id="searchFocusOff"
-       transform="translate(-13)">
-      <rect
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill"
-         id="rect1678"
-         width="12"
-         height="12"
-         x="-76"
-         y="56.362183" />
-      <path
-         d="M -66,62.362183 A 4,4 0 0 1 -69.999005,66.362182 4,4 0 0 1 -74,62.364172 a 4,4 0 0 1 3.997016,-4.001988 4,4 0 0 1 4.002982,3.996019"
-         sodipodi:open="true"
-         sodipodi:end="6.2821905"
-         sodipodi:start="0"
-         sodipodi:ry="4"
-         sodipodi:rx="4"
-         sodipodi:cy="62.362183"
-         sodipodi:cx="-70"
-         sodipodi:type="arc"
-         id="path1680"
-         style="opacity:1;fill:none;fill-opacity:1;stroke:#383838;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
-      <path
-         style="opacity:1;fill:none;fill-opacity:1;stroke:#9e9e9e;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
-         id="path1682"
-         sodipodi:type="arc"
-         sodipodi:cx="-70"
-         sodipodi:cy="62.362183"
-         sodipodi:rx="3.75"
-         sodipodi:ry="3.75"
-         sodipodi:start="0"
-         sodipodi:end="6.2821905"
-         sodipodi:open="true"
-         d="m -66.25,62.362183 a 3.75,3.75 0 0 1 -3.749067,3.75 3.75,3.75 0 0 1 -3.750933,-3.748135 3.75,3.75 0 0 1 3.747202,-3.751864 3.75,3.75 0 0 1 3.752796,3.746268" />
-      <path
-         style="opacity:1;fill:#9e9e9e;fill-opacity:1;stroke:#383838;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill"
-         id="path1684"
-         sodipodi:type="arc"
-         sodipodi:cx="-70"
-         sodipodi:cy="62.362183"
-         sodipodi:rx="1.5"
-         sodipodi:ry="1.5"
-         sodipodi:start="0"
-         sodipodi:end="6.2821905"
-         sodipodi:open="true"
-         d="m -68.5,62.362183 a 1.5,1.5 0 0 1 -1.499627,1.5 1.5,1.5 0 0 1 -1.500373,-1.499254 1.5,1.5 0 0 1 1.498881,-1.500746 1.5,1.5 0 0 1 1.501118,1.498507" />
+       style="display:inline"
+       id="g5781"
+       transform="translate(-216,1.5000004)">
+      <g
+         id="g5770">
+        <rect
+           style="display:inline;opacity:1;fill:#888888;fill-opacity:0.74509804;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:fill markers stroke"
+           id="grid-8"
+           width="20"
+           height="15.999878"
+           x="286.5"
+           y="1677.3622"
+           rx="2.2222223"
+           ry="2"
+           inkscape:label="#rect1734" />
+        <g
+           id="g41043"
+           transform="matrix(0.78835689,0,0,0.73973705,260.57319,1560.6954)"
+           inkscape:label="#g4104"
+           style="display:inline;stroke-width:1.40838981">
+          <path
+             sodipodi:nodetypes="ccccc"
+             style="fill:#919191;fill-opacity:1;stroke:none;stroke-width:1.40838981"
+             d="m 35.42406,171.23218 9.272,5.662 9.728,-5.51 L 45,167.36218 Z"
+             id="path3275-0"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="cc"
+             transform="translate(0,52.362183)"
+             inkscape:connector-curvature="0"
+             id="path3292-2"
+             d="m 41,116.88378 8.895356,4.80676"
+             style="fill:#000000;fill-opacity:0;stroke:#4d4d4d;stroke-width:0.97178906;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             transform="translate(0,52.362183)"
+             inkscape:connector-curvature="0"
+             id="path3296-4"
+             d="m 39.955806,121.28466 9.066291,-4.38952"
+             style="fill:#000000;fill-opacity:0;stroke:#4d4d4d;stroke-width:0.97178906;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4102-8"
+             d="m 35.42406,171.23218 9.272,5.662 9.728,-5.51 L 45,167.36218 Z"
+             style="fill:none;stroke:#3c3c3c;stroke-width:1.40838981;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="ccccc" />
+        </g>
+        <rect
+           style="display:inline;opacity:1;fill:url(#linearGradient1742);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:fill markers stroke"
+           id="rect1736"
+           width="4"
+           height="8"
+           x="300.5"
+           y="1682.3622" />
+        <path
+           style="display:inline;fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 292.00001,1679.3622 H 297.29412 301"
+           id="path1744"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccc" />
+      </g>
     </g>
     <g
        id="1644"
-       transform="matrix(0.51839037,-0.52369081,0.51839037,0.52369081,28.16121,131.08271)"
+       transform="matrix(0.51839037,-0.52369081,0.51839037,0.52369081,100.16121,339.08267)"
        inkscape:label="#g1644"
        style="stroke-width:1.35712254">
       <path
@@ -6143,10 +7585,10 @@
          inkscape:connector-curvature="0"
          d="M 210.5,56.362183 214,54.36219 h 11.5 c 1.33333,0 1.33333,3.999982 0,3.999982 H 214 Z"
          style="fill:#ababab;fill-opacity:0.99215686;stroke:#3b3b3b;stroke-width:1.35712254px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-         id="path1619" />
+         id="path1619-5" />
       <path
          inkscape:connector-curvature="0"
-         id="path1634"
+         id="path1634-2"
          d="m 224.00314,54.424672 v 4"
          style="fill:#3b3b3b;fill-opacity:1;stroke:#3b3b3b;stroke-width:1.35712254px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
@@ -6155,13 +7597,13 @@
        id="editOff"
        width="10"
        height="10"
-       x="166"
-       y="40.862156"
+       x="238"
+       y="248.86212"
        inkscape:label="#rect1698" />
     <g
        style="stroke-width:1.35712254"
        inkscape:label="#g1644"
-       transform="matrix(0.51839037,-0.52369081,0.51839037,0.52369081,39.16121,131.08271)"
+       transform="matrix(0.51839037,-0.52369081,0.51839037,0.52369081,111.16121,339.08267)"
        id="g1708">
       <path
          id="path1704"
@@ -6176,30 +7618,25 @@
          inkscape:connector-curvature="0" />
     </g>
     <rect
-       y="40.862156"
-       x="177"
+       y="248.86212"
+       x="249"
        height="10"
        width="10"
        id="editOn"
        style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
        inkscape:label="#rect1710" />
-    <g
-       id="g1716"
-       transform="matrix(0.51839037,-0.52369081,0.51839037,0.52369081,50.16121,131.08271)"
-       inkscape:label="#g1644"
-       style="stroke-width:1.35712254" />
     <rect
        style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
        id="editDisabled"
        width="10"
        height="10"
-       x="188"
-       y="40.862156"
+       x="260"
+       y="248.86212"
        inkscape:label="#rect1718" />
     <g
        style="stroke-width:1.35712254;filter:url(#filter2913)"
        inkscape:label="#g1644"
-       transform="matrix(0.51839037,-0.52369081,0.51839037,0.52369081,50.185263,131.10446)"
+       transform="matrix(0.51839037,-0.52369081,0.51839037,0.52369081,122.18526,339.10442)"
        id="g2887">
       <path
          id="path2883"
@@ -6213,52 +7650,20 @@
          id="path2885"
          inkscape:connector-curvature="0" />
     </g>
-    <rect
-       style="opacity:0;fill:#f73181;fill-opacity:0.81865288;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect2919"
-       width="14"
-       height="12"
-       x="218"
-       y="145.36218" />
-    <rect
-       style="opacity:1;fill:url(#linearGradient1742);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:fill markers stroke"
-       id="rect1736"
-       width="4"
-       height="8"
-       x="48.5"
-       y="168.86218" />
     <path
-       style="fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 40,166.86218 H 45.294117 49"
-       id="path1744"
+       inkscape:label="#path3271-4-9"
+       sodipodi:nodetypes="ccccccccccccc"
+       style="display:inline;fill:#9e9e9e;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 72.59094,121.08647 2.49095,2.49094 -2.49095,2.49095 1.99276,1.99275 2.49094,-2.49094 2.490951,2.49094 1.99275,-1.99275 -2.490941,-2.49095 2.490941,-2.49094 -1.99275,-1.99276 -2.490951,2.49095 -2.49094,-2.49095 z"
+       id="213223"
        inkscape:connector-curvature="0" />
     <rect
-       inkscape:label="#rect1735"
-       y="219.36218"
-       x="226"
-       height="16"
-       width="10"
-       id="lutGPU"
-       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
-    <rect
-       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
-       id="lutCPU"
-       width="10"
-       height="16"
-       x="207"
-       y="219.36218"
-       inkscape:label="#rect1735" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path2635"
-       d="m 213,220.36218 -5,9 4,-1 -1,6 5,-9 -4,1 z"
-       style="fill:#9e9e9e;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers" />
-    <path
-       style="fill:url(#linearGradient1733);fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
-       d="m 232,220.36218 -5,9 4,-1 -1,6 5,-9 -4,1 z"
-       id="path1726"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccc" />
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       id="clearSearch"
+       width="15.999999"
+       height="15.999999"
+       x="69.074638"
+       y="115.57742"
+       inkscape:label="rect2708" />
   </g>
 </svg>

--- a/src/GafferUI/Pointer.cpp
+++ b/src/GafferUI/Pointer.cpp
@@ -49,22 +49,22 @@ static Registry &registry()
 	if( !r.size() )
 	{
 		// register standard pointers
-		r["move"] = new Pointer( "move.png", Imath::V2i( 10, 10 ) );
-		r["moveDiagonallyUp"] = new Pointer( "moveDiagonallyUp.png", Imath::V2i( 7 ) );
-		r["moveDiagonallyDown"] = new Pointer( "moveDiagonallyDown.png", Imath::V2i( 7 ) );
-		r["moveHorizontally"] = new Pointer( "moveHorizontally.png", Imath::V2i( 9, 5 ) );
-		r["moveVertically"] = new Pointer( "moveVertically.png", Imath::V2i( 5, 9 ) );
-		r["nodes"] = new Pointer( "nodes.png", Imath::V2i( 11, 8 ) );
-		r["objects"] = new Pointer( "objects.png", Imath::V2i( 18 ) );
-		r["plug"] = new Pointer( "plug.png", Imath::V2i( 9 ) );
-		r["rgba"] = new Pointer( "rgba.png", Imath::V2i( 12, 7 ) );
-		r["values"] = new Pointer( "values.png", Imath::V2i( 19, 14 ) );
-		r["paths"] = new Pointer( "paths.png", Imath::V2i( 8 ) );
+		r["move"] = new Pointer( "move.png", Imath::V2i( 10 ) );
+		r["moveDiagonallyUp"] = new Pointer( "moveDiagonallyUp.png", Imath::V2i( 10 ) );
+		r["moveDiagonallyDown"] = new Pointer( "moveDiagonallyDown.png", Imath::V2i( 10 ) );
+		r["moveHorizontally"] = new Pointer( "moveHorizontally.png", Imath::V2i( 10 ) );
+		r["moveVertically"] = new Pointer( "moveVertically.png", Imath::V2i( 10 ) );
+		r["nodes"] = new Pointer( "nodes.png", Imath::V2i( 10, 5 ) );
+		r["objects"] = new Pointer( "objects.png", Imath::V2i( 53, 14 ) );
+		r["plug"] = new Pointer( "plug.png", Imath::V2i( 8, 7 ) );
+		r["rgba"] = new Pointer( "rgba.png", Imath::V2i( 11, 5 ) );
+		r["values"] = new Pointer( "values.png", Imath::V2i( 18, 11 ) );
+		r["paths"] = new Pointer( "paths.png", Imath::V2i( 7, 6 ) );
 		r["contextMenu"] = new Pointer( "pointerContextMenu.png", Imath::V2i( 1 ) );
-		r["tab"] = new Pointer( "pointerTab.png", Imath::V2i( 12, 15 ) );
-		r["detachedPanel"] = new Pointer( "pointerDetachedPanel.png", Imath::V2i( 12, 15 ) );
-		r["target"] = new Pointer( "pointerTarget.png", Imath::V2i( 12, 12 ) );
-		r["crossHair"] = new Pointer( "pointerCrossHair.png", Imath::V2i( 8, 8 ) );
+		r["tab"] = new Pointer( "pointerTab.png", Imath::V2i( 12, 13 ) );
+		r["detachedPanel"] = new Pointer( "pointerDetachedPanel.png", Imath::V2i( 12, 13 ) );
+		r["target"] = new Pointer( "pointerTarget.png", Imath::V2i( 14 ) );
+		r["crossHair"] = new Pointer( "pointerCrossHair.png", Imath::V2i( 14 ) );
 	}
 	return r;
 }


### PR DESCRIPTION
First steps in cleaning up `graphics.svg`. This is a WIP, but we were getting closer and closer to merge hell as ongoing feature work produced more graphics. As such, there are still a bunch of graphics that haven't been aligned/tidied yet.

![image](https://user-images.githubusercontent.com/896779/90395309-3fe16200-e08c-11ea-9c3d-b99b39931050.png)

Key changes:

 - Many images have slight visual tweaks to better align single pixel lines to the export pixel grid.
 - Some images have changed size to ensure related icons are the same pixel dimensions.
 - Cursor pointer coordinates may have changed.
 - The build now validates all conformed icons are aligned to the pixel grid and are of the right size.
 - The SVG file has been slightly re-organised, see notes in the document for more details.