### PR TITLE
Reference : Fix handling of added/removed spreadsheet columns

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 
 - InteractiveArnoldRender : Fixed interactive updates to `ArnoldOptions.progressiveMinAASamples`.
 - NodeEditor : Fixed width of widgets for integer plugs with minimum values that require more space than maximum values.
+- Reference : Fixed bugs triggered by changing the number of columns in a referenced spreadsheet.
 
 API
 ---


### PR DESCRIPTION
Rather than transfer the old children over to the new plug, we now create new children for the new plug and transfer over their values and connections using the existing transfer code. This allows us to use `addRow()` for Spreadsheets, which in turn ensures that the columns for the new child reflect any changes to the columns that have been made in the referenced file.