### PR TITLE
InteractiveRender/ShaderView improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -29,6 +29,7 @@ Fixes
   exist. A common cause was the usage of `...` or a non-existent path in a PathFilter.
 - ImageGadget : Fixed bug which prevented `stateChangedSignal()` from being emitted when
   `setPaused( false )` was called.
+- ShaderView : Pausing the viewer now stops the renderer.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -38,6 +38,7 @@ API
 - ScriptNode : Added support for cancellation of execution and serialisation.
 - ValuePlug : Improved warning emitted if cached value has unexpected type.
 - SceneAlgo : Added `linkedLights()` and `linkedObjects()` functions.
+- ImageView : Added `imageGadget()` accessor.
 
 0.59.4.0 (relative to 0.59.3.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,8 @@ Fixes
   updates from interactive renders.
 - Prune : Fixed bounds computation in the case that the filter claims to match descendants that don't
   exist. A common cause was the usage of `...` or a non-existent path in a PathFilter.
+- ImageGadget : Fixed bug which prevented `stateChangedSignal()` from being emitted when
+  `setPaused( false )` was called.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -29,6 +29,8 @@ Fixes
   exist. A common cause was the usage of `...` or a non-existent path in a PathFilter.
 - ImageGadget : Fixed bug which prevented `stateChangedSignal()` from being emitted when
   `setPaused( false )` was called.
+- InteractiveRender : Fixed error handling during render startup. Errors are now shown in the render
+  log and the terminal output.
 - ShaderView : Pausing the viewer now stops the renderer.
 
 API

--- a/include/GafferImageUI/ImageView.h
+++ b/include/GafferImageUI/ImageView.h
@@ -103,6 +103,10 @@ class GAFFERIMAGEUI_API ImageView : public GafferUI::View
 		Gaffer::BoolPlug *lutGPUPlug();
 		const Gaffer::BoolPlug *lutGPUPlug() const;
 
+		/// The gadget responsible for displaying the image.
+		ImageGadget *imageGadget();
+		const ImageGadget *imageGadget() const;
+
 		void setContext( Gaffer::ContextPtr context ) override;
 
 		typedef std::function<GafferImage::ImageProcessorPtr ()> DisplayTransformCreator;

--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -104,6 +104,7 @@ class GAFFERSCENEUI_API ShaderView : public GafferImageUI::ImageView
 		void updateRendererState();
 		void updateScene();
 		void preRender();
+		void imageGadgetStateChanged();
 
 		void driverCreated( IECoreImage::DisplayDriver *driver, const IECore::CompoundData *parameters );
 

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -97,11 +97,20 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		s["r2"] = self._createInteractiveRender( failOnError = False )
 		s["r2"]["in"].setInput( s["o"]["out"] )
 
-		errors = GafferTest.CapturingSlot( s["r2"].errorSignal() )
-		s["r2"]["state"].setValue( s["r"].State.Running )
+		try :
+			defaultHandler = IECore.MessageHandler.getDefaultHandler()
+			messageHandler = IECore.CapturingMessageHandler()
+			IECore.MessageHandler.setDefaultHandler( messageHandler )
+			s["r2"]["state"].setValue( s["r"].State.Running )
+		finally :
+			IECore.MessageHandler.setDefaultHandler( defaultHandler )
 
-		self.assertEqual( len( errors ), 1 )
-		self.assertTrue( "Arnold is already in use" in errors[0][2] )
+		messages = s["r2"]["messages"].getValue().value
+		self.assertEqual( len( messages ), 1 )
+		self.assertEqual( messages[0].message, "Arnold is already in use" )
+
+		self.assertEqual( len( messageHandler.messages ), 1 )
+		self.assertEqual( messageHandler.messages[0].message, "Arnold is already in use" )
 
 	def testEditSubdivisionAttributes( self ) :
 

--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -634,7 +634,6 @@ class _StateWidget( GafferUI.Widget ) :
 	def __buttonClick( self, button ) :
 
 		self.__imageGadget.setPaused( not self.__imageGadget.getPaused() )
-		self.__update()
 
 	def __update( self ) :
 

--- a/python/GafferImageUITest/ImageGadgetTest.py
+++ b/python/GafferImageUITest/ImageGadgetTest.py
@@ -40,6 +40,7 @@ import imath
 import IECore
 
 import Gaffer
+import GafferTest
 import GafferUI
 import GafferUITest
 import GafferImage
@@ -109,6 +110,22 @@ class ImageGadgetTest( GafferUITest.TestCase ) :
 
 		del g, w
 		del s
+
+	def testStateChangedSignal( self ) :
+
+		image = GafferImage.Constant()
+		gadget = GafferImageUI.ImageGadget()
+		gadget.setImage( image["out"] )
+		self.assertNotEqual( gadget.state(), gadget.State.Paused )
+
+		cs = GafferTest.CapturingSlot( gadget.stateChangedSignal() )
+		gadget.setPaused( True )
+		self.assertEqual( len( cs ), 1 )
+		self.assertEqual( gadget.state(), gadget.State.Paused )
+
+		gadget.setPaused( False )
+		self.assertEqual( len( cs ), 2 )
+		self.assertNotEqual( gadget.state(), gadget.State.Paused )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageUITest/ImageViewTest.py
+++ b/python/GafferImageUITest/ImageViewTest.py
@@ -85,5 +85,11 @@ class ImageViewTest( GafferUITest.TestCase ) :
 		view["exposure"].setValue( 1 )
 		view["gamma"].setValue( 0.5 )
 
+	def testImageGadget( self ) :
+
+		view = GafferImageUI.ImageView()
+		self.assertIsInstance( view.imageGadget(), GafferImageUI.ImageGadget )
+		self.assertTrue( view.viewportGadget().isAncestorOf( view.imageGadget() ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -655,12 +655,12 @@ void ImageGadget::setPaused( bool paused )
 	if( m_paused )
 	{
 		m_tilesTask.reset();
-		stateChangedSignal()( this );
 	}
 	else if( m_dirtyFlags )
 	{
 		Gadget::dirty( DirtyType::Render );
 	}
+	stateChangedSignal()( this );
 }
 
 bool ImageGadget::getPaused() const

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -499,6 +499,16 @@ const Gaffer::BoolPlug *ImageView::lutGPUPlug() const
 	return getChild<BoolPlug>( "lutGPU" );
 }
 
+ImageGadget *ImageView::imageGadget()
+{
+	return m_imageGadget.get();
+}
+
+const ImageGadget *ImageView::imageGadget() const
+{
+	return m_imageGadget.get();
+}
+
 void ImageView::setContext( Gaffer::ContextPtr context )
 {
 	View::setContext( context );

--- a/src/GafferImageUIModule/ImageViewBinding.cpp
+++ b/src/GafferImageUIModule/ImageViewBinding.cpp
@@ -38,6 +38,7 @@
 
 #include "ImageViewBinding.h"
 
+#include "GafferImageUI/ImageGadget.h"
 #include "GafferImageUI/ImageView.h"
 
 #include "GafferImage/ImageProcessor.h"
@@ -122,6 +123,7 @@ void GafferImageUIModule::bindImageView()
 
 	GafferBindings::NodeClass<ImageView, ImageViewWrapper>()
 		.def( init<const std::string &>() )
+		.def( "imageGadget", (ImageGadget *(ImageView::*)())&ImageView::imageGadget, return_value_policy<IECorePython::CastToIntrusivePtr>() )
 		.def( "_insertConverter", &ImageViewWrapper::insertConverter )
 		.def( "registerDisplayTransform", &registerDisplayTransform )
 		.staticmethod( "registerDisplayTransform" )

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -291,7 +291,7 @@ void InteractiveRender::plugSet( const Gaffer::Plug *plug )
 		}
 		catch( const std::exception &e )
 		{
-			errorSignal()( plug, plug, e.what() );
+			m_messageHandler->handle( IECore::MessageHandler::Error, "InteractiveRender", e.what() );
 		}
 	}
 }

