### PR TITLE
SpreadsheetUI : Refactor data model

### DIFF
--- a/python/GafferUI/SpreadsheetUI/_PlugTableModel.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableModel.py
@@ -45,18 +45,19 @@ from Qt import QtCore
 
 from . import _Formatting
 
+## The underlying model that provides data for the various TableViews used
+# in the SpreadsheetUI. It can be remapped into the specific
+# RowNames/Defaults/Cells views via one of the available proxy models.
 class _PlugTableModel( QtCore.QAbstractTableModel ) :
 
-	Mode = IECore.Enum.create( "RowNames", "Defaults", "Cells" )
 	CellPlugEnabledRole = QtCore.Qt.UserRole
 
-	def __init__( self, rowsPlug, context, mode, parent = None ) :
+	def __init__( self, rowsPlug, context, parent = None ) :
 
 		QtCore.QAbstractTableModel.__init__( self, parent )
 
 		self.__rowsPlug = rowsPlug
 		self.__context = context
-		self.__mode = mode
 
 		self.__plugDirtiedConnection = rowsPlug.node().plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ) )
 		self.__rowAddedConnection = rowsPlug.childAddedSignal().connect( Gaffer.WeakMethod( self.__rowAdded ) )
@@ -69,10 +70,6 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 	# Methods of our own
 	# ------------------
 
-	def mode( self ) :
-
-		return self.__mode
-
 	def rowsPlug( self ) :
 
 		return self.__rowsPlug
@@ -82,15 +79,15 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 		if not index.isValid() :
 			return None
 
-		if self.__mode in ( self.Mode.Cells, self.Mode.RowNames ) :
-			row = self.__rowsPlug[index.row()+1]
-		else :
-			row = self.__rowsPlug[0]
+		row = self.__rowsPlug[ index.row() ]
 
-		if self.__mode == self.Mode.RowNames :
-			return row[index.column()]
+		# Columns map across the logical view
+		# name, enabled, cells[ index - 2 ]
+
+		if index.column() < 2 :
+			return row[ index.column() ]
 		else :
-			return row["cells"][index.column()]
+			return row["cells"][ index.column() - 2 ]
 
 	def valuePlugForIndex( self, index ) :
 
@@ -103,31 +100,23 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 	def indexForPlug( self, plug ) :
 
 		rowPlug = plug.ancestor( Gaffer.Spreadsheet.RowPlug )
+
 		if rowPlug is None :
 			return QtCore.QModelIndex()
 
-		if self.__mode in ( self.Mode.Cells, self.Mode.RowNames ) :
-			rowIndex = rowPlug.parent().children().index( rowPlug )
-			if rowIndex == 0 :
-				return QtCore.QModelIndex()
-			else :
-				rowIndex -= 1
-		else :
-			rowIndex = 0
+		rowIndex = rowPlug.parent().children().index( rowPlug )
 
-		if self.__mode == self.Mode.RowNames :
-			if plug == rowPlug["name"] :
-				columnIndex = 0
-			elif plug == rowPlug["enabled"] :
-				columnIndex = 1
-			else :
-				return QtCore.QModelIndex()
+		columnIndex = None
+		if plug == rowPlug["name"] :
+			columnIndex = 0
+		elif plug == rowPlug["enabled"] :
+			columnIndex = 1
 		else :
 			cellPlug = plug if isinstance( plug, Gaffer.Spreadsheet.CellPlug ) else plug.ancestor( Gaffer.Spreadsheet.CellPlug )
-			if cellPlug is not None :
-				columnIndex = rowPlug["cells"].children().index( cellPlug )
-			else :
-				return QtCore.QModelIndex()
+			columnIndex = rowPlug["cells"].children().index( cellPlug ) + 2 if cellPlug is not None else None
+
+		if columnIndex is None :
+			return QtCore.QModelIndex()
 
 		return self.index( rowIndex, columnIndex )
 
@@ -159,30 +148,33 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 		if parent.isValid() :
 			return 0
 
-		if self.__mode == self.Mode.Defaults :
-			return 1
-		else :
-			return len( self.__rowsPlug ) - 1
+		return len( self.__rowsPlug )
 
 	def columnCount( self, parent = QtCore.QModelIndex() ) :
 
 		if parent.isValid() :
 			return 0
 
