### PR TITLE
Arnold Tests : Fix path to test image

### DIFF
--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -275,7 +275,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		s["Tex"] = GafferArnold.ArnoldShader( "image" )
 		s["Tex"].loadShader( "image" )
-		s["Tex"]["parameters"]["filename"].setValue( "python/GafferArnoldTest/images/sphereLightBake.exr" )
+		s["Tex"]["parameters"]["filename"].setValue( "${GAFFER_ROOT}/python/GafferArnoldTest/images/sphereLightBake.exr" )
 		s["Tex"]["parameters"]["multiply"].setValue( imath.Color3f( 1, 0, 0 ) )
 
 		s["Light"] = GafferArnold.ArnoldLight( "quad_light" )


### PR DESCRIPTION
The files need to be absolute as the tests don't need to be run within a local repo dir.