### PR TITLE
CropWindowTool : Handle exceptions thrown during render

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Arnold Renderer : Fixed hangs when instancing the output of an Encapsulate node.
+- CropWindowTool : Fixed error handling bugs.
 
 0.57.7.4 (relative to 0.57.7.3)
 ========

--- a/python/GafferSceneUITest/CropWindowToolTest.py
+++ b/python/GafferSceneUITest/CropWindowToolTest.py
@@ -1,0 +1,160 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferImage
+import GafferScene
+import GafferUI
+import GafferUITest
+import GafferSceneUI
+
+class CropWindowToolTest( GafferUITest.TestCase ) :
+
+	def testSceneViewStatus( self ) :
+
+		camera = GafferScene.Camera()
+
+		view = GafferUI.View.create( camera["out"] )
+
+		tool = GafferSceneUI.CropWindowTool( view )
+		tool["active"].setValue( True )
+
+		# Presently, crop window tool updates are coupled to `preRender`, so we
+		# need to actually show the View before we can verify our behaviour.
+
+		with GafferUI.Window() as window :
+			GafferUI.GadgetWidget( view.viewportGadget() )
+		window.setVisible( True )
+
+		# View camera isn't a real camera
+
+		self.waitForIdle( 1 )
+		self.assertEqual( tool.status(), "Error: No applicable crop window for this view" )
+
+		# Working camera, no node to edit
+
+		view["camera"]["lookThroughCamera"].setValue( "/camera" )
+		view["camera"]["lookThroughEnabled"].setValue( True )
+
+		self.waitForIdle( 1 )
+		self.assertEqual( tool.status(), "Error: No crop window found. Insert a <b>StandardOptions</b> node." )
+
+		# Editable
+
+		options = GafferScene.StandardOptions()
+		options["in"].setInput( camera["out"] )
+		view["in"].setInput( options["out"] )
+
+		self.waitForIdle( 1 )
+		self.assertEqual( tool.status(), "Info: Editing <b>StandardOptions.options.renderCropWindow.value</b>" )
+
+		# Locked value plug
+
+		Gaffer.MetadataAlgo.setReadOnly( options["options"]["renderCropWindow"]["value"], True )
+
+		self.waitForIdle( 1 )
+		self.assertEqual( tool.status(), "Warning: <b>StandardOptions.options.renderCropWindow.value</b> is locked" )
+
+		# Locked/off enabled plug
+
+		Gaffer.MetadataAlgo.setReadOnly( options["options"]["renderCropWindow"]["value"], False )
+		options["options"]["renderCropWindow"]["enabled"].setValue( False )
+		Gaffer.MetadataAlgo.setReadOnly( options["options"]["renderCropWindow"]["enabled"], True )
+
+		self.waitForIdle( 1 )
+		self.assertEqual( tool.status(), "Warning: <b>StandardOptions.options.renderCropWindow.value</b> isn't editable" )
+
+		# Check status across visible/invisible overlay transitions (this is
+		# really testing one of the gnarly parts of the status implementation
+		# that has caused trouble before, until we can properly refactor the tool).
+
+		view["camera"]["lookThroughEnabled"].setValue( False )
+
+		self.waitForIdle( 1 )
+		self.assertEqual( tool.status(), "Error: No applicable crop window for this view" )
+
+		view["camera"]["lookThroughEnabled"].setValue( True )
+
+		self.waitForIdle( 1 )
+		self.assertEqual( tool.status(), "Warning: <b>StandardOptions.options.renderCropWindow.value</b> isn't editable" )
+
+	def testImageViewStatus( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["image"] = GafferImage.ImageReader()
+
+		view = GafferUI.View.create( script["image"]["out"] )
+
+		tool = GafferSceneUI.CropWindowTool( view )
+		tool["active"].setValue( True )
+
+		# Presently, crop window tool updates are coupled to `preRender`, so we
+		# need to actually show the View before we can verify our behaviour.
+
+		with GafferUI.Window() as window :
+			GafferUI.GadgetWidget( view.viewportGadget() )
+		window.setVisible( True )
+
+		# Check process exceptions
+
+		script["image"]["fileName"].setValue( "/i/do/not/exist.exr" )
+
+		self.waitForIdle( 1 )
+		self.assertEqual( tool.status(), "Error: image.__oiioReader.out.format : OpenImageIOReader : Could not create ImageInput : Could not open file \"/i/do/not/exist.exr\"" )
+
+		# Missing metadata
+
+		script["image"]["fileName"].setValue( "${GAFFER_ROOT}/resources/images/macaw.exr" )
+
+		self.waitForIdle( 1 )
+		self.assertEqual( tool.status(), "Error: No <b>gaffer:sourceScene</b> metadata in image" )
+
+		script["meta"] = GafferImage.ImageMetadata()
+		script["meta"]["metadata"].addChild( Gaffer.NameValuePlug( "gaffer:sourceScene", "options.out", True, "member1" ) )
+		script["meta"]["in"].setInput( script["image"]["out"] )
+
+		script["options"] = GafferScene.StandardOptions()
+
+		view["in"].setInput( script["meta"]["out"] )
+
+		# Valid options path
+
+		self.waitForIdle( 1 )
+		self.assertEqual( tool.status(), "Info: Editing <b>options.options.renderCropWindow.value</b>" )
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneUITest/__init__.py
+++ b/python/GafferSceneUITest/__init__.py
@@ -51,6 +51,7 @@ from .CameraToolTest import CameraToolTest
 from .VisualiserTest import VisualiserTest
 from .TransformToolTest import TransformToolTest
 from .SourceSetTest import SourceSetTest
+from .CropWindowToolTest import CropWindowToolTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -723,66 +723,75 @@ void CropWindowTool::preRender()
 		return;
 	}
 
