### PR TITLE
Constraint : Add ignoreMissingTarget plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - Arnold Renderer : Improved performance when instancing large numbers of objects. A benchmark with 1 million instances shows a 25% reduction in scene generation time.
+- Constraints : Behaviour if the target location didn't exist was previously undefined, and often an error. This behaviour has now been specified - it is now consistently an error, unless you set the new `ignoreMissingTarget` plug, in which case the constraint will just do nothing.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,8 @@ Improvements
 ------------
 
 - Arnold Renderer : Improved performance when instancing large numbers of objects. A benchmark with 1 million instances shows a 25% reduction in scene generation time.
-- Constraints : Behaviour if the target location didn't exist was previously undefined, and often an error. This behaviour has now been specified - it is now consistently an error, unless you set the new `ignoreMissingTarget` plug, in which case the constraint will just do nothing.
+- Constraints : Behaviour if the target location didn't exist was previously undefined, and often an error. This behaviour has now been specified - it is now consistently an error, unless you set the new `ignoreMissingTarget` plug, in which case the constraint will just do nothing. Also, a target of "" is now a no-op, and you must explicitly enter "
+/" in order to constraint to the scene root.
 
 Fixes
 -----

--- a/include/GafferScene/Constraint.h
+++ b/include/GafferScene/Constraint.h
@@ -70,6 +70,9 @@ class GAFFERSCENE_API Constraint : public SceneElementProcessor
 		Gaffer::StringPlug *targetPlug();
 		const Gaffer::StringPlug *targetPlug() const;
 
+		Gaffer::BoolPlug *ignoreMissingTargetPlug();
+		const Gaffer::BoolPlug *ignoreMissingTargetPlug() const;
+
 		Gaffer::IntPlug *targetModePlug();
 		const Gaffer::IntPlug *targetModePlug() const;
 

--- a/include/GafferScene/Constraint.h
+++ b/include/GafferScene/Constraint.h
@@ -98,7 +98,7 @@ class GAFFERSCENE_API Constraint : public SceneElementProcessor
 
 	private :
 
-		void tokenizeTargetPath( ScenePath &path ) const;
+		boost::optional<ScenePath> targetPath() const;
 
 		static size_t g_firstPlugIndex;
 

--- a/python/GafferSceneTest/AimConstraintTest.py
+++ b/python/GafferSceneTest/AimConstraintTest.py
@@ -82,6 +82,7 @@ class AimConstraintTest( GafferSceneTest.SceneTestCase ) :
 		direction = aim["out"].fullTransform( "/group/constrained" ).multDirMatrix( aim["aim"].getValue() )
 		self.assertAlmostEqual( (targetTranslate - constrainedTranslate).normalized().dot( direction.normalized() ), 1, 6 )
 
+
 		# Test behaviour for missing target
 		plane1["name"].setValue( "targetX" )
 		with six.assertRaisesRegex( self, RuntimeError, 'AimConstraint.out.transform : Constraint target does not exist: "/group/target"' ):
@@ -90,6 +91,14 @@ class AimConstraintTest( GafferSceneTest.SceneTestCase ) :
 		aim["ignoreMissingTarget"].setValue( True )
 		self.assertEqual( aim["out"].fullTransform( "/group/constrained" ), aim["in"].fullTransform( "/group/constrained" ) )
 
+		# Constrain to root
+		aim["target"].setValue( "/" )
+		direction = aim["out"].fullTransform( "/group/constrained" ).multDirMatrix( aim["aim"].getValue() )
+		self.assertAlmostEqual( (-constrainedTranslate).normalized().dot( direction.normalized() ), 1, 6 )
+
+		# No op
+		aim["target"].setValue( "" )
+		self.assertEqual( aim["out"].fullTransform( "/group/constrained" ), aim["in"].fullTransform( "/group/constrained" ) )
 
 	def testConstrainedWithExistingRotation( self ) :
 

--- a/python/GafferSceneTest/AimConstraintTest.py
+++ b/python/GafferSceneTest/AimConstraintTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import imath
+import six
 
 import IECore
 
@@ -80,6 +81,15 @@ class AimConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		direction = aim["out"].fullTransform( "/group/constrained" ).multDirMatrix( aim["aim"].getValue() )
 		self.assertAlmostEqual( (targetTranslate - constrainedTranslate).normalized().dot( direction.normalized() ), 1, 6 )
