### PR TITLE
Instancer Context Variation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,14 @@
+0.59.x.x (relative to 0.59.3.0)
+========
+
+Features
+--------
+
+- Instancer : Added support for generating procedural variation via context variables.
+  - Time offsets for animation.
+  - Seeds for randomisation.
+  - Arbitrary context variables driven by primitive variables.
+
 0.59.3.0 (relative to 0.59.2.0)
 ========
 

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -48,6 +48,43 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 
 	public :
 
+
+		/// Compound plug for representing an image format in a way
+		/// easily edited by users, with individual child plugs for
+		/// each aspect of the format.
+		class ContextVariablePlug : public Gaffer::ValuePlug
+		{
+
+			public :
+
+				GAFFER_PLUG_DECLARE_TYPE( ContextVariablePlug, InstancerContextVariablePlugTypeId, Gaffer::ValuePlug );
+
+				ContextVariablePlug(
+					const std::string &name = defaultName<ContextVariablePlug>(),
+					Direction direction=In,
+					bool defaultEnable = true,
+					unsigned flags = Default
+				);
+
+				~ContextVariablePlug() override;
+
+				/// Accepts no children following construction.
+				bool acceptsChild( const GraphComponent *potentialChild ) const override;
+				Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
+
+				Gaffer::BoolPlug *enabledPlug();
+				const Gaffer::BoolPlug *enabledPlug() const;
+
+				Gaffer::StringPlug *namePlug();
+				const Gaffer::StringPlug *namePlug() const;
+
+				Gaffer::FloatPlug *quantizePlug();
+				const Gaffer::FloatPlug *quantizePlug() const;
+
+		};
+
+		IE_CORE_DECLAREPTR( ContextVariablePlug );
+
 		Instancer( const std::string &name=defaultName<Instancer>() );
 		~Instancer() override;
 
@@ -99,12 +136,39 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::BoolPlug *encapsulateInstanceGroupsPlug();
 		const Gaffer::BoolPlug *encapsulateInstanceGroupsPlug() const;
 
+		Gaffer::BoolPlug *seedEnabledPlug();
+		const Gaffer::BoolPlug *seedEnabledPlug() const;
+
+		Gaffer::StringPlug *seedVariablePlug();
+		const Gaffer::StringPlug *seedVariablePlug() const;
+
+		Gaffer::IntPlug *seedsPlug();
+		const Gaffer::IntPlug *seedsPlug() const;
+
+		Gaffer::IntPlug *seedPermutationPlug();
+		const Gaffer::IntPlug *seedPermutationPlug() const;
+
+		Gaffer::BoolPlug *rawSeedPlug();
+		const Gaffer::BoolPlug *rawSeedPlug() const;
+
+		Gaffer::ValuePlug *contextVariablesPlug();
+		const Gaffer::ValuePlug *contextVariablesPlug() const;
+
+		ContextVariablePlug *timeOffsetPlug();
+		const ContextVariablePlug *timeOffsetPlug() const;
+
+		Gaffer::AtomicCompoundDataPlug *variationsPlug();
+		const Gaffer::AtomicCompoundDataPlug *variationsPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
 		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
+		Gaffer::ValuePlug::CachePolicy hashCachePolicy( const Gaffer::ValuePlug *output ) const override;
 
 		bool affectsBranchBound( const Gaffer::Plug *input ) const override;
 		void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
@@ -157,6 +221,12 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 
 		GafferScene::ScenePlug *capsuleScenePlug();
 		const GafferScene::ScenePlug *capsuleScenePlug() const;
