### PR TITLE
EventLoop : Work around PySide crash with Qt 5.12

### DIFF
--- a/python/GafferUI/EventLoop.py
+++ b/python/GafferUI/EventLoop.py
@@ -161,6 +161,11 @@ class EventLoop( object ) :
 		assert( style is not None )
 		__qtApplication = QtWidgets.QApplication( [ "gaffer" ] )
 
+	# Ensure that PySide creates the wrapper for the main thread while
+	# running the main thread. PySide adds a property when first wrapping,
+	# and this can't be done on any other thread.
+	__qtApplication.thread()
+
 	__mainEventLoop = None
 	## Returns the main event loop for the application. This should always
 	# be started before running any other nested event loops. In the standalone

--- a/python/GafferUITest/EventLoopTest.py
+++ b/python/GafferUITest/EventLoopTest.py
@@ -36,9 +36,11 @@
 ##########################################################################
 
 import unittest
+import os
 import threading
 import time
 import functools
+import subprocess32 as subprocess
 
 import IECore
 
@@ -223,6 +225,12 @@ class EventLoopTest( GafferUITest.TestCase ) :
 
 		self.assertEqual( self.__runOnceCalls, 2 )
 		self.assertEqual( self.__addRunOnceCalls, 2 )
+
+	def testExecuteOnUIThreadBeforeEnsureIdleTimer( self ) :
+
+		subprocess.check_call(
+			[ "gaffer", "python", os.path.join( os.path.dirname( __file__ ), "scripts", "executeOnUIThread.py" ) ]
+		)
 
 	def setUp( self ) :
 

--- a/python/GafferUITest/scripts/executeOnUIThread.py
+++ b/python/GafferUITest/scripts/executeOnUIThread.py
@@ -1,0 +1,13 @@
+import threading
+import GafferUI
+
+def threadFunction() :
+
+	GafferUI.EventLoop.executeOnUIThread(
+		GafferUI.EventLoop.mainEventLoop().stop
+	)
+
+thread = threading.Thread( target = threadFunction )
+thread.start()
+
+GafferUI.EventLoop.mainEventLoop().start()


### PR DESCRIPTION
This problem could be triggered as follows :

	1. `gaffer op sequenceLs -gui`
	2. Set `dir` to a directory that doesn't exist.
	3. Hit OK to execute the Op.

It yielded an assertion failure as follows :

	```ASSERT failure in QCoreApplication::sendEvent: "Cannot send events to objects owned by a different thread. Current thread 0x0x7fff90001050. Receiver '' (of type 'QThread') was created in thread 0x0xa902b0", file kernel/qcoreapplication.cpp, line 578```

And a stack trace like so :

	```
	#2  0x00007fffe229d615 in qt_message_fatal (context=..., message=...) at global/qlogging.cpp:1907
	#3  0x00007fffe229e122 in QMessageLogger::fatal (this=this@entry=0x7fffa77fcd90, msg=msg@entry=0x7fffe25b0c60 "ASSERT failure in %s: \"%s\", file %s, line %d") at global/qlogging.cpp:888
	#4  0x00007fffe22985dc in qt_assert_x (where=where@entry=0x7fffe25c0144 "QCoreApplication::sendEvent", what=<optimized out>, file=file@entry=0x7fffe25c00cf "kernel/qcoreapplication.cpp", line=line@entry=578)
	    at global/qglobal.cpp:3220
	#5  0x00007fffe247aaa2 in QCoreApplicationPrivate::checkReceiverThread (receiver=receiver@entry=0xa902b0) at kernel/qcoreapplication.cpp:572
	#6  0x00007fffe16052b2 in QApplication::notify (this=0x1dc4170, receiver=0xa902b0, e=0x7fffa77fd120) at kernel/qapplication.cpp:2902
	#7  0x00007fffdc443cf6 in QApplicationWrapper::notify(QObject*, QEvent*) () from /disk1/john/dev/build/gafferPython2/lib/python2.7/site-packages/PySide2/QtWidgets.so
	#8  0x00007fffe247b0ec in QCoreApplication::notifyInternal2 (receiver=0xa902b0, event=0x7fffa77fd120) at kernel/qcoreapplication.cpp:1088
	#9  0x00007fffe247b2ea in QCoreApplication::sendEvent (receiver=receiver@entry=0xa902b0, event=event@entry=0x7fffa77fd120) at kernel/qcoreapplication.cpp:1476
	#10 0x00007fffe24b426b in QObject::setProperty (this=0xa902b0, name=0x7fffdce01d50 <PySide::invalidatePropertyName> "_PySideInvalidatePtr", value=...) at kernel/qobject.cpp:3945
	#11 0x00007fffdcdffa42 in PySide::getWrapperForQObject(QObject*, SbkObjectType*) () from /disk1/john/dev/build/gafferPython2/lib/python2.7/site-packages/PySide2/libpyside2-python2.7.so.5.12
	#12 0x00007fffdb768443 in Sbk_QObjectFunc_thread () from /disk1/john/dev/build/gafferPython2/lib/python2.7/site-packages/PySide2/QtCore.so
	```

The problem is that when PySide first makes a wrapper for a QObject, it adds a property to that object. Adding a property can only be performed on the thread that owns the object, so the first access to `__qtApplication.thread()` must be performed on the main thread. We ensure that this is the case by accessing it immediately after constructing the QApplication.

The test case for this has to be run externally via `gaffer python` because when running the full test suite we hit a code path that happens to first access `__qtApplication.thread()` from the main thread. The external script mimics what happens in `gaffer op -gui`, where we end up first accessing `__qtApplication.thread()` from a background thread.
