### PR TITLE
Attributes : Change type of `extraAttributes` to CompoundObjectPlug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -45,6 +45,7 @@ Improvements
   - Added "Reset Default Values" item to NodeEditor tool menu. This sets the default values for all plugs from their current values.
   - Added "Reset Default Value" item to plug context menu. This sets the default value from the current value.
 - ImageReader : Added initial support for reading RAW files.
+- CustomAttributes : `extraAttributes` is now a CompoundObjectPlug, allowing it to define complex attribute values including shading networks.
 - GraphEditor : Improved performance slightly for large graphs.
 - Warp : Defaulted `useDerivatives` to off for nodes created via the UI. Using derivatives is only beneficial when the warp is highly anisotropic, and it has a significant performance impact.
 - CopyChannels : Improved performance for the special case of a single input.
@@ -132,6 +133,7 @@ Breaking Changes
 - ValuePlug : Added virtual method.
 - ValuePlugSerialiser : Removed support for `valuePlugSerialiser:resetParentPlugDefaults` context variable.
 - NameValuePlugValueWidget : Removed support for using the `Plug.Dynamic` flag to determine whether or not the `name` plug is shown. Use `nameValuePlugValueWidget:ignoreNamePlug` metadata instead.
+- Attributes : Changed type of `extraAttributes` plug from AtomicCompoundDataPlug to CompoundObjectPlug.
 - Light/Camera : Removed button for adding custom plugs in the "Visualisation" section.
 - Metadata : Removed compatibility for loading graph bookmarks created in versions prior to 0.33.0.0. Resave the file from Gaffer 0.58.0.0 to preserve the bookmarks if necessary.
 - RendererAlgo :

--- a/Changes.md
+++ b/Changes.md
@@ -102,6 +102,7 @@ API
 - ValuePlugSerialiser :
   - Added `valueRepr()` method.
   - Added support for `valuePlugSerialiser:omitParentNodePlugValues` context variable. This is used for exporting Boxes for referencing, and by ExtensionAlgo.
+- CompoundObjectPlug : AtomicCompoundDataPlugs are now accepted as inputs.
 - ImageAlgo : `tiles()` now returns a top level dictionary containing all the tileOrigins as a V2iVectorData, and each channel as an ObjectVectorData of channelDatas with corresponding indices. This allows `tiles()` to run substantially faster, more than twice as fast if the input network is very cheap.
 - ConfirmationDialogue : Added optional `details` constructor argument which accepts text to be shown in a collapsed "Details" section.
 - Node :

--- a/include/GafferScene/Attributes.h
+++ b/include/GafferScene/Attributes.h
@@ -62,8 +62,8 @@ class GAFFERSCENE_API Attributes : public AttributeProcessor
 		Gaffer::BoolPlug *globalPlug();
 		const Gaffer::BoolPlug *globalPlug() const;
 
-		Gaffer::AtomicCompoundDataPlug *extraAttributesPlug();
-		const Gaffer::AtomicCompoundDataPlug *extraAttributesPlug() const;
+		Gaffer::CompoundObjectPlug *extraAttributesPlug();
+		const Gaffer::CompoundObjectPlug *extraAttributesPlug() const;
 
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 

--- a/python/GafferSceneTest/CustomAttributesTest.py
+++ b/python/GafferSceneTest/CustomAttributesTest.py
@@ -370,6 +370,28 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 			} )
 		)
 
+	def testAssignShader( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["sphere"] = GafferScene.Sphere()
+		script["sphereFilter"] = GafferScene.PathFilter()
+		script["sphereFilter"]["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		attributes = IECore.CompoundObject( {
+			"ai:surface" : IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "flat" ) }, output = "output" )
+		} )
+
+		script["attributes"] = GafferScene.CustomAttributes()
+		script["attributes"]["in"].setInput( script["sphere"]["out"] )
+		script["attributes"]["filter"].setInput( script["sphereFilter"]["out"] )
+		script["attributes"]["extraAttributes"].setValue( attributes )
+		self.assertEqual( script["attributes"]["out"].attributes( "/sphere" ), attributes )
+
+		script2 = Gaffer.ScriptNode()
+		script2.execute( script.serialise() )
+		self.assertEqual( script2["attributes"]["out"].attributes( "/sphere" ), attributes )
+
 	def testDirtyPropagation( self ) :
 
 		attributes = GafferScene.CustomAttributes()

