### PR TITLE
Dynamic metadata promotion

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 - Viewer : Fixed bug that caused the Inspector to edit the wrong node when SetFilters were in use.
 - Widget : Fixed incorrect `ButtonEvent` coordinate origin for mouse signals under certain widget configurations.
 - PlugAlgo : Fixed metadata handling when promoting plugs which were themselves promoted from the constructor of a custom node.
+- NodeAlgo : Fixed corner case where a preset could be listed twice if it was specified by both `preset:<name>` and `presetNames`.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Fixes
 
 - Viewer : Fixed bug that caused the Inspector to edit the wrong node when SetFilters were in use.
 - Widget : Fixed incorrect `ButtonEvent` coordinate origin for mouse signals under certain widget configurations.
+- CatalogueSelect : Fixed broken presets for promoted `imageName` plugs.
 - PlugAlgo : Fixed metadata handling when promoting plugs which were themselves promoted from the constructor of a custom node.
 - NodeAlgo : Fixed corner case where a preset could be listed twice if it was specified by both `preset:<name>` and `presetNames`.
 

--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Fixes
 
 - Viewer : Fixed bug that caused the Inspector to edit the wrong node when SetFilters were in use.
 - Widget : Fixed incorrect `ButtonEvent` coordinate origin for mouse signals under certain widget configurations.
+- PlugAlgo : Fixed metadata handling when promoting plugs which were themselves promoted from the constructor of a custom node.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,10 @@ API
 - PlugAlgo :
   - `extraDataFromPlug()` now supports M33fPlug and M33fVectorDataPlug.
   - `promote()` allows metadata to be excluded from promotion by registering a `<metadataName>:promotable` metadata value of `false`.
+- NodeAlgo : If an input plug does not have presets of its own, it now inherits them from its first output. This is particularly useful
+  when promoting plugs which have dynamic presets which are computed on demand. Previously the presets would have been baked in
+  to the promoted plug, but by preventing promotion using `presetNames:promotable = false` and `presetValues:promotable = false`
+  the promoted plug can continue to use the dynamic presets.
 - MetadataAlgo :
   - Added `copyIf()` function, to copy metadata matching an arbitrary predicate.
   - Deprecated the complex form of `copy()` in favour of a simpler overload and the new `copyIf()` function.

--- a/Changes.md
+++ b/Changes.md
@@ -20,8 +20,10 @@ API
 ---
 
 - M33fVectorDataPlug : Added new plug type for specifying arrays of 3x3 matrices.
-- PlugAlgo : `extraDataFromPlug()` now supports M33fPlug and M33fVectorDataPlug.
 - FilterPlug : Added `match` method to evaluate the filter for the specified `ScenePlug`.
+- PlugAlgo :
+  - `extraDataFromPlug()` now supports M33fPlug and M33fVectorDataPlug.
+  - `promote()` allows metadata to be excluded from promotion by registering a `<metadataName>:promotable` metadata value of `false`.
 - MetadataAlgo :
   - Added `copyIf()` function, to copy metadata matching an arbitrary predicate.
   - Deprecated the complex form of `copy()` in favour of a simpler overload and the new `copyIf()` function.

--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,9 @@ API
 - M33fVectorDataPlug : Added new plug type for specifying arrays of 3x3 matrices.
 - PlugAlgo : `extraDataFromPlug()` now supports M33fPlug and M33fVectorDataPlug.
 - FilterPlug : Added `match` method to evaluate the filter for the specified `ScenePlug`.
+- MetadataAlgo :
+  - Added `copyIf()` function, to copy metadata matching an arbitrary predicate.
+  - Deprecated the complex form of `copy()` in favour of a simpler overload and the new `copyIf()` function.
 
 0.59.0.0
 ========

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -134,8 +134,8 @@ GAFFER_API Node *getNumericBookmark( ScriptNode *script, int bookmark );
 GAFFER_API int numericBookmark( const Node *node );
 GAFFER_API bool numericBookmarkAffectedByChange( const IECore::InternedString &changedKey );
 
