### PR TITLE
Prototype : Spreadsheet selection and navigation

### DIFF
--- a/python/GafferUI/SpreadsheetUI.py
+++ b/python/GafferUI/SpreadsheetUI.py
@@ -715,7 +715,7 @@ class _PlugTableView( GafferUI.Widget ) :
 
 		QtCompat.setSectionResizeMode( tableView.verticalHeader(), QtWidgets.QHeaderView.Fixed )
 		tableView.verticalHeader().setDefaultSectionSize( 25 )
-		tableView.verticalHeader().setVisible( False )
+		tableView.verticalHeader().setVisible( mode is self.Mode.RowNames )
 
 		self.__horizontalHeader = GafferUI.Widget( QtWidgets.QHeaderView( QtCore.Qt.Horizontal, tableView ) )
 		self.__horizontalHeader._qtWidget().setDefaultAlignment( QtCore.Qt.AlignLeft )
@@ -747,6 +747,7 @@ class _PlugTableView( GafferUI.Widget ) :
 			# because we need to do it on a per-cell basis, so will need to use `_CellPlugItemDelegate.paint()`
 			# instead.
 			tableView.setProperty( "gafferToggleIndicator", True )
+			tableView.verticalHeader().setSectionsMovable( True )
 
 		if mode != self.Mode.Defaults :
 			tableView.horizontalHeader().setVisible( False )
@@ -761,8 +762,8 @@ class _PlugTableView( GafferUI.Widget ) :
 		# our own editing via PlugValueWidgets in _EditWindow.
 
 		tableView.setEditTriggers( tableView.NoEditTriggers )
-		tableView.setSelectionMode( QtWidgets.QAbstractItemView.NoSelection )
-		self.buttonPressSignal().connect( Gaffer.WeakMethod( self.__buttonPress ), scoped = False )
+		tableView.setSelectionMode( QtWidgets.QAbstractItemView.ExtendedSelection )
+		self.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__buttonPress ), scoped = False )
 
 		# Drawing
 
@@ -1186,6 +1187,8 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 				if not label :
 					label = IECore.CamelCase.toSpaced( cellPlug.getName() )
 				return label
+			elif orientation == QtCore.Qt.Vertical and self.__mode == _PlugTableView.Mode.RowNames :
+				return ""
 			return section
 
 	def flags( self, index ) :

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -648,6 +648,10 @@ _styleSheet = string.Template(
 	SpreadsheetUI.
 	*/
 
+	QTableView[gafferClass="GafferUI.SpreadsheetUI._PlugTableView"] QHeaderView::section:vertical {
+		padding: 5px;
+	}
+
 	QTabBar[gafferClass="GafferUI.SpreadsheetUI._SectionChooser"]::tab {
 
 		border-color: $tintDarkerStronger;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/896779/94673732-16645900-030f-11eb-83d3-75875d6ad99c.png)

This an early prototype of cell selection in the Spreadsheet node to test usability of the shift from single-click edit to double-click edit. It attempts to mimic the standard 'Excel' style spreadsheet navigation behaviour, namely:

 - **Single click** on _any_ cell selects it.
 - `Shift` and `Control` can be used to select multiple cells or modify the existing selection.
 - **Double click** edits a cell. Note: this resets the current selection to that cell
 - Right-click context menu item for `Edit Selection` (available if the selection shares a common plug type).
  - Pressing `return` edits the current selection (slightly different to spreadsheets but we don't have a good equivalent).
 - Arrow keys navigate cells.

## Known issues
 - Arrow key navigation is is not fully working in the prototype
    - `Left`/`Right` prev/next frame hotkey conflicts.
 - Loss of keyboard focus after closing a cell's editor window.
 - Row name and defaults row selection is not synchronised with the cell grid (clicking a row should select all cells in the row, clicking a column heading should select the entire column)
 - Numeric Widget maths doesn't work when editing multiple cells.