+
+		// This plug does heavy lifting when necessary to do an expensive set plug computation
+		// It uses a TaskCollaborate policy to allow threads to cooperate, and is evaluated with
+		// a scenePath in the context to return a PathMatcher for the set contents for one branch
+		Gaffer::PathMatcherDataPlug *setCollaboratePlug();
+		const Gaffer::PathMatcherDataPlug *setCollaboratePlug() const;
 
 		ConstEngineDataPtr engine( const ScenePath &parentPath, const Gaffer::Context *context ) const;
 		void engineHash( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -158,6 +158,7 @@ enum TypeId
 	CurveSamplerTypeId = 110613,
 	UnencapsulateTypeId = 110614,
 	MotionPathTypeId = 110615,
+	InstancerContextVariablePlugTypeId = 110616,
 
 	PreviewGeometryTypeId = 110648,
 	PreviewProceduralTypeId = 110649,

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -34,9 +34,298 @@
 #
 ##########################################################################
 
+import imath
+import inspect
+import IECore
 import Gaffer
 import GafferUI
 import GafferScene
+
+# Similar to CompoundDataPlugValueWidget, but different enough that the code can't be shared
+class _ContextVariableListWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug, **kw ) :
+
+		self.__column = GafferUI.ListContainer( spacing = 6 )
+
+		GafferUI.PlugValueWidget.__init__( self, self.__column, plug, **kw )
+
+		with self.__column :
+			_ColumnHeadings( [ "Primitive Variables", "Quantize", "Variations" ] )
+
+			self.__layout = GafferUI.PlugLayout( plug )
+
+			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal ) as self.__editRow :
+
+				GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
+
+				GafferUI.Button( image = "plus.png", hasFrame = False ).clickedSignal().connect( Gaffer.WeakMethod( self.__addItem ), scoped = False )
+
+				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
+
+	def hasLabel( self ) :
+
+		return True
+
+	def setPlug( self, plug ) :
+
+		GafferUI.PlugValueWidget.setPlug( self, plug )
+
+		self.__layout = GafferUI.PlugLayout( plug )
+		self.__column[0] = self.__layout
+
+	def setReadOnly( self, readOnly ) :
+
+		if readOnly == self.getReadOnly() :
+			return
+
+		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
+
+		self.__layout.setReadOnly( readOnly )
+
+	def childPlugValueWidget( self, childPlug ) :
+
+		return self.__layout.plugValueWidget( childPlug )
+
+	def __addItem( self, button ) :
+
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			self.getPlug().addChild( GafferScene.Instancer.ContextVariablePlug( "context", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+
+class _ContextVariableWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug, overrideName = None ) :
+
+		self.__row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
+
+		GafferUI.PlugValueWidget.__init__( self, self.__row, plug )
+
+		with self.__row:
+			GafferUI.StringPlugValueWidget( self.getPlug()["name"] ).textWidget()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
+
+			GafferUI.BoolPlugValueWidget( self.getPlug()["enabled"],
+				displayMode = GafferUI.BoolWidget.DisplayMode.Switch
+			)
+
+			GafferUI.PlugValueWidget.create( self.getPlug()["quantize"] )
+			toolTipPrefix = "Number of unique values of this context variable, which contribute to the total number of evaluations of the `prototypes` scene."
+			if overrideName:
+				_VariationsPlugValueWidget( self.getPlug().node()["variations"], overrideName, "", toolTipPrefix )
+			else:
+				_VariationsPlugValueWidget( self.getPlug().node()["variations"], self.getPlug()["name"], "", toolTipPrefix )
+
+		self._updateFromPlugs()
+
+	def setPlugs( self, plugs ) :
+
+		GafferUI.PlugValueWidget.setPlugs( self, plugs )
+
+		self.__row[0].setPlugs( plugs["name"] )
+		self.__row[1].setPlugs( plugs["enabled"] )
+		self.__row[2].setPlugs( plugs["quantize"] )
+
+	def hasLabel( self ) :
+
+		return True
+
+	def childPlugValueWidget( self, childPlug ) :
+
+		for w in self.__row :
+			if childPlug in w.getPlugs() :
+				return w
+
+		return None
+
+	def setReadOnly( self, readOnly ) :
+
+		if readOnly == self.getReadOnly() :
+			return
+
+		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
+
+		for w in self.__row :
+			w.setReadOnly( readOnly )
+
+	def _updateFromPlugs( self ) :
+
+		with self.getContext() :
+			enabled = self.getPlug()["enabled"].getValue()
+			self.__row[0].setEnabled( enabled )
+			self.__row[2].setEnabled( enabled )
+
+GafferUI.PlugValueWidget.registerType( GafferScene.Instancer.ContextVariablePlug, _ContextVariableWidget )
+
+class _VariationsPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	# The variations plug returns a count for each context variable, and a total.  This plug can
+	# display any one of these counts - which to display is selected by the "contextName" argument,
+	# which can be either a string literal, or a String plug which will be evaluated to find the
+	# name to access within the variations plug output
+	def __init__( self, plug, contextName, label, toolTipPrefix, **kw ) :
+
+		toolTip = toolTipPrefix + "  " + inspect.cleandoc(
+			"""
+			Varying the context requires extra evaluations of the `prototypes` scene, and can
+			dramatically increase the cost of the Instancer.
+
+			Note that variations are measured across all locations in the scene where the instancer is filtered.
+			"""
+		)
+
+		l = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4, toolTip = toolTip )
+
+		GafferUI.PlugValueWidget.__init__( self, l, plug, **kw )
+
+
+		if isinstance( contextName, Gaffer.StringPlug ):
+			self.contextName = None
+			self.contextNamePlug = contextName
+			self.contextNamePlug.node().plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__namePlugDirtied ), scoped = False )
+		else:
+			self.contextName = contextName
+			self.contextNamePlug = None
+
+		with l :
+			GafferUI.Spacer( imath.V2i( 0 ), preferredSize = imath.V2i( 0 ) )
+			if label :
+				GafferUI.Label( "<h4>%s</h4>" % label, toolTip = toolTip )
+			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 2, borderWidth = 3 ) as h :
+				h._qtWidget().setObjectName( "gafferVariationCount" )
+				self.__busyWidget = GafferUI.BusyWidget( size = 14 )
+				self.__countLabel = GafferUI.Label( horizontalAlignment = GafferUI.HorizontalAlignment.Right, toolTip = toolTip )
+				self.__countLabel._qtWidget().setMinimumWidth( 90 )
+
+		self.__updateLabel( -1 )
+		self._updateFromPlug()
+
+	def setPlugs( self, plugs ) :
+		# VariationsPlugValueWidget is a special widget that requires both the plug and contextName
+		# to be set in the constructor.  Does not support setPlugs.
+		raise NotImplementedError
+
+	def hasLabel( self ) :
+		return True
+
+	def __namePlugDirtied( self, plug ) :
+
+		if plug == self.contextNamePlug :
+			self._updateFromPlug()
+
+	def _updateFromPlug( self ) :
+
+		self.__updateLazily()
+
+	@GafferUI.LazyMethod()
+	def __updateLazily( self ) :
+
+		with self.getContext() :
+			self.__updateInBackground()
+
+	@GafferUI.BackgroundMethod()
+	def __updateInBackground( self ) :
+
+		resultDict = self.getPlug().getValue()
+
+		contextName = ""
+		if self.contextNamePlug:
+			contextName = self.contextNamePlug.getValue()
+
+			if contextName == "":
+				return -1
+		else:
+			contextName = self.contextName
+
+		if contextName in resultDict:
+			# Success. We have valid infomation to display.
+			return resultDict[contextName].value
+
+		# Could be that this variable is disabled
+		return -1
+
+	@__updateInBackground.preCall
+	def __updateInBackgroundPreCall( self ) :
+
+		self.__updateLabel( -1 )
+		self.__busyWidget.setBusy( True )
+
+	@__updateInBackground.postCall
+	def __updateInBackgroundPostCall( self, backgroundResult ) :
+
+		if isinstance( backgroundResult, IECore.Cancelled ) :
+			# Cancellation. This could be due to any of the
+			# following :
+			#
+			# - This widget being hidden.
+			# - A graph edit that will affect the result and will have
+			#   triggered a call to _updateFromPlug().
+			# - A graph edit that won't trigger a call to _updateFromPlug().
+			#
+			# LazyMethod takes care of all this for us. If we're hidden,
+			# it waits till we're visible. If `updateFromPlug()` has already
+			# called `__updateLazily()`, our call will just replace the
+			# pending call.
+			self.__updateLazily()
+			return
+		elif isinstance( backgroundResult, Exception ) :
+			# Computation error. This will be reported elsewhere
+			# in the UI.
+			self.__updateLabel( -1 )
+		else :
+			self.__updateLabel( backgroundResult )
+
+		self.__busyWidget.setBusy( False )
+
+	def __updateLabel( self, count ) :
+		self.__countLabel.setText( str(count) + " " if count >= 0 else " " )
+
+
+def _variationsPlugValueWidgetWidth() :
+	# Size of the visible part of the _VariationsPlugValueWidget
+	# the busy widget, plus a couple of border widths
+	return 112
+
+class _ColumnHeadings( GafferUI.ListContainer ):
+
+	def __init__( self, headings, toolTipOverride = "" ) :
+		GafferUI.ListContainer.__init__( self, GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
+		with self:
+			GafferUI.Label( "<h4><b>" + headings[0] + "</b></h4>", toolTip = toolTipOverride )._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
+			GafferUI.Spacer( imath.V2i( 25, 2 ) ) # approximate width of a BoolWidget Switch
+			self.addChild( GafferUI.Label( "<h4><b>" + headings[1] + "</b></h4>", toolTip = toolTipOverride ), expand = True, horizontalAlignment=GafferUI.HorizontalAlignment.Left )
+			GafferUI.Label( "<h4><b>" + headings[2] + "</b></h4>", toolTip = toolTipOverride )._qtWidget().setFixedWidth( _variationsPlugValueWidgetWidth() )
+
+# Would be really nice if we could specify constructor arguments for widgets in the metadata,
+# so we didn't need to declare specializations for different arguments
+
+_VariationSpacer = lambda node : GafferUI.Spacer( imath.V2i( _variationsPlugValueWidgetWidth(), 1 ), imath.V2i( _variationsPlugValueWidgetWidth(), 1 ) )
+
+_SeedColumnHeadings = lambda node : _ColumnHeadings( ["Seed", "", "Variations"], toolTipOverride = inspect.cleandoc(
+	"""
+	# Seed
+
+	Creates a seed context variable based on the id primvar or point index.  This hashes the point id
+	to create a persistent integer for each instance.  The context variable is available to the upstream
+	prototypes network.
+	"""
+) )
+
+_TimeOffsetColumnHeadings = lambda node : _ColumnHeadings( [ "Time Offset", "Quantize", "Variations" ], toolTipOverride = inspect.cleandoc(
+	"""
+	# Time Offset
+
+	Modify the current time when evaluating the prototypes network, by adding a primvar.
+	"""
+) )
+_SectionSpacer = lambda node : GafferUI.Spacer( imath.V2i( 1, 5 ), imath.V2i( 1, 5 ) )
+_SeedCountSpacer = lambda node : GafferUI.Spacer( imath.V2i( 0 ), imath.V2i( 999999, 0 ) )
+_SeedCountWidget = lambda node : _VariationsPlugValueWidget( node["variations"], node["seedVariable"], label = "",
+	toolTipPrefix = "Number of unique values of the seed context variable, which contribute to the total number of evaluations of the `prototypes` scene."
+)
+_TotalCountWidget = lambda plug : _VariationsPlugValueWidget( plug, "", label = "Total Variations",
+	toolTipPrefix = "The total number of unique contexts for evaluating the `prototypes` scene, including all context variables, and different prototype roots."
+)
+
+_TimeOffsetContextVariableWidget = lambda plug : _ContextVariableWidget( plug, overrideName = "frame" )
 
 ##########################################################################
 # Metadata
@@ -62,6 +351,55 @@ Gaffer.Metadata.registerNode(
 	"layout:activator:modeIsIndexedRootsList", lambda node : node["prototypeMode"].getValue() == GafferScene.Instancer.PrototypeMode.IndexedRootsList,
 	"layout:activator:modeIsNotIndexedRootsList", lambda node : node["prototypeMode"].getValue() != GafferScene.Instancer.PrototypeMode.IndexedRootsList,
 	"layout:activator:modeIsNotRootPerVertex", lambda node : node["prototypeMode"].getValue() != GafferScene.Instancer.PrototypeMode.RootPerVertex,
+	"layout:activator:seedEnabled", lambda node : node["seedEnabled"].getValue(),
+	"layout:activator:seedParameters", lambda node : not node["rawSeed"].getValue(),
+
+	"layout:customWidget:seedColumnHeadings:widgetType", "GafferSceneUI.InstancerUI._SeedColumnHeadings",
+	"layout:customWidget:seedColumnHeadings:section", "Context Variations",
+	"layout:customWidget:seedColumnHeadings:index", 18,
+
+	"layout:customWidget:idContextCountSpacer:widgetType", "GafferSceneUI.InstancerUI._SeedCountSpacer",
+	"layout:customWidget:idContextCountSpacer:section", "Context Variations",
+	"layout:customWidget:idContextCountSpacer:index", 19,
+	"layout:customWidget:idContextCountSpacer:accessory", True,
+
+	"layout:customWidget:idContextCount:widgetType", "GafferSceneUI.InstancerUI._SeedCountWidget",
+	"layout:customWidget:idContextCount:section", "Context Variations",
+	"layout:customWidget:idContextCount:index", 19,
+	"layout:customWidget:idContextCount:accessory", True,
+
+	"layout:customWidget:seedVariableSpacer:widgetType", "GafferSceneUI.InstancerUI._VariationSpacer",
+	"layout:customWidget:seedVariableSpacer:section", "Context Variations",
+	"layout:customWidget:seedVariableSpacer:index", 20,
+	"layout:customWidget:seedVariableSpacer:accessory", True,
+
+	"layout:customWidget:seedsSpacer:widgetType", "GafferSceneUI.InstancerUI._VariationSpacer",
+	"layout:customWidget:seedsSpacer:section", "Context Variations",
+	"layout:customWidget:seedsSpacer:index", 21,
+	"layout:customWidget:seedsSpacer:accessory", True,
+
+	"layout:customWidget:seedPermutationSpacer:widgetType", "GafferSceneUI.InstancerUI._VariationSpacer",
+	"layout:customWidget:seedPermutationSpacer:section", "Context Variations",
+	"layout:customWidget:seedPermutationSpacer:index", 22,
+	"layout:customWidget:seedPermutationSpacer:accessory", True,
+
+	"layout:customWidget:seedSpacer:widgetType", "GafferSceneUI.InstancerUI._SectionSpacer",
+	"layout:customWidget:seedSpacer:section", "Context Variations",
+	"layout:customWidget:seedSpacer:index", 23,
+
+	"layout:customWidget:timeOffsetHeadings:widgetType", "GafferSceneUI.InstancerUI._TimeOffsetColumnHeadings",
+	"layout:customWidget:timeOffsetHeadings:section", "Context Variations",
+	"layout:customWidget:timeOffsetHeadings:index", 24,
+	"layout:customWidget:timeOffsetHeadings:description", "Testing description",
+
+	"layout:customWidget:timeOffsetSpacer:widgetType", "GafferSceneUI.InstancerUI._SectionSpacer",
+	"layout:customWidget:timeOffsetSpacer:section", "Context Variations",
+	"layout:customWidget:timeOffsetSpacer:index", 25,
+	"layout:customWidget:timeOffsetSpacer:divider", True,
+
+	"layout:customWidget:totalSpacer:widgetType", "GafferSceneUI.InstancerUI._SectionSpacer",
+	"layout:customWidget:totalSpacer:section", "Context Variations",
+	"layout:customWidget:totalSpacer:index", 26,
 
 	plugs = {
 
@@ -306,6 +644,145 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"seedEnabled" : [
+			"description",
+			"""
+			Creates a seed context variable based on a hash of the instance ID, which could come
+			from the primitive varable specified in the `id` plug or otherwise the point index.
+			This integer is available to the upstream prototypes network, and might typically
+			be used with a Random node to randomise properties of the prototype.
+			""",
+			"layout:section", "Context Variations",
+		],
+
+		"seedVariable" : [
+			"description",
+			"""
+			Name of the context variable to put the seed value in.
+			""",
+			"layout:section", "Context Variations",
+			"layout:visibilityActivator", "seedEnabled",
+		],
+
+		"seeds" : [
+			"description",
+			"""
+			The number of possible seed values.  Increasing this allows for more different variations
+			to be driven by the seed, increasing the total number of variations required.
+			""",
+			"layout:section", "Context Variations",
+			"layout:visibilityActivator", "seedEnabled",
+			"layout:activator", "seedParameters",
+		],
+
+		"seedPermutation" : [
+			"description",
+			"""
+			Changing the seedPermutation changes the mapping of ids to seeds.  This results in a different
+			grouping of which instances end up with the same seed.
+			""",
+			"layout:section", "Context Variations",
+			"layout:visibilityActivator", "seedEnabled",
+			"layout:activator", "seedParameters",
+		],
+
+		"rawSeed" : [
+			"description",
+			"""
+			Enable this in rare cases when it is required to pass through every single id directly into the seed
+			context variable.  This is very expensive, because every single instance will need a separate
+			context, but is sometimes useful, and may be an acceptable cost if there isn't a huge number of
+			total instances.
+			""",
+			"layout:section", "Context Variations",
+			"layout:visibilityActivator", "seedEnabled",
+		],
+
+		"contextVariables" : [
+			"description",
+			"""
+			Specifies context variables to be created from primitive variables.  These variables are
+			available to upstream prototypes network, allowing the prototypes scene to be generated
+			differently depending on the source point.  Supports quantization to avoid re-evaluating the
+			prototypes scene too many times.
+			""",
+			"layout:section", "Context Variations",
+			"plugValueWidget:type", "GafferSceneUI.InstancerUI._ContextVariableListWidget",
+		],
+
+		"contextVariables.*" : [
+			"deletable", True
+		],
+
+		"contextVariables.*.name" : [
+			"description",
+			"""
+			Name of the primitive variable to read.  The same name will be used for the context variables
+			available to the upstream prototype network.
+			""",
+		],
+
+		"contextVariables.*.enabled" : [
+			"description",
+			"""
+			Puts this variable in the context for the upstream prototypes network.
+			""",
+		],
+
+		"contextVariables.*.quantize" : [
+			"description",
+			"""
+			Quantizing to a large interval reduces the number of variations created.  For example, if the primvar varies from 0 to 1, and you quantize to 0.2, then only 6 unique variations will be created, even if there are millions of instances.  This dramatically improves performance, but if you need to see more continuous changes in the primvar values, you will need to reduce quantize, or in extreme cases where you need full accuracy and don't care about performance, set it to 0.
+			""",
+		],
+
+		"timeOffset" : [
+			"description",
+			"Modify the current time when evaluating the prototypes network, by adding a primvar.",
+			"layout:section", "Context Variations",
+			"plugValueWidget:type", "GafferSceneUI.InstancerUI._TimeOffsetContextVariableWidget",
+		],
+		"timeOffset.name" : [
+			"description",
+			"""
+			Name of a primitive variable to add to the time.  Must be a float or int primvar.  It will
+			be treated as a number of frames, and can be negative or positive to adjust time forward or back.
+			""",
+		],
+		"timeOffset.enabled" : [
+			"description",
+			"""
+			Modifies the current time for the network upstream of the prototypes plug.
+			""",
+		],
+		"timeOffset.quantize" : [
+			"description",
+			"""
+			Quantizes the variable value before adding it to the time.  Quantizing to a large interval reduces the number of variations created.  For example, if the primvar varies from 0 to 1, and you quantize to 0.2, then only 6 unique variations will be created, even if there are millions of instances.  This dramatically improves performance, but if you need to see more continuous changes in the primvar values, you will need to reduce quantize, or in extreme cases where you need full accuracy and don't care about performance, set it to 0.
+			""",
+		],
+
+		"variations" : [
+			"description",
+			"""
+			This special output plug returns an CompoundData dictionary with counts about how many
+			variations are being created.  For each context variable variable being set ( including
+			"frame" when using Time Offset ), there is an entry with the name of the context variable,
+			with an IntData containing the number of unique values of that context variable.  There is
+			also an entry for "", with an IntData for the total number of unique contexts, considering
+			all the context variables being created.
+
+			Extracting the dictionary values and displaying them to users is handled by _VariationsPlugValueWidget.
+
+			This information is important to display to users because varying the context requires
+			extra evaluations of the `prototypes` scene, and can dramatically increase the cost of the Instancer.
+
+			Note that variations are measured across all locations in the scene where the instancer is filtered.
+			""",
+			"layout:section", "Context Variations",
+			"layout:index", 27,
+			"plugValueWidget:type", "GafferSceneUI.InstancerUI._TotalCountWidget",
+		],
 	}
 
 )

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -71,6 +71,7 @@ _styleColors = {
 	"backgroundDarkHighlight" : (62, 62, 62),
 
 	"backgroundLowlight" : (56, 56, 56),
+	"backgroundMidLowlight" : (61, 61, 61),
 	"background" : (66, 66, 66),
 	"backgroundAlt" : (60, 60, 60),
 	"backgroundHighlight" : (76, 76, 76),
@@ -1417,6 +1418,18 @@ _styleSheet = string.Template(
 	{
 		margin-left: $toolOverlayInset;
 		margin-right: $toolOverlayInset;
+	}
+
+	*[gafferClass="GafferSceneUI.InstancerUI._VariationsPlugValueWidget"] #gafferVariationCount
+	{
+		font-family: $monospaceFontFamily;
+		font-weight:bold;
+		font-size: 11px;
+		background: $background;
+		border: 1px solid $background;
+		border-top-color: $backgroundMidLowlight;
+		border-left-color: $backgroundMidLowlight;
+		border-radius: 6px;
 	}
 
 	/* Corner Rounding - also allow squaring based on adjacency of other widgets */

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -54,9 +54,12 @@
 #include "IECore/VectorTypedData.h"
 
 #include "boost/lexical_cast.hpp"
+#include "boost/unordered_set.hpp"
 
 #include "tbb/blocked_range.h"
+#include "tbb/parallel_for.h"
 #include "tbb/parallel_reduce.h"
+#include "tbb/spin_mutex.h"
 
 #include <functional>
 #include <unordered_map>
@@ -72,6 +75,211 @@ using namespace GafferScene;
 
 namespace
 {
+
+const PrimitiveVariable *findVertexVariable( const IECoreScene::Primitive* primitive, const InternedString &name )
+{
+	PrimitiveVariableMap::const_iterator it = primitive->variables.find( name );
+	if( it == primitive->variables.end() || it->second.interpolation != IECoreScene::PrimitiveVariable::Vertex )
+	{
+		return nullptr;
+	}
+	return &it->second;
+}
+
+// We need to able to quantize all our basic numeric values, so we have a set of templates for this, with
+// a special exception if you try to use a non-zero quantize on a type that can't be quantize ( ie. a string ).
+//
+// We quantize by forcing a value to the closest value that is a multiple of quantize.  For vector types,
+// this is done independently for each axis.
+class QuantizeException {};
+
+template <class T>
+inline T quantize( const T &v, float q )
+{
+	if( q != 0.0f )
+	{
+		throw QuantizeException();
+	}
+	return v;
+}
+
+template <>
+inline float quantize( const float &v, float q )
+{
+	if( q == 0.0f )
+	{
+		return v;
+	}
+	// \todo : Higher performance round
+	float r = q * round( v / q );
+
+	// Letting negative zeros slip through is confusing because they hash to different values
+	if( r == 0 )
+	{
+		r = 0;
+	}
+	return r;
+}
+
+template <>
+inline int quantize( const int &v, float q )
+{
+	if( q == 0.0f )
+	{
+		return v;
+	}
+	int intQuantize = round( q );
+	if( intQuantize == 0 )
+	{
+		return v;
+	}
+	int halfQuantize = intQuantize / 2;
+	return intQuantize * ( ( v + halfQuantize ) / intQuantize );
+}
+
+template <class T>
+inline Vec2<T> quantize( const Vec2<T> &v, float q )
+{
+	return Vec2<T>( quantize( v[0], q ), quantize( v[1], q ) );
+}
+
+template <class T>
+inline Vec3<T> quantize( const Vec3<T> &v, float q )
+{
+	return Vec3<T>( quantize( v[0], q ), quantize( v[1], q ), quantize( v[2], q ) );
+}
+
+template <>
+inline Color3f quantize( const Color3f &v, float q )
+{
+	return Color3f( quantize( v[0], q ), quantize( v[1], q ), quantize( v[2], q ) );
+}
+
+template <>
+inline Color4f quantize( const Color4f &v, float q )
+{
+	return Color4f( quantize( v[0], q ), quantize( v[1], q ), quantize( v[2], q ), quantize( v[3], q ) );
+}
+
+// An internal struct for storing everything we need to know about a context modification we're making
+// when accessing the prototypes scene
+struct PrototypeContextVariable
+{
+	InternedString name;               // Name of context variable
+	const PrimitiveVariable *primVar;  // Primitive variable that drives it
+	float quantize;                    // The interval we quantize to
+	bool offsetMode;                   // Special mode for adding to existing variable instead of replacing
+	bool seedMode;                     // Special mode for seed context which is driven from the id
+	int numSeeds;                      // When in seedMode, the number of distinct seeds to output
+	int seedScramble;                  // A random seed that affects how seeds are generated
+};
+
+
+// A functor for use with IECore::dispatch that sets a variable in a context, based on a PrototypeContextVariable
+// struct
+struct AccessPrototypeContextVariable
+{
+	template< class T>
+	void operator()( const TypedData<vector<T>> *data, const PrototypeContextVariable &v, int index, Context::EditableScope &scope )
+	{
+		T raw = PrimitiveVariable::IndexedView<T>( *v.primVar )[index];
+		T value = quantize( raw, v.quantize );
+		scope.set( v.name, value );
+	}
+
+	void operator()( const TypedData<vector<float>> *data, const PrototypeContextVariable &v, int index, Context::EditableScope &scope )
+	{
+		float raw = PrimitiveVariable::IndexedView<float>( *v.primVar )[index];
+		float value = quantize( raw, v.quantize );
+
+		if( v.offsetMode )
+		{
+			scope.set( v.name, value + scope.context()->get<float>( v.name ) );
+		}
+		else
+		{
+			scope.set( v.name, value );
+		}
+	}
+
+	void operator()( const TypedData<vector<int>> *data, const PrototypeContextVariable &v, int index, Context::EditableScope &scope )
+	{
+		int raw = PrimitiveVariable::IndexedView<int>( *v.primVar )[index];
+		int value = quantize( raw, v.quantize );
+
+		if( v.offsetMode )
+		{
+			scope.set( v.name, float(value) + scope.context()->get<float>( v.name ) );
+		}
+		else
+		{
+			scope.set( v.name, value );
+		}
+	}
+
+	void operator()( const Data *data, const PrototypeContextVariable &v, int index, Context::EditableScope &scope )
+	{
+		throw IECore::Exception( "Context variable prim vars must contain vector data" );
+	}
+};
+
+// A functor for use with IECore::dispatch that adds to a hash, based on a PrototypeContextVariable
+// struct.  This is only used to count the number of unique hashes, so we can take some shortcuts, for
+// example, we ignore the offsetMode, because adding the offsets to a different global time doesn't change
+// the number of unique offsets.  We also ignore the name of the context variable, since we always process
+// the same PrototypeContextVariables in the same order
+struct UniqueHashPrototypeContextVariable
+{
+	template< class T>
+	void operator()( const TypedData<vector<T>> *data, const PrototypeContextVariable &v, int index, MurmurHash &contextHash )
+
+	{
+		T raw = PrimitiveVariable::IndexedView<T>( *v.primVar )[index];
+		T value = quantize( raw, v.quantize );
+		contextHash.append( value );
+	}
+
+	void operator()( const Data *data, const PrototypeContextVariable &v, int index, MurmurHash &contextHash )
+	{
+		throw IECore::Exception( "Context variable prim vars must contain vector data" );
+	}
+};
+
+// We create a seed integer that corresponds to the id by hashing the id and then modulo'ing to
+// numSeeds, to create seeds in the range 0 .. numSeeds-1 that persistently correspond to the ids,
+// with a grouping pattern that can be changed with seedScramble
+int seedForPoint( int index, const PrimitiveVariable *primVar, int numSeeds, int seedScramble )
+{
+	int id = index;
+	if( primVar )
+	{
+		// TODO - the exception this will throw on non-int primvars may not be very clear to users
+		id = PrimitiveVariable::IndexedView<int>( *primVar )[index];
+	}
+
+	// numSeeds is set to 0 when we're just passing through the id
+	if( numSeeds != 0 )
+	{
+		// The method used for random generation of seeds is actually rather important.
+		// We need a random access RNG which allows evaluating any input id independently,
+		// and should not create lattice artifacts if interpreted as a spacial attribute
+		// such as size.  This is actually a somewhat demanding set of criteria - many
+		// easy to seed RNGs with a small state space could create lattice artifacts.
+		//
+		// Using MurmurHash doesn't seem conceptually perfect, but it uses code we already
+		// have around, should perform fairly well ( might help if the constructor was inlined ),
+		// and I've tested for lattice artifacts by generating 200 000 points with Y set to
+		// seedId, and X set to point index.  These points looked good, with even distribution
+		// and no latticing, so this is probably a reasonable approach to stick with
+
+		IECore::MurmurHash seedHash;
+		seedHash.append( seedScramble );
+		seedHash.append( id );
+		id = int( ( double( seedHash.h1() ) / double( UINT64_MAX ) ) * double( numSeeds ) );
+		id = id % numSeeds;  // For the rare case h1 / max == 1.0, make sure we stay in range
+	}
+	return id;
+}
 
 InternedString g_prototypeRootName( "root" );
 ConstInternedStringVectorDataPtr g_emptyNames = new InternedStringVectorData();
@@ -91,7 +299,7 @@ class Instancer::EngineData : public Data
 	public :
 
 		EngineData(
-			ConstObjectPtr object,
+			ConstPrimitivePtr primitive,
 			PrototypeMode mode,
 			const std::string &index,
 			const std::string &rootsVariable,
@@ -102,18 +310,20 @@ class Instancer::EngineData : public Data
 			const std::string &orientation,
 			const std::string &scale,
 			const std::string &attributes,
-			const std::string &attributePrefix
+			const std::string &attributePrefix,
+			const std::vector< PrototypeContextVariable > &prototypeContextVariables
 		)
-			:	m_numPrototypes( 0 ),
+			:	m_primitive( primitive ),
+				m_numPrototypes( 0 ),
 				m_numValidPrototypes( 0 ),
 				m_indices( nullptr ),
 				m_ids( nullptr ),
 				m_positions( nullptr ),
 				m_orientations( nullptr ),
 				m_scales( nullptr ),
-				m_uniformScales( nullptr )
+				m_uniformScales( nullptr ),
+				m_prototypeContextVariables( prototypeContextVariables )
 		{
-			m_primitive = runTimeCast<const Primitive>( object );
 			if( !m_primitive )
 			{
 				return;
@@ -176,6 +386,21 @@ class Instancer::EngineData : public Data
 			}
 
 			initAttributes( attributes, attributePrefix );
+
+			for( const auto &v : m_prototypeContextVariables )
+			{
+				// We need to check if the primVars driving the context are the right size.
+				// There's not an easy way to do this on PrimitiveVariable without knowing the type,
+				// but we can check that it is valid for the primitive, and that the primitive size for that
+				// variable is correct
+				if( v.primVar && !(
+					m_primitive->isPrimitiveVariableValid( *v.primVar ) &&
+					m_primitive->variableSize( v.primVar->interpolation ) == numPoints()
+				) )
+				{
+					throw IECore::Exception( boost::str( boost::format( "Context primitive variable for \"%1%\" is not a correctly sized Vertex primitive variable" ) % v.name.string() ) );
+				}
+			}
 		}
 
 		size_t numPoints() const
@@ -269,7 +494,116 @@ class Instancer::EngineData : public Data
 			return result;
 		}
 
+		typedef std::map< InternedString, boost::unordered_set< IECore::MurmurHash > > PrototypeHashes;
+
+		// In order to compute the number of variations, we compute a unique hash for every context we use
+		// for evaluating prototypes.  So that we can track which sources are responsible for variations,
+		// we return a map of hash sets, with a set of hashes for each variable name in
+		// m_prototypeContextVariables, plus an extra entry for "" for the combined result of all variation
+		// sources
+		std::unique_ptr<PrototypeHashes> uniquePrototypeHashes() const
+		{
+			std::vector< boost::unordered_set< IECore::MurmurHash > > variableHashAccumulate( m_prototypeContextVariables.size() );
+			boost::unordered_set< IECore::MurmurHash > totalHashAccumulate;
+
+			size_t n = numPoints();
+			for( unsigned int i = 0; i < n; i++ )
+			{
+				int protoIndex = prototypeIndex( i );
+				if( protoIndex == -1 )
+				{
+					continue;
+				}
+
+				IECore::MurmurHash totalHash;
+				const InternedStringVectorData &rootPath = *m_roots[ protoIndex ];
+
+				// Note that we are rehashing the root path for every point, even though they are heavily
+				// reused.  This seems suboptimal, but is simpler, and the more complex version doesn't
+				// appear to make any performance difference in practice
+				totalHash.append( &(rootPath.readable())[0], rootPath.readable().size() );
+				for( unsigned int j = 0; j < m_prototypeContextVariables.size(); j++ )
+				{
+					IECore::MurmurHash r; // TODO - if we're using this in inner loops, the constructor should probably be inlined?
+					hashPrototypeContextVariable( i, m_prototypeContextVariables[j], r );
+					variableHashAccumulate[j].insert( r );
+					totalHash.append( r );
+				}
+				totalHashAccumulate.insert( totalHash );
+			}
+
+			// \todo - should use make_unique once we standardize on C++14
+			std::unique_ptr<PrototypeHashes> result( new PrototypeHashes() );
+			for( unsigned int j = 0; j < m_prototypeContextVariables.size(); j++ )
+			{
+				(*result)[ m_prototypeContextVariables[j].name ] = variableHashAccumulate[j];
+			}
+			(*result)[ "" ] = totalHashAccumulate;
+
+			return result;
+		}
+
+		bool hasContextVariables() const
+		{
+			return m_prototypeContextVariables.size() != 0;
+		}
+
+		// Set the context variables in the context for this index, based on the m_prototypeContextVariables
+		// set up for this EngineData
+		void setPrototypeContextVariables( int index, Context::EditableScope &scope ) const
+		{
+			for( unsigned int i = 0; i < m_prototypeContextVariables.size(); i++ )
+			{
+				const PrototypeContextVariable &v = m_prototypeContextVariables[i];
+
+				if( v.seedMode )
+				{
+					scope.set( v.name, seedForPoint( index, v.primVar, v.numSeeds, v.seedScramble ) );
+					continue;
+				}
+
+				if( !v.primVar )
+				{
+					continue;
+				}
+
+				try
+				{
+					IECore::dispatch( v.primVar->data.get(), AccessPrototypeContextVariable(), v, index, scope );
+				}
+				catch( QuantizeException &e )
+				{
+					throw IECore::Exception( boost::str( boost::format( "Context variable \"%1%\" : cannot quantize variable of type %2%" ) % index % v.primVar->data->typeName() ) );
+				}
+			}
+		}
+
 	protected :
+
+		// Needs to match setPrototypeContextVariables above, except that it operates on one
+		// PrototypeContextVariable at a time instead of iterating through them
+		void hashPrototypeContextVariable( int index, const PrototypeContextVariable &v, IECore::MurmurHash &result ) const
+		{
+			if( v.seedMode )
+			{
+				result.append( seedForPoint( index, v.primVar, v.numSeeds, v.seedScramble ) );
+				return;
+			}
+
+			if( !v.primVar )
+			{
+				return;
+			}
+
+			try
+			{
+				IECore::dispatch( v.primVar->data.get(), UniqueHashPrototypeContextVariable(), v, index, result );
+			}
+			catch( QuantizeException &e )
+			{
+				throw IECore::Exception( boost::str( boost::format( "Context variable \"%1%\" : cannot quantize variable of type %2%" ) % index % v.primVar->data->typeName() ) );
+			}
+		}
 
 		void copyFrom( const Object *other, CopyContext *context ) override
 		{
@@ -471,7 +805,7 @@ class Instancer::EngineData : public Data
 		size_t m_numPrototypes;
 		size_t m_numValidPrototypes;
 		Private::ChildNamesMapPtr m_names;
-		std::vector<InternedStringVectorDataPtr> m_roots;
+		std::vector<ConstInternedStringVectorDataPtr> m_roots;
 		std::vector<int> m_prototypeIndexRemap;
 		const std::vector<int> *m_indices;
 		const std::vector<int> *m_ids;
@@ -486,17 +820,70 @@ class Instancer::EngineData : public Data
 		boost::container::flat_map<InternedString, AttributeCreator> m_attributeCreators;
 		MurmurHash m_attributesHash;
 
+		const std::vector< PrototypeContextVariable > m_prototypeContextVariables;
 };
 
 //////////////////////////////////////////////////////////////////////////
 // Instancer
 //////////////////////////////////////////////////////////////////////////
 
+GAFFER_PLUG_DEFINE_TYPE( Instancer::ContextVariablePlug );
+
+Instancer::ContextVariablePlug::ContextVariablePlug( const std::string &name, Direction direction, bool defaultEnable, unsigned flags )
+	:   ValuePlug( name, direction, flags )
+{
+	addChild( new BoolPlug( "enabled", direction, defaultEnable ) );
+	addChild( new StringPlug( "name", direction, "" ) );
+	addChild( new FloatPlug( "quantize", direction, 0.1, 0 ) );
+}
+
+Instancer::ContextVariablePlug::~ContextVariablePlug()
+{
+}
+
+bool Instancer::ContextVariablePlug::acceptsChild( const GraphComponent *potentialChild ) const
+{
+	return children().size() < 3;
+}
+
+Gaffer::PlugPtr Instancer::ContextVariablePlug::createCounterpart( const std::string &name, Direction direction ) const
+{
+	return new Instancer::ContextVariablePlug( name, direction, enabledPlug()->defaultValue(), getFlags() );
+}
+
+Gaffer::BoolPlug *Instancer::ContextVariablePlug::enabledPlug()
+{
+	return getChild<BoolPlug>( 0 );
+}
+
+const Gaffer::BoolPlug *Instancer::ContextVariablePlug::enabledPlug() const
+{
+	return getChild<BoolPlug>( 0 );
+}
+
+Gaffer::StringPlug *Instancer::ContextVariablePlug::namePlug()
+{
+	return getChild<StringPlug>( 1 );
+}
+
+const Gaffer::StringPlug *Instancer::ContextVariablePlug::namePlug() const
+{
+	return getChild<StringPlug>( 1 );
+}
+
+Gaffer::FloatPlug *Instancer::ContextVariablePlug::quantizePlug()
+{
+	return getChild<FloatPlug>( 2 );
+}
+
+const Gaffer::FloatPlug *Instancer::ContextVariablePlug::quantizePlug() const
+{
+	return getChild<FloatPlug>( 2 );
+}
+
 GAFFER_NODE_DEFINE_TYPE( Instancer );
 
 size_t Instancer::g_firstPlugIndex = 0;
-
-static const IECore::InternedString idContextName( "instancer:id" );
 
 Instancer::Instancer( const std::string &name )
 	:	BranchCreator( name )
@@ -515,9 +902,18 @@ Instancer::Instancer( const std::string &name )
 	addChild( new StringPlug( "attributes", Plug::In ) );
 	addChild( new StringPlug( "attributePrefix", Plug::In ) );
 	addChild( new BoolPlug( "encapsulateInstanceGroups", Plug::In ) );
+	addChild( new BoolPlug( "seedEnabled", Plug::In ) );
+	addChild( new StringPlug( "seedVariable", Plug::In, "seed" ) );
+	addChild( new IntPlug( "seeds", Plug::In, 10, 1 ) );
+	addChild( new IntPlug( "seedPermutation", Plug::In ) );
+	addChild( new BoolPlug( "rawSeed", Plug::In ) );
+	addChild( new ValuePlug( "contextVariables", Plug::In ) );
+	addChild( new ContextVariablePlug( "timeOffset", Plug::In, false, Plug::Flags::Default ) );
+	addChild( new AtomicCompoundDataPlug( "variations", Plug::Out, new CompoundData() ) );
 	addChild( new ObjectPlug( "__engine", Plug::Out, NullObject::defaultNullObject() ) );
 	addChild( new AtomicCompoundDataPlug( "__prototypeChildNames", Plug::Out, new CompoundData ) );
 	addChild( new ScenePlug( "__capsuleScene", Plug::Out ) );
+	addChild( new PathMatcherDataPlug( "__setCollaborate", Plug::Out, new IECore::PathMatcherData() ) );
 
 	capsuleScenePlug()->boundPlug()->setInput( outPlug()->boundPlug() );
 	capsuleScenePlug()->transformPlug()->setInput( outPlug()->transformPlug() );
@@ -660,34 +1056,124 @@ const Gaffer::BoolPlug *Instancer::encapsulateInstanceGroupsPlug() const
 	return getChild<BoolPlug>( g_firstPlugIndex + 12 );
 }
 
+Gaffer::BoolPlug *Instancer::seedEnabledPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 13 );
+}
+
+const Gaffer::BoolPlug *Instancer::seedEnabledPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 13 );
+}
+
+Gaffer::StringPlug *Instancer::seedVariablePlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 14 );
+}
+
+const Gaffer::StringPlug *Instancer::seedVariablePlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 14 );
+}
+
+Gaffer::IntPlug *Instancer::seedsPlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 15 );
+}
+
+const Gaffer::IntPlug *Instancer::seedsPlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 15 );
+}
+
+Gaffer::IntPlug *Instancer::seedPermutationPlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 16 );
+}
+
+const Gaffer::IntPlug *Instancer::seedPermutationPlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 16 );
+}
+
+Gaffer::BoolPlug *Instancer::rawSeedPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 17 );
+}
+
+const Gaffer::BoolPlug *Instancer::rawSeedPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 17 );
+}
+
+Gaffer::ValuePlug *Instancer::contextVariablesPlug()
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 18 );
+}
+
+const Gaffer::ValuePlug *Instancer::contextVariablesPlug() const
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 18 );
+}
+
+GafferScene::Instancer::ContextVariablePlug *Instancer::timeOffsetPlug()
+{
+	return getChild<ContextVariablePlug>( g_firstPlugIndex + 19 );
+}
+
+const GafferScene::Instancer::ContextVariablePlug *Instancer::timeOffsetPlug() const
+{
+	return getChild<ContextVariablePlug>( g_firstPlugIndex + 19 );
+}
+
+Gaffer::AtomicCompoundDataPlug *Instancer::variationsPlug()
+{
+	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 20 );
+}
+
+const Gaffer::AtomicCompoundDataPlug *Instancer::variationsPlug() const
+{
+	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 20 );
+}
+
 Gaffer::ObjectPlug *Instancer::enginePlug()
 {
-	return getChild<ObjectPlug>( g_firstPlugIndex + 13 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 21 );
 }
 
 const Gaffer::ObjectPlug *Instancer::enginePlug() const
 {
-	return getChild<ObjectPlug>( g_firstPlugIndex + 13 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 21 );
 }
 
 Gaffer::AtomicCompoundDataPlug *Instancer::prototypeChildNamesPlug()
 {
-	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 14 );
+	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 22 );
 }
 
 const Gaffer::AtomicCompoundDataPlug *Instancer::prototypeChildNamesPlug() const
 {
-	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 14 );
+	return getChild<AtomicCompoundDataPlug>( g_firstPlugIndex + 22 );
 }
 
 GafferScene::ScenePlug *Instancer::capsuleScenePlug()
 {
-	return getChild<ScenePlug>( g_firstPlugIndex + 15 );
+	return getChild<ScenePlug>( g_firstPlugIndex + 23 );
 }
 
 const GafferScene::ScenePlug *Instancer::capsuleScenePlug() const
 {
-	return getChild<ScenePlug>( g_firstPlugIndex + 15 );
+	return getChild<ScenePlug>( g_firstPlugIndex + 23 );
+}
+
+Gaffer::PathMatcherDataPlug *Instancer::setCollaboratePlug()
+{
+	return getChild<PathMatcherDataPlug>( g_firstPlugIndex + 24 );
+}
+
+const Gaffer::PathMatcherDataPlug *Instancer::setCollaboratePlug() const
+{
+	return getChild<PathMatcherDataPlug>( g_firstPlugIndex + 24 );
 }
 
 void Instancer::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
