### PR TITLE
Mac CI : Remove `depends_on :x11` from Inkscape cask

### DIFF
--- a/config/brew/Casks/inkscape.rb
+++ b/config/brew/Casks/inkscape.rb
@@ -6,8 +6,6 @@ cask 'inkscape' do
   name 'Inkscape'
   homepage 'https://inkscape.org/'
 
-  depends_on x11: true
-
   app 'Inkscape.app'
   binary "#{appdir}/Inkscape.app/Contents/Resources/bin/inkscape"
 


### PR DESCRIPTION
With a little bit of luck this might fix the following error :

```
Error: Calling depends_on :x11 is disabled! Use depends_on specific X11 formula(e) instead.
```