+
+		# Test behaviour for missing target
+		plane1["name"].setValue( "targetX" )
+		with six.assertRaisesRegex( self, RuntimeError, 'AimConstraint.out.transform : Constraint target does not exist: "/group/target"' ):
+			aim["out"].fullTransform( "/group/constrained" )
+
+		aim["ignoreMissingTarget"].setValue( True )
+		self.assertEqual( aim["out"].fullTransform( "/group/constrained" ), aim["in"].fullTransform( "/group/constrained" ) )
+
 
 	def testConstrainedWithExistingRotation( self ) :
 

--- a/python/GafferSceneTest/ParentConstraintTest.py
+++ b/python/GafferSceneTest/ParentConstraintTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import imath
+import six
 
 import IECore
 
@@ -74,6 +75,14 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 		self.assertSceneValid( constraint["out"] )
 
 		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ), group["out"].fullTransform( "/group/target" ) )
+
+		# Test behaviour for missing target
+		plane1["name"].setValue( "targetX" )
+		with six.assertRaisesRegex( self, RuntimeError, 'ParentConstraint.out.transform : Constraint target does not exist: "/group/target"' ):
+			constraint["out"].fullTransform( "/group/constrained" )
+
+		constraint["ignoreMissingTarget"].setValue( True )
+		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ), constraint["in"].fullTransform( "/group/constrained" ) )
 
 	def testRelativeTransform( self ) :
 

--- a/python/GafferSceneTest/ParentConstraintTest.py
+++ b/python/GafferSceneTest/ParentConstraintTest.py
@@ -84,6 +84,13 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 		constraint["ignoreMissingTarget"].setValue( True )
 		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ), constraint["in"].fullTransform( "/group/constrained" ) )
 
+		# Constrain to root and no-op empty constraint ( these are identical for a ParentConstraint )
+		constraint["target"].setValue( "/" )
+		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ), constraint["in"].fullTransform( "/group/constrained" ) )
+		constraint["target"].setValue( "" )
+		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ), constraint["in"].fullTransform( "/group/constrained" ) )
+
+
 	def testRelativeTransform( self ) :
 
 		plane1 = GafferScene.Plane()

--- a/python/GafferSceneTest/PointConstraintTest.py
+++ b/python/GafferSceneTest/PointConstraintTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import imath
+import six
 
 import IECore
 
@@ -114,6 +115,18 @@ class PointConstraintTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ).translation().x, constrainedTranslate.x )
 		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ).translation().y, constrainedTranslate.y )
 		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ).translation().z, constrainedTranslate.z )
+
+		# Test behaviour for missing target
+		plane1["name"].setValue( "targetX" )
+		constraint["xEnabled"].setValue( True )
+		constraint["yEnabled"].setValue( True )
+		constraint["zEnabled"].setValue( True )
+		with six.assertRaisesRegex( self, RuntimeError, 'PointConstraint.out.transform : Constraint target does not exist: "/group/target"' ):
+			constraint["out"].fullTransform( "/group/constrained" )
+
+		constraint["ignoreMissingTarget"].setValue( True )
+		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ), constraint["in"].fullTransform( "/group/constrained" ) )
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/PointConstraintTest.py
+++ b/python/GafferSceneTest/PointConstraintTest.py
@@ -127,6 +127,13 @@ class PointConstraintTest( GafferSceneTest.SceneTestCase ) :
 		constraint["ignoreMissingTarget"].setValue( True )
 		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ), constraint["in"].fullTransform( "/group/constrained" ) )
 
