### PR TITLE
FilterResults : Add `outStrings` plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,7 +14,9 @@ Improvements
 
 - FrameMask : Improved performance when dealing with long frame ranges.
 - Node : Improved performance of type queries related to dispatch processes.
-- FilterResults : Improved performance of hash.
+- FilterResults :
+  - Added `outStrings` plug, which provides the result converted to a list of strings.
+  - Improved performance of hash.
 - PrimitiveInspector : Improved responsiveness by performing work in the background instead of locking the UI.
 - Graph Editor : Prevented zooming in so far you can't see nodes.
 

--- a/include/GafferScene/FilterResults.h
+++ b/include/GafferScene/FilterResults.h
@@ -68,6 +68,9 @@ class GAFFERSCENE_API FilterResults : public Gaffer::ComputeNode
 		Gaffer::PathMatcherDataPlug *outPlug();
 		const Gaffer::PathMatcherDataPlug *outPlug() const;
 
+		Gaffer::StringVectorDataPlug *outStringsPlug();
+		const Gaffer::StringVectorDataPlug *outStringsPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :

--- a/python/GafferSceneTest/FilterResultsTest.py
+++ b/python/GafferSceneTest/FilterResultsTest.py
@@ -46,6 +46,13 @@ import GafferSceneTest
 
 class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
 
+	def assertExpectedOutStrings( self, node ) :
+
+		self.assertEqual(
+			node["outStrings"].getValue(),
+			IECore.StringVectorData( node["out"].getValue().value.paths() )
+		)
+
 	def testChangingFilter( self ) :
 
 		p = GafferScene.Plane()
@@ -68,6 +75,7 @@ class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
 				"/group/plane"
 			] )
 		)
+		self.assertExpectedOutStrings( n )
 
 		f["paths"].setValue( IECore.StringVectorData( [ "/group/p*" ] ) )
 
@@ -77,6 +85,7 @@ class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
 				"/group/plane"
 			] )
 		)
+		self.assertExpectedOutStrings( n )
 
 	def testChangingScene( self ) :
 
@@ -92,6 +101,7 @@ class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
 		n["filter"].setInput( f["out"] )
 
 		self.assertEqual( n["out"].getValue().value, IECore.PathMatcher() )
+		self.assertExpectedOutStrings( n )
 
 		p["name"].setValue( "plain" )
 
@@ -101,6 +111,7 @@ class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
 				"/group/plain"
 			] )
 		)
+		self.assertExpectedOutStrings( n )
 
 	def testDirtyPropagation( self ) :
 
@@ -206,8 +217,6 @@ class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
 
 		with GafferTest.TestRunner.PerformanceScope():
 			filterResults["out"].hash()
-
-
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/FilterResultsUI.py
+++ b/python/GafferSceneUI/FilterResultsUI.py
@@ -81,7 +81,22 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			The results of the search.
+			The results of the search, as an `IECore::PathMatcher` object. This
+			is most useful for performing hierarchical queries and for iterating
+			through the paths without an expensive conversion to strings.
+			""",
+
+			"plugValueWidget:type", "",
+
+		],
+
+		"outStrings" : [
+
+			"description",
+			"""
+			The results of the search, converted to a list of strings. This is
+			useful for connecting directly to other plugs, such as
+			`Wedge.strings` or `CollectScenes.rootNames`.
 			""",
 
 			"plugValueWidget:type", "",


### PR DESCRIPTION
This is useful for connecting directly into plugs like `CollectScenes.rootNames` and `Wedge.strings`.

There may be an argument to be made for a separate PathMatcherToStrings node instead of this specific functionality on the FilterResults node. I've chosen this route for a couple of reasons :

- Everywhere I've ever seen FilterResults used, people have immediately converted the result to a list of strings using a Python expression. I want to provide a path of least resistance away from that.
- FilterResults is the only node that outputs PathMatcherData, and the only one I can imagine in the immediate future. So a PathMatcherToStrings node would have no real utility of its own.
