### PR TITLE
DeleteFaces / DeleteCurves / DeletePoints : Address todo

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Breaking Changes
 ----------------
 
 - SceneAlgo : Changed signature of the following methods to use `GafferScene::FilterPlug` : `matchingPaths`, `filteredParallelTraverse`, `Detail::ThreadableFilteredFunctor`.
+- DeleteFaces / DeletePoints / DeleteCurves : The PrimitiveVariable name is now taken verbatim, rather than stripping whitespace.
 
 Build
 -----

--- a/src/GafferScene/DeleteCurves.cpp
+++ b/src/GafferScene/DeleteCurves.cpp
@@ -113,9 +113,7 @@ IECore::ConstObjectPtr DeleteCurves::computeProcessedObject( const ScenePath &pa
 
 	std::string deletePrimVarName = curvesPlug()->getValue();
 
-	/// \todo Remove. We take values verbatim everywhere else in Gaffer, and I don't
-	/// see any good reason to differ here.
-	if( boost::trim_copy( deletePrimVarName ).empty() )
+	if( deletePrimVarName.empty() )
 	{
 		return inputObject;
 	}

--- a/src/GafferScene/DeleteFaces.cpp
+++ b/src/GafferScene/DeleteFaces.cpp
@@ -112,9 +112,7 @@ IECore::ConstObjectPtr DeleteFaces::computeProcessedObject( const ScenePath &pat
 
 	std::string deletePrimVarName = facesPlug()->getValue();
 
-	/// \todo Remove. We take values verbatim everywhere else in Gaffer, and I don't
-	/// see any good reason to differ here.
-	if( boost::trim_copy( deletePrimVarName ).empty() )
+	if( deletePrimVarName.empty() )
 	{
 		return inputObject;
 	}

--- a/src/GafferScene/DeletePoints.cpp
+++ b/src/GafferScene/DeletePoints.cpp
@@ -113,9 +113,7 @@ IECore::ConstObjectPtr DeletePoints::computeProcessedObject( const ScenePath &pa
 
 	std::string deletePrimVarName = pointsPlug()->getValue();
 
-	/// \todo Remove. We take values verbatim everywhere else in Gaffer, and I don't
-	/// see any good reason to differ here.
-	if( boost::trim_copy( deletePrimVarName ).empty() )
+	if( deletePrimVarName.empty() )
 	{
 		return inputObject;
 	}


### PR DESCRIPTION
The PrimitiveVariable name is now taken verbatim, rather than stripping whitespace.