### PR TITLE
ImageGadget : Hack around GCC 4 compile bug

### DIFF
--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -34,6 +34,13 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+// Workaround for this bug in GCC 4.8 :
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59483
+#include "boost/config.hpp"
+#if defined(BOOST_GCC) && BOOST_GCC < 40900
+	#define protected public
+#endif
+
 #include "GafferImageUI/ImageGadget.h"
 
 #include "GafferImage/ImageAlgo.h"


### PR DESCRIPTION
John's recent changes to ImageGadget trip this bug:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59483

( GCC 4 doesn't allow you to access private or protected members by qualified name within lambdas )

Until we can get IE off of GCC 4, we'll need to use some sort of hack like this.