### PR TITLE
Spreadsheet : Add `resolvedRows` output plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,9 @@ Improvements
 
 - FileMenu : File loading and saving no longer locks the UI, and can be cancelled.
 - MapProjection : Added `position` plug to allow a custom position to be used for the projection.
+- Spreadsheet : Added `resolvedRows` output plug, containing the resolved cell values
+  for all active rows. This allows expressions to work with all the data in the spreadsheet,
+  independently of the `selector` mechanism.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,8 @@ Improvements
     independently of the `selector` mechanism.
   - Added <kbd>+</kbd> button for adding new columns directly. Existing plugs may be dragged on
     to it and new plugs can be created from a popup menu.
+- CustomOptions : Added `extraOptions` plug to facilitate the creation of dynamic numbers of options
+  from a single expression.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -6,9 +6,12 @@ Improvements
 
 - FileMenu : File loading and saving no longer locks the UI, and can be cancelled.
 - MapProjection : Added `position` plug to allow a custom position to be used for the projection.
-- Spreadsheet : Added `resolvedRows` output plug, containing the resolved cell values
-  for all active rows. This allows expressions to work with all the data in the spreadsheet,
-  independently of the `selector` mechanism.
+- Spreadsheet :
+  - Added `resolvedRows` output plug, containing the resolved cell values
+    for all active rows. This allows expressions to work with all the data in the spreadsheet,
+    independently of the `selector` mechanism.
+  - Added <kbd>+</kbd> button for adding new columns directly. Existing plugs may be dragged on
+    to it and new plugs can be created from a popup menu.
 
 API
 ---

--- a/include/Gaffer/Spreadsheet.h
+++ b/include/Gaffer/Spreadsheet.h
@@ -217,8 +217,8 @@ class GAFFER_API Spreadsheet : public ComputeNode
 		StringVectorDataPlug *activeRowNamesPlug();
 		const StringVectorDataPlug *activeRowNamesPlug() const;
 
-		ObjectVectorPlug *resolvedRowsPlug();
-		const ObjectVectorPlug *resolvedRowsPlug() const;
+		CompoundObjectPlug *resolvedRowsPlug();
+		const CompoundObjectPlug *resolvedRowsPlug() const;
 
 		/// Returns the input plug which provides the value
 		/// for `output` in the current context.

--- a/include/Gaffer/Spreadsheet.h
+++ b/include/Gaffer/Spreadsheet.h
@@ -217,6 +217,9 @@ class GAFFER_API Spreadsheet : public ComputeNode
 		StringVectorDataPlug *activeRowNamesPlug();
 		const StringVectorDataPlug *activeRowNamesPlug() const;
 
+		ObjectVectorPlug *resolvedRowsPlug();
+		const ObjectVectorPlug *resolvedRowsPlug() const;
+
 		/// Returns the input plug which provides the value
 		/// for `output` in the current context.
 		ValuePlug *activeInPlug( const ValuePlug *output );

--- a/include/GafferScene/Options.h
+++ b/include/GafferScene/Options.h
@@ -58,6 +58,9 @@ class GAFFERSCENE_API Options : public GlobalsProcessor
 		Gaffer::CompoundDataPlug *optionsPlug();
 		const Gaffer::CompoundDataPlug *optionsPlug() const;
 
+		Gaffer::CompoundObjectPlug *extraOptionsPlug();
+		const Gaffer::CompoundObjectPlug *extraOptionsPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :

--- a/python/GafferSceneTest/CustomOptionsTest.py
+++ b/python/GafferSceneTest/CustomOptionsTest.py
@@ -200,5 +200,27 @@ class CustomOptionsTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual( g["option:myCategory:test"], IECore.IntData( 10 ) )
 
