### PR TITLE
Spreadsheet : Multi-selection and associated tools

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,7 +16,7 @@ Improvements
   - Enabled cell selection, editing is now achieved with a double-click.
   - Added menu items to copy/paste the enabled state and value(s) of selected cells.
   - Added menu items to delete the selected rows.
-  - Added ability to copy/paste the enabled state and value(s) of selected cells.
+  - Added menu items to edit the values for all selected cells of the same type simultaneously.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -11,7 +11,10 @@ Improvements
 
 Improvements
 ------------
-- Spreadsheet : Enabled cell selection, editing is now achieved with a double-click.
+- Spreadsheet :
+  - Enabled cell selection, editing is now achieved with a double-click.
+  - Added menu items to copy/paste the enabled state and value(s) of selected cells.
+  - Added menu items to delete the selected rows.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,10 @@ Improvements
 0.58.5.2 (relative to 0.58.5.1)
 ========
 
+Improvements
+------------
+- Spreadsheet : Enabled cell selection, editing is now achieved with a double-click.
+
 Fixes
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -14,8 +14,8 @@ Improvements
 
 - Spreadsheet :
   - Enabled cell selection, editing is now achieved with a double-click.
-  - Added menu items to copy/paste the enabled state and value(s) of selected cells.
-  - Added menu items to delete the selected rows.
+  - Added menu items to cells & defaults sections to copy/paste the enabled state and value(s) of selected cells.
+  - Added menu items to the row names section to copy/paste or delete the selected rows.
   - Added menu items to edit the values for all selected cells of the same type simultaneously.
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -11,10 +11,12 @@ Improvements
 
 Improvements
 ------------
+
 - Spreadsheet :
   - Enabled cell selection, editing is now achieved with a double-click.
   - Added menu items to copy/paste the enabled state and value(s) of selected cells.
   - Added menu items to delete the selected rows.
+  - Added ability to copy/paste the enabled state and value(s) of selected cells.
 
 Fixes
 -----

--- a/python/GafferUI/SpreadsheetUI/_Algo.py
+++ b/python/GafferUI/SpreadsheetUI/_Algo.py
@@ -111,6 +111,22 @@ def addColumn( spreadsheet, plug ) :
 # UI Helpers
 # ----------
 
+# Returns True if all the supplied cells can be disabled. This may be false if
+# the list contains cells in the default row that aren't adopting the enabled
+# plug from their value plug.
+def cellsCanBeDisabled( cellPlugs ) :
+
+	if not cellPlugs :
+		return False
+
+	defaultRow = next( iter( cellPlugs ) ).ancestor( Gaffer.Spreadsheet.RowsPlug ).defaultRow()
+	defaultRowCells = [ cell for cell in cellPlugs if cell.ancestor( Gaffer.Spreadsheet.RowPlug ).isSame( defaultRow ) ]
+	for cell in defaultRowCells :
+		if "enabled" in cell :
+			return False
+
+	return True
+
 # Note, function may present dialogues.
 ## \todo Needs UndoScope removing
 def createSpreadsheetForNode( node, activeRowNamesConnection, selectorContextVariablePlug, selectorValue, menu ) :

