### PR TITLE
Plug : Fix dirty propagation performance regression

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- Plug : Fixed performance regression in dirtiness handling vs version 0.57. This affected script saving performance and GraphEditor navigation performance in particular.
 - ArnoldShader : Moved Arnold 6.1's new `standard_surface.dielectic_priority` parameter to the Transmission section of the UI.
 
 0.58.5.0 (relative to 0.58.4.0)

--- a/src/GafferModule/ContextProcessorBinding.cpp
+++ b/src/GafferModule/ContextProcessorBinding.cpp
@@ -107,6 +107,7 @@ class SetupBasedNodeSerialiser : public NodeSerialiser
 
 		// Add a call to `setup()` to recreate the plugs.
 
+		/// \todo Avoid creating a temporary plug.
 		PlugPtr plug = inPlug->createCounterpart( g_inPlugName, Plug::In );
 		plug->setFlags( Plug::Dynamic, false );
 

--- a/src/GafferModule/DotBinding.cpp
+++ b/src/GafferModule/DotBinding.cpp
@@ -97,6 +97,7 @@ class DotSerialiser : public NodeSerialiser
 
 		// Add a call to `setup()` to recreate the plugs.
 
+		/// \todo Avoid creating a temporary plug.
 		PlugPtr plug = dot->inPlug()->createCounterpart( "in", Plug::In );
 		plug->setFlags( Plug::Dynamic, false );
 

--- a/src/GafferModule/SubGraphBinding.cpp
+++ b/src/GafferModule/SubGraphBinding.cpp
@@ -129,6 +129,7 @@ class BoxIOSerialiser : public NodeSerialiser
 
 		// Add a call to `setup()` to recreate the plugs.
 
+		/// \todo Avoid creating a temporary plug.
 		PlugPtr plug = boxIO->plug()->createCounterpart( boxIO->plug()->getName(), Plug::In );
 		plug->setFlags( Plug::Dynamic, false );
 

--- a/src/GafferModule/SwitchBinding.cpp
+++ b/src/GafferModule/SwitchBinding.cpp
@@ -100,6 +100,7 @@ class SwitchSerialiser : public NodeSerialiser
 
 		// Add a call to `setup()` to recreate the plugs.
 
+		/// \todo Avoid creating a temporary plug.
 		PlugPtr plug = sw->inPlugs()->getChild<Plug>( 0 )->createCounterpart( "in", Plug::In );
 		if( IECore::runTimeCast<const NameSwitch>( sw ) )
 		{


### PR DESCRIPTION
This could be triggered by many repeated emissions with few or no dirty plugs. Unfortunately those can be triggered during serialisation by the creation of unnecessary temporary plugs, and also by destruction of many Gadgets because `~GraphComponent` contains a DirtyPropagationScope. We should reconsider those anyway, but this fix gets us back on par or better than 0.57 performance in the new test. The regression was originally introduced in a5b6d38c2b78a9b471ebf4453d14bdd089cce10f which was first released in 0.58.0.0.
