### PR TITLE
Context Experiment

### DIFF
--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -124,35 +124,34 @@ class GAFFER_API Context : public IECore::RefCounted
 
 		typedef boost::signal<void ( const Context *context, const IECore::InternedString & )> ChangedSignal;
 
-		template<typename T>
-		struct Accessor;
+		// Set a context entry with a generic data of an unknown type
+		void set( const IECore::InternedString &name, const IECore::Data *value );
 
-		/// Calling with simple types (e.g float) will automatically
-		/// create a TypedData<T> to store the value.
+		/// Setting with a specific type using this template is much faster.  Support a simple types like
+		/// TODO list types
 		// TODO - there has got to be a better way to specify the simple types that this works on,
-		// so that it doesn't match with Data* and beat out the overload below
+		// so that it doesn't match with Data* and beat out the overload above
 		template<typename T, typename boost::disable_if< boost::is_base_of<IECore::Data, typename boost::remove_pointer<T>::type >, int >::type = 0>
 		void set( const IECore::InternedString &name, const T &value );
 
-		void set( const IECore::InternedString &name, const IECore::Data *value );
+		// Get a context entry as a generic data without knowing it's type
+		IECore::ConstDataPtr get( const IECore::InternedString &name, bool throws = true ) const;
 
-		/// Can be used to retrieve simple types :
+		/// Can be used to retrieve simple types, much faster than the untyped version :
 		///		float f = context->get<float>( "myFloat" )
-		/// And also IECore::Data types :
-		///		const FloatData *f = context->get<FloatData>( "myFloat" )
 		template<typename T>
-		typename Accessor<T>::ResultType get( const IECore::InternedString &name ) const;
+		const T& get( const IECore::InternedString &name ) const;
+
 		/// As above but returns defaultValue when an entry is not found, rather than throwing
 		/// an Exception.
 		template<typename T>
-		typename Accessor<T>::ResultType get( const IECore::InternedString &name, typename Accessor<T>::ResultType defaultValue ) const;
+		const T& get( const IECore::InternedString &name, const T& defaultValue ) const;
 
 		/// For certain cases where we want to be speedy, return a pointer to the data, or nullptr if
 		/// if not found
 		template<typename T>
 		const T* getPointer( const IECore::InternedString &name ) const;
 
-		IECore::ConstDataPtr get( const IECore::InternedString &name, bool throws = true ) const;
 
 		/// Removes an entry from the context if it exists
 		void remove( const IECore::InternedString& name );

--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -45,6 +45,7 @@
 #include "IECore/InternedString.h"
 #include "IECore/MurmurHash.h"
 #include "IECore/StringAlgo.h"
+#include "IECore/TypedData.h"
 
 #include "boost/container/flat_map.hpp"
 #include "boost/signals.hpp"
@@ -123,13 +124,18 @@ class GAFFER_API Context : public IECore::RefCounted
 
 		typedef boost::signal<void ( const Context *context, const IECore::InternedString & )> ChangedSignal;
 
-		template<typename T, typename Enabler=void>
+		template<typename T>
 		struct Accessor;
 
 		/// Calling with simple types (e.g float) will automatically
 		/// create a TypedData<T> to store the value.
-		template<typename T>
+		// TODO - there has got to be a better way to specify the simple types that this works on,
+		// so that it doesn't match with Data* and beat out the overload below
+		template<typename T, typename boost::disable_if< boost::is_base_of<IECore::Data, typename boost::remove_pointer<T>::type >, int >::type = 0>
 		void set( const IECore::InternedString &name, const T &value );
+
+		void set( const IECore::InternedString &name, const IECore::Data *value );
+
 		/// Can be used to retrieve simple types :
 		///		float f = context->get<float>( "myFloat" )
 		/// And also IECore::Data types :
@@ -140,6 +146,13 @@ class GAFFER_API Context : public IECore::RefCounted
 		/// an Exception.
 		template<typename T>
 		typename Accessor<T>::ResultType get( const IECore::InternedString &name, typename Accessor<T>::ResultType defaultValue ) const;
+
+		/// For certain cases where we want to be speedy, return a pointer to the data, or nullptr if
+		/// if not found
+		template<typename T>
+		const T* getPointer( const IECore::InternedString &name ) const;
+
+		IECore::ConstDataPtr get( const IECore::InternedString &name, bool throws = true ) const;
 
 		/// Removes an entry from the context if it exists
 		void remove( const IECore::InternedString& name );
