### PR TITLE
Metadata : reduce signalling overhead

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - Serialisation : Reduced script save times by around 50%.
+- Metadata : Reduced signalling overhead, particularly when loading a script while the UI is open. One benchmark shows a reduction of 97%.
 - Expression : Improved error message when Python expression assigns an invalid value.
 - Numeric Bookmarks : Changed the Editor <kbd>1</kbd>-<kbd>9</kbd> hotkeys to follow the bookmark rather than pinning it (#4074).
 - Editors : Simplified the Editor Focus Menu, removing some seldom used (but potentially ambiguous) modes (#4074).

--- a/Changes.md
+++ b/Changes.md
@@ -39,6 +39,7 @@ Breaking Changes
   - `repr()` now takes a `Serialisation *` where it used to take a `const Serialisation *`.
   - `valueRepr()` now has an optional `serialisation` argument.
 - Metadata : Added new signals which are emitted with per-node granularity. These provide significantly reduced overhead compared to _all_ metadata observers being notified of _all_ metadata changes.
+- MetadataAlgo : Added `readOnlyAffectedByChange()` overload suitable for use with new metadata signals.
 - MetadataBinding :
   - Added `serialisation` required argument to `metadataSerialisation()`.
   - Removed `metadataModuleDependencies()` method. Module dependencies are now declared automatically by `metadataSerialisation()`.

--- a/Changes.md
+++ b/Changes.md
@@ -38,6 +38,7 @@ Breaking Changes
 - ValuePlugBinding :
   - `repr()` now takes a `Serialisation *` where it used to take a `const Serialisation *`.
   - `valueRepr()` now has an optional `serialisation` argument.
+- Metadata : Added new signals which are emitted with per-node granularity. These provide significantly reduced overhead compared to _all_ metadata observers being notified of _all_ metadata changes.
 - MetadataBinding :
   - Added `serialisation` required argument to `metadataSerialisation()`.
   - Removed `metadataModuleDependencies()` method. Module dependencies are now declared automatically by `metadataSerialisation()`.

--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -64,17 +64,6 @@ class GAFFER_API Metadata
 
 	public :
 
-		/// Type for a singal emitted when new metadata is registered.
-		typedef boost::signal<void ( IECore::InternedString target, IECore::InternedString key ), CatchingSignalCombiner<void> > ValueChangedSignal;
-		/// Type for a signal emitted when new node metadata is registered. The
-		/// node argument will be null when generic (rather than per-instance)
-		/// metadata is registered.
-		typedef boost::signal<void ( IECore::TypeId nodeTypeId, IECore::InternedString key, Gaffer::Node *node ), CatchingSignalCombiner<void> > NodeValueChangedSignal;
-		/// Type for a signal emitted when new plug metadata is registered. The
-		/// plug argument will be null when generic (rather than per-instance)
-		/// metadata is registered.
-		typedef boost::signal<void ( IECore::TypeId typeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, Gaffer::Plug *plug ), CatchingSignalCombiner<void> > PlugValueChangedSignal;
-
 		typedef std::function<IECore::ConstDataPtr ()> ValueFunction;
 		typedef std::function<IECore::ConstDataPtr ( const GraphComponent *graphComponent )> GraphComponentValueFunction;
 		typedef std::function<IECore::ConstDataPtr ( const Plug *plug )> PlugValueFunction;
@@ -153,22 +142,54 @@ class GAFFER_API Metadata
 		/// with a GraphComponentValueFunction or PlugValueFunction then it is the
 		/// responsibility of the registrant to manually emit the signals
 		/// when necessary.
+
+		enum class ValueChangedReason
+		{
+			StaticRegistration,
+			StaticDeregistration,
+			InstanceRegistration,
+			InstanceDeregistration
+		};
+
+		using ValueChangedSignal = boost::signal<void ( IECore::InternedString target, IECore::InternedString key ), CatchingSignalCombiner<void>>;
+		using NodeValueChangedSignal = boost::signal<void ( Node *node, IECore::InternedString key, ValueChangedReason reason ), CatchingSignalCombiner<void>>;
+		using PlugValueChangedSignal = boost::signal<void ( Plug *plug, IECore::InternedString key, ValueChangedReason reason ), CatchingSignalCombiner<void>>;
+
 		static ValueChangedSignal &valueChangedSignal();
-		static NodeValueChangedSignal &nodeValueChangedSignal();
-		static PlugValueChangedSignal &plugValueChangedSignal();
+		/// Returns a signal that will be emitted when metadata has changed for `node`.
+		static NodeValueChangedSignal &nodeValueChangedSignal( Node *node );
+		/// Returns a signal that will be emitted when metadata has changed for any plug on `node`.
+		static PlugValueChangedSignal &plugValueChangedSignal( Node *node );
+
+		/// Legacy signals
+		/// ==============
+		///
+		/// These signals are emitted when metadata is changed on _any_ node or
+		/// plug. Their usage leads to performance bottlenecks whereby all observers
+		/// are triggered by all edits. They will be removed in future.
+
+		using LegacyNodeValueChangedSignal = boost::signal<void ( IECore::TypeId nodeTypeId, IECore::InternedString key, Gaffer::Node *node ), CatchingSignalCombiner<void>>;
+		using LegacyPlugValueChangedSignal = boost::signal<void ( IECore::TypeId typeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, Gaffer::Plug *plug ), CatchingSignalCombiner<void>>;
+
+		/// Deprecated, but currently necessary for tracking inherited
+		/// changes to read-only metadata.
+		/// \deprecated
+		static LegacyNodeValueChangedSignal &nodeValueChangedSignal();
+		/// \deprecated
+		static LegacyPlugValueChangedSignal &plugValueChangedSignal();
 
 	private :
 
 		/// Per-instance Metadata is stored as a mapping from GraphComponent * to the
 		/// metadata values, and needs to be removed when the instance dies. Currently
 		/// there is no callback when a RefCounted object passes away, so we must rely
-		/// on the destructors for Node and Plug to call clearInstanceMetadata() for us.
+		/// on the destructors for Node and Plug to call instanceDestroyed() for us.
 		/// \todo This situation isn't particularly satisfactory - if we introduced
 		/// weak pointers and destruction callbacks for RefCounted objects then we could
 		/// tidy this up.
 		friend class Node;
 		friend class Plug;
-		static void clearInstanceMetadata( const GraphComponent *graphComponent );
+		static void instanceDestroyed( GraphComponent *graphComponent );
 
 		static IECore::ConstDataPtr valueInternal( IECore::InternedString target, IECore::InternedString key );
 		static IECore::ConstDataPtr valueInternal( const GraphComponent *target, IECore::InternedString key, bool instanceOnly );

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -103,6 +103,7 @@ GAFFER_API const GraphComponent *readOnlyReason( const GraphComponent *graphComp
 /// Determines if a metadata value change affects the result of `readOnly( graphComponent )`.
 GAFFER_API bool readOnlyAffectedByChange( const GraphComponent *graphComponent, IECore::TypeId changedNodeTypeId, const IECore::StringAlgo::MatchPattern &changedPlugPath, const IECore::InternedString &changedKey, const Gaffer::Plug *changedPlug );
 GAFFER_API bool readOnlyAffectedByChange( const GraphComponent *graphComponent, IECore::TypeId changedNodeTypeId, const IECore::InternedString &changedKey, const Gaffer::Node *changedNode );
+GAFFER_API bool readOnlyAffectedByChange( const GraphComponent *graphComponent, const Gaffer::GraphComponent *changedGraphComponent, const IECore::InternedString &changedKey );
 GAFFER_API bool readOnlyAffectedByChange( const IECore::InternedString &changedKey );
 
 /// Bookmarks

--- a/include/GafferUI/CompoundNumericNodule.h
+++ b/include/GafferUI/CompoundNumericNodule.h
@@ -74,7 +74,7 @@ class GAFFERUI_API CompoundNumericNodule : public StandardNodule
 		NoduleLayout *noduleLayout();
 		const NoduleLayout *noduleLayout() const;
 
-		void plugMetadataChanged( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
+		void plugMetadataChanged( const Gaffer::Plug *plug, IECore::InternedString key );
 		void updateChildNoduleVisibility();
 
 		static NoduleTypeDescription<CompoundNumericNodule> g_noduleTypeDescription;

--- a/include/GafferUI/NoduleLayout.h
+++ b/include/GafferUI/NoduleLayout.h
@@ -127,8 +127,8 @@ class GAFFERUI_API NoduleLayout : public Gadget
 		void childAdded( Gaffer::GraphComponent *child );
 		void childRemoved( Gaffer::GraphComponent *child );
 
-		void plugMetadataChanged( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
-		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node );
+		void plugMetadataChanged( const Gaffer::Plug *plug, IECore::InternedString key );
+		void nodeMetadataChanged( const Gaffer::Node *node, IECore::InternedString key );
 
 		std::vector<GadgetKey> layoutOrder();
 		void updateNoduleLayout();

--- a/include/GafferUI/StandardConnectionGadget.h
+++ b/include/GafferUI/StandardConnectionGadget.h
@@ -114,7 +114,7 @@ class GAFFERUI_API StandardConnectionGadget : public ConnectionGadget
 		bool keyPressed( const KeyEvent &event );
 		bool keyReleased( const KeyEvent &event );
 
-		void plugMetadataChanged( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
+		void plugMetadataChanged( const Gaffer::Plug *plug, IECore::InternedString key );
 
 		bool updateUserColor();
 

--- a/include/GafferUI/StandardNodule.h
+++ b/include/GafferUI/StandardNodule.h
@@ -93,7 +93,7 @@ class GAFFERUI_API StandardNodule : public Nodule
 
 	private :
 
-		void plugMetadataChanged( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug );
+		void plugMetadataChanged( const Gaffer::Plug *plug, IECore::InternedString key );
 
 		bool updateUserColor();
 

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -693,7 +693,7 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 					GafferUI.Label( "Description" )
 					self.__descriptionWidget = GafferUI.MultiLineStringPlugValueWidget( plug = None )
 
-		Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataValueChanged ), scoped = False )
+		Gaffer.Metadata.plugValueChangedSignal( plug.node() ).connect( Gaffer.WeakMethod( self.__plugMetadataValueChanged ), scoped = False )
 
 		self.contextMenuSignal().connect( Gaffer.WeakMethod( self.__contextMenu ), scoped = False )
 
@@ -725,15 +725,10 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 
 		self.__column.setEnabled( self._editable() )
 
-	def __plugMetadataValueChanged( self, typeId, plugPath, key, plug ) :
+	def __plugMetadataValueChanged( self, plug, key, reason ) :
 
-		if key != _columnsMetadataKey :
-			return
-
-		if plug and not plug.isSame( self.getPlug() ) :
-			return
-
-		self.__pathListing.setColumns( self.__listingColumns() )
+		if key == _columnsMetadataKey and plug == self.getPlug() :
+			self.__pathListing.setColumns( self.__listingColumns() )
 
 	def __getColumns( self ) :
 

--- a/python/GafferTest/BoxTest.py
+++ b/python/GafferTest/BoxTest.py
@@ -575,12 +575,12 @@ class BoxTest( GafferTest.TestCase ) :
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["r"] ] ) )
 		p = b.promotePlug( b["r"]["floatRange"] )
 
