### PR TITLE
OCIO context preferences and ImageGadget fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ API
 
 - MessageWidget : `setMessages()` now also accepts messages in the format used by IECore.CapturingMessageHandler.
 - WidgetAlgo : Added `keepUntilIdle()` method.
+- OpenColorIOTransform : Added `processor()` and `processorHash()` public methods.
 
 0.58.2.0 (relative to 0.58.1.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,7 @@
 Improvements
 ------------
 
-- Preferences : Added support for OpenColorIO context variables.
+- Preferences : Added support for OpenColorIO context variables. These may contain references to Gaffer context variables via the standard `${variable}` syntax, but please note that such variables are only available in the Viewer and not in the rest of the UI (for instance, colour swatches and pickers).
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.58.x.x (relative to 0.58.2.0)
 ========
 
+Improvements
+------------
+
+- Preferences : Added support for OpenColorIO context variables.
+
 Fixes
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Fixes
 - Node Editor : Fix bug in section decoration when a plug was set to its user default.
 - ErrorDialogue : Fixed extremely slow display of warning and error messages. This was particularly apparent when showing errors that occurred while opening files.
 - Viewer : Fixed Default display transform so that it updates correctly when the default is changed via the Preferences dialogue, and when the context changes.
+- UVView : Fixed a performance regression vs 0.57 when displaying many UDIM textures.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - Node Editor : Fix bug in section decoration when a plug was set to its user default.
 - ErrorDialogue : Fixed extremely slow display of warning and error messages. This was particularly apparent when showing errors that occurred while opening files.
+- Viewer : Fixed Default display transform so that it updates correctly when the default is changed via the Preferences dialogue, and when the context changes.
 
 API
 ---

--- a/include/GafferImage/OpenColorIOTransform.h
+++ b/include/GafferImage/OpenColorIOTransform.h
@@ -68,9 +68,18 @@ class GAFFERIMAGE_API OpenColorIOTransform : public ColorProcessor
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferImage::OpenColorIOTransform, OpenColorIOTransformTypeId, ColorProcessor );
 
+		/// Returns the OCIO processor for this node, taking into account
+		/// the current Gaffer context and the OCIO context specified by
+		/// `contextPlug()`. Returns nullptr if this node is a no-op.
+		OpenColorIO::ConstProcessorRcPtr processor() const;
+		/// Returns a hash that uniquely represents the result of calling
+		/// `processor()` in the current context.
+		IECore::MurmurHash processorHash() const;
+
 		/// Derived classes must implement this to return a valid OpenColorIO
 		/// Transform which can be used by an OpenColorIO Processor or a null
 		/// pointer if no processing should take place.
+		/// \todo Make protected again.
 		virtual OpenColorIO::ConstTransformRcPtr transform() const = 0;
 
 	protected :

--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -193,12 +193,10 @@ class GAFFERIMAGEUI_API ImageGadget : public GafferUI::Gadget
 		GafferImage::ImageProcessorPtr m_displayTransform;
 		OpenColorIO::ConstTransformRcPtr m_gpuOcioTransform;
 
-		IECoreGL::Shader *shader( bool dirty, const OpenColorIO::ConstTransformRcPtr& transform, GLuint &lut3d_textureID ) const;
+		IECoreGL::Shader *shader() const;
 		mutable GLuint m_lut3dTextureID;
 		mutable IECoreGL::ShaderPtr m_shader;
-
 		mutable bool m_shaderDirty;
-
 
 		bool m_useGPU;
 		bool m_labelsVisible;

--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -193,10 +193,11 @@ class GAFFERIMAGEUI_API ImageGadget : public GafferUI::Gadget
 		GafferImage::ImageProcessorPtr m_displayTransform;
 		OpenColorIO::ConstTransformRcPtr m_gpuOcioTransform;
 
-		IECoreGL::Shader *shader() const;
-		mutable GLuint m_lut3dTextureID;
-		mutable IECoreGL::ShaderPtr m_shader;
-		mutable bool m_shaderDirty;
+		IE_CORE_FORWARDDECLARE( TileShader ); /// \todo Move to rendering section below
+		TileShader *shader() const;  /// \todo Move to rendering section below
+		GLuint m_unused; /// \todo Remove
+		mutable TileShaderPtr m_shader; /// \todo Move to rendering section below
+		mutable bool m_shaderDirty; /// \todo Move to rendering section below
 
 		bool m_useGPU;
 		bool m_labelsVisible;

