### PR TITLE
SceneInspector : Alternate presentation options

### DIFF
--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -672,7 +672,7 @@ class TextDiff( SideBySideDiff ) :
 ## A class to simplify the process of making rows with alternating colours.
 class Row( GafferUI.Widget ) :
 
-	def __init__( self, borderWidth = 4, alternate = False, **kw ) :
+	def __init__( self, borderWidth = 4, **kw ) :
 
 		self.__frame = GafferUI.Frame( borderWidth = borderWidth, borderStyle = GafferUI.Frame.BorderStyle.None_ )
 
@@ -682,25 +682,9 @@ class Row( GafferUI.Widget ) :
 			 GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
 		)
 
-		self.__alternate = None
-		self.setAlternate( alternate )
-
 	def listContainer( self ) :
 
 		return self.__frame.getChild()
-
-	def setAlternate( self, alternate ) :
-
-		if alternate == self.__alternate :
-			return
-
-		self.__alternate = alternate
-		self.__frame._qtWidget().setProperty( "gafferAlternate", bool(alternate) )
-		self.__frame._repolish()
-
-	def getAlternate( self ) :
-
-		return self.__alternate
 
 ##########################################################################
 # Inspector
@@ -758,11 +742,11 @@ class Inspector( object ) :
 ## \todo This would probably be more accurately described as an InspectorRow
 class DiffRow( Row ) :
 
-	def __init__( self, inspector, diffCreator = TextDiff, alternate = False, **kw ) :
+	def __init__( self, inspector, diffCreator = TextDiff, **kw ) :
 
 		assert( isinstance( inspector, Inspector ) )
 
-		Row.__init__( self, alternate=alternate, **kw )
+		Row.__init__( self, **kw )
 
 		with self.listContainer() :
 
@@ -1102,7 +1086,6 @@ class DiffColumn( GafferUI.Widget ) :
 			patterns = " ".join( "*" + p + "*" if "*" not in p else p for p in patterns )
 
 		numValidRows = 0
-		numVisibleRows = 0
 		for row in self.__rowContainer :
 
 			visible = False
@@ -1112,9 +1095,6 @@ class DiffColumn( GafferUI.Widget ) :
 					visible = True
 
 			row.setVisible( visible )
-			if visible :
-				row.setAlternate( numVisibleRows % 2 )
-				numVisibleRows += 1
 
 		self.__header.setVisible( numValidRows )
 
@@ -1305,7 +1285,7 @@ class _InheritanceSection( Section ) :
 
 			if value is not None or atEitherEnd or prevValue is not None or i == 1 :
 
-				row = Row( borderWidth = 0, alternate = len( rows ) % 2 )
+				row = Row( borderWidth = 0 )
 				rows.append( row )
 				with row.listContainer() :
 
@@ -1493,7 +1473,7 @@ class _HistorySection( Section ) :
 					# just skip it.
 					continue
 
-			row = Row( borderWidth = 0, alternate = len( rows ) % 2 )
+			row = Row( borderWidth = 0 )
 			rows.append( row )
 
 			with row.listContainer() :
@@ -1663,24 +1643,17 @@ class __TransformSection( LocationSection ) :
 		LocationSection.__init__( self, collapsed = True, label = "Transform" )
 
 		with self._mainColumn() :
-			index = 0
 			for transform in ( "transform", "fullTransform" )  :
 
 				inspector = self.__Inspector( transform )
-				DiffRow(
-					inspector,
-					alternate = index % 2,
-				)
-				index += 1
+				DiffRow( inspector )
 
 				for component in ( "t", "r", "s", "h" ) :
 
 					DiffRow(
 						self.__Inspector( transform, component ),
 						diffCreator = functools.partial( self.__diffCreator, name = inspector.name() ),
-						alternate = index % 2,
 					)
-					index += 1
 
 	def update( self, targets ) :
 
@@ -1754,7 +1727,7 @@ class __BoundSection( LocationSection ) :
 
 		with self._mainColumn() :
 			self.__localBoundRow = DiffRow( self.__Inspector() )