-		cs = GafferTest.CapturingSlot( Gaffer.Metadata.plugValueChangedSignal() )
+		cs = GafferTest.CapturingSlot( Gaffer.Metadata.plugValueChangedSignal( b ) )
 
 		Gaffer.Metadata.registerValue( p, "description", "hello" )
 
 		self.assertEqual( len( cs ), 1 )
-		self.assertEqual( cs[0], ( Gaffer.Box.staticTypeId(), p.relativeName( b ), "description", p ) )
+		self.assertEqual( cs[0], ( p, "description", Gaffer.Metadata.ValueChangedReason.InstanceRegistration ) )
 
 	def testNodeMetadata( self ) :
 
@@ -609,16 +609,16 @@ class BoxTest( GafferTest.TestCase ) :
 		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["r"] ] ) )
 		p = b.promotePlug( b["r"]["floatRange"] )
 
-		ncs = GafferTest.CapturingSlot( Gaffer.Metadata.nodeValueChangedSignal() )
-		pcs = GafferTest.CapturingSlot( Gaffer.Metadata.plugValueChangedSignal() )
+		ncs = GafferTest.CapturingSlot( Gaffer.Metadata.nodeValueChangedSignal( b ) )
+		pcs = GafferTest.CapturingSlot( Gaffer.Metadata.plugValueChangedSignal( b ) )
 
 		Gaffer.Metadata.registerValue( b, "description", "t" )
 		Gaffer.Metadata.registerValue( p, "description", "tt" )
 
 		self.assertEqual( len( ncs ), 1 )
 		self.assertEqual( len( pcs ), 1 )
-		self.assertEqual( ncs[0], ( Gaffer.Box.staticTypeId(), "description", b ) )
-		self.assertEqual( pcs[0], ( Gaffer.Box.staticTypeId(), p.relativeName( b ), "description", p ) )
+		self.assertEqual( ncs[0], ( b, "description", Gaffer.Metadata.ValueChangedReason.InstanceRegistration ) )
+		self.assertEqual( pcs[0], ( p, "description", Gaffer.Metadata.ValueChangedReason.InstanceRegistration ) )
 
 		Gaffer.Metadata.registerValue( b, "description", "t" )
 		Gaffer.Metadata.registerValue( p, "description", "tt" )
@@ -631,8 +631,8 @@ class BoxTest( GafferTest.TestCase ) :
 
 		self.assertEqual( len( ncs ), 2 )
 		self.assertEqual( len( pcs ), 2 )
