### PR TITLE
GafferUI : Fix Qt crashes when deleting windows during close events

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ API
 ---
 
 - MessageWidget : `setMessages()` now also accepts messages in the format used by IECore.CapturingMessageHandler.
+- WidgetAlgo : Added `keepUntilIdle()` method.
 
 0.58.2.0 (relative to 0.58.1.0)
 ========

--- a/apps/screengrab/screengrab-1.py
+++ b/apps/screengrab/screengrab-1.py
@@ -251,6 +251,13 @@ class screengrab( Gaffer.Application ) :
 			with open( commandFile ) as f :
 				six.exec_( compile( f.read(), commandFile, "exec" ), d, d )
 
+		# Early out if we haven't been asked to save anything (we assume
+		# something meaningful was grabbed by one of the commands above).
+
+		if not args["image"].value :
+			self.__cleanup()
+			return 0
+
 		# Select any nodes we've been asked to.
 		for name in args["selection"] :
 			script.selection().add( script.descendant( name ) )
@@ -345,9 +352,12 @@ class screengrab( Gaffer.Application ) :
 
 		# Write the image, creating a directory for it if necessary.
 
-		if args["image"].value :
-			IECore.msg( IECore.Msg.Level.Info, "screengrab", "Writing image [ %s ]" % args["image"].value )
-			GafferUI.WidgetAlgo.grab( widget = self.getGrabWidget(), imagePath = args["image"].value )
+		IECore.msg( IECore.Msg.Level.Info, "screengrab", "Writing image [ %s ]" % args["image"].value )
+		GafferUI.WidgetAlgo.grab( widget = self.getGrabWidget(), imagePath = args["image"].value )
+
+		self.__cleanup()
+
+	def __cleanup( self ) :
 
 		# Remove the script and any reference to the grab widget up so
 		# we can shut down cleanly.

--- a/python/GafferUI/ColorSwatchPlugValueWidget.py
+++ b/python/GafferUI/ColorSwatchPlugValueWidget.py
@@ -197,16 +197,11 @@ class _ColorPlugValueDialogue( GafferUI.ColorChooserDialogue ) :
 				for p, v in self.__initialValues.items() :
 					p.setValue( v )
 
-		# ideally we'd just remove ourselves from our parent immediately, but that would
-		# trigger this bug :
-		#
-		# 	https://bugreports.qt-project.org/browse/QTBUG-26761
-		#
-		# so instead we destroy ourselves on the next idle event.
-
-		GafferUI.EventLoop.addIdleCallback( self.__destroy )
+		self.parent().removeChild( self )
+		# Workaround for https://bugreports.qt-project.org/browse/QTBUG-26761.
+		assert( not self.visible() )
+		GafferUI.WidgetAlgo.keepUntilIdle( self )
 
 	def __destroy( self, *unused ) :
 
 		self.parent().removeChild( self )
-		return False # to remove idle callback

--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -186,6 +186,9 @@ class CompoundEditor( GafferUI.Editor ) :
 		panel.__titleChangedConnection = None
 		panel._applyVisibility()
 
+		assert( not panel.visible() )
+		GafferUI.WidgetAlgo.keepUntilIdle( panel )
+
 	def __visibilityChanged(self, widget) :
 
 		v = self.visible()

--- a/python/GafferUI/NodeSetEditor.py
+++ b/python/GafferUI/NodeSetEditor.py
@@ -483,7 +483,7 @@ class _EditorWindow( GafferUI.Window ) :
 
 	def __nodeSetMemberRemoved( self, set, node ) :
 
-		if not len( set ) :
+		if not len( set ) and self.parent() is not None :
 			self.parent().removeChild( self )
 
 

--- a/python/GafferUI/NotificationMessageHandler.py
+++ b/python/GafferUI/NotificationMessageHandler.py
@@ -78,6 +78,7 @@ class NotificationMessageHandler( IECore.MessageHandler ) :
 	def __windowClosed( cls, window ) :
 
 		cls.__windows.remove( window )
+		GafferUI.WidgetAlgo.keepUntilIdle( window )
 
 class _Window( GafferUI.Window ) :
 

--- a/python/GafferUI/WidgetAlgo.py
+++ b/python/GafferUI/WidgetAlgo.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import functools
 import os
 import sys
 import six
@@ -116,3 +117,13 @@ def grab( widget, imagePath ) :
 		pixmap = QtGui.QPixmap.grabWindow( long( widget._qtWidget().winId() ) )
 
 	pixmap.save( imagePath )
+
+## Useful as a workaround when you want to dispose of a GafferUI.Widget immediately,
+# but Qt bugs prevent you from doing so.
+def keepUntilIdle( widget ) :
+
+	def keep( o ) :
+
+		return False # Removes idle callback
+
+	GafferUI.EventLoop.addIdleCallback( functools.partial( keep, widget ) )

--- a/python/GafferUI/Window.py
+++ b/python/GafferUI/Window.py
@@ -211,7 +211,14 @@ class Window( GafferUI.ContainerWidget ) :
 			childWindow._applyVisibility()
 
 		if removeOnClose :
-			childWindow.closedSignal().connect( lambda w : w.parent().removeChild( w ), scoped = False )
+
+			def remove( childWindow ) :
+
+				childWindow.parent().removeChild( childWindow )
+				assert( not childWindow.visible() )
+				GafferUI.WidgetAlgo.keepUntilIdle( childWindow )
+
+			childWindow.closedSignal().connect( remove, scoped = False )
 
 	## Returns a list of all the windows parented to this one.
 	def childWindows( self ) :

--- a/python/GafferUITest/NodeEditorTest.py
+++ b/python/GafferUITest/NodeEditorTest.py
@@ -104,8 +104,9 @@ class NodeEditorTest( GafferUITest.TestCase ) :
 		nw.close()
 		del nw
 
-		self.assertEqual( nww(), None )
 		self.assertEqual( sw.childWindows(), [] )
+		self.waitForIdle()
+		self.assertEqual( nww(), None )
 
 		ne2 = GafferUI.NodeEditor.acquire( s["n"] )
 		self.assertIsInstance( ne2, GafferUI.NodeEditor )

--- a/python/GafferUITest/WidgetAlgoTest.py
+++ b/python/GafferUITest/WidgetAlgoTest.py
@@ -36,6 +36,7 @@
 
 import os
 import unittest
+import weakref
 import imath
 
 import IECore
@@ -91,6 +92,18 @@ class WidgetAlgoTest( GafferUITest.TestCase ) :
 		GafferUI.EventLoop.mainEventLoop().start()
 
 		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/grab.png" ) )
+
+	def testKeepUntilIdle( self ) :
+
+		widget = GafferUI.Label()
+		weakWidget = weakref.ref( widget )
+
+		GafferUI.WidgetAlgo.keepUntilIdle( widget )
+		del widget
+		self.assertIsNotNone( weakWidget() )
+
+		self.waitForIdle()
+		self.assertIsNone( weakWidget() )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This fixes several crashes introduced by Qt 5.12. It's a minor reworking of @ivanimanishi's PR #3925, adding unit tests and deferring the absolute minimum of work till idle. Ivan, could you verify that it still fixes your original problems in Maya please? 