### PR TITLE
ImageGadget Refresh Order Experiments

### DIFF
--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -101,6 +101,16 @@ inline bool channelExists( const ImagePlug *image, const std::string &channelNam
 /// Returns true if the specified channel exists in channelNames
 inline bool channelExists( const std::vector<std::string> &channelNames, const std::string &channelName );
 
+
+/// Helpers for indexing tiles with an unwrapped integer index
+/// ==============================
+///
+
+inline int numTileIndices( const Imath::Box2i &dataWindow );
+inline int tileIndexFromOrigin( const Imath::V2i &tileOrigin, const Imath::Box2i &dataWindow );
+inline Imath::V2i tileOriginFromIndex( int i, const Imath::Box2i &dataWindow );
+
+
 /// Parallel processing functions
 /// ==============================
 ///

--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -128,7 +128,8 @@ void parallelProcessTiles(
 	const ImagePlug *imagePlug,
 	TileFunctor &&functor, // Signature : void functor( const ImagePlug *imagePlug, const V2i &tileOrigin )
 	const Imath::Box2i &window = Imath::Box2i(), // Uses dataWindow if not specified.
-	TileOrder tileOrder = Unordered
+	TileOrder tileOrder = Unordered,
+	int startIndex = 0 // Offset the order in which tiles will be processed by changing the start tile
 );
 
 // Call the functor in parallel, once per tile per channel
@@ -138,7 +139,8 @@ void parallelProcessTiles(
 	const std::vector<std::string> &channelNames,
 	TileFunctor &&functor, // Signature : void functor( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
 	const Imath::Box2i &window = Imath::Box2i(), // Uses dataWindow if not specified.
-	TileOrder tileOrder = Unordered
+	TileOrder tileOrder = Unordered,
+	int startIndex = 0 // Offset the order in which tiles will be processed by changing the start tile
 );
 
 // Process all tiles in parallel using TileFunctor, passing the
@@ -149,7 +151,8 @@ void parallelGatherTiles(
 	const TileFunctor &tileFunctor, // Signature : T tileFunctor( const ImagePlug *imagePlug, const V2i &tileOrigin )
 	GatherFunctor &&gatherFunctor, // Signature : void gatherFunctor( const ImagePlug *imagePlug, const V2i &tileOrigin, T &tileFunctorResult )
 	const Imath::Box2i &window = Imath::Box2i(), // Uses dataWindow if not specified.
-	TileOrder tileOrder = Unordered
+	TileOrder tileOrder = Unordered,
+	int startIndex = 0 // Offset the order in which tiles will be processed by changing the start tile
 );
 
 // Process all tiles in parallel using TileFunctor, passing the
@@ -161,7 +164,8 @@ void parallelGatherTiles(
 	const TileFunctor &tileFunctor, // Signature : T tileFunctor( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin )
 	GatherFunctor &&gatherFunctor, // Signature : void gatherFunctor( const ImagePlug *imagePlug, const string &channelName, const V2i &tileOrigin, T &tileFunctorResult )
 	const Imath::Box2i &window = Imath::Box2i(), // Uses dataWindow if not specified.
-	TileOrder tileOrder = Unordered
+	TileOrder tileOrder = Unordered,
+	int startIndex = 0 // Offset the order in which tiles will be processed by changing the start tile
 );
 
 /// Whole image operations

--- a/include/GafferImage/ImageAlgo.inl
+++ b/include/GafferImage/ImageAlgo.inl
@@ -117,13 +117,6 @@ class TileInputIterator : public boost::iterator_facade<TileInputIterator, const
 
 };
 
-struct OriginAndName
-{
-	Imath::V2i origin;
-	std::string name;
-};
-
-template <class Iterator>
 class TileInputFilter
 {
 	public:

--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -316,6 +316,10 @@ class GAFFERIMAGEUI_API ImageGadget : public GafferUI::Gadget
 		mutable TileShaderPtr m_shader;
 		mutable bool m_shaderDirty;
 
+		// Track index of the max tile that got updated last render.  This may not be the max tile in
+		// the dataWindow, if the last render was cancelled.
+		std::atomic<int> m_maxTileUpdated;
+
 };
 
 IE_CORE_DECLAREPTR( ImageGadget )


### PR DESCRIPTION
I'm not sure if this is how we want to implement this, but this seems adequate to demonstrate that the changing order which tiles update in for ImageGadget, rather than always starting from the first tile, is pretty desirable.

I've been testing with a simple image network which I've pasted at the end of this text.  Pasting in this, setting the frame range to 1000 - 1359, and hitting play, should clearly show the same sort of starvation issue Tom showed this morning, where the first tiles are updated at a very high rate, but the bottom half of the image never receives updates.

This PR switches it so that the ImageGadget starts updating after the last tile written before cancellation.  This produces an impression that is less smooth, but the whole image is updated.

It feels clearly better in the case of this animation playback, and I think it would also be much better in something like the render Tom showed ( with the comp network made heavier to be that slow on recent Gaffer ).

