### PR TITLE
Box/ValuePlugSerialiser/ExtensionAlgo : Improve export strategy 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -38,6 +38,7 @@ API
   - Added `valueRepr()` method.
   - Added support for `valuePlugSerialiser:omitParentNodePlugValues` context variable. This is used for exporting Boxes for referencing, and by ExtensionAlgo.
 - ImageAlgo : `tiles()` now returns a top level dictionary containing all the tileOrigins as a V2iVectorData, and each channel as an ObjectVectorData of channelDatas with corresponding indices. This allows `tiles()` to run substantially faster, more than twice as fast if the input network is very cheap.
+- ConfirmationDialogue : Added optional `details` constructor argument which accepts text to be shown in a collapsed "Details" section.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -13,7 +13,9 @@ Improvements
 
 - Merge : Optimized image merging.  This has been tackled in several ways, with different levels of impact.  Some extreme cases, such as using a multiply to merge two large datawindows with little overlap, now produce much smaller data windows.  Other cases can benefit a lot from being able to pass through input tiles unmodified.  For cases without a huge shortcut, there is an approximately 20% speedup from lower level optimization.
 - Box :
-  - Improved strategy used for exporting for referencing. Before, the current values of the Box plugs were converted into the default values of the Reference during export. This was error prone as it was too easy to export new defaults after changing values for testing. We now export default values as they are, and omit current values completely.
+  - Improved strategy used for exporting for referencing. Before, the current values of the Box plugs were converted into the default values of the Reference during export. This was error prone as it was too easy to export new defaults after changing values for testing. We now export default values as they are, and omit current values completely. Two new menu items allow the default values to be authored explicitly from the current values at any time.
+  - Added "Reset Default Values" item to NodeEditor tool menu. This sets the default values for all plugs from their current values.
+  - Added "Reset Default Value" item to plug context menu. This sets the default value from the current value.
 - Checkerboard : Optimized image generation when rotation is 0.
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,7 @@ Fixes
 - Box/Reference :
   - Fixed export and referencing of TransformPlugs with modified default values (#3946).
   - Fixed export and referencing of CompoundDataPlugs with modified default values (#3907).
+  - Fixed loss of spreadsheet values when using "Duplicate as Box" (#3972).
 - Spreadsheet : Fixed serialisation of default values which do not match those of the default row.
 - Checkerboard : Checker colors are now exactly equal to the colorA and colorB parameters.  Previously, there were very tiny floating point errors which grew larger as the distance from origin increased.
 - Transform2DPlug : Fixed serialisation of dynamic plugs, such as plugs promoted to a Box.

--- a/Changes.md
+++ b/Changes.md
@@ -19,7 +19,9 @@ Improvements
 Fixes
 -----
 
-- Box/Reference : Fixed export and referencing of TransformPlugs with modified default values (#3946).
+- Box/Reference :
+  - Fixed export and referencing of TransformPlugs with modified default values (#3946).
+  - Fixed export and referencing of CompoundDataPlugs with modified default values (#3907).
 - Spreadsheet : Fixed serialisation of default values which do not match those of the default row.
 - Checkerboard : Checker colors are now exactly equal to the colorA and colorB parameters.  Previously, there were very tiny floating point errors which grew larger as the distance from origin increased.
 - Transform2DPlug : Fixed serialisation of dynamic plugs, such as plugs promoted to a Box.

--- a/Changes.md
+++ b/Changes.md
@@ -30,6 +30,7 @@ API
 Breaking Changes
 ----------------
 
+- Reference : Removed support for boxes exported prior to version 0.9.0.0.
 - TransformPlug/Transform2DPlug : Added constructor arguments.
 - ValuePlug : Added virtual method.
 

--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,7 @@ Fixes
   - Fixed export and referencing of TransformPlugs with modified default values (#3946).
   - Fixed export and referencing of CompoundDataPlugs with modified default values (#3907).
   - Fixed loss of spreadsheet values when using "Duplicate as Box" (#3972).
+  - Fixed export and referencing of SplinePlugs.
 - Spreadsheet : Fixed serialisation of default values which do not match those of the default row.
 - Checkerboard : Checker colors are now exactly equal to the colorA and colorB parameters.  Previously, there were very tiny floating point errors which grew larger as the distance from origin increased.
 - Transform2DPlug : Fixed serialisation of dynamic plugs, such as plugs promoted to a Box.

--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,7 @@ Fixes
 - Spreadsheet : Fixed serialisation of default values which do not match those of the default row.
 - Checkerboard : Checker colors are now exactly equal to the colorA and colorB parameters.  Previously, there were very tiny floating point errors which grew larger as the distance from origin increased.
 - Transform2DPlug : Fixed serialisation of dynamic plugs, such as plugs promoted to a Box.
+- SplinePlug : Fixed bug that meant `isSetToDefault()` could return true even if it had computed inputs. It now returns false in this case, and never triggers an upstream compute.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Improvements
 Fixes
 -----
 
+- Box/Reference : Fixed export and referencing of TransformPlugs with modified default values (#3946).
 - Spreadsheet : Fixed serialisation of default values which do not match those of the default row.
 - Checkerboard : Checker colors are now exactly equal to the colorA and colorB parameters.  Previously, there were very tiny floating point errors which grew larger as the distance from origin increased.
 - Transform2DPlug : Fixed serialisation of dynamic plugs, such as plugs promoted to a Box.

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,8 @@
 0.59.x.x (relative to 0.59.0.0b3)
 ========
 
+> Caution : The current plug values are now omitted when exporting a Box for referencing. See Improvements section for more details.
+
 Features
 --------
 
@@ -10,7 +12,9 @@ Improvements
 ------------
 
 - Merge : Optimized image merging.  This has been tackled in several ways, with different levels of impact.  Some extreme cases, such as using a multiply to merge two large datawindows with little overlap, now produce much smaller data windows.  Other cases can benefit a lot from being able to pass through input tiles unmodified.  For cases without a huge shortcut, there is an approximately 20% speedup from lower level optimization.
-- Checkerboard : Optimize case when rotation is 0
+- Box :
+  - Improved strategy used for exporting for referencing. Before, the current values of the Box plugs were converted into the default values of the Reference during export. This was error prone as it was too easy to export new defaults after changing values for testing. We now export default values as they are, and omit current values completely.
+- Checkerboard : Optimized image generation when rotation is 0.
 
 Fixes
 -----
@@ -24,15 +28,19 @@ API
 
 - TransformPlug/Transform2DPlug : Added constructor arguments for specifying child plug default values.
 - ValuePlug : Added `defaultHash()` virtual method.
-- ValuePlugSerialiser : Added `valueRepr()` method.
+- ValuePlugSerialiser :
+  - Added `valueRepr()` method.
+  - Added support for `valuePlugSerialiser:omitParentNodePlugValues` context variable. This is used for exporting Boxes for referencing, and by ExtensionAlgo.
 - ImageAlgo : `tiles()` now returns a top level dictionary containing all the tileOrigins as a V2iVectorData, and each channel as an ObjectVectorData of channelDatas with corresponding indices. This allows `tiles()` to run substantially faster, more than twice as fast if the input network is very cheap.
 
 Breaking Changes
 ----------------
 
+- Box : The current plug values are now omitted when exporting for referencing, rather than being transformed into new default values.
 - Reference : Removed support for boxes exported prior to version 0.9.0.0.
 - TransformPlug/Transform2DPlug : Added constructor arguments.
 - ValuePlug : Added virtual method.
+- ValuePlugSerialiser : Removed support for `valuePlugSerialiser:resetParentPlugDefaults` context variable.
 
 0.59.0.0b3 (relative to 0.59.0.0b2)
 ==========

--- a/include/GafferBindings/ValuePlugBinding.h
+++ b/include/GafferBindings/ValuePlugBinding.h
@@ -47,11 +47,11 @@ namespace GafferBindings
 
 /// Supports the following Context variables :
 ///
-/// "valuePlugSerialiser:resetParentPlugDefaults"
+/// "valuePlugSerialiser:omitParentNodePlugValues"
 ///
-/// :	Replaces the default value with the current value for plugs
-///     of the parent node. This is used when exporting the contents
-///     of a Box node.
+/// :	Omits the `setValue()` calls for plugs of the parent
+///     node. This is used when exporting the contents of a
+///     Box node for referencing.
 class GAFFERBINDINGS_API ValuePlugSerialiser : public PlugSerialiser
 {
 

--- a/python/Gaffer/ExtensionAlgo.py
+++ b/python/Gaffer/ExtensionAlgo.py
@@ -142,7 +142,7 @@ def __nodeDefinition( box, extension ) :
 	with Gaffer.Context() as context :
 		context["serialiser:includeVersionMetadata"] = IECore.BoolData( False )
 		context["serialiser:protectParentNamespace"] = IECore.BoolData( False )
-		context["valuePlugSerialiser:resetParentPlugDefaults"] = IECore.BoolData( True )
+		context["valuePlugSerialiser:omitParentNodePlugValues"] = IECore.BoolData( True )
 		context["plugSerialiser:includeParentPlugMetadata"] = IECore.BoolData( False )
 		constructor = Gaffer.Serialisation( box, "self", children ).result()
 

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -1415,6 +1415,29 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertEqual( script["reference1"]["rows"][1]["cells"].keys(), script["box"]["rows"][1]["cells"].keys() )
 		self.assertEqual( script["reference1"]["rows"][1]["cells"]["string"]["value"].getValue(), "test" )
 
+	def testTransformPlugs( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["box"] = Gaffer.Box()
+
+		script["box"]["t2"] = Gaffer.Transform2DPlug( defaultTranslate = imath.V2f( 10, 11 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		script["box"]["t2"]["rotate"].setValue( 10 )
+		script["box"]["t3"] = Gaffer.TransformPlug( defaultTranslate = imath.V3f( 10, 11, 12 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		script["box"]["t3"]["rotate"].setValue( imath.V3f( 1, 2, 3 ) )
+
+		script["box"].exportForReference( self.temporaryDirectory() + "/test.grf" )
+
+		script["reference"] = Gaffer.Reference()
+		script["reference"].load( self.temporaryDirectory() + "/test.grf" )
+
+		self.assertTrue( script["reference"]["t2"].isSetToDefault() )
+		for name in script["reference"]["t2"].keys() :
+			self.assertEqual( script["reference"]["t2"][name].defaultValue(), script["box"]["t2"][name].defaultValue() )
+
+		self.assertTrue( script["reference"]["t3"].isSetToDefault() )
+		for name in script["reference"]["t3"].keys() :
+			self.assertEqual( script["reference"]["t3"][name].defaultValue(), script["box"]["t3"][name].defaultValue() )
+
 	def tearDown( self ) :
 
 		GafferTest.TestCase.tearDown( self )

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -1524,6 +1524,75 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertEqual( script["reference"]["rows"][1]["cells"]["c1"]["value"]["y"].getValue(), 3 )
 		self.assertEqual( script["reference"]["rows"][1]["cells"]["c1"]["value"]["z"].getValue(), 4 )
 
+	def testSplinePlug( self ) :
+
+		splines = [
+			Gaffer.SplineDefinitionff(
+				(
+					( 0, 0 ),
+					( 0.2, 0.3 ),
+					( 0.4, 0.9 ),
+					( 1, 1 ),
+				),
+				Gaffer.SplineDefinitionInterpolation.CatmullRom
+			),
+			Gaffer.SplineDefinitionff(
+				(
+					( 1, 1 ),
+					( 1, 1 ),
+					( 0.2, 0.3 ),
+					( 0.4, 0.9 ),
+					( 0, 0 ),
+					( 0, 0 ),
+				),
+				Gaffer.SplineDefinitionInterpolation.Linear
+			)
+		]
+
+		fileName = os.path.join( self.temporaryDirectory(), "test.grf" )
+
+		for nonDefaultAtExport in ( False, True ) :
+
+			for i in range( 0, 2 ) :
+
+				# On one iteration `defaultValue` has more points,
+				# and on the other iteration `otherValue` has more
+				# points. This is useful for catching bugs because
+				# SplinePlugs must add plugs to represent points.
+				defaultValue = splines[i]
+				otherValue = splines[(i+1)%2]
+
+				script = Gaffer.ScriptNode()
+
+				# Create Box with SplinePlug
+
+				script["box"] = Gaffer.Box()
+				script["box"]["spline"] = Gaffer.SplineffPlug( defaultValue = defaultValue, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+				if nonDefaultAtExport :
+					script["box"]["spline"].setValue( otherValue )
+				script["box"].exportForReference( fileName )
+
+				# Reference it and check we get what we want
+
+				script["reference"] = Gaffer.Reference()
+				script["reference"].load( fileName )
+
+				self.assertEqual( script["reference"]["spline"].getValue(), defaultValue )
+				self.assertEqual( script["reference"]["spline"].defaultValue(), defaultValue )
+				self.assertTrue( script["reference"]["spline"].isSetToDefault() )
+
+				# Set value on reference and save and reload it
+
+				script["reference"]["spline"].setValue( otherValue )
+				self.assertEqual( script["reference"]["spline"].getValue(), otherValue )
+
+				script2 = Gaffer.ScriptNode()
+				script2.execute( script.serialise() )
+
+				self.assertEqual( script2["reference"]["spline"].getValue(), otherValue )
+				self.assertEqual( script2["reference"]["spline"].defaultValue(), defaultValue )
+				self.assertFalse( script2["reference"]["spline"].isSetToDefault() )
+
 	def tearDown( self ) :
 
 		GafferTest.TestCase.tearDown( self )

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -1438,6 +1438,28 @@ class ReferenceTest( GafferTest.TestCase ) :
 		for name in script["reference"]["t3"].keys() :
 			self.assertEqual( script["reference"]["t3"][name].defaultValue(), script["box"]["t3"][name].defaultValue() )
 
+	def testCompoundDataPlugs( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["box"] = Gaffer.Box()
+
+		script["box"]["p"] = Gaffer.CompoundDataPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		script["box"]["p"]["m"] = Gaffer.NameValuePlug( "a", 10, defaultEnabled = True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		self.assertEqual( script["box"]["p"]["m"]["name"].defaultValue(), "a" )
+		self.assertEqual( script["box"]["p"]["m"]["value"].defaultValue(), 10 )
+		self.assertEqual( script["box"]["p"]["m"]["enabled"].defaultValue(), True )
+		script["box"]["p"]["m"]["name"].setValue( "b" )
+		script["box"]["p"]["m"]["value"].setValue( 11 )
+		script["box"]["p"]["m"]["enabled"].setValue( False )
+
+		script["box"].exportForReference( self.temporaryDirectory() + "/test.grf" )
+
+		script["reference"] = Gaffer.Reference()
+		script["reference"].load( self.temporaryDirectory() + "/test.grf" )
+
+		self.assertTrue( script["reference"]["p"].isSetToDefault() )
+		self.assertEqual( script["reference"]["p"].defaultHash(), script["box"]["p"].defaultHash() )
+
 	def tearDown( self ) :
 
 		GafferTest.TestCase.tearDown( self )

--- a/python/GafferTest/SplinePlugTest.py
+++ b/python/GafferTest/SplinePlugTest.py
@@ -698,5 +698,35 @@ class SplinePlugTest( GafferTest.TestCase ) :
 		p.setValue( s2 )
 		self.assertEqual( p.defaultHash(), h )
 
+	def testIsSetToDefaultAndConnections( self ) :
+
+		definition = Gaffer.SplineDefinitionff(
+			(
+				( 0, 0 ),
+				( 0.2, 0.3 ),
+				( 0.4, 0.9 ),
+				( 1, 1 ),
+			),
+			Gaffer.SplineDefinitionInterpolation.CatmullRom
+		)
+
+		plug = Gaffer.SplineffPlug( defaultValue = definition )
+		self.assertTrue( plug.isSetToDefault() )
+
+		# Static (not computed) input providing the same value as default.
+
+		staticInput = plug.pointPlug( 1 ).createCounterpart( "input", Gaffer.Plug.Direction.In )
+		plug.pointPlug( 1 ).setInput( staticInput )
+		self.assertTrue( plug.isSetToDefault() )
+
+		# Computed input that happens to provide the same value as default.
+		# This is treated as non-default, because it could differ by context
+		# and `ValuePlug::isSetToDefault()` is documented as never triggering
+		# computes.
+
+		computedInput = GafferTest.AddNode()
+		plug.pointPlug( 0 )["x"].setInput( computedInput["sum"] )
+		self.assertFalse( plug.isSetToDefault() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/ConfirmationDialogue.py
+++ b/python/GafferUI/ConfirmationDialogue.py
@@ -38,11 +38,22 @@ import GafferUI
 
 class ConfirmationDialogue( GafferUI.Dialogue ) :
 
-	def __init__( self, title, message, cancelLabel="Cancel", confirmLabel="OK", sizeMode=GafferUI.Window.SizeMode.Automatic, **kw ) :
+	def __init__( self, title, message, cancelLabel="Cancel", confirmLabel="OK", sizeMode=GafferUI.Window.SizeMode.Automatic, details = None, **kw ) :
 
 		GafferUI.Dialogue.__init__( self, title, sizeMode=sizeMode, **kw )
 
-		self._setWidget( GafferUI.Label( message ) )
+		with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing = 8 ) as column :
+
+			GafferUI.Label( message )
+
+			if details is not None :
+				with GafferUI.Collapsible( label = "Details", collapsed = True ) :
+					GafferUI.MultiLineTextWidget(
+						text = details,
+						editable = False,
+					)
+
+		self._setWidget( column )
 
 		self._addButton( cancelLabel )
 		self.__confirmButton = self._addButton( confirmLabel )

--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -168,7 +168,7 @@ void Box::exportForReference( const std::string &fileName ) const
 	}
 
 	ContextPtr context = new Context;
-	context->set( "valuePlugSerialiser:resetParentPlugDefaults", true );
+	context->set( "valuePlugSerialiser:omitParentNodePlugValues", true );
 	context->set( "serialiser:includeParentMetadata", true );
 	Context::Scope scopedContext( context.get() );
 

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -426,21 +426,6 @@ void Reference::loadInternal( const std::string &fileName )
 		}
 	}
 
-	// figure out what version of gaffer was used to save the reference. prior to
-	// version 0.9.0.0, references could contain setValue() calls for promoted plugs,
-	// and we must make sure they don't clobber the user-set values on the reference node.
-	int milestoneVersion = 0;
-	int majorVersion = 0;
-	if( IECore::ConstIntDataPtr v = Metadata::value<IECore::IntData>( this, "serialiser:milestoneVersion" ) )
-	{
-		milestoneVersion = v->readable();
-	}
-	if( IECore::ConstIntDataPtr v = Metadata::value<IECore::IntData>( this, "serialiser:majorVersion" ) )
-	{
-		majorVersion = v->readable();
-	}
-	const bool versionPriorTo09 = milestoneVersion == 0 && majorVersion < 9;
-
 	// Transfer connections, values and metadata from the old plugs onto the corresponding new ones.
 
 	for( std::map<std::string, Plug *>::const_iterator it = previousPlugs.begin(), eIt = previousPlugs.end(); it != eIt; ++it )
@@ -453,7 +438,7 @@ void Reference::loadInternal( const std::string &fileName )
 			{
 				if( newPlug->direction() == Plug::In && oldPlug->direction() == Plug::In )
 				{
-					copyInputsAndValues( oldPlug, newPlug, /* ignoreDefaultValues = */ !versionPriorTo09 );
+					copyInputsAndValues( oldPlug, newPlug, /* ignoreDefaultValues = */ true );
 				}
 				transferOutputs( oldPlug, newPlug );
 

--- a/src/Gaffer/SplinePlug.cpp
+++ b/src/Gaffer/SplinePlug.cpp
@@ -38,6 +38,7 @@
 #include "Gaffer/SplinePlug.h"
 
 #include "Gaffer/Action.h"
+#include "Gaffer/ComputeNode.h"
 
 using namespace Gaffer;
 
@@ -391,6 +392,20 @@ void SplinePlug<T>::resetDefault()
 template<typename T>
 bool SplinePlug<T>::isSetToDefault() const
 {
+	for( const auto &p : Plug::RecursiveRange( *this ) )
+	{
+		if( p->children().empty() )
+		{
+			const Plug *s = p->source();
+			if( s->direction() == Plug::Out && IECore::runTimeCast<const ComputeNode>( s->node() ) )
+			{
+				// Value is computed, and therefore can vary by context. There is no
+				// single "current value", so no true concept of whether or not it's at
+				// the default.
+				return false;
+			}
+		}
+	}
 	return getValue() == m_defaultValue;
 }
 

--- a/src/GafferBindings/ValuePlugBinding.cpp
+++ b/src/GafferBindings/ValuePlugBinding.cpp
@@ -76,30 +76,6 @@ bool shouldResetPlugDefault( const Gaffer::Plug *plug, const Serialisation *seri
 	return Context::current()->get<bool>( "valuePlugSerialiser:resetParentPlugDefaults", false );
 }
 
-bool shouldOmitDefaultValue( const Gaffer::ValuePlug *plug )
-{
-	if( const Reference *reference = IECore::runTimeCast<const Reference>( plug->node() ) )
-	{
-		// Prior to version 0.9.0.0, `.grf` files created with `Box::exportForReference()`
-		// could contain setValue() calls for promoted plugs like this one. When such
-		// files have been loaded on a Reference node, we must always serialise the plug values
-		// from the Reference node, lest they should get clobbered by the setValue() calls
-		// in the `.grf` file.
-		int milestoneVersion = 0;
-		int majorVersion = 0;
-		if( IECore::ConstIntDataPtr v = Metadata::value<IECore::IntData>( reference, "serialiser:milestoneVersion" ) )
-		{
-			milestoneVersion = v->readable();
-		}
-		if( IECore::ConstIntDataPtr v = Metadata::value<IECore::IntData>( reference, "serialiser:majorVersion" ) )
-		{
-			majorVersion = v->readable();
-		}
-		return milestoneVersion > 0 || majorVersion > 8;
-	}
-	return true;
-}
-
 std::string valueSerialisationWalk( const Gaffer::ValuePlug *plug, const std::string &identifier, const Serialisation &serialisation, bool &canCondense )
 {
 	// There's nothing to do if the plug isn't serialisable.
@@ -157,7 +133,7 @@ std::string valueSerialisationWalk( const Gaffer::ValuePlug *plug, const std::st
 
 	object pythonValue = pythonPlug.attr( "getValue" )();
 
-	if( shouldOmitDefaultValue( plug ) && PyObject_HasAttrString( pythonPlug.ptr(), "defaultValue" ) )
+	if( PyObject_HasAttrString( pythonPlug.ptr(), "defaultValue" ) )
 	{
 		object pythonDefaultValue = pythonPlug.attr( "defaultValue" )();
 		if( pythonValue == pythonDefaultValue )


### PR DESCRIPTION
When exporting a Box for referencing or via ExtensionAlgo, we want to provide a way for the user to author default values for the reference/extension. In the past, this was done by transforming the current values into defaults at the point of export. This was error prone, as it was far too easy to change the values while testing your creation, and then accidentally export them as new defaults. Changing the defaults breaks compatibility with previous versions, so isn't to be taken lightly. We now export the current defaults unchanged and completely omit the current values. Instead, users can author defaults explicitly using the `ValuePlug::resetDefault()` method. Additions to BoxUI warn about this new behaviour and provide menu items for authoring defaults explicitly. 