### PR TITLE
Animated camera parameter support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 ------------
 
 - Spreadsheet : Added support for drag and drop. Values and Plugs can be dragged from outside a Spreadsheet to a cell to set its value or connect to its value plug.
+- ArnoldRender : Added support for animated camera parameters, such as field of view.
 - DeleteFaces/DeletePoints/DeleteCurves : Added `ignoreMissingVariable` plug which allows users to opt-out of errors.
 - Constraint : Added `targetScene` plug, to allow constraining to locations in another scene.
 - OSLObject : Added support for connecting to the individual components of Vector, Point, Normal, UV and Color primitive variable inputs.

--- a/Changes.md
+++ b/Changes.md
@@ -52,6 +52,9 @@ API
   - Added `copyIf()` function, to copy metadata matching an arbitrary predicate.
   - Deprecated the complex form of `copy()` in favour of a simpler overload and the new `copyIf()` function.
 - ViewportGadget : `setCameraTransform` now properly removes scale and shear from the supplied matrix.
+- RendererAlgo :
+  - Added `objectSamples()` overload which fills `vector<ConstObjectPtr>` rather than `vector<ConstVisibleRenderablePtr>`.
+  - Deprecated original `objectSamples()` method.
 
 Build
 -----

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -66,6 +66,7 @@ class IECORESCENE_API CapturingRenderer : public Renderer
 			const std::string &fileName = "",
 			const IECore::MessageHandlerPtr &messageHandler = IECore::MessageHandlerPtr()
 		);
+		~CapturingRenderer() override;
 
 		/// Introspection
 		/// =============
@@ -161,8 +162,9 @@ class IECORESCENE_API CapturingRenderer : public Renderer
 
 		IECore::MessageHandlerPtr m_messageHandler;
 
+		RenderType m_renderType;
 		std::atomic_bool m_rendering;
-		using ObjectMap = tbb::concurrent_hash_map<std::string, const CapturedObject *>;
+		using ObjectMap = tbb::concurrent_hash_map<std::string, CapturedObject *>;
 		ObjectMap m_capturedObjects;
 
 		static Renderer::TypeDescription<CapturingRenderer> g_typeDescription;

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -149,6 +149,7 @@ class IECORESCENE_API CapturingRenderer : public Renderer
 		void output( const IECore::InternedString &name, const IECoreScene::Output *output ) override;
 		AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override;
 		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr camera( const std::string &name, const std::vector<const IECoreScene::Camera *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -256,6 +256,11 @@ class IECORESCENE_API Renderer : public IECore::RefCounted
 		///
 		/// May return a nullptr if the camera definition is not supported by the renderer.
 		virtual ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) = 0;
+		/// As above, but allowing animated camera parameters to be specified. A default implementation
+		/// that calls `camera( name, samples[0], attributes )` is provided for renderers which don't
+		/// support animated cameras. Renderers that do support animated cameras should implement a suitable
+		/// override.
+		virtual ObjectInterfacePtr camera( const std::string &name, const std::vector<const IECoreScene::Camera *> &samples, const std::vector<float> &times, const AttributesInterface *attributes );
 
 		/// Adds a named light with the initially supplied set of attributes, which are expected
 		/// to provide at least a light shader. Object may be non-null to specify arbitrary geometry

--- a/include/GafferScene/RendererAlgo.h
+++ b/include/GafferScene/RendererAlgo.h
@@ -73,8 +73,10 @@ GAFFERSCENE_API void createOutputDirectories( const IECore::CompoundObject *glob
 GAFFERSCENE_API void transformSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &shutter, std::vector<Imath::M44f> &samples, std::vector<float> &sampleTimes );
 
 /// Samples the object from the current location in preparation for output to the renderer. Sampling parameters
