### PR TITLE
ViewportGadget : Remove scaling and shear from camera matrix

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,12 +4,15 @@
 Fixes
 -----
 
-- Viewer : Fixed bug that caused the Inspector to edit the wrong node when SetFilters were in use.
+- Viewer :
+  - Fixed bug that caused the Inspector to edit the wrong node when SetFilters were in use.
+  - Fixed bugs when using the CameraTool to manipulate scaled cameras or lights. Note: the Viewport projection will no longer display the effects of scale or shear components in the view matrix.
 
 API
 ---
 
 - FilterPlug : Added `match` method to evaluate the filter for the specified `ScenePlug`.
+- ViewportGadget : `setCameraTransform` now properly removes scale and shear from the supplied matrix.
 
 0.58.6.0 (relative to 0.58.5.2)
 ========

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -112,6 +112,8 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		/// A copy is taken.
 		void setCamera( IECoreScene::CameraPtr camera );
 
+		/// Note: Scale and shear is removed from the camera
+		/// matrix to prevent unstable interaction.
 		const Imath::M44f &getCameraTransform() const;
 		void setCameraTransform( const Imath::M44f &transform );
 		/// A signal emitted when the camera is changed, either by

--- a/python/GafferUITest/ViewportGadgetTest.py
+++ b/python/GafferUITest/ViewportGadgetTest.py
@@ -313,5 +313,20 @@ class ViewportGadgetTest( GafferUITest.TestCase ) :
 				)
 			)
 
+	def testSetCameraTransform( self ) :
+
+		v = GafferUI.ViewportGadget()
+
+		m = imath.M44f()
+		m.translate( imath.V3f( 1, 2, 3 ) )
+		m.scale( imath.V3f( 4, 5, 6 ) )
+		m.shear( imath.V3f( 7, 8, 9 ) )
+
+		v.setCameraTransform( m )
+		self.assertNotEqual( v.getCameraTransform(), m )
+
+		m.removeScalingAndShear()
+		self.assertEqual( v.getCameraTransform(), m )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneUI/CameraTool.cpp
+++ b/src/GafferSceneUI/CameraTool.cpp
@@ -373,6 +373,8 @@ void CameraTool::viewportCameraChanged()
 
 	// Figure out the offset from where the camera is in the scene
 	// to where the user has just moved the viewport camera.
+	// Note: The ViewportGadget will have removed any scale/shear from
+	// the matrix.
 
 	const M44f viewportCameraTransform = view()->viewportGadget()->getCameraTransform();
 	M44f cameraTransform;

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -784,11 +784,12 @@ const Imath::M44f &ViewportGadget::getCameraTransform() const
 
 void ViewportGadget::setCameraTransform( const Imath::M44f &transform )
 {
-	if( transform == getCameraTransform() )
+	const Imath::M44f viewTransform = Imath::sansScalingAndShear( transform );
+	if( viewTransform == getCameraTransform() )
 	{
 		return;
 	}
-	m_cameraController->setTransform( transform );
+	m_cameraController->setTransform( viewTransform );
 	m_cameraChangedSignal( this );
 	requestRender();
 }


### PR DESCRIPTION
Fixes broken 'f' framing when looking through scaled lights.

Though Gaffer generally aims to be a 'source of truth' for scene data, presenting scale and shear is generally unhelpful. This is most pronounced when looking through Lights etc. where area lights are generally scaled arbitrarily.

As common renderer back-ends ignore camera scale, this seemed a more useful fix than updating `CameraController::frame`, `dolly`, `tumble` et. al. to support  scaled cameras - as the Viewport now better matches the majority of renders.