--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -179,6 +179,9 @@ class GAFFERIMAGEUI_API ImageGadget : public GafferUI::Gadget
 
 		// Settings to control how the image is displayed.
 
+		void displayTransformPlugDirtied( const Gaffer::Plug *plug );
+		bool usingGPU() const;
+
 		Channels m_rgbaChannels;
 		int m_soloChannel;
 		ImageGadgetSignal m_channelsChangedSignal;
@@ -191,11 +194,11 @@ class GAFFERIMAGEUI_API ImageGadget : public GafferUI::Gadget
 		GafferImage::ClampPtr m_clampNode;
 		GafferImage::GradePtr m_gradeNode;
 		GafferImage::ImageProcessorPtr m_displayTransform;
-		OpenColorIO::ConstTransformRcPtr m_gpuOcioTransform;
+		OpenColorIO::ConstTransformRcPtr m_unused1; /// \todo Remove
 
 		IE_CORE_FORWARDDECLARE( TileShader ); /// \todo Move to rendering section below
 		TileShader *shader() const;  /// \todo Move to rendering section below
-		GLuint m_unused; /// \todo Remove
+		GLuint m_unused2; /// \todo Remove
 		mutable TileShaderPtr m_shader; /// \todo Move to rendering section below
 		mutable bool m_shaderDirty; /// \todo Move to rendering section below
 

--- a/python/GafferImageUI/OpenColorIOTransformUI.py
+++ b/python/GafferImageUI/OpenColorIOTransformUI.py
@@ -44,12 +44,19 @@ import GafferImage
 
 def colorSpacePresetNames( plug ) :
 
-	return IECore.StringVectorData( [ "None" ] + sorted( map( lambda x: "Roles/{0}".format( x.replace( "_", " ").title() ), GafferImage.OpenColorIOTransform.availableRoles() ) ) + sorted( GafferImage.OpenColorIOTransform.availableColorSpaces() )  )
-
+	return IECore.StringVectorData(
+		[ "None" ] +
+		[ "Roles/{0}".format( x.replace( "_", " ").title() ) for x in sorted( GafferImage.OpenColorIOTransform.availableRoles() ) ] +
+		sorted( GafferImage.OpenColorIOTransform.availableColorSpaces() )
+	)
 
 def colorSpacePresetValues( plug ) :
 
