### PR TITLE
Improve Filter Hash Performance

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,11 @@ Improvements
 - FrameMask : Improved performance when dealing with long frame ranges.
 - Node : Improved performance of type queries related to dispatch processes.
 
+API
+---
+
+- SceneAlgo : Added matchingPathsHash.
+
 0.59.3.0 (relative to 0.59.2.0)
 ========
 

--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Improvements
 
 - FrameMask : Improved performance when dealing with long frame ranges.
 - Node : Improved performance of type queries related to dispatch processes.
+- FilterResults : Improved performance of hash.
 
 API
 ---

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -84,6 +84,11 @@ GAFFERSCENE_API void matchingPaths( const Gaffer::IntPlug *filterPlug, const Sce
 /// As above, but specifying the filter as a PathMatcher.
 GAFFERSCENE_API void matchingPaths( const IECore::PathMatcher &filter, const ScenePlug *scene, IECore::PathMatcher &paths );
 
+/// Matching above, but doing a fast hash of the matching paths instead of storing all paths
+GAFFERSCENE_API IECore::MurmurHash matchingPathsHash( const Filter *filter, const ScenePlug *scene );
+GAFFERSCENE_API IECore::MurmurHash matchingPathsHash( const GafferScene::FilterPlug *filterPlug, const ScenePlug *scene );
+GAFFERSCENE_API IECore::MurmurHash matchingPathsHash( const IECore::PathMatcher &filter, const ScenePlug *scene );
+
 /// Parallel scene traversal
 /// ========================
 

--- a/src/GafferScene/FilterResults.cpp
+++ b/src/GafferScene/FilterResults.cpp
@@ -131,9 +131,7 @@ void FilterResults::hash( const Gaffer::ValuePlug *output, const Gaffer::Context
 
 	if( output == internalOutPlug() )
 	{
-		PathMatcherDataPtr data = new PathMatcherData;
-		SceneAlgo::matchingPaths( filterPlug(), scenePlug(), data->writable() );
-		data->hash( h );
+		h.append( SceneAlgo::matchingPathsHash( filterPlug(), scenePlug() ) );
 	}
 	else if( output == outPlug() )
 	{


### PR DESCRIPTION
Initial pass on this was pretty straightforward.

Test may be oversimplified, but was chosen to highlight the difference ( it goes from 5.09 seconds to 3.64, an improvement of close to 30% ).

I should probably add a comment to explain the hash-summing-for-order-independence trick, and perhaps disable the perf test on CI, since we usually do?  Any other suggestions?