-	const Box2f r = resolutionGate();
-
-	if( runTimeCast<SceneView>( view() ) )
+	try
 	{
-		// This is the only check we have that tells us whether we have an
-		// appropriate camera to support the presentation of a crop window.
-		// We don't have any other signals tied to this, hence the need to
-		// check here before render.
-		if( r.isEmpty() )
+		const Box2f r = resolutionGate();
+
+		if( runTimeCast<SceneView>( view() ) )
 		{
-			setErrorMessage( "Error: No applicable crop window for this view" );
+			// This is the only check we have that tells us whether we have an
+			// appropriate camera to support the presentation of a crop window.
+			// We don't have any other signals tied to this, hence the need to
+			// check here before render.
+			if( r.isEmpty() )
+			{
+				setErrorMessage( "Error: No applicable crop window for this view" );
+				setOverlayVisible( false );
+				return;
+			}
+
+			setOverlayVisible( true );
+		}
+
+		if( !m_overlayDirty )
+		{
+			return;
+		}
+		m_overlayDirty = false;
+
+		findScenePlug();
+
+		// This occurs in the ImageView hosted case, when we don't know which node
+		// may have rendered the image being viewed.
+		if( !scenePlug()->getInput() )
+		{
 			setOverlayVisible( false );
 			return;
 		}
 
-		setOverlayVisible( true );
-	}
+		Box2f cropWindow( V2f( 0 ), V2f( 1 ) );
+		findCropWindowPlug();
+		if( m_cropWindowPlug )
+		{
+			cropWindow = m_cropWindowPlug->getValue();
+		}
+		if( runTimeCast<ImageView>( view() ) )
+		{
+			flipNDCOrigin( cropWindow );
+		}
 
