### PR TITLE
Image Threading Performance Cleanup

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ API
 - TransformPlug/Transform2DPlug : Added constructor arguments for specifying child plug default values.
 - ValuePlug : Added `defaultHash()` virtual method.
 - ValuePlugSerialiser : Added `valueRepr()` method.
+- ImageAlgo : `tiles()` now returns a top level dictionary containing all the tileOrigins as a V2iVectorData, and each channel as an ObjectVectorData of channelDatas with corresponding indices. This allows `tiles()` to run substantially faster, more than twice as fast if the input network is very cheap.
 
 Breaking Changes
 ----------------

--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -41,6 +41,7 @@
 
 #include "GafferImage/Export.h"
 
+#include "IECore/CompoundObject.h"
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
@@ -175,7 +176,7 @@ GAFFERIMAGE_API IECore::MurmurHash imageHash( const ImagePlug *imagePlug );
 /// and tile.  Among other things, this makes it possible to efficiently test
 /// from Python whether two ImagePlugs have identical pixel data.  Unlike the
 /// image() method above, it works on deep images.
-GAFFERIMAGE_API IECore::ConstCompoundDataPtr tiles( const ImagePlug *imagePlug );
+GAFFERIMAGE_API IECore::ConstCompoundObjectPtr tiles( const ImagePlug *imagePlug );
 
 /// Deep Utils
 /// ==============================

--- a/python/GafferImageTest/ImageTestCase.py
+++ b/python/GafferImageTest/ImageTestCase.py
@@ -115,13 +115,16 @@ class ImageTestCase( GafferTest.TestCase ) :
 			pixelDataB = GafferImage.ImageAlgo.tiles( imageB )
 			if pixelDataA != pixelDataB:
 				self.assertEqual( pixelDataA.keys(), pixelDataB.keys() )
+				self.assertEqual( pixelDataA["tileOrigins"], pixelDataB["tileOrigins"] )
 				for k in pixelDataA.keys():
-					self.assertEqual( pixelDataA[k].keys(), pixelDataB[k].keys() )
-					for j in pixelDataA[k].keys():
-						if pixelDataA[k][j] != pixelDataB[k][j]:
-							self.assertEqual( len( pixelDataA[k][j] ), len( pixelDataB[k][j] ), " while checking pixel data %s : %s" % ( k, j ) )
-							for i in range( len( pixelDataA[k][j] ) ):
-								self.assertEqual( pixelDataA[k][j][i], pixelDataB[k][j][i] , " while checking pixel data %s : %s at index %i" % ( k, j, i ) )
+					if k == "tileOrigins":
+						continue
+					for i in range( len( pixelDataA[k] ) ):
+						if pixelDataA[k][i] != pixelDataB[k][i]:
+							tileStr = str( pixelDataA["tileOrigins"][i] )
+							self.assertEqual( len( pixelDataA[k][i] ), len( pixelDataB[k][i] ), " while checking pixel data %s : %s" % ( k, tileStr ) )
+							for j in range( len( pixelDataA[k][i] ) ):
+								self.assertEqual( pixelDataA[k][i][j], pixelDataB[k][i][j] , " while checking pixel data %s : %s at index %i" % ( k, tileStr, j ) )
 
 
 	## Returns an image node with an empty data window. This is useful in

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -392,12 +392,11 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 						onePixelDataWindow = imath.Box2i( imath.V2i( 0, 99 ), imath.V2i( 1, 100 ) )
 						self.assertEqual( reRead["out"].dataWindow(), onePixelDataWindow )
 
-						emptyPixelData = IECore.CompoundData( dict( [
-							( key,  IECore.CompoundData( {
-								"0, 64" : IECore.FloatVectorData() if key != "sampleOffsets"
-									else GafferImage.ImagePlug.emptyTileSampleOffsets()
-							} ) ) for key in [ "sampleOffsets", "R", "G","B", "A", "Z", "ZBack" ]
-						] ) )
+						emptyPixelData = IECore.CompoundObject()
+						emptyPixelData["tileOrigins"] = IECore.V2iVectorData( [ imath.V2i( 0, 64 ) ] )
+						emptyPixelData["sampleOffsets"] = IECore.ObjectVector( [ GafferImage.ImagePlug.emptyTileSampleOffsets() ] )
+						for channel in [ "R", "G","B", "A", "Z", "ZBack" ]:
+							emptyPixelData[channel] = IECore.ObjectVector( [ IECore.FloatVectorData() ] )
 						self.assertEqual( GafferImage.ImageAlgo.tiles( reRead["out"] ), emptyPixelData )
 
 	# Write an RGBA image that has a data window to various supported formats and in both scanline and tile modes.

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -718,11 +718,11 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 		merge["in"][1].setInput( transform["out"] )
 
 		# Precache upstream network, we're only interested in the performance of Merge
-		GafferImage.ImageAlgo.tiles( alphaShuffle["out"], _copy = False )
-		GafferImage.ImageAlgo.tiles( transform["out"], _copy = False )
+		GafferImageTest.processTiles( alphaShuffle["out"] )
+		GafferImageTest.processTiles( transform["out"] )
 
 		with GafferTest.TestRunner.PerformanceScope() :
