### PR TITLE
Apply `clang-tidy modernize-use-override`

### DIFF
--- a/contrib/scripts/buildCompileCommands.py
+++ b/contrib/scripts/buildCompileCommands.py
@@ -16,7 +16,7 @@ import subprocess
 # Make SCons tell us everything it would do to build Gaffer
 
 subprocess.check_call( [ "scons", "--clean" ] )
-sconsOutput = subprocess.check_output( [ "scons", "build", "--dry-run", "--no-cache" ] )
+sconsOutput = subprocess.check_output( [ "scons", "build", "--dry-run", "--no-cache" ], universal_newlines = True )
 
 # Write that into a "compile_commands.json" file
 
@@ -31,7 +31,7 @@ for line in sconsOutput.split( "\n" ) :
 	file = line.split()[-1]
 	data.append(
 		{
-			"directory" : "/Users/john/dev/gaffer",
+			"directory" : os.getcwd(),
 			"command" : line,
 			"file" : file,
 		}

--- a/include/Gaffer/Monitor.h
+++ b/include/Gaffer/Monitor.h
@@ -53,7 +53,7 @@ class GAFFER_API Monitor : public IECore::RefCounted
 
 	public :
 
-		virtual ~Monitor();
+		~Monitor() override;
 
 		IE_CORE_DECLAREMEMBERPTR( Monitor )
 

--- a/include/Gaffer/Private/IECorePreview/TaskMutex.h
+++ b/include/Gaffer/Private/IECorePreview/TaskMutex.h
@@ -342,7 +342,7 @@ class TaskMutex : boost::noncopyable
 					observe( true );
 				}
 
-				~ArenaObserver()
+				~ArenaObserver() override
 				{
 					observe( false );
 				}
@@ -386,7 +386,7 @@ class TaskMutex : boost::noncopyable
 			}
 
 			// Work around https://bugs.llvm.org/show_bug.cgi?id=32978
-			~ExecutionState() noexcept( true )
+			~ExecutionState() noexcept( true ) override
 			{
 			}
 

--- a/include/Gaffer/Spreadsheet.h
+++ b/include/Gaffer/Spreadsheet.h
@@ -76,7 +76,7 @@ class GAFFER_API Spreadsheet : public ComputeNode
 			public :
 
 				RowsPlug( const std::string &name = defaultName<RowsPlug>(), Direction direction = In, unsigned flags = Default );
-				virtual ~RowsPlug();
+				~RowsPlug() override;
 
 				GAFFER_PLUG_DECLARE_TYPE( Gaffer::Spreadsheet::RowsPlug, Gaffer::SpreadsheetRowsPlugTypeId, Gaffer::ValuePlug );
 

--- a/include/GafferScene/InteractiveRender.h
+++ b/include/GafferScene/InteractiveRender.h
@@ -94,7 +94,7 @@ class GAFFERSCENE_API InteractiveRender : public Gaffer::ComputeNode
 		Gaffer::Context *getContext();
 		const Gaffer::Context *getContext() const;
 
-		virtual void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
@@ -104,12 +104,12 @@ class GAFFERSCENE_API InteractiveRender : public Gaffer::ComputeNode
 		// loading of the module which registers the required renderer type.
 		InteractiveRender( const IECore::InternedString &rendererType, const std::string &name );
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
 
-		virtual bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
 
 	private :
 

--- a/include/GafferScene/SetVisualiser.h
+++ b/include/GafferScene/SetVisualiser.h
@@ -86,8 +86,8 @@ class GAFFERSCENE_API SetVisualiser : public AttributeProcessor
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
 		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -132,8 +132,8 @@ class GAFFERSCENE_API Shader : public Gaffer::ComputeNode
 
 	protected :
 
-		virtual void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		virtual void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 		/// Attributes computation
 		/// ----------------------

--- a/src/GafferArnoldUI/LightBlockerVisualiser.cpp
+++ b/src/GafferArnoldUI/LightBlockerVisualiser.cpp
@@ -183,7 +183,7 @@ class LightBlockerVisualiser : public LightFilterVisualiser
 		LightBlockerVisualiser();
 		~LightBlockerVisualiser() override;
 
-		virtual Visualisations visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *filterShaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
+		Visualisations visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *filterShaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
 
 	protected :
 

--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -194,7 +194,7 @@ class ImageGadget::TileShader : public IECore::RefCounted
 			}
 		}
 
-		~TileShader()
+		~TileShader() override
 		{
 			if( m_lut3dTextureID )
 			{


### PR DESCRIPTION
This catches the last few spots where we weren't using it consistently.