### PR TITLE
OpenColorIOTransform : Fix compilation on gcc 4.8.3

### DIFF
--- a/src/GafferImage/OpenColorIOTransform.cpp
+++ b/src/GafferImage/OpenColorIOTransform.cpp
@@ -132,7 +132,7 @@ OpenColorIO::ConstProcessorRcPtr OpenColorIOTransform::processor() const
 	OpenColorIO::ConstTransformRcPtr colorTransform = transform();
 	if( !colorTransform )
 	{
-		return nullptr;
+		return OpenColorIO::ConstProcessorRcPtr();
 	}
 
 	OCIOMutex::scoped_lock lock( g_ocioMutex );


### PR DESCRIPTION
`OCIO_SHARED_PTR` is defined as `std::tr1::shared_ptr` and the previous `nullptr` return resulted in the following compilation error:

```
src/GafferImage/OpenColorIOTransform.cpp:135:10: error: could not convert 'nullptr' from 'std::nullptr_t' to 'OpenColorIO::v1_0_9::ConstProcessorRcPtr {aka std::tr1::shared_ptr<const OpenColorIO::v1_0_9::Processor>}'
```

In add a `#if` switch if that is preferred.