-			GafferImage.ImageAlgo.tiles( merge["out"], _copy = False )
+			GafferImageTest.processTiles( merge["out"] )
 
 	@unittest.skipIf( GafferTest.inCI(), "Performance not relevant on CI platform" )
 	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5)

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -718,11 +718,11 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 		merge["in"][1].setInput( transform["out"] )
 
 		# Precache upstream network, we're only interested in the performance of Merge
-		GafferImage.ImageAlgo.tiles( alphaShuffle["out"] )
-		GafferImage.ImageAlgo.tiles( transform["out"] )
+		GafferImage.ImageAlgo.tiles( alphaShuffle["out"], _copy = False )
+		GafferImage.ImageAlgo.tiles( transform["out"], _copy = False )
 
 		with GafferTest.TestRunner.PerformanceScope() :
-			GafferImage.ImageAlgo.tiles( merge["out"] )
+			GafferImage.ImageAlgo.tiles( merge["out"], _copy = False )
 
 	@unittest.skipIf( GafferTest.inCI(), "Performance not relevant on CI platform" )
 	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5)

--- a/python/GafferImageTest/ShuffleTest.py
+++ b/python/GafferImageTest/ShuffleTest.py
@@ -218,16 +218,16 @@ class ShuffleTest( GafferImageTest.ImageTestCase ) :
 		flatGreen = GafferImage.ImageAlgo.tiles( flatShuffle["out"] )
 		deepGreen = GafferImage.ImageAlgo.tiles( deepShuffle["out"] )
 
-		for k in flatGreen["R"].keys():
-			self.assertEqual( flatGreen["R"][k], GafferImage.ImagePlug.blackTile() )
-			self.assertEqual( flatGreen["G"][k], GafferImage.ImagePlug.whiteTile() )
-			self.assertEqual( flatGreen["B"][k], GafferImage.ImagePlug.blackTile() )
+		for i in range( len( flatGreen["R"] ) ):
+			self.assertEqual( flatGreen["R"][i], GafferImage.ImagePlug.blackTile() )
+			self.assertEqual( flatGreen["G"][i], GafferImage.ImagePlug.whiteTile() )
+			self.assertEqual( flatGreen["B"][i], GafferImage.ImagePlug.blackTile() )
 
-			numSamples = deepGreen["sampleOffsets"][k][-1]
+			numSamples = deepGreen["sampleOffsets"][i][-1]
 
-			self.assertEqual( deepGreen["R"][k], IECore.FloatVectorData( [ 0.0 ] * numSamples ) )
-			self.assertEqual( deepGreen["G"][k], IECore.FloatVectorData( [ 1.0 ] * numSamples ) )
-			self.assertEqual( deepGreen["B"][k], IECore.FloatVectorData( [ 0.0 ] * numSamples ) )
+			self.assertEqual( deepGreen["R"][i], IECore.FloatVectorData( [ 0.0 ] * numSamples ) )
+			self.assertEqual( deepGreen["G"][i], IECore.FloatVectorData( [ 1.0 ] * numSamples ) )
+			self.assertEqual( deepGreen["B"][i], IECore.FloatVectorData( [ 0.0 ] * numSamples ) )
 
 		deepPremult = GafferImage.Premultiply()
 		deepPremult["in"].setInput( deepShuffle["out"] )

--- a/src/GafferImageModule/ImageAlgoBinding.cpp
+++ b/src/GafferImageModule/ImageAlgoBinding.cpp
@@ -173,11 +173,11 @@ IECore::MurmurHash imageHashWrapper( const ImagePlug *plug )
 	return ImageAlgo::imageHash( plug );
 }
 
-IECore::CompoundDataPtr tilesWrapper( const ImagePlug *plug, bool copy )
+IECore::CompoundObjectPtr tilesWrapper( const ImagePlug *plug, bool copy )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	IECore::ConstCompoundDataPtr d = ImageAlgo::tiles( plug );
-	return copy ? d->copy() : boost::const_pointer_cast<IECore::CompoundData>( d );
+	IECore::ConstCompoundObjectPtr d = ImageAlgo::tiles( plug );
+	return copy ? d->copy() : boost::const_pointer_cast<IECore::CompoundObject>( d );
 }
 
 


### PR DESCRIPTION
This is a bit of a grab bag of commits, all arising from one investigation:  why was there so much overhead in the performance parts of GafferImage.MergeTest?

We identified that parallelGatherTiles has the potential to perform extremely badly if the serial gather step is slow, and that `tiles()` had a slow serial gather step, due to some ugly string munging in how it assembled it's output.

Because `tiles()` is not currently used very much, it seemed worthwhile to just switch its interface to something is easier to make performant.  The new format ( a top level dictionary containing all the tileOrigins as a V2iVectorData, and each channel as a ObjectVectorData of channel data with corresponding indices ) actually feels cleaner anyway, and is much faster to return.

For the sake of the record, I've left in the commit where I added the `_copy = False` parameter to tiles() in the performance tests, giving the tiles() calls performance quite close to ideal.

The next commit gets rid of these tiles() calls completely, replacing them with processTiles() calls that don't need to return results at all, for theoretically the best possible performance.  In order to reach the same performance as the optimized tiles(), I also needed to get rid of the parallel_for's from the ImageAlgo tile traversal functions - this code is now simpler anyway, the parallel_for's never showed any significant benefit, and the overhead of them is troublesome in lightweight situations.