### PR TITLE
NodeEditor : Decorate collapsibles

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,9 @@ Fixes
   - Fixed bug that could cause the inspector to show a different location to other Editors.
   - Fixed bug when the selected location doesn't exist in the input scene.
 - CollectScenes : Fixed childNames hashing bug.
+- NodeAlgo : Fixed bug that caused `isSetToUserDefault()` to return `True` when the plug's input was from a ComputeNode.
+  Like `ValuePlug::isSetToDefault()`, `isSetToUserDefault()` will now never trigger a compute, and all computed inputs
+  are treated as non-default.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - CollectScenes : Added support for collecting at roots of arbitrary depth.
 - AttributeVisualiser : Added support for V2f, V3f, V2i, V3i, V2d and V3d data types.
+- Node Editor : Added decoration to collapsed sections when any of their children have non-default values.
 
 Fixes
 -----

--- a/python/Gaffer/NodeAlgo.py
+++ b/python/Gaffer/NodeAlgo.py
@@ -126,6 +126,13 @@ def isSetToUserDefault( plug ) :
 	if userDefault is None :
 		return False
 
+	source = plug.source()
+	if source.direction() == Gaffer.Plug.Direction.Out and isinstance( source.node(), Gaffer.ComputeNode ) :
+		# Computed values may vary by context, as such there is no
+		# single "current value", so no true concept of whether or not
+		# it's at the user default.
+		return False
+
 	return userDefault == plug.getValue()
 
 def applyUserDefault( plug ) :

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -153,8 +153,8 @@ class MetadataTest( GafferTest.TestCase ) :
 
 	def testInstanceMetadata( self ) :
 
-		Gaffer.Metadata.registerValue( GafferTest.AddNode.staticTypeId(), "imt", "globalNodeValue" )
-		Gaffer.Metadata.registerValue( GafferTest.AddNode.staticTypeId(), "op1", "imt", "globalPlugValue" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "imt", "globalNodeValue" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "imt", "globalPlugValue" )
 
 		n = GafferTest.AddNode()
 

--- a/python/GafferTest/NodeAlgoTest.py
+++ b/python/GafferTest/NodeAlgoTest.py
@@ -75,6 +75,25 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 		self.assertEqual( node3["op1"].getValue(), 0 )
 		self.assertFalse( Gaffer.NodeAlgo.isSetToUserDefault( node["op1"] ) )
 
+	def testUserDefaultConnectedToCompute( self ) :
+
+		srcNode = GafferTest.AddNode()
+		node = GafferTest.AddNode()
+
+		Gaffer.Metadata.registerValue( GafferTest.AddNode.staticTypeId(), "op1", "userDefault", IECore.IntData( 7 ) )
+		node["op1"].setValue( 7 )
+		self.assertTrue( Gaffer.NodeAlgo.isSetToUserDefault( node["op1"] ) )
+
+		node["op1"].setInput( srcNode["sum"] )
+		self.assertFalse( Gaffer.NodeAlgo.isSetToUserDefault( node["op1"] ) )
+
+		# Even if it happens to have the same value
+
+		srcNode["op1"].setValue( 7 )
+		srcNode["op2"].setValue( 0 )
+		self.assertEqual( srcNode["sum"].getValue(), 7 )
+		self.assertFalse( Gaffer.NodeAlgo.isSetToUserDefault( node["op1"] ) )
+
 	def testCompoundPlugUserDefaults( self ) :
 
 		node = GafferTest.CompoundPlugNode()

--- a/python/GafferTest/NodeAlgoTest.py
+++ b/python/GafferTest/NodeAlgoTest.py
@@ -49,7 +49,7 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 
 		self.assertEqual( node["op1"].getValue(), 0 )
 		self.assertFalse( Gaffer.NodeAlgo.hasUserDefault( node["op1"] ) )
-		Gaffer.Metadata.registerValue( GafferTest.AddNode.staticTypeId(), "op1", "userDefault", IECore.IntData( 7 ) )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "userDefault", IECore.IntData( 7 ) )
 		self.assertTrue( Gaffer.NodeAlgo.hasUserDefault( node["op1"] ) )
 		self.assertFalse( Gaffer.NodeAlgo.isSetToUserDefault( node["op1"] ) )
 		Gaffer.NodeAlgo.applyUserDefaults( node )
