### PR TITLE
CropWindowTool : Allow crop to be disabled/reset

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,9 @@ Improvements
 ------------
 
 - Catalogue : Added <kbd>Ctrl-D</kbd> shortcut to duplicate selected images (#3545).
-- Viewer : Added <kbd>Ctrl-D</kbd> shortcut to duplicate currently viewed image when viewing the output of Catalogue node (#3545).
+- Viewer :
+ - Added <kbd>Ctrl-D</kbd> shortcut to duplicate currently viewed image when viewing the output of Catalogue node (#3545).
+ - Added enabled/reset controls to the Crop Window Tool.
 
 Fixes
 -----
@@ -16,6 +18,7 @@ API
 ---
 
 - EditScopeUI : Added support for listing user nodes in the Edit Scope navigation menu when their `editScope:includeInNavigationMenu` metadata entry is set to `True`.
+- CropWindowTool : Added `plug()` and `enabledPlug()` methods to return the currently edited plugs or `nullptr`.
 
 0.58.0.1 (relative to 0.58.0.0)
 ========

--- a/include/GafferSceneUI/CropWindowTool.h
+++ b/include/GafferSceneUI/CropWindowTool.h
@@ -65,6 +65,8 @@ class GAFFERSCENEUI_API CropWindowTool : public GafferUI::Tool
 		~CropWindowTool() override;
 
 		std::string status() const;
+		Gaffer::Box2fPlug *plug();
+		Gaffer::BoolPlug *enabledPlug();
 
 		using StatusChangedSignal = boost::signal<void (CropWindowTool &)>;
 		StatusChangedSignal &statusChangedSignal();

--- a/python/GafferSceneUI/CropWindowToolUI.py
+++ b/python/GafferSceneUI/CropWindowToolUI.py
@@ -87,11 +87,25 @@ class _StatusWidget( GafferUI.Frame ) :
 
 		with self :
 			with GafferUI.ListContainer( orientation = GafferUI.ListContainer.Orientation.Horizontal ) as self.__row :
+
 				self.__infoIcon = GafferUI.Image( "infoSmall.png" )
 				self.__errorIcon = GafferUI.Image( "errorSmall.png" )
 				self.__warningIcon = GafferUI.Image( "warningSmall.png" )
 				GafferUI.Spacer( size = imath.V2i( 4 ), maximumSize = imath.V2i( 4 ) )
 				self.__label = GafferUI.Label( "" )
+
+				GafferUI.Spacer( size = imath.V2i( 8 ), maximumSize = imath.V2i( 8 ) )
+				GafferUI.Divider( orientation = GafferUI.Divider.Orientation.Vertical )
+				GafferUI.Spacer( size = imath.V2i( 8 ), maximumSize = imath.V2i( 8 ) )
+
+				with GafferUI.ListContainer( orientation = GafferUI.ListContainer.Orientation.Horizontal ) as self.__controls :
+
+					self.__enabledLabel = GafferUI.Label( "Enabled" )
+					self.__enabled = GafferUI.BoolPlugValueWidget( None )
+					self.__enabled.boolWidget().setDisplayMode( GafferUI.BoolWidget.DisplayMode.Switch )
+
+					button = GafferUI.Button( "Reset" )
+					button.clickedSignal().connect( Gaffer.WeakMethod( self.__buttonClicked ), scoped = False )
 
 		self.__tool.statusChangedSignal().connect( Gaffer.WeakMethod( self.__update, fallbackResult = None ), scoped = False )
 
@@ -137,3 +151,23 @@ class _StatusWidget( GafferUI.Frame ) :
 		self.__infoIcon.setVisible( info )
 		self.__warningIcon.setVisible( warn )
 		self.__errorIcon.setVisible( error )
+
+		plug = self.__tool.plug()
+		enabledPlug = self.__tool.enabledPlug()
+
+		self.__controls.setVisible( plug is not None )
+
+		self.__enabled.setPlug( enabledPlug )
+		self.__enabled.setVisible( enabledPlug is not None )
+		self.__enabledLabel.setVisible( enabledPlug is not None )
+
+	def __buttonClicked( self, *unused ) :
+
+		plug = self.__tool.plug()
+
+		if plug is None :
+			return
+
+		with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
+			plug["min"].setValue( imath.V2f( 0 ) )
+			plug["max"].setValue( imath.V2f( 1 ) )

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -531,6 +531,18 @@ CropWindowTool::StatusChangedSignal &CropWindowTool::statusChangedSignal()
 	return m_statusChangedSignal;
 }
 
+Gaffer::Box2fPlug *CropWindowTool::plug()
+{
+	findCropWindowPlug();
+	return m_cropWindowPlug.get();
+}
+
+Gaffer::BoolPlug *CropWindowTool::enabledPlug()
+{
+	findCropWindowPlug();
+	return m_cropWindowEnabledPlug.get();
+}
+
 GafferScene::ScenePlug *CropWindowTool::scenePlug()
 {
 	return getChild<ScenePlug>( g_firstPlugIndex );

--- a/src/GafferSceneUIModule/ToolBinding.cpp
+++ b/src/GafferSceneUIModule/ToolBinding.cpp
@@ -64,6 +64,18 @@ using namespace GafferSceneUI;
 namespace
 {
 
+Gaffer::Box2fPlugPtr cropWindowToolPlugWrapper( CropWindowTool &tool )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return tool.plug();
+}
+
+Gaffer::BoolPlugPtr cropWindowToolEnabledPlugWrapper( CropWindowTool &tool )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return tool.enabledPlug();
+}
+
 struct StatusChangedSlotCaller
 {
 	boost::signals::detail::unusable operator()( boost::python::object slot, CropWindowTool &t )
@@ -174,6 +186,8 @@ void GafferSceneUIModule::bindTools()
 	{
 		GafferBindings::NodeClass<CropWindowTool>( nullptr, no_init )
 			.def( "status", &CropWindowTool::status )
+			.def( "plug", &cropWindowToolPlugWrapper )
+			.def( "enabledPlug", &cropWindowToolEnabledPlugWrapper )
 			.def( "statusChangedSignal", &CropWindowTool::statusChangedSignal, return_internal_reference<1>() )
 		;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/896779/90759891-fd609500-e2d8-11ea-9898-56aa324daece.png)

Closes #3822. Implemented as widgets in the overlay, rather than as a menu to make it more obvious to users.