### PR TITLE
Viewer : Basic support for nested edit scopes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Fixes
 -----
 
-- Viewer : Fixed bug preventing the Inspector from finding shaders when assigned via a Switch.
+- Viewer :
+ - Fixed bug preventing the Inspector from finding shaders when assigned via a Switch.
+ - Fixed bug that caused the wrong plug to be edited by the Inspector with nested EditScopes.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Fixes
 - Viewer :
  - Fixed bug preventing the Inspector from finding shaders when assigned via a Switch.
  - Fixed bug that caused the wrong plug to be edited by the Inspector with nested EditScopes.
+ - Fixed bug that prevented selecting an Edit Scope that contained other Edit Scopes.
 
 API
 ---

--- a/python/GafferSceneUI/_SceneViewInspector.py
+++ b/python/GafferSceneUI/_SceneViewInspector.py
@@ -598,7 +598,10 @@ class _ParameterInspector( object ) :
 
 				# We can potentially make use of this node
 
-				if ( editScope is None or editScope.isAncestorOf( attributeHistory.scene ) ) and edit.hasEdit :
+				# Check the first parent scope of the edit, as they may be nested
+				parentEditScope = attributeHistory.scene.ancestor( Gaffer.EditScope )
+
+				if edit.hasEdit and ( editScope is None or editScope.isSame( parentEditScope ) ) :
 					# If no editScope has been specified, or we're inside the target edit scope,
 					# then we can safely use this edit if we have one.
 					# The hasEdit check is deliberate to ensure that we don't include 'potential' targets, such

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -189,10 +189,13 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 		def addItem( editScope, enabled = True ) :
 
 			result.append(
-				"/" + editScope.relativeName( editScope.scriptNode() ).replace( ".", "/" ),
+				# The underscore suffix prevents collisions with a node and
+				# it's submenu if it has nested edit scopes.
+				"/%s_" % editScope.relativeName( editScope.scriptNode() ).replace( ".", "/" ),
 				{
 					"command" : functools.partial( Gaffer.WeakMethod( self.__connectEditScope ), editScope ),
 					"active" : enabled,
+					"label" : editScope.getName(),
 					"checkBox" : editScope == currentEditScope,
 				}
 			)


### PR DESCRIPTION
People are experimenting with nested edit scopes in production. We're not 100% on this yet, and there will most likely be other issues that arise. This PR proactively fixes a couple of known issues.
