### PR TITLE
Plug : Fix cache invalidation bug for plugs with AcceptsDependencyCycles 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,7 @@ Fixes
   Like `ValuePlug::isSetToDefault()`, `isSetToUserDefault()` will now never trigger a compute, and all computed inputs
   are treated as non-default.
 - GafferArnold : Added missing GafferOSL Python bindings import.
+- Plug : Fixed bug that could break IPR updates following a node graph edit (#3911).
 
 API
 ---

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -757,12 +757,15 @@ class Plug::DirtyPlugs
 
 			for( DownstreamIterator it( plugToDirty ); !it.done(); ++it )
 			{
-				InsertedVertex v = insertVertex( &*it );
+				// The `const_casts()` are harmless because we're starting iteration from
+				// a non-const plug. But they are necessary because DownstreamIterator
+				// doesn't currently have a non-const form, and always yields const plugs.
+				InsertedVertex v = insertVertex( const_cast<Plug *>( &*it ) );
 				if( !it->getFlags( Plug::AcceptsDependencyCycles ) )
 				{
 					add_edge(
 						v.first,
-						insertVertex( it.upstream() ).first,
+						insertVertex( const_cast<Plug *>( it.upstream() ) ).first,
 						m_graph
 					);
 				}
@@ -820,7 +823,7 @@ class Plug::DirtyPlugs
 		// inserted.
 		typedef std::pair<VertexDescriptor, bool> InsertedVertex;
 
-		InsertedVertex insertVertex( const Plug *plug )
+		InsertedVertex insertVertex( Plug *plug )
 		{
 			// We need to hold a reference to the plug, because otherwise
 			// it might be deleted between now and emit(). But if there is
@@ -837,11 +840,11 @@ class Plug::DirtyPlugs
 			}
 
 			VertexDescriptor result = add_vertex( m_graph );
-			m_graph[result] = const_cast<Plug *>( plug );
+			m_graph[result] = plug;
 			m_plugs[plug] = result;
 
 			// Insert parent plug.
-			if( const Plug *parent = plug->parent<Plug>() )
+			if( auto parent = plug->parent<Plug>() )
 			{
 				if( parent->refCount() )
 				{

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -842,6 +842,7 @@ class Plug::DirtyPlugs
 			VertexDescriptor result = add_vertex( m_graph );
 			m_graph[result] = plug;
 			m_plugs[plug] = result;
+			plug->dirty();
 
 			// Insert parent plug.
 			if( auto parent = plug->parent<Plug>() )
@@ -884,7 +885,6 @@ class Plug::DirtyPlugs
 			void finish_vertex( const VertexDescriptor &u, const Graph &graph )
 			{
 				Plug *plug = graph[u].get();
-				plug->dirty();
 				if( Node *node = plug->node() )
 				{
 					node->plugDirtiedSignal()( plug );


### PR DESCRIPTION
We use `depth_first_search()` to call `Plug::dirty()` and emit `plugDirtiedSignal()` for dirtied plugs in order, upstream plugs first, children before parents. But where a plug willingly participates in a dependency cycle as with the Loop node, we cannot guarantee the "upstream first" property for all observers. What constitutes "upstream" in such a cycle is dependent on your point of view. This was OK until Gaffer 0.58, since when `Plug::dirty()` has no longer invalidated the entire cache but now selectively invalidates the entries for individual plugs. This could lead to an observer triggering a compute from `plugDirtiedSignal()` before `dirty()` had been called on all "upstream" plugs. This would then cause the compute to see invalid cache entries for a subset of upstream plugs.

The fix is to decouple the calls to `Plug::dirty()` and `plugDirtiedSignal()`. We now call `Plug::dirty()` when first adding the plug to the graph of dirty plugs, so it is guaranteed to have been called before `plugDirtiedSignal()` is emitted for _any_ plug.

As an aside, I now wonder if the "upstream first" property of `plugDirtiedSignal()` is worth preserving at all, particularly as we are making increasing use of `Plug::AcceptsDependencyCycles`. As we optimise other things, dirty propagation is beginning to factor into interactive profiles, and it might be that relaxing the ordering requirements could provide some scope for improvements. The "children before parents" order must be preserved though.

Fixes #3911.