-		self.assertEqual( ncs[1], ( Gaffer.Box.staticTypeId(), "description", b ) )
-		self.assertEqual( pcs[1], ( Gaffer.Box.staticTypeId(), p.relativeName( b ), "description", p ) )
+		self.assertEqual( ncs[1], ( b, "description", Gaffer.Metadata.ValueChangedReason.InstanceRegistration ) )
+		self.assertEqual( pcs[1], ( p, "description", Gaffer.Metadata.ValueChangedReason.InstanceRegistration ) )
 
 	def testMetadataUndo( self ) :
 

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -341,6 +341,29 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s3["r"].load( self.temporaryDirectory() + "/test.grf" )
 		self.assertEqual( Gaffer.Metadata.value( s3["r"]["p"], "test" ), "edited" )
 
+	def testStaticMetadataRegistrationIsntAnEdit( self ) :
+
+		# Export a box
+
+		s = Gaffer.ScriptNode()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["staticMetadataTestPlug"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
+
+		# Reference it
+
+		s["r"] = Gaffer.Reference()
+		s["r"].load( self.temporaryDirectory() + "/test.grf" )
+
+		# Make a static metadata registration. Although this will
+		# be signalled as a metadata change, it must not be considered
+		# to be a metadata edit on the reference, as it does not apply
+		# to a specific plug instance.
+
+		Gaffer.Metadata.registerValue( Gaffer.Reference, "staticMetadataTestPlug", "test", 10 )
+		self.assertFalse( s["r"].hasMetadataEdit( s["r"]["staticMetadataTestPlug"], "test" ) )
+
 	def testAddPlugMetadata( self ) :
 
 		# Export a box with no metadata

--- a/python/GafferUI/ButtonPlugValueWidget.py
+++ b/python/GafferUI/ButtonPlugValueWidget.py
@@ -51,7 +51,6 @@ class ButtonPlugValueWidget( GafferUI.PlugValueWidget ) :
 		GafferUI.PlugValueWidget.__init__( self, self.__button, plug, **kw )
 
 		self.__button.clickedSignal().connect( Gaffer.WeakMethod( self.__clicked ), scoped = False )
-		Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = False )
 
 		self.setPlug( plug )
 
@@ -64,8 +63,12 @@ class ButtonPlugValueWidget( GafferUI.PlugValueWidget ) :
 		GafferUI.PlugValueWidget.setPlug( self, plug )
 
 		self.__nameChangedConnection = None
+		self.__plugMetadataChangedConnection = None
 		if plug is not None :
 			self.__nameChangedConnection = plug.nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ) )
+			self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( plug.node() ).connect(
+				Gaffer.WeakMethod( self.__plugMetadataChanged )
+			)
 
 		self.__updateLabel()
 
@@ -104,10 +107,7 @@ class ButtonPlugValueWidget( GafferUI.PlugValueWidget ) :
 				with self.getContext() :
 					exec( code, executionDict, executionDict )
 
-	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
+	def __plugMetadataChanged( self, plug, key, reason ) :
 
-		if self.getPlug() is None :
-			return
-
-		if key=="label" and Gaffer.MetadataAlgo.affectedByChange( self.getPlug(), nodeTypeId, plugPath, plug ) :
+		if key=="label" and plug == self.getPlug() :
 			self.__updateLabel()

--- a/python/GafferUI/MetadataWidget.py
+++ b/python/GafferUI/MetadataWidget.py
@@ -67,12 +67,12 @@ class MetadataWidget( GafferUI.Widget ) :
 		self.setEnabled( self.__target is not None )
 
 		if isinstance( self.__target, Gaffer.Node ) :
