### PR TITLE
SceneNode/SceneProcessor : Evaluate `enabled` in global scope

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ Improvements
   - Added support for sub-frame dragging with a <kbd>Ctrl</kbd> modifier, and fixed snapping of the frame indicator for regular drag operations.
   - The current frame is now drawn next to the playhead.
 - Increased image processing tile size from 64 pixels to 128 pixels. This reduces per-tile overhead on large images, dramatically increasing effective image performance in many cases.
+- SceneNode/SceneProcessor : Enforced that the value of the `enabled` plug may not be varied using the `scene:path` context variable. Attempts to do so could result in the generation of invalid scenes. Filters are the appropriate way to enable or disable a node on a per-location basis, and should be used instead. This change yielded a 5-10% performance improvement for a moderately complex scene.
 - OSLImage : Avoided some unnecessary computes and hashing when calculating channel names or passing through channel data unaltered.
 - Context : Optimized `hash()` method.
 

--- a/include/GafferScene/SceneNode.h
+++ b/include/GafferScene/SceneNode.h
@@ -127,6 +127,11 @@ class GAFFERSCENE_API SceneNode : public Gaffer::ComputeNode
 		Gaffer::ValuePlug::CachePolicy hashCachePolicy( const Gaffer::ValuePlug *output ) const override;
 		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
 
+		/// Returns `enabledPlug()->getValue()` evaluated in a global context.
+		/// Disabling is handled automatically by the SceneNode and SceneProcessor
+		/// base classes, so there should be little need to call this.
+		bool enabled( const Gaffer::Context *context ) const;
+
 	private :
 
 		void plugInputChanged( Gaffer::Plug *plug );

--- a/src/GafferScene/SceneProcessor.cpp
+++ b/src/GafferScene/SceneProcessor.cpp
@@ -125,7 +125,7 @@ const Plug *SceneProcessor::correspondingInput( const Plug *output ) const
 void SceneProcessor::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	const ScenePlug *scenePlug = output->parent<ScenePlug>();
-	if( scenePlug && !enabledPlug()->getValue() )
+	if( scenePlug && !enabled( context ) )
 	{
 		// if we're hashing the output scene, and we're disabled, we need to
 		// pass through the hash from the inPlug().
@@ -141,7 +141,7 @@ void SceneProcessor::hash( const Gaffer::ValuePlug *output, const Gaffer::Contex
 void SceneProcessor::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const
 {
 	const ScenePlug *scenePlug = output->parent<ScenePlug>();
-	if( scenePlug && !enabledPlug()->getValue() )
+	if( scenePlug && !enabled( context ) )
 	{
 		// if we're computing the output scene, and we're disabled, we need to
 		// pass through the scene from inPlug().


### PR DESCRIPTION
Using `scene:path` to drive enabled status has never been supported, and this makes that official by making it impossible. There is probably some discussion to be had around whether or not this is a breaking change. I'm making the PR for 0.58_maintenance for now so that @alex-savenko-at-cinesite can do some testing using the automated PR builds.