### PR TITLE
GLWidget : Handle exceptions during draw

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.57.7.x (relative to 0.57.7.5)
+========
+
+Fixes
+-----
+
+- Viewer : Fixed corruption of the GL stack and potential crash caused by exceptions thrown during draw.
+
 0.57.7.5 (relative to 0.57.7.4)
 ========
 

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -202,7 +202,10 @@ class GLWidget( GafferUI.Widget ) :
 		if self.__multisample:
 			GL.glEnable( GL.GL_MULTISAMPLE )
 
-		self._draw()
+		try :
+			self._draw()
+		except Exception as e :
+			IECore.msg( IECore.Msg.Level.Error, "GLWidget", str( e ) )
 
 class _GLGraphicsView( QtWidgets.QGraphicsView ) :
 

--- a/python/GafferUITest/GLWidgetTest.py
+++ b/python/GafferUITest/GLWidgetTest.py
@@ -153,5 +153,25 @@ class GLWidgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( b1.parent(), None )
 		self.assertEqual( b2.parent(), None )
 
+	def testDrawExceptionsHandled( self ) :
+
+		class TestWidget( GafferUI.GLWidget ) :
+
+			def _draw( self ) :
+				raise RuntimeError( "Draw Exception" )
+
+		w = GafferUI.Window( borderWidth = 10 )
+		g = TestWidget()
+		w.setChild( g )
+
+		with IECore.CapturingMessageHandler() as mh :
+			w.setVisible( True )
+			self.waitForIdle( 1000 )
+
+		self.assertEqual(
+			{ ( m.level, m.context, m.message ) for m in mh.messages },
+			{ ( IECore.Msg.Level.Error, "GLWidget", "Draw Exception" ) }
+		)
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
@johnhaddon This is the band-aid version that fixes both the stack corruption and potential subsequent crash for the issue reported by CS earlier.