-/// Utilities
-/// =========
+/// Change queries
+/// ==============
 
 /// Determines if a metadata value change (as signalled by `Metadata::plugValueChangedSignal()`
 /// or `Metadata:nodeValueChangedSignal()`) affects a given plug or node.
@@ -147,6 +147,9 @@ GAFFER_API bool childAffectedByChange( const GraphComponent *parent, IECore::Typ
 /// As above, but determines if any ancestor will be affected.
 GAFFER_API bool ancestorAffectedByChange( const Plug *plug, IECore::TypeId changedTypeId, const IECore::StringAlgo::MatchPattern &changedPlugPath, const Gaffer::Plug *changedPlug );
 GAFFER_API bool ancestorAffectedByChange( const GraphComponent *graphComponent, IECore::TypeId changedNodeTypeId, const Gaffer::Node *changedNode );
+
+/// Copying
+/// =======
 
 /// Copies metadata from one target to another. The exclude pattern is used with StringAlgo::matchMultiple().
 /// \undoable

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -151,8 +151,15 @@ GAFFER_API bool ancestorAffectedByChange( const GraphComponent *graphComponent, 
 /// Copying
 /// =======
 
-/// Copies metadata from one target to another. The exclude pattern is used with StringAlgo::matchMultiple().
+/// Copies metadata from one target to another.
 /// \undoable
+/// \todo Default `persistent` to true after removing the deprecated overload below.
+GAFFER_API void copy( const GraphComponent *from, GraphComponent *to, bool persistent );
+/// As above, but skipping items where `predicate( const GraphComponent *from, const GraphComponent *to, name )` returns false.
+/// \undoable
+template<typename Predicate>
+void copyIf( const GraphComponent *from, GraphComponent *to, Predicate &&predicate, bool persistent = true );
+/// \deprecated Either use the simpler version of `copy()`, or use `copyIf()` to implement exclusions.
 GAFFER_API void copy( const GraphComponent *from, GraphComponent *to, const IECore::StringAlgo::MatchPattern &exclude = "", bool persistentOnly = true, bool persistent = true );
 
 /// Copy nodule and noodle color meta data from srcPlug to dstPlug
@@ -162,5 +169,7 @@ GAFFER_API void copyColors( const Gaffer::Plug *srcPlug, Gaffer::Plug *dstPlug, 
 } // namespace MetadataAlgo
 
 } // namespace Gaffer
+
+#include "Gaffer/MetadataAlgo.inl"
 
 #endif // GAFFER_METADATAALGO_H

--- a/include/Gaffer/MetadataAlgo.inl
+++ b/include/Gaffer/MetadataAlgo.inl
@@ -1,0 +1,75 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_METADATAALGO_INL
+#define GAFFER_METADATAALGO_INL
+
+#include "Gaffer/GraphComponent.h"
+#include "Gaffer/Metadata.h"
+
+namespace Gaffer
+{
+
+namespace MetadataAlgo
+{
+
+template<typename Predicate>
+void copyIf( const GraphComponent *from, GraphComponent *to, Predicate &&predicate, bool persistent )
+{
+	std::vector<IECore::InternedString> names;
+	Metadata::registeredValues( from, names, /* instanceOnly = */ false, /* persistentOnly = */ false );
+	for( const auto &name : names )
+	{
+		if( predicate( from, const_cast<const GraphComponent *>( to ), name ) )
+		{
+			Metadata::registerValue( to, name, Metadata::value<IECore::Data>( from, name ), persistent );
+		}
+	}
+
+	for( const auto &child : from->children() )
+	{
+		if( auto childTo = to->getChild( child->getName() ) )
+		{
+			copyIf( child.get(), childTo, predicate, persistent );
+		}
+	}
+}
+
+} // namespace MetadataAlgo
+
+} // namespace Gaffer
+
+#endif // GAFFER_METADATAALGO_INL

--- a/include/Gaffer/PlugAlgo.h
+++ b/include/Gaffer/PlugAlgo.h
@@ -74,14 +74,13 @@ GAFFER_API IECore::DataPtr extractDataFromPlug( const ValuePlug *plug );
 /// Returns true if a call to `promote( plug, parent )` would
 /// succeed, false otherwise.
 GAFFER_API bool canPromote( const Plug *plug, const Plug *parent = nullptr );
-/// Promotes an internal plug, returning the newly created
-/// external plug. By default the external plug is parented
-/// directly to the node, but the `parent` argument
-/// may specify a plug on that node to be used as parent
-/// instead. By default, all metadata values except those
-/// related to plug layouts are copied to the external
-/// plug - this can be controlled with the `excludeMetadata`
-/// argument.
+/// Promotes an internal plug, returning the newly created external plug. By
+/// default the external plug is parented directly to the node, but the `parent`
+/// argument may specify a plug on that node to be used as parent instead.
+/// Metadata is copied to the promoted plug, but copying can be disabled
+/// by registering `"<metadataName>:promotable"` metadata with a value of `false`.
+/// The `excludeMetadata` argument provides a secondary mechaniscm for the caller
+/// to explicitly exclude other metadata from promotion.
 /// \undoable
 GAFFER_API Plug *promote( Plug *plug, Plug *parent = nullptr, const IECore::StringAlgo::MatchPattern &excludeMetadata = "layout:*" );
 /// As `promote` but by providing the name argument, you can skip an additional

--- a/include/Gaffer/Reference.h
+++ b/include/Gaffer/Reference.h
@@ -73,8 +73,6 @@ class GAFFER_API Reference : public SubGraph
 		bool isReferencePlug( const Plug *plug ) const;
 		void transferEditedMetadata( const Plug *srcPlug, Plug *dstPlug ) const;
 
-		void convertPersistentMetadata( Plug *plug ) const;
-
 		std::string m_fileName;
 		ReferenceLoadedSignal m_referenceLoadedSignal;
 

--- a/python/Gaffer/NodeAlgo.py
+++ b/python/Gaffer/NodeAlgo.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import collections
+
 import Gaffer
 
 # Import C++ bindings
@@ -55,17 +57,7 @@ from Gaffer._NodeAlgo import *
 # and the available presets will vary from instance to instance of a node.
 def presets( plug ) :
 
-	result = []
-	for n in Gaffer.Metadata.registeredValues( plug ) :
-		if n.startswith( "preset:" ) :
-			result.append( n[7:] )
-
-	presetNames = Gaffer.Metadata.value( plug, "presetNames" )
-	if presetNames :
-		toOmit = set( result )
-		result.extend( [ n for n in presetNames if n not in toOmit ] )
-
-	return result
+	return list( __presets( plug ).keys() )
 
 ## Returns the name of the preset currently applied to the plug.
 # Returns None if no preset is applied.
@@ -75,33 +67,43 @@ def currentPreset( plug ) :
 		return None
 
 	value = plug.getValue()
-	failedNames = set()
-	for n in Gaffer.Metadata.registeredValues( plug ) :
-		if n.startswith( "preset:" ) :
-			presetName = n[7:]
-			if Gaffer.Metadata.value( plug, n ) == value :
-				return presetName
-			else :
-				failedNames.add( presetName )
-
-	presetNames = Gaffer.Metadata.value( plug, "presetNames" )
-	if presetNames is not None :
-		for presetName, presetValue in zip( presetNames, Gaffer.Metadata.value( plug, "presetValues" ) ) :
-			if value == presetValue and presetName not in failedNames :
-				return presetName
+	for presetName, presetValue in __presets( plug ).items() :
+		if value == presetValue :
+			return presetName
 
 	return None
 
 ## Applies the named preset to the plug.
 def applyPreset( plug, presetName ) :
 
-	value = Gaffer.Metadata.value( plug, "preset:" + presetName )
-	if value is None :
-		presetNames = Gaffer.Metadata.value( plug, "presetNames" )
-		presetValues = Gaffer.Metadata.value( plug, "presetValues" )
-		value = presetValues[presetNames.index( presetName )]
+	plug.setValue( __presets( plug )[presetName] )
 
-	plug.setValue( value )
+def __presets( plug ) :
+
+	result = collections.OrderedDict()
+
+	for n in Gaffer.Metadata.registeredValues( plug ) :
+		if n.startswith( "preset:" ) :
+			result[n[7:]] = Gaffer.Metadata.value( plug, n )
+
+	presetNames = Gaffer.Metadata.value( plug, "presetNames" )
+	presetValues = Gaffer.Metadata.value( plug, "presetValues" )
+	if presetNames and presetValues :
+		for presetName, presetValue in zip( presetNames, presetValues ) :
+			result.setdefault( presetName, presetValue )
+
+	if result :
+		return result
+
+	# No presets from this plug. See if we can "inherit" them
+	# from a connected plug.
+
+	if plug.direction() == plug.Direction.In :
+		plug = next( iter( plug.outputs() ), None )
+		if plug is not None :
+			return __presets( plug )
+
+	return result
 
 ##########################################################################
 # User defaults

--- a/python/Gaffer/NodeAlgo.py
+++ b/python/Gaffer/NodeAlgo.py
@@ -60,7 +60,10 @@ def presets( plug ) :
 		if n.startswith( "preset:" ) :
 			result.append( n[7:] )
 
-	result.extend( Gaffer.Metadata.value( plug, "presetNames" ) or [] )
+	presetNames = Gaffer.Metadata.value( plug, "presetNames" )
+	if presetNames :
+		toOmit = set( result )
+		result.extend( [ n for n in presetNames if n not in toOmit ] )
 
 	return result
 

--- a/python/GafferImageUI/CatalogueSelectUI.py
+++ b/python/GafferImageUI/CatalogueSelectUI.py
@@ -73,6 +73,10 @@ Gaffer.Metadata.registerNode(
 
 			"presetNames", __imagePresetNames,
 			"presetValues", __imagePresetValues,
+			# Don't promote presets so they are still computed dynamically for
+			# the promoted plug rather than being baked.
+			"presetNames:promotable", False,
+			"presetValues:promotable", False,
 
 		]
 	}

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -373,6 +373,14 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 		for k in Gaffer.Metadata.registeredValues( t ) :
 			self.assertEqual( Gaffer.Metadata.value( t, k ), Gaffer.Metadata.value( s, k ) )
 
