### PR TITLE
Allow users to ignore missing primvars on decimation nodes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 ------------
 
 - Spreadsheet : Added support for drag and drop. Values and Plugs can be dragged from outside a Spreadsheet to a cell to set its value or connect to its value plug.
+- DeleteFaces / DeletePoints / DeleteCurves : Added "ignoreMissingVariable" plug which allows users to opt-out of errors.
 
 Fixes
 -----

--- a/include/GafferScene/DeleteCurves.h
+++ b/include/GafferScene/DeleteCurves.h
@@ -64,6 +64,9 @@ class GAFFERSCENE_API DeleteCurves : public Deformer
 		Gaffer::BoolPlug *invertPlug();
 		const Gaffer::BoolPlug *invertPlug() const;
 
+		Gaffer::BoolPlug *ignoreMissingVariablePlug();
+		const Gaffer::BoolPlug *ignoreMissingVariablePlug() const;
+
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::DeleteCurves, DeleteCurvesTypeId, Deformer );
 
 	protected :

--- a/include/GafferScene/DeleteFaces.h
+++ b/include/GafferScene/DeleteFaces.h
@@ -64,6 +64,9 @@ class GAFFERSCENE_API DeleteFaces : public Deformer
 		Gaffer::BoolPlug *invertPlug();
 		const Gaffer::BoolPlug *invertPlug() const;
 
+		Gaffer::BoolPlug *ignoreMissingVariablePlug();
+		const Gaffer::BoolPlug *ignoreMissingVariablePlug() const;
+
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::DeleteFaces, DeleteFacesTypeId, Deformer );
 
 	protected :

--- a/include/GafferScene/DeletePoints.h
+++ b/include/GafferScene/DeletePoints.h
@@ -64,6 +64,9 @@ class GAFFERSCENE_API DeletePoints : public Deformer
 		Gaffer::BoolPlug *invertPlug();
 		const Gaffer::BoolPlug *invertPlug() const;
 
+		Gaffer::BoolPlug *ignoreMissingVariablePlug();
+		const Gaffer::BoolPlug *ignoreMissingVariablePlug() const;
+
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::DeletePoints, DeletePointsTypeId, Deformer );
 
 	protected :

--- a/python/GafferSceneTest/DeleteCurvesTest.py
+++ b/python/GafferSceneTest/DeleteCurvesTest.py
@@ -182,3 +182,20 @@ class DeleteCurvesTest( GafferSceneTest.SceneTestCase ) :
 		expectedBoundingBox = imath.Box3f( imath.V3f( 0, -1, 0 ), imath.V3f( 2, 1, 0 ) )
 
 		self.assertEqual( actualCurveDeletedBounds, expectedBoundingBox )
+
+	def testIgnoreMissing( self ) :
+
+		curvesScene = self.makeCurves()
+		deleteCurves = GafferScene.DeleteCurves()
+		deleteCurves["in"].setInput( curvesScene["out"] )
+		pathFilter = GafferScene.PathFilter( "PathFilter" )
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ '/object' ] ) )
+		deleteCurves["filter"].setInput( pathFilter["out"] )
+
+		self.assertNotEqual( deleteCurves["in"].object( "/object" ), deleteCurves["out"].object( "/object" ) )
+
+		deleteCurves["curves"].setValue( "doesNotExist" )
+		self.assertRaises( RuntimeError, deleteCurves["out"].object, "/object" )
+
+		deleteCurves["ignoreMissingVariable"].setValue( True )
+		self.assertEqual( deleteCurves["in"].object( "/object" ), deleteCurves["out"].object( "/object" ) )

--- a/python/GafferSceneTest/DeleteFacesTest.py
+++ b/python/GafferSceneTest/DeleteFacesTest.py
@@ -150,5 +150,22 @@ class DeleteFacesTest( GafferSceneTest.SceneTestCase ) :
 		# including the sphere.
 		self.assertSceneValid( deleteFaces["out"] )
 
