### PR TITLE
SceneViewInspector : Improve edit window plug labels

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Fixes
  - Fixed bug preventing the Inspector from finding shaders when assigned via a Switch.
  - Fixed bug that caused the wrong plug to be edited by the Inspector with nested EditScopes.
  - Fixed bug that prevented selecting an Edit Scope that contained other Edit Scopes.
+ - Fixed bug that caused an exception when simultaneously editing multiple plugs the Inspector.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Improvements
 - Viewer :
  - Added <kbd>Ctrl-D</kbd> shortcut to duplicate currently viewed image when viewing the output of Catalogue node (#3545).
  - Added enabled/reset controls to the Crop Window Tool.
+ - Improved display of the edited plug in the Inspector's pop-up edit windows.
 
 Fixes
 -----

--- a/python/GafferSceneUI/_SceneViewInspector.py
+++ b/python/GafferSceneUI/_SceneViewInspector.py
@@ -894,7 +894,7 @@ class _EditWindow( GafferUI.Window ) :
 		if widget is not None and widgetUsable( widget ) :
 			return widget
 
-		for childPlug in Gaffer.Plug.Range( plugValueWidget.getPlug() ) :
+		for childPlug in Gaffer.Plug.Range( next( iter( plugValueWidget.getPlugs() ) ) ) :
 			childWidget = plugValueWidget.childPlugValueWidget( childPlug )
 			if childWidget is not None :
 				childTextWidget = cls.__textWidget( childWidget )


### PR DESCRIPTION
Reinstates the plug path when editing within an EditScope (otherwise you can't tell whether you're editing a source node, or a tweak).