@@ -707,7 +1193,14 @@ void Instancer::affects( const Plug *input, AffectedPlugsContainer &outputs ) co
 		input == orientationPlug() ||
 		input == scalePlug() ||
 		input == attributesPlug() ||
-		input == attributePrefixPlug()
+		input == attributePrefixPlug() ||
+		input == seedEnabledPlug() ||
+		input == seedVariablePlug() ||
+		input == seedsPlug() ||
+		input == seedPermutationPlug() ||
+		input == rawSeedPlug() ||
+		timeOffsetPlug()->isAncestorOf( input ) ||
+		contextVariablesPlug()->isAncestorOf( input )
 	)
 	{
 		outputs.push_back( enginePlug() );
@@ -744,6 +1237,25 @@ void Instancer::affects( const Plug *input, AffectedPlugsContainer &outputs ) co
 	{
 		outputs.push_back( capsuleScenePlug()->setPlug() );
 	}
+
+	if(
+		input == enginePlug() ||
+		input == filterPlug() ||
+		input == inPlug()->childNamesPlug()
+	)
+	{
+		outputs.push_back( variationsPlug() );
+	}
+
+	if(
+		input == enginePlug() ||
+		input == prototypesPlug()->setPlug() ||
+		input == prototypeChildNamesPlug() ||
+		input == namePlug()
+	)
+	{
+		outputs.push_back( setCollaboratePlug() );
+	}
 }
 
 void Instancer::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
