### PR TITLE
Alternate Approaches To Context Hashing

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,7 @@ Improvements
 - Improved performance of Python expressions when they are evaluated multiple times in parallel. This is the first use of the Standard cache policy in a node which could be downstream of a custom Gaffer node that could make an improperly isolated call to tbb, triggering a hang. If this causes a hang, set the env var GAFFER_PYTHONEXPRESSION_CACHEPOLICY=Legacy as a temporary workaround, and make sure that all C++ nodes that use tbb parallelism are isolating.
 - Increased image processing tile size from 64 pixels to 128 pixels. This reduces per-tile overhead on large images, dramatically increasing effective image performance in many cases.
 - OSLImage : Avoided some unnecessary computes and hashing when calculating channel names or passing through channel data unaltered.
+- Context : Optimized `hash()` method.
 
 Fixes
 -----

--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -269,13 +269,19 @@ class GAFFER_API Context : public IECore::RefCounted
 		struct Storage
 		{
 			Storage() : data( nullptr ), ownership( Copied ) {}
+			inline void updateHash( const IECore::InternedString &name );
 			// We reference the data with a raw pointer to avoid the compulsory
 			// overhead of an intrusive pointer.
 			const IECore::Data *data;
 			// And use this ownership flag to tell us when we need to do explicit
 			// reference count management.
 			Ownership ownership;
+			// Hash value of this entry's data and name - these will be summed to produce
+			// a total hash for the context
+			IECore::MurmurHash hash;
 		};
+
+		void validateHashes();
 
 		typedef boost::container::flat_map<IECore::InternedString, Storage> Map;
 

--- a/include/GafferTest/ContextTest.h
+++ b/include/GafferTest/ContextTest.h
@@ -39,6 +39,8 @@
 
 #include "GafferTest/Export.h"
 
+#include <tuple>
+
 namespace GafferTest
 {
 
@@ -47,6 +49,7 @@ GAFFERTEST_API void testManySubstitutions();
 GAFFERTEST_API void testManyEnvironmentSubstitutions();
 GAFFERTEST_API void testScopingNullContext();
 GAFFERTEST_API void testEditableScope();
+GAFFERTEST_API std::tuple<int,int,int,int> countContextHash32Collisions( int contexts, int mode, int seed );
 GAFFERTEST_API void testContextHashPerformance( int numEntries, int entrySize, bool startInitialized );
 
 } // namespace GafferTest

--- a/include/GafferTest/ContextTest.h
+++ b/include/GafferTest/ContextTest.h
@@ -47,6 +47,7 @@ GAFFERTEST_API void testManySubstitutions();
 GAFFERTEST_API void testManyEnvironmentSubstitutions();
 GAFFERTEST_API void testScopingNullContext();
 GAFFERTEST_API void testEditableScope();
+GAFFERTEST_API void testContextHashPerformance( int numEntries, int entrySize, bool startInitialized );
 
 } // namespace GafferTest
 

--- a/python/GafferTest/ContextTest.py
+++ b/python/GafferTest/ContextTest.py
@@ -684,5 +684,15 @@ class ContextTest( GafferTest.TestCase ) :
 		context3 = Gaffer.Context( context1, omitCanceller = False )
 		self.assertIsNotNone( context3.canceller() )
 
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testContextHashPerformance( self ) :
+
+		GafferTest.testContextHashPerformance( 10, 10, False )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testContextHashPerformanceStartInitialized( self ) :
+
+		GafferTest.testContextHashPerformance( 10, 10, True )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ContextTest.py
+++ b/python/GafferTest/ContextTest.py
@@ -65,33 +65,38 @@ class ContextTest( GafferTest.TestCase ) :
 		def f( context, name ) :
 
 			self.assertTrue( context.isSame( c ) )
-			changes.append( ( name, context.get( name, None ) ) )
+			changes.append( ( name, context.get( name, None ), context.hash() ) )
 
 		cn = c.changedSignal().connect( f )
 
 		c["a"] = 2
-		self.assertEqual( changes, [ ( "a", 2 ) ] )
+		hash1 = c.hash()
+		self.assertEqual( changes, [ ( "a", 2, hash1 ) ] )
 
 		c["a"] = 3
