### PR TITLE
OSLImage/OSLObject : Remove explicit nodule registrations

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,8 @@ Improvements
 - Spreadsheet : Added support for drag and drop. Values and Plugs can be dragged from outside a Spreadsheet to a cell to set its value or connect to its value plug.
 - DeleteFaces/DeletePoints/DeleteCurves : Added `ignoreMissingVariable` plug which allows users to opt-out of errors.
 - Constraint : Added `targetScene` plug, to allow constraining to locations in another scene.
+- OSLObject : Added support for connecting to the individual components of Vector, Point, Normal, UV and Color primitive variable inputs.
+- OSLImage : Added support for connecting to the individual components of channel inputs.
 
 Fixes
 -----

--- a/python/GafferOSLUI/OSLImageUI.py
+++ b/python/GafferOSLUI/OSLImageUI.py
@@ -247,7 +247,6 @@ Gaffer.Metadata.registerNode(
 			# for the case where they get promoted to a box
 			# individually.
 			"noduleLayout:section", "left",
-			"nodule:type", "GafferUI::StandardNodule",
 			"noduleLayout:label", __channelLabelFromPlug,
 			"ui:visibleDimensions", lambda plug : 2 if hasattr( plug, "interpretation" ) and plug.interpretation() == IECore.GeometricData.Interpretation.UV else None,
  		],

--- a/python/GafferOSLUI/OSLObjectUI.py
+++ b/python/GafferOSLUI/OSLObjectUI.py
@@ -238,7 +238,6 @@ Gaffer.Metadata.registerNode(
 			# for the case where they get promoted to a box
 			# individually.
 			"noduleLayout:section", "left",
-			"nodule:type", "GafferUI::StandardNodule",
 			"noduleLayout:label", lambda plug : plug.parent().getName() if plug.typeId() == GafferOSL.ClosurePlug.staticTypeId() else plug.parent()["name"].getValue(),
 			"ui:visibleDimensions", lambda plug : 2 if hasattr( plug, "interpretation" ) and plug.interpretation() == IECore.GeometricData.Interpretation.UV else None,
 		],


### PR DESCRIPTION
This allows the standard type-based registrations to be used, meaning we get CompoundNumericNodules for CompoundNumericPlugs. This allows convenient connection management at the per-component level.

![image](https://user-images.githubusercontent.com/1133871/104344656-5386dc80-54f5-11eb-952c-366814d0789b.png)
