### PR TITLE
NameValuePlugValueWidget : Don't use `Plug.DynamicFlag`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,7 @@ Fixes
   - Fixed export and referencing of CompoundDataPlugs with modified default values (#3907).
   - Fixed loss of spreadsheet values when using "Duplicate as Box" (#3972).
   - Fixed export and referencing of SplinePlugs.
+  - Fixed incorrect presentation of referenced CompoundDataPlugs (#4020).
 - Spreadsheet : Fixed serialisation of default values which do not match those of the default row.
 - Checkerboard : Checker colors are now exactly equal to the colorA and colorB parameters.  Previously, there were very tiny floating point errors which grew larger as the distance from origin increased.
 - Transform2DPlug : Fixed serialisation of dynamic plugs, such as plugs promoted to a Box.
@@ -50,6 +51,8 @@ Breaking Changes
 - TransformPlug/Transform2DPlug : Added constructor arguments.
 - ValuePlug : Added virtual method.
 - ValuePlugSerialiser : Removed support for `valuePlugSerialiser:resetParentPlugDefaults` context variable.
+- NameValuePlugValueWidget : Removed support for using the `Plug.Dynamic` flag to determine whether or not the `name` plug is shown. Use `nameValuePlugValueWidget:ignoreNamePlug` metadata instead.
+- Light/Camera : Removed button for adding custom plugs in the "Visualisation" section.
 
 0.59.0.0b3 (relative to 0.59.0.0b2)
 ==========

--- a/python/GafferSceneUI/AttributesUI.py
+++ b/python/GafferSceneUI/AttributesUI.py
@@ -65,6 +65,12 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"attributes.*" : [
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
+		],
+
 		"global" : [
 
 			"description",

--- a/python/GafferSceneUI/CameraUI.py
+++ b/python/GafferSceneUI/CameraUI.py
@@ -339,6 +339,12 @@ plugsMetadata = {
 
 	],
 
+	"renderSettingOverrides.*" : [
+
+		"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
+	],
+
 	"visualiserAttributes" : [
 
 			"description",
@@ -347,6 +353,13 @@ plugsMetadata = {
 			""",
 
 			"layout:section", "Visualisation",
+			"compoundDataPlugValueWidget:editable", False,
+
+	],
+
+	"visualiserAttributes.*" : [
+
+		"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
 
 	],
 

--- a/python/GafferSceneUI/CustomAttributesUI.py
+++ b/python/GafferSceneUI/CustomAttributesUI.py
@@ -64,6 +64,12 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"attributes.*" : [
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", False,
+
+		],
+
 		"attributes.*.name" : [
 
 			"ui:scene:acceptsAttributeName", True,

--- a/python/GafferSceneUI/CustomOptionsUI.py
+++ b/python/GafferSceneUI/CustomOptionsUI.py
@@ -67,6 +67,12 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"options.*" : [
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", False,
+
+		],
+
 		"prefix" : [
 
 			"description",

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -105,6 +105,13 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"layout:section", "Visualisation",
+			"compoundDataPlugValueWidget:editable", False,
+
+		],
+
+		"visualiserAttributes.*" : [
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
 
 		],
 

--- a/python/GafferSceneUI/OptionsUI.py
+++ b/python/GafferSceneUI/OptionsUI.py
@@ -62,6 +62,12 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"options.*" : [
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
+		],
+
 	}
 
 )

--- a/python/GafferUI/NameValuePlugValueWidget.py
+++ b/python/GafferUI/NameValuePlugValueWidget.py
@@ -47,8 +47,7 @@ from GafferUI.PlugValueWidget import sole
 ## Supported plug metadata :
 #
 # - "nameValuePlugPlugValueWidget:ignoreNamePlug", set to True to ignore the name plug and instead show a
-#   label with the name of the NameValuePlug.  This is the same behaviour you get by default if the plug
-#   is not dynamic
+#   label with the name of the NameValuePlug.
 class NameValuePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, childPlug ) :
@@ -60,12 +59,9 @@ class NameValuePlugValueWidget( GafferUI.PlugValueWidget ) :
 		## \todo We should support no plugs here. Move the UI configuration into setPlugs
 		assert( len( self.getPlugs() ) > 0 )
 
-		# We use a non-editable label for the name for non-dynamic plugs, or any that request it
+		# We use a non-editable label if requested by "nameValuePlugPlugValueWidget:ignoreNamePlug" metadata.
 
-		anyStatic = any( [ not p.getFlags( Gaffer.Plug.Flags.Dynamic ) for p in self.getPlugs() ] )
-		anyIgnoreName = any( [ Gaffer.Metadata.value( p, "nameValuePlugPlugValueWidget:ignoreNamePlug" ) for p in self.getPlugs() ] )
-
-		if anyStatic or anyIgnoreName :
+		if any( Gaffer.Metadata.value( p, "nameValuePlugPlugValueWidget:ignoreNamePlug" ) for p in self.getPlugs() ) :
 			nameWidget = GafferUI.LabelPlugValueWidget(
 				self.getPlugs(),
 				horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right,

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -199,6 +199,7 @@ if moduleSearchPath.find( "nsi.py" ) and moduleSearchPath.find( "GafferDelight" 
 
 			visibilityPlug = Gaffer.NameValuePlug( "dl:visibility.camera", False, "cameraVisibility", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 			node["attributes"].addChild( visibilityPlug )
+			Gaffer.Metadata.registerValue( visibilityPlug, "nameValuePlugPlugValueWidget:ignoreNamePlug", True )
 			Gaffer.MetadataAlgo.setReadOnly( visibilityPlug["name"], True )
 
 			return node


### PR DESCRIPTION
The use of this to decide whether or not to show the name plug dates back to before the existence of metadata. We want to phase out the flag entirely, and reliance on the flag is the cause of #4020, so we now use only the  "nameValuePlugPlugValueWidget:ignoreNamePlug" metadata that has existed for some time.

To maintain the previous behaviour, we now register metadata for various nodes. A couple of notes on that :

- For the Options/Attributes nodes we have three choices.
	1. Register `ignoreNamePlug = True` on the base class, and override it on the Custom subclass.
	3. Register `ignoreNamePlug = False` on the base class and override it on all subclasses except Custom.
	2. Register `ignoreNamePlug = foo` on all concrete classes, but not the base class.
  Here we have opted for 1, since it represents the least code change and provides maximum compatibility with other subclasses that may exist in the wild. This matches the decision already taken with regard to the `compoundDataPlugValueWidget:editable` metadata.
- This also registers `compoundDataPlugValueWidget:editable = False` for `LightUI.visualiserAttributes` and `CameraUI.visualiserAttributes` to avoid the possibility of adding custom attributes where `ignoreNamePlug = True` may not be appropriate. This is consistent with the fact that we already provide all the relevant visualisation attributes.

Fixes #4020.
