### PR TITLE
NoduleLayout : Don't shadow `Gadget::updateLayout()`

### DIFF
--- a/include/GafferUI/NoduleLayout.h
+++ b/include/GafferUI/NoduleLayout.h
@@ -131,7 +131,7 @@ class GAFFERUI_API NoduleLayout : public Gadget
 		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node );
 
 		std::vector<GadgetKey> layoutOrder();
-		void updateLayout();
+		void updateNoduleLayout();
 		void updateSpacing();
 		void updateDirection();
 		void updateOrientation();

--- a/src/GafferUI/NoduleLayout.cpp
+++ b/src/GafferUI/NoduleLayout.cpp
@@ -397,7 +397,7 @@ NoduleLayout::NoduleLayout( Gaffer::GraphComponentPtr parent, IECore::InternedSt
 	Metadata::plugValueChangedSignal().connect( boost::bind( &NoduleLayout::plugMetadataChanged, this, ::_1, ::_2, ::_3, ::_4 ) );
 	Metadata::nodeValueChangedSignal().connect( boost::bind( &NoduleLayout::nodeMetadataChanged, this, ::_1, ::_2, ::_3 ) );
 
-	updateLayout();
+	updateNoduleLayout();
 }
 
 NoduleLayout::~NoduleLayout()
@@ -479,7 +479,7 @@ void NoduleLayout::childAdded( Gaffer::GraphComponent *child )
 {
 	if( IECore::runTimeCast<Gaffer::Plug>( child ) )
 	{
-		updateLayout();
+		updateNoduleLayout();
 	}
 }
 
@@ -487,7 +487,7 @@ void NoduleLayout::childRemoved( Gaffer::GraphComponent *child )
 {
 	if( IECore::runTimeCast<Gaffer::Plug>( child ) )
 	{
-		updateLayout();
+		updateNoduleLayout();
 	}
 }
 
@@ -501,7 +501,7 @@ void NoduleLayout::plugMetadataChanged( IECore::TypeId nodeTypeId, const IECore:
 			key == g_nodulePositionKey || key == g_noduleIndexKey
 		)
 		{
-			updateLayout();
+			updateNoduleLayout();
 		}
 	}
 
@@ -523,7 +523,7 @@ void NoduleLayout::plugMetadataChanged( IECore::TypeId nodeTypeId, const IECore:
 			}
 			if( boost::starts_with( key.string(), "noduleLayout:customGadget" ) )
 			{
-				updateLayout();
+				updateNoduleLayout();
 			}
 		}
 	}
@@ -551,7 +551,7 @@ void NoduleLayout::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::Inter
 	}
 	if( boost::starts_with( key.string(), "noduleLayout:customGadget" ) )
 	{
-		updateLayout();
+		updateNoduleLayout();
 	}
 }
 
@@ -612,7 +612,7 @@ std::vector<NoduleLayout::GadgetKey> NoduleLayout::layoutOrder()
 	return result;
 }
 
-void NoduleLayout::updateLayout()
+void NoduleLayout::updateNoduleLayout()
 {
 	// Figure out the order we want to display things in
 	// and clear our main container ready for filling in


### PR DESCRIPTION
This fixes the following clang build error :

```
include/GafferUI/Gadget.h:298:16: note: hidden overloaded virtual function 'GafferUI::Gadget::updateLayout' declared here: different qualifiers ('const' vs unqualified)
                virtual void updateLayout() const;
                             ^
In file included from src/GafferOSLUI/OSLObjectUI.cpp:42:
include/GafferUI/NoduleLayout.h:134:8: error: 'GafferUI::NoduleLayout::updateLayout' hides overloaded virtual function [-Werror,-Woverloaded-virtual]
                void updateLayout();
                     ^
include/GafferUI/Gadget.h:298:16: note: hidden overloaded virtual function 'GafferUI::Gadget::updateLayout' declared here: different qualifiers ('const' vs unqualified)
                virtual void updateLayout() const;
```
