### PR TITLE
UITests : Test lifetime of all NodeUIs

### DIFF
--- a/python/GafferAppleseedUITest/NodeUITest.py
+++ b/python/GafferAppleseedUITest/NodeUITest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,25 +34,17 @@
 #
 ##########################################################################
 
-from .SceneViewTest import SceneViewTest
-from .ShaderAssignmentUITest import ShaderAssignmentUITest
-from .StandardGraphLayoutTest import StandardGraphLayoutTest
-from .SceneGadgetTest import SceneGadgetTest
-from .SceneInspectorTest import SceneInspectorTest
-from .HierarchyViewTest import HierarchyViewTest
-from .DocumentationTest import DocumentationTest
-from .ShaderViewTest import ShaderViewTest
-from .ShaderUITest import ShaderUITest
-from .TranslateToolTest import TranslateToolTest
-from .ScaleToolTest import ScaleToolTest
-from .RotateToolTest import RotateToolTest
-from .ContextAlgoTest import ContextAlgoTest
-from .CameraToolTest import CameraToolTest
-from .VisualiserTest import VisualiserTest
-from .TransformToolTest import TransformToolTest
-from .SourceSetTest import SourceSetTest
-from .CropWindowToolTest import CropWindowToolTest
-from .NodeUITest import NodeUITest
+import unittest
+
+import GafferAppleseed
+import GafferAppleseedUI
+import GafferUITest
+
+class NodeUITest( GafferUITest.TestCase ) :
+
+	def testLifetimes( self ) :
+
+		self.assertNodeUIsHaveExpectedLifetime( GafferAppleseed )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferAppleseedUITest/__init__.py
+++ b/python/GafferAppleseedUITest/__init__.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 from .DocumentationTest import DocumentationTest
+from .NodeUITest import NodeUITest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferArnoldUITest/NodeUITest.py
+++ b/python/GafferArnoldUITest/NodeUITest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,25 +34,17 @@
 #
 ##########################################################################
 
-from .SceneViewTest import SceneViewTest
-from .ShaderAssignmentUITest import ShaderAssignmentUITest
-from .StandardGraphLayoutTest import StandardGraphLayoutTest
-from .SceneGadgetTest import SceneGadgetTest
-from .SceneInspectorTest import SceneInspectorTest
-from .HierarchyViewTest import HierarchyViewTest
-from .DocumentationTest import DocumentationTest
-from .ShaderViewTest import ShaderViewTest
-from .ShaderUITest import ShaderUITest
-from .TranslateToolTest import TranslateToolTest
-from .ScaleToolTest import ScaleToolTest
-from .RotateToolTest import RotateToolTest
-from .ContextAlgoTest import ContextAlgoTest
-from .CameraToolTest import CameraToolTest
-from .VisualiserTest import VisualiserTest
-from .TransformToolTest import TransformToolTest
-from .SourceSetTest import SourceSetTest
-from .CropWindowToolTest import CropWindowToolTest
-from .NodeUITest import NodeUITest
+import unittest
+
+import GafferArnold
+import GafferArnoldUI
+import GafferUITest
+
+class NodeUITest( GafferUITest.TestCase ) :
+
+	def testLifetimes( self ) :
+
+		self.assertNodeUIsHaveExpectedLifetime( GafferArnold )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferArnoldUITest/__init__.py
+++ b/python/GafferArnoldUITest/__init__.py
@@ -38,6 +38,7 @@ from .DocumentationTest import DocumentationTest
 from .ArnoldShaderUITest import ArnoldShaderUITest
 from .VisualiserAlgoTest import VisualiserAlgoTest
 from .InteractiveArnoldRenderPerformanceTest import InteractiveArnoldRenderPerformanceTest
+from .NodeUITest import NodeUITest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDelightUITest/NodeUITest.py
+++ b/python/GafferDelightUITest/NodeUITest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,25 +34,17 @@
 #
 ##########################################################################
 