-		self.assertEqual( changes, [ ( "a", 2 ), ( "a", 3 ) ] )
+		hash2 = c.hash()
+		self.assertEqual( changes, [ ( "a", 2, hash1 ), ( "a", 3, hash2 ) ] )
 
 		c["b"] = 1
-		self.assertEqual( changes, [ ( "a", 2 ), ( "a", 3 ), ( "b", 1 ) ] )
+		hash3 = c.hash()
+		self.assertEqual( changes, [ ( "a", 2, hash1 ), ( "a", 3, hash2 ), ( "b", 1, hash3 ) ] )
 
 		# when an assignment makes no actual change, the signal should not
 		# be triggered again.
 		c["b"] = 1
-		self.assertEqual( changes, [ ( "a", 2 ), ( "a", 3 ), ( "b", 1 ) ] )
+		self.assertEqual( changes, [ ( "a", 2, hash1 ), ( "a", 3, hash2 ), ( "b", 1, hash3 ) ] )
 
 		# Removing variables should also trigger the changed signal.
 
 		del changes[:]
 
 		c.remove( "a" )
-		self.assertEqual( changes, [ ( "a", None ) ] )
+		hash4 = c.hash()
+		self.assertEqual( changes, [ ( "a", None, hash4 ) ] )
 
 		del c["b"]
-		self.assertEqual( changes, [ ( "a", None ), ( "b", None ) ] )
+		hash5 = c.hash()
+		self.assertEqual( changes, [ ( "a", None, hash4 ), ( "b", None, hash5 ) ] )
 
 	def testTypes( self ) :
 

--- a/src/GafferSceneUI/ContextAlgo.cpp
+++ b/src/GafferSceneUI/ContextAlgo.cpp
@@ -148,9 +148,9 @@ void expand( Context *context, const PathMatcher &paths, bool expandAncestors )
 	if( needUpdate )
 	{
 		// We modified the expanded paths in place to avoid unecessary copying,
-		// so the context doesn't know they've changed. So we emit the changed
-		// signal ourselves
-		context->changedSignal()( context, g_expandedPathsName );
+		// so the context doesn't know they've changed. So we must let it know
+		// about the change
+		context->changed( g_expandedPathsName );
 	}
 }
 