--- a/src/GafferSceneUI/ShaderView.cpp
+++ b/src/GafferSceneUI/ShaderView.cpp
@@ -42,6 +42,8 @@
 #include "GafferScene/Shader.h"
 #include "GafferScene/ShaderPlug.h"
 
+#include "GafferImageUI/ImageGadget.h"
+
 #include "GafferImage/Display.h"
 
 #include "Gaffer/Context.h"
@@ -161,7 +163,7 @@ ShaderView::ShaderView( const std::string &name )
 	plugDirtiedSignal().connect( boost::bind( &ShaderView::plugDirtied, this, ::_1 ) );
 	sceneRegistrationChangedSignal().connect( boost::bind( &ShaderView::sceneRegistrationChanged, this, ::_1 ) );
 	Display::driverCreatedSignal().connect( boost::bind( &ShaderView::driverCreated, this, ::_1, ::_2 ) );
-
+	imageGadget()->stateChangedSignal().connect( boost::bind( &ShaderView::imageGadgetStateChanged, this ) );
 }
 
 ShaderView::~ShaderView()
@@ -336,7 +338,7 @@ void ShaderView::updateRendererState()
 	}
 
 	m_renderer->statePlug()->setValue(
-		viewportGadget()->visible() ? InteractiveRender::Running : InteractiveRender::Stopped
+		( viewportGadget()->visible() && imageGadget()->state() != GafferImageUI::ImageGadget::Paused ) ? InteractiveRender::Running : InteractiveRender::Stopped
 	);
 }
 
@@ -423,6 +425,11 @@ void ShaderView::preRender()
 
 	viewportGadget()->frame( Imath::Box3f( Imath::V3f( 0 ), Imath::V3f( resolution.x, resolution.y, 0.0f ) ) );
 	m_framed = true;
+}
+
+void ShaderView::imageGadgetStateChanged()
+{
+	updateRendererState();
 }
 
 void ShaderView::registerRenderer( const std::string &shaderPrefix, RendererCreator rendererCreator )


### PR DESCRIPTION
A couple of small improvements to the situation where both the ShaderView and an InteractiveRender want access to Arnold. Should we maybe go further than this and automatically pause the ShaderView when an InteractiveRender is started?