### PR TITLE
RendererAlgo : Sample non-interpolable objects at integer frames

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - NodeMenu : Removed Loop node. This node can have severe consequences for performance if used inappropriately. Depending on the use case, the Collect nodes and others often provide a more performant alternative. The Loop node can still be created via the scripting API, but we recommend you consider the alternatives and/or request advice before using it.
 
+Fixes
+-----
+
+- Encapsulate : Fixed incorrect motion blur when deformation blur is turned on for the Capsule itself (#3557).
+
 API
 ---
 
@@ -22,7 +27,9 @@ API
 Breaking Changes
 ----------------
 
-- RendererAlgo : Changed type used to represent sample times from `std::set<float>` to `std::vector<float>`, to align with the `IECoreScenePreview::Renderer` API.
+- RendererAlgo :
+  - Objects which don't support deformation blur are now always sampled at the integer frame time. Previously they were sampled at shutter open time if deformation blur was turned on.
+  - Changed type used to represent sample times from `std::set<float>` to `std::vector<float>`, to align with the `IECoreScenePreview::Renderer` API.
 
 0.59.0.0b1
 ==========

--- a/Changes.md
+++ b/Changes.md
@@ -14,7 +14,9 @@ API
   - Added new `GAFFER_NODE_DECLARE_TYPE` and `GAFFER_NODE_DEFINE_TYPE` macros. Subclasses should use these in preference to `GAFFER_GRAPHCOMPONENT_DECLARE_TYPE` and `GAFFER_GRAPHCOMPONENT_DEFINE_TYPE`.
   - Deprecated all namespace-level iterator typedefs for Node and its subclasses. Use the class-level typedefs instead.
 - Plug : Deprecated all namespace-level iterator typedefs for Plug and its subclasses. Use the class-level typedefs instead.
-- RendererAlgo : Moved RendererAlgo bindings into a `GafferScene.RendererAlgo` submodule. The old names are provided for temporary backwards compatibility but are considered deprecated and will be removed in the future.
+- RendererAlgo :
+  - Moved RendererAlgo bindings into a `GafferScene.RendererAlgo` submodule. The old names are provided for temporary backwards compatibility but are considered deprecated and will be removed in the future.
+  - Added Python binding for `objectSamples()` function.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,11 @@ API
   - Deprecated all namespace-level iterator typedefs for Node and its subclasses. Use the class-level typedefs instead.
 - Plug : Deprecated all namespace-level iterator typedefs for Plug and its subclasses. Use the class-level typedefs instead.
 
+Breaking Changes
+----------------
+
+- RendererAlgo : Changed type used to represent sample times from `std::set<float>` to `std::vector<float>`, to align with the `IECoreScenePreview::Renderer` API.
+
 0.59.0.0b1
 ==========
 

--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ API
   - Added new `GAFFER_NODE_DECLARE_TYPE` and `GAFFER_NODE_DEFINE_TYPE` macros. Subclasses should use these in preference to `GAFFER_GRAPHCOMPONENT_DECLARE_TYPE` and `GAFFER_GRAPHCOMPONENT_DEFINE_TYPE`.
   - Deprecated all namespace-level iterator typedefs for Node and its subclasses. Use the class-level typedefs instead.
 - Plug : Deprecated all namespace-level iterator typedefs for Plug and its subclasses. Use the class-level typedefs instead.
+- RendererAlgo : Moved RendererAlgo bindings into a `GafferScene.RendererAlgo` submodule. The old names are provided for temporary backwards compatibility but are considered deprecated and will be removed in the future.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ API
 - RendererAlgo :
   - Moved RendererAlgo bindings into a `GafferScene.RendererAlgo` submodule. The old names are provided for temporary backwards compatibility but are considered deprecated and will be removed in the future.
   - Added Python binding for `objectSamples()` function.
+- SceneTestCase : Changed base class to ImageTestCase, to provide methods for comparing images.
 
 Breaking Changes
 ----------------

--- a/include/GafferScene/RendererAlgo.h
+++ b/include/GafferScene/RendererAlgo.h
@@ -70,12 +70,12 @@ GAFFERSCENE_API void createOutputDirectories( const IECore::CompoundObject *glob
 /// the sampling is performed evenly across the shutter interval, which should have been obtained via
 /// SceneAlgo::shutter(). If all samples turn out to be identical, they will be collapsed automatically
 /// into a single sample. The sampleTimes container is only filled if there is more than one sample.
-GAFFERSCENE_API void transformSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &shutter, std::vector<Imath::M44f> &samples, std::set<float> &sampleTimes );
+GAFFERSCENE_API void transformSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &shutter, std::vector<Imath::M44f> &samples, std::vector<float> &sampleTimes );
 
 /// Samples the object from the current location in preparation for output to the renderer. Sampling parameters
 /// are as for the transformSamples() method. Multiple samples will only be generated for Primitives, since other
 /// object types cannot be interpolated anyway.
