### PR TITLE
EventLoop : Rewrite `executeOnUIThread()` to avoid PySide/Qt bugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,8 @@ Fixes
 -----
 
 - Instancer : Fixed crash evaluating `variations` when there are no prototypes.
+- EventLoop : Fixed rare failures in `executeOnUIThread()`. Symptoms included a failure to display
+  updates from interactive renders.
 
 API
 ---


### PR DESCRIPTION
The original code had been in use for a long time, apparently without trouble.
But since moving to Qt 5.12 and adding `BlockedUIThreadExecution`, we have
been seeing intermittent failures in `testBlockedUIThreadExecution()` during
GitHub CI. Typically they look like this :

```
Error: FAIL: testBlockedUIThreadExecution (GafferUITest.EventLoopTest.EventLoopTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/gaffer/gaffer/build/python/GafferUITest/EventLoopTest.py", line 225, in testBlockedUIThreadExecution
    self.assertEqual( self.__uiThreadCallCount, callsToMake )
AssertionError: 9998 != 10000
```

At the same time, we've had a single report from production with an error along these
lines being emitted during interactive rendering :

```
ERROR : DisplayDriverServer::Session::handleReadDataParameters : Traceback (most recent call last):
  File "/packages/vendor/ImageEngine/gaffer/linux_64/0.59.3.0/python/GafferUI/EventLoop.py", line 253, in executeOnUIThread
    cls.__qtApplication.postEvent( uiThreadExecutor(), QtCore.QEvent( QtCore.QEvent.Type( _UIThreadExecutor.executeEventType ) ) )
RuntimeError: Internal C++ object (_UIThreadExecutor) already deleted.
```

I believe these errors are both symptoms of the same underlying problem, and that
`BlockedUIThreadExecution` is not actually the culprit. I verified this by adding
`testLotsOfUIThreadCalls()`, which demonstrates similar failures without blocking
execution. I couldn't get either problem to reproduce on my workstation directly,
but I could in a Docker container mimicking the GitHub CI environment.

It appears that some of our `_UIThreadExecutor` objects were deleted before they
had a chance to receive their event. Depending on the timing of this, it either
resulted in the `already deleted` error, or in the event simply being lost, leading
to `AssertionError: 9998 != 10000`. During testing, I also discovered a third failure
mode in which PySide/Qt crashed during destruction of the `QEvent` we posted, leading
to this stack trace :

```
0  0x00007fb2227bc84c in Shiboken::BindingManager::releaseWrapper(SbkObject*) () from /build/gaffer/lib/python2.7/site-packages/shiboken2/libshiboken2-python2.7.so.5.12
1  0x00007fb2227ae112 in Shiboken::Object::destroy(SbkObject*, void*) () from /build/gaffer/lib/python2.7/site-packages/shiboken2/libshiboken2-python2.7.so.5.12
2  0x00007fb220b99e49 in QEventWrapper::~QEventWrapper() () from /build/gaffer/lib/python2.7/site-packages/PySide2/QtCore.so
3  0x00007fb220b99e69 in QEventWrapper::~QEventWrapper() () from /build/gaffer/lib/python2.7/site-packages/PySide2/QtCore.so
4  0x00007fb2288ace18 in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) () from /build/gaffer/lib/libQt5Core.so.5
```

I've been unable to track down the root cause of any of these problems, but strongly
suspect a GIL/refcount bug in PySide somewhere. The solution uses a more minimal
mechanism for scheduling execution which fortunately seems to avoid the problem.
Verified by running `gaffer test GafferUITest.EventLoopTest.testLotsOfUIThreadCalls -repeat 100`
10 times for the old code and 10 times for the new code. Results below :

- Old code :
  - 6 `already deleted` errors
  - 3 assertion failures
  - 1 success
  - Mean time to failure : 17.7 iterations (in `-repeat`)
- New code : No failures.
