### PR TITLE
Python Expression Cache Policy (0.59)

### DIFF
--- a/include/Gaffer/Expression.h
+++ b/include/Gaffer/Expression.h
@@ -120,6 +120,8 @@ class GAFFER_API Expression : public ComputeNode
 				/// to apply them to each of the individual output plugs.
 				/// \threading This function may be called concurrently.
 				virtual IECore::ConstObjectVectorPtr execute( const Context *context, const std::vector<const ValuePlug *> &proxyInputs ) const = 0;
+				/// What cache policy should be used for executing the expression
+				virtual Gaffer::ValuePlug::CachePolicy executeCachePolicy() const = 0;
 				//@}
 
 				/// @name Language utilities
@@ -178,6 +180,8 @@ class GAFFER_API Expression : public ComputeNode
 
 		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
 		void compute( ValuePlug *output, const Context *context ) const override;
+
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
 
 	private :
 

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1454,5 +1454,24 @@ class ExpressionTest( GafferTest.TestCase ) :
 			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().y, 0.2 + 0.3 * i + 10 * i, places = 5 )
 			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().z, 0.3 + 0.3 * i + 10 * i, places = 5 )
 
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testParallelPerformance( self ):
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["p"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( inspect.cleandoc(
+			"""
+			q = 0
+			while q != 10000000:
+				q += 1
+			parent['n']['user']['p'] = 0
+			"""
+		) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferTest.parallelGetValue( s["n"]["user"]["p"], 100 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ValuePlugTest.py
+++ b/python/GafferTest/ValuePlugTest.py
@@ -659,8 +659,9 @@ class ValuePlugTest( GafferTest.TestCase ) :
 
 	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testContentionForOneItem( self ) :
+		m = GafferTest.MultiplyNode()
 
-		GafferTest.testValuePlugContentionForOneItem()
+		GafferTest.parallelGetValue( m["product"], 10000000 )
 
 	def testIsSetToDefault( self ) :
 

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -336,6 +336,23 @@ void Expression::hash( const ValuePlug *output, const Context *context, IECore::
 	}
 }
 
+Gaffer::ValuePlug::CachePolicy Expression::computeCachePolicy( const Gaffer::ValuePlug *output ) const
+{
+	if( output == executePlug() )
+	{
+		if( m_engine )
+		{
+			return m_engine->executeCachePolicy();
+		}
+		else
+		{
+			return ValuePlug::CachePolicy::Legacy;
+		}
+	}
+	return ComputeNode::computeCachePolicy( output );
+}
+
+
 void Expression::compute( ValuePlug *output, const Context *context ) const
 {
 	if( output == executePlug() )

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -394,6 +394,11 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 			return result;
 		}
 
+		ValuePlug::CachePolicy executeCachePolicy() const override
+		{
+			return ValuePlug::CachePolicy::Legacy;
+		}
+
 		void apply( Gaffer::ValuePlug *proxyOutput, const Gaffer::ValuePlug *topLevelProxyOutput, const IECore::Object *value ) const override
 		{
 			switch( value->typeId() )


### PR DESCRIPTION
This is just #4138 rebased onto 0.59 so we can use the CI builds to do some benchmarking on production scenes at Cinesite. We can't merge it because it contains an ABI break.