### PR TITLE
NumericWidget : Fix edit bug in Qt 5.12

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - NodeGadget : Fixed intermittent shutdown crash.
+- NumericWidget : Fixed editing bug in Qt 5.12.
 
 0.58.6.1 (relative to 0.58.6.0)
 ========

--- a/python/GafferUI/NumericWidget.py
+++ b/python/GafferUI/NumericWidget.py
@@ -117,7 +117,7 @@ class NumericWidget( GafferUI.TextWidget ) :
 	@staticmethod
 	def valueToString( value ) :
 
-		if type( value ) is int :
+		if type( value ) in six.integer_types :
 			return str( value )
 		else :
 			return ( "%.4f" % value ).rstrip( '0' ).rstrip( '.' )
@@ -281,7 +281,7 @@ class NumericWidget( GafferUI.TextWidget ) :
 
 		# update our validator based on the type of the value
 		numericType = type( value )
-		assert( numericType is int or numericType is float )
+		assert( numericType in six.integer_types or numericType is float )
 		if self.__numericType is not numericType :
 
 			self.__numericType = numericType
@@ -321,7 +321,7 @@ class _ExpressionValidator( QtGui.QValidator ) :
 		QtGui.QValidator.__init__( self, parent )
 
 		self.__numericType = numericType
-		if self.__numericType is int :
+		if self.__numericType in six.integer_types :
 			operand = r"-?[0-9]*"
 		else :
 			operand = r"-?[0-9]*\.?[0-9]{0,4}"
@@ -353,7 +353,7 @@ class _ExpressionValidator( QtGui.QValidator ) :
 		# Evaluate expression
 
 		op = {
-			"/" : operator.floordiv if self.__numericType is int else operator.truediv,
+			"/" : operator.floordiv if self.__numericType in six.integer_types else operator.truediv,
 			"*" : operator.mul,
 			"+" : operator.add,
 			"-" : operator.sub,


### PR DESCRIPTION
Qt 5.12 seems to provide a `long` value rather than an `int` in certain circumstances. The one we found was from an `IntVectorPlug`. I've used `six.integer_types` since `long` doesn't exist in python 3.7.

Note this is targetting 0.58_maintenance because we do use 0.58 with Qt 5.12 at IE when running inside DCCs.