### PR TITLE
CI : Update to Cortex 10.1.4.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
             variant: linux-python2
             publish: true
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.1.1/gafferDependencies-2.1.1-Python2-linux.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.1.4.0/cortex-10.1.4.0-linux-python2.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -57,7 +57,7 @@ jobs:
             variant: linux-python2
             publish: false
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.1.1/gafferDependencies-2.1.1-Python2-linux.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.1.4.0/cortex-10.1.4.0-linux-python2.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -69,7 +69,7 @@ jobs:
             variant: linux-python3
             publish: true
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.1.1/gafferDependencies-2.1.1-Python3-linux.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.1.4.0/cortex-10.1.4.0-linux-python3.tar.gz
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 
@@ -79,7 +79,7 @@ jobs:
             variant: macos-python2
             publish: true
             containerImage:
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.1.1/gafferDependencies-2.1.1-Python2-osx.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.1.4.0/cortex-10.1.4.0-macos-python2.tar.gz
             testRunner: bash -c
             sconsCacheMegabytes: 400
 

--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,11 @@ Improvements
 - Constraint : Added `targetScene` plug, to allow constraining to locations in another scene.
 - OSLObject : Added support for connecting to the individual components of Vector, Point, Normal, UV and Color primitive variable inputs.
 - OSLImage : Added support for connecting to the individual components of channel inputs.
+- SceneReader :
+  - Added support for USD skinning and blendshapes, which are now applied automatically to meshes during loading.
+  - Added interpolation for animated cameras loaded from Alembic caches.
+  - PointsPrimitive variables with Varying interpolation are now conformed to Vertex interpolation on load. This is particularly helpful when loading points written from Houdini.
+- SceneWriter : Added support for writing cameras to Alembic caches.
 
 Fixes
 -----
@@ -47,6 +52,11 @@ API
   - Added `copyIf()` function, to copy metadata matching an arbitrary predicate.
   - Deprecated the complex form of `copy()` in favour of a simpler overload and the new `copyIf()` function.
 - ViewportGadget : `setCameraTransform` now properly removes scale and shear from the supplied matrix.
+
+Build
+-----
+
+- Cortex : Updated to version 10.1.4.0.
 
 0.59.0.0
 ========


### PR DESCRIPTION
This uses the new release packages recently added to Cortex, which take an existing GafferHQ/dependencies package and refresh it with a more recent Cortex build.