-GAFFERSCENE_API void objectSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &shutter, std::vector<IECoreScene::ConstVisibleRenderablePtr> &samples, std::set<float> &sampleTimes );
+GAFFERSCENE_API void objectSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &shutter, std::vector<IECoreScene::ConstVisibleRenderablePtr> &samples, std::vector<float> &sampleTimes );
 
 /// Function to return a SceneProcessor used to adapt the
 /// scene for rendering.

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -1307,5 +1307,89 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 			lightFilter = arnold.AiNodeLookUpByName( "lightFilter:/lightGroup/lightFilter" )
 			self.assertEqual( arnold.AiNodeGetStr( lightFilter, "geometry_type" ), "cylinder" )
 
+	def testEncapsulateDeformationBlur( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		# Make a sphere where the red channel has the value of the current frame.
+
+		s["sphere"] = GafferScene.Sphere()
+
+		s["sphereFilter"] = GafferScene.PathFilter()
+		s["sphereFilter"]["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		s["frame"] = GafferTest.FrameNode()
+
+		s["flat"] = GafferArnold.ArnoldShader()
+		s["flat"].loadShader( "flat" )
+		s["flat"]["parameters"]["color"].setValue( imath.Color3f( 0 ) )
+		s["flat"]["parameters"]["color"]["r"].setInput( s["frame"]["output"] )
+
+		s["assignment"] = GafferScene.ShaderAssignment()
+		s["assignment"]["in"].setInput( s["sphere"]["out"] )
+		s["assignment"]["shader"].setInput( s["flat"]["out"] )
+		s["assignment"]["filter"].setInput( s["sphereFilter"]["out"] )
+
+		# Put the sphere in a capsule.
+
+		s["group"] = GafferScene.Group()
+		s["group"]["in"][0].setInput( s["assignment"]["out"] )
+
+		s["groupFilter"] = GafferScene.PathFilter()
+		s["groupFilter"]["paths"].setValue( IECore.StringVectorData( [ "/group" ] ) )
+
+		s["encapsulate"] = GafferScene.Encapsulate()
+		s["encapsulate"]["in"].setInput( s["group"]["out"] )
+		s["encapsulate"]["filter"].setInput( s["groupFilter"]["out"] )
+
+		# Do a render at frame 1, with deformation blur off.
+
+		s["outputs"] = GafferScene.Outputs()
+		s["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				os.path.join( self.temporaryDirectory(), "deformationBlurOff.exr" ),
+				"exr",
+				"rgba",
+				{
+				}
+			)
+		)
+		s["outputs"]["in"].setInput( s["encapsulate"]["out"] )
+
+		s["options"] = GafferScene.StandardOptions()
+		s["options"]["in"].setInput( s["outputs"]["out"] )
+
+		s["arnoldOptions"] = GafferArnold.ArnoldOptions()
+		s["arnoldOptions"]["in"].setInput( s["options"]["out"] )
+		s["arnoldOptions"]["options"]["aaSamples"]["enabled"].setValue( True )
+		s["arnoldOptions"]["options"]["aaSamples"]["value"].setValue( 6 )
+
+		s["render"] = GafferArnold.ArnoldRender()
+		s["render"]["in"].setInput( s["arnoldOptions"]["out"] )
+		s["render"]["task"].execute()
+
+		# Do another render at frame 1, but with deformation blur on.
+
+		s["options"]["options"]["deformationBlur"]["enabled"].setValue( True )
+		s["options"]["options"]["deformationBlur"]["value"].setValue( True )
+		s["options"]["options"]["shutter"]["enabled"].setValue( True )
+		s["options"]["options"]["shutter"]["value"].setValue( imath.V2f( -0.5, 0.5 ) )
+		s["outputs"]["outputs"][0]["fileName"].setValue( os.path.join( self.temporaryDirectory(), "deformationBlurOn.exr" ) )
+		s["render"]["task"].execute()
+
+		# Check that the renders are the same.
+
+		s["deformationOff"] = GafferImage.ImageReader()
+		s["deformationOff"]["fileName"].setValue( os.path.join( self.temporaryDirectory(), "deformationBlurOff.exr" ) )
+
+		s["deformationOn"] = GafferImage.ImageReader()
+		s["deformationOn"]["fileName"].setValue( os.path.join( self.temporaryDirectory(), "deformationBlurOn.exr" ) )
+
+		# The `maxDifference` is huge to account for noise and watermarks, but is still low enough to check what
+		# we want, since if the Encapsulate was sampled at shutter open and not the frame, the difference would be
+		# 0.5.
+		self.assertImagesEqual( s["deformationOff"]["out"], s["deformationOn"]["out"], maxDifference = 0.24, ignoreMetadata = True )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -72,7 +72,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		GafferSceneTest.SceneTestCase.tearDown( self )
 
-		GafferScene.deregisterAdaptor( "Test" )
+		GafferScene.RendererAlgo.deregisterAdaptor( "Test" )
 
 	def testExecute( self ) :
 
@@ -816,7 +816,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 			return result
 
-		GafferScene.registerAdaptor( "Test", a )
+		GafferScene.RendererAlgo.registerAdaptor( "Test", a )
 
 		sphere = GafferScene.Sphere()
 

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -1877,7 +1877,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 			return result
 
-		GafferScene.registerAdaptor( "Test", a )
+		GafferScene.RendererAlgo.registerAdaptor( "Test", a )
 
 		s["o"] = GafferScene.Outputs()
 		s["o"].addOutput(
@@ -2095,7 +2095,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		GafferSceneTest.SceneTestCase.tearDown( self )
 
-		GafferScene.deregisterAdaptor( "Test" )
+		GafferScene.RendererAlgo.deregisterAdaptor( "Test" )
 
 	## Should be used in test cases to create an InteractiveRender node
 	# suitably configured for error reporting. If failOnError is

--- a/python/GafferSceneTest/RendererAlgoTest.py
+++ b/python/GafferSceneTest/RendererAlgoTest.py
@@ -36,8 +36,12 @@
 
 import unittest
 
+import imath
+
 import IECore
 
+import Gaffer
+import GafferTest
 import GafferScene
 import GafferSceneTest
 
@@ -74,6 +78,21 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertScenesEqual( defaultAdaptors["out"], defaultAdaptors2["out"] )
 		self.assertSceneHashesEqual( defaultAdaptors["out"], defaultAdaptors2["out"] )
+
+	def testObjectSamples( self ) :
+
+		frame = GafferTest.FrameNode()
+
+		sphere = GafferScene.Sphere()
+		sphere["type"].setValue( sphere.Type.Primitive )
+		sphere["radius"].setInput( frame["output"] )
+
+		with Gaffer.Context() as c :
+			c["scene:path"] = IECore.InternedStringVectorData( [ "sphere" ] )
+			samples, sampleTimes = GafferScene.RendererAlgo.objectSamples( sphere["out"], 1, imath.V2f( 0.75, 1.25 ) )
+
+		self.assertEqual( [ s.radius() for s in samples ], [ 0.75, 1.25 ] )
+		self.assertEqual( sampleTimes, [ 0.75, 1.25 ] )
 
 	def tearDown( self ) :
 

--- a/python/GafferSceneTest/RendererAlgoTest.py
+++ b/python/GafferSceneTest/RendererAlgoTest.py
@@ -94,6 +94,22 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( [ s.radius() for s in samples ], [ 0.75, 1.25 ] )
 		self.assertEqual( sampleTimes, [ 0.75, 1.25 ] )
 
+	def testNonInterpolableObjectSamples( self ) :
+
+		frame = GafferTest.FrameNode()
+
+		procedural = GafferScene.ExternalProcedural()
+		procedural["parameters"]["frame"] = Gaffer.NameValuePlug( "frame", 0.0 )
+		procedural["parameters"]["frame"]["value"].setInput( frame["output"] )
+
+		with Gaffer.Context() as c :
+			c["scene:path"] = IECore.InternedStringVectorData( [ "procedural" ] )
+			samples, sampleTimes = GafferScene.RendererAlgo.objectSamples( procedural["out"], 1, imath.V2f( 0.75, 1.25 ) )
+
+		self.assertEqual( len( samples ), 1 )
+		self.assertEqual( samples[0].parameters()["frame"].value, 1.0 )
+		self.assertEqual( sampleTimes, [] )
+
 	def tearDown( self ) :
 
 		GafferSceneTest.SceneTestCase.tearDown( self )

--- a/python/GafferSceneTest/SceneTestCase.py
+++ b/python/GafferSceneTest/SceneTestCase.py
@@ -44,15 +44,15 @@ import IECore
 import IECoreScene
 
 import Gaffer
-import GafferTest
+import GafferImageTest
 import GafferScene
 import GafferSceneTest
 
-class SceneTestCase( GafferTest.TestCase ) :
+class SceneTestCase( GafferImageTest.ImageTestCase ) :
 
 	def setUp( self ) :
 
-		GafferTest.TestCase.setUp( self )
+		GafferImageTest.ImageTestCase.setUp( self )
 
 		sanitiser = GafferSceneTest.ContextSanitiser()
 		sanitiser.__enter__()

--- a/src/GafferSceneModule/RendererAlgoBinding.cpp
+++ b/src/GafferSceneModule/RendererAlgoBinding.cpp
@@ -42,12 +42,44 @@
 #include "GafferScene/SceneProcessor.h"
 
 #include "IECorePython/ScopedGILLock.h"
+#include "IECorePython/ScopedGILRelease.h"
 
 using namespace boost::python;
 using namespace GafferScene;
 
 namespace
 {
+
+tuple objectSamplesWrapper( const ScenePlug &scene, size_t segments, const Imath::V2f &shutter, bool copy )
+{
+	std::vector<IECoreScene::ConstVisibleRenderablePtr> samples;
+	std::vector<float> sampleTimes;
+	{
+		IECorePython::ScopedGILRelease gilRelease;
+		RendererAlgo::objectSamples( &scene, segments, shutter, samples, sampleTimes );
+	}
+
+	list pythonSamples;
+	for( auto &s : samples )
+	{
+		if( copy )
+		{
+			pythonSamples.append( s->copy() );
+		}
+		else
+		{
+			pythonSamples.append( boost::const_pointer_cast<IECoreScene::VisibleRenderable>( s ) );
+		}
+	}
+
+	list pythonSampleTimes;
+	for( auto &s : sampleTimes )
+	{
+		pythonSampleTimes.append( s );
+	}
+
+	return make_tuple( pythonSamples, pythonSampleTimes );
+}
 
 struct AdaptorWrapper
 {
@@ -86,6 +118,8 @@ void bindRendererAlgo()
 	object module( borrowed( PyImport_AddModule( "GafferScene.RendererAlgo" ) ) );
 	scope().attr( "RendererAlgo" ) = module;
 	scope moduleScope( module );
+
+	def( "objectSamples", &objectSamplesWrapper, ( arg( "scene" ), arg( "segments" ), arg( "shutter" ), arg( "_copy" ) = true ) );
 
 	def( "registerAdaptor", &registerAdaptorWrapper );
 	def( "deregisterAdaptor", &RendererAlgo::deregisterAdaptor );

--- a/src/GafferSceneModule/RendererAlgoBinding.cpp
+++ b/src/GafferSceneModule/RendererAlgoBinding.cpp
@@ -83,6 +83,10 @@ namespace GafferSceneModule
 void bindRendererAlgo()
 {
 
+	object module( borrowed( PyImport_AddModule( "GafferScene.RendererAlgo" ) ) );
+	scope().attr( "RendererAlgo" ) = module;
+	scope moduleScope( module );
+
 	def( "registerAdaptor", &registerAdaptorWrapper );
 	def( "deregisterAdaptor", &RendererAlgo::deregisterAdaptor );
 	def( "createAdaptors", &RendererAlgo::createAdaptors );

--- a/startup/GafferScene/rendererAlgoCompatibility.py
+++ b/startup/GafferScene/rendererAlgoCompatibility.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,51 +34,8 @@
 #
 ##########################################################################
 
-import unittest
-
-import IECore
-
 import GafferScene
-import GafferSceneTest
 
-class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
-
-	def test( self ) :
-
-		sphere = GafferScene.Sphere()
-
-		defaultAdaptors = GafferScene.RendererAlgo.createAdaptors()
-		defaultAdaptors["in"].setInput( sphere["out"] )
-
-		def a() :
-
-			r = GafferScene.StandardAttributes()
-			r["attributes"]["doubleSided"]["enabled"].setValue( True )
-			r["attributes"]["doubleSided"]["value"].setValue( False )
-
-			return r
-
-		GafferScene.RendererAlgo.registerAdaptor( "Test", a )
-
-		testAdaptors = GafferScene.RendererAlgo.createAdaptors()
-		testAdaptors["in"].setInput( sphere["out"] )
-
-		self.assertFalse( "doubleSided" in sphere["out"].attributes( "/sphere" ) )
-		self.assertTrue( "doubleSided" in testAdaptors["out"].attributes( "/sphere" ) )
-		self.assertEqual( testAdaptors["out"].attributes( "/sphere" )["doubleSided"].value, False )
-
-		GafferScene.RendererAlgo.deregisterAdaptor( "Test" )
-
-		defaultAdaptors2 = GafferScene.RendererAlgo.createAdaptors()
-		defaultAdaptors2["in"].setInput( sphere["out"] )
-
-		self.assertScenesEqual( defaultAdaptors["out"], defaultAdaptors2["out"] )
-		self.assertSceneHashesEqual( defaultAdaptors["out"], defaultAdaptors2["out"] )
-
-	def tearDown( self ) :
-
-		GafferSceneTest.SceneTestCase.tearDown( self )
-		GafferScene.RendererAlgo.deregisterAdaptor( "Test" )
-
-if __name__ == "__main__":
-	unittest.main()
+# Backwards compatibility for old bindings which were not namespaced correctly.
+for n in ( "registerAdaptor", "deregisterAdaptor", "createAdaptors" ) :
+	setattr( GafferScene, n, getattr( GafferScene.RendererAlgo, n ) )


### PR DESCRIPTION
This fixes motion-blur errors with the Encapsulate node when deformation blur is on (see #3557). I've also tidied up a few aspects of RendererAlgo and added a binding for `objectSamples()` to enable better testing.