-	if( !m_overlayDirty )
-	{
-		return;
-	}
-	m_overlayDirty = false;
-
-	findScenePlug();
-
-	// This occurs in the ImageView hosted case, when we don't know which node
-	// may have rendered the image being viewed.
-	if( !scenePlug()->getInput() )
-	{
-		setOverlayVisible( false );
-		return;
-	}
-
-	Box2f cropWindow( V2f( 0 ), V2f( 1 ) );
-	findCropWindowPlug();
-	if( m_cropWindowPlug )
-	{
-		cropWindow = m_cropWindowPlug->getValue();
-	}
-	if( runTimeCast<ImageView>( view() ) )
-	{
-		flipNDCOrigin( cropWindow );
-	}
-
-	BlockedConnection blockedConnection( m_overlayRectangleChangedConnection );
-	m_overlay->setRectangle(
-		Box2f(
-			V2f(
-				lerp( r.min.x, r.max.x, cropWindow.min.x ),
-				lerp( r.min.y, r.max.y, cropWindow.min.y )
-			),
-			V2f(
-				lerp( r.min.x, r.max.x, cropWindow.max.x ),
-				lerp( r.min.y, r.max.y, cropWindow.max.y )
+		BlockedConnection blockedConnection( m_overlayRectangleChangedConnection );
+		m_overlay->setRectangle(
+			Box2f(
+				V2f(
+					lerp( r.min.x, r.max.x, cropWindow.min.x ),
+					lerp( r.min.y, r.max.y, cropWindow.min.y )
+				),
+				V2f(
+					lerp( r.min.x, r.max.x, cropWindow.max.x ),
+					lerp( r.min.y, r.max.y, cropWindow.max.y )
+				)
 			)
-		)
-	);
+		);
 
-	setOverlayVisible( true );
+		setOverlayVisible( true );
+
+	}
+	catch( const std::exception &e )
+	{
+		setErrorMessage( std::string("Error: ") + e.what() );
+		setOverlayVisible( false );
+	}
 }
 
 void CropWindowTool::findScenePlug()