-/// are as for the transformSamples() method. Multiple samples will only be generated for Primitives, since other
-/// object types cannot be interpolated anyway.
+/// are as for the transformSamples() method. Multiple samples will only be generated for Primitives and Cameras,
+/// since other object types cannot be interpolated anyway.
+GAFFERSCENE_API void objectSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &shutter, std::vector<IECore::ConstObjectPtr> &samples, std::vector<float> &sampleTimes );
+/// \deprecated
 GAFFERSCENE_API void objectSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &shutter, std::vector<IECoreScene::ConstVisibleRenderablePtr> &samples, std::vector<float> &sampleTimes );
 
 /// Function to return a SceneProcessor used to adapt the

--- a/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
@@ -74,7 +74,7 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 		self.assertIsInstance( o, renderer.CapturedObject )
 		self.assertTrue( o.isSame( renderer.capturedObject( "o" ) ) )
 		self.assertEqual( o.capturedSamples(), [ IECoreScene.SpherePrimitive() ] )
-		self.assertEqual( o.capturedSampleTimes(), [ 0 ] )
+		self.assertEqual( o.capturedSampleTimes(), [] )
 		self.assertEqual( o.capturedAttributes(), attributes1 )
 		self.assertEqual( o.capturedLinks( "lights" ), None )
 		self.assertEqual( o.numAttributeEdits(), 1 )
@@ -146,6 +146,20 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 			renderer.lightFilter( "rl", IECore.NullObject(), renderableAttr ),
 			GafferScene.Private.IECoreScenePreview.Renderer.ObjectInterface
 		)
