### PR TITLE
EditScopeUI : Allow arbitrary nodes to be included in nav menu

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Fixes
 
 - Viewer : Fixed bug preventing the Inspector from finding shaders when assigned via a Switch.
 
+API
+---
+
+- EditScopeUI : Added support for listing user nodes in the Edit Scope navigation menu when their `editScope:includeInNavigationMenu` metadata entry is set to `True`.
+
 0.58.0.1 (relative to 0.58.0.0)
 ========
 

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -233,12 +233,16 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 			)
 			return result
 
-		if editScope.processors() :
-			for processor in editScope.processors() :
+		nodes = editScope.processors()
+		nodes.extend( self.__userNodes( editScope ) )
+
+		if nodes :
+			for node in nodes :
+				path = node.relativeName( editScope ).replace( ".", "/" )
 				result.append(
-					"/" + processor.getName(),
+					"/" + path,
 					{
-						"command" : functools.partial( GafferUI.NodeEditor.acquire, processor )
+						"command" : functools.partial( GafferUI.NodeEditor.acquire, node )
 					}
 				)
 		else :
@@ -248,3 +252,9 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 			)
 
 		return result
+
+	@staticmethod
+	def __userNodes( editScope ) :
+
+		nodes = Gaffer.Metadata.nodesWithMetadata( editScope, "editScope:includeInNavigationMenu" )
+		return [ n for n in nodes if n.ancestor( Gaffer.EditScope ).isSame( editScope ) ]


### PR DESCRIPTION
Not sure if we should be sorting this menu alphabetically or similar. It's not easy to list them in graph order
without some refactoring.