+	def testExtraOptions( self ) :
+
+		options = GafferScene.CustomOptions()
+
+		options["options"].addChild( Gaffer.NameValuePlug( "test1", IECore.IntData( 1 ) ) )
+		options["options"].addChild( Gaffer.NameValuePlug( "test2", IECore.IntData( 2 ) ) )
+		options["extraOptions"].setValue(
+			IECore.CompoundObject( {
+				"test1" : IECore.IntData( -1 ),
+				"test3" : IECore.IntData( 3 ),
+			} )
+		)
+
+		self.assertEqual(
+			options["out"].globals(),
+			IECore.CompoundObject( {
+				"option:test1" : IECore.IntData( -1 ),
+				"option:test2" : IECore.IntData( 2 ),
+				"option:test3" : IECore.IntData( 3 )
+			} )
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/CustomOptionsUI.py
+++ b/python/GafferSceneUI/CustomOptionsUI.py
@@ -84,7 +84,13 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Advanced",
 
-		]
+		],
+
+		"extraOptions" : [
+
+			"plugValueWidget:type", None,
+
+		],
 
 	}
 

--- a/python/GafferSceneUI/OptionsUI.py
+++ b/python/GafferSceneUI/OptionsUI.py
@@ -68,6 +68,29 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"extraOptions" : [
+
+			"description",
+			"""
+			An additional set of options to be added. Arbitrary numbers
+			of options may be specified within a single `IECore.CompoundObject`,
+			where each key/value pair in the object defines an option.
+			This is convenient when using an expression to define the options
+			and the option count might be dynamic. It can also be used to
+			create options whose type cannot be handled by the `options`
+			CompoundDataPlug.
+
+			If the same option is defined by both the `options` and the
+			`extraOptions` plugs, then the value from the `extraOptions`
+			is taken.
+			""",
+
+			"plugValueWidget:type", "",
+			"layout:section", "Extra",
+			"nodule:type", "",
+
+		],
+
 	}
 
 )

--- a/python/GafferTest/SpreadsheetTest.py
+++ b/python/GafferTest/SpreadsheetTest.py
@@ -881,6 +881,61 @@ class SpreadsheetTest( GafferTest.TestCase ) :
 		self.assertEqual( s["s"]["rows"].defaultHash(), s2["s"]["rows"].defaultHash() )
 		self.assertEqual( s["s"]["rows"].hash(), s2["s"]["rows"].hash() )
 
+	def testResolvedRows( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.IntPlug( "c1", defaultValue = 10 ) )
+		s["rows"].addColumn( Gaffer.StringPlug( "c2", defaultValue = "" ) )
+		s["rows"].addColumn( Gaffer.V2iPlug( "c3", defaultValue = imath.V2i( 0 ) ) )
+		s["rows"].addRows( 3 )
+		s["rows"][1]["name"].setValue( "row1" )
+		s["rows"][2]["name"].setValue( "row2" )
+		s["rows"][3]["name"].setValue( "row3" )
+
+		def assertExpectedValues( expected ) :
+
+			resolved = s["resolvedRows"].getValue()
+			self.assertIsInstance( resolved, IECore.ObjectVector )
+			self.assertEqual( len( resolved ), len( expected ) )
+
+			for i, expectedRow in enumerate( expected ) :
+				resolvedRow = resolved[i]
+				self.assertEqual( resolvedRow["name"].value, expectedRow[0] )
+				self.assertEqual( resolvedRow["cells"]["c1"].value, expectedRow[1] )
+				self.assertEqual( resolvedRow["cells"]["c2"].value, expectedRow[2] )
+				self.assertEqual( resolvedRow["cells"]["c3"].value, expectedRow[3] )
+
+		assertExpectedValues( [
+			[ "row1", 10, "", imath.V2i( 0 ) ],
+			[ "row2", 10, "", imath.V2i( 0 ) ],
+			[ "row3", 10, "", imath.V2i( 0 ) ],
+		] )
+
+		s["rows"][1]["cells"]["c1"]["value"].setValue( 20 )
+		s["rows"][2]["cells"]["c2"]["value"].setValue( "b" )
+		s["rows"][3]["cells"]["c3"]["value"].setValue( imath.V2i( 10 ) )
+
+		assertExpectedValues( [
+			[ "row1", 20, "", imath.V2i( 0 ) ],
+			[ "row2", 10, "b", imath.V2i( 0 ) ],
+			[ "row3", 10, "", imath.V2i( 10 ) ],
+		] )
+
+		s["rows"][1]["cells"]["c1"]["enabled"].setValue( False )
+
+		assertExpectedValues( [
+			[ "row1", 10, "", imath.V2i( 0 ) ],
+			[ "row2", 10, "b", imath.V2i( 0 ) ],
+			[ "row3", 10, "", imath.V2i( 10 ) ],
+		] )
+
+		s["rows"][3]["enabled"].setValue( False )
+
+		assertExpectedValues( [
+			[ "row1", 10, "", imath.V2i( 0 ) ],
+			[ "row2", 10, "b", imath.V2i( 0 ) ],
+		] )
+
 	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testAddRowPerformance( self ) :
 

