### PR TITLE
Stats app : Add `-serialise` argument

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.58.x.x (relative to 0.58.5.2)
+========
+
+Improvements
+------------
+
+- Stats app : Added `-serialise` argument to measure the time taken to serialise the script.
+
 0.58.5.2 (relative to 0.58.5.1)
 ========
 


### PR DESCRIPTION
We have a little list of improvements we think will have a decent impact on script save times. This is the first step in looking into that : a simple way of measuring save times for any scripts. Usage : `gaffer stats myScript.gfr -serialise`.