### PR TITLE
SpreadsheetUI : Allow rows to be copied between Spreadsheets

### DIFF
--- a/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
+++ b/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
@@ -142,7 +142,7 @@ def pasteCells( valueMatrix, plugs, atTime ) :
 
 	for rowIndex, row in enumerate( plugs ) :
 		for columnIndex, cell in enumerate( row ) :
-			ValueAdaptor.set( cell, __dataForPlug( rowIndex, columnIndex, valueMatrix ), atTime )
+			ValueAdaptor.set( __dataForPlug( rowIndex, columnIndex, valueMatrix ), cell, atTime )
 
 ## Returns a value matrix for the supplied row plugs.
 def copyRows( rowPlugs ) :
@@ -244,7 +244,7 @@ class ValueAdaptor :
 	## Sets the specified plug's value at the given time, keyframing animated values.
 	# \note This should be called from within an UndoScope.
 	@staticmethod
-	def set( plug, data, atTime ) :
+	def set( data, plug, atTime ) :
 
 		if Gaffer.MetadataAlgo.readOnly( plug ) :
 			return
@@ -320,7 +320,7 @@ class ValueAdaptor :
 			ValueAdaptor._setOrKeyValue( plug, data, atTime )
 		else :
 			for childName, childData in data.items() :
-				ValueAdaptor.set( plug[ childName ], childData, atTime )
+				ValueAdaptor.set( childData, plug[ childName ], atTime )
 
 	@staticmethod
 	def _setOrKeyValue( plug, value, atTime ) :
@@ -373,10 +373,10 @@ class NameValuePlugValueAdaptor( ValueAdaptor ) :
 			valueData = data
 			enabledData = None
 
-		ValueAdaptor.set( nameValuePlug[ "value" ], valueData, atTime )
+		ValueAdaptor.set( valueData, nameValuePlug[ "value" ], atTime )
 
 		if "enabled" in nameValuePlug and enabledData is not None :
-			ValueAdaptor.set( nameValuePlug[ "enabled" ], enabledData, atTime )
+			ValueAdaptor.set( enabledData, nameValuePlug[ "enabled" ], atTime )
 
 ValueAdaptor.registerAdaptor( Gaffer.NameValuePlug, NameValuePlugValueAdaptor )
 
@@ -397,12 +397,12 @@ class CellPlugValueAdaptor( ValueAdaptor ) :
 
 		enabledData, valueData = CellPlugValueAdaptor.__enabledAndValueData( data )
 
-		ValueAdaptor.set( cellPlug[ "value" ], valueData, atTime )
+		ValueAdaptor.set( valueData, cellPlug[ "value" ], atTime )
 
 		# Set enabled state last, such that when copying from a cell that doesn't adopt
 		# an enabled plug, to one that does, the final 'enabled' state matches.
 		if enabledData is not None :
-			ValueAdaptor.set( cellPlug.enabledPlug(), enabledData, atTime )
+			ValueAdaptor.set( enabledData, cellPlug.enabledPlug(), atTime )
 
 	@staticmethod
 	def __enabledAndValueData( data ) :
@@ -454,13 +454,13 @@ class RowPlugValueAdaptor( ValueAdaptor ) :
 
 		# Name/enabled
 		for plugName in ( "name", "enabled" ) :
-			ValueAdaptor.set( rowPlug[ plugName ], rowData[ plugName ], atTime )
+			ValueAdaptor.set( rowData[ plugName ], rowPlug[ plugName ], atTime )
 
 		# Cells
 		cellData = rowData[ "cells" ]
 		for cell in rowPlug[ "cells" ].children() :
 			data = cellData.get( cell.getName(), None )
 			if data is not None :
-				ValueAdaptor.set( cell, data, atTime )
+				ValueAdaptor.set( data, cell, atTime )
 
 ValueAdaptor.registerAdaptor( Gaffer.Spreadsheet.RowPlug, RowPlugValueAdaptor )

--- a/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
+++ b/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
@@ -296,14 +296,14 @@ class ValueAdaptor :
 	@classmethod
 	def _canSet( cls, data, plug ) :
 