--- a/python/GafferTest/SpreadsheetTest.py
+++ b/python/GafferTest/SpreadsheetTest.py
@@ -895,46 +895,50 @@ class SpreadsheetTest( GafferTest.TestCase ) :
 		def assertExpectedValues( expected ) :
 
 			resolved = s["resolvedRows"].getValue()
-			self.assertIsInstance( resolved, IECore.ObjectVector )
+			self.assertIsInstance( resolved, IECore.CompoundObject )
 			self.assertEqual( len( resolved ), len( expected ) )
 
-			for i, expectedRow in enumerate( expected ) :
-				resolvedRow = resolved[i]
-				self.assertEqual( resolvedRow["name"].value, expectedRow[0] )
-				self.assertEqual( resolvedRow["cells"]["c1"].value, expectedRow[1] )
-				self.assertEqual( resolvedRow["cells"]["c2"].value, expectedRow[2] )
-				self.assertEqual( resolvedRow["cells"]["c3"].value, expectedRow[3] )
+			for name, expectedRow in expected.items() :
+				self.assertEqual( resolved[name]["c1"].value, expectedRow[0] )
+				self.assertEqual( resolved[name]["c2"].value, expectedRow[1] )
+				self.assertEqual( resolved[name]["c3"].value, expectedRow[2] )
 
-		assertExpectedValues( [
-			[ "row1", 10, "", imath.V2i( 0 ) ],
-			[ "row2", 10, "", imath.V2i( 0 ) ],
-			[ "row3", 10, "", imath.V2i( 0 ) ],
-		] )
+		assertExpectedValues( {
+			"row1" : [ 10, "", imath.V2i( 0 ) ],
+			"row2" : [ 10, "", imath.V2i( 0 ) ],
+			"row3" : [ 10, "", imath.V2i( 0 ) ],
+		} )
 
 		s["rows"][1]["cells"]["c1"]["value"].setValue( 20 )
 		s["rows"][2]["cells"]["c2"]["value"].setValue( "b" )
 		s["rows"][3]["cells"]["c3"]["value"].setValue( imath.V2i( 10 ) )
 
-		assertExpectedValues( [
-			[ "row1", 20, "", imath.V2i( 0 ) ],
-			[ "row2", 10, "b", imath.V2i( 0 ) ],
-			[ "row3", 10, "", imath.V2i( 10 ) ],
-		] )
+		assertExpectedValues( {
+			"row1" : [ 20, "", imath.V2i( 0 ) ],
+			"row2" : [ 10, "b", imath.V2i( 0 ) ],
+			"row3" : [ 10, "", imath.V2i( 10 ) ],
+		} )
 
 		s["rows"][1]["cells"]["c1"]["enabled"].setValue( False )
 
-		assertExpectedValues( [
-			[ "row1", 10, "", imath.V2i( 0 ) ],
-			[ "row2", 10, "b", imath.V2i( 0 ) ],
-			[ "row3", 10, "", imath.V2i( 10 ) ],
-		] )
+		assertExpectedValues( {
+			"row1" : [ 10, "", imath.V2i( 0 ) ],
+			"row2" : [ 10, "b", imath.V2i( 0 ) ],
+			"row3" : [ 10, "", imath.V2i( 10 ) ],
+		} )
 
 		s["rows"][3]["enabled"].setValue( False )
 
-		assertExpectedValues( [
-			[ "row1", 10, "", imath.V2i( 0 ) ],
-			[ "row2", 10, "b", imath.V2i( 0 ) ],
-		] )
+		assertExpectedValues( {
+			"row1" : [ 10, "", imath.V2i( 0 ) ],
+			"row2" : [ 10, "b", imath.V2i( 0 ) ],
+		} )
+
+		s["rows"][2]["name"].setValue( "row1" )
+
+		assertExpectedValues( {
+			"row1" : [ 10, "", imath.V2i( 0 ) ],
+		} )
 
 	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testAddRowPerformance( self ) :