+		# Constrain to root
+		constraint["target"].setValue( "/" )
+		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ).translation(), imath.V3f(0) )
+
+		# No op
+		constraint["target"].setValue( "" )
+		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ), constraint["in"].fullTransform( "/group/constrained" ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/ConstraintUI.py
+++ b/python/GafferSceneUI/ConstraintUI.py
@@ -69,6 +69,16 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"ignoreMissingTarget" : [
+
+			"description",
+			"""
+			Causes the constraint to do nothing if the target location
+			doesn't exist in the scene, instead of erroring.
+			""",
+
+		],
+
 		"targetMode" : [
 
 			"description",

--- a/src/GafferScene/Constraint.cpp
+++ b/src/GafferScene/Constraint.cpp
@@ -52,6 +52,7 @@ Constraint::Constraint( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new StringPlug( "target" ) );
+	addChild( new BoolPlug( "ignoreMissingTarget" ) );
 	addChild( new IntPlug( "targetMode", Plug::In, Origin, Origin, BoundCenter ) );
 	addChild( new V3fPlug( "targetOffset" ) );
 
@@ -74,24 +75,34 @@ const Gaffer::StringPlug *Constraint::targetPlug() const
 	return getChild<Gaffer::StringPlug>( g_firstPlugIndex );
 }
 
+Gaffer::BoolPlug *Constraint::ignoreMissingTargetPlug()
+{
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 1);
+}
+
+const Gaffer::BoolPlug *Constraint::ignoreMissingTargetPlug() const
+{
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 1);
+}
+
 Gaffer::IntPlug *Constraint::targetModePlug()
 {
-	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 1 );
+	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 2 );
 }
 
 const Gaffer::IntPlug *Constraint::targetModePlug() const
 {
-	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 1 );
+	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 2 );
 }
 
 Gaffer::V3fPlug *Constraint::targetOffsetPlug()
 {
-	return getChild<Gaffer::V3fPlug>( g_firstPlugIndex + 2 );
+	return getChild<Gaffer::V3fPlug>( g_firstPlugIndex + 3 );
 }
 
 const Gaffer::V3fPlug *Constraint::targetOffsetPlug() const
 {
-	return getChild<Gaffer::V3fPlug>( g_firstPlugIndex + 2 );
+	return getChild<Gaffer::V3fPlug>( g_firstPlugIndex + 3 );
 }
 
 void Constraint::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
@@ -100,6 +111,8 @@ void Constraint::affects( const Gaffer::Plug *input, AffectedPlugsContainer &out
 
 	if(
 		input == targetPlug() ||
+		input == ignoreMissingTargetPlug() ||
+		input == inPlug()->existsPlug() ||
 		input == targetModePlug() ||
 		input->parent<Plug>() == targetOffsetPlug() ||
 		// TypeId comparison is necessary to avoid calling pure virtual
@@ -119,12 +132,19 @@ bool Constraint::processesTransform() const
 
 void Constraint::hashProcessedTransform( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
+	ScenePath targetPath;
+	tokenizeTargetPath( targetPath );
+
+	if( !inPlug()->exists( targetPath ) )
+	{
+		ignoreMissingTargetPlug()->hash( h );
+		return;
+	}
+
 	ScenePath parentPath = path;
 	parentPath.pop_back();
 	h.append( inPlug()->fullTransformHash( parentPath ) );
 
-	ScenePath targetPath;
-	tokenizeTargetPath( targetPath );
 	h.append( inPlug()->fullTransformHash( targetPath ) );
 
 	const TargetMode targetMode = (TargetMode)targetModePlug()->getValue();
@@ -141,14 +161,28 @@ void Constraint::hashProcessedTransform( const ScenePath &path, const Gaffer::Co
 
 Imath::M44f Constraint::computeProcessedTransform( const ScenePath &path, const Gaffer::Context *context, const Imath::M44f &inputTransform ) const
 {
+	ScenePath targetPath;
+	tokenizeTargetPath( targetPath );
+
+	if( !inPlug()->exists( targetPath ) )
+	{
+		if( ignoreMissingTargetPlug()->getValue() )
+		{
+			return inputTransform;
+		}
+		else
+		{
+			throw IECore::Exception( boost::str(
+				boost::format( "Constraint target does not exist: \"%s\".  Use 'ignoreMissingTarget' option if you want to just skip this constraint" ) % targetPlug()->getValue() ) );
+		}
+	}
+
 	ScenePath parentPath = path;
 	parentPath.pop_back();
 
 	const M44f parentTransform = inPlug()->fullTransform( parentPath );
 	const M44f fullInputTransform = inputTransform * parentTransform;
 
-	ScenePath targetPath;
-	tokenizeTargetPath( targetPath );
 	M44f fullTargetTransform = inPlug()->fullTransform( targetPath );
 
 	const TargetMode targetMode = (TargetMode)targetModePlug()->getValue();


### PR DESCRIPTION
The behaviour of the 3 constraint nodes if the target location didn't exist was previously undefined, and often an error.  This behaviour has now been specified - it is now consistently an error, unless you set the new `ignoreMissingTarget` plug, in which case the constraint will just do nothing.

This could technically break compatibility, but only if an old scene was somehow leveraging undefined behaviour.