### PR TITLE
Make ValuePlug::dirtyCount Public

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -43,6 +43,7 @@ API
 - ImageAlgo : `tiles()` now returns a top level dictionary containing all the tileOrigins as a V2iVectorData, and each channel as an ObjectVectorData of channelDatas with corresponding indices. This allows `tiles()` to run substantially faster, more than twice as fast if the input network is very cheap.
 - ConfirmationDialogue : Added optional `details` constructor argument which accepts text to be shown in a collapsed "Details" section.
 - Capsule : Expiry is no longer detected based on the dirtyCount of the source scene.  This removes a debugging tool that could be useful, but allows nodes that create Capsules to have more granular hashing behaviour - if the behaviour of the source scene is captured by a hash that can be used by the capsule, then we can reuse the capsule when that hash matches, and we don't need to invalidate if the capsule is changed back to a cached value.
+- ValuePlug : Added `dirtyCount` public method.
 
 Breaking Changes
 ----------------
@@ -55,6 +56,7 @@ Breaking Changes
 - NameValuePlugValueWidget : Removed support for using the `Plug.Dynamic` flag to determine whether or not the `name` plug is shown. Use `nameValuePlugValueWidget:ignoreNamePlug` metadata instead.
 - Light/Camera : Removed button for adding custom plugs in the "Visualisation" section.
 - Metadata : Removed compatibility for loading graph bookmarks created in versions prior to 0.33.0.0. Resave the file from Gaffer 0.58.0.0 to preserve the bookmarks if necessary.
+- Encapsulate : Removed data member
 
 0.59.0.0b3 (relative to 0.59.0.0b2)
 ==========

--- a/Changes.md
+++ b/Changes.md
@@ -42,6 +42,7 @@ API
   - Added support for `valuePlugSerialiser:omitParentNodePlugValues` context variable. This is used for exporting Boxes for referencing, and by ExtensionAlgo.
 - ImageAlgo : `tiles()` now returns a top level dictionary containing all the tileOrigins as a V2iVectorData, and each channel as an ObjectVectorData of channelDatas with corresponding indices. This allows `tiles()` to run substantially faster, more than twice as fast if the input network is very cheap.
 - ConfirmationDialogue : Added optional `details` constructor argument which accepts text to be shown in a collapsed "Details" section.
+- Capsule : Expiry is no longer detected based on the dirtyCount of the source scene.  This removes a debugging tool that could be useful, but allows nodes that create Capsules to have more granular hashing behaviour - if the behaviour of the source scene is captured by a hash that can be used by the capsule, then we can reuse the capsule when that hash matches, and we don't need to invalidate if the capsule is changed back to a cached value.
 
 Breaking Changes
 ----------------

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -205,6 +205,17 @@ class GAFFER_API ValuePlug : public Plug
 
 		//@}
 
+		/// Returns a counter that increments when this plug is been dirtied
+		/// ( but doesn't necessarily start at 0 ). This is used internally
+		/// for cache invalidation but may also be useful for debugging and
+		/// as part of a "poor man's hash" where computing the full upstream
+		/// hash might be prohibitively expensive
+		/// (see `Encapsulate::hashObject()` for example).
+		uint64_t dirtyCount() const
+		{
+			return m_dirtyCount;
+		}
+
 	protected :
 
 		/// This constructor must be used by all derived classes which wish

--- a/include/GafferScene/Encapsulate.h
+++ b/include/GafferScene/Encapsulate.h
@@ -67,11 +67,7 @@ class GAFFERSCENE_API Encapsulate : public FilteredSceneProcessor
 
 	private :
 
-		void plugDirtied( const Gaffer::Plug *plug );
-
 		IECore::PathMatcher::Result filterValueChecked( const Gaffer::Context *context ) const;
-
-		uint64_t m_dirtyCount;
 
 		static size_t g_firstPlugIndex;
 

--- a/python/GafferSceneTest/CapsuleTest.py
+++ b/python/GafferSceneTest/CapsuleTest.py
@@ -73,17 +73,9 @@ class CapsuleTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( capsuleCopy.bound(), sphere["out"].bound( "/" ) )
 		self.assertEqual( capsuleCopy.hash(), capsule.hash() )
 