--- a/python/GafferUI/SpreadsheetUI/_Metadata.py
+++ b/python/GafferUI/SpreadsheetUI/_Metadata.py
@@ -191,11 +191,11 @@ Gaffer.Metadata.registerNode(
 			values are formatted as follows :
 
 			```
-			[
-			    { "name" : "row1Name", "cells" : { "columnName" : columnValue, ... } },
-			    { "name" : "row2Name", "cells" : { "columnName" : columnValue, ... } },
+			{
+			    "row1Name" : { "columnName" : columnValue, ... },
+			    "row2Name" : { "columnName" : columnValue, ... },
 			    ...
-			]
+			}
 			```
 
 			> Note : The output is completely independent of the value of

--- a/python/GafferUI/SpreadsheetUI/_Metadata.py
+++ b/python/GafferUI/SpreadsheetUI/_Metadata.py
@@ -181,6 +181,32 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"resolvedRows" : [
+
+			"description",
+			"""
+			An output plug containing the resolved cell values for all active
+			rows, This can be used to drive expressions in situations where the
+			standard `out` plug is not useful, or would be awkward to use. The
+			values are formatted as follows :
+
+			```
+			[
+			    { "name" : "row1Name", "cells" : { "columnName" : columnValue, ... } },
+			    { "name" : "row2Name", "cells" : { "columnName" : columnValue, ... } },
+			    ...
+			]
+			```
+
+			> Note : The output is completely independent of the value of
+			> `selector`.
+			""",
+
+			"layout:section", "Advanced",
+			"plugValueWidget:type", "GafferUI.ConnectionPlugValueWidget"
+
+		],
+
 	}
 
 )

--- a/src/Gaffer/Spreadsheet.cpp
+++ b/src/Gaffer/Spreadsheet.cpp
@@ -36,6 +36,7 @@
 
 #include "Gaffer/Spreadsheet.h"
 
+#include "Gaffer/PlugAlgo.h"
 #include "Gaffer/StringPlug.h"
 
 #include "IECore/NullObject.h"
@@ -826,6 +827,7 @@ Spreadsheet::Spreadsheet( const std::string &name )
 	addChild( new RowsPlug( "rows" ) );
 	addChild( new ValuePlug( "out", Plug::Out ) );
 	addChild( new StringVectorDataPlug( "activeRowNames", Plug::Out, new IECore::StringVectorData ) );
+	addChild( new ObjectVectorPlug( "resolvedRows", Plug::Out, new IECore::ObjectVector() ) );
 	addChild( new ObjectPlug( "__rowsMap", Plug::Out, IECore::NullObject::defaultNullObject() ) );
 	addChild( new IntPlug( "__rowIndex", Plug::Out ) );
 }
@@ -884,24 +886,34 @@ const StringVectorDataPlug *Spreadsheet::activeRowNamesPlug() const
 	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 4 );
 }
 
+ObjectVectorPlug *Spreadsheet::resolvedRowsPlug()
+{
+	return getChild<ObjectVectorPlug>( g_firstPlugIndex + 5 );
+}
+
+const ObjectVectorPlug *Spreadsheet::resolvedRowsPlug() const
+{
+	return getChild<ObjectVectorPlug>( g_firstPlugIndex + 5 );
+}
+
 ObjectPlug *Spreadsheet::rowsMapPlug()
 {
-	return getChild<ObjectPlug>( g_firstPlugIndex + 5 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 6 );
 }
 
 const ObjectPlug *Spreadsheet::rowsMapPlug() const
 {
-	return getChild<ObjectPlug>( g_firstPlugIndex + 5 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 6 );
 }
 
 IntPlug *Spreadsheet::rowIndexPlug()
 {
-	return getChild<IntPlug>( g_firstPlugIndex + 6 );
+	return getChild<IntPlug>( g_firstPlugIndex + 7 );
 }
 
 const IntPlug *Spreadsheet::rowIndexPlug() const
 {
-	return getChild<IntPlug>( g_firstPlugIndex + 6 );
+	return getChild<IntPlug>( g_firstPlugIndex + 7 );
 }
 
 void Spreadsheet::affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const
