### PR TITLE
SpreadsheetUI : Support drop of values/plugs on to cells

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,11 @@ Features
   - Fewer unnecessary capsule invalidations, resulting in fewer interactive rendering updates.
   - Convenience.
 
+Improvements
+------------
+
+- Spreadsheet : Added support for plug drag and drop. Dropping a plug on a compatible cell will connect it to the cell's value plug.
+
 Fixes
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -12,7 +12,7 @@ Features
 Improvements
 ------------
 
-- Spreadsheet : Added support for plug drag and drop. Dropping a plug on a compatible cell will connect it to the cell's value plug.
+- Spreadsheet : Added support for drag and drop. Values and Plugs can be dragged from outside a Spreadsheet to a cell to set its value or connect to its value plug.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,7 @@ Fixes
 - PlugAlgo : Fixed metadata handling when promoting plugs which were themselves promoted from the constructor of a custom node.
 - NodeAlgo : Fixed corner case where a preset could be listed twice if it was specified by both `preset:<name>` and `presetNames`.
 - GafferUI : Fixed incorrect Tree/TableView horizontal header height.
+- Spreadsheet : Fixed bug that allowed values to be pasted onto plugs with inputs.
 
 API
 ---

--- a/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
+++ b/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
@@ -301,12 +301,8 @@ class ValueAdaptor :
 	@classmethod
 	def _canSet( cls, data, plug ) :
 
-		# Ensure we consider child plugs, eg: components of a V3fPlug
-		if Gaffer.MetadataAlgo.readOnly( plug ) :
+		if not cls._canSetKeyOrValue( plug ) :
 			return False
-		for p in Gaffer.Plug.RecursiveRange( plug ) :
-			if Gaffer.MetadataAlgo.getReadOnly( p ) :
-				return False
 
 		plugData = ValueAdaptor.get( plug )
 
@@ -361,9 +357,8 @@ class ValueAdaptor :
 
 		if Gaffer.Animation.isAnimated( plug ) :
 			curve = Gaffer.Animation.acquire( plug )
-			if not Gaffer.MetadataAlgo.readOnly( curve ) :
-				curve.addKey( Gaffer.Animation.Key( atTime, value, Gaffer.Animation.Type.Linear ) )
-		elif plug.settable() :
+			curve.addKey( Gaffer.Animation.Key( atTime, value, Gaffer.Animation.Type.Linear ) )
+		else :
 			plug.setValue( value )
 
 	@staticmethod
@@ -458,8 +453,11 @@ class FloatPlugValueAdaptor( ValueAdaptor ) :
 	@classmethod
 	def _canSet( cls, data, plug ) :
 
-		# FloatPlug.setValue will take care of this for us
-		return isinstance( data, ( IECore.FloatData, IECore.IntData ) )
+		# FloatPlug.setValue will take care conversion for us
+		if isinstance( data, ( IECore.FloatData, IECore.IntData ) ) :
+			return cls._canSetKeyOrValue( plug )
+
+		return ValueAdaptor._canSet( data, plug )
 
 ValueAdaptor.registerAdaptor( Gaffer.FloatPlug, FloatPlugValueAdaptor )
 
@@ -470,7 +468,7 @@ class StringPlugValueAdaptor( ValueAdaptor ) :
 
 		if isinstance( data, IECore.StringVectorData ) :
 			if len( data ) < 2 :
-				return True
+				return cls._canSetKeyOrValue( plug )
 
 		return ValueAdaptor._canSet( data, plug )
 
@@ -493,7 +491,7 @@ class StringVectorDataPlugValueAdaptor( ValueAdaptor ) :
 	def _canSet( cls, data, plug ) :
 
 		if isinstance( data, IECore.StringData ) :
-			return True
+			return cls._canSetKeyOrValue( plug )
 
 		return ValueAdaptor._canSet( data, plug )
 

