### PR TITLE
PlugValueWidget : Don't call `_updateFromPlugs()` on input change

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,7 @@ Fixes
 -----
 
 - ScriptNode : Fixed bugs that allowed global variables to remain in the context after they had been disabled, renamed or deleted.
+- PlugValueWidget : Fixed bug that tried to update the widget before all graph edits were complete.
 
 API
 ---

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -464,7 +464,6 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		if plug in self.__plugs :
 			self.__updateContextConnection()
-			self._updateFromPlugs()
 
 	def __plugMetadataChanged( self, plug, key, reason ) :
 


### PR DESCRIPTION
The input change may be a part of a broader set of graph edits, and we should wait for them all to be complete before evaluating the graph. This is what `__plugDirtied()` is already doing for us, because dirty propagation is batched by DirtyPropagationScope.
