### PR TITLE
GafferUI.FileMenu : Make `__open()` public as `openScript()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ API
 - EventLoop : Added `BlockedUIThreadExecution` context manager.
 - ScriptNode : Added support for cancellation of execution and serialisation.
 - ValuePlug : Improved warning emitted if cached value has unexpected type.
+- GafferUI.FileMenu :  `__open()` is now public as `openScript()`
 
 0.59.4.0 (relative to 0.59.3.0)
 ========

--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -85,7 +85,7 @@ def open( menu ) :
 	if not path :
 		return
 
-	__open( scriptWindow.scriptNode(), str( path ) )
+	openScript( scriptWindow.scriptNode(), str( path ) )
 
 ## Opens a script and adds it to the application, as if the user
 # had done so via the File Open dialogue.
@@ -137,7 +137,13 @@ def __addScript( application, fileName, dialogueParentWindow = None, asNew = Fal
 
 	return script
 
-def __open( currentScript, fileName ) :
+## Opens a script, adds it to the application, and closes the currentScript
+# if it was empty. as if the user had done so via the File Open dialogue.
+#
+# :param currentScript Gaffer.ScriptNode object associated with the current operation
+# :param fileName str with the file path to the script to open
+# :returns newly opened script or None
+def openScript( currentScript, fileName ) :
 
 	application = currentScript.ancestor( Gaffer.ApplicationRoot )
 	currentWindow = GafferUI.ScriptWindow.acquire( currentScript )
@@ -159,6 +165,8 @@ def __open( currentScript, fileName ) :
 		# a menu parented to it).
 		GafferUI.WidgetAlgo.keepUntilIdle( currentWindow )
 
+	return script
+
 ## A function suitable as the submenu callable for a File/OpenRecent menu item. It must be invoked
 # from a menu which has a ScriptWindow in its ancestry.
 def openRecent( menu ) :
@@ -178,7 +186,7 @@ def openRecent( menu ) :
 				"/" + str( index ),
 				{
 					"label": os.path.basename( fileName ),
-					"command" : functools.partial( __open, currentScript, fileName ),
+					"command" : functools.partial( openScript, currentScript, fileName ),
 					"description" : fileName,
 					"active" : os.path.isfile( fileName )
 				}


### PR DESCRIPTION
Hi @johnhaddon,

This makes `GafferUI.FileMenu.__open()` public, so we can officially access it from Jabuka, as well as adding a return value, given that the operation can now be cancelled.

Another option would be to use the already public `GafferUI.FileMenu.addScript()`, but then we'd be missing on the automatic replacing of the current window that the `__open()` offers, which would have to then be duplicated in Jabuka. But even in that case, we'd also want to add the  `dialogueParentWindow` argument, which exists in `GafferUI.FileMenu.__addScript()`, so we can provide it.

Let me know if that option sounds better to you, even with the code-duplication in Jabuka.

Or if you have another suggestion.