--- a/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
+++ b/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
@@ -463,6 +463,50 @@ class FloatPlugValueAdaptor( ValueAdaptor ) :
 
 ValueAdaptor.registerAdaptor( Gaffer.FloatPlug, FloatPlugValueAdaptor )
 
+class StringPlugValueAdaptor( ValueAdaptor ) :
+
+	@classmethod
+	def _canSet( cls, data, plug ) :
+
+		if isinstance( data, IECore.StringVectorData ) :
+			if len( data ) < 2 :
+				return True
+
+		return ValueAdaptor._canSet( data, plug )
+
+	@classmethod
+	def _set( cls, data, plug, atTime ) :
+
+		if isinstance( data, IECore.StringVectorData ) :
+			if len( data ) == 1 :
+				data = IECore.StringData( data[ 0 ] )
+			else :
+				data = IECore.StringData( "" )
+
+		ValueAdaptor._set( data, plug, atTime )
+
+ValueAdaptor.registerAdaptor( Gaffer.StringPlug, StringPlugValueAdaptor )
+
+class StringVectorDataPlugValueAdaptor( ValueAdaptor ) :
+
+	@classmethod
+	def _canSet( cls, data, plug ) :
+
+		if isinstance( data, IECore.StringData ) :
+			return True
+
+		return ValueAdaptor._canSet( data, plug )
+
+	@classmethod
+	def _set( cls, data, plug, atTime ) :
+
+		if isinstance( data, IECore.StringData ) :
+			data = IECore.StringVectorData( [ data.value ] )
+
+		ValueAdaptor._set( data, plug, atTime )
+
+ValueAdaptor.registerAdaptor( Gaffer.StringVectorDataPlug, StringVectorDataPlugValueAdaptor )
+
 ## Allows RowPlugs to be copy/pasted across different column configurations,
 # matching by the column names.
 class RowPlugValueAdaptor( ValueAdaptor ) :

--- a/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
+++ b/python/GafferUI/SpreadsheetUI/_ClipboardAlgo.py
@@ -335,6 +335,25 @@ class ValueAdaptor :
 				cls._set( childData, plug[ childName ], atTime )
 
 	@staticmethod
+	def _canSetKeyOrValue( plug ) :
+
+		def settable( p ) :
+			if Gaffer.Animation.isAnimated( p ) :
+				curve = Gaffer.Animation.acquire( p )
+				return not Gaffer.MetadataAlgo.readOnly( curve )
+			else :
+				return p.settable()
+
+		# Ensure we consider child plugs, eg: components of a V3fPlug
+		if Gaffer.MetadataAlgo.readOnly( plug ) or not settable( plug ) :
+			return False
+		for p in Gaffer.Plug.RecursiveRange( plug ) :
+			if Gaffer.MetadataAlgo.getReadOnly( p ) :
+				return False
+
+		return True
+
+	@staticmethod
 	def _setOrKeyValue( plug, value, atTime ) :
 
 		if hasattr( value, 'value' ) :

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -424,6 +424,21 @@ class _PlugTableView( GafferUI.Widget ) :
 			with Gaffer.UndoScope( targetPlug.ancestor( Gaffer.ScriptNode ) ) :
 				targetPlug.setInput( sourcePlug )
 
+		index = self._qtWidget().model().indexForPlug( cellPlug )
+		selectionModel = self._qtWidget().selectionModel()
+		selectionModel.select( index, QtCore.QItemSelectionModel.ClearAndSelect )
+		selectionModel.setCurrentIndex( index, QtCore.QItemSelectionModel.ClearAndSelect )
+
+		# People regularly have spreadsheets in separate windows. Ensure the
+		# sheet has focus after drop has concluded. It will have returned to
+		# the origin of the drag.
+		def focusOnIdle() :
+			if not self._qtWidget().isActiveWindow() :
+				self._qtWidget().activateWindow()
+			self._qtWidget().setFocus()
+			return False
+
+		GafferUI.EventLoop.addIdleCallback( focusOnIdle )
 		return True
 
 	def __connectionPlugs( self, sourcePlug, targetPlug ) :