-	return IECore.StringVectorData( [ "" ] + sorted( GafferImage.OpenColorIOTransform.availableRoles() ) + sorted( GafferImage.OpenColorIOTransform.availableColorSpaces() ) )
+	return IECore.StringVectorData(
+		[ "" ] +
+		sorted( GafferImage.OpenColorIOTransform.availableRoles() ) +
+		sorted( GafferImage.OpenColorIOTransform.availableColorSpaces() )
+	)
 
 Gaffer.Metadata.registerNode(
 

--- a/python/GafferImageUI/OpenColorIOTransformUI.py
+++ b/python/GafferImageUI/OpenColorIOTransformUI.py
@@ -68,11 +68,6 @@ Gaffer.Metadata.registerNode(
 	OpenColorIO.
 	""",
 
-	# Add a + button for creating new plugs in the Context tab.
-	"layout:customWidget:addButton:widgetType", "GafferImageUI.OpenColorIOTransformUI._ContextFooter",
-	"layout:customWidget:addButton:section", "Context",
-	"layout:customWidget:addButton:index", -2,
-
 	plugs = {
 
 		"context" : [
@@ -89,6 +84,9 @@ Gaffer.Metadata.registerNode(
 			## \todo Perhaps we should invent some metadata scheme to give
 			# this behaviour to the CompoundDataPlugValueWidget?
 			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
+			"layout:customWidget:addButton:widgetType", "GafferImageUI.OpenColorIOTransformUI._ContextFooter",
+			"layout:customWidget:addButton:index", -1,
+
 			"layout:section", "Context",
 			"layout:index", -3,
 
@@ -100,7 +98,7 @@ Gaffer.Metadata.registerNode(
 
 class _ContextFooter( GafferUI.Widget ) :
 
-	def __init__( self, node, **kw ) :
+	def __init__( self, plug, **kw ) :
 
 		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal )
 		GafferUI.Widget.__init__( self, row, **kw )
@@ -119,12 +117,12 @@ class _ContextFooter( GafferUI.Widget ) :
 
 			GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
-		self.__node = node
+		self.__plug = plug
 
 	def __clicked( self, button ) :
 
-		if Gaffer.MetadataAlgo.readOnly( self.__node["context"] ) :
+		if Gaffer.MetadataAlgo.readOnly( self.__plug ) :
 			return
 
-		with Gaffer.UndoScope( self.__node.ancestor( Gaffer.ScriptNode ) ) :
-			self.__node["context"].addChild( Gaffer.NameValuePlug( "", "", True, "member1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		with Gaffer.UndoScope( self.__plug.ancestor( Gaffer.ScriptNode ) ) :
+			self.__plug.addChild( Gaffer.NameValuePlug( "", "", True, "member1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )

--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -402,6 +402,8 @@ ImageGadget::ImageGadget()
 	m_gradeNode = new Grade;
 	m_gradeNode->inPlug()->setInput( m_clampNode->outPlug() );
 	m_gradeNode->channelsPlug()->setValue( "*" );
+
+	m_unused2 = 0; // Keep clang happy
 }
 
 ImageGadget::~ImageGadget()

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -598,6 +598,9 @@ void ImageView::insertDisplayTransform()
 		if( displayTransform )
 		{
 			m_displayTransforms[name] = displayTransform;
+			// Even though technically the ImageGadget will own `displayTransform`,
+			// we must parent it into our preprocessor so that `BackgroundTask::cancelAffectedTasks()`
+			// can find the relevant tasks to cancel if plugs on `displayTransform` are edited.
 			getPreprocessor()->addChild( displayTransform );
 		}
 	}

--- a/src/GafferSceneUI/UVView.cpp
+++ b/src/GafferSceneUI/UVView.cpp
@@ -503,6 +503,13 @@ class TextureGadget : public GafferUI::Gadget
 
 			setChild( g_imageGadgetName, new ImageGadget );
 			imageGadget()->setLabelsVisible( false );
+			// ImageGadget currently does no sharing of GPU shaders between
+			// instances, and GPU shaders for OCIO take a prohibitively long
+			// time to construct for the numbers of gadgets we make for typical
+			// UDIM counts. Disable GPU path until this is sorted. Since the
+			// texture images are static, we really don't need GPU performance
+			// anyway.
+			imageGadget()->setUseGPU( false );
 			imageGadget()->setImage( m_resize->outPlug() );
 		}
 

--- a/startup/gui/ocio.py
+++ b/startup/gui/ocio.py
@@ -95,7 +95,6 @@ def __plugSet( plug ) :
 		return
 
 	__setDisplayTransform()
-	__updateDefaultDisplayTransforms()
 
 preferences.plugSetSignal().connect( __plugSet, scoped = False )
 
@@ -117,24 +116,10 @@ for name in config.getViews( defaultDisplay ) :
 # and register a special "Default" display transform which tracks the
 # global settings from the preferences
 
-__defaultDisplayTransforms = []
-
-def __updateDefaultDisplayTransforms() :
-
-	view = preferences["displayColorSpace"]["view"].getValue()
-	for node in __defaultDisplayTransforms :
-		node["view"].setValue( view )
-
 def __defaultDisplayTransformCreator() :
 
-	result = GafferImage.DisplayTransform()
-	result["channels"].setValue( "[RGB] *.[RGB]" )
-	result["inputColorSpace"].setValue( config.getColorSpace( OCIO.Constants.ROLE_SCENE_LINEAR ).getName() )
-	result["display"].setValue( defaultDisplay )
-	result["view"].setValue( config.getDefaultView( defaultDisplay ) )
-
-	__defaultDisplayTransforms.append( result )
-	__updateDefaultDisplayTransforms()
+	result = __displayTransformCreator( "" )
+	result["view"].setInput( preferences["displayColorSpace"]["view"] )
 
 	return result
 


### PR DESCRIPTION
This implements #3914, adding an arbitrary list of OCIO context variables to the Preferences node. This part at least was simple, but it unfortunately revealed bugs introduced into Gaffer 0.58 along with the GPU OCIO work, which meant that the Viewer wouldn't reflect any changes made to the preferences. So this also refactors ImageGadget to fix those bugs. I've also fixed a UVView performance regression I found during testing.

The screenshot below shows an example setup to allow per-shot grades to be applied automatically by the Viewer in a multi-shot workflow. The OCIO config has been set up with SCENE and SHOT variables that OCIO uses to switch between LUTs as appropriate. These have been added to the Gaffer Preferences, with values referencing Gaffer context variables which are specified by the Script Settings as usual. Hence when the shot variables are switched in the script by the usual means, the OCIO context is automatically updated to reflect the change.

![image](https://user-images.githubusercontent.com/1133871/94920380-1cdd0700-04ae-11eb-9740-9eb29a2902b3.png)

