### PR TITLE
GafferArnold  : Support Memory and Timestamp log options

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - Preferences : Added support for OpenColorIO context variables. These may contain references to Gaffer context variables via the standard `${variable}` syntax, but please note that such variables are only available in the Viewer and not in the rest of the UI (for instance, colour swatches and pickers).
 - Viewer : Increased the size of transform tool handle hit areas.
+- Arnold : Moved debug log messages into the Debug severity.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,7 @@ Improvements
 
 - Preferences : Added support for OpenColorIO context variables. These may contain references to Gaffer context variables via the standard `${variable}` syntax, but please note that such variables are only available in the Viewer and not in the rest of the UI (for instance, colour swatches and pickers).
 - Viewer : Increased the size of transform tool handle hit areas.
-- Arnold : Moved debug log messages into the Debug severity.
+- Arnold : Moved debug log messages into the Debug severity and added support for Memory and Timestamp options.
 
 Fixes
 -----

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -3368,7 +3368,10 @@ class ArnoldGlobals
 		// we have to make do with a global handler.
 		static void aiMsgCallback( int logmask, int severity, const char *msg_string, int tabs )
 		{
-			g_currentMessageHandler->handle( g_ieMsgLevels[ min( severity, 3 ) ], "Arnold", std::string( tabs, ' ' ) + msg_string );
+			const IECore::Msg::Level level = \
+				( logmask == AI_LOG_DEBUG ) ? IECore::Msg::Level::Debug : g_ieMsgLevels[ min( severity, 3 ) ];
+
+			g_currentMessageHandler->handle( level, "Arnold", std::string( tabs, ' ' ) + msg_string );
 		}
 		static IECore::MessageHandlerPtr g_currentMessageHandler;
 		static const std::vector<IECore::MessageHandler::Level> g_ieMsgLevels;


### PR DESCRIPTION
Timestamp and memory usage is not part of the message string. Displaying this was a common request from artists, to help understand where time was going in expansion with other procedurals (eg: xgen), and as a warning as to how heavy their renders might be on the farm. Memory usage is described as that used by the _process_ so may well include our cache, but I'd at least hope its the same number as would be printed out in the shell by Arnold itself.