-			self.__metadataChangedConnection = Gaffer.Metadata.nodeValueChangedSignal().connect(
-				Gaffer.WeakMethod( self.__nodeMetadataChanged )
+			self.__metadataChangedConnection = Gaffer.Metadata.nodeValueChangedSignal( self.__target ).connect(
+				Gaffer.WeakMethod( self.__metadataChanged )
 			)
 		elif isinstance( self.__target, Gaffer.Plug ) :
-			self.__metadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect(
-				Gaffer.WeakMethod( self.__plugMetadataChanged )
+			self.__metadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( self.__target.node() ).connect(
+				Gaffer.WeakMethod( self.__metadataChanged )
 			)
 		else :
 			self.__metadataChangedConnection = None
@@ -139,23 +139,9 @@ class MetadataWidget( GafferUI.Widget ) :
 
 		self._updateFromValue( v if v is not None else self.defaultValue() )
 
-	def __nodeMetadataChanged( self, nodeTypeId, key, node ) :
+	def __metadataChanged( self, target, key, reason ) :
 
-		if self.__key != key :
-			return
-		if node is not None and not node.isSame( self.__target ) :
-			return
-		if not self.__target.isInstanceOf( nodeTypeId ) :
-			return
-
-		self.__update()
-
-	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
-
-		if self.__key != key :
-			return
-
-		if Gaffer.MetadataAlgo.affectedByChange( self.__target, nodeTypeId, plugPath, plug ) :
+		if key == self.__key and target == self.__target :
 			self.__update()
 
 	@staticmethod

--- a/python/GafferUI/NameWidget.py
+++ b/python/GafferUI/NameWidget.py
@@ -67,7 +67,7 @@ class NameWidget( GafferUI.TextWidget ) :
 			if isinstance( self.__graphComponent, Gaffer.Node ) :
 				self.__metadataChangedConnection = Gaffer.Metadata.nodeValueChangedSignal().connect( Gaffer.WeakMethod( self.__nodeMetadataChanged ) )
 			elif isinstance( self.__graphComponent, Gaffer.Plug ) :
-				self.__metadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
+				self.__metadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( self.__graphComponent.node() ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
 			else :
 				self.__metadataChangedConnection = None
 		else :
@@ -109,10 +109,10 @@ class NameWidget( GafferUI.TextWidget ) :
 		) :
 			self.__updateEditability()
 
-	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
+	def __plugMetadataChanged( self, plug, key, reason ) :
 
 		if (
-			Gaffer.MetadataAlgo.readOnlyAffectedByChange( self.__graphComponent, nodeTypeId, plugPath, key, plug ) or
+			Gaffer.MetadataAlgo.readOnlyAffectedByChange( self.__graphComponent, plug, key ) or
 			plug == self.__graphComponent and key == "renameable"
 		) :
 			self.__updateEditability()

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -114,7 +114,7 @@ class PlugLayout( GafferUI.Widget ) :
 
 		# since our layout is driven by metadata, we must respond dynamically
 		# to changes in that metadata.
-		Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = False )
+		Gaffer.Metadata.plugValueChangedSignal( self.__node() ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = False )
 
 		# and since our activations are driven by plug values, we must respond
 		# when the plugs are dirtied.
@@ -523,11 +523,9 @@ class PlugLayout( GafferUI.Widget ) :
 		elif hasattr( widget, "plugValueWidget" ) :
 			widget.plugValueWidget().setContext( context )
 
-	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
+	def __plugMetadataChanged( self, plug, key, reason ) :
 
-		parentAffected = isinstance( self.__parent, Gaffer.Plug ) and Gaffer.MetadataAlgo.affectedByChange( self.__parent, nodeTypeId, plugPath, plug )
-		childAffected = Gaffer.MetadataAlgo.childAffectedByChange( self.__parent, nodeTypeId, plugPath, plug )
-		if not parentAffected and not childAffected :
+		if plug != self.__parent and plug.parent() != self.__parent :
 			return
 
 		if key in (

--- a/python/GafferUI/SpreadsheetUI/_PlugTableModel.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableModel.py
@@ -64,7 +64,7 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 		self.__rowRemovedConnection = rowsPlug.childRemovedSignal().connect( Gaffer.WeakMethod( self.__rowRemoved ) )
 		self.__columnAddedConnection = rowsPlug.defaultRow()["cells"].childAddedSignal().connect( Gaffer.WeakMethod( self.__columnAdded ) )
 		self.__columnRemovedConnection = rowsPlug.defaultRow()["cells"].childRemovedSignal().connect( Gaffer.WeakMethod( self.__columnRemoved ) )
-		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
+		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( rowsPlug.node() ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
 		self.__contextChangedConnection = self.__context.changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ) )
 
 	# Methods of our own
@@ -337,10 +337,7 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 		if index.isValid() :
 			self.dataChanged.emit( index, index )
 
-	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
-
-		if plug is None :
-			return
+	def __plugMetadataChanged( self, plug, key, reason ) :
 
 		index = self.indexForPlug( plug )
 		if not index.isValid() :

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -106,7 +106,7 @@ class _PlugTableView( GafferUI.Widget ) :
 			# instead.
 			tableView.setProperty( "gafferToggleIndicator", True )
 
-		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect(
+		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( tableView.model().rowsPlug().node() ).connect(
 			Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = False
 		)
 
@@ -327,10 +327,7 @@ class _PlugTableView( GafferUI.Widget ) :
 
 		self.__applySectionOrderMetadata()
 
-	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
-
-		if plug is None :
-			return
+	def __plugMetadataChanged( self, plug, key, reason ) :
 
 		rowsPlug = self._qtWidget().model().rowsPlug()
 

--- a/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
+++ b/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
@@ -157,7 +157,7 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 			widget.mouseMoveSignal().connect( Gaffer.WeakMethod( self.__cellsMouseMove ), scoped = False )
 			widget.leaveSignal().connect( Gaffer.WeakMethod( self.__cellsLeave ), scoped = False )
 
-		Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = False )
+		Gaffer.Metadata.plugValueChangedSignal( plug.node() ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = False )
 
 		self.__updateVisibleSections()
 		self.__updateDefaultRowVisibility()
@@ -251,7 +251,7 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 		# would do the trick?
 		self.__defaultTable._qtWidget().setRowHidden( 0, not visible )
 
-	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
+	def __plugMetadataChanged( self, plug, key, reason ) :
 
 		if plug == self.getPlug() and key == "spreadsheet:defaultRowVisible" :
 			self.__updateDefaultRowVisibility()

--- a/python/GafferUI/SpreadsheetUI/_SectionChooser.py
+++ b/python/GafferUI/SpreadsheetUI/_SectionChooser.py
@@ -67,7 +67,7 @@ class _SectionChooser( GafferUI.Widget ) :
 		tabBar.currentChanged.connect( Gaffer.WeakMethod( self.__currentChanged ) )
 		self.__ignoreCurrentChanged = False
 		tabBar.tabMoved.connect( Gaffer.WeakMethod( self.__tabMoved ) )
-		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
+		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( self.__rowsPlug.node() ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
 		self.__rowsPlug.defaultRow()["cells"].childAddedSignal().connect( Gaffer.WeakMethod( self.__columnAdded ), scoped = False )
 		self.__rowsPlug.defaultRow()["cells"].childRemovedSignal().connect( Gaffer.WeakMethod( self.__columnRemoved ), scoped = False )
 
@@ -166,10 +166,7 @@ class _SectionChooser( GafferUI.Widget ) :
 				i
 			)
 
-	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
-
-		if plug is None :
-			return
+	def __plugMetadataChanged( self, plug, key, reason ) :
 
 		if key == "spreadsheet:section" and self.__rowsPlug.isAncestorOf( plug ) :
 			self.__updateTabs()

--- a/python/GafferUI/UserPlugs.py
+++ b/python/GafferUI/UserPlugs.py
@@ -123,9 +123,10 @@ class __PlugCreationWidget( GafferUI.Widget ) :
 		Gaffer.Metadata.nodeValueChangedSignal().connect(
 			Gaffer.WeakMethod( self.__nodeMetadataChanged ), scoped = False
 		)
-		Gaffer.Metadata.plugValueChangedSignal().connect(
-			Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = False
-		)
+		if isinstance( plugParent, Gaffer.Plug ) :
+			Gaffer.Metadata.plugValueChangedSignal( plugParent.node() ).connect(
+				Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = False
+			)
 
 		self.__updateReadOnly()
 
@@ -144,8 +145,7 @@ class __PlugCreationWidget( GafferUI.Widget ) :
 		if Gaffer.MetadataAlgo.readOnlyAffectedByChange( self.__plugParent, nodeTypeId, key, node ) :
 			self.__updateReadOnly()
 
-	def __plugMetadataChanged( self, nodeTypeId, plugPath, key, plug ) :
+	def __plugMetadataChanged( self, plug, key, reason ) :
 
-		if Gaffer.MetadataAlgo.readOnlyAffectedByChange( self.__plugParent, nodeTypeId, plugPath, key, plug ) :
+		if Gaffer.MetadataAlgo.readOnlyAffectedByChange( self.__plugParent, plug, key ) :
 			self.__updateReadOnly()
-

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -59,8 +59,15 @@ using namespace tbb;
 using namespace IECore;
 using namespace Gaffer;
 
+//////////////////////////////////////////////////////////////////////////
+// Internal implementation details
+//////////////////////////////////////////////////////////////////////////
+
 namespace
 {
+
+// Value storage for string targets
+// ================================
 
 typedef std::pair<InternedString, Metadata::ValueFunction> NamedValue;
 
@@ -81,6 +88,9 @@ MetadataMap &metadataMap()
 	static auto g_m = new MetadataMap;
 	return *g_m;
 }
+
+// Value storage for type-based targets
+// ====================================
 
 struct GraphComponentMetadata
 {
@@ -122,6 +132,9 @@ GraphComponentMetadataMap &graphComponentMetadataMap()
 	static auto g_m = new GraphComponentMetadataMap;
 	return *g_m;
 }
+
+// Value storage for instance targets
+// ==================================
 
 struct NamedInstanceValue
 {
@@ -294,6 +307,10 @@ void registeredInstanceValues( const GraphComponent *graphComponent, std::vector
 }
 
 } // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Public implementation
+//////////////////////////////////////////////////////////////////////////
 
 void Metadata::registerValue( IECore::InternedString target, IECore::InternedString key, IECore::ConstDataPtr value )
 {

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -53,6 +53,8 @@
 
 #include "tbb/tbb.h"
 
+#include <unordered_map>
+
 using namespace std;
 using namespace boost;
 using namespace tbb;
@@ -65,6 +67,140 @@ using namespace Gaffer;
 
 namespace
 {
+
+// Signals
+// =======
+//
+// We store all our signals in a map indexed by `Node *`. Although we do not
+// allow concurrent edits to a node graph, we do allow different node graphs to
+// be edited concurrently from different threads. This means that we require
+// thread-safety for the operations on the map, but _not_ for the signals
+// themselves. `tbb::concurrent_unordered_map` would be ideal for this if it
+// provided concurrent erasure, but it doesn't. And in practice we expect
+// very little contention anyway, so just use a simple `std::unordered_map`
+// protected by a mutex.
+
+struct Signals
+{
+	Metadata::NodeValueChangedSignal nodeSignal;
+	Metadata::PlugValueChangedSignal plugSignal;
+};
+
+using SignalsMap = std::unordered_map<Node *, unique_ptr<Signals>>;
+using SignalsMapLock = tbb::recursive_mutex::scoped_lock;
+
+// Access to the signals requires the passing of a scoped_lock that
+// will be locked for you automatically, and must remain locked while
+// the result is used.
+SignalsMap &signalsMap( SignalsMapLock &lock )
+{
+	static SignalsMap *g_signalsMap = new SignalsMap;
+	static tbb::recursive_mutex g_signalsMapMutex;
+	lock.acquire( g_signalsMapMutex );
+	return *g_signalsMap;
+}
+
+Signals *nodeSignals( Node *node, bool createIfMissing )
+{
+	SignalsMapLock lock;
+	auto &m = signalsMap( lock );
+
+	auto it = m.find( node );
+	if( it == m.end() )
+	{
+		if( !createIfMissing )
+		{
+			return nullptr;
+		}
+		it = m.emplace( node, std::make_unique<Signals>() ).first;
+	}
+	return it->second.get();
+}
+
+void emitValueChangedSignals( IECore::TypeId typeId, IECore::InternedString key, Metadata::ValueChangedReason reason )
+{
+	if( typeId == Node::staticTypeId() || RunTimeTyped::inheritsFrom( typeId, Node::staticTypeId() ) )
+	{
+		Metadata::nodeValueChangedSignal()( typeId, key, nullptr );
+
+		SignalsMapLock lock;
+		for( const auto &s : signalsMap( lock ) )
+		{
+			if( s.first->isInstanceOf( typeId ) )
+			{
+				s.second->nodeSignal( s.first, key, reason );
+			}
+		}
+	}
+	else if( typeId == Plug::staticTypeId() || RunTimeTyped::inheritsFrom( typeId, Plug::staticTypeId() ) )
+	{
+		Metadata::plugValueChangedSignal()( typeId, "", key, nullptr );
+
+		SignalsMapLock lock;
+		for( const auto &s : signalsMap( lock ) )
+		{
+			for( auto &plug : Plug::RecursiveRange( *s.first ) )
+			{
+				if( plug->isInstanceOf( typeId ) )
+				{
+					s.second->plugSignal( plug.get(), key, reason );
+				}
+			}
+		}
+	}
+}
+
+void emitMatchingPlugValueChangedSignals( Metadata::PlugValueChangedSignal &signal, Plug *plug, const vector<InternedString> &path, const StringAlgo::MatchPatternPath &matchPath, IECore::InternedString key, Metadata::ValueChangedReason reason )
+{
+	/// \todo There is scope for pruning the recursion here early if we
+	/// reproduce the logic of StringAlgo::match ourselves. We don't
+	/// really expect this code path to be exercised while there are active
+	/// signals though, as type-based (rather than instance-based) registrations
+	/// are typically only made during startup.
+	if( StringAlgo::match( path, matchPath ) )
+	{
+		signal( plug, key, reason );
+	}
+
+	vector<InternedString> childPath = path;
+	childPath.push_back( InternedString() ); // Room for child name
+	for( const auto &child : Plug::Range( *plug ) )
+	{
+		childPath.back() = child->getName();
+		emitMatchingPlugValueChangedSignals( signal, child.get(), childPath, matchPath, key, reason );
+	}
+}
+
+// The `matchPatternPath` is passed redundantly rather than derived from `plugPath`
+// because in all cases we have already done the work of tokenizing it outside this function.
+void emitPlugValueChangedSignals( IECore::TypeId ancestorTypeId, const StringAlgo::MatchPattern &plugPath, const StringAlgo::MatchPatternPath &matchPatternPath, IECore::InternedString key, Metadata::ValueChangedReason reason )
+{
+	assert( reason == Metadata::ValueChangedReason::StaticRegistration || reason == Metadata::ValueChangedReason::StaticDeregistration );
+
+	Metadata::plugValueChangedSignal()( ancestorTypeId, plugPath, key, nullptr );
+
+	SignalsMapLock lock;
+	for( const auto &s : signalsMap( lock ) )
+	{
+		if( s.first->isInstanceOf( ancestorTypeId ) )
+		{
+			for( const auto &plug : Plug::Range( *s.first ) )
+			{
+				emitMatchingPlugValueChangedSignals( s.second->plugSignal, plug.get(), { plug->getName() }, matchPatternPath, key, reason );
+			}
+		}
+		else if( ancestorTypeId == Plug::staticTypeId() || RunTimeTyped::inheritsFrom( ancestorTypeId, Plug::staticTypeId() ) )
+		{
+			for( const auto &plug : Plug::RecursiveRange( *s.first ) )
+			{
+				if( plug->isInstanceOf( ancestorTypeId ) )
+				{
+					emitMatchingPlugValueChangedSignals( s.second->plugSignal, plug.get(), {}, matchPatternPath, key, reason );
+				}
+			}
+		}
+	}
+}
 
 // Value storage for string targets
 // ================================
@@ -243,15 +379,25 @@ void registerInstanceValueAction( GraphComponent *instance, InternedString key, 
 		}
 	}
 
+	const Metadata::ValueChangedReason reason = value ? Metadata::ValueChangedReason::InstanceRegistration : Metadata::ValueChangedReason::InstanceDeregistration;
+
 	if( Node *node = runTimeCast<Node>( instance ) )
 	{
 		Metadata::nodeValueChangedSignal()( node->typeId(), key, node );
+		if( Signals *s = nodeSignals( node, /* createIfMissing = */ false ) )
+		{
+			s->nodeSignal( node, key, reason );
+		}
 	}
 	else if( Plug *plug = runTimeCast<Plug>( instance ) )
 	{
-		if( const Node *node = plug->node() )
+		if( Node *node = plug->node() )
 		{
 			Metadata::plugValueChangedSignal()( node->typeId(), plug->relativeName( node ), key, plug );
+			if( Signals *s = nodeSignals( node, /* createIfMissing = */ false ) )
+			{
+				s->plugSignal( plug, key, reason );
+			}
 		}
 	}
 }
@@ -403,14 +549,7 @@ void Metadata::registerValue( IECore::TypeId typeId, IECore::InternedString key,
 		m.replace( it, namedValue );
 	}
 
-	if( typeId == Node::staticTypeId() || RunTimeTyped::inheritsFrom( typeId, Node::staticTypeId() ) )
-	{
-		nodeValueChangedSignal()( typeId, key, nullptr );
-	}
-	else if( typeId == Plug::staticTypeId() || RunTimeTyped::inheritsFrom( typeId, Plug::staticTypeId() ) )
-	{
-		plugValueChangedSignal()( typeId, "", key, nullptr );
-	}
+	emitValueChangedSignals( typeId, key, Metadata::ValueChangedReason::StaticRegistration );
 }
 
 void Metadata::deregisterValue( IECore::TypeId typeId, IECore::InternedString key )
