### PR TITLE
Transform Tools : Increase thickness of tool handle hit areas

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - Preferences : Added support for OpenColorIO context variables. These may contain references to Gaffer context variables via the standard `${variable}` syntax, but please note that such variables are only available in the Viewer and not in the rest of the UI (for instance, colour swatches and pickers).
+- Viewer : Increased the size of transform tool handle hit areas.
 
 Fixes
 -----


### PR DESCRIPTION
~*Potential controversial PR*~

Assorted user feedback noted that handles could be hard to 'hit', especially with a tablet. At present, it would take some refactoring to support increasing the hit area without affecting the visual appearance. 

~As an interim compromise, this thickens the handles a little.~ This PR thickens the selection hit area for the handles, allowing them to operate from a wider range, without any change in visual appearance.

