### PR TITLE
ErrorDialogue/MessageWidget : Fix performance regression

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,9 +1,16 @@
 0.58.x.x (relative to 0.58.2.0)
+========
 
 Fixes
 -----
 
 - Node Editor : Fix bug in section decoration when a plug was set to its user default.
+- ErrorDialogue : Fixed extremely slow display of warning and error messages. This was particularly apparent when showing errors that occurred while opening files.
+
+API
+---
+
+- MessageWidget : `setMessages()` now also accepts messages in the format used by IECore.CapturingMessageHandler.
 
 0.58.2.0 (relative to 0.58.1.0)
 ========

--- a/python/GafferUI/ErrorDialogue.py
+++ b/python/GafferUI/ErrorDialogue.py
@@ -76,8 +76,7 @@ class ErrorDialogue( GafferUI.Dialogue ) :
 
 			if messages is not None :
 				messageWidget = GafferUI.MessageWidget()
-				for m in messages :
-					messageWidget.messageHandler().handle( m.level, m.context, m.message )
+				messageWidget.setMessages( messages )
 
 			if details is not None :
 				with GafferUI.Collapsible( label = "Details", collapsed = True ) :

--- a/python/GafferUI/MessageWidget.py
+++ b/python/GafferUI/MessageWidget.py
@@ -129,6 +129,17 @@ class MessageWidget( GafferUI.Widget ) :
 	# via the widget's message handler \see messageHandler().
 	def setMessages( self, messages ) :
 
+		if not isinstance( messages, Gaffer.Private.IECorePreview.Messages ) :
+			# Since IECorePreview.Messages is not public yet, we also support the legacy
+			# message format currently used by IECore.CapturingMessageHandler.
+			# \todo Update CapturingMessageHandler to use the new format.
+			converted = Gaffer.Private.IECorePreview.Messages()
+			for m in messages :
+				converted.add( Gaffer.Private.IECorePreview.Message(
+					m.level, m.context, m.message
+				) )
+			messages = converted
+
 		self.__table.setMessages( messages )
 
 	## Returns (a copy of) the messages displayed by the widget.


### PR DESCRIPTION
Ironically the regression seems to have coincided with the introduction of the optimised MessageWidget. It appears that `addMessage()` is now slower than before, but since we have all the messages in a single block anyway, it's easier to convert in `setMessages()`.

No doubt there are better ways of addressing this, going all the way to making `CapturingMessageHandler` use `IECorePreview.Messages`. This is intentionally just the minimum required to get us back to reasonable performance, so we can concentrate on more pressing tasks.

For testing, I found it useful to put this in a `.gfr` file to generate a bunch of synthetic messages :

```
import IECore

for i in range( 0, 1000 ) :
	IECore.msg( IECore.Msg.Level.Warning, "Test", str( i ) )
```