-		if self.__mode == self.Mode.RowNames :
-			return 2
-		else :
-			return len( self.__rowsPlug[0]["cells"] )
+		return len( self.__rowsPlug[0]["cells"] ) + 2
 
 	def headerData( self, section, orientation, role ) :
 
-		if role == QtCore.Qt.DisplayRole :
-			if orientation == QtCore.Qt.Horizontal and self.__mode != self.Mode.RowNames :
-				cellPlug = self.__rowsPlug.defaultRow()["cells"][section]
+		if role != QtCore.Qt.DisplayRole :
+			return
+
+		if orientation == QtCore.Qt.Horizontal :
+
+			if section < 2 :
+				label = ( "Name", "Enabled" )[ section ]
+			else :
+				cellPlug = self.__rowsPlug.defaultRow()["cells"][ section - 2 ]
 				label = Gaffer.Metadata.value( cellPlug, "spreadsheet:columnLabel" )
 				if not label :
 					label = IECore.CamelCase.toSpaced( cellPlug.getName() )
-				return label
+			return label
+
+		else :
+
 			return section
 
 	def flags( self, index ) :

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -60,13 +60,13 @@ class _PlugTableView( GafferUI.Widget ) :
 
 	Mode = IECore.Enum.create( "RowNames", "Defaults", "Cells" )
 
-	def __init__( self, plug, context, mode, **kw ) :
+	def __init__( self, model, mode, **kw ) :
 
 		tableView = _TableView()
 		GafferUI.Widget.__init__( self, tableView, **kw )
 
 		self.__mode = mode;
-		tableView.setModel( self.__displayModel( plug, context, mode ) )
+		tableView.setModel( self.__displayModel( model ) )
 
 		# Headers and column sizing
 
@@ -176,16 +176,15 @@ class _PlugTableView( GafferUI.Widget ) :
 
 		return self.__visibleSection
 
-	def __displayModel( self, rowsPlug, context, mode ) :
+	def __displayModel( self, model ) :
 
-		if mode == self.Mode.RowNames :
+		if self.__mode == self.Mode.RowNames :
 			proxy = _ProxyModels.RowNamesProxyModel( self._qtWidget() )
-		elif mode == self.Mode.Cells :
+		elif self.__mode == self.Mode.Cells :
 			proxy = _ProxyModels.CellsProxyModel( self._qtWidget() )
 		else :
 			proxy = _ProxyModels.DefaultsProxyModel( self._qtWidget() )
 
-		model = _PlugTableModel( rowsPlug, context, proxy )
 		proxy.setSourceModel( model )
 
 		return proxy

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -52,6 +52,7 @@ from . import _ProxyModels
 from ._EditWindow import _EditWindow
 from ._PlugTableDelegate import _PlugTableDelegate
 from ._PlugTableModel import _PlugTableModel
+from ._ProxySelectionModel import _ProxySelectionModel
 from ._SectionChooser import _SectionChooser
 
 from .._TableView import _TableView
@@ -60,13 +61,13 @@ class _PlugTableView( GafferUI.Widget ) :
 
 	Mode = IECore.Enum.create( "RowNames", "Defaults", "Cells" )
 
-	def __init__( self, model, mode, **kw ) :
+	def __init__( self, selectionModel, mode, **kw ) :
 
 		tableView = _TableView()
 		GafferUI.Widget.__init__( self, tableView, **kw )
 
 		self.__mode = mode;
-		tableView.setModel( self.__displayModel( model ) )
+		self.__setupModels( selectionModel )
 
 		# Headers and column sizing
 
@@ -176,18 +177,22 @@ class _PlugTableView( GafferUI.Widget ) :
 
 		return self.__visibleSection
 
-	def __displayModel( self, model ) :
+	def __setupModels( self, selectionModel ) :
+
+		tableView = self._qtWidget()
 
 		if self.__mode == self.Mode.RowNames :
-			proxy = _ProxyModels.RowNamesProxyModel( self._qtWidget() )
+			viewProxy = _ProxyModels.RowNamesProxyModel( tableView )
 		elif self.__mode == self.Mode.Cells :
