### PR TITLE
Update to GafferHQ/dependencies 3.0.0a1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.2.0/gafferDependencies-2.2.0-Python2-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/3.0.0a2/gafferDependencies-3.0.0-Python2-linux.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -55,7 +55,7 @@ jobs:
             buildType: DEBUG
             publish: false
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.2.0/gafferDependencies-2.2.0-Python2-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/3.0.0a2/gafferDependencies-3.0.0-Python2-linux.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -66,7 +66,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.2.0/gafferDependencies-2.2.0-Python3-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/3.0.0a2/gafferDependencies-3.0.0-Python3-linux.tar.gz
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 
@@ -75,7 +75,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage:
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/2.2.0/gafferDependencies-2.2.0-Python2-osx.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/3.0.0a2/gafferDependencies-3.0.0-Python2-osx.tar.gz
             testRunner: bash -c
             sconsCacheMegabytes: 400
 

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -43,7 +43,7 @@ import hashlib
 # Determine default archive URL.
 
 platform = "osx" if sys.platform == "darwin" else "linux"
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/2.1.1/gafferDependencies-2.1.1-Python2-" + platform + ".tar.gz"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/3.0.0a2/gafferDependencies-3.0.0-Python2-" + platform + ".tar.gz"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,8 @@
 0.60.x.x
 ========
 
+> Note : This version is built against Arnold 6.2.0.1, and is not compatible with earlier Arnold versions.
+
 Improvements
 ------------
 
@@ -69,6 +71,12 @@ Build
 
 - Moved minimum required C++ standard to C++14.
 - Moved minimum required TBB version to 2018 Update 3.
+- Dependencies : Updated to GafferHQ/dependencies 3.0.0 :
+  - OpenImageIO 2.2.11.1.
+  - LibTIFF 4.1.0.
+  - OpenShadingLanguage 1.11.11.0.
+  - LLVM 10.0.1.
+  - OpenVDB 7.2.2.
 
 0.59.x.x (relative to 0.59.3.0)
 ========

--- a/config/installArnold.sh
+++ b/config/installArnold.sh
@@ -37,7 +37,7 @@
 
 set -e
 
-arnoldVersion=6.0.1.0
+arnoldVersion=6.2.0.1
 
 if [[ `uname` = "Linux" ]] ; then
 	arnoldPlatform=linux

--- a/config/installDependencies.sh
+++ b/config/installDependencies.sh
@@ -55,8 +55,8 @@ buildDir=${1:-"build/gaffer-$gafferMilestoneVersion.$gafferMajorVersion.$gafferM
 
 # Get the prebuilt dependencies package and unpack it into the build directory
 
-dependenciesVersion="2.1.1"
-dependenciesVersionSuffix=""
+dependenciesVersion="3.0.0"
+dependenciesVersionSuffix="a2"
 dependenciesPythonVersion="2"
 dependenciesFileName="gafferDependencies-$dependenciesVersion-Python$dependenciesPythonVersion-$platform.tar.gz"
 downloadURL="https://github.com/GafferHQ/dependencies/releases/download/$dependenciesVersion$dependenciesVersionSuffix/$dependenciesFileName"

--- a/shaders/MaterialX/mx_pack_color.osl
+++ b/shaders/MaterialX/mx_pack_color.osl
@@ -1,0 +1,17 @@
+// MaterialX removed this shader in a minor version revision. But we still need it in
+// `IECore::ShaderNetworkAlgo::convertOSLComponentConnections()` so we have reimplementd it here.
+// We originally used it to emulate component-level connections for colors, but OSL supports
+// that natively now. But we continue to use it to work around bugs in Arnold - see
+// `ArnoldRenderTest.testOSLShaders()`.
+/// \todo Remove once the Arnold bug is fixed.
+shader mx_pack_color
+(
+	float in1 = 0,
+	float in2 = 0,
+	float in3 = 0,
+	float in4 = 0,
+	output color out = 0
+)
+{
+	out = color( in1, in2, in3 );
+}


### PR DESCRIPTION
I wouldn't be surprised if there are a few teething problems with this as I get the packages from GafferHQ/dependencies sorted out, but this PR is an important part of validating them.