### PR TITLE
OSLShader : Register compatible shader

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,8 @@ API
   - Added `updateLayout()` virtual method to simplify implementation of container types.
   - Added `dirty()` method for finer grained tracking of changes than `requestRender()` provided.
   - Deprecated `requestRender()` method. Use `dirty()` instead.
+- OSLShader : Added `registerCompatibleShader()` method to allow connections from non-OSL shaders
+ to be made.
 
 Breaking Changes
 ----------------

--- a/include/GafferOSL/OSLShader.h
+++ b/include/GafferOSL/OSLShader.h
@@ -102,6 +102,9 @@ class GAFFEROSL_API OSLShader : public GafferScene::Shader
 			}
 		}
 
+		/// Allows other renderer shaders to connect to OSL shaders by registering them.
+		/// Returns true on success, false if already added.
+		static bool registerCompatibleShader( const IECore::InternedString shaderType );
 
 
 	protected :

--- a/src/GafferArnold/ArnoldShader.cpp
+++ b/src/GafferArnold/ArnoldShader.cpp
@@ -39,6 +39,8 @@
 
 #include "GafferArnold/ParameterHandler.h"
 
+#include "GafferOSL/OSLShader.h"
+
 #include "Gaffer/CompoundNumericPlug.h"
 #include "Gaffer/NumericPlug.h"
 #include "Gaffer/StringPlug.h"
@@ -59,6 +61,15 @@ using namespace IECore;
 using namespace GafferScene;
 using namespace GafferArnold;
 using namespace Gaffer;
+using namespace GafferOSL;
+
+namespace
+{
+
+// This is to allow Arnold Shaders to be connected to OSL Shaders
+static bool g_oslRegistration = OSLShader::registerCompatibleShader( "ai:surface" );
+
+} // namespace
 
 GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( ArnoldShader );
 


### PR DESCRIPTION
This allows a way to register renderer-specific shaders to be allowed to connect to OSL shaders. Notably the current mechanism was a hard-coded to only allow Arnold shaders to connect, but other renderers like Cycles also allow OSL shaders to freely connect to Cycles-specific shaders, so there needs to be a mechanism for this.

### Related issues ###

- Allows other shaders to register their compatibility with OSL shaders to connect to them

### Dependencies ###

- N/A

### Breaking changes ###

- OSL Shader public static function added, Arnold shader needs to link with OSLShader now, causing a dependency.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.

Currently I have only made a basic test of connecting Arnold shaders to OSL shaders and vice-versa, and it seems to function like it did, however I am not sure if removing the output types checking "osl:shader" and "ai:surface" strings will cause side-effects (probably!) so don't merge just yet I would advise...