### PR TITLE
PlugValueWidget : Extended multi-plug support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ API
 
 - Serialisation : Added `objectToBase64()` and `objectFromBase64()` methods to provide base64 encoding and decoding for all `IECore::Objects`.
 - NumericWidget : Fixed bug that caused `editingFinished` to be called with the wrong `reason` when the widget was left with an invalid value. `Invalid` is now passed in these cases.
+- PlugValueWidget : Improved support for legacy widgets in `PlugValueWidget.create` when used to create widgets for single plugs supplied in a set.
 
 0.58.4.0 (relative to 0.58.3.2)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ API
 - Serialisation : Added `objectToBase64()` and `objectFromBase64()` methods to provide base64 encoding and decoding for all `IECore::Objects`.
 - NumericWidget : Fixed bug that caused `editingFinished` to be called with the wrong `reason` when the widget was left with an invalid value. `Invalid` is now passed in these cases.
 - PlugValueWidget : Improved support for legacy widgets in `PlugValueWidget.create` when used to create widgets for single plugs supplied in a set.
+- NameLabel : Added support for multiple graph components in the constructor, added `setGraphComponents`/`getGraphComponents` methods.
 
 0.58.4.0 (relative to 0.58.3.2)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -18,7 +18,7 @@ API
 - NumericWidget : Fixed bug that caused `editingFinished` to be called with the wrong `reason` when the widget was left with an invalid value. `Invalid` is now passed in these cases.
 - PlugValueWidget : Improved support for legacy widgets in `PlugValueWidget.create` when used to create widgets for single plugs supplied in a set.
 - NameLabel : Added support for multiple graph components in the constructor, added `setGraphComponents`/`getGraphComponents` methods.
-- LabelPlugValueWidget : Added support for multiple plugs.
+- LabelPlugValueWidget, NameValuePlugValuePlug : Added support for multiple plugs.
 
 0.58.4.0 (relative to 0.58.3.2)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ API
 - NumericWidget : Fixed bug that caused `editingFinished` to be called with the wrong `reason` when the widget was left with an invalid value. `Invalid` is now passed in these cases.
 - PlugValueWidget : Improved support for legacy widgets in `PlugValueWidget.create` when used to create widgets for single plugs supplied in a set.
 - NameLabel : Added support for multiple graph components in the constructor, added `setGraphComponents`/`getGraphComponents` methods.
+- LabelPlugValueWidget : Added support for multiple plugs.
 
 0.58.4.0 (relative to 0.58.3.2)
 ========

--- a/python/GafferUI/NameLabel.py
+++ b/python/GafferUI/NameLabel.py
@@ -34,26 +34,34 @@
 #
 ##########################################################################
 
+import functools
+
 import IECore
 
 import Gaffer
 import GafferUI
 
 ## The NameLabel class displays a label which is kept in sync with the name of
-# a particular GraphComponent. The label acts as a drag source for dragging the
-# GraphComponent to another widget.
+# one or more GraphComponents. The label acts as a drag source for dragging the
+# GraphComponents to another widget.
 class NameLabel( GafferUI.Label ) :
 
+	### \todo Rename numComponents -> numAncestors at the next API break
 	def __init__( self, graphComponent, horizontalAlignment=GafferUI.Label.HorizontalAlignment.Left, verticalAlignment=GafferUI.Label.VerticalAlignment.Center, numComponents=1, formatter=None, **kw ) :
+
+		if isinstance( graphComponent, Gaffer.GraphComponent ) :
+			graphComponents = { graphComponent }
+		else :
+			graphComponents = graphComponent or set()
 
 		GafferUI.Label.__init__( self, "", horizontalAlignment, verticalAlignment, **kw )
 
 		self.__formatter = formatter if formatter is not None else self.defaultFormatter
 		self.__numComponents = numComponents
 
-		self.__connections = []
-		self.__graphComponent = False # force setGraphComponent() to update no matter what
-		self.setGraphComponent( graphComponent )
+		self.__connections = {}
+		self.__graphComponents = None # force setGraphComponent() to update no matter what
+		self.setGraphComponents( graphComponents )
 
 		self.buttonPressSignal().connect( Gaffer.WeakMethod( self.__buttonPress ), scoped = False )
 		self.dragBeginSignal().connect( Gaffer.WeakMethod( self.__dragBegin ), scoped = False )
