### PR TITLE
TransformTool  : Use standardised selection logic

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -54,6 +54,7 @@ Improvements
 - Checkerboard : Optimized image generation when rotation is 0.
 - InteractiveRender : Added a warning when attribute edits require geometry to be regenerated, as this can have a performance impact. Examples in Arnold include subdivision changes or changes to attributes inherited by procedurals.
 - NodeMenu : Removed Loop node. This node can have severe consequences for performance if used inappropriately. Depending on the use case, the Collect nodes and others often provide a more performant alternative. The Loop node can still be created via the scripting API, but we recommend you consider the alternatives and/or request advice before using it.
+- TransformTool : Improved tool state messaging to include node names and/or paths.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -65,6 +65,7 @@ Fixes
   - Fixed handling of interpolation for normals.
   - Fixed writing of indexed primitive variables to non-indexed USD attributes.
   - Fixed handling of GeometricInterpretation/Role.
+- TransformTools : Fixed bug finding existing nodes inside EditScopes.
 - Viewer : Fixed bug that caused mouse clicks in empty toolbar regions to be ignored.
 - PlugAlgo/BoxIO : Fixed bug handling nested compound plugs.
 - Resample : Fixed hash of intermediate `deep` plug.

--- a/include/Gaffer/EditScope.h
+++ b/include/Gaffer/EditScope.h
@@ -44,8 +44,27 @@ namespace Gaffer
 
 class BoxOut;
 
-/// A container node for interactive tools to make nodes
-/// in as necessary.
+/// A container node for interactive tools to make nodes in as necessary.
+///
+/// EditScopes and Tools
+/// ====================
+///
+/// Tools that affect change by modifying nodes/plugs in the Node Graph
+/// should use the following logic to determine their edit target:
+///
+///  - If no EditScope has been selected, use the last (closest) upstream
+///    target.
+///
+///  - If an EditScope has been selected, prefer existing targets inside
+///    the EditScope over using the EditScopeAlgo to acquire a new target.
+///
+///  - If an EditScope has been selected, but is upstream of another target
+///    either error (if overrides preclude editing), or allow editing with
+///    a suitable warning identifying the last downstream target.
+///
+///  - If an EditScope has been selected but is not in the scene history,
+///    error.
+///
 class GAFFER_API EditScope : public Box
 {
 

--- a/include/GafferSceneUI/TransformTool.h
+++ b/include/GafferSceneUI/TransformTool.h
@@ -197,6 +197,7 @@ class GAFFERSCENEUI_API TransformTool : public GafferSceneUI::SelectionTool
 				Imath::M44f m_transformSpace;
 				bool m_aimConstraint;
 
+				static std::string displayName( const GraphComponent *component );
 		};
 
 		/// Returns the current selection.

--- a/include/GafferSceneUI/TransformTool.h
+++ b/include/GafferSceneUI/TransformTool.h
@@ -169,8 +169,16 @@ class GAFFERSCENEUI_API TransformTool : public GafferSceneUI::SelectionTool
 
 			private :
 
+				void initFromHistory( const GafferScene::SceneAlgo::History *history );
 				void initFromSceneNode( const GafferScene::SceneAlgo::History *history );
-				void initWalk( const GafferScene::SceneAlgo::History *history, bool &editScopeFound );
+				void initFromEditScope( const GafferScene::SceneAlgo::History *history );
+				void initWalk(
+					const GafferScene::SceneAlgo::History *history,
+					bool &editScopeFound,
+					const GafferScene::SceneAlgo::History *editScopeOutHistory = nullptr
+				);
+				bool initRequirementsSatisfied( bool editScopeFound );
+
 				void throwIfNotEditable() const;
 				Imath::M44f transformToLocalSpace() const;
 

--- a/python/GafferSceneUITest/TransformToolTest.py
+++ b/python/GafferSceneUITest/TransformToolTest.py
@@ -109,7 +109,7 @@ class TransformToolTest( GafferUITest.TestCase ) :
 
 		selection = GafferSceneUI.TransformTool.Selection( plane["out"], "/plane", Gaffer.Context(), editScope )
 		self.assertFalse( selection.editable() )
-		self.assertEqual( selection.warning(), "EditScope not in history" )
+		self.assertEqual( selection.warning(), "The target EditScope \"EditScope\" is not in the scene history" )
 		self.assertRaises( RuntimeError, selection.acquireTransformEdit )
 		self.assertRaises( RuntimeError, selection.transformSpace )
 		self.assertEqual( selection.editScope(), editScope )
@@ -132,7 +132,7 @@ class TransformToolTest( GafferUITest.TestCase ) :
 		editScope["enabled"].setValue( False )
 		selection = GafferSceneUI.TransformTool.Selection( transform["out"], "/plane", Gaffer.Context(), editScope )
 		self.assertFalse( selection.editable() )
-		self.assertEqual( selection.warning(), "EditScope disabled" )
+		self.assertEqual( selection.warning(), "The target EditScope \"EditScope\" is disabled" )
 		self.assertEqual( selection.editScope(), editScope )
 
 		editScope["enabled"].setValue( True )
@@ -150,7 +150,7 @@ class TransformToolTest( GafferUITest.TestCase ) :
 
 		selection = GafferSceneUI.TransformTool.Selection( transform["out"], "/plane", Gaffer.Context(), editScope )
 		self.assertFalse( selection.editable() )
-		self.assertEqual( selection.warning(), "EditScope overridden downstream" )
+		self.assertEqual( selection.warning(), "The target EditScope \"EditScope\" is overridden downstream by \"Transform\"" )
 		self.assertEqual( selection.upstreamScene(), transform["out"] )
 
 		# Disable the downstream node and we should be back in business.
@@ -186,7 +186,7 @@ class TransformToolTest( GafferUITest.TestCase ) :
 
 		selection = GafferSceneUI.TransformTool.Selection( editScope["parent"]["out"], "/plane", Gaffer.Context(), editScope )
 		self.assertFalse( selection.editable() )
-		self.assertEqual( selection.warning(), "EditScope output not in history" )
+		self.assertEqual( selection.warning(), "The output of the target EditScope \"EditScope\" is not in the scene history" )
 
 	def testNestedEditScopes( self ) :
 

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -670,7 +670,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		self.assertEqual( len( selection ), 1 )
 		self.assertEqual( selection[0].editTarget(), script["sceneReader"]["transform"] )
 		self.assertEqual( selection[0].path(), "/group" )
-		self.assertEqual( selection[0].warning(), "Editing parent location" )
+		self.assertEqual( selection[0].warning(), "Editing parent location \"/group\"" )
 
 	def testSelectionRefersToFirstPublicPlug( self ) :
 


### PR DESCRIPTION
When we built the `SceneViewInspector`, we came up with a slightly adjusted set of rule for how editing tools should work with `EditScopes` and existing nodes. We did however, completely forget to go back and update `TransformTool::Selection` to match the revised logic.

This PR hopefully makes the transform tools, and inspector behave consistently. The main changes are
 - Existing nodes _inside_ an `EditScope` will be used in preference to defining a new edit/`TransformEdit` node. 
 - Read-only is now respected for EditScopes, preventing new edits being made in locked scopes.
 - Tool messaging is generally improved to help diagnose the cause of uneditable selections.

This code is a somewhat subtle beast, and so this could do with a good bit of real-life testing.