@@ -766,10 +1278,107 @@ void Instancer::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 		scalePlug()->hash( h );
 		attributesPlug()->hash( h );
 		attributePrefixPlug()->hash( h );
+
+		seedEnabledPlug()->hash( h );
+		seedVariablePlug()->hash( h );
+		seedsPlug()->hash( h );
+		seedPermutationPlug()->hash( h );
+		rawSeedPlug()->hash( h );
+
+		for( ContextVariablePlug::Iterator it( contextVariablesPlug() ); !it.done(); ++it )
+		{
+			const ContextVariablePlug *plug = it->get();
+			if( plug->enabledPlug()->getValue() )
+			{
+				plug->namePlug()->hash( h );
+				plug->quantizePlug()->hash( h );
+			}
+		}
+
+		if( timeOffsetPlug()->enabledPlug()->getValue() )
+		{
+			timeOffsetPlug()->namePlug()->hash( h );
+			timeOffsetPlug()->quantizePlug()->hash( h );
+		}
 	}
 	else if( output == prototypeChildNamesPlug() )
 	{
 		enginePlug()->hash( h );
+	}
+	else if( output == variationsPlug() )
+	{
+		// The sum of the variations across different engines depends on all the engines, but
+		// not their order.  We can create a cheap order-independent hash by summing the hashes
+		// all of the engines
+		std::atomic<uint64_t> h1Accum( 0 ), h2Accum( 0 );
+		auto functor =[this, &h1Accum, &h2Accum]( const GafferScene::ScenePlug *scene, const GafferScene::ScenePlug::ScenePath &path )
+		{
+			IECore::MurmurHash h = enginePlug()->hash();
+			h1Accum += h.h1();
+			h2Accum += h.h2();
+			return true;
+		};
+		GafferScene::SceneAlgo::filteredParallelTraverse( inPlug(), filterPlug(), functor );
+		h.append( IECore::MurmurHash( h1Accum, h2Accum ) );
+	}
+	else if( output == setCollaboratePlug() )
+	{
+		const ScenePath &parentPath = context->get<ScenePath>( ScenePlug::scenePathContextName );
+
+		ConstEngineDataPtr engine = this->engine( parentPath, context );
+		if( !engine->hasContextVariables() )
+		{
+			// We use a slightly approximate version of hasContextVariables in hashBranchSet, to
+			// avoid computing engine before necessary.  If it turns out that all the context variables
+			// requested were actually invalid, then we can use the same fast approximate hash used in
+			// hashBranchSet.
+			//
+			// This is a little bit weird, because in this scenario, this plug will never be evaluated:
+			// computeBranchSet checks the accurate hasContextVariables before evaluating setCollaboratePlug.
+			// But hashBranchSet is evaluating us, so we have to give a hash that will work for it.
+			//
+			// We could always hash this stuff in hashBranchSet, but we would lose out a benefit of a more
+			// accurate hash when we do actually have context variables:  the slower hash won't change
+			// if point locations change, unlike the engineHash which includes all changes
+			engineHash( parentPath, context, h );
+			prototypeChildNamesHash( parentPath, context, h );
+			prototypesPlug()->setPlug()->hash( h );
+			namePlug()->hash( h );
+			return;
+		}
+
+		IECore::ConstCompoundDataPtr prototypeChildNames = this->prototypeChildNames( parentPath, context );
+
+		for( const auto &prototypeName : engine->prototypeNames()->readable() )
+		{
+			const vector<InternedString> &childNames = prototypeChildNames->member<InternedStringVectorData>( prototypeName )->readable();
+
+			std::atomic<uint64_t> h1Accum( 0 ), h2Accum( 0 );
+			const ThreadState &threadState = ThreadState::current();
+			tbb::parallel_for( tbb::blocked_range<size_t>( 0, childNames.size() ), [&]( const tbb::blocked_range<size_t> &r )
+				{
+					Context::EditableScope scope( threadState );
+					// As part of the setCollaborate plug machinery, we put the parentPath in the context.
+					// Need to remove it before evaluating the prototype sets
+					scope.remove( ScenePlug::scenePathContextName );
+					for( size_t i = r.begin(); i != r.end(); ++i )
+					{
+						const size_t pointIndex = engine->pointIndex( childNames[i] );
+						engine->setPrototypeContextVariables( pointIndex, scope );
+						IECore::MurmurHash instanceH;
+						instanceH.append( childNames[i] );
+						prototypesPlug()->setPlug()->hash( instanceH );
+						h1Accum += instanceH.h1();
+						h2Accum += instanceH.h2();
+					}
+				}
+			);
+
+			const ScenePlug::ScenePath &prototypeRoot = engine->prototypeRoot( prototypeName );
+			h.append( prototypeName );
+			h.append( &prototypeRoot[0], prototypeRoot.size() );
+			h.append( IECore::MurmurHash( h1Accum, h2Accum ) );
+		}
 	}
 }
 
