### PR TITLE
SceneAlgo : User FilterPlug instead of IntPlug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.60.x.x
 ========
 
+Breaking Changes
+----------------
+
+- SceneAlgo : Changed signature of the following methods to use `GafferScene::FilterPlug` : `matchingPaths`, `filteredParallelTraverse`, `Detail::ThreadableFilteredFunctor`.
+
 Build
 -----
 

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -80,7 +80,7 @@ GAFFERSCENE_API std::unordered_set<FilteredSceneProcessor *> filteredNodes( Filt
 GAFFERSCENE_API void matchingPaths( const Filter *filter, const ScenePlug *scene, IECore::PathMatcher &paths );
 /// As above, but specifying the filter as a plug - typically Filter::outPlug() or
 /// FilteredSceneProcessor::filterPlug() would be passed.
-GAFFERSCENE_API void matchingPaths( const Gaffer::IntPlug *filterPlug, const ScenePlug *scene, IECore::PathMatcher &paths );
+GAFFERSCENE_API void matchingPaths( const FilterPlug *filterPlug, const ScenePlug *scene, IECore::PathMatcher &paths );
 /// As above, but specifying the filter as a PathMatcher.
 GAFFERSCENE_API void matchingPaths( const IECore::PathMatcher &filter, const ScenePlug *scene, IECore::PathMatcher &paths );
 
@@ -129,7 +129,7 @@ void filteredParallelTraverse( const ScenePlug *scene, const GafferScene::Filter
 /// As above, but specifying the filter as a plug - typically Filter::outPlug() or
 /// FilteredSceneProcessor::filterPlug() would be passed.
 template <class ThreadableFunctor>
-void filteredParallelTraverse( const ScenePlug *scene, const Gaffer::IntPlug *filterPlug, ThreadableFunctor &f );
+void filteredParallelTraverse( const ScenePlug *scene, const FilterPlug *filterPlug, ThreadableFunctor &f );
 /// As above, but using a PathMatcher as a filter.
 template <class ThreadableFunctor>
 void filteredParallelTraverse( const ScenePlug *scene, const IECore::PathMatcher &filter, ThreadableFunctor &f );

--- a/include/GafferScene/SceneAlgo.inl
+++ b/include/GafferScene/SceneAlgo.inl
@@ -176,11 +176,7 @@ struct ThreadableFilteredFunctor
 
 	bool operator()( const GafferScene::ScenePlug *scene, const GafferScene::ScenePlug::ScenePath &path )
 	{
-		IECore::PathMatcher::Result match;
-		{
-			FilterPlug::SceneScope sceneScope( Gaffer::Context::current(), scene );
-			match = (IECore::PathMatcher::Result)m_filter->getValue();
-		}
+		IECore::PathMatcher::Result match = (IECore::PathMatcher::Result)m_filter->match( scene );
 
 		if( match & IECore::PathMatcher::ExactMatch )
 		{

--- a/include/GafferScene/SceneAlgo.inl
+++ b/include/GafferScene/SceneAlgo.inl
@@ -172,7 +172,7 @@ class LocationTask : public tbb::task
 template <class ThreadableFunctor>
 struct ThreadableFilteredFunctor
 {
-	ThreadableFilteredFunctor( ThreadableFunctor &f, const Gaffer::IntPlug *filter ): m_f( f ), m_filter( filter ){}
+	ThreadableFilteredFunctor( ThreadableFunctor &f, const GafferScene::FilterPlug *filter ): m_f( f ), m_filter( filter ){}
 
 	bool operator()( const GafferScene::ScenePlug *scene, const GafferScene::ScenePlug::ScenePath &path )
 	{
@@ -194,7 +194,7 @@ struct ThreadableFilteredFunctor
 	}
 
 	ThreadableFunctor &m_f;
-	const Gaffer::IntPlug *m_filter;
+	const FilterPlug *m_filter;
 
 };
 
@@ -262,7 +262,7 @@ void filteredParallelTraverse( const GafferScene::ScenePlug *scene, const Gaffer
 }
 
 template <class ThreadableFunctor>
-void filteredParallelTraverse( const GafferScene::ScenePlug *scene, const Gaffer::IntPlug *filterPlug, ThreadableFunctor &f )
+void filteredParallelTraverse( const GafferScene::ScenePlug *scene, const GafferScene::FilterPlug *filterPlug, ThreadableFunctor &f )
 {
 	Detail::ThreadableFilteredFunctor<ThreadableFunctor> ff( f, filterPlug );
 	parallelTraverse( scene, ff );

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -141,7 +141,7 @@ void GafferScene::SceneAlgo::matchingPaths( const Filter *filter, const ScenePlu
 	matchingPaths( filter->outPlug(), scene, paths );
 }
 
-void GafferScene::SceneAlgo::matchingPaths( const Gaffer::IntPlug *filterPlug, const ScenePlug *scene, PathMatcher &paths )
+void GafferScene::SceneAlgo::matchingPaths( const FilterPlug *filterPlug, const ScenePlug *scene, PathMatcher &paths )
 {
 	ThreadablePathAccumulator f( paths );
 	GafferScene::SceneAlgo::filteredParallelTraverse( scene, filterPlug, f );

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -61,17 +61,17 @@ using namespace GafferScene;
 namespace
 {
 
-bool existsWrapper( const ScenePlug *scene, const ScenePlug::ScenePath &path )
+bool existsWrapper( const ScenePlug &scene, const ScenePlug::ScenePath &path )
 {
 	// gil release in case the scene traversal dips back into python:
 	IECorePython::ScopedGILRelease r;
-	return SceneAlgo::exists( scene, path );
+	return SceneAlgo::exists( &scene, path );
 }
 
-bool visibleWrapper( const ScenePlug *scene, const ScenePlug::ScenePath &path )
+bool visibleWrapper( const ScenePlug &scene, const ScenePlug::ScenePath &path )
 {
 	IECorePython::ScopedGILRelease r;
-	return SceneAlgo::visible( scene, path );
+	return SceneAlgo::visible( &scene, path );
 }
 
 object filteredNodesWrapper( Filter &filter )
@@ -87,53 +87,53 @@ object filteredNodesWrapper( Filter &filter )
 	return object( handle<>( nodesSet ) );
 }
 
-void matchingPathsWrapper1( const Filter *filter, const ScenePlug *scene, PathMatcher &paths )
+void matchingPathsWrapper1( const Filter &filter, const ScenePlug &scene, PathMatcher &paths )
 {
 	// gil release in case the scene traversal dips back into python:
 	IECorePython::ScopedGILRelease r;
-	SceneAlgo::matchingPaths( filter, scene, paths );
+	SceneAlgo::matchingPaths( &filter, &scene, paths );
 }
 
-void matchingPathsWrapper2( const FilterPlug *filterPlug, const ScenePlug *scene, PathMatcher &paths )
+void matchingPathsWrapper2( const FilterPlug &filterPlug, const ScenePlug &scene, PathMatcher &paths )
 {
 	// gil release in case the scene traversal dips back into python:
 	IECorePython::ScopedGILRelease r;
-	SceneAlgo::matchingPaths( filterPlug, scene, paths );
+	SceneAlgo::matchingPaths( &filterPlug, &scene, paths );
 }
 
-void matchingPathsWrapper3( const PathMatcher &filter, const ScenePlug *scene, PathMatcher &paths )
+void matchingPathsWrapper3( const PathMatcher &filter, const ScenePlug &scene, PathMatcher &paths )
 {
 	// gil release in case the scene traversal dips back into python:
 	IECorePython::ScopedGILRelease r;
-	SceneAlgo::matchingPaths( filter, scene, paths );
+	SceneAlgo::matchingPaths( filter, &scene, paths );
 }
 
-Imath::V2f shutterWrapper( const IECore::CompoundObject *globals, const ScenePlug *scene )
+Imath::V2f shutterWrapper( const IECore::CompoundObject &globals, const ScenePlug &scene )
 {
 	IECorePython::ScopedGILRelease r;
-	return SceneAlgo::shutter( globals, scene );
+	return SceneAlgo::shutter( &globals, &scene );
 }
 
-bool setExistsWrapper( const ScenePlug *scene, const IECore::InternedString &setName )
+bool setExistsWrapper( const ScenePlug &scene, const IECore::InternedString &setName )
 {
 	IECorePython::ScopedGILRelease r;
-	return SceneAlgo::setExists( scene, setName );
+	return SceneAlgo::setExists( &scene, setName );
 }
 
-IECore::CompoundDataPtr setsWrapper1( const ScenePlug *scene, bool copy )
+IECore::CompoundDataPtr setsWrapper1( const ScenePlug &scene, bool copy )
 {
 	IECorePython::ScopedGILRelease r;
-	IECore::ConstCompoundDataPtr result = SceneAlgo::sets( scene );
+	IECore::ConstCompoundDataPtr result = SceneAlgo::sets( &scene );
 	return copy ? result->copy() : boost::const_pointer_cast<IECore::CompoundData>( result );
 }
 
-IECore::CompoundDataPtr setsWrapper2( const ScenePlug *scene, object pythonSetNames, bool copy )
+IECore::CompoundDataPtr setsWrapper2( const ScenePlug &scene, object pythonSetNames, bool copy )
 {
 	std::vector<IECore::InternedString> setNames;
 	boost::python::container_utils::extend_container( setNames, pythonSetNames );
 
 	IECorePython::ScopedGILRelease r;
-	IECore::ConstCompoundDataPtr result = SceneAlgo::sets( scene, setNames );
+	IECore::ConstCompoundDataPtr result = SceneAlgo::sets( &scene, setNames );
 	return copy ? result->copy() : boost::const_pointer_cast<IECore::CompoundData>( result );
 }
 

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -94,7 +94,7 @@ void matchingPathsWrapper1( const Filter *filter, const ScenePlug *scene, PathMa
 	SceneAlgo::matchingPaths( filter, scene, paths );
 }
 
-void matchingPathsWrapper2( const Gaffer::IntPlug *filterPlug, const ScenePlug *scene, PathMatcher &paths )
+void matchingPathsWrapper2( const FilterPlug *filterPlug, const ScenePlug *scene, PathMatcher &paths )
 {
 	// gil release in case the scene traversal dips back into python:
 	IECorePython::ScopedGILRelease r;


### PR DESCRIPTION
ABI breaking changes to use `FilterPlug::match`. This should only be merged after #4057 has been merged and `0.58_maintenance` has been merged forwards into `master`.