### PR TITLE
SpreadsheetUI : Update scroller styling for Qt5.12

### DIFF
--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -689,7 +689,7 @@ _styleSheet = string.Template(
 	/* pragmatic compromise that was more readily achievable.                   */
 
 	QTabBar[gafferClass="GafferUI.SpreadsheetUI._SectionChooser"]::scroller {
-		width: 20px;
+		width: 40px;
 	}
 
 	QTabBar[gafferClass="GafferUI.SpreadsheetUI._SectionChooser"]::tear {


### PR DESCRIPTION
They seem to have changed the presentation of the `::scroller` subcontrol, so it now applies this width to the whole scroller rather than each individual button.