### PR TITLE
SceneReader : Use Standard cache policy for objects and sets

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.60.x.x (relative to 0.60.2.1)
 ========
 
+Improvements
+------------
+
+- SceneReader : Improved loading performance of shared resources such as sets and instanced objects.
+
 API
 ---
 

--- a/include/GafferScene/SceneReader.h
+++ b/include/GafferScene/SceneReader.h
@@ -84,6 +84,8 @@ class GAFFERSCENE_API SceneReader : public SceneNode
 
 	protected :
 
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
+
 		/// \todo These methods defer to SceneInterface::hash() to do most of the work, but we could go further.
 		/// Currently we still hash in fileNamePlug() and refreshCountPlug() because we don't trust the current
 		/// implementation of SceneCache::hash() - it should hash the filename and modification time, but instead

--- a/src/GafferScene/SceneReader.cpp
+++ b/src/GafferScene/SceneReader.cpp
@@ -164,6 +164,22 @@ size_t SceneReader::supportedExtensions( std::vector<std::string> &extensions )
 	return extensions.size();
 }
 
+Gaffer::ValuePlug::CachePolicy SceneReader::computeCachePolicy( const Gaffer::ValuePlug *output ) const
+{
+	if( output == outPlug()->objectPlug() || output == outPlug()->setPlug() )
+	{
+		// For expensive reads, block rather than allow multiple threads to load duplicates
+		// of the same thing.
+		/// \todo Consider doing this for other children of `outPlug()` too, but
+		/// bear in mind that this is probably not a good idea for `boundPlug()`.
+		/// Because `computeBound()` forwards to `parent->childBoundsPlug()->getValue()`
+		/// and that uses TaskCollaboration, we want to allow as many threads through
+		/// as possible to take advantage of collaboration.
+		return ValuePlug::CachePolicy::Standard;
+	}
+	return SceneNode::computeCachePolicy( output );
+}
+
 void SceneReader::hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	SceneNode::hashBound( path, context, parent, h );


### PR DESCRIPTION
After implementing [hash sharing for USD instances](https://github.com/ImageEngine/cortex/pull/1086), I was a little surprised that although Gaffer's cache usage dropped by 90%, peak memory usage only dropped by 30%. The answer was pretty obvious : because SceneReader was using the Legacy cache policy, we were allowing multiple threads to load duplicates of objects and then leaving it to the compute cache to deduplicate them. Using the Standard policy instead gave a total reduction in peak memory usage of 80% and an additional 50% reduction in runtime.

I don't have benchmarks for sets, but since they are often needed by multiple threads at the same time, and can be expensive to load, I am expecting similar benefits.

I'm not aware of any SceneInterfaces using TBB tasks behind the scenes, but if any do, they would need to isolate their tasks now since they will be performed behind a lock.

It may be worth considering testing with a wider variety of production data before merging to check that there aren't any unforeseen consequences to this change. @murrays-ie, I wonder if this is something you might be able to do?