### PR TITLE
ImagePlug : Change tileSize from 64 to 128

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Improvements
   - Added support for sub-frame dragging with a <kbd>Ctrl</kbd> modifier, and fixed snapping of the frame indicator for regular drag operations.
   - The current frame is now drawn next to the playhead.
 - Improved performance of Python expressions when they are evaluated multiple times in parallel.  This is the first use of the Standard cache policy in a node which could be downstream of a custom Gaffer node that could make an improperly isolated call to tbb, triggering a hang.  If this causes a hang, set the env var GAFFER_PYTHONEXPRESSION_CACHEPOLICY=Legacy as a temporary workaround, and make sure that all C++ nodes that use tbb parallelism are isolating.
+- Increased image processing tile size from 64 pixels to 128 pixels.  This reduces per-tile overhead on large images, dramatically increasing effective image performance in many cases.
 
 Fixes
 -----

--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -229,7 +229,7 @@ class GAFFERIMAGE_API ImagePlug : public Gaffer::ValuePlug
 
 	private :
 
-		static int tileSizeLog2() { return 6; };
+		static int tileSizeLog2() { return 7; };
 
 		static void compoundObjectToCompoundData( const IECore::CompoundObject *object, IECore::CompoundData *data );
 

--- a/python/GafferImageTest/DisplayTest.py
+++ b/python/GafferImageTest/DisplayTest.py
@@ -249,7 +249,7 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 		driversCreated = GafferTest.CapturingSlot( GafferImage.Display.driverCreatedSignal() )
 
 		server = IECoreImage.DisplayDriverServer()
-		dataWindow = imath.Box2i( imath.V2i( 0 ), imath.V2i( 100 ) )
+		dataWindow = imath.Box2i( imath.V2i( 0 ), imath.V2i( GafferImage.ImagePlug.tileSize() ) )
 
 		driver = self.Driver(
 			GafferImage.Format( dataWindow ),

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -53,6 +53,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 	colorSpaceFileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/circles_as_cineon.exr" )
 	offsetDataWindowFileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/rgb.100x100.exr" )
 	jpgFileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/circles.jpg" )
+	largeFileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/colorbars_max_clamp.exr" )
 
 	def setUp( self ) :
 
@@ -91,7 +92,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 	def testChannelDataHashes( self ) :
 		# Test that two tiles within the same image have different hashes.
 		n = GafferImage.ImageReader()
-		n["fileName"].setValue( self.fileName )
+		n["fileName"].setValue( self.largeFileName )
 		h1 = n["out"].channelData( "R", imath.V2i( 0 ) ).hash()
 		h2 = n["out"].channelData( "R", imath.V2i( GafferImage.ImagePlug().tileSize() ) ).hash()
 

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -393,7 +393,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 						self.assertEqual( reRead["out"].dataWindow(), onePixelDataWindow )
 
 						emptyPixelData = IECore.CompoundObject()
-						emptyPixelData["tileOrigins"] = IECore.V2iVectorData( [ imath.V2i( 0, 64 ) ] )
+						emptyPixelData["tileOrigins"] = IECore.V2iVectorData( [ GafferImage.ImagePlug.tileOrigin( imath.V2i( 0, 99 ) ) ] )
 						emptyPixelData["sampleOffsets"] = IECore.ObjectVector( [ GafferImage.ImagePlug.emptyTileSampleOffsets() ] )
 						for channel in [ "R", "G","B", "A", "Z", "ZBack" ]:
 							emptyPixelData[channel] = IECore.ObjectVector( [ IECore.FloatVectorData() ] )


### PR DESCRIPTION
This incredibly tiny change dramatically improves image performance.  We've held off on doing it due to some more philosophical concerns:  what is the theoretically optimal tile size?  Should it be larger than 128?  Are there corner cases involving small image edits where this is worse?  Does it make cancellation a bit slower sometimes?  Would it be unnecessary if we took more general approaches to reducing hashing overhead?

But for the moment, the fact remains that this little change currently makes all the image stuff work a lot better.  The existing image performance tests show 20% - 50% time reductions.

One very troublesome performance cases is:  do a 2K render, merge it with another image, and resize it by 10%, and view it through the image network while doing an interactive render.
Our current policy is mostly just "don't do that".  The important performance metric in this case is how much the Arnold update rate needs to slow down before we can keep up with it - before this change in a case like this, in a simple render, the Arnold updates come so fast that the Gaffer computes keep getting cancelled before they can finish, and the bottom of the image never gets updated until the Arnold render finishes completely.  In a test of this scenario I set up, the increased tile size allows Gaffer to compute fast enough to keep up once the first second of the render has passed, which is the difference between "not usable" and "usable" in this case.