### PR TITLE
Checkerboard Performance

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - Merge : Optimized image merging.  This has been tackled in several ways, with different levels of impact.  Some extreme cases, such as using a multiply to merge two large datawindows with little overlap, now produce much smaller data windows.  Other cases can benefit a lot from being able to pass through input tiles unmodified.  For cases without a huge shortcut, there is an approximately 20% speedup from lower level optimization.
+- Checkerboard : Optimize case when rotation is 0
 
 Fixes
 -----

--- a/src/GafferImage/Checkerboard.cpp
+++ b/src/GafferImage/Checkerboard.cpp
@@ -57,10 +57,32 @@ namespace
 
 inline float filteredStripes( float x, float period, float filterWidth )
 {
-	// \todo : round / floor and int conversion are actually pretty slow by default.
-	// Could be worth trying out some intrinsics here, though of course, if we actually
-	// wanted this to not be slow, having a separable code path when there is no rotation
-	// would be a much bigger speedup
+	// \todo : this call to round is actually quite slow, and isn't being inlined.
+	//
+	// Replacing it with nearbyintf is faster, and should be inlinable, but there are
+	// two issues:
+	// * nearbyintf is influenced by the current rounding mode, which could be something
+	//   other than FE_TONEAREST ( but if it was something other than FE_TONEAREST, it looks
+	//   like that would also break OIIO's use of rint(), so maybe that's fine?
+	// * This bug in GCC means it wouldn't get inlined until we get on GCC 9:
+	//   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71278
+	//
+	// Alternatively, we could explicitly use an intrinsic for the ASM instruction we actually
+	// want, avoiding both issues:
+	//
+	//   float nearestBoundary;
+	//   __m128 d = _mm_load_ss(&xp);
+	//   d = _mm_round_ss(d, d, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+	//   _mm_store_ss(&nearestBoundary, d);
+	//
+	// But mm_round_ss requires sse4.2 - I doubt if anyone is running Gaffer without sse4.2
+	// support, but we would need to make a decision about what processors we support, and this
+	// isn't important enough to justify it.
+	//
+	// The other approach used by oiio's fast_rint is just static_cast<int>(x + copysignf(0.5f, x)).
+	// This is faster than round(), but messy, and not as fast as nearbyintf or mm_round_ss.
+	//
+	// Just sticking with the old round() for now, since this isn't too important
 	float xp = x / ( period * 0.5f );
 	float nearestBoundary = round( xp );
 	float boundaryDirection = (((int)nearestBoundary) % 2 ) == 0 ? -1.0f : 1.0f;


### PR DESCRIPTION
I had a couple of hours to spare after finishing the tasks we talked about, so I snuck in a silly one.  In the case of the Merge performance tests, this doesn't affect the test results, because I was careful to cache the inputs before measuring the merge timing, but it shaves 12 seconds off the total time to run them.