### PR TITLE
CI : Update brew cask installation flags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,8 @@ jobs:
         echo `pip show scons | grep "Location:" | cut -d ' ' -f2`/../../../bin >> $GITHUB_PATH
         pip install sphinx==1.8.1 sphinx_rtd_theme==0.4.3 recommonmark==0.5.0 docutils==0.12
         # Force inkscape < 1.0 until SConstruct is updated
-        brew cask install xquartz https://raw.githubusercontent.com/Homebrew/homebrew-cask/5eafe6e9877c5524100b9ac1c5375fe8a2d039be/Casks/inkscape.rb
+        brew install --cask xquartz &&
+        brew install --cask ./config/brew/Casks/inkscape.rb
       if: runner.os == 'macOS'
 
     - name: Install toolchain (Linux)

--- a/config/azure/build.yaml
+++ b/config/azure/build.yaml
@@ -29,7 +29,8 @@ jobs:
    steps:
 
    - script: |
-       brew cask install xquartz https://raw.githubusercontent.com/Homebrew/homebrew-cask/5eafe6e9877c5524100b9ac1c5375fe8a2d039be/Casks/inkscape.rb &&
+       brew install --cask xquartz &&
+       brew install --cask ./config/brew/Casks/inkscape.rb &&
        sudo pip install scons==3.1.2 &&
        pip install sphinx==1.8.1 sphinx_rtd_theme==0.4.3 recommonmark==0.5.0 docutils==0.12
        echo  "##vso[task.prependpath]"`pip show scons | grep "Location:" | cut -d ' ' -f2`/../../../bin

--- a/config/brew/Casks/inkscape.rb
+++ b/config/brew/Casks/inkscape.rb
@@ -1,0 +1,15 @@
+cask 'inkscape' do
+  version '0.92.2-1,11269'
+  sha256 'faece7a9a5fa9db7724b0c761f7f2014676d00ef8b90a0ef506fa39d09209fea'
+
+  url "https://inkscape.org/gallery/item/#{version.after_comma}/Inkscape-#{version.before_comma}-x11-10.7-x86_64.dmg"
+  name 'Inkscape'
+  homepage 'https://inkscape.org/'
+
+  depends_on x11: true
+
+  app 'Inkscape.app'
+  binary "#{appdir}/Inkscape.app/Contents/Resources/bin/inkscape"
+
+  zap delete: '~/.inkscape-etc'
+end


### PR DESCRIPTION
A recent release results in :

   `Error: Calling brew cask install is disabled! Use brew install [--cask] instead.`

Fixing this then precipitates :

   `Invalid usage: Non-checksummed download of inkscape formula file from an arbitrary URL is unsupported!`

Adds a local Cask to address this without the need for a repo.