### PR TITLE
IE Build : Required to get docs building at IE

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -312,6 +312,7 @@ LOCATE_DEPENDENCY_PYTHONPATH = [
 	os.path.join( IEEnv.Environment.rootPath(), "tools", "python", pythonVersion, IEEnv.platform(), compiler, compilerVersion, "PyOpenGL", "3" ),
 	os.path.join( IEEnv.Environment.rootPath(), "tools", "python", pythonVersion, "noarch" ),
 	os.path.join( IEEnv.Environment.rootPath(), "apps", "Qt.py", qtPyVersion ),
+	os.path.join( IEEnv.Environment.rootPath(), "apps", "six", os.environ["SIX_VERSION"] ),
 
 ]
 


### PR DESCRIPTION
I'm not sure if this come about after https://github.com/GafferHQ/gaffer/pull/3898 or because of an internal versioning issue, but we need this to build docs at IE on 0.58_maintenance.