### PR TITLE
CollectScenes : Support collection at roots of arbitrary depth

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Improvements
 ------------
 
+- CollectScenes : Added support for collecting at roots of arbitrary depth.
 - AttributeVisualiser : Added support for V2f, V3f, V2i, V3i, V2d and V3d data types.
 
 Fixes

--- a/include/GafferScene/CollectScenes.h
+++ b/include/GafferScene/CollectScenes.h
@@ -98,6 +98,9 @@ class GAFFERSCENE_API CollectScenes : public SceneProcessor
 
 	private :
 
+		class SourceScope;
+		class SourcePathScope;
+
 		static size_t g_firstPlugIndex;
 
 };

--- a/include/GafferScene/CollectScenes.h
+++ b/include/GafferScene/CollectScenes.h
@@ -72,6 +72,9 @@ class GAFFERSCENE_API CollectScenes : public SceneProcessor
 
 	protected :
 
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+
 		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
@@ -100,6 +103,9 @@ class GAFFERSCENE_API CollectScenes : public SceneProcessor
 
 		class SourceScope;
 		class SourcePathScope;
+
+		Gaffer::ObjectPlug *rootTreePlug();
+		const Gaffer::ObjectPlug *rootTreePlug() const;
 
 		static size_t g_firstPlugIndex;
 

--- a/python/GafferSceneTest/CollectScenesTest.py
+++ b/python/GafferSceneTest/CollectScenesTest.py
@@ -37,6 +37,8 @@
 import inspect
 import os
 import unittest
+import imath
+import six
 
 import IECore
 
@@ -281,20 +283,25 @@ class CollectScenesTest( GafferSceneTest.SceneTestCase ) :
 		group["in"][0].setInput( sphere["out"] )
 
 		collect = GafferScene.CollectScenes()
-		collect["rootNames"].setValue( IECore.StringVectorData( [ "A" ] ) )
+		collect["rootNames"].setValue( IECore.StringVectorData( [ "A", "/B/C" ] ) )
 		collect["in"].setInput( group["out"] )
 
 		self.assertSceneValid( collect["out"] )
