### PR TITLE
Instancer : Correct Handling of Non-Unique Prototype Roots

### DIFF
--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -1091,6 +1091,48 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 			script["instancer"]["out"].childNames, "/object/instances",
 		)
 
+		# Same tests with unindexed primvar
+		updateRoots( IECore.StringVectorData( [ "", "", "", ""] ), None )
+		self.assertUnderspecifiedRoots( script )
+		updateRoots( IECore.StringVectorData( [ "/foo", "/foo", "/foo", "/foo" ] ), None )
+		self.assertSingleRoot( script )
+		updateRoots( IECore.StringVectorData( [ "/foo", "/bar", "/bar", "/foo" ] ), None )
+		self.assertRootsMatchPrototypeSceneChildren( script )
+		updateRoots( IECore.StringVectorData( [ "/foo/bar", "/bar", "/bar", "/foo/bar" ] ), None )
+		self.assertConflictingRootNames( script )
+		updateRoots( IECore.StringVectorData( [ "/bar", "/foo", "/foo", "/bar" ] ), None )
+		self.assertSwappedRoots( script )
+		updateRoots( IECore.StringVectorData( [ "", "/bar", "/bar", "" ] ), None )
+		self.assertSkippedRoots( script )
+		updateRoots( IECore.StringVectorData( [ "/foo/bar/sphere", "/bar/baz/cube", "/bar/baz/cube", "/foo/bar/sphere" ] ), None )
+		self.assertRootsToLeaves( script )
+		updateRoots( IECore.StringVectorData( [ "/", "/", "/", "/" ] ), None )
+		self.assertRootsToRoot( script )
+		updateRoots( IECore.StringVectorData( [ "/foo", "/does/not/exist", "/does/not/exist", "/foo" ] ), None )
+		six.assertRaisesRegex( self,
+			Gaffer.ProcessException, '.*Prototype root "/does/not/exist" does not exist.*',
+			script["instancer"]["out"].childNames, "/object/instances",
+		)
+
+		# Same tests with indexed primvar that isn't fully unique
+		updateRoots( IECore.StringVectorData( [ "", "" ] ), IECore.IntVectorData( [ 0, 0, 1, 1 ] ) )
+		self.assertUnderspecifiedRoots( script )
+		updateRoots( IECore.StringVectorData( [ "/foo", "/foo" ] ), IECore.IntVectorData( [ 0, 0, 1, 1 ] ) )
+		self.assertSingleRoot( script )
+		updateRoots( IECore.StringVectorData( [ "/foo", "/bar", "/bar" ] ), IECore.IntVectorData( [ 0, 1, 2, 0 ] ) )
+		self.assertRootsMatchPrototypeSceneChildren( script )
+		updateRoots( IECore.StringVectorData( [ "/foo/bar", "/foo/bar", "/bar" ] ), IECore.IntVectorData( [ 0, 2, 2, 1 ] ) )
+		self.assertConflictingRootNames( script )
+		updateRoots( IECore.StringVectorData( [ "/bar", "/foo", "/foo" ] ), IECore.IntVectorData( [ 0, 2, 1, 0 ] ) )
+		self.assertSwappedRoots( script )
+		updateRoots( IECore.StringVectorData( [ "", "/bar", "", "/bar" ] ), IECore.IntVectorData( [ 0, 1, 3, 2 ] ) )
+		self.assertSkippedRoots( script )
+		updateRoots( IECore.StringVectorData( [ "/foo/bar/sphere", "/bar/baz/cube", "/bar/baz/cube" ] ), IECore.IntVectorData( [ 0, 1, 2, 0 ] ) )
+		self.assertRootsToLeaves( script )
+		updateRoots( IECore.StringVectorData( [ "/", "/" ] ), IECore.IntVectorData( [ 0, 0, 1, 0 ] ) )
+		self.assertRootsToRoot( script )
+
+
 		script["instancer"]["prototypeRoots"].setValue( "notAPrimVar" )
 		six.assertRaisesRegex( self,
 			Gaffer.ProcessException, ".*must be Vertex StringVectorData when using RootPerVertex mode.*does not exist.*",

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -210,9 +210,14 @@ class Instancer::EngineData : public Data
 			return m_numValidPrototypes;
 		}
 
-		int prototypeIndex( size_t pointIndex ) const
+		inline int prototypeRemap( size_t protoIndex ) const
 		{
-			return m_prototypeIndexRemap[ ( m_indices ? (*m_indices)[pointIndex] : 0 ) % m_numPrototypes ];
+			return m_prototypeIndexRemap[ protoIndex % m_numPrototypes ];
+		}
+
+		inline int prototypeIndex( size_t pointIndex ) const
+		{
+			return prototypeRemap( m_indices ? (*m_indices)[pointIndex] : 0 );
 		}
 
 		const ScenePlug::ScenePath &prototypeRoot( const InternedString &name ) const
@@ -441,25 +446,14 @@ class Instancer::EngineData : public Data
 					throw IECore::Exception( boost::str( boost::format( "Prototype root \"%1%\" does not exist in the `prototypes` scene" ) % root ) );
 				}
 
-				if( path.empty() )
+				if( path.empty() && root != "/" )
 				{
-					if( root == "/" )
-					{
-						inputNames.emplace_back( new InternedStringVectorData( { g_prototypeRootName } ) );
-						m_roots.emplace_back( new InternedStringVectorData( path ) );
-						m_prototypeIndexRemap.emplace_back( i++ );
-					}
-					else
-					{
-						m_prototypeIndexRemap.emplace_back( -1 );
-					}
+					m_prototypeIndexRemap.emplace_back( -1 );
+					continue;
 				}
-				else
-				{
-					inputNames.emplace_back( new InternedStringVectorData( { path.back() } ) );
-					m_roots.emplace_back( new InternedStringVectorData( path ) );
-					m_prototypeIndexRemap.emplace_back( i++ );
-				}
+				inputNames.emplace_back( new InternedStringVectorData( { root == "/" ? g_prototypeRootName : path.back() } ) );
+				m_roots.emplace_back( new InternedStringVectorData( path ) );
+				m_prototypeIndexRemap.emplace_back( i++ );
 			}
 
 			m_names = new Private::ChildNamesMap( inputNames );


### PR DESCRIPTION
This ended up stumping me way more than expected - the interaction between m_indices, m_prototypeIndexRemap, the different prototypeMode inputs, and the fact that performance may be important here, adds up to a kinda tricky knot.

I've added tests that show the problem, assuming my interpretation of what should be correct ( two PrimitiveVariables that would look the same through an IndexedView should produce identical outputs from the Instancer, independently of how they are actually indexed ).

For the sake of discussion, I've added a commit that works.  There is an issue with what keys to use in the uniqueness detector, which need to be both hashable, and fast to compare ( neither raw strings or ScenePath seem quite ideal for this ).  But aside from that, it all feels a bit overly tricky ... the trick with swapping the m_prototypeIndexRemap into being the actual indices when the indices are just a passthrough feels a bit overly clever and not clear enough.  Maybe looking at this suggests a clearer approach to you?