### PR TITLE
EditMenu : Add Unplug (Ctrl+U) to disconnect selected nodes.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.58.x.x
 ========
 
+Improvements
+------------
+
+- Edit Menu : Added "Unplug" (Ctrl+U) to detach selected nodes from their inputs/outputs, and re-wire the graph with new direct connections in their place.
+
 Fixes
 -----
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -156,6 +156,7 @@ Delete node(s)                        :kbd:`Backspace`
                                       
                                       :kbd:`Delete`
 Enable/disable node(s)                :kbd:`D`
+Unplug node(s)                        :kbd:`Ctrl` + :kbd:`U`
 ===================================== =============================================
 ```
 

--- a/python/GafferUI/EditMenu.py
+++ b/python/GafferUI/EditMenu.py
@@ -54,6 +54,7 @@ def appendDefinitions( menuDefinition, prefix="" ) :
 	menuDefinition.append( prefix + "/Copy", { "command" : copy, "shortCut" : "Ctrl+C", "active" : selectionAvailable } )
 	menuDefinition.append( prefix + "/Paste", { "command" : paste, "shortCut" : "Ctrl+V", "active" : __pasteAvailable } )
 	menuDefinition.append( prefix + "/Delete", { "command" : delete, "shortCut" : "Backspace, Delete", "active" : __mutableSelectionAvailable } )
+	menuDefinition.append( prefix + "/Unplug", { "command" : unplug, "shortCut" : "Ctrl+U", "active" : __mutableSelectionAvailable } )
 	menuDefinition.append( prefix + "/CutCopyPasteDeleteDivider", { "divider" : True } )
 
 	menuDefinition.append( prefix + "/Find...", { "command" : find, "shortCut" : "Ctrl+F" } )
@@ -198,6 +199,20 @@ def delete( menu ) :
 	s = scope( menu )
 	with Gaffer.UndoScope( s.script ) :
 		s.script.deleteNodes( s.parent, s.script.selection() )
+
+# A function suitable as the command for an Edit/Unplug menu item. It must
+# be invoked from a menu that has a ScriptWindow in its ancestry.
+def unplug( menu ) :
+
+	s = scope( menu )
+	with Gaffer.UndoScope( s.script ) :
+
+		s.script.cut( s.parent, s.script.selection() )
+		s.script.paste( s.parent )
+
+		for node in s.script.selection() :
+			position = s.nodeGraph.graphGadget().getNodePosition( node )
+			s.nodeGraph.graphGadget().setNodePosition( node, imath.V2f( position.x+2, position.y+2 ) )
 
 ## A function suitable as the command for an Edit/Find menu item.  It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.


### PR DESCRIPTION
Added "Unplug" (Ctrl+U) to detach selected nodes from their inputs/outputs, and re-wire the graph with new direct connections in their place.

Feel free to suggest alternate naming (or shortcut), I've just stuck with what we had internally at IE thus far.