### PR TITLE
Docs : Assorted build fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,7 +170,10 @@ jobs:
       # aborts them in a more timely fashion than the default 6hr timeout.
       timeout-minutes: 20
       run: |
-       scons -j 2 package BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions
+        # Treats warnings-as-errors so we know about broken links
+        echo "::add-matcher::./.github/workflows/main/problemMatchers/sphinx.json"
+        scons -j 2 package BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions
+        echo "::remove-matcher owner=sphinx::"
       if: matrix.publish
 
     - name: Validate

--- a/.github/workflows/main/problemMatchers/sphinx.json
+++ b/.github/workflows/main/problemMatchers/sphinx.json
@@ -1,0 +1,13 @@
+{
+	"problemMatcher": [
+		{
+			"owner": "sphinx",
+			"pattern": [
+				{
+					"regexp": "^(.+:.+ WARNING:.+)$",
+					"message": 1
+				}
+			]
+		}
+	]
+}

--- a/SConstruct
+++ b/SConstruct
@@ -1462,6 +1462,8 @@ def locateDocs( docRoot, env ) :
 					if targets:
 						command = env.Command( targets, sourceFile, generateDocs )
 						env.Depends( command, "build" )
+						if line.startswith( "# UndeclaredBuildTargets" ) :
+							env.NoCache( command )
 						# Force the commands to run serially, in case the doc generation
 						# has been run in parallel. Otherwise we can get overlapping
 						# screengrabs from the commands that launch Gaffer UIs.

--- a/SConstruct
+++ b/SConstruct
@@ -1520,6 +1520,8 @@ if haveSphinx and haveInkscape :
 	docEnv.Alias( "docs", docGraphicsCommands )
 	docSource, docGenerationCommands = locateDocs( "doc/source", docCommandEnv )
 	docs = docEnv.Command( "$BUILD_DIR/doc/gaffer/html/index.html", docSource, buildDocs )
+	# SCons doesn't know about the assorted outputs of sphinx, so only index.html ends up in the cache
+	docEnv.NoCache( docs )
 	docEnv.Depends( docGenerationCommands, docGraphicsCommands )
 	docEnv.Depends( docs, docGraphicsCommands )
 	docEnv.Depends( docs, "build" )

--- a/SConstruct
+++ b/SConstruct
@@ -1499,9 +1499,11 @@ if haveSphinx and haveInkscape :
 
 	# Since we don't copy the docs reference scripts, the screengrab
 	# scripts must read them from the source, so we use the reference
-	# env var.
+	# env var. We also extend startup paths to include any config
+	# we need for the docs to build correctly.
 	docCommandEnv = commandEnv.Clone()
 	docCommandEnv["ENV"]["GAFFER_REFERENCE_PATHS"] = os.path.abspath( "doc/references" )
+	docCommandEnv["ENV"]["GAFFER_STARTUP_PATHS"] = os.path.abspath( "doc/startup" )
 
 	# Ensure that Arnold, Appleseed and 3delight are available in the documentation
 	# environment.

--- a/SConstruct
+++ b/SConstruct
@@ -1455,8 +1455,11 @@ def locateDocs( docRoot, env ) :
 					# specifier so we need the second line
 					if ext == ".sh" :
 						line = s.readline()
-					if line.startswith( "# BuildTarget:" ) :
-						targets = [ os.path.join( root, x ) for x in line.partition( "# BuildTarget:" )[-1].strip( " \n" ).split( " " ) ]
+					targets = []
+					while line.startswith( "# BuildTarget:" ) :
+						targets.extend( [ os.path.join( root, x ) for x in line.partition( "# BuildTarget:" )[-1].strip( " \n" ).split( " " ) ] )
+						line = s.readline()
+					if targets:
 						command = env.Command( targets, sourceFile, generateDocs )
 						env.Depends( command, "build" )
 						# Force the commands to run serially, in case the doc generation

--- a/doc/source/GettingStarted/TutorialAssemblingTheGafferBot/generate.sh
+++ b/doc/source/GettingStarted/TutorialAssemblingTheGafferBot/generate.sh
@@ -1,5 +1,18 @@
 #! /bin/bash
 # BuildTarget: images/expansion.png
