### PR TITLE
Shader : support NameValuePlug parameters

### DIFF
--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -334,6 +334,45 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 				network.inputConnections( "n3" ),
 				[ network.Connection( network.Parameter( n, "", ), network.Parameter( "n3", "c" ) ) ]
 			)
+	
+	def testNameValuePlug( self ) :
+
+		s = GafferSceneTest.TestShader( "s" )
+		s["type"].setValue( "test:surface" )
+
+		# test value is included
+		network = s.attributes()["test:surface"]
+		self.assertIn( "nv", network.outputShader().parameters )
+
+		# test plug is disabled
+		s["parameters"]["nvPlug"]["enabled"].setValue( False )
+		network = s.attributes()["test:surface"]
+		self.assertNotIn( "nv", network.outputShader().parameters )
+
+		# test plug is enabled again
+		s["parameters"]["nvPlug"]["enabled"].setValue( True )
+		network = s.attributes()["test:surface"]
+		self.assertIn( "nv", network.outputShader().parameters )
+
+		# test shader network
+		n = GafferSceneTest.TestShader( "n" )
+		s["parameters"]["nvPlug"]["value"].setInput( n["out"] )
+		network = s.attributes()["test:surface"]
+		self.assertEqual( len( network ), 2 )
+		self.assertEqual(
+			network.inputConnections( "s" ),
+			[ network.Connection( network.Parameter( "n", "" ), network.Parameter( "s", "nv" ) ) ]
+		)
+
+		#test shader network disabled
+		s["parameters"]["nvPlug"]["enabled"].setValue( False )
+		network = s.attributes()["test:surface"]
+		self.assertEqual( len( network ), 1 )
+
+		#test NameValuePlug without switch
+		netowrk = s.attributes()["test:surface"]
+		self.assertIn( "nvNoSwitch", network.outputShader().parameters )
+	
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -61,6 +61,28 @@ def __parameterUserDefault( plug ) :
 		"userDefault"
 	)
 
+def __parameterNoduleType( plug ) :
+
+	if isinstance( plug, Gaffer.NameValuePlug ) :
+		return "GafferUI::CompoundNodule"
+	
+	return None
+
+def __nameValueParameterChildNoduleType( plug ) :
+
+	if isinstance( plug.parent(), Gaffer.NameValuePlug ) :
+		return ""
+	
+	return None
+
+def __nameValueParameterValueLabel( plug ) :
+
+	plugParent = plug.parent()
+	if isinstance( plugParent, Gaffer.NameValuePlug ) :
+		return plugParent["name"].getValue()
+	
+	return None
+
 Gaffer.Metadata.registerNode(
 
 	GafferScene.Shader,
@@ -133,6 +155,32 @@ Gaffer.Metadata.registerNode(
 
 			"userDefault", __parameterUserDefault,
 
+		],
+
+		"parameters.*" : [
+
+			# Set NameValuePlug parameters' nodule to CompoundNodule
+			"nodule:type", __parameterNoduleType
+		],
+
+		"parameters.*.name" : [
+
+			# Set the "name" plug nodule to hidden, only if
+			# it is a child of a NameValuePlug
+			"nodule:type", __nameValueParameterChildNoduleType
+		],
+
+		"parameters.*.enabled" : [
+
+			# Set the "enabled" plug nodule to hidden, only if
+			# it is a child of a NameValuePlug
+			"nodule:type", __nameValueParameterChildNoduleType
+		],
+
+		"parameters.*.value" : [
+
+			# Take the nodule label from the name plug
+			"noduleLayout:label", __nameValueParameterValueLabel
 		],
 
 		"out" : [

--- a/python/GafferSceneUITest/ShaderUITest.py
+++ b/python/GafferSceneUITest/ShaderUITest.py
@@ -36,6 +36,7 @@
 
 import IECore
 
+import Gaffer
 import GafferUI
 import GafferUITest
 import GafferSceneTest
@@ -56,6 +57,36 @@ class ShaderUITest( GafferUITest.TestCase ) :
 			n1.transformedBound( None ).center().y,
 			n2.transformedBound( None ).center().y
 		)
+	
+	def testNameValuePlugNodules( self ) :
+		s = GafferSceneTest.TestShader()
+
+		g = GafferUI.NodeGadget.create( s )
+		n1 = g.nodule( s["parameters"]["nvPlug"]["name"] )
+		n2 = g.nodule( s["parameters"]["nvPlug"]["enabled"] )
+		n3 = g.nodule( s["parameters"]["nvPlug"]["value"] )
+
+		self.assertEqual( 
+			Gaffer.Metadata.value( s["parameters"]["nvPlug"], "nodule:type" ),
+			"GafferUI::CompoundNodule"
+		)
+		self.assertEqual( 
+			Gaffer.Metadata.value( s["parameters"]["nvPlug"]["name"], "nodule:type" ),
+			""
+		)
+		self.assertEqual( 
+			Gaffer.Metadata.value( s["parameters"]["nvPlug"]["enabled"], "nodule:type" ),
+			""
+		)
+		self.assertEqual( 
+			Gaffer.Metadata.value( s["parameters"]["nvPlug"]["value"], "nodule:type" ),
+			None
+		)
+		self.assertEqual(
+			Gaffer.Metadata.value( s["parameters"]["nvPlug"]["value"], "noduleLayout:label" ),
+			"nv"
+		)
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneTest/TestShader.cpp
+++ b/src/GafferSceneTest/TestShader.cpp
@@ -38,6 +38,7 @@
 
 #include "Gaffer/CompoundNumericPlug.h"
 #include "Gaffer/StringPlug.h"
+#include "Gaffer/NameValuePlug.h"
 
 using namespace IECore;
 using namespace Gaffer;
@@ -57,6 +58,17 @@ TestShader::TestShader( const std::string &name )
 	addChild( new Color3fPlug( "out", Plug::Out ) );
 	parametersPlug()->addChild( new IntPlug( "i" ) );
 	parametersPlug()->addChild( new Color3fPlug( "c" ) );
+	parametersPlug()->addChild( new NameValuePlug( 
+		"nv", 
+		new Color3fPlug( "nvc" ),
+		true,
+		"nvPlug"
+	) );
+	parametersPlug()->addChild( new NameValuePlug( 
+		"nvNoSwitch", 
+		new Color3fPlug( "nvc" ),
+		"nvPlugNoSwitch"
+	) );
 }
 
 TestShader::~TestShader()


### PR DESCRIPTION
I'd like to propose adding support for NameValuePlug parameters for shaders. Particularly for my in-progress VRay extension, it would be very helpful to be able to enable and disable individual parameters and have them not show up in the computed attributes if they are disabled.

It seems to me to be a fairly straightforward addition to NetworkBuilder to swap in the "name" and "value" when walking the graph. I'm certainly open to discussion of better alternatives.

### Dependencies ###

None

### Breaking changes ###

I _think_ none. But I'm not familiar enough with the range of shaders to say with confidence.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
