### PR TITLE
CI : Fix Python 2 issues with Azure/GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
     - name: 'Install Python Modules'
       run: |
         python --version
-        pip install PyGitHub==1.45
+        pip install PyJWT==1.7.1 PyGitHub==1.45
 
     - name: Set Custom Variables
       run: |

--- a/config/azure/build.yaml
+++ b/config/azure/build.yaml
@@ -39,7 +39,7 @@ jobs:
         python --version
         # Pre-installs some floating dependencies of the main modules that no longer support 2.x
         pip install --user cryptography==2.9 &&
-        pip install --user azure-common==1.1.23 azure-nspkg==3.0.2 azure-storage-blob==2.1.0 azure-storage-common==2.1.0 azure-storage-nspkg==3.1.0 PyGithub==1.45
+        pip install --user azure-common==1.1.23 azure-nspkg==3.0.2 azure-storage-blob==2.1.0 azure-storage-common==2.1.0 azure-storage-nspkg==3.1.0 PyJWT==1.7.1 PyGithub==1.45
         # Works around issues with earlier Python versions, remove once the Docker image is updated
         pip install --user sphinx==1.8.1
      displayName: 'Install Python Modules'

--- a/config/azure/build.yaml
+++ b/config/azure/build.yaml
@@ -32,6 +32,7 @@ jobs:
        brew cask install xquartz https://raw.githubusercontent.com/Homebrew/homebrew-cask/5eafe6e9877c5524100b9ac1c5375fe8a2d039be/Casks/inkscape.rb &&
        sudo pip install scons==3.1.2 &&
        pip install sphinx==1.8.1 sphinx_rtd_theme==0.4.3 recommonmark==0.5.0 docutils==0.12
+       echo  "##vso[task.prependpath]"`pip show scons | grep "Location:" | cut -d ' ' -f2`/../../../bin
      displayName: 'Install Toolchain (Darwin)'
      condition: eq( variables['Agent.OS'], 'Darwin' )
 

--- a/config/azure/build.yaml
+++ b/config/azure/build.yaml
@@ -39,7 +39,7 @@ jobs:
         python --version
         # Pre-installs some floating dependencies of the main modules that no longer support 2.x
         pip install --user cryptography==2.9 &&
-        pip install --user azure-common==1.1.23 azure-nspkg==3.0.2 azure-storage-blob==2.1.0 azure-storage-common==2.1.0 azure-storage-nspkg==3.1.0 PyJWT==1.7.1 PyGithub==1.45
+        pip install --user azure-common==1.1.23 azure-nspkg==3.0.2 azure-storage-blob==2.1.0 azure-storage-common==2.1.0 azure-storage-nspkg==3.1.0 PyJWT==1.7.1 PyGithub==1.45 &&
         # Works around issues with earlier Python versions, remove once the Docker image is updated
         pip install --user sphinx==1.8.1
      displayName: 'Install Python Modules'


### PR DESCRIPTION
`PyJWT` released `2.0.0` over the festivities, which no longer support Python 2. Also fixes scons on Mac on Azure.