### PR TITLE
Arnold ShaderNetworkAlgo : Fix OSL component connections

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Encapsulate : Fixed bugs in shader/attribute inheritance when rendering in Arnold (#3559).
+- Arnold : Fixed OSLShader connections between color components.
 
 0.58.3.2 (relative to 0.58.3.1)
 ========

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -1090,9 +1090,9 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 	def testOSLShaders( self ) :
 
-		blue = GafferOSL.OSLShader()
-		blue.loadShader( "Maths/MixColor" )
-		blue["parameters"]["a"].setValue( imath.Color3f( 0, 0, 1 ) )
+		purple = GafferOSL.OSLShader()
+		purple.loadShader( "Maths/MixColor" )
+		purple["parameters"]["a"].setValue( imath.Color3f( 0.5, 0, 1 ) )
 
 		green = GafferOSL.OSLShader()
 		green.loadShader( "Maths/MixColor" )
@@ -1100,7 +1100,9 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		mix = GafferOSL.OSLShader()
 		mix.loadShader( "Maths/MixColor" )
-		mix["parameters"]["a"].setInput( blue["out"]["out"] )
+		# test component connections
+		mix["parameters"]["a"][2].setInput( purple["out"]["out"][2] )
+		# test color connections
 		mix["parameters"]["b"].setInput( green["out"]["out"] )
 		mix["parameters"]["m"].setValue( 0.5 )
 

--- a/src/GafferArnold/IECoreArnoldPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/ShaderNetworkAlgo.cpp
@@ -336,6 +336,11 @@ namespace ShaderNetworkAlgo
 
 std::vector<AtNode *> convert( const IECoreScene::ShaderNetwork *shaderNetwork, const std::string &name, const AtNode *parentNode )
 {
+	// \todo: remove this conversion once Arnold supports it natively
+	ShaderNetworkPtr networkCopy = shaderNetwork->copy();
+	IECoreScene::ShaderNetworkAlgo::convertOSLComponentConnections( networkCopy.get() );
+	shaderNetwork = networkCopy.get();
+
 	ShaderMap converted;
 	vector<AtNode *> result;
 	const InternedString output = shaderNetwork->getOutput().shader;


### PR DESCRIPTION
These were broken in 538b860473f1a07d4f8d9c6458f501e4611a6c02, where we assumed that Arnold handles component connections correctly internally.

The change to `ArnoldRenderTest.testOSLShaders` exposes a bug in Arnold (which results in a 0,0.5,0.25 pixel rather than the expected 0,0.5,0.5 pixel).

We're reverting to our old behaviour of translating component connections ourselves via MaterilaX swizzle and pack shaders until Arnold can provide a fix.
