### PR TITLE
PrimitiveInspector : Preserve scroll position when updating if possible

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- PrimitiveInspector : Fixed bug that caused data lists to lose their scroll position during updates.
 - CollectScenes : Fixed childNames hashing bug.
 
 0.57.7.1 (relative to 0.57.7.0)

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Fixes
 -----
 
-- PrimitiveInspector : Fixed bug that caused data lists to lose their scroll position during updates.
+- PrimitiveInspector :
+  - Fixed bug that caused data lists to lose their scroll position during updates.
+  - Fixed bug that could cause the inspector to show a different location to other Editors.
 - CollectScenes : Fixed childNames hashing bug.
 
 0.57.7.1 (relative to 0.57.7.0)

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Fixes
 - PrimitiveInspector :
   - Fixed bug that caused data lists to lose their scroll position during updates.
   - Fixed bug that could cause the inspector to show a different location to other Editors.
+  - Fixed bug when the selected location doesn't exist in the input scene.
 - CollectScenes : Fixed childNames hashing bug.
 
 0.57.7.1 (relative to 0.57.7.0)

--- a/python/GafferSceneUI/PrimitiveInspector.py
+++ b/python/GafferSceneUI/PrimitiveInspector.py
@@ -266,7 +266,6 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 
 	def __update( self ) :
 		with self.getContext() :
-			targetPaths = GafferSceneUI.ContextAlgo.getSelectedPaths( self.getContext() ).paths()
 
 			self.__locationLabel.setText( "Select a location to inspect" )
 
@@ -288,13 +287,15 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 				self.__nodeFrame._qtWidget().setProperty( "gafferDiff", "AB" )
 				self.__nodeFrame._repolish()
 
-				if len( targetPaths ) :
+				targetPath = GafferSceneUI.ContextAlgo.getLastSelectedPath( self.getContext() )
 
-					self.__locationLabel.setText( targetPaths[-1] )
+				if targetPath :
+
+					self.__locationLabel.setText( targetPath )
 					self.__locationFrame._qtWidget().setProperty( "gafferDiff", "AB" )
 					self.__locationFrame._repolish()
 
-					obj = self.__scenePlug.object( targetPaths[-1] )
+					obj = self.__scenePlug.object( targetPath )
 					if isinstance( obj, IECoreScene.Primitive ) :
 
 						haveData = True

--- a/python/GafferSceneUI/PrimitiveInspector.py
+++ b/python/GafferSceneUI/PrimitiveInspector.py
@@ -268,14 +268,6 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 		with self.getContext() :
 			targetPaths = GafferSceneUI.ContextAlgo.getSelectedPaths( self.getContext() ).paths()
 
-			for interpolation in [IECoreScene.PrimitiveVariable.Interpolation.Constant, IECoreScene.PrimitiveVariable.Interpolation.Uniform,
-				IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECoreScene.PrimitiveVariable.Interpolation.Varying,
-				IECoreScene.PrimitiveVariable.Interpolation.FaceVarying] :
-
-				self.__dataWidgets[interpolation].setData( None )
-				self.__dataWidgets[interpolation].setToolTips( [] )
-				self.__tabbedContainer.setLabel( self.__tabbedChildWidgets[interpolation], str( interpolation ) )
-
 			self.__locationLabel.setText( "Select a location to inspect" )
 
 			self.__locationFrame._qtWidget().setProperty( "gafferDiff", "Other" )
@@ -286,6 +278,8 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 			headers = collections.OrderedDict()
 			primVars = collections.OrderedDict()
 			toolTips = collections.OrderedDict()
+
+			haveData = False
 
 			if self.__scenePlug :
 
@@ -302,6 +296,9 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 
 					obj = self.__scenePlug.object( targetPaths[-1] )
 					if isinstance( obj, IECoreScene.Primitive ) :
+
+						haveData = True
+
 						for primvarName in _orderPrimitiveVariables( obj.keys() ) :
 							primvar = obj[primvarName]
 							if not primvar.interpolation in primVars :
@@ -328,5 +325,15 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 			else:
 
 				self.__nodeLabel.setFormatter( lambda x : "Select a node to inspect" )