@@ -958,6 +970,11 @@ void Spreadsheet::affects( const Plug *input, DependencyNode::AffectedPlugsConta
 	{
 		outputs.push_back( activeRowNamesPlug() );
 	}
+
+	if( rowsPlug()->isAncestorOf( input ) )
+	{
+		outputs.push_back( resolvedRowsPlug() );
+	}
 }
 
 Plug *Spreadsheet::correspondingInput( const Plug *output )
@@ -1004,6 +1021,11 @@ void Spreadsheet::hash( const ValuePlug *output, const Context *context, IECore:
 		rowsMapPlug()->hash( h );
 		return;
 	}
+	else if( output == resolvedRowsPlug() )
+	{
+		ComputeNode::hash( output, context, h );
+		rowsPlug()->hash( h );
+	}
 
 	ComputeNode::hash( output, context, h );
 }
@@ -1040,6 +1062,50 @@ void Spreadsheet::compute( ValuePlug *output, const Context *context ) const
 		ConstRowsMapPtr rowsMap = boost::static_pointer_cast<const RowsMap>( rowsMapPlug()->getValue() );
 		static_cast<StringVectorDataPlug *>( output )->setValue( rowsMap->activeRowNames() );
 		return;
+	}
+	else if( output == resolvedRowsPlug() )
+	{
+		ObjectVectorPtr result = new ObjectVector;
+		CompoundObjectPtr defaults = new CompoundObject;
+		for( const auto &cellPlug : CellPlug::Range( *rowsPlug()->defaultRow()->cellsPlug() ) )
+		{
+			defaults->members()[cellPlug->getName()] = PlugAlgo::extractDataFromPlug( cellPlug->valuePlug() );
+		}
+
+		for( size_t i = 1, s = rowsPlug()->children().size(); i < s; ++i )
+		{
+			const RowPlug *rowPlug = rowsPlug()->getChild<RowPlug>( i );
+			if( !rowPlug->enabledPlug()->getValue() )
+			{
+				continue;
+			}
+
+			CompoundObjectPtr cells = new CompoundObject;
+			for( const auto &cellPlug : CellPlug::Range( *rowPlug->cellsPlug() ) )
+			{
+				if( cellPlug->enabledPlug()->getValue() )
+				{
+					cells->members()[cellPlug->getName()] = PlugAlgo::extractDataFromPlug( cellPlug->valuePlug() );
+				}
+				else
+				{
+					cells->members()[cellPlug->getName()] = defaults->members().at( cellPlug->getName() );
+				}
+			}
+
+			if( !defaults )
+			{
+				defaults = cells;
+			}
+			else
+			{
+				CompoundObjectPtr row = new CompoundObject;
+				row->members()["name"] = new StringData( rowPlug->namePlug()->getValue() );
+				row->members()["cells"] = cells;
+				result->members().push_back( row );
+			}
+		}
+		static_cast<ObjectPlug *>( output )->setValue( result );
 	}
 
 	ComputeNode::compute( output, context );


### PR DESCRIPTION
This adds a `resolvedRows` output plug to the Spreadsheet node, which provides an object containing the complete resolved spreadsheet for use in expressions. This enables a completely different use pattern, where the `selector` semantics aren't relevant and you are free to use the spreadsheet as a convenient UI on top of an expression implementing your own semantics.

The motivation for this comes from observing a contorted production case where a Loop node was used to cycle through each row, modifying the scene globals on each iteration. Not only was this awkward to set up, it was also slow, and caused the whole scene - rather than only the globals - to be looped. I've pasted an approximation of this setup implemented using the new capabilities at the end of this description. Although it wasn't necessary for this mockup I've also added a `CustomOptions.extraOptions` plug analogous to `CustomAttributes.extraAttributes`, which should make this type of workflow even more flexible.

In addition to the usual review, I have a number of open questions :

