### PR TITLE
OSL : Fix warnings about using deprecated form of get_context

### DIFF
--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -331,9 +331,10 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 		IECore::ConstObjectVectorPtr execute( const Gaffer::Context *context, const std::vector<const Gaffer::ValuePlug *> &proxyInputs ) const override
 		{
 			ShadingSystem *s = shadingSystem();
-			OSL::ShadingContext *shadingContext = s->get_context( /* threadInfo */ nullptr );
+			OSL::PerThreadInfo *threadInfo = s->create_thread_info();
+			OSL::ShadingContext *shadingContext = s->get_context( threadInfo );
 
-		    OSL::ShaderGlobals shaderGlobals;
+			OSL::ShaderGlobals shaderGlobals;
 			memset( (void *)&shaderGlobals, 0, sizeof( ShaderGlobals ) );
 
 			if( m_needsTime )
@@ -391,6 +392,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 			}
 
 			s->release_context( shadingContext );
+			s->destroy_thread_info( threadInfo );
 			return result;
 		}
 


### PR DESCRIPTION
This is a pretty naive shot at fixing the warning "WARNING: ShadingSystem::get_context called without a PerThreadInfo".

It's not clear how much of a cost creating a PerThreadInfo carries - I'm just allocating one right where it's needed.  In the case of ShadingEngine, this is amortized over the grain size of 5000 on the parallel_for, which is probably makes it fine.  The expression engine doesn't benefit from any amortization, but running OSL on one point isn't expected to be entirely optimal anyway.

The obvious alternative would be to use boost::thread_specific_ptr like the OSL default path currently is, but that's what the OSL change was trying to avoid in the first place - though I don't fully understand why ( https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/pull/958 says "boost::thread_specific_pointer which could be easily mishandled and lead to problems." ).  It seems like for our purposes, either the version here, or explicitly using thread_specific_pointer, would probably be fine.
