### PR TITLE
Prune : Fix bounds computation when filter claims a non-existent match

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,8 @@ Fixes
 - Instancer : Fixed crash evaluating `variations` when there are no prototypes.
 - EventLoop : Fixed rare failures in `executeOnUIThread()`. Symptoms included a failure to display
   updates from interactive renders.
+- Prune : Fixed bounds computation in the case that the filter claims to match descendants that don't
+  exist. A common cause was the usage of `...` or a non-existent path in a PathFilter.
 
 API
 ---

--- a/python/GafferSceneTest/PruneTest.py
+++ b/python/GafferSceneTest/PruneTest.py
@@ -380,5 +380,28 @@ class PruneTest( GafferSceneTest.SceneTestCase ) :
 		plane["name"].setValue( "youCantPruneMe" )
 		self.assertEqual( prune["out"].bound( "/" ), plane["out"].bound( "/" ) )
 
+	def testFalseDescendantMatches( self ) :
+
+		plane = GafferScene.Plane()
+		plane["transform"]["translate"]["x"].setValue( 10 )
+
+		sphere = GafferScene.Sphere()
+		sphere["transform"]["translate"]["x"].setValue( -10 )
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( plane["out"] )
+		group["in"][1].setInput( sphere["out"] )
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/group/.../plane" ] ) )
+
+		prune = GafferScene.Prune()
+		prune["in"].setInput( group["out"] )
+		prune["filter"].setInput( pathFilter["out"] )
+		prune["adjustBounds"].setValue( True )
+
+		self.assertEqual( prune["out"].childNames( "/group"), IECore.InternedStringVectorData( [ "sphere" ] ) )
+		self.assertEqual( prune["out"].bound( "/" ), sphere["out"].bound( "/" ) )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
An alternative fix would have been to compute the local bound (by computing the object) and merge it with the child bounds. This would also have fixed the case where a location has an object and some children, and then all the children are pruned away. I don't think forcing the computation of objects in this case is prudent though, and we can fix the more common case much more cheaply by computing childnames, which we need to compute the child bounds anyway.

Longer term there's probably a good argument for having separate `objectBounds` and `childBounds` plugs so that we can cheaply get the object bound alone, without needing to compute the object.