+		t = Gaffer.Node()
+		Gaffer.MetadataAlgo.copyIf( s, t, lambda f, t, n : n.startswith( "a" ) )
+		self.assertEqual( registeredTestValues( t ), { "a", "a2" } )
+
+		t = Gaffer.Node()
+		Gaffer.MetadataAlgo.copyIf( s, t, lambda f, t, n : n.startswith( "c" ) )
+		self.assertEqual( registeredTestValues( t ), { "c" } )
+
 	def testCopyColorKeepExisting( self ) :
 
 		plug1 = Gaffer.IntPlug()

--- a/python/GafferTest/NodeAlgoTest.py
+++ b/python/GafferTest/NodeAlgoTest.py
@@ -209,6 +209,33 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 		self.assertEqual( node["op1"].getValue(), 10 )
 		self.assertEqual( Gaffer.NodeAlgo.currentPreset( node["op1"] ), "c" )
 
+	def testConnectedPresets( self ) :
+
+		box = Gaffer.Box()
+		box["n"] = GafferTest.AddNode()
+		p = Gaffer.PlugAlgo.promote( box["n"]["op1"] )
+
+		self.assertEqual( Gaffer.NodeAlgo.presets( p ), [] )
+		self.assertEqual( Gaffer.NodeAlgo.presets( box["n"]["op1"] ), [] )
+
+		Gaffer.Metadata.registerValue( box["n"]["op1"], "preset:a", 10 )
+		self.assertEqual( Gaffer.NodeAlgo.presets( box["n"]["op1"] ), [ "a" ] )
+		self.assertEqual( Gaffer.NodeAlgo.presets( p ), [ "a" ] )
+
+		Gaffer.Metadata.registerValue( box["n"]["op1"], "presetNames", IECore.StringVectorData( [ "b" ] ) )
+		Gaffer.Metadata.registerValue( box["n"]["op1"], "presetValues", IECore.IntVectorData( [ 20 ] ) )
+		self.assertEqual( Gaffer.NodeAlgo.presets( box["n"]["op1"] ), [ "a", "b" ] )
+		self.assertEqual( Gaffer.NodeAlgo.presets( p ), [ "a", "b" ] )
+
+		self.assertEqual( Gaffer.NodeAlgo.currentPreset( p ), None )
+		Gaffer.NodeAlgo.applyPreset( p, "a" )
+		self.assertEqual( Gaffer.NodeAlgo.currentPreset( p ), "a" )
+		self.assertEqual( p.getValue(), 10 )
+
+		Gaffer.NodeAlgo.applyPreset( p, "b" )
+		self.assertEqual( Gaffer.NodeAlgo.currentPreset( p ), "b" )
+		self.assertEqual( p.getValue(), 20 )
+
 	def __visitationGraph( self ) :
 
 		# L1_1     L1_2