@@ -177,9 +177,9 @@ IECore::PathMatcher expandDescendants( Context *context, const IECore::PathMatch
 	if( needUpdate )
 	{
 		// We modified the expanded paths in place to avoid unecessary copying,
-		// so the context doesn't know they've changed. So we emit the changed
-		// signal ourselves
-		context->changedSignal()( context, g_expandedPathsName );
+		// so the context doesn't know they've changed. So we must let it know
+		// about the change
+		context->changed( g_expandedPathsName );
 	}
 
 	return leafPaths;

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -1810,6 +1810,10 @@ void SceneView::frame( const PathMatcher &filter, const Imath::V3f &direction )
 
 void SceneView::expandSelection( size_t depth )
 {
+	// Note that we are scoping this context at the same time that expandDescendants is doing a cheeky in-place
+	// modification of the context.  In general this could result in highly inconsistent hash results ... it
+	// is safe only because the selected paths is a "ui:" prefixed context variable, and Context is hardcoded
+	// to ignore variables with this prefix during hashing
 	Context::Scope scope( getContext() );
 	PathMatcher selection = ContextAlgo::expandDescendants( getContext(), m_sceneGadget->getSelection(), preprocessedInPlug<ScenePlug>(), depth - 1 );
 	ContextAlgo::setSelectedPaths( getContext(), selection );

--- a/src/GafferTest/ContextTest.cpp
+++ b/src/GafferTest/ContextTest.cpp
@@ -44,6 +44,7 @@
 
 #include "boost/lexical_cast.hpp"
 #include "tbb/parallel_for.h"
+#include <unordered_set>
 
 using namespace std;
 using namespace boost;
@@ -206,9 +207,89 @@ void GafferTest::testEditableScope()
 
 }
 
+// Create the number of contexts specified, and return counts for how many collisions there are
+// in each of the four 32 bit sections of the context hash.  MurmurHash performs good mixing, so
+// the four sections should be independent, and as long as collisions within each section occur only
+// at the expected rate, the chance of a full collision across all 4 should be infinitesimal
+// ( we don't want to check for collisions in the whole 128 bit hash, since it would take years
+// for one to occur randomly )
+// "mode" switches betwen 4 modes for creating contexts:
+//   0 :  1 entry with a single increment int
+//   1 :  40 fixed strings, plus a single incrementing int
+//   2 :  20 random floats
+//   3 :  an even mixture of the previous 3 modes
+// "seed" can be used to perform different runs to get an average number.
+// The goal is that regardless of how we create the contexts, they are all unique, and should therefore
+// have an identical chance of collisions if our hashing performs ideally.
+std::tuple<int,int,int,int> GafferTest::countContextHash32Collisions( int contexts, int mode, int seed )
+{
+	std::unordered_set<uint32_t> used[4];
+
+	InternedString a( "a" );
+	InternedString numberNames[40];
+	for( int i = 0; i < 40; i++ )
+	{
+		numberNames[i] = InternedString( i );
+	}
+
+	unsigned int rand_seed = seed;
+	int collisions[4] = {0,0,0,0};
+	for( int i = 0; i < contexts; i++ )
+	{
+		int curMode = mode;
+		int elementSeed = seed * contexts + i;
+		if( curMode == 3 )
+		{
+			curMode = i % 3;
+			elementSeed = seed * contexts + i / 3;
+		}
+
+		Context c;
+		if( curMode == 0 )
+		{
+			c.set( a, elementSeed );
+		}
+		else if( curMode == 1 )
+		{
+			for( int j = 0; j < 40; j++ )
+			{
+				c.set( numberNames[j], j );
+			}
+			c.set( a, elementSeed );
+		}
+		else if( curMode == 2 )
+		{
+			for( int j = 0; j < 20; j++ )
+			{
+				c.set( numberNames[j], rand_r( &rand_seed ) );
+			}
+		}
+
+		if( !used[0].insert( (uint32_t)( c.hash().h1() ) ).second )
+		{
+			collisions[0]++;
+		}
+		if( !used[1].insert( (uint32_t)( c.hash().h1() >> 32 ) ).second )
+		{
+			collisions[1]++;
+		}
+		if( !used[2].insert( (uint32_t)( c.hash().h2() ) ).second )
+		{
+			collisions[2]++;
+		}
+		if( !used[3].insert( (uint32_t)( c.hash().h2() >> 32 ) ).second )
+		{
+			collisions[3]++;
+		}
+	}
+
+	return std::make_tuple( collisions[0], collisions[1], collisions[2], collisions[3] );
+}
+
 void GafferTest::testContextHashPerformance( int numEntries, int entrySize, bool startInitialized )
 {
-	// We usually deal with contexts that already have some base stuff in them
+	// We usually deal with contexts that already have some stuff in them, so adding some entries
+	// to the context makes this test more realistic
 	ContextPtr baseContext = new Context();
 	for( int i = 0; i < numEntries; i++ )
 	{
@@ -227,8 +308,6 @@ void GafferTest::testContextHashPerformance( int numEntries, int entrySize, bool
 
 	tbb::parallel_for( tbb::blocked_range<size_t>( 0, 10000000 ), [&threadState, &varyingVarName]( const tbb::blocked_range<size_t> &r )
 		{
-			// As part of the setCollaborate plug machinery, we put the parentPath in the context.
-			// Need to remove it before evaluating the prototype sets
 			for( size_t i = r.begin(); i != r.end(); ++i )
 			{
 				Context::EditableScope scope( threadState );

--- a/src/GafferTestModule/GafferTestModule.cpp
+++ b/src/GafferTestModule/GafferTestModule.cpp
@@ -83,6 +83,7 @@ BOOST_PYTHON_MODULE( _GafferTest )
 	def( "testManyEnvironmentSubstitutions", &testManyEnvironmentSubstitutions );
 	def( "testScopingNullContext", &testScopingNullContext );
 	def( "testEditableScope", &testEditableScope );
+	def( "testContextHashPerformance", &testContextHashPerformance );
 	def( "testComputeNodeThreading", &testComputeNodeThreading );
 	def( "testDownstreamIterator", &testDownstreamIterator );
 

--- a/src/GafferTestModule/GafferTestModule.cpp
+++ b/src/GafferTestModule/GafferTestModule.cpp
@@ -62,6 +62,13 @@ static void testMetadataThreadingWrapper()
 	testMetadataThreading();
 }
 
+static boost::python::tuple countContextHash32CollisionsWrapper( int entries, int mode, int seed )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	auto result = countContextHash32Collisions( entries, mode, seed );
+	return boost::python::make_tuple( std::get<0>(result), std::get<1>(result), std::get<2>(result), std::get<3>(result) );
+}
+
 BOOST_PYTHON_MODULE( _GafferTest )
 {
 
@@ -83,6 +90,7 @@ BOOST_PYTHON_MODULE( _GafferTest )
 	def( "testManyEnvironmentSubstitutions", &testManyEnvironmentSubstitutions );
 	def( "testScopingNullContext", &testScopingNullContext );
 	def( "testEditableScope", &testEditableScope );
+	def( "countContextHash32Collisions", &countContextHash32CollisionsWrapper );
 	def( "testContextHashPerformance", &testContextHashPerformance );
 	def( "testComputeNodeThreading", &testComputeNodeThreading );
 	def( "testDownstreamIterator", &testDownstreamIterator );


### PR DESCRIPTION
This is some exploration of things we can do to reduce the cost of hashing contexts, all based around the idea that a sum of the hashes of ( entry name, entry value ) is sufficient to uniquely represent the context ( since we do not care about order of context entries ).

There are 3 versions here:

V1:  store a running sum of the hash of all current context entries.  When an entry is set, compute the hash of the current value, subtract it off, the add the hash of the incoming value.
V2:  store a running sum of the hash of all current context entries, plus the hash of each entry.  When an entry is set, subtract off the stored hash, the add the hash of the incoming value.
V3: store the hash of each entry.  To compute the current hash, run through all entries and sum their hashes

These versions are kinda in reverse order - V1 is the version we discussed first, but it actually makes the most changes to the current code.  The diffs to master are more meaningful than diffing V2 and V3 from the previous commit, but this seemed like the quickest way to share all 3.

My preliminary performance results are below.  The basic summary is that V2 seems strictly inferior to V3 - if we're going to use the extra storage, summing the hashes when you need a total hash is insignificant in expense, and getting rid of the running accumulator makes the code much simpler, and harder to introduce bizarre inconsistent states.

So the main question is whether the extra storage cost is worth the reduction in complexity from V1 to V3.  I'm leaning towards thinking it is, particularly because you have some schemes for reducing the number of times we need to allocate cache entries, which could make V1 a lot harder to get working, but could also reduce the already farily small extra storage cost of V3.

Here are performance results, comparing 5 versions of the code, from current master to the V4 commit, with and without this Cortex PR: https://github.com/ImageEngine/cortex/pull/1130, and with the context initialized with a small state of 10 strings with 10 characters, or a larger state with 50 strings with 20 characters:

| --- | testContextHashPerformance | testContextHashPerformanceStartInitialized |
| --- | --- | --- |
| **default IECore, 10 existing 10 character strings** | - | - |
| original | 0.76s | 0.71s |
| V1 | 0.34s | 0.32s |
| V2 | 0.38s | 0.31s |
| V3 | 0.40s | 0.32s |
| V4 | 0.46s | 0.39s |
| **inlined MurmurHash, 10 existing 10 character strings** | - | - |
| original | 0.73s | 0.69s |
| V1 | 0.33s | 0.30s |
| V2 | 0.35s | 0.30s |
| V3 | 0.35s | 0.30s |
| V4 | 0.41s | 0.37s |
| **inlined MurmurHash, 50 existing 20 character strings** | - | - |
| original | 2.22s | 2.13s |
| V1 | 0.52s | 0.44s |
| V2 | 0.59s | 0.46s |
| V3 | 0.62s | 0.46s |
| V4 | 0.87s | 0.74s |