+
+	def testDeformingObject( self ) :
+
+		sphere1 = IECoreScene.SpherePrimitive( 1 )
+		sphere2 = IECoreScene.SpherePrimitive( 2 )
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+		o = renderer.object(
+			"o", [ sphere1, sphere2 ], [ 1, 2 ], renderer.attributes( IECore.CompoundObject() )
+		)
+
+		c = renderer.capturedObject( "o" )
+		self.assertEqual( c.capturedSamples(), [ sphere1, sphere2 ] )
+		self.assertEqual( c.capturedSampleTimes(), [ 1, 2 ] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -105,6 +105,11 @@ Renderer::ObjectInterfacePtr CapturingRenderer::camera( const std::string &name,
 	return this->object( name, camera, attributes );
 }
 
+Renderer::ObjectInterfacePtr CapturingRenderer::camera( const std::string &name, const std::vector<const IECoreScene::Camera *> &samples, const std::vector<float> &times, const AttributesInterface *attributes )
+{
+	return this->object( name, vector<const Object *>( samples.begin(), samples.end() ), times, attributes );
+}
+
 Renderer::ObjectInterfacePtr CapturingRenderer::light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
 {
 	return this->object( name, object, attributes );

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -117,7 +117,7 @@ Renderer::ObjectInterfacePtr CapturingRenderer::lightFilter( const std::string &
 
 Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
 {
-	return this->object( name, { object }, { 0.0f }, attributes );
+	return this->object( name, { object }, {}, attributes );
 }
 
 Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes )

--- a/src/GafferScene/IECoreScenePreview/Renderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/Renderer.cpp
@@ -79,6 +79,11 @@ Renderer::~Renderer()
 
 }
 
+Renderer::ObjectInterfacePtr Renderer::camera( const std::string &name,  const std::vector<const IECoreScene::Camera *> &samples, const std::vector<float> &times, const AttributesInterface *attributes )
+{
+	return camera( name, samples[0], attributes );
+}
+
 IECore::DataPtr Renderer::command( const IECore::InternedString name, const IECore::CompoundDataMap &parameters )
 {
 	throw IECore::NotImplementedException( "Renderer::command" );

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -1139,7 +1139,17 @@ struct CameraOutput : public LocationOutput
 
 			// Create ObjectInterface
 
-			if( cameraSamples.size() && cameraSamples.size() == samples.size() )
+			if( !samples.size() || cameraSamples.size() != samples.size() )
+			{
+				IECore::msg(
+					IECore::Msg::Warning,
+					"RendererAlgo::CameraOutput",
+					boost::format( "Camera missing for location \"%1%\" at frame %2%" )
+						% name( path )
+						% Context::current()->getFrame()
+				);
+			}
+			else
 			{
 				IECoreScenePreview::Renderer::ObjectInterfacePtr objectInterface;
 				if( !sampleTimes.size() )

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -155,7 +155,7 @@ void transformSamples( const ScenePlug *scene, size_t segments, const Imath::V2f
 	}
 }
 
-void objectSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &shutter, std::vector<IECoreScene::ConstVisibleRenderablePtr> &samples, std::vector<float> &sampleTimes )
+void objectSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &shutter, std::vector<IECore::ConstObjectPtr> &samples, std::vector<float> &sampleTimes )
 {
 	samples.clear();
 	sampleTimes.clear();
@@ -165,9 +165,12 @@ void objectSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &s
 	if( !segments )
 	{
 		ConstObjectPtr object = scene->objectPlug()->getValue();
-		if( const VisibleRenderable *renderable = runTimeCast<const VisibleRenderable>( object.get() ) )
+		if(
+			runTimeCast<const VisibleRenderable>( object.get() ) ||
+			runTimeCast<const Camera>( object.get() )
+		)
 		{
-			samples.push_back( renderable );
+			samples.push_back( object.get() );
 		}
 		return;
 	}
@@ -189,7 +192,10 @@ void objectSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &s
 		const MurmurHash objectHash = scene->objectPlug()->hash();
 		ConstObjectPtr object = scene->objectPlug()->getValue( &objectHash );
 
-		if( const Primitive *primitive = runTimeCast<const Primitive>( object.get() ) )
+		if(
+			runTimeCast<const Primitive>( object.get() ) ||
+			runTimeCast<const Camera>( object.get() )
+		)
 		{
 			// We can support multiple samples for these, so check to see
 			// if we actually have something moving.
@@ -197,7 +203,7 @@ void objectSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &s
 			{
 				moving = true;
 			}
-			samples.push_back( primitive );
+			samples.push_back( object.get() );
 			lastHash = objectHash;
 		}
 		else if( runTimeCast<const VisibleRenderable>( object.get() ) )
@@ -221,6 +227,31 @@ void objectSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &s
 	if( !moving )
 	{
 		samples.resize( std::min<size_t>( samples.size(), 1 ) );
+		sampleTimes.clear();
+	}
+}
+
+void objectSamples( const ScenePlug *scene, size_t segments, const Imath::V2f &shutter, std::vector<IECoreScene::ConstVisibleRenderablePtr> &samples, std::vector<float> &sampleTimes )
+{
+	vector<ConstObjectPtr> oSamples;
+	vector<float> oSampleTimes;
+	objectSamples( scene, segments, shutter, oSamples, oSampleTimes );
+
+	samples.clear();
+	for( size_t i = 0; i < oSamples.size(); ++i )
+	{
+		if( auto ts = runTimeCast<const VisibleRenderable>( oSamples[i] ) )
+		{
+			samples.push_back( ts );
+			if( i < oSampleTimes.size() )
+			{
+				sampleTimes.push_back( oSampleTimes[i] );
+			}
+		}
+	}
+
+	if( samples.size() < 2 )
+	{
 		sampleTimes.clear();
 	}
 }
@@ -1232,7 +1263,7 @@ struct ObjectOutput : public LocationOutput
 			return true;
 		}
 
