### PR TITLE
StringPlug : Make hash more exact when we already have the value

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Improvements
 - PrimitiveInspector : Improved responsiveness by performing work in the background instead of locking the UI.
 - Graph Editor : Prevented zooming in so far you can't see nodes.
 - FileMenu : Increased the maximum number of items in the "Open Recent" menu to 25.
+- StringPlug : Improved accuracy of hashes for strings not containing substitutions.
 
 API
 ---

--- a/python/GafferTest/StringPlugTest.py
+++ b/python/GafferTest/StringPlugTest.py
@@ -357,5 +357,25 @@ class StringPlugTest( GafferTest.TestCase ) :
 			self.assertEqual( s["substitionsOnIndirectly"]["out"].getValue( _precomputedHash = substitionsOnIndirectlyHash2 ), "test.#.exr" )
 			self.assertEqual( substitionsOnIndirectlyHash2, substitionsOnIndirectlyHash1 )
 
+	def testHashUsesValue( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = GafferTest.StringInOutNode()
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression(
+			"""parent["node"]["in"] = str( min( context.getFrame(), 10.0 ) )"""
+		)
+
+		hashes = {}
+		with Gaffer.Context() as context :
+			for i in range( 0, 20 ) :
+				context.setFrame( i )
+				hashes[i] = str( script["node"]["in"].hash() )
+
+		self.assertEqual( len( set( hashes.values() ) ), 11 )
+		for i in range( 10, 20 ) :
+			self.assertEqual( hashes[i], hashes[10] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/StringPlug.cpp
+++ b/src/Gaffer/StringPlug.cpp
@@ -136,6 +136,10 @@ IECore::MurmurHash StringPlug::hash() const
 			result.append( Context::current()->substitute( s->readable(), m_substitutions ) );
 			return result;
 		}
+		else
+		{
+			return s->Object::hash();
+		}
 	}
 
 	// no substitutions


### PR DESCRIPTION
When a StringPlug is going to perform substitutions in `getValue()` we already account for that in `StringPlug::hash()` and compute the most exact hash available. But in the case that the string doesn't have substitutions, we have been falling back to the default `ValuePlug::hash()` path which is less exact, even though we're already in possession of the exact string, and it's presumably hot in the cache from our call to `hasSubstitutions()`.

The main motivation here is actually the behaviour tested by `SceneReaderTest.testGlobalHashesUseFileNameValue()`, which could be implemented simply by calling `h.append( fileNamePlug()->getValue() )` in the SceneReader. But this broader change seemed like it was worth making because it has other potential upsides.