-from .SceneViewTest import SceneViewTest
-from .ShaderAssignmentUITest import ShaderAssignmentUITest
-from .StandardGraphLayoutTest import StandardGraphLayoutTest
-from .SceneGadgetTest import SceneGadgetTest
-from .SceneInspectorTest import SceneInspectorTest
-from .HierarchyViewTest import HierarchyViewTest
-from .DocumentationTest import DocumentationTest
-from .ShaderViewTest import ShaderViewTest
-from .ShaderUITest import ShaderUITest
-from .TranslateToolTest import TranslateToolTest
-from .ScaleToolTest import ScaleToolTest
-from .RotateToolTest import RotateToolTest
-from .ContextAlgoTest import ContextAlgoTest
-from .CameraToolTest import CameraToolTest
-from .VisualiserTest import VisualiserTest
-from .TransformToolTest import TransformToolTest
-from .SourceSetTest import SourceSetTest
-from .CropWindowToolTest import CropWindowToolTest
-from .NodeUITest import NodeUITest
+import unittest
+
+import GafferDelight
+import GafferDelightUI
+import GafferUITest
+
+class NodeUITest( GafferUITest.TestCase ) :
+
+	def testLifetimes( self ) :
+
+		self.assertNodeUIsHaveExpectedLifetime( GafferDelight )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDelightUITest/__init__.py
+++ b/python/GafferDelightUITest/__init__.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 from .DocumentationTest import DocumentationTest
+from .NodeUITest import NodeUITest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDispatchUITest/NodeUITest.py
+++ b/python/GafferDispatchUITest/NodeUITest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,25 +34,17 @@
 #
 ##########################################################################
 
-from .SceneViewTest import SceneViewTest
-from .ShaderAssignmentUITest import ShaderAssignmentUITest
-from .StandardGraphLayoutTest import StandardGraphLayoutTest
-from .SceneGadgetTest import SceneGadgetTest
-from .SceneInspectorTest import SceneInspectorTest
-from .HierarchyViewTest import HierarchyViewTest
-from .DocumentationTest import DocumentationTest
-from .ShaderViewTest import ShaderViewTest
-from .ShaderUITest import ShaderUITest
-from .TranslateToolTest import TranslateToolTest
-from .ScaleToolTest import ScaleToolTest
-from .RotateToolTest import RotateToolTest
-from .ContextAlgoTest import ContextAlgoTest
-from .CameraToolTest import CameraToolTest
-from .VisualiserTest import VisualiserTest
-from .TransformToolTest import TransformToolTest
-from .SourceSetTest import SourceSetTest
-from .CropWindowToolTest import CropWindowToolTest
-from .NodeUITest import NodeUITest
+import unittest
+
+import GafferDispatch
+import GafferDispatchUI
+import GafferUITest
+
+class NodeUITest( GafferUITest.TestCase ) :
+
+	def testLifetimes( self ) :
+
+		self.assertNodeUIsHaveExpectedLifetime( GafferDispatch )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDispatchUITest/__init__.py
+++ b/python/GafferDispatchUITest/__init__.py
@@ -37,6 +37,7 @@
 import unittest
 
 from .DocumentationTest import DocumentationTest
+from .NodeUITest import NodeUITest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageUITest/NodeUITest.py
+++ b/python/GafferImageUITest/NodeUITest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,25 +34,17 @@
 #
 ##########################################################################
 