+# BuildTarget: images/plus.png
+# BuildTarget: images/nodeSetDriverNodeSelection.png
+# BuildTarget: images/nodeSetDriverNodeSet.png
+# BuildTarget: images/nodeSetStandardSet.png
+# BuildTarget: images/layoutButton.png
+# BuildTarget: images/objects.png
+# BuildTarget: images/addObjects.png
+# BuildTarget: images/replaceObjects.png
+# BuildTarget: images/collapsibleArrowRight.png
+# BuildTarget: images/timelinePlay.png
+# BuildTarget: images/removeObjects.png
+# BuildTarget: images/gafferSceneUITranslateTool.png
+# BuildTarget: images/gafferSceneUIRotateTool.png
 
 set -e
 

--- a/doc/source/GettingStarted/TutorialAssemblingTheGafferBot/screengrab.py
+++ b/doc/source/GettingStarted/TutorialAssemblingTheGafferBot/screengrab.py
@@ -1,4 +1,27 @@
 # BuildTarget: images/mainDefaultLayout.png
+# BuildTarget: images/mainSceneReaderNode.png
+# BuildTarget: images/sceneReaderBound.png
+# BuildTarget: images/viewerSceneReaderBounding.png
+# BuildTarget: images/hierarchyViewExpandedTwoLevels.png
+# BuildTarget: images/mainHeadAndLeftLegExpanded.png
+# BuildTarget: images/viewerHeadAndLegsExpanded.png
+# BuildTarget: images/mainCameraNode.png
+# BuildTarget: images/mainGroupNode.png
+# BuildTarget: images/viewerCameraRepositioned.png
+# BuildTarget: images/viewerCameraRotated.png
+# BuildTarget: images/nodeEditorWindowCameraTransform.png
+# BuildTarget: images/graphEditorRenderSettings.png
+# BuildTarget: images/mainRenderGrey.png
+# BuildTarget: images/mainRenderSettingsWithGap.png
+# BuildTarget: images/graphEditorFirstShaderNodes.png
+# BuildTarget: images/graphEditorEnvironmentLightNode.png
+# BuildTarget: images/viewerRenderOneShader.png
+# BuildTarget: images/viewerRenderTextures.png
+# BuildTarget: images/graphEditorSecondShaderNodes.png
+# BuildTarget: images/mainRenderTwoShaders.png
+# BuildTarget: images/graphEditorPathFilterNode.png
+# BuildTarget: images/viewerSelectionFace.png
+# BuildTarget: images/viewerRenderFinal.png
 
 import os
 import time

--- a/doc/source/Reference/CommandLineReference/generate.py
+++ b/doc/source/Reference/CommandLineReference/generate.py
@@ -1,4 +1,5 @@
 # BuildTarget: index.md
+# UndeclaredBuildTargets
 
 import GafferUI
 

--- a/doc/source/Reference/NodeReference/generate.py
+++ b/doc/source/Reference/NodeReference/generate.py
@@ -1,4 +1,5 @@
 # BuildTarget: index.md
+# UndeclaredBuildTargets
 
 import GafferUI
 

--- a/doc/source/ReleaseNotes/generate.py
+++ b/doc/source/ReleaseNotes/generate.py
@@ -1,4 +1,5 @@
 # BuildTarget: index.md
+# UndeclaredBuildTargets
 
 import re
 import inspect

--- a/doc/source/WorkingWithScenes/AnatomyOfACamera/screengrab.py
+++ b/doc/source/WorkingWithScenes/AnatomyOfACamera/screengrab.py
@@ -1,4 +1,5 @@
 # BuildTarget: images/interfaceCameraParameters.png
+# BuildTarget: images/interfaceCameraSets.png
 
 import IECore
 import time

--- a/doc/source/WorkingWithScenes/AnatomyOfAScene/screengrab.py
+++ b/doc/source/WorkingWithScenes/AnatomyOfAScene/screengrab.py
@@ -1,4 +1,9 @@
+# BuildTarget: images/hierarchyView.png
 # BuildTarget: images/sceneInspector.png
+# BuildTarget: images/sceneInspectorAttributesSection.png
+# BuildTarget: images/sceneInspectorBoundSection.png
+# BuildTarget: images/sceneInspectorObjectSection.png
+# BuildTarget: images/sceneInspectorTransformSection.png
 
 import IECore
 import time

--- a/doc/source/WorkingWithScenes/Camera/generate.sh
+++ b/doc/source/WorkingWithScenes/Camera/generate.sh
@@ -1,5 +1,10 @@
 #! /bin/bash
 # BuildTarget: images/gafferSceneUIRotateTool.png