@@ -69,7 +69,7 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 
 		# the userDefault can be unregistered by overriding with None
 		node3 = GafferTest.AddNode()
-		Gaffer.Metadata.registerValue( GafferTest.AddNode.staticTypeId(), "op1", "userDefault", None )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "userDefault", None )
 		self.assertFalse( Gaffer.NodeAlgo.hasUserDefault( node3["op1"] ) )
 		Gaffer.NodeAlgo.applyUserDefaults( node3 )
 		self.assertEqual( node3["op1"].getValue(), 0 )
@@ -80,7 +80,7 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 		srcNode = GafferTest.AddNode()
 		node = GafferTest.AddNode()
 
-		Gaffer.Metadata.registerValue( GafferTest.AddNode.staticTypeId(), "op1", "userDefault", IECore.IntData( 7 ) )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "userDefault", IECore.IntData( 7 ) )
 		node["op1"].setValue( 7 )
 		self.assertTrue( Gaffer.NodeAlgo.isSetToUserDefault( node["op1"] ) )
 
@@ -99,7 +99,7 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 		node = GafferTest.CompoundPlugNode()
 
 		self.assertEqual( node["p"]["s"].getValue(), "" )
-		Gaffer.Metadata.registerValue( GafferTest.CompoundPlugNode.staticTypeId(), "p.s", "userDefault", IECore.StringData( "from the metadata" ) )
+		Gaffer.Metadata.registerValue( GafferTest.CompoundPlugNode, "p.s", "userDefault", IECore.StringData( "from the metadata" ) )
 		self.assertFalse( Gaffer.NodeAlgo.isSetToUserDefault( node["p"]["s"] ) )
 		Gaffer.NodeAlgo.applyUserDefaults( node )
 		self.assertEqual( node["p"]["s"].getValue(), "from the metadata" )
@@ -127,7 +127,7 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 		self.assertEqual( node["op1"].getValue(), 0 )
 		self.assertEqual( node2["op1"].getValue(), 0 )
 
-		Gaffer.Metadata.registerValue( GafferTest.AddNode.staticTypeId(), "op1", "userDefault", IECore.IntData( 1 ) )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "userDefault", IECore.IntData( 1 ) )
 		Gaffer.Metadata.registerValue( node2["op1"], "userDefault", IECore.IntData( 2 ) )
 		Gaffer.NodeAlgo.applyUserDefaults( [ node, node2 ] )
 

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -118,20 +118,10 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		valueChanged = plug.getInput() is not None
 		if not valueChanged and isinstance( plug, Gaffer.ValuePlug ) :
-			with self.getContext() :
-				if Gaffer.NodeAlgo.hasUserDefault( plug ) :
-					try:
-						valueChanged = not Gaffer.NodeAlgo.isSetToUserDefault( plug )
-					except:
-						# an error here should not cause the ui to break, specially since the value widget corresponding could be indicating the error itself
-						valueChanged = True
-				else :
-					try:
-						valueChanged = not plug.isSetToDefault()
-					except:
-						# an error here should not cause the ui to break, specially since the value widget corresponding could be indicating the error itself
-						valueChanged = True
-
+			if Gaffer.NodeAlgo.hasUserDefault( plug ) :
+				valueChanged = not Gaffer.NodeAlgo.isSetToUserDefault( plug )
+			else :
+				valueChanged = not plug.isSetToDefault()
 		self.__setValueChanged( valueChanged )
 
 	# Sets whether or not the label be rendered in a ValueChanged state.

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -116,6 +116,9 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		plug = self.getPlug()
 
+		## \todo: This is mirrored in PlugLayout and needs centralising in NodeAlgo (along
+		# with proper support for child plug connections/defaults) at the next API break.
+
 		valueChanged = plug.getInput() is not None
 		if not valueChanged and isinstance( plug, Gaffer.ValuePlug ) :
 			if Gaffer.NodeAlgo.hasUserDefault( plug ) :

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1,3 +1,4 @@
+
 ##########################################################################
 #
 #  Copyright (c) 2011-2012, John Haddon. All rights reserved.
