### PR TITLE
UIEditor : Work around PathListingWidget selection handling bug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - Box : Fixed GIL management bug that could cause hangs when promoting a plug.
 - SetFilter : Added missing set expression operators to node reference/tooltip.
+- UIEditor : Fixed bug which allowed the creation of non-selectable presets.
 
 0.57.7.0 (relative to 0.57.6.0)
 ========

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -41,6 +41,7 @@ import re
 import collections
 import imath
 import inspect
+import string
 
 import IECore
 
@@ -1282,8 +1283,10 @@ class _PresetsEditor( GafferUI.Widget ) :
 			nameWidget.setText( oldName )
 			return True
 
-		# Sanitize name
-		newName = newName.replace( "/", "_")
+		# Sanitize name. Strictly speaking we should only need to replace '/',
+		# but PathListingWidget has a bug handling wildcards in selections, so
+		# we replace those too.
+		newName = newName.translate( string.maketrans( "/*?\\[", "_____" ) )
 
 		items = self.__pathListing.getPath().dict().items()
 		with Gaffer.BlockedConnection( self.__plugMetadataChangedConnection ) :

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -796,6 +796,10 @@ class PathModel : public QAbstractItemModel
 
 		void indicesForPathsWalk( Item *item, const QModelIndex &itemIndex, const IECore::PathMatcher &paths, std::vector<QModelIndex> &indices )
 		{
+			/// \todo Using `match()` here isn't right, because we want to
+			/// treat wildcards in the selection verbatim rather than perform
+			/// matching with them. We should use `find()`, but that doesn't
+			/// provide a convenient way of checking for descendant matches.
 			const unsigned match = paths.match( item->path()->names() );
 			if( match & IECore::PathMatcher::ExactMatch )
 			{


### PR DESCRIPTION
And document bug in place. This code is pretty performance-sensitive, and a decent fix probably needs a Cortex update too. The following test case demonstrates the problem :

```
def testWildcardsInSelection( self ) :

	path = Gaffer.DictPath(
		{
			"a*" : 1,
			"aa" : 3,
		},
		"/"
	)

	widget = GafferUI.PathListingWidget( path )
	# Selection should be treated verbatim rather than be used to match
	# multiple paths.
	widget.setSelection( IECore.PathMatcher( [ "/a*" ] ) )
	self.assertEqual( widget.getSelection(), IECore.PathMatcher( [ "/a*" ] ) )
```
