### PR TITLE
ExtensionAlgo fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Fixes
 -----
 
-- ExtensionAlgo : Fixed copy/paste of nodes exported by ExtensionAlgo (#3886).
+- ExtensionAlgo :
+  - Fixed copy/paste of nodes exported by ExtensionAlgo (#3886).
+  - Fixed bug which prevented the use of internal Expression nodes.
 
 0.58.6.4 (relative to 0.58.6.3)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.58.6.x (relative to 0.58.6.4)
+========
+
+Fixes
+-----
+
+- ExtensionAlgo : Fixed copy/paste of nodes exported by ExtensionAlgo (#3886).
+
 0.58.6.4 (relative to 0.58.6.3)
 ========
 

--- a/python/Gaffer/ExtensionAlgo.py
+++ b/python/Gaffer/ExtensionAlgo.py
@@ -125,6 +125,18 @@ class {name}( Gaffer.SubGraph ) :
 
 {constructor}
 
+		self.__removeDynamicFlags()
+
+	# Remove dynamic flags using the same logic used by the Reference node.
+	## \todo : Create the plugs without the flags in the first place.
+	def __removeDynamicFlags( self ) :
+
+		for plug in Gaffer.Plug.Range( self ) :
+			plug.setFlags( Gaffer.Plug.Flags.Dynamic, False )
+			if not isinstance( plug, ( Gaffer.SplineffPlug, Gaffer.SplinefColor3fPlug, Gaffer.SplinefColor4fPlug ) ) :
+				for plug in Gaffer.Plug.RecursiveRange( plug ) :
+					plug.setFlags( Gaffer.Plug.Flags.Dynamic, False )
+
 IECore.registerRunTimeTyped( {name}, typeName = "{extension}::{name}" )
 """
 

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -509,7 +509,7 @@ void Expression::plugSet( const Plug *plug )
 	}
 
 	const ScriptNode *script = scriptNode();
-	if( !script || !script->isExecuting() )
+	if( script && !script->isExecuting() )
 	{
 		IECore::msg( IECore::Msg::Warning, "Expression::plugSet", "Unexpected change to __engine plug. Should you be calling setExpression() instead?" );
 		return;


### PR DESCRIPTION
ExtensionAlgo allows Boxes to be exported in the form of true Gaffer extensions - a Python module with custom node types in it. It was intended as the seed behind a Gafferpedia idea, but a couple of nasty bugs prevented it from being used seriously. I was hoping to fix these bugs cleanly as part of a wider serialisation overhaul, but time hasn't allowed. So this PR just makes the short-term pragmatic-but-ugly fixes necessary to make ExtensionAlgo useful in the mean time.