@@ -423,21 +562,14 @@ void Metadata::deregisterValue( IECore::TypeId typeId, IECore::InternedString ke
 	}
 
 	m.erase( it );
-
-	if( typeId == Node::staticTypeId() || RunTimeTyped::inheritsFrom( typeId, Node::staticTypeId() ) )
-	{
-		nodeValueChangedSignal()( typeId, key, nullptr );
-	}
-	else if( typeId == Plug::staticTypeId() || RunTimeTyped::inheritsFrom( typeId, Plug::staticTypeId() ) )
-	{
-		plugValueChangedSignal()( typeId, "", key, nullptr );
-	}
+	emitValueChangedSignals( typeId, key, Metadata::ValueChangedReason::StaticDeregistration );
 }
 
 void Metadata::deregisterValue( IECore::TypeId ancestorTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key )
 {
 	auto &m = graphComponentMetadataMap()[ancestorTypeId];
-	auto &plugValues = m.plugPathsToValues[StringAlgo::matchPatternPath( plugPath, '.' )];
+	const StringAlgo::MatchPatternPath matchPatternPath = StringAlgo::matchPatternPath( plugPath, '.' );
+	auto &plugValues = m.plugPathsToValues[matchPatternPath];
 
 	auto it = plugValues.find( key );
 	if( it == plugValues.end() )
@@ -446,7 +578,8 @@ void Metadata::deregisterValue( IECore::TypeId ancestorTypeId, const StringAlgo:
 	}
 
 	plugValues.erase( it );
-	plugValueChangedSignal()( ancestorTypeId, plugPath, key, nullptr );
+
+	emitPlugValueChangedSignals( ancestorTypeId, plugPath, matchPatternPath, key, Metadata::ValueChangedReason::StaticDeregistration );
 }
 
 void Metadata::deregisterValue( GraphComponent *target, IECore::InternedString key )
