### PR TITLE
PythonExpression : Better exception when result type is invalid

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.60.x.x
 ========
 
+Improvements
+------------
+
+- Expression : Improved error message when Python expression assigns an invalid value.
+
 Breaking Changes
 ----------------
 

--- a/python/Gaffer/PythonExpressionEngine.py
+++ b/python/Gaffer/PythonExpressionEngine.py
@@ -93,7 +93,11 @@ class PythonExpressionEngine( Gaffer.Expression.Engine ) :
 			plugPathSplit = plugPath.split( "." )
 			for p in plugPathSplit[:-1] :
 				parentDict = parentDict[p]
-			result.append( parentDict.get( plugPathSplit[-1], IECore.NullObject.defaultNullObject() ) )
+			r = parentDict.get( plugPathSplit[-1], IECore.NullObject.defaultNullObject() )
+			try:
+				result.append( r )
+			except:
+				raise TypeError( "Unsupported type for result \"%s\" for expression output \"%s\"" % ( str( r ), plugPath ) )
 
 		return result
 

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1454,5 +1454,26 @@ class ExpressionTest( GafferTest.TestCase ) :
 			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().y, 0.2 + 0.3 * i + 10 * i, places = 5 )
 			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().z, 0.3 + 0.3 * i + 10 * i, places = 5 )
 
+	def testNoneOutput( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["p"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( "parent['n']['user']['p'] = None" )
+		six.assertRaisesRegex( self,
+			Gaffer.ProcessException,
+			".*TypeError: Unsupported type for result \"None\" for expression output \"n.user.p\"",
+			s["n"]["user"]["p"].getValue
+		)
+
+		s["e"].setExpression( "import math; parent['n']['user']['p'] = math" )
+		six.assertRaisesRegex( self,
+			Gaffer.ProcessException,
+			".*TypeError: Unsupported type for result \"<module 'math' from .*\" for expression output \"n.user.p\"",
+			s["n"]["user"]["p"].getValue
+		)
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Tiny little thing to end off the week - this came up for an IE user, and the error message was obscure enough that I couldn't immediately identify the problem, I think this makes it a bit clearer, and more likely that people could figure it out for themselves.

This replaces the somewhat obscure message to users:

ProcessException: e.__execute : Traceback (most recent call last):
  File "/home/danield/apps/gaffer/0.59.0.0dev/cent7.x86_64/cortex/10.1/gaffer/python/Gaffer/PythonExpressionEngine.py", line 96, in execute
    result.append( parentDict.get( plugPathSplit[-1], IECore.NullObject.defaultNullObject() ) )
ValueError: Invalid Object pointer!

With:

ProcessException: e.__execute : Traceback (most recent call last):
  File "/home/danield/apps/gaffer/0.59.0.0dev/cent7.x86_64/cortex/10.1/gaffer/python/Gaffer/PythonExpressionEngine.py", line 100, in execute
    raise TypeError( "Unsupported type for result \"%s\" for expression output \"%s\"" % ( str( r ), plugPath ) )
TypeError: Unsupported type for result "None" for expression output "n.user.p"
