### PR TITLE
Qt : Use legacy xcb tablet coordinates

### DIFF
--- a/bin/gaffer
+++ b/bin/gaffer
@@ -56,8 +56,6 @@ fi
 
 export LC_NUMERIC=C
 
-##########################################################################
-
 # Find where this script is located, resolving any symlinks that were used
 # to invoke it. Set GAFFER_ROOT based on the script location.
 ##########################################################################
@@ -191,6 +189,9 @@ else
 	prependToPath /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ImageIO.framework/Resources/ DYLD_LIBRARY_PATH
 fi
 
+# Set up Qt
+##########################################################################
+
 if [[ -e $GAFFER_ROOT/qt/plugins ]] ; then
 	export QT_QPA_PLATFORM_PLUGIN_PATH="$GAFFER_ROOT/qt/plugins"
 fi
@@ -199,8 +200,6 @@ fi
 #   See https://bugreports.qt.io/browse/QTBUG-77826
 # This can hopefully be removed once this patch is in:
 #   https://codereview.qt-project.org/c/qt/qtbase/+/284141
-##########################################################################
-
 export QT_XCB_TABLET_LEGACY_COORDINATES=1
 
 # Get the executable path set up, for running child processes from Gaffer

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -56,6 +56,8 @@ fi
 
 export LC_NUMERIC=C
 
+##########################################################################
+
 # Find where this script is located, resolving any symlinks that were used
 # to invoke it. Set GAFFER_ROOT based on the script location.
 ##########################################################################
@@ -192,6 +194,14 @@ fi
 if [[ -e $GAFFER_ROOT/qt/plugins ]] ; then
 	export QT_QPA_PLATFORM_PLUGIN_PATH="$GAFFER_ROOT/qt/plugins"
 fi
+
+# Work around issue with Qt 5.12+ when using a wacom tablet on linux.
+#   See https://bugreports.qt.io/browse/QTBUG-77826
+# This can hopefully be removed once this patch is in:
+#   https://codereview.qt-project.org/c/qt/qtbase/+/284141
+##########################################################################
+
+export QT_XCB_TABLET_LEGACY_COORDINATES=1
 
 # Get the executable path set up, for running child processes from Gaffer
 ##########################################################################

--- a/python/GafferUI/EventLoop.py
+++ b/python/GafferUI/EventLoop.py
@@ -160,6 +160,9 @@ class EventLoop( object ) :
 		style = QtWidgets.QApplication.setStyle( "Fusion" )
 		assert( style is not None )
 		__qtApplication = QtWidgets.QApplication( [ "gaffer" ] )
+		# Fixes laggy interaction with tablets, equivalent to the old
+		# QT_COMPRESS_TABLET_EVENTS env var supported in Maya Qt builds.
+		__qtApplication.setAttribute( QtCore.Qt.AA_CompressTabletEvents, True )
 
 	__mainEventLoop = None
 	## Returns the main event loop for the application. This should always


### PR DESCRIPTION
Fixes broken tablet interaction with dependencies 2.0.0