-			proxy = _ProxyModels.CellsProxyModel( self._qtWidget() )
+			viewProxy = _ProxyModels.CellsProxyModel( tableView )
 		else :
-			proxy = _ProxyModels.DefaultsProxyModel( self._qtWidget() )
+			viewProxy = _ProxyModels.DefaultsProxyModel( tableView )
 
-		proxy.setSourceModel( model )
+		viewProxy.setSourceModel( selectionModel.model() )
+		tableView.setModel( viewProxy )
 
-		return proxy
+		selectionProxy = _ProxySelectionModel( viewProxy, selectionModel, tableView )
+		tableView.setSelectionModel( selectionProxy )
 
 	def __sectionMoved( self, logicalIndex, oldVisualIndex, newVisualIndex ) :
 

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -48,6 +48,7 @@ from Qt import QtWidgets
 from Qt import QtCompat
 
 from . import _Algo
+from . import _ProxyModels
 from ._EditWindow import _EditWindow
 from ._PlugTableDelegate import _PlugTableDelegate
 from ._PlugTableModel import _PlugTableModel
@@ -57,14 +58,15 @@ from .._TableView import _TableView
 
 class _PlugTableView( GafferUI.Widget ) :
 
-	Mode = _PlugTableModel.Mode
+	Mode = IECore.Enum.create( "RowNames", "Defaults", "Cells" )
 
 	def __init__( self, plug, context, mode, **kw ) :
 
 		tableView = _TableView()
 		GafferUI.Widget.__init__( self, tableView, **kw )
 
-		tableView.setModel( _PlugTableModel( plug, context, mode ) )
+		self.__mode = mode;
+		tableView.setModel( self.__displayModel( plug, context, mode ) )
 
 		# Headers and column sizing
 
@@ -174,6 +176,20 @@ class _PlugTableView( GafferUI.Widget ) :
 
 		return self.__visibleSection
 
+	def __displayModel( self, rowsPlug, context, mode ) :
+
+		if mode == self.Mode.RowNames :
+			proxy = _ProxyModels.RowNamesProxyModel( self._qtWidget() )
+		elif mode == self.Mode.Cells :
+			proxy = _ProxyModels.CellsProxyModel( self._qtWidget() )
+		else :
+			proxy = _ProxyModels.DefaultsProxyModel( self._qtWidget() )
+
+		model = _PlugTableModel( rowsPlug, context, proxy )
+		proxy.setSourceModel( model )
+
+		return proxy
+
 	def __sectionMoved( self, logicalIndex, oldVisualIndex, newVisualIndex ) :
 
 		if self.__callingMoveSection :
@@ -202,7 +218,7 @@ class _PlugTableView( GafferUI.Widget ) :
 
 	def __applyColumnWidthMetadata( self, cellPlug = None ) :
 
-		if self._qtWidget().model().mode() == self.Mode.RowNames :
+		if self.__mode == self.Mode.RowNames :
 			return
 
 		defaultCells = self._qtWidget().model().rowsPlug().defaultRow()["cells"]
@@ -230,7 +246,7 @@ class _PlugTableView( GafferUI.Widget ) :
 
 	def __applySectionOrderMetadata( self ) :
 
-		if self._qtWidget().model().mode() == self.Mode.RowNames :
+		if self.__mode == self.Mode.RowNames :
 			return
 
 		rowsPlug = self._qtWidget().model().rowsPlug()
@@ -243,7 +259,7 @@ class _PlugTableView( GafferUI.Widget ) :
 
 	def __applyColumnVisibility( self ) :
 
-		if self._qtWidget().model().mode() == self.Mode.RowNames :
+		if self.__mode == self.Mode.RowNames :
 			return
 
 		# Changing column visibility seems to cause the

