### PR TITLE
BranchCreator : Fix set computation bugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+0.57.7.x (relative to 0.57.7.3)
+========
+
+- BranchCreator : Fixed bugs affecting set computation.
+
 0.57.7.3 (relative to 0.57.7.2)
 ========
 

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -569,10 +569,11 @@ void BranchCreator::hashSet( const IECore::InternedString &setName, const Gaffer
 	if( parentPaths.isEmpty() )
 	{
 		h = inPlug()->setPlug()->hash();
+		return;
 	}
 
 	FilteredSceneProcessor::hashSet( setName, context, parent, h );
-	h.append( inPlug()->setHash( setName ) );
+	inPlug()->setPlug()->hash( h );
 
 	for( PathMatcher::Iterator it = parentPaths.begin(), eIt = parentPaths.end(); it != eIt; ++it )
 	{
@@ -585,6 +586,7 @@ void BranchCreator::hashSet( const IECore::InternedString &setName, const Gaffer
 		MurmurHash branchSetHash;
 		hashBranchSet( parentPath, setName, context, branchSetHash );
 		h.append( branchSetHash );
+		h.append( parentPath.data(), parentPath.size() );
 	}
 }
 
@@ -593,7 +595,7 @@ IECore::ConstPathMatcherDataPtr BranchCreator::computeSet( const IECore::Interne
 	ConstPathMatcherDataPtr parentPathsData = parentPathsPlug()->getValue();
 	const PathMatcher &parentPaths = parentPathsData->readable();
 
-	ConstPathMatcherDataPtr inputSetData = inPlug()->set( setName );
+	ConstPathMatcherDataPtr inputSetData = inPlug()->setPlug()->getValue();
 	if( parentPaths.isEmpty() )
 	{
 		return inputSetData;


### PR DESCRIPTION
- Pass through exactly in `hashSet()` when we will pass through exactly in `computeSet()`
- Don't use `ScenePlug::set()` and `ScenePlug::setHash()` unnecessarily. We are already in the right context for the set we want, so can call `setPlug()->getValue()` and `setPlug()->hash()` directly.
- Include parent paths in hash for set, so sets are recomputed when parent path changes.
