### PR TITLE
Node : Remove `plugFlagsChangedSignal()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -70,6 +70,7 @@ Breaking Changes
 - GafferSceneUI : Removed `SourceSet`.
 - ScriptNode : Added private member data.
 - Expression : Changed the Python expression cache policy to `Standard`. This executes expressions behind a lock, and can cause hangs if buggy upstream nodes perform TBB tasks without an appropriate `TaskIsolation` or `TaskCollaboration` policy. In this case, the `GAFFER_PYTHONEXPRESSION_CACHEPOLICY` environment variable may be set to `Legacy` or `TaskIsolation` while the bugs are fixed.
+- Node : Removed `plugFlagsChangedSignal()`. We aim to phase flags out completely in future, and none of the current flags are expected to be changed after construction.
 
 Build
 -----

--- a/include/Gaffer/Node.h
+++ b/include/Gaffer/Node.h
@@ -116,8 +116,6 @@ class GAFFER_API Node : public GraphComponent
 		/// onto an input plug of a plain Node (and potentially onwards if that plug
 		/// has its own output connections).
 		UnaryPlugSignal &plugDirtiedSignal();
-		/// Emitted when the flags are changed for a plug of this node.
-		UnaryPlugSignal &plugFlagsChangedSignal();
 		//@}
 
 		/// It's common for users to want to create their own plugs on
@@ -190,7 +188,6 @@ class GAFFER_API Node : public GraphComponent
 
 		UnaryPlugSignal m_plugSetSignal;
 		UnaryPlugSignal m_plugInputChangedSignal;
-		UnaryPlugSignal m_plugFlagsChangedSignal;
 		UnaryPlugSignal m_plugDirtiedSignal;
 		ErrorSignal m_errorSignal;
 

--- a/python/GafferTest/NodeTest.py
+++ b/python/GafferTest/NodeTest.py
@@ -248,26 +248,6 @@ class NodeTest( GafferTest.TestCase ) :
 
 		self.assertRaises( RuntimeError, n1["in"].setInput, n2["out"] )
 
-	def testPlugFlagsChangedSignal( self ) :
-
-		n = Gaffer.Node()
-		n["p"] = Gaffer.Plug()
-
-		cs = GafferTest.CapturingSlot( n.plugFlagsChangedSignal() )
-		self.assertEqual( len( cs ), 0 )
-
-		n["p"].setFlags( Gaffer.Plug.Flags.Dynamic, True )
-		self.assertEqual( len( cs ), 1 )
-		self.assertTrue( cs[0][0].isSame( n["p"] ) )
-
-		# second time should have no effect because they're the same
-		n["p"].setFlags( Gaffer.Plug.Flags.Dynamic, True )
-		self.assertEqual( len( cs ), 1 )
-
-		n["p"].setFlags( Gaffer.Plug.Flags.Dynamic, False )
-		self.assertEqual( len( cs ), 2 )
-		self.assertTrue( cs[1][0].isSame( n["p"] ) )
-
 	def testUserPlugs( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferTest/PlugTest.py
+++ b/python/GafferTest/PlugTest.py
@@ -647,19 +647,15 @@ class PlugTest( GafferTest.TestCase ) :
 
 		self.assertFalse( s["n"]["user"]["p"].getFlags( Gaffer.Plug.Flags.Dynamic ) )
 
-		cs = GafferTest.CapturingSlot( s["n"].plugFlagsChangedSignal() )
 		with Gaffer.UndoScope( s["n"]["user"]["p"].ancestor( Gaffer.ScriptNode ) ) :
 			s["n"]["user"]["p"].setFlags( Gaffer.Plug.Flags.Dynamic, True )
 			self.assertTrue( s["n"]["user"]["p"].getFlags( Gaffer.Plug.Flags.Dynamic ) )
-			self.assertEqual( len( cs ), 1 )
 
 		s.undo()
 		self.assertFalse( s["n"]["user"]["p"].getFlags( Gaffer.Plug.Flags.Dynamic ) )
-		self.assertEqual( len( cs ), 2 )
 
 		s.redo()
 		self.assertTrue( s["n"]["user"]["p"].getFlags( Gaffer.Plug.Flags.Dynamic ) )
-		self.assertEqual( len( cs ), 3 )
 
 	def testParentConnectionIgnoresOutOfOrderChildConnections( self ) :
 

--- a/src/Gaffer/Node.cpp
+++ b/src/Gaffer/Node.cpp
@@ -69,11 +69,6 @@ Node::UnaryPlugSignal &Node::plugInputChangedSignal()
 	return m_plugInputChangedSignal;
 }
 
-Node::UnaryPlugSignal &Node::plugFlagsChangedSignal()
-{
-	return m_plugFlagsChangedSignal;
-}
-
 Node::UnaryPlugSignal &Node::plugDirtiedSignal()
 {
 	return m_plugDirtiedSignal;

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -220,11 +220,6 @@ void Plug::setFlags( unsigned flags, bool enable )
 void Plug::setFlagsInternal( unsigned flags )
 {
 	m_flags = flags;
-
-	if( Node *n = node() )
-	{
-		n->plugFlagsChangedSignal()( this );
-	}
 }
 
 // The implementation of acceptsInputInternal() checks

--- a/src/GafferModule/NodeBinding.cpp
+++ b/src/GafferModule/NodeBinding.cpp
@@ -118,7 +118,6 @@ void GafferModule::bindNode()
 			.def( "scriptNode", (ScriptNode *(Node::*)())&Node::scriptNode, return_value_policy<CastToIntrusivePtr>() )
 			.def( "plugSetSignal", &Node::plugSetSignal, return_internal_reference<1>() )
 			.def( "plugInputChangedSignal", &Node::plugInputChangedSignal, return_internal_reference<1>() )
-			.def( "plugFlagsChangedSignal", &Node::plugFlagsChangedSignal, return_internal_reference<1>() )
 			.def( "plugDirtiedSignal", &Node::plugDirtiedSignal, return_internal_reference<1>() )
 			.def( "errorSignal", (Node::ErrorSignal &(Node::*)())&Node::errorSignal, return_internal_reference<1>() )
 		;


### PR DESCRIPTION
This is completely unused in the Gaffer codebase, and none of the current flags are expected to be changed after construction anyway.
