### PR TITLE
Capsule : Fix context management problems

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.57.7.x (relative to 0.57.7.2)
+========
+
+Fixes
+-----
+
+- Encapsulate : Fixed bug where globals and render sets were evaluated in the wrong context.
+
 0.57.7.2 (relative to 0.57.7.1)
 ========
 

--- a/src/GafferScene/Capsule.cpp
+++ b/src/GafferScene/Capsule.cpp
@@ -192,9 +192,9 @@ Imath::Box3f Capsule::bound() const
 void Capsule::render( IECoreScenePreview::Renderer *renderer ) const
 {
 	throwIfExpired();
+	ScenePlug::GlobalScope scope( m_context.get() );
 	IECore::ConstCompoundObjectPtr globals = m_scene->globalsPlug()->getValue();
 	RendererAlgo::RenderSets renderSets( m_scene );
-	Context::Scope scope( m_context.get() );
 	RendererAlgo::outputObjects( m_scene, globals.get(), renderSets, /* lightLinks = */ nullptr, renderer, m_root );
 }
 


### PR DESCRIPTION
- Scope the context when accessing globals and render sets.
- Use a GlobalScope so we don't leak `scene:path` into the global computes.
