### PR TITLE
__gaffer.py : Remove shebang

### DIFF
--- a/bin/__gaffer.py
+++ b/bin/__gaffer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2.6
 ##########################################################################
 #
 #  Copyright (c) 2011, John Haddon. All rights reserved.


### PR DESCRIPTION
We don't need it because `bin/gaffer` explicitly runs `python __gaffer.py`, and Python 2.6 has long since gone.
