### PR TITLE
Light linking queries

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,8 @@
 Improvements
 ------------
 
+- Viewer : Added "Light Links" submenu with "Select Linked Lights" and "Select Linked Objects"
+  operations.
 - FileMenu : File loading and saving no longer locks the UI, and can be cancelled.
 - MapProjection : Added `position` plug to allow a custom position to be used for the projection.
 - Spreadsheet :

--- a/Changes.md
+++ b/Changes.md
@@ -29,6 +29,7 @@ API
 - EventLoop : Added `BlockedUIThreadExecution` context manager.
 - ScriptNode : Added support for cancellation of execution and serialisation.
 - ValuePlug : Improved warning emitted if cached value has unexpected type.
+- SceneAlgo : Added `linkedLights()` and `linkedObjects()` functions.
 
 0.59.4.0 (relative to 0.59.3.0)
 ========

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -241,6 +241,19 @@ GAFFERSCENE_API std::string sourceSceneName( const GafferImage::ImagePlug *image
 /// can't be found.
 GAFFERSCENE_API ScenePlug *sourceScene( GafferImage::ImagePlug *image );
 
+/// Light linking queries
+/// =====================
+
+/// Returns the paths to locations which are linked to the specified light.
+GAFFERSCENE_API IECore::PathMatcher linkedObjects( const ScenePlug *scene, const ScenePlug::ScenePath &light );
+/// Returns the paths to locations which are linked to at least one of the specified lights.
+GAFFERSCENE_API IECore::PathMatcher linkedObjects( const ScenePlug *scene, const IECore::PathMatcher &lights );
+
+/// Returns the paths to all lights which are linked to the specified object.
+GAFFERSCENE_API IECore::PathMatcher linkedLights( const ScenePlug *scene, const ScenePlug::ScenePath &object );
+/// Returns the paths to all lights which are linked to at least one of the specified objects.
+GAFFERSCENE_API IECore::PathMatcher linkedLights( const ScenePlug *scene, const IECore::PathMatcher &objects );
+
 /// Miscellaneous
 /// =============
 

--- a/python/GafferSceneUI/StandardAttributesUI.py
+++ b/python/GafferSceneUI/StandardAttributesUI.py
@@ -179,10 +179,25 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			The lights to be linked to this object. Accepts a
-			set expression or a space separated list of lights.
-			Use \"defaultLights\" to refer to all lights that
-			contribute to illumination by default.
+			The lights to be linked to this object. Accepts a set expression or
+			a space separated list of lights. Use \"defaultLights\" to refer to
+			all lights that contribute to illumination by default.
+
+			Examples
+			--------
+
+			All the default lights plus the lights in the `characterLights` set
+			:
+
+			`defaultLights | characterLights`
+
+			All the default lights, but without the lights in the `interiorLights`
+			set :
+
+			`defaultLights - interiorLights`
+
+			> Info : Lights can be added to sets either by using the `sets` plug
+			> on the light node itself, or by using a separate Set node.
 			""",
 
 			"layout:section", "Light Linking",

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -44,11 +44,13 @@
 #include "GafferScene/MergeScenes.h"
 #include "GafferScene/PathFilter.h"
 #include "GafferScene/ScenePlug.h"
+#include "GafferScene/SetAlgo.h"
 #include "GafferScene/ShaderTweaks.h"
 #include "GafferScene/ShuffleAttributes.h"
 
 #include "Gaffer/Context.h"
 #include "Gaffer/Monitor.h"
+#include "Gaffer/Private/IECorePreview/LRUCache.h"
 #include "Gaffer/Process.h"
 #include "Gaffer/ScriptNode.h"
 
@@ -64,6 +66,7 @@
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/unordered_map.hpp"
 
+#include "tbb/concurrent_unordered_set.h"
 #include "tbb/parallel_for.h"
 #include "tbb/spin_mutex.h"
 #include "tbb/task.h"
@@ -799,6 +802,175 @@ ScenePlug *SceneAlgo::sourceScene( GafferImage::ImagePlug *image )
 	}
 
 	return scriptNode->descendant<ScenePlug>( path );
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Light linking
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+static InternedString g_lights( "__lights" );
+static InternedString g_linkedLights( "linkedLights" );
+
+template<typename AttributesPredicate>
+struct AttributesFinder
+{
+
+	AttributesFinder( const AttributesPredicate &predicate, tbb::spin_mutex &resultMutex, IECore::PathMatcher &result )
+		:	m_predicate( predicate ), m_resultMutex( resultMutex ), m_result( result )
+	{
+	}
+
+	bool operator()( const ScenePlug *scene, const ScenePlug::ScenePath &path )
+	{
+		bool inheritPredicateResult = false;
+		ConstCompoundObjectPtr attributes = scene->attributesPlug()->getValue();
+		if( path.empty() )
+		{
+			// Root
+			m_fullAttributes = attributes;
+		}
+		else
+		{
+			if( attributes->members().empty() )
+			{
+				inheritPredicateResult = true;
+			}
+			else
+			{
+				CompoundObjectPtr fullAttributes = new CompoundObject;
+				fullAttributes->members() = m_fullAttributes->members();
+				for( const auto &a : attributes->members() )
+				{
+					fullAttributes->members()[a.first] = a.second;
+				}
+				m_fullAttributes = fullAttributes;
+			}
+		}
+
+		if( !inheritPredicateResult )
+		{
+			m_predicateResult = m_predicate( m_fullAttributes.get() );
+		}
+		else
+		{
+			// `m_predicateResult` is inherited automatically because `parallelProcessLocations()`
+			// copy-constructs child functors from the parent.
+		}
+
+		if( m_predicateResult && !path.empty() )
+		{
+			/// \todo We could avoid this locking if we added a `functor.gatherChildren()`
+			/// phase to `parallelProcessLocations()` and built the result recursively.
+			tbb::spin_mutex::scoped_lock lock( m_resultMutex );
+			m_result.addPath( path );
+		}
+
+		return true;
+	}
+
+	private :
+
+		const AttributesPredicate &m_predicate;
+
+		ConstCompoundObjectPtr m_fullAttributes;
+		bool m_predicateResult;
+
+		tbb::spin_mutex &m_resultMutex;
+		IECore::PathMatcher &m_result;
+
+};
+
+/// \todo Perhaps this is worthy of inclusion in the public API?
+template<typename AttributesPredicate>
+IECore::PathMatcher findAttributes( const ScenePlug *scene, const AttributesPredicate &predicate )
+{
+	tbb::spin_mutex resultMutex;
+	IECore::PathMatcher result;
+	AttributesFinder<AttributesPredicate> attributesFinder( predicate, resultMutex, result );
+	parallelProcessLocations( scene, attributesFinder );
+	return result;
+}
+
+} // namespace
+
+IECore::PathMatcher GafferScene::SceneAlgo::linkedObjects( const ScenePlug *scene, const ScenePlug::ScenePath &light )
+{
+	PathMatcher lights;
+	lights.addPath( light );
+	return linkedObjects( scene, lights );
+}
+
+GAFFERSCENE_API IECore::PathMatcher GafferScene::SceneAlgo::linkedObjects( const ScenePlug *scene, const IECore::PathMatcher &lights )
+{
+	// We expect many locations to have the exact same expression for `linkedLights`,
+	// and evaluating the expression is fairly expensive. So we cache the results for
+	// sharing between locations. The cache only lives for the lifetime of this query.
+	using QueryCache = IECorePreview::LRUCache<std::string, bool, IECorePreview::LRUCachePolicy::TaskParallel>;
+	const Context *context = Context::current();
+	QueryCache queryCache(
+		[&lights, scene, context]( const std::string &setExpression, size_t &cost )
+		{
+			cost = 1;
+			Context::Scope scopedContext( context );
+			const IECore::PathMatcher linkedLights = SetAlgo::evaluateSetExpression( setExpression, scene );
+			for( PathMatcher::Iterator lightIt = lights.begin(), eIt = lights.end(); lightIt != eIt; ++lightIt )
+			{
+				if( linkedLights.match( *lightIt ) & PathMatcher::ExactMatch )
+				{
+					return true;
+				}
+			}
+			return false;
+		},
+		10000
+	);
+
+	IECore::PathMatcher result = findAttributes(
+		scene,
+		[&queryCache] ( const CompoundObject *fullAttributes ) {
+			auto *linkedLights = fullAttributes->member<StringData>( g_linkedLights );
+			return queryCache.get( linkedLights ? linkedLights->readable() : "defaultLights" );
+		}
+	);
+
+	result.removePaths( scene->set( g_lights )->readable() );
+	return result;
+}
+
+IECore::PathMatcher GafferScene::SceneAlgo::linkedLights( const ScenePlug *scene, const ScenePlug::ScenePath &object )
+{
+	IECore::ConstCompoundObjectPtr attributes = scene->fullAttributes( object );
+	auto *linkedLightsAttribute = attributes->member<StringData>( g_linkedLights );
+	const string linkedLights = linkedLightsAttribute ? linkedLightsAttribute->readable() : "defaultLights";
+	IECore::PathMatcher linkedPaths = SetAlgo::evaluateSetExpression( linkedLights, scene );
+	return linkedPaths.intersection( scene->set( g_lights )->readable() );
+}
+
+IECore::PathMatcher GafferScene::SceneAlgo::linkedLights( const ScenePlug *scene, const IECore::PathMatcher &objects )
+{
+	tbb::spin_mutex resultMutex;
+	IECore::PathMatcher result;
+	tbb::concurrent_unordered_set<std::string> processed;
+
+	auto functor = [&resultMutex, &result, &processed] ( const ScenePlug *scene, const ScenePlug::ScenePath &path ) {
+		IECore::ConstCompoundObjectPtr attributes = scene->fullAttributes( path );
+		auto *linkedLightsAttribute = attributes->member<StringData>( g_linkedLights );
+		const string linkedLights = linkedLightsAttribute ? linkedLightsAttribute->readable() : "defaultLights";
+		if( processed.insert( linkedLights ).second )
+		{
+			ScenePlug::GlobalScope globalScope( Context::current() );
+			IECore::PathMatcher linkedPaths = SetAlgo::evaluateSetExpression( linkedLights, scene );
+			tbb::spin_mutex::scoped_lock resultLock( resultMutex );
+			result.addPaths( linkedPaths );
+		}
+		return true;
+	};
+
+	filteredParallelTraverse( scene, objects, functor );
+	return result.intersection( scene->set( g_lights )->readable() );
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -226,6 +226,30 @@ ScenePlugPtr sourceSceneWrapper( GafferImage::ImagePlug &image )
 	return SceneAlgo::sourceScene( &image );
 }
 
+IECore::PathMatcher linkedObjectsWrapper1( const GafferScene::ScenePlug &scene, const ScenePlug::ScenePath &light )
+{
+	IECorePython::ScopedGILRelease r;
+	return SceneAlgo::linkedObjects( &scene, light );
+}
+
+IECore::PathMatcher linkedObjectsWrapper2( const GafferScene::ScenePlug &scene, const IECore::PathMatcher &lights )
+{
+	IECorePython::ScopedGILRelease r;
+	return SceneAlgo::linkedObjects( &scene, lights );
+}
+
+IECore::PathMatcher linkedLightsWrapper1( const GafferScene::ScenePlug &scene, const ScenePlug::ScenePath &object )
+{
+	IECorePython::ScopedGILRelease r;
+	return SceneAlgo::linkedLights( &scene, object );
+}
+
+IECore::PathMatcher linkedLightsWrapper2( const GafferScene::ScenePlug &scene, const IECore::PathMatcher &objects )
+{
+	IECorePython::ScopedGILRelease r;
+	return SceneAlgo::linkedLights( &scene, objects );
+}
+
 } // namespace
 
 namespace GafferSceneModule
@@ -292,6 +316,13 @@ void bindSceneAlgo()
 
 	def( "sourceSceneName", &sourceSceneNameWrapper );
 	def( "sourceScene", &sourceSceneWrapper );
+
+	// Light linking
+
+	def( "linkedObjects", &linkedObjectsWrapper1 );
+	def( "linkedObjects", &linkedObjectsWrapper2 );
+	def( "linkedLights", &linkedLightsWrapper1 );
+	def( "linkedLights", &linkedLightsWrapper2 );
 
 }
 

--- a/startup/gui/viewer.py
+++ b/startup/gui/viewer.py
@@ -73,6 +73,7 @@ GafferUI.View.registerView( GafferScene.ScenePlug.staticTypeId(), __sceneView )
 
 def __viewContextMenu( viewer, view, menuDefinition ) :
 
+	GafferSceneUI.LightUI.appendViewContextMenuItems( viewer, view, menuDefinition )
 	GafferSceneUI.SceneHistoryUI.appendViewContextMenuItems( viewer, view, menuDefinition )
 
 GafferUI.Viewer.viewContextMenuSignal().connect( __viewContextMenu, scoped = False )


### PR DESCRIPTION
This adds some handy menu items in the viewer, for selecting the objects linked to a light and the lights linked to an object :

![lightLinks](https://user-images.githubusercontent.com/1133871/111613152-1f21ec00-87d6-11eb-8839-0a06bab13be2.gif)

The underlying scene queries are available via the API in `SceneAlgo`.