@@ -242,8 +255,12 @@ class GAFFER_API Context : public IECore::RefCounted
 				EditableScope( const ThreadState &threadState );
 				~EditableScope();
 
-				template<typename T>
+				// TODO - there has got to be a better way to specify the simple types that this works on,
+				// so that it doesn't match with Data* and beat out the overload below
+				template<typename T, typename boost::disable_if< boost::is_base_of<IECore::Data, typename boost::remove_pointer<T>::type >, int >::type = 0>
 				void set( const IECore::InternedString &name, const T &value );
+
+				void set( const IECore::InternedString &name, const IECore::Data *value );
 
 				void setFrame( float frame );
 				void setFramesPerSecond( float framesPerSecond );

--- a/include/Gaffer/Context.inl
+++ b/include/Gaffer/Context.inl
@@ -85,7 +85,7 @@ struct DataTraits<Imath::Vec3<T> >
 
 } // namespace Detail
 
-template<typename T, typename Enabler>
+template<typename T>
 struct Context::Accessor
 {
 	typedef const T &ResultType;
@@ -138,6 +138,7 @@ struct Context::Accessor
 	}
 };
 
+/*
 template<typename T>
 struct Context::Accessor<T, typename boost::enable_if<boost::is_base_of<IECore::Data, typename boost::remove_pointer<T>::type > >::type>
 {
@@ -173,9 +174,9 @@ struct Context::Accessor<T, typename boost::enable_if<boost::is_base_of<IECore::
 		}
 		return static_cast<const T *>( data );
 	}
-};
+};*/
 
