### PR TITLE
WarpUI : Set userDefault for useDerivatives to False

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - GraphEditor : Improved performance slightly for large graphs.
+- Warp : Defaulted `useDerivatives` to off for nodes created via the UI. Using derivatives is only beneficial when the warp is highly anisotropic, and it has a significant performance impact.
 
 Fixes
 -----

--- a/python/GafferImageUI/WarpUI.py
+++ b/python/GafferImageUI/WarpUI.py
@@ -92,6 +92,8 @@ Gaffer.Metadata.registerNode(
 			that mostly preserve the size of pixels, but could have a large impact if there is
 			heavy distortion.  Fixes problems with aliasing, at the cost of some extra calculations.
 			""",
+
+			"userDefault", False,
 		],
 
 	}


### PR DESCRIPTION
"useDerivatives" is technically more correct, and we had made it the default on this basis.  But in most common cases, the filter isn't highly anisotropic, and turning off useDerivatives makes little difference, or is acceptable anyway.  Due the performance cost of useDerivatives, we now default it off.