### PR TITLE
TransformPlug default values

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,16 @@ Fixes
 
 - Checkerboard : Checker colors are now exactly equal to the colorA and colorB parameters.  Previously, there were very tiny floating point errors which grew larger as the distance from origin increased.
 
+API
+---
+
+- TransformPlug : Added constructor arguments for specifying child plug default values.
+
+Breaking Changes
+----------------
+
+- TransformPlug : Added constructor arguments.
+
 0.59.0.0b3 (relative to 0.59.0.0b2)
 ==========
 

--- a/Changes.md
+++ b/Changes.md
@@ -10,16 +10,17 @@ Fixes
 -----
 
 - Checkerboard : Checker colors are now exactly equal to the colorA and colorB parameters.  Previously, there were very tiny floating point errors which grew larger as the distance from origin increased.
+- Transform2DPlug : Fixed serialisation of dynamic plugs, such as plugs promoted to a Box.
 
 API
 ---
 
-- TransformPlug : Added constructor arguments for specifying child plug default values.
+- TransformPlug/Transform2DPlug : Added constructor arguments for specifying child plug default values.
 
 Breaking Changes
 ----------------
 
-- TransformPlug : Added constructor arguments.
+- TransformPlug/Transform2DPlug : Added constructor arguments.
 
 0.59.0.0b3 (relative to 0.59.0.0b2)
 ==========

--- a/include/Gaffer/Transform2DPlug.h
+++ b/include/Gaffer/Transform2DPlug.h
@@ -55,14 +55,14 @@ class GAFFER_API Transform2DPlug : public ValuePlug
 		bool acceptsChild( const GraphComponent *potentialChild ) const override;
 		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
-		V2fPlug *pivotPlug();
-		const V2fPlug *pivotPlug() const;
 		V2fPlug *translatePlug();
 		const V2fPlug *translatePlug() const;
 		FloatPlug *rotatePlug();
 		const FloatPlug *rotatePlug() const;
 		V2fPlug *scalePlug();
 		const V2fPlug *scalePlug() const;
+		V2fPlug *pivotPlug();
+		const V2fPlug *pivotPlug() const;
 
 		Imath::M33f matrix() const;
 

--- a/include/Gaffer/Transform2DPlug.h
+++ b/include/Gaffer/Transform2DPlug.h
@@ -47,7 +47,15 @@ class GAFFER_API Transform2DPlug : public ValuePlug
 
 	public :
 
-		Transform2DPlug( const std::string &name = defaultName<Transform2DPlug>(), Direction direction=In, unsigned flags = Default );
+		Transform2DPlug(
+			const std::string &name = defaultName<Transform2DPlug>(),
+			Direction direction=In,
+			const Imath::V2f &defaultTranslate = Imath::V2f( 0 ),
+			float defaultRotate = 0,
+			const Imath::V2f &defaultScale = Imath::V2f( 1 ),
+			const Imath::V2f &defaultPivot = Imath::V2f( 0 ),
+			unsigned flags = Default
+		);
 		~Transform2DPlug() override;
 
 		GAFFER_PLUG_DECLARE_TYPE( Gaffer::Transform2DPlug, Transform2DPlugTypeId, ValuePlug );

--- a/include/Gaffer/TransformPlug.h
+++ b/include/Gaffer/TransformPlug.h
@@ -48,7 +48,15 @@ class GAFFER_API TransformPlug : public ValuePlug
 
 	public :
 
-		TransformPlug( const std::string &name = defaultName<TransformPlug>(), Direction direction=In, unsigned flags = Default );
+		TransformPlug(
+			const std::string &name = defaultName<TransformPlug>(),
+			Direction direction=In,
+			const Imath::V3f &defaultTranslate = Imath::V3f( 0 ),
+			const Imath::V3f &defaultRotate = Imath::V3f( 0 ),
+			const Imath::V3f &defaultScale = Imath::V3f( 1 ),
+			const Imath::V3f &defaultPivot = Imath::V3f( 0 ),
+			unsigned flags = Default
+		);
 		~TransformPlug() override;
 
 		GAFFER_PLUG_DECLARE_TYPE( Gaffer::TransformPlug, TransformPlugTypeId, ValuePlug );

--- a/python/GafferTest/Transform2DPlugTest.py
+++ b/python/GafferTest/Transform2DPlugTest.py
@@ -118,5 +118,43 @@ class Transform2DPlugTest( GafferTest.TestCase ) :
 		self.assertNotEqual( p.typeId(), Gaffer.ValuePlug.staticTypeId() )
 		self.assertTrue( p.isInstanceOf( Gaffer.ValuePlug.staticTypeId() ) )
 
