### PR TITLE
PlugLayout : Fix section decoration when plugs set to user default values

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,10 @@
+0.58.x.x (relative to 0.58.2.0)
+
+Fixes
+-----
+
+- Node Editor : Fix bug in section decoration when a plug was set to its user default.
+
 0.58.2.0 (relative to 0.58.1.0)
 ========
 

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -392,7 +392,7 @@ class PlugLayout( GafferUI.Widget ) :
 		valueChanged = plug.getInput() is not None
 		if not valueChanged and isinstance( plug, Gaffer.ValuePlug ) :
 			if Gaffer.NodeAlgo.hasUserDefault( plug ) :
-				valueChanged = Gaffer.NodeAlgo.isSetToUserDefault( plug )
+				valueChanged = not Gaffer.NodeAlgo.isSetToUserDefault( plug )
 			else :
 				valueChanged = not plug.isSetToDefault()
 		return valueChanged


### PR DESCRIPTION
@johnhaddon Is this the correct behaviour, that if a plug has a user default, setting it's value to the default default shows as 'value changed'?