### PR TITLE
FilterPlug : Add match() method

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.58.6.x (relative to 0.58.6.0)
+========
+
+API
+---
+
+- FilterPlug : Added `match` method to evaluate the filter for the specified `ScenePlug`.
+
 0.58.6.0 (relative to 0.58.5.2)
 ========
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.58.6.x (relative to 0.58.6.0)
 ========
 
+Fixes
+-----
+
+- Viewer : Fixed bug that caused the Inspector to edit the wrong node when SetFilters were in use.
+
 API
 ---
 

--- a/include/GafferScene/Filter.h
+++ b/include/GafferScene/Filter.h
@@ -74,7 +74,7 @@ class GAFFERSCENE_API Filter : public Gaffer::ComputeNode
 		/// > where `input` is a child of a ScenePlug that will later be provided to `computeMatch()`.
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
-		/// \deprecated Use FilterPlug::SceneScope instead.
+		/// \deprecated Use FilterPlug::SceneScope or FilterPlug::match instead.
 		static void setInputScene( Gaffer::Context *context, const ScenePlug *scenePlug );
 		/// \deprecated
 		static const ScenePlug *getInputScene( const Gaffer::Context *context );

--- a/include/GafferScene/FilterPlug.h
+++ b/include/GafferScene/FilterPlug.h
@@ -88,6 +88,10 @@ class GAFFERSCENE_API FilterPlug : public Gaffer::IntPlug
 		/// usage, see `FilteredSceneProcessor::affects()`.
 		void sceneAffects( const Gaffer::Plug *scenePlugChild, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const;
 
+		/// Evaluates the filter for the specified scene plug. Should be used in preference to
+		/// singular calls to getValue(), as it ensures a suitable SceneScope before evaluating the filter.
+		unsigned match( const ScenePlug *scene ) const;
+
 		/// Name of a context variable used to provide the input
 		/// scene to the filter
 		static const IECore::InternedString inputSceneContextName;

--- a/python/GafferSceneUI/_SceneViewInspector.py
+++ b/python/GafferSceneUI/_SceneViewInspector.py
@@ -470,7 +470,7 @@ class _ParameterInspector( object ) :
 			if not node["enabled"].getValue() :
 				return None
 
-			if "filter" in node and not ( node["filter"].getValue() & IECore.PathMatcher.Result.ExactMatch ) :
+			if "filter" in node and not ( node["filter"].match( attributeHistory.scene ) & IECore.PathMatcher.Result.ExactMatch ) :
 				return None
 
 			if isinstance( node, ( GafferScene.Light, GafferScene.LightFilter ) ) :

--- a/src/GafferScene/FilterPlug.cpp
+++ b/src/GafferScene/FilterPlug.cpp
@@ -155,6 +155,12 @@ void FilterPlug::sceneAffects( const Gaffer::Plug *scenePlugChild, Gaffer::Depen
 	}
 }
 
+unsigned FilterPlug::match( const ScenePlug *scene ) const
+{
+	FilterPlug::SceneScope scope( Context::current(), scene );
+	return getValue();
+}
+
 FilterPlug::SceneScope::SceneScope( const Gaffer::Context *context, const ScenePlug *scenePlug )
 	:	EditableScope( context )
 {

--- a/src/GafferSceneModule/FilterBinding.cpp
+++ b/src/GafferSceneModule/FilterBinding.cpp
@@ -63,6 +63,13 @@ ScenePlugPtr getInputScene( const Gaffer::Context *context )
 	return const_cast<ScenePlug *>( Filter::getInputScene( context ) );
 }
 
+int match( const FilterPlug &plug, const ScenePlug &scene )
+{
+	IECorePython::ScopedGILRelease r;
+	return plug.match( &scene );
+}
+
+
 } // namespace
 
 void GafferSceneModule::bindFilter()
@@ -95,6 +102,7 @@ void GafferSceneModule::bindFilter()
 				)
 			)
 		)
+		.def( "match", &match )
 	;
 
 	GafferBindings::DependencyNodeClass<PathFilter>();

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -98,12 +98,6 @@ M44f signOnlyScaling( const M44f &m )
 	return result;
 }
 
-int filterResult( const FilterPlug *filter, const ScenePlug *scene )
-{
-	FilterPlug::SceneScope scope( Context::current(), scene );
-	return filter->getValue();
-}
-
 bool ancestorMakesChildNodesReadOnly( const Node *node )
 {
 	node = node->parent<Node>();
@@ -294,7 +288,7 @@ void TransformTool::Selection::initFromSceneNode( const GafferScene::SceneAlgo::
 	{
 		if(
 			history->scene == constraint->outPlug() &&
-			( filterResult( constraint->filterPlug(), constraint->inPlug() ) & PathMatcher::ExactMatch )
+			( constraint->filterPlug()->match( constraint->inPlug() ) & PathMatcher::ExactMatch )
 		)
 		{
 			m_aimConstraint = true;
@@ -326,7 +320,7 @@ void TransformTool::Selection::initFromSceneNode( const GafferScene::SceneAlgo::
 	{
 		if(
 			history->scene == transform->outPlug() &&
-			( filterResult( transform->filterPlug(), transform->inPlug() ) & PathMatcher::ExactMatch )
+			( transform->filterPlug()->match( transform->inPlug() ) & PathMatcher::ExactMatch )
 		)
 		{
 			transformPlug = const_cast<TransformPlug *>( transform->transformPlug() );


### PR DESCRIPTION
Allows us to fix a bug in the `_SceneViewInspector` where we were querying the filter with no scene set.

@johnhaddon this is currently targeted at `0.58_maintenance` as we discussed, let me know if there are any ABI issues or we'd feel happier with it on `0.59_maintenance`