@@ -497,8 +630,9 @@ void Metadata::registerValue( IECore::TypeId ancestorTypeId, const StringAlgo::M
 
 void Metadata::registerValue( IECore::TypeId ancestorTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key, PlugValueFunction value )
 {
-	auto &graphComponentMetadata = graphComponentMetadataMap()[ancestorTypeId];
-	auto &plugValues = graphComponentMetadata.plugPathsToValues[StringAlgo::matchPatternPath( plugPath, '.' )];
+	auto &m = graphComponentMetadataMap()[ancestorTypeId];
+	const StringAlgo::MatchPatternPath matchPatternPath = StringAlgo::matchPatternPath( plugPath, '.' );
+	auto &plugValues = m.plugPathsToValues[matchPatternPath];
 
 	GraphComponentMetadata::NamedPlugValue namedValue( key, value );
 
@@ -512,7 +646,7 @@ void Metadata::registerValue( IECore::TypeId ancestorTypeId, const StringAlgo::M
 		plugValues.replace( it, namedValue );
 	}
 
-	plugValueChangedSignal()( ancestorTypeId, plugPath, key, nullptr );
+	emitPlugValueChangedSignals( ancestorTypeId, plugPath, matchPatternPath, key, Metadata::ValueChangedReason::StaticRegistration );
 }
 
 std::vector<Plug*> Metadata::plugsWithMetadata( GraphComponent *root, IECore::InternedString key, bool instanceOnly )
@@ -706,19 +840,34 @@ Metadata::ValueChangedSignal &Metadata::valueChangedSignal()
 	return *s;
 }
 
-Metadata::NodeValueChangedSignal &Metadata::nodeValueChangedSignal()
+Metadata::NodeValueChangedSignal &Metadata::nodeValueChangedSignal( Node *node )
 {
-	static NodeValueChangedSignal *s = new NodeValueChangedSignal;
+	return nodeSignals( node, /* createIfMissing = */ true )->nodeSignal;
+}
+
+Metadata::PlugValueChangedSignal &Metadata::plugValueChangedSignal( Node *node )
+{
+	return nodeSignals( node, /* createIfMissing = */ true )->plugSignal;
+}
+
+Metadata::LegacyNodeValueChangedSignal &Metadata::nodeValueChangedSignal()
+{
+	static LegacyNodeValueChangedSignal *s = new LegacyNodeValueChangedSignal;
 	return *s;
 }
 
-Metadata::PlugValueChangedSignal &Metadata::plugValueChangedSignal()
+Metadata::LegacyPlugValueChangedSignal &Metadata::plugValueChangedSignal()
 {
-	static PlugValueChangedSignal *s = new PlugValueChangedSignal;
+	static LegacyPlugValueChangedSignal *s = new LegacyPlugValueChangedSignal;
 	return *s;
 }
 
-void Metadata::clearInstanceMetadata( const GraphComponent *graphComponent )
+void Metadata::instanceDestroyed( GraphComponent *graphComponent )
 {
 	instanceMetadataMap().erase( graphComponent );
+	if( auto node = runTimeCast<Node>( graphComponent ) )
+	{
+		SignalsMapLock lock;
+		signalsMap( lock ).erase( node );
+	}
 }

--- a/src/Gaffer/MetadataAlgo.cpp
+++ b/src/Gaffer/MetadataAlgo.cpp
@@ -203,6 +203,19 @@ bool readOnlyAffectedByChange( const GraphComponent *graphComponent, IECore::Typ
 	return false;
 }
 
+bool readOnlyAffectedByChange( const GraphComponent *graphComponent, const Gaffer::GraphComponent *changedGraphComponent, const IECore::InternedString &changedKey )
+{
+	if( changedKey == g_readOnlyName )
+	{
+		return changedGraphComponent == graphComponent || changedGraphComponent->isAncestorOf( graphComponent );
+	}
+	else if( changedKey == g_childNodesAreReadOnlyName )
+	{
+		return changedGraphComponent->isAncestorOf( graphComponent );
+	}
+	return false;
+}
+
 bool readOnlyAffectedByChange( const IECore::InternedString &changedKey )
 {
 	return changedKey == g_readOnlyName || changedKey == g_childNodesAreReadOnlyName;

--- a/src/Gaffer/Node.cpp
+++ b/src/Gaffer/Node.cpp
@@ -56,7 +56,7 @@ Node::Node( const std::string &name )
 
 Node::~Node()
 {
-	Metadata::clearInstanceMetadata( this );
+	Metadata::instanceDestroyed( this );
 }
 
 Node::UnaryPlugSignal &Node::plugSetSignal()

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -125,7 +125,7 @@ Plug::~Plug()
 		(*it)->setInputInternal( nullptr, true );
 		it = next;
 	}
