### PR TITLE
ScriptWindow : Fix broken shortcuts in floating editors

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.58.6.x (relative to 0.58.6.3)
+========
+
+Fixes
+-----
+
+- Layouts : Fixed broken keyboard shortcuts in floating editors.
+
 0.58.6.3 (relative to 0.58.6.2)
 ========
 

--- a/python/GafferUI/ScriptWindow.py
+++ b/python/GafferUI/ScriptWindow.py
@@ -58,6 +58,10 @@ class ScriptWindow( GafferUI.Window ) :
 
 		menuDefinition = self.menuDefinition( script.applicationRoot() ) if script.applicationRoot() else IECore.MenuDefinition()
 		self.__listContainer.append( GafferUI.MenuBar( menuDefinition ) )
+		# Must parent `__listContainer` to the window before setting the layout,
+		# because `CompoundEditor.__parentChanged` needs to find the ancestor
+		# ScriptWindow.
+		self.setChild( self.__listContainer )
 
 		applicationRoot = self.__script.ancestor( Gaffer.ApplicationRoot )
 		layouts = GafferUI.Layouts.acquire( applicationRoot ) if applicationRoot is not None else None
@@ -65,8 +69,6 @@ class ScriptWindow( GafferUI.Window ) :
 			self.setLayout( layouts.createDefault( script ) )
 		else :
 			self.setLayout( GafferUI.CompoundEditor( script ) )
-
-		self.setChild( self.__listContainer )
 
 		self.closedSignal().connect( Gaffer.WeakMethod( self.__closed ), scoped = False )
 


### PR DESCRIPTION
Again! This mechanism is proving to be very fragile. A better approach may be to deal with this automatically at a lower level, by having Windows know about MenuBars. Then `Window.addChildWindow()` could automatically ensure shortcuts are propagated appropriately. That's a bigger upheaval though, so for now, we use a simple workaround.

Would be good to get this reviewed today @danieldresser-ie, so I can get a fix out on Monday.