### PR TITLE
FileMenu : Increase number of recent files to 25

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Improvements
 - FilterResults : Improved performance of hash.
 - PrimitiveInspector : Improved responsiveness by performing work in the background instead of locking the UI.
 - Graph Editor : Prevented zooming in so far you can't see nodes.
+- FileMenu : Increased the maximum number of items in the "Open Recent" menu to 25.
 
 API
 ---

--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -192,7 +192,11 @@ def openRecent( menu ) :
 
 ## This function adds a file to the list shown in the File/OpenRecent menu, and saves a recentFiles.py
 # in the application's user startup folder so the settings will persist.
-def addRecentFile( application, fileName ) :
+## \todo In a future major version, add a datetime argument and use it to
+# split the recent files menu into sections to make it easier to read. The
+# `_reserved` argument is a placeholder so that when we do this, older versions
+# will be able to continue to load the `recentFiles.py` config.
+def addRecentFile( application, fileName, *_reserved ) :
 
 	if isinstance( application, Gaffer.Application ) :
 		applicationRoot = application.root()
@@ -208,7 +212,7 @@ def addRecentFile( application, fileName ) :
 		applicationRoot.__recentFiles.remove( fileName )
 
 	applicationRoot.__recentFiles.insert( 0, fileName )
-	del applicationRoot.__recentFiles[6:]
+	del applicationRoot.__recentFiles[25:]
 
 	# Accessing via builtins to avoid shadowing by our own `open()` method above.
 	with __builtins__["open"]( os.path.join( applicationRoot.preferencesLocation(), "recentFiles.py" ), "w" ) as f :


### PR DESCRIPTION
Also reserve a parameter to `addRecentFile()` so that we can improve the presentation in future.

Note that `addRecentFile()` does have a theoretical quadratic scaling issue because it uses linear search in `__recentFiles.remove()` and also saves out the config with every call. I have verified that although the new limit does increase runtime slightly, it is still only in the order of a few milliseconds.