+	def testDefaultValues( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["p"] = Gaffer.Transform2DPlug(
+			defaultTranslate = imath.V2f( 1, 2 ),
+			defaultRotate = 3,
+			defaultScale = imath.V2f( 4, 5 ),
+			defaultPivot = imath.V2f( 6, 7 ),
+			flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+		)
+		self.assertEqual( s["n"]["user"]["p"]["translate"].defaultValue(), imath.V2f( 1, 2 ) )
+		self.assertEqual( s["n"]["user"]["p"]["rotate"].defaultValue(), 3 )
+		self.assertEqual( s["n"]["user"]["p"]["scale"].defaultValue(), imath.V2f( 4, 5 ) )
+		self.assertEqual( s["n"]["user"]["p"]["pivot"].defaultValue(), imath.V2f( 6, 7 ) )
+
+		s["n"]["user"]["p2"] = s["n"]["user"]["p"].createCounterpart( "p2", Gaffer.Plug.Direction.In )
+		self.assertEqual( s["n"]["user"]["p2"]["translate"].defaultValue(), imath.V2f( 1, 2 ) )
+		self.assertEqual( s["n"]["user"]["p2"]["rotate"].defaultValue(), 3 )
+		self.assertEqual( s["n"]["user"]["p2"]["scale"].defaultValue(), imath.V2f( 4, 5 ) )
+		self.assertEqual( s["n"]["user"]["p2"]["pivot"].defaultValue(), imath.V2f( 6, 7 ) )
+
+		s["n"]["user"]["p2"]["translate"].setValue( imath.V2f( -1, -2 ) )
+		s["n"]["user"]["p2"]["translate"].resetDefault()
+		self.assertEqual( s["n"]["user"]["p2"]["translate"].defaultValue(), imath.V2f( -1, -2 ) )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( s2["n"]["user"]["p"]["translate"].defaultValue(), imath.V2f( 1, 2 ) )
+		self.assertEqual( s2["n"]["user"]["p"]["rotate"].defaultValue(), 3 )
+		self.assertEqual( s2["n"]["user"]["p"]["scale"].defaultValue(), imath.V2f( 4, 5 ) )
+		self.assertEqual( s2["n"]["user"]["p"]["pivot"].defaultValue(), imath.V2f( 6, 7 ) )
+		self.assertEqual( s2["n"]["user"]["p2"]["translate"].defaultValue(), imath.V2f( -1, -2 ) )
+		self.assertEqual( s2["n"]["user"]["p2"]["rotate"].defaultValue(), 3 )
+		self.assertEqual( s2["n"]["user"]["p2"]["scale"].defaultValue(), imath.V2f( 4, 5 ) )
+		self.assertEqual( s2["n"]["user"]["p2"]["pivot"].defaultValue(), imath.V2f( 6, 7 ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/TransformPlugTest.py
+++ b/python/GafferTest/TransformPlugTest.py
@@ -161,5 +161,43 @@ class TransformPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( s2["n"]["p"]["translate"].getValue(), imath.V3f( 1, 2, 3 ) )
 		self.assertEqual( s2["n"]["p"]["rotate"].getValue(), imath.V3f( 4, 5, 6 ) )
 
+	def testDefaultValues( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["p"] = Gaffer.TransformPlug(
+			defaultTranslate = imath.V3f( 1, 2, 3 ),
+			defaultRotate = imath.V3f( 4, 5, 6 ),
+			defaultScale = imath.V3f( 7, 8, 9 ),
+			defaultPivot = imath.V3f( 10, 11, 12 ),
+			flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic
+		)
+		self.assertEqual( s["n"]["user"]["p"]["translate"].defaultValue(), imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( s["n"]["user"]["p"]["rotate"].defaultValue(), imath.V3f( 4, 5, 6 ) )
+		self.assertEqual( s["n"]["user"]["p"]["scale"].defaultValue(), imath.V3f( 7, 8, 9 ) )
+		self.assertEqual( s["n"]["user"]["p"]["pivot"].defaultValue(), imath.V3f( 10, 11, 12 ) )
+
+		s["n"]["user"]["p2"] = s["n"]["user"]["p"].createCounterpart( "p2", Gaffer.Plug.Direction.In )
+		self.assertEqual( s["n"]["user"]["p2"]["translate"].defaultValue(), imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( s["n"]["user"]["p2"]["rotate"].defaultValue(), imath.V3f( 4, 5, 6 ) )
+		self.assertEqual( s["n"]["user"]["p2"]["scale"].defaultValue(), imath.V3f( 7, 8, 9 ) )
+		self.assertEqual( s["n"]["user"]["p2"]["pivot"].defaultValue(), imath.V3f( 10, 11, 12 ) )
+
+		s["n"]["user"]["p2"]["translate"].setValue( imath.V3f( -1, -2, -3 ) )
+		s["n"]["user"]["p2"]["translate"].resetDefault()
+		self.assertEqual( s["n"]["user"]["p2"]["translate"].defaultValue(), imath.V3f( -1, -2, -3 ) )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( s2["n"]["user"]["p"]["translate"].defaultValue(), imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( s2["n"]["user"]["p"]["rotate"].defaultValue(), imath.V3f( 4, 5, 6 ) )
+		self.assertEqual( s2["n"]["user"]["p"]["scale"].defaultValue(), imath.V3f( 7, 8, 9 ) )
+		self.assertEqual( s2["n"]["user"]["p"]["pivot"].defaultValue(), imath.V3f( 10, 11, 12 ) )
+		self.assertEqual( s2["n"]["user"]["p2"]["translate"].defaultValue(), imath.V3f( -1, -2, -3 ) )
+		self.assertEqual( s2["n"]["user"]["p2"]["rotate"].defaultValue(), imath.V3f( 4, 5, 6 ) )
+		self.assertEqual( s2["n"]["user"]["p2"]["scale"].defaultValue(), imath.V3f( 7, 8, 9 ) )
+		self.assertEqual( s2["n"]["user"]["p2"]["pivot"].defaultValue(), imath.V3f( 10, 11, 12 ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/Transform2DPlug.cpp
+++ b/src/Gaffer/Transform2DPlug.cpp
@@ -45,7 +45,14 @@ GAFFER_PLUG_DEFINE_TYPE( Transform2DPlug );
 
 size_t Transform2DPlug::g_firstPlugIndex = 0;
 
-Transform2DPlug::Transform2DPlug( const std::string &name, Direction direction, unsigned flags )
+Transform2DPlug::Transform2DPlug(
+	const std::string &name, Direction direction,
+	const Imath::V2f &defaultTranslate,
+	float defaultRotate,
+	const Imath::V2f &defaultScale,
+	const Imath::V2f &defaultPivot,
+	unsigned flags
+)
 	:	ValuePlug( name, direction, flags )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
@@ -54,7 +61,7 @@ Transform2DPlug::Transform2DPlug( const std::string &name, Direction direction, 
 		new V2fPlug(
 			"translate",
 			direction,
-			V2f( 0 ),
+			defaultTranslate,
 			V2f( limits<float>::min() ),
 			V2f( limits<float>::max() ),
 			flags
@@ -65,7 +72,7 @@ Transform2DPlug::Transform2DPlug( const std::string &name, Direction direction, 
 		new FloatPlug(
 			"rotate",
 			direction,
-			0.,
+			defaultRotate,
 			limits<float>::min(),
 			limits<float>::max(),
 			flags
@@ -76,7 +83,7 @@ Transform2DPlug::Transform2DPlug( const std::string &name, Direction direction, 
 		new V2fPlug(
 			"scale",
 			direction,
-			V2f( 1 ),
+			defaultScale,
 			V2f( limits<float>::min() ),
 			V2f( limits<float>::max() ),
 			flags
@@ -87,7 +94,7 @@ Transform2DPlug::Transform2DPlug( const std::string &name, Direction direction, 
 		new V2fPlug(
 			"pivot",
 			direction,
-			V2f( 0 ),
+			defaultPivot,
 			V2f( limits<float>::min() ),
 			V2f( limits<float>::max() ),
 			flags
@@ -107,7 +114,14 @@ bool Transform2DPlug::acceptsChild( const GraphComponent *potentialChild ) const
 
 PlugPtr Transform2DPlug::createCounterpart( const std::string &name, Direction direction ) const
 {
-	return new Transform2DPlug( name, direction, getFlags() );
+	return new Transform2DPlug(
+		name, direction,
+		translatePlug()->defaultValue(),
+		rotatePlug()->defaultValue(),
+		scalePlug()->defaultValue(),
+		pivotPlug()->defaultValue(),
+		getFlags()
+	);
 }
 
 V2fPlug *Transform2DPlug::translatePlug()

--- a/src/Gaffer/Transform2DPlug.cpp
+++ b/src/Gaffer/Transform2DPlug.cpp
@@ -110,16 +110,6 @@ PlugPtr Transform2DPlug::createCounterpart( const std::string &name, Direction d
 	return new Transform2DPlug( name, direction, getFlags() );
 }
 
-V2fPlug *Transform2DPlug::pivotPlug()
-{
-	return getChild<V2fPlug>( g_firstPlugIndex+3 );
-}
-
-const V2fPlug *Transform2DPlug::pivotPlug() const
-{
-	return getChild<V2fPlug>( g_firstPlugIndex+3 );
-}
-
 V2fPlug *Transform2DPlug::translatePlug()
 {
 	return getChild<V2fPlug>( g_firstPlugIndex );
@@ -148,6 +138,16 @@ V2fPlug *Transform2DPlug::scalePlug()
 const V2fPlug *Transform2DPlug::scalePlug() const
 {
 	return getChild<V2fPlug>( g_firstPlugIndex+2 );
+}
+
+V2fPlug *Transform2DPlug::pivotPlug()
+{
+	return getChild<V2fPlug>( g_firstPlugIndex+3 );
+}
+
+const V2fPlug *Transform2DPlug::pivotPlug() const
+{
+	return getChild<V2fPlug>( g_firstPlugIndex+3 );
 }
 
 Imath::M33f Transform2DPlug::matrix() const

--- a/src/Gaffer/TransformPlug.cpp
+++ b/src/Gaffer/TransformPlug.cpp
@@ -46,22 +46,26 @@ GAFFER_PLUG_DEFINE_TYPE( TransformPlug );
 
 size_t TransformPlug::g_firstPlugIndex = 0;
 
-TransformPlug::TransformPlug( const std::string &name, Direction direction, unsigned flags )
+TransformPlug::TransformPlug(
+	const std::string &name, Direction direction,
+	const V3f &defaultTranslate,
+	const V3f &defaultRotate,
+	const V3f &defaultScale,
+	const V3f &defaultPivot,
+	unsigned flags
+)
 	:	ValuePlug( name, direction, flags )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-
-	// We create our children automatically, so they should never be created dynamically
-	unsigned childFlags = flags & ~Plug::Dynamic;
 
 	addChild(
 		new V3fPlug(
 			"translate",
 			direction,
-			V3f( 0 ),
+			defaultTranslate,
 			V3f( limits<float>::min() ),
 			V3f( limits<float>::max() ),
-			childFlags
+			flags
 		)
 	);
 
@@ -69,10 +73,10 @@ TransformPlug::TransformPlug( const std::string &name, Direction direction, unsi
 		new V3fPlug(
 			"rotate",
 			direction,
-			V3f( 0 ),
+			defaultRotate,
 			V3f( limits<float>::min() ),
 			V3f( limits<float>::max() ),
-			childFlags
+			flags
 		)
 	);
 
@@ -80,10 +84,10 @@ TransformPlug::TransformPlug( const std::string &name, Direction direction, unsi
 		new V3fPlug(
 			"scale",
 			direction,
-			V3f( 1 ),
+			defaultScale,
 			V3f( limits<float>::min() ),
 			V3f( limits<float>::max() ),
-			childFlags
+			flags
 		)
 	);
 
@@ -91,10 +95,10 @@ TransformPlug::TransformPlug( const std::string &name, Direction direction, unsi
 		new V3fPlug(
 			"pivot",
 			direction,
-			V3f( 0 ),
+			defaultPivot,
 			V3f( limits<float>::min() ),
 			V3f( limits<float>::max() ),
-			childFlags
+			flags
 		)
 	);
 }
@@ -110,7 +114,14 @@ bool TransformPlug::acceptsChild( const GraphComponent *potentialChild ) const
 
 PlugPtr TransformPlug::createCounterpart( const std::string &name, Direction direction ) const
 {
-	return new TransformPlug( name, direction, getFlags() );
+	return new TransformPlug(
+		name, direction,
+		translatePlug()->defaultValue(),
+		rotatePlug()->defaultValue(),
+		scalePlug()->defaultValue(),
+		pivotPlug()->defaultValue(),
+		getFlags()
+	);
 }
 
 V3fPlug *TransformPlug::translatePlug()


### PR DESCRIPTION
This is the first PR in a series intended to overhaul the Box/Reference workflow, fixing some longstanding bugs particularly with respect to default values. This one is pretty straightforward, just making it possible to specify default values for TransformPlug and Transform2DPlug, and round-trip them through serialisation/loading.