### PR TITLE
RendererAlgo : Fix context management for light filter linking

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Fixes
 - Viewer :
   - Fixed bug that caused the Inspector to edit the wrong node when SetFilters were in use.
   - Fixed bugs when using the CameraTool to manipulate scaled cameras or lights. Note: the Viewport projection will no longer display the effects of scale or shear components in the view matrix.
+- Render/InteractiveRender : Fixed bug in light filter context handling. This could result in light filters not being linked to the correct lights, or cause exceptions during scene translation.
 
 API
 ---

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -721,11 +721,13 @@ void LightLinks::outputLightFilterLinks( const ScenePlug *scene )
 	// Update the `filteredLights` fields in our FilterLinks.
 
 	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
+	const ThreadState &threadState = ThreadState::current();
 
 	tbb::parallel_for(
 		m_filterLinks.range(),
-		[scene]( FilterLinkMap::range_type &range )
+		[scene, &threadState]( FilterLinkMap::range_type &range )
 		{
+			ThreadState::Scope threadStateScope( threadState );
 			for( auto &f : range )
 			{
 				if( f.second.filteredLightsDirty )
@@ -746,6 +748,8 @@ void LightLinks::outputLightFilterLinks( const ScenePlug *scene )
 		m_lights.range(),
 		[this]( const LightMap::range_type &range )
 		{
+			// No need to scope `threadState` here, as `outputLightFilterLinks()`
+			// doesn't trigger Gaffer processes.
 			for( const auto &l : range )
 			{
 				outputLightFilterLinks( l.first, l.second.get() );


### PR DESCRIPTION
When doing parallel processing via TBB, it is our responsibility to transfer the current thread state (which includes the context) to the tasks being performed by other threads. Failure to do so could lead to set expressions being evaluated in the wrong context, and light filters not being linked appropriately.

This fixes a bug first reported on the gaffer-dev mailing list :

https://groups.google.com/g/gaffer-dev/c/wgOVxlDAkHw/m/ys3vMfXWBgAJ