@@ -793,9 +1402,95 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 			);
 		}
 
+		ConstPrimitivePtr primitive = runTimeCast<const Primitive>( inPlug()->objectPlug()->getValue() );
+
+		// Prepare the list of all context variables that affect the prototype scope, in an internal
+		// struct that makes it easier to use them later
+		std::vector< PrototypeContextVariable > prototypeContextVariables;
+
+		// Put together a list of everything that affect the contexts this engine will evaluate prototypes
+		// in
+		if( primitive )
+		{
+			bool timeOffsetEnabled = timeOffsetPlug()->enabledPlug()->getValue();
+			std::string seedContextName = "";
+			if( seedEnabledPlug()->getValue() )
+			{
+				seedContextName = seedVariablePlug()->getValue();
+			}
+
+			for( ContextVariablePlug::Iterator it( contextVariablesPlug() ); !it.done(); ++it )
+			{
+				const ContextVariablePlug *plug = it->get();
+
+				InternedString name = plug->namePlug()->getValue();
+				if( !plug->enabledPlug()->getValue() || name == "" )
+				{
+					continue;
+				}
+
+				if( name.string() == seedContextName )
+				{
+					throw IECore::Exception( "Cannot manually specify \"" + name.string() + "\" which is driven by seedVariable." );
+				}
+				else if( name.string() == "frame" && timeOffsetEnabled )
+				{
+					throw IECore::Exception( "Cannot manually specify \"frame\" when time offset is enabled." );
+				}
+
+				float quantize = plug->quantizePlug()->getValue();
+
+				// We hold onto m_primitive for the lifetime of EngineData, so it's safe to keep raw pointers
+				// to the primvars
+				const PrimitiveVariable *primVar = findVertexVariable( primitive.get(), name );
+
+				// If primVar is null, it will be silently ignored
+				//
+				// \todo : We usually don't want to error on a missing primVar when there's an
+				// obvious fallback ( like just not setting the corresponding context variable ).
+				// But should we at least warn about this somehow?
+				//
+				// We do still insert it into prototypeContextVariables though - this ensures that
+				// all EngineData for this instancer has the same set of variables, which makes it
+				// easier when we compare all the engines to count unique prototypes
+
+				prototypeContextVariables.push_back( { name, primVar, quantize, false, false, 0, 0 } );
+			}
+
+			if( seedContextName != "" )
+			{
+				const PrimitiveVariable *idPrimVar = findVertexVariable( primitive.get(), idPlug()->getValue() );
+				if( idPrimVar && idPrimVar->data->typeId() != IntVectorDataTypeId )
+				{
+					idPrimVar = nullptr;
+				}
+
+				int seeds = rawSeedPlug()->getValue() ? 0 : seedsPlug()->getValue();
+				int seedScramble = seedPermutationPlug()->getValue();
+				prototypeContextVariables.push_back( { seedContextName, idPrimVar, 0, false, true, seeds, seedScramble } );
+			}
+
+			if( timeOffsetEnabled )
+			{
+				const PrimitiveVariable *timeOffsetPrimVar = findVertexVariable( primitive.get(), timeOffsetPlug()->namePlug()->getValue() );
+				if( timeOffsetPrimVar &&
+					timeOffsetPrimVar->data->typeId() != FloatVectorDataTypeId &&
+					timeOffsetPrimVar->data->typeId() != IntVectorDataTypeId
+				)
+				{
+					// \todo : Are we really OK with silently ignoring primvars of the wrong type?
+					// This feels very confusing to users, but matches other behaviour in Instancer
+					timeOffsetPrimVar = nullptr;
+				}
+
+				float quantize = IECore::runTimeCast< const FloatPlug >( timeOffsetPlug()->quantizePlug() )->getValue();
+				prototypeContextVariables.push_back( { "frame", timeOffsetPrimVar, quantize, true, false, 0, 0 } );
+			}
+		}
+
 		static_cast<ObjectPlug *>( output )->setValue(
 			new EngineData(
-				inPlug()->objectPlug()->getValue(),
+				primitive,
 				mode,
 				prototypeIndexPlug()->getValue(),
 				prototypeRootsPlug()->getValue(),
@@ -806,7 +1501,8 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 				orientationPlug()->getValue(),
 				scalePlug()->getValue(),
 				attributesPlug()->getValue(),
-				attributePrefixPlug()->getValue()
+				attributePrefixPlug()->getValue(),
+				prototypeContextVariables
 			)
 		);
 		return;