--- a/python/GafferTest/NodeAlgoTest.py
+++ b/python/GafferTest/NodeAlgoTest.py
@@ -202,6 +202,7 @@ class NodeAlgoTest( GafferTest.TestCase ) :
 		# a preset registered individually should take precedence
 
 		Gaffer.Metadata.registerValue( node["op1"], "preset:c", 10 )
+		self.assertEqual( Gaffer.NodeAlgo.presets( node["op1"] ), [ "c", "a", "b" ] )
 		self.assertEqual( Gaffer.NodeAlgo.currentPreset( node["op1"] ), None )
 
 		Gaffer.NodeAlgo.applyPreset( node["op1"], "c" )

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -597,5 +597,27 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script2["box"]["in"] ) )
 		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script2["box"]["in"], persistentOnly = True ) )
 
+	def testPromotableMetadata( self ) :
+
+		box = Gaffer.Box()
+		box["n"] = Gaffer.Node()
+		box["n"]["user"]["p"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		Gaffer.Metadata.registerValue( box["n"]["user"]["p"], "a", 10 )
+		Gaffer.Metadata.registerValue( box["n"]["user"]["p"], "b", 20 )
+		Gaffer.Metadata.registerValue( box["n"]["user"]["p"], "b:promotable", False )
+		Gaffer.Metadata.registerValue( box["n"]["user"]["p"], "c", 30 )
+		Gaffer.Metadata.registerValue( box["n"]["user"]["p"], "c:promotable", True )
+
+		p = Gaffer.PlugAlgo.promote( box["n"]["user"]["p"] )
+		self.assertEqual( Gaffer.Metadata.value( p, "a" ), 10 )
+		self.assertIsNone( Gaffer.Metadata.value( p, "b" ) )
+		self.assertIsNone( Gaffer.Metadata.value( p, "b:promotable" ) )
+		self.assertNotIn( "b", Gaffer.Metadata.registeredValues( p ) )
+		self.assertNotIn( "b:promotable", Gaffer.Metadata.registeredValues( p ) )
+		self.assertEqual( Gaffer.Metadata.value( p, "c" ), 30 )
+		self.assertIsNone( Gaffer.Metadata.value( p, "b:promotable" ) )
+		self.assertNotIn( "c:promotable", Gaffer.Metadata.registeredValues( p ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -44,6 +44,12 @@ import GafferTest
 
 class PlugAlgoTest( GafferTest.TestCase ) :
 
+	def tearDown( self ) :
+
+		GafferTest.TestCase.tearDown( self )
+
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "op1", "plugAlgoTest:a" )
+
 	def testPromote( self ) :
 
 		s = Gaffer.ScriptNode()
@@ -543,6 +549,53 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		s2.execute( s.serialise() )
 
 		self.assertEqual( len( s2["b"]["n"]["user"]["p"]["c"] ), 3 )
+
+	class AddTen( Gaffer.Node ) :
+
+		def __init__( self, name = "AddTen" ) :
+
+			Gaffer.Node.__init__( self, name )
+
+			self["__add"] = GafferTest.AddNode()
+			self["__add"]["op2"].setValue( 10 )
+
+			Gaffer.PlugAlgo.promoteWithName( self["__add"]["op1"], "in" )
+			Gaffer.PlugAlgo.promoteWithName( self["__add"]["sum"], "out" )
+
+	IECore.registerRunTimeTyped( AddTen )
+
+	def testPromoteInNodeConstructor( self ) :
+
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "op1", "plugAlgoTest:a", "a" )
+
+		script = Gaffer.ScriptNode()
+		script["box"] = Gaffer.Box()
+		script["box"]["n"] = self.AddTen()
+
+		# We want the metadata from the AddNode to have been promoted, but registered
+		# as non-persistent so that it won't be serialised unnecessarily.
+
+		self.assertEqual( Gaffer.Metadata.value( script["box"]["n"]["in"], "plugAlgoTest:a" ), "a" )
+		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script["box"]["n"]["in"] ) )
+		self.assertNotIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script["box"]["n"]["in"], persistentOnly = True ) )
+
+		# And if we promote up one more level, we want that to work, and we want the
+		# new metadata to be persistent so that it will be serialised and restored.
+
+		Gaffer.PlugAlgo.promote( script["box"]["n"]["in"] )
+		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script["box"]["in"] ) )
+		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script["box"]["in"], persistentOnly = True ) )
+
+		# After serialisation and loading, everything should look the same.
+
+		script2 = Gaffer.ScriptNode()
+		script2.execute( script.serialise() )
+
+		self.assertEqual( Gaffer.Metadata.value( script2["box"]["n"]["in"], "plugAlgoTest:a" ), "a" )
+		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script2["box"]["n"]["in"] ) )
+		self.assertNotIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script2["box"]["n"]["in"], persistentOnly = True ) )
+		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script2["box"]["in"] ) )
+		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script2["box"]["in"], persistentOnly = True ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/RampPlugValueWidget.py
+++ b/python/GafferUI/RampPlugValueWidget.py
@@ -60,15 +60,6 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 				drawModeWidget.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__drawModeChanged ), scoped = False )
 
 				GafferUI.Spacer( imath.V2i( 0 ), parenting = { "expand" : True } )