-		vector<ConstVisibleRenderablePtr> samples; vector<float> sampleTimes;
+		vector<ConstObjectPtr> samples; vector<float> sampleTimes;
 		RendererAlgo::objectSamples( scene, deformationSegments(), shutter(), samples, sampleTimes );
 		if( !samples.size() )
 		{

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -147,6 +147,23 @@ IECoreScenePreview::Renderer::ObjectInterfacePtr rendererObject2( Renderer &rend
 	return renderer.object( name, samples, times, attributes );
 }
 
+
+IECoreScenePreview::Renderer::ObjectInterfacePtr rendererCamera1( Renderer &renderer, const std::string &name, const IECoreScene::Camera *camera, const Renderer::AttributesInterface *attributes )
+{
+	return renderer.camera( name, camera, attributes );
+}
+
+IECoreScenePreview::Renderer::ObjectInterfacePtr rendererCamera2( Renderer &renderer, const std::string &name, object pythonSamples, object pythonTimes, const Renderer::AttributesInterface *attributes )
+{
+	std::vector<const IECoreScene::Camera *> samples;
+	container_utils::extend_container( samples, pythonSamples );
+
+	std::vector<float> times;
+	container_utils::extend_container( times, pythonTimes );
+
+	return renderer.camera( name, samples, times, attributes );
+}
+
 object rendererCommand( Renderer &renderer, const IECore::InternedString name, const IECore::CompoundDataMap &parameters = IECore::CompoundDataMap() )
 {
 	return dataToPython(
@@ -350,7 +367,8 @@ void GafferSceneModule::bindRender()
 
 			.def( "attributes", &Renderer::attributes )
 
-			.def( "camera", &Renderer::camera )
+			.def( "camera", &rendererCamera1 )
+			.def( "camera", &rendererCamera2 )
 			.def( "light", &Renderer::light )
 			.def( "lightFilter", &Renderer::lightFilter )
 

--- a/src/GafferSceneModule/RendererAlgoBinding.cpp
+++ b/src/GafferSceneModule/RendererAlgoBinding.cpp
@@ -52,7 +52,7 @@ namespace
 
 tuple objectSamplesWrapper( const ScenePlug &scene, size_t segments, const Imath::V2f &shutter, bool copy )
 {
-	std::vector<IECoreScene::ConstVisibleRenderablePtr> samples;
+	std::vector<IECore::ConstObjectPtr> samples;
 	std::vector<float> sampleTimes;
 	{
 		IECorePython::ScopedGILRelease gilRelease;
@@ -68,7 +68,7 @@ tuple objectSamplesWrapper( const ScenePlug &scene, size_t segments, const Imath
 		}
 		else
 		{
-			pythonSamples.append( boost::const_pointer_cast<IECoreScene::VisibleRenderable>( s ) );
+			pythonSamples.append( boost::const_pointer_cast<IECore::Object>( s ) );
 		}
 	}
 

--- a/src/GafferSceneModule/RendererAlgoBinding.cpp
+++ b/src/GafferSceneModule/RendererAlgoBinding.cpp
@@ -107,6 +107,18 @@ void registerAdaptorWrapper( const std::string &name, object adaptor )
 	RendererAlgo::registerAdaptor( name, AdaptorWrapper( adaptor ) );
 }
 
+void outputCamerasWrapper( const ScenePlug &scene, const IECore::CompoundObject &globals, const RendererAlgo::RenderSets &renderSets, IECoreScenePreview::Renderer &renderer )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	RendererAlgo::outputCameras( &scene, &globals, renderSets, &renderer );
+}
+
+void applyCameraGlobalsWrapper( IECoreScene::Camera &camera, const IECore::CompoundObject &globals, const ScenePlug &scene )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	RendererAlgo::applyCameraGlobals( &camera, &globals, &scene );
+}
+
 } // namespace
 
 namespace GafferSceneModule
@@ -124,6 +136,14 @@ void bindRendererAlgo()
 	def( "registerAdaptor", &registerAdaptorWrapper );
 	def( "deregisterAdaptor", &RendererAlgo::deregisterAdaptor );
 	def( "createAdaptors", &RendererAlgo::createAdaptors );
+
+	class_<RendererAlgo::RenderSets, boost::noncopyable>( "RenderSets" )
+		.def( init<const ScenePlug *>() )
+	;
+
+	def( "outputCameras", &outputCamerasWrapper );
+
+	def( "applyCameraGlobals", &applyCameraGlobalsWrapper );
 
 }
 


### PR DESCRIPTION
This adds support for motion blurred camera projections when rendering with Arnold, for instance to get motion blur from an extreme crash zoom. It requires https://github.com/ImageEngine/cortex/pull/1115, so CI won't pass until we have updated to that version, but I think it's in a good place to review.