### PR TITLE
InteractiveRenderUI : Fix controls downstream of compositing operations

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - Stats app : Added `-serialise` argument to measure the time taken to serialise the script.
 
+API
+---
+
+- Catalogue : Added `gaffer:isRendering` metadata, set to `True` if the viewed image is still receiving data from a display driver.
+
 0.58.5.2 (relative to 0.58.5.1)
 ========
 

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - Stats app : Added `-serialise` argument to measure the time taken to serialise the script.
 
+Fixes
+-----
+
+- Viewer : Render controls should now work when viewing a render after it has passed through a compositing network, providing `gaffer:sourceScene` and `gaffer:isRendering` metadata is preserved (#3888).
+
 API
 ---
 

--- a/python/GafferImageTest/CatalogueTest.py
+++ b/python/GafferImageTest/CatalogueTest.py
@@ -64,6 +64,8 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
 		return result
 
+	__catalogueIsRenderingMetadataKey = "gaffer:isRendering"
+
 	def testImages( self ) :
 
 		images = []
@@ -184,7 +186,11 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
 		r = GafferImage.ImageReader()
 		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/checker.exr" )
-		self.sendImage( r["out"], c )
+
+		driver = self.sendImage( r["out"], c, close = False )
+		self.assertEqual( c["out"]["metadata"].getValue()[ self.__catalogueIsRenderingMetadataKey ].value, True )
+		driver.close()
+		self.assertNotIn( self.__catalogueIsRenderingMetadataKey, c["out"]["metadata"].getValue() )
 
 		self.assertEqual( len( c["images"] ), 1 )
 		self.assertEqual( c["images"][0]["fileName"].getValue(), "" )
@@ -232,10 +238,12 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		r = GafferImage.ImageReader()
 		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/blurRange.exr" )
 		self.sendImage( r["out"], s["c"] )
-
 		self.assertEqual( len( s["c"]["images"] ), 1 )
 		self.assertEqual( os.path.dirname( s["c"]["images"][0]["fileName"].getValue() ), s["c"]["directory"].getValue() )
 		self.assertImagesEqual( s["c"]["out"], r["out"], ignoreMetadata = True, maxDifference = 0.0003 )
+
+		r["fileName"].setValue( s["c"]["images"][0]["fileName"].getValue() )
+		self.assertNotIn( self.__catalogueIsRenderingMetadataKey, r["out"]["metadata"].getValue() )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
@@ -243,6 +251,9 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( len( s2["c"]["images"] ), 1 )
 		self.assertEqual( s2["c"]["images"][0]["fileName"].getValue(), s["c"]["images"][0]["fileName"].getValue() )
 		self.assertImagesEqual( s2["c"]["out"], r["out"], ignoreMetadata = True, maxDifference = 0.0003 )
+
+		r["fileName"].setValue( s2["c"]["images"][0]["fileName"].getValue() )
+		self.assertNotIn( self.__catalogueIsRenderingMetadataKey, r["out"]["metadata"].getValue() )
 
 	def testCatalogueName( self ) :
 
@@ -536,6 +547,9 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual( c["images"][1]["description"].getValue(), c["images"][0]["description"].getValue() )
 		self.assertEqual( c["images"][1]["fileName"].getValue(), c["images"][0]["fileName"].getValue() )
+
+		c["imageIndex"].setValue( 1 )
+		self.assertNotIn( self.__catalogueIsRenderingMetadataKey, c["out"]["metadata"].getValue() )
 
 	def testDeleteBeforeSaveCompletes( self ) :
 

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -152,13 +152,14 @@ class _ViewRenderControlUI( GafferUI.Widget ) :
 
 	def __imageIsRendering( self, imagePlug ) :
 
-		# Make-shift detection of an in-progress render.
-		# Finished images have the `fileFormat` key courtesy of OIIO.
-		## \TODO add more formal metadata to determine this
+		rendering = False
+
 		try :
-			return "fileFormat" not in imagePlug.metadata()
+			rendering = imagePlug.metadata()[ "gaffer:isRendering" ].value
 		except :
-			return False
+			pass
+
+		return rendering
 
 	@GafferUI.LazyMethod()
 	def __updateLazily( self ) :


### PR DESCRIPTION
Fixes #3888.

We had been relying on OIIO provided headers to indicate if an image was on disk or in memory for a render. This was flawed, as the presence of OIIO headers may not be a reflection of render state downstream of any compositing operations.

This adds first-class support of render status to `Catalogue`, via the new `gaffer:isRendering` Bool metadata. This will be set to `True` whilst data is being received from a display driver.