### PR TITLE
IECoreArnoldPreview : Translate ShaderNetwork node name to Arnold.

### DIFF
--- a/src/GafferArnold/IECoreArnoldPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/ShaderNetworkAlgo.cpp
@@ -354,6 +354,10 @@ std::vector<AtNode *> convert( const IECoreScene::ShaderNetwork *shaderNetwork, 
 			return AiNode( nodeType, nodeName, parentNode );
 		};
 		convertWalk( shaderNetwork->getOutput(), shaderNetwork, name, nodeCreator, result, converted );
+		for( const auto &kv : shaderNetwork->outputShader()->blindData()->readable() )
+		{
+			ParameterAlgo::setParameter( result.back(), AtString( kv.first.c_str() ), kv.second.get() );
+		}
 	}
 	return result;
 }


### PR DESCRIPTION
This allows Arnold shaders (eg cryptomatte) to provide better names for shader nodes.

I put this up as a draft for now, because (a) I wasn't entirely sure I've put the code in the right spot, (b) I wasn't sure if we should address the todo now as well, (c) I know we discussed a more elegant mechanism that doesn't require nice node names in Gaffer, and (d) I didn't have time to write tests today.