--- a/python/GafferUI/SpreadsheetUI/_ProxyModels.py
+++ b/python/GafferUI/SpreadsheetUI/_ProxyModels.py
@@ -1,0 +1,183 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+from Qt import QtCore
+
+from ._PlugTableModel import _PlugTableModel
+
+class __PlugTableProxyModel( QtCore.QAbstractProxyModel ) :
+
+	def __init__( self, startRow = 0, startColumn = 0, rowCount = None, columnCount = 0, parent = None ) :
+
+		QtCore.QAbstractProxyModel.__init__( self, parent = parent )
+
+		self.__startRow = startRow
+		self.__startColumn = startColumn
+		self.__rowCount = rowCount
+		self.__columnCount = columnCount
+
+	def index( self, row, column, parent = QtCore.QModelIndex() ) :
+
+		if parent.isValid() :
+			return QtCore.QModelIndex()
+
+		return self.createIndex( row, column )
+
+	def parent( self, index ) :
+
+		return QtCore.QModelIndex()
+
+	def setSourceModel( self, model ) :
+
+		assert( isinstance( model, _PlugTableModel ) )
+
+		# _PlugTableModel only emits modelReset and dataChanged signals (for now)
+		# so we can avoid the headache of remapping the plethora of row/column signals.
+
+		oldModel = self.sourceModel()
+		if oldModel :
+			oldModel.dataChanged.disconnect( self.__dataChanged )
+			oldModel.modelReset.disconnect( self.modelReset )
+
+		if model :
+			model.dataChanged.connect( self.__dataChanged )
+			model.modelReset.connect( self.modelReset )
+
+		self.beginResetModel()
+		QtCore.QAbstractProxyModel.setSourceModel( self, model )
+		self.endResetModel()
+
+	def columnCount( self, parent = QtCore.QModelIndex() ) :
+
+		if parent.isValid() :
+			return 0
+
+		if self.__columnCount :
+			return self.__columnCount
+		else :
+			return self.sourceModel().columnCount() - self.__startColumn
+
+	def rowCount( self, parent = QtCore.QModelIndex() ) :
+
+		if parent.isValid() :
+			return 0
+
+		if self.__rowCount :
+			return self.__rowCount
+		else :
+			return self.sourceModel().rowCount() - self.__startRow
+
+	def mapFromSource( self, sourceIndex )  :
+
+		if not sourceIndex.isValid() :
+			return QtCore.QModelIndex()
+
+		row = sourceIndex.row() - self.__startRow
+		column = sourceIndex.column() - self.__startColumn
+
+		if row < 0 or row >= self.rowCount() :
+			return QtCore.QModelIndex()
+
+		if column < 0 or column >= self.columnCount() :
+			return QtCore.QModelIndex()
+
+		return self.index( row, column )
+
+	def mapToSource( self, proxyIndex ) :
+
+		if not proxyIndex.isValid():
+			return QtCore.QModelIndex()
+
+		row = proxyIndex.row() + self.__startRow
+		column = proxyIndex.column() + self.__startColumn
+		return self.sourceModel().index( row, column )
+
+	def rowsPlug( self ) :
+
+		return self.sourceModel().rowsPlug()
+
+	def plugForIndex( self, index ) :
+
+		return self.sourceModel().plugForIndex( self.mapToSource( index ) )
+
+	def valuePlugForIndex( self, index ) :
+
+		return self.sourceModel().valuePlugForIndex( self.mapToSource( index ) )
+
+	def indexForPlug( self, plug ) :
+
+		return self.mapFromSource( self.sourceModel().indexForPlug( plug ) )
+
+	def __dataChanged( self, topLeft, bottomRight, roles ) :
+
+		# Early out if the changed range doesn't intersect the remapped model
+
+		if bottomRight.row() < self.__startRow or bottomRight.column() < self.__startColumn :
+			return
+
+		if topLeft.row() - self.__startRow >= self.rowCount() \
+		   or topLeft.column() - self.__startColumn >= self.columnCount() :
+			return
+
+		# Clamp to presented range
+
+		proxyTopLeft = self.mapFromSource( topLeft )
+		if not proxyTopLeft.isValid() :
+			proxyTopLeft = self.index( 0, 0 )
+
+		proxyBottomRight = self.mapFromSource( bottomRight )
+		if not proxyBottomRight.isValid() :
+			proxyBottomRight = self.index( self.rowCount() - 1, self.columnCount() - 1 )
+
+		self.dataChanged.emit( proxyTopLeft, proxyBottomRight, roles )
+
+class RowNamesProxyModel( __PlugTableProxyModel ) :
+
+	def __init__( self, parent = None ) :
+
+		super( RowNamesProxyModel, self ).__init__( startRow = 1, columnCount = 2, parent = parent )
+
+class DefaultsProxyModel( __PlugTableProxyModel ) :
+
+	def __init__( self, parent = None ) :
+
+		super( DefaultsProxyModel, self ).__init__( startColumn = 2, rowCount = 1, parent = parent )
+
+class CellsProxyModel( __PlugTableProxyModel ) :
+
+	def __init__( self, parent = None ) :
+
+		super( CellsProxyModel, self ).__init__( startRow = 1, startColumn = 2, parent = parent )

