### PR TITLE
Require C++14

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.60.x.x
 ========
 
+Build
+-----
+
+- Moved minimum required C++ standard to C++14.
+
 0.59.0.0
 ========
 

--- a/SConstruct
+++ b/SConstruct
@@ -100,8 +100,8 @@ options.Add(
 
 options.Add(
 	"CXXSTD",
-	"The C++ standard to build against. A minimum of C++11 is required.",
-	"c++11",
+	"The C++ standard to build against. A minimum of C++14 is required.",
+	"c++14",
 )
 
 options.Add(

--- a/src/Gaffer/ParallelAlgo.cpp
+++ b/src/Gaffer/ParallelAlgo.cpp
@@ -40,8 +40,6 @@
 #include "Gaffer/Context.h"
 #include "Gaffer/Monitor.h"
 
-#include "boost/make_unique.hpp"
-
 #include <mutex>
 #include <stack>
 
@@ -102,7 +100,7 @@ GAFFER_API std::unique_ptr<BackgroundTask> ParallelAlgo::callOnBackgroundThread(
 	ContextPtr backgroundContext = new Context( *Context::current() );
 	Monitor::MonitorSet backgroundMonitors = Monitor::current();
 
-	return boost::make_unique<BackgroundTask>(
+	return std::make_unique<BackgroundTask>(
 
 		subject,
 

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -49,7 +49,6 @@
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/bind.hpp"
 #include "boost/container/flat_set.hpp"
-#include "boost/make_unique.hpp"
 
 #include "tbb/task.h"
 
@@ -1041,7 +1040,7 @@ RenderController::RenderController( const ConstScenePlugPtr &scene, const Gaffer
 	{
 		// We avoid light linking overhead for the GL renderer,
 		// because we know it doesn't support it.
-		m_lightLinks = boost::make_unique<LightLinks>();
+		m_lightLinks = std::make_unique<LightLinks>();
 	}
 
 	CompoundObjectPtr boundAttributes = new CompoundObject;

--- a/src/GafferTestModule/TaskMutexTest.cpp
+++ b/src/GafferTestModule/TaskMutexTest.cpp
@@ -43,8 +43,6 @@
 #include "Gaffer/Private/IECorePreview/ParallelAlgo.h"
 #include "Gaffer/Private/IECorePreview/TaskMutex.h"
 
-#include "boost/make_unique.hpp"
-
 #include "tbb/enumerable_thread_specific.h"
 #include "tbb/parallel_for.h"
 
@@ -207,7 +205,7 @@ void testTaskMutexJoiningOuterTasks()
 	std::vector<TaskMutexPtr> independentTasks;
 	for( size_t i = 0; i < tbb::tbb_thread::hardware_concurrency() * 1000; ++i )
 	{
-		independentTasks.push_back( boost::make_unique<TaskMutex>() );
+		independentTasks.push_back( std::make_unique<TaskMutex>() );
 	}
 
 	tbb::parallel_for(


### PR DESCRIPTION
This bumps our minimum build requirement to C++14, taking effect for the next major version, 0.60.0.0. This was the VFXPlatform mandated version since 2018, and is also required by USD 20.05. The VFXPlatform 2021 standard is C++17, so we're still being pretty conservative here.