### PR TITLE
Viewer : Better differentiate when an EditScope is in use

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Improvements
   - Added menu items to edit the values for all selected cells of the same type simultaneously.
   - Added menu items to the section chooser to quickly select a specific section.
 - Stats app : Added `-serialise` argument to measure the time taken to serialise the script.
+- Viewer : Improved highlighting of EditScope selector when an EditScope is active.
 
 Fixes
 -----

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -135,14 +135,19 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 	def _updateFromPlug( self ) :
 
 		editScope = self.__editScope()
+		editScopeActive = editScope is not None
 		self.__updateMenuButton( editScope )
-		self.__navigationMenuButton.setEnabled( editScope is not None )
-		if editScope is not None :
+		self.__navigationMenuButton.setEnabled( editScopeActive )
+		if editScopeActive :
 			self.__editScopeNameChangedConnection = editScope.nameChangedSignal().connect(
 				Gaffer.WeakMethod( self.__editScopeNameChanged ), scoped = True
 			)
 		else :
 			self.__editScopeNameChangedConnection = None
+
+		if self._qtWidget().property( "editScopeActive" ) != editScopeActive :
+			self._qtWidget().setProperty( "editScopeActive", GafferUI._Variant.toVariant( editScopeActive ) )
+			self._repolish()
 
 	def __updateMenuButton( self, editScope ) :
 

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1386,6 +1386,14 @@ _styleSheet = string.Template(
 		padding: 2px;
 	}
 
+	*[gafferClass="GafferUI.EditScopeUI.EditScopePlugValueWidget"][editScopeActive="true"] QPushButton[gafferWithFrame="true"][gafferMenuIndicator="true"]
+	{
+		border: 1px solid rgb( 46, 75, 107 );
+		border-top-color: rgb( 75, 113, 155 );
+		border-left-color: rgb( 75, 113, 155 );
+		background-color : qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgba( 69, 113, 161 ), stop: 0.1 rgb( 48, 99, 153 ), stop: 0.90 rgb( 54, 88, 125 ));
+	}
+
 	*[gafferClass="GafferSceneUI.InteractiveRenderUI._ViewRenderControlUI"] QPushButton[gafferWithFrame="true"] {
 		padding: 1px;
 	}


### PR DESCRIPTION
Updated Version:

![image](https://user-images.githubusercontent.com/896779/100903487-df045b00-34bd-11eb-9be0-8cd9f4f7d2e0.png)

Feedback from users is that the difference between `None` and an `EditScope` being used is too subtle for the relative change in tool behaviour.