@@ -857,8 +1553,147 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 		static_cast<AtomicCompoundDataPlug *>( output )->setValue( result );
 		return;
 	}
+	else if( output == variationsPlug() )
+	{
+		// Compute the number of variations by accumulating massive lists of unique hashes from all EngineDatas
+		// and then counting the total number of uniques
+		tbb::spin_mutex locationMutex;
+		std::vector< std::unique_ptr< EngineData::PrototypeHashes > > perLocationHashes;
+
+		auto functor =[this, &locationMutex, &perLocationHashes]( const GafferScene::ScenePlug *scene, const GafferScene::ScenePlug::ScenePath &path )
+		{
+			ConstEngineDataPtr engine = boost::static_pointer_cast<const EngineData>( enginePlug()->getValue() );
+			std::unique_ptr< EngineData::PrototypeHashes > locationHashes = engine->uniquePrototypeHashes();
+
+			tbb::spin_mutex::scoped_lock lock( locationMutex );
+			perLocationHashes.push_back( std::move( locationHashes ) );
+			return true;
+		};
+
+		GafferScene::SceneAlgo::filteredParallelTraverse( inPlug(), filterPlug(), functor );
+
+		CompoundDataPtr result = new CompoundData;
+
+		std::vector< int > numUnique;
+		std::vector< InternedString > outputNames;
+		if( perLocationHashes.size() == 0 )
+		{
+			// There is always an entry for the empty string, which contains the total variations
+			// for all context variables combined
+			result->writable()[""] = new IntData( 0 );
+		}
+		else
+		{
+			if( perLocationHashes.size() == 1 )
+			{
+				// We only have one location, so we can just output the sizes of the hash sets
+				// we got
+				for( const auto &var : *perLocationHashes[0] )
+				{
+					result->writable()[var.first] = new IntData( var.second.size() );
+				}
+			}
+			else
+			{
+				// For multiple locations, we need to merge the hash sets into a single giant set,
+				// and then check its size.  This seems very expensive, but we only do this when
+				// users are using the Context Variation tab, and need a display of how many
+				// variations they are creating.  This plug isn't evaluated at render time.
+				EngineData::PrototypeHashes combine( *perLocationHashes[0] );
+				for( unsigned int i = 1; i < perLocationHashes.size(); i++ )
+				{
+					for( auto &var : *perLocationHashes[i] )
+					{
+						combine[ var.first ].merge( var.second );
+					}
+				}
+				for( const auto &var : combine )
+				{
+					result->writable()[var.first] = new IntData( var.second.size() );
+				}
+			}
+		}
+
+		static_cast<AtomicCompoundDataPlug *>( output )->setValue( result );
+		return;
+	}
+	else if( output == setCollaboratePlug() )
+	{
+		const ScenePath &parentPath = context->get<ScenePath>( ScenePlug::scenePathContextName );
+
+		ConstEngineDataPtr engine = this->engine( parentPath, context );
+
+		IECore::ConstCompoundDataPtr prototypeChildNames = this->prototypeChildNames( parentPath, context );
+
+		PathMatcherDataPtr outputSetData = new PathMatcherData;
+		PathMatcher &outputSet = outputSetData->writable();
+
+		vector<InternedString> branchPath( { namePlug()->getValue() } );
+
+		for( const auto &prototypeName : engine->prototypeNames()->readable() )
+		{
+			branchPath.resize( 2 );
+			branchPath.back() = prototypeName;
+			const ScenePlug::ScenePath &prototypeRoot = engine->prototypeRoot( prototypeName );
+
+			const vector<InternedString> &childNames = prototypeChildNames->member<InternedStringVectorData>( prototypeName )->readable();
+
+			tbb::spin_mutex instanceMutex;
+			branchPath.emplace_back( InternedString() );
+			const ThreadState &threadState = ThreadState::current();
+			tbb::parallel_for( tbb::blocked_range<size_t>( 0, childNames.size() ), [&]( const tbb::blocked_range<size_t> &r )
+				{
+					Context::EditableScope scope( threadState );
+					// As part of the setCollaborate plug machinery, we put the parentPath in the context.
+					// Need to remove it before evaluating the prototype sets
+					scope.remove( ScenePlug::scenePathContextName );
+
+					for( size_t i = r.begin(); i != r.end(); ++i )
+					{
+						const size_t pointIndex = engine->pointIndex( childNames[i] );
+						engine->setPrototypeContextVariables( pointIndex, scope );
+						ConstPathMatcherDataPtr instanceSet = prototypesPlug()->setPlug()->getValue();
+						PathMatcher pointInstanceSet = instanceSet->readable().subTree( prototypeRoot );
+
+						tbb::spin_mutex::scoped_lock lock( instanceMutex );
+						branchPath.back() = childNames[i];
+						outputSet.addPaths( pointInstanceSet, branchPath );
+					}
+				}
+			);
+		}
+
+		static_cast<PathMatcherDataPlug *>( output )->setValue( outputSetData );
+		return;
+	}
 
 	BranchCreator::compute( output, context );
