### PR TITLE
LRUCache : Fix deadlock bug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Fixes
 - SplinePlug :
   - Fixed bugs affecting default values. All child plugs are now at their default values following construction and following a call to either `setToDefault()` or `resetDefault()`.
   - Fixed bug that prevented a spline from being promoted to a Box if it had a non-default number of points. This also affected the use of a spline as the input to an Expression.
+- LRUCache : Fixed bug which could cause hangs during scene generation (#4016).
 - ArnoldShader : Moved the toon shader's `rim_light_tint` and `aov_prefix` parameters to appropriate sections in the UI.
 
 API

--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,7 @@ API
 ---
 
 - Catalogue : Added `gaffer:isRendering` metadata, set to `True` if the viewed image is still receiving data from a display driver.
+- LRUCache : Added `getIfCached()` method.
 
 0.58.5.2 (relative to 0.58.5.1)
 ========

--- a/include/Gaffer/Private/IECorePreview/LRUCache.h
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.h
@@ -176,7 +176,7 @@ class LRUCache : private boost::noncopyable
 			//
 			// - Uncached : A boost::blank instance
 			// - Cached : The Value itself
-			// - Failed ; The exception thrown by the GetterFn
+			// - Failed : The exception thrown by the GetterFn
 			typedef boost::variant<boost::blank, Value, std::exception_ptr> State;
 
 			State state;

--- a/include/Gaffer/Private/IECorePreview/LRUCache.h
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.h
@@ -115,6 +115,10 @@ class LRUCache : private boost::noncopyable
 		/// Throws if the item can not be computed.
 		Value get( const GetterKey &key );
 
+		/// Retrieves an item from the cache if it has been computed or set
+		/// previously. Throws if a previous call to `get()` failed.
+		boost::optional<Value> getIfCached( const Key &key );
+
 		/// Adds an item to the cache directly, bypassing the GetterFunction.
 		/// Returns true for success and false on failure - failure can occur
 		/// if the cost exceeds the maximum cost for the cache. Note that even

--- a/include/Gaffer/Private/IECorePreview/LRUCache.inl
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.inl
@@ -460,14 +460,19 @@ class Parallel
 						{
 							if( !m_writable && mode == Insert && it->cacheEntry.status() == LRUCache::Uncached )
 							{
-								// We found an old item that doesn't have
-								// a value. This can either be because it
-								// was erased but hasn't been popped yet,
-								// or because the item was too big to fit
-								// in the cache. Upgrade to writer status
-								// so it can be updated in get().
-								m_itemLock.upgrade_to_writer();
-								m_writable = true;
+								// We found an old item that doesn't have a
+								// value. This can either be because it was
+								// erased but hasn't been popped yet, or because
+								// the item was too big to fit in the cache. We
+								// need to get writer status so it can be
+								// updated in `get()`, but we can't use the obvious
+								// `m_itemLock.upgrade_to_writer()` call as it can
+								// lead to deadlock. So we must retry using
+								// InsertWritable instead.
+								mode = InsertWritable;
+								m_itemLock.release();
+								binLock.release();
+								continue;
 							}
 							// Success!
 							m_item = &*it;
@@ -605,6 +610,8 @@ class Parallel
 
 		Bin &bin( const Key &key )
 		{
+			// Note : `testLRUCacheUncacheableItem()` requires keys to share
+			// a bin, and needs updating if the indexing strategy changes.
 			size_t binIndex = boost::hash<Key>()( key ) % m_bins.size();
 			return m_bins[binIndex];
 		};
@@ -832,13 +839,19 @@ class TaskParallel
 								mode == Insert && it->cacheEntry.status() == LRUCache::Uncached
 							)
 							{
-								// We found an old item that doesn't have
-								// a value. This can either be because it
-								// was erased but hasn't been popped yet,
-								// or because the item was too big to fit
-								// in the cache. Upgrade to writer status
-								// so it can be updated in get().
-								m_itemLock.upgradeToWriter();
+								// We found an old item that doesn't have a
+								// value. This can either be because it was
+								// erased but hasn't been popped yet, or because
+								// the item was too big to fit in the cache. We
+								// need to get writer status so it can be
+								// updated in `get()`, but we can't use the obvious
+								// `m_itemLock.upgradeToWriter()` call as it can
+								// lead to deadlock. So we must retry using
+								// InsertWritable instead.
+								mode = InsertWritable;
+								m_itemLock.release();
+								binLock.release();
+								continue;
 							}
 							// Success!
 							m_item = &*it;
@@ -980,6 +993,8 @@ class TaskParallel
 
 		Bin &bin( const Key &key )
 		{
+			// Note : `testLRUCacheUncacheableItem()` requires keys to share
+			// a bin, and needs updating if the indexing strategy changes.
 			size_t binIndex = boost::hash<Key>()( key ) % m_bins.size();
 			return m_bins[binIndex];
 		};

--- a/python/GafferTest/IECorePreviewTest/LRUCacheTest.py
+++ b/python/GafferTest/IECorePreviewTest/LRUCacheTest.py
@@ -195,5 +195,17 @@ class LRUCacheTest( GafferTest.TestCase ) :
 
 		GafferTest.testLRUCacheUncacheableItem( "taskParallel" )
 
+	def testGetIfCachedSerial( self ) :
+
+		GafferTest.testLRUCacheGetIfCached( "serial" )
+
+	def testGetIfCachedParallel( self ) :
+
+		GafferTest.testLRUCacheGetIfCached( "parallel" )
+
+	def testGetIfCachedTaskParallel( self ) :
+
+		GafferTest.testLRUCacheGetIfCached( "taskParallel" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/IECorePreviewTest/LRUCacheTest.py
+++ b/python/GafferTest/IECorePreviewTest/LRUCacheTest.py
@@ -183,5 +183,17 @@ class LRUCacheTest( GafferTest.TestCase ) :
 
 		GafferTest.testLRUCacheCancellation( "taskParallel" )
 
+	def testUncacheableItemSerial( self ) :
+
+		GafferTest.testLRUCacheUncacheableItem( "serial" )
+
+	def testUncacheableItemParallel( self ) :
+
+		GafferTest.testLRUCacheUncacheableItem( "parallel" )
+
+	def testUncacheableItemTaskParallel( self ) :
+
+		GafferTest.testLRUCacheUncacheableItem( "taskParallel" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferTestModule/LRUCacheTest.cpp
+++ b/src/GafferTestModule/LRUCacheTest.cpp
@@ -608,6 +608,66 @@ void testLRUCacheCancellation( const std::string &policy )
 	DispatchTest<TestLRUCacheCancellation>()( policy );
 }
 
+// This test exposes a potential source of bugs when some items
+// are too big to store in the cache, and their getter recurses
+// to pull another item from the cache. This leads to `Handle::acquire`
+// taking an optimistic read lock on the item, only to find it
+// is uncached and the lock must be upgraded to a writer. If multiple
+// threads do this at once, and we are not careful, deadlock can
+// ensue.
+template<template<typename> class Policy>
+struct TestLRUCacheUncacheableItem
+{
+
+	void operator()()
+	{
+		using Cache = IECorePreview::LRUCache<int, int, Policy>;
+		using CachePtr = std::unique_ptr<Cache>;
+
+		CachePtr cache;
+		cache.reset(
+			new Cache(
+				[&cache]( int key, size_t &cost ) {
+					if( key == 0 )
+					{
+						// Too big to cache
+						cost = std::numeric_limits<size_t>::max();
+						// Recursive call to cache, with new key chosen to require
+						// the same bin as this key.
+						return cache->get( key + tbb::tbb_thread::hardware_concurrency() );
+					}
+					else
+					{
+						cost = 1;
+						return key;
+					}
+				},
+				1000
+			)
+		);
+
+		for( int i = 0; i < 10000; ++i )
+		{
+			cache->clear();
+			tbb::parallel_for(
+				tbb::blocked_range<size_t>( 0, 100 ),
+				[&]( const tbb::blocked_range<size_t> &r ) {
+					for( size_t i = r.begin(); i < r.end(); ++i )
+					{
+						cache->get( 0 );
+					}
+				}
+			);
+		}
+	}
+
+};
+
+void testLRUCacheUncacheableItem( const std::string &policy )
+{
+	DispatchTest<TestLRUCacheUncacheableItem>()( policy );
+}
+
 } // namespace
 
 void GafferTestModule::bindLRUCacheTest()
@@ -620,4 +680,5 @@ void GafferTestModule::bindLRUCacheTest()
 	def( "testLRUCacheClearFromGet", &testLRUCacheClearFromGet );
 	def( "testLRUCacheExceptions", &testLRUCacheExceptions );
 	def( "testLRUCacheCancellation", &testLRUCacheCancellation );
+	def( "testLRUCacheUncacheableItem", &testLRUCacheUncacheableItem );
 }

