### PR TITLE
NameLabel : Fix `setText()` bug which caused error updating connections

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - ArnoldAttributes : Fixed minimum value for `subdivIterations` plug. It is now `0` rather than `1`.
+- Spline editor : Fixed bug that prevented dragging of spline points.
 
 0.58.5.1 (relative to 0.58.5.0)
 ========

--- a/python/GafferUI/NameLabel.py
+++ b/python/GafferUI/NameLabel.py
@@ -73,7 +73,7 @@ class NameLabel( GafferUI.Label ) :
 
 		GafferUI.Label.setText( self, text )
 
-		self.__connections = []
+		self.__connections = {}
 
 	def setGraphComponent( self, graphComponent ) :
 


### PR DESCRIPTION
This was introduced in c4f099067fd517e385d944204780e3dc0a9795d2 where we switched the type of `self.__connections` from list to dict. This one missed spot led to the spline editor breaking with the following stack :

```
Traceback (most recent call last):
  File "/disk1/john/dev/build/gafferPython2/python/GafferUI/Widget.py", line 936, in eventFilter
    return self.__mouseButtonPress( qObject, qEvent )
  File "/disk1/john/dev/build/gafferPython2/python/GafferUI/Widget.py", line 1044, in __mouseButtonPress
    result = widget._buttonPressSignal( widget, event )
IECore.Exception: Traceback (most recent call last):
  File "/disk1/john/dev/build/gafferPython2/python/Gaffer/WeakMethod.py", line 65, in __call__
    return self.__method( s, *args, **kwArgs )
  File "/disk1/john/dev/build/gafferPython2/python/GafferUI/RampPlugValueWidget.py", line 191, in __selectedIndexChanged
    self.__positionLabel.setPlug( pointPlug["x"] )
  File "/disk1/john/dev/build/gafferPython2/python/GafferUI/PlugValueWidget.py", line 127, in setPlug
    self.setPlugs( { plug } if plug is not None else set() )
  File "/disk1/john/dev/build/gafferPython2/python/GafferUI/LabelPlugValueWidget.py", line 91, in setPlugs
    self.__label.setGraphComponents( plugs )
  File "/disk1/john/dev/build/gafferPython2/python/GafferUI/NameLabel.py", line 102, in setGraphComponents
    self.__setupConnections()
  File "/disk1/john/dev/build/gafferPython2/python/GafferUI/NameLabel.py", line 152, in __setupConnections
    self.__updateConnections( component )
  File "/disk1/john/dev/build/gafferPython2/python/GafferUI/NameLabel.py", line 194, in __updateConnections
    self.__connections[ component ] = updatedConnections
TypeError: list indices must be integers, not FloatPlug
```