### PR TITLE
NumericPlugValueWidget : Fix min/max width logic

### DIFF
--- a/python/GafferUI/NumericPlugValueWidget.py
+++ b/python/GafferUI/NumericPlugValueWidget.py
@@ -211,11 +211,8 @@ class NumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 		for plug in self.getPlugs() :
 			plugCharWidth = Gaffer.Metadata.value( plug, "numericPlugValueWidget:fixedCharacterWidth" )
 			if plugCharWidth is None and isinstance( plug, Gaffer.IntPlug ) :
-				if plug.hasMaxValue() :
-					plugCharWidth = len( str( plug.maxValue() ) )
-				if plug.hasMinValue() :
-					minValueCharWidth = len( str( plug.minValue() ) )
-					plugCharWidth = max( plugCharWidth, minValueCharWidth ) if plugCharWidth is not None else minValueCharWidth
+				if plug.hasMinValue() and plug.hasMaxValue() :
+					plugCharWidth = max( len( str( plug.minValue() ) ), len( str( plug.maxValue() ) ) )
 			if plugCharWidth is not None :
 				charWidth = max( charWidth, plugCharWidth ) if charWidth is not None else plugCharWidth
 

--- a/python/GafferUITest/NumericPlugValueWidgetTest.py
+++ b/python/GafferUITest/NumericPlugValueWidgetTest.py
@@ -137,8 +137,9 @@ class NumericPlugValueWidgetTest( GafferUITest.TestCase ) :
 	def testFixedCharacterWidth( self ) :
 
 		n = Gaffer.Node()
-		n["user"]["i1"] = Gaffer.IntPlug( maxValue = 100 )
-		n["user"]["i2"] = Gaffer.IntPlug( maxValue = 1000 )
+		n["user"]["i1"] = Gaffer.IntPlug( minValue = 0, maxValue = 100 )
+		n["user"]["i2"] = Gaffer.IntPlug( minValue = 0, maxValue = 1000 )
+		n["user"]["i3"] = Gaffer.IntPlug( minValue = -5, maxValue = 0 )
 
 		w = GafferUI.NumericPlugValueWidget( n["user"]["i2"] )
 		self.assertEqual( w.numericWidget().getFixedCharacterWidth(), 4 )
@@ -151,6 +152,9 @@ class NumericPlugValueWidgetTest( GafferUITest.TestCase ) :
 
 		w.setPlugs( { n["user"]["i1"] } )
 		self.assertEqual( w.numericWidget().getFixedCharacterWidth(), 3 )
+
+		w.setPlugs( { n["user"]["i3"] } )
+		self.assertEqual( w.numericWidget().getFixedCharacterWidth(), 2 )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
We can only constrain the width of the widget if the plug has both a min _and_ a max value. I noticed that I had broken this while reviewing https://github.com/GafferHQ/gaffer/pull/4116, where we have a plug with a min value but no max.