1. Is `resolvedRows` the right name for the plug?
2. Is the data format for `resolvedRows` correct? I chose it to preserve the row order, and also so you receive all rows even if some have identical names. But it could be simplified by returning a dictionary of rows indexed by name, meaning we'd resolve duplicate rows using the same "first wins" rules we use elsewhere. e.g. `{ "row1" : { "column1" : 10 }, ... }`.
3. Are we overloading the use of the Spreadsheet node too much? There's probably an argument for separate SpreadsheetThatWorksLikeTheOldOne and SpreadsheetThatJustHasResolvedRows nodes, but I can't think of good names, and think that it's probably OK to just put this on an Advanced tab for now.

```
import Gaffer
import GafferScene
import IECore
import imath

Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 59, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 4, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )

__children = {}

__children["CustomOptions"] = GafferScene.CustomOptions( "CustomOptions" )
parent.addChild( __children["CustomOptions"] )
__children["CustomOptions"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Layers"] = Gaffer.Spreadsheet( "Layers" )
parent.addChild( __children["Layers"] )
__children["Layers"]["rows"].addColumn( Gaffer.BoolPlug( "Beauty", defaultValue = False, ) )
__children["Layers"]["rows"].addColumn( Gaffer.BoolPlug( "Shadow", defaultValue = False, ) )
__children["Layers"]["rows"].addRows( 4 )
__children["Layers"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Expression"] = Gaffer.Expression( "Expression" )
parent.addChild( __children["Expression"] )
__children["Expression"]["__in"].addChild( Gaffer.ObjectVectorPlug( "p0", defaultValue = IECore.ObjectVector(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Expression"]["__out"].addChild( Gaffer.CompoundObjectPlug( "p0", direction = Gaffer.Plug.Direction.Out, defaultValue = IECore.CompoundObject(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Expression"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["CustomOptions"]["extraOptions"].setInput( __children["Expression"]["__out"]["p0"] )
__children["CustomOptions"]["__uiPosition"].setValue( imath.V2f( 3.55000043, -3.75000048 ) )
Gaffer.Metadata.registerValue( __children["Layers"], 'nodeGadget:type', 'GafferUI::StandardNodeGadget' )
Gaffer.Metadata.registerValue( __children["Layers"]["selector"], 'plugValueWidget:type', '' )
__children["Layers"]["rows"][1]["name"].setValue( 'heroCharacters' )
__children["Layers"]["rows"][1]["cells"]["Beauty"]["value"].setValue( True )
__children["Layers"]["rows"][2]["name"].setValue( 'backgroundCharacters' )
__children["Layers"]["rows"][2]["cells"]["Beauty"]["value"].setValue( True )
__children["Layers"]["rows"][2]["cells"]["Shadow"]["value"].setValue( True )
__children["Layers"]["rows"][3]["name"].setValue( 'set' )
__children["Layers"]["rows"][3]["cells"]["Shadow"]["value"].setValue( True )
__children["Layers"]["rows"][4]["name"].setValue( 'fx' )
__children["Layers"]["rows"][4]["cells"]["Shadow"]["value"].setValue( True )
Gaffer.Metadata.registerValue( __children["Layers"]["rows"][0]["cells"]["Beauty"], 'spreadsheet:columnWidth', 55 )
Gaffer.Metadata.registerValue( __children["Layers"]["rows"][0]["cells"]["Shadow"], 'spreadsheet:columnWidth', 59 )
__children["Layers"]["__uiPosition"].setValue( imath.V2f( -13.5499973, -3.6500001 ) )
__children["Expression"]["__in"]["p0"].setInput( __children["Layers"]["resolvedRows"] )
__children["Expression"]["__uiPosition"].setValue( imath.V2f( -4.91505051, -3.46796918 ) )
__children["Expression"]["__engine"].setValue( 'python' )
__children["Expression"]["__expression"].setValue( 'rows = parent["__in"]["p0"]\n\nlayers = IECore.StringVectorData()\nfor row in rows :\n\tfor name, enabled in row["cells"].items() :\n\t\tif enabled.value :\n\t\t\tlayers.append( row["name"].value + "_" + name )\n\n\nparent["__out"]["p0"] = IECore.CompoundObject( {\n\t"cs:layerNames" : layers\n} )\n' )


del __children

```