### PR TITLE
EventLoop : Fix potential issues with _UIThreadExecutor

### DIFF
--- a/python/GafferUI/EventLoop.py
+++ b/python/GafferUI/EventLoop.py
@@ -331,7 +331,7 @@ class _UIThreadExecutor( QtCore.QObject ) :
 		# thread where we live.
 		self.__instances.add( self )
 
-	def event( self, event ) :
+	def customEvent( self, event ) :
 
 		if event.type() == self.executeEventType :
 			result = self.__callable()


### PR DESCRIPTION
We weren't calling the base class `QObject.event()` for events we weren't interested in handling. This prevents the base class from processing events related to the `moveToThread()` call we make. Moving to `customEvent()` means we know we're being called only for our own event type, and the QObject's event handling remains intact.

This is a speculative fix for an IPR update bug that has been reported but I've been unable to reproduce. It certainly fixes bad code, but whether or not it'll solve the real world problem I don't know.