### PR TITLE
ArnoldOptions : Add `enabledProgressiveMinAASamples` plug

### DIFF
--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -553,6 +553,13 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"options.enableProgressiveMinAASamples" : [
+
+			"layout:section", "Interactive Rendering",
+			"label", "Enable Min AA Samples",
+
+		],
+
 		"options.progressiveMinAASamples" : [
 
 			"description",

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -77,6 +77,7 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	// Interactive rendering parameters
 
 	options->addChild( new Gaffer::NameValuePlug( "ai:enable_progressive_render", new IECore::BoolData( true ), false, "enableProgressiveRender" ) );
+	options->addChild( new Gaffer::NameValuePlug( "ai:enable_progressive_min_AA_samples", new IECore::BoolData( true ), false, "enableProgressiveMinAASamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:progressive_min_AA_samples", new Gaffer::IntPlug( "value", Gaffer::Plug::In, -4, -10, 0 ), false, "progressiveMinAASamples" ) );
 
 	// Ray depth parameters


### PR DESCRIPTION
This draft PR implements the additional progressive controls discussed in https://github.com/GafferHQ/gaffer/pull/4110. As I said on that PR, I don't plan to merge it, but I thought it was worth opening a PR so folks can download the build artifacts and make up their own minds. If there's a consensus that it's worthwhile, then I'll be happy to tidy it up and merge.