### PR TITLE
GafferUI.Window : Delay removal of window reference

### DIFF
--- a/python/GafferUI/Window.py
+++ b/python/GafferUI/Window.py
@@ -39,6 +39,7 @@ import six
 import sys
 import warnings
 import imath
+import functools
 
 import IECore
 
@@ -211,7 +212,13 @@ class Window( GafferUI.ContainerWidget ) :
 			childWindow._applyVisibility()
 
 		if removeOnClose :
-			childWindow.closedSignal().connect( lambda w : w.parent().removeChild( w ), scoped = False )
+			# Delay removal of the window reference to an idle callback
+			# to avoid issues where Qt destroy event is called when
+			# the object has already been garbage collected
+			childWindow.closedSignal().connect(
+				lambda w : GafferUI.EventLoop.addIdleCallback( functools.partial( w.parent().removeChild, w ) ),
+				scoped = False
+			)
 
 	## Returns a list of all the windows parented to this one.
 	def childWindows( self ) :


### PR DESCRIPTION
This adds a delay in the removal of the window reference when closing a window with the option of `removeOnClose`.
The reason for that is crashes in caribou when closing floating `NodeEditor` windows.

I'm opening this PR initially as a draft, as maybe you guys have some suggestions of alternative solutions to the issue.

I've seen consistent crashes with gaffer versions 0.57.7.2 and 0.58.2.0 and maya 2020.

The way to reproduce the crashes (at IE) is:
1) launch `maya`
2) open `caribou`
3) double click on the `MainSceneInput` node (or a create a `SceneReader` node and double click on that) to launch the `NodeEditor` window
4) close the `NodeEditor` window
5) It will usually crash. But we may have to repeat steps 3-4 a few times.

This mirrors similar crashes we had been seeing with Jabuka-managed windows both in maya 2020 and nuke 12, though the caribou crashes seem more consistent.

I've applied a similar solution to the one we used in Jabuka, by delaying the release of the window object to an idle callback. My reasoning is that the crashes might be happening because the release of the window object is somehow happening before an event processing related to the destruction of the window after it's closed by qt.

Once the changes are installed, I don't see crashes anymore.

Here is the backtrace for the crashes:
```
#0  0x00007fb91a8dee81 in QWindow::destroy() () from /software/apps/maya/2020.2/cent7.x86_64/lib/libQt5Gui.so.5
#1  0x00007fb91a8df90f in QWindow::event(QEvent*) () from /software/apps/maya/2020.2/cent7.x86_64/lib/libQt5Gui.so.5
#2  0x00007fb91af8e6a6 in QWidgetWindow::event(QEvent*) ()
   from /software/apps/maya/2020.2/cent7.x86_64/lib/libQt5Widgets.so.5
#3  0x00007fb91af33f3c in QApplicationPrivate::notify_helper(QObject*, QEvent*) ()
   from /software/apps/maya/2020.2/cent7.x86_64/lib/libQt5Widgets.so.5
#4  0x00007fb91af3b034 in QApplication::notify(QObject*, QEvent*) ()
   from /software/apps/maya/2020.2/cent7.x86_64/lib/libQt5Widgets.so.5
#5  0x00007fb91c8c8b2b in ?? () from /software/apps/maya/2020.2/cent7.x86_64/lib/libExtensionLayer.so
#6  0x00007fb918576c88 in QCoreApplication::notifyInternal2(QObject*, QEvent*) ()
   from /software/apps/maya/2020.2/cent7.x86_64/lib/libQt5Core.so.5
#7  0x00007fb91a8d2188 in QGuiApplicationPrivate::processCloseEvent(QWindowSystemInterfacePrivate::CloseEvent*) ()
   from /software/apps/maya/2020.2/cent7.x86_64/lib/libQt5Gui.so.5
#8  0x00007fb91a8d6385 in QGuiApplicationPrivate::processWindowSystemEvent(QWindowSystemInterfacePrivate::WindowSystemEvent*) () from /software/apps/maya/2020.2/cent7.x86_64/lib/libQt5Gui.so.5
#9  0x00007fb91a8b3cfb in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) ()
   from /software/apps/maya/2020.2/cent7.x86_64/lib/libQt5Gui.so.5
#10 0x00007fb8ecc104aa in xcbSourceDispatch(_GSource*, int (*)(void*), void*) ()
   from /software/apps/maya/2020.2/cent7.x86_64/lib/libQt5XcbQpa.so.5
#11 0x00007fb9039be049 in g_main_context_dispatch () from /lib64/libglib-2.0.so.0
#12 0x00007fb9039be3a8 in g_main_context_iterate.isra.19 () from /lib64/libglib-2.0.so.0
#13 0x00007fb9039be45c in g_main_context_iteration () from /lib64/libglib-2.0.so.0
#14 0x00007fb9185cf27f in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) ()
   from /software/apps/maya/2020.2/cent7.x86_64/lib/libQt5Core.so.5
#15 0x00007fb91857552a in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) ()
   from /software/apps/maya/2020.2/cent7.x86_64/lib/libQt5Core.so.5
#16 0x00007fb91857e060 in QCoreApplication::exec() ()
   from /software/apps/maya/2020.2/cent7.x86_64/lib/libQt5Core.so.5
#17 0x00007fb91c8af41e in Tapplication::start() ()
   from /software/apps/maya/2020.2/cent7.x86_64/lib/libExtensionLayer.so
#18 0x000000000040ee99 in appmain() ()
#19 0x000000000040d436 in main ()
```

Looking for python backtrace information, I found none in any of the running threads. Again, this is the same as what I had been seeing when debugging the Jabuka-related crashes.

The only bug-report I've seen that could be related is this: https://bugreports.qt.io/browse/QTBUG-69277?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&showAll=true

I have not been able to replicate this type of crash in Gaffer, but I haven't tested it with the current master and Qt 5.12.

Let me know if any of you have any ideas I could try, particularly since it would be difficult for you to test caribou/maya by yourselves.

