### PR TITLE
OSLExpressionEngine : Fix parsing bug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,9 @@
 Fixes
 -----
 
+- Expression : Fixed OSL expression parsing bug triggered by plug names which were
+  prefixes of other plug names. This caused a very confusing `Syntax error: syntax error`
+  error.
 - ExtensionAlgo :
   - Fixed copy/paste of nodes exported by ExtensionAlgo (#3886).
   - Fixed bug which prevented the use of internal Expression nodes.

--- a/python/GafferOSLTest/OSLExpressionEngineTest.py
+++ b/python/GafferOSLTest/OSLExpressionEngineTest.py
@@ -533,12 +533,14 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 		s["n"]["user"]["a"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["n"]["user"]["ab"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["n"]["user"]["abc"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["user"]["abcd"] = Gaffer.V2iPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
 		expression = inspect.cleandoc(
 			"""
 			parent.n.user.ab = 1;
 			parent.n.user.a = 2;
 			parent.n.user.abc = 3;
+			parent.n.user.abcd.x = 4;
 			"""
 		)
 
@@ -550,6 +552,7 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( s["n"]["user"]["ab"].getValue(), 1 )
 		self.assertEqual( s["n"]["user"]["a"].getValue(), 2 )
 		self.assertEqual( s["n"]["user"]["abc"].getValue(), 3 )
+		self.assertEqual( s["n"]["user"]["abcd"]["x"].getValue(), 4 )
 
 		s2 = Gaffer.ScriptNode()
 		s2.execute( s.serialise() )
@@ -559,6 +562,7 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( s2["n"]["user"]["ab"].getValue(), 1 )
 		self.assertEqual( s2["n"]["user"]["a"].getValue(), 2 )
 		self.assertEqual( s2["n"]["user"]["abc"].getValue(), 3 )
+		self.assertEqual( s2["n"]["user"]["abcd"]["x"].getValue(), 4 )
 
 	def testStringComparison( self ) :
 


### PR DESCRIPTION
We had fixed the equivalent bugs in the `replace()` method long ago, but
the problem remained in the `shaderSource()` method.