-		sphere["radius"].setValue( 2 )
+		del sphere
 
-		six.assertRaisesRegex( self, RuntimeError, "Capsule has expired", capsule.scene )
-		six.assertRaisesRegex( self, RuntimeError, "Capsule has expired", capsule.root )
-		six.assertRaisesRegex( self, RuntimeError, "Capsule has expired", capsule.hash )
-		six.assertRaisesRegex( self, RuntimeError, "Capsule has expired", capsule.bound )
-
-		six.assertRaisesRegex( self, RuntimeError, "Capsule has expired", capsuleCopy.scene )
-		six.assertRaisesRegex( self, RuntimeError, "Capsule has expired", capsuleCopy.root )
-		six.assertRaisesRegex( self, RuntimeError, "Capsule has expired", capsuleCopy.hash )
-		six.assertRaisesRegex( self, RuntimeError, "Capsule has expired", capsuleCopy.bound )
+		six.assertRaisesRegex( self, RuntimeError, "Source scene plug no longer valid.", capsule.scene )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/EncapsulateTest.py
+++ b/python/GafferSceneTest/EncapsulateTest.py
@@ -205,6 +205,27 @@ class EncapsulateTest( GafferSceneTest.SceneTestCase ) :
 		encapsulate["in"].setInput( group1["out"] )
 		assertHashesUnique( "/group" )
 
+		# Test changing the filter or globals
+		group2["in"][1].setInput( group1["out"] )
+
+		options = GafferScene.CustomOptions()
+		options["in"].setInput( group2["out"] )
+
+		encapsulate["in"].setInput( options["out"] )
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/group/group" ] ) )
+
+		c = encapsulate["out"].object( "/group/group" )
+
+		# Changing filter doesn't affect hash
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/group/group", "/group/group2" ] ) )
+		self.assertEqual( c, encapsulate["out"].object( "/group/group" ) )
+
+		# Changing globals shouldn't affect hash
+		# \todo : But it currently does due to current issue with handling motion blur.  Change this
+		# assertNotEqual to an assertEqual after fixing shutter handling for capsules
+		options["options"].addChild( Gaffer.NameValuePlug( "test", IECore.IntData( 10 ) ) )
+		self.assertNotEqual( c, encapsulate["out"].object( "/group/group" ) )
+
 	def testSetMemberAtRoot( self ) :
 
 		sphere = GafferScene.Sphere()

--- a/python/GafferTest/ValuePlugTest.py
+++ b/python/GafferTest/ValuePlugTest.py
@@ -148,6 +148,43 @@ class ValuePlugTest( GafferTest.TestCase ) :
 
 		self.assertEqual( len( cs ), 1 )
 