+# BuildTarget: images/gafferSceneUITranslateTool.png
+# BuildTarget: images/cameraOff.png
+# BuildTarget: images/gafferSceneUICameraTool.png
+# BuildTarget: images/toggleOff.png
+# BuildTarget: images/plus.png
 
 set -e
 

--- a/doc/source/WorkingWithScenes/Camera/screengrab.py
+++ b/doc/source/WorkingWithScenes/Camera/screengrab.py
@@ -1,4 +1,14 @@
+# BuildTarget: images/exampleAnamorphicCameraSetup.png
+# BuildTarget: images/exampleSphericalCameraSetupArnoldTweaks.png
 # BuildTarget: images/interfaceCameraVisualizer.png
+# BuildTarget: images/renderDepthOfFieldBlur.png
+# BuildTarget: images/taskCameraApertureFocalLengthPlugs.png
+# BuildTarget: images/taskCameraCustomAperturePlugs.png
+# BuildTarget: images/taskCameraDepthOfFieldPlugs.png
+# BuildTarget: images/taskCameraFOVPlugs.png
+# BuildTarget: images/taskCameraRenderOverridePlugs.png
+# BuildTarget: images/taskCameraTweaksTweaks.png
+# BuildTarget: images/taskStandardOptionsDepthOfFieldPlug.png
 
 import os
 import subprocess32 as subprocess

--- a/doc/source/WorkingWithScenes/LightLinking/screengrab.py
+++ b/doc/source/WorkingWithScenes/LightLinking/screengrab.py
@@ -1,10 +1,11 @@
 # BuildTarget: images/interfaceDefaultLightPlug.png
-# BuildTarget: images/interfaceLinkedLightsAttribute.png
 # BuildTarget: images/interfaceLightLinkSetupGraphEditor.png
-# BuildTarget: images/interfaceLinkedLightsPlug.png
-# BuildTarget: images/taskLightLinkingSetExpressionLocation.png
-# BuildTarget: images/interfaceLightSetNodeEditor.png
 # BuildTarget: images/interfaceLightSetGraphEditor.png
+# BuildTarget: images/interfaceLightSetNodeEditor.png
+# BuildTarget: images/interfaceLinkedLightsAttribute.png
+# BuildTarget: images/interfaceLinkedLightsPlug.png
+# BuildTarget: images/interfactLinkedLightsAttribute.png
+# BuildTarget: images/taskLightLinkingSetExpressionLocation.png
 # BuildTarget: images/taskLightLinkingSetExpressionSet.png
 
 import os

--- a/doc/source/WorkingWithTheNodeGraph/BoxNode/generate.sh
+++ b/doc/source/WorkingWithTheNodeGraph/BoxNode/generate.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 # BuildTarget: images/gear.png
+# BuildTarget: images/info.png
+# BuildTarget: images/plugAdder.png
+# BuildTarget: images/valueChanged.png
 
 set -e
 

--- a/doc/source/WorkingWithTheNodeGraph/BoxNode/screengrab.py
+++ b/doc/source/WorkingWithTheNodeGraph/BoxNode/screengrab.py
@@ -1,4 +1,5 @@
 # BuildTarget: images/interfaceUIEditor.png
+# BuildTarget: images/exampleBoxBasics.png
 
 import os
 

--- a/doc/source/WorkingWithTheNodeGraph/Contexts/screengrab.py
+++ b/doc/source/WorkingWithTheNodeGraph/Contexts/screengrab.py
@@ -1,4 +1,18 @@
-# BuildTarget: images/conceptContextsReadingContextVariable.png images/conceptContextsEditorFocus.png images/conceptContextsContextVariablesInExpressions.png images/conceptContextsContextVariablesInExpressionsNodeEditor.png images/conceptContextsRandomNode1.png images/conceptContextsRandomNode2.png images/conceptContextsRandomNode2NodeEditor.png images/conceptContextsQueryingResults.png images/conceptContextsQueryingResultsPythonEditor.png images/conceptContextsQueryingResultsFixedPythonEditor.png images/conceptContextsQueryingResultsSceneInspector.png images/conceptContextsInParallelBranchesNodeEditor.png images/conceptContextsInParallelBranches.png images/conceptContextsInParallelBranchesDownstream.png images/conceptContextsInParallelBranchesDownstreamNodeEditor.png
+# BuildTarget: images/conceptContextsContextVariablesInExpressions.png
+# BuildTarget: images/conceptContextsContextVariablesInExpressionsNodeEditor.png
+# BuildTarget: images/conceptContextsEditorFocus.png
+# BuildTarget: images/conceptContextsInParallelBranches.png
+# BuildTarget: images/conceptContextsInParallelBranchesDownstream.png
+# BuildTarget: images/conceptContextsInParallelBranchesDownstreamNodeEditor.png
+# BuildTarget: images/conceptContextsInParallelBranchesNodeEditor.png
+# BuildTarget: images/conceptContextsQueryingResults.png
+# BuildTarget: images/conceptContextsQueryingResultsFixedPythonEditor.png
+# BuildTarget: images/conceptContextsQueryingResultsPythonEditor.png
+# BuildTarget: images/conceptContextsQueryingResultsSceneInspector.png
+# BuildTarget: images/conceptContextsRandomNode1.png
+# BuildTarget: images/conceptContextsRandomNode2.png
+# BuildTarget: images/conceptContextsRandomNode2NodeEditor.png
+# BuildTarget: images/conceptContextsReadingContextVariable.png
 
 import os
 import time

