### PR TITLE
Encapsulation in Instancer 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,14 @@
 0.59.x.x (relative to 0.59.0.0)
 ========
 
+Features
+--------
+
+- Instancer : Added `encapsulateInstanceGroups` plug, which outputs the instances within capsules. This has the same performance benefits as using an Encapsulate node downstream, with the following additional benefits :
+  - Significantly improved performance when the prototypes define sets. A benchmarch with 1 million instances saw set generation time go from 10s using a downstream Encapsulate node to 0.002s using `encapsulateInstanceGroups`.
+  - Fewer unnecessary capsule invalidations, resulting in fewer interactive rendering updates.
+  - Convenience.
+
 Fixes
 -----
 

--- a/include/GafferScene/BranchCreator.h
+++ b/include/GafferScene/BranchCreator.h
@@ -151,6 +151,31 @@ class GAFFERSCENE_API BranchCreator : public FilteredSceneProcessor
 		virtual IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const;
 		//@}
 
+		// Computes the relevant parent and branch paths for computing the result
+		// at the specified path. Returns a PathMatcher::Result to describe where path is
+		// relative to the parent, as follows :
+		//
+		// AncestorMatch
+		//
+		// The path is on a branch below the parent, parentPath and branchPath
+		// are filled in appropriately, and branchPath will not be empty.
+		//
+		// ExactMatch
+		//
+		// The path is at the parent exactly, parentPath will be filled
+		// in appropriately and branchPath will be empty.
+		//
+		// DescendantMatch
+		//
+		// The path is above one or more parents. Neither parentPath nor branchPath
+		// will be filled in.
+		//
+		// NoMatch
+		//
+		// The path is a direct pass through from the input - neither
+		// parentPath nor branchPath will be filled in.
+		IECore::PathMatcher::Result parentAndBranchPaths( const ScenePath &path, ScenePath &parentPath, ScenePath &branchPath ) const;
+
 	private :
 
 		/// Returns the path specified by `parentPlug()`, only if it is non-empty
@@ -178,31 +203,6 @@ class GAFFERSCENE_API BranchCreator : public FilteredSceneProcessor
 		// the input set will be passed through unchanged.
 		IECore::PathMatcher parentPathsForSet( const IECore::InternedString &setName, const Gaffer::Context *context ) const;
 		bool affectsParentPathsForSet( const Gaffer::Plug *input ) const;
-
-		// Computes the relevant parent and branch paths for computing the result
-		// at the specified path. Returns a PathMatcher::Result to describe where path is
-		// relative to the parent, as follows :
-		//
-		// AncestorMatch
-		//
-		// The path is on a branch below the parent, parentPath and branchPath
-		// are filled in appropriately, and branchPath will not be empty.
-		//
-		// ExactMatch
-		//
-		// The path is at the parent exactly, parentPath will be filled
-		// in appropriately and branchPath will be empty.
-		//
-		// DescendantMatch
-		//
-		// The path is above one or more parents. Neither parentPath nor branchPath
-		// will be filled in.
-		//
-		// NoMatch
-		//
-		// The path is a direct pass through from the input - neither
-		// parentPath nor branchPath will be filled in.
-		IECore::PathMatcher::Result parentAndBranchPaths( const ScenePath &path, ScenePath &parentPath, ScenePath &branchPath ) const;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -96,6 +96,9 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::StringPlug *attributePrefixPlug();
 		const Gaffer::StringPlug *attributePrefixPlug() const;
 
+		Gaffer::BoolPlug *encapsulateInstanceGroupsPlug();
+		const Gaffer::BoolPlug *encapsulateInstanceGroupsPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
@@ -121,9 +124,15 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
+		void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+
 		bool affectsBranchChildNames( const Gaffer::Plug *input ) const override;
 		void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+
+		void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 		bool affectsBranchSetNames( const Gaffer::Plug *input ) const override;
 		void hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
@@ -132,6 +141,9 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		bool affectsBranchSet( const Gaffer::Plug *input ) const override;
 		void hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const override;
+
+		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 	private :
 
@@ -142,6 +154,9 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 
 		Gaffer::AtomicCompoundDataPlug *prototypeChildNamesPlug();
 		const Gaffer::AtomicCompoundDataPlug *prototypeChildNamesPlug() const;