@@ -753,6 +754,18 @@ _styleSheet = string.Template(
 	QCheckBox#gafferCollapsibleToggle::indicator:checked:hover,
 	QCheckBox#gafferCollapsibleToggle::indicator:checked:focus {
 		image: url($GAFFER_ROOT/graphics/collapsibleArrowRightHover.png);
+	}
+
+	*[gafferValueChanged="true"] > QCheckBox#gafferCollapsibleToggle::indicator:unchecked,
+	*[gafferValueChanged="true"] > QCheckBox#gafferCollapsibleToggle::indicator:unchecked:hover,
+	*[gafferValueChanged="true"] > CheckBox#gafferCollapsibleToggle::indicator:unchecked:focus {
+		image: url($GAFFER_ROOT/graphics/collapsibleArrowDownValueChanged.png);
+	}
+
+	*[gafferValueChanged="true"] > QCheckBox#gafferCollapsibleToggle::indicator:checked,
+	*[gafferValueChanged="true"] > QCheckBox#gafferCollapsibleToggle::indicator:checked:hover,
+	*[gafferValueChanged="true"] > QCheckBox#gafferCollapsibleToggle::indicator:checked:focus {
+		image: url($GAFFER_ROOT/graphics/collapsibleArrowRightValueChanged.png);
 	}
 
 	QHeaderView {

--- a/python/GafferUITest/NodeEditorTest.py
+++ b/python/GafferUITest/NodeEditorTest.py
@@ -39,10 +39,40 @@ import unittest
 import weakref
 
 import Gaffer
+import GafferTest
 import GafferUI
 import GafferUITest
 
 class NodeEditorTest( GafferUITest.TestCase ) :
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testPerformance( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["smallNode"] = Gaffer.Node()
+
+		bn = Gaffer.Node()
+		s["bigNode"] = bn
+
+		for i in range( 5 ) :
+			for j in range( 5 ) :
+				for k in range( 10 ) :
+					p = Gaffer.IntPlug( defaultValue = i+j+k )
+					Gaffer.Metadata.registerValue( p, "layout:section", "%d.%d" % ( i, j ) )
+					bn.addChild( p )
+
+		a =  Gaffer.StandardSet( [ s["smallNode"] ] )
+		b =  Gaffer.StandardSet( [ s["bigNode"] ] )
+
+		sw = GafferUI.ScriptWindow.acquire( s )
+		ne = GafferUI.NodeEditor.acquire( s["smallNode"] )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			for i in range( 2 ) :
+				ne.setNodeSet( a )
+				ne.nodeUI()
+				ne.setNodeSet( b )
+				ne.nodeUI()
 
 	def testAcquireReusesEditors( self ) :
 

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -64,8 +64,10 @@
 				'arrowRight10',
 				'collapsibleArrowDown',
 				'collapsibleArrowDownHover',
+				'collapsibleArrowDownValueChanged',
 				'collapsibleArrowRight',
-				'collapsibleArrowRightHover'
+				'collapsibleArrowRightHover',
+				'collapsibleArrowRightValueChanged'
 			]
 
 		},

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -2638,6 +2638,22 @@
          x="130"
          y="1494"
          inkscape:label="collapsibleArrowRightHover" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         id="collapsibleArrowDownValueChanged"
+         width="10"
+         height="10"
+         x="148"
+         y="1494"
+         inkscape:label="collapsibleArrowDownValueChanged" />
+      <rect
+         inkscape:label="collapsibleArrowRightValueChanged"
+         y="1494"
+         x="162"
+         height="10"
+         width="10"
+         id="collapsibleArrowRightValueChanged"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
     </g>
     <g
        id="g2684"
@@ -3567,6 +3583,40 @@
          d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
          transform="matrix(0,-0.65333366,-0.646633,0,494.80333,1626.7289)"
          inkscape:label="collapsibleDownHover" />