--- a/python/GafferUI/SpreadsheetUI/_ProxySelectionModel.py
+++ b/python/GafferUI/SpreadsheetUI/_ProxySelectionModel.py
@@ -1,0 +1,159 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+from Qt import QtCore
+
+class _ProxySelectionModel( QtCore.QItemSelectionModel ) :
+
+	def __init__( self, viewModel, sourceSelectionModel, parent = None ) :
+
+		QtCore.QItemSelectionModel.__init__( self, viewModel, parent )
+
+		self.__sourceSelectionModel = sourceSelectionModel
+		self.__initModelChain()
+
+		self.__sourceSelectionModel.selectionChanged.connect( self.__sourceSelectionChanged )
+		self.__sourceSelectionModel.currentChanged.connect( self.__sourceCurrentChanged )
+		self.__sourceSelectionModel.modelChanged.connect( self.__modelChanged )
+
+		self.__settingSelection = False
+		self.currentChanged.connect( self.__currentChanged )
+		self.modelChanged.connect( self.__modelChanged )
+
+	def select( self, selection, flags ) :
+
+		assert( isinstance( selection, ( QtCore.QItemSelection, QtCore.QModelIndex ) ) )
+
+		if isinstance( selection, QtCore.QModelIndex ) :
+			# The overload of this just wraps the selection and calls back here
+			# which results in double evaluation
+			selection = QtCore.QItemSelection( selection, selection )
+
+		QtCore.QItemSelectionModel.select( self, selection, flags )
+
+		# Forward to source model
+		self.__settingSelection = True
+		try :
+			sourceSelection = self.mapSelectionToSource( selection )
+			self.__sourceSelectionModel.select( sourceSelection, flags )
+		finally :
+			self.__settingSelection = False
+
+	def mapToSource( self, index ) :
+
+		assert( self.__modelChain )
+
+		for model in self.__modelChain :
+			index = model.mapToSource( index )
+
+		if index.isValid() :
+			assert( index.model() is self.__sourceSelectionModel.model() )
+
+		return index
+
+	def mapFromSource( self, index ) :
+
+		assert( self.__modelChain )
+
+		for model in reversed( self.__modelChain ) :
+			index = model.mapFromSource( index )
+
+		if index.isValid() :
+			assert( index.model() is self.model() )
+
+		return index
+
+	def mapSelectionToSource( self, itemSelection ) :
+
+		assert( self.__modelChain )
+
+		for model in self.__modelChain :
+			itemSelection = model.mapSelectionToSource( itemSelection )
+
+		return itemSelection
+
+	def mapSelectionFromSource( self, itemSelection ) :
+
+		assert( self.__modelChain )
+
+		for model in reversed( self.__modelChain ) :
+			itemSelection = model.mapSelectionFromSource( itemSelection )
+
+		return itemSelection
+
+	def __modelChanged( self ) :
+
+		self.__initModelChain()
+
+	def __initModelChain( self ) :
+
+		# Build a chain of models from this views model to the target
+
+		assert( self.model() )
+		assert( self.__sourceSelectionModel )
+
+		model = self.model()
+		targetModel = self.__sourceSelectionModel.model()
+
+		models = []
+		while model != targetModel :
+			assert( hasattr( model, 'sourceModel' ) )
+			models.append( model )
+			model = model.sourceModel()
+
+		self.__modelChain = models
+
+	def __currentChanged( self, index ) :
+
+		sourceIndex = self.mapToSource( index )
+		self.__sourceSelectionModel.setCurrentIndex( sourceIndex, QtCore.QItemSelectionModel.NoUpdate )
+
+	def __sourceSelectionChanged( self, selected, deselected ) :
+
+		viewSelected = self.mapSelectionFromSource( selected )
+		viewDeselected = self.mapSelectionFromSource( deselected )
+
+		QtCore.QItemSelectionModel.select( self, viewDeselected, QtCore.QItemSelectionModel.Deselect )
+		QtCore.QItemSelectionModel.select( self, viewSelected, QtCore.QItemSelectionModel.Select )
+
+	def __sourceCurrentChanged( self, current, previous ) :
+
+		if self.__settingSelection :
+			return
+
+		viewCurrent = self.mapFromSource( current )
+		if viewCurrent.isValid() :
+			self.setCurrentIndex( viewCurrent, QtCore.QItemSelectionModel.NoUpdate )