+}
+
+Gaffer::ValuePlug::CachePolicy Instancer::computeCachePolicy( const Gaffer::ValuePlug *output ) const
+{
+	if( output == variationsPlug() )
+	{
+		return ValuePlug::CachePolicy::TaskCollaboration;
+	}
+	else if( output == setCollaboratePlug() )
+	{
+		return ValuePlug::CachePolicy::TaskCollaboration;
+	}
+	return BranchCreator::computeCachePolicy( output );
+}
+
+Gaffer::ValuePlug::CachePolicy Instancer::hashCachePolicy( const Gaffer::ValuePlug *output ) const
+{
+	if( output == variationsPlug() )
+	{
+		return ValuePlug::CachePolicy::TaskCollaboration;
+	}
+	else if( output == setCollaboratePlug() )
+	{
+		return ValuePlug::CachePolicy::TaskCollaboration;
+	}
+	return BranchCreator::hashCachePolicy( output );
 }
 
 bool Instancer::affectsBranchBound( const Gaffer::Plug *input ) const
@@ -1337,7 +2172,8 @@ bool Instancer::affectsBranchSet( const Gaffer::Plug *input ) const
 		input == enginePlug() ||
 		input == prototypesPlug()->setPlug() ||
 		input == prototypeChildNamesPlug() ||