+
+		GafferScene::ScenePlug *capsuleScenePlug();
+		const GafferScene::ScenePlug *capsuleScenePlug() const;
 
 		ConstEngineDataPtr engine( const ScenePath &parentPath, const Gaffer::Context *context ) const;
 		void engineHash( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -125,6 +125,40 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( instancer["out"].bound( instancePath ), sphere.bound() )
 			self.assertEqual( instancer["out"].childNames( instancePath ), IECore.InternedStringVectorData() )
 
+		# Test encapsulation options
+		encapInstancer = GafferScene.Instancer()
+		encapInstancer["in"].setInput( seedsInput["out"] )
+		encapInstancer["prototypes"].setInput( instanceInput["out"] )
+		encapInstancer["parent"].setValue( "/seeds" )
+		encapInstancer["name"].setValue( "instances" )
+		encapInstancer["encapsulateInstanceGroups"].setValue( True )
+
+		unencapFilter = GafferScene.PathFilter()
+		unencapFilter["paths"].setValue( IECore.StringVectorData( [ "/..." ] ) )
+
+		unencap = GafferScene.Unencapsulate()
+		unencap["in"].setInput( encapInstancer["out"] )
+		unencap["filter"].setInput( unencapFilter["out"] )
+
+		self.assertTrue( isinstance( encapInstancer["out"].object( "/seeds/instances/sphere/" ), GafferScene.Capsule ) )
+		self.assertEqual( encapInstancer["out"].childNames( "/seeds/instances/sphere/" ), IECore.InternedStringVectorData() )
+		self.assertScenesEqual( unencap["out"], instancer["out"] )
+
+		# Edit seeds object
+		freezeTransform = GafferScene.FreezeTransform()
+		freezeTransform["in"].setInput( seedsInput["out"] )
+		freezeTransform["filter"].setInput( unencapFilter["out"] )
+
+		instancer["in"].setInput( freezeTransform["out"] )
+		encapInstancer["in"].setInput( freezeTransform["out"] )
+
+		self.assertScenesEqual( unencap["out"], instancer["out"] )
+
+		# Then set it back ( to make sure that returning to a previously cached value after
+		# changing the seeds doesn't pull an expired Capsule out of the cache )
+		freezeTransform["enabled"].setValue( False )
+		self.assertScenesEqual( unencap["out"], instancer["out"] )
+
 	def testThreading( self ) :
 
 		sphere = IECoreScene.SpherePrimitive()
@@ -1121,6 +1155,27 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 				"/object/instances/cubeGroup/2/cube",
 			}
 		)
+
+		# Test encapsulation options
+		encapInstancer = GafferScene.Instancer()
+		encapInstancer["in"].setInput( objectToScene["out"] )
+		encapInstancer["prototypes"].setInput( instances["out"] )
+		encapInstancer["parent"].setValue( "/object" )
+		encapInstancer["prototypeIndex"].setValue( "index" )
+		encapInstancer["encapsulateInstanceGroups"].setValue( True )
+
+		unencapFilter = GafferScene.PathFilter()
+		unencapFilter["paths"].setValue( IECore.StringVectorData( [ "/..." ] ) )
+
+		unencap = GafferScene.Unencapsulate()
+		unencap["in"].setInput( encapInstancer["out"] )
+		unencap["filter"].setInput( unencapFilter["out"] )
+
+		# Sets should be empty while encapsulated
+		self.assertEqual( encapInstancer["out"].set( "sphereSet" ).value.paths(), [] )
+		self.assertEqual( encapInstancer["out"].set( "cubeSet" ).value.paths(), [] )
+		# But should match after unencapsulating
+		self.assertScenesEqual( unencap["out"], instancer["out"] )
 
 	def testSetsWithDeepPrototypeRoots( self ) :
 

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -285,6 +285,27 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"encapsulateInstanceGroups" : [
+
+			"description",
+			"""
+			Converts each group of instances into a capsule, which won't
+			be expanded until you Unencapsulate or render. When keeping
+			these locations encapsulated, downstream nodes can't see the
+			instance locations, which prevents editing but improves
+			performance. This option should be preferred to a downstream
+			Encapsulate node because it has the following benefits :
+
+			- Substantially improved performance when the prototypes
+			  define sets.
+			- Fewer unnecessary updates during interactive rendering.
+			""",
+			"label", "Instance Groups",
+
+			"layout:section", "Settings.Encapsulation",
+
+		],
+
 	}
 
 )


### PR DESCRIPTION
This is very early, but it looks like it's going to work fine.  There's some cleanup required for how affects() is handled, and I should probably do a bit more testing, but after switching to a method where I don't use contexts, this is looking reasonably good.

The main thing I could use feedback on is the Version 1 and Version 2 PRs.  Originally, I did what we talked about:  adding internal versions of [compute/hash]Branch[ChildNames/Object/Set], which take a boolean for whether they are being evaluated outPlug() or capsuleScenePlug(), and when appropriate, calling them with inCapsule=true from an overridden hashObject when evaluating the capsuleScene plug.  But when it came time to implement computeSet, I encountered a problem:  I would have to reimplement all the logic from BranchCreator::computeSet, which is kind of complicated, and sounds like it may change in the future to increase parallelism.

Then I realized that I got just turn this logic inside out:  the logic for computeSet on outPlug when encapsulating is trivial ( no sets are added to until you expand the capsules, so the input sets can just be passed through ( Oh wait, I guess I do still need to check if the set exists in the input, and return an empty set if it doesn't? ) ).  This meant that I could just have the overridden computeSet handle the special easy case of computing the sets when encapsulating, instead of using any of the default mechanism, and then computeBranchSet can be set up to always do the more complicated default behaviour without checking the encapsulate plug.

For sets, this is both cleaner and simpler - but it's a bit annoying that the structure is now quite different for object/childNames and for sets.  In version 2, I apply the same transform to object/childNames, which I think also feels a bit cleaner, but it costs an extra call to parentAndBranchPaths, which is probably not worth it.

So, I still need to make a decision on this, and do some cleanup, and it might make sense to add support for the prototype encapsulation as well before putting this up for merging.  But it all feels like it's going reasonably smoothly so far.