+	def testDirtyCountPlug( self ) :
+
+		# The dirtyCount is relative to the current dirtyCountEpoch
+		refPlug = Gaffer.ValuePlug()
+		epoch = refPlug.dirtyCount()
+
+
+		i = Gaffer.IntPlug()
+		self.assertEqual( i.dirtyCount(), epoch + 0 )
+		i.setValue( 10 )
+		self.assertEqual( i.dirtyCount(), epoch + 1 )
+		i.setValue( 20 )
+		self.assertEqual( i.dirtyCount(), epoch + 2 )
+
+		i2 = Gaffer.IntPlug()
+		v = Gaffer.ValuePlug()
+
+		self.assertEqual( i2.dirtyCount(), epoch + 0 )
+		self.assertEqual( v.dirtyCount(), epoch + 0 )
+
+		# Need to parent to a node before dirtying based on plug reparenting will work
+		n = Gaffer.Node()
+		n.addChild( v )
+
+		self.assertEqual( v.dirtyCount(), epoch + 1 )
+		self.assertEqual( i2.dirtyCount(), epoch + 0 )
+
+		# Parenting dirties both parent and child
+		v.addChild( i2 )
+		self.assertEqual( v.dirtyCount(), epoch + 2 )
+		self.assertEqual( i2.dirtyCount(), epoch + 1 )
+
+		# Setting the value of the child should also dirty the parent
+		i2.setValue( 10 )
+		self.assertEqual( v.dirtyCount(), epoch + 3 )
+		self.assertEqual( i2.dirtyCount(), epoch + 2 )
+
 	def testCopyPasteDoesntRetainComputedValues( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/src/GafferModule/ValuePlugBinding.cpp
+++ b/src/GafferModule/ValuePlugBinding.cpp
@@ -145,6 +145,7 @@ void GafferModule::bindValuePlug()
 		.staticmethod( "getHashCacheMode" )
 		.def( "setHashCacheMode", &ValuePlug::setHashCacheMode )
 		.staticmethod( "setHashCacheMode" )
+		.def( "dirtyCount", &ValuePlug::dirtyCount )
 		.def( "__repr__", &repr )
 	;
 

--- a/src/GafferScene/Encapsulate.cpp
+++ b/src/GafferScene/Encapsulate.cpp
@@ -253,7 +253,7 @@ IECore::ConstPathMatcherDataPtr Encapsulate::computeSet( const IECore::InternedS
 
 void Encapsulate::plugDirtied( const Gaffer::Plug *plug )
 {
-	if( plug->parent() == outPlug() )
+	if( plug->parent() == inPlug() )
 	{
 		++m_dirtyCount;
 	}

--- a/src/GafferScene/Encapsulate.cpp
+++ b/src/GafferScene/Encapsulate.cpp
@@ -49,7 +49,7 @@ GAFFER_NODE_DEFINE_TYPE( Encapsulate );
 size_t Encapsulate::g_firstPlugIndex = 0;
 
 Encapsulate::Encapsulate( const std::string &name )
-	:	FilteredSceneProcessor( name, IECore::PathMatcher::NoMatch ), m_dirtyCount( 0 )
+	:	FilteredSceneProcessor( name, IECore::PathMatcher::NoMatch )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 
@@ -58,8 +58,6 @@ Encapsulate::Encapsulate( const std::string &name )
 	outPlug()->attributesPlug()->setInput( inPlug()->attributesPlug() );
 	outPlug()->globalsPlug()->setInput( inPlug()->globalsPlug() );
 	outPlug()->setNamesPlug()->setInput( inPlug()->setNamesPlug() );
-
-	plugDirtiedSignal().connect( 0, boost::bind( &Encapsulate::plugDirtied, this, ::_1 ) );
 }
 
 Encapsulate::~Encapsulate()
@@ -126,7 +124,11 @@ void Encapsulate::hashObject( const ScenePath &path, const Gaffer::Context *cont
 		/// up and compute the accurate hash? Or at least provide the
 		/// option?
 		h.append( reinterpret_cast<uint64_t>( this ) );
-		h.append( m_dirtyCount );
+
+		/// \todo : This shouldn't include the dirtyCount of the globals plug,
+		/// once we fix things so that capsules don't depend on the shutter
+		/// setting of the source scene
+		h.append( inPlug()->dirtyCount() );
 		h.append( context->hash() );
 		inPlug()->boundPlug()->hash( h );
 	}
@@ -250,13 +252,3 @@ IECore::ConstPathMatcherDataPtr Encapsulate::computeSet( const IECore::InternedS
 
 	return outputSetData;
 }
-
-void Encapsulate::plugDirtied( const Gaffer::Plug *plug )
-{
-	if( plug->parent() == inPlug() )
-	{
-		++m_dirtyCount;
-	}
-}
-
-


### PR DESCRIPTION
This was pretty hasty since I got caught up in figuring out how to make the Instancer stuff work today, but I went ahead and did a quick naive pass on this.  Two issues:

* When updating the encapsulate tests I realized that we should also make sure changing globals doesn't invalidate capsules.  This now means that the strategy can't be as simple as we suggested in just taking inPlug()->dirtyCount().  I guess we could combine the dirtyCounts of all the child plugs we care about?
* Capsule was explicitly ignoring globalsPlug for the dirtyCount previously, but I've temporarily just naively used the full plug hash in Capsule as well ... and there isn't a test failure, so we should probably both add a test case for this, and fix it.