+      <path
+         sodipodi:type="star"
+         style="fill:#63ba86;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path4943"
+         sodipodi:sides="3"
+         sodipodi:cx="117.14286"
+         sodipodi:cy="578.07648"
+         sodipodi:r1="7.1428571"
+         sodipodi:r2="5.7786927"
+         sodipodi:arg1="1.0471976"
+         sodipodi:arg2="2.0943952"
+         inkscape:flatsided="true"
+         inkscape:rounded="0"
+         inkscape:randomized="0"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+         transform="matrix(-0.65333366,0,0,0.646633,242.3667,1177.5589)"
+         inkscape:label="collapsibleRightValueChanged" />
+      <path
+         inkscape:label="collapsibleDownValueChanged"
+         transform="matrix(0,-0.65333366,-0.646633,0,526.80332,1626.7289)"
+         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+         inkscape:randomized="0"
+         inkscape:rounded="0"
+         inkscape:flatsided="true"
+         sodipodi:arg2="2.0943952"
+         sodipodi:arg1="1.0471976"
+         sodipodi:r2="5.7786927"
+         sodipodi:r1="7.1428571"
+         sodipodi:cy="578.07648"
+         sodipodi:cx="117.14286"
+         sodipodi:sides="3"
+         id="path4945"
+         style="fill:#63ba86;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:type="star" />
     </g>
     <rect
        style="display:inline;fill:url(#linearGradient1646);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.80000001;stroke-opacity:1"

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -4465,23 +4465,6 @@
        sodipodi:type="arc"
        inkscape:label="#path3352" />
     <path
-       sodipodi:type="star"
-       style="fill:#69ffa5;fill-opacity:0.99215686;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.5598439;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="valueChanged"
-       sodipodi:sides="6"
-       sodipodi:cx="298.875"
-       sodipodi:cy="13.687498"
-       sodipodi:r1="5.8454323"
-       sodipodi:r2="1.2886781"
-       sodipodi:arg1="0.94448073"
-       sodipodi:arg2="1.4443827"
-       inkscape:flatsided="false"
-       inkscape:rounded="0"
-       inkscape:randomized="0"
-       d="m 302.30138,18.423424 -3.26391,-3.457531 -2.55071,4.0569 1.36235,-4.555392 -4.78873,-0.180534 4.62626,-1.097861 -2.23802,-4.2374343 3.26391,3.4575313 2.55071,-4.0569002 -1.36235,4.5553922 4.78873,0.180534 -4.62626,1.097861 z"
-       transform="matrix(1.1039167,-0.49853331,0.49895085,1.1048412,55.474744,203.81434)"
-       inkscape:label="#path3064" />
-    <path
        inkscape:connector-curvature="0"
        style="fill:url(#backgroundLighter);fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686"
        d="m 448,72.862183 h -8.5 v 3 l -7,-6 7,-6 v 3 h 8.5"
@@ -7665,5 +7648,20 @@
        x="69.074638"
        y="115.57742"
        inkscape:label="rect2708" />
+    <circle
+       id="path6430"
+       cx="397"
+       cy="70.362183"
+       style="fill:#63ba86;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-opacity:1"
+       inkscape:label="#path6430"
+       r="3" />
+    <rect
+       style="fill:none;fill-opacity:0.99215686;stroke:none;stroke-opacity:1"
+       id="valueChanged"
+       width="10"
+       height="8"
+       x="391"
+       y="66.362183"
+       inkscape:label="#rect9457" />
   </g>
 </svg>


### PR DESCRIPTION
Decorates collapsibles whose children are set to non-default values.

![image](https://user-images.githubusercontent.com/896779/92254451-d30dfa80-eec8-11ea-94c8-3f58c22a8167.png)

Ideally we'd decorate the tab title, but Qt is being somewhat unstable adding/removing tab buttons on the fly. So, to avoid this becoming a time sink, we'll keep it simple for now.

@johnhaddon, wasn't 100% on the name of the attribute we're storing the `valuesChanged` state in on each section, as its very plug specific. Using something more generic then seemed a bit contrived. Any preferences most welcome.