-			self.__worldBoundRow = DiffRow( self.__Inspector( world = True ), alternate = True )
+			self.__worldBoundRow = DiffRow( self.__Inspector( world = True ) )
 
 	def update( self, targets ) :
 
@@ -2419,7 +2392,6 @@ class __OutputsSection( Section ) :
 				self.__rows[outputName] = row
 
 			row.update( targets )
-			row.setAlternate( len( rows ) % 2 )
 			rows.append( row )
 
 		self._mainColumn()[:] = rows

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1356,6 +1356,16 @@ _styleSheet = string.Template(
 	 * and use that to drive the styling.
 	 */
 
+	*[gafferDiff="A"],
+	*[gafferDiff="B"],
+	*[gafferDiff="AB"],
+	*[gafferDiff="Other"]
+	{
+		border: 1px solid $tintLighterSubtle;
+		border-top-color: $tintDarkerStrong;
+		border-left-color: $tintDarkerStrong;
+	}
+
 	*[gafferDiff="A"] {
 		background: solid rgba( 181, 30, 0, 80 );
 	}
@@ -1365,15 +1375,19 @@ _styleSheet = string.Template(
 	}
 
 	*[gafferDiff="AB"] {
-		background: solid rgba( 170, 170, 170, 60 );
+		background: solid $tintDarker;
 	}
 
 	*[gafferDiff="Other"] {
-		background: solid rgba( 70, 184, 255, 25 );
+		background: solid rgba( 10, 94, 165, 25 );
 	}
 
 	*[gafferAlternate="true"] {
-		background-color: $backgroundAlt;
+		background-color: $tintLighterSubtle;
+	}
+
+	*[gafferAlternate="true" ] *[gafferDiff="AB"] {
+		background-color: $tintDarkerStrong;
 	}
 
 	*[gafferDiff="A"][gafferHighlighted="true"],
@@ -1432,6 +1446,7 @@ _styleSheet = string.Template(
 	/* relevant adjoining properties to false, rather than omitting them   */
 
 	*[gafferAdjoinedTop="true"] {
+		border-top: none;
 		border-top-left-radius: 0px;
 		border-top-right-radius: 0px;
 	}
@@ -1442,6 +1457,7 @@ _styleSheet = string.Template(
 	}
 
 	*[gafferAdjoinedBottom="true"] {
+		border-bottom: none;
 		border-bottom-left-radius: 0px;
 		border-bottom-right-radius: 0px;
 	}
@@ -1452,6 +1468,7 @@ _styleSheet = string.Template(
 	}
 
 	*[gafferAdjoinedLeft="true"] {
+		border-left: none;
 		border-top-left-radius: 0px;
 		border-bottom-left-radius: 0px;
 	}
@@ -1462,6 +1479,7 @@ _styleSheet = string.Template(
 	}
 
 	*[gafferAdjoinedRight="true"] {
+		border-right: none;
 		border-top-right-radius: 0px;
 		border-bottom-right-radius: 0px;
 	}


### PR DESCRIPTION
Following on from the discussions on #4091 (and prior work in #3832), if we wish to follow the 'dark background for non-editable data' pattern established in #3832, we need to ensure we are consistent in existing UIs.

The premise established was that in an EditScope-aware workflow, value presentation needs to reflect edit state. Usually one of :

 - Not editable
 - Editable (no existing edits)
 - Edited

The SceneView Inspector settled on:

 - Non editable : Dark background
 - Edited (existing edits) Light/tinted background.

Several existing UI elements make use of a light background for read-only data. When presenting this along side editable fields, this can be a little confusing as there are few clues to differentiate an editing widget vs a read-only value display.

This PR provides two potential amendments to the `SceneInspector` that better aligns it with these principals. The second commit removes alternating backgrounds. It visually simplifies the UI, but perhaps looses some readability. This needs some further testing.

<img src="https://user-images.githubusercontent.com/896779/105070031-9e1ad280-5a7a-11eb-9fa9-0b0e6939ffa1.png" width=350/><img src="https://user-images.githubusercontent.com/896779/105070038-a07d2c80-5a7a-11eb-84be-988c866eae6c.png" width=350/>