-		plugData = cls.get( plug )
+		plugData = ValueAdaptor.get( plug )
 
 		if cls.dataSchemaMatches( data, plugData ) :
 			return True
 
 		# Support basic value embedding for NameValuePlug -> ValuePlug
 		if isinstance( data, IECore.CompoundData ) and "value" in data :
-			return cls.dataSchemaMatches( data[ "value" ], plugData )
+			return ValueAdaptor.dataSchemaMatches( data[ "value" ], plugData )
 
 		return False
 
@@ -313,14 +313,14 @@ class ValueAdaptor :
 
 		if isinstance( data, IECore.CompoundData ) :
 			# Only perform schema check for compound data types, to allow value coercion for basic types
-			if not cls.dataSchemaMatches( data, cls.get( plug ) ) and "value" in data :
+			if not ValueAdaptor.dataSchemaMatches( data, ValueAdaptor.get( plug ) ) and "value" in data :
 				data = data[ "value" ]
 
 		if hasattr( plug, 'setValue' ) :
-			cls._setOrKeyValue( plug, data, atTime )
+			ValueAdaptor._setOrKeyValue( plug, data, atTime )
 		else :
 			for childName, childData in data.items() :
-				cls.set( plug[ childName ], childData, atTime )
+				ValueAdaptor.set( plug[ childName ], childData, atTime )
 
 	@staticmethod
 	def _setOrKeyValue( plug, value, atTime ) :
@@ -373,10 +373,10 @@ class NameValuePlugValueAdaptor( ValueAdaptor ) :
 			valueData = data
 			enabledData = None
 
-		cls.set( nameValuePlug[ "value" ], valueData, atTime )
+		ValueAdaptor.set( nameValuePlug[ "value" ], valueData, atTime )
 
 		if "enabled" in nameValuePlug and enabledData is not None :
-			cls.set( nameValuePlug[ "enabled" ], enabledData, atTime )
+			ValueAdaptor.set( nameValuePlug[ "enabled" ], enabledData, atTime )
 
 ValueAdaptor.registerAdaptor( Gaffer.NameValuePlug, NameValuePlugValueAdaptor )
 

--- a/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
+++ b/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
@@ -254,9 +254,6 @@ class ValueAdaptor :
 	@staticmethod
 	def set( data, plug, atTime ) :
 
-		if Gaffer.MetadataAlgo.readOnly( plug ) :
-			return
-
 		ValueAdaptor.__adaptor( plug )._set( data, plug, atTime )
 
 	## \return True if the schema (ie. class hierarchy) of the two supplied
@@ -303,6 +300,13 @@ class ValueAdaptor :
 	# set on the specified plug.
 	@classmethod
 	def _canSet( cls, data, plug ) :
+
+		# Ensure we consider child plugs, eg: components of a V3fPlug
+		if Gaffer.MetadataAlgo.readOnly( plug ) :
+			return False
+		for p in Gaffer.Plug.RecursiveRange( plug ) :
+			if Gaffer.MetadataAlgo.getReadOnly( p ) :
+				return False
 
 		plugData = ValueAdaptor.get( plug )
 

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -716,10 +716,9 @@ class _PlugTableView( GafferUI.Widget ) :
 	def __copyRows( self ) :
 
 		rowPlugs = _PlugTableView.__orderedRowsPlugs( self.selectedPlugs() )
-		plugMatrix = [ row.children() for row in rowPlugs ]
 
 		with self.ancestor( GafferUI.PlugValueWidget ).getContext() :
-			clipboardData = _ClipboardAlgo.valueMatrix( plugMatrix )
+			clipboardData = _ClipboardAlgo.copyRows( rowPlugs )
 
 		self.__setClipboard( clipboardData )
 


### PR DESCRIPTION
Allows rows to be coped/pasted between Spreadsheets. If the target Spreadsheet has a different column configuration to the source, columns will be matched by name.

@johnhaddon This also contains a little cleanup/bug fixing from the PR