+
+			if not haveData :
+
+				for interpolation in [IECoreScene.PrimitiveVariable.Interpolation.Constant, IECoreScene.PrimitiveVariable.Interpolation.Uniform,
+					IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECoreScene.PrimitiveVariable.Interpolation.Varying,
+					IECoreScene.PrimitiveVariable.Interpolation.FaceVarying] :
+
+					self.__dataWidgets[interpolation].setData( None )
+					self.__dataWidgets[interpolation].setToolTips( [] )
+					self.__tabbedContainer.setLabel( self.__tabbedChildWidgets[interpolation], str( interpolation ) )
 
 GafferUI.Editor.registerType( "PrimitiveInspector", PrimitiveInspector )

--- a/python/GafferSceneUI/PrimitiveInspector.py
+++ b/python/GafferSceneUI/PrimitiveInspector.py
@@ -265,9 +265,8 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 		self.__update()
 
 	def __update( self ) :
-		with self.getContext() :
 
-			self.__locationLabel.setText( "Select a location to inspect" )
+		with self.getContext() :
 
 			self.__locationFrame._qtWidget().setProperty( "gafferDiff", "Other" )
 			self.__locationFrame._repolish()
@@ -291,38 +290,48 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 
 				if targetPath :
 
-					self.__locationLabel.setText( targetPath )
-					self.__locationFrame._qtWidget().setProperty( "gafferDiff", "AB" )
-					self.__locationFrame._repolish()
+					if self.__scenePlug.exists( targetPath ) :
 
-					obj = self.__scenePlug.object( targetPath )
-					if isinstance( obj, IECoreScene.Primitive ) :
+						self.__locationLabel.setText( targetPath )
+						self.__locationFrame._qtWidget().setProperty( "gafferDiff", "AB" )
+						self.__locationFrame._repolish()
 
-						haveData = True
+						obj = self.__scenePlug.object( targetPath )
+						if isinstance( obj, IECoreScene.Primitive ) :
 
-						for primvarName in _orderPrimitiveVariables( obj.keys() ) :
-							primvar = obj[primvarName]
-							if not primvar.interpolation in primVars :
-								headers[primvar.interpolation] = []
-								primVars[primvar.interpolation] = []
-								toolTips[primvar.interpolation] = []
+							haveData = True
 
-							headers[primvar.interpolation].append( primvarName )
-							primVars[primvar.interpolation].append( conditionPrimvar( primvar ) )
-							toolTips[primvar.interpolation].append( _getPrimvarToolTip( primvarName, primvar ) )
+							for primvarName in _orderPrimitiveVariables( obj.keys() ) :
+								primvar = obj[primvarName]
+								if not primvar.interpolation in primVars :
+									headers[primvar.interpolation] = []
+									primVars[primvar.interpolation] = []
+									toolTips[primvar.interpolation] = []
 
-						for interpolation in primVars.keys() :
+								headers[primvar.interpolation].append( primvarName )
+								primVars[primvar.interpolation].append( conditionPrimvar( primvar ) )
+								toolTips[primvar.interpolation].append( _getPrimvarToolTip( primvarName, primvar ) )
 
-							pv = primVars.get( interpolation, None )
-							h = headers.get( interpolation, None )
-							t = toolTips.get( interpolation, None )
+							for interpolation in primVars.keys() :
 
-							self.__tabbedContainer.setLabel( self.__tabbedChildWidgets[interpolation],
-								"{0} ({1})".format( str( interpolation ), len( pv ) ) )
+								pv = primVars.get( interpolation, None )
+								h = headers.get( interpolation, None )
+								t = toolTips.get( interpolation, None )
 
-							self.__dataWidgets[interpolation].setToolTips( t )
-							self.__dataWidgets[interpolation].setHeader( h )
-							self.__dataWidgets[interpolation].setData( pv )
+								self.__tabbedContainer.setLabel( self.__tabbedChildWidgets[interpolation],
+									"{0} ({1})".format( str( interpolation ), len( pv ) ) )
+
+								self.__dataWidgets[interpolation].setToolTips( t )
+								self.__dataWidgets[interpolation].setHeader( h )
+								self.__dataWidgets[interpolation].setData( pv )
+					else :
+
+						self.__locationLabel.setText( 'Location %s does not exist' % targetPath )
+
+				else :
+
+					self.__locationLabel.setText( "Select a location to inspect" )
+
 			else:
 
 				self.__nodeLabel.setFormatter( lambda x : "Select a node to inspect" )


### PR DESCRIPTION
We were clearing out the widget before setting new data, which would result in any existing scroll position being reset.