### PR TITLE
Reference : Track addition of children to RowsPlugs and CompoundDataPlugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - ImageWriter : Added `openexr.dwaCompressionLevel` plug. This controls the size/quality tradeoff when using DWAA or DWAB compression.
+- Reference : Rows may now be added to and removed from referenced spreadsheets. Initially this is only allowed if the spreadsheet was published without any rows, to avoid anticipated problems merging referenced rows and user-edited rows.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
 Fixes
 -----
 
+- Reference : Fixed loss of additional CompoundDataPlug children during reloading.
 - UIEditor : Fixed Python 3 compatibility in plug presets editor.
 - NodeGadget : Fixed intermittent shutdown crash.
 - Expression : Fixed handling of expressions which assign CompoundData to `Attributes.extraAttributes`.

--- a/include/Gaffer/Reference.h
+++ b/include/Gaffer/Reference.h
@@ -65,7 +65,17 @@ class GAFFER_API Reference : public SubGraph
 		/// Emitted when a reference is loaded (or unloaded following an undo).
 		ReferenceLoadedSignal &referenceLoadedSignal();
 
+		/// Edits
+		/// =====
+		///
+		/// Edits are changes to referenced plugs that are made by the user
+		/// after the reference has been loaded via `load()`. The Reference
+		/// node provides some limited tracking of edits, exposing them
+		/// via the following methods.
+
 		bool hasMetadataEdit( const Plug *plug, const IECore::InternedString key ) const;
+		/// Returns true if `plug` has been added as a child of a referenced plug.
+		bool isChildEdit( const Plug *plug ) const;
 
 	private :
 

--- a/include/Gaffer/Reference.h
+++ b/include/Gaffer/Reference.h
@@ -71,7 +71,6 @@ class GAFFER_API Reference : public SubGraph
 
 		void loadInternal( const std::string &fileName );
 		bool isReferencePlug( const Plug *plug ) const;
-		void transferEditedMetadata( const Plug *srcPlug, Plug *dstPlug ) const;
 
 		std::string m_fileName;
 		ReferenceLoadedSignal m_referenceLoadedSignal;

--- a/python/GafferUI/SpreadsheetUI/_Algo.py
+++ b/python/GafferUI/SpreadsheetUI/_Algo.py
@@ -47,13 +47,6 @@ from ._SectionChooser import _SectionChooser
 # suitable for that, but they do represent useful functionality we would like
 # to be more generally available.
 
-def dimensionsEditable( rowsPlug ) :
-
-	# We don't currently allow addition/removal of rows/columns
-	# when a RowsPlug is hosted on a Reference node, to avoid
-	# merge hell when reloading or updating the reference.
-	return not isinstance( rowsPlug.node(), Gaffer.Reference )
-
 ## \todo Needs UndoScope removing
 def createSpreadsheet( plug ) :
 

--- a/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
+++ b/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
@@ -135,7 +135,16 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 			addRowButton.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__addRowButtonDragLeave ), scoped = False )
 			addRowButton.dropSignal().connect( Gaffer.WeakMethod( self.__addRowButtonDrop ), scoped = False )
 
-			addRowButton.setVisible( _Algo.dimensionsEditable( plug ) )
+			if isinstance( plug.node(), Gaffer.Reference ) :
+				# Currently we only allow new rows to be added to references
+				# that had no rows when they were exported. We don't want to
+				# get into merge hell trying to combine user-added and referenced
+				# rows, particularly as we are planning to add row-reordering
+				# features in future.
+				for row in plug.children()[1:] :
+					if not plug.node().isChildEdit( row ) :
+						addRowButton.setVisible( False )
+						break
 
 			self.__statusLabel = GafferUI.Label(
 				"",

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -214,6 +214,8 @@ class Reference::PlugEdits : public boost::signals::trackable
 			{
 				if( edit->sizeAfterLoad != -1 )
 				{
+					// Adding the child to `newPlug` removes it from `oldPlug`, hence
+					// `oldPlug` shrinks back to its original `sizeAfterLoad`.
 					while( oldPlug->children().size() > (size_t)edit->sizeAfterLoad )
 					{
 						newPlug->addChild( oldPlug->getChild( edit->sizeAfterLoad ) );
@@ -245,6 +247,10 @@ class Reference::PlugEdits : public boost::signals::trackable
 		Reference *m_reference;
 		boost::signals::scoped_connection m_connection;
 
+		// Struct for tracking all edits to a plug, where an edit is conceptually
+		// any change the user makes to the plug after it has been loaded by
+		// `Reference::load()`. In practice we currently only track metadata
+		// edits and the addition of children to a subset of plug types.
 		struct PlugEdit
 		{
 			boost::container::flat_set<InternedString> metadataEdits;

--- a/src/GafferModule/SubGraphBinding.cpp
+++ b/src/GafferModule/SubGraphBinding.cpp
@@ -343,6 +343,7 @@ void GafferModule::bindSubGraph()
 		.def( "fileName", &Reference::fileName, return_value_policy<copy_const_reference>() )
 		.def( "referenceLoadedSignal", &Reference::referenceLoadedSignal, return_internal_reference<1>() )
 		.def( "hasMetadataEdit", &Reference::hasMetadataEdit )
+		.def( "isChildEdit", &Reference::isChildEdit )
 	;
 
 	SignalClass<Reference::ReferenceLoadedSignal, DefaultSignalCaller<Reference::ReferenceLoadedSignal>, ReferenceLoadedSlotCaller >( "ReferenceLoadedSignal" );


### PR DESCRIPTION
This allows us to enable the addition of rows to referenced spreadsheets. Initially I've only enabled this for spreadsheets that were exported only with the default row. The approach taken here does have some scope for more ambitious merging of referenced and user-added rows, but ideally we won't need it. We intend to add drag-reordering of rows in future, and I don't like the prospect of resolvings conflicts between interleaved reference/user rows and the addition/removal of referenced rows.