### PR TITLE
Docs : Disable GPU LUTs for doc builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,10 @@ jobs:
       # aborts them in a more timely fashion than the default 6hr timeout.
       timeout-minutes: 20
       run: |
-       scons -j 2 package BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions
+        # Treats warnings-as-errors so we know about broken links
+        echo "::add-matcher::./.github/workflows/main/problemMatchers/sphinx.json"
+        scons -j 2 package BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions
+        echo "::remove-matcher owner=sphinx::"
       if: matrix.publish
 
     - name: Validate

--- a/.github/workflows/main/problemMatchers/sphinx.json
+++ b/.github/workflows/main/problemMatchers/sphinx.json
@@ -1,0 +1,15 @@
+{
+	"problemMatcher": [
+		{
+			"owner": "sphinx",
+			"pattern": [
+				{
+					"regexp": "^(.+):(0-9)*:.+WARNING:\s*(.+)$",
+					"file": 1,
+					"line": 2,
+					"message": 3
+				}
+			]
+		}
+	]
+}

--- a/SConstruct
+++ b/SConstruct
@@ -1494,9 +1494,11 @@ if haveSphinx and haveInkscape :
 
 	# Since we don't copy the docs reference scripts, the screengrab
 	# scripts must read them from the source, so we use the reference
-	# env var.
+	# env var. We also extend startup paths to include any config
+	# we need for the docs to build correctly.
 	docCommandEnv = commandEnv.Clone()
 	docCommandEnv["ENV"]["GAFFER_REFERENCE_PATHS"] = os.path.abspath( "doc/references" )
+	docCommandEnv["ENV"]["GAFFER_STARTUP_PATHS"] = os.path.abspath( "doc/startup" )
 
 	# Ensure that Arnold, Appleseed and 3delight are available in the documentation
 	# environment.

--- a/SConstruct
+++ b/SConstruct
@@ -1522,6 +1522,8 @@ if haveSphinx and haveInkscape :
 	docEnv.Alias( "docs", docGraphicsCommands )
 	docSource, docGenerationCommands = locateDocs( "doc/source", docCommandEnv )
 	docs = docEnv.Command( "$BUILD_DIR/doc/gaffer/html/index.html", docSource, buildDocs )
+	# SCons doesn't know about the assorted outputs of sphinx, so only index.html ends up in the cache
+	docEnv.NoCache( docs )
 	docEnv.Depends( docGenerationCommands, docGraphicsCommands )
 	docEnv.Depends( docs, docGraphicsCommands )
 	docEnv.Depends( docs, "build" )

--- a/doc/startup/gui/lut.py
+++ b/doc/startup/gui/lut.py
@@ -1,0 +1,42 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferImageUI
+
+# We don't always run with a real GPU. This can result in assorted artefacts in the ImageView
+# display transform. Disable GPU LUTs by default.
+Gaffer.Metadata.registerValue( GafferImageUI.ImageView, "lutGPU", "userDefault", False )


### PR DESCRIPTION
It seems like the odd backgrounds/shading artefacts in the Gafferbot tutorial images were a side effect of leaving GPU enabled for the Viewer LUT during doc builds on CI.

`WARNING : ImageGadget : Could not find supported floating point texture format in OpenGL.  GPU image viewer path will be low quality, recommend switching to CPU display transform, or resolving graphics driver issue.`