-template<typename T>
+template<typename T, typename boost::disable_if< boost::is_base_of<IECore::Data, typename boost::remove_pointer<T>::type >, int >::type>
 void Context::set( const IECore::InternedString &name, const T &value )
 {
 	Storage &s = m_map[name];
@@ -214,6 +215,18 @@ typename Context::Accessor<T>::ResultType Context::get( const IECore::InternedSt
 }
 
 template<typename T>
+const T* Context::getPointer( const IECore::InternedString &name ) const
+{
+	Map::const_iterator it = m_map.find( name );
+	if( it == m_map.end() )
+	{
+		return nullptr;
+	}
+	return &Accessor<T>().get( it->second.data );
+}
+
+
+template<typename T, typename boost::disable_if< boost::is_base_of<IECore::Data, typename boost::remove_pointer<T>::type >, int >::type>
 void Context::EditableScope::set( const IECore::InternedString &name, const T &value )
 {
 	m_context->set( name, value );

--- a/src/Gaffer/ContextMonitor.cpp
+++ b/src/Gaffer/ContextMonitor.cpp
@@ -82,7 +82,8 @@ ContextMonitor::Statistics & ContextMonitor::Statistics::operator += ( const Con
 	context->names( names );
 	for( vector<InternedString>::const_iterator it = names.begin(), eIt = names.end(); it != eIt; ++it )
 	{
-		const Data *d = context->get<Data>( *it );
+		// TODO - expose hash
+		ConstDataPtr d = context->get( *it );
 		m_variables[*it][d->Object::hash()] += 1;
 	}
 	return *this;

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -316,7 +316,8 @@ void Expression::hash( const ValuePlug *output, const Context *context, IECore::
 
 		for( std::vector<IECore::InternedString>::const_iterator it = m_contextNames.begin(); it != m_contextNames.end(); it++ )
 		{
-			const IECore::Data *d = context->get<IECore::Data>( *it, nullptr );
+			// TODO - expose entry hash to avoid rehashing?
+			IECore::ConstDataPtr d = context->get( *it, false );
 			if( d )
 			{
 				d->hash( h );

--- a/src/Gaffer/ProcessMessageHandler.cpp
+++ b/src/Gaffer/ProcessMessageHandler.cpp
@@ -80,15 +80,15 @@ void ProcessMessageHandler::handle( Level level, const string &context, const st
 
 		ss << "[ plug: '" << p->plug()->fullName() << "'";
 
-		if( auto frame = p->context()->get<IECore::FloatData>( g_frame, nullptr ) )
+		if( const float *frame = p->context()->getPointer<float>( g_frame ) )
 		{
-			ss << ", frame: " << frame->readable();
+			ss << ", frame: " << *frame;
 		}
 
-		if( auto path = p->context()->get<IECore::InternedStringVectorData>( g_scenePath, nullptr ) )
+		if( auto path = p->context()->getPointer< std::vector<IECore::InternedString> >( g_scenePath ) )
 		{
 			std::string strPath = std::string("/") + join(
-				path->readable() | transformed(
+				*path | transformed(
 					[]( const IECore::InternedString &s )
 					{
 						return s.string();

--- a/src/Gaffer/Random.cpp
+++ b/src/Gaffer/Random.cpp
@@ -277,10 +277,11 @@ void Random::hashSeed( const Context *context, IECore::MurmurHash &h ) const
 	std::string contextEntry = contextEntryPlug()->getValue();
 	if( contextEntry.size() )
 	{
-		const IECore::Data *contextData = nullptr;
+		IECore::ConstDataPtr contextData;
 		try
 		{
-			contextData = context->get<IECore::Data>( contextEntry );
+			// TODO - expose hash
+			contextData = context->get( contextEntry );
 		}
 		catch( ... )
 		{
@@ -298,10 +299,11 @@ unsigned long int Random::computeSeed( const Context *context ) const
 	std::string contextEntry = contextEntryPlug()->getValue();
 	if( contextEntry.size() )
 	{
-		const IECore::Data *contextData = nullptr;
+		IECore::ConstDataPtr contextData;
 		try
 		{
-			contextData = context->get<IECore::Data>( contextEntry );
+			// TODO - expose hash
+			contextData = context->get( contextEntry );
 		}
 		catch( ... )
 		{
@@ -310,7 +312,7 @@ unsigned long int Random::computeSeed( const Context *context ) const
 		{
 			IECore::MurmurHash hash = contextData->Object::hash();
 			/// \todo It'd be nice if there was a way of getting the hash folded into an
-			/// int so we could avoid this jiggery pokery.
+			/// int so we could avoid this jiggery pokery. TODO : Can now use hash.h1()
 			std::string s = hash.toString();
 			seed += boost::hash<std::string>()( s );
 		}

--- a/src/Gaffer/Spreadsheet.cpp
+++ b/src/Gaffer/Spreadsheet.cpp
@@ -278,9 +278,9 @@ class RowsMapScope : boost::noncopyable, public Context::SubstitutionProvider
 			{
 				// Special case for `scene:path`, which users will expect to use PathMatcher
 				// style matching rather than `StringAlgo::match()`.
-				if( auto path = context->get<InternedStringVectorData>( g_scenePath, nullptr ) )
+				if( auto path = context->getPointer< std::vector<InternedString> >( g_scenePath ) )
 				{
-					m_selector = &path->readable();
+					m_selector = path;
 				}
 				else
 				{

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -658,7 +658,8 @@ class Dispatcher::Batcher
 				}
 
 				result.append( *it );
-				context->get<const IECore::Data>( *it )->hash( result );
+				// TODO - expose hash
+				context->get( *it )->hash( result );
 			}
 			return result;
 		}

--- a/src/GafferImageTest/ContextSanitiser.cpp
+++ b/src/GafferImageTest/ContextSanitiser.cpp
@@ -71,20 +71,21 @@ void ContextSanitiser::processStarted( const Gaffer::Process *process )
 {
 	if( const ImagePlug *image = process->plug()->parent<ImagePlug>() )
 	{
+		// TODO - needs testing.  Is it OK that these are now type specific?
 		if( process->plug() == image->sampleOffsetsPlug() )
 		{
-			if( process->context()->get<IECore::Data>( ImagePlug::channelNameContextName, nullptr ) )
+			if( process->context()->getPointer<std::string>( ImagePlug::channelNameContextName ) )
 			{
 				warn( *process, ImagePlug::channelNameContextName );
 			}
 		}
 		else if( process->plug() != image->channelDataPlug() )
 		{
-			if( process->context()->get<IECore::Data>( ImagePlug::channelNameContextName, nullptr ) )
+			if( process->context()->getPointer<std::string>( ImagePlug::channelNameContextName ) )
 			{
 				warn( *process, ImagePlug::channelNameContextName );
 			}
-			if( process->context()->get<IECore::Data>( ImagePlug::tileOriginContextName, nullptr ) )
+			if( process->context()->getPointer<Imath::V2i>( ImagePlug::tileOriginContextName ) )
 			{
 				warn( *process, ImagePlug::tileOriginContextName );
 			}

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -126,13 +126,15 @@ class RendererServices : public OSL::RendererServices
 				return false;
 			}
 
-			const Data *data = renderState->context->get<Data>( name.c_str(), nullptr );
+			// TODO - might be nice if there was some way to speed this up by directly querying the type matching
+			// the TypeDesc, instead of getting as a generic Data?
+			const ConstDataPtr data = renderState->context->get( name.c_str(), false );
 			if( !data )
 			{
 				return false;
 			}
 
-			IECoreImage::OpenImageIOAlgo::DataView dataView( data, /* createUStrings = */ true );
+			IECoreImage::OpenImageIOAlgo::DataView dataView( data.get(), /* createUStrings = */ true );
 			if( !dataView.data )
 			{
 				if( auto b = runTimeCast<const BoolData>( data ) )

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -311,7 +311,7 @@ class RenderState
 					make_pair(
 						ustring( name.c_str() ),
 						IECoreImage::OpenImageIOAlgo::DataView(
-							context->get<Data>( name.string(), nullptr ),
+							context->get( name.string(), false ).get(),  // TODO - is immediately destructing this temp data going to be OK?
 							/* createUStrings = */ true
 						)
 					)
@@ -1121,7 +1121,8 @@ void ShadingEngine::hash( IECore::MurmurHash &h ) const
 		}
 		for( const auto &name : m_contextVariablesNeeded )
 		{
-			const IECore::Data *d = context->get<IECore::Data>( name, nullptr );
+			// TODO - expose hash
+			IECore::ConstDataPtr d = context->get( name, false );
 			if( d )
 			{
 				d->hash( h );

--- a/src/GafferScene/PathFilter.cpp
+++ b/src/GafferScene/PathFilter.cpp
@@ -201,10 +201,9 @@ void PathFilter::compute( Gaffer::ValuePlug *output, const Gaffer::Context *cont
 
 void PathFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	typedef IECore::TypedData<ScenePlug::ScenePath> ScenePathData;
-	const ScenePathData *pathData = context->get<ScenePathData>( ScenePlug::scenePathContextName, nullptr );
+	const ScenePlug::ScenePath *path = context->getPointer<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
 
-	if( !pathData )
+	if( !path )
 	{
 		// This is a special case used by the Prune and Isolate nodes
 		// to request a hash representing the effects of the filter
@@ -229,8 +228,7 @@ void PathFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *conte
 
 	// Standard case
 
-	const ScenePlug::ScenePath &path = pathData->readable();
-	h.append( path.data(), path.size() );
+	h.append( path->data(), path->size() );
 
 	if( m_pathMatcher )
 	{

--- a/src/GafferScene/PrimitiveVariableExists.cpp
+++ b/src/GafferScene/PrimitiveVariableExists.cpp
@@ -108,7 +108,7 @@ void PrimitiveVariableExists::hash( const ValuePlug *output, const Context *cont
 	ComputeNode::hash( output, context, h );
 	if( output == outPlug() )
 	{
-		if( context->get<InternedStringVectorData>( ScenePlug::scenePathContextName, nullptr ) )
+		if( context->getPointer<std::vector<std::string> >( ScenePlug::scenePathContextName ) )
 		{
 			h.append( primitiveVariablePlug()->hash() );
 			h.append( inPlug()->objectPlug()->hash() );
@@ -125,7 +125,7 @@ void PrimitiveVariableExists::compute( ValuePlug *output, const Context *context
 	if( output == outPlug() )
 	{
 		bool exists = false;
-		if( context->get<InternedStringVectorData>( ScenePlug::scenePathContextName, nullptr ) )
+		if( context->getPointer<std::vector<std::string> >( ScenePlug::scenePathContextName ) )
 		{
 			ConstObjectPtr inObject = inPlug()->objectPlug()->getValue();
 

--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -69,9 +69,9 @@ struct RenderScope : public Context::EditableScope
 	RenderScope( const Context *context )
 		:	EditableScope( context ), m_sceneTranslationOnly( false )
 	{
-		if( auto d = context->get<BoolData>( g_sceneTranslationOnlyContextName, nullptr ) )
+		if( const bool *d = context->getPointer<bool>( g_sceneTranslationOnlyContextName ) )
 		{
-			m_sceneTranslationOnly = d->readable();
+			m_sceneTranslationOnly = *d;
 			// Don't leak variable upstream.
 			remove( g_sceneTranslationOnlyContextName );
 		}

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -1387,7 +1387,7 @@ ConstOutputPtr addGafferOutputHeaders( const Output *output, const ScenePlug *sc
 	for( const auto &name : names )
 	{
 		// Output params are never mutated, so this is 'safe'...
-		DataPtr data = const_cast<Data*>( context->get<Data>( name ) );
+		DataPtr data = const_cast<Data*>( context->get( name ).get() );
 		// The requires a round-trip through the renderer's native type system, as such, it requires
 		// bi-directional conversion in Cortex. Unsupported types result in a slew of warning messages
 		// in render output. As many facilities employ un-supported types in their contexts as standard,

--- a/src/GafferScene/SetFilter.cpp
+++ b/src/GafferScene/SetFilter.cpp
@@ -145,12 +145,10 @@ void SetFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *contex
 	/// the scene then we would be able to use that in these situations and have a broader range
 	/// of filters. If we manage that, then we should go back to throwing an exception here if
 	/// the context doesn't contain a path. We should then do the same in the PathFilter.
-	typedef IECore::TypedData<ScenePlug::ScenePath> ScenePathData;
-	const ScenePathData *pathData = context->get<ScenePathData>( ScenePlug::scenePathContextName, nullptr );
-	if( pathData )
+	const ScenePlug::ScenePath *path = context->getPointer<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+	if( path )
 	{
-		const ScenePlug::ScenePath &path = pathData->readable();
-		h.append( &(path[0]), path.size() );
+		h.append( &((*path)[0]), path->size() );
 	}
 
 	Gaffer::Context::EditableScope expressionResultScope( context );

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -767,9 +767,9 @@ void Shader::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *conte
 	{
 		ComputeNode::hash( output, context, h );
 		const Plug *outputParameter = outPlug();
-		if( auto *name = context->get<IECore::StringData>( g_outputParameterContextName, nullptr ) )
+		if( const std::string *name = context->getPointer< std::string >( g_outputParameterContextName ) )
 		{
-			outputParameter = outputParameter->descendant<Plug>( name->readable() );
+			outputParameter = outputParameter->descendant<Plug>( *name );
 		}
 		attributesHash( outputParameter, h );
 		return;
@@ -793,9 +793,9 @@ void Shader::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context 
 	if( output == outAttributesPlug() )
 	{
 		const Plug *outputParameter = outPlug();
-		if( auto *name = context->get<IECore::StringData>( g_outputParameterContextName, nullptr ) )
+		if( const std::string *name = context->getPointer< std::string >( g_outputParameterContextName ) )
 		{
-			outputParameter = outputParameter->descendant<Plug>( name->readable() );
+			outputParameter = outputParameter->descendant<Plug>( *name );
 		}
 		static_cast<CompoundObjectPlug *>( output )->setValue( attributes( outputParameter ) );
 		return;

--- a/src/GafferSceneTest/ContextSanitiser.cpp
+++ b/src/GafferSceneTest/ContextSanitiser.cpp
@@ -81,14 +81,15 @@ void ContextSanitiser::processStarted( const Gaffer::Process *process )
 {
 	if( const ScenePlug *scene = process->plug()->parent<ScenePlug>() )
 	{
-		if( process->context()->get<IECore::Data>( FilterPlug::inputSceneContextName, nullptr ) )
+		// TODO - needs testing.  Is it OK that these are now type specific?
+		if( process->context()->getPointer<uint64_t>( FilterPlug::inputSceneContextName ) )
 		{
 			warn( *process, FilterPlug::inputSceneContextName );
 		}
 
 		if( process->plug() != scene->setPlug() )
 		{
-			if( process->context()->get<IECore::Data>( ScenePlug::setNameContextName, nullptr ) )
+			if( process->context()->getPointer<InternedString>( ScenePlug::setNameContextName ) )
 			{
 				warn( *process, ScenePlug::setNameContextName );
 			}
@@ -107,7 +108,7 @@ void ContextSanitiser::processStarted( const Gaffer::Process *process )
 			process->plug()->getName() != g_sortedChildNames
 		)
 		{
-			if( process->context()->get<IECore::Data>( ScenePlug::scenePathContextName, nullptr ) )
+			if( process->context()->getPointer<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ) )
 			{
 				warn( *process, ScenePlug::scenePathContextName );
 			}
@@ -118,11 +119,11 @@ void ContextSanitiser::processStarted( const Gaffer::Process *process )
 	{
 		if( process->plug()->getName() == g_internalOut )
 		{
-			if( process->context()->get<IECore::Data>( ScenePlug::scenePathContextName, nullptr ) )
+			if( process->context()->getPointer<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ) )
 			{
 				warn( *process, ScenePlug::scenePathContextName );
 			}
-			if( process->context()->get<IECore::Data>( ScenePlug::setNameContextName, nullptr ) )
+			if( process->context()->getPointer<InternedString>( ScenePlug::setNameContextName ) )
 			{
 				warn( *process, ScenePlug::setNameContextName );
 			}

--- a/src/GafferSceneUIModule/HierarchyViewBinding.cpp
+++ b/src/GafferSceneUIModule/HierarchyViewBinding.cpp
@@ -146,9 +146,9 @@ class HierarchyViewFilter : public Gaffer::PathFilter
 			m_context->names( names );
 			for( vector<InternedString>::const_iterator it = names.begin(), eIt = names.end(); it != eIt; ++it )
 			{
-				const Data *newValue = m_context->get<Data>( *it );
-				const Data *oldValue = oldContext->get<Data>( *it, nullptr );
-				if( !oldValue || !newValue->isEqualTo( oldValue ) )
+				IECore::ConstDataPtr newValue = m_context->get( *it );
+				IECore::ConstDataPtr oldValue = oldContext->get( *it, false );
+				if( !oldValue || !newValue->isEqualTo( oldValue.get() ) )
 				{
 					contextChanged( *it );
 				}
@@ -159,7 +159,7 @@ class HierarchyViewFilter : public Gaffer::PathFilter
 			oldContext->names( names );
 			for( vector<InternedString>::const_iterator it = names.begin(), eIt = names.end(); it != eIt; ++it )
 			{
-				if( !m_context->get<Data>( *it, nullptr ) )
+				if( !m_context->get( *it, false ) )
 				{
 					contextChanged( *it );
 				}

--- a/src/GafferTest/ContextTest.cpp
+++ b/src/GafferTest/ContextTest.cpp
@@ -142,7 +142,8 @@ void GafferTest::testScopingNullContext()
 
 void GafferTest::testEditableScope()
 {
-	ContextPtr baseContext = new Context();
+	// TODO - this test needs complete reworking once we stop using Data internally
+	/*ContextPtr baseContext = new Context();
 	baseContext->set( "a", 10 );
 	baseContext->set( "b", 20 );
 
@@ -204,6 +205,7 @@ void GafferTest::testEditableScope()
 		GAFFERTEST_ASSERT( aData->refCount() == aRefCount );
 		GAFFERTEST_ASSERT( bData->refCount() == bRefCount );
 	}
+	*/
 
 }
 


### PR DESCRIPTION
As a way of assessing the lie of the land for the Context overhaul, I tried removing all use of Context::set<TypedData>, and seeing what broke.

I'm not necessarily suggesting that this is a good idea, and it certainly isn't useful in its current form, but as groundwork for an overhaul, I think it might be the right direction.

Removing use of Context::set<TypedData> but keeping everything else the same, it appears to have not been too hard to get all the tests passing ( err, preliminarily, I'm in a bit of a hurry at end of day and I've only checked GafferTest ), and it really doesn't seem like we lose too much.

The most common use of set<TypedData> appears to be when we want a fast way to get both whether an entry exists, and its value if it exists.  This is a case where we definitely don't want to keep using this once we transition internal storage to something other than Data.  Alloc'ing a new Data as a part of a quick test if an entry exists is extremely counterproductive.  To try things out, I've added a `getPointer` that returns null if the entry isn't found - there are lots of other interfaces we could use.  The problem with `const T& get( const IECore::InternedString &name, const T& defaultValue ) const;` is that it doesn't offer any way to tell whether entry exists, unless you set defaultValue to some weird flag value, which doesn't feel like a pattern we want to continue.

Other interesting observations:
* One common use of getting context entries as Data is in order to generically hash them.  We should now be able to add an accessor for the entry hashes on Context, to save this work.
* The ContextAlgo::expand cheeky-modify-on-the-fly thing I was able to currently get working in this current scheme by forcing the insertion of a new entry if it doesn't exist, and then using getPointer to get access to it's internal storage with a const_cast.  This whole scheme is going to be very sketchy though once the Context doesn't have ownership of its storage.  It seems pretty unintuitive and tricky to get threadsafe that Gaffer threads could be modifying variables stored in whatever function called them, once those variables are added into a context.
* Even if we stop do the cheekily-modify-the-parent-context variables thing, there are going to be a bunch of places where once we get rid of internal storage, we're going to be keeping pointers to dead memory.  `functionThatAddsThingsToContext( Context &toModify )` is not an unheard of pattern in this codebase, and often those sorts of functions will add things based on stack variables.  I think the proposal is still totally worth it, but I'm expecting a bunch of test failures and auditing.