### PR TITLE
ShadingEngine : Don't read past the end of the data

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Encapsulate : Fixed bug where globals and render sets were evaluated in the wrong context.
+- OSLObject : Fixed invalid reads from Constant array primitive variables.
 
 0.57.7.2 (relative to 0.57.7.1)
 ========

--- a/python/GafferOSLTest/ShadingEngineTest.py
+++ b/python/GafferOSLTest/ShadingEngineTest.py
@@ -908,5 +908,26 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 		self.assertFalse( e.hasDeformation() )
 
+	def testReadConstantArraySize1( self ) :
+
+		s = self.compileShader( os.path.dirname( __file__ ) +  "/shaders/attribute.osl" )
+		e = GafferOSL.ShadingEngine( IECoreScene.ShaderNetwork(
+			shaders = {
+				"output" : IECoreScene.Shader( s, "osl:surface", { "name" : "constantColor" } )
+			},
+			output = "output"
+		) )
+
+		p = self.rectanglePoints()
+		p["constantColor"] = IECore.Color3fVectorData( [ imath.Color3f( 1, 2, 3 ) ] )
+
+		r = e.shade( p )
+
+		for i, c in enumerate( r["Ci"] ) :
+			self.assertEqual(
+				c,
+				imath.Color3f( 1, 2, 3 )
+			)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -289,12 +289,12 @@ class RenderState
 				userData.dataView = IECoreImage::OpenImageIOAlgo::DataView( it->second.get(), /* createUStrings = */ true );
 				if( userData.dataView.data )
 				{
+					userData.numValues = std::max( userData.dataView.type.arraylen, 1 );
 					if( userData.dataView.type.arraylen )
 					{
 						// we unarray the TypeDesc so we can use it directly with
 						// convertValue() in get_userdata().
 						userData.dataView.type.unarray();
-						userData.array = true;
 					}
 					m_userData.insert( make_pair( ustring( it->first.c_str() ), userData ) );
 				}
@@ -355,10 +355,7 @@ class RenderState
 			}
 
 			const char *src = static_cast<const char *>( it->second.dataView.data );
-			if( it->second.array )
-			{
-				src += pointIndex * it->second.dataView.type.elementsize();
-			}
+			src += std::min( pointIndex, it->second.numValues - 1 ) * it->second.dataView.type.elementsize();
 
 			return convertValue( value, type, src,  it->second.dataView.type );
 		}
@@ -392,13 +389,8 @@ class RenderState
 
 		struct UserData
 		{
-			UserData()
-				:	array( false )
-			{
-			}
-
 			IECoreImage::OpenImageIOAlgo::DataView dataView;
-			bool array;
+			size_t numValues;
 		};
 
 		container::flat_map<ustring, UserData, OIIO::ustringPtrIsLess> m_userData;


### PR DESCRIPTION
The `ShadingEngine::shade()` interface isn't currently fit for purpose. It assumes that all VectorTypedData values are per-point, and everything else is constant. This falls down when OSLObject passes a constant PrimitiveVariable which happens to contain VectorTypedData, such as USD's `displayColor`. Without a change to the API we can't do better than avoiding reads past the end, which in the `displayColor` case is happily enough to do what people want. This is not sufficient for constant arrays with length greater than one, in which case we would need to allow the OSL shader to specify which index to read from the array, or to read the entire array in one go. That can wait though.