--- a/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
+++ b/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
@@ -1,0 +1,225 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+
+import IECore
+
+## Returns True if the supplied plugs are sufficiently consistent
+# to copy values from. Copy is possible if:
+#
+#   - There is a single row or column.
+#   - There is a contiguous selection across multiple rows/columns.
+#   - Non-contiguous selections have consistent column types per row.
+#
+# `plugMatrix` should be a row-major list of value plugs,
+# as returned by createPlugMatrixFromCells, ie: [ [ r1c1, ... ], [ r2c1, ... ] ]
+def canCopyPlugs( plugMatrix ) :
+
+	if not plugMatrix :
+		return False
+
+	if not plugMatrix[0] :
+		return False
+
+	# Check each row has the same column configuration
+	if len( plugMatrix ) > 1 :
+
+		def rowData( row ) :
+			return [ __getValueAsData( cell ) for cell in row ]
+
+		columnTemplate = rowData( plugMatrix[0] )
+		for row in plugMatrix[ 1 : ] :
+			if not __dataSchemaMatches( rowData( row ), columnTemplate )  :
+				return False
+
+	return True
+
+## Builds a 'paste-able' data for the supplied plug matrix
+def valueMatrix( plugMatrix ) :
+
+	assert( canCopyPlugs( plugMatrix ) )
+	return IECore.ObjectVector(
+		[ IECore.ObjectVector( [ __getValueAsData( column ) for column in row ] ) for row in plugMatrix ]
+	)
+
+# Returns True if the supplied object appears to be pasteable cell data
+def isValueMatrix( data ) :
+
+	if not data :
+		return False
+
+	if not isinstance( data, IECore.ObjectVector ) :
+		return False
+
+	if not all( [ isinstance( row, IECore.ObjectVector ) and row for row in data ] ) :
+		return False
+
+	templateRow = data[ 0 ]
+
+	if not all( [ isinstance( valueData, IECore.Data ) for valueData in templateRow ] ) :
+		return False
+
+	for i in range( 1, len(data) ) :
+		if not __dataSchemaMatches( data[i], templateRow ) :
+			return False
+
+	return True
+
+# Returns True if the supplied data can be pasted on to the supplied
+# spreadsheet cell plugs, in that the cell value types are compatible with the
+# corresponding valueMatrix.
+def canPasteCells( valueMatrix, plugMatrix ) :
+
+	if not isValueMatrix( valueMatrix ) :
+		return False
+
+	# Check global read-only status, early out if none can be modified
+	rowsPlug = plugMatrix[0][0].ancestor( Gaffer.Spreadsheet.RowsPlug )
+	if rowsPlug and Gaffer.MetadataAlgo.readOnly( rowsPlug ) :
+		return False
+
+	# Though we know valueMatrix is coherent, we still need to check the
+	# full target cell matrix as it may be of different dimensions
+	# and/or made from a non-contiguous selection.
+	# This allows us to support copy/paste entirely by compatible value type,
+	# rather than any semantics of the plugs themselves, which maximises the
+	# potential re-use between columns.
+	for targetRowIndex, row in enumerate( plugMatrix ) :
+		for targetColumnIndex, cell in enumerate( row ) :
+			data = __dataForPlug( targetRowIndex, targetColumnIndex, valueMatrix )
+			if not __dataSchemaMatches( data, __getValueAsData( cell ) ) :
+				return False
+
+	return True
+
+def pasteCells( valueMatrix, plugs, atTime ) :
+
+	assert( canPasteCells( valueMatrix, plugs ) )
+
+	for targetRowIndex, row in enumerate( plugs ) :
+		for targetColumnIndex, cell in enumerate( row ) :
+			__setValueFromData( cell, __dataForPlug( targetRowIndex, targetColumnIndex, valueMatrix ), atTime )
+
+## Takes an arbitrary list of spreadsheet CellPlugs (perhaps as obtained from a
+# selection, which may be in a jumbled order) and groups them, ordered by row
+# then by column to be compatible with copy/paste.
+def createPlugMatrixFromCells( cellPlugs ) :
+
+	if not cellPlugs :
+		return []
+
+	rowsPlug = next( iter( cellPlugs ) ).ancestor( Gaffer.Spreadsheet.RowsPlug )
+	assert( rowsPlug is not None )
+
+	# Build a matrix of rows/columns in ascending order. We don't actually
+	# care what the original row/column indices were, we just need them
+	# to be ascending so the matrix represents the logical order of the cells.
+
+	matrix = []
+
+	# First, group cells by row
+	rows = {}
+	for cell in cellPlugs :
+		rowPlug = cell.ancestor( Gaffer.Spreadsheet.RowPlug )
+		rows.setdefault( rowPlug, [] ).append( cell )
+
+	# Then sort the rows, and their cells
+	spreadsheetRows = rowsPlug.children()
+	for rowPlug, cells in sorted( rows.items(), key = lambda item : spreadsheetRows.index( item[0] ) ) :
+		rowCells = rowPlug["cells"].children()
+		matrix.append( sorted( cells, key = rowCells.index ) )
+
+	return matrix
+
+# Wraps the lookup indices into the available data space
+def __dataForPlug( targetRowIndex, targetColumnIndex, data ) :
+
+	return data[ targetRowIndex % len(data) ][ targetColumnIndex % len(data[0]) ]
+
+# Returns an IECore.Data that represents either the plug value, or a hierarchy
+# of CompoundData representing the values of the plug's leaves.
+def __getValueAsData( plug ) :
+
+	if hasattr( plug, 'getValue' ) :
+		return IECore.CompoundData( { "v" : plug.getValue() } )["v"]
+
+	return IECore.CompoundData( { child.getName() : __getValueAsData( child ) for child in plug } )
+
+def __setValueFromData( plug, data, atTime ) :
+
+	if Gaffer.MetadataAlgo.readOnly( plug ) :
+		return
+
+	if hasattr( plug, 'setValue' ) :
+
+		if hasattr( data, 'value' ) :
+			data = data.value
+
+		if Gaffer.Animation.isAnimated( plug ) :
+			curve = Gaffer.Animation.acquire( plug )
+			if not Gaffer.MetadataAlgo.readOnly( curve ) :
+				curve.addKey( Gaffer.Animation.Key( atTime, data, Gaffer.Animation.Type.Linear ) )
+		elif plug.settable() :
+			plug.setValue( data )
+
+	else :
+
+		for childName, childData in data.items() :
+			__setValueFromData( plug[ childName ], childData, atTime )
+
+def __dataSchemaMatches( data, otherData ) :
+
+	if type( data ) != type( otherData ) :
+		return False
+
+	if isinstance( data, ( dict, IECore.CompoundData ) ) :
+
+		if data.keys() != otherData.keys() :
+			return False
+		for a, b in zip( data.values(), otherData.values() ) :
+			if not __dataSchemaMatches( a, b ) :
+				return False
+
+	elif isinstance( data, ( list, tuple, IECore.ObjectVector ) ) :
+
+		if len( data ) != len( otherData ) :
+			return False
+		for a, b in zip( data, otherData ) :
+			if not __dataSchemaMatches( a, b ) :
+				return False
+
+	return True

--- a/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
+++ b/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
@@ -134,6 +134,30 @@ def pasteCells( valueMatrix, plugs, atTime ) :
 		for targetColumnIndex, cell in enumerate( row ) :
 			__setValueFromData( cell, __dataForPlug( targetRowIndex, targetColumnIndex, valueMatrix ), atTime )
 
+# Returns True if the supplied data can be pasted as new rows, this
+# requires the target plugs columns to have matching data types.
+def canPasteRows( data, rowsPlug ) :
+
+	if not isValueMatrix( data ) :
+		return False
+
+	# Check global read-only status, early out if none can be modified
+	if Gaffer.MetadataAlgo.readOnly( rowsPlug ) :
+		return False
+
+	defaultsData = valueMatrix( [ rowsPlug.defaultRow().children() ] )[0]
+	return __dataSchemaMatches( data[0], defaultsData )
+
+# Pastes the supplied data as new rows at the end of the supplied rows plug.
+def pasteRows( valueMatrix, rowsPlug ) :
+
+	assert( canPasteRows( valueMatrix, rowsPlug ) )
+
+	# addRows currently returns None, so this is easier
+	newRows = [ rowsPlug.addRow() for _ in valueMatrix ]
+	# We know these aren't animated as we've just made them so time is irrelevant
+	pasteCells( valueMatrix, [ row.children() for row in newRows ], 0 )
+
 ## Takes an arbitrary list of spreadsheet CellPlugs (perhaps as obtained from a
 # selection, which may be in a jumbled order) and groups them, ordered by row
 # then by column to be compatible with copy/paste.

