### PR TITLE
Build : Use Docker image 1.2.0 and dependencies 2.0.0a5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
             variant: linux-python2
             publish: true
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.6.0/gafferDependencies-1.6.0-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.0.0a5/gafferDependencies-2.0.0-Python2-linux.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -57,7 +57,7 @@ jobs:
             variant: linux-python2
             publish: false
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.6.0/gafferDependencies-1.6.0-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.0.0a5/gafferDependencies-2.0.0-Python2-linux.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -79,7 +79,7 @@ jobs:
             variant: macos-python2
             publish: true
             containerImage:
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.6.0/gafferDependencies-1.6.0-osx.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.0.0a5/gafferDependencies-2.0.0-Python2-osx.tar.gz
             testRunner: bash -c
             sconsCacheMegabytes: 400
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
             buildType: RELEASE
             variant: linux-python2
             publish: true
-            containerImage: gafferhq/build:1.1.0
+            containerImage: gafferhq/build:1.2.0
             dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.6.0/gafferDependencies-1.6.0-linux.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
@@ -56,7 +56,7 @@ jobs:
             buildType: DEBUG
             variant: linux-python2
             publish: false
-            containerImage: gafferhq/build:1.1.0
+            containerImage: gafferhq/build:1.2.0
             dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/1.6.0/gafferDependencies-1.6.0-linux.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
@@ -68,7 +68,7 @@ jobs:
             buildType: RELEASE
             variant: linux-python3
             publish: true
-            containerImage: gafferhq/build:1.1.0
+            containerImage: gafferhq/build:1.2.0
             dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.0.0a5/gafferDependencies-2.0.0-Python3-linux.tar.gz
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
@@ -113,8 +113,6 @@ jobs:
         Xvfb :99 -screen 0 1280x1024x24 &
         metacity&
         useradd -m testUser
-        # Works around issues with earlier Python versions, remove once the Docker image is updated
-        pip install --user sphinx==1.8.1
       if: runner.os == 'Linux'
 
     - name: 'Install Python Modules'

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -43,7 +43,7 @@ import hashlib
 # Determine default archive URL.
 
 platform = "osx" if sys.platform == "darwin" else "linux"
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/1.6.0/gafferDependencies-1.6.0-" + platform + ".tar.gz"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/2.0.0a5/gafferDependencies-2.0.0-Python2-" + platform + ".tar.gz"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -29,6 +29,11 @@ Breaking Changes
 - OpenColorIOTransform : Made `transform()` method protected rather than public.
 - BackgroundMethodTest : Removed public visibility from private `TestWidget` and `WaitingSlot`.
 
+Build
+-----
+
+- Dependencies : Updated to version 2.0.0
+
 0.58.3.0 (relative to 0.58.2.0)
 ========
 

--- a/config/installDependencies.sh
+++ b/config/installDependencies.sh
@@ -55,9 +55,10 @@ buildDir=${1:-"build/gaffer-$gafferMilestoneVersion.$gafferMajorVersion.$gafferM
 
 # Get the prebuilt dependencies package and unpack it into the build directory
 
-dependenciesVersion="1.6.0"
-dependenciesVersionSuffix=""
-dependenciesFileName="gafferDependencies-$dependenciesVersion-$platform.tar.gz"
+dependenciesVersion="2.0.0"
+dependenciesVersionSuffix="a5"
+dependenciesPythonVersion="2"
+dependenciesFileName="gafferDependencies-$dependenciesVersion-Python$dependenciesPythonVersion-$platform.tar.gz"
 downloadURL="https://github.com/GafferHQ/dependencies/releases/download/$dependenciesVersion$dependenciesVersionSuffix/$dependenciesFileName"
 
 echo "Downloading dependencies \"$downloadURL\""


### PR DESCRIPTION
Due to the number of issues seen under Qt 5.12 and friends, we want to switch all builds over to this sooner rather than later, to help surface any more issues before 0.59 is released.
