### PR TITLE
GafferArnold : Add missing GafferOSL binding import

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Fixes
   - Fixed bug that could cause the inspector to show a different location to other Editors.
   - Fixed bug when the selected location doesn't exist in the input scene.
 - CollectScenes : Fixed childNames hashing bug.
+- GafferArnold : Added missing GafferOSL Python bindings import.
 
 0.57.7.1 (relative to 0.57.7.0)
 ========

--- a/python/GafferArnold/__init__.py
+++ b/python/GafferArnold/__init__.py
@@ -36,6 +36,10 @@
 
 __import__( "GafferScene" )
 
+# GafferArnold makes use of OSL closure plugs, this ensures that the bindings
+# are always loaded for these, even if people only import GafferArnold
+__import__( "GafferOSL" )
+
 try :
 
 	# Make sure we import IECoreArnold and _GafferArnold


### PR DESCRIPTION
GafferArnold makes use of OSL closure plugs. If the GafferOSL isn't imported when using GafferArnold nodes in python, then the missing plug bindings can result in errors such as:

```
File "python/GafferUI/PlugLayout.py", line 425, in __staticItemMetadataValue
    return cls.__metadataValue( parent, layoutName + ":customWidget:" + item + ":" + name )
TypeError: cannot concatenate 'str' and 'GraphComponent' objects
```