+	def testIgnoreMissing( self ) :
+
+		rectangle = self.makeRectangleFromTwoSquaresScene()
+		deleteFaces = GafferScene.DeleteFaces()
+		deleteFaces["in"].setInput( rectangle["out"] )
+		pathFilter = GafferScene.PathFilter( "PathFilter" )
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ '/object' ] ) )
+		deleteFaces["filter"].setInput( pathFilter["out"] )
+
+		self.assertNotEqual( deleteFaces["in"].object( "/object" ), deleteFaces["out"].object( "/object" ) )
+
+		deleteFaces["faces"].setValue( "doesNotExist" )
+		self.assertRaises( RuntimeError, deleteFaces["out"].object, "/object" )
+
+		deleteFaces["ignoreMissingVariable"].setValue( True )
+		self.assertEqual( deleteFaces["in"].object( "/object" ), deleteFaces["out"].object( "/object" ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/DeletePointsTest.py
+++ b/python/GafferSceneTest/DeletePointsTest.py
@@ -149,3 +149,19 @@ class DeletePointsTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual( actualPointsDeletedBounds, expectedBoundingBox )
 
+	def testIgnoreMissing( self ) :
+
+		pointsScene = self.makePoints()
+		deletePoints = GafferScene.DeletePoints()
+		deletePoints["in"].setInput( pointsScene["out"] )
+		pathFilter = GafferScene.PathFilter( "PathFilter" )
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ '/object' ] ) )
+		deletePoints["filter"].setInput( pathFilter["out"] )
+
+		self.assertNotEqual( deletePoints["in"].object( "/object" ), deletePoints["out"].object( "/object" ) )
+
+		deletePoints["points"].setValue( "doesNotExist" )
+		self.assertRaises( RuntimeError, deletePoints["out"].object, "/object" )
+
+		deletePoints["ignoreMissingVariable"].setValue( True )
+		self.assertEqual( deletePoints["in"].object( "/object" ), deletePoints["out"].object( "/object" ) )