-
-				# TODO: Since we don't have a good way to register metadata on child plugs, we just write the
-				# metadata on this child plug right before constructing a widget for it.  There should probably
-				# be some way to do this genericly during initialization
-				Gaffer.Metadata.registerValue( plug['interpolation'],
-					"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget", persistent=False )
-				for name, value in sorted( Gaffer.SplineDefinitionInterpolation.names.items() ):
-					Gaffer.Metadata.registerValue( plug['interpolation'], "preset:" + name, value, persistent=False )
-
 				GafferUI.PlugWidget( GafferUI.PlugValueWidget.create( plug["interpolation"] ) )
 
 			self.__splineWidget = GafferUI.SplineWidget()

--- a/python/GafferUI/SplinePlugValueWidget.py
+++ b/python/GafferUI/SplinePlugValueWidget.py
@@ -89,9 +89,12 @@ class SplinePlugValueWidget( GafferUI.PlugValueWidget ) :
 			_SplinePlugValueDialogue.acquire( self.getPlug() )
 			return True
 
-GafferUI.PlugValueWidget.registerType( Gaffer.SplineffPlug, SplinePlugValueWidget )
-GafferUI.PlugValueWidget.registerType( Gaffer.SplinefColor3fPlug, SplinePlugValueWidget )
-GafferUI.PlugValueWidget.registerType( Gaffer.SplinefColor4fPlug, SplinePlugValueWidget )
+for plugType in ( Gaffer.SplineffPlug, Gaffer.SplinefColor3fPlug, Gaffer.SplinefColor4fPlug ) :
+
+	GafferUI.PlugValueWidget.registerType( plugType, SplinePlugValueWidget )
+	Gaffer.Metadata.registerValue( plugType, "interpolation", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
+	for name, value in sorted( Gaffer.SplineDefinitionInterpolation.names.items() ):
+		Gaffer.Metadata.registerValue( plugType, "interpolation", "preset:" + name, value )
 
 ## \todo See comments for `ColorSwatchPlugValueWidget._ColorPlugValueDialogue`.
 # I think the best approach is probably to move the `acquire()` mechanism to the

--- a/src/Gaffer/MetadataAlgo.cpp
+++ b/src/Gaffer/MetadataAlgo.cpp
@@ -463,6 +463,15 @@ bool affectedByChange( const Node *node, IECore::TypeId changedNodeTypeId, const
 	return node->isInstanceOf( changedNodeTypeId );
 }
 
+void copy( const GraphComponent *from, GraphComponent *to, bool persistent )
+{
+	copyIf(
+		from, to,
+		[]( const GraphComponent *, const GraphComponent *, InternedString ) { return true; },
+		persistent
+	);
+}
+
 void copy( const GraphComponent *from, GraphComponent *to, const IECore::StringAlgo::MatchPattern &exclude, bool persistentOnly, bool persistent )
 {
 	vector<IECore::InternedString> keys;

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -717,7 +717,11 @@ Plug *promoteWithName( Plug *plug, const InternedString &name, Plug *parent, con
 
 	Node *externalNode = ::externalNode( plug );
 	const bool dynamic = runTimeCast<Box>( externalNode ) || parent == externalNode->userPlug();
-	MetadataAlgo::copy( plug, externalPlug.get(), excludeMetadata, /* persistentOnly = */ dynamic, /* persistent = */ dynamic );
+	// We use `persistent = dynamic` so that `promoteWithName()` can be used in
+	// constructors for custom nodes, to promote a plug from an internal
+	// network. In this case, we don't want the metadata to be serialised with
+	// the node, as it will be recreated upon construction anyway.
+	MetadataAlgo::copy( plug, externalPlug.get(), excludeMetadata, /* persistentOnly = */ false, /* persistent = */ dynamic );
 	if( dynamic )
 	{
 		applyDynamicFlag( externalPlug.get() );

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -564,13 +564,3 @@ void Reference::transferEditedMetadata( const Plug *srcPlug, Plug *dstPlug ) con
 	}
 }
 
-void Reference::convertPersistentMetadata( Plug *plug ) const
-{
-	vector<InternedString> keys;
-	Metadata::registeredValues( plug, keys, /* instanceOnly = */ true, /* persistentOnly = */ true );
-	for( vector<InternedString>::const_iterator it = keys.begin(), eIt = keys.end(); it != eIt; ++it )
-	{
-		ConstDataPtr value = Metadata::value( plug, *it );
-		Metadata::registerValue( plug, *it, value, /* persistent = */ false );
-	}
-}


### PR DESCRIPTION
It's fairly common to register dynamically changeable presets for plugs using the `presetNames` and `presetValues` metadata. For instance, the `CatalogueSelect.imageName` presets are derived on the fly from the current images in the first upstream catalogue. Until now, such presets have been "baked" during plug promotion, so that the promoted plug has a snapshot rather than continuing to compute the presets dynamically. In the CatalogueSelect example, this means the presets no longer track changes to the Catalogue, and can become incomplete and/or contain invalid values.

This PR aims to fix this by allowing presets to continue to be computed dynamically for promoted plugs. We discussed a number of ways of doing this, with perhaps the ideal being support for completely generic callable metadata at a per-plug-instance level (we only support static registrations for this currently). That has a number of thorny issues though, so we had agreed to add an explicit "delegate to connected plug" mechanism to the `Metadata` API. When it came to implementing this though, I felt that it wasn't generally useful enough to warrant existence at that level, and would muddy the waters when/if we do support generic callables in future.

In the end I've settled on the most brain-dead implementation I could come up with, targeted solely at presets. This tidies up some loose ends with promotion and provides finer control over what metadata is promoted. It builds on that by allowing NodeAlgo to search for presets on connected plugs if there are none on the main plug. By opting out of promotion of presets you can trigger this search and maintain dynamic presets for promoted plugs. I've only taken advantage of this for CatalogueSelect in this PR, but if it looks OK I should probably also add the OpenColorIO colorspace plugs as well.