### PR TITLE
CI : Simplify build vars slightly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,18 +29,17 @@ jobs:
         # and then use `include` to define their settings.
 
         name: [
-          linux,
-          linux-debug,
+          linux-python2,
+          linux-python2-debug,
           linux-python3,
-          macos,
+          macos-python2,
         ]
 
         include:
 
-          - name: linux
+          - name: linux-python2
             os: ubuntu-16.04
             buildType: RELEASE
-            variant: linux-python2
             publish: true
             containerImage: gafferhq/build:1.2.0
             dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.1.1/gafferDependencies-2.1.1-Python2-linux.tar.gz
@@ -51,10 +50,9 @@ jobs:
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 
-          - name: linux-debug
+          - name: linux-python2-debug
             os: ubuntu-16.04
             buildType: DEBUG
-            variant: linux-python2
             publish: false
             containerImage: gafferhq/build:1.2.0
             dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.1.1/gafferDependencies-2.1.1-Python2-linux.tar.gz
@@ -66,17 +64,15 @@ jobs:
           - name: linux-python3
             os: ubuntu-16.04
             buildType: RELEASE
-            variant: linux-python3
             publish: true
             containerImage: gafferhq/build:1.2.0
             dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.1.1/gafferDependencies-2.1.1-Python3-linux.tar.gz
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 
-          - name: macos
+          - name: macos-python2
             os: macos-10.15
             buildType: RELEASE
-            variant: macos-python2
             publish: true
             containerImage:
             dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.1.1/gafferDependencies-2.1.1-Python2-osx.tar.gz
@@ -128,7 +124,7 @@ jobs:
         echo GAFFER_SPHINX=`which sphinx-build` >> $GITHUB_ENV
       env:
        GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-       GAFFER_BUILD_VARIANT: ${{ matrix.variant }}
+       GAFFER_BUILD_VARIANT: ${{ matrix.name }}
 
     - name: Disable macOS PR Docs
       run: |

--- a/.github/workflows/main/setBuildVars.py
+++ b/.github/workflows/main/setBuildVars.py
@@ -118,7 +118,6 @@ if tag :
 # We have a couple of naming conventions for builds, depending on the nature of the trigger.
 
 formatVars = {
-	"buildTypeSuffix" : "-debug" if os.environ.get( "BUILD_TYPE", "" ) == "DEBUG" else "",
 	"variant" : os.environ["GAFFER_BUILD_VARIANT"],
 	"timestamp" : datetime.datetime.now().strftime( "%Y_%m_%d_%H%M" ),
 	"pullRequest" : pullRequest,
@@ -128,9 +127,9 @@ formatVars = {
 }
 
 nameFormats = {
-	"default" : "gaffer-{timestamp}-{shortCommit}-{variant}{buildTypeSuffix}",
-	"pull_request" : "gaffer-pr{pullRequest}-{branch}-{timestamp}-{shortCommit}-{variant}{buildTypeSuffix}",
-	"release" : "gaffer-{tag}-{variant}{buildTypeSuffix}"
+	"default" : "gaffer-{timestamp}-{shortCommit}-{variant}",
+	"pull_request" : "gaffer-pr{pullRequest}-{branch}-{timestamp}-{shortCommit}-{variant}",
+	"release" : "gaffer-{tag}-{variant}"
 }
 
 trigger = os.environ.get( 'GITHUB_EVENT_NAME', '' )


### PR DESCRIPTION
Make `matrix.name` describe the build comprehensively so we can drop`matrix.variant` and simplify `setBuildVars.py` slightly.