### PR TITLE
Constraint : Add `targetScene` plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,7 +13,8 @@ Improvements
 ------------
 
 - Spreadsheet : Added support for drag and drop. Values and Plugs can be dragged from outside a Spreadsheet to a cell to set its value or connect to its value plug.
-- DeleteFaces / DeletePoints / DeleteCurves : Added "ignoreMissingVariable" plug which allows users to opt-out of errors.
+- DeleteFaces/DeletePoints/DeleteCurves : Added `ignoreMissingVariable` plug which allows users to opt-out of errors.
+- Constraint : Added `targetScene` plug, to allow constraining to locations in another scene.
 
 Fixes
 -----

--- a/include/GafferScene/Constraint.h
+++ b/include/GafferScene/Constraint.h
@@ -67,6 +67,9 @@ class GAFFERSCENE_API Constraint : public SceneElementProcessor
 			BoundCenter = 3
 		};
 
+		ScenePlug *targetScenePlug();
+		const ScenePlug *targetScenePlug() const;
+
 		Gaffer::StringPlug *targetPlug();
 		const Gaffer::StringPlug *targetPlug() const;
 
@@ -98,7 +101,13 @@ class GAFFERSCENE_API Constraint : public SceneElementProcessor
 
 	private :
 
-		boost::optional<ScenePath> targetPath() const;
+		struct Target
+		{
+			ScenePath path;
+			const ScenePlug *scene;
+		};
+
+		boost::optional<Target> target() const;
 
 		static size_t g_firstPlugIndex;
 

--- a/python/GafferSceneTest/ParentConstraintTest.py
+++ b/python/GafferSceneTest/ParentConstraintTest.py
@@ -185,5 +185,34 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual( parent["out"].fullTransform( "/target/constrained" ), constraint["out"].fullTransform( "/group/constrained" ) )
 
+	def testTargetScene( self ) :
+
+		cube = GafferScene.Cube()
+		sphere1 = GafferScene.Sphere()
+		sphere1["transform"]["translate"]["x"].setValue( 1 )
+		parent = GafferScene.Parent()
+		parent["parent"].setValue( "/" )
+		parent["in"].setInput( cube["out"] )
+		parent["child"][0].setInput( sphere1["out"] )
+
+		sphere2 = GafferScene.Sphere()
+		sphere2["transform"]["translate"]["y"].setValue( 1 )
+
+		cubeFilter = GafferScene.PathFilter()
+		cubeFilter["paths"].setValue( IECore.StringVectorData( [ "/cube" ] ) )
+
+		constraint = GafferScene.ParentConstraint()
+		constraint["in"].setInput( parent["out"] )
+		constraint["filter"].setInput( cubeFilter["out"] )
+		constraint["target"].setValue( "/sphere" )
+		self.assertEqual( constraint["out"].fullTransform( "/cube" ), parent["out"].fullTransform( "/sphere" ) )
+
+		constraint["targetScene"].setInput( sphere2["out"] )
+		self.assertEqual( constraint["out"].fullTransform( "/cube" ), sphere2["out"].fullTransform( "/sphere" ) )
+
+		sphere2["name"].setValue( "ball" )
+		constraint["ignoreMissingTarget"].setValue( True )
+		self.assertEqual( constraint["out"].fullTransform( "/cube" ), constraint["in"].fullTransform( "/cube" ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/ConstraintUI.py
+++ b/python/GafferSceneUI/ConstraintUI.py
@@ -55,6 +55,17 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+		"targetScene" : [
+
+			"description",
+			"""
+			The scene containing the target location to which objects are
+			constrained. If this is unconnected, the main input scene
+			is used instead.
+			""",
+
+		],
+
 		"target" : [
 
 			"description",


### PR DESCRIPTION
This allows the target of a constraint to be provided by a scene other than the main input scene. If left unconnected, the main scene is used, for backwards compatibility.
