### PR TITLE
ImageGadget : Fix crash viewing monochrome or soloed channels

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.58.x.x (relative to 0.58.3.0)
+========
+
+Fixes
+-----
+
+- Viewer : Fixed crash when viewing a rapidly changing monochrome image or soloed channel.
+
 0.58.3.0 (relative to 0.58.2.0)
 ========
 

--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -255,7 +255,7 @@ class ImageGadget::TileShader : public IECore::RefCounted
 				glUseProgram( m_previousProgram );
 			}
 
-			void loadTile( const IECoreGL::Texture *channelTextures[4], bool active )
+			void loadTile( IECoreGL::ConstTexturePtr channelTextures[4], bool active )
 			{
 				for( int i = 0; i < 4; ++i )
 				{
@@ -1168,7 +1168,7 @@ void ImageGadget::renderTiles() const
 		for( tileOrigin.x = ImagePlug::tileOrigin( dataWindow.min ).x; tileOrigin.x < dataWindow.max.x; tileOrigin.x += ImagePlug::tileSize() )
 		{
 			bool active = false;
-			const IECoreGL::Texture *channelTextures[4];
+			IECoreGL::ConstTexturePtr channelTextures[4];
 			for( int i = 0; i < 4; ++i )
 			{
 				const InternedString channelName = m_soloChannel == -1 ? m_rgbaChannels[i] : m_rgbaChannels[m_soloChannel];


### PR DESCRIPTION
In this case, we call `Tile::texture()` on the _same_ tile more than once, before calling `loadTile()` with all the textures we've gathered. If we're unlucky, in between calls, new data can arrive in `Tile::m_channelDataToConvert`, so that the next call to `texture()` will discard the previous texture. By owning a reference to the textures we prevent them from being deleted before `loadTile()` has completed and we have drawn the tile.

This fixes a regression introduced in 1c55a780d5af0a4aff32722a1b0e1d777b63ea84. Prior to that, we would call `Texture::bind()` _before_ the texture was destroyed, avoiding the crash we're fixing here. But the `Texture` could still have been deleted between the `bind()` and the drawing of the tile. It's not clear to me how we were getting away with that, but _maybe_ it could explain a rare drawing glitch we've seen during IPR?