@@ -69,19 +77,34 @@ class NameLabel( GafferUI.Label ) :
 
 	def setGraphComponent( self, graphComponent ) :
 
-		if graphComponent is not None and self.__graphComponent is not False :
-			if graphComponent.isSame( self.__graphComponent ) :
-				return
-		elif self.__graphComponent is None :
-			return
-
-		self.__graphComponent = graphComponent
-		self.__setupConnections()
-		self.__setText()
+		self.setGraphComponents( { graphComponent } if graphComponent is not None else set() )
 
 	def getGraphComponent( self ) :
 
-		return self.__graphComponent
+		count = len( self.__graphComponents )
+
+		if count > 1 :
+			raise RuntimeError( "getGraphComponent called with multiple GraphComponents" )
+		elif count == 1 :
+			return next( iter( self.__graphComponents ) )
+
+		return None
+
+	def setGraphComponents( self, graphComponents ) :
+
+		if not isinstance( graphComponents, set ) :
+			graphComponents = set( graphComponents )
+
+		if graphComponents == self.__graphComponents :
+			return
+
+		self.__graphComponents = graphComponents.copy()
+		self.__setupConnections()
+		self.__setText()
+
+	def getGraphComponents( self ):
+
+		return self.__graphComponents.copy()
 
 	## Specifies how many levels of the hierarchy to be displayed in
 	# the name. A value of 1 shows only the name of getGraphComponent().
@@ -119,11 +142,20 @@ class NameLabel( GafferUI.Label ) :
 
 		return ".".join( IECore.CamelCase.toSpaced( g.getName() ) for g in graphComponents )
 
-	def __setupConnections( self, reuseUntil=None ) :
+	def __setupConnections( self ) :
 
-		if self.__graphComponent is None :
-			self.__connections = []
+		if not self.__graphComponents :
+			self.__connections = {}
 			return
+
+		for component in self.__graphComponents :
+			self.__updateConnections( component )
+
+		for component in list( self.__connections.keys() ) :
+			if component not in self.__graphComponents :
+				del self.__connections[ component ]
+
+	def __updateConnections( self, component, reuseUntil=None ) :
 
 		# when a parent has changed somewhere in the hierarchy,
 		# we only need to make new connections for the components
@@ -139,15 +171,19 @@ class NameLabel( GafferUI.Label ) :
 		updatedConnections = []
 
 		n = 0
-		g = self.__graphComponent
+		g = component
 		reuse = reuseUntil is not None
 		while g is not None and n < self.__numComponents :
 			if reuse :
-				updatedConnections.extend( self.__connections[n*2:n*2+2] )
+				updatedConnections.extend( self.__connections[ component ][ n*2 : n*2+2 ] )
 			else :
 				updatedConnections.append( g.nameChangedSignal().connect( Gaffer.WeakMethod( self.__setText ) ) )
 				if n < self.__numComponents - 1 :
-					updatedConnections.append( g.parentChangedSignal().connect( Gaffer.WeakMethod( self.__parentChanged ) ) )
+					updatedConnections.append(
+						g.parentChangedSignal().connect(
+							functools.partial( Gaffer.WeakMethod( self.__parentChanged ), component )
+						)
+					)
 
 			if g.isSame( reuseUntil ) :
 				reuse = False
@@ -155,36 +191,53 @@ class NameLabel( GafferUI.Label ) :
 			g = g.parent()
 			n += 1
 
-		self.__connections = updatedConnections
+		self.__connections[ component ] = updatedConnections
 
-	def __parentChanged( self, child, oldParent ) :
+	def __parentChanged( self, presentedComponent, child, oldParent ) :
 
 		self.__setText()
-		self.__setupConnections( reuseUntil = child )
+		self.__updateConnections( presentedComponent, reuseUntil = child )
 
 	def __setText( self, *unwantedArgs ) :
 
-		graphComponents = []
+		names = set()
 
-		n = 0
-		g = self.__graphComponent
-		while g is not None and n < self.__numComponents :
-			graphComponents.append( g )
-			g = g.parent()
-			n += 1
+		for graphComponent in self.__graphComponents :
 