--- a/src/GafferTestModule/LRUCacheTest.cpp
+++ b/src/GafferTestModule/LRUCacheTest.cpp
@@ -668,6 +668,45 @@ void testLRUCacheUncacheableItem( const std::string &policy )
 	DispatchTest<TestLRUCacheUncacheableItem>()( policy );
 }
 
+template<template<typename> class Policy>
+struct TestLRUCacheGetIfCached
+{
+
+	void operator()()
+	{
+		using Cache = IECorePreview::LRUCache<int, int, Policy>;
+
+		Cache cache(
+			[]( int key, size_t &cost ) {
+				cost = 1;
+				return key;
+			},
+			1000
+		);
+
+		GAFFERTEST_ASSERT( !cache.getIfCached( 0 ) );
+		GAFFERTEST_ASSERT( !cache.getIfCached( 1 ) );
+
+		GAFFERTEST_ASSERTEQUAL( cache.get( 0 ), 0 );
+		cache.set( 1, 1, 1 );
+		GAFFERTEST_ASSERTEQUAL( cache.get( 1 ), 1 );
+
+		GAFFERTEST_ASSERTEQUAL( *cache.getIfCached( 0 ), 0 );
+		GAFFERTEST_ASSERTEQUAL( *cache.getIfCached( 1 ), 1 );
+
+		cache.erase( 0 );
+		GAFFERTEST_ASSERT( !cache.getIfCached( 0 ) );
+		GAFFERTEST_ASSERTEQUAL( *cache.getIfCached( 1 ), 1 );
+
+	}
+
+};
+
+void testLRUCacheGetIfCached( const std::string &policy )
+{
+	DispatchTest<TestLRUCacheGetIfCached>()( policy );
+}
+
 } // namespace
 
 void GafferTestModule::bindLRUCacheTest()
@@ -681,4 +720,5 @@ void GafferTestModule::bindLRUCacheTest()
 	def( "testLRUCacheExceptions", &testLRUCacheExceptions );
 	def( "testLRUCacheCancellation", &testLRUCacheCancellation );
 	def( "testLRUCacheUncacheableItem", &testLRUCacheUncacheableItem );
+	def( "testLRUCacheGetIfCached", &testLRUCacheGetIfCached );
 }


### PR DESCRIPTION
This fixes the bug reported in https://github.com/GafferHQ/gaffer/issues/4016. Since the fix involved introducing some potential overhead in the caching code, I also took the opportunity to review that and came up with a simple change that brings us out ahead in performance overall. The gory details are described in the commit log.