### PR TITLE
SetUI : Support plugs in Spreadsheet cells

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -22,8 +22,10 @@ Fixes
   - Fixed bug that prevented a spline from being promoted to a Box if it had a non-default number of points. This also affected the use of a spline as the input to an Expression.
 - LRUCache : Fixed bug which could cause hangs during scene generation (#4016).
 - ArnoldShader : Moved the toon shader's `rim_light_tint` and `aov_prefix` parameters to appropriate sections in the UI.
-- Spreadsheet : Fixed bug that caused sections to overflow the available space.
 - Attributes : Added support for loading `extraAttributes` values and connections from Gaffer 0.59 and above.
+- Spreadsheet :
+  - Fixed bug that caused sections to overflow the available space.
+  - Fixed bug that prevented Set Expression helper menu items from appearing when accessed from a Spreadsheet cell.
 
 API
 ---

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -136,6 +136,23 @@ def __setValue( plug, value, *unused ) :
 	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		plug.setValue( value )
 
+def __spreadsheetTargetNode( plug ) :
+
+	# Find the first node the plug's column is connected to
+	# if it is a spreadsheet cell.
+
+	cellPlug = plug.ancestor( Gaffer.Spreadsheet.CellPlug )
+
+	# Could be a user plug on a Spreadsheet node
+	if cellPlug is None :
+		return None
+
+	outputs = plug.node()[ "out" ][ cellPlug.getName() ].outputs()
+	if not outputs :
+		return None
+
+	return outputs[ 0 ].node()
+
 def __downstreamNodes( plug ) :
 
 	result = set()
@@ -195,6 +212,10 @@ def __setsPopupMenu( menuDefinition, plugValueWidget ) :
 			insertAt = (cursorPosition, cursorPosition)
 
 	node = plug.node()
+
+	if isinstance( node, Gaffer.Spreadsheet ) :
+		node = __spreadsheetTargetNode( plug ) or node
+
 	if isinstance( node, GafferScene.Filter ) :
 		nodes = __downstreamNodes( node["out"] )
 	else :

--- a/python/GafferUI/SpreadsheetUI/_Metadata.py
+++ b/python/GafferUI/SpreadsheetUI/_Metadata.py
@@ -208,7 +208,10 @@ def __defaultCellMetadata( plug, key ) :
 for key in [
 	"spreadsheet:columnLabel",
 	"plugValueWidget:type",
-	"presetsPlugValueWidget:allowCustom"
+	"presetsPlugValueWidget:allowCustom",
+	"ui:scene:acceptsSetName",
+	"ui:scene:acceptsSetNames",
+	"ui:scene:acceptsSetExpression"
 ] :
 
 	Gaffer.Metadata.registerValue(


### PR DESCRIPTION
Set expression helpers should now appear in the edit window context menu for applicable plugs when driven by a Spreadsheet column.