--- a/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
+++ b/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
@@ -43,6 +43,7 @@ import IECore
 import Gaffer
 import GafferUI
 
+from Qt import QtCore
 from Qt import QtWidgets
 
 from . import _Algo
@@ -65,6 +66,7 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 		GafferUI.PlugValueWidget.__init__( self, self.__grid, plug )
 
 		model = _PlugTableModel( plug, self.getContext(), self._qtWidget() )
+		selectionModel = QtCore.QItemSelectionModel( model, self._qtWidget() )
 
 		with self.__grid :
 
@@ -88,14 +90,14 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 				GafferUI.Spacer( imath.V2i( 1, 8 ) )
 
 			self.__defaultTable = _PlugTableView(
-				model, _PlugTableView.Mode.Defaults,
+				selectionModel, _PlugTableView.Mode.Defaults,
 				parenting = {
 					"index" : ( 1, 1 ),
 				}
 			)
 
 			self.__rowNamesTable = _PlugTableView(
-				model, _PlugTableView.Mode.RowNames,
+				selectionModel, _PlugTableView.Mode.RowNames,
 				parenting = {
 					"index" : ( 0, 2 ),
 				}
@@ -103,7 +105,7 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__updateRowNamesWidth()
 
 			self.__cellsTable = _PlugTableView(
-				model, _PlugTableView.Mode.Cells,
+				selectionModel, _PlugTableView.Mode.Cells,
 				parenting = {
 					"index" : ( 1, 2 ),
 				}

--- a/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
+++ b/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
@@ -47,6 +47,7 @@ from Qt import QtWidgets
 
 from . import _Algo
 from ._LinkedScrollBar import _LinkedScrollBar
+from ._PlugTableModel import _PlugTableModel
 from ._PlugTableView import _PlugTableView
 from ._SectionChooser import _SectionChooser
 
@@ -62,6 +63,8 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__grid = GafferUI.GridContainer( spacing = 4 )
 
 		GafferUI.PlugValueWidget.__init__( self, self.__grid, plug )
+
+		model = _PlugTableModel( plug, self.getContext(), self._qtWidget() )
 
 		with self.__grid :
 
@@ -85,14 +88,14 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 				GafferUI.Spacer( imath.V2i( 1, 8 ) )
 
 			self.__defaultTable = _PlugTableView(
-				plug, self.getContext(), _PlugTableView.Mode.Defaults,
+				model, _PlugTableView.Mode.Defaults,
 				parenting = {
 					"index" : ( 1, 1 ),
 				}
 			)
 
 			self.__rowNamesTable = _PlugTableView(
-				plug, self.getContext(), _PlugTableView.Mode.RowNames,
+				model, _PlugTableView.Mode.RowNames,
 				parenting = {
 					"index" : ( 0, 2 ),
 				}
@@ -100,7 +103,7 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__updateRowNamesWidth()
 
 			self.__cellsTable = _PlugTableView(
-				plug, self.getContext(), _PlugTableView.Mode.Cells,
+				model, _PlugTableView.Mode.Cells,
 				parenting = {
 					"index" : ( 1, 2 ),
 				}


### PR DESCRIPTION
This PR follows on from #3992, moving to a shared data model that feeds all three Table Views via Proxy models. This includes a shared selection model, to allow the selection state between the individual views to remain in sync.

There should be no user-facing or API changes.