@@ -795,7 +804,17 @@ void CropWindowTool::findScenePlug()
 	if( runTimeCast<ImageView>( view() ) )
 	{
 		std::string msg;
-		ScenePlug *scene = findSceneForImage( imagePlug(), msg );
+		ScenePlug *scene = nullptr;
+
+		try
+		{
+			scene = findSceneForImage( imagePlug(), msg );
+		}
+		catch( const std::exception &e )
+		{
+			msg = std::string( "Error: " ) + e.what();
+		}
+
 		scenePlug()->setInput( scene );
 		if( !scene )
 		{
@@ -821,51 +840,67 @@ void CropWindowTool::findCropWindowPlug()
 
 	findScenePlug();
 
-	const GafferScene::ScenePlug::ScenePath rootPath;
-	SceneAlgo::History::Ptr history = SceneAlgo::history( scenePlug()->globalsPlug(), rootPath );
-	const bool foundAnEnabledPlug = findCropWindowPlug( history.get(), /* enabledOnly = */ true );
-	// If we didn't find an enabled cropWindow plug upstream, or we did and it's
-	// read-only, look again for any other plugs that could be edited, but aren't
-	// enabled yet. We'll enable it if the user makes an edit.
-	if( !foundAnEnabledPlug || MetadataAlgo::readOnly( m_cropWindowPlug.get() ) )
+	try
 	{
-		findCropWindowPlug( history.get(), /* enabledOnly = */ false );
-	}
-
-	if( m_cropWindowPlug )
-	{
-		const std::string plugName =  m_cropWindowPlug->relativeName( m_cropWindowPlug->ancestor<ScriptNode>() );
-
-		// Even after the second search, we could still be read-only
-		if( MetadataAlgo::readOnly( m_cropWindowPlug.get() ) )
+		const GafferScene::ScenePlug::ScenePath rootPath;
+		SceneAlgo::History::Ptr history = SceneAlgo::history( scenePlug()->globalsPlug(), rootPath );
+		const bool foundAnEnabledPlug = findCropWindowPlug( history.get(), /* enabledOnly = */ true );
+		// If we didn't find an enabled cropWindow plug upstream, or we did and it's
+		// read-only, look again for any other plugs that could be edited, but aren't
+		// enabled yet. We'll enable it if the user makes an edit.
+		if( !foundAnEnabledPlug || MetadataAlgo::readOnly( m_cropWindowPlug.get() ) )
 		{
-			m_overlay->setEditable( false );
-			setOverlayMessage( "Warning: <b>" + plugName + "</b> is locked" );
+			findCropWindowPlug( history.get(), /* enabledOnly = */ false );
+		}
+
+		if( m_cropWindowPlug )
+		{
+			const std::string plugName =  m_cropWindowPlug->relativeName( m_cropWindowPlug->ancestor<ScriptNode>() );
+
+			// Even after the second search, we could still be read-only
+			if( MetadataAlgo::readOnly( m_cropWindowPlug.get() ) )
+			{
+				m_overlay->setEditable( false );
+				setOverlayMessage( "Warning: <b>" + plugName + "</b> is locked" );
+			}
+			else
+			{
+				bool plugEditable = m_cropWindowPlug->settable();
+
+				// If our cropWindow plug hasn't been enabled, we need to check if it's corresponding 'enabled'
+				// plug is editable, it could be expressioned or locked even if our value plug isn't.
+				if( m_cropWindowEnabledPlug && m_cropWindowEnabledPlug->getValue() == false )
+				{
+					plugEditable &= ( m_cropWindowEnabledPlug->settable() && !MetadataAlgo::readOnly( m_cropWindowEnabledPlug.get() ) );
+				}
+
+				m_overlay->setEditable( plugEditable );
+				setOverlayMessage( plugEditable
+					? ( "Info: Editing <b>" + plugName + "</b>" )
+					: ( "Warning: <b>" + plugName + "</b> isn't editable" )
+				);
+			}
+
+			m_cropWindowPlugDirtiedConnection = m_cropWindowPlug->node()->plugDirtiedSignal().connect( boost::bind( &CropWindowTool::plugDirtied, this, ::_1 ) );
 		}
 		else
 		{
-			bool plugEditable = m_cropWindowPlug->settable();
-
-			// If our cropWindow plug hasn't been enabled, we need to check if it's corresponding 'enabled'
-			// plug is editable, it could be expressioned or locked even if our value plug isn't.
-			if( m_cropWindowEnabledPlug && m_cropWindowEnabledPlug->getValue() == false )
-			{
-				plugEditable &= ( m_cropWindowEnabledPlug->settable() && !MetadataAlgo::readOnly( m_cropWindowEnabledPlug.get() ) );
-			}
-
-			m_overlay->setEditable( plugEditable );
-			setOverlayMessage( plugEditable
-				? ( "Info: Editing <b>" + plugName + "</b>" )
-				: ( "Warning: <b>" + plugName + "</b> isn't editable" )
-			);
+			// Though this is an 'error' for the user, `setErrorMessage` is used in situations when the
+			// tool has failed such that the overlay is hidden. As we still show the overlay without a plug
+			// (as the crop is still defined in the scene), we use the overlay message instead.
+			setOverlayMessage( "Error: No crop window found. Insert a <b>StandardOptions</b> node." );
 		}
 
-		m_cropWindowPlugDirtiedConnection = m_cropWindowPlug->node()->plugDirtiedSignal().connect( boost::bind( &CropWindowTool::plugDirtied, this, ::_1 ) );
 	}
-	else
+	catch( const std::exception &e )
+	{
+		m_cropWindowPlug = nullptr;
+		setOverlayMessage( std::string("Error: ") + e.what() );
+	}
+
+	if( !m_cropWindowPlug )
 	{
 		m_overlay->setEditable( false );
-		setOverlayMessage( "Error: No crop window found. Insert a <b>StandardOptions</b> node." );
 		m_cropWindowPlugDirtiedConnection.disconnect();
 	}
 

--- a/src/GafferSceneUIModule/ToolBinding.cpp
+++ b/src/GafferSceneUIModule/ToolBinding.cpp
@@ -173,6 +173,7 @@ void GafferSceneUIModule::bindTools()
 
 	{
 		GafferBindings::NodeClass<CropWindowTool>( nullptr, no_init )
+			.def( init<GafferUI::View *>() )
 			.def( "status", &CropWindowTool::status )
 			.def( "statusChangedSignal", &CropWindowTool::statusChangedSignal, return_internal_reference<1>() )
 		;


### PR DESCRIPTION
We were leaking any exceptions from our `getValue` calls (or similar), resulting in corruption of the GL stack.

@johnhaddon, I wondered if we should also be careful [here](https://github.com/GafferHQ/gaffer/blob/cb751689d45a64839c7a8de5867b1df41f6ce108/src/GafferSceneUI/CropWindowTool.cpp#L665), but wasn't 100% on the best way to pass those on. I _think_  we might always catch any errors there in `findCropWindowPlug`, as that pulls on the values, but I'd need a little more time with a finer toothed comb to verify 100%. 