-		graphComponents.reverse()
-		GafferUI.Label.setText( self, self.__formatter( graphComponents ) )
+			hierarchyComponents = []
+
+			n = 0
+			g = graphComponent
+			while g is not None and n < self.__numComponents :
+				hierarchyComponents.append( g )
+				g = g.parent()
+				n += 1
+
+			hierarchyComponents.reverse()
+
+			names.add( self.__formatter( hierarchyComponents ) )
+
+		if len( names ) == 1 :
+			label = next( iter( names ) )
+		elif names :
+			label = "---"
+		else:
+			label = ""
+
+		GafferUI.Label.setText( self, label )
 
 	def __buttonPress( self, widget, event ) :
 
-		return self.getGraphComponent() is not None and event.buttons & ( event.Buttons.Left | event.Buttons.Middle )
+		return bool( self.getGraphComponents() ) and event.buttons & ( event.Buttons.Left | event.Buttons.Middle )
 
 	def __dragBegin( self, widget, event ) :
 
 		if event.buttons & ( event.Buttons.Left | event.Buttons.Middle ) :
 			GafferUI.Pointer.setCurrent( "nodes" )
-			return self.getGraphComponent()
+			if len( self.__graphComponents ) == 1 :
+				return next( iter( self.__graphComponents ) )
+			else :
+				return Gaffer.StandardSet( self.__graphComponents )
 
 		return None
 

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -242,6 +242,11 @@ class PlugValueWidget( GafferUI.Widget ) :
 			creators = { cls.__creator( plugs, useTypeOnly ) }
 		else :
 			creators = { cls.__creator( p, useTypeOnly ) for p in plugs }
+			# Not all PlugValueWidgets support multiple plugs, and some
+			# except in their constructors if passed a sequence type.
+			# Unwrap where possible.
+			if len( plugs ) == 1 :
+				plugs = next( iter( plugs ) )
 
 		if len( creators ) > 1 :
 			raise Exception( "Multiple widget creators" )

--- a/python/GafferUITest/NameLabelTest.py
+++ b/python/GafferUITest/NameLabelTest.py
@@ -38,6 +38,8 @@ import Gaffer
 import GafferUI
 import GafferUITest
 
+import six
+
 class NameLabelTest( GafferUITest.TestCase ) :
 
 	def test( self ) :
@@ -61,7 +63,10 @@ class NameLabelTest( GafferUITest.TestCase ) :
 		n.setName( "somethingElse" )
 		self.assertEqual( l.getText(), "SOMETHINGELSE" )
 
-	def testMultipleComponents( self ) :
+		l.setGraphComponent( None )
+		self.assertEqual( l.getText(), "" )
+
+	def testMultipleHierarchyComponents( self ) :
 
 		n1 = Gaffer.Node( "n1" )
 		n1["n2"] = Gaffer.Node()
@@ -138,6 +143,34 @@ class NameLabelTest( GafferUITest.TestCase ) :
 
 		n.setName( "B" )
 		self.assertTrue( l.getText(), "woteva" )
+
+	def testMultipleComponents( self ) :
+
+		n1 = Gaffer.Node( "n1" )
+		n2 = Gaffer.Node( "n2" )
+
+		l = GafferUI.NameLabel( { n1, n2 } )
+
+		self.assertEqual( l.getGraphComponents(), { n1, n2 } )
+		with six.assertRaisesRegex( self, RuntimeError, "getGraphComponent called with multiple GraphComponents" ) :
+			l.getGraphComponent()
+
+		self.assertTrue( l.getText(), "---" )
+
+		n1["user"]["plug"] = Gaffer.Plug()
+		n2["user"]["plug"] = Gaffer.Plug()
+
+		l.setGraphComponents( set() )
+		self.assertEqual( l.getText(), "" )
+
+		l.setGraphComponents( { n1["user"]["plug"], n2["user"]["plug"] } )
+		self.assertEqual( l.getText(), "Plug" )
+
+		l.setNumComponents( 2 )
+		self.assertTrue( l.getText(), "---" )
+
+		l.setGraphComponent( None )
+		self.assertEqual( l.getText(), "" )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
In order to facilitate multi-cell edits in the `SpreadsheetUI`, we need to extend multiple plug support in the core Gaffer widgets.

This PR hopefully increases support in several core widgets, whilst maintaining compatibility with legacy single-plug code. As this is targeting `0.58_maintenance`, it preserves the existing arg names for compatibility.