### PR TITLE
Arnold Renderer : Avoid deadlock when expanding procedurals

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.57.7.x (relative to 0.57.7.4)
+========
+
+Fixes
+-----
+
+- Arnold Renderer : Fixed hangs when instancing the output of an Encapsulate node.
+
 0.57.7.4 (relative to 0.57.7.3)
 ========
 


### PR DESCRIPTION
We could hit the classic TBB task-stealing deadlock when expanding a Capsule, as expansion happens behind a lock and would spawn TBB tasks that might steal other tasks that in turn needed the same lock.