--- a/python/GafferUITest/SpreadsheetUITest.py
+++ b/python/GafferUITest/SpreadsheetUITest.py
@@ -752,5 +752,18 @@ class SpreadsheetUITest( GafferUITest.TestCase ) :
 		self.assertEqual( row["cells"][0]["value"].getValue(), 3 )
 		self.assertEqual( row["cells"][1]["value"]["value"].getValue(), 3 )
 
+	def testCantPasteWithConnections( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.IntPlug() )
+		s["rows"].addRow()
+
+		self.assertTrue( _ClipboardAlgo.canPasteCells( IECore.IntData( 1 ), [ s["rows"][1]["cells"].children() ] ) )
+
+		p = Gaffer.IntPlug()
+		s["rows"][1]["cells"][0]["value"].setInput( p )
+
+		self.assertFalse( _ClipboardAlgo.canPasteCells( IECore.IntData( 1 ), [ s["rows"][1]["cells"].children() ] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/SpreadsheetUITest.py
+++ b/python/GafferUITest/SpreadsheetUITest.py
@@ -705,6 +705,36 @@ class SpreadsheetUITest( GafferUITest.TestCase ) :
 		self.assertEqual( s["rows"][1]["cells"][0]["value"].getValue(), 2.0 )
 		self.assertEqual( s["rows"][1]["cells"][1]["value"].getValue(), 2 )
 
+	def testStringConversion( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.StringPlug() )
+		s["rows"].addColumn( Gaffer.StringVectorDataPlug( "v", defaultValue = IECore.StringVectorData() ) )
+		row = s["rows"].addRow()
+
+		bothColumns = [ s["rows"][1]["cells"].children() ]
+
+		data = IECore.StringData( "string" )
+		self.assertTrue( _ClipboardAlgo.canPasteCells( data, bothColumns ) )
+		_ClipboardAlgo.pasteCells( data, bothColumns, 0 )
+		self.assertEqual( s["rows"][1]["cells"][0]["value"].getValue(), "string" )
+		self.assertEqual( s["rows"][1]["cells"][1]["value"].getValue(), IECore.StringVectorData( [ "string" ] ) )
+
+		for data in (
+			IECore.StringVectorData( [] ),
+			IECore.StringVectorData( [ "one" ] )
+		) :
+			self.assertTrue( _ClipboardAlgo.canPasteCells( data, bothColumns ) )
+			_ClipboardAlgo.pasteCells( data, bothColumns, 0 )
+			self.assertEqual( s["rows"][1]["cells"][0]["value"].getValue(), data[0] if data else "" )
+			self.assertEqual( s["rows"][1]["cells"][1]["value"].getValue(), data )
+
+		data = IECore.StringVectorData( [ "one", "two" ] )
+		self.assertFalse( _ClipboardAlgo.canPasteCells( data, bothColumns ) )
+		self.assertTrue( _ClipboardAlgo.canPasteCells( data, [ [ s["rows"][1]["cells"][1] ] ] ) )
+		_ClipboardAlgo.pasteCells( data, [ [ s["rows"][1]["cells"][1] ] ], 0 )
+		self.assertEqual( s["rows"][1]["cells"][1]["value"].getValue(), data )
+
 	def testPasteBasicValues( self ) :
 
 		s = Gaffer.Spreadsheet()


### PR DESCRIPTION
There was some debate as to how drag/drop should interact with the sheet's selection. This option simply replaces the selection as appropriate target cells are hovered. This mimics the existing `setHighlighted` behaviours of other UI elements.

An alternative suggestion was to only apply the drop to the current selection. This would simplify setting the input to multiple cells at once, but make the case of setting a single cell harder as it would need to be selected first. 

We can always revisit this over time as
it is used more in practice.