--- a/python/GafferUI/SpreadsheetUI/_EditWindow.py
+++ b/python/GafferUI/SpreadsheetUI/_EditWindow.py
@@ -57,18 +57,13 @@ class _EditWindow( GafferUI.Window ) :
 		self.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ), scoped = False )
 
 	@classmethod
-	def popupEditor( cls, plug, plugBound ) :
+	def popupEditor( cls, plugs, plugBound ) :
 
-		plugValueWidget = GafferUI.PlugValueWidget.create( plug )
+		if not isinstance( plugs, set ) :
+			plugs = set( plugs )
+
+		plugValueWidget = GafferUI.PlugValueWidget.create( plugs )
 		cls.__currentWindow = _EditWindow( plugValueWidget )
-
-		if isinstance( plugValueWidget, _CellPlugValueWidget ) :
-			valuePlugValueWidget = plugValueWidget.childPlugValueWidget( plug["value"] )
-			if isinstance( valuePlugValueWidget, GafferUI.PresetsPlugValueWidget ) :
-				if not Gaffer.Metadata.value( valuePlugValueWidget.getPlug(), "presetsPlugValueWidget:isCustom" ) :
-					valuePlugValueWidget.menu().popup()
-					return
-
 		cls.__currentWindow.resizeToFitChild()
 		windowSize = cls.__currentWindow.bound().size()
 		cls.__currentWindow.setPosition( plugBound.center() - windowSize / 2 )
@@ -120,7 +115,7 @@ class _EditWindow( GafferUI.Window ) :
 		if widget is not None and widgetUsable( widget ) :
 			return widget
 
-		for childPlug in Gaffer.Plug.Range( plugValueWidget.getPlug() ) :
+		for childPlug in Gaffer.Plug.Range( next( iter( plugValueWidget.getPlugs() ) ) ) :
 			childWidget = plugValueWidget.childPlugValueWidget( childPlug )
 			if childWidget is not None :
 				childTextWidget = cls.__textWidget( childWidget )

--- a/python/GafferUI/SpreadsheetUI/_PlugTableDelegate.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableDelegate.py
@@ -78,3 +78,14 @@ class _PlugTableDelegate( QtWidgets.QStyledItemDelegate ) :
 			painter.fillRect( option.rect, overlayColor )
 
 		painter.restore()
+
+	__filteredEvents = ( QtCore.QEvent.MouseButtonPress, QtCore.QEvent.MouseButtonRelease )
+
+	def editorEvent( self, event, model, option, index ) :
+
+		if event.type() in self.__filteredEvents and bool( index.flags() & QtCore.Qt.ItemIsUserCheckable ) :
+			# Prevent checkable items from being editable via single click
+			return False
+		else :
+			return super( _PlugTableDelegate, self ).editorEvent( event, model, option, index )
+

--- a/python/GafferUI/SpreadsheetUI/_PlugTableDelegate.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableDelegate.py
@@ -60,7 +60,9 @@ class _PlugTableDelegate( QtWidgets.QStyledItemDelegate ) :
 		painter.save()
 
 		painter.setRenderHint( QtGui.QPainter.Antialiasing )
-		overlayColor = QtGui.QColor( 40, 40, 40, 200 )
+
+		overlayAlpha = 100 if option.state & QtWidgets.QStyle.State_Selected else 200
+		overlayColor = QtGui.QColor( 40, 40, 40, overlayAlpha )
 
 		if not cellPlugEnabled :
 

--- a/python/GafferUI/SpreadsheetUI/_PlugTableDelegate.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableDelegate.py
@@ -54,6 +54,16 @@ class _PlugTableDelegate( QtWidgets.QStyledItemDelegate ) :
 		enabled = flags & QtCore.Qt.ItemIsEnabled and flags & QtCore.Qt.ItemIsEditable
 		cellPlugEnabled = index.data( _PlugTableModel.CellPlugEnabledRole )
 
+		if option.state & QtWidgets.QStyle.State_HasFocus :
+
+			if option.state & QtWidgets.QStyle.State_Selected :
+				focusColour = QtGui.QColor( QtCore.Qt.white )
+			else :
+				focusColour = option.palette.color( QtGui.QPalette.Highlight )
+
+			focusColour.setAlpha( 30 )
+			painter.fillRect( option.rect, focusColour )
+
 		if enabled and cellPlugEnabled :
 			return
 

--- a/python/GafferUI/SpreadsheetUI/_PlugTableModel.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableModel.py
@@ -281,6 +281,10 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 
 		return True
 
+	def presentsCheckstate( self, index )  :
+
+		return self.__checkStatePlug( index ) is not None
+
 	# Methods of our own
 	# ------------------
 

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -359,6 +359,7 @@ class _PlugTableView( GafferUI.Widget ) :
 
 		index = self._qtWidget().indexAt( QtCore.QPoint( event.line.p0.x, event.line.p0.y ) )
 
+		# Disabled items won't show up in the selection model
 		if not index.flags() & QtCore.Qt.ItemIsEnabled :
 			return True
 
