### PR TITLE
ScriptNode : Fix disabling/deletion of context variables

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,11 @@ Improvements
 - Numeric Bookmarks : Changed the Editor <kbd>1</kbd>-<kbd>9</kbd> hotkeys to follow the bookmark rather than pinning it (#4074).
 - Editors : Simplified the Editor Focus Menu, removing some seldom used (but potentially ambiguous) modes (#4074).
 
+Fixes
+-----
+
+- ScriptNode : Fixed bugs that allowed global variables to remain in the context after they had been disabled, renamed or deleted.
+
 API
 ---
 
@@ -38,6 +43,7 @@ Breaking Changes
   - Removed `metadataModuleDependencies()` method. Module dependencies are now declared automatically by `metadataSerialisation()`.
 - Editors : Removed the 'Follow Scene Selection' mode from the Node Editor Focus menu (#4074).
 - GafferSceneUI : Removed `SourceSet`.
+- ScriptNode : Added private member data.
 
 Build
 -----

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -46,6 +46,8 @@
 #include "Gaffer/TypedPlug.h"
 #include "Gaffer/UndoScope.h"
 
+#include "boost/container/flat_set.hpp"
+
 #include <functional>
 #include <stack>
 
@@ -320,7 +322,11 @@ class GAFFER_API ScriptNode : public Node
 		// =================
 
 		ContextPtr m_context;
+		// The names of variables that we have added to `m_context`
+		// from `variablesPlug()`.
+		boost::container::flat_set<IECore::InternedString> m_currentVariables;
 
+		void updateContextVariables();
 		void plugSet( Plug *plug );
 		void contextChanged( const Context *context, const IECore::InternedString &name );
 


### PR DESCRIPTION
~There is one other bug I deliberately haven't fixed here : if you delete the last character of the name from a NameValuePlug, that should remove the variable from the context. But we don't know what that last character was - in `plugSet()` that information has been lost already. We could fix this by simpling deleting everything we don't recognise from the context, and that would probably be simpler than the implementation used here. But I'm a little worried about the hypothetical scenario described in `ScriptNodeTest.testExternalContextVariable()`, so have taken a conservative approach for now.~ John made it fix all of the :bug: 