--- a/python/GafferSceneTest/scripts/extraAttributes-0.58.5.2.gfr
+++ b/python/GafferSceneTest/scripts/extraAttributes-0.58.5.2.gfr
@@ -1,0 +1,65 @@
+import Gaffer
+import GafferImage
+import GafferScene
+import IECore
+import imath
+
+Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 58, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 5, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 2, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.NameValuePlug( "image:catalogue:port", Gaffer.IntPlug( "value", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "imageCataloguePort", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+parent["variables"].addChild( Gaffer.NameValuePlug( "project:name", Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectName", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+parent["variables"].addChild( Gaffer.NameValuePlug( "project:rootDirectory", Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectRootDirectory", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format( 1920, 1080, 1.000 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["defaultFormat"] )
+__children["CustomAttributesWithExpression"] = GafferScene.CustomAttributes( "CustomAttributesWithExpression" )
+parent.addChild( __children["CustomAttributesWithExpression"] )
+__children["CustomAttributesWithExpression"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Sphere"] = GafferScene.Sphere( "Sphere" )
+parent.addChild( __children["Sphere"] )
+__children["Sphere"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["PathFilter"] = GafferScene.PathFilter( "PathFilter" )
+parent.addChild( __children["PathFilter"] )
+__children["PathFilter"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Expression"] = Gaffer.Expression( "Expression" )
+parent.addChild( __children["Expression"] )
+__children["Expression"]["__out"].addChild( Gaffer.AtomicCompoundDataPlug( "p0", direction = Gaffer.Plug.Direction.Out, defaultValue = IECore.CompoundData(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Expression"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["CustomAttributesWithValue"] = GafferScene.CustomAttributes( "CustomAttributesWithValue" )
+parent.addChild( __children["CustomAttributesWithValue"] )
+__children["CustomAttributesWithValue"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["CustomAttributesWithConnection"] = GafferScene.CustomAttributes( "CustomAttributesWithConnection" )
+parent.addChild( __children["CustomAttributesWithConnection"] )
+__children["CustomAttributesWithConnection"]["user"].addChild( Gaffer.AtomicCompoundDataPlug( "compoundData", defaultValue = IECore.CompoundData(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["CustomAttributesWithConnection"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"]["value"].setValue( 33728 )
+Gaffer.Metadata.registerValue( parent["variables"]["imageCataloguePort"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectName"]["name"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectRootDirectory"]["name"], 'readOnly', True )
+__children["CustomAttributesWithExpression"]["in"].setInput( __children["Sphere"]["out"] )
+__children["CustomAttributesWithExpression"]["filter"].setInput( __children["PathFilter"]["out"] )
+__children["CustomAttributesWithExpression"]["extraAttributes"].setInput( __children["Expression"]["__out"]["p0"] )
+__children["CustomAttributesWithExpression"]["__uiPosition"].setValue( imath.V2f( -24.9270096, 3.32281518 ) )
+__children["Sphere"]["__uiPosition"].setValue( imath.V2f( -2.77768087, 15.2868776 ) )
+__children["PathFilter"]["paths"].setValue( IECore.StringVectorData( [ '/sphere' ] ) )
+__children["PathFilter"]["__uiPosition"].setValue( imath.V2f( 23.5434246, 16.0048466 ) )
+__children["Expression"]["__uiPosition"].setValue( imath.V2f( -40.7513466, 3.32193732 ) )
+__children["CustomAttributesWithValue"]["in"].setInput( __children["Sphere"]["out"] )
+__children["CustomAttributesWithValue"]["filter"].setInput( __children["PathFilter"]["out"] )
+__children["CustomAttributesWithValue"]["extraAttributes"].setValue( IECore.CompoundData({'b':IECore.StringData( 'b' )}) )
+__children["CustomAttributesWithValue"]["__uiPosition"].setValue( imath.V2f( -2.77768087, 3.32281518 ) )
+__children["CustomAttributesWithConnection"]["user"]["compoundData"].setValue( IECore.CompoundData({'c':IECore.StringData( 'c' )}) )
+__children["CustomAttributesWithConnection"]["in"].setInput( __children["Sphere"]["out"] )
+__children["CustomAttributesWithConnection"]["filter"].setInput( __children["PathFilter"]["out"] )
+__children["CustomAttributesWithConnection"]["extraAttributes"].setInput( __children["CustomAttributesWithConnection"]["user"]["compoundData"] )
+__children["CustomAttributesWithConnection"]["__uiPosition"].setValue( imath.V2f( 20.4991722, 3.22281384 ) )
+__children["Expression"]["__engine"].setValue( 'python' )
+__children["Expression"]["__expression"].setValue( 'parent["__out"]["p0"] = IECore.CompoundData( {\n\t"a" : IECore.StringData( "a" )\n} )' )
+
+
+del __children
+

--- a/python/GafferSceneUI/AttributesUI.py
+++ b/python/GafferSceneUI/AttributesUI.py
@@ -94,10 +94,12 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			An additional set of attributes to be added. Arbitrary numbers
-			of attributes may be specified within a single IECore::CompoundData
-			object, where each key/value pair in the object defines an attribute.
+			of attributes may be specified within a single `IECore.CompoundObject`,
+			where each key/value pair in the object defines an attribute.
 			This is convenient when using an expression to define the attributes
-			and the attribute count might be dynamic.
+			and the attribute count might be dynamic. It can also be used to
+			create attributes whose type cannot be handled by the `attributes`
+			CompoundDataPlug, with `IECoreScene.ShaderNetwork` being one example.
 
 			If the same attribute is defined by both the attributes and the
 			extraAttributes plugs, then the value from the extraAttributes

--- a/python/GafferTest/TypedObjectPlugTest.py
+++ b/python/GafferTest/TypedObjectPlugTest.py
@@ -239,6 +239,13 @@ class TypedObjectPlugTest( GafferTest.TestCase ) :
 			)
 		)
 
+		v3 = IECore.CompoundObject( {
+			"a" : IECore.IntData( 10 ),
+			"b" : v1,
+			"c" : v2,
+			"d" : IECore.StringData( "test" ),
+		} )
+
 		with self.assertRaises( Exception ) :
 			eval( repr( v1 ) )
 
@@ -246,23 +253,29 @@ class TypedObjectPlugTest( GafferTest.TestCase ) :
 		s["n"] = Gaffer.Node()
 		s["n"]["user"]["p1"] = Gaffer.ObjectPlug( defaultValue = v1, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["n"]["user"]["p2"] = Gaffer.ObjectPlug( defaultValue = v2, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["user"]["p3"] = Gaffer.ObjectPlug( defaultValue = v3, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 		self.assertEqual( s2["n"]["user"]["p1"].defaultValue(), v1 )
 		self.assertEqual( s2["n"]["user"]["p2"].defaultValue(), v2 )
+		self.assertEqual( s2["n"]["user"]["p3"].defaultValue(), v3 )
 		self.assertEqual( s2["n"]["user"]["p1"].getValue(), v1 )
 		self.assertEqual( s2["n"]["user"]["p2"].getValue(), v2 )
+		self.assertEqual( s2["n"]["user"]["p3"].getValue(), v3 )
 
 		s["n"]["user"]["p1"].setValue( v2 )
-		s["n"]["user"]["p2"].setValue( v1 )
+		s["n"]["user"]["p2"].setValue( v3 )
+		s["n"]["user"]["p3"].setValue( v1 )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
 		self.assertEqual( s2["n"]["user"]["p1"].defaultValue(), v1 )
 		self.assertEqual( s2["n"]["user"]["p2"].defaultValue(), v2 )
+		self.assertEqual( s2["n"]["user"]["p3"].defaultValue(), v3 )
 		self.assertEqual( s2["n"]["user"]["p1"].getValue(), v2 )
-		self.assertEqual( s2["n"]["user"]["p2"].getValue(), v1 )
+		self.assertEqual( s2["n"]["user"]["p2"].getValue(), v3 )
+		self.assertEqual( s2["n"]["user"]["p3"].getValue(), v1 )
 
 	def testConnectCompoundDataToCompoundObject( self ) :
 

--- a/python/GafferTest/TypedObjectPlugTest.py
+++ b/python/GafferTest/TypedObjectPlugTest.py
@@ -264,5 +264,28 @@ class TypedObjectPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( s2["n"]["user"]["p1"].getValue(), v2 )
 		self.assertEqual( s2["n"]["user"]["p2"].getValue(), v1 )
 
+	def testConnectCompoundDataToCompoundObject( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["compoundData"] = Gaffer.AtomicCompoundDataPlug( defaultValue = IECore.CompoundData(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["user"]["compoundObject"] = Gaffer.CompoundObjectPlug( defaultValue = IECore.CompoundObject(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		self.assertTrue( s["n"]["user"]["compoundObject"].acceptsInput( s["n"]["user"]["compoundData"] ) )
+		self.assertFalse( s["n"]["user"]["compoundData"].acceptsInput( s["n"]["user"]["compoundObject"] ) )
+
+		s["n"]["user"]["compoundObject"].setInput( s["n"]["user"]["compoundData"] )
+		self.assertEqual( s["n"]["user"]["compoundObject"].getInput(), s["n"]["user"]["compoundData"] )
+		self.assertEqual( s["n"]["user"]["compoundObject"].getValue(), IECore.CompoundObject() )
+
+		s["n"]["user"]["compoundData"].setValue( IECore.CompoundData( { "a" : IECore.IntData( 10 ) } ) )
+		self.assertEqual( s["n"]["user"]["compoundObject"].getValue(), IECore.CompoundObject( { "a" : IECore.IntData( 10 ) } ) )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+		self.assertEqual( s2["n"]["user"]["compoundObject"].getInput(), s2["n"]["user"]["compoundData"] )
+		self.assertEqual( s2["n"]["user"]["compoundObject"].getValue(), IECore.CompoundObject( { "a" : IECore.IntData( 10 ) } ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/Attributes.cpp
+++ b/src/GafferScene/Attributes.cpp
@@ -211,10 +211,6 @@ IECore::ConstCompoundObjectPtr Attributes::computeProcessedAttributes( const Sce
 		return inputAttributes;
 	}
 
-	/// \todo You might think that we wouldn't have to check this again
-	/// because the base class would have used processesAttributes()
-	/// to avoid even calling this function. But that isn't the case for
-	/// some reason.
 	if( globalPlug()->getValue() )
 	{
 		return inputAttributes;

--- a/startup/GafferScene/attributesCompatibility.py
+++ b/startup/GafferScene/attributesCompatibility.py
@@ -1,0 +1,67 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import types
+
+import IECore
+import Gaffer
+import GafferScene
+
+# The `extraAttributes` plug used to be an AtomicCompoundDataPlug, but
+# now it is a CompoundObjectPlug. Here we monkey-patch `setValue()` so
+# that we can load old files containing CompoundData values.
+
+def __extraAttributesSetValue( self, value ) :
+
+	if isinstance( value, IECore.CompoundData ) :
+		value = IECore.CompoundObject( {
+			k : v for k, v in value.items()
+		} )
+
+	Gaffer.CompoundObjectPlug.setValue( self, value )
+
+def __attributesGetItem( originalGetItem ) :
+
+	def getItem( self, key ) :
+
+		result = originalGetItem( self, key )
+		if key == "extraAttributes" :
+			result.setValue = types.MethodType( __extraAttributesSetValue, result )
+		return result
+
+	return getItem
+
+GafferScene.Attributes.__getitem__ = __attributesGetItem( GafferScene.Attributes.__getitem__ )


### PR DESCRIPTION
This allows it to express the full range of possible attributes, including shader networks. The initial motivation is for @alex-savenko-at-cinesite to be able to use it to convert large shading node graphs into simple blobs on a CustomAttributes node at lookdev publish time. This provides a halfway house between fully dynamic and fully baked lookdev.

I'm a little uncomfortable with proposing this so close to the release of 0.59 (tomorrow, if all goes well). But I have included a unit test to cover the three backwards compatibility cases I could think of - `setValue( compoundData )`, `setInput( atomicCompoundDataPlug )` and expressions outputting CompoundData. Would welcome opinions from @andrewkaufman, @ivanimanishi and @alex-savenko-at-cinesite as to whether we should include this in 0.59 or save it for 0.60.