--- a/doc/source/WorkingWithTheNodeGraph/PerformanceBestPractices/screengrab.py
+++ b/doc/source/WorkingWithTheNodeGraph/PerformanceBestPractices/screengrab.py
@@ -1,4 +1,9 @@
-# BuildTarget: images/graphEditorGroupFirst.png images/graphEditorGroupSecond.png images/conceptPerformanceBestPracticesContextsViewer.png images/conceptPerformanceBestPracticesContextsGraphEditor.png images/conceptPerformanceBestPracticesContextsStats.png images/conceptPerformanceBestPracticesContextsImprovedStats.png
+# BuildTarget: images/conceptPerformanceBestPracticesContextsGraphEditor.png
+# BuildTarget: images/conceptPerformanceBestPracticesContextsImprovedStats.png
+# BuildTarget: images/conceptPerformanceBestPracticesContextsStats.png
+# BuildTarget: images/conceptPerformanceBestPracticesContextsViewer.png
+# BuildTarget: images/graphEditorGroupFirst.png
+# BuildTarget: images/graphEditorGroupSecond.png
 
 import os
 import time

--- a/doc/source/WorkingWithTheNodeGraph/SpreadsheetNode/generate.sh
+++ b/doc/source/WorkingWithTheNodeGraph/SpreadsheetNode/generate.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
-# BuildTarget: images/gear.png images/plus.png images/toggleOn.png images/toggleOff.png
+# BuildTarget: images/gear.png
+# BuildTarget: images/plus.png
+# BuildTarget: images/toggleOn.png
+# BuildTarget: images/toggleOff.png
 
 set -e
 

--- a/doc/source/WorkingWithTheNodeGraph/SpreadsheetNode/screengrab.py
+++ b/doc/source/WorkingWithTheNodeGraph/SpreadsheetNode/screengrab.py
@@ -1,4 +1,25 @@
-# BuildTarget: images/interfaceSpreadsheetNode.png images/interfaceSpreadsheetNodeInterface.png images/interfaceSpreadsheetNodeRenderNetwork.png images/interfaceSpreadsheetNodeBreakdown.png images/interfaceSpreadsheetNodeAuxiliaryConnections.png images/taskSpreadsheetNodeAddPlugBasic.png images/taskSpreadsheetNodeAddPlugVectorWhole.png images/taskSpreadsheetNodeAddPlugVectorSingle.png images/taskSpreadsheetNodeAddPlugCompound.png images/interfaceSpreadsheetNodeCompoundEnabledSwitch.png images/taskSpreadsheetNodeAddPlugTweak.png images/interfaceSpreadsheetNodeDisabledCell.png images/interfaceSpreadsheetNodeFullName.png images/interfaceSpreadsheetNodePatternWidths.png images/taskSpreadsheetNodeResizeColumnAutomatic.png images/taskSpreadsheetNodeResizeColumnManual.png images/taskSpreadsheetNodeReorderColumn.png images/interfaceSpreadsheetNodeColumnSections.png images/taskSpreadsheetNodeReorderSection.png images/examplePerLocationTransformSpreadsheet.png images/examplePerLocationLightTweakSpreadsheet.png images/exampleMultiShotRenderSpreadsheet.png
+# BuildTarget: images/exampleMultiShotRenderSpreadsheet.png
+# BuildTarget: images/examplePerLocationLightTweakSpreadsheet.png
+# BuildTarget: images/examplePerLocationTransformSpreadsheet.png
+# BuildTarget: images/interfaceSpreadsheetNode.png
+# BuildTarget: images/interfaceSpreadsheetNodeAuxiliaryConnections.png
+# BuildTarget: images/interfaceSpreadsheetNodeBreakdown.png
+# BuildTarget: images/interfaceSpreadsheetNodeColumnSections.png
+# BuildTarget: images/interfaceSpreadsheetNodeCompoundEnabledSwitch.png
+# BuildTarget: images/interfaceSpreadsheetNodeDisabledCell.png
+# BuildTarget: images/interfaceSpreadsheetNodeFullName.png
+# BuildTarget: images/interfaceSpreadsheetNodeInterface.png
+# BuildTarget: images/interfaceSpreadsheetNodePatternWidths.png
+# BuildTarget: images/interfaceSpreadsheetNodeRenderNetwork.png
+# BuildTarget: images/taskSpreadsheetNodeAddPlugBasic.png
+# BuildTarget: images/taskSpreadsheetNodeAddPlugCompound.png
+# BuildTarget: images/taskSpreadsheetNodeAddPlugTweak.png
+# BuildTarget: images/taskSpreadsheetNodeAddPlugVectorSingle.png
+# BuildTarget: images/taskSpreadsheetNodeAddPlugVectorWhole.png
+# BuildTarget: images/taskSpreadsheetNodeReorderColumn.png
+# BuildTarget: images/taskSpreadsheetNodeReorderSection.png
+# BuildTarget: images/taskSpreadsheetNodeResizeColumnAutomatic.png
+# BuildTarget: images/taskSpreadsheetNodeResizeColumnManual.png
 
 import sys
 import os