@@ -435,6 +436,12 @@ class _PlugTableView( GafferUI.Widget ) :
 
 			if event.key == "Return" :
 				self.__returnKeyPress()
+				return True
+
+			if event.key == "D" :
+				# See note in __prependRowMenuItems
+				if self.__mode != self.Mode.RowNames :
+					self.__toggleCellEnabledState()
 				return True
 
 		elif event.modifiers == event.Modifiers.Control :
@@ -561,6 +568,11 @@ class _PlugTableView( GafferUI.Widget ) :
 				}
 			) )
 
+		# We don't have an item for managing the enabled state of rows, because when a
+		# row is disabled (via Qt.ItemIsEnabled flag), those indices are no longer reported
+		# from the selection model. So you could use the item to turn them off, but its
+		# hard to turn them back on again.
+
 		items.extend( (
 			(
 				"/__DeleteRowDivider__", { "divider" : True }
@@ -593,7 +605,8 @@ class _PlugTableView( GafferUI.Widget ) :
 				( "/Disable Cell%s" if currentEnabledState else "/Enable Cell%s" ) % pluralSuffix,
 				{
 					"command" : functools.partial( Gaffer.WeakMethod( self.__setPlugValues ), enabledPlugs, not currentEnabledState ),
-					"active" : canChangeEnabledState
+					"active" : canChangeEnabledState,
+					"shortCut" : "D"
 				}
 			)
 		]

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -434,6 +434,10 @@ class _PlugTableView( GafferUI.Widget ) :
 
 		forRows = self.__mode == self.Mode.RowNames
 
+		if event.key == "Space" :
+			self.__spaceBarPressed()
+			return True
+
 		if event.modifiers == event.Modifiers.None_ :
 
 			if event.key == "Return" :
@@ -477,6 +481,16 @@ class _PlugTableView( GafferUI.Widget ) :
 			self.__toggleBooleans( valuePlugs )
 		else :
 			self.__editSelectedPlugs()
+
+	def __spaceBarPressed( self ) :
+
+		# Qt has the odd behaviour that space will toggle the selection of the
+		# focused cell, unless it has a checked state, and then it'll toggle
+		# that. As we support `return` to do that, then make sure space only
+		# ever toggles the selection state of the focused cell.
+		currentIndex = self._qtWidget().selectionModel().currentIndex()
+		if currentIndex.isValid() :
+			self._qtWidget().selectionModel().select( currentIndex, QtCore.QItemSelectionModel.Toggle )
 
 	def __headerButtonPress( self, header, event ) :
 

--- a/python/GafferUI/SpreadsheetUI/_ProxyModels.py
+++ b/python/GafferUI/SpreadsheetUI/_ProxyModels.py
@@ -141,6 +141,10 @@ class __PlugTableProxyModel( QtCore.QAbstractProxyModel ) :
 
 		return self.mapFromSource( self.sourceModel().indexForPlug( plug ) )
 
+	def presentsCheckstate( self, index ) :
+
+		return self.sourceModel().presentsCheckstate( self.mapToSource( index ) )
+
 	def __dataChanged( self, topLeft, bottomRight, roles ) :
 
 		# Early out if the changed range doesn't intersect the remapped model

--- a/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
+++ b/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
@@ -179,7 +179,7 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		# Select new row for editing. Have to do this on idle as otherwise it doesn't scroll
 		# right to the bottom.
-		GafferUI.EventLoop.addIdleCallback( functools.partial( self.__rowNamesTable.editPlug, row["name"] ) )
+		GafferUI.EventLoop.addIdleCallback( functools.partial( self.__rowNamesTable.editPlugs, [ row["name"] ] ) )
 
 	def __addRowButtonDragEnter( self, addButton, event ) :
 

--- a/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
+++ b/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
@@ -102,7 +102,6 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 					"index" : ( 0, 2 ),
 				}
 			)
-			self.__updateRowNamesWidth()
 
 			self.__cellsTable = _PlugTableView(
 				selectionModel, _PlugTableView.Mode.Cells,
@@ -173,24 +172,6 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.getPlug().getInput() is None and not Gaffer.MetadataAlgo.readOnly( self.getPlug() )
 		)
 
-	@staticmethod
-	def _affectsRowNameWidth( key ) :
-
-		return key == "spreadsheet:rowNameWidth"
-
-	@staticmethod
-	def _getRowNameWidth( rowsPlug ) :
-
-		assert( isinstance( rowsPlug, Gaffer.Spreadsheet.RowsPlug ) )
-		width = Gaffer.Metadata.value( rowsPlug.defaultRow(), "spreadsheet:rowNameWidth" )
-		return width if width is not None else GafferUI.PlugWidget.labelWidth()
-
-	@staticmethod
-	def _setRowNameWidth( rowsPlug, width ) :
-
-		assert( isinstance( rowsPlug, Gaffer.Spreadsheet.RowsPlug ) )
-		Gaffer.Metadata.registerValue( rowsPlug.defaultRow(), "spreadsheet:rowNameWidth", width )
-
 	def __addRowButtonClicked( self, *unused ) :
 
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
@@ -256,10 +237,6 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.__statusLabel.setText( "" )
 
-	def __updateRowNamesWidth( self ) :
-
-		self.__rowNamesTable._qtWidget().setFixedWidth( self._getRowNameWidth( self.getPlug() ) )
-
 	def __updateDefaultRowVisibility( self ) :
 
 		visible = Gaffer.Metadata.value( self.getPlug(), "spreadsheet:defaultRowVisible" )
@@ -275,10 +252,6 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__defaultTable._qtWidget().setRowHidden( 0, not visible )
 
 	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