-		self.assertEqual( collect["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "A" ] ) )
+		self.assertEqual( collect["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "A", "B" ] ) )
 		self.assertEqual( collect["out"].childNames( "/A" ), IECore.InternedStringVectorData( [ "group" ] ) )
 		self.assertEqual( collect["out"].childNames( "/A/group" ), IECore.InternedStringVectorData( [ "sphere" ] ) )
 		self.assertEqual( collect["out"].childNames( "/A/group/sphere" ), IECore.InternedStringVectorData() )
+		self.assertEqual( collect["out"].childNames( "/B" ), IECore.InternedStringVectorData( [ "C" ] ) )
+		self.assertEqual( collect["out"].childNames( "/B/C" ), IECore.InternedStringVectorData( [ "group" ] ) )
+		self.assertEqual( collect["out"].childNames( "/B/C/group" ), IECore.InternedStringVectorData( [ "sphere" ] ) )
+		self.assertEqual( collect["out"].childNames( "/B/C/group/sphere" ), IECore.InternedStringVectorData() )
 
 		collect["sourceRoot"].setValue( "iDontExist" )
 
 		self.assertSceneValid( collect["out"] )
-		self.assertEqual( collect["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "A" ] ) )
+		self.assertEqual( collect["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "A", "B" ] ) )
 		self.assertEqual( collect["out"].childNames( "/A" ), IECore.InternedStringVectorData() )
+		self.assertEqual( collect["out"].childNames( "/B/C" ), IECore.InternedStringVectorData() )
 
 	def testSetRespectsRootName( self ) :
 
@@ -325,6 +332,106 @@ class CollectScenesTest( GafferSceneTest.SceneTestCase ) :
 			list( GafferScene.CollectScenes.RecursiveRange( script ) ),
 			[ script["collect"], script["box"]["collect"] ],
 		)
+
+	def testDeepRoots( self ) :
+
+		sphere = GafferScene.Sphere()
+		sphere["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
+		sphere["sets"].setValue( "setA" )
+
+		collect = GafferScene.CollectScenes()
+		collect["in"].setInput( sphere["out"] )
+		collect["rootNames"].setValue( IECore.StringVectorData( [
+			"/world/ball",
+			"/world/sphere",
+			"/world/marbles/one",
+			"/world/marbles/two",
+		] ) )
+
+		self.assertEqual(
+			collect["out"].childNames( "/" ),
+			IECore.InternedStringVectorData( [ "world" ] )
+		)
+
+		self.assertEqual(
+			collect["out"].childNames( "/world" ),
+			IECore.InternedStringVectorData( [ "ball", "sphere", "marbles" ] )
+		)
+
+		self.assertEqual(
+			collect["out"].childNames( "/world/marbles" ),
+			IECore.InternedStringVectorData( [ "one", "two" ] )
+		)
+
+		self.assertSceneValid( collect["out"] )
+
+		subTree = GafferScene.SubTree()
+		subTree["in"].setInput( collect["out"] )
+
+		for root in collect["rootNames"].getValue() :
+
+			self.assertEqual( collect["out"].transform( root ), imath.M44f() )
+			self.assertEqual( collect["out"].attributes( root ), IECore.CompoundObject() )
+
+			subTree["root"].setValue( root )
+			self.assertScenesEqual( subTree["out"], sphere["out"] )
+
+	def testDuplicateRoots( self ) :
+
+		sphere = GafferScene.Sphere()
+		sphere["sets"].setValue( "${collect:rootName}" )
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		attributes = GafferScene.CustomAttributes()
+		attributes["in"].setInput( sphere["out"] )
+		attributes["filter"].setInput( sphereFilter["out"] )
+		attributes["attributes"]["test"] = Gaffer.NameValuePlug( "test", "${collect:rootName}" )
+
+		options = GafferScene.CustomOptions()
+		options["in"].setInput( attributes["out"] )
+		options["options"]["test"] = Gaffer.NameValuePlug( "test", "${collect:rootName}" )
+
+		collect = GafferScene.CollectScenes()
+		collect["in"].setInput( options["out"] )
+
+		# The user might enter the exact same value multiple times by accident.
+		# And because the values represent paths, they may even enter _different_
+		# values that map to the same path.
+		collect["rootNames"].setValue(
+			IECore.StringVectorData( [
+				"A/B",
+				"/A/B",
+				"/A/B/",
+				"A/B",
+			] )
+		)
+
+		# We automatically uniquefy the names, using the first string as the
+		# value of `collect:rootName`.
+		self.assertEqual( collect["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "A" ] ) )
+		self.assertEqual( collect["out"].childNames( "/A" ), IECore.InternedStringVectorData( [ "B" ] ) )
+		self.assertEqual( collect["out"].attributes( "/A/B/sphere" ), IECore.CompoundObject( { "test" : IECore.StringData( "A/B" ) } ) )
+		self.assertEqual( collect["out"].setNames(), IECore.InternedStringVectorData( [ "A/B" ] ) )
+		self.assertEqual( collect["out"].set( "A/B" ).value, IECore.PathMatcher( [ "/A/B/sphere" ] ) )
+		self.assertEqual( collect["out"].globals(), IECore.CompoundObject( { "option:test" : IECore.StringData( "A/B" ) } ) )
+
+	def testNonLeafRoots( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		collect = GafferScene.CollectScenes()
+		collect["in"].setInput( sphere["out"] )
+		collect["rootNames"].setValue( IECore.StringVectorData( [ "/root", "/root/nested" ] ) )
+
+		with six.assertRaisesRegex( self, Gaffer.ProcessException, '"/root" contains nested roots' ) :
+			collect["out"].childNames( "/root" )
+
+		collect["rootNames"].setValue( IECore.StringVectorData( [ "/root/nested", "/root" ] ) )
+
+		with six.assertRaisesRegex( self, Gaffer.ProcessException, '"/root" contains nested roots' ) :
+			collect["out"].childNames( "/root" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/CollectScenesUI.py
+++ b/python/GafferSceneUI/CollectScenesUI.py
@@ -65,9 +65,8 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			The names of the locations to create at the root of
-			the output scene. The input scene is copied underneath
-			each of these root locations.
+			The paths to the root locations to create in the output scene.
+			The input scene is copied underneath each of these root locations.
 
 			Often the rootNames will be driven by an expression that generates
 			a dynamic number of root locations, perhaps by querying an asset
@@ -81,7 +80,7 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The name of a Context Variable that is set to the current
-			root name when evaluating the input scene. This can be used
+			root location when evaluating the input scene. This can be used
 			in upstream expressions and string substitutions to generate
 			a different hierarchy under each root location.
 			""",
@@ -97,7 +96,7 @@ Gaffer.Metadata.registerNode(
 
 			The rootName variable may be used in expressions and string
 			substitutions for this plug, allowing different subtrees to be
-			collected for each root name in the output.
+			collected for each root location in the output.
 
 			> Tip :
 			> By specifying a leaf location as the root, it is possible to


### PR DESCRIPTION
Previously you could only collect into immediate children of `/`, such as `/A`, `/B` etc. You can now collect at completely arbitrary depths such as `/A/B` and `/A/C`. This is particularly useful for the Spreadsheet+CollectScenes pattern used for things like making lights.

![image](https://user-images.githubusercontent.com/1133871/93205302-82f82900-f74f-11ea-8890-299b6081c9a2.png)

Note that rather than deal with the name collisions that are possible if nested roots (e.g. `/A` and `/A/B`) are specified, we are currently erroring for that case. I have a branch where I've started work on dealing with the collisions, but I'm not yet convinced it's worth the effort, given that we don't anticipate nested roots being useful for our current motivating use cases.