It might be more ambiguous whether this is desirable while changing a parameter interactively ... I've kind of gotten used to seeing smooth updates on the top quarter of the image, and then stopping my parameter drag when I want to see the whole image.  Doing fast dragging of the rotate parameter on the ImageTransform in this test doesn't feel great with this PR - it's possible to produce confusing slitscan results ... but dragging more slowly is fine.  Sticking a Grade in after the ImageReader and tweaking Grade parameters interactively feels a lot better, because you don't get a starved section of the image showing completely old data.

If we agree that this behaviour is desirable, then we'll need to talk about how to implement it.  I quite like some things about this approach ( and the tile index helpers could be quite handy if we decide my proposal for the output format of tiles() is good ), but there are certainly things to discuss before this would be ready to merge.

===============

import Gaffer
import GafferImage
import IECore
import imath

Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 59, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )

__children = {}

__children["Resize1"] = GafferImage.Resize( "Resize1" )
parent.addChild( __children["Resize1"] )
__children["Resize1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["ImageReader"] = GafferImage.ImageReader( "ImageReader" )
parent.addChild( __children["ImageReader"] )
__children["ImageReader"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["ImageTransform"] = GafferImage.ImageTransform( "ImageTransform" )
parent.addChild( __children["ImageTransform"] )
__children["ImageTransform"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Animation1"] = Gaffer.Animation( "Animation1" )
parent.addChild( __children["Animation1"] )
__children["Animation1"]["curves"].addChild( Gaffer.Animation.CurvePlug( "curve0", flags = ( Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) & ~Gaffer.Plug.Flags.AcceptsInputs, ) )
__children["Animation1"]["curves"]["curve0"].addKey( Gaffer.Animation.Key( 41.7083321, 0, Gaffer.Animation.Type.Linear ) )
__children["Animation1"]["curves"]["curve0"].addKey( Gaffer.Animation.Key( 56.625, 359, Gaffer.Animation.Type.Linear ) )
__children["Animation1"]["curves"]["curve0"].addKey( Gaffer.Animation.Key( 56.6666679, 3, Gaffer.Animation.Type.Linear ) )
__children["Animation1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Resize"] = GafferImage.Resize( "Resize" )
parent.addChild( __children["Resize"] )
__children["Resize"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Crop"] = GafferImage.Crop( "Crop" )
parent.addChild( __children["Crop"] )
__children["Crop"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Grade"] = GafferImage.Grade( "Grade" )
parent.addChild( __children["Grade"] )
__children["Grade"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Resize1"]["in"].setInput( __children["Resize"]["out"] )
__children["Resize1"]["format"].setValue( GafferImage.Format( 1024, 1024, 1.000 ) )
Gaffer.Metadata.registerValue( __children["Resize1"]["format"], 'formatPlugValueWidget:mode', 'custom' )
__children["Resize1"]["__uiPosition"].setValue( imath.V2f( 53.0235672, 2.59947395 ) )
__children["ImageReader"]["fileName"].setValue( '${GAFFER_ROOT}/python/GafferImageTest/images/circles.exr' )
__children["ImageReader"]["__uiPosition"].setValue( imath.V2f( 53.0235672, 31.1557274 ) )
__children["ImageTransform"]["in"].setInput( __children["Grade"]["out"] )
__children["ImageTransform"]["transform"]["pivot"].setValue( imath.V2f( 64, 64 ) )
__children["ImageTransform"]["transform"]["rotate"].setInput( __children["Animation1"]["curves"]["curve0"]["out"] )
__children["ImageTransform"]["__uiPosition"].setValue( imath.V2f( 53.0235672, 19.5916615 ) )
__children["Animation1"]["__uiPosition"].setValue( imath.V2f( 39.6532249, 18.8729992 ) )
__children["Resize"]["in"].setInput( __children["Crop"]["out"] )
__children["Resize"]["format"]["displayWindow"]["min"].setValue( imath.V2i( 0, 0 ) )
__children["Resize"]["format"]["displayWindow"]["max"]["x"].setValue( 2048 )
Gaffer.Metadata.registerValue( __children["Resize"]["format"], 'formatPlugValueWidget:mode', 'custom' )
__children["Resize"]["format"]["displayWindow"]["max"]["y"].setInput( __children["Resize"]["format"]["displayWindow"]["max"]["x"] )
__children["Resize"]["__uiPosition"].setValue( imath.V2f( 53.0235672, 8.26353645 ) )
__children["Crop"]["in"].setInput( __children["ImageTransform"]["out"] )
__children["Crop"]["area"].setValue( imath.Box2i( imath.V2i( 0, 0 ), imath.V2i( 128, 128 ) ) )
__children["Crop"]["__uiPosition"].setValue( imath.V2f( 53.0235672, 13.927599 ) )
__children["Grade"]["in"].setInput( __children["ImageReader"]["out"] )
__children["Grade"]["multiply"].setValue( imath.Color4f( 0.699999988, 0.400000006, 0.920000017, 1 ) )
__children["Grade"]["__uiPosition"].setValue( imath.V2f( 53.0235672, 25.255724 ) )


del __children