-from .SceneViewTest import SceneViewTest
-from .ShaderAssignmentUITest import ShaderAssignmentUITest
-from .StandardGraphLayoutTest import StandardGraphLayoutTest
-from .SceneGadgetTest import SceneGadgetTest
-from .SceneInspectorTest import SceneInspectorTest
-from .HierarchyViewTest import HierarchyViewTest
-from .DocumentationTest import DocumentationTest
-from .ShaderViewTest import ShaderViewTest
-from .ShaderUITest import ShaderUITest
-from .TranslateToolTest import TranslateToolTest
-from .ScaleToolTest import ScaleToolTest
-from .RotateToolTest import RotateToolTest
-from .ContextAlgoTest import ContextAlgoTest
-from .CameraToolTest import CameraToolTest
-from .VisualiserTest import VisualiserTest
-from .TransformToolTest import TransformToolTest
-from .SourceSetTest import SourceSetTest
-from .CropWindowToolTest import CropWindowToolTest
-from .NodeUITest import NodeUITest
+import unittest
+
+import GafferImage
+import GafferImageUI
+import GafferUITest
+
+class NodeUITest( GafferUITest.TestCase ) :
+
+	def testLifetimes( self ) :
+
+		self.assertNodeUIsHaveExpectedLifetime( GafferImage )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageUITest/__init__.py
+++ b/python/GafferImageUITest/__init__.py
@@ -39,6 +39,7 @@ from .ImageViewTest import ImageViewTest
 from .DocumentationTest import DocumentationTest
 from .ImageGadgetTest import ImageGadgetTest
 from .CatalogueUITest import CatalogueUITest
+from .NodeUITest import NodeUITest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLUITest/NodeUITest.py
+++ b/python/GafferOSLUITest/NodeUITest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,25 +34,17 @@
 #
 ##########################################################################
 
-from .SceneViewTest import SceneViewTest
-from .ShaderAssignmentUITest import ShaderAssignmentUITest
-from .StandardGraphLayoutTest import StandardGraphLayoutTest
-from .SceneGadgetTest import SceneGadgetTest
-from .SceneInspectorTest import SceneInspectorTest
-from .HierarchyViewTest import HierarchyViewTest
-from .DocumentationTest import DocumentationTest
-from .ShaderViewTest import ShaderViewTest
-from .ShaderUITest import ShaderUITest
-from .TranslateToolTest import TranslateToolTest
-from .ScaleToolTest import ScaleToolTest
-from .RotateToolTest import RotateToolTest
-from .ContextAlgoTest import ContextAlgoTest
-from .CameraToolTest import CameraToolTest
-from .VisualiserTest import VisualiserTest
-from .TransformToolTest import TransformToolTest
-from .SourceSetTest import SourceSetTest
-from .CropWindowToolTest import CropWindowToolTest
-from .NodeUITest import NodeUITest
+import unittest
+
+import GafferOSL
+import GafferOSLUI
+import GafferUITest
+
+class NodeUITest( GafferUITest.TestCase ) :
+
+	def testLifetimes( self ) :
+
+		self.assertNodeUIsHaveExpectedLifetime( GafferOSL )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLUITest/__init__.py
+++ b/python/GafferOSLUITest/__init__.py
@@ -37,6 +37,7 @@
 from .DocumentationTest import DocumentationTest
 from .OSLShaderUITest import OSLShaderUITest
 from .OSLCodeUITest import OSLCodeUITest
+from .NodeUITest import NodeUITest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/NodeUITest.py
+++ b/python/GafferSceneUITest/NodeUITest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,25 +34,17 @@
 #
 ##########################################################################
 
-from .SceneViewTest import SceneViewTest
-from .ShaderAssignmentUITest import ShaderAssignmentUITest
-from .StandardGraphLayoutTest import StandardGraphLayoutTest
-from .SceneGadgetTest import SceneGadgetTest
-from .SceneInspectorTest import SceneInspectorTest
-from .HierarchyViewTest import HierarchyViewTest
-from .DocumentationTest import DocumentationTest
-from .ShaderViewTest import ShaderViewTest
-from .ShaderUITest import ShaderUITest
-from .TranslateToolTest import TranslateToolTest
-from .ScaleToolTest import ScaleToolTest
-from .RotateToolTest import RotateToolTest
-from .ContextAlgoTest import ContextAlgoTest
-from .CameraToolTest import CameraToolTest
-from .VisualiserTest import VisualiserTest
-from .TransformToolTest import TransformToolTest
-from .SourceSetTest import SourceSetTest
-from .CropWindowToolTest import CropWindowToolTest
-from .NodeUITest import NodeUITest
+import unittest
+
+import GafferScene
+import GafferSceneUI
+import GafferUITest
+
+class NodeUITest( GafferUITest.TestCase ) :
+
+	def testLifetimes( self ) :
+
+		self.assertNodeUIsHaveExpectedLifetime( GafferScene )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/NodeUITest.py
+++ b/python/GafferUITest/NodeUITest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,25 +34,17 @@
 #
 ##########################################################################
 