--- a/doc/source/WorkingWithTheNodeGraph/TutorialSettingUpASpreadsheet/generate.sh
+++ b/doc/source/WorkingWithTheNodeGraph/TutorialSettingUpASpreadsheet/generate.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
-# BuildTarget: images/gear.png images/plus.png
+# BuildTarget: images/gear.png
+# BuildTarget: images/plus.png
 
 set -e
 

--- a/doc/source/WorkingWithTheNodeGraph/TutorialSettingUpASpreadsheet/screengrab.py
+++ b/doc/source/WorkingWithTheNodeGraph/TutorialSettingUpASpreadsheet/screengrab.py
@@ -1,4 +1,16 @@
-# BuildTarget: images/tutorialSettingUpASpreadsheetRow2Other.png images/tutorialSettingUpASpreadsheetRows2A2B.png images/tutorialSettingUpASpreadsheetOverscanValues.png images/tutorialSettingUpASpreadsheetFullName.png images/tutorialSettingUpASpreadsheetRow2.png images/tutorialSettingUpASpreadsheetCleanColumn.png images/tutorialSettingUpASpreadsheetDefaultCell.png images/tutorialSettingUpASpreadsheetRow1.png images/tutorialSettingUpASpreadsheetSelector.png images/tutorialSettingUpASpreadsheetNewSpreadsheet.png images/tutorialSettingUpASpreadsheetGlobalContextVariables.png images/tutorialSettingUpASpreadsheetAppleseedOptionsNode.png images/tutorialSettingUpASpreadsheetStandardOptionsNode.png
+# BuildTarget: images/tutorialSettingUpASpreadsheetAppleseedOptionsNode.png
+# BuildTarget: images/tutorialSettingUpASpreadsheetCleanColumn.png
+# BuildTarget: images/tutorialSettingUpASpreadsheetDefaultCell.png
+# BuildTarget: images/tutorialSettingUpASpreadsheetFullName.png
+# BuildTarget: images/tutorialSettingUpASpreadsheetGlobalContextVariables.png
+# BuildTarget: images/tutorialSettingUpASpreadsheetNewSpreadsheet.png
+# BuildTarget: images/tutorialSettingUpASpreadsheetOverscanValues.png
+# BuildTarget: images/tutorialSettingUpASpreadsheetRow1.png
+# BuildTarget: images/tutorialSettingUpASpreadsheetRow2.png
+# BuildTarget: images/tutorialSettingUpASpreadsheetRow2Other.png
+# BuildTarget: images/tutorialSettingUpASpreadsheetRows2A2B.png
+# BuildTarget: images/tutorialSettingUpASpreadsheetSelector.png
+# BuildTarget: images/tutorialSettingUpASpreadsheetStandardOptionsNode.png
 
 import os
 import time

--- a/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/screengrab.py
+++ b/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/screengrab.py
@@ -1,4 +1,7 @@
 # BuildTarget: images/blank.png
