### PR TITLE
_TableView : Fix oversized horizontal header

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Fixes
 - CatalogueSelect : Fixed broken presets for promoted `imageName` plugs.
 - PlugAlgo : Fixed metadata handling when promoting plugs which were themselves promoted from the constructor of a custom node.
 - NodeAlgo : Fixed corner case where a preset could be listed twice if it was specified by both `preset:<name>` and `presetNames`.
+- GafferUI : Fixed incorrect Tree/TableView horizontal header height.
 
 API
 ---

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -815,6 +815,15 @@ _styleSheet = string.Template(
 		background-color: $tintLighter;
 	}
 
+	/* For some reason, in Qt 5.12+ we're seeing extra vertical space in the */
+	/* horizontal headers. Fixing the size here doesn't seem right, but have */
+	/* been unable to work out where it is coming from.                      */
+	_TableView QHeaderView::section:horizontal,
+	*[gafferClass="GafferUI.PathListingWidget"] QHeaderView::section::horizontal
+	{
+		height: 13px;
+	}
+
 	_TableView QHeaderView::section:vertical:first {
 		border-top-left-radius: $widgetCornerRadius;
 	}


### PR DESCRIPTION
Don't really like this as a fix, but haven't yet been able to work out where this extra space is coming from.

## Pre 5.12
![image](https://user-images.githubusercontent.com/896779/102117193-f0425580-3e35-11eb-8d05-8a53ace7cb2e.png)

## 0.59.0.0
![image](https://user-images.githubusercontent.com/896779/102117029-b2ddc800-3e35-11eb-8051-5ea2f12a64ce.png)

## This PR
![image](https://user-images.githubusercontent.com/896779/102117582-69da4380-3e36-11eb-85ee-bbcc2b7e2864.png)