-	Metadata::clearInstanceMetadata( this );
+	Metadata::instanceDestroyed( this );
 }
 
 bool Plug::acceptsChild( const GraphComponent *potentialChild ) const

--- a/src/GafferModule/MetadataAlgoBinding.cpp
+++ b/src/GafferModule/MetadataAlgoBinding.cpp
@@ -168,6 +168,11 @@ void GafferModule::bindMetadataAlgo()
 	);
 	def(
 		"readOnlyAffectedByChange",
+		(bool (*)( const GraphComponent *, const GraphComponent *, const IECore::InternedString & ))&readOnlyAffectedByChange,
+		( arg( "graphComponent" ), arg( "changedGraphComponent"), arg( "changedKey" ) )
+	);
+	def(
+		"readOnlyAffectedByChange",
 		(bool (*)( const IECore::InternedString & ))&readOnlyAffectedByChange,
 		( arg( "changedKey" ) )
 	);

--- a/src/GafferModule/MetadataBinding.cpp
+++ b/src/GafferModule/MetadataBinding.cpp
@@ -254,6 +254,18 @@ struct ValueChangedSlotCaller
 		return boost::signals::detail::unusable();
 	}
 
+	boost::signals::detail::unusable operator()( boost::python::object slot, Node *node, IECore::InternedString key, Metadata::ValueChangedReason reason )
+	{
+		slot( NodePtr( node ), key.c_str(), reason );
+		return boost::signals::detail::unusable();
+	}
+
+	boost::signals::detail::unusable operator()( boost::python::object slot, Plug *plug, IECore::InternedString key, Metadata::ValueChangedReason reason )
+	{
+		slot( PlugPtr( plug ), key.c_str(), reason );
+		return boost::signals::detail::unusable();
+	}
+
 	boost::signals::detail::unusable operator()( boost::python::object slot, IECore::TypeId nodeTypeId, IECore::InternedString key, Node *node )
 	{
 		slot( nodeTypeId, key.c_str(), NodePtr( node ) );
@@ -386,10 +398,12 @@ void GafferModule::bindMetadata()
 		.def( "valueChangedSignal", &Metadata::valueChangedSignal, return_value_policy<reference_existing_object>() )
 		.staticmethod( "valueChangedSignal" )
 
-		.def( "nodeValueChangedSignal", &Metadata::nodeValueChangedSignal, return_value_policy<reference_existing_object>() )
+		.def( "nodeValueChangedSignal", (Metadata::LegacyNodeValueChangedSignal &(*)() )&Metadata::nodeValueChangedSignal, return_value_policy<reference_existing_object>() )
+		.def( "nodeValueChangedSignal", (Metadata::NodeValueChangedSignal &(*)( Gaffer::Node * ) )&Metadata::nodeValueChangedSignal, return_value_policy<reference_existing_object>() )
 		.staticmethod( "nodeValueChangedSignal" )
 
-		.def( "plugValueChangedSignal", &Metadata::plugValueChangedSignal, return_value_policy<reference_existing_object>() )
+		.def( "plugValueChangedSignal", (Metadata::LegacyPlugValueChangedSignal &(*)() )&Metadata::plugValueChangedSignal, return_value_policy<reference_existing_object>() )
+		.def( "plugValueChangedSignal", (Metadata::PlugValueChangedSignal &(*)( Gaffer::Node * ) )&Metadata::plugValueChangedSignal, return_value_policy<reference_existing_object>() )
 		.staticmethod( "plugValueChangedSignal" )
 
 		.def( "plugsWithMetadata", &plugsWithMetadata,
@@ -411,8 +425,17 @@ void GafferModule::bindMetadata()
 		.staticmethod( "nodesWithMetadata" )
 	;
 
+	enum_<Metadata::ValueChangedReason>( "ValueChangedReason" )
+		.value( "StaticRegistration", Metadata::ValueChangedReason::StaticRegistration )
+		.value( "StaticDeregistration", Metadata::ValueChangedReason::StaticDeregistration )
+		.value( "InstanceRegistration", Metadata::ValueChangedReason::InstanceRegistration )
+		.value( "InstanceDeregistration", Metadata::ValueChangedReason::InstanceDeregistration )
+	;
+
 	SignalClass<Metadata::ValueChangedSignal, DefaultSignalCaller<Metadata::ValueChangedSignal>, ValueChangedSlotCaller>( "ValueChangedSignal" );
 	SignalClass<Metadata::NodeValueChangedSignal, DefaultSignalCaller<Metadata::NodeValueChangedSignal>, ValueChangedSlotCaller>( "NodeValueChangedSignal" );
 	SignalClass<Metadata::PlugValueChangedSignal, DefaultSignalCaller<Metadata::PlugValueChangedSignal>, ValueChangedSlotCaller>( "PlugValueChangedSignal" );
+	SignalClass<Metadata::LegacyNodeValueChangedSignal, DefaultSignalCaller<Metadata::LegacyNodeValueChangedSignal>, ValueChangedSlotCaller>( "LegacyNodeValueChangedSignal" );
+	SignalClass<Metadata::LegacyPlugValueChangedSignal, DefaultSignalCaller<Metadata::LegacyPlugValueChangedSignal>, ValueChangedSlotCaller>( "LegacyPlugValueChangedSignal" );
 
 }

--- a/src/GafferOSL/OSLCode.cpp
+++ b/src/GafferOSL/OSLCode.cpp
@@ -461,7 +461,7 @@ void OSLCode::parameterAdded( const Gaffer::GraphComponent *parent, Gaffer::Grap
 		// OSLShaderUI registers a dynamic metadata entry which depends on whether or
 		// not the plug has children, so we must notify the world that the value will
 		// have changed.
-		Metadata::plugValueChangedSignal()( staticTypeId(), "out", "nodule:type", outPlug() );
+		Metadata::plugValueChangedSignal( this )( outPlug(), "nodule:type", Metadata::ValueChangedReason::StaticRegistration );
 	}
 
 	child->nameChangedSignal().connect( boost::bind( &OSLCode::parameterNameChanged, this ) );
@@ -475,7 +475,7 @@ void OSLCode::parameterRemoved( const Gaffer::GraphComponent *parent, Gaffer::Gr
 		// OSLShaderUI registers a dynamic metadata entry which depends on whether or
 		// not the plug has children, so we must notify the world that the value will
 		// have changed.
-		Metadata::plugValueChangedSignal()( staticTypeId(), "out", "nodule:type", outPlug() );
+		Metadata::plugValueChangedSignal( this )( outPlug(), "nodule:type", Metadata::ValueChangedReason::StaticRegistration );
 	}
 
 	child->nameChangedSignal().disconnect( boost::bind( &OSLCode::parameterNameChanged, this ) );

--- a/src/GafferOSL/OSLShader.cpp
+++ b/src/GafferOSL/OSLShader.cpp
@@ -1077,7 +1077,7 @@ void OSLShader::loadShader( const std::string &shaderName, bool keepExistingValu
 		// OSLShaderUI registers a dynamic metadata entry which depends on whether or
 		// not the plug has children, so we must notify the world that the value will
 		// have changed.
-		Metadata::plugValueChangedSignal()( staticTypeId(), "out", "nodule:type", outPlug() );
+		Metadata::plugValueChangedSignal( this )( outPlug(), "nodule:type", Metadata::ValueChangedReason::StaticRegistration );
 	}
 }
 