-
-		if plug is not None and _RowsPlugValueWidget._affectsRowNameWidth( key ) :
-			if self.getPlug().isAncestorOf( plug ) :
-				self.__updateRowNamesWidth()
 
 		if plug == self.getPlug() and key == "spreadsheet:defaultRowVisible" :
 			self.__updateDefaultRowVisibility()

--- a/python/GafferUITest/SpreadsheetUITest.py
+++ b/python/GafferUITest/SpreadsheetUITest.py
@@ -1,0 +1,493 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+import GafferUITest
+
+import IECore
+
+import unittest
+
+import GafferUI.SpreadsheetUI._ClipboardAlgo as _ClipboardAlgo
+
+class SpreadsheetUITest( GafferUITest.TestCase ) :
+
+	@staticmethod
+	def __createSpreadsheet( numRows = 10 ) :
+
+		s = Gaffer.Spreadsheet()
+
+		rowsPlug = s["rows"]
+
+		# N = row number, starting at 1
+		# Rows named 'rowN'
+		# Column 0 - string - 'sN'
+		# Column 1 - int - N
+		# Column 2 - int - 10N - even rows disabled
+		# Column 3 - float - 100N
+		# Column 4 - int - 1000N
+		# Column 5 - compound plug
+		# Column 6 - Non-adopted NameValuePlug
+		# Column 7 - Adopted NameValuePlug
+
+		compoundPlug = Gaffer.ValuePlug()
+		compoundPlug["a"] = Gaffer.FloatPlug()
+		compoundPlug["b"] = Gaffer.StringPlug()
+		nameValuePlug = Gaffer.NameValuePlug( "nvp", IECore.FloatData( 0 ), True )
+
+		for i, columnPlug in enumerate( (
+			Gaffer.StringPlug(),     # 0
+			Gaffer.IntPlug(),        # 1
+			Gaffer.IntPlug(),        # 2
+			Gaffer.FloatPlug(),      # 3
+			Gaffer.IntPlug(),        # 4
+			compoundPlug,            # 5
+			nameValuePlug            # 6
+		) ) :
+			rowsPlug.addColumn( columnPlug, "column%d" % i, adoptEnabledPlug = False )
+
+		rowsPlug.addColumn( nameValuePlug, "column7", adoptEnabledPlug = True )
+
+		for i in range( 1, numRows ) :
+			rowsPlug.addRow()["name"].setValue( "row%d" % i )
+			rowsPlug[i]["cells"][0]["value"].setValue( "s%d" % ( i ) )
+			rowsPlug[i]["cells"][2]["enabled"].setValue( i % 2 )
+			for c in range( 1, 5 ) :
+				rowsPlug[i]["cells"][c]["value"].setValue( i * pow( 10, c - 1 ) )
+			rowsPlug[i]["cells"][5]["value"]["a"].setValue( i * 0.1 )
+			rowsPlug[i]["cells"][5]["value"]["b"].setValue( "string %f" % ( i * 0.1 ) )
+			rowsPlug[i]["cells"][6]["value"]["value"].setValue( i * 0.01 )
+
+		return s
+
+	# Provides a way to easily check the resulting value hierarchy under a cell plug.
+	@staticmethod
+	def __cellPlugHashes( cellPlugMatrix ) :
+
+		return [ [ c.hash() for c in row ] for row in cellPlugMatrix ]
+
+	def testCellPlugMatrix( self ) :
+
+		s = self.__createSpreadsheet()
+
+		self.assertEqual( _ClipboardAlgo.createPlugMatrixFromCells( [] ), [] )
+
+		self.assertEqual(
+			_ClipboardAlgo.createPlugMatrixFromCells( [ s["rows"][1]["cells"][2] ] ),
+			[ [ s["rows"][1]["cells"][2] ] ]
+		)
+
+		columns = [ 2, 0, 3 ]
+		rows = ( 0, 4, 2, 5 )
+
+		plugs = []
+		for r in rows :
+			for c in columns :
+				plugs.append( s["rows"][r]["cells"][c] )
+				columns.append( columns.pop( 0 ) )
+
+		expected = [ [ s["rows"][r]["cells"][c] for c in sorted(columns) ] for r in sorted(rows) ]
+
+		self.assertEqual( _ClipboardAlgo.createPlugMatrixFromCells( plugs ), expected )
+
+	def testCanCopyPlugs( self ) :
+
+		s = self.__createSpreadsheet()
+
+		self.assertFalse( _ClipboardAlgo.canCopyPlugs( [] ) )
+		self.assertFalse( _ClipboardAlgo.canCopyPlugs( [ [] ] ) )
+
+		# Single cell
+
+		self.assertTrue( _ClipboardAlgo.canCopyPlugs( [
+			[ s["rows"][1]["cells"][0] ]
+		] ) )
+
+		# Two rows (contigious)
+
+		self.assertTrue( _ClipboardAlgo.canCopyPlugs( [
+			[ s["rows"][1]["cells"][0] ],
+			[ s["rows"][2]["cells"][0] ]
+		] ) )
+
+		# Three rows (non-contiguous)
+
+		self.assertTrue( _ClipboardAlgo.canCopyPlugs( [
+			[ s["rows"][1]["cells"][0] ],
+			[ s["rows"][3]["cells"][0] ],
+			[ s["rows"][5]["cells"][0] ]
+		] ) )
+
+		# Two columns (contiguous)
+
+		self.assertTrue( _ClipboardAlgo.canCopyPlugs( [
+			[ s["rows"][1]["cells"][0], s["rows"][1]["cells"][1] ]
+		] ) )
+
+		# Three columns (non-contiguous)
+
+		self.assertTrue( _ClipboardAlgo.canCopyPlugs( [
+			[ s["rows"][1]["cells"][0], s["rows"][1]["cells"][1], s["rows"][1]["cells"][3] ]
+		] ) )
+
+		# Three rows, two columns (non-contiguous)
+
+		self.assertTrue( _ClipboardAlgo.canCopyPlugs( [
+			[ s["rows"][1]["cells"][0], s["rows"][1]["cells"][2] ],
+			[ s["rows"][3]["cells"][0], s["rows"][3]["cells"][2] ],
+			[ s["rows"][4]["cells"][0], s["rows"][4]["cells"][2] ],
+		] ) )
+
+		# Non-contiguous but compatible column types
+
+		self.assertTrue( _ClipboardAlgo.canCopyPlugs( [
+			[ s["rows"][1]["cells"][1], s["rows"][1]["cells"][4] ],
+			[ s["rows"][4]["cells"][2], s["rows"][4]["cells"][4] ],
+		] ) )
+
+		# Mixed column types
+
+		self.assertFalse( _ClipboardAlgo.canCopyPlugs( [
+			[ s["rows"][1]["cells"][0], s["rows"][1]["cells"][1] ],
+			[ s["rows"][4]["cells"][1], s["rows"][4]["cells"][2] ],
+		] ) )
+
+		# Inconsistent column counts
+
+		self.assertFalse( _ClipboardAlgo.canCopyPlugs( [
+			[ s["rows"][1]["cells"][0], s["rows"][1]["cells"][1] ],
+			[ s["rows"][4]["cells"][1] ]
+		] ) )
+
+	def testIsValueMatrix( self ) :
+
+		O = IECore.ObjectVector
+		C = IECore.CompoundData
+		B = IECore.BoolData
+		I = IECore.IntData
+		F = IECore.FloatData
+
+		for d in (
+			"cat",
+			1,
+			None,
+			[],
+			[ 1, 2, 3 ],
+			[ [ 1 ] ],
+			[ [ 1, 4 ] ],
+			# Incorrect cell data type
+			O([
+				O([ O([ I( 1 ), I( 2 ) ]) ])
+			]),
+			# Mixed row value types
+			O([
+				O([ C({ "enabled" : B( True ), "value" : I( 2 ) }) ]),
+				O([ C({ "enabled" : B( True ), "value" : F( 2 ) }) ])
+			]),
+			# Mixed row keys
+			O([
+				O([ C({ "enabled" : B( True ), "value" : I( 2 ) }) ]),
+				O([ C({ "znabled" : B( True ), "value" : I( 2 ) }) ])
+			]),
+		) :
+			self.assertFalse( _ClipboardAlgo.isValueMatrix( d ) )
+
+		for d in (
+			# one row, one column
+			O([ O([ C({ "enabled" : B( True ), "value" : I( 1 ) }) ]) ]),
+			# one row, two columns
+			O([ O([ C({ "enabled" : B( True ), "value" : I( 2 ) }), C({ "enabled" : B( True ), "value" : F( 2 ) }) ]) ]),
+			# two rows, one column
+			O([
+				O([ C({ "enabled" : B( True ), "value" : I( 3 ) }) ]),
+				O([ C({ "enabled" : B( True ), "value" : I( 3 ) }) ])
+			]),
+			# two rows, two columns
+			O([
+				O([ C({ "enabled" : B( True ), "value" : I( 4 ) }), C({ "enabled" : B( False ), "value" : F( 4 ) }) ]),
+				O([ C({ "enabled" : B( True ), "value" : I( 4 ) }), C({ "enabled" : B( True ),  "value" : F( 4 ) }) ])
+			]),
+		) :
+			self.assertTrue( _ClipboardAlgo.isValueMatrix( d ) )
+
+	def testValueMatrix( self ) :
+
+		s = self.__createSpreadsheet()
+
+		plugs = [
+			[
+				s["rows"][1]["cells"][0], s["rows"][1]["cells"][1], s["rows"][1]["cells"][2],
+				s["rows"][1]["cells"][3], s["rows"][1]["cells"][4]
+			],
+			[
+				s["rows"][2]["cells"][0], s["rows"][2]["cells"][1], s["rows"][2]["cells"][2],
+				s["rows"][2]["cells"][3], s["rows"][2]["cells"][4]
+			]
+		]
+
+		expected = IECore.ObjectVector( [
+			IECore.ObjectVector( [
+				IECore.CompoundData( { "enabled" : c["enabled"].getValue(), "value" : c["value"].getValue() } ) for c in r
+			] ) for r in plugs
+		] )
+
+		data = _ClipboardAlgo.valueMatrix( plugs )
+
+		self.assertTrue( _ClipboardAlgo.isValueMatrix( data ) )
+		self.assertEqual( data, expected )
+
+		# Test inerleaved compatible (int) columns
+
+		plugs = [ [ s["rows"][r]["cells"][ ( r % 2 ) + 1 ] ] for r in ( 1, 2 ) ]
+
+		expected = IECore.ObjectVector( [
+			IECore.ObjectVector( [
+				IECore.CompoundData( {
+					"enabled" : s["rows"][r]["cells"][ ( r % 2 ) + 1 ]["enabled"].getValue(),
+					"value" : s["rows"][r]["cells"][ ( r % 2 ) + 1 ]["value"].getValue()
+				} )
+			] ) for r in ( 1, 2 )
+		] )
+
+		self.assertEqual( _ClipboardAlgo.valueMatrix( plugs ), expected )
+
+	def testCanPasteCells( self ) :
+
+		s = self.__createSpreadsheet()
+
+		# Single Column
+
+		plugs = [ [ s["rows"][r]["cells"][1] ] for r in ( 1, 2 ) ]
+		data = _ClipboardAlgo.valueMatrix( plugs )
+
+		# Bad data
+
+		self.assertFalse( _ClipboardAlgo.canPasteCells( "I'm a duck", plugs ) )
+
+		self.assertTrue( _ClipboardAlgo.canPasteCells( data, plugs ) )
+
+		#   - fewer rows
+
+		self.assertTrue( _ClipboardAlgo.canPasteCells( data, [ [ s["rows"][4]["cells"][1] ] ] ) )
+
+		#   - row wrap with more rows
+
+		self.assertTrue( _ClipboardAlgo.canPasteCells( data, [ [ s["rows"][r]["cells"][1] ] for r in range( 1, 5 ) ] ) )
+
+		#   - different column, same type
+
+		self.assertTrue( _ClipboardAlgo.canPasteCells( data, [ [ s["rows"][r]["cells"][2] ] for r in range( 1, 5 ) ] ) )
+
+		#   - different columns, same type
+
+		self.assertTrue( _ClipboardAlgo.canPasteCells( data, [ [ s["rows"][r]["cells"][ ( r % 2 ) + 1 ] ] for r in range( 1, 5 ) ] ) )
+
+		#   - invalid column type
+
+		self.assertFalse( _ClipboardAlgo.canPasteCells( data, [ [ s["rows"][r]["cells"][0] ] for r in range( 1, 5 ) ] ) )
+
+		#   - different columns, one invalid type
+
+		self.assertFalse( _ClipboardAlgo.canPasteCells( data, [ [ s["rows"][r]["cells"][ ( r % 2 ) ] ] for r in range( 1, 5 ) ] ) )
+
+		#   - column wrap with multiple valid target columns
+
+		self.assertTrue( _ClipboardAlgo.canPasteCells( data, [ [ s["rows"][r]["cells"][c] for c in ( 1, 2, 4 ) ] for r in range( 1, 5 ) ] ) )
+
+		# Multiple Columns
+
+		plugs = [ [ s["rows"][r]["cells"][c] for c in range( 3 ) ] for r in ( 1, 2 ) ]
+		data = _ClipboardAlgo.valueMatrix( plugs )
+
+		self.assertTrue( _ClipboardAlgo.canPasteCells( data, plugs ) )
+
+		#   - fewer rows
+
+		self.assertTrue(
+			_ClipboardAlgo.canPasteCells( data, [ [ s["rows"][4]["cells"][c] for c in range( 3 ) ] ] )
+		)
+
+		#   - row wrap with more rows
+
+		self.assertTrue(
+			_ClipboardAlgo.canPasteCells( data, [ [ s["rows"][r]["cells"][c] for c in range( 3 ) ] for r in range( 1, 3 ) ] )
+		)
+
+		#  - invalid column types
+
+		self.assertFalse(
+			_ClipboardAlgo.canPasteCells( data, [ [ s["rows"][r]["cells"][c] for c in range( 3 + 1 ) ] for r in range( 1, 3 ) ] )
+		)
+
+		#  - valid column subset
+
+		self.assertTrue(
+			_ClipboardAlgo.canPasteCells( data, [ [ s["rows"][r]["cells"][0] ] for r in range( 1, 3 ) ] )
+		)
+
+		#  - column wrap with additional colunms
+
+		plugs = [ [ s["rows"][r]["cells"][c] for c in ( 1, 2 ) ] for r in ( 1, 2 ) ]
+		data = _ClipboardAlgo.valueMatrix( plugs )
+
+		self.assertTrue(
+			_ClipboardAlgo.canPasteCells( data, [ [ s["rows"][r]["cells"][c] for c in ( 1, 2, 4 ) ] for r in range( 1, 2 ) ] )
+		)
+
+	def testPasteCells( self ) :
+
+		# Single column
+
+		s = self.__createSpreadsheet()
+
+		sourceCells = [ [ s["rows"][r]["cells"][1] ] for r in range( 1, 5 ) ]
+		sourceHashes = self.__cellPlugHashes( sourceCells )
+
+		data = _ClipboardAlgo.valueMatrix( sourceCells )
+
+		#   - matching dest
+
+		destCells = [ [ s["rows"][r]["cells"][2] ] for r in range( 1, 5 ) ]
+		self.assertNotEqual( self.__cellPlugHashes( destCells ), sourceHashes )
+
+		_ClipboardAlgo.pasteCells( data, destCells, 0 )
+		self.assertEqual( self.__cellPlugHashes( destCells ), sourceHashes )
+
+		#  - column wrap
+
+		s = self.__createSpreadsheet()
+
+		destCells = [ [ s["rows"][r]["cells"][c] for c in ( 2, 4 ) ] for r in range( 1, 5 ) ]
+		expected = [ [ r[0], r[0] ] for r in sourceHashes ]
+		self.assertNotEqual( self.__cellPlugHashes( destCells ), expected )
+
+		_ClipboardAlgo.pasteCells( data, destCells, 0 )
+		self.assertEqual( self.__cellPlugHashes( destCells ), expected )
+
+		# - row wrap
+
+		s = self.__createSpreadsheet()
+
+		destCells = [ [ s["rows"][r]["cells"][2] ] for r in range( 1, 9 ) ]
+		expected = sourceHashes[:] + sourceHashes[:4]
+		self.assertNotEqual( self.__cellPlugHashes( destCells ), expected )
+
+		_ClipboardAlgo.pasteCells( data, destCells, 0 )
+		self.assertEqual( self.__cellPlugHashes( destCells ), expected )
+
+		# - interleaved paste across 2 matching column types
+
+		s = self.__createSpreadsheet()
+
+		destCells = [ [ s["rows"][r]["cells"][ ( r % 2 ) + 1 ] ] for r in range( 1, 5 ) ]
+		self.assertNotEqual( self.__cellPlugHashes( destCells ), sourceHashes )
+
+		_ClipboardAlgo.pasteCells( data, destCells, 0 )
+		self.assertEqual( self.__cellPlugHashes( destCells ), sourceHashes )
+
+		# Multi-column + row wrap
+
+		s = self.__createSpreadsheet()
+
+		sourceCells = [ [ s["rows"][r]["cells"][c] for c in range( len(s["rows"][0]["cells"]) ) ] for r in range( 1, 3 ) ]
+		sourceHashes = self.__cellPlugHashes( sourceCells )
+
+		data = _ClipboardAlgo.valueMatrix( sourceCells )
+
+		destCells = [ [ s["rows"][r]["cells"][c] for c in range( len(s["rows"][0]["cells"]) ) ] for r in range( 5, 9 ) ]
+		self.assertNotEqual( self.__cellPlugHashes( destCells ), sourceHashes )
+
+		_ClipboardAlgo.pasteCells( data, destCells, 0 )
+
+		expected = sourceHashes[:] + sourceHashes[:]
+		self.assertEqual( self.__cellPlugHashes( destCells ), expected )
+
+	def testClipboardRespectsReadOnly( self ) :
+
+		s = self.__createSpreadsheet()
+
+		Gaffer.MetadataAlgo.setReadOnly( s["rows"][2]["cells"][2]["value"], True )
+		Gaffer.MetadataAlgo.setReadOnly( s["rows"][3]["cells"][2], True )
+		Gaffer.MetadataAlgo.setReadOnly( s["rows"], True )
+		Gaffer.MetadataAlgo.setReadOnly( s, True )
+
+		sourceCells = [ [ s["rows"][r]["cells"][1] ] for r in range( 7 ) ]
+		sourceHashes = self.__cellPlugHashes( sourceCells )
+		data = _ClipboardAlgo.valueMatrix( sourceCells )
+
+		destCells = [ [ s["rows"][r]["cells"][2] ] for r in range( 7 ) ]
+		origHashes = self.__cellPlugHashes( destCells )
+
+		self.assertFalse( _ClipboardAlgo.canPasteCells( data, destCells ) )
+
+		Gaffer.MetadataAlgo.setReadOnly( s, False )
+		self.assertFalse( _ClipboardAlgo.canPasteCells( data, destCells ) )
+
+		Gaffer.MetadataAlgo.setReadOnly( s["rows"], False )
+		self.assertTrue( _ClipboardAlgo.canPasteCells( data, destCells ) )
+
+		origLockedValueHash = s["rows"][2]["cells"][2]["value"].hash()
+
+		_ClipboardAlgo.pasteCells( data, destCells, 0 )
+		updatedHashes = self.__cellPlugHashes( destCells )
+
+		for i in ( 0, 1, 4, 5, 6 ) :
+			self.assertEqual( updatedHashes[i][0], sourceHashes[i][0] )
+		self.assertEqual( s["rows"][2]["cells"][2]["enabled"].hash(), s["rows"][2]["cells"][1]["enabled"].hash() )
+		self.assertEqual( s["rows"][2]["cells"][2]["value"].hash(), origLockedValueHash )
+		self.assertEqual( updatedHashes[3][0], origHashes[3][0] )
+
+	def testPasteCellsSetsKeyframe( self ) :
+
+		s = self.__createSpreadsheet()
+		script = Gaffer.ScriptNode()
+		script["s"] = s
+
+		targetPlug = s["rows"][2]["cells"][1]["value"]
+		curve = Gaffer.Animation.acquire( targetPlug )
+		curve.addKey( Gaffer.Animation.Key( 0, 1001 ) )
+		self.assertFalse( curve.hasKey( 1002 ) )
+
+		data = _ClipboardAlgo.valueMatrix( [ [ s["rows"][5]["cells"][1]["value"] ] ] )
+		_ClipboardAlgo.pasteCells( data, [ [ targetPlug ] ], 1002 )
+
+		self.assertTrue( curve.hasKey( 1002 ) )
+		key = curve.getKey( 1002 )
+		self.assertEqual( key.getValue(), 5 )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -122,6 +122,7 @@ from .StringPlugValueWidgetTest import StringPlugValueWidgetTest
 from .BoolPlugValueWidgetTest import BoolPlugValueWidgetTest
 from .NumericWidgetTest import NumericWidgetTest
 from .PresetsPlugValueWidgetTest import PresetsPlugValueWidgetTest
+from .SpreadsheetUITest import SpreadsheetUITest
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Puts the changes made in #3992 and #3995 to use, adding the following to the Spreadsheet UI:

![image](https://user-images.githubusercontent.com/896779/97445004-aef8f380-1924-11eb-90d1-90dbcb050fd0.png)

  - Enabled cell selection, editing is now achieved with a double-click.
  - Added menu items to copy/paste the enabled state and value(s) of selected cells.
  - Added menu items to delete the selected rows.
  - Added menu items to edit the values for all selected cells of the same type simultaneously.
  - Added menu items to copy/paste selected rows. When copying across spreadsheets, their columns must match (value types at least).

The double-click behaviour of Bool plug cells (checkbox) and presets menu cells is a bit of a compromise between consistency and not making every day life too painful. Let us know how well it works in practice.

Note, the following are not addressed in this PR and will come in future work:

 - Row reordering.
 - Plug Metadata/widget fixes.
 - Table/Section layout/scrolling issues.
 - SetFilter/PathFilter context menu issues.
