### PR TITLE
OpenImageIOReader : Don't leak tileBatchIndex context to input plugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Fixes
 
 - Encapsulate : Fixed bugs in shader/attribute inheritance when rendering in Arnold (#3559).
 - Arnold : Fixed OSLShader connections between color components.
+- ImageReader : Fixed bug which caused fileName to be evaluated in unnecessary contexts.
 
 0.58.3.2 (relative to 0.58.3.1)
 ========

--- a/python/GafferImageTest/OpenImageIOReaderTest.py
+++ b/python/GafferImageTest/OpenImageIOReaderTest.py
@@ -515,6 +515,19 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 
 				self.assertImagesEqual( r["out"], offsetIn["out"], ignoreMetadata = True )
 
+	def testFileNameContext( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["reader"] = GafferImage.OpenImageIOReader()
+
+		s["expression"] = Gaffer.Expression()
+		s["expression"].setExpression( 'parent["reader"]["fileName"] = "%s"' % self.fileName )
+
+		with Gaffer.ContextMonitor( root = s["expression"] ) as cm :
+			GafferImage.ImageAlgo.tiles( s["reader"]["out"] )
+
+		self.assertEqual( set( cm.combinedStatistics().variableNames() ), set( ['frame', 'framesPerSecond'] ) )
+
 	def testMultipartRead( self ) :
 
 		rgbReader = GafferImage.OpenImageIOReader()

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -898,12 +898,13 @@ void OpenImageIOReader::hash( const ValuePlug *output, const Context *context, I
 	else if( output == tileBatchPlug() )
 	{
 		h.append( context->get<V3i>( g_tileBatchIndexContextName ) );
-		{
-			ImagePlug::GlobalScope c( context );
-			hashFileName( context, h );
-			refreshCountPlug()->hash( h );
-			missingFrameModePlug()->hash( h );
-		}
+
+		Gaffer::Context::EditableScope c( context );
+		c.remove( g_tileBatchIndexContextName );
+
+		hashFileName( c.context(), h );
+		refreshCountPlug()->hash( h );
+		missingFrameModePlug()->hash( h );
 	}
 }
 
@@ -933,8 +934,12 @@ void OpenImageIOReader::compute( ValuePlug *output, const Context *context ) con
 	{
 		V3i tileBatchIndex = context->get<V3i>( g_tileBatchIndexContextName );
 
+		Gaffer::Context::EditableScope c( context );
+		c.remove( g_tileBatchIndexContextName );
+
 		std::string fileName = fileNamePlug()->getValue();
-		FilePtr file = retrieveFile( fileName, (MissingFrameMode)missingFrameModePlug()->getValue(), this, context );
+		FilePtr file = retrieveFile( fileName, (MissingFrameMode)missingFrameModePlug()->getValue(), this, c.context() );
+
 		if( !file )
 		{
 			throw IECore::Exception( "OpenImageIOReader - trying to evaluate tileBatchPlug() with invalid file, this should never happen." );


### PR DESCRIPTION
Fairly straightforward fix with corresponding test.

Note that I've removed the use of a GlobalScope - as far as I can tell, whenever tileBatch is evaluated, it's already within a global scope, though it would be good for you to double check this.