--- a/src/GafferSceneUI/ShaderTweaksUI.cpp
+++ b/src/GafferSceneUI/ShaderTweaksUI.cpp
@@ -72,7 +72,9 @@ class TweakPlugAdder : public PlugAdder
 			plugsParent->node()->plugInputChangedSignal().connect( boost::bind( &TweakPlugAdder::plugInputChanged, this, ::_1 ) );
 			plugsParent->childAddedSignal().connect( boost::bind( &TweakPlugAdder::childAdded, this ) );
 			plugsParent->childRemovedSignal().connect( boost::bind( &TweakPlugAdder::childRemoved, this ) );
-			Metadata::plugValueChangedSignal().connect( boost::bind( &TweakPlugAdder::plugMetadataChanged, this, ::_1, ::_2, ::_3, ::_4 ) );
+			Metadata::plugValueChangedSignal( plugsParent->node() ).connect(
+				boost::bind( &TweakPlugAdder::plugMetadataChanged, this, ::_1, ::_2 )
+			);
 			buttonReleaseSignal().connect( boost::bind( &TweakPlugAdder::buttonRelease, this, ::_2 ) );
 
 			updateVisibility();
@@ -200,9 +202,9 @@ class TweakPlugAdder : public PlugAdder
 			updateVisibility();
 		}
 
-		void plugMetadataChanged( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
+		void plugMetadataChanged( const Gaffer::Plug *plug, IECore::InternedString key )
 		{
-			if( MetadataAlgo::childAffectedByChange( m_plugsParent.get(), nodeTypeId, plugPath, plug ) )
+			if( plug->parent() == m_plugsParent )
 			{
 				if( key == g_visibleKey || key == g_noduleTypeKey )
 				{

--- a/src/GafferSceneUI/ShaderUI.cpp
+++ b/src/GafferSceneUI/ShaderUI.cpp
@@ -68,7 +68,9 @@ class ShaderPlugAdder : public PlugAdder
 		{
 			plugsParent->childAddedSignal().connect( boost::bind( &ShaderPlugAdder::childAdded, this ) );
 			plugsParent->childRemovedSignal().connect( boost::bind( &ShaderPlugAdder::childRemoved, this ) );
-			Metadata::plugValueChangedSignal().connect( boost::bind( &ShaderPlugAdder::plugMetadataChanged, this, ::_1, ::_2, ::_3, ::_4 ) );
+			Metadata::plugValueChangedSignal( plugsParent->ancestor<Node>() ).connect(
+				boost::bind( &ShaderPlugAdder::plugMetadataChanged, this, ::_1, ::_2 )
+			);
 
 			buttonReleaseSignal().connect( boost::bind( &ShaderPlugAdder::buttonRelease, this, ::_2 ) );
 
@@ -171,9 +173,9 @@ class ShaderPlugAdder : public PlugAdder
 			updateVisibility();
 		}
 
-		void plugMetadataChanged( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
+		void plugMetadataChanged( const Gaffer::Plug *plug, IECore::InternedString key )
 		{
-			if( MetadataAlgo::childAffectedByChange( m_plugsParent.get(), nodeTypeId, plugPath, plug ) )
+			if( plug->parent() == m_plugsParent )
 			{
 				if( key == g_visibleKey || key == g_noduleTypeKey )
 				{

--- a/src/GafferUI/CompoundNumericNodule.cpp
+++ b/src/GafferUI/CompoundNumericNodule.cpp
@@ -154,7 +154,7 @@ GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( CompoundNumericNodule );
 CompoundNumericNodule::CompoundNumericNodule( Gaffer::PlugPtr plug )
 	:	StandardNodule( plug )
 {
-	Metadata::plugValueChangedSignal().connect( boost::bind( &CompoundNumericNodule::plugMetadataChanged, this, ::_1, ::_2, ::_3, ::_4 ) );
+	Metadata::plugValueChangedSignal( plug->node() ).connect( boost::bind( &CompoundNumericNodule::plugMetadataChanged, this, ::_1, ::_2 ) );
 	updateChildNoduleVisibility();
 }
 
@@ -305,9 +305,9 @@ const NoduleLayout *CompoundNumericNodule::noduleLayout() const
 	return children().size() ? getChild<NoduleLayout>( 0 ) : nullptr;
 }
 
-void CompoundNumericNodule::plugMetadataChanged( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
+void CompoundNumericNodule::plugMetadataChanged( const Gaffer::Plug *plug, IECore::InternedString key )
 {
-	if( !MetadataAlgo::affectedByChange( this->plug(), nodeTypeId, plugPath, plug ) )
+	if( plug != this->plug() )
 	{
 		return;
 	}

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -83,7 +83,7 @@ StandardNodule::StandardNodule( Gaffer::PlugPtr plug )
 
 	dropSignal().connect( boost::bind( &StandardNodule::drop, this, ::_1, ::_2 ) );
 
-	Metadata::plugValueChangedSignal().connect( boost::bind( &StandardNodule::plugMetadataChanged, this, ::_1, ::_2, ::_3, ::_4 ) );
+	Metadata::plugValueChangedSignal( plug->node() ).connect( boost::bind( &StandardNodule::plugMetadataChanged, this, ::_1, ::_2 ) );
 
 	updateUserColor();
 }
@@ -474,9 +474,9 @@ void StandardNodule::setCompatibleLabelsVisible( const DragDropEvent &event, boo
 	}
 }
 
-void StandardNodule::plugMetadataChanged( IECore::TypeId nodeTypeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, const Gaffer::Plug *plug )
+void StandardNodule::plugMetadataChanged( const Gaffer::Plug *plug, IECore::InternedString key )
 {
-	if( !MetadataAlgo::affectedByChange( this->plug(), nodeTypeId, plugPath, plug ) )
+	if( plug != this->plug() )
 	{
 		return;
 	}


### PR DESCRIPTION
Most of our signals are emitted at the granularity of a single node or plug, so that observers can connect to only the changes relevant to them. Not so for our metadata signals. Here, a single signal was used for _all_ metadata changes to _all_ plugs. Which meant that _all_ observers were notified of _all_ changes. This had nasty performance implications :

- Reference nodes observe metadata changes to track plug edits. This gave us quadratic scaling where N nodes are all observing the effects of edits on all N nodes.
- Loading was much slower when the UI was open, because the UI components were observing metadata changes on the script being loaded, even though they were irrelevant.

This PR deprecates the old signals, and provides new signals which are emitted at the granularity of individual nodes. This gives significant performance improvements in the scenarios above. It also simplifies the client code a little, as the new signals have fewer arguments and it is much simpler to check that the change affects something you care about.

There is some work remaining to be done, because certain clients need to track inherited metadata for read-onliness, and this is still done more easily with the old signals. We'll revisit that in future, perhaps when we reconsider how read-onliness works as part of #4032.