### PR TITLE
Python Expression Cache Policy

### DIFF
--- a/include/Gaffer/Expression.h
+++ b/include/Gaffer/Expression.h
@@ -120,6 +120,8 @@ class GAFFER_API Expression : public ComputeNode
 				/// to apply them to each of the individual output plugs.
 				/// \threading This function may be called concurrently.
 				virtual IECore::ConstObjectVectorPtr execute( const Context *context, const std::vector<const ValuePlug *> &proxyInputs ) const = 0;
+				/// What cache policy should be used for executing the expression.
+				virtual Gaffer::ValuePlug::CachePolicy executeCachePolicy() const = 0;
 				//@}
 
 				/// @name Language utilities
@@ -178,6 +180,8 @@ class GAFFER_API Expression : public ComputeNode
 
 		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
 		void compute( ValuePlug *output, const Context *context ) const override;
+
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
 
 	private :
 

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1475,5 +1475,26 @@ class ExpressionTest( GafferTest.TestCase ) :
 			s["n"]["user"]["p"].getValue
 		)
 
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testParallelPerformance( self ):
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["p"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( inspect.cleandoc(
+			"""
+			q = 0
+			while q != 10000000:
+				q += 1
+			parent['n']['user']['p'] = 0
+			"""
+		) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferTest.parallelGetValue( s["n"]["user"]["p"], 100 )
+
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ValuePlugTest.py
+++ b/python/GafferTest/ValuePlugTest.py
@@ -659,8 +659,9 @@ class ValuePlugTest( GafferTest.TestCase ) :
 
 	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testContentionForOneItem( self ) :
+		m = GafferTest.MultiplyNode()
 
-		GafferTest.testValuePlugContentionForOneItem()
+		GafferTest.parallelGetValue( m["product"], 10000000 )
 
 	def testIsSetToDefault( self ) :
 

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -336,6 +336,23 @@ void Expression::hash( const ValuePlug *output, const Context *context, IECore::
 	}
 }
 
+Gaffer::ValuePlug::CachePolicy Expression::computeCachePolicy( const Gaffer::ValuePlug *output ) const
+{
+	if( output == executePlug() )
+	{
+		if( m_engine )
+		{
+			return m_engine->executeCachePolicy();
+		}
+		else
+		{
+			return ValuePlug::CachePolicy::Legacy;
+		}
+	}
+	return ComputeNode::computeCachePolicy( output );
+}
+
+
 void Expression::compute( ValuePlug *output, const Context *context ) const
 {
 	if( output == executePlug() )

--- a/src/GafferModule/ExpressionBinding.cpp
+++ b/src/GafferModule/ExpressionBinding.cpp
@@ -106,6 +106,44 @@ struct ExpressionChangedSlotCaller
 	}
 };
 
+ValuePlug::CachePolicy defaultExecuteCachePolicy()
+{
+	// Expressions implemented through Python will be forced to run serially due to the GIL,
+	// which makes it very bad to allow parallel evaluations of the same plug, since they will
+	// all compete over the same GIL.
+
+	// In the long term, we can probably lock this to Standard, but in the short term, overriding
+	// to Legacy or TaskIsolation using an env var could provide a workaround if facilities have
+	// Gaffer nodes that do their own tbb calls without properly isolating them, which could
+	// cause hangs when using the Standard policy
+	if( const char *cp = getenv( "GAFFER_PYTHONEXPRESSION_CACHEPOLICY" ) )
+	{
+		if( !strcmp( cp, "Standard" ) )
+		{
+			return ValuePlug::CachePolicy::Standard;
+		}
+		else if( !strcmp( cp, "TaskCollaboration" ) )
+		{
+			return ValuePlug::CachePolicy::TaskCollaboration;
+		}
+		else if( !strcmp( cp, "TaskIsolation" ) )
+		{
+			return ValuePlug::CachePolicy::TaskIsolation;
+		}
+		else if( !strcmp( cp, "Legacy" ) )
+		{
+			return ValuePlug::CachePolicy::Legacy;
+		}
+		else
+		{
+			IECore::msg( IECore::Msg::Warning, "Expression", "Invalid value for GAFFER_GAFFER_PYTHONEXPRESSION_CACHEPOLICY. Must be Standard, TaskCollaboration, TaskIsolation or Legacy." );
+		}
+	}
+
+	return  ValuePlug::CachePolicy::Standard;
+}
+
+
 class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 {
 	public :
@@ -170,6 +208,11 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 			}
 
 			throw IECore::Exception( "Engine::execute() python method not defined" );
+		}
+
+		ValuePlug::CachePolicy executeCachePolicy() const override
+		{
+			return g_cachePolicy;
 		}
 
 		void apply( ValuePlug *proxyOutput, const ValuePlug *topLevelProxyOutput, const IECore::Object *value ) const override
@@ -292,7 +335,11 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 			return boost::python::tuple( l );
 		}
 
+		static ValuePlug::CachePolicy g_cachePolicy;
 };
+
+
+ValuePlug::CachePolicy EngineWrapper::g_cachePolicy( defaultExecuteCachePolicy() );
 
 static tuple languages()
 {

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -394,6 +394,11 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 			return result;
 		}
 
+		ValuePlug::CachePolicy executeCachePolicy() const override
+		{
+			return ValuePlug::CachePolicy::Legacy;
+		}
+
 		void apply( Gaffer::ValuePlug *proxyOutput, const Gaffer::ValuePlug *topLevelProxyOutput, const IECore::Object *value ) const override
 		{
 			switch( value->typeId() )


### PR DESCRIPTION
Since evaluating Python expressions is limited by the GIL, evaluating the same result multiple times in parallel just slows things down proportionally.  This is exactly the case for using the new "Standard" cache policy, where one thread computes it, and the other threads wait.

This provides a speedup up to 10X on synthetic tests designed to stress expression parallelism, 2X on an IESceneBuilder duplicated out a couple times to increase parallelism, 30% on a production example of an image network where a colorspace is driven by a database query, and 15% on a groom assignment production scene using complex expressions.

The main cost for this speedup is that now that we're actually using "Standard", we need everyone to isolate their tbb tasks properly - as far as we know, this has been done for all built in Gaffer nodes, and appears to have been done at IE, but will require some careful testing.  The new env var GAFFER_PYTHONEXPRESSION_CACHEPOLICY can be set to "Legacy" if someone has badly behaved nodes and needs to disable this change.

The one thing I forgot to talk to John about this morning:  it's a bit weird that this change can dramatically increase CPU usage in simple cases, since yielding in tbb when there aren't any tbb tasks waiting to pick up ends up being a busy wait, but keeping the CPU hot is probably an acceptable cost for reducing wallclock times.