### PR TITLE
Arnold Renderer : Work around unhelpful Arnold "inheritance" behaviour 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.58.x.x (relative to 0.58.3.2)
+========
+
+Fixes
+-----
+
+- Encapsulate : Fixed bugs in shader/attribute inheritance when rendering in Arnold (#3559).
+
 0.58.3.2 (relative to 0.58.3.1)
 ========
 

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1107,9 +1107,12 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			if( isConvertedProcedural( geometry ) )
 			{
 				// Arnold neither inherits nor overrides visibility parameters. Instead
-				// it does a bitwise `&` between the procedural and its children. Apply
-				// full visibility to the `ginstance` to override the full invisibility
-				// of the procedural it references.
+				// it does a bitwise `&` between the procedural and its children. The
+				// `procedural` node itself will have `visibility == 0` applied by the
+				// `Instance` constructor, so it can be instanced without the original
+				// being seen. Override that by applying full visibility to the `ginstance`
+				// so that the children of the procedural have full control of their final
+				// visibility.
 				AiNodeSetByte( node, g_visibilityArnoldString, AI_RAY_ALL );
 				return true;
 			}

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1383,104 +1383,104 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 		};
 
-	struct Volume
-	{
-		Volume( const IECore::CompoundObject *attributes )
+		struct Volume
 		{
-			volumeGrids = attribute<IECore::StringVectorData>( g_volumeGridsAttributeName, attributes );
-			velocityGrids = attribute<IECore::StringVectorData>( g_velocityGridsAttributeName, attributes );
-			velocityScale = optionalAttribute<float>( g_velocityScaleAttributeName, attributes );
-			velocityFPS = optionalAttribute<float>( g_velocityFPSAttributeName, attributes );
-			velocityOutlierThreshold = optionalAttribute<float>( g_velocityOutlierThresholdAttributeName, attributes );
-			stepSize = optionalAttribute<float> ( g_volumeStepSizeAttributeName, attributes );
-			stepScale = optionalAttribute<float>( g_volumeStepScaleAttributeName, attributes );
-		}
-
-		IECore::ConstStringVectorDataPtr volumeGrids;
-		IECore::ConstStringVectorDataPtr velocityGrids;
-		boost::optional<float> velocityScale;
-		boost::optional<float> velocityFPS;
-		boost::optional<float> velocityOutlierThreshold;
-		boost::optional<float> stepSize;
-		boost::optional<float> stepScale;
-
-		void hash( IECore::MurmurHash &h ) const
-		{
-			if( volumeGrids )
+			Volume( const IECore::CompoundObject *attributes )
 			{
-				volumeGrids->hash( h );
+				volumeGrids = attribute<IECore::StringVectorData>( g_volumeGridsAttributeName, attributes );
+				velocityGrids = attribute<IECore::StringVectorData>( g_velocityGridsAttributeName, attributes );
+				velocityScale = optionalAttribute<float>( g_velocityScaleAttributeName, attributes );
+				velocityFPS = optionalAttribute<float>( g_velocityFPSAttributeName, attributes );
+				velocityOutlierThreshold = optionalAttribute<float>( g_velocityOutlierThresholdAttributeName, attributes );
+				stepSize = optionalAttribute<float> ( g_volumeStepSizeAttributeName, attributes );
+				stepScale = optionalAttribute<float>( g_volumeStepScaleAttributeName, attributes );
 			}
 
-			if( velocityGrids )
+			IECore::ConstStringVectorDataPtr volumeGrids;
+			IECore::ConstStringVectorDataPtr velocityGrids;
+			boost::optional<float> velocityScale;
+			boost::optional<float> velocityFPS;
+			boost::optional<float> velocityOutlierThreshold;
+			boost::optional<float> stepSize;
+			boost::optional<float> stepScale;
+
+			void hash( IECore::MurmurHash &h ) const
 			{
-				velocityGrids->hash( h );
-			}
-
-			h.append( velocityScale.get_value_or( 1.0f ) );
-			h.append( velocityFPS.get_value_or( 24.0f ) );
-			h.append( velocityOutlierThreshold.get_value_or( 0.001f ) );
-			h.append( stepSize.get_value_or( 0.0f ) );
-			h.append( stepScale.get_value_or( 1.0f ) );
-		}
-
-		void apply( AtNode *node ) const
-		{
-			if( volumeGrids && volumeGrids->readable().size() )
-			{
-				AtArray *array = ParameterAlgo::dataToArray( volumeGrids.get(), AI_TYPE_STRING );
-				AiNodeSetArray( node, g_volumeGridsArnoldString, array );
-			}
-
-			if( velocityGrids && velocityGrids->readable().size() )
-			{
-				AtArray *array = ParameterAlgo::dataToArray( velocityGrids.get(), AI_TYPE_STRING );
-				AiNodeSetArray( node, g_velocityGridsArnoldString, array );
-			}
-
-			if( !velocityScale || velocityScale.get() > 0 )
-			{
-				AtNode *options = AiUniverseGetOptions();
-				const AtNode *arnoldCamera = static_cast<const AtNode *>( AiNodeGetPtr( options, "camera" ) );
-
-				if( arnoldCamera )
+				if( volumeGrids )
 				{
-					float shutterStart = AiNodeGetFlt( arnoldCamera, g_shutterStartArnoldString );
-					float shutterEnd = AiNodeGetFlt( arnoldCamera, g_shutterEndArnoldString );
+					volumeGrids->hash( h );
+				}
 
-					// We're getting very lucky here:
-					//  - Arnold has automatically set options.camera the first time we made a camera
-					//  - All cameras output by Gaffer at present will have the same shutter,
-					//    so it doesn't matter if we get it from the final render camera or not.
-					AiNodeSetFlt( node, g_motionStartArnoldString, shutterStart );
-					AiNodeSetFlt( node, g_motionEndArnoldString, shutterEnd );
+				if( velocityGrids )
+				{
+					velocityGrids->hash( h );
+				}
+
+				h.append( velocityScale.get_value_or( 1.0f ) );
+				h.append( velocityFPS.get_value_or( 24.0f ) );
+				h.append( velocityOutlierThreshold.get_value_or( 0.001f ) );
+				h.append( stepSize.get_value_or( 0.0f ) );
+				h.append( stepScale.get_value_or( 1.0f ) );
+			}
+
+			void apply( AtNode *node ) const
+			{
+				if( volumeGrids && volumeGrids->readable().size() )
+				{
+					AtArray *array = ParameterAlgo::dataToArray( volumeGrids.get(), AI_TYPE_STRING );
+					AiNodeSetArray( node, g_volumeGridsArnoldString, array );
+				}
+
+				if( velocityGrids && velocityGrids->readable().size() )
+				{
+					AtArray *array = ParameterAlgo::dataToArray( velocityGrids.get(), AI_TYPE_STRING );
+					AiNodeSetArray( node, g_velocityGridsArnoldString, array );
+				}
+
+				if( !velocityScale || velocityScale.get() > 0 )
+				{
+					AtNode *options = AiUniverseGetOptions();
+					const AtNode *arnoldCamera = static_cast<const AtNode *>( AiNodeGetPtr( options, "camera" ) );
+
+					if( arnoldCamera )
+					{
+						float shutterStart = AiNodeGetFlt( arnoldCamera, g_shutterStartArnoldString );
+						float shutterEnd = AiNodeGetFlt( arnoldCamera, g_shutterEndArnoldString );
+
+						// We're getting very lucky here:
+						//  - Arnold has automatically set options.camera the first time we made a camera
+						//  - All cameras output by Gaffer at present will have the same shutter,
+						//    so it doesn't matter if we get it from the final render camera or not.
+						AiNodeSetFlt( node, g_motionStartArnoldString, shutterStart );
+						AiNodeSetFlt( node, g_motionEndArnoldString, shutterEnd );
+					}
+				}
+
+				if( velocityScale )
+				{
+					AiNodeSetFlt( node, g_velocityScaleArnoldString, velocityScale.get() );
+				}
+
+				if( velocityFPS )
+				{
+					AiNodeSetFlt( node, g_velocityFPSArnoldString, velocityFPS.get() );
+				}
+
+				if( velocityOutlierThreshold )
+				{
+					AiNodeSetFlt( node, g_velocityOutlierThresholdArnoldString, velocityOutlierThreshold.get() );
+				}
+
+				if ( stepSize )
+				{
+					AiNodeSetFlt( node, g_stepSizeArnoldString, stepSize.get() * stepScale.get_value_or( 1.0f ) );
+				}
+				else if ( stepScale )
+				{
+					AiNodeSetFlt( node, g_stepScaleArnoldString, stepScale.get() );
 				}
 			}
-
-			if( velocityScale )
-			{
-				AiNodeSetFlt( node, g_velocityScaleArnoldString, velocityScale.get() );
-			}
-
-			if( velocityFPS )
-			{
-				AiNodeSetFlt( node, g_velocityFPSArnoldString, velocityFPS.get() );
-			}
-
-			if( velocityOutlierThreshold )
-			{
-				AiNodeSetFlt( node, g_velocityOutlierThresholdArnoldString, velocityOutlierThreshold.get() );
-			}
-
-			if ( stepSize )
-			{
-				AiNodeSetFlt( node, g_stepSizeArnoldString, stepSize.get() * stepScale.get_value_or( 1.0f ) );
-			}
-			else if ( stepScale )
-			{
-				AiNodeSetFlt( node, g_stepScaleArnoldString, stepScale.get() );
-			}
-		}
-	};
+		};
 
 		enum ShadingFlags
 		{


### PR DESCRIPTION
Procedurals are the only way to introduce hierarchy into an Arnold scene, and therefore the only way to do high-level instancing. But their behaviour with respect to attribute inheritance makes them unsuitable for this task, because attributes defined on the procedural completely override any attributes defined on its children. The rules appear to be :

- `matrix` is concatenated as you would expect.
- `visibility` takes a bitwise `&` of the procedural value and the child value.
- User parameters are treated properly, with child nodes inheriting them from `ginstance` nodes referencing the procedural.
- Everything else is backwards, with the procedural's values trashing the child values. This was presumably helpful in some standin workflows prior to operators being a thing, but it is totally unsuited to our purposes.

We work around this by emulating the inheritance ourself. This has several downsides compared to hypothetical native support in Arnold :

- We can't instance procedurals if they have different attributes.
- We can't edit attributes on procedurals after they have been created. Instead we must force a complete re-expand.

I have been careful to ensure that these downsides don't apply where the only differences are in user attributes, so that we can still instance encapsulated prototypes effectively for the Gaffer Instancer node.

Fixes #3559.