### PR TITLE
MenuBar : Fix tablet hover interaction

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Fixes
 -----
 
 - Encapsulate : Fixed incorrect motion blur when deformation blur is turned on for the Capsule itself (#3557).
+- MenuBar : Fixed Qt bug that prevented hover interaction with the menu bar when using a tablet.
 
 API
 ---


### PR DESCRIPTION
Qt creates synthetic mouse events for tablet interaction. [This commit](https://code.qt.io/cgit/qt/qtbase.git/commit/src/widgets/widgets?id=c5307203f5c0b0e588cc93e70764c090dd4c2ce0) intended to better support touch screens inadvertently causes tablet mouse-move events (source MouseEventSynthesizedByQt) to be ignored by the menu bar.

   

This prevents hover interaction with the menu bar. Work around this by creating a new, non-synthesized event.