### PR TITLE
ContextSanitisers : Use IECore's `tbb_hasher(InternedString)` if available

### DIFF
--- a/src/GafferImageTest/ContextSanitiser.cpp
+++ b/src/GafferImageTest/ContextSanitiser.cpp
@@ -48,16 +48,20 @@ using namespace Gaffer;
 using namespace GafferImage;
 using namespace GafferImageTest;
 
+/// \todo Remove
+#ifndef IECORE_INTERNEDSTRING_WITH_TBB_HASHER
+
 namespace IECore
 {
 
-/// \todo Move to Cortex
 size_t tbb_hasher( const InternedString &s )
 {
 	return tbb::tbb_hasher( s.string() );
 }
 
 } // namespace IECore
+
+#endif
 
 ContextSanitiser::ContextSanitiser()
 {

--- a/src/GafferSceneTest/ContextSanitiser.cpp
+++ b/src/GafferSceneTest/ContextSanitiser.cpp
@@ -50,16 +50,20 @@ using namespace Gaffer;
 using namespace GafferScene;
 using namespace GafferSceneTest;
 
+/// \todo Remove
+#ifndef IECORE_INTERNEDSTRING_WITH_TBB_HASHER
+
 namespace IECore
 {
 
-/// \todo Move to Cortex
 size_t tbb_hasher( const InternedString &s )
 {
 	return tbb::tbb_hasher( s.string() );
 }
 
 } // namespace IECore
+
+#endif
 
 namespace
 {


### PR DESCRIPTION
This will be needed to build against Cortex after https://github.com/ImageEngine/cortex/pull/1088 is merged.