--- a/python/GafferSceneUI/DeleteCurvesUI.py
+++ b/python/GafferSceneUI/DeleteCurvesUI.py
@@ -60,12 +60,20 @@ Gaffer.Metadata.registerNode(
 			Uniformly interpolated int, float or bool primitive variable to choose which curves to delete. Note a non-zero value indicates the curve will be deleted.
 			"""
 		],
+
 		"invert" : [
 			"description",
 			"""
 			Invert the condition used to delete curves. If the primvar is zero then the curve will be deleted.
 			"""
-		]
+		],
+
+		"ignoreMissingVariable" : [
+			"description",
+			"""
+			Causes the node to do nothing if the primitive variable doesn't exist on the curves, instead of erroring.
+			"""
+		],
 
 	}
 

--- a/python/GafferSceneUI/DeleteFacesUI.py
+++ b/python/GafferSceneUI/DeleteFacesUI.py
@@ -66,7 +66,15 @@ Gaffer.Metadata.registerNode(
 			"""
 			Invert the condition used to delete faces. If the primvar is zero then the face will be deleted.
 			"""
-		]
+		],
+
+		"ignoreMissingVariable" : [
+			"description",
+			"""
+			Causes the node to do nothing if the primitive variable doesn't exist on the curves, instead of erroring.
+			"""
+		],
+
 	}
 
 )

--- a/python/GafferSceneUI/DeletePointsUI.py
+++ b/python/GafferSceneUI/DeletePointsUI.py
@@ -66,7 +66,15 @@ Gaffer.Metadata.registerNode(
 			"""
 			Invert the condition used to delete points. If the primvar is zero then the point will be deleted.
 			"""
-		]
+		],
+
+		"ignoreMissingVariable" : [
+			"description",
+			"""
+			Causes the node to do nothing if the primitive variable doesn't exist on the points, instead of erroring.
+			"""
+		],
+
 	}
 
 )

--- a/src/GafferScene/DeleteCurves.cpp
+++ b/src/GafferScene/DeleteCurves.cpp
@@ -60,6 +60,7 @@ DeleteCurves::DeleteCurves( const std::string &name )
 
 	addChild( new StringPlug( "curves", Plug::In, "deleteCurves" ) );
 	addChild( new BoolPlug( "invert", Plug::In, false ) );
+	addChild( new BoolPlug( "ignoreMissingVariable", Plug::In, false ) );
 }
 
 DeleteCurves::~DeleteCurves()
@@ -86,12 +87,23 @@ const Gaffer::BoolPlug *DeleteCurves::invertPlug() const
 	return getChild<BoolPlug>( g_firstPlugIndex + 1);
 }
 
+Gaffer::BoolPlug *DeleteCurves::ignoreMissingVariablePlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::BoolPlug *DeleteCurves::ignoreMissingVariablePlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 2 );
+}
+
 bool DeleteCurves::affectsProcessedObject( const Gaffer::Plug *input ) const
 {
 	return
 		Deformer::affectsProcessedObject( input ) ||
 		input == curvesPlug() ||
-		input == invertPlug()
+		input == invertPlug() ||
+		input == ignoreMissingVariablePlug()
 	;
 }
 
@@ -101,6 +113,7 @@ void DeleteCurves::hashProcessedObject( const ScenePath &path, const Gaffer::Con
 	Deformer::hashProcessedObject( path, context, h );
 	curvesPlug()->hash( h );
 	invertPlug()->hash( h );
+	ignoreMissingVariablePlug()->hash( h );
 }
 
 IECore::ConstObjectPtr DeleteCurves::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const
@@ -123,6 +136,11 @@ IECore::ConstObjectPtr DeleteCurves::computeProcessedObject( const ScenePath &pa
 	PrimitiveVariableMap::const_iterator it = curves->variables.find( deletePrimVarName );
 	if (it == curves->variables.end())
 	{
+		if( ignoreMissingVariablePlug()->getValue() )
+		{
+			return inputObject;
+		}
+
 		throw InvalidArgumentException( boost::str( boost::format( "DeleteCurves : No primitive variable \"%s\" found" ) % deletePrimVarName ) );
 	}
 

--- a/src/GafferScene/DeleteFaces.cpp
+++ b/src/GafferScene/DeleteFaces.cpp
@@ -60,6 +60,7 @@ DeleteFaces::DeleteFaces( const std::string &name )
 
 	addChild( new StringPlug( "faces", Plug::In, "deleteFaces" ) );
 	addChild( new BoolPlug( "invert", Plug::In, false ) );
+	addChild( new BoolPlug( "ignoreMissingVariable", Plug::In, false ) );
 }
 
 DeleteFaces::~DeleteFaces()
@@ -86,12 +87,23 @@ const Gaffer::BoolPlug *DeleteFaces::invertPlug() const
 	return getChild<BoolPlug>( g_firstPlugIndex + 1);
 }
 
+Gaffer::BoolPlug *DeleteFaces::ignoreMissingVariablePlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::BoolPlug *DeleteFaces::ignoreMissingVariablePlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 2 );
+}
+
 bool DeleteFaces::affectsProcessedObject( const Gaffer::Plug *input ) const
 {
 	return
 		Deformer::affectsProcessedObject( input ) ||
 		input == facesPlug() ||
-		input == invertPlug()
+		input == invertPlug() ||
+		input == ignoreMissingVariablePlug()
 	;
 }
 
@@ -100,6 +112,7 @@ void DeleteFaces::hashProcessedObject( const ScenePath &path, const Gaffer::Cont
 	Deformer::hashProcessedObject( path, context, h );
 	facesPlug()->hash( h );
 	invertPlug()->hash( h );
+	ignoreMissingVariablePlug()->hash( h );
 }
 
 IECore::ConstObjectPtr DeleteFaces::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const
@@ -122,6 +135,11 @@ IECore::ConstObjectPtr DeleteFaces::computeProcessedObject( const ScenePath &pat
 	PrimitiveVariableMap::const_iterator it = mesh->variables.find( deletePrimVarName );
 	if( it == mesh->variables.end() )
 	{
+		if( ignoreMissingVariablePlug()->getValue() )
+		{
+			return inputObject;
+		}
+
 		throw InvalidArgumentException( boost::str( boost::format( "DeleteFaces : No primitive variable \"%s\" found" ) % deletePrimVarName ) );
 	}
 


### PR DESCRIPTION
This adds an "ignoreMissingVariable" plug to DeleteFaces, DeletePoints, and DeleteCurves. In certain workflows it can be advantageous to disable the error for missing deletion primvars on these nodes. For instance, a particle emmitter might have produce a PointsPrimitive with 0 points on certain frames and the user might prefer the same behaviour as if there was no object at all.

I've also addressed a todo about removing `boost::trim_copy` in all those nodes. Is there a reason not to have done that yet?