### PR TITLE
ArnoldRenderTest : Relax test threshold

### DIFF
--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -1389,7 +1389,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		# The `maxDifference` is huge to account for noise and watermarks, but is still low enough to check what
 		# we want, since if the Encapsulate was sampled at shutter open and not the frame, the difference would be
 		# 0.5.
-		self.assertImagesEqual( s["deformationOff"]["out"], s["deformationOn"]["out"], maxDifference = 0.24, ignoreMetadata = True )
+		self.assertImagesEqual( s["deformationOff"]["out"], s["deformationOn"]["out"], maxDifference = 0.25, ignoreMetadata = True )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This should hopefully deal with some false failures we're seeing on CI. As documented in the comment above, although the allowed delta is large, it still guards against the problem it was intended to.