-		input == namePlug()
+		input == namePlug() ||
+		input == setCollaboratePlug()
 	;
 }
 
@@ -1345,14 +2181,54 @@ void Instancer::hashBranchSet( const ScenePath &parentPath, const IECore::Intern
 {
 	BranchCreator::hashBranchSet( parentPath, setName, context, h );
 
-	engineHash( parentPath, context, h );
-	prototypeChildNamesHash( parentPath, context, h );
-	prototypesPlug()->setPlug()->hash( h );
-	namePlug()->hash( h );
+	// If we have context variables, we need to do a much more expensive evaluation of the prototype set
+	// plug in every instance context.  We allow task collaboration on this expensive evaluation by redirecting
+	// to an internal plug when we have context variables.  We could request hasContextVariables off the engine,
+	// but we don't need to evaluate the engine here, so instead we make a conservative hasContextVariables
+	// based on whether the source plugs have been touched
+	bool hasContextVariables =
+		( !timeOffsetPlug()->enabledPlug()->isSetToDefault() && !timeOffsetPlug()->namePlug()->isSetToDefault() ) ||
+		!seedEnabledPlug()->isSetToDefault();
+
+	for( ContextVariablePlug::Iterator it( contextVariablesPlug() ); !it.done() && !hasContextVariables; ++it )
+	{
+		const ContextVariablePlug *plug = it->get();
+
+		hasContextVariables |=
+			( plug->enabledPlug()->getInput() || plug->enabledPlug()->getValue() ) &&
+			!plug->namePlug()->isSetToDefault();
+	}
+
+	if( hasContextVariables )
+	{
+		Context::EditableScope scope( context );
+		scope.set( ScenePlug::scenePathContextName, parentPath );
+		setCollaboratePlug()->hash( h );
+	}
+	else
+	{
+		engineHash( parentPath, context, h );
+		prototypeChildNamesHash( parentPath, context, h );
+		prototypesPlug()->setPlug()->hash( h );
+		namePlug()->hash( h );
+	}
 }
 
 IECore::ConstPathMatcherDataPtr Instancer::computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const
 {
+	ConstEngineDataPtr engine = this->engine( parentPath, context );
+
+	if( engine->hasContextVariables() )
+	{
+		// When doing the much expensive work required when we have context variables, we try to share the
+		// work between multiple threads using an internal PathMatcher plug with a TaskCollaborate policy.
+		// The setCollaborate plug does all the heavy work.  It is evaluated with the parentPath in the
+		// context's scenePath, and it returns a PathMatcher for the set contents of one branch.
+		Context::EditableScope scope( context );
+		scope.set( ScenePlug::scenePathContextName, parentPath );
+		return setCollaboratePlug()->getValue();
+	}
+
 	IECore::ConstCompoundDataPtr prototypeChildNames = this->prototypeChildNames( parentPath, context );
 	ConstPathMatcherDataPtr inputSet = prototypesPlug()->setPlug()->getValue();
 
@@ -1361,7 +2237,6 @@ IECore::ConstPathMatcherDataPtr Instancer::computeBranchSet( const ScenePath &pa
 
 	vector<InternedString> branchPath( { namePlug()->getValue() } );
 
-	ConstEngineDataPtr engine = this->engine( parentPath, context );
 	for( const auto &prototypeName : engine->prototypeNames()->readable() )
 	{
 		branchPath.resize( 2 );
@@ -1435,6 +2310,12 @@ Instancer::PrototypeScope::PrototypeScope( const Gaffer::ObjectPlug *enginePlug,
 	set( ScenePlug::scenePathContextName, parentPath );
 	ConstEngineDataPtr engine = boost::static_pointer_cast<const EngineData>( enginePlug->getValue() );
 	const ScenePlug::ScenePath &prototypeRoot = engine->prototypeRoot( branchPath[1] );
+
+	if( branchPath.size() >= 3 && engine->hasContextVariables() )
+	{
+		const size_t pointIndex = engine->pointIndex( branchPath[2] );
+		engine->setPrototypeContextVariables( pointIndex, *this );
+	}
 
 	if( branchPath.size() > 3 )
 	{

--- a/src/GafferSceneModule/HierarchyBinding.cpp
+++ b/src/GafferSceneModule/HierarchyBinding.cpp
@@ -54,6 +54,7 @@
 #include "GafferScene/MotionPath.h"
 
 #include "GafferBindings/DependencyNodeBinding.h"
+#include "GafferBindings/PlugBinding.h"
 
 using namespace boost::python;
 using namespace IECorePython;
@@ -132,6 +133,20 @@ void GafferSceneModule::bindHierarchy()
 			.value( "IndexedRootsVariable", Instancer::PrototypeMode::IndexedRootsVariable )
 			.value( "RootPerVertex", Instancer::PrototypeMode::RootPerVertex )
 		;
+
+		GafferBindings::PlugClass<Instancer::ContextVariablePlug>()
+			.def( init<const char *, Plug::Direction, bool, unsigned>(
+					(
+						boost::python::arg_( "name" )=GraphComponent::defaultName<Instancer::ContextVariablePlug>(),
+						boost::python::arg_( "direction" )=Plug::In,
+						boost::python::arg_( "defaultEnable" )=true,
+						boost::python::arg_( "flags" )=Plug::Default
+					)
+				)
+			)
+			.attr( "__qualname__" ) = "Instancer.ContextVariablePlug"
+		;
+
 	}
 
 	{


### PR DESCRIPTION
![instancerContexts3](https://user-images.githubusercontent.com/27969079/104797094-71ac4100-5770-11eb-8e63-3d30ae6ae927.png)

Allow changing the contexts that the prototypes plug is evaluated in - a very powerful feature for instancer setups where the instances differ in more complicated ways that just transforms and attributes, but also a very easy way to make very slow setups.  To avoid users creating incredibly slow setups, we've implemented a display for the current number of unique variations being evaluated, and quantization features to reduce this.

Some of this probably still needs work ( particularly tooltips I haven't edited for brevity yet ), but I've now taken an initial cleanup pass over everything, and I think it's close enough to be worth reviewing.

The number of dummy classes I need to use in UI code really makes me wish there was a way to specify arguments for widgets in the metadata, but maybe that's a topic for a different day.