### PR TITLE
Editor : Don't steal focus if it is already with a child

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 - NumericPlugValueWidget : Fixed bug that caused plug values to be set to 0 if editing completed with invalid text.
 - StringPlugValueWidget : Fixed bug that could cause plug values to be overwritten when editing multiple plugs and focus was lost without change, or the value state changed to mixed via external action.
 - TypedObjectPlug : Fixed serialisation of values for which `repr()` is not available (#106).
+- Editor : Fixed bug that caused child widgets to lose focus when the mouse re-enters an Editor that already has focus.
 
 API
 ---

--- a/python/GafferUI/Editor.py
+++ b/python/GafferUI/Editor.py
@@ -206,8 +206,23 @@ class Editor( six.with_metaclass( _EditorMetaclass, GafferUI.Widget ) ) :
 
 	def __enter( self, widget ) :
 
-		if not isinstance( QtWidgets.QApplication.focusWidget(), ( QtWidgets.QLineEdit, QtWidgets.QPlainTextEdit ) ) :
-			self._qtWidget().setFocus()
+		currentFocusWidget = QtWidgets.QApplication.focusWidget()
+
+		# Don't disrupt in-progress text edits
+		if isinstance( currentFocusWidget, ( QtWidgets.QLineEdit, QtWidgets.QPlainTextEdit ) ) :
+			return
+
+		try :
+			gafferWidget = GafferUI.Widget._owner( currentFocusWidget )
+		except :
+			gafferWidget = None
+
+		# Don't adjust focus if it is already with one of our children. This can happen,
+		# for example, when a popup window launched by a child widget is dismissed.
+		if gafferWidget is not None and ( gafferWidget is self or self.isAncestorOf( gafferWidget ) ) :
+			return
+
+		self._qtWidget().setFocus()
 
 	def __leave( self, widget ) :
 


### PR DESCRIPTION
Fixes keyboard navigation in the upcoming Spreadsheet multi-select work.