### PR TITLE
Wrapper : Unset `PYTHONHOME` environment variable

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -30,6 +30,7 @@ Fixes
 - ScriptNode : Fixed bugs that allowed global variables to remain in the context after they had been disabled, renamed or deleted.
 - PlugValueWidget : Fixed bug that tried to update the widget before all graph edits were complete.
 - UDIMQuery and OSLImage : Fixed incorrectly isolated TBB which could cause hang when other nodes use Standard cache policy. Now uses TaskCollaboration to improve performance.
+- Wrapper : Removed the `PYTHONHOME` environment variable. This fixes problems running Gaffer in python-enabled versions of `gdb`.
 
 API
 ---

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -155,19 +155,12 @@ fi
 # Get python set up properly
 ##########################################################################
 
-# Make sure PYTHONHOME is pointing to our internal python build.
-# We only do this if Gaffer has been built with an internal version
-# of python - otherwise we assume the existing environment is providing
-# the right value.
-
+# Unset PYTHONHOME to make sure our internal Python build is used in preference
+# to anything in the external environment. We only do this if Gaffer has been
+# built with an internal version of Python - otherwise we assume the existing
+# environment is providing the right value.
 if [[ -e $GAFFER_ROOT/bin/python ]] ; then
-
-	if [[ `uname` = "Linux" ]] ; then
-		export PYTHONHOME="$GAFFER_ROOT"
-	else
-		export PYTHONHOME="$GAFFER_ROOT/lib/Python.framework/Versions/Current"
-	fi
-
+	unset PYTHONHOME
 fi
 
 # Get python module path set up


### PR DESCRIPTION
This still prevents us getting clobbered by the external environment, but also
doesn't clobber `gdb` when it is launched by `GAFFER_DEBUG=1`. GDB links
to the system Python which can get mighty upset if used with the modules from
our internal Python.

Note : I'm not sure why we check for the existence of `$GAFFER_ROOT/bin/python`
since official builds always include it and Image Engine builds don't use the
wrapper. But I've left it for now just in case.