-from .SceneViewTest import SceneViewTest
-from .ShaderAssignmentUITest import ShaderAssignmentUITest
-from .StandardGraphLayoutTest import StandardGraphLayoutTest
-from .SceneGadgetTest import SceneGadgetTest
-from .SceneInspectorTest import SceneInspectorTest
-from .HierarchyViewTest import HierarchyViewTest
-from .DocumentationTest import DocumentationTest
-from .ShaderViewTest import ShaderViewTest
-from .ShaderUITest import ShaderUITest
-from .TranslateToolTest import TranslateToolTest
-from .ScaleToolTest import ScaleToolTest
-from .RotateToolTest import RotateToolTest
-from .ContextAlgoTest import ContextAlgoTest
-from .CameraToolTest import CameraToolTest
-from .VisualiserTest import VisualiserTest
-from .TransformToolTest import TransformToolTest
-from .SourceSetTest import SourceSetTest
-from .CropWindowToolTest import CropWindowToolTest
-from .NodeUITest import NodeUITest
+import unittest
+
+import Gaffer
+import GafferUI
+import GafferUITest
+
+class NodeUITest( GafferUITest.TestCase ) :
+
+	def testLifetimes( self ) :
+
+		self.assertNodeUIsHaveExpectedLifetime( Gaffer )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -123,6 +123,7 @@ from .BoolPlugValueWidgetTest import BoolPlugValueWidgetTest
 from .NumericWidgetTest import NumericWidgetTest
 from .PresetsPlugValueWidgetTest import PresetsPlugValueWidgetTest
 from .SpreadsheetUITest import SpreadsheetUITest
+from .NodeUITest import NodeUITest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferVDBUITest/NodeUITest.py
+++ b/python/GafferVDBUITest/NodeUITest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,25 +34,17 @@
 #
 ##########################################################################
 
-from .SceneViewTest import SceneViewTest
-from .ShaderAssignmentUITest import ShaderAssignmentUITest
-from .StandardGraphLayoutTest import StandardGraphLayoutTest
-from .SceneGadgetTest import SceneGadgetTest
-from .SceneInspectorTest import SceneInspectorTest
-from .HierarchyViewTest import HierarchyViewTest
-from .DocumentationTest import DocumentationTest
-from .ShaderViewTest import ShaderViewTest
-from .ShaderUITest import ShaderUITest
-from .TranslateToolTest import TranslateToolTest
-from .ScaleToolTest import ScaleToolTest
-from .RotateToolTest import RotateToolTest
-from .ContextAlgoTest import ContextAlgoTest
-from .CameraToolTest import CameraToolTest
-from .VisualiserTest import VisualiserTest
-from .TransformToolTest import TransformToolTest
-from .SourceSetTest import SourceSetTest
-from .CropWindowToolTest import CropWindowToolTest
-from .NodeUITest import NodeUITest
+import unittest
+
+import GafferVDB
+import GafferVDBUI
+import GafferUITest
+
+class NodeUITest( GafferUITest.TestCase ) :
+
+	def testLifetimes( self ) :
+
+		self.assertNodeUIsHaveExpectedLifetime( GafferVDB )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferVDBUITest/__init__.py
+++ b/python/GafferVDBUITest/__init__.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 from .DocumentationTest import DocumentationTest
+from .NodeUITest import NodeUITest
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This gives us some coverage against circular references etc in the NodeEditor for every single node type. Although the test itself only catches lifetime issues for the top-level NodeUI, `GafferUITest.TestCase.tearDown()` will automatically detect any child widgets which outlive the parent. This gives us coverage against bugs in our many node-specific custom Widgets and PlugValueWidgets.
