### PR TITLE
SceneWriter : Fix bug handling fileNames with frame dependencies

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,8 @@ Fixes
   - Fixed bug that could cause the inspector to show a different location to other Editors.
   - Fixed bug when the selected location doesn't exist in the input scene.
 - CollectScenes : Fixed childNames hashing bug.
+- SceneWriter : Fixed error caused by computed filenames with a dependency on time. This
+  makes it possible to write to a sequence of cache files rather than one monolithic file.
 - GafferArnold : Added missing GafferOSL Python bindings import.
 
 0.57.7.1 (relative to 0.57.7.0)

--- a/src/GafferScene/SceneWriter.cpp
+++ b/src/GafferScene/SceneWriter.cpp
@@ -201,7 +201,6 @@ const ScenePlug *SceneWriter::outPlug() const
 
 IECore::MurmurHash SceneWriter::hash( const Gaffer::Context *context ) const
 {
-	Context::Scope scope( context );
 	const ScenePlug *scenePlug = inPlug()->source<ScenePlug>();
 	if ( ( fileNamePlug()->getValue() == "" ) || ( scenePlug == inPlug() ) )
 	{

--- a/src/GafferScene/SceneWriter.cpp
+++ b/src/GafferScene/SceneWriter.cpp
@@ -230,9 +230,7 @@ void SceneWriter::executeSequence( const std::vector<float> &frames ) const
 		throw IECore::Exception( "No input scene" );
 	}
 
-	const std::string fileName = fileNamePlug()->getValue();
-	createDirectories( fileName );
-	SceneInterfacePtr output = SceneInterface::create( fileName, IndexedIO::Write );
+	SceneInterfacePtr output;
 	tbb::mutex mutex;
 	ContextPtr context = new Context( *Context::current() );
 	Context::Scope scopedContext( context.get() );
@@ -240,6 +238,13 @@ void SceneWriter::executeSequence( const std::vector<float> &frames ) const
 	for( std::vector<float>::const_iterator it = frames.begin(); it != frames.end(); ++it )
 	{
 		context->setFrame( *it );
+
+		const std::string fileName = fileNamePlug()->getValue();
+		if( !output || output->fileName() != fileName )
+		{
+			createDirectories( fileName );
+			output = SceneInterface::create( fileName, IndexedIO::Write );
+		}
 
 		ConstCompoundDataPtr sets = SceneAlgo::sets( scene );
 		LocationWriter locationWriter( output, sets, context->getTime(), mutex );


### PR DESCRIPTION
This allows sequences of caches such as `test.####.scc` to be written, as well as supporting cases which have arisen in production where the filename is actually constant, but its hash appears to vary with time (because it has been pulled out of scene globals which do actually vary with time).