+# BuildTarget: images/parameters.png
+# BuildTarget: images/shaderBallColoredStripes.png
+# BuildTarget: images/shaderBallStripes.png
 
 import time
 

--- a/doc/source/WorkingWithThePythonScriptingAPI/TutorialNodeGraphEditingInPython/generate.sh
+++ b/doc/source/WorkingWithThePythonScriptingAPI/TutorialNodeGraphEditingInPython/generate.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 # BuildTarget: images/nodes.png
+# BuildTarget: images/plus.png
+# BuildTarget: images/values.png
 
 set -e
 

--- a/doc/source/WorkingWithThePythonScriptingAPI/TutorialNodeGraphEditingInPython/screengrab.py
+++ b/doc/source/WorkingWithThePythonScriptingAPI/TutorialNodeGraphEditingInPython/screengrab.py
@@ -1,4 +1,17 @@
+# BuildTarget: images/graphEditorAllNodes.png
+# BuildTarget: images/graphEditorGroupConnections.png
+# BuildTarget: images/graphEditorRearrangedNodes.png
+# BuildTarget: images/graphEditorShaderAssignmentConnections.png
+# BuildTarget: images/mainWindowFinalScene.png
+# BuildTarget: images/mainWindowSphereNode.png
+# BuildTarget: images/nodeEditorOpenGLPlug.png
 # BuildTarget: images/pythonEditorHelloWorld.png
+# BuildTarget: images/pythonEditorNodeReference.png
+# BuildTarget: images/pythonEditorPlugReference.png
+# BuildTarget: images/pythonEditorPlugValueReference.png
+# BuildTarget: images/viewerCameraPosition.png
+# BuildTarget: images/viewerFinalScene.png
+# BuildTarget: images/viewerSphereRadius.png
 
 import os
 import IECore

--- a/doc/source/WorkingWithThePythonScriptingAPI/TutorialStartupConfig1/screengrab.py
+++ b/doc/source/WorkingWithThePythonScriptingAPI/TutorialStartupConfig1/screengrab.py
@@ -1,7 +1,8 @@
-# BuildTarget: images/tutorialSettingsWindowDefaultContextVariables.png
+# BuildTarget: images/illustrationStartupConfigDirectoryTree.png
 # BuildTarget: images/tutorialSettingsWindowCustomContextVariable.png
-# BuildTarget: images/tutorialVariableSubstitutionInStringPlug.png
+# BuildTarget: images/tutorialSettingsWindowDefaultContextVariables.png
 # BuildTarget: images/tutorialVariableSubstitutionExpression.png
+# BuildTarget: images/tutorialVariableSubstitutionInStringPlug.png
 # BuildTarget: images/tutorialVariableSubstitutionTest.png
 
 import os

--- a/doc/source/WorkingWithThePythonScriptingAPI/TutorialStartupConfig2/generate.sh
+++ b/doc/source/WorkingWithThePythonScriptingAPI/TutorialStartupConfig2/generate.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 # BuildTarget: images/pathChooser.png
+# BuildTarget: images/bookmarks.png
 
 set -e
 

--- a/doc/source/generate.sh
+++ b/doc/source/generate.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
-# BuildTarget: _static/GafferLogo.svg _static/GafferLogoMini.svg
+# BuildTarget: _static/GafferLogo.svg
+# BuildTarget: _static/GafferLogoMini.svg
 
 set -e
 

--- a/doc/startup/gui/lut.py
+++ b/doc/startup/gui/lut.py
@@ -1,0 +1,42 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferImageUI
+
+# We don't always run with a real GPU. This can result in assorted artefacts in the ImageView
+# display transform. Disable GPU LUTs by default.
+Gaffer.Metadata.registerValue( GafferImageUI.ImageView, "lutGPU", "userDefault", False )


### PR DESCRIPTION
Fixes a myriad of issues that could cause incomplete docs builds when re-using elements from the scons build cache.

- Fixed missing target definitions from `screengrab.py` and `generate.sh`.
- Adds `NoCache` to dynamic content (node/CLI reference).
- Disables GPU LUT for docEnv commands to avoid artefacts from display transform in CI.

This also adds a 'Problem Matcher' to Actions that watches for sphinx WARNINGS - which are generally broken links or missing images - and reports them as errors.  For some unfathomable reason however, these error annotations don't actually cause the run to error :shrug: :man_shrugging: :woman_shrugging:.